### PR TITLE
fix(onboarding): pack-aware first-task templates (ISSUE-005)

### DIFF
--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -14,6 +14,10 @@ import (
 // Pass nil to defer wiring — the broker should supply a real implementation
 // that seeds the team, posts the first message, and triggers the CEO turn.
 //
+// packSlug identifies the active agent pack (e.g. "founding-team", "revops").
+// HandleTemplates uses it to return pack-appropriate first-task suggestions.
+// Pass "" to fall back to the default founding-team templates.
+//
 // Routes registered:
 //
 //	GET  /onboarding/state
@@ -24,13 +28,13 @@ import (
 //	GET  /onboarding/templates
 //	POST /onboarding/checklist/{id}/done
 //	POST /onboarding/checklist/dismiss
-func RegisterRoutes(mux *http.ServeMux, completeFn func(task string, skipTask bool) error) {
+func RegisterRoutes(mux *http.ServeMux, completeFn func(task string, skipTask bool) error, packSlug string) {
 	mux.HandleFunc("/onboarding/state", HandleState)
 	mux.HandleFunc("/onboarding/progress", HandleProgress)
 	mux.HandleFunc("/onboarding/complete", makeHandleComplete(completeFn))
 	mux.HandleFunc("/onboarding/prereqs", HandlePrereqs)
 	mux.HandleFunc("/onboarding/validate-key", HandleValidateKey)
-	mux.HandleFunc("/onboarding/templates", HandleTemplates)
+	mux.HandleFunc("/onboarding/templates", makeHandleTemplates(packSlug))
 	mux.HandleFunc("/onboarding/checklist/dismiss", HandleChecklistDismiss)
 	// Pattern must be registered after the more-specific /dismiss route so
 	// that /dismiss is not swallowed by the /{id}/done prefix match.
@@ -302,15 +306,25 @@ func HandleValidateKey(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"status": status})
 }
 
+// makeHandleTemplates returns a handler for GET /onboarding/templates that
+// closes over packSlug. The broker supplies the active pack slug so the
+// first-task suggestions match the team the user is actually launching.
+func makeHandleTemplates(packSlug string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		HandleTemplates(w, r, packSlug)
+	}
+}
+
 // HandleTemplates handles GET /onboarding/templates.
-// Returns JSON array of TaskTemplate for the default starter pack.
-func HandleTemplates(w http.ResponseWriter, r *http.Request) {
+// Returns JSON array of TaskTemplate for the given pack. An empty packSlug
+// falls back to the default founding-team templates.
+func HandleTemplates(w http.ResponseWriter, r *http.Request, packSlug string) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(DefaultTemplates())
+	json.NewEncoder(w).Encode(TemplatesForPack(packSlug))
 }
 
 // HandleChecklistDismiss handles POST /onboarding/checklist/dismiss.

--- a/internal/onboarding/handlers_test.go
+++ b/internal/onboarding/handlers_test.go
@@ -240,7 +240,7 @@ func TestHandleChecklistDismiss(t *testing.T) {
 func TestRegisterRoutesRegistersAllPaths(t *testing.T) {
 	withTempHome(t, func(_ string) {
 		mux := http.NewServeMux()
-		RegisterRoutes(mux, nil)
+		RegisterRoutes(mux, nil, "")
 
 		routes := []struct {
 			method string

--- a/internal/onboarding/templates.go
+++ b/internal/onboarding/templates.go
@@ -54,3 +54,54 @@ func DefaultTemplates() []TaskTemplate {
 		},
 	}
 }
+
+// RevOpsTemplates returns the five starter task templates scoped to the
+// RevOps pack (CRO, ops-lead, AE, SDR, analyst). These map to the skills
+// already pre-seeded by the pack so the first-task suggestions read as
+// real work the team can execute on day one.
+func RevOpsTemplates() []TaskTemplate {
+	return []TaskTemplate{
+		{
+			ID:          "pipeline_audit",
+			Title:       "Run a pipeline audit",
+			Description: "CRM hygiene sweep — stale deals, missing fields, bad data. Find the leaks before forecast.",
+			OwnerSlug:   "analyst",
+		},
+		{
+			ID:          "meeting_prep",
+			Title:       "Prep me for my next call",
+			Description: "One-page brief on the account, deal stage, stakeholders, and the ask. No fluff.",
+			OwnerSlug:   "ae",
+		},
+		{
+			ID:          "revive_closed_lost",
+			Title:       "Revive closed-lost leads",
+			Description: "Surface deals lost 3–18 months ago with trigger events. Draft re-engagement outreach.",
+			OwnerSlug:   "sdr",
+		},
+		{
+			ID:          "score_inbound",
+			Title:       "Score new inbound",
+			Description: "Rate unworked leads on fit and intent. Route Tier 1 to the AE within 24 hours.",
+			OwnerSlug:   "analyst",
+		},
+		{
+			ID:          "stalled_deals",
+			Title:       "Find stalled deals",
+			Description: "Open pipeline with no activity in 10+ days. Diagnose the cause and recommend a next step.",
+			OwnerSlug:   "ops-lead",
+		},
+	}
+}
+
+// TemplatesForPack returns the starter task templates for the given pack
+// slug. Unknown or empty slugs fall through to DefaultTemplates so the
+// founding-team behavior is preserved verbatim.
+func TemplatesForPack(packSlug string) []TaskTemplate {
+	switch packSlug {
+	case "revops":
+		return RevOpsTemplates()
+	default:
+		return DefaultTemplates()
+	}
+}

--- a/internal/onboarding/templates_test.go
+++ b/internal/onboarding/templates_test.go
@@ -62,3 +62,56 @@ func TestDefaultTemplatesUniqueIDs(t *testing.T) {
 		seen[tmpl.ID] = true
 	}
 }
+
+func TestRevOpsTemplatesReturnsFiveItems(t *testing.T) {
+	templates := RevOpsTemplates()
+	if len(templates) != 5 {
+		t.Fatalf("RevOpsTemplates: got %d items, want 5", len(templates))
+	}
+}
+
+func TestRevOpsTemplatesExpectedIDs(t *testing.T) {
+	wantIDs := []string{"pipeline_audit", "meeting_prep", "revive_closed_lost", "score_inbound", "stalled_deals"}
+	templates := RevOpsTemplates()
+	for i, want := range wantIDs {
+		if templates[i].ID != want {
+			t.Errorf("revops templates[%d].ID: got %q, want %q", i, templates[i].ID, want)
+		}
+	}
+}
+
+func TestRevOpsTemplatesNonEmptyFields(t *testing.T) {
+	for _, tmpl := range RevOpsTemplates() {
+		if tmpl.ID == "" || tmpl.Title == "" || tmpl.Description == "" || tmpl.OwnerSlug == "" {
+			t.Errorf("revops template %+v: all fields must be non-empty", tmpl)
+		}
+	}
+}
+
+func TestRevOpsTemplatesOwnerSlugsMatchPack(t *testing.T) {
+	// Every owner slug should be one of the slugs present in the RevOps pack.
+	validSlugs := map[string]bool{"ceo": true, "ops-lead": true, "ae": true, "sdr": true, "analyst": true}
+	for _, tmpl := range RevOpsTemplates() {
+		if !validSlugs[tmpl.OwnerSlug] {
+			t.Errorf("revops template %q: OwnerSlug %q not in RevOps pack", tmpl.ID, tmpl.OwnerSlug)
+		}
+	}
+}
+
+func TestTemplatesForPackRouting(t *testing.T) {
+	cases := []struct {
+		slug    string
+		firstID string
+	}{
+		{"", "landing"},                    // fallback to default
+		{"founding-team", "landing"},       // explicit default
+		{"revops", "pipeline_audit"},       // revops-specific
+		{"unknown-pack", "landing"},        // unknown falls through to default
+	}
+	for _, tc := range cases {
+		got := TemplatesForPack(tc.slug)
+		if len(got) == 0 || got[0].ID != tc.firstID {
+			t.Errorf("TemplatesForPack(%q): first ID got %q, want %q", tc.slug, got[0].ID, tc.firstID)
+		}
+	}
+}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -430,6 +430,7 @@ type Broker struct {
 	addr                string         // actual listen address (useful when port=0)
 	webUIOrigins        []string       // allowed CORS origins for web UI (set by ServeWebUI)
 	runtimeProvider     string         // "codex" or "claude" — set by launcher
+	packSlug            string         // active agent pack slug ("founding-team", "revops", ...) — set by launcher
 	generateMemberFn    func(prompt string) (generatedMemberTemplate, error)
 	generateChannelFn   func(prompt string) (generatedChannelTemplate, error)
 	policies            []officePolicy // active office operating rules
@@ -803,7 +804,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/web-token", b.handleWebToken)
 	// Onboarding: state/progress/complete + prereqs/templates/validate-key + checklist.
 	// completeFn posts the first task as a human message and seeds the team.
-	onboarding.RegisterRoutes(mux, b.onboardingCompleteFn)
+	onboarding.RegisterRoutes(mux, b.onboardingCompleteFn, b.packSlug)
 
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	ln, err := net.Listen("tcp", addr)

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -52,6 +52,7 @@ func (l *Launcher) launchHeadlessCodex() error {
 	exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 
 	l.broker = NewBroker()
+	l.broker.packSlug = l.packSlug
 	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
 		return fmt.Errorf("set session mode: %w", err)
 	}

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -171,6 +171,7 @@ func (l *Launcher) Launch() error {
 	// Start the shared channel broker
 	l.broker = NewBroker()
 	l.broker.runtimeProvider = l.provider
+	l.broker.packSlug = l.packSlug
 	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
 		return fmt.Errorf("set session mode: %w", err)
 	}
@@ -3181,6 +3182,7 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 
 	l.broker = NewBroker()
 	l.broker.runtimeProvider = l.provider
+	l.broker.packSlug = l.packSlug
 	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
 		return fmt.Errorf("set session mode: %w", err)
 	}


### PR DESCRIPTION
## Summary

- `GET /api/onboarding/templates` now returns templates matching the active pack. RevOps pack returns `pipeline_audit`, `meeting_prep`, `revive_closed_lost`, `score_inbound`, `stalled_deals` (routed to `analyst`/`ae`/`sdr`/`ops-lead`).
- Default founding-team pack returns the existing `landing/repo/spec/readme/audit` set — byte-identical.
- Active pack slug is piped from launcher → broker → onboarding handlers via the same constructor pattern used for `completeFn`.
- Unknown/empty slugs fall through to `DefaultTemplates()`.

## Context

Before this PR, launching `./wuphf --pack revops` showed founding-team templates ("Draft the landing page", etc.) in the wizard's first-task step. Deferred from `/qa` report (ISSUE-005).

## Test plan

- [ ] `./wuphf --pack revops`, open wizard step 3 → 5 RevOps templates
- [ ] Default pack → unchanged founding-team templates
- [ ] `go test ./...` green (new `TestRevOps*` + `TestTemplatesForPackRouting` cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)