### PR TITLE
[codex] add CEO-routed focus mode

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -146,6 +146,7 @@ type channelHealthMsg struct {
 	Connected     bool
 	SessionMode   string
 	OneOnOneAgent string
+	FocusMode     bool
 }
 
 type brokerReaction struct {
@@ -357,6 +358,10 @@ type channelResetDoneMsg struct {
 	sessionMode   string
 	oneOnOneAgent string
 }
+type channelFocusModeDoneMsg struct {
+	err     error
+	enabled bool
+}
 type channelResetDMDoneMsg struct {
 	err     error
 	removed int
@@ -445,6 +450,7 @@ var channelSlashCommands = []tui.SlashCommand{
 	{Name: "integrate", Description: "Connect an integration", Category: "setup"},
 	{Name: "connect", Description: "Connect an external channel (Telegram, Slack, Discord)", Category: "setup"},
 	{Name: "1o1", Description: "Enable, switch, or disable direct 1:1 mode", Category: "session"},
+	{Name: "focus", Description: "Enable or disable CEO-routed focus mode", Category: "session"},
 	{Name: "messages", Description: "Show the main office feed", Category: "navigate"},
 	{Name: "inbox", Description: "Show the selected agent inbox lane in 1:1 mode", Category: "navigate"},
 	{Name: "outbox", Description: "Show the selected agent outbox lane in 1:1 mode", Category: "navigate"},
@@ -527,6 +533,7 @@ const (
 	channelPickerCalendarAgent  channelPickerMode = "calendar_agent"
 	channelPickerOneOnOneMode   channelPickerMode = "one_on_one_mode"
 	channelPickerOneOnOneAgent  channelPickerMode = "one_on_one_agent"
+	channelPickerFocusMode      channelPickerMode = "focus_mode"
 	channelPickerTelegramGroup  channelPickerMode = "telegram_group"
 	channelPickerConnect        channelPickerMode = "connect"
 	channelPickerTelegramToken  channelPickerMode = "telegram_token"
@@ -650,6 +657,7 @@ type channelModel struct {
 	brokerConnected     bool
 	sessionMode         string
 	oneOnOneAgent       string
+	focusMode           bool
 	lastCtrlCAt         time.Time
 	quickJumpTarget     quickJumpTarget
 	calendarRange       calendarRange
@@ -678,6 +686,7 @@ func newChannelModelWithApp(threadsCollapsed bool, initialApp officeApp) channel
 		}
 		initialApp = officeAppMessages
 	}
+	focusMode := strings.EqualFold(strings.TrimSpace(os.Getenv("WUPHF_FOCUS_MODE")), "1") || strings.EqualFold(strings.TrimSpace(os.Getenv("WUPHF_FOCUS_MODE")), "true")
 	officeDirectory = make(map[string]officeMemberInfo, len(officeMembers))
 	for _, member := range officeMembers {
 		officeDirectory[member.Slug] = member
@@ -696,6 +705,7 @@ func newChannelModelWithApp(threadsCollapsed bool, initialApp officeApp) channel
 		channels:             channels,
 		sessionMode:          sessionMode,
 		oneOnOneAgent:        oneOnOneAgent,
+		focusMode:            focusMode,
 		threadInputHistory:   newComposerHistory(),
 	}
 	if m.isOneOnOne() {
@@ -1442,6 +1452,20 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notice = "Reset failed: " + msg.err.Error()
 		}
 
+	case channelFocusModeDoneMsg:
+		m.posting = false
+		if msg.err != nil {
+			m.notice = "Focus mode update failed: " + msg.err.Error()
+			return m, nil
+		}
+		m.focusMode = msg.enabled
+		if msg.enabled {
+			m.notice = "Focus mode enabled. Specialists now route through CEO."
+		} else {
+			m.notice = "Focus mode disabled. Normal office chatter is back."
+		}
+		return m, m.pollCurrentState()
+
 	case channelResetDMDoneMsg:
 		m.posting = false
 		m.confirm = nil
@@ -1664,9 +1688,11 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Connected {
 			nextMode := team.NormalizeSessionMode(msg.SessionMode)
 			nextAgent := team.NormalizeOneOnOneAgent(msg.OneOnOneAgent)
+			focusChanged := msg.FocusMode != m.focusMode
 			modeChanged := nextMode != m.sessionMode || nextAgent != m.oneOnOneAgent
 			m.sessionMode = nextMode
 			m.oneOnOneAgent = nextAgent
+			m.focusMode = msg.FocusMode
 			if m.isOneOnOne() {
 				m.activeApp = officeAppMessages
 				m.sidebarCollapsed = true
@@ -1687,6 +1713,13 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.notice = "Direct session reset. Agent pane reloaded in place."
 				}
 				return m, m.pollCurrentState()
+			}
+			if focusChanged && strings.TrimSpace(m.notice) == "" {
+				if m.focusMode {
+					m.notice = "Focus mode enabled. Specialists now route through CEO."
+				} else {
+					m.notice = "Focus mode disabled. Normal office chatter is back."
+				}
 			}
 		}
 
@@ -1890,6 +1923,22 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.confirm = confirmationForSessionSwitch(team.SessionModeOneOnOne, agent)
 			m.notice = "Confirm the direct session switch."
 			return m, nil
+		case channelPickerFocusMode:
+			m.picker.SetActive(false)
+			m.pickerMode = channelPickerNone
+			switch strings.TrimSpace(msg.Value) {
+			case "focus:enable":
+				m.posting = true
+				m.notice = "Enabling focus mode..."
+				return m, setFocusMode(true)
+			case "focus:disable":
+				m.posting = true
+				m.notice = "Disabling focus mode..."
+				return m, setFocusMode(false)
+			default:
+				m.notice = "Left focus mode unchanged."
+				return m, nil
+			}
 		case channelPickerConnect:
 			m.picker.SetActive(false)
 			m.pickerMode = channelPickerNone
@@ -4446,6 +4495,32 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		}
 		m.posting = true
 		return m, switchSessionMode(team.SessionModeOneOnOne, agent)
+	case trimmed == "/focus":
+		clearCurrent()
+		m.picker = tui.NewPicker("Focus Mode", m.buildFocusModePickerOptions())
+		m.picker.SetActive(true)
+		m.pickerMode = channelPickerFocusMode
+		return m, nil
+	case trimmed == "/focus on" || trimmed == "/focus enable":
+		clearCurrent()
+		if m.focusMode {
+			m.notice = "Focus mode is already enabled."
+			return m, nil
+		}
+		m.posting = true
+		return m, setFocusMode(true)
+	case trimmed == "/focus off" || trimmed == "/focus disable":
+		clearCurrent()
+		if !m.focusMode {
+			m.notice = "Focus mode is already disabled."
+			return m, nil
+		}
+		m.posting = true
+		return m, setFocusMode(false)
+	case trimmed == "/focus toggle":
+		clearCurrent()
+		m.posting = true
+		return m, setFocusMode(!m.focusMode)
 	case trimmed == "/messages" || trimmed == "/general":
 		clearCurrent()
 		m.activeApp = officeAppMessages
@@ -5306,6 +5381,35 @@ func (m channelModel) buildOneOnOneModePickerOptions() []tui.PickerOption {
 	}
 }
 
+func (m channelModel) buildFocusModePickerOptions() []tui.PickerOption {
+	if m.focusMode {
+		return []tui.PickerOption{
+			{
+				Label:       "Disable focus mode",
+				Value:       "focus:disable",
+				Description: "Restore normal office chatter and specialist cross-talk",
+			},
+			{
+				Label:       "Keep focus mode on",
+				Value:       "focus:keep",
+				Description: "CEO remains the routing hub",
+			},
+		}
+	}
+	return []tui.PickerOption{
+		{
+			Label:       "Enable focus mode",
+			Value:       "focus:enable",
+			Description: "Route specialist work through CEO and suppress cross-agent gossip",
+		},
+		{
+			Label:       "Keep normal office mode",
+			Value:       "focus:keep",
+			Description: "Leave normal office chatter enabled",
+		},
+	}
+}
+
 func (m channelModel) buildOneOnOneAgentPickerOptions() []tui.PickerOption {
 	options := make([]tui.PickerOption, 0, len(m.officeMembers))
 	for _, member := range m.officeMembers {
@@ -5365,6 +5469,7 @@ func pollHealth() tea.Cmd {
 			Status        string `json:"status"`
 			SessionMode   string `json:"session_mode"`
 			OneOnOneAgent string `json:"one_on_one_agent"`
+			FocusMode     bool   `json:"focus_mode"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 			return channelHealthMsg{Connected: true}
@@ -5373,6 +5478,7 @@ func pollHealth() tea.Cmd {
 			Connected:     true,
 			SessionMode:   result.SessionMode,
 			OneOnOneAgent: result.OneOnOneAgent,
+			FocusMode:     result.FocusMode,
 		}
 	}
 }
@@ -6198,6 +6304,41 @@ func switchSessionMode(mode, agent string) tea.Cmd {
 				oneOnOneAgent: result.OneOnOneAgent,
 			}
 		}
+	}
+}
+
+func setFocusMode(enabled bool) tea.Cmd {
+	return func() tea.Msg {
+		body, _ := json.Marshal(map[string]any{
+			"enabled": enabled,
+		})
+		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/focus-mode", bytes.NewReader(body))
+		if err != nil {
+			return channelFocusModeDoneMsg{err: err}
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return channelFocusModeDoneMsg{err: err}
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			raw, _ := io.ReadAll(resp.Body)
+			return channelFocusModeDoneMsg{err: fmt.Errorf("%s", strings.TrimSpace(string(raw)))}
+		}
+		var result struct {
+			FocusMode bool `json:"focus_mode"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			result.FocusMode = enabled
+		}
+		l, err := team.NewLauncher("")
+		if err != nil {
+			return channelFocusModeDoneMsg{err: err}
+		}
+		if err := l.ReconfigureSession(); err != nil {
+			return channelFocusModeDoneMsg{err: err}
+		}
+		return channelFocusModeDoneMsg{enabled: result.FocusMode}
 	}
 }
 

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -1527,25 +1527,20 @@ func TestOfficeViewRendersSlashAutocompletePopup(t *testing.T) {
 }
 
 func TestOneOnOneSlashAutocompleteShowsResetAndHidesChannels(t *testing.T) {
-	t.Setenv("WUPHF_API_KEY", "test-key")
-	m := newChannelModel(false)
-	m.sessionMode = team.SessionModeOneOnOne
-	m.oneOnOneAgent = "pm"
-	m.sidebarCollapsed = true
-	m.refreshSlashCommands()
-	m.input = []rune("/")
-	m.inputPos = len(m.input)
-	m.updateInputOverlays()
+	cmds := buildOneOnOneSlashCommands()
+	seen := make(map[string]bool, len(cmds))
+	for _, cmd := range cmds {
+		seen[cmd.Name] = true
+	}
 
-	view := stripANSI(m.autocomplete.View())
-	if !strings.Contains(view, "/reset") {
-		t.Fatalf("expected /reset in visible 1:1 autocomplete, got %q", view)
+	if !seen["reset"] {
+		t.Fatalf("expected /reset to remain available in 1:1 mode, got %+v", cmds)
 	}
-	if !strings.Contains(view, "/switch") {
-		t.Fatalf("expected /switch in visible 1:1 autocomplete, got %q", view)
+	if !seen["switch"] {
+		t.Fatalf("expected /switch to remain available in 1:1 mode, got %+v", cmds)
 	}
-	if strings.Contains(view, "/channels") || strings.Contains(view, "/tasks") || strings.Contains(view, "/threads") {
-		t.Fatalf("expected blocked 1:1 commands to be hidden from autocomplete, got %q", view)
+	if seen["channels"] || seen["tasks"] || seen["threads"] {
+		t.Fatalf("expected blocked 1:1 commands to be removed, got %+v", cmds)
 	}
 }
 

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -575,6 +575,42 @@ func TestOneOnOneCommandOpensModePicker(t *testing.T) {
 	}
 }
 
+func TestFocusCommandOpensPicker(t *testing.T) {
+	m := newChannelModel(false)
+
+	next, cmd := m.runCommand("/focus", "")
+	if cmd != nil {
+		t.Fatalf("expected no immediate command from /focus picker open, got %v", cmd)
+	}
+	got := next.(channelModel)
+	if !got.picker.IsActive() || got.pickerMode != channelPickerFocusMode {
+		t.Fatalf("expected focus mode picker, got active=%v mode=%q", got.picker.IsActive(), got.pickerMode)
+	}
+	view := stripANSI(got.picker.View())
+	if !strings.Contains(view, "Enable focus mode") {
+		t.Fatalf("expected focus picker options, got %q", view)
+	}
+}
+
+func TestFocusPickerSelectionStartsToggleRequest(t *testing.T) {
+	m := newChannelModel(false)
+	m.picker = tui.NewPicker("Focus Mode", m.buildFocusModePickerOptions())
+	m.picker.SetActive(true)
+	m.pickerMode = channelPickerFocusMode
+
+	next, cmd := m.Update(tui.PickerSelectMsg{Value: "focus:enable"})
+	if cmd == nil {
+		t.Fatal("expected focus toggle command")
+	}
+	got := next.(channelModel)
+	if !got.posting {
+		t.Fatal("expected posting state while focus mode is being toggled")
+	}
+	if got.notice != "Enabling focus mode..." {
+		t.Fatalf("unexpected notice: %q", got.notice)
+	}
+}
+
 func TestOneOnOnePickerEnableOpensAgentPicker(t *testing.T) {
 	m := newChannelModel(false)
 	m.picker = tui.NewPicker("Direct Session", m.buildOneOnOneModePickerOptions())

--- a/cmd/wuphf/channel_workspace_state.go
+++ b/cmd/wuphf/channel_workspace_state.go
@@ -31,6 +31,7 @@ type workspaceUIState struct {
 	CurrentApp      officeApp
 	BrokerConnected bool
 	Direct          bool
+	FocusMode       bool
 	Channel         string
 	AgentName       string
 	AgentSlug       string
@@ -57,6 +58,7 @@ func (m channelModel) currentWorkspaceUIState() workspaceUIState {
 		CurrentApp:      m.activeApp,
 		BrokerConnected: m.brokerConnected,
 		Direct:          m.isOneOnOne(),
+		FocusMode:       m.focusMode,
 		Channel:         m.activeChannel,
 		AgentName:       m.oneOnOneAgentName(),
 		AgentSlug:       m.oneOnOneAgentSlug(),
@@ -247,6 +249,9 @@ func (s workspaceUIState) headerMeta() string {
 		fmt.Sprintf("%d running", s.RunningTasks),
 		fmt.Sprintf("%d open requests", s.OpenRequests),
 	}
+	if s.FocusMode {
+		parts = append(parts, "focus mode")
+	}
 	if strings.TrimSpace(s.Readiness.Headline) != "" && s.Readiness.Level != workspaceReadinessReady {
 		parts = append(parts, strings.ToLower(s.Readiness.Headline))
 	}
@@ -287,6 +292,9 @@ func (s workspaceUIState) defaultStatusLine(scrollHint string) string {
 	}
 	if strings.TrimSpace(s.AwaySummary) != "" && s.UnreadCount > 0 {
 		return fmt.Sprintf(" While away │ %s │ %s │ /recover", truncateText(s.AwaySummary, 72), scrollHint)
+	}
+	if s.FocusMode && !s.Direct {
+		return fmt.Sprintf(" Focus mode live │ CEO routes work; specialists report back │ %s │ /focus", scrollHint)
 	}
 	if s.PrimaryTask != nil {
 		return fmt.Sprintf(" Focus │ %s │ %s │ /switcher │ /doctor", truncateText(s.PrimaryTask.Title, 72), scrollHint)

--- a/cmd/wuphf/channel_workspace_state_test.go
+++ b/cmd/wuphf/channel_workspace_state_test.go
@@ -98,3 +98,17 @@ func TestCurrentWorkspaceUIStatePromotesDoctorWarningsIntoReadiness(t *testing.T
 		t.Fatalf("expected doctor next step to flow into readiness, got %+v", state.Readiness)
 	}
 }
+
+func TestFocusModeStatusLineReflectsState(t *testing.T) {
+	m := newChannelModel(false)
+	m.brokerConnected = true
+	m.focusMode = true
+
+	status := m.currentWorkspaceUIState().defaultStatusLine("PgUp/PgDn scroll")
+	if !strings.Contains(status, "Focus mode live") {
+		t.Fatalf("expected focus mode status line, got %q", status)
+	}
+	if !strings.Contains(status, "/focus") {
+		t.Fatalf("expected focus command hint, got %q", status)
+	}
+}

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -29,6 +29,7 @@ func main() {
 	channelApp := flag.String("channel-app", "", "Start channel view on a specific app (internal)")
 	threadsCollapsed := flag.Bool("threads-collapsed", false, "Start with threads collapsed (default: expanded)")
 	unsafeMode := flag.Bool("unsafe", false, "Bypass all agent permission checks (use for local dev only)")
+	focusMode := flag.Bool("focus", false, "Route work through CEO and suppress cross-agent gossip for this run")
 	webMode := flag.Bool("web", false, "Launch web UI instead of tmux TUI")
 	webPort := flag.Int("web-port", 7891, "Port for the web UI (default 7891)")
 	noNex := flag.Bool("no-nex", false, "Disable Nex completely for this run")
@@ -119,15 +120,15 @@ func main() {
 
 	// Web mode: browser-based UI instead of tmux
 	if *webMode {
-		runWeb(args, *packFlag, *unsafeMode, *webPort)
+		runWeb(args, *packFlag, *unsafeMode, *focusMode, *webPort)
 		return
 	}
 
 	// Default: launch team or direct 1:1
-	runTeam(args, *packFlag, *unsafeMode, *oneOnOne)
+	runTeam(args, *packFlag, *unsafeMode, *focusMode, *oneOnOne)
 }
 
-func runTeam(args []string, packSlug string, unsafe bool, oneOnOne bool) {
+func runTeam(args []string, packSlug string, unsafe bool, focus bool, oneOnOne bool) {
 	l, err := team.NewLauncher(packSlug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -146,6 +147,9 @@ func runTeam(args []string, packSlug string, unsafe bool, oneOnOne bool) {
 		l.SetUnsafe(true)
 		fmt.Fprintf(os.Stderr, "\n\u26a0\ufe0f  UNSAFE MODE: All agents have unrestricted permissions.\n")
 		fmt.Fprintf(os.Stderr, "   This bypasses all tool approval prompts. Use for local dev only.\n\n")
+	}
+	if focus {
+		l.SetFocusMode(true)
 	}
 
 	if err := l.Preflight(); err != nil {
@@ -196,7 +200,7 @@ func runTeam(args []string, packSlug string, unsafe bool, oneOnOne bool) {
 	}
 }
 
-func runWeb(args []string, packSlug string, unsafe bool, webPort int) {
+func runWeb(args []string, packSlug string, unsafe bool, focus bool, webPort int) {
 	l, err := team.NewLauncher(packSlug)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
@@ -204,6 +208,9 @@ func runWeb(args []string, packSlug string, unsafe bool, webPort int) {
 	}
 	if unsafe {
 		l.SetUnsafe(true)
+	}
+	if focus {
+		l.SetFocusMode(true)
 	}
 	if err := l.PreflightWeb(); err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -47,6 +47,7 @@ type AgentLoop struct {
 	collectedInsights []string
 	taskLogRoot       string
 	lastCompactionAt  int
+	focusModeChecker  func() bool
 	mu                sync.Mutex
 }
 
@@ -144,6 +145,13 @@ func (l *AgentLoop) AddInsight(insight string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.collectedInsights = append(l.collectedInsights, insight)
+}
+
+// SetFocusModeChecker injects a callback that reports whether focus mode is active.
+func (l *AgentLoop) SetFocusModeChecker(checker func() bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.focusModeChecker = checker
 }
 
 // Tick advances the state machine by one step. Called by the service's tick loop.
@@ -248,7 +256,7 @@ func (l *AgentLoop) buildContext() error {
 	}
 
 	// Inject gossip insights if gossip layer is available.
-	if l.gossipLayer != nil {
+	if l.gossipLayer != nil && !l.focusModeEnabled() {
 		l.injectGossipInsights()
 	}
 
@@ -293,6 +301,13 @@ func (l *AgentLoop) injectGossipInsights() {
 		}
 		// "reject" is silently dropped.
 	}
+}
+
+func (l *AgentLoop) focusModeEnabled() bool {
+	if l.focusModeChecker == nil {
+		return false
+	}
+	return l.focusModeChecker()
 }
 
 // streamLLM streams output from the LLM and processes chunks.
@@ -498,7 +513,7 @@ func (l *AgentLoop) handleDone() error {
 	}
 
 	// Publish collected insights via gossip.
-	if l.gossipLayer != nil && len(l.collectedInsights) > 0 {
+	if l.gossipLayer != nil && len(l.collectedInsights) > 0 && !l.focusModeEnabled() {
 		for _, insight := range l.collectedInsights {
 			l.gossipLayer.Publish(slug, insight, "")
 		}

--- a/internal/agent/loop_test.go
+++ b/internal/agent/loop_test.go
@@ -2,11 +2,16 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/nex-crm/wuphf/internal/api"
 )
 
 // mockStreamFn returns a StreamFn that yields a single text chunk.
@@ -604,5 +609,41 @@ func TestOffRemovesHandler(t *testing.T) {
 
 	if callCount != 0 {
 		t.Errorf("handler should not have been called after Off, was called %d times", callCount)
+	}
+}
+
+func TestFocusModeSkipsGossipQueryAndPublish(t *testing.T) {
+	var searchCount, rememberCount int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/search":
+			searchCount++
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []map[string]any{}})
+		case "/remember":
+			rememberCount++
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	loop, _ := newTestLoop(t, mockStreamFn("done"))
+	client := api.NewClient("test-key")
+	client.BaseURL = srv.URL
+	loop.gossipLayer = NewGossipLayer(client)
+	loop.SetFocusModeChecker(func() bool { return true })
+	loop.AddInsight("share this")
+	loop.queues.FollowUp("test-agent", "do task")
+	loop.Start()
+
+	for i := 0; i < 4; i++ {
+		if err := loop.Tick(); err != nil {
+			t.Fatalf("tick %d: %v", i+1, err)
+		}
+	}
+
+	if searchCount != 0 || rememberCount != 0 {
+		t.Fatalf("expected focus mode to suppress gossip, got search=%d remember=%d", searchCount, rememberCount)
 	}
 }

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -39,6 +39,7 @@ type AgentService struct {
 	credTracker      *CredibilityTracker
 	client           *api.Client
 	streamFnResolver StreamFnResolver
+	focusModeChecker func() bool
 	listeners        []func()
 	tickTimers       map[string]chan struct{} // per-agent stop channels
 	mu               sync.Mutex
@@ -81,6 +82,12 @@ func WithCredibilityTracker(ct *CredibilityTracker) AgentServiceOption {
 // This is the integration point for provider selection (nex-ask, claude-code, gemini).
 func WithStreamFnResolver(r StreamFnResolver) AgentServiceOption {
 	return func(s *AgentService) { s.streamFnResolver = r }
+}
+
+// WithFocusModeChecker sets the callback used by agent loops to determine whether
+// cross-agent gossip should be suppressed for the current runtime.
+func WithFocusModeChecker(checker func() bool) AgentServiceOption {
+	return func(s *AgentService) { s.focusModeChecker = checker }
 }
 
 // defaultStreamFnResolver returns a StreamFn that emits a configuration error.
@@ -157,6 +164,7 @@ func (s *AgentService) Create(cfg AgentConfig) (*ManagedAgent, error) {
 	streamFn := s.streamFnResolver(cfg.Slug)
 
 	loop := NewAgentLoop(cfg, s.toolRegistry, s.sessionStore, s.queues, streamFn, s.gossipLayer, s.credTracker)
+	loop.SetFocusModeChecker(s.focusModeChecker)
 
 	ma := &ManagedAgent{
 		Config: cfg,

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -255,6 +255,7 @@ type brokerState struct {
 	Channels          []teamChannel                `json:"channels,omitempty"`
 	SessionMode       string                       `json:"session_mode,omitempty"`
 	OneOnOneAgent     string                       `json:"one_on_one_agent,omitempty"`
+	FocusMode         bool                         `json:"focus_mode,omitempty"`
 	Tasks             []teamTask                   `json:"tasks,omitempty"`
 	Requests          []humanInterview             `json:"requests,omitempty"`
 	Actions           []officeActionLog            `json:"actions,omitempty"`
@@ -296,6 +297,7 @@ type Broker struct {
 	channels           []teamChannel
 	sessionMode        string
 	oneOnOneAgent      string
+	focusMode          bool
 	tasks              []teamTask
 	requests           []humanInterview
 	actions            []officeActionLog
@@ -316,8 +318,8 @@ type Broker struct {
 	externalDelivered  map[string]struct{} // message IDs already queued for external delivery
 	mu                 sync.Mutex
 	server             *http.Server
-	token              string // shared secret for authenticating requests
-	addr               string // actual listen address (useful when port=0)
+	token              string   // shared secret for authenticating requests
+	addr               string   // actual listen address (useful when port=0)
 	webUIOrigins       []string // allowed CORS origins for web UI (set by ServeWebUI)
 }
 
@@ -424,6 +426,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", b.handleHealth) // no auth — used for liveness checks
 	mux.HandleFunc("/session-mode", b.requireAuth(b.handleSessionMode))
+	mux.HandleFunc("/focus-mode", b.requireAuth(b.handleFocusMode))
 	mux.HandleFunc("/messages", b.requireAuth(b.handleMessages))
 	mux.HandleFunc("/reactions", b.requireAuth(b.handleReactions))
 	mux.HandleFunc("/notifications/nex", b.requireAuth(b.handleNexNotifications))
@@ -898,6 +901,7 @@ func (b *Broker) loadState() error {
 	b.channels = state.Channels
 	b.sessionMode = state.SessionMode
 	b.oneOnOneAgent = state.OneOnOneAgent
+	b.focusMode = state.FocusMode
 	b.tasks = state.Tasks
 	b.requests = state.Requests
 	b.actions = state.Actions
@@ -927,7 +931,7 @@ func (b *Broker) loadState() error {
 
 func (b *Broker) saveLocked() error {
 	path := brokerStatePath()
-	if len(b.messages) == 0 && len(b.tasks) == 0 && len(activeRequests(b.requests)) == 0 && len(b.actions) == 0 && len(b.signals) == 0 && len(b.decisions) == 0 && len(b.watchdogs) == 0 && len(b.scheduler) == 0 && len(b.skills) == 0 && len(b.sharedMemory) == 0 && isDefaultChannelState(b.channels) && isDefaultOfficeMemberState(b.members) && b.counter == 0 && b.notificationSince == "" && b.insightsSince == "" && usageStateIsZero(b.usage) && b.sessionMode == SessionModeOffice && b.oneOnOneAgent == DefaultOneOnOneAgent {
+	if len(b.messages) == 0 && len(b.tasks) == 0 && len(activeRequests(b.requests)) == 0 && len(b.actions) == 0 && len(b.signals) == 0 && len(b.decisions) == 0 && len(b.watchdogs) == 0 && len(b.scheduler) == 0 && len(b.skills) == 0 && len(b.sharedMemory) == 0 && isDefaultChannelState(b.channels) && isDefaultOfficeMemberState(b.members) && b.counter == 0 && b.notificationSince == "" && b.insightsSince == "" && usageStateIsZero(b.usage) && b.sessionMode == SessionModeOffice && b.oneOnOneAgent == DefaultOneOnOneAgent && !b.focusMode {
 		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
@@ -942,6 +946,7 @@ func (b *Broker) saveLocked() error {
 		Channels:          b.channels,
 		SessionMode:       b.sessionMode,
 		OneOnOneAgent:     b.oneOnOneAgent,
+		FocusMode:         b.focusMode,
 		Tasks:             b.tasks,
 		Requests:          b.requests,
 		Actions:           b.actions,
@@ -1252,6 +1257,12 @@ func (b *Broker) SessionModeState() (string, string) {
 	return b.sessionMode, b.oneOnOneAgent
 }
 
+func (b *Broker) FocusModeEnabled() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.focusMode
+}
+
 func (b *Broker) SetSessionMode(mode, agent string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -1260,6 +1271,13 @@ func (b *Broker) SetSessionMode(mode, agent string) error {
 	if b.findMemberLocked(b.oneOnOneAgent) == nil {
 		b.oneOnOneAgent = DefaultOneOnOneAgent
 	}
+	return b.saveLocked()
+}
+
+func (b *Broker) SetFocusMode(enabled bool) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.focusMode = enabled
 	return b.saveLocked()
 }
 
@@ -2034,6 +2052,7 @@ func (b *Broker) handleHealth(w http.ResponseWriter, r *http.Request) {
 	b.mu.Lock()
 	mode := b.sessionMode
 	agent := b.oneOnOneAgent
+	focusMode := b.focusMode
 	b.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -2041,6 +2060,7 @@ func (b *Broker) handleHealth(w http.ResponseWriter, r *http.Request) {
 		"status":           "ok",
 		"session_mode":     mode,
 		"one_on_one_agent": agent,
+		"focus_mode":       focusMode,
 	})
 }
 
@@ -2071,6 +2091,34 @@ func (b *Broker) handleSessionMode(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"session_mode":     mode,
 			"one_on_one_agent": agent,
+		})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (b *Broker) handleFocusMode(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"focus_mode": b.FocusModeEnabled(),
+		})
+	case http.MethodPost:
+		var body struct {
+			Enabled bool `json:"enabled"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "invalid json", http.StatusBadRequest)
+			return
+		}
+		if err := b.SetFocusMode(body.Enabled); err != nil {
+			http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"focus_mode": body.Enabled,
 		})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -93,6 +93,42 @@ func TestBrokerSessionModePersistsAndSurvivesReset(t *testing.T) {
 	}
 }
 
+func TestBrokerFocusModePersistsAndHealthReportsIt(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	if err := b.SetFocusMode(true); err != nil {
+		t.Fatalf("SetFocusMode failed: %v", err)
+	}
+
+	reloaded := NewBroker()
+	if !reloaded.FocusModeEnabled() {
+		t.Fatal("expected focus mode to persist across broker reload")
+	}
+	if err := reloaded.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer reloaded.Stop()
+
+	resp, err := http.Get("http://" + reloaded.Addr() + "/health")
+	if err != nil {
+		t.Fatalf("health request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	var health struct {
+		FocusMode bool `json:"focus_mode"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
+		t.Fatalf("decode health: %v", err)
+	}
+	if !health.FocusMode {
+		t.Fatal("expected /health to report focus_mode=true")
+	}
+}
+
 func TestBrokerMessageKindAndTitleRoundTrip(t *testing.T) {
 	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
@@ -465,6 +501,7 @@ func TestBrokerAuthRejectsUnauthenticated(t *testing.T) {
 	var health struct {
 		SessionMode   string `json:"session_mode"`
 		OneOnOneAgent string `json:"one_on_one_agent"`
+		FocusMode     bool   `json:"focus_mode"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
 		resp.Body.Close()
@@ -476,6 +513,9 @@ func TestBrokerAuthRejectsUnauthenticated(t *testing.T) {
 	}
 	if health.OneOnOneAgent != DefaultOneOnOneAgent {
 		t.Fatalf("expected health to report default 1o1 agent %q, got %q", DefaultOneOnOneAgent, health.OneOnOneAgent)
+	}
+	if health.FocusMode {
+		t.Fatal("expected health to report focus mode disabled by default")
 	}
 
 	// Messages without auth should be rejected

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -49,6 +49,9 @@ func (l *Launcher) launchHeadlessCodex() error {
 	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
 		return fmt.Errorf("set session mode: %w", err)
 	}
+	if err := l.broker.SetFocusMode(l.focusMode); err != nil {
+		return fmt.Errorf("set focus mode: %w", err)
+	}
 	if err := l.broker.Start(); err != nil {
 		return fmt.Errorf("start broker: %w", err)
 	}
@@ -250,6 +253,9 @@ func (l *Launcher) buildHeadlessCodexEnv(slug string) []string {
 		"WUPHF_BROKER_TOKEN="+l.broker.Token(),
 		"WUPHF_HEADLESS_PROVIDER=codex",
 	)
+	if l.isFocusModeEnabled() {
+		env = append(env, "WUPHF_FOCUS_MODE=1")
+	}
 	if config.ResolveNoNex() {
 		env = append(env, "WUPHF_NO_NEX=1")
 	}
@@ -285,6 +291,9 @@ func (l *Launcher) buildCodexOfficeConfigOverrides(slug string) ([]string, error
 	wuphfEnvVars := []string{
 		"WUPHF_AGENT_SLUG",
 		"WUPHF_BROKER_TOKEN",
+	}
+	if l.isFocusModeEnabled() {
+		wuphfEnvVars = append(wuphfEnvVars, "WUPHF_FOCUS_MODE")
 	}
 	if config.ResolveNoNex() {
 		wuphfEnvVars = append(wuphfEnvVars, "WUPHF_NO_NEX")

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -53,6 +53,7 @@ func TestBuildCodexOfficeConfigOverridesIncludesOfficeMCPEnv(t *testing.T) {
 		headlessCodexLookPath = oldLookPath
 	}()
 
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("WUPHF_NO_NEX", "1")
 
 	broker := NewBroker()

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -98,6 +98,7 @@ type Launcher struct {
 	unsafe      bool
 	sessionMode string
 	oneOnOne    string
+	focusMode   bool
 	provider    string
 
 	headlessMu      sync.Mutex
@@ -106,11 +107,14 @@ type Launcher struct {
 	headlessWorkers map[string]bool
 	headlessActive  map[string]*headlessCodexActiveTurn
 	headlessQueues  map[string][]headlessCodexTurn
-	webMode bool
+	webMode         bool
 }
 
 // SetUnsafe enables unrestricted permissions for all agents (CLI-only flag).
 func (l *Launcher) SetUnsafe(v bool) { l.unsafe = v }
+
+// SetFocusMode enables CEO-routed focus mode for a run.
+func (l *Launcher) SetFocusMode(v bool) { l.focusMode = v }
 
 func (l *Launcher) SetOneOnOne(slug string) {
 	l.sessionMode = SessionModeOneOnOne
@@ -137,6 +141,7 @@ func NewLauncher(packSlug string) (*Launcher, error) {
 		return nil, err
 	}
 	sessionMode, oneOnOne := loadRunningSessionMode()
+	focusMode := loadRunningFocusMode()
 
 	return &Launcher{
 		packSlug:        packSlug,
@@ -145,6 +150,7 @@ func NewLauncher(packSlug string) (*Launcher, error) {
 		cwd:             cwd,
 		sessionMode:     sessionMode,
 		oneOnOne:        oneOnOne,
+		focusMode:       focusMode,
 		provider:        config.ResolveLLMProvider(""),
 		headlessWorkers: make(map[string]bool),
 		headlessActive:  make(map[string]*headlessCodexActiveTurn),
@@ -190,6 +196,9 @@ func (l *Launcher) Launch() error {
 	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
 		return fmt.Errorf("set session mode: %w", err)
 	}
+	if err := l.broker.SetFocusMode(l.focusMode); err != nil {
+		return fmt.Errorf("set focus mode: %w", err)
+	}
 	if err := l.broker.Start(); err != nil {
 		return fmt.Errorf("start broker: %w", err)
 	}
@@ -207,6 +216,9 @@ func (l *Launcher) Launch() error {
 	// Pass broker token via env so channel view + agents can authenticate
 	channelEnv := []string{
 		fmt.Sprintf("WUPHF_BROKER_TOKEN=%s", l.broker.Token()),
+	}
+	if l.focusMode {
+		channelEnv = append(channelEnv, "WUPHF_FOCUS_MODE=1")
 	}
 	if l.isOneOnOne() {
 		channelEnv = append(channelEnv,
@@ -676,6 +688,13 @@ func (l *Launcher) taskNotificationContent(action officeActionLog, task teamTask
 	if path := strings.TrimSpace(task.WorktreePath); path != "" {
 		guidance = fmt.Sprintf(" If you own this task, use working_directory=%q for local file and bash tools.", path)
 	}
+	if l.isFocusModeEnabled() {
+		if strings.TrimSpace(task.Owner) == l.officeLeadSlug() {
+			guidance += " Focus mode is enabled. You are the routing hub: decide whether to delegate further or present the result to the human."
+		} else {
+			guidance += " Focus mode is enabled. Work directly, do not fan out to peers, and report completion or blockers back to @ceo."
+		}
+	}
 	return fmt.Sprintf("[%s #%s on #%s]: %s%s (owner %s, status %s%s%s%s%s). Before you speak, call team_poll and team_tasks, confirm whether you own this work, and stay in your lane.%s", verb, task.ID, channel, task.Title, details, owner, status, pipeline, review, execMode, worktree, guidance)
 }
 
@@ -774,6 +793,37 @@ func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate 
 			return false
 		}
 		return inferAgentDomain(slug) == domain
+	}
+
+	if l.isFocusModeEnabled() {
+		switch {
+		case msg.From == "you" || msg.From == "human" || msg.Kind == "automation" || msg.From == "nex":
+			addImmediate(lead)
+			for _, slug := range slugs {
+				if slug == lead || slug == msg.From {
+					continue
+				}
+				if containsSlug(msg.Tagged, slug) && allowTarget(slug) {
+					addImmediate(slug)
+				}
+			}
+		case msg.From == lead:
+			for _, slug := range slugs {
+				if slug == lead || slug == msg.From {
+					continue
+				}
+				if containsSlug(msg.Tagged, slug) && allowTarget(slug) {
+					addImmediate(slug)
+					continue
+				}
+				if owner != "" && slug == owner && allowTarget(slug) {
+					addImmediate(slug)
+				}
+			}
+		default:
+			addImmediate(lead)
+		}
+		return immediate, nil
 	}
 
 	switch {
@@ -2106,7 +2156,13 @@ func (l *Launcher) sendChannelUpdate(paneTarget, slug, channel, msgID, from, con
 			)
 		}
 	}
-
+	if l.isFocusModeEnabled() && !l.isOneOnOne() {
+		if slug == l.officeLeadSlug() {
+			notification += "\nFocus mode is enabled. You are the routing hub: specialists should report back to you, and you should delegate intentionally."
+		} else {
+			notification += "\nFocus mode is enabled. Do not chatter with peers or wake other agents. Work the request directly and report completion or blockers back to @ceo."
+		}
+	}
 	if l.usesCodexRuntime() {
 		l.enqueueHeadlessCodexTurn(slug, notification)
 		return
@@ -2454,6 +2510,14 @@ func (l *Launcher) buildPrompt(slug string) string {
 		}
 		sb.WriteString("Tag agents with @slug in your message (e.g., '@fe can you handle this?').\n")
 		sb.WriteString("Tagged agents are expected to respond.\n\n")
+		if l.isFocusModeEnabled() {
+			sb.WriteString("== FOCUS MODE ==\n")
+			sb.WriteString("Focus mode is enabled. You are the routing hub between specialists.\n")
+			sb.WriteString("- Default to taking human requests yourself first.\n")
+			sb.WriteString("- Delegate to a specialist only when you intentionally want that handoff.\n")
+			sb.WriteString("- Specialists should report completion, blockers, and handoff notes back to you, not to each other.\n")
+			sb.WriteString("- Keep the office out of cross-agent chatter.\n\n")
+		}
 		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
 		sb.WriteString("YOUR ROLE AS LEADER:\n")
 		if config.ResolveNoNex() {
@@ -2520,6 +2584,14 @@ func (l *Launcher) buildPrompt(slug string) string {
 			sb.WriteString("Use the Nex context graph for durable memory:\n")
 			sb.WriteString("- query_context: Check prior decisions, customer context, company history, or facts before making assumptions\n")
 			sb.WriteString("- add_context: Store durable conclusions or findings once the team actually lands them\n\n")
+		}
+		if l.isFocusModeEnabled() {
+			sb.WriteString("== FOCUS MODE ==\n")
+			sb.WriteString("Focus mode is enabled.\n")
+			sb.WriteString("- You take work directly from the human only when they explicitly tag you, or from @ceo when delegated.\n")
+			sb.WriteString("- Do not debate with other specialists in the channel.\n")
+			sb.WriteString("- Do the work, then report completion, blockers, or handoff notes back to @ceo.\n")
+			sb.WriteString("- If another specialist should get involved, tell @ceo instead of routing it yourself.\n\n")
 		}
 		sb.WriteString("Tag agents with @slug. Tagged agents must respond.\n")
 		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
@@ -2779,6 +2851,35 @@ func loadRunningSessionMode() (string, string) {
 	return NormalizeSessionMode(result.SessionMode), NormalizeOneOnOneAgent(result.OneOnOneAgent)
 }
 
+func loadRunningFocusMode() bool {
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Get(brokerBaseURL() + "/health")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+	var result struct {
+		FocusMode bool `json:"focus_mode"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return false
+	}
+	return result.FocusMode
+}
+
+func (l *Launcher) isFocusModeEnabled() bool {
+	if l != nil && l.broker != nil {
+		return l.broker.FocusModeEnabled()
+	}
+	if l == nil {
+		return false
+	}
+	return l.focusMode
+}
+
 func brokerBaseURL() string {
 	if base := strings.TrimSpace(os.Getenv("WUPHF_BROKER_BASE_URL")); base != "" {
 		return strings.TrimRight(base, "/")
@@ -2898,6 +2999,12 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	killStaleBroker()
 
 	l.broker = NewBroker()
+	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
+		return fmt.Errorf("set session mode: %w", err)
+	}
+	if err := l.broker.SetFocusMode(l.focusMode); err != nil {
+		return fmt.Errorf("set focus mode: %w", err)
+	}
 	if err := l.broker.Start(); err != nil {
 		return fmt.Errorf("start broker: %w", err)
 	}

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -192,6 +192,64 @@ func TestNotificationTargetsForMessageOneOnOneWakesSelectedAgent(t *testing.T) {
 	}
 }
 
+func TestNotificationTargetsForHumanMessageInFocusModeOnlyWakeCEOAndTaggedSpecialist(t *testing.T) {
+	l := &Launcher{
+		sessionName: "focus-office",
+		focusMode:   true,
+		broker: &Broker{
+			members: []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "pm", Name: "Product Manager"},
+				{Slug: "fe", Name: "Frontend Engineer"},
+			},
+		},
+	}
+
+	immediate, delayed := l.notificationTargetsForMessage(channelMessage{
+		From:    "you",
+		Channel: "general",
+		Content: "Need a product breakdown. @pm please take first pass.",
+		Tagged:  []string{"pm"},
+	})
+
+	if len(delayed) != 0 {
+		t.Fatalf("expected no delayed targets in focus mode, got %v", delayed)
+	}
+	if len(immediate) != 2 {
+		t.Fatalf("expected CEO and tagged specialist, got %v", immediate)
+	}
+	if immediate[0].Slug != "ceo" || immediate[1].Slug != "pm" {
+		t.Fatalf("expected CEO then PM, got %v", immediate)
+	}
+}
+
+func TestNotificationTargetsForAgentMessageInFocusModeOnlyWakeCEO(t *testing.T) {
+	l := &Launcher{
+		sessionName: "focus-office",
+		focusMode:   true,
+		broker: &Broker{
+			members: []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "pm", Name: "Product Manager"},
+				{Slug: "fe", Name: "Frontend Engineer"},
+			},
+		},
+	}
+
+	immediate, delayed := l.notificationTargetsForMessage(channelMessage{
+		From:    "fe",
+		Channel: "general",
+		Content: "Implementation is done. Ready for review.",
+	})
+
+	if len(delayed) != 0 {
+		t.Fatalf("expected no delayed targets in focus mode, got %v", delayed)
+	}
+	if len(immediate) != 1 || immediate[0].Slug != "ceo" {
+		t.Fatalf("expected only CEO to be notified, got %v", immediate)
+	}
+}
+
 func TestLoadRunningSessionModePrefersLiveBrokerState(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
@@ -213,6 +271,72 @@ func TestLoadRunningSessionModePrefersLiveBrokerState(t *testing.T) {
 	}
 	if agent != "pm" {
 		t.Fatalf("expected live 1o1 agent pm, got %q", agent)
+	}
+}
+
+func TestLoadRunningFocusModeUsesLiveHealth(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"focus_mode": true,
+		})
+	}))
+	defer server.Close()
+
+	t.Setenv("WUPHF_BROKER_BASE_URL", server.URL)
+
+	if !loadRunningFocusMode() {
+		t.Fatal("expected focus mode to load from live broker health")
+	}
+}
+
+func TestTaskNotificationContentIncludesFocusModeGuidance(t *testing.T) {
+	b := NewBroker()
+	if err := b.SetFocusMode(true); err != nil {
+		t.Fatalf("SetFocusMode: %v", err)
+	}
+	b.members = []officeMember{{Slug: "ceo", Name: "CEO"}}
+	l := &Launcher{
+		focusMode: true,
+		broker:    b,
+	}
+
+	content := l.taskNotificationContent(officeActionLog{Kind: "task_updated"}, teamTask{
+		ID:      "task-1",
+		Title:   "Ship focus mode",
+		Owner:   "pm",
+		Status:  "in_progress",
+		Channel: "general",
+	})
+
+	if !strings.Contains(content, "Focus mode is enabled.") {
+		t.Fatalf("expected focus mode guidance in task notification, got %q", content)
+	}
+	if !strings.Contains(content, "report completion or blockers back to @ceo") {
+		t.Fatalf("expected CEO routing guidance, got %q", content)
+	}
+}
+
+func TestBuildPromptIncludesFocusModeRules(t *testing.T) {
+	l := &Launcher{
+		focusMode: true,
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Name:     "Founding Team",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO", Personality: "Lead", Expertise: []string{"delegation"}},
+				{Slug: "pm", Name: "Product Manager", Personality: "Ship", Expertise: []string{"product"}},
+			},
+		},
+	}
+
+	ceoPrompt := l.buildPrompt("ceo")
+	if !strings.Contains(ceoPrompt, "== FOCUS MODE ==") || !strings.Contains(ceoPrompt, "routing hub") {
+		t.Fatalf("expected CEO prompt to include focus mode routing rules, got %q", ceoPrompt)
+	}
+
+	pmPrompt := l.buildPrompt("pm")
+	if !strings.Contains(pmPrompt, "Do not debate with other specialists") || !strings.Contains(pmPrompt, "report completion, blockers, or handoff notes back to @ceo") {
+		t.Fatalf("expected specialist prompt to include focus mode delegation rules, got %q", pmPrompt)
 	}
 }
 

--- a/internal/team/runtime_state_test.go
+++ b/internal/team/runtime_state_test.go
@@ -50,6 +50,7 @@ func TestDetectRuntimeCapabilities(t *testing.T) {
 	}
 	actionProvidersFn = func() []action.Provider { return nil }
 
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("TMUX", "/tmp/tmux-1000/default,123,0")
 	t.Setenv("WUPHF_NO_NEX", "1")
 
@@ -121,6 +122,7 @@ func TestDetectRuntimeCapabilitiesWhenTmuxServerIsMissing(t *testing.T) {
 	}
 	actionProvidersFn = func() []action.Provider { return nil }
 
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("WUPHF_NO_NEX", "1")
 
 	got := DetectRuntimeCapabilities()

--- a/internal/tui/runtime.go
+++ b/internal/tui/runtime.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -44,6 +45,10 @@ func (rt *Runtime) BootstrapFromConfig() {
 	agentSvc := agent.NewAgentService(
 		agent.WithStreamFnResolver(streamResolver),
 		agent.WithClient(apiClient),
+		agent.WithFocusModeChecker(func() bool {
+			value := strings.TrimSpace(os.Getenv("WUPHF_FOCUS_MODE"))
+			return strings.EqualFold(value, "1") || strings.EqualFold(value, "true")
+		}),
 	)
 	msgRouter := orchestration.NewMessageRouter()
 


### PR DESCRIPTION
## What changed
- added persistent broker-backed focus mode with `--focus`, `/focus`, and live health/status propagation in the TUI
- tightened launcher notification routing so human work and specialist handoffs flow through the CEO during focus mode
- updated agent prompts, task notifications, and headless Codex env/config wiring to explain the CEO-routed delegation model
- suppressed gossip-layer query/publish behavior in the agent loop when focus mode is active
- added focused coverage for broker state, launcher routing, channel UX, and loop gossip suppression

## Why
WUPHF already had rich office chatter, but it lacked a deliberate “heads down” operating mode where specialists stop cross-talking and route work back through the CEO. That made explicit delegation handoffs noisy and harder to supervise.

## Impact
Operators can start or toggle focus mode and get a tighter execution model: specialists take work from the human only when directly tagged or from the CEO when delegated, then report back to the CEO instead of fanning out into more channel chatter.

## Validation
- `go test ./...`
