### PR TITLE
feat: interactive Nex setup on first launch

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -2869,12 +2869,14 @@ func (b *Broker) handleHealth(w http.ResponseWriter, r *http.Request) {
 	b.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+	nexConnected := !config.ResolveNoNex() && config.ResolveAPIKey("") != ""
 	json.NewEncoder(w).Encode(map[string]any{
 		"status":           "ok",
 		"session_mode":     mode,
 		"one_on_one_agent": agent,
 		"focus_mode":       focus,
 		"provider":         provider,
+		"nex_connected":    nexConnected,
 		"build":            buildinfo.Current(),
 	})
 }

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -3403,7 +3403,7 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	// Ask user about Nex setup if API key is missing
 	if !config.ResolveNoNex() && config.ResolveAPIKey("") == "" {
 		fmt.Println()
-		fmt.Print("  Connect Nex for organizational memory? (agents remember across sessions) [Y/n] ")
+		fmt.Print("  Connect Nex for memory and context? [Y/n] ")
 		var answer string
 		fmt.Scanln(&answer)
 		answer = strings.TrimSpace(strings.ToLower(answer))

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -2774,7 +2774,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 	agentCfg := agentConfigFromMember(member)
 	officeMembers := l.officeMembersSnapshot()
 	lead := officeLeadSlugFrom(officeMembers, l.pack)
-	noNex := config.ResolveNoNex()
+	noNex := config.ResolveNoNex() || config.ResolveAPIKey("") == ""
 
 	var sb strings.Builder
 
@@ -3055,20 +3055,15 @@ func (l *Launcher) buildMCPServerMap() (map[string]any, error) {
 		entry["env"] = env
 	}
 
-	if !config.ResolveNoNex() {
+	if !config.ResolveNoNex() && apiKey != "" {
 		if nexMCP, err := exec.LookPath("nex-mcp"); err == nil {
-			nexEnv := map[string]string{}
-			if apiKey != "" {
-				nexEnv["WUPHF_API_KEY"] = apiKey
-				nexEnv["NEX_API_KEY"] = apiKey
-			}
-			nexEntry := map[string]any{
+			servers["nex"] = map[string]any{
 				"command": nexMCP,
+				"env": map[string]string{
+					"WUPHF_API_KEY": apiKey,
+					"NEX_API_KEY":   apiKey,
+				},
 			}
-			if len(nexEnv) > 0 {
-				nexEntry["env"] = nexEnv
-			}
-			servers["nex"] = nexEntry
 		}
 	}
 

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -33,6 +33,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/calendar"
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/setup"
 	"github.com/nex-crm/wuphf/internal/provider"
 )
 
@@ -3399,17 +3400,42 @@ func (l *Launcher) PreflightWeb() error {
 
 // LaunchWeb starts the broker, web UI server, and background agents without tmux.
 func (l *Launcher) LaunchWeb(webPort int) error {
-	// Prompt user about Nex setup if API key is missing
+	// Ask user about Nex setup if API key is missing
 	if !config.ResolveNoNex() && config.ResolveAPIKey("") == "" {
 		fmt.Println()
-		fmt.Println("  ⚠  Nex API key not configured.")
-		fmt.Println("     Agents will run without organizational memory (no knowledge graph,")
-		fmt.Println("     no cross-session context, no CRM/email/calendar integration).")
-		fmt.Println()
-		fmt.Println("     To set up Nex:  wuphf init")
-		fmt.Println("     To register:    nex setup")
-		fmt.Println("     To skip:        wuphf --no-nex")
-		fmt.Println()
+		fmt.Print("  Connect Nex for organizational memory? (agents remember across sessions) [Y/n] ")
+		var answer string
+		fmt.Scanln(&answer)
+		answer = strings.TrimSpace(strings.ToLower(answer))
+		if answer == "" || answer == "y" || answer == "yes" {
+			fmt.Println()
+			nexBin, err := exec.LookPath("nex")
+			if err != nil {
+				fmt.Println("  Nex CLI not found. Installing...")
+				if _, installErr := setup.InstallLatestCLI(); installErr != nil {
+					fmt.Printf("  Could not install: %v\n", installErr)
+					fmt.Println("  Continuing without Nex.")
+				} else {
+					nexBin, _ = exec.LookPath("nex")
+				}
+			}
+			if nexBin != "" {
+				cmd := exec.Command(nexBin, "setup")
+				cmd.Stdin = os.Stdin
+				cmd.Stdout = os.Stdout
+				cmd.Stderr = os.Stderr
+				if err := cmd.Run(); err != nil {
+					fmt.Printf("  Setup did not complete: %v\n", err)
+					fmt.Println("  Continuing without Nex.")
+				} else {
+					fmt.Println("  Nex connected.")
+				}
+			}
+			fmt.Println()
+		} else {
+			fmt.Println("  Skipping Nex. Agents will work without organizational memory.")
+			fmt.Println()
+		}
 	}
 
 	mcpConfig, err := l.ensureMCPConfig()

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -3399,6 +3399,19 @@ func (l *Launcher) PreflightWeb() error {
 
 // LaunchWeb starts the broker, web UI server, and background agents without tmux.
 func (l *Launcher) LaunchWeb(webPort int) error {
+	// Prompt user about Nex setup if API key is missing
+	if !config.ResolveNoNex() && config.ResolveAPIKey("") == "" {
+		fmt.Println()
+		fmt.Println("  ⚠  Nex API key not configured.")
+		fmt.Println("     Agents will run without organizational memory (no knowledge graph,")
+		fmt.Println("     no cross-session context, no CRM/email/calendar integration).")
+		fmt.Println()
+		fmt.Println("     To set up Nex:  wuphf init")
+		fmt.Println("     To register:    nex setup")
+		fmt.Println("     To skip:        wuphf --no-nex")
+		fmt.Println()
+	}
+
 	mcpConfig, err := l.ensureMCPConfig()
 	if err != nil {
 		return fmt.Errorf("prepare mcp config: %w", err)


### PR DESCRIPTION
## Summary

When launching WUPHF without a Nex API key, asks the user one question:

```
Connect Nex for memory and context? [Y/n]
```

- **Y**: runs `nex setup` interactively (installs nex CLI if needed)
- **n**: skips Nex, agents work without organizational memory

No instructions, no docs dump. Just a question and an action.

## Changes

- Don't load nex MCP server when API key is missing (prevents broken `query_context` calls wasting tokens)
- Interactive prompt in web mode, init flow in TUI mode (already existed)
- Health endpoint exposes `nex_connected` flag for web UI
- System prompt reflects nex availability accurately

## Test plan

- [x] `go build` clean
- [x] `go test ./internal/team/` passes
- [x] Without API key: prompts, declining skips nex
- [x] With API key: no prompt, nex loads normally
- [x] `--no-nex` flag: no prompt, nex disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)