### PR TITLE
refactor(nex): migrate to nex-cli shell-outs, drop legacy HTTP register

### DIFF
--- a/internal/action/nex_client.go
+++ b/internal/action/nex_client.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nex-crm/wuphf/internal/api"
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/nex"
 )
 
 type nexAskResponse struct {
@@ -49,43 +50,31 @@ func nexAsk(query string) (nexAskResponse, error) {
 
 // FetchEntityBrief asks Nex for context relevant to the given work notification
 // and returns a formatted brief string to prepend to the agent's stdin input.
-// Returns an empty string when Nex is disabled, not configured, or the call
-// fails — callers should always append the original notification regardless.
-// The provided context is used for the request timeout.
+// Returns an empty string when Nex is disabled, not connected (nex-cli missing),
+// or the call fails — callers should always append the original notification
+// regardless. The provided context bounds the shell-out duration.
+//
+// Migration note: this used to POST to app.nex.ai/api/v1/context/ask. It now
+// shells out to `nex-cli recall <query>`. If the binary is missing or errors,
+// we silently degrade so the agent turn still runs on the raw notification.
 func FetchEntityBrief(ctx context.Context, notification string) string {
-	if config.ResolveNoNex() {
+	if !nex.Connected() {
 		return ""
 	}
 	query := strings.TrimSpace(notification)
 	if query == "" {
 		return ""
 	}
-	// Summarise the notification into a concise Nex query.
-	// We limit the query length to avoid runaway token usage.
+	// Cap the recall query so we don't blast the CLI with massive payloads.
 	if len(query) > 400 {
 		query = query[:400]
 	}
-	query = "Given this work item, what company context, contacts, or recent activity is most relevant? Work item: " + query
 
-	type result struct {
-		answer string
-		err    error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		resp, err := nexAsk(query)
-		ch <- result{resp.Answer, err}
-	}()
-
-	select {
-	case <-ctx.Done():
+	answer, err := nex.Recall(ctx, query)
+	if err != nil || strings.TrimSpace(answer) == "" {
 		return ""
-	case r := <-ch:
-		if r.err != nil || strings.TrimSpace(r.answer) == "" {
-			return ""
-		}
-		return "== NEX CONTEXT ==\n" + strings.TrimSpace(r.answer) + "\n== END NEX CONTEXT =="
 	}
+	return "== NEX CONTEXT ==\n" + strings.TrimSpace(answer) + "\n== END NEX CONTEXT =="
 }
 
 func nexInsightsSince(since time.Time, limit int) (nexInsightsResponse, error) {

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -181,20 +181,7 @@ func Delete[T any](c *Client, path string, timeout time.Duration) (T, error) {
 	return request[T](c, http.MethodDelete, c.BaseURL+path, nil, timeout)
 }
 
-// Register creates a new account. Does not require authentication.
-// On success, sets the API key from the response if present.
-func (c *Client) Register(email, name, companyName string) (map[string]interface{}, error) {
-	payload := RegisterRequest{
-		Email:       email,
-		Name:        name,
-		CompanyName: companyName,
-	}
-	result, err := request[map[string]interface{}](c, http.MethodPost, config.RegisterURL(), payload, 0)
-	if err != nil {
-		return nil, err
-	}
-	if key, ok := result["api_key"].(string); ok && key != "" {
-		c.SetAPIKey(key)
-	}
-	return result, nil
-}
+// Registration has moved off the legacy HTTP API. Callers that need to
+// register a WUPHF user now shell out via internal/nex.Register, which
+// drives the nex-cli binary. RegisterRequest is kept in this package for
+// backwards compatibility with existing JSON callers only.

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -145,40 +145,32 @@ func TestGetRaw_ReturnsText(t *testing.T) {
 	}
 }
 
-func TestRegister_SetsAPIKey(t *testing.T) {
-	// Register posts to RegisterURL (not BaseURL), so we point the whole client
-	// at the test server and override RegisterURL by setting BaseURL is not
-	// enough — Register uses config.RegisterURL() directly.
-	// We work around this by temporarily replacing the server via a local helper
-	// that calls the unexported request directly.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"api_key": "new-key-from-server",
-			"email":   "test@example.com",
-		})
-	}))
-	defer srv.Close()
-
-	c := NewClient("")
-	// Call request directly (same package) to simulate Register behaviour
-	// against our test server, since Register calls config.RegisterURL().
-	result, err := request[map[string]interface{}](c, http.MethodPost, srv.URL, RegisterRequest{
-		Email: "test@example.com",
-	}, 0)
+// TestRegisterRequest_RoundTrips locks in the JSON shape of the legacy
+// RegisterRequest struct for any external callers still marshaling it.
+// The HTTP Register() method itself has been removed — nex-cli owns
+// registration now (see internal/nex.Register).
+func TestRegisterRequest_RoundTrips(t *testing.T) {
+	payload := RegisterRequest{
+		Email:       "test@example.com",
+		Name:        "Test",
+		CompanyName: "Acme",
+	}
+	data, err := json.Marshal(payload)
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("marshal RegisterRequest: %v", err)
 	}
-	if key, ok := result["api_key"].(string); !ok || key != "new-key-from-server" {
-		t.Fatalf("unexpected api_key in response: %v", result)
+	var got map[string]string
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal RegisterRequest: %v", err)
 	}
-
-	// Simulate the key-setting logic from Register
-	if key, ok := result["api_key"].(string); ok && key != "" {
-		c.SetAPIKey(key)
+	if got["email"] != "test@example.com" {
+		t.Fatalf("email: got %q", got["email"])
 	}
-	if c.APIKey != "new-key-from-server" {
-		t.Fatalf("expected API key to be set, got %q", c.APIKey)
+	if got["name"] != "Test" {
+		t.Fatalf("name: got %q", got["name"])
+	}
+	if got["company_name"] != "Acme" {
+		t.Fatalf("company_name: got %q", got["company_name"])
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,11 @@ func ConfigPath() string {
 
 // BaseURL returns the resolved base URL.
 // Priority: WUPHF_DEV_URL env > NEX_DEV_URL env > config dev_url > production default.
+//
+// Note: as of the nex-cli migration, BaseURL is only used by the legacy
+// developer API client surface (api.Client) which still backs the workflow
+// engine's /v1/insights and /v1/context/ask calls. New Nex integrations
+// should shell out via the internal/nex package instead.
 func BaseURL() string {
 	if v := os.Getenv("WUPHF_DEV_URL"); v != "" {
 		return v
@@ -80,11 +85,6 @@ func BaseURL() string {
 // APIBase returns the developer API base URL.
 func APIBase() string {
 	return fmt.Sprintf("%s/api/developers", BaseURL())
-}
-
-// RegisterURL returns the agent registration URL.
-func RegisterURL() string {
-	return fmt.Sprintf("%s/api/v1/agents/register", BaseURL())
 }
 
 // Load reads the config file. Returns an empty config if the file is missing or unreadable.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -539,12 +539,6 @@ func TestAPIBase(t *testing.T) {
 	})
 }
 
-func TestRegisterURL(t *testing.T) {
-	t.Setenv("WUPHF_DEV_URL", "")
-	withTempConfig(t, func(_ string) {
-		want := "https://app.nex.ai/api/v1/agents/register"
-		if got := RegisterURL(); got != want {
-			t.Fatalf("RegisterURL: got %q, want %q", got, want)
-		}
-	})
-}
+// RegisterURL used to point at the legacy HTTP registration endpoint.
+// Registration now shells out via internal/nex.Register (nex-cli), so the
+// URL builder is gone. The test is removed along with it.

--- a/internal/nex/cli.go
+++ b/internal/nex/cli.go
@@ -1,0 +1,134 @@
+// Package nex wraps the nex-cli binary. WUPHF no longer speaks the legacy
+// app.nex.ai HTTP API for detection, registration, or memory recall — those
+// paths now shell out to the nex-cli binary from the nex-as-a-skill project:
+//
+//	https://github.com/nex-crm/nex-as-a-skill
+//
+// The user is considered "Nex-connected" when nex-cli is on PATH and the
+// --no-nex flag (WUPHF_NO_NEX) is not set. Every shell-out uses a context
+// with a real timeout; failures are returned to callers so they can log and
+// fall back gracefully — missing binary is NOT a crash.
+package nex
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// DefaultTimeout is the deadline applied to every nex-cli shell-out when the
+// caller does not provide one of their own.
+const DefaultTimeout = 8 * time.Second
+
+// ErrNotInstalled is returned when nex-cli is not on PATH.
+var ErrNotInstalled = errors.New("nex-cli not installed")
+
+// ErrDisabled is returned when --no-nex (WUPHF_NO_NEX) is set for this run.
+var ErrDisabled = errors.New("nex disabled via --no-nex")
+
+// binaryCandidates lists the executable names we accept as "nex-cli",
+// in priority order. `nex-cli` is the canonical name; `nex` is the alias
+// the npm package ships with (`@nex-ai/nex`).
+var binaryCandidates = []string{"nex-cli", "nex"}
+
+// BinaryPath returns the absolute path to the nex-cli binary, or the empty
+// string if none of the candidate names are on PATH. Lookups are cheap but
+// hit the filesystem — callers that need to branch on availability should
+// prefer IsInstalled() which wraps this.
+func BinaryPath() string {
+	for _, name := range binaryCandidates {
+		if path, err := exec.LookPath(name); err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+// IsInstalled reports whether the nex-cli binary is available on PATH.
+// Does NOT consult --no-nex — use Connected() for the full picture.
+func IsInstalled() bool {
+	return BinaryPath() != ""
+}
+
+// Disabled reports whether the user has turned Nex off for this session
+// via the --no-nex flag / WUPHF_NO_NEX env var. --no-nex takes precedence
+// over auto-detection: even if nex-cli is installed, Disabled() wins.
+func Disabled() bool {
+	return config.ResolveNoNex()
+}
+
+// Connected reports whether WUPHF should treat the user as Nex-connected
+// for this session. True iff nex-cli is on PATH AND the user hasn't set
+// --no-nex. This is the replacement for the legacy `nex_connected` HTTP
+// ping check.
+func Connected() bool {
+	if Disabled() {
+		return false
+	}
+	return IsInstalled()
+}
+
+// Run executes `nex-cli <args...>` with the given context/timeout and returns
+// stdout (trimmed) on success. A non-zero exit code, missing binary, or
+// context timeout are all returned as errors. The caller is responsible for
+// logging and falling back.
+func Run(ctx context.Context, args ...string) (string, error) {
+	if Disabled() {
+		return "", ErrDisabled
+	}
+	bin := BinaryPath()
+	if bin == "" {
+		return "", ErrNotInstalled
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, DefaultTimeout)
+		defer cancel()
+	}
+	cmd := exec.CommandContext(ctx, bin, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("nex-cli %s: timeout after %s", strings.Join(args, " "), DefaultTimeout)
+		}
+		trimmed := strings.TrimSpace(stderr.String())
+		if trimmed != "" {
+			return "", fmt.Errorf("nex-cli %s: %s", strings.Join(args, " "), trimmed)
+		}
+		return "", fmt.Errorf("nex-cli %s: %w", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// Register shells out to `nex-cli register --email <email>`. Used by the
+// WUPHF onboarding flow in place of the legacy POST to /api/v1/agents/register
+// on app.nex.ai. Blocks until the command exits (or the default timeout trips).
+func Register(ctx context.Context, email string) (string, error) {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		return "", fmt.Errorf("register: email is required")
+	}
+	return Run(ctx, "register", "--email", email)
+}
+
+// Recall shells out to `nex-cli recall <query>` and returns the trimmed
+// stdout. Used by FetchEntityBrief and any future memory-lookup call sites.
+// Callers that need a short deadline should pass a pre-scoped context.
+func Recall(ctx context.Context, query string) (string, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return "", fmt.Errorf("recall: query is required")
+	}
+	return Run(ctx, "recall", query)
+}

--- a/internal/nex/cli_test.go
+++ b/internal/nex/cli_test.go
@@ -1,0 +1,149 @@
+package nex
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// writeFakeNexCLI creates a shell script that simulates nex-cli on a temp
+// PATH. The script echoes args + a canned response so tests can assert both
+// detection and shell-out plumbing without touching the real binary.
+func writeFakeNexCLI(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake shell script requires a POSIX shell")
+	}
+	path := filepath.Join(dir, name)
+	script := "#!/bin/sh\n" + body + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake nex-cli: %v", err)
+	}
+}
+
+// withIsolatedPATH points PATH at a dedicated tmp dir and restores it on cleanup.
+// Returns the tmp dir so the test can drop fake binaries into it.
+func withIsolatedPATH(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("PATH", dir)
+	return dir
+}
+
+func TestIsInstalled_Missing(t *testing.T) {
+	withIsolatedPATH(t)
+	t.Setenv("WUPHF_NO_NEX", "")
+	if IsInstalled() {
+		t.Fatal("expected nex-cli to be missing on an empty PATH")
+	}
+}
+
+func TestIsInstalled_Present(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex-cli", "echo installed")
+	if !IsInstalled() {
+		t.Fatal("expected nex-cli to be detected")
+	}
+}
+
+func TestConnected_DisabledBeatsInstalled(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex-cli", "echo installed")
+	t.Setenv("WUPHF_NO_NEX", "1")
+	if Connected() {
+		t.Fatal("--no-nex must take precedence over detection")
+	}
+}
+
+func TestConnected_Happy(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex-cli", "echo installed")
+	t.Setenv("WUPHF_NO_NEX", "")
+	if !Connected() {
+		t.Fatal("expected Connected() when nex-cli is installed and --no-nex is off")
+	}
+}
+
+func TestRun_ReturnsStdout(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex-cli", `printf 'recall: %s\n' "$1"`)
+	t.Setenv("WUPHF_NO_NEX", "")
+	out, err := Run(context.Background(), "recall", "acme")
+	if err != nil {
+		t.Fatalf("Run: unexpected error: %v", err)
+	}
+	if out != "recall: recall" {
+		// the fake echoes the first arg, which is "recall" (subcommand)
+		t.Fatalf("Run: unexpected stdout %q", out)
+	}
+}
+
+func TestRun_MissingBinary(t *testing.T) {
+	withIsolatedPATH(t)
+	t.Setenv("WUPHF_NO_NEX", "")
+	_, err := Run(context.Background(), "recall", "foo")
+	if !errors.Is(err, ErrNotInstalled) {
+		t.Fatalf("Run: expected ErrNotInstalled, got %v", err)
+	}
+}
+
+func TestRun_Disabled(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex-cli", "echo ok")
+	t.Setenv("WUPHF_NO_NEX", "1")
+	_, err := Run(context.Background(), "recall", "foo")
+	if !errors.Is(err, ErrDisabled) {
+		t.Fatalf("Run: expected ErrDisabled, got %v", err)
+	}
+}
+
+func TestRecall_ShellsOut(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	// Emit the query so we can assert it was forwarded.
+	writeFakeNexCLI(t, dir, "nex-cli", `printf '%s' "$2"`)
+	t.Setenv("WUPHF_NO_NEX", "")
+	out, err := Recall(context.Background(), "acme q3 renewal")
+	if err != nil {
+		t.Fatalf("Recall: unexpected error: %v", err)
+	}
+	if out != "acme q3 renewal" {
+		t.Fatalf("Recall: expected query echoed back, got %q", out)
+	}
+}
+
+func TestRegister_PassesEmail(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex-cli", `printf '%s' "$3"`)
+	t.Setenv("WUPHF_NO_NEX", "")
+	out, err := Register(context.Background(), "founder@example.com")
+	if err != nil {
+		t.Fatalf("Register: unexpected error: %v", err)
+	}
+	if out != "founder@example.com" {
+		t.Fatalf("Register: expected email forwarded, got %q", out)
+	}
+}
+
+func TestRegister_RejectsEmpty(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex-cli", "echo ok")
+	t.Setenv("WUPHF_NO_NEX", "")
+	if _, err := Register(context.Background(), "  "); err == nil {
+		t.Fatal("Register: expected error on blank email")
+	}
+}
+
+func TestRun_Timeout(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex-cli", "sleep 2")
+	t.Setenv("WUPHF_NO_NEX", "")
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if _, err := Run(ctx, "slow"); err == nil {
+		t.Fatal("Run: expected timeout error")
+	}
+}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/channel"
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/nex"
 	"github.com/nex-crm/wuphf/internal/onboarding"
 	"github.com/nex-crm/wuphf/internal/provider"
 )
@@ -2923,7 +2924,10 @@ func (b *Broker) handleHealth(w http.ResponseWriter, r *http.Request) {
 	b.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	nexConnected := !config.ResolveNoNex() && config.ResolveAPIKey("") != ""
+	// nex_connected now reflects whether the local nex-cli binary is available
+	// and the user hasn't disabled Nex for this session via --no-nex. The legacy
+	// HTTP ping to app.nex.ai is gone; Nex memory now lives behind nex-cli.
+	nexConnected := nex.Connected()
 	json.NewEncoder(w).Encode(map[string]any{
 		"status":           "ok",
 		"session_mode":     mode,

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -31,6 +31,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/calendar"
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/nex"
 	"github.com/nex-crm/wuphf/internal/setup"
 	"github.com/nex-crm/wuphf/internal/provider"
 )
@@ -3133,8 +3134,10 @@ func (l *Launcher) PreflightWeb() error {
 
 // LaunchWeb starts the broker, web UI server, and background agents without tmux.
 func (l *Launcher) LaunchWeb(webPort int) error {
-	// Ask user about Nex setup if API key is missing
-	if !config.ResolveNoNex() && config.ResolveAPIKey("") == "" {
+	// Offer to wire Nex when the user hasn't opted out and nex-cli isn't yet
+	// installed. `nex setup` handles detection and wiring for us — we just
+	// surface the prompt.
+	if !config.ResolveNoNex() && !nex.IsInstalled() {
 		fmt.Println()
 		fmt.Print("  Connect Nex for memory and context? [Y/n] ")
 		var answer string
@@ -3142,17 +3145,12 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		answer = strings.TrimSpace(strings.ToLower(answer))
 		if answer == "" || answer == "y" || answer == "yes" {
 			fmt.Println()
-			nexBin, err := exec.LookPath("nex")
-			if err != nil {
-				fmt.Println("  Nex CLI not found. Installing...")
-				if _, installErr := setup.InstallLatestCLI(); installErr != nil {
-					fmt.Printf("  Could not install: %v\n", installErr)
-					fmt.Println("  Continuing without Nex.")
-				} else {
-					nexBin, _ = exec.LookPath("nex")
-				}
+			fmt.Println("  Nex CLI not found. Installing...")
+			if _, installErr := setup.InstallLatestCLI(); installErr != nil {
+				fmt.Printf("  Could not install: %v\n", installErr)
+				fmt.Println("  Continuing without Nex.")
 			}
-			if nexBin != "" {
+			if nexBin := nex.BinaryPath(); nexBin != "" {
 				cmd := exec.Command(nexBin, "setup")
 				cmd.Stdin = os.Stdin
 				cmd.Stdout = os.Stdout


### PR DESCRIPTION
## Summary

Swaps WUPHF's Nex integration from the legacy `app.nex.ai` HTTP API over to `nex-cli` / `nex-mcp` shell-outs per the new `nex-crm/nex-as-a-skill` architecture. The `--no-nex` flag name is preserved; detection semantics change from "did the HTTP ping succeed" to "is `nex-cli` on PATH and not disabled."

## What changed

### Detection
- New `internal/nex/cli.go` wraps `nex-cli` (with `nex` alias fallback for the `@nex-ai/nex` npm install) behind `IsInstalled()` / `Connected()` / `Disabled()`. Pure `exec.LookPath` — no HTTP ping.
- `handleHealth` at `internal/team/broker.go:2929-2932` now sets `nex_connected` via `nex.Connected()`.
- `LaunchWeb` onboarding at `internal/team/launcher.go:3134-3172` funnels through `nex.IsInstalled` / `nex.BinaryPath`.

### Register
- Removed legacy `api.Client.Register` + `config.RegisterURL()` (`internal/api/client.go:184-188`, `internal/config/config.go:85-88`) — only its own test called it.
- Replaced with `nex.Register(ctx, email)` → `nex-cli register --email <email>` with an 8s deadline (`internal/nex/cli.go:110-117`).
- Test rewritten to lock the `RegisterRequest` JSON shape (`internal/api/client_test.go:148-175`).

### Recall / entity brief
- `action.FetchEntityBrief` used to POST to `/v1/context/ask`; now shells out to `nex-cli recall <query>` via `nex.Recall` (`internal/action/nex_client.go:50-78`). Gracefully degrades (empty brief) when the binary is missing or the call errors.

### --no-nex semantics
- Flag name + env var (`WUPHF_NO_NEX`) unchanged. `config.ResolveNoNex()` remains source of truth. `nex.Disabled()` wraps it; `nex.Connected()` checks `!Disabled() && IsInstalled()` so the flag takes precedence over auto-detection.

### Health endpoint
- `nex_connected` is now `true` iff `nex-cli` is on PATH **and** `--no-nex` is off. No more false-positive "connected" from a stale env key.

## Left in place deliberately

- `api.Client` (and `config.BaseURL` / `config.APIBase`) still back `internal/action/composio_workflows.go` steps `executeWorkflowNexAskStep` and `executeWorkflowNexInsightsStep` via `nexAsk` / `nexInsightsSince`. Bigger workflow-engine surface; flagged with a TODO comment on `BaseURL` for the next migration wave.
- `setup.InstallLatestCLI` (npm install of `@nex-ai/nex`) stays — it's the bootstrap path that installs `nex-cli` in the first place.

## Test plan

- [ ] `go test ./...` passes (confirmed by agent)
- [ ] Fresh machine without `nex-cli` installed: `/api/health` returns `nex_connected: false`, onboarding does not crash
- [ ] `brew install nex-cli` (or `npm i -g @nex-ai/nex`), restart wuphf: `/api/health` flips to `nex_connected: true`
- [ ] `./wuphf --no-nex` on a machine with `nex-cli` installed: `/api/health` stays `nex_connected: false`
- [ ] User-facing `nex register` flow: fills in email in wizard → shells out to `nex-cli register`

🤖 Generated with [Claude Code](https://claude.com/claude-code)