### PR TITLE
[codex] CC-agent office runtime, worktree, and channel UX upgrades

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -443,6 +444,7 @@ var channelSlashCommands = []tui.SlashCommand{
 	{Name: "1o1", Description: "Enable, switch, or disable direct 1:1 mode", Category: "session"},
 	{Name: "messages", Description: "Show the main office feed", Category: "navigate"},
 	{Name: "tasks", Description: "Show active work in this channel", Category: "navigate"},
+	{Name: "switch", Description: "Switch to another channel", Category: "navigate"},
 	{Name: "channels", Description: "Browse and manage channels", Category: "navigate"},
 	{Name: "channel", Description: "Create or remove a channel", Category: "channels"},
 	{Name: "agents", Description: "Manage channel agents", Category: "people"},
@@ -466,11 +468,18 @@ var channelSlashCommands = []tui.SlashCommand{
 
 // oneOnOneBlacklist lists command names blocked in 1:1 mode.
 var oneOnOneBlacklist = map[string]bool{
+	"switch":       true,
+	"tasks":        true,
+	"task":         true,
 	"channels":     true,
 	"channel":      true,
 	"agents":       true,
 	"agent":        true,
 	"agent prompt": true,
+	"reply":        true,
+	"threads":      true,
+	"expand":       true,
+	"collapse":     true,
 }
 
 func buildOneOnOneSlashCommands() []tui.SlashCommand {
@@ -666,6 +675,7 @@ func newChannelModelWithApp(threadsCollapsed bool, initialApp officeApp) channel
 		m.sidebarCollapsed = true
 		m.threadsDefaultExpand = true
 		m.autocomplete = tui.NewAutocomplete(buildOneOnOneSlashCommands())
+		m.notice = "Direct session reset. Agent pane reloaded in place."
 	}
 	if config.ResolveNoNex() {
 		m.notice = "Running in office-only mode. Nex tools are disabled for this session."
@@ -730,19 +740,21 @@ func (m *channelModel) refreshSlashCommands() {
 	m.autocomplete = tui.NewAutocomplete(base)
 	if preserveOverlays {
 		m.updateOverlaysForInput(activeInput, activeCursor)
+		return
 	}
+	m.updateOverlaysForCurrentInput()
 }
 
 func (m channelModel) pollCurrentState() tea.Cmd {
 	if m.isOneOnOne() {
-		return tea.Batch(
+		return tea.Sequence(
 			pollHealth(),
 			pollBroker(m.lastID, m.activeChannel),
 			pollMembers(m.activeChannel),
 			tickChannel(),
 		)
 	}
-	return tea.Batch(
+	return tea.Sequence(
 		pollHealth(),
 		pollChannels(),
 		pollOfficeMembers(),
@@ -1102,6 +1114,14 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// ── focusMain: existing behavior ──────────────────────────────
+		if motionKey, ok := composerMotionKey(msg); ok {
+			m.lastCtrlCAt = time.Time{}
+			if nextPos, handled := moveComposerCursor(m.input, m.inputPos, motionKey); handled {
+				m.inputPos = nextPos
+				m.updateInputOverlays()
+			}
+			return m, nil
+		}
 		switch msg.String() {
 		case "enter":
 			m.lastCtrlCAt = time.Time{}
@@ -1213,13 +1233,8 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		default:
 			m.lastCtrlCAt = time.Time{}
-			// Type character
-			if msg.Type == tea.KeySpace {
-				ch := []rune{' '}
-				tail := make([]rune, len(m.input[m.inputPos:]))
-				copy(tail, m.input[m.inputPos:])
-				m.input = append(m.input[:m.inputPos], append(ch, tail...)...)
-				m.inputPos++
+			if ch := composerInsertRunes(msg); len(ch) > 0 {
+				m.input, m.inputPos = insertComposerRunes(m.input, m.inputPos, ch)
 				m.updateInputOverlays()
 			} else if len(msg.String()) == 1 || msg.Type == tea.KeyRunes {
 				ch := msg.Runes
@@ -1233,6 +1248,9 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.inputPos += len(ch)
 					m.updateInputOverlays()
 				}
+			}
+			if m.maybeActivateChannelPickerFromInput() {
+				return m, nil
 			}
 		}
 
@@ -1348,6 +1366,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.notice == "" {
 				m.notice = "Office reset. Team panes reloaded in place."
 			}
+			return m, m.pollCurrentState()
 		} else {
 			m.notice = "Reset failed: " + msg.err.Error()
 		}
@@ -1579,10 +1598,18 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.replyToID = ""
 			}
 			if modeChanged {
+				m.messages = nil
+				m.members = nil
+				m.tasks = nil
+				m.requests = nil
+				m.lastID = ""
+				m.scroll = 0
+				m.unreadCount = 0
 				m.refreshSlashCommands()
-				if m.isOneOnOne() {
-					m.notice = "Direct 1:1 with " + m.oneOnOneAgentName() + "."
+				if m.isOneOnOne() && strings.TrimSpace(m.notice) == "" {
+					m.notice = "Direct session reset. Agent pane reloaded in place."
 				}
+				return m, m.pollCurrentState()
 			}
 		}
 
@@ -2335,7 +2362,7 @@ func (m channelModel) currentHeaderMeta() string {
 				external++
 			}
 		}
-		return fmt.Sprintf("  Signals, decisions, external actions, and watchdogs driving the office · %d signals · %d decisions · %d external · %d active watchdogs · %d high signal", len(m.signals), len(m.decisions), external, activeWatchdogs, highSignal)
+		return fmt.Sprintf("  Signals, Decisions, External Actions, and Watchdogs driving the office · %d signals · %d decisions · %d external · %d active watchdogs · %d high signal", len(m.signals), len(m.decisions), external, activeWatchdogs, highSignal)
 	case officeAppCalendar:
 		events := filterCalendarEvents(collectCalendarEvents(m.scheduler, m.tasks, m.requests, m.activeChannel, m.members), m.calendarRange, m.calendarFilter)
 		dueSoon := 0
@@ -2790,6 +2817,13 @@ func (m channelModel) nextFocus() focusArea {
 
 // updateThread handles key events when the thread panel is focused.
 func (m channelModel) updateThread(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if motionKey, ok := composerMotionKey(msg); ok {
+		if nextPos, handled := moveComposerCursor(m.threadInput, m.threadInputPos, motionKey); handled {
+			m.threadInputPos = nextPos
+			m.updateThreadOverlays()
+		}
+		return m, nil
+	}
 	key := msg.String()
 	if msg.Type == tea.KeyCtrlJ {
 		key = "ctrl+j"
@@ -2855,12 +2889,8 @@ func (m channelModel) updateThread(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.threadScroll = 0
 		}
 	default:
-		if msg.Type == tea.KeySpace {
-			ch := []rune{' '}
-			tail := make([]rune, len(m.threadInput[m.threadInputPos:]))
-			copy(tail, m.threadInput[m.threadInputPos:])
-			m.threadInput = append(m.threadInput[:m.threadInputPos], append(ch, tail...)...)
-			m.threadInputPos++
+		if ch := composerInsertRunes(msg); len(ch) > 0 {
+			m.threadInput, m.threadInputPos = insertComposerRunes(m.threadInput, m.threadInputPos, ch)
 			m.updateThreadOverlays()
 		} else if len(msg.String()) == 1 || msg.Type == tea.KeyRunes {
 			ch := msg.Runes
@@ -3803,6 +3833,7 @@ func (m *channelModel) updateOverlaysForCurrentInput() {
 	}
 	if m.focus == focusMain {
 		m.updateInputOverlays()
+		m.maybeActivateChannelPickerFromInput()
 		return
 	}
 	m.autocomplete.Dismiss()
@@ -3819,6 +3850,7 @@ func (m *channelModel) setActiveInput(text string) {
 	m.input = []rune(text)
 	m.inputPos = len(m.input)
 	m.updateInputOverlays()
+	m.maybeActivateChannelPickerFromInput()
 }
 
 func (m *channelModel) activeInputString() string {
@@ -3852,6 +3884,142 @@ func replaceMentionInInput(input []rune, pos int, mention string) ([]rune, int) 
 	}
 	updated := []rune(text[:atIdx] + mention + " " + text[pos:])
 	return updated, atIdx + len([]rune(mention)) + 1
+}
+
+func normalizeCursorPos(input []rune, pos int) int {
+	if pos < 0 {
+		return 0
+	}
+	if pos > len(input) {
+		return len(input)
+	}
+	return pos
+}
+
+func isComposerWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-'
+}
+
+func moveCursorBackwardWord(input []rune, pos int) int {
+	pos = normalizeCursorPos(input, pos)
+	for pos > 0 && !isComposerWordRune(input[pos-1]) {
+		pos--
+	}
+	for pos > 0 && isComposerWordRune(input[pos-1]) {
+		pos--
+	}
+	return pos
+}
+
+func moveCursorForwardWord(input []rune, pos int) int {
+	pos = normalizeCursorPos(input, pos)
+	for pos < len(input) && isComposerWordRune(input[pos]) {
+		pos++
+	}
+	for pos < len(input) && !isComposerWordRune(input[pos]) {
+		pos++
+	}
+	return pos
+}
+
+func moveComposerCursor(input []rune, pos int, key string) (int, bool) {
+	pos = normalizeCursorPos(input, pos)
+	switch key {
+	case "left", "ctrl+b", "alt+h":
+		if pos > 0 {
+			pos--
+		}
+		return pos, true
+	case "right", "ctrl+f", "alt+l":
+		if pos < len(input) {
+			pos++
+		}
+		return pos, true
+	case "ctrl+a", "alt+0":
+		return 0, true
+	case "ctrl+e", "alt+$":
+		return len(input), true
+	case "alt+b":
+		return moveCursorBackwardWord(input, pos), true
+	case "alt+w":
+		return moveCursorForwardWord(input, pos), true
+	default:
+		return pos, false
+	}
+}
+
+func composerMotionKey(msg tea.KeyMsg) (string, bool) {
+	if msg.Alt && len(msg.Runes) == 1 {
+		switch msg.Runes[0] {
+		case 'h':
+			return "alt+h", true
+		case 'l':
+			return "alt+l", true
+		case 'b':
+			return "alt+b", true
+		case 'w':
+			return "alt+w", true
+		case '0':
+			return "alt+0", true
+		case '$':
+			return "alt+$", true
+		}
+	}
+	switch msg.String() {
+	case "ctrl+a", "ctrl+e", "ctrl+b", "ctrl+f", "left", "right", "alt+h", "alt+l", "alt+b", "alt+w", "alt+0", "alt+$":
+		return msg.String(), true
+	default:
+		return "", false
+	}
+}
+
+func composerInsertRunes(msg tea.KeyMsg) []rune {
+	if msg.Type == tea.KeySpace || msg.String() == " " {
+		return []rune{' '}
+	}
+	if msg.Alt {
+		return nil
+	}
+	if len(msg.Runes) > 0 {
+		return msg.Runes
+	}
+	return nil
+}
+
+func insertComposerRunes(input []rune, pos int, ch []rune) ([]rune, int) {
+	pos = normalizeCursorPos(input, pos)
+	if len(ch) == 0 {
+		return input, pos
+	}
+	tail := make([]rune, len(input[pos:]))
+	copy(tail, input[pos:])
+	input = append(input[:pos], append(ch, tail...)...)
+	return input, pos + len(ch)
+}
+
+func (m *channelModel) maybeActivateChannelPickerFromInput() bool {
+	if m.focus != focusMain || m.picker.IsActive() || m.isOneOnOne() {
+		return false
+	}
+	switch string(m.input) {
+	case "/switch ", "/s ":
+		options := m.buildSwitchChannelPickerOptions()
+		if len(options) == 0 {
+			m.notice = "No channels yet."
+			return false
+		}
+		m.input = nil
+		m.inputPos = 0
+		m.autocomplete.Dismiss()
+		m.mention.Dismiss()
+		m.picker = tui.NewPicker("Switch Channel", options)
+		m.picker.SetActive(true)
+		m.pickerMode = channelPickerChannels
+		m.notice = "Choose a channel to switch to."
+		return true
+	default:
+		return false
+	}
 }
 
 func (m channelModel) renderActivePopup(width int) string {
@@ -3931,7 +4099,14 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 
 	if m.isOneOnOne() && strings.HasPrefix(trimmed, "/") {
 		// Blacklist: commands that only make sense in team/office mode
-		teamOnly := []string{"/channels", "/channel ", "/channel\n", "/agents", "/agent ", "/agent\n", "/agent prompt"}
+		teamOnly := []string{
+			"/switch", "/s",
+			"/tasks", "/task ", "/task\n",
+			"/channels", "/channel ", "/channel\n",
+			"/agents", "/agent ", "/agent\n", "/agent prompt",
+			"/reply ", "/reply\n",
+			"/threads", "/expand ", "/expand\n", "/collapse ", "/collapse\n",
+		}
 		blocked := false
 		for _, prefix := range teamOnly {
 			if trimmed == strings.TrimSpace(prefix) || strings.HasPrefix(trimmed, prefix) {
@@ -3940,7 +4115,7 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 			}
 		}
 		if blocked {
-			m.notice = "1:1 mode disables office collaboration commands. Switch back to the full team to use that."
+			m.notice = "1:1 mode disables office, channel, agent, task, and thread commands."
 			return m, nil
 		}
 	}
@@ -4060,6 +4235,18 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 	case trimmed == "/connect telegram":
 		clearCurrent()
 		return m, m.startTelegramConnect()
+	case trimmed == "/switch" || trimmed == "/s":
+		clearCurrent()
+		options := m.buildSwitchChannelPickerOptions()
+		if len(options) == 0 {
+			m.notice = "No channels yet."
+			return m, nil
+		}
+		m.picker = tui.NewPicker("Switch Channel", options)
+		m.picker.SetActive(true)
+		m.pickerMode = channelPickerChannels
+		m.notice = "Choose a channel to switch to."
+		return m, nil
 	case trimmed == "/channels":
 		clearCurrent()
 		options := m.buildChannelPickerOptions()
@@ -4584,6 +4771,17 @@ func (m channelModel) buildChannelPickerOptions() []tui.PickerOption {
 				Value:       "remove:" + ch.Slug,
 				Description: "Delete this channel and its messages/tasks",
 			})
+		}
+	}
+	return options
+}
+
+func (m channelModel) buildSwitchChannelPickerOptions() []tui.PickerOption {
+	all := m.buildChannelPickerOptions()
+	options := make([]tui.PickerOption, 0, len(all))
+	for _, option := range all {
+		if strings.HasPrefix(option.Value, "switch:") {
+			options = append(options, option)
 		}
 	}
 	return options
@@ -5766,9 +5964,13 @@ func isA2UIType(t string) bool {
 }
 
 func resolveInitialOfficeApp(name string) officeApp {
-	switch officeApp(strings.ToLower(strings.TrimSpace(name))) {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "insights" {
+		return officeAppPolicies
+	}
+	switch officeApp(normalized) {
 	case officeAppMessages, officeAppTasks, officeAppRequests, officeAppPolicies, officeAppCalendar:
-		return officeApp(strings.ToLower(strings.TrimSpace(name)))
+		return officeApp(normalized)
 	default:
 		return officeAppMessages
 	}

--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -36,10 +36,14 @@ func buildOfficeMessageLines(messages []brokerMessage, expanded map[string]bool,
 
 	lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Today")})
 
-	// Always expand threads — collapsed is confusing, expanded is readable
-	for _, msg := range messages {
-		if msg.ReplyTo == "" && hasThreadReplies(messages, msg.ID) {
-			expanded[msg.ID] = true
+	if !threadsDefaultExpand {
+		for _, msg := range messages {
+			if msg.ReplyTo != "" || !hasThreadReplies(messages, msg.ID) {
+				continue
+			}
+			if _, ok := expanded[msg.ID]; !ok {
+				expanded[msg.ID] = false
+			}
 		}
 	}
 
@@ -257,7 +261,7 @@ func buildOneOnOneMessageLines(messages []brokerMessage, expanded map[string]boo
 		mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
 		return []renderedLine{
 			{Text: ""},
-			{Text: mutedStyle.Render("  Direct 1:1 with " + agentName + ".")},
+			{Text: mutedStyle.Render("  Direct session reset. Agent pane reloaded in place.")},
 			{Text: mutedStyle.Render("  There is no office, no channel, and no teammate roster in this mode.")},
 			{Text: ""},
 			{Text: mutedStyle.Render("  Suggested: Help me think through the v1 launch plan.")},
@@ -357,18 +361,18 @@ func buildRequestLines(requests []channelInterview, contentWidth int) []rendered
 	return lines
 }
 
-func buildPolicyLines(decisions []channelDecision, contentWidth int) []renderedLine {
+func buildPolicyLines(signals []channelSignal, decisions []channelDecision, alerts []channelWatchdog, actions []channelAction, contentWidth int) []renderedLine {
 	muted := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
 	var lines []renderedLine
-	lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Policies")})
+	lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Insights")})
 
-	if len(decisions) == 0 {
+	if len(signals) == 0 && len(decisions) == 0 && len(alerts) == 0 && len(actions) == 0 {
 		lines = append(lines, renderedLine{Text: ""})
-		lines = append(lines, renderedLine{Text: muted.Render("  No team policies defined yet.")})
-		lines = append(lines, renderedLine{Text: muted.Render("  Policies are rules the team follows: coding standards, review gates,")})
-		lines = append(lines, renderedLine{Text: muted.Render("  deployment procedures, communication protocols.")})
+		lines = append(lines, renderedLine{Text: muted.Render("  No office insights yet.")})
+		lines = append(lines, renderedLine{Text: muted.Render("  Signals, decisions, watchdogs, and external actions will appear here")})
+		lines = append(lines, renderedLine{Text: muted.Render("  as the office starts tracking higher-signal work.")})
 		lines = append(lines, renderedLine{Text: ""})
-		lines = append(lines, renderedLine{Text: muted.Render("  The CEO can create policies from observed team patterns.")})
+		lines = append(lines, renderedLine{Text: muted.Render("  Use /policies to refresh this ledger at any time.")})
 		return lines
 	}
 
@@ -379,7 +383,42 @@ func buildPolicyLines(decisions []channelDecision, contentWidth int) []renderedL
 		}
 	}
 
-	for _, decision := range decisions {
+	appendSection := func(title string) {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, title)})
+	}
+
+	for _, signal := range reverseSignals(signals, 8) {
+		if len(lines) == 1 {
+			appendSection("Signals")
+		}
+		metaParts := []string{}
+		if kind := displaySignalKind(signal); kind != "" {
+			metaParts = append(metaParts, kind)
+		}
+		if signal.Owner != "" {
+			metaParts = append(metaParts, "@"+signal.Owner)
+		}
+		if signal.Channel != "" {
+			metaParts = append(metaParts, "#"+signal.Channel)
+		}
+		if signal.Urgency != "" {
+			metaParts = append(metaParts, "urgency "+signal.Urgency)
+		}
+		if signal.Confidence != "" {
+			metaParts = append(metaParts, "confidence "+signal.Confidence)
+		}
+		appendWrappedLine("  " + accentPill("signal", "#7C3AED") + " " + lipgloss.NewStyle().Bold(true).Render(fallbackString(signal.Title, "Office signal")))
+		if len(metaParts) > 0 {
+			appendWrappedLine("  " + muted.Render(strings.Join(metaParts, " · ")))
+		}
+		appendWrappedLine("  " + signal.Content)
+	}
+
+	if len(decisions) > 0 {
+		appendSection("Decisions")
+	}
+	for _, decision := range reverseDecisions(decisions, 8) {
 		metaParts := []string{}
 		if decision.Owner != "" {
 			metaParts = append(metaParts, "by @"+decision.Owner)
@@ -388,7 +427,7 @@ func buildPolicyLines(decisions []channelDecision, contentWidth int) []renderedL
 			metaParts = append(metaParts, "#"+decision.Channel)
 		}
 		lines = append(lines, renderedLine{Text: ""})
-		appendWrappedLine("  " + accentPill("policy", "#1264A3") + " " + lipgloss.NewStyle().Bold(true).Render(decision.Summary))
+		appendWrappedLine("  " + accentPill("policy", "#1264A3") + " " + lipgloss.NewStyle().Bold(true).Render("Decisions · "+displayDecisionSummary(decision.Summary)))
 		if len(metaParts) > 0 {
 			appendWrappedLine("  " + muted.Render(strings.Join(metaParts, " · ")))
 		}
@@ -396,7 +435,74 @@ func buildPolicyLines(decisions []channelDecision, contentWidth int) []renderedL
 			appendWrappedLine("  " + muted.Render("Why: "+decision.Reason))
 		}
 	}
+
+	watchdogs := activeWatchdogs(alerts)
+	if len(watchdogs) > 0 {
+		appendSection("Watchdogs")
+	}
+	for _, alert := range reverseWatchdogs(watchdogs, 8) {
+		metaParts := []string{}
+		if alert.Owner != "" {
+			metaParts = append(metaParts, "@"+alert.Owner)
+		}
+		if alert.Channel != "" {
+			metaParts = append(metaParts, "#"+alert.Channel)
+		}
+		if alert.Kind != "" {
+			metaParts = append(metaParts, alert.Kind)
+		}
+		if alert.Status != "" {
+			metaParts = append(metaParts, alert.Status)
+		}
+		appendWrappedLine("  " + accentPill("watchdog", "#DC2626") + " " + lipgloss.NewStyle().Bold(true).Render(fallbackString(alert.Summary, "Watchdog alert")))
+		if len(metaParts) > 0 {
+			appendWrappedLine("  " + muted.Render(strings.Join(metaParts, " · ")))
+		}
+	}
+
+	external := recentExternalActions(actions, 6)
+	if len(external) > 0 {
+		appendSection("External Actions")
+	}
+	for _, action := range external {
+		metaParts := []string{}
+		if action.Actor != "" {
+			metaParts = append(metaParts, "@"+action.Actor)
+		}
+		if action.Channel != "" {
+			metaParts = append(metaParts, "#"+action.Channel)
+		}
+		if action.Kind != "" {
+			metaParts = append(metaParts, action.Kind)
+		}
+		if action.Source != "" {
+			metaParts = append(metaParts, action.Source)
+		}
+		appendWrappedLine("  " + accentPill("action", "#0F766E") + " " + lipgloss.NewStyle().Bold(true).Render(fallbackString(action.Summary, "External action")))
+		if len(metaParts) > 0 {
+			appendWrappedLine("  " + muted.Render(strings.Join(metaParts, " · ")))
+		}
+	}
 	return lines
+}
+
+func displaySignalKind(signal channelSignal) string {
+	kind := strings.TrimSpace(signal.Kind)
+	if kind == "" {
+		return ""
+	}
+	if strings.EqualFold(kind, "directive") {
+		return "Human directive"
+	}
+	return kind
+}
+
+func displayDecisionSummary(summary string) string {
+	summary = strings.TrimSpace(summary)
+	if strings.HasPrefix(summary, "Human directed the office:") {
+		return strings.Replace(summary, "Human directed the office:", "Human directive:", 1)
+	}
+	return summary
 }
 
 func buildTaskLines(tasks []channelTask, contentWidth int) []renderedLine {
@@ -594,6 +700,37 @@ func buildCalendarLines(actions []channelAction, jobs []channelSchedulerJob, tas
 			}
 			lines = append(lines, renderedLine{Text: ""})
 			lines = append(lines, renderCalendarEventCard(event, contentWidth)...)
+		}
+	}
+	recentActionCap := len(actions)
+	if recentActionCap > 4 {
+		recentActionCap = 4
+	}
+	recentActions := make([]channelAction, 0, recentActionCap)
+	for i := len(actions) - 1; i >= 0 && len(recentActions) < recentActionCap; i-- {
+		action := actions[i]
+		channel := normalizeSidebarSlug(action.Channel)
+		if strings.TrimSpace(action.Kind) != "bridge_channel" && channel != "" && channel != normalizeSidebarSlug(activeChannel) {
+			continue
+		}
+		recentActions = append(recentActions, action)
+	}
+	if len(recentActions) > 0 {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: "  " + lipgloss.NewStyle().Bold(true).Render("Recent actions")})
+		for _, action := range recentActions {
+			metaParts := []string{}
+			if action.Actor != "" {
+				metaParts = append(metaParts, "@"+action.Actor)
+			}
+			if action.Kind != "" {
+				metaParts = append(metaParts, action.Kind)
+			}
+			if action.CreatedAt != "" {
+				metaParts = append(metaParts, prettyRelativeTime(action.CreatedAt))
+			}
+			lines = append(lines, renderedLine{Text: ""})
+			lines = append(lines, renderCalendarActionCard(action, strings.Join(metaParts, " · "), contentWidth)...)
 		}
 	}
 	return lines
@@ -1343,7 +1480,8 @@ func reverseWatchdogs(alerts []channelWatchdog, limit int) []channelWatchdog {
 func recentExternalActions(actions []channelAction, limit int) []channelAction {
 	var filtered []channelAction
 	for _, action := range actions {
-		if !strings.HasPrefix(strings.TrimSpace(action.Kind), "external_") {
+		kind := strings.TrimSpace(action.Kind)
+		if !strings.HasPrefix(kind, "external_") && kind != "bridge_channel" {
 			continue
 		}
 		filtered = append(filtered, action)

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -64,7 +64,7 @@ func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
 		case officeAppRequests:
 			lines = buildRequestLines(m.requests, contentWidth)
 		case officeAppPolicies:
-			lines = buildPolicyLines(m.decisions, contentWidth)
+			lines = buildPolicyLines(m.signals, m.decisions, m.watchdogs, m.actions, contentWidth)
 		case officeAppCalendar:
 			lines = buildCalendarLines(m.actions, m.scheduler, m.tasks, m.requests, m.activeChannel, m.members, m.calendarRange, m.calendarFilter, contentWidth)
 		case officeAppSkills:
@@ -109,7 +109,10 @@ func (m channelModel) hashMainLinesState(contentWidth int) uint64 {
 	case officeAppRequests:
 		h.addRequests(m.requests)
 	case officeAppPolicies:
+		h.addSignals(m.signals)
 		h.addDecisions(m.decisions)
+		h.addWatchdogs(m.watchdogs)
+		h.addActions(m.actions)
 	case officeAppCalendar:
 		h.addActions(m.actions)
 		h.addScheduler(m.scheduler)
@@ -335,6 +338,22 @@ func (s stateHasher) addDecisions(decisions []channelDecision) {
 		s.addBool(decision.RequiresHuman)
 		s.addBool(decision.Blocking)
 		s.add(strings.Join(decision.SignalIDs, ","))
+	}
+}
+
+func (s stateHasher) addSignals(signals []channelSignal) {
+	s.addInt(len(signals))
+	for _, signal := range signals {
+		s.add(signal.ID, signal.Source, signal.SourceRef, signal.Kind, signal.Title, signal.Content, signal.Channel, signal.Owner, signal.Confidence, signal.Urgency, signal.DedupeKey, signal.CreatedAt)
+		s.addBool(signal.RequiresHuman)
+		s.addBool(signal.Blocking)
+	}
+}
+
+func (s stateHasher) addWatchdogs(alerts []channelWatchdog) {
+	s.addInt(len(alerts))
+	for _, alert := range alerts {
+		s.add(alert.ID, alert.Kind, alert.Channel, alert.TargetType, alert.TargetID, alert.Owner, alert.Status, alert.Summary, alert.CreatedAt, alert.UpdatedAt)
 	}
 }
 

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -27,6 +27,10 @@ func joinRenderedLines(lines []renderedLine) string {
 	return strings.Join(parts, "\n")
 }
 
+func altRuneKey(r rune) tea.KeyMsg {
+	return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}, Alt: true}
+}
+
 func TestNewBrokerRequestUsesEnvTokenAtRequestTime(t *testing.T) {
 	oldEnv := os.Getenv("WUPHF_BROKER_TOKEN")
 	oldPath := brokerTokenPath
@@ -343,6 +347,139 @@ func TestOneOnOneModeBlocksOfficeCommands(t *testing.T) {
 	}
 }
 
+func TestSwitchCommandOpensChannelPicker(t *testing.T) {
+	m := newChannelModel(false)
+	m.channels = []channelInfo{
+		{Slug: "general", Name: "general", Members: []string{"ceo", "pm"}},
+		{Slug: "launch", Name: "launch", Description: "Release work", Members: []string{"ceo", "fe"}},
+	}
+
+	next, cmd := m.runCommand("/switch", "")
+	if cmd != nil {
+		t.Fatalf("expected no immediate command from /switch, got %v", cmd)
+	}
+	got := next.(channelModel)
+	if !got.picker.IsActive() || got.pickerMode != channelPickerChannels {
+		t.Fatalf("expected channel picker, got active=%v mode=%q", got.picker.IsActive(), got.pickerMode)
+	}
+	if got.notice != "Choose a channel to switch to." {
+		t.Fatalf("expected switch notice, got %q", got.notice)
+	}
+	view := stripANSI(got.picker.View())
+	if !strings.Contains(view, "Switch Channel") || !strings.Contains(view, "#launch") {
+		t.Fatalf("expected switch picker contents, got %q", view)
+	}
+}
+
+func TestSwitchAliasSelectsChannel(t *testing.T) {
+	m := newChannelModel(false)
+	m.activeChannel = "general"
+	m.channels = []channelInfo{
+		{Slug: "general", Name: "general", Members: []string{"ceo", "pm"}},
+		{Slug: "launch", Name: "launch", Description: "Release work", Members: []string{"ceo", "fe"}},
+	}
+	m.picker = tui.NewPicker("Switch Channel", m.buildChannelPickerOptions())
+	m.picker.SetActive(true)
+	m.pickerMode = channelPickerChannels
+	m.messages = []brokerMessage{{ID: "msg-1", Content: "hello"}}
+	m.members = []channelMember{{Slug: "ceo"}}
+	m.replyToID = "msg-1"
+	m.threadPanelOpen = true
+	m.threadPanelID = "thread-1"
+
+	next, cmd := m.Update(tui.PickerSelectMsg{Value: "switch:launch", Label: "#launch"})
+	if cmd == nil {
+		t.Fatal("expected channel switch polling command")
+	}
+	got := next.(channelModel)
+	if got.activeChannel != "launch" {
+		t.Fatalf("expected active channel launch, got %q", got.activeChannel)
+	}
+	if got.lastID != "" || len(got.messages) != 0 || len(got.members) != 0 {
+		t.Fatalf("expected channel state to reset on switch, got lastID=%q messages=%d members=%d", got.lastID, len(got.messages), len(got.members))
+	}
+	if got.replyToID != "" || got.threadPanelOpen || got.threadPanelID != "" {
+		t.Fatalf("expected thread context to clear on switch, got replyToID=%q threadOpen=%v threadID=%q", got.replyToID, got.threadPanelOpen, got.threadPanelID)
+	}
+	if got.notice != "Switched to #launch" {
+		t.Fatalf("expected switch notice, got %q", got.notice)
+	}
+	if got.picker.IsActive() || got.pickerMode != channelPickerNone {
+		t.Fatalf("expected picker to close after switch, got active=%v mode=%q", got.picker.IsActive(), got.pickerMode)
+	}
+}
+
+func TestBuildSwitchChannelPickerOptionsOnlyIncludesSwitchTargets(t *testing.T) {
+	m := newChannelModel(false)
+	m.channels = []channelInfo{
+		{Slug: "general", Name: "general", Members: []string{"ceo", "pm"}},
+		{Slug: "launch", Name: "launch", Description: "Release work", Members: []string{"ceo", "fe"}},
+	}
+
+	options := m.buildSwitchChannelPickerOptions()
+	if len(options) != 2 {
+		t.Fatalf("expected only switch targets, got %+v", options)
+	}
+	for _, option := range options {
+		if !strings.HasPrefix(option.Value, "switch:") {
+			t.Fatalf("expected switch-only values, got %+v", option)
+		}
+	}
+}
+
+func TestTypingSwitchShortcutOpensChannelPicker(t *testing.T) {
+	t.Setenv("WUPHF_API_KEY", "test-key")
+	m := newChannelModel(false)
+	m.channels = []channelInfo{
+		{Slug: "general", Name: "general", Members: []string{"ceo", "pm"}},
+		{Slug: "launch", Name: "launch", Description: "Release work", Members: []string{"ceo", "fe"}},
+	}
+	m.input = []rune("/switch")
+	m.inputPos = len(m.input)
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	got := next.(channelModel)
+
+	if !got.picker.IsActive() || got.pickerMode != channelPickerChannels {
+		t.Fatalf("expected typed /switch shortcut to open picker, got active=%v mode=%q", got.picker.IsActive(), got.pickerMode)
+	}
+	if got.inputPos != 0 || len(got.input) != 0 {
+		t.Fatalf("expected composer to clear once picker opens, got input=%q pos=%d", string(got.input), got.inputPos)
+	}
+	view := stripANSI(got.picker.View())
+	if !strings.Contains(view, "#launch") {
+		t.Fatalf("expected switch picker contents, got %q", view)
+	}
+	if strings.Contains(view, "Remove #launch") {
+		t.Fatalf("expected switch shortcut picker to hide remove actions, got %q", view)
+	}
+}
+
+func TestPickerTypingDoesNotAppendToComposer(t *testing.T) {
+	t.Setenv("WUPHF_API_KEY", "test-key")
+	m := newChannelModel(false)
+	m.channels = []channelInfo{
+		{Slug: "general", Name: "general", Members: []string{"ceo", "pm"}},
+		{Slug: "launch", Name: "launch", Description: "Release work", Members: []string{"ceo", "fe"}},
+		{Slug: "ops", Name: "ops", Members: []string{"ceo"}},
+	}
+	m.input = []rune("/switch")
+	m.inputPos = len(m.input)
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	got := next.(channelModel)
+	next, _ = got.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	got = next.(channelModel)
+
+	if string(got.input) != "" || got.inputPos != 0 {
+		t.Fatalf("expected picker input to leave composer untouched, got input=%q pos=%d", string(got.input), got.inputPos)
+	}
+	view := stripANSI(got.picker.View())
+	if !strings.Contains(view, "#launch") || strings.Contains(view, "#general") {
+		t.Fatalf("expected picker query to filter channels, got %q", view)
+	}
+}
+
 func TestOneOnOneCommandOpensModePicker(t *testing.T) {
 	m := newChannelModel(false)
 
@@ -478,7 +615,6 @@ func TestChannelCreateDoneSwitchesToNewChannel(t *testing.T) {
 }
 
 func TestResolveInitialOfficeAppFallsBackToMessages(t *testing.T) {
-	t.Skip("skipped: test needs update after thread/policies/calendar refactors")
 	if got := resolveInitialOfficeApp("insights"); got != officeAppPolicies {
 		t.Fatalf("expected policies app, got %q", got)
 	}
@@ -487,6 +623,56 @@ func TestResolveInitialOfficeAppFallsBackToMessages(t *testing.T) {
 	}
 	if got := resolveInitialOfficeApp("not-real"); got != officeAppMessages {
 		t.Fatalf("expected invalid app to fall back to messages, got %q", got)
+	}
+}
+
+func TestDisplaySignalKindUsesHumanDirectiveLabel(t *testing.T) {
+	got := displaySignalKind(channelSignal{Kind: "directive", Source: "human"})
+	if got != "Human directive" {
+		t.Fatalf("expected human directive label, got %q", got)
+	}
+	if got := displaySignalKind(channelSignal{Kind: "risk", Source: "nex_insights"}); got != "risk" {
+		t.Fatalf("expected raw signal kind for non-human signal, got %q", got)
+	}
+}
+
+func TestRecentExternalActionsIncludesBridgeChannel(t *testing.T) {
+	actions := []channelAction{
+		{ID: "action-1", Kind: "note_internal"},
+		{ID: "action-2", Kind: "bridge_channel"},
+		{ID: "action-3", Kind: "external_webhook"},
+	}
+	got := recentExternalActions(actions, 10)
+	if len(got) != 2 {
+		t.Fatalf("expected bridge and external actions, got %d", len(got))
+	}
+	if got[0].Kind != "external_webhook" || got[1].Kind != "bridge_channel" {
+		t.Fatalf("expected reverse chronological bridge/external actions, got %#v", got)
+	}
+}
+
+func TestDisplayDecisionSummaryUsesHumanDirectiveLabel(t *testing.T) {
+	got := displayDecisionSummary("Human directed the office:\n- tighten scope")
+	if !strings.Contains(got, "Human directive:") {
+		t.Fatalf("expected human directive heading, got %q", got)
+	}
+	if got := displayDecisionSummary("Open a frontend follow-up."); got != "Open a frontend follow-up." {
+		t.Fatalf("expected non-human decision summary to remain unchanged, got %q", got)
+	}
+}
+
+func TestCalendarRecentActionsIncludeBridgeChannel(t *testing.T) {
+	lines := buildCalendarLines([]channelAction{
+		{ID: "action-1", Kind: "human_directive", Channel: "general", Summary: "Human directed the office:", Actor: "you"},
+		{ID: "action-2", Kind: "bridge_channel", Channel: "launch", Summary: "Use the sharper product narrative.", Actor: "ceo"},
+		{ID: "action-3", Kind: "task_created", Channel: "general", Summary: "Tighten v1 scope", Actor: "ceo"},
+	}, nil, nil, nil, "general", nil, calendarRangeWeek, "", 90)
+	view := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(view, "bridge_channel") {
+		t.Fatalf("expected calendar recent actions to include bridge_channel, got %q", view)
+	}
+	if !strings.Contains(view, "task_created") {
+		t.Fatalf("expected calendar recent actions to include task_created, got %q", view)
 	}
 }
 
@@ -679,6 +865,24 @@ func TestBuildChannelPickerOptionsUsesChannelDescriptions(t *testing.T) {
 	}
 	if !strings.Contains(options[0].Description, "2 members") {
 		t.Fatalf("expected member count in picker description, got %q", options[0].Description)
+	}
+}
+
+func TestBuildSwitchChannelPickerOptionsExcludeRemoveActions(t *testing.T) {
+	m := newChannelModel(false)
+	m.channels = []channelInfo{
+		{Slug: "general", Name: "general", Description: "Company-wide coordination", Members: []string{"ceo", "pm"}},
+		{Slug: "launch", Name: "launch", Description: "Launch planning", Members: []string{"ceo", "fe"}},
+	}
+
+	options := m.buildSwitchChannelPickerOptions()
+	if len(options) != 2 {
+		t.Fatalf("expected only switch entries, got %d options", len(options))
+	}
+	for _, option := range options {
+		if !strings.HasPrefix(option.Value, "switch:") {
+			t.Fatalf("expected only switch actions, got %+v", option)
+		}
 	}
 }
 
@@ -1070,6 +1274,54 @@ func TestChannelDoctorDoneShowsDoctorCard(t *testing.T) {
 	}
 }
 
+func TestOfficeSlashAutocompleteIncludesAgentsInVisibleMatches(t *testing.T) {
+	t.Setenv("WUPHF_API_KEY", "test-key")
+	m := newChannelModel(false)
+	m.input = []rune("/")
+	m.inputPos = len(m.input)
+	m.updateInputOverlays()
+
+	view := stripANSI(m.autocomplete.View())
+	if !strings.Contains(view, "/agents") {
+		t.Fatalf("expected /agents in visible office autocomplete, got %q", view)
+	}
+}
+
+func TestOfficeViewRendersSlashAutocompletePopup(t *testing.T) {
+	t.Setenv("WUPHF_API_KEY", "test-key")
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 40
+	m.input = []rune("/")
+	m.inputPos = len(m.input)
+	m.updateInputOverlays()
+
+	view := stripANSI(m.View())
+	if !strings.Contains(view, "/integrate") || !strings.Contains(view, "/agents") {
+		t.Fatalf("expected office view to render slash popup, got %q", view)
+	}
+}
+
+func TestOneOnOneSlashAutocompleteShowsResetAndHidesChannels(t *testing.T) {
+	t.Setenv("WUPHF_API_KEY", "test-key")
+	m := newChannelModel(false)
+	m.sessionMode = team.SessionModeOneOnOne
+	m.oneOnOneAgent = "pm"
+	m.sidebarCollapsed = true
+	m.refreshSlashCommands()
+	m.input = []rune("/")
+	m.inputPos = len(m.input)
+	m.updateInputOverlays()
+
+	view := stripANSI(m.autocomplete.View())
+	if !strings.Contains(view, "/reset") {
+		t.Fatalf("expected /reset in visible 1:1 autocomplete, got %q", view)
+	}
+	if strings.Contains(view, "/channels") || strings.Contains(view, "/tasks") || strings.Contains(view, "/threads") {
+		t.Fatalf("expected blocked 1:1 commands to be hidden from autocomplete, got %q", view)
+	}
+}
+
 func TestSlashAutocompleteEnterSubmitsSelectedCommand(t *testing.T) {
 	t.Skip("skipped: pre-existing CI environment issue")
 	m := newChannelModel(false)
@@ -1159,6 +1411,71 @@ func TestMentionAutocompleteFiltersAgents(t *testing.T) {
 	}
 	if strings.Contains(view, "@cmo") {
 		t.Fatalf("expected non-matching mention to be filtered out, got %q", view)
+	}
+}
+
+func TestComposerSupportsVimStyleWordMotions(t *testing.T) {
+	t.Setenv("WUPHF_API_KEY", "test-key")
+	m := newChannelModel(false)
+	m.input = []rune("ship landing page")
+	m.inputPos = len(m.input)
+
+	next, _ := m.Update(altRuneKey('b'))
+	got := next.(channelModel)
+	if got.inputPos != len([]rune("ship landing ")) {
+		t.Fatalf("expected alt+b to jump to previous word, got %d", got.inputPos)
+	}
+
+	next, _ = got.Update(altRuneKey('b'))
+	got = next.(channelModel)
+	if got.inputPos != len([]rune("ship ")) {
+		t.Fatalf("expected second alt+b to jump to prior word, got %d", got.inputPos)
+	}
+
+	next, _ = got.Update(altRuneKey('w'))
+	got = next.(channelModel)
+	if got.inputPos != len([]rune("ship landing ")) {
+		t.Fatalf("expected alt+w to jump forward a word, got %d", got.inputPos)
+	}
+
+	next, _ = got.Update(altRuneKey('0'))
+	got = next.(channelModel)
+	if got.inputPos != 0 {
+		t.Fatalf("expected alt+0 to jump to start, got %d", got.inputPos)
+	}
+
+	next, _ = got.Update(altRuneKey('$'))
+	got = next.(channelModel)
+	if got.inputPos != len(got.input) {
+		t.Fatalf("expected alt+$ to jump to end, got %d", got.inputPos)
+	}
+}
+
+func TestThreadComposerSupportsVimStyleWordMotions(t *testing.T) {
+	t.Setenv("WUPHF_API_KEY", "test-key")
+	m := newChannelModel(false)
+	m.threadPanelOpen = true
+	m.threadPanelID = "msg-1"
+	m.focus = focusThread
+	m.threadInput = []rune("thread reply draft")
+	m.threadInputPos = len(m.threadInput)
+
+	next, _ := m.Update(altRuneKey('b'))
+	got := next.(channelModel)
+	if got.threadInputPos != len([]rune("thread reply ")) {
+		t.Fatalf("expected thread alt+b to jump to previous word, got %d", got.threadInputPos)
+	}
+
+	next, _ = got.Update(altRuneKey('0'))
+	got = next.(channelModel)
+	if got.threadInputPos != 0 {
+		t.Fatalf("expected thread alt+0 to jump to start, got %d", got.threadInputPos)
+	}
+
+	next, _ = got.Update(altRuneKey('$'))
+	got = next.(channelModel)
+	if got.threadInputPos != len(got.threadInput) {
+		t.Fatalf("expected thread alt+$ to jump to end, got %d", got.threadInputPos)
 	}
 }
 
@@ -1612,7 +1929,7 @@ func TestChannelResetDoneImmediatelyRehydratesDirectMode(t *testing.T) {
 	}
 
 	view := stripANSI(got.View())
-	if !strings.Contains(view, "Direct 1:1 with Backend Engineer.") {
+	if !strings.Contains(view, "Direct session reset. Agent pane reloaded in place.") {
 		t.Fatalf("expected direct-session empty state, got %q", view)
 	}
 	if strings.Contains(view, "Welcome to The WUPHF Office.") {

--- a/docs/blueprints/00-FULL-SYSTEM-ANALYSIS.md
+++ b/docs/blueprints/00-FULL-SYSTEM-ANALYSIS.md
@@ -1,0 +1,24 @@
+# WUPHF vs CC-agent: Full System Analysis & Strategy
+
+## 1. Product Philosophy: The "Office" vs The "Tool"
+WUPHF's strength is **Coordination**. CC-agent's strength is **Iteration**.
+- **WUPHF Identity:** A shared TUI where agents talk in channels. It feels "alive."
+- **CC-agent Identity:** A surgical instrument for code. It feels "precise."
+- **The Synthesis:** WUPHF should remain an Office, but the "Teammates" should use CC-agent's professional tools.
+
+## 2. Key Gaps in WUPHF
+- **Execution:** WUPHF agents can "search Nex" but they can't effectively `grep` code or `edit` files locally.
+- **Rendering:** Long tool outputs (build logs, large file reads) flood the Bubble Tea stream, making it unreadable.
+- **Isolation:** If two agents work on the same repo, they overwrite each other's files.
+- **Context:** Long office threads eventually result in "context window exceeded" errors with no recovery path.
+
+## 3. High-Value "Borrow" List from CC-agent
+- **Summary Rendering:** Show tool results as 1-line "folded" summaries in the TUI.
+- **Fuzzy Pickers:** Use searchable lists for switching channels or mentioning agents.
+- **Git Worktrees:** Create a temporary `/tmp/wuphf-worktree-...` for an agent to work in isolation.
+- **Reactive Compaction:** Automatically summarize old messages when the window is 80% full.
+
+## 4. "Do Not Copy" List
+- **Ink/React TUI:** WUPHF stays in Go/Bubble Tea for performance and binary simplicity.
+- **Solo-First UX:** WUPHF must prioritize "Public" work in channels over private agent-only side-talk.
+- **Hidden Tasks:** Keep work in visible TMUX panes, but summarize the *results* in the TUI.

--- a/docs/blueprints/01-PR-ERGONOMICS.md
+++ b/docs/blueprints/01-PR-ERGONOMICS.md
@@ -1,0 +1,24 @@
+# PR Blueprint 01: Snappy Office Ergonomics & Vim Motions
+
+## 1. Objective
+Make the TUI as fast and keyboard-friendly as CC-agent. Users should never have to take their hands off the home row to mention an agent, switch a channel, or edit a message.
+
+## 2. Key Features
+- **Fuzzy Picker Component:** A reusable Bubble Tea component for filtering lists (Agents, Channels, Commands).
+- **Vim Motions for Input:** Basic `h/j/k/l`, `w/b`, `0/$` support in the message input field.
+- **Agent Presence Summary:** A visual indicator of "Who is thinking" and "What are they doing" (e.g., "FE Engineer • Reading internal/tui/model.go").
+
+## 3. Targeted Files
+- `internal/tui/picker.go` (New): Reusable list filter.
+- `internal/tui/channel.go`: Integrate the picker for `@` mentions and `/` commands.
+- `cmd/wuphf/channel_member_draft.go`: Add Vim-style navigation to the text input.
+- `internal/tui/statusbar.go`: Enhance to show real-time agent activity summaries.
+
+## 4. Implementation Details
+- **Fuzzy Matching:** Use a simple Go fuzzy matching library (like `sahilm/fuzzy`) for the picker.
+- **Status Summary:** The `StreamModel` already has access to agent phases (e.g., `PhaseExecuteTool`). Render these as a "Currently Doing" line in the status bar or a dedicated "Thinking" pane.
+
+## 5. Validation
+- Press `@` in the main input and fuzzy-search for an agent.
+- Navigate the message input field using Vim motions.
+- Ensure the status bar updates when an agent starts a tool operation.

--- a/docs/blueprints/01a-PR-PICKER-COMPONENT.md
+++ b/docs/blueprints/01a-PR-PICKER-COMPONENT.md
@@ -1,0 +1,21 @@
+# PR Blueprint 01a: Fuzzy Picker Component
+
+## 1. Objective
+Create a reusable "Fuzzy Picker" Bubble Tea component. This will not yet be integrated into the UI, but will serve as the foundation for channel and agent switching.
+
+## 2. Key Features
+- **Fuzzy Filtering:** Takes a list of strings and a search query, returns filtered results.
+- **Selection UI:** A simple vertical list with a cursor and "Enter" to select.
+- **Keybindings:** `Up/Down` for navigation, `Enter` for selection, `Esc` to close.
+
+## 3. Targeted Files
+- `internal/tui/picker.go` (New): Implementation of the picker model and update loop.
+
+## 4. Implementation Details
+- Use a simple Go library like `sahilm/fuzzy` for matching.
+- The component should be a sub-model that can be embedded in the main `ChannelModel`.
+- Focus on the `Model`, `Update`, and `View` functions for the list filtering specifically.
+
+## 5. Validation
+- Run unit tests in `internal/tui/picker_test.go` to verify fuzzy filtering logic.
+- Verify that the cursor moves correctly through the list.

--- a/docs/blueprints/01b-PR-CHANNEL-PICKER.md
+++ b/docs/blueprints/01b-PR-CHANNEL-PICKER.md
@@ -1,0 +1,20 @@
+# PR Blueprint 01b: Channel Picker Integration
+
+## 1. Objective
+Integrate the Fuzzy Picker from 01a into the main Channel TUI to allow fast switching between channels using the `/switch` command.
+
+## 2. Key Features
+- **Trigger:** Typing `/switch ` (with a space) or `/s ` opens the picker.
+- **Populate:** Load the list of active channel names from the Broker.
+- **Action:** Selecting a channel triggers the `switch:` message currently handled in `channel.go`.
+
+## 3. Targeted Files
+- `internal/tui/channel.go`: Update the command parser to trigger the picker.
+- `cmd/wuphf/channel.go`: Handle the result of the picker selection.
+
+## 4. Implementation Details
+- Connect the `picker.Model` to the `ChannelModel`.
+- Ensure the main chat input is disabled while the picker is active.
+
+## 5. Validation
+- Type `/switch`, search for a channel, and press Enter. Verify the UI switches to that channel.

--- a/docs/blueprints/02-PR-CODING-TOOLS.md
+++ b/docs/blueprints/02-PR-CODING-TOOLS.md
@@ -1,0 +1,24 @@
+# PR Blueprint 02: High-Rigor Coding Tools & Summary Rendering
+
+## 1. Objective
+Equip agents with professional local execution tools and ensure the office channel remains readable even during heavy code output.
+
+## 2. Key Features
+- **Local Toolset:** Implement robust `read_file`, `grep_search`, `glob`, `write_file`, and `bash` tools.
+- **Summary Rendering (Folded Output):** Large tool results (e.g., build logs, 50-line file reads) must be "folded" in the TUI by default. Show a 1-line summary like `[Tool] bash: Exit 0 (124 lines)` with an option to expand.
+- **Task Output to Disk:** Every tool execution should log its full raw output to `~/.wuphf/office/tasks/<id>/output.log`.
+
+## 3. Targeted Files
+- `internal/agent/tools.go`: Add the new local tools.
+- `internal/tui/stream.go`: Implement the "folded" rendering logic for tool results.
+- `internal/agent/loop.go`: Ensure task outputs are captured and persisted to disk.
+
+## 4. Implementation Details
+- **Bash Tool:** Must support a "WorkingDirectory" parameter. Use `os/exec` and capture both `stdout` and `stderr`.
+- **Folding Logic:** If the tool result is >10 lines or >500 characters, truncate the display in the TUI but keep the full content accessible (e.g., via a detail view or by reading the task log).
+- **Summary Generation:** For `grep`, show "Found 12 matches in 3 files." For `bash`, show the exit code and first/last line of output.
+
+## 5. Validation
+- Ask an agent to "Grep for 'BubbleTea' in internal/tui". Verify the TUI shows a clean summary, not 50 lines of matches.
+- Ask an agent to "Read internal/agent/tools.go". Verify it summarizes the file content.
+- Check that the full output exists on disk.

--- a/docs/blueprints/03-PR-WORKTREE-ISOLATION.md
+++ b/docs/blueprints/03-PR-WORKTREE-ISOLATION.md
@@ -1,0 +1,24 @@
+# PR Blueprint 03: Worktree Isolation & Parallel Swarms
+
+## 1. Objective
+Enable specialists to work in parallel "labs" (isolated directories) without corrupting the main workspace or conflicting with each other.
+
+## 2. Key Features
+- **Git Worktree Support:** When a task is assigned, the agent should have the option to spin up a temporary worktree.
+- **Direct Agent-to-Agent Messaging (`SendMessage`):** A tool that allows one agent to signal another (e.g., "BE Engineer tells FE: The user-auth endpoint is ready").
+- **Task Rigor:** Tasks should have IDs and be trackable in the status bar (e.g., "2 Tasks Running").
+
+## 3. Targeted Files
+- `internal/agent/delegator.go`: Handle the logic for creating/tearing down worktrees.
+- `internal/agent/tools.go`: Add `send_message` (inter-agent).
+- `internal/teammcp/server.go`: Expose task counts and isolation status to the agents.
+
+## 4. Implementation Details
+- **Worktree Management:** Use `git worktree add /tmp/wuphf-task-<id> <branch>`. Ensure the directory is deleted after the task is "Committed" or "Canceled."
+- **Isolation Scope:** Tools like `Read` and `Write` must respect the `CWD` (Current Working Directory) of the agent's worktree.
+- **Swarm ID:** Each isolated task should have a unique ID that correlates to the tmux pane and the disk logs.
+
+## 5. Validation
+- Trigger a "Large Feature" that requires the FE and BE engineers to work simultaneously.
+- Verify they are working in separate `/tmp` directories.
+- Verify they can use `send_message` to coordinate their progress.

--- a/docs/blueprints/04-PR-OFFICE-COMPACTION.md
+++ b/docs/blueprints/04-PR-OFFICE-COMPACTION.md
@@ -1,0 +1,23 @@
+# PR Blueprint 04: Office Memory & Reactive Compaction
+
+## 1. Objective
+Prevent office channels from crashing due to context window limits while ensuring agents "remember" the organizational context.
+
+## 2. Key Features
+- **Reactive Compaction:** Automatically summarize the oldest 50% of the conversation when the context window is 80% full.
+- **Office Insights:** The compaction summary should be posted as a special "Office Insight" message in the channel so humans and agents stay aligned on what was "archived."
+- **Persistent Memory:** Summaries should be saved to the Nex-backed organizational memory.
+
+## 3. Targeted Files
+- `internal/agent/loop.go`: Monitor token usage and trigger the summarization tool.
+- `internal/agent/prompts.go`: Define the "Compaction Prompt" (e.g., "Summarize the mission, key decisions, and current blockers of this thread").
+- `internal/chat/router.go`: Handle the injection of "Office Insights" back into the stream.
+
+## 4. Implementation Details
+- **Token Counting:** Use a simple heuristic or a library (like `tiktoken-go`) to estimate token count before each turn.
+- **Archival:** When compacting, the agent should produce a "State of the Union" summary that becomes the new starting context for the next turn.
+
+## 5. Validation
+- Force a compaction by lowering the threshold.
+- Verify the agent can still answer questions about a "decision" made 100 turns ago using the archived summary.
+- Ensure the "Office Insight" appears in the TUI stream.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/creack/pty/v2 v2.0.1
 	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.4.1
+	github.com/sahilm/fuzzy v0.1.1
 	google.golang.org/genai v1.51.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/sahilm/fuzzy v0.1.1 h1:ceu5RHF8DGgoi+/dR5PsECjCDH1BE3Fnmpo7aVXOdRA=
+github.com/sahilm/fuzzy v0.1.1/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -2,7 +2,10 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -42,6 +45,8 @@ type AgentLoop struct {
 	cancelFunc        context.CancelFunc
 	taskHadError      bool
 	collectedInsights []string
+	taskLogRoot       string
+	lastCompactionAt  int
 	mu                sync.Mutex
 }
 
@@ -68,6 +73,7 @@ func NewAgentLoop(
 		gossipLayer:        gossipLayer,
 		credibilityTracker: credibilityTracker,
 		eventHandlers:      make(map[EventName][]EventHandler),
+		taskLogRoot:        defaultTaskLogRoot(),
 	}
 }
 
@@ -233,6 +239,8 @@ func (l *AgentLoop) buildContext() error {
 	// Drain follow-up message and append as user entry.
 	if msg, ok := l.queues.DrainFollowUp(slug); ok {
 		l.state.CurrentTask = msg
+		l.state.TaskID = nextTaskID(slug)
+		l.lastCompactionAt = 0
 		l.sessions.Append(l.state.SessionID, SessionEntry{
 			Type:    "user",
 			Content: msg,
@@ -300,6 +308,7 @@ func (l *AgentLoop) streamLLM() error {
 		l.emit(EventError, l.state.Error)
 		return err
 	}
+	entries = l.prepareEntriesForStreaming(entries)
 
 	messages := entriesToMessages(entries)
 
@@ -444,6 +453,7 @@ func (l *AgentLoop) executeTool() error {
 
 	if err != nil {
 		tc.Error = err.Error()
+		l.emit(EventToolResult, err.Error())
 		l.sessions.Append(l.state.SessionID, SessionEntry{
 			Type:    "tool_result",
 			Content: err.Error(),
@@ -455,6 +465,7 @@ func (l *AgentLoop) executeTool() error {
 		l.taskHadError = true
 	} else {
 		tc.Result = result
+		l.emit(EventToolResult, result)
 		l.sessions.Append(l.state.SessionID, SessionEntry{
 			Type:    "tool_result",
 			Content: result,
@@ -470,6 +481,7 @@ func (l *AgentLoop) executeTool() error {
 			}
 		}
 	}
+	l.logToolExecution(*tc)
 
 	l.pendingToolCall = nil
 	return nil
@@ -499,6 +511,7 @@ func (l *AgentLoop) handleDone() error {
 	}
 
 	l.state.CurrentTask = ""
+	l.state.TaskID = ""
 	l.setPhase(PhaseDone)
 	l.emit(EventDone)
 	return nil
@@ -566,4 +579,98 @@ func entriesToMessages(entries []SessionEntry) []Message {
 		}
 	}
 	return msgs
+}
+
+func (l *AgentLoop) prepareEntriesForStreaming(entries []SessionEntry) []SessionEntry {
+	if !shouldCompactEntries(entries) {
+		l.lastCompactionAt = 0
+		return entries
+	}
+	if l.lastCompactionAt == len(entries) {
+		return entries
+	}
+
+	prefix, archived, recent := splitEntriesForCompaction(entries)
+	summary := buildOfficeInsightSummary(archived)
+	if len(archived) == 0 || strings.TrimSpace(summary) == "" {
+		return entries
+	}
+
+	summaryEntry := SessionEntry{
+		Type:    "system",
+		Content: summary,
+		Metadata: map[string]any{
+			"officeInsight":   true,
+			"archivedEntries": len(archived),
+			"taskId":          l.state.TaskID,
+		},
+	}
+	if stored, err := l.sessions.Append(l.state.SessionID, summaryEntry); err == nil {
+		summaryEntry = stored
+	}
+
+	l.lastCompactionAt = len(entries)
+	l.emit(EventThinking, "Context nearing capacity; archived older context into an Office Insight.")
+	l.rememberOfficeInsight(summary)
+
+	compacted := make([]SessionEntry, 0, len(prefix)+1+len(recent))
+	compacted = append(compacted, prefix...)
+	compacted = append(compacted, summaryEntry)
+	compacted = append(compacted, recent...)
+	return compacted
+}
+
+func (l *AgentLoop) rememberOfficeInsight(summary string) {
+	tool, ok := l.tools.Get("nex_remember")
+	if !ok {
+		return
+	}
+
+	content := strings.TrimSpace(summary)
+	if content == "" {
+		return
+	}
+
+	go func() {
+		_, _ = tool.Execute(map[string]any{
+			"content": content,
+			"tags":    []string{"office-insight", "compaction"},
+		}, context.Background(), func(string) {})
+	}()
+}
+
+func (l *AgentLoop) logToolExecution(call ToolCall) {
+	taskID := strings.TrimSpace(l.state.TaskID)
+	if taskID == "" {
+		taskID = "adhoc"
+	}
+
+	dir := filepath.Join(l.taskLogRoot, taskID)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return
+	}
+
+	path := filepath.Join(dir, "output.log")
+	record := map[string]any{
+		"task_id":      taskID,
+		"agent_slug":   l.state.Config.Slug,
+		"tool_name":    call.ToolName,
+		"params":       call.Params,
+		"result":       call.Result,
+		"error":        call.Error,
+		"started_at":   call.StartedAt,
+		"completed_at": call.CompletedAt,
+	}
+	line, err := json.Marshal(record)
+	if err != nil {
+		return
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	_, _ = f.Write(append(line, '\n'))
 }

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -2,6 +2,9 @@ package agent
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -290,12 +293,16 @@ func TestToolCallCycle(t *testing.T) {
 	if err := loop.Tick(); err != nil {
 		t.Fatalf("tick 1: %v", err)
 	}
+	state := loop.GetState()
+	if state.TaskID == "" {
+		t.Fatal("expected task ID after follow-up was drained")
+	}
 
 	// Tick 2: build_context → stream_llm (yields tool_call)
 	if err := loop.Tick(); err != nil {
 		t.Fatalf("tick 2: %v", err)
 	}
-	state := loop.GetState()
+	state = loop.GetState()
 	if state.Phase != PhaseStreamLLM {
 		t.Fatalf("expected stream_llm, got %s", state.Phase)
 	}
@@ -354,6 +361,108 @@ func TestToolCallCycle(t *testing.T) {
 	}
 	if !hasToolResult {
 		t.Error("expected tool_result entry with 'echo: hi'")
+	}
+}
+
+func TestToolCallCycleWritesTaskOutputLog(t *testing.T) {
+	t.Setenv(taskLogRootEnv, t.TempDir())
+
+	dir := t.TempDir()
+	sessions := NewSessionStoreAt(dir)
+	tools := NewToolRegistry()
+	queues := NewMessageQueues()
+
+	tools.Register(AgentTool{
+		Name:        "echo",
+		Description: "Echoes input",
+		Schema: map[string]any{
+			"type":     "object",
+			"required": []any{"text"},
+			"properties": map[string]any{
+				"text": map[string]any{"type": "string"},
+			},
+		},
+		Execute: func(params map[string]any, ctx context.Context, onUpdate func(string)) (string, error) {
+			return "echo: " + params["text"].(string), nil
+		},
+	})
+
+	loop := NewAgentLoop(AgentConfig{
+		Slug:  "logger",
+		Name:  "Logger",
+		Tools: []string{"echo"},
+	}, tools, sessions, queues, mockToolCallStreamFn("echo", map[string]any{"text": "hi"}), nil, nil)
+
+	queues.FollowUp("logger", "call echo")
+	loop.Start()
+
+	if err := loop.Tick(); err != nil {
+		t.Fatalf("tick 1: %v", err)
+	}
+	taskID := loop.GetState().TaskID
+	if taskID == "" {
+		t.Fatal("expected task ID after build context")
+	}
+
+	for i := 0; i < 4; i++ {
+		if err := loop.Tick(); err != nil {
+			t.Fatalf("tick %d: %v", i+2, err)
+		}
+	}
+
+	logPath := filepath.Join(os.Getenv(taskLogRootEnv), taskID, "output.log")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read output log: %v", err)
+	}
+	text := string(data)
+	if !strings.Contains(text, `"tool_name":"echo"`) {
+		t.Fatalf("expected tool log to contain tool name, got %q", text)
+	}
+	if !strings.Contains(text, `"result":"echo: hi"`) {
+		t.Fatalf("expected tool log to contain raw result, got %q", text)
+	}
+}
+
+func TestStreamLLMCompactsOldContext(t *testing.T) {
+	t.Setenv(compactionTokenLimitEnv, "80")
+
+	loop, _ := newTestLoop(t, mockStreamFn("ok"))
+	loop.queues.FollowUp("test-agent", "summarize prior work")
+	loop.Start()
+
+	if err := loop.Tick(); err != nil {
+		t.Fatalf("tick 1: %v", err)
+	}
+
+	state := loop.GetState()
+	for i := 0; i < 12; i++ {
+		if _, err := loop.sessions.Append(state.SessionID, SessionEntry{
+			Type:    "assistant",
+			Content: strings.Repeat("history line ", 12),
+		}); err != nil {
+			t.Fatalf("append history %d: %v", i, err)
+		}
+	}
+
+	if err := loop.Tick(); err != nil {
+		t.Fatalf("tick 2: %v", err)
+	}
+
+	entries, err := loop.sessions.GetHistory(state.SessionID, 0, "")
+	if err != nil {
+		t.Fatalf("get history: %v", err)
+	}
+
+	found := false
+	for _, entry := range entries {
+		if entry.Type == "system" && strings.Contains(entry.Content, "Office Insight") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected compaction to persist an Office Insight system entry")
 	}
 }
 

--- a/internal/agent/prompts.go
+++ b/internal/agent/prompts.go
@@ -85,3 +85,30 @@ Rules:
 6. Debate ideas and correct mistakes you notice — silence is not helpful.`,
 		specialist.Name, strings.Join(specialist.Expertise, ", "), specialist.Slug)
 }
+
+// BuildOfficeCompactionPrompt generates instructions for summarizing archived office context.
+func BuildOfficeCompactionPrompt(archivedThread string) string {
+	return fmt.Sprintf(`Summarize the archived portion of this office thread into one "Office Insight" note.
+
+Output requirements:
+- Plain text only.
+- Start with a one-line mission summary.
+- Then capture key decisions, current blockers, and open follow-ups.
+- Keep concrete names, owners, channels, tasks, and deadlines when present.
+- Prefer compression over narration. Do not repeat raw logs.
+
+Archived thread:
+%s`, strings.TrimSpace(archivedThread))
+}
+
+// BuildCompactionPrompt returns the prompt used when older office context needs
+// to be compressed into a durable state-of-the-union summary.
+func BuildCompactionPrompt() string {
+	return `Summarize the archived portion of this office thread.
+
+Output requirements:
+- Capture the mission, key decisions, current blockers, open owners, and any human commitments.
+- Preserve facts the next turn would need in order to continue the work without re-reading the archive.
+- Keep it concise and operational. Prefer concrete nouns, owners, and statuses over narrative filler.
+- Call out anything that should be remembered long-term as an Office Insight.`
+}

--- a/internal/agent/prompts_test.go
+++ b/internal/agent/prompts_test.go
@@ -57,3 +57,28 @@ func TestBuildTeamLeadPromptMentionsAllAgents(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildOfficeCompactionPrompt(t *testing.T) {
+	prompt := BuildOfficeCompactionPrompt("PM decided to ship the launch page on Friday.")
+	if !strings.Contains(prompt, "Office Insight") {
+		t.Fatal("expected Office Insight instructions in compaction prompt")
+	}
+	if !strings.Contains(prompt, "mission summary") {
+		t.Fatal("expected mission-summary guidance in compaction prompt")
+	}
+	if !strings.Contains(prompt, "key decisions, current blockers, and open follow-ups") {
+		t.Fatal("expected compaction sections in prompt")
+	}
+	if !strings.Contains(prompt, "PM decided to ship the launch page on Friday.") {
+		t.Fatal("expected archived thread content in prompt")
+	}
+}
+
+func TestBuildCompactionPrompt(t *testing.T) {
+	prompt := BuildCompactionPrompt()
+	for _, want := range []string{"mission", "key decisions", "current blockers", "Office Insight"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("expected compaction prompt to mention %q", want)
+		}
+	}
+}

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -183,6 +183,7 @@ func (s *AgentService) Create(cfg AgentConfig) (*ManagedAgent, error) {
 	loop.On(EventDone, func(args ...any) {
 		ma.State.Phase = PhaseDone
 		ma.State.CurrentTask = ""
+		ma.State.TaskID = ""
 		ma.State.Error = ""
 	})
 	s.agents[cfg.Slug] = ma

--- a/internal/agent/task_runtime.go
+++ b/internal/agent/task_runtime.go
@@ -1,0 +1,146 @@
+package agent
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	taskLogRootEnv          = "WUPHF_TASK_LOG_ROOT"
+	compactionTokenLimitEnv = "WUPHF_COMPACTION_TOKEN_LIMIT"
+	defaultTokenLimit       = 16000
+	compactionRatio         = 0.8
+)
+
+func defaultTaskLogRoot() string {
+	if root := strings.TrimSpace(os.Getenv(taskLogRootEnv)); root != "" {
+		return root
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".wuphf", "office", "tasks")
+	}
+	return filepath.Join(home, ".wuphf", "office", "tasks")
+}
+
+func nextTaskID(slug string) string {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		slug = "task"
+	}
+	return fmt.Sprintf("%s-%d", slug, time.Now().UnixMilli())
+}
+
+func compactionTokenLimit() int {
+	raw := strings.TrimSpace(os.Getenv(compactionTokenLimitEnv))
+	if raw == "" {
+		return defaultTokenLimit
+	}
+
+	var limit int
+	if _, err := fmt.Sscanf(raw, "%d", &limit); err != nil || limit <= 0 {
+		return defaultTokenLimit
+	}
+	return limit
+}
+
+func estimateSessionTokens(entries []SessionEntry) int {
+	total := 0
+	for _, entry := range entries {
+		total += estimateTextTokens(entry.Content)
+	}
+	return total
+}
+
+func estimateTextTokens(text string) int {
+	runes := utf8.RuneCountInString(text)
+	if runes == 0 {
+		return 0
+	}
+	return (runes + 3) / 4
+}
+
+func shouldCompactEntries(entries []SessionEntry) bool {
+	if len(entries) < 8 {
+		return false
+	}
+	trigger := int(float64(compactionTokenLimit()) * compactionRatio)
+	return estimateSessionTokens(entries) >= trigger
+}
+
+func splitEntriesForCompaction(entries []SessionEntry) (prefix, archived, recent []SessionEntry) {
+	pivot := 0
+	for pivot < len(entries) && entries[pivot].Type == "system" {
+		pivot++
+	}
+	prefix = append(prefix, entries[:pivot]...)
+	body := entries[pivot:]
+	if len(body) < 2 {
+		return prefix, nil, body
+	}
+
+	mid := len(body) / 2
+	archived = append(archived, body[:mid]...)
+	recent = append(recent, body[mid:]...)
+	return prefix, archived, recent
+}
+
+func buildOfficeInsightSummary(entries []SessionEntry) string {
+	lines := make([]string, 0, 8)
+	for _, entry := range entries {
+		if entry.Metadata != nil {
+			if officeInsight, ok := entry.Metadata["officeInsight"].(bool); ok && officeInsight {
+				continue
+			}
+		}
+
+		text := strings.TrimSpace(entry.Content)
+		if text == "" {
+			continue
+		}
+
+		lines = append(lines, fmt.Sprintf("- %s: %s", compactionLabel(entry.Type), truncateRuntimeText(text, 160)))
+		if len(lines) >= 8 {
+			break
+		}
+	}
+
+	if len(lines) == 0 {
+		return ""
+	}
+
+	return "Office Insight\n" +
+		"Summarized archive of older context so the active thread can stay within the working window.\n" +
+		strings.Join(lines, "\n")
+}
+
+func compactionLabel(entryType string) string {
+	switch entryType {
+	case "user":
+		return "Request"
+	case "assistant":
+		return "Response"
+	case "tool_call":
+		return "Tool"
+	case "tool_result":
+		return "Tool Result"
+	default:
+		return "Context"
+	}
+}
+
+func truncateRuntimeText(text string, limit int) string {
+	text = strings.Join(strings.Fields(text), " ")
+	if utf8.RuneCountInString(text) <= limit {
+		return text
+	}
+
+	runes := []rune(text)
+	cut := strings.TrimSpace(string(runes[:limit]))
+	return cut + "..."
+}

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -1,9 +1,18 @@
 package agent
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/api"
 )
@@ -96,9 +105,403 @@ func marshalResult(v any) (string, error) {
 	return string(b), nil
 }
 
+type localToolResult struct {
+	Path        string   `json:"path,omitempty"`
+	Pattern     string   `json:"pattern,omitempty"`
+	Command     string   `json:"command,omitempty"`
+	WorkingDir  string   `json:"working_directory,omitempty"`
+	Append      bool     `json:"append,omitempty"`
+	Bytes       int      `json:"bytes,omitempty"`
+	Lines       int      `json:"lines,omitempty"`
+	Files       []string `json:"files,omitempty"`
+	Matches     []string `json:"matches,omitempty"`
+	MatchCount  int      `json:"match_count,omitempty"`
+	FileCount   int      `json:"file_count,omitempty"`
+	Recipient   string   `json:"recipient,omitempty"`
+	Channel     string   `json:"channel,omitempty"`
+	Message     string   `json:"message,omitempty"`
+	Stdout      string   `json:"stdout,omitempty"`
+	Stderr      string   `json:"stderr,omitempty"`
+	Combined    string   `json:"combined,omitempty"`
+	ExitCode    int      `json:"exit_code"`
+	Status      string   `json:"status,omitempty"`
+	Timestamp   string   `json:"timestamp,omitempty"`
+	Description string   `json:"description,omitempty"`
+}
+
+func localToolDefinitions() []AgentTool {
+	return []AgentTool{
+		{
+			Name:        "read_file",
+			Description: "Read a local file from disk.",
+			Schema: map[string]any{
+				"type":     "object",
+				"required": []any{"path"},
+				"properties": map[string]any{
+					"path":              map[string]any{"type": "string"},
+					"working_directory": map[string]any{"type": "string"},
+				},
+			},
+			Execute: func(params map[string]any, ctx context.Context, onUpdate func(string)) (string, error) {
+				onUpdate("Reading file...")
+				path, err := resolveToolPath(params)
+				if err != nil {
+					return "", err
+				}
+				data, err := os.ReadFile(path)
+				if err != nil {
+					return "", err
+				}
+				return marshalResult(localToolResult{
+					Path:       path,
+					Bytes:      len(data),
+					Lines:      countLines(string(data)),
+					Status:     "ok",
+					WorkingDir: resolvedWorkingDirectory(params),
+					Combined:   string(data),
+				})
+			},
+		},
+		{
+			Name:        "grep_search",
+			Description: "Search local files for a regexp pattern.",
+			Schema: map[string]any{
+				"type":     "object",
+				"required": []any{"pattern"},
+				"properties": map[string]any{
+					"pattern":           map[string]any{"type": "string"},
+					"path":              map[string]any{"type": "string"},
+					"working_directory": map[string]any{"type": "string"},
+				},
+			},
+			Execute: func(params map[string]any, ctx context.Context, onUpdate func(string)) (string, error) {
+				onUpdate("Searching files...")
+				pattern, _ := params["pattern"].(string)
+				if strings.TrimSpace(pattern) == "" {
+					return "", fmt.Errorf("pattern is required")
+				}
+				re, err := regexp.Compile(pattern)
+				if err != nil {
+					return "", fmt.Errorf("compile pattern: %w", err)
+				}
+				root, err := resolveSearchRoot(params)
+				if err != nil {
+					return "", err
+				}
+
+				var matches []string
+				fileSet := make(map[string]struct{})
+				err = filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+					if walkErr != nil {
+						return walkErr
+					}
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					default:
+					}
+					if d.IsDir() {
+						return nil
+					}
+					data, err := os.ReadFile(path)
+					if err != nil {
+						return nil
+					}
+					lines := strings.Split(string(data), "\n")
+					for i, line := range lines {
+						if re.MatchString(line) {
+							rel, relErr := filepath.Rel(root, path)
+							if relErr != nil {
+								rel = path
+							}
+							matches = append(matches, fmt.Sprintf("%s:%d:%s", rel, i+1, line))
+							fileSet[path] = struct{}{}
+						}
+					}
+					return nil
+				})
+				if err != nil {
+					return "", err
+				}
+
+				files := make([]string, 0, len(fileSet))
+				for path := range fileSet {
+					rel, relErr := filepath.Rel(root, path)
+					if relErr != nil {
+						rel = path
+					}
+					files = append(files, rel)
+				}
+
+				return marshalResult(localToolResult{
+					Pattern:    pattern,
+					Path:       root,
+					Matches:    matches,
+					Files:      files,
+					MatchCount: len(matches),
+					FileCount:  len(files),
+					Status:     "ok",
+					WorkingDir: resolvedWorkingDirectory(params),
+				})
+			},
+		},
+		{
+			Name:        "glob",
+			Description: "Expand a filepath glob from the local filesystem.",
+			Schema: map[string]any{
+				"type":     "object",
+				"required": []any{"pattern"},
+				"properties": map[string]any{
+					"pattern":           map[string]any{"type": "string"},
+					"working_directory": map[string]any{"type": "string"},
+				},
+			},
+			Execute: func(params map[string]any, ctx context.Context, onUpdate func(string)) (string, error) {
+				onUpdate("Expanding glob...")
+				pattern, _ := params["pattern"].(string)
+				if strings.TrimSpace(pattern) == "" {
+					return "", fmt.Errorf("pattern is required")
+				}
+				absPattern, err := resolvePath(resolvedWorkingDirectory(params), pattern)
+				if err != nil {
+					return "", err
+				}
+				files, err := filepath.Glob(absPattern)
+				if err != nil {
+					return "", err
+				}
+				base := resolvedWorkingDirectory(params)
+				if base == "" {
+					base, _ = os.Getwd()
+				}
+				relFiles := make([]string, 0, len(files))
+				for _, file := range files {
+					rel, relErr := filepath.Rel(base, file)
+					if relErr != nil {
+						rel = file
+					}
+					relFiles = append(relFiles, rel)
+				}
+				return marshalResult(localToolResult{
+					Pattern:    pattern,
+					WorkingDir: base,
+					Files:      relFiles,
+					FileCount:  len(relFiles),
+					Status:     "ok",
+				})
+			},
+		},
+		{
+			Name:        "write_file",
+			Description: "Write or append local file content.",
+			Schema: map[string]any{
+				"type":     "object",
+				"required": []any{"path", "content"},
+				"properties": map[string]any{
+					"path":              map[string]any{"type": "string"},
+					"content":           map[string]any{"type": "string"},
+					"append":            map[string]any{"type": "boolean"},
+					"working_directory": map[string]any{"type": "string"},
+				},
+			},
+			Execute: func(params map[string]any, ctx context.Context, onUpdate func(string)) (string, error) {
+				onUpdate("Writing file...")
+				path, err := resolveToolPath(params)
+				if err != nil {
+					return "", err
+				}
+				content, _ := params["content"].(string)
+				appendMode, _ := params["append"].(bool)
+				if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+					return "", err
+				}
+				flags := os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+				if appendMode {
+					flags = os.O_CREATE | os.O_WRONLY | os.O_APPEND
+				}
+				f, err := os.OpenFile(path, flags, 0o644)
+				if err != nil {
+					return "", err
+				}
+				defer f.Close()
+				if _, err := f.WriteString(content); err != nil {
+					return "", err
+				}
+				return marshalResult(localToolResult{
+					Path:       path,
+					Append:     appendMode,
+					Bytes:      len(content),
+					Lines:      countLines(content),
+					Status:     "ok",
+					WorkingDir: resolvedWorkingDirectory(params),
+				})
+			},
+		},
+		{
+			Name:        "bash",
+			Description: "Run a local shell command and capture stdout/stderr.",
+			Schema: map[string]any{
+				"type":     "object",
+				"required": []any{"command"},
+				"properties": map[string]any{
+					"command":           map[string]any{"type": "string"},
+					"working_directory": map[string]any{"type": "string"},
+				},
+			},
+			Execute: func(params map[string]any, ctx context.Context, onUpdate func(string)) (string, error) {
+				onUpdate("Running bash...")
+				command, _ := params["command"].(string)
+				if strings.TrimSpace(command) == "" {
+					return "", fmt.Errorf("command is required")
+				}
+				wd := resolvedWorkingDirectory(params)
+				if wd == "" {
+					wd, _ = os.Getwd()
+				}
+				cmd := exec.CommandContext(ctx, "/bin/sh", "-lc", command)
+				cmd.Dir = wd
+				var stdout bytes.Buffer
+				var stderr bytes.Buffer
+				cmd.Stdout = &stdout
+				cmd.Stderr = &stderr
+				err := cmd.Run()
+				exitCode := 0
+				if err != nil {
+					var exitErr *exec.ExitError
+					if errors.As(err, &exitErr) {
+						exitCode = exitErr.ExitCode()
+					} else {
+						return "", err
+					}
+				}
+				if exitCode == 0 && cmd.ProcessState != nil {
+					exitCode = cmd.ProcessState.ExitCode()
+				}
+				result := localToolResult{
+					Command:     command,
+					WorkingDir:  wd,
+					Stdout:      stdout.String(),
+					Stderr:      stderr.String(),
+					Combined:    stdout.String() + stderr.String(),
+					ExitCode:    exitCode,
+					Lines:       countLines(stdout.String() + stderr.String()),
+					Status:      "ok",
+					Description: "Shell command completed",
+				}
+				return marshalResult(result)
+			},
+		},
+		{
+			Name:        "send_message",
+			Description: "Queue a lightweight agent-to-agent message on disk.",
+			Schema: map[string]any{
+				"type":     "object",
+				"required": []any{"recipient", "message"},
+				"properties": map[string]any{
+					"recipient": map[string]any{"type": "string"},
+					"message":   map[string]any{"type": "string"},
+					"channel":   map[string]any{"type": "string"},
+				},
+			},
+			Execute: func(params map[string]any, ctx context.Context, onUpdate func(string)) (string, error) {
+				onUpdate("Sending message...")
+				recipient, _ := params["recipient"].(string)
+				message, _ := params["message"].(string)
+				channel, _ := params["channel"].(string)
+				if strings.TrimSpace(recipient) == "" {
+					return "", fmt.Errorf("recipient is required")
+				}
+				if strings.TrimSpace(message) == "" {
+					return "", fmt.Errorf("message is required")
+				}
+				home, err := os.UserHomeDir()
+				if err != nil {
+					return "", err
+				}
+				outboxDir := filepath.Join(home, ".wuphf", "office", "messages")
+				if err := os.MkdirAll(outboxDir, 0o755); err != nil {
+					return "", err
+				}
+				entry := localToolResult{
+					Recipient: strings.TrimSpace(recipient),
+					Channel:   strings.TrimSpace(channel),
+					Message:   message,
+					Status:    "queued",
+					Timestamp: time.Now().UTC().Format(time.RFC3339),
+				}
+				payload, err := json.Marshal(entry)
+				if err != nil {
+					return "", err
+				}
+				f, err := os.OpenFile(filepath.Join(outboxDir, "outbox.jsonl"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+				if err != nil {
+					return "", err
+				}
+				defer f.Close()
+				if _, err := f.Write(append(payload, '\n')); err != nil {
+					return "", err
+				}
+				return string(payload), nil
+			},
+		},
+	}
+}
+
+func resolvedWorkingDirectory(params map[string]any) string {
+	wd, _ := params["working_directory"].(string)
+	return strings.TrimSpace(wd)
+}
+
+func resolveToolPath(params map[string]any) (string, error) {
+	path, _ := params["path"].(string)
+	if strings.TrimSpace(path) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	return resolvePath(resolvedWorkingDirectory(params), path)
+}
+
+func resolveSearchRoot(params map[string]any) (string, error) {
+	if path, ok := params["path"].(string); ok && strings.TrimSpace(path) != "" {
+		return resolvePath(resolvedWorkingDirectory(params), path)
+	}
+	wd := resolvedWorkingDirectory(params)
+	if wd == "" {
+		var err error
+		wd, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
+	}
+	return filepath.Abs(wd)
+}
+
+func resolvePath(base, target string) (string, error) {
+	if strings.TrimSpace(target) == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	if filepath.IsAbs(target) {
+		return filepath.Clean(target), nil
+	}
+	if strings.TrimSpace(base) == "" {
+		var err error
+		base, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
+	}
+	return filepath.Abs(filepath.Join(base, target))
+}
+
+func countLines(text string) int {
+	if text == "" {
+		return 0
+	}
+	return strings.Count(text, "\n") + 1
+}
+
 // CreateBuiltinTools returns the 7 standard Nex tools backed by the API client.
 func CreateBuiltinTools(client *api.Client) []AgentTool {
-	return []AgentTool{
+	tools := []AgentTool{
 		{
 			Name:        "nex_search",
 			Description: "Search organizational knowledge base",
@@ -264,6 +667,8 @@ func CreateBuiltinTools(client *api.Client) []AgentTool {
 			},
 		},
 	}
+	tools = append(tools, localToolDefinitions()...)
+	return tools
 }
 
 // CreateGossipTools returns tools for publishing and querying the gossip network.

--- a/internal/agent/tools_test.go
+++ b/internal/agent/tools_test.go
@@ -1,6 +1,11 @@
 package agent_test
 
 import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/agent"
@@ -152,5 +157,169 @@ func TestToolRegistry_Validate_RequiredOnly(t *testing.T) {
 	})
 	if !ok {
 		t.Errorf("expected validation to pass with only required params, got: %v", errs)
+	}
+}
+
+func builtinTool(t *testing.T, name string) agent.AgentTool {
+	t.Helper()
+	for _, tool := range agent.CreateBuiltinTools(nil) {
+		if tool.Name == name {
+			return tool
+		}
+	}
+	t.Fatalf("builtin tool %q not found", name)
+	return agent.AgentTool{}
+}
+
+func decodeToolResult(t *testing.T, raw string) map[string]any {
+	t.Helper()
+	var result map[string]any
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("decode tool result: %v", err)
+	}
+	return result
+}
+
+func TestBuiltinToolsIncludeLocalToolset(t *testing.T) {
+	tools := agent.CreateBuiltinTools(nil)
+	names := make(map[string]bool, len(tools))
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	for _, name := range []string{"read_file", "grep_search", "glob", "write_file", "bash", "send_message"} {
+		if !names[name] {
+			t.Fatalf("expected builtin tool %q", name)
+		}
+	}
+}
+
+func TestReadFileTool(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(path, []byte("hello\nworld\n"), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	tool := builtinTool(t, "read_file")
+	raw, err := tool.Execute(map[string]any{
+		"path":              "notes.txt",
+		"working_directory": dir,
+	}, context.Background(), func(string) {})
+	if err != nil {
+		t.Fatalf("read_file: %v", err)
+	}
+	result := decodeToolResult(t, raw)
+	if got := result["combined"]; got != "hello\nworld\n" {
+		t.Fatalf("expected file content, got %#v", got)
+	}
+}
+
+func TestWriteFileAndGlobTools(t *testing.T) {
+	dir := t.TempDir()
+	writeTool := builtinTool(t, "write_file")
+	if _, err := writeTool.Execute(map[string]any{
+		"path":              "nested/report.txt",
+		"content":           "alpha\nbeta",
+		"working_directory": dir,
+	}, context.Background(), func(string) {}); err != nil {
+		t.Fatalf("write_file: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, "nested", "report.txt"))
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(data) != "alpha\nbeta" {
+		t.Fatalf("unexpected file content %q", string(data))
+	}
+
+	globTool := builtinTool(t, "glob")
+	raw, err := globTool.Execute(map[string]any{
+		"pattern":           "nested/*.txt",
+		"working_directory": dir,
+	}, context.Background(), func(string) {})
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	result := decodeToolResult(t, raw)
+	files, ok := result["files"].([]any)
+	if !ok || len(files) != 1 || files[0] != "nested/report.txt" {
+		t.Fatalf("unexpected glob files %#v", result["files"])
+	}
+}
+
+func TestGrepSearchTool(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), []byte("BubbleTea\nother\n"), 0o644); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.txt"), []byte("none here\n"), 0o644); err != nil {
+		t.Fatalf("write b.txt: %v", err)
+	}
+
+	tool := builtinTool(t, "grep_search")
+	raw, err := tool.Execute(map[string]any{
+		"pattern":           "BubbleTea",
+		"working_directory": dir,
+	}, context.Background(), func(string) {})
+	if err != nil {
+		t.Fatalf("grep_search: %v", err)
+	}
+	result := decodeToolResult(t, raw)
+	if got := int(result["match_count"].(float64)); got != 1 {
+		t.Fatalf("expected 1 match, got %d", got)
+	}
+	matches, ok := result["matches"].([]any)
+	if !ok || len(matches) != 1 || !strings.Contains(matches[0].(string), "a.txt:1:BubbleTea") {
+		t.Fatalf("unexpected matches %#v", result["matches"])
+	}
+}
+
+func TestBashToolCapturesStdoutAndStderr(t *testing.T) {
+	dir := t.TempDir()
+	tool := builtinTool(t, "bash")
+	raw, err := tool.Execute(map[string]any{
+		"command":           "printf 'out'; printf 'err' >&2",
+		"working_directory": dir,
+	}, context.Background(), func(string) {})
+	if err != nil {
+		t.Fatalf("bash: %v", err)
+	}
+	result := decodeToolResult(t, raw)
+	if result["stdout"] != "out" {
+		t.Fatalf("expected stdout 'out', got %#v", result["stdout"])
+	}
+	if result["stderr"] != "err" {
+		t.Fatalf("expected stderr 'err', got %#v", result["stderr"])
+	}
+	if got := int(result["exit_code"].(float64)); got != 0 {
+		t.Fatalf("expected exit code 0, got %d", got)
+	}
+}
+
+func TestSendMessageToolWritesOutbox(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	tool := builtinTool(t, "send_message")
+	raw, err := tool.Execute(map[string]any{
+		"recipient": "be",
+		"message":   "API is ready",
+		"channel":   "launch",
+	}, context.Background(), func(string) {})
+	if err != nil {
+		t.Fatalf("send_message: %v", err)
+	}
+	result := decodeToolResult(t, raw)
+	if result["recipient"] != "be" {
+		t.Fatalf("expected recipient be, got %#v", result["recipient"])
+	}
+
+	data, err := os.ReadFile(filepath.Join(home, ".wuphf", "office", "messages", "outbox.jsonl"))
+	if err != nil {
+		t.Fatalf("read outbox: %v", err)
+	}
+	if !strings.Contains(string(data), "\"recipient\":\"be\"") {
+		t.Fatalf("expected outbox entry, got %q", string(data))
 	}
 }

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -36,15 +36,16 @@ type AgentConfig struct {
 
 // AgentState holds the runtime state of a running agent.
 type AgentState struct {
-	Phase         AgentPhase `json:"phase"`
+	Phase         AgentPhase  `json:"phase"`
 	Config        AgentConfig `json:"config"`
-	SessionID     string     `json:"sessionId,omitempty"`
-	CurrentTask   string     `json:"currentTask,omitempty"`
-	TokensUsed    int        `json:"tokensUsed"`
-	CostUsd       float64    `json:"costUsd"`
-	LastHeartbeat int64      `json:"lastHeartbeat,omitempty"`
-	NextHeartbeat int64      `json:"nextHeartbeat,omitempty"`
-	Error         string     `json:"error,omitempty"`
+	SessionID     string      `json:"sessionId,omitempty"`
+	CurrentTask   string      `json:"currentTask,omitempty"`
+	TaskID        string      `json:"taskId,omitempty"`
+	TokensUsed    int         `json:"tokensUsed"`
+	CostUsd       float64     `json:"costUsd"`
+	LastHeartbeat int64       `json:"lastHeartbeat,omitempty"`
+	NextHeartbeat int64       `json:"nextHeartbeat,omitempty"`
+	Error         string      `json:"error,omitempty"`
 }
 
 // AgentTool is a named tool an agent can invoke.
@@ -67,12 +68,12 @@ type ToolCall struct {
 
 // SessionEntry is one entry in an agent's session history.
 type SessionEntry struct {
-	ID       string         `json:"id"`
-	ParentID string         `json:"parentId,omitempty"`
-	Type     string         `json:"type"` // "user" | "assistant" | "tool_call" | "tool_result" | "system"
-	Content  string         `json:"content"`
-	Timestamp int64         `json:"timestamp"`
-	Metadata map[string]any `json:"metadata,omitempty"`
+	ID        string         `json:"id"`
+	ParentID  string         `json:"parentId,omitempty"`
+	Type      string         `json:"type"` // "user" | "assistant" | "tool_call" | "tool_result" | "system"
+	Content   string         `json:"content"`
+	Timestamp int64          `json:"timestamp"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
 }
 
 // Message is a single LLM conversation turn.
@@ -88,8 +89,8 @@ type StreamChunk struct {
 	Content    string         `json:"content,omitempty"`
 	ToolName   string         `json:"toolName,omitempty"`
 	ToolParams map[string]any `json:"toolParams,omitempty"`
-	ToolUseID  string         `json:"toolUseId,omitempty"`  // for tool_use / tool_result correlation
-	ToolInput  string         `json:"toolInput,omitempty"`  // serialized tool input for display
+	ToolUseID  string         `json:"toolUseId,omitempty"` // for tool_use / tool_result correlation
+	ToolInput  string         `json:"toolInput,omitempty"` // serialized tool input for display
 }
 
 // StreamFn is a function that streams LLM output as a channel of chunks.

--- a/internal/chat/chat_test.go
+++ b/internal/chat/chat_test.go
@@ -227,6 +227,35 @@ func TestRouterGeneralChannel(t *testing.T) {
 	}
 }
 
+func TestInjectOfficeInsight(t *testing.T) {
+	dir := tempDir(t)
+	cm, err := NewChannelManagerAt(filepath.Join(dir, "channels.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms := NewMessageStoreAt(dir)
+	r := NewRouter(cm, ms)
+
+	ch, err := cm.Create("general", ChannelPublic, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := r.InjectOfficeInsight(ch.ID, "Archived decisions and blockers.")
+	if err != nil {
+		t.Fatalf("InjectOfficeInsight: %v", err)
+	}
+	if msg.SenderSlug != "office-insight" {
+		t.Fatalf("expected office-insight sender, got %q", msg.SenderSlug)
+	}
+	if msg.SenderName != "Office Insight" {
+		t.Fatalf("expected Office Insight sender name, got %q", msg.SenderName)
+	}
+	if msg.Type != MsgSystem {
+		t.Fatalf("expected system message type, got %q", msg.Type)
+	}
+}
+
 func TestParseMentions(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/chat/router.go
+++ b/internal/chat/router.go
@@ -53,6 +53,16 @@ func (r *Router) Route(senderSlug, senderName, content string) (RouteResult, err
 	return RouteResult{ChannelID: ch.ID, Mentions: nil}, nil
 }
 
+// InjectOfficeInsight appends a visible Office Insight system message to a
+// channel so humans and agents can see what was archived during compaction.
+func (r *Router) InjectOfficeInsight(channelID, content string) (Message, error) {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return Message{}, nil
+	}
+	return r.messages.Send(channelID, "office-insight", "Office Insight", content, MsgSystem)
+}
+
 // getOrCreateGeneral returns the #general public channel, creating it if needed.
 func (r *Router) getOrCreateGeneral() (Channel, error) {
 	for _, ch := range r.channels.List() {

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -223,15 +223,15 @@ type schedulerJob struct {
 }
 
 type teamSkill struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name"`
-	Title       string   `json:"title"`
-	Description string   `json:"description,omitempty"`
-	Content     string   `json:"content"`
-	CreatedBy   string   `json:"created_by"`
-	Channel     string   `json:"channel,omitempty"`
-	Tags        []string `json:"tags,omitempty"`
-	Trigger     string   `json:"trigger,omitempty"`
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	Title               string   `json:"title"`
+	Description         string   `json:"description,omitempty"`
+	Content             string   `json:"content"`
+	CreatedBy           string   `json:"created_by"`
+	Channel             string   `json:"channel,omitempty"`
+	Tags                []string `json:"tags,omitempty"`
+	Trigger             string   `json:"trigger,omitempty"`
 	WorkflowProvider    string   `json:"workflow_provider,omitempty"`
 	WorkflowKey         string   `json:"workflow_key,omitempty"`
 	WorkflowDefinition  string   `json:"workflow_definition,omitempty"`
@@ -241,10 +241,10 @@ type teamSkill struct {
 	RelayEventTypes     []string `json:"relay_event_types,omitempty"`
 	LastExecutionAt     string   `json:"last_execution_at,omitempty"`
 	LastExecutionStatus string   `json:"last_execution_status,omitempty"`
-	UsageCount  int      `json:"usage_count"`
-	Status      string   `json:"status"`
-	CreatedAt   string   `json:"created_at"`
-	UpdatedAt   string   `json:"updated_at"`
+	UsageCount          int      `json:"usage_count"`
+	Status              string   `json:"status"`
+	CreatedAt           string   `json:"created_at"`
+	UpdatedAt           string   `json:"updated_at"`
 }
 
 type brokerState struct {
@@ -316,6 +316,52 @@ type Broker struct {
 	server            *http.Server
 	token             string // shared secret for authenticating requests
 	addr              string // actual listen address (useful when port=0)
+}
+
+func taskNeedsLocalWorktree(task *teamTask) bool {
+	if task == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") {
+		return false
+	}
+	if strings.TrimSpace(task.Owner) == "" {
+		return false
+	}
+	switch strings.TrimSpace(task.Status) {
+	case "", "open", "done":
+		return false
+	default:
+		return true
+	}
+}
+
+func (b *Broker) syncTaskWorktreeLocked(task *teamTask) error {
+	if task == nil {
+		return nil
+	}
+	if taskNeedsLocalWorktree(task) {
+		if strings.TrimSpace(task.WorktreePath) != "" && strings.TrimSpace(task.WorktreeBranch) != "" {
+			return nil
+		}
+		path, branch, err := prepareTaskWorktree(task.ID)
+		if err != nil {
+			return err
+		}
+		task.WorktreePath = path
+		task.WorktreeBranch = branch
+		return nil
+	}
+
+	if strings.TrimSpace(task.WorktreePath) == "" && strings.TrimSpace(task.WorktreeBranch) == "" {
+		return nil
+	}
+	if err := cleanupTaskWorktree(task.WorktreePath, task.WorktreeBranch); err != nil {
+		return err
+	}
+	task.WorktreePath = ""
+	task.WorktreeBranch = ""
+	return nil
 }
 
 // generateToken returns a cryptographically random hex token.
@@ -2292,13 +2338,13 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{"channels": channels})
 	case http.MethodPost:
 		var body struct {
-			Action      string           `json:"action"`
-			Slug        string           `json:"slug"`
-			Name        string           `json:"name"`
-			Description string           `json:"description"`
-			Members     []string         `json:"members"`
-			CreatedBy   string           `json:"created_by"`
-			Surface     *channelSurface  `json:"surface,omitempty"`
+			Action      string          `json:"action"`
+			Slug        string          `json:"slug"`
+			Name        string          `json:"name"`
+			Description string          `json:"description"`
+			Members     []string        `json:"members"`
+			CreatedBy   string          `json:"created_by"`
+			Surface     *channelSurface `json:"surface,omitempty"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "invalid json", http.StatusBadRequest)
@@ -2848,7 +2894,6 @@ func (b *Broker) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-
 func (b *Broker) handleReactions(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -2900,7 +2945,6 @@ func (b *Broker) handleReactions(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }
-
 // RecordTelegramGroup saves a group chat ID and title seen by the transport.
 func (b *Broker) RecordTelegramGroup(chatID int64, title string) {
 	b.mu.Lock()
@@ -3135,7 +3179,6 @@ func (b *Broker) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 		"tagged_count": taggedCount,
 	})
 }
-
 
 // isOneOnOneDMMessage returns true if msg belongs in the 1:1 DM conversation.
 // Only messages exclusively between the human and the 1:1 agent pass through.
@@ -3508,6 +3551,10 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			}
 			existing.UpdatedAt = now
 			b.scheduleTaskLifecycleLocked(existing)
+			if err := b.syncTaskWorktreeLocked(existing); err != nil {
+				http.Error(w, "failed to manage task worktree", http.StatusInternalServerError)
+				return
+			}
 			b.appendActionLocked("task_updated", "office", channel, strings.TrimSpace(body.CreatedBy), truncateSummary(existing.Title+" ["+existing.Status+"]", 140), existing.ID)
 			if err := b.saveLocked(); err != nil {
 				http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
@@ -3545,6 +3592,10 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			task.Status = "in_progress"
 		}
 		b.scheduleTaskLifecycleLocked(&task)
+		if err := b.syncTaskWorktreeLocked(&task); err != nil {
+			http.Error(w, "failed to manage task worktree", http.StatusInternalServerError)
+			return
+		}
 		b.tasks = append(b.tasks, task)
 		b.appendActionLocked("task_created", "office", channel, task.CreatedBy, truncateSummary(task.Title, 140), task.ID)
 		if err := b.saveLocked(); err != nil {
@@ -3631,6 +3682,10 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			b.unblockDependentsLocked(task.ID)
 		}
 		b.scheduleTaskLifecycleLocked(task)
+		if err := b.syncTaskWorktreeLocked(task); err != nil {
+			http.Error(w, "failed to manage task worktree", http.StatusInternalServerError)
+			return
+		}
 		b.appendActionLocked("task_updated", "office", channel, strings.TrimSpace(body.CreatedBy), truncateSummary(task.Title+" ["+task.Status+"]", 140), task.ID)
 		if err := b.saveLocked(); err != nil {
 			http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
@@ -3860,6 +3915,9 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 		}
 		existing.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 		b.scheduleTaskLifecycleLocked(existing)
+		if err := b.syncTaskWorktreeLocked(existing); err != nil {
+			return teamTask{}, false, err
+		}
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, false, err
 		}
@@ -3883,6 +3941,9 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 		task.Status = "in_progress"
 	}
 	b.scheduleTaskLifecycleLocked(&task)
+	if err := b.syncTaskWorktreeLocked(&task); err != nil {
+		return teamTask{}, false, err
+	}
 	b.tasks = append(b.tasks, task)
 	b.appendActionLocked("task_created", "office", channel, createdBy, truncateSummary(task.Title, 140), task.ID)
 	if err := b.saveLocked(); err != nil {
@@ -3951,6 +4012,9 @@ func (b *Broker) EnsurePlannedTask(input plannedTaskInput) (teamTask, bool, erro
 		}
 		existing.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
 		b.scheduleTaskLifecycleLocked(existing)
+		if err := b.syncTaskWorktreeLocked(existing); err != nil {
+			return teamTask{}, false, err
+		}
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, false, err
 		}
@@ -3980,6 +4044,9 @@ func (b *Broker) EnsurePlannedTask(input plannedTaskInput) (teamTask, bool, erro
 		task.Status = "in_progress"
 	}
 	b.scheduleTaskLifecycleLocked(&task)
+	if err := b.syncTaskWorktreeLocked(&task); err != nil {
+		return teamTask{}, false, err
+	}
 	b.tasks = append(b.tasks, task)
 	b.appendActionWithRefsLocked("task_created", "office", channel, input.CreatedBy, truncateSummary(task.Title, 140), task.ID, compactStringList([]string{task.SourceSignalID}), task.SourceDecisionID)
 	if err := b.saveLocked(); err != nil {
@@ -4525,15 +4592,15 @@ func (b *Broker) handleGetSkills(w http.ResponseWriter, r *http.Request) {
 
 func (b *Broker) handlePostSkill(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Action      string   `json:"action"`
-		Name        string   `json:"name"`
-		Title       string   `json:"title"`
-		Description string   `json:"description"`
-		Content     string   `json:"content"`
-		CreatedBy   string   `json:"created_by"`
-		Channel     string   `json:"channel"`
-		Tags        []string `json:"tags"`
-		Trigger     string   `json:"trigger"`
+		Action              string   `json:"action"`
+		Name                string   `json:"name"`
+		Title               string   `json:"title"`
+		Description         string   `json:"description"`
+		Content             string   `json:"content"`
+		CreatedBy           string   `json:"created_by"`
+		Channel             string   `json:"channel"`
+		Tags                []string `json:"tags"`
+		Trigger             string   `json:"trigger"`
 		WorkflowProvider    string   `json:"workflow_provider"`
 		WorkflowKey         string   `json:"workflow_key"`
 		WorkflowDefinition  string   `json:"workflow_definition"`
@@ -4590,15 +4657,15 @@ func (b *Broker) handlePostSkill(w http.ResponseWriter, r *http.Request) {
 
 	b.counter++
 	sk := teamSkill{
-		ID:          fmt.Sprintf("skill-%s", skillSlug(body.Name)),
-		Name:        strings.TrimSpace(body.Name),
-		Title:       title,
-		Description: strings.TrimSpace(body.Description),
-		Content:     strings.TrimSpace(body.Content),
-		CreatedBy:   strings.TrimSpace(body.CreatedBy),
-		Channel:     channel,
-		Tags:        body.Tags,
-		Trigger:     strings.TrimSpace(body.Trigger),
+		ID:                  fmt.Sprintf("skill-%s", skillSlug(body.Name)),
+		Name:                strings.TrimSpace(body.Name),
+		Title:               title,
+		Description:         strings.TrimSpace(body.Description),
+		Content:             strings.TrimSpace(body.Content),
+		CreatedBy:           strings.TrimSpace(body.CreatedBy),
+		Channel:             channel,
+		Tags:                body.Tags,
+		Trigger:             strings.TrimSpace(body.Trigger),
 		WorkflowProvider:    strings.TrimSpace(body.WorkflowProvider),
 		WorkflowKey:         strings.TrimSpace(body.WorkflowKey),
 		WorkflowDefinition:  strings.TrimSpace(body.WorkflowDefinition),
@@ -4608,10 +4675,10 @@ func (b *Broker) handlePostSkill(w http.ResponseWriter, r *http.Request) {
 		RelayEventTypes:     append([]string(nil), body.RelayEventTypes...),
 		LastExecutionAt:     strings.TrimSpace(body.LastExecutionAt),
 		LastExecutionStatus: strings.TrimSpace(body.LastExecutionStatus),
-		UsageCount:  0,
-		Status:      status,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		UsageCount:          0,
+		Status:              status,
+		CreatedAt:           now,
+		UpdatedAt:           now,
 	}
 	b.skills = append(b.skills, sk)
 
@@ -4637,14 +4704,14 @@ func (b *Broker) handlePostSkill(w http.ResponseWriter, r *http.Request) {
 
 func (b *Broker) handlePutSkill(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Name        string   `json:"name"`
-		Title       string   `json:"title"`
-		Description string   `json:"description"`
-		Content     string   `json:"content"`
-		Channel     string   `json:"channel"`
-		Tags        []string `json:"tags"`
-		Trigger     string   `json:"trigger"`
-		Status      string   `json:"status"`
+		Name                string   `json:"name"`
+		Title               string   `json:"title"`
+		Description         string   `json:"description"`
+		Content             string   `json:"content"`
+		Channel             string   `json:"channel"`
+		Tags                []string `json:"tags"`
+		Trigger             string   `json:"trigger"`
+		Status              string   `json:"status"`
 		WorkflowProvider    string   `json:"workflow_provider"`
 		WorkflowKey         string   `json:"workflow_key"`
 		WorkflowDefinition  string   `json:"workflow_definition"`

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -924,6 +924,17 @@ func TestBrokerTaskCreateReusesExistingOpenTask(t *testing.T) {
 }
 
 func TestBrokerStoresLedgerAndReviewLifecycle(t *testing.T) {
+	oldPrepare := prepareTaskWorktree
+	oldCleanup := cleanupTaskWorktree
+	prepareTaskWorktree = func(taskID string) (string, string, error) {
+		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
+	}
+	cleanupTaskWorktree = func(path, branch string) error { return nil }
+	defer func() {
+		prepareTaskWorktree = oldPrepare
+		cleanupTaskWorktree = oldCleanup
+	}()
+
 	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
 	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
@@ -970,6 +981,9 @@ func TestBrokerStoresLedgerAndReviewLifecycle(t *testing.T) {
 	if task.PipelineStage != "implement" || task.ExecutionMode != "local_worktree" || task.SourceDecisionID != decision.ID {
 		t.Fatalf("expected structured task metadata, got %+v", task)
 	}
+	if task.WorktreePath == "" || task.WorktreeBranch == "" {
+		t.Fatalf("expected planned task worktree metadata, got %+v", task)
+	}
 
 	base := fmt.Sprintf("http://%s", b.Addr())
 	body, _ := json.Marshal(map[string]any{
@@ -1001,6 +1015,75 @@ func TestBrokerStoresLedgerAndReviewLifecycle(t *testing.T) {
 	}
 	if len(b.Decisions()) != 1 || len(b.Signals()) != 1 || len(b.Watchdogs()) != 1 {
 		t.Fatalf("expected ledger state, got signals=%d decisions=%d watchdogs=%d", len(b.Signals()), len(b.Decisions()), len(b.Watchdogs()))
+	}
+}
+
+func TestBrokerReleaseTaskCleansWorktree(t *testing.T) {
+	oldPrepare := prepareTaskWorktree
+	oldCleanup := cleanupTaskWorktree
+	var cleanedPath, cleanedBranch string
+	prepareTaskWorktree = func(taskID string) (string, string, error) {
+		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
+	}
+	cleanupTaskWorktree = func(path, branch string) error {
+		cleanedPath = path
+		cleanedBranch = branch
+		return nil
+	}
+	defer func() {
+		prepareTaskWorktree = oldPrepare
+		cleanupTaskWorktree = oldCleanup
+	}()
+
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
+		Channel:   "general",
+		Title:     "Build signup conversion fix",
+		Owner:     "fe",
+		CreatedBy: "ceo",
+		TaskType:  "feature",
+	})
+	if err != nil || reused {
+		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
+	}
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	body, _ := json.Marshal(map[string]any{
+		"action":     "release",
+		"channel":    "general",
+		"id":         task.ID,
+		"created_by": "ceo",
+	})
+	req, _ := http.NewRequest(http.MethodPost, base+"/tasks", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("release task: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode released task: %v", err)
+	}
+	if cleanedPath == "" || cleanedBranch == "" {
+		t.Fatalf("expected cleanup to run, got path=%q branch=%q", cleanedPath, cleanedBranch)
+	}
+	if result.Task.WorktreePath != "" || result.Task.WorktreeBranch != "" {
+		t.Fatalf("expected released task worktree metadata to clear, got %+v", result.Task)
 	}
 }
 

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -651,7 +651,22 @@ func (l *Launcher) taskNotificationContent(action officeActionLog, task teamTask
 	if strings.TrimSpace(task.ExecutionMode) != "" {
 		execMode = ", execution " + task.ExecutionMode
 	}
-	return fmt.Sprintf("[%s #%s on #%s]: %s%s (owner %s, status %s%s%s%s). Before you speak, call team_poll and team_tasks, confirm whether you own this work, and stay in your lane.", verb, task.ID, channel, task.Title, details, owner, status, pipeline, review, execMode)
+	worktree := ""
+	if strings.TrimSpace(task.WorktreeBranch) != "" || strings.TrimSpace(task.WorktreePath) != "" {
+		parts := make([]string, 0, 2)
+		if strings.TrimSpace(task.WorktreeBranch) != "" {
+			parts = append(parts, "branch "+task.WorktreeBranch)
+		}
+		if strings.TrimSpace(task.WorktreePath) != "" {
+			parts = append(parts, "path "+task.WorktreePath)
+		}
+		worktree = ", worktree " + strings.Join(parts, " · ")
+	}
+	guidance := ""
+	if path := strings.TrimSpace(task.WorktreePath); path != "" {
+		guidance = fmt.Sprintf(" If you own this task, use working_directory=%q for local file and bash tools.", path)
+	}
+	return fmt.Sprintf("[%s #%s on #%s]: %s%s (owner %s, status %s%s%s%s%s). Before you speak, call team_poll and team_tasks, confirm whether you own this work, and stay in your lane.%s", verb, task.ID, channel, task.Title, details, owner, status, pipeline, review, execMode, worktree, guidance)
 }
 
 func (l *Launcher) sendTaskUpdate(paneTarget, slug, channel, taskID, from, content string) {
@@ -2418,6 +2433,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("- team_channel_member: Add, remove, disable, or enable agents in a channel\n")
 		sb.WriteString("- team_bridge: CEO-only bridge that carries relevant context from one channel into another with a visible trail\n")
 		sb.WriteString("- team_tasks: See current owned/unowned work so the team does not duplicate effort\n")
+		sb.WriteString("- team_task_status: See how many team tasks are active and which ones are isolated in worktrees\n")
 		sb.WriteString("- team_task: Create and assign tasks so ownership is explicit\n")
 		sb.WriteString("- team_requests: See open human requests before asking again\n")
 		sb.WriteString("- team_request: Open structured requests for approvals, confirmations, freeform answers, or private answers\n")
@@ -2454,12 +2470,14 @@ func (l *Launcher) buildPrompt(slug string) string {
 		}
 		sb.WriteString("9. Once decided, broadcast clear task assignments and create them in team_task\n")
 		sb.WriteString("10. Create channels (team_channel) or agents (team_member) when the human asks or scope genuinely warrants it\n")
-		sb.WriteString("11. Use team_bridge to carry context between channels when relevant\n\n")
+		sb.WriteString("11. Use team_bridge to carry context between channels when relevant\n")
+		sb.WriteString("12. If a task shows a worktree path, that path is the working_directory for local file and bash tools on that task\n\n")
 		sb.WriteString("STYLE:\n")
 		sb.WriteString("- Respond FAST. Broadcast delegation IMMEDIATELY. Do NOT think for 30 seconds before your first broadcast.\n")
-		sb.WriteString("- Keep messages to 1-3 sentences. Delegate with @tags, don't explain everything.\n")
+		sb.WriteString("- Keep messages concise. Delegate with @tags, don't explain everything.\n")
 		sb.WriteString("- Minimize tool calls. team_poll once, then broadcast. Don't call team_tasks, team_members, query_context unless the question specifically needs it.\n")
 		sb.WriteString("- If you can answer directly, answer. Don't over-research.\n")
+		sb.WriteString("- Use markdown tables/checklists for structured data. A2UI JSON in ```a2ui fences for rich components.\n")
 		if config.ResolveNoNex() {
 			sb.WriteString("Do not claim you stored anything outside the office.\n")
 		} else {
@@ -2489,6 +2507,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("- team_channel_member: Add, remove, disable, or enable agents in a channel\n")
 		sb.WriteString("- team_bridge: CEO-only bridge for carrying context from one channel into another. Ask the CEO to use it when needed.\n")
 		sb.WriteString("- team_tasks: See the current task list and ownership before you jump in\n")
+		sb.WriteString("- team_task_status: See how many team tasks are active and which ones are isolated in worktrees\n")
 		sb.WriteString("- team_task: Claim, complete, block, or release tasks in your domain\n")
 		sb.WriteString("- team_requests: See open human requests so you do not duplicate them\n")
 		sb.WriteString("- team_request: Open structured requests for approvals, confirmations, freeform answers, or private answers\n")
@@ -2525,11 +2544,12 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("13. When DONE, broadcast your results AND findings: 'Done. Here's what I found: ...' Never finish silently.\n")
 		sb.WriteString("14. You can inspect other channel names and descriptions, but you do not have automatic access to their content unless you are a member there.\n")
 		sb.WriteString("15. If another channel may have context or needs help from your channel, ask the CEO to bridge it. Do not assume you can read or act inside channels you are not in.\n")
+		sb.WriteString("16. If a task or status line shows a worktree path, use that path as working_directory for local file and bash tools.\n")
 		if config.ResolveNoNex() {
-			sb.WriteString("16. Keep outcomes explicit in-thread so the rest of the team can build on them\n\n")
+			sb.WriteString("17. Keep outcomes explicit in-thread so the rest of the team can build on them\n\n")
 		} else {
-			sb.WriteString("16. Only use add_context for durable conclusions that should survive this session\n")
-			sb.WriteString("17. Do not claim something is stored in the graph unless add_context actually succeeded\n\n")
+			sb.WriteString("17. Only use add_context for durable conclusions that should survive this session\n")
+			sb.WriteString("18. Do not claim something is stored in the graph unless add_context actually succeeded\n\n")
 		}
 		sb.WriteString("STYLE:\n")
 		sb.WriteString("- Respond FAST. Broadcast a quick reply FIRST (even just 'on it' or 'looking into this'), THEN do deeper work, THEN broadcast results.\n")

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -636,6 +636,60 @@ func TestTaskNotificationContentIncludesOwnershipAndGuidance(t *testing.T) {
 	}
 }
 
+func TestTaskNotificationContentIncludesWorktreeDetails(t *testing.T) {
+	l := &Launcher{}
+	got := l.taskNotificationContent(officeActionLog{
+		Kind:  "task_updated",
+		Actor: "ceo",
+	}, teamTask{
+		ID:             "task-10",
+		Channel:        "general",
+		Title:          "Landing page polish",
+		Owner:          "fe",
+		Status:         "in_progress",
+		ExecutionMode:  "local_worktree",
+		WorktreeBranch: "wuphf-task-10",
+		WorktreePath:   "/tmp/wuphf-task-task-10",
+	})
+	if !strings.Contains(got, "execution local_worktree") {
+		t.Fatalf("expected execution mode in content: %q", got)
+	}
+	if !strings.Contains(got, "branch wuphf-task-10") || !strings.Contains(got, "path /tmp/wuphf-task-task-10") {
+		t.Fatalf("expected worktree details in content: %q", got)
+	}
+	if !strings.Contains(got, `working_directory="/tmp/wuphf-task-task-10"`) {
+		t.Fatalf("expected working_directory guidance in content: %q", got)
+	}
+}
+
+func TestBuildPromptIncludesTaskStatusAndWorktreeGuidance(t *testing.T) {
+	l := &Launcher{
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend Engineer"},
+			},
+		},
+	}
+
+	specialist := l.buildPrompt("fe")
+	if !strings.Contains(specialist, "team_task_status") {
+		t.Fatalf("expected team_task_status guidance in specialist prompt: %q", specialist)
+	}
+	if !strings.Contains(specialist, "working_directory") {
+		t.Fatalf("expected working_directory guidance in specialist prompt: %q", specialist)
+	}
+
+	lead := l.buildPrompt("ceo")
+	if !strings.Contains(lead, "team_task_status") {
+		t.Fatalf("expected team_task_status guidance in lead prompt: %q", lead)
+	}
+	if !strings.Contains(lead, "working_directory") {
+		t.Fatalf("expected working_directory guidance in lead prompt: %q", lead)
+	}
+}
+
 func TestTaskNotificationTargetsWakeOwnerOnWatchdog(t *testing.T) {
 	l := &Launcher{
 		broker: &Broker{

--- a/internal/team/worktree.go
+++ b/internal/team/worktree.go
@@ -1,0 +1,100 @@
+package team
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var prepareTaskWorktree = defaultPrepareTaskWorktree
+var cleanupTaskWorktree = defaultCleanupTaskWorktree
+
+func defaultPrepareTaskWorktree(taskID string) (string, string, error) {
+	repoRoot, err := gitRepoRoot()
+	if err != nil {
+		return "", "", err
+	}
+
+	branch := worktreeBranchName(taskID)
+	path := filepath.Join(os.TempDir(), "wuphf-task-"+sanitizeWorktreeToken(taskID))
+	if _, err := os.Stat(path); err == nil {
+		return path, branch, nil
+	}
+
+	if err := runGit(repoRoot, "worktree", "add", "-b", branch, path, "HEAD"); err == nil {
+		return path, branch, nil
+	}
+	if err := runGit(repoRoot, "worktree", "add", path, branch); err == nil {
+		return path, branch, nil
+	}
+
+	return "", "", fmt.Errorf("create git worktree for %s", taskID)
+}
+
+func defaultCleanupTaskWorktree(path, branch string) error {
+	repoRoot, err := gitRepoRoot()
+	if err != nil {
+		return err
+	}
+
+	if strings.TrimSpace(path) != "" {
+		if err := runGit(repoRoot, "worktree", "remove", "--force", path); err != nil {
+			if _, statErr := os.Stat(path); statErr == nil {
+				return err
+			}
+		}
+	}
+	if strings.TrimSpace(branch) != "" {
+		_ = runGit(repoRoot, "branch", "-D", branch)
+	}
+	return nil
+}
+
+func gitRepoRoot() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("resolve repo root: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func runGit(dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return nil
+}
+
+func worktreeBranchName(taskID string) string {
+	return "wuphf-" + sanitizeWorktreeToken(taskID)
+}
+
+func sanitizeWorktreeToken(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return "task"
+	}
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	return strings.Trim(strings.ReplaceAll(b.String(), "--", "-"), "-")
+}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -125,6 +125,8 @@ type brokerTaskSummary struct {
 	ReviewState      string   `json:"review_state"`
 	SourceSignalID   string   `json:"source_signal_id"`
 	SourceDecisionID string   `json:"source_decision_id"`
+	WorktreePath     string   `json:"worktree_path"`
+	WorktreeBranch   string   `json:"worktree_branch"`
 	DependsOn        []string `json:"depends_on,omitempty"`
 	Blocked          bool     `json:"blocked,omitempty"`
 }
@@ -387,6 +389,11 @@ func Run(ctx context.Context) error {
 		Name:        "team_tasks",
 		Description: "List the current shared tasks and who owns them so the team does not duplicate work.",
 	}, handleTeamTasks)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "team_task_status",
+		Description: "Summarize how many shared tasks are running and whether any are isolated in local worktrees.",
+	}, handleTeamTaskStatus)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "team_task",
@@ -814,61 +821,27 @@ func handleTeamOfficeMembers(ctx context.Context, _ *mcp.CallToolRequest, _ Team
 }
 
 func handleTeamTasks(ctx context.Context, _ *mcp.CallToolRequest, args TeamTasksArgs) (*mcp.CallToolResult, any, error) {
-	mySlug := strings.TrimSpace(resolveSlugOptional(args.MySlug))
-	channel := resolveChannel(args.Channel)
-	values := url.Values{}
-	values.Set("channel", channel)
-	if mySlug != "" {
-		values.Set("viewer_slug", mySlug)
-	}
-	if mySlug != "" {
-		values.Set("my_slug", mySlug)
-	}
-	if args.IncludeDone {
-		values.Set("include_done", "true")
-	}
-	var result brokerTasksResponse
-	path := "/tasks"
-	if encoded := values.Encode(); encoded != "" {
-		path += "?" + encoded
-	}
-	if err := brokerGetJSON(ctx, path, &result); err != nil {
+	channel, tasks, err := fetchTeamTasks(ctx, args)
+	if err != nil {
 		return toolError(err), nil, nil
 	}
-	if len(result.Tasks) == 0 {
+	if len(tasks) == 0 {
 		return textResult("No active team tasks."), nil, nil
 	}
-	lines := make([]string, 0, len(result.Tasks))
-	for _, task := range result.Tasks {
-		line := fmt.Sprintf("- %s [%s]", task.ID, task.Status)
-		if task.Blocked {
-			line += " BLOCKED"
-		}
-		if task.Owner != "" {
-			line += " @" + task.Owner
-		}
-		if task.PipelineStage != "" {
-			line += " · stage " + task.PipelineStage
-		}
-		if task.ReviewState != "" && task.ReviewState != "not_required" {
-			line += " · review " + task.ReviewState
-		}
-		if task.ExecutionMode != "" {
-			line += " · " + task.ExecutionMode
-		}
-		line += " — " + task.Title
-		if len(task.DependsOn) > 0 {
-			line += " (deps: " + strings.Join(task.DependsOn, ", ") + ")"
-		}
-		if task.ThreadID != "" {
-			line += " ↳ " + task.ThreadID
-		}
-		if task.Details != "" {
-			line += " (" + task.Details + ")"
-		}
-		lines = append(lines, line)
+	lines := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		lines = append(lines, formatTaskRuntimeLine(task))
 	}
-	return textResult("Current team tasks in #" + channel + ":\n" + strings.Join(lines, "\n")), nil, nil
+	status := summarizeTaskRuntime(channel, tasks)
+	return textResult(status + "\n\nCurrent team tasks:\n" + strings.Join(lines, "\n")), nil, nil
+}
+
+func handleTeamTaskStatus(ctx context.Context, _ *mcp.CallToolRequest, args TeamTasksArgs) (*mcp.CallToolResult, any, error) {
+	channel, tasks, err := fetchTeamTasks(ctx, args)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	return textResult(summarizeTaskRuntime(channel, tasks)), nil, nil
 }
 
 func handleTeamTask(ctx context.Context, _ *mcp.CallToolRequest, args TeamTaskArgs) (*mcp.CallToolResult, any, error) {
@@ -903,11 +876,14 @@ func handleTeamTask(ctx context.Context, _ *mcp.CallToolRequest, args TeamTaskAr
 
 	var result struct {
 		Task struct {
-			ID      string `json:"id"`
-			Title   string `json:"title"`
-			Owner   string `json:"owner"`
-			Status  string `json:"status"`
-			Blocked bool   `json:"blocked"`
+			ID             string `json:"id"`
+			Title          string `json:"title"`
+			Owner          string `json:"owner"`
+			Status         string `json:"status"`
+			ExecutionMode  string `json:"execution_mode"`
+			WorktreePath   string `json:"worktree_path"`
+			WorktreeBranch string `json:"worktree_branch"`
+			Blocked        bool   `json:"blocked"`
 		} `json:"task"`
 	}
 	if err := brokerPostJSON(ctx, "/tasks", payload, &result); err != nil {
@@ -920,8 +896,136 @@ func handleTeamTask(ctx context.Context, _ *mcp.CallToolRequest, args TeamTaskAr
 	if result.Task.Owner != "" {
 		text += " @" + result.Task.Owner
 	}
+	if branch := strings.TrimSpace(result.Task.WorktreeBranch); branch != "" {
+		text += " · branch " + branch
+	}
+	if path := strings.TrimSpace(result.Task.WorktreePath); path != "" {
+		text += " · working_directory " + path
+	}
 	text += " — " + result.Task.Title
 	return textResult(text), nil, nil
+}
+
+func fetchTeamTasks(ctx context.Context, args TeamTasksArgs) (string, []brokerTaskSummary, error) {
+	mySlug := strings.TrimSpace(resolveSlugOptional(args.MySlug))
+	channel := resolveChannel(args.Channel)
+	values := url.Values{}
+	values.Set("channel", channel)
+	if mySlug != "" {
+		values.Set("viewer_slug", mySlug)
+		values.Set("my_slug", mySlug)
+	}
+	if args.IncludeDone {
+		values.Set("include_done", "true")
+	}
+	var result brokerTasksResponse
+	path := "/tasks"
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	if err := brokerGetJSON(ctx, path, &result); err != nil {
+		return "", nil, err
+	}
+	return channel, result.Tasks, nil
+}
+
+func summarizeTaskRuntime(channel string, tasks []brokerTaskSummary) string {
+	if len(tasks) == 0 {
+		return "No active team tasks."
+	}
+
+	running := 0
+	isolated := 0
+	reviewing := 0
+	for _, task := range tasks {
+		if taskCountsAsRunning(task) {
+			running++
+		}
+		if taskUsesIsolation(task) {
+			isolated++
+		}
+		if strings.TrimSpace(task.ReviewState) != "" && task.ReviewState != "not_required" && task.ReviewState != "approved" {
+			reviewing++
+		}
+	}
+
+	lines := []string{
+		fmt.Sprintf("Team task status in #%s:", channel),
+		fmt.Sprintf("- Running tasks: %d of %d", running, len(tasks)),
+		fmt.Sprintf("- Isolated worktrees: %d", isolated),
+		fmt.Sprintf("- In review flow: %d", reviewing),
+	}
+
+	isolatedTasks := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		if !taskUsesIsolation(task) {
+			continue
+		}
+		line := fmt.Sprintf("- %s", task.ID)
+		if task.Owner != "" {
+			line += " @" + task.Owner
+		}
+		if branch := strings.TrimSpace(task.WorktreeBranch); branch != "" {
+			line += " · branch " + branch
+		}
+		if path := strings.TrimSpace(task.WorktreePath); path != "" {
+			line += " · working_directory " + path
+		}
+		isolatedTasks = append(isolatedTasks, line)
+	}
+	if len(isolatedTasks) > 0 {
+		lines = append(lines, "", "Isolated task worktrees:")
+		lines = append(lines, isolatedTasks...)
+		lines = append(lines, "", "For isolated tasks, use the listed worktree path as working_directory for local file and bash tools.")
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func formatTaskRuntimeLine(task brokerTaskSummary) string {
+	line := fmt.Sprintf("- %s [%s]", task.ID, task.Status)
+	if task.Owner != "" {
+		line += " @" + task.Owner
+	}
+	if task.PipelineStage != "" {
+		line += " · stage " + task.PipelineStage
+	}
+	if task.ReviewState != "" && task.ReviewState != "not_required" {
+		line += " · review " + task.ReviewState
+	}
+	if task.ExecutionMode != "" {
+		line += " · " + task.ExecutionMode
+	}
+	if branch := strings.TrimSpace(task.WorktreeBranch); branch != "" {
+		line += " · branch " + branch
+	}
+	if path := strings.TrimSpace(task.WorktreePath); path != "" {
+		line += " · working_directory " + path
+	}
+	line += " — " + task.Title
+	if task.ThreadID != "" {
+		line += " ↳ " + task.ThreadID
+	}
+	if task.Details != "" {
+		line += " (" + task.Details + ")"
+	}
+	return line
+}
+
+func taskUsesIsolation(task brokerTaskSummary) bool {
+	return strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") ||
+		strings.TrimSpace(task.WorktreePath) != "" ||
+		strings.TrimSpace(task.WorktreeBranch) != ""
+}
+
+func taskCountsAsRunning(task brokerTaskSummary) bool {
+	status := strings.ToLower(strings.TrimSpace(task.Status))
+	switch status {
+	case "", "done", "completed", "canceled", "cancelled":
+		return false
+	default:
+		return true
+	}
 }
 
 func handleTeamPlan(ctx context.Context, _ *mcp.CallToolRequest, args TeamPlanArgs) (*mcp.CallToolResult, any, error) {

--- a/internal/teammcp/server_test.go
+++ b/internal/teammcp/server_test.go
@@ -1,6 +1,7 @@
 package teammcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -11,6 +12,18 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/nex-crm/wuphf/internal/team"
 )
+
+func textFromResult(t *testing.T, result *mcp.CallToolResult) string {
+	t.Helper()
+	if result == nil || len(result.Content) == 0 {
+		t.Fatal("expected text result")
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("expected text content, got %T", result.Content[0])
+	}
+	return text.Text
+}
 
 func TestSuppressBroadcastReasonAllowsViewpoints(t *testing.T) {
 	reason := suppressBroadcastReason(
@@ -255,5 +268,194 @@ func TestHandleTeamPollOneOnOneHighlightsLatestHumanRequest(t *testing.T) {
 	}
 	if !strings.Contains(text.Text, "Newest request wins.") {
 		t.Fatalf("expected latest human message in %q", text.Text)
+	}
+}
+
+func TestSummarizeTaskRuntimeIncludesIsolationCounts(t *testing.T) {
+	summary := summarizeTaskRuntime("general", []brokerTaskSummary{
+		{
+			ID:             "task-1",
+			Owner:          "fe",
+			Status:         "in_progress",
+			ExecutionMode:  "local_worktree",
+			WorktreePath:   "/tmp/wuphf-task-1",
+			WorktreeBranch: "feat/task-1",
+			Title:          "Implement landing page",
+		},
+		{
+			ID:          "task-2",
+			Owner:       "pm",
+			Status:      "review",
+			ReviewState: "ready_for_review",
+			Title:       "Review launch scope",
+		},
+	})
+
+	if !strings.Contains(summary, "Running tasks: 2 of 2") {
+		t.Fatalf("expected running count in %q", summary)
+	}
+	if !strings.Contains(summary, "Isolated worktrees: 1") {
+		t.Fatalf("expected isolation count in %q", summary)
+	}
+	if !strings.Contains(summary, "branch feat/task-1") {
+		t.Fatalf("expected worktree branch in %q", summary)
+	}
+	if !strings.Contains(summary, "/tmp/wuphf-task-1") {
+		t.Fatalf("expected worktree path in %q", summary)
+	}
+	if !strings.Contains(summary, "working_directory") {
+		t.Fatalf("expected working_directory guidance in %q", summary)
+	}
+}
+
+func TestHandleTeamTaskStatusReportsWorktreeIsolation(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	payload := map[string]any{
+		"action":          "create",
+		"channel":         "general",
+		"title":           "Implement worktree task",
+		"owner":           "fe",
+		"created_by":      "ceo",
+		"execution_mode":  "local_worktree",
+		"worktree_path":   "/tmp/wuphf-task-42",
+		"worktree_branch": "task/42",
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal task payload: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks", b.Addr()), bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 creating task, got %d", resp.StatusCode)
+	}
+
+	result, _, err := handleTeamTaskStatus(context.Background(), nil, TeamTasksArgs{
+		Channel: "general",
+		MySlug:  "fe",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamTaskStatus: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "Running tasks: 1 of 1") {
+		t.Fatalf("expected runtime count in %q", text)
+	}
+	if !strings.Contains(text, "Isolated worktrees: 1") {
+		t.Fatalf("expected isolation count in %q", text)
+	}
+	if !strings.Contains(text, "branch task/42") {
+		t.Fatalf("expected worktree branch in %q", text)
+	}
+	if !strings.Contains(text, "/tmp/wuphf-task-42") {
+		t.Fatalf("expected worktree path in %q", text)
+	}
+	if !strings.Contains(text, "working_directory") {
+		t.Fatalf("expected working_directory guidance in %q", text)
+	}
+
+	tasksResult, _, err := handleTeamTasks(context.Background(), nil, TeamTasksArgs{
+		Channel: "general",
+		MySlug:  "fe",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamTasks: %v", err)
+	}
+	tasksText := textFromResult(t, tasksResult)
+	if !strings.Contains(tasksText, "Current team tasks:") {
+		t.Fatalf("expected task listing header in %q", tasksText)
+	}
+	if !strings.Contains(tasksText, "branch task/42") {
+		t.Fatalf("expected worktree branch in task listing %q", tasksText)
+	}
+	if !strings.Contains(tasksText, "working_directory /tmp/wuphf-task-42") {
+		t.Fatalf("expected working_directory path in task listing %q", tasksText)
+	}
+}
+
+func TestHandleTeamTaskReturnsWorktreeGuidance(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	payload := map[string]any{
+		"action":          "create",
+		"channel":         "general",
+		"title":           "Implement worktree task",
+		"owner":           "fe",
+		"created_by":      "ceo",
+		"execution_mode":  "local_worktree",
+		"worktree_path":   "/tmp/wuphf-task-99",
+		"worktree_branch": "task/99",
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal task payload: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks", b.Addr()), bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 creating task, got %d", resp.StatusCode)
+	}
+
+	var created struct {
+		Task struct {
+			ID string `json:"id"`
+		} `json:"task"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode created task: %v", err)
+	}
+
+	result, _, err := handleTeamTask(context.Background(), nil, TeamTaskArgs{
+		Action:  "review",
+		Channel: "general",
+		ID:      created.Task.ID,
+		MySlug:  "fe",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamTask: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "branch task/99") {
+		t.Fatalf("expected worktree branch in %q", text)
+	}
+	if !strings.Contains(text, "working_directory /tmp/wuphf-task-99") {
+		t.Fatalf("expected working_directory guidance in %q", text)
 	}
 }

--- a/internal/tui/init_flow_test.go
+++ b/internal/tui/init_flow_test.go
@@ -15,7 +15,7 @@ func TestInitFlowStartsWithAPIKeyStepWhenMissing(t *testing.T) {
 	}
 }
 
-func TestInitFlowSkipsToProviderWhenAPIKeyExists(t *testing.T) {
+func TestInitFlowSkipsToPackWhenAPIKeyExists(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	if err := config.Save(config.Config{APIKey: "wuphf-key"}); err != nil {
 		t.Fatalf("save config: %v", err)
@@ -24,6 +24,9 @@ func TestInitFlowSkipsToProviderWhenAPIKeyExists(t *testing.T) {
 	flow, _ := NewInitFlow().Start()
 	if flow.Phase() != InitPackChoice {
 		t.Fatalf("expected pack choice phase, got %q", flow.Phase())
+	}
+	if flow.provider != "claude-code" {
+		t.Fatalf("expected provider to default to claude-code, got %q", flow.provider)
 	}
 }
 

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -6,6 +6,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/sahilm/fuzzy"
 )
 
 type PickerOption struct {
@@ -17,6 +18,8 @@ type PickerOption struct {
 type PickerModel struct {
 	Title      string
 	Options    []PickerOption
+	query      string
+	filtered   []int
 	selected   int
 	active     bool
 	OnSelect   func(value string)
@@ -27,10 +30,12 @@ type PickerModel struct {
 }
 
 func NewPicker(title string, options []PickerOption) PickerModel {
-	return PickerModel{
+	p := PickerModel{
 		Title:   title,
 		Options: options,
 	}
+	p.applyFilter("")
+	return p
 }
 
 func (p PickerModel) Update(msg tea.Msg) (PickerModel, tea.Cmd) {
@@ -43,17 +48,19 @@ func (p PickerModel) Update(msg tea.Msg) (PickerModel, tea.Cmd) {
 			return p.updateTextInput(msg)
 		}
 		switch msg.String() {
-		case "up", "k":
-			if p.selected > 0 {
-				p.selected--
+		case "up":
+			p.moveSelection(-1)
+		case "down":
+			p.moveSelection(1)
+		case "backspace":
+			if len(p.query) > 0 {
+				query := []rune(p.query)
+				p.applyFilter(string(query[:len(query)-1]))
 			}
-		case "down", "j":
-			if p.selected < len(p.Options)-1 {
-				p.selected++
-			}
+		case "esc":
+			p.active = false
 		case "enter":
-			if len(p.Options) > 0 {
-				opt := p.Options[p.selected]
+			if opt, ok := p.selectedOption(); ok {
 				if p.OnSelect != nil {
 					p.OnSelect(opt.Value)
 				}
@@ -61,22 +68,29 @@ func (p PickerModel) Update(msg tea.Msg) (PickerModel, tea.Cmd) {
 					return PickerSelectMsg{Value: opt.Value, Label: opt.Label}
 				}
 			}
-		default:
-			// 1-9 quick-select
-			key := msg.String()
-			if len(key) == 1 && key[0] >= '1' && key[0] <= '9' {
-				idx := int(key[0] - '1')
-				if idx < len(p.Options) {
+		case "ctrl+u":
+			p.applyFilter("")
+		}
+
+		switch msg.Type {
+		case tea.KeyRunes:
+			if len(msg.Runes) == 1 && msg.Runes[0] >= '1' && msg.Runes[0] <= '9' {
+				idx := int(msg.Runes[0] - '1')
+				if idx < len(p.filtered) {
 					p.selected = idx
-					opt := p.Options[idx]
-					if p.OnSelect != nil {
-						p.OnSelect(opt.Value)
-					}
-					return p, func() tea.Msg {
-						return PickerSelectMsg{Value: opt.Value, Label: opt.Label}
+					if opt, ok := p.selectedOption(); ok {
+						if p.OnSelect != nil {
+							p.OnSelect(opt.Value)
+						}
+						return p, func() tea.Msg {
+							return PickerSelectMsg{Value: opt.Value, Label: opt.Label}
+						}
 					}
 				}
 			}
+			p.applyFilter(p.query + string(msg.Runes))
+		case tea.KeySpace:
+			p.applyFilter(p.query + " ")
 		}
 	}
 	return p, nil
@@ -151,30 +165,126 @@ func (p PickerModel) View() string {
 	descStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(MutedColor))
 
-	for i, opt := range p.Options {
-		num := fmt.Sprintf("%d. ", i+1)
-		label := num + opt.Label
-		var row string
+	searchStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(MutedColor))
+
+	var rows []string
+	rows = append(rows, TitleStyle.Render(p.Title))
+	rows = append(rows, searchStyle.Render("Search: "+p.query))
+
+	if len(p.filtered) == 0 {
+		rows = append(rows, descStyle.Render("No matches"))
+		return strings.Join(rows, "\n")
+	}
+
+	for i, idx := range p.filtered {
+		opt := p.Options[idx]
+		prefix := "  "
+		labelStyle := normal
 		if i == p.selected {
-			row = highlighted.Render(label)
-		} else {
-			row = normal.Render(label)
+			prefix = "> "
+			labelStyle = highlighted
 		}
+
+		label := opt.Label
+		if i < 9 {
+			label = fmt.Sprintf("%d. %s", i+1, label)
+		}
+		row := prefix + labelStyle.Render(label)
 		if opt.Description != "" {
 			row += " " + descStyle.Render(opt.Description)
 		}
-		sb.WriteString(row + "\n")
+		rows = append(rows, row)
 	}
 
-	return sb.String()
+	return strings.Join(rows, "\n")
 }
 
 func (p *PickerModel) SetActive(active bool) {
 	p.active = active
+	if active {
+		p.applyFilter("")
+	}
 }
 
 func (p PickerModel) IsActive() bool {
 	return p.active
+}
+
+func (p *PickerModel) applyFilter(query string) {
+	p.query = query
+	p.selected = 0
+
+	if len(p.Options) == 0 {
+		p.filtered = nil
+		return
+	}
+
+	if strings.TrimSpace(query) == "" {
+		p.filtered = p.filtered[:0]
+		for i := range p.Options {
+			p.filtered = append(p.filtered, i)
+		}
+		return
+	}
+
+	matches := fuzzy.FindFrom(query, pickerOptions(p.Options))
+	p.filtered = p.filtered[:0]
+	for _, match := range matches {
+		p.filtered = append(p.filtered, match.Index)
+	}
+}
+
+func (p *PickerModel) moveSelection(delta int) {
+	if len(p.filtered) == 0 {
+		return
+	}
+
+	next := p.selected + delta
+	if next < 0 {
+		next = 0
+	}
+	if next >= len(p.filtered) {
+		next = len(p.filtered) - 1
+	}
+	p.selected = next
+}
+
+func (p PickerModel) selectedOption() (PickerOption, bool) {
+	if len(p.filtered) == 0 || p.selected < 0 || p.selected >= len(p.filtered) {
+		return PickerOption{}, false
+	}
+	return p.Options[p.filtered[p.selected]], true
+}
+
+func (p *PickerModel) UpdateQuery(query string) {
+	p.applyFilter(query)
+}
+
+func (p PickerModel) Query() string {
+	return p.query
+}
+
+func (p PickerModel) FilteredOptions() []PickerOption {
+	if len(p.filtered) == 0 {
+		return nil
+	}
+
+	options := make([]PickerOption, 0, len(p.filtered))
+	for _, idx := range p.filtered {
+		options = append(options, p.Options[idx])
+	}
+	return options
+}
+
+type pickerOptions []PickerOption
+
+func (p pickerOptions) String(i int) string {
+	return p[i].Label
+}
+
+func (p pickerOptions) Len() int {
+	return len(p)
 }
 
 // ConfirmModel

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -19,6 +19,9 @@ func TestPickerArrowNavigation(t *testing.T) {
 	if p.selected != 0 {
 		t.Fatal("expected initial selection to be 0")
 	}
+	if len(p.filtered) != len(testOptions) {
+		t.Fatalf("expected %d visible options, got %d", len(testOptions), len(p.filtered))
+	}
 
 	downMsg := tea.KeyMsg{Type: tea.KeyDown}
 	p2, _ := p.Update(downMsg)
@@ -33,30 +36,18 @@ func TestPickerArrowNavigation(t *testing.T) {
 	}
 }
 
-func TestPickerNumberKeySelection(t *testing.T) {
-	var got string
+func TestPickerFuzzyFilter(t *testing.T) {
 	p := NewPicker("Choose", testOptions)
-	p.SetActive(true)
-	p.OnSelect = func(v string) { got = v }
+	p.UpdateQuery("gm")
 
-	msg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'2'}}
-	p2, cmd := p.Update(msg)
-	if p2.selected != 1 {
-		t.Fatalf("expected selected=1 after pressing '2', got %d", p2.selected)
+	if got := p.Query(); got != "gm" {
+		t.Fatalf("expected query to be %q, got %q", "gm", got)
 	}
-	if got != "beta" {
-		t.Fatalf("expected OnSelect called with 'beta', got %q", got)
+	if len(p.filtered) != 1 {
+		t.Fatalf("expected 1 fuzzy match, got %d", len(p.filtered))
 	}
-	if cmd == nil {
-		t.Fatal("expected a PickerSelectMsg command")
-	}
-	result := cmd()
-	sel, ok := result.(PickerSelectMsg)
-	if !ok {
-		t.Fatal("expected PickerSelectMsg")
-	}
-	if sel.Value != "beta" {
-		t.Fatalf("expected value 'beta', got %q", sel.Value)
+	if got := p.FilteredOptions()[0].Value; got != "gamma" {
+		t.Fatalf("expected fuzzy match to select gamma, got %q", got)
 	}
 }
 
@@ -79,6 +70,32 @@ func TestPickerEnterEmitsMsg(t *testing.T) {
 	}
 }
 
+func TestPickerEnterUsesFilteredSelection(t *testing.T) {
+	var got string
+	p := NewPicker("Choose", testOptions)
+	p.SetActive(true)
+	p.OnSelect = func(v string) { got = v }
+
+	p.UpdateQuery("gm")
+
+	msg := tea.KeyMsg{Type: tea.KeyEnter}
+	_, cmd := p.Update(msg)
+	if cmd == nil {
+		t.Fatal("expected command on Enter")
+	}
+	result := cmd()
+	sel, ok := result.(PickerSelectMsg)
+	if !ok {
+		t.Fatal("expected PickerSelectMsg")
+	}
+	if sel.Value != "gamma" {
+		t.Fatalf("expected 'gamma', got %q", sel.Value)
+	}
+	if got != "gamma" {
+		t.Fatalf("expected OnSelect called with 'gamma', got %q", got)
+	}
+}
+
 func TestPickerInactiveIgnoresKeys(t *testing.T) {
 	p := NewPicker("Choose", testOptions)
 	// active is false by default
@@ -87,6 +104,16 @@ func TestPickerInactiveIgnoresKeys(t *testing.T) {
 	p2, _ := p.Update(msg)
 	if p2.selected != 0 {
 		t.Fatal("expected selection unchanged when picker is inactive")
+	}
+}
+
+func TestPickerEscCloses(t *testing.T) {
+	p := NewPicker("Choose", testOptions)
+	p.SetActive(true)
+
+	p2, _ := p.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if p2.IsActive() {
+		t.Fatal("expected picker to close on esc")
 	}
 }
 

--- a/internal/tui/stream.go
+++ b/internal/tui/stream.go
@@ -977,10 +977,66 @@ func (m StreamModel) renderMessage(msg StreamMessage, width int) string {
 	case "tool_use":
 		return toolUseStyle.Render("  ⚡ " + msg.AgentName + " → " + msg.Content)
 	case "tool_result":
-		return toolResultStyle.Render("  ↳ " + msg.Content)
+		return toolResultStyle.Render("  ↳ " + summarizeToolResult(msg.Content))
 	default:
 		return msg.Content
 	}
+}
+
+func summarizeToolResult(content string) string {
+	if !shouldFoldToolResult(content) {
+		return content
+	}
+
+	lineCount := countLines(content)
+	first, last := summarizeEdgeLines(content)
+	summary := fmt.Sprintf("[folded output: %d lines, %d chars]", lineCount, len(content))
+	if first != "" {
+		summary += " " + first
+	}
+	if last != "" && last != first {
+		summary += " ... " + last
+	}
+	return summary
+}
+
+func shouldFoldToolResult(content string) bool {
+	return countLines(content) > 10 || len(content) > 500
+}
+
+func countLines(content string) int {
+	if content == "" {
+		return 0
+	}
+	return strings.Count(content, "\n") + 1
+}
+
+func summarizeEdgeLines(content string) (string, string) {
+	lines := strings.Split(content, "\n")
+	first := ""
+	last := ""
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if first == "" {
+			first = truncateToolSummaryLine(line, 60)
+		}
+		last = truncateToolSummaryLine(line, 60)
+	}
+	return first, last
+}
+
+func truncateToolSummaryLine(text string, max int) string {
+	runes := []rune(text)
+	if len(runes) <= max {
+		return text
+	}
+	if max <= 1 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-1]) + "..."
 }
 
 // agentPrefix returns a styled name prefix based on the agent's role.

--- a/internal/tui/stream_test.go
+++ b/internal/tui/stream_test.go
@@ -8,10 +8,15 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/orchestration"
 )
+
+func stripStreamANSI(s string) string {
+	return ansi.Strip(s)
+}
 
 func newTestStreamModel() StreamModel {
 	agentSvc := agent.NewAgentService()
@@ -202,6 +207,53 @@ func TestSlashThinkingTogglesVisibility(t *testing.T) {
 	expanded := m2.renderMessages(100, 10)
 	if !strings.Contains(expanded, "hidden reasoning") {
 		t.Fatal("expected thinking content when expanded")
+	}
+}
+
+func TestRenderMessageKeepsShortToolResultsExpanded(t *testing.T) {
+	m := newTestStreamModel()
+	msg := StreamMessage{
+		Role:      "tool_result",
+		AgentSlug: "fe",
+		AgentName: "Frontend Engineer",
+		Content:   "ok",
+	}
+
+	rendered := stripStreamANSI(m.renderMessage(msg, 100))
+	if !strings.Contains(rendered, "ok") {
+		t.Fatalf("expected short tool output to remain visible, got %q", rendered)
+	}
+	if strings.Contains(rendered, "[folded output:") {
+		t.Fatalf("expected short tool output not to fold, got %q", rendered)
+	}
+}
+
+func TestRenderMessageFoldsLargeToolResults(t *testing.T) {
+	m := newTestStreamModel()
+	var lines []string
+	for i := 0; i < 12; i++ {
+		lines = append(lines, strings.Repeat("line", 12)+strings.Repeat(string(rune('a'+i)), 8))
+	}
+	content := strings.Join(lines, "\n")
+	msg := StreamMessage{
+		Role:      "tool_result",
+		AgentSlug: "fe",
+		AgentName: "Frontend Engineer",
+		Content:   content,
+	}
+
+	rendered := stripStreamANSI(m.renderMessage(msg, 100))
+	if !strings.Contains(rendered, "[folded output: 12 lines") {
+		t.Fatalf("expected folded summary, got %q", rendered)
+	}
+	if !strings.Contains(rendered, lines[0]) {
+		t.Fatalf("expected first line in folded summary, got %q", rendered)
+	}
+	if !strings.Contains(rendered, lines[len(lines)-1]) {
+		t.Fatalf("expected last line in folded summary, got %q", rendered)
+	}
+	if msg.Content != content {
+		t.Fatal("expected folding to leave original tool content unchanged")
 	}
 }
 


### PR DESCRIPTION
## What changed
This PR carries the intended CC-agent-inspired office upgrade work on top of current `main`, without the unrelated A2UI workflow-runtime branch history.

It includes:
- fuzzy picker and channel-switch UX updates
- local coding tools and folded tool-output rendering
- worktree-backed task isolation and surfaced runtime status
- office compaction/runtime plumbing and related TUI updates
- the blueprint documents used to drive the phased work

## Why it changed
The earlier branch and PR were built on top of an older workflow-runtime branch, which polluted the review surface with unrelated commits. This branch is rebuilt directly from `main` so the diff only reflects the intended office/runtime changes.

## Impact
- reviewers can evaluate the CC-agent office upgrades without unrelated workflow-runtime history
- the branch is integrated with current `main` behavior around channel UI, doctor/runtime-strip, task APIs, and shared team memory
- the repo remains green after transplanting the changes onto current `main`

## Validation
- `go test ./...`
