### PR TITLE
fix: 1:1 normalization, DM simplification, strategy docs

### DIFF
--- a/docs/plans/2026-04-11-paperclip-vs-wuphf-grounded.md
+++ b/docs/plans/2026-04-11-paperclip-vs-wuphf-grounded.md
@@ -1,0 +1,174 @@
+# Paperclip vs WUPHF — Grounded Analysis
+
+Generated 2026-04-11 on branch `nazz/feat/web-view`. This supersedes an earlier shallow analysis that relied on WebFetch summaries instead of reading the actual source. Paperclip was cloned to `/tmp/paperclip-analysis/paperclip` (HEAD `b00d52c`) and the claims below cite real files and line numbers.
+
+## Executive summary
+
+Paperclip and WUPHF are optimizing for different products. Paperclip is a **task-execution control plane** with strong audit, retry, and budget semantics. WUPHF is a **conversational office runtime** with A2UI, Nex integration, and a terminal-first TUI. The earlier "steal from Paperclip" framing understated both how much Paperclip has built (it's much larger than I implied) and what WUPHF already has that Paperclip does not. The grounded answer: lift three specific patterns, avoid four others that look attractive but don't serve WUPHF's current shape.
+
+## Corrections to the earlier analysis
+
+| Earlier claim | Reality |
+|---|---|
+| "Adapter interface is a 3-method contract (`invoke/status/cancel`)." | Real interface is `ServerAdapterModule` with ~15 methods, defined in `packages/adapter-utils/src/types.ts:292-331`. It includes `execute`, `testEnvironment`, `listSkills`, `syncSkills`, `sessionCodec`, `sessionManagement`, `models`, `listModels`, `supportsLocalAgentJwt`, `agentConfigurationDoc`, `onHireApproved`, `getQuotaWindows`, `detectModel`, `getConfigSchema`. |
+| "Paperclip ships with ~5 adapters." | 10 built-in adapters: `claude_local`, `codex_local`, `opencode_local`, `pi_local`, `cursor`, `gemini_local`, `openclaw_gateway`, `hermes_local`, `process`, `http`. Each is its own npm package. External adapters can override built-ins via `plugin-loader.ts` with pause/resume semantics. (`server/src/adapters/registry.ts:207-222`) |
+| "The scheduler is ~150 lines." | `server/src/services/heartbeat.ts` is **4,533 lines**. It's the engine: run claim, concurrency control, budget guard, orphan reaping, retry tracking, session compaction, workspace isolation, live event publishing. |
+| "One `PropertiesPanel` reused with 3 modes." | It's a 29-line render-slot (`ui/src/components/PropertiesPanel.tsx`) backed by React Context (`ui/src/context/PanelContext.tsx`). Any page calls `openPanel(<jsx/>)` to push its own content. Completely different (and better) pattern than what I described. Visibility persisted to localStorage. |
+| "IssueChatThread has a clean chain-of-thought fold primitive." | It's a 2,007-line component built on top of `@assistant-ui/react` primitives (`MessagePrimitive`, `ActionBarPrimitive`, `ThreadPrimitive`, `useMessage`, `useAuiState`). Not a small lift. The fold logic itself (`resolveAssistantMessageFoldedState` + synchronous render-time state derivation, `IssueChatThread.tsx:1001-1016`) is clean, but it depends on the assistant-ui runtime. |
+| "Billing codes as a separate concept." | Cost is tracked in `cost_events` (5-dimensional: company, agent, issue, project, goal, heartbeat_run) with `billingCode` as one field among many. The adapter returns `costUsd` directly in `AdapterExecutionResult` (`packages/adapter-utils/src/types.ts:78-83`), so billing is a consequence of the adapter reporting cost per run, not a separate subsystem. |
+| "Budgets are a single monthly limit." | Layered system: `budget_policies` table (scope = company/agent/project, metric = billed_cents, hard-stop flag, soft-alert threshold), `budget_incidents` table (audit when a policy fires), `agents.{budgetMonthlyCents, spentMonthlyCents}` convenience fields, plus `companies.pauseReason = 'budget'` for auto-pause. `getInvocationBlock(companyId, agentId, ctx)` in `server/src/services/budgets.ts:716` checks all layers before dispatch. |
+| "Task-centric communication, no side channel." | Confirmed and stronger than I described. `SPEC-implementation.md:38` says: `"Communication | Tasks + comments only (no separate chat system)"`. They explicitly rejected chat. |
+
+## Grounded comparison
+
+| Dimension | Paperclip | WUPHF (current) |
+|---|---|---|
+| **Runtime surface** | `heartbeat_runs` table, queued→running→succeeded/failed/cancelled/timed_out lifecycle, content-addressed log storage (`logSha256`, `logCompressed`), retry tracking (`retryOfRunId`, `processLossRetryCount`), orphan reaping via `reapOrphanedRuns` in `heartbeat.ts:2333` | Implicit — `runHeadlessClaudeTurn(ctx, slug, notification)` (`internal/team/headless_claude.go:21`) and `runHeadlessCodexTurn` (`internal/team/headless_codex.go:185`). No queue, no run table, no retry, no orphan detection. Each turn is fire-and-forget. |
+| **Agent dispatch** | `startNextQueuedRunForAgent` uses `withAgentStartLock` (`heartbeat.ts:309`) to serialize, checks `parseHeartbeatPolicy(agent).{enabled, intervalSec, wakeOnDemand, maxConcurrentRuns}`, atomic DB claim via `heartbeatRuns UPDATE WHERE status = 'queued'` | `notifyAgentsLoop` (`launcher.go:310`) polls message stream, calls `deliverMessageNotification` → launches headless turn. No locks, no policy, no concurrency cap per agent. |
+| **Adapter per agent** | `agents.adapterType` + `agents.adapterConfig` jsonb (`packages/db/src/schema/agents.ts:25-26`), so CEO can run Opus Claude and dev can run Codex | Global `--provider claude|codex` flag at startup. All agents share one provider. Model per agent is hardcoded: CEO gets Opus, specialists get Sonnet (`headless_claude.go:152-157`). |
+| **Cost tracking** | `cost_events` table indexed 5 ways (`packages/db/src/schema/cost_events.ts`), populated from `AdapterExecutionResult.{inputTokens, outputTokens, costUsd, provider, biller, model, billingType}` | None. Latency is logged (`appendHeadlessClaudeLatency`) but token counts and dollars are not captured. |
+| **Budget enforcement** | `getInvocationBlock` called at run claim time, checks company/agent/project in layers, auto-pauses scopes that exceed hard-stop, logs `budget_incidents` | None. Turns run until the underlying CLI runs out of quota. |
+| **Activity log** | One 94-line service, `logActivity(db, input)` in `server/src/services/activity-log.ts`. Invariant: every mutation calls it. Writes to table, publishes live event, emits to plugin event bus, redacts sensitive values. | Scattered across `office-ledger`, `watchdog-ledger`, individual service handlers. No single invariant, no redaction, no live event fan-out. |
+| **Approvals** | `approvals` table with polymorphic `type` ("hire_agent", "approve_ceo_strategy", etc.), payload jsonb, state machine (pending→approved/rejected/cancelled). Separate `approval_comments` table for discussion. (`packages/db/src/schema/approvals.ts`) | `requests` table serves a similar purpose but is ad-hoc (kind/summary/blocking/required) with no typed payloads or state machine. |
+| **Task model** | `issues` table with `checkoutRunId`, `executionRunId`, `executionLockedAt`, single-assignee atomic checkout, parent/sub-issue hierarchy, `originKind`/`originId`/`originRunId`, `billingCode`, per-issue `assigneeAdapterOverrides`, execution workspace isolation via git worktrees (`packages/db/src/schema/issues.ts`, 94 lines) | `tasks` on broker have `{id, channel, owner, status, title, ...}`. No atomic claim, no parent/child, no per-task adapter override, no workspace isolation. |
+| **Web UI shell** | One `Layout.tsx` (486 lines) for mobile + desktop, `CompanyRail` + `Sidebar` + `BreadcrumbBar` + `<Outlet/>` + `PropertiesPanel` + `MobileBottomNav`, swipe gestures at 30px edge zone with 50px minimum, body overflow management, skip link for a11y, 2 keyboard shortcuts hooks. | Hand-rolled vanilla JS in `web/index.html` (7,274 lines including themes). No mobile story. Agent-specific bespoke `#agent-panel`. |
+| **Chat surface** | `IssueChatThread.tsx` (2,007 lines) on `@assistant-ui/react`, chain-of-thought fold with synchronous render-time state derivation, rolling reasoning line with CSS enter/exit animations (`cot-line-enter`, `cot-line-exit`), rolling tool display, user/assistant/system message primitives, feedback buttons with optional reason popover | Chat feed in `web/index.html` (`appendMessageToContainer`), hand-rolled. No fold, no rolling display, no feedback capture, no error boundary. The recent-actions panel was just removed for being space-wasteful. |
+| **Generative UI** | None. Chat is text + tool traces. | **A2UI exists** (`internal/tui/generative.go`, 269 lines): `A2UIComponent` struct with type/children/props/dataRef/action, RFC 6901 JSON Pointer resolution, component registry, inline table and progress rendering. This is an architectural advantage Paperclip does not have. |
+| **Workflow runtime** | None. Agents execute prompts, emit text + tool calls. | Partial: `internal/action/workflow_store.go` (131 lines) as scaffolding. Approved April 1 design targets a JSON workflow runtime on top of A2UI — not yet implemented. |
+| **Integration** | Terminal-native via adapters only. No CRM, email, or calendar integration beyond `openclaw_gateway`. | Nex integration for insights/notifications/memory. One CLI for Gmail/Calendar/CRM. |
+
+## What's actually worth stealing
+
+Ranked by ROI-for-WUPHF's-current-state, not by how interesting the idea is.
+
+### 1. `logActivity` as an invariant — 1 day, high ROI
+
+The 94-line `activity-log.ts` is the cleanest pattern in Paperclip. One function, three jobs: write to a table, publish a live event, emit to a plugin event bus. Every mutation in Paperclip calls it. The `runId` foreign key enables per-run audit replay, which is how you debug agent misbehavior after the fact.
+
+For WUPHF, the equivalent is `func (b *Broker) logActivity(ActivityInput) error` that:
+- Appends to an `activity_log` slice on `brokerState` (persisted via `saveLocked`)
+- Broadcasts to any SSE/websocket subscribers (for real-time web view updates)
+- Takes `{actorType, actorId, action, entityType, entityId, runId, details}` — same shape
+
+WUPHF has partial audit today (office-ledger, watchdog ledger, request lifecycle logs). Unifying would be ~50 lines of Go + ~30 lines of Go to migrate existing call sites. Enables the rest: replay, inline system messages in chat, cleaner `/doctor` output.
+
+### 2. PropertiesPanel render-slot pattern — 0.5 day, high ROI
+
+The 29-line `PropertiesPanel.tsx` is a dumb container. `PanelContext` holds `panelContent: ReactNode | null`. Pages call `openPanel(<jsx/>)` on mount to push their detail. The panel's visibility is persisted to localStorage.
+
+For WUPHF's vanilla JS web view, the equivalent is:
+- One `#detail-panel` element in `web/index.html`
+- One `WuphfDetail.show(contentEl)` / `WuphfDetail.hide()` API
+- `localStorage` for the visible preference
+- `openAgentPanel(slug)` becomes `WuphfDetail.show(buildAgentDetail(slug))`
+- Tasks and requests gain their own `buildTaskDetail(id)` / `buildRequestDetail(id)` that push into the same slot
+
+Replaces the bespoke `#agent-panel` with one slot. About 150 lines of JS added, 200 lines removed. Biggest ergonomic win in the web view.
+
+### 3. Chain-of-thought fold inline in chat — 1-2 days, medium-high ROI
+
+The fold pattern is strictly better than the "Recent Actions" panel that was just removed. Agent messages collapse their work by default, expand on click, auto-expand while running. The rolling reasoning line during active runs (`IssueChatReasoningPart`, animates via CSS `cot-line-enter`/`cot-line-exit`) is a small detail that makes active runs feel alive.
+
+For WUPHF's web view, **don't depend on `@assistant-ui/react`** — that's a big library for a vanilla JS project. Build a minimal version:
+- Agent messages get an optional `_cot` array of `{type: 'reasoning' | 'tool_call', ...}` entries
+- When present and the message is not actively running, wrap in a fold button with chevron
+- When running, auto-expand and show the latest tool call with a spinner
+- Use CSS keyframe animations for the rolling text
+- Click expands/collapses; preserves fold state per message ID
+
+WUPHF already emits tool_use/tool_result events during `runHeadlessClaudeTurn` (`headless_claude.go:90-99`) — they just need to be attached to the message in broker state. ~300 lines of JS + ~50 lines of Go to plumb the events through.
+
+### Bonus (if/when the workflow runtime lands)
+
+**Adopt `heartbeat_runs`-style run table** once WUPHF has a queue worth tracking (e.g., workflow steps running async). The schema fields to copy: `{id, companyId, agentId, invocationSource, triggerDetail, status, startedAt, finishedAt, error, errorCode, usageJson, resultJson, contextSnapshot, retryOfRunId, processLossRetryCount}`. Don't copy `logStore`/`logRef`/`logSha256` — that's premature.
+
+## What WUPHF has that Paperclip doesn't
+
+These are real structural advantages. Paperclip is a control plane for task execution; WUPHF is (becoming) a conversational office with generative UI.
+
+1. **A2UI (`internal/tui/generative.go`).** Agents can emit JSON schemas that render as real UI components — tables, cards, progress bars. RFC 6901 JSON Pointer resolution for data binding. This is the foundation the April 1 approved workflow runtime sits on. Paperclip has nothing here — chat is text + collapsible tool traces.
+
+2. **Office metaphor.** Channels, threads, tasks, requests, calendar as a unified conversational surface. Paperclip explicitly rejected this ("Tasks + comments only (no separate chat system)"). Whether Paperclip is right depends on user type: for task-execution power users, tasks+comments is cleaner. For founders running a small AI company who want the legibility of a Slack office, WUPHF's model reads better.
+
+3. **Nex integration.** Real-time context from the outside world (CRM changes, email, calendar, meetings). Paperclip is a closed system with `process` and `http` adapters but no first-class knowledge integration.
+
+4. **Terminal-first TUI + web view parity.** Two surfaces for the same broker. Paperclip is web-only. For a terminal-native builder audience, the TUI is a moat.
+
+5. **Telegram, Gmail, calendar, slash commands, MCP integration.** WUPHF's daily operator surface is further along than Paperclip's for actual work. Paperclip has routines (cron) and MCP, but the integration set is thinner.
+
+6. **The `channel_email.go` and email-triage code path** — this is where the workflow runtime was supposed to replace hardcoded Go but didn't. It's still an asset — a working email assistant — even if the generalization didn't land.
+
+## What NOT to adopt
+
+These patterns look attractive but don't serve WUPHF's current shape.
+
+1. **Full `ServerAdapterModule` interface.** The 15-method shape is sized for a plugin ecosystem with 10+ external adapters. WUPHF needs 2 (claude, codex) plus a third (process/http) if/when it wants to call external services. Lift a minimal `HeadlessAdapter` interface with just `Execute(ctx, slug, notification) error` and `Cancel(ctx, slug) error`. Store provider per agent in `officeMember.adapterType`. That's the MVP of the idea without the complexity.
+
+2. **Full budget policy system.** `budget_policies` + `budget_incidents` + multi-scope enforcement is appropriate for ops teams with real dollars on the line. WUPHF has one user. Add `cost_events` as passive logging now — when each headless run finishes, write `{agent, model, input_tokens, output_tokens, cost_cents, occurred_at}` to a file or broker state. That's enough to answer "how much did today cost." Policies can come later.
+
+3. **Agent Companies protocol / Clipmart.** Markdown-based portable company packages are only relevant once you have multiple packs worth sharing. WUPHF has one pack (Founding Team), one user.
+
+4. **Plugin system.** Paperclip has 20+ files under `plugin-*` (plugin-host-services, plugin-job-coordinator, plugin-job-scheduler, plugin-job-store, plugin-lifecycle, plugin-loader, plugin-registry, plugin-runtime-sandbox, plugin-secrets-handler, plugin-state-store, plugin-stream-bus, plugin-tool-dispatcher, plugin-tool-registry, plugin-worker-manager, plugin-dev-watcher, plugin-event-bus, plugin-config-validator, plugin-capability-validator, plugin-manifest-validator, plugin-log-retention, plugin-ui-static). This is where Paperclip got expensive. Only worth it when third parties want to build against you, which WUPHF does not need.
+
+5. **Organizational hierarchy (goals → projects → milestones → issues → sub-issues).** WUPHF's current flat task model is appropriate for its scope. Adding a single `project_id` field on tasks if needed is fine. Don't copy the full hierarchy.
+
+6. **`@assistant-ui/react` dependency.** A big library with its own runtime primitives. The chain-of-thought fold pattern is worth stealing; the library is not. Implement a minimal equivalent in vanilla JS.
+
+7. **`reapOrphanedRuns` / `processLossRetryCount`.** These matter when runs are long-lived and can be orphaned by process death. WUPHF's turns are short (a few seconds to a few minutes). Don't need it until the workflow runtime has async steps.
+
+## The real 3-item shortlist
+
+Not 15. Not 7. **Three.**
+
+1. **Unify audit via `logActivity`** — ~1 day — unblocks replay, inline system messages in chat, real-time web view updates
+2. **Render-slot `#detail-panel` replacing bespoke `#agent-panel`** — ~0.5 day — biggest ergonomic improvement in the web view
+3. **Chain-of-thought fold inline in chat messages** — ~1-2 days — the right answer to "where should agent tool traces live visually"
+
+Everything else waits. In particular:
+- The adapter interface wait until there's a concrete reason to run mixed providers in one office
+- Cost tracking waits until the first bill gets uncomfortable
+- Budgets wait until that bill has stakeholders other than the founder
+- The workflow runtime is on a different branch with a different plan (see `najmuzzaman-nazz-email-postmortem-design-20260401-153916.md`) and should not be re-scoped through a Paperclip lens
+
+## What I still do not know
+
+Things worth verifying before implementation, not before deciding:
+
+1. Whether WUPHF's activity log should write to broker state JSON or a SQLite file (Paperclip uses Postgres; WUPHF uses JSON state files today)
+2. Whether the fold pattern should live inside `appendMessageToContainer` or as a separate `renderAgentMessage` helper
+3. Whether the detail panel should be responsive (hide on mobile?) — Paperclip's is `hidden md:flex`, desktop-only
+4. Whether to integrate with the existing `publishLiveEvent`-equivalent or introduce a new broadcast mechanism in the broker
+5. Whether the chain-of-thought fold should also be available in the TUI (`cmd/wuphf/channel.go`) or web-only for now
+
+## Sources (verified reads, not WebFetch)
+
+Paperclip clone: `/tmp/paperclip-analysis/paperclip` at HEAD `b00d52c`.
+
+- `packages/adapter-utils/src/types.ts:13-331` (AdapterRuntime, AdapterExecutionContext, ServerAdapterModule, AdapterExecutionResult, AdapterBillingType)
+- `server/src/adapters/registry.ts:1-416` (10 built-in adapters, override/pause)
+- `server/src/adapters/process/execute.ts:14-86` (process adapter implementation)
+- `server/src/services/heartbeat.ts:2182-2192` (parseHeartbeatPolicy), `:2202-2278` (claimQueuedRun with budget check), `:2333-2358` (reapOrphanedRuns)
+- `server/src/services/budgets.ts:716-830` (getInvocationBlock layered check)
+- `server/src/services/activity-log.ts:1-95` (the entire file)
+- `packages/db/src/schema/heartbeat_runs.ts:1-55` (full schema with content-addressed logs)
+- `packages/db/src/schema/cost_events.ts:1-54` (5-dimensional cost tracking)
+- `packages/db/src/schema/activity_log.ts:1-26` (runId linkage)
+- `packages/db/src/schema/approvals.ts:1-28`
+- `packages/db/src/schema/agents.ts:1-42` (adapter_type, adapter_config, runtime_config, budget_monthly_cents)
+- `packages/db/src/schema/issues.ts:1-94` (single-assignee, atomic checkout, per-issue adapter overrides)
+- `ui/src/components/Layout.tsx:58-486` (responsive single layout, swipe gestures)
+- `ui/src/components/PropertiesPanel.tsx:1-29` (render-slot pattern)
+- `ui/src/context/PanelContext.tsx:1-75` (the context that powers PropertiesPanel)
+- `ui/src/components/IssueChatThread.tsx:513-628` (ChainOfThought component), `:677-733` (RollingToolPart), `:967-1172` (AssistantMessage with fold)
+- `doc/SPEC-implementation.md:38-52` (V1 product decisions, including "Tasks + comments only")
+
+WUPHF cross-reference reads:
+
+- `internal/team/headless_claude.go:1-190` (current runtime model)
+- `internal/team/headless_codex.go:1-50` (codex worker queue)
+- `internal/team/broker.go:264-306` (brokerState, Broker structs)
+- `internal/team/launcher.go:113-175` (Launcher lifecycle)
+- `internal/tui/generative.go:1-269` (A2UI component system, RFC 6901 pointer resolution)
+- `internal/action/workflow_store.go` (131 lines of workflow scaffolding)
+- `docs/competitive-analysis-multi-agent-projects.md:1-120` (WUPHF's own positioning doc)
+- `~/.gstack/projects/nex-crm-wuphf/najmuzzaman-nazz-email-postmortem-design-20260401-153916.md` (approved April 1 workflow runtime design)

--- a/docs/plans/2026-04-12-wuphf-strategy-vs-paperclip.md
+++ b/docs/plans/2026-04-12-wuphf-strategy-vs-paperclip.md
@@ -1,0 +1,709 @@
+# WUPHF Strategy: The Paperclip Playbook
+
+Written 2026-04-12 on branch `nazz/feat/web-view`. This is the strategic plan for
+positioning WUPHF as the better multi-agent office runtime, informed by a deep source
+read of Paperclip (cloned at b00d52c, 94k lines server TS + 68k lines UI TSX) and a
+review of its GitHub issue tracker, user community, and public reception.
+
+## Decisions Made
+
+### KILL: A2UI (generative UI component system)
+- Files: `internal/tui/generative.go` (269), `generative_registry.go` (294),
+  `generative_test.go` (465), `internal/action/workflow_store.go` (131)
+- References: 14 in `channel.go`, 8 in `stream.go`, 57 in `web/index.html`
+- Reason: not functional, never shipped a working user-facing feature
+- The April 1 approved design doc (workflow runtime + A2UI hybrid) is dead in its
+  current form. If workflow runtime comes back, it comes back without A2UI.
+
+### KILL: Email Postmortem as a separate product direction
+- Branch `nazz/email-postmortem` has 113 commits. Not deleting the branch.
+- Decision: stop investing as a parallel direction. Fold email triage into WUPHF
+  as a pre-built pack ("Inbox Triage" or "Customer Ops" pack).
+
+### CHANGE: Focus mode (delegation) becomes the default
+- PR #25 (`codex/focus-mode`) already shipped CEO-routed delegation mode.
+- Decision: flip to default. Specialists only wake when CEO delegates or human tags directly.
+- Rename: "focus mode" → "delegation mode" (the default, unnamed in UI)
+- Add: `/team` command to enable collaborative mode (inverse of current `/focus`)
+- CEO agent suggests `/team` when 2+ agents work on related tasks — the "aha moment"
+- Rationale: cheaper (fewer agents firing), simpler (Paperclip-familiar), safer (smaller
+  blast radius for month 1). Collab mode is the upgrade, not the baseline.
+
+### ELEVATE: Nex is the strategic core, not a nice-to-have
+- Dorsey's framework: "the value is in the world model, not the interfaces"
+- ericosiu's evidence: "the data accumulates in ways that can't be fast-forwarded"
+- Decision: Nex integration quality is a prerequisite for launch, not a post-launch item.
+  The comparison post should show Nex making decisions Paperclip can't because Paperclip
+  has no world model.
+
+---
+
+## Part 1: Why Paperclip Got Famous
+
+### The growth story
+- Created by [@cryppadotta / "dotta"](https://github.com/paperclipai)
+- Launched March 4, 2026
+- 30k stars in 3 weeks, 38k in 4 weeks, 43k+ as of April 2026
+- Did NOT break out on Hacker News. Multiple submissions, max 6 points, 1 comment
+  ("Love paperclip I've been using it for a few days now the UI is really nice.")
+- Growth came from: YC network, Twitter/X, and a coordinated wave of 8+ Medium articles
+  in a 2-week window (Towards AI, MindStudio, SOTAAZ, 4thPath, DealRoom, Flowtivity,
+  UCStrategies, MrDelegate)
+
+### The actual fame drivers
+1. **"Zero-human company" framing is polarizing.** Every discourse camp reacts. Polarizing = shareable.
+2. **Timing.** Multi-agent coordination pain became acute in early 2026 as more people ran
+   multiple Claude Code / Codex / OpenClaw sessions. The coordination gap was felt.
+3. **Company metaphor maps to how developers already think.** Reviewer quote: "The
+   company/project/issue metaphor maps directly to how developers already think about work."
+4. **Zero-friction onboarding.** 16 pre-built company templates, embedded PGlite (no Docker),
+   MIT licensed, self-hosted, no account.
+5. **Provider-agnostic.** "If it can receive a heartbeat, it's hired." Works with Claude,
+   Codex, OpenClaw, Cursor, Gemini, Hermes, Pi, OpenCode, any subprocess, any HTTP webhook.
+6. **Logan (OpenClaw adjacent):** "When I first started playing with OpenClaw this was the
+   vision I had for where you could take Agents. Everyone should go try Paperclip right now."
+7. **Opensoul** (6-agent marketing agency built on Paperclip) validated the stack in
+   production — a concrete reference customer.
+
+### What users actually love (smaller list than the hype)
+- The dashboard. "Browser-based dashboard for oversight, without writing any UI code yourself."
+- Persistence out of the box. "No Docker Compose, no Supabase setup."
+- The control/execution plane split is "architecturally correct."
+- Self-hosted, MIT, no account.
+
+---
+
+## Part 2: What's Actually Broken (from GitHub issues and user reports)
+
+### Token burn is the #1 pain
+
+**Issue #544** — "consumes 10x more tokens than alternatives for the same work."
+User Neelkanthsahu02 identified the **3 hidden token killers** via 100+ bash debugging calls:
+
+1. **Session Resume (~70% of waste).** `--resume` carries full conversation history from all
+   previous runs. 13 accumulated sessions = millions of cached tokens re-read every turn.
+   Fix: fresh sessions per task.
+2. **12 MCP Servers inherited globally (~24k tokens/turn).** Every agent loads all MCP servers
+   from the user's global Claude config. 240 tool definitions = 24k tokens overhead.
+   Fix: per-agent MCP scoping.
+3. **Unnecessary skills.** Agents inherit skills they don't use.
+   Fix: per-agent skill selection.
+
+Follow-up from garfieldcoked: "I like the concept of Paperclip but hitting my limits too fast."
+
+**Issue #1183** — "Full conversation history + verbose tool outputs sent every heartbeat.
+Leads to exponential token consumption, reaching model limits within minutes." Proposed:
+instruction caching, tool output truncation (2k token limit), rolling context window,
+metadata stripping after first turn.
+
+**Issue #3401** (filed 2026-04-11) — "Heartbeat is architecturally heavyweight — burns LLM
+tokens without delivering proportional value." Maintainer response: "This is a legitimate
+architectural concern. The current heartbeat model is polling-over-push — it spends LLM
+tokens to learn 'nothing to do.' The report is correct."
+
+**Issue #2101** — Agents hit rate limits, retry on fixed 3600s schedule instead of honoring
+the actual reset time from the rate-limit response.
+
+**Issue #1348** — "Archived companies still running heartbeats and consuming tokens." Comment:
+"This is urgently needed !!!"
+
+**Issue #1756** — Budget is dollar-denominated. Claude Enterprise/Max users track tokens, not
+dollars. Workaround: set budget to 0 (unlimited) and track externally — defeating the purpose.
+
+### Workspace corruption is the #2 pain
+
+**Issue #3335** — "222 active execution workspaces all pointing at the same cwd across 8
+agents. Every agent was reading and writing the same files simultaneously." Git worktree
+isolation exists in the codebase but gated behind 3 experimental flags, no UI, no docs.
+The known-dangerous behavior is still the production default a month after being filed.
+
+Combined with #3207 (workspace cleanup destroying unpushed work): agents can silently lose
+each other's completed work.
+
+### Other production bugs
+- **#3338** — Session tokens logged in plaintext in server.log. Security.
+- **#3352** — DELETE /api/agents fails with FK constraint violation. Can't delete agents.
+- **#3407** — Routine dispatch crashes with duplicate key errors.
+- **#3325** — gemini_local resumes stale session and hallucinates completion.
+- **#3364** — Retry wakeups lose their issue context after failure.
+- **#3377** — Org chart broken on mobile portrait.
+- **Effloow (14 agents)** — Day one fabrication incident: "agents filled the site with
+  invented content — plausible but entirely false data, statistics, and narratives."
+- **Reviewer note** — "batch outreach hit 23 leads instead of 3 due to cascading mistakes."
+
+### The pattern
+Paperclip shipped the vision before they shipped the discipline. Token complaints dominate
+their issue tracker. Workspace integrity is broken by default. These are the gaps.
+
+---
+
+## Part 3: The Collaboration Model Question
+
+### The tension
+Paperclip uses a Linear-style ticket system: agents check out tasks, do them, post comments.
+No chat, no channels, no real-time conversation. Their SPEC explicitly says "Tasks + comments
+only (no separate chat system)."
+
+WUPHF uses a Slack-style office: agents live in channels, respond to messages, have threads
+and DMs. Tasks exist but emerge from the conversation.
+
+### Where Paperclip's ticket model wins
+- **Batch work**: 50 independent issues, each assigned to an agent. No coordination needed.
+- **Time-shifted work**: agents run at 3am, human reviews at 9am. No conversation needed.
+- **Scale**: 20+ agents doing parallelizable work. Shared context = token cost.
+- **Clean audit**: task → comments → cost → billing code. Easy to search and filter.
+- **Fire-and-forget**: assign, wait, review. No supervision required.
+
+### Where WUPHF's collaboration model wins
+- **Ambiguity**: "figure out why users are churning" needs discussion, not a ticket.
+- **Real-time human-in-the-loop**: typing in the channel > commenting on a ticket.
+- **Quality through visibility**: Agent A sees Agent B's output in the shared channel,
+  catches conflicts before shipping. In Paperclip, A never sees B's output.
+- **Creative work**: brainstorming, design reviews, strategy — conversation, not tickets.
+- **Small team feel**: the "founding team in a room" mental model. This is what the
+  20x company looks like — 3-5 agents + 1 human, same Slack, same context.
+- **Observability**: "what's happening right now" is a glance at the channel.
+  In Paperclip, it's filtering the issue tracker by status.
+- **Preventing fabrication**: agents seeing each other's output in real-time catches
+  "this data looks invented" faster than post-hoc task review.
+
+### The critical insight: WUPHF is the superset
+WUPHF has channels AND tasks. Paperclip has tasks only.
+
+WUPHF can offer:
+- "Collaborative mode" — agents work in a shared channel, human watches and steers
+- "Quiet mode" — agents work silently on assigned tasks, post results when done (Paperclip's model)
+
+Paperclip CANNOT offer collaborative mode. They explicitly rejected chat. Adding it
+requires rebuilding their data model — a multi-month rewrite.
+
+### Evidence from multi-agent ecosystem
+- AutoGen, CrewAI, OpenAI Swarm, LangGraph — all use conversation as the coordination
+  primitive, not task queues. Paperclip's task-only model is the industry outlier.
+- Opensoul (marketing agency on Paperclip) is forced into task structure for collaborative
+  work that's naturally conversational. The friction is tolerated, not chosen.
+- Garry Tan's "20x company" thesis: small teams + AI. These teams talk in Slack, not Linear.
+- The Effloow fabrication incident is partly a visibility problem — no shared channel where
+  agents could flag "this data looks invented."
+
+### The risk
+Token cost of shared context. In Paperclip, each agent sees only its task. In WUPHF, each
+agent sees the whole channel. More visibility = more tokens.
+
+Mitigation: the same token discipline patterns from Part 2, applied to WUPHF's model:
+- Rolling context window (last N relevant messages)
+- Per-agent channel filtering (frontend agent doesn't need CRO's sales discussion)
+- Summary blocks (every 50 messages, CEO posts a summary that replaces raw messages)
+- Task-scoped context option (narrow to task thread when assigned)
+
+### Strategic recommendation
+Don't dilute the collaboration model to match Paperclip. Double down as the positioning.
+
+---
+
+## Part 4: Final Positioning (Converged)
+
+### One-liner
+"Your AI team, same office, 70% cheaper than Paperclip."
+
+### The pitch (for Paperclip switchers)
+
+> "Paperclip treats agents like remote contractors: assign a ticket, wait for the result.
+> WUPHF treats agents like your founding team: same office, same context, same room.
+> Start in delegation mode — familiar, clean, cheap. When you're ready, unlock team mode
+> and watch your agents collaborate. Your Claude bill is 70% lower either way."
+
+### Four pillars (updated from three)
+
+1. **"Your bill dropped 70%"** — token discipline baked in from day one.
+   Fresh sessions (no --resume accumulation), per-agent MCP scope (~24k tokens/turn saved),
+   tool output truncation, no LLM polling. These directly address Paperclip issues
+   #544, #1183, #3401, #3402.
+
+2. **"Nothing corrupts"** — workspace isolation by default (git worktree per agent per task),
+   atomic task checkout (compare-and-swap under broker mutex), paused = fully stopped.
+   Directly addresses Paperclip issue #3335 (222 workspaces sharing one cwd).
+
+3. **"Two modes, one office"** — delegation mode (focus, CEO-routed) is the default.
+   Familiar to Paperclip users. Team mode (collaborative channels) is one command away.
+   CEO agent suggests switching when 2+ agents work on related tasks. Paperclip can only
+   do delegation. WUPHF can do both. PR #25 already shipped.
+
+4. **"A world model that compounds"** — Nex integration as the shared knowledge graph.
+   Dorsey's Layer 2, ericosiu's Single Brain. Contacts, companies, deals, emails, meetings,
+   call transcripts — all indexed, queryable by every agent. "The data accumulates in ways
+   that can't be fast-forwarded." Paperclip has no equivalent.
+
+### The switch progression (user journey)
+- **Minute 0**: `wuphf import paperclip --from ~/.paperclip` → office loads with their agents
+- **Day 1**: delegation mode. CEO receives tasks, delegates to specialists, clean and quiet.
+  User notices: "my bill is way lower." Token savings visible in cost dashboard.
+- **Week 1**: user gets comfortable. Adds Nex connection (Gmail, CRM). CEO starts referencing
+  real customer data in its decisions. "Wait, it knows about that deal?"
+- **Week 2**: CEO suggests: "PM and Frontend are both working on the pricing page. Want me to
+  turn on team mode so they can coordinate?" User types `/team`. Agents start riffing in the
+  shared channel. The "aha moment."
+- **Month 1**: routines running (morning brief at 8am, lead scoring 3x/day, content scan 2x/day).
+  System is compounding. The "flywheel" ericosiu described.
+- **Month 3**: the world model (Nex) has 90 days of accumulated context. CEO makes connections
+  no human noticed. "This is a different game entirely."
+
+### What WUPHF is
+"The AI company operating system — delegation mode for execution, team mode for collaboration,
+Nex for memory. Starts quiet, gets smarter."
+
+### What WUPHF is not
+- Not a task queue (that's Paperclip — we're the superset)
+- Not a session manager (that's Claude Squad)
+- Not a control room (that's claude-code-by-agents)
+- Not an autonomous OS without oversight (that's AI-company / AI Team OS)
+- Not N isolated personal agents (that's NemoClaw — we're one shared office)
+
+---
+
+## Part 5: Technical Patterns to Adopt
+
+### From Paperclip (verified in source)
+
+**Steal directly:**
+1. `logActivity` invariant (`server/src/services/activity-log.ts`, 94 lines) — one function,
+   every mutation calls it, writes + publishes live event. WUPHF equivalent: ~50 lines Go.
+2. PropertiesPanel render-slot (`ui/src/components/PropertiesPanel.tsx`, 29 lines +
+   `ui/src/context/PanelContext.tsx`, 75 lines) — any page pushes JSX into one panel via context.
+3. Chain-of-thought fold (`IssueChatThread.tsx:1001-1016`) — synchronous render-time state
+   derivation, auto-expand while running, collapse when done. Build minimal vanilla JS version.
+4. `cost_events` table shape (`packages/db/src/schema/cost_events.ts`) — 5-dimensional
+   (company, agent, issue, project, goal, heartbeat_run) with billingCode, provider, biller,
+   billingType, model, inputTokens, cachedInputTokens, outputTokens, costCents, occurredAt.
+5. Atomic checkout via compare-and-swap (`heartbeat.ts:2225-2234`) — UPDATE WHERE status = 'queued'.
+
+**Understand but defer:**
+6. `WakeupOptions` envelope (`heartbeat.ts:326-336`) — structured wakes with provenance.
+7. Wake coalescing (`mergeCoalescedContextSnapshot`, `heartbeat.ts:856`) — dedupe multiple
+   wake triggers for the same agent.
+8. Session compaction policies — per-agent context window tuning.
+9. `requestDepth` on tasks — delegation hop counter, infinite loop prevention.
+10. Budget policies as layered enforcement (company → agent → project).
+
+**Skip entirely:**
+11. Full `ServerAdapterModule` interface (15 methods, sized for 10+ adapter ecosystem)
+12. Plugin system (20+ files)
+13. Agent Companies protocol / Clipmart
+14. Goals → projects → milestones → issues hierarchy
+15. `@assistant-ui/react` dependency
+
+### Things WUPHF already does better
+- **Push-driven agent wake** (not timer-based LLM polling)
+- **Per-agent system prompts** (not global system prompt inheritance)
+- **Per-agent model selection** (CEO gets Opus, specialists get Sonnet)
+- **Office metaphor with channels** (vs task-only communication)
+- **CEO-routed focus mode** (PR #25, merged) — specialists stop cross-talking, take
+  work only from CEO delegation or direct human tag, report back to CEO. This IS
+  Paperclip's task-delegation model, shipped as a toggle. WUPHF can do BOTH
+  collaborative (default) AND task-delegation (focus mode). Paperclip can only do one.
+- **Nex integration** (real-world context from CRM, email, calendar) — validates
+  Jack Dorsey's "World Model" layer and ericosiu's "Single Brain" pattern.
+  See Part 9 for analysis.
+- **Terminal-first TUI** (Paperclip is web-only)
+
+### Validated by real production usage (ericosiu OpenClaw post, 2026-04-12)
+
+ericosiu (founder, revenue agent company + marketing agency) runs 5 named agents
+on OpenClaw with 48 daily crons, local inference on Mac Mini M4 + DGX Spark + Mac
+Studio. Six months of compounding data. 6,862 Gong transcripts, 6k+ sales leads.
+
+Key validations:
+- The "Single Brain" (unified vector DB, 15-min ingestion) IS Nex
+- The org chart (Alfred CEO + 4 specialists with lanes) IS WUPHF's office model
+- Focus mode delegation IS how ericosiu's agents coordinate
+- "Never instruct twice" IS save-as-skill
+- "Flat files over databases" IS WUPHF's JSON state approach
+- "The system compounds" — month 1 terrible, month 3 flywheel
+- Local inference cut costs 70% — hardware pays for itself in weeks
+
+Key patterns to adopt:
+- **Broker-native routines** (48 daily crons, not LLM polling)
+- **Self-healing cron doctor** (automated, runs 2x/daily, auto-repairs)
+- **Security gates on all outbound actions** (confirmation for side effects)
+- **LLMs for judgment, scripts for everything else** (explicit boundary)
+- **Personal agents per team member** (multi-user WUPHF offices)
+- **"The data accumulates in ways that can't be fast-forwarded"** — Nex as moat
+
+### Token discipline — the wedge features
+These are the specific engineering tasks that deliver claim #1 ("your bill dropped 70%"):
+
+1. **Verify no `--resume` by default.** Audit `headless_claude.go:29-40`. Confirmed: args
+   list does not include `--resume`. Good. Document this as a design invariant: "WUPHF
+   agents start fresh sessions per turn by default."
+2. **Per-agent MCP config.** Currently `--mcp-config` at `headless_claude.go:38` passes one
+   global config. Change to: generate a per-agent `mcp.json` at turn start containing only
+   the MCP servers that agent needs. ~30 lines of Go.
+3. **Tool output truncation.** Wrap the Claude stream reader to cap tool_result content at
+   2k tokens, showing head/tail with "[truncated]" in the middle.
+4. **`cost_events` passive logging.** After each turn completes, write `{agent, provider,
+   model, input_tokens, output_tokens, cost_cents, occurred_at}` to broker state. Read from
+   `provider.ClaudeStreamResult` which already has token counts.
+5. **No LLM polling.** Already correct. Document: "WUPHF agents wake on push. There is no
+   timer-based heartbeat that burns tokens."
+6. **Paused/archived state stops all dispatch.** Audit broker to confirm.
+7. **Rolling context window.** Summarize older channel messages into short-term memory.
+   Medium effort (~1-2 weeks). Per-agent configurable.
+
+---
+
+## Part 6: Final Roadmap (Converged)
+
+Everything below serves ONE goal: ship a comparison post in 5 weeks that makes the
+switch obvious. Every task earns its place by contributing to a specific pillar.
+
+### Week 1: Clean slate + token foundation
+**Goal: WUPHF starts clean, default mode is delegation, token savings begin.**
+
+- [ ] Delete A2UI (generative.go, generative_registry.go, generative_test.go,
+      renderA2UIBlocks in channel.go, /generative in stream.go, a2ui CSS+JS in web)
+- [ ] Check workflow_store.go + composio_workflows.go — remove if orphaned by A2UI kill
+- [ ] Flip focus mode to default in launcher.go — rename to "delegation mode" in UI/docs
+- [ ] Add `/team` command to enable collaborative mode (inverse of current `/focus`)
+- [ ] CEO system prompt addition: suggest `/team` when 2+ agents work on related tasks
+- [ ] Per-agent MCP config generation in headless_claude.go:38 (~30 lines)
+      → generates per-turn mcp.json with only the MCP servers that agent needs
+- [ ] `cost_events` passive logging: after each turn, write {agent, provider, model,
+      input_tokens, output_tokens, cost_cents, occurred_at} to broker state
+
+**Pillar served:** "Your bill dropped 70%" (per-agent MCP = biggest single token savings)
+
+### Week 2: Token discipline + audit
+**Goal: every known Paperclip token-burn pattern is avoided by design.**
+
+- [ ] Tool output truncation: wrap Claude stream reader, cap tool_result at 2k tokens,
+      show head/tail with [truncated]. Configurable per tool type.
+- [ ] Verify no --resume session accumulation (audit headless_claude.go args)
+- [ ] Verify paused/archived state stops ALL dispatch (audit broker.isPaused paths)
+- [ ] logActivity invariant: `func (b *Broker) logActivity(input ActivityInput) error`
+      → append to activity_log slice in brokerState, persist via saveLocked
+      → broadcast to SSE/websocket subscribers (live web view updates)
+      → ~50 lines Go, migrate existing office-ledger + watchdog calls
+- [ ] Rolling context window: configurable per agent, summarize older messages into
+      short-term memory block, drop raw messages from next turn's context
+- [ ] Document token discipline as design invariants in CLAUDE.md:
+      "WUPHF agents start fresh sessions per turn. No --resume. No global MCP inheritance.
+       No LLM polling. Tool outputs are truncated at 2k tokens."
+
+**Pillar served:** "Your bill dropped 70%" (full token discipline pass)
+
+### Week 3: Workspace integrity + web UX
+**Goal: multi-agent workspace is safe by default, web view has the three Paperclip-lifted patterns.**
+
+- [ ] Git worktree per agent per active task (default for multi-agent projects)
+      → single-agent projects use project root
+      → second agent assigned → worktree auto-created
+      → cleanup preserves unpushed commits
+- [ ] Atomic task checkout: `POST /tasks/:id/checkout {slug}` in broker
+      → compare-and-swap under mutex, 409 if already owned
+- [ ] PropertiesPanel render-slot in web view: replace bespoke #agent-panel with one
+      generic #detail-panel via WuphfDetail.show(contentEl) / hide()
+      → agent detail, task detail, request detail, cost detail all push into same slot
+- [ ] Chain-of-thought fold in web chat: agent messages get expandable tool-call sections
+      → collapsed when done, auto-expand while running
+      → rolling reasoning line during active runs (CSS keyframe animations)
+      → plumb tool_use/tool_result events from headless_claude.go into message in broker
+- [ ] Inline system messages in chat: task state changes + run completions as thin
+      divider lines in the message feed (fed by logActivity)
+
+**Pillar served:** "Nothing corrupts" + web UX polish for the demo
+
+### Week 4: Migration + routines + world model
+**Goal: Paperclip users can import their setup, Nex integration is tight, routines work.**
+
+- [ ] `wuphf import paperclip --from <path>` command (~400 lines Go)
+      → read PGlite DB or JSON state from Paperclip's data directory
+      → map: companies → packs, agents → officeMembers (with adapterType), issues → tasks
+      → import cost_events history, activity_log
+      → rewrite adapter configs (claude_local → claude, codex_local → codex)
+      → print: "Imported N agents, M tasks, $X in cost history. Office running at :7891"
+- [ ] Minimal HeadlessAdapter interface: Execute(ctx, slug, notification) error +
+      Cancel(ctx, slug) error. Store adapterType per officeMember. Refactor
+      headless_claude.go + headless_codex.go behind it. Enables mixed providers.
+- [ ] Broker-native routines: cron schedule per agent stored in broker state
+      → fires wake events on schedule (no LLM involved in scheduling)
+      → routine = {id, agentSlug, schedule, prompt, enabled, lastRun, nextRun}
+      → CEO morning brief at 8am, lead scoring 3x/day, etc.
+      → self-healing: if routine fails, log to activity, surface in doctor panel
+- [ ] Nex integration depth pass:
+      → verify insights → CEO notification → delegation flow is tight
+      → CEO's system prompt references Nex context for decisions
+      → cost dashboard shows Nex-attributed value (e.g., "CEO used Nex context
+        to prioritize lead X, which closed for $Y")
+- [ ] Security gates: outbound action confirmation via requests system
+      → any MCP tool call with external side effects (email, CRM update, deploy)
+        creates a pending request unless explicitly approved in agent's permissions
+
+**Pillar served:** "Migrate in 5 minutes" + "A world model that compounds"
+
+### Week 5: Proof + launch prep
+**Goal: the comparison post is written with real numbers.**
+
+- [ ] Port Opensoul-style stack (6-agent marketing office) to WUPHF
+      → agents: CEO, Strategist, Creative, Producer, Growth, Analyst
+      → tasks: same workload as Opensoul case study
+      → routines: content scan, lead scoring, competitor analysis
+      → Nex: connect Gmail + Calendar + CRM
+- [ ] Run head-to-head benchmark: same 24h workload on WUPHF vs Paperclip
+      → measure: total tokens, cost in dollars, workspace corruptions,
+        fabrication incidents, time-to-first-output
+      → expected result: ~70% fewer tokens, 0 corruptions, 0 fabrication
+- [ ] Write comparison post with real numbers, code, prompts
+      → title: "We ported a Paperclip marketing office to WUPHF. 73% fewer tokens."
+      → structure: setup → what we measured → results → why → try it yourself
+      → include: `curl | sh && wuphf import paperclip` install path
+- [ ] "Switching from Paperclip" doc: what's the same, what's different, what's better
+- [ ] 3 starter packs:
+      → Founding Team (coding): CEO, PM, FE, BE, Designer
+      → Marketing Office (ericosiu-inspired): CEO, Strategist, Content, SEO, Sales
+      → Customer Ops: CEO, Support, Sales, Account Manager
+- [ ] Record 2-minute demo video: import → delegation mode → task completion → cost comparison
+
+### Week 6: Ship
+**Goal: the world knows WUPHF exists.**
+
+- [ ] Publish comparison post
+- [ ] Submit to: HN, Lobsters, r/LocalLLaMA, r/ClaudeAI, r/AI_Agents, r/selfhosted
+- [ ] Post in OpenClaw Discord, Paperclip Discord, relevant Telegram/Slack communities
+- [ ] DM Paperclip users who filed the loudest issues:
+      → #544 (garfieldcoked, Neelkanthsahu02): "we built per-agent MCP scoping"
+      → #3335 (rudyjellis): "workspace isolation is our default, not behind 3 flags"
+      → #3401 (ttomiczek): "we don't burn tokens on empty inboxes"
+      → #1183 (ed2ti): "we cap tool output at 2k tokens + rolling context window"
+- [ ] X/Twitter thread: the ericosiu framework adapted for WUPHF
+      → show: same 5-agent structure, same Single Brain (Nex), but shared office
+- [ ] Hacker News "Show HN" with a different angle than Paperclip used:
+      → not "zero-human company" (polarizing, already used)
+      → try: "Show HN: I built an AI office that costs 70% less to run than Paperclip"
+      → or: "Show HN: Multi-agent Slack where agents collaborate (and your bill drops 70%)"
+
+---
+
+## Part 7: Hard Truths (Updated)
+
+1. **The window is 4-8 weeks.** Paperclip's token optimization and workspace isolation are
+   in their Phase 4 backlog. If they ship before our comparison post, the wedge weakens.
+   Speed > polish.
+2. **"80%" is the ambition, 10-20% is realistic.** ~500-1000 active users switching is still
+   a massive outcome for a solo-founder project. Don't optimize for the number — optimize
+   for making the switch obvious for anyone who hits the pain.
+3. **People switch because of the bill. They stay because of the office.** Delegation mode
+   gets them in the door. Team mode + Nex compounding is why they don't go back.
+4. **The comparison post is the single highest-leverage artifact.** Without it, nobody knows
+   WUPHF exists. Everything in weeks 1-4 exists to make week 5 credible.
+5. **Token discipline is hard.** Paperclip burns tokens because the engineering is genuinely
+   difficult. WUPHF will hit the same problems. The advantage is knowing WHERE the problems
+   are (from reading their issue tracker) before building.
+6. **Nex is the moat, but it's also the dependency.** If Nex integration is buggy or slow,
+   the "world model that compounds" pillar collapses. Nex stability is a prerequisite.
+7. **Month 1 will be terrible for WUPHF users too.** ericosiu was honest about this. Don't
+   overpromise. The messaging should be: "The first week is setup. The second week it starts
+   working. The third week you can't live without it."
+8. **Local inference is the real cost play long-term.** ericosiu cut costs 70% via hardware,
+   not prompt optimization. If WUPHF supports local models via Ollama/llama.cpp (through the
+   adapter interface), that's a second cost-reduction vector beyond token discipline. Defer
+   to post-launch but keep the adapter interface open for it.
+
+---
+
+## Part 9: The ericosiu Signal — Real Production Multi-Agent
+
+Source: ericosiu post "How I built a real marketing team on OpenClaw" (2026-04-12).
+References Jack Dorsey "From Hierarchy to Intelligence" + Karpathy AutoResearch.
+
+### Architecture
+- Mac Mini M4 (32GB) + DGX Spark GB10 (128GB) x2 + Mac Studio Ultra
+- Local inference cut costs ~70%. Hardware pays for itself in weeks.
+- 5 agents: Alfred (CEO/ops), Oracle (SEO), Arrow (Sales), Cyborg (Recruiting), Flash (Content)
+- World Agent above all — organizational brain that coordinates across agents
+- Single Brain: unified vector DB, ingests all company data every 15 minutes
+  (Slack, CRM, Gong, GA4, GSC, docs, meeting notes, financials)
+- 48 daily cron jobs
+- Self-healing cron doctor runs 2x/daily
+
+### Dorsey's four layers mapped
+| Layer | ericosiu | WUPHF | Paperclip |
+|---|---|---|---|
+| Capabilities | OpenClaw + MCP + scripts | MCP + One CLI | Adapters (10 types) |
+| World Model | Single Brain (vector DB) | Nex (knowledge graph) | None |
+| Intelligence | 5 named agents with lanes | Office members with roles | Agents in org tree |
+| Surfaces | Slack cards, email, dashboards | TUI + web + Telegram | React dashboard |
+
+### Design principles (verbatim from post)
+1. "LLMs handle judgment, scripts handle everything else"
+2. "Never instruct twice" — automate on second occurrence
+3. "Security gates on everything" — inbound and outbound scanners
+4. "Self-healing over monitoring" — auto-repair before human notices
+5. "Flat files over databases" — markdown/JSON, no abstraction layer
+6. "The system compounds" — month 1 terrible, month 3 flywheel
+
+### What this means for WUPHF strategy
+1. **Nex is the moat, not the orchestration.** The Single Brain is the competitive
+   advantage that "can't be fast-forwarded." WUPHF + Nex already has this.
+   Paperclip does not.
+2. **Cron-based routines are how real operators run multi-agent.** Not heartbeats,
+   not chat. 48 scheduled jobs. WUPHF needs broker-native routines.
+3. **The target user invests months.** "Month 1 was terrible. Month 3, the flywheel
+   kicked in." WUPHF should shorten month 1, not promise to skip it.
+4. **The product angle**: "Your internal implementation becomes your product."
+   WUPHF packs are this — save your office config, sell it as a template.
+5. **Local inference is the real cost play.** ericosiu cut costs 70% via local
+   hardware, not via prompt optimization. Worth considering for WUPHF's roadmap
+   whether local model support (via Ollama, llama.cpp, etc.) is a priority.
+
+## Part 10: Dorsey's "From Hierarchy to Intelligence" — WUPHF's Blueprint
+
+Source: [Sequoia article](https://sequoiacap.com/article/from-hierarchy-to-intelligence/),
+[Block essay](https://block.xyz/inside/from-hierarchy-to-intelligence). Published 2026-03-31.
+Context: Block cut ~4,000 positions (~40-50% headcount) to implement this.
+
+### The four layers
+1. **Capabilities** — atomic primitives with no UI of their own
+2. **World Model** — dual-sided: company self-understanding + per-customer understanding
+3. **Intelligence Layer** — composes capabilities into proactive solutions
+4. **Interfaces** — delivery surfaces ("not where the value is created")
+
+### The 1:1 mapping to WUPHF
+
+| Dorsey layer | WUPHF implementation |
+|---|---|
+| Capabilities | MCP tools + One CLI + Nex actions (`capability_registry.go`) |
+| Company World Model | Nex knowledge graph + office channel history + task/request state |
+| Customer World Model | Nex entities (contacts, companies, deals) enriched with CRM/email/calendar |
+| Intelligence Layer | CEO agent + broker notification routing + Nex insights |
+| Interfaces | TUI + web view + Telegram bridge |
+| ICs | Specialist agents (FE, BE, Designer, PM, etc.) |
+| DRIs | Task owners — agents assigned to cross-cutting outcomes |
+| Player-Coaches | CEO agent — builds + coordinates |
+
+### Key strategic implications from Dorsey
+- **"The value is in the model and the intelligence, not the interfaces."** — Reorders
+  WUPHF priorities: Nex depth (Layer 2) > CEO routing intelligence (Layer 3) > web polish
+  (Layer 4). Most of this session was spent on Layer 4. Should shift.
+- **"Customer reality generates the backlog directly."** — When the CEO agent can't handle
+  a Nex notification because no specialist has the right capability, that failure IS the
+  roadmap. Log these capability gaps; they tell you what agents/skills to build next.
+- **"AI doesn't augment your company. It reveals what your company actually is."** — WUPHF's
+  role is to make the intelligence visible, not to pretty up the dashboard.
+
+## Part 11: Karpathy's AutoResearch — The Loop Pattern for WUPHF
+
+Source: [github.com/karpathy/autoresearch](https://github.com/karpathy/autoresearch). 21k
+stars, 8.6M views. Released 2026-03-07.
+
+### The core loop
+```
+human writes program.md (research direction)
+→ agent modifies code
+→ train 5 min (fixed time budget)
+→ evaluate val_bpb (single metric)
+→ improved? → commit and keep
+→ not improved? → revert
+→ repeat
+```
+
+### WUPHF equivalent
+```
+founder writes pack config (office direction)
+→ routine fires (scheduled)
+→ agent executes (MCP tools, emails, CRM updates)
+→ evaluate outcome (Nex insights: pipeline value, response rate, etc.)
+→ worked? → save-as-skill, repeat
+→ didn't work? → log failure, try different approach
+→ repeat
+```
+
+Karpathy's vision: "not to emulate a single PhD student, it's to emulate a research
+community." That's WUPHF's shared office — agents share findings in channels, build on
+each other's discoveries. Paperclip's isolated task model can't do this.
+
+ericosiu's "AutoGrowth" is this pattern applied to marketing: "Arrow tests different
+subject lines. After four weeks, questions outperformed statements by 2.3x. That insight
+got applied automatically." WUPHF routines should be AutoResearch loops.
+
+## Part 12: The Personal Agent Model — Why WUPHF's Shared Office Wins
+
+ericosiu's NemoClaw rollout: each team member gets their own isolated agent. N people =
+N agents. They share data through the Single Brain but don't see each other's work.
+
+WUPHF's model: the whole team shares ONE office. Shared channels for team context. Private
+DMs (1:1 mode) for personal conversations. Any team member can DM any agent directly.
+
+### Why shared office beats isolated personal agents
+1. **Cross-pollination** — Alice's sales question in #sales gets seen by Oracle (SEO), who
+   surfaces a relevant content piece. In ericosiu's model, that only happens through the
+   Single Brain if someone wrote it down. In WUPHF, it happens in real-time.
+2. **Onboarding** — new person scrolls back, sees how the team works. Isolated agents start
+   blank.
+3. **No routing bottleneck** — coordination happens via shared channels, not through a
+   central World Agent. No single point of failure.
+4. **Privacy when needed** — 1:1 DM mode (PR #25, `/1o1`). Personal stays private, team
+   stays shared.
+5. **One world model** — all agents share the same Nex knowledge graph. Not N copies.
+6. **Fewer agents** — one Arrow serves 5 salespeople. Cheaper and smarter than 5 isolated
+   Arrows that can't see each other's work.
+
+### The pitch
+"ericosiu gives each person a private agent. WUPHF gives the whole team a shared office
+where every agent works for everyone — and you can DM any of them privately. One Arrow
+serving 5 people is cheaper and smarter than 5 Arrows that can't see each other."
+
+## Part 8: Open Questions
+
+1. Should WUPHF support Paperclip's company templates as an import format? (Would expand
+   the "import your existing setup" pitch to template-only users too.)
+2. Does the email-postmortem code path stay as-is, or get stripped to a minimal pack spec?
+3. What's the right channel context budget per agent turn? (Need to benchmark.)
+4. Should the comparison post target Opensoul (marketing) or a coding workflow? Marketing
+   is more accessible; coding is where the founder's expertise is.
+5. Is Windows binary support worth the effort for v1, or Mac/Linux only?
+6. Does WUPHF need Docker, or is the Go binary + JSON state file sufficient?
+
+---
+
+## References
+
+### Paperclip source (cloned locally)
+- `packages/adapter-utils/src/types.ts:292-331` — ServerAdapterModule interface
+- `server/src/adapters/registry.ts:207-222` — 10 built-in adapters
+- `server/src/services/heartbeat.ts` — 4,533-line runtime engine
+- `server/src/services/activity-log.ts` — 94-line logActivity invariant
+- `server/src/services/budgets.ts:716-830` — layered budget enforcement
+- `packages/db/src/schema/heartbeat_runs.ts` — run lifecycle schema
+- `packages/db/src/schema/cost_events.ts` — 5-dimensional cost tracking
+- `packages/db/src/schema/issues.ts` — 94-line issue schema with atomic checkout
+- `ui/src/components/Layout.tsx` — 486-line responsive single layout
+- `ui/src/components/IssueChatThread.tsx` — 2,007-line chat surface
+- `ui/src/components/PropertiesPanel.tsx` — 29-line render slot
+- `doc/SPEC-implementation.md:38` — "Tasks + comments only (no separate chat system)"
+
+### GitHub issues cited
+- [#544](https://github.com/paperclipai/paperclip/issues/544) — 10x token consumption, 3 hidden killers
+- [#1183](https://github.com/paperclipai/paperclip/issues/1183) — context window management proposal
+- [#1348](https://github.com/paperclipai/paperclip/issues/1348) — archived companies burn tokens
+- [#1756](https://github.com/paperclipai/paperclip/issues/1756) — token-based budgets needed
+- [#2101](https://github.com/paperclipai/paperclip/issues/2101) — retry after rate limits
+- [#3335](https://github.com/paperclipai/paperclip/issues/3335) — workspace isolation not default (222 workspaces, 1 cwd)
+- [#3338](https://github.com/paperclipai/paperclip/issues/3338) — session tokens in plaintext
+- [#3352](https://github.com/paperclipai/paperclip/issues/3352) — can't delete agents (FK violations)
+- [#3401](https://github.com/paperclipai/paperclip/issues/3401) — heartbeat burns tokens learning nothing
+- [#3402](https://github.com/paperclipai/paperclip/issues/3402) — token burn despite best practices
+- [#3406](https://github.com/paperclipai/paperclip/issues/3406) — subscription-aware budgets
+- [#3407](https://github.com/paperclipai/paperclip/issues/3407) — routine dispatch duplicate key
+
+### External reviews and articles
+- [Towards AI explainer](https://pub.towardsai.net/paperclip-the-open-source-operating-system-for-zero-human-companies-2c16f3f22182)
+- [4th Path review — 8.7/10](https://www.the4thpath.com/2026/03/paperclip-ai-review-if-agents-are.html)
+- [vibecoding.app review](https://vibecoding.app/blog/paperclip-review)
+- [Effloow 14-agent case study](https://dev.to/jangwook_kim_e31e7291ad98/how-we-built-a-company-powered-by-14-ai-agents-using-paperclip-4bg6)
+- [HN: noduerme multi-agent wrangling](https://news.ycombinator.com/item?id=47422091)
+- [HN: Opensoul marketing stack](https://news.ycombinator.com/item?id=47336615)
+
+### WUPHF prior docs
+- `docs/competitive-analysis-multi-agent-projects.md` — WUPHF's own positioning
+- `docs/plans/2026-04-11-paperclip-vs-wuphf-grounded.md` — grounded technical comparison
+- `~/.gstack/projects/nex-crm-wuphf/najmuzzaman-nazz-email-postmortem-design-20260401-153916.md` — April 1 approved design (now killed in hybrid form)

--- a/internal/team/session_mode.go
+++ b/internal/team/session_mode.go
@@ -11,7 +11,7 @@ const (
 
 func NormalizeSessionMode(mode string) string {
 	switch strings.ToLower(strings.TrimSpace(mode)) {
-	case SessionModeOneOnOne, "one-on-one", "one_on_one", "1on1", "solo":
+	case SessionModeOneOnOne, "1:1", "one-on-one", "one_on_one", "1on1", "solo":
 		return SessionModeOneOnOne
 	default:
 		return SessionModeOffice

--- a/internal/team/session_mode_test.go
+++ b/internal/team/session_mode_test.go
@@ -1,0 +1,24 @@
+package team
+
+import "testing"
+
+func TestNormalizeSessionMode(t *testing.T) {
+	cases := map[string]string{
+		"1o1":         SessionModeOneOnOne,
+		"1:1":         SessionModeOneOnOne,
+		"one-on-one":  SessionModeOneOnOne,
+		"one_on_one":  SessionModeOneOnOne,
+		"1on1":        SessionModeOneOnOne,
+		"solo":        SessionModeOneOnOne,
+		"  1:1  ":     SessionModeOneOnOne,
+		"1:1 ":        SessionModeOneOnOne,
+		"office":      SessionModeOffice,
+		"":            SessionModeOffice,
+		"nonsense":    SessionModeOffice,
+	}
+	for in, want := range cases {
+		if got := NormalizeSessionMode(in); got != want {
+			t.Errorf("NormalizeSessionMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/web/index.html
+++ b/web/index.html
@@ -789,19 +789,8 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 .pixel-avatar-panel { width: 56px; height: 56px; }
 
 /* ─── Inbox/Outbox DM Lanes ─── */
-.dm-lanes { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; flex: 1; overflow: hidden; padding: 16px 20px; }
-.dm-lane { display: flex; flex-direction: column; overflow-y: auto; gap: 12px; }
-.dm-lane-header { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-tertiary); padding-bottom: 8px; border-bottom: 2px solid var(--border); display: flex; align-items: center; gap: 6px; }
-.dm-lane-empty { text-align: center; padding: 20px; color: var(--text-tertiary); font-size: 13px; }
 
 /* ─── Execution Timeline (#78) ─── */
-.exec-timeline { margin-top: 12px; }
-.exec-timeline-title { font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-tertiary); margin-bottom: 6px; }
-.exec-timeline-item { display: flex; align-items: center; gap: 8px; padding: 4px 0; font-size: 12px; color: var(--text-secondary); border-bottom: 1px solid var(--border-light); }
-.exec-timeline-item:last-child { border-bottom: none; }
-.exec-timeline-time { font-family: var(--font-mono); font-size: 10px; color: var(--text-tertiary); min-width: 52px; flex-shrink: 0; }
-.exec-timeline-agent { font-size: 14px; flex-shrink: 0; }
-.exec-timeline-summary { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
 /* ─── Wait State (#79) ─── */
 @keyframes wait-pulse { 0%, 100% { opacity: 0.5; } 50% { opacity: 1; } }
@@ -1207,16 +1196,7 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
         </button>
       </div>
       <div class="messages" id="messages"></div>
-      <div class="dm-lanes" id="dm-lanes" style="display:none;">
-        <div class="dm-lane">
-          <div class="dm-lane-header">Inbox (from agent)</div>
-          <div id="dm-inbox" style="display:flex;flex-direction:column;gap:12px;overflow-y:auto;flex:1;"></div>
-        </div>
-        <div class="dm-lane">
-          <div class="dm-lane-header">Outbox (from you)</div>
-          <div id="dm-outbox" style="display:flex;flex-direction:column;gap:12px;overflow-y:auto;flex:1;"></div>
-        </div>
-      </div>
+      <div class="messages" id="dm-messages" style="display:none;"></div>
       <div class="app-panel" id="app-tasks"></div>
       <div class="app-panel" id="app-requests"></div>
       <div class="app-panel" id="app-policies"></div>
@@ -2751,47 +2731,6 @@ function renderLiveWork() {
   }
 }
 
-// ─── Execution Timeline (#78) ───
-function renderExecutionTimeline() {
-  var section = document.getElementById('live-work-section');
-  if (!section) return;
-  var existing = section.querySelector('.exec-timeline');
-  if (existing) existing.remove();
-
-  WuphfAPI.getActions().catch(function() { return { actions: [] }; }).then(function(resp) {
-    var actions = resp.actions || resp || [];
-    if (!Array.isArray(actions) || actions.length === 0) return;
-    var recent = actions.slice(-8).reverse();
-    var timeline = document.createElement('div');
-    timeline.className = 'exec-timeline';
-    var title = document.createElement('div');
-    title.className = 'exec-timeline-title';
-    title.textContent = 'Recent actions';
-    timeline.appendChild(title);
-    recent.forEach(function(action) {
-      var item = document.createElement('div');
-      item.className = 'exec-timeline-item';
-      var timeEl = document.createElement('span');
-      timeEl.className = 'exec-timeline-time';
-      if (action.timestamp || action.created_at || action.time) {
-        var d = new Date(action.timestamp || action.created_at || action.time);
-        timeEl.textContent = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-      }
-      item.appendChild(timeEl);
-      var agentEmoji = document.createElement('span');
-      agentEmoji.className = 'exec-timeline-agent';
-      var agent = AGENTS.find(function(a) { return a.slug === (action.agent || action.from || action.owner); });
-      agentEmoji.textContent = agent ? agent.emoji : '\u2699';
-      item.appendChild(agentEmoji);
-      var summary = document.createElement('span');
-      summary.className = 'exec-timeline-summary';
-      summary.textContent = action.summary || action.description || action.action || action.type || '';
-      item.appendChild(summary);
-      timeline.appendChild(item);
-    });
-    section.appendChild(timeline);
-  });
-}
 
 function renderSidebarChannels() {
   var container = document.getElementById('sidebar-channels');
@@ -3199,19 +3138,16 @@ function appendBrokerMessage(msg) {
 
   var container = document.getElementById('messages');
 
-  // In DM mode, route messages to inbox/outbox lanes
+  // In DM mode, route messages to the DM thread
   if (dmModeActive && dmAgent) {
     var isFromAgent = msg.from === dmAgent.slug;
     var isFromHuman = msg.from === 'you' || msg.from === 'human';
-    if (isFromAgent) {
-      appendMessageToContainer(msg, document.getElementById('dm-inbox'));
-      var inbox = document.getElementById('dm-inbox');
-      inbox.scrollTop = inbox.scrollHeight;
-    } else if (isFromHuman) {
-      appendMessageToContainer(msg, document.getElementById('dm-outbox'));
-      var outbox = document.getElementById('dm-outbox');
-      outbox.scrollTop = outbox.scrollHeight;
+    if (isFromAgent || isFromHuman) {
+      var dmMessages = document.getElementById('dm-messages');
+      appendMessageToContainer(msg, dmMessages);
+      dmMessages.scrollTop = dmMessages.scrollHeight;
     }
+    return;
   }
 
   // Insert date separator if day changed
@@ -3717,7 +3653,6 @@ function fetchMemberActivity() {
     cachedTasks = (results[1].tasks || results[1] || []);
     if (Array.isArray(cachedTasks) === false) cachedTasks = [];
     refreshLiveActivityUI();
-    renderExecutionTimeline();
   });
 }
 
@@ -4332,8 +4267,7 @@ function handleSlashCommand(input) {
           onConfirm: function() {
             WuphfAPI.post('/reset-dm', { agent: resetAgent.slug })
               .then(function() {
-                document.getElementById('dm-inbox').textContent = '';
-                document.getElementById('dm-outbox').textContent = '';
+                document.getElementById('dm-messages').textContent = '';
                 showNotice('1:1 session reset', 'success');
                 showSystem('DM session with ' + resetAgent.name + ' cleared');
               })
@@ -5512,11 +5446,11 @@ function enterDMMode(agentSlug) {
   // Update composer placeholder
   document.getElementById('composer-input').placeholder = 'Message ' + agent.name + ' directly...';
 
-  // Show DM lanes, hide regular messages
+  // Show DM thread, hide regular messages
   document.getElementById('messages').style.display = 'none';
-  document.getElementById('dm-lanes').style.display = 'grid';
-  document.getElementById('dm-inbox').textContent = '';
-  document.getElementById('dm-outbox').textContent = '';
+  var dmMessages = document.getElementById('dm-messages');
+  dmMessages.textContent = '';
+  dmMessages.style.display = '';
   lastMessageId = null;
 
   // Try to switch mode via broker
@@ -5534,8 +5468,8 @@ function exitDMMode() {
   dmModeActive = false;
   dmAgent = null;
 
-  // Hide DM lanes, show regular messages
-  document.getElementById('dm-lanes').style.display = 'none';
+  // Hide DM thread, show regular messages
+  document.getElementById('dm-messages').style.display = 'none';
   document.getElementById('messages').style.display = '';
 
   // Hide DM banner


### PR DESCRIPTION
## Summary
- Fix 1:1 mode normalization (web sends "1:1", broker now accepts it)
- Replace inbox/outbox DM with simple chat thread
- Remove dead execution timeline / recent actions UI
- Add Paperclip comparison + strategy docs

## Test plan
- [x] `go test ./internal/team/...` passes
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)