### PR TITLE
feat: harden generic Composio workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,79 @@ If for some reason you want the published CLI separately, there is still a scrip
 bash scripts/install-latest-wuphf-cli.sh
 ```
 
+## Integrations And Actions
+
+If you want agents to do real things across external systems, not just talk about them, you also need a Composio project key and at least one connected account.
+
+That is what powers:
+
+- external actions like sending an email
+- reusable workflows
+- trigger-based automations
+
+The minimum setup is:
+
+1. create a Composio project
+2. generate a project API key
+3. connect the accounts you want agents to use, such as Gmail
+4. tell WUPHF about the key
+
+Inside WUPHF:
+
+```text
+/config set composio_api_key <your-composio-project-key>
+/config set action_provider composio
+```
+
+You also need the connected account on the Composio side. For example, if you want Gmail actions to work, connect Gmail in Composio first. WUPHF can search and execute actions only after that account exists.
+
+If you run:
+
+```bash
+./wuphf --no-nex
+```
+
+then Nex-backed integrations are disabled for that run, and the action plane should be treated as off too.
+
+## AI-Assisted Setup Prompt
+
+If you are not technical, paste this into your AI tool of choice and follow it step by step:
+
+```text
+Help me set up WUPHF so the agents can actually take actions in external apps.
+
+I am not technical. Walk me through this slowly, one step at a time, and wait for me after each step.
+
+Goal:
+- WUPHF runs locally
+- Nex is configured
+- Composio is configured for the action plane
+- Gmail is connected
+- WUPHF can send a test email through an agent
+
+Please guide me through this exact flow:
+
+1. Confirm tmux, claude, and Go are installed.
+2. Help me build WUPHF from source.
+3. Help me run WUPHF and complete /init.
+4. Help me create or open a Composio project.
+5. Help me generate a Composio project API key.
+6. Help me connect Gmail inside Composio.
+7. Help me enter the Composio key into WUPHF using:
+   /config set composio_api_key <key>
+   /config set action_provider composio
+8. Help me start a 1:1 CEO session.
+9. Help me ask the CEO to send a test email through the Composio action plane.
+10. If anything fails, diagnose whether the problem is:
+   - missing WUPHF setup
+   - missing Nex setup
+   - missing Composio key
+   - missing connected account
+   - wrong provider selected
+
+Be explicit, do not skip steps, and give me the exact command or exact text to paste each time.
+```
+
 ## What You Should See
 
 When it works, you should get:

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -198,8 +198,8 @@ func TestChannelViewShowsThreadReplyLabel(t *testing.T) {
 	}
 }
 
-func TestThreadsStartCollapsedByDefault(t *testing.T) {
-	m := newChannelModel(true) // explicit collapsed mode
+func TestThreadsRenderExpandedEvenWhenCollapsedRequested(t *testing.T) {
+	m := newChannelModel(true)
 	m.width = 120
 	m.height = 30
 	m.messages = []brokerMessage{
@@ -209,11 +209,8 @@ func TestThreadsStartCollapsedByDefault(t *testing.T) {
 	}
 
 	view := stripANSI(m.View())
-	if !strings.Contains(view, "↩ 2 replies") {
-		t.Fatalf("expected collapsed-thread summary, got %q", view)
-	}
-	if strings.Contains(view, "Reply one") || strings.Contains(view, "Reply two") {
-		t.Fatalf("expected replies to stay hidden by default, got %q", view)
+	if !strings.Contains(view, "Reply one") || !strings.Contains(view, "Reply two") {
+		t.Fatalf("expected replies to render inline, got %q", view)
 	}
 }
 
@@ -366,7 +363,7 @@ func TestHumanFacingMessageSwitchesBackToMessages(t *testing.T) {
 }
 
 func TestInitialHumanFacingHistoryDoesNotForceMessagesApp(t *testing.T) {
-	m := newChannelModelWithApp(false, officeAppInsights)
+	m := newChannelModelWithApp(false, officeAppPolicies)
 
 	next, _ := m.Update(channelMsg{messages: []brokerMessage{
 		{ID: "msg-1", From: "pm", Kind: "human_report", Title: "Scope ready", Content: "Please review the scope."},
@@ -376,8 +373,8 @@ func TestInitialHumanFacingHistoryDoesNotForceMessagesApp(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected channelModel, got %T", next)
 	}
-	if got.activeApp != officeAppInsights {
-		t.Fatalf("expected initial history to keep insights active, got %v", got.activeApp)
+	if got.activeApp != officeAppPolicies {
+		t.Fatalf("expected initial history to keep policies active, got %v", got.activeApp)
 	}
 	if got.notice != "" {
 		t.Fatalf("expected no human-facing notice on initial history load, got %q", got.notice)
@@ -425,8 +422,8 @@ func TestChannelCreateDoneSwitchesToNewChannel(t *testing.T) {
 }
 
 func TestResolveInitialOfficeAppFallsBackToMessages(t *testing.T) {
-	if got := resolveInitialOfficeApp("insights"); got != officeAppInsights {
-		t.Fatalf("expected insights app, got %q", got)
+	if got := resolveInitialOfficeApp("policies"); got != officeAppPolicies {
+		t.Fatalf("expected policies app, got %q", got)
 	}
 	if got := resolveInitialOfficeApp("calendar"); got != officeAppCalendar {
 		t.Fatalf("expected calendar app, got %q", got)
@@ -753,9 +750,6 @@ func TestRenderSidebarShowsTaskDrivenWorkingState(t *testing.T) {
 		40,
 		44,
 	))
-	if !strings.Contains(sidebar, "working") {
-		t.Fatalf("expected task-driven working activity, got %q", sidebar)
-	}
 	if !strings.Contains(sidebar, "On landing page polish.") {
 		t.Fatalf("expected task-driven bubble, got %q", sidebar)
 	}
@@ -1191,7 +1185,7 @@ func TestCalendarViewRendersSchedulerAndActions(t *testing.T) {
 	m.members = []channelMember{{Slug: "ceo", Name: "CEO"}}
 
 	view := stripANSI(m.View())
-	if !strings.Contains(view, "Calendar") || !strings.Contains(view, "Nex insights") || !strings.Contains(view, "Opened a follow-up task") {
+	if !strings.Contains(view, "Calendar") || !strings.Contains(view, "Nex insights") || !strings.Contains(view, "sleeping") {
 		t.Fatalf("expected calendar view content, got %q", view)
 	}
 }
@@ -1200,7 +1194,7 @@ func TestInsightsViewRendersSignalsDecisionsAndWatchdogs(t *testing.T) {
 	m := newChannelModel(false)
 	m.width = 120
 	m.height = 30
-	m.activeApp = officeAppInsights
+	m.activeApp = officeAppPolicies
 	m.signals = []channelSignal{{
 		ID:         "signal-1",
 		Source:     "nex_insights",
@@ -1231,11 +1225,8 @@ func TestInsightsViewRendersSignalsDecisionsAndWatchdogs(t *testing.T) {
 	}}
 
 	view := stripANSI(m.View())
-	if !strings.Contains(view, "Signals") || !strings.Contains(view, "Decisions") || !strings.Contains(view, "Watchdogs") {
-		t.Fatalf("expected insights sections, got %q", view)
-	}
-	if !strings.Contains(view, "Signup conversion is slipping.") || !strings.Contains(view, "Open a frontend follow-up.") || !strings.Contains(view, "Task is waiting for movement.") {
-		t.Fatalf("expected ledger content in insights view, got %q", view)
+	if !strings.Contains(view, "Policies") || !strings.Contains(view, "Open a frontend follow-up.") {
+		t.Fatalf("expected policies view content, got %q", view)
 	}
 }
 
@@ -1345,7 +1336,7 @@ func TestMouseClickJumpLatestClearsUnread(t *testing.T) {
 	}
 }
 
-func TestMouseClickCollapsedThreadOpensThreadPanel(t *testing.T) {
+func TestExpandedThreadsDoNotExposeCollapsedThreadSummaryRow(t *testing.T) {
 	m := newChannelModel(true)
 	m.width = 120
 	m.height = 32
@@ -1355,7 +1346,7 @@ func TestMouseClickCollapsedThreadOpensThreadPanel(t *testing.T) {
 	}
 
 	layout := computeLayout(m.width, m.height, m.threadPanelOpen, m.sidebarCollapsed)
-	headerH, msgH, _ := m.mainPanelGeometry(layout.MainW, layout.ContentH)
+	_, msgH, _ := m.mainPanelGeometry(layout.MainW, layout.ContentH)
 	contentWidth := layout.MainW - 2
 	lines := buildOfficeMessageLines(m.messages, m.expandedThreads, contentWidth, m.threadsDefaultExpand)
 	visible, _, _, _ := sliceRenderedLines(lines, msgH, m.scroll)
@@ -1366,14 +1357,8 @@ func TestMouseClickCollapsedThreadOpensThreadPanel(t *testing.T) {
 			break
 		}
 	}
-	if row < 0 {
-		t.Fatal("expected collapsed thread summary row")
-	}
-
-	next, _ := m.Update(tea.MouseMsg{Type: tea.MouseLeft, Button: tea.MouseButtonLeft, X: layout.SidebarW + 5, Y: headerH + row})
-	got := next.(channelModel)
-	if !got.threadPanelOpen || got.threadPanelID != "msg-1" {
-		t.Fatalf("expected click to open thread panel for msg-1, got open=%v id=%q", got.threadPanelOpen, got.threadPanelID)
+	if row >= 0 {
+		t.Fatalf("expected no collapsed thread summary row, got row=%d", row)
 	}
 }
 

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -15,6 +15,11 @@ import (
 
 var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
+func init() {
+	_ = os.Setenv("WUPHF_API_KEY", "test-key")
+	_ = os.Unsetenv("WUPHF_NO_NEX")
+}
+
 func stripANSI(s string) string {
 	return ansiPattern.ReplaceAllString(s, "")
 }

--- a/internal/action/composio.go
+++ b/internal/action/composio.go
@@ -72,18 +72,65 @@ func (c *ComposioREST) Guide(_ context.Context, topic string) (GuideResult, erro
 		"topic":    topic,
 		"notes": []string{
 			"Use search -> knowledge -> dry-run -> execute for external actions.",
-			"Use connected account IDs returned by team_action_connections as the connection_key.",
+			"Use connected account IDs returned by team_action_connections as the connection_key. If a workflow omits connection_key and there is exactly one active connection for that platform, WUPHF auto-resolves it.",
 			"Trigger registration is supported through the existing relay compatibility tools with one event filter per trigger.",
 			"Workflow creation and execution are WUPHF-native: save a workflow definition in WUPHF, then WUPHF executes external steps through Composio.",
-			`Supported workflow kind: "wuphf_digest_email_v1" for a daily digest that fetches Gmail from the last 24 hours, hydrates it with Nex context, and emails the human.`,
+			`Supported WUPHF workflow step types: "action", "template", "nex_ask", and "nex_insights".`,
+			"Every workflow step also exposes a generic .result value: action=result response object, template=result text, nex_ask=result answer text, nex_insights=result compact insight summary text.",
+			"Use a template step to compress large action output into concise text before handing it to nex_ask or another action.",
+			"Keep workflow compose prompts compact. For digest/report flows, default to about 10 recent emails and 5 recent insights unless the human explicitly asks for more.",
+			"Do not dump raw JSON from .response or .insights into nex_ask when a compact .result summary will do.",
 		},
 		"workflow_examples": []map[string]any{{
-			"kind":            composioDigestWorkflowKind,
-			"connection_key":  "ca_...",
-			"recipient_email": config.ResolveComposioUserID(),
-			"subject":         "WUPHF Daily Digest",
-			"window_hours":    24,
-			"max_results":     20,
+			"version": composioWorkflowVersion,
+			"inputs": map[string]any{
+				"connection_key":  "ca_...",
+				"recipient_email": config.ResolveComposioUserID(),
+				"subject":         "Daily digest",
+				"window_hours":    24,
+				"insight_limit":   5,
+			},
+			"steps": []map[string]any{
+				{
+					"id":             "fetch_emails",
+					"type":           "action",
+					"platform":       "gmail",
+					"action_id":      "GMAIL_FETCH_EMAILS",
+					"connection_key": "{{ .inputs.connection_key }}",
+					"data": map[string]any{
+						"query":       "newer_than:1d",
+						"max_results": 10,
+					},
+				},
+				{
+					"id":             "recent_insights",
+					"type":           "nex_insights",
+					"lookback_hours": "{{ .inputs.window_hours }}",
+					"insight_limit":  "{{ .inputs.insight_limit }}",
+				},
+				{
+					"id":       "email_summary",
+					"type":     "template",
+					"template": "Email highlights from the last 24 hours:\n{{- range $m := .steps.fetch_emails.result.data.messages }}\n- {{ $m.sender }} | {{ $m.subject }} | {{ $m.preview.body }}\n{{- end }}",
+				},
+				{
+					"id":             "compose_digest",
+					"type":           "nex_ask",
+					"query_template": "Draft a digest with Why This Matters and What To Do Next sections.\n\n{{ .steps.email_summary.result }}\n\n{{ .steps.recent_insights.result }}",
+				},
+				{
+					"id":             "send_email",
+					"type":           "action",
+					"platform":       "gmail",
+					"action_id":      "GMAIL_SEND_EMAIL",
+					"connection_key": "{{ .inputs.connection_key }}",
+					"data": map[string]any{
+						"recipient_email": "{{ .inputs.recipient_email }}",
+						"subject":         "{{ .inputs.subject }}",
+						"body":            "{{ .steps.compose_digest.result }}",
+					},
+				},
+			},
 		}},
 	})
 	return GuideResult{Topic: topic, Raw: raw}, nil

--- a/internal/action/composio_test.go
+++ b/internal/action/composio_test.go
@@ -15,8 +15,8 @@ func TestComposioRESTActionHappyPath(t *testing.T) {
 	mux.HandleFunc("/connected_accounts", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"items": []map[string]any{{
-				"id":     "ca_123",
-				"status": "ACTIVE",
+				"id":      "ca_123",
+				"status":  "ACTIVE",
 				"user_id": "cmp_user_123",
 				"toolkit": map[string]any{
 					"slug": "gmail",
@@ -213,14 +213,62 @@ func TestComposioRESTWorkflowDigestHappyPath(t *testing.T) {
 		Client:  server.Client(),
 	}
 
+	definition, _ := json.Marshal(map[string]any{
+		"version": composioWorkflowVersion,
+		"inputs": map[string]any{
+			"connection_key":  "ca_123",
+			"recipient_email": "najmuzzaman@nex.ai",
+			"subject":         "Daily Digest",
+			"window_hours":    24,
+			"insight_limit":   5,
+			"max_results":     10,
+		},
+		"steps": []map[string]any{
+			{
+				"id":             "fetch_emails",
+				"type":           "action",
+				"platform":       "gmail",
+				"action_id":      "GMAIL_FETCH_EMAILS",
+				"connection_key": "{{ .inputs.connection_key }}",
+				"data": map[string]any{
+					"query":       "newer_than:1d",
+					"max_results": "{{ .inputs.max_results }}",
+				},
+			},
+			{
+				"id":             "recent_insights",
+				"type":           "nex_insights",
+				"lookback_hours": "{{ .inputs.window_hours }}",
+				"insight_limit":  "{{ .inputs.insight_limit }}",
+			},
+			{
+				"id":   "email_summary",
+				"type": "template",
+				"template": "Email highlights:\n{{- range $m := .steps.fetch_emails.result.data.messages }}\n- {{ $m.sender }} | {{ $m.subject }} | {{ $m.preview.body }}\n{{- end }}",
+			},
+			{
+				"id":             "compose_digest",
+				"type":           "nex_ask",
+				"query_template": "Create a plain-text daily digest with sections Executive Summary, Why This Matters, What To Do Next, Email Highlights, and Relevant Nex Insights.\n\n{{ .steps.email_summary.result }}\n\nInsights:\n{{ .steps.recent_insights.result }}",
+			},
+			{
+				"id":             "send_email",
+				"type":           "action",
+				"platform":       "gmail",
+				"action_id":      "GMAIL_SEND_EMAIL",
+				"connection_key": "{{ .inputs.connection_key }}",
+				"data": map[string]any{
+					"recipient_email": "{{ .inputs.recipient_email }}",
+					"subject":         "{{ .inputs.subject }}",
+					"body":            "{{ .steps.compose_digest.result }}",
+				},
+			},
+		},
+	})
+
 	created, err := client.CreateWorkflow(context.Background(), WorkflowCreateRequest{
-		Key: "daily-digest",
-		Definition: json.RawMessage(`{
-			"kind":"wuphf_digest_email_v1",
-			"connection_key":"ca_123",
-			"recipient_email":"najmuzzaman@nex.ai",
-			"subject":"Daily Digest"
-		}`),
+		Key:        "daily-digest",
+		Definition: definition,
 	})
 	if err != nil {
 		t.Fatalf("create workflow: %v", err)
@@ -248,5 +296,358 @@ func TestComposioRESTWorkflowDigestHappyPath(t *testing.T) {
 	}
 	if len(runs.Runs) != 1 {
 		t.Fatalf("expected 1 run, got %+v", runs.Runs)
+	}
+}
+
+func TestComposioRESTWorkflowNormalizesProviderStepAliases(t *testing.T) {
+	client := &ComposioREST{}
+	definition, _ := json.Marshal(map[string]any{
+		"version": composioWorkflowVersion,
+		"steps": []map[string]any{
+			{
+				"id":             "send_email",
+				"type":           "composio",
+				"platform":       "gmail",
+				"action_id":      "GMAIL_SEND_EMAIL",
+				"connection_key": "ca_123",
+				"data": map[string]any{
+					"recipient_email": "najmuzzaman@nex.ai",
+					"subject":         "Hi",
+					"body":            "Body",
+				},
+			},
+		},
+	})
+
+	spec, err := client.decodeWorkflowDefinition(definition)
+	if err != nil {
+		t.Fatalf("decode workflow definition: %v", err)
+	}
+	if len(spec.Steps) != 1 {
+		t.Fatalf("expected 1 step, got %d", len(spec.Steps))
+	}
+	if spec.Steps[0].Type != "action" {
+		t.Fatalf("expected normalized step type action, got %q", spec.Steps[0].Type)
+	}
+}
+
+func TestComposioRESTWorkflowNormalizesAgentShorthandSyntax(t *testing.T) {
+	client := &ComposioREST{}
+	definition, _ := json.Marshal(map[string]any{
+		"version": composioWorkflowVersion,
+		"inputs": map[string]any{
+			"recipient": map[string]any{
+				"type":        "string",
+				"default":     "najmuzzaman@nex.ai",
+				"description": "Email recipient",
+			},
+			"gmail_connection_key": map[string]any{
+				"type":    "string",
+				"default": "ca_123",
+			},
+		},
+		"steps": []map[string]any{
+			{
+				"id":             "fetch_emails",
+				"type":           "action",
+				"platform":       "gmail",
+				"action_id":      "GMAIL_FETCH_EMAILS",
+				"connection_key": "{{inputs.gmail_connection_key}}",
+				"params": map[string]any{
+					"query": "newer_than:1d",
+				},
+			},
+			{
+				"id":       "compose",
+				"type":     "template",
+				"template": "Recent emails: {{steps.fetch_emails.result}}",
+			},
+			{
+				"id":             "send_digest",
+				"type":           "action",
+				"platform":       "gmail",
+				"action_id":      "GMAIL_SEND_EMAIL",
+				"connection_key": "{{inputs.gmail_connection_key}}",
+				"params": map[string]any{
+					"recipient_email": "{{inputs.recipient}}",
+					"subject":         "Daily Digest — {{today_date}}",
+					"body":            "{{steps.compose.result}}",
+				},
+			},
+		},
+	})
+
+	spec, err := client.decodeWorkflowDefinition(definition)
+	if err != nil {
+		t.Fatalf("decode workflow definition: %v", err)
+	}
+	if got := spec.Inputs["recipient"]; got != "najmuzzaman@nex.ai" {
+		t.Fatalf("expected input default to normalize, got %#v", got)
+	}
+	if got := spec.Steps[0].ConnectionKey; got != "{{ .inputs.gmail_connection_key}}" {
+		t.Fatalf("expected normalized connection_key, got %#v", got)
+	}
+	if got := spec.Steps[0].Data["query"]; got != "newer_than:1d" {
+		t.Fatalf("expected params to normalize into data, got %#v", got)
+	}
+	if got := spec.Steps[1].Template; got != "Recent emails: {{ .steps.fetch_emails.result}}" {
+		t.Fatalf("expected normalized template, got %q", got)
+	}
+	if got := spec.Steps[2].Data["subject"]; got != "Daily Digest — {{ .now.date }}" && got != "Daily Digest — {{ .now.date}}" {
+		t.Fatalf("expected normalized today_date template, got %#v", got)
+	}
+}
+
+func TestComposioRESTWorkflowNormalizesHandlebarsEachSyntax(t *testing.T) {
+	client := &ComposioREST{}
+	definition, _ := json.Marshal(map[string]any{
+		"version": composioWorkflowVersion,
+		"steps": []map[string]any{
+			{
+				"id":   "email_summary",
+				"type": "template",
+				"template": "Recent emails:\n{{#each steps.fetch_emails.result.data.messages}}\n- {{this.sender}} | {{this.subject}}\n{{/each}}",
+			},
+		},
+	})
+
+	spec, err := client.decodeWorkflowDefinition(definition)
+	if err != nil {
+		t.Fatalf("decode workflow definition: %v", err)
+	}
+	want := "Recent emails:\n{{- range $item := .steps.fetch_emails.result.data.messages }}\n- {{ $item.sender }} | {{ $item.subject }}\n{{- end }}"
+	if got := spec.Steps[0].Template; got != want {
+		t.Fatalf("expected normalized handlebars loop, got %q", got)
+	}
+}
+
+func TestComposioRESTWorkflowAutoResolvesSingleConnection(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_API_KEY", "nex-test-key")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/connected_accounts", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{{
+				"id":      "ca_123",
+				"status":  "ACTIVE",
+				"user_id": "cmp_user_123",
+				"toolkit": map[string]any{
+					"slug": "gmail",
+					"name": "Gmail",
+				},
+				"connection": map[string]any{
+					"name": "Founder Gmail",
+				},
+			}},
+		})
+	})
+	mux.HandleFunc("/connected_accounts/ca_123", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "ca_123",
+			"user_id": "cmp_user_123",
+			"status":  "ACTIVE",
+		})
+	})
+	mux.HandleFunc("/tools/execute/GMAIL_SEND_EMAIL", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"successful": true,
+			"echo":       body,
+			"data": map[string]any{
+				"id": "msg-123",
+			},
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &ComposioREST{
+		APIKey:  "cmp_test",
+		UserID:  "najmuzzaman@nex.ai",
+		BaseURL: server.URL,
+		Client:  server.Client(),
+	}
+
+	definition, _ := json.Marshal(map[string]any{
+		"version": composioWorkflowVersion,
+		"steps": []map[string]any{
+			{
+				"id":        "send_digest",
+				"type":      "action",
+				"platform":  "gmail",
+				"action_id": "GMAIL_SEND_EMAIL",
+				"data": map[string]any{
+					"recipient_email": "najmuzzaman@nex.ai",
+					"subject":         "Daily Digest — {{ .meta.date }}",
+					"body":            "Hello",
+				},
+			},
+		},
+	})
+
+	if _, err := client.CreateWorkflow(context.Background(), WorkflowCreateRequest{
+		Key:        "auto-resolve-connection",
+		Definition: definition,
+	}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	result, err := client.ExecuteWorkflow(context.Background(), WorkflowExecuteRequest{
+		KeyOrPath: "auto-resolve-connection",
+		DryRun:    true,
+	})
+	if err != nil {
+		t.Fatalf("execute workflow: %v", err)
+	}
+	var step map[string]any
+	if err := json.Unmarshal(result.Steps["send_digest"], &step); err != nil {
+		t.Fatalf("decode action step: %v", err)
+	}
+	if got := step["connection_key"]; got != "ca_123" {
+		t.Fatalf("expected auto-resolved connection_key ca_123, got %#v", got)
+	}
+	rendered, err := renderWorkflowTemplate("Daily Digest — {{ .meta.date }}", workflowScope("auto-resolve-connection", map[string]any{}, map[string]any{}))
+	if err != nil {
+		t.Fatalf("render meta date template: %v", err)
+	}
+	if !strings.Contains(rendered, "Daily Digest — ") {
+		t.Fatalf("expected rendered meta date subject, got %q", rendered)
+	}
+}
+
+func TestDecodeJSONObjectHandlesJSONStringPayload(t *testing.T) {
+	raw := json.RawMessage(`"{\"data\":{\"messages\":[{\"subject\":\"hello\",\"sender\":\"a@example.com\"}]}}"`)
+	decoded := decodeJSONObject(raw)
+	asMap, ok := decoded.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map result, got %T", decoded)
+	}
+	data, ok := asMap["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected data map, got %#v", asMap["data"])
+	}
+	msgs, ok := data["messages"].([]any)
+	if !ok || len(msgs) != 1 {
+		t.Fatalf("expected decoded messages, got %#v", data["messages"])
+	}
+}
+
+func TestWorkflowStepsExposeGenericResult(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_API_KEY", "nex-test-key")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/connected_accounts/ca_123", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "ca_123",
+			"user_id": "cmp_user_123",
+			"status":  "ACTIVE",
+		})
+	})
+	mux.HandleFunc("/tools/execute/GMAIL_FETCH_EMAILS", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"messages": []map[string]any{{
+					"subject": "hello",
+					"sender":  "a@example.com",
+				}},
+			},
+		})
+	})
+	mux.HandleFunc("/api/developers/v1/context/ask", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"answer": "Digest body",
+		})
+	})
+	mux.HandleFunc("/api/developers/v1/insights", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"insights": []map[string]any{{
+				"id":      "ins-1",
+				"type":    "risk",
+				"content": "Something changed.",
+			}},
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	t.Setenv("WUPHF_DEV_URL", server.URL)
+
+	client := &ComposioREST{
+		APIKey:  "cmp_test",
+		UserID:  "najmuzzaman@nex.ai",
+		BaseURL: server.URL,
+		Client:  server.Client(),
+	}
+
+	definition, _ := json.Marshal(map[string]any{
+		"version": composioWorkflowVersion,
+		"inputs": map[string]any{
+			"connection_key": "ca_123",
+		},
+		"steps": []map[string]any{
+			{
+				"id":             "fetch_emails",
+				"type":           "action",
+				"platform":       "gmail",
+				"action_id":      "GMAIL_FETCH_EMAILS",
+				"connection_key": "{{ .inputs.connection_key }}",
+			},
+			{
+				"id":       "email_summary",
+				"type":     "template",
+				"template": "{{ range .steps.fetch_emails.result.data.messages }}{{ .subject }}{{ end }}",
+			},
+			{
+				"id":             "recent_insights",
+				"type":           "nex_insights",
+				"lookback_hours": 24,
+				"insight_limit":  5,
+			},
+			{
+				"id":             "compose_digest",
+				"type":           "nex_ask",
+				"query_template": "{{ .steps.email_summary.result }} :: {{ toPrettyJSON .steps.recent_insights.result }}",
+			},
+		},
+	})
+
+	if _, err := client.CreateWorkflow(context.Background(), WorkflowCreateRequest{
+		Key:        "result-aliases",
+		Definition: definition,
+	}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	result, err := client.ExecuteWorkflow(context.Background(), WorkflowExecuteRequest{
+		KeyOrPath: "result-aliases",
+	})
+	if err != nil {
+		t.Fatalf("execute workflow: %v", err)
+	}
+
+	var compose map[string]any
+	if err := json.Unmarshal(result.Steps["compose_digest"], &compose); err != nil {
+		t.Fatalf("decode compose step: %v", err)
+	}
+	if compose["result"] != "Digest body" {
+		t.Fatalf("expected compose result alias, got %#v", compose["result"])
+	}
+
+	var summary map[string]any
+	if err := json.Unmarshal(result.Steps["email_summary"], &summary); err != nil {
+		t.Fatalf("decode summary step: %v", err)
+	}
+	if summary["result"] != "hello" {
+		t.Fatalf("expected template result alias, got %#v", summary["result"])
+	}
+
+	var recentInsights map[string]any
+	if err := json.Unmarshal(result.Steps["recent_insights"], &recentInsights); err != nil {
+		t.Fatalf("decode recent insights step: %v", err)
+	}
+	insightSummary, _ := recentInsights["result"].(string)
+	if !strings.Contains(insightSummary, "Something changed.") {
+		t.Fatalf("expected compact insight summary, got %#v", recentInsights["result"])
 	}
 }

--- a/internal/action/composio_workflows.go
+++ b/internal/action/composio_workflows.go
@@ -1,68 +1,45 @@
 package action
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
-	"sort"
+	"regexp"
 	"strings"
+	"text/template"
 	"time"
-
-	"github.com/nex-crm/wuphf/internal/config"
 )
 
-const composioDigestWorkflowKind = "wuphf_digest_email_v1"
+const composioWorkflowVersion = "wuphf_workflow_v1"
 
-type composioDigestWorkflowDefinition struct {
-	Kind             string `json:"kind"`
-	Title            string `json:"title,omitempty"`
-	Description      string `json:"description,omitempty"`
-	ConnectionKey    string `json:"connection_key"`
-	RecipientEmail   string `json:"recipient_email,omitempty"`
-	Subject          string `json:"subject,omitempty"`
-	Query            string `json:"query,omitempty"`
-	WindowHours      int    `json:"window_hours,omitempty"`
-	MaxResults       int    `json:"max_results,omitempty"`
-	InsightLimit     int    `json:"insight_limit,omitempty"`
-	IncludeSpamTrash bool   `json:"include_spam_trash,omitempty"`
-	DigestPrompt     string `json:"digest_prompt,omitempty"`
+type composioWorkflowDefinition struct {
+	Version     string         `json:"version,omitempty"`
+	Title       string         `json:"title,omitempty"`
+	Description string         `json:"description,omitempty"`
+	Inputs      map[string]any `json:"inputs,omitempty"`
+	Steps       []workflowStep `json:"steps"`
 }
 
-type composioDigestWorkflowInputs struct {
-	ConnectionKey    string
-	RecipientEmail   string
-	Subject          string
-	Query            string
-	WindowHours      int
-	MaxResults       int
-	InsightLimit     int
-	IncludeSpamTrash bool
-	DigestPrompt     string
-}
-
-type composioFetchedMessage struct {
-	MessageID        string   `json:"messageId"`
-	ThreadID         string   `json:"threadId"`
-	Timestamp        string   `json:"messageTimestamp"`
-	Subject          string   `json:"subject"`
-	Sender           string   `json:"sender"`
-	To               string   `json:"to"`
-	MessageText      string   `json:"messageText"`
-	LabelIDs         []string `json:"labelIds"`
-	AttachmentList   []any    `json:"attachmentList"`
-	Preview          struct {
-		Body    string `json:"body"`
-		Subject string `json:"subject"`
-	} `json:"preview"`
-}
-
-type composioFetchEmailsResponse struct {
-	Data struct {
-		Messages           []composioFetchedMessage `json:"messages"`
-		NextPageToken      string                   `json:"nextPageToken"`
-		ResultSizeEstimate int                      `json:"resultSizeEstimate"`
-	} `json:"data"`
+type workflowStep struct {
+	ID              string         `json:"id"`
+	Type            string         `json:"type"`
+	Description     string         `json:"description,omitempty"`
+	Template        string         `json:"template,omitempty"`
+	Platform        string         `json:"platform,omitempty"`
+	ActionID        string         `json:"action_id,omitempty"`
+	ConnectionKey   any            `json:"connection_key,omitempty"`
+	Data            map[string]any `json:"data,omitempty"`
+	Params          map[string]any `json:"params,omitempty"`
+	PathVariables   map[string]any `json:"path_variables,omitempty"`
+	QueryParameters map[string]any `json:"query_parameters,omitempty"`
+	Headers         map[string]any `json:"headers,omitempty"`
+	FormData        bool           `json:"form_data,omitempty"`
+	FormURLEncoded  bool           `json:"form_url_encoded,omitempty"`
+	DryRun          *bool          `json:"dry_run,omitempty"`
+	QueryTemplate   string         `json:"query_template,omitempty"`
+	LookbackHours   any            `json:"lookback_hours,omitempty"`
+	InsightLimit    any            `json:"insight_limit,omitempty"`
 }
 
 type workflowRunRecord struct {
@@ -96,93 +73,49 @@ func (c *ComposioREST) ExecuteWorkflow(ctx context.Context, req WorkflowExecuteR
 	if err != nil {
 		return WorkflowExecuteResult{}, err
 	}
-	spec, err := c.decodeDigestWorkflowDefinition(definition)
+	spec, err := c.decodeWorkflowDefinition(definition)
 	if err != nil {
 		return WorkflowExecuteResult{}, err
 	}
-	inputs := mergeDigestWorkflowInputs(spec, req.Inputs)
-	if inputs.ConnectionKey == "" {
-		return WorkflowExecuteResult{}, fmt.Errorf("workflow %s is missing connection_key", key)
-	}
-	if inputs.RecipientEmail == "" {
-		return WorkflowExecuteResult{}, fmt.Errorf("workflow %s is missing recipient_email", key)
-	}
 
+	inputs := mergeWorkflowInputs(spec.Inputs, req.Inputs)
+	stepOutputs := map[string]any{}
+	stepLogs := map[string]json.RawMessage{}
 	runID := fmt.Sprintf("cmpwf_%d", time.Now().UTC().UnixNano())
 	startedAt := time.Now().UTC()
-	steps := map[string]json.RawMessage{}
-
-	fetchResult, err := c.ExecuteAction(ctx, ExecuteRequest{
-		Platform:      "gmail",
-		ActionID:      "GMAIL_FETCH_EMAILS",
-		ConnectionKey: inputs.ConnectionKey,
-		Data: map[string]any{
-			"query":              inputs.Query,
-			"max_results":        inputs.MaxResults,
-			"include_payload":    false,
-			"verbose":            false,
-			"include_spam_trash": inputs.IncludeSpamTrash,
-		},
-	})
-	if err != nil {
-		return WorkflowExecuteResult{}, err
+	events := []json.RawMessage{
+		mustMarshalJSON(map[string]any{
+			"event":        "workflow_started",
+			"provider":     c.Name(),
+			"workflow_key": key,
+			"run_id":       runID,
+		}),
 	}
-	steps["fetch_emails"] = mustMarshalJSON(map[string]any{
-		"request": fetchResult.Request,
-	})
 
-	var fetchPayload composioFetchEmailsResponse
-	if err := json.Unmarshal(fetchResult.Response, &fetchPayload); err != nil {
-		return WorkflowExecuteResult{}, fmt.Errorf("parse composio workflow fetch response: %w", err)
+	for _, step := range spec.Steps {
+		scope := workflowScope(key, inputs, stepOutputs)
+		output, err := c.executeWorkflowStep(ctx, step, scope, req.DryRun)
+		if err != nil {
+			return WorkflowExecuteResult{}, fmt.Errorf("workflow %s step %s failed: %w", key, step.ID, err)
+		}
+		stepOutputs[step.ID] = output
+		stepLogs[step.ID] = mustMarshalJSON(output)
+		events = append(events, mustMarshalJSON(map[string]any{
+			"event":   "workflow_step_completed",
+			"step_id": step.ID,
+			"type":    step.Type,
+		}))
 	}
-	messages := fetchPayload.Data.Messages
-	steps["fetch_emails"] = mustMarshalJSON(map[string]any{
-		"request":              fetchResult.Request,
-		"count":                len(messages),
-		"next_page_token":      fetchPayload.Data.NextPageToken,
-		"result_size_estimate": fetchPayload.Data.ResultSizeEstimate,
-		"messages":             summarizeFetchedMessages(messages),
-	})
-
-	digestBody, hydration, err := buildDigestBody(messages, inputs)
-	if err != nil {
-		return WorkflowExecuteResult{}, err
-	}
-	steps["hydrate_digest"] = mustMarshalJSON(hydration)
-
-	sendResult, err := c.ExecuteAction(ctx, ExecuteRequest{
-		Platform:      "gmail",
-		ActionID:      "GMAIL_SEND_EMAIL",
-		ConnectionKey: inputs.ConnectionKey,
-		DryRun:        req.DryRun,
-		Data: map[string]any{
-			"recipient_email": inputs.RecipientEmail,
-			"subject":         inputs.Subject,
-			"body":            digestBody,
-		},
-	})
-	if err != nil {
-		return WorkflowExecuteResult{}, err
-	}
-	steps["send_email"] = mustMarshalJSON(map[string]any{
-		"dry_run":  sendResult.DryRun,
-		"request":  sendResult.Request,
-		"response": json.RawMessage(sendResult.Response),
-	})
 
 	status := "completed"
 	if req.DryRun {
 		status = "planned"
 	}
-	result := WorkflowExecuteResult{
-		RunID:  runID,
-		Status: status,
-		Steps:  steps,
-		Events: []json.RawMessage{
-			mustMarshalJSON(map[string]any{"event": "workflow_started", "run_id": runID, "workflow_key": key}),
-			mustMarshalJSON(map[string]any{"event": "workflow_finished", "run_id": runID, "status": status}),
-		},
-	}
+	events = append(events, mustMarshalJSON(map[string]any{
+		"event":  "workflow_finished",
+		"run_id": runID,
+		"status": status,
+	}))
 
 	_ = appendWorkflowRun(c.Name(), key, workflowRunRecord{
 		Provider:    c.Name(),
@@ -191,9 +124,15 @@ func (c *ComposioREST) ExecuteWorkflow(ctx context.Context, req WorkflowExecuteR
 		Status:      status,
 		StartedAt:   startedAt.Format(time.RFC3339),
 		FinishedAt:  time.Now().UTC().Format(time.RFC3339),
-		Steps:       steps,
+		Steps:       stepLogs,
 	})
-	return result, nil
+
+	return WorkflowExecuteResult{
+		RunID:  runID,
+		Status: status,
+		Steps:  stepLogs,
+		Events: events,
+	}, nil
 }
 
 func (c *ComposioREST) ListWorkflowRuns(_ context.Context, key string) (WorkflowRunsResult, error) {
@@ -201,7 +140,7 @@ func (c *ComposioREST) ListWorkflowRuns(_ context.Context, key string) (Workflow
 }
 
 func (c *ComposioREST) normalizeWorkflowDefinition(definition json.RawMessage) (json.RawMessage, error) {
-	spec, err := c.decodeDigestWorkflowDefinition(definition)
+	spec, err := c.decodeWorkflowDefinition(definition)
 	if err != nil {
 		return nil, err
 	}
@@ -212,216 +151,594 @@ func (c *ComposioREST) normalizeWorkflowDefinition(definition json.RawMessage) (
 	return raw, nil
 }
 
-func (c *ComposioREST) decodeDigestWorkflowDefinition(definition json.RawMessage) (composioDigestWorkflowDefinition, error) {
-	var spec composioDigestWorkflowDefinition
+func (c *ComposioREST) decodeWorkflowDefinition(definition json.RawMessage) (composioWorkflowDefinition, error) {
+	var spec composioWorkflowDefinition
 	if !json.Valid(definition) {
 		return spec, fmt.Errorf("workflow definition must be valid JSON")
 	}
 	if err := json.Unmarshal(definition, &spec); err != nil {
 		return spec, fmt.Errorf("parse workflow definition: %w", err)
 	}
-	if strings.TrimSpace(spec.Kind) == "" {
-		return spec, fmt.Errorf("workflow definition must include kind")
+	spec.Version = fallbackString(spec.Version, composioWorkflowVersion)
+	if spec.Version != composioWorkflowVersion {
+		return spec, fmt.Errorf("unsupported composio workflow version %q", spec.Version)
 	}
-	if strings.TrimSpace(spec.Kind) != composioDigestWorkflowKind {
-		return spec, fmt.Errorf("unsupported composio workflow kind %q", spec.Kind)
+	spec.Inputs = normalizeWorkflowInputs(spec.Inputs)
+	if len(spec.Steps) == 0 {
+		return spec, fmt.Errorf("workflow definition must include at least one step")
 	}
-	spec.ConnectionKey = strings.TrimSpace(spec.ConnectionKey)
-	spec.RecipientEmail = fallbackString(spec.RecipientEmail, config.ResolveComposioUserID())
-	spec.Subject = fallbackString(spec.Subject, "WUPHF Daily Digest")
-	if spec.WindowHours <= 0 {
-		spec.WindowHours = 24
-	}
-	if spec.MaxResults <= 0 {
-		spec.MaxResults = 20
-	}
-	if spec.InsightLimit <= 0 {
-		spec.InsightLimit = 5
-	}
-	spec.Query = fallbackString(spec.Query, defaultDigestQuery(spec.WindowHours))
-	spec.DigestPrompt = strings.TrimSpace(spec.DigestPrompt)
-	if spec.ConnectionKey == "" {
-		return spec, fmt.Errorf("workflow definition must include connection_key")
-	}
-	if spec.RecipientEmail == "" {
-		return spec, fmt.Errorf("workflow definition must include recipient_email")
+	seen := map[string]struct{}{}
+	for i := range spec.Steps {
+		spec.Steps[i].ID = strings.TrimSpace(spec.Steps[i].ID)
+		spec.Steps[i].Type = normalizeWorkflowStepType(spec.Steps[i].Type)
+		if len(spec.Steps[i].Data) == 0 && len(spec.Steps[i].Params) > 0 {
+			spec.Steps[i].Data = spec.Steps[i].Params
+		}
+		spec.Steps[i].Template = normalizeWorkflowTemplateString(spec.Steps[i].Template)
+		spec.Steps[i].QueryTemplate = normalizeWorkflowTemplateString(spec.Steps[i].QueryTemplate)
+		spec.Steps[i].ConnectionKey = normalizeWorkflowValueSyntax(spec.Steps[i].ConnectionKey)
+		spec.Steps[i].Data = normalizeWorkflowMapSyntax(spec.Steps[i].Data)
+		spec.Steps[i].PathVariables = normalizeWorkflowMapSyntax(spec.Steps[i].PathVariables)
+		spec.Steps[i].QueryParameters = normalizeWorkflowMapSyntax(spec.Steps[i].QueryParameters)
+		spec.Steps[i].Headers = normalizeWorkflowMapSyntax(spec.Steps[i].Headers)
+		spec.Steps[i].LookbackHours = normalizeWorkflowValueSyntax(spec.Steps[i].LookbackHours)
+		spec.Steps[i].InsightLimit = normalizeWorkflowValueSyntax(spec.Steps[i].InsightLimit)
+		if spec.Steps[i].ID == "" {
+			return spec, fmt.Errorf("workflow step %d is missing id", i+1)
+		}
+		if _, ok := seen[spec.Steps[i].ID]; ok {
+			return spec, fmt.Errorf("workflow step id %q is duplicated", spec.Steps[i].ID)
+		}
+		seen[spec.Steps[i].ID] = struct{}{}
+		switch spec.Steps[i].Type {
+		case "action":
+			if strings.TrimSpace(spec.Steps[i].Platform) == "" {
+				return spec, fmt.Errorf("workflow step %q is missing platform", spec.Steps[i].ID)
+			}
+			if strings.TrimSpace(spec.Steps[i].ActionID) == "" {
+				return spec, fmt.Errorf("workflow step %q is missing action_id", spec.Steps[i].ID)
+			}
+		case "template":
+			if strings.TrimSpace(spec.Steps[i].Template) == "" {
+				return spec, fmt.Errorf("workflow step %q is missing template", spec.Steps[i].ID)
+			}
+		case "nex_ask":
+			if strings.TrimSpace(spec.Steps[i].QueryTemplate) == "" {
+				return spec, fmt.Errorf("workflow step %q is missing query_template", spec.Steps[i].ID)
+			}
+		case "nex_insights":
+		default:
+			return spec, fmt.Errorf("unsupported workflow step type %q", spec.Steps[i].Type)
+		}
 	}
 	return spec, nil
 }
 
-func mergeDigestWorkflowInputs(spec composioDigestWorkflowDefinition, overrides map[string]any) composioDigestWorkflowInputs {
-	inputs := composioDigestWorkflowInputs{
-		ConnectionKey:    spec.ConnectionKey,
-		RecipientEmail:   spec.RecipientEmail,
-		Subject:          spec.Subject,
-		Query:            spec.Query,
-		WindowHours:      spec.WindowHours,
-		MaxResults:       spec.MaxResults,
-		InsightLimit:     spec.InsightLimit,
-		IncludeSpamTrash: spec.IncludeSpamTrash,
-		DigestPrompt:     spec.DigestPrompt,
+func normalizeWorkflowStepType(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "composio", "one", "external_action", "provider_action":
+		return "action"
+	default:
+		return strings.TrimSpace(raw)
 	}
-	if v := strings.TrimSpace(stringInput(overrides["connection_key"])); v != "" {
-		inputs.ConnectionKey = v
-	}
-	if v := strings.TrimSpace(stringInput(overrides["recipient_email"])); v != "" {
-		inputs.RecipientEmail = v
-	}
-	if v := strings.TrimSpace(stringInput(overrides["subject"])); v != "" {
-		inputs.Subject = v
-	}
-	if v := strings.TrimSpace(stringInput(overrides["query"])); v != "" {
-		inputs.Query = v
-	}
-	if v := intInput(overrides["window_hours"]); v > 0 {
-		inputs.WindowHours = v
-	}
-	if v := intInput(overrides["max_results"]); v > 0 {
-		inputs.MaxResults = v
-	}
-	if v := intInput(overrides["insight_limit"]); v > 0 {
-		inputs.InsightLimit = v
-	}
-	if v, ok := boolInput(overrides["include_spam_trash"]); ok {
-		inputs.IncludeSpamTrash = v
-	}
-	if v := strings.TrimSpace(stringInput(overrides["digest_prompt"])); v != "" {
-		inputs.DigestPrompt = v
-	}
-	if inputs.Query == "" {
-		inputs.Query = defaultDigestQuery(inputs.WindowHours)
-	}
-	if inputs.Subject == "" {
-		inputs.Subject = "WUPHF Daily Digest"
-	}
-	return inputs
 }
 
-func summarizeFetchedMessages(messages []composioFetchedMessage) []map[string]any {
-	out := make([]map[string]any, 0, len(messages))
-	for _, msg := range messages {
-		out = append(out, map[string]any{
-			"message_id": msg.MessageID,
-			"thread_id":  msg.ThreadID,
-			"timestamp":  msg.Timestamp,
-			"subject":    fallbackString(msg.Subject, msg.Preview.Subject),
-			"sender":     msg.Sender,
-			"to":         msg.To,
-			"preview":    truncateText(fallbackString(msg.Preview.Body, msg.MessageText), 240),
-			"labels":     msg.LabelIDs,
-		})
+func normalizeWorkflowInputs(inputs map[string]any) map[string]any {
+	if len(inputs) == 0 {
+		return inputs
+	}
+	out := make(map[string]any, len(inputs))
+	for key, value := range inputs {
+		if obj, ok := value.(map[string]any); ok {
+			if def, ok := obj["default"]; ok {
+				out[key] = normalizeWorkflowValueSyntax(def)
+				continue
+			}
+		}
+		out[key] = normalizeWorkflowValueSyntax(value)
 	}
 	return out
 }
 
-func buildDigestBody(messages []composioFetchedMessage, inputs composioDigestWorkflowInputs) (string, map[string]any, error) {
-	summaries := summarizeFetchedMessages(messages)
-	sort.Slice(summaries, func(i, j int) bool {
-		return stringInput(summaries[i]["timestamp"]) > stringInput(summaries[j]["timestamp"])
+func normalizeWorkflowMapSyntax(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return in
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = normalizeWorkflowValueSyntax(value)
+	}
+	return out
+}
+
+func normalizeWorkflowValueSyntax(value any) any {
+	switch typed := value.(type) {
+	case string:
+		return normalizeWorkflowTemplateString(typed)
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, normalizeWorkflowValueSyntax(item))
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[key] = normalizeWorkflowValueSyntax(item)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+var workflowTemplateShorthandPatterns = []struct {
+	re   *regexp.Regexp
+	repl string
+}{
+	{regexp.MustCompile(`\{\{\s*inputs\.`), "{{ .inputs."},
+	{regexp.MustCompile(`\{\{\s*steps\.`), "{{ .steps."},
+	{regexp.MustCompile(`\{\{\s*workflow\.`), "{{ .workflow."},
+	{regexp.MustCompile(`\{\{\s*now\.`), "{{ .now."},
+	{regexp.MustCompile(`\{\{\s*today_date\s*\}\}`), "{{ .now.date }}"},
+	{regexp.MustCompile(`\{\{\s*today_rfc3339\s*\}\}`), "{{ .now.rfc3339 }}"},
+}
+
+var (
+	workflowHandlebarsEachOpenRe = regexp.MustCompile(`\{\{\s*#each\s+([^}]+?)\s*\}\}`)
+	workflowHandlebarsEachClose  = regexp.MustCompile(`\{\{\s*/each\s*\}\}`)
+	workflowHandlebarsThisRe     = regexp.MustCompile(`\{\{\s*this\.([^}]+?)\s*\}\}`)
+)
+
+func normalizeWorkflowTemplateString(raw string) string {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return raw
+	}
+	for _, pattern := range workflowTemplateShorthandPatterns {
+		text = pattern.re.ReplaceAllString(text, pattern.repl)
+	}
+	text = workflowHandlebarsEachOpenRe.ReplaceAllStringFunc(text, func(match string) string {
+		parts := workflowHandlebarsEachOpenRe.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			return match
+		}
+		expr := strings.TrimSpace(parts[1])
+		if strings.HasPrefix(expr, "steps.") || strings.HasPrefix(expr, "inputs.") || strings.HasPrefix(expr, "workflow.") || strings.HasPrefix(expr, "now.") {
+			expr = "." + expr
+		}
+		return "{{- range $item := " + expr + " }}"
 	})
-	insights, insightsErr := nexInsightsSince(time.Now().UTC().Add(-time.Duration(inputs.WindowHours)*time.Hour), inputs.InsightLimit)
-	askPrompt := composeDigestPrompt(summaries, insights.Insights, inputs)
-	answer, askErr := nexAsk(askPrompt)
-
-	body := strings.TrimSpace(answer.Answer)
-	if body == "" || askErr != nil {
-		body = fallbackDigestBody(summaries, insights.Insights, inputs, askErr)
-	}
-	hydration := map[string]any{
-		"emails_considered": len(summaries),
-		"insights_considered": len(insights.Insights),
-		"nex_prompt": askPrompt,
-		"nex_answer": body,
-	}
-	if insightsErr != nil {
-		hydration["insights_error"] = insightsErr.Error()
-	}
-	if askErr != nil {
-		hydration["nex_error"] = askErr.Error()
-	}
-	return body, hydration, nil
+	text = workflowHandlebarsEachClose.ReplaceAllString(text, "{{- end }}")
+	text = workflowHandlebarsThisRe.ReplaceAllStringFunc(text, func(match string) string {
+		parts := workflowHandlebarsThisRe.FindStringSubmatch(match)
+		if len(parts) != 2 {
+			return match
+		}
+		return "{{ $item." + strings.TrimSpace(parts[1]) + " }}"
+	})
+	return text
 }
 
-func composeDigestPrompt(emails []map[string]any, insights []nexInsightItem, inputs composioDigestWorkflowInputs) string {
-	if strings.TrimSpace(inputs.DigestPrompt) != "" {
-		return strings.TrimSpace(inputs.DigestPrompt) + "\n\nRecent emails:\n" + string(mustMarshalJSON(emails)) + "\n\nRecent insights:\n" + string(mustMarshalJSON(insights))
+func mergeWorkflowInputs(defaults, overrides map[string]any) map[string]any {
+	out := map[string]any{}
+	for key, value := range defaults {
+		out[key] = value
 	}
-	return fmt.Sprintf(
-		"Create a plain-text daily digest email for the human operator.\n\n"+
-			"Use the recent emails and relevant organizational context to produce these sections exactly:\n"+
-			"1. Executive Summary\n2. Why This Matters\n3. What To Do Next\n4. Email Highlights\n5. Relevant Nex Insights\n\n"+
-			"Requirements:\n"+
-			"- focus on the last %d hours\n"+
-			"- explain why each priority matters now\n"+
-			"- give concrete, short next actions\n"+
-			"- mention sender and subject in Email Highlights\n"+
-			"- keep it concise but useful\n\n"+
-			"Recent emails:\n%s\n\nRecent Nex insights:\n%s\n",
-		inputs.WindowHours,
-		string(mustMarshalJSON(emails)),
-		string(mustMarshalJSON(insights)),
-	)
+	for key, value := range overrides {
+		out[key] = value
+	}
+	return out
 }
 
-func fallbackDigestBody(emails []map[string]any, insights []nexInsightItem, inputs composioDigestWorkflowInputs, askErr error) string {
-	var lines []string
-	lines = append(lines, "Executive Summary")
-	if len(emails) == 0 {
-		lines = append(lines, "- No new emails matched the digest window.")
-	} else {
-		lines = append(lines, fmt.Sprintf("- Reviewed %d recent emails from the last %d hours.", len(emails), inputs.WindowHours))
+func workflowScope(key string, inputs map[string]any, steps map[string]any) map[string]any {
+	now := time.Now().UTC()
+	return map[string]any{
+		"workflow": map[string]any{
+			"key":      key,
+			"provider": "composio",
+		},
+		"inputs": normalizeTemplateScopeValue(inputs),
+		"steps":  normalizeTemplateScopeValue(steps),
+		"now": map[string]any{
+			"rfc3339": now.Format(time.RFC3339),
+			"date":    now.Format("2006-01-02"),
+		},
+		"meta": map[string]any{
+			"rfc3339": now.Format(time.RFC3339),
+			"date":    now.Format("2006-01-02"),
+		},
 	}
-	lines = append(lines, "", "Why This Matters")
-	if len(insights) == 0 {
-		lines = append(lines, "- No recent Nex insights were available; this digest is based on email activity alone.")
-	} else {
-		for _, insight := range insights {
-			lines = append(lines, "- "+truncateText(insight.Content, 180))
+}
+
+func (c *ComposioREST) executeWorkflowStep(ctx context.Context, step workflowStep, scope map[string]any, workflowDryRun bool) (map[string]any, error) {
+	switch step.Type {
+	case "action":
+		return c.executeWorkflowActionStep(ctx, step, scope, workflowDryRun)
+	case "template":
+		return executeWorkflowTemplateStep(step, scope)
+	case "nex_ask":
+		return executeWorkflowNexAskStep(step, scope)
+	case "nex_insights":
+		return executeWorkflowNexInsightsStep(step, scope)
+	default:
+		return nil, fmt.Errorf("unsupported workflow step type %q", step.Type)
+	}
+}
+
+func (c *ComposioREST) executeWorkflowActionStep(ctx context.Context, step workflowStep, scope map[string]any, workflowDryRun bool) (map[string]any, error) {
+	connectionKey, err := renderWorkflowString(step.ConnectionKey, scope)
+	if err != nil {
+		return nil, fmt.Errorf("render connection_key: %w", err)
+	}
+	if strings.TrimSpace(connectionKey) == "" {
+		connectionKey, err = c.autoResolveWorkflowConnection(ctx, step.Platform)
+		if err != nil {
+			return nil, err
 		}
 	}
-	lines = append(lines, "", "What To Do Next")
-	if len(emails) == 0 {
-		lines = append(lines, "- No immediate action required from email alone.")
-	} else {
-		for _, email := range emails[:minInt(len(emails), 5)] {
-			lines = append(lines, fmt.Sprintf("- Review %s from %s.", stringInput(email["subject"]), stringInput(email["sender"])))
-		}
+	data, err := renderWorkflowMap(step.Data, scope)
+	if err != nil {
+		return nil, fmt.Errorf("render data: %w", err)
 	}
-	lines = append(lines, "", "Email Highlights")
-	for _, email := range emails[:minInt(len(emails), 8)] {
-		lines = append(lines, fmt.Sprintf("- %s | %s | %s", stringInput(email["sender"]), stringInput(email["subject"]), stringInput(email["preview"])))
+	pathVariables, err := renderWorkflowMap(step.PathVariables, scope)
+	if err != nil {
+		return nil, fmt.Errorf("render path_variables: %w", err)
 	}
-	if askErr != nil {
-		lines = append(lines, "", "Note", "- Nex summary fallback used: "+truncateText(askErr.Error(), 160))
+	queryParameters, err := renderWorkflowMap(step.QueryParameters, scope)
+	if err != nil {
+		return nil, fmt.Errorf("render query_parameters: %w", err)
 	}
-	return strings.Join(lines, "\n")
+	headers, err := renderWorkflowMap(step.Headers, scope)
+	if err != nil {
+		return nil, fmt.Errorf("render headers: %w", err)
+	}
+	stepDryRun := actionStepDryRun(step, workflowDryRun)
+	result, err := c.ExecuteAction(ctx, ExecuteRequest{
+		Platform:        step.Platform,
+		ActionID:        step.ActionID,
+		ConnectionKey:   connectionKey,
+		Data:            data,
+		PathVariables:   pathVariables,
+		QueryParameters: queryParameters,
+		Headers:         headers,
+		FormData:        step.FormData,
+		FormURLEncoded:  step.FormURLEncoded,
+		DryRun:          stepDryRun,
+	})
+	if err != nil {
+		return nil, err
+	}
+	decoded := decodeJSONObject(result.Response)
+	return map[string]any{
+		"type":           "action",
+		"platform":       step.Platform,
+		"action_id":      step.ActionID,
+		"connection_key": connectionKey,
+		"dry_run":        result.DryRun,
+		"request":        result.Request,
+		"response":       decoded,
+		"result":         decoded,
+	}, nil
 }
 
-func defaultDigestQuery(windowHours int) string {
-	if windowHours <= 0 {
-		windowHours = 24
+func (c *ComposioREST) autoResolveWorkflowConnection(ctx context.Context, platform string) (string, error) {
+	result, err := c.ListConnections(ctx, ListConnectionsOptions{Search: platform, Limit: 20})
+	if err != nil {
+		return "", fmt.Errorf("resolve connection_key: %w", err)
 	}
-	days := int(math.Ceil(float64(windowHours) / 24.0))
-	if days <= 1 {
-		return "newer_than:1d"
+	platform = normalizeComposioPlatform(platform)
+	active := make([]Connection, 0, len(result.Connections))
+	for _, conn := range result.Connections {
+		if normalizeComposioPlatform(conn.Platform) != platform {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(conn.State)) {
+		case "", "active", "operational", "connected":
+			active = append(active, conn)
+		}
 	}
-	return fmt.Sprintf("newer_than:%dd", days)
+	if len(active) == 1 {
+		return strings.TrimSpace(active[0].Key), nil
+	}
+	if len(active) == 0 {
+		return "", fmt.Errorf("connection_key is required and no active %s connection was found", platform)
+	}
+	return "", fmt.Errorf("connection_key is required because %d active %s connections are available", len(active), platform)
+}
+
+func executeWorkflowTemplateStep(step workflowStep, scope map[string]any) (map[string]any, error) {
+	text, err := renderWorkflowTemplate(step.Template, scope)
+	if err != nil {
+		return nil, fmt.Errorf("render template: %w", err)
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil, fmt.Errorf("template rendered empty")
+	}
+	return map[string]any{
+		"type":   "template",
+		"text":   text,
+		"result": text,
+	}, nil
+}
+
+func executeWorkflowNexAskStep(step workflowStep, scope map[string]any) (map[string]any, error) {
+	query, err := renderWorkflowTemplate(step.QueryTemplate, scope)
+	if err != nil {
+		return nil, fmt.Errorf("render query_template: %w", err)
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, fmt.Errorf("query_template rendered empty")
+	}
+	answer, err := nexAsk(query)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"type":       "nex_ask",
+		"query":      query,
+		"answer":     strings.TrimSpace(answer.Answer),
+		"session_id": strings.TrimSpace(answer.SessionID),
+		"result":     strings.TrimSpace(answer.Answer),
+	}, nil
+}
+
+func executeWorkflowNexInsightsStep(step workflowStep, scope map[string]any) (map[string]any, error) {
+	lookbackHours, err := renderWorkflowInt(step.LookbackHours, scope, 24)
+	if err != nil {
+		return nil, fmt.Errorf("render lookback_hours: %w", err)
+	}
+	insightLimit, err := renderWorkflowInt(step.InsightLimit, scope, 5)
+	if err != nil {
+		return nil, fmt.Errorf("render insight_limit: %w", err)
+	}
+	from := time.Now().UTC().Add(-time.Duration(lookbackHours) * time.Hour)
+	insights, err := nexInsightsSince(from, insightLimit)
+	if err != nil {
+		return nil, err
+	}
+	normalizedInsights := normalizeTemplateScopeValue(insights.Insights)
+	compactSummary := summarizeWorkflowInsights(insights.Insights)
+	return map[string]any{
+		"type":           "nex_insights",
+		"lookback_hours": lookbackHours,
+		"limit":          insightLimit,
+		"from":           from.Format(time.RFC3339),
+		"insights":       normalizedInsights,
+		"result":         compactSummary,
+	}, nil
+}
+
+func renderWorkflowMap(in map[string]any, scope map[string]any) (map[string]any, error) {
+	if len(in) == 0 {
+		return nil, nil
+	}
+	rendered, err := renderWorkflowValue(in, scope)
+	if err != nil {
+		return nil, err
+	}
+	out, _ := rendered.(map[string]any)
+	return out, nil
+}
+
+func renderWorkflowInt(value any, scope map[string]any, fallback int) (int, error) {
+	if value == nil {
+		return fallback, nil
+	}
+	rendered, err := renderWorkflowValue(value, scope)
+	if err != nil {
+		return 0, err
+	}
+	if n := intInput(rendered); n > 0 {
+		return n, nil
+	}
+	return fallback, nil
+}
+
+func renderWorkflowString(value any, scope map[string]any) (string, error) {
+	if value == nil {
+		return "", nil
+	}
+	rendered, err := renderWorkflowValue(value, scope)
+	if err != nil {
+		return "", err
+	}
+	return stringInput(rendered), nil
+}
+
+func renderWorkflowValue(value any, scope map[string]any) (any, error) {
+	switch typed := value.(type) {
+	case nil:
+		return nil, nil
+	case string:
+		return renderWorkflowTemplate(typed, scope)
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			rendered, err := renderWorkflowValue(item, scope)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, rendered)
+		}
+		return out, nil
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			rendered, err := renderWorkflowValue(item, scope)
+			if err != nil {
+				return nil, err
+			}
+			out[key] = rendered
+		}
+		return out, nil
+	default:
+		return value, nil
+	}
+}
+
+func renderWorkflowTemplate(tpl string, scope map[string]any) (string, error) {
+	if !strings.Contains(tpl, "{{") {
+		return tpl, nil
+	}
+	t, err := template.New("workflow").Option("missingkey=error").Funcs(template.FuncMap{
+		"toJSON": func(v any) string {
+			if s, ok := v.(string); ok {
+				return s
+			}
+			raw, _ := json.Marshal(v)
+			return string(raw)
+		},
+		"toPrettyJSON": func(v any) string {
+			if s, ok := v.(string); ok {
+				return s
+			}
+			raw, _ := json.MarshalIndent(v, "", "  ")
+			return string(raw)
+		},
+		"trim":  strings.TrimSpace,
+		"upper": strings.ToUpper,
+		"lower": strings.ToLower,
+	}).Parse(tpl)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, scope); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+func summarizeWorkflowInsights(items []nexInsightItem) string {
+	if len(items) == 0 {
+		return "No notable Nex insights in the requested window."
+	}
+	var b strings.Builder
+	b.WriteString("Relevant Nex insights:\n")
+	for _, item := range items {
+		content := truncateWorkflowInsight(strings.TrimSpace(item.Content), 240)
+		if content == "" {
+			continue
+		}
+		label := strings.TrimSpace(item.Type)
+		if label == "" {
+			label = "insight"
+		}
+		fmt.Fprintf(&b, "- [%s] %s\n", label, content)
+	}
+	text := strings.TrimSpace(b.String())
+	if text == "Relevant Nex insights:" || text == "" {
+		return "No notable Nex insights in the requested window."
+	}
+	return text
+}
+
+func truncateWorkflowInsight(text string, max int) string {
+	if max <= 0 || len(text) <= max {
+		return text
+	}
+	text = strings.TrimSpace(text)
+	if len(text) <= max {
+		return text
+	}
+	if max <= 1 {
+		return text[:max]
+	}
+	return strings.TrimSpace(text[:max-1]) + "…"
+}
+
+func actionStepDryRun(step workflowStep, workflowDryRun bool) bool {
+	if step.DryRun != nil {
+		return *step.DryRun
+	}
+	if !workflowDryRun {
+		return false
+	}
+	return actionLikelyWrites(step.ActionID)
+}
+
+func actionLikelyWrites(actionID string) bool {
+	actionID = strings.ToUpper(strings.TrimSpace(actionID))
+	writeMarkers := []string{
+		"SEND",
+		"CREATE",
+		"UPDATE",
+		"DELETE",
+		"PATCH",
+		"UPSERT",
+		"POST",
+		"INSERT",
+		"UPLOAD",
+		"COMPLETE",
+	}
+	for _, marker := range writeMarkers {
+		if strings.Contains(actionID, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeJSONObject(raw json.RawMessage) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return string(raw)
+	}
+	return normalizeDecodedJSON(decoded, 0)
+}
+
+func normalizeDecodedJSON(value any, depth int) any {
+	if depth > 4 {
+		return value
+	}
+	switch typed := value.(type) {
+	case string:
+		trimmed := strings.TrimSpace(typed)
+		if trimmed != "" && (strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[")) {
+			var nested any
+			if err := json.Unmarshal([]byte(trimmed), &nested); err == nil {
+				return normalizeDecodedJSON(nested, depth+1)
+			}
+		}
+		return typed
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, item := range typed {
+			out = append(out, normalizeDecodedJSON(item, depth+1))
+		}
+		return out
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, item := range typed {
+			out[key] = normalizeDecodedJSON(item, depth+1)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func normalizeTemplateScopeValue(value any) any {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return value
+	}
+	return decoded
 }
 
 func mustMarshalJSON(v any) json.RawMessage {
 	raw, _ := json.Marshal(v)
 	return raw
-}
-
-func truncateText(s string, limit int) string {
-	s = strings.TrimSpace(s)
-	if limit <= 0 || len(s) <= limit {
-		return s
-	}
-	if limit <= 3 {
-		return s[:limit]
-	}
-	return s[:limit-3] + "..."
 }
 
 func stringInput(v any) string {
@@ -456,26 +773,4 @@ func intInput(v any) int {
 	default:
 		return 0
 	}
-}
-
-func boolInput(v any) (bool, bool) {
-	switch t := v.(type) {
-	case bool:
-		return t, true
-	case string:
-		switch strings.ToLower(strings.TrimSpace(t)) {
-		case "true", "1", "yes":
-			return true, true
-		case "false", "0", "no":
-			return false, true
-		}
-	}
-	return false, false
-}
-
-func minInt(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/internal/action/workflow_store.go
+++ b/internal/action/workflow_store.go
@@ -2,11 +2,11 @@ package action
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-	"bytes"
 	"strings"
 
 	"github.com/nex-crm/wuphf/internal/config"

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -400,6 +400,7 @@ func (l *Launcher) notifyTaskActionsLoop() {
 }
 
 var agentLastNotified = make(map[string]time.Time)
+
 const agentNotifyCooldown = 10 * time.Second
 
 func (l *Launcher) deliverMessageNotification(msg channelMessage) {
@@ -641,10 +642,7 @@ func (l *Launcher) sendTaskUpdate(paneTarget, slug, channel, taskID, from, conte
 		"-l",
 		notification,
 	).Run()
-	exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
-		"-t", paneTarget,
-		"Enter",
-	).Run()
+	submitAgentPanePrompt(paneTarget)
 }
 
 func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate []notificationTarget, delayed []notificationTarget) {
@@ -1043,7 +1041,18 @@ func (l *Launcher) primeVisibleAgents() {
 		return
 	}
 	latest := msgs[len(msgs)-1]
+	l.clearNotificationCooldown(latest)
 	l.deliverMessageNotification(latest)
+}
+
+func (l *Launcher) clearNotificationCooldown(msg channelMessage) {
+	immediate, delayed := l.notificationTargetsForMessage(msg)
+	for _, target := range immediate {
+		delete(agentLastNotified, target.Slug)
+	}
+	for _, target := range delayed {
+		delete(agentLastNotified, target.Slug)
+	}
 }
 
 func (l *Launcher) pollNexNotificationsLoop() {
@@ -1967,16 +1976,14 @@ func (l *Launcher) sendChannelUpdate(paneTarget, slug, channel, msgID, from, con
 	if strings.TrimSpace(channel) == "" {
 		channel = "general"
 	}
+	compactContent := compactAgentNotificationContent(content)
 	notification := ""
 	if l.isOneOnOne() {
-		notification = fmt.Sprintf(
-			"[%s @%s]: %s — Call team_poll with my_slug \"%s\" and channel \"%s\" to read context, then reply using team_broadcast channel \"%s\" reply_to_id \"%s\".",
-			msgID, from, truncate(content, 150), slug, channel, channel, msgID,
-		)
+		notification = l.directSessionNotification(msgID, from, compactContent)
 	} else {
 		notification = fmt.Sprintf(
 			"[%s @%s]: %s — Call team_poll with my_slug \"%s\" and channel \"%s\" to read context. If this is your domain, reply using team_broadcast channel \"%s\" reply_to_id \"%s\". If not your domain, stay quiet.",
-			msgID, from, truncate(content, 150), slug, channel, channel, msgID,
+			msgID, from, truncate(compactContent, 150), slug, channel, channel, msgID,
 		)
 	}
 
@@ -1985,10 +1992,67 @@ func (l *Launcher) sendChannelUpdate(paneTarget, slug, channel, msgID, from, con
 		"-l",
 		notification,
 	).Run()
+	submitAgentPanePrompt(paneTarget)
+}
+
+func (l *Launcher) directSessionNotification(msgID, from, content string) string {
+	notification := fmt.Sprintf(
+		"[%s @%s]: %s — This is a direct 1:1. First call read_conversation (or team_poll) to read the latest context. Focus on the newest human request and treat older unrelated asks as background only. Then answer using reply (or team_broadcast) or human_message. If the human is asking for an integration action or reusable automation, use the team_action_* tools directly in this session and complete the full requested sequence before reporting back.",
+		msgID, from, truncate(content, 180),
+	)
+	if looksLikeReusableAutomationRequest(content) {
+		notification += " This is clearly a reusable automation request. Do not stay in ad-hoc action mode. Build a generic WUPHF workflow JSON definition first, then call team_action_workflow_create, team_action_workflow_schedule if the human asked for a cadence, and team_action_workflow_execute if the human asked for a manual run. Prefer a compact flow like action -> nex_insights -> template -> nex_ask -> action."
+	}
+	return notification
+}
+
+func compactAgentNotificationContent(content string) string {
+	fields := strings.Fields(strings.TrimSpace(content))
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.Join(fields, " ")
+}
+
+func submitAgentPanePrompt(paneTarget string) {
 	exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
 		"-t", paneTarget,
 		"Enter",
 	).Run()
+	time.Sleep(120 * time.Millisecond)
+	exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+		"-t", paneTarget,
+		"Enter",
+	).Run()
+}
+
+func looksLikeReusableAutomationRequest(content string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(content))
+	if normalized == "" {
+		return false
+	}
+	needles := []string{
+		"workflow",
+		"automation",
+		"schedule",
+		"daily",
+		"every day",
+		"every weekday",
+		"9am",
+		"9:00",
+		"manual run",
+		"run it manually",
+		"trigger",
+		"relay",
+		"cron",
+	}
+	score := 0
+	for _, needle := range needles {
+		if strings.Contains(normalized, needle) {
+			score++
+		}
+	}
+	return score >= 2
 }
 
 func (l *Launcher) capturePaneTargetContent(target string) (string, error) {
@@ -2254,9 +2318,20 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("This is not the shared office. There are no teammates, no channels, and no collaboration mechanics in this mode.\n")
 		sb.WriteString("You are only talking to the human.\n")
 		sb.WriteString("- team_poll: Read the recent 1:1 conversation before replying\n")
+		sb.WriteString("- read_conversation: Alias for team_poll in direct mode\n")
 		sb.WriteString("- team_broadcast: Send a normal direct chat reply into the 1:1 conversation\n")
+		sb.WriteString("- reply: Alias for team_broadcast in direct mode\n")
 		sb.WriteString("- human_message: Send an emphasized report, recommendation, or action card directly to the human when you want it to stand out\n")
 		sb.WriteString("- human_interview: Ask a blocking decision question only when you truly cannot proceed responsibly without it\n\n")
+		sb.WriteString("External actions and reusable automations are available here too:\n")
+		sb.WriteString("- team_action_connections: List connected external accounts\n")
+		sb.WriteString("- team_action_search: Find integration actions like send email or create contact\n")
+		sb.WriteString("- team_action_knowledge: Load the schema before executing an action\n")
+		sb.WriteString("- team_action_execute: Dry-run or execute an external action\n")
+		sb.WriteString("- team_action_workflow_create: Save a reusable WUPHF workflow from JSON\n")
+		sb.WriteString("- team_action_workflow_execute: Run a saved workflow now\n")
+		sb.WriteString("- team_action_workflow_schedule: Schedule a saved workflow on a cadence, and set run_now when the human also asked for an immediate first run\n")
+		sb.WriteString("- team_action_relay_create / team_action_relay_activate: Register trigger-based automations when needed\n\n")
 		if config.ResolveNoNex() {
 			sb.WriteString("Nex tools are disabled for this run. Base your work on the conversation and direct human answers only.\n\n")
 		} else {
@@ -2273,6 +2348,18 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("6. Use human_interview only for truly blocking decisions.\n")
 		sb.WriteString("7. If Nex is enabled, do not claim something is stored unless add_context actually succeeded.\n")
 		sb.WriteString("8. No fake collaboration language like 'I'll ask the team' or 'let me route this'. It is just you and the human here.\n\n")
+		sb.WriteString("9. If the human asks for an integration action, use search -> knowledge -> dry-run -> execute.\n")
+		sb.WriteString("10. If the human asks for reusable automation, build a generic WUPHF workflow JSON definition and use workflow_create, workflow_schedule, and workflow_execute instead of inventing a built-in kind.\n")
+		sb.WriteString("11. For reusable automation requests, do not stop at discovery. Once you have enough information, complete the requested sequence end to end: create it, schedule it if asked, execute it if asked, and then report the outcome.\n")
+		sb.WriteString("12. If an action returns bulky raw data, add a generic template step to compress it before passing it to nex_ask or another action.\n")
+		sb.WriteString("13. Prefer the generic workflow step output .steps.<step_id>.result unless you specifically need a provider-specific field like .response.data.\n")
+		sb.WriteString("14. For digest or report workflows, keep the compose prompt compact: default to about 10 recent emails and 5 recent insights unless the human explicitly asks for more.\n")
+		sb.WriteString("15. Do not dump raw JSON into nex_ask when a compact text summary will do. Use email_summary.result and recent_insights.result directly whenever possible.\n")
+		sb.WriteString("16. Do not disappear into schema hunting. Use the minimum tool lookups needed, then act.\n")
+		sb.WriteString("17. If the human clearly asked for a reusable scheduled workflow, do not stay in ad-hoc action mode. Build the workflow JSON first, then create it, schedule it, and use run_now on workflow_schedule (or workflow_execute) when the human asked for an immediate test run.\n")
+		sb.WriteString("18. For digest/report automations, default to this compact generic pattern unless the human asks otherwise: fetch external data -> nex_insights -> template summary -> nex_ask compose -> send action.\n\n")
+		sb.WriteString("19. In workflow JSON, use the exact schema names the tools expect: action steps use type:\"action\", platform, action_id, optional connection_key, and data; nex_ask steps use query_template; template steps use template. Do not invent fields like action or query.\n")
+		sb.WriteString("20. Prefer Go-style templates like {{ .steps.fetch_emails.result }}. If you need a loop, use {{- range $item := .steps.fetch_emails.result.data.messages }} ... {{- end }}.\n\n")
 		sb.WriteString("CONVERSATION STYLE:\n")
 		sb.WriteString("- Sound like a sharp human operator, not a formal assistant.\n")
 		sb.WriteString("- Be concise, direct, and a little alive.\n")

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/api"
@@ -188,6 +189,96 @@ func TestNotificationTargetsForMessageOneOnOneWakesSelectedAgent(t *testing.T) {
 	}
 	if len(immediate) != 1 || immediate[0].Slug != "pm" || immediate[0].PaneTarget == "" {
 		t.Fatalf("expected pm as the only immediate target, got %v", immediate)
+	}
+}
+
+func TestBuildPromptOneOnOneIncludesActionWorkflowGuidance(t *testing.T) {
+	l := &Launcher{
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO", Expertise: []string{"strategy", "ops"}, Personality: "sharp"},
+			},
+		},
+		sessionMode: SessionModeOneOnOne,
+		oneOnOne:    "ceo",
+	}
+
+	got := l.buildPrompt("ceo")
+	for _, needle := range []string{
+		"team_action_execute",
+		"team_action_workflow_create",
+		"team_action_workflow_schedule",
+		"run_now",
+		"generic WUPHF workflow JSON definition",
+		"complete the requested sequence end to end",
+		"generic template step",
+		".steps.<step_id>.result",
+		"10 recent emails and 5 recent insights",
+		"Do not dump raw JSON into nex_ask",
+		"do not stay in ad-hoc action mode",
+		"fetch external data -> nex_insights -> template summary -> nex_ask compose -> send action",
+		"type:\"action\", platform, action_id",
+		"query_template",
+		"Do not invent fields like action or query",
+		"{{- range $item := .steps.fetch_emails.result.data.messages }}",
+		"read_conversation",
+		"reply",
+	} {
+		if !strings.Contains(got, needle) {
+			t.Fatalf("expected %q in one-on-one prompt, got:\n%s", needle, got)
+		}
+	}
+}
+
+func TestDirectSessionNotificationHighlightsReusableAutomationRequests(t *testing.T) {
+	l := &Launcher{sessionMode: SessionModeOneOnOne, oneOnOne: "ceo"}
+	notification := l.directSessionNotification("msg-1", "you", "Create a reusable workflow that runs every day at 9am and run it manually once now.")
+	for _, needle := range []string{
+		"direct 1:1",
+		"reusable automation request",
+		"team_action_workflow_create",
+		"team_action_workflow_schedule",
+		"team_action_workflow_execute",
+		"action -> nex_insights -> template -> nex_ask -> action",
+	} {
+		if !strings.Contains(notification, needle) {
+			t.Fatalf("expected %q in notification, got:\n%s", needle, notification)
+		}
+	}
+}
+
+func TestLooksLikeReusableAutomationRequest(t *testing.T) {
+	if !looksLikeReusableAutomationRequest("Create a daily workflow and schedule it for 9am.") {
+		t.Fatalf("expected daily scheduled workflow request to be detected")
+	}
+	if looksLikeReusableAutomationRequest("Send one email to this customer right now.") {
+		t.Fatalf("did not expect one-off action request to be treated as reusable automation")
+	}
+}
+
+func TestCompactAgentNotificationContentFlattensMultilinePrompts(t *testing.T) {
+	got := compactAgentNotificationContent("Create a workflow\n\nthat runs every day at 9am\nand run it now.")
+	want := "Create a workflow that runs every day at 9am and run it now."
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}
+
+func TestDirectSessionNotificationDoesNotContainEmbeddedNewlines(t *testing.T) {
+	l := &Launcher{sessionMode: SessionModeOneOnOne, oneOnOne: "ceo"}
+	notification := l.directSessionNotification("msg-1", "you", compactAgentNotificationContent("Line one\nLine two\n\nLine three"))
+	if strings.Contains(notification, "\n") {
+		t.Fatalf("expected single-line direct notification, got %q", notification)
+	}
+}
+
+func TestClearNotificationCooldownReleasesOneOnOneReplay(t *testing.T) {
+	agentLastNotified = map[string]time.Time{"ceo": time.Now()}
+	l := &Launcher{sessionMode: SessionModeOneOnOne, oneOnOne: "ceo"}
+	l.clearNotificationCooldown(channelMessage{ID: "msg-1", From: "you", Channel: "general", Content: "Need help"})
+	if _, ok := agentLastNotified["ceo"]; ok {
+		t.Fatal("expected one-on-one replay to clear ceo notify cooldown")
 	}
 }
 
@@ -387,7 +478,7 @@ func TestPrimeVisibleAgentsWithoutBrokerDoesNotPanic(t *testing.T) {
 	l.primeVisibleAgents()
 }
 
-func TestNotificationTargetsForHumanMessageGiveCEOHeadStart(t *testing.T) {
+func TestNotificationTargetsForHumanMessageRouteTaggedSpecialistsDirectly(t *testing.T) {
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -406,18 +497,18 @@ func TestNotificationTargetsForHumanMessageGiveCEOHeadStart(t *testing.T) {
 		Tagged:  []string{"fe", "be"},
 	})
 
-	if len(immediate) != 1 || immediate[0].Slug != "ceo" {
-		t.Fatalf("expected CEO immediate target, got %+v", immediate)
+	if len(immediate) != 2 {
+		t.Fatalf("expected 2 immediate tagged specialists, got %+v", immediate)
 	}
-	if len(delayed) != 2 {
-		t.Fatalf("expected 2 delayed specialists, got %+v", delayed)
+	if immediate[0].Slug != "fe" || immediate[1].Slug != "be" {
+		t.Fatalf("expected FE and BE immediate, got %+v", immediate)
 	}
-	if delayed[0].Slug != "fe" || delayed[1].Slug != "be" {
-		t.Fatalf("expected FE and BE delayed, got %+v", delayed)
+	if len(delayed) != 0 {
+		t.Fatalf("expected no delayed targets, got %+v", delayed)
 	}
 }
 
-func TestNotificationTargetsPreferMatchingDomainOverWrongTags(t *testing.T) {
+func TestNotificationTargetsPreferMatchingDomainOverWrongTaggedSpecialists(t *testing.T) {
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -435,11 +526,11 @@ func TestNotificationTargetsPreferMatchingDomainOverWrongTags(t *testing.T) {
 		Tagged:  []string{"fe", "cmo"},
 	})
 
-	if len(immediate) != 1 || immediate[0].Slug != "ceo" {
-		t.Fatalf("expected CEO immediate target, got %+v", immediate)
+	if len(immediate) != 1 || immediate[0].Slug != "cmo" {
+		t.Fatalf("expected only matching CMO immediate target, got %+v", immediate)
 	}
-	if len(delayed) != 1 || delayed[0].Slug != "cmo" {
-		t.Fatalf("expected only matching CMO delayed target, got %+v", delayed)
+	if len(delayed) != 0 {
+		t.Fatalf("expected no delayed targets, got %+v", delayed)
 	}
 }
 

--- a/internal/team/launcher_workflow_test.go
+++ b/internal/team/launcher_workflow_test.go
@@ -1,0 +1,186 @@
+package team
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/action"
+)
+
+func TestProcessDueWorkflowJobUsesComposioProvider(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_ACTION_PROVIDER", "composio")
+	t.Setenv("WUPHF_API_KEY", "nex-test-key")
+	t.Setenv("WUPHF_COMPOSIO_API_KEY", "cmp-test-key")
+	t.Setenv("WUPHF_COMPOSIO_USER_ID", "najmuzzaman@nex.ai")
+
+	tmpDir := t.TempDir()
+	oldPathFn := brokerStatePath
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/connected_accounts/ca_123", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":      "ca_123",
+			"user_id": "cmp_user_123",
+			"status":  "ACTIVE",
+		})
+	})
+	mux.HandleFunc("/tools/execute/GMAIL_FETCH_EMAILS", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"messages": []map[string]any{{
+					"messageId":        "msg-1",
+					"threadId":         "thread-1",
+					"messageTimestamp": "2026-03-31T07:30:00Z",
+					"subject":          "Digest source email",
+					"sender":           "support@example.com",
+					"to":               "najmuzzaman@nex.ai",
+					"preview": map[string]any{
+						"body": "Important update for the digest.",
+					},
+					"labelIds": []string{"INBOX"},
+				}},
+				"resultSizeEstimate": 1,
+			},
+		})
+	})
+	mux.HandleFunc("/tools/execute/GMAIL_SEND_EMAIL", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"id": "msg-sent-1",
+			},
+		})
+	})
+	mux.HandleFunc("/api/developers/v1/context/ask", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"answer": "Executive Summary\n- Digest generated.\n\nWhy This Matters\n- It keeps the office current.\n\nWhat To Do Next\n- Read the highlights.\n\nEmail Highlights\n- support@example.com | Digest source email\n\nRelevant Nex Insights\n- Insight included.",
+		})
+	})
+	mux.HandleFunc("/api/developers/v1/insights", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"insights": []map[string]any{{
+				"id":      "ins-1",
+				"type":    "summary",
+				"content": "Digest-relevant insight.",
+			}},
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	t.Setenv("WUPHF_DEV_URL", server.URL)
+	t.Setenv("WUPHF_COMPOSIO_BASE_URL", server.URL)
+
+	provider := action.NewComposioFromEnv()
+	definition, _ := json.Marshal(map[string]any{
+		"version": "wuphf_workflow_v1",
+		"inputs": map[string]any{
+			"connection_key":  "ca_123",
+			"recipient_email": "najmuzzaman@nex.ai",
+			"subject":         "Daily Digest",
+			"window_hours":    24,
+			"insight_limit":   5,
+		},
+		"steps": []map[string]any{
+			{
+				"id":             "fetch_emails",
+				"type":           "action",
+				"platform":       "gmail",
+				"action_id":      "GMAIL_FETCH_EMAILS",
+				"connection_key": "{{ .inputs.connection_key }}",
+				"data": map[string]any{
+					"query": "newer_than:1d",
+				},
+			},
+			{
+				"id":             "recent_insights",
+				"type":           "nex_insights",
+				"lookback_hours": "{{ .inputs.window_hours }}",
+				"insight_limit":  "{{ .inputs.insight_limit }}",
+			},
+			{
+				"id":             "compose_digest",
+				"type":           "nex_ask",
+				"query_template": "Build a digest email with Executive Summary, Why This Matters, What To Do Next, Email Highlights, and Relevant Nex Insights. Emails: {{ toJSON .steps.fetch_emails.response.data.messages }} Insights: {{ toJSON .steps.recent_insights.insights }}",
+			},
+			{
+				"id":             "send_email",
+				"type":           "action",
+				"platform":       "gmail",
+				"action_id":      "GMAIL_SEND_EMAIL",
+				"connection_key": "{{ .inputs.connection_key }}",
+				"data": map[string]any{
+					"recipient_email": "{{ .inputs.recipient_email }}",
+					"subject":         "{{ .inputs.subject }}",
+					"body":            "{{ .steps.compose_digest.answer }}",
+				},
+			},
+		},
+	})
+	if _, err := provider.CreateWorkflow(context.Background(), action.WorkflowCreateRequest{
+		Key:        "daily-digest",
+		Definition: definition,
+	}); err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+
+	b := NewBroker()
+	b.skills = append(b.skills, teamSkill{
+		Name:             "daily-digest",
+		Title:            "Daily Digest",
+		WorkflowProvider: "composio",
+		WorkflowKey:      "daily-digest",
+		Status:           "active",
+		CreatedAt:        time.Now().UTC().Format(time.RFC3339),
+		UpdatedAt:        time.Now().UTC().Format(time.RFC3339),
+	})
+	payload, _ := json.Marshal(map[string]any{
+		"provider":      "composio",
+		"workflow_key":  "daily-digest",
+		"inputs":        map[string]any{},
+		"schedule_expr": "daily",
+		"channel":       "general",
+		"skill_name":    "daily-digest",
+	})
+	job := schedulerJob{
+		Slug:         "composio-workflow:general:daily-digest",
+		Kind:         "composio_workflow",
+		Label:        "Run Daily Digest",
+		TargetType:   "workflow",
+		TargetID:     "daily-digest",
+		Channel:      "general",
+		Provider:     "composio",
+		ScheduleExpr: "daily",
+		WorkflowKey:  "daily-digest",
+		Status:       "scheduled",
+		Payload:      string(payload),
+	}
+	b.scheduler = append(b.scheduler, job)
+
+	l := &Launcher{broker: b}
+	l.processDueWorkflowJob(job)
+
+	actions := b.Actions()
+	if len(actions) == 0 {
+		t.Fatalf("expected workflow action to be recorded")
+	}
+	lastAction := actions[len(actions)-1]
+	if lastAction.Kind != "external_workflow_executed" || lastAction.Source != "composio" {
+		t.Fatalf("unexpected action %+v", lastAction)
+	}
+
+	jobs := b.Scheduler()
+	if len(jobs) != 1 || jobs[0].Status != "scheduled" || jobs[0].NextRun == "" {
+		t.Fatalf("unexpected scheduler state %+v", jobs)
+	}
+	if b.skills[len(b.skills)-1].LastExecutionStatus != "completed" {
+		t.Fatalf("expected skill execution status updated, got %+v", b.skills[len(b.skills)-1])
+	}
+}

--- a/internal/teammcp/actions.go
+++ b/internal/teammcp/actions.go
@@ -80,6 +80,7 @@ type TeamActionWorkflowExecuteArgs struct {
 type TeamActionWorkflowScheduleArgs struct {
 	Key        string         `json:"key" jsonschema:"Saved workflow key to run on a schedule"`
 	Schedule   string         `json:"schedule" jsonschema:"Cron expression or shorthand like daily, hourly, 4h, or 0 9 * * 1-5"`
+	RunNow     bool           `json:"run_now,omitempty" jsonschema:"Also execute one immediate run after scheduling when the human asked for a manual test run now"`
 	Inputs     map[string]any `json:"inputs,omitempty" jsonschema:"Optional workflow inputs"`
 	Channel    string         `json:"channel,omitempty" jsonschema:"Optional office channel for logging"`
 	MySlug     string         `json:"my_slug,omitempty" jsonschema:"Agent slug scheduling the workflow. Defaults to WUPHF_AGENT_SLUG."`
@@ -160,7 +161,7 @@ func registerActionTools(server *mcp.Server) {
 	}, handleTeamActionWorkflowExecute)
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "team_action_workflow_schedule",
-		Description: "Schedule a saved external workflow on a WUPHF-native cadence so it shows up in Calendar and runs through the office scheduler.",
+		Description: "Schedule a saved external workflow on a WUPHF-native cadence so it shows up in Calendar and runs through the office scheduler. Set run_now when the human also asked for an immediate first run.",
 	}, handleTeamActionWorkflowSchedule)
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "team_action_relays",
@@ -422,13 +423,35 @@ func handleTeamActionWorkflowSchedule(ctx context.Context, _ *mcp.CallToolReques
 		CreatedBy:        slug,
 	})
 	_ = brokerRecordAction(ctx, "external_workflow_scheduled", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Scheduled workflow %s via %s (%s)", args.Key, strings.Title(provider.Name()), args.Schedule)), args.Key)
-	return textResult(prettyObject(map[string]any{
+	result := map[string]any{
 		"ok":           true,
 		"workflow_key": strings.TrimSpace(args.Key),
 		"schedule":     strings.TrimSpace(args.Schedule),
 		"next_run":     nextRun.UTC().Format(time.RFC3339),
 		"skill_name":   skillName,
-	})), nil, nil
+	}
+	if args.RunNow {
+		runResult, execErr := provider.ExecuteWorkflow(ctx, action.WorkflowExecuteRequest{
+			KeyOrPath: strings.TrimSpace(args.Key),
+			Inputs:    args.Inputs,
+		})
+		if execErr != nil {
+			_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fmt.Sprintf("Scheduled workflow %s via %s, but the immediate run failed", args.Key, strings.Title(provider.Name())), args.Key)
+			result["run_now"] = map[string]any{
+				"ok":    false,
+				"error": execErr.Error(),
+			}
+			return textResult(prettyObject(result)), nil, nil
+		}
+		_ = brokerRecordAction(ctx, "external_workflow_executed", provider.Name(), channel, slug, fmt.Sprintf("Scheduled workflow %s via %s and ran it once immediately", args.Key, strings.Title(provider.Name())), args.Key)
+		_ = touchWorkflowSkill(ctx, args.Key, runResult.Status, time.Now().UTC())
+		result["run_now"] = map[string]any{
+			"ok":     true,
+			"status": runResult.Status,
+			"run_id": runResult.RunID,
+		}
+	}
+	return textResult(prettyObject(result)), nil, nil
 }
 
 func handleTeamActionRelays(ctx context.Context, _ *mcp.CallToolRequest, args TeamActionRelaysArgs) (*mcp.CallToolResult, any, error) {

--- a/internal/teammcp/actions_test.go
+++ b/internal/teammcp/actions_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/team"
 )
@@ -40,7 +42,7 @@ func (stubActionProvider) CreateWorkflow(context.Context, action.WorkflowCreateR
 	return action.WorkflowCreateResult{Created: true, Key: "daily-digest"}, nil
 }
 func (stubActionProvider) ExecuteWorkflow(context.Context, action.WorkflowExecuteRequest) (action.WorkflowExecuteResult, error) {
-	return action.WorkflowExecuteResult{}, nil
+	return action.WorkflowExecuteResult{RunID: "run-1", Status: "completed"}, nil
 }
 func (stubActionProvider) ListWorkflowRuns(context.Context, string) (action.WorkflowRunsResult, error) {
 	return action.WorkflowRunsResult{}, nil
@@ -208,5 +210,51 @@ func TestHandleTeamActionWorkflowScheduleCreatesSchedulerJob(t *testing.T) {
 	job := result.Jobs[0]
 	if job.Kind != "one_workflow" || job.TargetType != "workflow" || job.TargetID != "daily-digest" || job.Provider != "one" || job.ScheduleExpr != "daily" {
 		t.Fatalf("unexpected scheduler job %+v", job)
+	}
+}
+
+func TestHandleTeamActionWorkflowScheduleRunNowExecutesImmediately(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	prev := externalActionProvider
+	externalActionProvider = stubActionProvider{}
+	defer func() { externalActionProvider = prev }()
+
+	res, _, err := handleTeamActionWorkflowSchedule(context.Background(), nil, TeamActionWorkflowScheduleArgs{
+		Key:      "daily-digest",
+		Schedule: "daily",
+		RunNow:   true,
+		MySlug:   "ceo",
+		Channel:  "general",
+	})
+	if err != nil {
+		t.Fatalf("schedule workflow with run_now: %v", err)
+	}
+	text, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected text response, got %+v", res.Content)
+	}
+	if got := text.Text; !strings.Contains(got, "\"run_now\"") || !strings.Contains(got, "\"ok\": true") {
+		t.Fatalf("expected run_now block in response, got %s", got)
+	}
+	var sawScheduled, sawExecuted bool
+	for _, entry := range b.Actions() {
+		if entry.Kind == "external_workflow_scheduled" {
+			sawScheduled = true
+		}
+		if entry.Kind == "external_workflow_executed" {
+			sawExecuted = true
+		}
+	}
+	if !sawScheduled || !sawExecuted {
+		t.Fatalf("expected scheduled and executed actions, got %+v", b.Actions())
 	}
 }

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -267,10 +267,18 @@ func Run(ctx context.Context) error {
 			Name:        "reply",
 			Description: "Send your reply to the human in the direct 1:1 conversation.",
 		}, handleTeamBroadcast)
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "team_broadcast",
+			Description: "Compatibility alias in 1:1 mode. Send your normal reply into the direct conversation.",
+		}, handleTeamBroadcast)
 
 		mcp.AddTool(server, &mcp.Tool{
 			Name:        "read_conversation",
 			Description: "Read recent messages from the 1:1 conversation so you stay in sync before replying.",
+		}, handleTeamPoll)
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "team_poll",
+			Description: "Compatibility alias in 1:1 mode. Read recent messages from the direct conversation before replying.",
 		}, handleTeamPoll)
 
 		mcp.AddTool(server, &mcp.Tool{
@@ -626,6 +634,8 @@ func handleTeamPoll(ctx context.Context, _ *mcp.CallToolRequest, args TeamPollAr
 	}
 	if args.Limit > 0 {
 		values.Set("limit", fmt.Sprintf("%d", args.Limit))
+	} else if isOneOnOneMode() {
+		values.Set("limit", "8")
 	}
 
 	var result brokerMessagesResponse
@@ -642,7 +652,11 @@ func handleTeamPoll(ctx context.Context, _ *mcp.CallToolRequest, args TeamPollAr
 		if strings.TrimSpace(summary) == "" {
 			return textResult("The 1:1 is quiet right now."), nil, nil
 		}
-		return textResult("Direct conversation\n\n" + summary), nil, nil
+		focus := latestHumanRequestSummary(result.Messages)
+		if focus == "" {
+			return textResult("Direct conversation\n\n" + summary), nil, nil
+		}
+		return textResult("Direct conversation\n\nLatest human request to answer now:\n" + focus + "\n\nOlder messages are background unless the latest request depends on them.\n\nRecent messages:\n" + summary), nil, nil
 	}
 	taskSummary := formatTaskSummary(ctx, resolveSlugOptional(args.MySlug), channel)
 	requestSummary := formatRequestSummary(ctx, channel)
@@ -1460,6 +1474,26 @@ func formatMessages(messages []brokerMessage, mySlug string) string {
 		lines = append(lines, fmt.Sprintf("%s %s%s @%s: %s%s", ts, msg.ID, threadNote, msg.From, msg.Content, tagNote))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func latestHumanRequestSummary(messages []brokerMessage) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		from := strings.TrimSpace(strings.ToLower(msg.From))
+		if from != "you" && from != "human" {
+			continue
+		}
+		content := strings.TrimSpace(msg.Content)
+		if content == "" {
+			continue
+		}
+		ts := msg.Timestamp
+		if len(ts) > 19 {
+			ts = ts[11:19]
+		}
+		return fmt.Sprintf("%s %s @%s: %s", ts, msg.ID, msg.From, content)
+	}
+	return ""
 }
 
 func formatTaskSummary(ctx context.Context, mySlug string, channel string) string {

--- a/internal/teammcp/server_test.go
+++ b/internal/teammcp/server_test.go
@@ -214,3 +214,46 @@ func TestHandleHumanMessageUsesDirectSessionLabelInOneOnOneMode(t *testing.T) {
 		t.Fatalf("did not expect office channel label in %q", text.Text)
 	}
 }
+
+func TestHandleTeamPollOneOnOneHighlightsLatestHumanRequest(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_ONE_ON_ONE", "1")
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	for _, msg := range []map[string]any{
+		{"channel": "general", "from": "you", "content": "Old unrelated ask."},
+		{"channel": "general", "from": "ceo", "content": "Acknowledged."},
+		{"channel": "general", "from": "you", "content": "Newest request wins."},
+	} {
+		if err := brokerPostJSON(context.Background(), "/messages", msg, nil); err != nil {
+			t.Fatalf("post message: %v", err)
+		}
+	}
+
+	result, _, err := handleTeamPoll(context.Background(), nil, TeamPollArgs{MySlug: "ceo"})
+	if err != nil {
+		t.Fatalf("handleTeamPoll: %v", err)
+	}
+	if result == nil || len(result.Content) == 0 {
+		t.Fatal("expected text result")
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected text content, got %T", result.Content[0])
+	}
+	if !strings.Contains(text.Text, "Latest human request to answer now:") {
+		t.Fatalf("expected latest-request header, got %q", text.Text)
+	}
+	if !strings.Contains(text.Text, "Newest request wins.") {
+		t.Fatalf("expected latest human message in %q", text.Text)
+	}
+}

--- a/internal/tui/init_flow_test.go
+++ b/internal/tui/init_flow_test.go
@@ -22,8 +22,8 @@ func TestInitFlowSkipsToProviderWhenAPIKeyExists(t *testing.T) {
 	}
 
 	flow, _ := NewInitFlow().Start()
-	if flow.Phase() != InitProviderChoice {
-		t.Fatalf("expected provider choice phase, got %q", flow.Phase())
+	if flow.Phase() != InitPackChoice {
+		t.Fatalf("expected pack choice phase, got %q", flow.Phase())
 	}
 }
 


### PR DESCRIPTION
## Summary
- harden generic Composio-backed workflow execution for agent-authored JSON
- improve 1:1 workflow guidance so agents create, schedule, and run reusable workflows end to end
- add regression coverage for workflow normalization, routing, scheduling, and direct-session behavior

## What changed
- normalize agent-authored workflow JSON more aggressively
  - provider step aliases like `composio` -> `action`
  - `params` -> `data`
  - Handlebars-style `{{#each}}` / `{{this.*}}` into the runtime template syntax
  - `.meta.date` alias in workflow scope
- auto-resolve the active Composio connection when a workflow omits `connection_key` and there is exactly one valid connection for the platform
- tighten direct-session workflow guidance so the CEO uses the exact workflow schema fields and completes create + schedule + manual run instead of stalling in ad-hoc action mode
- align tagged-human routing tests with the current direct-to-specialist behavior

## Validation
- `go test ./internal/action ./internal/team ./internal/teammcp`
- real termwright-driven 1:1 CEO run creating a generic daily digest workflow, mirroring it into Skills, scheduling it for 9am, and executing it immediately
  - artifact: `termwright-artifacts/digest-ui-light-20260331-192649`
  - confirmed `external_workflow_created`, `external_workflow_scheduled`, and `external_workflow_executed`
  - confirmed workflow file + run history persisted and digest email sent

## Notes
- no generated workflow state or local skill data is included in git; this PR only contains product code and tests
