### PR TITLE
feat: multi-agent improvements from open-multi-agent research

### DIFF
--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -28,6 +28,16 @@ Rules:
 6. Keep your response extremely short. Do not use headings, bullets, markdown, JSON, YAML, metadata, or long explanations.
 7. If you mention any teammate without an @slug from the roster above, your response is invalid.
 
+TASK PLANNING:
+For work involving 2+ agents, use team_plan to create a structured plan:
+[
+  { "title": "Design API", "assignee": "be", "depends_on": [] },
+  { "title": "Implement UI", "assignee": "fe", "depends_on": ["Design API"] }
+]
+The framework ensures tasks execute in dependency order. Blocked tasks won't notify agents until dependencies complete.
+
+Use team_memory_write to share decisions, specs, and findings. All agents see shared memory via team_poll.
+
 SKILL DETECTION:
 You have the ability to create reusable skills for the team. Watch for patterns in team conversations that are NOT already documented in project files (CLAUDE.md, *.rules, etc.).
 

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -614,6 +614,28 @@ func (b *Broker) ChannelTasks(channel string) []teamTask {
 	return out
 }
 
+// UnackedTasks returns in_progress tasks with an owner that have not been acked
+// and were created more than the given duration ago.
+func (b *Broker) UnackedTasks(timeout time.Duration) []teamTask {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	cutoff := time.Now().UTC().Add(-timeout)
+	out := make([]teamTask, 0)
+	for _, task := range b.tasks {
+		if task.Status != "in_progress" || task.Owner == "" || task.AckedAt != "" {
+			continue
+		}
+		created, err := time.Parse(time.RFC3339, task.CreatedAt)
+		if err != nil {
+			continue
+		}
+		if created.Before(cutoff) {
+			out = append(out, task)
+		}
+	}
+	return out
+}
+
 func (b *Broker) Requests(channel string, includeResolved bool) []humanInterview {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -101,8 +101,11 @@ type teamTask struct {
 	SourceSignalID   string `json:"source_signal_id,omitempty"`
 	SourceDecisionID string `json:"source_decision_id,omitempty"`
 	WorktreePath     string `json:"worktree_path,omitempty"`
-	WorktreeBranch   string `json:"worktree_branch,omitempty"`
-	DueAt            string `json:"due_at,omitempty"`
+	WorktreeBranch   string   `json:"worktree_branch,omitempty"`
+	DependsOn        []string `json:"depends_on,omitempty"`
+	Blocked          bool     `json:"blocked,omitempty"`
+	AckedAt          string   `json:"acked_at,omitempty"`
+	DueAt            string   `json:"due_at,omitempty"`
 	FollowUpAt       string `json:"follow_up_at,omitempty"`
 	ReminderAt       string `json:"reminder_at,omitempty"`
 	RecheckAt        string `json:"recheck_at,omitempty"`
@@ -3393,22 +3396,23 @@ func (b *Broker) handleGetTasks(w http.ResponseWriter, r *http.Request) {
 
 func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Action           string `json:"action"`
-		Channel          string `json:"channel"`
-		ID               string `json:"id"`
-		Title            string `json:"title"`
-		Details          string `json:"details"`
-		Owner            string `json:"owner"`
-		CreatedBy        string `json:"created_by"`
-		ThreadID         string `json:"thread_id"`
-		TaskType         string `json:"task_type"`
-		PipelineID       string `json:"pipeline_id"`
-		ExecutionMode    string `json:"execution_mode"`
-		ReviewState      string `json:"review_state"`
-		SourceSignalID   string `json:"source_signal_id"`
-		SourceDecisionID string `json:"source_decision_id"`
-		WorktreePath     string `json:"worktree_path"`
-		WorktreeBranch   string `json:"worktree_branch"`
+		Action           string   `json:"action"`
+		Channel          string   `json:"channel"`
+		ID               string   `json:"id"`
+		Title            string   `json:"title"`
+		Details          string   `json:"details"`
+		Owner            string   `json:"owner"`
+		CreatedBy        string   `json:"created_by"`
+		ThreadID         string   `json:"thread_id"`
+		TaskType         string   `json:"task_type"`
+		PipelineID       string   `json:"pipeline_id"`
+		ExecutionMode    string   `json:"execution_mode"`
+		ReviewState      string   `json:"review_state"`
+		SourceSignalID   string   `json:"source_signal_id"`
+		SourceDecisionID string   `json:"source_decision_id"`
+		WorktreePath     string   `json:"worktree_path"`
+		WorktreeBranch   string   `json:"worktree_branch"`
+		DependsOn        []string `json:"depends_on"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -3502,10 +3506,13 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			SourceDecisionID: strings.TrimSpace(body.SourceDecisionID),
 			WorktreePath:     strings.TrimSpace(body.WorktreePath),
 			WorktreeBranch:   strings.TrimSpace(body.WorktreeBranch),
+			DependsOn:        body.DependsOn,
 			CreatedAt:        now,
 			UpdatedAt:        now,
 		}
-		if task.Owner != "" {
+		if len(task.DependsOn) > 0 && b.hasUnresolvedDepsLocked(&task) {
+			task.Blocked = true
+		} else if task.Owner != "" {
 			task.Status = "in_progress"
 		}
 		b.scheduleTaskLifecycleLocked(&task)
@@ -3591,6 +3598,9 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			task.WorktreeBranch = worktreeBranch
 		}
 		task.UpdatedAt = now
+		if task.Status == "done" {
+			b.unblockDependentsLocked(task.ID)
+		}
 		b.scheduleTaskLifecycleLocked(task)
 		b.appendActionLocked("task_updated", "office", channel, strings.TrimSpace(body.CreatedBy), truncateSummary(task.Title+" ["+task.Status+"]", 140), task.ID)
 		if err := b.saveLocked(); err != nil {
@@ -3758,6 +3768,48 @@ func (b *Broker) EnsurePlannedTask(input plannedTaskInput) (teamTask, bool, erro
 		return teamTask{}, false, err
 	}
 	return task, false, nil
+}
+
+// hasUnresolvedDepsLocked returns true if any of the task's dependencies are not done.
+func (b *Broker) hasUnresolvedDepsLocked(task *teamTask) bool {
+	for _, depID := range task.DependsOn {
+		found := false
+		for j := range b.tasks {
+			if b.tasks[j].ID == depID {
+				found = true
+				if b.tasks[j].Status != "done" {
+					return true
+				}
+				break
+			}
+		}
+		if !found {
+			return true // dependency doesn't exist yet — treat as unresolved
+		}
+	}
+	return false
+}
+
+// unblockDependentsLocked checks all blocked tasks and unblocks those whose dependencies are now resolved.
+func (b *Broker) unblockDependentsLocked(completedTaskID string) {
+	for i := range b.tasks {
+		if !b.tasks[i].Blocked {
+			continue
+		}
+		hasDep := false
+		for _, depID := range b.tasks[i].DependsOn {
+			if depID == completedTaskID {
+				hasDep = true
+				break
+			}
+		}
+		if !hasDep {
+			continue
+		}
+		if !b.hasUnresolvedDepsLocked(&b.tasks[i]) {
+			b.tasks[i].Blocked = false
+		}
+	}
 }
 
 func (b *Broker) findReusableTaskLocked(channel, title, threadID, owner string) *teamTask {

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -260,8 +260,9 @@ type brokerState struct {
 	Decisions         []officeDecisionRecord `json:"decisions,omitempty"`
 	Watchdogs         []watchdogAlert        `json:"watchdogs,omitempty"`
 	Scheduler         []schedulerJob         `json:"scheduler,omitempty"`
-	Skills            []teamSkill            `json:"skills,omitempty"`
-	Counter           int                    `json:"counter"`
+	Skills            []teamSkill                   `json:"skills,omitempty"`
+	SharedMemory      map[string]map[string]string  `json:"shared_memory,omitempty"`
+	Counter           int                           `json:"counter"`
 	NotificationSince string                 `json:"notification_since,omitempty"`
 	InsightsSince     string                 `json:"insights_since,omitempty"`
 	PendingInterview  *humanInterview        `json:"pending_interview,omitempty"`
@@ -301,6 +302,7 @@ type Broker struct {
 	watchdogs         []watchdogAlert
 	scheduler         []schedulerJob
 	skills            []teamSkill
+	sharedMemory      map[string]map[string]string // namespace → key → value
 	lastTaggedAt      map[string]time.Time   // when each agent was last @mentioned
 	lastPaneSnapshot  map[string]string      // last captured pane content per agent (for change detection)
 	seenTelegramGroups map[int64]string      // chat_id -> title, populated by transport
@@ -381,6 +383,9 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/channel-members", b.requireAuth(b.handleChannelMembers))
 	mux.HandleFunc("/members", b.requireAuth(b.handleMembers))
 	mux.HandleFunc("/tasks", b.requireAuth(b.handleTasks))
+	mux.HandleFunc("/tasks/ack", b.requireAuth(b.handleTaskAck))
+	mux.HandleFunc("/task-plan", b.requireAuth(b.handleTaskPlan))
+	mux.HandleFunc("/memory", b.requireAuth(b.handleMemory))
 	mux.HandleFunc("/requests", b.requireAuth(b.handleRequests))
 	mux.HandleFunc("/requests/answer", b.requireAuth(b.handleRequestAnswer))
 	mux.HandleFunc("/interview", b.requireAuth(b.handleInterview))
@@ -777,6 +782,7 @@ func (b *Broker) loadState() error {
 	b.watchdogs = state.Watchdogs
 	b.scheduler = state.Scheduler
 	b.skills = state.Skills
+	b.sharedMemory = state.SharedMemory
 	b.counter = state.Counter
 	b.notificationSince = state.NotificationSince
 	b.insightsSince = state.InsightsSince
@@ -797,7 +803,7 @@ func (b *Broker) loadState() error {
 
 func (b *Broker) saveLocked() error {
 	path := brokerStatePath()
-	if len(b.messages) == 0 && len(b.tasks) == 0 && len(activeRequests(b.requests)) == 0 && len(b.actions) == 0 && len(b.signals) == 0 && len(b.decisions) == 0 && len(b.watchdogs) == 0 && len(b.scheduler) == 0 && len(b.skills) == 0 && isDefaultChannelState(b.channels) && isDefaultOfficeMemberState(b.members) && b.counter == 0 && b.notificationSince == "" && b.insightsSince == "" && usageStateIsZero(b.usage) && b.sessionMode == SessionModeOffice && b.oneOnOneAgent == DefaultOneOnOneAgent {
+	if len(b.messages) == 0 && len(b.tasks) == 0 && len(activeRequests(b.requests)) == 0 && len(b.actions) == 0 && len(b.signals) == 0 && len(b.decisions) == 0 && len(b.watchdogs) == 0 && len(b.scheduler) == 0 && len(b.skills) == 0 && len(b.sharedMemory) == 0 && isDefaultChannelState(b.channels) && isDefaultOfficeMemberState(b.members) && b.counter == 0 && b.notificationSince == "" && b.insightsSince == "" && usageStateIsZero(b.usage) && b.sessionMode == SessionModeOffice && b.oneOnOneAgent == DefaultOneOnOneAgent {
 		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
@@ -820,6 +826,7 @@ func (b *Broker) saveLocked() error {
 		Watchdogs:         b.watchdogs,
 		Scheduler:         b.scheduler,
 		Skills:            b.skills,
+		SharedMemory:      b.sharedMemory,
 		Counter:           b.counter,
 		NotificationSince: b.notificationSince,
 		InsightsSince:     b.insightsSince,
@@ -3612,6 +3619,195 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	http.Error(w, "task not found", http.StatusNotFound)
+}
+
+func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Channel   string `json:"channel"`
+		CreatedBy string `json:"created_by"`
+		Tasks     []struct {
+			Title     string   `json:"title"`
+			Assignee  string   `json:"assignee"`
+			Details   string   `json:"details"`
+			DependsOn []string `json:"depends_on"`
+		} `json:"tasks"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	channel := normalizeChannelSlug(body.Channel)
+	if channel == "" {
+		channel = "general"
+	}
+	createdBy := strings.TrimSpace(body.CreatedBy)
+	if createdBy == "" || len(body.Tasks) == 0 {
+		http.Error(w, "created_by and tasks required", http.StatusBadRequest)
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.findChannelLocked(channel) == nil {
+		http.Error(w, "channel not found", http.StatusNotFound)
+		return
+	}
+
+	// Map title → task ID for resolving depends_on by title
+	titleToID := map[string]string{}
+	now := time.Now().UTC().Format(time.RFC3339)
+	created := make([]teamTask, 0, len(body.Tasks))
+
+	for _, item := range body.Tasks {
+		b.counter++
+		taskID := fmt.Sprintf("task-%d", b.counter)
+		titleToID[strings.TrimSpace(item.Title)] = taskID
+
+		// Resolve depends_on: accept both task IDs and titles
+		resolvedDeps := make([]string, 0, len(item.DependsOn))
+		for _, dep := range item.DependsOn {
+			dep = strings.TrimSpace(dep)
+			if id, ok := titleToID[dep]; ok {
+				resolvedDeps = append(resolvedDeps, id)
+			} else {
+				resolvedDeps = append(resolvedDeps, dep) // assume it's a task ID
+			}
+		}
+
+		task := teamTask{
+			ID:        taskID,
+			Channel:   channel,
+			Title:     strings.TrimSpace(item.Title),
+			Details:   strings.TrimSpace(item.Details),
+			Owner:     strings.TrimSpace(item.Assignee),
+			Status:    "open",
+			CreatedBy: createdBy,
+			DependsOn: resolvedDeps,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if task.Owner != "" && len(resolvedDeps) == 0 {
+			task.Status = "in_progress"
+		}
+		if len(resolvedDeps) > 0 && b.hasUnresolvedDepsLocked(&task) {
+			task.Blocked = true
+		}
+		b.scheduleTaskLifecycleLocked(&task)
+		b.tasks = append(b.tasks, task)
+		b.appendActionLocked("task_created", "office", channel, createdBy, truncateSummary(task.Title, 140), task.ID)
+		created = append(created, task)
+	}
+
+	if err := b.saveLocked(); err != nil {
+		http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{"tasks": created})
+}
+
+func (b *Broker) handleMemory(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		channel := normalizeChannelSlug(r.URL.Query().Get("channel"))
+		if channel == "" {
+			channel = "general"
+		}
+		b.mu.Lock()
+		mem := b.sharedMemory
+		b.mu.Unlock()
+		if mem == nil {
+			mem = make(map[string]map[string]string)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"memory": mem})
+	case http.MethodPost:
+		var body struct {
+			Namespace string `json:"namespace"`
+			Key       string `json:"key"`
+			Value     string `json:"value"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		ns := strings.TrimSpace(body.Namespace)
+		key := strings.TrimSpace(body.Key)
+		if ns == "" || key == "" {
+			http.Error(w, "namespace and key required", http.StatusBadRequest)
+			return
+		}
+		b.mu.Lock()
+		if b.sharedMemory == nil {
+			b.sharedMemory = make(map[string]map[string]string)
+		}
+		if b.sharedMemory[ns] == nil {
+			b.sharedMemory[ns] = make(map[string]string)
+		}
+		b.sharedMemory[ns][key] = body.Value
+		if err := b.saveLocked(); err != nil {
+			b.mu.Unlock()
+			http.Error(w, "failed to persist", http.StatusInternalServerError)
+			return
+		}
+		b.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"ok": true, "namespace": ns, "key": key})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (b *Broker) handleTaskAck(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		ID      string `json:"id"`
+		Channel string `json:"channel"`
+		Slug    string `json:"slug"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	taskID := strings.TrimSpace(body.ID)
+	slug := strings.TrimSpace(body.Slug)
+	channel := normalizeChannelSlug(body.Channel)
+	if channel == "" {
+		channel = "general"
+	}
+	if taskID == "" || slug == "" {
+		http.Error(w, "id and slug required", http.StatusBadRequest)
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := range b.tasks {
+		if b.tasks[i].ID == taskID && normalizeChannelSlug(b.tasks[i].Channel) == channel {
+			if b.tasks[i].Owner != slug {
+				http.Error(w, "only the task owner can ack", http.StatusForbidden)
+				return
+			}
+			now := time.Now().UTC().Format(time.RFC3339)
+			b.tasks[i].AckedAt = now
+			b.tasks[i].UpdatedAt = now
+			if err := b.saveLocked(); err != nil {
+				http.Error(w, "failed to persist", http.StatusInternalServerError)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"task": b.tasks[i]})
+			return
+		}
+	}
 	http.Error(w, "task not found", http.StatusNotFound)
 }
 

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -709,9 +709,33 @@ func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate 
 		}
 	}
 
-	// Broadcast model: every message goes to every agent.
-	// CEO gets a small head start (immediate), everyone else is delayed.
-	// The sender is always excluded.
+	// Context-aware notification gating:
+	// 1. CEO/lead messages always broadcast to all (they're directives)
+	// 2. If message tags specific agents → notify tagged + CEO
+	// 3. If message is in a thread → notify thread participants + CEO
+	// 4. Otherwise → broadcast all (fallback)
+	// CEO always gets immediate delivery on non-CEO messages.
+
+	broadcastAll := msg.From == lead
+
+	if !broadcastAll && len(msg.Tagged) > 0 {
+		addTarget(lead, &immediate)
+		for _, slug := range msg.Tagged {
+			addTarget(slug, &delayed)
+		}
+		return immediate, delayed
+	}
+
+	if !broadcastAll && msg.ReplyTo != "" && l.broker != nil {
+		threadParticipants := l.threadParticipants(msg.Channel, msg.ReplyTo)
+		addTarget(lead, &immediate)
+		for _, slug := range threadParticipants {
+			addTarget(slug, &delayed)
+		}
+		return immediate, delayed
+	}
+
+	// Broadcast to all enabled agents.
 	addTarget(lead, &immediate)
 	for _, slug := range slugs {
 		if slug == lead {
@@ -720,6 +744,25 @@ func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate 
 		addTarget(slug, &delayed)
 	}
 	return immediate, delayed
+}
+
+// threadParticipants returns the slugs of agents who have posted in a given thread.
+func (l *Launcher) threadParticipants(channel, threadRoot string) []string {
+	if l.broker == nil {
+		return nil
+	}
+	messages := l.broker.ChannelMessages(channel)
+	seen := map[string]struct{}{}
+	for _, msg := range messages {
+		if msg.ID == threadRoot || msg.ReplyTo == threadRoot {
+			seen[msg.From] = struct{}{}
+		}
+	}
+	slugs := make([]string, 0, len(seen))
+	for slug := range seen {
+		slugs = append(slugs, slug)
+	}
+	return slugs
 }
 
 func (l *Launcher) shouldDeliverDelayedNotification(targetSlug string, source channelMessage) bool {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -277,6 +277,7 @@ func (l *Launcher) Launch() error {
 		go l.notifyTaskActionsLoop()
 		go l.pollNexNotificationsLoop()
 		go l.watchdogSchedulerLoop()
+		go l.taskAckWatchdogLoop()
 	}
 
 	// Start Telegram transport if any channel has a telegram surface
@@ -763,6 +764,46 @@ func (l *Launcher) threadParticipants(channel, threadRoot string) []string {
 		slugs = append(slugs, slug)
 	}
 	return slugs
+}
+
+const taskAckTimeout = 30 * time.Second
+
+// taskAckWatchdogLoop checks for in_progress tasks that haven't been acknowledged
+// by their owner within the ack timeout. Unacked tasks are escalated to the CEO.
+func (l *Launcher) taskAckWatchdogLoop() {
+	escalated := make(map[string]struct{}) // track which task IDs we already escalated
+	for {
+		time.Sleep(10 * time.Second)
+		if l.broker == nil {
+			continue
+		}
+		unacked := l.broker.UnackedTasks(taskAckTimeout)
+		if len(unacked) == 0 {
+			continue
+		}
+		lead := l.officeLeadSlug()
+		targetMap := l.agentPaneTargets()
+		ceoTarget, ok := targetMap[lead]
+		if !ok {
+			continue
+		}
+		for _, task := range unacked {
+			if _, done := escalated[task.ID]; done {
+				continue
+			}
+			escalated[task.ID] = struct{}{}
+			notification := fmt.Sprintf(
+				"[ACK TIMEOUT] Task %s (%s) assigned to @%s has not been acknowledged after %s. Consider reassigning or checking on the agent.",
+				task.ID, truncate(task.Title, 80), task.Owner, taskAckTimeout,
+			)
+			exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+				"-t", ceoTarget.PaneTarget,
+				"-l",
+				notification,
+			).Run()
+			submitAgentPanePrompt(ceoTarget.PaneTarget)
+		}
+	}
 }
 
 func (l *Launcher) shouldDeliverDelayedNotification(targetSlug string, source channelMessage) bool {

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -111,20 +111,22 @@ type brokerTasksResponse struct {
 }
 
 type brokerTaskSummary struct {
-	ID               string `json:"id"`
-	Channel          string `json:"channel"`
-	Title            string `json:"title"`
-	Details          string `json:"details"`
-	Owner            string `json:"owner"`
-	Status           string `json:"status"`
-	CreatedBy        string `json:"created_by"`
-	ThreadID         string `json:"thread_id"`
-	TaskType         string `json:"task_type"`
-	PipelineStage    string `json:"pipeline_stage"`
-	ExecutionMode    string `json:"execution_mode"`
-	ReviewState      string `json:"review_state"`
-	SourceSignalID   string `json:"source_signal_id"`
-	SourceDecisionID string `json:"source_decision_id"`
+	ID               string   `json:"id"`
+	Channel          string   `json:"channel"`
+	Title            string   `json:"title"`
+	Details          string   `json:"details"`
+	Owner            string   `json:"owner"`
+	Status           string   `json:"status"`
+	CreatedBy        string   `json:"created_by"`
+	ThreadID         string   `json:"thread_id"`
+	TaskType         string   `json:"task_type"`
+	PipelineStage    string   `json:"pipeline_stage"`
+	ExecutionMode    string   `json:"execution_mode"`
+	ReviewState      string   `json:"review_state"`
+	SourceSignalID   string   `json:"source_signal_id"`
+	SourceDecisionID string   `json:"source_decision_id"`
+	DependsOn        []string `json:"depends_on,omitempty"`
+	Blocked          bool     `json:"blocked,omitempty"`
 }
 
 type TeamBroadcastArgs struct {
@@ -207,14 +209,15 @@ type TeamTasksArgs struct {
 }
 
 type TeamTaskArgs struct {
-	Action   string `json:"action" jsonschema:"One of: create, claim, assign, complete, block, release"`
-	Channel  string `json:"channel,omitempty" jsonschema:"Channel slug. Defaults to the agent's current channel or general."`
-	ID       string `json:"id,omitempty" jsonschema:"Task ID for non-create actions"`
-	Title    string `json:"title,omitempty" jsonschema:"Task title when creating a task"`
-	Details  string `json:"details,omitempty" jsonschema:"Optional detail or update"`
-	Owner    string `json:"owner,omitempty" jsonschema:"Owner slug for claim or assign"`
-	ThreadID string `json:"thread_id,omitempty" jsonschema:"Related thread or message id"`
-	MySlug   string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
+	Action    string   `json:"action" jsonschema:"One of: create, claim, assign, complete, block, release"`
+	Channel   string   `json:"channel,omitempty" jsonschema:"Channel slug. Defaults to the agent's current channel or general."`
+	ID        string   `json:"id,omitempty" jsonschema:"Task ID for non-create actions"`
+	Title     string   `json:"title,omitempty" jsonschema:"Task title when creating a task"`
+	Details   string   `json:"details,omitempty" jsonschema:"Optional detail or update"`
+	Owner     string   `json:"owner,omitempty" jsonschema:"Owner slug for claim or assign"`
+	ThreadID  string   `json:"thread_id,omitempty" jsonschema:"Related thread or message id"`
+	DependsOn []string `json:"depends_on,omitempty" jsonschema:"Task IDs this task depends on. Blocked until all dependencies are done."`
+	MySlug    string   `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
 }
 
 type TeamChannelsArgs struct{}
@@ -799,6 +802,9 @@ func handleTeamTasks(ctx context.Context, _ *mcp.CallToolRequest, args TeamTasks
 	lines := make([]string, 0, len(result.Tasks))
 	for _, task := range result.Tasks {
 		line := fmt.Sprintf("- %s [%s]", task.ID, task.Status)
+		if task.Blocked {
+			line += " BLOCKED"
+		}
 		if task.Owner != "" {
 			line += " @" + task.Owner
 		}
@@ -812,6 +818,9 @@ func handleTeamTasks(ctx context.Context, _ *mcp.CallToolRequest, args TeamTasks
 			line += " · " + task.ExecutionMode
 		}
 		line += " — " + task.Title
+		if len(task.DependsOn) > 0 {
+			line += " (deps: " + strings.Join(task.DependsOn, ", ") + ")"
+		}
 		if task.ThreadID != "" {
 			line += " ↳ " + task.ThreadID
 		}
@@ -839,6 +848,9 @@ func handleTeamTask(ctx context.Context, _ *mcp.CallToolRequest, args TeamTaskAr
 		"thread_id":  strings.TrimSpace(args.ThreadID),
 		"created_by": mySlug,
 	}
+	if len(args.DependsOn) > 0 {
+		payload["depends_on"] = args.DependsOn
+	}
 	switch action {
 	case "claim":
 		payload["owner"] = mySlug
@@ -852,16 +864,20 @@ func handleTeamTask(ctx context.Context, _ *mcp.CallToolRequest, args TeamTaskAr
 
 	var result struct {
 		Task struct {
-			ID     string `json:"id"`
-			Title  string `json:"title"`
-			Owner  string `json:"owner"`
-			Status string `json:"status"`
+			ID      string `json:"id"`
+			Title   string `json:"title"`
+			Owner   string `json:"owner"`
+			Status  string `json:"status"`
+			Blocked bool   `json:"blocked"`
 		} `json:"task"`
 	}
 	if err := brokerPostJSON(ctx, "/tasks", payload, &result); err != nil {
 		return toolError(err), nil, nil
 	}
 	text := fmt.Sprintf("Task %s in #%s is now %s", result.Task.ID, channel, result.Task.Status)
+	if result.Task.Blocked {
+		text += " (BLOCKED — waiting on dependencies)"
+	}
 	if result.Task.Owner != "" {
 		text += " @" + result.Task.Owner
 	}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -220,6 +220,29 @@ type TeamTaskArgs struct {
 	MySlug    string   `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
 }
 
+type TeamPlanArgs struct {
+	Channel string `json:"channel,omitempty" jsonschema:"Channel slug. Defaults to the agent's current channel or general."`
+	Tasks   []struct {
+		Title     string   `json:"title" jsonschema:"Task title"`
+		Assignee  string   `json:"assignee" jsonschema:"Agent slug to own this task"`
+		Details   string   `json:"details,omitempty" jsonschema:"Optional task details"`
+		DependsOn []string `json:"depends_on,omitempty" jsonschema:"Titles or IDs of tasks this depends on"`
+	} `json:"tasks" jsonschema:"List of tasks to create in dependency order"`
+	MySlug string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
+}
+
+type TeamMemoryWriteArgs struct {
+	Key    string `json:"key" jsonschema:"Key to store under your namespace"`
+	Value  string `json:"value" jsonschema:"Value to store"`
+	MySlug string `json:"my_slug,omitempty" jsonschema:"Your agent slug (used as namespace). Defaults to WUPHF_AGENT_SLUG."`
+}
+
+type TeamTaskAckArgs struct {
+	ID      string `json:"id" jsonschema:"Task ID to acknowledge"`
+	Channel string `json:"channel,omitempty" jsonschema:"Channel slug. Defaults to the agent's current channel or general."`
+	MySlug  string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
+}
+
 type TeamChannelsArgs struct{}
 
 type TeamMembersArgs struct {
@@ -369,6 +392,21 @@ func Run(ctx context.Context) error {
 		Name:        "team_task",
 		Description: "Create, claim, assign, complete, block, or release a shared task in the office task list.",
 	}, handleTeamTask)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "team_plan",
+		Description: "Create a structured task plan with dependencies in one call. Tasks execute in dependency order. Use this for work involving 2+ agents.",
+	}, handleTeamPlan)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "team_memory_write",
+		Description: "Write a key-value pair into the shared team memory under your namespace. All agents can read all namespaces via team_poll.",
+	}, handleTeamMemoryWrite)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "team_task_ack",
+		Description: "Acknowledge a task assigned to you, confirming you have seen it and will begin work.",
+	}, handleTeamTaskAck)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "team_requests",
@@ -883,6 +921,109 @@ func handleTeamTask(ctx context.Context, _ *mcp.CallToolRequest, args TeamTaskAr
 	}
 	text += " — " + result.Task.Title
 	return textResult(text), nil, nil
+}
+
+func handleTeamPlan(ctx context.Context, _ *mcp.CallToolRequest, args TeamPlanArgs) (*mcp.CallToolResult, any, error) {
+	mySlug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	channel := resolveChannel(args.Channel)
+	if len(args.Tasks) == 0 {
+		return toolError(fmt.Errorf("tasks list is empty")), nil, nil
+	}
+
+	type planItem struct {
+		Title     string   `json:"title"`
+		Assignee  string   `json:"assignee"`
+		Details   string   `json:"details,omitempty"`
+		DependsOn []string `json:"depends_on,omitempty"`
+	}
+	items := make([]planItem, 0, len(args.Tasks))
+	for _, t := range args.Tasks {
+		items = append(items, planItem{
+			Title:     strings.TrimSpace(t.Title),
+			Assignee:  strings.TrimSpace(t.Assignee),
+			Details:   strings.TrimSpace(t.Details),
+			DependsOn: t.DependsOn,
+		})
+	}
+
+	var result struct {
+		Tasks []struct {
+			ID      string `json:"id"`
+			Title   string `json:"title"`
+			Owner   string `json:"owner"`
+			Status  string `json:"status"`
+			Blocked bool   `json:"blocked"`
+		} `json:"tasks"`
+	}
+	if err := brokerPostJSON(ctx, "/task-plan", map[string]any{
+		"channel":    channel,
+		"created_by": mySlug,
+		"tasks":      items,
+	}, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+
+	lines := make([]string, 0, len(result.Tasks))
+	for _, t := range result.Tasks {
+		line := fmt.Sprintf("- %s [%s]", t.ID, t.Status)
+		if t.Blocked {
+			line += " BLOCKED"
+		}
+		if t.Owner != "" {
+			line += " @" + t.Owner
+		}
+		line += " — " + t.Title
+		lines = append(lines, line)
+	}
+	return textResult(fmt.Sprintf("Created %d tasks in #%s:\n%s", len(result.Tasks), channel, strings.Join(lines, "\n"))), nil, nil
+}
+
+func handleTeamMemoryWrite(ctx context.Context, _ *mcp.CallToolRequest, args TeamMemoryWriteArgs) (*mcp.CallToolResult, any, error) {
+	mySlug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	key := strings.TrimSpace(args.Key)
+	if key == "" {
+		return toolError(fmt.Errorf("key is required")), nil, nil
+	}
+	if err := brokerPostJSON(ctx, "/memory", map[string]any{
+		"namespace": mySlug,
+		"key":       key,
+		"value":     args.Value,
+	}, nil); err != nil {
+		return toolError(err), nil, nil
+	}
+	return textResult(fmt.Sprintf("Saved %s/%s to shared memory.", mySlug, key)), nil, nil
+}
+
+func handleTeamTaskAck(ctx context.Context, _ *mcp.CallToolRequest, args TeamTaskAckArgs) (*mcp.CallToolResult, any, error) {
+	mySlug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	channel := resolveChannel(args.Channel)
+	taskID := strings.TrimSpace(args.ID)
+	if taskID == "" {
+		return toolError(fmt.Errorf("task ID is required")), nil, nil
+	}
+	var result struct {
+		Task struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		} `json:"task"`
+	}
+	if err := brokerPostJSON(ctx, "/tasks/ack", map[string]any{
+		"id":      taskID,
+		"channel": channel,
+		"slug":    mySlug,
+	}, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return textResult(fmt.Sprintf("Acknowledged task %s — %s", result.Task.ID, result.Task.Title)), nil, nil
 }
 
 func handleTeamRequests(ctx context.Context, _ *mcp.CallToolRequest, args TeamRequestsArgs) (*mcp.CallToolResult, any, error) {

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -729,7 +729,8 @@ func handleTeamPoll(ctx context.Context, _ *mcp.CallToolRequest, args TeamPollAr
 	}
 	taskSummary := formatTaskSummary(ctx, resolveSlugOptional(args.MySlug), channel)
 	requestSummary := formatRequestSummary(ctx, channel)
-	return textResult(fmt.Sprintf("Channel #%s\n\n%s\n\nTagged messages for you: %d\n\n%s\n\n%s", channel, summary, result.TaggedCount, taskSummary, requestSummary)), nil, nil
+	memorySummary := formatMemorySummary(ctx)
+	return textResult(fmt.Sprintf("Channel #%s\n\n%s\n\nTagged messages for you: %d\n\n%s\n\n%s\n\n%s", channel, summary, result.TaggedCount, taskSummary, requestSummary, memorySummary)), nil, nil
 }
 
 func handleTeamStatus(ctx context.Context, _ *mcp.CallToolRequest, args TeamStatusArgs) (*mcp.CallToolResult, any, error) {
@@ -1729,6 +1730,24 @@ func formatRequestSummary(ctx context.Context, channel string) string {
 		lines = append(lines, line)
 	}
 	return "Open requests:\n" + strings.Join(lines, "\n")
+}
+
+func formatMemorySummary(ctx context.Context) string {
+	var result struct {
+		Memory map[string]map[string]string `json:"memory"`
+	}
+	if err := brokerGetJSON(ctx, "/memory", &result); err != nil || len(result.Memory) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("## Shared Context\n")
+	for ns, entries := range result.Memory {
+		sb.WriteString("### " + ns + "\n")
+		for key, val := range entries {
+			sb.WriteString("- " + key + ": " + val + "\n")
+		}
+	}
+	return sb.String()
 }
 
 func contains(items []string, want string) bool {


### PR DESCRIPTION
## Summary

Multi-agent improvements inspired by the open-multi-agent TypeScript framework, plus thread lifecycle and structured handoffs.

### Phase 1-5: open-multi-agent learnings
- **Task dependency graph**: Tasks declare `depends_on` (task IDs). Blocked tasks auto-unblock when dependencies complete.
- **Context-aware notification gating**: Specialist messages gate on tags or thread participation. CEO messages always broadcast.
- **Coordinator task planning**: `team_plan` MCP tool creates structured task DAGs in one call.
- **Namespaced shared memory**: `team_memory_write` stores agent-attributable KV pairs, injected into `team_poll`.
- **Task ack + timeout**: `team_task_ack` for agents to acknowledge tasks. 30s watchdog escalates to CEO.

### Phase 6-10: Thread lifecycle & structured handoffs
- **Thread conclusions**: `team_conclude` closes a thread with structured summary (discussed/decided/done/open items). Posted as `[CONCLUSION]` message for TUI visibility. Only thread participants can conclude. Idempotent.
- **Concluded-thread gating**: Auto-notifications suppressed for concluded threads. Tagged messages and CEO messages pierce the barrier.
- **Thread reopening**: `team_reopen` (CEO/human only) reopens concluded threads.
- **Structured handoffs**: `team_handoff` transfers task ownership with full context (what I did, what to do, relevant details). Validates owner and target agent. Handoff context injected into receiving agent's notification.
- **Poll enhancements**: `team_poll` now includes Recent Conclusions and Pending Handoffs sections.
- **Agent prompts**: CEO and specialist prompts updated with conclude/handoff instructions.

## Test plan
- [x] `go build -o wuphf ./cmd/wuphf` compiles
- [x] `go test ./...` — all 17 packages pass
- [ ] Manual: Create task with `depends_on`, confirm blocked → unblocks on completion
- [ ] Manual: Agent concludes thread → notifications suppressed, summary visible
- [ ] Manual: Tagged message in concluded thread still delivers
- [ ] Manual: Agent hands off task → receiving agent gets full context
- [ ] Manual: Non-participant cannot conclude, non-owner cannot handoff
- [ ] Manual: CEO uses `team_plan` with dependencies, `team_poll` shows conclusions

🤖 Generated with [Claude Code](https://claude.com/claude-code)