### PR TITLE
fix(onboarding): persist wizard runtime choice to config.json (ISSUE-004)

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -797,6 +797,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/bridges", b.requireAuth(b.handleBridge))
 	mux.HandleFunc("/queue", b.requireAuth(b.handleQueue))
 	mux.HandleFunc("/company", b.requireAuth(b.handleCompany))
+	mux.HandleFunc("/config", b.requireAuth(b.handleConfig))
 	mux.HandleFunc("/v1/logs", b.requireAuth(b.handleOTLPLogs))
 	mux.HandleFunc("/events", b.handleEvents)
 	mux.HandleFunc("/agent-stream/", b.requireAuth(b.handleAgentStream))
@@ -3501,6 +3502,52 @@ func (b *Broker) handleCompany(w http.ResponseWriter, r *http.Request) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleConfig exposes a narrow GET/POST surface over ~/.wuphf/config.json so
+// the onboarding wizard can persist the user's runtime pick (claude-code | codex)
+// without shelling into the full config. Only llm_provider is writable here;
+// other fields are owned by their dedicated endpoints (e.g. /company, Nex register).
+func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		cfg, _ := config.Load()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"llm_provider": cfg.LLMProvider,
+		})
+	case http.MethodPost:
+		var body struct {
+			LLMProvider string `json:"llm_provider"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		provider := strings.TrimSpace(strings.ToLower(body.LLMProvider))
+		switch provider {
+		case "claude-code", "codex":
+			// ok
+		default:
+			http.Error(w, "unsupported llm_provider", http.StatusBadRequest)
+			return
+		}
+		cfg, _ := config.Load()
+		cfg.LLMProvider = provider
+		if err := config.Save(cfg); err != nil {
+			http.Error(w, "save failed", http.StatusInternalServerError)
+			return
+		}
+		// Keep /health in sync for this process so the wizard choice is
+		// reflected immediately without requiring a broker restart.
+		b.mu.Lock()
+		b.runtimeProvider = provider
+		b.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok", "llm_provider": provider})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}

--- a/internal/team/config_endpoint_test.go
+++ b/internal/team/config_endpoint_test.go
@@ -1,0 +1,107 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestConfigEndpointAndHealth is a smoke test for ISSUE-004: the wizard's
+// POST /config must persist llm_provider and /health must reflect it.
+func TestConfigEndpointAndHealth(t *testing.T) {
+	// Redirect config file to a temp HOME so we don't clobber user state.
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	if err := os.MkdirAll(filepath.Join(tmp, ".wuphf"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Seed config with claude-code, then POST codex.
+	initial := `{"llm_provider":"claude-code"}`
+	if err := os.WriteFile(filepath.Join(tmp, ".wuphf", "config.json"), []byte(initial), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	b := NewBroker()
+	b.runtimeProvider = "claude-code"
+	b.token = "test-token"
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer func() {
+		if b.server != nil {
+			_ = b.server.Shutdown(context.Background())
+		}
+	}()
+
+	// /health before — should be claude-code (the launcher-seeded default)
+	healthURL := "http://" + b.addr + "/health"
+	resp, err := http.Get(healthURL)
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	var h1 map[string]any
+	raw1, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	_ = json.Unmarshal(raw1, &h1)
+	t.Logf("GET /health (initial) -> %s", string(raw1))
+	if p, _ := h1["provider"].(string); p != "claude-code" {
+		t.Fatalf("expected provider=claude-code before POST, got %q", p)
+	}
+
+	// POST /config with codex — simulates the wizard tile click
+	body := bytes.NewBufferString(`{"llm_provider":"codex"}`)
+	req, _ := http.NewRequest(http.MethodPost, "http://"+b.addr+"/config", body)
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /config: %v", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	t.Logf("POST /config {llm_provider:codex} -> %d %s", resp.StatusCode, string(raw))
+	if resp.StatusCode != 200 {
+		t.Fatalf("POST /config status=%d body=%s", resp.StatusCode, string(raw))
+	}
+
+	// /health after — should be codex
+	resp, err = http.Get(healthURL)
+	if err != nil {
+		t.Fatalf("GET /health: %v", err)
+	}
+	var h2 map[string]any
+	raw2, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	_ = json.Unmarshal(raw2, &h2)
+	t.Logf("GET /health (after POST) -> %s", string(raw2))
+	if p, _ := h2["provider"].(string); p != "codex" {
+		t.Fatalf("expected provider=codex after POST, got %q", p)
+	}
+
+	// Verify persisted to disk
+	disk, _ := os.ReadFile(filepath.Join(tmp, ".wuphf", "config.json"))
+	if !strings.Contains(string(disk), `"llm_provider": "codex"`) {
+		t.Fatalf("config.json missing codex: %s", string(disk))
+	}
+
+	// Reject unsupported provider
+	body = bytes.NewBufferString(`{"llm_provider":"anthropic"}`)
+	req, _ = http.NewRequest(http.MethodPost, "http://"+b.addr+"/config", body)
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /config reject: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for unsupported provider, got %d", resp.StatusCode)
+	}
+
+}

--- a/web/index.html
+++ b/web/index.html
@@ -6671,6 +6671,19 @@ var RUNTIME_TILES = [
   },
 ];
 
+// Persist the wizard runtime tile choice to ~/.wuphf/config.json so
+// config.ResolveLLMProvider (and /health) reflect the user's pick after
+// the wizard. Tile ids map: 'claude' -> 'claude-code', 'codex' -> 'codex'.
+function persistRuntimeChoice(tileId) {
+  var provider = tileId === 'claude' ? 'claude-code' : (tileId === 'codex' ? 'codex' : '');
+  if (!provider) return;
+  fetch('/api/config', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ llm_provider: provider })
+  }).catch(function() { /* best-effort; wizard still completes */ });
+}
+
 function renderRuntimeTiles() {
   var host = document.getElementById('wiz-runtime-tiles');
   if (!host) return;
@@ -6750,6 +6763,7 @@ function renderRuntimeTiles() {
 
     tile.addEventListener('click', function() {
       wizSelectedRuntime = rt.id;
+      persistRuntimeChoice(rt.id);
       renderRuntimeTiles();
       updateReadyButton();
     });
@@ -6894,6 +6908,9 @@ function completeOnboarding(skipTask) {
     var ta = document.getElementById('wiz-task-input');
     task = ta ? (ta.value || '') : '';
   }
+  // Safety net: persist the selected runtime in case the user landed on the
+  // auto-selected default without clicking a tile.
+  if (wizSelectedRuntime) persistRuntimeChoice(wizSelectedRuntime);
   fetch('/api/onboarding/complete', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

- Adds `POST /config` (accepts `{"llm_provider": "claude-code" | "codex"}`) that persists via `config.Save` and updates `b.runtimeProvider` under the broker mutex so `/health` reflects the new choice immediately.
- Wizard posts the selected runtime on tile click and again as a safety-net during `completeOnboarding`.
- Maps tile id `claude` → `claude-code`.

## Context

Before this PR, the wizard's runtime tile picker only set a local JS variable. `/health` kept returning whatever was in `config.json` before the user's selection. Deferred from `/qa` report (ISSUE-004).

## Test plan

- [ ] Fresh install, pick Claude Code in wizard → `curl /api/health` returns `provider: claude-code`
- [ ] Pick Codex instead → `curl /api/health` returns `provider: codex`
- [ ] `cat ~/.wuphf/config.json` shows the chosen `llm_provider`
- [ ] `POST /api/config {"llm_provider":"anthropic"}` returns 400 (only runtime values allowed)
- [ ] `go test ./internal/team/ -run TestConfigEndpointAndHealth` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)