### PR TITLE
feat: Slack-style DM nav — sidebar stays, DM is a channel

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -659,10 +659,6 @@ type channelModel struct {
 	telegramGroups []team.TelegramGroup
 	telegramToken  string
 
-	// Inline DM — office stays active, no session mode switch.
-	dmTargetSlug string
-	dmTargetName string
-
 	// lastAgentContent tracks the latest streaming text per agent for sidebar display.
 	lastAgentContent map[string]string
 }
@@ -969,12 +965,13 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		case "ctrl+d":
-			// Close inline DM (Ctrl+D toggles the DM target).
-			if m.dmTargetSlug != "" {
-				prevName := m.dmTargetName
-				m.dmTargetSlug = ""
-				m.dmTargetName = ""
-				m.notice = fmt.Sprintf("DM with %s closed — back to office.", prevName)
+			// Return to #general from a DM channel.
+			if strings.HasPrefix(m.activeChannel, "dm-") {
+				m.activeChannel = "general"
+				m.lastID = ""
+				m.messages = nil
+				m.notice = "Back to #general"
+				return m, pollBroker("", m.activeChannel)
 			}
 			return m, nil
 		}
@@ -1212,12 +1209,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.inputPos = 0
 				m.notice = ""
 				m.posting = true
-				// When inline DM is active, target the message directly at that agent.
-				postText := text
-				if m.dmTargetSlug != "" && !strings.HasPrefix(text, "@"+m.dmTargetSlug) {
-					postText = "@" + m.dmTargetSlug + " " + text
-				}
-				return m, postToChannel(postText, m.replyToID, m.activeChannel)
+				return m, postToChannel(text, m.replyToID, m.activeChannel)
 			}
 			if m.pending != nil {
 				if opt := m.selectedInterviewOption(); opt != nil {
@@ -2972,8 +2964,9 @@ func (m channelModel) composerTargetLabel() string {
 	if m.isOneOnOne() {
 		return "1:1 with " + m.oneOnOneAgentName()
 	}
-	if m.dmTargetSlug != "" {
-		return "DM→" + m.dmTargetName
+	if strings.HasPrefix(m.activeChannel, "dm-") {
+		slug := strings.TrimPrefix(m.activeChannel, "dm-")
+		return "DM→" + slug
 	}
 	return m.activeChannel
 }
@@ -3244,8 +3237,8 @@ func (m channelModel) updateSidebar(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, m.selectSidebarItem(items[m.sidebarCursor])
 	case "d":
-		// Open inline DM with the agent visible at current roster scroll position.
-		// Office stays active — no session mode switch.
+		// Switch the main channel view to the per-agent DM channel.
+		// The office continues running; this is just a channel switch.
 		roster := mergeOfficeMembers(m.officeMembers, m.members, m.currentChannelInfo())
 		if len(roster) > 0 {
 			idx := m.sidebarRosterOffset
@@ -3256,13 +3249,15 @@ func (m channelModel) updateSidebar(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				idx = len(roster) - 1
 			}
 			target := roster[idx]
-			m.dmTargetSlug = target.Slug
-			m.dmTargetName = target.Name
-			if m.dmTargetName == "" {
-				m.dmTargetName = target.Slug
+			name := target.Name
+			if name == "" {
+				name = target.Slug
 			}
+			m.activeChannel = "dm-" + target.Slug
 			m.focus = focusMain
-			m.notice = fmt.Sprintf("DM open with %s — Ctrl+D to close, office stays active", m.dmTargetName)
+			m.lastID = ""
+			m.messages = nil
+			m.notice = fmt.Sprintf("DM with %s — Ctrl+D to return to #general", name)
 		}
 	}
 	return m, nil

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -26,6 +26,52 @@ const brokerTokenFile = "/tmp/wuphf-broker-token"
 
 var brokerStatePath = defaultBrokerStatePath
 
+// agentStreamBuffer holds recent stdout/stderr lines from a headless agent
+// process and fans them out to SSE subscribers in real time.
+type agentStreamBuffer struct {
+	mu     sync.Mutex
+	lines  []string
+	subs   map[int]chan string
+	nextID int
+}
+
+func (s *agentStreamBuffer) Push(line string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lines = append(s.lines, line)
+	if len(s.lines) > 2000 {
+		s.lines = s.lines[len(s.lines)-2000:]
+	}
+	for _, ch := range s.subs {
+		select {
+		case ch <- line:
+		default:
+		}
+	}
+}
+
+func (s *agentStreamBuffer) subscribe() (<-chan string, func()) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	id := s.nextID
+	s.nextID++
+	ch := make(chan string, 128)
+	s.subs[id] = ch
+	return ch, func() {
+		s.mu.Lock()
+		delete(s.subs, id)
+		s.mu.Unlock()
+	}
+}
+
+func (s *agentStreamBuffer) recent() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]string, len(s.lines))
+	copy(out, s.lines)
+	return out
+}
+
 type messageReaction struct {
 	Emoji string `json:"emoji"`
 	From  string `json:"from"`
@@ -332,6 +378,7 @@ type Broker struct {
 	activity            map[string]agentActivitySnapshot
 	activitySubscribers map[int]chan agentActivitySnapshot
 	nextSubscriberID    int
+	agentStreams        map[string]*agentStreamBuffer
 	mu                  sync.Mutex
 	server              *http.Server
 	token               string   // shared secret for authenticating requests
@@ -397,6 +444,22 @@ func generateToken() string {
 	return hex.EncodeToString(b)
 }
 
+// AgentStream returns (or lazily creates) the stream buffer for a given agent slug.
+// It is safe to call concurrently.
+func (b *Broker) AgentStream(slug string) *agentStreamBuffer {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.agentStreams == nil {
+		b.agentStreams = make(map[string]*agentStreamBuffer)
+	}
+	s, ok := b.agentStreams[slug]
+	if !ok {
+		s = &agentStreamBuffer{subs: make(map[int]chan string)}
+		b.agentStreams[slug] = s
+	}
+	return s
+}
+
 // NewBroker creates a new channel broker with a random auth token.
 func NewBroker() *Broker {
 	b := &Broker{
@@ -405,6 +468,7 @@ func NewBroker() *Broker {
 		actionSubscribers:   make(map[int]chan officeActionLog),
 		activity:            make(map[string]agentActivitySnapshot),
 		activitySubscribers: make(map[int]chan agentActivitySnapshot),
+		agentStreams:        make(map[string]*agentStreamBuffer),
 	}
 	_ = b.loadState()
 	b.mu.Lock()
@@ -619,6 +683,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/queue", b.requireAuth(b.handleQueue))
 	mux.HandleFunc("/v1/logs", b.requireAuth(b.handleOTLPLogs))
 	mux.HandleFunc("/events", b.handleEvents)
+	mux.HandleFunc("/agent-stream/", b.requireAuth(b.handleAgentStream))
 	mux.HandleFunc("/web-token", b.handleWebToken)
 
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
@@ -763,6 +828,62 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 			if !ok || writeEvent("activity", map[string]any{"activity": snapshot}) != nil {
 				return
 			}
+		case <-heartbeat.C:
+			if _, err := fmt.Fprintf(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// handleAgentStream serves a per-agent stdout SSE stream.
+// Recent lines are replayed as initial history, then new lines are pushed live.
+// Path: /agent-stream/{slug}
+func (b *Broker) handleAgentStream(w http.ResponseWriter, r *http.Request) {
+	slug := strings.TrimPrefix(r.URL.Path, "/agent-stream/")
+	if slug == "" {
+		http.Error(w, "missing agent slug", http.StatusBadRequest)
+		return
+	}
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	stream := b.AgentStream(slug)
+
+	// Replay recent history so the client sees context immediately.
+	for _, line := range stream.recent() {
+		if _, err := fmt.Fprintf(w, "data: %s\n\n", line); err != nil {
+			return
+		}
+	}
+	flusher.Flush()
+
+	lines, unsubscribe := stream.subscribe()
+	defer unsubscribe()
+
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case line, ok := <-lines:
+			if !ok {
+				return
+			}
+			if _, err := fmt.Fprintf(w, "data: %s\n\n", line); err != nil {
+				return
+			}
+			flusher.Flush()
 		case <-heartbeat.C:
 			if _, err := fmt.Fprintf(w, ": ping\n\n"); err != nil {
 				return

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -10,9 +10,11 @@
 package team
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -2986,12 +2988,26 @@ func (l *Launcher) runBackgroundAgent(slug, cmdStr string) {
 		cmd := exec.Command("bash", "-c", cmdStr)
 		cmd.Dir = l.cwd
 		cmd.Env = append(os.Environ(), fmt.Sprintf("WUPHF_BROKER_TOKEN=%s", l.broker.Token()))
-		cmd.Stdout = logFile
-		cmd.Stderr = logFile
 		cmd.Stdin = nil
+
+		// Fan-out stdout+stderr to the log file AND the broker's per-agent
+		// stream buffer so the web UI can tail it in real time via SSE.
+		pr, pw := io.Pipe()
+		cmd.Stdout = io.MultiWriter(logFile, pw)
+		cmd.Stderr = io.MultiWriter(logFile, pw)
+
+		stream := l.broker.AgentStream(slug)
+		go func() {
+			scanner := bufio.NewScanner(pr)
+			scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+			for scanner.Scan() {
+				stream.Push(scanner.Text())
+			}
+		}()
 
 		fmt.Fprintf(os.Stderr, "[%s] agent starting (log: %s)\n", slug, logPath)
 		runErr := cmd.Run()
+		pw.Close() // signals scanner goroutine to exit
 		logFile.Close()
 
 		if runErr != nil {

--- a/web/index.html
+++ b/web/index.html
@@ -859,37 +859,22 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 .runtime-strip.paused { border-bottom-color: var(--red); box-shadow: inset 0 -2px 0 var(--red); }
 .runtime-paused-pill { background: var(--red-bg); color: var(--red); font-weight: 600; padding: 2px 8px; border-radius: var(--radius-full); font-size: 10px; animation: pulse-dot 1.5s ease-in-out infinite; }
 
-/* ─── Full-window agent DM view (Slack-style) ─── */
-.dm-view { display: none; flex: 1; flex-direction: column; height: 100vh; overflow: hidden; background: var(--bg); }
-.dm-view.active { display: flex; }
-.dm-view-header { display: flex; align-items: center; justify-content: space-between; padding: 0 20px; height: 52px; min-height: 52px; border-bottom: 1px solid var(--border); background: var(--bg-card); flex-shrink: 0; }
-.dm-view-agent { display: flex; align-items: center; gap: 10px; }
-.dm-view-avatar { width: 30px; height: 30px; border-radius: 50%; background: var(--accent-bg); display: flex; align-items: center; justify-content: center; font-size: 14px; flex-shrink: 0; }
-.dm-view-name { font-size: 15px; font-weight: 700; color: var(--text); }
-.dm-view-status { font-size: 11px; color: var(--text-tertiary); }
-.dm-view-close { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-secondary); background: transparent; border: 1px solid var(--border); border-radius: var(--radius-md); padding: 4px 10px; cursor: pointer; transition: all 0.15s; }
-.dm-view-close:hover { background: var(--bg); color: var(--text); }
-.dm-view-body { display: flex; flex: 1; overflow: hidden; flex-direction: column; }
-/* Stream pane — live agent stdout */
-.dm-stream-pane { flex: 1; min-height: 0; display: flex; flex-direction: column; border-bottom: 2px solid var(--border); overflow: hidden; }
-.dm-stream-header { display: flex; align-items: center; gap: 8px; padding: 6px 16px; background: #1a1a1a; border-bottom: 1px solid #333; flex-shrink: 0; }
-.dm-stream-title { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: #888; font-family: var(--font-mono); }
+/* ─── Agent stdout stream strip (inside .main, shown on dm-* channels) ─── */
+#dm-stream-strip { flex-shrink: 0; border-bottom: 1px solid var(--border); max-height: 260px; display: flex; flex-direction: column; }
+.dm-stream-header { display: flex; align-items: center; gap: 8px; padding: 5px 20px; background: #1a1a1a; border-bottom: 1px solid #2a2a2a; flex-shrink: 0; }
+.dm-stream-title { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: #888; font-family: var(--font-mono); flex: 1; }
 .dm-stream-dot { width: 6px; height: 6px; border-radius: 50%; background: #22c55e; animation: pulse-dot 1.5s ease-in-out infinite; flex-shrink: 0; }
 .dm-stream-dot.idle { background: #555; animation: none; }
-.dm-stream-lines { flex: 1; overflow-y: auto; padding: 8px 16px; background: #1a1a1a; font-family: var(--font-mono); font-size: 12px; line-height: 1.55; color: #d4d4d4; }
+.dm-stream-toggle { background: transparent; border: none; color: #555; cursor: pointer; font-size: 12px; padding: 0 2px; line-height: 1; }
+.dm-stream-toggle:hover { color: #aaa; }
+#dm-stream-strip.collapsed .dm-stream-lines { display: none; }
+#dm-stream-strip.collapsed { max-height: none; }
+.dm-stream-lines { flex: 1; overflow-y: auto; padding: 6px 20px 8px; background: #1a1a1a; font-family: var(--font-mono); font-size: 12px; line-height: 1.5; color: #d4d4d4; }
 .dm-stream-line { white-space: pre-wrap; word-break: break-all; padding: 1px 0; }
 .dm-stream-line.thinking { color: #888; font-style: italic; }
 .dm-stream-line.tool { color: #60a5fa; }
 .dm-stream-line.result { color: #86efac; }
-.dm-stream-empty { color: #555; font-style: italic; font-size: 11px; padding: 12px 0; }
-/* Conversation pane */
-.dm-convo-pane { display: flex; flex-direction: column; max-height: 45%; min-height: 120px; overflow: hidden; flex-shrink: 0; }
-.dm-convo-messages { flex: 1; overflow-y: auto; padding: 12px 20px; display: flex; flex-direction: column; gap: 8px; }
-/* Composer */
-.dm-composer { padding: 8px 16px 12px; border-top: 1px solid var(--border); background: var(--bg-card); flex-shrink: 0; }
-.dm-composer-inner { display: flex; align-items: flex-end; gap: 8px; }
-.dm-composer-input { flex: 1; border: 1px solid var(--border); border-radius: var(--radius-md); padding: 8px 12px; font-family: var(--font-sans); font-size: 13px; color: var(--text); background: var(--bg); outline: none; resize: none; line-height: 1.4; transition: border-color 0.2s; }
-.dm-composer-input:focus { border-color: var(--accent); }
+.dm-stream-empty { color: #555; font-style: italic; }
 /* DM button on sidebar agent rows */
 .sidebar-agent-dm-btn { font-size: 9px; font-weight: 600; opacity: 0; padding: 1px 5px; border: 1px solid var(--border); border-radius: 3px; background: transparent; color: var(--text-tertiary); cursor: pointer; margin-left: auto; transition: all 0.12s; font-family: var(--font-sans); text-transform: uppercase; letter-spacing: 0.04em; flex-shrink: 0; }
 .sidebar-agent:hover .sidebar-agent-dm-btn { opacity: 1; }
@@ -1179,6 +1164,10 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
       </div>
       <div class="sidebar-channels" id="sidebar-channels"></div>
       <div class="sidebar-section" style="margin-top:4px;border-top:1px solid var(--border);padding-top:8px;">
+        <p class="sidebar-section-title">Direct messages</p>
+      </div>
+      <div class="sidebar-channels" id="sidebar-dms"></div>
+      <div class="sidebar-section" style="margin-top:4px;border-top:1px solid var(--border);padding-top:8px;">
         <p class="sidebar-section-title">Apps</p>
       </div>
       <div class="sidebar-channels" id="sidebar-apps"></div>
@@ -1216,6 +1205,15 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
           Back to office
         </button>
+      </div>
+      <!-- Agent stdout stream strip — shown when currentChannel is dm-* -->
+      <div id="dm-stream-strip" style="display:none;">
+        <div class="dm-stream-header">
+          <span class="dm-stream-dot idle" id="dm-stream-dot"></span>
+          <span class="dm-stream-title" id="dm-stream-title">Live output</span>
+          <button class="dm-stream-toggle" id="dm-stream-toggle" aria-label="Toggle stream" onclick="toggleDMStream()">&#x25B4;</button>
+        </div>
+        <div class="dm-stream-lines" id="dm-stream-lines"></div>
       </div>
       <div class="messages" id="messages"></div>
       <div class="messages" id="dm-messages" style="display:none;"></div>
@@ -1273,48 +1271,6 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
         </div>
       </div>
     </aside>
-
-    <!-- Full-window agent DM view (replaces main panel, sidebar stays) -->
-    <div class="dm-view" id="dm-view" role="region" aria-label="Direct message">
-      <div class="dm-view-header">
-        <div class="dm-view-agent">
-          <div class="dm-view-avatar" id="dm-view-avatar">?</div>
-          <div>
-            <div class="dm-view-name" id="dm-view-name">Agent</div>
-            <div class="dm-view-status" id="dm-view-status">active</div>
-          </div>
-        </div>
-        <button class="dm-view-close" onclick="closeAgentDM()" aria-label="Back to office">
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
-          Back to office
-        </button>
-      </div>
-      <div class="dm-view-body">
-        <!-- Live stream pane -->
-        <div class="dm-stream-pane">
-          <div class="dm-stream-header">
-            <span class="dm-stream-dot" id="dm-stream-dot"></span>
-            <span class="dm-stream-title">Live output</span>
-          </div>
-          <div class="dm-stream-lines" id="dm-stream-lines">
-            <div class="dm-stream-empty">Waiting for agent output&hellip;</div>
-          </div>
-        </div>
-        <!-- Conversation pane -->
-        <div class="dm-convo-pane">
-          <div class="dm-convo-messages" id="dm-convo-messages"></div>
-        </div>
-      </div>
-      <!-- Composer -->
-      <div class="dm-composer">
-        <div class="dm-composer-inner">
-          <textarea class="dm-composer-input" id="dm-composer-input" aria-label="Message agent directly" rows="1" placeholder="Message agent…"></textarea>
-          <button class="composer-send" id="dm-composer-send" aria-label="Send direct message" disabled>
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4z"/><path d="m22 2-10 10"/></svg>
-          </button>
-        </div>
-      </div>
-    </div>
 
     <!-- Agent Panel -->
     <aside class="agent-panel" id="agent-panel">
@@ -2032,6 +1988,7 @@ function showOffice() {
           });
         }
         renderSidebarAgents();
+        renderSidebarDMs();
         renderSidebarChannels();
         renderSidebarApps();
         startMessagePolling();
@@ -2040,12 +1997,14 @@ function showOffice() {
       })
       .catch(function() {
         renderSidebarAgents();
+        renderSidebarDMs();
         renderSidebarChannels();
         renderSidebarApps();
         animateMessages();
       });
   } else {
     renderSidebarAgents();
+    renderSidebarDMs();
     renderSidebarChannels();
     renderSidebarApps();
     animateMessages();
@@ -2102,6 +2061,7 @@ function normalizeMemberActivityHints(members) {
 
 function refreshLiveActivityUI() {
   renderSidebarAgents();
+  renderSidebarDMs();
   renderWorkspaceSummary();
   renderRuntimeStrip();
   renderLiveWork();
@@ -2207,7 +2167,7 @@ function renderSidebarAgents() {
     dmBtn.title = 'Open direct channel with ' + a.name;
     dmBtn.addEventListener('click', function(e) {
       e.stopPropagation(); // don't open agent panel
-      openAgentDM(a.slug);
+      switchChannel('dm-' + a.slug);
     });
     btn.appendChild(avatarEl);
     btn.appendChild(wrap);
@@ -2863,7 +2823,14 @@ function switchChannel(name) {
   if (lastMessageId) {
     localStorage.setItem('wuphf_last_seen_msg_' + currentChannel, lastMessageId);
   }
+  // DM channel enter/leave hooks (Slack-style)
+  var prevChannel = currentChannel;
   currentChannel = name;
+  if (name.indexOf('dm-') === 0) {
+    onDMChannelEnter(name.slice(3));
+  } else if (prevChannel && prevChannel.indexOf('dm-') === 0) {
+    onDMChannelLeave();
+  }
   lastMessageId = null;
   // Reset unread/grouping/date state for new channel
   lastSeenMessageId = localStorage.getItem('wuphf_last_seen_msg_' + name) || null;
@@ -2875,9 +2842,17 @@ function switchChannel(name) {
   lastRenderedDate = null;
   document.getElementById('messages').textContent = '';
   var ch = CHANNELS.find(function(c) { return c.name === name; });
-  document.getElementById('channel-title').textContent = '# ' + name;
-  document.getElementById('channel-desc').textContent = ch ? ch.desc : '';
-  document.getElementById('composer-input').placeholder = 'Message #' + name + ' \u2014 type / for commands, @ to mention';
+  if (name.indexOf('dm-') === 0) {
+    var dmSlug = name.slice(3);
+    var dmAgent = AGENTS.find(function(a) { return a.slug === dmSlug; });
+    document.getElementById('channel-title').textContent = (dmAgent ? dmAgent.name : dmSlug);
+    document.getElementById('channel-desc').textContent = dmAgent ? (dmAgent.role || '') : '';
+    document.getElementById('composer-input').placeholder = 'Message ' + (dmAgent ? dmAgent.name : dmSlug) + '\u2026';
+  } else {
+    document.getElementById('channel-title').textContent = '# ' + name;
+    document.getElementById('channel-desc').textContent = ch ? ch.desc : '';
+    document.getElementById('composer-input').placeholder = 'Message #' + name + ' \u2014 type / for commands, @ to mention';
+  }
   // Close recovery view if open
   if (recoveryViewOpen) closeRecoveryView();
 
@@ -5592,76 +5567,81 @@ function setupAgentDMHandlers() {
 }
 
 // ═══════════════════════════════════════════════════════════════
-//   AGENT DM VIEW — full-window Slack-style direct message
+//   AGENT DM — Slack-style navigation (sidebar stays, channel switches)
 // ═══════════════════════════════════════════════════════════════
-var inlineDMAgent = null;   // keep for any legacy refs
-var dmViewAgent   = null;   // agent currently open in the DM view
-var dmStreamES    = null;   // active EventSource for live stdout
+var inlineDMAgent = null;   // compat alias; tracks current DM agent
 var agentLatestText = {};   // sidebar streaming snippets
+var dmStreamES    = null;   // active EventSource for live stdout
 
-function messageTagsAgent(msg, agentSlug) {
-  return Array.isArray(msg.tagged) && msg.tagged.indexOf(agentSlug) !== -1;
+// Called by switchChannel when entering / leaving a dm-* channel.
+function onDMChannelEnter(slug) {
+  var agent = AGENTS.find(function(a) { return a.slug === slug; });
+  inlineDMAgent = agent || null;
+  // Update header to show agent name instead of raw channel id
+  if (agent) {
+    document.getElementById('channel-title').textContent = agent.emoji
+      ? agent.emoji + '\u2009' + agent.name
+      : '@ ' + agent.name;
+    document.getElementById('channel-desc').textContent = (agent.status || 'active') + ' \u00B7 direct message';
+    document.getElementById('composer-input').placeholder = 'Message ' + agent.name + '\u2026';
+  }
+  // Show and connect stream strip
+  var strip = document.getElementById('dm-stream-strip');
+  if (strip) strip.style.display = '';
+  connectAgentStream(slug);
+  renderSidebarDMs();
 }
 
-function isDMViewRelevantMessage(msg, agentSlug) {
-  if (!msg || !agentSlug || msg.reply_to) return false;
-  if (msg.from === agentSlug) return true;
-  if (msg.from === 'you' || msg.from === 'human') return messageTagsAgent(msg, agentSlug);
-  return false;
-}
-
-function setStreamEmpty(container, text) {
-  container.textContent = '';
-  var el = document.createElement('div');
-  el.className = 'dm-stream-empty';
-  el.textContent = text;
-  container.appendChild(el);
-}
-
-function openAgentDM(agentSlug) {
-  var agent = AGENTS.find(function(a) { return a.slug === agentSlug; });
-  if (!agent) return;
-
+function onDMChannelLeave() {
+  inlineDMAgent = null;
   if (dmStreamES) { dmStreamES.close(); dmStreamES = null; }
-  dmViewAgent   = agent;
-  inlineDMAgent = agent;
+  var strip = document.getElementById('dm-stream-strip');
+  if (strip) strip.style.display = 'none';
+  renderSidebarDMs();
+}
 
-  document.getElementById('dm-view-avatar').textContent = agent.emoji || agent.name.charAt(0).toUpperCase();
-  document.getElementById('dm-view-name').textContent = agent.name;
-  document.getElementById('dm-view-status').textContent = agent.status || 'active';
-
-  var convo = document.getElementById('dm-convo-messages');
-  convo.textContent = '';
-  var sorted = Object.values(allMessages).sort(function(a, b) { return (a.id || 0) - (b.id || 0); });
-  sorted.forEach(function(msg) {
-    if (isDMViewRelevantMessage(msg, agent.slug)) appendMessageToContainer(msg, convo);
+// Render "Direct messages" section in the sidebar listing all agents.
+function renderSidebarDMs() {
+  var container = document.getElementById('sidebar-dms');
+  if (!container) return;
+  container.textContent = '';
+  var dmChannel = currentChannel && currentChannel.indexOf('dm-') === 0
+    ? currentChannel.replace('dm-', '') : null;
+  AGENTS.forEach(function(agent) {
+    var btn = document.createElement('button');
+    btn.className = 'sidebar-item' + (dmChannel === agent.slug ? ' active' : '');
+    btn.setAttribute('aria-label', 'Direct message ' + agent.name);
+    // Status dot
+    var dot = document.createElement('span');
+    dot.className = 'status-dot ' + (agent.status === 'thinking' || agent.status === 'active' ? 'active' : 'lurking');
+    dot.style.cssText = 'flex-shrink:0;';
+    // Name
+    var nameEl = document.createElement('span');
+    nameEl.style.cssText = 'flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;';
+    nameEl.textContent = agent.name;
+    btn.appendChild(dot);
+    btn.appendChild(nameEl);
+    btn.addEventListener('click', function() { switchChannel('dm-' + agent.slug); });
+    container.appendChild(btn);
   });
-  convo.scrollTop = convo.scrollHeight;
+}
 
+// Connect EventSource to /api/agent-stream/{slug} for live stdout.
+function connectAgentStream(slug) {
+  if (dmStreamES) { dmStreamES.close(); dmStreamES = null; }
   var streamLines = document.getElementById('dm-stream-lines');
-  setStreamEmpty(streamLines, 'Connecting to agent stream\u2026');
+  if (!streamLines) return;
+  streamLines.textContent = '';
+  var placeholder = document.createElement('div');
+  placeholder.className = 'dm-stream-empty';
+  placeholder.textContent = 'Connecting\u2026';
+  streamLines.appendChild(placeholder);
   document.getElementById('dm-stream-dot').className = 'dm-stream-dot idle';
 
-  var dmInput = document.getElementById('dm-composer-input');
-  dmInput.placeholder = 'Message ' + agent.name + '\u2026';
-  dmInput.value = '';
-  document.getElementById('dm-composer-send').disabled = true;
-
-  document.getElementById('dm-view').classList.add('active');
-  document.querySelector('.main').style.display = 'none';
-  document.getElementById('thread-panel').style.display = 'none';
-
-  dmInput.focus();
-  connectAgentStream(agent.slug);
-}
-
-function connectAgentStream(slug) {
-  var streamLines = document.getElementById('dm-stream-lines');
   if (!brokerConnected) {
-    setStreamEmpty(streamLines, 'Broker not connected \u2014 stream unavailable.');
+    placeholder.textContent = 'Broker not connected \u2014 stream unavailable.';
     return;
   }
-  // EventSource cannot set custom headers; pass auth token as query param.
   fetch('/api-token')
     .then(function(r) { return r.json(); })
     .then(function(data) {
@@ -5674,23 +5654,35 @@ function connectAgentStream(slug) {
         if (!hasContent) {
           streamLines.textContent = '';
           hasContent = true;
-          document.getElementById('dm-stream-dot').className = 'dm-stream-dot';
+          var dot = document.getElementById('dm-stream-dot');
+          if (dot) dot.className = 'dm-stream-dot';
         }
         var line = document.createElement('div');
         line.className = 'dm-stream-line' + classifyStreamLine(e.data);
         line.textContent = e.data;
         streamLines.appendChild(line);
-        if (streamLines.scrollHeight - streamLines.scrollTop < streamLines.clientHeight + 120) {
+        if (streamLines.scrollHeight - streamLines.scrollTop < streamLines.clientHeight + 100) {
           streamLines.scrollTop = streamLines.scrollHeight;
         }
       };
       es.onerror = function() {
-        document.getElementById('dm-stream-dot').className = 'dm-stream-dot idle';
-        if (!hasContent) setStreamEmpty(streamLines, 'Agent stream idle \u2014 no output yet.');
+        var dot = document.getElementById('dm-stream-dot');
+        if (dot) dot.className = 'dm-stream-dot idle';
+        if (!hasContent) {
+          streamLines.textContent = '';
+          var el = document.createElement('div');
+          el.className = 'dm-stream-empty';
+          el.textContent = 'Agent stream idle \u2014 no output yet.';
+          streamLines.appendChild(el);
+        }
       };
     })
     .catch(function() {
-      setStreamEmpty(streamLines, 'Could not connect to stream.');
+      streamLines.textContent = '';
+      var el = document.createElement('div');
+      el.className = 'dm-stream-empty';
+      el.textContent = 'Could not connect to stream.';
+      streamLines.appendChild(el);
     });
 }
 
@@ -5703,56 +5695,17 @@ function classifyStreamLine(text) {
   return '';
 }
 
-function closeAgentDM() {
-  if (dmStreamES) { dmStreamES.close(); dmStreamES = null; }
-  dmViewAgent   = null;
-  inlineDMAgent = null;
-  document.getElementById('dm-view').classList.remove('active');
-  document.querySelector('.main').style.display = '';
-  document.getElementById('thread-panel').style.display = '';
+var dmStreamCollapsed = false;
+function toggleDMStream() {
+  dmStreamCollapsed = !dmStreamCollapsed;
+  var strip = document.getElementById('dm-stream-strip');
+  var btn = document.getElementById('dm-stream-toggle');
+  if (strip) strip.classList.toggle('collapsed', dmStreamCollapsed);
+  if (btn) btn.textContent = dmStreamCollapsed ? '\u25BE' : '\u25B4';
 }
 
-function sendDirectMessage() {
-  if (!dmViewAgent) return;
-  var dmInput = document.getElementById('dm-composer-input');
-  var text = dmInput.value.trim();
-  if (!text) return;
-  dmInput.value = '';
-  document.getElementById('dm-composer-send').disabled = true;
-  var payload = { from: 'you', channel: 'dm-' + dmViewAgent.slug, content: text, tagged: [dmViewAgent.slug] };
-  if (brokerConnected) {
-    WuphfAPI.post('/messages', payload).catch(function(err) {
-      showNotice('DM send failed: ' + err.message, 'error');
-    });
-  }
-}
-
-function maybeAppendToDMView(msg) {
-  if (!dmViewAgent) return;
-  if (!isDMViewRelevantMessage(msg, dmViewAgent.slug)) return;
-  var convo = document.getElementById('dm-convo-messages');
-  if (!convo) return;
-  appendMessageToContainer(msg, convo);
-  convo.scrollTop = convo.scrollHeight;
-}
-
-(function() {
-  function wireDMComposer() {
-    var dmInput = document.getElementById('dm-composer-input');
-    var dmSend  = document.getElementById('dm-composer-send');
-    if (!dmInput || !dmSend) return;
-    dmInput.addEventListener('input', function() { dmSend.disabled = dmInput.value.trim() === ''; });
-    dmInput.addEventListener('keydown', function(e) {
-      if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendDirectMessage(); }
-    });
-    dmSend.addEventListener('click', sendDirectMessage);
-  }
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', wireDMComposer);
-  } else {
-    wireDMComposer();
-  }
-})();
+// No-op kept for any remaining call sites from the legacy appendBrokerMessage path.
+function maybeAppendToDMView(msg) {}
 
 // ═══════════════════════════════════════════════════════════════
 //   RECOVERY VIEW (#55)

--- a/web/index.html
+++ b/web/index.html
@@ -196,7 +196,7 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 .landing-block p { font-size: 16px; line-height: 1.7; color: var(--text-secondary); }
 .landing-pain p { color: var(--text); }
 .landing-objection { display: flex; flex-direction: column; gap: 10px; }
-.landing-objection-lead { font-family: var(--font-mono); font-size: 12px; line-height: 1.7; letter-spacing: 0.02em; text-transform: uppercase; color: var(--text-tertiary); }
+.landing-objection-lead { font-family: var(--font-mono); font-size: 12px; line-height: 1.7; letter-spacing: 0.02em; text-transform: uppercase; color: var(--text-secondary); }
 .landing-objection-detail { color: var(--text); }
 .landing-final-cta { padding: 24px 28px; display: flex; justify-content: center; }
 
@@ -765,24 +765,6 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 /* ─── Agent Character Face ─── */
 .msg-agent-char { display: inline-flex; margin-right: 4px; font-size: 14px; }
 
-/* ─── A2UI Blocks ─── */
-.a2ui-block { background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 12px; margin-top: 8px; font-size: 13px; }
-.a2ui-table { width: 100%; border-collapse: collapse; font-size: 12px; }
-.a2ui-table th { text-align: left; font-weight: 600; padding: 6px 8px; border-bottom: 2px solid var(--border); color: var(--text); }
-.a2ui-table td { padding: 6px 8px; border-bottom: 1px solid var(--border-light); color: var(--text-secondary); }
-.a2ui-kv { display: grid; grid-template-columns: auto 1fr; gap: 4px 12px; }
-.a2ui-kv-key { font-weight: 600; color: var(--text); font-size: 12px; }
-.a2ui-kv-val { color: var(--text-secondary); font-size: 12px; }
-.a2ui-progress { display: flex; align-items: center; gap: 8px; }
-.a2ui-progress-bar { flex: 1; height: 8px; background: var(--border); border-radius: 4px; overflow: hidden; }
-.a2ui-progress-fill { height: 100%; background: var(--accent); border-radius: 4px; transition: width 0.3s; }
-.a2ui-progress-label { font-size: 12px; font-weight: 600; color: var(--text); min-width: 36px; text-align: right; }
-.a2ui-status { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: var(--radius-full); font-size: 12px; font-weight: 500; }
-.a2ui-status-ok { background: var(--green-bg); color: var(--green); }
-.a2ui-status-warn { background: var(--yellow-bg); color: var(--yellow); }
-.a2ui-status-error { background: var(--red-bg); color: var(--red); }
-.a2ui-status-info { background: var(--blue-bg); color: var(--blue); }
-
 /* ─── Pixel Art Avatar ─── */
 .pixel-avatar { image-rendering: pixelated; border-radius: 4px; }
 .pixel-avatar-sidebar { width: 24px; height: 24px; }
@@ -877,20 +859,37 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 .runtime-strip.paused { border-bottom-color: var(--red); box-shadow: inset 0 -2px 0 var(--red); }
 .runtime-paused-pill { background: var(--red-bg); color: var(--red); font-weight: 600; padding: 2px 8px; border-radius: var(--radius-full); font-size: 10px; animation: pulse-dot 1.5s ease-in-out infinite; }
 
-/* ─── Inline DM panel (office stays active) ─── */
-.inline-dm-panel { width: 360px; flex-shrink: 0; background: var(--bg-card); border-left: 1px solid var(--border); display: none; flex-direction: column; height: 100vh; overflow: hidden; }
-.inline-dm-panel.open { display: flex; }
-.inline-dm-panel-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid var(--border); background: var(--accent-bg); }
-.inline-dm-panel-title { font-size: 14px; font-weight: 700; display: flex; align-items: center; gap: 8px; }
-.inline-dm-panel-badge { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; color: var(--accent); background: white; border: 1px solid var(--accent); border-radius: 4px; padding: 1px 5px; }
-.inline-dm-panel-close { width: 28px; height: 28px; border: none; background: transparent; cursor: pointer; display: flex; align-items: center; justify-content: center; border-radius: 6px; color: var(--text-secondary); font-size: 16px; }
-.inline-dm-panel-close:hover { background: var(--bg); }
-.inline-dm-notice { font-size: 10px; color: var(--text-tertiary); padding: 6px 16px; border-bottom: 1px solid var(--border); text-align: center; letter-spacing: 0.02em; }
-.inline-dm-messages { flex: 1; overflow-y: auto; padding: 12px 16px; display: flex; flex-direction: column; gap: 10px; }
-.inline-dm-composer { padding: 8px 12px 12px; border-top: 1px solid var(--border); }
-.inline-dm-input { width: 100%; box-sizing: border-box; border: 1px solid var(--border); border-radius: var(--radius-md); padding: 8px 10px; font-family: var(--font-sans); font-size: 13px; color: var(--text); background: var(--bg); outline: none; resize: none; transition: border-color 0.2s; }
-.inline-dm-input:focus { border-color: var(--accent); }
-.inline-dm-send-row { display: flex; justify-content: flex-end; margin-top: 6px; }
+/* ─── Full-window agent DM view (Slack-style) ─── */
+.dm-view { display: none; flex: 1; flex-direction: column; height: 100vh; overflow: hidden; background: var(--bg); }
+.dm-view.active { display: flex; }
+.dm-view-header { display: flex; align-items: center; justify-content: space-between; padding: 0 20px; height: 52px; min-height: 52px; border-bottom: 1px solid var(--border); background: var(--bg-card); flex-shrink: 0; }
+.dm-view-agent { display: flex; align-items: center; gap: 10px; }
+.dm-view-avatar { width: 30px; height: 30px; border-radius: 50%; background: var(--accent-bg); display: flex; align-items: center; justify-content: center; font-size: 14px; flex-shrink: 0; }
+.dm-view-name { font-size: 15px; font-weight: 700; color: var(--text); }
+.dm-view-status { font-size: 11px; color: var(--text-tertiary); }
+.dm-view-close { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text-secondary); background: transparent; border: 1px solid var(--border); border-radius: var(--radius-md); padding: 4px 10px; cursor: pointer; transition: all 0.15s; }
+.dm-view-close:hover { background: var(--bg); color: var(--text); }
+.dm-view-body { display: flex; flex: 1; overflow: hidden; flex-direction: column; }
+/* Stream pane — live agent stdout */
+.dm-stream-pane { flex: 1; min-height: 0; display: flex; flex-direction: column; border-bottom: 2px solid var(--border); overflow: hidden; }
+.dm-stream-header { display: flex; align-items: center; gap: 8px; padding: 6px 16px; background: #1a1a1a; border-bottom: 1px solid #333; flex-shrink: 0; }
+.dm-stream-title { font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: #888; font-family: var(--font-mono); }
+.dm-stream-dot { width: 6px; height: 6px; border-radius: 50%; background: #22c55e; animation: pulse-dot 1.5s ease-in-out infinite; flex-shrink: 0; }
+.dm-stream-dot.idle { background: #555; animation: none; }
+.dm-stream-lines { flex: 1; overflow-y: auto; padding: 8px 16px; background: #1a1a1a; font-family: var(--font-mono); font-size: 12px; line-height: 1.55; color: #d4d4d4; }
+.dm-stream-line { white-space: pre-wrap; word-break: break-all; padding: 1px 0; }
+.dm-stream-line.thinking { color: #888; font-style: italic; }
+.dm-stream-line.tool { color: #60a5fa; }
+.dm-stream-line.result { color: #86efac; }
+.dm-stream-empty { color: #555; font-style: italic; font-size: 11px; padding: 12px 0; }
+/* Conversation pane */
+.dm-convo-pane { display: flex; flex-direction: column; max-height: 45%; min-height: 120px; overflow: hidden; flex-shrink: 0; }
+.dm-convo-messages { flex: 1; overflow-y: auto; padding: 12px 20px; display: flex; flex-direction: column; gap: 8px; }
+/* Composer */
+.dm-composer { padding: 8px 16px 12px; border-top: 1px solid var(--border); background: var(--bg-card); flex-shrink: 0; }
+.dm-composer-inner { display: flex; align-items: flex-end; gap: 8px; }
+.dm-composer-input { flex: 1; border: 1px solid var(--border); border-radius: var(--radius-md); padding: 8px 12px; font-family: var(--font-sans); font-size: 13px; color: var(--text); background: var(--bg); outline: none; resize: none; line-height: 1.4; transition: border-color 0.2s; }
+.dm-composer-input:focus { border-color: var(--accent); }
 /* DM button on sidebar agent rows */
 .sidebar-agent-dm-btn { font-size: 9px; font-weight: 600; opacity: 0; padding: 1px 5px; border: 1px solid var(--border); border-radius: 3px; background: transparent; color: var(--text-tertiary); cursor: pointer; margin-left: auto; transition: all 0.12s; font-family: var(--font-sans); text-transform: uppercase; letter-spacing: 0.04em; flex-shrink: 0; }
 .sidebar-agent:hover .sidebar-agent-dm-btn { opacity: 1; }
@@ -915,7 +914,7 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 
 <div id="app">
   <!-- ONBOARDING -->
-  <div class="onboarding dot-grid" id="onboarding" data-step="0">
+  <main class="onboarding dot-grid" id="onboarding" data-step="0">
     <div class="onboarding-inner">
       <div class="progress-dots" id="progress-dots"></div>
 
@@ -970,15 +969,15 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
         <h1 class="step-title">Tell me about your company</h1>
         <div class="card form-card" style="max-width:540px;margin:0 auto;">
           <div class="form-group">
-            <label class="label">What's your company or project name?</label>
+            <label class="label" for="q-company">What's your company or project name?</label>
             <input class="input" id="q-company" placeholder="Stealth Mode Labs" />
           </div>
           <div class="form-group">
-            <label class="label">What do you do?</label>
+            <label class="label" for="q-description">What do you do?</label>
             <input class="input" id="q-description" placeholder="We build AI-powered analytics for e-commerce" />
           </div>
           <div class="form-group">
-            <label class="label">What are your top 3 goals right now?</label>
+            <label class="label" for="q-goals">What are your top 3 goals right now?</label>
             <input class="input" id="q-goals" placeholder="Ship MVP, get first 10 customers, close seed round" />
           </div>
         </div>
@@ -1003,7 +1002,7 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
             <div class="size-options" id="size-options"></div>
           </div>
           <div class="form-group">
-            <label class="label">What's your most immediate priority?</label>
+            <label class="label" for="q-priority">What's your most immediate priority?</label>
             <input class="input" id="q-priority" placeholder="Get the landing page live and start collecting leads" />
           </div>
         </div>
@@ -1146,7 +1145,7 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
       </div>
 
     </div>
-  </div>
+  </main>
 
   <!-- LAUNCH ANIMATION -->
   <div class="launch-screen" id="launch-screen">
@@ -1160,7 +1159,7 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
     <aside class="sidebar">
       <div class="sidebar-header">
         <span class="sidebar-logo">wuphf</span>
-        <button class="sidebar-btn" title="Collapse sidebar">
+        <button class="sidebar-btn" title="Collapse sidebar" aria-label="Collapse sidebar">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M9 3v18"/></svg>
         </button>
       </div>
@@ -1184,7 +1183,8 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
       </div>
       <div class="sidebar-channels" id="sidebar-apps"></div>
       <div class="sidebar-bottom" style="flex-direction:column;gap:6px;">
-        <select id="theme-switcher" style="width:100%;padding:4px 6px;font-size:11px;font-family:var(--font-sans);border:1px solid var(--border);border-radius:4px;background:var(--bg-card);color:var(--text);cursor:pointer;">
+        <label class="sr-only" for="theme-switcher">Switch theme</label>
+        <select id="theme-switcher" aria-label="Switch theme" style="width:100%;padding:4px 6px;font-size:11px;font-family:var(--font-sans);border:1px solid var(--border);border-radius:4px;background:var(--bg-card);color:var(--text);cursor:pointer;">
           <option value="">Editorial</option>
           <option value="slack">Slack</option>
           <option value="slack-dark">Slack (Dark)</option>
@@ -1200,10 +1200,10 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
           <span class="channel-desc" id="channel-desc">The shared office channel</span>
         </div>
         <div class="channel-actions">
-          <button class="sidebar-btn" title="Search">
+          <button class="sidebar-btn" title="Search" aria-label="Search">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
           </button>
-          <button class="sidebar-btn" title="Requests">
+          <button class="sidebar-btn" title="Requests" aria-label="Requests">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0"/></svg>
           </button>
         </div>
@@ -1235,8 +1235,8 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
       <div class="composer" style="position:relative;">
         <div class="autocomplete" id="autocomplete"></div>
         <div class="composer-inner">
-          <textarea class="composer-input" id="composer-input" placeholder="Message #general &mdash; type / for commands, @ to mention" rows="1"></textarea>
-          <button class="composer-send" id="composer-send" disabled>
+          <textarea class="composer-input" id="composer-input" aria-label="Message general channel" placeholder="Message #general &mdash; type / for commands, @ to mention" rows="1"></textarea>
+          <button class="composer-send" id="composer-send" aria-label="Send message" disabled>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4z"/><path d="m22 2-10 10"/></svg>
           </button>
         </div>
@@ -1266,40 +1266,61 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
       <div class="thread-panel-messages" id="thread-messages" role="region" aria-label="Thread replies"></div>
       <div class="thread-panel-composer">
         <div class="composer-inner">
-          <textarea class="composer-input" id="thread-composer-input" placeholder="Reply in thread..." rows="1"></textarea>
-          <button class="composer-send" id="thread-composer-send" type="button" disabled>
+          <textarea class="composer-input" id="thread-composer-input" aria-label="Reply in thread" placeholder="Reply in thread..." rows="1"></textarea>
+          <button class="composer-send" id="thread-composer-send" type="button" aria-label="Send thread reply" disabled>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4z"/><path d="m22 2-10 10"/></svg>
           </button>
         </div>
       </div>
     </aside>
 
-    <!-- Inline DM Panel (office stays active, no mode switch) -->
-    <aside class="inline-dm-panel" id="inline-dm-panel">
-      <div class="inline-dm-panel-header">
-        <div class="inline-dm-panel-title">
-          <span id="inline-dm-panel-name">Agent</span>
-          <span class="inline-dm-panel-badge">DM</span>
+    <!-- Full-window agent DM view (replaces main panel, sidebar stays) -->
+    <div class="dm-view" id="dm-view" role="region" aria-label="Direct message">
+      <div class="dm-view-header">
+        <div class="dm-view-agent">
+          <div class="dm-view-avatar" id="dm-view-avatar">?</div>
+          <div>
+            <div class="dm-view-name" id="dm-view-name">Agent</div>
+            <div class="dm-view-status" id="dm-view-status">active</div>
+          </div>
         </div>
-        <button class="inline-dm-panel-close" onclick="closeInlineDM()" title="Close DM">✕</button>
+        <button class="dm-view-close" onclick="closeAgentDM()" aria-label="Back to office">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
+          Back to office
+        </button>
       </div>
-      <div class="inline-dm-notice">Office stays active — direct channel only</div>
-      <div class="inline-dm-messages" id="inline-dm-messages"></div>
-      <div class="inline-dm-composer">
-        <textarea class="inline-dm-input" id="inline-dm-input" rows="2" placeholder="Message directly…"></textarea>
-        <div class="inline-dm-send-row">
-          <button class="composer-send" id="inline-dm-send" disabled>
+      <div class="dm-view-body">
+        <!-- Live stream pane -->
+        <div class="dm-stream-pane">
+          <div class="dm-stream-header">
+            <span class="dm-stream-dot" id="dm-stream-dot"></span>
+            <span class="dm-stream-title">Live output</span>
+          </div>
+          <div class="dm-stream-lines" id="dm-stream-lines">
+            <div class="dm-stream-empty">Waiting for agent output&hellip;</div>
+          </div>
+        </div>
+        <!-- Conversation pane -->
+        <div class="dm-convo-pane">
+          <div class="dm-convo-messages" id="dm-convo-messages"></div>
+        </div>
+      </div>
+      <!-- Composer -->
+      <div class="dm-composer">
+        <div class="dm-composer-inner">
+          <textarea class="dm-composer-input" id="dm-composer-input" aria-label="Message agent directly" rows="1" placeholder="Message agent…"></textarea>
+          <button class="composer-send" id="dm-composer-send" aria-label="Send direct message" disabled>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4z"/><path d="m22 2-10 10"/></svg>
           </button>
         </div>
       </div>
-    </aside>
+    </div>
 
     <!-- Agent Panel -->
     <aside class="agent-panel" id="agent-panel">
       <div class="agent-panel-header">
         <span style="font-size:14px;font-weight:600;">Agent Detail</span>
-        <button class="agent-panel-close" onclick="closeAgentPanel()">
+        <button class="agent-panel-close" onclick="closeAgentPanel()" aria-label="Close agent detail">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg>
         </button>
       </div>
@@ -1312,7 +1333,7 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
     <div class="cmd-palette" id="cmd-palette">
       <div class="cmd-palette-input-wrap">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
-        <input class="cmd-palette-input" id="cmd-palette-input" placeholder="Search channels, agents, commands..." autocomplete="off" />
+        <input class="cmd-palette-input" id="cmd-palette-input" aria-label="Search channels, agents, and commands" placeholder="Search channels, agents, commands..." autocomplete="off" />
         <span class="cmd-palette-kbd">esc</span>
       </div>
       <div class="cmd-palette-results" id="cmd-palette-results"></div>
@@ -2186,7 +2207,7 @@ function renderSidebarAgents() {
     dmBtn.title = 'Open direct channel with ' + a.name;
     dmBtn.addEventListener('click', function(e) {
       e.stopPropagation(); // don't open agent panel
-      openInlineDM(a.slug);
+      openAgentDM(a.slug);
     });
     btn.appendChild(avatarEl);
     btn.appendChild(wrap);
@@ -3182,7 +3203,7 @@ function appendBrokerMessage(msg) {
   }
 
   // Mirror to inline DM panel if open and message is relevant
-  maybeAppendToInlineDM(msg);
+  maybeAppendToDMView(msg);
 
   // Track all messages for thread lookups
   allMessages[msg.id] = msg;
@@ -3428,20 +3449,6 @@ function appendMessageToContainer(msg, container, opts) {
   }
   else {
     content.appendChild(textDiv);
-  }
-
-  // A2UI structured blocks (#13) — from msg.blocks or msg.kind === 'a2ui'
-  if (msg.blocks && Array.isArray(msg.blocks)) {
-    msg.blocks.forEach(function(block) {
-      var rendered = renderA2UIBlocks(block, content);
-      if (rendered) content.appendChild(rendered);
-    });
-  } else if (msg.kind === 'a2ui' && msg.content) {
-    var parsed = parseA2UIBlocks(msg.content);
-    parsed.blocks.forEach(function(blockText) {
-      var rendered = renderA2UIBlock(blockText);
-      if (rendered) content.appendChild(rendered);
-    });
   }
 
   // Threads are flat conversations — no per-message reply indicators
@@ -4214,7 +4221,7 @@ function handleSlashCommand(input) {
       showSystem('Messages cleared');
       break;
     case '/help':
-      showSystem('Commands: /clear /help /requests /tasks /reset /reply /1o1 <agent> /search /recover /threads /agents /insert /rewind /reset-dm /connect /skill /artifacts /pause /doctor /provider /newagent');
+      showSystem('Commands: /clear /help /collab /focus /requests /tasks /reset /reply /1o1 <agent> /search /recover /threads /agents /insert /rewind /reset-dm /connect /skill /artifacts /pause /doctor /provider /newagent');
       break;
     case '/requests':
       switchApp('requests');
@@ -4247,6 +4254,16 @@ function handleSlashCommand(input) {
           }
         }
       }
+      break;
+    case '/collab':
+      WuphfAPI.post('/focus-mode', { focus_mode: false }).then(function() {
+        showSystem('Switched to collaborative mode. All agents see all messages.');
+      });
+      break;
+    case '/focus':
+      WuphfAPI.post('/focus-mode', { focus_mode: true }).then(function() {
+        showSystem('Switched to delegation mode. CEO routes, specialists execute.');
+      });
       break;
     case '/reset':
       showConfirmDialog({
@@ -5575,58 +5592,134 @@ function setupAgentDMHandlers() {
 }
 
 // ═══════════════════════════════════════════════════════════════
-//   INLINE DM PANEL — office stays active, no mode switch
+//   AGENT DM VIEW — full-window Slack-style direct message
 // ═══════════════════════════════════════════════════════════════
-var inlineDMAgent = null;
-// Tracks last streaming snippet per agent slug (updated on each message append)
-var agentLatestText = {};
+var inlineDMAgent = null;   // keep for any legacy refs
+var dmViewAgent   = null;   // agent currently open in the DM view
+var dmStreamES    = null;   // active EventSource for live stdout
+var agentLatestText = {};   // sidebar streaming snippets
 
-function openInlineDM(agentSlug) {
+function messageTagsAgent(msg, agentSlug) {
+  return Array.isArray(msg.tagged) && msg.tagged.indexOf(agentSlug) !== -1;
+}
+
+function isDMViewRelevantMessage(msg, agentSlug) {
+  if (!msg || !agentSlug || msg.reply_to) return false;
+  if (msg.from === agentSlug) return true;
+  if (msg.from === 'you' || msg.from === 'human') return messageTagsAgent(msg, agentSlug);
+  return false;
+}
+
+function setStreamEmpty(container, text) {
+  container.textContent = '';
+  var el = document.createElement('div');
+  el.className = 'dm-stream-empty';
+  el.textContent = text;
+  container.appendChild(el);
+}
+
+function openAgentDM(agentSlug) {
   var agent = AGENTS.find(function(a) { return a.slug === agentSlug; });
   if (!agent) return;
+
+  if (dmStreamES) { dmStreamES.close(); dmStreamES = null; }
+  dmViewAgent   = agent;
   inlineDMAgent = agent;
 
-  document.getElementById('inline-dm-panel-name').textContent = agent.name;
-  var dmInput = document.getElementById('inline-dm-input');
-  dmInput.placeholder = 'Message ' + agent.name + ' directly\u2026';
+  document.getElementById('dm-view-avatar').textContent = agent.emoji || agent.name.charAt(0).toUpperCase();
+  document.getElementById('dm-view-name').textContent = agent.name;
+  document.getElementById('dm-view-status').textContent = agent.status || 'active';
 
-  // Seed panel with existing messages from allMessages cache
-  var container = document.getElementById('inline-dm-messages');
-  container.textContent = '';
-  var sorted = Object.values(allMessages).sort(function(a, b) {
-    return (a.id || 0) - (b.id || 0);
-  });
+  var convo = document.getElementById('dm-convo-messages');
+  convo.textContent = '';
+  var sorted = Object.values(allMessages).sort(function(a, b) { return (a.id || 0) - (b.id || 0); });
   sorted.forEach(function(msg) {
-    if (msg.from === agent.slug || msg.from === 'you' || msg.from === 'human') {
-      appendMessageToContainer(msg, container);
-    }
+    if (isDMViewRelevantMessage(msg, agent.slug)) appendMessageToContainer(msg, convo);
   });
-  container.scrollTop = container.scrollHeight;
+  convo.scrollTop = convo.scrollHeight;
 
-  document.getElementById('inline-dm-panel').classList.add('open');
+  var streamLines = document.getElementById('dm-stream-lines');
+  setStreamEmpty(streamLines, 'Connecting to agent stream\u2026');
+  document.getElementById('dm-stream-dot').className = 'dm-stream-dot idle';
+
+  var dmInput = document.getElementById('dm-composer-input');
+  dmInput.placeholder = 'Message ' + agent.name + '\u2026';
+  dmInput.value = '';
+  document.getElementById('dm-composer-send').disabled = true;
+
+  document.getElementById('dm-view').classList.add('active');
+  document.querySelector('.main').style.display = 'none';
+  document.getElementById('thread-panel').style.display = 'none';
+
   dmInput.focus();
+  connectAgentStream(agent.slug);
 }
 
-function closeInlineDM() {
+function connectAgentStream(slug) {
+  var streamLines = document.getElementById('dm-stream-lines');
+  if (!brokerConnected) {
+    setStreamEmpty(streamLines, 'Broker not connected \u2014 stream unavailable.');
+    return;
+  }
+  // EventSource cannot set custom headers; pass auth token as query param.
+  fetch('/api-token')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      var url = '/api/agent-stream/' + encodeURIComponent(slug) +
+                '?token=' + encodeURIComponent(data.token || '');
+      var es = new EventSource(url);
+      dmStreamES = es;
+      var hasContent = false;
+      es.onmessage = function(e) {
+        if (!hasContent) {
+          streamLines.textContent = '';
+          hasContent = true;
+          document.getElementById('dm-stream-dot').className = 'dm-stream-dot';
+        }
+        var line = document.createElement('div');
+        line.className = 'dm-stream-line' + classifyStreamLine(e.data);
+        line.textContent = e.data;
+        streamLines.appendChild(line);
+        if (streamLines.scrollHeight - streamLines.scrollTop < streamLines.clientHeight + 120) {
+          streamLines.scrollTop = streamLines.scrollHeight;
+        }
+      };
+      es.onerror = function() {
+        document.getElementById('dm-stream-dot').className = 'dm-stream-dot idle';
+        if (!hasContent) setStreamEmpty(streamLines, 'Agent stream idle \u2014 no output yet.');
+      };
+    })
+    .catch(function() {
+      setStreamEmpty(streamLines, 'Could not connect to stream.');
+    });
+}
+
+function classifyStreamLine(text) {
+  if (!text) return '';
+  var t = text.toLowerCase();
+  if (t.indexOf('thinking') !== -1 || text.charAt(0) === '<') return ' thinking';
+  if (t.indexOf('tool_use') !== -1 || t.indexOf('bash(') !== -1 || t.indexOf('read(') !== -1) return ' tool';
+  if (t.indexOf('result') !== -1) return ' result';
+  return '';
+}
+
+function closeAgentDM() {
+  if (dmStreamES) { dmStreamES.close(); dmStreamES = null; }
+  dmViewAgent   = null;
   inlineDMAgent = null;
-  document.getElementById('inline-dm-panel').classList.remove('open');
+  document.getElementById('dm-view').classList.remove('active');
+  document.querySelector('.main').style.display = '';
+  document.getElementById('thread-panel').style.display = '';
 }
 
-function sendInlineDMMessage() {
-  if (!inlineDMAgent) return;
-  var dmInput = document.getElementById('inline-dm-input');
+function sendDirectMessage() {
+  if (!dmViewAgent) return;
+  var dmInput = document.getElementById('dm-composer-input');
   var text = dmInput.value.trim();
   if (!text) return;
   dmInput.value = '';
-  document.getElementById('inline-dm-send').disabled = true;
-
-  // Send as @mention so the broker routes directly to this agent
-  var payload = {
-    from: 'you',
-    channel: currentChannel,
-    content: '@' + inlineDMAgent.slug + ' ' + text,
-    tagged: [inlineDMAgent.slug]
-  };
+  document.getElementById('dm-composer-send').disabled = true;
+  var payload = { from: 'you', channel: 'dm-' + dmViewAgent.slug, content: text, tagged: [dmViewAgent.slug] };
   if (brokerConnected) {
     WuphfAPI.post('/messages', payload).catch(function(err) {
       showNotice('DM send failed: ' + err.message, 'error');
@@ -5634,39 +5727,30 @@ function sendInlineDMMessage() {
   }
 }
 
-// Called by appendBrokerMessage to mirror messages into the open DM panel
-function maybeAppendToInlineDM(msg) {
-  if (!inlineDMAgent) return;
-  var isFromTarget = msg.from === inlineDMAgent.slug;
-  var isFromMe = msg.from === 'you' || msg.from === 'human';
-  if (!isFromTarget && !isFromMe) return;
-  var container = document.getElementById('inline-dm-messages');
-  if (!container) return;
-  appendMessageToContainer(msg, container);
-  container.scrollTop = container.scrollHeight;
+function maybeAppendToDMView(msg) {
+  if (!dmViewAgent) return;
+  if (!isDMViewRelevantMessage(msg, dmViewAgent.slug)) return;
+  var convo = document.getElementById('dm-convo-messages');
+  if (!convo) return;
+  appendMessageToContainer(msg, convo);
+  convo.scrollTop = convo.scrollHeight;
 }
 
-// Wire up inline DM input enable/disable and keyboard submit
 (function() {
-  function wireInlineDMComposer() {
-    var dmInput = document.getElementById('inline-dm-input');
-    var dmSend = document.getElementById('inline-dm-send');
+  function wireDMComposer() {
+    var dmInput = document.getElementById('dm-composer-input');
+    var dmSend  = document.getElementById('dm-composer-send');
     if (!dmInput || !dmSend) return;
-    dmInput.addEventListener('input', function() {
-      dmSend.disabled = dmInput.value.trim() === '';
-    });
+    dmInput.addEventListener('input', function() { dmSend.disabled = dmInput.value.trim() === ''; });
     dmInput.addEventListener('keydown', function(e) {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        sendInlineDMMessage();
-      }
+      if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendDirectMessage(); }
     });
-    dmSend.addEventListener('click', sendInlineDMMessage);
+    dmSend.addEventListener('click', sendDirectMessage);
   }
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', wireInlineDMComposer);
+    document.addEventListener('DOMContentLoaded', wireDMComposer);
   } else {
-    wireInlineDMComposer();
+    wireDMComposer();
   }
 })();
 
@@ -6463,228 +6547,6 @@ function inferMood(text) {
   // Shipping signals
   if (/\bdeploy|\bpush|\bmerge|\brelease|\bship\b|\blaunched\b/.test(t)) return { emoji: '\uD83D\uDE80', label: 'shipping' };
   return null;
-}
-
-// ═══════════════════════════════════════════════════════════════
-//   A2UI BLOCK RENDERING (#13)
-// ═══════════════════════════════════════════════════════════════
-function renderA2UIBlocks(block, parentContainer) {
-  if (!block) return null;
-  var container = document.createElement('div');
-  container.className = 'a2ui-block';
-
-  // Table: array of objects
-  if (Array.isArray(block.rows || block.data || block)) {
-    var rows = block.rows || block.data || block;
-    if (rows.length > 0 && typeof rows[0] === 'object') {
-      var table = document.createElement('table');
-      table.className = 'a2ui-table';
-      var keys = Object.keys(rows[0]);
-      var thead = document.createElement('tr');
-      keys.forEach(function(k) {
-        var th = document.createElement('th');
-        th.textContent = k;
-        thead.appendChild(th);
-      });
-      table.appendChild(thead);
-      rows.forEach(function(row) {
-        var tr = document.createElement('tr');
-        keys.forEach(function(k) {
-          var td = document.createElement('td');
-          td.textContent = row[k] != null ? String(row[k]) : '';
-          tr.appendChild(td);
-        });
-        table.appendChild(tr);
-      });
-      container.appendChild(table);
-      return container;
-    }
-  }
-
-  // Progress bar
-  if (block.type === 'progress' || block.progress != null) {
-    var pct = typeof block.progress === 'number' ? block.progress : parseInt(block.value || block.percent || 0);
-    var progressDiv = document.createElement('div');
-    progressDiv.className = 'a2ui-progress';
-    if (block.label) {
-      var labelEl = document.createElement('span');
-      labelEl.style.cssText = 'font-size:12px;color:var(--text-secondary);min-width:60px;';
-      labelEl.textContent = block.label;
-      progressDiv.appendChild(labelEl);
-    }
-    var bar = document.createElement('div');
-    bar.className = 'a2ui-progress-bar';
-    var fill = document.createElement('div');
-    fill.className = 'a2ui-progress-fill';
-    fill.style.width = Math.min(pct, 100) + '%';
-    bar.appendChild(fill);
-    progressDiv.appendChild(bar);
-    var pctLabel = document.createElement('span');
-    pctLabel.className = 'a2ui-progress-label';
-    pctLabel.textContent = pct + '%';
-    progressDiv.appendChild(pctLabel);
-    container.appendChild(progressDiv);
-    return container;
-  }
-
-  // Key-value pairs
-  if (block.type === 'kv' || block.pairs || block.fields) {
-    var pairs = block.pairs || block.fields || block;
-    var kvDiv = document.createElement('div');
-    kvDiv.className = 'a2ui-kv';
-    var entries = Array.isArray(pairs) ? pairs : Object.entries(pairs).filter(function(e) { return e[0] !== 'type'; });
-    entries.forEach(function(entry) {
-      var key = Array.isArray(entry) ? entry[0] : (entry.key || entry.label);
-      var val = Array.isArray(entry) ? entry[1] : (entry.value || entry.val);
-      var keyEl = document.createElement('span');
-      keyEl.className = 'a2ui-kv-key';
-      keyEl.textContent = key;
-      var valEl = document.createElement('span');
-      valEl.className = 'a2ui-kv-val';
-      valEl.textContent = val != null ? String(val) : '';
-      kvDiv.appendChild(keyEl);
-      kvDiv.appendChild(valEl);
-    });
-    container.appendChild(kvDiv);
-    return container;
-  }
-
-  // Fallback: render as text if block has a text/content field
-  if (block.text || block.content) {
-    return renderA2UIBlock(block.text || block.content);
-  }
-
-  return null;
-}
-
-function parseA2UIBlocks(text) {
-  // Detect ```a2ui ... ``` or [A2UI] ... [/A2UI] markers
-  var blocks = [];
-  var remaining = text;
-
-  // Pattern 1: ```a2ui\n...\n```
-  remaining = remaining.replace(/```a2ui\n([\s\S]*?)```/g, function(match, inner) {
-    blocks.push(inner.trim());
-    return '<!--A2UI_PLACEHOLDER_' + (blocks.length - 1) + '-->';
-  });
-
-  // Pattern 2: [A2UI]...[/A2UI]
-  remaining = remaining.replace(/\[A2UI\]([\s\S]*?)\[\/A2UI\]/gi, function(match, inner) {
-    blocks.push(inner.trim());
-    return '<!--A2UI_PLACEHOLDER_' + (blocks.length - 1) + '-->';
-  });
-
-  return { text: remaining, blocks: blocks };
-}
-
-function renderA2UIBlock(blockText) {
-  var container = document.createElement('div');
-  container.className = 'a2ui-block';
-
-  var lines = blockText.split('\n').filter(function(l) { return l.trim(); });
-  if (lines.length === 0) return null;
-
-  // Detect block type
-  var firstLine = lines[0].trim().toLowerCase();
-
-  // Table: lines with | separators
-  if (firstLine.indexOf('|') !== -1 && lines.length >= 2) {
-    var table = document.createElement('table');
-    table.className = 'a2ui-table';
-    lines.forEach(function(line, i) {
-      if (line.trim().match(/^[\|\-\s:]+$/)) return; // skip separator rows
-      var cells = line.split('|').map(function(c) { return c.trim(); }).filter(function(c) { return c; });
-      var tr = document.createElement('tr');
-      cells.forEach(function(cell) {
-        var td = document.createElement(i === 0 ? 'th' : 'td');
-        td.textContent = cell;
-        tr.appendChild(td);
-      });
-      table.appendChild(tr);
-    });
-    container.appendChild(table);
-    return container;
-  }
-
-  // Progress bar: "progress: N%" or "progress N/M"
-  var progressMatch = blockText.match(/progress[:\s]+(\d+)%/i);
-  if (!progressMatch) progressMatch = blockText.match(/progress[:\s]+(\d+)\s*\/\s*(\d+)/i);
-  if (progressMatch) {
-    var pct = progressMatch[2]
-      ? Math.round((parseInt(progressMatch[1]) / parseInt(progressMatch[2])) * 100)
-      : parseInt(progressMatch[1]);
-    var label = blockText.split('\n')[0].replace(/progress[:\s].*$/i, '').trim();
-
-    var progressDiv = document.createElement('div');
-    progressDiv.className = 'a2ui-progress';
-    if (label) {
-      var labelEl = document.createElement('span');
-      labelEl.style.cssText = 'font-size:12px;color:var(--text-secondary);min-width:60px;';
-      labelEl.textContent = label;
-      progressDiv.appendChild(labelEl);
-    }
-    var bar = document.createElement('div');
-    bar.className = 'a2ui-progress-bar';
-    var fill = document.createElement('div');
-    fill.className = 'a2ui-progress-fill';
-    fill.style.width = Math.min(pct, 100) + '%';
-    bar.appendChild(fill);
-    progressDiv.appendChild(bar);
-    var pctLabel = document.createElement('span');
-    pctLabel.className = 'a2ui-progress-label';
-    pctLabel.textContent = pct + '%';
-    progressDiv.appendChild(pctLabel);
-    container.appendChild(progressDiv);
-    return container;
-  }
-
-  // Status indicator: "status: ok/warn/error/info"
-  var statusMatch = blockText.match(/status[:\s]+(ok|success|warn|warning|error|fail|failed|info)/i);
-  if (statusMatch) {
-    var statusVal = statusMatch[1].toLowerCase();
-    var statusClass = 'a2ui-status-info';
-    if (statusVal === 'ok' || statusVal === 'success') statusClass = 'a2ui-status-ok';
-    else if (statusVal === 'warn' || statusVal === 'warning') statusClass = 'a2ui-status-warn';
-    else if (statusVal === 'error' || statusVal === 'fail' || statusVal === 'failed') statusClass = 'a2ui-status-error';
-    var statusLabel = blockText.replace(/status[:\s]+\S+/i, '').trim() || statusVal;
-    var statusDiv = document.createElement('div');
-    statusDiv.className = 'a2ui-status ' + statusClass;
-    var dot = document.createElement('span');
-    dot.style.cssText = 'width:8px;height:8px;border-radius:50%;background:currentColor;flex-shrink:0;';
-    statusDiv.appendChild(dot);
-    statusDiv.appendChild(document.createTextNode(statusLabel.charAt(0).toUpperCase() + statusLabel.slice(1)));
-    container.appendChild(statusDiv);
-    return container;
-  }
-
-  // Key-value list: lines with "key: value" pattern
-  var kvLines = lines.filter(function(l) { return l.indexOf(':') !== -1; });
-  if (kvLines.length >= 2 && kvLines.length === lines.length) {
-    var kvDiv = document.createElement('div');
-    kvDiv.className = 'a2ui-kv';
-    kvLines.forEach(function(line) {
-      var colonIdx = line.indexOf(':');
-      var key = line.substring(0, colonIdx).trim();
-      var val = line.substring(colonIdx + 1).trim();
-      var keyEl = document.createElement('span');
-      keyEl.className = 'a2ui-kv-key';
-      keyEl.textContent = key;
-      var valEl = document.createElement('span');
-      valEl.className = 'a2ui-kv-val';
-      valEl.textContent = val;
-      kvDiv.appendChild(keyEl);
-      kvDiv.appendChild(valEl);
-    });
-    container.appendChild(kvDiv);
-    return container;
-  }
-
-  // Fallback: render as preformatted text
-  var pre = document.createElement('pre');
-  pre.style.cssText = 'font-family:var(--font-mono);font-size:12px;white-space:pre-wrap;margin:0;';
-  pre.textContent = blockText;
-  container.appendChild(pre);
-  return container;
 }
 
 initApp();


### PR DESCRIPTION
## Summary

- **Sidebar never hides**: DM is now a normal channel switch (`dm-<slug>`), not an overlay. The sidebar stays visible at all times — exactly how Slack works.
- **"Direct messages" section** in sidebar lists all agents as clickable DM nav items. Active agent gets highlighted.
- **Stream strip** (live agent stdout) appears inside the main panel above messages when on a `dm-*` channel, hides when leaving.
- **Header updates** to show agent name (not `# dm-ceo`) when in DM channel.
- Agent "DM" buttons in sidebar now call `switchChannel('dm-'+slug)` instead of the old overlay.
- `renderSidebarDMs()` wired into all init and refresh paths.

## Architecture

```
switchChannel('dm-ceo')
  → currentChannel = 'dm-ceo'
  → onDMChannelEnter('ceo')
      → show #dm-stream-strip
      → connectAgentStream(slug)  [SSE to /api/agent-stream/{slug}]
      → renderSidebarDMs()        [highlights CEO as active]

switchChannel('general')
  → currentChannel = 'general'
  → onDMChannelLeave()
      → hide #dm-stream-strip, close SSE
      → renderSidebarDMs()        [clears active highlight]
```

## Test plan

- [x] `sidebar.display === "flex"` after switching to dm-ceo (sidebar never hides)
- [x] `currentChannel === "dm-ceo"` after clicking CEO in DM section
- [x] `#dm-stream-strip` visible on dm-* channel, hidden on regular channel
- [x] `channel-title` shows `"CEO"` not `"# dm-ceo"`
- [x] Active DM highlighted in sidebar (`#sidebar-dms .sidebar-item.active`)
- [x] All state clears correctly when switching back to `general`
- [x] Build passes (`go build ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)