### PR TITLE
feat: make onboarding questions useful — persist and inject into agents

### DIFF
--- a/internal/commands/cmd_config.go
+++ b/internal/commands/cmd_config.go
@@ -127,9 +127,19 @@ func configSet(ctx *SlashContext, key, value string) error {
 		cfg.DevURL = value
 	case "default_format":
 		cfg.DefaultFormat = value
+	case "company_name":
+		cfg.CompanyName = value
+	case "company_description":
+		cfg.CompanyDescription = value
+	case "company_goals":
+		cfg.CompanyGoals = value
+	case "company_size":
+		cfg.CompanySize = value
+	case "company_priority":
+		cfg.CompanyPriority = value
 	default:
 		ctx.AddMessage("system", "Unknown config key: "+key+
-			"\nValid keys: api_key, composio_api_key, action_provider, workspace_id, workspace_slug, llm_provider, gemini_api_key, anthropic_api_key, openai_api_key, minimax_api_key, pack, team_lead_slug, dev_url, default_format")
+			"\nValid keys: api_key, composio_api_key, action_provider, workspace_id, workspace_slug, llm_provider, gemini_api_key, anthropic_api_key, openai_api_key, minimax_api_key, pack, team_lead_slug, dev_url, default_format, company_name, company_description, company_goals, company_size, company_priority")
 		return nil
 	}
 

--- a/internal/company/manifest.go
+++ b/internal/company/manifest.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/config"
 )
 
 type MemberSpec struct {
@@ -84,8 +85,26 @@ func LoadManifest() (Manifest, error) {
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return Manifest{}, err
 	}
+	manifest = backfillFromConfig(manifest)
 	manifest = normalizeManifest(manifest)
 	return manifest, nil
+}
+
+// backfillFromConfig fills empty manifest Name/Description from config
+// so onboarding answers flow into the company manifest.
+func backfillFromConfig(manifest Manifest) Manifest {
+	cfg, _ := config.Load()
+	if strings.TrimSpace(manifest.Name) == "" || manifest.Name == "The WUPHF Office" {
+		if name := strings.TrimSpace(cfg.CompanyName); name != "" {
+			manifest.Name = name
+		}
+	}
+	if strings.TrimSpace(manifest.Description) == "" || manifest.Description == "Autonomous office runtime for the founding team." {
+		if desc := strings.TrimSpace(cfg.CompanyDescription); desc != "" {
+			manifest.Description = desc
+		}
+	}
+	return manifest
 }
 
 func SaveManifest(manifest Manifest) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,11 @@ type Config struct {
 	TaskReminderMinutes int    `json:"task_reminder_minutes,omitempty"`
 	TaskRecheckMinutes  int    `json:"task_recheck_minutes,omitempty"`
 	TelegramBotToken    string `json:"telegram_bot_token,omitempty"`
+	CompanyName         string `json:"company_name,omitempty"`
+	CompanyDescription  string `json:"company_description,omitempty"`
+	CompanyGoals        string `json:"company_goals,omitempty"`
+	CompanySize         string `json:"company_size,omitempty"`
+	CompanyPriority     string `json:"company_priority,omitempty"`
 }
 
 // ConfigPath returns the absolute path to ~/.wuphf/config.json, with a legacy
@@ -356,6 +361,30 @@ func SaveTelegramBotToken(token string) {
 	cfg, _ := Load()
 	cfg.TelegramBotToken = strings.TrimSpace(token)
 	_ = Save(cfg)
+}
+
+// CompanyContextBlock returns a prompt fragment with company context for agent
+// system prompts. Returns empty string if no company name is configured.
+func CompanyContextBlock() string {
+	cfg, _ := Load()
+	name := strings.TrimSpace(cfg.CompanyName)
+	if name == "" {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("== COMPANY CONTEXT ==\n")
+	sb.WriteString(fmt.Sprintf("Company: %s\n", name))
+	if desc := strings.TrimSpace(cfg.CompanyDescription); desc != "" {
+		sb.WriteString(fmt.Sprintf("What they do: %s\n", desc))
+	}
+	if goals := strings.TrimSpace(cfg.CompanyGoals); goals != "" {
+		sb.WriteString(fmt.Sprintf("Current goals: %s\n", goals))
+	}
+	if priority := strings.TrimSpace(cfg.CompanyPriority); priority != "" {
+		sb.WriteString(fmt.Sprintf("Immediate priority: %s\n", priority))
+	}
+	sb.WriteString("\n")
+	return sb.String()
 }
 
 // ResolveGeminiAPIKey resolves the Gemini API key.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -33,18 +34,23 @@ func TestLoadMissingFileReturnsEmpty(t *testing.T) {
 func TestRoundtrip(t *testing.T) {
 	withTempConfig(t, func(_ string) {
 		in := Config{
-			APIKey:          "test-key",
-			Email:           "user@example.com",
-			WorkspaceID:     "ws-123",
-			WorkspaceSlug:   "my-ws",
-			LLMProvider:     "gemini",
-			GeminiAPIKey:    "gemini-key",
-			AnthropicAPIKey: "anthropic-key",
-			OpenAIAPIKey:    "openai-key",
-			MinimaxAPIKey:   "minimax-key",
-			DefaultFormat:   "json",
-			DefaultTimeout:  30_000,
-			DevURL:          "http://localhost:3000",
+			APIKey:             "test-key",
+			Email:              "user@example.com",
+			WorkspaceID:        "ws-123",
+			WorkspaceSlug:      "my-ws",
+			LLMProvider:        "gemini",
+			GeminiAPIKey:       "gemini-key",
+			AnthropicAPIKey:    "anthropic-key",
+			OpenAIAPIKey:       "openai-key",
+			MinimaxAPIKey:      "minimax-key",
+			DefaultFormat:      "json",
+			DefaultTimeout:     30_000,
+			DevURL:             "http://localhost:3000",
+			CompanyName:        "Acme Corp",
+			CompanyDescription: "AI-powered analytics",
+			CompanyGoals:       "Ship MVP, get 10 customers",
+			CompanySize:        "2-5",
+			CompanyPriority:    "Launch landing page",
 		}
 		if err := Save(in); err != nil {
 			t.Fatalf("Save failed: %v", err)
@@ -265,6 +271,51 @@ func TestResolveMinimaxAPIKeyConfig(t *testing.T) {
 		_ = Save(Config{MinimaxAPIKey: "cfg-minimax"})
 		if got := ResolveMinimaxAPIKey(); got != "cfg-minimax" {
 			t.Fatalf("expected config fallback, got %q", got)
+		}
+	})
+}
+
+func TestCompanyContextBlockFull(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		_ = Save(Config{
+			CompanyName:        "Acme Corp",
+			CompanyDescription: "AI analytics for e-commerce",
+			CompanyGoals:       "Ship MVP, get 10 customers",
+			CompanyPriority:    "Launch landing page",
+		})
+		block := CompanyContextBlock()
+		if block == "" {
+			t.Fatal("expected non-empty company context block")
+		}
+		for _, want := range []string{"Acme Corp", "AI analytics", "Ship MVP", "Launch landing page"} {
+			if !strings.Contains(block, want) {
+				t.Errorf("expected block to contain %q, got:\n%s", want, block)
+			}
+		}
+	})
+}
+
+func TestCompanyContextBlockEmpty(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		block := CompanyContextBlock()
+		if block != "" {
+			t.Fatalf("expected empty block when no company name, got: %q", block)
+		}
+	})
+}
+
+func TestCompanyContextBlockNameOnly(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		_ = Save(Config{CompanyName: "Solo Inc"})
+		block := CompanyContextBlock()
+		if block == "" {
+			t.Fatal("expected non-empty block with name only")
+		}
+		if !strings.Contains(block, "Solo Inc") {
+			t.Errorf("expected block to contain company name")
+		}
+		if strings.Contains(block, "Current goals") {
+			t.Errorf("should not contain goals when empty")
 		}
 	})
 }

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -705,6 +705,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/telegram/groups", b.requireAuth(b.handleTelegramGroups))
 	mux.HandleFunc("/bridges", b.requireAuth(b.handleBridge))
 	mux.HandleFunc("/queue", b.requireAuth(b.handleQueue))
+	mux.HandleFunc("/company", b.requireAuth(b.handleCompany))
 	mux.HandleFunc("/v1/logs", b.requireAuth(b.handleOTLPLogs))
 	mux.HandleFunc("/events", b.handleEvents)
 	mux.HandleFunc("/agent-stream/", b.requireAuth(b.handleAgentStream))
@@ -3218,6 +3219,57 @@ func (b *Broker) handleQueue(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(b.QueueSnapshot())
+}
+
+func (b *Broker) handleCompany(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		cfg, _ := config.Load()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"name":        cfg.CompanyName,
+			"description": cfg.CompanyDescription,
+			"goals":       cfg.CompanyGoals,
+			"size":        cfg.CompanySize,
+			"priority":    cfg.CompanyPriority,
+		})
+	case http.MethodPost:
+		var body struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			Goals       string `json:"goals"`
+			Size        string `json:"size"`
+			Priority    string `json:"priority"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		cfg, _ := config.Load()
+		if body.Name != "" {
+			cfg.CompanyName = strings.TrimSpace(body.Name)
+		}
+		if body.Description != "" {
+			cfg.CompanyDescription = strings.TrimSpace(body.Description)
+		}
+		if body.Goals != "" {
+			cfg.CompanyGoals = strings.TrimSpace(body.Goals)
+		}
+		if body.Size != "" {
+			cfg.CompanySize = strings.TrimSpace(body.Size)
+		}
+		if body.Priority != "" {
+			cfg.CompanyPriority = strings.TrimSpace(body.Priority)
+		}
+		if err := config.Save(cfg); err != nil {
+			http.Error(w, "save failed", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
 }
 
 func (b *Broker) handleOfficeMembers(w http.ResponseWriter, r *http.Request) {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -2677,8 +2677,11 @@ func (l *Launcher) buildPrompt(slug string) string {
 
 	var sb strings.Builder
 
+	companyCtx := config.CompanyContextBlock()
+
 	if l.isOneOnOne() {
 		sb.WriteString(fmt.Sprintf("You are %s in a direct one-on-one WUPHF session with the human.\n\n", agentCfg.Name))
+		sb.WriteString(companyCtx)
 		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
 		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
 		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
@@ -2717,6 +2720,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 
 	if slug == lead {
 		sb.WriteString(fmt.Sprintf("You are the %s of the %s.\n\n", agentCfg.Name, l.PackName()))
+		sb.WriteString(companyCtx)
 		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
 		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
 		sb.WriteString("== YOUR TEAM ==\n")
@@ -2778,6 +2782,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 		}
 	} else {
 		sb.WriteString(fmt.Sprintf("You are %s on the %s.\n", agentCfg.Name, l.PackName()))
+		sb.WriteString(companyCtx)
 		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
 		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
 		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))

--- a/web/index.html
+++ b/web/index.html
@@ -2570,6 +2570,18 @@ function renderTeamGrid() {
 
 // ─── Launch ───
 function launchOffice() {
+  // Persist onboarding answers to broker config — fire and forget
+  var companyData = {
+    name: (document.getElementById('q-company') ? document.getElementById('q-company').value.trim() : ''),
+    description: (document.getElementById('q-description') ? document.getElementById('q-description').value.trim() : ''),
+    goals: (document.getElementById('q-goals') ? document.getElementById('q-goals').value.trim() : ''),
+    size: selectedSize || '',
+    priority: (document.getElementById('q-priority') ? document.getElementById('q-priority').value.trim() : '')
+  };
+  if (companyData.name || companyData.description || companyData.goals) {
+    WuphfAPI.post('/company', companyData).catch(function() {});
+  }
+
   document.getElementById('onboarding').style.display = 'none';
   showSplashScreen(function() { showOffice(); });
 }


### PR DESCRIPTION
## Summary

The web onboarding collected 5 questions (company name, description, goals, team size, priority) but only used 3 for a client-side regex to pre-check agent cards. Nothing persisted past page refresh. Now the full pipeline works:

**Web form → broker API → config.json → company manifest → agent system prompts**

**Config layer**
- 5 new fields on `Config`: `CompanyName`, `CompanyDescription`, `CompanyGoals`, `CompanySize`, `CompanyPriority`
- `CompanyContextBlock()` builds a system prompt fragment only when company name is set
- Fields settable via `/config set company_name "Acme"` etc.
- Not displayed in `/config show` (metadata, not user-facing config)

**Broker: `/company` endpoint**
- GET returns stored company fields
- POST accepts `{name, description, goals, size, priority}`, persists to config

**Company manifest backfill**
- `LoadManifest()` now replaces default "The WUPHF Office" name/description with config values when set

**Agent prompt injection**
- All 3 prompt paths in `buildPrompt()` (1:1, lead, specialist) inject the company context block after the identity line
- Agents now know "You work at Acme Corp. They build AI analytics for e-commerce. Current goals: Ship MVP..."

**Web UI**
- `launchOffice()` collects all form values and POSTs to `/api/company` (fire-and-forget, non-blocking)

## Test Coverage
- 3 new tests for `CompanyContextBlock()` (full context, empty, name-only)
- Config roundtrip test expanded with all 5 company fields
- All existing tests pass (config, company, team, commands)

## Test plan
- [x] All Go tests pass (18 packages, 0 failures)
- [x] Build compiles clean
- [x] CompanyContextBlock returns empty when no name set
- [x] CompanyContextBlock includes all set fields
- [x] Config roundtrip preserves company fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)