### PR TITLE
fix(web): wire SSE message events to unread counter, guard autocomplete

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -3005,7 +3005,10 @@ function showOffice() {
         var channelsData = results[1];
         var liveMembersData = results[2];
         if (membersData.members) {
-          AGENTS = membersData.members.map(function(m) {
+          // Filter out entries with an empty slug. Stale broker state from a
+          // previous pack could leave nameless placeholder members here, and
+          // passing them to the @-mention autocomplete broke filtering.
+          AGENTS = membersData.members.filter(function(m) { return m && m.slug; }).map(function(m) {
             return {
               slug: m.slug,
               emoji: m.emoji || m.slug.charAt(0).toUpperCase(),
@@ -4899,12 +4902,34 @@ function fetchMemberActivity() {
 
 // ─── Office change SSE (live sidebar updates) ───
 var officeEventSource = null;
+// IDs of messages we have already applied to the unread counter. The SSE
+// `message` stream can overlap with the per-channel poll on the active
+// channel, so we dedupe by id to avoid double-counting.
+var seenMessageIds = {};
 function connectOfficeEvents() {
   if (officeEventSource) { officeEventSource.close(); officeEventSource = null; }
   var url = WuphfAPI.sseURL('/events');
   officeEventSource = new EventSource(url);
   officeEventSource.addEventListener('office_changed', function() {
     refreshOfficeSidebar();
+  });
+  // Message events fire for every channel. Use them to track unreads for
+  // channels the user is not currently looking at — the per-channel poll
+  // only delivers messages for currentChannel so it cannot maintain a
+  // badge count for anywhere else.
+  officeEventSource.addEventListener('message', function(e) {
+    try {
+      var data = JSON.parse(e.data || '{}');
+      var msg = data.message || data;
+      if (!msg || !msg.id || !msg.channel) return;
+      if (seenMessageIds[msg.id]) return;
+      seenMessageIds[msg.id] = true;
+      if (msg.channel === currentChannel) return;
+      if (msg.from === 'you' || msg.from === 'human' || msg.from === 'system') return;
+      incrementUnreadCount(msg.channel);
+    } catch (err) {
+      // Ignore malformed payloads — reconnection handles transient errors.
+    }
   });
   officeEventSource.onerror = function() {
     // Reconnection is automatic with EventSource
@@ -4916,7 +4941,7 @@ function refreshOfficeSidebar() {
     WuphfAPI.getChannels().catch(function() { return { channels: [] }; })
   ]).then(function(results) {
     if (results[0].members && results[0].members.length > 0) {
-      AGENTS = results[0].members.map(function(m) {
+      AGENTS = results[0].members.filter(function(m) { return m && m.slug; }).map(function(m) {
         return {
           slug: m.slug,
           emoji: m.emoji || m.slug.charAt(0).toUpperCase(),


### PR DESCRIPTION
## Two bugs surfaced during RevOps demo prep

**1. Unread counter stuck at 0 when not viewing the target channel.**
The per-channel poll (\`startMessagePolling\`) only fetches messages for \`currentChannel\`. When the user is in a DM with one agent and another agent posts in #general, the message never reaches \`appendBrokerMessage\`, so \`incrementUnreadCount\` is never called and the sidebar badge stays blank.

Fix: subscribe to the existing SSE \`message\` events on \`/events\` and increment the unread count for any channel that is not the currently-active one. Dedupe by message id so SSE + poll overlap on currentChannel does not double-count. Skip self and system messages.

**2. @-mention autocomplete blank with stale members.**
Before #57 added a real CEO to the RevOps pack, the broker occasionally kept a nameless placeholder \"ceo\" member in state from a prior pack launch. \`AGENTS\` was populated with that entry, and its empty slug/name broke the mention picker.

Fix: filter out entries without a slug before building \`AGENTS\`. #57 removes the original source; this adds a belt-and-suspenders guard for any future stale state.

## Test plan

- [x] \`go test ./...\` green
- [x] SSE \`message\` event payload verified: \`{message: {id, channel, from, ...}}\`
- [ ] CI green
- [ ] Manual: open DM with @ops-lead, have a second agent post in #general (or tag @ceo from the thread), sidebar badge on general should tick up

🤖 Generated with [Claude Code](https://claude.com/claude-code)