### PR TITLE
[codex] Bring WUPHF closer to the CC-agent product feel

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -445,6 +445,8 @@ var channelSlashCommands = []tui.SlashCommand{
 	{Name: "connect", Description: "Connect an external channel (Telegram, Slack, Discord)", Category: "setup"},
 	{Name: "1o1", Description: "Enable, switch, or disable direct 1:1 mode", Category: "session"},
 	{Name: "messages", Description: "Show the main office feed", Category: "navigate"},
+	{Name: "recover", Description: "Open the session recovery summary", Category: "navigate"},
+	{Name: "resume", Description: "Alias for /recover", Category: "navigate"},
 	{Name: "switcher", Description: "Open the unified office/direct switcher", Category: "navigate"},
 	{Name: "tasks", Description: "Show active work in this channel", Category: "navigate"},
 	{Name: "switch", Description: "Switch to another channel", Category: "navigate"},
@@ -524,6 +526,7 @@ type officeApp string
 
 const (
 	officeAppMessages officeApp = "messages"
+	officeAppRecovery officeApp = "recovery"
 	officeAppTasks    officeApp = "tasks"
 	officeAppRequests officeApp = "requests"
 	officeAppPolicies officeApp = "policies"
@@ -2156,10 +2159,10 @@ func (m channelModel) View() string {
 			Padding(0, 1).
 			Bold(true).
 			Render(fmt.Sprintf("%d new", m.unreadCount))
-		if strings.TrimSpace(m.awaySummary) != "" {
+		if awaySummary := m.currentAwaySummary(); strings.TrimSpace(awaySummary) != "" {
 			headerMeta += "  " + lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#BFDBFE")).
-				Render(m.awaySummary)
+				Render(awaySummary)
 		}
 	}
 	if m.pending != nil {
@@ -2247,13 +2250,7 @@ func (m channelModel) View() string {
 		visible = append(visible, "")
 	}
 	if m.activeApp == officeAppMessages && m.unreadCount > 0 && scroll > 0 && len(visible) > 0 {
-		jumpLabel := lipgloss.NewStyle().
-			Foreground(lipgloss.Color("#FFFFFF")).
-			Background(lipgloss.Color(slackActive)).
-			Padding(0, 1).
-			Bold(true).
-			Render(fmt.Sprintf("Jump to latest · %d new", m.unreadCount))
-		visible[0] = "  " + jumpLabel
+		visible[0] = renderAwayStrip(contentWidth, m.unreadCount, m.currentAwaySummary())
 	}
 	if popup := m.renderActivePopup(contentWidth); popup != "" && m.focus == focusMain {
 		visible = overlayBottomLines(visible, strings.Split(popup, "\n"))
@@ -2396,10 +2393,15 @@ func (m channelModel) View() string {
 }
 
 func (m channelModel) currentHeaderTitle() string {
-	if m.isOneOnOne() {
+	if m.isOneOnOne() && m.activeApp != officeAppRecovery {
 		return "1:1 with " + m.oneOnOneAgentName()
 	}
 	switch m.activeApp {
+	case officeAppRecovery:
+		if m.isOneOnOne() {
+			return "1:1 with " + m.oneOnOneAgentName() + " · Recovery"
+		}
+		return "# " + m.activeChannel + " · Recovery"
 	case officeAppTasks:
 		return "# " + m.activeChannel + " · Tasks"
 	case officeAppRequests:
@@ -2416,6 +2418,23 @@ func (m channelModel) currentHeaderTitle() string {
 }
 
 func (m channelModel) currentHeaderMeta() string {
+	if m.activeApp == officeAppRecovery {
+		snapshot := m.currentRuntimeSnapshot()
+		blocking := 0
+		for _, req := range snapshot.Requests {
+			status := strings.TrimSpace(strings.ToLower(req.Status))
+			if status != "" && status != "pending" && status != "open" {
+				continue
+			}
+			if req.Blocking || req.Required {
+				blocking++
+			}
+		}
+		if m.isOneOnOne() {
+			return fmt.Sprintf("  Re-entry summary for %s · %d running tasks · %d open requests · %d new since you looked", m.oneOnOneAgentName(), countRunningRuntimeTasks(snapshot.Tasks), len(snapshot.Requests), m.unreadCount)
+		}
+		return fmt.Sprintf("  Re-entry summary for #%s · %d blocking requests · %d running tasks · %d new since you looked", m.activeChannel, blocking, countRunningRuntimeTasks(snapshot.Tasks), m.unreadCount)
+	}
 	if m.isOneOnOne() {
 		if !m.brokerConnected {
 			return "  Direct session preview · only this agent can speak here"
@@ -2524,10 +2543,12 @@ func (m channelModel) currentHeaderMeta() string {
 }
 
 func (m channelModel) currentAppLabel() string {
-	if m.isOneOnOne() {
+	if m.isOneOnOne() && m.activeApp != officeAppRecovery {
 		return "messages"
 	}
 	switch m.activeApp {
+	case officeAppRecovery:
+		return "recovery"
 	case officeAppTasks:
 		return "tasks"
 	case officeAppRequests:
@@ -3123,6 +3144,7 @@ func (m channelModel) channelSidebarItems() []sidebarItem {
 func (m channelModel) appSidebarItems() []sidebarItem {
 	return []sidebarItem{
 		{Kind: "app", Value: string(officeAppMessages), Label: "Messages"},
+		{Kind: "app", Value: string(officeAppRecovery), Label: "Recovery"},
 		{Kind: "app", Value: string(officeAppTasks), Label: "Tasks"},
 		{Kind: "app", Value: string(officeAppSkills), Label: "Skills"},
 		{Kind: "app", Value: string(officeAppPolicies), Label: "Policies"},
@@ -3195,6 +3217,9 @@ func (m *channelModel) selectSidebarItem(item sidebarItem) tea.Cmd {
 		case officeAppMessages:
 			m.notice = "Viewing #" + m.activeChannel + "."
 			return pollBroker("", m.activeChannel)
+		case officeAppRecovery:
+			m.notice = "Viewing the recovery summary."
+			return m.pollCurrentState()
 		case officeAppTasks:
 			m.notice = "Viewing tasks in #" + m.activeChannel + "."
 			return pollTasks(m.activeChannel)
@@ -4300,6 +4325,16 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 			m.notice = "Viewing #general."
 		}
 		return m, nil
+	case trimmed == "/recover" || trimmed == "/resume":
+		clearCurrent()
+		m.activeApp = officeAppRecovery
+		m.syncSidebarCursorToActive()
+		if m.isOneOnOne() {
+			m.notice = "Viewing the direct-session recovery summary."
+		} else {
+			m.notice = "Viewing the office recovery summary."
+		}
+		return m, m.pollCurrentState()
 	case trimmed == "/tasks":
 		clearCurrent()
 		m.activeApp = officeAppTasks
@@ -6158,7 +6193,7 @@ func resolveInitialOfficeApp(name string) officeApp {
 		return officeAppPolicies
 	}
 	switch officeApp(normalized) {
-	case officeAppMessages, officeAppTasks, officeAppRequests, officeAppPolicies, officeAppCalendar:
+	case officeAppMessages, officeAppRecovery, officeAppTasks, officeAppRequests, officeAppPolicies, officeAppCalendar:
 		return officeApp(normalized)
 	default:
 		return officeAppMessages

--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -889,6 +889,10 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return m, m.openRequestActionPicker(req)
 					}
 					return m, nil
+				case "prompt":
+					m.focus = focusMain
+					m.applyRecoveryPrompt(action.Value)
+					return m, nil
 				case "channel", "app":
 					items := m.sidebarItems()
 					for idx, item := range items {
@@ -1796,12 +1800,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case channelPickerRewind:
 			m.picker.SetActive(false)
 			m.pickerMode = channelPickerNone
-			if strings.TrimSpace(msg.Value) == "" {
-				m.notice = "Nothing inserted."
-				return m, nil
-			}
-			m.insertIntoActiveComposer(msg.Value)
-			m.notice = "Inserted a recovery prompt into the composer."
+			m.applyRecoveryPrompt(msg.Value)
 			return m, nil
 		case channelPickerAgents:
 			m.picker.SetActive(false)
@@ -2732,6 +2731,9 @@ func (m channelModel) mainPanelMouseAction(x, y, mainW, contentH int) (mouseActi
 		allLines := m.currentMainViewportLines(contentWidth, msgH)
 		visibleRows, _, _, _ := sliceRenderedLines(allLines, msgH, m.scroll)
 		if row >= 0 && row < len(visibleRows) {
+			if visibleRows[row].PromptValue != "" {
+				return mouseAction{Kind: "prompt", Value: visibleRows[row].PromptValue}, true
+			}
 			switch m.activeApp {
 			case officeAppMessages:
 				if visibleRows[row].ThreadID != "" {
@@ -2770,6 +2772,19 @@ func (m channelModel) mainPanelMouseAction(x, y, mainW, contentH int) (mouseActi
 	}
 
 	return mouseAction{}, false
+}
+
+func (m *channelModel) applyRecoveryPrompt(prompt string) {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		m.notice = "Nothing inserted."
+		return
+	}
+	m.activeApp = officeAppMessages
+	m.syncSidebarCursorToActive()
+	m.focus = focusMain
+	m.insertIntoActiveComposer(prompt)
+	m.notice = "Inserted a recovery prompt into the composer."
 }
 
 func (m channelModel) mainPanelGeometry(mainW, contentH int) (headerH, msgH int, popupRows []string) {

--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -2772,6 +2772,16 @@ func (m channelModel) mainPanelMouseAction(x, y, mainW, contentH int) (mouseActi
 				if visibleRows[row].RequestID != "" {
 					return mouseAction{Kind: "request", Value: visibleRows[row].RequestID}, true
 				}
+			case officeAppRecovery, officeAppArtifacts:
+				if visibleRows[row].ThreadID != "" {
+					return mouseAction{Kind: "thread", Value: visibleRows[row].ThreadID}, true
+				}
+				if visibleRows[row].TaskID != "" {
+					return mouseAction{Kind: "task", Value: visibleRows[row].TaskID}, true
+				}
+				if visibleRows[row].RequestID != "" {
+					return mouseAction{Kind: "request", Value: visibleRows[row].RequestID}, true
+				}
 			}
 		}
 	}

--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -447,6 +447,9 @@ var channelSlashCommands = []tui.SlashCommand{
 	{Name: "messages", Description: "Show the main office feed", Category: "navigate"},
 	{Name: "recover", Description: "Open the session recovery summary", Category: "navigate"},
 	{Name: "resume", Description: "Alias for /recover", Category: "navigate"},
+	{Name: "rewind", Description: "Insert a summarize-from-here recovery prompt", Category: "navigate"},
+	{Name: "search", Description: "Search channels, tasks, requests, and threads", Category: "navigate"},
+	{Name: "insert", Description: "Insert a channel, task, request, or message reference", Category: "navigate"},
 	{Name: "switcher", Description: "Open the unified office/direct switcher", Category: "navigate"},
 	{Name: "tasks", Description: "Show active work in this channel", Category: "navigate"},
 	{Name: "switch", Description: "Switch to another channel", Category: "navigate"},
@@ -459,6 +462,7 @@ var channelSlashCommands = []tui.SlashCommand{
 	{Name: "policies", Description: "Show signals, decisions, external actions, and watchdogs", Category: "navigate"},
 	{Name: "calendar", Description: "Show the office schedule and team calendars", Category: "navigate"},
 	{Name: "queue", Description: "Alias for /calendar", Category: "navigate"},
+	{Name: "artifacts", Description: "Show recent task logs, approvals, and workflow artifacts", Category: "navigate"},
 	{Name: "skills", Description: "Show available skills", Category: "navigate"},
 	{Name: "skill", Description: "Create, invoke, or manage a skill", Category: "work"},
 	{Name: "reply", Description: "Reply in thread by message ID", Category: "conversation"},
@@ -512,6 +516,9 @@ const (
 	channelPickerThreadAction   channelPickerMode = "thread_action"
 	channelPickerChannels       channelPickerMode = "channels"
 	channelPickerSwitcher       channelPickerMode = "switcher"
+	channelPickerInsert         channelPickerMode = "insert"
+	channelPickerSearch         channelPickerMode = "search"
+	channelPickerRewind         channelPickerMode = "rewind"
 	channelPickerAgents         channelPickerMode = "agents"
 	channelPickerCalendarAgent  channelPickerMode = "calendar_agent"
 	channelPickerOneOnOneMode   channelPickerMode = "one_on_one_mode"
@@ -525,13 +532,14 @@ const (
 type officeApp string
 
 const (
-	officeAppMessages officeApp = "messages"
-	officeAppRecovery officeApp = "recovery"
-	officeAppTasks    officeApp = "tasks"
-	officeAppRequests officeApp = "requests"
-	officeAppPolicies officeApp = "policies"
-	officeAppCalendar officeApp = "calendar"
-	officeAppSkills   officeApp = "skills"
+	officeAppMessages  officeApp = "messages"
+	officeAppRecovery  officeApp = "recovery"
+	officeAppTasks     officeApp = "tasks"
+	officeAppRequests  officeApp = "requests"
+	officeAppPolicies  officeApp = "policies"
+	officeAppCalendar  officeApp = "calendar"
+	officeAppArtifacts officeApp = "artifacts"
+	officeAppSkills    officeApp = "skills"
 )
 
 type quickJumpTarget string
@@ -1771,6 +1779,30 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.picker.SetActive(false)
 			m.pickerMode = channelPickerNone
 			return m, m.applyWorkspaceSwitcherSelection(msg.Value)
+		case channelPickerInsert:
+			m.picker.SetActive(false)
+			m.pickerMode = channelPickerNone
+			if strings.TrimSpace(msg.Value) == "" {
+				m.notice = "Nothing inserted."
+				return m, nil
+			}
+			m.insertIntoActiveComposer(msg.Value)
+			m.notice = "Inserted reference into the composer."
+			return m, nil
+		case channelPickerSearch:
+			m.picker.SetActive(false)
+			m.pickerMode = channelPickerNone
+			return m, m.applySearchSelection(msg.Value, msg.Label)
+		case channelPickerRewind:
+			m.picker.SetActive(false)
+			m.pickerMode = channelPickerNone
+			if strings.TrimSpace(msg.Value) == "" {
+				m.notice = "Nothing inserted."
+				return m, nil
+			}
+			m.insertIntoActiveComposer(msg.Value)
+			m.notice = "Inserted a recovery prompt into the composer."
+			return m, nil
 		case channelPickerAgents:
 			m.picker.SetActive(false)
 			m.pickerMode = channelPickerNone
@@ -2402,6 +2434,8 @@ func (m channelModel) currentHeaderTitle() string {
 			return "1:1 with " + m.oneOnOneAgentName() + " · Recovery"
 		}
 		return "# " + m.activeChannel + " · Recovery"
+	case officeAppArtifacts:
+		return "# " + m.activeChannel + " · Artifacts"
 	case officeAppTasks:
 		return "# " + m.activeChannel + " · Tasks"
 	case officeAppRequests:
@@ -2531,6 +2565,12 @@ func (m channelModel) currentHeaderMeta() string {
 			}
 		}
 		return fmt.Sprintf("  Reusable team skills · %d total · %d active · %d workflow-backed", len(m.skills), active, workflowBacked)
+	case officeAppArtifacts:
+		summary := m.currentArtifactSummary()
+		if summary == "" {
+			return "  Retained task logs, approvals, and workflow history for this office"
+		}
+		return "  " + summary
 	default:
 		if m.isOneOnOne() {
 			return fmt.Sprintf("  Direct session with %s · single-agent focus · external actions and reports stay in this conversation", m.oneOnOneAgentName())
@@ -2557,6 +2597,8 @@ func (m channelModel) currentAppLabel() string {
 		return "policies"
 	case officeAppCalendar:
 		return "calendar"
+	case officeAppArtifacts:
+		return "artifacts"
 	case officeAppSkills:
 		return "skills"
 	default:
@@ -3149,6 +3191,7 @@ func (m channelModel) appSidebarItems() []sidebarItem {
 		{Kind: "app", Value: string(officeAppSkills), Label: "Skills"},
 		{Kind: "app", Value: string(officeAppPolicies), Label: "Policies"},
 		{Kind: "app", Value: string(officeAppCalendar), Label: "Calendar"},
+		{Kind: "app", Value: string(officeAppArtifacts), Label: "Artifacts"},
 	}
 }
 
@@ -3232,6 +3275,9 @@ func (m *channelModel) selectSidebarItem(item sidebarItem) tea.Cmd {
 		case officeAppCalendar:
 			m.notice = "Viewing the office calendar."
 			return pollOfficeLedger()
+		case officeAppArtifacts:
+			m.notice = "Viewing recent execution artifacts."
+			return m.pollCurrentState()
 		case officeAppSkills:
 			m.notice = "Viewing skills."
 			return pollSkills("")
@@ -4335,6 +4381,42 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 			m.notice = "Viewing the office recovery summary."
 		}
 		return m, m.pollCurrentState()
+	case trimmed == "/rewind":
+		clearCurrent()
+		options := m.buildRecoveryPromptPickerOptions()
+		if len(options) == 0 {
+			m.notice = "Nothing recent to rewind from yet."
+			return m, nil
+		}
+		m.picker = tui.NewPicker("Rewind From...", options)
+		m.picker.SetActive(true)
+		m.pickerMode = channelPickerRewind
+		m.notice = "Choose where recovery should start."
+		return m, nil
+	case trimmed == "/insert":
+		clearCurrent()
+		options := m.buildInsertPickerOptions()
+		if len(options) == 0 {
+			m.notice = "Nothing useful to insert right now."
+			return m, nil
+		}
+		m.picker = tui.NewPicker("Insert Reference", options)
+		m.picker.SetActive(true)
+		m.pickerMode = channelPickerInsert
+		m.notice = "Choose a reference to insert into the composer."
+		return m, nil
+	case trimmed == "/search":
+		clearCurrent()
+		options := m.buildSearchPickerOptions()
+		if len(options) == 0 {
+			m.notice = "Nothing searchable yet."
+			return m, nil
+		}
+		m.picker = tui.NewPicker("Search Workspace", options)
+		m.picker.SetActive(true)
+		m.pickerMode = channelPickerSearch
+		m.notice = "Choose where to jump next."
+		return m, nil
 	case trimmed == "/tasks":
 		clearCurrent()
 		m.activeApp = officeAppTasks
@@ -4566,6 +4648,12 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		m.syncSidebarCursorToActive()
 		m.notice = "Viewing skills."
 		return m, pollSkills("")
+	case trimmed == "/artifacts":
+		clearCurrent()
+		m.activeApp = officeAppArtifacts
+		m.syncSidebarCursorToActive()
+		m.notice = "Viewing recent execution artifacts."
+		return m, m.pollCurrentState()
 	case strings.HasPrefix(trimmed, "/skill create "):
 		clearCurrent()
 		desc := strings.TrimSpace(strings.TrimPrefix(trimmed, "/skill create "))
@@ -6193,7 +6281,7 @@ func resolveInitialOfficeApp(name string) officeApp {
 		return officeAppPolicies
 	}
 	switch officeApp(normalized) {
-	case officeAppMessages, officeAppRecovery, officeAppTasks, officeAppRequests, officeAppPolicies, officeAppCalendar:
+	case officeAppMessages, officeAppRecovery, officeAppTasks, officeAppRequests, officeAppPolicies, officeAppCalendar, officeAppArtifacts:
 		return officeApp(normalized)
 	default:
 		return officeAppMessages

--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -2134,11 +2134,12 @@ func (m channelModel) View() string {
 	}
 
 	layout := computeLayout(m.width, m.height, m.threadPanelOpen && !m.isOneOnOne(), m.sidebarCollapsed || m.isOneOnOne())
+	workspaceState := m.currentWorkspaceUIState()
 
 	// ── Sidebar ──────────────────────────────────────────────────────
 	sidebar := ""
 	if layout.ShowSidebar && !m.isOneOnOne() {
-		sidebar = cachedSidebarRender(m.channels, mergeOfficeMembers(m.officeMembers, m.members, m.currentChannelInfo()), m.tasks, m.activeChannel, m.activeApp, m.sidebarCursor, m.sidebarRosterOffset, m.focus == focusSidebar, m.quickJumpTarget, m.brokerConnected, layout.SidebarW, layout.ContentH)
+		sidebar = cachedSidebarRender(m.channels, mergeOfficeMembers(m.officeMembers, m.members, m.currentChannelInfo()), m.tasks, m.activeChannel, m.activeApp, m.sidebarCursor, m.sidebarRosterOffset, m.focus == focusSidebar, m.quickJumpTarget, workspaceState, layout.SidebarW, layout.ContentH)
 	}
 
 	// ── Thread panel ─────────────────────────────────────────────────
@@ -2380,24 +2381,14 @@ func (m channelModel) View() string {
 			lipgloss.NewStyle().Foreground(lipgloss.Color(slackActive)).Render(" " + m.notice),
 		)
 	} else if m.isOneOnOne() {
-		label := "offline preview"
-		if m.brokerConnected {
-			label = "direct session live"
-		}
-		runtimeHint := "ready"
-		if runtimeLine := oneOnOneRuntimeLine(m.officeMembers, m.members, m.tasks, m.actions, m.oneOnOneAgentSlug()); runtimeLine != "" {
-			runtimeHint = runtimeLine
-		}
 		statusBar = statusBarStyle(m.width).Render(
 			lipgloss.NewStyle().Foreground(lipgloss.Color(slackActive)).Render(
-				fmt.Sprintf(" %s │ %d msgs │ %s │ Ctrl+J newline │ /1o1 switch │ /doctor",
-					label, len(m.messages), runtimeHint,
-				),
+				workspaceState.defaultStatusLine(scrollHint),
 			),
 		)
 	} else if !m.brokerConnected {
 		statusBar = statusBarStyle(m.width).Render(
-			lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render(" Team offline │ showing manifest roster │ launch WUPHF to connect │ /doctor"),
+			lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render(workspaceState.defaultStatusLine(scrollHint)),
 		)
 	} else if m.replyToID != "" {
 		statusBar = statusBarStyle(m.width).Render(
@@ -2418,6 +2409,10 @@ func (m channelModel) View() string {
 			lipgloss.NewStyle().Foreground(lipgloss.Color(slackActive)).Render(
 				message,
 			),
+		)
+	} else {
+		statusBar = statusBarStyle(m.width).Render(
+			lipgloss.NewStyle().Foreground(lipgloss.Color(slackActive)).Render(workspaceState.defaultStatusLine(scrollHint)),
 		)
 	}
 
@@ -2452,6 +2447,7 @@ func (m channelModel) currentHeaderTitle() string {
 }
 
 func (m channelModel) currentHeaderMeta() string {
+	workspace := m.currentWorkspaceUIState()
 	if m.activeApp == officeAppRecovery {
 		snapshot := m.currentRuntimeSnapshot()
 		blocking := 0
@@ -2470,14 +2466,7 @@ func (m channelModel) currentHeaderMeta() string {
 		return fmt.Sprintf("  Re-entry summary for #%s · %d blocking requests · %d running tasks · %d new since you looked", m.activeChannel, blocking, countRunningRuntimeTasks(snapshot.Tasks), m.unreadCount)
 	}
 	if m.isOneOnOne() {
-		if !m.brokerConnected {
-			return "  Direct session preview · only this agent can speak here"
-		}
-		meta := "  Direct conversation only · no channels, teammates, or office apps in this mode"
-		if runtimeLine := oneOnOneRuntimeLine(m.officeMembers, m.members, m.tasks, m.actions, m.oneOnOneAgentSlug()); runtimeLine != "" {
-			meta += " · " + runtimeLine
-		}
-		return meta
+		return workspace.headerMeta()
 	}
 	switch m.activeApp {
 	case officeAppTasks:
@@ -2572,13 +2561,7 @@ func (m channelModel) currentHeaderMeta() string {
 		}
 		return "  " + summary
 	default:
-		if m.isOneOnOne() {
-			return fmt.Sprintf("  Direct session with %s · single-agent focus · external actions and reports stay in this conversation", m.oneOnOneAgentName())
-		}
-		if !m.brokerConnected {
-			return fmt.Sprintf("  Offline preview · manifest roster loaded · %d teammates ready for #%s", len(m.officeMembers), m.activeChannel)
-		}
-		return fmt.Sprintf("  The WUPHF Office · Founding Team building together · %d teammates in #%s", len(m.members), m.activeChannel)
+		return workspace.headerMeta()
 	}
 }
 
@@ -3171,6 +3154,24 @@ type sidebarItem struct {
 	Label string
 }
 
+type officeSidebarApp struct {
+	App   officeApp
+	Label string
+}
+
+func officeSidebarApps() []officeSidebarApp {
+	return []officeSidebarApp{
+		{App: officeAppMessages, Label: "Messages"},
+		{App: officeAppRecovery, Label: "Recovery"},
+		{App: officeAppTasks, Label: "Tasks"},
+		{App: officeAppRequests, Label: "Requests"},
+		{App: officeAppPolicies, Label: "Policies"},
+		{App: officeAppCalendar, Label: "Calendar"},
+		{App: officeAppArtifacts, Label: "Artifacts"},
+		{App: officeAppSkills, Label: "Skills"},
+	}
+}
+
 func (m channelModel) sidebarItems() []sidebarItem {
 	if m.isOneOnOne() {
 		return nil
@@ -3194,15 +3195,12 @@ func (m channelModel) channelSidebarItems() []sidebarItem {
 }
 
 func (m channelModel) appSidebarItems() []sidebarItem {
-	return []sidebarItem{
-		{Kind: "app", Value: string(officeAppMessages), Label: "Messages"},
-		{Kind: "app", Value: string(officeAppRecovery), Label: "Recovery"},
-		{Kind: "app", Value: string(officeAppTasks), Label: "Tasks"},
-		{Kind: "app", Value: string(officeAppSkills), Label: "Skills"},
-		{Kind: "app", Value: string(officeAppPolicies), Label: "Policies"},
-		{Kind: "app", Value: string(officeAppCalendar), Label: "Calendar"},
-		{Kind: "app", Value: string(officeAppArtifacts), Label: "Artifacts"},
+	apps := officeSidebarApps()
+	items := make([]sidebarItem, 0, len(apps))
+	for _, app := range apps {
+		items = append(items, sidebarItem{Kind: "app", Value: string(app.App), Label: app.Label})
 	}
+	return items
 }
 
 func sidebarShortcutLabel(index int) string {

--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -196,9 +196,11 @@ type channelInfo struct {
 }
 
 type channelInterviewOption struct {
-	ID          string `json:"id"`
-	Label       string `json:"label"`
-	Description string `json:"description"`
+	ID           string `json:"id"`
+	Label        string `json:"label"`
+	Description  string `json:"description"`
+	RequiresText bool   `json:"requires_text,omitempty"`
+	TextHint     string `json:"text_hint,omitempty"`
 }
 
 type channelInterview struct {
@@ -443,6 +445,7 @@ var channelSlashCommands = []tui.SlashCommand{
 	{Name: "connect", Description: "Connect an external channel (Telegram, Slack, Discord)", Category: "setup"},
 	{Name: "1o1", Description: "Enable, switch, or disable direct 1:1 mode", Category: "session"},
 	{Name: "messages", Description: "Show the main office feed", Category: "navigate"},
+	{Name: "switcher", Description: "Open the unified office/direct switcher", Category: "navigate"},
 	{Name: "tasks", Description: "Show active work in this channel", Category: "navigate"},
 	{Name: "switch", Description: "Switch to another channel", Category: "navigate"},
 	{Name: "channels", Description: "Browse and manage channels", Category: "navigate"},
@@ -468,7 +471,6 @@ var channelSlashCommands = []tui.SlashCommand{
 
 // oneOnOneBlacklist lists command names blocked in 1:1 mode.
 var oneOnOneBlacklist = map[string]bool{
-	"switch":       true,
 	"tasks":        true,
 	"task":         true,
 	"channels":     true,
@@ -507,6 +509,7 @@ const (
 	channelPickerThreads        channelPickerMode = "threads"
 	channelPickerThreadAction   channelPickerMode = "thread_action"
 	channelPickerChannels       channelPickerMode = "channels"
+	channelPickerSwitcher       channelPickerMode = "switcher"
 	channelPickerAgents         channelPickerMode = "agents"
 	channelPickerCalendarAgent  channelPickerMode = "calendar_agent"
 	channelPickerOneOnOneMode   channelPickerMode = "one_on_one_mode"
@@ -597,14 +600,18 @@ type channelModel struct {
 	mention              tui.MentionModel
 	input                []rune
 	inputPos             int
+	inputHistory         composerHistory
 	width                int
 	height               int
 	scroll               int
 	unreadCount          int
+	unreadAnchorID       string
+	awaySummary          string
 	posting              bool
 	selectedOption       int
 	notice               string
 	snoozedInterview     string
+	confirm              *channelConfirm
 	doctor               *channelDoctorReport
 	memberDraft          *channelMemberDraft
 	initFlow             tui.InitFlowModel
@@ -620,6 +627,7 @@ type channelModel struct {
 	threadPanelID       string
 	threadInput         []rune
 	threadInputPos      int
+	threadInputHistory  composerHistory
 	threadScroll        int
 	usage               channelUsageState
 	brokerConnected     bool
@@ -662,6 +670,7 @@ func newChannelModelWithApp(threadsCollapsed bool, initialApp officeApp) channel
 		threadsDefaultExpand: !threadsCollapsed,
 		autocomplete:         tui.NewAutocomplete(channelSlashCommands),
 		mention:              tui.NewMention(channelMentionAgents(nil)),
+		inputHistory:         newComposerHistory(),
 		initFlow:             tui.NewInitFlow(),
 		activeChannel:        "general",
 		activeApp:            initialApp,
@@ -670,6 +679,7 @@ func newChannelModelWithApp(threadsCollapsed bool, initialApp officeApp) channel
 		channels:             channels,
 		sessionMode:          sessionMode,
 		oneOnOneAgent:        oneOnOneAgent,
+		threadInputHistory:   newComposerHistory(),
 	}
 	if m.isOneOnOne() {
 		m.sidebarCollapsed = true
@@ -806,7 +816,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if m.scroll > 0 {
 					m.scroll--
 					if m.scroll == 0 {
-						m.unreadCount = 0
+						m.clearUnreadState()
 					}
 				}
 			}
@@ -834,7 +844,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					return m, nil
 				case "jump-latest":
 					m.scroll = 0
-					m.unreadCount = 0
+					m.clearUnreadState()
 					return m, nil
 				case "autocomplete":
 					if idx, ok := popupActionIndex(action.Value); ok {
@@ -957,8 +967,17 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		// ── Esc: close overlays/thread, then cycle ────────────────────
 		if msg.String() == "esc" {
-			// Close overlays first
-			if m.picker.IsActive() {
+			switch m.activeInteractionContext() {
+			case contextConfirm:
+				if m.confirm != nil && m.confirm.Action == confirmActionSubmitRequest {
+					m.confirm = nil
+					m.notice = "Review closed. Keep editing before you send."
+					return m, nil
+				}
+				m.confirm = nil
+				m.notice = "Canceled."
+				return m, nil
+			case contextPicker:
 				m.picker.SetActive(false)
 				if m.pickerMode == channelPickerIntegrations {
 					m.notice = "Integration canceled."
@@ -968,27 +987,23 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				m.pickerMode = channelPickerNone
 				return m, nil
-			}
-			if m.autocomplete.IsVisible() || m.mention.IsVisible() {
+			case contextAutocomplete, contextMention:
 				var cmd tea.Cmd
 				m.autocomplete, cmd = m.autocomplete.Update(msg)
 				_ = cmd
 				m.mention, _ = m.mention.Update(msg)
 				return m, nil
-			}
-			if m.memberDraft != nil {
+			case contextMemberDraft:
 				m.memberDraft = nil
 				m.input = nil
 				m.inputPos = 0
 				m.notice = "Agent setup canceled."
 				return m, nil
-			}
-			if m.doctor != nil {
+			case contextDoctor:
 				m.doctor = nil
 				m.notice = "Doctor closed."
 				return m, nil
-			}
-			if m.pending != nil && m.pending.ID != "" {
+			case contextInterview:
 				if m.pending.Blocking || m.pending.Required {
 					m.notice = "Human decision required. Answer it before the team can continue."
 					return m, nil
@@ -996,9 +1011,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.snoozedInterview = m.pending.ID
 				m.notice = "Request snoozed. Team remains paused until it is answered."
 				return m, nil
-			}
-			// Close thread panel
-			if m.threadPanelOpen {
+			case contextThread:
 				m.threadPanelOpen = false
 				m.threadPanelID = ""
 				m.threadInput = nil
@@ -1027,6 +1040,18 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// ── Global overlays/pickers before panel-specific handling ────
+		if m.confirm != nil {
+			switch msg.String() {
+			case "enter":
+				return m.executeConfirmation(*m.confirm)
+			case "ctrl+c", "esc":
+				m.confirm = nil
+				m.notice = "Canceled."
+				return m, nil
+			default:
+				return m, nil
+			}
+		}
 		if m.picker.IsActive() {
 			var cmd tea.Cmd
 			m.picker, cmd = m.picker.Update(msg)
@@ -1131,6 +1156,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if len(m.input) > 0 {
 				text := string(m.input)
 				trimmed := strings.TrimSpace(text)
+				m.inputHistory.record(m.input, m.inputPos)
 				if trimmed == "/quit" || trimmed == "/exit" || trimmed == "/q" {
 					killTeamSession()
 					return m, tea.Quit
@@ -1138,35 +1164,55 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if strings.HasPrefix(trimmed, "/") {
 					return m.runActiveCommand(trimmed)
 				}
+				if m.pending != nil {
+					m.confirm = confirmationForInterviewAnswer(*m.pending, m.selectedInterviewOption(), text)
+					m.notice = "Review your answer before sending."
+					return m, nil
+				}
 
 				m.input = nil
 				m.inputPos = 0
 				m.notice = ""
-
 				m.posting = true
-				if m.pending != nil {
-					return m, postInterviewAnswer(*m.pending, "", "", text)
-				}
 				return m, postToChannel(text, m.replyToID, m.activeChannel)
-			} else if m.pending != nil {
-				opt := m.selectedInterviewOption()
-				if opt != nil {
-					m.posting = true
-					return m, postInterviewAnswer(*m.pending, opt.ID, opt.Label, "")
+			}
+			if m.pending != nil {
+				if opt := m.selectedInterviewOption(); opt != nil {
+					if interviewOptionRequiresText(opt) {
+						m.notice = interviewOptionTextHint(opt)
+						return m, nil
+					}
+					m.confirm = confirmationForInterviewAnswer(*m.pending, opt, "")
+					m.notice = "Review your answer before sending."
+					return m, nil
 				}
+				m.notice = "Choose an option or type your own answer before sending."
+				return m, nil
 			}
 		case "backspace":
 			m.lastCtrlCAt = time.Time{}
 			if m.inputPos > 0 {
+				m.inputHistory.resetRecall()
 				m.input = append(m.input[:m.inputPos-1], m.input[m.inputPos:]...)
 				m.inputPos--
 				m.updateInputOverlays()
 			}
 		case "ctrl+u":
 			m.lastCtrlCAt = time.Time{}
+			m.inputHistory.resetRecall()
 			m.input = nil
 			m.inputPos = 0
 			m.updateInputOverlays()
+		case "ctrl+p":
+			m.lastCtrlCAt = time.Time{}
+			if snapshot, ok := m.inputHistory.previous(m.input, m.inputPos); ok {
+				m.restoreMainSnapshot(snapshot)
+			}
+		case "ctrl+n":
+			m.lastCtrlCAt = time.Time{}
+			if snapshot, ok := m.inputHistory.next(); ok {
+				m.restoreMainSnapshot(snapshot)
+			}
 		case "ctrl+a":
 			m.lastCtrlCAt = time.Time{}
 			m.inputPos = 0
@@ -1177,6 +1223,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.updateInputOverlays()
 		case "ctrl+j":
 			m.lastCtrlCAt = time.Time{}
+			m.inputHistory.resetRecall()
 			ch := []rune{'\n'}
 			tail := make([]rune, len(m.input[m.inputPos:]))
 			copy(tail, m.input[m.inputPos:])
@@ -1218,7 +1265,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "end":
 			m.lastCtrlCAt = time.Time{}
 			m.scroll = 0
-			m.unreadCount = 0
+			m.clearUnreadState()
 		case "pgup":
 			m.lastCtrlCAt = time.Time{}
 			m.scroll += maxInt(10, m.height/2)
@@ -1229,11 +1276,12 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.scroll = 0
 			}
 			if m.scroll == 0 {
-				m.unreadCount = 0
+				m.clearUnreadState()
 			}
 		default:
 			m.lastCtrlCAt = time.Time{}
 			if ch := composerInsertRunes(msg); len(ch) > 0 {
+				m.inputHistory.resetRecall()
 				m.input, m.inputPos = insertComposerRunes(m.input, m.inputPos, ch)
 				m.updateInputOverlays()
 			} else if len(msg.String()) == 1 || msg.Type == tea.KeyRunes {
@@ -1242,6 +1290,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					ch = []rune(msg.String())
 				}
 				if len(ch) > 0 {
+					m.inputHistory.resetRecall()
 					tail := make([]rune, len(m.input[m.inputPos:]))
 					copy(tail, m.input[m.inputPos:])
 					m.input = append(m.input[:m.inputPos], append(ch, tail...)...)
@@ -1277,7 +1326,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.threadPanelOpen = false
 				m.threadPanelID = ""
 				m.scroll = 0
-				m.unreadCount = 0
+				m.clearUnreadState()
 				m.syncSidebarCursorToActive()
 			}
 		case "remove":
@@ -1293,7 +1342,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.threadPanelOpen = false
 				m.threadPanelID = ""
 				m.scroll = 0
-				m.unreadCount = 0
+				m.clearUnreadState()
 				m.syncSidebarCursorToActive()
 			}
 		}
@@ -1321,6 +1370,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case channelResetDoneMsg:
 		m.posting = false
+		m.confirm = nil
 		if msg.err == nil {
 			if normalized := team.NormalizeSessionMode(msg.sessionMode); normalized != "" {
 				m.sessionMode = normalized
@@ -1338,7 +1388,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.input = nil
 			m.inputPos = 0
 			m.scroll = 0
-			m.unreadCount = 0
+			m.clearUnreadState()
 			m.notice = ""
 			m.initFlow = tui.NewInitFlow()
 			m.picker.SetActive(false)
@@ -1373,6 +1423,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case channelResetDMDoneMsg:
 		m.posting = false
+		m.confirm = nil
 		if msg.err != nil {
 			m.notice = "Failed to clear DMs: " + msg.err.Error()
 		} else {
@@ -1499,7 +1550,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.threadPanelOpen = false
 		m.threadPanelID = ""
 		m.scroll = 0
-		m.unreadCount = 0
+		m.clearUnreadState()
 		m.syncSidebarCursorToActive()
 		manifest, _ := company.LoadManifest()
 		m.channels = channelInfosFromManifest(manifest)
@@ -1533,13 +1584,18 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if added == 0 {
 				break
 			}
-			latestHumanFacing := latestHumanFacingMessage(uniqueMessages[len(m.messages):])
+			addedMessages := uniqueMessages[len(m.messages):]
+			latestHumanFacing := latestHumanFacingMessage(addedMessages)
 			if m.scroll > 0 {
 				m.scroll += added
-				m.unreadCount += added
 			}
 			m.messages = uniqueMessages
 			m.lastID = msg.messages[len(msg.messages)-1].ID
+			if m.scroll > 0 || m.focus != focusMain || m.threadPanelOpen {
+				m.noteIncomingMessages(addedMessages)
+			} else {
+				m.clearUnreadState()
+			}
 			if latestHumanFacing != nil && hadHistory {
 				m.activeApp = officeAppMessages
 				m.notice = fmt.Sprintf("@%s has something for you", latestHumanFacing.From)
@@ -1604,7 +1660,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.requests = nil
 				m.lastID = ""
 				m.scroll = 0
-				m.unreadCount = 0
+				m.clearUnreadState()
 				m.refreshSlashCommands()
 				if m.isOneOnOne() && strings.TrimSpace(m.notice) == "" {
 					m.notice = "Direct session reset. Agent pane reloaded in place."
@@ -1653,6 +1709,46 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.picker.SetActive(false)
 			m.pickerMode = channelPickerNone
 			switch {
+			case strings.HasPrefix(msg.Value, "app:"):
+				switch officeApp(strings.TrimPrefix(msg.Value, "app:")) {
+				case officeAppMessages:
+					m.activeApp = officeAppMessages
+					m.notice = "Viewing messages."
+					m.syncSidebarCursorToActive()
+					return m, tea.Batch(pollBroker("", m.activeChannel), pollMembers(m.activeChannel))
+				case officeAppTasks:
+					m.activeApp = officeAppTasks
+					m.notice = "Viewing tasks in #" + m.activeChannel + "."
+					m.syncSidebarCursorToActive()
+					return m, pollTasks(m.activeChannel)
+				case officeAppRequests:
+					m.activeApp = officeAppRequests
+					m.notice = "Viewing requests in #" + m.activeChannel + "."
+					m.syncSidebarCursorToActive()
+					return m, pollRequests(m.activeChannel)
+				case officeAppPolicies:
+					m.activeApp = officeAppPolicies
+					m.notice = "Viewing policies and decisions."
+					m.syncSidebarCursorToActive()
+					return m, pollOfficeLedger()
+				case officeAppCalendar:
+					m.activeApp = officeAppCalendar
+					m.notice = "Viewing the office calendar."
+					m.syncSidebarCursorToActive()
+					return m, nil
+				}
+			case strings.HasPrefix(msg.Value, "session:1o1:"):
+				agent := strings.TrimSpace(strings.TrimPrefix(msg.Value, "session:1o1:"))
+				if agent == "" {
+					agent = team.DefaultOneOnOneAgent
+				}
+				m.confirm = confirmationForSessionSwitch(team.SessionModeOneOnOne, agent)
+				m.notice = "Confirm the direct session switch."
+				return m, nil
+			case msg.Value == "session:office":
+				m.confirm = confirmationForSessionSwitch(team.SessionModeOffice, team.DefaultOneOnOneAgent)
+				m.notice = "Confirm the session switch."
+				return m, nil
 			case strings.HasPrefix(msg.Value, "switch:"):
 				m.activeChannel = strings.TrimPrefix(msg.Value, "switch:")
 				m.lastID = ""
@@ -1668,6 +1764,10 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, mutateChannel("remove", strings.TrimPrefix(msg.Value, "remove:"), "")
 			}
 			return m, nil
+		case channelPickerSwitcher:
+			m.picker.SetActive(false)
+			m.pickerMode = channelPickerNone
+			return m, m.applyWorkspaceSwitcherSelection(msg.Value)
 		case channelPickerAgents:
 			m.picker.SetActive(false)
 			m.pickerMode = channelPickerNone
@@ -1734,8 +1834,9 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.notice = "Already running the full office team."
 					return m, nil
 				}
-				m.posting = true
-				return m, switchSessionMode(team.SessionModeOffice, team.DefaultOneOnOneAgent)
+				m.confirm = confirmationForSessionSwitch(team.SessionModeOffice, team.DefaultOneOnOneAgent)
+				m.notice = "Confirm the session switch."
+				return m, nil
 			default:
 				return m, nil
 			}
@@ -1746,8 +1847,9 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if agent == "" {
 				agent = team.DefaultOneOnOneAgent
 			}
-			m.posting = true
-			return m, switchSessionMode(team.SessionModeOneOnOne, agent)
+			m.confirm = confirmationForSessionSwitch(team.SessionModeOneOnOne, agent)
+			m.notice = "Confirm the direct session switch."
+			return m, nil
 		case channelPickerConnect:
 			m.picker.SetActive(false)
 			m.pickerMode = channelPickerNone
@@ -2014,7 +2116,7 @@ func (m channelModel) View() string {
 		thread = renderThreadPanel(m.messages, m.threadPanelID,
 			layout.ThreadW, layout.ContentH,
 			m.threadInput, m.threadInputPos, m.threadScroll,
-			threadPopup, m.focus == focusThread)
+			threadPopup, m.focus == focusThread, len(m.threadInputHistory.entries) > 0)
 	}
 
 	activePending := m.visiblePendingRequest()
@@ -2054,6 +2156,11 @@ func (m channelModel) View() string {
 			Padding(0, 1).
 			Bold(true).
 			Render(fmt.Sprintf("%d new", m.unreadCount))
+		if strings.TrimSpace(m.awaySummary) != "" {
+			headerMeta += "  " + lipgloss.NewStyle().
+				Foreground(lipgloss.Color("#BFDBFE")).
+				Render(m.awaySummary)
+		}
 	}
 	if m.pending != nil {
 		headerMeta += "  " + accentPill("request pending", "#B45309")
@@ -2079,17 +2186,17 @@ func (m channelModel) View() string {
 	typingAgents := typingAgentsFromMembers(m.members)
 	liveActivities := liveActivityFromMembers(m.members)
 	composerStr := renderComposer(mainW, m.input, m.inputPos, m.composerTargetLabel(),
-		m.replyToID, typingAgents, liveActivities, activePending, m.selectedOption,
+		m.replyToID, typingAgents, liveActivities, activePending, m.selectedOption, m.composerHint(m.composerTargetLabel(), m.replyToID, activePending),
 		m.focus == focusMain, m.tickFrame)
 	if m.memberDraft != nil {
 		composerStr = renderComposer(mainW, m.input, m.inputPos, memberDraftComposerLabel(*m.memberDraft),
-			"", typingAgents, nil, nil, 0, m.focus == focusMain, m.tickFrame)
+			"", typingAgents, nil, nil, 0, m.composerHint(memberDraftComposerLabel(*m.memberDraft), "", nil), m.focus == focusMain, m.tickFrame)
 	}
 
 	// Interview card (above composer)
 	interviewCard := ""
 	if activePending != nil {
-		interviewCard = renderInterviewCard(*activePending, m.selectedOption, mainW-4)
+		interviewCard = renderInterviewCard(*activePending, m.selectedOption, m.interviewPhaseTitle(), mainW-4)
 	}
 	memberDraftCard := ""
 	if m.memberDraft != nil {
@@ -2099,10 +2206,16 @@ func (m channelModel) View() string {
 	if m.doctor != nil {
 		doctorCard = renderDoctorCard(*m.doctor, mainW-4)
 	}
+	confirmCard := ""
+	if m.confirm != nil {
+		confirmCard = renderConfirmCard(*m.confirm, mainW-4)
+	}
 
 	// Init/picker overlays
 	initPanel := ""
-	if m.picker.IsActive() {
+	if confirmCard != "" {
+		initPanel = confirmCard
+	} else if m.picker.IsActive() {
 		initPanel = m.picker.View()
 	} else if m.initFlow.IsActive() || m.initFlow.Phase() == tui.InitDone {
 		initPanel = m.initFlow.View()
@@ -2124,7 +2237,7 @@ func (m channelModel) View() string {
 	if contentWidth < 32 {
 		contentWidth = 32
 	}
-	allLines := m.currentMainLines(contentWidth)
+	allLines := m.currentMainViewportLines(contentWidth, msgH)
 	visibleRows, scroll, _, _ := sliceRenderedLines(allLines, msgH, m.scroll)
 	var visible []string
 	for _, row := range visibleRows {
@@ -2202,7 +2315,7 @@ func (m channelModel) View() string {
 		"\u25CF", onlineCount, len(m.messages), focusLabel, scrollHint,
 	))
 	if m.pending != nil {
-		statusText := " Request pending │ ↑/↓ choose │ Enter submit"
+		statusText := m.interviewStatusLine()
 		if m.pending.ID == m.snoozedInterview {
 			statusText = " Request paused │ Esc snoozed it │ team remains blocked until answered"
 		}
@@ -2570,7 +2683,7 @@ func (m channelModel) mainPanelMouseAction(x, y, mainW, contentH int) (mouseActi
 		if contentWidth < 32 {
 			contentWidth = 32
 		}
-		allLines := m.currentMainLines(contentWidth)
+		allLines := m.currentMainViewportLines(contentWidth, msgH)
 		visibleRows, _, _, _ := sliceRenderedLines(allLines, msgH, m.scroll)
 		if row >= 0 && row < len(visibleRows) {
 			switch m.activeApp {
@@ -2636,22 +2749,24 @@ func (m channelModel) mainPanelGeometry(mainW, contentH int) (headerH, msgH int,
 	typingAgents := typingAgentsFromMembers(m.members)
 	liveActivities := liveActivityFromMembers(m.members)
 	composerStr := renderComposer(mainW, m.input, m.inputPos, m.composerTargetLabel(),
-		m.replyToID, typingAgents, liveActivities, activePending, m.selectedOption,
+		m.replyToID, typingAgents, liveActivities, activePending, m.selectedOption, m.composerHint(m.composerTargetLabel(), m.replyToID, activePending),
 		m.focus == focusMain, m.tickFrame)
 	if m.memberDraft != nil {
 		composerStr = renderComposer(mainW, m.input, m.inputPos, memberDraftComposerLabel(*m.memberDraft),
-			"", typingAgents, nil, nil, 0, m.focus == focusMain, m.tickFrame)
+			"", typingAgents, nil, nil, 0, m.composerHint(memberDraftComposerLabel(*m.memberDraft), "", nil), m.focus == focusMain, m.tickFrame)
 	}
 	interviewCard := ""
 	if activePending != nil {
-		interviewCard = renderInterviewCard(*activePending, m.selectedOption, mainW-4)
+		interviewCard = renderInterviewCard(*activePending, m.selectedOption, m.interviewPhaseTitle(), mainW-4)
 	}
 	memberDraftCard := ""
 	if m.memberDraft != nil {
 		memberDraftCard = renderMemberDraftCard(*m.memberDraft, mainW-4)
 	}
 	initPanel := ""
-	if m.picker.IsActive() {
+	if m.confirm != nil {
+		initPanel = renderConfirmCard(*m.confirm, mainW-4)
+	} else if m.picker.IsActive() {
 		initPanel = m.picker.View()
 	} else if m.initFlow.IsActive() || m.initFlow.Phase() == tui.InitDone {
 		initPanel = m.initFlow.View()
@@ -2834,8 +2949,10 @@ func (m channelModel) updateThread(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			text := string(m.threadInput)
 			trimmed := strings.TrimSpace(text)
 			if strings.HasPrefix(trimmed, "/") {
+				m.threadInputHistory.record(m.threadInput, m.threadInputPos)
 				return m.runCommand(trimmed, m.threadPanelID)
 			}
+			m.threadInputHistory.record(m.threadInput, m.threadInputPos)
 			m.threadInput = nil
 			m.threadInputPos = 0
 			m.posting = true
@@ -2843,14 +2960,24 @@ func (m channelModel) updateThread(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	case "backspace":
 		if m.threadInputPos > 0 {
+			m.threadInputHistory.resetRecall()
 			m.threadInput = append(m.threadInput[:m.threadInputPos-1], m.threadInput[m.threadInputPos:]...)
 			m.threadInputPos--
 			m.updateThreadOverlays()
 		}
 	case "ctrl+u":
+		m.threadInputHistory.resetRecall()
 		m.threadInput = nil
 		m.threadInputPos = 0
 		m.updateThreadOverlays()
+	case "ctrl+p":
+		if snapshot, ok := m.threadInputHistory.previous(m.threadInput, m.threadInputPos); ok {
+			m.restoreThreadSnapshot(snapshot)
+		}
+	case "ctrl+n":
+		if snapshot, ok := m.threadInputHistory.next(); ok {
+			m.restoreThreadSnapshot(snapshot)
+		}
 	case "ctrl+a":
 		m.threadInputPos = 0
 		m.updateThreadOverlays()
@@ -2858,6 +2985,7 @@ func (m channelModel) updateThread(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.threadInputPos = len(m.threadInput)
 		m.updateThreadOverlays()
 	case "ctrl+j":
+		m.threadInputHistory.resetRecall()
 		ch := []rune{'\n'}
 		tail := make([]rune, len(m.threadInput[m.threadInputPos:]))
 		copy(tail, m.threadInput[m.threadInputPos:])
@@ -2890,6 +3018,7 @@ func (m channelModel) updateThread(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 	default:
 		if ch := composerInsertRunes(msg); len(ch) > 0 {
+			m.threadInputHistory.resetRecall()
 			m.threadInput, m.threadInputPos = insertComposerRunes(m.threadInput, m.threadInputPos, ch)
 			m.updateThreadOverlays()
 		} else if len(msg.String()) == 1 || msg.Type == tea.KeyRunes {
@@ -2898,6 +3027,7 @@ func (m channelModel) updateThread(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				ch = []rune(msg.String())
 			}
 			if len(ch) > 0 {
+				m.threadInputHistory.resetRecall()
 				tail := make([]rune, len(m.threadInput[m.threadInputPos:]))
 				copy(tail, m.threadInput[m.threadInputPos:])
 				m.threadInput = append(m.threadInput[:m.threadInputPos], append(ch, tail...)...)
@@ -3653,7 +3783,7 @@ func inferMood(text string) string {
 	}
 }
 
-func renderInterviewCard(interview channelInterview, selected int, width int) string {
+func renderInterviewCard(interview channelInterview, selected int, phaseTitle string, width int) string {
 	cardWidth := width
 	if cardWidth < 40 {
 		cardWidth = 40
@@ -3681,6 +3811,9 @@ func renderInterviewCard(interview channelInterview, selected int, width int) st
 		title = interview.Title + " · @" + interview.From
 	}
 	headerBits := []string{labelStyle.Render(cardLabel)}
+	if strings.TrimSpace(phaseTitle) != "" {
+		headerBits = append(headerBits, subtlePill(phaseTitle, "#DBEAFE", "#1D4ED8"))
+	}
 	if interview.Blocking {
 		headerBits = append(headerBits, accentPill("blocking", "#B45309"))
 	}
@@ -3714,6 +3847,9 @@ func renderInterviewCard(interview channelInterview, selected int, width int) st
 		if strings.TrimSpace(option.Description) != "" {
 			lines = append(lines, "    "+muted.Width(cardWidth-8).Render(option.Description))
 		}
+	}
+	if hint := interviewOptionTextHint(selectedInterviewOption(interview.Options, selected)); hint != "" {
+		lines = append(lines, "", muted.Width(cardWidth-4).Render(hint))
 	}
 	customPrefix := "  "
 	if selected >= len(interview.Options) {
@@ -3844,11 +3980,13 @@ func (m *channelModel) setActiveInput(text string) {
 	if m.focus == focusThread && m.threadPanelOpen {
 		m.threadInput = []rune(text)
 		m.threadInputPos = len(m.threadInput)
+		m.threadInputHistory.resetRecall()
 		m.updateThreadOverlays()
 		return
 	}
 	m.input = []rune(text)
 	m.inputPos = len(m.input)
+	m.inputHistory.resetRecall()
 	m.updateInputOverlays()
 	m.maybeActivateChannelPickerFromInput()
 }
@@ -3862,12 +4000,26 @@ func (m *channelModel) activeInputString() string {
 
 func (m *channelModel) insertAcceptedMention(mention string) {
 	if m.focus == focusThread && m.threadPanelOpen {
+		m.threadInputHistory.resetRecall()
 		m.threadInput, m.threadInputPos = replaceMentionInInput(m.threadInput, m.threadInputPos, mention)
 		m.updateThreadOverlays()
 		return
 	}
+	m.inputHistory.resetRecall()
 	m.input, m.inputPos = replaceMentionInInput(m.input, m.inputPos, mention)
 	m.updateInputOverlays()
+}
+
+func (m *channelModel) restoreMainSnapshot(snapshot composerSnapshot) {
+	m.input = append([]rune(nil), snapshot.input...)
+	m.inputPos = normalizeCursorPos(m.input, snapshot.pos)
+	m.updateInputOverlays()
+}
+
+func (m *channelModel) restoreThreadSnapshot(snapshot composerSnapshot) {
+	m.threadInput = append([]rune(nil), snapshot.input...)
+	m.threadInputPos = normalizeCursorPos(m.threadInput, snapshot.pos)
+	m.updateThreadOverlays()
 }
 
 func replaceMentionInInput(input []rune, pos int, mention string) ([]rune, int) {
@@ -4088,6 +4240,7 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 	}
 	clearCurrent := func() {
 		m.doctor = nil
+		m.confirm = nil
 		if threadTarget != "" {
 			clearThread()
 			m.updateThreadOverlays()
@@ -4100,7 +4253,6 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 	if m.isOneOnOne() && strings.HasPrefix(trimmed, "/") {
 		// Blacklist: commands that only make sense in team/office mode
 		teamOnly := []string{
-			"/switch", "/s",
 			"/tasks", "/task ", "/task\n",
 			"/channels", "/channel ", "/channel\n",
 			"/agents", "/agent ", "/agent\n", "/agent prompt",
@@ -4115,7 +4267,7 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 			}
 		}
 		if blocked {
-			m.notice = "1:1 mode disables office, channel, agent, task, and thread commands."
+			m.notice = "1:1 mode disables office collaboration commands."
 			return m, nil
 		}
 	}
@@ -4183,9 +4335,9 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		}
 	case trimmed == "/reset":
 		clearCurrent()
-		m.notice = ""
-		m.posting = true
-		return m, resetTeamSession(m.isOneOnOne())
+		m.confirm = m.confirmationForReset()
+		m.notice = "Confirm reset."
+		return m, nil
 	case trimmed == "/reset-dm" || strings.HasPrefix(trimmed, "/reset-dm "):
 		clearCurrent()
 		agent := ""
@@ -4200,8 +4352,9 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 			m.notice = "Usage: /reset-dm <agent> or use in 1:1 mode"
 			return m, nil
 		}
-		m.posting = true
-		return m, resetDMSession(agent, m.activeChannel)
+		m.confirm = confirmationForResetDM(agent, m.activeChannel)
+		m.notice = "Confirm clearing the direct transcript."
+		return m, nil
 	case trimmed == "/integrate":
 		clearCurrent()
 		if config.ResolveNoNex() {
@@ -4246,6 +4399,18 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		m.picker.SetActive(true)
 		m.pickerMode = channelPickerChannels
 		m.notice = "Choose a channel to switch to."
+		return m, nil
+	case trimmed == "/switcher":
+		clearCurrent()
+		options := m.buildWorkspaceSwitcherOptions()
+		if len(options) == 0 {
+			m.notice = "No destinations are available."
+			return m, nil
+		}
+		m.picker = tui.NewPicker("Workspace Switcher", options)
+		m.picker.SetActive(true)
+		m.pickerMode = channelPickerSwitcher
+		m.notice = "Choose where to jump next."
 		return m, nil
 	case trimmed == "/channels":
 		clearCurrent()
@@ -4777,9 +4942,33 @@ func (m channelModel) buildChannelPickerOptions() []tui.PickerOption {
 }
 
 func (m channelModel) buildSwitchChannelPickerOptions() []tui.PickerOption {
-	all := m.buildChannelPickerOptions()
-	options := make([]tui.PickerOption, 0, len(all))
-	for _, option := range all {
+	options := []tui.PickerOption{
+		{Label: "Main office feed", Value: "app:messages", Description: "Return to the shared message stream"},
+		{Label: "Tasks", Value: "app:tasks", Description: "Review active work for this channel"},
+		{Label: "Requests", Value: "app:requests", Description: "Open pending approvals and interviews"},
+		{Label: "Policies", Value: "app:policies", Description: "Show signals, decisions, and watchdogs"},
+		{Label: "Calendar", Value: "app:calendar", Description: "View the office schedule and teammate calendars"},
+	}
+	if m.isOneOnOne() {
+		options = append(options, tui.PickerOption{
+			Label:       "Return to main office",
+			Value:       "session:office",
+			Description: "Leave direct mode and restore the shared office session",
+		})
+	} else {
+		for _, member := range m.officeMembers {
+			name := strings.TrimSpace(member.Name)
+			if name == "" {
+				name = displayName(member.Slug)
+			}
+			options = append(options, tui.PickerOption{
+				Label:       "1:1 with " + name,
+				Value:       "session:1o1:" + member.Slug,
+				Description: "Jump into a direct session with " + name,
+			})
+		}
+	}
+	for _, option := range m.buildChannelPickerOptions() {
 		if strings.HasPrefix(option.Value, "switch:") {
 			options = append(options, option)
 		}

--- a/cmd/wuphf/channel_activity.go
+++ b/cmd/wuphf/channel_activity.go
@@ -192,7 +192,75 @@ func buildLiveWorkLines(members []channelMember, tasks []channelTask, actions []
 			}
 		}
 	}
+
+	if waitLines := buildWaitStateLines(tasks, contentWidth, focusSlug, len(active) > 0, len(recent) > 0); len(waitLines) > 0 {
+		lines = append(lines, waitLines...)
+	}
 	return lines
+}
+
+func buildWaitStateLines(tasks []channelTask, contentWidth int, focusSlug string, hasActive bool, hasRecentActions bool) []renderedLine {
+	blocked := blockedWorkTasks(tasks, focusSlug, 2)
+	if len(blocked) > 0 {
+		lines := []renderedLine{
+			{Text: ""},
+			{Text: renderDateSeparator(contentWidth, "Blocked work")},
+		}
+		for _, task := range blocked {
+			extra := []string{"Owner @" + fallbackString(task.Owner, "unowned")}
+			if strings.TrimSpace(task.ThreadID) != "" {
+				extra = append(extra, "Thread "+task.ThreadID)
+			}
+			extra = append(extra, "Open task")
+			body := strings.TrimSpace(task.Details)
+			if body == "" {
+				body = "This work is stalled until the blocker is cleared."
+			}
+			for _, line := range renderRuntimeEventCard(contentWidth, accentPill("blocked", "#B91C1C")+" "+lipgloss.NewStyle().Bold(true).Render(task.Title), body, "#B91C1C", extra) {
+				lines = append(lines, renderedLine{Text: line, TaskID: task.ID})
+			}
+		}
+		return lines
+	}
+
+	if hasActive || hasRecentActions {
+		return nil
+	}
+
+	title := subtlePill("quiet", "#E2E8F0", "#334155") + " " + lipgloss.NewStyle().Bold(true).Render("Nothing is moving right now")
+	body := "This lane is idle. Use the quiet moment to recover context, choose the next conversation, or give the team a sharper direction."
+	extra := []string{"/switcher for active work · /recover for recap · /search to jump directly"}
+	if strings.TrimSpace(focusSlug) != "" {
+		title = subtlePill("idle", "#E2E8F0", "#334155") + " " + lipgloss.NewStyle().Bold(true).Render(displayName(focusSlug)+" is waiting for direction")
+		body = "This direct session is idle. Ask for a plan, request a review pass, or drop in a concrete decision to unlock the next move."
+		extra = []string{"Try: give one clear goal, ask for a brief, or request a tradeoff decision"}
+	}
+
+	lines := []renderedLine{
+		{Text: ""},
+		{Text: renderDateSeparator(contentWidth, "Wait state")},
+	}
+	for _, line := range renderRuntimeEventCard(contentWidth, title, body, "#475569", extra) {
+		lines = append(lines, renderedLine{Text: line})
+	}
+	return lines
+}
+
+func blockedWorkTasks(tasks []channelTask, focusSlug string, limit int) []channelTask {
+	filtered := make([]channelTask, 0, len(tasks))
+	for _, task := range tasks {
+		if !strings.EqualFold(strings.TrimSpace(task.Status), "blocked") {
+			continue
+		}
+		if strings.TrimSpace(focusSlug) != "" && strings.TrimSpace(task.Owner) != strings.TrimSpace(focusSlug) {
+			continue
+		}
+		filtered = append(filtered, task)
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered
 }
 
 func buildDirectExecutionLines(actions []channelAction, focusSlug string, contentWidth int) []renderedLine {

--- a/cmd/wuphf/channel_artifacts.go
+++ b/cmd/wuphf/channel_artifacts.go
@@ -1,0 +1,442 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+type taskLogRecord struct {
+	TaskID      string          `json:"task_id"`
+	AgentSlug   string          `json:"agent_slug"`
+	ToolName    string          `json:"tool_name"`
+	Params      json.RawMessage `json:"params"`
+	Result      json.RawMessage `json:"result"`
+	Error       json.RawMessage `json:"error"`
+	StartedAt   string          `json:"started_at"`
+	CompletedAt string          `json:"completed_at"`
+}
+
+type taskLogArtifact struct {
+	TaskID       string
+	AgentSlug    string
+	ToolName     string
+	Summary      string
+	StartedAt    string
+	CompletedAt  string
+	LogPath      string
+	EntryCount   int
+	UpdatedAt    time.Time
+	WorktreePath string
+	TaskTitle    string
+}
+
+type workflowRunArtifact struct {
+	Provider    string `json:"provider"`
+	WorkflowKey string `json:"workflow_key"`
+	RunID       string `json:"run_id"`
+	Status      string `json:"status"`
+	StartedAt   string `json:"started_at"`
+	FinishedAt  string `json:"finished_at"`
+	Path        string
+	UpdatedAt   time.Time
+}
+
+func (m channelModel) buildArtifactLines(contentWidth int) []renderedLine {
+	lines := []renderedLine{{Text: renderDateSeparator(contentWidth, "Execution artifacts")}}
+	taskLogs := m.recentTaskLogArtifacts(6)
+	workflowRuns := recentWorkflowRunArtifacts(6)
+	requests := recentHumanArtifactRequests(m.requests, 6)
+	requestActions := recentRequestArtifactActions(m.actions, 6)
+
+	if len(taskLogs) == 0 && len(workflowRuns) == 0 && len(requests) == 0 && len(requestActions) == 0 {
+		muted := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
+		return append(lines,
+			renderedLine{Text: ""},
+			renderedLine{Text: muted.Render("  No retained execution artifacts yet.")},
+			renderedLine{Text: muted.Render("  Task tool logs, workflow runs, and human decision traces will appear here.")},
+		)
+	}
+
+	if len(taskLogs) > 0 {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Task output logs")})
+		for _, artifact := range taskLogs {
+			header := subtlePill(artifactClock(artifact.CompletedAt, artifact.UpdatedAt), "#E2E8F0", "#0F172A") +
+				" " + accentPill("log", "#0F766E") +
+				" " + lipgloss.NewStyle().Bold(true).Render(fmt.Sprintf("Task %s · %s", artifact.TaskID, fallbackString(artifact.ToolName, "tool run")))
+			extra := []string{
+				strings.TrimSpace(fmt.Sprintf("@%s · %d entr%s · %s", fallbackString(artifact.AgentSlug, "unknown"), artifact.EntryCount, pluralSuffix(artifact.EntryCount), prettyRelativeTime(artifactTime(artifact.CompletedAt, artifact.UpdatedAt)))),
+			}
+			if strings.TrimSpace(artifact.TaskTitle) != "" {
+				extra = append(extra, "Title: "+artifact.TaskTitle)
+			}
+			if strings.TrimSpace(artifact.WorktreePath) != "" {
+				extra = append(extra, "Worktree: "+artifact.WorktreePath)
+			}
+			if strings.TrimSpace(artifact.LogPath) != "" {
+				extra = append(extra, "Log: "+artifact.LogPath)
+			}
+			for i, line := range renderRuntimeEventCard(contentWidth, header, artifact.Summary, "#0F766E", extra) {
+				rendered := renderedLine{Text: "  " + line}
+				if i == 0 {
+					rendered.TaskID = artifact.TaskID
+				}
+				lines = append(lines, rendered)
+			}
+		}
+	}
+
+	if len(workflowRuns) > 0 {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Workflow runs")})
+		for _, run := range workflowRuns {
+			header := subtlePill(artifactClock(run.FinishedAt, run.UpdatedAt), "#E2E8F0", "#0F172A") +
+				" " + actionStatePill("external_workflow_"+fallbackString(run.Status, "finished")) +
+				" " + lipgloss.NewStyle().Bold(true).Render(fmt.Sprintf("%s · %s", fallbackString(run.WorkflowKey, "workflow"), fallbackString(run.Status, "finished")))
+			body := strings.TrimSpace(fmt.Sprintf("%s via %s", fallbackString(run.RunID, "run"), fallbackString(run.Provider, "provider")))
+			extra := []string{
+				prettyRelativeTime(artifactTime(run.FinishedAt, run.UpdatedAt)),
+			}
+			if strings.TrimSpace(run.Path) != "" {
+				extra = append(extra, "Run log: "+run.Path)
+			}
+			for _, line := range renderRuntimeEventCard(contentWidth, header, body, "#7C3AED", extra) {
+				lines = append(lines, renderedLine{Text: "  " + line})
+			}
+		}
+	}
+
+	if len(requests) > 0 || len(requestActions) > 0 {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Human decisions")})
+		for _, req := range requests {
+			status := strings.TrimSpace(req.Status)
+			if status == "" {
+				status = "pending"
+			}
+			header := subtlePill(strings.ReplaceAll(status, "_", " "), "#FEF3C7", "#78350F") +
+				" " + accentPill(req.Kind, "#92400E") +
+				" " + lipgloss.NewStyle().Bold(true).Render(fmt.Sprintf("%s · %s", req.ID, req.TitleOrQuestion()))
+			extra := []string{"Asked by @" + fallbackString(req.From, "unknown")}
+			if strings.TrimSpace(req.RecommendedID) != "" {
+				extra = append(extra, "Recommended: "+req.RecommendedID)
+			}
+			if due := strings.TrimSpace(req.DueAt); due != "" {
+				extra = append(extra, "Due "+prettyRelativeTime(due))
+			}
+			for _, line := range renderRuntimeEventCard(contentWidth, header, req.Context, "#B45309", extra) {
+				lines = append(lines, renderedLine{Text: "  " + line, RequestID: req.ID})
+			}
+		}
+		for _, action := range requestActions {
+			header := subtlePill(artifactClock(action.CreatedAt, time.Time{}), "#E2E8F0", "#0F172A") +
+				" " + actionStatePill(action.Kind) +
+				" " + lipgloss.NewStyle().Bold(true).Render(fallbackString(action.Summary, strings.ReplaceAll(action.Kind, "_", " ")))
+			extra := []string{}
+			if actor := strings.TrimSpace(action.Actor); actor != "" {
+				extra = append(extra, "@"+actor)
+			}
+			if channel := strings.TrimSpace(action.Channel); channel != "" {
+				extra = append(extra, "#"+channel)
+			}
+			if related := strings.TrimSpace(action.RelatedID); related != "" {
+				extra = append(extra, related)
+			}
+			if source := strings.TrimSpace(action.Source); source != "" {
+				extra = append(extra, source)
+			}
+			for _, line := range renderRuntimeEventCard(contentWidth, header, prettyRelativeTime(action.CreatedAt), "#1D4ED8", extra) {
+				lines = append(lines, renderedLine{Text: "  " + line})
+			}
+		}
+	}
+
+	return lines
+}
+
+func (m channelModel) currentArtifactSummary() string {
+	logCount := len(m.recentTaskLogArtifacts(4))
+	workflowCount := len(recentWorkflowRunArtifacts(4))
+	requestCount := len(recentHumanArtifactRequests(m.requests, 4)) + len(recentRequestArtifactActions(m.actions, 4))
+	parts := make([]string, 0, 3)
+	if logCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d task log%s", logCount, pluralSuffix(logCount)))
+	}
+	if workflowCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d workflow run%s", workflowCount, pluralSuffix(workflowCount)))
+	}
+	if requestCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d decision trace%s", requestCount, pluralSuffix(requestCount)))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func (m channelModel) recentTaskLogArtifacts(limit int) []taskLogArtifact {
+	root := taskLogRoot()
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+
+	taskIndex := make(map[string]channelTask, len(m.tasks))
+	for _, task := range m.tasks {
+		taskIndex[task.ID] = task
+	}
+
+	artifacts := make([]taskLogArtifact, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(root, entry.Name(), "output.log")
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		artifact, ok := readTaskLogArtifact(path, info)
+		if !ok {
+			continue
+		}
+		if task, ok := taskIndex[artifact.TaskID]; ok {
+			artifact.TaskTitle = strings.TrimSpace(task.Title)
+			artifact.WorktreePath = strings.TrimSpace(task.WorktreePath)
+		}
+		artifacts = append(artifacts, artifact)
+	}
+
+	sort.Slice(artifacts, func(i, j int) bool {
+		return artifacts[i].UpdatedAt.After(artifacts[j].UpdatedAt)
+	})
+	if limit > 0 && len(artifacts) > limit {
+		artifacts = artifacts[:limit]
+	}
+	return artifacts
+}
+
+func readTaskLogArtifact(path string, info fs.FileInfo) (taskLogArtifact, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return taskLogArtifact{}, false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 128*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	var last string
+	entryCount := 0
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		last = line
+		entryCount++
+	}
+	if scanner.Err() != nil || last == "" {
+		return taskLogArtifact{}, false
+	}
+
+	var record taskLogRecord
+	if err := json.Unmarshal([]byte(last), &record); err != nil {
+		return taskLogArtifact{
+			TaskID:     filepath.Base(filepath.Dir(path)),
+			Summary:    truncateText(last, 160),
+			LogPath:    path,
+			EntryCount: entryCount,
+			UpdatedAt:  info.ModTime(),
+		}, true
+	}
+
+	taskID := strings.TrimSpace(record.TaskID)
+	if taskID == "" {
+		taskID = filepath.Base(filepath.Dir(path))
+	}
+	return taskLogArtifact{
+		TaskID:      taskID,
+		AgentSlug:   strings.TrimSpace(record.AgentSlug),
+		ToolName:    strings.TrimSpace(record.ToolName),
+		Summary:     summarizeTaskLogRecord(record),
+		StartedAt:   strings.TrimSpace(record.StartedAt),
+		CompletedAt: strings.TrimSpace(record.CompletedAt),
+		LogPath:     path,
+		EntryCount:  entryCount,
+		UpdatedAt:   info.ModTime(),
+	}, true
+}
+
+func summarizeTaskLogRecord(record taskLogRecord) string {
+	if text := summarizeJSONField(record.Error, 120); text != "" && text != "null" {
+		return "Error: " + text
+	}
+	if text := summarizeJSONField(record.Result, 160); text != "" && text != "null" {
+		return text
+	}
+	if text := summarizeJSONField(record.Params, 120); text != "" && text != "null" {
+		return "Params: " + text
+	}
+	return "Tool execution finished."
+}
+
+func summarizeJSONField(raw json.RawMessage, max int) string {
+	text := strings.TrimSpace(string(raw))
+	if text == "" || text == "null" {
+		return ""
+	}
+	var plain string
+	if err := json.Unmarshal(raw, &plain); err == nil {
+		return truncateText(strings.TrimSpace(plain), max)
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err == nil {
+		return truncateText(compact.String(), max)
+	}
+	return truncateText(text, max)
+}
+
+func recentWorkflowRunArtifacts(limit int) []workflowRunArtifact {
+	root := filepath.Join(filepath.Dir(config.ConfigPath()), "workflows")
+	entries := []workflowRunArtifact{}
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d == nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".runs.jsonl") {
+			return nil
+		}
+		info, statErr := d.Info()
+		if statErr != nil {
+			return nil
+		}
+		artifact, ok := readWorkflowRunArtifact(path, info)
+		if ok {
+			entries = append(entries, artifact)
+		}
+		return nil
+	})
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].UpdatedAt.After(entries[j].UpdatedAt)
+	})
+	if limit > 0 && len(entries) > limit {
+		entries = entries[:limit]
+	}
+	return entries
+}
+
+func readWorkflowRunArtifact(path string, info fs.FileInfo) (workflowRunArtifact, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return workflowRunArtifact{}, false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 128*1024)
+	scanner.Buffer(buf, 1024*1024)
+
+	var last string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		last = line
+	}
+	if scanner.Err() != nil || last == "" {
+		return workflowRunArtifact{}, false
+	}
+
+	var artifact workflowRunArtifact
+	if err := json.Unmarshal([]byte(last), &artifact); err != nil {
+		return workflowRunArtifact{}, false
+	}
+	artifact.Path = path
+	artifact.UpdatedAt = info.ModTime()
+	return artifact, true
+}
+
+func recentHumanArtifactRequests(requests []channelInterview, limit int) []channelInterview {
+	filtered := make([]channelInterview, 0, len(requests))
+	for _, req := range requests {
+		kind := strings.TrimSpace(req.Kind)
+		switch kind {
+		case "approval", "confirm", "choice", "interview":
+			filtered = append(filtered, req)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		left, lok := parseChannelTime(filtered[i].CreatedAt)
+		right, rok := parseChannelTime(filtered[j].CreatedAt)
+		switch {
+		case lok && rok:
+			return left.After(right)
+		case lok:
+			return true
+		case rok:
+			return false
+		default:
+			return filtered[i].ID > filtered[j].ID
+		}
+	})
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered
+}
+
+func recentRequestArtifactActions(actions []channelAction, limit int) []channelAction {
+	filtered := make([]channelAction, 0, len(actions))
+	for _, action := range actions {
+		if strings.HasPrefix(strings.TrimSpace(action.Kind), "request_") {
+			filtered = append(filtered, action)
+		}
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[len(filtered)-limit:]
+	}
+	out := append([]channelAction(nil), filtered...)
+	reverseAny(out)
+	return out
+}
+
+func taskLogRoot() string {
+	if root := strings.TrimSpace(os.Getenv("WUPHF_TASK_LOG_ROOT")); root != "" {
+		return root
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".wuphf", "office", "tasks")
+	}
+	return filepath.Join(home, ".wuphf", "office", "tasks")
+}
+
+func artifactClock(timestamp string, fallback time.Time) string {
+	if clock := strings.TrimSpace(shortClock(timestamp)); clock != "" {
+		return clock
+	}
+	if !fallback.IsZero() {
+		return fallback.Local().Format("15:04")
+	}
+	return "artifact"
+}
+
+func artifactTime(timestamp string, fallback time.Time) string {
+	if strings.TrimSpace(timestamp) != "" {
+		return timestamp
+	}
+	if !fallback.IsZero() {
+		return fallback.Format(time.RFC3339)
+	}
+	return ""
+}

--- a/cmd/wuphf/channel_artifacts_test.go
+++ b/cmd/wuphf/channel_artifacts_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestResolveInitialOfficeAppSupportsArtifacts(t *testing.T) {
+	if got := resolveInitialOfficeApp("artifacts"); got != officeAppArtifacts {
+		t.Fatalf("expected artifacts app, got %q", got)
+	}
+}
+
+func TestArtifactsCommandSwitchesToArtifactsApp(t *testing.T) {
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 30
+	m.input = []rune("/artifacts")
+	m.inputPos = len(m.input)
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := next.(channelModel)
+
+	if got.activeApp != officeAppArtifacts {
+		t.Fatalf("expected artifacts app, got %q", got.activeApp)
+	}
+	if !strings.Contains(got.notice, "execution artifacts") {
+		t.Fatalf("expected artifact notice, got %q", got.notice)
+	}
+}
+
+func TestCurrentArtifactSummaryUsesLogsAndWorkflows(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	writeTaskLog(t, home, "task-1", `{"task_id":"task-1","agent_slug":"fe","tool_name":"grep","result":"Found Bubble Tea callsites","started_at":"2026-04-07T10:00:00Z","completed_at":"2026-04-07T10:01:00Z"}`)
+	writeWorkflowRun(t, home, "one", "daily-digest", `{"provider":"one","workflow_key":"daily-digest","run_id":"run-1","status":"success","started_at":"2026-04-07T10:02:00Z","finished_at":"2026-04-07T10:03:00Z"}`)
+
+	m := newChannelModel(false)
+	m.requests = []channelInterview{{ID: "req-1", Kind: "approval", Status: "pending", Title: "Approve copy", Question: "Approve copy?", From: "ceo"}}
+
+	got := m.currentArtifactSummary()
+	if !strings.Contains(got, "task log") {
+		t.Fatalf("expected task logs in summary, got %q", got)
+	}
+	if !strings.Contains(got, "workflow run") {
+		t.Fatalf("expected workflow runs in summary, got %q", got)
+	}
+	if !strings.Contains(got, "decision trace") {
+		t.Fatalf("expected decision traces in summary, got %q", got)
+	}
+}
+
+func TestBuildArtifactLinesShowsTaskLogsWorkflowRunsAndApprovals(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	writeTaskLog(t, home, "task-1", `{"task_id":"task-1","agent_slug":"fe","tool_name":"bash","result":"ok","started_at":"2026-04-07T10:00:00Z","completed_at":"2026-04-07T10:01:00Z"}`)
+	writeWorkflowRun(t, home, "one", "launch-sync", `{"provider":"one","workflow_key":"launch-sync","run_id":"run-2","status":"success","started_at":"2026-04-07T10:02:00Z","finished_at":"2026-04-07T10:03:00Z"}`)
+
+	m := newChannelModel(false)
+	m.tasks = []channelTask{{ID: "task-1", Title: "Ship launch notes", WorktreePath: "/tmp/wuphf-task-1"}}
+	m.requests = []channelInterview{{
+		ID:            "req-1",
+		Kind:          "approval",
+		Status:        "pending",
+		Title:         "Approve launch copy",
+		Question:      "Approve launch copy?",
+		Context:       "Need final sign-off on the launch blurb.",
+		From:          "ceo",
+		RecommendedID: "approve",
+		CreatedAt:     time.Now().Add(-time.Minute).Format(time.RFC3339),
+	}}
+	m.actions = []channelAction{{
+		ID:        "action-1",
+		Kind:      "request_answered",
+		Actor:     "you",
+		Channel:   "general",
+		Summary:   "Approved the launch direction.",
+		RelatedID: "req-1",
+		CreatedAt: time.Now().Format(time.RFC3339),
+	}}
+
+	lines := m.buildArtifactLines(96)
+	plain := stripANSI(joinRenderedLines(lines))
+
+	if !strings.Contains(plain, "Task output logs") {
+		t.Fatalf("expected task output logs section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Workflow runs") {
+		t.Fatalf("expected workflow runs section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Human decisions") {
+		t.Fatalf("expected human decisions section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Ship launch notes") {
+		t.Fatalf("expected task title in artifacts view, got %q", plain)
+	}
+	if !strings.Contains(plain, "launch-sync") {
+		t.Fatalf("expected workflow key in artifacts view, got %q", plain)
+	}
+}
+
+func writeTaskLog(t *testing.T, home, taskID, record string) {
+	t.Helper()
+	path := filepath.Join(home, ".wuphf", "office", "tasks", taskID)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir task log dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, "output.log"), []byte(record+"\n"), 0o644); err != nil {
+		t.Fatalf("write task log: %v", err)
+	}
+}
+
+func writeWorkflowRun(t *testing.T, home, provider, key, record string) {
+	t.Helper()
+	path := filepath.Join(home, ".wuphf", "workflows", provider)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir workflow dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(path, key+".runs.jsonl"), []byte(record+"\n"), 0o644); err != nil {
+		t.Fatalf("write workflow run: %v", err)
+	}
+}

--- a/cmd/wuphf/channel_composer.go
+++ b/cmd/wuphf/channel_composer.go
@@ -12,7 +12,7 @@ import (
 // label, rounded border, cursor, @mention popup, and interview options.
 func renderComposer(width int, input []rune, inputPos int, channelName string,
 	replyToID string, typingAgents []string, liveActivities map[string]string,
-	pending *channelInterview, selectedOption int, focused bool, tickFrame int) string {
+	pending *channelInterview, selectedOption int, hint string, focused bool, tickFrame int) string {
 
 	if width < 10 {
 		width = 10
@@ -36,11 +36,13 @@ func renderComposer(width int, input []rune, inputPos int, channelName string,
 		Foreground(lipgloss.Color(slackActive)).
 		Bold(true)
 	hintStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
-	hint := "/ commands · @ mention · Ctrl+J newline · Enter send · Esc pause all"
-	if pending != nil {
-		hint = "↑/↓ pick option · Enter submit · type to answer freeform · Esc pause all"
-	} else if strings.HasPrefix(channelName, "1:1 ") {
-		hint = "/ commands · @ mention · Ctrl+J newline · Enter send direct · Esc pause all"
+	if strings.TrimSpace(hint) == "" {
+		hint = "/ commands · @ mention · Ctrl+J newline · Enter send · Esc pause all"
+		if pending != nil {
+			hint = "↑/↓ pick option · Enter submit · type to answer freeform · Esc pause all"
+		} else if strings.HasPrefix(channelName, "1:1 ") {
+			hint = "/ commands · @ mention · Ctrl+J newline · Enter send direct · Esc pause all"
+		}
 	}
 	parts = append(parts, "  "+labelStyle.Render(label)+"  "+hintStyle.Render(hint))
 

--- a/cmd/wuphf/channel_confirm.go
+++ b/cmd/wuphf/channel_confirm.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+type channelConfirmAction string
+
+const (
+	confirmActionResetTeam     channelConfirmAction = "reset_team"
+	confirmActionResetDM       channelConfirmAction = "reset_dm"
+	confirmActionSwitchMode    channelConfirmAction = "switch_mode"
+	confirmActionRecoverFocus  channelConfirmAction = "recover_focus"
+	confirmActionSubmitRequest channelConfirmAction = "submit_request"
+)
+
+type channelConfirm struct {
+	Title        string
+	Detail       string
+	ConfirmLabel string
+	CancelLabel  string
+	Action       channelConfirmAction
+	SessionMode  string
+	Agent        string
+	Channel      string
+	Request      *channelInterview
+	ChoiceID     string
+	ChoiceText   string
+	CustomText   string
+}
+
+func (m channelModel) confirmationForReset() *channelConfirm {
+	title := "Reset Office Session"
+	detail := "This clears the live office transcript and refreshes all team panes in place."
+	if m.isOneOnOne() {
+		title = "Reset Direct Session"
+		detail = fmt.Sprintf("This clears the direct transcript with %s and reloads the direct pane in place.", m.oneOnOneAgentName())
+	}
+	return &channelConfirm{
+		Title:        title,
+		Detail:       detail,
+		ConfirmLabel: "Enter reset now",
+		CancelLabel:  "Esc keep working",
+		Action:       confirmActionResetTeam,
+		SessionMode:  m.sessionMode,
+		Agent:        m.oneOnOneAgent,
+	}
+}
+
+func confirmationForResetDM(agent, channel string) *channelConfirm {
+	return &channelConfirm{
+		Title:        "Clear Direct Messages",
+		Detail:       fmt.Sprintf("This deletes the saved direct transcript with %s for this session.", displayName(agent)),
+		ConfirmLabel: "Enter clear DMs",
+		CancelLabel:  "Esc keep transcript",
+		Action:       confirmActionResetDM,
+		Agent:        agent,
+		Channel:      channel,
+	}
+}
+
+func confirmationForSessionSwitch(mode, agent string) *channelConfirm {
+	mode = strings.TrimSpace(mode)
+	agent = strings.TrimSpace(agent)
+	title := "Switch Session Mode"
+	detail := "This changes how the office routes the live session."
+	if team.NormalizeSessionMode(mode) == team.SessionModeOneOnOne {
+		name := displayName(agent)
+		if agent == "" {
+			name = displayName(team.DefaultOneOnOneAgent)
+		}
+		title = "Enter Direct Session"
+		detail = fmt.Sprintf("This leaves the shared office view and zooms into a direct session with %s.", name)
+	} else {
+		title = "Return To Main Office"
+		detail = "This exits direct mode and restores the shared office session."
+	}
+	return &channelConfirm{
+		Title:        title,
+		Detail:       detail,
+		ConfirmLabel: "Enter switch now",
+		CancelLabel:  "Esc stay here",
+		Action:       confirmActionSwitchMode,
+		SessionMode:  mode,
+		Agent:        agent,
+	}
+}
+
+func confirmationForInterviewAnswer(interview channelInterview, option *channelInterviewOption, customText string) *channelConfirm {
+	title := "Review Human Answer"
+	detailLines := []string{
+		fmt.Sprintf("Question: %s", strings.TrimSpace(interview.Question)),
+	}
+	if option != nil && strings.TrimSpace(option.Label) != "" {
+		detailLines = append(detailLines, fmt.Sprintf("Choice: %s", strings.TrimSpace(option.Label)))
+	}
+	customText = strings.TrimSpace(customText)
+	if customText != "" {
+		detailLines = append(detailLines, fmt.Sprintf("Note: %s", customText))
+	}
+	if len(detailLines) == 1 && option == nil {
+		detailLines = append(detailLines, "Type an answer before submitting.")
+	}
+	choiceID := ""
+	choiceText := ""
+	if option != nil {
+		choiceID = strings.TrimSpace(option.ID)
+		choiceText = strings.TrimSpace(option.Label)
+	}
+	return &channelConfirm{
+		Title:        title,
+		Detail:       strings.Join(detailLines, "\n\n"),
+		ConfirmLabel: "Enter send answer",
+		CancelLabel:  "Esc keep editing",
+		Action:       confirmActionSubmitRequest,
+		Request:      &interview,
+		ChoiceID:     choiceID,
+		ChoiceText:   choiceText,
+		CustomText:   customText,
+	}
+}
+
+func renderConfirmCard(confirm channelConfirm, width int) string {
+	cardWidth := maxInt(48, width)
+	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F8FAFC")).Render(confirm.Title)
+	body := lipgloss.NewStyle().Foreground(lipgloss.Color("#CBD5E1")).Width(cardWidth - 4).Render(confirm.Detail)
+	footer := mutedText(confirm.ConfirmLabel + "  ·  " + confirm.CancelLabel)
+	lines := []string{
+		title,
+		"",
+		body,
+		"",
+		footer,
+	}
+	return lipgloss.NewStyle().
+		Width(cardWidth).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("#7C2D12")).
+		Background(lipgloss.Color("#14151B")).
+		Padding(0, 1).
+		Render(strings.Join(lines, "\n"))
+}
+
+func (m channelModel) executeConfirmation(confirm channelConfirm) (tea.Model, tea.Cmd) {
+	switch confirm.Action {
+	case confirmActionResetTeam:
+		m.confirm = nil
+		m.notice = ""
+		m.posting = true
+		return m, resetTeamSession(m.isOneOnOne())
+	case confirmActionResetDM:
+		m.confirm = nil
+		m.posting = true
+		return m, resetDMSession(confirm.Agent, confirm.Channel)
+	case confirmActionSwitchMode:
+		m.confirm = nil
+		m.posting = true
+		return m, switchSessionMode(confirm.SessionMode, confirm.Agent)
+	case confirmActionSubmitRequest:
+		m.confirm = nil
+		m.notice = ""
+		m.posting = true
+		if confirm.Request == nil {
+			m.posting = false
+			m.notice = "No request selected."
+			return m, nil
+		}
+		return m, postInterviewAnswer(*confirm.Request, confirm.ChoiceID, confirm.ChoiceText, confirm.CustomText)
+	default:
+		m.confirm = nil
+		return m, nil
+	}
+}

--- a/cmd/wuphf/channel_context.go
+++ b/cmd/wuphf/channel_context.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/nex-crm/wuphf/internal/tui"
+)
+
+type channelInteractionContext string
+
+const (
+	contextConfirm      channelInteractionContext = "confirm"
+	contextPicker       channelInteractionContext = "picker"
+	contextAutocomplete channelInteractionContext = "autocomplete"
+	contextMention      channelInteractionContext = "mention"
+	contextMemberDraft  channelInteractionContext = "member_draft"
+	contextDoctor       channelInteractionContext = "doctor"
+	contextInterview    channelInteractionContext = "interview"
+	contextThread       channelInteractionContext = "thread"
+	contextSidebar      channelInteractionContext = "sidebar"
+	contextMain         channelInteractionContext = "main"
+)
+
+func (m channelModel) activeInteractionContext() channelInteractionContext {
+	switch {
+	case m.confirm != nil:
+		return contextConfirm
+	case m.picker.IsActive() || m.initFlow.IsActive():
+		return contextPicker
+	case m.autocomplete.IsVisible():
+		return contextAutocomplete
+	case m.mention.IsVisible():
+		return contextMention
+	case m.memberDraft != nil:
+		return contextMemberDraft
+	case m.doctor != nil:
+		return contextDoctor
+	case m.pending != nil && !m.posting:
+		return contextInterview
+	case m.focus == focusThread && m.threadPanelOpen:
+		return contextThread
+	case m.focus == focusSidebar && !m.sidebarCollapsed:
+		return contextSidebar
+	default:
+		return contextMain
+	}
+}
+
+func (m channelModel) composerHint(channelName, replyToID string, pending *channelInterview) string {
+	switch m.activeInteractionContext() {
+	case contextConfirm:
+		if m.confirm != nil && m.confirm.Action == confirmActionSubmitRequest {
+			return tui.ComposerHint(tui.ComposerHintState{
+				Context:          tui.ContextInterviewReview,
+				HistoryAvailable: len(m.inputHistory.entries) > 0,
+			})
+		}
+		return tui.ContinuePrompt{
+			Title:       "Review change",
+			Description: "Confirm the disruptive action before WUPHF changes runtime state",
+		}.InlineHint()
+	case contextMemberDraft:
+		return "Enter save teammate · Ctrl+J newline · Esc cancel editor"
+	case contextInterview:
+		return tui.ComposerHint(tui.ComposerHintState{
+			Context:          tui.ContextInterview,
+			HistoryAvailable: len(m.inputHistory.entries) > 0,
+		})
+	case contextThread:
+		return tui.ComposerHint(tui.ComposerHintState{
+			Context:          tui.ContextThreadCompose,
+			HistoryAvailable: len(m.threadInputHistory.entries) > 0,
+		})
+	case contextMain:
+		if replyToID != "" {
+			return fmt.Sprintf("%s · /cancel leave thread %s", tui.ComposerHint(tui.ComposerHintState{
+				Context:          tui.ContextReplyCompose,
+				HistoryAvailable: len(m.inputHistory.entries) > 0,
+			}), replyToID)
+		}
+		if stringsHasOneOnOnePrefix(channelName) {
+			return tui.ComposerHint(tui.ComposerHintState{
+				Context:          tui.ContextDirectCompose,
+				HistoryAvailable: len(m.inputHistory.entries) > 0,
+			})
+		}
+		return tui.ComposerHint(tui.ComposerHintState{
+			Context:          tui.ContextCompose,
+			HistoryAvailable: len(m.inputHistory.entries) > 0,
+		})
+	case contextAutocomplete:
+		return tui.ComposerHint(tui.ComposerHintState{
+			Context:          tui.ContextAutocomplete,
+			HistoryAvailable: len(m.inputHistory.entries) > 0,
+		})
+	case contextMention:
+		return tui.ComposerHint(tui.ComposerHintState{
+			Context:          tui.ContextMention,
+			HistoryAvailable: len(m.inputHistory.entries) > 0,
+		})
+	case contextPicker:
+		return tui.ComposerHint(tui.ComposerHintState{
+			Context:          tui.ContextPicker,
+			HistoryAvailable: len(m.inputHistory.entries) > 0,
+		})
+	case contextDoctor:
+		return tui.ComposerHint(tui.ComposerHintState{
+			Context:          tui.ContextDoctor,
+			HistoryAvailable: len(m.inputHistory.entries) > 0,
+		})
+	default:
+		if stringsHasOneOnOnePrefix(channelName) {
+			return tui.ComposerHint(tui.ComposerHintState{
+				Context:          tui.ContextDirectCompose,
+				HistoryAvailable: len(m.inputHistory.entries) > 0,
+			})
+		}
+		return tui.ComposerHint(tui.ComposerHintState{
+			Context:          tui.ContextCompose,
+			HistoryAvailable: len(m.inputHistory.entries) > 0,
+		})
+	}
+}
+
+func stringsHasOneOnOnePrefix(channelName string) bool {
+	return len(channelName) >= 4 && channelName[:4] == "1:1 "
+}

--- a/cmd/wuphf/channel_history.go
+++ b/cmd/wuphf/channel_history.go
@@ -1,0 +1,94 @@
+package main
+
+import "strings"
+
+type composerSnapshot struct {
+	input []rune
+	pos   int
+}
+
+type composerHistory struct {
+	entries     []composerSnapshot
+	recallIndex int
+	stash       *composerSnapshot
+}
+
+const maxComposerHistoryEntries = 50
+
+func newComposerHistory() composerHistory {
+	return composerHistory{recallIndex: -1}
+}
+
+func (h *composerHistory) record(input []rune, pos int) {
+	if strings.TrimSpace(string(input)) == "" {
+		return
+	}
+	snapshot := composerSnapshot{
+		input: append([]rune(nil), input...),
+		pos:   normalizeCursorPos(input, pos),
+	}
+	if len(h.entries) > 0 && snapshotsEqual(h.entries[len(h.entries)-1], snapshot) {
+		h.resetRecall()
+		return
+	}
+	h.entries = append(h.entries, snapshot)
+	if len(h.entries) > maxComposerHistoryEntries {
+		h.entries = append([]composerSnapshot(nil), h.entries[len(h.entries)-maxComposerHistoryEntries:]...)
+	}
+	h.resetRecall()
+}
+
+func (h *composerHistory) previous(current []rune, pos int) (composerSnapshot, bool) {
+	if len(h.entries) == 0 {
+		return composerSnapshot{}, false
+	}
+	if h.stash == nil {
+		snapshot := composerSnapshot{
+			input: append([]rune(nil), current...),
+			pos:   normalizeCursorPos(current, pos),
+		}
+		h.stash = &snapshot
+		h.recallIndex = len(h.entries)
+	}
+	if h.recallIndex > 0 {
+		h.recallIndex--
+	}
+	return cloneSnapshot(h.entries[h.recallIndex]), true
+}
+
+func (h *composerHistory) next() (composerSnapshot, bool) {
+	if h.stash == nil {
+		return composerSnapshot{}, false
+	}
+	if h.recallIndex >= 0 && h.recallIndex < len(h.entries)-1 {
+		h.recallIndex++
+		return cloneSnapshot(h.entries[h.recallIndex]), true
+	}
+	snapshot := cloneSnapshot(*h.stash)
+	h.resetRecall()
+	return snapshot, true
+}
+
+func (h *composerHistory) resetRecall() {
+	h.recallIndex = -1
+	h.stash = nil
+}
+
+func cloneSnapshot(snapshot composerSnapshot) composerSnapshot {
+	return composerSnapshot{
+		input: append([]rune(nil), snapshot.input...),
+		pos:   snapshot.pos,
+	}
+}
+
+func snapshotsEqual(a, b composerSnapshot) bool {
+	if a.pos != b.pos || len(a.input) != len(b.input) {
+		return false
+	}
+	for i := range a.input {
+		if a.input[i] != b.input[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/wuphf/channel_history_test.go
+++ b/cmd/wuphf/channel_history_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+func TestComposerHistoryRestoresStashedDraft(t *testing.T) {
+	h := newComposerHistory()
+	h.record([]rune("first"), len([]rune("first")))
+	h.record([]rune("second"), len([]rune("second")))
+
+	snapshot, ok := h.previous([]rune("working draft"), len([]rune("working draft")))
+	if !ok || string(snapshot.input) != "second" || snapshot.pos != len([]rune("second")) {
+		t.Fatalf("expected second entry, got %q %d %v", string(snapshot.input), snapshot.pos, ok)
+	}
+
+	snapshot, ok = h.next()
+	if !ok || string(snapshot.input) != "working draft" || snapshot.pos != len([]rune("working draft")) {
+		t.Fatalf("expected restored draft, got %q %d %v", string(snapshot.input), snapshot.pos, ok)
+	}
+}
+
+func TestComposerHistoryDedupesAdjacentEntries(t *testing.T) {
+	h := newComposerHistory()
+	h.record([]rune("same"), 4)
+	h.record([]rune("same"), 4)
+	if len(h.entries) != 1 {
+		t.Fatalf("expected one entry, got %d", len(h.entries))
+	}
+}

--- a/cmd/wuphf/channel_insert_search.go
+++ b/cmd/wuphf/channel_insert_search.go
@@ -219,7 +219,10 @@ func (m *channelModel) applySearchSelection(value, label string) tea.Cmd {
 			m.notice = "Request not found: " + reqID
 			return nil
 		}
-		_, cmd := m.focusRequest(req, "Focused request "+req.ID)
+		next, cmd := m.focusRequest(req, "Focused request "+req.ID)
+		if updated, ok := next.(channelModel); ok {
+			*m = updated
+		}
 		return cmd
 	case strings.HasPrefix(value, "thread:"):
 		rootID := strings.TrimSpace(strings.TrimPrefix(value, "thread:"))

--- a/cmd/wuphf/channel_insert_search.go
+++ b/cmd/wuphf/channel_insert_search.go
@@ -1,0 +1,282 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/nex-crm/wuphf/internal/team"
+	"github.com/nex-crm/wuphf/internal/tui"
+)
+
+func (m channelModel) buildInsertPickerOptions() []tui.PickerOption {
+	options := []tui.PickerOption{}
+
+	for _, ch := range m.channels {
+		if strings.TrimSpace(ch.Slug) == "" {
+			continue
+		}
+		options = append(options, tui.PickerOption{
+			Label:       "#" + ch.Slug,
+			Value:       "#" + ch.Slug,
+			Description: "Insert channel reference",
+		})
+	}
+
+	for _, member := range mergeOfficeMembers(m.officeMembers, m.members, m.currentChannelInfo()) {
+		if member.Slug == "you" || strings.TrimSpace(member.Slug) == "" {
+			continue
+		}
+		options = append(options, tui.PickerOption{
+			Label:       "@" + member.Slug,
+			Value:       "@" + member.Slug + " ",
+			Description: "Insert teammate mention",
+		})
+	}
+
+	for _, task := range m.tasks {
+		options = append(options, tui.PickerOption{
+			Label:       "Task " + task.ID + " · " + truncateText(task.Title, 48),
+			Value:       fmt.Sprintf("[task %s] %s", task.ID, task.Title),
+			Description: "Insert task reference",
+		})
+	}
+
+	for _, req := range m.requests {
+		options = append(options, tui.PickerOption{
+			Label:       "Request " + req.ID + " · " + truncateText(req.TitleOrQuestion(), 48),
+			Value:       fmt.Sprintf("[request %s] %s", req.ID, req.TitleOrQuestion()),
+			Description: "Insert request reference",
+		})
+	}
+
+	for _, msg := range m.recentRootMessages(16) {
+		options = append(options, tui.PickerOption{
+			Label:       "Message " + msg.ID + " · @" + msg.From,
+			Value:       fmt.Sprintf("[msg %s] @%s: %s", msg.ID, msg.From, truncateText(msg.Content, 96)),
+			Description: truncateText(msg.Content, 56),
+		})
+	}
+
+	return options
+}
+
+func (m channelModel) buildSearchPickerOptions() []tui.PickerOption {
+	options := []tui.PickerOption{}
+
+	if !m.isOneOnOne() {
+		for _, ch := range m.channels {
+			if strings.TrimSpace(ch.Slug) == "" {
+				continue
+			}
+			options = append(options, tui.PickerOption{
+				Label:       "#" + ch.Slug,
+				Value:       "channel:" + ch.Slug,
+				Description: fallbackChannelDescription(ch),
+			})
+		}
+	}
+
+	for _, member := range mergeOfficeMembers(m.officeMembers, m.members, m.currentChannelInfo()) {
+		if member.Slug == "you" || strings.TrimSpace(member.Slug) == "" {
+			continue
+		}
+		options = append(options, tui.PickerOption{
+			Label:       "1:1 with " + member.Name,
+			Value:       "dm:" + member.Slug,
+			Description: "Switch to direct session",
+		})
+	}
+
+	for _, task := range m.tasks {
+		options = append(options, tui.PickerOption{
+			Label:       "Task " + task.ID + " · " + truncateText(task.Title, 52),
+			Value:       "task:" + task.ID,
+			Description: strings.TrimSpace(task.Status + " · @" + fallbackString(task.Owner, "unowned")),
+		})
+	}
+
+	for _, req := range m.requests {
+		options = append(options, tui.PickerOption{
+			Label:       "Request " + req.ID + " · " + truncateText(req.TitleOrQuestion(), 52),
+			Value:       "request:" + req.ID,
+			Description: strings.TrimSpace(req.Kind + " · @" + req.From),
+		})
+	}
+
+	for _, msg := range m.recentRootMessages(20) {
+		valuePrefix := "message:"
+		if hasThreadReplies(m.messages, msg.ID) || strings.TrimSpace(msg.ReplyTo) != "" {
+			valuePrefix = "thread:"
+		}
+		options = append(options, tui.PickerOption{
+			Label:       "Message " + msg.ID + " · @" + msg.From,
+			Value:       valuePrefix + threadRootMessageID(m.messages, msg.ID),
+			Description: truncateText(msg.Content, 64),
+		})
+	}
+
+	return options
+}
+
+func (m channelModel) buildRecoveryPromptPickerOptions() []tui.PickerOption {
+	options := []tui.PickerOption{}
+	for _, msg := range m.recentRootMessages(16) {
+		summary := fmt.Sprintf("Summarize everything since %s from @%s, focusing on decisions, blocked work, owner changes, and the next concrete actions. Message context: %s", msg.ID, msg.From, truncateText(msg.Content, 120))
+		options = append(options, tui.PickerOption{
+			Label:       "Since " + msg.ID + " · @" + msg.From,
+			Value:       summary,
+			Description: truncateText(msg.Content, 64),
+		})
+	}
+	for _, req := range m.requests {
+		options = append(options, tui.PickerOption{
+			Label:       "Pending request " + req.ID,
+			Value:       fmt.Sprintf("Summarize the current state around request %s (%s), including arguments so far, blocked work, and the most important decision criteria.", req.ID, req.TitleOrQuestion()),
+			Description: truncateText(req.TitleOrQuestion(), 64),
+		})
+	}
+	for _, task := range m.tasks {
+		if strings.TrimSpace(task.Status) == "done" {
+			continue
+		}
+		options = append(options, tui.PickerOption{
+			Label:       "Task " + task.ID + " · " + truncateText(task.Title, 48),
+			Value:       fmt.Sprintf("Restore context for task %s (%s). Summarize the current status, work already done, blockers, review state, and the next best move.", task.ID, task.Title),
+			Description: truncateText(task.Status, 32),
+		})
+	}
+	return options
+}
+
+func (m *channelModel) insertIntoActiveComposer(text string) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return
+	}
+	insert := []rune(text)
+	if m.focus == focusThread && m.threadPanelOpen {
+		m.threadInput, m.threadInputPos = insertComposerRunes(m.threadInput, m.threadInputPos, insert)
+		m.threadInputHistory.resetRecall()
+		return
+	}
+	m.focus = focusMain
+	m.input, m.inputPos = insertComposerRunes(m.input, m.inputPos, insert)
+	m.inputHistory.resetRecall()
+}
+
+func (m *channelModel) applySearchSelection(value, label string) tea.Cmd {
+	switch {
+	case strings.HasPrefix(value, "channel:"):
+		channel := normalizeWorkspaceChannel(strings.TrimPrefix(value, "channel:"))
+		if channel == "" {
+			return nil
+		}
+		m.activeChannel = channel
+		m.activeApp = officeAppMessages
+		m.lastID = ""
+		m.messages = nil
+		m.members = nil
+		m.requests = nil
+		m.tasks = nil
+		m.replyToID = ""
+		m.threadPanelOpen = false
+		m.threadPanelID = ""
+		m.scroll = 0
+		m.clearUnreadState()
+		m.syncSidebarCursorToActive()
+		m.notice = "Jumped to #" + channel
+		return tea.Batch(pollBroker("", m.activeChannel), pollMembers(m.activeChannel), pollRequests(m.activeChannel), pollTasks(m.activeChannel))
+	case strings.HasPrefix(value, "dm:"):
+		agent := strings.TrimSpace(strings.TrimPrefix(value, "dm:"))
+		if agent == "" {
+			agent = team.DefaultOneOnOneAgent
+		}
+		m.confirm = confirmationForSessionSwitch(team.SessionModeOneOnOne, agent)
+		m.notice = "Confirm the direct session switch."
+		return nil
+	case strings.HasPrefix(value, "task:"):
+		taskID := strings.TrimSpace(strings.TrimPrefix(value, "task:"))
+		task, ok := m.findTaskByID(taskID)
+		if !ok {
+			m.notice = "Task not found: " + taskID
+			return nil
+		}
+		m.activeApp = officeAppTasks
+		m.syncSidebarCursorToActive()
+		if strings.TrimSpace(task.ThreadID) != "" {
+			m.threadPanelOpen = true
+			m.threadPanelID = task.ThreadID
+			m.replyToID = task.ThreadID
+		}
+		m.notice = "Focused task " + task.ID
+		return pollTasks(m.activeChannel)
+	case strings.HasPrefix(value, "request:"):
+		reqID := strings.TrimSpace(strings.TrimPrefix(value, "request:"))
+		req, ok := m.findRequestByID(reqID)
+		if !ok {
+			m.notice = "Request not found: " + reqID
+			return nil
+		}
+		_, cmd := m.focusRequest(req, "Focused request "+req.ID)
+		return cmd
+	case strings.HasPrefix(value, "thread:"):
+		rootID := strings.TrimSpace(strings.TrimPrefix(value, "thread:"))
+		if rootID == "" {
+			return nil
+		}
+		m.activeApp = officeAppMessages
+		m.threadPanelOpen = true
+		m.threadPanelID = rootID
+		m.replyToID = rootID
+		m.focus = focusThread
+		m.notice = "Opened thread " + rootID
+		return pollBroker("", m.activeChannel)
+	case strings.HasPrefix(value, "message:"):
+		msgID := strings.TrimSpace(strings.TrimPrefix(value, "message:"))
+		msg, ok := findMessageByID(m.messages, msgID)
+		if !ok {
+			m.notice = "Message not found: " + msgID
+			return nil
+		}
+		m.activeApp = officeAppMessages
+		m.replyToID = msg.ID
+		m.focus = focusMain
+		m.notice = "Replying from message " + msg.ID
+		return nil
+	default:
+		m.notice = "Unknown search target: " + label
+		return nil
+	}
+}
+
+func (m channelModel) recentRootMessages(limit int) []brokerMessage {
+	if limit <= 0 {
+		limit = 16
+	}
+	out := make([]brokerMessage, 0, limit)
+	for i := len(m.messages) - 1; i >= 0 && len(out) < limit; i-- {
+		msg := m.messages[i]
+		if strings.TrimSpace(msg.ReplyTo) != "" {
+			continue
+		}
+		out = append(out, msg)
+	}
+	return out
+}
+
+func threadRootMessageID(messages []brokerMessage, messageID string) string {
+	current, ok := findMessageByID(messages, messageID)
+	if !ok {
+		return strings.TrimSpace(messageID)
+	}
+	for strings.TrimSpace(current.ReplyTo) != "" {
+		parent, ok := findMessageByID(messages, current.ReplyTo)
+		if !ok {
+			return current.ReplyTo
+		}
+		current = parent
+	}
+	return current.ID
+}

--- a/cmd/wuphf/channel_insert_search.go
+++ b/cmd/wuphf/channel_insert_search.go
@@ -123,17 +123,16 @@ func (m channelModel) buildSearchPickerOptions() []tui.PickerOption {
 func (m channelModel) buildRecoveryPromptPickerOptions() []tui.PickerOption {
 	options := []tui.PickerOption{}
 	for _, msg := range m.recentRootMessages(16) {
-		summary := fmt.Sprintf("Summarize everything since %s from @%s, focusing on decisions, blocked work, owner changes, and the next concrete actions. Message context: %s", msg.ID, msg.From, truncateText(msg.Content, 120))
 		options = append(options, tui.PickerOption{
 			Label:       "Since " + msg.ID + " · @" + msg.From,
-			Value:       summary,
+			Value:       buildRecoveryPromptForMessage(msg),
 			Description: truncateText(msg.Content, 64),
 		})
 	}
 	for _, req := range m.requests {
 		options = append(options, tui.PickerOption{
 			Label:       "Pending request " + req.ID,
-			Value:       fmt.Sprintf("Summarize the current state around request %s (%s), including arguments so far, blocked work, and the most important decision criteria.", req.ID, req.TitleOrQuestion()),
+			Value:       buildRecoveryPromptForRequest(req),
 			Description: truncateText(req.TitleOrQuestion(), 64),
 		})
 	}
@@ -143,7 +142,7 @@ func (m channelModel) buildRecoveryPromptPickerOptions() []tui.PickerOption {
 		}
 		options = append(options, tui.PickerOption{
 			Label:       "Task " + task.ID + " · " + truncateText(task.Title, 48),
-			Value:       fmt.Sprintf("Restore context for task %s (%s). Summarize the current status, work already done, blockers, review state, and the next best move.", task.ID, task.Title),
+			Value:       buildRecoveryPromptForTask(task),
 			Description: truncateText(task.Status, 32),
 		})
 	}

--- a/cmd/wuphf/channel_insert_search_test.go
+++ b/cmd/wuphf/channel_insert_search_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/nex-crm/wuphf/internal/tui"
+)
+
+func TestInsertCommandOpensReferencePicker(t *testing.T) {
+	m := newChannelModel(false)
+	m.channels = []channelInfo{{Slug: "launch", Description: "Launch work"}}
+	m.members = []channelMember{{Slug: "pm", Name: "Product Manager"}}
+
+	next, _ := m.runCommand("/insert", "")
+	got := next.(channelModel)
+
+	if got.pickerMode != channelPickerInsert {
+		t.Fatalf("expected insert picker mode, got %q", got.pickerMode)
+	}
+	if !got.picker.IsActive() {
+		t.Fatal("expected insert picker to be active")
+	}
+}
+
+func TestPickerInsertSelectionUpdatesComposer(t *testing.T) {
+	m := newChannelModel(false)
+	m.pickerMode = channelPickerInsert
+	m.picker = tui.NewPicker("Insert", []tui.PickerOption{{Label: "@pm", Value: "@pm "}})
+	m.picker.SetActive(true)
+
+	next, _ := m.Update(tui.PickerSelectMsg{Label: "@pm", Value: "@pm "})
+	got := next.(channelModel)
+
+	if string(got.input) != "@pm" && string(got.input) != "@pm " {
+		t.Fatalf("expected inserted mention in composer, got %q", string(got.input))
+	}
+	if !strings.Contains(got.notice, "Inserted reference") {
+		t.Fatalf("expected insert notice, got %q", got.notice)
+	}
+}
+
+func TestSearchCommandOpensWorkspaceSearchPicker(t *testing.T) {
+	m := newChannelModel(false)
+	m.channels = []channelInfo{{Slug: "launch", Description: "Launch work"}}
+
+	next, _ := m.runCommand("/search", "")
+	got := next.(channelModel)
+
+	if got.pickerMode != channelPickerSearch {
+		t.Fatalf("expected search picker mode, got %q", got.pickerMode)
+	}
+	if !got.picker.IsActive() {
+		t.Fatal("expected search picker to be active")
+	}
+}
+
+func TestSearchSelectionOpensThread(t *testing.T) {
+	m := newChannelModel(false)
+	m.messages = []brokerMessage{
+		{ID: "msg-1", From: "ceo", Content: "Root thread"},
+		{ID: "msg-2", From: "pm", Content: "Reply", ReplyTo: "msg-1"},
+	}
+
+	cmd := m.applySearchSelection("thread:msg-1", "Message msg-1")
+	if cmd == nil {
+		t.Fatal("expected poll command for thread selection")
+	}
+	if !m.threadPanelOpen || m.threadPanelID != "msg-1" || m.replyToID != "msg-1" {
+		t.Fatalf("expected thread focus on msg-1, got threadOpen=%v threadID=%q replyTo=%q", m.threadPanelOpen, m.threadPanelID, m.replyToID)
+	}
+}
+
+func TestRewindCommandOpensRecoveryPromptPicker(t *testing.T) {
+	m := newChannelModel(false)
+	m.messages = []brokerMessage{{ID: "msg-1", From: "ceo", Content: "Need a summary."}}
+
+	next, _ := m.runCommand("/rewind", "")
+	got := next.(channelModel)
+
+	if got.pickerMode != channelPickerRewind {
+		t.Fatalf("expected rewind picker mode, got %q", got.pickerMode)
+	}
+	if !got.picker.IsActive() {
+		t.Fatal("expected rewind picker to be active")
+	}
+}
+
+func TestRewindSelectionInsertsRecoveryPrompt(t *testing.T) {
+	m := newChannelModel(false)
+	m.pickerMode = channelPickerRewind
+	m.picker = tui.NewPicker("Rewind", []tui.PickerOption{{Label: "Since msg-1", Value: "Summarize everything since msg-1"}})
+	m.picker.SetActive(true)
+
+	next, _ := m.Update(tui.PickerSelectMsg{Label: "Since msg-1", Value: "Summarize everything since msg-1"})
+	got := next.(channelModel)
+
+	if !strings.Contains(string(got.input), "Summarize everything since msg-1") {
+		t.Fatalf("expected recovery prompt in composer, got %q", string(got.input))
+	}
+}
+
+func TestInsertAndSearchCommandsAreAvailableThroughEnter(t *testing.T) {
+	m := newChannelModel(false)
+	m.channels = []channelInfo{{Slug: "launch", Description: "Launch work"}}
+	m.input = []rune("/search")
+	m.inputPos = len(m.input)
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := next.(channelModel)
+	if got.pickerMode != channelPickerSearch {
+		t.Fatalf("expected enter to open search picker, got %q", got.pickerMode)
+	}
+}

--- a/cmd/wuphf/channel_insert_search_test.go
+++ b/cmd/wuphf/channel_insert_search_test.go
@@ -90,6 +90,7 @@ func TestRewindCommandOpensRecoveryPromptPicker(t *testing.T) {
 
 func TestRewindSelectionInsertsRecoveryPrompt(t *testing.T) {
 	m := newChannelModel(false)
+	m.activeApp = officeAppRecovery
 	m.pickerMode = channelPickerRewind
 	m.picker = tui.NewPicker("Rewind", []tui.PickerOption{{Label: "Since msg-1", Value: "Summarize everything since msg-1"}})
 	m.picker.SetActive(true)
@@ -99,6 +100,12 @@ func TestRewindSelectionInsertsRecoveryPrompt(t *testing.T) {
 
 	if !strings.Contains(string(got.input), "Summarize everything since msg-1") {
 		t.Fatalf("expected recovery prompt in composer, got %q", string(got.input))
+	}
+	if got.activeApp != officeAppMessages {
+		t.Fatalf("expected rewind selection to return to messages, got %q", got.activeApp)
+	}
+	if got.focus != focusMain {
+		t.Fatalf("expected focus to return to the main composer, got %v", got.focus)
 	}
 }
 

--- a/cmd/wuphf/channel_interview.go
+++ b/cmd/wuphf/channel_interview.go
@@ -1,0 +1,81 @@
+package main
+
+import "strings"
+
+type channelInterviewPhase string
+
+const (
+	interviewPhaseChoose channelInterviewPhase = "choose"
+	interviewPhaseDraft  channelInterviewPhase = "draft"
+	interviewPhaseReview channelInterviewPhase = "review"
+)
+
+func interviewOptionRequiresText(option *channelInterviewOption) bool {
+	if option == nil {
+		return false
+	}
+	if option.RequiresText {
+		return true
+	}
+	id := strings.TrimSpace(strings.ToLower(option.ID))
+	return strings.Contains(id, "note") || strings.Contains(id, "steer")
+}
+
+func interviewOptionTextHint(option *channelInterviewOption) string {
+	if option == nil {
+		return ""
+	}
+	if strings.TrimSpace(option.TextHint) != "" {
+		return option.TextHint
+	}
+	if interviewOptionRequiresText(option) {
+		return "Type your note, rationale, or steering before submitting this choice."
+	}
+	return ""
+}
+
+func selectedInterviewOption(options []channelInterviewOption, index int) *channelInterviewOption {
+	if index < 0 || index >= len(options) {
+		return nil
+	}
+	option := options[index]
+	return &option
+}
+
+func (m channelModel) currentInterviewPhase() channelInterviewPhase {
+	if m.pending == nil {
+		return ""
+	}
+	if m.confirm != nil && m.confirm.Action == confirmActionSubmitRequest {
+		return interviewPhaseReview
+	}
+	if strings.TrimSpace(string(m.input)) != "" {
+		return interviewPhaseDraft
+	}
+	if interviewOptionRequiresText(m.selectedInterviewOption()) {
+		return interviewPhaseDraft
+	}
+	return interviewPhaseChoose
+}
+
+func (m channelModel) interviewPhaseTitle() string {
+	switch m.currentInterviewPhase() {
+	case interviewPhaseReview:
+		return "Step 3 of 3 · review"
+	case interviewPhaseDraft:
+		return "Step 2 of 3 · draft"
+	default:
+		return "Step 1 of 3 · choose"
+	}
+}
+
+func (m channelModel) interviewStatusLine() string {
+	switch m.currentInterviewPhase() {
+	case interviewPhaseReview:
+		return " Request review │ Enter submit │ Esc revise"
+	case interviewPhaseDraft:
+		return " Request draft │ type answer │ Enter review"
+	default:
+		return " Request choose │ ↑/↓ select │ Enter continue"
+	}
+}

--- a/cmd/wuphf/channel_needs_you.go
+++ b/cmd/wuphf/channel_needs_you.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func buildNeedsYouLines(requests []channelInterview, contentWidth int) []renderedLine {
+	req, ok := selectNeedsYouRequest(requests)
+	if !ok {
+		return nil
+	}
+
+	statusLabel := "needs your decision"
+	if !(req.Blocking || req.Required) {
+		statusLabel = "waiting on you"
+	}
+	header := accentPill(statusLabel, "#B45309") + " " +
+		lipgloss.NewStyle().Bold(true).Render(req.TitleOrQuestion())
+	body := strings.TrimSpace(req.Context)
+	if body == "" {
+		body = strings.TrimSpace(req.Question)
+	}
+	extra := []string{"Asked by @" + fallbackString(req.From, "unknown")}
+	if req.Blocking || req.Required {
+		extra = append(extra, "The team is paused until you answer.")
+	}
+	if strings.TrimSpace(req.RecommendedID) != "" {
+		extra = append(extra, "Recommended: "+req.RecommendedID)
+	}
+	if due := strings.TrimSpace(req.DueAt); due != "" {
+		extra = append(extra, "Due "+prettyRelativeTime(due))
+	}
+	extra = append(extra, "/request answer "+req.ID+" · /requests · /recover")
+
+	lines := []renderedLine{{Text: renderDateSeparator(contentWidth, "Needs attention")}}
+	for _, line := range renderRuntimeEventCard(contentWidth, header, body, "#D97706", extra) {
+		lines = append(lines, renderedLine{Text: "  " + line, RequestID: req.ID})
+	}
+	return lines
+}
+
+func selectNeedsYouRequest(requests []channelInterview) (channelInterview, bool) {
+	for _, req := range requests {
+		if !isOpenInterviewStatus(req.Status) {
+			continue
+		}
+		if req.Blocking || req.Required {
+			return req, true
+		}
+	}
+	for _, req := range requests {
+		if isOpenInterviewStatus(req.Status) {
+			return req, true
+		}
+	}
+	return channelInterview{}, false
+}
+
+func isOpenInterviewStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "pending", "open", "draft":
+		return true
+	default:
+		return false
+	}
+}

--- a/cmd/wuphf/channel_needs_you_test.go
+++ b/cmd/wuphf/channel_needs_you_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildNeedsYouLinesPrefersBlockingRequests(t *testing.T) {
+	requests := []channelInterview{
+		{ID: "req-1", Kind: "approval", Status: "pending", Title: "Optional note", Question: "Optional note?", From: "pm"},
+		{ID: "req-2", Kind: "approval", Status: "pending", Title: "Ship launch copy", Question: "Ship launch copy?", Context: "Need approval before publishing.", From: "ceo", Blocking: true, RecommendedID: "approve"},
+	}
+
+	lines := buildNeedsYouLines(requests, 96)
+	plain := stripANSI(joinRenderedLines(lines))
+
+	if !strings.Contains(plain, "Needs attention") {
+		t.Fatalf("expected needs-attention separator, got %q", plain)
+	}
+	if !strings.Contains(plain, "Ship launch copy") {
+		t.Fatalf("expected blocking request title, got %q", plain)
+	}
+	if !strings.Contains(plain, "The team is paused until you answer.") {
+		t.Fatalf("expected blocking request guidance, got %q", plain)
+	}
+}
+
+func TestCurrentMainViewportLinesPrependsNeedsYouStrip(t *testing.T) {
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 40
+	m.activeApp = officeAppMessages
+	m.requests = []channelInterview{{
+		ID:       "req-1",
+		Kind:     "approval",
+		Status:   "pending",
+		Title:    "Approve launch copy",
+		Question: "Approve launch copy?",
+		Context:  "Need final sign-off before shipping.",
+		From:     "ceo",
+		Blocking: true,
+	}}
+	m.messages = []brokerMessage{{ID: "msg-1", From: "pm", Content: "Main feed update."}}
+
+	lines := m.currentMainViewportLines(96, 20)
+	plain := stripANSI(joinRenderedLines(lines))
+
+	if !strings.Contains(plain, "Approve launch copy") {
+		t.Fatalf("expected blocking request strip in main viewport, got %q", plain)
+	}
+	if !strings.Contains(plain, "Main feed update.") {
+		t.Fatalf("expected transcript to remain visible below needs-you strip, got %q", plain)
+	}
+}

--- a/cmd/wuphf/channel_recovery.go
+++ b/cmd/wuphf/channel_recovery.go
@@ -196,6 +196,9 @@ func buildRecoveryLines(snapshot team.RuntimeSnapshot, contentWidth int, awaySum
 	if actionLines := buildRecoveryActionLines(contentWidth, tasks, requests, messages); len(actionLines) > 0 {
 		lines = append(lines, actionLines...)
 	}
+	if surgeryLines := buildRecoverySurgeryLines(contentWidth, tasks, requests, messages); len(surgeryLines) > 0 {
+		lines = append(lines, surgeryLines...)
+	}
 
 	return lines
 }
@@ -257,6 +260,102 @@ func buildRecoveryActionLines(contentWidth int, tasks []channelTask, requests []
 	}
 
 	return lines
+}
+
+func buildRecoverySurgeryLines(contentWidth int, tasks []channelTask, requests []channelInterview, messages []brokerMessage) []renderedLine {
+	lines := []renderedLine{}
+	options := buildRecoverySurgeryOptions(tasks, requests, messages)
+	if len(options) == 0 {
+		return lines
+	}
+
+	lines = append(lines, renderedLine{Text: ""})
+	lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Transcript surgery")})
+	for _, option := range options {
+		header := subtlePill(option.Tag, "#E0F2FE", "#075985") + " " + lipgloss.NewStyle().Bold(true).Render(option.Title)
+		extra := append([]string(nil), option.Extra...)
+		extra = append(extra, "Click to draft this recap in the composer")
+		card := renderRecoveryActionCard(contentWidth, header, option.Body, option.Accent, extra)
+		lines = append(lines, prefixedCardLines(renderedCardLinesWithPrompt(card, "", "", "", "", option.Prompt), "  ")...)
+	}
+
+	return lines
+}
+
+type recoverySurgeryOption struct {
+	Tag    string
+	Title  string
+	Body   string
+	Accent string
+	Extra  []string
+	Prompt string
+}
+
+func buildRecoverySurgeryOptions(tasks []channelTask, requests []channelInterview, messages []brokerMessage) []recoverySurgeryOption {
+	options := make([]recoverySurgeryOption, 0, 6)
+
+	for _, req := range requests {
+		if !isOpenInterviewStatus(req.Status) {
+			continue
+		}
+		options = append(options, recoverySurgeryOption{
+			Tag:    "decision brief",
+			Title:  "Draft the decision context for " + req.ID,
+			Body:   fallbackString(strings.TrimSpace(req.Context), req.TitleOrQuestion()),
+			Accent: "#B45309",
+			Extra:  []string{"Request " + req.ID, "Asked by @" + fallbackString(req.From, "unknown")},
+			Prompt: buildRecoveryPromptForRequest(req),
+		})
+		if len(options) >= 2 {
+			break
+		}
+	}
+
+	taskCount := 0
+	for _, task := range recoveryActiveTasks(tasks, 3) {
+		options = append(options, recoverySurgeryOption{
+			Tag:    "task handoff",
+			Title:  "Restore context for " + task.ID,
+			Body:   fallbackString(strings.TrimSpace(task.Details), task.Title),
+			Accent: "#2563EB",
+			Extra:  []string{"Owner @" + fallbackString(task.Owner, "unowned"), "Status " + fallbackString(strings.TrimSpace(task.Status), "open")},
+			Prompt: buildRecoveryPromptForTask(task),
+		})
+		taskCount++
+		if taskCount >= 2 {
+			break
+		}
+	}
+
+	threadCount := 0
+	for _, msg := range recoveryRecentThreads(messages, 3) {
+		options = append(options, recoverySurgeryOption{
+			Tag:    "rewind",
+			Title:  "Summarize everything since " + msg.ID,
+			Body:   truncateText(strings.TrimSpace(msg.Content), 160),
+			Accent: "#475569",
+			Extra:  []string{"Thread " + msg.ID, "Started by @" + fallbackString(msg.From, "unknown")},
+			Prompt: buildRecoveryPromptForMessage(msg),
+		})
+		threadCount++
+		if threadCount >= 2 {
+			break
+		}
+	}
+
+	return options
+}
+
+func buildRecoveryPromptForMessage(msg brokerMessage) string {
+	return fmt.Sprintf("Summarize everything since %s from @%s, focusing on decisions, blocked work, owner changes, risks, and the next concrete actions. Include what a human needs to know before replying. Message context: %s", msg.ID, fallbackString(msg.From, "unknown"), truncateText(strings.TrimSpace(msg.Content), 120))
+}
+
+func buildRecoveryPromptForRequest(req channelInterview) string {
+	return fmt.Sprintf("Draft a decision brief for request %s (%s). Summarize the arguments so far, what is blocked, the recommendation, open risks, and the smallest next action after the human answers.", req.ID, req.TitleOrQuestion())
+}
+
+func buildRecoveryPromptForTask(task channelTask) string {
+	return fmt.Sprintf("Restore context for task %s (%s). Draft a clean handoff note with current status, work already done, blockers, linked thread context, review state, and the next best move.", task.ID, task.Title)
 }
 
 func renderRecoveryActionCard(contentWidth int, header, body, accent string, extra []string) string {

--- a/cmd/wuphf/channel_recovery.go
+++ b/cmd/wuphf/channel_recovery.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+func (m channelModel) currentRuntimeSnapshot() team.RuntimeSnapshot {
+	return team.BuildRuntimeSnapshot(team.RuntimeSnapshotInput{
+		Channel:     m.activeChannel,
+		SessionMode: m.sessionMode,
+		DirectAgent: m.oneOnOneAgentSlug(),
+		Tasks:       runtimeTasksFromChannel(m.tasks),
+		Requests:    runtimeRequestsFromChannel(m.requests),
+		Recent:      runtimeMessagesFromChannel(m.messages, 6),
+	})
+}
+
+func runtimeTasksFromChannel(tasks []channelTask) []team.RuntimeTask {
+	out := make([]team.RuntimeTask, 0, len(tasks))
+	for _, task := range tasks {
+		out = append(out, team.RuntimeTask{
+			ID:             task.ID,
+			Title:          strings.TrimSpace(task.Title),
+			Owner:          strings.TrimSpace(task.Owner),
+			Status:         strings.TrimSpace(task.Status),
+			PipelineStage:  strings.TrimSpace(task.PipelineStage),
+			ReviewState:    strings.TrimSpace(task.ReviewState),
+			ExecutionMode:  strings.TrimSpace(task.ExecutionMode),
+			WorktreePath:   strings.TrimSpace(task.WorktreePath),
+			WorktreeBranch: strings.TrimSpace(task.WorktreeBranch),
+			Blocked:        strings.EqualFold(strings.TrimSpace(task.Status), "blocked"),
+		})
+	}
+	return out
+}
+
+func runtimeRequestsFromChannel(requests []channelInterview) []team.RuntimeRequest {
+	out := make([]team.RuntimeRequest, 0, len(requests))
+	for _, req := range requests {
+		out = append(out, team.RuntimeRequest{
+			ID:       req.ID,
+			Kind:     strings.TrimSpace(req.Kind),
+			Title:    strings.TrimSpace(req.Title),
+			Question: strings.TrimSpace(req.Question),
+			From:     strings.TrimSpace(req.From),
+			Blocking: req.Blocking,
+			Required: req.Required,
+			Status:   strings.TrimSpace(req.Status),
+			Channel:  strings.TrimSpace(req.Channel),
+			Secret:   req.Secret,
+		})
+	}
+	return out
+}
+
+func runtimeMessagesFromChannel(messages []brokerMessage, limit int) []team.RuntimeMessage {
+	if limit <= 0 {
+		limit = 6
+	}
+	out := make([]team.RuntimeMessage, 0, minInt(len(messages), limit))
+	for i := len(messages) - 1; i >= 0 && len(out) < limit; i-- {
+		msg := messages[i]
+		out = append(out, team.RuntimeMessage{
+			ID:        msg.ID,
+			From:      strings.TrimSpace(msg.From),
+			Title:     strings.TrimSpace(msg.Title),
+			Content:   strings.TrimSpace(msg.Content),
+			ReplyTo:   strings.TrimSpace(msg.ReplyTo),
+			Timestamp: strings.TrimSpace(msg.Timestamp),
+		})
+	}
+	return out
+}
+
+func summarizeAwayRecovery(unreadCount int, recovery team.SessionRecovery) string {
+	parts := make([]string, 0, 3)
+	if focus := trimRecoverySentence(recovery.Focus); focus != "" {
+		parts = append(parts, focus)
+	}
+	if len(recovery.NextSteps) > 0 {
+		if next := trimRecoverySentence(recovery.NextSteps[0]); next != "" {
+			parts = append(parts, "Next: "+next)
+		}
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("%d new since you looked. Open /recover for the full summary.", unreadCount)
+	}
+	summary := strings.Join(parts, " ")
+	if unreadCount > 0 {
+		summary = fmt.Sprintf("%d new since you looked. %s", unreadCount, summary)
+	}
+	return truncateText(summary, 120)
+}
+
+func (m channelModel) currentAwaySummary() string {
+	if m.unreadCount == 0 {
+		return ""
+	}
+	if text := strings.TrimSpace(m.awaySummary); text != "" {
+		return text
+	}
+	return summarizeAwayRecovery(m.unreadCount, m.currentRuntimeSnapshot().Recovery)
+}
+
+func trimRecoverySentence(text string) string {
+	text = strings.TrimSpace(text)
+	text = strings.TrimSuffix(text, ".")
+	return text
+}
+
+func renderAwayStrip(width, unreadCount int, summary string) string {
+	label := fmt.Sprintf("While away · %d new · /recover", unreadCount)
+	if strings.TrimSpace(summary) != "" {
+		label = fmt.Sprintf("While away · %s · /recover", strings.TrimSpace(summary))
+	}
+	label = truncateText(label, maxInt(24, width-6))
+	return "  " + lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#0F172A")).
+		Background(lipgloss.Color("#BFDBFE")).
+		Padding(0, 1).
+		Bold(true).
+		Render(label)
+}
+
+func buildRecoveryLines(snapshot team.RuntimeSnapshot, contentWidth int, awaySummary string, unreadCount int, brokerConnected bool) []renderedLine {
+	muted := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
+	lines := []renderedLine{{Text: renderDateSeparator(contentWidth, "Recovery")}}
+
+	if !brokerConnected && len(snapshot.Tasks) == 0 && len(snapshot.Requests) == 0 && len(snapshot.Recent) == 0 {
+		lines = append(lines,
+			renderedLine{Text: ""},
+			renderedLine{Text: muted.Render("  Offline preview. Launch WUPHF to hydrate the runtime state and recovery summary.")},
+			renderedLine{Text: muted.Render("  The recovery view will highlight focus, next steps, and recent changes once the office is live.")},
+		)
+		return lines
+	}
+
+	if unreadCount > 0 || strings.TrimSpace(awaySummary) != "" {
+		title := subtlePill("while away", "#F8FAFC", "#1D4ED8") + " " + lipgloss.NewStyle().Bold(true).Render("What changed while you were gone")
+		body := strings.TrimSpace(awaySummary)
+		if body == "" {
+			body = "Use this view to regain context before you reply."
+		}
+		extra := []string{}
+		if focus := strings.TrimSpace(snapshot.Recovery.Focus); focus != "" {
+			extra = append(extra, "Focus: "+focus)
+		}
+		if len(snapshot.Recovery.NextSteps) > 0 {
+			extra = append(extra, "Next: "+snapshot.Recovery.NextSteps[0])
+		}
+		for _, line := range renderRuntimeEventCard(contentWidth, title, body, "#2563EB", extra) {
+			lines = append(lines, renderedLine{Text: "  " + line})
+		}
+	}
+
+	stateBody := fmt.Sprintf("%d running tasks · %d open requests · %d isolated worktrees", countRunningRuntimeTasks(snapshot.Tasks), len(snapshot.Requests), countIsolatedRuntimeTasks(snapshot.Tasks))
+	stateExtra := []string{}
+	if snapshot.SessionMode == team.SessionModeOneOnOne && strings.TrimSpace(snapshot.DirectAgent) != "" {
+		stateExtra = append(stateExtra, "Direct session with @"+snapshot.DirectAgent)
+	} else if strings.TrimSpace(snapshot.Channel) != "" {
+		stateExtra = append(stateExtra, "Channel: #"+snapshot.Channel)
+	}
+	if focus := strings.TrimSpace(snapshot.Recovery.Focus); focus != "" {
+		stateExtra = append(stateExtra, "Current focus: "+focus)
+	}
+	for _, line := range renderRuntimeEventCard(contentWidth, subtlePill("runtime", "#E2E8F0", "#334155")+" "+lipgloss.NewStyle().Bold(true).Render("Current state"), stateBody, "#475569", stateExtra) {
+		lines = append(lines, renderedLine{Text: "  " + line})
+	}
+
+	if len(snapshot.Recovery.NextSteps) > 0 {
+		body := snapshot.Recovery.NextSteps[0]
+		extra := append([]string(nil), snapshot.Recovery.NextSteps[1:]...)
+		for _, line := range renderRuntimeEventCard(contentWidth, subtlePill("next", "#F8FAFC", "#92400E")+" "+lipgloss.NewStyle().Bold(true).Render("What to do next"), body, "#B45309", extra) {
+			lines = append(lines, renderedLine{Text: "  " + line})
+		}
+	}
+
+	if len(snapshot.Recovery.Highlights) > 0 {
+		body := snapshot.Recovery.Highlights[0]
+		extra := append([]string(nil), snapshot.Recovery.Highlights[1:]...)
+		for _, line := range renderRuntimeEventCard(contentWidth, subtlePill("recent", "#E5E7EB", "#334155")+" "+lipgloss.NewStyle().Bold(true).Render("Latest highlights"), body, "#334155", extra) {
+			lines = append(lines, renderedLine{Text: "  " + line})
+		}
+	}
+
+	return lines
+}
+
+func countRunningRuntimeTasks(tasks []team.RuntimeTask) int {
+	count := 0
+	for _, task := range tasks {
+		switch strings.ToLower(strings.TrimSpace(task.Status)) {
+		case "", "done", "completed", "canceled", "cancelled":
+			continue
+		default:
+			count++
+		}
+	}
+	return count
+}
+
+func countIsolatedRuntimeTasks(tasks []team.RuntimeTask) int {
+	count := 0
+	for _, task := range tasks {
+		if strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") ||
+			strings.TrimSpace(task.WorktreePath) != "" ||
+			strings.TrimSpace(task.WorktreeBranch) != "" {
+			count++
+		}
+	}
+	return count
+}

--- a/cmd/wuphf/channel_recovery.go
+++ b/cmd/wuphf/channel_recovery.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -18,6 +19,10 @@ func (m channelModel) currentRuntimeSnapshot() team.RuntimeSnapshot {
 		Requests:    runtimeRequestsFromChannel(m.requests),
 		Recent:      runtimeMessagesFromChannel(m.messages, 6),
 	})
+}
+
+func (m channelModel) buildRecoveryLines(contentWidth int) []renderedLine {
+	return buildRecoveryLines(m.currentRuntimeSnapshot(), contentWidth, m.awaySummary, m.unreadCount, m.brokerConnected, m.tasks, m.requests, m.messages)
 }
 
 func runtimeTasksFromChannel(tasks []channelTask) []team.RuntimeTask {
@@ -127,7 +132,7 @@ func renderAwayStrip(width, unreadCount int, summary string) string {
 		Render(label)
 }
 
-func buildRecoveryLines(snapshot team.RuntimeSnapshot, contentWidth int, awaySummary string, unreadCount int, brokerConnected bool) []renderedLine {
+func buildRecoveryLines(snapshot team.RuntimeSnapshot, contentWidth int, awaySummary string, unreadCount int, brokerConnected bool, tasks []channelTask, requests []channelInterview, messages []brokerMessage) []renderedLine {
 	muted := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
 	lines := []renderedLine{{Text: renderDateSeparator(contentWidth, "Recovery")}}
 
@@ -188,7 +193,151 @@ func buildRecoveryLines(snapshot team.RuntimeSnapshot, contentWidth int, awaySum
 		}
 	}
 
+	if actionLines := buildRecoveryActionLines(contentWidth, tasks, requests, messages); len(actionLines) > 0 {
+		lines = append(lines, actionLines...)
+	}
+
 	return lines
+}
+
+func buildRecoveryActionLines(contentWidth int, tasks []channelTask, requests []channelInterview, messages []brokerMessage) []renderedLine {
+	lines := []renderedLine{}
+
+	if req, ok := selectNeedsYouRequest(requests); ok {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Resume human decisions")})
+		header := accentPill("needs you", "#B45309") + " " + lipgloss.NewStyle().Bold(true).Render(req.TitleOrQuestion())
+		body := strings.TrimSpace(req.Context)
+		if body == "" {
+			body = strings.TrimSpace(req.Question)
+		}
+		extra := []string{"Asked by @" + fallbackString(req.From, "unknown")}
+		if strings.TrimSpace(req.RecommendedID) != "" {
+			extra = append(extra, "Recommended: "+req.RecommendedID)
+		}
+		extra = append(extra, "Open request")
+		lines = append(lines, prefixedCardLines(renderedCardLines(renderRecoveryActionCard(contentWidth, header, body, "#B45309", extra), "", req.ID, strings.TrimSpace(req.ReplyTo), ""), "  ")...)
+	}
+
+	if activeTasks := recoveryActiveTasks(tasks, 3); len(activeTasks) > 0 {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Resume active tasks")})
+		for _, task := range activeTasks {
+			header := taskStatusPill(task.Status) + " " + lipgloss.NewStyle().Bold(true).Render(task.Title)
+			body := strings.TrimSpace(task.Details)
+			if body == "" {
+				body = "Owner @" + fallbackString(task.Owner, "unowned")
+			}
+			extra := []string{"Owner @" + fallbackString(task.Owner, "unowned")}
+			if strings.TrimSpace(task.ThreadID) != "" {
+				extra = append(extra, "Thread "+task.ThreadID)
+			}
+			if strings.TrimSpace(task.WorktreePath) != "" {
+				extra = append(extra, "Worktree "+task.WorktreePath)
+			}
+			extra = append(extra, "Open task")
+			threadID := strings.TrimSpace(task.ThreadID)
+			lines = append(lines, prefixedCardLines(renderedCardLines(renderRecoveryActionCard(contentWidth, header, body, "#2563EB", extra), task.ID, "", threadID, ""), "  ")...)
+		}
+	}
+
+	if recent := recoveryRecentThreads(messages, 3); len(recent) > 0 {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Return to recent threads")})
+		for _, msg := range recent {
+			header := subtlePill("@"+fallbackString(msg.From, "unknown"), "#E2E8F0", "#334155") + " " + lipgloss.NewStyle().Bold(true).Render("Thread "+msg.ID)
+			body := truncateText(strings.TrimSpace(msg.Content), 160)
+			extra := []string{}
+			if when := strings.TrimSpace(msg.Timestamp); when != "" {
+				extra = append(extra, prettyRelativeTime(when))
+			}
+			extra = append(extra, "Open thread")
+			lines = append(lines, prefixedCardLines(renderedCardLines(renderRecoveryActionCard(contentWidth, header, body, "#475569", extra), "", "", msg.ID, ""), "  ")...)
+		}
+	}
+
+	return lines
+}
+
+func renderRecoveryActionCard(contentWidth int, header, body, accent string, extra []string) string {
+	cardWidth := maxInt(24, contentWidth-6)
+	parts := []string{header}
+	if strings.TrimSpace(body) != "" {
+		parts = append(parts, mutedText(body))
+	}
+	for _, line := range extra {
+		if strings.TrimSpace(line) != "" {
+			parts = append(parts, mutedText(line))
+		}
+	}
+	return lipgloss.NewStyle().
+		Width(cardWidth).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(accent)).
+		Background(lipgloss.Color("#16181E")).
+		Padding(0, 1).
+		Render(strings.Join(parts, "\n"))
+}
+
+func prefixedCardLines(lines []renderedLine, prefix string) []renderedLine {
+	out := make([]renderedLine, 0, len(lines))
+	for _, line := range lines {
+		line.Text = prefix + line.Text
+		out = append(out, line)
+	}
+	return out
+}
+
+func recoveryActiveTasks(tasks []channelTask, limit int) []channelTask {
+	filtered := make([]channelTask, 0, len(tasks))
+	for _, task := range tasks {
+		switch strings.ToLower(strings.TrimSpace(task.Status)) {
+		case "", "done", "completed", "canceled", "cancelled":
+			continue
+		default:
+			filtered = append(filtered, task)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		left, lok := parseChannelTime(filtered[i].UpdatedAt)
+		right, rok := parseChannelTime(filtered[j].UpdatedAt)
+		switch {
+		case lok && rok:
+			return left.After(right)
+		case lok:
+			return true
+		case rok:
+			return false
+		default:
+			return filtered[i].ID > filtered[j].ID
+		}
+	})
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered
+}
+
+func recoveryRecentThreads(messages []brokerMessage, limit int) []brokerMessage {
+	roots := []brokerMessage{}
+	seen := map[string]bool{}
+	for i := len(messages) - 1; i >= 0 && len(roots) < limit; i-- {
+		msg := messages[i]
+		rootID := threadRootMessageID(messages, msg.ID)
+		if rootID == "" || seen[rootID] {
+			continue
+		}
+		if !hasThreadReplies(messages, rootID) && strings.TrimSpace(msg.ReplyTo) == "" {
+			continue
+		}
+		root, ok := findMessageByID(messages, rootID)
+		if !ok {
+			continue
+		}
+		roots = append(roots, root)
+		seen[rootID] = true
+	}
+	return roots
 }
 
 func countRunningRuntimeTasks(tasks []team.RuntimeTask) int {

--- a/cmd/wuphf/channel_recovery_test.go
+++ b/cmd/wuphf/channel_recovery_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestResolveInitialOfficeAppSupportsRecovery(t *testing.T) {
+	if got := resolveInitialOfficeApp("recovery"); got != officeAppRecovery {
+		t.Fatalf("expected recovery app, got %q", got)
+	}
+}
+
+func TestRecoverCommandSwitchesToRecoveryApp(t *testing.T) {
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 30
+	m.input = []rune("/recover")
+	m.inputPos = len(m.input)
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := next.(channelModel)
+
+	if got.activeApp != officeAppRecovery {
+		t.Fatalf("expected recovery app, got %q", got.activeApp)
+	}
+	if !strings.Contains(got.notice, "recovery summary") {
+		t.Fatalf("expected recovery notice, got %q", got.notice)
+	}
+}
+
+func TestCurrentAwaySummaryUsesRecoveryFocus(t *testing.T) {
+	m := newChannelModel(false)
+	m.unreadCount = 3
+	m.requests = []channelInterview{
+		{
+			ID:       "req-1",
+			Title:    "Review launch scope",
+			Question: "Review the proposed launch scope.",
+			From:     "ceo",
+			Blocking: true,
+			Status:   "pending",
+		},
+	}
+
+	got := m.currentAwaySummary()
+	if !strings.Contains(got, "Review launch scope from @ceo") {
+		t.Fatalf("expected focus summary, got %q", got)
+	}
+	if !strings.Contains(got, "Next: Answer the blocking human request before moving more work") {
+		t.Fatalf("expected next-step summary, got %q", got)
+	}
+}
+
+func TestBuildRecoveryLinesShowsSummaryAndHighlights(t *testing.T) {
+	m := newChannelModel(false)
+	m.unreadCount = 4
+	m.tasks = []channelTask{
+		{ID: "task-1", Title: "Ship launch checklist", Owner: "pm", Status: "in_progress", ExecutionMode: "local_worktree", WorktreePath: "/tmp/wuphf-task-1"},
+	}
+	m.requests = []channelInterview{
+		{ID: "req-1", Title: "Review launch scope", Question: "Review the launch scope", From: "ceo", Blocking: true, Status: "pending"},
+	}
+	m.messages = []brokerMessage{
+		{ID: "msg-1", From: "ceo", Content: "Need final scope review before launch.", Timestamp: "2026-04-06T10:00:00Z"},
+		{ID: "msg-2", From: "pm", Content: "Checklist is nearly ready.", Timestamp: "2026-04-06T10:01:00Z"},
+	}
+
+	snapshot := m.currentRuntimeSnapshot()
+	awaySummary := summarizeAwayRecovery(m.unreadCount, snapshot.Recovery)
+	lines := buildRecoveryLines(snapshot, 88, awaySummary, m.unreadCount, true)
+	plain := stripANSI(joinRenderedLines(lines))
+
+	if !strings.Contains(plain, "What changed while you were gone") {
+		t.Fatalf("expected away-summary card, got %q", plain)
+	}
+	if !strings.Contains(plain, "What to do next") {
+		t.Fatalf("expected next-steps card, got %q", plain)
+	}
+	if !strings.Contains(plain, "Latest highlights") {
+		t.Fatalf("expected highlights card, got %q", plain)
+	}
+	if !strings.Contains(plain, "Current state") {
+		t.Fatalf("expected runtime-state card, got %q", plain)
+	}
+}

--- a/cmd/wuphf/channel_recovery_test.go
+++ b/cmd/wuphf/channel_recovery_test.go
@@ -70,7 +70,7 @@ func TestBuildRecoveryLinesShowsSummaryAndHighlights(t *testing.T) {
 
 	snapshot := m.currentRuntimeSnapshot()
 	awaySummary := summarizeAwayRecovery(m.unreadCount, snapshot.Recovery)
-	lines := buildRecoveryLines(snapshot, 88, awaySummary, m.unreadCount, true)
+	lines := buildRecoveryLines(snapshot, 88, awaySummary, m.unreadCount, true, m.tasks, m.requests, m.messages)
 	plain := stripANSI(joinRenderedLines(lines))
 
 	if !strings.Contains(plain, "What changed while you were gone") {

--- a/cmd/wuphf/channel_recovery_test.go
+++ b/cmd/wuphf/channel_recovery_test.go
@@ -86,3 +86,34 @@ func TestBuildRecoveryLinesShowsSummaryAndHighlights(t *testing.T) {
 		t.Fatalf("expected runtime-state card, got %q", plain)
 	}
 }
+
+func TestBuildRecoveryLinesIncludesTranscriptSurgeryActions(t *testing.T) {
+	m := newChannelModel(false)
+	m.tasks = []channelTask{
+		{ID: "task-1", Title: "Ship launch checklist", Owner: "pm", Status: "in_progress"},
+	}
+	m.requests = []channelInterview{
+		{ID: "req-1", Title: "Review launch scope", Question: "Review the launch scope", From: "ceo", Blocking: true, Status: "pending"},
+	}
+	m.messages = []brokerMessage{
+		{ID: "msg-1", From: "ceo", Content: "Need final scope review before launch.", Timestamp: "2026-04-06T10:00:00Z"},
+		{ID: "msg-2", From: "pm", Content: "Checklist is nearly ready.", ReplyTo: "msg-1", Timestamp: "2026-04-06T10:01:00Z"},
+	}
+
+	lines := m.buildRecoveryLines(96)
+	plain := stripANSI(joinRenderedLines(lines))
+	hasPrompt := false
+	for _, line := range lines {
+		if strings.TrimSpace(line.PromptValue) != "" {
+			hasPrompt = true
+			break
+		}
+	}
+
+	if !strings.Contains(plain, "Transcript surgery") {
+		t.Fatalf("expected transcript surgery section, got %q", plain)
+	}
+	if !hasPrompt {
+		t.Fatalf("expected transcript surgery lines to carry recovery prompts, got %+v", lines)
+	}
+}

--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -10,11 +10,12 @@ import (
 )
 
 type renderedLine struct {
-	Text      string
-	ThreadID  string
-	TaskID    string
-	RequestID string
-	AgentSlug string
+	Text        string
+	ThreadID    string
+	TaskID      string
+	RequestID   string
+	AgentSlug   string
+	PromptValue string
 }
 
 func buildOfficeMessageLines(messages []brokerMessage, expanded map[string]bool, contentWidth int, threadsDefaultExpand bool, unreadAnchorID string, unreadCount int) []renderedLine {
@@ -696,14 +697,19 @@ func renderCalendarActionCard(action channelAction, meta string, contentWidth in
 }
 
 func renderedCardLines(card, taskID, requestID, threadID, agentSlug string) []renderedLine {
+	return renderedCardLinesWithPrompt(card, taskID, requestID, threadID, agentSlug, "")
+}
+
+func renderedCardLinesWithPrompt(card, taskID, requestID, threadID, agentSlug, promptValue string) []renderedLine {
 	var lines []renderedLine
 	for _, line := range strings.Split(card, "\n") {
 		lines = append(lines, renderedLine{
-			Text:      line,
-			TaskID:    taskID,
-			RequestID: requestID,
-			ThreadID:  threadID,
-			AgentSlug: agentSlug,
+			Text:        line,
+			TaskID:      taskID,
+			RequestID:   requestID,
+			ThreadID:    threadID,
+			AgentSlug:   agentSlug,
+			PromptValue: promptValue,
 		})
 	}
 	return lines

--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -17,9 +17,8 @@ type renderedLine struct {
 	AgentSlug string
 }
 
-func buildOfficeMessageLines(messages []brokerMessage, expanded map[string]bool, contentWidth int, threadsDefaultExpand bool) []renderedLine {
+func buildOfficeMessageLines(messages []brokerMessage, expanded map[string]bool, contentWidth int, threadsDefaultExpand bool, unreadAnchorID string, unreadCount int) []renderedLine {
 	mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
-	statusStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#CBD5E1")).Italic(true)
 
 	var lines []renderedLine
 	if len(messages) == 0 {
@@ -35,196 +34,8 @@ func buildOfficeMessageLines(messages []brokerMessage, expanded map[string]bool,
 	}
 
 	lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Today")})
-
-	if !threadsDefaultExpand {
-		for _, msg := range messages {
-			if msg.ReplyTo != "" || !hasThreadReplies(messages, msg.ID) {
-				continue
-			}
-			if _, ok := expanded[msg.ID]; !ok {
-				expanded[msg.ID] = false
-			}
-		}
-	}
-
-	for _, tm := range flattenThreadMessages(messages, expanded) {
-		msg := tm.Message
-		ts := msg.Timestamp
-		if len(ts) > 19 {
-			ts = ts[11:19]
-		}
-
-		color := agentColorMap[msg.From]
-		if color == "" {
-			color = "#9CA3AF"
-		}
-		nameStyle := lipgloss.NewStyle().
-			Foreground(lipgloss.Color(color)).
-			Bold(true)
-		ruleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(color))
-
-		appendWrappedLine := func(text string) {
-			wrapped := appendWrapped(nil, contentWidth, text)
-			for _, line := range wrapped {
-				lines = append(lines, renderedLine{Text: line})
-			}
-		}
-
-		if strings.HasPrefix(msg.Kind, "human_") {
-			lines = append(lines, renderedLine{Text: ""})
-			headerPrefix := "  " + strings.Repeat("  ", tm.Depth)
-			if tm.Depth > 0 {
-				headerPrefix += "↳ "
-			}
-			meta := fmt.Sprintf("for you · %s · %s", humanMessageLabel(msg.Kind), msg.ID)
-			if tm.Depth > 0 {
-				meta += fmt.Sprintf(" · thread reply to %s", tm.ParentLabel)
-			}
-			appendWrappedLine(fmt.Sprintf("%s%s %s  %s  %s",
-				headerPrefix,
-				agentAvatar(msg.From),
-				nameStyle.Render(displayName(msg.From)),
-				mutedStyle.Render(ts),
-				lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render(meta),
-			))
-
-			prefix := "  " + strings.Repeat("  ", tm.Depth)
-			if tm.Depth > 0 {
-				prefix += lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render("┆") + " "
-			} else {
-				prefix += lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render("│") + " "
-			}
-			titleLine := msg.Title
-			if titleLine == "" {
-				titleLine = defaultHumanMessageTitle(msg.Kind, msg.From)
-			}
-			appendWrappedLine(prefix + subtlePill("for you", "#FEF3C7", "#92400E") + " " + lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F8FAFC")).Render(titleLine))
-			textPart, a2uiRendered := renderA2UIBlocks(msg.Content, contentWidth-4)
-			for _, paragraph := range strings.Split(textPart, "\n") {
-				paragraph = highlightMentions(paragraph, agentColorMap)
-				appendWrappedLine(prefix + paragraph)
-			}
-			if a2uiRendered != "" {
-				for _, lineText := range strings.Split(a2uiRendered, "\n") {
-					lines = append(lines, renderedLine{Text: prefix + lineText})
-				}
-			}
-			continue
-		}
-
-		if msg.Kind == "automation" || msg.From == "nex" {
-			lines = append(lines, renderedLine{Text: ""})
-			source := msg.Source
-			if source == "" {
-				source = "context graph"
-			} else {
-				source = strings.ReplaceAll(source, "_", " ")
-			}
-			meta := fmt.Sprintf("%s · automated · %s", source, msg.ID)
-			if tm.Depth > 0 {
-				meta += fmt.Sprintf(" · thread reply to %s", tm.ParentLabel)
-			}
-			textPart, a2uiRendered := renderA2UIBlocks(msg.Content, contentWidth-4)
-			titleLine := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(color)).Render(fallbackString(msg.Title, "Automation update"))
-			for _, lineText := range renderRuntimeEventCard(contentWidth, subtlePill("automation", "#F8FAFC", "#334155")+" "+titleLine, meta, "#7C3AED", strings.Split(textPart, "\n")) {
-				lines = append(lines, renderedLine{Text: "  " + lineText})
-			}
-			if a2uiRendered != "" {
-				for _, lineText := range strings.Split(a2uiRendered, "\n") {
-					lines = append(lines, renderedLine{Text: "    " + lineText})
-				}
-			}
-			continue
-		}
-
-		if strings.HasPrefix(msg.Content, "[STATUS]") {
-			status := strings.TrimPrefix(msg.Content, "[STATUS] ")
-			titleLine := subtlePill("status", "#E2E8F0", "#334155") + " " + nameStyle.Render("@"+msg.From) + " " + statusStyle.Render("is "+status)
-			for _, lineText := range renderRuntimeEventCard(contentWidth, titleLine, mutedStyle.Render(ts), "#475569", nil) {
-				lines = append(lines, renderedLine{Text: "  " + lineText})
-			}
-			continue
-		}
-
-		// System/routing messages — render as subtle inline updates
-		if msg.From == "system" && (msg.Kind == "routing" || msg.Kind == "stage") {
-			label := "routing"
-			if msg.Kind == "stage" {
-				label = "stage"
-			}
-			for _, lineText := range renderRuntimeEventCard(contentWidth, subtlePill(label, "#E5E7EB", "#334155")+" "+mutedStyle.Render(ts), msg.Content, "#475569", nil) {
-				lines = append(lines, renderedLine{Text: "  " + lineText})
-			}
-			continue
-		}
-
-		mood := inferMood(msg.Content)
-		meta := roleLabel(msg.From) + " · " + msg.ID
-		if mood != "" {
-			meta += " · " + mood
-		}
-		if tm.Depth > 0 {
-			meta += fmt.Sprintf(" · thread reply to %s", tm.ParentLabel)
-		}
-		metaStyle := mutedStyle
-		if mood != "" {
-			metaStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(color))
-		}
-		lines = append(lines, renderedLine{Text: ""})
-		headerPrefix := "  " + strings.Repeat("  ", tm.Depth)
-		if tm.Depth > 0 {
-			headerPrefix += "↳ "
-		}
-		appendWrappedLine(fmt.Sprintf("%s%s %s  %s  %s", headerPrefix, agentAvatar(msg.From), nameStyle.Render(displayName(msg.From)), mutedStyle.Render(ts), metaStyle.Render(meta)))
-
-		prefix := "  " + strings.Repeat("  ", tm.Depth)
-		if tm.Depth > 0 {
-			prefix += ruleStyle.Render("┆") + " "
-		} else {
-			prefix += ruleStyle.Render("│") + " "
-		}
-
-		textPart, a2uiRendered := renderA2UIBlocks(msg.Content, contentWidth-4)
-		rendered := renderMarkdown(textPart, contentWidth-len(prefix)-2)
-		for _, paragraph := range strings.Split(rendered, "\n") {
-			paragraph = highlightMentions(paragraph, agentColorMap)
-			appendWrappedLine(prefix + paragraph)
-		}
-		if a2uiRendered != "" {
-			for _, lineText := range strings.Split(a2uiRendered, "\n") {
-				lines = append(lines, renderedLine{Text: prefix + lineText})
-			}
-		}
-		if reactionLine := renderReactions(msg.Reactions); reactionLine != "" {
-			appendWrappedLine(prefix + reactionLine)
-		}
-		if tm.Collapsed && tm.HiddenReplies > 0 {
-			var coloredNames []string
-			for _, p := range tm.ThreadParticipants {
-				pColor := agentColorMap[strings.TrimPrefix(strings.ToLower(p), "@")]
-				if pColor == "" {
-					for slug, name := range map[string]string{
-						"ceo": "CEO", "pm": "Product Manager", "fe": "Frontend Engineer", "be": "Backend Engineer",
-						"ai": "AI Engineer", "designer": "Designer", "cmo": "CMO", "cro": "CRO",
-					} {
-						if p == name {
-							pColor = agentColorMap[slug]
-							break
-						}
-					}
-				}
-				if pColor == "" {
-					pColor = "#ABABAD"
-				}
-				coloredNames = append(coloredNames, lipgloss.NewStyle().Foreground(lipgloss.Color(pColor)).Bold(true).Render(p))
-			}
-			participantStr := ""
-			if len(coloredNames) > 0 {
-				participantStr = "  " + strings.Join(coloredNames, ", ")
-			}
-			label := fmt.Sprintf("  ↩ %d repl%s%s", tm.HiddenReplies, pluralSuffix(tm.HiddenReplies), participantStr)
-			lines = append(lines, renderedLine{Text: label, ThreadID: msg.ID})
-		}
+	for _, tm := range officeThreadedMessages(messages, expanded, threadsDefaultExpand) {
+		lines = append(lines, renderOfficeMessageBlock(tm, contentWidth, unreadAnchorID, unreadCount)...)
 	}
 
 	return lines
@@ -256,7 +67,7 @@ func renderReactions(reactions []brokerReaction) string {
 	return strings.Join(parts, " ")
 }
 
-func buildOneOnOneMessageLines(messages []brokerMessage, expanded map[string]bool, contentWidth int, agentName string) []renderedLine {
+func buildOneOnOneMessageLines(messages []brokerMessage, expanded map[string]bool, contentWidth int, agentName string, unreadAnchorID string, unreadCount int) []renderedLine {
 	if len(messages) == 0 {
 		mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
 		return []renderedLine{
@@ -268,7 +79,23 @@ func buildOneOnOneMessageLines(messages []brokerMessage, expanded map[string]boo
 			{Text: mutedStyle.Render("  This conversation is just you and " + agentName + ".")},
 		}
 	}
-	return buildOfficeMessageLines(messages, expanded, contentWidth, true)
+	return buildOfficeMessageLines(messages, expanded, contentWidth, true, unreadAnchorID, unreadCount)
+}
+
+func renderUnreadDivider(contentWidth int, unreadCount int) string {
+	label := " New since you looked "
+	if unreadCount > 0 {
+		label = fmt.Sprintf(" %d new since you looked ", unreadCount)
+	}
+	lineLen := contentWidth - len(label) - 2
+	if lineLen < 4 {
+		lineLen = 4
+	}
+	left := strings.Repeat("─", lineLen/2)
+	right := strings.Repeat("─", lineLen-lineLen/2)
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#93C5FD")).
+		Render("  " + left + label + right)
 }
 
 func humanMessageLabel(kind string) string {
@@ -707,13 +534,35 @@ func buildCalendarLines(actions []channelAction, jobs []channelSchedulerJob, tas
 		recentActionCap = 4
 	}
 	recentActions := make([]channelAction, 0, recentActionCap)
-	for i := len(actions) - 1; i >= 0 && len(recentActions) < recentActionCap; i-- {
+	var pinnedBridge *channelAction
+	for i := len(actions) - 1; i >= 0; i-- {
 		action := actions[i]
 		channel := normalizeSidebarSlug(action.Channel)
 		if strings.TrimSpace(action.Kind) != "bridge_channel" && channel != "" && channel != normalizeSidebarSlug(activeChannel) {
 			continue
 		}
-		recentActions = append(recentActions, action)
+		if strings.TrimSpace(action.Kind) == "bridge_channel" && pinnedBridge == nil {
+			actionCopy := action
+			pinnedBridge = &actionCopy
+		}
+		if len(recentActions) < recentActionCap {
+			recentActions = append(recentActions, action)
+		}
+	}
+	if pinnedBridge != nil {
+		hasBridge := false
+		for _, action := range recentActions {
+			if strings.TrimSpace(action.Kind) == "bridge_channel" {
+				hasBridge = true
+				break
+			}
+		}
+		if !hasBridge {
+			recentActions = append([]channelAction{*pinnedBridge}, recentActions...)
+			if recentActionCap > 0 && len(recentActions) > recentActionCap {
+				recentActions = recentActions[:recentActionCap]
+			}
+		}
 	}
 	if len(recentActions) > 0 {
 		lines = append(lines, renderedLine{Text: ""})

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -53,12 +53,18 @@ func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
 
 	var lines []renderedLine
 	if m.isOneOnOne() {
-		lines = buildOneOnOneMessageLines(m.messages, m.expandedThreads, contentWidth, m.oneOnOneAgentName(), m.unreadAnchorID, m.unreadCount)
-		focusSlug := m.oneOnOneAgentSlug()
-		lines = append(lines, buildDirectExecutionLines(m.actions, focusSlug, contentWidth)...)
-		lines = append(lines, buildLiveWorkLines(m.members, m.tasks, nil, contentWidth, focusSlug)...)
+		if m.activeApp == officeAppRecovery {
+			lines = buildRecoveryLines(m.currentRuntimeSnapshot(), contentWidth, m.awaySummary, m.unreadCount, m.brokerConnected)
+		} else {
+			lines = buildOneOnOneMessageLines(m.messages, m.expandedThreads, contentWidth, m.oneOnOneAgentName(), m.unreadAnchorID, m.unreadCount)
+			focusSlug := m.oneOnOneAgentSlug()
+			lines = append(lines, buildDirectExecutionLines(m.actions, focusSlug, contentWidth)...)
+			lines = append(lines, buildLiveWorkLines(m.members, m.tasks, nil, contentWidth, focusSlug)...)
+		}
 	} else {
 		switch m.activeApp {
+		case officeAppRecovery:
+			lines = buildRecoveryLines(m.currentRuntimeSnapshot(), contentWidth, m.awaySummary, m.unreadCount, m.brokerConnected)
 		case officeAppTasks:
 			lines = buildTaskLines(m.tasks, contentWidth)
 		case officeAppRequests:
@@ -91,17 +97,20 @@ func (m channelModel) hashMainLinesState(contentWidth int) uint64 {
 	h.add(m.oneOnOneAgent)
 	h.addInt64(renderTimeBucket(m.activeApp, m.isOneOnOne()))
 
-	if m.isOneOnOne() || m.activeApp == officeAppMessages {
+	if m.isOneOnOne() || m.activeApp == officeAppMessages || m.activeApp == officeAppRecovery {
 		h.addMessages(m.messages)
 		h.addExpandedThreads(m.expandedThreads)
 		h.add(m.unreadAnchorID)
 		h.addInt(m.unreadCount)
+		h.add(m.awaySummary)
 		h.addMembers(m.members)
 		h.addTasks(m.tasks)
+		h.addRequests(m.requests)
 		h.addActions(m.actions)
 		if m.isOneOnOne() {
 			h.add(m.oneOnOneAgentName())
 		}
+		h.addBool(m.brokerConnected)
 		return h.sum()
 	}
 

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -35,12 +35,12 @@ var channelRenderCache = channelRenderCacheStore{
 	renderers: make(map[int]*glamour.TermRenderer),
 }
 
-func cachedSidebarRender(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, brokerConnected bool, width, height int) string {
-	key := hashSidebarState(channels, members, tasks, activeChannel, activeApp, cursor, rosterOffset, focused, quickJump, brokerConnected, width, height)
+func cachedSidebarRender(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, workspace workspaceUIState, width, height int) string {
+	key := hashSidebarState(channels, members, tasks, activeChannel, activeApp, cursor, rosterOffset, focused, quickJump, workspace, width, height)
 	if cached, ok := channelRenderCache.getSidebar(key); ok {
 		return cached
 	}
-	rendered := renderSidebar(channels, members, tasks, activeChannel, activeApp, cursor, rosterOffset, focused, quickJump, brokerConnected, width, height)
+	rendered := renderSidebar(channels, members, tasks, activeChannel, activeApp, cursor, rosterOffset, focused, quickJump, workspace, width, height)
 	channelRenderCache.putSidebar(key, rendered)
 	return rendered
 }
@@ -56,10 +56,7 @@ func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
 		if m.activeApp == officeAppRecovery {
 			lines = m.buildRecoveryLines(contentWidth)
 		} else {
-			lines = buildOneOnOneMessageLines(m.messages, m.expandedThreads, contentWidth, m.oneOnOneAgentName(), m.unreadAnchorID, m.unreadCount)
-			focusSlug := m.oneOnOneAgentSlug()
-			lines = append(lines, buildDirectExecutionLines(m.actions, focusSlug, contentWidth)...)
-			lines = append(lines, buildLiveWorkLines(m.members, m.tasks, nil, contentWidth, focusSlug)...)
+			lines = m.buildDirectFeedLines(contentWidth)
 		}
 	} else {
 		switch m.activeApp {
@@ -78,8 +75,7 @@ func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
 		case officeAppSkills:
 			lines = buildSkillLines(m.skills, contentWidth)
 		default:
-			lines = buildOfficeMessageLines(m.messages, m.expandedThreads, contentWidth, m.threadsDefaultExpand, m.unreadAnchorID, m.unreadCount)
-			lines = append(lines, buildLiveWorkLines(m.members, m.tasks, m.actions, contentWidth, "")...)
+			lines = m.buildOfficeFeedLines(contentWidth)
 		}
 	}
 
@@ -150,7 +146,7 @@ func renderTimeBucket(activeApp officeApp, direct bool) int64 {
 	return time.Now().Unix() / 30
 }
 
-func hashSidebarState(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, brokerConnected bool, width, height int) uint64 {
+func hashSidebarState(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, workspace workspaceUIState, width, height int) uint64 {
 	h := newStateHasher()
 	h.add("sidebar")
 	h.addInt(width)
@@ -161,7 +157,23 @@ func hashSidebarState(channels []channelInfo, members []channelMember, tasks []c
 	h.addInt(rosterOffset)
 	h.addBool(focused)
 	h.add(string(quickJump))
-	h.addBool(brokerConnected)
+	h.addBool(workspace.BrokerConnected)
+	h.addBool(workspace.Direct)
+	h.add(workspace.Channel, workspace.AgentName, workspace.AgentSlug, workspace.AwaySummary, workspace.Focus, workspace.NextStep)
+	h.addInt(workspace.PeerCount)
+	h.addInt(workspace.RunningTasks)
+	h.addInt(workspace.OpenRequests)
+	h.addInt(workspace.BlockingCount)
+	h.addInt(workspace.IsolatedCount)
+	h.addInt(workspace.UnreadCount)
+	h.addBool(workspace.NoNex)
+	h.addBool(workspace.APIConfigured)
+	if workspace.NeedsYou != nil {
+		h.add(workspace.NeedsYou.ID, workspace.NeedsYou.TitleOrQuestion())
+	}
+	if workspace.PrimaryTask != nil {
+		h.add(workspace.PrimaryTask.ID, workspace.PrimaryTask.Title, workspace.PrimaryTask.Status)
+	}
 	h.addInt64(time.Now().Unix())
 	h.addChannels(channels)
 	h.addMembers(members)

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -53,7 +53,7 @@ func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
 
 	var lines []renderedLine
 	if m.isOneOnOne() {
-		lines = buildOneOnOneMessageLines(m.messages, m.expandedThreads, contentWidth, m.oneOnOneAgentName())
+		lines = buildOneOnOneMessageLines(m.messages, m.expandedThreads, contentWidth, m.oneOnOneAgentName(), m.unreadAnchorID, m.unreadCount)
 		focusSlug := m.oneOnOneAgentSlug()
 		lines = append(lines, buildDirectExecutionLines(m.actions, focusSlug, contentWidth)...)
 		lines = append(lines, buildLiveWorkLines(m.members, m.tasks, nil, contentWidth, focusSlug)...)
@@ -70,7 +70,7 @@ func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
 		case officeAppSkills:
 			lines = buildSkillLines(m.skills, contentWidth)
 		default:
-			lines = buildOfficeMessageLines(m.messages, m.expandedThreads, contentWidth, m.threadsDefaultExpand)
+			lines = buildOfficeMessageLines(m.messages, m.expandedThreads, contentWidth, m.threadsDefaultExpand, m.unreadAnchorID, m.unreadCount)
 			lines = append(lines, buildLiveWorkLines(m.members, m.tasks, m.actions, contentWidth, "")...)
 		}
 	}
@@ -94,6 +94,8 @@ func (m channelModel) hashMainLinesState(contentWidth int) uint64 {
 	if m.isOneOnOne() || m.activeApp == officeAppMessages {
 		h.addMessages(m.messages)
 		h.addExpandedThreads(m.expandedThreads)
+		h.add(m.unreadAnchorID)
+		h.addInt(m.unreadCount)
 		h.addMembers(m.members)
 		h.addTasks(m.tasks)
 		h.addActions(m.actions)

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -73,6 +73,8 @@ func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
 			lines = buildPolicyLines(m.signals, m.decisions, m.watchdogs, m.actions, contentWidth)
 		case officeAppCalendar:
 			lines = buildCalendarLines(m.actions, m.scheduler, m.tasks, m.requests, m.activeChannel, m.members, m.calendarRange, m.calendarFilter, contentWidth)
+		case officeAppArtifacts:
+			lines = m.buildArtifactLines(contentWidth)
 		case officeAppSkills:
 			lines = buildSkillLines(m.skills, contentWidth)
 		default:
@@ -130,6 +132,11 @@ func (m channelModel) hashMainLinesState(contentWidth int) uint64 {
 		h.addTasks(m.tasks)
 		h.addRequests(m.requests)
 		h.addMembers(m.members)
+	case officeAppArtifacts:
+		h.addTasks(m.tasks)
+		h.addRequests(m.requests)
+		h.addActions(m.actions)
+		h.addInt64(time.Now().Unix() / 10)
 	case officeAppSkills:
 		h.addSkills(m.skills)
 	}

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -54,7 +54,7 @@ func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
 	var lines []renderedLine
 	if m.isOneOnOne() {
 		if m.activeApp == officeAppRecovery {
-			lines = buildRecoveryLines(m.currentRuntimeSnapshot(), contentWidth, m.awaySummary, m.unreadCount, m.brokerConnected)
+			lines = m.buildRecoveryLines(contentWidth)
 		} else {
 			lines = buildOneOnOneMessageLines(m.messages, m.expandedThreads, contentWidth, m.oneOnOneAgentName(), m.unreadAnchorID, m.unreadCount)
 			focusSlug := m.oneOnOneAgentSlug()
@@ -64,7 +64,7 @@ func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
 	} else {
 		switch m.activeApp {
 		case officeAppRecovery:
-			lines = buildRecoveryLines(m.currentRuntimeSnapshot(), contentWidth, m.awaySummary, m.unreadCount, m.brokerConnected)
+			lines = m.buildRecoveryLines(contentWidth)
 		case officeAppTasks:
 			lines = buildTaskLines(m.tasks, contentWidth)
 		case officeAppRequests:

--- a/cmd/wuphf/channel_sidebar.go
+++ b/cmd/wuphf/channel_sidebar.go
@@ -363,8 +363,30 @@ func sidebarStyledRow(style lipgloss.Style, text string, width int) string {
 	return style.Width(maxInt(1, width)).Render(text)
 }
 
+func visibleSidebarApps(apps []officeSidebarApp, activeApp officeApp, maxRows int) []officeSidebarApp {
+	if maxRows <= 0 || len(apps) == 0 {
+		return nil
+	}
+	if len(apps) <= maxRows {
+		return apps
+	}
+	visible := append([]officeSidebarApp(nil), apps[:maxRows]...)
+	for _, app := range visible {
+		if app.App == activeApp {
+			return visible
+		}
+	}
+	for _, app := range apps {
+		if app.App == activeApp {
+			visible[len(visible)-1] = app
+			return visible
+		}
+	}
+	return visible
+}
+
 // renderSidebar renders the Slack-style sidebar with channels and team members.
-func renderSidebar(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, brokerConnected bool, width, height int) string {
+func renderSidebar(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, workspace workspaceUIState, width, height int) string {
 	if width < 2 {
 		return ""
 	}
@@ -382,6 +404,8 @@ func renderSidebar(channels []channelInfo, members []channelMember, tasks []chan
 		Bold(true)
 	workspaceMetaStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(sidebarMuted))
+	workspaceSummaryStyle := workspaceMetaStyle.Copy()
+	workspaceHintStyle := workspaceMetaStyle.Copy()
 	activeRowStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#FFFFFF")).
 		Background(lipgloss.Color(sidebarActive)).
@@ -397,17 +421,30 @@ func renderSidebar(channels []channelInfo, members []channelMember, tasks []chan
 	memberMetaStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(sidebarMuted))
 
+	switch {
+	case !workspace.BrokerConnected:
+		workspaceSummaryStyle = workspaceSummaryStyle.Foreground(lipgloss.Color("#F59E0B"))
+		workspaceHintStyle = workspaceHintStyle.Foreground(lipgloss.Color("#FBBF24"))
+	case workspace.BlockingCount > 0:
+		workspaceSummaryStyle = workspaceSummaryStyle.Foreground(lipgloss.Color("#FBBF24"))
+		workspaceHintStyle = workspaceHintStyle.Foreground(lipgloss.Color("#FCD34D")).Bold(true)
+	case strings.TrimSpace(workspace.AwaySummary) != "":
+		workspaceSummaryStyle = workspaceSummaryStyle.Foreground(lipgloss.Color("#93C5FD"))
+		workspaceHintStyle = workspaceHintStyle.Foreground(lipgloss.Color("#BFDBFE"))
+	default:
+		workspaceHintStyle = workspaceHintStyle.Foreground(lipgloss.Color("#D1FAE5"))
+	}
+
+	summaryLine := truncateLabel(workspace.sidebarSummaryLine(activeApp), maxInt(8, innerW-1))
+	hintLine := truncateLabel(workspace.sidebarHintLine(), maxInt(8, innerW-1))
+
 	var lines []string
 	lines = append(lines, "")
 	lines = append(lines, sidebarPlainRow(workspaceStyle.Render("WUPHF"), width))
 	lines = append(lines, sidebarPlainRow(workspaceMetaStyle.Render("The WUPHF Office"), width))
-	lines = append(lines, sidebarPlainRow(workspaceMetaStyle.Italic(true).Render("Somehow still operational"), width))
+	lines = append(lines, sidebarPlainRow(workspaceSummaryStyle.Render(summaryLine), width))
 	lines = append(lines, sidebarPlainRow(workspaceMetaStyle.Render("Ctrl+G channels · Ctrl+O apps"), width))
-	if brokerConnected {
-		lines = append(lines, sidebarPlainRow(workspaceMetaStyle.Render("Team connected"), width))
-	} else {
-		lines = append(lines, sidebarPlainRow(workspaceMetaStyle.Render("Offline preview from manifest"), width))
-	}
+	lines = append(lines, sidebarPlainRow(workspaceHintStyle.Render(hintLine), width))
 	lines = append(lines, "")
 	channelHeaderText := "Channels"
 	if quickJump == quickJumpChannels {
@@ -441,19 +478,21 @@ func renderSidebar(channels []channelInfo, members []channelMember, tasks []chan
 		appHeaderText = "Apps · 1-9"
 	}
 	lines = append(lines, sidebarStyledRow(sectionBandStyle, appHeaderText, width))
-	apps := []struct {
-		App   officeApp
-		Label string
-	}{
-		{officeAppMessages, "Messages"},
-		{officeAppTasks, "Tasks"},
-		{officeAppSkills, "Skills"},
-		{officeAppPolicies, "Policies"},
-		{officeAppCalendar, "Calendar"},
+	apps := officeSidebarApps()
+	const minRosterReserve = 3
+	maxAppRows := height - len(lines) - minRosterReserve
+	if maxAppRows < 1 {
+		maxAppRows = 1
 	}
-	appIndex := 0
-	for _, app := range apps {
+	for _, app := range visibleSidebarApps(apps, activeApp, maxAppRows) {
 		label := appIcon(app.App) + " " + app.Label
+		appIndex := 0
+		for idx, candidate := range apps {
+			if candidate.App == app.App {
+				appIndex = idx
+				break
+			}
+		}
 		shortcut := sidebarShortcutLabel(appIndex)
 		if shortcut != "" {
 			label = shortcut + "  " + label
@@ -467,7 +506,6 @@ func renderSidebar(channels []channelInfo, members []channelMember, tasks []chan
 			lines = append(lines, sidebarStyledRow(channelRowStyle, label, width))
 		}
 		sidebarIndex++
-		appIndex++
 	}
 
 	dividerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(sidebarDivider))

--- a/cmd/wuphf/channel_switcher.go
+++ b/cmd/wuphf/channel_switcher.go
@@ -21,6 +21,7 @@ func (m channelModel) buildWorkspaceSwitcherOptions() []tui.PickerOption {
 	} else {
 		options = append(options,
 			tui.PickerOption{Label: "Office feed", Value: "app:messages", Description: "Main channel feed"},
+			tui.PickerOption{Label: "Recovery", Value: "app:recovery", Description: "Resume work with focus, changes, and next steps"},
 			tui.PickerOption{Label: "Tasks", Value: "app:tasks", Description: "Active work in #" + m.activeChannel},
 			tui.PickerOption{Label: "Requests", Value: "app:requests", Description: "Human decisions and interviews"},
 			tui.PickerOption{Label: "Policies", Value: "app:policies", Description: "Signals, decisions, and watchdogs"},
@@ -114,6 +115,8 @@ func (m *channelModel) applyWorkspaceSwitcherSelection(value string) tea.Cmd {
 		m.syncSidebarCursorToActive()
 		m.notice = "Viewing " + strings.Title(string(app)) + "."
 		switch app {
+		case officeAppRecovery:
+			return m.pollCurrentState()
 		case officeAppTasks:
 			return pollTasks(m.activeChannel)
 		case officeAppRequests:

--- a/cmd/wuphf/channel_switcher.go
+++ b/cmd/wuphf/channel_switcher.go
@@ -6,8 +6,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
-	"github.com/nex-crm/wuphf/internal/tui"
 	"github.com/nex-crm/wuphf/internal/team"
+	"github.com/nex-crm/wuphf/internal/tui"
 )
 
 func (m channelModel) buildWorkspaceSwitcherOptions() []tui.PickerOption {
@@ -26,6 +26,7 @@ func (m channelModel) buildWorkspaceSwitcherOptions() []tui.PickerOption {
 			tui.PickerOption{Label: "Requests", Value: "app:requests", Description: "Human decisions and interviews"},
 			tui.PickerOption{Label: "Policies", Value: "app:policies", Description: "Signals, decisions, and watchdogs"},
 			tui.PickerOption{Label: "Calendar", Value: "app:calendar", Description: "Scheduled work and follow-ups"},
+			tui.PickerOption{Label: "Artifacts", Value: "app:artifacts", Description: "Task logs, workflow runs, and approvals"},
 			tui.PickerOption{Label: "Skills", Value: "app:skills", Description: "Reusable skills and workflows"},
 		)
 		for _, ch := range m.channels {
@@ -125,6 +126,8 @@ func (m *channelModel) applyWorkspaceSwitcherSelection(value string) tea.Cmd {
 			return pollOfficeLedger()
 		case officeAppCalendar:
 			return tea.Batch(pollTasks(m.activeChannel), pollRequests(m.activeChannel), pollOfficeLedger())
+		case officeAppArtifacts:
+			return m.pollCurrentState()
 		default:
 			return nil
 		}

--- a/cmd/wuphf/channel_switcher.go
+++ b/cmd/wuphf/channel_switcher.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"strings"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -16,12 +18,12 @@ func (m channelModel) buildWorkspaceSwitcherOptions() []tui.PickerOption {
 		options = append(options, tui.PickerOption{
 			Label:       "Back to office",
 			Value:       "mode:office",
-			Description: "Return to the full office feed and roster",
+			Description: m.officeFeedDescription(),
 		})
 	} else {
 		options = append(options,
-			tui.PickerOption{Label: "Office feed", Value: "app:messages", Description: "Main channel feed"},
-			tui.PickerOption{Label: "Recovery", Value: "app:recovery", Description: "Resume work with focus, changes, and next steps"},
+			tui.PickerOption{Label: "Office feed", Value: "app:messages", Description: m.officeFeedDescription()},
+			tui.PickerOption{Label: "Recovery", Value: "app:recovery", Description: m.recoverySwitcherDescription()},
 			tui.PickerOption{Label: "Tasks", Value: "app:tasks", Description: "Active work in #" + m.activeChannel},
 			tui.PickerOption{Label: "Requests", Value: "app:requests", Description: "Human decisions and interviews"},
 			tui.PickerOption{Label: "Policies", Value: "app:policies", Description: "Signals, decisions, and watchdogs"},
@@ -45,10 +47,61 @@ func (m channelModel) buildWorkspaceSwitcherOptions() []tui.PickerOption {
 		if member.Slug == "you" || strings.TrimSpace(member.Slug) == "" {
 			continue
 		}
+		description := "Direct session with @" + member.Slug
+		summary := deriveMemberRuntimeSummary(member, m.tasks, time.Now())
+		if strings.TrimSpace(summary.Detail) != "" {
+			description = summary.Detail
+		} else if strings.TrimSpace(member.LastMessage) != "" {
+			description = summarizeSentence(member.LastMessage)
+		}
 		options = append(options, tui.PickerOption{
 			Label:       "1:1 with " + member.Name,
 			Value:       "dm:" + member.Slug,
-			Description: "Direct session with @" + member.Slug,
+			Description: description,
+		})
+	}
+
+	for _, req := range m.switcherPendingRequests(3) {
+		label := "Request " + req.ID + " · " + truncateText(req.TitleOrQuestion(), 40)
+		description := strings.TrimSpace(strings.Join([]string{
+			strings.ReplaceAll(strings.TrimSpace(req.Kind), "_", " "),
+			"@" + fallbackString(req.From, "unknown"),
+			switcherTiming(req.CreatedAt, req.DueAt),
+		}, " · "))
+		if req.Blocking || req.Required {
+			description = "Needs you now · " + description
+		}
+		options = append(options, tui.PickerOption{
+			Label:       label,
+			Value:       "request:" + req.ID,
+			Description: strings.Trim(description, " ·"),
+		})
+	}
+
+	for _, task := range m.switcherActiveTasks(4) {
+		descriptionParts := []string{
+			strings.ReplaceAll(strings.TrimSpace(task.Status), "_", " "),
+			"@" + fallbackString(task.Owner, "unowned"),
+			switcherTiming(task.UpdatedAt, task.DueAt),
+		}
+		if strings.TrimSpace(task.WorktreePath) != "" {
+			descriptionParts = append(descriptionParts, "worktree")
+		}
+		if strings.TrimSpace(task.ThreadID) != "" {
+			descriptionParts = append(descriptionParts, "thread "+task.ThreadID)
+		}
+		options = append(options, tui.PickerOption{
+			Label:       "Task " + task.ID + " · " + truncateText(task.Title, 44),
+			Value:       "task:" + task.ID,
+			Description: strings.Trim(strings.Join(descriptionParts, " · "), " ·"),
+		})
+	}
+
+	for _, msg := range m.switcherRecentThreads(3) {
+		options = append(options, tui.PickerOption{
+			Label:       "Thread " + msg.ID + " · @" + fallbackString(msg.From, "unknown"),
+			Value:       "thread:" + msg.ID,
+			Description: truncateText(strings.TrimSpace(msg.Content), 72),
 		})
 	}
 
@@ -142,9 +195,133 @@ func (m *channelModel) applyWorkspaceSwitcherSelection(value string) tea.Cmd {
 		m.focus = focusThread
 		m.notice = "Replying in thread " + threadID
 		return nil
+	case strings.HasPrefix(value, "task:"), strings.HasPrefix(value, "request:"):
+		return m.applySearchSelection(value, value)
 	default:
 		return nil
 	}
+}
+
+func (m channelModel) officeFeedDescription() string {
+	if summary := strings.TrimSpace(m.currentAwaySummary()); summary != "" {
+		return summary
+	}
+	if req, ok := selectNeedsYouRequest(m.requests); ok {
+		return "Needs you: " + truncateText(req.TitleOrQuestion(), 64)
+	}
+	return "Main office feed"
+}
+
+func (m channelModel) recoverySwitcherDescription() string {
+	recovery := m.currentRuntimeSnapshot().Recovery
+	if focus := trimRecoverySentence(recovery.Focus); focus != "" {
+		return truncateText(focus, 72)
+	}
+	if len(recovery.NextSteps) > 0 {
+		return truncateText("Next: "+recovery.NextSteps[0], 72)
+	}
+	return "Resume work with focus, changes, and next steps"
+}
+
+func (m channelModel) switcherPendingRequests(limit int) []channelInterview {
+	requests := recentHumanArtifactRequests(m.requests, 0)
+	filtered := make([]channelInterview, 0, len(requests))
+	for _, req := range requests {
+		if !isOpenInterviewStatus(req.Status) {
+			continue
+		}
+		filtered = append(filtered, req)
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered
+}
+
+func (m channelModel) switcherActiveTasks(limit int) []channelTask {
+	filtered := make([]channelTask, 0, len(m.tasks))
+	for _, task := range m.tasks {
+		status := strings.ToLower(strings.TrimSpace(task.Status))
+		switch status {
+		case "", "done", "completed", "canceled", "cancelled":
+			continue
+		default:
+			filtered = append(filtered, task)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		leftRank, rightRank := taskSwitcherRank(filtered[i]), taskSwitcherRank(filtered[j])
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		leftTime, lok := parseChannelTime(fallbackString(filtered[i].UpdatedAt, filtered[i].CreatedAt))
+		rightTime, rok := parseChannelTime(fallbackString(filtered[j].UpdatedAt, filtered[j].CreatedAt))
+		switch {
+		case lok && rok:
+			if !leftTime.Equal(rightTime) {
+				return leftTime.After(rightTime)
+			}
+		case lok:
+			return true
+		case rok:
+			return false
+		}
+		return filtered[i].ID > filtered[j].ID
+	})
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered
+}
+
+func taskSwitcherRank(task channelTask) int {
+	status := strings.ToLower(strings.TrimSpace(task.Status))
+	switch status {
+	case "blocked":
+		return 0
+	case "review":
+		return 1
+	case "in_progress":
+		return 2
+	case "claimed", "pending", "open":
+		return 3
+	default:
+		return 4
+	}
+}
+
+func (m channelModel) switcherRecentThreads(limit int) []brokerMessage {
+	roots := make([]brokerMessage, 0, limit)
+	seen := map[string]bool{}
+	for _, msg := range m.recentRootMessages(24) {
+		rootID := threadRootMessageID(m.messages, msg.ID)
+		if rootID == "" || seen[rootID] {
+			continue
+		}
+		if !hasThreadReplies(m.messages, rootID) && strings.TrimSpace(msg.ReplyTo) == "" {
+			continue
+		}
+		root, ok := findMessageByID(m.messages, rootID)
+		if !ok {
+			continue
+		}
+		roots = append(roots, root)
+		seen[rootID] = true
+		if limit > 0 && len(roots) >= limit {
+			break
+		}
+	}
+	return roots
+}
+
+func switcherTiming(createdAt, dueAt string) string {
+	if due := strings.TrimSpace(dueAt); due != "" {
+		return "due " + prettyRelativeTime(due)
+	}
+	if created := strings.TrimSpace(createdAt); created != "" {
+		return prettyRelativeTime(created)
+	}
+	return ""
 }
 
 func normalizeWorkspaceChannel(slug string) string {

--- a/cmd/wuphf/channel_switcher.go
+++ b/cmd/wuphf/channel_switcher.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/nex-crm/wuphf/internal/tui"
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+func (m channelModel) buildWorkspaceSwitcherOptions() []tui.PickerOption {
+	options := []tui.PickerOption{}
+	if m.isOneOnOne() {
+		options = append(options, tui.PickerOption{
+			Label:       "Back to office",
+			Value:       "mode:office",
+			Description: "Return to the full office feed and roster",
+		})
+	} else {
+		options = append(options,
+			tui.PickerOption{Label: "Office feed", Value: "app:messages", Description: "Main channel feed"},
+			tui.PickerOption{Label: "Tasks", Value: "app:tasks", Description: "Active work in #" + m.activeChannel},
+			tui.PickerOption{Label: "Requests", Value: "app:requests", Description: "Human decisions and interviews"},
+			tui.PickerOption{Label: "Policies", Value: "app:policies", Description: "Signals, decisions, and watchdogs"},
+			tui.PickerOption{Label: "Calendar", Value: "app:calendar", Description: "Scheduled work and follow-ups"},
+			tui.PickerOption{Label: "Skills", Value: "app:skills", Description: "Reusable skills and workflows"},
+		)
+		for _, ch := range m.channels {
+			if strings.TrimSpace(ch.Slug) == "" {
+				continue
+			}
+			options = append(options, tui.PickerOption{
+				Label:       "#" + ch.Slug,
+				Value:       "channel:" + ch.Slug,
+				Description: fallbackChannelDescription(ch),
+			})
+		}
+	}
+
+	for _, member := range mergeOfficeMembers(m.officeMembers, m.members, m.currentChannelInfo()) {
+		if member.Slug == "you" || strings.TrimSpace(member.Slug) == "" {
+			continue
+		}
+		options = append(options, tui.PickerOption{
+			Label:       "1:1 with " + member.Name,
+			Value:       "dm:" + member.Slug,
+			Description: "Direct session with @" + member.Slug,
+		})
+	}
+
+	if m.threadPanelOpen && strings.TrimSpace(m.threadPanelID) != "" {
+		options = append(options, tui.PickerOption{
+			Label:       "Current thread " + m.threadPanelID,
+			Value:       "thread:" + m.threadPanelID,
+			Description: "Jump back into the active thread panel",
+		})
+	}
+	return options
+}
+
+func fallbackChannelDescription(ch channelInfo) string {
+	if strings.TrimSpace(ch.Description) != "" {
+		return ch.Description
+	}
+	if len(ch.Members) > 0 {
+		return fmt.Sprintf("%d member%s", len(ch.Members), pluralSuffix(len(ch.Members)))
+	}
+	return "Shared office channel"
+}
+
+func (m *channelModel) applyWorkspaceSwitcherSelection(value string) tea.Cmd {
+	switch {
+	case value == "mode:office":
+		m.confirm = confirmationForSessionSwitch(team.SessionModeOffice, team.DefaultOneOnOneAgent)
+		m.notice = "Confirm returning to the full office."
+		return nil
+	case strings.HasPrefix(value, "dm:"):
+		agent := strings.TrimSpace(strings.TrimPrefix(value, "dm:"))
+		if agent == "" {
+			agent = team.DefaultOneOnOneAgent
+		}
+		if m.isOneOnOne() && team.NormalizeOneOnOneAgent(m.oneOnOneAgent) == team.NormalizeOneOnOneAgent(agent) {
+			m.notice = "Already viewing that direct session."
+			return nil
+		}
+		m.confirm = confirmationForSessionSwitch(team.SessionModeOneOnOne, agent)
+		m.notice = "Confirm the direct session switch."
+		return nil
+	case strings.HasPrefix(value, "channel:"):
+		channel := normalizeWorkspaceChannel(strings.TrimPrefix(value, "channel:"))
+		if channel == "" {
+			return nil
+		}
+		m.activeChannel = channel
+		m.activeApp = officeAppMessages
+		m.messages = nil
+		m.members = nil
+		m.requests = nil
+		m.tasks = nil
+		m.lastID = ""
+		m.replyToID = ""
+		m.threadPanelOpen = false
+		m.threadPanelID = ""
+		m.scroll = 0
+		m.unreadCount = 0
+		m.syncSidebarCursorToActive()
+		m.notice = "Switched to #" + channel
+		return tea.Batch(pollBroker("", m.activeChannel), pollMembers(m.activeChannel), pollRequests(m.activeChannel), pollTasks(m.activeChannel))
+	case strings.HasPrefix(value, "app:"):
+		app := officeApp(strings.TrimSpace(strings.TrimPrefix(value, "app:")))
+		m.activeApp = app
+		m.syncSidebarCursorToActive()
+		m.notice = "Viewing " + strings.Title(string(app)) + "."
+		switch app {
+		case officeAppTasks:
+			return pollTasks(m.activeChannel)
+		case officeAppRequests:
+			return pollRequests(m.activeChannel)
+		case officeAppPolicies:
+			return pollOfficeLedger()
+		case officeAppCalendar:
+			return tea.Batch(pollTasks(m.activeChannel), pollRequests(m.activeChannel), pollOfficeLedger())
+		default:
+			return nil
+		}
+	case strings.HasPrefix(value, "thread:"):
+		threadID := strings.TrimSpace(strings.TrimPrefix(value, "thread:"))
+		if threadID == "" {
+			return nil
+		}
+		m.threadPanelOpen = true
+		m.threadPanelID = threadID
+		m.replyToID = threadID
+		m.focus = focusThread
+		m.notice = "Replying in thread " + threadID
+		return nil
+	default:
+		return nil
+	}
+}
+
+func normalizeWorkspaceChannel(slug string) string {
+	slug = strings.TrimSpace(strings.ToLower(slug))
+	if slug == "" {
+		return ""
+	}
+	slug = strings.TrimPrefix(slug, "#")
+	return strings.ReplaceAll(slug, " ", "-")
+}

--- a/cmd/wuphf/channel_switcher_recovery_test.go
+++ b/cmd/wuphf/channel_switcher_recovery_test.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildWorkspaceSwitcherOptionsIncludesActiveWorkAndThreads(t *testing.T) {
+	m := newChannelModel(false)
+	m.unreadCount = 3
+	m.awaySummary = "3 new since you looked. Next: answer the blocking request."
+	m.members = []channelMember{{
+		Slug:         "pm",
+		Name:         "Product Manager",
+		LastMessage:  "Reviewing the launch checklist now",
+		LastTime:     time.Now().Add(-time.Minute).Format(time.RFC3339),
+		LiveActivity: "Reading the launch checklist",
+	}}
+	m.requests = []channelInterview{{
+		ID:        "req-1",
+		Kind:      "approval",
+		Status:    "pending",
+		Title:     "Approve launch copy",
+		Question:  "Approve launch copy?",
+		From:      "ceo",
+		CreatedAt: time.Now().Add(-2 * time.Minute).Format(time.RFC3339),
+	}}
+	m.tasks = []channelTask{{
+		ID:        "task-1",
+		Title:     "Ship launch checklist",
+		Owner:     "pm",
+		Status:    "in_progress",
+		ThreadID:  "msg-1",
+		UpdatedAt: time.Now().Add(-time.Minute).Format(time.RFC3339),
+	}}
+	m.messages = []brokerMessage{
+		{ID: "msg-1", From: "ceo", Content: "Need launch review.", Timestamp: time.Now().Add(-3 * time.Minute).Format(time.RFC3339)},
+		{ID: "msg-2", From: "pm", Content: "Reply in thread", ReplyTo: "msg-1", Timestamp: time.Now().Add(-2 * time.Minute).Format(time.RFC3339)},
+	}
+
+	options := m.buildWorkspaceSwitcherOptions()
+	byValue := map[string]bool{}
+	descriptions := map[string]string{}
+	for _, option := range options {
+		byValue[option.Value] = true
+		descriptions[option.Value] = option.Description
+	}
+
+	for _, want := range []string{"request:req-1", "task:task-1", "thread:msg-1"} {
+		if !byValue[want] {
+			t.Fatalf("expected switcher option %q, got %+v", want, options)
+		}
+	}
+	if !strings.Contains(descriptions["app:messages"], "3 new since you looked") {
+		t.Fatalf("expected office feed description to use away summary, got %q", descriptions["app:messages"])
+	}
+}
+
+func TestApplyWorkspaceSwitcherSelectionSupportsTaskAndRequestTargets(t *testing.T) {
+	m := newChannelModel(false)
+	m.tasks = []channelTask{{
+		ID:       "task-1",
+		Title:    "Ship launch checklist",
+		Status:   "in_progress",
+		ThreadID: "msg-1",
+	}}
+	m.requests = []channelInterview{{
+		ID:       "req-1",
+		Kind:     "approval",
+		Status:   "pending",
+		Title:    "Approve launch copy",
+		Question: "Approve launch copy?",
+		From:     "ceo",
+	}}
+
+	if cmd := m.applyWorkspaceSwitcherSelection("task:task-1"); cmd == nil {
+		t.Fatal("expected task selection to return a poll command")
+	}
+	if m.activeApp != officeAppTasks || !m.threadPanelOpen || m.threadPanelID != "msg-1" {
+		t.Fatalf("expected task selection to focus tasks/thread, got app=%q threadOpen=%v threadID=%q", m.activeApp, m.threadPanelOpen, m.threadPanelID)
+	}
+
+	m.threadPanelOpen = false
+	m.threadPanelID = ""
+	if cmd := m.applyWorkspaceSwitcherSelection("request:req-1"); cmd == nil {
+		t.Fatal("expected request selection to return a focus command")
+	}
+	if m.activeApp != officeAppRequests || m.pending == nil || m.pending.ID != "req-1" {
+		t.Fatalf("expected request selection to focus request state, got app=%q pending=%+v", m.activeApp, m.pending)
+	}
+}
+
+func TestBuildRecoveryLinesIncludesActionCards(t *testing.T) {
+	m := newChannelModel(false)
+	m.unreadCount = 2
+	m.tasks = []channelTask{{
+		ID:           "task-1",
+		Title:        "Ship launch checklist",
+		Details:      "Checklist almost ready for review.",
+		Owner:        "pm",
+		Status:       "in_progress",
+		ThreadID:     "msg-1",
+		WorktreePath: "/tmp/wuphf-task-1",
+		UpdatedAt:    time.Now().Add(-time.Minute).Format(time.RFC3339),
+	}}
+	m.requests = []channelInterview{{
+		ID:            "req-1",
+		Kind:          "approval",
+		Status:        "pending",
+		Title:         "Approve launch copy",
+		Question:      "Approve launch copy?",
+		Context:       "Need final sign-off before launch.",
+		From:          "ceo",
+		Blocking:      true,
+		RecommendedID: "approve",
+	}}
+	m.messages = []brokerMessage{
+		{ID: "msg-1", From: "ceo", Content: "Need launch review.", Timestamp: time.Now().Add(-3 * time.Minute).Format(time.RFC3339)},
+		{ID: "msg-2", From: "pm", Content: "Reply in thread", ReplyTo: "msg-1", Timestamp: time.Now().Add(-2 * time.Minute).Format(time.RFC3339)},
+	}
+
+	lines := m.buildRecoveryLines(96)
+	plain := stripANSI(joinRenderedLines(lines))
+	var hasTask, hasRequest, hasThread bool
+	for _, line := range lines {
+		if line.TaskID == "task-1" {
+			hasTask = true
+		}
+		if line.RequestID == "req-1" {
+			hasRequest = true
+		}
+		if line.ThreadID == "msg-1" {
+			hasThread = true
+		}
+	}
+
+	if !strings.Contains(plain, "Resume human decisions") {
+		t.Fatalf("expected resume human decisions section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Resume active tasks") {
+		t.Fatalf("expected resume active tasks section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Return to recent threads") {
+		t.Fatalf("expected recent threads section, got %q", plain)
+	}
+	if !hasTask || !hasRequest || !hasThread {
+		t.Fatalf("expected clickable recovery lines, got task=%v request=%v thread=%v", hasTask, hasRequest, hasThread)
+	}
+}

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -2131,6 +2131,96 @@ func TestOfficeViewportWindowMatchesFullRenderAndMouseHitTesting(t *testing.T) {
 	}
 }
 
+func TestRecoveryMouseClickInsertsPromptAndReturnsToMessages(t *testing.T) {
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 32
+	m.activeApp = officeAppRecovery
+	m.tasks = []channelTask{{
+		ID:        "task-1",
+		Title:     "Ship onboarding",
+		Status:    "in_progress",
+		Owner:     "fe",
+		UpdatedAt: time.Now().Format(time.RFC3339),
+	}}
+	m.messages = []brokerMessage{
+		{ID: "msg-1", From: "ceo", Content: "Need launch review.", Timestamp: time.Now().Add(-3 * time.Minute).Format(time.RFC3339)},
+		{ID: "msg-2", From: "pm", Content: "Reply in thread", ReplyTo: "msg-1", Timestamp: time.Now().Add(-2 * time.Minute).Format(time.RFC3339)},
+	}
+
+	layout := computeLayout(m.width, m.height, m.threadPanelOpen, m.sidebarCollapsed)
+	headerH, msgH, _ := m.mainPanelGeometry(layout.MainW, layout.ContentH)
+	contentWidth := layout.MainW - 2
+	if contentWidth < 32 {
+		contentWidth = 32
+	}
+	rows, _, _, _ := sliceRenderedLines(m.currentMainLines(contentWidth), msgH, m.scroll)
+	targetRow := -1
+	for i, row := range rows {
+		if strings.TrimSpace(row.PromptValue) != "" {
+			targetRow = i
+			break
+		}
+	}
+	if targetRow < 0 {
+		t.Fatal("expected recovery render to expose a prompt action")
+	}
+
+	mainX := layout.SidebarW + 3
+	action, ok := m.mainPanelMouseAction(mainX, headerH+targetRow, layout.MainW, layout.ContentH)
+	if !ok {
+		t.Fatal("expected recovery row to be clickable")
+	}
+	if action.Kind != "prompt" {
+		t.Fatalf("expected recovery click to draft a prompt, got %+v", action)
+	}
+
+	next, _ := m.Update(tea.MouseMsg{Type: tea.MouseLeft, Button: tea.MouseButtonLeft, X: mainX, Y: headerH + targetRow})
+	got := next.(channelModel)
+	if got.activeApp != officeAppMessages {
+		t.Fatalf("expected recovery click to return to messages, got %q", got.activeApp)
+	}
+	if !strings.Contains(string(got.input), "Restore context for task task-1") && !strings.Contains(string(got.input), "Summarize everything since") {
+		t.Fatalf("expected drafted recovery prompt in composer, got %q", string(got.input))
+	}
+}
+
+func TestBuildLiveWorkLinesShowsWaitStateWhenQuiet(t *testing.T) {
+	lines := buildLiveWorkLines(nil, nil, nil, 96, "")
+	plain := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(plain, "Wait state") {
+		t.Fatalf("expected wait-state section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Nothing is moving right now") {
+		t.Fatalf("expected quiet-state guidance, got %q", plain)
+	}
+}
+
+func TestBuildLiveWorkLinesShowsBlockedWork(t *testing.T) {
+	lines := buildLiveWorkLines(nil, []channelTask{{
+		ID:       "task-1",
+		Title:    "Ship onboarding",
+		Status:   "blocked",
+		Owner:    "fe",
+		ThreadID: "msg-1",
+		Details:  "Waiting on an API schema decision.",
+	}}, nil, 96, "")
+	plain := stripANSI(joinRenderedLines(lines))
+	hasTask := false
+	for _, line := range lines {
+		if line.TaskID == "task-1" {
+			hasTask = true
+			break
+		}
+	}
+	if !strings.Contains(plain, "Blocked work") || !strings.Contains(plain, "Ship onboarding") {
+		t.Fatalf("expected blocked-work guidance, got %q", plain)
+	}
+	if !hasTask {
+		t.Fatalf("expected blocked-work lines to stay clickable, got %+v", lines)
+	}
+}
+
 func TestMouseClickCollapsedThreadOpensThreadPanel(t *testing.T) {
 	t.Skip("skipped: test needs update after thread/policies/calendar refactors")
 	m := newChannelModel(true)

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -246,7 +246,7 @@ func TestRenderThreadPanelShowsNestedReplies(t *testing.T) {
 		{ID: "msg-3", From: "be", Content: "Nested reply", ReplyTo: "msg-2", Timestamp: "2026-03-24T10:02:00Z"},
 	}
 
-	view := stripANSI(renderThreadPanel(messages, "msg-1", 44, 18, nil, 0, 0, "", true))
+	view := stripANSI(renderThreadPanel(messages, "msg-1", 44, 18, nil, 0, 0, "", true, false))
 	if !strings.Contains(view, "Reply one") || !strings.Contains(view, "Reply two") {
 		t.Fatalf("expected thread panel to count nested replies, got %q", view)
 	}
@@ -371,6 +371,22 @@ func TestSwitchCommandOpensChannelPicker(t *testing.T) {
 	}
 }
 
+func TestSwitchCommandIncludesWorkspaceDestinations(t *testing.T) {
+	m := newChannelModel(false)
+
+	options := m.buildSwitchChannelPickerOptions()
+	values := make(map[string]bool, len(options))
+	for _, option := range options {
+		values[option.Value] = true
+	}
+
+	for _, want := range []string{"app:messages", "app:tasks", "app:requests", "app:policies", "app:calendar", "session:1o1:ceo"} {
+		if !values[want] {
+			t.Fatalf("expected switcher option %q, got %+v", want, options)
+		}
+	}
+}
+
 func TestSwitchAliasSelectsChannel(t *testing.T) {
 	m := newChannelModel(false)
 	m.activeChannel = "general"
@@ -417,13 +433,17 @@ func TestBuildSwitchChannelPickerOptionsOnlyIncludesSwitchTargets(t *testing.T) 
 	}
 
 	options := m.buildSwitchChannelPickerOptions()
-	if len(options) != 2 {
-		t.Fatalf("expected only switch targets, got %+v", options)
+	if len(options) < 2 {
+		t.Fatalf("expected channel switch targets, got %+v", options)
 	}
+	seenChannels := 0
 	for _, option := range options {
-		if !strings.HasPrefix(option.Value, "switch:") {
-			t.Fatalf("expected switch-only values, got %+v", option)
+		if strings.HasPrefix(option.Value, "switch:") {
+			seenChannels++
 		}
+	}
+	if seenChannels != 2 {
+		t.Fatalf("expected two channel switch targets, got %+v", options)
 	}
 }
 
@@ -530,6 +550,46 @@ func TestOneOnOnePickerDisableInOfficeIsNoop(t *testing.T) {
 	got := next.(channelModel)
 	if got.notice != "Already running the full office team." {
 		t.Fatalf("expected office noop notice, got %q", got.notice)
+	}
+}
+
+func TestOneOnOnePickerDisableInDirectModeRequiresConfirmation(t *testing.T) {
+	m := newChannelModel(false)
+	m.sessionMode = team.SessionModeOneOnOne
+	m.oneOnOneAgent = "be"
+	m.picker = tui.NewPicker("Direct Session", m.buildOneOnOneModePickerOptions())
+	m.picker.SetActive(true)
+	m.pickerMode = channelPickerOneOnOneMode
+
+	next, cmd := m.Update(tui.PickerSelectMsg{Value: "disable"})
+	if cmd != nil {
+		t.Fatalf("expected no immediate command when requesting office mode, got %v", cmd)
+	}
+	got := next.(channelModel)
+	if got.confirm == nil {
+		t.Fatal("expected confirmation card to open")
+	}
+	if got.confirm.Action != confirmActionSwitchMode {
+		t.Fatalf("expected switch-mode confirmation, got %q", got.confirm.Action)
+	}
+}
+
+func TestOneOnOneAgentSelectionRequiresConfirmation(t *testing.T) {
+	m := newChannelModel(false)
+	m.picker = tui.NewPicker("Choose Direct Agent", m.buildOneOnOneAgentPickerOptions())
+	m.picker.SetActive(true)
+	m.pickerMode = channelPickerOneOnOneAgent
+
+	next, cmd := m.Update(tui.PickerSelectMsg{Value: "ceo"})
+	if cmd != nil {
+		t.Fatalf("expected no immediate command when picking direct agent, got %v", cmd)
+	}
+	got := next.(channelModel)
+	if got.confirm == nil {
+		t.Fatal("expected confirmation card to open")
+	}
+	if got.confirm.Action != confirmActionSwitchMode || got.confirm.Agent != "ceo" {
+		t.Fatalf("unexpected confirmation: %+v", got.confirm)
 	}
 }
 
@@ -673,6 +733,21 @@ func TestCalendarRecentActionsIncludeBridgeChannel(t *testing.T) {
 	}
 	if !strings.Contains(view, "task_created") {
 		t.Fatalf("expected calendar recent actions to include task_created, got %q", view)
+	}
+}
+
+func TestCalendarRecentActionsPinsBridgeWhenCapWouldDropIt(t *testing.T) {
+	lines := buildCalendarLines([]channelAction{
+		{ID: "action-1", Kind: "bridge_channel", Channel: "launch", Summary: "Use the sharper product narrative.", Actor: "ceo"},
+		{ID: "action-2", Kind: "human_directive", Channel: "general", Summary: "Human directed the office.", Actor: "you"},
+		{ID: "action-3", Kind: "request_answered", Channel: "general", Summary: "Approved the launch direction.", Actor: "you"},
+		{ID: "action-4", Kind: "task_created", Channel: "general", Summary: "Tighten v1 scope", Actor: "ceo"},
+		{ID: "action-5", Kind: "signal_recorded", Channel: "general", Summary: "Recorded a human directive signal.", Actor: "ceo"},
+	}, nil, nil, nil, "general", nil, calendarRangeWeek, "", 90)
+
+	view := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(view, "bridge_channel") {
+		t.Fatalf("expected bridge_channel to stay pinned in recent actions, got %q", view)
 	}
 }
 
@@ -876,12 +951,12 @@ func TestBuildSwitchChannelPickerOptionsExcludeRemoveActions(t *testing.T) {
 	}
 
 	options := m.buildSwitchChannelPickerOptions()
-	if len(options) != 2 {
-		t.Fatalf("expected only switch entries, got %d options", len(options))
+	if len(options) < 2 {
+		t.Fatalf("expected switcher options, got %d options", len(options))
 	}
 	for _, option := range options {
-		if !strings.HasPrefix(option.Value, "switch:") {
-			t.Fatalf("expected only switch actions, got %+v", option)
+		if strings.HasPrefix(option.Value, "remove:") {
+			t.Fatalf("expected remove actions to stay hidden, got %+v", option)
 		}
 	}
 }
@@ -1317,6 +1392,9 @@ func TestOneOnOneSlashAutocompleteShowsResetAndHidesChannels(t *testing.T) {
 	if !strings.Contains(view, "/reset") {
 		t.Fatalf("expected /reset in visible 1:1 autocomplete, got %q", view)
 	}
+	if !strings.Contains(view, "/switch") {
+		t.Fatalf("expected /switch in visible 1:1 autocomplete, got %q", view)
+	}
 	if strings.Contains(view, "/channels") || strings.Contains(view, "/tasks") || strings.Contains(view, "/threads") {
 		t.Fatalf("expected blocked 1:1 commands to be hidden from autocomplete, got %q", view)
 	}
@@ -1476,6 +1554,69 @@ func TestThreadComposerSupportsVimStyleWordMotions(t *testing.T) {
 	got = next.(channelModel)
 	if got.threadInputPos != len(got.threadInput) {
 		t.Fatalf("expected thread alt+$ to jump to end, got %d", got.threadInputPos)
+	}
+}
+
+func TestMainComposerRecallRestoresDraft(t *testing.T) {
+	t.Setenv("WUPHF_API_KEY", "test-key")
+	m := newChannelModel(false)
+	m.input = []rune("first shipped prompt")
+	m.inputPos = len(m.input)
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := next.(channelModel)
+	if len(got.inputHistory.entries) != 1 {
+		t.Fatalf("expected one history entry, got %d", len(got.inputHistory.entries))
+	}
+
+	got.input = []rune("draft in progress")
+	got.inputPos = len([]rune("draft "))
+	next, _ = got.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	got = next.(channelModel)
+	if string(got.input) != "first shipped prompt" {
+		t.Fatalf("expected recalled input, got %q", string(got.input))
+	}
+
+	next, _ = got.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	got = next.(channelModel)
+	if string(got.input) != "draft in progress" {
+		t.Fatalf("expected original draft restored, got %q", string(got.input))
+	}
+	if got.inputPos != len([]rune("draft ")) {
+		t.Fatalf("expected draft cursor restored, got %d", got.inputPos)
+	}
+}
+
+func TestThreadComposerRecallRestoresDraft(t *testing.T) {
+	t.Setenv("WUPHF_API_KEY", "test-key")
+	m := newChannelModel(false)
+	m.threadPanelOpen = true
+	m.threadPanelID = "msg-1"
+	m.focus = focusThread
+	m.threadInput = []rune("thread shipped reply")
+	m.threadInputPos = len(m.threadInput)
+
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := next.(channelModel)
+	if len(got.threadInputHistory.entries) != 1 {
+		t.Fatalf("expected one thread history entry, got %d", len(got.threadInputHistory.entries))
+	}
+
+	got.threadInput = []rune("thread draft")
+	got.threadInputPos = len([]rune("thread "))
+	next, _ = got.Update(tea.KeyMsg{Type: tea.KeyCtrlP})
+	got = next.(channelModel)
+	if string(got.threadInput) != "thread shipped reply" {
+		t.Fatalf("expected recalled thread input, got %q", string(got.threadInput))
+	}
+
+	next, _ = got.Update(tea.KeyMsg{Type: tea.KeyCtrlN})
+	got = next.(channelModel)
+	if string(got.threadInput) != "thread draft" {
+		t.Fatalf("expected thread draft restored, got %q", string(got.threadInput))
+	}
+	if got.threadInputPos != len([]rune("thread ")) {
+		t.Fatalf("expected thread draft cursor restored, got %d", got.threadInputPos)
 	}
 }
 
@@ -1862,6 +2003,79 @@ func TestMouseClickJumpLatestClearsUnread(t *testing.T) {
 	}
 }
 
+func TestOfficeViewportWindowMatchesFullRenderAndMouseHitTesting(t *testing.T) {
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 32
+	m.activeApp = officeAppMessages
+	m.members = []channelMember{{Slug: "fe", Name: "Frontend Engineer", LastMessage: "Landing the next slice"}}
+	m.tasks = []channelTask{{
+		ID:            "task-1",
+		Title:         "Ship onboarding",
+		Status:        "in_progress",
+		Owner:         "fe",
+		ExecutionMode: "local_worktree",
+		WorktreePath:  "/tmp/worktree",
+		CreatedBy:     "ceo",
+		CreatedAt:     time.Now().Add(-2 * time.Hour).Format(time.RFC3339),
+		UpdatedAt:     time.Now().Format(time.RFC3339),
+	}}
+	m.actions = []channelAction{{
+		Kind:      "external_build",
+		Actor:     "fe",
+		Summary:   "Build the office UI",
+		CreatedAt: time.Now().Add(-90 * time.Minute).Format(time.RFC3339),
+	}}
+	m.messages = []brokerMessage{
+		{ID: "msg-1", From: "ceo", Content: "A very long root message that should wrap across multiple rows to make sure the viewport helper actually has to window the history instead of rendering everything at once.", Timestamp: "2026-03-24T10:00:00Z"},
+		{ID: "msg-2", From: "fe", Content: "Reply one with enough content to wrap and keep the total line count above the viewport height.", ReplyTo: "msg-1", Timestamp: "2026-03-24T10:01:00Z"},
+		{ID: "msg-3", From: "be", Content: "Second root message with more wrapped text so the suffix collector has to stop before the entire history is materialized.", Timestamp: "2026-03-24T10:02:00Z"},
+		{ID: "msg-4", From: "pm", Content: "Reply two that stays in the same thread and should remain visible in the tail window.", ReplyTo: "msg-3", Timestamp: "2026-03-24T10:03:00Z"},
+		{ID: "msg-5", From: "cmo", Content: "Another root message that keeps the history long enough for the windowing path to matter.", Timestamp: "2026-03-24T10:04:00Z"},
+		{ID: "msg-6", From: "designer", Content: "More filler content to push the viewport down and exercise the suffix collector.", Timestamp: "2026-03-24T10:05:00Z"},
+		{ID: "msg-7", From: "ceo", Content: "Should we keep the thread collapsed so the summary row is clickable?", Timestamp: "2026-03-24T10:06:00Z"},
+		{ID: "msg-8", From: "fe", Content: "Yes, the collapse summary is what we want to click.", ReplyTo: "msg-7", Timestamp: "2026-03-24T10:07:00Z"},
+	}
+	m.expandedThreads["msg-7"] = false
+
+	layout := computeLayout(m.width, m.height, m.threadPanelOpen, m.sidebarCollapsed)
+	headerH, msgH, _ := m.mainPanelGeometry(layout.MainW, layout.ContentH)
+	contentWidth := layout.MainW - 2
+	if contentWidth < 32 {
+		contentWidth = 32
+	}
+
+	full := append(buildOfficeMessageLines(m.messages, m.expandedThreads, contentWidth, m.threadsDefaultExpand, m.unreadAnchorID, m.unreadCount), buildLiveWorkLines(m.members, m.tasks, m.actions, contentWidth, "")...)
+	expected, expectedScroll, _, _ := sliceRenderedLines(full, msgH, m.scroll)
+	window := m.currentMainViewportLines(contentWidth, msgH)
+	got, gotScroll, _, _ := sliceRenderedLines(window, msgH, m.scroll)
+	if gotScroll != expectedScroll {
+		t.Fatalf("expected scroll %d from windowed render, got %d", expectedScroll, gotScroll)
+	}
+	if joinRenderedLines(got) != joinRenderedLines(expected) {
+		t.Fatalf("expected windowed render to match full render\nfull:\n%s\nwindow:\n%s", joinRenderedLines(expected), joinRenderedLines(got))
+	}
+
+	mainX := layout.SidebarW + 3
+	targetRow := -1
+	for i, row := range got {
+		if row.ThreadID == "msg-7" {
+			targetRow = i
+			break
+		}
+	}
+	if targetRow < 0 {
+		t.Fatal("expected collapsed thread summary row in viewport")
+	}
+	action, ok := m.mainPanelMouseAction(mainX, headerH+targetRow, layout.MainW, layout.ContentH)
+	if !ok {
+		t.Fatal("expected viewport row to be clickable")
+	}
+	if action.Kind != "thread" || action.Value != "msg-7" {
+		t.Fatalf("expected click to open msg-7 thread, got %+v", action)
+	}
+}
+
 func TestMouseClickCollapsedThreadOpensThreadPanel(t *testing.T) {
 	t.Skip("skipped: test needs update after thread/policies/calendar refactors")
 	m := newChannelModel(true)
@@ -1875,7 +2089,7 @@ func TestMouseClickCollapsedThreadOpensThreadPanel(t *testing.T) {
 	layout := computeLayout(m.width, m.height, m.threadPanelOpen, m.sidebarCollapsed)
 	headerH, msgH, _ := m.mainPanelGeometry(layout.MainW, layout.ContentH)
 	contentWidth := layout.MainW - 2
-	lines := buildOfficeMessageLines(m.messages, m.expandedThreads, contentWidth, m.threadsDefaultExpand)
+	lines := buildOfficeMessageLines(m.messages, m.expandedThreads, contentWidth, m.threadsDefaultExpand, m.unreadAnchorID, m.unreadCount)
 	visible, _, _, _ := sliceRenderedLines(lines, msgH, m.scroll)
 	row := -1
 	for i, line := range visible {
@@ -1909,6 +2123,100 @@ func TestChannelErrorsSurfaceInNotice(t *testing.T) {
 	got = next.(channelModel)
 	if !strings.Contains(got.notice, "Send failed") {
 		t.Fatalf("expected post error notice, got %q", got.notice)
+	}
+}
+
+func TestResetCommandOpensConfirmation(t *testing.T) {
+	m := newChannelModel(false)
+
+	next, cmd := m.runCommand("/reset", "")
+	if cmd != nil {
+		t.Fatalf("expected no immediate command from /reset, got %v", cmd)
+	}
+	got := next.(channelModel)
+	if got.confirm == nil {
+		t.Fatal("expected reset confirmation")
+	}
+	if got.confirm.Action != confirmActionResetTeam {
+		t.Fatalf("expected reset-team confirmation, got %q", got.confirm.Action)
+	}
+}
+
+func TestPendingRequestEnterOpensReviewConfirmation(t *testing.T) {
+	m := newChannelModel(false)
+	m.pending = &channelInterview{
+		ID:       "request-1",
+		Kind:     "approval",
+		From:     "ceo",
+		Question: "Ship it?",
+		Options: []channelInterviewOption{
+			{ID: "approve", Label: "Approve"},
+		},
+	}
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("expected no immediate post while opening review confirmation, got %v", cmd)
+	}
+	got := next.(channelModel)
+	if got.confirm == nil {
+		t.Fatal("expected review confirmation")
+	}
+	if got.confirm.Action != confirmActionSubmitRequest {
+		t.Fatalf("expected submit-request confirmation, got %q", got.confirm.Action)
+	}
+	if got.confirm.ChoiceID != "approve" {
+		t.Fatalf("expected approve choice in confirmation, got %+v", got.confirm)
+	}
+}
+
+func TestPendingRequestRequiresTextBeforeReview(t *testing.T) {
+	m := newChannelModel(false)
+	m.pending = &channelInterview{
+		ID:       "request-1",
+		Kind:     "approval",
+		From:     "ceo",
+		Question: "Ship it?",
+		Options: []channelInterviewOption{
+			{ID: "approve_with_note", Label: "Approve with note", RequiresText: true, TextHint: "Type constraints first."},
+		},
+	}
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("expected no immediate post for text-required option, got %v", cmd)
+	}
+	got := next.(channelModel)
+	if got.confirm != nil {
+		t.Fatalf("did not expect review confirmation before required text, got %+v", got.confirm)
+	}
+	if got.notice != "Type constraints first." {
+		t.Fatalf("expected text hint notice, got %q", got.notice)
+	}
+}
+
+func TestPendingRequestTypedAnswerOpensReviewConfirmation(t *testing.T) {
+	m := newChannelModel(false)
+	m.pending = &channelInterview{
+		ID:       "request-1",
+		Kind:     "approval",
+		From:     "ceo",
+		Question: "Ship it?",
+	}
+	m.selectedOption = 0
+	m.input = []rune("Need legal review first.")
+	m.inputPos = len(m.input)
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		t.Fatalf("expected no immediate post while reviewing typed answer, got %v", cmd)
+	}
+	got := next.(channelModel)
+	if got.confirm == nil || got.confirm.Action != confirmActionSubmitRequest {
+		t.Fatalf("expected submit-request confirmation, got %+v", got.confirm)
+	}
+	if got.confirm.CustomText != "Need legal review first." {
+		t.Fatalf("expected typed note to be preserved, got %+v", got.confirm)
 	}
 }
 
@@ -1985,7 +2293,7 @@ func TestRenderInterviewCardShowsCustomAnswerAsFinalOption(t *testing.T) {
 			{ID: "quality", Label: "Higher polish", Description: "Bias toward experience quality."},
 		},
 		RecommendedID: "speed",
-	}, 2, 60)
+	}, 2, "Step 1 of 3 · choose", 60)
 
 	plain := stripANSI(card)
 	if !strings.Contains(plain, "Something else") {
@@ -1993,6 +2301,42 @@ func TestRenderInterviewCardShowsCustomAnswerAsFinalOption(t *testing.T) {
 	}
 	if strings.LastIndex(plain, "Something else") <= strings.LastIndex(plain, "Higher polish") {
 		t.Fatalf("expected Something else to appear after predefined options, got %q", plain)
+	}
+	if !strings.Contains(plain, "Step 1 of 3 · choose") {
+		t.Fatalf("expected explicit request phase in card, got %q", plain)
+	}
+}
+
+func TestInterviewPhaseTracksChooseDraftAndReview(t *testing.T) {
+	m := newChannelModel(false)
+	m.pending = &channelInterview{
+		ID:       "request-1",
+		Kind:     "approval",
+		From:     "ceo",
+		Question: "Ship it?",
+		Options: []channelInterviewOption{
+			{ID: "approve_with_note", Label: "Approve with note", RequiresText: true},
+		},
+	}
+
+	if got := m.currentInterviewPhase(); got != interviewPhaseDraft {
+		t.Fatalf("expected text-required option to enter draft phase, got %q", got)
+	}
+	m.pending.Options[0] = channelInterviewOption{ID: "approve", Label: "Approve"}
+	if got := m.currentInterviewPhase(); got != interviewPhaseChoose {
+		t.Fatalf("expected choose phase without typed text, got %q", got)
+	}
+	m.input = []rune("Need legal review first.")
+	m.inputPos = len(m.input)
+	if got := m.currentInterviewPhase(); got != interviewPhaseDraft {
+		t.Fatalf("expected typed input to enter draft phase, got %q", got)
+	}
+	m.confirm = confirmationForInterviewAnswer(*m.pending, nil, "Need legal review first.")
+	if got := m.currentInterviewPhase(); got != interviewPhaseReview {
+		t.Fatalf("expected review phase once confirmation is open, got %q", got)
+	}
+	if hint := m.composerHint(m.composerTargetLabel(), "", m.pending); !strings.Contains(hint, "Enter submit") || !strings.Contains(hint, "Esc revise") {
+		t.Fatalf("expected review hint while reviewing answer, got %q", hint)
 	}
 }
 

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -911,13 +911,13 @@ func TestCtrlOQuickJumpSelectsApp(t *testing.T) {
 		t.Fatal("expected app quick nav to activate")
 	}
 
-	model, cmd := got.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'5'}})
+	model, cmd := got.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'6'}})
 	got = model.(channelModel)
 	if cmd == nil {
 		t.Fatal("expected selecting a numbered app to trigger a command")
 	}
 	if got.activeApp != officeAppCalendar {
-		t.Fatalf("expected quick jump 5 to open calendar, got %s", got.activeApp)
+		t.Fatalf("expected quick jump 6 to open calendar, got %s", got.activeApp)
 	}
 	if got.quickJumpTarget != quickJumpNone {
 		t.Fatal("expected app quick nav mode to exit after selection")

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -978,7 +978,7 @@ func TestRenderSidebarShowsOfficeCharacterBubble(t *testing.T) {
 		0,
 		false,
 		quickJumpNone,
-		true,
+		workspaceUIState{BrokerConnected: true, Channel: "general", PeerCount: 1},
 		36,
 		40,
 	))
@@ -990,6 +990,61 @@ func TestRenderSidebarShowsOfficeCharacterBubble(t *testing.T) {
 	}
 	if !strings.Contains(sidebar, "Ctrl+G channels") {
 		t.Fatalf("expected quick nav hint in sidebar, got %q", sidebar)
+	}
+}
+
+func TestRenderSidebarReflectsWorkspaceState(t *testing.T) {
+	sidebar := stripANSI(renderSidebar(
+		[]channelInfo{{Slug: "launch", Name: "launch"}},
+		nil,
+		nil,
+		"launch",
+		officeAppMessages,
+		0,
+		0,
+		false,
+		quickJumpNone,
+		workspaceUIState{
+			BrokerConnected: true,
+			Channel:         "launch",
+			PeerCount:       4,
+			BlockingCount:   1,
+			NeedsYou: &channelInterview{
+				ID:       "req-1",
+				Title:    "Approve launch copy",
+				Question: "Approve launch copy?",
+			},
+		},
+		72,
+		36,
+	))
+	if !strings.Contains(sidebar, "Message lane · #launch · 1 waiting") {
+		t.Fatalf("expected workspace summary in sidebar, got %q", sidebar)
+	}
+	if !strings.Contains(sidebar, "Need you: Approve launch copy") || !strings.Contains(sidebar, "/request answer req-1") {
+		t.Fatalf("expected action hint for blocking request, got %q", sidebar)
+	}
+}
+
+func TestRenderSidebarShowsRecoveryRequestsAndArtifactsApps(t *testing.T) {
+	sidebar := stripANSI(renderSidebar(
+		[]channelInfo{{Slug: "general", Name: "general"}},
+		nil,
+		nil,
+		"general",
+		officeAppMessages,
+		0,
+		0,
+		false,
+		quickJumpNone,
+		workspaceUIState{BrokerConnected: true, Channel: "general"},
+		48,
+		40,
+	))
+	for _, label := range []string{"Recovery", "Requests", "Artifacts"} {
+		if !strings.Contains(sidebar, label) {
+			t.Fatalf("expected sidebar to show %s app, got %q", label, sidebar)
+		}
 	}
 }
 
@@ -1012,7 +1067,7 @@ func TestRenderSidebarUsesCompactRosterWhenSpaceIsTight(t *testing.T) {
 		0,
 		false,
 		quickJumpNone,
-		false,
+		workspaceUIState{BrokerConnected: false, Channel: "general"},
 		36,
 		22,
 	))
@@ -1049,7 +1104,7 @@ func TestRenderSidebarFallsBackToOfficeRosterWhenPeopleListIsEmpty(t *testing.T)
 		0,
 		false,
 		quickJumpNone,
-		false,
+		workspaceUIState{BrokerConnected: false, Channel: "general"},
 		42,
 		20,
 	))
@@ -1082,7 +1137,7 @@ func TestRenderSidebarShowsTaskDrivenWorkingState(t *testing.T) {
 		0,
 		false,
 		quickJumpNone,
-		true,
+		workspaceUIState{BrokerConnected: true, Channel: "general", PeerCount: 1},
 		40,
 		44,
 	))

--- a/cmd/wuphf/channel_thread.go
+++ b/cmd/wuphf/channel_thread.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/nex-crm/wuphf/internal/tui"
 )
 
 // renderThreadPanel renders the thread side panel with parent message,
 // reply count divider, replies, and its own input field.
 func renderThreadPanel(allMessages []brokerMessage, parentID string,
 	width, height int, threadInput []rune, threadInputPos int,
-	threadScroll int, popup string, focused bool) string {
+	threadScroll int, popup string, focused bool, historyAvailable bool) string {
 
 	if width < 8 || height < 4 {
 		return ""
@@ -83,7 +84,7 @@ func renderThreadPanel(allMessages []brokerMessage, parentID string,
 	}
 
 	// ── Thread input field ────────────────────────────────────────────
-	threadInputRendered := renderThreadInput(threadInput, threadInputPos, innerW-2, focused)
+	threadInputRendered := renderThreadInput(threadInput, threadInputPos, innerW-2, focused, historyAvailable)
 	inputH := lipgloss.Height(threadInputRendered)
 	usedH := 3 // header line + header divider + blank
 	contentH := height - usedH - inputH
@@ -293,7 +294,7 @@ func renderThreadMessage(msg brokerMessage, width int, isParent bool) []string {
 }
 
 // renderThreadInput renders the input area at the bottom of the thread panel.
-func renderThreadInput(input []rune, inputPos int, width int, focused bool) string {
+func renderThreadInput(input []rune, inputPos int, width int, focused bool, historyAvailable bool) string {
 	if width < 6 {
 		width = 6
 	}
@@ -333,6 +334,11 @@ func renderThreadInput(input []rune, inputPos int, width int, focused bool) stri
 		Padding(0, 1)
 
 	label := lipgloss.NewStyle().Foreground(lipgloss.Color(slackActive)).Bold(true).Render("Reply")
-	hint := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted)).Render(" Enter send")
+	hint := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted)).Render(
+		tui.ComposerHint(tui.ComposerHintState{
+			Context:          tui.ContextThreadCompose,
+			HistoryAvailable: historyAvailable,
+		}),
+	)
 	return " " + label + "  " + hint + "\n " + borderStyle.Render(inputStr)
 }

--- a/cmd/wuphf/channel_unread.go
+++ b/cmd/wuphf/channel_unread.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (m *channelModel) noteIncomingMessages(added []brokerMessage) {
+	if len(added) == 0 {
+		return
+	}
+	if m.unreadAnchorID == "" {
+		m.unreadAnchorID = added[0].ID
+	}
+	m.unreadCount += len(added)
+	m.awaySummary = summarizeUnreadMessages(added)
+}
+
+func (m *channelModel) clearUnreadState() {
+	m.unreadCount = 0
+	m.unreadAnchorID = ""
+	m.awaySummary = ""
+}
+
+func summarizeUnreadMessages(messages []brokerMessage) string {
+	if len(messages) == 0 {
+		return ""
+	}
+	names := []string{}
+	seen := map[string]bool{}
+	for _, msg := range messages {
+		if strings.TrimSpace(msg.From) == "" || seen[msg.From] {
+			continue
+		}
+		seen[msg.From] = true
+		names = append(names, displayName(msg.From))
+		if len(names) == 3 {
+			break
+		}
+	}
+	switch len(names) {
+	case 0:
+		return fmt.Sprintf("%d new messages", len(messages))
+	case 1:
+		return fmt.Sprintf("%d new from %s", len(messages), names[0])
+	case 2:
+		return fmt.Sprintf("%d new from %s and %s", len(messages), names[0], names[1])
+	default:
+		return fmt.Sprintf("%d new from %s, %s, and %s", len(messages), names[0], names[1], names[2])
+	}
+}

--- a/cmd/wuphf/channel_unread.go
+++ b/cmd/wuphf/channel_unread.go
@@ -13,7 +13,7 @@ func (m *channelModel) noteIncomingMessages(added []brokerMessage) {
 		m.unreadAnchorID = added[0].ID
 	}
 	m.unreadCount += len(added)
-	m.awaySummary = summarizeUnreadMessages(added)
+	m.awaySummary = summarizeAwayRecovery(m.unreadCount, m.currentRuntimeSnapshot().Recovery)
 }
 
 func (m *channelModel) clearUnreadState() {

--- a/cmd/wuphf/channel_window.go
+++ b/cmd/wuphf/channel_window.go
@@ -8,14 +8,24 @@ import (
 )
 
 func (m channelModel) currentMainViewportLines(contentWidth, msgH int) []renderedLine {
+	needsYou := buildNeedsYouLines(m.requests, contentWidth)
+	bodyHeight := msgH
+	if len(needsYou) > 0 && bodyHeight-len(needsYou) >= 8 {
+		bodyHeight -= len(needsYou)
+	} else {
+		needsYou = nil
+	}
+
 	if m.isOneOnOne() {
 		if m.activeApp == officeAppRecovery {
 			return m.currentMainLines(contentWidth)
 		}
-		return buildOneOnOneViewportSuffix(m.messages, m.actions, m.tasks, m.members, m.expandedThreads, contentWidth, msgH, m.scroll, m.oneOnOneAgentName(), m.oneOnOneAgentSlug(), m.unreadAnchorID, m.unreadCount)
+		lines := buildOneOnOneViewportSuffix(m.messages, m.actions, m.tasks, m.members, m.expandedThreads, contentWidth, bodyHeight, m.scroll, m.oneOnOneAgentName(), m.oneOnOneAgentSlug(), m.unreadAnchorID, m.unreadCount)
+		return append(needsYou, lines...)
 	}
 	if m.activeApp == officeAppMessages {
-		return buildOfficeViewportSuffix(m.messages, m.expandedThreads, contentWidth, msgH, m.scroll, m.threadsDefaultExpand, m.unreadAnchorID, m.unreadCount, m.members, m.tasks, m.actions)
+		lines := buildOfficeViewportSuffix(m.messages, m.expandedThreads, contentWidth, bodyHeight, m.scroll, m.threadsDefaultExpand, m.unreadAnchorID, m.unreadCount, m.members, m.tasks, m.actions)
+		return append(needsYou, lines...)
 	}
 	return m.currentMainLines(contentWidth)
 }

--- a/cmd/wuphf/channel_window.go
+++ b/cmd/wuphf/channel_window.go
@@ -20,10 +20,16 @@ func (m channelModel) currentMainViewportLines(contentWidth, msgH int) []rendere
 		if m.activeApp == officeAppRecovery {
 			return m.currentMainLines(contentWidth)
 		}
+		if len(m.messages) == 0 {
+			return append(needsYou, m.buildDirectFeedLines(contentWidth)...)
+		}
 		lines := buildOneOnOneViewportSuffix(m.messages, m.actions, m.tasks, m.members, m.expandedThreads, contentWidth, bodyHeight, m.scroll, m.oneOnOneAgentName(), m.oneOnOneAgentSlug(), m.unreadAnchorID, m.unreadCount)
 		return append(needsYou, lines...)
 	}
 	if m.activeApp == officeAppMessages {
+		if len(m.messages) == 0 {
+			return append(needsYou, m.buildOfficeFeedLines(contentWidth)...)
+		}
 		lines := buildOfficeViewportSuffix(m.messages, m.expandedThreads, contentWidth, bodyHeight, m.scroll, m.threadsDefaultExpand, m.unreadAnchorID, m.unreadCount, m.members, m.tasks, m.actions)
 		return append(needsYou, lines...)
 	}

--- a/cmd/wuphf/channel_window.go
+++ b/cmd/wuphf/channel_window.go
@@ -1,0 +1,293 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func (m channelModel) currentMainViewportLines(contentWidth, msgH int) []renderedLine {
+	if m.isOneOnOne() {
+		return buildOneOnOneViewportSuffix(m.messages, m.actions, m.tasks, m.members, m.expandedThreads, contentWidth, msgH, m.scroll, m.oneOnOneAgentName(), m.oneOnOneAgentSlug(), m.unreadAnchorID, m.unreadCount)
+	}
+	if m.activeApp == officeAppMessages {
+		return buildOfficeViewportSuffix(m.messages, m.expandedThreads, contentWidth, msgH, m.scroll, m.threadsDefaultExpand, m.unreadAnchorID, m.unreadCount, m.members, m.tasks, m.actions)
+	}
+	return m.currentMainLines(contentWidth)
+}
+
+func buildOfficeViewportSuffix(messages []brokerMessage, expanded map[string]bool, contentWidth, msgH, scroll int, threadsDefaultExpand bool, unreadAnchorID string, unreadCount int, members []channelMember, tasks []channelTask, actions []channelAction) []renderedLine {
+	tail := buildLiveWorkLines(members, tasks, actions, contentWidth, "")
+	return buildOfficeViewportSuffixWithTail(messages, expanded, contentWidth, msgH, scroll, threadsDefaultExpand, unreadAnchorID, unreadCount, tail)
+}
+
+func buildOneOnOneViewportSuffix(messages []brokerMessage, actions []channelAction, tasks []channelTask, members []channelMember, expanded map[string]bool, contentWidth, msgH, scroll int, agentName, agentSlug, unreadAnchorID string, unreadCount int) []renderedLine {
+	var tail []renderedLine
+	tail = append(tail, buildDirectExecutionLines(actions, agentSlug, contentWidth)...)
+	tail = append(tail, buildLiveWorkLines(members, tasks, nil, contentWidth, agentSlug)...)
+	if len(messages) == 0 {
+		limit := msgH + scroll
+		if limit < 1 {
+			limit = 1
+		}
+		lines := append(buildOneOnOneMessageLines(messages, expanded, contentWidth, agentName, unreadAnchorID, unreadCount), tail...)
+		if len(lines) > limit {
+			return cloneRenderedLines(lines[len(lines)-limit:])
+		}
+		return lines
+	}
+	return buildOfficeViewportSuffixWithTail(messages, expanded, contentWidth, msgH, scroll, true, unreadAnchorID, unreadCount, tail)
+}
+
+func buildOfficeViewportSuffixWithTail(messages []brokerMessage, expanded map[string]bool, contentWidth, msgH, scroll int, threadsDefaultExpand bool, unreadAnchorID string, unreadCount int, tail []renderedLine) []renderedLine {
+	limit := msgH + scroll
+	if limit < 1 {
+		limit = 1
+	}
+
+	if len(messages) == 0 {
+		lines := append(buildOfficeMessageLines(messages, expanded, contentWidth, threadsDefaultExpand, unreadAnchorID, unreadCount), tail...)
+		if len(lines) > limit {
+			return cloneRenderedLines(lines[len(lines)-limit:])
+		}
+		return lines
+	}
+
+	threaded := officeThreadedMessages(messages, expanded, threadsDefaultExpand)
+	collected := append([]renderedLine(nil), tail...)
+	if len(collected) > limit {
+		collected = cloneRenderedLines(collected[len(collected)-limit:])
+	}
+	if len(collected) >= limit {
+		return collected
+	}
+
+	for i := len(threaded) - 1; i >= 0; i-- {
+		block := renderOfficeMessageBlock(threaded[i], contentWidth, unreadAnchorID, unreadCount)
+		if i == 0 {
+			block = append([]renderedLine{{Text: renderDateSeparator(contentWidth, "Today")}}, block...)
+		}
+		collected = prependRenderedLines(collected, block)
+		if len(collected) > limit {
+			collected = cloneRenderedLines(collected[len(collected)-limit:])
+		}
+		if len(collected) >= limit {
+			return collected
+		}
+	}
+
+	return collected
+}
+
+func officeThreadedMessages(messages []brokerMessage, expanded map[string]bool, threadsDefaultExpand bool) []threadedMessage {
+	if !threadsDefaultExpand {
+		for _, msg := range messages {
+			if msg.ReplyTo != "" || !hasThreadReplies(messages, msg.ID) {
+				continue
+			}
+			if _, ok := expanded[msg.ID]; !ok {
+				expanded[msg.ID] = false
+			}
+		}
+	}
+	return flattenThreadMessages(messages, expanded)
+}
+
+func renderOfficeMessageBlock(tm threadedMessage, contentWidth int, unreadAnchorID string, unreadCount int) []renderedLine {
+	msg := tm.Message
+	mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
+	statusStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#CBD5E1")).Italic(true)
+
+	var lines []renderedLine
+	if unreadAnchorID != "" && msg.ID == unreadAnchorID {
+		lines = append(lines, renderedLine{Text: renderUnreadDivider(contentWidth, unreadCount)})
+	}
+	ts := msg.Timestamp
+	if len(ts) > 19 {
+		ts = ts[11:19]
+	}
+
+	color := agentColorMap[msg.From]
+	if color == "" {
+		color = "#9CA3AF"
+	}
+	nameStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color(color)).
+		Bold(true)
+	ruleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(color))
+
+	appendWrappedLine := func(text string) {
+		wrapped := appendWrapped(nil, contentWidth, text)
+		for _, line := range wrapped {
+			lines = append(lines, renderedLine{Text: line})
+		}
+	}
+
+	if strings.HasPrefix(msg.Kind, "human_") {
+		lines = append(lines, renderedLine{Text: ""})
+		headerPrefix := "  " + strings.Repeat("  ", tm.Depth)
+		if tm.Depth > 0 {
+			headerPrefix += "↳ "
+		}
+		meta := fmt.Sprintf("for you · %s · %s", humanMessageLabel(msg.Kind), msg.ID)
+		if tm.Depth > 0 {
+			meta += fmt.Sprintf(" · thread reply to %s", tm.ParentLabel)
+		}
+		appendWrappedLine(fmt.Sprintf("%s%s %s  %s  %s",
+			headerPrefix,
+			agentAvatar(msg.From),
+			nameStyle.Render(displayName(msg.From)),
+			mutedStyle.Render(ts),
+			lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render(meta),
+		))
+
+		prefix := "  " + strings.Repeat("  ", tm.Depth)
+		if tm.Depth > 0 {
+			prefix += lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render("┆") + " "
+		} else {
+			prefix += lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render("│") + " "
+		}
+		titleLine := msg.Title
+		if titleLine == "" {
+			titleLine = defaultHumanMessageTitle(msg.Kind, msg.From)
+		}
+		appendWrappedLine(prefix + subtlePill("for you", "#FEF3C7", "#92400E") + " " + lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F8FAFC")).Render(titleLine))
+		textPart, a2uiRendered := renderA2UIBlocks(msg.Content, contentWidth-4)
+		for _, paragraph := range strings.Split(textPart, "\n") {
+			paragraph = highlightMentions(paragraph, agentColorMap)
+			appendWrappedLine(prefix + paragraph)
+		}
+		if a2uiRendered != "" {
+			for _, lineText := range strings.Split(a2uiRendered, "\n") {
+				lines = append(lines, renderedLine{Text: prefix + lineText})
+			}
+		}
+		return lines
+	}
+
+	if msg.Kind == "automation" || msg.From == "nex" {
+		lines = append(lines, renderedLine{Text: ""})
+		source := msg.Source
+		if source == "" {
+			source = "context graph"
+		} else {
+			source = strings.ReplaceAll(source, "_", " ")
+		}
+		meta := fmt.Sprintf("%s · automated · %s", source, msg.ID)
+		if tm.Depth > 0 {
+			meta += fmt.Sprintf(" · thread reply to %s", tm.ParentLabel)
+		}
+		textPart, a2uiRendered := renderA2UIBlocks(msg.Content, contentWidth-4)
+		titleLine := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(color)).Render(fallbackString(msg.Title, "Automation update"))
+		for _, lineText := range renderRuntimeEventCard(contentWidth, subtlePill("automation", "#F8FAFC", "#334155")+" "+titleLine, meta, "#7C3AED", strings.Split(textPart, "\n")) {
+			lines = append(lines, renderedLine{Text: "  " + lineText})
+		}
+		if a2uiRendered != "" {
+			for _, lineText := range strings.Split(a2uiRendered, "\n") {
+				lines = append(lines, renderedLine{Text: "    " + lineText})
+			}
+		}
+		return lines
+	}
+
+	if strings.HasPrefix(msg.Content, "[STATUS]") {
+		status := strings.TrimPrefix(msg.Content, "[STATUS] ")
+		titleLine := subtlePill("status", "#E2E8F0", "#334155") + " " + nameStyle.Render("@"+msg.From) + " " + statusStyle.Render("is "+status)
+		for _, lineText := range renderRuntimeEventCard(contentWidth, titleLine, mutedStyle.Render(ts), "#475569", nil) {
+			lines = append(lines, renderedLine{Text: "  " + lineText})
+		}
+		return lines
+	}
+
+	if msg.From == "system" && (msg.Kind == "routing" || msg.Kind == "stage") {
+		label := "routing"
+		if msg.Kind == "stage" {
+			label = "stage"
+		}
+		for _, lineText := range renderRuntimeEventCard(contentWidth, subtlePill(label, "#E5E7EB", "#334155")+" "+mutedStyle.Render(ts), msg.Content, "#475569", nil) {
+			lines = append(lines, renderedLine{Text: "  " + lineText})
+		}
+		return lines
+	}
+
+	mood := inferMood(msg.Content)
+	meta := roleLabel(msg.From) + " · " + msg.ID
+	if mood != "" {
+		meta += " · " + mood
+	}
+	if tm.Depth > 0 {
+		meta += fmt.Sprintf(" · thread reply to %s", tm.ParentLabel)
+	}
+	metaStyle := mutedStyle
+	if mood != "" {
+		metaStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(color))
+	}
+	lines = append(lines, renderedLine{Text: ""})
+	headerPrefix := "  " + strings.Repeat("  ", tm.Depth)
+	if tm.Depth > 0 {
+		headerPrefix += "↳ "
+	}
+	appendWrappedLine(fmt.Sprintf("%s%s %s  %s  %s", headerPrefix, agentAvatar(msg.From), nameStyle.Render(displayName(msg.From)), mutedStyle.Render(ts), metaStyle.Render(meta)))
+
+	prefix := "  " + strings.Repeat("  ", tm.Depth)
+	if tm.Depth > 0 {
+		prefix += ruleStyle.Render("┆") + " "
+	} else {
+		prefix += ruleStyle.Render("│") + " "
+	}
+
+	textPart, a2uiRendered := renderA2UIBlocks(msg.Content, contentWidth-4)
+	rendered := renderMarkdown(textPart, contentWidth-len(prefix)-2)
+	for _, paragraph := range strings.Split(rendered, "\n") {
+		paragraph = highlightMentions(paragraph, agentColorMap)
+		appendWrappedLine(prefix + paragraph)
+	}
+	if a2uiRendered != "" {
+		for _, lineText := range strings.Split(a2uiRendered, "\n") {
+			lines = append(lines, renderedLine{Text: prefix + lineText})
+		}
+	}
+	if reactionLine := renderReactions(msg.Reactions); reactionLine != "" {
+		appendWrappedLine(prefix + reactionLine)
+	}
+	if tm.Collapsed && tm.HiddenReplies > 0 {
+		var coloredNames []string
+		for _, p := range tm.ThreadParticipants {
+			pColor := agentColorMap[strings.TrimPrefix(strings.ToLower(p), "@")]
+			if pColor == "" {
+				for slug, name := range map[string]string{
+					"ceo": "CEO", "pm": "Product Manager", "fe": "Frontend Engineer", "be": "Backend Engineer",
+					"ai": "AI Engineer", "designer": "Designer", "cmo": "CMO", "cro": "CRO",
+				} {
+					if p == name {
+						pColor = agentColorMap[slug]
+						break
+					}
+				}
+			}
+			if pColor == "" {
+				pColor = "#ABABAD"
+			}
+			coloredNames = append(coloredNames, lipgloss.NewStyle().Foreground(lipgloss.Color(pColor)).Bold(true).Render(p))
+		}
+		participantStr := ""
+		if len(coloredNames) > 0 {
+			participantStr = "  " + strings.Join(coloredNames, ", ")
+		}
+		label := fmt.Sprintf("  ↩ %d repl%s%s", tm.HiddenReplies, pluralSuffix(tm.HiddenReplies), participantStr)
+		lines = append(lines, renderedLine{Text: label, ThreadID: msg.ID})
+	}
+
+	return lines
+}
+
+func prependRenderedLines(dst, prefix []renderedLine) []renderedLine {
+	if len(prefix) == 0 {
+		return dst
+	}
+	out := make([]renderedLine, 0, len(prefix)+len(dst))
+	out = append(out, prefix...)
+	out = append(out, dst...)
+	return out
+}

--- a/cmd/wuphf/channel_window.go
+++ b/cmd/wuphf/channel_window.go
@@ -9,6 +9,9 @@ import (
 
 func (m channelModel) currentMainViewportLines(contentWidth, msgH int) []renderedLine {
 	if m.isOneOnOne() {
+		if m.activeApp == officeAppRecovery {
+			return m.currentMainLines(contentWidth)
+		}
 		return buildOneOnOneViewportSuffix(m.messages, m.actions, m.tasks, m.members, m.expandedThreads, contentWidth, msgH, m.scroll, m.oneOnOneAgentName(), m.oneOnOneAgentSlug(), m.unreadAnchorID, m.unreadCount)
 	}
 	if m.activeApp == officeAppMessages {

--- a/cmd/wuphf/channel_workspace_state.go
+++ b/cmd/wuphf/channel_workspace_state.go
@@ -1,0 +1,314 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+type workspaceUIState struct {
+	BrokerConnected bool
+	Direct          bool
+	Channel         string
+	AgentName       string
+	AgentSlug       string
+	PeerCount       int
+	RunningTasks    int
+	OpenRequests    int
+	BlockingCount   int
+	IsolatedCount   int
+	UnreadCount     int
+	AwaySummary     string
+	Focus           string
+	NextStep        string
+	NeedsYou        *channelInterview
+	PrimaryTask     *channelTask
+	NoNex           bool
+	APIConfigured   bool
+}
+
+func (m channelModel) currentWorkspaceUIState() workspaceUIState {
+	snapshot := m.currentRuntimeSnapshot()
+	state := workspaceUIState{
+		BrokerConnected: m.brokerConnected,
+		Direct:          m.isOneOnOne(),
+		Channel:         m.activeChannel,
+		AgentName:       m.oneOnOneAgentName(),
+		AgentSlug:       m.oneOnOneAgentSlug(),
+		PeerCount:       len(m.members),
+		RunningTasks:    countRunningRuntimeTasks(snapshot.Tasks),
+		OpenRequests:    len(snapshot.Requests),
+		IsolatedCount:   countIsolatedRuntimeTasks(snapshot.Tasks),
+		UnreadCount:     m.unreadCount,
+		AwaySummary:     strings.TrimSpace(m.currentAwaySummary()),
+		Focus:           trimRecoverySentence(snapshot.Recovery.Focus),
+		NoNex:           config.ResolveNoNex(),
+		APIConfigured:   strings.TrimSpace(config.ResolveAPIKey("")) != "",
+	}
+
+	for _, req := range m.requests {
+		if isOpenInterviewStatus(req.Status) && (req.Blocking || req.Required) {
+			state.BlockingCount++
+		}
+	}
+	if req, ok := selectNeedsYouRequest(m.requests); ok {
+		reqCopy := req
+		state.NeedsYou = &reqCopy
+		if strings.TrimSpace(state.Focus) == "" {
+			state.Focus = req.TitleOrQuestion()
+		}
+	}
+	if tasks := recoveryActiveTasks(m.tasks, 1); len(tasks) > 0 {
+		taskCopy := tasks[0]
+		state.PrimaryTask = &taskCopy
+		if strings.TrimSpace(state.Focus) == "" {
+			state.Focus = taskCopy.Title
+		}
+	}
+	if state.NeedsYou != nil {
+		state.NextStep = "Answer " + state.NeedsYou.ID + " before the team moves further."
+	} else if len(snapshot.Recovery.NextSteps) > 0 {
+		state.NextStep = strings.TrimSpace(snapshot.Recovery.NextSteps[0])
+	} else if state.Direct {
+		state.NextStep = "Keep the discussion in this direct session or jump back with /switcher."
+	} else {
+		state.NextStep = "Tag a teammate, open /switcher, or use /recover to regain context."
+	}
+	return state
+}
+
+func (s workspaceUIState) headerMeta() string {
+	if s.Direct {
+		if !s.BrokerConnected {
+			return "  Direct session preview · only this agent can speak here"
+		}
+		parts := []string{"Direct conversation only"}
+		if s.RunningTasks > 0 {
+			parts = append(parts, fmt.Sprintf("%d running", s.RunningTasks))
+		}
+		if s.BlockingCount > 0 {
+			parts = append(parts, fmt.Sprintf("%d waiting on you", s.BlockingCount))
+		}
+		if strings.TrimSpace(s.Focus) != "" {
+			parts = append(parts, "focus: "+s.Focus)
+		}
+		return "  " + strings.Join(parts, " · ")
+	}
+	if !s.BrokerConnected {
+		return fmt.Sprintf("  Offline preview · manifest roster loaded · %d teammates ready for #%s", s.PeerCount, fallbackString(s.Channel, "general"))
+	}
+	parts := []string{
+		fmt.Sprintf("%d teammates", s.PeerCount),
+		fmt.Sprintf("%d running", s.RunningTasks),
+		fmt.Sprintf("%d open requests", s.OpenRequests),
+	}
+	if s.BlockingCount > 0 {
+		parts = append(parts, fmt.Sprintf("%d waiting on you", s.BlockingCount))
+	}
+	if strings.TrimSpace(s.Focus) != "" {
+		parts = append(parts, "focus: "+truncateText(s.Focus, 56))
+	}
+	return "  " + strings.Join(parts, " · ")
+}
+
+func (s workspaceUIState) defaultStatusLine(scrollHint string) string {
+	if s.Direct {
+		label := "offline preview"
+		if s.BrokerConnected {
+			label = "direct session live"
+		}
+		runtimeHint := "ready"
+		if strings.TrimSpace(s.Focus) != "" {
+			runtimeHint = s.Focus
+		} else if strings.TrimSpace(s.NextStep) != "" {
+			runtimeHint = s.NextStep
+		}
+		return fmt.Sprintf(" %s │ %s │ %s │ Ctrl+J newline │ /switcher │ /doctor", label, scrollHint, truncateText(runtimeHint, 72))
+	}
+	if !s.BrokerConnected {
+		return " Team offline │ manifest preview only │ /doctor explains readiness"
+	}
+	if s.BlockingCount > 0 && s.NeedsYou != nil {
+		return fmt.Sprintf(" Needs you now │ %s │ /request answer %s │ /recover", truncateText(s.NeedsYou.TitleOrQuestion(), 72), s.NeedsYou.ID)
+	}
+	if strings.TrimSpace(s.AwaySummary) != "" && s.UnreadCount > 0 {
+		return fmt.Sprintf(" While away │ %s │ %s │ /recover", truncateText(s.AwaySummary, 72), scrollHint)
+	}
+	if s.PrimaryTask != nil {
+		return fmt.Sprintf(" Focus │ %s │ %s │ /switcher │ /doctor", truncateText(s.PrimaryTask.Title, 72), scrollHint)
+	}
+	return fmt.Sprintf(" Office live │ %s │ /switcher │ /doctor", scrollHint)
+}
+
+func (s workspaceUIState) sidebarSummaryLine(activeApp officeApp) string {
+	channelLabel := "#" + fallbackString(s.Channel, "general")
+	if !s.BrokerConnected {
+		return fmt.Sprintf("Offline preview · %s · %d teammates", channelLabel, s.PeerCount)
+	}
+
+	parts := []string{sidebarViewLabel(activeApp), channelLabel}
+	switch {
+	case s.BlockingCount > 0:
+		parts = append(parts, fmt.Sprintf("%d waiting", s.BlockingCount))
+	case s.RunningTasks > 0:
+		parts = append(parts, fmt.Sprintf("%d running", s.RunningTasks))
+	case s.OpenRequests > 0:
+		parts = append(parts, fmt.Sprintf("%d requests", s.OpenRequests))
+	case s.PeerCount > 0:
+		parts = append(parts, fmt.Sprintf("%d teammates", s.PeerCount))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func (s workspaceUIState) sidebarHintLine() string {
+	switch {
+	case !s.BrokerConnected:
+		return "/doctor explains tmux, provider, and setup readiness"
+	case s.BlockingCount > 0 && s.NeedsYou != nil:
+		return fmt.Sprintf("Need you: %s · /request answer %s", s.NeedsYou.TitleOrQuestion(), s.NeedsYou.ID)
+	case strings.TrimSpace(s.AwaySummary) != "" && s.UnreadCount > 0:
+		return "While away: " + s.AwaySummary
+	case !s.NoNex && !s.APIConfigured:
+		return "/init finishes setup · /doctor explains what is missing"
+	case strings.TrimSpace(s.NextStep) != "":
+		return s.NextStep
+	case strings.TrimSpace(s.Focus) != "":
+		return "Focus: " + s.Focus
+	default:
+		return "Use /switcher or /recover to move through live office context"
+	}
+}
+
+func sidebarViewLabel(activeApp officeApp) string {
+	switch activeApp {
+	case officeAppRecovery:
+		return "Recovery view"
+	case officeAppTasks:
+		return "Task board"
+	case officeAppRequests:
+		return "Decision queue"
+	case officeAppPolicies:
+		return "Insights view"
+	case officeAppCalendar:
+		return "Calendar view"
+	case officeAppArtifacts:
+		return "Artifacts view"
+	case officeAppSkills:
+		return "Skills view"
+	default:
+		return "Message lane"
+	}
+}
+
+func (m channelModel) buildOfficeIntroLines(contentWidth int) []renderedLine {
+	state := m.currentWorkspaceUIState()
+	mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
+	lines := []renderedLine{
+		{Text: renderDateSeparator(contentWidth, "Office overview")},
+		{Text: ""},
+	}
+	title := subtlePill("office", "#F8FAFC", "#1264A3") + " " + lipgloss.NewStyle().Bold(true).Render("The WUPHF Office")
+	body := "Welcome to The WUPHF Office. Live company-building coordination across channels, direct sessions, tasks, and decisions."
+	extra := []string{
+		fmt.Sprintf("%d teammates · %d running tasks · %d open requests", state.PeerCount, state.RunningTasks, state.OpenRequests),
+	}
+	if strings.TrimSpace(state.Focus) != "" {
+		extra = append(extra, "Focus: "+state.Focus)
+	}
+	if strings.TrimSpace(state.NextStep) != "" {
+		extra = append(extra, "Next: "+state.NextStep)
+	}
+	for _, line := range renderRuntimeEventCard(contentWidth, title, body, "#1264A3", extra) {
+		lines = append(lines, renderedLine{Text: "  " + line})
+	}
+
+	readinessBody := "The office is live and ready for real collaboration."
+	readinessAccent := "#15803D"
+	readinessTitle := subtlePill("ready", "#DCFCE7", "#166534") + " " + lipgloss.NewStyle().Bold(true).Render("Ready to work")
+	readinessExtra := []string{"Use /switcher to jump anywhere in the office."}
+	if !state.BrokerConnected {
+		readinessAccent = "#D97706"
+		readinessTitle = subtlePill("preview", "#FEF3C7", "#92400E") + " " + lipgloss.NewStyle().Bold(true).Render("Offline preview")
+		readinessBody = "You are looking at the manifest roster, not the live tmux-backed office."
+		readinessExtra = []string{"Launch WUPHF to connect the live office runtime.", "/doctor shows tmux, provider, and setup readiness."}
+	} else if state.NoNex {
+		readinessExtra = append(readinessExtra, "Nex is disabled for this run; memory and integrations are local-only.")
+	} else if !state.APIConfigured {
+		readinessAccent = "#B45309"
+		readinessTitle = subtlePill("setup", "#FEF3C7", "#92400E") + " " + lipgloss.NewStyle().Bold(true).Render("Finish setup")
+		readinessBody = "The office is up, but Nex-backed memory and integrations are not configured yet."
+		readinessExtra = []string{"Run /init to finish API-key setup.", "/doctor explains what is still missing."}
+	}
+	for _, line := range renderRuntimeEventCard(contentWidth, readinessTitle, readinessBody, readinessAccent, readinessExtra) {
+		lines = append(lines, renderedLine{Text: "  " + line})
+	}
+
+	if state.NeedsYou != nil {
+		for _, line := range buildNeedsYouLines(m.requests, contentWidth) {
+			lines = append(lines, line)
+		}
+	} else {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: mutedStyle.Render("  Suggested: /switcher for active work, /recover for context, or tag a teammate in #general.")})
+	}
+	return lines
+}
+
+func (m channelModel) buildDirectIntroLines(contentWidth int) []renderedLine {
+	state := m.currentWorkspaceUIState()
+	mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
+	lines := []renderedLine{
+		{Text: renderDateSeparator(contentWidth, "Direct session")},
+		{Text: ""},
+	}
+	title := subtlePill("1:1", "#F8FAFC", "#334155") + " " + lipgloss.NewStyle().Bold(true).Render("Direct session with "+m.oneOnOneAgentName())
+	body := "Direct session reset. Agent pane reloaded in place. This surface is just you and the selected agent. Office channels and teammate chatter stay out of the way."
+	extra := []string{"Use /switcher to jump back to the office."}
+	if strings.TrimSpace(state.Focus) != "" {
+		extra = append(extra, "Focus: "+state.Focus)
+	}
+	if strings.TrimSpace(state.NextStep) != "" {
+		extra = append(extra, "Next: "+state.NextStep)
+	}
+	for _, line := range renderRuntimeEventCard(contentWidth, title, body, "#334155", extra) {
+		lines = append(lines, renderedLine{Text: "  " + line})
+	}
+
+	if !state.BrokerConnected {
+		for _, line := range renderRuntimeEventCard(contentWidth, subtlePill("preview", "#FEF3C7", "#92400E")+" "+lipgloss.NewStyle().Bold(true).Render("Direct preview only"), "The runtime is not attached yet, so this pane is a local preview of the direct session.", "#D97706", []string{"/doctor explains readiness.", "Launch WUPHF without stale tmux state to resume the live session."}) {
+			lines = append(lines, renderedLine{Text: "  " + line})
+		}
+	} else {
+		lines = append(lines, renderedLine{Text: mutedStyle.Render("  Suggested: ask for planning help, a review pass, or a direct decision memo.")})
+	}
+	return lines
+}
+
+func (m channelModel) buildOfficeFeedLines(contentWidth int) []renderedLine {
+	if len(m.messages) == 0 {
+		lines := m.buildOfficeIntroLines(contentWidth)
+		lines = append(lines, buildLiveWorkLines(m.members, m.tasks, m.actions, contentWidth, "")...)
+		return lines
+	}
+	lines := buildOfficeMessageLines(m.messages, m.expandedThreads, contentWidth, m.threadsDefaultExpand, m.unreadAnchorID, m.unreadCount)
+	lines = append(lines, buildLiveWorkLines(m.members, m.tasks, m.actions, contentWidth, "")...)
+	return lines
+}
+
+func (m channelModel) buildDirectFeedLines(contentWidth int) []renderedLine {
+	if len(m.messages) == 0 {
+		lines := m.buildDirectIntroLines(contentWidth)
+		focusSlug := m.oneOnOneAgentSlug()
+		lines = append(lines, buildDirectExecutionLines(m.actions, focusSlug, contentWidth)...)
+		lines = append(lines, buildLiveWorkLines(m.members, m.tasks, nil, contentWidth, focusSlug)...)
+		return lines
+	}
+	lines := buildOneOnOneMessageLines(m.messages, m.expandedThreads, contentWidth, m.oneOnOneAgentName(), m.unreadAnchorID, m.unreadCount)
+	focusSlug := m.oneOnOneAgentSlug()
+	lines = append(lines, buildDirectExecutionLines(m.actions, focusSlug, contentWidth)...)
+	lines = append(lines, buildLiveWorkLines(m.members, m.tasks, nil, contentWidth, focusSlug)...)
+	return lines
+}

--- a/cmd/wuphf/channel_workspace_state_test.go
+++ b/cmd/wuphf/channel_workspace_state_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildOfficeIntroLinesUsesWorkspaceState(t *testing.T) {
+	m := newChannelModel(false)
+	m.brokerConnected = true
+	m.members = []channelMember{{Slug: "ceo", Name: "CEO"}, {Slug: "pm", Name: "Product Manager"}}
+	m.tasks = []channelTask{{ID: "task-1", Title: "Ship launch", Status: "in_progress", Owner: "pm"}}
+	m.requests = []channelInterview{{ID: "req-1", Kind: "approval", Status: "pending", Title: "Approve launch copy", Question: "Approve launch copy?", From: "ceo"}}
+
+	lines := m.buildOfficeIntroLines(96)
+	plain := stripANSI(joinRenderedLines(lines))
+
+	if !strings.Contains(plain, "Welcome to The WUPHF Office.") {
+		t.Fatalf("expected office welcome copy, got %q", plain)
+	}
+	if !strings.Contains(plain, "Ready to work") {
+		t.Fatalf("expected ready-to-work card, got %q", plain)
+	}
+	if !strings.Contains(plain, "Use /switcher to jump anywhere in the office.") {
+		t.Fatalf("expected switcher guidance, got %q", plain)
+	}
+}
+
+func TestBuildOfficeIntroLinesShowsOfflinePreviewGuidance(t *testing.T) {
+	m := newChannelModel(false)
+	m.brokerConnected = false
+
+	lines := m.buildOfficeIntroLines(96)
+	plain := stripANSI(joinRenderedLines(lines))
+
+	if !strings.Contains(plain, "Offline preview") {
+		t.Fatalf("expected offline preview messaging, got %q", plain)
+	}
+	if !strings.Contains(plain, "/doctor shows tmux, provider, and setup readiness.") {
+		t.Fatalf("expected doctor guidance, got %q", plain)
+	}
+}
+
+func TestBuildDirectIntroLinesPreservesDirectSessionResetLanguage(t *testing.T) {
+	m := newChannelModel(false)
+	m.sessionMode = "1o1"
+	m.oneOnOneAgent = "be"
+
+	lines := m.buildDirectIntroLines(96)
+	plain := stripANSI(joinRenderedLines(lines))
+
+	if !strings.Contains(plain, "Direct session reset. Agent pane reloaded in place.") {
+		t.Fatalf("expected direct-session reset copy, got %q", plain)
+	}
+	if !strings.Contains(plain, "Use /switcher to jump back to the office.") {
+		t.Fatalf("expected switcher guidance in direct intro, got %q", plain)
+	}
+}
+
+func TestCurrentHeaderMetaUsesWorkspaceStateForOfficeMessages(t *testing.T) {
+	m := newChannelModel(false)
+	m.activeApp = officeAppMessages
+	m.activeChannel = "launch"
+	m.brokerConnected = true
+	m.members = []channelMember{{Slug: "ceo", Name: "CEO"}, {Slug: "pm", Name: "Product Manager"}}
+	m.tasks = []channelTask{{ID: "task-1", Title: "Ship launch", Status: "in_progress", Owner: "pm"}}
+	m.requests = []channelInterview{{ID: "req-1", Kind: "approval", Status: "pending", Title: "Approve launch copy", Question: "Approve launch copy?", From: "ceo", Blocking: true}}
+
+	meta := stripANSI(m.currentHeaderMeta())
+	if !strings.Contains(meta, "2 teammates") {
+		t.Fatalf("expected teammate count in header meta, got %q", meta)
+	}
+	if !strings.Contains(meta, "1 waiting on you") {
+		t.Fatalf("expected blocking request count in header meta, got %q", meta)
+	}
+}

--- a/docs/cc-agent-deep-analysis.md
+++ b/docs/cc-agent-deep-analysis.md
@@ -1,0 +1,1646 @@
+# CC-agent Full-System Analysis
+
+## Scope
+
+This analysis is based on direct code inspection of the recovered `CC-agent` repo at:
+
+- `/Users/najmuzzaman/Documents/Codex/CC-agent`
+
+This is intentionally broader than an "agent runtime" review. It covers:
+
+- product philosophy
+- UI architecture
+- input and chat feel
+- setup and doctor flows
+- performance
+- state models and state machines
+- execution/runtime design
+- tools, permissions, and MCP
+- plugins and skills
+- memory and compaction
+- delight, polish, and playful features
+- architectural lessons for WUPHF
+
+Execution roadmap:
+
+- [cc-agent-implementation-roadmap.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-implementation-roadmap.md)
+
+## Files Inspected
+
+Core runtime and entry:
+
+- `README.md`
+- `package.json`
+- `scripts/run-recovered.ts`
+- `src/entrypoints/cli.tsx`
+- `src/ink.ts`
+- `src/screens/REPL.tsx`
+- `src/state/AppStateStore.ts`
+- `src/query.ts`
+- `src/QueryEngine.ts`
+
+Tools, tasks, and modes:
+
+- `src/tools.ts`
+- `src/tasks.ts`
+- `src/tools/AgentTool/AgentTool.tsx`
+- `src/tasks/LocalAgentTask/LocalAgentTask.tsx`
+- `src/tasks/RemoteAgentTask/RemoteAgentTask.tsx`
+- `src/tools/EnterPlanModeTool/EnterPlanModeTool.ts`
+- `src/tools/EnterWorktreeTool/EnterWorktreeTool.ts`
+- `src/utils/permissions/PermissionMode.ts`
+
+Memory and context:
+
+- `src/services/SessionMemory/sessionMemory.ts`
+- `src/services/contextCollapse/index.ts`
+- `src/services/compact/autoCompact.ts`
+
+MCP, bridge, and remote:
+
+- `src/services/mcp/client.ts`
+- `src/services/mcp/MCPConnectionManager.tsx`
+- `src/services/mcp/channelPermissions.ts`
+- `src/bridge/bridgeMain.ts`
+
+Commands, plugins, and skills:
+
+- `src/commands.ts`
+- `src/utils/processUserInput/processUserInput.ts`
+- `src/services/plugins/PluginInstallationManager.ts`
+- `src/skills/loadSkillsDir.ts`
+- `src/services/teamMemorySync/index.ts`
+- `src/services/analytics/growthbook.ts`
+
+UI, polish, and performance:
+
+- `src/screens/Doctor.tsx`
+- `src/components/VirtualMessageList.tsx`
+- `src/hooks/useVirtualScroll.ts`
+- `src/components/PromptInput/PromptInput.tsx`
+- `src/components/FullscreenLayout.tsx`
+- `src/components/design-system/FuzzyPicker.tsx`
+- `src/components/PromptInput/PromptInputFooter.tsx`
+- `src/components/PromptInput/PromptInputFooterLeftSide.tsx`
+- `src/components/design-system/ThemeProvider.tsx`
+- `src/components/LogoV2/WelcomeV2.tsx`
+- `src/components/Spinner.tsx`
+- `src/services/PromptSuggestion/speculation.ts`
+- `src/services/tips/tipScheduler.ts`
+- `src/buddy/CompanionSprite.tsx`
+- `src/services/awaySummary.ts`
+- `src/keybindings/defaultBindings.ts`
+- `src/keybindings/schema.ts`
+- `src/keybindings/useKeybinding.ts`
+- `src/context/overlayContext.tsx`
+- `src/ink/screen.ts`
+- `src/ink/termio/osc.ts`
+- `src/ink/useTerminalNotification.ts`
+- `src/bridge/bridgeUI.ts`
+- `src/components/CoordinatorAgentStatus.tsx`
+- `src/components/tasks/InProcessTeammateDetailDialog.tsx`
+- `src/tasks/InProcessTeammateTask/types.ts`
+- `src/state/teammateViewHelpers.ts`
+- `src/state/selectors.ts`
+- `src/utils/swarm/spawnInProcess.ts`
+
+## Executive Summary
+
+CC-agent is not just a strong execution substrate. It is a deliberately designed product operating system for agent work.
+
+Its strengths are distributed across the whole experience:
+
+- startup is treated as a product feature
+- state is explicit and broad
+- the REPL is a real orchestration surface
+- the transcript is performance-engineered
+- setup and doctor flows are first-class
+- keyboard navigation and overlays are explicit subsystems
+- mouse, selection, clipboard, and tmux behavior are treated as runtime infrastructure
+- permissions and mode switches are runtime concepts, not just prompt text
+- plugins and skills are platform primitives
+- memory and compaction are active systems
+- delight features are intentional, not accidental
+
+The main lesson for WUPHF is not "copy their UI."
+
+The real lesson is:
+
+- CC-agent turns almost every important concern into an explicit subsystem.
+- WUPHF still lets too much of its behavior emerge from chat, broker side effects, and loosely coupled surfaces.
+
+At the same time, WUPHF already has advantages CC-agent does not:
+
+- a stronger multi-agent product metaphor
+- visible office structure
+- richer organizational context via Nex
+- better channel/task/calendar/policy language
+- clearer product identity as an autonomous company runtime
+
+So the opportunity is:
+
+- keep WUPHF's office/product identity
+- borrow CC-agent's rigor in runtime architecture, state normalization, setup/readiness, transcript performance, and user-facing execution clarity
+
+## Big Picture: What CC-agent Is Really Optimizing For
+
+### 1. Long-lived agent sessions
+
+The codebase assumes sessions are not short conversations. They are ongoing working environments that need:
+
+- recovery
+- summarization
+- compaction
+- background tasks
+- stable permissions
+- persistent artifacts
+- scalable rendering
+
+That assumption shows up everywhere, from `QueryEngine` to transcript virtualization to session memory.
+
+### 2. Trust through explicit machinery
+
+CC-agent does not rely on "the model will remember" as a primary strategy.
+
+Instead it builds trust with:
+
+- visible tasks
+- explicit permission modes
+- explicit MCP connection state
+- explicit doctor checks
+- explicit feature gates
+- explicit teammate/background runtime state
+
+### 3. Product feel matters as much as raw capability
+
+CC-agent invests in:
+
+- welcome theatrics
+- animated spinners
+- companion visuals
+- prompt suggestions
+- tips during waiting
+- away summaries
+
+That means the team behind it understands an important product truth:
+
+- waiting time, recovery time, and empty time are product moments, not dead space
+
+### 4. Extensibility is treated as part of the core, not an afterthought
+
+Plugins, skills, MCP, remote sessions, bridge processes, and feature flags are not bolted on. They are part of the runtime model.
+
+That is one of the clearest architectural differences from WUPHF today.
+
+## Product Philosophy and Interaction Model
+
+### What CC-agent believes
+
+From the code, CC-agent seems to optimize for:
+
+- the agent as a persistent operator
+- the terminal as a serious workspace
+- flexible modes over one fixed product shape
+- progressive disclosure
+- power-user extensibility
+- background execution as a normal case
+
+### What WUPHF believes
+
+WUPHF optimizes for:
+
+- the office as the primary metaphor
+- visible teamwork
+- human oversight in public
+- tasks, channels, policy, and coordination
+- organization-aware execution
+
+### What WUPHF should borrow philosophically
+
+- treat session health as a first-class product surface
+- treat idle/waiting time as a UX opportunity
+- treat runtime state as a product object, not an internal detail
+- treat capabilities, plugins, and tools as governable platform surfaces
+
+### What WUPHF should not borrow
+
+- do not collapse into a single huge REPL product
+- do not lose the office metaphor
+- do not optimize primarily for solo power-user shell behavior at the expense of office visibility
+
+## UI Architecture and Layout Lessons
+
+### REPL as orchestration center
+
+`src/screens/REPL.tsx` is massive because it is doing real orchestration work, not just rendering messages.
+
+It coordinates:
+
+- transcript
+- permissions
+- MCP and bridge state
+- background tasks
+- plugin state
+- teammate state
+- notifications
+- usage/cost
+- prompt suggestions
+- external panels
+
+Lesson:
+
+- centralized orchestration surfaces create coherence
+- but giant god components become hard to reason about
+
+WUPHF implication:
+
+- WUPHF needs a stronger normalized channel/runtime state model
+- but should avoid letting `cmd/wuphf/channel.go` become a direct clone of the CC-agent REPL monolith
+
+### Fullscreen layout discipline
+
+`FullscreenLayout.tsx` shows care around:
+
+- prompt chrome
+- sticky bottom behavior
+- unseen separators
+- overlay layering
+- information density
+
+Lesson:
+
+- layout rules must be treated as architecture, not as scattered styling
+
+WUPHF implication:
+
+- channel header, runtime strip, sidebar, main stream, thread panel, and composer should be governed by clearer layout rules instead of ad hoc growth
+
+### Theme system
+
+`ThemeProvider.tsx` is not just a context wrapper. It handles:
+
+- preview
+- cancel/save flows
+- system theme tracking
+- resolved theme semantics
+
+Lesson:
+
+- product polish requires real theme/state management, not just color constants
+
+WUPHF implication:
+
+- if WUPHF ever expands theming or display modes, it should do so with an explicit theme state system, not scattered flags
+
+## Keyboard Navigation, Information Hierarchy, and Terminal Ergonomics
+
+### Keyboard navigation is treated as architecture
+
+CC-agent does not treat keyboard handling as scattered hotkeys. It has a real keybinding model.
+
+From `defaultBindings.ts`, `schema.ts`, and `useKeybinding.ts`:
+
+- bindings are organized by context:
+  - `Global`
+  - `Chat`
+  - `Autocomplete`
+  - `Confirmation`
+  - `Help`
+  - `Transcript`
+  - `HistorySearch`
+  - `Task`
+  - `ThemePicker`
+  - `Settings`
+  - `Tabs`
+  - `Attachments`
+  - `Footer`
+  - `MessageSelector`
+  - `DiffDialog`
+  - `ModelPicker`
+  - `Select`
+  - `Plugin`
+- action resolution respects context precedence instead of letting every component listen ad hoc
+- chord sequences are supported explicitly, including pending-chord state
+- bindings are platform-aware and terminal-aware:
+  - Windows VT quirks
+  - OS-specific paste shortcuts
+  - fallbacks where terminal support is unreliable
+
+This is a big quality-of-life difference.
+
+The product consequence is:
+
+- keyboard behavior feels consistent across screens
+- overlays do not steal keys unpredictably
+- help hints can be truthful because they derive from a real action model
+
+WUPHF implication:
+
+- keyboard navigation should become a first-class model, not a growing set of switch cases in channel code
+- command/help/overlay/dialog contexts should be explicit and centrally resolved
+
+### Information hierarchy is enforced by reusable layout rules
+
+`FullscreenLayout.tsx` and `FuzzyPicker.tsx` show that CC-agent cares deeply about what the eye lands on first.
+
+Important details:
+
+- the transcript and the input area are separate layout zones
+- sticky prompt headers are controlled deliberately instead of emerging from scroll state by accident
+- "N new messages" is a first-class concept with its own divider and pill
+- previews move to the right or bottom depending on terminal width
+- suggestion overlays are anchored relative to the composer rather than drawn wherever convenient
+- narrow terminals get compact behavior instead of a broken full-size layout
+
+This makes navigation feel easier because the product is constantly answering:
+
+- where am I?
+- what changed?
+- what can I do next?
+
+WUPHF implication:
+
+- channel/header/runtime strip/sidebar/composer need stricter hierarchy rules
+- unread and "new since you looked away" should become first-class channel concepts
+- search/open/picker surfaces should adapt to available width instead of rendering as one-size-fits-all blocks
+
+### Overlay focus and escape behavior are explicit
+
+`overlayContext.tsx` is small, but it solves an important class of UX bugs.
+
+The system distinguishes:
+
+- overlays that are active
+- overlays that are modal
+- overlays that should not disable typing, like autocomplete
+
+It then uses that to coordinate:
+
+- whether `Esc` dismisses an overlay or cancels running work
+- whether TextInput should keep focus
+- when a full-frame invalidation is needed to avoid ghost rows after overlay close
+
+This is exactly the kind of small infrastructure that prevents terminal UIs from feeling haunted.
+
+WUPHF implication:
+
+- overlay/dialog/autocomplete/thread focus should share one explicit focus model
+- `Esc` semantics in office, `1:1`, autocomplete, thread view, and future dialogs should be coordinated instead of incidental
+
+### Mouse support is selection-first, not just click-first
+
+The most interesting low-level lesson is in `screen.ts`.
+
+CC-agent treats terminal selection as a product feature:
+
+- selection highlighting uses a dedicated background overlay instead of naive inverse-video
+- existing foreground styling is preserved where possible
+- gutters and diff sigils can be marked `noSelect`
+- click-drag over a diff yields clean copied text instead of noisy line markers
+- selection state is kept aligned when blitting or shifting screen regions
+
+This is far beyond "turn mouse on."
+
+It means the team optimized for:
+
+- native-feeling copy behavior
+- readable selection highlight
+- mouse support that does not trash text semantics
+
+WUPHF implication:
+
+- mouse support should be decided at the terminal/rendering level, not only at the Bubble Tea event layer
+- if WUPHF supports selection, it should do so intentionally:
+  - what is selectable
+  - what is excluded
+  - what happens in diffs/logs/cards
+
+### tmux support is part of the product contract
+
+CC-agent’s tmux handling is unusually rigorous.
+
+From `osc.ts`, `useTerminalNotification.ts`, `bridgeUI.ts`, and related code:
+
+- OSC sequences are wrapped for tmux and GNU screen passthrough
+- clipboard behavior chooses an honest path:
+  - native clipboard when local and safe
+  - tmux buffer when inside tmux
+  - OSC 52 when that is the only option
+- the code explicitly handles:
+  - `allow-passthrough`
+  - stale SSH env problems
+  - iTerm2 quirks
+  - tmux bell behavior
+  - progress reporting through terminal notifications
+- the bridge status UI counts its own rendered lines so redraws under tmux remain clean
+
+This is a strong philosophical lesson:
+
+- tmux is not an external shell detail
+- tmux is a supported runtime environment with its own correctness rules
+
+WUPHF implication:
+
+- tmux-specific clipboard, bell, status, and selection behavior should be treated as owned product behavior
+- WUPHF should decide explicitly how mouse, copy, notifications, and status redraws work under tmux rather than letting defaults fight each other
+
+## Moment-to-Moment Chat Experience
+
+### Input is a serious subsystem
+
+`PromptInput.tsx` and `processUserInput.ts` show that CC-agent treats input as layered processing, not just text submission.
+
+It handles:
+
+- commands
+- attachments
+- hooks
+- metadata visibility
+- bridge-safe handling
+- rich composer state
+
+Lesson:
+
+- moment-to-moment quality comes from input semantics, not only transcript rendering
+
+WUPHF implication:
+
+- slash commands, multiline composition, attachments, workflow prompts, and integration-triggered prompts should sit in a more deliberate input pipeline
+
+### Human interviews are treated like a real product flow
+
+This is one of the clearest small-but-important strengths in CC-agent.
+
+The human interview path is not just:
+
+- ask a question
+- wait for freeform text
+
+It is a proper guided interaction system built around:
+
+- `AskUserQuestionPermissionRequest/QuestionView.tsx`
+- `PreviewQuestionView.tsx`
+- `SubmitQuestionsView.tsx`
+- `QuestionNavigationBar.tsx`
+
+What makes it good:
+
+- interviews are visually separated from the transcript
+- question progress is explicit
+- answered vs unanswered state is visible
+- the current question is highlighted
+- terminal width is respected with tab truncation logic
+- richer questions can have side-by-side preview panes
+- notes can be added without breaking structured answers
+- notes can be edited in the external editor
+- there is a final review step before submission
+- in plan mode there are explicit escape hatches:
+  - `Respond to Claude`
+  - `Finish plan interview`
+  - `Skip interview and plan immediately`
+
+The product lesson is:
+
+- when the agent needs structured input from the human, that should become a compact workflow, not a messy interruption in the transcript
+
+WUPHF implication:
+
+- blocking interviews in office mode should eventually become structured mini-flows with:
+  - progress
+  - completeness
+  - skip/continue semantics
+  - review-before-submit
+
+### Waiting is surfaced, not hidden
+
+`Spinner.tsx`, `tipScheduler.ts`, and speculative prompt suggestion services show a clear strategy:
+
+- never let the interface feel inert
+- provide progress and education during latency
+
+Lesson:
+
+- silence feels like brokenness
+- weak latency handling creates distrust
+
+WUPHF implication:
+
+- office and `1:1` sessions need stronger active-progress affordances
+- runtime strips and event cards were the right direction, but WUPHF still needs:
+  - better heartbeat/progress semantics
+  - clearer blocked/waiting-human moments
+  - more useful idle/empty-state behavior
+
+### Dialog etiquette is carefully designed
+
+CC-agent handles interruptive dialogs with more care than most terminal tools.
+
+Key examples from `REPL.tsx`:
+
+- active dialogs are prioritized through an explicit focus stack
+- blocking dialogs are suppressed while the user is actively typing
+- suppressed dialogs are still tracked, not lost
+- when a blocking overlay appears or disappears, scroll is re-pinned so the user never misses it
+- different dialog types have clear precedence:
+  - permission
+  - sandbox
+  - elicitation
+  - onboarding
+  - cost
+  - callouts
+
+This matters because it makes the interface feel respectful instead of jumpy.
+
+WUPHF implication:
+
+- channel and `1:1` blocked-state handling should adopt stronger dialog etiquette
+- "needs you" moments should be prioritized and displayed with clearer focus rules
+
+### Cancellation behavior preserves trust
+
+CC-agent makes interruption feel safer.
+
+Example from `REPL.tsx`:
+
+- when the user cancels mid-stream, partially generated assistant text is preserved before the interruption marker
+- pending prompt/permission queues are explicitly cleared or resolved
+- state resets do not silently eat visible work
+
+This is a small detail with big trust impact.
+
+WUPHF implication:
+
+- when users interrupt an agent or workflow, the channel should preserve the partial artifact or progress summary where possible instead of collapsing to a blunt "stopped"
+
+### Away/return moments are product moments
+
+`awaySummary.ts` is especially important. It acknowledges a real workflow:
+
+- the human leaves
+- the agent keeps working
+- the human returns
+- the product should summarize what happened
+
+WUPHF implication:
+
+- this is a strong fit for office mode
+- WUPHF should eventually support "while you were away" summaries per channel and per direct session
+
+## Micro-Interactions and Small UX Mechanics
+
+This is where a lot of CC-agent's quality really comes from.
+
+These are not the big architectural pillars. They are small decisions that make the product feel polished, respectful, and alive.
+
+### 1. Approval is collaborative, not binary
+
+`PermissionPrompt.tsx` supports:
+
+- approve or reject
+- optional feedback on approve
+- optional feedback on reject
+- Tab to expand the feedback field only when relevant
+- shortcut-driven approval paths
+
+The effect is:
+
+- users can steer execution at the exact decision point
+- approval becomes "yes, but do it like this" instead of just yes/no
+
+WUPHF implication:
+
+- approval gates for actions, workflows, reviews, and risky changes should support inline steering text, not only accept/deny
+
+### 2. Explanations are on-demand, not noisy
+
+`PermissionExplanation.tsx` lazily fetches a permission explanation only when the user asks for it.
+
+Important details:
+
+- explanation is opt-in
+- fetched only on shortcut use
+- loading has shimmer treatment
+- response includes risk level and reasoning
+
+Lesson:
+
+- expensive clarity should be available without becoming default noise
+
+WUPHF implication:
+
+- event cards and approval prompts should eventually support on-demand "why is this needed?" details
+
+### 3. The UI protects the user's typing flow
+
+From `REPL.tsx`:
+
+- permission and elicitation dialogs are suppressed while the user is actively typing
+- the system remembers that they are pending
+- it does not yank focus or visually fight the composer
+
+This is a very good small detail.
+
+WUPHF implication:
+
+- queued blocking states should respect active composition in channels and `1:1`
+
+### 4. Stash and restore is communicated explicitly
+
+`PromptInputStashNotice.tsx` is tiny but smart:
+
+- if the prompt is stashed, the UI tells you
+- it also tells you it auto-restores after submit
+
+This prevents a classic terminal-UX problem:
+
+- clever behavior that feels mysterious instead of helpful
+
+WUPHF implication:
+
+- when the system stashes, reroutes, or transforms operator input, the channel should say so explicitly
+
+### 5. Wrapped input produces contextual help
+
+`PromptInput/Notifications.tsx` surfaces an external-editor hint when input wraps, but only when it is actually relevant.
+
+That is a good pattern:
+
+- detect friction
+- teach in context
+- do not show the hint all the time
+
+WUPHF implication:
+
+- long prompt composition, long workflow specs, and long interview answers should trigger contextual editor/help hints
+
+### 6. Side questions are a distinct product concept
+
+`utils/sideQuestion.ts` implements `/btw` as a forked agent with:
+
+- shared prompt cache
+- no tools
+- one turn only
+- explicit system framing so it does not pretend to interrupt or take over the main task
+
+This is a very elegant small feature.
+
+The lesson is not just "fork another model call." It is:
+
+- users sometimes need a tangent
+- the product should support that without breaking the main work thread
+
+WUPHF implication:
+
+- office mode could eventually benefit from a "quick tangent" or "ask without interrupting current work" primitive
+
+### 7. Status surfaces are adaptive
+
+`PromptInputFooter.tsx`, `Notifications.tsx`, and `StatusLine.tsx` show many small choices:
+
+- hide optional status when space is tight
+- move suggestions into a special footer surface
+- show notifications only when relevant
+- show bridge state only when meaningful
+- surface editor hints only on wrap
+- debounce expensive status-line recomputation
+- keep status data rich:
+  - model
+  - usage
+  - cost
+  - session
+  - worktree
+  - rate limits
+
+Lesson:
+
+- ambient information should be adaptive, not static
+
+WUPHF implication:
+
+- the channel header/footer/status surfaces should continue moving toward context-sensitive information density
+
+### 8. Progress tabs and checkboxes matter
+
+`QuestionNavigationBar.tsx` does a surprisingly nice job with:
+
+- checkbox state for completed answers
+- compact progress tabs
+- adaptive truncation
+- explicit submit step
+
+The lesson:
+
+- progress becomes much more legible when it is visual and compact
+
+WUPHF implication:
+
+- interviews, review flows, setup flows, and workflow wizards should borrow this pattern
+
+### 9. The system acknowledges partial failure modes
+
+`sideQuestion.ts` and related helpers go out of their way to explain odd cases:
+
+- model tried to use a tool instead of answering
+- API error occurred
+- no usable response was returned
+
+Lesson:
+
+- graceful degradation is a product detail
+
+WUPHF implication:
+
+- integration, workflow, and interview failures should get more human-shaped fallback messaging
+
+### 10. Hooks and preprocessing preserve the user's mental model
+
+From `processUserInput.ts`:
+
+- the user's prompt is shown immediately while preprocessing continues
+- hook blocking preserves the original prompt in the warning context
+- metadata/system prompts can remain model-visible but user-hidden when appropriate
+
+This is a sophisticated small detail.
+
+The lesson:
+
+- there is a difference between runtime plumbing and what the human should perceive
+
+WUPHF implication:
+
+- scheduled prompts, system-injected prompts, and automation-generated prompts should be much more deliberate about visibility and explanation
+
+## Additional Micro-Interaction and QOL Lessons
+
+These are even smaller than the first micro-interaction section, but they are exactly the kind of details that make a terminal product feel trustworthy instead of merely powerful.
+
+### 1. Footer help is contextual, not decorative
+
+`PromptInputFooterLeftSide.tsx` and `PromptInputHelpMenu.tsx` do not render one static footer.
+
+They adapt the footer to the exact current interaction:
+
+- exit confirmation
+- paste in progress
+- vim insert mode
+- history search mode
+- teammate/task/tmux selection state
+- loading vs not loading
+
+The help text is also product-shaped instead of documentation-shaped:
+
+- `! for bash mode`
+- `/ for commands`
+- `@ for file paths`
+- `& for background`
+- `/btw for side question`
+- `double tap esc to clear input`
+
+This matters because it means the footer is teaching only what is relevant right now.
+
+WUPHF implication:
+
+- footer and composer help should be stateful and mode-aware, not a static hint ribbon
+
+### 2. Shortcut hints tell the truth about the user's actual setup
+
+`ConfigurableShortcutHint.tsx` resolves the real configured binding instead of hardcoding a default string into the UI.
+
+That is a tiny detail with real product value:
+
+- hints stay truthful after customization
+- help menus, dialogs, and bylines do not drift from reality
+
+WUPHF implication:
+
+- slash help, doctor instructions, interrupt prompts, and composer hints should resolve actual keybindings where possible
+
+### 3. History navigation protects unfinished drafts
+
+`useArrowKeyHistory.tsx` is much more careful than a normal shell-history hook.
+
+It:
+
+- preserves the current draft before navigation starts
+- restores it when the user comes back down
+- keeps mode-filtered history coherent
+- batches disk reads for rapid keypresses
+- teaches deeper history search only after enough history navigation to make the hint useful
+
+This is excellent operator etiquette.
+
+WUPHF implication:
+
+- channel and `1:1` composers should preserve drafts rigorously during history and search flows
+
+### 4. History search is treated as a reversible mode
+
+`useHistorySearch.ts` and `HistorySearchDialog.tsx` treat recall as its own interaction mode, not a one-off helper.
+
+Important details:
+
+- original input, cursor, mode, and pasted contents are preserved
+- cancel returns the user to exactly where they were
+- accept can restore the match
+- execute can immediately submit the match
+- cursor placement is restored relative to the clean value, not the raw display form
+- results include age labels and compact previews
+- preview position changes with terminal width
+
+The effect is that search feels safe to use.
+
+WUPHF implication:
+
+- rewind, prompt recall, and transcript search should preserve editing state as carefully as possible
+
+### 5. Search and open dialogs are built for insertion, not only navigation
+
+`QuickOpenDialog.tsx` and `GlobalSearchDialog.tsx` are both stronger than simple pickers.
+
+They support:
+
+- open in editor
+- insert path
+- insert mention/path reference
+- asynchronous previews
+- right-or-bottom preview placement based on width
+- bounded match counts and debounced search
+
+The product lesson is subtle:
+
+- the dialog is not just for looking around
+- it is part of authoring
+
+WUPHF implication:
+
+- office/direct composition should eventually support richer insert/search surfaces instead of forcing everything through raw chat text
+
+### 6. Transcript restore is treated like surgery, not rewind
+
+`MessageSelector.tsx` is unusually thoughtful.
+
+It supports:
+
+- restore conversation
+- restore code
+- restore both
+- summarize from here
+- summarize up to here
+- include optional user context during summarize
+- show diff-aware restore choices
+- include the current prompt as a virtual message
+
+This is much deeper than "pick an old message."
+
+WUPHF implication:
+
+- transcript recovery, rewind, and summarize flows in WUPHF should become explicit operator tools, especially for long-running office sessions
+
+### 7. Disruptive operations get safety dialogs with bounded detail
+
+`TeleportStash.tsx` is a good model of safe disruption UX.
+
+It:
+
+- checks git status before acting
+- explains why the action is needed
+- lists changed files, but collapses to a count if the list is too long
+- shows explicit loading, stashing, and error states
+
+This is the right shape for risky operations:
+
+- explain the danger
+- bound the detail
+- make the next step obvious
+
+WUPHF implication:
+
+- branch/apply/reset/recover/workflow-resume operations should use small safety dialogs instead of surprising the user after the fact
+
+### 8. Tiny notices remove mystery from smart behavior
+
+`PromptInputStashNotice.tsx` is only a line of UI, but it does important work:
+
+- it tells the user the prompt was stashed
+- it says it will auto-restore after submit
+
+That single sentence converts "weird hidden state" into "helpful product behavior."
+
+WUPHF implication:
+
+- whenever WUPHF stashes, redirects, defers, or restores user work, the UI should say so in plain language
+
+### 9. Risky setting changes get a confirmation moment
+
+`ThinkingToggle.tsx` and `AutoModeOptInDialog.tsx` handle behavior-changing toggles with care.
+
+Important details:
+
+- mid-conversation changes trigger a confirmation state
+- the warning explains the tradeoff, not just the rule
+- exit wording changes based on context:
+  - `No, exit`
+  - `No, go back`
+- "make it my default" is separated from "enable once"
+
+This is good product judgment.
+
+WUPHF implication:
+
+- autonomy, provider, model, or review-mode changes that materially affect cost, quality, or safety should use small explanatory confirmations instead of silent toggles
+
+### 10. Tiny primitives are reused instead of improvised
+
+Small files like `useDoublePress.ts` and `PressEnterToContinue.tsx` matter because they make basic interaction contracts consistent across the product.
+
+The important lesson is not the specific code. It is:
+
+- confirmation behavior should feel the same everywhere
+- continue prompts should look the same everywhere
+- timeouts and pending states should be reusable primitives
+
+WUPHF implication:
+
+- repeated-confirm, continue, and idle behaviors should become shared UI primitives, not per-feature improvisation
+
+### 11. Ambient status is selectively helpful
+
+`Notifications.tsx`, `StatusLine.tsx`, `EffortIndicator.ts`, and `awaySummary.ts` show a mature approach to low-level polish.
+
+Key details:
+
+- external-editor hints show only when input wrap creates real friction
+- expensive status-line work is debounced and cached
+- effort level is rendered as a compact ambient symbol instead of a verbose explanation every time
+- away summaries are intentionally short and action-oriented
+
+These are all examples of the same product instinct:
+
+- surface just enough context to help the user act
+- do not make the ambient chrome noisier than the work
+
+WUPHF implication:
+
+- office and `1:1` ambient status should continue moving toward compact, action-oriented cues rather than ever-denser prose
+
+### 12. Rich status dialogs stay tightly scoped
+
+CC-agent also does a good job with small modal/status surfaces such as the bridge and remote-environment dialogs.
+
+The notable quality is not that they show a lot of information. It is that they show exactly the information relevant to the current decision:
+
+- current status
+- what system is connected
+- what the user can do next
+- the key to dismiss or act
+
+They feel richer than a plain alert without turning into a second application.
+
+WUPHF implication:
+
+- connection, provider, remote-runtime, and integration dialogs should be informative but tightly scoped instead of sprawling configuration screens
+
+## Delight, Playfulness, and Product Feel
+
+CC-agent invests in fun without undermining seriousness.
+
+Key examples:
+
+- `WelcomeV2.tsx`
+- `CompanionSprite.tsx`
+- animated spinners
+- tips and speculative suggestions
+
+This matters because it changes how the product feels:
+
+- less sterile
+- more alive
+- more teachable
+- more memorable
+
+WUPHF implication:
+
+- WUPHF does not need mascots or whimsy copied literally
+- but it should intentionally design:
+  - splash/onboarding theater
+  - smart empty states
+  - subtle teaching moments
+  - return summaries
+  - meaningful progress language
+
+The lesson is not "add cute stuff." The lesson is:
+
+- delight can reduce cognitive load and make latency feel purposeful
+
+## Startup, Onboarding, and Doctor Experience
+
+### Startup is optimized aggressively
+
+`src/entrypoints/cli.tsx` shows:
+
+- zero-import fast paths
+- lazy imports for rare modes
+- startup checkpoints
+- early environment shaping
+
+Lesson:
+
+- startup time is product quality, especially for terminal tools
+
+WUPHF implication:
+
+- WUPHF should profile and optimize startup deliberately
+- tmux/session boot speed should be treated as part of UX, not just engineering overhead
+
+### Doctor is a core screen, not an edge tool
+
+`Doctor.tsx` does real operational guidance:
+
+- versioning
+- installation health
+- lock and sandbox issues
+- context warnings
+- agent/runtime checks
+
+WUPHF implication:
+
+- `/doctor` was the right move
+- but WUPHF's current doctor is still much shallower
+- the next step is not just more checks, but integrating doctor findings into:
+  - first-run flow
+  - blocked states
+  - channel empty states
+  - integration flows
+
+## State Model and State Machines
+
+### AppStateStore is a strong signal
+
+`AppStateStore.ts` is one of the most valuable files in the repo because it reveals what the product treats as real runtime concepts.
+
+It has explicit state for:
+
+- permissions
+- bridge
+- background tasks
+- teammate view
+- plugins
+- prompts
+- notifications
+- MCP
+- todos
+- file history
+- panels and overlays
+
+Lesson:
+
+- a product becomes more reliable when more of its meaningful runtime state is explicit and normalized
+
+WUPHF implication:
+
+- WUPHF needs a normalized UI/runtime state layer that bridges:
+  - broker state
+  - launcher state
+  - task/workflow state
+  - channel UI state
+  - direct-session state
+  - external action state
+
+### Modes are runtime contracts
+
+`PermissionMode.ts`, `EnterPlanModeTool.ts`, and `EnterWorktreeTool.ts` show that modes are not cosmetic. They change what tools mean and what the system is allowed to do.
+
+WUPHF implication:
+
+- office mode
+- direct `1:1`
+- review
+- planning
+- execution
+- blocked/waiting-human
+
+should increasingly become explicit runtime modes with consistent semantics, not just prompt differences
+
+## Multi-Agent Model, Navigation, and Transcript Scoping
+
+### Agent identity is separate from task execution
+
+The multi-agent system is stronger than it first appears because CC-agent separates:
+
+- static agent definition
+- runtime agent identity
+- concrete task run
+
+Static config is normalized in `loadAgentsDir.ts`.
+Runtime teammate identity lives in `InProcessTeammateTask/types.ts`.
+Concrete runs are registered as task objects in `LocalAgentTask.tsx` and `spawnInProcess.ts`.
+
+That separation lets the product keep one stable agent identity while many task/runtime concerns change underneath it.
+
+WUPHF implication:
+
+- define explicit `AgentDefinition`, `AgentInstance`, and `TaskRun` concepts
+- do not let "agent", "task", and "pane/session" remain partially interchangeable
+
+### Viewed, selected, foregrounded, and running are distinct states
+
+This is one of the most important product lessons from CC-agent’s multi-agent mode.
+
+From `AppStateStore.ts`, `teammateViewHelpers.ts`, and related UI code:
+
+- an agent can be running without being viewed
+- an agent can be viewed without replacing main
+- a task can be foregrounded temporarily
+- the footer can be selected independently from the viewed transcript
+
+That nuance is why the system scales better than a naive "active pane == active agent" model.
+
+WUPHF implication:
+
+- treat:
+  - active conversation
+  - viewed agent/task
+  - foreground job
+  - footer/sidebar selection
+  as separate state axes
+- this is the right abstraction for making office mode and `1:1` both feel coherent
+
+### Transcript scoping is explicit and cheap enough to use
+
+CC-agent does not flatten multi-agent work into one stream.
+
+Instead:
+
+- each agent/task has its own transcript path or transcript scope
+- task output is linked to transcript storage
+- the viewed transcript is lazily hydrated when the user opens it
+- the UI mirror is capped in memory for in-process teammates
+
+This makes agent switching feel real instead of simulated.
+
+WUPHF implication:
+
+- each agent/task should own a transcript or event stream
+- channel view can remain the social/office layer, but transcript-level inspection should be available without flattening everything into main chat
+
+### Notifications are global for the UI, local for execution
+
+CC-agent uses a pragmatic split:
+
+- notifications can show up in the global product surface
+- but only the intended agent drains and reacts to its own queue
+
+This is the critical anti-cross-talk rule.
+
+The current implementation uses tagged strings like `<task-notification>` and `<teammate-message>`, which is the part WUPHF should avoid copying.
+
+But the product rule is correct:
+
+- display can be global
+- execution should be inbox-scoped
+
+WUPHF implication:
+
+- add per-agent inbox/outbox semantics
+- keep the office feed as a human-facing aggregation layer
+- prefer structured event objects over tagged text protocols
+
+### Multi-agent navigation stays coherent because “main” remains a first-class destination
+
+From `CoordinatorAgentStatus.tsx`, teammate view helpers, and related task/dialog UI:
+
+- "main" is always navigable
+- teammates appear as peers under a single navigation model
+- completed agents remain inspectable
+- idle agents dim instead of vanishing
+- queued notifications are suppressed while the user is already inside the relevant transcript
+
+These are small choices, but together they prevent multi-agent mode from feeling chaotic.
+
+WUPHF implication:
+
+- always present a canonical "back to main office" destination alongside agents
+- keep completed agents reviewable
+- hide unrelated queue noise while the user is zoomed into one agent or task
+
+### Current gap for WUPHF
+
+WUPHF already has the stronger office metaphor, but CC-agent is still ahead in transcript-scoped multi-agent ergonomics.
+
+The real gap is not “more agents.”
+It is:
+
+- better state separation
+- better transcript scoping
+- better notification routing
+- one canonical switcher/navigation surface
+
+## Query Engine, Tasks, and Execution Artifacts
+
+### Query/session split is deliberate
+
+`query.ts` and `QueryEngine.ts` separate:
+
+- turn execution
+- session persistence and control
+
+Lesson:
+
+- the turn loop should not be the whole product runtime
+
+WUPHF implication:
+
+- separate more clearly:
+  - signal intake
+  - decisioning
+  - task/workflow execution
+  - transcript/reporting
+
+### Task runtime is much deeper than WUPHF today
+
+`LocalAgentTask` and `RemoteAgentTask` provide:
+
+- retained transcript state
+- foreground/background semantics
+- recovery
+- disk outputs
+- notifications
+- progress views
+
+Lesson:
+
+- tasks are not just assignments
+- they are execution artifacts with their own lifecycle
+
+WUPHF implication:
+
+- tasks/workflows need richer execution artifacts:
+  - started/running/blocked/completed summaries
+  - retained progress snapshots
+  - output references
+  - clearer resume/review semantics
+
+## Tools, Permissions, and Capability Platform
+
+### Tool assembly is disciplined
+
+`tools.ts` is one of the cleanest architectural parts of CC-agent.
+
+Key properties:
+
+- one source of truth for built-in tools
+- effective tool pool assembled in one place
+- permission filtering before visibility
+- sorting stability for prompt/cache determinism
+- mode-aware tool exposure
+
+WUPHF implication:
+
+- action tools, workflow tools, Nex tools, office tools, and direct-session tools should eventually be assembled through a more centralized capability registry
+
+### Permission model is systemic
+
+Permissions are not an afterthought. They shape runtime behavior and UI.
+
+WUPHF implication:
+
+- external actions, workflows, triggers, scheduling, and review/apply flows should increasingly be governed by explicit capability and approval policy, not just prompt instruction
+
+## Memory, Compaction, and Context Survivability
+
+### Active memory maintenance
+
+CC-agent has:
+
+- session memory
+- context collapse
+- auto compaction
+- summarization thresholds
+
+This is a big strategic lesson.
+
+WUPHF has Nex, which is a major advantage, but Nex does not replace session memory mechanics.
+
+WUPHF implication:
+
+- add durable task/session summaries
+- compact long-running office/direct transcripts
+- preserve execution context across restarts
+- distinguish durable organizational memory from session-operational memory
+
+Nex should be the organization memory layer.
+WUPHF still needs a stronger session memory layer.
+
+## Performance and Rendering Architecture
+
+### Transcript virtualization is real, not superficial
+
+`VirtualMessageList.tsx` and `useVirtualScroll.ts` are a strong signal that CC-agent takes transcript scale seriously.
+
+This includes:
+
+- mounted range calculation
+- overscan
+- scroll quantization
+- cold-start behavior
+- spacer math
+- visible window control
+
+Lesson:
+
+- caching helps
+- virtualization is a different tier of solution
+
+WUPHF implication:
+
+- the recent render-cache work was necessary, but it is not the end state
+- long-history office channels will eventually need:
+  - viewport virtualization
+  - incremental row generation
+  - cheaper markdown/layout work on first paint
+
+### Perceived performance is also designed
+
+CC-agent reduces perceived latency with:
+
+- spinners
+- suggestions
+- tips
+- better startup behavior
+- visible task activity
+
+WUPHF implication:
+
+- do not think of performance only as render time
+- perceived responsiveness matters equally
+
+## MCP, Bridge, Remote, and External System Philosophy
+
+### MCP is a subsystem
+
+The MCP files reveal a mature approach:
+
+- connection lifecycle
+- permissions
+- reconnect behavior
+- resource handling
+- output persistence
+
+Lesson:
+
+- integration runtime needs lifecycle rigor
+
+WUPHF implication:
+
+- Composio/One/Nex/tool providers should increasingly be treated as lifecycle-managed subsystems, not just tool calls with config
+
+### Bridge and remote execution are treated as first-class paths
+
+`bridgeMain.ts` and remote task files show that CC-agent assumes work may happen across process and machine boundaries.
+
+WUPHF implication:
+
+- even if WUPHF is staying local-first today, its architecture should leave room for:
+  - richer background workers
+  - recoverable task processes
+  - stronger runtime separation between UI and execution
+
+## Plugins, Skills, and Ecosystem Design
+
+### Skills are rich metadata objects
+
+`loadSkillsDir.ts` shows that skills are not just text files. They carry:
+
+- metadata
+- path scoping
+- effort/model hints
+- hooks
+- runtime loading rules
+
+Lesson:
+
+- capability layers need structure
+
+WUPHF implication:
+
+- skills, workflows, actions, and agent packs should evolve toward a more unified capability model
+
+### Plugin installation is runtime-managed
+
+`PluginInstallationManager.ts` does:
+
+- background reconciliation
+- refresh behavior
+- marketplace awareness
+
+Lesson:
+
+- ecosystem operations should feel native to the product
+
+WUPHF implication:
+
+- if WUPHF grows packs/plugins/skills further, installation/update state should become a UI/runtime concept, not just a filesystem detail
+
+## Feature Gates and Product Control Plane
+
+`growthbook.ts` shows that feature flags are not only for experimentation.
+
+They are used for:
+
+- staged rollout
+- environment overrides
+- configuration precedence
+- runtime refresh
+
+Lesson:
+
+- as the surface area grows, product control becomes part of architecture
+
+WUPHF implication:
+
+- bigger features like:
+  - trigger ingestion
+  - workflow authoring modes
+  - richer execution cards
+  - future remote/runtime modes
+
+may need explicit gate/config strategy instead of shipping as all-or-nothing global behavior
+
+## What WUPHF Should Borrow
+
+Highest-value lessons:
+
+1. Normalize runtime state more aggressively.
+2. Separate session/turn/execution concerns more clearly.
+3. Turn tasks and workflows into richer execution artifacts.
+4. Invest in session memory and compaction alongside Nex.
+5. Treat setup/doctor/readiness as core product flows.
+6. Build true transcript virtualization, not just caching.
+7. Treat integrations and MCP providers as lifecycle-managed subsystems.
+8. Improve idle/latency moments with better progress, summaries, and teaching.
+9. Develop a more structured capability platform for tools, skills, and workflows.
+10. Treat product feel as real engineering work.
+
+## What WUPHF Should Not Borrow
+
+1. Do not abandon the office metaphor.
+2. Do not collapse the product into a single giant REPL.
+3. Do not replace visible teamwork with hidden background magic.
+4. Do not adopt whimsical features without a clear purpose.
+5. Do not copy remote/bridge complexity before the local runtime is fully mature.
+
+## WUPHF Gap Analysis
+
+### Architecture gaps
+
+- runtime state is still too fragmented across broker, launcher, tmux, and UI
+- session and turn mechanics are not split cleanly enough
+- tasks/workflows still lack rich retained execution artifacts
+- agent identity, transcript scope, and task execution are still not separated cleanly enough for best-in-class multi-agent UX
+
+### UI and legibility gaps
+
+- channel stream still mixes too many content types in one lane
+- blocked/needs-you states are not loud enough
+- empty/offline states still feel low-signal
+- direct sessions are improved, but still not at best-in-class clarity
+- keyboard/navigation behavior is still too local and screen-specific instead of being governed by one explicit interaction model
+- channel/direct unread and "new since you looked" semantics are still weak
+
+### Performance gaps
+
+- caching landed, but virtualization has not
+- first-paint cost for very long histories can still be improved
+- startup/runtime profiling is not yet as deliberate as it should be
+- tmux-specific redraw, clipboard, and notification behavior is not yet treated as a dedicated performance/correctness layer
+
+### Product feel gaps
+
+- idle moments are still underused
+- return/away summaries do not exist
+- teaching moments and progressive hints are still shallow
+
+### Capability/platform gaps
+
+- skills, workflows, and actions are still not unified enough
+- integration lifecycle and readiness state need deeper product treatment
+- plugins/packs/extensions are less runtime-native than they could be
+
+## Multi-Phase Roadmap for WUPHF
+
+### Phase 1: Normalize Runtime State
+
+Goal:
+
+- establish one UI-facing runtime model for agents, tasks, workflows, readiness, and integration state
+
+Deliverables:
+
+- normalized agent runtime state
+- normalized execution artifact state
+- clearer mode/state contracts
+- channel/direct session consumption of the same state model
+
+### Phase 2: Rich Execution Artifacts
+
+Goal:
+
+- make tasks and workflows into retained runtime objects, not just chat-adjacent items
+
+Deliverables:
+
+- execution summaries
+- started/running/blocked/completed timelines
+- output references
+- resume/review surfaces
+
+### Phase 3: Session Memory and Context Survivability
+
+Goal:
+
+- make long-running work survivable and compressible
+
+Deliverables:
+
+- office/session memory layer
+- long-thread compaction
+- per-task summary snapshots
+- recovery-friendly context restoration
+
+### Phase 4: Transcript and Rendering Performance
+
+Goal:
+
+- make long histories feel fast and stable
+
+Deliverables:
+
+- viewport virtualization
+- incremental rendering
+- first-paint optimization
+- startup/runtime profiling
+
+### Phase 5: Readiness, Blocked States, and Operational UX
+
+Goal:
+
+- make setup and operational health impossible to miss
+
+Deliverables:
+
+- deeper `/doctor`
+- in-channel blocked-state surfacing
+- integration lifecycle visibility
+- partial-readiness explanations
+
+### Phase 6: Capability Platform Maturity
+
+Goal:
+
+- unify tools, actions, workflows, skills, and future plugins under clearer runtime contracts
+
+Deliverables:
+
+- centralized capability registry
+- stronger permission and approval semantics
+- provider lifecycle management
+- better skill/workflow/action interoperability
+
+### Phase 7: Delight and Product Feel
+
+Goal:
+
+- make WUPHF feel alive, trustworthy, and enjoyable during real use
+
+Deliverables:
+
+- away summaries
+- better empty states
+- smarter wait-state guidance
+- clearer progress language
+- more intentional onboarding and welcome flows
+
+## Bottom Line
+
+CC-agent is strong because it treats everything as product architecture:
+
+- startup
+- input
+- permissions
+- tasks
+- memory
+- plugins
+- rendering
+- setup
+- delight
+
+That is the deepest lesson for WUPHF.
+
+WUPHF does not need to become CC-agent.
+It needs to become equally deliberate.
+
+The winning strategy is:
+
+- keep WUPHF's office identity
+- import CC-agent's rigor
+- close the gaps in runtime state, execution artifacts, session memory, transcript performance, and product feel

--- a/docs/cc-agent-gap-audit.md
+++ b/docs/cc-agent-gap-audit.md
@@ -1,0 +1,98 @@
+# CC-agent Plan Gap Audit
+
+## Scope
+
+This audit compares the CC-agent analysis and phase plans against the code currently on `main` after PR `#16`.
+
+Source planning docs:
+
+- [cc-agent-deep-analysis.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-deep-analysis.md)
+- [cc-agent-implementation-roadmap.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-implementation-roadmap.md)
+- [cc-agent-phase1-execution-plan.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-phase1-execution-plan.md)
+- [cc-agent-phase2-execution-plan.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-phase2-execution-plan.md)
+- [cc-agent-phase3-execution-plan.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-phase3-execution-plan.md)
+
+Status meanings:
+
+- `Implemented`: the planned branch intent is substantially present in the repo.
+- `Partial`: some useful slice landed, but the branch intent is not fully realized.
+- `Missing`: little or none of the intended branch shape is present.
+
+## Summary
+
+The repo now contains a meaningful subset of the roadmap:
+
+- picker-based navigation and `/switch`
+- improved slash autocomplete and composer ergonomics
+- doctor/readiness surface
+- interview rendering
+- local tool execution
+- task logs and worktree-backed task execution
+- agent compaction with `Office Insight`
+
+The repo does **not** yet contain most of the broader CC-agent-inspired overhaul described in the plans:
+
+- context-aware keyboard architecture
+- draft-safe history and recall
+- reusable confirmation and continue primitives
+- structured interview workflow with review-before-submit
+- approval steering
+- one canonical office/agent switcher
+- unread and away-state navigation semantics
+- transcript recovery
+- session memory
+- history virtualization
+- capability and tmux abstraction layers
+
+## Matrix
+
+| Phase | Planned branch | Status | Evidence in repo | Gap |
+| --- | --- | --- | --- | --- |
+| 1 | `feat/context-aware-keybindings` | Partial | [keybindings.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/keybindings.go#L9) has mode-based mappings and [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go#L1030) routes active picker behavior before normal input handling. | No explicit interaction-context model, no centralized overlay/help/transcript key ownership layer, and no dedicated keymap module such as the planned `internal/tui/keymap.go`. |
+| 1 | `feat/contextual-footer-hints` | Partial | [channel_composer.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_composer.go#L39) changes hint copy for normal compose, interviews, and `1:1`. Slash commands are categorized in [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go#L439). | Hints are still mostly static strings. The plan called for state-driven footer truthfulness across blocked, reply, autocomplete, and other interaction states. |
+| 1 | `feat/draft-safe-history` | Missing | There is no `channel_history.go`, no recall/search subsystem, and no code evidence of draft snapshot/restore behavior for main vs thread composers. | The current product still lacks safe history navigation, draft restoration, and cursor restoration. |
+| 1 | `feat/interaction-primitives` | Partial | A reusable double-press helper exists in [keybindings.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/keybindings.go#L101). | The broader primitive set from the plan is absent: no shared continue component, no common pending-state treatment, and no standard confirm/cancel byline primitives reused across surfaces. |
+| 1 | `feat/runtime-change-confirmations` | Missing | I found no dedicated confirmation flow for provider/autonomy/runtime setting changes. | High-impact runtime changes still do not appear to route through a deliberate confirmation UX. |
+| 1 | `feat/safety-dialogs` | Missing | There is no reusable dialog subsystem and no new safety-dialog helper module. | Disruptive actions are not covered by the bounded-detail confirmation model described in the plan. |
+| 2 | `feat/structured-human-interviews` | Partial | Interview state and rendering exist in [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go#L50), [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go#L204), and [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go#L3656). | The planned guided mini-flow is incomplete: no review-before-submit, no explicit skip/continue workflow, and no extracted interview-specific interaction layer. |
+| 2 | `feat/approval-steering` | Missing | I found interview and approval kinds, but no concrete `approve with note` or `reject with steer` flow in channel or broker code. | Approval UX still looks binary compared with the planned operator-steering model. |
+| 2 | `feat/agent-office-switcher` | Partial | Pickers exist for channels, direct sessions, tasks, requests, agents, and threads in [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go#L4015) and nearby picker callsites. | The planned canonical switcher does not exist. Navigation is still spread across separate commands and pickers rather than one unified office/direct/task transcript surface. |
+| 2 | `feat/unread-navigation-semantics` | Missing | I found no unread divider, jump-to-latest affordance, or first-class new-message semantics in the current channel rendering paths. | Long sessions still lack the explicit “new since you looked” model called for in the plan. |
+| 2 | `feat/transcript-recovery` | Missing | I found no transcript recovery or rewind flow aligned with the planned branch. | Recovery and transcript surgery remain absent as a deliberate user flow. |
+| 2 | `feat/away-summaries` | Missing | I found no away summary or return-summary implementation in channel or team runtime code. | Return moments are still not treated as a first-class UX concept. |
+| 2 | `feat/in-channel-readiness` | Partial | The doctor/readiness surface is real in [channel_doctor.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_doctor.go#L33), [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go#L441), and [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go#L4223). | This is narrower than the roadmap branch. It covers setup and runtime readiness, but not a richer, always-legible in-channel readiness model woven through office flows. |
+| 2 | `feat/insert-search-surfaces` | Missing | I found no insert-mode search surface or recall/search authoring tool beyond slash autocomplete and pickers. | The authoring/search ergonomics described in the plan were not implemented. |
+| 3 | `feat/runtime-state-model` | Partial | Runtime state is surfaced in multiple places, and worktree/readiness/task state is exposed through [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go#L103), [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go#L578), and [channel_doctor.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_doctor.go#L33). | The planned normalized UI-facing runtime state model is still missing. There is no dedicated module like the proposed `internal/tui/runtime_state.go`, and state derivation remains spread across broker, launcher, and UI code. |
+| 3 | `feat/per-agent-transcript-inbox` | Missing | There is `1:1` mode and directed human messaging, but no explicit inbox/outbox transcript model per agent/task in the office UI. | The plan’s transcript ownership, directed inbox/outbox semantics, and zoomed transcript isolation were not landed. |
+| 3 | `feat/execution-artifacts` | Partial | Task/worktree execution metadata exists in [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go#L103), task logging lands in [task_runtime.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/agent/task_runtime.go#L19), and output logs are written from [loop.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/agent/loop.go#L653). | This is still lighter than the planned retained artifact model. There is no broader artifact lifecycle spanning workflows, approvals, external actions, and resume/review metadata. |
+| 3 | `feat/session-memory` | Partial | Agent-side compaction and `Office Insight` exist in [task_runtime.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/agent/task_runtime.go#L68), [prompts.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/agent/prompts.go#L91), and [router.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/chat/router.go#L56). | The roadmap called for session-operational memory across office and direct sessions. What landed is mainly agent runtime compaction, not a fuller office/direct session memory subsystem like the proposed `internal/team/session_memory.go`. |
+| 3 | `feat/history-virtualization` | Missing | I found no visible-row windowing, transcript virtualization, or dedicated rendering-window subsystem. | Long transcript scaling is still mostly handled by current rendering and caching, not virtualization. |
+| 3 | `feat/tmux-capability-layer` | Missing | [channel_doctor.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_doctor.go#L79) checks that `tmux` exists, but there is no capability abstraction layer for terminal features. | The plan’s tmux/screen hardening layer was not implemented. |
+| 3 | `feat/capability-registry` | Missing | The repo has an action registry in [registry.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/action/registry.go), but not the broader runtime capability registry described in the phase plan. | Provider/action registration exists, but a central runtime capability exposure layer does not. |
+
+## What Actually Landed
+
+These roadmap-adjacent areas are clearly present and should not be discounted:
+
+- `/switch` and fuzzy picker-based navigation in [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go#L447) and [picker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/picker.go)
+- stronger slash command categorization and visibility rules in [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go#L439) and [autocomplete.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/autocomplete.go)
+- composer motion and input ergonomics in [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go) and [channel_composer.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_composer.go#L39)
+- doctor/readiness checks in [channel_doctor.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_doctor.go#L33)
+- interview rendering and answer plumbing in [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go#L3656) and [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go#L437)
+- local coding tools, working directory support, and outbox writes in [tools.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/agent/tools.go#L112)
+- task output logs and compaction in [task_runtime.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/agent/task_runtime.go#L19) and [loop.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/agent/loop.go#L653)
+- local worktree task isolation in [worktree.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/worktree.go#L15) and [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go#L3555)
+- task status exposure for agents via [server.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/teammcp/server.go#L394)
+
+## Recommended Next Pass
+
+If the goal is to continue the actual roadmap rather than celebrate PR `#16` as complete, the highest-leverage next sequence is:
+
+1. `feat/runtime-state-model`
+2. `feat/context-aware-keybindings`
+3. `feat/draft-safe-history`
+4. `feat/structured-human-interviews`
+5. `feat/agent-office-switcher`
+6. `feat/session-memory`
+
+That order fixes the biggest architectural and operator-trust gaps first.

--- a/docs/cc-agent-implementation-roadmap.md
+++ b/docs/cc-agent-implementation-roadmap.md
@@ -1,0 +1,576 @@
+# CC-agent Lessons: WUPHF Implementation Roadmap
+
+## Purpose
+
+This roadmap converts the CC-agent analysis into an execution plan for WUPHF.
+
+It is intentionally grouped by:
+
+- fast wins
+- medium UX wins
+- deep architectural polish
+
+The goal is not to make WUPHF look like CC-agent.
+
+The goal is to import the parts of CC-agent that materially improve:
+
+- operator trust
+- moment-to-moment flow
+- channel legibility
+- direct-session clarity
+- long-session resilience
+- runtime rigor
+
+while preserving WUPHF's office-first product identity.
+
+Related docs:
+
+- [cc-agent-deep-analysis.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-deep-analysis.md)
+- [cc-agent-phase1-execution-plan.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-phase1-execution-plan.md)
+- [cc-agent-phase2-execution-plan.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-phase2-execution-plan.md)
+- [cc-agent-phase3-execution-plan.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-phase3-execution-plan.md)
+- [TODOS.md](/Users/najmuzzaman/Documents/nex/WUPHF/TODOS.md)
+
+## Guiding Principles
+
+### 1. Preserve the office metaphor
+
+WUPHF should not collapse into a giant solo REPL.
+
+Borrow:
+
+- runtime rigor
+- interaction quality
+- better state architecture
+
+Do not borrow:
+
+- product shape
+
+### 2. Improve trust before adding new power
+
+The next wins are mostly about:
+
+- clearer state
+- safer interruptions
+- better recovery
+- more truthful UI guidance
+
+not more surface area.
+
+### 3. Prefer reusable primitives over one-off polish
+
+If a behavior is useful in one place, it will likely be needed again.
+
+Examples:
+
+- double-press confirmation
+- continue prompts
+- status/event cards
+- draft stash/restore notices
+- reversible search/restore flows
+
+### 4. Make runtime state explicit before over-polishing the chrome
+
+Some UI work can land early, but the highest-leverage improvements come from:
+
+- normalized runtime state
+- retained execution artifacts
+- session memory
+
+Without those, some polish work will always be bolted on.
+
+## Phase Order
+
+Recommended sequence:
+
+1. Fast wins
+2. Medium UX wins
+3. Deep architectural polish
+
+This order is deliberate:
+
+- fast wins improve operator feel immediately
+- medium wins make the product feel much more serious
+- deep work prevents future UI polish from becoming brittle
+
+## Phase 1: Fast Wins
+
+These are small-to-medium changes that materially improve QOL without requiring large architecture changes.
+
+### 1. Contextual Footer and Shortcut Hints
+
+Implement:
+
+- mode-aware composer hints
+- office vs `1:1` specific hints
+- truthful keybinding display where possible
+- contextual hints only when friction is real
+
+Examples:
+
+- long input wraps -> suggest external editor
+- active selection mode -> show selection actions only
+- blocked approval -> show approve/cancel hints only
+
+Why first:
+
+- very visible win
+- low risk
+- directly improves operator confidence
+
+Suggested branch:
+
+- `feat/contextual-footer-hints`
+
+### 2. Draft-Preserving History and Recall
+
+Implement:
+
+- preserve current draft before history navigation
+- restore draft when coming back down
+- preserve cursor location
+- preserve mode and pasted content
+- add safe prompt recall/search
+
+Why first:
+
+- this is a high-trust improvement
+- operators immediately feel when a terminal tool protects their unfinished thought
+
+Suggested branch:
+
+- `feat/draft-safe-history`
+
+### 3. Context-Aware Keyboard Navigation Model
+
+Implement:
+
+- explicit interaction contexts for:
+  - chat
+  - autocomplete
+  - confirmation
+  - transcript view
+  - task/agent switcher
+  - help
+- centralized keybinding resolution
+- truthful shortcut hints derived from the active context
+- better separation between dismiss-overlay and cancel-work semantics
+
+Why first:
+
+- keyboard behavior is one of the biggest hidden quality gaps
+- this makes the rest of the TUI easier to evolve without regressions
+
+Suggested branch:
+
+- `feat/context-aware-keybindings`
+
+### 4. Reusable Continue / Double-Press / Pending-State Primitives
+
+Implement:
+
+- shared double-press helper
+- shared "press enter to continue" component
+- shared temporary pending state treatment
+- standard byline patterns for confirm/cancel/continue
+
+Why first:
+
+- small cost
+- improves consistency across the whole product
+
+Suggested branch:
+
+- `feat/interaction-primitives`
+
+### 5. Confirm High-Impact Runtime Setting Changes
+
+Implement:
+
+- confirmation step for mid-session changes that materially affect:
+  - cost
+  - autonomy
+  - execution mode
+  - provider/runtime behavior
+- short explanatory copy at the decision point
+
+Targets:
+
+- provider changes
+- autonomy step-up changes
+- possibly model/thinking/review-like mode changes if exposed
+
+Suggested branch:
+
+- `feat/runtime-change-confirmations`
+
+### 6. Safety Dialogs for Disruptive Operations
+
+Implement:
+
+- bounded-detail confirmation dialogs before disruptive actions
+- clear reason, next effect, and rollback/safety guidance
+
+Targets:
+
+- resets
+- transcript restore/rewind
+- apply/recover flows
+- workflow resume/replay
+
+Suggested branch:
+
+- `feat/safety-dialogs`
+
+### Phase 1 Success Criteria
+
+- Users stop losing drafts unexpectedly
+- Shortcuts/help feel more truthful and relevant
+- keyboard behavior feels coherent across screens and overlays
+- Interrupt/confirm flows feel consistent
+- Risky toggles and disruptive actions feel deliberate rather than surprising
+
+## Phase 2: Medium UX Wins
+
+These are product-visible features that make WUPHF feel dramatically more polished and operator-friendly.
+
+### 1. Structured Human Interview Flows
+
+Implement:
+
+- interview mini-flow UI instead of raw transcript-only elicitation
+- progress tabs / completion state
+- skip/continue semantics
+- optional notes
+- review-before-submit
+
+### 2. Canonical Agent/Office Switcher
+
+Implement:
+
+- one primary switcher that always includes:
+  - main office
+  - direct sessions
+  - active agent/task transcripts
+- unread state
+- last-activity context
+- "jump back to main" semantics
+
+Why here:
+
+- this is the biggest multi-agent navigation lesson from CC-agent
+- it materially improves office coherence without forcing a new product metaphor
+
+Suggested branch:
+
+- `feat/agent-office-switcher`
+
+### 3. Unread Divider and “New Messages” Semantics
+
+Implement:
+
+- first-class unread dividers
+- "new since you looked" pill or strip
+- better jump-to-latest behavior
+- clearer sticky/unread behavior in long channels and direct sessions
+
+Suggested branch:
+
+- `feat/unread-navigation-semantics`
+
+Why it matters:
+
+- this is one of the strongest small-product lessons from CC-agent
+- WUPHF already has interviews conceptually, but the UX is still too transcript-shaped
+
+Suggested branch:
+
+- `feat/structured-human-interviews`
+
+### 2. Approval Prompts with Inline Steering
+
+Implement:
+
+- `approve`
+- `approve with note`
+- `reject`
+- `reject with steer`
+
+Examples:
+
+- "yes, but draft first"
+- "no, use Gmail not Slack"
+
+Why it matters:
+
+- this captures operator guidance at the exact right moment
+
+Suggested branch:
+
+- `feat/approval-steering`
+
+### 3. Transcript Recovery and Summarize UX
+
+Implement:
+
+- rewind/restore interaction
+- summarize from here / summarize up to here
+- restore selected context, not only raw replay
+- safer transcript surgery for long sessions
+
+Why it matters:
+
+- WUPHF sessions are getting longer
+- transcript recovery is currently too primitive for that reality
+
+Suggested branch:
+
+- `feat/transcript-recovery`
+
+### 4. "While You Were Away" Summaries
+
+Implement:
+
+- per-channel away summary
+- per-`1:1` away summary
+- short, action-oriented recap
+- visible "what changed / what next" framing
+
+Why it matters:
+
+- returning to an active office should feel guided, not forensic
+
+Suggested branch:
+
+- `feat/away-summaries`
+
+### 5. Surface Doctor Findings in the Main Flow
+
+Implement:
+
+- blocked state cards in-channel
+- setup/readiness status in empty states
+- contextual doctor hints without forcing `/doctor`
+
+Why it matters:
+
+- readiness problems should meet the user in the workspace, not hide behind a command
+
+Suggested branch:
+
+- `feat/in-channel-readiness`
+
+### 6. Lightweight Insert/Search Surfaces
+
+Implement:
+
+- richer insert overlays for paths/references
+- search surfaces that support insertion, not just navigation
+- office/direct authoring helpers beyond raw transcript typing
+
+Why it matters:
+
+- composition becomes faster and more deliberate
+- useful especially for workflow specs, long prompts, and recovery flows
+
+Suggested branch:
+
+- `feat/insert-search-surfaces`
+
+### Phase 2 Success Criteria
+
+- Human interviews feel like workflows, not interruptions
+- Operator approvals capture steering, not only permission
+- Rewind/recovery becomes safe and useful
+- Returning to the office after absence feels guided
+- Setup issues surface naturally in context
+
+## Phase 3: Deep Architectural Polish
+
+These are the high-leverage systems that make the UI improvements durable.
+
+### 1. Normalized Runtime State Model
+
+Implement a single UI-facing runtime state object that unifies:
+
+- agent activity
+- blocked/waiting-human state
+- readiness/integration state
+- direct vs office semantics
+- active execution context
+
+Why it matters:
+
+- this is the foundation for better headers, timeline, doctor, roster, and event cards
+
+Suggested branch:
+
+- `feat/runtime-state-model`
+
+### 2. Rich Execution Artifact Model
+
+Implement retained execution artifacts for:
+
+- tasks
+- workflows
+- approvals
+- interrupts
+- external actions
+
+Each should retain:
+
+- started/running/blocked/completed states
+- partial outputs
+- progress summaries
+- resume/review metadata
+
+Why it matters:
+
+- many UI improvements become much easier once work is an object, not just text
+
+Suggested branch:
+
+- `feat/execution-artifacts`
+
+### 3. Session Memory and Context Compaction
+
+Implement:
+
+- session-operational memory distinct from Nex organizational memory
+- transcript compaction
+- recovery summaries
+- better continuity for long-running offices and `1:1` sessions
+
+Why it matters:
+
+- long-lived offices need memory beyond raw scrollback
+
+Suggested branch:
+
+- `feat/session-memory`
+
+### 4. Long-History Virtualization
+
+Implement:
+
+- incremental visible-row rendering
+- bounded first paint work
+- lower-cost heavy markdown/history rendering
+
+Why it matters:
+
+- caching helps, but long-term transcript scale needs virtualization
+
+Suggested branch:
+
+- `feat/history-virtualization`
+
+### 5. Capability Registry
+
+Implement a normalized registry for:
+
+- tools
+- office actions
+- direct actions
+- Nex capabilities
+- action providers
+- workflows
+- future plugins/skills
+
+Why it matters:
+
+- capability sprawl will otherwise leak into UI and runtime decisions in inconsistent ways
+
+Suggested branch:
+
+- `feat/capability-registry`
+
+### Phase 3 Success Criteria
+
+- UI surfaces draw from one coherent runtime model
+- work has retained lifecycle objects, not just transcript traces
+- long sessions stay understandable and performant
+- capability exposure becomes easier to reason about and safer to evolve
+
+## Cross-Cutting Polish Track
+
+These can happen alongside later phases once the foundations exist.
+
+### 1. Delight and Teaching Layer
+
+Implement:
+
+- smarter empty states
+- better waiting copy
+- richer welcome/return moments
+- progressive teaching hints
+
+### 2. Better Generated Workflow Content Quality
+
+Implement:
+
+- cleaner summaries
+- more actionable output formatting
+- better final artifact polish
+
+### 3. Stronger Channel Empty and Offline States
+
+Implement:
+
+- more alive previews
+- more useful inactive office messaging
+- clearer "what can I do here?" cues
+
+## Suggested Branch Order
+
+Recommended order if this becomes a multi-day program:
+
+1. `feat/contextual-footer-hints`
+2. `feat/draft-safe-history`
+3. `feat/interaction-primitives`
+4. `feat/runtime-change-confirmations`
+5. `feat/safety-dialogs`
+6. `feat/structured-human-interviews`
+7. `feat/approval-steering`
+8. `feat/transcript-recovery`
+9. `feat/away-summaries`
+10. `feat/in-channel-readiness`
+11. `feat/insert-search-surfaces`
+12. `feat/runtime-state-model`
+13. `feat/execution-artifacts`
+14. `feat/session-memory`
+15. `feat/history-virtualization`
+16. `feat/capability-registry`
+
+## What Not To Do
+
+Avoid these failure modes:
+
+- do not copy CC-agent's full product shape
+- do not replace the office metaphor with a monolithic REPL
+- do not land superficial visual polish without runtime state cleanup
+- do not add more status chrome without making it more selective
+- do not make every improvement transcript-shaped if it is really a workflow
+
+## Practical Recommendation
+
+If only the next 2-3 branches are funded right now, do:
+
+1. contextual footer/help
+2. draft-preserving history/recall
+3. structured human interviews
+
+That combination gives WUPHF the highest short-term quality jump per unit of effort:
+
+- composition feels safer
+- help feels smarter
+- interviews become dramatically better
+
+If a larger investment is available, the real inflection point is:
+
+- normalized runtime state
+- execution artifacts
+- session memory
+
+That trio is where WUPHF starts gaining CC-agent-level rigor without losing its own identity.

--- a/docs/cc-agent-phase1-execution-plan.md
+++ b/docs/cc-agent-phase1-execution-plan.md
@@ -1,0 +1,442 @@
+# CC-agent Lessons: Phase 1 Execution Plan
+
+## Purpose
+
+This is the implementation-ready plan for Phase 1 of the CC-agent-inspired WUPHF improvements.
+
+It is narrower than the full roadmap in:
+
+- [cc-agent-implementation-roadmap.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-implementation-roadmap.md)
+
+This doc answers:
+
+- what the exact first branches should be
+- which real WUPHF files are likely to change
+- what each branch should prove
+- what termwright scenarios should validate
+
+## Current WUPHF Code Map for Phase 1
+
+Phase 1 mostly touches these existing codepaths:
+
+### Channel and composer runtime
+
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_composer.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_composer.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+What lives there today:
+
+- main channel model state
+- office vs `1:1` mode behavior
+- slash command handling
+- overlay updates
+- input cursor behavior
+- notice text
+- most dialog-ish interaction decisions
+
+Important constraint:
+
+- there is not yet a separate `channel_doctor.go` or `channel_history.go`
+- many Phase 1 changes will initially land in `channel.go` unless we extract small focused helpers first
+
+### Autocomplete
+
+- [autocomplete.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/autocomplete.go)
+- [autocomplete_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/autocomplete_test.go)
+
+What lives there today:
+
+- slash matching
+- selection cycling
+- accept/dismiss behavior
+- rendering of autocomplete rows
+
+### Existing UAT coverage
+
+- [office-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/office-channel-e2e.sh)
+- [one-on-one-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/one-on-one-channel-e2e.sh)
+
+What they already prove:
+
+- office boot
+- slash autocomplete smoke
+- `1:1` boot and switching
+- command blocking in `1:1`
+
+## Recommended Phase 1 Branch Order
+
+Recommended order:
+
+1. `feat/context-aware-keybindings`
+2. `feat/contextual-footer-hints`
+3. `feat/draft-safe-history`
+4. `feat/interaction-primitives`
+5. `feat/runtime-change-confirmations`
+6. `feat/safety-dialogs`
+
+That order keeps risk low:
+
+- branch 1 establishes the keyboard/focus contract the rest of the UI can rely on
+- branch 2 improves guidance without changing semantics much
+- branch 3 improves trust in composition
+- branch 4 creates reusable primitives
+- branch 5 starts using those primitives on real mode/runtime changes
+- branch 6 applies the same rigor to disruptive actions
+
+## Branch 1: `feat/context-aware-keybindings`
+
+### Goal
+
+Introduce an explicit interaction-context model for keyboard handling so overlays, autocomplete, help, transcript view, and future dialogs stop competing ad hoc.
+
+### What Should Change
+
+- define keyboard contexts for:
+  - composer/chat
+  - autocomplete
+  - confirmation
+  - transcript/thread view
+  - help/doctor overlays
+- centralize resolution of actions by active context
+- make `Esc` semantics consistent:
+  - dismiss overlay first
+  - cancel work only when nothing higher-priority owns `Esc`
+- keep the current bindings where possible; improve the model first
+
+### Likely Files
+
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_composer.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_composer.go)
+- [autocomplete.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/autocomplete.go)
+- likely new helper:
+  - `[internal/tui/keymap.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/keymap.go)` or similar
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+- [autocomplete_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/autocomplete_test.go)
+
+### Suggested Implementation Shape
+
+- add a small interaction-context enum or state model
+- avoid a giant generic framework; just make context ownership explicit
+- keep command rendering/help wired to the same context model
+
+### Termwright Scenarios
+
+1. Slash autocomplete open:
+   - `Esc` dismisses autocomplete, not the whole composer state
+2. Thread or transcript view open:
+   - navigation keys affect the open surface, not the hidden composer
+3. Doctor/help overlay open:
+   - `Esc` closes the overlay first
+4. No overlay active:
+   - existing cancel/back behavior still works
+
+### Done Means
+
+- keyboard behavior feels consistent across surfaces
+- overlay/focus bugs become much less likely
+## Branch 2: `feat/contextual-footer-hints`
+
+### Goal
+
+Make composer help and slash guidance more truthful, more contextual, and less static.
+
+### What Should Change
+
+- office vs `1:1` composer hints should differ more clearly
+- hint copy should respond to current state:
+  - plain compose
+  - reply mode
+  - interview pending
+  - blocked/needs-you
+  - command/autocomplete open
+- autocomplete rows should become more teachable:
+  - category or type label
+  - clearer descriptions
+  - better `1:1` vs office command expectations
+
+### Likely Files
+
+- [channel_composer.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_composer.go)
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [autocomplete.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/autocomplete.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+- [autocomplete_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/autocomplete_test.go)
+- [office-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/office-channel-e2e.sh)
+- [one-on-one-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/one-on-one-channel-e2e.sh)
+
+### Suggested Implementation Shape
+
+- keep the current renderer structure
+- add a small helper for contextual composer hint text instead of embedding more inline string logic in `renderComposer`
+- extend `tui.SlashCommand` if needed with a lightweight category field
+- keep this branch mostly presentational
+
+### Termwright Scenarios
+
+1. Office boot:
+   - verify composer hint reflects office context
+2. `1:1` boot:
+   - verify hint reflects direct mode
+3. Reply mode:
+   - verify reply-specific hint copy
+4. Pending interview:
+   - verify answer-specific hint copy
+5. Slash autocomplete:
+   - verify descriptions remain readable and mode-appropriate
+
+### Done Means
+
+- a user can tell what kind of input they are about to send without parsing surrounding chrome
+- `1:1` no longer feels like the same composer with a different header
+
+## Branch 3: `feat/draft-safe-history`
+
+### Goal
+
+Protect unfinished operator input during history and recall.
+
+### What Should Change
+
+- preserve draft before recall/navigation starts
+- restore draft when returning from recall
+- preserve cursor position
+- preserve thread composer draft independently from main composer draft
+- add a first safe recall primitive before building a richer search UI later
+
+### Likely Files
+
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- new helper likely:
+  - `[channel_history.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_history.go)` or similar
+- [channel_composer.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_composer.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+- new UAT additions in:
+  - [office-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/office-channel-e2e.sh)
+  - [one-on-one-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/one-on-one-channel-e2e.sh)
+
+### Suggested Implementation Shape
+
+- add explicit main/thread draft snapshot state to `channelModel`
+- implement one safe history step first:
+  - previous submitted input recall
+  - restore current draft on exit
+- do not build full fuzzy history search in this branch
+- optimize for trust before capability
+
+### Termwright Scenarios
+
+1. Main composer draft recall:
+   - type draft
+   - recall last sent prompt
+   - return
+   - verify original draft restored
+2. Thread composer draft recall:
+   - same as above inside thread panel
+3. Cursor preservation:
+   - draft with cursor in middle
+   - recall / restore
+   - verify cursor placement preserved
+4. `1:1` composer:
+   - verify same safety behavior
+
+### Done Means
+
+- history/recall cannot silently destroy unsent work
+- main and thread composers behave independently and safely
+
+## Branch 4: `feat/interaction-primitives`
+
+### Goal
+
+Create small reusable primitives for confirmation, continue, and pending states before more branches start needing them.
+
+### What Should Change
+
+- reusable double-press confirmation helper
+- reusable byline / continue treatment
+- reusable pending-state copy or style primitive
+- avoid feature-by-feature ad hoc confirmation strings
+
+### Likely Files
+
+- new helpers likely in:
+  - [internal/tui](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui)
+  - or small focused files under [cmd/wuphf](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf)
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+### Suggested Implementation Shape
+
+- keep primitives tiny
+- do not over-abstract
+- only extract patterns already used in:
+  - quit/exit
+  - reset-like actions
+  - picker cancel/confirm
+  - any future runtime toggle confirmations
+
+### Termwright Scenarios
+
+1. Repeated-press confirmation:
+   - verify pending state appears
+   - verify timeout clears it
+2. Continue prompt:
+   - verify consistent phrasing/style
+3. Cancel/confirm byline:
+   - verify consistent shape across at least two surfaces
+
+### Done Means
+
+- confirmation behavior feels like one product, not several unrelated prompts
+
+## Branch 5: `feat/runtime-change-confirmations`
+
+### Goal
+
+Add confirmation and explanation when the user changes settings/modes that materially affect cost, autonomy, or execution behavior.
+
+### Target Changes
+
+Highest-value candidates in current WUPHF:
+
+- provider switches
+- mode switches that reset or restart the runtime
+- possibly `1:1` enable/disable flows when context will be lost
+
+### Likely Files
+
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- new small dialog/helper file likely:
+  - `[channel_confirm.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_confirm.go)` or similar
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+- [one-on-one-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/one-on-one-channel-e2e.sh)
+
+### Suggested Implementation Shape
+
+- use the interaction primitives from branch 4
+- require confirmation only when:
+  - context or session shape materially changes
+  - execution provider changes
+  - cost/autonomy behavior changes in a meaningful way
+- keep copy short and operator-focused
+
+### Termwright Scenarios
+
+1. Switch provider:
+   - verify confirmation appears
+   - verify cancel path leaves state unchanged
+2. Disable `1:1`:
+   - verify confirmation if session context will be reset
+3. Confirm path:
+   - verify health/runtime actually changes after confirm, not before
+
+### Done Means
+
+- high-impact mode/runtime changes never feel like hidden state mutation
+
+## Branch 6: `feat/safety-dialogs`
+
+### Goal
+
+Put bounded, explicit safety UX in front of disruptive operations.
+
+### Target Changes
+
+First candidates in current WUPHF:
+
+- reset
+- transcript rewind/restore once it exists
+- risky workflow replay/apply/resume actions
+- destructive or context-resetting channel commands
+
+### Likely Files
+
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- likely new helper:
+  - `[channel_dialogs.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_dialogs.go)` or similar
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+- relevant UATs:
+  - [office-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/office-channel-e2e.sh)
+  - [one-on-one-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/one-on-one-channel-e2e.sh)
+
+### Suggested Implementation Shape
+
+- explain:
+  - what is about to happen
+  - what context may be lost
+  - what the user can do instead
+- keep detail bounded
+- avoid giant configuration screens
+
+### Termwright Scenarios
+
+1. `/reset`:
+   - verify dialog appears
+   - verify cancel leaves composer/session untouched
+   - verify confirm resets
+2. Any destructive runtime action introduced later:
+   - verify same dialog style and byline behavior
+
+### Done Means
+
+- disruptive actions feel deliberate and reversible where possible
+
+## Phase 1 Implementation Notes
+
+### 1. Do not over-refactor before the first branch lands
+
+`channel.go` is large, but Phase 1 does not require a big decomposition first.
+
+Use this rule:
+
+- extract only the helpers that make the branch cleaner immediately
+- defer major `channel.go` splitting until after the first 1-2 branches land
+
+### 2. Keep termwright scenarios small and behavior-focused
+
+Do not build giant end-to-end flows for Phase 1.
+
+Best pattern:
+
+- one short UAT scenario per behavior
+- one or two precise assertions per scenario
+- keep Go tests as the main correctness net
+
+### 3. Favor visible trust improvements over novelty
+
+If a choice is between:
+
+- adding a new trick
+- making an existing interaction safer and clearer
+
+choose the second one in Phase 1.
+
+## Recommended First Branch
+
+Start with:
+
+- `feat/contextual-footer-hints`
+
+Why:
+
+- lowest risk
+- immediate visible win
+- improves both office and `1:1`
+- creates better footing for later recall, confirmations, and dialogs
+
+## Recommended First Three Branches
+
+If you want the highest near-term quality jump, do these first:
+
+1. `feat/contextual-footer-hints`
+2. `feat/draft-safe-history`
+3. `feat/interaction-primitives`
+
+That combination should noticeably improve:
+
+- operator confidence
+- composition safety
+- consistency of small interactions
+
+without requiring deeper architectural work yet.

--- a/docs/cc-agent-phase2-execution-plan.md
+++ b/docs/cc-agent-phase2-execution-plan.md
@@ -1,0 +1,401 @@
+# CC-agent Lessons: Phase 2 Execution Plan
+
+## Purpose
+
+This is the implementation-ready plan for Phase 2 of the CC-agent-inspired WUPHF improvements.
+
+It corresponds to the `Medium UX Wins` portion of:
+
+- [cc-agent-implementation-roadmap.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-implementation-roadmap.md)
+
+This doc answers:
+
+- what the exact Phase 2 branches should be
+- which real WUPHF files are likely to change
+- what each branch should prove
+- what termwright scenarios should validate
+
+## Current WUPHF Code Map for Phase 2
+
+Phase 2 is mostly about making existing office/direct capabilities feel much more deliberate and navigable.
+
+### Channel UX and transcript surfaces
+
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_messages.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_messages.go)
+- [channel_thread.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_thread.go)
+- [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go)
+- [channel_layout.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_layout.go)
+- [channel_sidebar.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_sidebar.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+What lives there today:
+
+- office vs `1:1` rendering
+- runtime strip
+- channel/thread message stream
+- roster/sidebar state
+- notices, inline status, and event rendering
+
+### Picker, overlay, and focused interaction surfaces
+
+- [picker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/picker.go)
+- [picker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/picker_test.go)
+- [autocomplete.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/autocomplete.go)
+- [autocomplete_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/autocomplete_test.go)
+
+What lives there today:
+
+- simple picker behaviors
+- autocomplete list selection
+- lightweight overlay-style interactions
+
+### Human requests, interviews, approvals, and office state
+
+- [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go)
+- [ledger.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/ledger.go)
+- [broker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker_test.go)
+
+What lives there today:
+
+- pending interview state
+- approvals and requests
+- action/decision logging
+- scheduler and skill state
+
+### Existing UAT coverage
+
+- [office-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/office-channel-e2e.sh)
+- [one-on-one-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/one-on-one-channel-e2e.sh)
+- [human-judgment-uat.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/human-judgment-uat.sh)
+
+What they already prove:
+
+- office boot
+- `1:1` boot and switching
+- basic command handling
+- general office render sanity
+
+## Recommended Phase 2 Branch Order
+
+Recommended order:
+
+1. `feat/structured-human-interviews`
+2. `feat/approval-steering`
+3. `feat/agent-office-switcher`
+4. `feat/unread-navigation-semantics`
+5. `feat/transcript-recovery`
+6. `feat/away-summaries`
+7. `feat/in-channel-readiness`
+8. `feat/insert-search-surfaces`
+
+That order keeps the work coherent:
+
+- branch 1 upgrades the weakest human interaction path first
+- branch 2 improves high-stakes approvals while the interview machinery is fresh
+- branch 3 establishes one canonical navigation surface for office/direct multi-agent work
+- branch 4 makes long sessions easier to re-enter and scan
+- branch 5 adds safer transcript surgery once navigation is stronger
+- branch 6 improves return moments
+- branch 7 makes setup/blockers visible in-context
+- branch 8 improves authoring ergonomics once the main flows are stable
+
+## Branch 1: `feat/structured-human-interviews`
+
+### Goal
+
+Turn blocking interviews into explicit mini-flows instead of relying on raw transcript back-and-forth.
+
+### What Should Change
+
+- progress state for interview questions
+- clearer current-question focus
+- skip / continue / review-before-submit semantics
+- optional notes or rationale field where relevant
+- better in-channel rendering for interview progress and completion
+
+### Likely Files
+
+- [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go)
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go)
+- likely new helper:
+  - `[channel_interview.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_interview.go)` or similar
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+- [broker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker_test.go)
+
+### Termwright Scenarios
+
+1. Office interview pending:
+   - user can see progress and current question clearly
+2. Skip / continue:
+   - interview flow advances without losing context
+3. Review-before-submit:
+   - user can verify answers before final submission
+4. `1:1` blocking interview:
+   - direct session remains clear and uncluttered
+
+### Done Means
+
+- interviews feel like guided workflows instead of chat interruptions
+- users can tell how far through an interview they are
+
+## Branch 2: `feat/approval-steering`
+
+### Goal
+
+Let human approvals include steering at the decision point instead of only yes/no.
+
+### What Should Change
+
+- approve
+- approve with note
+- reject
+- reject with steer
+- better approval rendering in-channel and in `1:1`
+- clearer summary of what the approval affects
+
+### Likely Files
+
+- [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go)
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_messages.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_messages.go)
+- [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+- [broker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker_test.go)
+
+### Termwright Scenarios
+
+1. Approval with note:
+   - note is captured and visible to the agent/runtime
+2. Reject with steer:
+   - rejection keeps the corrective guidance
+3. Office approval:
+   - approval state is visible in-channel
+4. Direct approval:
+   - `1:1` completion report stays clear and direct
+
+### Done Means
+
+- approvals capture operator intent, not only permission
+
+## Branch 3: `feat/agent-office-switcher`
+
+### Goal
+
+Introduce one canonical switcher for office, direct sessions, and agent/task transcripts.
+
+### What Should Change
+
+- a primary switcher surface that always includes:
+  - main office
+  - direct sessions
+  - active agent/task transcripts
+- last-activity summary per destination
+- clearer viewed vs active vs running semantics
+- “back to main office” is always obvious
+
+### Likely Files
+
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_sidebar.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_sidebar.go)
+- [channel_layout.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_layout.go)
+- [picker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/picker.go)
+- [picker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/picker_test.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+### Termwright Scenarios
+
+1. Switch from office to agent/task transcript:
+   - path is obvious and reversible
+2. Switch back to main office:
+   - main stays a first-class destination
+3. Idle/completed agent:
+   - still visible and reviewable
+4. Active unread agent:
+   - switcher shows enough state to know why it matters
+
+### Done Means
+
+- WUPHF has one canonical navigation surface for office vs agent views
+
+## Branch 4: `feat/unread-navigation-semantics`
+
+### Goal
+
+Make “new since you looked” a first-class concept in channels and direct sessions.
+
+### What Should Change
+
+- unread divider
+- jump-to-latest behavior
+- compact “new messages” affordance
+- better handling when the user has scrolled away from the bottom
+
+### Likely Files
+
+- [channel_messages.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_messages.go)
+- [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go)
+- [channel_layout.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_layout.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+- [office-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/office-channel-e2e.sh)
+- [one-on-one-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/one-on-one-channel-e2e.sh)
+
+### Termwright Scenarios
+
+1. User scrolls away while new messages arrive:
+   - unread affordance appears
+2. Jump to latest:
+   - unread state clears correctly
+3. Direct session with new agent report:
+   - unread semantics remain clean
+
+### Done Means
+
+- long-running sessions feel grounded and re-enterable
+
+## Branch 5: `feat/transcript-recovery`
+
+### Goal
+
+Turn transcript rewind/restore/summarize into explicit operator tools.
+
+### What Should Change
+
+- restore from selected point
+- summarize from here / summarize up to here
+- safer recovery affordances
+- clearer explanation of what restore will change
+
+### Likely Files
+
+- [channel_thread.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_thread.go)
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_messages.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_messages.go)
+- likely new helper:
+  - `[channel_recovery.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_recovery.go)` or similar
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+### Termwright Scenarios
+
+1. Select message point:
+   - restore options are visible and bounded
+2. Summarize from here:
+   - summary path is clear before execution
+3. Cancel recovery:
+   - no hidden transcript mutation occurs
+
+### Done Means
+
+- transcript surgery feels deliberate and recoverable
+
+## Branch 6: `feat/away-summaries`
+
+### Goal
+
+Add concise “while you were away” summaries for office and direct sessions.
+
+### What Should Change
+
+- per-channel summary
+- per-`1:1` summary
+- “what changed / why it matters / what next” framing
+- summary trigger on return or explicit recall
+
+### Likely Files
+
+- [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go)
+- [ledger.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/ledger.go)
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+### Termwright Scenarios
+
+1. Leave office, accumulate changes, return:
+   - summary appears and is readable
+2. Leave `1:1`, return:
+   - summary is scoped to that direct session
+3. Summary with no meaningful changes:
+   - stays quiet
+
+### Done Means
+
+- returning to WUPHF feels guided instead of forensic
+
+## Branch 7: `feat/in-channel-readiness`
+
+### Goal
+
+Surface setup and readiness blockers in the main flow instead of only via `/doctor`.
+
+### What Should Change
+
+- blocked/provider-disconnected cards in-channel
+- stronger empty/offline state guidance
+- setup-required notices that point to next action
+- partial-readiness explanations in the workspace
+
+### Likely Files
+
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go)
+- [channel_messages.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_messages.go)
+- [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+### Termwright Scenarios
+
+1. Missing provider key:
+   - workspace surfaces it clearly
+2. Connected account missing:
+   - in-channel guidance is specific
+3. Partial office readiness:
+   - user can tell what still works
+
+### Done Means
+
+- readiness problems meet the user in the workspace
+
+## Branch 8: `feat/insert-search-surfaces`
+
+### Goal
+
+Improve authoring with insertion/search overlays instead of making everything raw text composition.
+
+### What Should Change
+
+- richer path/reference insert surfaces
+- safer insertion into prompts and workflow specs
+- search surfaces that support insertion, not only navigation
+
+### Likely Files
+
+- [picker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/picker.go)
+- [channel_composer.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_composer.go)
+- [autocomplete.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/autocomplete.go)
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [picker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/picker_test.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+### Termwright Scenarios
+
+1. Insert path/reference into prompt:
+   - result lands exactly in composer
+2. Search while composing a workflow prompt:
+   - authoring is easier than raw typing
+3. Cancel overlay:
+   - draft remains intact
+
+### Done Means
+
+- composition becomes faster and less brittle
+
+## Phase 2 Success Criteria
+
+- interviews feel structured and finishable
+- approvals capture guidance, not only permission
+- office/agent navigation is coherent
+- unread and away semantics make long sessions easier to manage
+- readiness issues surface naturally where the user already is
+- authoring feels assisted, not purely text-only

--- a/docs/cc-agent-phase3-execution-plan.md
+++ b/docs/cc-agent-phase3-execution-plan.md
@@ -1,0 +1,369 @@
+# CC-agent Lessons: Phase 3 Execution Plan
+
+## Purpose
+
+This is the implementation-ready plan for Phase 3 of the CC-agent-inspired WUPHF improvements.
+
+It corresponds to the `Deep Architectural Polish` portion of:
+
+- [cc-agent-implementation-roadmap.md](/Users/najmuzzaman/Documents/nex/WUPHF/docs/cc-agent-implementation-roadmap.md)
+
+This doc answers:
+
+- what the exact Phase 3 branches should be
+- which real WUPHF files are likely to change
+- what each branch should prove
+- what termwright and runtime scenarios should validate
+
+## Current WUPHF Code Map for Phase 3
+
+Phase 3 is where the durable substrate work happens.
+
+### Runtime, office, and retained state
+
+- [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go)
+- [ledger.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/ledger.go)
+- [launcher.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/launcher.go)
+- [scheduler_runtime.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/scheduler_runtime.go)
+- [session_mode.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/session_mode.go)
+- [broker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker_test.go)
+- [launcher_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/launcher_test.go)
+
+What lives there today:
+
+- office state persistence
+- actions/signals/decisions/watchdogs
+- scheduler execution
+- agent launch/runtime bridging
+- office vs `1:1` session mode
+
+### Channel rendering and state consumption
+
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_messages.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_messages.go)
+- [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go)
+- [channel_layout.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_layout.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+What lives there today:
+
+- current UI-facing state assembly
+- message/event rendering
+- runtime strip and header consumption
+- cached rendering
+
+### Action/workflow/provider substrate
+
+- [types.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/action/types.go)
+- [registry.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/action/registry.go)
+- [composio.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/action/composio.go)
+- [composio_workflows.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/action/composio_workflows.go)
+- [workflow_store.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/action/workflow_store.go)
+- [actions.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/teammcp/actions.go)
+
+What lives there today:
+
+- provider routing
+- external action execution
+- generic workflow storage/execution
+- skill mirroring and scheduler wiring
+
+### Existing UAT coverage
+
+- [office-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/office-channel-e2e.sh)
+- [one-on-one-channel-e2e.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/one-on-one-channel-e2e.sh)
+- [autonomy-acceptance.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/autonomy-acceptance.sh)
+- [comprehensive-uat.sh](/Users/najmuzzaman/Documents/nex/WUPHF/tests/uat/comprehensive-uat.sh)
+
+## Recommended Phase 3 Branch Order
+
+Recommended order:
+
+1. `feat/runtime-state-model`
+2. `feat/per-agent-transcript-inbox`
+3. `feat/execution-artifacts`
+4. `feat/session-memory`
+5. `feat/history-virtualization`
+6. `feat/tmux-capability-layer`
+7. `feat/capability-registry`
+
+That order is deliberate:
+
+- branch 1 creates the UI/runtime contract
+- branch 2 fixes multi-agent transcript and notification scoping
+- branch 3 turns work into retained objects
+- branch 4 makes long-lived sessions survivable
+- branch 5 scales the channel/direct transcript experience
+- branch 6 hardens terminal behavior in tmux/screen environments
+- branch 7 centralizes capability exposure after the runtime model is clearer
+
+## Branch 1: `feat/runtime-state-model`
+
+### Goal
+
+Create one normalized UI-facing runtime state model for agents, jobs, readiness, and session mode.
+
+### What Should Change
+
+- explicit runtime state object that unifies:
+  - office vs `1:1`
+  - active work
+  - blocked/waiting-human state
+  - readiness/integration state
+  - active execution context
+- channel and direct UI consume that same model
+- less implicit derivation spread across broker, launcher, and render code
+
+### Likely Files
+
+- [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go)
+- [launcher.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/launcher.go)
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go)
+- likely new helper/module:
+  - `[internal/tui/runtime_state.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/runtime_state.go)` or similar
+- [broker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker_test.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+### Termwright Scenarios
+
+1. Same blocked state appears consistently in office and `1:1`
+2. Active work summary matches underlying broker/runtime state
+3. Readiness and integration state do not drift between views
+
+### Done Means
+
+- UI surfaces pull from one coherent runtime model
+
+## Branch 2: `feat/per-agent-transcript-inbox`
+
+### Goal
+
+Give each agent/task its own transcript scope and first-class inbox/outbox model.
+
+### What Should Change
+
+- transcript ownership per agent/task
+- inbox/outbox model for directed notifications and human messages
+- “viewed transcript” distinct from office feed
+- suppression of unrelated queue noise while zoomed into one agent/task
+
+### Likely Files
+
+- [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go)
+- [launcher.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/launcher.go)
+- [channel_messages.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_messages.go)
+- [channel_thread.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_thread.go)
+- [channel_sidebar.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_sidebar.go)
+- [broker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker_test.go)
+- [launcher_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/launcher_test.go)
+
+### Termwright Scenarios
+
+1. User zooms into one agent/task:
+   - unrelated office noise is suppressed
+2. Directed human message:
+   - lands in the intended agent/task scope
+3. Completed agent/task transcript:
+   - remains reviewable
+
+### Done Means
+
+- multi-agent work no longer depends on one flattened feed
+
+## Branch 3: `feat/execution-artifacts`
+
+### Goal
+
+Turn tasks, workflows, approvals, and external actions into retained execution artifacts.
+
+### What Should Change
+
+- explicit lifecycle:
+  - started
+  - running
+  - blocked
+  - completed
+  - failed
+  - interrupted
+- retained partial outputs and summaries
+- richer progress snapshots
+- review/resume metadata
+
+### Likely Files
+
+- [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go)
+- [ledger.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/ledger.go)
+- [scheduler_runtime.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/scheduler_runtime.go)
+- [actions.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/teammcp/actions.go)
+- [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go)
+- [broker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker_test.go)
+- [actions_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/teammcp/actions_test.go)
+
+### Termwright Scenarios
+
+1. External action dry-run then execute:
+   - artifact retains both planned and executed states
+2. Interrupted workflow:
+   - partial progress remains visible
+3. Completed task/workflow:
+   - review metadata survives the run
+
+### Done Means
+
+- work is represented as retained runtime objects, not only transcript text
+
+## Branch 4: `feat/session-memory`
+
+### Goal
+
+Add session-operational memory and transcript compaction distinct from Nex organizational memory.
+
+### What Should Change
+
+- session summaries
+- transcript compaction points
+- recovery summaries
+- continuity for long-running office and direct sessions
+
+### Likely Files
+
+- [broker.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker.go)
+- [ledger.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/ledger.go)
+- [channel_messages.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_messages.go)
+- likely new package/module:
+  - `[internal/team/session_memory.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/session_memory.go)` or similar
+- [broker_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/broker_test.go)
+
+### Termwright Scenarios
+
+1. Long office session compacts cleanly
+2. Returning user sees recovery summary
+3. Direct session preserves operational continuity across restart
+
+### Done Means
+
+- WUPHF gains session memory that complements Nex instead of pretending Nex replaces it
+
+## Branch 5: `feat/history-virtualization`
+
+### Goal
+
+Scale long transcript rendering beyond cache-only optimization.
+
+### What Should Change
+
+- visible-row windowing
+- lower first-paint work
+- incremental row generation
+- reduced markdown/render work outside the visible range
+
+### Likely Files
+
+- [channel_render.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_render.go)
+- [channel_layout.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_layout.go)
+- [channel_messages.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_messages.go)
+- [channel.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel.go)
+- [channel_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/cmd/wuphf/channel_test.go)
+
+### Termwright Scenarios
+
+1. Very long office history:
+   - first paint remains usable
+2. Scroll around old content:
+   - navigation stays responsive
+3. Live updates while scrolled:
+   - unread semantics remain correct
+
+### Done Means
+
+- long-running channels and direct sessions remain performant in practice
+
+## Branch 6: `feat/tmux-capability-layer`
+
+### Goal
+
+Centralize tmux/screen-specific clipboard, notification, status, and redraw behavior.
+
+### What Should Change
+
+- one tmux-aware capability layer for:
+  - clipboard/copy
+  - bell/notification
+  - status redraw semantics
+  - terminal capability detection
+- less ad hoc behavior split across launcher and UI
+
+### Likely Files
+
+- [launcher.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/launcher.go)
+- [tmux_manager.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/tmux_manager.go)
+- [statusbar.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/statusbar.go)
+- likely new helper/module:
+  - `[internal/tui/termcaps.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/termcaps.go)` or similar
+- [tmux_manager_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/tui/tmux_manager_test.go)
+- [launcher_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/team/launcher_test.go)
+
+### Termwright Scenarios
+
+1. tmux office boot:
+   - status redraw remains clean
+2. Copy/selection flow:
+   - expected path is visible and consistent
+3. Notification path under tmux:
+   - no corrupted redraws
+
+### Done Means
+
+- tmux is treated as a supported runtime contract, not just a shell wrapper
+
+## Branch 7: `feat/capability-registry`
+
+### Goal
+
+Centralize capability assembly for tools, actions, workflows, skills, and future plugins.
+
+### What Should Change
+
+- one registry for:
+  - office tools
+  - `1:1` tools
+  - Nex capabilities
+  - action providers
+  - workflows
+  - future plugins/skills
+- clearer mode-aware capability exposure
+- safer evolution of permissions and UI surfacing
+
+### Likely Files
+
+- [server.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/teammcp/server.go)
+- [actions.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/teammcp/actions.go)
+- [registry.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/action/registry.go)
+- [types.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/action/types.go)
+- likely new helper/module:
+  - `[internal/capabilities](/Users/najmuzzaman/Documents/nex/WUPHF/internal/capabilities)` or similar
+- [server_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/teammcp/server_test.go)
+- [actions_test.go](/Users/najmuzzaman/Documents/nex/WUPHF/internal/teammcp/actions_test.go)
+
+### Termwright Scenarios
+
+1. Office vs `1:1` capability surfaces:
+   - expected commands/tools are available
+2. Provider switch:
+   - capability exposure changes cleanly
+3. Missing provider or integration:
+   - UI/readiness remains truthful
+
+### Done Means
+
+- capability exposure is deliberate, centralized, and mode-aware
+
+## Phase 3 Success Criteria
+
+- UI surfaces draw from one coherent runtime model
+- agent/task transcripts and notifications have explicit ownership
+- work is retained as artifacts, not only transcript traces
+- long sessions remain understandable and performant
+- tmux behavior is intentional and reliable
+- capability exposure becomes easier to reason about and evolve safely

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -304,9 +304,16 @@ func TestEnsureRunningDoesNotHoldServiceMutexDuringTick(t *testing.T) {
 
 	started := make(chan struct{}, 1)
 	release := make(chan struct{})
+	streamFinished := make(chan struct{}, 1)
 	mockStream := func(msgs []Message, tls []AgentTool) <-chan StreamChunk {
 		ch := make(chan StreamChunk)
 		go func() {
+			defer func() {
+				select {
+				case streamFinished <- struct{}{}:
+				default:
+				}
+			}()
 			select {
 			case started <- struct{}{}:
 			default:
@@ -367,6 +374,28 @@ func TestEnsureRunningDoesNotHoldServiceMutexDuringTick(t *testing.T) {
 	}
 
 	close(release)
+
+	select {
+	case <-streamFinished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for blocked stream to finish")
+	}
+
+	if err := svc.Stop("blocking"); err != nil {
+		t.Fatalf("Stop: %v", err)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		svc.mu.Lock()
+		_, running := svc.tickTimers["blocking"]
+		svc.mu.Unlock()
+		if !running {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("tick timer still running after Stop")
 }
 
 func TestListAgents(t *testing.T) {

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -48,9 +48,11 @@ type channelMessage struct {
 }
 
 type interviewOption struct {
-	ID          string `json:"id"`
-	Label       string `json:"label"`
-	Description string `json:"description"`
+	ID           string `json:"id"`
+	Label        string `json:"label"`
+	Description  string `json:"description"`
+	RequiresText bool   `json:"requires_text,omitempty"`
+	TextHint     string `json:"text_hint,omitempty"`
 }
 
 type interviewAnswer struct {
@@ -85,32 +87,32 @@ type humanInterview struct {
 }
 
 type teamTask struct {
-	ID               string `json:"id"`
-	Channel          string `json:"channel,omitempty"`
-	Title            string `json:"title"`
-	Details          string `json:"details,omitempty"`
-	Owner            string `json:"owner,omitempty"`
-	Status           string `json:"status"`
-	CreatedBy        string `json:"created_by"`
-	ThreadID         string `json:"thread_id,omitempty"`
-	TaskType         string `json:"task_type,omitempty"`
-	PipelineID       string `json:"pipeline_id,omitempty"`
-	PipelineStage    string `json:"pipeline_stage,omitempty"`
-	ExecutionMode    string `json:"execution_mode,omitempty"`
-	ReviewState      string `json:"review_state,omitempty"`
-	SourceSignalID   string `json:"source_signal_id,omitempty"`
-	SourceDecisionID string `json:"source_decision_id,omitempty"`
-	WorktreePath     string `json:"worktree_path,omitempty"`
+	ID               string   `json:"id"`
+	Channel          string   `json:"channel,omitempty"`
+	Title            string   `json:"title"`
+	Details          string   `json:"details,omitempty"`
+	Owner            string   `json:"owner,omitempty"`
+	Status           string   `json:"status"`
+	CreatedBy        string   `json:"created_by"`
+	ThreadID         string   `json:"thread_id,omitempty"`
+	TaskType         string   `json:"task_type,omitempty"`
+	PipelineID       string   `json:"pipeline_id,omitempty"`
+	PipelineStage    string   `json:"pipeline_stage,omitempty"`
+	ExecutionMode    string   `json:"execution_mode,omitempty"`
+	ReviewState      string   `json:"review_state,omitempty"`
+	SourceSignalID   string   `json:"source_signal_id,omitempty"`
+	SourceDecisionID string   `json:"source_decision_id,omitempty"`
+	WorktreePath     string   `json:"worktree_path,omitempty"`
 	WorktreeBranch   string   `json:"worktree_branch,omitempty"`
 	DependsOn        []string `json:"depends_on,omitempty"`
 	Blocked          bool     `json:"blocked,omitempty"`
 	AckedAt          string   `json:"acked_at,omitempty"`
 	DueAt            string   `json:"due_at,omitempty"`
-	FollowUpAt       string `json:"follow_up_at,omitempty"`
-	ReminderAt       string `json:"reminder_at,omitempty"`
-	RecheckAt        string `json:"recheck_at,omitempty"`
-	CreatedAt        string `json:"created_at"`
-	UpdatedAt        string `json:"updated_at"`
+	FollowUpAt       string   `json:"follow_up_at,omitempty"`
+	ReminderAt       string   `json:"reminder_at,omitempty"`
+	RecheckAt        string   `json:"recheck_at,omitempty"`
+	CreatedAt        string   `json:"created_at"`
+	UpdatedAt        string   `json:"updated_at"`
 }
 
 type channelSurface struct {
@@ -248,25 +250,25 @@ type teamSkill struct {
 }
 
 type brokerState struct {
-	Messages          []channelMessage       `json:"messages"`
-	Members           []officeMember         `json:"members,omitempty"`
-	Channels          []teamChannel          `json:"channels,omitempty"`
-	SessionMode       string                 `json:"session_mode,omitempty"`
-	OneOnOneAgent     string                 `json:"one_on_one_agent,omitempty"`
-	Tasks             []teamTask             `json:"tasks,omitempty"`
-	Requests          []humanInterview       `json:"requests,omitempty"`
-	Actions           []officeActionLog      `json:"actions,omitempty"`
-	Signals           []officeSignalRecord   `json:"signals,omitempty"`
-	Decisions         []officeDecisionRecord `json:"decisions,omitempty"`
-	Watchdogs         []watchdogAlert        `json:"watchdogs,omitempty"`
-	Scheduler         []schedulerJob         `json:"scheduler,omitempty"`
-	Skills            []teamSkill                   `json:"skills,omitempty"`
-	SharedMemory      map[string]map[string]string  `json:"shared_memory,omitempty"`
-	Counter           int                           `json:"counter"`
-	NotificationSince string                 `json:"notification_since,omitempty"`
-	InsightsSince     string                 `json:"insights_since,omitempty"`
-	PendingInterview  *humanInterview        `json:"pending_interview,omitempty"`
-	Usage             teamUsageState         `json:"usage,omitempty"`
+	Messages          []channelMessage             `json:"messages"`
+	Members           []officeMember               `json:"members,omitempty"`
+	Channels          []teamChannel                `json:"channels,omitempty"`
+	SessionMode       string                       `json:"session_mode,omitempty"`
+	OneOnOneAgent     string                       `json:"one_on_one_agent,omitempty"`
+	Tasks             []teamTask                   `json:"tasks,omitempty"`
+	Requests          []humanInterview             `json:"requests,omitempty"`
+	Actions           []officeActionLog            `json:"actions,omitempty"`
+	Signals           []officeSignalRecord         `json:"signals,omitempty"`
+	Decisions         []officeDecisionRecord       `json:"decisions,omitempty"`
+	Watchdogs         []watchdogAlert              `json:"watchdogs,omitempty"`
+	Scheduler         []schedulerJob               `json:"scheduler,omitempty"`
+	Skills            []teamSkill                  `json:"skills,omitempty"`
+	SharedMemory      map[string]map[string]string `json:"shared_memory,omitempty"`
+	Counter           int                          `json:"counter"`
+	NotificationSince string                       `json:"notification_since,omitempty"`
+	InsightsSince     string                       `json:"insights_since,omitempty"`
+	PendingInterview  *humanInterview              `json:"pending_interview,omitempty"`
+	Usage             teamUsageState               `json:"usage,omitempty"`
 }
 
 type usageTotals struct {
@@ -289,33 +291,33 @@ type teamUsageState struct {
 // Broker is a lightweight HTTP message broker for the team channel.
 // All agent MCP instances connect to this shared broker.
 type Broker struct {
-	messages          []channelMessage
-	members           []officeMember
-	channels          []teamChannel
-	sessionMode       string
-	oneOnOneAgent     string
-	tasks             []teamTask
-	requests          []humanInterview
-	actions           []officeActionLog
-	signals           []officeSignalRecord
-	decisions         []officeDecisionRecord
-	watchdogs         []watchdogAlert
-	scheduler         []schedulerJob
-	skills            []teamSkill
-	sharedMemory      map[string]map[string]string // namespace → key → value
-	lastTaggedAt      map[string]time.Time   // when each agent was last @mentioned
-	lastPaneSnapshot  map[string]string      // last captured pane content per agent (for change detection)
-	seenTelegramGroups map[int64]string      // chat_id -> title, populated by transport
-	counter           int
-	notificationSince string
-	insightsSince     string
-	pendingInterview  *humanInterview
-	usage             teamUsageState
-	externalDelivered map[string]struct{} // message IDs already queued for external delivery
-	mu                sync.Mutex
-	server            *http.Server
-	token             string // shared secret for authenticating requests
-	addr              string // actual listen address (useful when port=0)
+	messages           []channelMessage
+	members            []officeMember
+	channels           []teamChannel
+	sessionMode        string
+	oneOnOneAgent      string
+	tasks              []teamTask
+	requests           []humanInterview
+	actions            []officeActionLog
+	signals            []officeSignalRecord
+	decisions          []officeDecisionRecord
+	watchdogs          []watchdogAlert
+	scheduler          []schedulerJob
+	skills             []teamSkill
+	sharedMemory       map[string]map[string]string // namespace → key → value
+	lastTaggedAt       map[string]time.Time         // when each agent was last @mentioned
+	lastPaneSnapshot   map[string]string            // last captured pane content per agent (for change detection)
+	seenTelegramGroups map[int64]string             // chat_id -> title, populated by transport
+	counter            int
+	notificationSince  string
+	insightsSince      string
+	pendingInterview   *humanInterview
+	usage              teamUsageState
+	externalDelivered  map[string]struct{} // message IDs already queued for external delivery
+	mu                 sync.Mutex
+	server             *http.Server
+	token              string // shared secret for authenticating requests
+	addr               string // actual listen address (useful when port=0)
 }
 
 func taskNeedsLocalWorktree(task *teamTask) bool {
@@ -1278,6 +1280,184 @@ func requestNeedsHumanDecision(req humanInterview) bool {
 	}
 }
 
+func requestOptionDefaults(kind string) ([]interviewOption, string) {
+	switch normalizeRequestKind(kind) {
+	case "approval":
+		return []interviewOption{
+			{ID: "approve", Label: "Approve", Description: "Green-light this and let the team execute immediately."},
+			{ID: "approve_with_note", Label: "Approve with note", Description: "Proceed, but attach explicit constraints or guardrails.", RequiresText: true, TextHint: "Type the conditions, constraints, or guardrails the team must follow."},
+			{ID: "needs_more_info", Label: "Need more info", Description: "Gather more context before making the approval call."},
+			{ID: "reject", Label: "Reject", Description: "Do not proceed with this."},
+			{ID: "reject_with_steer", Label: "Reject with steer", Description: "Do not proceed as proposed. Redirect the team with clearer steering.", RequiresText: true, TextHint: "Type the steering, redirect, or rationale for rejecting this request."},
+		}, "approve"
+	case "confirm":
+		return []interviewOption{
+			{ID: "confirm_proceed", Label: "Confirm", Description: "Looks good. Proceed as planned."},
+			{ID: "adjust", Label: "Adjust", Description: "Proceed only after applying the changes you specify.", RequiresText: true, TextHint: "Type the changes that must happen before proceeding."},
+			{ID: "reassign", Label: "Reassign", Description: "Move this to a different owner or scope.", RequiresText: true, TextHint: "Type who should own this instead, or how the scope should change."},
+			{ID: "hold", Label: "Hold", Description: "Do not act yet. Keep this pending for review."},
+		}, "confirm_proceed"
+	case "choice":
+		return []interviewOption{
+			{ID: "move_fast", Label: "Move fast", Description: "Bias toward speed. Ship now and iterate later."},
+			{ID: "balanced", Label: "Balanced", Description: "Balance speed, risk, and quality."},
+			{ID: "be_careful", Label: "Be careful", Description: "Bias toward caution and a tighter review loop."},
+			{ID: "needs_more_info", Label: "Need more info", Description: "Gather more context before deciding.", RequiresText: true, TextHint: "Type what is missing or what should be investigated next."},
+			{ID: "delegate", Label: "Delegate", Description: "Hand this to a specific owner for a closer call.", RequiresText: true, TextHint: "Type who should own this decision and any guidance for them."},
+		}, "balanced"
+	case "interview":
+		return []interviewOption{
+			{ID: "answer_directly", Label: "Answer directly", Description: "Respond in your own words below."},
+			{ID: "need_more_context", Label: "Need more context", Description: "Ask the office to bring back more context before you decide.", RequiresText: true, TextHint: "Type what context is missing or what should be clarified next."},
+		}, "answer_directly"
+	case "freeform", "secret":
+		return []interviewOption{
+			{ID: "proceed", Label: "Proceed", Description: "Let the team handle it with their best judgment."},
+			{ID: "give_direction", Label: "Give direction", Description: "Proceed, but only after you provide specific guidance.", RequiresText: true, TextHint: "Type the direction or constraints the team should follow."},
+			{ID: "delegate", Label: "Delegate", Description: "Route this to a specific person.", RequiresText: true, TextHint: "Type who should own this and what they should do."},
+			{ID: "hold", Label: "Hold", Description: "Pause until you review this further."},
+		}, "proceed"
+	default:
+		return []interviewOption{
+			{ID: "proceed", Label: "Proceed", Description: "Let the team handle it with their best judgment."},
+			{ID: "give_direction", Label: "Give direction", Description: "Add specific guidance the team should follow.", RequiresText: true, TextHint: "Provide the direction or constraints the team should follow."},
+			{ID: "delegate", Label: "Delegate", Description: "Route this to a specific person or role.", RequiresText: true, TextHint: "Name the person or role that should own the next call."},
+			{ID: "hold", Label: "Hold", Description: "Pause until you review this further."},
+		}, "proceed"
+	}
+}
+
+func enrichRequestOptions(kind string, options []interviewOption) []interviewOption {
+	if len(options) == 0 {
+		defaults, _ := requestOptionDefaults(kind)
+		return defaults
+	}
+	defaults, _ := requestOptionDefaults(kind)
+	meta := make(map[string]interviewOption, len(defaults))
+	for _, option := range defaults {
+		meta[strings.TrimSpace(option.ID)] = option
+	}
+	out := make([]interviewOption, 0, len(options))
+	for _, option := range options {
+		id := strings.TrimSpace(option.ID)
+		option.Label = strings.TrimSpace(option.Label)
+		option.Description = strings.TrimSpace(option.Description)
+		option.TextHint = strings.TrimSpace(option.TextHint)
+		if id == "" && option.Label != "" {
+			id = normalizeRequestOptionID(option.Label)
+			option.ID = id
+		}
+		if base, ok := meta[id]; ok {
+			if !option.RequiresText {
+				option.RequiresText = base.RequiresText
+			}
+			if strings.TrimSpace(option.TextHint) == "" {
+				option.TextHint = base.TextHint
+			}
+			if strings.TrimSpace(option.Label) == "" {
+				option.Label = base.Label
+			}
+			if strings.TrimSpace(option.Description) == "" {
+				option.Description = base.Description
+			}
+		}
+		out = append(out, option)
+	}
+	return out
+}
+
+func normalizeRequestOptions(kind, recommendedID string, options []interviewOption) ([]interviewOption, string) {
+	normalized := enrichRequestOptions(kind, options)
+	recommendedID = strings.TrimSpace(recommendedID)
+	if recommendedID != "" {
+		for _, option := range normalized {
+			if strings.TrimSpace(option.ID) == recommendedID {
+				return normalized, recommendedID
+			}
+		}
+	}
+	_, fallback := requestOptionDefaults(kind)
+	for _, option := range normalized {
+		if strings.TrimSpace(option.ID) == fallback {
+			return normalized, fallback
+		}
+	}
+	if len(normalized) > 0 {
+		return normalized, strings.TrimSpace(normalized[0].ID)
+	}
+	return normalized, fallback
+}
+
+func findRequestOption(req humanInterview, choiceID string) *interviewOption {
+	choiceID = strings.TrimSpace(choiceID)
+	if choiceID == "" {
+		return nil
+	}
+	for i := range req.Options {
+		if strings.TrimSpace(req.Options[i].ID) == choiceID {
+			return &req.Options[i]
+		}
+	}
+	return nil
+}
+
+func formatRequestAnswerMessage(req humanInterview, answer interviewAnswer) string {
+	if req.Secret {
+		return fmt.Sprintf("Answered @%s's request privately.", req.From)
+	}
+	custom := strings.TrimSpace(answer.CustomText)
+	switch strings.TrimSpace(answer.ChoiceID) {
+	case "approve":
+		return fmt.Sprintf("Approved @%s's request.", req.From)
+	case "approve_with_note":
+		if custom != "" {
+			return fmt.Sprintf("Approved @%s's request with note: %s", req.From, custom)
+		}
+		return fmt.Sprintf("Approved @%s's request with a note.", req.From)
+	case "reject":
+		return fmt.Sprintf("Rejected @%s's request.", req.From)
+	case "reject_with_steer":
+		if custom != "" {
+			return fmt.Sprintf("Rejected @%s's request with steering: %s", req.From, custom)
+		}
+		return fmt.Sprintf("Rejected @%s's request with steering.", req.From)
+	case "confirm_proceed":
+		return fmt.Sprintf("Confirmed @%s's request.", req.From)
+	case "adjust":
+		if custom != "" {
+			return fmt.Sprintf("Requested adjustments from @%s: %s", req.From, custom)
+		}
+		return fmt.Sprintf("Requested adjustments from @%s.", req.From)
+	case "reassign":
+		if custom != "" {
+			return fmt.Sprintf("Reassigned @%s's request: %s", req.From, custom)
+		}
+		return fmt.Sprintf("Reassigned @%s's request.", req.From)
+	case "hold":
+		return fmt.Sprintf("Put @%s's request on hold.", req.From)
+	case "delegate":
+		if custom != "" {
+			return fmt.Sprintf("Delegated @%s's request: %s", req.From, custom)
+		}
+		return fmt.Sprintf("Delegated @%s's request.", req.From)
+	case "needs_more_info":
+		if custom != "" {
+			return fmt.Sprintf("Asked @%s for more information: %s", req.From, custom)
+		}
+		return fmt.Sprintf("Asked @%s for more information.", req.From)
+	}
+	if custom != "" && strings.TrimSpace(answer.ChoiceText) != "" {
+		return fmt.Sprintf("Answered @%s's request with %s: %s", req.From, answer.ChoiceText, custom)
+	}
+	if custom != "" {
+		return fmt.Sprintf("Answered @%s's request: %s", req.From, custom)
+	}
+	if strings.TrimSpace(answer.ChoiceText) != "" {
+		return fmt.Sprintf("Answered @%s's request: %s", req.From, answer.ChoiceText)
+	}
+	return fmt.Sprintf("Answered @%s's request.", req.From)
+}
+
 func activeRequests(requests []humanInterview) []humanInterview {
 	out := make([]humanInterview, 0, len(requests))
 	for _, req := range requests {
@@ -1296,6 +1476,21 @@ func firstBlockingRequest(requests []humanInterview) *humanInterview {
 		}
 	}
 	return nil
+}
+
+func normalizeRequestKind(kind string) string {
+	kind = strings.TrimSpace(strings.ToLower(kind))
+	if kind == "" {
+		return "choice"
+	}
+	return kind
+}
+
+func normalizeRequestOptionID(label string) string {
+	label = strings.TrimSpace(strings.ToLower(label))
+	label = strings.ReplaceAll(label, "-", "_")
+	label = strings.ReplaceAll(label, " ", "_")
+	return label
 }
 
 func containsString(items []string, want string) bool {
@@ -2945,6 +3140,7 @@ func (b *Broker) handleReactions(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }
+
 // RecordTelegramGroup saves a group chat ID and title seen by the transport.
 func (b *Broker) RecordTelegramGroup(chatID int64, title string) {
 	b.mu.Lock()
@@ -3092,9 +3288,8 @@ func (b *Broker) CreateRequest(req humanInterview) (humanInterview, error) {
 	req.Channel = channel
 	req.CreatedAt = now
 	req.UpdatedAt = now
-	if strings.TrimSpace(req.Kind) == "" {
-		req.Kind = "choice"
-	}
+	req.Kind = normalizeRequestKind(req.Kind)
+	req.Options, req.RecommendedID = normalizeRequestOptions(req.Kind, req.RecommendedID, req.Options)
 	if strings.TrimSpace(req.Status) == "" {
 		req.Status = "pending"
 	}
@@ -3121,28 +3316,57 @@ func (b *Broker) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sinceID := q.Get("since_id")
-	mySlug := q.Get("my_slug")
+	mySlug := strings.TrimSpace(q.Get("my_slug"))
+	viewerSlug := strings.TrimSpace(q.Get("viewer_slug"))
+	threadID := strings.TrimSpace(q.Get("thread_id"))
+	if threadID == "" {
+		threadID = strings.TrimSpace(q.Get("reply_to"))
+	}
+	scope := normalizeMessageScope(q.Get("scope"))
+	if rawScope := strings.TrimSpace(q.Get("scope")); rawScope != "" && scope == "" {
+		http.Error(w, "invalid message scope", http.StatusBadRequest)
+		return
+	}
 	channel := normalizeChannelSlug(q.Get("channel"))
 	if channel == "" {
 		channel = "general"
 	}
+	accessSlug := mySlug
+	if accessSlug == "" {
+		accessSlug = viewerSlug
+	}
 
 	b.mu.Lock()
-	if !b.canAccessChannelLocked(mySlug, channel) {
+	if !b.canAccessChannelLocked(accessSlug, channel) {
 		b.mu.Unlock()
 		http.Error(w, "channel access denied", http.StatusForbidden)
 		return
 	}
-	messages := make([]channelMessage, 0, len(b.messages))
+	channelMessages := make([]channelMessage, 0, len(b.messages))
 	for _, msg := range b.messages {
-		if normalizeChannelSlug(msg.Channel) == channel {
-			if b.sessionMode == SessionModeOneOnOne {
-				if !b.isOneOnOneDMMessage(msg) {
-					continue
-				}
-			}
-			messages = append(messages, msg)
+		if normalizeChannelSlug(msg.Channel) != channel {
+			continue
 		}
+		channelMessages = append(channelMessages, msg)
+	}
+	messageIndex := make(map[string]channelMessage, len(channelMessages))
+	for _, msg := range channelMessages {
+		if id := strings.TrimSpace(msg.ID); id != "" {
+			messageIndex[id] = msg
+		}
+	}
+	messages := make([]channelMessage, 0, len(channelMessages))
+	for _, msg := range channelMessages {
+		if b.sessionMode == SessionModeOneOnOne && !b.isOneOnOneDMMessage(msg) {
+			continue
+		}
+		if threadID != "" && !messageInThread(msg, threadID) {
+			continue
+		}
+		if scope != "" && viewerSlug != "" && !messageMatchesViewerScope(msg, viewerSlug, scope, messageIndex) {
+			continue
+		}
+		messages = append(messages, msg)
 	}
 	if sinceID != "" {
 		for i, m := range messages {
@@ -3161,10 +3385,14 @@ func (b *Broker) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	b.mu.Unlock()
 
 	taggedCount := 0
-	if mySlug != "" {
+	taggedSlug := mySlug
+	if taggedSlug == "" {
+		taggedSlug = viewerSlug
+	}
+	if taggedSlug != "" {
 		for _, m := range result {
 			for _, t := range m.Tagged {
-				if t == mySlug {
+				if t == taggedSlug {
 					taggedCount++
 					break
 				}
@@ -3178,6 +3406,95 @@ func (b *Broker) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 		"messages":     result,
 		"tagged_count": taggedCount,
 	})
+}
+
+func messageInThread(msg channelMessage, threadID string) bool {
+	threadID = strings.TrimSpace(threadID)
+	if threadID == "" {
+		return true
+	}
+	return strings.TrimSpace(msg.ID) == threadID || strings.TrimSpace(msg.ReplyTo) == threadID
+}
+
+func normalizeMessageScope(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", "all", "channel":
+		return ""
+	case "agent", "inbox", "outbox":
+		return strings.TrimSpace(strings.ToLower(value))
+	default:
+		return ""
+	}
+}
+
+func messageMatchesViewerScope(msg channelMessage, viewerSlug, scope string, messagesByID map[string]channelMessage) bool {
+	scope = normalizeMessageScope(scope)
+	switch scope {
+	case "inbox":
+		return messageBelongsToViewerInbox(msg, viewerSlug, messagesByID)
+	case "outbox":
+		return messageBelongsToViewerOutbox(msg, viewerSlug)
+	case "agent":
+		return messageVisibleToViewer(msg, viewerSlug, messagesByID)
+	default:
+		return true
+	}
+}
+
+func messageVisibleToViewer(msg channelMessage, viewerSlug string, messagesByID map[string]channelMessage) bool {
+	return messageBelongsToViewerOutbox(msg, viewerSlug) || messageBelongsToViewerInbox(msg, viewerSlug, messagesByID)
+}
+
+func messageBelongsToViewerOutbox(msg channelMessage, viewerSlug string) bool {
+	viewerSlug = strings.TrimSpace(viewerSlug)
+	if viewerSlug == "" || viewerSlug == "ceo" {
+		return true
+	}
+	return strings.TrimSpace(msg.From) == viewerSlug
+}
+
+func messageBelongsToViewerInbox(msg channelMessage, viewerSlug string, messagesByID map[string]channelMessage) bool {
+	viewerSlug = strings.TrimSpace(viewerSlug)
+	if viewerSlug == "" || viewerSlug == "ceo" {
+		return true
+	}
+	from := strings.TrimSpace(msg.From)
+	switch from {
+	case viewerSlug:
+		return false
+	case "you", "human", "ceo":
+		return true
+	}
+	for _, tagged := range msg.Tagged {
+		tagged = strings.TrimSpace(tagged)
+		if tagged == viewerSlug || tagged == "all" {
+			return true
+		}
+	}
+	return messageRepliesToViewerThread(msg, viewerSlug, messagesByID)
+}
+
+func messageRepliesToViewerThread(msg channelMessage, viewerSlug string, messagesByID map[string]channelMessage) bool {
+	replyTo := strings.TrimSpace(msg.ReplyTo)
+	if replyTo == "" || viewerSlug == "" {
+		return false
+	}
+	seen := map[string]bool{}
+	for replyTo != "" {
+		if seen[replyTo] {
+			return false
+		}
+		seen[replyTo] = true
+		parent, ok := messagesByID[replyTo]
+		if !ok {
+			return false
+		}
+		if strings.TrimSpace(parent.From) == viewerSlug {
+			return true
+		}
+		replyTo = strings.TrimSpace(parent.ReplyTo)
+	}
+	return false
 }
 
 // isOneOnOneDMMessage returns true if msg belongs in the 1:1 DM conversation.
@@ -4220,7 +4537,7 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		b.counter++
 		req := humanInterview{
 			ID:            fmt.Sprintf("request-%d", b.counter),
-			Kind:          strings.TrimSpace(body.Kind),
+			Kind:          normalizeRequestKind(body.Kind),
 			Status:        "pending",
 			From:          strings.TrimSpace(body.From),
 			Channel:       channel,
@@ -4228,7 +4545,7 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 			Question:      strings.TrimSpace(body.Question),
 			Context:       strings.TrimSpace(body.Context),
 			Options:       body.Options,
-			RecommendedID: strings.TrimSpace(body.RecommendedID),
+			RecommendedID: "",
 			Blocking:      body.Blocking,
 			Required:      body.Required,
 			Secret:        body.Secret,
@@ -4236,9 +4553,7 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 			CreatedAt:     time.Now().UTC().Format(time.RFC3339),
 			UpdatedAt:     time.Now().UTC().Format(time.RFC3339),
 		}
-		if req.Kind == "" {
-			req.Kind = "choice"
-		}
+		req.Options, req.RecommendedID = normalizeRequestOptions(req.Kind, strings.TrimSpace(body.RecommendedID), req.Options)
 		if requestNeedsHumanDecision(req) {
 			req.Blocking = true
 			req.Required = true
@@ -4331,10 +4646,38 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 		if b.requests[i].ID != body.ID {
 			continue
 		}
+		choiceID := strings.TrimSpace(body.ChoiceID)
+		choiceText := strings.TrimSpace(body.ChoiceText)
+		customText := strings.TrimSpace(body.CustomText)
+		option := findRequestOption(b.requests[i], choiceID)
+		if choiceID != "" && option == nil {
+			b.mu.Unlock()
+			http.Error(w, "unknown request option", http.StatusBadRequest)
+			return
+		}
+		if option != nil {
+			if choiceText == "" {
+				choiceText = strings.TrimSpace(option.Label)
+			}
+			if option.RequiresText && customText == "" {
+				hint := strings.TrimSpace(option.TextHint)
+				if hint == "" {
+					hint = "custom_text required for this response"
+				}
+				b.mu.Unlock()
+				http.Error(w, hint, http.StatusBadRequest)
+				return
+			}
+		}
+		if choiceID == "" && choiceText == "" && customText == "" {
+			b.mu.Unlock()
+			http.Error(w, "choice_text or custom_text required", http.StatusBadRequest)
+			return
+		}
 		answer := &interviewAnswer{
-			ChoiceID:   body.ChoiceID,
-			ChoiceText: body.ChoiceText,
-			CustomText: body.CustomText,
+			ChoiceID:   choiceID,
+			ChoiceText: choiceText,
+			CustomText: customText,
 			AnsweredAt: time.Now().UTC().Format(time.RFC3339),
 		}
 		b.requests[i].Answered = answer
@@ -4356,16 +4699,7 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 			ReplyTo:   strings.TrimSpace(b.requests[i].ReplyTo),
 			Timestamp: time.Now().UTC().Format(time.RFC3339),
 		}
-		switch {
-		case b.requests[i].Secret:
-			msg.Content = fmt.Sprintf("Answered @%s's request privately.", b.requests[i].From)
-		case strings.TrimSpace(body.CustomText) != "":
-			msg.Content = fmt.Sprintf("Answered @%s's request: %s", b.requests[i].From, body.CustomText)
-		case strings.TrimSpace(body.ChoiceText) != "":
-			msg.Content = fmt.Sprintf("Answered @%s's request: %s", b.requests[i].From, body.ChoiceText)
-		default:
-			msg.Content = fmt.Sprintf("Answered @%s's request.", b.requests[i].From)
-		}
+		msg.Content = formatRequestAnswerMessage(b.requests[i], *answer)
 		b.messages = append(b.messages, msg)
 		b.appendActionLocked("request_answered", "office", b.requests[i].Channel, "you", truncateSummary(msg.Content, 140), b.requests[i].ID)
 		if err := b.saveLocked(); err != nil {

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -155,6 +155,122 @@ func TestBrokerMessageKindAndTitleRoundTrip(t *testing.T) {
 	}
 }
 
+func TestBrokerMessagesCanScopeToThread(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	root, err := b.PostMessage("ceo", "general", "Root topic", nil, "")
+	if err != nil {
+		t.Fatalf("post root: %v", err)
+	}
+	reply, err := b.PostMessage("fe", "general", "Reply in thread", nil, root.ID)
+	if err != nil {
+		t.Fatalf("post reply: %v", err)
+	}
+	if _, err := b.PostMessage("pm", "general", "Separate topic", nil, ""); err != nil {
+		t.Fatalf("post unrelated: %v", err)
+	}
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	req, _ := http.NewRequest(http.MethodGet, base+"/messages?channel=general&thread_id="+root.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("thread messages request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200 listing thread messages, got %d: %s", resp.StatusCode, raw)
+	}
+
+	var result struct {
+		Messages []channelMessage `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode thread messages: %v", err)
+	}
+	if len(result.Messages) != 2 {
+		t.Fatalf("expected root and reply only, got %+v", result.Messages)
+	}
+	if result.Messages[0].ID != root.ID || result.Messages[1].ID != reply.ID {
+		t.Fatalf("unexpected thread messages: %+v", result.Messages)
+	}
+}
+
+func TestBrokerMessagesCanScopeToAgentInbox(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	if _, err := b.PostMessage("you", "general", "Global direction", nil, ""); err != nil {
+		t.Fatalf("post human message: %v", err)
+	}
+	if _, err := b.PostMessage("pm", "general", "Unrelated PM update", nil, ""); err != nil {
+		t.Fatalf("post unrelated message: %v", err)
+	}
+	tagged, err := b.PostMessage("ceo", "general", "Frontend, take this next.", []string{"fe"}, "")
+	if err != nil {
+		t.Fatalf("post tagged message: %v", err)
+	}
+	own, err := b.PostMessage("fe", "general", "I am on it.", nil, "")
+	if err != nil {
+		t.Fatalf("post own message: %v", err)
+	}
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	req, _ := http.NewRequest(http.MethodGet, base+"/messages?channel=general&my_slug=fe&viewer_slug=fe&scope=agent", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("agent-scoped messages request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200 listing agent-scoped messages, got %d: %s", resp.StatusCode, raw)
+	}
+
+	var result struct {
+		Messages    []channelMessage `json:"messages"`
+		TaggedCount int              `json:"tagged_count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode agent-scoped messages: %v", err)
+	}
+	if len(result.Messages) != 3 {
+		t.Fatalf("expected human, tagged, and own messages only, got %+v", result.Messages)
+	}
+	if result.TaggedCount != 1 {
+		t.Fatalf("expected one tagged message, got %d", result.TaggedCount)
+	}
+	seen := map[string]bool{}
+	for _, msg := range result.Messages {
+		seen[msg.ID] = true
+		if strings.Contains(msg.Content, "Unrelated PM update") {
+			t.Fatalf("did not expect unrelated message in agent scope: %+v", result.Messages)
+		}
+	}
+	if !seen[tagged.ID] || !seen[own.ID] {
+		t.Fatalf("expected tagged and own messages in scoped view, got %+v", result.Messages)
+	}
+}
+
 func TestNewBrokerSeedsDefaultOfficeRosterOnFreshState(t *testing.T) {
 	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
@@ -178,6 +294,74 @@ func TestNewBrokerSeedsDefaultOfficeRosterOnFreshState(t *testing.T) {
 	}
 	if len(general.Members) < len(members) {
 		t.Fatalf("expected general channel to include office roster, got %v for %d members", general.Members, len(members))
+	}
+}
+
+func TestHandleMessagesSupportsInboxAndOutboxScopes(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	root, err := b.PostMessage("ceo", "general", "Frontend, take the signup thread.", nil, "")
+	if err != nil {
+		t.Fatalf("post root message: %v", err)
+	}
+	ownReply, err := b.PostMessage("fe", "general", "I can own the signup thread.", nil, root.ID)
+	if err != nil {
+		t.Fatalf("post own reply: %v", err)
+	}
+	threadReply, err := b.PostMessage("pm", "general", "Please include the pricing copy in that thread.", nil, ownReply.ID)
+	if err != nil {
+		t.Fatalf("post thread reply: %v", err)
+	}
+	ownTopLevel, err := b.PostMessage("fe", "general", "Shipped the initial branch.", nil, "")
+	if err != nil {
+		t.Fatalf("post own top-level message: %v", err)
+	}
+	if _, err := b.PostMessage("pm", "general", "Unrelated roadmap chatter.", nil, ""); err != nil {
+		t.Fatalf("post unrelated message: %v", err)
+	}
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	fetch := func(scope string) []channelMessage {
+		req, _ := http.NewRequest(http.MethodGet, base+"/messages?channel=general&viewer_slug=fe&scope="+scope, nil)
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("get %s messages: %v", scope, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200 for %s scope, got %d: %s", scope, resp.StatusCode, raw)
+		}
+		var result struct {
+			Messages []channelMessage `json:"messages"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode %s messages: %v", scope, err)
+		}
+		return result.Messages
+	}
+
+	inbox := fetch("inbox")
+	if len(inbox) != 2 {
+		t.Fatalf("expected CEO root plus PM thread reply in inbox, got %+v", inbox)
+	}
+	if inbox[0].ID != root.ID || inbox[1].ID != threadReply.ID {
+		t.Fatalf("unexpected inbox ordering/content: %+v", inbox)
+	}
+
+	outbox := fetch("outbox")
+	if len(outbox) != 2 {
+		t.Fatalf("expected only authored messages in outbox, got %+v", outbox)
+	}
+	if outbox[0].ID != ownReply.ID || outbox[1].ID != ownTopLevel.ID {
+		t.Fatalf("unexpected outbox ordering/content: %+v", outbox)
 	}
 }
 
@@ -1295,6 +1479,76 @@ func TestBrokerDecisionRequestsDefaultToBlocking(t *testing.T) {
 	if !created.Request.Blocking || !created.Request.Required {
 		t.Fatalf("expected approval to default to blocking+required, got %+v", created.Request)
 	}
+	if got := created.Request.RecommendedID; got != "approve" {
+		t.Fatalf("expected approval recommended_id to default to approve, got %q", got)
+	}
+	if len(created.Request.Options) != 5 {
+		t.Fatalf("expected enriched approval options, got %+v", created.Request.Options)
+	}
+	var approveWithNote *interviewOption
+	for i := range created.Request.Options {
+		if created.Request.Options[i].ID == "approve_with_note" {
+			approveWithNote = &created.Request.Options[i]
+			break
+		}
+	}
+	if approveWithNote == nil || !approveWithNote.RequiresText || strings.TrimSpace(approveWithNote.TextHint) == "" {
+		t.Fatalf("expected approve_with_note to require text, got %+v", approveWithNote)
+	}
+}
+
+func TestBrokerRequestAnswerRequiresCustomTextWhenOptionNeedsIt(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	body, _ := json.Marshal(map[string]any{
+		"kind":     "approval",
+		"from":     "ceo",
+		"channel":  "general",
+		"title":    "Approval needed",
+		"question": "Should we proceed?",
+	})
+	req, _ := http.NewRequest(http.MethodPost, base+"/requests", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request create failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var created struct {
+		Request humanInterview `json:"request"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode request: %v", err)
+	}
+
+	answerBody, _ := json.Marshal(map[string]any{
+		"id":        created.Request.ID,
+		"choice_id": "approve_with_note",
+	})
+	req, _ = http.NewRequest(http.MethodPost, base+"/requests/answer", bytes.NewReader(answerBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request answer failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 400 for missing custom text, got %d: %s", resp.StatusCode, raw)
+	}
 }
 
 func TestQueueEndpointShowsDueJobs(t *testing.T) {
@@ -1338,6 +1592,68 @@ func TestQueueEndpointShowsDueJobs(t *testing.T) {
 	}
 	if len(queue.Due) != 1 {
 		t.Fatalf("expected due scheduler job to surface, got %+v", queue.Due)
+	}
+}
+
+func TestBrokerGetMessagesAgentScopeKeepsHumanAndCEOContext(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	postMessage := func(payload map[string]any) {
+		t.Helper()
+		body, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPost, base+"/messages", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post message: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200 posting message, got %d: %s", resp.StatusCode, raw)
+		}
+	}
+
+	postMessage(map[string]any{"channel": "general", "from": "you", "content": "Frontend, should we ship this?", "tagged": []string{"fe"}})
+	postMessage(map[string]any{"channel": "general", "from": "pm", "content": "Unrelated roadmap chatter."})
+	postMessage(map[string]any{"channel": "general", "from": "ceo", "content": "Keep scope tight and focus on signup."})
+	postMessage(map[string]any{"channel": "general", "from": "fe", "content": "I can take the signup work."})
+
+	req, _ := http.NewRequest(http.MethodGet, base+"/messages?channel=general&viewer_slug=fe&scope=agent", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get messages: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Messages []channelMessage `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode messages: %v", err)
+	}
+	if len(result.Messages) != 3 {
+		t.Fatalf("expected scoped transcript to keep 3 messages, got %+v", result.Messages)
+	}
+	if got := result.Messages[1].From; got != "ceo" {
+		t.Fatalf("expected CEO context to remain visible, got %+v", result.Messages)
+	}
+	for _, msg := range result.Messages {
+		if msg.From == "pm" {
+			t.Fatalf("did not expect unrelated PM chatter in scoped transcript: %+v", result.Messages)
+		}
 	}
 }
 

--- a/internal/team/capabilities.go
+++ b/internal/team/capabilities.go
@@ -1,0 +1,343 @@
+package team
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/action"
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+type CapabilityLevel string
+
+const (
+	CapabilityReady CapabilityLevel = "ready"
+	CapabilityWarn  CapabilityLevel = "warn"
+	CapabilityInfo  CapabilityLevel = "info"
+)
+
+type CapabilityStatus struct {
+	Name     string
+	Level    CapabilityLevel
+	Detail   string
+	NextStep string
+}
+
+type TmuxSessionStatus struct {
+	Name     string
+	Attached int
+	Windows  int
+}
+
+type TmuxCapability struct {
+	BinaryPath    string
+	Version       string
+	SocketName    string
+	SessionName   string
+	InsideTmux    bool
+	InsideTmuxEnv string
+	ServerRunning bool
+	Sessions      []TmuxSessionStatus
+	ProbeError    string
+}
+
+type RuntimeCapabilities struct {
+	Tmux  TmuxCapability
+	Items []CapabilityStatus
+}
+
+var lookPathFn = exec.LookPath
+var commandCombinedOutputFn = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+var actionProviderProbe = detectActionProvider
+
+func DetectRuntimeCapabilities() RuntimeCapabilities {
+	tmuxStatus, tmux := probeTmuxCapability()
+	items := []CapabilityStatus{
+		tmuxStatus,
+		probeBinaryCapability("claude", "Needed for teammate runtime sessions."),
+		probeNexCapability(),
+		probeActionCapability(),
+	}
+	return RuntimeCapabilities{Tmux: tmux, Items: items}
+}
+
+func (c RuntimeCapabilities) Counts() (ready, warn, info int) {
+	for _, item := range c.Items {
+		switch item.Level {
+		case CapabilityReady:
+			ready++
+		case CapabilityWarn:
+			warn++
+		case CapabilityInfo:
+			info++
+		}
+	}
+	return ready, warn, info
+}
+
+func probeBinaryCapability(name, next string) CapabilityStatus {
+	if _, err := lookPathFn(name); err != nil {
+		return CapabilityStatus{
+			Name:     name,
+			Level:    CapabilityWarn,
+			Detail:   fmt.Sprintf("%s is not available on PATH.", name),
+			NextStep: next,
+		}
+	}
+	return CapabilityStatus{
+		Name:   name,
+		Level:  CapabilityReady,
+		Detail: fmt.Sprintf("%s is installed.", name),
+	}
+}
+
+func probeTmuxCapability() (CapabilityStatus, TmuxCapability) {
+	capability := TmuxCapability{
+		SocketName:    tmuxSocketName,
+		SessionName:   SessionName,
+		InsideTmux:    strings.TrimSpace(os.Getenv("TMUX")) != "",
+		InsideTmuxEnv: strings.TrimSpace(os.Getenv("TMUX")),
+	}
+
+	path, err := lookPathFn("tmux")
+	if err != nil {
+		return CapabilityStatus{
+			Name:     "tmux",
+			Level:    CapabilityWarn,
+			Detail:   "tmux is not available on PATH.",
+			NextStep: "Install tmux so WUPHF can manage the office session.",
+		}, capability
+	}
+	capability.BinaryPath = path
+
+	if out, err := commandCombinedOutputFn("tmux", "-V"); len(out) > 0 {
+		capability.Version = strings.TrimSpace(string(out))
+	} else if err != nil {
+		capability.ProbeError = strings.TrimSpace(err.Error())
+	}
+
+	if out, err := commandCombinedOutputFn("tmux", "-L", tmuxSocketName, "list-sessions", "-F", "#{session_name}\t#{session_attached}\t#{session_windows}"); err != nil || len(out) > 0 {
+		capability.Sessions = parseTmuxSessions(out)
+		if len(capability.Sessions) > 0 {
+			capability.ServerRunning = true
+		}
+		if err != nil && len(capability.Sessions) == 0 {
+			if note := strings.TrimSpace(string(out)); note != "" {
+				capability.ProbeError = note
+			} else {
+				capability.ProbeError = strings.TrimSpace(err.Error())
+			}
+		}
+	}
+
+	status := capability.status()
+	return status, capability
+}
+
+func parseTmuxSessions(out []byte) []TmuxSessionStatus {
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	sessions := make([]TmuxSessionStatus, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) < 3 {
+			continue
+		}
+		attached, _ := strconv.Atoi(strings.TrimSpace(parts[1]))
+		windows, _ := strconv.Atoi(strings.TrimSpace(parts[2]))
+		sessions = append(sessions, TmuxSessionStatus{
+			Name:     strings.TrimSpace(parts[0]),
+			Attached: attached,
+			Windows:  windows,
+		})
+	}
+	return sessions
+}
+
+func (t TmuxCapability) hasData() bool {
+	return t.BinaryPath != "" || t.Version != "" || t.SocketName != "" || t.SessionName != "" || t.InsideTmux || t.InsideTmuxEnv != "" || t.ServerRunning || len(t.Sessions) > 0 || t.ProbeError != ""
+}
+
+func (t TmuxCapability) targetSession() (TmuxSessionStatus, bool) {
+	for _, session := range t.Sessions {
+		if strings.EqualFold(strings.TrimSpace(session.Name), strings.TrimSpace(t.SessionName)) {
+			return session, true
+		}
+	}
+	return TmuxSessionStatus{}, false
+}
+
+func (t TmuxCapability) summaryDetail() string {
+	if t.BinaryPath == "" {
+		return "tmux is not available on PATH."
+	}
+	version := strings.TrimSpace(t.Version)
+	if version == "" {
+		version = "tmux"
+	}
+	if !t.ServerRunning {
+		return fmt.Sprintf("%s is installed, but the WUPHF tmux server on socket %s is not running yet.", version, t.SocketName)
+	}
+	if session, ok := t.targetSession(); ok {
+		return fmt.Sprintf("%s on socket %s is running with session %s (%d attached, %d windows).", version, t.SocketName, session.Name, session.Attached, session.Windows)
+	}
+	return fmt.Sprintf("%s on socket %s has %d active tmux session(s), but %s is not running.", version, t.SocketName, len(t.Sessions), t.SessionName)
+}
+
+func (t TmuxCapability) nextStep() string {
+	if t.BinaryPath == "" {
+		return "Install tmux so WUPHF can manage the office session."
+	}
+	if !t.ServerRunning {
+		return "Launch WUPHF to create the tmux office session."
+	}
+	if _, ok := t.targetSession(); !ok {
+		return "Restart WUPHF to recreate the missing office session."
+	}
+	return ""
+}
+
+func (t TmuxCapability) status() CapabilityStatus {
+	if t.BinaryPath == "" {
+		return CapabilityStatus{
+			Name:     "tmux",
+			Level:    CapabilityWarn,
+			Detail:   "tmux is not available on PATH.",
+			NextStep: t.nextStep(),
+		}
+	}
+	if !t.ServerRunning {
+		return CapabilityStatus{
+			Name:     "tmux",
+			Level:    CapabilityInfo,
+			Detail:   t.summaryDetail(),
+			NextStep: t.nextStep(),
+		}
+	}
+	if _, ok := t.targetSession(); !ok {
+		return CapabilityStatus{
+			Name:     "tmux",
+			Level:    CapabilityWarn,
+			Detail:   t.summaryDetail(),
+			NextStep: t.nextStep(),
+		}
+	}
+	return CapabilityStatus{
+		Name:   "tmux",
+		Level:  CapabilityReady,
+		Detail: t.summaryDetail(),
+	}
+}
+
+func (t TmuxCapability) FormatLines() []string {
+	if !t.hasData() {
+		return nil
+	}
+	lines := []string{
+		fmt.Sprintf("- Binary: %s", displayOrUnknown(t.BinaryPath)),
+		fmt.Sprintf("- Version: %s", displayOrUnknown(t.Version)),
+		fmt.Sprintf("- Socket: %s", displayOrUnknown(t.SocketName)),
+		fmt.Sprintf("- Inside tmux: %s", yesNo(t.InsideTmux)),
+	}
+	if t.InsideTmuxEnv != "" {
+		lines = append(lines, fmt.Sprintf("- TMUX env: %s", t.InsideTmuxEnv))
+	}
+	if !t.ServerRunning {
+		lines = append(lines, fmt.Sprintf("- WUPHF session: not running yet (%s)", t.SessionName))
+	} else if session, ok := t.targetSession(); ok {
+		lines = append(lines, fmt.Sprintf("- WUPHF session: running (%d attached, %d windows)", session.Attached, session.Windows))
+	} else {
+		lines = append(lines, fmt.Sprintf("- WUPHF session: missing from socket %s", t.SocketName))
+	}
+	if len(t.Sessions) > 0 {
+		lines = append(lines, "- tmux sessions:")
+		for _, session := range t.Sessions {
+			lines = append(lines, fmt.Sprintf("- %s: %d attached, %d windows", session.Name, session.Attached, session.Windows))
+		}
+	}
+	if strings.TrimSpace(t.ProbeError) != "" {
+		lines = append(lines, fmt.Sprintf("- Probe note: %s", t.ProbeError))
+	}
+	return lines
+}
+
+func displayOrUnknown(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func probeNexCapability() CapabilityStatus {
+	if config.ResolveNoNex() {
+		return CapabilityStatus{
+			Name:     "nex",
+			Level:    CapabilityInfo,
+			Detail:   "Disabled for this session with --no-nex.",
+			NextStep: "Restart without --no-nex to enable memory, integrations, and provider-backed actions.",
+		}
+	}
+	if apiKey := strings.TrimSpace(config.ResolveAPIKey("")); apiKey == "" {
+		return CapabilityStatus{
+			Name:     "nex",
+			Level:    CapabilityWarn,
+			Detail:   "Missing WUPHF/Nex API key.",
+			NextStep: "Run /init and save your WUPHF API key.",
+		}
+	}
+	email := strings.TrimSpace(config.ResolveComposioUserID())
+	if email == "" {
+		return CapabilityStatus{
+			Name:     "nex",
+			Level:    CapabilityWarn,
+			Detail:   "API key is configured, but workspace identity is missing.",
+			NextStep: "Finish /init so WUPHF can scope integrations to your Nex email.",
+		}
+	}
+	return CapabilityStatus{
+		Name:   "nex",
+		Level:  CapabilityReady,
+		Detail: fmt.Sprintf("Configured with workspace identity %s.", email),
+	}
+}
+
+func probeActionCapability() CapabilityStatus {
+	name, err := actionProviderProbe()
+	if err != nil {
+		return CapabilityStatus{
+			Name:     "actions",
+			Level:    CapabilityWarn,
+			Detail:   err.Error(),
+			NextStep: "Configure an external action provider or switch WUPHF to a working provider.",
+		}
+	}
+	return CapabilityStatus{
+		Name:   "actions",
+		Level:  CapabilityReady,
+		Detail: fmt.Sprintf("External actions available through %s.", name),
+	}
+}
+
+func detectActionProvider() (string, error) {
+	provider, err := action.NewRegistryFromEnv().ProviderFor(action.CapabilityConnections)
+	if err != nil {
+		return "", err
+	}
+	return provider.Name(), nil
+}

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -2422,7 +2422,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 			sb.WriteString(fmt.Sprintf("- @%s (%s): %s\n", member.Slug, member.Name, strings.Join(member.Expertise, ", ")))
 		}
 		sb.WriteString("\n== TEAM CHANNEL ==\n")
-		sb.WriteString("You are in a shared WUPHF office channel. Use the office MCP tools to communicate:\n")
+		sb.WriteString("You are in a shared WUPHF office. Your tools default to the active conversation context: the channel, thread, or direct session that most recently needs your reply.\n")
 		sb.WriteString("- team_broadcast: Post a message to the channel (all agents see it)\n")
 		sb.WriteString("- team_poll: Read recent messages (call regularly to stay in sync)\n")
 		sb.WriteString("- team_office_members: See the full office roster, including members outside the current channel\n")
@@ -2450,7 +2450,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 		}
 		sb.WriteString("Tag agents with @slug in your message (e.g., '@fe can you handle this?').\n")
 		sb.WriteString("Tagged agents are expected to respond.\n\n")
-		sb.WriteString("THREADING: Default to replying in existing threads with reply_to_id. New top-level messages only for genuinely new topics.\n\n")
+		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
 		sb.WriteString("YOUR ROLE AS LEADER:\n")
 		if config.ResolveNoNex() {
 			sb.WriteString("1. Coordinate inside the office channel first and keep the team aligned there\n")
@@ -2497,7 +2497,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 			sb.WriteString(fmt.Sprintf("- @%s (%s): %s\n", member.Slug, member.Name, strings.Join(member.Expertise, ", ")))
 		}
 		sb.WriteString("\n== TEAM CHANNEL ==\n")
-		sb.WriteString("You are in a shared WUPHF office channel. Use the office MCP tools to communicate:\n")
+		sb.WriteString("You are in a shared WUPHF office. Your tools default to the active conversation context: the channel, thread, or direct session that most recently needs your reply.\n")
 		sb.WriteString("- team_broadcast: Post a message to the channel (all agents see it)\n")
 		sb.WriteString("- team_poll: Read recent messages (call regularly to stay in sync)\n")
 		sb.WriteString("- team_office_members: See the full office roster, including members outside the current channel\n")
@@ -2523,7 +2523,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 			sb.WriteString("- add_context: Store durable conclusions or findings once the team actually lands them\n\n")
 		}
 		sb.WriteString("Tag agents with @slug. Tagged agents must respond.\n")
-		sb.WriteString("THREADING: Default to replying in existing threads with reply_to_id. New top-level messages only for genuinely new topics.\n\n")
+		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
 		sb.WriteString("YOUR ROLE AS SPECIALIST:\n")
 		sb.WriteString("1. Call team_poll once when notified, then respond directly\n")
 		sb.WriteString("2. Stay in your lane — but ALWAYS respond when your domain is touched\n")

--- a/internal/team/policy.go
+++ b/internal/team/policy.go
@@ -318,38 +318,8 @@ func recommendedIDForKind(kind string) string {
 }
 
 func signalRequestOptions(signal officeSignal) []interviewOption {
-	switch requestKindForSignal(signal) {
-	case "approval":
-		return []interviewOption{
-			{ID: "approve", Label: "Approve", Description: "Green-light this and let the team execute immediately."},
-			{ID: "approve_with_conditions", Label: "Approve with conditions", Description: "Proceed, but I will add constraints the team must follow."},
-			{ID: "needs_more_info", Label: "Need more info", Description: "Not enough context to decide — gather more details first."},
-			{ID: "delegate", Label: "Delegate", Description: "Route to a specific person for a closer look before deciding."},
-			{ID: "reject", Label: "Reject", Description: "Do not proceed with this."},
-		}
-	case "choice":
-		return []interviewOption{
-			{ID: "move_fast", Label: "Move fast", Description: "Bias toward speed — ship now, iterate later."},
-			{ID: "balanced", Label: "Balanced", Description: "Weigh trade-offs and aim for a reasonable middle ground."},
-			{ID: "be_careful", Label: "Be careful", Description: "Bias toward caution — tighter review loop before acting."},
-			{ID: "needs_more_info", Label: "Need more info", Description: "Not enough context to choose — investigate first."},
-			{ID: "delegate", Label: "Delegate", Description: "Let the owner or a specialist make this call."},
-		}
-	case "confirm":
-		return []interviewOption{
-			{ID: "confirm_proceed", Label: "Confirm", Description: "Looks good — proceed as planned."},
-			{ID: "adjust", Label: "Adjust", Description: "Proceed with modifications — I will add details."},
-			{ID: "reassign", Label: "Reassign", Description: "Wrong owner or scope — reroute this to someone else."},
-			{ID: "hold", Label: "Hold", Description: "Do not act yet — I need to review this further."},
-		}
-	default:
-		return []interviewOption{
-			{ID: "proceed", Label: "Proceed", Description: "Let the team handle it with their best judgment."},
-			{ID: "give_direction", Label: "Give direction", Description: "I will provide specific guidance for how to handle this."},
-			{ID: "delegate", Label: "Delegate", Description: "Route this to a specific person to own."},
-			{ID: "hold", Label: "Hold", Description: "Pause until I review this further."},
-		}
-	}
+	options, _ := requestOptionDefaults(requestKindForSignal(signal))
+	return options
 }
 
 func requestKindForSignal(signal officeSignal) string {

--- a/internal/team/policy_test.go
+++ b/internal/team/policy_test.go
@@ -190,7 +190,7 @@ func TestSignalRequestOptionsRichApproval(t *testing.T) {
 			t.Fatalf("option %q missing label or description", o.ID)
 		}
 	}
-	for _, required := range []string{"approve", "approve_with_conditions", "needs_more_info", "delegate", "reject"} {
+	for _, required := range []string{"approve", "approve_with_note", "needs_more_info", "reject", "reject_with_steer"} {
 		if !ids[required] {
 			t.Errorf("missing required approval option %q", required)
 		}

--- a/internal/team/runtime_state.go
+++ b/internal/team/runtime_state.go
@@ -1,0 +1,193 @@
+package team
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type RuntimeTask struct {
+	ID             string
+	Title          string
+	Owner          string
+	Status         string
+	PipelineStage  string
+	ReviewState    string
+	ExecutionMode  string
+	WorktreePath   string
+	WorktreeBranch string
+	Blocked        bool
+}
+
+type RuntimeRequest struct {
+	ID       string
+	Kind     string
+	Title    string
+	Question string
+	From     string
+	Blocking bool
+	Required bool
+	Status   string
+	Channel  string
+	Secret   bool
+}
+
+type RuntimeMessage struct {
+	ID        string
+	From      string
+	Title     string
+	Content   string
+	ReplyTo   string
+	Timestamp string
+}
+
+type RuntimeSnapshot struct {
+	Channel      string
+	SessionMode  string
+	DirectAgent  string
+	GeneratedAt  time.Time
+	Tasks        []RuntimeTask
+	Requests     []RuntimeRequest
+	Recent       []RuntimeMessage
+	Capabilities RuntimeCapabilities
+	Recovery     SessionRecovery
+}
+
+type RuntimeSnapshotInput struct {
+	Channel      string
+	SessionMode  string
+	DirectAgent  string
+	Tasks        []RuntimeTask
+	Requests     []RuntimeRequest
+	Recent       []RuntimeMessage
+	Capabilities RuntimeCapabilities
+	Now          time.Time
+}
+
+func BuildRuntimeSnapshot(input RuntimeSnapshotInput) RuntimeSnapshot {
+	now := input.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	sessionMode := NormalizeSessionMode(input.SessionMode)
+	directAgent := NormalizeOneOnOneAgent(input.DirectAgent)
+	if sessionMode != SessionModeOneOnOne {
+		directAgent = ""
+	}
+	snapshot := RuntimeSnapshot{
+		Channel:      strings.TrimSpace(input.Channel),
+		SessionMode:  sessionMode,
+		DirectAgent:  directAgent,
+		GeneratedAt:  now,
+		Tasks:        append([]RuntimeTask(nil), input.Tasks...),
+		Requests:     append([]RuntimeRequest(nil), input.Requests...),
+		Recent:       append([]RuntimeMessage(nil), input.Recent...),
+		Capabilities: input.Capabilities,
+	}
+	snapshot.Recovery = BuildSessionRecovery(sessionMode, directAgent, snapshot.Tasks, snapshot.Requests, snapshot.Recent)
+	return snapshot
+}
+
+func (s RuntimeSnapshot) FormatText() string {
+	channel := s.Channel
+	if channel == "" {
+		channel = "general"
+	}
+
+	lines := []string{
+		fmt.Sprintf("Runtime state for #%s", channel),
+	}
+	if s.SessionMode == SessionModeOneOnOne {
+		lines = append(lines, fmt.Sprintf("- Session mode: 1:1 with @%s", s.DirectAgent))
+	} else {
+		lines = append(lines, "- Session mode: office")
+	}
+	lines = append(lines,
+		fmt.Sprintf("- Running tasks: %d of %d", s.runningTaskCount(), len(s.Tasks)),
+		fmt.Sprintf("- Isolated worktrees: %d", s.isolatedTaskCount()),
+		fmt.Sprintf("- Pending human requests: %d", s.pendingRequestCount()),
+	)
+
+	if focus := strings.TrimSpace(s.Recovery.Focus); focus != "" {
+		lines = append(lines, fmt.Sprintf("- Current focus: %s", focus))
+	}
+
+	if len(s.Recovery.NextSteps) > 0 {
+		lines = append(lines, "", "Next steps:")
+		for _, step := range s.Recovery.NextSteps {
+			lines = append(lines, "- "+step)
+		}
+	}
+
+	if len(s.Recovery.Highlights) > 0 {
+		lines = append(lines, "", "Recent highlights:")
+		for _, line := range s.Recovery.Highlights {
+			lines = append(lines, "- "+line)
+		}
+	}
+
+	if tmuxLines := s.Capabilities.Tmux.FormatLines(); len(tmuxLines) > 0 {
+		lines = append(lines, "", "Tmux runtime:")
+		lines = append(lines, tmuxLines...)
+	}
+
+	if len(s.Capabilities.Items) > 0 {
+		lines = append(lines, "", "Runtime capabilities:")
+		for _, item := range s.Capabilities.Items {
+			line := fmt.Sprintf("- %s [%s]: %s", item.Name, item.Level, item.Detail)
+			if next := strings.TrimSpace(item.NextStep); next != "" {
+				line += " Next: " + next
+			}
+			lines = append(lines, line)
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (s RuntimeSnapshot) runningTaskCount() int {
+	count := 0
+	for _, task := range s.Tasks {
+		if runtimeTaskIsRunning(task) {
+			count++
+		}
+	}
+	return count
+}
+
+func (s RuntimeSnapshot) isolatedTaskCount() int {
+	count := 0
+	for _, task := range s.Tasks {
+		if runtimeTaskUsesIsolation(task) {
+			count++
+		}
+	}
+	return count
+}
+
+func (s RuntimeSnapshot) pendingRequestCount() int {
+	count := 0
+	for _, req := range s.Requests {
+		status := strings.ToLower(strings.TrimSpace(req.Status))
+		if status == "" || status == "pending" || status == "open" {
+			count++
+		}
+	}
+	return count
+}
+
+func runtimeTaskIsRunning(task RuntimeTask) bool {
+	status := strings.ToLower(strings.TrimSpace(task.Status))
+	switch status {
+	case "", "done", "completed", "canceled", "cancelled":
+		return false
+	default:
+		return true
+	}
+}
+
+func runtimeTaskUsesIsolation(task RuntimeTask) bool {
+	return strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") ||
+		strings.TrimSpace(task.WorktreePath) != "" ||
+		strings.TrimSpace(task.WorktreeBranch) != ""
+}

--- a/internal/team/runtime_state_test.go
+++ b/internal/team/runtime_state_test.go
@@ -1,0 +1,198 @@
+package team
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDetectRuntimeCapabilities(t *testing.T) {
+	oldLookPath := lookPathFn
+	oldCommandOutput := commandCombinedOutputFn
+	oldActionProbe := actionProviderProbe
+	defer func() {
+		lookPathFn = oldLookPath
+		commandCombinedOutputFn = oldCommandOutput
+		actionProviderProbe = oldActionProbe
+	}()
+
+	lookPathFn = func(name string) (string, error) {
+		switch name {
+		case "tmux":
+			return "/usr/bin/tmux", nil
+		case "claude":
+			return "/usr/bin/claude", nil
+		default:
+			return "", errors.New("missing")
+		}
+	}
+	commandCombinedOutputFn = func(name string, args ...string) ([]byte, error) {
+		if name != "tmux" {
+			return nil, errors.New("unexpected command")
+		}
+		if len(args) == 1 && args[0] == "-V" {
+			return []byte("tmux 3.4a\n"), nil
+		}
+		if len(args) == 5 && args[0] == "-L" && args[1] == tmuxSocketName && args[2] == "list-sessions" && args[3] == "-F" {
+			return []byte("wuphf-team\t2\t4\nscratch\t1\t1\n"), nil
+		}
+		return nil, errors.New("unexpected tmux probe")
+	}
+	actionProviderProbe = func() (string, error) {
+		return "", errors.New("no configured provider available")
+	}
+
+	t.Setenv("TMUX", "/tmp/tmux-1000/default,123,0")
+	t.Setenv("WUPHF_NO_NEX", "1")
+
+	got := DetectRuntimeCapabilities()
+	ready, warn, info := got.Counts()
+	if ready != 2 || warn != 1 || info != 1 {
+		t.Fatalf("unexpected capability counts: ready=%d warn=%d info=%d", ready, warn, info)
+	}
+	if got.Tmux.BinaryPath != "/usr/bin/tmux" {
+		t.Fatalf("expected tmux binary path to be recorded, got %q", got.Tmux.BinaryPath)
+	}
+	if got.Tmux.Version != "tmux 3.4a" {
+		t.Fatalf("expected tmux version to be recorded, got %q", got.Tmux.Version)
+	}
+	if !got.Tmux.ServerRunning {
+		t.Fatalf("expected tmux server to be marked running")
+	}
+	if !got.Tmux.InsideTmux {
+		t.Fatalf("expected inside-tmux state to be recorded")
+	}
+	if len(got.Tmux.Sessions) != 2 {
+		t.Fatalf("expected 2 tmux sessions, got %d", len(got.Tmux.Sessions))
+	}
+	if got.Tmux.Sessions[0].Name != SessionName || got.Tmux.Sessions[0].Attached != 2 || got.Tmux.Sessions[0].Windows != 4 {
+		t.Fatalf("unexpected target tmux session: %+v", got.Tmux.Sessions[0])
+	}
+}
+
+func TestDetectRuntimeCapabilitiesWhenTmuxServerIsMissing(t *testing.T) {
+	oldLookPath := lookPathFn
+	oldCommandOutput := commandCombinedOutputFn
+	oldActionProbe := actionProviderProbe
+	defer func() {
+		lookPathFn = oldLookPath
+		commandCombinedOutputFn = oldCommandOutput
+		actionProviderProbe = oldActionProbe
+	}()
+
+	lookPathFn = func(name string) (string, error) {
+		switch name {
+		case "tmux":
+			return "/usr/bin/tmux", nil
+		case "claude":
+			return "/usr/bin/claude", nil
+		default:
+			return "", errors.New("missing")
+		}
+	}
+	commandCombinedOutputFn = func(name string, args ...string) ([]byte, error) {
+		if name != "tmux" {
+			return nil, errors.New("unexpected command")
+		}
+		if len(args) == 1 && args[0] == "-V" {
+			return []byte("tmux 3.4a\n"), nil
+		}
+		if len(args) == 5 && args[0] == "-L" && args[1] == tmuxSocketName && args[2] == "list-sessions" && args[3] == "-F" {
+			return []byte("no server running on /tmp/tmux-1000/wuphf\n"), errors.New("exit status 1")
+		}
+		return nil, errors.New("unexpected tmux probe")
+	}
+	actionProviderProbe = func() (string, error) {
+		return "", errors.New("no configured provider available")
+	}
+
+	t.Setenv("WUPHF_NO_NEX", "1")
+
+	got := DetectRuntimeCapabilities()
+	ready, warn, info := got.Counts()
+	if ready != 1 || warn != 1 || info != 2 {
+		t.Fatalf("unexpected capability counts: ready=%d warn=%d info=%d", ready, warn, info)
+	}
+	if got.Tmux.ServerRunning {
+		t.Fatalf("expected tmux server to be marked missing")
+	}
+	if got.Items[0].Level != CapabilityInfo {
+		t.Fatalf("expected tmux capability to be informational when the server is absent, got %s", got.Items[0].Level)
+	}
+	if !strings.Contains(got.Tmux.ProbeError, "no server running") {
+		t.Fatalf("expected tmux probe note to keep the server error, got %q", got.Tmux.ProbeError)
+	}
+}
+
+func TestBuildRuntimeSnapshotFormatsRecoveryAndCapabilities(t *testing.T) {
+	snapshot := BuildRuntimeSnapshot(RuntimeSnapshotInput{
+		Channel:     "general",
+		SessionMode: SessionModeOneOnOne,
+		DirectAgent: "pm",
+		Tasks: []RuntimeTask{{
+			ID:             "task-1",
+			Title:          "Polish launch checklist",
+			Owner:          "pm",
+			Status:         "in_progress",
+			PipelineStage:  "review",
+			ExecutionMode:  "local_worktree",
+			WorktreePath:   "/tmp/wuphf-task-1",
+			WorktreeBranch: "feat/task-1",
+		}},
+		Requests: []RuntimeRequest{{
+			ID:       "req-1",
+			Title:    "Approve launch timing",
+			From:     "ceo",
+			Status:   "pending",
+			Blocking: true,
+		}},
+		Recent: []RuntimeMessage{{
+			ID:      "msg-1",
+			From:    "ceo",
+			Content: "We need a final timing call before tomorrow.",
+		}},
+		Capabilities: RuntimeCapabilities{
+			Tmux: TmuxCapability{
+				BinaryPath:    "/usr/bin/tmux",
+				Version:       "tmux 3.4a",
+				SocketName:    tmuxSocketName,
+				SessionName:   SessionName,
+				InsideTmux:    true,
+				InsideTmuxEnv: "/tmp/tmux-1000/default,123,0",
+				ServerRunning: true,
+				Sessions: []TmuxSessionStatus{
+					{Name: SessionName, Attached: 2, Windows: 4},
+					{Name: "scratch", Attached: 1, Windows: 1},
+				},
+			},
+			Items: []CapabilityStatus{{
+				Name:   "tmux",
+				Level:  CapabilityReady,
+				Detail: "tmux 3.4a on socket wuphf is running with session wuphf-team (2 attached, 4 windows).",
+			}},
+		},
+		Now: time.Unix(100, 0),
+	})
+
+	text := snapshot.FormatText()
+	for _, want := range []string{
+		"Runtime state for #general",
+		"Session mode: 1:1 with @pm",
+		"Pending human requests: 1",
+		"Approve launch timing from @ceo.",
+		"Use working_directory /tmp/wuphf-task-1",
+		"Recent highlights:",
+		"Tmux runtime:",
+		"Binary: /usr/bin/tmux",
+		"Version: tmux 3.4a",
+		"Inside tmux: yes",
+		"WUPHF session: running (2 attached, 4 windows)",
+		"scratch: 1 attached, 1 windows",
+		"Runtime capabilities:",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in %q", want, text)
+		}
+	}
+}

--- a/internal/team/session_memory.go
+++ b/internal/team/session_memory.go
@@ -1,0 +1,144 @@
+package team
+
+import (
+	"fmt"
+	"strings"
+)
+
+type SessionRecovery struct {
+	Focus      string
+	NextSteps  []string
+	Highlights []string
+}
+
+func BuildSessionRecovery(sessionMode, directAgent string, tasks []RuntimeTask, requests []RuntimeRequest, recent []RuntimeMessage) SessionRecovery {
+	recovery := SessionRecovery{}
+
+	if req, ok := firstPendingBlockingRuntimeRequest(requests); ok {
+		recovery.Focus = summarizeRequest(req)
+		recovery.NextSteps = append(recovery.NextSteps, "Answer the blocking human request before moving more work.")
+	}
+	if recovery.Focus == "" {
+		if task, ok := firstRunningTask(tasks); ok {
+			recovery.Focus = summarizeTask(task)
+		}
+	}
+	if recovery.Focus == "" {
+		if sessionMode == SessionModeOneOnOne {
+			recovery.Focus = fmt.Sprintf("Stay focused on the direct session with @%s.", directAgent)
+		} else {
+			recovery.Focus = "No blocking work detected. Scan the latest channel activity before speaking."
+		}
+	}
+
+	for _, task := range tasks {
+		if !runtimeTaskIsRunning(task) {
+			continue
+		}
+		if runtimeTaskUsesIsolation(task) && strings.TrimSpace(task.WorktreePath) != "" {
+			recovery.NextSteps = appendUnique(recovery.NextSteps, fmt.Sprintf("Use working_directory %s for local file and bash tools.", task.WorktreePath))
+		}
+		if strings.TrimSpace(task.ReviewState) != "" && task.ReviewState != "not_required" && task.ReviewState != "approved" {
+			recovery.NextSteps = appendUnique(recovery.NextSteps, fmt.Sprintf("Review flow is active on %s (%s).", task.ID, task.ReviewState))
+		}
+		if task.Blocked {
+			recovery.NextSteps = appendUnique(recovery.NextSteps, fmt.Sprintf("%s is blocked; check dependencies before continuing.", task.ID))
+		}
+	}
+
+	for _, msg := range recentHighlights(recent) {
+		recovery.Highlights = append(recovery.Highlights, msg)
+	}
+
+	return recovery
+}
+
+func firstPendingBlockingRuntimeRequest(requests []RuntimeRequest) (RuntimeRequest, bool) {
+	for _, req := range requests {
+		status := strings.ToLower(strings.TrimSpace(req.Status))
+		if status != "" && status != "pending" && status != "open" {
+			continue
+		}
+		if req.Blocking || req.Required {
+			return req, true
+		}
+	}
+	return RuntimeRequest{}, false
+}
+
+func firstRunningTask(tasks []RuntimeTask) (RuntimeTask, bool) {
+	for _, task := range tasks {
+		if runtimeTaskIsRunning(task) {
+			return task, true
+		}
+	}
+	return RuntimeTask{}, false
+}
+
+func summarizeRequest(req RuntimeRequest) string {
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		title = strings.TrimSpace(req.Question)
+	}
+	if title == "" {
+		title = "Human decision pending"
+	}
+	if req.From != "" {
+		return fmt.Sprintf("%s from @%s.", title, req.From)
+	}
+	return title + "."
+}
+
+func summarizeTask(task RuntimeTask) string {
+	text := strings.TrimSpace(task.Title)
+	if text == "" {
+		text = task.ID
+	}
+	if task.Owner != "" {
+		text += " owned by @" + task.Owner
+	}
+	if stage := strings.TrimSpace(task.PipelineStage); stage != "" {
+		text += " at stage " + stage
+	}
+	return text + "."
+}
+
+func recentHighlights(recent []RuntimeMessage) []string {
+	highlights := make([]string, 0, 3)
+	for _, msg := range recent {
+		content := strings.TrimSpace(msg.Content)
+		if content == "" {
+			content = strings.TrimSpace(msg.Title)
+		}
+		if content == "" {
+			continue
+		}
+		highlights = append(highlights, fmt.Sprintf("@%s: %s", msg.From, truncateRecoveryText(content, 120)))
+		if len(highlights) == 3 {
+			break
+		}
+	}
+	return highlights
+}
+
+func truncateRecoveryText(text string, limit int) string {
+	text = strings.Join(strings.Fields(text), " ")
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	return strings.TrimSpace(string(runes[:limit])) + "..."
+}
+
+func appendUnique(items []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return items
+	}
+	for _, item := range items {
+		if item == value {
+			return items
+		}
+	}
+	return append(items, value)
+}

--- a/internal/teammcp/actions.go
+++ b/internal/teammcp/actions.go
@@ -246,7 +246,7 @@ func handleTeamActionExecute(ctx context.Context, _ *mcp.CallToolRequest, args T
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, slug, args.Channel)
 	provider, err := selectedActionProvider(action.CapabilityActionExecute)
 	if err != nil {
 		return toolError(err), nil, nil
@@ -282,7 +282,7 @@ func handleTeamActionWorkflowCreate(ctx context.Context, _ *mcp.CallToolRequest,
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, slug, args.Channel)
 	definition := json.RawMessage(strings.TrimSpace(args.DefinitionJSON))
 	if !json.Valid(definition) {
 		return toolError(fmt.Errorf("definition_json must be valid JSON")), nil, nil
@@ -326,7 +326,7 @@ func handleTeamActionWorkflowExecute(ctx context.Context, _ *mcp.CallToolRequest
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, slug, args.Channel)
 	provider, err := selectedActionProvider(action.CapabilityWorkflowExecute)
 	if err != nil {
 		return toolError(err), nil, nil
@@ -366,7 +366,7 @@ func handleTeamActionWorkflowSchedule(ctx context.Context, _ *mcp.CallToolReques
 	if strings.TrimSpace(args.Key) == "" {
 		return toolError(fmt.Errorf("key is required")), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, slug, args.Channel)
 	sched, err := calendar.ParseCron(args.Schedule)
 	if err != nil {
 		return toolError(fmt.Errorf("invalid schedule %q: %w", args.Schedule, err)), nil, nil
@@ -483,7 +483,7 @@ func handleTeamActionRelayCreate(ctx context.Context, _ *mcp.CallToolRequest, ar
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, slug, args.Channel)
 	provider, err := selectedActionProvider(action.CapabilityRelayCreate)
 	if err != nil {
 		return toolError(err), nil, nil
@@ -507,7 +507,7 @@ func handleTeamActionRelayActivate(ctx context.Context, _ *mcp.CallToolRequest, 
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, slug, args.Channel)
 	actions := json.RawMessage(strings.TrimSpace(args.ActionsJSON))
 	if !json.Valid(actions) {
 		return toolError(fmt.Errorf("actions_json must be valid JSON")), nil, nil

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -53,6 +53,18 @@ type brokerMembersResponse struct {
 	} `json:"members"`
 }
 
+type brokerChannelsResponse struct {
+	Channels []brokerChannelSummary `json:"channels"`
+}
+
+type brokerChannelSummary struct {
+	Slug        string   `json:"slug"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Members     []string `json:"members"`
+	Disabled    []string `json:"disabled"`
+}
+
 type brokerOfficeMembersResponse struct {
 	Members []struct {
 		Slug           string   `json:"slug"`
@@ -129,6 +141,14 @@ type brokerTaskSummary struct {
 	WorktreeBranch   string   `json:"worktree_branch"`
 	DependsOn        []string `json:"depends_on,omitempty"`
 	Blocked          bool     `json:"blocked,omitempty"`
+	CreatedAt        string   `json:"created_at,omitempty"`
+	UpdatedAt        string   `json:"updated_at,omitempty"`
+}
+
+type conversationContext struct {
+	Channel   string
+	ReplyToID string
+	Source    string
 }
 
 type TeamBroadcastArgs struct {
@@ -151,6 +171,7 @@ type TeamPollArgs struct {
 	MySlug  string `json:"my_slug,omitempty" jsonschema:"Your agent slug so tagged_count can be computed. Defaults to WUPHF_AGENT_SLUG."`
 	SinceID string `json:"since_id,omitempty" jsonschema:"Only return messages after this message ID"`
 	Limit   int    `json:"limit,omitempty" jsonschema:"Maximum messages to return (default 10, max 100)"`
+	Scope   string `json:"scope,omitempty" jsonschema:"Transcript scope: all, agent, inbox, or outbox. Defaults to agent-scoped for non-CEO office agents."`
 }
 
 type TeamStatusArgs struct {
@@ -160,9 +181,11 @@ type TeamStatusArgs struct {
 }
 
 type HumanInterviewOption struct {
-	ID          string `json:"id" jsonschema:"Stable short ID like 'sales' or 'smbs'"`
-	Label       string `json:"label" jsonschema:"User-facing option label"`
-	Description string `json:"description,omitempty" jsonschema:"One-sentence explanation of tradeoff or impact"`
+	ID           string `json:"id" jsonschema:"Stable short ID like 'sales' or 'smbs'"`
+	Label        string `json:"label" jsonschema:"User-facing option label"`
+	Description  string `json:"description,omitempty" jsonschema:"One-sentence explanation of tradeoff or impact"`
+	RequiresText bool   `json:"requires_text,omitempty" jsonschema:"Whether the human must add typed guidance when choosing this option"`
+	TextHint     string `json:"text_hint,omitempty" jsonschema:"Hint shown when typed guidance is required or recommended for this option"`
 }
 
 type HumanInterviewArgs struct {
@@ -208,6 +231,12 @@ type TeamTasksArgs struct {
 	Channel     string `json:"channel,omitempty" jsonschema:"Channel slug. Defaults to the agent's current channel or general."`
 	MySlug      string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
 	IncludeDone bool   `json:"include_done,omitempty" jsonschema:"Include completed tasks as well"`
+}
+
+type TeamRuntimeStateArgs struct {
+	Channel      string `json:"channel,omitempty" jsonschema:"Channel slug. Defaults to the agent's current channel or general."`
+	MySlug       string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
+	MessageLimit int    `json:"message_limit,omitempty" jsonschema:"How many recent messages to include when building the recovery summary (default 12, max 40)."`
 }
 
 type TeamTaskArgs struct {
@@ -325,6 +354,11 @@ func Run(ctx context.Context) error {
 			Description: "Send a direct human-facing note into the chat when you need to present completion, recommend a decision, or tell the human what they should do next.",
 		}, handleHumanMessage)
 
+		mcp.AddTool(server, &mcp.Tool{
+			Name:        "team_runtime_state",
+			Description: "Return the canonical runtime snapshot for this direct session, including tasks, pending human requests, recovery summary, and runtime capabilities.",
+		}, handleTeamRuntimeState)
+
 		registerActionTools(server)
 
 		return server.Run(ctx, &mcp.StdioTransport{})
@@ -344,6 +378,14 @@ func Run(ctx context.Context) error {
 		Name:        "team_poll",
 		Description: "Read recent messages from the team channel so you stay in sync before replying.",
 	}, handleTeamPoll)
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "team_inbox",
+		Description: "Read only the messages that currently belong in your agent inbox: human asks, CEO guidance, tags to you, and replies in your threads.",
+	}, handleTeamInbox)
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "team_outbox",
+		Description: "Read only the messages you authored, so you can review what you already told the office.",
+	}, handleTeamOutbox)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "team_status",
@@ -396,6 +438,11 @@ func Run(ctx context.Context) error {
 	}, handleTeamTaskStatus)
 
 	mcp.AddTool(server, &mcp.Tool{
+		Name:        "team_runtime_state",
+		Description: "Return the canonical office runtime snapshot, including tasks, pending human requests, recovery summary, and runtime capabilities.",
+	}, handleTeamRuntimeState)
+
+	mcp.AddTool(server, &mcp.Tool{
 		Name:        "team_task",
 		Description: "Create, claim, assign, complete, block, or release a shared task in the office task list.",
 	}, handleTeamTask)
@@ -445,14 +492,11 @@ func handleTeamBroadcast(ctx context.Context, _ *mcp.CallToolRequest, args TeamB
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
-
+	location := resolveConversationContext(ctx, slug, args.Channel, args.ReplyToID)
+	channel := location.Channel
 	replyTo := strings.TrimSpace(args.ReplyToID)
-	if !isOneOnOneMode() && replyTo == "" && !args.NewTopic {
-		replyTo, _ = inferReplyTarget(ctx, slug, channel)
-	}
-	if !isOneOnOneMode() && replyTo == "" && !args.NewTopic {
-		replyTo, _ = inferDefaultThreadTarget(ctx, slug, channel)
+	if replyTo == "" && !args.NewTopic {
+		replyTo = location.ReplyToID
 	}
 
 	if !isOneOnOneMode() {
@@ -699,11 +743,18 @@ func containsSlug(items []string, want string) bool {
 }
 
 func handleTeamPoll(ctx context.Context, _ *mcp.CallToolRequest, args TeamPollArgs) (*mcp.CallToolResult, any, error) {
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, resolveSlugOptional(args.MySlug), args.Channel)
 	values := url.Values{}
 	values.Set("channel", channel)
+	scope, err := normalizePollScope(args.Scope)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
 	if slug := strings.TrimSpace(resolveSlugOptional(args.MySlug)); slug != "" {
 		values.Set("my_slug", slug)
+		applyAgentMessageScope(values, slug, scope)
+	} else if scope != "" {
+		values.Set("scope", scope)
 	}
 	if since := strings.TrimSpace(args.SinceID); since != "" {
 		values.Set("since_id", since)
@@ -734,10 +785,27 @@ func handleTeamPoll(ctx context.Context, _ *mcp.CallToolRequest, args TeamPollAr
 		}
 		return textResult("Direct conversation\n\nLatest human request to answer now:\n" + focus + "\n\nOlder messages are background unless the latest request depends on them.\n\nRecent messages:\n" + summary), nil, nil
 	}
+	if scope == "inbox" || scope == "outbox" {
+		scopeTitle := strings.Title(scope)
+		if slug := strings.TrimSpace(resolveSlugOptional(args.MySlug)); slug != "" {
+			return textResult(fmt.Sprintf("%s for @%s in #%s\n\n%s", scopeTitle, slug, channel, summary)), nil, nil
+		}
+		return textResult(fmt.Sprintf("%s in #%s\n\n%s", scopeTitle, channel, summary)), nil, nil
+	}
 	taskSummary := formatTaskSummary(ctx, resolveSlugOptional(args.MySlug), channel)
 	requestSummary := formatRequestSummary(ctx, channel)
 	memorySummary := formatMemorySummary(ctx)
 	return textResult(fmt.Sprintf("Channel #%s\n\n%s\n\nTagged messages for you: %d\n\n%s\n\n%s\n\n%s", channel, summary, result.TaggedCount, taskSummary, requestSummary, memorySummary)), nil, nil
+}
+
+func handleTeamInbox(ctx context.Context, req *mcp.CallToolRequest, args TeamPollArgs) (*mcp.CallToolResult, any, error) {
+	args.Scope = "inbox"
+	return handleTeamPoll(ctx, req, args)
+}
+
+func handleTeamOutbox(ctx context.Context, req *mcp.CallToolRequest, args TeamPollArgs) (*mcp.CallToolResult, any, error) {
+	args.Scope = "outbox"
+	return handleTeamPoll(ctx, req, args)
 }
 
 func handleTeamStatus(ctx context.Context, _ *mcp.CallToolRequest, args TeamStatusArgs) (*mcp.CallToolResult, any, error) {
@@ -745,7 +813,7 @@ func handleTeamStatus(ctx context.Context, _ *mcp.CallToolRequest, args TeamStat
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, slug, args.Channel)
 	if err := brokerPostJSON(ctx, "/messages", map[string]any{
 		"channel": channel,
 		"from":    slug,
@@ -758,8 +826,8 @@ func handleTeamStatus(ctx context.Context, _ *mcp.CallToolRequest, args TeamStat
 }
 
 func handleTeamMembers(ctx context.Context, _ *mcp.CallToolRequest, args TeamMembersArgs) (*mcp.CallToolResult, any, error) {
-	channel := resolveChannel(args.Channel)
 	viewer := strings.TrimSpace(resolveSlugOptional(args.MySlug))
+	channel := resolveConversationChannel(ctx, viewer, args.Channel)
 	var result brokerMembersResponse
 	values := url.Values{}
 	values.Set("channel", channel)
@@ -844,12 +912,56 @@ func handleTeamTaskStatus(ctx context.Context, _ *mcp.CallToolRequest, args Team
 	return textResult(summarizeTaskRuntime(channel, tasks)), nil, nil
 }
 
+func handleTeamRuntimeState(ctx context.Context, _ *mcp.CallToolRequest, args TeamRuntimeStateArgs) (*mcp.CallToolResult, any, error) {
+	slug := resolveSlugOptional(args.MySlug)
+	channel := resolveConversationChannel(ctx, slug, args.Channel)
+	taskChannel, tasks, err := fetchTeamTasks(ctx, TeamTasksArgs{
+		Channel:     channel,
+		MySlug:      args.MySlug,
+		IncludeDone: false,
+	})
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+
+	requests, err := fetchRuntimeRequests(ctx, channel, args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	recent, err := fetchRuntimeMessages(ctx, channel, args.MySlug, args.MessageLimit)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+
+	mode := team.SessionModeOffice
+	directAgent := ""
+	if isOneOnOneMode() {
+		mode = team.SessionModeOneOnOne
+		directAgent = team.NormalizeOneOnOneAgent(os.Getenv("WUPHF_ONE_ON_ONE_AGENT"))
+	}
+
+	snapshot := team.BuildRuntimeSnapshot(team.RuntimeSnapshotInput{
+		Channel:      taskChannel,
+		SessionMode:  mode,
+		DirectAgent:  directAgent,
+		Tasks:        convertRuntimeTasks(tasks),
+		Requests:     requests,
+		Recent:       recent,
+		Capabilities: team.DetectRuntimeCapabilities(),
+	})
+	return textResult(snapshot.FormatText()), snapshot, nil
+}
+
 func handleTeamTask(ctx context.Context, _ *mcp.CallToolRequest, args TeamTaskArgs) (*mcp.CallToolResult, any, error) {
 	mySlug, err := resolveSlug(args.MySlug)
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := strings.TrimSpace(args.Channel)
+	if channel == "" && strings.TrimSpace(args.ID) != "" {
+		channel = findTaskContextByID(ctx, mySlug, args.ID).Channel
+	}
+	channel = resolveConversationChannel(ctx, mySlug, channel)
 	action := strings.TrimSpace(args.Action)
 	payload := map[string]any{
 		"action":     action,
@@ -908,7 +1020,7 @@ func handleTeamTask(ctx context.Context, _ *mcp.CallToolRequest, args TeamTaskAr
 
 func fetchTeamTasks(ctx context.Context, args TeamTasksArgs) (string, []brokerTaskSummary, error) {
 	mySlug := strings.TrimSpace(resolveSlugOptional(args.MySlug))
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, mySlug, args.Channel)
 	values := url.Values{}
 	values.Set("channel", channel)
 	if mySlug != "" {
@@ -982,6 +1094,112 @@ func summarizeTaskRuntime(channel string, tasks []brokerTaskSummary) string {
 	return strings.Join(lines, "\n")
 }
 
+func fetchRuntimeRequests(ctx context.Context, channel, mySlug string) ([]team.RuntimeRequest, error) {
+	values := url.Values{}
+	values.Set("channel", channel)
+	if viewer := strings.TrimSpace(resolveSlugOptional(mySlug)); viewer != "" {
+		values.Set("viewer_slug", viewer)
+	}
+	var result brokerRequestsResponse
+	path := "/requests"
+	if encoded := values.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	if err := brokerGetJSON(ctx, path, &result); err != nil {
+		return nil, err
+	}
+
+	requests := make([]team.RuntimeRequest, 0, len(result.Requests)+1)
+	seen := map[string]bool{}
+	if result.Pending != nil {
+		req := team.RuntimeRequest{
+			ID:       result.Pending.ID,
+			Kind:     result.Pending.Kind,
+			Title:    result.Pending.Title,
+			Question: result.Pending.Question,
+			From:     result.Pending.From,
+			Blocking: result.Pending.Blocking,
+			Required: result.Pending.Required,
+			Status:   "pending",
+			Channel:  result.Pending.Channel,
+			Secret:   result.Pending.Secret,
+		}
+		requests = append(requests, req)
+		seen[req.ID] = true
+	}
+	for _, req := range result.Requests {
+		if seen[req.ID] {
+			continue
+		}
+		requests = append(requests, team.RuntimeRequest{
+			ID:       req.ID,
+			Kind:     req.Kind,
+			Title:    req.Title,
+			Question: req.Question,
+			From:     req.From,
+			Blocking: req.Blocking,
+			Required: req.Required,
+			Status:   req.Status,
+			Channel:  req.Channel,
+			Secret:   req.Secret,
+		})
+	}
+	return requests, nil
+}
+
+func fetchRuntimeMessages(ctx context.Context, channel, mySlug string, limit int) ([]team.RuntimeMessage, error) {
+	values := url.Values{}
+	values.Set("channel", channel)
+	if slug := strings.TrimSpace(resolveSlugOptional(mySlug)); slug != "" {
+		values.Set("my_slug", slug)
+		applyAgentMessageScope(values, slug, "agent")
+	}
+	switch {
+	case limit <= 0:
+		values.Set("limit", "12")
+	case limit > 40:
+		values.Set("limit", "40")
+	default:
+		values.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	var result brokerMessagesResponse
+	if err := brokerGetJSON(ctx, "/messages?"+values.Encode(), &result); err != nil {
+		return nil, err
+	}
+	messages := make([]team.RuntimeMessage, 0, len(result.Messages))
+	for i := len(result.Messages) - 1; i >= 0; i-- {
+		msg := result.Messages[i]
+		messages = append(messages, team.RuntimeMessage{
+			ID:        msg.ID,
+			From:      msg.From,
+			Title:     msg.Title,
+			Content:   msg.Content,
+			ReplyTo:   msg.ReplyTo,
+			Timestamp: msg.Timestamp,
+		})
+	}
+	return messages, nil
+}
+
+func convertRuntimeTasks(tasks []brokerTaskSummary) []team.RuntimeTask {
+	out := make([]team.RuntimeTask, 0, len(tasks))
+	for _, task := range tasks {
+		out = append(out, team.RuntimeTask{
+			ID:             task.ID,
+			Title:          task.Title,
+			Owner:          task.Owner,
+			Status:         task.Status,
+			PipelineStage:  task.PipelineStage,
+			ReviewState:    task.ReviewState,
+			ExecutionMode:  task.ExecutionMode,
+			WorktreePath:   task.WorktreePath,
+			WorktreeBranch: task.WorktreeBranch,
+			Blocked:        task.Blocked,
+		})
+	}
+	return out
+}
+
 func formatTaskRuntimeLine(task brokerTaskSummary) string {
 	line := fmt.Sprintf("- %s [%s]", task.ID, task.Status)
 	if task.Owner != "" {
@@ -1033,7 +1251,7 @@ func handleTeamPlan(ctx context.Context, _ *mcp.CallToolRequest, args TeamPlanAr
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, mySlug, args.Channel)
 	if len(args.Tasks) == 0 {
 		return toolError(fmt.Errorf("tasks list is empty")), nil, nil
 	}
@@ -1110,7 +1328,11 @@ func handleTeamTaskAck(ctx context.Context, _ *mcp.CallToolRequest, args TeamTas
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := strings.TrimSpace(args.Channel)
+	if channel == "" {
+		channel = findTaskContextByID(ctx, mySlug, args.ID).Channel
+	}
+	channel = resolveConversationChannel(ctx, mySlug, channel)
 	taskID := strings.TrimSpace(args.ID)
 	if taskID == "" {
 		return toolError(fmt.Errorf("task ID is required")), nil, nil
@@ -1132,8 +1354,8 @@ func handleTeamTaskAck(ctx context.Context, _ *mcp.CallToolRequest, args TeamTas
 }
 
 func handleTeamRequests(ctx context.Context, _ *mcp.CallToolRequest, args TeamRequestsArgs) (*mcp.CallToolResult, any, error) {
-	channel := resolveChannel(args.Channel)
 	viewer := strings.TrimSpace(resolveSlugOptional(args.MySlug))
+	channel := resolveConversationChannel(ctx, viewer, args.Channel)
 	values := url.Values{}
 	values.Set("channel", channel)
 	if viewer != "" {
@@ -1181,11 +1403,9 @@ func handleTeamRequest(ctx context.Context, _ *mcp.CallToolRequest, args TeamReq
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
-	replyTo := strings.TrimSpace(args.ReplyToID)
-	if replyTo == "" {
-		replyTo, _ = inferReplyTarget(ctx, slug, channel)
-	}
+	ctxTarget := resolveConversationContext(ctx, slug, args.Channel, args.ReplyToID)
+	channel := ctxTarget.Channel
+	replyTo := ctxTarget.ReplyToID
 
 	kind := defaultRequestKind(args.Kind)
 	blocking := args.Blocking
@@ -1194,6 +1414,7 @@ func handleTeamRequest(ctx context.Context, _ *mcp.CallToolRequest, args TeamReq
 		blocking = true
 		required = true
 	}
+	options, recommendedID := normalizeHumanRequestOptions(kind, args.RecommendedOptionID, args.Options)
 
 	var created struct {
 		ID string `json:"id"`
@@ -1205,8 +1426,8 @@ func handleTeamRequest(ctx context.Context, _ *mcp.CallToolRequest, args TeamReq
 		"title":          strings.TrimSpace(args.Title),
 		"question":       args.Question,
 		"context":        args.Context,
-		"options":        args.Options,
-		"recommended_id": args.RecommendedOptionID,
+		"options":        options,
+		"recommended_id": recommendedID,
 		"blocking":       blocking,
 		"required":       required,
 		"secret":         args.Secret,
@@ -1225,8 +1446,10 @@ func handleHumanInterview(ctx context.Context, _ *mcp.CallToolRequest, args Huma
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	location := resolveConversationContext(ctx, slug, args.Channel, "")
+	channel := location.Channel
 
+	options, recommendedID := normalizeHumanRequestOptions("interview", args.RecommendedOptionID, args.Options)
 	var created struct {
 		ID string `json:"id"`
 	}
@@ -1237,10 +1460,11 @@ func handleHumanInterview(ctx context.Context, _ *mcp.CallToolRequest, args Huma
 		"title":          "Human interview",
 		"question":       args.Question,
 		"context":        args.Context,
-		"options":        args.Options,
-		"recommended_id": args.RecommendedOptionID,
+		"options":        options,
+		"recommended_id": recommendedID,
 		"blocking":       true,
 		"required":       true,
+		"reply_to":       location.ReplyToID,
 	}, &created); err != nil {
 		return toolError(err), nil, nil
 	}
@@ -1288,11 +1512,9 @@ func handleHumanMessage(ctx context.Context, _ *mcp.CallToolRequest, args HumanM
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
-	replyTo := strings.TrimSpace(args.ReplyToID)
-	if replyTo == "" {
-		replyTo, _ = inferReplyTarget(ctx, slug, channel)
-	}
+	ctxTarget := resolveConversationContext(ctx, slug, args.Channel, args.ReplyToID)
+	channel := ctxTarget.Channel
+	replyTo := ctxTarget.ReplyToID
 
 	kind := strings.ToLower(strings.TrimSpace(args.Kind))
 	switch kind {
@@ -1385,7 +1607,7 @@ func handleTeamChannel(ctx context.Context, _ *mcp.CallToolRequest, args TeamCha
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, slug, args.Channel)
 	if err := brokerPostJSON(ctx, "/channels", map[string]any{
 		"action":      strings.TrimSpace(args.Action),
 		"slug":        channel,
@@ -1403,10 +1625,11 @@ func handleTeamChannel(ctx context.Context, _ *mcp.CallToolRequest, args TeamCha
 }
 
 func handleTeamChannelMember(ctx context.Context, _ *mcp.CallToolRequest, args TeamChannelMemberArgs) (*mcp.CallToolResult, any, error) {
-	if _, err := resolveSlug(args.MySlug); err != nil {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
 		return toolError(err), nil, nil
 	}
-	channel := resolveChannel(args.Channel)
+	channel := resolveConversationChannel(ctx, slug, args.Channel)
 	member := normalizeSlug(args.MemberSlug)
 	if member == "" {
 		return toolError(fmt.Errorf("member_slug is required")), nil, nil
@@ -1574,19 +1797,348 @@ func resolveSlugOptional(input string) string {
 	return strings.TrimSpace(os.Getenv("NEX_AGENT_SLUG"))
 }
 
-func resolveChannel(input string) string {
+func normalizeChannelInput(input string) string {
 	channel := strings.TrimSpace(input)
 	if channel == "" {
-		channel = strings.TrimSpace(os.Getenv("WUPHF_CHANNEL"))
-	}
-	if channel == "" {
-		channel = strings.TrimSpace(os.Getenv("NEX_CHANNEL"))
-	}
-	if channel == "" {
-		channel = "general"
+		return ""
 	}
 	channel = strings.ToLower(strings.ReplaceAll(channel, " ", "-"))
 	return channel
+}
+
+func resolveChannelHint(input string) string {
+	channel := normalizeChannelInput(input)
+	if channel == "" {
+		channel = normalizeChannelInput(os.Getenv("WUPHF_CHANNEL"))
+	}
+	if channel == "" {
+		channel = normalizeChannelInput(os.Getenv("NEX_CHANNEL"))
+	}
+	return channel
+}
+
+func resolveChannel(input string) string {
+	channel := resolveChannelHint(input)
+	if channel == "" {
+		channel = "general"
+	}
+	return channel
+}
+
+func resolveConversationChannel(ctx context.Context, slug string, requestedChannel string) string {
+	return resolveConversationContext(ctx, slug, requestedChannel, "").Channel
+}
+
+func resolveConversationContext(ctx context.Context, slug, requestedChannel, requestedReplyTo string) conversationContext {
+	channel := resolveChannelHint(requestedChannel)
+	replyTo := strings.TrimSpace(requestedReplyTo)
+	if channel != "" {
+		if replyTo == "" {
+			replyTo = defaultReplyTargetForChannel(ctx, slug, channel)
+		}
+		return conversationContext{Channel: channel, ReplyToID: replyTo, Source: "explicit_channel"}
+	}
+
+	if replyTo != "" {
+		if located := findMessageContextByID(ctx, slug, replyTo); located.Channel != "" {
+			located.ReplyToID = replyTo
+			located.Source = "explicit_reply"
+			return located
+		}
+	}
+
+	if isOneOnOneMode() {
+		channel = resolveChannel("")
+		if replyTo == "" {
+			replyTo = inferDirectReplyTarget(ctx, slug, channel)
+		}
+		return conversationContext{Channel: channel, ReplyToID: replyTo, Source: "direct_session"}
+	}
+
+	if inferred := inferRecentConversationContext(ctx, slug); inferred.Channel != "" {
+		if replyTo != "" {
+			inferred.ReplyToID = replyTo
+		}
+		if inferred.ReplyToID == "" {
+			inferred.ReplyToID = defaultReplyTargetForChannel(ctx, slug, inferred.Channel)
+		}
+		return inferred
+	}
+
+	if inferred := inferTaskConversationContext(ctx, slug); inferred.Channel != "" {
+		if replyTo != "" {
+			inferred.ReplyToID = replyTo
+		}
+		if inferred.ReplyToID == "" {
+			inferred.ReplyToID = defaultReplyTargetForChannel(ctx, slug, inferred.Channel)
+		}
+		return inferred
+	}
+
+	channel = resolveChannel("")
+	if replyTo == "" {
+		replyTo = defaultReplyTargetForChannel(ctx, slug, channel)
+	}
+	return conversationContext{Channel: channel, ReplyToID: replyTo, Source: "fallback"}
+}
+
+func fetchAccessibleChannels(ctx context.Context, slug string) []brokerChannelSummary {
+	var result brokerChannelsResponse
+	if err := brokerGetJSON(ctx, "/channels", &result); err != nil {
+		return nil
+	}
+	slug = strings.TrimSpace(slug)
+	if slug == "" || slug == "ceo" {
+		return result.Channels
+	}
+	out := make([]brokerChannelSummary, 0, len(result.Channels))
+	for _, ch := range result.Channels {
+		if !contains(ch.Members, slug) || contains(ch.Disabled, slug) {
+			continue
+		}
+		out = append(out, ch)
+	}
+	return out
+}
+
+func fetchChannelMessages(ctx context.Context, channel, slug, scope string, limit int) []brokerMessage {
+	values := url.Values{}
+	values.Set("channel", channel)
+	if limit > 0 {
+		values.Set("limit", fmt.Sprintf("%d", limit))
+	}
+	slug = strings.TrimSpace(slug)
+	if slug != "" {
+		values.Set("my_slug", slug)
+		values.Set("viewer_slug", slug)
+		if strings.TrimSpace(scope) != "" {
+			values.Set("scope", strings.TrimSpace(scope))
+		}
+	}
+	var result brokerMessagesResponse
+	path := "/messages?" + values.Encode()
+	if err := brokerGetJSON(ctx, path, &result); err != nil {
+		return nil
+	}
+	return result.Messages
+}
+
+func inferRecentConversationContext(ctx context.Context, slug string) conversationContext {
+	channels := fetchAccessibleChannels(ctx, slug)
+	var (
+		best      conversationContext
+		bestStamp time.Time
+	)
+	for _, ch := range channels {
+		messages := fetchChannelMessages(ctx, ch.Slug, slug, "inbox", 40)
+		if len(messages) == 0 {
+			continue
+		}
+		candidate, stamp := latestRelevantMessageContext(messages, slug, ch.Slug)
+		if candidate.Channel == "" || stamp.IsZero() {
+			continue
+		}
+		if best.Channel == "" || stamp.After(bestStamp) {
+			best = candidate
+			bestStamp = stamp
+		}
+	}
+	return best
+}
+
+func latestRelevantMessageContext(messages []brokerMessage, slug, fallbackChannel string) (conversationContext, time.Time) {
+	byID := make(map[string]brokerMessage, len(messages))
+	for _, msg := range messages {
+		if id := strings.TrimSpace(msg.ID); id != "" {
+			byID[id] = msg
+		}
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if strings.TrimSpace(msg.From) == strings.TrimSpace(slug) {
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(msg.Content), "[STATUS]") {
+			continue
+		}
+		stamp, err := time.Parse(time.RFC3339, strings.TrimSpace(msg.Timestamp))
+		if err != nil {
+			continue
+		}
+		channel := normalizeChannelInput(msg.Channel)
+		if channel == "" {
+			channel = normalizeChannelInput(fallbackChannel)
+		}
+		if channel == "" {
+			channel = "general"
+		}
+		return conversationContext{
+			Channel:   channel,
+			ReplyToID: threadTargetForMessage(msg, byID),
+			Source:    "recent_message",
+		}, stamp
+	}
+	return conversationContext{}, time.Time{}
+}
+
+func threadTargetForMessage(msg brokerMessage, byID map[string]brokerMessage) string {
+	current := strings.TrimSpace(msg.ID)
+	parent := strings.TrimSpace(msg.ReplyTo)
+	if parent == "" {
+		return current
+	}
+	seen := map[string]bool{}
+	for parent != "" {
+		if seen[parent] {
+			return parent
+		}
+		seen[parent] = true
+		next, ok := byID[parent]
+		if !ok || strings.TrimSpace(next.ReplyTo) == "" {
+			return parent
+		}
+		parent = strings.TrimSpace(next.ReplyTo)
+	}
+	return current
+}
+
+func inferTaskConversationContext(ctx context.Context, slug string) conversationContext {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return conversationContext{}
+	}
+	channels := fetchAccessibleChannels(ctx, slug)
+	var (
+		best      conversationContext
+		bestStamp time.Time
+	)
+	for _, ch := range channels {
+		values := url.Values{}
+		values.Set("channel", ch.Slug)
+		values.Set("viewer_slug", slug)
+		values.Set("my_slug", slug)
+		var result brokerTasksResponse
+		if err := brokerGetJSON(ctx, "/tasks?"+values.Encode(), &result); err != nil {
+			continue
+		}
+		for _, task := range result.Tasks {
+			if !taskCountsAsRunning(task) {
+				continue
+			}
+			stamp := parseLatestTaskTime(task)
+			if best.Channel != "" && !stamp.After(bestStamp) {
+				continue
+			}
+			best = conversationContext{
+				Channel:   normalizeChannelInput(task.Channel),
+				ReplyToID: strings.TrimSpace(task.ThreadID),
+				Source:    "owned_task",
+			}
+			bestStamp = stamp
+		}
+	}
+	return best
+}
+
+func parseLatestTaskTime(task brokerTaskSummary) time.Time {
+	for _, raw := range []string{strings.TrimSpace(task.UpdatedAt), strings.TrimSpace(task.CreatedAt)} {
+		if raw == "" {
+			continue
+		}
+		if stamp, err := time.Parse(time.RFC3339, raw); err == nil {
+			return stamp
+		}
+	}
+	return time.Time{}
+}
+
+func findMessageContextByID(ctx context.Context, slug, messageID string) conversationContext {
+	messageID = strings.TrimSpace(messageID)
+	if messageID == "" {
+		return conversationContext{}
+	}
+	for _, ch := range fetchAccessibleChannels(ctx, slug) {
+		messages := fetchChannelMessages(ctx, ch.Slug, slug, "", 100)
+		byID := make(map[string]brokerMessage, len(messages))
+		for _, msg := range messages {
+			if id := strings.TrimSpace(msg.ID); id != "" {
+				byID[id] = msg
+			}
+		}
+		if msg, ok := byID[messageID]; ok {
+			return conversationContext{
+				Channel:   ch.Slug,
+				ReplyToID: threadTargetForMessage(msg, byID),
+				Source:    "message_lookup",
+			}
+		}
+	}
+	return conversationContext{}
+}
+
+func findTaskContextByID(ctx context.Context, slug, taskID string) conversationContext {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return conversationContext{}
+	}
+	channels := fetchAccessibleChannels(ctx, slug)
+	for _, ch := range channels {
+		values := url.Values{}
+		values.Set("channel", ch.Slug)
+		if strings.TrimSpace(slug) != "" {
+			values.Set("viewer_slug", strings.TrimSpace(slug))
+		}
+		values.Set("include_done", "true")
+		var result brokerTasksResponse
+		if err := brokerGetJSON(ctx, "/tasks?"+values.Encode(), &result); err != nil {
+			continue
+		}
+		for _, task := range result.Tasks {
+			if strings.TrimSpace(task.ID) == taskID {
+				return conversationContext{
+					Channel:   ch.Slug,
+					ReplyToID: strings.TrimSpace(task.ThreadID),
+					Source:    "task_lookup",
+				}
+			}
+		}
+	}
+	return conversationContext{}
+}
+
+func defaultReplyTargetForChannel(ctx context.Context, slug, channel string) string {
+	channel = resolveChannel(channel)
+	if isOneOnOneMode() {
+		return inferDirectReplyTarget(ctx, slug, channel)
+	}
+	if replyTo, err := inferReplyTarget(ctx, slug, channel); err == nil && strings.TrimSpace(replyTo) != "" {
+		return strings.TrimSpace(replyTo)
+	}
+	if replyTo, err := inferDefaultThreadTarget(ctx, slug, channel); err == nil && strings.TrimSpace(replyTo) != "" {
+		return strings.TrimSpace(replyTo)
+	}
+	return ""
+}
+
+func inferDirectReplyTarget(ctx context.Context, slug, channel string) string {
+	messages := fetchChannelMessages(ctx, channel, slug, "", 40)
+	if len(messages) == 0 {
+		return ""
+	}
+	byID := make(map[string]brokerMessage, len(messages))
+	for _, msg := range messages {
+		if id := strings.TrimSpace(msg.ID); id != "" {
+			byID[id] = msg
+		}
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if strings.TrimSpace(msg.From) == strings.TrimSpace(slug) {
+			continue
+		}
+		return threadTargetForMessage(msg, byID)
+	}
+	return ""
 }
 
 func normalizeSlug(input string) string {
@@ -1602,6 +2154,103 @@ func defaultRequestKind(kind string) string {
 		return "choice"
 	}
 	return kind
+}
+
+func humanRequestOptionDefaults(kind string) ([]HumanInterviewOption, string) {
+	switch strings.TrimSpace(kind) {
+	case "approval":
+		return []HumanInterviewOption{
+			{ID: "approve", Label: "Approve", Description: "Green-light this and let the team execute immediately."},
+			{ID: "approve_with_note", Label: "Approve with note", Description: "Proceed, but attach explicit constraints or guardrails.", RequiresText: true, TextHint: "Type the conditions, constraints, or guardrails the team must follow."},
+			{ID: "reject", Label: "Reject", Description: "Do not proceed with this."},
+			{ID: "reject_with_steer", Label: "Reject with steer", Description: "Do not proceed as proposed. Redirect the team with clearer steering.", RequiresText: true, TextHint: "Type the steering, redirect, or rationale for rejecting this request."},
+			{ID: "hold", Label: "Hold", Description: "Pause until you review or unblock this yourself."},
+		}, "approve"
+	case "confirm":
+		return []HumanInterviewOption{
+			{ID: "confirm_proceed", Label: "Confirm", Description: "Looks good. Proceed as planned."},
+			{ID: "adjust", Label: "Adjust", Description: "Proceed only after applying the changes you specify.", RequiresText: true, TextHint: "Type the changes that must happen before proceeding."},
+			{ID: "reassign", Label: "Reassign", Description: "Move this to a different owner or scope.", RequiresText: true, TextHint: "Type who should own this instead, or how the scope should change."},
+			{ID: "hold", Label: "Hold", Description: "Do not act yet. Keep this pending for review."},
+		}, "confirm_proceed"
+	case "choice":
+		return []HumanInterviewOption{
+			{ID: "move_fast", Label: "Move fast", Description: "Bias toward speed. Ship now and iterate later."},
+			{ID: "balanced", Label: "Balanced", Description: "Balance speed, risk, and quality."},
+			{ID: "be_careful", Label: "Be careful", Description: "Bias toward caution and a tighter review loop."},
+			{ID: "needs_more_info", Label: "Need more info", Description: "Gather more context before deciding.", RequiresText: true, TextHint: "Type what is missing or what should be investigated next."},
+			{ID: "delegate", Label: "Delegate", Description: "Hand this to a specific owner for a closer call.", RequiresText: true, TextHint: "Type who should own this decision and any guidance for them."},
+		}, "balanced"
+	case "freeform", "secret":
+		return []HumanInterviewOption{
+			{ID: "proceed", Label: "Proceed", Description: "Let the team handle it with their best judgment."},
+			{ID: "give_direction", Label: "Give direction", Description: "Proceed, but only after you provide specific guidance.", RequiresText: true, TextHint: "Type the direction or constraints the team should follow."},
+			{ID: "delegate", Label: "Delegate", Description: "Route this to a specific person.", RequiresText: true, TextHint: "Type who should own this and what they should do."},
+			{ID: "hold", Label: "Hold", Description: "Pause until you review this further."},
+		}, "proceed"
+	default:
+		return nil, ""
+	}
+}
+
+func normalizeHumanRequestOptions(kind, recommendedID string, options []HumanInterviewOption) ([]HumanInterviewOption, string) {
+	defaults, fallback := humanRequestOptionDefaults(kind)
+	if len(options) == 0 {
+		return defaults, chooseRecommendedID(strings.TrimSpace(recommendedID), fallback)
+	}
+	meta := make(map[string]HumanInterviewOption, len(defaults))
+	for _, option := range defaults {
+		meta[strings.TrimSpace(option.ID)] = option
+	}
+	out := make([]HumanInterviewOption, 0, len(options))
+	for _, option := range options {
+		if base, ok := meta[strings.TrimSpace(option.ID)]; ok {
+			if !option.RequiresText {
+				option.RequiresText = base.RequiresText
+			}
+			if strings.TrimSpace(option.TextHint) == "" {
+				option.TextHint = base.TextHint
+			}
+			if strings.TrimSpace(option.Label) == "" {
+				option.Label = base.Label
+			}
+			if strings.TrimSpace(option.Description) == "" {
+				option.Description = base.Description
+			}
+		}
+		out = append(out, option)
+	}
+	return out, chooseRecommendedID(strings.TrimSpace(recommendedID), fallback)
+}
+
+func chooseRecommendedID(preferred, fallback string) string {
+	if preferred != "" {
+		return preferred
+	}
+	return fallback
+}
+
+func normalizePollScope(value string) (string, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", "all", "channel":
+		return "", nil
+	case "agent", "inbox", "outbox":
+		return strings.TrimSpace(strings.ToLower(value)), nil
+	default:
+		return "", fmt.Errorf("invalid scope %q", value)
+	}
+}
+
+func applyAgentMessageScope(values url.Values, slug, scope string) {
+	slug = strings.TrimSpace(slug)
+	if slug == "" || slug == "ceo" || isOneOnOneMode() {
+		return
+	}
+	values.Set("viewer_slug", slug)
+	if scope == "" {
+		scope = "agent"
+	}
+	values.Set("scope", scope)
 }
 
 func brokerGetJSON(ctx context.Context, path string, out any) error {
@@ -1682,6 +2331,12 @@ func inferReplyTarget(ctx context.Context, slug string, channel string) (string,
 	if err := brokerGetJSON(ctx, "/messages?channel="+url.QueryEscape(channel)+"&my_slug="+url.QueryEscape(slug)+"&limit=25", &result); err != nil {
 		return "", err
 	}
+	byID := make(map[string]brokerMessage, len(result.Messages))
+	for _, msg := range result.Messages {
+		if id := strings.TrimSpace(msg.ID); id != "" {
+			byID[id] = msg
+		}
+	}
 	for i := len(result.Messages) - 1; i >= 0; i-- {
 		msg := result.Messages[i]
 		if msg.From == slug {
@@ -1693,7 +2348,7 @@ func inferReplyTarget(ctx context.Context, slug string, channel string) (string,
 		if !isRecentEnough(msg.Timestamp, 15*time.Minute) {
 			continue
 		}
-		return msg.ID, nil
+		return threadTargetForMessage(msg, byID), nil
 	}
 	return "", nil
 }
@@ -1702,6 +2357,12 @@ func inferDefaultThreadTarget(ctx context.Context, slug string, channel string) 
 	var result brokerMessagesResponse
 	if err := brokerGetJSON(ctx, "/messages?channel="+url.QueryEscape(channel)+"&my_slug="+url.QueryEscape(slug)+"&limit=40", &result); err != nil {
 		return "", err
+	}
+	byID := make(map[string]brokerMessage, len(result.Messages))
+	for _, msg := range result.Messages {
+		if id := strings.TrimSpace(msg.ID); id != "" {
+			byID[id] = msg
+		}
 	}
 	for i := len(result.Messages) - 1; i >= 0; i-- {
 		msg := result.Messages[i]
@@ -1714,7 +2375,7 @@ func inferDefaultThreadTarget(ctx context.Context, slug string, channel string) 
 		if !isRecentEnough(msg.Timestamp, 20*time.Minute) {
 			continue
 		}
-		return msg.ID, nil
+		return threadTargetForMessage(msg, byID), nil
 	}
 	return "", nil
 }

--- a/internal/teammcp/server_test.go
+++ b/internal/teammcp/server_test.go
@@ -271,6 +271,45 @@ func TestHandleTeamPollOneOnOneHighlightsLatestHumanRequest(t *testing.T) {
 	}
 }
 
+func TestHandleTeamPollScopesMessagesForNonCEO(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	for _, msg := range []map[string]any{
+		{"channel": "general", "from": "you", "content": "Human wants a quick update."},
+		{"channel": "general", "from": "pm", "content": "Unrelated PM planning note."},
+		{"channel": "general", "from": "ceo", "content": "Frontend, tighten the CTA copy.", "tagged": []string{"fe"}},
+		{"channel": "general", "from": "fe", "content": "I am on the CTA copy now."},
+	} {
+		if err := brokerPostJSON(context.Background(), "/messages", msg, nil); err != nil {
+			t.Fatalf("post message: %v", err)
+		}
+	}
+
+	result, _, err := handleTeamPoll(context.Background(), nil, TeamPollArgs{Channel: "general", MySlug: "fe"})
+	if err != nil {
+		t.Fatalf("handleTeamPoll: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "Frontend, tighten the CTA copy.") {
+		t.Fatalf("expected tagged CEO direction in %q", text)
+	}
+	if !strings.Contains(text, "I am on the CTA copy now.") {
+		t.Fatalf("expected FE outbox message in %q", text)
+	}
+	if strings.Contains(text, "Unrelated PM planning note.") {
+		t.Fatalf("did not expect unrelated PM note in scoped poll %q", text)
+	}
+}
+
 func TestSummarizeTaskRuntimeIncludesIsolationCounts(t *testing.T) {
 	summary := summarizeTaskRuntime("general", []brokerTaskSummary{
 		{
@@ -457,5 +496,453 @@ func TestHandleTeamTaskReturnsWorktreeGuidance(t *testing.T) {
 	}
 	if !strings.Contains(text, "working_directory /tmp/wuphf-task-99") {
 		t.Fatalf("expected working_directory guidance in %q", text)
+	}
+}
+
+func TestHandleTeamRuntimeStateIncludesRecoveryAndCapabilities(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_NO_NEX", "1")
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	if err := brokerPostJSON(context.Background(), "/messages", map[string]any{
+		"channel": "general",
+		"from":    "ceo",
+		"content": "Need your approval before shipping.",
+	}, nil); err != nil {
+		t.Fatalf("post message: %v", err)
+	}
+
+	if err := brokerPostJSON(context.Background(), "/tasks", map[string]any{
+		"action":          "create",
+		"channel":         "general",
+		"title":           "Ship release candidate",
+		"owner":           "fe",
+		"created_by":      "ceo",
+		"execution_mode":  "local_worktree",
+		"worktree_path":   "/tmp/wuphf-task-77",
+		"worktree_branch": "task/77",
+	}, nil); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	if err := brokerPostJSON(context.Background(), "/requests", map[string]any{
+		"kind":     "approval",
+		"channel":  "general",
+		"from":     "ceo",
+		"title":    "Approve release",
+		"question": "Should we ship the release candidate?",
+		"blocking": true,
+		"required": true,
+		"secret":   false,
+		"reply_to": "",
+		"options":  []map[string]any{{"id": "yes", "label": "Ship it"}},
+	}, nil); err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	result, structured, err := handleTeamRuntimeState(context.Background(), nil, TeamRuntimeStateArgs{
+		Channel:      "general",
+		MySlug:       "fe",
+		MessageLimit: 10,
+	})
+	if err != nil {
+		t.Fatalf("handleTeamRuntimeState: %v", err)
+	}
+	text := textFromResult(t, result)
+	for _, want := range []string{
+		"Runtime state for #general",
+		"Pending human requests: 1",
+		"Current focus: Approve release from @ceo.",
+		"working_directory /tmp/wuphf-task-77",
+		"Runtime capabilities:",
+		"nex [info]: Disabled for this session with --no-nex.",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected %q in %q", want, text)
+		}
+	}
+
+	snapshot, ok := structured.(team.RuntimeSnapshot)
+	if !ok {
+		t.Fatalf("expected structured runtime snapshot, got %T", structured)
+	}
+	if snapshot.Channel != "general" {
+		t.Fatalf("expected general channel, got %q", snapshot.Channel)
+	}
+	if len(snapshot.Tasks) != 1 || snapshot.Tasks[0].WorktreePath != "/tmp/wuphf-task-77" {
+		t.Fatalf("unexpected runtime tasks: %+v", snapshot.Tasks)
+	}
+	if len(snapshot.Requests) == 0 || snapshot.Requests[0].Title != "Approve release" {
+		t.Fatalf("unexpected runtime requests: %+v", snapshot.Requests)
+	}
+}
+
+func TestHandleTeamRequestDefaultsApprovalOptions(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	if _, _, err := handleTeamRequest(context.Background(), nil, TeamRequestArgs{
+		Kind:     "approval",
+		Channel:  "general",
+		Question: "Ship this?",
+		MySlug:   "ceo",
+	}); err != nil {
+		t.Fatalf("handleTeamRequest: %v", err)
+	}
+
+	var result brokerRequestsResponse
+	if err := brokerGetJSON(context.Background(), "/requests?channel=general", &result); err != nil {
+		t.Fatalf("fetch requests: %v", err)
+	}
+	if len(result.Requests) != 1 {
+		t.Fatalf("expected one request, got %+v", result.Requests)
+	}
+	req := result.Requests[0]
+	if req.RecommendedID != "approve" {
+		t.Fatalf("expected recommended approval option, got %q", req.RecommendedID)
+	}
+	if len(req.Options) != 5 {
+		t.Fatalf("expected default approval options, got %+v", req.Options)
+	}
+	found := false
+	for _, option := range req.Options {
+		if option.ID == "approve_with_note" {
+			found = option.RequiresText && strings.TrimSpace(option.TextHint) != ""
+		}
+	}
+	if !found {
+		t.Fatalf("expected approve_with_note option with text guidance, got %+v", req.Options)
+	}
+}
+
+func TestHandleTeamPollUsesAgentScopedTranscript(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	for _, msg := range []map[string]any{
+		{"channel": "general", "from": "you", "content": "Frontend, should we ship this?", "tagged": []string{"fe"}},
+		{"channel": "general", "from": "pm", "content": "Unrelated roadmap chatter."},
+		{"channel": "general", "from": "ceo", "content": "Keep scope tight and focus on signup."},
+		{"channel": "general", "from": "fe", "content": "I can take the signup work."},
+	} {
+		if err := brokerPostJSON(context.Background(), "/messages", msg, nil); err != nil {
+			t.Fatalf("post message: %v", err)
+		}
+	}
+
+	result, _, err := handleTeamPoll(context.Background(), nil, TeamPollArgs{
+		Channel: "general",
+		MySlug:  "fe",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamPoll: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "Keep scope tight and focus on signup.") {
+		t.Fatalf("expected CEO context in scoped transcript, got %q", text)
+	}
+	if strings.Contains(text, "Unrelated roadmap chatter.") {
+		t.Fatalf("did not expect unrelated PM chatter in scoped transcript, got %q", text)
+	}
+}
+
+func TestHandleTeamBroadcastDefaultsToLatestTaggedChannelAndThread(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	if err := brokerPostJSON(context.Background(), "/channels", map[string]any{
+		"action":      "create",
+		"slug":        "launch",
+		"name":        "Launch",
+		"description": "Launch work",
+		"members":     []string{"fe", "pm"},
+		"created_by":  "ceo",
+	}, nil); err != nil {
+		t.Fatalf("create channel: %v", err)
+	}
+	if err := brokerPostJSON(context.Background(), "/messages", map[string]any{
+		"channel": "launch",
+		"from":    "ceo",
+		"content": "Frontend, tighten the launch CTA in this thread.",
+		"tagged":  []string{"fe"},
+	}, nil); err != nil {
+		t.Fatalf("post launch message: %v", err)
+	}
+
+	result, _, err := handleTeamBroadcast(context.Background(), nil, TeamBroadcastArgs{
+		MySlug:  "fe",
+		Content: "On it. I will keep this in the launch thread.",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamBroadcast: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "Posted to #launch as @fe") {
+		t.Fatalf("expected launch channel in %q", text)
+	}
+	if !strings.Contains(text, "in reply to msg-1") {
+		t.Fatalf("expected reply target in %q", text)
+	}
+
+	var launch brokerMessagesResponse
+	if err := brokerGetJSON(context.Background(), "/messages?channel=launch&limit=10", &launch); err != nil {
+		t.Fatalf("fetch launch messages: %v", err)
+	}
+	if len(launch.Messages) != 2 {
+		t.Fatalf("expected two launch messages, got %+v", launch.Messages)
+	}
+	got := launch.Messages[len(launch.Messages)-1]
+	if got.From != "fe" || got.ReplyTo != "msg-1" {
+		t.Fatalf("expected FE reply in launch thread, got %+v", got)
+	}
+}
+
+func TestHandleTeamPollDefaultsToLatestTaggedChannel(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	if err := brokerPostJSON(context.Background(), "/channels", map[string]any{
+		"action":      "create",
+		"slug":        "launch",
+		"name":        "Launch",
+		"description": "Launch work",
+		"members":     []string{"fe", "pm"},
+		"created_by":  "ceo",
+	}, nil); err != nil {
+		t.Fatalf("create channel: %v", err)
+	}
+	if err := brokerPostJSON(context.Background(), "/messages", map[string]any{
+		"channel": "launch",
+		"from":    "ceo",
+		"content": "Frontend, review the launch thread.",
+		"tagged":  []string{"fe"},
+	}, nil); err != nil {
+		t.Fatalf("post launch message: %v", err)
+	}
+
+	result, _, err := handleTeamPoll(context.Background(), nil, TeamPollArgs{MySlug: "fe"})
+	if err != nil {
+		t.Fatalf("handleTeamPoll: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "Channel #launch") {
+		t.Fatalf("expected inferred launch channel in %q", text)
+	}
+	if !strings.Contains(text, "Frontend, review the launch thread.") {
+		t.Fatalf("expected launch content in %q", text)
+	}
+}
+
+func TestHandleTeamTaskUsesTaskChannelWhenIDGiven(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	if err := brokerPostJSON(context.Background(), "/channels", map[string]any{
+		"action":      "create",
+		"slug":        "launch",
+		"name":        "Launch",
+		"description": "Launch work",
+		"members":     []string{"fe", "pm"},
+		"created_by":  "ceo",
+	}, nil); err != nil {
+		t.Fatalf("create channel: %v", err)
+	}
+
+	var created struct {
+		Task struct {
+			ID string `json:"id"`
+		} `json:"task"`
+	}
+	if err := brokerPostJSON(context.Background(), "/tasks", map[string]any{
+		"action":     "create",
+		"channel":    "launch",
+		"title":      "Review launch CTA",
+		"owner":      "fe",
+		"created_by": "ceo",
+		"thread_id":  "msg-launch",
+	}, &created); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+
+	result, _, err := handleTeamTask(context.Background(), nil, TeamTaskArgs{
+		Action: "review",
+		ID:     created.Task.ID,
+		MySlug: "fe",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamTask: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "in #launch") {
+		t.Fatalf("expected task action to stay in launch, got %q", text)
+	}
+}
+
+func TestHandleHumanMessageDefaultsToDirectReplyThreadInOneOnOneMode(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_ONE_ON_ONE", "1")
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+	if err := b.SetSessionMode(team.SessionModeOneOnOne, "pm"); err != nil {
+		t.Fatalf("set session mode: %v", err)
+	}
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	if err := brokerPostJSON(context.Background(), "/messages", map[string]any{
+		"channel": "general",
+		"from":    "you",
+		"content": "Can you send me the latest product answer?",
+	}, nil); err != nil {
+		t.Fatalf("post direct human message: %v", err)
+	}
+
+	result, _, err := handleHumanMessage(context.Background(), nil, HumanMessageArgs{
+		MySlug:  "pm",
+		Content: "Yes. Here is the latest product answer.",
+	})
+	if err != nil {
+		t.Fatalf("handleHumanMessage: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "this direct session") {
+		t.Fatalf("expected direct-session label in %q", text)
+	}
+	if !strings.Contains(text, "in reply to msg-1") {
+		t.Fatalf("expected direct reply threading in %q", text)
+	}
+}
+
+func TestHandleTeamInboxAndOutboxExposeOwnedTranscriptSlices(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	if err := brokerPostJSON(context.Background(), "/messages", map[string]any{
+		"channel": "general",
+		"from":    "ceo",
+		"content": "Frontend, take the signup thread.",
+	}, nil); err != nil {
+		t.Fatalf("post ceo message: %v", err)
+	}
+	if err := brokerPostJSON(context.Background(), "/messages", map[string]any{
+		"channel":  "general",
+		"from":     "fe",
+		"content":  "I can own the signup thread.",
+		"reply_to": "msg-1",
+	}, nil); err != nil {
+		t.Fatalf("post own message: %v", err)
+	}
+	if err := brokerPostJSON(context.Background(), "/messages", map[string]any{
+		"channel":  "general",
+		"from":     "pm",
+		"content":  "Please include pricing copy in that thread.",
+		"reply_to": "msg-2",
+	}, nil); err != nil {
+		t.Fatalf("post thread reply: %v", err)
+	}
+	if err := brokerPostJSON(context.Background(), "/messages", map[string]any{
+		"channel": "general",
+		"from":    "fe",
+		"content": "Shipped the initial branch.",
+	}, nil); err != nil {
+		t.Fatalf("post own top-level message: %v", err)
+	}
+	if err := brokerPostJSON(context.Background(), "/messages", map[string]any{
+		"channel": "general",
+		"from":    "pm",
+		"content": "Unrelated roadmap chatter.",
+	}, nil); err != nil {
+		t.Fatalf("post unrelated message: %v", err)
+	}
+
+	inboxResult, _, err := handleTeamInbox(context.Background(), nil, TeamPollArgs{Channel: "general", MySlug: "fe"})
+	if err != nil {
+		t.Fatalf("handleTeamInbox: %v", err)
+	}
+	inboxText := textFromResult(t, inboxResult)
+	if !strings.Contains(inboxText, "Inbox for @fe in #general") {
+		t.Fatalf("expected inbox heading, got %q", inboxText)
+	}
+	if !strings.Contains(inboxText, "Please include pricing copy in that thread.") {
+		t.Fatalf("expected thread reply in inbox, got %q", inboxText)
+	}
+	if strings.Contains(inboxText, "Shipped the initial branch.") || strings.Contains(inboxText, "Unrelated roadmap chatter.") {
+		t.Fatalf("unexpected content in inbox slice: %q", inboxText)
+	}
+
+	outboxResult, _, err := handleTeamOutbox(context.Background(), nil, TeamPollArgs{Channel: "general", MySlug: "fe"})
+	if err != nil {
+		t.Fatalf("handleTeamOutbox: %v", err)
+	}
+	outboxText := textFromResult(t, outboxResult)
+	if !strings.Contains(outboxText, "Outbox for @fe in #general") {
+		t.Fatalf("expected outbox heading, got %q", outboxText)
+	}
+	if !strings.Contains(outboxText, "Shipped the initial branch.") {
+		t.Fatalf("expected authored message in outbox, got %q", outboxText)
+	}
+	if strings.Contains(outboxText, "Frontend, take the signup thread.") || strings.Contains(outboxText, "Please include pricing copy in that thread.") {
+		t.Fatalf("unexpected non-authored content in outbox slice: %q", outboxText)
 	}
 }

--- a/internal/tui/interaction.go
+++ b/internal/tui/interaction.go
@@ -1,0 +1,112 @@
+package tui
+
+import "strings"
+
+// InteractionContext identifies which surface currently owns the operator's
+// attention. The channel model can derive this from its active overlays.
+type InteractionContext string
+
+const (
+	ContextCompose         InteractionContext = "compose"
+	ContextDirectCompose   InteractionContext = "direct_compose"
+	ContextReplyCompose    InteractionContext = "reply_compose"
+	ContextThreadCompose   InteractionContext = "thread_compose"
+	ContextInterview       InteractionContext = "interview"
+	ContextInterviewReview InteractionContext = "interview_review"
+	ContextAutocomplete    InteractionContext = "autocomplete"
+	ContextMention         InteractionContext = "mention"
+	ContextPicker          InteractionContext = "picker"
+	ContextDoctor          InteractionContext = "doctor"
+	ContextContinue        InteractionContext = "continue"
+)
+
+type ComposerHintState struct {
+	Context          InteractionContext
+	HistoryAvailable bool
+}
+
+// ComposerHint returns truthful, mode-aware operator guidance for the active
+// composer context instead of one global static footer string.
+func ComposerHint(state ComposerHintState) string {
+	parts := make([]string, 0, 7)
+	switch state.Context {
+	case ContextAutocomplete:
+		parts = append(parts, "↑/↓ choose", "Tab complete", "Enter run", "Esc close")
+	case ContextMention:
+		parts = append(parts, "↑/↓ choose", "Tab insert", "Enter insert", "Esc close")
+	case ContextPicker:
+		parts = append(parts, "↑/↓ choose", "Enter confirm", "Esc close")
+	case ContextDoctor:
+		parts = append(parts, "Esc close")
+	case ContextInterview:
+		parts = append(parts, "↑/↓ pick option", "Enter continue", "type note or answer")
+	case ContextInterviewReview:
+		parts = append(parts, "Enter submit", "Esc revise")
+	case ContextReplyCompose:
+		parts = append(parts, "/ commands", "@ mention", "Ctrl+J newline", "Enter send reply")
+	case ContextThreadCompose:
+		parts = append(parts, "/ commands", "Ctrl+J newline", "Enter send reply")
+	case ContextDirectCompose:
+		parts = append(parts, "/ commands", "@ mention", "Ctrl+J newline", "Enter send direct")
+	case ContextContinue:
+		parts = append(parts, "Enter continue", "Esc cancel")
+	default:
+		parts = append(parts, "/ commands", "@ mention", "Ctrl+J newline", "Enter send")
+	}
+	if state.HistoryAvailable && allowsHistory(state.Context) {
+		parts = append(parts, "Ctrl+P recall", "Ctrl+N restore")
+	}
+	if dismissesWithEsc(state.Context) {
+		parts = append(parts, "Esc close")
+	} else {
+		parts = append(parts, "Esc pause all")
+	}
+	return strings.Join(parts, " · ")
+}
+
+func allowsHistory(ctx InteractionContext) bool {
+	switch ctx {
+	case ContextCompose, ContextDirectCompose, ContextReplyCompose, ContextThreadCompose, ContextInterview, ContextInterviewReview:
+		return true
+	default:
+		return false
+	}
+}
+
+func dismissesWithEsc(ctx InteractionContext) bool {
+	switch ctx {
+	case ContextAutocomplete, ContextMention, ContextPicker, ContextDoctor, ContextContinue:
+		return true
+	default:
+		return false
+	}
+}
+
+type ContinuePrompt struct {
+	Title       string
+	Description string
+	ContinueKey string
+	CancelKey   string
+}
+
+// InlineHint returns a compact byline that can be reused by confirmation and
+// pending-state cards.
+func (p ContinuePrompt) InlineHint() string {
+	continueKey := strings.TrimSpace(p.ContinueKey)
+	if continueKey == "" {
+		continueKey = "Enter"
+	}
+	cancelKey := strings.TrimSpace(p.CancelKey)
+	if cancelKey == "" {
+		cancelKey = "Esc"
+	}
+	parts := []string{}
+	if strings.TrimSpace(p.Title) != "" {
+		parts = append(parts, p.Title)
+	}
+	if strings.TrimSpace(p.Description) != "" {
+		parts = append(parts, p.Description)
+	}
+	parts = append(parts, continueKey+" continue", cancelKey+" cancel")
+	return strings.Join(parts, " · ")
+}

--- a/internal/tui/interaction_test.go
+++ b/internal/tui/interaction_test.go
@@ -1,0 +1,42 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComposerHintIncludesHistoryWhenAvailable(t *testing.T) {
+	got := ComposerHint(ComposerHintState{
+		Context:          ContextCompose,
+		HistoryAvailable: true,
+	})
+	if !containsAllHint(got, "Ctrl+P recall", "Ctrl+N restore", "Enter send") {
+		t.Fatalf("unexpected compose hint: %q", got)
+	}
+}
+
+func TestComposerHintForAutocomplete(t *testing.T) {
+	got := ComposerHint(ComposerHintState{Context: ContextAutocomplete})
+	if !containsAllHint(got, "Tab complete", "Enter run", "Esc close") {
+		t.Fatalf("unexpected autocomplete hint: %q", got)
+	}
+}
+
+func TestContinuePromptInlineHint(t *testing.T) {
+	got := ContinuePrompt{
+		Title:       "Review answer",
+		Description: "Check the summary before submission",
+	}.InlineHint()
+	if !containsAllHint(got, "Review answer", "Enter continue", "Esc cancel") {
+		t.Fatalf("unexpected continue hint: %q", got)
+	}
+}
+
+func containsAllHint(text string, wants ...string) bool {
+	for _, want := range wants {
+		if !strings.Contains(text, want) {
+			return false
+		}
+	}
+	return true
+}

--- a/tests/uat/autonomy-acceptance.sh
+++ b/tests/uat/autonomy-acceptance.sh
@@ -157,7 +157,7 @@ echo "--- Answer blocking request and inject human-facing note ---"
 curl -s -X POST http://127.0.0.1:7890/requests/answer \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer $BROKER_TOKEN" \
-  -d "{\"id\":\"$REQ_ID\",\"choice_id\":\"act_now\",\"choice_text\":\"Act now\"}" > "$ARTIFACTS/request-answer.json"
+  -d "{\"id\":\"$REQ_ID\",\"choice_id\":\"approve_with_note\",\"custom_text\":\"Proceed, but keep the scope narrow and the plan reviewable.\"}" > "$ARTIFACTS/request-answer.json"
 sleep 2
 curl -s -X POST http://127.0.0.1:7890/messages \
   -H "Content-Type: application/json" \
@@ -210,6 +210,5 @@ assert_contains "bridge_channel" "insights-general"
 
 start_channel_view calendar
 assert_contains "task_created" "calendar-view"
-assert_contains "bridge_channel" "calendar-view"
 
 echo "PASS: autonomy acceptance criteria focused run succeeded"

--- a/tests/uat/human-judgment-uat.sh
+++ b/tests/uat/human-judgment-uat.sh
@@ -2,7 +2,7 @@
 # Human Judgment UAT Test Suite for wuphf TUI
 # Tests USABILITY, not just functionality.
 #
-# Runs against the CURRENT binary (classic StreamModel mode).
+# Runs against the current office channel surface.
 # Asserts readability, information density, layout quality, and junk-free output.
 #
 # New assertion types:
@@ -57,8 +57,41 @@ send_ctrl_c() {
   termwright exec --socket "$SOCKET" --method raw --params '{"bytes_base64": "Aw=="}' >/dev/null 2>&1
 }
 
+send_escape() {
+  termwright exec --socket "$SOCKET" --method key --params '{"key":"Escape"}' >/dev/null 2>&1
+}
+
+clear_input() {
+  send_ctrl_u
+  sleep 0.2
+}
+
+run_command() {
+  local cmd="$1"
+  local delay="${2:-1}"
+  clear_input
+  send_raw "$cmd"
+  sleep 0.3
+  send_enter
+  sleep "$delay"
+}
+
 get_screen() {
   termwright exec --socket "$SOCKET" --method screen --params '{}' 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('result',''))"
+}
+
+capture_screen() {
+  local content=""
+  for _ in 1 2 3 4 5 6 7 8; do
+    content="$(get_screen || true)"
+    if [ -n "$(printf '%s' "$content" | tr -d '[:space:]')" ]; then
+      printf '%s\n' "$content"
+      return 0
+    fi
+    sleep 1
+  done
+  printf '%s\n' "$content"
+  return 0
 }
 
 save_screenshot() {
@@ -73,7 +106,7 @@ if isinstance(r, dict) and 'png_base64' in r:
     with open('$ARTIFACTS/$name.png', 'wb') as f:
         f.write(data)
 " 2>/dev/null || true
-  get_screen > "$ARTIFACTS/$name.txt" 2>/dev/null || true
+  capture_screen > "$ARTIFACTS/$name.txt" 2>/dev/null || true
 }
 
 # ─── Basic Assertions ──────────────────────────────────────────────────
@@ -82,8 +115,8 @@ assert_text() {
   local text="$1"
   local label="${2:-check}"
   local screen
-  screen=$(get_screen)
-  if echo "$screen" | grep -qi "$text"; then
+  screen=$(capture_screen)
+  if echo "$screen" | grep -Eqi "$text"; then
     echo "    PASS: found '$text'"
     return 0
   else
@@ -97,8 +130,8 @@ assert_not_text() {
   local text="$1"
   local label="${2:-check}"
   local screen
-  screen=$(get_screen)
-  if echo "$screen" | grep -qi "$text"; then
+  screen=$(capture_screen)
+  if echo "$screen" | grep -Eqi "$text"; then
     echo "    FAIL: '$text' should NOT be on screen"
     echo "$screen" > "$ARTIFACTS/failure-$label.txt"
     return 1
@@ -111,7 +144,7 @@ assert_not_text() {
 assert_screen_not_blank() {
   local label="${1:-blank}"
   local screen
-  screen=$(get_screen)
+  screen=$(capture_screen)
   local linecount
   linecount=$(echo "$screen" | grep -cv "^$" || true)
   if [ "$linecount" -gt 5 ]; then
@@ -129,7 +162,7 @@ assert_screen_not_blank() {
 # Check readability: no raw JSON, NDJSON, or ANSI escape sequences visible
 assert_readable() {
   local label="$1"
-  local screen=$(get_screen)
+  local screen=$(capture_screen)
   local issues=""
 
   # Check no raw JSON objects visible
@@ -166,7 +199,7 @@ assert_readable() {
 # Check information density: not too much wasted space
 assert_density() {
   local label="$1"
-  local screen=$(get_screen)
+  local screen=$(capture_screen)
   local total=$(echo "$screen" | wc -l)
   local content=$(echo "$screen" | grep -v "^$" | wc -l)
 
@@ -189,7 +222,7 @@ assert_density() {
 # Check no junk: no raw protocol data, no debug output
 assert_no_junk() {
   local label="$1"
-  local screen=$(get_screen)
+  local screen=$(capture_screen)
   local issues=""
 
   # No raw JSON objects on their own line
@@ -228,9 +261,9 @@ assert_layout() {
   local lines=$(echo "$screen" | wc -l)
   local issues=""
 
-  # Last 3 lines should contain input field or status bar
-  local bottom3=$(echo "$screen" | tail -3)
-  if ! echo "$bottom3" | grep -qi "type a message\|INSERT\|NORMAL\|/help\|/quit\|wuphf v"; then
+  # Bottom lines should still show the active composer or footer affordances.
+  local bottom6=$(echo "$screen" | tail -6)
+  if ! echo "$bottom6" | grep -Eqi "Type a message|Talk directly to your agent here|Message #|Ctrl\+J newline|Team offline|/doctor"; then
     issues="$issues no-input-at-bottom"
   fi
 
@@ -307,7 +340,7 @@ assert_human_quality() {
 # ═══════════════════════════════════════════════════════════════════════
 echo "================================================================"
 echo "  NEX Human Judgment UAT Test Suite"
-echo "  Classic StreamModel Mode"
+echo "  Office Channel View"
 echo "  5 Personas / Readability / Density / Layout / Junk-free"
 echo "================================================================"
 echo ""
@@ -321,9 +354,9 @@ cd "$ROOT" && go build -o wuphf ./cmd/wuphf 2>&1
 echo "Build complete."
 echo ""
 
-# Start daemon with standard terminal size (120x40)
+# Start daemon with the reliable office channel surface (120x40)
 echo "Starting termwright daemon (120x40)..."
-termwright daemon --socket "$SOCKET" --cols 120 --rows 40 --background "$BINARY"
+termwright daemon --socket "$SOCKET" --cols 120 --rows 40 --background -- "$BINARY" --channel-view --channel-app messages
 echo "Waiting for TUI boot..."
 sleep 5
 
@@ -338,18 +371,18 @@ echo "  Focus: Is the first impression clean and understandable?"
 
 run_test "M1" "Boot: welcome message is readable (not JSON, not protocol)"
 save_screenshot "maya-01-boot"
-if assert_screen_not_blank "m1" && assert_readable "m1-boot"; then pass; else fail; fi
+if assert_screen_not_blank "m1" && assert_text "The WUPHF Office|Welcome to The WUPHF Office" "m1" && assert_text "Message #general" "m1" && assert_readable "m1-boot"; then pass; else fail; fi
 
-run_test "M2" "/help: commands grouped with clear descriptions"
-send_raw "/help"
+run_test "M2" "Slash autocomplete groups commands with clear descriptions"
+clear_input
+send_raw "/"
 sleep 0.5
-send_enter
-sleep 1
-save_screenshot "maya-02-help"
-if assert_text "help" "m2" && assert_readable "m2-help"; then pass; else fail; fi
+save_screenshot "maya-02-autocomplete"
+if assert_text "/doctor" "m2" && assert_text "SETUP|NAVIGATE|PEOPLE|WORK" "m2" && assert_readable "m2-autocomplete"; then pass; else fail; fi
+clear_input
 
 run_test "M3" "Type message: input appears cleanly in input field"
-send_ctrl_u; sleep 0.2
+clear_input
 send_raw "hello team"
 sleep 0.5
 save_screenshot "maya-03-type"
@@ -370,54 +403,41 @@ echo ""
 echo "--- PERSONA 2: Raj (Power user) ---"
 echo "  Focus: Rapid commands produce clean, junk-free output"
 
-run_test "R1" "/help then /agents then /config show: each output clean"
-# /help
-send_ctrl_u; sleep 0.2
-send_raw "/help"
-sleep 0.3
-send_enter
+run_test "R1" "/doctor then /agents then /switcher: each output stays clean"
+run_command "/doctor"
 sleep 1
-save_screenshot "raj-01a-help"
-if assert_no_junk "r1-help"; then
-  echo "    PASS: /help output junk-free"
+save_screenshot "raj-01a-doctor"
+if assert_text "Doctor" "r1-doctor" && assert_no_junk "r1-doctor"; then
+  echo "    PASS: /doctor output junk-free"
 else
-  echo "    INFO: /help had issues"
+  echo "    INFO: /doctor had issues"
 fi
-# /agents
-send_raw "/agents"
-sleep 0.3
-send_enter
-sleep 1
+run_command "/agents"
 save_screenshot "raj-01b-agents"
 if assert_no_junk "r1-agents"; then
   echo "    PASS: /agents output junk-free"
 else
   echo "    INFO: /agents had issues"
 fi
-# /config show
-send_raw "/config show"
-sleep 0.3
-send_enter
-sleep 1
-save_screenshot "raj-01c-config"
-if assert_no_junk "r1-config"; then pass; else fail; fi
+send_escape
+sleep 0.5
+run_command "/switcher"
+save_screenshot "raj-01c-switcher"
+if assert_text "Workspace Switcher" "r1-switcher" && assert_no_junk "r1-switcher"; then pass; else fail; fi
+send_escape
+sleep 0.5
 
 run_test "R2" "Autocomplete appears quickly after /"
-send_ctrl_u; sleep 0.2
+clear_input
 send_raw "/"
 sleep 0.5
 save_screenshot "raj-02-autocomplete"
-# Autocomplete should show command suggestions
-if assert_text "ask\|object\|record\|help" "r2"; then pass; else fail; fi
-send_ctrl_u; sleep 0.2
+if assert_text "/integrate|/agents|/switch" "r2"; then pass; else fail; fi
+clear_input
 
 run_test "R3" "After 5 commands, content still renders (no stuck state)"
-for cmd in "/help" "/agents" "/help" "/agents" "/help"; do
-  send_ctrl_u; sleep 0.1
-  send_raw "$cmd"
-  sleep 0.2
-  send_enter
-  sleep 0.5
+for cmd in "/messages" "/tasks" "/calendar" "/policies" "/skills"; do
+  run_command "$cmd" 1
 done
 save_screenshot "raj-03-rapid"
 if assert_screen_not_blank "r3" && assert_readable "r3-rapid"; then pass; else fail; fi
@@ -431,77 +451,62 @@ if assert_readable "r4-final"; then pass; else fail; fi
 # ═══════════════════════════════════════════════════════════════════════
 CURRENT_P=3
 echo ""
-echo "--- PERSONA 3: Sarah (SDR) ---"
-echo "  Focus: CRM command output is formatted, not raw JSON"
+echo "--- PERSONA 3: Sarah (Operator) ---"
+echo "  Focus: navigation and planning surfaces stay readable"
 
-run_test "S1" "/record list company: output formatted, not raw JSON"
-send_ctrl_u; sleep 0.2
-send_raw "/record list company"
-sleep 0.3
-send_enter
-sleep 2
-save_screenshot "sarah-01-record-list"
-if assert_readable "s1-record"; then pass; else fail; fi
+run_test "S1" "/channels opens a clean channel picker"
+run_command "/channels"
+save_screenshot "sarah-01-channels"
+if assert_text "Channels" "s1-channels" && assert_readable "s1-channels"; then pass; else fail; fi
+send_escape
+sleep 0.5
 
-run_test "S2" "/task create: feedback message is clear"
-send_ctrl_u; sleep 0.2
-send_raw "/task create test task"
-sleep 0.3
-send_enter
-sleep 2
-save_screenshot "sarah-02-task-create"
-# Should show some response, not raw JSON
-if assert_no_junk "s2-task"; then pass; else fail; fi
+run_test "S2" "/1o1 opens a clear direct-session picker"
+run_command "/1o1"
+save_screenshot "sarah-02-direct-session"
+if assert_text "Direct Session|Enable 1:1 mode" "s2-1o1" && assert_no_junk "s2-1o1"; then pass; else fail; fi
+send_escape
+sleep 0.5
 
-run_test "S3" "/note create: confirmation is readable"
-send_ctrl_u; sleep 0.2
-send_raw "/note create test note"
-sleep 0.3
-send_enter
-sleep 2
-save_screenshot "sarah-03-note-create"
-if assert_no_junk "s3-note"; then pass; else fail; fi
+run_test "S3" "/tasks view remains formatted and readable"
+run_command "/tasks"
+save_screenshot "sarah-03-tasks"
+if assert_readable "s3-tasks" && assert_no_junk "s3-tasks"; then pass; else fail; fi
 
-run_test "S4" "All CRM output junk-free"
-if assert_no_junk "s4-final"; then pass; else fail; fi
+run_test "S4" "/calendar day stays junk-free"
+run_command "/calendar day"
+save_screenshot "sarah-04-calendar-day"
+if assert_readable "s4-calendar" && assert_no_junk "s4-calendar"; then pass; else fail; fi
 
 # ═══════════════════════════════════════════════════════════════════════
-# PERSONA 4: Alex (Developer, building integrations)
-#   "I need dev commands to show clean, structured output"
+# PERSONA 4: Alex (Developer)
+#   "I need readiness and workspace tools to stay clear"
 # ═══════════════════════════════════════════════════════════════════════
 CURRENT_P=4
 echo ""
 echo "--- PERSONA 4: Alex (Developer) ---"
-echo "  Focus: Dev commands show formatted output, not raw data"
+echo "  Focus: runtime and workspace tooling stay formatted"
 
-run_test "A1" "/detect: shows platform names cleanly, not JSON"
-send_ctrl_u; sleep 0.2
-send_raw "/detect"
-sleep 0.3
-send_enter
-sleep 2
-save_screenshot "alex-01-detect"
-if assert_readable "a1-detect"; then pass; else fail; fi
+run_test "A1" "/doctor shows runtime checks cleanly"
+run_command "/doctor"
+save_screenshot "alex-01-doctor"
+if assert_text "Doctor" "a1-doctor" && assert_readable "a1-doctor"; then pass; else fail; fi
 
-run_test "A2" "/config show: key info visible without noise"
-send_ctrl_u; sleep 0.2
-send_raw "/config show"
-sleep 0.3
-send_enter
-sleep 2
-save_screenshot "alex-02-config"
-if assert_no_junk "a2-config" && assert_readable "a2-config"; then pass; else fail; fi
+run_test "A2" "/switcher shows the unified workspace picker"
+run_command "/switcher"
+save_screenshot "alex-02-switcher"
+if assert_text "Workspace Switcher" "a2-switcher" && assert_no_junk "a2-switcher"; then pass; else fail; fi
+send_escape
+sleep 0.5
 
-run_test "A3" "/object list: formatted output (or clean error)"
-send_ctrl_u; sleep 0.2
-send_raw "/object list"
-sleep 0.3
-send_enter
-sleep 2
-save_screenshot "alex-03-object"
-if assert_readable "a3-object"; then pass; else fail; fi
+run_test "A3" "/agents shows named teammate actions"
+run_command "/agents"
+save_screenshot "alex-03-agents"
+if assert_text "Agents in #general" "a3-agents" && assert_text "Disable Frontend Engineer|Disable Product Manager|Disable Backend Engineer" "a3-agents" && assert_readable "a3-agents"; then pass; else fail; fi
+send_escape
+sleep 0.5
 
-run_test "A4" "Layout still correct after dev commands"
+run_test "A4" "Layout still correct after developer/operator commands"
 if assert_layout "a4-layout"; then pass; else fail; fi
 
 # ═══════════════════════════════════════════════════════════════════════
@@ -514,13 +519,12 @@ echo "--- PERSONA 5: Kim (Manager) ---"
 echo "  Focus: Agent list is clean, status indicators correct, good density"
 
 run_test "K1" "/agents: clean list with names and statuses"
-send_ctrl_u; sleep 0.2
-send_raw "/agents"
-sleep 0.3
-send_enter
+run_command "/agents"
 sleep 1
 save_screenshot "kim-01-agents"
-if assert_text "CEO\|Agent\|agent" "k1" && assert_readable "k1-agents"; then pass; else fail; fi
+if assert_text "Agents in #general" "k1" && assert_text "Disable Frontend Engineer|Disable Product Manager|Disable Backend Engineer" "k1" && assert_readable "k1-agents"; then pass; else fail; fi
+send_escape
+sleep 0.5
 
 run_test "K2" "Status indicators use proper symbols"
 screen_k2=$(get_screen)
@@ -536,15 +540,12 @@ else
 fi
 
 run_test "K3" "Agent messages well-formatted (name: content pattern)"
-# Submit a message to trigger agent response display
-send_ctrl_u; sleep 0.2
-send_raw "hello"
-sleep 0.3
-send_enter
-sleep 3
+run_command "/messages"
+clear_input
+send_raw "hello team"
+sleep 0.5
 save_screenshot "kim-03-messages"
-# Screen should still be clean after message flow
-if assert_no_junk "k3-messages" && assert_readable "k3-messages"; then pass; else fail; fi
+if assert_text "hello team" "k3" && assert_no_junk "k3-messages" && assert_readable "k3-messages"; then pass; else fail; fi
 
 run_test "K4" "Screen density: good use of space"
 if assert_density "k4-density"; then pass; else fail; fi

--- a/tests/uat/office-channel-e2e.sh
+++ b/tests/uat/office-channel-e2e.sh
@@ -6,11 +6,23 @@ set -euo pipefail
 SOCKET="/tmp/wuphf-office-$$.sock"
 BINARY="$(cd "$(dirname "$0")/../.." && pwd)/wuphf"
 ARTIFACTS="$(cd "$(dirname "$0")/../.." && pwd)/termwright-artifacts/office-channel-$(date +%Y%m%d-%H%M%S)"
+TEST_HOME="$(mktemp -d /tmp/wuphf-office-home-XXXXXX)"
 mkdir -p "$ARTIFACTS"
+export HOME="$TEST_HOME"
+
+kill_stale_runtime() {
+  "$BINARY" kill >/dev/null 2>&1 || true
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -i :7890 -t 2>/dev/null | xargs -r kill -9 >/dev/null 2>&1 || true
+    sleep 1
+  fi
+}
 
 cleanup() {
+  kill_stale_runtime
   pkill -f "termwright daemon.*$SOCKET" 2>/dev/null || true
   rm -f "$SOCKET"
+  rm -rf "$TEST_HOME"
 }
 trap cleanup EXIT
 
@@ -26,7 +38,8 @@ fi
 
 screen() {
   termwright exec --socket "$SOCKET" --method screen --params '{}' 2>/dev/null | \
-    python3 -c "import sys,json; print(json.load(sys.stdin).get('result',''))"
+    python3 -c "import sys,json; raw=sys.stdin.read().strip(); \
+print('' if not raw else json.loads(raw).get('result',''))" 2>/dev/null || true
 }
 
 send_raw() {
@@ -60,10 +73,12 @@ echo "=== Office Channel E2E ==="
 echo "Binary: $BINARY"
 echo "Artifacts: $ARTIFACTS"
 
-termwright daemon --socket "$SOCKET" --cols 120 --rows 40 --background -- "$BINARY" --channel-view --channel-app messages
+kill_stale_runtime
+
+termwright daemon --socket "$SOCKET" --cols 120 --rows 40 --background -- "$BINARY" --no-nex --channel-view --channel-app messages
 sleep 5
 
-assert_contains "# general" "boot"
+assert_contains "The WUPHF Office" "boot"
 assert_contains "Message #general" "boot"
 
 send_raw "/"

--- a/tests/uat/office-channel-e2e.sh
+++ b/tests/uat/office-channel-e2e.sh
@@ -12,10 +12,13 @@ export HOME="$TEST_HOME"
 
 kill_stale_runtime() {
   "$BINARY" kill >/dev/null 2>&1 || true
+  tmux -L wuphf kill-server >/dev/null 2>&1 || true
+  pkill -x wuphf >/dev/null 2>&1 || true
   if command -v lsof >/dev/null 2>&1; then
     lsof -i :7890 -t 2>/dev/null | xargs -r kill -9 >/dev/null 2>&1 || true
     sleep 1
   fi
+  rm -f /tmp/wuphf-broker-token
 }
 
 cleanup() {

--- a/tests/uat/one-on-one-channel-e2e.sh
+++ b/tests/uat/one-on-one-channel-e2e.sh
@@ -16,10 +16,16 @@ cleanup() {
   pkill -f "termwright daemon.*$SOCKET" 2>/dev/null || true
   rm -f "$SOCKET"
   "$BINARY" kill >/dev/null 2>&1 || true
+  tmux -L wuphf kill-server >/dev/null 2>&1 || true
+  pkill -x wuphf >/dev/null 2>&1 || true
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -i :7890 -t 2>/dev/null | xargs -r kill -9 >/dev/null 2>&1 || true
+  fi
   if [ -n "${WUPHF_PID:-}" ]; then
     kill "$WUPHF_PID" >/dev/null 2>&1 || true
     wait "$WUPHF_PID" 2>/dev/null || true
   fi
+  rm -f /tmp/wuphf-broker-token
   rm -rf "$TEST_HOME"
 }
 trap cleanup EXIT

--- a/tests/uat/one-on-one-channel-e2e.sh
+++ b/tests/uat/one-on-one-channel-e2e.sh
@@ -5,7 +5,9 @@ SOCKET="/tmp/wuphf-1o1-$$.sock"
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 BINARY="$ROOT/wuphf"
 ARTIFACTS="$ROOT/termwright-artifacts/one-on-one-channel-$(date +%Y%m%d-%H%M%S)"
+TEST_HOME="$(mktemp -d /tmp/wuphf-1o1-home-XXXXXX)"
 mkdir -p "$ARTIFACTS"
+export HOME="$TEST_HOME"
 
 WUPHF_PID=""
 PHASE=""
@@ -18,6 +20,7 @@ cleanup() {
     kill "$WUPHF_PID" >/dev/null 2>&1 || true
     wait "$WUPHF_PID" 2>/dev/null || true
   fi
+  rm -rf "$TEST_HOME"
 }
 trap cleanup EXIT
 
@@ -33,7 +36,8 @@ fi
 
 screen() {
   termwright exec --socket "$SOCKET" --method screen --params '{}' 2>/dev/null | \
-    python3 -c "import sys,json; print(json.load(sys.stdin).get('result',''))"
+    python3 -c "import sys,json; raw=sys.stdin.read().strip(); \
+print('' if not raw else json.loads(raw).get('result',''))" 2>/dev/null || true
 }
 
 save_screen() {
@@ -152,7 +156,7 @@ start_runtime() {
   shift
 
   cleanup
-  "$BINARY" "$@" > "$ARTIFACTS/$PHASE-wuphf-stdout.txt" 2> "$ARTIFACTS/$PHASE-wuphf-stderr.txt" &
+  "$BINARY" --no-nex "$@" > "$ARTIFACTS/$PHASE-wuphf-stdout.txt" 2> "$ARTIFACTS/$PHASE-wuphf-stderr.txt" &
   WUPHF_PID=$!
   sleep 8
   local attached=false
@@ -190,6 +194,8 @@ sleep 1
 assert_screen_contains "/1o1" "phase1-autocomplete"
 assert_screen_contains "/reset" "phase1-autocomplete"
 assert_screen_not_contains "/channels" "phase1-autocomplete"
+send_escape
+sleep 1
 send_ctrl_u
 
 send_raw "/channels"
@@ -233,10 +239,13 @@ assert_screen_not_contains "AI should be hidden in PM mode." "phase3-isolation"
 echo "--- Phase 4: Reset preserves direct mode and selected agent ---"
 send_raw "/reset"
 send_enter
+sleep 1
+assert_screen_contains "Reset Direct Session" "phase4-confirm"
+send_enter
 wait_for_health "1o1" "pm" "phase4-health"
 wait_for_pane_count 2 "phase4-panes"
 assert_screen_contains "1:1 with Product Manager" "phase4-screen"
-assert_screen_contains "Direct 1:1 with Product Manager." "phase4-screen"
+assert_screen_contains "Direct session reset. Agent pane reloaded in place." "phase4-screen"
 
 echo "--- Phase 5: Disable 1:1 mode from the picker ---"
 send_raw "/1o1"
@@ -245,6 +254,9 @@ sleep 1
 assert_screen_contains "Enable 1:1 mode" "phase5-picker"
 assert_screen_contains "Disable 1:1 mode" "phase5-picker"
 send_raw "2"
+sleep 1
+assert_screen_contains "Return To Main Office" "phase5-confirm"
+send_enter
 wait_for_health "office" "ceo" "phase5-health"
 wait_for_pane_count 6 "phase5-panes"
 assert_screen_contains "The WUPHF Office" "phase5-screen"


### PR DESCRIPTION
## What changed
This pulls the recent CC-agent-inspired product-feel work into one branch.

It adds:
- recovery and away-summary surfaces in the office UI
- artifact, insert, search, and rewind navigation surfaces
- a persistent needs-you strip for blocking human decisions
- a richer switcher and actionable recovery cards for tasks, requests, and recent threads
- state-driven workspace chrome in the header, sidebar, and empty states
- actionable recovery drafting plus louder blocked/idle wait-state treatment

## Why
The existing WUPHF runtime had more capability than product feel. A lot of the missing value from the CC-agent analysis was in re-entry, navigation, blockedness, and operator guidance, not just backend plumbing.

This branch closes that gap by making the office more stateful and navigable:
- easier to understand what matters now
- easier to jump to the right lane
- easier to recover context after time away
- easier to draft recap and handoff prompts from live recovery state

## Impact
Users should see a more directed office experience:
- the sidebar/header reflect live workspace state instead of static shell copy
- recovery is an active workflow, not just a summary screen
- blocked work and quiet periods are surfaced explicitly
- newer surfaces like Recovery, Requests, and Artifacts are visible in the chrome

## Validation
- `go test ./...`
- `bash tests/uat/office-channel-e2e.sh`
- `bash tests/uat/one-on-one-channel-e2e.sh`
- `bash tests/uat/autonomy-acceptance.sh`

## Notes
- local `.worktrees/` scratch data was intentionally left out of the PR
