### PR TITLE
fix(revops): add CEO (Chief Revenue Officer) as pack lead

### DIFF
--- a/internal/agent/packs.go
+++ b/internal/agent/packs.go
@@ -77,13 +77,20 @@ var Packs = []PackDefinition{
 		Slug:        "revops",
 		Name:        "RevOps Team",
 		Description: "Revenue operations team — CRM hygiene, pipeline health, and GTM execution",
-		LeadSlug:    "ops-lead",
+		LeadSlug:    "ceo",
 		Agents: []AgentConfig{
+			{
+				Slug:           "ceo",
+				Name:           "Chief Revenue Officer",
+				Expertise:      []string{"revenue-leadership", "GTM-strategy", "prioritization", "delegation", "orchestration", "forecasting"},
+				Personality:    "Revenue-obsessed leader who breaks down GTM directives into clear specialist assignments. Routes CRM hygiene to the analyst, deal work to the AE, outbound to the SDR, and keeps ops-lead focused on pipeline mechanics.",
+				PermissionMode: "plan",
+			},
 			{
 				Slug:           "ops-lead",
 				Name:           "Revenue Operations Lead",
 				Expertise:      []string{"revenue-operations", "GTM-strategy", "pipeline-management", "forecasting", "CRM", "data-quality", "process-design"},
-				Personality:    "Data-driven RevOps lead who spots pipeline leaks, enforces CRM discipline, and keeps the GTM machine humming. Routes work to the right specialist without ceremony.",
+				Personality:    "Data-driven RevOps lead who spots pipeline leaks, enforces CRM discipline, and keeps the GTM machine humming. Reports to the CRO on pipeline health and process improvements.",
 				PermissionMode: "plan",
 			},
 			{

--- a/internal/agent/packs_test.go
+++ b/internal/agent/packs_test.go
@@ -80,11 +80,23 @@ func TestRevOpsPack(t *testing.T) {
 	if p == nil {
 		t.Fatal("revops pack not found")
 	}
-	if p.LeadSlug != "ops-lead" {
-		t.Errorf("expected lead 'ops-lead', got '%s'", p.LeadSlug)
+	if p.LeadSlug != "ceo" {
+		t.Errorf("expected lead 'ceo', got '%s'", p.LeadSlug)
 	}
-	if len(p.Agents) != 4 {
-		t.Errorf("expected 4 agents, got %d", len(p.Agents))
+	if len(p.Agents) != 5 {
+		t.Errorf("expected 5 agents, got %d", len(p.Agents))
+	}
+	// CEO (Chief Revenue Officer) must be present so the broker's CEO-routed
+	// delegation and hardcoded "ceo" checks keep working.
+	hasCEO := false
+	for _, a := range p.Agents {
+		if a.Slug == "ceo" {
+			hasCEO = true
+			break
+		}
+	}
+	if !hasCEO {
+		t.Error("revops pack missing required 'ceo' agent")
 	}
 	if len(p.DefaultSkills) != 5 {
 		t.Errorf("expected 5 default skills, got %d", len(p.DefaultSkills))


### PR DESCRIPTION
## The problem

The RevOps pack (merged in #54) shipped without a CEO agent. The broker, MCP, and agent orchestration code has hardcoded \`"ceo"\` assumptions in dozens of places:

- CEO-routed delegation checks (\`broker.go\` lines 2020, 3362, 3394, 3607, 3784, 4010, 4806)
- Channel membership defaults (\`broker.go:2017\` auto-adds \`ceo\` to channel members)
- MCP server gate checks (\`teammcp/server.go\` lines 409, 773, 1815, 2056, 2411)
- Skill-awareness and task-ownership logic
- Company manifest defaults (\`manifest.go\`)

Running a pack without a \`ceo\` slug silently broke anything routed through the lead — tasks claimed by "you" or "nex" failed the \`actor == "ceo"\` check, messages tagged for delegation went nowhere, channel membership omitted specialists.

## Fix

Add a "Chief Revenue Officer" agent (slug: \`ceo\`) as the revops pack lead. ops-lead now reports into the CRO. Matches the convention used by starter, founding-team, and coding-team packs where the pack lead is always \`ceo\`.

## Not fixed here (separate PR)

A proper refactor — making \`pack.LeadSlug\` authoritative everywhere and removing hardcoded \`"ceo"\` checks — is a much larger change spanning broker, teammcp, manifest, and templates. That refactor is the right long-term answer but it is not the critical path for today. Opening as a follow-up.

## Test plan

- [x] \`go test -count=1 ./...\` green (18/18 packages)
- [x] Manual: \`./wuphf --pack revops\` shows 5 office members including CEO as \`built_in: true\`, CRO routes delegation to ops-lead / AE / SDR / analyst as defined in its personality
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)