### PR TITLE
[codex] Finish CC-agent end-state upgrades

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -445,6 +445,8 @@ var channelSlashCommands = []tui.SlashCommand{
 	{Name: "connect", Description: "Connect an external channel (Telegram, Slack, Discord)", Category: "setup"},
 	{Name: "1o1", Description: "Enable, switch, or disable direct 1:1 mode", Category: "session"},
 	{Name: "messages", Description: "Show the main office feed", Category: "navigate"},
+	{Name: "inbox", Description: "Show the selected agent inbox lane in 1:1 mode", Category: "navigate"},
+	{Name: "outbox", Description: "Show the selected agent outbox lane in 1:1 mode", Category: "navigate"},
 	{Name: "recover", Description: "Open the session recovery summary", Category: "navigate"},
 	{Name: "resume", Description: "Alias for /recover", Category: "navigate"},
 	{Name: "rewind", Description: "Insert a summarize-from-here recovery prompt", Category: "navigate"},
@@ -533,6 +535,8 @@ type officeApp string
 
 const (
 	officeAppMessages  officeApp = "messages"
+	officeAppInbox     officeApp = "inbox"
+	officeAppOutbox    officeApp = "outbox"
 	officeAppRecovery  officeApp = "recovery"
 	officeAppTasks     officeApp = "tasks"
 	officeAppRequests  officeApp = "requests"
@@ -2419,7 +2423,7 @@ func (m channelModel) View() string {
 }
 
 func (m channelModel) currentHeaderTitle() string {
-	if m.isOneOnOne() && m.activeApp != officeAppRecovery {
+	if m.isOneOnOne() && m.activeApp != officeAppRecovery && m.activeApp != officeAppInbox && m.activeApp != officeAppOutbox {
 		return "1:1 with " + m.oneOnOneAgentName()
 	}
 	switch m.activeApp {
@@ -2428,6 +2432,16 @@ func (m channelModel) currentHeaderTitle() string {
 			return "1:1 with " + m.oneOnOneAgentName() + " · Recovery"
 		}
 		return "# " + m.activeChannel + " · Recovery"
+	case officeAppInbox:
+		if m.isOneOnOne() {
+			return "1:1 with " + m.oneOnOneAgentName() + " · Inbox"
+		}
+		return "# " + m.activeChannel + " · Inbox"
+	case officeAppOutbox:
+		if m.isOneOnOne() {
+			return "1:1 with " + m.oneOnOneAgentName() + " · Outbox"
+		}
+		return "# " + m.activeChannel + " · Outbox"
 	case officeAppArtifacts:
 		return "# " + m.activeChannel + " · Artifacts"
 	case officeAppTasks:
@@ -2448,26 +2462,47 @@ func (m channelModel) currentHeaderTitle() string {
 func (m channelModel) currentHeaderMeta() string {
 	workspace := m.currentWorkspaceUIState()
 	if m.activeApp == officeAppRecovery {
-		snapshot := m.currentRuntimeSnapshot()
-		blocking := 0
-		for _, req := range snapshot.Requests {
-			status := strings.TrimSpace(strings.ToLower(req.Status))
-			if status != "" && status != "pending" && status != "open" {
-				continue
-			}
-			if req.Blocking || req.Required {
-				blocking++
-			}
-		}
+		snapshot := workspace.Runtime
 		if m.isOneOnOne() {
-			return fmt.Sprintf("  Re-entry summary for %s · %d running tasks · %d open requests · %d new since you looked", m.oneOnOneAgentName(), countRunningRuntimeTasks(snapshot.Tasks), len(snapshot.Requests), m.unreadCount)
+			return fmt.Sprintf("  Re-entry summary for %s · %d running tasks · %d open requests · %d new since you looked", m.oneOnOneAgentName(), workspace.RunningTasks, workspace.OpenRequests, workspace.UnreadCount)
 		}
-		return fmt.Sprintf("  Re-entry summary for #%s · %d blocking requests · %d running tasks · %d new since you looked", m.activeChannel, blocking, countRunningRuntimeTasks(snapshot.Tasks), m.unreadCount)
+		parts := []string{
+			fmt.Sprintf("Re-entry summary for #%s", fallbackString(snapshot.Channel, m.activeChannel)),
+			fmt.Sprintf("%d blocking requests", workspace.BlockingCount),
+			fmt.Sprintf("%d running tasks", workspace.RunningTasks),
+			fmt.Sprintf("%d new since you looked", workspace.UnreadCount),
+		}
+		if workspace.Readiness.Level != workspaceReadinessReady && strings.TrimSpace(workspace.Readiness.Headline) != "" {
+			parts = append(parts, strings.ToLower(workspace.Readiness.Headline))
+		}
+		return "  " + strings.Join(parts, " · ")
+	}
+	if m.isOneOnOne() && (m.activeApp == officeAppInbox || m.activeApp == officeAppOutbox) {
+		scopeLabel := "inbox"
+		if m.activeApp == officeAppOutbox {
+			scopeLabel = "outbox"
+		}
+		scopeCount := len(filterMessagesForViewerScope(m.messages, m.oneOnOneAgentSlug(), scopeLabel))
+		parts := []string{
+			fmt.Sprintf("%s lane for %s", strings.Title(scopeLabel), m.oneOnOneAgentName()),
+			fmt.Sprintf("%d visible messages", scopeCount),
+		}
+		if workspace.RunningTasks > 0 {
+			parts = append(parts, fmt.Sprintf("%d running tasks", workspace.RunningTasks))
+		}
+		if strings.TrimSpace(workspace.Focus) != "" {
+			parts = append(parts, "focus: "+workspace.Focus)
+		}
+		return "  " + strings.Join(parts, " · ")
 	}
 	if m.isOneOnOne() {
 		return workspace.headerMeta()
 	}
 	switch m.activeApp {
+	case officeAppInbox:
+		return fmt.Sprintf("  Inbox lane · %d visible messages · %d open requests", len(m.messages), len(m.requests))
+	case officeAppOutbox:
+		return fmt.Sprintf("  Outbox lane · %d visible messages · %d recent actions", len(m.messages), len(m.actions))
 	case officeAppTasks:
 		open, inProgress, review, blocked, overdue := 0, 0, 0, 0, 0
 		for _, task := range m.tasks {
@@ -2565,12 +2600,16 @@ func (m channelModel) currentHeaderMeta() string {
 }
 
 func (m channelModel) currentAppLabel() string {
-	if m.isOneOnOne() && m.activeApp != officeAppRecovery {
+	if m.isOneOnOne() && m.activeApp != officeAppRecovery && m.activeApp != officeAppInbox && m.activeApp != officeAppOutbox {
 		return "messages"
 	}
 	switch m.activeApp {
 	case officeAppRecovery:
 		return "recovery"
+	case officeAppInbox:
+		return "inbox"
+	case officeAppOutbox:
+		return "outbox"
 	case officeAppTasks:
 		return "tasks"
 	case officeAppRequests:
@@ -2738,6 +2777,13 @@ func (m channelModel) mainPanelMouseAction(x, y, mainW, contentH int) (mouseActi
 			case officeAppMessages:
 				if visibleRows[row].ThreadID != "" {
 					return mouseAction{Kind: "thread", Value: visibleRows[row].ThreadID}, true
+				}
+			case officeAppInbox, officeAppOutbox:
+				if visibleRows[row].ThreadID != "" {
+					return mouseAction{Kind: "thread", Value: visibleRows[row].ThreadID}, true
+				}
+				if visibleRows[row].RequestID != "" {
+					return mouseAction{Kind: "request", Value: visibleRows[row].RequestID}, true
 				}
 			case officeAppTasks:
 				if visibleRows[row].TaskID != "" {
@@ -3282,6 +3328,12 @@ func (m *channelModel) selectSidebarItem(item sidebarItem) tea.Cmd {
 		switch m.activeApp {
 		case officeAppMessages:
 			m.notice = "Viewing #" + m.activeChannel + "."
+			return pollBroker("", m.activeChannel)
+		case officeAppInbox:
+			m.notice = "Viewing the selected agent inbox."
+			return pollBroker("", m.activeChannel)
+		case officeAppOutbox:
+			m.notice = "Viewing the selected agent outbox."
 			return pollBroker("", m.activeChannel)
 		case officeAppRecovery:
 			m.notice = "Viewing the recovery summary."
@@ -4393,6 +4445,26 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		} else {
 			m.notice = "Viewing #general."
 		}
+		return m, nil
+	case trimmed == "/inbox":
+		clearCurrent()
+		if !m.isOneOnOne() {
+			m.notice = "/inbox only applies in direct 1:1 mode."
+			return m, nil
+		}
+		m.activeApp = officeAppInbox
+		m.syncSidebarCursorToActive()
+		m.notice = "Viewing the selected agent inbox."
+		return m, nil
+	case trimmed == "/outbox":
+		clearCurrent()
+		if !m.isOneOnOne() {
+			m.notice = "/outbox only applies in direct 1:1 mode."
+			return m, nil
+		}
+		m.activeApp = officeAppOutbox
+		m.syncSidebarCursorToActive()
+		m.notice = "Viewing the selected agent outbox."
 		return m, nil
 	case trimmed == "/recover" || trimmed == "/resume":
 		clearCurrent()
@@ -6304,7 +6376,7 @@ func resolveInitialOfficeApp(name string) officeApp {
 		return officeAppPolicies
 	}
 	switch officeApp(normalized) {
-	case officeAppMessages, officeAppRecovery, officeAppTasks, officeAppRequests, officeAppPolicies, officeAppCalendar, officeAppArtifacts:
+	case officeAppMessages, officeAppInbox, officeAppOutbox, officeAppRecovery, officeAppTasks, officeAppRequests, officeAppPolicies, officeAppCalendar, officeAppArtifacts:
 		return officeApp(normalized)
 	default:
 		return officeAppMessages

--- a/cmd/wuphf/channel_artifact_snapshot.go
+++ b/cmd/wuphf/channel_artifact_snapshot.go
@@ -1,0 +1,456 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+type runtimeArtifactSnapshot struct {
+	Items []team.RuntimeArtifact
+}
+
+func (m channelModel) currentArtifactSnapshot(limit int) runtimeArtifactSnapshot {
+	taskLogs := m.recentTaskLogArtifacts(maxInt(limit, 12))
+	taskLogsByID := make(map[string]taskLogArtifact, len(taskLogs))
+	for _, artifact := range taskLogs {
+		if id := strings.TrimSpace(artifact.TaskID); id != "" {
+			taskLogsByID[id] = artifact
+		}
+	}
+
+	artifacts := make([]team.RuntimeArtifact, 0, len(m.tasks)+len(taskLogs)+len(m.requests)+len(m.actions)+8)
+	for _, task := range recentArtifactTasks(m.tasks, maxInt(limit, 12)) {
+		logArtifact, ok := taskLogsByID[strings.TrimSpace(task.ID)]
+		if ok {
+			delete(taskLogsByID, strings.TrimSpace(task.ID))
+		}
+		artifacts = append(artifacts, buildTaskRuntimeArtifact(task, logArtifact, ok))
+	}
+	for _, orphan := range taskLogs {
+		if _, ok := taskLogsByID[strings.TrimSpace(orphan.TaskID)]; !ok {
+			continue
+		}
+		artifacts = append(artifacts, buildOrphanTaskLogRuntimeArtifact(orphan))
+	}
+	for _, run := range recentWorkflowRunArtifacts(maxInt(limit, 8)) {
+		artifacts = append(artifacts, buildWorkflowRuntimeArtifact(run))
+	}
+	for _, req := range recentHumanArtifactRequests(m.requests, maxInt(limit, 8)) {
+		artifacts = append(artifacts, buildRequestRuntimeArtifact(req))
+	}
+	for _, action := range recentExecutionArtifactActions(m.actions, maxInt(limit, 8)) {
+		artifacts = append(artifacts, buildActionRuntimeArtifact(action))
+	}
+
+	sort.SliceStable(artifacts, func(i, j int) bool {
+		left := parseArtifactTimestamp(artifacts[i].UpdatedAt, artifacts[i].StartedAt)
+		right := parseArtifactTimestamp(artifacts[j].UpdatedAt, artifacts[j].StartedAt)
+		switch {
+		case !left.IsZero() && !right.IsZero():
+			return left.After(right)
+		case !left.IsZero():
+			return true
+		case !right.IsZero():
+			return false
+		default:
+			return artifacts[i].ID > artifacts[j].ID
+		}
+	})
+	if limit > 0 && len(artifacts) > limit {
+		artifacts = artifacts[:limit]
+	}
+	return runtimeArtifactSnapshot{Items: artifacts}
+}
+
+func (s runtimeArtifactSnapshot) Count(kinds ...team.RuntimeArtifactKind) int {
+	return len(s.Filter(kinds...))
+}
+
+func (s runtimeArtifactSnapshot) Filter(kinds ...team.RuntimeArtifactKind) []team.RuntimeArtifact {
+	if len(kinds) == 0 {
+		return append([]team.RuntimeArtifact(nil), s.Items...)
+	}
+	set := make(map[team.RuntimeArtifactKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		set[kind] = struct{}{}
+	}
+	out := make([]team.RuntimeArtifact, 0, len(s.Items))
+	for _, artifact := range s.Items {
+		if _, ok := set[artifact.Kind]; ok {
+			out = append(out, artifact)
+		}
+	}
+	return out
+}
+
+func recentArtifactTasks(tasks []channelTask, limit int) []channelTask {
+	filtered := make([]channelTask, 0, len(tasks))
+	for _, task := range tasks {
+		if strings.TrimSpace(task.ID) == "" && strings.TrimSpace(task.Title) == "" {
+			continue
+		}
+		filtered = append(filtered, task)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		left := parseArtifactTimestamp(filtered[i].UpdatedAt, filtered[i].CreatedAt)
+		right := parseArtifactTimestamp(filtered[j].UpdatedAt, filtered[j].CreatedAt)
+		switch {
+		case !left.IsZero() && !right.IsZero():
+			return left.After(right)
+		case !left.IsZero():
+			return true
+		case !right.IsZero():
+			return false
+		default:
+			return filtered[i].ID > filtered[j].ID
+		}
+	})
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered
+}
+
+func buildTaskRuntimeArtifact(task channelTask, logArtifact taskLogArtifact, hasLog bool) team.RuntimeArtifact {
+	state := normalizeTaskArtifactState(task.Status, task.ReviewState)
+	reviewHint := buildTaskArtifactReviewHint(task, logArtifact, hasLog)
+	updatedAt := latestArtifactTimestamp(task.UpdatedAt, task.CreatedAt, logArtifact.CompletedAt, logArtifact.StartedAt, logArtifact.UpdatedAt.Format(time.RFC3339))
+	path := ""
+	partialOutput := ""
+	if hasLog {
+		path = strings.TrimSpace(logArtifact.LogPath)
+		partialOutput = strings.TrimSpace(logArtifact.Summary)
+	}
+	return team.RuntimeArtifact{
+		ID:            strings.TrimSpace(task.ID),
+		Kind:          team.RuntimeArtifactTask,
+		Title:         fallbackString(strings.TrimSpace(task.Title), "Task "+fallbackString(task.ID, "artifact")),
+		Summary:       buildTaskArtifactSummary(task, state),
+		State:         state,
+		Progress:      buildTaskArtifactProgress(task),
+		Owner:         strings.TrimSpace(task.Owner),
+		Channel:       strings.TrimSpace(task.Channel),
+		RelatedID:     strings.TrimSpace(task.ThreadID),
+		StartedAt:     strings.TrimSpace(task.CreatedAt),
+		UpdatedAt:     updatedAt,
+		Path:          path,
+		Worktree:      strings.TrimSpace(task.WorktreePath),
+		PartialOutput: partialOutput,
+		ResumeHint:    buildTaskArtifactResumeHint(task, state),
+		ReviewHint:    reviewHint,
+		Blocking:      state == "blocked",
+	}
+}
+
+func buildOrphanTaskLogRuntimeArtifact(artifact taskLogArtifact) team.RuntimeArtifact {
+	state := "completed"
+	if strings.TrimSpace(artifact.CompletedAt) == "" {
+		state = "running"
+	}
+	reviewHint := ""
+	if artifact.EntryCount > 0 {
+		reviewHint = fmt.Sprintf("Retained %d log entr%s.", artifact.EntryCount, pluralSuffix(artifact.EntryCount))
+	}
+	return team.RuntimeArtifact{
+		ID:            strings.TrimSpace(artifact.TaskID),
+		Kind:          team.RuntimeArtifactTaskLog,
+		Title:         fmt.Sprintf("Task %s log", fallbackString(artifact.TaskID, "artifact")),
+		Summary:       "Retained task output from a task that is no longer in the active runtime list.",
+		State:         state,
+		Owner:         strings.TrimSpace(artifact.AgentSlug),
+		StartedAt:     strings.TrimSpace(artifact.StartedAt),
+		UpdatedAt:     latestArtifactTimestamp(artifact.CompletedAt, artifact.StartedAt, artifact.UpdatedAt.Format(time.RFC3339)),
+		Path:          strings.TrimSpace(artifact.LogPath),
+		Worktree:      strings.TrimSpace(artifact.WorktreePath),
+		PartialOutput: strings.TrimSpace(artifact.Summary),
+		ResumeHint:    "Inspect the retained log on disk or reopen the task from the office history.",
+		ReviewHint:    reviewHint,
+	}
+}
+
+func buildWorkflowRuntimeArtifact(run workflowRunArtifact) team.RuntimeArtifact {
+	state := normalizeWorkflowArtifactState(run.Status)
+	reviewHint := ""
+	if status := strings.TrimSpace(run.Status); status != "" && !strings.EqualFold(status, state) {
+		reviewHint = "Provider status: " + status
+	}
+	resumeHint := "Review the retained run log or rerun the workflow from the provider."
+	if state == "running" {
+		resumeHint = "Review the retained run log or wait for the provider to finish."
+	}
+	return team.RuntimeArtifact{
+		ID:         fallbackString(strings.TrimSpace(run.RunID), strings.TrimSpace(run.WorkflowKey)),
+		Kind:       team.RuntimeArtifactWorkflowRun,
+		Title:      fallbackString(strings.TrimSpace(run.WorkflowKey), "workflow"),
+		Summary:    fmt.Sprintf("%s via %s", fallbackString(strings.TrimSpace(run.RunID), "run"), fallbackString(strings.TrimSpace(run.Provider), "provider")),
+		State:      state,
+		Progress:   workflowArtifactProgress(run),
+		StartedAt:  strings.TrimSpace(run.StartedAt),
+		UpdatedAt:  latestArtifactTimestamp(run.FinishedAt, run.StartedAt, run.UpdatedAt.Format(time.RFC3339)),
+		Path:       strings.TrimSpace(run.Path),
+		ResumeHint: resumeHint,
+		ReviewHint: reviewHint,
+	}
+}
+
+func buildRequestRuntimeArtifact(req channelInterview) team.RuntimeArtifact {
+	state := normalizeRequestArtifactState(req.Status)
+	return team.RuntimeArtifact{
+		ID:         strings.TrimSpace(req.ID),
+		Kind:       team.RuntimeArtifactRequest,
+		Title:      req.TitleOrQuestion(),
+		Summary:    fallbackString(strings.TrimSpace(req.Context), strings.TrimSpace(req.Question)),
+		State:      state,
+		Progress:   requestArtifactProgress(req),
+		Owner:      strings.TrimSpace(req.From),
+		Channel:    strings.TrimSpace(req.Channel),
+		RelatedID:  strings.TrimSpace(req.ReplyTo),
+		StartedAt:  strings.TrimSpace(req.CreatedAt),
+		UpdatedAt:  latestArtifactTimestamp(req.FollowUpAt, req.ReminderAt, req.RecheckAt, req.DueAt, req.CreatedAt),
+		ResumeHint: "Answer the request or reopen it from Recovery.",
+		ReviewHint: requestArtifactReviewHint(req),
+		Blocking:   req.Blocking || req.Required,
+	}
+}
+
+func buildActionRuntimeArtifact(action channelAction) team.RuntimeArtifact {
+	kind := team.RuntimeArtifactHumanAction
+	if strings.HasPrefix(strings.TrimSpace(action.Kind), "external_") {
+		kind = team.RuntimeArtifactExternalAction
+	}
+	title := strings.TrimSpace(action.Summary)
+	if title == "" {
+		title = strings.ReplaceAll(strings.TrimSpace(action.Kind), "_", " ")
+	}
+	return team.RuntimeArtifact{
+		ID:         strings.TrimSpace(action.ID),
+		Kind:       kind,
+		Title:      title,
+		Summary:    actionArtifactSummary(action),
+		State:      normalizeActionArtifactState(action.Kind),
+		Progress:   actionArtifactProgress(action),
+		Owner:      strings.TrimSpace(action.Actor),
+		Channel:    strings.TrimSpace(action.Channel),
+		RelatedID:  fallbackString(strings.TrimSpace(action.RelatedID), strings.TrimSpace(action.DecisionID)),
+		StartedAt:  strings.TrimSpace(action.CreatedAt),
+		UpdatedAt:  strings.TrimSpace(action.CreatedAt),
+		ResumeHint: actionArtifactResumeHint(action),
+		ReviewHint: strings.TrimSpace(action.Source),
+	}
+}
+
+func buildTaskArtifactSummary(task channelTask, state string) string {
+	if details := strings.TrimSpace(task.Details); details != "" {
+		return details
+	}
+	switch state {
+	case "blocked":
+		return "This task is blocked and needs a human decision, dependency update, or follow-up."
+	case "review":
+		return "This task is waiting for review, approval, or a final handoff."
+	case "completed":
+		return "This task finished and keeps its latest output and resume context here."
+	default:
+		return "This task is retained as a live execution artifact with its current runtime context."
+	}
+}
+
+func buildTaskArtifactProgress(task channelTask) string {
+	parts := make([]string, 0, 4)
+	if stage := strings.TrimSpace(task.PipelineStage); stage != "" {
+		parts = append(parts, "Stage: "+strings.ReplaceAll(stage, "_", " "))
+	}
+	if review := strings.TrimSpace(task.ReviewState); review != "" {
+		parts = append(parts, "Review: "+strings.ReplaceAll(review, "_", " "))
+	}
+	if mode := strings.TrimSpace(task.ExecutionMode); mode != "" {
+		parts = append(parts, "Execution: "+strings.ReplaceAll(mode, "_", " "))
+	}
+	if due := strings.TrimSpace(task.DueAt); due != "" {
+		parts = append(parts, "Due "+prettyRelativeTime(due))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func buildTaskArtifactReviewHint(task channelTask, logArtifact taskLogArtifact, hasLog bool) string {
+	parts := make([]string, 0, 3)
+	if review := strings.TrimSpace(task.ReviewState); review != "" {
+		parts = append(parts, "Review "+strings.ReplaceAll(review, "_", " "))
+	}
+	if strings.EqualFold(strings.TrimSpace(task.Status), "review") {
+		parts = append(parts, "Review is the current pipeline state.")
+	}
+	if hasLog && logArtifact.EntryCount > 0 {
+		parts = append(parts, fmt.Sprintf("Retained %d log entr%s.", logArtifact.EntryCount, pluralSuffix(logArtifact.EntryCount)))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func buildTaskArtifactResumeHint(task channelTask, state string) string {
+	if worktree := strings.TrimSpace(task.WorktreePath); worktree != "" {
+		switch state {
+		case "completed":
+			return "Review the retained output or reopen the task thread before reusing the worktree."
+		case "blocked":
+			return "Resolve the blocker, then continue in " + worktree + " or reopen the task thread."
+		default:
+			return "Resume in " + worktree + " or reopen the task thread."
+		}
+	}
+	if thread := strings.TrimSpace(task.ThreadID); thread != "" {
+		return "Resume from thread " + thread + " or reopen the task in Tasks."
+	}
+	return "Reopen the task in Tasks to continue or review it."
+}
+
+func normalizeTaskArtifactState(status, reviewState string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "done", "completed":
+		return "completed"
+	case "blocked":
+		return "blocked"
+	case "review":
+		return "review"
+	case "open", "queued", "pending":
+		return "started"
+	case "", "running", "in_progress":
+		if strings.EqualFold(strings.TrimSpace(reviewState), "ready_for_review") || strings.EqualFold(strings.TrimSpace(reviewState), "pending_review") {
+			return "review"
+		}
+		return "running"
+	default:
+		return strings.TrimSpace(strings.ToLower(status))
+	}
+}
+
+func workflowArtifactProgress(run workflowRunArtifact) string {
+	parts := []string{}
+	if provider := strings.TrimSpace(run.Provider); provider != "" {
+		parts = append(parts, "Provider: "+provider)
+	}
+	if rawStatus := strings.TrimSpace(run.Status); rawStatus != "" {
+		parts = append(parts, "Raw status: "+rawStatus)
+	}
+	return strings.Join(parts, " · ")
+}
+
+func normalizeWorkflowArtifactState(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "success", "succeeded", "done", "completed", "finished":
+		return "completed"
+	case "failed", "error":
+		return "failed"
+	case "queued", "pending", "running", "in_progress", "started":
+		return "running"
+	case "":
+		return "completed"
+	default:
+		return strings.TrimSpace(strings.ToLower(status))
+	}
+}
+
+func requestArtifactProgress(req channelInterview) string {
+	parts := make([]string, 0, 3)
+	if choice := strings.TrimSpace(req.RecommendedID); choice != "" {
+		parts = append(parts, "Recommended: "+choice)
+	}
+	if due := strings.TrimSpace(req.DueAt); due != "" {
+		parts = append(parts, "Due "+prettyRelativeTime(due))
+	}
+	if followUp := strings.TrimSpace(req.FollowUpAt); followUp != "" {
+		parts = append(parts, "Follow-up "+prettyRelativeTime(followUp))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func requestArtifactReviewHint(req channelInterview) string {
+	if recommended := strings.TrimSpace(req.RecommendedID); recommended != "" {
+		return "Review recommendation " + recommended + " before answering."
+	}
+	if due := strings.TrimSpace(req.DueAt); due != "" {
+		return "Due " + prettyRelativeTime(due)
+	}
+	return ""
+}
+
+func normalizeRequestArtifactState(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "", "pending", "open":
+		return "pending"
+	case "answered", "complete", "completed":
+		return "completed"
+	case "canceled", "cancelled":
+		return "canceled"
+	default:
+		return strings.TrimSpace(strings.ToLower(status))
+	}
+}
+
+func actionArtifactSummary(action channelAction) string {
+	parts := make([]string, 0, 4)
+	if channel := strings.TrimSpace(action.Channel); channel != "" {
+		parts = append(parts, "#"+channel)
+	}
+	if actor := strings.TrimSpace(action.Actor); actor != "" {
+		parts = append(parts, "@"+actor)
+	}
+	if when := strings.TrimSpace(prettyRelativeTime(action.CreatedAt)); when != "" {
+		parts = append(parts, when)
+	}
+	if len(parts) == 0 {
+		return "Retained action trace."
+	}
+	return strings.Join(parts, " · ")
+}
+
+func actionArtifactProgress(action channelAction) string {
+	if source := strings.TrimSpace(action.Source); source != "" {
+		return "Source: " + source
+	}
+	return ""
+}
+
+func actionArtifactResumeHint(action channelAction) string {
+	if related := strings.TrimSpace(action.RelatedID); related != "" {
+		return "Review the related artifact or thread " + related + "."
+	}
+	if decision := strings.TrimSpace(action.DecisionID); decision != "" {
+		return "Review decision " + decision + " or reopen the related thread."
+	}
+	return "Review the related thread or action provider details."
+}
+
+func normalizeActionArtifactState(kind string) string {
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	switch {
+	case strings.Contains(kind, "failed"), strings.Contains(kind, "error"):
+		return "failed"
+	case strings.Contains(kind, "canceled"), strings.Contains(kind, "cancelled"):
+		return "canceled"
+	case strings.Contains(kind, "blocked"), strings.Contains(kind, "waiting"), strings.Contains(kind, "follow_up"):
+		return "blocked"
+	case strings.Contains(kind, "planned"), strings.Contains(kind, "created"), strings.Contains(kind, "received"), strings.Contains(kind, "started"):
+		return "running"
+	case strings.Contains(kind, "answered"), strings.Contains(kind, "executed"), strings.Contains(kind, "completed"), strings.Contains(kind, "sent"):
+		return "completed"
+	default:
+		return fallbackString(kind, "running")
+	}
+}
+
+func latestArtifactTimestamp(candidates ...string) string {
+	var latest time.Time
+	for _, candidate := range candidates {
+		if ts, ok := parseChannelTime(candidate); ok && ts.After(latest) {
+			latest = ts
+		}
+	}
+	if latest.IsZero() {
+		return ""
+	}
+	return latest.Format(time.RFC3339)
+}

--- a/cmd/wuphf/channel_artifacts.go
+++ b/cmd/wuphf/channel_artifacts.go
@@ -15,6 +15,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/team"
 )
 
 type taskLogRecord struct {
@@ -55,12 +56,10 @@ type workflowRunArtifact struct {
 
 func (m channelModel) buildArtifactLines(contentWidth int) []renderedLine {
 	lines := []renderedLine{{Text: renderDateSeparator(contentWidth, "Execution artifacts")}}
-	taskLogs := m.recentTaskLogArtifacts(6)
-	workflowRuns := recentWorkflowRunArtifacts(6)
-	requests := recentHumanArtifactRequests(m.requests, 6)
-	requestActions := recentRequestArtifactActions(m.actions, 6)
+	snapshot := m.currentArtifactSnapshot(24)
+	artifacts := snapshot.Items
 
-	if len(taskLogs) == 0 && len(workflowRuns) == 0 && len(requests) == 0 && len(requestActions) == 0 {
+	if len(artifacts) == 0 {
 		muted := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
 		return append(lines,
 			renderedLine{Text: ""},
@@ -69,118 +68,149 @@ func (m channelModel) buildArtifactLines(contentWidth int) []renderedLine {
 		)
 	}
 
-	if len(taskLogs) > 0 {
-		lines = append(lines, renderedLine{Text: ""})
-		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Task output logs")})
-		for _, artifact := range taskLogs {
-			header := subtlePill(artifactClock(artifact.CompletedAt, artifact.UpdatedAt), "#E2E8F0", "#0F172A") +
-				" " + accentPill("log", "#0F766E") +
-				" " + lipgloss.NewStyle().Bold(true).Render(fmt.Sprintf("Task %s · %s", artifact.TaskID, fallbackString(artifact.ToolName, "tool run")))
-			extra := []string{
-				strings.TrimSpace(fmt.Sprintf("@%s · %d entr%s · %s", fallbackString(artifact.AgentSlug, "unknown"), artifact.EntryCount, pluralSuffix(artifact.EntryCount), prettyRelativeTime(artifactTime(artifact.CompletedAt, artifact.UpdatedAt)))),
-			}
-			if strings.TrimSpace(artifact.TaskTitle) != "" {
-				extra = append(extra, "Title: "+artifact.TaskTitle)
-			}
-			if strings.TrimSpace(artifact.WorktreePath) != "" {
-				extra = append(extra, "Worktree: "+artifact.WorktreePath)
-			}
-			if strings.TrimSpace(artifact.LogPath) != "" {
-				extra = append(extra, "Log: "+artifact.LogPath)
-			}
-			for i, line := range renderRuntimeEventCard(contentWidth, header, artifact.Summary, "#0F766E", extra) {
-				rendered := renderedLine{Text: "  " + line}
-				if i == 0 {
-					rendered.TaskID = artifact.TaskID
-				}
-				lines = append(lines, rendered)
-			}
-		}
-	}
-
-	if len(workflowRuns) > 0 {
-		lines = append(lines, renderedLine{Text: ""})
-		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Workflow runs")})
-		for _, run := range workflowRuns {
-			header := subtlePill(artifactClock(run.FinishedAt, run.UpdatedAt), "#E2E8F0", "#0F172A") +
-				" " + actionStatePill("external_workflow_"+fallbackString(run.Status, "finished")) +
-				" " + lipgloss.NewStyle().Bold(true).Render(fmt.Sprintf("%s · %s", fallbackString(run.WorkflowKey, "workflow"), fallbackString(run.Status, "finished")))
-			body := strings.TrimSpace(fmt.Sprintf("%s via %s", fallbackString(run.RunID, "run"), fallbackString(run.Provider, "provider")))
-			extra := []string{
-				prettyRelativeTime(artifactTime(run.FinishedAt, run.UpdatedAt)),
-			}
-			if strings.TrimSpace(run.Path) != "" {
-				extra = append(extra, "Run log: "+run.Path)
-			}
-			for _, line := range renderRuntimeEventCard(contentWidth, header, body, "#7C3AED", extra) {
-				lines = append(lines, renderedLine{Text: "  " + line})
-			}
-		}
-	}
-
-	if len(requests) > 0 || len(requestActions) > 0 {
-		lines = append(lines, renderedLine{Text: ""})
-		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Human decisions")})
-		for _, req := range requests {
-			status := strings.TrimSpace(req.Status)
-			if status == "" {
-				status = "pending"
-			}
-			header := subtlePill(strings.ReplaceAll(status, "_", " "), "#FEF3C7", "#78350F") +
-				" " + accentPill(req.Kind, "#92400E") +
-				" " + lipgloss.NewStyle().Bold(true).Render(fmt.Sprintf("%s · %s", req.ID, req.TitleOrQuestion()))
-			extra := []string{"Asked by @" + fallbackString(req.From, "unknown")}
-			if strings.TrimSpace(req.RecommendedID) != "" {
-				extra = append(extra, "Recommended: "+req.RecommendedID)
-			}
-			if due := strings.TrimSpace(req.DueAt); due != "" {
-				extra = append(extra, "Due "+prettyRelativeTime(due))
-			}
-			for _, line := range renderRuntimeEventCard(contentWidth, header, req.Context, "#B45309", extra) {
-				lines = append(lines, renderedLine{Text: "  " + line, RequestID: req.ID})
-			}
-		}
-		for _, action := range requestActions {
-			header := subtlePill(artifactClock(action.CreatedAt, time.Time{}), "#E2E8F0", "#0F172A") +
-				" " + actionStatePill(action.Kind) +
-				" " + lipgloss.NewStyle().Bold(true).Render(fallbackString(action.Summary, strings.ReplaceAll(action.Kind, "_", " ")))
-			extra := []string{}
-			if actor := strings.TrimSpace(action.Actor); actor != "" {
-				extra = append(extra, "@"+actor)
-			}
-			if channel := strings.TrimSpace(action.Channel); channel != "" {
-				extra = append(extra, "#"+channel)
-			}
-			if related := strings.TrimSpace(action.RelatedID); related != "" {
-				extra = append(extra, related)
-			}
-			if source := strings.TrimSpace(action.Source); source != "" {
-				extra = append(extra, source)
-			}
-			for _, line := range renderRuntimeEventCard(contentWidth, header, prettyRelativeTime(action.CreatedAt), "#1D4ED8", extra) {
-				lines = append(lines, renderedLine{Text: "  " + line})
-			}
-		}
-	}
+	lines = append(lines, renderArtifactSection(contentWidth, "Task execution", snapshot.Filter(team.RuntimeArtifactTask, team.RuntimeArtifactTaskLog))...)
+	lines = append(lines, renderArtifactSection(contentWidth, "Workflow runs", snapshot.Filter(team.RuntimeArtifactWorkflowRun))...)
+	lines = append(lines, renderArtifactSection(contentWidth, "Requests and approvals", snapshot.Filter(team.RuntimeArtifactRequest))...)
+	lines = append(lines, renderArtifactSection(contentWidth, "Action traces", snapshot.Filter(team.RuntimeArtifactHumanAction, team.RuntimeArtifactExternalAction))...)
 
 	return lines
 }
 
 func (m channelModel) currentArtifactSummary() string {
-	logCount := len(m.recentTaskLogArtifacts(4))
-	workflowCount := len(recentWorkflowRunArtifacts(4))
-	requestCount := len(recentHumanArtifactRequests(m.requests, 4)) + len(recentRequestArtifactActions(m.actions, 4))
+	snapshot := m.currentArtifactSnapshot(24)
+	logCount := snapshot.Count(team.RuntimeArtifactTask, team.RuntimeArtifactTaskLog)
+	workflowCount := snapshot.Count(team.RuntimeArtifactWorkflowRun)
+	requestCount := snapshot.Count(team.RuntimeArtifactRequest, team.RuntimeArtifactHumanAction, team.RuntimeArtifactExternalAction)
 	parts := make([]string, 0, 3)
 	if logCount > 0 {
-		parts = append(parts, fmt.Sprintf("%d task log%s", logCount, pluralSuffix(logCount)))
+		parts = append(parts, fmt.Sprintf("%d task run%s", logCount, pluralSuffix(logCount)))
 	}
 	if workflowCount > 0 {
 		parts = append(parts, fmt.Sprintf("%d workflow run%s", workflowCount, pluralSuffix(workflowCount)))
 	}
 	if requestCount > 0 {
-		parts = append(parts, fmt.Sprintf("%d decision trace%s", requestCount, pluralSuffix(requestCount)))
+		parts = append(parts, fmt.Sprintf("%d action trace%s", requestCount, pluralSuffix(requestCount)))
 	}
 	return strings.Join(parts, " · ")
+}
+
+func (m channelModel) currentRuntimeArtifacts(limit int) []team.RuntimeArtifact {
+	return m.currentArtifactSnapshot(limit).Items
+}
+
+func renderArtifactSection(contentWidth int, title string, artifacts []team.RuntimeArtifact) []renderedLine {
+	if len(artifacts) == 0 {
+		return nil
+	}
+	lines := []renderedLine{{Text: ""}, {Text: renderDateSeparator(contentWidth, title)}}
+	for _, artifact := range artifacts {
+		header, accent := renderArtifactHeader(artifact)
+		extra := artifactExtraLines(artifact)
+		for i, line := range renderRuntimeEventCard(contentWidth, header, artifact.EffectiveSummary(), accent, extra) {
+			rendered := renderedLine{Text: "  " + line}
+			if (artifact.Kind == team.RuntimeArtifactTask || artifact.Kind == team.RuntimeArtifactTaskLog) && i == 0 {
+				rendered.TaskID = artifact.ID
+			}
+			if artifact.Kind == team.RuntimeArtifactRequest && i == 0 {
+				rendered.RequestID = artifact.ID
+			}
+			lines = append(lines, rendered)
+		}
+	}
+	return lines
+}
+
+func renderArtifactHeader(artifact team.RuntimeArtifact) (string, string) {
+	clock := subtlePill(artifactClock(artifact.UpdatedAt, parseArtifactTimestamp(artifact.UpdatedAt, artifact.StartedAt)), "#E2E8F0", "#0F172A")
+	title := lipgloss.NewStyle().Bold(true).Render(artifact.EffectiveTitle())
+	switch artifact.Kind {
+	case team.RuntimeArtifactTask:
+		return clock + " " + artifactLifecyclePill(artifact.State, "#0F766E", "#B45309", "#B91C1C", "#15803D") + " " + title, artifactAccentColor(artifact.State, "#0F766E")
+	case team.RuntimeArtifactTaskLog:
+		return clock + " " + accentPill("log", "#0F766E") + " " + title, "#0F766E"
+	case team.RuntimeArtifactWorkflowRun:
+		return clock + " " + artifactLifecyclePill(artifact.State, "#7C3AED", "#B45309", "#B91C1C", "#15803D") + " " + title, artifactAccentColor(artifact.State, "#7C3AED")
+	case team.RuntimeArtifactRequest:
+		return clock + " " + artifactLifecyclePill(artifact.State, "#B45309", "#B45309", "#B91C1C", "#15803D") + " " + title, artifactAccentColor(artifact.State, "#B45309")
+	case team.RuntimeArtifactExternalAction:
+		return clock + " " + artifactLifecyclePill(artifact.State, "#1D4ED8", "#B45309", "#B91C1C", "#15803D") + " " + title, artifactAccentColor(artifact.State, "#1D4ED8")
+	default:
+		return clock + " " + artifactLifecyclePill(artifact.State, "#475569", "#B45309", "#B91C1C", "#15803D") + " " + title, artifactAccentColor(artifact.State, "#475569")
+	}
+}
+
+func artifactExtraLines(artifact team.RuntimeArtifact) []string {
+	extra := []string{}
+	if progress := strings.TrimSpace(artifact.EffectiveProgress()); progress != "" && !strings.EqualFold(progress, strings.TrimSpace(artifact.EffectiveSummary())) {
+		extra = append(extra, "Progress: "+progress)
+	}
+	if output := strings.TrimSpace(artifact.PartialOutput); output != "" {
+		extra = append(extra, "Output: "+output)
+	}
+	if strings.TrimSpace(artifact.Owner) != "" {
+		extra = append(extra, "@"+artifact.Owner)
+	}
+	if strings.TrimSpace(artifact.Channel) != "" {
+		extra = append(extra, "#"+artifact.Channel)
+	}
+	if strings.TrimSpace(artifact.Worktree) != "" {
+		extra = append(extra, "Worktree: "+artifact.Worktree)
+	}
+	if strings.TrimSpace(artifact.Path) != "" {
+		extra = append(extra, "Path: "+artifact.Path)
+	}
+	if strings.TrimSpace(artifact.RelatedID) != "" {
+		extra = append(extra, "Related: "+artifact.RelatedID)
+	}
+	if artifact.Blocking {
+		extra = append(extra, "Blocking")
+	}
+	if strings.TrimSpace(artifact.ReviewHint) != "" {
+		extra = append(extra, artifact.ReviewHint)
+	}
+	if strings.TrimSpace(artifact.ResumeHint) != "" {
+		extra = append(extra, artifact.ResumeHint)
+	}
+	return extra
+}
+
+func artifactLifecyclePill(state, runningColor, pendingColor, failedColor, completedColor string) string {
+	label := strings.ReplaceAll(fallbackString(strings.TrimSpace(state), "retained"), "_", " ")
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "blocked", "failed", "canceled", "cancelled":
+		return accentPill(label, failedColor)
+	case "pending", "review", "started":
+		return subtlePill(label, "#FEF3C7", pendingColor)
+	case "completed":
+		return subtlePill(label, "#DCFCE7", completedColor)
+	default:
+		return subtlePill(label, "#DBEAFE", runningColor)
+	}
+}
+
+func artifactAccentColor(state, fallback string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "blocked", "failed", "canceled", "cancelled":
+		return "#B91C1C"
+	case "pending", "review", "started":
+		return "#B45309"
+	case "completed":
+		return "#15803D"
+	default:
+		return fallback
+	}
+}
+
+func parseArtifactTimestamp(primary, fallback string) time.Time {
+	for _, candidate := range []string{strings.TrimSpace(primary), strings.TrimSpace(fallback)} {
+		if candidate == "" {
+			continue
+		}
+		if ts, ok := parseChannelTime(candidate); ok {
+			return ts
+		}
+	}
+	return time.Time{}
 }
 
 func (m channelModel) recentTaskLogArtifacts(limit int) []taskLogArtifact {
@@ -395,10 +425,11 @@ func recentHumanArtifactRequests(requests []channelInterview, limit int) []chann
 	return filtered
 }
 
-func recentRequestArtifactActions(actions []channelAction, limit int) []channelAction {
+func recentExecutionArtifactActions(actions []channelAction, limit int) []channelAction {
 	filtered := make([]channelAction, 0, len(actions))
 	for _, action := range actions {
-		if strings.HasPrefix(strings.TrimSpace(action.Kind), "request_") {
+		kind := strings.TrimSpace(action.Kind)
+		if strings.HasPrefix(kind, "request_") || strings.HasPrefix(kind, "external_") || strings.HasPrefix(kind, "interrupt_") || strings.HasPrefix(kind, "human_") {
 			filtered = append(filtered, action)
 		}
 	}

--- a/cmd/wuphf/channel_artifacts_test.go
+++ b/cmd/wuphf/channel_artifacts_test.go
@@ -45,14 +45,14 @@ func TestCurrentArtifactSummaryUsesLogsAndWorkflows(t *testing.T) {
 	m.requests = []channelInterview{{ID: "req-1", Kind: "approval", Status: "pending", Title: "Approve copy", Question: "Approve copy?", From: "ceo"}}
 
 	got := m.currentArtifactSummary()
-	if !strings.Contains(got, "task log") {
-		t.Fatalf("expected task logs in summary, got %q", got)
+	if !strings.Contains(got, "task run") {
+		t.Fatalf("expected task runs in summary, got %q", got)
 	}
 	if !strings.Contains(got, "workflow run") {
 		t.Fatalf("expected workflow runs in summary, got %q", got)
 	}
-	if !strings.Contains(got, "decision trace") {
-		t.Fatalf("expected decision traces in summary, got %q", got)
+	if !strings.Contains(got, "action trace") {
+		t.Fatalf("expected action traces in summary, got %q", got)
 	}
 }
 
@@ -89,20 +89,32 @@ func TestBuildArtifactLinesShowsTaskLogsWorkflowRunsAndApprovals(t *testing.T) {
 	lines := m.buildArtifactLines(96)
 	plain := stripANSI(joinRenderedLines(lines))
 
-	if !strings.Contains(plain, "Task output logs") {
-		t.Fatalf("expected task output logs section, got %q", plain)
+	if !strings.Contains(plain, "Task execution") {
+		t.Fatalf("expected task execution section, got %q", plain)
 	}
 	if !strings.Contains(plain, "Workflow runs") {
 		t.Fatalf("expected workflow runs section, got %q", plain)
 	}
-	if !strings.Contains(plain, "Human decisions") {
-		t.Fatalf("expected human decisions section, got %q", plain)
+	if !strings.Contains(plain, "Requests and approvals") {
+		t.Fatalf("expected request section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Action traces") {
+		t.Fatalf("expected action traces section, got %q", plain)
 	}
 	if !strings.Contains(plain, "Ship launch notes") {
 		t.Fatalf("expected task title in artifacts view, got %q", plain)
 	}
 	if !strings.Contains(plain, "launch-sync") {
 		t.Fatalf("expected workflow key in artifacts view, got %q", plain)
+	}
+	if !strings.Contains(plain, "Progress:") {
+		t.Fatalf("expected lifecycle progress metadata, got %q", plain)
+	}
+	if !strings.Contains(plain, "Output: ok") {
+		t.Fatalf("expected retained output summary, got %q", plain)
+	}
+	if !strings.Contains(plain, "Resume in /tmp/wuphf-task-1") {
+		t.Fatalf("expected resume hint, got %q", plain)
 	}
 }
 

--- a/cmd/wuphf/channel_doctor.go
+++ b/cmd/wuphf/channel_doctor.go
@@ -1,17 +1,14 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
-	"github.com/nex-crm/wuphf/internal/action"
-	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/team"
 )
 
 type doctorSeverity string
@@ -24,20 +21,26 @@ const (
 )
 
 type doctorCheck struct {
-	Label    string
-	Severity doctorSeverity
-	Detail   string
-	NextStep string
+	Label     string
+	Severity  doctorSeverity
+	Lifecycle team.CapabilityLifecycle
+	Detail    string
+	NextStep  string
 }
 
 type channelDoctorReport struct {
 	GeneratedAt time.Time
 	Checks      []doctorCheck
+	Registry    team.CapabilityRegistry
 }
 
 type channelDoctorDoneMsg struct {
 	report channelDoctorReport
 	err    error
+}
+
+var detectRuntimeCapabilitiesFn = func(opts team.CapabilityProbeOptions) team.RuntimeCapabilities {
+	return team.DetectRuntimeCapabilitiesWithOptions(opts)
 }
 
 func (r channelDoctorReport) counts() (ok, warn, fail int) {
@@ -74,119 +77,40 @@ func runDoctorChecks() tea.Cmd {
 }
 
 func inspectDoctor() (channelDoctorReport, error) {
-	report := channelDoctorReport{GeneratedAt: time.Now()}
-	report.Checks = append(report.Checks,
-		doctorBinaryCheck("tmux", "Needed for the office panes and session management."),
-		doctorBinaryCheck("claude", "Needed for the teammate runtime."),
-	)
-
-	if config.ResolveNoNex() {
-		report.Checks = append(report.Checks, doctorCheck{
-			Label:    "Nex",
-			Severity: doctorInfo,
-			Detail:   "Disabled for this session with --no-nex.",
-			NextStep: "Restart WUPHF without --no-nex to enable memory, integrations, and provider-backed actions.",
-		})
-		return report, nil
-	}
-
-	apiKey := strings.TrimSpace(config.ResolveAPIKey(""))
-	if apiKey == "" {
-		report.Checks = append(report.Checks, doctorCheck{
-			Label:    "Nex API key",
-			Severity: doctorFail,
-			Detail:   "Missing WUPHF/Nex API key.",
-			NextStep: "Run /init and paste your WUPHF API key.",
-		})
-	} else {
-		report.Checks = append(report.Checks, doctorCheck{
-			Label:    "Nex API key",
-			Severity: doctorOK,
-			Detail:   "Configured and ready for Nex-backed context.",
-		})
-	}
-
-	email := strings.TrimSpace(config.ResolveComposioUserID())
-	if email == "" {
-		report.Checks = append(report.Checks, doctorCheck{
-			Label:    "Workspace identity",
-			Severity: doctorWarn,
-			Detail:   "No saved email identity for integrations.",
-			NextStep: "Finish /init so WUPHF can scope integration providers to your Nex email.",
-		})
-	} else {
-		report.Checks = append(report.Checks, doctorCheck{
-			Label:    "Workspace identity",
-			Severity: doctorOK,
-			Detail:   fmt.Sprintf("Using %s for provider identity.", email),
-		})
-	}
-
-	resolvedProvider := config.ResolveActionProvider()
-	if resolvedProvider == "" {
-		resolvedProvider = "auto"
-	}
-	registry := action.NewRegistryFromEnv()
-	provider, err := registry.ProviderFor(action.CapabilityConnections)
-	if err != nil {
-		report.Checks = append(report.Checks, doctorCheck{
-			Label:    "Action provider",
-			Severity: doctorFail,
-			Detail:   fmt.Sprintf("No working provider for external actions (%s).", resolvedProvider),
-			NextStep: "Set /config set composio_api_key <key> or choose a configured provider.",
-		})
-		return report, nil
-	}
-
-	report.Checks = append(report.Checks, doctorCheck{
-		Label:    "Action provider",
-		Severity: doctorOK,
-		Detail:   fmt.Sprintf("Using %s for external actions.", provider.Name()),
+	capabilities := detectRuntimeCapabilitiesFn(team.CapabilityProbeOptions{
+		IncludeConnections: true,
+		ConnectionLimit:    5,
+		ConnectionTimeout:  5 * time.Second,
 	})
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	connections, err := provider.ListConnections(ctx, action.ListConnectionsOptions{Limit: 5})
-	if err != nil {
-		report.Checks = append(report.Checks, doctorCheck{
-			Label:    "Connected accounts",
-			Severity: doctorWarn,
-			Detail:   fmt.Sprintf("Provider responded with an error: %v", err),
-			NextStep: "Open the provider dashboard and confirm at least one account is connected for your Nex email.",
-		})
-		return report, nil
+	report := channelDoctorReport{
+		GeneratedAt: time.Now(),
+		Registry:    capabilities.Registry,
 	}
-	if len(connections.Connections) == 0 {
+	for _, entry := range capabilities.Registry.Entries {
 		report.Checks = append(report.Checks, doctorCheck{
-			Label:    "Connected accounts",
-			Severity: doctorWarn,
-			Detail:   fmt.Sprintf("%s is configured, but no connected accounts are available yet.", strings.Title(provider.Name())),
-			NextStep: "Connect Gmail, CRM, or another account in the provider dashboard, then rerun /doctor.",
+			Label:     entry.Label,
+			Severity:  doctorSeverityForCapability(entry),
+			Lifecycle: entry.Lifecycle,
+			Detail:    entry.Detail,
+			NextStep:  entry.NextStep,
 		})
-		return report, nil
 	}
-
-	report.Checks = append(report.Checks, doctorCheck{
-		Label:    "Connected accounts",
-		Severity: doctorOK,
-		Detail:   fmt.Sprintf("%d account%s ready through %s.", len(connections.Connections), pluralSuffix(len(connections.Connections)), strings.Title(provider.Name())),
-	})
 	return report, nil
 }
 
-func doctorBinaryCheck(name, reason string) doctorCheck {
-	if _, err := exec.LookPath(name); err != nil {
-		return doctorCheck{
-			Label:    name,
-			Severity: doctorFail,
-			Detail:   fmt.Sprintf("%s is not available on PATH.", name),
-			NextStep: reason,
+func doctorSeverityForCapability(entry team.CapabilityDescriptor) doctorSeverity {
+	switch entry.Level {
+	case team.CapabilityReady:
+		return doctorOK
+	case team.CapabilityWarn:
+		switch entry.Lifecycle {
+		case team.CapabilityLifecycleNeedsSetup:
+			return doctorFail
+		default:
+			return doctorWarn
 		}
-	}
-	return doctorCheck{
-		Label:    name,
-		Severity: doctorOK,
-		Detail:   fmt.Sprintf("%s is installed.", name),
+	default:
+		return doctorInfo
 	}
 }
 
@@ -202,9 +126,23 @@ func renderDoctorCard(report channelDoctorReport, width int) string {
 
 	for _, check := range report.Checks {
 		label := renderDoctorLabel(check)
+		if strings.TrimSpace(string(check.Lifecycle)) != "" {
+			label += " " + renderDoctorLifecycle(check.Lifecycle)
+		}
 		lines = append(lines, label+" "+check.Detail)
 		if strings.TrimSpace(check.NextStep) != "" {
 			lines = append(lines, "  "+mutedText("Next: "+check.NextStep))
+		}
+		lines = append(lines, "")
+	}
+	if len(report.Registry.Entries) > 0 {
+		lines = append(lines, "Capability map:")
+		for _, entry := range report.Registry.Entries {
+			lines = append(lines, fmt.Sprintf("  %s [%s · %s] %s", entry.Label, entry.Category, entry.Lifecycle, entry.Level))
+			lines = append(lines, "    "+entry.Detail)
+			if strings.TrimSpace(entry.NextStep) != "" {
+				lines = append(lines, "    "+mutedText("Next: "+entry.NextStep))
+			}
 		}
 		lines = append(lines, "")
 	}
@@ -229,5 +167,19 @@ func renderDoctorLabel(check doctorCheck) string {
 		return accentPill(check.Label, "#B91C1C")
 	default:
 		return subtlePill(check.Label, "#E2E8F0", "#334155")
+	}
+}
+
+func renderDoctorLifecycle(lifecycle team.CapabilityLifecycle) string {
+	label := strings.ReplaceAll(string(lifecycle), "_", " ")
+	switch lifecycle {
+	case team.CapabilityLifecycleReady:
+		return subtlePill(label, "#DCFCE7", "#166534")
+	case team.CapabilityLifecycleDisabled:
+		return subtlePill(label, "#E2E8F0", "#334155")
+	case team.CapabilityLifecycleDeferred, team.CapabilityLifecyclePartial, team.CapabilityLifecycleProvisioning:
+		return subtlePill(label, "#FEF3C7", "#92400E")
+	default:
+		return subtlePill(label, "#FEE2E2", "#991B1B")
 	}
 }

--- a/cmd/wuphf/channel_doctor_test.go
+++ b/cmd/wuphf/channel_doctor_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+func TestInspectDoctorUsesCapabilityRegistry(t *testing.T) {
+	prev := detectRuntimeCapabilitiesFn
+	detectRuntimeCapabilitiesFn = func(team.CapabilityProbeOptions) team.RuntimeCapabilities {
+		return team.RuntimeCapabilities{
+			Registry: team.CapabilityRegistry{
+				Entries: []team.CapabilityDescriptor{
+					{
+						Key:       team.CapabilityKeyActions,
+						Label:     "External actions",
+						Category:  team.CapabilityCategoryAction,
+						Level:     team.CapabilityWarn,
+						Lifecycle: team.CapabilityLifecycleNeedsSetup,
+						Detail:    "No configured provider available for action_execute.",
+						NextStep:  "Configure a working provider.",
+					},
+					{
+						Key:       team.CapabilityKeyConnections,
+						Label:     "Connected accounts",
+						Category:  team.CapabilityCategoryAction,
+						Level:     team.CapabilityWarn,
+						Lifecycle: team.CapabilityLifecyclePartial,
+						Detail:    "One is configured, but no connected accounts are available yet.",
+						NextStep:  "Connect Gmail, CRM, or another account.",
+					},
+				},
+			},
+		}
+	}
+	defer func() { detectRuntimeCapabilitiesFn = prev }()
+
+	report, err := inspectDoctor()
+	if err != nil {
+		t.Fatalf("inspectDoctor: %v", err)
+	}
+	if len(report.Checks) != 2 {
+		t.Fatalf("expected two checks, got %+v", report.Checks)
+	}
+	if report.Checks[0].Severity != doctorFail {
+		t.Fatalf("expected needs-setup capability to map to fail, got %+v", report.Checks[0])
+	}
+	if report.Checks[1].Severity != doctorWarn {
+		t.Fatalf("expected partial capability to map to warn, got %+v", report.Checks[1])
+	}
+
+	card := renderDoctorCard(report, 80)
+	for _, want := range []string{"Capability map:", "needs setup", "partial", "Connected accounts"} {
+		if !strings.Contains(card, want) {
+			t.Fatalf("expected %q in doctor card: %q", want, card)
+		}
+	}
+}

--- a/cmd/wuphf/channel_mailboxes.go
+++ b/cmd/wuphf/channel_mailboxes.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func buildInboxLines(messages []brokerMessage, requests []channelInterview, contentWidth int) []renderedLine {
+	lines := []renderedLine{{Text: renderDateSeparator(contentWidth, "Inbox")}}
+	if len(requests) == 0 && len(messages) == 0 {
+		muted := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
+		return append(lines,
+			renderedLine{Text: ""},
+			renderedLine{Text: muted.Render("  Nothing is waiting in the inbox lane.")},
+			renderedLine{Text: muted.Render("  Human asks, CEO guidance, tags, and thread replies will collect here.")},
+		)
+	}
+	if len(requests) > 0 {
+		lines = append(lines, buildRequestLines(requests, contentWidth)...)
+	}
+	if len(messages) > 0 {
+		if len(lines) > 1 {
+			lines = append(lines, renderedLine{Text: ""})
+		}
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Inbox messages")})
+		lines = append(lines, buildOfficeMessageLines(messages, map[string]bool{}, contentWidth, true, "", 0)...)
+	}
+	return lines
+}
+
+func buildOutboxLines(messages []brokerMessage, actions []channelAction, contentWidth int) []renderedLine {
+	lines := []renderedLine{{Text: renderDateSeparator(contentWidth, "Outbox")}}
+	if len(messages) == 0 && len(actions) == 0 {
+		muted := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
+		return append(lines,
+			renderedLine{Text: ""},
+			renderedLine{Text: muted.Render("  Nothing is in the outbox yet.")},
+			renderedLine{Text: muted.Render("  Agent-authored updates and recent external actions will collect here.")},
+		)
+	}
+	if len(messages) > 0 {
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Authored messages")})
+		lines = append(lines, buildOfficeMessageLines(messages, map[string]bool{}, contentWidth, true, "", 0)...)
+	}
+	if len(actions) > 0 {
+		lines = append(lines, renderedLine{Text: ""})
+		lines = append(lines, renderedLine{Text: renderDateSeparator(contentWidth, "Recent actions")})
+		for _, action := range actions {
+			header := subtlePill(artifactClock(action.CreatedAt, time.Time{}), "#E2E8F0", "#0F172A") +
+				" " + actionStatePill(action.Kind) +
+				" " + lipgloss.NewStyle().Bold(true).Render(fallbackString(action.Summary, strings.ReplaceAll(action.Kind, "_", " ")))
+			extra := []string{}
+			if actor := strings.TrimSpace(action.Actor); actor != "" {
+				extra = append(extra, "@"+actor)
+			}
+			if source := strings.TrimSpace(action.Source); source != "" {
+				extra = append(extra, source)
+			}
+			for _, line := range renderRuntimeEventCard(contentWidth, header, prettyRelativeTime(action.CreatedAt), "#1D4ED8", extra) {
+				lines = append(lines, renderedLine{Text: "  " + line})
+			}
+		}
+	}
+	return lines
+}
+
+func filterMessagesForViewerScope(messages []brokerMessage, viewerSlug, scope string) []brokerMessage {
+	scope = normalizeMailboxScope(scope)
+	if scope == "" {
+		return append([]brokerMessage(nil), messages...)
+	}
+	index := make(map[string]brokerMessage, len(messages))
+	for _, msg := range messages {
+		if id := strings.TrimSpace(msg.ID); id != "" {
+			index[id] = msg
+		}
+	}
+	filtered := make([]brokerMessage, 0, len(messages))
+	for _, msg := range messages {
+		if mailboxMessageMatchesViewerScope(msg, viewerSlug, scope, index) {
+			filtered = append(filtered, msg)
+		}
+	}
+	return filtered
+}
+
+func normalizeMailboxScope(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "inbox", "outbox", "agent":
+		return strings.TrimSpace(strings.ToLower(value))
+	default:
+		return ""
+	}
+}
+
+func mailboxMessageMatchesViewerScope(msg brokerMessage, viewerSlug, scope string, messagesByID map[string]brokerMessage) bool {
+	switch normalizeMailboxScope(scope) {
+	case "inbox":
+		return mailboxMessageBelongsToViewerInbox(msg, viewerSlug, messagesByID)
+	case "outbox":
+		return mailboxMessageBelongsToViewerOutbox(msg, viewerSlug)
+	case "agent":
+		return mailboxMessageBelongsToViewerOutbox(msg, viewerSlug) || mailboxMessageBelongsToViewerInbox(msg, viewerSlug, messagesByID)
+	default:
+		return true
+	}
+}
+
+func mailboxMessageBelongsToViewerOutbox(msg brokerMessage, viewerSlug string) bool {
+	viewerSlug = strings.TrimSpace(viewerSlug)
+	return viewerSlug != "" && strings.TrimSpace(msg.From) == viewerSlug
+}
+
+func mailboxMessageBelongsToViewerInbox(msg brokerMessage, viewerSlug string, messagesByID map[string]brokerMessage) bool {
+	viewerSlug = strings.TrimSpace(viewerSlug)
+	if viewerSlug == "" {
+		return false
+	}
+	from := strings.TrimSpace(msg.From)
+	switch from {
+	case viewerSlug:
+		return false
+	case "you", "human", "ceo":
+		return true
+	}
+	for _, tagged := range msg.Tagged {
+		tagged = strings.TrimSpace(tagged)
+		if tagged == viewerSlug || tagged == "all" {
+			return true
+		}
+	}
+	return mailboxMessageRepliesToViewerThread(msg, viewerSlug, messagesByID)
+}
+
+func mailboxMessageRepliesToViewerThread(msg brokerMessage, viewerSlug string, messagesByID map[string]brokerMessage) bool {
+	replyTo := strings.TrimSpace(msg.ReplyTo)
+	if replyTo == "" || viewerSlug == "" {
+		return false
+	}
+	seen := map[string]bool{}
+	for replyTo != "" {
+		if seen[replyTo] {
+			return false
+		}
+		seen[replyTo] = true
+		parent, ok := messagesByID[replyTo]
+		if !ok {
+			return false
+		}
+		if strings.TrimSpace(parent.From) == viewerSlug {
+			return true
+		}
+		replyTo = strings.TrimSpace(parent.ReplyTo)
+	}
+	return false
+}

--- a/cmd/wuphf/channel_needs_you.go
+++ b/cmd/wuphf/channel_needs_you.go
@@ -11,6 +11,13 @@ func buildNeedsYouLines(requests []channelInterview, contentWidth int) []rendere
 	if !ok {
 		return nil
 	}
+	return buildNeedsYouLinesForRequest(&req, contentWidth)
+}
+
+func buildNeedsYouLinesForRequest(req *channelInterview, contentWidth int) []renderedLine {
+	if req == nil {
+		return nil
+	}
 
 	statusLabel := "needs your decision"
 	if !(req.Blocking || req.Required) {

--- a/cmd/wuphf/channel_recovery.go
+++ b/cmd/wuphf/channel_recovery.go
@@ -22,7 +22,7 @@ func (m channelModel) currentRuntimeSnapshot() team.RuntimeSnapshot {
 }
 
 func (m channelModel) buildRecoveryLines(contentWidth int) []renderedLine {
-	return buildRecoveryLines(m.currentRuntimeSnapshot(), contentWidth, m.awaySummary, m.unreadCount, m.brokerConnected, m.tasks, m.requests, m.messages)
+	return buildRecoveryLines(m.currentWorkspaceUIState(), contentWidth, m.tasks, m.requests, m.messages)
 }
 
 func runtimeTasksFromChannel(tasks []channelTask) []team.RuntimeTask {
@@ -103,13 +103,7 @@ func summarizeAwayRecovery(unreadCount int, recovery team.SessionRecovery) strin
 }
 
 func (m channelModel) currentAwaySummary() string {
-	if m.unreadCount == 0 {
-		return ""
-	}
-	if text := strings.TrimSpace(m.awaySummary); text != "" {
-		return text
-	}
-	return summarizeAwayRecovery(m.unreadCount, m.currentRuntimeSnapshot().Recovery)
+	return m.currentWorkspaceUIState().AwaySummary
 }
 
 func trimRecoverySentence(text string) string {
@@ -132,11 +126,12 @@ func renderAwayStrip(width, unreadCount int, summary string) string {
 		Render(label)
 }
 
-func buildRecoveryLines(snapshot team.RuntimeSnapshot, contentWidth int, awaySummary string, unreadCount int, brokerConnected bool, tasks []channelTask, requests []channelInterview, messages []brokerMessage) []renderedLine {
+func buildRecoveryLines(workspace workspaceUIState, contentWidth int, tasks []channelTask, requests []channelInterview, messages []brokerMessage) []renderedLine {
+	snapshot := workspace.Runtime
 	muted := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
 	lines := []renderedLine{{Text: renderDateSeparator(contentWidth, "Recovery")}}
 
-	if !brokerConnected && len(snapshot.Tasks) == 0 && len(snapshot.Requests) == 0 && len(snapshot.Recent) == 0 {
+	if !workspace.BrokerConnected && len(snapshot.Tasks) == 0 && len(snapshot.Requests) == 0 && len(snapshot.Recent) == 0 {
 		lines = append(lines,
 			renderedLine{Text: ""},
 			renderedLine{Text: muted.Render("  Offline preview. Launch WUPHF to hydrate the runtime state and recovery summary.")},
@@ -145,9 +140,9 @@ func buildRecoveryLines(snapshot team.RuntimeSnapshot, contentWidth int, awaySum
 		return lines
 	}
 
-	if unreadCount > 0 || strings.TrimSpace(awaySummary) != "" {
+	if workspace.UnreadCount > 0 || strings.TrimSpace(workspace.AwaySummary) != "" {
 		title := subtlePill("while away", "#F8FAFC", "#1D4ED8") + " " + lipgloss.NewStyle().Bold(true).Render("What changed while you were gone")
-		body := strings.TrimSpace(awaySummary)
+		body := strings.TrimSpace(workspace.AwaySummary)
 		if body == "" {
 			body = "Use this view to regain context before you reply."
 		}
@@ -174,6 +169,11 @@ func buildRecoveryLines(snapshot team.RuntimeSnapshot, contentWidth int, awaySum
 		stateExtra = append(stateExtra, "Current focus: "+focus)
 	}
 	for _, line := range renderRuntimeEventCard(contentWidth, subtlePill("runtime", "#E2E8F0", "#334155")+" "+lipgloss.NewStyle().Bold(true).Render("Current state"), stateBody, "#475569", stateExtra) {
+		lines = append(lines, renderedLine{Text: "  " + line})
+	}
+
+	readinessTitle, readinessBody, readinessAccent, readinessExtra := workspace.readinessCard()
+	for _, line := range renderRuntimeEventCard(contentWidth, readinessTitle, readinessBody, readinessAccent, readinessExtra) {
 		lines = append(lines, renderedLine{Text: "  " + line})
 	}
 

--- a/cmd/wuphf/channel_recovery_test.go
+++ b/cmd/wuphf/channel_recovery_test.go
@@ -56,6 +56,7 @@ func TestCurrentAwaySummaryUsesRecoveryFocus(t *testing.T) {
 
 func TestBuildRecoveryLinesShowsSummaryAndHighlights(t *testing.T) {
 	m := newChannelModel(false)
+	m.brokerConnected = true
 	m.unreadCount = 4
 	m.tasks = []channelTask{
 		{ID: "task-1", Title: "Ship launch checklist", Owner: "pm", Status: "in_progress", ExecutionMode: "local_worktree", WorktreePath: "/tmp/wuphf-task-1"},
@@ -68,9 +69,8 @@ func TestBuildRecoveryLinesShowsSummaryAndHighlights(t *testing.T) {
 		{ID: "msg-2", From: "pm", Content: "Checklist is nearly ready.", Timestamp: "2026-04-06T10:01:00Z"},
 	}
 
-	snapshot := m.currentRuntimeSnapshot()
-	awaySummary := summarizeAwayRecovery(m.unreadCount, snapshot.Recovery)
-	lines := buildRecoveryLines(snapshot, 88, awaySummary, m.unreadCount, true, m.tasks, m.requests, m.messages)
+	workspace := m.currentWorkspaceUIState()
+	lines := buildRecoveryLines(workspace, 88, m.tasks, m.requests, m.messages)
 	plain := stripANSI(joinRenderedLines(lines))
 
 	if !strings.Contains(plain, "What changed while you were gone") {
@@ -84,6 +84,9 @@ func TestBuildRecoveryLinesShowsSummaryAndHighlights(t *testing.T) {
 	}
 	if !strings.Contains(plain, "Current state") {
 		t.Fatalf("expected runtime-state card, got %q", plain)
+	}
+	if !strings.Contains(plain, "Waiting on you") {
+		t.Fatalf("expected normalized readiness card, got %q", plain)
 	}
 }
 

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -17,6 +17,8 @@ const (
 	mainLinesCacheLimit = 48
 	sidebarCacheLimit   = 24
 	markdownCacheLimit  = 256
+	threadedCacheLimit  = 96
+	viewportBlockLimit  = 2048
 )
 
 type channelRenderCacheStore struct {
@@ -26,6 +28,8 @@ type channelRenderCacheStore struct {
 	sidebars  map[uint64]string
 	markdown  map[uint64]string
 	renderers map[int]*glamour.TermRenderer
+	threaded  map[uint64][]threadedMessage
+	blocks    map[uint64][]renderedLine
 }
 
 var channelRenderCache = channelRenderCacheStore{
@@ -33,6 +37,8 @@ var channelRenderCache = channelRenderCacheStore{
 	sidebars:  make(map[uint64]string),
 	markdown:  make(map[uint64]string),
 	renderers: make(map[int]*glamour.TermRenderer),
+	threaded:  make(map[uint64][]threadedMessage),
+	blocks:    make(map[uint64][]renderedLine),
 }
 
 func cachedSidebarRender(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, workspace workspaceUIState, width, height int) string {
@@ -53,13 +59,22 @@ func (m channelModel) cachedMainLines(contentWidth int) []renderedLine {
 
 	var lines []renderedLine
 	if m.isOneOnOne() {
-		if m.activeApp == officeAppRecovery {
+		switch m.activeApp {
+		case officeAppRecovery:
 			lines = m.buildRecoveryLines(contentWidth)
-		} else {
+		case officeAppInbox:
+			lines = buildInboxLines(filterMessagesForViewerScope(m.messages, m.oneOnOneAgentSlug(), "inbox"), m.requests, contentWidth)
+		case officeAppOutbox:
+			lines = buildOutboxLines(filterMessagesForViewerScope(m.messages, m.oneOnOneAgentSlug(), "outbox"), m.actions, contentWidth)
+		default:
 			lines = m.buildDirectFeedLines(contentWidth)
 		}
 	} else {
 		switch m.activeApp {
+		case officeAppInbox:
+			lines = buildInboxLines(m.messages, m.requests, contentWidth)
+		case officeAppOutbox:
+			lines = buildOutboxLines(m.messages, m.actions, contentWidth)
 		case officeAppRecovery:
 			lines = m.buildRecoveryLines(contentWidth)
 		case officeAppTasks:
@@ -95,7 +110,8 @@ func (m channelModel) hashMainLinesState(contentWidth int) uint64 {
 	h.add(m.oneOnOneAgent)
 	h.addInt64(renderTimeBucket(m.activeApp, m.isOneOnOne()))
 
-	if m.isOneOnOne() || m.activeApp == officeAppMessages || m.activeApp == officeAppRecovery {
+	if m.isOneOnOne() || m.activeApp == officeAppMessages || m.activeApp == officeAppInbox || m.activeApp == officeAppOutbox || m.activeApp == officeAppRecovery {
+		workspace := m.currentWorkspaceUIState()
 		h.addMessages(m.messages)
 		h.addExpandedThreads(m.expandedThreads)
 		h.add(m.unreadAnchorID)
@@ -109,10 +125,21 @@ func (m channelModel) hashMainLinesState(contentWidth int) uint64 {
 			h.add(m.oneOnOneAgentName())
 		}
 		h.addBool(m.brokerConnected)
+		h.add(string(workspace.Readiness.Level), workspace.Readiness.Headline, workspace.Readiness.Detail, workspace.Readiness.NextStep)
+		h.add(workspace.Focus, workspace.NextStep)
+		if workspace.NeedsYou != nil {
+			h.add(workspace.NeedsYou.ID, workspace.NeedsYou.TitleOrQuestion(), workspace.NeedsYou.Status)
+		}
 		return h.sum()
 	}
 
 	switch m.activeApp {
+	case officeAppInbox:
+		h.addMessages(m.messages)
+		h.addRequests(m.requests)
+	case officeAppOutbox:
+		h.addMessages(m.messages)
+		h.addActions(m.actions)
 	case officeAppTasks:
 		h.addTasks(m.tasks)
 	case officeAppRequests:
@@ -168,6 +195,7 @@ func hashSidebarState(channels []channelInfo, members []channelMember, tasks []c
 	h.addInt(workspace.UnreadCount)
 	h.addBool(workspace.NoNex)
 	h.addBool(workspace.APIConfigured)
+	h.add(string(workspace.Readiness.Level), workspace.Readiness.Headline, workspace.Readiness.Detail, workspace.Readiness.NextStep)
 	if workspace.NeedsYou != nil {
 		h.add(workspace.NeedsYou.ID, workspace.NeedsYou.TitleOrQuestion())
 	}
@@ -187,6 +215,15 @@ func cloneRenderedLines(lines []renderedLine) []renderedLine {
 	}
 	out := make([]renderedLine, len(lines))
 	copy(out, lines)
+	return out
+}
+
+func cloneThreadedMessages(items []threadedMessage) []threadedMessage {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]threadedMessage, len(items))
+	copy(out, items)
 	return out
 }
 
@@ -239,6 +276,44 @@ func (c *channelRenderCacheStore) putMarkdown(key uint64, rendered string) {
 		c.markdown = make(map[uint64]string)
 	}
 	c.markdown[key] = rendered
+}
+
+func (c *channelRenderCacheStore) getThreaded(key uint64) ([]threadedMessage, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	items, ok := c.threaded[key]
+	if !ok {
+		return nil, false
+	}
+	return cloneThreadedMessages(items), true
+}
+
+func (c *channelRenderCacheStore) putThreaded(key uint64, items []threadedMessage) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.threaded) >= threadedCacheLimit {
+		c.threaded = make(map[uint64][]threadedMessage)
+	}
+	c.threaded[key] = cloneThreadedMessages(items)
+}
+
+func (c *channelRenderCacheStore) getViewportBlock(key uint64) ([]renderedLine, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	lines, ok := c.blocks[key]
+	if !ok {
+		return nil, false
+	}
+	return cloneRenderedLines(lines), true
+}
+
+func (c *channelRenderCacheStore) putViewportBlock(key uint64, lines []renderedLine) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.blocks) >= viewportBlockLimit {
+		c.blocks = make(map[uint64][]renderedLine)
+	}
+	c.blocks[key] = cloneRenderedLines(lines)
 }
 
 func (c *channelRenderCacheStore) renderer(width int) (*glamour.TermRenderer, error) {

--- a/cmd/wuphf/channel_switcher.go
+++ b/cmd/wuphf/channel_switcher.go
@@ -13,17 +13,35 @@ import (
 )
 
 func (m channelModel) buildWorkspaceSwitcherOptions() []tui.PickerOption {
+	workspace := m.currentWorkspaceUIState()
 	options := []tui.PickerOption{}
 	if m.isOneOnOne() {
-		options = append(options, tui.PickerOption{
-			Label:       "Back to office",
-			Value:       "mode:office",
-			Description: m.officeFeedDescription(),
-		})
+		options = append(options,
+			tui.PickerOption{
+				Label:       "Back to office",
+				Value:       "mode:office",
+				Description: m.officeFeedDescription(workspace),
+			},
+			tui.PickerOption{
+				Label:       "Inbox",
+				Value:       "app:inbox",
+				Description: "Only the messages that currently belong in @" + m.oneOnOneAgentSlug() + "'s inbox",
+			},
+			tui.PickerOption{
+				Label:       "Outbox",
+				Value:       "app:outbox",
+				Description: "Only the messages currently authored by @" + m.oneOnOneAgentSlug(),
+			},
+			tui.PickerOption{
+				Label:       "Recovery",
+				Value:       "app:recovery",
+				Description: m.recoverySwitcherDescription(workspace),
+			},
+		)
 	} else {
 		options = append(options,
-			tui.PickerOption{Label: "Office feed", Value: "app:messages", Description: m.officeFeedDescription()},
-			tui.PickerOption{Label: "Recovery", Value: "app:recovery", Description: m.recoverySwitcherDescription()},
+			tui.PickerOption{Label: "Office feed", Value: "app:messages", Description: m.officeFeedDescription(workspace)},
+			tui.PickerOption{Label: "Recovery", Value: "app:recovery", Description: m.recoverySwitcherDescription(workspace)},
 			tui.PickerOption{Label: "Tasks", Value: "app:tasks", Description: "Active work in #" + m.activeChannel},
 			tui.PickerOption{Label: "Requests", Value: "app:requests", Description: "Human decisions and interviews"},
 			tui.PickerOption{Label: "Policies", Value: "app:policies", Description: "Signals, decisions, and watchdogs"},
@@ -171,6 +189,8 @@ func (m *channelModel) applyWorkspaceSwitcherSelection(value string) tea.Cmd {
 		switch app {
 		case officeAppRecovery:
 			return m.pollCurrentState()
+		case officeAppInbox, officeAppOutbox:
+			return pollBroker("", m.activeChannel)
 		case officeAppTasks:
 			return pollTasks(m.activeChannel)
 		case officeAppRequests:
@@ -202,18 +222,21 @@ func (m *channelModel) applyWorkspaceSwitcherSelection(value string) tea.Cmd {
 	}
 }
 
-func (m channelModel) officeFeedDescription() string {
-	if summary := strings.TrimSpace(m.currentAwaySummary()); summary != "" {
+func (m channelModel) officeFeedDescription(workspace workspaceUIState) string {
+	if summary := strings.TrimSpace(workspace.AwaySummary); summary != "" {
 		return summary
 	}
-	if req, ok := selectNeedsYouRequest(m.requests); ok {
-		return "Needs you: " + truncateText(req.TitleOrQuestion(), 64)
+	if workspace.NeedsYou != nil {
+		return "Needs you: " + truncateText(workspace.NeedsYou.TitleOrQuestion(), 64)
+	}
+	if strings.TrimSpace(workspace.Focus) != "" {
+		return truncateText(workspace.Focus, 64)
 	}
 	return "Main office feed"
 }
 
-func (m channelModel) recoverySwitcherDescription() string {
-	recovery := m.currentRuntimeSnapshot().Recovery
+func (m channelModel) recoverySwitcherDescription(workspace workspaceUIState) string {
+	recovery := workspace.Runtime.Recovery
 	if focus := trimRecoverySentence(recovery.Focus); focus != "" {
 		return truncateText(focus, 72)
 	}

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
@@ -834,7 +835,7 @@ func TestBuildCalendarLinesShowsNextRunMetadata(t *testing.T) {
 	}, nil, nil, "general", []channelMember{{Slug: "ceo", Name: "CEO"}}, calendarRangeWeek, "", 80)
 
 	rendered := stripANSI(joinRenderedLines(lines))
-	if !strings.Contains(rendered, "every 15 min") || !strings.Contains(rendered, "today") {
+	if !strings.Contains(rendered, "every 15 min") || (!strings.Contains(rendered, "today") && !strings.Contains(rendered, "tomorrow")) {
 		t.Fatalf("expected scheduler timing metadata, got %q", rendered)
 	}
 	if !strings.Contains(rendered, "#general") || !strings.Contains(rendered, "CEO") {
@@ -2128,6 +2129,62 @@ func TestOfficeViewportWindowMatchesFullRenderAndMouseHitTesting(t *testing.T) {
 	}
 	if action.Kind != "thread" || action.Value != "msg-7" {
 		t.Fatalf("expected click to open msg-7 thread, got %+v", action)
+	}
+}
+
+func TestOfficeViewportVirtualizationCachesVisibleBlocks(t *testing.T) {
+	oldRender := renderOfficeMessageBlockFn
+	defer func() { renderOfficeMessageBlockFn = oldRender }()
+
+	channelRenderCache.mu.Lock()
+	channelRenderCache.threaded = make(map[uint64][]threadedMessage)
+	channelRenderCache.blocks = make(map[uint64][]renderedLine)
+	channelRenderCache.mu.Unlock()
+
+	renderCalls := 0
+	renderOfficeMessageBlockFn = func(tm threadedMessage, contentWidth int, unreadAnchorID string, unreadCount int) []renderedLine {
+		renderCalls++
+		return renderOfficeMessageBlock(tm, contentWidth, unreadAnchorID, unreadCount)
+	}
+
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 22
+	m.activeApp = officeAppMessages
+	for i := 0; i < 120; i++ {
+		m.messages = append(m.messages, brokerMessage{
+			ID:        fmt.Sprintf("msg-%03d", i),
+			From:      "ceo",
+			Content:   fmt.Sprintf("Longer history row %03d should not force the viewport to render the full transcript before showing the tail.", i),
+			Timestamp: time.Date(2026, 4, 7, 10, i%60, 0, 0, time.UTC).Format(time.RFC3339),
+		})
+	}
+
+	layout := computeLayout(m.width, m.height, m.threadPanelOpen, m.sidebarCollapsed)
+	_, msgH, _ := m.mainPanelGeometry(layout.MainW, layout.ContentH)
+	contentWidth := layout.MainW - 2
+
+	_ = m.currentMainViewportLines(contentWidth, msgH)
+	firstRenderCalls := renderCalls
+	if firstRenderCalls == 0 {
+		t.Fatal("expected virtual viewport to render at least one visible block")
+	}
+	if firstRenderCalls >= len(m.messages) {
+		t.Fatalf("expected virtual viewport to avoid rendering the full transcript, rendered %d blocks for %d messages", firstRenderCalls, len(m.messages))
+	}
+
+	_ = m.currentMainViewportLines(contentWidth, msgH)
+	if renderCalls != firstRenderCalls {
+		t.Fatalf("expected second viewport pass to reuse cached blocks, got %d render calls after second pass vs %d initially", renderCalls, firstRenderCalls)
+	}
+
+	m.scroll = msgH
+	_ = m.currentMainViewportLines(contentWidth, msgH)
+	if renderCalls <= firstRenderCalls {
+		t.Fatalf("expected deeper scroll to render additional older blocks, got %d vs %d", renderCalls, firstRenderCalls)
+	}
+	if renderCalls >= len(m.messages) {
+		t.Fatalf("expected deep scroll to stay virtualized, rendered %d blocks for %d messages", renderCalls, len(m.messages))
 	}
 }
 

--- a/cmd/wuphf/channel_unread.go
+++ b/cmd/wuphf/channel_unread.go
@@ -13,7 +13,7 @@ func (m *channelModel) noteIncomingMessages(added []brokerMessage) {
 		m.unreadAnchorID = added[0].ID
 	}
 	m.unreadCount += len(added)
-	m.awaySummary = summarizeAwayRecovery(m.unreadCount, m.currentRuntimeSnapshot().Recovery)
+	m.awaySummary = resolveWorkspaceAwaySummary("", m.unreadCount, m.currentRuntimeSnapshot().Recovery)
 }
 
 func (m *channelModel) clearUnreadState() {

--- a/cmd/wuphf/channel_viewport_virtual.go
+++ b/cmd/wuphf/channel_viewport_virtual.go
@@ -1,0 +1,131 @@
+package main
+
+import "strings"
+
+var renderOfficeMessageBlockFn = renderOfficeMessageBlock
+
+func buildVirtualizedOfficeViewport(messages []brokerMessage, expanded map[string]bool, contentWidth, msgH, scroll int, threadsDefaultExpand bool, unreadAnchorID string, unreadCount int, tail []renderedLine) []renderedLine {
+	limit := msgH + scroll
+	if limit < 1 {
+		limit = 1
+	}
+
+	if len(messages) == 0 {
+		lines := append(buildOfficeMessageLines(messages, expanded, contentWidth, threadsDefaultExpand, unreadAnchorID, unreadCount), tail...)
+		if len(lines) > limit {
+			return cloneRenderedLines(lines[len(lines)-limit:])
+		}
+		return lines
+	}
+
+	threaded := cachedThreadedMessages(messages, expanded, threadsDefaultExpand)
+	collected := trimRenderedTail(tail, limit)
+	if len(collected) >= limit {
+		return collected
+	}
+
+	selected := make([][]renderedLine, 0, minInt(len(threaded), limit))
+	total := len(collected)
+	for i := len(threaded) - 1; i >= 0 && total < limit; i-- {
+		block := cachedThreadedMessageBlock(threaded[i], contentWidth, unreadAnchorID, unreadCount)
+		selected = append(selected, block)
+		total += len(block)
+	}
+	if total < limit {
+		selected = append(selected, cachedViewportTextBlock(contentWidth, "Today"))
+	}
+
+	out := make([]renderedLine, 0, total)
+	for i := len(selected) - 1; i >= 0; i-- {
+		out = append(out, selected[i]...)
+	}
+	out = append(out, collected...)
+	if len(out) > limit {
+		return cloneRenderedLines(out[len(out)-limit:])
+	}
+	return out
+}
+
+func cachedThreadedMessages(messages []brokerMessage, expanded map[string]bool, threadsDefaultExpand bool) []threadedMessage {
+	ensureCollapsedThreadDefaults(messages, expanded, threadsDefaultExpand)
+	h := newStateHasher()
+	h.add("threaded-messages")
+	h.addBool(threadsDefaultExpand)
+	h.addMessages(messages)
+	h.addExpandedThreads(expanded)
+	key := h.sum()
+	if cached, ok := channelRenderCache.getThreaded(key); ok {
+		return cached
+	}
+	threaded := flattenThreadMessages(messages, expanded)
+	channelRenderCache.putThreaded(key, threaded)
+	return cloneThreadedMessages(threaded)
+}
+
+func ensureCollapsedThreadDefaults(messages []brokerMessage, expanded map[string]bool, threadsDefaultExpand bool) {
+	if threadsDefaultExpand {
+		return
+	}
+	for _, msg := range messages {
+		if msg.ReplyTo != "" || !hasThreadReplies(messages, msg.ID) {
+			continue
+		}
+		if _, ok := expanded[msg.ID]; !ok {
+			expanded[msg.ID] = false
+		}
+	}
+}
+
+func cachedThreadedMessageBlock(tm threadedMessage, contentWidth int, unreadAnchorID string, unreadCount int) []renderedLine {
+	h := newStateHasher()
+	h.add("threaded-block")
+	h.addInt(contentWidth)
+	msg := tm.Message
+	h.add(msg.ID, msg.From, msg.Kind, msg.Source, msg.Title, msg.ReplyTo, msg.Timestamp, msg.Content)
+	h.add(strings.Join(msg.Tagged, ","))
+	for _, reaction := range msg.Reactions {
+		h.add(reaction.Emoji, reaction.From)
+	}
+	h.addInt(tm.Depth)
+	h.add(tm.ParentLabel)
+	h.addBool(tm.Collapsed)
+	h.addInt(tm.HiddenReplies)
+	h.add(strings.Join(tm.ThreadParticipants, ","))
+	if msg.ID == unreadAnchorID {
+		h.add(unreadAnchorID)
+		h.addInt(unreadCount)
+	}
+	key := h.sum()
+	if cached, ok := channelRenderCache.getViewportBlock(key); ok {
+		return cached
+	}
+	lines := renderOfficeMessageBlockFn(tm, contentWidth, unreadAnchorID, unreadCount)
+	channelRenderCache.putViewportBlock(key, lines)
+	return cloneRenderedLines(lines)
+}
+
+func cachedViewportTextBlock(contentWidth int, label string) []renderedLine {
+	h := newStateHasher()
+	h.add("viewport-text-block", label)
+	h.addInt(contentWidth)
+	key := h.sum()
+	if cached, ok := channelRenderCache.getViewportBlock(key); ok {
+		return cached
+	}
+	lines := []renderedLine{{Text: renderDateSeparator(contentWidth, label)}}
+	channelRenderCache.putViewportBlock(key, lines)
+	return cloneRenderedLines(lines)
+}
+
+func trimRenderedTail(lines []renderedLine, limit int) []renderedLine {
+	if len(lines) == 0 {
+		return nil
+	}
+	if limit < 1 {
+		limit = 1
+	}
+	if len(lines) <= limit {
+		return cloneRenderedLines(lines)
+	}
+	return cloneRenderedLines(lines[len(lines)-limit:])
+}

--- a/cmd/wuphf/channel_window.go
+++ b/cmd/wuphf/channel_window.go
@@ -8,7 +8,8 @@ import (
 )
 
 func (m channelModel) currentMainViewportLines(contentWidth, msgH int) []renderedLine {
-	needsYou := buildNeedsYouLines(m.requests, contentWidth)
+	workspace := m.currentWorkspaceUIState()
+	needsYou := workspace.needsYouLines(contentWidth)
 	bodyHeight := msgH
 	if len(needsYou) > 0 && bodyHeight-len(needsYou) >= 8 {
 		bodyHeight -= len(needsYou)
@@ -19,6 +20,9 @@ func (m channelModel) currentMainViewportLines(contentWidth, msgH int) []rendere
 	if m.isOneOnOne() {
 		if m.activeApp == officeAppRecovery {
 			return m.currentMainLines(contentWidth)
+		}
+		if m.activeApp == officeAppInbox || m.activeApp == officeAppOutbox {
+			return append(needsYou, m.currentMainLines(contentWidth)...)
 		}
 		if len(m.messages) == 0 {
 			return append(needsYou, m.buildDirectFeedLines(contentWidth)...)
@@ -38,7 +42,7 @@ func (m channelModel) currentMainViewportLines(contentWidth, msgH int) []rendere
 
 func buildOfficeViewportSuffix(messages []brokerMessage, expanded map[string]bool, contentWidth, msgH, scroll int, threadsDefaultExpand bool, unreadAnchorID string, unreadCount int, members []channelMember, tasks []channelTask, actions []channelAction) []renderedLine {
 	tail := buildLiveWorkLines(members, tasks, actions, contentWidth, "")
-	return buildOfficeViewportSuffixWithTail(messages, expanded, contentWidth, msgH, scroll, threadsDefaultExpand, unreadAnchorID, unreadCount, tail)
+	return buildVirtualizedOfficeViewport(messages, expanded, contentWidth, msgH, scroll, threadsDefaultExpand, unreadAnchorID, unreadCount, tail)
 }
 
 func buildOneOnOneViewportSuffix(messages []brokerMessage, actions []channelAction, tasks []channelTask, members []channelMember, expanded map[string]bool, contentWidth, msgH, scroll int, agentName, agentSlug, unreadAnchorID string, unreadCount int) []renderedLine {
@@ -56,61 +60,11 @@ func buildOneOnOneViewportSuffix(messages []brokerMessage, actions []channelActi
 		}
 		return lines
 	}
-	return buildOfficeViewportSuffixWithTail(messages, expanded, contentWidth, msgH, scroll, true, unreadAnchorID, unreadCount, tail)
-}
-
-func buildOfficeViewportSuffixWithTail(messages []brokerMessage, expanded map[string]bool, contentWidth, msgH, scroll int, threadsDefaultExpand bool, unreadAnchorID string, unreadCount int, tail []renderedLine) []renderedLine {
-	limit := msgH + scroll
-	if limit < 1 {
-		limit = 1
-	}
-
-	if len(messages) == 0 {
-		lines := append(buildOfficeMessageLines(messages, expanded, contentWidth, threadsDefaultExpand, unreadAnchorID, unreadCount), tail...)
-		if len(lines) > limit {
-			return cloneRenderedLines(lines[len(lines)-limit:])
-		}
-		return lines
-	}
-
-	threaded := officeThreadedMessages(messages, expanded, threadsDefaultExpand)
-	collected := append([]renderedLine(nil), tail...)
-	if len(collected) > limit {
-		collected = cloneRenderedLines(collected[len(collected)-limit:])
-	}
-	if len(collected) >= limit {
-		return collected
-	}
-
-	for i := len(threaded) - 1; i >= 0; i-- {
-		block := renderOfficeMessageBlock(threaded[i], contentWidth, unreadAnchorID, unreadCount)
-		if i == 0 {
-			block = append([]renderedLine{{Text: renderDateSeparator(contentWidth, "Today")}}, block...)
-		}
-		collected = prependRenderedLines(collected, block)
-		if len(collected) > limit {
-			collected = cloneRenderedLines(collected[len(collected)-limit:])
-		}
-		if len(collected) >= limit {
-			return collected
-		}
-	}
-
-	return collected
+	return buildVirtualizedOfficeViewport(messages, expanded, contentWidth, msgH, scroll, true, unreadAnchorID, unreadCount, tail)
 }
 
 func officeThreadedMessages(messages []brokerMessage, expanded map[string]bool, threadsDefaultExpand bool) []threadedMessage {
-	if !threadsDefaultExpand {
-		for _, msg := range messages {
-			if msg.ReplyTo != "" || !hasThreadReplies(messages, msg.ID) {
-				continue
-			}
-			if _, ok := expanded[msg.ID]; !ok {
-				expanded[msg.ID] = false
-			}
-		}
-	}
-	return flattenThreadMessages(messages, expanded)
+	return cachedThreadedMessages(messages, expanded, threadsDefaultExpand)
 }
 
 func renderOfficeMessageBlock(tm threadedMessage, contentWidth int, unreadAnchorID string, unreadCount int) []renderedLine {

--- a/cmd/wuphf/channel_workspace_state.go
+++ b/cmd/wuphf/channel_workspace_state.go
@@ -7,9 +7,28 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/team"
 )
 
+type workspaceReadinessLevel string
+
+const (
+	workspaceReadinessReady   workspaceReadinessLevel = "ready"
+	workspaceReadinessWarn    workspaceReadinessLevel = "warn"
+	workspaceReadinessPreview workspaceReadinessLevel = "preview"
+)
+
+type workspaceReadinessState struct {
+	Level    workspaceReadinessLevel
+	Headline string
+	Detail   string
+	NextStep string
+}
+
 type workspaceUIState struct {
+	Runtime         team.RuntimeSnapshot
+	Readiness       workspaceReadinessState
+	CurrentApp      officeApp
 	BrokerConnected bool
 	Direct          bool
 	Channel         string
@@ -32,7 +51,10 @@ type workspaceUIState struct {
 
 func (m channelModel) currentWorkspaceUIState() workspaceUIState {
 	snapshot := m.currentRuntimeSnapshot()
+	awaySummary := resolveWorkspaceAwaySummary(strings.TrimSpace(m.awaySummary), m.unreadCount, snapshot.Recovery)
 	state := workspaceUIState{
+		Runtime:         snapshot,
+		CurrentApp:      m.activeApp,
 		BrokerConnected: m.brokerConnected,
 		Direct:          m.isOneOnOne(),
 		Channel:         m.activeChannel,
@@ -43,14 +65,14 @@ func (m channelModel) currentWorkspaceUIState() workspaceUIState {
 		OpenRequests:    len(snapshot.Requests),
 		IsolatedCount:   countIsolatedRuntimeTasks(snapshot.Tasks),
 		UnreadCount:     m.unreadCount,
-		AwaySummary:     strings.TrimSpace(m.currentAwaySummary()),
+		AwaySummary:     awaySummary,
 		Focus:           trimRecoverySentence(snapshot.Recovery.Focus),
 		NoNex:           config.ResolveNoNex(),
 		APIConfigured:   strings.TrimSpace(config.ResolveAPIKey("")) != "",
 	}
 
-	for _, req := range m.requests {
-		if isOpenInterviewStatus(req.Status) && (req.Blocking || req.Required) {
+	for _, req := range snapshot.Requests {
+		if runtimeRequestIsOpen(req) && (req.Blocking || req.Required) {
 			state.BlockingCount++
 		}
 	}
@@ -77,7 +99,124 @@ func (m channelModel) currentWorkspaceUIState() workspaceUIState {
 	} else {
 		state.NextStep = "Tag a teammate, open /switcher, or use /recover to regain context."
 	}
+	state.Readiness = deriveWorkspaceReadiness(state, m.doctor)
 	return state
+}
+
+func resolveWorkspaceAwaySummary(cached string, unreadCount int, recovery team.SessionRecovery) string {
+	if unreadCount == 0 {
+		return ""
+	}
+	cached = strings.TrimSpace(cached)
+	if cached != "" {
+		return cached
+	}
+	return summarizeAwayRecovery(unreadCount, recovery)
+}
+
+func runtimeRequestIsOpen(req team.RuntimeRequest) bool {
+	status := strings.ToLower(strings.TrimSpace(req.Status))
+	return status == "" || status == "pending" || status == "open" || status == "draft"
+}
+
+func deriveWorkspaceReadiness(state workspaceUIState, doctor *channelDoctorReport) workspaceReadinessState {
+	if !state.BrokerConnected {
+		return workspaceReadinessState{
+			Level:    workspaceReadinessPreview,
+			Headline: "Offline preview",
+			Detail:   "The workspace is showing manifest-backed context, not the live tmux office runtime.",
+			NextStep: "Launch WUPHF to attach the live office, or run /doctor to inspect tmux and setup readiness.",
+		}
+	}
+	if state.NoNex {
+		return workspaceReadinessState{
+			Level:    workspaceReadinessReady,
+			Headline: "Local-only runtime",
+			Detail:   "The office is live, but Nex-backed memory and integrations are disabled for this run.",
+			NextStep: "Restart without --no-nex when you want memory, integrations, and provider-backed context.",
+		}
+	}
+	if !state.APIConfigured {
+		return workspaceReadinessState{
+			Level:    workspaceReadinessWarn,
+			Headline: "Finish setup",
+			Detail:   "The office runtime is up, but Nex-backed context and integrations are not configured yet.",
+			NextStep: "Run /init to finish API-key setup, or /doctor to inspect the remaining blockers.",
+		}
+	}
+	if doctor != nil {
+		ok, warn, fail := doctor.counts()
+		switch {
+		case fail > 0:
+			return workspaceReadinessState{
+				Level:    workspaceReadinessWarn,
+				Headline: "Runtime blocked",
+				Detail:   doctor.StatusLine(),
+				NextStep: firstDoctorNextStep(*doctor, "/doctor shows the full readiness report."),
+			}
+		case warn > 0:
+			return workspaceReadinessState{
+				Level:    workspaceReadinessWarn,
+				Headline: "Runtime has warnings",
+				Detail:   doctor.StatusLine(),
+				NextStep: firstDoctorNextStep(*doctor, fmt.Sprintf("%d checks are healthy; inspect /doctor for the warnings.", ok)),
+			}
+		}
+	}
+	if state.BlockingCount > 0 && state.NeedsYou != nil {
+		return workspaceReadinessState{
+			Level:    workspaceReadinessWarn,
+			Headline: "Waiting on you",
+			Detail:   fmt.Sprintf("The runtime is healthy, but %s is blocking the team.", state.NeedsYou.ID),
+			NextStep: fmt.Sprintf("Answer %s or open /recover before delegating more work.", state.NeedsYou.ID),
+		}
+	}
+	return workspaceReadinessState{
+		Level:    workspaceReadinessReady,
+		Headline: "Ready to work",
+		Detail:   "The live office runtime is attached and ready for collaboration.",
+		NextStep: "Use /switcher to move through the office, or /recover to regain context before replying.",
+	}
+}
+
+func firstDoctorNextStep(report channelDoctorReport, fallback string) string {
+	for _, check := range report.Checks {
+		if strings.TrimSpace(check.NextStep) == "" {
+			continue
+		}
+		if check.Severity == doctorFail || check.Severity == doctorWarn {
+			return check.NextStep
+		}
+	}
+	return fallback
+}
+
+func (s workspaceUIState) readinessCard() (title, body, accent string, extra []string) {
+	accent = "#15803D"
+	title = subtlePill("ready", "#DCFCE7", "#166534") + " " + lipgloss.NewStyle().Bold(true).Render(s.Readiness.Headline)
+	switch s.Readiness.Level {
+	case workspaceReadinessPreview:
+		accent = "#D97706"
+		title = subtlePill("preview", "#FEF3C7", "#92400E") + " " + lipgloss.NewStyle().Bold(true).Render(s.Readiness.Headline)
+	case workspaceReadinessWarn:
+		accent = "#B45309"
+		title = subtlePill("attention", "#FEF3C7", "#92400E") + " " + lipgloss.NewStyle().Bold(true).Render(s.Readiness.Headline)
+	}
+	body = s.Readiness.Detail
+	if body == "" {
+		body = "Workspace state is current."
+	}
+	if strings.TrimSpace(s.Readiness.NextStep) != "" {
+		extra = append(extra, s.Readiness.NextStep)
+	}
+	if strings.TrimSpace(s.Focus) != "" {
+		extra = append(extra, "Focus: "+s.Focus)
+	}
+	return title, body, accent, extra
+}
+
+func (s workspaceUIState) needsYouLines(contentWidth int) []renderedLine {
+	return buildNeedsYouLinesForRequest(s.NeedsYou, contentWidth)
 }
 
 func (s workspaceUIState) headerMeta() string {
@@ -92,6 +231,9 @@ func (s workspaceUIState) headerMeta() string {
 		if s.BlockingCount > 0 {
 			parts = append(parts, fmt.Sprintf("%d waiting on you", s.BlockingCount))
 		}
+		if strings.TrimSpace(s.Readiness.Headline) != "" && s.Readiness.Level != workspaceReadinessReady {
+			parts = append(parts, strings.ToLower(s.Readiness.Headline))
+		}
 		if strings.TrimSpace(s.Focus) != "" {
 			parts = append(parts, "focus: "+s.Focus)
 		}
@@ -104,6 +246,9 @@ func (s workspaceUIState) headerMeta() string {
 		fmt.Sprintf("%d teammates", s.PeerCount),
 		fmt.Sprintf("%d running", s.RunningTasks),
 		fmt.Sprintf("%d open requests", s.OpenRequests),
+	}
+	if strings.TrimSpace(s.Readiness.Headline) != "" && s.Readiness.Level != workspaceReadinessReady {
+		parts = append(parts, strings.ToLower(s.Readiness.Headline))
 	}
 	if s.BlockingCount > 0 {
 		parts = append(parts, fmt.Sprintf("%d waiting on you", s.BlockingCount))
@@ -120,6 +265,9 @@ func (s workspaceUIState) defaultStatusLine(scrollHint string) string {
 		if s.BrokerConnected {
 			label = "direct session live"
 		}
+		if s.Readiness.Level == workspaceReadinessWarn {
+			label = "direct session attention"
+		}
 		runtimeHint := "ready"
 		if strings.TrimSpace(s.Focus) != "" {
 			runtimeHint = s.Focus
@@ -133,6 +281,9 @@ func (s workspaceUIState) defaultStatusLine(scrollHint string) string {
 	}
 	if s.BlockingCount > 0 && s.NeedsYou != nil {
 		return fmt.Sprintf(" Needs you now │ %s │ /request answer %s │ /recover", truncateText(s.NeedsYou.TitleOrQuestion(), 72), s.NeedsYou.ID)
+	}
+	if s.Readiness.Level == workspaceReadinessWarn && strings.TrimSpace(s.Readiness.NextStep) != "" {
+		return fmt.Sprintf(" Attention │ %s │ %s │ /doctor", truncateText(s.Readiness.Headline, 32), truncateText(s.Readiness.NextStep, 72))
 	}
 	if strings.TrimSpace(s.AwaySummary) != "" && s.UnreadCount > 0 {
 		return fmt.Sprintf(" While away │ %s │ %s │ /recover", truncateText(s.AwaySummary, 72), scrollHint)
@@ -153,6 +304,8 @@ func (s workspaceUIState) sidebarSummaryLine(activeApp officeApp) string {
 	switch {
 	case s.BlockingCount > 0:
 		parts = append(parts, fmt.Sprintf("%d waiting", s.BlockingCount))
+	case s.Readiness.Level == workspaceReadinessWarn:
+		parts = append(parts, "attention")
 	case s.RunningTasks > 0:
 		parts = append(parts, fmt.Sprintf("%d running", s.RunningTasks))
 	case s.OpenRequests > 0:
@@ -166,9 +319,11 @@ func (s workspaceUIState) sidebarSummaryLine(activeApp officeApp) string {
 func (s workspaceUIState) sidebarHintLine() string {
 	switch {
 	case !s.BrokerConnected:
-		return "/doctor explains tmux, provider, and setup readiness"
+		return s.Readiness.NextStep
 	case s.BlockingCount > 0 && s.NeedsYou != nil:
 		return fmt.Sprintf("Need you: %s · /request answer %s", s.NeedsYou.TitleOrQuestion(), s.NeedsYou.ID)
+	case s.Readiness.Level == workspaceReadinessWarn && strings.TrimSpace(s.Readiness.NextStep) != "":
+		return s.Readiness.NextStep
 	case strings.TrimSpace(s.AwaySummary) != "" && s.UnreadCount > 0:
 		return "While away: " + s.AwaySummary
 	case !s.NoNex && !s.APIConfigured:
@@ -225,29 +380,16 @@ func (m channelModel) buildOfficeIntroLines(contentWidth int) []renderedLine {
 		lines = append(lines, renderedLine{Text: "  " + line})
 	}
 
-	readinessBody := "The office is live and ready for real collaboration."
-	readinessAccent := "#15803D"
-	readinessTitle := subtlePill("ready", "#DCFCE7", "#166534") + " " + lipgloss.NewStyle().Bold(true).Render("Ready to work")
-	readinessExtra := []string{"Use /switcher to jump anywhere in the office."}
-	if !state.BrokerConnected {
-		readinessAccent = "#D97706"
-		readinessTitle = subtlePill("preview", "#FEF3C7", "#92400E") + " " + lipgloss.NewStyle().Bold(true).Render("Offline preview")
-		readinessBody = "You are looking at the manifest roster, not the live tmux-backed office."
-		readinessExtra = []string{"Launch WUPHF to connect the live office runtime.", "/doctor shows tmux, provider, and setup readiness."}
-	} else if state.NoNex {
+	readinessTitle, readinessBody, readinessAccent, readinessExtra := state.readinessCard()
+	if state.NoNex && state.BrokerConnected {
 		readinessExtra = append(readinessExtra, "Nex is disabled for this run; memory and integrations are local-only.")
-	} else if !state.APIConfigured {
-		readinessAccent = "#B45309"
-		readinessTitle = subtlePill("setup", "#FEF3C7", "#92400E") + " " + lipgloss.NewStyle().Bold(true).Render("Finish setup")
-		readinessBody = "The office is up, but Nex-backed memory and integrations are not configured yet."
-		readinessExtra = []string{"Run /init to finish API-key setup.", "/doctor explains what is still missing."}
 	}
 	for _, line := range renderRuntimeEventCard(contentWidth, readinessTitle, readinessBody, readinessAccent, readinessExtra) {
 		lines = append(lines, renderedLine{Text: "  " + line})
 	}
 
 	if state.NeedsYou != nil {
-		for _, line := range buildNeedsYouLines(m.requests, contentWidth) {
+		for _, line := range state.needsYouLines(contentWidth) {
 			lines = append(lines, line)
 		}
 	} else {
@@ -278,7 +420,8 @@ func (m channelModel) buildDirectIntroLines(contentWidth int) []renderedLine {
 	}
 
 	if !state.BrokerConnected {
-		for _, line := range renderRuntimeEventCard(contentWidth, subtlePill("preview", "#FEF3C7", "#92400E")+" "+lipgloss.NewStyle().Bold(true).Render("Direct preview only"), "The runtime is not attached yet, so this pane is a local preview of the direct session.", "#D97706", []string{"/doctor explains readiness.", "Launch WUPHF without stale tmux state to resume the live session."}) {
+		readinessTitle, readinessBody, readinessAccent, readinessExtra := state.readinessCard()
+		for _, line := range renderRuntimeEventCard(contentWidth, readinessTitle, readinessBody, readinessAccent, readinessExtra) {
 			lines = append(lines, renderedLine{Text: "  " + line})
 		}
 	} else {

--- a/cmd/wuphf/channel_workspace_state_test.go
+++ b/cmd/wuphf/channel_workspace_state_test.go
@@ -21,7 +21,7 @@ func TestBuildOfficeIntroLinesUsesWorkspaceState(t *testing.T) {
 	if !strings.Contains(plain, "Ready to work") {
 		t.Fatalf("expected ready-to-work card, got %q", plain)
 	}
-	if !strings.Contains(plain, "Use /switcher to jump anywhere in the office.") {
+	if !strings.Contains(plain, "Use /switcher to move through the office, or /recover to regain context before replying.") {
 		t.Fatalf("expected switcher guidance, got %q", plain)
 	}
 }
@@ -36,7 +36,7 @@ func TestBuildOfficeIntroLinesShowsOfflinePreviewGuidance(t *testing.T) {
 	if !strings.Contains(plain, "Offline preview") {
 		t.Fatalf("expected offline preview messaging, got %q", plain)
 	}
-	if !strings.Contains(plain, "/doctor shows tmux, provider, and setup readiness.") {
+	if !strings.Contains(plain, "Launch WUPHF to attach the live office, or run /doctor to inspect tmux and setup readiness.") {
 		t.Fatalf("expected doctor guidance, got %q", plain)
 	}
 }
@@ -72,5 +72,29 @@ func TestCurrentHeaderMetaUsesWorkspaceStateForOfficeMessages(t *testing.T) {
 	}
 	if !strings.Contains(meta, "1 waiting on you") {
 		t.Fatalf("expected blocking request count in header meta, got %q", meta)
+	}
+}
+
+func TestCurrentWorkspaceUIStatePromotesDoctorWarningsIntoReadiness(t *testing.T) {
+	m := newChannelModel(false)
+	m.brokerConnected = true
+	m.activeChannel = "general"
+	m.doctor = &channelDoctorReport{
+		Checks: []doctorCheck{
+			{
+				Label:    "Connected accounts",
+				Severity: doctorWarn,
+				Detail:   "No accounts connected.",
+				NextStep: "Connect Gmail, CRM, or another account in the provider dashboard.",
+			},
+		},
+	}
+
+	state := m.currentWorkspaceUIState()
+	if state.Readiness.Level != workspaceReadinessWarn {
+		t.Fatalf("expected warning readiness, got %+v", state.Readiness)
+	}
+	if !strings.Contains(state.Readiness.NextStep, "Connect Gmail, CRM") {
+		t.Fatalf("expected doctor next step to flow into readiness, got %+v", state.Readiness)
 	}
 }

--- a/internal/team/capabilities.go
+++ b/internal/team/capabilities.go
@@ -6,9 +6,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-
-	"github.com/nex-crm/wuphf/internal/action"
-	"github.com/nex-crm/wuphf/internal/config"
 )
 
 type CapabilityLevel string
@@ -20,10 +17,11 @@ const (
 )
 
 type CapabilityStatus struct {
-	Name     string
-	Level    CapabilityLevel
-	Detail   string
-	NextStep string
+	Name      string
+	Level     CapabilityLevel
+	Lifecycle CapabilityLifecycle
+	Detail    string
+	NextStep  string
 }
 
 type TmuxSessionStatus struct {
@@ -45,25 +43,41 @@ type TmuxCapability struct {
 }
 
 type RuntimeCapabilities struct {
-	Tmux  TmuxCapability
-	Items []CapabilityStatus
+	Tmux     TmuxCapability
+	Items    []CapabilityStatus
+	Registry CapabilityRegistry
 }
 
 var lookPathFn = exec.LookPath
 var commandCombinedOutputFn = func(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).CombinedOutput()
 }
-var actionProviderProbe = detectActionProvider
 
 func DetectRuntimeCapabilities() RuntimeCapabilities {
+	return DetectRuntimeCapabilitiesWithOptions(CapabilityProbeOptions{})
+}
+
+func DetectRuntimeCapabilitiesWithOptions(opts CapabilityProbeOptions) RuntimeCapabilities {
 	tmuxStatus, tmux := probeTmuxCapability()
-	items := []CapabilityStatus{
-		tmuxStatus,
-		probeBinaryCapability("claude", "Needed for teammate runtime sessions."),
-		probeNexCapability(),
-		probeActionCapability(),
+	claudeStatus := probeBinaryCapability("claude", "Install claude so WUPHF can start teammate runtime sessions.")
+	registry := buildCapabilityRegistry(tmuxStatus, claudeStatus, opts)
+	summaryKeys := []string{
+		CapabilityKeyOfficeRuntime,
+		CapabilityKeyDirectRuntime,
+		CapabilityKeyNex,
+		CapabilityKeyActions,
+		CapabilityKeyWorkflows,
+		CapabilityKeyOfficeActions,
+		CapabilityKeyDirectActions,
 	}
-	return RuntimeCapabilities{Tmux: tmux, Items: items}
+	if opts.IncludeConnections {
+		summaryKeys = append(summaryKeys[:4], append([]string{CapabilityKeyConnections}, summaryKeys[4:]...)...)
+	}
+	return RuntimeCapabilities{
+		Tmux:     tmux,
+		Items:    registry.SummaryStatuses(summaryKeys...),
+		Registry: registry,
+	}
 }
 
 func (c RuntimeCapabilities) Counts() (ready, warn, info int) {
@@ -282,62 +296,4 @@ func yesNo(v bool) string {
 		return "yes"
 	}
 	return "no"
-}
-
-func probeNexCapability() CapabilityStatus {
-	if config.ResolveNoNex() {
-		return CapabilityStatus{
-			Name:     "nex",
-			Level:    CapabilityInfo,
-			Detail:   "Disabled for this session with --no-nex.",
-			NextStep: "Restart without --no-nex to enable memory, integrations, and provider-backed actions.",
-		}
-	}
-	if apiKey := strings.TrimSpace(config.ResolveAPIKey("")); apiKey == "" {
-		return CapabilityStatus{
-			Name:     "nex",
-			Level:    CapabilityWarn,
-			Detail:   "Missing WUPHF/Nex API key.",
-			NextStep: "Run /init and save your WUPHF API key.",
-		}
-	}
-	email := strings.TrimSpace(config.ResolveComposioUserID())
-	if email == "" {
-		return CapabilityStatus{
-			Name:     "nex",
-			Level:    CapabilityWarn,
-			Detail:   "API key is configured, but workspace identity is missing.",
-			NextStep: "Finish /init so WUPHF can scope integrations to your Nex email.",
-		}
-	}
-	return CapabilityStatus{
-		Name:   "nex",
-		Level:  CapabilityReady,
-		Detail: fmt.Sprintf("Configured with workspace identity %s.", email),
-	}
-}
-
-func probeActionCapability() CapabilityStatus {
-	name, err := actionProviderProbe()
-	if err != nil {
-		return CapabilityStatus{
-			Name:     "actions",
-			Level:    CapabilityWarn,
-			Detail:   err.Error(),
-			NextStep: "Configure an external action provider or switch WUPHF to a working provider.",
-		}
-	}
-	return CapabilityStatus{
-		Name:   "actions",
-		Level:  CapabilityReady,
-		Detail: fmt.Sprintf("External actions available through %s.", name),
-	}
-}
-
-func detectActionProvider() (string, error) {
-	provider, err := action.NewRegistryFromEnv().ProviderFor(action.CapabilityConnections)
-	if err != nil {
-		return "", err
-	}
-	return provider.Name(), nil
 }

--- a/internal/team/capability_registry.go
+++ b/internal/team/capability_registry.go
@@ -1,0 +1,399 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/action"
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+type CapabilityLifecycle string
+
+const (
+	CapabilityLifecycleReady        CapabilityLifecycle = "ready"
+	CapabilityLifecycleNeedsSetup   CapabilityLifecycle = "needs_setup"
+	CapabilityLifecycleDisabled     CapabilityLifecycle = "disabled"
+	CapabilityLifecycleDeferred     CapabilityLifecycle = "deferred"
+	CapabilityLifecyclePartial      CapabilityLifecycle = "partial"
+	CapabilityLifecycleProvisioning CapabilityLifecycle = "provisioning"
+)
+
+type CapabilityCategory string
+
+const (
+	CapabilityCategoryRuntime  CapabilityCategory = "runtime"
+	CapabilityCategoryMemory   CapabilityCategory = "memory"
+	CapabilityCategoryAction   CapabilityCategory = "action"
+	CapabilityCategoryWorkflow CapabilityCategory = "workflow"
+	CapabilityCategoryOffice   CapabilityCategory = "office"
+	CapabilityCategoryDirect   CapabilityCategory = "direct"
+)
+
+const (
+	CapabilityKeyTmux          = "tmux"
+	CapabilityKeyClaude        = "claude"
+	CapabilityKeyOfficeRuntime = "office_runtime"
+	CapabilityKeyDirectRuntime = "direct_runtime"
+	CapabilityKeyNex           = "nex"
+	CapabilityKeyConnections   = "connections"
+	CapabilityKeyActions       = "actions"
+	CapabilityKeyWorkflows     = "workflows"
+	CapabilityKeyOfficeActions = "office_actions"
+	CapabilityKeyDirectActions = "direct_actions"
+)
+
+type CapabilityProbeOptions struct {
+	IncludeConnections bool
+	ConnectionLimit    int
+	ConnectionTimeout  time.Duration
+}
+
+type CapabilityDescriptor struct {
+	Key       string
+	Label     string
+	Category  CapabilityCategory
+	Level     CapabilityLevel
+	Lifecycle CapabilityLifecycle
+	Detail    string
+	NextStep  string
+}
+
+type CapabilityRegistry struct {
+	Entries []CapabilityDescriptor
+}
+
+var actionProvidersFn = func() []action.Provider {
+	return []action.Provider{
+		action.NewComposioFromEnv(),
+		action.NewOneCLIFromEnv(),
+	}
+}
+
+var actionProviderForCapabilityFn = func(cap action.Capability) (action.Provider, error) {
+	return action.NewRegistryFromEnv().ProviderFor(cap)
+}
+
+var actionConnectionsProbeFn = func(ctx context.Context, provider action.Provider, opts action.ListConnectionsOptions) (action.ConnectionsResult, error) {
+	return provider.ListConnections(ctx, opts)
+}
+
+func (r CapabilityRegistry) Entry(key string) (CapabilityDescriptor, bool) {
+	key = strings.TrimSpace(key)
+	for _, entry := range r.Entries {
+		if strings.EqualFold(strings.TrimSpace(entry.Key), key) {
+			return entry, true
+		}
+	}
+	return CapabilityDescriptor{}, false
+}
+
+func (r CapabilityRegistry) SummaryStatuses(keys ...string) []CapabilityStatus {
+	if len(keys) == 0 {
+		keys = make([]string, 0, len(r.Entries))
+		for _, entry := range r.Entries {
+			keys = append(keys, entry.Key)
+		}
+	}
+	statuses := make([]CapabilityStatus, 0, len(keys))
+	for _, key := range keys {
+		entry, ok := r.Entry(key)
+		if !ok {
+			continue
+		}
+		statuses = append(statuses, CapabilityStatus{
+			Name:      entry.Label,
+			Level:     entry.Level,
+			Lifecycle: entry.Lifecycle,
+			Detail:    entry.Detail,
+			NextStep:  entry.NextStep,
+		})
+	}
+	return statuses
+}
+
+func BuildCapabilityRegistry(runtime RuntimeCapabilities) CapabilityRegistry {
+	if len(runtime.Registry.Entries) > 0 {
+		return runtime.Registry
+	}
+	return buildCapabilityRegistry(runtimeCapabilityStatus(runtime, "tmux"), runtimeCapabilityStatus(runtime, "claude"), CapabilityProbeOptions{})
+}
+
+func buildCapabilityRegistry(tmuxStatus, claudeStatus CapabilityStatus, opts CapabilityProbeOptions) CapabilityRegistry {
+	entries := []CapabilityDescriptor{
+		buildOfficeRuntimeDescriptor(tmuxStatus, claudeStatus),
+		buildDirectRuntimeDescriptor(claudeStatus),
+		descriptorFromStatus(CapabilityKeyTmux, "tmux", CapabilityCategoryRuntime, tmuxStatus),
+		descriptorFromStatus(CapabilityKeyClaude, "claude", CapabilityCategoryRuntime, claudeStatus),
+		buildNexDescriptor(),
+		buildActionCapabilityDescriptor(CapabilityKeyActions, "Action execution", CapabilityCategoryAction, action.CapabilityActionExecute),
+		buildActionCapabilityDescriptor(CapabilityKeyWorkflows, "Workflow execution", CapabilityCategoryWorkflow, action.CapabilityWorkflowExecute),
+		buildActionCapabilityDescriptor(CapabilityKeyOfficeActions, "Office actions", CapabilityCategoryOffice, action.CapabilityActionExecute),
+		buildActionCapabilityDescriptor(CapabilityKeyDirectActions, "Direct actions", CapabilityCategoryDirect, action.CapabilityActionExecute),
+	}
+	if opts.IncludeConnections {
+		entries = append(entries, buildConnectionsDescriptor(opts))
+	}
+	return CapabilityRegistry{Entries: entries}
+}
+
+func ResolveActionProviderForCapability(cap action.Capability) (action.Provider, error) {
+	return actionProviderForCapabilityFn(cap)
+}
+
+func RegistryKeyForActionCapability(cap action.Capability) string {
+	switch cap {
+	case action.CapabilityConnections:
+		return CapabilityKeyConnections
+	case action.CapabilityWorkflowExecute, action.CapabilityWorkflowRuns, action.CapabilityWorkflowCreate:
+		return CapabilityKeyWorkflows
+	default:
+		return CapabilityKeyActions
+	}
+}
+
+func buildOfficeRuntimeDescriptor(tmuxStatus, claudeStatus CapabilityStatus) CapabilityDescriptor {
+	level := CapabilityReady
+	lifecycle := CapabilityLifecycleReady
+	nextStep := ""
+	if tmuxStatus.Level != CapabilityReady || claudeStatus.Level != CapabilityReady {
+		level = CapabilityWarn
+		lifecycle = CapabilityLifecycleNeedsSetup
+		nextStep = firstNonEmpty(tmuxStatus.NextStep, claudeStatus.NextStep)
+	}
+	return CapabilityDescriptor{
+		Key:       CapabilityKeyOfficeRuntime,
+		Label:     "Office runtime",
+		Category:  CapabilityCategoryOffice,
+		Level:     level,
+		Lifecycle: lifecycle,
+		Detail:    strings.TrimSpace(strings.Join(compactStrings([]string{tmuxStatus.Detail, claudeStatus.Detail}), " ")),
+		NextStep:  nextStep,
+	}
+}
+
+func buildDirectRuntimeDescriptor(claudeStatus CapabilityStatus) CapabilityDescriptor {
+	level := claudeStatus.Level
+	lifecycle := CapabilityLifecycleReady
+	if level != CapabilityReady {
+		lifecycle = CapabilityLifecycleNeedsSetup
+	}
+	return CapabilityDescriptor{
+		Key:       CapabilityKeyDirectRuntime,
+		Label:     "Direct runtime",
+		Category:  CapabilityCategoryDirect,
+		Level:     level,
+		Lifecycle: lifecycle,
+		Detail:    claudeStatus.Detail,
+		NextStep:  claudeStatus.NextStep,
+	}
+}
+
+func buildNexDescriptor() CapabilityDescriptor {
+	if config.ResolveNoNex() {
+		return CapabilityDescriptor{
+			Key:       CapabilityKeyNex,
+			Label:     "Nex memory",
+			Category:  CapabilityCategoryMemory,
+			Level:     CapabilityInfo,
+			Lifecycle: CapabilityLifecycleDisabled,
+			Detail:    "Disabled for this session with --no-nex.",
+			NextStep:  "Restart without --no-nex to enable organizational context and memory.",
+		}
+	}
+	if strings.TrimSpace(config.ResolveAPIKey("")) == "" {
+		return CapabilityDescriptor{
+			Key:       CapabilityKeyNex,
+			Label:     "Nex memory",
+			Category:  CapabilityCategoryMemory,
+			Level:     CapabilityWarn,
+			Lifecycle: CapabilityLifecycleNeedsSetup,
+			Detail:    "No WUPHF/Nex API key is configured.",
+			NextStep:  "Run /init or set WUPHF_API_KEY to enable Nex-backed context.",
+		}
+	}
+	return CapabilityDescriptor{
+		Key:       CapabilityKeyNex,
+		Label:     "Nex memory",
+		Category:  CapabilityCategoryMemory,
+		Level:     CapabilityReady,
+		Lifecycle: CapabilityLifecycleReady,
+		Detail:    "Nex-backed organizational context is configured.",
+	}
+}
+
+func buildActionCapabilityDescriptor(key, label string, category CapabilityCategory, cap action.Capability) CapabilityDescriptor {
+	if config.ResolveNoNex() {
+		return CapabilityDescriptor{
+			Key:       key,
+			Label:     label,
+			Category:  category,
+			Level:     CapabilityInfo,
+			Lifecycle: CapabilityLifecycleDisabled,
+			Detail:    "Disabled for this session with --no-nex.",
+			NextStep:  "Restart without --no-nex to enable provider-backed actions.",
+		}
+	}
+	provider, err := ResolveActionProviderForCapability(cap)
+	if err != nil {
+		return CapabilityDescriptor{
+			Key:       key,
+			Label:     label,
+			Category:  category,
+			Level:     CapabilityWarn,
+			Lifecycle: CapabilityLifecycleNeedsSetup,
+			Detail:    err.Error(),
+			NextStep:  "Configure a supported action provider or connect the required account.",
+		}
+	}
+	return CapabilityDescriptor{
+		Key:       key,
+		Label:     label,
+		Category:  category,
+		Level:     CapabilityReady,
+		Lifecycle: CapabilityLifecycleReady,
+		Detail:    fmt.Sprintf("%s is available via %s.", label, provider.Name()),
+	}
+}
+
+func buildConnectionsDescriptor(opts CapabilityProbeOptions) CapabilityDescriptor {
+	if config.ResolveNoNex() {
+		return CapabilityDescriptor{
+			Key:       CapabilityKeyConnections,
+			Label:     "Connected accounts",
+			Category:  CapabilityCategoryAction,
+			Level:     CapabilityInfo,
+			Lifecycle: CapabilityLifecycleDisabled,
+			Detail:    "Disabled for this session with --no-nex.",
+			NextStep:  "Restart without --no-nex to enable live connected accounts.",
+		}
+	}
+	provider, err := ResolveActionProviderForCapability(action.CapabilityConnections)
+	if err != nil {
+		return CapabilityDescriptor{
+			Key:       CapabilityKeyConnections,
+			Label:     "Connected accounts",
+			Category:  CapabilityCategoryAction,
+			Level:     CapabilityWarn,
+			Lifecycle: CapabilityLifecycleNeedsSetup,
+			Detail:    err.Error(),
+			NextStep:  "Configure an action provider and connect an account.",
+		}
+	}
+
+	timeout := opts.ConnectionTimeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+	limit := opts.ConnectionLimit
+	if limit <= 0 {
+		limit = 5
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	result, err := actionConnectionsProbeFn(ctx, provider, action.ListConnectionsOptions{Limit: limit})
+	if err != nil {
+		return CapabilityDescriptor{
+			Key:       CapabilityKeyConnections,
+			Label:     "Connected accounts",
+			Category:  CapabilityCategoryAction,
+			Level:     CapabilityWarn,
+			Lifecycle: CapabilityLifecycleProvisioning,
+			Detail:    err.Error(),
+			NextStep:  "Reconnect the action provider and rerun /doctor.",
+		}
+	}
+	if len(result.Connections) == 0 {
+		return CapabilityDescriptor{
+			Key:       CapabilityKeyConnections,
+			Label:     "Connected accounts",
+			Category:  CapabilityCategoryAction,
+			Level:     CapabilityWarn,
+			Lifecycle: CapabilityLifecycleNeedsSetup,
+			Detail:    fmt.Sprintf("%s is configured, but no connected accounts are available.", provider.Name()),
+			NextStep:  "Connect Gmail, CRM, or another provider-backed account.",
+		}
+	}
+	return CapabilityDescriptor{
+		Key:       CapabilityKeyConnections,
+		Label:     "Connected accounts",
+		Category:  CapabilityCategoryAction,
+		Level:     CapabilityReady,
+		Lifecycle: CapabilityLifecycleReady,
+		Detail:    fmt.Sprintf("%d account%s ready through %s.", len(result.Connections), capabilityPluralSuffix(len(result.Connections)), provider.Name()),
+	}
+}
+
+func capabilityKey(name string) string {
+	name = strings.TrimSpace(strings.ToLower(name))
+	name = strings.ReplaceAll(name, " ", "_")
+	return name
+}
+
+func descriptorFromStatus(key, label string, category CapabilityCategory, status CapabilityStatus) CapabilityDescriptor {
+	lifecycle := status.Lifecycle
+	if lifecycle == "" {
+		switch status.Level {
+		case CapabilityReady:
+			lifecycle = CapabilityLifecycleReady
+		case CapabilityWarn:
+			lifecycle = CapabilityLifecycleNeedsSetup
+		default:
+			lifecycle = CapabilityLifecycleProvisioning
+		}
+	}
+	return CapabilityDescriptor{
+		Key:       key,
+		Label:     label,
+		Category:  category,
+		Level:     status.Level,
+		Lifecycle: lifecycle,
+		Detail:    status.Detail,
+		NextStep:  status.NextStep,
+	}
+}
+
+func runtimeCapabilityStatus(runtime RuntimeCapabilities, name string) CapabilityStatus {
+	name = strings.TrimSpace(strings.ToLower(name))
+	if name == "tmux" && runtime.Tmux.hasData() {
+		status := runtime.Tmux.status()
+		if strings.TrimSpace(status.Name) == "" {
+			status.Name = "tmux"
+		}
+		return status
+	}
+	for _, item := range runtime.Items {
+		if strings.EqualFold(strings.TrimSpace(item.Name), name) {
+			return item
+		}
+	}
+	return CapabilityStatus{Name: name, Level: CapabilityInfo}
+}
+
+func compactStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func capabilityPluralSuffix(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}

--- a/internal/team/capability_registry_test.go
+++ b/internal/team/capability_registry_test.go
@@ -1,0 +1,40 @@
+package team
+
+import "testing"
+
+func TestBuildCapabilityRegistryIncludesRuntimeAndWorkflowEntries(t *testing.T) {
+	registry := BuildCapabilityRegistry(RuntimeCapabilities{
+		Items: []CapabilityStatus{{
+			Name:   "tmux",
+			Level:  CapabilityReady,
+			Detail: "tmux is installed.",
+		}},
+	})
+
+	if len(registry.Entries) == 0 {
+		t.Fatal("expected capability registry entries")
+	}
+
+	foundRuntime := false
+	foundWorkflow := false
+	for _, item := range registry.Entries {
+		switch item.Key {
+		case "tmux":
+			foundRuntime = true
+			if item.Category != CapabilityCategoryRuntime {
+				t.Fatalf("expected tmux to be runtime category, got %+v", item)
+			}
+		case "workflows":
+			foundWorkflow = true
+			if item.Category != CapabilityCategoryWorkflow {
+				t.Fatalf("expected workflows to be workflow category, got %+v", item)
+			}
+		}
+	}
+	if !foundRuntime {
+		t.Fatalf("expected tmux entry in registry, got %+v", registry.Entries)
+	}
+	if !foundWorkflow {
+		t.Fatalf("expected workflow entry in registry, got %+v", registry.Entries)
+	}
+}

--- a/internal/team/runtime_artifacts.go
+++ b/internal/team/runtime_artifacts.go
@@ -1,0 +1,67 @@
+package team
+
+import "strings"
+
+type RuntimeArtifactKind string
+
+const (
+	RuntimeArtifactTask           RuntimeArtifactKind = "task"
+	RuntimeArtifactTaskLog        RuntimeArtifactKind = "task_log"
+	RuntimeArtifactWorkflowRun    RuntimeArtifactKind = "workflow_run"
+	RuntimeArtifactRequest        RuntimeArtifactKind = "request"
+	RuntimeArtifactHumanAction    RuntimeArtifactKind = "human_action"
+	RuntimeArtifactExternalAction RuntimeArtifactKind = "external_action"
+)
+
+type RuntimeArtifact struct {
+	ID            string
+	Kind          RuntimeArtifactKind
+	Title         string
+	Summary       string
+	State         string
+	Progress      string
+	Owner         string
+	Channel       string
+	RelatedID     string
+	StartedAt     string
+	UpdatedAt     string
+	Path          string
+	Worktree      string
+	PartialOutput string
+	ResumeHint    string
+	ReviewHint    string
+	Blocking      bool
+}
+
+func (a RuntimeArtifact) EffectiveTitle() string {
+	title := strings.TrimSpace(a.Title)
+	if title != "" {
+		return title
+	}
+	if id := strings.TrimSpace(a.ID); id != "" {
+		return id
+	}
+	return "artifact"
+}
+
+func (a RuntimeArtifact) EffectiveSummary() string {
+	summary := strings.TrimSpace(a.Summary)
+	if summary != "" {
+		return summary
+	}
+	if progress := strings.TrimSpace(a.Progress); progress != "" {
+		return progress
+	}
+	if state := strings.TrimSpace(a.State); state != "" {
+		return strings.ReplaceAll(state, "_", " ")
+	}
+	return "No summary yet."
+}
+
+func (a RuntimeArtifact) EffectiveProgress() string {
+	progress := strings.TrimSpace(a.Progress)
+	if progress != "" {
+		return progress
+	}
+	return strings.ReplaceAll(strings.TrimSpace(a.State), "_", " ")
+}

--- a/internal/team/runtime_state.go
+++ b/internal/team/runtime_state.go
@@ -49,7 +49,10 @@ type RuntimeSnapshot struct {
 	Tasks        []RuntimeTask
 	Requests     []RuntimeRequest
 	Recent       []RuntimeMessage
+	Artifacts    []RuntimeArtifact
 	Capabilities RuntimeCapabilities
+	Registry     CapabilityRegistry
+	Memory       SessionMemorySnapshot
 	Recovery     SessionRecovery
 }
 
@@ -60,7 +63,9 @@ type RuntimeSnapshotInput struct {
 	Tasks        []RuntimeTask
 	Requests     []RuntimeRequest
 	Recent       []RuntimeMessage
+	Artifacts    []RuntimeArtifact
 	Capabilities RuntimeCapabilities
+	Registry     CapabilityRegistry
 	Now          time.Time
 }
 
@@ -82,9 +87,15 @@ func BuildRuntimeSnapshot(input RuntimeSnapshotInput) RuntimeSnapshot {
 		Tasks:        append([]RuntimeTask(nil), input.Tasks...),
 		Requests:     append([]RuntimeRequest(nil), input.Requests...),
 		Recent:       append([]RuntimeMessage(nil), input.Recent...),
+		Artifacts:    append([]RuntimeArtifact(nil), input.Artifacts...),
 		Capabilities: input.Capabilities,
+		Registry:     input.Registry,
 	}
-	snapshot.Recovery = BuildSessionRecovery(sessionMode, directAgent, snapshot.Tasks, snapshot.Requests, snapshot.Recent)
+	if len(snapshot.Registry.Entries) == 0 {
+		snapshot.Registry = BuildCapabilityRegistry(snapshot.Capabilities)
+	}
+	snapshot.Memory = BuildSessionMemorySnapshot(sessionMode, directAgent, snapshot.Tasks, snapshot.Requests, snapshot.Recent)
+	snapshot.Recovery = snapshot.Memory.ToRecovery()
 	return snapshot
 }
 
@@ -107,6 +118,9 @@ func (s RuntimeSnapshot) FormatText() string {
 		fmt.Sprintf("- Isolated worktrees: %d", s.isolatedTaskCount()),
 		fmt.Sprintf("- Pending human requests: %d", s.pendingRequestCount()),
 	)
+	if len(s.Artifacts) > 0 {
+		lines = append(lines, fmt.Sprintf("- Retained execution artifacts: %d", len(s.Artifacts)))
+	}
 
 	if focus := strings.TrimSpace(s.Recovery.Focus); focus != "" {
 		lines = append(lines, fmt.Sprintf("- Current focus: %s", focus))
@@ -126,6 +140,20 @@ func (s RuntimeSnapshot) FormatText() string {
 		}
 	}
 
+	if len(s.Artifacts) > 0 {
+		lines = append(lines, "", "Execution artifacts:")
+		for _, artifact := range firstRuntimeArtifacts(s.Artifacts, 4) {
+			line := fmt.Sprintf("- %s [%s]", artifact.EffectiveTitle(), artifact.Kind)
+			if state := strings.TrimSpace(artifact.State); state != "" {
+				line += " " + strings.ReplaceAll(state, "_", " ")
+			}
+			if summary := strings.TrimSpace(artifact.Summary); summary != "" {
+				line += ": " + summary
+			}
+			lines = append(lines, line)
+		}
+	}
+
 	if tmuxLines := s.Capabilities.Tmux.FormatLines(); len(tmuxLines) > 0 {
 		lines = append(lines, "", "Tmux runtime:")
 		lines = append(lines, tmuxLines...)
@@ -135,6 +163,17 @@ func (s RuntimeSnapshot) FormatText() string {
 		lines = append(lines, "", "Runtime capabilities:")
 		for _, item := range s.Capabilities.Items {
 			line := fmt.Sprintf("- %s [%s]: %s", item.Name, item.Level, item.Detail)
+			if next := strings.TrimSpace(item.NextStep); next != "" {
+				line += " Next: " + next
+			}
+			lines = append(lines, line)
+		}
+	}
+
+	if len(s.Registry.Entries) > 0 {
+		lines = append(lines, "", "Capability registry:")
+		for _, item := range s.Registry.Entries {
+			line := fmt.Sprintf("- %s (%s) [%s]: %s", item.Label, item.Category, item.Level, item.Detail)
 			if next := strings.TrimSpace(item.NextStep); next != "" {
 				line += " Next: " + next
 			}
@@ -190,4 +229,11 @@ func runtimeTaskUsesIsolation(task RuntimeTask) bool {
 	return strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") ||
 		strings.TrimSpace(task.WorktreePath) != "" ||
 		strings.TrimSpace(task.WorktreeBranch) != ""
+}
+
+func firstRuntimeArtifacts(artifacts []RuntimeArtifact, limit int) []RuntimeArtifact {
+	if limit <= 0 || len(artifacts) <= limit {
+		return append([]RuntimeArtifact(nil), artifacts...)
+	}
+	return append([]RuntimeArtifact(nil), artifacts[:limit]...)
 }

--- a/internal/team/runtime_state_test.go
+++ b/internal/team/runtime_state_test.go
@@ -5,16 +5,20 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/nex-crm/wuphf/internal/action"
 )
 
 func TestDetectRuntimeCapabilities(t *testing.T) {
 	oldLookPath := lookPathFn
 	oldCommandOutput := commandCombinedOutputFn
-	oldActionProbe := actionProviderProbe
+	oldActionProviderForCapability := actionProviderForCapabilityFn
+	oldActionProviders := actionProvidersFn
 	defer func() {
 		lookPathFn = oldLookPath
 		commandCombinedOutputFn = oldCommandOutput
-		actionProviderProbe = oldActionProbe
+		actionProviderForCapabilityFn = oldActionProviderForCapability
+		actionProvidersFn = oldActionProviders
 	}()
 
 	lookPathFn = func(name string) (string, error) {
@@ -39,18 +43,15 @@ func TestDetectRuntimeCapabilities(t *testing.T) {
 		}
 		return nil, errors.New("unexpected tmux probe")
 	}
-	actionProviderProbe = func() (string, error) {
-		return "", errors.New("no configured provider available")
+	actionProviderForCapabilityFn = func(action.Capability) (action.Provider, error) {
+		return nil, errors.New("no configured provider available")
 	}
+	actionProvidersFn = func() []action.Provider { return nil }
 
 	t.Setenv("TMUX", "/tmp/tmux-1000/default,123,0")
 	t.Setenv("WUPHF_NO_NEX", "1")
 
 	got := DetectRuntimeCapabilities()
-	ready, warn, info := got.Counts()
-	if ready != 2 || warn != 1 || info != 1 {
-		t.Fatalf("unexpected capability counts: ready=%d warn=%d info=%d", ready, warn, info)
-	}
 	if got.Tmux.BinaryPath != "/usr/bin/tmux" {
 		t.Fatalf("expected tmux binary path to be recorded, got %q", got.Tmux.BinaryPath)
 	}
@@ -69,16 +70,24 @@ func TestDetectRuntimeCapabilities(t *testing.T) {
 	if got.Tmux.Sessions[0].Name != SessionName || got.Tmux.Sessions[0].Attached != 2 || got.Tmux.Sessions[0].Windows != 4 {
 		t.Fatalf("unexpected target tmux session: %+v", got.Tmux.Sessions[0])
 	}
+	if office, ok := got.Registry.Entry(CapabilityKeyOfficeRuntime); !ok || office.Level != CapabilityReady {
+		t.Fatalf("expected office runtime to be ready, got %+v", office)
+	}
+	if nex, ok := got.Registry.Entry(CapabilityKeyNex); !ok || nex.Lifecycle != CapabilityLifecycleDisabled {
+		t.Fatalf("expected Nex to be disabled in --no-nex mode, got %+v", nex)
+	}
 }
 
 func TestDetectRuntimeCapabilitiesWhenTmuxServerIsMissing(t *testing.T) {
 	oldLookPath := lookPathFn
 	oldCommandOutput := commandCombinedOutputFn
-	oldActionProbe := actionProviderProbe
+	oldActionProviderForCapability := actionProviderForCapabilityFn
+	oldActionProviders := actionProvidersFn
 	defer func() {
 		lookPathFn = oldLookPath
 		commandCombinedOutputFn = oldCommandOutput
-		actionProviderProbe = oldActionProbe
+		actionProviderForCapabilityFn = oldActionProviderForCapability
+		actionProvidersFn = oldActionProviders
 	}()
 
 	lookPathFn = func(name string) (string, error) {
@@ -103,25 +112,25 @@ func TestDetectRuntimeCapabilitiesWhenTmuxServerIsMissing(t *testing.T) {
 		}
 		return nil, errors.New("unexpected tmux probe")
 	}
-	actionProviderProbe = func() (string, error) {
-		return "", errors.New("no configured provider available")
+	actionProviderForCapabilityFn = func(action.Capability) (action.Provider, error) {
+		return nil, errors.New("no configured provider available")
 	}
+	actionProvidersFn = func() []action.Provider { return nil }
 
 	t.Setenv("WUPHF_NO_NEX", "1")
 
 	got := DetectRuntimeCapabilities()
-	ready, warn, info := got.Counts()
-	if ready != 1 || warn != 1 || info != 2 {
-		t.Fatalf("unexpected capability counts: ready=%d warn=%d info=%d", ready, warn, info)
-	}
 	if got.Tmux.ServerRunning {
 		t.Fatalf("expected tmux server to be marked missing")
 	}
-	if got.Items[0].Level != CapabilityInfo {
-		t.Fatalf("expected tmux capability to be informational when the server is absent, got %s", got.Items[0].Level)
-	}
 	if !strings.Contains(got.Tmux.ProbeError, "no server running") {
 		t.Fatalf("expected tmux probe note to keep the server error, got %q", got.Tmux.ProbeError)
+	}
+	if tmux, ok := got.Registry.Entry(CapabilityKeyTmux); !ok || tmux.Level != CapabilityInfo {
+		t.Fatalf("expected tmux capability to be informational when the server is absent, got %+v", tmux)
+	}
+	if office, ok := got.Registry.Entry(CapabilityKeyOfficeRuntime); !ok || office.Level != CapabilityWarn {
+		t.Fatalf("expected office runtime to stay warning-level when tmux session is missing, got %+v", office)
 	}
 }
 
@@ -152,6 +161,29 @@ func TestBuildRuntimeSnapshotFormatsRecoveryAndCapabilities(t *testing.T) {
 			From:    "ceo",
 			Content: "We need a final timing call before tomorrow.",
 		}},
+		Artifacts: []RuntimeArtifact{
+			{
+				ID:            "task-1",
+				Kind:          RuntimeArtifactTask,
+				Title:         "Polish launch checklist",
+				Summary:       "This task is retained as a live execution artifact with its current runtime context.",
+				State:         "review",
+				Progress:      "Stage: review · Review: pending review · Execution: local worktree",
+				PartialOutput: "Latest task output retained for review.",
+				Path:          "/tmp/wuphf-task-1/output.log",
+				Worktree:      "/tmp/wuphf-task-1",
+				ResumeHint:    "Resume in /tmp/wuphf-task-1 or reopen the task thread.",
+				ReviewHint:    "Review pending review.",
+			},
+			{
+				ID:         "req-1",
+				Kind:       RuntimeArtifactRequest,
+				Title:      "Approve launch timing",
+				Summary:    "Blocking approval before tomorrow.",
+				State:      "pending",
+				ResumeHint: "Answer the request or reopen it from Recovery.",
+			},
+		},
 		Capabilities: RuntimeCapabilities{
 			Tmux: TmuxCapability{
 				BinaryPath:    "/usr/bin/tmux",
@@ -172,6 +204,15 @@ func TestBuildRuntimeSnapshotFormatsRecoveryAndCapabilities(t *testing.T) {
 				Detail: "tmux 3.4a on socket wuphf is running with session wuphf-team (2 attached, 4 windows).",
 			}},
 		},
+		Registry: CapabilityRegistry{
+			Entries: []CapabilityDescriptor{{
+				Key:      "workflow_execute",
+				Label:    "Workflow execution",
+				Category: CapabilityCategoryWorkflow,
+				Level:    CapabilityReady,
+				Detail:   "Workflow execution is available via one.",
+			}},
+		},
 		Now: time.Unix(100, 0),
 	})
 
@@ -180,8 +221,12 @@ func TestBuildRuntimeSnapshotFormatsRecoveryAndCapabilities(t *testing.T) {
 		"Runtime state for #general",
 		"Session mode: 1:1 with @pm",
 		"Pending human requests: 1",
+		"Retained execution artifacts: 2",
 		"Approve launch timing from @ceo.",
 		"Use working_directory /tmp/wuphf-task-1",
+		"Execution artifacts:",
+		"Polish launch checklist [task] review: This task is retained as a live execution artifact with its current runtime context.",
+		"Approve launch timing [request] pending: Blocking approval before tomorrow.",
 		"Recent highlights:",
 		"Tmux runtime:",
 		"Binary: /usr/bin/tmux",
@@ -190,9 +235,21 @@ func TestBuildRuntimeSnapshotFormatsRecoveryAndCapabilities(t *testing.T) {
 		"WUPHF session: running (2 attached, 4 windows)",
 		"scratch: 1 attached, 1 windows",
 		"Runtime capabilities:",
+		"Capability registry:",
+		"Workflow execution (workflow) [ready]: Workflow execution is available via one.",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected %q in %q", want, text)
 		}
+	}
+	if len(snapshot.Memory.Tasks) != 1 {
+		t.Fatalf("expected task memory summary, got %+v", snapshot.Memory.Tasks)
+	}
+	restore := snapshot.Memory.RestorationContext()
+	if len(restore.ActiveTaskIDs) != 1 || restore.ActiveTaskIDs[0] != "task-1" {
+		t.Fatalf("expected restore context to keep active task, got %+v", restore)
+	}
+	if len(restore.PendingRequestIDs) != 1 || restore.PendingRequestIDs[0] != "req-1" {
+		t.Fatalf("expected restore context to keep pending request, got %+v", restore)
 	}
 }

--- a/internal/team/session_memory.go
+++ b/internal/team/session_memory.go
@@ -12,6 +12,10 @@ type SessionRecovery struct {
 }
 
 func BuildSessionRecovery(sessionMode, directAgent string, tasks []RuntimeTask, requests []RuntimeRequest, recent []RuntimeMessage) SessionRecovery {
+	return buildSessionRecovery(sessionMode, directAgent, tasks, requests, recent)
+}
+
+func buildSessionRecovery(sessionMode, directAgent string, tasks []RuntimeTask, requests []RuntimeRequest, recent []RuntimeMessage) SessionRecovery {
 	recovery := SessionRecovery{}
 
 	if req, ok := firstPendingBlockingRuntimeRequest(requests); ok {
@@ -51,6 +55,11 @@ func BuildSessionRecovery(sessionMode, directAgent string, tasks []RuntimeTask, 
 	}
 
 	return recovery
+}
+
+func runtimeRequestIsOpen(req RuntimeRequest) bool {
+	status := strings.ToLower(strings.TrimSpace(req.Status))
+	return status == "" || status == "pending" || status == "open" || status == "draft"
 }
 
 func firstPendingBlockingRuntimeRequest(requests []RuntimeRequest) (RuntimeRequest, bool) {

--- a/internal/team/session_memory_snapshot.go
+++ b/internal/team/session_memory_snapshot.go
@@ -1,0 +1,359 @@
+package team
+
+import (
+	"strings"
+	"time"
+)
+
+type SessionMemoryTaskSummary struct {
+	ID             string   `json:"id"`
+	Title          string   `json:"title,omitempty"`
+	Owner          string   `json:"owner,omitempty"`
+	Status         string   `json:"status,omitempty"`
+	PipelineStage  string   `json:"pipeline_stage,omitempty"`
+	ReviewState    string   `json:"review_state,omitempty"`
+	ExecutionMode  string   `json:"execution_mode,omitempty"`
+	WorktreePath   string   `json:"worktree_path,omitempty"`
+	WorktreeBranch string   `json:"worktree_branch,omitempty"`
+	ThreadID       string   `json:"thread_id,omitempty"`
+	Blocked        bool     `json:"blocked,omitempty"`
+	DependsOn      []string `json:"depends_on,omitempty"`
+	Summary        string   `json:"summary,omitempty"`
+}
+
+type SessionMemoryRequestSummary struct {
+	ID            string `json:"id"`
+	Kind          string `json:"kind,omitempty"`
+	Status        string `json:"status,omitempty"`
+	From          string `json:"from,omitempty"`
+	Title         string `json:"title,omitempty"`
+	Question      string `json:"question,omitempty"`
+	Channel       string `json:"channel,omitempty"`
+	ReplyTo       string `json:"reply_to,omitempty"`
+	RecommendedID string `json:"recommended_id,omitempty"`
+	Blocking      bool   `json:"blocking,omitempty"`
+	Required      bool   `json:"required,omitempty"`
+	Secret        bool   `json:"secret,omitempty"`
+	Summary       string `json:"summary,omitempty"`
+}
+
+type SessionMemoryActionSummary struct {
+	ID         string   `json:"id"`
+	Kind       string   `json:"kind,omitempty"`
+	Source     string   `json:"source,omitempty"`
+	Channel    string   `json:"channel,omitempty"`
+	Actor      string   `json:"actor,omitempty"`
+	Summary    string   `json:"summary,omitempty"`
+	RelatedID  string   `json:"related_id,omitempty"`
+	SignalIDs  []string `json:"signal_ids,omitempty"`
+	DecisionID string   `json:"decision_id,omitempty"`
+	CreatedAt  string   `json:"created_at,omitempty"`
+}
+
+type SessionMemoryMessageSummary struct {
+	ID        string `json:"id"`
+	From      string `json:"from,omitempty"`
+	Title     string `json:"title,omitempty"`
+	Content   string `json:"content,omitempty"`
+	ReplyTo   string `json:"reply_to,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+	Summary   string `json:"summary,omitempty"`
+}
+
+type SessionMemorySnapshot struct {
+	Version     int                           `json:"version"`
+	SessionMode string                        `json:"session_mode,omitempty"`
+	DirectAgent string                        `json:"direct_agent,omitempty"`
+	GeneratedAt string                        `json:"generated_at,omitempty"`
+	Focus       string                        `json:"focus,omitempty"`
+	NextSteps   []string                      `json:"next_steps,omitempty"`
+	Highlights  []string                      `json:"highlights,omitempty"`
+	Tasks       []SessionMemoryTaskSummary    `json:"tasks,omitempty"`
+	Requests    []SessionMemoryRequestSummary `json:"requests,omitempty"`
+	Actions     []SessionMemoryActionSummary  `json:"actions,omitempty"`
+	Messages    []SessionMemoryMessageSummary `json:"messages,omitempty"`
+}
+
+type SessionRestoreContext struct {
+	Focus              string   `json:"focus,omitempty"`
+	NextSteps          []string `json:"next_steps,omitempty"`
+	ActiveTaskIDs      []string `json:"active_task_ids,omitempty"`
+	PendingRequestIDs  []string `json:"pending_request_ids,omitempty"`
+	WorkingDirectories []string `json:"working_directories,omitempty"`
+	ThreadIDs          []string `json:"thread_ids,omitempty"`
+}
+
+func BuildSessionMemorySnapshot(sessionMode, directAgent string, tasks []RuntimeTask, requests []RuntimeRequest, recent []RuntimeMessage) SessionMemorySnapshot {
+	sessionMode = NormalizeSessionMode(sessionMode)
+	directAgent = NormalizeOneOnOneAgent(directAgent)
+	if sessionMode != SessionModeOneOnOne {
+		directAgent = ""
+	}
+	recovery := buildSessionRecovery(sessionMode, directAgent, tasks, requests, recent)
+	snapshot := SessionMemorySnapshot{
+		Version:     1,
+		SessionMode: sessionMode,
+		DirectAgent: directAgent,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Focus:       recovery.Focus,
+		NextSteps:   append([]string(nil), recovery.NextSteps...),
+		Highlights:  append([]string(nil), recovery.Highlights...),
+		Tasks:       make([]SessionMemoryTaskSummary, 0, len(tasks)),
+		Requests:    make([]SessionMemoryRequestSummary, 0, len(requests)),
+		Messages:    make([]SessionMemoryMessageSummary, 0, len(recent)),
+	}
+	for _, task := range tasks {
+		snapshot.Tasks = append(snapshot.Tasks, SessionMemoryTaskSummary{
+			ID:             strings.TrimSpace(task.ID),
+			Title:          strings.TrimSpace(task.Title),
+			Owner:          strings.TrimSpace(task.Owner),
+			Status:         strings.TrimSpace(task.Status),
+			PipelineStage:  strings.TrimSpace(task.PipelineStage),
+			ReviewState:    strings.TrimSpace(task.ReviewState),
+			ExecutionMode:  strings.TrimSpace(task.ExecutionMode),
+			WorktreePath:   strings.TrimSpace(task.WorktreePath),
+			WorktreeBranch: strings.TrimSpace(task.WorktreeBranch),
+			Blocked:        task.Blocked,
+			Summary:        summarizeTask(task),
+		})
+	}
+	for _, req := range requests {
+		snapshot.Requests = append(snapshot.Requests, SessionMemoryRequestSummary{
+			ID:            strings.TrimSpace(req.ID),
+			Kind:          strings.TrimSpace(req.Kind),
+			Status:        strings.TrimSpace(req.Status),
+			From:          strings.TrimSpace(req.From),
+			Title:         strings.TrimSpace(req.Title),
+			Question:      strings.TrimSpace(req.Question),
+			Channel:       strings.TrimSpace(req.Channel),
+			RecommendedID: "",
+			Blocking:      req.Blocking,
+			Required:      req.Required,
+			Secret:        req.Secret,
+			Summary:       summarizeRequest(req),
+		})
+	}
+	for _, msg := range recent {
+		snapshot.Messages = append(snapshot.Messages, SessionMemoryMessageSummary{
+			ID:        strings.TrimSpace(msg.ID),
+			From:      strings.TrimSpace(msg.From),
+			Title:     strings.TrimSpace(msg.Title),
+			Content:   strings.TrimSpace(msg.Content),
+			ReplyTo:   strings.TrimSpace(msg.ReplyTo),
+			Timestamp: strings.TrimSpace(msg.Timestamp),
+			Summary:   summarizeRuntimeMessage(msg),
+		})
+	}
+	return snapshot
+}
+
+func BuildSessionMemorySnapshotFromOfficeState(sessionMode, directAgent string, tasks []teamTask, requests []humanInterview, actions []officeActionLog, messages []channelMessage) SessionMemorySnapshot {
+	runtimeTasks := make([]RuntimeTask, 0, len(tasks))
+	taskSummaries := make([]SessionMemoryTaskSummary, 0, len(tasks))
+	for _, task := range tasks {
+		if !sessionMemoryTaskRelevant(task) {
+			continue
+		}
+		runtimeTasks = append(runtimeTasks, RuntimeTask{
+			ID:             strings.TrimSpace(task.ID),
+			Title:          strings.TrimSpace(task.Title),
+			Owner:          strings.TrimSpace(task.Owner),
+			Status:         strings.TrimSpace(task.Status),
+			PipelineStage:  strings.TrimSpace(task.PipelineStage),
+			ReviewState:    strings.TrimSpace(task.ReviewState),
+			ExecutionMode:  strings.TrimSpace(task.ExecutionMode),
+			WorktreePath:   strings.TrimSpace(task.WorktreePath),
+			WorktreeBranch: strings.TrimSpace(task.WorktreeBranch),
+			Blocked:        task.Blocked,
+		})
+		taskSummaries = append(taskSummaries, SessionMemoryTaskSummary{
+			ID:             strings.TrimSpace(task.ID),
+			Title:          strings.TrimSpace(task.Title),
+			Owner:          strings.TrimSpace(task.Owner),
+			Status:         strings.TrimSpace(task.Status),
+			PipelineStage:  strings.TrimSpace(task.PipelineStage),
+			ReviewState:    strings.TrimSpace(task.ReviewState),
+			ExecutionMode:  strings.TrimSpace(task.ExecutionMode),
+			WorktreePath:   strings.TrimSpace(task.WorktreePath),
+			WorktreeBranch: strings.TrimSpace(task.WorktreeBranch),
+			ThreadID:       strings.TrimSpace(task.ThreadID),
+			Blocked:        task.Blocked,
+			DependsOn:      append([]string(nil), task.DependsOn...),
+			Summary:        summarizeTask(RuntimeTask{ID: task.ID, Title: task.Title, Owner: task.Owner, Status: task.Status, PipelineStage: task.PipelineStage, ReviewState: task.ReviewState, ExecutionMode: task.ExecutionMode, WorktreePath: task.WorktreePath, WorktreeBranch: task.WorktreeBranch, Blocked: task.Blocked}),
+		})
+	}
+
+	runtimeRequests := make([]RuntimeRequest, 0, len(requests))
+	requestSummaries := make([]SessionMemoryRequestSummary, 0, len(requests))
+	for _, req := range requests {
+		if !requestIsActive(req) {
+			continue
+		}
+		runtimeRequests = append(runtimeRequests, RuntimeRequest{
+			ID:       strings.TrimSpace(req.ID),
+			Kind:     strings.TrimSpace(req.Kind),
+			Title:    strings.TrimSpace(req.Title),
+			Question: strings.TrimSpace(req.Question),
+			From:     strings.TrimSpace(req.From),
+			Blocking: req.Blocking,
+			Required: req.Required,
+			Status:   strings.TrimSpace(req.Status),
+			Channel:  strings.TrimSpace(req.Channel),
+			Secret:   req.Secret,
+		})
+		requestSummaries = append(requestSummaries, SessionMemoryRequestSummary{
+			ID:            strings.TrimSpace(req.ID),
+			Kind:          strings.TrimSpace(req.Kind),
+			Status:        strings.TrimSpace(req.Status),
+			From:          strings.TrimSpace(req.From),
+			Title:         strings.TrimSpace(req.Title),
+			Question:      strings.TrimSpace(req.Question),
+			Channel:       strings.TrimSpace(req.Channel),
+			ReplyTo:       strings.TrimSpace(req.ReplyTo),
+			RecommendedID: strings.TrimSpace(req.RecommendedID),
+			Blocking:      req.Blocking,
+			Required:      req.Required,
+			Secret:        req.Secret,
+			Summary:       summarizeRequest(RuntimeRequest{ID: req.ID, Kind: req.Kind, Title: req.Title, Question: req.Question, From: req.From, Blocking: req.Blocking, Required: req.Required, Status: req.Status, Channel: req.Channel, Secret: req.Secret}),
+		})
+	}
+
+	runtimeRecent := make([]RuntimeMessage, 0, 5)
+	messageSummaries := make([]SessionMemoryMessageSummary, 0, 5)
+	for _, msg := range latestSessionMemoryMessages(messages, 5) {
+		runtimeRecent = append(runtimeRecent, RuntimeMessage{
+			ID:        strings.TrimSpace(msg.ID),
+			From:      strings.TrimSpace(msg.From),
+			Title:     strings.TrimSpace(msg.Title),
+			Content:   strings.TrimSpace(msg.Content),
+			ReplyTo:   strings.TrimSpace(msg.ReplyTo),
+			Timestamp: strings.TrimSpace(msg.Timestamp),
+		})
+		messageSummaries = append(messageSummaries, SessionMemoryMessageSummary{
+			ID:        strings.TrimSpace(msg.ID),
+			From:      strings.TrimSpace(msg.From),
+			Title:     strings.TrimSpace(msg.Title),
+			Content:   strings.TrimSpace(msg.Content),
+			ReplyTo:   strings.TrimSpace(msg.ReplyTo),
+			Timestamp: strings.TrimSpace(msg.Timestamp),
+			Summary:   summarizeChannelMessage(msg),
+		})
+	}
+
+	snapshot := BuildSessionMemorySnapshot(sessionMode, directAgent, runtimeTasks, runtimeRequests, runtimeRecent)
+	snapshot.Tasks = taskSummaries
+	snapshot.Requests = requestSummaries
+	snapshot.Messages = messageSummaries
+	snapshot.Actions = latestSessionMemoryActions(actions, 6)
+	return snapshot
+}
+
+func (s SessionMemorySnapshot) ToRecovery() SessionRecovery {
+	return SessionRecovery{
+		Focus:      strings.TrimSpace(s.Focus),
+		NextSteps:  append([]string(nil), s.NextSteps...),
+		Highlights: append([]string(nil), s.Highlights...),
+	}
+}
+
+func (s SessionMemorySnapshot) RestorationContext() SessionRestoreContext {
+	ctx := SessionRestoreContext{
+		Focus:     strings.TrimSpace(s.Focus),
+		NextSteps: append([]string(nil), s.NextSteps...),
+	}
+	for _, task := range s.Tasks {
+		status := strings.ToLower(strings.TrimSpace(task.Status))
+		if status == "" || status == "open" || status == "in_progress" || status == "review" || task.Blocked {
+			ctx.ActiveTaskIDs = appendUnique(ctx.ActiveTaskIDs, task.ID)
+		}
+		if path := strings.TrimSpace(task.WorktreePath); path != "" {
+			ctx.WorkingDirectories = appendUnique(ctx.WorkingDirectories, path)
+		}
+		if threadID := strings.TrimSpace(task.ThreadID); threadID != "" {
+			ctx.ThreadIDs = appendUnique(ctx.ThreadIDs, threadID)
+		}
+	}
+	for _, req := range s.Requests {
+		status := strings.ToLower(strings.TrimSpace(req.Status))
+		if status == "" || status == "pending" || status == "open" {
+			if req.Blocking || req.Required {
+				ctx.PendingRequestIDs = appendUnique(ctx.PendingRequestIDs, req.ID)
+			}
+			if replyTo := strings.TrimSpace(req.ReplyTo); replyTo != "" {
+				ctx.ThreadIDs = appendUnique(ctx.ThreadIDs, replyTo)
+			}
+		}
+	}
+	return ctx
+}
+
+func sessionMemoryTaskRelevant(task teamTask) bool {
+	status := strings.ToLower(strings.TrimSpace(task.Status))
+	if task.Blocked {
+		return true
+	}
+	return status == "" || status == "open" || status == "in_progress" || status == "review"
+}
+
+func latestSessionMemoryMessages(messages []channelMessage, limit int) []channelMessage {
+	if limit <= 0 {
+		return nil
+	}
+	recent := make([]channelMessage, 0, limit)
+	for i := len(messages) - 1; i >= 0 && len(recent) < limit; i-- {
+		msg := messages[i]
+		if strings.TrimSpace(msg.Content) == "" && strings.TrimSpace(msg.Title) == "" {
+			continue
+		}
+		recent = append([]channelMessage{msg}, recent...)
+	}
+	return recent
+}
+
+func latestSessionMemoryActions(actions []officeActionLog, limit int) []SessionMemoryActionSummary {
+	if limit <= 0 {
+		return nil
+	}
+	start := 0
+	if len(actions) > limit {
+		start = len(actions) - limit
+	}
+	summaries := make([]SessionMemoryActionSummary, 0, len(actions)-start)
+	for _, action := range actions[start:] {
+		summaries = append(summaries, SessionMemoryActionSummary{
+			ID:         strings.TrimSpace(action.ID),
+			Kind:       strings.TrimSpace(action.Kind),
+			Source:     strings.TrimSpace(action.Source),
+			Channel:    strings.TrimSpace(action.Channel),
+			Actor:      strings.TrimSpace(action.Actor),
+			Summary:    strings.TrimSpace(action.Summary),
+			RelatedID:  strings.TrimSpace(action.RelatedID),
+			SignalIDs:  append([]string(nil), action.SignalIDs...),
+			DecisionID: strings.TrimSpace(action.DecisionID),
+			CreatedAt:  strings.TrimSpace(action.CreatedAt),
+		})
+	}
+	return summaries
+}
+
+func summarizeRuntimeMessage(msg RuntimeMessage) string {
+	content := strings.TrimSpace(msg.Content)
+	if content == "" {
+		content = strings.TrimSpace(msg.Title)
+	}
+	if content == "" {
+		return ""
+	}
+	return "@" + strings.TrimSpace(msg.From) + ": " + truncateRecoveryText(content, 120)
+}
+
+func summarizeChannelMessage(msg channelMessage) string {
+	content := strings.TrimSpace(msg.Content)
+	if content == "" {
+		content = strings.TrimSpace(msg.Title)
+	}
+	if content == "" {
+		return ""
+	}
+	return "@" + strings.TrimSpace(msg.From) + ": " + truncateRecoveryText(content, 120)
+}

--- a/internal/team/session_memory_test.go
+++ b/internal/team/session_memory_test.go
@@ -1,0 +1,174 @@
+package team
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildSessionMemorySnapshotIncludesSerializableSummaries(t *testing.T) {
+	snapshot := BuildSessionMemorySnapshot(SessionModeOneOnOne, "pm", []RuntimeTask{{
+		ID:             "task-1",
+		Title:          "Polish launch checklist",
+		Owner:          "pm",
+		Status:         "in_progress",
+		PipelineStage:  "review",
+		ReviewState:    "pending_review",
+		ExecutionMode:  "local_worktree",
+		WorktreePath:   "/tmp/wuphf-task-1",
+		WorktreeBranch: "task/1",
+	}}, []RuntimeRequest{{
+		ID:       "req-1",
+		Kind:     "approval",
+		Title:    "Approve launch timing",
+		Question: "Should we ship tomorrow?",
+		From:     "ceo",
+		Blocking: true,
+		Status:   "pending",
+	}}, []RuntimeMessage{{
+		ID:      "msg-1",
+		From:    "ceo",
+		Content: "We need a final timing call before tomorrow.",
+	}})
+
+	if snapshot.Version != 1 {
+		t.Fatalf("expected version 1, got %d", snapshot.Version)
+	}
+	if snapshot.SessionMode != SessionModeOneOnOne || snapshot.DirectAgent != "pm" {
+		t.Fatalf("unexpected session metadata: %+v", snapshot)
+	}
+	if snapshot.Focus == "" || !strings.Contains(snapshot.Focus, "Approve launch timing") {
+		t.Fatalf("expected request focus, got %+v", snapshot)
+	}
+	if len(snapshot.Tasks) != 1 || snapshot.Tasks[0].Summary == "" {
+		t.Fatalf("expected summarized task, got %+v", snapshot.Tasks)
+	}
+	if len(snapshot.Requests) != 1 || snapshot.Requests[0].Summary == "" {
+		t.Fatalf("expected summarized request, got %+v", snapshot.Requests)
+	}
+	if len(snapshot.Messages) != 1 || !strings.Contains(snapshot.Messages[0].Summary, "@ceo:") {
+		t.Fatalf("expected summarized recent message, got %+v", snapshot.Messages)
+	}
+	if len(snapshot.NextSteps) == 0 {
+		t.Fatalf("expected next steps, got %+v", snapshot)
+	}
+}
+
+func TestSessionMemorySnapshotRestorationContextCollectsResumeHandles(t *testing.T) {
+	snapshot := SessionMemorySnapshot{
+		Focus:     "Resume launch work.",
+		NextSteps: []string{"Answer the blocker.", "Use the worktree."},
+		Tasks: []SessionMemoryTaskSummary{
+			{ID: "task-1", Status: "in_progress", WorktreePath: "/tmp/wuphf-task-1", ThreadID: "msg-9"},
+			{ID: "task-2", Status: "review", WorktreePath: "/tmp/wuphf-task-1", ThreadID: "msg-10"},
+		},
+		Requests: []SessionMemoryRequestSummary{
+			{ID: "req-1", Status: "pending", Blocking: true, ReplyTo: "msg-9"},
+			{ID: "req-2", Status: "answered", Blocking: true, ReplyTo: "msg-12"},
+		},
+	}
+
+	ctx := snapshot.RestorationContext()
+	if ctx.Focus != "Resume launch work." {
+		t.Fatalf("unexpected focus: %+v", ctx)
+	}
+	if len(ctx.ActiveTaskIDs) != 2 {
+		t.Fatalf("expected two active task ids, got %+v", ctx)
+	}
+	if len(ctx.PendingRequestIDs) != 1 || ctx.PendingRequestIDs[0] != "req-1" {
+		t.Fatalf("expected only pending blocking request, got %+v", ctx.PendingRequestIDs)
+	}
+	if len(ctx.WorkingDirectories) != 1 || ctx.WorkingDirectories[0] != "/tmp/wuphf-task-1" {
+		t.Fatalf("expected deduped worktree path, got %+v", ctx.WorkingDirectories)
+	}
+	if len(ctx.ThreadIDs) != 2 {
+		t.Fatalf("expected deduped thread ids, got %+v", ctx.ThreadIDs)
+	}
+}
+
+func TestBuildSessionMemorySnapshotFromOfficeStateReconstructsContext(t *testing.T) {
+	snapshot := BuildSessionMemorySnapshotFromOfficeState(SessionModeOffice, "", []teamTask{
+		{
+			ID:             "task-7",
+			Title:          "Ship release candidate",
+			Owner:          "fe",
+			Status:         "in_progress",
+			PipelineStage:  "execution",
+			ReviewState:    "pending_review",
+			ExecutionMode:  "local_worktree",
+			WorktreePath:   "/tmp/wuphf-task-7",
+			WorktreeBranch: "task/7",
+			ThreadID:       "msg-7",
+		},
+		{
+			ID:     "task-8",
+			Title:  "Old done task",
+			Status: "done",
+		},
+	}, []humanInterview{
+		{
+			ID:            "req-3",
+			Kind:          "confirm",
+			Status:        "pending",
+			From:          "ceo",
+			Title:         "Confirm launch plan",
+			Question:      "Should the office proceed with this launch plan?",
+			Blocking:      true,
+			Required:      true,
+			ReplyTo:       "msg-7",
+			RecommendedID: "confirm_proceed",
+		},
+		{
+			ID:       "req-4",
+			Status:   "answered",
+			Title:    "Old answered request",
+			Question: "Ignore me",
+		},
+	}, []officeActionLog{
+		{ID: "action-1", Kind: "task_created", Actor: "ceo", Summary: "Opened launch task", RelatedID: "task-7", CreatedAt: "2026-04-07T10:00:00Z"},
+		{ID: "action-2", Kind: "request_created", Actor: "ceo", Summary: "Asked for launch confirmation", RelatedID: "req-3", CreatedAt: "2026-04-07T10:05:00Z"},
+	}, []channelMessage{
+		{ID: "msg-1", From: "ceo", Content: "We need a launch decision today.", Timestamp: "2026-04-07T10:00:00Z"},
+		{ID: "msg-7", From: "fe", Content: "Release candidate is ready for review.", Timestamp: "2026-04-07T10:06:00Z"},
+	})
+
+	if len(snapshot.Tasks) != 1 || snapshot.Tasks[0].ID != "task-7" {
+		t.Fatalf("expected only relevant active task summary, got %+v", snapshot.Tasks)
+	}
+	if len(snapshot.Requests) != 1 || snapshot.Requests[0].ID != "req-3" {
+		t.Fatalf("expected only active request summary, got %+v", snapshot.Requests)
+	}
+	if len(snapshot.Actions) != 2 {
+		t.Fatalf("expected action summaries, got %+v", snapshot.Actions)
+	}
+	if len(snapshot.Messages) != 2 {
+		t.Fatalf("expected recent message summaries, got %+v", snapshot.Messages)
+	}
+	if !strings.Contains(snapshot.Focus, "Confirm launch plan") {
+		t.Fatalf("expected request-led focus, got %+v", snapshot)
+	}
+	restore := snapshot.RestorationContext()
+	if len(restore.WorkingDirectories) != 1 || restore.WorkingDirectories[0] != "/tmp/wuphf-task-7" {
+		t.Fatalf("expected worktree restore hint, got %+v", restore)
+	}
+	if len(restore.PendingRequestIDs) != 1 || restore.PendingRequestIDs[0] != "req-3" {
+		t.Fatalf("expected pending request restore hint, got %+v", restore)
+	}
+}
+
+func TestSessionMemorySnapshotToRecoveryPreservesFields(t *testing.T) {
+	snapshot := SessionMemorySnapshot{
+		Focus:      "Keep the release on hold.",
+		NextSteps:  []string{"Wait for legal."},
+		Highlights: []string{"@ceo: Legal review is still pending."},
+	}
+	recovery := snapshot.ToRecovery()
+	if recovery.Focus != snapshot.Focus {
+		t.Fatalf("expected focus round-trip, got %+v", recovery)
+	}
+	if len(recovery.NextSteps) != 1 || recovery.NextSteps[0] != "Wait for legal." {
+		t.Fatalf("unexpected next steps: %+v", recovery)
+	}
+	if len(recovery.Highlights) != 1 || recovery.Highlights[0] != "@ceo: Legal review is still pending." {
+		t.Fatalf("unexpected highlights: %+v", recovery)
+	}
+}

--- a/internal/teammcp/actions.go
+++ b/internal/teammcp/actions.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/calendar"
+	"github.com/nex-crm/wuphf/internal/team"
 )
 
 var externalActionProvider action.Provider
@@ -731,5 +732,14 @@ func selectedActionProvider(cap action.Capability) (action.Provider, error) {
 	if externalActionProvider != nil {
 		return externalActionProvider, nil
 	}
-	return action.NewRegistryFromEnv().ProviderFor(cap)
+	provider, err := team.ResolveActionProviderForCapability(cap)
+	if err == nil {
+		return provider, nil
+	}
+	caps := team.DetectRuntimeCapabilities()
+	entry, ok := caps.Registry.Entry(team.RegistryKeyForActionCapability(cap))
+	if !ok || strings.TrimSpace(entry.NextStep) == "" {
+		return nil, err
+	}
+	return nil, fmt.Errorf("%w. Next: %s", err, entry.NextStep)
 }

--- a/internal/teammcp/actions_test.go
+++ b/internal/teammcp/actions_test.go
@@ -258,3 +258,20 @@ func TestHandleTeamActionWorkflowScheduleRunNowExecutesImmediately(t *testing.T)
 		t.Fatalf("expected scheduled and executed actions, got %+v", b.Actions())
 	}
 }
+
+func TestSelectedActionProviderIncludesCapabilityGuidance(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_NO_NEX", "1")
+
+	prev := externalActionProvider
+	externalActionProvider = nil
+	defer func() { externalActionProvider = prev }()
+
+	_, err := selectedActionProvider(action.CapabilityActionExecute)
+	if err == nil {
+		t.Fatal("expected provider selection to fail when Nex is disabled")
+	}
+	if !strings.Contains(err.Error(), "Restart without --no-nex") {
+		t.Fatalf("expected readiness next step in %q", err)
+	}
+}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -873,13 +873,17 @@ func handleTeamRuntimeState(ctx context.Context, _ *mcp.CallToolRequest, args Te
 	}
 
 	snapshot := team.BuildRuntimeSnapshot(team.RuntimeSnapshotInput{
-		Channel:      taskChannel,
-		SessionMode:  mode,
-		DirectAgent:  directAgent,
-		Tasks:        convertRuntimeTasks(tasks),
-		Requests:     requests,
-		Recent:       recent,
-		Capabilities: team.DetectRuntimeCapabilities(),
+		Channel:     taskChannel,
+		SessionMode: mode,
+		DirectAgent: directAgent,
+		Tasks:       convertRuntimeTasks(tasks),
+		Requests:    requests,
+		Recent:      recent,
+		Capabilities: team.DetectRuntimeCapabilitiesWithOptions(team.CapabilityProbeOptions{
+			IncludeConnections: true,
+			ConnectionLimit:    5,
+			ConnectionTimeout:  3 * time.Second,
+		}),
 	})
 	return textResult(snapshot.FormatText()), snapshot, nil
 }

--- a/internal/teammcp/server_test.go
+++ b/internal/teammcp/server_test.go
@@ -564,7 +564,7 @@ func TestHandleTeamRuntimeStateIncludesRecoveryAndCapabilities(t *testing.T) {
 		"Current focus: Approve release from @ceo.",
 		"working_directory /tmp/wuphf-task-77",
 		"Runtime capabilities:",
-		"nex [info]: Disabled for this session with --no-nex.",
+		"Nex memory [info]: Disabled for this session with --no-nex.",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected %q in %q", want, text)
@@ -583,6 +583,12 @@ func TestHandleTeamRuntimeStateIncludesRecoveryAndCapabilities(t *testing.T) {
 	}
 	if len(snapshot.Requests) == 0 || snapshot.Requests[0].Title != "Approve release" {
 		t.Fatalf("unexpected runtime requests: %+v", snapshot.Requests)
+	}
+	if _, ok := snapshot.Registry.Entry(team.CapabilityKeyConnections); !ok {
+		t.Fatalf("expected connections readiness in runtime registry, got %+v", snapshot.Registry.Entries)
+	}
+	if _, ok := snapshot.Registry.Entry(team.CapabilityKeyOfficeActions); !ok {
+		t.Fatalf("expected office actions readiness in runtime registry, got %+v", snapshot.Registry.Entries)
 	}
 }
 


### PR DESCRIPTION
## What changed
This PR finishes the remaining CC-agent-inspired end-state work that was still local in WUPHF.

It adds:
- deep large-history transcript virtualization for the office/direct message viewport
- first-class retained execution artifacts and artifact rendering surfaces
- richer session memory snapshots and restore context for recovery
- capability registry and readiness lifecycle wiring across runtime state, `/doctor`, and MCP action guidance
- inbox/outbox mailbox lanes for direct sessions
- workspace-state and recovery/artifact surface integration on top of the newer runtime model

## Why
The product had most of the mid-layer workflow plumbing, but it still lacked the last large-history and operational-state pieces needed for the CC-agent-style end state. The heaviest remaining gap was the transcript path: the UI still rebuilt threaded history and rendered suffixes on each frame instead of treating history as a virtualized viewport.

This PR closes that by caching threaded message state, caching rendered/measured transcript blocks, and assembling only the visible viewport window. It also packages the remaining artifact, memory, readiness, and mailbox slices into the same reviewed branch so the experience is coherent instead of partially landed.

## User impact
- Very long office/direct histories should feel materially cheaper to scroll and repaint.
- Recovery and artifact surfaces now have richer backing state.
- `/doctor` and MCP runtime status now expose clearer readiness and next-step guidance.
- Direct sessions now have inbox/outbox lanes.

## Validation
- `go test ./...`
- `bash tests/uat/office-channel-e2e.sh`
- `bash tests/uat/one-on-one-channel-e2e.sh`
- `bash tests/uat/autonomy-acceptance.sh`
