### PR TITLE
perf: auto-promote CEO from Sonnet to Opus after warmup

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -1086,6 +1086,34 @@ func (l *Launcher) primeVisibleAgents() {
 				"-t", target.PaneTarget,
 				"Enter",
 			).Run()
+
+			// After warmup completes, promote CEO from Sonnet → Opus.
+			go func(paneTarget string) {
+				for i := 0; i < 20; i++ {
+					time.Sleep(2 * time.Second)
+					content, err := l.capturePaneTargetContent(paneTarget)
+					if err != nil {
+						continue
+					}
+					lines := strings.Split(content, "\n")
+					for j := len(lines) - 1; j >= 0; j-- {
+						trimmed := strings.TrimSpace(lines[j])
+						if trimmed == "" {
+							continue
+						}
+						if strings.HasPrefix(trimmed, "\u276f") || strings.HasPrefix(trimmed, ">") {
+							exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+								"-t", paneTarget, "-l", "/model opus").Run()
+							time.Sleep(200 * time.Millisecond)
+							exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+								"-t", paneTarget, "Enter").Run()
+							fmt.Println("[ceo] promoted to Opus after warmup")
+							return
+						}
+						break
+					}
+				}
+			}(target.PaneTarget)
 			break
 		}
 	}


### PR DESCRIPTION
## Summary
- After pre-warm completes, a goroutine polls the CEO pane every 2s for the ready prompt
- Once the `❯` prompt appears, injects `/model opus` + Enter via tmux send-keys
- CEO gets Opus quality for actual work while keeping the fast Sonnet cold start (~16s vs ~30s)

## Test plan
- [x] `go build` compiles clean
- [x] `go test ./...` — all 17 packages pass
- [x] Termwright E2E: 15/18 pass (3 failures are pre-existing termwright/Bubbletea interaction quirks, not regressions)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>