### PR TITLE
fix(openclaw): make the bridge actually work against a real OpenClaw daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Already running [OpenClaw](https://openclaw.ai) agents? You can bring them into 
 
 Inside the office, run `/connect openclaw`, paste your gateway URL (default `ws://127.0.0.1:18789`) and the `gateway.auth.token` from your `~/.openclaw/openclaw.json`, then pick which sessions to bridge. Each becomes a first-class office member you can `@mention`. OpenClaw agents keep running in their own sandbox; WUPHF just gives them a shared office to collaborate in.
 
+WUPHF authenticates to the gateway using an Ed25519 keypair (persisted at `~/.wuphf/openclaw/identity.json`, 0600), signed against the server-issued nonce during every connect. OpenClaw grants zero scopes to token-only clients, so device pairing is mandatory — on loopback the gateway approves silently on first use.
+
 ## External Actions
 
 To let agents take real actions (send emails, update CRMs, etc.), WUPHF ships with two action providers. Pick whichever fits your style.

--- a/cmd/wuphf-oc-probe/main.go
+++ b/cmd/wuphf-oc-probe/main.go
@@ -1,0 +1,108 @@
+// wuphf-oc-probe is a tiny smoke test that drives the OpenClaw bridge client
+// against a running local daemon. Build and run it with:
+//
+//	OPENCLAW_TOKEN=... go run ./cmd/wuphf-oc-probe
+//
+// It performs: handshake → sessions.list → subscribe → sessions.send, and
+// prints session.message events for ~5 seconds. Used to validate protocol
+// assumptions against a real `openclaw daemon` install without polluting the
+// unit-test suite.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/openclaw"
+)
+
+func main() {
+	token := os.Getenv("OPENCLAW_TOKEN")
+	if token == "" {
+		data, err := os.ReadFile("/tmp/oc-token.txt")
+		if err != nil {
+			die("OPENCLAW_TOKEN unset and /tmp/oc-token.txt unreadable: %v", err)
+		}
+		token = strings.TrimSpace(string(data))
+	}
+	identity, err := openclaw.LoadOrCreateDeviceIdentity(os.ExpandEnv("$HOME/.wuphf/openclaw/identity.json"))
+	if err != nil {
+		die("identity: %v", err)
+	}
+	fmt.Println("deviceId:", identity.DeviceID()[:16], "...")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	client, err := openclaw.Dial(ctx, openclaw.Config{
+		URL:      "ws://127.0.0.1:18789",
+		Token:    token,
+		Identity: identity,
+	})
+	if err != nil {
+		die("dial: %v", err)
+	}
+	defer client.Close()
+	fmt.Println("dialed + handshake ok")
+
+	rows, err := client.SessionsList(ctx, openclaw.SessionsListFilter{Limit: 5, IncludeLastMessage: true})
+	if err != nil {
+		die("sessions.list: %v", err)
+	}
+	fmt.Printf("found %d session(s)\n", len(rows))
+	if len(rows) == 0 {
+		fmt.Println("PASS (no sessions to send to, but protocol works)")
+		return
+	}
+	sess := rows[0]
+	fmt.Printf("first session: key=%s displayName=%q kind=%s\n", sess.Key, sess.DisplayName, sess.Kind)
+
+	if err := client.SessionsMessagesSubscribe(ctx, sess.Key); err != nil {
+		die("subscribe: %v", err)
+	}
+	fmt.Println("subscribed")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for evt := range client.Events() {
+			switch evt.Kind {
+			case openclaw.EventKindMessage:
+				m := evt.SessionMessage
+				fmt.Printf("  EVT message role=%q text=%q\n", m.Role, snippet(m.MessageText, 140))
+			case openclaw.EventKindChanged:
+				fmt.Printf("  EVT changed reason=%s phase=%s\n", evt.SessionsChanged.Reason, evt.SessionsChanged.Phase)
+			case openclaw.EventKindGap:
+				fmt.Printf("  EVT gap from=%d to=%d\n", evt.Gap.FromSeq, evt.Gap.ToSeq)
+			case openclaw.EventKindClose:
+				fmt.Println("  connection closed")
+				return
+			}
+		}
+	}()
+
+	res, err := client.SessionsSend(ctx, sess.Key, "hello from wuphf Go probe", fmt.Sprintf("probe-%d", time.Now().UnixNano()))
+	if err != nil {
+		die("sessions.send: %v", err)
+	}
+	fmt.Printf("sent: runId=%s status=%s messageSeq=%d\n", res.RunID, res.Status, res.MessageSeq)
+
+	time.Sleep(5 * time.Second)
+	client.Close()
+	<-done
+	fmt.Println("PASS")
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "FAIL: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func snippet(s string, n int) string {
+	if len(s) > n {
+		return s[:n] + "..."
+	}
+	return s
+}

--- a/cmd/wuphf/channel_integration.go
+++ b/cmd/wuphf/channel_integration.go
@@ -308,7 +308,11 @@ func fetchOpenclawSessions(url, token string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
-		client, err := openclaw.Dial(ctx, openclaw.Config{URL: url, Token: token})
+		identity, err := openclaw.LoadOrCreateDeviceIdentity(config.ResolveOpenclawIdentityPath())
+		if err != nil {
+			return openclawSessionsMsg{err: err}
+		}
+		client, err := openclaw.Dial(ctx, openclaw.Config{URL: url, Token: token, Identity: identity})
 		if err != nil {
 			return openclawSessionsMsg{err: err}
 		}
@@ -324,14 +328,14 @@ func fetchOpenclawSessions(url, token string) tea.Cmd {
 				label = r.Label
 			}
 			if label == "" {
-				label = r.SessionKey
+				label = r.Key
 			}
 			preview := strings.TrimSpace(r.LastMessage)
 			if preview == "" && r.Kind != "" {
 				preview = r.Kind
 			}
 			out = append(out, openclawSessionOption{
-				SessionKey: r.SessionKey,
+				SessionKey: r.Key,
 				Label:      label,
 				Preview:    preview,
 			})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -613,3 +613,18 @@ func ResolveOpenclawGatewayURL() string {
 	}
 	return "ws://127.0.0.1:18789"
 }
+
+// ResolveOpenclawIdentityPath returns where the Ed25519 device identity is
+// persisted. OpenClaw's gateway requires device-pair auth — token alone grants
+// zero scopes — so this keypair is effectively credentials: write only to a
+// user-scoped 0600 file under the WUPHF home.
+func ResolveOpenclawIdentityPath() string {
+	if v := strings.TrimSpace(os.Getenv("WUPHF_OPENCLAW_IDENTITY_PATH")); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".wuphf", "openclaw", "identity.json")
+	}
+	return filepath.Join(home, ".wuphf", "openclaw", "identity.json")
+}

--- a/internal/openclaw/client.go
+++ b/internal/openclaw/client.go
@@ -17,10 +17,10 @@ import (
 
 // Config configures a Client.
 type Config struct {
-	URL         string // e.g. ws://127.0.0.1:18789 or wss://host:18789
-	Token       string // shared secret (from wuphf config or env)
-	ClientID    string // defaults to "wuphf"
-	UserAgent   string // optional
+	URL         string          // e.g. ws://127.0.0.1:18789 or wss://host:18789
+	Token       string          // shared secret (from wuphf config or env)
+	Identity    *DeviceIdentity // required — OpenClaw grants zero scopes without device auth
+	UserAgent   string          // optional
 	DialTimeout time.Duration
 }
 
@@ -47,16 +47,16 @@ func (c *Client) writeJSON(v any) error {
 	return c.conn.WriteJSON(v)
 }
 
-// Dial establishes a connection and completes the hello handshake.
+// Dial establishes a connection and completes the challenge-response handshake.
 func Dial(ctx context.Context, cfg Config) (*Client, error) {
 	if err := enforceTransportSecurity(cfg.URL); err != nil {
 		return nil, err
 	}
+	if cfg.Identity == nil {
+		return nil, errors.New("openclaw: DeviceIdentity required (see LoadOrCreateDeviceIdentity)")
+	}
 	if cfg.DialTimeout == 0 {
 		cfg.DialTimeout = 10 * time.Second
-	}
-	if cfg.ClientID == "" {
-		cfg.ClientID = "wuphf"
 	}
 	dialer := websocket.Dialer{HandshakeTimeout: cfg.DialTimeout}
 	dctx, cancel := context.WithTimeout(ctx, cfg.DialTimeout)
@@ -110,49 +110,158 @@ func isLoopbackHost(host string) bool {
 	return ip != nil && ip.IsLoopback()
 }
 
+// connectChallengeEvent is the shape of the first frame the gateway pushes.
+type connectChallengeEvent struct {
+	Nonce string `json:"nonce"`
+	TS    int64  `json:"ts"`
+}
+
+const (
+	clientIDBackend    = "gateway-client"
+	clientModeBackend  = "backend"
+	connectRole        = "operator"
+	connectDeviceFamily = "wuphf"
+	connectScopeAdmin  = "operator.admin"
+	supportedProtocol  = 3
+)
+
 func (c *Client) doHandshake(ctx context.Context) error {
+	// Deadline guards every read/write in the handshake.
+	deadline := time.Now().Add(c.cfg.DialTimeout)
+	_ = c.conn.SetReadDeadline(deadline)
+	_ = c.conn.SetWriteDeadline(deadline)
+	defer func() {
+		_ = c.conn.SetReadDeadline(time.Time{})
+		_ = c.conn.SetWriteDeadline(time.Time{})
+	}()
+
+	// 1. Wait for connect.challenge event with the server nonce.
+	nonce, err := c.readConnectChallenge()
+	if err != nil {
+		return err
+	}
+
+	// 2. Build + sign device auth payload (v3, pipe-delimited).
+	signedAtMs := nowMs()
+	platform := runtimeOS()
+	payload := BuildDeviceAuthPayloadV3(DeviceAuthPayloadV3{
+		DeviceID:     c.cfg.Identity.DeviceID(),
+		ClientID:     clientIDBackend,
+		ClientMode:   clientModeBackend,
+		Role:         connectRole,
+		Scopes:       []string{connectScopeAdmin},
+		SignedAtMs:   signedAtMs,
+		Token:        c.cfg.Token,
+		Nonce:        nonce,
+		Platform:     platform,
+		DeviceFamily: connectDeviceFamily,
+	})
+	signature := c.cfg.Identity.Sign(payload)
+
+	// 3. Send connect with device auth.
+	connectID := c.newID()
 	connectReq := RequestFrame{
 		Type:   "req",
-		ID:     c.newID(),
+		ID:     connectID,
 		Method: "connect",
 		Params: map[string]any{
-			"minProtocol": 1,
-			"maxProtocol": 2,
+			"minProtocol": supportedProtocol,
+			"maxProtocol": supportedProtocol,
 			"client": map[string]any{
-				"id":       c.cfg.ClientID,
-				"version":  "0.1",
-				"platform": runtimeOS(),
-				"mode":     "operator",
+				"id":           clientIDBackend,
+				"version":      "0.1",
+				"platform":     platform,
+				"deviceFamily": connectDeviceFamily,
+				"mode":         clientModeBackend,
 			},
-			"auth": map[string]any{"token": c.cfg.Token},
+			"auth":   map[string]any{"token": c.cfg.Token},
+			"role":   connectRole,
+			"scopes": []string{connectScopeAdmin},
+			"caps":   []string{},
+			"device": map[string]any{
+				"id":        c.cfg.Identity.DeviceID(),
+				"publicKey": c.cfg.Identity.PublicKeyB64URL(),
+				"signature": signature,
+				"signedAt":  signedAtMs,
+				"nonce":     nonce,
+			},
 		},
 	}
 	if err := c.writeJSON(connectReq); err != nil {
 		return fmt.Errorf("openclaw: write connect: %w", err)
 	}
-	// Expect hello-ok.
-	_, raw, err := c.conn.ReadMessage()
-	if err != nil {
-		return fmt.Errorf("openclaw: read hello-ok: %w", err)
-	}
-	var hello struct {
-		Type     string      `json:"type"`
-		Protocol int         `json:"protocol"`
-		Error    *ErrorShape `json:"error,omitempty"`
-	}
-	if err := json.Unmarshal(raw, &hello); err != nil {
-		return fmt.Errorf("openclaw: decode hello-ok: %w", err)
-	}
-	if hello.Type != "hello-ok" {
-		if hello.Error != nil {
-			return fmt.Errorf("openclaw: handshake refused: %s: %s", hello.Error.Code, hello.Error.Message)
+
+	// 4. Read frames until we see the hello-ok response (skipping pre-handshake events).
+	for {
+		_, raw, err := c.conn.ReadMessage()
+		if err != nil {
+			return fmt.Errorf("openclaw: read hello-ok: %w", err)
 		}
-		return fmt.Errorf("openclaw: unexpected handshake frame type %q", hello.Type)
+		kind, _, err := DecodeFrame(raw)
+		if err != nil {
+			continue // ignore unrecognized pre-handshake traffic
+		}
+		if kind != "res" {
+			continue
+		}
+		var res ResponseFrame
+		if err := json.Unmarshal(raw, &res); err != nil {
+			return fmt.Errorf("openclaw: decode connect response: %w", err)
+		}
+		if res.ID != connectID {
+			continue
+		}
+		if !res.OK {
+			if res.Error != nil {
+				return fmt.Errorf("openclaw: handshake refused: %s: %s", res.Error.Code, res.Error.Message)
+			}
+			return errors.New("openclaw: handshake refused (no error detail)")
+		}
+		var hello struct {
+			Type     string `json:"type"`
+			Protocol int    `json:"protocol"`
+		}
+		if err := json.Unmarshal(res.Payload, &hello); err != nil {
+			return fmt.Errorf("openclaw: decode hello-ok: %w", err)
+		}
+		if hello.Type != "hello-ok" {
+			return fmt.Errorf("openclaw: unexpected connect payload type %q", hello.Type)
+		}
+		if hello.Protocol < supportedProtocol {
+			return fmt.Errorf("openclaw: server protocol %d < required %d", hello.Protocol, supportedProtocol)
+		}
+		return nil
 	}
-	if hello.Protocol < 1 {
-		return fmt.Errorf("openclaw: unsupported protocol %d", hello.Protocol)
+}
+
+// readConnectChallenge consumes frames until it sees the connect.challenge event.
+// Other early events (e.g. health) are discarded to keep the handshake linear.
+func (c *Client) readConnectChallenge() (string, error) {
+	for {
+		_, raw, err := c.conn.ReadMessage()
+		if err != nil {
+			return "", fmt.Errorf("openclaw: read connect.challenge: %w", err)
+		}
+		kind, _, err := DecodeFrame(raw)
+		if err != nil || kind != "event" {
+			continue
+		}
+		var evt EventFrame
+		if err := json.Unmarshal(raw, &evt); err != nil {
+			continue
+		}
+		if evt.Event != "connect.challenge" {
+			continue
+		}
+		var ch connectChallengeEvent
+		if err := json.Unmarshal(evt.Payload, &ch); err != nil {
+			return "", fmt.Errorf("openclaw: decode connect.challenge payload: %w", err)
+		}
+		if ch.Nonce == "" {
+			return "", errors.New("openclaw: connect.challenge missing nonce")
+		}
+		return ch.Nonce, nil
 	}
-	return nil
 }
 
 func (c *Client) readLoop() {
@@ -266,6 +375,10 @@ func (c *Client) newID() string {
 // runtimeOS reports the current OS. Split out as a var so tests can override.
 var runtimeOS = func() string {
 	return runtime.GOOS
+}
+
+var nowMs = func() int64 {
+	return time.Now().UnixMilli()
 }
 
 // GatewayError is returned by Call when the gateway responds with ok=false.

--- a/internal/openclaw/client_test.go
+++ b/internal/openclaw/client_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -13,9 +14,11 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// startFakeGateway returns an httptest server that upgrades to WS and answers
-// the "connect" request with hello-ok. Additional handlers can be registered
-// via onRequest for req/res roundtrip tests in later tasks.
+// startFakeGateway returns an httptest server that mirrors the real OpenClaw
+// handshake closely enough for client tests: it pushes connect.challenge first,
+// accepts the device-authed connect request, and replies with a wrapped res
+// frame whose payload is `hello-ok`. Additional method handlers can be
+// registered via onRequest.
 func startFakeGateway(t *testing.T, onRequest func(method string, params json.RawMessage) (payload any, errMsg string)) *httptest.Server {
 	t.Helper()
 	up := websocket.Upgrader{CheckOrigin: func(r *http.Request) bool { return true }}
@@ -26,7 +29,14 @@ func startFakeGateway(t *testing.T, onRequest func(method string, params json.Ra
 			return
 		}
 		defer c.Close()
-		// Expect connect request.
+		// 1. Push connect.challenge FIRST — the real daemon does this before
+		// reading anything from the client.
+		_ = c.WriteJSON(map[string]any{
+			"type":    "event",
+			"event":   "connect.challenge",
+			"payload": map[string]any{"nonce": "test-nonce", "ts": time.Now().UnixMilli()},
+		})
+		// 2. Expect connect request.
 		_, raw, err := c.ReadMessage()
 		if err != nil {
 			return
@@ -40,17 +50,23 @@ func startFakeGateway(t *testing.T, onRequest func(method string, params json.Ra
 		if req.Method != "connect" {
 			return
 		}
-		// Reply hello-ok.
-		hello := map[string]any{
-			"type":     "hello-ok",
-			"protocol": 1,
-			"server":   map[string]any{"version": "test", "connId": "c1"},
-			"features": map[string]any{"methods": []string{"sessions.list"}, "events": []string{"session.message"}},
-			"snapshot": map[string]any{},
-			"policy":   map[string]any{"maxPayload": 1024 * 1024, "maxBufferedBytes": 1024 * 1024, "tickIntervalMs": 30000},
-		}
-		_ = c.WriteJSON(hello)
-		// Serve further requests.
+		// 3. Reply res(hello-ok) — matching the real server at
+		// dist/server.impl:22706 which wraps the hello-ok body inside a
+		// res frame rather than sending it as a top-level frame.
+		_ = c.WriteJSON(map[string]any{
+			"type": "res",
+			"id":   req.ID,
+			"ok":   true,
+			"payload": map[string]any{
+				"type":     "hello-ok",
+				"protocol": 3,
+				"server":   map[string]any{"version": "test", "connId": "c1"},
+				"features": map[string]any{"methods": []string{"sessions.list"}, "events": []string{"session.message"}},
+				"snapshot": map[string]any{},
+				"policy":   map[string]any{"maxPayload": 1024 * 1024, "maxBufferedBytes": 1024 * 1024, "tickIntervalMs": 30000},
+			},
+		})
+		// 4. Serve further requests.
 		for {
 			_, raw, err := c.ReadMessage()
 			if err != nil {
@@ -93,12 +109,23 @@ func wsURL(srv *httptest.Server) string {
 	return "ws" + strings.TrimPrefix(srv.URL, "http")
 }
 
+// testIdentity returns a fresh throwaway DeviceIdentity rooted in t.TempDir().
+// Each test gets its own file so the path is writeable under the sandbox.
+func testIdentity(t *testing.T) *DeviceIdentity {
+	t.Helper()
+	id, err := LoadOrCreateDeviceIdentity(filepath.Join(t.TempDir(), "identity.json"))
+	if err != nil {
+		t.Fatalf("LoadOrCreateDeviceIdentity: %v", err)
+	}
+	return id
+}
+
 func TestClientDialHappyPath(t *testing.T) {
 	srv := startFakeGateway(t, nil)
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t"})
+	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t", Identity: testIdentity(t)})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
@@ -108,7 +135,7 @@ func TestClientDialHappyPath(t *testing.T) {
 func TestClientRejectsPlaintextNonLoopback(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	_, err := Dial(ctx, Config{URL: "ws://example.com:18789", Token: "t"})
+	_, err := Dial(ctx, Config{URL: "ws://example.com:18789", Token: "t", Identity: testIdentity(t)})
 	if err == nil {
 		t.Fatal("expected error for ws:// non-loopback")
 	}
@@ -119,16 +146,29 @@ func TestClientRejectsPlaintextNonLoopback(t *testing.T) {
 
 func TestClientAllowsPlaintextNonLoopbackWhenEnvSet(t *testing.T) {
 	t.Setenv("OPENCLAW_ALLOW_INSECURE_PRIVATE_WS", "1")
-	// No real server; we only verify Dial accepts the URL past the security check.
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
-	_, err := Dial(ctx, Config{URL: "ws://10.0.0.1:18789", Token: "t"})
+	_, err := Dial(ctx, Config{URL: "ws://10.0.0.1:18789", Token: "t", Identity: testIdentity(t)})
 	if err == nil {
 		t.Fatal("expected dial failure (no server); got nil")
 	}
-	// The error should NOT be the insecure-url message.
 	if strings.Contains(err.Error(), "insecure") || strings.Contains(err.Error(), "plaintext") {
 		t.Fatalf("env-allowed insecure URL rejected at policy: %v", err)
+	}
+}
+
+func TestDialRequiresDeviceIdentity(t *testing.T) {
+	// OpenClaw grants zero scopes to token-only clients, so the bridge MUST
+	// pass an identity — we'd rather fail fast with a clear error than hit
+	// cryptic missing-scope errors on every session method.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	_, err := Dial(ctx, Config{URL: "ws://127.0.0.1:1", Token: "t"})
+	if err == nil {
+		t.Fatal("expected error when Identity is nil")
+	}
+	if !strings.Contains(err.Error(), "DeviceIdentity") {
+		t.Fatalf("expected DeviceIdentity error, got %v", err)
 	}
 }
 
@@ -142,7 +182,7 @@ func TestClientCallRoundTrip(t *testing.T) {
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t"})
+	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t", Identity: testIdentity(t)})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
@@ -169,7 +209,7 @@ func TestClientCallServerError(t *testing.T) {
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t"})
+	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t", Identity: testIdentity(t)})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
@@ -188,7 +228,6 @@ func TestClientCallServerError(t *testing.T) {
 }
 
 func TestClientCallContextCancel(t *testing.T) {
-	// Server never responds.
 	srv := startFakeGateway(t, func(method string, params json.RawMessage) (any, string) {
 		time.Sleep(2 * time.Second)
 		return nil, ""
@@ -196,7 +235,7 @@ func TestClientCallContextCancel(t *testing.T) {
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t"})
+	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t", Identity: testIdentity(t)})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}

--- a/internal/openclaw/events.go
+++ b/internal/openclaw/events.go
@@ -1,6 +1,9 @@
 package openclaw
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // ClientEventKind discriminates the ClientEvent union.
 type ClientEventKind int
@@ -23,13 +26,29 @@ type ClientEvent struct {
 }
 
 // SessionMessageEvent mirrors the OpenClaw "session.message" payload.
+//
+// Real-daemon shape (observed 2026-04-15 against OpenClaw 2026.4.14):
+//
+//	{
+//	  "sessionKey": "agent:main:main",
+//	  "message": {
+//	    "role": "user" | "assistant",
+//	    "content": "<string>"            // role=user
+//	              | [{"type":"text","text":"..."}]  // role=assistant (array of parts)
+//	    "timestamp": 1776254522461,
+//	    "__openclaw": {"seq": 0}
+//	  },
+//	  "messageSeq": 0,
+//	  "session": {...},
+//	  ...
+//	}
 type SessionMessageEvent struct {
-	SessionKey   string          `json:"sessionKey"`
-	MessageID    string          `json:"messageId,omitempty"`
-	MessageSeq   *int64          `json:"messageSeq,omitempty"`
-	Message      json.RawMessage `json:"message,omitempty"`
-	MessageState string          `json:"-"`
-	MessageText  string          `json:"-"`
+	SessionKey  string          `json:"sessionKey"`
+	MessageID   string          `json:"messageId,omitempty"`
+	MessageSeq  *int64          `json:"messageSeq,omitempty"`
+	Message     json.RawMessage `json:"message,omitempty"`
+	Role        string          `json:"-"` // "user" | "assistant" | ""
+	MessageText string          `json:"-"` // extracted text for display
 }
 
 // SessionsChangedEvent mirrors "sessions.changed".
@@ -47,26 +66,58 @@ type GapEvent struct {
 	ToSeq      int64 // seq we just received
 }
 
+// parseSessionMessage extracts role + text from the polymorphic OpenClaw message
+// shape. `content` is either a string (user message) or an array of content parts
+// for assistant messages; we concatenate all `type:"text"` parts.
 func parseSessionMessage(raw json.RawMessage) (*SessionMessageEvent, error) {
 	var e SessionMessageEvent
 	if err := json.Unmarshal(raw, &e); err != nil {
 		return nil, err
 	}
-	var inner struct {
-		State   string `json:"state"`
-		Content string `json:"content"`
-		Text    string `json:"text"`
+	if len(e.Message) == 0 {
+		return &e, nil
 	}
-	if len(e.Message) > 0 {
-		_ = json.Unmarshal(e.Message, &inner)
-		e.MessageState = inner.State
-		if inner.Content != "" {
-			e.MessageText = inner.Content
-		} else {
-			e.MessageText = inner.Text
-		}
+	var envelope struct {
+		Role    string          `json:"role"`
+		Content json.RawMessage `json:"content"`
+		Text    string          `json:"text"`
+	}
+	if err := json.Unmarshal(e.Message, &envelope); err == nil {
+		e.Role = envelope.Role
+		e.MessageText = extractMessageText(envelope.Content, envelope.Text)
 	}
 	return &e, nil
+}
+
+func extractMessageText(content json.RawMessage, fallback string) string {
+	if len(content) == 0 {
+		return fallback
+	}
+	// Fast path: string content (user messages).
+	var asString string
+	if err := json.Unmarshal(content, &asString); err == nil {
+		return asString
+	}
+	// Array of parts (assistant messages).
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(content, &parts); err == nil {
+		var b strings.Builder
+		for _, p := range parts {
+			if p.Type == "text" && p.Text != "" {
+				if b.Len() > 0 {
+					b.WriteByte('\n')
+				}
+				b.WriteString(p.Text)
+			}
+		}
+		if b.Len() > 0 {
+			return b.String()
+		}
+	}
+	return fallback
 }
 
 func parseSessionsChanged(raw json.RawMessage) (*SessionsChangedEvent, error) {

--- a/internal/openclaw/events_test.go
+++ b/internal/openclaw/events_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 )
 
-func TestParseSessionMessageEvent(t *testing.T) {
-	raw := []byte(`{"sessionKey":"agent:main:main","message":{"id":"m1","role":"assistant","content":"hello"},"messageSeq":7}`)
+func TestParseSessionMessageAssistantPartsArray(t *testing.T) {
+	// Real OpenClaw shape for an assistant reply: content is an array of
+	// {type, text} parts. Verified 2026-04-15 against OpenClaw 2026.4.14.
+	raw := []byte(`{"sessionKey":"agent:main:main","message":{"role":"assistant","content":[{"type":"text","text":"hello there"}],"timestamp":1776254522461},"messageSeq":7}`)
 	evt, err := parseSessionMessage(raw)
 	if err != nil {
 		t.Fatalf("parseSessionMessage: %v", err)
@@ -17,23 +19,32 @@ func TestParseSessionMessageEvent(t *testing.T) {
 	if evt.MessageSeq == nil || *evt.MessageSeq != 7 {
 		t.Fatalf("messageSeq: %v", evt.MessageSeq)
 	}
-	if evt.MessageText != "hello" {
-		t.Fatalf("MessageText from nested content: %q", evt.MessageText)
+	if evt.Role != "assistant" {
+		t.Fatalf("Role: %q", evt.Role)
 	}
+	if evt.MessageText != "hello there" {
+		t.Fatalf("MessageText: %q", evt.MessageText)
+	}
+}
 
-	// state extraction + text fallback
-	raw2 := []byte(`{"sessionKey":"k","message":{"state":"delta","text":"partial"}}`)
-	evt2, err := parseSessionMessage(raw2)
+func TestParseSessionMessageUserStringContent(t *testing.T) {
+	// User-role messages in the real feed carry content as a plain string.
+	raw := []byte(`{"sessionKey":"k","message":{"role":"user","content":"hi","timestamp":0},"messageSeq":0}`)
+	evt, err := parseSessionMessage(raw)
 	if err != nil {
-		t.Fatalf("parseSessionMessage state: %v", err)
+		t.Fatalf("parseSessionMessage: %v", err)
 	}
-	if evt2.MessageState != "delta" {
-		t.Fatalf("MessageState: %q", evt2.MessageState)
+	if evt.Role != "user" || evt.MessageText != "hi" {
+		t.Fatalf("Role/Text: %q/%q", evt.Role, evt.MessageText)
 	}
-	if evt2.MessageText != "partial" {
-		t.Fatalf("MessageText from text fallback: %q", evt2.MessageText)
+}
+
+func TestExtractMessageTextMultiplePartsJoined(t *testing.T) {
+	parts := json.RawMessage(`[{"type":"text","text":"line 1"},{"type":"text","text":"line 2"}]`)
+	got := extractMessageText(parts, "")
+	if got != "line 1\nline 2" {
+		t.Fatalf("joined text: %q", got)
 	}
-	_ = json.RawMessage(raw)
 }
 
 func TestParseSessionsChangedEvent(t *testing.T) {

--- a/internal/openclaw/identity.go
+++ b/internal/openclaw/identity.go
@@ -1,0 +1,228 @@
+package openclaw
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// DeviceIdentity is a persistent Ed25519 keypair used for OpenClaw device auth.
+//
+// OpenClaw requires clients to pair as a device: present a public key + a signature
+// over a payload that includes the server-sent nonce. On loopback the gateway
+// auto-approves pairing silently. Token auth alone grants ZERO scopes.
+type DeviceIdentity struct {
+	deviceID string
+	priv     ed25519.PrivateKey
+	pub      ed25519.PublicKey
+}
+
+type storedIdentity struct {
+	Version       int    `json:"version"`
+	DeviceID      string `json:"deviceId"`
+	PrivateKeyB64 string `json:"privateKeyB64url"`
+	CreatedAtMs   int64  `json:"createdAtMs"`
+}
+
+// LoadOrCreateDeviceIdentity returns the keypair at path, creating one if missing.
+// The file is written mode 0600 so it stays private.
+func LoadOrCreateDeviceIdentity(path string) (*DeviceIdentity, error) {
+	if path == "" {
+		return nil, errors.New("openclaw: identity path required")
+	}
+	if data, err := os.ReadFile(path); err == nil {
+		id, err := parseIdentity(data)
+		if err == nil {
+			return id, nil
+		}
+		// Corrupt file — regenerate rather than fail startup.
+	}
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("openclaw: generate identity: %w", err)
+	}
+	id := &DeviceIdentity{
+		deviceID: computeDeviceID(pub),
+		priv:     priv,
+		pub:      pub,
+	}
+	stored := storedIdentity{
+		Version:       1,
+		DeviceID:      id.deviceID,
+		PrivateKeyB64: base64URLNoPad(priv),
+		CreatedAtMs:   nowMs(),
+	}
+	body, err := json.MarshalIndent(&stored, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("openclaw: marshal identity: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return nil, fmt.Errorf("openclaw: mkdir identity: %w", err)
+	}
+	if err := os.WriteFile(path, append(body, '\n'), 0o600); err != nil {
+		return nil, fmt.Errorf("openclaw: write identity: %w", err)
+	}
+	return id, nil
+}
+
+func parseIdentity(raw []byte) (*DeviceIdentity, error) {
+	var s storedIdentity
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return nil, err
+	}
+	if s.Version != 1 || s.PrivateKeyB64 == "" {
+		return nil, errors.New("identity: unsupported version")
+	}
+	priv, err := base64URLDecodeNoPad(s.PrivateKeyB64)
+	if err != nil {
+		return nil, err
+	}
+	if len(priv) != ed25519.PrivateKeySize {
+		return nil, errors.New("identity: wrong key size")
+	}
+	privKey := ed25519.PrivateKey(priv)
+	pub := privKey.Public().(ed25519.PublicKey)
+	return &DeviceIdentity{
+		deviceID: computeDeviceID(pub),
+		priv:     privKey,
+		pub:      pub,
+	}, nil
+}
+
+// DeviceID is hex(sha256(raw 32-byte ed25519 public key)), matching OpenClaw's
+// deriveDeviceIdFromPublicKey at infra/device-identity.ts.
+func (d *DeviceIdentity) DeviceID() string { return d.deviceID }
+
+// PublicKeyB64URL returns the raw 32-byte public key as base64url (no padding).
+// This is what OpenClaw expects in connect.params.device.publicKey.
+func (d *DeviceIdentity) PublicKeyB64URL() string { return base64URLNoPad(d.pub) }
+
+// Sign returns base64url(no-pad) Ed25519 signature over payload.
+func (d *DeviceIdentity) Sign(payload []byte) string {
+	return base64URLNoPad(ed25519.Sign(d.priv, payload))
+}
+
+// BuildDeviceAuthPayloadV3 produces the exact pipe-delimited string OpenClaw
+// signs/verifies in buildDeviceAuthPayloadV3 (gateway/device-auth.ts).
+//
+// Format: v3|deviceId|clientId|clientMode|role|scopes|signedAtMs|token|nonce|platform|deviceFamily
+// platform and deviceFamily are lowercase-trimmed.
+func BuildDeviceAuthPayloadV3(p DeviceAuthPayloadV3) []byte {
+	scopes := joinCSV(p.Scopes)
+	return []byte(
+		"v3|" +
+			p.DeviceID + "|" +
+			p.ClientID + "|" +
+			p.ClientMode + "|" +
+			p.Role + "|" +
+			scopes + "|" +
+			fmtInt64(p.SignedAtMs) + "|" +
+			p.Token + "|" +
+			p.Nonce + "|" +
+			normalizeMetadata(p.Platform) + "|" +
+			normalizeMetadata(p.DeviceFamily),
+	)
+}
+
+type DeviceAuthPayloadV3 struct {
+	DeviceID     string
+	ClientID     string
+	ClientMode   string
+	Role         string
+	Scopes       []string
+	SignedAtMs   int64
+	Token        string
+	Nonce        string
+	Platform     string
+	DeviceFamily string
+}
+
+func computeDeviceID(pub ed25519.PublicKey) string {
+	sum := sha256.Sum256(pub)
+	return hex.EncodeToString(sum[:])
+}
+
+func base64URLNoPad(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+func base64URLDecodeNoPad(s string) ([]byte, error) {
+	if out, err := base64.RawURLEncoding.DecodeString(s); err == nil {
+		return out, nil
+	}
+	return base64.URLEncoding.DecodeString(s)
+}
+
+func normalizeMetadata(s string) string {
+	out := make([]byte, 0, len(s))
+	start, end := 0, len(s)
+	for start < end && isASCIISpace(s[start]) {
+		start++
+	}
+	for end > start && isASCIISpace(s[end-1]) {
+		end--
+	}
+	for i := start; i < end; i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 32
+		}
+		out = append(out, c)
+	}
+	return string(out)
+}
+
+func isASCIISpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\v', '\f':
+		return true
+	}
+	return false
+}
+
+func joinCSV(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	total := 0
+	for _, s := range items {
+		total += len(s) + 1
+	}
+	out := make([]byte, 0, total)
+	for i, s := range items {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = append(out, s...)
+	}
+	return string(out)
+}
+
+func fmtInt64(v int64) string {
+	if v == 0 {
+		return "0"
+	}
+	neg := v < 0
+	if neg {
+		v = -v
+	}
+	var buf [20]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/openclaw/identity_test.go
+++ b/internal/openclaw/identity_test.go
@@ -1,0 +1,79 @@
+package openclaw
+
+import (
+	"crypto/ed25519"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadOrCreateDeviceIdentityPersists(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "identity.json")
+
+	a, err := LoadOrCreateDeviceIdentity(path)
+	if err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	if len(a.DeviceID()) != 64 { // sha256 hex = 64 chars
+		t.Fatalf("deviceId hex length: %d", len(a.DeviceID()))
+	}
+	if _, err := hex.DecodeString(a.DeviceID()); err != nil {
+		t.Fatalf("deviceId not hex: %v", err)
+	}
+
+	// Reload and confirm the same identity materializes.
+	b, err := LoadOrCreateDeviceIdentity(path)
+	if err != nil {
+		t.Fatalf("second load: %v", err)
+	}
+	if a.DeviceID() != b.DeviceID() {
+		t.Fatalf("deviceId changed on reload: %q vs %q", a.DeviceID(), b.DeviceID())
+	}
+	if a.PublicKeyB64URL() != b.PublicKeyB64URL() {
+		t.Fatalf("publicKey changed on reload")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("identity file should be 0600; got %v", info.Mode().Perm())
+	}
+}
+
+func TestSignVerifiesAgainstPublicKey(t *testing.T) {
+	id, err := LoadOrCreateDeviceIdentity(filepath.Join(t.TempDir(), "identity.json"))
+	if err != nil {
+		t.Fatalf("LoadOrCreateDeviceIdentity: %v", err)
+	}
+	payload := []byte("v3|abc|gateway-client|backend|operator|operator.admin|123|tok|nonce|darwin|wuphf")
+	sigB64 := id.Sign(payload)
+	sig, err := base64URLDecodeNoPad(sigB64)
+	if err != nil {
+		t.Fatalf("decode sig: %v", err)
+	}
+	if !ed25519.Verify(id.pub, payload, sig) {
+		t.Fatal("signature did not verify with the same identity's public key")
+	}
+}
+
+func TestBuildDeviceAuthPayloadV3WireFormat(t *testing.T) {
+	got := string(BuildDeviceAuthPayloadV3(DeviceAuthPayloadV3{
+		DeviceID:     "abc123",
+		ClientID:     "gateway-client",
+		ClientMode:   "backend",
+		Role:         "operator",
+		Scopes:       []string{"operator.admin", "operator.read"},
+		SignedAtMs:   1776254522461,
+		Token:        "tok",
+		Nonce:        "n1",
+		Platform:     " DARWIN ",
+		DeviceFamily: "WUPHF",
+	}))
+	want := "v3|abc123|gateway-client|backend|operator|operator.admin,operator.read|1776254522461|tok|n1|darwin|wuphf"
+	if got != want {
+		t.Fatalf("payload wire format\n got:  %q\n want: %q", got, want)
+	}
+}

--- a/internal/openclaw/methods.go
+++ b/internal/openclaw/methods.go
@@ -12,20 +12,28 @@ type SessionsListFilter struct {
 	Kinds              []string `json:"kinds,omitempty"`
 	IncludeLastMessage bool     `json:"includeLastMessage,omitempty"`
 	Search             string   `json:"search,omitempty"`
+	AgentID            string   `json:"agentId,omitempty"`
 }
 
-// SessionRow is the subset of OpenClaw SessionListRow WUPHF needs.
+// SessionRow is the subset of OpenClaw session-list-row WUPHF needs.
+//
+// The real daemon uses "key" as the session identifier (NOT "sessionKey").
+// Verified 2026-04-15 against OpenClaw 2026.4.14 sessions.list output.
 type SessionRow struct {
-	SessionKey  string `json:"sessionKey"`
+	Key         string `json:"key"`
 	Label       string `json:"label,omitempty"`
 	DisplayName string `json:"displayName,omitempty"`
 	Kind        string `json:"kind,omitempty"`
+	ChatType    string `json:"chatType,omitempty"`
+	SessionID   string `json:"sessionId,omitempty"`
 	LastMessage string `json:"lastMessage,omitempty"`
+	UpdatedAt   int64  `json:"updatedAt,omitempty"`
 }
 
 type sessionsListResult struct {
 	Sessions []SessionRow `json:"sessions"`
 	Path     string       `json:"path,omitempty"`
+	Count    int          `json:"count,omitempty"`
 }
 
 func (c *Client) SessionsList(ctx context.Context, f SessionsListFilter) ([]SessionRow, error) {
@@ -40,15 +48,32 @@ func (c *Client) SessionsList(ctx context.Context, f SessionsListFilter) ([]Sess
 	return res.Sessions, nil
 }
 
-// SessionsSend fires a message into an OpenClaw session. Reply arrives as events.
-// idempotencyKey MUST be reused across retries of the same logical send.
-func (c *Client) SessionsSend(ctx context.Context, key, message, idempotencyKey string) error {
+// SessionsSend fires a message into an OpenClaw session. The agent's reply
+// arrives asynchronously as session.message events.
+//
+// idempotencyKey MUST be reused across retries of the same logical send so the
+// gateway deduplicates. The returned runId identifies the turn on the daemon
+// side and can be correlated with chat/session events.
+type SessionsSendResult struct {
+	RunID      string `json:"runId,omitempty"`
+	Status     string `json:"status,omitempty"` // "started" | ...
+	MessageSeq int64  `json:"messageSeq,omitempty"`
+}
+
+func (c *Client) SessionsSend(ctx context.Context, key, message, idempotencyKey string) (*SessionsSendResult, error) {
 	params := map[string]any{"key": key, "message": message}
 	if idempotencyKey != "" {
 		params["idempotencyKey"] = idempotencyKey
 	}
-	_, err := c.Call(ctx, "sessions.send", params)
-	return err
+	raw, err := c.Call(ctx, "sessions.send", params)
+	if err != nil {
+		return nil, err
+	}
+	var res SessionsSendResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
 }
 
 func (c *Client) SessionsMessagesSubscribe(ctx context.Context, key string) error {
@@ -59,36 +84,4 @@ func (c *Client) SessionsMessagesSubscribe(ctx context.Context, key string) erro
 func (c *Client) SessionsMessagesUnsubscribe(ctx context.Context, key string) error {
 	_, err := c.Call(ctx, "sessions.messages.unsubscribe", map[string]any{"key": key})
 	return err
-}
-
-// HistoricMessage is a minimal representation of a past transcript entry.
-type HistoricMessage struct {
-	SessionKey string          `json:"sessionKey,omitempty"`
-	Seq        *int64          `json:"messageSeq,omitempty"`
-	Message    json.RawMessage `json:"message,omitempty"`
-}
-
-// SessionsHistory fetches transcript entries since sinceSeq for gap catch-up.
-// Returns messages in chronological order.
-func (c *Client) SessionsHistory(ctx context.Context, key string, sinceSeq int64) ([]HistoricMessage, error) {
-	params := map[string]any{"sessionKey": key}
-	if sinceSeq > 0 {
-		params["sinceSeq"] = sinceSeq
-	}
-	raw, err := c.Call(ctx, "sessions.history", params)
-	if err != nil {
-		return nil, err
-	}
-	var wrap struct {
-		Messages []HistoricMessage `json:"messages"`
-	}
-	if err := json.Unmarshal(raw, &wrap); err != nil {
-		// Fallback: some servers return a bare array.
-		var arr []HistoricMessage
-		if err2 := json.Unmarshal(raw, &arr); err2 == nil {
-			return arr, nil
-		}
-		return nil, err
-	}
-	return wrap.Messages, nil
 }

--- a/internal/openclaw/methods_test.go
+++ b/internal/openclaw/methods_test.go
@@ -13,14 +13,15 @@ func TestSessionsListSerialization(t *testing.T) {
 		if method == "sessions.list" {
 			captured.Method = method
 			_ = json.Unmarshal(params, &captured.Params)
-			return map[string]any{"sessions": []any{map[string]any{"sessionKey": "k", "label": "Agent"}}, "path": "/p"}, ""
+			// Real daemon uses "key" as the session identifier, not "sessionKey".
+			return map[string]any{"sessions": []any{map[string]any{"key": "agent:main:main", "kind": "direct"}}, "path": "/p"}, ""
 		}
 		return nil, "unknown"
 	})
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t"})
+	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t", Identity: testIdentity(t)})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
@@ -30,10 +31,9 @@ func TestSessionsListSerialization(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SessionsList: %v", err)
 	}
-	if len(rows) != 1 || rows[0].SessionKey != "k" {
+	if len(rows) != 1 || rows[0].Key != "agent:main:main" {
 		t.Fatalf("rows: %+v", rows)
 	}
-	// Check the params were sent.
 	pm, _ := captured.Params.(map[string]any)
 	if pm == nil || pm["limit"].(float64) != 10 {
 		t.Fatalf("params: %+v", captured.Params)
@@ -45,20 +45,24 @@ func TestSessionsSendIncludesIdempotencyKey(t *testing.T) {
 	srv := startFakeGateway(t, func(method string, params json.RawMessage) (any, string) {
 		if method == "sessions.send" {
 			_ = json.Unmarshal(params, &got)
-			return map[string]any{"ok": true}, ""
+			return map[string]any{"runId": "r-1", "status": "started", "messageSeq": 1}, ""
 		}
 		return nil, "unknown"
 	})
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t"})
+	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t", Identity: testIdentity(t)})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
 	defer c.Close()
-	if err := c.SessionsSend(ctx, "agent:main:main", "hello", "idem-1"); err != nil {
+	res, err := c.SessionsSend(ctx, "agent:main:main", "hello", "idem-1")
+	if err != nil {
 		t.Fatalf("SessionsSend: %v", err)
+	}
+	if res == nil || res.RunID != "r-1" || res.Status != "started" {
+		t.Fatalf("unexpected send result: %+v", res)
 	}
 	if got["idempotencyKey"] != "idem-1" {
 		t.Fatalf("idempotencyKey missing: %+v", got)
@@ -80,7 +84,7 @@ func TestSessionsMessagesSubscribe(t *testing.T) {
 	defer srv.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t"})
+	c, err := Dial(ctx, Config{URL: wsURL(srv), Token: "t", Identity: testIdentity(t)})
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}

--- a/internal/team/openclaw.go
+++ b/internal/team/openclaw.go
@@ -2,7 +2,6 @@ package team
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -19,10 +18,9 @@ var defaultOpenclawRetryDelays = []time.Duration{1 * time.Second, 5 * time.Secon
 // Having it here (not in the openclaw package) keeps the mock test-local.
 type openclawClient interface {
 	SessionsList(ctx context.Context, f openclaw.SessionsListFilter) ([]openclaw.SessionRow, error)
-	SessionsSend(ctx context.Context, key, message, idempotencyKey string) error
+	SessionsSend(ctx context.Context, key, message, idempotencyKey string) (*openclaw.SessionsSendResult, error)
 	SessionsMessagesSubscribe(ctx context.Context, key string) error
 	SessionsMessagesUnsubscribe(ctx context.Context, key string) error
-	SessionsHistory(ctx context.Context, key string, sinceSeq int64) ([]openclaw.HistoricMessage, error)
 	Events() <-chan openclaw.ClientEvent
 	Close() error
 }
@@ -55,7 +53,7 @@ type OpenclawBridge struct {
 	// noticedOffline is true while the circuit breaker has been reported as
 	// open via a system message; reset to false when the breaker closes so
 	// each offline episode posts exactly one notice (not one per 5-minute
-	// supervise tick — reviewer Important issue 5).
+	// supervise tick).
 	noticedOffline bool
 }
 
@@ -146,9 +144,6 @@ func (b *OpenclawBridge) supervise() {
 			return
 		}
 		if b.breaker != nil && b.breaker.Open() {
-			// Post the offline notice at most once per breaker-open episode.
-			// Without this guard supervise() loops every 5 minutes and floods
-			// #general with the same system message until the breaker closes.
 			if !b.noticedOffline {
 				b.postSystemMessage("openclaw gateway offline")
 				b.noticedOffline = true
@@ -160,9 +155,6 @@ func (b *OpenclawBridge) supervise() {
 				return
 			}
 		}
-		// Once the breaker has closed (or was never open) we're back in a state
-		// where a future trip should re-notify. Clearing here covers both the
-		// cold-start path and the half-open-recovery path.
 		b.noticedOffline = false
 		err := b.runOnce()
 		if err != nil && !errors.Is(err, context.Canceled) {
@@ -210,7 +202,6 @@ func (b *OpenclawBridge) runOnce() error {
 			return err
 		}
 	}
-	// Successful subscribe => breaker reset (pre-impl decision 5).
 	if b.breaker != nil {
 		b.breaker.RecordSuccess()
 	}
@@ -234,12 +225,13 @@ func (b *OpenclawBridge) runOnce() error {
 }
 
 // handleClientEvent dispatches one event from the OpenClaw Client into the
-// appropriate broker surface: delta chunks flow into the per-agent stream so
-// they render as a live typing indicator, while finals (and bare messages
-// without an explicit state) become chat messages authored by the bridged
-// slug. Error/aborted states and "session ended" changes fan out as system
-// notices. Gap kinds trigger history catch-up; Close kinds are handled by
-// the supervise loop via the events channel close.
+// broker. session.message events arrive as finalized transcript entries (there
+// is no separate streaming path on the daemon's sessions.messages.subscribe).
+// We only forward role=assistant messages — user messages in the stream are
+// echoes of what we just sent, and forwarding them would double-post.
+//
+// sessions.changed events with reason=ended post a system notice so humans
+// know the agent shut down that conversation.
 func (b *OpenclawBridge) handleClientEvent(evt openclaw.ClientEvent) {
 	switch evt.Kind {
 	case openclaw.EventKindMessage:
@@ -250,20 +242,12 @@ func (b *OpenclawBridge) handleClientEvent(evt openclaw.ClientEvent) {
 		if !ok {
 			return // not a bridged session, ignore
 		}
-		switch evt.SessionMessage.MessageState {
-		case "delta":
-			if stream := b.broker.AgentStream(slug); stream != nil && evt.SessionMessage.MessageText != "" {
-				stream.Push(evt.SessionMessage.MessageText)
-			}
-		case "final", "":
-			// Treat empty state as a complete message (some servers omit state).
-			if text := evt.SessionMessage.MessageText; text != "" {
-				b.postBridgeMessage(slug, text)
-			}
-		case "error":
-			b.postSystemMessage(fmt.Sprintf("openclaw agent %q reported an error", slug))
-		case "aborted":
-			b.postSystemMessage(fmt.Sprintf("openclaw agent %q aborted the turn", slug))
+		// Skip user/system echoes — only publish agent replies.
+		if evt.SessionMessage.Role != "" && evt.SessionMessage.Role != "assistant" {
+			return
+		}
+		if text := evt.SessionMessage.MessageText; text != "" {
+			b.postBridgeMessage(slug, text)
 		}
 	case openclaw.EventKindChanged:
 		if evt.SessionsChanged != nil && evt.SessionsChanged.Reason == "ended" {
@@ -272,46 +256,17 @@ func (b *OpenclawBridge) handleClientEvent(evt openclaw.ClientEvent) {
 			}
 		}
 	case openclaw.EventKindGap:
+		// The real OpenClaw daemon does not expose sessions.history, so we have
+		// no authoritative catch-up source. Log a system notice instead so the
+		// user knows an event was dropped — they can re-prompt if needed.
 		if evt.Gap == nil {
 			return
 		}
-		slug, ok := b.slugByKey[evt.Gap.SessionKey]
-		if !ok {
-			return
+		if slug, ok := b.slugByKey[evt.Gap.SessionKey]; ok {
+			b.postSystemMessage(fmt.Sprintf("missed %d message(s) from @%s — daemon event gap", evt.Gap.ToSeq-evt.Gap.FromSeq-1, slug))
 		}
-		go b.catchUp(slug, evt.Gap.SessionKey, evt.Gap.FromSeq)
 	case openclaw.EventKindClose:
 		// Handled by supervise loop via events-channel close.
-	}
-}
-
-// catchUp fetches historic messages since fromSeq and replays final messages
-// as bridged "[catch-up] ..." chat messages in #general.
-func (b *OpenclawBridge) catchUp(slug, sessionKey string, sinceSeq int64) {
-	client := b.getClient()
-	if client == nil {
-		return
-	}
-	msgs, err := client.SessionsHistory(b.ctx, sessionKey, sinceSeq)
-	if err != nil {
-		b.postSystemMessage(fmt.Sprintf("openclaw catch-up failed for @%s: %v", slug, err))
-		return
-	}
-	for _, m := range msgs {
-		var inner struct {
-			State   string `json:"state"`
-			Content string `json:"content"`
-			Text    string `json:"text"`
-		}
-		_ = json.Unmarshal(m.Message, &inner)
-		text := inner.Content
-		if text == "" {
-			text = inner.Text
-		}
-		if text == "" || (inner.State != "" && inner.State != "final") {
-			continue
-		}
-		b.postBridgeMessage(slug, "[catch-up] "+text)
 	}
 }
 
@@ -329,7 +284,7 @@ func (b *OpenclawBridge) SetRetryDelaysForTest(d []time.Duration) { b.retryDelay
 
 // OnOfficeMessage sends an office message from user/@mention to the OpenClaw
 // agent identified by slug. Retries on transient errors with a SINGLE reused
-// idempotency key (per-call, per pre-implementation decision 3).
+// idempotency key so the gateway can deduplicate.
 func (b *OpenclawBridge) OnOfficeMessage(ctx context.Context, slug, message string) error {
 	key, ok := b.keyBySlug[slug]
 	if !ok {
@@ -343,7 +298,7 @@ func (b *OpenclawBridge) OnOfficeMessage(ctx context.Context, slug, message stri
 		if client == nil {
 			lastErr = fmt.Errorf("openclaw: no active client")
 		} else {
-			err := client.SessionsSend(ctx, key, message, idem)
+			_, err := client.SessionsSend(ctx, key, message, idem)
 			if err == nil {
 				return nil
 			}
@@ -377,7 +332,6 @@ func (b *OpenclawBridge) postBridgeMessage(slug, text string) {
 }
 
 // postSystemMessage posts a `system`-authored notice into #general.
-// PostSystemMessage already uses sender="system", which the tests rely on.
 func (b *OpenclawBridge) postSystemMessage(text string) {
 	if b.broker == nil {
 		return

--- a/internal/team/openclaw_bootstrap.go
+++ b/internal/team/openclaw_bootstrap.go
@@ -87,14 +87,18 @@ func routeOpenclawMentionsLoop(ctx context.Context, broker *Broker, bridge *Open
 	}
 }
 
-// defaultOpenclawDialer is the production dialer: a thin wrapper that resolves
-// the gateway URL + token from env/config at dial-time (so rotated credentials
-// take effect on reconnect without a restart) and returns the Client unchanged
-// — *openclaw.Client already satisfies the openclawClient interface.
+// defaultOpenclawDialer is the production dialer. It resolves URL, token, and
+// device identity at dial-time so rotated credentials take effect on reconnect
+// without a WUPHF restart. OpenClaw rejects token-only clients with zero scopes,
+// so loading the Ed25519 identity is non-optional.
 func defaultOpenclawDialer(ctx context.Context) (openclawClient, error) {
 	url := config.ResolveOpenclawGatewayURL()
 	token := config.ResolveOpenclawToken()
-	c, err := openclaw.Dial(ctx, openclaw.Config{URL: url, Token: token})
+	identity, err := openclaw.LoadOrCreateDeviceIdentity(config.ResolveOpenclawIdentityPath())
+	if err != nil {
+		return nil, fmt.Errorf("openclaw identity: %w", err)
+	}
+	c, err := openclaw.Dial(ctx, openclaw.Config{URL: url, Token: token, Identity: identity})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/team/openclaw_e2e_test.go
+++ b/internal/team/openclaw_e2e_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -16,14 +17,13 @@ import (
 )
 
 // TestOpenclawBridgeFullPipeline_E2E exercises the OpenClaw bridge end-to-end
-// against a fake gateway running over a real WebSocket. It proves the full data
-// flow:
+// against a fake gateway running over a real WebSocket. It proves:
 //
-//   1. Real openclaw.Dial → real WS handshake against fake gateway
-//   2. NewOpenclawBridgeWithDialer + Start → bridge subscribes bound sessions
-//   3. Bridge.OnOfficeMessage → real sessions.send frame delivered to gateway
-//   4. Gateway pushes session.message event → bridge routes to broker
-//   5. Outbound + inbound + delta + final all observable from the broker side
+//  1. Real openclaw.Dial → connect.challenge + device-authed connect + wrapped hello-ok
+//  2. NewOpenclawBridgeWithDialer + Start → bridge subscribes bound sessions
+//  3. Bridge.OnOfficeMessage → real sessions.send frame delivered to gateway
+//  4. Gateway pushes session.message event with assistant role → broker gets it
+//  5. Gateway pushes session.message with user role → broker is NOT echoed
 //
 // No mocks of the protocol layer. Real bytes flow over real sockets through
 // the real openclaw.Client.
@@ -31,12 +31,17 @@ func TestOpenclawBridgeFullPipeline_E2E(t *testing.T) {
 	gw := startFakeOpenclawGatewayE2E(t)
 	defer gw.Close()
 
+	identity, err := openclaw.LoadOrCreateDeviceIdentity(filepath.Join(t.TempDir(), "identity.json"))
+	if err != nil {
+		t.Fatalf("identity: %v", err)
+	}
+
 	broker := NewBroker()
 	bindings := []config.OpenclawBridgeBinding{
 		{SessionKey: "agent:e2e:demo", Slug: "openclaw-demo-e2e", DisplayName: "Demo"},
 	}
 	dialer := func(ctx context.Context) (openclawClient, error) {
-		return openclaw.Dial(ctx, openclaw.Config{URL: gw.URL(), Token: "test-token"})
+		return openclaw.Dial(ctx, openclaw.Config{URL: gw.URL(), Token: "test-token", Identity: identity})
 	}
 	bridge := NewOpenclawBridgeWithDialer(broker, nil, dialer, bindings)
 	if err := bridge.Start(context.Background()); err != nil {
@@ -60,20 +65,22 @@ func TestOpenclawBridgeFullPipeline_E2E(t *testing.T) {
 		return gw.lastSendForKey("agent:e2e:demo") == "hello agent"
 	}, "gateway never received hello agent")
 
-	// Inbound delta: gateway → bridge → AgentStream
-	gw.pushDelta("agent:e2e:demo", "thinking…")
-	waitForE2E(t, 2*time.Second, func() bool {
-		buf := broker.AgentStream("openclaw-demo-e2e")
-		return buf != nil && len(buf.recent()) > 0
-	}, "delta event never reached AgentStream")
+	// Inbound user echo: gateway pushes our own message back. Bridge MUST NOT
+	// re-post it (otherwise every outbound turn double-fires in #general).
+	beforeEchoes := countMessagesFrom(broker, "openclaw-demo-e2e", "hello agent")
+	gw.pushUserMessage("agent:e2e:demo", "hello agent")
+	time.Sleep(150 * time.Millisecond)
+	if got := countMessagesFrom(broker, "openclaw-demo-e2e", "hello agent"); got != beforeEchoes {
+		t.Fatalf("bridge re-posted a user-role echo; before=%d after=%d", beforeEchoes, got)
+	}
 
-	// Inbound final: gateway → bridge → broker message
+	// Inbound assistant reply: gateway → bridge → broker message.
 	wantContent := "hi from openclaw, tell Michael Scott we're back"
 	beforeCount := countMessagesFrom(broker, "openclaw-demo-e2e", wantContent)
-	gw.pushFinal("agent:e2e:demo", wantContent)
+	gw.pushAssistantMessage("agent:e2e:demo", wantContent)
 	waitForE2E(t, 2*time.Second, func() bool {
 		return countMessagesFrom(broker, "openclaw-demo-e2e", wantContent) > beforeCount
-	}, "final event never appeared as broker message")
+	}, "assistant event never appeared as broker message")
 }
 
 func countMessagesFrom(b *Broker, slug, contains string) int {
@@ -86,10 +93,13 @@ func countMessagesFrom(b *Broker, slug, contains string) int {
 	return n
 }
 
-// fakeOpenclawGatewayE2E implements the minimum OpenClaw Gateway protocol the
-// WUPHF bridge needs: hello-ok handshake, sessions.list, sessions.send,
-// sessions.messages.subscribe, sessions.history. Tests can push session.message
-// events into subscribed connections via pushFinal/pushDelta.
+// fakeOpenclawGatewayE2E implements the subset of OpenClaw Gateway protocol
+// the WUPHF bridge actually hits, matching the observed real-daemon shape:
+//
+//   - connect.challenge event pushed BEFORE reading client
+//   - wrapped res(hello-ok) as the connect response (protocol 3)
+//   - sessions.list uses "key" as the session identifier
+//   - session.message events use role + content parts (not state/content)
 type fakeOpenclawGatewayE2E struct {
 	srv          *httptest.Server
 	mu           sync.Mutex
@@ -135,7 +145,15 @@ func (g *fakeOpenclawGatewayE2E) Close() { g.srv.Close() }
 
 func (g *fakeOpenclawGatewayE2E) serve(fc *fakeOCGwConn) {
 	defer fc.c.Close()
-	// Expect connect.
+
+	// 1. Push connect.challenge first.
+	fc.write(map[string]any{
+		"type":    "event",
+		"event":   "connect.challenge",
+		"payload": map[string]any{"nonce": "e2e-nonce", "ts": time.Now().UnixMilli()},
+	})
+
+	// 2. Read connect.
 	_, raw, err := fc.c.ReadMessage()
 	if err != nil {
 		return
@@ -149,15 +167,24 @@ func (g *fakeOpenclawGatewayE2E) serve(fc *fakeOCGwConn) {
 	if req.Method != "connect" {
 		return
 	}
-	hello := map[string]any{
-		"type":     "hello-ok",
-		"protocol": 1,
-		"server":   map[string]any{"version": "fake", "connId": "fc-1"},
-		"features": map[string]any{"methods": []string{"sessions.list", "sessions.send", "sessions.messages.subscribe", "sessions.history"}, "events": []string{"session.message"}},
-		"snapshot": map[string]any{},
-		"policy":   map[string]any{"maxPayload": 1 << 20, "maxBufferedBytes": 1 << 20, "tickIntervalMs": 30000},
-	}
-	fc.write(hello)
+
+	// 3. Reply res(hello-ok) — wrapped.
+	fc.write(map[string]any{
+		"type": "res",
+		"id":   req.ID,
+		"ok":   true,
+		"payload": map[string]any{
+			"type":     "hello-ok",
+			"protocol": 3,
+			"server":   map[string]any{"version": "fake", "connId": "fc-1"},
+			"features": map[string]any{
+				"methods": []string{"sessions.list", "sessions.send", "sessions.messages.subscribe", "sessions.messages.unsubscribe"},
+				"events":  []string{"session.message", "sessions.changed"},
+			},
+			"snapshot": map[string]any{},
+			"policy":   map[string]any{"maxPayload": 1 << 20, "maxBufferedBytes": 1 << 20, "tickIntervalMs": 30000},
+		},
+	})
 
 	for {
 		_, raw, err := fc.c.ReadMessage()
@@ -176,8 +203,8 @@ func (g *fakeOpenclawGatewayE2E) serve(fc *fakeOCGwConn) {
 		switch r.Method {
 		case "sessions.list":
 			g.respond(fc, r.ID, true, map[string]any{"sessions": []any{
-				map[string]any{"sessionKey": "agent:e2e:demo", "label": "Demo", "displayName": "Demo Agent"},
-			}, "path": "/tmp/fake"}, nil)
+				map[string]any{"key": "agent:e2e:demo", "label": "Demo", "displayName": "Demo Agent", "kind": "direct"},
+			}, "path": "/tmp/fake", "count": 1}, nil)
 		case "sessions.send":
 			var p struct {
 				Key     string `json:"key"`
@@ -187,7 +214,7 @@ func (g *fakeOpenclawGatewayE2E) serve(fc *fakeOCGwConn) {
 			g.mu.Lock()
 			g.sentMessages[p.Key] = p.Message
 			g.mu.Unlock()
-			g.respond(fc, r.ID, true, map[string]any{"ok": true}, nil)
+			g.respond(fc, r.ID, true, map[string]any{"runId": "run-" + r.ID, "status": "started", "messageSeq": 1}, nil)
 		case "sessions.messages.subscribe":
 			var p struct {
 				Key string `json:"key"`
@@ -198,8 +225,6 @@ func (g *fakeOpenclawGatewayE2E) serve(fc *fakeOCGwConn) {
 			g.subsCount[p.Key]++
 			g.mu.Unlock()
 			g.respond(fc, r.ID, true, map[string]any{"ok": true}, nil)
-		case "sessions.history":
-			g.respond(fc, r.ID, true, map[string]any{"messages": []any{}}, nil)
 		default:
 			g.respond(fc, r.ID, false, nil, map[string]any{"code": "UNKNOWN", "message": "method not implemented in fake"})
 		}
@@ -235,15 +260,27 @@ func (g *fakeOpenclawGatewayE2E) lastSendForKey(key string) string {
 	return g.sentMessages[key]
 }
 
-func (g *fakeOpenclawGatewayE2E) pushFinal(sessionKey, content string) {
-	g.pushEvent(sessionKey, "final", content)
+// pushAssistantMessage emits the real-daemon shape for an agent reply: role
+// "assistant" with content as an array of {type,text} parts.
+func (g *fakeOpenclawGatewayE2E) pushAssistantMessage(sessionKey, text string) {
+	g.pushEvent(sessionKey, map[string]any{
+		"role":      "assistant",
+		"content":   []any{map[string]any{"type": "text", "text": text}},
+		"timestamp": time.Now().UnixMilli(),
+	})
 }
 
-func (g *fakeOpenclawGatewayE2E) pushDelta(sessionKey, content string) {
-	g.pushEvent(sessionKey, "delta", content)
+// pushUserMessage emits the shape the server uses to echo our own outbound
+// messages — a user role with a plain string content.
+func (g *fakeOpenclawGatewayE2E) pushUserMessage(sessionKey, text string) {
+	g.pushEvent(sessionKey, map[string]any{
+		"role":      "user",
+		"content":   text,
+		"timestamp": time.Now().UnixMilli(),
+	})
 }
 
-func (g *fakeOpenclawGatewayE2E) pushEvent(sessionKey, state, content string) {
+func (g *fakeOpenclawGatewayE2E) pushEvent(sessionKey string, message map[string]any) {
 	g.mu.Lock()
 	g.seq++
 	subs := g.subscribed[sessionKey]
@@ -256,7 +293,7 @@ func (g *fakeOpenclawGatewayE2E) pushEvent(sessionKey, state, content string) {
 		"payload": map[string]any{
 			"sessionKey": sessionKey,
 			"messageSeq": seq,
-			"message":    map[string]any{"state": state, "content": content},
+			"message":    message,
 		},
 	}
 	for _, fc := range subs {

--- a/internal/team/openclaw_test.go
+++ b/internal/team/openclaw_test.go
@@ -19,7 +19,6 @@ type fakeOCClient struct {
 	events       chan openclaw.ClientEvent
 	sendErr      error
 	nextSendErrs []error // drained FIFO if non-empty
-	historyByKey map[string][]openclaw.HistoricMessage
 	closed       bool
 }
 
@@ -31,16 +30,21 @@ func (f *fakeOCClient) SessionsList(ctx context.Context, _ openclaw.SessionsList
 	return nil, nil
 }
 
-func (f *fakeOCClient) SessionsSend(ctx context.Context, key, msg, idem string) error {
+func (f *fakeOCClient) SessionsSend(ctx context.Context, key, msg, idem string) (*openclaw.SessionsSendResult, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.sentKeys = append(f.sentKeys, key+"|"+msg+"|"+idem)
 	if len(f.nextSendErrs) > 0 {
 		err := f.nextSendErrs[0]
 		f.nextSendErrs = f.nextSendErrs[1:]
-		return err
+		if err != nil {
+			return nil, err
+		}
 	}
-	return f.sendErr
+	if f.sendErr != nil {
+		return nil, f.sendErr
+	}
+	return &openclaw.SessionsSendResult{RunID: "run-" + idem, Status: "started"}, nil
 }
 
 func (f *fakeOCClient) SessionsMessagesSubscribe(ctx context.Context, key string) error {
@@ -52,12 +56,6 @@ func (f *fakeOCClient) SessionsMessagesSubscribe(ctx context.Context, key string
 
 func (f *fakeOCClient) SessionsMessagesUnsubscribe(ctx context.Context, key string) error {
 	return nil
-}
-
-func (f *fakeOCClient) SessionsHistory(ctx context.Context, key string, sinceSeq int64) ([]openclaw.HistoricMessage, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.historyByKey[key], nil
 }
 
 func (f *fakeOCClient) Events() <-chan openclaw.ClientEvent { return f.events }
@@ -84,17 +82,19 @@ func TestBridgeStartSubscribesAllBindings(t *testing.T) {
 	if err := b.Start(ctx); err != nil {
 		t.Fatalf("Start: %v", err)
 	}
-	// Give the subscribe loop a moment.
 	time.Sleep(50 * time.Millisecond)
 	fake.mu.Lock()
 	defer fake.mu.Unlock()
 	if len(fake.subscribed) != 2 {
 		t.Fatalf("expected 2 subscriptions, got %d: %v", len(fake.subscribed), fake.subscribed)
 	}
-	_ = errors.New
 }
 
-func TestHandleClientEventSplitsDeltaAndFinal(t *testing.T) {
+// TestHandleClientEventForwardsAssistantMessage confirms an assistant reply
+// emitted on sessions.messages.subscribe is posted into #general under the
+// bridged slug's name. The real OpenClaw daemon sends every transcript update
+// as a single session.message event — there is no delta/final split.
+func TestHandleClientEventForwardsAssistantMessage(t *testing.T) {
 	fake := newFakeOC()
 	broker := NewBroker()
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k", Slug: "openclaw-a", DisplayName: "A"}}
@@ -106,46 +106,64 @@ func TestHandleClientEventSplitsDeltaAndFinal(t *testing.T) {
 	}
 	defer b.Stop()
 
-	// Push a delta event.
-	seq := int64(1)
+	seq := int64(2)
 	fake.events <- openclaw.ClientEvent{
 		Kind: openclaw.EventKindMessage,
 		SessionMessage: &openclaw.SessionMessageEvent{
-			SessionKey:   "k",
-			MessageSeq:   &seq,
-			MessageState: "delta",
-			MessageText:  "partial chunk",
-		},
-	}
-	// Give event loop a tick.
-	time.Sleep(30 * time.Millisecond)
-	// agentStreamBuffer has an unexported recent() usable from within internal/team tests.
-	if buf := broker.AgentStream("openclaw-a"); buf == nil || len(buf.recent()) == 0 {
-		t.Fatalf("expected delta in AgentStream for openclaw-a")
-	}
-
-	// Push a final event.
-	seq2 := int64(2)
-	fake.events <- openclaw.ClientEvent{
-		Kind: openclaw.EventKindMessage,
-		SessionMessage: &openclaw.SessionMessageEvent{
-			SessionKey:   "k",
-			MessageSeq:   &seq2,
-			MessageState: "final",
-			MessageText:  "complete response",
+			SessionKey:  "k",
+			MessageSeq:  &seq,
+			Role:        "assistant",
+			MessageText: "complete response",
 		},
 	}
 	time.Sleep(30 * time.Millisecond)
-	msgs := broker.AllMessages()
 	found := false
-	for _, m := range msgs {
+	for _, m := range broker.AllMessages() {
 		if m.From == "openclaw-a" && m.Content == "complete response" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Fatalf("expected final message posted to broker from openclaw-a; got %+v", msgs)
+		t.Fatalf("expected assistant message posted to broker from openclaw-a; got %+v", broker.AllMessages())
+	}
+}
+
+// TestHandleClientEventSkipsUserRole confirms the bridge does NOT re-post
+// user-role echoes — otherwise every message the user sends via OnOfficeMessage
+// would boomerang back into #general as though the bridged agent had spoken.
+//
+// We snapshot the broker state before emitting the event and assert the delta
+// is zero, not that openclaw-a never appears, because NewBroker() rehydrates
+// from persisted state that may contain messages from prior runs or tests.
+func TestHandleClientEventSkipsUserRole(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	fake := newFakeOC()
+	broker := NewBroker()
+	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k", Slug: "openclaw-a"}}
+	b := NewOpenclawBridge(broker, fake, bindings)
+	_ = b.Start(context.Background())
+	defer b.Stop()
+
+	before := len(broker.AllMessages())
+
+	seq := int64(0)
+	fake.events <- openclaw.ClientEvent{
+		Kind: openclaw.EventKindMessage,
+		SessionMessage: &openclaw.SessionMessageEvent{
+			SessionKey:  "k",
+			MessageSeq:  &seq,
+			Role:        "user",
+			MessageText: "hello from office",
+		},
+	}
+	time.Sleep(60 * time.Millisecond)
+
+	after := broker.AllMessages()
+	if len(after) != before {
+		for _, m := range after[before:] {
+			t.Fatalf("bridge must not echo user-role messages; got %+v", m)
+		}
 	}
 }
 
@@ -171,7 +189,6 @@ func TestOnOfficeMessageRetriesTransient(t *testing.T) {
 	fake.nextSendErrs = []error{errors.New("transient 1"), errors.New("transient 2")} // first two fail, third succeeds
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k", Slug: "openclaw-a"}}
 	b := NewOpenclawBridge(NewBroker(), fake, bindings)
-	// Shrink retry delays for the test.
 	b.SetRetryDelaysForTest([]time.Duration{10 * time.Millisecond, 10 * time.Millisecond})
 	_ = b.Start(context.Background())
 	defer b.Stop()
@@ -185,7 +202,6 @@ func TestOnOfficeMessageRetriesTransient(t *testing.T) {
 		t.Fatalf("expected 3 send attempts, got %d: %v", len(fake.sentKeys), fake.sentKeys)
 	}
 	// All three attempts MUST reuse the same idempotency key (last field).
-	// Each entry is "key|message|idempotencyKey".
 	prev := ""
 	for _, entry := range fake.sentKeys {
 		parts := strings.Split(entry, "|")
@@ -202,43 +218,40 @@ func TestOnOfficeMessageRetriesTransient(t *testing.T) {
 	}
 }
 
-func TestGapEventTriggersHistoryReplay(t *testing.T) {
+// TestGapEventPostsSystemNotice replaces the prior catch-up-replay test. The
+// real OpenClaw daemon does not expose sessions.history, so the bridge can't
+// reconstruct missed messages — it now surfaces a system notice so a human
+// can re-prompt.
+func TestGapEventPostsSystemNotice(t *testing.T) {
 	fake := newFakeOC()
-	fake.historyByKey = map[string][]openclaw.HistoricMessage{
-		"k-gaptest": {
-			{SessionKey: "k-gaptest", Message: []byte(`{"state":"final","content":"missed 1"}`)},
-			{SessionKey: "k-gaptest", Message: []byte(`{"state":"final","content":"missed 2"}`)},
-		},
-	}
 	broker := NewBroker()
-	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k-gaptest", Slug: "openclaw-gaptest"}}
+	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k-gap", Slug: "openclaw-gap"}}
 	b := NewOpenclawBridge(broker, fake, bindings)
 	_ = b.Start(context.Background())
 	defer b.Stop()
 
-	// The broker may have persisted messages from prior runs. Snapshot the catch-up
-	// count BEFORE pushing the gap event and count only the delta.
-	before := countCatchups(broker, "openclaw-gaptest")
+	before := 0
+	for _, m := range broker.AllMessages() {
+		if m.From == "system" && strings.Contains(m.Content, "daemon event gap") {
+			before++
+		}
+	}
 
 	fake.events <- openclaw.ClientEvent{
 		Kind: openclaw.EventKindGap,
-		Gap:  &openclaw.GapEvent{SessionKey: "k-gaptest", FromSeq: 5, ToSeq: 7},
+		Gap:  &openclaw.GapEvent{SessionKey: "k-gap", FromSeq: 5, ToSeq: 7},
 	}
 	time.Sleep(100 * time.Millisecond)
-	delta := countCatchups(broker, "openclaw-gaptest") - before
-	if delta != 2 {
-		t.Fatalf("expected 2 NEW catch-up messages, got %d (broker state may be polluted)", delta)
-	}
-}
 
-func countCatchups(broker *Broker, slug string) int {
-	n := 0
+	after := 0
 	for _, m := range broker.AllMessages() {
-		if m.From == slug && strings.Contains(m.Content, "[catch-up]") {
-			n++
+		if m.From == "system" && strings.Contains(m.Content, "daemon event gap") {
+			after++
 		}
 	}
-	return n
+	if after-before != 1 {
+		t.Fatalf("expected exactly 1 new gap notice, got %d (before=%d after=%d)", after-before, before, after)
+	}
 }
 
 func TestReconnectOnClientClose(t *testing.T) {
@@ -260,16 +273,13 @@ func TestReconnectOnClientClose(t *testing.T) {
 	_ = b.Start(context.Background())
 	defer b.Stop()
 
-	// Let supervise dial + subscribe the first client.
 	time.Sleep(40 * time.Millisecond)
 	mu.Lock()
 	first := clients[0]
 	mu.Unlock()
 
-	// Force the first client's event channel to close, simulating a drop.
 	_ = first.Close()
 
-	// Allow reconnect.
 	time.Sleep(200 * time.Millisecond)
 
 	mu.Lock()
@@ -286,13 +296,9 @@ func TestReconnectOnClientClose(t *testing.T) {
 	}
 }
 
-// TestStartOpenclawBridgeFromConfigNoBindings confirms the bootstrap is a
-// no-op when config has no bridges — the integration is opt-in and must not
-// dial the gateway or spin up a supervise goroutine.
 func TestStartOpenclawBridgeFromConfigNoBindings(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
-	// No config file written; Load() will return zero-value Config.
 	broker := NewBroker()
 	bridge, err := StartOpenclawBridgeFromConfig(context.Background(), broker)
 	if err != nil {
@@ -303,9 +309,6 @@ func TestStartOpenclawBridgeFromConfigNoBindings(t *testing.T) {
 	}
 }
 
-// TestStartOpenclawBridgeFromConfigWithBindings confirms the bootstrap builds
-// and starts a supervised bridge when bindings are present. We inject a fake
-// dialer so this test never touches the real gateway.
 func TestStartOpenclawBridgeFromConfigWithBindings(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
@@ -332,7 +335,6 @@ func TestStartOpenclawBridgeFromConfigWithBindings(t *testing.T) {
 	}
 	defer bridge.Stop()
 
-	// Give supervise a tick to dial + subscribe.
 	time.Sleep(80 * time.Millisecond)
 	fake.mu.Lock()
 	subs := len(fake.subscribed)
@@ -348,9 +350,6 @@ func TestStartOpenclawBridgeFromConfigWithBindings(t *testing.T) {
 	}
 }
 
-// TestRouteOpenclawMentionsLoopForwardsHumanMention confirms the mention
-// dispatcher invokes OnOfficeMessage when a human posts an @mention that
-// matches a bridged slug — the missing runtime link this PR closes.
 func TestRouteOpenclawMentionsLoopForwardsHumanMention(t *testing.T) {
 	fake := newFakeOC()
 	broker := NewBroker()
@@ -363,12 +362,9 @@ func TestRouteOpenclawMentionsLoopForwardsHumanMention(t *testing.T) {
 	}
 	defer bridge.Stop()
 
-	// Kick off the mention-routing loop.
 	go routeOpenclawMentionsLoop(ctx, broker, bridge)
-	// Let the subscriber register before we publish.
 	time.Sleep(20 * time.Millisecond)
 
-	// Simulate a human posting into #general with the bridged slug tagged.
 	broker.mu.Lock()
 	broker.counter++
 	msg := channelMessage{
@@ -382,7 +378,6 @@ func TestRouteOpenclawMentionsLoopForwardsHumanMention(t *testing.T) {
 	broker.appendMessageLocked(msg)
 	broker.mu.Unlock()
 
-	// Allow the subscriber + OnOfficeMessage goroutine to run.
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		fake.mu.Lock()
@@ -404,10 +399,6 @@ func TestRouteOpenclawMentionsLoopForwardsHumanMention(t *testing.T) {
 	}
 }
 
-// TestRouteOpenclawMentionsLoopIgnoresUnrelated confirms the dispatcher is
-// narrow: it does not forward system messages, agent-to-agent chatter, or
-// mentions of non-bridged slugs. Without this the bridge would double-post
-// every office message.
 func TestRouteOpenclawMentionsLoopIgnoresUnrelated(t *testing.T) {
 	fake := newFakeOC()
 	broker := NewBroker()
@@ -421,8 +412,6 @@ func TestRouteOpenclawMentionsLoopIgnoresUnrelated(t *testing.T) {
 	go routeOpenclawMentionsLoop(ctx, broker, bridge)
 	time.Sleep(20 * time.Millisecond)
 
-	// Three negatives: system author, agent author, and mention of
-	// a non-bridged slug. None should reach the gateway.
 	cases := []channelMessage{
 		{ID: "msg-neg-1", From: "system", Channel: "general", Content: "sys", Tagged: []string{"openclaw-only"}},
 		{ID: "msg-neg-2", From: "ceo", Channel: "general", Content: "agent", Tagged: []string{"openclaw-only"}},
@@ -444,10 +433,6 @@ func TestRouteOpenclawMentionsLoopIgnoresUnrelated(t *testing.T) {
 	}
 }
 
-// TestSuperviseOfflineNoticeDeduped drives the supervise loop into
-// breaker-open state and confirms the "openclaw gateway offline" system
-// message is posted at most once per episode — not every 5-minute tick
-// (reviewer Important issue 5).
 func TestSuperviseOfflineNoticeDeduped(t *testing.T) {
 	broker := NewBroker()
 	dialer := func(ctx context.Context) (openclawClient, error) {
@@ -455,16 +440,12 @@ func TestSuperviseOfflineNoticeDeduped(t *testing.T) {
 	}
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k", Slug: "openclaw-dead"}}
 	bridge := NewOpenclawBridgeWithDialer(broker, nil, dialer, bindings)
-	// Fast-fail backoff + low threshold so the breaker trips quickly.
 	bridge.backoff = NewBridgeBackoff(1*time.Millisecond, 2*time.Millisecond)
 	bridge.breaker = NewCircuitBreaker(2, 5*time.Minute)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	_ = bridge.Start(ctx)
 
-	// Give supervise time to fail twice (trips breaker) and iterate the
-	// breaker-open branch several times. Without the noticedOffline guard
-	// each iteration would post another system message.
 	time.Sleep(200 * time.Millisecond)
 	cancel()
 	bridge.Stop()


### PR DESCRIPTION
## Summary

The OpenClaw bridge shipped in #73 could not talk to a real OpenClaw daemon. Verified against OpenClaw 2026.4.14 on loopback, four protocol mismatches surface immediately. This PR fixes all of them and proves the fix end-to-end against a running daemon.

**Bugs fixed:**

1. **Token-only auth gets ZERO scopes.** The gateway wipes all requested scopes for token-authed clients without a device identity (`server.impl:21832`). Every session method errored out `missing scope: operator.read`. We now generate an Ed25519 keypair (persisted at `~/.wuphf/openclaw/identity.json`, 0600), sign a v3 pipe-delimited payload bound to the server-issued nonce, and present as a device — the gateway auto-approves silently on loopback.
2. **Protocol version.** Sent `minProtocol:1, maxProtocol:2` → server hard-rejects (`server.impl:22163` requires 3). Bumped to 3.
3. **`client.id` / `client.mode` are constant enums.** Free-form strings fail JSON schema validation. Hardcoded to `gateway-client` / `backend` (matches OpenClaw's own default client at `client-CJI3Hi9b.js:518`).
4. **`hello-ok` is wrapped in a `res` frame.** Real server sends `{type:"res", id, ok:true, payload:{type:"hello-ok", protocol:3, ...}}`, not a bare `{type:"hello-ok"}`. Rewrote `doHandshake` to read the wrapped form.

Also discovered and fixed in the process:
- `SessionRow.SessionKey` → `.Key` (the real daemon field is `key`)
- Removed `SessionsHistory` — method doesn't exist on the real daemon
- Removed the delta/streaming code path — `sessions.messages.subscribe` only emits finalized transcript entries; there is no streaming channel
- Bridge now filters role=user echoes (the daemon re-pushes our own outbound messages), forwards only role=assistant

## Real-daemon receipts

`OPENCLAW_TOKEN=… go run ./cmd/wuphf-oc-probe` against a local `openclaw daemon` listening on `ws://127.0.0.1:18789`:

```
deviceId: 290fc10f07b9387c ...
dialed + handshake ok
found 1 session(s)
first session: key=agent:main:main displayName="" kind=direct
subscribed
sent: runId=probe-1776255224647274000 status=started messageSeq=2
  EVT message role="user" text="hello from wuphf Go probe"
  EVT message role="assistant" text="⚠️ Agent failed before reply: No API key found for provider ..."
PASS
```

The assistant's text is an OpenClaw config error (no OpenAI key), not a bridge error — that's a valid round-trip session.message event, proving the whole pipeline.

## Test plan

- [x] `go test -race ./...` — all 21 packages pass
- [x] `go run ./cmd/wuphf-oc-probe` against real daemon — PASS (see receipts above)
- [x] E2E bridge test updated to match real protocol (challenge → wrapped hello-ok → role-aware events)
- [x] Unit tests for DeviceID stability, signature round-trip, wire format of BuildDeviceAuthPayloadV3

🤖 Generated with [Claude Code](https://claude.com/claude-code)