### PR TITLE
feat(revops): RevOps pack + Nex entity brief injection + goreleaser CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go test ./...
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -34,7 +34,7 @@ How WUPHF works under the hood, anchored to files you can open. One page. Read i
 | `internal/team/worktree.go` | Per-agent isolated git worktree so agents can't corrupt each other |
 | `internal/team/resume.go` | On restart, replays unfinished tasks + unanswered messages to the right agents |
 | `internal/teammcp/` | The per-agent MCP tool surface. DM mode loads ~4 tools; office mode loads more |
-| `internal/agent/packs.go` | The team compositions (`starter`, `founding-team`, `coding-team`, `lead-gen-agency`) |
+| `internal/agent/packs.go` | The team compositions (`starter`, `founding-team`, `coding-team`, `lead-gen-agency`, `revops`) — packs can also pre-seed default skills |
 | `web/index.html` | The office UI — channels, composer, live streams |
 | `mcp/` | MCP servers WUPHF ships for Nex context, human-in-the-loop approvals, etc. |
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ That's it. The browser opens automatically and you're in the office. Unlike Ryan
 | `--no-nex` | Run without Nex (no context graph, notifications, or integrations) |
 | `--tui` | Use the tmux TUI instead of the web UI |
 | `--no-open` | Don't auto-open the browser |
-| `--pack <name>` | Pick an agent pack (`starter`, `founding-team`, `coding-team`, `lead-gen-agency`) |
+| `--pack <name>` | Pick an agent pack (`starter`, `founding-team`, `coding-team`, `lead-gen-agency`, `revops`) |
 | `--opus-ceo` | Upgrade CEO from Sonnet to Opus |
 | `--collab` | All agents see all messages (default is CEO-routed delegation) |
 | `--unsafe` | Bypass agent permission checks (local dev only) |

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -22,7 +22,7 @@ func main() {
 	format := flag.String("format", "text", "Output format (text, json)")
 	apiKeyFlag := flag.String("api-key", "", "API key for authentication")
 	showVersion := flag.Bool("version", false, "Print version and exit")
-	packFlag := flag.String("pack", "", "Agent pack (starter, founding-team, coding-team, lead-gen-agency)")
+	packFlag := flag.String("pack", "", "Agent pack (starter, founding-team, coding-team, lead-gen-agency, revops)")
 	providerFlag := flag.String("provider", "", "LLM provider override for this run (claude-code, codex)")
 	oneOnOne := flag.Bool("1o1", false, "Launch a direct 1:1 session with a single agent (default ceo)")
 	channelView := flag.Bool("channel-view", false, "Run as channel view (internal)")

--- a/internal/action/nex_client.go
+++ b/internal/action/nex_client.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -44,6 +45,47 @@ func nexAsk(query string) (nexAskResponse, error) {
 		return nexAskResponse{}, err
 	}
 	return api.Post[nexAskResponse](client, "/v1/context/ask", map[string]any{"query": strings.TrimSpace(query)}, 0)
+}
+
+// FetchEntityBrief asks Nex for context relevant to the given work notification
+// and returns a formatted brief string to prepend to the agent's stdin input.
+// Returns an empty string when Nex is disabled, not configured, or the call
+// fails — callers should always append the original notification regardless.
+// The provided context is used for the request timeout.
+func FetchEntityBrief(ctx context.Context, notification string) string {
+	if config.ResolveNoNex() {
+		return ""
+	}
+	query := strings.TrimSpace(notification)
+	if query == "" {
+		return ""
+	}
+	// Summarise the notification into a concise Nex query.
+	// We limit the query length to avoid runaway token usage.
+	if len(query) > 400 {
+		query = query[:400]
+	}
+	query = "Given this work item, what company context, contacts, or recent activity is most relevant? Work item: " + query
+
+	type result struct {
+		answer string
+		err    error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		resp, err := nexAsk(query)
+		ch <- result{resp.Answer, err}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ""
+	case r := <-ch:
+		if r.err != nil || strings.TrimSpace(r.answer) == "" {
+			return ""
+		}
+		return "== NEX CONTEXT ==\n" + strings.TrimSpace(r.answer) + "\n== END NEX CONTEXT =="
+	}
 }
 
 func nexInsightsSince(since time.Time, limit int) (nexInsightsResponse, error) {

--- a/internal/agent/packs.go
+++ b/internal/agent/packs.go
@@ -1,12 +1,23 @@
 package agent
 
+// PackSkillSpec defines a skill to pre-seed when a pack is first launched.
+type PackSkillSpec struct {
+	Name        string
+	Title       string
+	Description string
+	Tags        []string
+	Trigger     string
+	Content     string
+}
+
 // PackDefinition defines a team of agents that work together.
 type PackDefinition struct {
-	Slug        string
-	Name        string
-	Description string
-	LeadSlug    string
-	Agents      []AgentConfig
+	Slug          string
+	Name          string
+	Description   string
+	LeadSlug      string
+	Agents        []AgentConfig
+	DefaultSkills []PackSkillSpec
 }
 
 // Packs is the registry of all available agent packs.
@@ -60,6 +71,241 @@ var Packs = []PackDefinition{
 			{Slug: "sdr", Name: "SDR", Expertise: []string{"cold-outreach", "qualification", "booking-meetings", "sequences"}, Personality: "Persistent SDR who opens doors and qualifies opportunities"},
 			{Slug: "research", Name: "Research Analyst", Expertise: []string{"market-research", "competitive-analysis", "ICP-profiling", "trends"}, Personality: "Analytical researcher who surfaces actionable intelligence"},
 			{Slug: "content", Name: "Content Strategist", Expertise: []string{"SEO", "copywriting", "nurture-sequences", "thought-leadership"}, Personality: "Strategic writer who creates content that drives engagement"},
+		},
+	},
+	{
+		Slug:        "revops",
+		Name:        "RevOps Team",
+		Description: "Revenue operations team — CRM hygiene, pipeline health, and GTM execution",
+		LeadSlug:    "ops-lead",
+		Agents: []AgentConfig{
+			{
+				Slug:           "ops-lead",
+				Name:           "Revenue Operations Lead",
+				Expertise:      []string{"revenue-operations", "GTM-strategy", "pipeline-management", "forecasting", "CRM", "data-quality", "process-design"},
+				Personality:    "Data-driven RevOps lead who spots pipeline leaks, enforces CRM discipline, and keeps the GTM machine humming. Routes work to the right specialist without ceremony.",
+				PermissionMode: "plan",
+			},
+			{
+				Slug:           "ae",
+				Name:           "Account Executive",
+				Expertise:      []string{"pipeline", "deal-management", "closing", "negotiation", "stakeholder-mapping", "discovery", "objection-handling"},
+				Personality:    "Seasoned AE focused on moving deals forward. Keeps detailed notes, flags stalled opportunities early, and knows when to escalate vs. push through.",
+				PermissionMode: "plan",
+			},
+			{
+				Slug:           "sdr",
+				Name:           "SDR",
+				Expertise:      []string{"outbound", "cold-outreach", "prospecting", "sequences", "qualification", "re-engagement", "ICP-targeting"},
+				Personality:    "High-output SDR who writes sharp, relevant outreach. Understands that personalization beats volume and always ties messaging to business context.",
+				PermissionMode: "plan",
+			},
+			{
+				Slug:           "analyst",
+				Name:           "Revenue Analyst",
+				Expertise:      []string{"CRM-hygiene", "data-quality", "lead-scoring", "reporting", "funnel-analysis", "attribution", "forecasting"},
+				Personality:    "Methodical analyst who treats the CRM as a source of truth, not a filing cabinet. Flags data gaps, builds scoring models, and turns pipeline data into decisions.",
+				PermissionMode: "plan",
+			},
+		},
+		DefaultSkills: []PackSkillSpec{
+			{
+				Name:        "CRM Hygiene Audit",
+				Title:       "CRM Hygiene Audit",
+				Description: "Audit CRM for stale contacts, missing fields, and data quality issues",
+				Tags:        []string{"crm", "data-quality", "ops"},
+				Trigger:     "When asked to audit the CRM, check data quality, or find stale records",
+				Content: `You are performing a CRM hygiene audit. Your goal is to surface data quality issues so the team can keep the CRM accurate and actionable.
+
+## What to do
+
+1. **Query Nex for CRM context**: Ask Nex "What contacts or companies in our CRM have incomplete or stale data?" and "What are the most common data quality issues in our pipeline?"
+
+2. **Identify the worst offenders** across these dimensions:
+   - Contacts missing email, phone, or job title
+   - Companies missing industry, size, or website
+   - Open deals with no activity in 14+ days
+   - Deals missing close date or next step
+   - Leads with no owner assigned
+
+3. **Prioritize by revenue impact**: Focus first on open deals and high-value accounts. A stale $200k opportunity matters more than a missing phone number on a cold contact.
+
+4. **Structure your output** as a prioritized list:
+   - Critical (blocks forecasting): deals missing close date, stage, or ARR
+   - High (degrades pipeline quality): open opps with no recent activity
+   - Medium (reduces signal): contacts missing key fields
+   - Low (nice-to-have): cosmetic or optional fields
+
+5. **For each issue**, include: what's missing, how many records affected, and a recommended fix action.
+
+6. **Propose fixes** where you can automate them (e.g., enrichment via known data sources, bulk updates to assignee). Gate destructive changes (bulk delete, stage resets) on human approval via a human_interview.
+
+## Output format
+
+Post findings to #general as a summary table with issue, count, impact, and recommended action. If using Composio to make CRM updates, confirm the change count before executing.`,
+			},
+			{
+				Name:        "Meeting Prep Brief",
+				Title:       "Meeting Prep Brief",
+				Description: "Prepare reps with a concise brief before customer or prospect meetings",
+				Tags:        []string{"sales", "meetings", "prep", "crm"},
+				Trigger:     "When asked to prep for a meeting, generate a brief, or summarize a prospect before a call",
+				Content: `You are preparing a meeting brief for an upcoming sales or customer call. Your goal is to give the rep everything they need to walk in sharp.
+
+## What to do
+
+1. **Identify the meeting**: Who is it with? What company? What stage is the deal or relationship?
+
+2. **Query Nex for context**:
+   - Ask "What do we know about [company name] — their business, buying signals, and recent activity?"
+   - Ask "What is the current status of our relationship or deal with [company name]?"
+   - Ask "Are there any open action items, blockers, or commitments from previous interactions?"
+
+3. **Pull CRM data** (via Composio if configured):
+   - Last interaction date and type (email, call, demo)
+   - Deal stage, ARR, close date
+   - Key stakeholders and their roles
+   - Any recorded objections or concerns
+
+4. **Research the prospect** (if first meeting):
+   - Company size, industry, recent news
+   - Known tech stack or competitive tools in use
+   - ICP fit score if lead scoring is active
+
+5. **Build the brief** with these sections:
+   - **Who you're meeting**: Name, title, company, decision-maker status
+   - **Where we are**: Deal stage, last touch, next step on file
+   - **Context from Nex**: Buying signals, known pain points, company priorities
+   - **Your agenda**: 2-3 suggested talking points based on where the deal is
+   - **Watch-outs**: Open objections, competitor mentions, any red flags
+   - **Ask**: The one clear ask for this call (demo booked, POC scoped, legal introduced, etc.)
+
+6. **Keep it under one page**. If the rep has to scroll past the fold, it's too long.
+
+Post the brief to #general tagged with the rep's name and meeting time.`,
+			},
+			{
+				Name:        "Closed-Lost Re-engagement",
+				Title:       "Closed-Lost Re-engagement",
+				Description: "Re-engage closed-lost deals that may be ready to revisit",
+				Tags:        []string{"sales", "re-engagement", "closed-lost", "outbound"},
+				Trigger:     "When asked to find re-engagement opportunities, surface closed-lost deals, or run a win-back campaign",
+				Content: `You are running a closed-lost re-engagement motion. Your goal is to find deals that went cold but may now be worth revisiting, and draft outreach that's worth opening.
+
+## What to do
+
+1. **Query Nex for signal**:
+   - Ask "Are there any closed-lost deals where the company has since had a leadership change, funding event, or relevant trigger?"
+   - Ask "Which lost deals had the most positive engagement before they closed-lost?"
+   - Ask "What were the most common reasons we lost deals in the last 6 months?"
+
+2. **Filter closed-lost deals** by re-engagement potential:
+   - Lost 3-18 months ago (not too fresh, not too stale)
+   - Lost reason was timing, budget, or internal priority — not product fit
+   - Company has had a trigger event: new funding, new exec, product launch, or hiring surge
+   - Deal size was meaningful (above your ACV floor)
+
+3. **Score each opportunity** (1-5):
+   - 5: Strong fit, timing trigger, positive prior relationship
+   - 3: Good fit, no clear trigger, but worth a touch
+   - 1: Bad fit or hard no — skip entirely
+
+4. **Draft re-engagement messages** for each scored 4+:
+   - Reference the specific trigger event ("I saw you just raised a Series B...")
+   - Acknowledge the prior conversation briefly without being weird about it
+   - Lead with what's changed on your side (new capability, customer win in their space, etc.)
+   - One clear ask: 20-minute catch-up, not a full demo
+
+5. **Gate sending** on human approval: present the draft list with scores and messages via human_interview before any outreach is sent.
+
+Output a re-engagement queue with: company, deal size, lost reason, trigger event, score, and draft message. Post to #general.`,
+			},
+			{
+				Name:        "Deals Going Dark",
+				Title:       "Deals Going Dark",
+				Description: "Surface active pipeline deals with no recent activity before they go cold",
+				Tags:        []string{"pipeline", "sales", "alerts", "crm"},
+				Trigger:     "When asked to check pipeline health, find stalled deals, or surface deals with no recent activity",
+				Content: `You are running a pipeline health check to surface deals at risk of going dark before they're formally lost.
+
+## What to do
+
+1. **Query Nex for deal context**:
+   - Ask "Which of our open deals have had no recent activity or contact?"
+   - Ask "Are there any deals where the champion has gone quiet or changed roles?"
+   - Ask "What deals are approaching their close date without a clear next step?"
+
+2. **Pull open pipeline** (via Composio if configured):
+   - Filter deals with no logged activity (call, email, meeting) in 10+ days
+   - Flag deals where close date is within 30 days but no next step is set
+   - Flag deals where the primary contact hasn't responded to the last 2 touches
+
+3. **Assess risk by stage**:
+   - Late stage (proposal/negotiation) going dark: critical — flag immediately
+   - Mid stage (demo/evaluation) going dark: high — needs a nudge within 48 hours
+   - Early stage (discovery) going dark: medium — assess fit before re-investing
+
+4. **For each at-risk deal**, diagnose the likely cause:
+   - Champion went quiet: internal blocker, competing priority, or lost sponsor
+   - No next step: last meeting ended without a commitment
+   - Approaching close date: artificial deadline that wasn't real, or deal is slipping
+
+5. **Recommend a specific action** for each deal:
+   - "Send a 'just checking in' with a clear ask"
+   - "Reach out to a second stakeholder to triangulate"
+   - "Propose a 2-week extension and reset the close date"
+   - "Mark at-risk in CRM and flag for forecast call"
+
+6. **Post a pipeline health report** to #general:
+   - Red (critical, needs action today): deal name, stage, days dark, recommended action
+   - Amber (needs attention this week): same format
+   - Green (healthy): summary count only
+
+Gate any CRM stage updates on human review via human_interview.`,
+			},
+			{
+				Name:        "Lead Scoring",
+				Title:       "Lead Scoring",
+				Description: "Score and prioritize inbound leads by fit and buying intent",
+				Tags:        []string{"leads", "scoring", "qualification", "crm"},
+				Trigger:     "When asked to score leads, prioritize inbound, or identify best-fit prospects",
+				Content: `You are scoring inbound leads to help the team focus time on the prospects most likely to convert.
+
+## What to do
+
+1. **Query Nex for ICP and playbook context**:
+   - Ask "What does our ideal customer profile look like — industry, size, buying signals?"
+   - Ask "What are the strongest indicators that a lead is ready to buy?"
+   - Ask "Which lead sources have historically converted best?"
+
+2. **Pull the lead list** (via Composio if configured):
+   - Unworked leads added in the last 14 days
+   - Leads that re-engaged (opened email, visited pricing page, booked a demo)
+   - MQLs that haven't been contacted within 48 hours
+
+3. **Score each lead** across two dimensions:
+
+   **Fit score (1-5)** — how well do they match the ICP?
+   - 5: Perfect match on industry, size, and use case
+   - 3: Partial match — one dimension off
+   - 1: Clear mismatch — wrong segment
+
+   **Intent score (1-5)** — how ready are they to buy?
+   - 5: Demo request, pricing page visit, or inbound inquiry
+   - 3: Content download, webinar attendance, or re-engagement
+   - 1: Cold list import or conference badge scan
+
+4. **Tier the leads**:
+   - Tier 1 (fit 4-5 + intent 3-5): route to AE immediately
+   - Tier 2 (fit 3+ + intent 2+): SDR sequence within 24 hours
+   - Tier 3 (fit ≤2 or intent 1): nurture or disqualify
+
+5. **For each Tier 1 lead**, include a suggested opening line for the AE based on the lead's company, role, and most recent action.
+
+6. **Post the scored lead list** to #general with: lead name, company, fit score, intent score, tier, and suggested action. Flag any Tier 1 leads that have been sitting more than 24 hours without contact.
+
+Gate any CRM field updates (score, tier, owner assignment) on human approval via human_interview.`,
+			},
 		},
 	},
 }

--- a/internal/agent/packs_test.go
+++ b/internal/agent/packs_test.go
@@ -3,8 +3,8 @@ package agent
 import "testing"
 
 func TestPacksRegistered(t *testing.T) {
-	if len(Packs) != 4 {
-		t.Fatalf("expected 4 packs, got %d", len(Packs))
+	if len(Packs) != 5 {
+		t.Fatalf("expected 5 packs, got %d", len(Packs))
 	}
 	founding := GetPack("founding-team")
 	if founding == nil {
@@ -72,5 +72,33 @@ func TestLeadGenAgencyPack(t *testing.T) {
 	}
 	if len(p.Agents) != 4 {
 		t.Errorf("expected 4 agents, got %d", len(p.Agents))
+	}
+}
+
+func TestRevOpsPack(t *testing.T) {
+	p := GetPack("revops")
+	if p == nil {
+		t.Fatal("revops pack not found")
+	}
+	if p.LeadSlug != "ops-lead" {
+		t.Errorf("expected lead 'ops-lead', got '%s'", p.LeadSlug)
+	}
+	if len(p.Agents) != 4 {
+		t.Errorf("expected 4 agents, got %d", len(p.Agents))
+	}
+	if len(p.DefaultSkills) != 5 {
+		t.Errorf("expected 5 default skills, got %d", len(p.DefaultSkills))
+	}
+	// Every default skill must have non-empty Name, Title, and Content.
+	for i, s := range p.DefaultSkills {
+		if s.Name == "" {
+			t.Errorf("skill[%d]: empty Name", i)
+		}
+		if s.Title == "" {
+			t.Errorf("skill[%d]: empty Title", i)
+		}
+		if s.Content == "" {
+			t.Errorf("skill[%d]: empty Content", i)
+		}
 	}
 }

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/buildinfo"
 	"github.com/nex-crm/wuphf/internal/channel"
 	"github.com/nex-crm/wuphf/internal/company"
@@ -6838,4 +6839,46 @@ func (b *Broker) parseSkillProposalLocked(msg channelMessage) {
 		{ID: "reject", Label: "Reject"},
 	})
 	b.requests = append(b.requests, interview)
+}
+
+// SeedDefaultSkills pre-populates the broker with the pack's default skills.
+// It is idempotent: skills whose name already exists (by slug) are skipped.
+// Call this after broker.Start() from the Launcher so that the first time a
+// pack is launched the team has its playbooks ready to reference.
+func (b *Broker) SeedDefaultSkills(specs []agent.PackSkillSpec) {
+	if len(specs) == 0 {
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, spec := range specs {
+		name := strings.TrimSpace(spec.Name)
+		if name == "" {
+			continue
+		}
+		if b.findSkillByNameLocked(name) != nil {
+			continue // already exists, skip
+		}
+		title := strings.TrimSpace(spec.Title)
+		if title == "" {
+			title = name
+		}
+		b.counter++
+		sk := teamSkill{
+			ID:          fmt.Sprintf("skill-%s", skillSlug(name)),
+			Name:        name,
+			Title:       title,
+			Description: strings.TrimSpace(spec.Description),
+			Content:     strings.TrimSpace(spec.Content),
+			CreatedBy:   "system",
+			Tags:        append([]string(nil), spec.Tags...),
+			Trigger:     strings.TrimSpace(spec.Trigger),
+			Status:      "active",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}
+		b.skills = append(b.skills, sk)
+	}
+	b.saveLocked()
 }

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/provider"
 )
@@ -70,7 +71,17 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		env = append(env, "WUPHF_WORKTREE_PATH="+worktreeDir)
 	}
 	cmd.Env = env
-	cmd.Stdin = strings.NewReader(notification)
+
+	// Enrich the notification with Nex entity context. Use a 2s deadline so a
+	// slow or unreachable Nex API never holds up the agent turn. The brief is
+	// prepended to the notification so the original work packet stays intact.
+	stdinPayload := notification
+	nexCtx, nexCancel := context.WithTimeout(ctx, 2*time.Second)
+	if brief := action.FetchEntityBrief(nexCtx, notification); brief != "" {
+		stdinPayload = brief + "\n\n" + notification
+	}
+	nexCancel()
+	cmd.Stdin = strings.NewReader(stdinPayload)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -229,6 +229,11 @@ func (l *Launcher) Launch() error {
 		return fmt.Errorf("start broker: %w", err)
 	}
 
+	// Pre-seed any default skills declared by the pack (idempotent).
+	if l.pack != nil && len(l.pack.DefaultSkills) > 0 {
+		l.broker.SeedDefaultSkills(l.pack.DefaultSkills)
+	}
+
 	// Kill any existing session
 	exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 
@@ -3466,6 +3471,11 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	}
 	if err := l.broker.Start(); err != nil {
 		return fmt.Errorf("start broker: %w", err)
+	}
+
+	// Pre-seed any default skills declared by the pack (idempotent).
+	if l.pack != nil && len(l.pack.DefaultSkills) > 0 {
+		l.broker.SeedDefaultSkills(l.pack.DefaultSkills)
 	}
 
 	l.broker.SetGenerateMemberFn(l.GenerateMemberTemplateFromPrompt)


### PR DESCRIPTION
## Summary

Three items that turn WUPHF into a shippable MVP for the Nex homepage promises:

- **RevOps pack** (`revops`): new team of ops-lead, ae, sdr, analyst with **5 default skills pre-seeded on first launch** — CRM Hygiene Audit, Meeting Prep Brief, Closed-Lost Re-engagement, Deals Going Dark, Lead Scoring. Each skill has full instruction content that references Nex context queries, Composio CRM actions, and human_interview gating for destructive operations.
- **Nex entity brief injection**: each agent turn now fetches relevant company context from Nex (`/v1/context/ask`) with a 2s timeout and prepends it to the work packet on stdin. System prompt stays untouched so prompt cache hits are preserved. No-op when `--no-nex` is set or Nex is unreachable.
- **Goreleaser release CI** (`.github/workflows/release.yml`): triggers on `v*` tag push, runs tests, then `goreleaser release --clean`. No secrets required beyond the automatic `GITHUB_TOKEN`.

## What this unlocks

WUPHF already has the runtime architecture (push-driven wakes, fresh sessions, per-agent MCP scoping, workspace isolation) that Nex's issue #910 refactor is pushing toward. These three changes close the content and distribution gap:

1. The homepage GTM promises are now **concrete skill files** a RevOps team can run against, not just agent prompts hoping to guess the right motion.
2. Nex context graph data **actually flows into agent turns** instead of living in a parallel MCP channel agents may or may not call.
3. `git tag v0.1.0 && git push --tags` produces signed binaries for darwin/linux arm64/amd64 — unblocks `nex-cli template run wuphf` as a real install path.

## Files

- `internal/agent/packs.go` — new `PackSkillSpec` type, `DefaultSkills` field on `PackDefinition`, revops pack definition
- `internal/agent/packs_test.go` — updated count assertion + new `TestRevOpsPack`
- `internal/team/broker.go` — idempotent `SeedDefaultSkills` method
- `internal/team/launcher.go` — calls `SeedDefaultSkills` after `broker.Start()` in both `Launch()` and `LaunchWeb()`
- `internal/team/headless_claude.go` — `action.FetchEntityBrief` call with 2s deadline prepended to stdin payload
- `internal/action/nex_client.go` — exported `FetchEntityBrief(ctx, notification)` with timeout + no-op fallbacks
- `.github/workflows/release.yml` — goreleaser on `v*` tags
- `cmd/wuphf/main.go`, `README.md`, `ARCHITECTURE.md` — list revops in the pack options

## Test plan

- [x] `go test -count=1 ./...` — 18/18 packages pass uncached
- [x] `go vet ./...` — clean
- [x] `go build ./cmd/wuphf` — produces working binary
- [x] `./wuphf --help` shows `revops` in `--pack` options
- [x] New `TestRevOpsPack` asserts pack structure + all 5 skills have non-empty Name/Title/Content
- [ ] CI green on the `go` job
- [ ] Manual: `./wuphf --pack revops --no-nex` launches the office, skills appear active in the web UI (no Nex call path exercised yet — smoke test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)