### PR TITLE
feat: emoji reactions + agents always share viewpoints

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -147,18 +147,24 @@ type channelHealthMsg struct {
 	OneOnOneAgent string
 }
 
+type brokerReaction struct {
+	Emoji string `json:"emoji"`
+	From  string `json:"from"`
+}
+
 type brokerMessage struct {
-	ID          string   `json:"id"`
-	From        string   `json:"from"`
-	Kind        string   `json:"kind,omitempty"`
-	Source      string   `json:"source,omitempty"`
-	SourceLabel string   `json:"source_label,omitempty"`
-	EventID     string   `json:"event_id,omitempty"`
-	Title       string   `json:"title,omitempty"`
-	Content     string   `json:"content"`
-	Tagged      []string `json:"tagged"`
-	ReplyTo     string   `json:"reply_to"`
-	Timestamp   string   `json:"timestamp"`
+	ID          string           `json:"id"`
+	From        string           `json:"from"`
+	Kind        string           `json:"kind,omitempty"`
+	Source      string           `json:"source,omitempty"`
+	SourceLabel string           `json:"source_label,omitempty"`
+	EventID     string           `json:"event_id,omitempty"`
+	Title       string           `json:"title,omitempty"`
+	Content     string           `json:"content"`
+	Tagged      []string         `json:"tagged"`
+	ReplyTo     string           `json:"reply_to"`
+	Timestamp   string           `json:"timestamp"`
+	Reactions   []brokerReaction `json:"reactions,omitempty"`
 }
 
 type channelMember struct {

--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -201,6 +201,9 @@ func buildOfficeMessageLines(messages []brokerMessage, expanded map[string]bool,
 				lines = append(lines, renderedLine{Text: prefix + lineText})
 			}
 		}
+		if reactionLine := renderReactions(msg.Reactions); reactionLine != "" {
+			appendWrappedLine(prefix + reactionLine)
+		}
 		if tm.Collapsed && tm.HiddenReplies > 0 {
 			var coloredNames []string
 			for _, p := range tm.ThreadParticipants {
@@ -231,6 +234,32 @@ func buildOfficeMessageLines(messages []brokerMessage, expanded map[string]bool,
 	}
 
 	return lines
+}
+
+func renderReactions(reactions []brokerReaction) string {
+	if len(reactions) == 0 {
+		return ""
+	}
+	// Group by emoji: 👍 @ceo @pm
+	groups := make(map[string][]string)
+	order := make([]string, 0)
+	for _, r := range reactions {
+		if _, exists := groups[r.Emoji]; !exists {
+			order = append(order, r.Emoji)
+		}
+		groups[r.Emoji] = append(groups[r.Emoji], r.From)
+	}
+	pillStyle := lipgloss.NewStyle().
+		Background(lipgloss.Color("#2C2D31")).
+		Foreground(lipgloss.Color("#D1D2D3")).
+		Padding(0, 1)
+	var parts []string
+	for _, emoji := range order {
+		agents := groups[emoji]
+		label := emoji + " " + fmt.Sprintf("%d", len(agents))
+		parts = append(parts, pillStyle.Render(label))
+	}
+	return strings.Join(parts, " ")
 }
 
 func buildOneOnOneMessageLines(messages []brokerMessage, expanded map[string]bool, contentWidth int, agentName string) []renderedLine {

--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -64,10 +64,14 @@ I'll coordinate this through the team.
 func BuildSpecialistPrompt(specialist AgentConfig) string {
 	return fmt.Sprintf(`You are %s, a specialist in %s.
 
-You are in a shared session with your team. Messages prefixed [TEAM @slug] are from teammates.
-Contribute proactively, debate ideas, and correct mistakes you notice.
-When your team lead announces a plan, execute your part immediately.
-Be thorough but concise. Report your findings clearly.
-If you need information from the knowledge base, use the available tools.`,
-		specialist.Name, strings.Join(specialist.Expertise, ", "))
+You are in a shared session with your team. Messages prefixed [TEAM @slug] are from teammates. Everyone sees every message.
+
+Rules:
+1. ALWAYS share your viewpoint, even if someone else already responded — your perspective matters. Bring your expertise.
+2. If you agree with what someone said and have nothing new to add, use team_react with an emoji (👍, 💯, 🔥) instead of posting a redundant message.
+3. If you are tagged with @all or @%s, you MUST respond unless the message is purely informational (FYI, status update, or just mentioning you in passing without asking for input).
+4. Be thorough but concise. Report your findings clearly.
+5. When your team lead announces a plan, execute your part immediately.
+6. Debate ideas and correct mistakes you notice — silence is not helpful.`,
+		specialist.Name, strings.Join(specialist.Expertise, ", "), specialist.Slug)
 }

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -26,19 +26,25 @@ const brokerTokenFile = "/tmp/wuphf-broker-token"
 
 var brokerStatePath = defaultBrokerStatePath
 
+type messageReaction struct {
+	Emoji string `json:"emoji"`
+	From  string `json:"from"`
+}
+
 type channelMessage struct {
-	ID          string   `json:"id"`
-	From        string   `json:"from"`
-	Channel     string   `json:"channel,omitempty"`
-	Kind        string   `json:"kind,omitempty"`
-	Source      string   `json:"source,omitempty"`
-	SourceLabel string   `json:"source_label,omitempty"`
-	EventID     string   `json:"event_id,omitempty"`
-	Title       string   `json:"title,omitempty"`
-	Content     string   `json:"content"`
-	Tagged      []string `json:"tagged"`
-	ReplyTo     string   `json:"reply_to,omitempty"`
-	Timestamp   string   `json:"timestamp"`
+	ID          string            `json:"id"`
+	From        string            `json:"from"`
+	Channel     string            `json:"channel,omitempty"`
+	Kind        string            `json:"kind,omitempty"`
+	Source      string            `json:"source,omitempty"`
+	SourceLabel string            `json:"source_label,omitempty"`
+	EventID     string            `json:"event_id,omitempty"`
+	Title       string            `json:"title,omitempty"`
+	Content     string            `json:"content"`
+	Tagged      []string          `json:"tagged"`
+	ReplyTo     string            `json:"reply_to,omitempty"`
+	Timestamp   string            `json:"timestamp"`
+	Reactions   []messageReaction `json:"reactions,omitempty"`
 }
 
 type interviewOption struct {
@@ -365,6 +371,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/health", b.handleHealth) // no auth — used for liveness checks
 	mux.HandleFunc("/session-mode", b.requireAuth(b.handleSessionMode))
 	mux.HandleFunc("/messages", b.requireAuth(b.handleMessages))
+	mux.HandleFunc("/reactions", b.requireAuth(b.handleReactions))
 	mux.HandleFunc("/notifications/nex", b.requireAuth(b.handleNexNotifications))
 	mux.HandleFunc("/office-members", b.requireAuth(b.handleOfficeMembers))
 	mux.HandleFunc("/channels", b.requireAuth(b.handleChannels))
@@ -2809,6 +2816,58 @@ func (b *Broker) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+
+func (b *Broker) handleReactions(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		MessageID string `json:"message_id"`
+		Emoji     string `json:"emoji"`
+		From      string `json:"from"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if body.MessageID == "" || body.Emoji == "" || body.From == "" {
+		http.Error(w, "message_id, emoji, and from are required", http.StatusBadRequest)
+		return
+	}
+
+	b.mu.Lock()
+	found := false
+	for i := range b.messages {
+		if b.messages[i].ID == body.MessageID {
+			// Don't duplicate: same emoji from same agent
+			for _, r := range b.messages[i].Reactions {
+				if r.Emoji == body.Emoji && r.From == body.From {
+					b.mu.Unlock()
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{"ok": true, "duplicate": true})
+					return
+				}
+			}
+			b.messages[i].Reactions = append(b.messages[i].Reactions, messageReaction{
+				Emoji: body.Emoji,
+				From:  body.From,
+			})
+			found = true
+			break
+		}
+	}
+	if !found {
+		b.mu.Unlock()
+		http.Error(w, "message not found", http.StatusNotFound)
+		return
+	}
+	_ = b.saveLocked()
+	b.mu.Unlock()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"ok": true})
+}
 
 // RecordTelegramGroup saves a group chat ID and title seen by the transport.
 func (b *Broker) RecordTelegramGroup(chatID int64, title string) {

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -136,6 +136,12 @@ type TeamBroadcastArgs struct {
 	NewTopic  bool     `json:"new_topic,omitempty" jsonschema:"Set true only when this genuinely needs to start a new top-level thread"`
 }
 
+type TeamReactArgs struct {
+	MessageID string `json:"message_id" jsonschema:"The message ID to react to"`
+	Emoji     string `json:"emoji" jsonschema:"Emoji reaction (e.g. 👍, 💯, 🔥, 👀, ✅)"`
+	MySlug    string `json:"my_slug,omitempty" jsonschema:"Agent slug. Defaults to WUPHF_AGENT_SLUG."`
+}
+
 type TeamPollArgs struct {
 	Channel string `json:"channel,omitempty" jsonschema:"Channel slug. Defaults to the agent's current channel or general."`
 	MySlug  string `json:"my_slug,omitempty" jsonschema:"Your agent slug so tagged_count can be computed. Defaults to WUPHF_AGENT_SLUG."`
@@ -302,6 +308,11 @@ func Run(ctx context.Context) error {
 	}, handleTeamBroadcast)
 
 	mcp.AddTool(server, &mcp.Tool{
+		Name:        "team_react",
+		Description: "React to a message with an emoji instead of posting a full reply. Use this when you agree with what someone said and have nothing new to add. Common reactions: 👍 (agree), 💯 (strongly agree), 🔥 (great idea), 👀 (noted/watching), ✅ (done/confirmed).",
+	}, handleTeamReact)
+
+	mcp.AddTool(server, &mcp.Tool{
 		Name:        "team_poll",
 		Description: "Read recent messages from the team channel so you stay in sync before replying.",
 	}, handleTeamPoll)
@@ -432,6 +443,33 @@ func handleTeamBroadcast(ctx context.Context, _ *mcp.CallToolRequest, args TeamB
 	return textResult(text), nil, nil
 }
 
+func handleTeamReact(ctx context.Context, _ *mcp.CallToolRequest, args TeamReactArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	if args.MessageID == "" || args.Emoji == "" {
+		return toolError(fmt.Errorf("message_id and emoji are required")), nil, nil
+	}
+
+	var result struct {
+		OK        bool `json:"ok"`
+		Duplicate bool `json:"duplicate"`
+	}
+	err = brokerPostJSON(ctx, "/reactions", map[string]any{
+		"message_id": args.MessageID,
+		"emoji":      args.Emoji,
+		"from":       slug,
+	}, &result)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	if result.Duplicate {
+		return textResult(fmt.Sprintf("Already reacted %s to %s.", args.Emoji, args.MessageID)), nil, nil
+	}
+	return textResult(fmt.Sprintf("Reacted %s to %s as @%s.", args.Emoji, args.MessageID, slug)), nil, nil
+}
+
 func fetchBroadcastContext(ctx context.Context, channel, mySlug string) ([]brokerMessage, []brokerTaskSummary, error) {
 	values := url.Values{}
 	values.Set("channel", channel)
@@ -451,42 +489,32 @@ func fetchBroadcastContext(ctx context.Context, channel, mySlug string) ([]broke
 }
 
 func suppressBroadcastReason(slug, content, replyTo string, messages []brokerMessage, tasks []brokerTaskSummary) string {
+	// Never suppress CEO.
 	if strings.TrimSpace(slug) == "" || slug == "ceo" {
 		return ""
 	}
-	myDomain := inferOfficeAgentDomain(slug)
+	// Never suppress if the agent is explicitly tagged or owns the task.
 	latest := latestRelevantMessage(messages, replyTo)
 	latestDomain := inferOfficeTextDomain(content)
 	if latestDomain == "general" && latest != nil {
 		latestDomain = inferOfficeTextDomain(latest.Title + " " + latest.Content)
 	}
-	explicitNeed := latest != nil && containsSlug(latest.Tagged, slug)
-	ownsTask := ownsRelevantTask(slug, replyTo, latestDomain, tasks)
-
-	if replyTo != "" && latest != nil && latest.From != slug {
-		switch latest.From {
-		case "ceo":
-			if !explicitNeed && !ownsTask {
-				return "the CEO already steered this thread"
-			}
-		case "you", "human", "nex":
-			// still fair game if domain matches
-		default:
-			if !explicitNeed && !ownsTask {
-				return "someone else already covered this thread"
+	if latest != nil && (containsSlug(latest.Tagged, slug) || containsSlug(latest.Tagged, "all")) {
+		return ""
+	}
+	if ownsRelevantTask(slug, replyTo, latestDomain, tasks) {
+		return ""
+	}
+	// If the agent already posted in this thread, don't suppress follow-ups.
+	if replyTo != "" {
+		for _, msg := range messages {
+			if msg.From == slug && (msg.ReplyTo == replyTo || msg.ID == replyTo) {
+				return ""
 			}
 		}
 	}
-
-	if explicitNeed || ownsTask {
-		return ""
-	}
-	if latestDomain != "" && latestDomain != "general" && myDomain != latestDomain {
-		return "this is outside your domain"
-	}
-	if latestDomain == "general" {
-		return "there is no clear need for your role yet"
-	}
+	// Allow everything else — agents should share viewpoints.
+	// The specialist prompt tells them to use reactions for agreement instead.
 	return ""
 }
 

--- a/internal/teammcp/server_test.go
+++ b/internal/teammcp/server_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/team"
 )
 
-func TestSuppressBroadcastReasonBlocksOutOfDomainReply(t *testing.T) {
+func TestSuppressBroadcastReasonAllowsViewpoints(t *testing.T) {
 	reason := suppressBroadcastReason(
 		"fe",
 		"Here is my thought.",
@@ -22,8 +22,8 @@ func TestSuppressBroadcastReasonBlocksOutOfDomainReply(t *testing.T) {
 		},
 		nil,
 	)
-	if reason == "" {
-		t.Fatal("expected FE reply to be suppressed for marketing-only work")
+	if reason != "" {
+		t.Fatalf("expected FE reply to be allowed (agents should share viewpoints), got %q", reason)
 	}
 }
 
@@ -44,7 +44,7 @@ func TestSuppressBroadcastReasonAllowsOwnedTaskReply(t *testing.T) {
 	}
 }
 
-func TestSuppressBroadcastReasonBlocksAfterUntargetedCEOReply(t *testing.T) {
+func TestSuppressBroadcastReasonAllowsAfterCEOReply(t *testing.T) {
 	reason := suppressBroadcastReason(
 		"fe",
 		"I can take this too.",
@@ -55,8 +55,8 @@ func TestSuppressBroadcastReasonBlocksAfterUntargetedCEOReply(t *testing.T) {
 		},
 		nil,
 	)
-	if reason == "" {
-		t.Fatal("expected untargeted post-CEO specialist reply to be suppressed")
+	if reason != "" {
+		t.Fatalf("expected FE reply to be allowed after CEO (agents share viewpoints), got %q", reason)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Agents always share their viewpoint, even if someone else responded first
- When they agree with nothing new to add, they use `team_react` with an emoji instead of a redundant message
- Reactions render as compact pills under messages: `👍 2` `💯 1`
- Tagged agents (`@all` or direct `@slug`) must respond unless the tag is FYI

## New components
- `messageReaction` struct on `channelMessage` (emoji + from)
- `POST /reactions` broker endpoint (deduplicates same emoji/agent)
- `team_react` MCP tool with common emoji suggestions
- Reaction rendering in message feed (compact pills)

## Behavior changes
- `suppressBroadcastReason` no longer blocks agents from responding
- Specialist prompt encourages viewpoints and debate, reactions for agreement
- Agents tagged with `@all` or `@slug` must respond unless purely informational

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>