### PR TITLE
docs: add Discord community badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WUPHF
 
+[![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/gjSySC3PzV)
+
 A terminal office where your AI team works in the open.
 
 One command. One shared office. CEO, PM, engineers, designer, CMO, CRO — all visible, arguing, claiming tasks, and shipping work instead of disappearing behind an API.


### PR DESCRIPTION
## Summary

- Adds a Discord community badge to the WUPHF README, matching the badge style used in [nex-as-a-skill](https://github.com/nex-crm/nex-as-a-skill)
- Link: https://discord.gg/gjSySC3PzV

## Test plan

- [ ] Badge renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)