### PR TITLE
fix: protect agentLastNotified map with mutex (data race)

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/action"
@@ -399,6 +400,7 @@ func (l *Launcher) notifyTaskActionsLoop() {
 	}
 }
 
+var agentLastNotifiedMu sync.Mutex
 var agentLastNotified = make(map[string]time.Time)
 
 const (
@@ -418,6 +420,7 @@ func (l *Launcher) deliverMessageNotification(msg channelMessage) {
 	}
 	now := time.Now()
 	filtered := make([]notificationTarget, 0, len(immediate))
+	agentLastNotifiedMu.Lock()
 	for _, t := range immediate {
 		if last, ok := agentLastNotified[t.Slug]; ok && now.Sub(last) < cooldown {
 			continue
@@ -425,6 +428,7 @@ func (l *Launcher) deliverMessageNotification(msg channelMessage) {
 		agentLastNotified[t.Slug] = now
 		filtered = append(filtered, t)
 	}
+	agentLastNotifiedMu.Unlock()
 	immediate = filtered
 
 	// Broadcast stage update only for untagged messages in team mode


### PR DESCRIPTION
## Summary
`agentLastNotified` is a plain `map[string]time.Time` at package scope, written from multiple goroutines with no synchronization. This is a data race.

Fix: add `sync.Mutex` around the read/write block in `deliverMessageNotification`.

## Test plan
- [ ] Run with `-race` flag — should no longer panic
- [ ] Notification cooldown still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)