### PR TITLE
fix: harden codex office runtime

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -440,6 +440,7 @@ func newBrokerRequest(method, url string, body io.Reader) (*http.Request, error)
 
 var channelSlashCommands = []tui.SlashCommand{
 	{Name: "init", Description: "Run setup", Category: "setup"},
+	{Name: "provider", Description: "Switch LLM provider", Category: "setup"},
 	{Name: "doctor", Description: "Check readiness, integrations, and runtime health", Category: "setup"},
 	{Name: "integrate", Description: "Connect an integration", Category: "setup"},
 	{Name: "connect", Description: "Connect an external channel (Telegram, Slack, Discord)", Category: "setup"},
@@ -509,6 +510,7 @@ const (
 	channelPickerNone           channelPickerMode = ""
 	channelPickerInitProvider   channelPickerMode = "init_provider"
 	channelPickerInitPack       channelPickerMode = "init_pack"
+	channelPickerProvider       channelPickerMode = "provider"
 	channelPickerIntegrations   channelPickerMode = "integrations"
 	channelPickerRequests       channelPickerMode = "requests"
 	channelPickerTasks          channelPickerMode = "tasks"
@@ -2072,6 +2074,11 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				delete(m.expandedThreads, msgID)
 			}
 			return m, nil
+		case channelPickerProvider:
+			m.picker.SetActive(false)
+			m.pickerMode = channelPickerNone
+			m.posting = true
+			return m, applyProviderSelection(msg.Value)
 		default:
 			m.picker.SetActive(false)
 			var cmd tea.Cmd
@@ -4880,6 +4887,13 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		var cmd tea.Cmd
 		m.initFlow, cmd = m.initFlow.Start()
 		return m, cmd
+	case trimmed == "/provider":
+		clearCurrent()
+		m.picker = tui.NewPicker("Switch LLM Provider", tui.ProviderOptions())
+		m.picker.SetActive(true)
+		m.pickerMode = channelPickerProvider
+		m.notice = "Choose an LLM provider."
+		return m, nil
 	case trimmed == "/cancel":
 		clearCurrent()
 		if m.replyToID != "" {
@@ -6197,7 +6211,7 @@ func applyTeamSetup() tea.Cmd {
 		if current := strings.TrimSpace(os.Getenv("WUPHF_HEADLESS_PROVIDER")); current != "" {
 			return channelInitDoneMsg{notice: notice + " Setup saved. Restart WUPHF to reload the " + current + " office runtime with the new configuration."}
 		}
-		if strings.TrimSpace(cfg.LLMProvider) == "codex" {
+		if config.ResolveLLMProvider("") == "codex" || strings.TrimSpace(cfg.LLMProvider) == "codex" {
 			return channelInitDoneMsg{notice: notice + " Codex was saved as the LLM provider. Restart WUPHF to launch the headless Codex office runtime."}
 		}
 		l, err := team.NewLauncher("")
@@ -6208,6 +6222,48 @@ func applyTeamSetup() tea.Cmd {
 			return channelInitDoneMsg{err: err}
 		}
 		return channelInitDoneMsg{notice: notice + " Setup applied. Team reloaded with the new configuration."}
+	}
+}
+
+func applyProviderSelection(providerName string) tea.Cmd {
+	return func() tea.Msg {
+		providerName = strings.TrimSpace(providerName)
+		if providerName == "" {
+			return channelInitDoneMsg{err: errors.New("choose a provider")}
+		}
+
+		cfg, _ := config.Load()
+		currentProvider := config.ResolveLLMProvider("")
+		cfg.LLMProvider = providerName
+		if err := config.Save(cfg); err != nil {
+			return channelInitDoneMsg{err: err}
+		}
+
+		if current := strings.TrimSpace(os.Getenv("WUPHF_HEADLESS_PROVIDER")); current != "" {
+			return channelInitDoneMsg{notice: "Provider switched to " + providerName + ". Restart WUPHF to reload the office runtime with the new configuration."}
+		}
+		if providerName == "codex" {
+			l, err := team.NewLauncher("")
+			if err != nil {
+				return channelInitDoneMsg{err: err}
+			}
+			if err := l.ReconfigureSession(); err != nil {
+				return channelInitDoneMsg{err: err}
+			}
+			return channelInitDoneMsg{notice: "Provider switched to codex. Claude teammate panes were stopped. Restart WUPHF to launch the headless Codex office runtime."}
+		}
+		if currentProvider == "codex" {
+			return channelInitDoneMsg{notice: "Provider switched to " + providerName + ". Restart WUPHF to reload the office runtime with the new configuration."}
+		}
+
+		l, err := team.NewLauncher("")
+		if err != nil {
+			return channelInitDoneMsg{err: err}
+		}
+		if err := l.ReconfigureSession(); err != nil {
+			return channelInitDoneMsg{err: err}
+		}
+		return channelInitDoneMsg{notice: "Provider switched to " + providerName + ". Team reloaded with the new configuration."}
 	}
 }
 

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/team"
 	"github.com/nex-crm/wuphf/internal/tui"
 )
@@ -445,6 +446,62 @@ func TestBuildSwitchChannelPickerOptionsOnlyIncludesSwitchTargets(t *testing.T) 
 	}
 	if seenChannels != 2 {
 		t.Fatalf("expected two channel switch targets, got %+v", options)
+	}
+}
+
+func TestProviderCommandOpensProviderPicker(t *testing.T) {
+	m := newChannelModel(false)
+
+	next, cmd := m.runCommand("/provider", "")
+	if cmd != nil {
+		t.Fatalf("expected no async command when opening provider picker, got %v", cmd)
+	}
+	got := next.(channelModel)
+	if !got.picker.IsActive() || got.pickerMode != channelPickerProvider {
+		t.Fatalf("expected provider picker, got active=%v mode=%q", got.picker.IsActive(), got.pickerMode)
+	}
+	view := stripANSI(got.picker.View())
+	if !strings.Contains(view, "Codex CLI") || !strings.Contains(view, "Claude Code") {
+		t.Fatalf("expected provider options in picker, got %q", view)
+	}
+}
+
+func TestProviderSelectionSavesCodexAndRequestsRestart(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := config.Save(config.Config{LLMProvider: "claude-code", Pack: "founding-team"}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	m := newChannelModel(false)
+	m.picker = tui.NewPicker("Switch LLM Provider", tui.ProviderOptions())
+	m.picker.SetActive(true)
+	m.pickerMode = channelPickerProvider
+
+	next, cmd := m.Update(tui.PickerSelectMsg{Value: "codex", Label: "Codex CLI"})
+	if cmd == nil {
+		t.Fatal("expected provider selection to emit follow-up command")
+	}
+	got := next.(channelModel)
+	if !got.posting {
+		t.Fatal("expected provider selection to enter posting state")
+	}
+
+	msg := cmd()
+	followUp, _ := got.Update(msg)
+	done := followUp.(channelModel)
+	if done.posting {
+		t.Fatal("expected provider selection to clear posting state after completion")
+	}
+	if !strings.Contains(done.notice, "Claude teammate panes were stopped.") || !strings.Contains(done.notice, "Restart WUPHF to launch the headless Codex office runtime.") {
+		t.Fatalf("expected codex restart notice, got %q", done.notice)
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.LLMProvider != "codex" {
+		t.Fatalf("expected codex provider saved, got %q", cfg.LLMProvider)
 	}
 }
 

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -23,6 +23,7 @@ func main() {
 	apiKeyFlag := flag.String("api-key", "", "API key for authentication")
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	packFlag := flag.String("pack", "", "Agent pack (founding-team, coding-team, lead-gen-agency)")
+	providerFlag := flag.String("provider", "", "LLM provider override for this run (claude-code, codex)")
 	oneOnOne := flag.Bool("1o1", false, "Launch a direct 1:1 session with a single agent (default ceo)")
 	channelView := flag.Bool("channel-view", false, "Run as channel view (internal)")
 	channelApp := flag.String("channel-app", "", "Start channel view on a specific app (internal)")
@@ -45,6 +46,15 @@ func main() {
 
 	if *noNex {
 		_ = os.Setenv("WUPHF_NO_NEX", "1")
+	}
+	if provider := strings.TrimSpace(*providerFlag); provider != "" {
+		switch provider {
+		case "claude-code", "codex":
+			_ = os.Setenv("WUPHF_LLM_PROVIDER", provider)
+		default:
+			fmt.Fprintf(os.Stderr, "error: unsupported provider %q (expected claude-code or codex)\n", provider)
+			os.Exit(1)
+		}
 	}
 
 	if *showVersion {

--- a/internal/commands/cmd_system.go
+++ b/internal/commands/cmd_system.go
@@ -90,12 +90,8 @@ func cmdInit(ctx *SlashContext, args string) error {
 
 func cmdProvider(ctx *SlashContext, args string) error {
 	options := []PickerOption{
-		{Label: "Gemini", Value: "gemini", Description: "Google Gemini via API key"},
 		{Label: "Codex CLI", Value: "codex", Description: "Codex via codex CLI"},
 		{Label: "Claude Code", Value: "claude-code", Description: "Claude via claude-code CLI"},
-	}
-	if !config.ResolveNoNex() {
-		options = append(options, PickerOption{Label: "Nex Ask", Value: "nex-ask", Description: "Nex hosted AI"})
 	}
 	if ctx.ShowPicker != nil {
 		ctx.ShowPicker("Switch LLM Provider", options)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -119,6 +120,107 @@ func ResolveNoNex() bool {
 		return false
 	}
 	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+}
+
+// ResolveLLMProvider resolves the active LLM provider for this run.
+// Resolution: flag/env override > config file > default claude-code.
+// Only supported interactive providers are returned.
+func ResolveLLMProvider(flagValue string) string {
+	if v := normalizeLLMProvider(flagValue); v != "" {
+		return v
+	}
+	if v := normalizeLLMProvider(os.Getenv("WUPHF_LLM_PROVIDER")); v != "" {
+		return v
+	}
+	cfg, _ := Load()
+	if v := normalizeLLMProvider(cfg.LLMProvider); v != "" {
+		return v
+	}
+	return "claude-code"
+}
+
+func normalizeLLMProvider(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "claude-code":
+		return "claude-code"
+	case "codex":
+		return "codex"
+	default:
+		return ""
+	}
+}
+
+var codexModelLinePattern = regexp.MustCompile(`(?m)^\s*model\s*=\s*("([^"\\]|\\.)*"|'[^']*')`)
+
+// ResolveCodexModel returns the effective Codex model for the current working
+// directory, following the documented Codex config layering:
+// WUPHF_CODEX_MODEL/CODEX_MODEL env > nearest .codex/config.toml > ~/.codex/config.toml.
+func ResolveCodexModel(cwd string) string {
+	if v := strings.TrimSpace(os.Getenv("WUPHF_CODEX_MODEL")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("CODEX_MODEL")); v != "" {
+		return v
+	}
+	for _, path := range codexConfigSearchPaths(cwd) {
+		if model := codexModelFromFile(path); model != "" {
+			return model
+		}
+	}
+	return ""
+}
+
+func codexConfigSearchPaths(cwd string) []string {
+	seen := map[string]struct{}{}
+	paths := make([]string, 0, 8)
+	add := func(path string) {
+		if path == "" {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+
+	if absCwd, err := filepath.Abs(strings.TrimSpace(cwd)); err == nil && absCwd != "" {
+		for dir := absCwd; ; dir = filepath.Dir(dir) {
+			add(filepath.Join(dir, ".codex", "config.toml"))
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+		}
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		add(filepath.Join(home, ".codex", "config.toml"))
+	}
+	return paths
+}
+
+func codexModelFromFile(path string) string {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	match := codexModelLinePattern.FindSubmatch(raw)
+	if len(match) < 2 {
+		return ""
+	}
+	value := strings.TrimSpace(string(match[1]))
+	if len(value) >= 2 {
+		if strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`) {
+			if unquoted, err := strconv.Unquote(value); err == nil {
+				return strings.TrimSpace(unquoted)
+			}
+		}
+		if strings.HasPrefix(value, `'`) && strings.HasSuffix(value, `'`) {
+			return strings.TrimSpace(value[1 : len(value)-1])
+		}
+	}
+	return strings.TrimSpace(value)
 }
 
 // ResolveAPIKey resolves the API key via: flag > WUPHF_API_KEY env > NEX_API_KEY env > config file.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -171,6 +171,71 @@ func TestResolveActionProviderUsesConfig(t *testing.T) {
 	})
 }
 
+func TestResolveLLMProviderDefaultsToClaude(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		if got := ResolveLLMProvider(""); got != "claude-code" {
+			t.Fatalf("expected claude-code default, got %q", got)
+		}
+	})
+}
+
+func TestResolveLLMProviderUsesEnvOverride(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		t.Setenv("WUPHF_LLM_PROVIDER", "codex")
+		if got := ResolveLLMProvider(""); got != "codex" {
+			t.Fatalf("expected codex env override, got %q", got)
+		}
+	})
+}
+
+func TestResolveLLMProviderNormalizesUnsupportedConfig(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		_ = Save(Config{LLMProvider: "gemini"})
+		if got := ResolveLLMProvider(""); got != "claude-code" {
+			t.Fatalf("expected unsupported provider to normalize to claude-code, got %q", got)
+		}
+	})
+}
+
+func TestResolveCodexModelUsesEnvOverride(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		t.Setenv("WUPHF_CODEX_MODEL", "gpt-5.4")
+		if got := ResolveCodexModel(""); got != "gpt-5.4" {
+			t.Fatalf("expected env codex model, got %q", got)
+		}
+	})
+}
+
+func TestResolveCodexModelPrefersNearestProjectConfig(t *testing.T) {
+	withTempConfig(t, func(dir string) {
+		homeConfigDir := filepath.Join(dir, ".codex")
+		if err := os.MkdirAll(homeConfigDir, 0o755); err != nil {
+			t.Fatalf("mkdir home codex dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(homeConfigDir, "config.toml"), []byte("model = \"gpt-5.4\"\n"), 0o644); err != nil {
+			t.Fatalf("write home config: %v", err)
+		}
+
+		projectRoot := filepath.Join(dir, "repo")
+		projectConfigDir := filepath.Join(projectRoot, ".codex")
+		if err := os.MkdirAll(projectConfigDir, 0o755); err != nil {
+			t.Fatalf("mkdir project codex dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(projectConfigDir, "config.toml"), []byte("model = \"gpt-5.4-mini\"\n"), 0o644); err != nil {
+			t.Fatalf("write project config: %v", err)
+		}
+
+		nested := filepath.Join(projectRoot, "nested", "deeper")
+		if err := os.MkdirAll(nested, 0o755); err != nil {
+			t.Fatalf("mkdir nested dir: %v", err)
+		}
+
+		if got := ResolveCodexModel(nested); got != "gpt-5.4-mini" {
+			t.Fatalf("expected nearest project codex model, got %q", got)
+		}
+	})
+}
+
 func TestResolveFormatFlag(t *testing.T) {
 	withTempConfig(t, func(_ string) {
 		if got := ResolveFormat("json"); got != "json" {

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -1,12 +1,16 @@
 package provider
 
 import (
+	"bufio"
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
 
 	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/config"
 )
 
 var (
@@ -64,56 +68,56 @@ func RunCodexOneShot(systemPrompt, prompt, cwd string) (string, error) {
 }
 
 func runCodexOnce(systemPrompt, prompt, cwd string) (string, error) {
-	outputFile, err := os.CreateTemp("", "wuphf-codex-*.txt")
-	if err != nil {
-		return "", fmt.Errorf("create codex output file: %w", err)
-	}
-	outputPath := outputFile.Name()
-	outputFile.Close()
-	defer os.Remove(outputPath)
-
-	args := buildCodexArgs(cwd, outputPath)
+	args := buildCodexArgs(cwd, config.ResolveCodexModel(cwd))
 	cmd := codexCommand("codex", args...)
 	cmd.Dir = cwd
 	cmd.Env = filteredEnv(nil)
 	cmd.Stdin = strings.NewReader(buildCodexPrompt(systemPrompt, prompt))
 
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("attach codex stdout: %w", err)
+	}
+
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
-		if content, readErr := os.ReadFile(outputPath); readErr == nil {
-			if text := strings.TrimSpace(string(content)); text != "" {
-				return text, nil
-			}
-		}
-		if stderrText := strings.TrimSpace(stderr.String()); stderrText != "" {
-			return "", fmt.Errorf("%w: %s", err, stderrText)
-		}
+	if err := cmd.Start(); err != nil {
 		return "", err
 	}
 
-	content, err := os.ReadFile(outputPath)
-	if err != nil {
-		return "", fmt.Errorf("read codex output: %w", err)
+	result, parseErr := readCodexJSONStream(stdout)
+	if err := cmd.Wait(); err != nil {
+		detail := firstNonEmpty(result.LastError, strings.TrimSpace(stderr.String()))
+		if detail != "" {
+			return "", fmt.Errorf("%w: %s", err, detail)
+		}
+		return "", err
 	}
-	text := strings.TrimSpace(string(content))
+	if parseErr != nil {
+		return "", parseErr
+	}
+	text := strings.TrimSpace(firstNonEmpty(result.FinalMessage, result.LastPlainLine))
 	if text == "" {
 		return "", fmt.Errorf("codex returned no final text")
 	}
 	return text, nil
 }
 
-func buildCodexArgs(cwd string, outputPath string) []string {
-	return []string{
-		"exec",
+func buildCodexArgs(cwd string, model string) []string {
+	args := []string{"exec"}
+	if strings.TrimSpace(model) != "" {
+		args = append(args, "--model", strings.TrimSpace(model))
+	}
+	args = append(args,
 		"-C", cwd,
 		"--skip-git-repo-check",
 		"--ephemeral",
 		"--color", "never",
-		"--output-last-message", outputPath,
+		"--json",
 		"-",
-	}
+	)
+	return args
 }
 
 func buildCodexPrompt(systemPrompt, prompt string) string {
@@ -133,4 +137,94 @@ func describeCodexFailure(err error) string {
 		return "Codex CLI requires login. Run `codex login` or use /provider to choose a different provider."
 	}
 	return fmt.Sprintf("codex exited with error: %v", err)
+}
+
+type codexJSONResult struct {
+	FinalMessage  string
+	LastPlainLine string
+	LastError     string
+}
+
+type codexJSONEvent struct {
+	Type    string `json:"type"`
+	Message string `json:"message,omitempty"`
+	Error   *struct {
+		Message string `json:"message,omitempty"`
+	} `json:"error,omitempty"`
+	Item *struct {
+		Type    string `json:"type,omitempty"`
+		Text    string `json:"text,omitempty"`
+		Content []struct {
+			Type string `json:"type,omitempty"`
+			Text string `json:"text,omitempty"`
+		} `json:"content,omitempty"`
+	} `json:"item,omitempty"`
+}
+
+func readCodexJSONStream(r io.Reader) (codexJSONResult, error) {
+	var result codexJSONResult
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var event codexJSONEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			result.LastPlainLine = line
+			continue
+		}
+		if text := strings.TrimSpace(extractCodexAgentMessage(event)); text != "" {
+			result.FinalMessage = text
+		}
+		if detail := strings.TrimSpace(extractCodexError(event)); detail != "" {
+			result.LastError = detail
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return result, fmt.Errorf("read codex json stream: %w", err)
+	}
+	return result, nil
+}
+
+func extractCodexAgentMessage(event codexJSONEvent) string {
+	if event.Type != "item.completed" || event.Item == nil || event.Item.Type != "agent_message" {
+		return ""
+	}
+	if text := strings.TrimSpace(event.Item.Text); text != "" {
+		return text
+	}
+	parts := make([]string, 0, len(event.Item.Content))
+	for _, item := range event.Item.Content {
+		if item.Type == "output_text" || item.Type == "text" {
+			if text := strings.TrimSpace(item.Text); text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n"))
+}
+
+func extractCodexError(event codexJSONEvent) string {
+	switch event.Type {
+	case "error", "turn.failed":
+		if event.Error != nil && strings.TrimSpace(event.Error.Message) != "" {
+			return event.Error.Message
+		}
+		if strings.TrimSpace(event.Message) != "" {
+			return event.Message
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }

--- a/internal/provider/codex_test.go
+++ b/internal/provider/codex_test.go
@@ -17,7 +17,7 @@ type codexHelperRecord struct {
 }
 
 func TestBuildCodexArgsIncludesOutputFile(t *testing.T) {
-	args := buildCodexArgs("/tmp/work", "/tmp/out.txt")
+	args := buildCodexArgs("/tmp/work", "gpt-5.4")
 	joined := strings.Join(args, " ")
 	if !strings.Contains(joined, "exec") {
 		t.Fatalf("expected exec command, got %q", joined)
@@ -25,11 +25,14 @@ func TestBuildCodexArgsIncludesOutputFile(t *testing.T) {
 	if !strings.Contains(joined, "-C /tmp/work") {
 		t.Fatalf("expected working directory, got %q", joined)
 	}
-	if !strings.Contains(joined, "--output-last-message /tmp/out.txt") {
-		t.Fatalf("expected output file flag, got %q", joined)
+	if !strings.Contains(joined, "--json") {
+		t.Fatalf("expected json flag, got %q", joined)
 	}
 	if !strings.Contains(joined, "--ephemeral") {
 		t.Fatalf("expected ephemeral execution, got %q", joined)
+	}
+	if !strings.Contains(joined, "--model gpt-5.4") {
+		t.Fatalf("expected explicit model flag, got %q", joined)
 	}
 }
 
@@ -106,6 +109,7 @@ func stubCodexRuntime(t *testing.T, recordFile string, scenario string, cwd stri
 	t.Setenv("GO_WANT_CODEX_HELPER_PROCESS", "1")
 	t.Setenv("CODEX_TEST_RECORD_FILE", recordFile)
 	t.Setenv("CODEX_TEST_SCENARIO", scenario)
+	t.Setenv("HOME", t.TempDir())
 
 	codexLookPath = func(file string) (string, error) {
 		return "/usr/bin/codex", nil
@@ -153,25 +157,16 @@ func TestCodexHelperProcess(t *testing.T) {
 	}
 	file.Close()
 
-	outputPath := ""
-	for i := 0; i < len(codexArgs)-1; i++ {
-		if codexArgs[i] == "--output-last-message" {
-			outputPath = codexArgs[i+1]
-			break
-		}
-	}
-	if outputPath == "" {
-		t.Fatalf("missing --output-last-message arg: %#v", codexArgs)
+	if !containsArg(codexArgs, "--json") {
+		t.Fatalf("missing --json arg: %#v", codexArgs)
 	}
 
 	switch os.Getenv("CODEX_TEST_SCENARIO") {
 	case "success":
-		if err := os.WriteFile(outputPath, []byte("codex final answer"), 0o644); err != nil {
-			t.Fatalf("write codex output: %v", err)
-		}
+		_, _ = os.Stdout.WriteString("{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"codex final answer\"}}\n")
 		os.Exit(0)
 	case "login-required":
-		_ = os.WriteFile(outputPath, []byte(""), 0o644)
+		_, _ = os.Stdout.WriteString("{\"type\":\"turn.failed\",\"error\":{\"message\":\"authentication required\"}}\n")
 		_, _ = os.Stderr.WriteString("authentication required\n")
 		os.Exit(1)
 	default:

--- a/internal/provider/oneshot.go
+++ b/internal/provider/oneshot.go
@@ -1,16 +1,13 @@
 package provider
 
 import (
-	"strings"
-
 	"github.com/nex-crm/wuphf/internal/config"
 )
 
 // RunConfiguredOneShot runs a single-shot generation using the configured LLM provider.
 // Providers without a dedicated one-shot path fall back to Claude for now.
 func RunConfiguredOneShot(systemPrompt, prompt, cwd string) (string, error) {
-	cfg, _ := config.Load()
-	switch strings.TrimSpace(cfg.LLMProvider) {
+	switch config.ResolveLLMProvider("") {
 	case "codex":
 		return RunCodexOneShot(systemPrompt, prompt, cwd)
 	default:

--- a/internal/provider/resolver.go
+++ b/internal/provider/resolver.go
@@ -11,17 +11,9 @@ import (
 // Config is re-read on each call so runtime provider changes take effect.
 func DefaultStreamFnResolver(client *api.Client) agent.StreamFnResolver {
 	return func(agentSlug string) agent.StreamFn {
-		cfg, _ := config.Load()
-		if config.ResolveNoNex() && cfg.LLMProvider == "nex-ask" {
-			cfg.LLMProvider = "claude-code"
-		}
-		switch cfg.LLMProvider {
+		switch config.ResolveLLMProvider("") {
 		case "codex":
 			return CreateCodexCLIStreamFn(agentSlug)
-		case "gemini":
-			return CreateGeminiStreamFn(cfg.GeminiAPIKey)
-		case "nex-ask":
-			return CreateNexAskStreamFn(client)
 		case "claude-code", "":
 			// Default to Claude Code — most capable for multi-turn orchestration
 			return CreateClaudeCodeStreamFn(agentSlug)

--- a/internal/team/capabilities.go
+++ b/internal/team/capabilities.go
@@ -64,8 +64,7 @@ func DetectRuntimeCapabilitiesWithOptions(opts CapabilityProbeOptions) RuntimeCa
 	tmuxStatus, tmux := probeTmuxCapability()
 	claudeStatus := probeBinaryCapability("claude", "Install claude so WUPHF can start teammate runtime sessions.")
 	codexStatus := probeBinaryCapability("codex", "Install Codex CLI and run `codex login` so WUPHF can start the headless Codex office runtime.")
-	cfg, _ := config.Load()
-	registry := buildCapabilityRegistry(strings.TrimSpace(cfg.LLMProvider), tmuxStatus, claudeStatus, codexStatus, opts)
+	registry := buildCapabilityRegistry(config.ResolveLLMProvider(""), tmuxStatus, claudeStatus, codexStatus, opts)
 	summaryKeys := []string{
 		CapabilityKeyOfficeRuntime,
 		CapabilityKeyDirectRuntime,

--- a/internal/team/capability_registry.go
+++ b/internal/team/capability_registry.go
@@ -119,8 +119,7 @@ func BuildCapabilityRegistry(runtime RuntimeCapabilities) CapabilityRegistry {
 	if len(runtime.Registry.Entries) > 0 {
 		return runtime.Registry
 	}
-	cfg, _ := config.Load()
-	return buildCapabilityRegistry(strings.TrimSpace(cfg.LLMProvider), runtimeCapabilityStatus(runtime, "tmux"), runtimeCapabilityStatus(runtime, "claude"), runtimeCapabilityStatus(runtime, "codex"), CapabilityProbeOptions{})
+	return buildCapabilityRegistry(config.ResolveLLMProvider(""), runtimeCapabilityStatus(runtime, "tmux"), runtimeCapabilityStatus(runtime, "claude"), runtimeCapabilityStatus(runtime, "codex"), CapabilityProbeOptions{})
 }
 
 func buildCapabilityRegistry(providerName string, tmuxStatus, claudeStatus, codexStatus CapabilityStatus, opts CapabilityProbeOptions) CapabilityRegistry {

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -1,12 +1,15 @@
 package team
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
@@ -17,10 +20,30 @@ var (
 	headlessCodexLookPath       = exec.LookPath
 	headlessCodexCommandContext = exec.CommandContext
 	headlessCodexExecutablePath = os.Executable
+	headlessCodexRunTurn        = func(l *Launcher, ctx context.Context, slug, notification string) error {
+		return l.runHeadlessCodexTurn(ctx, slug, notification)
+	}
 )
+
+var (
+	headlessCodexTurnTimeout      = 2 * time.Minute
+	headlessCodexStaleCancelAfter = 45 * time.Second
+)
+
+type headlessCodexTurn struct {
+	Prompt     string
+	EnqueuedAt time.Time
+}
+
+type headlessCodexActiveTurn struct {
+	Turn      headlessCodexTurn
+	StartedAt time.Time
+	Cancel    context.CancelFunc
+}
 
 func (l *Launcher) launchHeadlessCodex() error {
 	killStaleBroker()
+	exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 
 	l.broker = NewBroker()
 	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
@@ -49,70 +72,115 @@ func (l *Launcher) enqueueHeadlessCodexTurn(slug string, prompt string) {
 		return
 	}
 
+	var cancel context.CancelFunc
+	var staleAge time.Duration
+	startWorker := false
+
 	l.headlessMu.Lock()
-	if l.headlessRunning[slug] {
-		l.headlessPending[slug] = prompt
-		l.headlessMu.Unlock()
-		return
+	l.headlessQueues[slug] = append(l.headlessQueues[slug], headlessCodexTurn{
+		Prompt:     prompt,
+		EnqueuedAt: time.Now(),
+	})
+	if !l.headlessWorkers[slug] {
+		l.headlessWorkers[slug] = true
+		startWorker = true
 	}
-	l.headlessRunning[slug] = true
+	if active := l.headlessActive[slug]; active != nil && active.Cancel != nil {
+		age := time.Since(active.StartedAt)
+		if age >= headlessCodexStaleCancelAfter {
+			cancel = active.Cancel
+			staleAge = age
+		}
+	}
 	l.headlessMu.Unlock()
 
-	go l.runHeadlessCodexQueue(slug, prompt)
+	if cancel != nil {
+		appendHeadlessCodexLog(slug, fmt.Sprintf("stale-turn: cancelling active turn after %s to process queued work", staleAge.Round(time.Second)))
+		cancel()
+	}
+	if startWorker {
+		go l.runHeadlessCodexQueue(slug)
+	}
 }
 
-func (l *Launcher) runHeadlessCodexQueue(slug string, prompt string) {
-	current := prompt
+func (l *Launcher) runHeadlessCodexQueue(slug string) {
 	for {
-		if ctx := l.headlessCtx; ctx != nil {
-			select {
-			case <-ctx.Done():
-				l.finishHeadlessTurn(slug)
-				return
-			default:
-			}
+		turn, turnCtx, ok := l.beginHeadlessCodexTurn(slug)
+		if !ok {
+			l.finishHeadlessWorker(slug)
+			return
 		}
 
-		if err := l.runHeadlessCodexTurn(slug, current); err != nil {
+		err := headlessCodexRunTurn(l, turnCtx, slug, turn.Prompt)
+		ctxErr := turnCtx.Err()
+		switch {
+		case err == nil:
+		case errors.Is(ctxErr, context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded):
+			appendHeadlessCodexLog(slug, fmt.Sprintf("error: headless codex turn timed out after %s", headlessCodexTurnTimeout))
+		case errors.Is(ctxErr, context.Canceled) || errors.Is(err, context.Canceled):
+			appendHeadlessCodexLog(slug, "error: headless codex turn cancelled so newer queued work can run")
+		default:
 			appendHeadlessCodexLog(slug, fmt.Sprintf("error: %v", err))
 		}
-
-		l.headlessMu.Lock()
-		next, ok := l.headlessPending[slug]
-		if ok {
-			delete(l.headlessPending, slug)
-			l.headlessMu.Unlock()
-			current = next
-			continue
-		}
-		delete(l.headlessRunning, slug)
-		l.headlessMu.Unlock()
-		return
+		l.finishHeadlessTurn(slug)
 	}
 }
 
 func (l *Launcher) finishHeadlessTurn(slug string) {
 	l.headlessMu.Lock()
-	delete(l.headlessRunning, slug)
-	delete(l.headlessPending, slug)
+	if active := l.headlessActive[slug]; active != nil && active.Cancel != nil {
+		active.Cancel()
+	}
+	delete(l.headlessActive, slug)
 	l.headlessMu.Unlock()
 }
 
-func (l *Launcher) runHeadlessCodexTurn(slug string, notification string) error {
+func (l *Launcher) finishHeadlessWorker(slug string) {
+	l.headlessMu.Lock()
+	delete(l.headlessWorkers, slug)
+	if len(l.headlessQueues[slug]) == 0 {
+		delete(l.headlessQueues, slug)
+	}
+	l.headlessMu.Unlock()
+}
+
+func (l *Launcher) beginHeadlessCodexTurn(slug string) (headlessCodexTurn, context.Context, bool) {
+	l.headlessMu.Lock()
+	defer l.headlessMu.Unlock()
+
+	queue := l.headlessQueues[slug]
+	if len(queue) == 0 {
+		delete(l.headlessQueues, slug)
+		return headlessCodexTurn{}, nil, false
+	}
+
+	turn := queue[0]
+	if len(queue) == 1 {
+		delete(l.headlessQueues, slug)
+	} else {
+		l.headlessQueues[slug] = queue[1:]
+	}
+
+	baseCtx := l.headlessCtx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	turnCtx, cancel := context.WithTimeout(baseCtx, headlessCodexTurnTimeout)
+	l.headlessActive[slug] = &headlessCodexActiveTurn{
+		Turn:      turn,
+		StartedAt: time.Now(),
+		Cancel:    cancel,
+	}
+	return turn, turnCtx, true
+}
+
+func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notification string) error {
 	if _, err := headlessCodexLookPath("codex"); err != nil {
 		return fmt.Errorf("codex not found: %w", err)
 	}
 	if l == nil || l.broker == nil {
 		return fmt.Errorf("broker is not running")
 	}
-
-	outputFile, err := os.CreateTemp("", "wuphf-office-codex-*.txt")
-	if err != nil {
-		return fmt.Errorf("create codex output file: %w", err)
-	}
-	outputPath := outputFile.Name()
-	outputFile.Close()
-	defer os.Remove(outputPath)
 
 	overrides, err := l.buildCodexOfficeConfigOverrides(slug)
 	if err != nil {
@@ -131,35 +199,46 @@ func (l *Launcher) runHeadlessCodexTurn(slug string, notification string) error 
 		"--skip-git-repo-check",
 		"--ephemeral",
 		"--color", "never",
+		"--json",
 	)
+	if model := strings.TrimSpace(config.ResolveCodexModel(l.cwd)); model != "" {
+		args = append(args, "--model", model)
+	}
 	for _, override := range overrides {
 		args = append(args, "-c", override)
 	}
-	args = append(args, "--output-last-message", outputPath, "-")
+	args = append(args, "-")
 
-	ctx := l.headlessCtx
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	cmd := headlessCodexCommandContext(ctx, "codex", args...)
 	cmd.Dir = l.cwd
 	cmd.Env = l.buildHeadlessCodexEnv(slug)
 	cmd.Stdin = strings.NewReader(buildHeadlessCodexPrompt(l.buildPrompt(slug), notification))
 
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("attach codex stdout: %w", err)
+	}
+
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		if stderrText := strings.TrimSpace(stderr.String()); stderrText != "" {
-			appendHeadlessCodexLog(slug, "stderr: "+stderrText)
-			return fmt.Errorf("%w: %s", err, stderrText)
-		}
+	if err := cmd.Start(); err != nil {
 		return err
 	}
 
-	if raw, err := os.ReadFile(outputPath); err == nil {
-		if text := strings.TrimSpace(string(raw)); text != "" {
-			appendHeadlessCodexLog(slug, "result: "+text)
+	result, parseErr := readHeadlessCodexJSONStream(stdout)
+	if err := cmd.Wait(); err != nil {
+		detail := firstNonEmpty(result.LastError, strings.TrimSpace(stderr.String()))
+		if detail != "" {
+			appendHeadlessCodexLog(slug, "stderr: "+detail)
+			return fmt.Errorf("%w: %s", err, detail)
 		}
+		return err
+	}
+	if parseErr != nil {
+		return parseErr
+	}
+	if text := strings.TrimSpace(firstNonEmpty(result.FinalMessage, result.LastPlainLine)); text != "" {
+		appendHeadlessCodexLog(slug, "result: "+text)
 	}
 	return nil
 }
@@ -189,6 +268,12 @@ func (l *Launcher) buildHeadlessCodexEnv(slug string) []string {
 			env = append(env, "ONE_IDENTITY_TYPE="+identityType)
 		}
 	}
+	if apiKey := strings.TrimSpace(config.ResolveAPIKey("")); apiKey != "" {
+		env = append(env,
+			"WUPHF_API_KEY="+apiKey,
+			"NEX_API_KEY="+apiKey,
+		)
+	}
 	return env
 }
 
@@ -197,43 +282,43 @@ func (l *Launcher) buildCodexOfficeConfigOverrides(slug string) ([]string, error
 	if err != nil {
 		return nil, err
 	}
-	wuphfEnv := map[string]string{
-		"WUPHF_AGENT_SLUG":   slug,
-		"WUPHF_BROKER_TOKEN": l.broker.Token(),
+	wuphfEnvVars := []string{
+		"WUPHF_AGENT_SLUG",
+		"WUPHF_BROKER_TOKEN",
 	}
 	if config.ResolveNoNex() {
-		wuphfEnv["WUPHF_NO_NEX"] = "1"
+		wuphfEnvVars = append(wuphfEnvVars, "WUPHF_NO_NEX")
 	}
 	if l.isOneOnOne() {
-		wuphfEnv["WUPHF_ONE_ON_ONE"] = "1"
-		wuphfEnv["WUPHF_ONE_ON_ONE_AGENT"] = l.oneOnOneAgent()
+		wuphfEnvVars = append(wuphfEnvVars,
+			"WUPHF_ONE_ON_ONE",
+			"WUPHF_ONE_ON_ONE_AGENT",
+		)
 	}
 	if secret := strings.TrimSpace(config.ResolveOneSecret()); secret != "" {
-		wuphfEnv["ONE_SECRET"] = secret
+		wuphfEnvVars = append(wuphfEnvVars, "ONE_SECRET")
 	}
 	if identity := strings.TrimSpace(config.ResolveOneIdentity()); identity != "" {
-		wuphfEnv["ONE_IDENTITY"] = identity
+		wuphfEnvVars = append(wuphfEnvVars, "ONE_IDENTITY")
 		if identityType := strings.TrimSpace(config.ResolveOneIdentityType()); identityType != "" {
-			wuphfEnv["ONE_IDENTITY_TYPE"] = identityType
+			wuphfEnvVars = append(wuphfEnvVars, "ONE_IDENTITY_TYPE")
 		}
 	}
 
 	overrides := []string{
 		fmt.Sprintf(`mcp_servers.wuphf-office.command=%s`, tomlQuote(wuphfBinary)),
 		`mcp_servers.wuphf-office.args=["mcp-team"]`,
-		fmt.Sprintf(`mcp_servers.wuphf-office.env=%s`, tomlInlineTable(wuphfEnv)),
+		fmt.Sprintf(`mcp_servers.wuphf-office.env_vars=%s`, tomlStringArray(wuphfEnvVars)),
 	}
 
 	if !config.ResolveNoNex() {
 		if nexMCP, err := headlessCodexLookPath("nex-mcp"); err == nil {
 			overrides = append(overrides, fmt.Sprintf(`mcp_servers.nex.command=%s`, tomlQuote(nexMCP)))
-			nexEnv := map[string]string{}
 			if apiKey := strings.TrimSpace(config.ResolveAPIKey("")); apiKey != "" {
-				nexEnv["WUPHF_API_KEY"] = apiKey
-				nexEnv["NEX_API_KEY"] = apiKey
-			}
-			if len(nexEnv) > 0 {
-				overrides = append(overrides, fmt.Sprintf(`mcp_servers.nex.env=%s`, tomlInlineTable(nexEnv)))
+				overrides = append(overrides, fmt.Sprintf(`mcp_servers.nex.env_vars=%s`, tomlStringArray([]string{
+					"WUPHF_API_KEY",
+					"NEX_API_KEY",
+				})))
 			}
 		}
 	}
@@ -274,18 +359,100 @@ func tomlQuote(value string) string {
 	return fmt.Sprintf("%q", value)
 }
 
-func tomlInlineTable(values map[string]string) string {
+func tomlStringArray(values []string) string {
 	if len(values) == 0 {
-		return "{}"
+		return "[]"
 	}
-	keys := make([]string, 0, len(values))
-	for key := range values {
-		keys = append(keys, key)
+	parts := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		parts = append(parts, tomlQuote(value))
 	}
-	sort.Strings(keys)
-	parts := make([]string, 0, len(keys))
-	for _, key := range keys {
-		parts = append(parts, fmt.Sprintf("%s=%s", key, tomlQuote(values[key])))
+	if len(parts) == 0 {
+		return "[]"
 	}
-	return "{" + strings.Join(parts, ", ") + "}"
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+type headlessCodexJSONResult struct {
+	FinalMessage  string
+	LastPlainLine string
+	LastError     string
+}
+
+type headlessCodexJSONEvent struct {
+	Type    string `json:"type"`
+	Message string `json:"message,omitempty"`
+	Error   *struct {
+		Message string `json:"message,omitempty"`
+	} `json:"error,omitempty"`
+	Item *struct {
+		Type    string `json:"type,omitempty"`
+		Text    string `json:"text,omitempty"`
+		Content []struct {
+			Type string `json:"type,omitempty"`
+			Text string `json:"text,omitempty"`
+		} `json:"content,omitempty"`
+	} `json:"item,omitempty"`
+}
+
+func readHeadlessCodexJSONStream(r io.Reader) (headlessCodexJSONResult, error) {
+	var result headlessCodexJSONResult
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+
+		var event headlessCodexJSONEvent
+		if err := json.Unmarshal([]byte(line), &event); err != nil {
+			result.LastPlainLine = line
+			continue
+		}
+		if text := strings.TrimSpace(extractHeadlessCodexAgentMessage(event)); text != "" {
+			result.FinalMessage = text
+		}
+		if detail := strings.TrimSpace(extractHeadlessCodexError(event)); detail != "" {
+			result.LastError = detail
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return result, fmt.Errorf("read codex json stream: %w", err)
+	}
+	return result, nil
+}
+
+func extractHeadlessCodexAgentMessage(event headlessCodexJSONEvent) string {
+	if event.Type != "item.completed" || event.Item == nil || event.Item.Type != "agent_message" {
+		return ""
+	}
+	if text := strings.TrimSpace(event.Item.Text); text != "" {
+		return text
+	}
+	parts := make([]string, 0, len(event.Item.Content))
+	for _, item := range event.Item.Content {
+		if item.Type == "output_text" || item.Type == "text" {
+			if text := strings.TrimSpace(item.Text); text != "" {
+				parts = append(parts, text)
+			}
+		}
+	}
+	return strings.TrimSpace(strings.Join(parts, "\n"))
+}
+
+func extractHeadlessCodexError(event headlessCodexJSONEvent) string {
+	switch event.Type {
+	case "error", "turn.failed":
+		if event.Error != nil && strings.TrimSpace(event.Error.Message) != "" {
+			return event.Error.Message
+		}
+		if strings.TrimSpace(event.Message) != "" {
+			return event.Message
+		}
+	}
+	return ""
 }

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/config"
@@ -76,14 +77,11 @@ func TestBuildCodexOfficeConfigOverridesIncludesOfficeMCPEnv(t *testing.T) {
 	if !strings.Contains(joined, `mcp_servers.wuphf-office.args=["mcp-team"]`) {
 		t.Fatalf("expected WUPHF MCP args override, got %q", joined)
 	}
-	if !strings.Contains(joined, `WUPHF_AGENT_SLUG="pm"`) {
-		t.Fatalf("expected agent slug in MCP env, got %q", joined)
+	if !strings.Contains(joined, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "WUPHF_NO_NEX", "WUPHF_ONE_ON_ONE", "WUPHF_ONE_ON_ONE_AGENT"]`) {
+		t.Fatalf("expected office env var forwarding, got %q", joined)
 	}
-	if !strings.Contains(joined, `WUPHF_BROKER_TOKEN="`) {
-		t.Fatalf("expected broker token in MCP env, got %q", joined)
-	}
-	if !strings.Contains(joined, `WUPHF_ONE_ON_ONE="1"`) || !strings.Contains(joined, `WUPHF_ONE_ON_ONE_AGENT="pm"`) {
-		t.Fatalf("expected 1:1 env in MCP override, got %q", joined)
+	if strings.Contains(joined, broker.Token()) {
+		t.Fatalf("expected broker token value to stay out of args, got %q", joined)
 	}
 	if strings.Contains(joined, `mcp_servers.nex.command=`) {
 		t.Fatalf("expected Nex MCP to stay disabled with WUPHF_NO_NEX, got %q", joined)
@@ -99,6 +97,8 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 		switch file {
 		case "codex":
 			return "/usr/bin/codex", nil
+		case "nex-mcp":
+			return "/usr/bin/nex-mcp", nil
 		default:
 			return "", exec.ErrNotFound
 		}
@@ -118,7 +118,10 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 	t.Setenv("GO_WANT_HEADLESS_CODEX_HELPER_PROCESS", "1")
 	t.Setenv("HEADLESS_CODEX_RECORD_FILE", recordFile)
 	t.Setenv("HOME", t.TempDir())
-	t.Setenv("WUPHF_NO_NEX", "1")
+	t.Setenv("WUPHF_API_KEY", "nex-secret-key")
+	t.Setenv("WUPHF_ONE_SECRET", "one-secret-value")
+	t.Setenv("WUPHF_ONE_IDENTITY", "founder@example.com")
+	t.Setenv("WUPHF_ONE_IDENTITY_TYPE", "user")
 
 	l := &Launcher{
 		pack:        agent.GetPack("founding-team"),
@@ -127,7 +130,7 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 		headlessCtx: context.Background(),
 	}
 
-	if err := l.runHeadlessCodexTurn("ceo", "You have new work in #launch."); err != nil {
+	if err := l.runHeadlessCodexTurn(context.Background(), "ceo", "You have new work in #launch."); err != nil {
 		t.Fatalf("runHeadlessCodexTurn: %v", err)
 	}
 
@@ -139,6 +142,15 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 	if !strings.Contains(joinedArgs, `mcp_servers.wuphf-office.command="/tmp/wuphf"`) {
 		t.Fatalf("expected office MCP override, got %#v", record.Args)
 	}
+	if !strings.Contains(joinedArgs, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "ONE_SECRET", "ONE_IDENTITY", "ONE_IDENTITY_TYPE"]`) {
+		t.Fatalf("expected office env var forwarding, got %#v", record.Args)
+	}
+	if !strings.Contains(joinedArgs, `mcp_servers.nex.command="/usr/bin/nex-mcp"`) {
+		t.Fatalf("expected nex MCP override, got %#v", record.Args)
+	}
+	if !strings.Contains(joinedArgs, `mcp_servers.nex.env_vars=["WUPHF_API_KEY", "NEX_API_KEY"]`) {
+		t.Fatalf("expected nex env var forwarding, got %#v", record.Args)
+	}
 	if !containsEnv(record.Env, "WUPHF_AGENT_SLUG=ceo") {
 		t.Fatalf("expected agent env, got %#v", record.Env)
 	}
@@ -148,8 +160,82 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 	if !containsEnvPrefix(record.Env, "WUPHF_BROKER_TOKEN=") {
 		t.Fatalf("expected broker token env, got %#v", record.Env)
 	}
+	if !containsEnv(record.Env, "WUPHF_API_KEY=nex-secret-key") || !containsEnv(record.Env, "NEX_API_KEY=nex-secret-key") {
+		t.Fatalf("expected nex API env, got %#v", record.Env)
+	}
+	if !containsEnv(record.Env, "ONE_SECRET=one-secret-value") {
+		t.Fatalf("expected one secret env, got %#v", record.Env)
+	}
+	if strings.Contains(joinedArgs, l.broker.Token()) || strings.Contains(joinedArgs, "nex-secret-key") || strings.Contains(joinedArgs, "one-secret-value") {
+		t.Fatalf("expected secret values to stay out of args, got %#v", record.Args)
+	}
 	if !strings.Contains(record.Stdin, "<system>") || !strings.Contains(record.Stdin, "You have new work in #launch.") {
 		t.Fatalf("expected notification prompt in stdin, got %q", record.Stdin)
+	}
+}
+
+func TestEnqueueHeadlessCodexTurnProcessesFIFO(t *testing.T) {
+	oldRunTurn := headlessCodexRunTurn
+	processed := make(chan string, 4)
+	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, _ string, notification string) error {
+		processed <- notification
+		return nil
+	}
+	defer func() { headlessCodexRunTurn = oldRunTurn }()
+
+	l := newHeadlessLauncherForTest()
+
+	l.enqueueHeadlessCodexTurn("ceo", "first")
+	l.enqueueHeadlessCodexTurn("ceo", "second")
+
+	first := waitForString(t, processed)
+	second := waitForString(t, processed)
+	if first != "first" || second != "second" {
+		t.Fatalf("expected FIFO order, got %q then %q", first, second)
+	}
+}
+
+func TestEnqueueHeadlessCodexTurnCancelsStaleTurn(t *testing.T) {
+	oldRunTurn := headlessCodexRunTurn
+	oldTimeout := headlessCodexTurnTimeout
+	oldStale := headlessCodexStaleCancelAfter
+	headlessCodexTurnTimeout = 5 * time.Second
+	headlessCodexStaleCancelAfter = 20 * time.Millisecond
+	defer func() {
+		headlessCodexRunTurn = oldRunTurn
+		headlessCodexTurnTimeout = oldTimeout
+		headlessCodexStaleCancelAfter = oldStale
+	}()
+
+	started := make(chan struct{}, 1)
+	cancelled := make(chan struct{}, 1)
+	processed := make(chan string, 4)
+	headlessCodexRunTurn = func(_ *Launcher, ctx context.Context, _ string, notification string) error {
+		if notification == "first" {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			select {
+			case cancelled <- struct{}{}:
+			default:
+			}
+			return ctx.Err()
+		}
+		processed <- notification
+		return nil
+	}
+
+	l := newHeadlessLauncherForTest()
+	l.enqueueHeadlessCodexTurn("ceo", "first")
+	waitForSignal(t, started)
+	time.Sleep(35 * time.Millisecond)
+	l.enqueueHeadlessCodexTurn("ceo", "second")
+
+	waitForSignal(t, cancelled)
+	if got := waitForString(t, processed); got != "second" {
+		t.Fatalf("expected queued turn to run after cancellation, got %q", got)
 	}
 }
 
@@ -183,19 +269,10 @@ func TestHeadlessCodexHelperProcess(t *testing.T) {
 		t.Fatalf("write helper record: %v", err)
 	}
 
-	outputPath := ""
-	for i := 0; i < len(codexArgs)-1; i++ {
-		if codexArgs[i] == "--output-last-message" {
-			outputPath = codexArgs[i+1]
-			break
-		}
+	if !containsArg(codexArgs, "--json") {
+		t.Fatalf("missing --json arg: %#v", codexArgs)
 	}
-	if outputPath == "" {
-		t.Fatalf("missing --output-last-message arg: %#v", codexArgs)
-	}
-	if err := os.WriteFile(outputPath, []byte("codex office reply"), 0o644); err != nil {
-		t.Fatalf("write codex output: %v", err)
-	}
+	_, _ = os.Stdout.WriteString("{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\",\"text\":\"codex office reply\"}}\n")
 	os.Exit(0)
 }
 
@@ -228,4 +305,42 @@ func containsEnvPrefix(values []string, prefix string) bool {
 		}
 	}
 	return false
+}
+
+func containsArg(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}
+
+func newHeadlessLauncherForTest() *Launcher {
+	return &Launcher{
+		headlessCtx:     context.Background(),
+		headlessWorkers: make(map[string]bool),
+		headlessActive:  make(map[string]*headlessCodexActiveTurn),
+		headlessQueues:  make(map[string][]headlessCodexTurn),
+	}
+}
+
+func waitForSignal(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for signal")
+	}
+}
+
+func waitForString(t *testing.T, ch <-chan string) string {
+	t.Helper()
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for string")
+		return ""
+	}
 }

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -103,8 +103,9 @@ type Launcher struct {
 	headlessMu      sync.Mutex
 	headlessCtx     context.Context
 	headlessCancel  context.CancelFunc
-	headlessRunning map[string]bool
-	headlessPending map[string]string
+	headlessWorkers map[string]bool
+	headlessActive  map[string]*headlessCodexActiveTurn
+	headlessQueues  map[string][]headlessCodexTurn
 }
 
 // SetUnsafe enables unrestricted permissions for all agents (CLI-only flag).
@@ -143,9 +144,10 @@ func NewLauncher(packSlug string) (*Launcher, error) {
 		cwd:             cwd,
 		sessionMode:     sessionMode,
 		oneOnOne:        oneOnOne,
-		provider:        firstNonEmpty(strings.TrimSpace(cfg.LLMProvider), "claude-code"),
-		headlessRunning: make(map[string]bool),
-		headlessPending: make(map[string]string),
+		provider:        config.ResolveLLMProvider(""),
+		headlessWorkers: make(map[string]bool),
+		headlessActive:  make(map[string]*headlessCodexActiveTurn),
+		headlessQueues:  make(map[string][]headlessCodexTurn),
 	}, nil
 }
 
@@ -1953,6 +1955,13 @@ func (l *Launcher) ResetSession() error {
 
 func (l *Launcher) ReconfigureSession() error {
 	if l.usesCodexRuntime() {
+		if err := provider.ResetClaudeSessions(); err != nil {
+			return fmt.Errorf("reset Claude sessions: %w", err)
+		}
+		if err := l.clearAgentPanes(); err != nil {
+			return err
+		}
+		l.clearOverflowAgentWindows()
 		return nil
 	}
 	return l.reconfigureVisibleAgents()

--- a/internal/team/runtime_state_test.go
+++ b/internal/team/runtime_state_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestDetectRuntimeCapabilities(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_LLM_PROVIDER", "claude-code")
 	oldLookPath := lookPathFn
 	oldCommandOutput := commandCombinedOutputFn
 	oldActionProviderForCapability := actionProviderForCapabilityFn
@@ -79,6 +81,8 @@ func TestDetectRuntimeCapabilities(t *testing.T) {
 }
 
 func TestDetectRuntimeCapabilitiesWhenTmuxServerIsMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_LLM_PROVIDER", "claude-code")
 	oldLookPath := lookPathFn
 	oldCommandOutput := commandCombinedOutputFn
 	oldActionProviderForCapability := actionProviderForCapabilityFn

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -22,6 +22,41 @@ const defaultBrokerTokenFile = "/tmp/wuphf-broker-token"
 
 var reconfigureOfficeSessionFn = reconfigureLiveOffice
 
+func boolPtr(v bool) *bool { return &v }
+
+func readOnlyTool(name, description string) *mcp.Tool {
+	return &mcp.Tool{
+		Name:        name,
+		Description: description,
+		Annotations: &mcp.ToolAnnotations{
+			ReadOnlyHint:  true,
+			OpenWorldHint: boolPtr(false),
+		},
+	}
+}
+
+func officeWriteTool(name, description string) *mcp.Tool {
+	return &mcp.Tool{
+		Name:        name,
+		Description: description,
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(false),
+			OpenWorldHint:   boolPtr(false),
+		},
+	}
+}
+
+func officeDestructiveTool(name, description string) *mcp.Tool {
+	return &mcp.Tool{
+		Name:        name,
+		Description: description,
+		Annotations: &mcp.ToolAnnotations{
+			DestructiveHint: boolPtr(true),
+			OpenWorldHint:   boolPtr(false),
+		},
+	}
+}
+
 type brokerMessage struct {
 	ID          string   `json:"id"`
 	From        string   `json:"from"`
@@ -323,133 +358,133 @@ func Run(ctx context.Context) error {
 	}, nil)
 
 	if isOneOnOneMode() {
-		mcp.AddTool(server, &mcp.Tool{
-			Name:        "reply",
-			Description: "Send your reply to the human in the direct 1:1 conversation.",
-		}, handleTeamBroadcast)
+		mcp.AddTool(server, officeWriteTool(
+			"reply",
+			"Send your reply to the human in the direct 1:1 conversation.",
+		), handleTeamBroadcast)
 
-		mcp.AddTool(server, &mcp.Tool{
-			Name:        "read_conversation",
-			Description: "Read recent messages from the 1:1 conversation so you stay in sync before replying.",
-		}, handleTeamPoll)
+		mcp.AddTool(server, readOnlyTool(
+			"read_conversation",
+			"Read recent messages from the 1:1 conversation so you stay in sync before replying.",
+		), handleTeamPoll)
 
-		mcp.AddTool(server, &mcp.Tool{
-			Name:        "human_interview",
-			Description: "Ask the human a blocking interview question when you truly cannot proceed responsibly without a decision.",
-		}, handleHumanInterview)
+		mcp.AddTool(server, officeWriteTool(
+			"human_interview",
+			"Ask the human a blocking interview question when you truly cannot proceed responsibly without a decision.",
+		), handleHumanInterview)
 
-		mcp.AddTool(server, &mcp.Tool{
-			Name:        "human_message",
-			Description: "Send a direct human-facing note into the chat when you need to present completion, recommend a decision, or tell the human what they should do next.",
-		}, handleHumanMessage)
+		mcp.AddTool(server, officeWriteTool(
+			"human_message",
+			"Send a direct human-facing note into the chat when you need to present completion, recommend a decision, or tell the human what they should do next.",
+		), handleHumanMessage)
 
-		mcp.AddTool(server, &mcp.Tool{
-			Name:        "team_runtime_state",
-			Description: "Return the canonical runtime snapshot for this direct session, including tasks, pending human requests, recovery summary, and runtime capabilities.",
-		}, handleTeamRuntimeState)
+		mcp.AddTool(server, readOnlyTool(
+			"team_runtime_state",
+			"Return the canonical runtime snapshot for this direct session, including tasks, pending human requests, recovery summary, and runtime capabilities.",
+		), handleTeamRuntimeState)
 
 		registerActionTools(server)
 
 		return server.Run(ctx, &mcp.StdioTransport{})
 	}
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_broadcast",
-		Description: "Post a message into the team channel for all teammates to see.",
-	}, handleTeamBroadcast)
+	mcp.AddTool(server, officeWriteTool(
+		"team_broadcast",
+		"Post a message into the team channel for all teammates to see.",
+	), handleTeamBroadcast)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_poll",
-		Description: "Read recent messages from the team channel so you stay in sync before replying.",
-	}, handleTeamPoll)
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_inbox",
-		Description: "Read only the messages that currently belong in your agent inbox: human asks, CEO guidance, tags to you, and replies in your threads.",
-	}, handleTeamInbox)
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_outbox",
-		Description: "Read only the messages you authored, so you can review what you already told the office.",
-	}, handleTeamOutbox)
+	mcp.AddTool(server, readOnlyTool(
+		"team_poll",
+		"Read recent messages from the team channel so you stay in sync before replying.",
+	), handleTeamPoll)
+	mcp.AddTool(server, readOnlyTool(
+		"team_inbox",
+		"Read only the messages that currently belong in your agent inbox: human asks, CEO guidance, tags to you, and replies in your threads.",
+	), handleTeamInbox)
+	mcp.AddTool(server, readOnlyTool(
+		"team_outbox",
+		"Read only the messages you authored, so you can review what you already told the office.",
+	), handleTeamOutbox)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_status",
-		Description: "Share a short status update in the team channel. This is rendered as lightweight activity in the channel UI.",
-	}, handleTeamStatus)
+	mcp.AddTool(server, officeWriteTool(
+		"team_status",
+		"Share a short status update in the team channel. This is rendered as lightweight activity in the channel UI.",
+	), handleTeamStatus)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_members",
-		Description: "List active participants in the shared team channel with their latest visible activity.",
-	}, handleTeamMembers)
+	mcp.AddTool(server, readOnlyTool(
+		"team_members",
+		"List active participants in the shared team channel with their latest visible activity.",
+	), handleTeamMembers)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_office_members",
-		Description: "List the office-wide roster, including members who are not in the current channel.",
-	}, handleTeamOfficeMembers)
+	mcp.AddTool(server, readOnlyTool(
+		"team_office_members",
+		"List the office-wide roster, including members who are not in the current channel.",
+	), handleTeamOfficeMembers)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_channels",
-		Description: "List available office channels, their descriptions, and their memberships. Agents can see channel metadata even when they are not members.",
-	}, handleTeamChannels)
+	mcp.AddTool(server, readOnlyTool(
+		"team_channels",
+		"List available office channels, their descriptions, and their memberships. Agents can see channel metadata even when they are not members.",
+	), handleTeamChannels)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_channel",
-		Description: "Create or remove an office channel. When creating a channel, include a clear description of what work belongs there and the initial roster that should be in it. Only do this when the human explicitly wants channel structure.",
-	}, handleTeamChannel)
+	mcp.AddTool(server, officeDestructiveTool(
+		"team_channel",
+		"Create or remove an office channel. When creating a channel, include a clear description of what work belongs there and the initial roster that should be in it. Only do this when the human explicitly wants channel structure.",
+	), handleTeamChannel)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_channel_member",
-		Description: "Add, remove, disable, or enable an agent in a specific office channel.",
-	}, handleTeamChannelMember)
+	mcp.AddTool(server, officeDestructiveTool(
+		"team_channel_member",
+		"Add, remove, disable, or enable an agent in a specific office channel.",
+	), handleTeamChannelMember)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_bridge",
-		Description: "CEO-only tool to bridge relevant context from one channel into another and leave a visible cross-channel trail.",
-	}, handleTeamBridge)
+	mcp.AddTool(server, officeWriteTool(
+		"team_bridge",
+		"CEO-only tool to bridge relevant context from one channel into another and leave a visible cross-channel trail.",
+	), handleTeamBridge)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_member",
-		Description: "Create or remove an office-wide member. Only create new members when the human explicitly wants to expand the team.",
-	}, handleTeamMember)
+	mcp.AddTool(server, officeDestructiveTool(
+		"team_member",
+		"Create or remove an office-wide member. Only create new members when the human explicitly wants to expand the team.",
+	), handleTeamMember)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_tasks",
-		Description: "List the current shared tasks and who owns them so the team does not duplicate work.",
-	}, handleTeamTasks)
+	mcp.AddTool(server, readOnlyTool(
+		"team_tasks",
+		"List the current shared tasks and who owns them so the team does not duplicate work.",
+	), handleTeamTasks)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_task_status",
-		Description: "Summarize how many shared tasks are running and whether any are isolated in local worktrees.",
-	}, handleTeamTaskStatus)
+	mcp.AddTool(server, readOnlyTool(
+		"team_task_status",
+		"Summarize how many shared tasks are running and whether any are isolated in local worktrees.",
+	), handleTeamTaskStatus)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_runtime_state",
-		Description: "Return the canonical office runtime snapshot, including tasks, pending human requests, recovery summary, and runtime capabilities.",
-	}, handleTeamRuntimeState)
+	mcp.AddTool(server, readOnlyTool(
+		"team_runtime_state",
+		"Return the canonical office runtime snapshot, including tasks, pending human requests, recovery summary, and runtime capabilities.",
+	), handleTeamRuntimeState)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_task",
-		Description: "Create, claim, assign, complete, block, or release a shared task in the office task list.",
-	}, handleTeamTask)
+	mcp.AddTool(server, officeWriteTool(
+		"team_task",
+		"Create, claim, assign, complete, block, or release a shared task in the office task list.",
+	), handleTeamTask)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_requests",
-		Description: "List the current office requests so you know whether the human already owes the team a decision.",
-	}, handleTeamRequests)
+	mcp.AddTool(server, readOnlyTool(
+		"team_requests",
+		"List the current office requests so you know whether the human already owes the team a decision.",
+	), handleTeamRequests)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "team_request",
-		Description: "Create a structured request for the human: confirmation, choice, approval, freeform answer, or private/secret answer.",
-	}, handleTeamRequest)
+	mcp.AddTool(server, officeWriteTool(
+		"team_request",
+		"Create a structured request for the human: confirmation, choice, approval, freeform answer, or private/secret answer.",
+	), handleTeamRequest)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "human_interview",
-		Description: "Ask the human a blocking interview question when the team cannot proceed responsibly without a decision.",
-	}, handleHumanInterview)
+	mcp.AddTool(server, officeWriteTool(
+		"human_interview",
+		"Ask the human a blocking interview question when the team cannot proceed responsibly without a decision.",
+	), handleHumanInterview)
 
-	mcp.AddTool(server, &mcp.Tool{
-		Name:        "human_message",
-		Description: "Send a direct human-facing note into the main chat when you need to present completion, recommend a decision, or tell the human what they should do next.",
-	}, handleHumanMessage)
+	mcp.AddTool(server, officeWriteTool(
+		"human_message",
+		"Send a direct human-facing note into the main chat when you need to present completion, recommend a decision, or tell the human what they should do next.",
+	), handleHumanMessage)
 
 	registerActionTools(server)
 

--- a/internal/tui/init_flow.go
+++ b/internal/tui/init_flow.go
@@ -60,12 +60,8 @@ func (f InitFlowModel) IsActive() bool {
 
 // Start begins the init flow. API key → provider choice → pack choice → done.
 func (f InitFlowModel) Start() (InitFlowModel, tea.Cmd) {
-	cfg, _ := config.Load()
 	f.apiKey = strings.TrimSpace(config.ResolveAPIKey(""))
-	f.provider = strings.TrimSpace(cfg.LLMProvider)
-	if f.provider == "" {
-		f.provider = "claude-code"
-	}
+	f.provider = config.ResolveLLMProvider("")
 	if f.apiKey == "" {
 		f.phase = InitAPIKey
 		return f, f.emitPhase(InitAPIKey)
@@ -196,10 +192,6 @@ func ProviderOptions() []PickerOption {
 	options := []PickerOption{
 		{Label: "Claude Code (default)", Value: "claude-code", Description: claudeDesc},
 		{Label: "Codex CLI", Value: "codex", Description: codexDesc},
-		{Label: "Gemini", Value: "gemini", Description: "Google Gemini via API key"},
-	}
-	if !config.ResolveNoNex() {
-		options = append(options, PickerOption{Label: "Nex Ask", Value: "nex-ask", Description: "Nex hosted AI (uses WUPHF_API_KEY)"})
 	}
 	return options
 }

--- a/internal/tui/init_flow_test.go
+++ b/internal/tui/init_flow_test.go
@@ -96,6 +96,18 @@ func TestProviderOptionsIncludeCodex(t *testing.T) {
 	t.Fatal("expected codex provider option")
 }
 
+func TestProviderOptionsOnlyExposeClaudeAndCodex(t *testing.T) {
+	options := ProviderOptions()
+	values := make([]string, 0, len(options))
+	for _, opt := range options {
+		values = append(values, opt.Value)
+	}
+	joined := strings.Join(values, ",")
+	if strings.Contains(joined, "gemini") || strings.Contains(joined, "nex-ask") {
+		t.Fatalf("expected provider options to hide gemini and nex-ask, got %q", joined)
+	}
+}
+
 func containsAll(s string, needles ...string) bool {
 	for _, needle := range needles {
 		if !strings.Contains(s, needle) {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -62,8 +62,7 @@ func NewModel(panesMode bool) Model {
 	rt := NewRuntime(events)
 
 	hasAPIKey := config.ResolveAPIKey("") != ""
-	cfg, _ := config.Load()
-	providerName := strings.TrimSpace(cfg.LLMProvider)
+	providerName := config.ResolveLLMProvider("")
 
 	m := Model{
 		runtime:     rt,


### PR DESCRIPTION
## Summary
- make Codex a first-class office provider in the channel UI, including `/provider` and `--provider codex`
- harden the headless Codex runtime with JSON-stream parsing, per-agent FIFO turns, stale-turn cancellation, and clearer provider readiness
- stop leaking broker/Nex/One secrets in `codex exec` argv by forwarding them via `env_vars` instead

## Validation
- `go test ./internal/team -run 'TestBuildCodexOfficeConfigOverridesIncludesOfficeMCPEnv|TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime|TestEnqueueHeadlessCodexTurnProcessesFIFO|TestEnqueueHeadlessCodexTurnCancelsStaleTurn|TestNewLauncherUsesCodexProviderFromConfig'`
- `go test ./...`
- `go build -o ./wuphf ./cmd/wuphf`