### PR TITLE
feat: broadcast all messages to every agent, CEO gets head start

### DIFF
--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -17,18 +17,15 @@ func BuildTeamLeadPrompt(lead AgentConfig, team []AgentConfig, packName string) 
 
 	return fmt.Sprintf(`You are the %s of the %s. Your team consists of:
 %s
-Messages prefixed [TEAM @slug] are from teammates. They can see everything you say. Make final decisions but listen first.
+Messages prefixed [TEAM @slug] are from teammates. Everyone sees every message — you do NOT need to forward, delegate, or re-send messages to specialists. They already have the message.
 
 Rules:
-1. For any request that spans multiple domains or would benefit from specialists, you MUST delegate using only the roster agents above by their exact @slug.
-2. Never invent external teammates, titles, or names that are not in the roster above.
-3. Never claim specialist work is already complete unless that specialist has already replied in this session or you used tools yourself.
-4. Keep your response extremely short. Do not use headings, bullets, markdown, JSON, YAML, metadata, or long explanations.
-5. For multi-domain work, use this exact format:
-   One short coordination sentence.
-   @slug task
-   @slug task
-6. If the request is truly single-domain and does not need delegation, answer in one or two short sentences without pretending delegated work happened.
+1. You see the same messages as everyone else. Do NOT duplicate or relay what the human said. Your teammates already received it.
+2. Your role is to coordinate, make final decisions, and contribute your own expertise. You are a participant, not a router.
+3. If you want a specific teammate to focus on something, tag them with a short direction: "@fe focus on the header layout". But do NOT repeat the human's full message.
+4. Never invent external teammates, titles, or names that are not in the roster above.
+5. Never claim specialist work is already complete unless that specialist has already replied in this session or you used tools yourself.
+6. Keep your response extremely short. Do not use headings, bullets, markdown, JSON, YAML, metadata, or long explanations.
 7. If you mention any teammate without an @slug from the roster above, your response is invalid.
 
 SKILL DETECTION:

--- a/internal/agent/prompts_test.go
+++ b/internal/agent/prompts_test.go
@@ -18,8 +18,8 @@ func TestBuildTeamLeadPrompt(t *testing.T) {
 	if !strings.Contains(prompt, "@be") {
 		t.Error("expected prompt to contain @be")
 	}
-	if !strings.Contains(prompt, "delegate") || !strings.Contains(prompt, "MUST delegate") {
-		t.Error("expected delegation instructions in prompt")
+	if !strings.Contains(prompt, "do NOT need to forward") {
+		t.Error("expected broadcast instructions in prompt")
 	}
 	if !strings.Contains(prompt, "Never invent external teammates") {
 		t.Error("expected prompt to forbid invented teammates")

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -459,23 +459,6 @@ func (l *Launcher) deliverMessageNotification(msg channelMessage) {
 	}
 	immediate = filtered
 
-	// Broadcast stage update only for untagged messages in team mode
-	// (tagged messages go directly to the agent — user already knows who's handling it)
-	if l.broker != nil && len(immediate) > 0 && (msg.From == "you" || msg.From == "human") && !l.isOneOnOne() && len(msg.Tagged) == 0 {
-		names := make([]string, 0, len(immediate))
-		for _, t := range immediate {
-			names = append(names, "@"+t.Slug)
-		}
-		channel := msg.Channel
-		if channel == "" {
-			channel = "general"
-		}
-		l.broker.PostSystemMessage(channel,
-			fmt.Sprintf("Routing to %s...", strings.Join(names, ", ")),
-			"routing",
-		)
-	}
-
 	for _, target := range immediate {
 		l.sendChannelUpdate(target.PaneTarget, target.Slug, msg.Channel, msg.ID, msg.From, msg.Content)
 	}
@@ -704,11 +687,6 @@ func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate 
 		return []notificationTarget{target}, nil
 	}
 	lead := l.officeLeadSlug()
-	domain := inferMessageDomain(msg)
-	owner := ""
-	if l.broker != nil {
-		owner = l.taskOwnerForDomain(msg.Channel, domain)
-	}
 	enabledMembers := map[string]struct{}{}
 	if l.broker != nil {
 		for _, member := range l.broker.EnabledMembers(msg.Channel) {
@@ -716,7 +694,7 @@ func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate 
 		}
 	}
 
-	addImmediate := func(slug string) {
+	addTarget := func(slug string, list *[]notificationTarget) {
 		if slug == "" || slug == msg.From {
 			return
 		}
@@ -726,128 +704,20 @@ func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate 
 			}
 		}
 		if target, ok := targetMap[slug]; ok {
-			immediate = append(immediate, target)
+			*list = append(*list, target)
 			delete(targetMap, slug)
 		}
-	}
-	addDelayed := func(slug string) {
-		if slug == "" || slug == msg.From {
-			return
-		}
-		if len(enabledMembers) > 0 {
-			if _, ok := enabledMembers[slug]; !ok {
-				return
-			}
-		}
-		if target, ok := targetMap[slug]; ok {
-			delayed = append(delayed, target)
-			delete(targetMap, slug)
-		}
-	}
-	allowTarget := func(slug string) bool {
-		if slug == "" || slug == msg.From {
-			return false
-		}
-		if len(enabledMembers) > 0 {
-			if _, ok := enabledMembers[slug]; !ok {
-				return false
-			}
-		}
-		if slug == lead {
-			return true
-		}
-		if owner != "" && slug != owner {
-			return false
-		}
-		if containsSlug(msg.Tagged, slug) {
-			if domain == "" || domain == "general" {
-				return true
-			}
-			return inferAgentDomain(slug) == domain
-		}
-		if domain == "" || domain == "general" {
-			return false
-		}
-		return inferAgentDomain(slug) == domain
 	}
 
-	switch {
-	case msg.From == "you" || msg.From == "human" || msg.Kind == "automation" || msg.From == "nex":
-		// @all: notify every agent immediately, including lead.
-		if containsSlug(msg.Tagged, "all") {
-			addImmediate(lead)
-			for _, slug := range slugs {
-				if slug == lead || slug == msg.From {
-					continue
-				}
-				addImmediate(slug)
-			}
-			break
+	// Broadcast model: every message goes to every agent.
+	// CEO gets a small head start (immediate), everyone else is delayed.
+	// The sender is always excluded.
+	addTarget(lead, &immediate)
+	for _, slug := range slugs {
+		if slug == lead {
+			continue
 		}
-		// Direct routing: if user tags specific agents, route to them directly
-		// without CEO bottleneck. CEO only gets untagged or multi-tagged messages.
-		directRouted := false
-		if len(msg.Tagged) > 0 && !containsSlug(msg.Tagged, lead) {
-			for _, slug := range slugs {
-				if slug == lead || slug == msg.From {
-					continue
-				}
-				if containsSlug(msg.Tagged, slug) {
-					if allowTarget(slug) {
-						addImmediate(slug)
-						directRouted = true
-					}
-				}
-			}
-		}
-		if !directRouted {
-			addImmediate(lead)
-		}
-		for _, slug := range slugs {
-			if slug == lead || slug == msg.From {
-				continue
-			}
-			if containsSlug(msg.Tagged, slug) && !directRouted {
-				if allowTarget(slug) {
-					addDelayed(slug)
-				}
-			}
-		}
-	case msg.From == lead:
-		for _, slug := range slugs {
-			if slug == lead || slug == msg.From {
-				continue
-			}
-			if containsSlug(msg.Tagged, slug) || (domain != "" && domain != "general" && inferAgentDomain(slug) == domain) {
-				if allowTarget(slug) {
-					addImmediate(slug)
-				}
-			}
-		}
-	case containsSlug(msg.Tagged, lead):
-		addImmediate(lead)
-		for _, slug := range slugs {
-			if slug == lead || slug == msg.From {
-				continue
-			}
-			if containsSlug(msg.Tagged, slug) || (domain != "" && domain != "general" && inferAgentDomain(slug) == domain) {
-				if allowTarget(slug) {
-					addImmediate(slug)
-				}
-			}
-		}
-	default:
-		addImmediate(lead)
-		for _, slug := range slugs {
-			if slug == lead || slug == msg.From {
-				continue
-			}
-			if containsSlug(msg.Tagged, slug) || (domain != "" && domain != "general" && inferAgentDomain(slug) == domain) {
-				if allowTarget(slug) {
-					addImmediate(slug)
-				}
-			}
-		}
+		addTarget(slug, &delayed)
 	}
 	return immediate, delayed
 }
@@ -856,55 +726,28 @@ func (l *Launcher) shouldDeliverDelayedNotification(targetSlug string, source ch
 	if l.broker == nil {
 		return true
 	}
+	// Only gate: the agent must be an enabled member of the channel.
 	if !containsSlug(l.broker.EnabledMembers(source.Channel), targetSlug) {
 		return false
 	}
-	domain := inferMessageDomain(source)
-	if owner := l.taskOwnerForDomain(source.Channel, domain); owner != "" && owner != targetSlug && targetSlug != l.officeLeadSlug() {
-		return false
-	}
-	if domain != "" && domain != "general" && targetSlug != l.officeLeadSlug() && inferAgentDomain(targetSlug) != domain {
-		return false
-	}
-
+	// If the agent already replied in the same thread since this message,
+	// skip the notification — they're already engaged.
 	threadRoot := source.ID
 	if source.ReplyTo != "" {
 		threadRoot = source.ReplyTo
 	}
-	sourceIndex := -1
 	messages := l.broker.ChannelMessages(source.Channel)
-	for i := range messages {
-		if messages[i].ID == source.ID {
-			sourceIndex = i
-			break
-		}
-	}
-	if sourceIndex >= 0 {
-		for _, msg := range messages[sourceIndex+1:] {
-			sameThread := msg.ID == threadRoot || msg.ReplyTo == threadRoot || msg.ReplyTo == source.ID
-			if !sameThread {
-				continue
-			}
-			if msg.From == targetSlug {
-				return false
-			}
-			if msg.From == l.officeLeadSlug() && !containsSlug(msg.Tagged, targetSlug) {
-				return false
-			}
-			if msg.From != "you" && msg.From != "human" && msg.From != "nex" && msg.Kind != "automation" && !containsSlug(msg.Tagged, targetSlug) {
-				return false
-			}
-		}
-	}
-
-	for _, task := range l.broker.ChannelTasks(source.Channel) {
-		if task.Status == "done" {
+	past := false
+	for _, msg := range messages {
+		if msg.ID == source.ID {
+			past = true
 			continue
 		}
-		if task.ThreadID != "" && task.ThreadID != source.ID && task.ThreadID != threadRoot {
+		if !past {
 			continue
 		}
-		if task.Owner != "" && task.Owner != targetSlug && targetSlug != l.officeLeadSlug() {
+		sameThread := msg.ID == threadRoot || msg.ReplyTo == threadRoot || msg.ReplyTo == source.ID
+		if sameThread && msg.From == targetSlug {
 			return false
 		}
 	}

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -384,7 +384,7 @@ func TestPrimeVisibleAgentsWithoutBrokerDoesNotPanic(t *testing.T) {
 	l.primeVisibleAgents()
 }
 
-func TestNotificationTargetsForHumanMessageGiveCEOHeadStart(t *testing.T) {
+func TestNotificationTargetsForHumanMessageBroadcastAll(t *testing.T) {
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -397,15 +397,26 @@ func TestNotificationTargetsForHumanMessageGiveCEOHeadStart(t *testing.T) {
 		},
 	}
 
-	immediate, _ := l.notificationTargetsForMessage(channelMessage{
+	immediate, delayed := l.notificationTargetsForMessage(channelMessage{
 		From:    "you",
 		Content: "Build the landing page",
 		Tagged:  []string{"fe", "be"},
 	})
 
-	// Direct routing: tagged agents go immediate, CEO skipped
-	if len(immediate) != 2 {
-		t.Fatalf("expected 2 immediate targets (fe, be), got %+v", immediate)
+	// Broadcast model: CEO immediate, everyone else delayed
+	if len(immediate) != 1 || immediate[0].Slug != "ceo" {
+		t.Fatalf("expected CEO as only immediate target, got %+v", immediate)
+	}
+	if len(delayed) == 0 {
+		t.Fatal("expected delayed targets for other agents, got none")
+	}
+	// Verify fe and be are in delayed targets
+	slugs := make(map[string]bool)
+	for _, d := range delayed {
+		slugs[d.Slug] = true
+	}
+	if !slugs["fe"] || !slugs["be"] {
+		t.Fatalf("expected fe and be in delayed targets, got %+v", delayed)
 	}
 }
 
@@ -434,7 +445,7 @@ func TestNotificationTargetsPreferMatchingDomainOverWrongTags(t *testing.T) {
 	
 }
 
-func TestNotificationTargetsForCEOMessageNotifyTaggedOnly(t *testing.T) {
+func TestNotificationTargetsForCEOMessageBroadcastsToAll(t *testing.T) {
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -447,19 +458,30 @@ func TestNotificationTargetsForCEOMessageNotifyTaggedOnly(t *testing.T) {
 		},
 	}
 
-	immediate, _ := l.notificationTargetsForMessage(channelMessage{
+	// CEO sends a message — everyone else gets it (CEO excluded as sender)
+	immediate, delayed := l.notificationTargetsForMessage(channelMessage{
 		From:    "ceo",
 		Content: "Frontend take this",
 		Tagged:  []string{"fe"},
 	})
 
-	// delayed targets not checked — direct routing may vary
-	if len(immediate) != 1 || immediate[0].Slug != "fe" {
-		t.Fatalf("expected only FE immediate target, got %+v", immediate)
+	// No immediate (CEO is lead but also sender), all others delayed
+	if len(immediate) != 0 {
+		t.Fatalf("expected no immediate targets (CEO is sender), got %+v", immediate)
+	}
+	if len(delayed) == 0 {
+		t.Fatal("expected delayed targets for other agents, got none")
+	}
+	slugs := make(map[string]bool)
+	for _, d := range delayed {
+		slugs[d.Slug] = true
+	}
+	if !slugs["fe"] || !slugs["be"] || !slugs["cmo"] {
+		t.Fatalf("expected fe, be, cmo in delayed targets, got %+v", delayed)
 	}
 }
 
-func TestShouldDeliverDelayedNotificationSkipsAfterCEOAlreadyAnswered(t *testing.T) {
+func TestShouldDeliverDelayedNotificationSkipsIfAgentAlreadyReplied(t *testing.T) {
 	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
 	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
@@ -470,8 +492,9 @@ func TestShouldDeliverDelayedNotificationSkipsAfterCEOAlreadyAnswered(t *testing
 	if err != nil {
 		t.Fatalf("post human message: %v", err)
 	}
-	if _, err := b.PostMessage("ceo", "general", "I have this. PM and CMO first.", []string{"pm", "cmo"}, msg1.ID); err != nil {
-		t.Fatalf("post ceo message: %v", err)
+	// FE already replied in the same thread
+	if _, err := b.PostMessage("fe", "general", "On it!", nil, msg1.ID); err != nil {
+		t.Fatalf("post fe message: %v", err)
 	}
 
 	l := &Launcher{
@@ -481,35 +504,21 @@ func TestShouldDeliverDelayedNotificationSkipsAfterCEOAlreadyAnswered(t *testing
 			Agents: []agent.AgentConfig{
 				{Slug: "ceo", Name: "CEO"},
 				{Slug: "fe", Name: "Frontend Engineer"},
-				{Slug: "pm", Name: "Product Manager"},
-				{Slug: "cmo", Name: "CMO"},
 			},
 		},
 	}
 	if l.shouldDeliverDelayedNotification("fe", msg1) {
-		t.Fatal("expected FE delayed notification to be skipped after CEO answered without FE tag")
+		t.Fatal("expected FE delayed notification to be skipped — FE already replied")
 	}
 }
 
-func TestShouldDeliverDelayedNotificationSkipsWrongDomainAndTaskOwnerConflict(t *testing.T) {
+func TestShouldDeliverDelayedNotificationAllowsAllEnabledMembers(t *testing.T) {
 	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
 	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
 	defer func() { brokerStatePath = oldPathFn }()
 
 	b := NewBroker()
-	task, _, err := b.EnsureTask("general", "Positioning work", "Marketing follow-up", "cmo", "ceo", "")
-	if err != nil {
-		t.Fatalf("create task: %v", err)
-	}
-	b.mu.Lock()
-	if ch := b.findChannelLocked("general"); ch != nil && !containsString(ch.Members, "cmo") {
-		ch.Members = append(ch.Members, "cmo")
-	}
-	b.mu.Unlock()
-	if task.Owner != "cmo" {
-		t.Fatalf("expected task owner cmo, got %+v", task)
-	}
 
 	l := &Launcher{
 		broker: b,
@@ -522,12 +531,13 @@ func TestShouldDeliverDelayedNotificationSkipsWrongDomainAndTaskOwnerConflict(t 
 			},
 		},
 	}
-	msg := channelMessage{From: "you", Channel: "general", Content: "We need a positioning shift and launch campaign.", ID: "msg-1"}
-	if l.shouldDeliverDelayedNotification("fe", msg) {
-		t.Fatal("expected FE delayed notification to be skipped for marketing work owned by CMO")
+	msg := channelMessage{From: "you", Channel: "general", Content: "We need a positioning shift.", ID: "msg-1"}
+	// All enabled members should receive the delayed notification
+	if !l.shouldDeliverDelayedNotification("fe", msg) {
+		t.Fatal("expected FE delayed notification to be allowed")
 	}
 	if !l.shouldDeliverDelayedNotification("cmo", msg) {
-		t.Fatal("expected CMO delayed notification to be allowed for matching domain owner")
+		t.Fatal("expected CMO delayed notification to be allowed")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Every message now goes to **all agents** — CEO immediate, everyone else with 2s delay
- CEO no longer acts as a router/delegator — agents see messages directly
- Routing system messages removed (no "→ routing to @ceo..." spam)
- CEO prompt updated: participant + coordinator, not a message forwarder
- Net -150 lines — massive simplification of notification routing

## What changes for the user
- Say anything in #general → every agent sees it and can respond
- No more "only CEO responds" for untagged messages
- CEO still gets a head start to coordinate, but doesn't gate other agents

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>