### PR TITLE
feat: improve TUI runtime clarity and readiness

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -76,15 +76,15 @@ type channelSchedulerMsg struct {
 }
 
 type channelSkill struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Title       string   `json:"title"`
-	Description string   `json:"description"`
-	Content     string   `json:"content"`
-	CreatedBy   string   `json:"created_by"`
-	Channel     string   `json:"channel"`
-	Tags        []string `json:"tags"`
-	Trigger     string   `json:"trigger"`
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	Title               string   `json:"title"`
+	Description         string   `json:"description"`
+	Content             string   `json:"content"`
+	CreatedBy           string   `json:"created_by"`
+	Channel             string   `json:"channel"`
+	Tags                []string `json:"tags"`
+	Trigger             string   `json:"trigger"`
 	WorkflowProvider    string   `json:"workflow_provider"`
 	WorkflowKey         string   `json:"workflow_key"`
 	WorkflowDefinition  string   `json:"workflow_definition"`
@@ -94,10 +94,10 @@ type channelSkill struct {
 	RelayEventTypes     []string `json:"relay_event_types"`
 	LastExecutionAt     string   `json:"last_execution_at"`
 	LastExecutionStatus string   `json:"last_execution_status"`
-	UsageCount  int      `json:"usage_count"`
-	Status      string   `json:"status"`
-	CreatedAt   string   `json:"created_at"`
-	UpdatedAt   string   `json:"updated_at"`
+	UsageCount          int      `json:"usage_count"`
+	Status              string   `json:"status"`
+	CreatedAt           string   `json:"created_at"`
+	UpdatedAt           string   `json:"updated_at"`
 }
 
 type channelSkillsMsg struct {
@@ -343,8 +343,10 @@ type channelPostDoneMsg struct {
 type channelInterviewAnswerDoneMsg struct{ err error }
 type channelInterruptDoneMsg struct{ err error }
 type channelResetDoneMsg struct {
-	err    error
-	notice string
+	err           error
+	notice        string
+	sessionMode   string
+	oneOnOneAgent string
 }
 type channelResetDMDoneMsg struct {
 	err     error
@@ -428,31 +430,32 @@ func newBrokerRequest(method, url string, body io.Reader) (*http.Request, error)
 }
 
 var channelSlashCommands = []tui.SlashCommand{
-	{Name: "init", Description: "Run setup"},
-	{Name: "integrate", Description: "Connect an integration"},
-	{Name: "connect", Description: "Connect an external channel (Telegram, Slack, Discord)"},
-	{Name: "1o1", Description: "Enable, switch, or disable direct 1:1 mode"},
-	{Name: "messages", Description: "Show the main office feed"},
-	{Name: "tasks", Description: "Show active work in this channel"},
-	{Name: "channels", Description: "Browse and manage channels"},
-	{Name: "channel", Description: "Create or remove a channel"},
-	{Name: "agents", Description: "Manage channel agents"},
-	{Name: "agent", Description: "Add, remove, enable, or disable an agent"},
-	{Name: "agent prompt", Description: "Generate a new agent from a prompt"},
-	{Name: "task", Description: "Claim, release, or complete a task"},
-	{Name: "policies", Description: "Show team policies and rules"},
-	{Name: "calendar", Description: "Show the office schedule and team calendars"},
-	{Name: "queue", Description: "Alias for /calendar"},
-	{Name: "skills", Description: "Show available skills"},
-	{Name: "skill", Description: "Create, invoke, or manage a skill"},
-	{Name: "reply", Description: "Reply in thread by message ID"},
-	{Name: "threads", Description: "Browse and manage threads"},
-	{Name: "expand", Description: "Expand a collapsed thread"},
-	{Name: "collapse", Description: "Collapse a thread"},
-	{Name: "cancel", Description: "Exit reply/setup mode"},
-	{Name: "reset", Description: "Reset channel and agents"},
-	{Name: "reset-dm", Description: "Clear direct messages with an agent"},
-	{Name: "quit", Description: "Exit WUPHF"},
+	{Name: "init", Description: "Run setup", Category: "setup"},
+	{Name: "doctor", Description: "Check readiness, integrations, and runtime health", Category: "setup"},
+	{Name: "integrate", Description: "Connect an integration", Category: "setup"},
+	{Name: "connect", Description: "Connect an external channel (Telegram, Slack, Discord)", Category: "setup"},
+	{Name: "1o1", Description: "Enable, switch, or disable direct 1:1 mode", Category: "session"},
+	{Name: "messages", Description: "Show the main office feed", Category: "navigate"},
+	{Name: "tasks", Description: "Show active work in this channel", Category: "navigate"},
+	{Name: "channels", Description: "Browse and manage channels", Category: "navigate"},
+	{Name: "channel", Description: "Create or remove a channel", Category: "channels"},
+	{Name: "agents", Description: "Manage channel agents", Category: "people"},
+	{Name: "agent", Description: "Add, remove, enable, or disable an agent", Category: "people"},
+	{Name: "agent prompt", Description: "Generate a new agent from a prompt", Category: "people"},
+	{Name: "task", Description: "Claim, release, or complete a task", Category: "work"},
+	{Name: "policies", Description: "Show signals, decisions, external actions, and watchdogs", Category: "navigate"},
+	{Name: "calendar", Description: "Show the office schedule and team calendars", Category: "navigate"},
+	{Name: "queue", Description: "Alias for /calendar", Category: "navigate"},
+	{Name: "skills", Description: "Show available skills", Category: "navigate"},
+	{Name: "skill", Description: "Create, invoke, or manage a skill", Category: "work"},
+	{Name: "reply", Description: "Reply in thread by message ID", Category: "conversation"},
+	{Name: "threads", Description: "Browse and manage threads", Category: "conversation"},
+	{Name: "expand", Description: "Expand a collapsed thread", Category: "conversation"},
+	{Name: "collapse", Description: "Collapse a thread", Category: "conversation"},
+	{Name: "cancel", Description: "Exit reply/setup/doctor mode", Category: "conversation"},
+	{Name: "reset", Description: "Reset channel and agents", Category: "session"},
+	{Name: "reset-dm", Description: "Clear direct messages with an agent", Category: "session"},
+	{Name: "quit", Description: "Exit WUPHF", Category: "session"},
 }
 
 // oneOnOneBlacklist lists command names blocked in 1:1 mode.
@@ -478,22 +481,22 @@ func buildOneOnOneSlashCommands() []tui.SlashCommand {
 type channelPickerMode string
 
 const (
-	channelPickerNone          channelPickerMode = ""
-	channelPickerInitProvider  channelPickerMode = "init_provider"
-	channelPickerInitPack      channelPickerMode = "init_pack"
-	channelPickerIntegrations  channelPickerMode = "integrations"
-	channelPickerRequests      channelPickerMode = "requests"
-	channelPickerTasks         channelPickerMode = "tasks"
-	channelPickerTaskAction    channelPickerMode = "task_action"
-	channelPickerRequestAction channelPickerMode = "request_action"
-	channelPickerThreads       channelPickerMode = "threads"
-	channelPickerThreadAction  channelPickerMode = "thread_action"
-	channelPickerChannels      channelPickerMode = "channels"
-	channelPickerAgents        channelPickerMode = "agents"
-	channelPickerCalendarAgent channelPickerMode = "calendar_agent"
-	channelPickerOneOnOneMode  channelPickerMode = "one_on_one_mode"
-	channelPickerOneOnOneAgent channelPickerMode = "one_on_one_agent"
-	channelPickerTelegramGroup channelPickerMode = "telegram_group"
+	channelPickerNone           channelPickerMode = ""
+	channelPickerInitProvider   channelPickerMode = "init_provider"
+	channelPickerInitPack       channelPickerMode = "init_pack"
+	channelPickerIntegrations   channelPickerMode = "integrations"
+	channelPickerRequests       channelPickerMode = "requests"
+	channelPickerTasks          channelPickerMode = "tasks"
+	channelPickerTaskAction     channelPickerMode = "task_action"
+	channelPickerRequestAction  channelPickerMode = "request_action"
+	channelPickerThreads        channelPickerMode = "threads"
+	channelPickerThreadAction   channelPickerMode = "thread_action"
+	channelPickerChannels       channelPickerMode = "channels"
+	channelPickerAgents         channelPickerMode = "agents"
+	channelPickerCalendarAgent  channelPickerMode = "calendar_agent"
+	channelPickerOneOnOneMode   channelPickerMode = "one_on_one_mode"
+	channelPickerOneOnOneAgent  channelPickerMode = "one_on_one_agent"
+	channelPickerTelegramGroup  channelPickerMode = "telegram_group"
 	channelPickerConnect        channelPickerMode = "connect"
 	channelPickerTelegramToken  channelPickerMode = "telegram_token"
 	channelPickerTelegramChatID channelPickerMode = "telegram_chat_id"
@@ -587,6 +590,7 @@ type channelModel struct {
 	selectedOption       int
 	notice               string
 	snoozedInterview     string
+	doctor               *channelDoctorReport
 	memberDraft          *channelMemberDraft
 	initFlow             tui.InitFlowModel
 	picker               tui.PickerModel
@@ -686,6 +690,18 @@ func (m channelModel) oneOnOneAgentName() string {
 }
 
 func (m *channelModel) refreshSlashCommands() {
+	var activeInput []rune
+	activeCursor := 0
+	preserveOverlays := false
+	if m.focus == focusThread && m.threadPanelOpen {
+		activeInput = append([]rune(nil), m.threadInput...)
+		activeCursor = m.threadInputPos
+		preserveOverlays = true
+	} else if m.focus == focusMain {
+		activeInput = append([]rune(nil), m.input...)
+		activeCursor = m.inputPos
+		preserveOverlays = true
+	}
 	var base []tui.SlashCommand
 	if m.isOneOnOne() {
 		base = buildOneOnOneSlashCommands()
@@ -693,17 +709,22 @@ func (m *channelModel) refreshSlashCommands() {
 		base = make([]tui.SlashCommand, len(channelSlashCommands))
 		copy(base, channelSlashCommands)
 	}
-	// Append active skills as slash commands
+	var skillCommands []tui.SlashCommand
 	for _, sk := range m.skills {
 		if sk.Status != "active" {
 			continue
 		}
-		base = append(base, tui.SlashCommand{
+		skillCommands = append(skillCommands, tui.SlashCommand{
 			Name:        sk.Name,
 			Description: sk.Description,
+			Category:    "skills",
 		})
 	}
+	base = append(skillCommands, base...)
 	m.autocomplete = tui.NewAutocomplete(base)
+	if preserveOverlays {
+		m.updateOverlaysForInput(activeInput, activeCursor)
+	}
 }
 
 func (m channelModel) pollCurrentState() tea.Cmd {
@@ -846,7 +867,11 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyMsg:
 		// ── Global keys (always active) ───────────────────────────────
-		switch msg.String() {
+		key := msg.String()
+		if msg.Type == tea.KeyCtrlJ {
+			key = "ctrl+j"
+		}
+		switch key {
 		case "ctrl+c":
 			now := time.Now()
 			if !m.lastCtrlCAt.IsZero() && now.Sub(m.lastCtrlCAt) <= 2*time.Second {
@@ -938,6 +963,11 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.input = nil
 				m.inputPos = 0
 				m.notice = "Agent setup canceled."
+				return m, nil
+			}
+			if m.doctor != nil {
+				m.doctor = nil
+				m.notice = "Doctor closed."
 				return m, nil
 			}
 			if m.pending != nil && m.pending.ID != "" {
@@ -1119,6 +1149,14 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.lastCtrlCAt = time.Time{}
 			m.inputPos = len(m.input)
 			m.updateInputOverlays()
+		case "ctrl+j":
+			m.lastCtrlCAt = time.Time{}
+			ch := []rune{'\n'}
+			tail := make([]rune, len(m.input[m.inputPos:]))
+			copy(tail, m.input[m.inputPos:])
+			m.input = append(m.input[:m.inputPos], append(ch, tail...)...)
+			m.inputPos++
+			m.updateInputOverlays()
 		case "left":
 			m.lastCtrlCAt = time.Time{}
 			if m.inputPos > 0 {
@@ -1179,6 +1217,9 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.updateInputOverlays()
 			} else if len(msg.String()) == 1 || msg.Type == tea.KeyRunes {
 				ch := msg.Runes
+				if len(ch) == 0 {
+					ch = []rune(msg.String())
+				}
 				if len(ch) > 0 {
 					tail := make([]rune, len(m.input[m.inputPos:]))
 					copy(tail, m.input[m.inputPos:])
@@ -1257,6 +1298,12 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case channelResetDoneMsg:
 		m.posting = false
 		if msg.err == nil {
+			if normalized := team.NormalizeSessionMode(msg.sessionMode); normalized != "" {
+				m.sessionMode = normalized
+			}
+			if strings.TrimSpace(msg.oneOnOneAgent) != "" || m.sessionMode == team.SessionModeOneOnOne {
+				m.oneOnOneAgent = team.NormalizeOneOnOneAgent(msg.oneOnOneAgent)
+			}
 			m.messages = nil
 			m.members = nil
 			m.requests = nil
@@ -1279,9 +1326,18 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.focus = focusMain
 			m.pickerMode = channelPickerNone
 			m.snoozedInterview = ""
+			m.doctor = nil
 			m.tasks = nil
 			m.actions = nil
 			m.scheduler = nil
+			m.refreshSlashCommands()
+			if m.isOneOnOne() {
+				m.activeApp = officeAppMessages
+				m.sidebarCollapsed = true
+				m.threadPanelOpen = false
+				m.threadPanelID = ""
+				m.replyToID = ""
+			}
 			m.notice = strings.TrimSpace(msg.notice)
 			if m.notice == "" {
 				m.notice = "Office reset. Team panes reloaded in place."
@@ -1325,6 +1381,16 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notice = fmt.Sprintf("%s connected. Browser opened at %s", msg.label, msg.url)
 		} else {
 			m.notice = fmt.Sprintf("%s connected.", msg.label)
+		}
+
+	case channelDoctorDoneMsg:
+		if msg.err != nil {
+			m.notice = "Doctor failed: " + msg.err.Error()
+			m.doctor = nil
+		} else {
+			report := msg.report
+			m.doctor = &report
+			m.notice = "Doctor: " + report.StatusLine()
 		}
 
 	case telegramDiscoverMsg:
@@ -1902,7 +1968,7 @@ func (m channelModel) View() string {
 	// ── Sidebar ──────────────────────────────────────────────────────
 	sidebar := ""
 	if layout.ShowSidebar && !m.isOneOnOne() {
-		sidebar = renderSidebar(m.channels, mergeOfficeMembers(m.officeMembers, m.members, m.currentChannelInfo()), m.tasks, m.activeChannel, m.activeApp, m.sidebarCursor, m.sidebarRosterOffset, m.focus == focusSidebar, m.quickJumpTarget, m.brokerConnected, layout.SidebarW, layout.ContentH)
+		sidebar = cachedSidebarRender(m.channels, mergeOfficeMembers(m.officeMembers, m.members, m.currentChannelInfo()), m.tasks, m.activeChannel, m.activeApp, m.sidebarCursor, m.sidebarRosterOffset, m.focus == focusSidebar, m.quickJumpTarget, m.brokerConnected, layout.SidebarW, layout.ContentH)
 	}
 
 	// ── Thread panel ─────────────────────────────────────────────────
@@ -1987,6 +2053,10 @@ func (m channelModel) View() string {
 	if m.memberDraft != nil {
 		memberDraftCard = renderMemberDraftCard(*m.memberDraft, mainW-4)
 	}
+	doctorCard := ""
+	if m.doctor != nil {
+		doctorCard = renderDoctorCard(*m.doctor, mainW-4)
+	}
 
 	// Init/picker overlays
 	initPanel := ""
@@ -1999,10 +2069,11 @@ func (m channelModel) View() string {
 	composerH := lipgloss.Height(composerStr)
 	interviewH := lipgloss.Height(interviewCard)
 	memberDraftH := lipgloss.Height(memberDraftCard)
+	doctorH := lipgloss.Height(doctorCard)
 	initH := lipgloss.Height(initPanel)
 
 	// Message area height
-	msgH := layout.ContentH - headerH - composerH - interviewH - memberDraftH - initH - 1 // 1 for status bar
+	msgH := layout.ContentH - headerH - composerH - interviewH - memberDraftH - doctorH - initH - 1 // 1 for status bar
 	if msgH < 1 {
 		msgH = 1
 	}
@@ -2012,66 +2083,6 @@ func (m channelModel) View() string {
 		contentWidth = 32
 	}
 	allLines := m.currentMainLines(contentWidth)
-
-	// Append inline typing indicators for active agents (Slack-style)
-	// Shows "Name is typing..." + last 5 lines from their tmux pane as a stream
-	if m.activeApp == officeAppMessages || m.isOneOnOne() {
-		hasTyping := false
-		for _, member := range m.members {
-			if member.Slug == "you" || member.Slug == "human" {
-				continue
-			}
-			if member.LiveActivity != "" {
-				if !hasTyping {
-					allLines = append(allLines, renderedLine{Text: ""})
-					hasTyping = true
-				}
-				name := member.Name
-				if name == "" {
-					name = displayName(member.Slug)
-				}
-				color := agentColorMap[member.Slug]
-				if color == "" {
-					color = "#64748B"
-				}
-				nameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(color)).Bold(true)
-				dotStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(color))
-				streamStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#7C7C85")).Italic(true)
-				dots := "..."
-				switch m.tickFrame % 3 {
-				case 0:
-					dots = ".  "
-				case 1:
-					dots = ".. "
-				case 2:
-					dots = "..."
-				}
-				indicator := "  " + nameStyle.Render(name) + " " + dotStyle.Render("is typing"+dots)
-				allLines = append(allLines, renderedLine{Text: indicator})
-
-				// Show last 5 meaningful lines from pane as a live stream
-				paneLines := strings.Split(member.LiveActivity, "\n")
-				for _, pl := range paneLines {
-					pl = strings.TrimSpace(pl)
-					if pl == "" {
-						continue
-					}
-					// Filter out Claude Code chrome
-					lower := strings.ToLower(pl)
-					if strings.Contains(lower, "bypass") || strings.Contains(lower, "/effort") ||
-						strings.Contains(lower, "shift+tab") || strings.Contains(lower, "permissions") ||
-						strings.HasPrefix(pl, "\u276f") || pl == "\u276f" ||
-						strings.HasPrefix(pl, "\u2500") || strings.HasPrefix(pl, "\u2501") {
-						continue
-					}
-					if len(pl) > contentWidth-6 {
-						pl = pl[:contentWidth-9] + "..."
-					}
-					allLines = append(allLines, renderedLine{Text: "    " + streamStyle.Render("\u2502 "+pl)})
-				}
-			}
-		}
-	}
 	visibleRows, scroll, _, _ := sliceRenderedLines(allLines, msgH, m.scroll)
 	var visible []string
 	for _, row := range visibleRows {
@@ -2102,6 +2113,9 @@ func (m channelModel) View() string {
 	}
 	if memberDraftCard != "" {
 		mainParts = append(mainParts, memberDraftCard)
+	}
+	if doctorCard != "" {
+		mainParts = append(mainParts, doctorCard)
 	}
 	if initPanel != "" {
 		mainParts = append(mainParts, initPanel)
@@ -2138,8 +2152,8 @@ func (m channelModel) View() string {
 		focusLabel = "thread"
 	}
 	statusBar := statusBarStyle(m.width).Render(fmt.Sprintf(
-		" %s %d around │ %d msgs │ focus:%s",
-		"\u25CF", onlineCount, len(m.messages), focusLabel,
+		" %s %d online │ %d msgs │ focus:%s │ %s │ Ctrl+J newline │ /doctor",
+		"\u25CF", onlineCount, len(m.messages), focusLabel, scrollHint,
 	))
 	if m.pending != nil {
 		statusText := " Request pending │ ↑/↓ choose │ Enter submit"
@@ -2157,11 +2171,11 @@ func (m channelModel) View() string {
 			}
 		}
 		statusBar = statusBarStyle(m.width).Render(fmt.Sprintf(
-			" %s %d online │ session %s · %s │ total %s · %s%s │ %s │ Tab focus:%s │ /quit",
+			" %s %d online │ session %s · %s │ total %s · %s%s │ %s │ Ctrl+J newline │ /doctor",
 			"\u25CF", onlineCount,
 			formatUsd(m.usage.Session.CostUsd), formatTokenCount(m.usage.Session.TotalTokens),
 			formatUsd(m.usage.Total.CostUsd), formatTokenCount(m.usage.Total.TotalTokens),
-			sinceStatus, scrollHint, focusLabel,
+			sinceStatus, scrollHint,
 		))
 	} else if m.quickJumpTarget != quickJumpNone {
 		label := "channels"
@@ -2182,25 +2196,29 @@ func (m channelModel) View() string {
 		if m.brokerConnected {
 			label = "direct session live"
 		}
+		runtimeHint := "ready"
+		if runtimeLine := oneOnOneRuntimeLine(m.officeMembers, m.members, m.tasks, m.actions, m.oneOnOneAgentSlug()); runtimeLine != "" {
+			runtimeHint = runtimeLine
+		}
 		statusBar = statusBarStyle(m.width).Render(
 			lipgloss.NewStyle().Foreground(lipgloss.Color(slackActive)).Render(
-				fmt.Sprintf(" %s │ %d msgs │ direct with %s │ /1o1 @agent to switch │ /quit",
-					label, len(m.messages), m.oneOnOneAgentName(),
+				fmt.Sprintf(" %s │ %d msgs │ %s │ Ctrl+J newline │ /1o1 switch │ /doctor",
+					label, len(m.messages), runtimeHint,
 				),
 			),
 		)
 	} else if !m.brokerConnected {
 		statusBar = statusBarStyle(m.width).Render(
-			lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render(" Team offline │ showing manifest roster │ launch WUPHF to connect"),
+			lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render(" Team offline │ showing manifest roster │ launch WUPHF to connect │ /doctor"),
 		)
 	} else if m.replyToID != "" {
 		statusBar = statusBarStyle(m.width).Render(
 			lipgloss.NewStyle().Foreground(lipgloss.Color(slackActive)).Render(
-				fmt.Sprintf(" ↩ Reply mode │ thread %s │ /cancel to return", m.replyToID),
+				fmt.Sprintf(" ↩ Reply mode │ thread %s │ Ctrl+J newline │ /cancel to return", m.replyToID),
 			),
 		)
 	} else if m.activeApp != officeAppMessages {
-		message := fmt.Sprintf(" Viewing %s │ Tab focus:%s │ /messages to return", m.currentAppLabel(), focusLabel)
+		message := fmt.Sprintf(" Viewing %s │ %s │ /messages to return │ /doctor", m.currentAppLabel(), scrollHint)
 		if m.activeApp == officeAppCalendar {
 			filter := "all"
 			if strings.TrimSpace(m.calendarFilter) != "" {
@@ -2243,7 +2261,11 @@ func (m channelModel) currentHeaderMeta() string {
 		if !m.brokerConnected {
 			return "  Direct session preview · only this agent can speak here"
 		}
-		return "  Direct conversation only · no channels, teammates, or office apps in this mode"
+		meta := "  Direct conversation only · no channels, teammates, or office apps in this mode"
+		if runtimeLine := oneOnOneRuntimeLine(m.officeMembers, m.members, m.tasks, m.actions, m.oneOnOneAgentSlug()); runtimeLine != "" {
+			meta += " · " + runtimeLine
+		}
+		return meta
 	}
 	switch m.activeApp {
 	case officeAppTasks:
@@ -2332,6 +2354,9 @@ func (m channelModel) currentHeaderMeta() string {
 		}
 		return fmt.Sprintf("  Reusable team skills · %d total · %d active · %d workflow-backed", len(m.skills), active, workflowBacked)
 	default:
+		if m.isOneOnOne() {
+			return fmt.Sprintf("  Direct session with %s · single-agent focus · external actions and reports stay in this conversation", m.oneOnOneAgentName())
+		}
 		if !m.brokerConnected {
 			return fmt.Sprintf("  Offline preview · manifest roster loaded · %d teammates ready for #%s", len(m.officeMembers), m.activeChannel)
 		}
@@ -2360,23 +2385,7 @@ func (m channelModel) currentAppLabel() string {
 }
 
 func (m channelModel) currentMainLines(contentWidth int) []renderedLine {
-	if m.isOneOnOne() {
-		return buildOneOnOneMessageLines(m.messages, m.expandedThreads, contentWidth, m.oneOnOneAgentName())
-	}
-	switch m.activeApp {
-	case officeAppTasks:
-		return buildTaskLines(m.tasks, contentWidth)
-	case officeAppRequests:
-		return buildRequestLines(m.requests, contentWidth)
-	case officeAppPolicies:
-		return buildPolicyLines(m.decisions, contentWidth)
-	case officeAppCalendar:
-		return buildCalendarLines(m.actions, m.scheduler, m.tasks, m.requests, m.activeChannel, m.members, m.calendarRange, m.calendarFilter, contentWidth)
-	case officeAppSkills:
-		return buildSkillLines(m.skills, contentWidth)
-	default:
-		return buildOfficeMessageLines(m.messages, m.expandedThreads, contentWidth, m.threadsDefaultExpand)
-	}
+	return m.cachedMainLines(contentWidth)
 }
 
 func filterInsightMessages(messages []brokerMessage) []brokerMessage {
@@ -2762,7 +2771,11 @@ func (m channelModel) nextFocus() focusArea {
 
 // updateThread handles key events when the thread panel is focused.
 func (m channelModel) updateThread(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	switch msg.String() {
+	key := msg.String()
+	if msg.Type == tea.KeyCtrlJ {
+		key = "ctrl+j"
+	}
+	switch key {
 	case "enter":
 		if len(m.threadInput) > 0 {
 			text := string(m.threadInput)
@@ -2790,6 +2803,13 @@ func (m channelModel) updateThread(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.updateThreadOverlays()
 	case "ctrl+e":
 		m.threadInputPos = len(m.threadInput)
+		m.updateThreadOverlays()
+	case "ctrl+j":
+		ch := []rune{'\n'}
+		tail := make([]rune, len(m.threadInput[m.threadInputPos:]))
+		copy(tail, m.threadInput[m.threadInputPos:])
+		m.threadInput = append(m.threadInput[:m.threadInputPos], append(ch, tail...)...)
+		m.threadInputPos++
 		m.updateThreadOverlays()
 	case "left":
 		if m.threadInputPos > 0 {
@@ -2825,6 +2845,9 @@ func (m channelModel) updateThread(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.updateThreadOverlays()
 		} else if len(msg.String()) == 1 || msg.Type == tea.KeyRunes {
 			ch := msg.Runes
+			if len(ch) == 0 {
+				ch = []rune(msg.String())
+			}
 			if len(ch) > 0 {
 				tail := make([]rune, len(m.threadInput[m.threadInputPos:]))
 				copy(tail, m.threadInput[m.threadInputPos:])
@@ -3818,9 +3841,13 @@ func (m channelModel) renderActivePopup(width int) string {
 	if m.autocomplete.IsVisible() {
 		var options []composerPopupOption
 		for _, cmd := range m.autocomplete.Matches() {
+			meta := cmd.Description
+			if strings.TrimSpace(cmd.Category) != "" {
+				meta = strings.ToUpper(cmd.Category) + " · " + meta
+			}
 			options = append(options, composerPopupOption{
 				Label: "/" + cmd.Name,
-				Meta:  cmd.Description,
+				Meta:  meta,
 			})
 		}
 		return renderComposerPopup(options, m.autocomplete.SelectedIndex(), width, slackActive)
@@ -3872,6 +3899,7 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		m.threadInputPos = 0
 	}
 	clearCurrent := func() {
+		m.doctor = nil
 		if threadTarget != "" {
 			clearThread()
 			m.updateThreadOverlays()
@@ -3995,6 +4023,10 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		m.pickerMode = channelPickerIntegrations
 		m.notice = "Choose an integration to connect."
 		return m, nil
+	case trimmed == "/doctor":
+		clearCurrent()
+		m.notice = "Checking readiness..."
+		return m, runDoctorChecks()
 	case trimmed == "/connect":
 		clearCurrent()
 		m.picker = tui.NewPicker("Connect a channel", []tui.PickerOption{
@@ -4267,6 +4299,9 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 				m.focus = focusMain
 			}
 			m.notice = "Reply mode cleared."
+		} else if m.doctor != nil {
+			m.doctor = nil
+			m.notice = "Doctor closed."
 		} else if m.initFlow.IsActive() || m.initFlow.Phase() == tui.InitDone || m.picker.IsActive() {
 			m.initFlow = tui.NewInitFlow()
 			m.picker.SetActive(false)
@@ -5376,10 +5411,10 @@ func connectTelegramGroup(token string, group team.TelegramGroup) tea.Cmd {
 			"members":     members,
 			"created_by":  "you",
 			"surface": map[string]any{
-				"provider":     "telegram",
-				"remote_id":   fmt.Sprintf("%d", group.ChatID),
-				"remote_title": group.Title,
-				"mode":        group.Type,
+				"provider":      "telegram",
+				"remote_id":     fmt.Sprintf("%d", group.ChatID),
+				"remote_title":  group.Title,
+				"mode":          group.Type,
 				"bot_token_env": "WUPHF_TELEGRAM_BOT_TOKEN",
 			},
 		})
@@ -5457,10 +5492,15 @@ func resetTeamSession(oneOnOne bool) tea.Cmd {
 		if err := l.ReconfigureSession(); err != nil {
 			return channelResetDoneMsg{err: err}
 		}
+		mode := team.SessionModeOffice
+		agent := ""
 		if oneOnOne {
-			return channelResetDoneMsg{notice: "Direct session reset. Agent pane reloaded in place."}
+			mode = team.SessionModeOneOnOne
 		}
-		return channelResetDoneMsg{notice: "Office reset. Team panes reloaded in place."}
+		if oneOnOne {
+			return channelResetDoneMsg{notice: "Direct session reset. Agent pane reloaded in place.", sessionMode: mode, oneOnOneAgent: agent}
+		}
+		return channelResetDoneMsg{notice: "Office reset. Team panes reloaded in place.", sessionMode: mode, oneOnOneAgent: agent}
 	}
 }
 
@@ -5504,9 +5544,17 @@ func switchSessionMode(mode, agent string) tea.Cmd {
 		}
 		switch team.NormalizeSessionMode(result.SessionMode) {
 		case team.SessionModeOneOnOne:
-			return channelResetDoneMsg{notice: "Direct 1:1 with " + displayName(team.NormalizeOneOnOneAgent(result.OneOnOneAgent)) + " is ready."}
+			return channelResetDoneMsg{
+				notice:        "Direct 1:1 with " + displayName(team.NormalizeOneOnOneAgent(result.OneOnOneAgent)) + " is ready.",
+				sessionMode:   result.SessionMode,
+				oneOnOneAgent: result.OneOnOneAgent,
+			}
 		default:
-			return channelResetDoneMsg{notice: "Office mode is ready."}
+			return channelResetDoneMsg{
+				notice:        "Office mode is ready.",
+				sessionMode:   result.SessionMode,
+				oneOnOneAgent: result.OneOnOneAgent,
+			}
 		}
 	}
 }

--- a/cmd/wuphf/channel_activity.go
+++ b/cmd/wuphf/channel_activity.go
@@ -1,0 +1,357 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+type memberRuntimeSummary struct {
+	Activity memberActivity
+	Detail   string
+	Bubble   string
+}
+
+func deriveMemberRuntimeSummary(member channelMember, tasks []channelTask, now time.Time) memberRuntimeSummary {
+	act := classifyActivity(member)
+	task, hasTask := activeSidebarTask(tasks, member.Slug)
+	if hasTask {
+		act = applyTaskActivity(act, task)
+	}
+
+	detail := summarizeLiveActivity(member.LiveActivity)
+	if hasTask {
+		taskLine := taskStatusLine(task)
+		switch {
+		case taskLine != "" && detail != "":
+			detail = taskLine + " · " + detail
+		case taskLine != "":
+			detail = taskLine
+		}
+	}
+	if detail == "" && strings.TrimSpace(member.LastMessage) != "" && act.Label != "lurking" {
+		detail = summarizeSentence(member.LastMessage)
+	}
+
+	bubble := officeAside(member.Slug, act.Label, member.LastMessage, now)
+	if hasTask && bubble == "" {
+		bubble = taskBubbleText(task)
+	}
+
+	return memberRuntimeSummary{
+		Activity: act,
+		Detail:   detail,
+		Bubble:   bubble,
+	}
+}
+
+func taskStatusLine(task channelTask) string {
+	title := strings.TrimSpace(task.Title)
+	if title == "" {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(task.Status)) {
+	case "in_progress":
+		return "Working on " + title
+	case "review":
+		return "Reviewing " + title
+	case "blocked":
+		return "Blocked on " + title
+	case "claimed", "pending", "open":
+		return "Queued: " + title
+	default:
+		return title
+	}
+}
+
+func summarizeLiveActivity(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	lines := strings.Split(raw, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := sanitizeActivityLine(lines[i])
+		if line == "" {
+			continue
+		}
+		return line
+	}
+	return ""
+}
+
+func sanitizeActivityLine(line string) string {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return ""
+	}
+	lower := strings.ToLower(line)
+	switch {
+	case strings.Contains(lower, "shift+tab"),
+		strings.Contains(lower, "permissions"),
+		strings.Contains(lower, "bypass"),
+		strings.HasPrefix(line, "❯"),
+		strings.HasPrefix(line, "─"),
+		strings.HasPrefix(line, "━"):
+		return ""
+	case strings.Contains(lower, "rg "),
+		strings.Contains(lower, "grep "),
+		strings.Contains(lower, "search"):
+		return "Searching the codebase"
+	case strings.Contains(lower, "read "),
+		strings.Contains(lower, "open "),
+		strings.Contains(lower, "inspect"):
+		return "Reading files"
+	case strings.Contains(lower, "go test"),
+		strings.Contains(lower, "npm test"),
+		strings.Contains(lower, "pytest"):
+		return "Running tests"
+	case strings.Contains(lower, "go build"),
+		strings.Contains(lower, "npm run build"),
+		strings.Contains(lower, "bun run build"):
+		return "Building the project"
+	case strings.Contains(lower, "curl "),
+		strings.Contains(lower, "http://"),
+		strings.Contains(lower, "https://"):
+		return "Calling an external system"
+	}
+	return summarizeSentence(line)
+}
+
+func summarizeSentence(text string) string {
+	text = strings.TrimSpace(strings.ReplaceAll(text, "\n", " "))
+	text = strings.Trim(text, "\"")
+	text = strings.TrimSpace(text)
+	if len(text) <= 88 {
+		return text
+	}
+	return text[:85] + "..."
+}
+
+func buildLiveWorkLines(members []channelMember, tasks []channelTask, actions []channelAction, contentWidth int, focusSlug string) []renderedLine {
+	var lines []renderedLine
+	now := time.Now()
+	var active []channelMember
+	for _, member := range members {
+		if member.Slug == "you" || member.Slug == "human" {
+			continue
+		}
+		summary := deriveMemberRuntimeSummary(member, tasks, now)
+		if summary.Activity.Label == "lurking" && summary.Detail == "" {
+			continue
+		}
+		if focusSlug != "" && member.Slug != focusSlug {
+			continue
+		}
+		active = append(active, member)
+	}
+	if len(active) > 0 {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Live work now")})
+		for _, member := range active {
+			summary := deriveMemberRuntimeSummary(member, tasks, now)
+			nameColor := agentColorMap[member.Slug]
+			if nameColor == "" {
+				nameColor = "#64748B"
+			}
+			name := member.Name
+			if strings.TrimSpace(name) == "" {
+				name = displayName(member.Slug)
+			}
+			header := "  " + activityPill(summary.Activity) + " " + lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(nameColor)).Render(name)
+			lines = append(lines, renderedLine{Text: header})
+			if summary.Detail != "" {
+				lines = append(lines, renderedLine{Text: "    " + mutedText(summary.Detail)})
+			}
+		}
+	}
+
+	recent := recentExternalActions(actions, 3)
+	if len(recent) > 0 {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Recent external actions")})
+		for _, action := range recent {
+			lines = append(lines, renderedLine{Text: "  " + actionStatePill(action.Kind) + " " + lipgloss.NewStyle().Bold(true).Render(action.Summary)})
+			metaParts := []string{}
+			if actor := strings.TrimSpace(action.Actor); actor != "" {
+				metaParts = append(metaParts, "@"+actor)
+			}
+			if source := strings.TrimSpace(action.Source); source != "" {
+				metaParts = append(metaParts, source)
+			}
+			if created := strings.TrimSpace(action.CreatedAt); created != "" {
+				metaParts = append(metaParts, prettyRelativeTime(created))
+			}
+			if len(metaParts) > 0 {
+				lines = append(lines, renderedLine{Text: "    " + mutedText(strings.Join(metaParts, " · "))})
+			}
+		}
+	}
+	return lines
+}
+
+func buildDirectExecutionLines(actions []channelAction, focusSlug string, contentWidth int) []renderedLine {
+	recent := recentDirectExecutionActions(actions, focusSlug, 6)
+	if len(recent) == 0 {
+		return nil
+	}
+	lines := []renderedLine{
+		{Text: ""},
+		{Text: renderDateSeparator(contentWidth, "Execution timeline")},
+	}
+	for _, action := range recent {
+		title := strings.TrimSpace(action.Summary)
+		if title == "" {
+			title = strings.ReplaceAll(action.Kind, "_", " ")
+		}
+		when := strings.TrimSpace(shortClock(action.CreatedAt))
+		if when == "" {
+			when = prettyRelativeTime(action.CreatedAt)
+		}
+		lines = append(lines, renderedLine{
+			Text: "  " + subtlePill(when, "#E2E8F0", "#1E293B") + " " + actionStatePill(action.Kind) + " " + lipgloss.NewStyle().Bold(true).Render(title),
+		})
+		meta := executionMetaLine(action)
+		if meta != "" {
+			lines = append(lines, renderedLine{Text: "    " + mutedText(meta)})
+		}
+	}
+	return lines
+}
+
+func recentDirectExecutionActions(actions []channelAction, focusSlug string, limit int) []channelAction {
+	var filtered []channelAction
+	for _, action := range actions {
+		if !strings.HasPrefix(strings.TrimSpace(action.Kind), "external_") {
+			continue
+		}
+		actor := strings.TrimSpace(action.Actor)
+		if focusSlug != "" && actor != "" && actor != focusSlug && actor != "scheduler" {
+			continue
+		}
+		filtered = append(filtered, action)
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[len(filtered)-limit:]
+	}
+	out := append([]channelAction(nil), filtered...)
+	reverseAny(out)
+	return out
+}
+
+func executionMetaLine(action channelAction) string {
+	parts := []string{}
+	if source := strings.TrimSpace(action.Source); source != "" {
+		parts = append(parts, source)
+	}
+	if actor := strings.TrimSpace(action.Actor); actor != "" {
+		parts = append(parts, "@"+actor)
+	}
+	if related := strings.TrimSpace(action.RelatedID); related != "" {
+		parts = append(parts, related)
+	}
+	if when := strings.TrimSpace(action.CreatedAt); when != "" {
+		parts = append(parts, prettyRelativeTime(when))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func oneOnOneRuntimeLine(officeMembers []officeMemberInfo, members []channelMember, tasks []channelTask, actions []channelAction, slug string) string {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return ""
+	}
+	var selected channelMember
+	found := false
+	for _, member := range mergeOfficeMembers(officeMembers, members, nil) {
+		if member.Slug == slug {
+			selected = member
+			found = true
+			break
+		}
+	}
+	if !found {
+		return ""
+	}
+	summary := deriveMemberRuntimeSummary(selected, tasks, time.Now())
+	parts := []string{displayName(slug)}
+	if summary.Activity.Label != "" {
+		parts = append(parts, summary.Activity.Label)
+	}
+	if summary.Detail != "" {
+		parts = append(parts, summary.Detail)
+	}
+	if latest, ok := latestRelevantAction(actions, slug); ok {
+		parts = append(parts, describeActionState(latest))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func latestRelevantAction(actions []channelAction, slug string) (channelAction, bool) {
+	slug = strings.TrimSpace(slug)
+	for i := len(actions) - 1; i >= 0; i-- {
+		action := actions[i]
+		if !strings.HasPrefix(strings.TrimSpace(action.Kind), "external_") {
+			continue
+		}
+		actor := strings.TrimSpace(action.Actor)
+		if actor != "" && actor != slug && actor != "scheduler" {
+			continue
+		}
+		return action, true
+	}
+	return channelAction{}, false
+}
+
+func describeActionState(action channelAction) string {
+	switch {
+	case strings.Contains(action.Kind, "failed"):
+		return fmt.Sprintf("last action failed: %s", strings.TrimSpace(action.Summary))
+	case strings.Contains(action.Kind, "planned"):
+		return fmt.Sprintf("dry-run ready: %s", strings.TrimSpace(action.Summary))
+	case strings.Contains(action.Kind, "scheduled"):
+		return fmt.Sprintf("scheduled: %s", strings.TrimSpace(action.Summary))
+	case strings.Contains(action.Kind, "registered"):
+		return fmt.Sprintf("listening: %s", strings.TrimSpace(action.Summary))
+	case strings.Contains(action.Kind, "executed"), strings.Contains(action.Kind, "created"):
+		return fmt.Sprintf("completed: %s", strings.TrimSpace(action.Summary))
+	default:
+		return strings.TrimSpace(action.Summary)
+	}
+}
+
+func activityPill(act memberActivity) string {
+	switch act.Label {
+	case "working", "shipping":
+		return accentPill(act.Label, "#7C3AED")
+	case "reviewing":
+		return accentPill(act.Label, "#2563EB")
+	case "blocked":
+		return accentPill(act.Label, "#B91C1C")
+	case "queued", "plotting":
+		return accentPill(act.Label, "#B45309")
+	case "talking":
+		return accentPill(act.Label, "#15803D")
+	case "away":
+		return subtlePill(act.Label, "#CBD5E1", "#475569")
+	default:
+		return subtlePill(act.Label, "#CBD5E1", "#334155")
+	}
+}
+
+func actionStatePill(kind string) string {
+	switch {
+	case strings.Contains(kind, "failed"):
+		return accentPill("failed", "#B91C1C")
+	case strings.Contains(kind, "planned"):
+		return accentPill("planned", "#1D4ED8")
+	case strings.Contains(kind, "registered"), strings.Contains(kind, "received"):
+		return accentPill("listening", "#7C3AED")
+	case strings.Contains(kind, "executed"), strings.Contains(kind, "created"), strings.Contains(kind, "scheduled"):
+		return accentPill("completed", "#15803D")
+	default:
+		return subtlePill(strings.ReplaceAll(kind, "_", " "), "#E2E8F0", "#334155")
+	}
+}

--- a/cmd/wuphf/channel_composer.go
+++ b/cmd/wuphf/channel_composer.go
@@ -22,7 +22,6 @@ func renderComposer(width int, input []rune, inputPos int, channelName string,
 
 	// ── Typing indicator ──────────────────────────────────────────────
 
-
 	// ── Composer label ────────────────────────────────────────────────
 	label := fmt.Sprintf("Message #%s", channelName)
 	if strings.HasPrefix(channelName, "1:1 ") {
@@ -37,7 +36,13 @@ func renderComposer(width int, input []rune, inputPos int, channelName string,
 		Foreground(lipgloss.Color(slackActive)).
 		Bold(true)
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
-	parts = append(parts, "  "+labelStyle.Render(label)+"  "+hintStyle.Render("/ commands · @ mention · Enter send · Esc pause all"))
+	hint := "/ commands · @ mention · Ctrl+J newline · Enter send · Esc pause all"
+	if pending != nil {
+		hint = "↑/↓ pick option · Enter submit · type to answer freeform · Esc pause all"
+	} else if strings.HasPrefix(channelName, "1:1 ") {
+		hint = "/ commands · @ mention · Ctrl+J newline · Enter send direct · Esc pause all"
+	}
+	parts = append(parts, "  "+labelStyle.Render(label)+"  "+hintStyle.Render(hint))
 
 	// ── Input field with rounded border ───────────────────────────────
 	innerW := width - 6 // border (2) + padding (2) + outer margin (2)
@@ -50,12 +55,12 @@ func renderComposer(width int, input []rune, inputPos int, channelName string,
 		cursorStyle := lipgloss.NewStyle().Reverse(true)
 		placeholder := "Type a message... (/ commands, @ mention)"
 		if strings.HasPrefix(channelName, "1:1 ") {
-			placeholder = "Talk directly to your agent here..."
+			placeholder = "Talk directly to your agent here... (Ctrl+J for a new line)"
 		}
 		if pending != nil {
 			placeholder = "Type your answer here, or Enter to accept the highlighted option"
 		} else if replyToID != "" {
-			placeholder = fmt.Sprintf("Reply in thread %s... (/cancel to go back)", replyToID)
+			placeholder = fmt.Sprintf("Reply in thread %s... (Ctrl+J newline, /cancel to go back)", replyToID)
 		}
 		inputStr = cursorStyle.Render(" ") + lipgloss.NewStyle().
 			Foreground(lipgloss.Color(slackMuted)).Render(" "+placeholder)

--- a/cmd/wuphf/channel_doctor.go
+++ b/cmd/wuphf/channel_doctor.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/nex-crm/wuphf/internal/action"
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+type doctorSeverity string
+
+const (
+	doctorOK   doctorSeverity = "ok"
+	doctorWarn doctorSeverity = "warn"
+	doctorFail doctorSeverity = "fail"
+	doctorInfo doctorSeverity = "info"
+)
+
+type doctorCheck struct {
+	Label    string
+	Severity doctorSeverity
+	Detail   string
+	NextStep string
+}
+
+type channelDoctorReport struct {
+	GeneratedAt time.Time
+	Checks      []doctorCheck
+}
+
+type channelDoctorDoneMsg struct {
+	report channelDoctorReport
+	err    error
+}
+
+func (r channelDoctorReport) counts() (ok, warn, fail int) {
+	for _, check := range r.Checks {
+		switch check.Severity {
+		case doctorOK:
+			ok++
+		case doctorWarn:
+			warn++
+		case doctorFail:
+			fail++
+		}
+	}
+	return ok, warn, fail
+}
+
+func (r channelDoctorReport) StatusLine() string {
+	ok, warn, fail := r.counts()
+	switch {
+	case fail > 0:
+		return fmt.Sprintf("%d healthy · %d warning · %d blocked", ok, warn, fail)
+	case warn > 0:
+		return fmt.Sprintf("%d healthy · %d warning", ok, warn)
+	default:
+		return fmt.Sprintf("%d healthy · ready to work", ok)
+	}
+}
+
+func runDoctorChecks() tea.Cmd {
+	return func() tea.Msg {
+		report, err := inspectDoctor()
+		return channelDoctorDoneMsg{report: report, err: err}
+	}
+}
+
+func inspectDoctor() (channelDoctorReport, error) {
+	report := channelDoctorReport{GeneratedAt: time.Now()}
+	report.Checks = append(report.Checks,
+		doctorBinaryCheck("tmux", "Needed for the office panes and session management."),
+		doctorBinaryCheck("claude", "Needed for the teammate runtime."),
+	)
+
+	if config.ResolveNoNex() {
+		report.Checks = append(report.Checks, doctorCheck{
+			Label:    "Nex",
+			Severity: doctorInfo,
+			Detail:   "Disabled for this session with --no-nex.",
+			NextStep: "Restart WUPHF without --no-nex to enable memory, integrations, and provider-backed actions.",
+		})
+		return report, nil
+	}
+
+	apiKey := strings.TrimSpace(config.ResolveAPIKey(""))
+	if apiKey == "" {
+		report.Checks = append(report.Checks, doctorCheck{
+			Label:    "Nex API key",
+			Severity: doctorFail,
+			Detail:   "Missing WUPHF/Nex API key.",
+			NextStep: "Run /init and paste your WUPHF API key.",
+		})
+	} else {
+		report.Checks = append(report.Checks, doctorCheck{
+			Label:    "Nex API key",
+			Severity: doctorOK,
+			Detail:   "Configured and ready for Nex-backed context.",
+		})
+	}
+
+	email := strings.TrimSpace(config.ResolveComposioUserID())
+	if email == "" {
+		report.Checks = append(report.Checks, doctorCheck{
+			Label:    "Workspace identity",
+			Severity: doctorWarn,
+			Detail:   "No saved email identity for integrations.",
+			NextStep: "Finish /init so WUPHF can scope integration providers to your Nex email.",
+		})
+	} else {
+		report.Checks = append(report.Checks, doctorCheck{
+			Label:    "Workspace identity",
+			Severity: doctorOK,
+			Detail:   fmt.Sprintf("Using %s for provider identity.", email),
+		})
+	}
+
+	resolvedProvider := config.ResolveActionProvider()
+	if resolvedProvider == "" {
+		resolvedProvider = "auto"
+	}
+	registry := action.NewRegistryFromEnv()
+	provider, err := registry.ProviderFor(action.CapabilityConnections)
+	if err != nil {
+		report.Checks = append(report.Checks, doctorCheck{
+			Label:    "Action provider",
+			Severity: doctorFail,
+			Detail:   fmt.Sprintf("No working provider for external actions (%s).", resolvedProvider),
+			NextStep: "Set /config set composio_api_key <key> or choose a configured provider.",
+		})
+		return report, nil
+	}
+
+	report.Checks = append(report.Checks, doctorCheck{
+		Label:    "Action provider",
+		Severity: doctorOK,
+		Detail:   fmt.Sprintf("Using %s for external actions.", provider.Name()),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	connections, err := provider.ListConnections(ctx, action.ListConnectionsOptions{Limit: 5})
+	if err != nil {
+		report.Checks = append(report.Checks, doctorCheck{
+			Label:    "Connected accounts",
+			Severity: doctorWarn,
+			Detail:   fmt.Sprintf("Provider responded with an error: %v", err),
+			NextStep: "Open the provider dashboard and confirm at least one account is connected for your Nex email.",
+		})
+		return report, nil
+	}
+	if len(connections.Connections) == 0 {
+		report.Checks = append(report.Checks, doctorCheck{
+			Label:    "Connected accounts",
+			Severity: doctorWarn,
+			Detail:   fmt.Sprintf("%s is configured, but no connected accounts are available yet.", strings.Title(provider.Name())),
+			NextStep: "Connect Gmail, CRM, or another account in the provider dashboard, then rerun /doctor.",
+		})
+		return report, nil
+	}
+
+	report.Checks = append(report.Checks, doctorCheck{
+		Label:    "Connected accounts",
+		Severity: doctorOK,
+		Detail:   fmt.Sprintf("%d account%s ready through %s.", len(connections.Connections), pluralSuffix(len(connections.Connections)), strings.Title(provider.Name())),
+	})
+	return report, nil
+}
+
+func doctorBinaryCheck(name, reason string) doctorCheck {
+	if _, err := exec.LookPath(name); err != nil {
+		return doctorCheck{
+			Label:    name,
+			Severity: doctorFail,
+			Detail:   fmt.Sprintf("%s is not available on PATH.", name),
+			NextStep: reason,
+		}
+	}
+	return doctorCheck{
+		Label:    name,
+		Severity: doctorOK,
+		Detail:   fmt.Sprintf("%s is installed.", name),
+	}
+}
+
+func renderDoctorCard(report channelDoctorReport, width int) string {
+	cardWidth := maxInt(48, width)
+	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F8FAFC")).Render("Doctor")
+	meta := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted)).Render(report.GeneratedAt.Format("Jan 2 15:04"))
+	lines := []string{
+		title + "  " + subtlePill(report.StatusLine(), "#E5E7EB", "#334155") + "  " + meta,
+		mutedText("This is the live readiness check for setup, integrations, and the agent runtime."),
+		"",
+	}
+
+	for _, check := range report.Checks {
+		label := renderDoctorLabel(check)
+		lines = append(lines, label+" "+check.Detail)
+		if strings.TrimSpace(check.NextStep) != "" {
+			lines = append(lines, "  "+mutedText("Next: "+check.NextStep))
+		}
+		lines = append(lines, "")
+	}
+	lines = append(lines, mutedText("Esc or /cancel closes this panel."))
+
+	return lipgloss.NewStyle().
+		Width(cardWidth).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("#334155")).
+		Background(lipgloss.Color("#14151B")).
+		Padding(0, 1).
+		Render(strings.Join(lines, "\n"))
+}
+
+func renderDoctorLabel(check doctorCheck) string {
+	switch check.Severity {
+	case doctorOK:
+		return accentPill(check.Label, "#15803D")
+	case doctorWarn:
+		return accentPill(check.Label, "#B45309")
+	case doctorFail:
+		return accentPill(check.Label, "#B91C1C")
+	default:
+		return subtlePill(check.Label, "#E2E8F0", "#334155")
+	}
+}

--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -516,7 +515,7 @@ func buildSkillLines(skills []channelSkill, contentWidth int) []renderedLine {
 			lines = append(lines, renderedLine{Text: "  " + muted.Render(fmt.Sprintf("workflow: %s via %s", skill.WorkflowKey, fallbackString(skill.WorkflowProvider, "one")))})
 		}
 		if skill.WorkflowSchedule != "" {
-			lines = append(lines, renderedLine{Text: "  " + muted.Render("schedule: " + skill.WorkflowSchedule)})
+			lines = append(lines, renderedLine{Text: "  " + muted.Render("schedule: "+skill.WorkflowSchedule)})
 		}
 		if skill.RelayID != "" || skill.RelayPlatform != "" || len(skill.RelayEventTypes) > 0 {
 			relayParts := []string{}
@@ -529,7 +528,7 @@ func buildSkillLines(skills []channelSkill, contentWidth int) []renderedLine {
 			if skill.RelayID != "" {
 				relayParts = append(relayParts, skill.RelayID)
 			}
-			lines = append(lines, renderedLine{Text: "  " + muted.Render("relay: " + strings.Join(relayParts, " · "))})
+			lines = append(lines, renderedLine{Text: "  " + muted.Render("relay: "+strings.Join(relayParts, " · "))})
 		}
 		if skill.LastExecutionAt != "" || skill.LastExecutionStatus != "" {
 			runParts := []string{}
@@ -539,7 +538,7 @@ func buildSkillLines(skills []channelSkill, contentWidth int) []renderedLine {
 			if skill.LastExecutionAt != "" {
 				runParts = append(runParts, prettyRelativeTime(skill.LastExecutionAt))
 			}
-			lines = append(lines, renderedLine{Text: "  " + muted.Render("last run: " + strings.Join(runParts, " · "))})
+			lines = append(lines, renderedLine{Text: "  " + muted.Render("last run: "+strings.Join(runParts, " · "))})
 		}
 	}
 	return lines
@@ -1354,10 +1353,11 @@ func renderMarkdown(text string, width int) string {
 	if !strings.ContainsAny(text, "*_`#|-[]>") {
 		return text
 	}
-	r, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
-		glamour.WithWordWrap(width),
-	)
+	key := markdownCacheKey(width, text)
+	if cached, ok := channelRenderCache.getMarkdown(key); ok {
+		return cached
+	}
+	r, err := channelRenderCache.renderer(width)
 	if err != nil {
 		return text
 	}
@@ -1369,5 +1369,6 @@ func renderMarkdown(text string, width int) string {
 	result := strings.TrimRight(rendered, "\n ")
 	// Remove glamour's auto-linked mailto: URLs that duplicate email addresses
 	result = strings.ReplaceAll(result, "mailto:", "")
+	channelRenderCache.putMarkdown(key, result)
 	return result
 }

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -1,0 +1,363 @@
+package main
+
+import (
+	"fmt"
+	"hash"
+	"hash/fnv"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/glamour"
+)
+
+const (
+	mainLinesCacheLimit = 48
+	sidebarCacheLimit   = 24
+	markdownCacheLimit  = 256
+)
+
+type channelRenderCacheStore struct {
+	mu sync.Mutex
+
+	mainLines map[uint64][]renderedLine
+	sidebars  map[uint64]string
+	markdown  map[uint64]string
+	renderers map[int]*glamour.TermRenderer
+}
+
+var channelRenderCache = channelRenderCacheStore{
+	mainLines: make(map[uint64][]renderedLine),
+	sidebars:  make(map[uint64]string),
+	markdown:  make(map[uint64]string),
+	renderers: make(map[int]*glamour.TermRenderer),
+}
+
+func cachedSidebarRender(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, brokerConnected bool, width, height int) string {
+	key := hashSidebarState(channels, members, tasks, activeChannel, activeApp, cursor, rosterOffset, focused, quickJump, brokerConnected, width, height)
+	if cached, ok := channelRenderCache.getSidebar(key); ok {
+		return cached
+	}
+	rendered := renderSidebar(channels, members, tasks, activeChannel, activeApp, cursor, rosterOffset, focused, quickJump, brokerConnected, width, height)
+	channelRenderCache.putSidebar(key, rendered)
+	return rendered
+}
+
+func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
+	key := m.hashMainLinesState(contentWidth)
+	if cached, ok := channelRenderCache.getMainLines(key); ok {
+		return cached
+	}
+
+	var lines []renderedLine
+	if m.isOneOnOne() {
+		lines = buildOneOnOneMessageLines(m.messages, m.expandedThreads, contentWidth, m.oneOnOneAgentName())
+		focusSlug := m.oneOnOneAgentSlug()
+		lines = append(lines, buildDirectExecutionLines(m.actions, focusSlug, contentWidth)...)
+		lines = append(lines, buildLiveWorkLines(m.members, m.tasks, nil, contentWidth, focusSlug)...)
+	} else {
+		switch m.activeApp {
+		case officeAppTasks:
+			lines = buildTaskLines(m.tasks, contentWidth)
+		case officeAppRequests:
+			lines = buildRequestLines(m.requests, contentWidth)
+		case officeAppPolicies:
+			lines = buildPolicyLines(m.decisions, contentWidth)
+		case officeAppCalendar:
+			lines = buildCalendarLines(m.actions, m.scheduler, m.tasks, m.requests, m.activeChannel, m.members, m.calendarRange, m.calendarFilter, contentWidth)
+		case officeAppSkills:
+			lines = buildSkillLines(m.skills, contentWidth)
+		default:
+			lines = buildOfficeMessageLines(m.messages, m.expandedThreads, contentWidth, m.threadsDefaultExpand)
+			lines = append(lines, buildLiveWorkLines(m.members, m.tasks, m.actions, contentWidth, "")...)
+		}
+	}
+
+	channelRenderCache.putMainLines(key, lines)
+	return cloneRenderedLines(lines)
+}
+
+func (m channelModel) hashMainLinesState(contentWidth int) uint64 {
+	h := newStateHasher()
+	h.add("main-lines")
+	h.addInt(contentWidth)
+	h.add(string(m.activeApp))
+	h.add(m.activeChannel)
+	h.add(string(m.calendarRange))
+	h.add(m.calendarFilter)
+	h.add(m.sessionMode)
+	h.add(m.oneOnOneAgent)
+	h.addInt64(renderTimeBucket(m.activeApp, m.isOneOnOne()))
+
+	if m.isOneOnOne() || m.activeApp == officeAppMessages {
+		h.addMessages(m.messages)
+		h.addExpandedThreads(m.expandedThreads)
+		h.addMembers(m.members)
+		h.addTasks(m.tasks)
+		h.addActions(m.actions)
+		if m.isOneOnOne() {
+			h.add(m.oneOnOneAgentName())
+		}
+		return h.sum()
+	}
+
+	switch m.activeApp {
+	case officeAppTasks:
+		h.addTasks(m.tasks)
+	case officeAppRequests:
+		h.addRequests(m.requests)
+	case officeAppPolicies:
+		h.addDecisions(m.decisions)
+	case officeAppCalendar:
+		h.addActions(m.actions)
+		h.addScheduler(m.scheduler)
+		h.addTasks(m.tasks)
+		h.addRequests(m.requests)
+		h.addMembers(m.members)
+	case officeAppSkills:
+		h.addSkills(m.skills)
+	}
+	return h.sum()
+}
+
+func renderTimeBucket(activeApp officeApp, direct bool) int64 {
+	if direct || activeApp == officeAppMessages {
+		return time.Now().Unix()
+	}
+	return time.Now().Unix() / 30
+}
+
+func hashSidebarState(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, brokerConnected bool, width, height int) uint64 {
+	h := newStateHasher()
+	h.add("sidebar")
+	h.addInt(width)
+	h.addInt(height)
+	h.add(activeChannel)
+	h.add(string(activeApp))
+	h.addInt(cursor)
+	h.addInt(rosterOffset)
+	h.addBool(focused)
+	h.add(string(quickJump))
+	h.addBool(brokerConnected)
+	h.addInt64(time.Now().Unix())
+	h.addChannels(channels)
+	h.addMembers(members)
+	h.addTasks(tasks)
+	return h.sum()
+}
+
+func cloneRenderedLines(lines []renderedLine) []renderedLine {
+	if len(lines) == 0 {
+		return nil
+	}
+	out := make([]renderedLine, len(lines))
+	copy(out, lines)
+	return out
+}
+
+func (c *channelRenderCacheStore) getMainLines(key uint64) ([]renderedLine, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	lines, ok := c.mainLines[key]
+	if !ok {
+		return nil, false
+	}
+	return cloneRenderedLines(lines), true
+}
+
+func (c *channelRenderCacheStore) putMainLines(key uint64, lines []renderedLine) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.mainLines) >= mainLinesCacheLimit {
+		c.mainLines = make(map[uint64][]renderedLine)
+	}
+	c.mainLines[key] = cloneRenderedLines(lines)
+}
+
+func (c *channelRenderCacheStore) getSidebar(key uint64) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	rendered, ok := c.sidebars[key]
+	return rendered, ok
+}
+
+func (c *channelRenderCacheStore) putSidebar(key uint64, rendered string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.sidebars) >= sidebarCacheLimit {
+		c.sidebars = make(map[uint64]string)
+	}
+	c.sidebars[key] = rendered
+}
+
+func (c *channelRenderCacheStore) getMarkdown(key uint64) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	rendered, ok := c.markdown[key]
+	return rendered, ok
+}
+
+func (c *channelRenderCacheStore) putMarkdown(key uint64, rendered string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.markdown) >= markdownCacheLimit {
+		c.markdown = make(map[uint64]string)
+	}
+	c.markdown[key] = rendered
+}
+
+func (c *channelRenderCacheStore) renderer(width int) (*glamour.TermRenderer, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if renderer, ok := c.renderers[width]; ok {
+		return renderer, nil
+	}
+	renderer, err := glamour.NewTermRenderer(
+		glamour.WithAutoStyle(),
+		glamour.WithWordWrap(width),
+	)
+	if err != nil {
+		return nil, err
+	}
+	c.renderers[width] = renderer
+	return renderer, nil
+}
+
+type stateHasher struct {
+	h hash.Hash64
+}
+
+func newStateHasher() stateHasher {
+	return stateHasher{h: fnv.New64a()}
+}
+
+func (s stateHasher) add(parts ...string) {
+	for _, part := range parts {
+		_, _ = s.h.Write([]byte(part))
+		_, _ = s.h.Write([]byte{0})
+	}
+}
+
+func (s stateHasher) addInt(v int) {
+	s.add(strconv.Itoa(v))
+}
+
+func (s stateHasher) addInt64(v int64) {
+	s.add(strconv.FormatInt(v, 10))
+}
+
+func (s stateHasher) addBool(v bool) {
+	if v {
+		s.add("1")
+		return
+	}
+	s.add("0")
+}
+
+func (s stateHasher) sum() uint64 {
+	return s.h.Sum64()
+}
+
+func (s stateHasher) addMessages(messages []brokerMessage) {
+	s.addInt(len(messages))
+	for _, msg := range messages {
+		s.add(msg.ID, msg.From, msg.Kind, msg.Source, msg.Title, msg.ReplyTo, msg.Timestamp, msg.Content)
+		s.add(strings.Join(msg.Tagged, ","))
+	}
+}
+
+func (s stateHasher) addExpandedThreads(expanded map[string]bool) {
+	if len(expanded) == 0 {
+		s.add("no-expanded")
+		return
+	}
+	keys := make([]string, 0, len(expanded))
+	for key, expanded := range expanded {
+		if expanded {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	s.add(strings.Join(keys, ","))
+}
+
+func (s stateHasher) addMembers(members []channelMember) {
+	s.addInt(len(members))
+	for _, member := range members {
+		s.add(member.Slug, member.Name, member.Role, member.LastMessage, member.LastTime, member.LiveActivity)
+		s.addBool(member.Disabled)
+	}
+}
+
+func (s stateHasher) addChannels(channels []channelInfo) {
+	s.addInt(len(channels))
+	for _, channel := range channels {
+		s.add(channel.Slug, channel.Name, channel.Description)
+		s.add(strings.Join(channel.Members, ","))
+		s.add(strings.Join(channel.Disabled, ","))
+	}
+}
+
+func (s stateHasher) addTasks(tasks []channelTask) {
+	s.addInt(len(tasks))
+	for _, task := range tasks {
+		s.add(task.ID, task.Channel, task.Title, task.Owner, task.Status, task.TaskType, task.PipelineStage, task.ExecutionMode, task.ReviewState, task.DueAt, task.UpdatedAt)
+	}
+}
+
+func (s stateHasher) addActions(actions []channelAction) {
+	s.addInt(len(actions))
+	for _, action := range actions {
+		s.add(action.ID, action.Kind, action.Source, action.Channel, action.Actor, action.Summary, action.RelatedID, action.DecisionID, action.CreatedAt)
+		s.add(strings.Join(action.SignalIDs, ","))
+	}
+}
+
+func (s stateHasher) addRequests(requests []channelInterview) {
+	s.addInt(len(requests))
+	for _, req := range requests {
+		s.add(req.ID, req.Kind, req.Status, req.From, req.Channel, req.Title, req.Question, req.Context, req.RecommendedID, req.ReplyTo, req.CreatedAt, req.DueAt, req.FollowUpAt, req.ReminderAt, req.RecheckAt)
+		s.addBool(req.Blocking)
+		s.addBool(req.Required)
+		s.addBool(req.Secret)
+		for _, opt := range req.Options {
+			s.add(opt.ID, opt.Label, opt.Description)
+		}
+	}
+}
+
+func (s stateHasher) addDecisions(decisions []channelDecision) {
+	s.addInt(len(decisions))
+	for _, decision := range decisions {
+		s.add(decision.ID, decision.Kind, decision.Channel, decision.Summary, decision.Reason, decision.Owner, decision.CreatedAt)
+		s.addBool(decision.RequiresHuman)
+		s.addBool(decision.Blocking)
+		s.add(strings.Join(decision.SignalIDs, ","))
+	}
+}
+
+func (s stateHasher) addScheduler(jobs []channelSchedulerJob) {
+	s.addInt(len(jobs))
+	for _, job := range jobs {
+		s.add(job.Slug, job.Label, job.Kind, job.TargetType, job.TargetID, job.Channel, job.Provider, job.ScheduleExpr, job.WorkflowKey, job.SkillName, job.DueAt, job.NextRun, job.LastRun, job.Status)
+		s.addInt(job.IntervalMinutes)
+	}
+}
+
+func (s stateHasher) addSkills(skills []channelSkill) {
+	s.addInt(len(skills))
+	for _, skill := range skills {
+		s.add(skill.ID, skill.Name, skill.Title, skill.Description, skill.Channel, skill.WorkflowProvider, skill.WorkflowKey, skill.WorkflowSchedule, skill.RelayID, skill.RelayPlatform, skill.LastExecutionAt, skill.LastExecutionStatus, skill.Status, skill.UpdatedAt)
+		s.add(strings.Join(skill.Tags, ","))
+		s.add(strings.Join(skill.RelayEventTypes, ","))
+		s.addInt(skill.UsageCount)
+	}
+}
+
+func markdownCacheKey(width int, text string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(fmt.Sprintf("%d|%s", width, text)))
+	return h.Sum64()
+}

--- a/cmd/wuphf/channel_sidebar.go
+++ b/cmd/wuphf/channel_sidebar.go
@@ -99,7 +99,6 @@ func classifyActivity(m channelMember) memberActivity {
 	return memberActivity{Label: "lurking", Color: dotIdle, Dot: "●"} // ● grey filled
 }
 
-
 func defaultSidebarRoster() []channelMember {
 	return []channelMember{
 		{Slug: "ceo", Name: "CEO", Role: "strategy"},
@@ -524,13 +523,11 @@ func renderSidebar(channels []channelInfo, members []channelMember, tasks []chan
 	now := time.Now()
 	for i := start; i < end; i++ {
 		m := members[i]
-		act := classifyActivity(m)
-		if task, ok := activeSidebarTask(tasks, m.Slug); ok {
-			act = applyTaskActivity(act, task)
-		}
+		summary := deriveMemberRuntimeSummary(m, tasks, now)
+		act := summary.Activity
 		character := renderOfficeCharacter(m, act, now)
-		if task, ok := activeSidebarTask(tasks, m.Slug); ok && character.Bubble == "" {
-			character.Bubble = taskBubbleText(task)
+		if summary.Bubble != "" {
+			character.Bubble = summary.Bubble
 		}
 
 		dotStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(act.Color))
@@ -544,7 +541,7 @@ func renderSidebar(channels []channelInfo, members []channelMember, tasks []chan
 		if name == "" {
 			name = displayName(m.Slug)
 		}
-		sidebarLabel := "" // dots only, no text labels in sidebar
+		sidebarLabel := act.Label
 		nameMax := innerW - 8 - ansi.StringWidth(sidebarLabel)
 		if nameMax < 8 {
 			nameMax = 8

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -280,6 +280,56 @@ func TestChannelViewUsesOneOnOneChrome(t *testing.T) {
 	}
 }
 
+func TestOneOnOneViewShowsExecutionTimeline(t *testing.T) {
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 30
+	m.sessionMode = team.SessionModeOneOnOne
+	m.oneOnOneAgent = "ceo"
+	m.sidebarCollapsed = true
+	m.refreshSlashCommands()
+	m.actions = []channelAction{
+		{ID: "action-1", Kind: "external_action_planned", Source: "composio", Actor: "ceo", Summary: "Dry-run Gmail send ready.", RelatedID: "GMAIL_SEND_EMAIL", CreatedAt: "2026-04-02T10:00:00Z"},
+		{ID: "action-2", Kind: "external_action_executed", Source: "composio", Actor: "ceo", Summary: "Sent the test email.", RelatedID: "GMAIL_SEND_EMAIL", CreatedAt: "2026-04-02T10:01:00Z"},
+	}
+
+	view := stripANSI(m.View())
+	if !strings.Contains(view, "Execution timeline") || !strings.Contains(view, "Sent the test email.") {
+		t.Fatalf("expected 1:1 execution timeline, got %q", view)
+	}
+	if !strings.Contains(view, "completed") || !strings.Contains(view, "planned") {
+		t.Fatalf("expected action state pills in 1:1 timeline, got %q", view)
+	}
+}
+
+func TestOneOnOneStatusBarShowsRuntimeSummary(t *testing.T) {
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 30
+	m.sessionMode = team.SessionModeOneOnOne
+	m.oneOnOneAgent = "ceo"
+	m.sidebarCollapsed = true
+	m.refreshSlashCommands()
+	m.brokerConnected = true
+	m.members = []channelMember{{
+		Slug:         "ceo",
+		Name:         "CEO",
+		LiveActivity: "go test ./cmd/wuphf",
+	}}
+	m.tasks = []channelTask{{
+		ID:      "task-1",
+		Channel: "general",
+		Title:   "launch review",
+		Owner:   "ceo",
+		Status:  "in_progress",
+	}}
+
+	view := stripANSI(m.View())
+	if !strings.Contains(view, "Ctrl+J newline") || !strings.Contains(view, "Running tests") {
+		t.Fatalf("expected richer 1:1 status text, got %q", view)
+	}
+}
+
 func TestOneOnOneModeBlocksOfficeCommands(t *testing.T) {
 	m := newChannelModel(false)
 	m.sessionMode = team.SessionModeOneOnOne
@@ -891,6 +941,94 @@ func TestSlashAutocompleteShowsAllCommandsOnSlash(t *testing.T) {
 	if !strings.Contains(view, "/init") || !strings.Contains(view, "/tasks") {
 		t.Fatalf("expected command list in autocomplete, got %q", view)
 	}
+	if !strings.Contains(view, "setup") || !strings.Contains(view, "navigate") {
+		t.Fatalf("expected command categories in autocomplete, got %q", view)
+	}
+}
+
+func TestRefreshSlashCommandsPreservesAutocompleteQuery(t *testing.T) {
+	m := newChannelModel(false)
+	m.input = []rune("/")
+	m.inputPos = len(m.input)
+	m.updateInputOverlays()
+	m.skills = []channelSkill{{Name: "daily-digest", Description: "Run the digest", Status: "active"}}
+
+	m.refreshSlashCommands()
+
+	if !m.autocomplete.IsVisible() {
+		t.Fatal("expected slash autocomplete to remain visible")
+	}
+	view := stripANSI(m.autocomplete.View())
+	if !strings.Contains(view, "/integrate") || !strings.Contains(view, "/daily-digest") {
+		t.Fatalf("expected refreshed command list, got %q", view)
+	}
+}
+
+func TestCtrlJInsertsNewlineInComposer(t *testing.T) {
+	m := newChannelModel(false)
+	m.input = []rune("hello")
+	m.inputPos = len(m.input)
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlJ})
+	got := next.(channelModel)
+
+	if string(got.input) != "hello\n" {
+		t.Fatalf("expected newline in composer, got %q", string(got.input))
+	}
+}
+
+func TestCtrlJInsertsNewlineInThreadComposer(t *testing.T) {
+	m := newChannelModel(false)
+	m.threadPanelOpen = true
+	m.threadPanelID = "msg-1"
+	m.focus = focusThread
+	m.threadInput = []rune("hello")
+	m.threadInputPos = len(m.threadInput)
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyCtrlJ})
+	got := next.(channelModel)
+
+	if string(got.threadInput) != "hello\n" {
+		t.Fatalf("expected newline in thread composer, got %q", string(got.threadInput))
+	}
+}
+
+func TestDoctorCommandStartsReadinessCheck(t *testing.T) {
+	m := newChannelModel(false)
+
+	next, cmd := m.runCommand("/doctor", "")
+	if cmd == nil {
+		t.Fatal("expected /doctor to emit a follow-up command")
+	}
+	got := next.(channelModel)
+	if got.notice != "Checking readiness..." {
+		t.Fatalf("expected doctor notice, got %q", got.notice)
+	}
+}
+
+func TestChannelDoctorDoneShowsDoctorCard(t *testing.T) {
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 30
+
+	next, _ := m.Update(channelDoctorDoneMsg{report: channelDoctorReport{
+		GeneratedAt: time.Now(),
+		Checks: []doctorCheck{{
+			Label:    "Nex API key",
+			Severity: doctorWarn,
+			Detail:   "Missing WUPHF/Nex API key.",
+			NextStep: "Run /init and paste your WUPHF API key.",
+		}},
+	}})
+	got := next.(channelModel)
+
+	if got.doctor == nil {
+		t.Fatal("expected doctor report to be visible")
+	}
+	view := stripANSI(got.View())
+	if !strings.Contains(view, "Doctor") || !strings.Contains(view, "Nex API key") {
+		t.Fatalf("expected doctor card in view, got %q", view)
+	}
 }
 
 func TestSlashAutocompleteEnterSubmitsSelectedCommand(t *testing.T) {
@@ -1418,6 +1556,31 @@ func TestChannelErrorsSurfaceInNotice(t *testing.T) {
 	}
 }
 
+func TestChannelResetDoneImmediatelyRehydratesDirectMode(t *testing.T) {
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 30
+
+	next, _ := m.Update(channelResetDoneMsg{
+		notice:        "Direct 1:1 with Backend Engineer is ready.",
+		sessionMode:   team.SessionModeOneOnOne,
+		oneOnOneAgent: "be",
+	})
+	got := next.(channelModel)
+
+	if !got.isOneOnOne() {
+		t.Fatal("expected model to enter 1:1 mode immediately")
+	}
+
+	view := stripANSI(got.View())
+	if !strings.Contains(view, "Direct 1:1 with Backend Engineer.") {
+		t.Fatalf("expected direct-session empty state, got %q", view)
+	}
+	if strings.Contains(view, "Welcome to The WUPHF Office.") {
+		t.Fatalf("expected office welcome to disappear in direct mode, got %q", view)
+	}
+}
+
 func TestChannelViewShowsMessageIDInMeta(t *testing.T) {
 	m := newChannelModel(false)
 	m.width = 120
@@ -1620,5 +1783,7 @@ func TestMain(m *testing.M) {
 	// Use a temp home dir so tests don't read the real ~/.wuphf/config.json
 	tmp, _ := os.MkdirTemp("", "wuphf-test-*")
 	os.Setenv("HOME", tmp)
+	os.Setenv("WUPHF_API_KEY", "test-key")
+	os.Unsetenv("WUPHF_NO_NEX")
 	os.Exit(m.Run())
 }

--- a/docs/tui-gap-analysis-hermes-openclaw.md
+++ b/docs/tui-gap-analysis-hermes-openclaw.md
@@ -1,0 +1,296 @@
+# WUPHF TUI Gap Analysis vs Hermes Agent and OpenClaw
+
+## Context
+
+This analysis is grounded in the actual WUPHF repo at:
+
+- `/Users/najmuzzaman/Documents/nex/WUPHF`
+
+It replaces an earlier incorrect pass that was done in the wrong neighboring repo.
+
+External references:
+
+- Hermes Agent README: <https://github.com/NousResearch/hermes-agent>
+- OpenClaw README: <https://github.com/openclaw/openclaw>
+
+## Executive Summary
+
+WUPHF is not missing a TUI from scratch.
+
+It already has:
+
+- a real multi-pane office UI
+- `1:1` mode
+- slash-command autocomplete
+- task, request, policy, calendar, and skills surfaces
+- session and lifetime token/cost display
+- live activity hints from agent panes
+- Nex / integration setup and direct-mode switching
+
+So the right next step is not a large redesign.
+
+The real opportunity is to tighten three things:
+
+1. make active work more explicit in the main message surface
+2. add a clearer readiness / doctor experience
+3. make direct `1:1` execution feel more intentional and inspectable
+
+That aligns with the strongest relevant lessons from Hermes and OpenClaw without diluting WUPHF's office model.
+
+## What Hermes Actually Suggests
+
+From the public Hermes README, the parts most relevant to WUPHF are:
+
+- strong terminal interaction quality
+- multiline editing
+- slash-command autocomplete
+- interrupt / redirect behavior
+- streaming tool output
+- built-in setup and doctor flows
+- explicit scheduling and automation affordances
+
+What matters for WUPHF:
+
+- Hermes treats agent execution as something the human can follow in real time
+- Hermes treats setup and recovery as first-class product flows, not just docs
+
+What does **not** map directly:
+
+- Hermes is fundamentally a personal agent surface with broad platform reach
+- WUPHF is an office runtime with a visible team model and channel-based coordination
+
+So WUPHF should borrow:
+
+- execution visibility
+- setup ergonomics
+- command clarity
+
+It should not copy:
+
+- the single-assistant product framing
+- the remote / gateway-first mental model
+
+## What OpenClaw Actually Suggests
+
+From the public OpenClaw README, the most relevant lessons are:
+
+- onboarding is a product, not a README
+- `onboard` and `doctor` are explicit control points
+- operational readiness is surfaced clearly
+- the control plane is separate from the assistant experience
+
+What matters for WUPHF:
+
+- a new user should know what is missing and what to do next
+- risky or incomplete runtime setup should be legible from inside the app
+
+What does **not** map directly:
+
+- OpenClaw is a personal assistant and gateway product
+- WUPHF is an office TUI, not a personal messaging hub
+
+So WUPHF should borrow:
+
+- doctor/readiness concepts
+- guided setup quality
+- explicit runtime health reporting
+
+It should not copy:
+
+- the personal-assistant framing
+- the platform-messaging-heavy UX
+
+## What WUPHF Already Has
+
+Compared against the real WUPHF codebase, WUPHF already has far more than the wrong-pass analysis assumed.
+
+Current strengths in the actual repo:
+
+- `1:1` mode already exists via `--1o1` and `/1o1`
+- slash autocomplete already exists in both the office stream and the channel UI
+- message, task, request, policy, calendar, and skills views already exist
+- policy visibility is already present through signals, decisions, actions, and watchdogs
+- usage display already shows session and total cost/tokens
+- live activity is already tracked from teammate panes
+- the calendar is already more than a flat queue
+- integration commands already exist in the TUI
+
+This means the real gap is not “WUPHF lacks a modern agent TUI.”
+
+The real gap is that the product still sometimes feels:
+
+- harder to read than it should be
+- less explicit about current work than it should be
+- less guided during setup / integration-readiness problems than it should be
+
+## The Actual WUPHF Gaps
+
+### 1. Agent work is still too implicit
+
+WUPHF has message history and some activity hints, but active execution is not yet surfaced as a crisp first-class runtime story.
+
+Examples of missing clarity:
+
+- what an agent is doing right now
+- whether it is reading, thinking, executing, blocked, or reporting
+- which tool / integration / workflow it is currently touching
+- what changed in the last few seconds without reading the whole channel
+
+### 2. `1:1` mode needs stronger execution affordances
+
+WUPHF has direct mode, but it should feel more like a deliberate “agent console.”
+
+What is still missing:
+
+- a direct execution timeline
+- clearer step-by-step action progress
+- stronger separation between internal chatter and direct reporting
+- better reassurance that the selected agent is actively working
+
+### 3. Readiness/setup is still too distributed
+
+The pieces exist, but the product does not yet feel as guided as Hermes / OpenClaw.
+
+What is missing:
+
+- a compact doctor/readiness view in the office itself
+- clearer distinction between:
+  - Nex unavailable
+  - provider key missing
+  - connected account missing
+  - runtime unhealthy
+- next-step guidance written for non-technical users
+
+### 4. The command layer is functional, but not expressive enough
+
+Autocomplete exists, but it is still closer to a raw list than to a guided control layer.
+
+What is missing:
+
+- categories in slash autocomplete
+- better descriptions for commands
+- clearer mode-sensitive command sets
+- more instructional failure messages
+
+### 5. Status surfaces need better hierarchy
+
+WUPHF already exposes a lot of signal, but it is not always arranged in the most legible way.
+
+What is missing:
+
+- clearer pane headers
+- stronger status-bar summaries
+- better “what needs me?” prioritization
+- less reliance on reading dense message content for simple state questions
+
+## Recommended Direction
+
+Do **not** do a major UI rewrite.
+
+Do **not** try to make WUPHF feel like Hermes or OpenClaw.
+
+Do:
+
+- keep the office model
+- keep channels
+- keep the visible team
+- make agent execution and setup health much more legible
+
+In short:
+
+- Hermes should influence the execution UX
+- OpenClaw should influence onboarding and doctor UX
+- WUPHF should stay visibly and unmistakably an office
+
+## Implementation Priorities
+
+### Priority 1: Runtime visibility
+
+Add a normalized runtime status model for agents:
+
+- idle
+- reading
+- thinking
+- tool-running
+- blocked
+- waiting-human
+- reporting
+
+Surface that in:
+
+- roster
+- pane header
+- `1:1` header
+- message/event summaries
+
+### Priority 2: Direct execution timeline
+
+In `1:1`, add a compact execution strip / timeline for:
+
+- action search
+- schema lookup
+- dry-run
+- execute
+- workflow create
+- workflow schedule
+- trigger create / activate
+
+This should be rendered distinctly from chat content.
+
+### Priority 3: Doctor/readiness view
+
+Add `/doctor` or equivalent in the real WUPHF repo and make it show:
+
+- Nex status
+- action provider status
+- connected account status
+- tmux/runtime status
+- what is missing
+- exact next step
+
+### Priority 4: Better slash-command UX
+
+Upgrade autocomplete to include:
+
+- categories
+- clearer descriptions
+- mode-aware command lists
+
+### Priority 5: Status hierarchy cleanup
+
+Refine:
+
+- header copy
+- status bar
+- office summary lines
+
+Focus on:
+
+- what is happening
+- what is blocked
+- what needs the human
+
+## What To Avoid
+
+- do not replace the office with a single chat view
+- do not add visual noise just because Hermes is polished
+- do not add remote-session complexity as part of this pass
+- do not cargo-cult OpenClaw's gateway model into WUPHF
+
+## Proposed Next Pass
+
+Implement in this order:
+
+1. runtime status model + roster/pane display
+2. `1:1` execution timeline
+3. doctor/readiness panel
+4. slash autocomplete categories and descriptions
+5. header/status hierarchy cleanup
+
+## Local Note
+
+At the time of writing, the real WUPHF repo already has an unrelated local modification in:
+
+- `internal/team/launcher.go`
+
+That should be preserved and not overwritten by TUI work.

--- a/internal/tui/autocomplete.go
+++ b/internal/tui/autocomplete.go
@@ -7,11 +7,12 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-const maxAutocompleteMatches = 8
+const maxAutocompleteMatches = 24
 
 type SlashCommand struct {
 	Name        string
 	Description string
+	Category    string
 }
 
 type AutocompleteModel struct {
@@ -61,14 +62,22 @@ func (a AutocompleteModel) View() string {
 	desc := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(MutedColor)).
 		Padding(0, 1)
+	category := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#D6E4FF")).
+		Background(lipgloss.Color("#22324A")).
+		Padding(0, 1)
 
 	var rows []string
 	for i, cmd := range a.matches {
 		name := "/" + cmd.Name
+		entry := ""
+		if cmd.Category != "" {
+			entry = category.Render(cmd.Category) + " "
+		}
 		if i == a.selected {
-			rows = append(rows, highlighted.Render(name)+" "+desc.Render(cmd.Description))
+			rows = append(rows, entry+highlighted.Render(name)+" "+desc.Render(cmd.Description))
 		} else {
-			rows = append(rows, normal.Render(name)+" "+desc.Render(cmd.Description))
+			rows = append(rows, entry+normal.Render(name)+" "+desc.Render(cmd.Description))
 		}
 	}
 

--- a/internal/tui/autocomplete_test.go
+++ b/internal/tui/autocomplete_test.go
@@ -1,16 +1,17 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 var testCommands = []SlashCommand{
-	{Name: "help", Description: "Show help"},
-	{Name: "history", Description: "Show history"},
-	{Name: "agents", Description: "List agents"},
-	{Name: "clear", Description: "Clear screen"},
+	{Name: "help", Description: "Show help", Category: "general"},
+	{Name: "history", Description: "Show history", Category: "general"},
+	{Name: "agents", Description: "List agents", Category: "team"},
+	{Name: "clear", Description: "Clear screen", Category: "general"},
 }
 
 func TestAutocompleteFilter(t *testing.T) {
@@ -96,5 +97,18 @@ func TestAutocompleteMaxMatches(t *testing.T) {
 
 	if len(ac.matches) > maxAutocompleteMatches {
 		t.Fatalf("expected at most %d matches, got %d", maxAutocompleteMatches, len(ac.matches))
+	}
+}
+
+func TestAutocompleteViewShowsCategoryLabels(t *testing.T) {
+	ac := NewAutocomplete(testCommands)
+	ac.UpdateQuery("/")
+
+	view := ac.View()
+	if view == "" {
+		t.Fatal("expected autocomplete view to render")
+	}
+	if !strings.Contains(view, "general") || !strings.Contains(view, "team") {
+		t.Fatalf("expected category labels in autocomplete view, got %q", view)
 	}
 }

--- a/tests/uat/one-on-one-channel-e2e.sh
+++ b/tests/uat/one-on-one-channel-e2e.sh
@@ -195,7 +195,7 @@ send_ctrl_u
 send_raw "/channels"
 send_enter
 sleep 2
-assert_screen_contains "1:1 mode disables office, channel, agent, task, and thread commands." "phase1-blocked"
+assert_screen_contains "1:1 mode disables office collaboration commands." "phase1-blocked"
 send_ctrl_u
 
 echo "--- Phase 2: Invalid agent falls back to CEO ---"
@@ -236,7 +236,7 @@ send_enter
 wait_for_health "1o1" "pm" "phase4-health"
 wait_for_pane_count 2 "phase4-panes"
 assert_screen_contains "1:1 with Product Manager" "phase4-screen"
-assert_screen_contains "Direct session reset. Agent pane reloaded in place." "phase4-screen"
+assert_screen_contains "Direct 1:1 with Product Manager." "phase4-screen"
 
 echo "--- Phase 5: Disable 1:1 mode from the picker ---"
 send_raw "/1o1"


### PR DESCRIPTION
## Summary
- add clearer runtime visibility for office and 1:1 sessions
- add a doctor/readiness panel and richer slash command UX
- cache main-panel, sidebar, and markdown rendering to reduce redraw cost

## Testing
- go test ./internal/team ./cmd/wuphf ./internal/tui
- bash tests/uat/office-channel-e2e.sh
- bash tests/uat/one-on-one-channel-e2e.sh