### PR TITLE
[codex] add approval steering review flow

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -3651,7 +3651,7 @@ func (m channelModel) answerRequest(req channelInterview) (tea.Model, tea.Cmd) {
 	m.pending = &req
 	m.snoozedInterview = ""
 	m.selectedOption = m.recommendedOptionIndex()
-	m.notice = "Answering request " + req.ID + ". Type your answer and press Enter."
+	m.notice = answerRequestNotice(req)
 	if req.ReplyTo != "" {
 		m.threadPanelOpen = true
 		m.threadPanelID = req.ReplyTo
@@ -3995,11 +3995,14 @@ func renderInterviewCard(interview channelInterview, selected int, phaseTitle st
 		if i == selected {
 			prefix = lipgloss.NewStyle().Foreground(lipgloss.Color("#60A5FA")).Bold(true).Render("→ ")
 		}
-		label := option.Label
+		labelBits := []string{titleStyle.Render(interviewOptionDisplayLabel(&option))}
 		if option.ID == interview.RecommendedID {
-			label += " (Recommended)"
+			labelBits = append(labelBits, subtlePill("recommended", "#DBEAFE", "#1D4ED8"))
 		}
-		lines = append(lines, prefix+titleStyle.Render(label))
+		if badge := interviewOptionDraftBadge(&option); badge != "" {
+			labelBits = append(labelBits, subtlePill(badge, "#FDE68A", "#78350F"))
+		}
+		lines = append(lines, prefix+strings.Join(labelBits, " "))
 		if strings.TrimSpace(option.Description) != "" {
 			lines = append(lines, "    "+muted.Width(cardWidth-8).Render(option.Description))
 		}

--- a/cmd/wuphf/channel_artifact_snapshot.go
+++ b/cmd/wuphf/channel_artifact_snapshot.go
@@ -355,8 +355,8 @@ func normalizeWorkflowArtifactState(status string) string {
 
 func requestArtifactProgress(req channelInterview) string {
 	parts := make([]string, 0, 3)
-	if choice := strings.TrimSpace(req.RecommendedID); choice != "" {
-		parts = append(parts, "Recommended: "+choice)
+	if recommended := req.recommendedOptionLabel(); recommended != "" {
+		parts = append(parts, "Recommended: "+recommended)
 	}
 	if due := strings.TrimSpace(req.DueAt); due != "" {
 		parts = append(parts, "Due "+prettyRelativeTime(due))
@@ -368,7 +368,7 @@ func requestArtifactProgress(req channelInterview) string {
 }
 
 func requestArtifactReviewHint(req channelInterview) string {
-	if recommended := strings.TrimSpace(req.RecommendedID); recommended != "" {
+	if recommended := req.recommendedOptionLabel(); recommended != "" {
 		return "Review recommendation " + recommended + " before answering."
 	}
 	if due := strings.TrimSpace(req.DueAt); due != "" {

--- a/cmd/wuphf/channel_confirm.go
+++ b/cmd/wuphf/channel_confirm.go
@@ -93,16 +93,19 @@ func confirmationForSessionSwitch(mode, agent string) *channelConfirm {
 }
 
 func confirmationForInterviewAnswer(interview channelInterview, option *channelInterviewOption, customText string) *channelConfirm {
-	title := "Review Human Answer"
+	title := interviewReviewTitle(interview)
 	detailLines := []string{
 		fmt.Sprintf("Question: %s", strings.TrimSpace(interview.Question)),
 	}
-	if option != nil && strings.TrimSpace(option.Label) != "" {
-		detailLines = append(detailLines, fmt.Sprintf("Choice: %s", strings.TrimSpace(option.Label)))
+	if label := interviewOptionDisplayLabel(option); label != "" {
+		detailLines = append(detailLines, fmt.Sprintf("Decision: %s", label))
+	}
+	if outcome := interviewOptionOutcome(interview, option); outcome != "" {
+		detailLines = append(detailLines, fmt.Sprintf("Outcome: %s", outcome))
 	}
 	customText = strings.TrimSpace(customText)
 	if customText != "" {
-		detailLines = append(detailLines, fmt.Sprintf("Note: %s", customText))
+		detailLines = append(detailLines, fmt.Sprintf("%s: %s", interviewCustomTextLabel(option), customText))
 	}
 	if len(detailLines) == 1 && option == nil {
 		detailLines = append(detailLines, "Type an answer before submitting.")

--- a/cmd/wuphf/channel_interview.go
+++ b/cmd/wuphf/channel_interview.go
@@ -21,6 +21,177 @@ func interviewOptionRequiresText(option *channelInterviewOption) bool {
 	return strings.Contains(id, "note") || strings.Contains(id, "steer")
 }
 
+func normalizeInterviewKind(kind string) string {
+	return strings.ToLower(strings.TrimSpace(kind))
+}
+
+func normalizeInterviewOptionID(id string) string {
+	return strings.ToLower(strings.TrimSpace(id))
+}
+
+func humanizeInterviewOptionID(id string) string {
+	parts := strings.FieldsFunc(strings.TrimSpace(id), func(r rune) bool {
+		return r == '_' || r == '-' || r == ' '
+	})
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + strings.ToLower(part[1:])
+	}
+	return strings.Join(parts, " ")
+}
+
+func interviewOptionDisplayLabel(option *channelInterviewOption) string {
+	if option == nil {
+		return ""
+	}
+	if label := strings.TrimSpace(option.Label); label != "" {
+		return label
+	}
+	return humanizeInterviewOptionID(option.ID)
+}
+
+func (req channelInterview) optionByID(id string) *channelInterviewOption {
+	id = normalizeInterviewOptionID(id)
+	if id == "" {
+		return nil
+	}
+	for i := range req.Options {
+		if normalizeInterviewOptionID(req.Options[i].ID) == id {
+			return &req.Options[i]
+		}
+	}
+	return nil
+}
+
+func (req channelInterview) recommendedOptionLabel() string {
+	if option := req.optionByID(req.RecommendedID); option != nil {
+		return interviewOptionDisplayLabel(option)
+	}
+	return humanizeInterviewOptionID(req.RecommendedID)
+}
+
+func interviewReviewTitle(interview channelInterview) string {
+	switch normalizeInterviewKind(interview.Kind) {
+	case "approval":
+		return "Review Approval Decision"
+	case "confirm":
+		return "Review Confirmation"
+	case "choice":
+		return "Review Direction"
+	case "secret":
+		return "Review Private Reply"
+	case "interview":
+		return "Review Human Answer"
+	default:
+		return "Review Request Response"
+	}
+}
+
+func interviewOptionOutcome(interview channelInterview, option *channelInterviewOption) string {
+	switch normalizeInterviewOptionID(optionID(option)) {
+	case "approve":
+		return "The team will proceed immediately."
+	case "approve_with_note":
+		return "The team will proceed, but your note becomes explicit guardrails."
+	case "needs_more_info", "need_more_context":
+		return "The office will gather the missing context before coming back."
+	case "reject":
+		return "The proposed work will stop here."
+	case "reject_with_steer":
+		return "The team will not proceed as proposed and will redirect around your steering."
+	case "confirm_proceed":
+		return "The office will proceed as planned."
+	case "adjust":
+		return "The office will revise the plan before proceeding."
+	case "reassign":
+		return "The office will reroute ownership or scope before proceeding."
+	case "hold":
+		return "The office will keep this paused for later review."
+	case "answer_directly":
+		return "Your answer will go directly back to the team."
+	case "give_direction":
+		return "The team will proceed using your direction."
+	case "delegate":
+		return "The office will route this to the owner you name."
+	case "proceed":
+		return "The team will proceed using its best judgment."
+	}
+
+	switch normalizeInterviewKind(interview.Kind) {
+	case "approval":
+		return "Your decision will either unblock or redirect the proposed work."
+	case "confirm":
+		return "Your answer will confirm, hold, or adjust the office plan."
+	case "choice":
+		return "Your answer will set the office direction."
+	default:
+		return "Your answer will be sent back to the team."
+	}
+}
+
+func interviewCustomTextLabel(option *channelInterviewOption) string {
+	switch normalizeInterviewOptionID(optionID(option)) {
+	case "approve_with_note":
+		return "Guardrails"
+	case "reject_with_steer":
+		return "Steering"
+	case "adjust":
+		return "Required changes"
+	case "reassign", "delegate":
+		return "Routing"
+	case "needs_more_info", "need_more_context":
+		return "Missing context"
+	case "give_direction":
+		return "Direction"
+	}
+	if interviewOptionRequiresText(option) {
+		return "Note"
+	}
+	return "Answer"
+}
+
+func interviewOptionDraftBadge(option *channelInterviewOption) string {
+	switch normalizeInterviewOptionID(optionID(option)) {
+	case "approve_with_note", "give_direction":
+		return "add guidance"
+	case "reject_with_steer", "delegate", "reassign":
+		return "add steering"
+	case "adjust":
+		return "add changes"
+	case "needs_more_info", "need_more_context":
+		return "add context gap"
+	default:
+		if interviewOptionRequiresText(option) {
+			return "needs note"
+		}
+		return ""
+	}
+}
+
+func answerRequestNotice(req channelInterview) string {
+	switch normalizeInterviewKind(req.Kind) {
+	case "approval":
+		return "Answering approval " + req.ID + ". Pick a decision or type steering, then press Enter."
+	case "confirm":
+		return "Answering confirmation " + req.ID + ". Confirm, adjust, or hold before sending."
+	case "choice":
+		return "Answering decision " + req.ID + ". Choose a direction or add guidance, then press Enter."
+	case "interview":
+		return "Answering request " + req.ID + ". Type your answer and press Enter."
+	default:
+		return "Answering request " + req.ID + ". Pick an option or type your answer, then press Enter."
+	}
+}
+
+func optionID(option *channelInterviewOption) string {
+	if option == nil {
+		return ""
+	}
+	return option.ID
+}
+
 func interviewOptionTextHint(option *channelInterviewOption) string {
 	if option == nil {
 		return ""
@@ -76,6 +247,6 @@ func (m channelModel) interviewStatusLine() string {
 	case interviewPhaseDraft:
 		return " Request draft │ type answer │ Enter review"
 	default:
-		return " Request choose │ ↑/↓ select │ Enter continue"
+		return " Request choose │ ↑/↓ select │ Enter review"
 	}
 }

--- a/cmd/wuphf/channel_needs_you.go
+++ b/cmd/wuphf/channel_needs_you.go
@@ -33,8 +33,8 @@ func buildNeedsYouLinesForRequest(req *channelInterview, contentWidth int) []ren
 	if req.Blocking || req.Required {
 		extra = append(extra, "The team is paused until you answer.")
 	}
-	if strings.TrimSpace(req.RecommendedID) != "" {
-		extra = append(extra, "Recommended: "+req.RecommendedID)
+	if recommended := req.recommendedOptionLabel(); recommended != "" {
+		extra = append(extra, "Recommended: "+recommended)
 	}
 	if due := strings.TrimSpace(req.DueAt); due != "" {
 		extra = append(extra, "Due "+prettyRelativeTime(due))

--- a/cmd/wuphf/channel_needs_you_test.go
+++ b/cmd/wuphf/channel_needs_you_test.go
@@ -23,6 +23,9 @@ func TestBuildNeedsYouLinesPrefersBlockingRequests(t *testing.T) {
 	if !strings.Contains(plain, "The team is paused until you answer.") {
 		t.Fatalf("expected blocking request guidance, got %q", plain)
 	}
+	if !strings.Contains(plain, "Recommended: Approve") {
+		t.Fatalf("expected human-readable recommendation label, got %q", plain)
+	}
 }
 
 func TestCurrentMainViewportLinesPrependsNeedsYouStrip(t *testing.T) {

--- a/cmd/wuphf/channel_recovery.go
+++ b/cmd/wuphf/channel_recovery.go
@@ -215,8 +215,8 @@ func buildRecoveryActionLines(contentWidth int, tasks []channelTask, requests []
 			body = strings.TrimSpace(req.Question)
 		}
 		extra := []string{"Asked by @" + fallbackString(req.From, "unknown")}
-		if strings.TrimSpace(req.RecommendedID) != "" {
-			extra = append(extra, "Recommended: "+req.RecommendedID)
+		if recommended := req.recommendedOptionLabel(); recommended != "" {
+			extra = append(extra, "Recommended: "+recommended)
 		}
 		extra = append(extra, "Open request")
 		lines = append(lines, prefixedCardLines(renderedCardLines(renderRecoveryActionCard(contentWidth, header, body, "#B45309", extra), "", req.ID, strings.TrimSpace(req.ReplyTo), ""), "  ")...)

--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -181,8 +181,8 @@ func buildRequestLines(requests []channelInterview, contentWidth int) []rendered
 		if timing := renderTimingSummary(req.DueAt, req.FollowUpAt, req.ReminderAt, req.RecheckAt); timing != "" {
 			lines = append(lines, renderedLine{Text: "  " + muted.Render(timing), RequestID: req.ID})
 		}
-		if req.RecommendedID != "" {
-			lines = append(lines, renderedLine{Text: "  " + highlight.Render("Recommended: "+req.RecommendedID), RequestID: req.ID})
+		if recommended := req.recommendedOptionLabel(); recommended != "" {
+			lines = append(lines, renderedLine{Text: "  " + highlight.Render("Recommended: "+recommended), RequestID: req.ID})
 		}
 		lines = append(lines, renderedLine{Text: "  " + muted.Render("Click to focus, answer, or snooze. Esc hides it locally; the team still waits."), RequestID: req.ID})
 	}

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -2479,6 +2479,28 @@ func TestPendingRequestTypedAnswerOpensReviewConfirmation(t *testing.T) {
 	}
 }
 
+func TestAnswerRequestUsesApprovalSteeringNotice(t *testing.T) {
+	m := newChannelModel(false)
+	req := channelInterview{
+		ID:       "request-1",
+		Kind:     "approval",
+		From:     "ceo",
+		Question: "Ship it?",
+		Options: []channelInterviewOption{
+			{ID: "approve", Label: "Approve"},
+			{ID: "reject_with_steer", Label: "Reject with steer", RequiresText: true},
+		},
+		RecommendedID: "approve",
+	}
+
+	next, _ := m.answerRequest(req)
+	got := next.(channelModel)
+
+	if !strings.Contains(got.notice, "Pick a decision or type steering") {
+		t.Fatalf("expected approval-specific notice, got %q", got.notice)
+	}
+}
+
 func TestChannelResetDoneImmediatelyRehydratesDirectMode(t *testing.T) {
 	m := newChannelModel(false)
 	m.width = 120
@@ -2566,6 +2588,27 @@ func TestRenderInterviewCardShowsCustomAnswerAsFinalOption(t *testing.T) {
 	}
 }
 
+func TestRenderInterviewCardShowsApprovalBadges(t *testing.T) {
+	card := renderInterviewCard(channelInterview{
+		Kind:     "approval",
+		From:     "ceo",
+		Question: "Ship the launch copy?",
+		Options: []channelInterviewOption{
+			{ID: "approve_with_note", Label: "Approve with note", RequiresText: true},
+			{ID: "reject", Label: "Reject"},
+		},
+		RecommendedID: "approve_with_note",
+	}, 0, "Step 1 of 3 · choose", 72)
+
+	plain := stripANSI(card)
+	if !strings.Contains(plain, "recommended") {
+		t.Fatalf("expected recommended badge in approval card, got %q", plain)
+	}
+	if !strings.Contains(plain, "add guidance") {
+		t.Fatalf("expected guidance badge for text-required choice, got %q", plain)
+	}
+}
+
 func TestInterviewPhaseTracksChooseDraftAndReview(t *testing.T) {
 	m := newChannelModel(false)
 	m.pending = &channelInterview{
@@ -2596,6 +2639,31 @@ func TestInterviewPhaseTracksChooseDraftAndReview(t *testing.T) {
 	}
 	if hint := m.composerHint(m.composerTargetLabel(), "", m.pending); !strings.Contains(hint, "Enter submit") || !strings.Contains(hint, "Esc revise") {
 		t.Fatalf("expected review hint while reviewing answer, got %q", hint)
+	}
+}
+
+func TestConfirmationForApprovalShowsOutcomeAndGuardrails(t *testing.T) {
+	req := channelInterview{
+		ID:       "request-1",
+		Kind:     "approval",
+		From:     "ceo",
+		Question: "Ship it?",
+	}
+	option := &channelInterviewOption{ID: "approve_with_note", Label: "Approve with note", RequiresText: true}
+
+	confirm := confirmationForInterviewAnswer(req, option, "Need legal sign-off first.")
+
+	if confirm.Title != "Review Approval Decision" {
+		t.Fatalf("expected approval review title, got %q", confirm.Title)
+	}
+	if !strings.Contains(confirm.Detail, "Decision: Approve with note") {
+		t.Fatalf("expected decision label in detail, got %q", confirm.Detail)
+	}
+	if !strings.Contains(confirm.Detail, "Outcome: The team will proceed, but your note becomes explicit guardrails.") {
+		t.Fatalf("expected approval outcome in detail, got %q", confirm.Detail)
+	}
+	if !strings.Contains(confirm.Detail, "Guardrails: Need legal sign-off first.") {
+		t.Fatalf("expected guardrails label in detail, got %q", confirm.Detail)
 	}
 }
 


### PR DESCRIPTION
## What changed
- added approval-specific review helpers and labels so requests read like explicit decisions instead of generic answers
- updated the confirm/review step to show decision, outcome, and steering/guardrail guidance
- replaced raw recommendation IDs in needs-you, recovery, artifacts, and request surfaces with human-readable labels

## Why
Approval requests were structurally powerful but UX-thin. The team could ask for a decision, but the human-facing review flow did not clearly frame the choice, consequence, or optional steering guidance.

## Impact
Humans can review and answer approval requests with clearer intent, better labels, and more legible recommendation surfaces.

## Validation
- `go test ./cmd/wuphf`
