### PR TITLE
fix: agent/channel creation in web mode + prompt-based UI

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -416,6 +416,7 @@ type Broker struct {
 	actionSubscribers   map[int]chan officeActionLog
 	activity            map[string]agentActivitySnapshot
 	activitySubscribers map[int]chan agentActivitySnapshot
+	officeSubscribers   map[int]chan officeChangeEvent
 	nextSubscriberID    int
 	agentStreams        map[string]*agentStreamBuffer
 	mu                  sync.Mutex
@@ -424,6 +425,8 @@ type Broker struct {
 	addr                string         // actual listen address (useful when port=0)
 	webUIOrigins        []string       // allowed CORS origins for web UI (set by ServeWebUI)
 	runtimeProvider     string         // "codex" or "claude" — set by launcher
+	generateMemberFn    func(prompt string) (generatedMemberTemplate, error)
+	generateChannelFn   func(prompt string) (generatedChannelTemplate, error)
 	policies            []officePolicy // active office operating rules
 	rateLimitBuckets    map[string]ipRateLimitBucket
 	rateLimitWindow     time.Duration
@@ -511,6 +514,7 @@ func NewBroker() *Broker {
 		actionSubscribers:   make(map[int]chan officeActionLog),
 		activity:            make(map[string]agentActivitySnapshot),
 		activitySubscribers: make(map[int]chan agentActivitySnapshot),
+		officeSubscribers:   make(map[int]chan officeChangeEvent),
 		agentStreams:        make(map[string]*agentStreamBuffer),
 		rateLimitBuckets:    make(map[string]ipRateLimitBucket),
 		rateLimitWindow:     defaultRateLimitWindow,
@@ -623,6 +627,42 @@ func (b *Broker) SubscribeActivity(buffer int) (<-chan agentActivitySnapshot, fu
 	}
 }
 
+type officeChangeEvent struct {
+	Kind string `json:"kind"` // "member_created", "member_removed", "channel_created", "channel_removed"
+	Slug string `json:"slug"`
+}
+
+func (b *Broker) SubscribeOfficeChanges(buffer int) (<-chan officeChangeEvent, func()) {
+	if buffer <= 0 {
+		buffer = 1
+	}
+	ch := make(chan officeChangeEvent, buffer)
+
+	b.mu.Lock()
+	id := b.nextSubscriberID
+	b.nextSubscriberID++
+	b.officeSubscribers[id] = ch
+	b.mu.Unlock()
+
+	return ch, func() {
+		b.mu.Lock()
+		if existing, ok := b.officeSubscribers[id]; ok {
+			delete(b.officeSubscribers, id)
+			close(existing)
+		}
+		b.mu.Unlock()
+	}
+}
+
+func (b *Broker) publishOfficeChangeLocked(evt officeChangeEvent) {
+	for _, ch := range b.officeSubscribers {
+		select {
+		case ch <- evt:
+		default:
+		}
+	}
+}
+
 func (b *Broker) UpdateAgentActivity(update agentActivitySnapshot) {
 	slug := normalizeChannelSlug(update.Slug)
 	if slug == "" {
@@ -708,7 +748,9 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/reactions", b.requireAuth(b.handleReactions))
 	mux.HandleFunc("/notifications/nex", b.requireAuth(b.handleNexNotifications))
 	mux.HandleFunc("/office-members", b.requireAuth(b.handleOfficeMembers))
+	mux.HandleFunc("/office-members/generate", b.requireAuth(b.handleGenerateMember))
 	mux.HandleFunc("/channels", b.requireAuth(b.handleChannels))
+	mux.HandleFunc("/channels/generate", b.requireAuth(b.handleGenerateChannel))
 	mux.HandleFunc("/channel-members", b.requireAuth(b.handleChannelMembers))
 	mux.HandleFunc("/members", b.requireAuth(b.handleMembers))
 	mux.HandleFunc("/tasks", b.requireAuth(b.handleTasks))
@@ -990,6 +1032,8 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 	defer unsubscribeActions()
 	activity, unsubscribeActivity := b.SubscribeActivity(256)
 	defer unsubscribeActivity()
+	officeChanges, unsubscribeOffice := b.SubscribeOfficeChanges(64)
+	defer unsubscribeOffice()
 
 	writeEvent := func(name string, payload any) error {
 		data, err := json.Marshal(payload)
@@ -1024,6 +1068,10 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		case snapshot, ok := <-activity:
 			if !ok || writeEvent("activity", map[string]any{"activity": snapshot}) != nil {
+				return
+			}
+		case evt, ok := <-officeChanges:
+			if !ok || writeEvent("office_changed", evt) != nil {
 				return
 			}
 		case <-heartbeat.C:
@@ -1949,6 +1997,14 @@ func (b *Broker) SetFocusMode(enabled bool) error {
 	defer b.mu.Unlock()
 	b.focusMode = enabled
 	return b.saveLocked()
+}
+
+func (b *Broker) SetGenerateMemberFn(fn func(string) (generatedMemberTemplate, error)) {
+	b.generateMemberFn = fn
+}
+
+func (b *Broker) SetGenerateChannelFn(fn func(string) (generatedChannelTemplate, error)) {
+	b.generateChannelFn = fn
 }
 
 func (b *Broker) FocusModeEnabled() bool {
@@ -3398,6 +3454,7 @@ func (b *Broker) handleOfficeMembers(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
 				return
 			}
+			b.publishOfficeChangeLocked(officeChangeEvent{Kind: "member_created", Slug: slug})
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{"member": member})
 		case "update":
@@ -3476,6 +3533,7 @@ func (b *Broker) handleOfficeMembers(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
 				return
 			}
+			b.publishOfficeChangeLocked(officeChangeEvent{Kind: "member_removed", Slug: slug})
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:
@@ -3484,6 +3542,66 @@ func (b *Broker) handleOfficeMembers(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+func (b *Broker) handleGenerateMember(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if b.generateMemberFn == nil {
+		http.Error(w, "generate not available", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	prompt := strings.TrimSpace(body.Prompt)
+	if prompt == "" {
+		http.Error(w, "prompt required", http.StatusBadRequest)
+		return
+	}
+	tmpl, err := b.generateMemberFn(prompt)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(tmpl)
+}
+
+func (b *Broker) handleGenerateChannel(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if b.generateChannelFn == nil {
+		http.Error(w, "generate not available", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		Prompt string `json:"prompt"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	prompt := strings.TrimSpace(body.Prompt)
+	if prompt == "" {
+		http.Error(w, "prompt required", http.StatusBadRequest)
+		return
+	}
+	tmpl, err := b.generateChannelFn(prompt)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(tmpl)
 }
 
 func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
@@ -3578,6 +3696,7 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
 				return
 			}
+			b.publishOfficeChangeLocked(officeChangeEvent{Kind: "channel_created", Slug: slug})
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{"channel": ch})
 		case "remove":
@@ -3623,6 +3742,7 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
 				return
 			}
+			b.publishOfficeChangeLocked(officeChangeEvent{Kind: "channel_removed", Slug: slug})
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -2521,6 +2521,12 @@ func (l *Launcher) listTeamPanes() ([]int, error) {
 	return parseAgentPaneIndices(string(out)), nil
 }
 
+// HasLiveTmuxSession returns true if a wuphf-team tmux session is running.
+func HasLiveTmuxSession() bool {
+	err := exec.Command("tmux", "-L", tmuxSocketName, "has-session", "-t", SessionName).Run()
+	return err == nil
+}
+
 func isMissingTmuxSession(output string) bool {
 	normalized := strings.ToLower(strings.TrimSpace(output))
 	if normalized == "" {
@@ -3336,6 +3342,8 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		return fmt.Errorf("start broker: %w", err)
 	}
 
+	l.broker.SetGenerateMemberFn(l.GenerateMemberTemplateFromPrompt)
+	l.broker.SetGenerateChannelFn(l.GenerateChannelTemplateFromPrompt)
 	l.broker.ServeWebUI(webPort)
 
 	// Web mode always uses queued headless turns so notifications can push

--- a/internal/team/template.go
+++ b/internal/team/template.go
@@ -89,6 +89,83 @@ func parseGeneratedMemberTemplate(raw string) (generatedMemberTemplate, error) {
 	return tmpl, nil
 }
 
+type generatedChannelTemplate struct {
+	Slug        string   `json:"slug"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Members     []string `json:"members"`
+}
+
+func (l *Launcher) GenerateChannelTemplateFromPrompt(request string) (generatedChannelTemplate, error) {
+	request = strings.TrimSpace(request)
+	if request == "" {
+		return generatedChannelTemplate{}, fmt.Errorf("prompt is required")
+	}
+	if stub := strings.TrimSpace(os.Getenv("WUPHF_CHANNEL_TEMPLATE_STUB")); stub != "" {
+		return parseGeneratedChannelTemplate(stub)
+	}
+	systemPrompt := l.buildPrompt(l.officeLeadSlug()) + `
+
+You are designing a NEW office channel for WUPHF.
+Return exactly one JSON object and nothing else.
+Do not wrap it in markdown fences.
+Do not explain your reasoning.
+
+Required schema:
+{
+  "slug": "lowercase-hyphen-slug",
+  "name": "Display Name",
+  "description": "One sentence explaining the channel purpose",
+  "members": ["ceo", "relevant-member-slug"]
+}
+
+Constraints:
+- Never use slug "general".
+- Keep the channel focused on a specific topic or workstream.
+- Always include "ceo" in members.
+- Pick members that match the channel topic from the existing office roster.
+- If the prompt is vague, still make a crisp decision.
+`
+	userPrompt := "Design a new office channel from this request:\n\n" + request
+	raw, err := provider.RunConfiguredOneShot(systemPrompt, userPrompt, l.cwd)
+	if err != nil {
+		return generatedChannelTemplate{}, err
+	}
+	jsonText := extractJSONObjectString(raw)
+	if jsonText == "" {
+		jsonText = strings.TrimSpace(raw)
+	}
+	return parseGeneratedChannelTemplate(jsonText)
+}
+
+func parseGeneratedChannelTemplate(raw string) (generatedChannelTemplate, error) {
+	var tmpl generatedChannelTemplate
+	if err := json.Unmarshal([]byte(raw), &tmpl); err != nil {
+		return generatedChannelTemplate{}, fmt.Errorf("parse generated channel template: %w", err)
+	}
+	tmpl.Slug = normalizeChannelSlug(tmpl.Slug)
+	if tmpl.Slug == "" || tmpl.Slug == "general" {
+		return generatedChannelTemplate{}, fmt.Errorf("generated invalid slug %q", tmpl.Slug)
+	}
+	if tmpl.Name == "" {
+		tmpl.Name = humanizeSlug(tmpl.Slug)
+	}
+	if tmpl.Description == "" {
+		tmpl.Description = defaultTeamChannelDescription(tmpl.Slug, tmpl.Name)
+	}
+	hasCEO := false
+	for _, m := range tmpl.Members {
+		if m == "ceo" {
+			hasCEO = true
+			break
+		}
+	}
+	if !hasCEO {
+		tmpl.Members = append([]string{"ceo"}, tmpl.Members...)
+	}
+	return tmpl, nil
+}
+
 func extractJSONObjectString(raw string) string {
 	start := strings.Index(raw, "{")
 	if start < 0 {

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -1744,6 +1744,11 @@ func handleTeamMember(ctx context.Context, _ *mcp.CallToolRequest, args TeamMemb
 }
 
 func reconfigureLiveOffice() error {
+	if !team.HasLiveTmuxSession() {
+		// Web mode: no tmux session to reconfigure. The broker state is already
+		// updated, and the headless turn system picks up new members by slug.
+		return nil
+	}
 	l, err := team.NewLauncher("")
 	if err != nil {
 		return err

--- a/web/index.html
+++ b/web/index.html
@@ -2671,6 +2671,7 @@ function showOffice() {
         startMessagePolling();
         startRequestPolling();
         startMemberActivityPolling();
+        connectOfficeEvents();
       })
       .catch(function() {
         renderSidebarAgents();
@@ -3470,6 +3471,178 @@ function renderSidebarChannels() {
     btn.appendChild(name);
     container.appendChild(btn);
   });
+
+  // "New Channel" button
+  var addBtn = document.createElement('button');
+  addBtn.className = 'sidebar-item sidebar-add-btn';
+  addBtn.style.cssText = 'color:var(--text-secondary);opacity:0.7;font-size:12px;';
+  addBtn.addEventListener('click', function() { openChannelWizard(); });
+  var plusIcon = document.createElement('span');
+  plusIcon.className = 'sidebar-item-icon';
+  plusIcon.style.cssText = 'font-weight:bold;font-size:14px;';
+  plusIcon.textContent = '+';
+  var addLabel = document.createElement('span');
+  addLabel.textContent = 'New Channel';
+  addBtn.appendChild(plusIcon);
+  addBtn.appendChild(addLabel);
+  container.appendChild(addBtn);
+}
+
+function openChannelWizard() {
+  var overlay = document.createElement('div');
+  overlay.className = 'agent-wizard-overlay';
+  overlay.addEventListener('click', function(e) { if (e.target === overlay) overlay.remove(); });
+
+  var card = document.createElement('div');
+  card.className = 'agent-wizard-card';
+
+  var title = document.createElement('h3');
+  title.textContent = 'New Channel';
+  card.appendChild(title);
+
+  var promptSection = document.createElement('div');
+  var formSection = document.createElement('div');
+
+  // ── Mode toggle ──
+  var modeToggle = document.createElement('div');
+  modeToggle.style.cssText = 'display:flex;gap:0;margin-bottom:12px;border:1px solid var(--border);border-radius:6px;overflow:hidden;';
+  var describeTab = document.createElement('button');
+  describeTab.textContent = 'Describe';
+  describeTab.className = 'btn btn-sm';
+  describeTab.style.cssText = 'flex:1;border-radius:0;border:none;background:var(--accent);color:#fff;';
+  var manualTab = document.createElement('button');
+  manualTab.textContent = 'Manual';
+  manualTab.className = 'btn btn-sm';
+  manualTab.style.cssText = 'flex:1;border-radius:0;border:none;background:transparent;color:var(--text-secondary);';
+
+  function setMode(mode) {
+    if (mode === 'describe') {
+      describeTab.style.background = 'var(--accent)';
+      describeTab.style.color = '#fff';
+      manualTab.style.background = 'transparent';
+      manualTab.style.color = 'var(--text-secondary)';
+      promptSection.style.display = '';
+      formSection.style.display = 'none';
+    } else {
+      manualTab.style.background = 'var(--accent)';
+      manualTab.style.color = '#fff';
+      describeTab.style.background = 'transparent';
+      describeTab.style.color = 'var(--text-secondary)';
+      promptSection.style.display = 'none';
+      formSection.style.display = '';
+    }
+  }
+  describeTab.addEventListener('click', function() { setMode('describe'); });
+  manualTab.addEventListener('click', function() { setMode('manual'); });
+  modeToggle.appendChild(describeTab);
+  modeToggle.appendChild(manualTab);
+  card.appendChild(modeToggle);
+
+  // ── Describe section ──
+  var promptField = document.createElement('div');
+  promptField.className = 'agent-wizard-field';
+  var promptLabel = document.createElement('label');
+  promptLabel.textContent = 'Describe the channel you want';
+  promptField.appendChild(promptLabel);
+  var promptInput = document.createElement('textarea');
+  promptInput.placeholder = 'e.g. "A channel for the frontend team to discuss UI work"';
+  promptInput.style.minHeight = '80px';
+  promptField.appendChild(promptInput);
+  promptSection.appendChild(promptField);
+
+  var generateBtn = document.createElement('button');
+  generateBtn.className = 'btn btn-primary';
+  generateBtn.style.width = '100%';
+  generateBtn.textContent = 'Generate';
+  generateBtn.addEventListener('click', function() {
+    var prompt = (promptInput.value || '').trim();
+    if (!prompt) { showNotice('Describe the channel first', 'error'); return; }
+    generateBtn.disabled = true;
+    generateBtn.textContent = 'Generating...';
+    WuphfAPI.post('/channels/generate', { prompt: prompt })
+      .then(function(tmpl) {
+        chInputs.slug.value = tmpl.slug || '';
+        chInputs.name.value = tmpl.name || '';
+        chInputs.description.value = tmpl.description || '';
+        setMode('manual');
+        generateBtn.disabled = false;
+        generateBtn.textContent = 'Generate';
+      })
+      .catch(function(e) {
+        generateBtn.disabled = false;
+        generateBtn.textContent = 'Generate';
+        showNotice('Generation failed: ' + (e.message || e), 'error');
+      });
+  });
+  promptSection.appendChild(generateBtn);
+  card.appendChild(promptSection);
+
+  // ── Manual form fields ──
+  var chFields = [
+    { key: 'slug', label: 'Slug', placeholder: 'e.g. frontend' },
+    { key: 'name', label: 'Name', placeholder: 'e.g. Frontend' },
+    { key: 'description', label: 'Description', placeholder: 'What is this channel for?', type: 'textarea' }
+  ];
+  var chInputs = {};
+  chFields.forEach(function(f) {
+    var fieldDiv = document.createElement('div');
+    fieldDiv.className = 'agent-wizard-field';
+    var label = document.createElement('label');
+    label.textContent = f.label;
+    fieldDiv.appendChild(label);
+    var inp;
+    if (f.type === 'textarea') {
+      inp = document.createElement('textarea');
+    } else {
+      inp = document.createElement('input');
+      inp.type = 'text';
+    }
+    inp.placeholder = f.placeholder || '';
+    chInputs[f.key] = inp;
+    fieldDiv.appendChild(inp);
+    formSection.appendChild(fieldDiv);
+  });
+  card.appendChild(formSection);
+  formSection.style.display = 'none';
+
+  // ── Actions ──
+  var actions = document.createElement('div');
+  actions.className = 'agent-wizard-actions';
+  var cancelBtn = document.createElement('button');
+  cancelBtn.className = 'btn btn-secondary';
+  cancelBtn.textContent = 'Cancel';
+  cancelBtn.addEventListener('click', function() { overlay.remove(); });
+
+  var submitBtn = document.createElement('button');
+  submitBtn.className = 'btn btn-primary';
+  submitBtn.textContent = 'Create Channel';
+  submitBtn.addEventListener('click', function() {
+    var slug = (chInputs.slug.value || '').trim().toLowerCase().replace(/[^a-z0-9-]/g, '-');
+    var chName = (chInputs.name.value || '').trim();
+    var desc = (chInputs.description.value || '').trim();
+    if (!slug) { showNotice('Slug is required', 'error'); return; }
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Creating...';
+    WuphfAPI.post('/channels', { action: 'create', slug: slug, name: chName || slug, description: desc, created_by: 'you' })
+      .then(function() {
+        overlay.remove();
+        showNotice('Channel #' + slug + ' created', 'success');
+        CHANNELS.push({ name: chName || slug, desc: desc });
+        renderSidebarChannels();
+        switchChannel(chName || slug);
+      })
+      .catch(function(e) {
+        submitBtn.disabled = false;
+        submitBtn.textContent = 'Create Channel';
+        showNotice('Failed: ' + (e.message || e), 'error');
+      });
+  });
+
+  actions.appendChild(cancelBtn);
+  actions.appendChild(submitBtn);
+  card.appendChild(actions);
+  overlay.appendChild(card);
+  document.body.appendChild(overlay);
 }
 
 function switchChannel(name) {
@@ -4391,6 +4564,48 @@ function fetchMemberActivity() {
     cachedTasks = (results[1].tasks || results[1] || []);
     if (Array.isArray(cachedTasks) === false) cachedTasks = [];
     refreshLiveActivityUI();
+  });
+}
+
+// ─── Office change SSE (live sidebar updates) ───
+var officeEventSource = null;
+function connectOfficeEvents() {
+  if (officeEventSource) { officeEventSource.close(); officeEventSource = null; }
+  var url = WuphfAPI.sseURL('/events');
+  officeEventSource = new EventSource(url);
+  officeEventSource.addEventListener('office_changed', function() {
+    refreshOfficeSidebar();
+  });
+  officeEventSource.onerror = function() {
+    // Reconnection is automatic with EventSource
+  };
+}
+function refreshOfficeSidebar() {
+  Promise.all([
+    WuphfAPI.getOfficeMembers().catch(function() { return { members: [] }; }),
+    WuphfAPI.getChannels().catch(function() { return { channels: [] }; })
+  ]).then(function(results) {
+    if (results[0].members && results[0].members.length > 0) {
+      AGENTS = results[0].members.map(function(m) {
+        return {
+          slug: m.slug,
+          emoji: m.emoji || m.slug.charAt(0).toUpperCase(),
+          name: m.name || m.slug,
+          role: m.role || '',
+          checked: true,
+          type: m.type || 'specialist',
+          expertise: m.expertise || [],
+          personality: m.personality || ''
+        };
+      });
+    }
+    if (results[1].channels && results[1].channels.length > 0) {
+      CHANNELS = results[1].channels.map(function(ch) {
+        return { name: ch.name || ch.slug, desc: ch.description || '' };
+      });
+    }
+    renderSidebarAgents();
+    renderSidebarChannels();
   });
 }
 
@@ -5462,6 +5677,88 @@ function openAgentWizard(existingAgent) {
   title.textContent = isEdit ? 'Edit Agent' : 'New Agent';
   card.appendChild(title);
 
+  // ── Mode toggle (Describe / Manual) ──
+  var promptSection = document.createElement('div');
+  var formSection = document.createElement('div');
+
+  if (!isEdit) {
+    var modeToggle = document.createElement('div');
+    modeToggle.style.cssText = 'display:flex;gap:0;margin-bottom:12px;border:1px solid var(--border);border-radius:6px;overflow:hidden;';
+    var describeTab = document.createElement('button');
+    describeTab.textContent = 'Describe';
+    describeTab.className = 'btn btn-sm';
+    describeTab.style.cssText = 'flex:1;border-radius:0;border:none;background:var(--accent);color:#fff;';
+    var manualTab = document.createElement('button');
+    manualTab.textContent = 'Manual';
+    manualTab.className = 'btn btn-sm';
+    manualTab.style.cssText = 'flex:1;border-radius:0;border:none;background:transparent;color:var(--text-secondary);';
+
+    function setMode(mode) {
+      if (mode === 'describe') {
+        describeTab.style.background = 'var(--accent)';
+        describeTab.style.color = '#fff';
+        manualTab.style.background = 'transparent';
+        manualTab.style.color = 'var(--text-secondary)';
+        promptSection.style.display = '';
+        formSection.style.display = 'none';
+      } else {
+        manualTab.style.background = 'var(--accent)';
+        manualTab.style.color = '#fff';
+        describeTab.style.background = 'transparent';
+        describeTab.style.color = 'var(--text-secondary)';
+        promptSection.style.display = 'none';
+        formSection.style.display = '';
+      }
+    }
+    describeTab.addEventListener('click', function() { setMode('describe'); });
+    manualTab.addEventListener('click', function() { setMode('manual'); });
+    modeToggle.appendChild(describeTab);
+    modeToggle.appendChild(manualTab);
+    card.appendChild(modeToggle);
+
+    // ── Describe section ──
+    var promptField = document.createElement('div');
+    promptField.className = 'agent-wizard-field';
+    var promptLabel = document.createElement('label');
+    promptLabel.textContent = 'Describe the agent you want';
+    promptField.appendChild(promptLabel);
+    var promptInput = document.createElement('textarea');
+    promptInput.placeholder = 'e.g. "A DevOps engineer who manages CI/CD and infrastructure"';
+    promptInput.style.minHeight = '80px';
+    promptField.appendChild(promptInput);
+    promptSection.appendChild(promptField);
+
+    var generateBtn = document.createElement('button');
+    generateBtn.className = 'btn btn-primary';
+    generateBtn.style.width = '100%';
+    generateBtn.textContent = 'Generate';
+    generateBtn.addEventListener('click', function() {
+      var prompt = (promptInput.value || '').trim();
+      if (!prompt) { showNotice('Describe the agent first', 'error'); return; }
+      generateBtn.disabled = true;
+      generateBtn.textContent = 'Generating...';
+      WuphfAPI.post('/office-members/generate', { prompt: prompt })
+        .then(function(tmpl) {
+          inputs.slug.value = tmpl.slug || '';
+          inputs.name.value = tmpl.name || '';
+          inputs.role.value = tmpl.role || '';
+          inputs.expertise.value = (tmpl.expertise || []).join(', ');
+          inputs.personality.value = tmpl.personality || '';
+          setMode('manual');
+          generateBtn.disabled = false;
+          generateBtn.textContent = 'Generate';
+        })
+        .catch(function(e) {
+          generateBtn.disabled = false;
+          generateBtn.textContent = 'Generate';
+          showNotice('Generation failed: ' + (e.message || e), 'error');
+        });
+    });
+    promptSection.appendChild(generateBtn);
+    card.appendChild(promptSection);
+  }
+
+  // ── Manual form fields ──
   var fields = [
     { key: 'slug', label: 'Slug', type: 'input', placeholder: 'e.g. devops', disabled: isEdit },
     { key: 'name', label: 'Name', type: 'input', placeholder: 'e.g. DevOps Engineer' },
@@ -5495,8 +5792,10 @@ function openAgentWizard(existingAgent) {
     }
     inputs[f.key] = inp;
     fieldDiv.appendChild(inp);
-    card.appendChild(fieldDiv);
+    formSection.appendChild(fieldDiv);
   });
+  card.appendChild(formSection);
+  if (!isEdit) formSection.style.display = 'none';
 
   var actions = document.createElement('div');
   actions.className = 'agent-wizard-actions';
@@ -5557,7 +5856,9 @@ function openAgentWizard(existingAgent) {
   card.appendChild(actions);
   overlay.appendChild(card);
   document.body.appendChild(overlay);
-  inputs[isEdit ? 'name' : 'slug'].focus();
+  if (isEdit) {
+    inputs.name.focus();
+  }
 }
 
 // ─── Doctor Panel (#82, #97) ───


### PR DESCRIPTION
## Summary

- **Bug fix**: CEO agent couldn't create new agents in web mode. `reconfigureLiveOffice()` tried tmux operations that don't exist in web mode, causing the MCP `team_member` tool to error even though the broker already created the member. Now detects web mode and skips tmux reconfiguration.
- **SSE office_changed events**: Web UI now gets live updates when agents or channels are created/removed (no more stale sidebar).
- **Prompt-based agent creation**: Agent wizard modal now has Describe/Manual tabs. "Describe" sends a prompt to the LLM, which generates slug, name, role, expertise, and personality. Then switches to Manual for review before creating.
- **Channel creation UI**: New "+" button in sidebar channels section. Same Describe/Manual wizard pattern. Broker endpoints: `POST /office-members/generate` and `POST /channels/generate`.

## Test plan

- [ ] Launch `./wuphf` in web mode, ask CEO to create a new agent via chat — agent should appear in sidebar
- [ ] Click "New Agent" button, use Describe mode, verify LLM fills form fields
- [ ] Click "+" next to channels, create a channel via Describe and Manual modes
- [ ] Verify SSE updates: create an agent via one tab, verify it appears in another tab without refresh
- [ ] Verify `go test ./internal/team/... ./internal/teammcp/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)