### PR TITLE
[codex] tag agent messages with token usage

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -152,19 +152,28 @@ type brokerReaction struct {
 	From  string `json:"from"`
 }
 
+type brokerMessageUsage struct {
+	InputTokens         int `json:"input_tokens,omitempty"`
+	OutputTokens        int `json:"output_tokens,omitempty"`
+	CacheReadTokens     int `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+	TotalTokens         int `json:"total_tokens,omitempty"`
+}
+
 type brokerMessage struct {
-	ID          string           `json:"id"`
-	From        string           `json:"from"`
-	Kind        string           `json:"kind,omitempty"`
-	Source      string           `json:"source,omitempty"`
-	SourceLabel string           `json:"source_label,omitempty"`
-	EventID     string           `json:"event_id,omitempty"`
-	Title       string           `json:"title,omitempty"`
-	Content     string           `json:"content"`
-	Tagged      []string         `json:"tagged"`
-	ReplyTo     string           `json:"reply_to"`
-	Timestamp   string           `json:"timestamp"`
-	Reactions   []brokerReaction `json:"reactions,omitempty"`
+	ID          string              `json:"id"`
+	From        string              `json:"from"`
+	Kind        string              `json:"kind,omitempty"`
+	Source      string              `json:"source,omitempty"`
+	SourceLabel string              `json:"source_label,omitempty"`
+	EventID     string              `json:"event_id,omitempty"`
+	Title       string              `json:"title,omitempty"`
+	Content     string              `json:"content"`
+	Tagged      []string            `json:"tagged"`
+	ReplyTo     string              `json:"reply_to"`
+	Timestamp   string              `json:"timestamp"`
+	Usage       *brokerMessageUsage `json:"usage,omitempty"`
+	Reactions   []brokerReaction    `json:"reactions,omitempty"`
 }
 
 type channelMember struct {

--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -68,6 +68,27 @@ func renderReactions(reactions []brokerReaction) string {
 	return strings.Join(parts, " ")
 }
 
+func messageUsageTotal(usage *brokerMessageUsage) int {
+	if usage == nil {
+		return 0
+	}
+	if usage.TotalTokens > 0 {
+		return usage.TotalTokens
+	}
+	return usage.InputTokens + usage.OutputTokens + usage.CacheReadTokens + usage.CacheCreationTokens
+}
+
+func renderMessageUsageMeta(usage *brokerMessageUsage, accent string) string {
+	total := messageUsageTotal(usage)
+	if total == 0 {
+		return ""
+	}
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color(accent)).
+		Bold(true).
+		Render(formatTokenCount(total))
+}
+
 func buildOneOnOneMessageLines(messages []brokerMessage, expanded map[string]bool, contentWidth int, agentName string, unreadAnchorID string, unreadCount int) []renderedLine {
 	if len(messages) == 0 {
 		mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -2462,6 +2462,26 @@ func TestChannelViewShowsMessageIDInMeta(t *testing.T) {
 	}
 }
 
+func TestChannelViewShowsPerMessageTokenUsage(t *testing.T) {
+	m := newChannelModel(false)
+	m.width = 120
+	m.height = 30
+	m.messages = []brokerMessage{
+		{
+			ID:        "msg-token-1",
+			From:      "ceo",
+			Content:   "We should choose a sharper wedge.",
+			Timestamp: "2026-03-24T10:00:00Z",
+			Usage:     &brokerMessageUsage{TotalTokens: 1234},
+		},
+	}
+
+	view := stripANSI(m.View())
+	if !strings.Contains(view, "1.2k tok") {
+		t.Fatalf("expected per-message token usage in view, got %q", view)
+	}
+}
+
 func TestChannelViewShowsUsageTotals(t *testing.T) {
 	m := newChannelModel(false)
 	m.width = 120

--- a/cmd/wuphf/channel_thread.go
+++ b/cmd/wuphf/channel_thread.go
@@ -211,6 +211,9 @@ func renderThreadReply(reply threadedMessage, width int) []string {
 	}
 
 	meta := roleLabel(msg.From)
+	if usageMeta := renderMessageUsageMeta(msg.Usage, color); usageMeta != "" {
+		meta += " · " + usageMeta
+	}
 	if reply.ParentLabel != "" {
 		meta += " · reply to " + reply.ParentLabel
 	}
@@ -268,6 +271,9 @@ func renderThreadMessage(msg brokerMessage, width int, isParent bool) []string {
 	var lines []string
 	lines = append(lines, fmt.Sprintf("  %s %s%s%s",
 		agentAvatar(msg.From), nameRendered, strings.Repeat(" ", gap), tsRendered))
+	if usageMeta := renderMessageUsageMeta(msg.Usage, color); usageMeta != "" {
+		lines = append(lines, "  "+usageMeta)
+	}
 
 	// Render content
 	for _, paragraph := range strings.Split(msg.Content, "\n") {

--- a/cmd/wuphf/channel_window.go
+++ b/cmd/wuphf/channel_window.go
@@ -177,6 +177,9 @@ func renderOfficeMessageBlock(tm threadedMessage, contentWidth int, unreadAnchor
 	if mood != "" {
 		meta += " · " + mood
 	}
+	if usageMeta := renderMessageUsageMeta(msg.Usage, color); usageMeta != "" {
+		meta += " · " + usageMeta
+	}
 	if tm.Depth > 0 {
 		meta += fmt.Sprintf(" · thread reply to %s", tm.ParentLabel)
 	}

--- a/internal/provider/codex_stream.go
+++ b/internal/provider/codex_stream.go
@@ -24,6 +24,7 @@ type CodexStreamResult struct {
 	FinalMessage  string
 	LastPlainLine string
 	LastError     string
+	Usage         ClaudeUsage
 }
 
 type codexJSONEvent struct {
@@ -107,6 +108,9 @@ func ReadCodexJSONStream(r io.Reader, onEvent func(CodexStreamEvent)) (CodexStre
 
 		state.consumeToolEvent(event, onEvent)
 		state.consumeTextDelta(event, onEvent)
+		if usage, ok := extractCodexUsage(line); ok {
+			result.Usage = usage
+		}
 
 		if text := strings.TrimSpace(extractCodexCompletedMessage(event)); text != "" {
 			if _, seen := state.completedMessageSet[text]; !seen {
@@ -261,6 +265,82 @@ func extractCodexTextFromItem(item codexJSONItem) string {
 		}
 	}
 	return strings.TrimSpace(strings.Join(parts, "\n"))
+}
+
+func extractCodexUsage(line string) (ClaudeUsage, bool) {
+	var raw map[string]any
+	if err := json.Unmarshal([]byte(line), &raw); err != nil {
+		return ClaudeUsage{}, false
+	}
+
+	usageMap, ok := nestedUsageMap(raw)
+	if !ok {
+		return ClaudeUsage{}, false
+	}
+
+	usage := ClaudeUsage{
+		InputTokens:         usageInt(usageMap["input_tokens"]),
+		OutputTokens:        usageInt(usageMap["output_tokens"]),
+		CacheReadTokens:     usageInt(firstPresent(usageMap, "cached_input_tokens", "cache_read_input_tokens", "cache_read_tokens")),
+		CacheCreationTokens: usageInt(firstPresent(usageMap, "cache_creation_input_tokens", "cache_creation_tokens")),
+		CostUSD:             usageFloat(firstPresent(raw, "total_cost_usd", "cost_usd")),
+	}
+	total := usage.InputTokens + usage.OutputTokens + usage.CacheReadTokens + usage.CacheCreationTokens
+	return usage, total > 0 || usage.CostUSD > 0
+}
+
+func nestedUsageMap(raw map[string]any) (map[string]any, bool) {
+	if usage, ok := raw["usage"].(map[string]any); ok {
+		return usage, true
+	}
+	if response, ok := raw["response"].(map[string]any); ok {
+		if usage, ok := response["usage"].(map[string]any); ok {
+			return usage, true
+		}
+	}
+	if data, ok := raw["data"].(map[string]any); ok {
+		if usage, ok := data["usage"].(map[string]any); ok {
+			return usage, true
+		}
+	}
+	return nil, false
+}
+
+func firstPresent(raw map[string]any, keys ...string) any {
+	for _, key := range keys {
+		if value, ok := raw[key]; ok {
+			return value
+		}
+	}
+	return nil
+}
+
+func usageInt(value any) int {
+	switch v := value.(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case json.Number:
+		n, _ := v.Int64()
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+func usageFloat(value any) float64 {
+	switch v := value.(type) {
+	case float64:
+		return v
+	case json.Number:
+		n, _ := v.Float64()
+		return n
+	default:
+		return 0
+	}
 }
 
 func extractCodexError(event codexJSONEvent) string {

--- a/internal/provider/codex_stream_test.go
+++ b/internal/provider/codex_stream_test.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadCodexJSONStreamParsesUsage(t *testing.T) {
+	raw := strings.Join([]string{
+		`{"type":"response.output_text.delta","delta":"Shipped "}`,
+		`{"type":"response.output_text.delta","delta":"it."}`,
+		`{"type":"response.output_item.done","item":{"type":"message","content":[{"type":"output_text","text":"Shipped it."}]}}`,
+		`{"type":"response.completed","response":{"usage":{"input_tokens":120,"output_tokens":45,"cached_input_tokens":30,"cache_creation_input_tokens":10}}}`,
+	}, "\n")
+
+	result, err := ReadCodexJSONStream(strings.NewReader(raw), nil)
+	if err != nil {
+		t.Fatalf("ReadCodexJSONStream: %v", err)
+	}
+	if result.FinalMessage != "Shipped it." {
+		t.Fatalf("FinalMessage = %q, want %q", result.FinalMessage, "Shipped it.")
+	}
+	if result.Usage.InputTokens != 120 || result.Usage.OutputTokens != 45 {
+		t.Fatalf("unexpected usage counts: %+v", result.Usage)
+	}
+	if result.Usage.CacheReadTokens != 30 || result.Usage.CacheCreationTokens != 10 {
+		t.Fatalf("unexpected cache usage: %+v", result.Usage)
+	}
+}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -103,7 +103,16 @@ type channelMessage struct {
 	Tagged      []string          `json:"tagged"`
 	ReplyTo     string            `json:"reply_to,omitempty"`
 	Timestamp   string            `json:"timestamp"`
+	Usage       *messageUsage     `json:"usage,omitempty"`
 	Reactions   []messageReaction `json:"reactions,omitempty"`
+}
+
+type messageUsage struct {
+	InputTokens         int `json:"input_tokens,omitempty"`
+	OutputTokens        int `json:"output_tokens,omitempty"`
+	CacheReadTokens     int `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+	TotalTokens         int `json:"total_tokens,omitempty"`
 }
 
 type interviewOption struct {
@@ -427,11 +436,11 @@ type Broker struct {
 	agentStreams        map[string]*agentStreamBuffer
 	mu                  sync.Mutex
 	server              *http.Server
-	token               string         // shared secret for authenticating requests
-	addr                string         // actual listen address (useful when port=0)
-	webUIOrigins        []string       // allowed CORS origins for web UI (set by ServeWebUI)
-	runtimeProvider     string         // "codex" or "claude" — set by launcher
-	packSlug            string         // active agent pack slug ("founding-team", "revops", ...) — set by launcher
+	token               string   // shared secret for authenticating requests
+	addr                string   // actual listen address (useful when port=0)
+	webUIOrigins        []string // allowed CORS origins for web UI (set by ServeWebUI)
+	runtimeProvider     string   // "codex" or "claude" — set by launcher
+	packSlug            string   // active agent pack slug ("founding-team", "revops", ...) — set by launcher
 	generateMemberFn    func(prompt string) (generatedMemberTemplate, error)
 	generateChannelFn   func(prompt string) (generatedChannelTemplate, error)
 	policies            []officePolicy // active office operating rules
@@ -4277,6 +4286,8 @@ type usageEvent struct {
 	CostUsd             float64
 }
 
+const messageUsageAttachMaxAge = 15 * time.Minute
+
 func (b *Broker) recordUsageLocked(event usageEvent) {
 	if b.usage.Agents == nil {
 		b.usage.Agents = make(map[string]usageTotals)
@@ -4295,6 +4306,7 @@ func (b *Broker) recordUsageLocked(event usageEvent) {
 	total := b.usage.Total
 	applyUsageEvent(&total, event)
 	b.usage.Total = total
+	b.attachUsageToRecentMessagesLocked(event)
 }
 
 func applyUsageEvent(dst *usageTotals, event usageEvent) {
@@ -4305,6 +4317,68 @@ func applyUsageEvent(dst *usageTotals, event usageEvent) {
 	dst.TotalTokens += event.InputTokens + event.OutputTokens + event.CacheReadTokens + event.CacheCreationTokens
 	dst.CostUsd += event.CostUsd
 	dst.Requests++
+}
+
+func usageEventToMessageUsage(event usageEvent) *messageUsage {
+	total := event.InputTokens + event.OutputTokens + event.CacheReadTokens + event.CacheCreationTokens
+	if total == 0 {
+		return nil
+	}
+	return &messageUsage{
+		InputTokens:         event.InputTokens,
+		OutputTokens:        event.OutputTokens,
+		CacheReadTokens:     event.CacheReadTokens,
+		CacheCreationTokens: event.CacheCreationTokens,
+		TotalTokens:         total,
+	}
+}
+
+func cloneMessageUsage(src *messageUsage) *messageUsage {
+	if src == nil {
+		return nil
+	}
+	cp := *src
+	return &cp
+}
+
+func messageIsWithinUsageAttachWindow(timestamp string, now time.Time) bool {
+	ts := strings.TrimSpace(timestamp)
+	if ts == "" {
+		return true
+	}
+	parsed, err := time.Parse(time.RFC3339, ts)
+	if err != nil {
+		parsed, err = time.Parse(time.RFC3339Nano, ts)
+		if err != nil {
+			return true
+		}
+	}
+	return now.Sub(parsed) <= messageUsageAttachMaxAge
+}
+
+func (b *Broker) attachUsageToRecentMessagesLocked(event usageEvent) {
+	usage := usageEventToMessageUsage(event)
+	if usage == nil {
+		return
+	}
+	slug := strings.TrimSpace(event.AgentSlug)
+	if slug == "" {
+		return
+	}
+	now := time.Now().UTC()
+	for i := len(b.messages) - 1; i >= 0; i-- {
+		msg := &b.messages[i]
+		if strings.TrimSpace(msg.From) != slug {
+			continue
+		}
+		if msg.Usage != nil {
+			break
+		}
+		if !messageIsWithinUsageAttachWindow(msg.Timestamp, now) {
+			break
+		}
+		msg.Usage = cloneMessageUsage(usage)
+	}
 }
 
 // RecordAgentUsage records token usage from a Claude stream result for a given agent.
@@ -6362,16 +6436,30 @@ func FormatChannelView(messages []channelMessage) string {
 			continue
 		}
 		if strings.HasPrefix(m.Content, "[STATUS]") {
-			sb.WriteString(fmt.Sprintf("  %s  @%s %s\n", ts, prefix, m.Content))
+			sb.WriteString(fmt.Sprintf("  %s  @%s %s%s\n", ts, prefix, m.Content, formatMessageUsageSuffix(m.Usage)))
 		} else {
 			thread := ""
 			if m.ReplyTo != "" {
 				thread = fmt.Sprintf(" ↳ %s", m.ReplyTo)
 			}
-			sb.WriteString(fmt.Sprintf("  %s%s  @%s: %s\n", ts, thread, prefix, m.Content))
+			sb.WriteString(fmt.Sprintf("  %s%s  @%s: %s%s\n", ts, thread, prefix, m.Content, formatMessageUsageSuffix(m.Usage)))
 		}
 	}
 	return sb.String()
+}
+
+func formatMessageUsageSuffix(usage *messageUsage) string {
+	if usage == nil {
+		return ""
+	}
+	total := usage.TotalTokens
+	if total == 0 {
+		total = usage.InputTokens + usage.OutputTokens + usage.CacheReadTokens + usage.CacheCreationTokens
+	}
+	if total == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" [%d tok]", total)
 }
 
 // --------------- Skills ---------------
@@ -6929,17 +7017,17 @@ func (b *Broker) parseSkillProposalLocked(msg channelMessage) {
 	// Surface the proposal in the Requests panel as a non-blocking human decision.
 	b.counter++
 	interview := humanInterview{
-		ID:            fmt.Sprintf("request-%d", b.counter),
-		Kind:          "skill_proposal",
-		Status:        "pending",
-		From:          msg.From,
-		Channel:       channel,
-		Title:         "Approve skill: " + title,
-		Question:      fmt.Sprintf("@%s proposed skill **%s**: %s\n\nActivate it?", msg.From, title, description),
-		ReplyTo:       slug,
-		Blocking:      false,
-		CreatedAt:     now,
-		UpdatedAt:     now,
+		ID:        fmt.Sprintf("request-%d", b.counter),
+		Kind:      "skill_proposal",
+		Status:    "pending",
+		From:      msg.From,
+		Channel:   channel,
+		Title:     "Approve skill: " + title,
+		Question:  fmt.Sprintf("@%s proposed skill **%s**: %s\n\nActivate it?", msg.From, title, description),
+		ReplyTo:   slug,
+		Blocking:  false,
+		CreatedAt: now,
+		UpdatedAt: now,
 	}
 	interview.Options, interview.RecommendedID = normalizeRequestOptions(interview.Kind, "accept", []interviewOption{
 		{ID: "accept", Label: "Accept"},

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/buildinfo"
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/provider"
 )
 
 func TestMain(m *testing.M) {
@@ -142,6 +143,64 @@ func TestBrokerMessageSubscribersReceivePostedMessages(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for subscribed message")
+	}
+}
+
+func TestRecordAgentUsageAttachesToCurrentTurnMessagesOnly(t *testing.T) {
+	b := NewBroker()
+	now := time.Now().UTC()
+	b.mu.Lock()
+	b.messages = []channelMessage{
+		{
+			ID:        "msg-1",
+			From:      "ceo",
+			Content:   "older turn",
+			Timestamp: now.Add(-2 * time.Minute).Format(time.RFC3339),
+			Usage:     &messageUsage{TotalTokens: 111},
+		},
+		{
+			ID:        "msg-2",
+			From:      "pm",
+			Content:   "interleaved",
+			Timestamp: now.Add(-30 * time.Second).Format(time.RFC3339),
+		},
+		{
+			ID:        "msg-3",
+			From:      "ceo",
+			Content:   "current turn kickoff",
+			Timestamp: now.Add(-10 * time.Second).Format(time.RFC3339),
+		},
+		{
+			ID:        "msg-4",
+			From:      "system",
+			Content:   "routing",
+			Timestamp: now.Add(-5 * time.Second).Format(time.RFC3339),
+		},
+		{
+			ID:        "msg-5",
+			From:      "ceo",
+			Content:   "current turn answer",
+			Timestamp: now.Format(time.RFC3339),
+		},
+	}
+	b.mu.Unlock()
+
+	b.RecordAgentUsage("ceo", "claude-sonnet-4-6", provider.ClaudeUsage{
+		InputTokens:         800,
+		OutputTokens:        200,
+		CacheReadTokens:     50,
+		CacheCreationTokens: 25,
+	})
+
+	msgs := b.Messages()
+	if msgs[0].Usage == nil || msgs[0].Usage.TotalTokens != 111 {
+		t.Fatalf("expected older turn usage to remain untouched, got %+v", msgs[0].Usage)
+	}
+	if msgs[2].Usage == nil || msgs[2].Usage.TotalTokens != 1075 {
+		t.Fatalf("expected msg-3 to receive usage, got %+v", msgs[2].Usage)
+	}
+	if msgs[4].Usage == nil || msgs[4].Usage.TotalTokens != 1075 {
+		t.Fatalf("expected msg-5 to receive usage, got %+v", msgs[4].Usage)
 	}
 }
 
@@ -2476,7 +2535,6 @@ func TestRecentHumanMessagesIncludesNexSender(t *testing.T) {
 		t.Error("expected agent message m1 to be excluded")
 	}
 }
-
 
 // --- Skill proposal system tests ---
 

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -490,6 +490,9 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 		summary = "reply ready · " + summary
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
+	if l.broker != nil {
+		l.broker.RecordAgentUsage(slug, config.ResolveCodexModel(l.cwd), result.Usage)
+	}
 	if text := strings.TrimSpace(firstNonEmpty(result.FinalMessage, result.LastPlainLine)); text != "" {
 		appendHeadlessCodexLog(slug, "result: "+text)
 	}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -70,6 +70,13 @@ type brokerMessage struct {
 	Tagged      []string `json:"tagged,omitempty"`
 	ReplyTo     string   `json:"reply_to,omitempty"`
 	Timestamp   string   `json:"timestamp"`
+	Usage       *struct {
+		InputTokens         int `json:"input_tokens,omitempty"`
+		OutputTokens        int `json:"output_tokens,omitempty"`
+		CacheReadTokens     int `json:"cache_read_tokens,omitempty"`
+		CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+		TotalTokens         int `json:"total_tokens,omitempty"`
+	} `json:"usage,omitempty"`
 }
 
 type brokerMessagesResponse struct {
@@ -858,8 +865,8 @@ func ownsRelevantTask(slug, replyTo, domain string, tasks []brokerTaskSummary) b
 // team.InferAgentDomain / team.InferTextDomain. All domain classification lives in
 // team/domains.go — update keywords there and both packages stay in sync.
 
-func inferOfficeAgentDomain(slug string) string   { return team.InferAgentDomain(slug) }
-func inferOfficeTextDomain(text string) string    { return team.InferTextDomain(text) }
+func inferOfficeAgentDomain(slug string) string { return team.InferAgentDomain(slug) }
+func inferOfficeTextDomain(text string) string  { return team.InferTextDomain(text) }
 
 func containsSlug(items []string, want string) bool {
 	want = strings.TrimSpace(strings.ToLower(want))

--- a/web/index.html
+++ b/web/index.html
@@ -692,6 +692,8 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 .message-header { display: flex; align-items: baseline; gap: 8px; margin-bottom: 4px; }
 .message-author { font-size: 13px; font-weight: 600; }
 .message-time { font-size: 11px; color: var(--text-tertiary); }
+.message-token-badge { display: inline-flex; align-items: center; padding: 1px 6px; border-radius: 999px; background: rgba(18, 100, 163, 0.08); border: 1px solid rgba(18, 100, 163, 0.18); color: var(--accent); font-size: 11px; font-weight: 600; font-family: var(--font-mono); }
+.message-token-row { margin-bottom: 4px; }
 .message-text { font-size: 14px; line-height: 1.6; color: var(--text-secondary); }
 .message-text strong { color: var(--text); font-weight: 600; }
 .message-text code { background: var(--bg-warm); border-radius: 4px; padding: 1px 5px; font-family: var(--font-mono); font-size: 12px; }
@@ -4814,6 +4816,14 @@ function appendMessageToContainer(msg, container, opts) {
     timeEl.textContent = d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
   }
   header.appendChild(timeEl);
+  var usageTotal = messageUsageTotal(msg.usage);
+  if (usageTotal > 0) {
+    var usageEl = document.createElement('span');
+    usageEl.className = 'message-token-badge';
+    usageEl.textContent = formatTokens(usageTotal) + ' tok';
+    usageEl.title = messageUsageTitle(msg.usage);
+    header.appendChild(usageEl);
+  }
 
   // Mood inference (#10)
   if (!isHuman && msg.content) {
@@ -4836,6 +4846,16 @@ function appendMessageToContainer(msg, container, opts) {
   }
 
   content.appendChild(header);
+  if (opts.grouped && usageTotal > 0) {
+    var usageRow = document.createElement('div');
+    usageRow.className = 'message-token-row';
+    var groupedUsageEl = document.createElement('span');
+    groupedUsageEl.className = 'message-token-badge';
+    groupedUsageEl.textContent = formatTokens(usageTotal) + ' tok';
+    groupedUsageEl.title = messageUsageTitle(msg.usage);
+    usageRow.appendChild(groupedUsageEl);
+    content.appendChild(usageRow);
+  }
 
   if (opts.showReplyContext && opts.parentName) {
     content.appendChild(el('div', { className: 'thread-reply-to' }, 'Replying to ' + opts.parentName));
@@ -7924,15 +7944,21 @@ function renderStreamLine(container, rawText) {
   var card = document.createElement('div');
   card.className = 'stream-card';
 
-  // ── turn.completed → compact token line ──
-  if (evtType === 'turn.completed' && parsed.usage) {
-    var u = parsed.usage;
+  // ── turn/response completed → compact token line ──
+  var completedUsage = extractStreamUsage(parsed);
+  if ((evtType === 'turn.completed' || evtType === 'response.completed') && completedUsage) {
+    var u = completedUsage;
     var tokenLine = document.createElement('div');
     tokenLine.className = 'cc-token-line';
     var inTok = u.input_tokens || 0;
     var outTok = u.output_tokens || 0;
-    var cached = u.cached_input_tokens || 0;
-    tokenLine.textContent = '\u2500\u2500 ' + formatTokens(inTok + outTok) + ' tokens (' + formatTokens(inTok) + ' in, ' + formatTokens(outTok) + ' out' + (cached > 0 ? ', ' + formatTokens(cached) + ' cached' : '') + ')';
+    var cacheRead = u.cached_input_tokens || u.cache_read_input_tokens || u.cache_read_tokens || 0;
+    var cacheCreate = u.cache_creation_input_tokens || u.cache_creation_tokens || 0;
+    var total = inTok + outTok + cacheRead + cacheCreate;
+    var extra = '';
+    if (cacheRead > 0) extra += ', ' + formatTokens(cacheRead) + ' cache read';
+    if (cacheCreate > 0) extra += ', ' + formatTokens(cacheCreate) + ' cache write';
+    tokenLine.textContent = '\u2500\u2500 ' + formatTokens(total) + ' tokens (' + formatTokens(inTok) + ' in, ' + formatTokens(outTok) + ' out' + extra + ')';
     container.appendChild(tokenLine);
     return;
   }
@@ -9791,6 +9817,30 @@ function formatTokens(n) {
   if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
   if (n >= 1000) return (n / 1000).toFixed(1) + 'k';
   return String(n);
+}
+
+function messageUsageTotal(usage) {
+  if (!usage) return 0;
+  if (usage.total_tokens) return usage.total_tokens;
+  return (usage.input_tokens || 0) + (usage.output_tokens || 0) + (usage.cache_read_tokens || 0) + (usage.cache_creation_tokens || 0);
+}
+
+function messageUsageTitle(usage) {
+  if (!usage) return '';
+  var parts = [formatTokens(messageUsageTotal(usage)) + ' total'];
+  if (usage.input_tokens) parts.push(formatTokens(usage.input_tokens) + ' in');
+  if (usage.output_tokens) parts.push(formatTokens(usage.output_tokens) + ' out');
+  if (usage.cache_read_tokens) parts.push(formatTokens(usage.cache_read_tokens) + ' cache read');
+  if (usage.cache_creation_tokens) parts.push(formatTokens(usage.cache_creation_tokens) + ' cache write');
+  return parts.join(' · ');
+}
+
+function extractStreamUsage(parsed) {
+  if (!parsed || typeof parsed !== 'object') return null;
+  if (parsed.usage) return parsed.usage;
+  if (parsed.response && parsed.response.usage) return parsed.response.usage;
+  if (parsed.data && parsed.data.usage) return parsed.data.usage;
+  return null;
 }
 
 function fetchUsage() {


### PR DESCRIPTION
## What changed
- persist per-message token usage on broker messages so human-visible agent output carries its own token burn metadata
- attach turn usage back onto the recent agent-authored messages when usage arrives, instead of only showing session totals
- parse Codex streamed usage and record it through the same broker path as Claude
- render token tags in both the terminal channel view and the web UI message header / DM stream

## Why
Token accounting existed at the aggregate session level and in the live DM stream, but not on the actual messages the human sees in channels and DMs. That made the requirement incomplete: a human could see the output without seeing the tokens burned to produce it.

## Impact
Every persisted human-visible AI message can now show its token burn directly, with the same behavior for Claude and Codex runtimes.

## Validation
- `go test ./internal/provider`
- `go test ./internal/team`
- `go test ./cmd/wuphf`
- started a broader `go test ./...` pass locally before switching to PR checks