### PR TITLE
Improve review and resume UX for retained work

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -3573,14 +3573,21 @@ func (m channelModel) buildTaskPickerOptions() []tui.PickerOption {
 }
 
 func (m channelModel) buildTaskActionPickerOptions(task channelTask) []tui.PickerOption {
+	claimLabel := "Claim task"
+	claimDescription := "Take ownership as you"
+	if strings.TrimSpace(task.WorktreePath) != "" || strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") {
+		claimLabel = "Resume task"
+		claimDescription = "Take ownership and continue the retained worktree-backed run"
+	}
+
 	options := []tui.PickerOption{
-		{Label: "Claim task", Value: "claim:" + task.ID, Description: "Take ownership as you"},
+		{Label: claimLabel, Value: "claim:" + task.ID, Description: claimDescription},
 		{Label: "Release task", Value: "release:" + task.ID, Description: "Clear the current owner"},
 	}
 	if task.ReviewState == "ready_for_review" || task.Status == "review" {
-		options = append(options, tui.PickerOption{Label: "Approve task", Value: "approve:" + task.ID, Description: "Mark this review-ready task done"})
+		options = append(options, tui.PickerOption{Label: "Review and approve", Value: "approve:" + task.ID, Description: "Mark this review-ready task done"})
 	} else if task.ReviewState == "pending_review" || task.ExecutionMode == "local_worktree" {
-		options = append(options, tui.PickerOption{Label: "Ready for review", Value: "complete:" + task.ID, Description: "Move this task into review"})
+		options = append(options, tui.PickerOption{Label: "Hand off for review", Value: "complete:" + task.ID, Description: "Move this retained task into review"})
 	} else {
 		options = append(options, tui.PickerOption{Label: "Complete task", Value: "complete:" + task.ID, Description: "Mark this task done"})
 	}
@@ -3588,7 +3595,11 @@ func (m channelModel) buildTaskActionPickerOptions(task channelTask) []tui.Picke
 		options = append(options, tui.PickerOption{Label: "Block task", Value: "block:" + task.ID, Description: "Mark this work blocked"})
 	}
 	if task.ThreadID != "" {
-		options = append(options, tui.PickerOption{Label: "Open thread", Value: "open:" + task.ID, Description: "Jump to the thread for this task"})
+		description := "Jump to the thread for this task"
+		if strings.TrimSpace(task.WorktreePath) != "" {
+			description = "Jump to the handoff thread before resuming"
+		}
+		options = append(options, tui.PickerOption{Label: "Open thread", Value: "open:" + task.ID, Description: description})
 	}
 	return options
 }

--- a/cmd/wuphf/channel_artifact_snapshot.go
+++ b/cmd/wuphf/channel_artifact_snapshot.go
@@ -87,6 +87,97 @@ func (s runtimeArtifactSnapshot) Filter(kinds ...team.RuntimeArtifactKind) []tea
 	return out
 }
 
+func (s runtimeArtifactSnapshot) ReviewCandidates(limit int) []team.RuntimeArtifact {
+	return prioritizeArtifacts(s.Items, limit, artifactReviewRank)
+}
+
+func (s runtimeArtifactSnapshot) ResumeCandidates(limit int) []team.RuntimeArtifact {
+	return prioritizeArtifacts(s.Items, limit, artifactResumeRank)
+}
+
+type artifactRankFn func(team.RuntimeArtifact) (int, bool)
+
+func prioritizeArtifacts(items []team.RuntimeArtifact, limit int, rankFn artifactRankFn) []team.RuntimeArtifact {
+	type rankedArtifact struct {
+		artifact team.RuntimeArtifact
+		rank     int
+		updated  time.Time
+	}
+	ranked := make([]rankedArtifact, 0, len(items))
+	for _, artifact := range items {
+		rank, ok := rankFn(artifact)
+		if !ok {
+			continue
+		}
+		ranked = append(ranked, rankedArtifact{
+			artifact: artifact,
+			rank:     rank,
+			updated:  parseArtifactTimestamp(artifact.UpdatedAt, artifact.StartedAt),
+		})
+	}
+	sort.SliceStable(ranked, func(i, j int) bool {
+		if ranked[i].rank != ranked[j].rank {
+			return ranked[i].rank < ranked[j].rank
+		}
+		left, right := ranked[i].updated, ranked[j].updated
+		switch {
+		case !left.IsZero() && !right.IsZero():
+			return left.After(right)
+		case !left.IsZero():
+			return true
+		case !right.IsZero():
+			return false
+		default:
+			return ranked[i].artifact.ID > ranked[j].artifact.ID
+		}
+	})
+	if limit > 0 && len(ranked) > limit {
+		ranked = ranked[:limit]
+	}
+	out := make([]team.RuntimeArtifact, 0, len(ranked))
+	for _, item := range ranked {
+		out = append(out, item.artifact)
+	}
+	return out
+}
+
+func artifactReviewRank(artifact team.RuntimeArtifact) (int, bool) {
+	if !artifact.Reviewable() {
+		return 0, false
+	}
+	switch artifact.Kind {
+	case team.RuntimeArtifactRequest:
+		if artifact.Blocking {
+			return 0, true
+		}
+		return 1, true
+	case team.RuntimeArtifactTask:
+		if artifact.NormalizedState() == "review" {
+			return 2, true
+		}
+		return 3, true
+	default:
+		return 0, false
+	}
+}
+
+func artifactResumeRank(artifact team.RuntimeArtifact) (int, bool) {
+	if !artifact.Resumable() {
+		return 0, false
+	}
+	state := artifact.NormalizedState()
+	switch {
+	case state == "blocked" && strings.TrimSpace(artifact.Worktree) != "":
+		return 0, true
+	case strings.TrimSpace(artifact.Worktree) != "":
+		return 1, true
+	case strings.TrimSpace(artifact.RelatedID) != "":
+		return 2, true
+	default:
+		return 3, true
+	}
+}
+
 func recentArtifactTasks(tasks []channelTask, limit int) []channelTask {
 	filtered := make([]channelTask, 0, len(tasks))
 	for _, task := range tasks {
@@ -139,6 +230,7 @@ func buildTaskRuntimeArtifact(task channelTask, logArtifact taskLogArtifact, has
 		UpdatedAt:     updatedAt,
 		Path:          path,
 		Worktree:      strings.TrimSpace(task.WorktreePath),
+		Branch:        strings.TrimSpace(task.WorktreeBranch),
 		PartialOutput: partialOutput,
 		ResumeHint:    buildTaskArtifactResumeHint(task, state),
 		ReviewHint:    reviewHint,
@@ -291,14 +383,19 @@ func buildTaskArtifactReviewHint(task channelTask, logArtifact taskLogArtifact, 
 }
 
 func buildTaskArtifactResumeHint(task channelTask, state string) string {
+	branch := strings.TrimSpace(task.WorktreeBranch)
 	if worktree := strings.TrimSpace(task.WorktreePath); worktree != "" {
+		target := worktree
+		if branch != "" {
+			target += " on " + branch
+		}
 		switch state {
 		case "completed":
-			return "Review the retained output or reopen the task thread before reusing the worktree."
+			return "Review the retained output or reopen the task thread before reusing " + target + "."
 		case "blocked":
-			return "Resolve the blocker, then continue in " + worktree + " or reopen the task thread."
+			return "Resolve the blocker, then continue in " + target + " or reopen the task thread."
 		default:
-			return "Resume in " + worktree + " or reopen the task thread."
+			return "Resume in " + target + " or reopen the task thread."
 		}
 	}
 	if thread := strings.TrimSpace(task.ThreadID); thread != "" {

--- a/cmd/wuphf/channel_artifacts.go
+++ b/cmd/wuphf/channel_artifacts.go
@@ -68,6 +68,9 @@ func (m channelModel) buildArtifactLines(contentWidth int) []renderedLine {
 		)
 	}
 
+	if priority := buildArtifactPriorityLines(contentWidth, snapshot); len(priority) > 0 {
+		lines = append(lines, priority...)
+	}
 	lines = append(lines, renderArtifactSection(contentWidth, "Task execution", snapshot.Filter(team.RuntimeArtifactTask, team.RuntimeArtifactTaskLog))...)
 	lines = append(lines, renderArtifactSection(contentWidth, "Workflow runs", snapshot.Filter(team.RuntimeArtifactWorkflowRun))...)
 	lines = append(lines, renderArtifactSection(contentWidth, "Requests and approvals", snapshot.Filter(team.RuntimeArtifactRequest))...)
@@ -94,8 +97,102 @@ func (m channelModel) currentArtifactSummary() string {
 	return strings.Join(parts, " · ")
 }
 
+func (m channelModel) currentArtifactFocusSummary() string {
+	snapshot := m.currentArtifactSnapshot(24)
+	if review := snapshot.ReviewCandidates(1); len(review) > 0 {
+		if resume := snapshot.ResumeCandidates(1); len(resume) > 0 {
+			return truncateText("Review "+review[0].EffectiveTitle()+" · Resume "+resume[0].EffectiveTitle(), 96)
+		}
+		return truncateText("Review "+review[0].EffectiveTitle(), 96)
+	}
+	if resume := snapshot.ResumeCandidates(1); len(resume) > 0 {
+		return truncateText("Resume "+resume[0].EffectiveTitle(), 96)
+	}
+	return ""
+}
+
 func (m channelModel) currentRuntimeArtifacts(limit int) []team.RuntimeArtifact {
 	return m.currentArtifactSnapshot(limit).Items
+}
+
+func buildArtifactPriorityLines(contentWidth int, snapshot runtimeArtifactSnapshot) []renderedLine {
+	lines := []renderedLine{}
+	if review := snapshot.ReviewCandidates(2); len(review) > 0 {
+		lines = append(lines, renderArtifactFocusSection(contentWidth, "Review next", "#B45309", review, true)...)
+	}
+	if resume := snapshot.ResumeCandidates(2); len(resume) > 0 {
+		lines = append(lines, renderArtifactFocusSection(contentWidth, "Resume next", "#2563EB", resume, false)...)
+	}
+	return lines
+}
+
+func renderArtifactFocusSection(contentWidth int, title, accent string, artifacts []team.RuntimeArtifact, review bool) []renderedLine {
+	if len(artifacts) == 0 {
+		return nil
+	}
+	lines := []renderedLine{{Text: ""}, {Text: renderDateSeparator(contentWidth, title)}}
+	for _, artifact := range artifacts {
+		body := artifactReviewSummary(artifact)
+		if !review {
+			body = artifactResumeSummary(artifact)
+		}
+		extra := []string{}
+		if progress := strings.TrimSpace(artifact.EffectiveProgress()); progress != "" && !strings.EqualFold(progress, body) {
+			extra = append(extra, "Progress: "+progress)
+		}
+		if review && strings.TrimSpace(artifact.ReviewHint) != "" {
+			extra = append(extra, "Review: "+artifact.ReviewHint)
+		}
+		if !review && strings.TrimSpace(artifact.ResumeHint) != "" {
+			extra = append(extra, "Resume: "+artifact.ResumeHint)
+		}
+		if taskID, requestID, threadID := artifactNavigationTargets(artifact); taskID != "" || requestID != "" || threadID != "" {
+			extra = append(extra, artifactInteractionCTA(artifact, review))
+			card := renderRecoveryActionCard(contentWidth, subtlePill(strings.ToLower(title), "#F8FAFC", accent)+" "+lipgloss.NewStyle().Bold(true).Render(artifact.EffectiveTitle()), body, accent, extra)
+			lines = append(lines, prefixedCardLines(renderedCardLines(card, taskID, requestID, threadID, ""), "  ")...)
+			continue
+		}
+		header := subtlePill(strings.ToLower(title), "#F8FAFC", accent) + " " + lipgloss.NewStyle().Bold(true).Render(artifact.EffectiveTitle())
+		for _, line := range renderRuntimeEventCard(contentWidth, header, body, accent, extra) {
+			lines = append(lines, renderedLine{Text: "  " + line})
+		}
+	}
+	return lines
+}
+
+func artifactReviewSummary(artifact team.RuntimeArtifact) string {
+	switch artifact.Kind {
+	case team.RuntimeArtifactRequest:
+		return "Human decision waiting: " + artifact.EffectiveSummary()
+	default:
+		return fallbackString(strings.TrimSpace(artifact.EffectiveSummary()), "Review this retained work before moving it forward.")
+	}
+}
+
+func artifactResumeSummary(artifact team.RuntimeArtifact) string {
+	switch {
+	case strings.TrimSpace(artifact.Worktree) != "":
+		summary := "Resume from worktree " + artifact.Worktree
+		if branch := strings.TrimSpace(artifact.Branch); branch != "" {
+			summary += " on " + branch
+		}
+		return summary
+	case strings.TrimSpace(artifact.RelatedID) != "":
+		return "Resume from thread " + artifact.RelatedID
+	default:
+		return fallbackString(strings.TrimSpace(artifact.ResumeHint), "Resume this retained work.")
+	}
+}
+
+func artifactNavigationTargets(artifact team.RuntimeArtifact) (taskID, requestID, threadID string) {
+	switch artifact.Kind {
+	case team.RuntimeArtifactTask:
+		taskID = strings.TrimSpace(artifact.ID)
+	case team.RuntimeArtifactRequest:
+		requestID = strings.TrimSpace(artifact.ID)
+	}
+	threadID = strings.TrimSpace(artifact.RelatedID)
+	return taskID, requestID, threadID
 }
 
 func renderArtifactSection(contentWidth int, title string, artifacts []team.RuntimeArtifact) []renderedLine {
@@ -156,6 +253,9 @@ func artifactExtraLines(artifact team.RuntimeArtifact) []string {
 	if strings.TrimSpace(artifact.Worktree) != "" {
 		extra = append(extra, "Worktree: "+artifact.Worktree)
 	}
+	if strings.TrimSpace(artifact.Branch) != "" {
+		extra = append(extra, "Branch: "+artifact.Branch)
+	}
 	if strings.TrimSpace(artifact.Path) != "" {
 		extra = append(extra, "Path: "+artifact.Path)
 	}
@@ -166,12 +266,32 @@ func artifactExtraLines(artifact team.RuntimeArtifact) []string {
 		extra = append(extra, "Blocking")
 	}
 	if strings.TrimSpace(artifact.ReviewHint) != "" {
-		extra = append(extra, artifact.ReviewHint)
+		extra = append(extra, "Review: "+artifact.ReviewHint)
 	}
 	if strings.TrimSpace(artifact.ResumeHint) != "" {
-		extra = append(extra, artifact.ResumeHint)
+		extra = append(extra, "Resume: "+artifact.ResumeHint)
+	}
+	if cta := artifactInteractionCTA(artifact, artifact.Reviewable()); cta != "" {
+		extra = append(extra, cta)
 	}
 	return extra
+}
+
+func artifactInteractionCTA(artifact team.RuntimeArtifact, review bool) string {
+	switch artifact.Kind {
+	case team.RuntimeArtifactTask:
+		if review {
+			return "Click to open task actions and review context."
+		}
+		return "Click to open task actions and resume context."
+	case team.RuntimeArtifactRequest:
+		if review {
+			return "Click to reopen the decision and answer it."
+		}
+		return "Click to reopen the request context."
+	default:
+		return ""
+	}
 }
 
 func artifactLifecyclePill(state, runningColor, pendingColor, failedColor, completedColor string) string {

--- a/cmd/wuphf/channel_artifacts_test.go
+++ b/cmd/wuphf/channel_artifacts_test.go
@@ -64,7 +64,7 @@ func TestBuildArtifactLinesShowsTaskLogsWorkflowRunsAndApprovals(t *testing.T) {
 	writeWorkflowRun(t, home, "one", "launch-sync", `{"provider":"one","workflow_key":"launch-sync","run_id":"run-2","status":"success","started_at":"2026-04-07T10:02:00Z","finished_at":"2026-04-07T10:03:00Z"}`)
 
 	m := newChannelModel(false)
-	m.tasks = []channelTask{{ID: "task-1", Title: "Ship launch notes", WorktreePath: "/tmp/wuphf-task-1"}}
+	m.tasks = []channelTask{{ID: "task-1", Title: "Ship launch notes", WorktreePath: "/tmp/wuphf-task-1", WorktreeBranch: "codex/task-1"}}
 	m.requests = []channelInterview{{
 		ID:            "req-1",
 		Kind:          "approval",
@@ -92,6 +92,12 @@ func TestBuildArtifactLinesShowsTaskLogsWorkflowRunsAndApprovals(t *testing.T) {
 	if !strings.Contains(plain, "Task execution") {
 		t.Fatalf("expected task execution section, got %q", plain)
 	}
+	if !strings.Contains(plain, "Review next") {
+		t.Fatalf("expected review-next section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Resume next") {
+		t.Fatalf("expected resume-next section, got %q", plain)
+	}
 	if !strings.Contains(plain, "Workflow runs") {
 		t.Fatalf("expected workflow runs section, got %q", plain)
 	}
@@ -113,8 +119,14 @@ func TestBuildArtifactLinesShowsTaskLogsWorkflowRunsAndApprovals(t *testing.T) {
 	if !strings.Contains(plain, "Output: ok") {
 		t.Fatalf("expected retained output summary, got %q", plain)
 	}
-	if !strings.Contains(plain, "Resume in /tmp/wuphf-task-1") {
+	if !strings.Contains(plain, "Resume in /tmp/wuphf-task-1 on codex/task-1") {
 		t.Fatalf("expected resume hint, got %q", plain)
+	}
+	if !strings.Contains(plain, "Branch: codex/task-1") {
+		t.Fatalf("expected worktree branch metadata, got %q", plain)
+	}
+	if !strings.Contains(plain, "Click to open task actions and resume context.") {
+		t.Fatalf("expected explicit review/resume CTA, got %q", plain)
 	}
 }
 

--- a/cmd/wuphf/channel_recovery.go
+++ b/cmd/wuphf/channel_recovery.go
@@ -22,7 +22,7 @@ func (m channelModel) currentRuntimeSnapshot() team.RuntimeSnapshot {
 }
 
 func (m channelModel) buildRecoveryLines(contentWidth int) []renderedLine {
-	return buildRecoveryLines(m.currentWorkspaceUIState(), contentWidth, m.tasks, m.requests, m.messages)
+	return buildRecoveryLines(m.currentWorkspaceUIState(), contentWidth, m.tasks, m.requests, m.messages, m.currentArtifactSnapshot(24))
 }
 
 func runtimeTasksFromChannel(tasks []channelTask) []team.RuntimeTask {
@@ -126,7 +126,7 @@ func renderAwayStrip(width, unreadCount int, summary string) string {
 		Render(label)
 }
 
-func buildRecoveryLines(workspace workspaceUIState, contentWidth int, tasks []channelTask, requests []channelInterview, messages []brokerMessage) []renderedLine {
+func buildRecoveryLines(workspace workspaceUIState, contentWidth int, tasks []channelTask, requests []channelInterview, messages []brokerMessage, artifacts runtimeArtifactSnapshot) []renderedLine {
 	snapshot := workspace.Runtime
 	muted := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
 	lines := []renderedLine{{Text: renderDateSeparator(contentWidth, "Recovery")}}
@@ -196,10 +196,24 @@ func buildRecoveryLines(workspace workspaceUIState, contentWidth int, tasks []ch
 	if actionLines := buildRecoveryActionLines(contentWidth, tasks, requests, messages); len(actionLines) > 0 {
 		lines = append(lines, actionLines...)
 	}
+	if artifactLines := buildRecoveryArtifactLines(contentWidth, artifacts); len(artifactLines) > 0 {
+		lines = append(lines, artifactLines...)
+	}
 	if surgeryLines := buildRecoverySurgeryLines(contentWidth, tasks, requests, messages); len(surgeryLines) > 0 {
 		lines = append(lines, surgeryLines...)
 	}
 
+	return lines
+}
+
+func buildRecoveryArtifactLines(contentWidth int, artifacts runtimeArtifactSnapshot) []renderedLine {
+	lines := []renderedLine{}
+	if review := artifacts.ReviewCandidates(2); len(review) > 0 {
+		lines = append(lines, renderArtifactFocusSection(contentWidth, "Review next", "#B45309", review, true)...)
+	}
+	if resume := artifacts.ResumeCandidates(2); len(resume) > 0 {
+		lines = append(lines, renderArtifactFocusSection(contentWidth, "Resume next", "#2563EB", resume, false)...)
+	}
 	return lines
 }
 

--- a/cmd/wuphf/channel_recovery_test.go
+++ b/cmd/wuphf/channel_recovery_test.go
@@ -62,7 +62,7 @@ func TestBuildRecoveryLinesShowsSummaryAndHighlights(t *testing.T) {
 		{ID: "task-1", Title: "Ship launch checklist", Owner: "pm", Status: "in_progress", ExecutionMode: "local_worktree", WorktreePath: "/tmp/wuphf-task-1"},
 	}
 	m.requests = []channelInterview{
-		{ID: "req-1", Title: "Review launch scope", Question: "Review the launch scope", From: "ceo", Blocking: true, Status: "pending"},
+		{ID: "req-1", Kind: "approval", Title: "Review launch scope", Question: "Review the launch scope", From: "ceo", Blocking: true, Status: "pending"},
 	}
 	m.messages = []brokerMessage{
 		{ID: "msg-1", From: "ceo", Content: "Need final scope review before launch.", Timestamp: "2026-04-06T10:00:00Z"},
@@ -70,7 +70,7 @@ func TestBuildRecoveryLinesShowsSummaryAndHighlights(t *testing.T) {
 	}
 
 	workspace := m.currentWorkspaceUIState()
-	lines := buildRecoveryLines(workspace, 88, m.tasks, m.requests, m.messages)
+	lines := buildRecoveryLines(workspace, 88, m.tasks, m.requests, m.messages, m.currentArtifactSnapshot(24))
 	plain := stripANSI(joinRenderedLines(lines))
 
 	if !strings.Contains(plain, "What changed while you were gone") {
@@ -87,6 +87,12 @@ func TestBuildRecoveryLinesShowsSummaryAndHighlights(t *testing.T) {
 	}
 	if !strings.Contains(plain, "Waiting on you") {
 		t.Fatalf("expected normalized readiness card, got %q", plain)
+	}
+	if !strings.Contains(plain, "Review next") {
+		t.Fatalf("expected review-next artifact section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Resume next") {
+		t.Fatalf("expected resume-next artifact section, got %q", plain)
 	}
 }
 

--- a/cmd/wuphf/channel_switcher.go
+++ b/cmd/wuphf/channel_switcher.go
@@ -46,7 +46,7 @@ func (m channelModel) buildWorkspaceSwitcherOptions() []tui.PickerOption {
 			tui.PickerOption{Label: "Requests", Value: "app:requests", Description: "Human decisions and interviews"},
 			tui.PickerOption{Label: "Policies", Value: "app:policies", Description: "Signals, decisions, and watchdogs"},
 			tui.PickerOption{Label: "Calendar", Value: "app:calendar", Description: "Scheduled work and follow-ups"},
-			tui.PickerOption{Label: "Artifacts", Value: "app:artifacts", Description: "Task logs, workflow runs, and approvals"},
+			tui.PickerOption{Label: "Artifacts", Value: "app:artifacts", Description: fallbackString(m.currentArtifactFocusSummary(), fallbackString(m.currentArtifactSummary(), "Task logs, workflow runs, and approvals"))},
 			tui.PickerOption{Label: "Skills", Value: "app:skills", Description: "Reusable skills and workflows"},
 		)
 		for _, ch := range m.channels {
@@ -236,6 +236,13 @@ func (m channelModel) officeFeedDescription(workspace workspaceUIState) string {
 }
 
 func (m channelModel) recoverySwitcherDescription(workspace workspaceUIState) string {
+	artifacts := m.currentArtifactSnapshot(24)
+	if review := artifacts.ReviewCandidates(1); len(review) > 0 {
+		return truncateText("Review: "+review[0].EffectiveTitle(), 72)
+	}
+	if resume := artifacts.ResumeCandidates(1); len(resume) > 0 {
+		return truncateText("Resume: "+resume[0].EffectiveTitle(), 72)
+	}
 	recovery := workspace.Runtime.Recovery
 	if focus := trimRecoverySentence(recovery.Focus); focus != "" {
 		return truncateText(focus, 72)

--- a/cmd/wuphf/channel_switcher_recovery_test.go
+++ b/cmd/wuphf/channel_switcher_recovery_test.go
@@ -55,6 +55,12 @@ func TestBuildWorkspaceSwitcherOptionsIncludesActiveWorkAndThreads(t *testing.T)
 	if !strings.Contains(descriptions["app:messages"], "3 new since you looked") {
 		t.Fatalf("expected office feed description to use away summary, got %q", descriptions["app:messages"])
 	}
+	if !strings.Contains(descriptions["app:recovery"], "Review: Approve launch copy") {
+		t.Fatalf("expected recovery description to promote review target, got %q", descriptions["app:recovery"])
+	}
+	if !strings.Contains(descriptions["app:artifacts"], "Review Approve launch copy") {
+		t.Fatalf("expected artifacts description to summarize review/resume work, got %q", descriptions["app:artifacts"])
+	}
 }
 
 func TestApplyWorkspaceSwitcherSelectionSupportsTaskAndRequestTargets(t *testing.T) {
@@ -143,6 +149,12 @@ func TestBuildRecoveryLinesIncludesActionCards(t *testing.T) {
 	}
 	if !strings.Contains(plain, "Return to recent threads") {
 		t.Fatalf("expected recent threads section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Review next") {
+		t.Fatalf("expected review-retained section, got %q", plain)
+	}
+	if !strings.Contains(plain, "Resume next") {
+		t.Fatalf("expected resume-retained section, got %q", plain)
 	}
 	if !hasTask || !hasRequest || !hasThread {
 		t.Fatalf("expected clickable recovery lines, got task=%v request=%v thread=%v", hasTask, hasRequest, hasThread)

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -651,6 +651,34 @@ func TestOneOnOneAgentSelectionRequiresConfirmation(t *testing.T) {
 	}
 }
 
+func TestTaskActionPickerUsesReviewResumeLanguageForWorktreeTasks(t *testing.T) {
+	m := newChannelModel(false)
+	options := m.buildTaskActionPickerOptions(channelTask{
+		ID:            "task-1",
+		Title:         "Ship review-resume UX",
+		Status:        "in_progress",
+		ExecutionMode: "local_worktree",
+		WorktreePath:  "/tmp/wuphf-task-1",
+		ThreadID:      "msg-1",
+	})
+
+	joined := make([]string, 0, len(options))
+	for _, option := range options {
+		joined = append(joined, option.Label+" :: "+option.Description)
+	}
+	text := strings.Join(joined, "\n")
+
+	if !strings.Contains(text, "Resume task :: Take ownership and continue the retained worktree-backed run") {
+		t.Fatalf("expected resume-first copy for worktree task, got %q", text)
+	}
+	if !strings.Contains(text, "Hand off for review") {
+		t.Fatalf("expected review handoff copy for worktree task, got %q", text)
+	}
+	if !strings.Contains(text, "Open thread :: Jump to the handoff thread before resuming") {
+		t.Fatalf("expected open-thread handoff copy, got %q", text)
+	}
+}
+
 func TestHumanFacingMessageSwitchesBackToMessages(t *testing.T) {
 	m := newChannelModel(false)
 	m.activeApp = officeAppTasks

--- a/internal/team/runtime_artifacts.go
+++ b/internal/team/runtime_artifacts.go
@@ -27,6 +27,7 @@ type RuntimeArtifact struct {
 	UpdatedAt     string
 	Path          string
 	Worktree      string
+	Branch        string
 	PartialOutput string
 	ResumeHint    string
 	ReviewHint    string
@@ -64,4 +65,31 @@ func (a RuntimeArtifact) EffectiveProgress() string {
 		return progress
 	}
 	return strings.ReplaceAll(strings.TrimSpace(a.State), "_", " ")
+}
+
+func (a RuntimeArtifact) NormalizedState() string {
+	return strings.ToLower(strings.TrimSpace(a.State))
+}
+
+func (a RuntimeArtifact) Reviewable() bool {
+	switch a.Kind {
+	case RuntimeArtifactTask:
+		return a.NormalizedState() == "review" || strings.TrimSpace(a.ReviewHint) != ""
+	case RuntimeArtifactRequest:
+		state := a.NormalizedState()
+		return state == "pending" || state == "review"
+	default:
+		return false
+	}
+}
+
+func (a RuntimeArtifact) Resumable() bool {
+	if a.Kind != RuntimeArtifactTask {
+		return false
+	}
+	switch a.NormalizedState() {
+	case "completed", "canceled", "cancelled":
+		return false
+	}
+	return strings.TrimSpace(a.Worktree) != "" || strings.TrimSpace(a.RelatedID) != ""
 }


### PR DESCRIPTION
## Summary
- prioritize retained artifacts into explicit review-next and resume-next sections in Artifacts and Recovery
- surface worktree branch metadata and clearer review/resume CTAs for retained task and approval artifacts
- tighten task action, switcher, and recovery copy around review handoffs and resume flows

## Testing
- `go test ./cmd/wuphf ./internal/team`
- `go test ./...`