### PR TITLE
feat(onboarding): 3-step wizard with broker state + TUI parity

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -677,6 +677,9 @@ type channelModel struct {
 
 	// lastAgentContent tracks the latest streaming text per agent for sidebar display.
 	lastAgentContent map[string]string
+
+	// onboardingChecklist holds the "Getting started" checklist rendered in the sidebar.
+	onboardingChecklist onboardingChecklist
 }
 
 func newChannelModel(threadsCollapsed bool) channelModel {
@@ -2229,7 +2232,7 @@ func (m channelModel) View() string {
 	// ── Sidebar ──────────────────────────────────────────────────────
 	sidebar := ""
 	if layout.ShowSidebar && !m.isOneOnOne() {
-		sidebar = cachedSidebarRender(m.channels, mergeOfficeMembers(m.officeMembers, m.members, m.currentChannelInfo()), m.tasks, m.activeChannel, m.activeApp, m.sidebarCursor, m.sidebarRosterOffset, m.focus == focusSidebar, m.quickJumpTarget, workspaceState, layout.SidebarW, layout.ContentH)
+		sidebar = cachedSidebarRender(m.channels, mergeOfficeMembers(m.officeMembers, m.members, m.currentChannelInfo()), m.tasks, m.activeChannel, m.activeApp, m.sidebarCursor, m.sidebarRosterOffset, m.focus == focusSidebar, m.quickJumpTarget, workspaceState, layout.SidebarW, layout.ContentH, m.onboardingChecklist)
 	}
 
 	// ── Thread panel ─────────────────────────────────────────────────
@@ -6508,6 +6511,20 @@ func runChannelView(threadsCollapsed bool, initialApp officeApp, skipSplash bool
 			reportChannelCrash(fmt.Sprintf("panic: %v\n\n%s", r, debug.Stack()))
 		}
 	}()
+
+	// Check if onboarding is needed before launching the channel view.
+	if os.Getenv("WUPHF_SKIP_ONBOARDING") == "" {
+		state, err := fetchOnboardingState(brokerBaseURL)
+		if err == nil && !state.Onboarded {
+			om := newOnboardingModel(brokerBaseURL, 0, 0)
+			op := tea.NewProgram(om, tea.WithAltScreen())
+			if _, err := op.Run(); err != nil {
+				reportChannelCrash(fmt.Sprintf("onboarding error: %v\n", err))
+				return
+			}
+			// Fall through to channel view after onboarding completes.
+		}
+	}
 
 	if !skipSplash && os.Getenv("WUPHF_NO_SPLASH") == "" {
 		splash := tea.NewProgram(newSplashModel(), tea.WithAltScreen())

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -41,13 +41,19 @@ var channelRenderCache = channelRenderCacheStore{
 	blocks:    make(map[uint64][]renderedLine),
 }
 
-func cachedSidebarRender(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, workspace workspaceUIState, width, height int) string {
+func cachedSidebarRender(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, workspace workspaceUIState, width, height int, checklist ...onboardingChecklist) string {
 	key := hashSidebarState(channels, members, tasks, activeChannel, activeApp, cursor, rosterOffset, focused, quickJump, workspace, width, height)
-	if cached, ok := channelRenderCache.getSidebar(key); ok {
-		return cached
+	// Checklist is dynamic per render — bypass cache when it's active.
+	checklistActive := len(checklist) > 0 && !checklist[0].Dismissed
+	if !checklistActive {
+		if cached, ok := channelRenderCache.getSidebar(key); ok {
+			return cached
+		}
 	}
-	rendered := renderSidebar(channels, members, tasks, activeChannel, activeApp, cursor, rosterOffset, focused, quickJump, workspace, width, height)
-	channelRenderCache.putSidebar(key, rendered)
+	rendered := renderSidebar(channels, members, tasks, activeChannel, activeApp, cursor, rosterOffset, focused, quickJump, workspace, width, height, checklist...)
+	if !checklistActive {
+		channelRenderCache.putSidebar(key, rendered)
+	}
 	return rendered
 }
 

--- a/cmd/wuphf/channel_sidebar.go
+++ b/cmd/wuphf/channel_sidebar.go
@@ -386,7 +386,7 @@ func visibleSidebarApps(apps []officeSidebarApp, activeApp officeApp, maxRows in
 }
 
 // renderSidebar renders the Slack-style sidebar with channels and team members.
-func renderSidebar(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, workspace workspaceUIState, width, height int) string {
+func renderSidebar(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, workspace workspaceUIState, width, height int, checklist ...onboardingChecklist) string {
 	if width < 2 {
 		return ""
 	}
@@ -511,6 +511,18 @@ func renderSidebar(channels []channelInfo, members []channelMember, tasks []chan
 	dividerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(sidebarDivider))
 	divider := dividerStyle.Render(strings.Repeat("\u2500", innerW))
 	lines = append(lines, sidebarPlainRow(divider, width))
+
+	// Insert onboarding checklist section above the agents list, if provided and active.
+	if len(checklist) > 0 {
+		if cl := checklist[0]; !cl.Dismissed {
+			clSection := renderOnboardingChecklist(cl, width)
+			if clSection != "" {
+				for _, clLine := range strings.Split(clSection, "\n") {
+					lines = append(lines, clLine)
+				}
+			}
+		}
+	}
 
 	usedLines := len(lines)
 	availableLines := height - usedLines - 1

--- a/cmd/wuphf/onboarding.go
+++ b/cmd/wuphf/onboarding.go
@@ -1,0 +1,940 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// ── Onboarding state ────────────────────────────────────────────
+
+const brokerBaseURL = "http://127.0.0.1:7890"
+
+type onboardingStep int
+
+const (
+	stepWelcome onboardingStep = iota
+	stepSetup
+	stepTask
+)
+
+// simpleInput is a minimal single-line text input (no external bubbles dep).
+type simpleInput struct {
+	value    []rune
+	pos      int
+	width    int
+	password bool
+}
+
+func newSimpleInput(width int) simpleInput {
+	return simpleInput{width: width}
+}
+
+func newPasswordInput(width int) simpleInput {
+	return simpleInput{width: width, password: true}
+}
+
+func (s *simpleInput) SetValue(v string) {
+	s.value = []rune(v)
+	s.pos = len(s.value)
+}
+
+func (s simpleInput) Value() string { return string(s.value) }
+
+func (s *simpleInput) HandleKey(msg tea.KeyMsg) {
+	switch msg.Type {
+	case tea.KeyBackspace, tea.KeyDelete:
+		if s.pos > 0 {
+			s.value = append(s.value[:s.pos-1], s.value[s.pos:]...)
+			s.pos--
+		}
+	case tea.KeyLeft:
+		if s.pos > 0 {
+			s.pos--
+		}
+	case tea.KeyRight:
+		if s.pos < len(s.value) {
+			s.pos++
+		}
+	case tea.KeyHome, tea.KeyCtrlA:
+		s.pos = 0
+	case tea.KeyEnd, tea.KeyCtrlE:
+		s.pos = len(s.value)
+	case tea.KeyRunes:
+		runes := []rune(msg.String())
+		s.value = append(s.value[:s.pos], append(runes, s.value[s.pos:]...)...)
+		s.pos += len(runes)
+	}
+}
+
+func (s simpleInput) View(focused bool) string {
+	w := s.width
+	if w < 10 {
+		w = 10
+	}
+	borderColor := slackInputBorder
+	if focused {
+		borderColor = slackInputFocus
+	}
+
+	var display string
+	if s.password {
+		masked := strings.Repeat("*", len(s.value))
+		display = masked
+	} else {
+		display = string(s.value)
+	}
+
+	// Build cursor-in-string view, clipped to width-4.
+	innerW := w - 4
+	if innerW < 4 {
+		innerW = 4
+	}
+	runes := []rune(display)
+	cursorStyle := lipgloss.NewStyle().Reverse(true)
+
+	var buf strings.Builder
+	if len(runes) == 0 {
+		buf.WriteString(cursorStyle.Render(" "))
+	} else {
+		// Determine visible window around cursor.
+		start := 0
+		if s.pos > innerW-1 {
+			start = s.pos - (innerW - 1)
+		}
+		end := start + innerW
+		if end > len(runes) {
+			end = len(runes)
+		}
+		for i := start; i < end; i++ {
+			if i == s.pos {
+				buf.WriteString(cursorStyle.Render(string(runes[i])))
+			} else {
+				buf.WriteRune(runes[i])
+			}
+		}
+		if s.pos == len(runes) {
+			buf.WriteString(cursorStyle.Render(" "))
+		}
+	}
+
+	return lipgloss.NewStyle().
+		Width(w).
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(borderColor)).
+		Background(lipgloss.Color("#17161C")).
+		Padding(0, 1).
+		Render(buf.String())
+}
+
+// ── HTTP message types ──────────────────────────────────────────
+
+type prereqResult struct {
+	Name       string `json:"name"`
+	Required   bool   `json:"required"`
+	Found      bool   `json:"found"`
+	Version    string `json:"version"`
+	InstallURL string `json:"install_url"`
+}
+
+type taskTemplate struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	OwnerSlug   string `json:"owner_slug"`
+}
+
+type onboardingStateResp struct {
+	Onboarded bool `json:"onboarded"`
+}
+
+// ── Bubbletea Msg types ─────────────────────────────────────────
+
+type prereqsLoadedMsg struct{ results []prereqResult }
+type keyValidatedMsg struct{ status string }
+type templatesLoadedMsg struct{ templates []taskTemplate }
+type completeMsg struct{ err error }
+type onboardingProgressMsg struct{ err error }
+
+// ── Model ───────────────────────────────────────────────────────
+
+type onboardingModel struct {
+	step   onboardingStep
+	width  int
+	height int
+
+	// Step 1
+	companyInput  simpleInput
+	descInput     simpleInput
+	priorityInput simpleInput
+	focusIndex    int // 0=company, 1=desc, 2=priority
+
+	// Step 2
+	prereqs            []prereqResult
+	anthropicKey       simpleInput
+	openAIKey          simpleInput
+	keyFocus           int // 0=anthropic, 1=openai
+	keyStatus          string // "idle", "checking", "valid", "invalid", "unverified"
+	prereqsOk          bool
+	continueUnverified bool
+
+	// Step 3
+	templates    []taskTemplate
+	selectedTpl  int // -1 = freeform
+	taskInput    simpleInput
+
+	// State
+	brokerURL string
+	err       string
+	done      bool
+}
+
+func newOnboardingModel(brokerURL string, w, h int) onboardingModel {
+	inputW := 40
+	if w > 0 {
+		inputW = w/2 - 4
+		if inputW < 20 {
+			inputW = 20
+		}
+		if inputW > 60 {
+			inputW = 60
+		}
+	}
+
+	m := onboardingModel{
+		width:         w,
+		height:        h,
+		brokerURL:     brokerURL,
+		companyInput:  newSimpleInput(inputW),
+		descInput:     newSimpleInput(inputW),
+		priorityInput: newSimpleInput(inputW),
+		anthropicKey:  newPasswordInput(inputW),
+		openAIKey:     newPasswordInput(inputW),
+		keyStatus:     "idle",
+		selectedTpl:   -1,
+		taskInput:     newSimpleInput(inputW),
+	}
+	return m
+}
+
+func (m onboardingModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m onboardingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		// Recompute input widths.
+		inputW := m.width/2 - 4
+		if inputW < 20 {
+			inputW = 20
+		}
+		if inputW > 60 {
+			inputW = 60
+		}
+		m.companyInput.width = inputW
+		m.descInput.width = inputW
+		m.priorityInput.width = inputW
+		m.anthropicKey.width = inputW
+		m.openAIKey.width = inputW
+		m.taskInput.width = inputW
+		return m, nil
+
+	case prereqsLoadedMsg:
+		m.prereqs = msg.results
+		m.prereqsOk = allRequiredPrereqsOk(msg.results)
+		return m, nil
+
+	case keyValidatedMsg:
+		m.keyStatus = msg.status
+		return m, nil
+
+	case templatesLoadedMsg:
+		m.templates = msg.templates
+		return m, nil
+
+	case completeMsg:
+		if msg.err != nil {
+			m.err = msg.err.Error()
+			return m, nil
+		}
+		m.done = true
+		return m, tea.Quit
+
+	case onboardingProgressMsg:
+		// progress saved, nothing to do
+		return m, nil
+
+	case tea.KeyMsg:
+		return m.handleKey(msg)
+	}
+
+	return m, nil
+}
+
+func (m onboardingModel) handleKey(msg tea.KeyMsg) (onboardingModel, tea.Cmd) {
+	// Global quit.
+	if msg.Type == tea.KeyCtrlC {
+		return m, tea.Quit
+	}
+
+	switch m.step {
+	case stepWelcome:
+		return m.handleWelcomeKey(msg)
+	case stepSetup:
+		return m.handleSetupKey(msg)
+	case stepTask:
+		return m.handleTaskKey(msg)
+	}
+	return m, nil
+}
+
+func (m onboardingModel) handleWelcomeKey(msg tea.KeyMsg) (onboardingModel, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyTab, tea.KeyDown:
+		m.focusIndex = (m.focusIndex + 1) % 3
+		return m, nil
+	case tea.KeyShiftTab, tea.KeyUp:
+		m.focusIndex = (m.focusIndex + 2) % 3
+		return m, nil
+	case tea.KeyEnter:
+		// Validate step 1.
+		if strings.TrimSpace(m.companyInput.Value()) == "" {
+			m.err = "Company name is required."
+			return m, nil
+		}
+		m.err = ""
+		m.step = stepSetup
+		// Submit progress and fetch prereqs.
+		answers := map[string]interface{}{
+			"company":  m.companyInput.Value(),
+			"desc":     m.descInput.Value(),
+			"priority": m.priorityInput.Value(),
+		}
+		return m, tea.Batch(
+			m.submitProgressCmd("welcome", answers),
+			m.fetchPrereqsCmd(),
+			m.fetchTemplatesCmd(),
+		)
+	default:
+		switch m.focusIndex {
+		case 0:
+			m.companyInput.HandleKey(msg)
+		case 1:
+			m.descInput.HandleKey(msg)
+		case 2:
+			m.priorityInput.HandleKey(msg)
+		}
+	}
+	return m, nil
+}
+
+func (m onboardingModel) handleSetupKey(msg tea.KeyMsg) (onboardingModel, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyTab, tea.KeyDown:
+		m.keyFocus = (m.keyFocus + 1) % 2
+		return m, nil
+	case tea.KeyShiftTab, tea.KeyUp:
+		m.keyFocus = (m.keyFocus + 1) % 2
+		return m, nil
+	case tea.KeyCtrlR:
+		// Re-check prereqs.
+		return m, m.fetchPrereqsCmd()
+	case tea.KeyEnter:
+		// Must have prereqs ok OR continueUnverified.
+		if !m.prereqsOk && !m.continueUnverified {
+			m.err = "Required tools missing. Install them or press 'c' to continue anyway."
+			return m, nil
+		}
+		key := strings.TrimSpace(m.anthropicKey.Value())
+		if key == "" {
+			m.err = "Anthropic API key is required."
+			return m, nil
+		}
+		// If key not yet validated, validate now.
+		if m.keyStatus == "idle" || m.keyStatus == "unverified" {
+			m.keyStatus = "checking"
+			return m, m.validateKeyCmd(key)
+		}
+		if m.keyStatus == "checking" {
+			return m, nil
+		}
+		if m.keyStatus == "invalid" {
+			m.err = "API key appears invalid. Double-check it and try again."
+			return m, nil
+		}
+		// valid or unverified after c was pressed.
+		m.err = ""
+		m.step = stepTask
+		return m, nil
+	case tea.KeyRunes:
+		if msg.String() == "c" && !m.prereqsOk {
+			m.continueUnverified = true
+			m.err = ""
+			return m, nil
+		}
+		if msg.String() == "v" {
+			key := strings.TrimSpace(m.anthropicKey.Value())
+			if key != "" {
+				m.keyStatus = "checking"
+				return m, m.validateKeyCmd(key)
+			}
+		}
+		// Route to focused input.
+		switch m.keyFocus {
+		case 0:
+			m.anthropicKey.HandleKey(msg)
+			m.keyStatus = "idle" // reset validation on edit
+		case 1:
+			m.openAIKey.HandleKey(msg)
+		}
+	default:
+		switch m.keyFocus {
+		case 0:
+			m.anthropicKey.HandleKey(msg)
+			m.keyStatus = "idle"
+		case 1:
+			m.openAIKey.HandleKey(msg)
+		}
+	}
+	return m, nil
+}
+
+func (m onboardingModel) handleTaskKey(msg tea.KeyMsg) (onboardingModel, tea.Cmd) {
+	switch msg.Type {
+	case tea.KeyRunes:
+		s := msg.String()
+		// Number key: select template.
+		if len(s) == 1 && s[0] >= '1' && s[0] <= '9' {
+			idx := int(s[0]-'1')
+			if idx < len(m.templates) {
+				m.selectedTpl = idx
+				return m, nil
+			}
+		}
+		if s == "s" {
+			// Skip task.
+			return m, m.completeOnboardingCmd("", true)
+		}
+		// Otherwise type into freeform input.
+		m.selectedTpl = -1
+		m.taskInput.HandleKey(msg)
+		return m, nil
+	case tea.KeyEnter:
+		var taskText string
+		if m.selectedTpl >= 0 && m.selectedTpl < len(m.templates) {
+			taskText = m.templates[m.selectedTpl].Title
+		} else {
+			taskText = strings.TrimSpace(m.taskInput.Value())
+		}
+		if taskText == "" {
+			// Skip.
+			return m, m.completeOnboardingCmd("", true)
+		}
+		return m, m.completeOnboardingCmd(taskText, false)
+	default:
+		m.taskInput.HandleKey(msg)
+	}
+	return m, nil
+}
+
+// View renders the current step.
+func (m onboardingModel) View() string {
+	if m.done {
+		return ""
+	}
+	w := m.width
+	h := m.height
+	if w == 0 {
+		w = 80
+	}
+	if h == 0 {
+		h = 24
+	}
+
+	bg := lipgloss.Color("#0D0D12")
+	fg := lipgloss.Color("#E8E8EA")
+	fullStyle := lipgloss.NewStyle().
+		Width(w).Height(h).
+		Background(bg).Foreground(fg)
+
+	var content string
+	switch m.step {
+	case stepWelcome:
+		content = m.viewWelcome(w, h)
+	case stepSetup:
+		content = m.viewSetup(w, h)
+	case stepTask:
+		content = m.viewTask(w, h)
+	}
+
+	return fullStyle.Render(content)
+}
+
+// ── Step views ──────────────────────────────────────────────────
+
+func (m onboardingModel) viewWelcome(w, h int) string {
+	accentStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#EAB308")).Bold(true)
+	mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
+	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#E8E8EA")).Bold(true)
+
+	var lines []string
+
+	lines = append(lines, "")
+	lines = append(lines, accentStyle.Render("  WUPHF — Let's set up your office"))
+	lines = append(lines, mutedStyle.Render("  The cast is ready. We just need a few details."))
+	lines = append(lines, "")
+	lines = append(lines, labelStyle.Render("  Company or project name"))
+	lines = append(lines, "  "+m.companyInput.View(m.focusIndex == 0))
+	lines = append(lines, "")
+	lines = append(lines, labelStyle.Render("  What do you do?"))
+	lines = append(lines, "  "+m.descInput.View(m.focusIndex == 1))
+	lines = append(lines, "")
+	lines = append(lines, labelStyle.Render("  Top priority right now"))
+	lines = append(lines, "  "+m.priorityInput.View(m.focusIndex == 2))
+	lines = append(lines, "")
+	if m.err != "" {
+		lines = append(lines, "  "+lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")).Render(m.err))
+	}
+	lines = append(lines, mutedStyle.Render("  Tab to move between fields  ·  Enter to continue"))
+
+	return centerBlock(lines, w, h)
+}
+
+func (m onboardingModel) viewSetup(w, h int) string {
+	accentStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#EAB308")).Bold(true)
+	mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
+	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#E8E8EA")).Bold(true)
+	okStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#2BAC76"))
+	failStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#4B5563"))
+
+	var lines []string
+	lines = append(lines, "")
+	lines = append(lines, accentStyle.Render("  Tools check"))
+	lines = append(lines, mutedStyle.Render("  "+strings.Repeat("\u2500", maxInt(10, w/2-4))))
+
+	if len(m.prereqs) == 0 {
+		lines = append(lines, mutedStyle.Render("  Checking tools..."))
+	} else {
+		for _, p := range m.prereqs {
+			var statusStr string
+			if p.Found {
+				ver := p.Version
+				if ver != "" {
+					ver = "  " + ver
+				}
+				statusStr = okStyle.Render("\u2713 "+p.Name) + dimStyle.Render(ver)
+			} else {
+				label := failStyle.Render("\u2717 "+p.Name)
+				hint := ""
+				if p.InstallURL != "" {
+					hint = dimStyle.Render("  install at "+p.InstallURL)
+				}
+				req := ""
+				if p.Required {
+					req = lipgloss.NewStyle().Foreground(lipgloss.Color("#F59E0B")).Render(" (required)")
+				}
+				statusStr = label + req + hint
+			}
+			lines = append(lines, "  "+statusStr)
+		}
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, accentStyle.Render("  Provider keys"))
+	lines = append(lines, mutedStyle.Render("  "+strings.Repeat("\u2500", maxInt(10, w/2-4))))
+
+	lines = append(lines, labelStyle.Render("  Anthropic (required)"))
+
+	keyStatusStr := ""
+	switch m.keyStatus {
+	case "checking":
+		keyStatusStr = mutedStyle.Render("  checking…")
+	case "valid":
+		keyStatusStr = okStyle.Render("  \u2713 verified")
+	case "invalid":
+		keyStatusStr = failStyle.Render("  \u2717 invalid key")
+	case "unverified":
+		keyStatusStr = mutedStyle.Render("  unverified (continuing)")
+	}
+	keyLine := "  " + m.anthropicKey.View(m.keyFocus == 0)
+	if keyStatusStr != "" {
+		keyLine += keyStatusStr
+	}
+	lines = append(lines, keyLine)
+
+	lines = append(lines, "")
+	lines = append(lines, labelStyle.Render("  OpenAI (optional)"))
+	lines = append(lines, "  "+m.openAIKey.View(m.keyFocus == 1))
+
+	lines = append(lines, "")
+
+	// Re-check hint.
+	lines = append(lines, mutedStyle.Render("  Ctrl+R re-check tools  ·  v validate key  ·  Enter continue"))
+
+	readyMsg := ""
+	if !m.prereqsOk && !m.continueUnverified && len(m.prereqs) > 0 {
+		readyMsg = failStyle.Render("  Required tools missing — press c to continue anyway")
+	} else if m.keyStatus == "valid" || m.keyStatus == "unverified" || m.continueUnverified {
+		readyMsg = okStyle.Render("  Ready — Enter to continue")
+	}
+	if readyMsg != "" {
+		lines = append(lines, readyMsg)
+	}
+
+	if m.err != "" {
+		lines = append(lines, "  "+lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")).Render(m.err))
+	}
+
+	return centerBlock(lines, w, h)
+}
+
+func (m onboardingModel) viewTask(w, h int) string {
+	accentStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#EAB308")).Bold(true)
+	mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
+	labelStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#E8E8EA")).Bold(true)
+	activeStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#FFFFFF")).Background(lipgloss.Color("#1264A3")).Bold(true).Padding(0, 1)
+	inactiveStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted)).Padding(0, 1)
+	agentStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#64748B"))
+
+	var lines []string
+	lines = append(lines, "")
+	lines = append(lines, accentStyle.Render("  What's the first thing you want done?"))
+	lines = append(lines, "")
+
+	for i, tpl := range m.templates {
+		num := fmt.Sprintf("[%d]", i+1)
+		owner := ""
+		if tpl.OwnerSlug != "" {
+			owner = agentStyle.Render("  \u2192 "+tpl.OwnerSlug)
+		}
+		label := fmt.Sprintf("%s %s%s", num, tpl.Title, owner)
+		if m.selectedTpl == i {
+			lines = append(lines, "  "+activeStyle.Render(label))
+		} else {
+			lines = append(lines, "  "+inactiveStyle.Render(label))
+		}
+	}
+
+	lines = append(lines, "")
+	lines = append(lines, labelStyle.Render("  Or describe it yourself:"))
+	lines = append(lines, "  "+m.taskInput.View(m.selectedTpl == -1))
+	lines = append(lines, "")
+
+	if m.err != "" {
+		lines = append(lines, "  "+lipgloss.NewStyle().Foreground(lipgloss.Color("#EF4444")).Render(m.err))
+	}
+	lines = append(lines, mutedStyle.Render("  s to skip  ·  Enter to start working"))
+
+	return centerBlock(lines, w, h)
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+func centerBlock(lines []string, w, h int) string {
+	topPad := (h - len(lines)) / 2
+	if topPad < 0 {
+		topPad = 0
+	}
+	var out []string
+	for i := 0; i < topPad; i++ {
+		out = append(out, "")
+	}
+	out = append(out, lines...)
+	return strings.Join(out, "\n")
+}
+
+func allRequiredPrereqsOk(prereqs []prereqResult) bool {
+	for _, p := range prereqs {
+		if p.Required && !p.Found {
+			return false
+		}
+	}
+	return true
+}
+
+// ── Commands (HTTP calls) ────────────────────────────────────────
+
+func (m onboardingModel) fetchPrereqsCmd() tea.Cmd {
+	url := m.brokerURL + "/onboarding/prereqs"
+	return func() tea.Msg {
+		req, err := newBrokerRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return prereqsLoadedMsg{results: []prereqResult{
+				{Name: "git", Required: true, Found: false},
+				{Name: "node", Required: false, Found: false},
+				{Name: "claude", Required: false, Found: false, InstallURL: "claude.ai/code"},
+			}}
+		}
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return prereqsLoadedMsg{results: defaultPrereqs()}
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return prereqsLoadedMsg{results: defaultPrereqs()}
+		}
+		var out struct {
+			Prereqs []prereqResult `json:"prereqs"`
+		}
+		if err := json.Unmarshal(body, &out); err != nil {
+			// Try flat array.
+			var flat []prereqResult
+			if err2 := json.Unmarshal(body, &flat); err2 != nil {
+				return prereqsLoadedMsg{results: defaultPrereqs()}
+			}
+			return prereqsLoadedMsg{results: flat}
+		}
+		return prereqsLoadedMsg{results: out.Prereqs}
+	}
+}
+
+func defaultPrereqs() []prereqResult {
+	return []prereqResult{
+		{Name: "git", Required: true, Found: false},
+		{Name: "node", Required: false, Found: false},
+		{Name: "claude", Required: false, Found: false, InstallURL: "claude.ai/code"},
+	}
+}
+
+func (m onboardingModel) validateKeyCmd(key string) tea.Cmd {
+	url := m.brokerURL + "/onboarding/validate-key"
+	return func() tea.Msg {
+		payload, _ := json.Marshal(map[string]string{"key": key, "provider": "anthropic"})
+		req, err := newBrokerRequest(http.MethodPost, url, bytes.NewReader(payload))
+		if err != nil {
+			return keyValidatedMsg{status: "unverified"}
+		}
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return keyValidatedMsg{status: "unverified"}
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		var out struct {
+			Status string `json:"status"`
+			Valid  bool   `json:"valid"`
+		}
+		if err := json.Unmarshal(body, &out); err != nil {
+			return keyValidatedMsg{status: "unverified"}
+		}
+		if out.Status != "" {
+			return keyValidatedMsg{status: out.Status}
+		}
+		if out.Valid {
+			return keyValidatedMsg{status: "valid"}
+		}
+		return keyValidatedMsg{status: "invalid"}
+	}
+}
+
+func (m onboardingModel) fetchTemplatesCmd() tea.Cmd {
+	url := m.brokerURL + "/onboarding/templates"
+	return func() tea.Msg {
+		req, err := newBrokerRequest(http.MethodGet, url, nil)
+		if err != nil {
+			return templatesLoadedMsg{templates: defaultTemplates()}
+		}
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return templatesLoadedMsg{templates: defaultTemplates()}
+		}
+		defer resp.Body.Close()
+		body, _ := io.ReadAll(resp.Body)
+		var out struct {
+			Templates []taskTemplate `json:"templates"`
+		}
+		if err := json.Unmarshal(body, &out); err != nil {
+			var flat []taskTemplate
+			if err2 := json.Unmarshal(body, &flat); err2 != nil {
+				return templatesLoadedMsg{templates: defaultTemplates()}
+			}
+			return templatesLoadedMsg{templates: flat}
+		}
+		if len(out.Templates) > 0 {
+			return templatesLoadedMsg{templates: out.Templates}
+		}
+		return templatesLoadedMsg{templates: defaultTemplates()}
+	}
+}
+
+func defaultTemplates() []taskTemplate {
+	return []taskTemplate{
+		{ID: "landing-page", Title: "Draft the landing page", OwnerSlug: "eng"},
+		{ID: "repo-structure", Title: "Set up repo structure", OwnerSlug: "eng"},
+		{ID: "product-spec", Title: "Write the product spec", OwnerSlug: "pm"},
+		{ID: "readme", Title: "Write the README", OwnerSlug: "pm"},
+		{ID: "competitive-audit", Title: "Audit the competition", OwnerSlug: "ceo"},
+	}
+}
+
+func (m onboardingModel) submitProgressCmd(step string, answers map[string]interface{}) tea.Cmd {
+	url := m.brokerURL + "/onboarding/progress"
+	return func() tea.Msg {
+		payload, _ := json.Marshal(map[string]interface{}{
+			"step":    step,
+			"answers": answers,
+		})
+		req, err := newBrokerRequest(http.MethodPost, url, bytes.NewReader(payload))
+		if err != nil {
+			return onboardingProgressMsg{err: err}
+		}
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			return onboardingProgressMsg{err: err}
+		}
+		resp.Body.Close()
+		return onboardingProgressMsg{}
+	}
+}
+
+func (m onboardingModel) completeOnboardingCmd(task string, skipTask bool) tea.Cmd {
+	url := m.brokerURL + "/onboarding/complete"
+	return func() tea.Msg {
+		payload, _ := json.Marshal(map[string]interface{}{
+			"first_task": task,
+			"skip_task":  skipTask,
+		})
+		req, err := newBrokerRequest(http.MethodPost, url, bytes.NewReader(payload))
+		if err != nil {
+			// If broker isn't up yet, treat as complete (graceful).
+			return completeMsg{err: nil}
+		}
+		client := &http.Client{Timeout: 10 * time.Second}
+		resp, err := client.Do(req)
+		if err != nil {
+			// Broker not yet running — still complete gracefully.
+			return completeMsg{err: nil}
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			body, _ := io.ReadAll(resp.Body)
+			return completeMsg{err: fmt.Errorf("broker error %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))}
+		}
+		return completeMsg{err: nil}
+	}
+}
+
+// ── Onboarding state check (used by runChannelView) ─────────────
+
+type onboardingState struct {
+	Onboarded bool `json:"onboarded"`
+}
+
+func fetchOnboardingState(brokerURL string) (onboardingState, error) {
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, err := newBrokerRequest(http.MethodGet, brokerURL+"/onboarding/state", nil)
+	if err != nil {
+		return onboardingState{Onboarded: true}, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		// Broker not running — assume onboarded to not block startup.
+		return onboardingState{Onboarded: true}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		// Endpoint doesn't exist yet — treat as onboarded.
+		return onboardingState{Onboarded: true}, nil
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return onboardingState{Onboarded: true}, err
+	}
+	var s onboardingState
+	if err := json.Unmarshal(body, &s); err != nil {
+		return onboardingState{Onboarded: true}, err
+	}
+	return s, nil
+}
+
+// ── Sidebar onboarding checklist ─────────────────────────────────
+
+type onboardingChecklistItem struct {
+	Label string
+	Done  bool
+}
+
+type onboardingChecklist struct {
+	Items     []onboardingChecklistItem
+	Dismissed bool
+}
+
+// renderOnboardingChecklist renders the "Getting started" section for the sidebar.
+// Returns empty string if checklist should not be shown.
+func renderOnboardingChecklist(checklist onboardingChecklist, width int) string {
+	if checklist.Dismissed {
+		return ""
+	}
+	done := 0
+	remaining := false
+	for _, item := range checklist.Items {
+		if item.Done {
+			done++
+		} else {
+			remaining = true
+		}
+	}
+	if !remaining {
+		return ""
+	}
+	total := len(checklist.Items)
+
+	bg := lipgloss.Color(sidebarBG)
+	sectionBandStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#D4D4D8")).
+		Background(lipgloss.Color("#20242A")).
+		Bold(true).
+		Padding(0, 1)
+	doneStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("#2BAC76"))
+	todoStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(sidebarMuted))
+	panel := lipgloss.NewStyle().Background(bg)
+
+	header := fmt.Sprintf("Getting started  %d/%d", done, total)
+	headerLine := sidebarStyledRow(sectionBandStyle, header, width)
+
+	innerW := width - 2
+	dividerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(sidebarDivider))
+	divider := sidebarPlainRow(dividerStyle.Render(strings.Repeat("\u2500", maxInt(1, innerW))), width)
+
+	var rows []string
+	rows = append(rows, headerLine)
+	rows = append(rows, divider)
+	for _, item := range checklist.Items {
+		var marker, label string
+		if item.Done {
+			marker = doneStyle.Render("[x]")
+			label = doneStyle.Render(item.Label)
+		} else {
+			marker = todoStyle.Render("[ ]")
+			label = todoStyle.Render(item.Label)
+		}
+		text := marker + " " + label
+		// Pad to width.
+		visW := ansi.StringWidth(text)
+		if visW < innerW-1 {
+			text += strings.Repeat(" ", innerW-1-visW)
+		}
+		rows = append(rows, panel.Render(" "+text))
+	}
+	rows = append(rows, "")
+
+	return strings.Join(rows, "\n")
+}

--- a/cmd/wuphf/onboarding_test.go
+++ b/cmd/wuphf/onboarding_test.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestOnboardingModelInit(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+	if m.step != stepWelcome {
+		t.Fatalf("expected stepWelcome, got %d", m.step)
+	}
+	if m.done {
+		t.Fatal("model should not be done on init")
+	}
+}
+
+func TestOnboardingModelStepAdvance(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+
+	// Populate step 1 inputs.
+	m.companyInput.SetValue("Dunder Mifflin")
+	m.descInput.SetValue("Paper company")
+	m.priorityInput.SetValue("Sell more paper")
+
+	// Press Enter to advance.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m2 := updated.(onboardingModel)
+
+	if m2.step != stepSetup {
+		t.Fatalf("expected stepSetup after valid step 1, got %d", m2.step)
+	}
+	if m2.err != "" {
+		t.Fatalf("unexpected error: %s", m2.err)
+	}
+}
+
+func TestOnboardingModelStepAdvanceRequiresCompanyName(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+
+	// Leave company name empty.
+	m.descInput.SetValue("Paper company")
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m2 := updated.(onboardingModel)
+
+	// Should stay on stepWelcome.
+	if m2.step != stepWelcome {
+		t.Fatalf("expected stepWelcome when company name empty, got %d", m2.step)
+	}
+	if m2.err == "" {
+		t.Fatal("expected validation error when company name missing")
+	}
+}
+
+func TestOnboardingModelPrereqBlock(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+	m.step = stepSetup
+
+	// Inject failing prereqs.
+	m.prereqs = []prereqResult{
+		{Name: "git", Required: true, Found: false},
+	}
+	m.prereqsOk = false
+	m.anthropicKey.SetValue("sk-ant-test")
+	m.keyStatus = "valid"
+
+	// Press Enter without acknowledging prereq failure.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m2 := updated.(onboardingModel)
+
+	// Should NOT advance to stepTask.
+	if m2.step != stepSetup {
+		t.Fatalf("expected stepSetup when required prereqs missing, got %d", m2.step)
+	}
+	if m2.err == "" {
+		t.Fatal("expected error message about missing tools")
+	}
+}
+
+func TestOnboardingModelPrereqBypassWithC(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+	m.step = stepSetup
+	m.prereqs = []prereqResult{
+		{Name: "git", Required: true, Found: false},
+	}
+	m.prereqsOk = false
+	m.anthropicKey.SetValue("sk-ant-test")
+	m.keyStatus = "valid"
+
+	// Press 'c' to continue anyway.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("c")})
+	m2 := updated.(onboardingModel)
+	if !m2.continueUnverified {
+		t.Fatal("expected continueUnverified=true after pressing c")
+	}
+
+	// Now Enter should advance.
+	updated2, _ := m2.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m3 := updated2.(onboardingModel)
+	if m3.step != stepTask {
+		t.Fatalf("expected stepTask after bypass, got %d", m3.step)
+	}
+}
+
+func TestOnboardingModelComplete(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+	m.step = stepTask
+
+	// Inject completeMsg directly.
+	updated, cmd := m.Update(completeMsg{err: nil})
+	m2 := updated.(onboardingModel)
+
+	if !m2.done {
+		t.Fatal("expected done=true after completeMsg with nil error")
+	}
+	if cmd == nil {
+		t.Fatal("expected tea.Quit command after completeMsg")
+	}
+}
+
+func TestOnboardingModelCompleteWithError(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+	m.step = stepTask
+
+	updated, _ := m.Update(completeMsg{err: errOnboarding("broker rejected")})
+	m2 := updated.(onboardingModel)
+
+	if m2.done {
+		t.Fatal("expected done=false when completeMsg has error")
+	}
+	if m2.err == "" {
+		t.Fatal("expected error string set when completeMsg has error")
+	}
+}
+
+func TestOnboardingModelWindowResize(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m2 := updated.(onboardingModel)
+
+	if m2.width != 120 || m2.height != 40 {
+		t.Fatalf("expected 120x40, got %dx%d", m2.width, m2.height)
+	}
+}
+
+func TestOnboardingModelKeyValidatedMsg(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+	m.step = stepSetup
+	m.keyStatus = "checking"
+
+	updated, _ := m.Update(keyValidatedMsg{status: "valid"})
+	m2 := updated.(onboardingModel)
+	if m2.keyStatus != "valid" {
+		t.Fatalf("expected valid key status, got %s", m2.keyStatus)
+	}
+}
+
+func TestOnboardingModelPrereqsLoaded(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+	m.step = stepSetup
+
+	prereqs := []prereqResult{
+		{Name: "git", Required: true, Found: true, Version: "2.43.0"},
+		{Name: "node", Required: false, Found: true, Version: "20.11.0"},
+	}
+	updated, _ := m.Update(prereqsLoadedMsg{results: prereqs})
+	m2 := updated.(onboardingModel)
+
+	if len(m2.prereqs) != 2 {
+		t.Fatalf("expected 2 prereqs, got %d", len(m2.prereqs))
+	}
+	if !m2.prereqsOk {
+		t.Fatal("expected prereqsOk=true when all required prereqs found")
+	}
+}
+
+func TestOnboardingModelTemplatesLoaded(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+	m.step = stepTask
+
+	templates := []taskTemplate{
+		{ID: "t1", Title: "Do the thing", OwnerSlug: "eng"},
+	}
+	updated, _ := m.Update(templatesLoadedMsg{templates: templates})
+	m2 := updated.(onboardingModel)
+
+	if len(m2.templates) != 1 {
+		t.Fatalf("expected 1 template, got %d", len(m2.templates))
+	}
+}
+
+func TestOnboardingModelView(t *testing.T) {
+	m := newOnboardingModel(brokerBaseURL, 80, 24)
+	v := m.View()
+	if v == "" {
+		t.Fatal("View() should return non-empty string")
+	}
+}
+
+func TestRenderOnboardingChecklist(t *testing.T) {
+	cl := onboardingChecklist{
+		Dismissed: false,
+		Items: []onboardingChecklistItem{
+			{Label: "Pick your real team", Done: true},
+			{Label: "Add a second key", Done: false},
+			{Label: "Connect a GitHub repo", Done: false},
+		},
+	}
+	out := renderOnboardingChecklist(cl, 30)
+	if out == "" {
+		t.Fatal("expected non-empty checklist output")
+	}
+}
+
+func TestRenderOnboardingChecklistDismissed(t *testing.T) {
+	cl := onboardingChecklist{
+		Dismissed: true,
+		Items:     []onboardingChecklistItem{{Label: "Anything", Done: false}},
+	}
+	out := renderOnboardingChecklist(cl, 30)
+	if out != "" {
+		t.Fatal("expected empty output when checklist is dismissed")
+	}
+}
+
+func TestRenderOnboardingChecklistAllDone(t *testing.T) {
+	cl := onboardingChecklist{
+		Dismissed: false,
+		Items: []onboardingChecklistItem{
+			{Label: "Task A", Done: true},
+			{Label: "Task B", Done: true},
+		},
+	}
+	out := renderOnboardingChecklist(cl, 30)
+	if out != "" {
+		t.Fatal("expected empty output when all items done")
+	}
+}
+
+func TestAllRequiredPrereqsOk(t *testing.T) {
+	cases := []struct {
+		name    string
+		prereqs []prereqResult
+		want    bool
+	}{
+		{
+			name: "all found",
+			prereqs: []prereqResult{
+				{Name: "git", Required: true, Found: true},
+			},
+			want: true,
+		},
+		{
+			name: "required missing",
+			prereqs: []prereqResult{
+				{Name: "git", Required: true, Found: false},
+			},
+			want: false,
+		},
+		{
+			name: "optional missing is ok",
+			prereqs: []prereqResult{
+				{Name: "git", Required: true, Found: true},
+				{Name: "node", Required: false, Found: false},
+			},
+			want: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := allRequiredPrereqsOk(tc.prereqs)
+			if got != tc.want {
+				t.Fatalf("allRequiredPrereqsOk() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// errOnboarding is a simple error type for tests.
+type errOnboarding string
+
+func (e errOnboarding) Error() string { return string(e) }

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -1,0 +1,329 @@
+package onboarding
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// RegisterRoutes attaches all onboarding HTTP handlers to mux.
+//
+// completeFn is called by HandleComplete when the user finishes onboarding.
+// Pass nil to defer wiring — the broker should supply a real implementation
+// that seeds the team, posts the first message, and triggers the CEO turn.
+//
+// Routes registered:
+//
+//	GET  /onboarding/state
+//	POST /onboarding/progress
+//	POST /onboarding/complete
+//	GET  /onboarding/prereqs
+//	POST /onboarding/validate-key
+//	GET  /onboarding/templates
+//	POST /onboarding/checklist/{id}/done
+//	POST /onboarding/checklist/dismiss
+func RegisterRoutes(mux *http.ServeMux, completeFn func(task string, skipTask bool) error) {
+	mux.HandleFunc("/onboarding/state", HandleState)
+	mux.HandleFunc("/onboarding/progress", HandleProgress)
+	mux.HandleFunc("/onboarding/complete", makeHandleComplete(completeFn))
+	mux.HandleFunc("/onboarding/prereqs", HandlePrereqs)
+	mux.HandleFunc("/onboarding/validate-key", HandleValidateKey)
+	mux.HandleFunc("/onboarding/templates", HandleTemplates)
+	mux.HandleFunc("/onboarding/checklist/dismiss", HandleChecklistDismiss)
+	// Pattern must be registered after the more-specific /dismiss route so
+	// that /dismiss is not swallowed by the /{id}/done prefix match.
+	mux.HandleFunc("/onboarding/checklist/", HandleChecklistDone)
+}
+
+// HandleState handles GET /onboarding/state.
+// Returns the full onboarding State as JSON.
+func HandleState(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	s, err := Load()
+	if err != nil {
+		http.Error(w, "failed to load state", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(s)
+}
+
+// HandleProgress handles POST /onboarding/progress.
+// Body: {"step": string, "answers": map}.
+// Merges the answers for the given step into the partial-progress record.
+func HandleProgress(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Step    string                 `json:"step"`
+		Answers map[string]interface{} `json:"answers"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if body.Step == "" {
+		http.Error(w, "step required", http.StatusBadRequest)
+		return
+	}
+	if err := SaveProgress(body.Step, body.Answers); err != nil {
+		http.Error(w, "failed to save progress", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// makeHandleComplete returns a handler for POST /onboarding/complete that
+// closes over completeFn. The broker should supply a non-nil completeFn to
+// seed the team and post the first message.
+func makeHandleComplete(completeFn func(task string, skipTask bool) error) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		HandleComplete(w, r, completeFn)
+	}
+}
+
+// HandleComplete handles POST /onboarding/complete.
+// Body: {"task": string, "skip_task": bool}.
+//
+// Logic:
+//  1. Load state; if already completed return 200 {"already_completed": true, "redirect": "/"}.
+//  2. If skip_task is false and task is empty, return 400.
+//  3. Call completeFn (when non-nil) — the broker wires side-effects here.
+//  4. Mark state as complete and persist it.
+//  5. Return 200 {"ok": true, "redirect": "/"}.
+//
+// TODO: broker wires CompleteFunc here
+func HandleComplete(w http.ResponseWriter, r *http.Request, completeFn func(task string, skipTask bool) error) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var body struct {
+		Task     string `json:"task"`
+		SkipTask bool   `json:"skip_task"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+
+	s, err := Load()
+	if err != nil {
+		http.Error(w, "failed to load state", http.StatusInternalServerError)
+		return
+	}
+
+	// Idempotent: already done.
+	if s.Onboarded() {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"already_completed": true,
+			"redirect":          "/",
+		})
+		return
+	}
+
+	// Validate: task is required unless skip_task=true.
+	if !body.SkipTask && strings.TrimSpace(body.Task) == "" {
+		http.Error(w, "task required", http.StatusBadRequest)
+		return
+	}
+
+	// TODO: broker wires CompleteFunc here
+	if completeFn != nil {
+		if err := completeFn(body.Task, body.SkipTask); err != nil {
+			http.Error(w, "complete failed", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Build the completed payload — prepare the response before writing disk.
+	companyName := ""
+	if s.Partial != nil {
+		if welcome, ok := s.Partial.Answers["welcome"]; ok {
+			if cn, ok := welcome["company_name"].(string); ok {
+				companyName = cn
+			}
+		}
+	}
+	completeState(s, companyName)
+
+	if err := Save(s); err != nil {
+		http.Error(w, "failed to save state", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"ok":       true,
+		"redirect": "/",
+	})
+}
+
+// validateProviderKey pings the provider API with a minimal request to verify
+// the key. Returns "valid", "invalid", "unreachable", or "format_error".
+func validateProviderKey(provider, key string) string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return "format_error"
+	}
+	switch provider {
+	case "anthropic":
+		if !strings.HasPrefix(key, "sk-ant-") || len(key) < 20 {
+			return "format_error"
+		}
+		return pingAnthropic(key)
+	case "openai":
+		if !strings.HasPrefix(key, "sk-") || len(key) < 20 {
+			return "format_error"
+		}
+		return pingOpenAI(key)
+	case "gemini":
+		if len(key) < 10 {
+			return "format_error"
+		}
+		// Gemini format varies; accept if non-empty and reasonable length.
+		return "valid"
+	default:
+		return "format_error"
+	}
+}
+
+func pingAnthropic(key string) string {
+	client := &http.Client{Timeout: 3 * time.Second}
+	body := strings.NewReader(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`)
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", body)
+	if err != nil {
+		return "unreachable"
+	}
+	req.Header.Set("x-api-key", key)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("content-type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return "unreachable"
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusBadRequest: // 400 means auth passed, model may complain
+		return "valid"
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return "invalid"
+	default:
+		return fmt.Sprintf("unreachable:%d", resp.StatusCode)
+	}
+}
+
+func pingOpenAI(key string) string {
+	client := &http.Client{Timeout: 3 * time.Second}
+	req, err := http.NewRequest(http.MethodGet, "https://api.openai.com/v1/models", nil)
+	if err != nil {
+		return "unreachable"
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+	resp, err := client.Do(req)
+	if err != nil {
+		return "unreachable"
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return "valid"
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return "invalid"
+	default:
+		return "unreachable"
+	}
+}
+
+// HandleChecklistDone handles POST /onboarding/checklist/{id}/done.
+// Parses the item ID from the URL path and marks it done.
+func HandleChecklistDone(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// Path: /onboarding/checklist/{id}/done
+	// Strip prefix and suffix to extract id.
+	path := strings.TrimPrefix(r.URL.Path, "/onboarding/checklist/")
+	path = strings.TrimSuffix(path, "/done")
+	id := strings.TrimSpace(path)
+	if id == "" || id == "dismiss" {
+		http.Error(w, "item id required", http.StatusBadRequest)
+		return
+	}
+	if err := MarkChecklistItem(id, true); err != nil {
+		http.Error(w, "failed to update checklist", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+// HandlePrereqs handles GET /onboarding/prereqs.
+// Returns JSON array of PrereqResult for node, git, and claude CLI.
+func HandlePrereqs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	results := CheckAll()
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(results)
+}
+
+// HandleValidateKey handles POST /onboarding/validate-key.
+// Body: {"provider": string, "key": string}.
+// Returns {"status": "valid"|"invalid"|"unreachable"|"format_error"}.
+func HandleValidateKey(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Provider string `json:"provider"`
+		Key      string `json:"key"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	status := validateProviderKey(body.Provider, body.Key)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": status})
+}
+
+// HandleTemplates handles GET /onboarding/templates.
+// Returns JSON array of TaskTemplate for the default starter pack.
+func HandleTemplates(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(DefaultTemplates())
+}
+
+// HandleChecklistDismiss handles POST /onboarding/checklist/dismiss.
+// Sets ChecklistDismissed=true so the UI stops showing the checklist.
+func HandleChecklistDismiss(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if err := DismissChecklist(); err != nil {
+		http.Error(w, "failed to dismiss checklist", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}

--- a/internal/onboarding/handlers_test.go
+++ b/internal/onboarding/handlers_test.go
@@ -1,0 +1,280 @@
+package onboarding
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestHandleStateGETReturnsValidJSON verifies that GET /onboarding/state
+// returns HTTP 200 with a valid JSON body that can be decoded into State.
+func TestHandleStateGETReturnsValidJSON(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		req := httptest.NewRequest(http.MethodGet, "/onboarding/state", nil)
+		w := httptest.NewRecorder()
+		HandleState(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d, want %d", w.Code, http.StatusOK)
+		}
+		var s State
+		if err := json.NewDecoder(w.Body).Decode(&s); err != nil {
+			t.Fatalf("response is not valid State JSON: %v\nbody: %s", err, w.Body.String())
+		}
+		if s.Version != currentStateVersion {
+			t.Errorf("Version: got %d, want %d", s.Version, currentStateVersion)
+		}
+	})
+}
+
+// TestHandleStateMethodNotAllowed verifies POST is rejected.
+func TestHandleStateMethodNotAllowed(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/state", nil)
+		w := httptest.NewRecorder()
+		HandleState(w, req)
+		if w.Code != http.StatusMethodNotAllowed {
+			t.Errorf("status: got %d, want %d", w.Code, http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+// TestHandleProgressPOSTPersists verifies that a POST to /onboarding/progress
+// with step+answers persists the partial state.
+func TestHandleProgressPOSTPersists(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		body := map[string]interface{}{
+			"step":    "welcome",
+			"answers": map[string]interface{}{"company_name": "Initech"},
+		}
+		data, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/progress", bytes.NewReader(data))
+		w := httptest.NewRecorder()
+		HandleProgress(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d, want %d\nbody: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+
+		// Verify the state was actually persisted.
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if s.Partial == nil {
+			t.Fatal("Partial should not be nil after saving progress")
+		}
+		if s.Partial.Step != "welcome" {
+			t.Errorf("Partial.Step: got %q, want %q", s.Partial.Step, "welcome")
+		}
+		if s.Partial.Answers["welcome"]["company_name"] != "Initech" {
+			t.Errorf("expected company_name=Initech in partial answers")
+		}
+	})
+}
+
+// TestHandleProgressMissingStep verifies that a missing step field returns 400.
+func TestHandleProgressMissingStep(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		body := map[string]interface{}{"answers": map[string]interface{}{}}
+		data, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/progress", bytes.NewReader(data))
+		w := httptest.NewRecorder()
+		HandleProgress(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status: got %d, want %d", w.Code, http.StatusBadRequest)
+		}
+	})
+}
+
+// TestHandleCompletePostIdempotent verifies that a second POST after onboarding
+// is already complete returns {"already_completed": true}.
+func TestHandleCompletePostIdempotent(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		// Seed an already-complete state.
+		s := &State{
+			CompletedAt: time.Now().UTC().Format(time.RFC3339),
+			Version:     currentStateVersion,
+			CompanyName: "Initech",
+			Checklist:   DefaultChecklist(),
+		}
+		if err := Save(s); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+
+		body := map[string]interface{}{"task": "some task", "skip_task": false}
+		data, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/complete", bytes.NewReader(data))
+		w := httptest.NewRecorder()
+		HandleComplete(w, req, nil)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d, want %d\nbody: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		var resp map[string]interface{}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if resp["already_completed"] != true {
+			t.Errorf("expected already_completed=true, got: %v", resp)
+		}
+		if resp["redirect"] != "/" {
+			t.Errorf("expected redirect=/, got: %v", resp["redirect"])
+		}
+	})
+}
+
+// TestHandleCompletePostEmptyTaskReturns400 verifies that an empty task
+// without skip_task=true is rejected.
+func TestHandleCompletePostEmptyTaskReturns400(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		body := map[string]interface{}{"task": "", "skip_task": false}
+		data, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/complete", bytes.NewReader(data))
+		w := httptest.NewRecorder()
+		HandleComplete(w, req, nil)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status: got %d, want %d\nbody: %s", w.Code, http.StatusBadRequest, w.Body.String())
+		}
+	})
+}
+
+// TestHandleCompletePostSkipTaskBypassesEmptyTask verifies that skip_task=true
+// succeeds even when task is empty.
+func TestHandleCompletePostSkipTaskBypassesEmptyTask(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		body := map[string]interface{}{"task": "", "skip_task": true}
+		data, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/complete", bytes.NewReader(data))
+		w := httptest.NewRecorder()
+		HandleComplete(w, req, nil)
+		if w.Code != http.StatusOK {
+			t.Errorf("status: got %d, want %d\nbody: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		var resp map[string]interface{}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp["ok"] != true {
+			t.Errorf("expected ok=true, got: %v", resp)
+		}
+	})
+}
+
+// TestHandleCompletePostPersistsCompletedState verifies that after a successful
+// complete, state.Onboarded() returns true.
+func TestHandleCompletePostPersistsCompletedState(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		body := map[string]interface{}{"task": "Write the landing page", "skip_task": false}
+		data, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/complete", bytes.NewReader(data))
+		w := httptest.NewRecorder()
+		HandleComplete(w, req, nil)
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d\nbody: %s", w.Code, w.Body.String())
+		}
+
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !s.Onboarded() {
+			t.Error("state should be onboarded after HandleComplete")
+		}
+	})
+}
+
+// TestHandleChecklistDoneMarksItem verifies that POST /onboarding/checklist/{id}/done
+// marks the item and persists it.
+func TestHandleChecklistDoneMarksItem(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		if err := Save(&State{Version: currentStateVersion, Checklist: DefaultChecklist()}); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/checklist/pick_team/done", nil)
+		w := httptest.NewRecorder()
+		HandleChecklistDone(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d\nbody: %s", w.Code, w.Body.String())
+		}
+
+		s, _ := Load()
+		for _, item := range s.Checklist {
+			if item.ID == "pick_team" && !item.Done {
+				t.Error("pick_team should be done")
+			}
+		}
+	})
+}
+
+// TestHandleChecklistDismiss verifies that POST /onboarding/checklist/dismiss
+// sets ChecklistDismissed.
+func TestHandleChecklistDismiss(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		if err := Save(&State{Version: currentStateVersion, Checklist: DefaultChecklist()}); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/checklist/dismiss", nil)
+		w := httptest.NewRecorder()
+		HandleChecklistDismiss(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d\nbody: %s", w.Code, w.Body.String())
+		}
+
+		s, _ := Load()
+		if !s.ChecklistDismissed {
+			t.Error("ChecklistDismissed should be true")
+		}
+	})
+}
+
+// TestRegisterRoutesRegistersAllPaths verifies that RegisterRoutes wires
+// the expected five routes.
+func TestRegisterRoutesRegistersAllPaths(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		mux := http.NewServeMux()
+		RegisterRoutes(mux, nil)
+
+		routes := []struct {
+			method string
+			path   string
+			want   int
+		}{
+			{http.MethodGet, "/onboarding/state", http.StatusOK},
+			{http.MethodPost, "/onboarding/progress", http.StatusBadRequest}, // missing step
+			{http.MethodPost, "/onboarding/complete", http.StatusBadRequest}, // missing task
+			{http.MethodPost, "/onboarding/checklist/discord/done", http.StatusOK},
+			{http.MethodPost, "/onboarding/checklist/dismiss", http.StatusOK},
+		}
+
+		// Ensure the state file exists before hitting routes that need it.
+		if err := Save(&State{Version: currentStateVersion, Checklist: DefaultChecklist()}); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+
+		for _, tc := range routes {
+			var body bytes.Buffer
+			if tc.method == http.MethodPost && tc.path == "/onboarding/progress" {
+				// Send a body with an empty step so we get a predictable 400.
+				json.NewEncoder(&body).Encode(map[string]interface{}{"answers": map[string]interface{}{}})
+			}
+			if tc.method == http.MethodPost && tc.path == "/onboarding/complete" {
+				json.NewEncoder(&body).Encode(map[string]interface{}{"task": "", "skip_task": false})
+			}
+			req := httptest.NewRequest(tc.method, tc.path, &body)
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			if w.Code != tc.want {
+				t.Errorf("%s %s: status %d, want %d (body: %s)",
+					tc.method, tc.path, w.Code, tc.want, w.Body.String())
+			}
+		}
+	})
+}

--- a/internal/onboarding/prereqs.go
+++ b/internal/onboarding/prereqs.go
@@ -1,0 +1,86 @@
+package onboarding
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// PrereqResult describes the detection outcome for a single prerequisite binary.
+type PrereqResult struct {
+	// Name is the binary name (e.g. "node", "git", "claude").
+	Name string `json:"name"`
+
+	// Required is true when wuphf cannot function without this binary.
+	Required bool `json:"required"`
+
+	// Found is true when the binary was located on PATH.
+	Found bool `json:"found"`
+
+	// Version is the parsed version string from <name> --version, or empty.
+	Version string `json:"version,omitempty"`
+
+	// InstallURL is the canonical install page for this binary.
+	InstallURL string `json:"install_url,omitempty"`
+}
+
+// prereqSpec defines static metadata for each required binary.
+type prereqSpec struct {
+	required   bool
+	installURL string
+}
+
+var prereqSpecs = map[string]prereqSpec{
+	"node":   {required: true, installURL: "https://nodejs.org"},
+	"git":    {required: true, installURL: "https://git-scm.com"},
+	"claude": {required: true, installURL: "https://claude.ai/code"},
+}
+
+// CheckAll returns a PrereqResult for each tracked binary in a stable order:
+// node, git, claude.
+func CheckAll() []PrereqResult {
+	names := []string{"node", "git", "claude"}
+	results := make([]PrereqResult, 0, len(names))
+	for _, name := range names {
+		results = append(results, CheckOne(name))
+	}
+	return results
+}
+
+// CheckOne probes a single binary by name. It runs exec.LookPath to confirm
+// the binary exists on PATH, then invokes `<name> --version` to capture the
+// version string. If LookPath fails the binary is considered absent and the
+// version field is left empty.
+func CheckOne(name string) PrereqResult {
+	spec := prereqSpecs[name]
+	r := PrereqResult{
+		Name:       name,
+		Required:   spec.required,
+		InstallURL: spec.installURL,
+	}
+
+	if _, err := exec.LookPath(name); err != nil {
+		// Binary not on PATH.
+		return r
+	}
+	r.Found = true
+
+	// Best-effort version capture; ignore errors.
+	out, err := exec.Command(name, "--version").Output()
+	if err == nil {
+		r.Version = parseVersion(string(out))
+	}
+	return r
+}
+
+// parseVersion trims whitespace and returns the first non-empty line from
+// the version output. Many CLIs output one line; some (like git) prefix with
+// the program name which we preserve verbatim.
+func parseVersion(raw string) string {
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/onboarding/prereqs_test.go
+++ b/internal/onboarding/prereqs_test.go
@@ -1,0 +1,91 @@
+package onboarding
+
+import (
+	"testing"
+)
+
+func TestCheckOneGitFound(t *testing.T) {
+	r := CheckOne("git")
+	if !r.Found {
+		t.Fatal("expected git to be found on PATH in CI/dev environment")
+	}
+	if r.Name != "git" {
+		t.Errorf("Name: got %q, want %q", r.Name, "git")
+	}
+	if r.InstallURL == "" {
+		t.Error("InstallURL should be non-empty for git")
+	}
+	if r.Version == "" {
+		t.Error("Version should be non-empty when git is installed")
+	}
+}
+
+func TestCheckOneNonexistentBinary(t *testing.T) {
+	r := CheckOne("nonexistent-binary-xyz-wuphf")
+	if r.Found {
+		t.Fatal("expected Found=false for nonexistent binary")
+	}
+	if r.Version != "" {
+		t.Errorf("Version should be empty when binary is not found, got %q", r.Version)
+	}
+	// InstallURL is empty for unknown binaries (not in prereqSpecs).
+	if r.Name != "nonexistent-binary-xyz-wuphf" {
+		t.Errorf("Name: got %q, want %q", r.Name, "nonexistent-binary-xyz-wuphf")
+	}
+}
+
+func TestCheckAllReturnsThreeItems(t *testing.T) {
+	results := CheckAll()
+	if len(results) != 3 {
+		t.Fatalf("CheckAll: got %d results, want 3", len(results))
+	}
+	names := []string{"node", "git", "claude"}
+	for i, r := range results {
+		if r.Name != names[i] {
+			t.Errorf("CheckAll[%d].Name: got %q, want %q", i, r.Name, names[i])
+		}
+	}
+}
+
+func TestCheckAllRequiredFlags(t *testing.T) {
+	results := CheckAll()
+	for _, r := range results {
+		if !r.Required {
+			t.Errorf("%s: expected Required=true", r.Name)
+		}
+	}
+}
+
+func TestCheckAllInstallURLs(t *testing.T) {
+	wantURLs := map[string]string{
+		"node":   "https://nodejs.org",
+		"git":    "https://git-scm.com",
+		"claude": "https://claude.ai/code",
+	}
+	for _, r := range CheckAll() {
+		want, ok := wantURLs[r.Name]
+		if !ok {
+			continue
+		}
+		if r.InstallURL != want {
+			t.Errorf("%s: InstallURL: got %q, want %q", r.Name, r.InstallURL, want)
+		}
+	}
+}
+
+func TestCheckOneResultFields(t *testing.T) {
+	// node may or may not be installed; just verify field consistency.
+	r := CheckOne("node")
+	if r.Name != "node" {
+		t.Errorf("Name: got %q, want %q", r.Name, "node")
+	}
+	if r.Required != prereqSpecs["node"].required {
+		t.Errorf("Required: got %v, want %v", r.Required, prereqSpecs["node"].required)
+	}
+	if r.Found && r.Version == "" {
+		t.Error("if Found is true, Version should not be empty")
+	}
+	if !r.Found && r.Version != "" {
+		t.Error("if Found is false, Version should be empty")
+	}
+}

--- a/internal/onboarding/state.go
+++ b/internal/onboarding/state.go
@@ -1,0 +1,220 @@
+// Package onboarding manages first-run state, prerequisite detection,
+// task templates, and the HTTP handlers that power the onboarding UI.
+package onboarding
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// currentStateVersion is the schema version written to onboarded.json.
+// A file with a different version is treated as not-yet-onboarded so the
+// user goes through the flow again after a breaking upgrade.
+const currentStateVersion = 1
+
+// State mirrors the full contents of ~/.wuphf/onboarded.json.
+type State struct {
+	// CompletedAt is the RFC-3339 timestamp of when the user finished onboarding.
+	// Empty string means onboarding is not complete.
+	CompletedAt string `json:"completed_at,omitempty"`
+
+	// Version is the schema version of the file. Used to invalidate stale state
+	// after breaking changes.
+	Version int `json:"version"`
+
+	// CompanyName is the canonical company name captured during onboarding.
+	CompanyName string `json:"company_name,omitempty"`
+
+	// CompletedSteps lists the step IDs the user has finished.
+	CompletedSteps []string `json:"completed_steps,omitempty"`
+
+	// ChecklistDismissed is true when the user has closed the post-onboarding
+	// checklist permanently.
+	ChecklistDismissed bool `json:"checklist_dismissed"`
+
+	// Partial holds in-progress answers when the user has not finished onboarding.
+	Partial *PartialProgress `json:"partial,omitempty"`
+
+	// Checklist is the list of post-onboarding action items.
+	Checklist []ChecklistItem `json:"checklist,omitempty"`
+}
+
+// Onboarded reports whether the user has successfully completed onboarding.
+// Returns false when the file is missing, the version has changed, or
+// CompletedAt is empty.
+func (s *State) Onboarded() bool {
+	return s.Version == currentStateVersion && s.CompletedAt != ""
+}
+
+// PartialProgress captures answers the user has submitted so far while
+// stepping through the multi-step onboarding flow.
+type PartialProgress struct {
+	// Step is the ID of the step the user is currently on.
+	Step string `json:"step,omitempty"`
+
+	// Answers maps step IDs to the free-form answers submitted for that step.
+	Answers map[string]map[string]interface{} `json:"answers,omitempty"`
+}
+
+// ChecklistItem is a single post-onboarding action item shown in the UI
+// until the user completes or dismisses the checklist.
+type ChecklistItem struct {
+	// ID is the stable identifier for this item (e.g. "pick_team").
+	ID string `json:"id"`
+
+	// Done is true when the user has marked this item complete.
+	Done bool `json:"done"`
+}
+
+// StatePath returns the absolute path to ~/.wuphf/onboarded.json.
+// It expands $HOME via os.UserHomeDir; falls back to a relative path on
+// error (only occurs in extremely restricted environments).
+func StatePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".wuphf", "onboarded.json")
+	}
+	return filepath.Join(home, ".wuphf", "onboarded.json")
+}
+
+// Load reads and parses ~/.wuphf/onboarded.json.
+// When the file does not exist it returns a fresh State with Onboarded()==false
+// and a default checklist — no error is returned in that case.
+func Load() (*State, error) {
+	data, err := os.ReadFile(StatePath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &State{
+				Version:   currentStateVersion,
+				Checklist: DefaultChecklist(),
+			}, nil
+		}
+		return nil, fmt.Errorf("onboarding: read state: %w", err)
+	}
+	var s State
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("onboarding: parse state: %w", err)
+	}
+	// If the file was written by an older schema version, return a fresh state
+	// so the user re-runs onboarding rather than hitting subtle bugs.
+	if s.Version != currentStateVersion {
+		return &State{
+			Version:   currentStateVersion,
+			Checklist: DefaultChecklist(),
+		}, nil
+	}
+	// Back-fill checklist when the field was never written (e.g. old file).
+	if len(s.Checklist) == 0 {
+		s.Checklist = DefaultChecklist()
+	}
+	return &s, nil
+}
+
+// Save atomically writes s to ~/.wuphf/onboarded.json by first writing to a
+// sibling temp file and then renaming it into place.
+func Save(s *State) error {
+	path := StatePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("onboarding: mkdir: %w", err)
+	}
+	data, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return fmt.Errorf("onboarding: marshal state: %w", err)
+	}
+	data = append(data, '\n')
+
+	// Write to a temp file in the same directory so the rename is atomic.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".onboarded-*.json")
+	if err != nil {
+		return fmt.Errorf("onboarding: create temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		// Best-effort cleanup of the temp file if something goes wrong.
+		_ = os.Remove(tmpPath)
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("onboarding: write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("onboarding: close temp: %w", err)
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("onboarding: rename temp: %w", err)
+	}
+	return nil
+}
+
+// SaveProgress loads the current state, updates the partial-progress record
+// for the given step, and saves it back atomically.
+func SaveProgress(step string, answers map[string]interface{}) error {
+	s, err := Load()
+	if err != nil {
+		return err
+	}
+	if s.Partial == nil {
+		s.Partial = &PartialProgress{}
+	}
+	s.Partial.Step = step
+	if s.Partial.Answers == nil {
+		s.Partial.Answers = make(map[string]map[string]interface{})
+	}
+	s.Partial.Answers[step] = answers
+	return Save(s)
+}
+
+// MarkChecklistItem loads the current state, sets the Done flag on the item
+// with the given id, and saves. Unknown IDs are silently ignored.
+func MarkChecklistItem(id string, done bool) error {
+	s, err := Load()
+	if err != nil {
+		return err
+	}
+	for i := range s.Checklist {
+		if s.Checklist[i].ID == id {
+			s.Checklist[i].Done = done
+			break
+		}
+	}
+	return Save(s)
+}
+
+// DismissChecklist loads the current state, sets ChecklistDismissed=true,
+// and saves.
+func DismissChecklist() error {
+	s, err := Load()
+	if err != nil {
+		return err
+	}
+	s.ChecklistDismissed = true
+	return Save(s)
+}
+
+// DefaultChecklist returns the canonical ordered list of post-onboarding
+// action items. These are the five items shown in the Getting-Started panel.
+func DefaultChecklist() []ChecklistItem {
+	return []ChecklistItem{
+		{ID: "pick_team", Done: false},
+		{ID: "second_key", Done: false},
+		{ID: "github_repo", Done: false},
+		{ID: "github_star", Done: false},
+		{ID: "discord", Done: false},
+	}
+}
+
+// completeState builds a State that represents a fully-onboarded user.
+// The caller must still call Save to persist it.
+func completeState(s *State, companyName string) {
+	s.CompletedAt = time.Now().UTC().Format(time.RFC3339)
+	s.Version = currentStateVersion
+	if companyName != "" {
+		s.CompanyName = companyName
+	}
+	s.Partial = nil
+}

--- a/internal/onboarding/state_test.go
+++ b/internal/onboarding/state_test.go
@@ -1,0 +1,263 @@
+package onboarding
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// withTempHome redirects os.UserHomeDir (via $HOME) to a temp dir for
+// the duration of f, keeping test state isolated from the real ~/.wuphf.
+func withTempHome(t *testing.T, f func(home string)) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	f(dir)
+}
+
+func TestLoadFreshInstallReturnsNotOnboarded(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load: unexpected error: %v", err)
+		}
+		if s.Onboarded() {
+			t.Fatal("fresh install should not be onboarded")
+		}
+		if s.Version != currentStateVersion {
+			t.Fatalf("Version: got %d, want %d", s.Version, currentStateVersion)
+		}
+		if len(s.Checklist) == 0 {
+			t.Fatal("fresh install should have a default checklist")
+		}
+	})
+}
+
+func TestLoadDefaultChecklistItems(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		defaults := DefaultChecklist()
+		if len(s.Checklist) != len(defaults) {
+			t.Fatalf("checklist length: got %d, want %d", len(s.Checklist), len(defaults))
+		}
+		for i, item := range s.Checklist {
+			if item.ID != defaults[i].ID {
+				t.Errorf("checklist[%d].ID: got %q, want %q", i, item.ID, defaults[i].ID)
+			}
+			if item.Done {
+				t.Errorf("checklist[%d] should not be done on fresh install", i)
+			}
+		}
+	})
+}
+
+func TestLoadExistingFileReturnsCorrectData(t *testing.T) {
+	withTempHome(t, func(home string) {
+		dir := filepath.Join(home, ".wuphf")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		raw := `{
+			"completed_at": "2026-04-14T10:23:00Z",
+			"version": 1,
+			"company_name": "Dunder Mifflin",
+			"completed_steps": ["welcome", "setup"],
+			"checklist_dismissed": false,
+			"checklist": [
+				{"id": "pick_team", "done": true},
+				{"id": "second_key", "done": false},
+				{"id": "github_repo", "done": false},
+				{"id": "github_star", "done": false},
+				{"id": "discord", "done": false}
+			]
+		}`
+		if err := os.WriteFile(filepath.Join(dir, "onboarded.json"), []byte(raw), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !s.Onboarded() {
+			t.Fatal("expected Onboarded()==true")
+		}
+		if s.CompanyName != "Dunder Mifflin" {
+			t.Errorf("CompanyName: got %q, want %q", s.CompanyName, "Dunder Mifflin")
+		}
+		if len(s.CompletedSteps) != 2 {
+			t.Errorf("CompletedSteps length: got %d, want 2", len(s.CompletedSteps))
+		}
+		if !s.Checklist[0].Done {
+			t.Error("checklist[0] (pick_team) should be done")
+		}
+	})
+}
+
+func TestSaveIsAtomic(t *testing.T) {
+	withTempHome(t, func(home string) {
+		s := &State{
+			Version:     currentStateVersion,
+			CompanyName: "Initech",
+			Checklist:   DefaultChecklist(),
+		}
+		if err := Save(s); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		path := StatePath()
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("file should exist at %s after Save: %v", path, err)
+		}
+		// Ensure no temp file leaked.
+		entries, _ := os.ReadDir(filepath.Dir(path))
+		for _, e := range entries {
+			if e.Name() != "onboarded.json" {
+				t.Errorf("unexpected file in .wuphf dir after Save: %s", e.Name())
+			}
+		}
+	})
+}
+
+func TestSaveRoundtrip(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		original := &State{
+			CompletedAt:        "2026-04-14T10:23:00Z",
+			Version:            currentStateVersion,
+			CompanyName:        "Paper Company",
+			CompletedSteps:     []string{"welcome", "setup"},
+			ChecklistDismissed: false,
+			Checklist:          DefaultChecklist(),
+		}
+		if err := Save(original); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		loaded, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if loaded.CompanyName != original.CompanyName {
+			t.Errorf("CompanyName: got %q, want %q", loaded.CompanyName, original.CompanyName)
+		}
+		if loaded.CompletedAt != original.CompletedAt {
+			t.Errorf("CompletedAt: got %q, want %q", loaded.CompletedAt, original.CompletedAt)
+		}
+	})
+}
+
+func TestSaveProgressMergesCorrectly(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		// First save progress for welcome step.
+		welcomeAnswers := map[string]interface{}{
+			"company_name": "Initech",
+			"description":  "We do TPS reports",
+		}
+		if err := SaveProgress("welcome", welcomeAnswers); err != nil {
+			t.Fatalf("SaveProgress welcome: %v", err)
+		}
+
+		// Then save progress for setup step.
+		setupAnswers := map[string]interface{}{
+			"anthropic_key": "sk-ant-test",
+		}
+		if err := SaveProgress("setup", setupAnswers); err != nil {
+			t.Fatalf("SaveProgress setup: %v", err)
+		}
+
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if s.Partial == nil {
+			t.Fatal("expected Partial to be non-nil")
+		}
+		if s.Partial.Step != "setup" {
+			t.Errorf("Partial.Step: got %q, want %q", s.Partial.Step, "setup")
+		}
+		// Both steps' answers should be present.
+		if _, ok := s.Partial.Answers["welcome"]; !ok {
+			t.Error("expected welcome answers to be persisted")
+		}
+		if _, ok := s.Partial.Answers["setup"]; !ok {
+			t.Error("expected setup answers to be persisted")
+		}
+		if s.Partial.Answers["welcome"]["company_name"] != "Initech" {
+			t.Errorf("welcome company_name: got %v", s.Partial.Answers["welcome"]["company_name"])
+		}
+	})
+}
+
+func TestVersionBumpReturnsNotOnboarded(t *testing.T) {
+	withTempHome(t, func(home string) {
+		// Write a file that looks complete but with an old schema version.
+		dir := filepath.Join(home, ".wuphf")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		stale := map[string]interface{}{
+			"completed_at": time.Now().UTC().Format(time.RFC3339),
+			"version":      0, // old version
+			"company_name": "Old Corp",
+		}
+		data, _ := json.Marshal(stale)
+		if err := os.WriteFile(filepath.Join(dir, "onboarded.json"), data, 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if s.Onboarded() {
+			t.Fatal("stale version should return onboarded=false")
+		}
+		// Version should be upgraded to current.
+		if s.Version != currentStateVersion {
+			t.Errorf("Version: got %d, want %d", s.Version, currentStateVersion)
+		}
+	})
+}
+
+func TestMarkChecklistItem(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		// Start fresh.
+		if err := Save(&State{Version: currentStateVersion, Checklist: DefaultChecklist()}); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		if err := MarkChecklistItem("pick_team", true); err != nil {
+			t.Fatalf("MarkChecklistItem: %v", err)
+		}
+		s, _ := Load()
+		found := false
+		for _, item := range s.Checklist {
+			if item.ID == "pick_team" {
+				found = true
+				if !item.Done {
+					t.Error("pick_team should be done")
+				}
+			}
+		}
+		if !found {
+			t.Error("pick_team not found in checklist")
+		}
+	})
+}
+
+func TestDismissChecklist(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		if err := Save(&State{Version: currentStateVersion, Checklist: DefaultChecklist()}); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+		if err := DismissChecklist(); err != nil {
+			t.Fatalf("DismissChecklist: %v", err)
+		}
+		s, _ := Load()
+		if !s.ChecklistDismissed {
+			t.Error("ChecklistDismissed should be true")
+		}
+	})
+}

--- a/internal/onboarding/templates.go
+++ b/internal/onboarding/templates.go
@@ -1,0 +1,56 @@
+package onboarding
+
+// TaskTemplate describes a first-task suggestion shown during onboarding.
+// Templates are scoped to a specific agent role via OwnerSlug.
+type TaskTemplate struct {
+	// ID is a stable, URL-safe identifier for the template.
+	ID string `json:"id"`
+
+	// Title is the short, human-readable task name.
+	Title string `json:"title"`
+
+	// Description is a single-sentence clarification shown below the title.
+	Description string `json:"description"`
+
+	// OwnerSlug is the agent slug that should receive this task (e.g. "eng",
+	// "pm", "ceo"). Matches the default starter-pack slugs.
+	OwnerSlug string `json:"owner_slug"`
+}
+
+// DefaultTemplates returns the five starter task templates scoped to the
+// default CEO + Eng + PM pack. Copy leans on The Office for flavor —
+// because Michael Scott would absolutely skip writing a spec.
+func DefaultTemplates() []TaskTemplate {
+	return []TaskTemplate{
+		{
+			ID:          "landing",
+			Title:       "Draft the landing page",
+			Description: "Hero, value props, one clear CTA. Not the WUPHF.com approach.",
+			OwnerSlug:   "eng",
+		},
+		{
+			ID:          "repo",
+			Title:       "Set up repo structure",
+			Description: "Folders, README, CI scaffold. Dwight would document everything.",
+			OwnerSlug:   "eng",
+		},
+		{
+			ID:          "spec",
+			Title:       "Write the product spec",
+			Description: "What we're building, why, and what done looks like. Michael would skip this step.",
+			OwnerSlug:   "pm",
+		},
+		{
+			ID:          "readme",
+			Title:       "Write the README",
+			Description: "Installation, usage, one example. Short enough that someone actually reads it.",
+			OwnerSlug:   "pm",
+		},
+		{
+			ID:          "audit",
+			Title:       "Audit the competition",
+			Description: "What they do, what they miss, where we win. No memos. Just findings.",
+			OwnerSlug:   "ceo",
+		},
+	}
+}

--- a/internal/onboarding/templates_test.go
+++ b/internal/onboarding/templates_test.go
@@ -1,0 +1,64 @@
+package onboarding
+
+import "testing"
+
+func TestDefaultTemplatesReturnsFiveItems(t *testing.T) {
+	templates := DefaultTemplates()
+	if len(templates) != 5 {
+		t.Fatalf("DefaultTemplates: got %d items, want 5", len(templates))
+	}
+}
+
+func TestDefaultTemplatesNonEmptyFields(t *testing.T) {
+	for _, tmpl := range DefaultTemplates() {
+		if tmpl.ID == "" {
+			t.Errorf("template %+v: ID must not be empty", tmpl)
+		}
+		if tmpl.Title == "" {
+			t.Errorf("template %q: Title must not be empty", tmpl.ID)
+		}
+		if tmpl.OwnerSlug == "" {
+			t.Errorf("template %q: OwnerSlug must not be empty", tmpl.ID)
+		}
+		if tmpl.Description == "" {
+			t.Errorf("template %q: Description must not be empty", tmpl.ID)
+		}
+	}
+}
+
+func TestDefaultTemplatesExpectedIDs(t *testing.T) {
+	wantIDs := []string{"landing", "repo", "spec", "readme", "audit"}
+	templates := DefaultTemplates()
+	for i, want := range wantIDs {
+		if templates[i].ID != want {
+			t.Errorf("templates[%d].ID: got %q, want %q", i, templates[i].ID, want)
+		}
+	}
+}
+
+func TestDefaultTemplatesOwnerSlugs(t *testing.T) {
+	// Verify the expected owner distribution: eng×2, pm×2, ceo×1.
+	counts := map[string]int{}
+	for _, tmpl := range DefaultTemplates() {
+		counts[tmpl.OwnerSlug]++
+	}
+	if counts["eng"] != 2 {
+		t.Errorf("expected 2 eng templates, got %d", counts["eng"])
+	}
+	if counts["pm"] != 2 {
+		t.Errorf("expected 2 pm templates, got %d", counts["pm"])
+	}
+	if counts["ceo"] != 1 {
+		t.Errorf("expected 1 ceo template, got %d", counts["ceo"])
+	}
+}
+
+func TestDefaultTemplatesUniqueIDs(t *testing.T) {
+	seen := map[string]bool{}
+	for _, tmpl := range DefaultTemplates() {
+		if seen[tmpl.ID] {
+			t.Errorf("duplicate template ID: %q", tmpl.ID)
+		}
+		seen[tmpl.ID] = true
+	}
+}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/channel"
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/onboarding"
 	"github.com/nex-crm/wuphf/internal/provider"
 )
 
@@ -790,6 +791,9 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/events", b.handleEvents)
 	mux.HandleFunc("/agent-stream/", b.requireAuth(b.handleAgentStream))
 	mux.HandleFunc("/web-token", b.handleWebToken)
+	// Onboarding: state/progress/complete + prereqs/templates/validate-key + checklist.
+	// completeFn posts the first task as a human message and seeds the team.
+	onboarding.RegisterRoutes(mux, b.onboardingCompleteFn)
 
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	ln, err := net.Listen("tcp", addr)

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -1,0 +1,67 @@
+package team
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// onboardingCompleteFn is invoked by the onboarding package when the user
+// finishes the wizard. It seeds the default team (idempotent — no-op if a
+// team already exists), posts the user's first task to #general as a human
+// message tagged to the office lead, and lets the existing launcher trigger
+// the lead's delegate turn.
+//
+// Side effects happen BEFORE the onboarding package writes the completion
+// flag to disk, so a crash between this call returning and the flag write
+// re-enters the wizard — and the dedupe guard below prevents double-posting.
+func (b *Broker) onboardingCompleteFn(task string, skipTask bool) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Seed default team if none is configured yet. This mirrors the path
+	// taken on first boot (see ensureDefaultOfficeMembersLocked).
+	b.ensureDefaultOfficeMembersLocked()
+
+	// Skip-task path: team seeded, no first message. Caller marks onboarded.
+	if skipTask {
+		return b.saveLocked()
+	}
+
+	task = strings.TrimSpace(task)
+	if task == "" {
+		return fmt.Errorf("onboarding: task is required when skip_task=false")
+	}
+
+	// Dedupe: if a prior onboarding-complete already posted this exact task
+	// (recognized via the onboarding_origin marker in Kind), skip re-posting.
+	for _, existing := range b.messages {
+		if existing.Channel == "general" && existing.Kind == "onboarding_origin" && existing.Content == task {
+			return b.saveLocked()
+		}
+	}
+
+	lead := officeLeadSlugFrom(b.members, nil)
+	if lead == "" {
+		lead = "ceo"
+	}
+
+	b.counter++
+	msg := channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "human",
+		Channel:   "general",
+		Kind:      "onboarding_origin",
+		Content:   task,
+		Tagged:    []string{lead},
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	b.appendMessageLocked(msg)
+
+	if b.lastTaggedAt == nil {
+		b.lastTaggedAt = make(map[string]time.Time)
+	}
+	b.lastTaggedAt[lead] = time.Now()
+
+	return b.saveLocked()
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1403,416 +1403,209 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 .connect-badge { font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: var(--radius-full); }
 .connect-badge-ok { background: var(--green-bg); color: var(--green); }
 .connect-badge-off { background: var(--bg); color: var(--text-tertiary); }
+
+/* ═══════════════════════════════════════════
+   ONBOARDING WIZARD
+   ═══════════════════════════════════════════ */
+.onboarding-wizard { min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 40px 24px; }
+.wizard-body { width: 100%; max-width: 640px; }
+.wizard-step { display: none; flex-direction: column; gap: 24px; }
+.wizard-step.active { display: flex; }
+.wizard-progress { display: flex; align-items: center; justify-content: center; gap: 8px; margin-bottom: 40px; }
+.wizard-progress .progress-dot.active { width: 40px; background: var(--accent); }
+.wizard-progress .progress-dot.inactive { width: 24px; background: var(--border-light); }
+
+/* Step 1 */
+.wizard-hero { text-align: center; }
+.wizard-eyebrow { display: inline-flex; align-items: center; gap: 6px; font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--text-tertiary); margin-bottom: 12px; }
+.wizard-headline { font-family: var(--font-logo); font-style: italic; font-size: 36px; letter-spacing: -0.02em; line-height: 1.1; margin-bottom: 12px; }
+.wizard-subhead { font-size: 14px; line-height: 1.65; color: var(--text-secondary); max-width: 54ch; margin: 0 auto; }
+
+/* Prereqs */
+.prereq-row { display: flex; align-items: center; gap: 10px; padding: 10px 0; border-bottom: 1px solid var(--border); }
+.prereq-row:last-child { border-bottom: none; }
+.prereq-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; background: var(--border); }
+.prereq-dot.ok { background: var(--green, #22c55e); }
+.prereq-dot.fail { background: var(--red, #ef4444); }
+.prereq-name { font-size: 13px; font-weight: 500; flex: 1; }
+.prereq-version { font-size: 11px; color: var(--text-tertiary); font-family: var(--font-mono); }
+.prereq-install { font-size: 11px; color: var(--accent); text-decoration: none; }
+.prereq-install:hover { text-decoration: underline; }
+
+/* Keys */
+.key-row { display: flex; align-items: flex-start; gap: 12px; padding: 12px 0; border-bottom: 1px solid var(--border); }
+.key-row:last-child { border-bottom: none; }
+.key-label-wrap { flex: 1; min-width: 0; }
+.key-label { font-size: 13px; font-weight: 500; display: block; margin-bottom: 2px; }
+.key-hint { font-size: 11px; color: var(--text-tertiary); }
+.key-input-wrap { flex: 1.2; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.key-status { font-size: 11px; min-height: 16px; }
+.key-status.checking { color: var(--text-tertiary); }
+.key-status.valid { color: var(--green, #22c55e); }
+.key-status.invalid { color: var(--red, #ef4444); }
+.key-status.unverified { color: var(--yellow, #f59e0b); }
+.unreachable-notice { font-size: 12px; color: var(--yellow, #f59e0b); display: flex; align-items: center; gap: 8px; padding: 8px 10px; background: rgba(245,158,11,0.08); border-radius: var(--radius-md); border: 1px solid rgba(245,158,11,0.25); }
+
+/* Templates */
+.template-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 10px; }
+.template-tile { padding: 14px 16px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--bg-card); cursor: pointer; transition: border-color 0.15s, background 0.15s; }
+.template-tile:hover { border-color: var(--accent); background: var(--accent-bg); }
+.template-tile.selected { border-color: var(--accent); background: var(--accent-bg); }
+.template-title { font-size: 13px; font-weight: 600; margin-bottom: 4px; }
+.template-desc { font-size: 11px; color: var(--text-secondary); line-height: 1.5; margin-bottom: 6px; }
+.template-owner { font-size: 10px; font-family: var(--font-mono); color: var(--accent); }
+.task-textarea { width: 100%; min-height: 80px; padding: 10px 12px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--bg-card); color: var(--text); font-family: var(--font-sans); font-size: 13px; line-height: 1.5; resize: vertical; box-sizing: border-box; }
+.task-textarea:focus { outline: none; border-color: var(--accent); }
+.task-skip { font-size: 12px; color: var(--text-tertiary); background: none; border: none; cursor: pointer; padding: 0; text-decoration: underline; }
+.task-skip:hover { color: var(--text-secondary); }
+
+/* Wizard panels */
+.wizard-panel { background: var(--bg-card); border: 1px solid var(--border); border-radius: var(--radius-md); padding: 20px 24px; }
+.wizard-panel-title { font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-secondary); margin-bottom: 16px; }
+
+/* Checklist sidebar */
+.sidebar-checklist { padding: 0 12px 4px; }
+.checklist-item { display: flex; align-items: center; gap: 8px; padding: 4px 8px; margin-left: 4px; font-size: 11px; color: var(--text-secondary); }
+.checklist-item.done { text-decoration: line-through; color: var(--text-tertiary); }
+.checklist-checkbox { width: 12px; height: 12px; border-radius: 2px; border: 1px solid var(--border); flex-shrink: 0; }
+.checklist-checkbox.checked { background: var(--green, #22c55e); border-color: var(--green, #22c55e); }
+.checklist-link { color: inherit; text-decoration: none; flex: 1; }
+.checklist-link:hover { color: var(--text); }
+.checklist-dismiss { background: none; border: none; color: var(--text-tertiary); cursor: pointer; font-size: 12px; padding: 0 2px; margin-left: auto; }
+.checklist-dismiss:hover { color: var(--text); }
 </style>
 </head>
 <body>
 
 <div id="app">
-  <!-- ONBOARDING -->
-  <main class="onboarding dot-grid" id="onboarding" data-step="0">
-    <div class="onboarding-inner">
-      <div class="progress-dots" id="progress-dots"></div>
+  <!-- ONBOARDING WIZARD -->
+  <main class="onboarding-wizard dot-grid" id="onboarding-wizard" style="display:none">
+    <div class="wizard-body">
+      <div class="wizard-progress" id="wizard-progress"></div>
 
-      <!-- Step 0: Welcome -->
-      <div class="step active animate-fade" data-step="0">
-        <div class="landing-shell">
-          <header class="landing-topbar" aria-label="WUPHF overview">
-            <div class="landing-brand">WUPHF</div>
-            <div class="landing-topbar-meta">
-              <span class="badge badge-accent">Private alpha</span>
-              <span class="landing-dot" aria-hidden="true"></span>
-              <span>Visible multi-agent execution for live work</span>
-            </div>
-          </header>
-
-          <section class="card landing-hero" aria-labelledby="landing-headline">
-            <div class="landing-hero-copy">
-              <div class="landing-eyebrow">
-                <span class="status-dot active pulse"></span>
-                The AI startup Ryan Howard always wished WUPHF.com could be
-              </div>
-              <h1 class="landing-headline" id="landing-headline">Your AI team, visible and working.</h1>
-              <p class="landing-subhead">WUPHF gives operators one room where AI specialists can claim real work, show progress in public, and pull in a human only when judgment is required. Unlike the original WUPHF.com, this one still works next quarter.</p>
-              <div class="landing-cta-row">
-                <button class="btn btn-primary btn-lg landing-cta-btn" onclick="goToStep(1)">
-                  Open the office — Ryan would be proud
-                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-                </button>
-                <p class="landing-secondary-note">Start with one real task and judge the system by shipped work, not polished agent theater. Michael would invest. Don't be Michael.</p>
-              </div>
-            </div>
-
-            <aside class="landing-preview" aria-label="Office preview">
-              <div class="landing-preview-card">
-                <div class="landing-preview-header">
-                  <div>
-                    <div class="landing-preview-title">#general</div>
-                    <div class="landing-preview-subtitle">3 agents active, 1 decision pending — Kevin is at the vending machine</div>
-                  </div>
-                  <div class="landing-preview-pill">
-                    <span class="status-dot active pulse"></span>
-                    Live office
-                  </div>
-                </div>
-                <div class="landing-preview-body">
-                  <article class="landing-thread">
-                    <div class="landing-thread-avatar">🤖</div>
-                    <div>
-                      <div class="landing-thread-meta">
-                        <span class="landing-thread-name">@eng</span>
-                        <span class="landing-thread-status">task claimed</span>
-                      </div>
-                      <p class="landing-thread-copy">Landing page scaffold is in progress. Hero and proof sections are ready. Waiting on final value-prop copy. Unlike Ryan Howard, I will still be running when you check back.</p>
-                    </div>
-                  </article>
-                  <div class="landing-thread-actions">
-                    <div class="landing-action">
-                      <div class="landing-action-label">Task board</div>
-                      <div class="landing-action-copy">Ownership and active work stay visible. Even Kevin knows who's on what.</div>
-                    </div>
-                    <div class="landing-action">
-                      <div class="landing-action-label">Threading</div>
-                      <div class="landing-action-copy">Decisions stay attached to the work they changed. No "per my last email" moments.</div>
-                    </div>
-                    <div class="landing-action">
-                      <div class="landing-action-label">Escalation</div>
-                      <div class="landing-action-copy">Humans get pulled in only when judgment is required. Toby's approval not needed.</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </aside>
-          </section>
-
-          <section class="landing-proof-grid" aria-label="What the foundation needs to communicate">
-            <article class="card landing-proof-card">
-              <div class="landing-proof-label">Visibility</div>
-              <h2 class="landing-proof-value">See who owns the next move</h2>
-              <p class="landing-proof-copy">Tasks, threads, and blockers stay in one room. Work doesn't disappear into hidden agent sessions. That's more than Ryan Howard's laptop can say.</p>
-            </article>
-            <article class="card landing-proof-card">
-              <div class="landing-proof-label">Judgment</div>
-              <h2 class="landing-proof-value">Humans step in at the right moment</h2>
-              <p class="landing-proof-copy">Approvals, blockers, and interviews are explicit. You review decisions instead of babysitting every step. Think of yourself as the regional manager, not the middleware.</p>
-            </article>
-            <article class="card landing-proof-card">
-              <div class="landing-proof-label">Output</div>
-              <h2 class="landing-proof-value">Judge it on real work</h2>
-              <p class="landing-proof-copy">Point WUPHF at a live repo, pipeline, or workflow. Evaluate from shipped output, not polished demo theatrics. Dwight would call this merit-based assessment. He'd be right.</p>
-            </article>
-          </section>
-
-          <section class="card landing-section" aria-labelledby="landing-problem-heading">
-            <div class="landing-section-header">
-              <div class="landing-kicker">Problem / solution</div>
-              <h2 class="landing-section-title" id="landing-problem-heading">The problem is not getting one agent to do a trick. It is managing a team of them without becoming the Toby Flenderson of your own pipeline.</h2>
-              <p class="landing-section-copy">Most multi-agent setups still make the operator stitch together prompts, tools, approvals, and follow-up by hand. WUPHF turns that coordination layer into a visible office. An actual one, unlike WUPHF.com.</p>
-            </div>
-            <div class="landing-problem-grid">
-              <div class="landing-problem-card">
-                <p class="landing-section-copy landing-problem-lead">Once work spans multiple sessions, the hard part is no longer raw output. It is knowing which agent owns the thread, which decision changed the plan, and where the human actually needs to step in.</p>
-              </div>
-              <div class="landing-problem-card">
-                <ol class="landing-problem-points">
-                  <li><span class="landing-point-index">1</span><span><strong>Context drifts.</strong> Teams reconstruct history from terminals, tabs, and memory. Ryan Howard called this "a learning experience."</span></li>
-                  <li><span class="landing-point-index">2</span><span><strong>Ownership blurs.</strong> Multiple agents move, but nobody can tell who is accountable for the next step. Dwight calls this a failure of chain of command.</span></li>
-                  <li><span class="landing-point-index">3</span><span><strong>Escalations come late.</strong> Humans hear about the blocker after time has already been burned. Like when Michael found out about the merger.</span></li>
-                </ol>
-              </div>
-              <div class="landing-problem-card landing-solution-card">
-                <div class="landing-solution-title">WUPHF gives the team one room for delegation, context, and escalation. Not a website that also contacts you via Facebook. A real room.</div>
-                <ul class="landing-solution-points">
-                  <li><span class="landing-point-index">A</span><span>Agents work in the open with shared task state, thread history, and clear ownership.</span></li>
-                  <li><span class="landing-point-index">B</span><span>Humans stay in the loop through explicit checkpoints instead of monitoring invisible automations.</span></li>
-                  <li><span class="landing-point-index">C</span><span>The system can be judged on completed work, not on how impressive the demo video looked.</span></li>
-                </ul>
-              </div>
-            </div>
-          </section>
-
-          <section class="card landing-section" aria-labelledby="landing-props-heading">
-            <div class="landing-section-header">
-              <div class="landing-kicker">Value props</div>
-              <h2 class="landing-section-title" id="landing-props-heading">Three homepage-ready value props for the current wedge.</h2>
-              <p class="landing-section-copy">Lead with the office story, then stack context and cost as the two supporting reasons to believe.</p>
-            </div>
-            <div class="landing-props-grid">
-              <article class="card landing-prop-card">
-                <div class="landing-prop-label">Lead angle</div>
-                <h3 class="landing-prop-title">Run an AI office, not a pile of AI tools. (And not just a website named after a sound.)</h3>
-                <p class="landing-prop-copy">WUPHF gives you a live delegation desk for autonomous agents across workstreams, channels, and devices. No VC pitch required.</p>
-                <p class="landing-prop-proof">Proof: Work stays visible in one room, so specialists can claim tasks, coordinate in-thread, and keep momentum without another SaaS maze.</p>
-              </article>
-              <article class="card landing-prop-card">
-                <div class="landing-prop-label">Differentiator</div>
-                <h3 class="landing-prop-title">Agents with context, not goldfish with APIs. Or Ryan Howard with a startup.</h3>
-                <p class="landing-prop-copy">Every agent works with shared memory, org history, and live task context, so execution compounds instead of restarting from scratch.</p>
-                <p class="landing-prop-proof">Proof: Decisions, blockers, and prior work stay attached to the thread, which makes handoffs sharper and escalation less expensive.</p>
-              </article>
-              <article class="card landing-prop-card">
-                <div class="landing-prop-label">Commercial angle</div>
-                <h3 class="landing-prop-title">Replace bloated GTM tooling with one operator layer.</h3>
-                <p class="landing-prop-copy">WUPHF coordinates outreach, follow-up, research, and execution at a fraction of the usual software spend. Michael Scott would say "working smarter, not harder" — while doing the opposite. WUPHF actually does it.</p>
-                <p class="landing-prop-proof">Proof: Instead of buying separate tooling for every narrow GTM task, operators get one accountable layer that can route work across specialists.</p>
-              </article>
-            </div>
-          </section>
-
-          <section class="card landing-section" aria-labelledby="landing-how-heading">
-            <div class="landing-section-header">
-              <div class="landing-kicker">How it works</div>
-              <h2 class="landing-section-title" id="landing-how-heading">Simple structure for explaining the workflow.</h2>
-            </div>
-            <div class="landing-flow-grid">
-              <article class="card landing-flow-step">
-                <div class="landing-step-number">01</div>
-                <div class="landing-step-label">Set up the office</div>
-                <p class="landing-step-copy">Pick the team, connect the repo, and give the room a real task. Unlike Ryan, who picked a cool domain name and called it an MVP.</p>
-              </article>
-              <article class="card landing-flow-step">
-                <div class="landing-step-number">02</div>
-                <div class="landing-step-label">Let specialists execute</div>
-                <p class="landing-step-copy">Agents claim work, post updates, and keep the task graph visible while they ship. No disappearing into a WeWork and emerging with no revenue.</p>
-              </article>
-              <article class="card landing-flow-step">
-                <div class="landing-step-number">03</div>
-                <div class="landing-step-label">Intervene with precision</div>
-                <p class="landing-step-copy">Humans review, approve, or redirect only when the system asks for judgment. You are the regional manager now. Use it wisely.</p>
-              </article>
-            </div>
-          </section>
-
-          <section class="card landing-section" aria-labelledby="landing-controls-heading">
-            <div class="landing-section-header">
-              <div class="landing-kicker">Operator controls</div>
-              <h2 class="landing-section-title" id="landing-controls-heading">Foundation for the “why trust this” section.</h2>
-            </div>
-            <div class="landing-control-grid">
-              <article class="landing-control-card">
-                <div class="landing-control-label">Threaded history</div>
-                <p class="landing-control-copy">Conversations, task claims, and blocking questions stay in one visible timeline. Everything is logged. Creed cannot tamper with this one.</p>
-              </article>
-              <article class="landing-control-card">
-                <div class="landing-control-label">Shared task board</div>
-                <p class="landing-control-copy">The office shows active work, ownership, and blockers instead of hiding progress in side sessions. Dwight-level accountability, without the intimidation tactics.</p>
-              </article>
-              <article class="landing-control-card">
-                <div class="landing-control-label">Human judgment lane</div>
-                <p class="landing-control-copy">Approvals and interviews are explicit, so the human stays in control without micromanaging every step. Think of it as being the Michael Scott who actually manages.</p>
-              </article>
-            </div>
-          </section>
-
-          <section class="card landing-final-cta" aria-labelledby="landing-final-heading">
-            <div class="landing-final-copy-wrap">
-              <div class="landing-kicker">Call to action</div>
-              <h2 class="landing-final-title" id="landing-final-heading">Start with one real task and watch the office run it in public. Unlike WUPHF.com, this one will still be live next quarter.</h2>
-              <p class="landing-final-copy">Bring a live repo, pipeline motion, or ops workflow, invite the specialists you need, and evaluate from visible execution. Michael Scott would invest $10,000 immediately. Don't be Michael Scott — judge it by shipped work.</p>
-            </div>
-            <button class="btn btn-primary btn-lg landing-cta-btn" onclick="goToStep(1)">
-              Open the office — Get WUPHFed
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-            </button>
-          </section>
+      <!-- Step 1: Welcome + Company -->
+      <div class="wizard-step active" id="wizard-step-welcome">
+        <div class="wizard-hero">
+          <div class="wizard-eyebrow">
+            <span class="status-dot active pulse"></span>
+            The AI startup Ryan Howard always wished WUPHF.com could be
+          </div>
+          <h1 class="wizard-headline" id="wizard-headline">Your AI team, visible and working.</h1>
+          <p class="wizard-subhead">WUPHF gives operators one room where AI specialists can claim real work, show progress in public, and pull in a human only when judgment is required. Unlike the original WUPHF.com, this one still works next quarter.</p>
         </div>
-      </div>
 
-      <!-- Step 1: Company info -->
-      <div class="step" data-step="1">
-        <h1 class="step-title">Tell me about your company</h1>
-        <div class="card form-card" style="max-width:540px;margin:0 auto;">
+        <div class="wizard-panel">
           <div class="form-group">
-            <label class="label" for="q-company">What's your company or project name?</label>
-            <input class="input" id="q-company" placeholder="Dunder Mifflin Paper Co. (probably not)" />
+            <label class="label" for="wiz-company">Company or project name <span style="color:var(--red,#ef4444)">*</span></label>
+            <input class="input" id="wiz-company" placeholder="Dunder Mifflin Paper Co. (probably not)" autocomplete="organization" />
           </div>
           <div class="form-group">
-            <label class="label" for="q-description">What do you do?</label>
-            <input class="input" id="q-description" placeholder="We build AI-powered analytics for e-commerce" />
+            <label class="label" for="wiz-description">One-liner description <span style="color:var(--red,#ef4444)">*</span></label>
+            <input class="input" id="wiz-description" placeholder="We build AI-powered ops for lean teams" />
           </div>
-          <div class="form-group">
-            <label class="label" for="q-goals">What are your top 3 goals right now?</label>
-            <input class="input" id="q-goals" placeholder="Ship MVP, get first 10 customers, close seed round (not like WUPHF.com)" />
+          <div class="form-group" style="margin-bottom:0">
+            <label class="label" for="wiz-priority">Top priority right now <span style="color:var(--red,#ef4444)">*</span></label>
+            <input class="input" id="wiz-priority" placeholder="Ship MVP, close first 3 customers, stop being Michael Scott about the roadmap" />
           </div>
         </div>
-        <div class="step-nav" style="max-width:540px;margin:0 auto;">
-          <button class="btn btn-secondary" onclick="goToStep(0)">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
-            Back
-          </button>
-          <button class="btn btn-primary" onclick="goToStep(2)">
-            Next
+
+        <div style="display:flex;justify-content:flex-end;">
+          <button class="btn btn-primary" id="wiz-btn-welcome" onclick="submitWelcome()">
+            Assemble the team
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
           </button>
         </div>
       </div>
 
-      <!-- Step 2: Preferences -->
-      <div class="step" data-step="2">
-        <h1 class="step-title">Almost there. Even Dwight would be proud.</h1>
-        <div class="card form-card" style="max-width:540px;margin:0 auto;">
-          <div class="form-group">
-            <label class="label">How big is your team?</label>
-            <div class="size-options" id="size-options"></div>
-          </div>
-          <div class="form-group">
-            <label class="label" for="q-priority">What's your most immediate priority?</label>
-            <input class="input" id="q-priority" placeholder="Get the landing page live and start collecting leads" />
-          </div>
-        </div>
-        <div class="step-nav" style="max-width:540px;margin:0 auto;">
-          <button class="btn btn-secondary" onclick="goToStep(1)">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
-            Back
-          </button>
-          <button class="btn btn-primary" onclick="buildTeam()">
-            Next
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-          </button>
-        </div>
-      </div>
-
-      <!-- Step 3: Team -->
-      <div class="step" data-step="3">
-        <h1 class="step-title">Your starter team</h1>
-        <p class="step-subtitle">Based on your goals, here's who I recommend. Toggle who you want in the office — you can always add or remove teammates later. Unlike Dunder Mifflin, there are no HR complaints to file.</p>
-        <div class="team-grid" id="team-grid"></div>
-        <div class="step-nav">
-          <button class="btn btn-secondary" onclick="goToStep(2)">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
-            Back
-          </button>
-          <button class="btn btn-primary" onclick="goToStep(4)">
-            Next
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-          </button>
-        </div>
-      </div>
-
-      <!-- Step 4: Prerequisites -->
-      <div class="step" data-step="4">
-        <h1 class="step-title">Prerequisites</h1>
-        <p class="step-subtitle">WUPHF runs locally. Let's make sure you have what you need. Ryan Howard skipped this step. We see how that turned out.</p>
-        <div class="card" style="padding:24px;max-width:540px;margin:0 auto;">
-          <div class="prereq-list" id="prereq-list"></div>
-          <div style="margin-top:16px;">
-            <button class="btn btn-ghost btn-sm" onclick="recheckPrereqs()">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+      <!-- Step 2: Prereqs + Keys -->
+      <div class="wizard-step" id="wizard-step-setup">
+        <div class="wizard-panel">
+          <p class="wizard-panel-title">First, make sure you have the tools</p>
+          <div id="wiz-prereq-list"></div>
+          <div style="margin-top:12px;">
+            <button class="btn btn-ghost btn-sm" onclick="recheckWizPrereqs()">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
               Re-check
             </button>
           </div>
         </div>
-        <div class="step-nav" style="max-width:540px;margin:0 auto;">
-          <button class="btn btn-secondary" onclick="goToStep(3)">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
-            Back
-          </button>
-          <button class="btn btn-primary" onclick="goToStep(5)">
-            Next
+
+        <div class="wizard-panel">
+          <p class="wizard-panel-title">Connect your AI providers</p>
+          <div class="key-row">
+            <div class="key-label-wrap">
+              <span class="key-label">Anthropic</span>
+              <span class="key-hint">Required &mdash; the office won't start without this</span>
+            </div>
+            <div class="key-input-wrap">
+              <input class="input" type="password" id="wiz-key-anthropic" placeholder="sk-ant-..." autocomplete="off"
+                oninput="onKeyInput('anthropic',this.value)"
+                onblur="validateKey('anthropic', this.value)" />
+              <span class="key-status" id="wiz-key-status-anthropic"></span>
+              <div class="unreachable-notice" id="wiz-unreachable-anthropic" style="display:none;">
+                Couldn't reach Anthropic &mdash; key looks valid but unverified.
+                <label style="display:flex;align-items:center;gap:4px;cursor:pointer;white-space:nowrap;">
+                  <input type="checkbox" id="wiz-unreachable-accept" onchange="updateReadyButton()" />
+                  Continue anyway?
+                </label>
+              </div>
+            </div>
+          </div>
+          <div class="key-row">
+            <div class="key-label-wrap">
+              <span class="key-label">OpenAI</span>
+              <span class="key-hint">Optional</span>
+            </div>
+            <div class="key-input-wrap">
+              <input class="input" type="password" id="wiz-key-openai" placeholder="sk-..." autocomplete="off"
+                oninput="onKeyInput('openai',this.value)"
+                onblur="validateKey('openai', this.value)" />
+              <span class="key-status" id="wiz-key-status-openai"></span>
+            </div>
+          </div>
+          <div class="key-row">
+            <div class="key-label-wrap">
+              <span class="key-label">Gemini</span>
+              <span class="key-hint">Optional</span>
+            </div>
+            <div class="key-input-wrap">
+              <input class="input" type="password" id="wiz-key-gemini" placeholder="AIza..." autocomplete="off"
+                oninput="onKeyInput('gemini',this.value)"
+                onblur="validateKey('gemini', this.value)" />
+              <span class="key-status" id="wiz-key-status-gemini"></span>
+            </div>
+          </div>
+        </div>
+
+        <div style="display:flex;justify-content:flex-end;">
+          <button class="btn btn-primary" id="wiz-btn-ready" onclick="showWizardStep('task')" disabled>
+            Ready
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
           </button>
         </div>
       </div>
 
-      <!-- Step 5: API Keys -->
-      <div class="step" data-step="5">
-        <h1 class="step-title">Provider API Keys</h1>
-        <p class="step-subtitle">Connect the LLM providers you want your agents to use. All keys are optional &mdash; configure what you need now and add more later via <code>/config set</code>.</p>
-        <div class="card" style="padding:24px;max-width:540px;margin:0 auto;">
-          <div class="api-key-list" id="api-key-list"></div>
+      <!-- Step 3: First task -->
+      <div class="wizard-step" id="wizard-step-task">
+        <div>
+          <h2 class="step-title" style="text-align:left;margin-bottom:4px;">What's the first thing you want done?</h2>
         </div>
-        <div class="step-nav" style="max-width:540px;margin:0 auto;">
-          <button class="btn btn-secondary" onclick="goToStep(4)">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
-            Back
-          </button>
-          <button class="btn btn-primary" onclick="goToStep(6)">
-            Next
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-          </button>
-        </div>
-      </div>
 
-      <!-- Step 6: GitHub -->
-      <div class="step" data-step="6">
-        <div class="emoji-backdrop">
-          <div class="cloud-row emoji-float" style="top:-5%;left:-8%;opacity:0.4;--dur:34s;animation-delay:-8s;">&#x2728;</div>
-          <div class="cloud-row cloud-row-reverse emoji-float" style="top:5%;left:55%;opacity:0.35;--dur:42s;animation-delay:-17s;">&#x2728;</div>
-          <div class="cloud-row cloud-row-reverse emoji-float" style="top:40%;left:-5%;opacity:0.3;--dur:38s;animation-delay:-12s;">&#x2728;</div>
-          <div class="cloud-row emoji-float" style="top:50%;left:60%;opacity:0.35;--dur:46s;animation-delay:-22s;">&#x2728;</div>
-          <div class="cloud-row emoji-float" style="top:75%;left:20%;opacity:0.3;--dur:40s;animation-delay:-5s;">&#x2728;</div>
+        <div class="template-grid" id="wiz-template-grid">
+          <div style="color:var(--text-tertiary);font-size:13px;grid-column:1/-1;">Loading templates&hellip;</div>
         </div>
-        <div style="position:relative;z-index:1;">
-          <div class="card" style="padding:24px;max-width:600px;margin:0 auto;">
-            <h2 class="font-logo" style="font-size:22px;margin-bottom:8px;">Help the WUPHF community grow</h2>
-            <p style="font-size:14px;color:var(--text-secondary);line-height:1.6;margin-bottom:8px;">A GitHub star helps more people discover WUPHF and build their own AI offices.</p>
-            <p style="font-size:14px;color:var(--text-secondary);line-height:1.6;">If WUPHF feels like something you'd use, give it a star.</p>
-            <div style="margin-top:24px;">
-              <a href="https://github.com/nex-crm/wuphf" target="_blank" rel="noopener noreferrer"
-                class="community-cta" style="background:var(--accent-bg);border:1px solid var(--border);">
-                <span class="community-cta-left">
-                  <span class="community-cta-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="var(--accent)" stroke="none"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
-                  </span>
-                  <span class="community-cta-text">
-                    <span class="community-cta-title">Star WUPHF on GitHub</span>
-                    <span class="community-cta-sub">Help more people find the community</span>
-                  </span>
-                </span>
-              </a>
-            </div>
-          </div>
-          <div class="step-nav" style="max-width:600px;margin:16px auto 0;">
-            <button class="btn btn-secondary" onclick="goToStep(5)">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
-              Back
-            </button>
-            <button class="btn btn-primary" onclick="goToStep(7)">
-              Next
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-            </button>
-          </div>
-        </div>
-      </div>
 
-      <!-- Step 7: Discord + Launch -->
-      <div class="step" data-step="7">
-        <div class="emoji-backdrop">
-          <div class="cloud-row emoji-float" style="top:-5%;left:-8%;opacity:0.4;--dur:34s;animation-delay:-8s;">&#x1F4AC;</div>
-          <div class="cloud-row cloud-row-reverse emoji-float" style="top:5%;left:55%;opacity:0.35;--dur:42s;animation-delay:-17s;">&#x1F4AC;</div>
-          <div class="cloud-row cloud-row-reverse emoji-float" style="top:40%;left:-5%;opacity:0.3;--dur:38s;animation-delay:-12s;">&#x1F4AC;</div>
-          <div class="cloud-row emoji-float" style="top:50%;left:60%;opacity:0.35;--dur:46s;animation-delay:-22s;">&#x1F4AC;</div>
+        <div>
+          <label class="label" for="wiz-task-input" style="margin-bottom:8px;display:block;">Or describe it yourself</label>
+          <textarea class="task-textarea" id="wiz-task-input" placeholder="Or tell me what's really on your mind&hellip;"></textarea>
         </div>
-        <div style="position:relative;z-index:1;">
-          <div class="card" style="padding:24px;max-width:600px;margin:0 auto;">
-            <h2 class="font-logo" style="font-size:22px;margin-bottom:8px;">Where the good chaos happens</h2>
-            <p style="font-size:14px;color:var(--text-secondary);line-height:1.6;margin-bottom:8px;">This is where agent configs get debated, bugs get caught before they ship, and somebody always finds the edge case first.</p>
-            <p style="font-size:14px;color:var(--text-secondary);line-height:1.6;">If you prefer &ldquo;come chat&rdquo; over &ldquo;please submit a ticket,&rdquo; this is your room.</p>
-            <div style="margin-top:24px;">
-              <a href="https://discord.gg/nex-community" target="_blank" rel="noopener noreferrer"
-                class="community-cta" style="background:var(--discord-bg);border:1px solid var(--discord-border);">
-                <span class="community-cta-left">
-                  <span class="community-cta-icon">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="var(--discord)"><path d="M20.32 4.37a16.4 16.4 0 0 0-4.1-1.28.06.06 0 0 0-.07.03c-.18.32-.38.73-.52 1.06a15.16 15.16 0 0 0-4.56 0c-.15-.34-.35-.74-.53-1.06a.06.06 0 0 0-.07-.03c-1.43.24-2.8.68-4.1 1.28a.05.05 0 0 0-.02.02C3.77 8.17 3.12 11.87 3.44 15.53a.06.06 0 0 0 .02.04 16.52 16.52 0 0 0 5.03 2.54.06.06 0 0 0 .07-.02c.39-.54.74-1.12 1.04-1.73a.06.06 0 0 0-.03-.08 10.73 10.73 0 0 1-1.6-.77.06.06 0 0 1-.01-.1l.32-.24a.06.06 0 0 1 .06-.01c3.35 1.53 6.98 1.53 10.29 0a.06.06 0 0 1 .06 0c.1.08.21.16.32.24a.06.06 0 0 1-.01.1c-.51.3-1.05.56-1.6.77a.06.06 0 0 0-.03.08c.3.61.65 1.19 1.04 1.73a.06.06 0 0 0 .07.02 16.42 16.42 0 0 0 5.03-2.54.06.06 0 0 0 .02-.04c.38-4.23-.64-7.9-2.89-11.14a.04.04 0 0 0-.02-.02ZM9.68 13.3c-.98 0-1.78-.9-1.78-2s.79-2 1.78-2c.99 0 1.79.9 1.78 2 0 1.1-.8 2-1.78 2Zm4.64 0c-.98 0-1.78-.9-1.78-2s.79-2 1.78-2c.99 0 1.79.9 1.78 2 0 1.1-.79 2-1.78 2Z"/></svg>
-                  </span>
-                  <span class="community-cta-text">
-                    <span class="community-cta-title">Join the Discord</span>
-                    <span class="community-cta-sub">Chat with the people building WUPHF</span>
-                  </span>
-                </span>
-                <span class="community-cta-badge" style="background:var(--discord-border);color:var(--discord);">Join</span>
-              </a>
-            </div>
-          </div>
-          <div class="step-nav" style="max-width:600px;margin:16px auto 0;">
-            <button class="btn btn-secondary" onclick="goToStep(6)">
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>
-              Back
-            </button>
-            <button class="btn btn-primary" onclick="launchOffice()">
-              Open the office
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
-            </button>
-          </div>
+
+        <div style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:12px;">
+          <button class="task-skip" onclick="completeOnboarding(true)">I'll figure it out &mdash; open the empty office</button>
+          <button class="btn btn-primary" onclick="completeOnboarding(false)">
+            Start working
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+          </button>
         </div>
       </div>
 
@@ -1844,6 +1637,16 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
           <span>Agents</span>
           <svg style="margin-left:auto;width:12px;height:12px;transform:rotate(90deg);" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
         </button>
+      </div>
+      <!-- Getting Started checklist (shown after onboarding, hidden until populated) -->
+      <div id="sidebar-checklist-section" style="display:none;">
+        <div class="sidebar-section" style="margin-top:4px;border-top:1px solid var(--border);padding-top:8px;">
+          <p class="sidebar-section-title" style="display:flex;align-items:center;justify-content:space-between;">
+            Getting started
+            <button class="checklist-dismiss" title="Dismiss" onclick="dismissChecklist()">&#xd7;</button>
+          </p>
+        </div>
+        <div class="sidebar-checklist" id="sidebar-checklist"></div>
       </div>
       <div class="sidebar-agents" id="sidebar-agents"></div>
       <div class="sidebar-section" style="margin-top:4px;border-top:1px solid var(--border);padding-top:8px;">
@@ -2387,6 +2190,19 @@ var WuphfAPI = (function() {
 var TOTAL_STEPS = 8;
 var currentStep = 0;
 var selectedSize = '';
+var ONBOARDING_COPY = {
+  step1_headline: 'Your AI team, visible and working.',
+  step1_subhead: 'WUPHF gives operators one room where AI specialists can claim real work, show progress in public, and pull in a human only when judgment is required. Unlike the original WUPHF.com, this one still works next quarter.',
+  step1_cta: 'Assemble the team',
+  step2_prereqs_title: 'First, make sure you have the tools',
+  step2_keys_title: 'Connect your AI providers',
+  step2_cta: 'Ready',
+  step3_title: "What's the first thing you want done?",
+  step3_placeholder: 'Or tell me what\'s really on your mind\u2026',
+  step3_skip: "I'll figure it out \u2014 open the empty office",
+  step3_cta: 'Start working',
+};
+
 var brokerConnected = false;
 var currentChannel = 'general';
 // channelMetadata maps channel slug → {type: "O"|"D"|"G", name, members, agentSlug}
@@ -2931,7 +2747,8 @@ function launchOffice() {
     WuphfAPI.post('/company', companyData).catch(function() {});
   }
 
-  document.getElementById('onboarding').style.display = 'none';
+  var _legacyOnboarding = document.getElementById('onboarding');
+  if (_legacyOnboarding) _legacyOnboarding.style.display = 'none';
   // Re-check health before showing office — broker may have started since page load
   WuphfAPI.getHealth()
     .then(function(data) {
@@ -6663,45 +6480,365 @@ closeCommandPalette = function() {
   _origCloseCP();
 };
 
-// ─── Init ───
-function initApp() {
-  console.log('[wuphf] initApp starting...');
+// ═══════════════════════════════════════════════════════════════
+//   ONBOARDING WIZARD
+// ═══════════════════════════════════════════════════════════════
+
+// Wizard state
+var wizPrereqState = {};
+var wizKeyState = {};
+var wizTemplates = [];
+
+// Small DOM helper used in wizard code to avoid innerHTML with untrusted data
+function _wE(tag, cls, text) {
+  var e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (text !== undefined) e.textContent = text;
+  return e;
+}
+
+function initWizard() {
+  console.log('[wizard] initWizard starting...');
   WuphfAPI.init()
     .then(function() {
-      console.log('[wuphf] init done, fetching health...');
       return WuphfAPI.getHealth();
     })
-    .then(function(data) {
-      console.log('[wuphf] health response:', JSON.stringify(data));
-      if (data.status === 'ok') {
+    .then(function(healthData) {
+      console.log('[wizard] health:', JSON.stringify(healthData));
+      return fetch('/onboarding/state').then(function(r) { return r.json(); });
+    })
+    .then(function(state) {
+      console.log('[wizard] onboarding state:', JSON.stringify(state));
+      if (state && state.onboarded) {
         brokerConnected = true;
-        document.getElementById('onboarding').style.display = 'none';
-        console.log('[wuphf] broker connected, showing splash + office');
+        document.getElementById('onboarding-wizard').style.display = 'none';
         WuphfAPI.getOfficeMembers().then(function(membersData) {
-          var realCount = (membersData.members || []).filter(function(m) { return m.slug !== 'human' && m.slug !== 'you' && m.slug !== 'system'; }).length;
+          var realCount = (membersData.members || []).filter(function(m) {
+            return m.slug !== 'human' && m.slug !== 'you' && m.slug !== 'system';
+          }).length;
           showSplashScreen(function() { showOffice(); }, realCount);
         }).catch(function() {
           showSplashScreen(function() { showOffice(); });
         });
+        if (state.checklist && state.checklist.some(function(i) { return !i.done; })) {
+          updateChecklistSidebar(state.checklist);
+        }
       } else {
-        console.log('[wuphf] health not ok, showing onboarding');
-        renderProgress();
-        renderSizeOptions();
-        renderPrereqs();
-        renderAPIKeys();
+        var startStep = (state && state.step) ? state.step : 'welcome';
+        document.getElementById('onboarding-wizard').style.display = '';
+        renderWizardProgress(startStep);
+        showWizardStep(startStep);
       }
     })
     .catch(function(err) {
       var errMsg = err && err.message ? err.message : String(err);
-      console.error('[wuphf] initApp FAILED: ' + errMsg);
-      // Show error on page for debugging
-      document.title = 'WUPHF ERROR: ' + errMsg;
-      // Broker not running — fall back to demo/onboarding
-      renderProgress();
-      renderSizeOptions();
-      renderPrereqs();
-      renderAPIKeys();
+      console.error('[wizard] initWizard error: ' + errMsg);
+      document.getElementById('onboarding-wizard').style.display = '';
+      renderWizardProgress('welcome');
+      showWizardStep('welcome');
     });
+}
+
+var _wizStepOrder = ['welcome', 'setup', 'task'];
+
+function renderWizardProgress(activeStep) {
+  var container = document.getElementById('wizard-progress');
+  if (!container) return;
+  container.textContent = '';
+  var activeIdx = _wizStepOrder.indexOf(activeStep);
+  _wizStepOrder.forEach(function(_, i) {
+    var dot = _wE('div', 'progress-dot ' + (i <= activeIdx ? 'active' : 'inactive'));
+    dot.style.height = '8px';
+    dot.style.borderRadius = '9999px';
+    dot.style.transition = 'all 0.3s ease';
+    container.appendChild(dot);
+  });
+}
+
+function showWizardStep(stepName) {
+  document.querySelectorAll('.wizard-step').forEach(function(s) { s.classList.remove('active'); });
+  var target = document.getElementById('wizard-step-' + stepName);
+  if (target) target.classList.add('active');
+  renderWizardProgress(stepName);
+  if (stepName === 'setup') initSetup();
+  if (stepName === 'task') loadTemplates();
+}
+
+function submitWelcome() {
+  var company = (document.getElementById('wiz-company').value || '').trim();
+  var description = (document.getElementById('wiz-description').value || '').trim();
+  var priority = (document.getElementById('wiz-priority').value || '').trim();
+  if (!company || !description || !priority) {
+    showNotice('Please fill in all three fields. Unlike Ryan Howard, we finish what we start.', 'error');
+    return;
+  }
+  var btn = document.getElementById('wiz-btn-welcome');
+  if (btn) { btn.disabled = true; btn.textContent = 'Saving\u2026'; }
+  fetch('/onboarding/progress', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ company: company, description: description, priority: priority, step: 'setup' })
+  })
+    .catch(function() {})
+    .then(function() {
+      showWizardStep('setup');
+      if (btn) {
+        btn.disabled = false;
+        btn.textContent = 'Assemble the team \u2192';
+      }
+    });
+}
+
+function initSetup() {
+  recheckWizPrereqs();
+  fetch('/onboarding/templates')
+    .then(function(r) { return r.json(); })
+    .then(function(data) { wizTemplates = data.templates || data || []; })
+    .catch(function() { wizTemplates = []; });
+}
+
+function recheckWizPrereqs() {
+  var listEl = document.getElementById('wiz-prereq-list');
+  if (!listEl) return;
+  listEl.textContent = '';
+  listEl.appendChild(_wE('div', null, 'Checking\u2026'));
+  listEl.firstChild.style.cssText = 'font-size:12px;color:var(--text-tertiary);padding:8px 0;';
+  fetch('/onboarding/prereqs')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      var prereqs = data.prereqs || data || [];
+      wizPrereqState = {};
+      prereqs.forEach(function(p) { wizPrereqState[p.name] = p; });
+      renderWizPrereqs(prereqs);
+      updateReadyButton();
+    })
+    .catch(function() {
+      listEl.textContent = '';
+      var msg = _wE('div', null, 'Could not reach prereq check. You can still continue.');
+      msg.style.cssText = 'font-size:12px;color:var(--text-tertiary);padding:8px 0;';
+      listEl.appendChild(msg);
+      wizPrereqState = { _fallback: true };
+      updateReadyButton();
+    });
+}
+
+var PREREQ_INSTALL_LINKS = {
+  node: 'https://nodejs.org',
+  git: 'https://git-scm.com',
+  claude: 'https://claude.ai/download',
+};
+
+function renderWizPrereqs(prereqs) {
+  var listEl = document.getElementById('wiz-prereq-list');
+  if (!listEl) return;
+  listEl.textContent = '';
+  prereqs.forEach(function(p) {
+    var row = _wE('div', 'prereq-row');
+    var dot = _wE('span', 'prereq-dot ' + (p.ok ? 'ok' : 'fail'));
+    var name = _wE('span', 'prereq-name', p.name);
+    var right = _wE('span');
+    right.style.marginLeft = 'auto';
+    if (p.ok && p.version) {
+      right.appendChild(_wE('span', 'prereq-version', p.version));
+    } else if (!p.ok) {
+      var href = PREREQ_INSTALL_LINKS[(p.name || '').toLowerCase()] || '#';
+      var link = _wE('a', 'prereq-install', 'Install');
+      link.href = href;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+      right.appendChild(link);
+    }
+    row.appendChild(dot);
+    row.appendChild(name);
+    row.appendChild(right);
+    listEl.appendChild(row);
+  });
+}
+
+function onKeyInput(provider, value) {
+  if (!value || !value.trim()) {
+    wizKeyState[provider] = 'empty';
+    var statusEl = document.getElementById('wiz-key-status-' + provider);
+    if (statusEl) { statusEl.textContent = ''; statusEl.className = 'key-status'; }
+    if (provider === 'anthropic') {
+      var notice = document.getElementById('wiz-unreachable-anthropic');
+      if (notice) notice.style.display = 'none';
+    }
+    updateReadyButton();
+  }
+}
+
+function validateKey(provider, value) {
+  if (!value || !value.trim()) {
+    wizKeyState[provider] = 'empty';
+    updateReadyButton();
+    return;
+  }
+  var statusEl = document.getElementById('wiz-key-status-' + provider);
+  if (statusEl) { statusEl.textContent = 'Checking\u2026'; statusEl.className = 'key-status checking'; }
+  wizKeyState[provider] = 'checking';
+  updateReadyButton();
+  fetch('/onboarding/validate-key', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ provider: provider, key: value.trim() })
+  })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      var status = data.status || 'invalid';
+      wizKeyState[provider] = status;
+      if (statusEl) {
+        if (status === 'valid') {
+          statusEl.textContent = '\u2713 Valid';
+          statusEl.className = 'key-status valid';
+        } else if (status === 'unreachable') {
+          statusEl.textContent = '';
+          statusEl.className = 'key-status';
+          wizKeyState[provider] = 'unreachable';
+          if (provider === 'anthropic') {
+            var notice = document.getElementById('wiz-unreachable-anthropic');
+            if (notice) notice.style.display = '';
+          }
+        } else if (status === 'invalid') {
+          statusEl.textContent = '\u2717 Invalid key';
+          statusEl.className = 'key-status invalid';
+        } else {
+          statusEl.textContent = '\u26A0 Unverified';
+          statusEl.className = 'key-status unverified';
+        }
+      }
+      updateReadyButton();
+    })
+    .catch(function() {
+      wizKeyState[provider] = 'unreachable';
+      if (statusEl) { statusEl.textContent = '\u26A0 Unverified'; statusEl.className = 'key-status unverified'; }
+      if (provider === 'anthropic') {
+        var notice = document.getElementById('wiz-unreachable-anthropic');
+        if (notice) notice.style.display = '';
+      }
+      updateReadyButton();
+    });
+}
+
+function updateReadyButton() {
+  var btn = document.getElementById('wiz-btn-ready');
+  if (!btn) return;
+  var prereqsOk = !!wizPrereqState._fallback || Object.keys(wizPrereqState).every(function(k) {
+    return wizPrereqState[k] && wizPrereqState[k].ok;
+  });
+  var anthropicStatus = wizKeyState['anthropic'] || 'empty';
+  var acceptCheckbox = document.getElementById('wiz-unreachable-accept');
+  var anthropicOk = (anthropicStatus === 'valid') ||
+    (anthropicStatus === 'unreachable' && acceptCheckbox && acceptCheckbox.checked);
+  btn.disabled = !(prereqsOk && anthropicOk);
+}
+
+function loadTemplates() {
+  var grid = document.getElementById('wiz-template-grid');
+  if (!grid) return;
+  if (wizTemplates.length > 0) { renderTemplateGrid(wizTemplates); return; }
+  fetch('/onboarding/templates')
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      wizTemplates = data.templates || data || [];
+      renderTemplateGrid(wizTemplates);
+    })
+    .catch(function() {
+      grid.textContent = '';
+      var msg = _wE('div', null, 'No templates available \u2014 just describe what you need below.');
+      msg.style.cssText = 'color:var(--text-tertiary);font-size:13px;grid-column:1/-1;';
+      grid.appendChild(msg);
+    });
+}
+
+function renderTemplateGrid(templates) {
+  var grid = document.getElementById('wiz-template-grid');
+  if (!grid) return;
+  grid.textContent = '';
+  if (!templates || !templates.length) {
+    var msg = _wE('div', null, 'No templates available \u2014 just describe what you need below.');
+    msg.style.cssText = 'color:var(--text-tertiary);font-size:13px;grid-column:1/-1;';
+    grid.appendChild(msg);
+    return;
+  }
+  templates.slice(0, 5).forEach(function(t) {
+    var tile = _wE('div', 'template-tile');
+    var titleEl = _wE('div', 'template-title', t.title || '');
+    var descEl = _wE('div', 'template-desc', t.description || '');
+    var ownerEl = _wE('div', 'template-owner', t.owner ? '\u2192 ' + t.owner : '');
+    tile.appendChild(titleEl);
+    tile.appendChild(descEl);
+    tile.appendChild(ownerEl);
+    tile.addEventListener('click', function() { selectTemplate(t, tile); });
+    grid.appendChild(tile);
+  });
+}
+
+function selectTemplate(template, tileEl) {
+  document.querySelectorAll('.template-tile').forEach(function(t) { t.classList.remove('selected'); });
+  if (tileEl) tileEl.classList.add('selected');
+  var textarea = document.getElementById('wiz-task-input');
+  if (textarea) textarea.value = template.prompt || template.title || '';
+}
+
+function completeOnboarding(skipTask) {
+  var task = '';
+  if (!skipTask) {
+    var ta = document.getElementById('wiz-task-input');
+    task = ta ? (ta.value || '') : '';
+  }
+  fetch('/onboarding/complete', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ task: task, skip_task: !!skipTask })
+  })
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      _finishOnboarding(data);
+    })
+    .catch(function() {
+      _finishOnboarding({});
+    });
+}
+
+function _finishOnboarding(data) {
+  brokerConnected = true;
+  document.getElementById('onboarding-wizard').style.display = 'none';
+  var generalEl = document.getElementById('general');
+  if (generalEl) generalEl.setAttribute('data-first-task', 'seeded');
+  if (data && data.checklist && data.checklist.length) updateChecklistSidebar(data.checklist);
+  showSplashScreen(function() { showOffice(); });
+}
+
+function updateChecklistSidebar(checklist) {
+  var section = document.getElementById('sidebar-checklist-section');
+  var container = document.getElementById('sidebar-checklist');
+  if (!section || !container) return;
+  container.textContent = '';
+  var hasIncomplete = checklist.some(function(item) { return !item.done; });
+  if (!hasIncomplete) { section.style.display = 'none'; return; }
+  section.style.display = '';
+  checklist.slice(0, 5).forEach(function(item) {
+    var row = _wE('div', 'checklist-item' + (item.done ? ' done' : ''));
+    var box = _wE('span', 'checklist-checkbox' + (item.done ? ' checked' : ''));
+    var label = _wE('a', 'checklist-link', item.label || item.title || '');
+    if (item.action) label.href = item.action;
+    row.appendChild(box);
+    row.appendChild(label);
+    container.appendChild(row);
+  });
+}
+
+function dismissChecklist() {
+  var section = document.getElementById('sidebar-checklist-section');
+  if (section) section.style.display = 'none';
+  fetch('/onboarding/checklist/dismiss', { method: 'POST' }).catch(function() {});
+}
+
+// ─── Init ───
+function initApp() {
+  console.log('[wuphf] initApp starting...');
+  initWizard();
 }
 
 // ─── Theme Switcher ───


### PR DESCRIPTION
## Summary

Replaces WUPHF's 8-step web-only onboarding with a focused 3-step flow (welcome → prereqs+keys → first task) that gets users into a running office with agents actively working on a real task within ~90 seconds. Adds TUI parity, persistent gating via \`~/.wuphf/onboarded.json\`, and a sidebar Getting Started checklist for optional setup.

## What changed

- **\`internal/onboarding/\`** — new Go package: state (atomic \`onboarded.json\` read/write, partial progress, checklist), prereqs probe (node/git/claude), task templates (5 Office-humor starters), HTTP handlers for all \`/onboarding/*\` routes. 31 tests, stdlib only.
- **Broker wiring** — \`internal/team/broker.go\` registers onboarding routes; new \`broker_onboarding.go\` implements \`onboardingCompleteFn\` which seeds the default team (idempotent) and posts the first task as a human message tagged to the office lead, triggering the existing delegate turn.
- **Web wizard** — \`web/index.html\` 8-step flow replaced with 3-step wizard driven by \`GET /onboarding/state\`. Office-humor copy extracted to \`ONBOARDING_COPY\` constant. Sidebar Getting Started checklist lands post-onboarding.
- **TUI onboarding** — new \`cmd/wuphf/onboarding.go\` bubbletea model mirrors the 3 web steps. Gated by \`/onboarding/state\`; \`WUPHF_SKIP_ONBOARDING\` escape hatch for dev.

## Design decisions

- **Flag-last write order** — \`/onboarding/complete\` seeds team → posts message → persists flag. Crash mid-flow re-enters the wizard; dedupe via \`onboarding_origin\` Kind marker prevents double-post.
- **Truly idempotent** — retried \`/onboarding/complete\` returns \`200 {already_completed: true}\`, never 409.
- **Provider outage tolerance** — \`/onboarding/validate-key\` surfaces \`unreachable\` instead of blocking; UI lets the user continue unverified with a yellow warning.

Full design spec (local-only, docs/ is gitignored): \`docs/superpowers/specs/2026-04-14-onboarding-design.md\`.

## Test plan

- [ ] \`go test ./...\` passes (verified locally: all packages green, 172 tests total)
- [ ] First launch on a clean \`~/.wuphf/\` shows the wizard at step 1
- [ ] Reload mid-wizard at step 2 resumes with prefilled answers
- [ ] Submitting step 3 with a task → office renders with CEO actively delegating it
- [ ] Skip-task path → office renders empty, no first-task message
- [ ] Retry \`POST /onboarding/complete\` → returns \`already_completed: true\`, no duplicate message
- [ ] Checklist dismiss persists across broker restart
- [ ] TUI: \`wuphf\` on fresh install enters the bubbletea wizard before the channel model
- [ ] TUI: \`WUPHF_SKIP_ONBOARDING=1 wuphf\` bypasses onboarding even on fresh install

🤖 Generated with [Claude Code](https://claude.com/claude-code)