### PR TITLE
feat: add Codex CLI office runtime

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -6193,6 +6193,13 @@ func applyTeamSetup() tea.Cmd {
 		if err != nil {
 			return channelInitDoneMsg{err: err}
 		}
+		cfg, _ := config.Load()
+		if current := strings.TrimSpace(os.Getenv("WUPHF_HEADLESS_PROVIDER")); current != "" {
+			return channelInitDoneMsg{notice: notice + " Setup saved. Restart WUPHF to reload the " + current + " office runtime with the new configuration."}
+		}
+		if strings.TrimSpace(cfg.LLMProvider) == "codex" {
+			return channelInitDoneMsg{notice: notice + " Codex was saved as the LLM provider. Restart WUPHF to launch the headless Codex office runtime."}
+		}
 		l, err := team.NewLauncher("")
 		if err != nil {
 			return channelInitDoneMsg{err: err}
@@ -6413,8 +6420,12 @@ func reportChannelCrash(details string) {
 	fmt.Fprintln(os.Stderr, "Log:", channelCrashLogPath())
 	fmt.Fprintln(os.Stderr, "")
 	fmt.Fprintln(os.Stderr, "The rest of the team is still running.")
-	fmt.Fprintln(os.Stderr, "Use `tmux -L wuphf attach -t wuphf-team` to inspect panes,")
-	fmt.Fprintln(os.Stderr, "then restart WUPHF when ready.")
+	if strings.TrimSpace(os.Getenv("WUPHF_HEADLESS_PROVIDER")) != "" {
+		fmt.Fprintln(os.Stderr, "Restart WUPHF when ready to reconnect to the headless office runtime.")
+	} else {
+		fmt.Fprintln(os.Stderr, "Use `tmux -L wuphf attach -t wuphf-team` to inspect panes,")
+		fmt.Fprintln(os.Stderr, "then restart WUPHF when ready.")
+	}
 	select {}
 }
 

--- a/cmd/wuphf/channel_workspace_state.go
+++ b/cmd/wuphf/channel_workspace_state.go
@@ -124,8 +124,8 @@ func deriveWorkspaceReadiness(state workspaceUIState, doctor *channelDoctorRepor
 		return workspaceReadinessState{
 			Level:    workspaceReadinessPreview,
 			Headline: "Offline preview",
-			Detail:   "The workspace is showing manifest-backed context, not the live tmux office runtime.",
-			NextStep: "Launch WUPHF to attach the live office, or run /doctor to inspect tmux and setup readiness.",
+			Detail:   "The workspace is showing manifest-backed context, not the live office runtime.",
+			NextStep: "Launch WUPHF to attach the live office, or run /doctor to inspect runtime readiness.",
 		}
 	}
 	if state.NoNex {

--- a/cmd/wuphf/channel_workspace_state_test.go
+++ b/cmd/wuphf/channel_workspace_state_test.go
@@ -36,7 +36,7 @@ func TestBuildOfficeIntroLinesShowsOfflinePreviewGuidance(t *testing.T) {
 	if !strings.Contains(plain, "Offline preview") {
 		t.Fatalf("expected offline preview messaging, got %q", plain)
 	}
-	if !strings.Contains(plain, "Launch WUPHF to attach the live office, or run /doctor to inspect tmux and setup readiness.") {
+	if !strings.Contains(plain, "Launch WUPHF to attach the live office, or run /doctor to inspect runtime readiness.") {
 		t.Fatalf("expected doctor guidance, got %q", plain)
 	}
 }

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -141,6 +141,19 @@ func runTeam(args []string, packSlug string, unsafe bool, oneOnOne bool) {
 		fmt.Fprintf(os.Stderr, "error launching team: %v\n", err)
 		os.Exit(1)
 	}
+	if !l.UsesTmuxRuntime() {
+		if token := strings.TrimSpace(l.BrokerToken()); token != "" {
+			_ = os.Setenv("WUPHF_BROKER_TOKEN", token)
+		}
+		_ = os.Setenv("WUPHF_HEADLESS_PROVIDER", "codex")
+		if oneOnOne {
+			_ = os.Setenv("WUPHF_ONE_ON_ONE", "1")
+			_ = os.Setenv("WUPHF_ONE_ON_ONE_AGENT", l.OneOnOneAgent())
+		}
+		defer l.Kill()
+		runChannelView(false, resolveInitialOfficeApp(""), false)
+		return
+	}
 
 	fmt.Println("Team launched. Attaching...")
 	fmt.Println()

--- a/internal/commands/cmd_system.go
+++ b/internal/commands/cmd_system.go
@@ -91,6 +91,7 @@ func cmdInit(ctx *SlashContext, args string) error {
 func cmdProvider(ctx *SlashContext, args string) error {
 	options := []PickerOption{
 		{Label: "Gemini", Value: "gemini", Description: "Google Gemini via API key"},
+		{Label: "Codex CLI", Value: "codex", Description: "Codex via codex CLI"},
 		{Label: "Claude Code", Value: "claude-code", Description: "Claude via claude-code CLI"},
 	}
 	if !config.ResolveNoNex() {

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -1,0 +1,136 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+)
+
+var (
+	codexLookPath = exec.LookPath
+	codexCommand  = exec.Command
+	codexGetwd    = os.Getwd
+)
+
+// CreateCodexCLIStreamFn returns a StreamFn that runs Codex CLI non-interactively.
+// WUPHF keeps the conversation history, so each invocation is intentionally ephemeral.
+func CreateCodexCLIStreamFn(agentSlug string) agent.StreamFn {
+	return func(msgs []agent.Message, tools []agent.AgentTool) <-chan agent.StreamChunk {
+		ch := make(chan agent.StreamChunk, 64)
+		go func() {
+			defer close(ch)
+
+			if _, err := codexLookPath("codex"); err != nil {
+				ch <- agent.StreamChunk{Type: "error", Content: "Codex CLI not found. Run `codex login` or use /provider to choose a different provider."}
+				return
+			}
+
+			cwd, err := codexGetwd()
+			if err != nil {
+				ch <- agent.StreamChunk{Type: "error", Content: fmt.Sprintf("resolve working directory: %v", err)}
+				return
+			}
+
+			systemPrompt, prompt := buildClaudePrompts(msgs)
+			if prompt == "" {
+				prompt = "Proceed with the task."
+			}
+
+			text, err := runCodexOnce(systemPrompt, prompt, cwd)
+			if err != nil {
+				ch <- agent.StreamChunk{Type: "error", Content: describeCodexFailure(err)}
+				return
+			}
+			streamTextChunks(ch, text)
+		}()
+		return ch
+	}
+}
+
+// RunCodexOneShot runs Codex once with the given system prompt and user prompt
+// and returns the final plain-text result.
+func RunCodexOneShot(systemPrompt, prompt, cwd string) (string, error) {
+	if cwd == "" {
+		var err error
+		cwd, err = codexGetwd()
+		if err != nil {
+			return "", err
+		}
+	}
+	return runCodexOnce(systemPrompt, prompt, cwd)
+}
+
+func runCodexOnce(systemPrompt, prompt, cwd string) (string, error) {
+	outputFile, err := os.CreateTemp("", "wuphf-codex-*.txt")
+	if err != nil {
+		return "", fmt.Errorf("create codex output file: %w", err)
+	}
+	outputPath := outputFile.Name()
+	outputFile.Close()
+	defer os.Remove(outputPath)
+
+	args := buildCodexArgs(cwd, outputPath)
+	cmd := codexCommand("codex", args...)
+	cmd.Dir = cwd
+	cmd.Env = filteredEnv(nil)
+	cmd.Stdin = strings.NewReader(buildCodexPrompt(systemPrompt, prompt))
+
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if content, readErr := os.ReadFile(outputPath); readErr == nil {
+			if text := strings.TrimSpace(string(content)); text != "" {
+				return text, nil
+			}
+		}
+		if stderrText := strings.TrimSpace(stderr.String()); stderrText != "" {
+			return "", fmt.Errorf("%w: %s", err, stderrText)
+		}
+		return "", err
+	}
+
+	content, err := os.ReadFile(outputPath)
+	if err != nil {
+		return "", fmt.Errorf("read codex output: %w", err)
+	}
+	text := strings.TrimSpace(string(content))
+	if text == "" {
+		return "", fmt.Errorf("codex returned no final text")
+	}
+	return text, nil
+}
+
+func buildCodexArgs(cwd string, outputPath string) []string {
+	return []string{
+		"exec",
+		"-C", cwd,
+		"--skip-git-repo-check",
+		"--ephemeral",
+		"--color", "never",
+		"--output-last-message", outputPath,
+		"-",
+	}
+}
+
+func buildCodexPrompt(systemPrompt, prompt string) string {
+	var parts []string
+	if strings.TrimSpace(systemPrompt) != "" {
+		parts = append(parts, "<system>\n"+strings.TrimSpace(systemPrompt)+"\n</system>")
+	}
+	if strings.TrimSpace(prompt) != "" {
+		parts = append(parts, strings.TrimSpace(prompt))
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func describeCodexFailure(err error) string {
+	text := strings.ToLower(strings.TrimSpace(err.Error()))
+	if strings.Contains(text, "login") || strings.Contains(text, "auth") || strings.Contains(text, "unauthorized") {
+		return "Codex CLI requires login. Run `codex login` or use /provider to choose a different provider."
+	}
+	return fmt.Sprintf("codex exited with error: %v", err)
+}

--- a/internal/provider/codex_test.go
+++ b/internal/provider/codex_test.go
@@ -1,0 +1,180 @@
+package provider
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+)
+
+type codexHelperRecord struct {
+	Args  []string `json:"args"`
+	Stdin string   `json:"stdin"`
+}
+
+func TestBuildCodexArgsIncludesOutputFile(t *testing.T) {
+	args := buildCodexArgs("/tmp/work", "/tmp/out.txt")
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "exec") {
+		t.Fatalf("expected exec command, got %q", joined)
+	}
+	if !strings.Contains(joined, "-C /tmp/work") {
+		t.Fatalf("expected working directory, got %q", joined)
+	}
+	if !strings.Contains(joined, "--output-last-message /tmp/out.txt") {
+		t.Fatalf("expected output file flag, got %q", joined)
+	}
+	if !strings.Contains(joined, "--ephemeral") {
+		t.Fatalf("expected ephemeral execution, got %q", joined)
+	}
+}
+
+func TestCreateCodexCLIStreamFnStreamsFinalMessage(t *testing.T) {
+	recordFile := t.TempDir() + "/codex-record.jsonl"
+	cwd := t.TempDir()
+
+	restore := stubCodexRuntime(t, recordFile, "success", cwd)
+	defer restore()
+
+	fn := CreateCodexCLIStreamFn("ceo")
+	chunks := collectStreamChunks(fn([]agent.Message{
+		{Role: "system", Content: "You are the CEO."},
+		{Role: "user", Content: "Ship it."},
+	}, nil))
+
+	if joinedChunkText(chunks) != "codex final answer" {
+		t.Fatalf("unexpected codex response: %#v", chunks)
+	}
+
+	records := readCodexHelperRecords(t, recordFile)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 codex invocation, got %d", len(records))
+	}
+	if !containsArgPair(records[0].Args, "-C", cwd) {
+		t.Fatalf("expected codex cwd arg, got %#v", records[0].Args)
+	}
+	if !strings.Contains(records[0].Stdin, "<system>") {
+		t.Fatalf("expected system prompt wrapper in stdin, got %q", records[0].Stdin)
+	}
+}
+
+func TestCreateCodexCLIStreamFnShowsLoginError(t *testing.T) {
+	recordFile := t.TempDir() + "/codex-login-record.jsonl"
+	cwd := t.TempDir()
+
+	restore := stubCodexRuntime(t, recordFile, "login-required", cwd)
+	defer restore()
+
+	fn := CreateCodexCLIStreamFn("ceo")
+	chunks := collectStreamChunks(fn([]agent.Message{{Role: "user", Content: "hello"}}, nil))
+	if !hasErrorChunkContaining(chunks, "Codex CLI requires login") {
+		t.Fatalf("expected login guidance error, got %#v", chunks)
+	}
+}
+
+func readCodexHelperRecords(t *testing.T, path string) []codexHelperRecord {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read record file: %v", err)
+	}
+
+	var records []codexHelperRecord
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var record codexHelperRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("unmarshal helper record: %v", err)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func stubCodexRuntime(t *testing.T, recordFile string, scenario string, cwd string) func() {
+	t.Helper()
+
+	oldLookPath := codexLookPath
+	oldCommand := codexCommand
+	oldGetwd := codexGetwd
+	t.Setenv("GO_WANT_CODEX_HELPER_PROCESS", "1")
+	t.Setenv("CODEX_TEST_RECORD_FILE", recordFile)
+	t.Setenv("CODEX_TEST_SCENARIO", scenario)
+
+	codexLookPath = func(file string) (string, error) {
+		return "/usr/bin/codex", nil
+	}
+	codexGetwd = func() (string, error) {
+		return cwd, nil
+	}
+	codexCommand = func(name string, args ...string) *exec.Cmd {
+		cmdArgs := []string{"-test.run=TestCodexHelperProcess", "--"}
+		cmdArgs = append(cmdArgs, args...)
+		return exec.Command(os.Args[0], cmdArgs...)
+	}
+
+	return func() {
+		codexLookPath = oldLookPath
+		codexCommand = oldCommand
+		codexGetwd = oldGetwd
+	}
+}
+
+func TestCodexHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_CODEX_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	doubleDash := 0
+	for i, arg := range args {
+		if arg == "--" {
+			doubleDash = i
+			break
+		}
+	}
+	codexArgs := append([]string(nil), args[doubleDash+1:]...)
+	stdin, _ := io.ReadAll(os.Stdin)
+
+	recordPath := os.Getenv("CODEX_TEST_RECORD_FILE")
+	record, _ := json.Marshal(codexHelperRecord{Args: codexArgs, Stdin: string(stdin)})
+	file, err := os.OpenFile(recordPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open helper record file: %v", err)
+	}
+	if _, err := file.Write(append(record, '\n')); err != nil {
+		t.Fatalf("write helper record: %v", err)
+	}
+	file.Close()
+
+	outputPath := ""
+	for i := 0; i < len(codexArgs)-1; i++ {
+		if codexArgs[i] == "--output-last-message" {
+			outputPath = codexArgs[i+1]
+			break
+		}
+	}
+	if outputPath == "" {
+		t.Fatalf("missing --output-last-message arg: %#v", codexArgs)
+	}
+
+	switch os.Getenv("CODEX_TEST_SCENARIO") {
+	case "success":
+		if err := os.WriteFile(outputPath, []byte("codex final answer"), 0o644); err != nil {
+			t.Fatalf("write codex output: %v", err)
+		}
+		os.Exit(0)
+	case "login-required":
+		_ = os.WriteFile(outputPath, []byte(""), 0o644)
+		_, _ = os.Stderr.WriteString("authentication required\n")
+		os.Exit(1)
+	default:
+		t.Fatalf("unknown helper scenario: %s", os.Getenv("CODEX_TEST_SCENARIO"))
+	}
+}

--- a/internal/provider/oneshot.go
+++ b/internal/provider/oneshot.go
@@ -1,0 +1,19 @@
+package provider
+
+import (
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// RunConfiguredOneShot runs a single-shot generation using the configured LLM provider.
+// Providers without a dedicated one-shot path fall back to Claude for now.
+func RunConfiguredOneShot(systemPrompt, prompt, cwd string) (string, error) {
+	cfg, _ := config.Load()
+	switch strings.TrimSpace(cfg.LLMProvider) {
+	case "codex":
+		return RunCodexOneShot(systemPrompt, prompt, cwd)
+	default:
+		return RunClaudeOneShot(systemPrompt, prompt, cwd)
+	}
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -20,6 +20,13 @@ func TestClaudeStreamFnBuilds(t *testing.T) {
 	}
 }
 
+func TestCodexStreamFnBuilds(t *testing.T) {
+	fn := provider.CreateCodexCLIStreamFn("test-agent")
+	if fn == nil {
+		t.Fatal("expected non-nil StreamFn")
+	}
+}
+
 func TestNexAskStreamFn_NoAPIKey(t *testing.T) {
 	c := api.NewClient("") // no key
 	fn := provider.CreateNexAskStreamFn(c)

--- a/internal/provider/resolver.go
+++ b/internal/provider/resolver.go
@@ -16,6 +16,8 @@ func DefaultStreamFnResolver(client *api.Client) agent.StreamFnResolver {
 			cfg.LLMProvider = "claude-code"
 		}
 		switch cfg.LLMProvider {
+		case "codex":
+			return CreateCodexCLIStreamFn(agentSlug)
 		case "gemini":
 			return CreateGeminiStreamFn(cfg.GeminiAPIKey)
 		case "nex-ask":

--- a/internal/team/capabilities.go
+++ b/internal/team/capabilities.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+
+	"github.com/nex-crm/wuphf/internal/config"
 )
 
 type CapabilityLevel string
@@ -44,6 +46,7 @@ type TmuxCapability struct {
 
 type RuntimeCapabilities struct {
 	Tmux     TmuxCapability
+	Codex    CapabilityStatus
 	Items    []CapabilityStatus
 	Registry CapabilityRegistry
 }
@@ -60,7 +63,9 @@ func DetectRuntimeCapabilities() RuntimeCapabilities {
 func DetectRuntimeCapabilitiesWithOptions(opts CapabilityProbeOptions) RuntimeCapabilities {
 	tmuxStatus, tmux := probeTmuxCapability()
 	claudeStatus := probeBinaryCapability("claude", "Install claude so WUPHF can start teammate runtime sessions.")
-	registry := buildCapabilityRegistry(tmuxStatus, claudeStatus, opts)
+	codexStatus := probeBinaryCapability("codex", "Install Codex CLI and run `codex login` so WUPHF can start the headless Codex office runtime.")
+	cfg, _ := config.Load()
+	registry := buildCapabilityRegistry(strings.TrimSpace(cfg.LLMProvider), tmuxStatus, claudeStatus, codexStatus, opts)
 	summaryKeys := []string{
 		CapabilityKeyOfficeRuntime,
 		CapabilityKeyDirectRuntime,
@@ -75,6 +80,7 @@ func DetectRuntimeCapabilitiesWithOptions(opts CapabilityProbeOptions) RuntimeCa
 	}
 	return RuntimeCapabilities{
 		Tmux:     tmux,
+		Codex:    codexStatus,
 		Items:    registry.SummaryStatuses(summaryKeys...),
 		Registry: registry,
 	}

--- a/internal/team/capability_registry.go
+++ b/internal/team/capability_registry.go
@@ -35,6 +35,7 @@ const (
 const (
 	CapabilityKeyTmux          = "tmux"
 	CapabilityKeyClaude        = "claude"
+	CapabilityKeyCodex         = "codex"
 	CapabilityKeyOfficeRuntime = "office_runtime"
 	CapabilityKeyDirectRuntime = "direct_runtime"
 	CapabilityKeyNex           = "nex"
@@ -118,15 +119,17 @@ func BuildCapabilityRegistry(runtime RuntimeCapabilities) CapabilityRegistry {
 	if len(runtime.Registry.Entries) > 0 {
 		return runtime.Registry
 	}
-	return buildCapabilityRegistry(runtimeCapabilityStatus(runtime, "tmux"), runtimeCapabilityStatus(runtime, "claude"), CapabilityProbeOptions{})
+	cfg, _ := config.Load()
+	return buildCapabilityRegistry(strings.TrimSpace(cfg.LLMProvider), runtimeCapabilityStatus(runtime, "tmux"), runtimeCapabilityStatus(runtime, "claude"), runtimeCapabilityStatus(runtime, "codex"), CapabilityProbeOptions{})
 }
 
-func buildCapabilityRegistry(tmuxStatus, claudeStatus CapabilityStatus, opts CapabilityProbeOptions) CapabilityRegistry {
+func buildCapabilityRegistry(providerName string, tmuxStatus, claudeStatus, codexStatus CapabilityStatus, opts CapabilityProbeOptions) CapabilityRegistry {
 	entries := []CapabilityDescriptor{
-		buildOfficeRuntimeDescriptor(tmuxStatus, claudeStatus),
-		buildDirectRuntimeDescriptor(claudeStatus),
+		buildOfficeRuntimeDescriptor(providerName, tmuxStatus, claudeStatus, codexStatus),
+		buildDirectRuntimeDescriptor(providerName, claudeStatus, codexStatus),
 		descriptorFromStatus(CapabilityKeyTmux, "tmux", CapabilityCategoryRuntime, tmuxStatus),
 		descriptorFromStatus(CapabilityKeyClaude, "claude", CapabilityCategoryRuntime, claudeStatus),
+		descriptorFromStatus(CapabilityKeyCodex, "codex", CapabilityCategoryRuntime, codexStatus),
 		buildNexDescriptor(),
 		buildActionCapabilityDescriptor(CapabilityKeyActions, "Action execution", CapabilityCategoryAction, action.CapabilityActionExecute),
 		buildActionCapabilityDescriptor(CapabilityKeyWorkflows, "Workflow execution", CapabilityCategoryWorkflow, action.CapabilityWorkflowExecute),
@@ -154,7 +157,23 @@ func RegistryKeyForActionCapability(cap action.Capability) string {
 	}
 }
 
-func buildOfficeRuntimeDescriptor(tmuxStatus, claudeStatus CapabilityStatus) CapabilityDescriptor {
+func buildOfficeRuntimeDescriptor(providerName string, tmuxStatus, claudeStatus, codexStatus CapabilityStatus) CapabilityDescriptor {
+	if strings.EqualFold(strings.TrimSpace(providerName), "codex") {
+		level := codexStatus.Level
+		lifecycle := CapabilityLifecycleReady
+		if level != CapabilityReady {
+			lifecycle = CapabilityLifecycleNeedsSetup
+		}
+		return CapabilityDescriptor{
+			Key:       CapabilityKeyOfficeRuntime,
+			Label:     "Office runtime",
+			Category:  CapabilityCategoryOffice,
+			Level:     level,
+			Lifecycle: lifecycle,
+			Detail:    codexStatus.Detail,
+			NextStep:  codexStatus.NextStep,
+		}
+	}
 	level := CapabilityReady
 	lifecycle := CapabilityLifecycleReady
 	nextStep := ""
@@ -174,8 +193,12 @@ func buildOfficeRuntimeDescriptor(tmuxStatus, claudeStatus CapabilityStatus) Cap
 	}
 }
 
-func buildDirectRuntimeDescriptor(claudeStatus CapabilityStatus) CapabilityDescriptor {
-	level := claudeStatus.Level
+func buildDirectRuntimeDescriptor(providerName string, claudeStatus, codexStatus CapabilityStatus) CapabilityDescriptor {
+	status := claudeStatus
+	if strings.EqualFold(strings.TrimSpace(providerName), "codex") {
+		status = codexStatus
+	}
+	level := status.Level
 	lifecycle := CapabilityLifecycleReady
 	if level != CapabilityReady {
 		lifecycle = CapabilityLifecycleNeedsSetup
@@ -186,8 +209,8 @@ func buildDirectRuntimeDescriptor(claudeStatus CapabilityStatus) CapabilityDescr
 		Category:  CapabilityCategoryDirect,
 		Level:     level,
 		Lifecycle: lifecycle,
-		Detail:    claudeStatus.Detail,
-		NextStep:  claudeStatus.NextStep,
+		Detail:    status.Detail,
+		NextStep:  status.NextStep,
 	}
 }
 
@@ -361,6 +384,13 @@ func runtimeCapabilityStatus(runtime RuntimeCapabilities, name string) Capabilit
 		status := runtime.Tmux.status()
 		if strings.TrimSpace(status.Name) == "" {
 			status.Name = "tmux"
+		}
+		return status
+	}
+	if name == "codex" && strings.TrimSpace(runtime.Codex.Name) != "" {
+		status := runtime.Codex
+		if strings.TrimSpace(status.Name) == "" {
+			status.Name = "codex"
 		}
 		return status
 	}

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -1,0 +1,291 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+var (
+	headlessCodexLookPath       = exec.LookPath
+	headlessCodexCommandContext = exec.CommandContext
+	headlessCodexExecutablePath = os.Executable
+)
+
+func (l *Launcher) launchHeadlessCodex() error {
+	killStaleBroker()
+
+	l.broker = NewBroker()
+	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
+		return fmt.Errorf("set session mode: %w", err)
+	}
+	if err := l.broker.Start(); err != nil {
+		return fmt.Errorf("start broker: %w", err)
+	}
+
+	l.headlessCtx, l.headlessCancel = context.WithCancel(context.Background())
+
+	go l.notifyAgentsLoop()
+	if !l.isOneOnOne() {
+		go l.notifyTaskActionsLoop()
+		go l.pollNexNotificationsLoop()
+		go l.watchdogSchedulerLoop()
+	}
+
+	return nil
+}
+
+func (l *Launcher) enqueueHeadlessCodexTurn(slug string, prompt string) {
+	slug = strings.TrimSpace(slug)
+	prompt = strings.TrimSpace(prompt)
+	if slug == "" || prompt == "" {
+		return
+	}
+
+	l.headlessMu.Lock()
+	if l.headlessRunning[slug] {
+		l.headlessPending[slug] = prompt
+		l.headlessMu.Unlock()
+		return
+	}
+	l.headlessRunning[slug] = true
+	l.headlessMu.Unlock()
+
+	go l.runHeadlessCodexQueue(slug, prompt)
+}
+
+func (l *Launcher) runHeadlessCodexQueue(slug string, prompt string) {
+	current := prompt
+	for {
+		if ctx := l.headlessCtx; ctx != nil {
+			select {
+			case <-ctx.Done():
+				l.finishHeadlessTurn(slug)
+				return
+			default:
+			}
+		}
+
+		if err := l.runHeadlessCodexTurn(slug, current); err != nil {
+			appendHeadlessCodexLog(slug, fmt.Sprintf("error: %v", err))
+		}
+
+		l.headlessMu.Lock()
+		next, ok := l.headlessPending[slug]
+		if ok {
+			delete(l.headlessPending, slug)
+			l.headlessMu.Unlock()
+			current = next
+			continue
+		}
+		delete(l.headlessRunning, slug)
+		l.headlessMu.Unlock()
+		return
+	}
+}
+
+func (l *Launcher) finishHeadlessTurn(slug string) {
+	l.headlessMu.Lock()
+	delete(l.headlessRunning, slug)
+	delete(l.headlessPending, slug)
+	l.headlessMu.Unlock()
+}
+
+func (l *Launcher) runHeadlessCodexTurn(slug string, notification string) error {
+	if _, err := headlessCodexLookPath("codex"); err != nil {
+		return fmt.Errorf("codex not found: %w", err)
+	}
+	if l == nil || l.broker == nil {
+		return fmt.Errorf("broker is not running")
+	}
+
+	outputFile, err := os.CreateTemp("", "wuphf-office-codex-*.txt")
+	if err != nil {
+		return fmt.Errorf("create codex output file: %w", err)
+	}
+	outputPath := outputFile.Name()
+	outputFile.Close()
+	defer os.Remove(outputPath)
+
+	overrides, err := l.buildCodexOfficeConfigOverrides(slug)
+	if err != nil {
+		return err
+	}
+
+	args := make([]string, 0, 16+len(overrides)*2)
+	if l.unsafe {
+		args = append(args, "--dangerously-bypass-approvals-and-sandbox")
+	} else {
+		args = append(args, "-a", "never", "-s", "workspace-write")
+	}
+	args = append(args,
+		"exec",
+		"-C", l.cwd,
+		"--skip-git-repo-check",
+		"--ephemeral",
+		"--color", "never",
+	)
+	for _, override := range overrides {
+		args = append(args, "-c", override)
+	}
+	args = append(args, "--output-last-message", outputPath, "-")
+
+	ctx := l.headlessCtx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := headlessCodexCommandContext(ctx, "codex", args...)
+	cmd.Dir = l.cwd
+	cmd.Env = l.buildHeadlessCodexEnv(slug)
+	cmd.Stdin = strings.NewReader(buildHeadlessCodexPrompt(l.buildPrompt(slug), notification))
+
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if stderrText := strings.TrimSpace(stderr.String()); stderrText != "" {
+			appendHeadlessCodexLog(slug, "stderr: "+stderrText)
+			return fmt.Errorf("%w: %s", err, stderrText)
+		}
+		return err
+	}
+
+	if raw, err := os.ReadFile(outputPath); err == nil {
+		if text := strings.TrimSpace(string(raw)); text != "" {
+			appendHeadlessCodexLog(slug, "result: "+text)
+		}
+	}
+	return nil
+}
+
+func (l *Launcher) buildHeadlessCodexEnv(slug string) []string {
+	env := os.Environ()
+	env = append(env,
+		"WUPHF_AGENT_SLUG="+slug,
+		"WUPHF_BROKER_TOKEN="+l.broker.Token(),
+		"WUPHF_HEADLESS_PROVIDER=codex",
+	)
+	if config.ResolveNoNex() {
+		env = append(env, "WUPHF_NO_NEX=1")
+	}
+	if l.isOneOnOne() {
+		env = append(env,
+			"WUPHF_ONE_ON_ONE=1",
+			"WUPHF_ONE_ON_ONE_AGENT="+l.oneOnOneAgent(),
+		)
+	}
+	if secret := strings.TrimSpace(config.ResolveOneSecret()); secret != "" {
+		env = append(env, "ONE_SECRET="+secret)
+	}
+	if identity := strings.TrimSpace(config.ResolveOneIdentity()); identity != "" {
+		env = append(env, "ONE_IDENTITY="+identity)
+		if identityType := strings.TrimSpace(config.ResolveOneIdentityType()); identityType != "" {
+			env = append(env, "ONE_IDENTITY_TYPE="+identityType)
+		}
+	}
+	return env
+}
+
+func (l *Launcher) buildCodexOfficeConfigOverrides(slug string) ([]string, error) {
+	wuphfBinary, err := headlessCodexExecutablePath()
+	if err != nil {
+		return nil, err
+	}
+	wuphfEnv := map[string]string{
+		"WUPHF_AGENT_SLUG":   slug,
+		"WUPHF_BROKER_TOKEN": l.broker.Token(),
+	}
+	if config.ResolveNoNex() {
+		wuphfEnv["WUPHF_NO_NEX"] = "1"
+	}
+	if l.isOneOnOne() {
+		wuphfEnv["WUPHF_ONE_ON_ONE"] = "1"
+		wuphfEnv["WUPHF_ONE_ON_ONE_AGENT"] = l.oneOnOneAgent()
+	}
+	if secret := strings.TrimSpace(config.ResolveOneSecret()); secret != "" {
+		wuphfEnv["ONE_SECRET"] = secret
+	}
+	if identity := strings.TrimSpace(config.ResolveOneIdentity()); identity != "" {
+		wuphfEnv["ONE_IDENTITY"] = identity
+		if identityType := strings.TrimSpace(config.ResolveOneIdentityType()); identityType != "" {
+			wuphfEnv["ONE_IDENTITY_TYPE"] = identityType
+		}
+	}
+
+	overrides := []string{
+		fmt.Sprintf(`mcp_servers.wuphf-office.command=%s`, tomlQuote(wuphfBinary)),
+		`mcp_servers.wuphf-office.args=["mcp-team"]`,
+		fmt.Sprintf(`mcp_servers.wuphf-office.env=%s`, tomlInlineTable(wuphfEnv)),
+	}
+
+	if !config.ResolveNoNex() {
+		if nexMCP, err := headlessCodexLookPath("nex-mcp"); err == nil {
+			overrides = append(overrides, fmt.Sprintf(`mcp_servers.nex.command=%s`, tomlQuote(nexMCP)))
+			nexEnv := map[string]string{}
+			if apiKey := strings.TrimSpace(config.ResolveAPIKey("")); apiKey != "" {
+				nexEnv["WUPHF_API_KEY"] = apiKey
+				nexEnv["NEX_API_KEY"] = apiKey
+			}
+			if len(nexEnv) > 0 {
+				overrides = append(overrides, fmt.Sprintf(`mcp_servers.nex.env=%s`, tomlInlineTable(nexEnv)))
+			}
+		}
+	}
+
+	return overrides, nil
+}
+
+func buildHeadlessCodexPrompt(systemPrompt string, prompt string) string {
+	var parts []string
+	if trimmed := strings.TrimSpace(systemPrompt); trimmed != "" {
+		parts = append(parts, "<system>\n"+trimmed+"\n</system>")
+	}
+	if trimmed := strings.TrimSpace(prompt); trimmed != "" {
+		parts = append(parts, trimmed)
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func appendHeadlessCodexLog(slug string, line string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	logDir := filepath.Join(home, ".wuphf", "logs")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return
+	}
+	path := filepath.Join(logDir, "headless-codex-"+slug+".log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	_, _ = fmt.Fprintf(f, "[%s] %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(line))
+}
+
+func tomlQuote(value string) string {
+	return fmt.Sprintf("%q", value)
+}
+
+func tomlInlineTable(values map[string]string) string {
+	if len(values) == 0 {
+		return "{}"
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%s", key, tomlQuote(values[key])))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -1,0 +1,231 @@
+package team
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+type headlessCodexRecord struct {
+	Args  []string `json:"args"`
+	Env   []string `json:"env"`
+	Stdin string   `json:"stdin"`
+}
+
+func TestNewLauncherUsesCodexProviderFromConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WUPHF_BROKER_TOKEN", "")
+	if err := config.Save(config.Config{LLMProvider: "codex"}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	l, err := NewLauncher("founding-team")
+	if err != nil {
+		t.Fatalf("NewLauncher: %v", err)
+	}
+	if l.provider != "codex" {
+		t.Fatalf("expected codex provider, got %q", l.provider)
+	}
+	if l.UsesTmuxRuntime() {
+		t.Fatal("expected codex launcher to use headless runtime")
+	}
+}
+
+func TestBuildCodexOfficeConfigOverridesIncludesOfficeMCPEnv(t *testing.T) {
+	oldExecutablePath := headlessCodexExecutablePath
+	oldLookPath := headlessCodexLookPath
+	headlessCodexExecutablePath = func() (string, error) { return "/tmp/wuphf", nil }
+	headlessCodexLookPath = func(file string) (string, error) {
+		return "", exec.ErrNotFound
+	}
+	defer func() {
+		headlessCodexExecutablePath = oldExecutablePath
+		headlessCodexLookPath = oldLookPath
+	}()
+
+	t.Setenv("WUPHF_NO_NEX", "1")
+
+	broker := NewBroker()
+	if err := broker.SetSessionMode(SessionModeOneOnOne, "pm"); err != nil {
+		t.Fatalf("SetSessionMode: %v", err)
+	}
+	l := &Launcher{
+		broker:      broker,
+		pack:        agent.GetPack("founding-team"),
+		sessionMode: SessionModeOneOnOne,
+		oneOnOne:    "pm",
+	}
+
+	overrides, err := l.buildCodexOfficeConfigOverrides("pm")
+	if err != nil {
+		t.Fatalf("buildCodexOfficeConfigOverrides: %v", err)
+	}
+	joined := strings.Join(overrides, "\n")
+	if !strings.Contains(joined, `mcp_servers.wuphf-office.command="/tmp/wuphf"`) {
+		t.Fatalf("expected WUPHF MCP command override, got %q", joined)
+	}
+	if !strings.Contains(joined, `mcp_servers.wuphf-office.args=["mcp-team"]`) {
+		t.Fatalf("expected WUPHF MCP args override, got %q", joined)
+	}
+	if !strings.Contains(joined, `WUPHF_AGENT_SLUG="pm"`) {
+		t.Fatalf("expected agent slug in MCP env, got %q", joined)
+	}
+	if !strings.Contains(joined, `WUPHF_BROKER_TOKEN="`) {
+		t.Fatalf("expected broker token in MCP env, got %q", joined)
+	}
+	if !strings.Contains(joined, `WUPHF_ONE_ON_ONE="1"`) || !strings.Contains(joined, `WUPHF_ONE_ON_ONE_AGENT="pm"`) {
+		t.Fatalf("expected 1:1 env in MCP override, got %q", joined)
+	}
+	if strings.Contains(joined, `mcp_servers.nex.command=`) {
+		t.Fatalf("expected Nex MCP to stay disabled with WUPHF_NO_NEX, got %q", joined)
+	}
+}
+
+func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
+	recordFile := filepath.Join(t.TempDir(), "headless-codex-record.jsonl")
+	oldLookPath := headlessCodexLookPath
+	oldExecutablePath := headlessCodexExecutablePath
+	oldCommandContext := headlessCodexCommandContext
+	headlessCodexLookPath = func(file string) (string, error) {
+		switch file {
+		case "codex":
+			return "/usr/bin/codex", nil
+		default:
+			return "", exec.ErrNotFound
+		}
+	}
+	headlessCodexExecutablePath = func() (string, error) { return "/tmp/wuphf", nil }
+	headlessCodexCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
+		cmdArgs := []string{"-test.run=TestHeadlessCodexHelperProcess", "--"}
+		cmdArgs = append(cmdArgs, args...)
+		return exec.CommandContext(ctx, os.Args[0], cmdArgs...)
+	}
+	defer func() {
+		headlessCodexLookPath = oldLookPath
+		headlessCodexExecutablePath = oldExecutablePath
+		headlessCodexCommandContext = oldCommandContext
+	}()
+
+	t.Setenv("GO_WANT_HEADLESS_CODEX_HELPER_PROCESS", "1")
+	t.Setenv("HEADLESS_CODEX_RECORD_FILE", recordFile)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_NO_NEX", "1")
+
+	l := &Launcher{
+		pack:        agent.GetPack("founding-team"),
+		cwd:         t.TempDir(),
+		broker:      NewBroker(),
+		headlessCtx: context.Background(),
+	}
+
+	if err := l.runHeadlessCodexTurn("ceo", "You have new work in #launch."); err != nil {
+		t.Fatalf("runHeadlessCodexTurn: %v", err)
+	}
+
+	record := readHeadlessCodexRecord(t, recordFile)
+	joinedArgs := strings.Join(record.Args, " ")
+	if !strings.Contains(joinedArgs, "exec") || !strings.Contains(joinedArgs, "--ephemeral") {
+		t.Fatalf("expected codex exec args, got %#v", record.Args)
+	}
+	if !strings.Contains(joinedArgs, `mcp_servers.wuphf-office.command="/tmp/wuphf"`) {
+		t.Fatalf("expected office MCP override, got %#v", record.Args)
+	}
+	if !containsEnv(record.Env, "WUPHF_AGENT_SLUG=ceo") {
+		t.Fatalf("expected agent env, got %#v", record.Env)
+	}
+	if !containsEnv(record.Env, "WUPHF_HEADLESS_PROVIDER=codex") {
+		t.Fatalf("expected headless provider env, got %#v", record.Env)
+	}
+	if !containsEnvPrefix(record.Env, "WUPHF_BROKER_TOKEN=") {
+		t.Fatalf("expected broker token env, got %#v", record.Env)
+	}
+	if !strings.Contains(record.Stdin, "<system>") || !strings.Contains(record.Stdin, "You have new work in #launch.") {
+		t.Fatalf("expected notification prompt in stdin, got %q", record.Stdin)
+	}
+}
+
+func TestHeadlessCodexHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HEADLESS_CODEX_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	doubleDash := 0
+	for i, arg := range args {
+		if arg == "--" {
+			doubleDash = i
+			break
+		}
+	}
+	codexArgs := append([]string(nil), args[doubleDash+1:]...)
+	stdin, _ := io.ReadAll(os.Stdin)
+
+	record := headlessCodexRecord{
+		Args:  codexArgs,
+		Env:   os.Environ(),
+		Stdin: string(stdin),
+	}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		t.Fatalf("marshal helper record: %v", err)
+	}
+	recordPath := os.Getenv("HEADLESS_CODEX_RECORD_FILE")
+	if err := os.WriteFile(recordPath, append(raw, '\n'), 0o644); err != nil {
+		t.Fatalf("write helper record: %v", err)
+	}
+
+	outputPath := ""
+	for i := 0; i < len(codexArgs)-1; i++ {
+		if codexArgs[i] == "--output-last-message" {
+			outputPath = codexArgs[i+1]
+			break
+		}
+	}
+	if outputPath == "" {
+		t.Fatalf("missing --output-last-message arg: %#v", codexArgs)
+	}
+	if err := os.WriteFile(outputPath, []byte("codex office reply"), 0o644); err != nil {
+		t.Fatalf("write codex output: %v", err)
+	}
+	os.Exit(0)
+}
+
+func readHeadlessCodexRecord(t *testing.T, path string) headlessCodexRecord {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read record file: %v", err)
+	}
+	var record headlessCodexRecord
+	if err := json.Unmarshal(raw, &record); err != nil {
+		t.Fatalf("unmarshal record: %v", err)
+	}
+	return record
+}
+
+func containsEnv(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEnvPrefix(values []string, prefix string) bool {
+	for _, value := range values {
+		if strings.HasPrefix(value, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -98,6 +98,13 @@ type Launcher struct {
 	unsafe      bool
 	sessionMode string
 	oneOnOne    string
+	provider    string
+
+	headlessMu      sync.Mutex
+	headlessCtx     context.Context
+	headlessCancel  context.CancelFunc
+	headlessRunning map[string]bool
+	headlessPending map[string]string
 }
 
 // SetUnsafe enables unrestricted permissions for all agents (CLI-only flag).
@@ -110,8 +117,8 @@ func (l *Launcher) SetOneOnOne(slug string) {
 
 // NewLauncher creates a launcher for the given pack.
 func NewLauncher(packSlug string) (*Launcher, error) {
+	cfg, _ := config.Load()
 	if packSlug == "" {
-		cfg, _ := config.Load()
 		packSlug = cfg.Pack
 		if packSlug == "" {
 			packSlug = "founding-team"
@@ -130,17 +137,26 @@ func NewLauncher(packSlug string) (*Launcher, error) {
 	sessionMode, oneOnOne := loadRunningSessionMode()
 
 	return &Launcher{
-		packSlug:    packSlug,
-		pack:        pack,
-		sessionName: SessionName,
-		cwd:         cwd,
-		sessionMode: sessionMode,
-		oneOnOne:    oneOnOne,
+		packSlug:        packSlug,
+		pack:            pack,
+		sessionName:     SessionName,
+		cwd:             cwd,
+		sessionMode:     sessionMode,
+		oneOnOne:        oneOnOne,
+		provider:        firstNonEmpty(strings.TrimSpace(cfg.LLMProvider), "claude-code"),
+		headlessRunning: make(map[string]bool),
+		headlessPending: make(map[string]string),
 	}, nil
 }
 
 // Preflight checks that required tools are available.
 func (l *Launcher) Preflight() error {
+	if l.usesCodexRuntime() {
+		if _, err := exec.LookPath("codex"); err != nil {
+			return fmt.Errorf("codex not found. Install Codex CLI and run `codex login`")
+		}
+		return nil
+	}
 	if _, err := exec.LookPath("tmux"); err != nil {
 		return fmt.Errorf("tmux not found. Install: brew install tmux")
 	}
@@ -154,6 +170,9 @@ func (l *Launcher) Preflight() error {
 //   - Window 0 "team": Channel on left, agent panes on the right
 //   - No extra windows: all team activity is visible in one place
 func (l *Launcher) Launch() error {
+	if l.usesCodexRuntime() {
+		return l.launchHeadlessCodex()
+	}
 	mcpConfig, err := l.ensureMCPConfig()
 	if err != nil {
 		return fmt.Errorf("prepare mcp config: %w", err)
@@ -665,6 +684,10 @@ func (l *Launcher) sendTaskUpdate(paneTarget, slug, channel, taskID, from, conte
 		"[Task #%s %s from @%s]: %s — You own this task. Reply with the concrete next step and update via team_task with my_slug \"%s\".",
 		channel, taskID, from, truncate(content, 150), slug,
 	)
+	if l.usesCodexRuntime() {
+		l.enqueueHeadlessCodexTurn(slug, notification)
+		return
+	}
 	exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
 		"-t", paneTarget,
 		"-l",
@@ -1813,6 +1836,26 @@ func (l *Launcher) oneOnOneAgent() string {
 	return NormalizeOneOnOneAgent(l.oneOnOne)
 }
 
+func (l *Launcher) usesCodexRuntime() bool {
+	return strings.EqualFold(strings.TrimSpace(l.provider), "codex")
+}
+
+func (l *Launcher) UsesTmuxRuntime() bool {
+	return !l.usesCodexRuntime()
+}
+
+func (l *Launcher) BrokerToken() string {
+	if l == nil || l.broker == nil {
+		return ""
+	}
+	return l.broker.Token()
+}
+
+// OneOnOneAgent returns the active direct-session agent slug, if any.
+func (l *Launcher) OneOnOneAgent() string {
+	return l.oneOnOneAgent()
+}
+
 // killStaleBroker kills any process holding port 7890 from a previous run.
 func killStaleBroker() {
 	out, err := exec.Command("lsof", "-i", fmt.Sprintf(":%d", BrokerPort), "-t").Output()
@@ -1863,8 +1906,14 @@ func (l *Launcher) Attach() error {
 
 // Kill destroys the tmux session, all agent processes, and the broker.
 func (l *Launcher) Kill() error {
+	if l.headlessCancel != nil {
+		l.headlessCancel()
+	}
 	if l.broker != nil {
 		l.broker.Stop()
+	}
+	if l.usesCodexRuntime() {
+		return nil
 	}
 	err := exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 	if err != nil {
@@ -1879,6 +1928,16 @@ func (l *Launcher) Kill() error {
 }
 
 func (l *Launcher) ResetSession() error {
+	if l.usesCodexRuntime() {
+		if l != nil && l.broker != nil {
+			l.broker.Reset()
+			return nil
+		}
+		if err := ResetBrokerState(); err != nil {
+			return fmt.Errorf("reset broker state: %w", err)
+		}
+		return nil
+	}
 	if err := provider.ResetClaudeSessions(); err != nil {
 		return fmt.Errorf("reset Claude sessions: %w", err)
 	}
@@ -1893,6 +1952,9 @@ func (l *Launcher) ResetSession() error {
 }
 
 func (l *Launcher) ReconfigureSession() error {
+	if l.usesCodexRuntime() {
+		return nil
+	}
 	return l.reconfigureVisibleAgents()
 }
 
@@ -2029,6 +2091,10 @@ func (l *Launcher) sendChannelUpdate(paneTarget, slug, channel, msgID, from, con
 		}
 	}
 
+	if l.usesCodexRuntime() {
+		l.enqueueHeadlessCodexTurn(slug, notification)
+		return
+	}
 	exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
 		"-t", paneTarget,
 		"-l",

--- a/internal/team/template.go
+++ b/internal/team/template.go
@@ -51,7 +51,7 @@ Constraints:
 - permission_mode should usually be "plan" unless the role clearly needs autonomous editing/coding.
 `
 	userPrompt := "Design a new office teammate from this request:\n\n" + request
-	raw, err := provider.RunClaudeOneShot(systemPrompt, userPrompt, l.cwd)
+	raw, err := provider.RunConfiguredOneShot(systemPrompt, userPrompt, l.cwd)
 	if err != nil {
 		return generatedMemberTemplate{}, err
 	}

--- a/internal/tui/init_flow.go
+++ b/internal/tui/init_flow.go
@@ -11,6 +11,14 @@ import (
 	"github.com/nex-crm/wuphf/internal/config"
 )
 
+var initFlowLookPathFn = exec.LookPath
+
+type initReadinessCheck struct {
+	Label  string
+	Status string
+	Detail string
+}
+
 // InitPhase represents a step in the onboarding flow.
 type InitPhase string
 
@@ -50,21 +58,20 @@ func (f InitFlowModel) IsActive() bool {
 	return f.phase != InitIdle && f.phase != InitDone
 }
 
-// Start begins the init flow. API key → pack choice → done.
-// Provider is always claude-code.
+// Start begins the init flow. API key → provider choice → pack choice → done.
 func (f InitFlowModel) Start() (InitFlowModel, tea.Cmd) {
 	cfg, _ := config.Load()
-	if cfg.APIKey != "" {
-		f.apiKey = cfg.APIKey
+	f.apiKey = strings.TrimSpace(config.ResolveAPIKey(""))
+	f.provider = strings.TrimSpace(cfg.LLMProvider)
+	if f.provider == "" {
+		f.provider = "claude-code"
 	}
-	f.provider = "claude-code"
 	if f.apiKey == "" {
 		f.phase = InitAPIKey
 		return f, f.emitPhase(InitAPIKey)
 	}
-	// Already have API key — skip to pack choice
-	f.phase = InitPackChoice
-	return f, f.emitPhase(InitPackChoice)
+	f.phase = InitProviderChoice
+	return f, f.emitPhase(InitProviderChoice)
 }
 
 // Update advances the flow based on incoming messages.
@@ -117,9 +124,11 @@ func (f InitFlowModel) updateAPIKeyInput(msg tea.KeyMsg) (InitFlowModel, tea.Cmd
 		f.apiKey = key
 		f.keyError = ""
 		f.keyInput = nil
-		f.provider = "claude-code"
-		f.phase = InitPackChoice
-		return f, f.emitPhase(InitPackChoice)
+		if strings.TrimSpace(f.provider) == "" {
+			f.provider = "claude-code"
+		}
+		f.phase = InitProviderChoice
+		return f, f.emitPhase(InitProviderChoice)
 	case "backspace":
 		if len(f.keyInput) > 0 {
 			f.keyInput = f.keyInput[:len(f.keyInput)-1]
@@ -177,11 +186,16 @@ func (f InitFlowModel) emitPhase(phase InitPhase) tea.Cmd {
 // ProviderOptions returns the picker options for LLM provider selection.
 func ProviderOptions() []PickerOption {
 	claudeDesc := "Claude via claude CLI (recommended)"
-	if _, err := exec.LookPath("claude"); err != nil {
+	if _, err := initFlowLookPathFn("claude"); err != nil {
 		claudeDesc = "Claude via claude CLI (not found in PATH!)"
+	}
+	codexDesc := "Codex via codex CLI"
+	if _, err := initFlowLookPathFn("codex"); err != nil {
+		codexDesc = "Codex via codex CLI (not found in PATH!)"
 	}
 	options := []PickerOption{
 		{Label: "Claude Code (default)", Value: "claude-code", Description: claudeDesc},
+		{Label: "Codex CLI", Value: "codex", Description: codexDesc},
 		{Label: "Gemini", Value: "gemini", Description: "Google Gemini via API key"},
 	}
 	if !config.ResolveNoNex() {
@@ -215,8 +229,12 @@ func (f InitFlowModel) View() string {
 
 	view := labelStyle.Render(heading) + "\n" + muteStyle.Render(instructions)
 
+	if readiness := f.renderReadinessSummary(); readiness != "" {
+		view += "\n\n" + readiness
+	}
+
 	if f.requiresTextInput() {
-		view += "\n" + f.renderAPIKeyInput()
+		view += "\n\n" + f.renderAPIKeyInput()
 	}
 
 	return view
@@ -237,6 +255,160 @@ func (f InitFlowModel) renderAPIKeyInput() string {
 	}
 
 	return display
+}
+
+func (f InitFlowModel) renderReadinessSummary() string {
+	checks := f.readinessChecks()
+	if len(checks) == 0 {
+		return ""
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(NexBlue))
+	mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(MutedColor))
+
+	lines := []string{
+		titleStyle.Render("Setup Readiness"),
+		mutedStyle.Render("Use /doctor for the full capability report."),
+	}
+	for _, check := range checks {
+		lines = append(lines, f.renderReadinessCheck(check))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (f InitFlowModel) renderReadinessCheck(check initReadinessCheck) string {
+	statusStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("#E5E7EB")).
+		Background(lipgloss.Color(readinessStatusColor(check.Status))).
+		Padding(0, 1)
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(ValueColor))
+	detailStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(MutedColor))
+
+	return statusStyle.Render(strings.ToUpper(check.Status)) + " " +
+		labelStyle.Render(check.Label) + " " +
+		detailStyle.Render(check.Detail)
+}
+
+func readinessStatusColor(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "ready":
+		return "#166534"
+	case "next":
+		return "#1D4ED8"
+	default:
+		return "#991B1B"
+	}
+}
+
+func (f InitFlowModel) readinessChecks() []initReadinessCheck {
+	effectiveAPIKey := strings.TrimSpace(f.apiKey)
+	if effectiveAPIKey == "" {
+		effectiveAPIKey = strings.TrimSpace(config.ResolveAPIKey(""))
+	}
+	provider := strings.TrimSpace(f.provider)
+	if provider == "" {
+		provider = "claude-code"
+	}
+
+	checks := []initReadinessCheck{
+		{
+			Label:  "Nex identity",
+			Status: readinessStatusForBool(effectiveAPIKey != ""),
+			Detail: apiKeyReadinessDetail(effectiveAPIKey != ""),
+		},
+		{
+			Label:  "tmux office runtime",
+			Status: readinessStatusForBool(binaryAvailable("tmux")),
+			Detail: binaryReadinessDetail("tmux", "WUPHF can open the office panes.", "Install tmux before launching the office."),
+		},
+		{
+			Label:  "LLM runtime",
+			Status: providerRuntimeStatus(provider),
+			Detail: providerRuntimeDetail(provider),
+		},
+		{
+			Label:  "Agent pack",
+			Status: packReadinessStatus(f.pack),
+			Detail: packReadinessDetail(f.pack),
+		},
+		{
+			Label:  "Integrations",
+			Status: "ready",
+			Detail: config.OneSetupSummary(),
+		},
+	}
+
+	return checks
+}
+
+func readinessStatusForBool(ok bool) string {
+	if ok {
+		return "ready"
+	}
+	return "missing"
+}
+
+func apiKeyReadinessDetail(ok bool) string {
+	if ok {
+		return "WUPHF/Nex API key is configured."
+	}
+	return "Paste your WUPHF/Nex API key to enable memory and managed integrations."
+}
+
+func packReadinessStatus(pack string) string {
+	if strings.TrimSpace(pack) == "" {
+		return "next"
+	}
+	return "ready"
+}
+
+func packReadinessDetail(pack string) string {
+	if p := agent.GetPack(strings.TrimSpace(pack)); p != nil {
+		return "Selected " + p.Name + "."
+	}
+	if strings.TrimSpace(pack) != "" {
+		return "Selected " + pack + "."
+	}
+	return "Choose which team should open after setup."
+}
+
+func providerRuntimeStatus(provider string) string {
+	switch strings.TrimSpace(provider) {
+	case "", "claude-code":
+		return readinessStatusForBool(binaryAvailable("claude"))
+	case "codex":
+		return readinessStatusForBool(binaryAvailable("codex"))
+	default:
+		return "ready"
+	}
+}
+
+func providerRuntimeDetail(provider string) string {
+	switch strings.TrimSpace(provider) {
+	case "", "claude-code":
+		return binaryReadinessDetail("claude", "Claude CLI is ready for teammate sessions.", "Install claude or pick another provider.")
+	case "codex":
+		return binaryReadinessDetail("codex", "Codex CLI is ready for teammate sessions.", "Install codex or pick another provider.")
+	case "gemini":
+		return "Gemini uses an API key. No local CLI is required."
+	case "nex-ask":
+		return "Managed through Nex. WUPHF will route requests through your Nex identity."
+	default:
+		return provider + " is selected."
+	}
+}
+
+func binaryReadinessDetail(name, readyDetail, missingDetail string) string {
+	if binaryAvailable(name) {
+		return readyDetail
+	}
+	return missingDetail
+}
+
+func binaryAvailable(name string) bool {
+	_, err := initFlowLookPathFn(name)
+	return err == nil
 }
 
 func (f InitFlowModel) phaseText() (heading, instructions string) {

--- a/internal/tui/init_flow_test.go
+++ b/internal/tui/init_flow_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -15,6 +16,19 @@ func TestInitFlowStartsWithAPIKeyStepWhenMissing(t *testing.T) {
 	}
 }
 
+func TestInitFlowUsesResolvedAPIKeyFromEnv(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_API_KEY", "env-key")
+
+	flow, _ := NewInitFlow().Start()
+	if flow.Phase() != InitProviderChoice {
+		t.Fatalf("expected provider choice phase, got %q", flow.Phase())
+	}
+	if flow.apiKey != "env-key" {
+		t.Fatalf("expected resolved env API key, got %q", flow.apiKey)
+	}
+}
+
 func TestInitFlowSkipsToPackWhenAPIKeyExists(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	if err := config.Save(config.Config{APIKey: "wuphf-key"}); err != nil {
@@ -22,11 +36,39 @@ func TestInitFlowSkipsToPackWhenAPIKeyExists(t *testing.T) {
 	}
 
 	flow, _ := NewInitFlow().Start()
-	if flow.Phase() != InitPackChoice {
-		t.Fatalf("expected pack choice phase, got %q", flow.Phase())
+	if flow.Phase() != InitProviderChoice {
+		t.Fatalf("expected provider choice phase, got %q", flow.Phase())
 	}
 	if flow.provider != "claude-code" {
 		t.Fatalf("expected provider to default to claude-code, got %q", flow.provider)
+	}
+}
+
+func TestInitFlowViewShowsReadinessSummary(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	prevLookPath := initFlowLookPathFn
+	initFlowLookPathFn = func(name string) (string, error) {
+		switch name {
+		case "tmux", "claude":
+			return "/usr/bin/" + name, nil
+		default:
+			return "", fmt.Errorf("%s not found", name)
+		}
+	}
+	t.Cleanup(func() {
+		initFlowLookPathFn = prevLookPath
+	})
+
+	flow := NewInitFlow()
+	flow.phase = InitAPIKey
+	flow.provider = "claude-code"
+
+	view := flow.View()
+	if !containsAll(view, "Setup Readiness", "Nex identity", "tmux office runtime", "LLM runtime", "Agent pack") {
+		t.Fatalf("expected readiness summary in init view, got %q", view)
+	}
+	if !strings.Contains(view, "Paste your WUPHF/Nex API key") {
+		t.Fatalf("expected API key guidance in readiness summary, got %q", view)
 	}
 }
 
@@ -42,6 +84,16 @@ func TestInitFlowMentionsManagedIntegrations(t *testing.T) {
 	if instructions == "" || !containsAll(instructions, "One", "automatically") {
 		t.Fatalf("expected managed integration copy, got %q", instructions)
 	}
+}
+
+func TestProviderOptionsIncludeCodex(t *testing.T) {
+	options := ProviderOptions()
+	for _, opt := range options {
+		if opt.Value == "codex" {
+			return
+		}
+	}
+	t.Fatal("expected codex provider option")
 }
 
 func containsAll(s string, needles ...string) bool {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -62,6 +62,8 @@ func NewModel(panesMode bool) Model {
 	rt := NewRuntime(events)
 
 	hasAPIKey := config.ResolveAPIKey("") != ""
+	cfg, _ := config.Load()
+	providerName := strings.TrimSpace(cfg.LLMProvider)
 
 	m := Model{
 		runtime:     rt,
@@ -71,7 +73,7 @@ func NewModel(panesMode bool) Model {
 		hasAPIKey:   hasAPIKey,
 	}
 
-	if panesMode && HasClaude() {
+	if shouldUseEmbeddedPanes(providerName, panesMode, HasClaude()) {
 		// Embedded terminal mode (--panes flag): each agent gets its own PTY.
 		pm := NewPaneManager()
 		bus := NewGossipBus(rt.TeamLeadSlug)
@@ -91,7 +93,7 @@ func NewModel(panesMode bool) Model {
 		m.paneManager = pm
 		m.gossipBus = bus
 		m.roster = roster
-	} else if HasTmux() && HasClaude() {
+	} else if shouldUseTmuxChannelMode(providerName, HasTmux(), HasClaude()) {
 		// Channel mode (default): agents run in tmux, output feeds into stream view.
 		stream := NewStreamModel(rt, events)
 		stream.channelMode = true
@@ -108,6 +110,14 @@ func NewModel(panesMode bool) Model {
 	}
 
 	return m
+}
+
+func shouldUseEmbeddedPanes(providerName string, panesMode bool, hasClaude bool) bool {
+	return strings.TrimSpace(providerName) != "codex" && panesMode && hasClaude
+}
+
+func shouldUseTmuxChannelMode(providerName string, hasTmux bool, hasClaude bool) bool {
+	return strings.TrimSpace(providerName) != "codex" && hasTmux && hasClaude
 }
 
 // Init starts the appropriate mode.

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1,0 +1,21 @@
+package tui
+
+import "testing"
+
+func TestCodexDisablesTmuxAndPaneModes(t *testing.T) {
+	if shouldUseEmbeddedPanes("codex", true, true) {
+		t.Fatal("expected codex provider to disable embedded Claude panes")
+	}
+	if shouldUseTmuxChannelMode("codex", true, true) {
+		t.Fatal("expected codex provider to disable tmux channel mode")
+	}
+}
+
+func TestClaudeStillUsesTmuxModesWhenAvailable(t *testing.T) {
+	if !shouldUseEmbeddedPanes("claude-code", true, true) {
+		t.Fatal("expected claude provider to allow embedded panes")
+	}
+	if !shouldUseTmuxChannelMode("claude-code", true, true) {
+		t.Fatal("expected claude provider to allow tmux channel mode")
+	}
+}

--- a/internal/tui/stream.go
+++ b/internal/tui/stream.go
@@ -730,6 +730,13 @@ func (m StreamModel) handleSlashCommand(input string) (StreamModel, tea.Cmd) {
 		}
 		return m, nil
 	case "reset":
+		cfg, _ := config.Load()
+		if strings.TrimSpace(cfg.LLMProvider) == "codex" {
+			m.runtime.Reconfigure()
+			m.resetDelegationState()
+			m.appendSystemMessage("Codex runs ephemerally in WUPHF. The runtime was reconfigured and the next Codex task will start fresh.")
+			return m, nil
+		}
 		if err := provider.ResetClaudeSessions(); err != nil {
 			m.appendSystemMessage("Failed to reset Claude session persistence: " + err.Error())
 			return m, nil


### PR DESCRIPTION
## Summary
- add `codex` as a real WUPHF provider option in `/init`, `/provider`, provider resolution, and one-shot generation
- run the full office/channel runtime on a headless Codex launcher instead of falling back to the older standalone stream model
- make setup, reset, crash, and readiness surfaces truthful for Codex-backed office sessions

## Implementation notes
- adds a headless launcher path that starts the normal broker-backed office and dispatches agent turns through ephemeral `codex exec` calls with the office MCP attached
- keeps tmux/Claude as the default runtime and only switches to the headless path when `llm_provider=codex`
- adds focused tests for the Codex provider and the headless office launcher wiring

## Validation
- `go test ./...`