### PR TITLE
feat: add @all to tag every agent in the channel

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -3707,6 +3707,7 @@ func postToChannel(text string, replyTo string, channel string) tea.Cmd {
 
 func channelMentionAgents(members []channelMember) []tui.AgentMention {
 	defaults := []tui.AgentMention{
+		{Slug: "all", Name: "All agents"},
 		{Slug: "ceo", Name: "CEO"},
 		{Slug: "pm", Name: "Product Manager"},
 		{Slug: "fe", Name: "Frontend Engineer"},

--- a/cmd/wuphf/channel_styles.go
+++ b/cmd/wuphf/channel_styles.go
@@ -25,6 +25,7 @@ const (
 
 // agentColorMap maps agent slugs to their brand colors.
 var agentColorMap = map[string]string{
+	"all":      "#FFFFFF",
 	"ceo":      "#EAB308",
 	"pm":       "#22C55E",
 	"fe":       "#3B82F6",

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -773,6 +773,17 @@ func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate 
 
 	switch {
 	case msg.From == "you" || msg.From == "human" || msg.Kind == "automation" || msg.From == "nex":
+		// @all: notify every agent immediately, including lead.
+		if containsSlug(msg.Tagged, "all") {
+			addImmediate(lead)
+			for _, slug := range slugs {
+				if slug == lead || slug == msg.From {
+					continue
+				}
+				addImmediate(slug)
+			}
+			break
+		}
 		// Direct routing: if user tags specific agents, route to them directly
 		// without CEO bottleneck. CEO only gets untagged or multi-tagged messages.
 		directRouted := false


### PR DESCRIPTION
## Summary
- `@all` appears first in the `@` mention autocomplete popup
- Highlights in white bold in the message feed
- Notification routing sends to every agent immediately, bypassing CEO-first triage

## Changes
- `channel.go`: added `{Slug: "all", Name: "All agents"}` to mention list
- `channel_styles.go`: added `"all": "#FFFFFF"` to color map
- `launcher.go`: explicit `@all` handling in `notificationTargetsForMessage` — adds all agents as immediate targets

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>