### PR TITLE
Handle missing tmux sessions during provider reconfigure

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -106,7 +106,7 @@ type Launcher struct {
 	headlessWorkers map[string]bool
 	headlessActive  map[string]*headlessCodexActiveTurn
 	headlessQueues  map[string][]headlessCodexTurn
-	webMode bool
+	webMode         bool
 }
 
 // SetUnsafe enables unrestricted permissions for all agents (CLI-only flag).
@@ -2208,12 +2208,24 @@ func (l *Launcher) listTeamPanes() ([]int, error) {
 	).CombinedOutput()
 	if err != nil {
 		// If the session isn't up, there's nothing to clear.
-		if strings.Contains(string(out), "no server") || strings.Contains(string(out), "can't find") {
+		if isMissingTmuxSession(string(out)) {
 			return nil, nil
 		}
 		return nil, fmt.Errorf("list panes: %w", err)
 	}
 	return parseAgentPaneIndices(string(out)), nil
+}
+
+func isMissingTmuxSession(output string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(output))
+	if normalized == "" {
+		return false
+	}
+	return strings.Contains(normalized, "no server") ||
+		strings.Contains(normalized, "can't find") ||
+		strings.Contains(normalized, "failed to connect to server") ||
+		strings.Contains(normalized, "error connecting to") ||
+		strings.Contains(normalized, "no such file or directory")
 }
 
 func parseAgentPaneIndices(output string) []int {

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -27,6 +27,26 @@ func TestParseAgentPaneIndicesSkipsChannelPane(t *testing.T) {
 	}
 }
 
+func TestIsMissingTmuxSessionRecognizesCommonErrors(t *testing.T) {
+	cases := []string{
+		"no server running on /tmp/tmux-1000/wuphf",
+		"can't find session: wuphf-team",
+		"failed to connect to server",
+		"error connecting to /tmp/tmux-1001/wuphf (No such file or directory)",
+	}
+	for _, tc := range cases {
+		if !isMissingTmuxSession(tc) {
+			t.Fatalf("expected missing-session detection for %q", tc)
+		}
+	}
+}
+
+func TestIsMissingTmuxSessionIgnoresUnexpectedErrors(t *testing.T) {
+	if isMissingTmuxSession("unknown option: -bogus") {
+		t.Fatal("expected non-session tmux errors to remain actionable")
+	}
+}
+
 func TestResetBrokerStateUsesAuthToken(t *testing.T) {
 	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary
- normalize additional tmux "session missing" errors during pane enumeration
- avoid failing provider reconfiguration when there is no live tmux office to clean up
- add focused coverage for the new missing-session detection helper

## Testing
- `go test ./internal/team ./cmd/wuphf -count=1`
- `go test ./... -count=1`