### PR TITLE
fix(onboarding): QA fixes — onboarded boolean + checklist labels

### DIFF
--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -38,7 +38,11 @@ func RegisterRoutes(mux *http.ServeMux, completeFn func(task string, skipTask bo
 }
 
 // HandleState handles GET /onboarding/state.
-// Returns the full onboarding State as JSON.
+// Returns the full onboarding State plus an "onboarded" convenience boolean.
+// The frontend wizard reads state.onboarded to decide whether to show itself
+// on page load. Without this boolean, a completed user who refreshes the
+// page sees the wizard again because the frontend has no simple flag to
+// check.
 func HandleState(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -49,8 +53,18 @@ func HandleState(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to load state", http.StatusInternalServerError)
 		return
 	}
+	payload := map[string]any{
+		"version":             s.Version,
+		"completed_at":        s.CompletedAt,
+		"company_name":        s.CompanyName,
+		"completed_steps":     s.CompletedSteps,
+		"checklist_dismissed": s.ChecklistDismissed,
+		"partial":             s.Partial,
+		"checklist":           s.Checklist,
+		"onboarded":           s.Onboarded(),
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(s)
+	json.NewEncoder(w).Encode(payload)
 }
 
 // HandleProgress handles POST /onboarding/progress.

--- a/web/index.html
+++ b/web/index.html
@@ -6917,6 +6917,17 @@ function _finishOnboarding(data) {
   showSplashScreen(function() { showOffice(); });
 }
 
+// The server returns checklist items with only {id, done}. Map each known
+// id to a human label + optional action link. Unknown ids fall back to the
+// id itself so they are still visible instead of rendering as empty rows.
+var CHECKLIST_LABELS = {
+  pick_team: { label: 'Pick your team', action: '#team-picker' },
+  second_key: { label: 'Add a second provider key', action: '#settings' },
+  github_repo: { label: 'Browse the WUPHF repo', action: 'https://github.com/nex-crm/wuphf' },
+  github_star: { label: 'Star WUPHF on GitHub', action: 'https://github.com/nex-crm/wuphf' },
+  discord: { label: 'Join the Discord', action: 'https://discord.gg/gjSySC3PzV' }
+};
+
 function updateChecklistSidebar(checklist) {
   var section = document.getElementById('sidebar-checklist-section');
   var container = document.getElementById('sidebar-checklist');
@@ -6926,10 +6937,19 @@ function updateChecklistSidebar(checklist) {
   if (!hasIncomplete) { section.style.display = 'none'; return; }
   section.style.display = '';
   checklist.slice(0, 5).forEach(function(item) {
+    var meta = CHECKLIST_LABELS[item.id] || {};
+    var text = item.label || item.title || meta.label || item.id || '';
+    var href = item.action || meta.action || '';
     var row = _wE('div', 'checklist-item' + (item.done ? ' done' : ''));
     var box = _wE('span', 'checklist-checkbox' + (item.done ? ' checked' : ''));
-    var label = _wE('a', 'checklist-link', item.label || item.title || '');
-    if (item.action) label.href = item.action;
+    var label = _wE('a', 'checklist-link', text);
+    if (href) {
+      label.href = href;
+      if (href.indexOf('http') === 0) {
+        label.target = '_blank';
+        label.rel = 'noopener noreferrer';
+      }
+    }
     row.appendChild(box);
     row.appendChild(label);
     container.appendChild(row);


### PR DESCRIPTION
## Summary

- `/api/onboarding/state` now returns an `onboarded` boolean the frontend actually checks, so refreshing after completion keeps the user in the office instead of reshowing the wizard.
- Getting Started sidebar now renders human labels for each checklist id (`pick_team`, `second_key`, `github_repo`, `github_star`, `discord`) instead of empty rows.

## Context

Found during `/qa` on `localhost:7891` against the RevOps pack. Full report: `.gstack/qa-reports/qa-report-localhost-7891-2026-04-14.md`.

## Test plan

- [ ] Fresh install: remove `~/.wuphf/onboarded.json`, launch, complete wizard, refresh browser → office stays up
- [ ] After completion, sidebar "Getting started" shows 5 labeled rows, no empties
- [ ] `curl http://localhost:7891/api/onboarding/state | jq .onboarded` returns `true` post-completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)