### PR TITLE
fix(openclaw): route DMs + reply to the source channel

### DIFF
--- a/cmd/wuphf-oc-probe/bridge/main.go
+++ b/cmd/wuphf-oc-probe/bridge/main.go
@@ -151,15 +151,19 @@ func main() {
 	}
 
 	// 4. Multi-turn conversation. Send three distinct messages, collect replies.
+	// Use concrete questions so the agent produces real answers instead of
+	// shrugging the turn off as noise ("NO_REPLY"). Each prompt references the
+	// prior turn so we can visually confirm multi-turn context is preserved.
+	nonce := fmt.Sprint(time.Now().UnixNano())
 	prompts := []string{
-		"turn-1 " + fmt.Sprint(time.Now().UnixNano()),
-		"turn-2 " + fmt.Sprint(time.Now().UnixNano()),
-		"turn-3 " + fmt.Sprint(time.Now().UnixNano()),
+		"ping " + nonce + " — answer with exactly the single word: pong",
+		"what is 2+2? Reply with just the number.",
+		"in one short sentence, what was the first question I asked you in this session?",
 	}
 	repliesByTurn := make([]string, len(prompts))
 	for i, msg := range prompts {
 		before := len(broker.AllMessages())
-		if err := bridge.OnOfficeMessage(ctx, bridgeSlug, msg); err != nil {
+		if err := bridge.OnOfficeMessage(ctx, bridgeSlug, "general", msg); err != nil {
 			die("turn %d OnOfficeMessage: %v", i+1, err)
 		}
 		fmt.Printf("SEND turn-%d: %q\n", i+1, msg)

--- a/cmd/wuphf-oc-probe/pack/main.go
+++ b/cmd/wuphf-oc-probe/pack/main.go
@@ -176,6 +176,80 @@ func main() {
 		fmt.Printf("  RECV DM←%s: %q\n", m.slug, truncate(replies[m.slug], 140))
 	}
 
+	// 4. Multi-turn channel test. Address just pm-bot so we also verify that
+	// @mention targeting keeps routing correctly across turns and that the
+	// per-session conversation history OpenClaw keeps is visible through the
+	// bridge.
+	fmt.Println("\n--- channel multi-turn (@pm-bot only) ---")
+	channelTurns := []string{
+		"pm-bot: please remember the number 42 for me. Reply with exactly: ok, 42",
+		"pm-bot: what number did I ask you to remember? Reply with just the digits.",
+		"pm-bot: add 8 to that number. Reply with just the digits.",
+	}
+	for i, prompt := range channelTurns {
+		beforeT := len(broker.AllMessages())
+		if _, err := broker.PostMessage("human", "general", prompt, []string{members[0].slug}, ""); err != nil {
+			die("channel turn %d post: %v", i+1, err)
+		}
+		fmt.Printf("SEND ch-turn-%d: %q\n", i+1, prompt)
+		want := map[string]bool{members[0].slug: false}
+		r := waitForReplies(broker, beforeT, want, "general", 45*time.Second)
+		fmt.Printf("  RECV ch-turn-%d from %s: %q\n", i+1, members[0].slug, truncate(r[members[0].slug], 160))
+	}
+
+	// 5. Multi-turn DM test. Same shape, but in eng-bot's DM — confirms
+	// DM-partner inference handles repeated sends without the router falling
+	// back to "general" on turn N when it got it right on turn 1.
+	fmt.Println("\n--- DM multi-turn (eng-bot) ---")
+	engDM, err := broker.EnsureDirectChannel(members[1].slug)
+	if err != nil {
+		die("eng DM open: %v", err)
+	}
+	dmTurns := []string{
+		"pick a fruit (just one lowercase word) and tell me what it is.",
+		"now spell that fruit backwards. Reply with just the reversed word, lowercase.",
+		"how many letters does the fruit you picked have? Reply with just the digit.",
+	}
+	for i, prompt := range dmTurns {
+		beforeT := len(broker.AllMessages())
+		if _, err := broker.PostMessage("human", engDM, prompt, nil, ""); err != nil {
+			die("DM turn %d post: %v", i+1, err)
+		}
+		fmt.Printf("SEND dm-turn-%d: %q\n", i+1, prompt)
+		want := map[string]bool{members[1].slug: false}
+		r := waitForReplies(broker, beforeT, want, engDM, 45*time.Second)
+		fmt.Printf("  RECV dm-turn-%d from %s: %q\n", i+1, members[1].slug, truncate(r[members[1].slug], 160))
+	}
+
+	// 6. "Pick up a task" test — give one agent a multi-step task in a single
+	// DM message and verify the deterministic final answer. This is the
+	// closest smoke for "can this agent actually do work" short of wiring
+	// MCP tools, files, or shell access.
+	fmt.Println("\n--- DM task handoff (pm-bot) ---")
+	pmDM, err := broker.EnsureDirectChannel(members[0].slug)
+	if err != nil {
+		die("pm DM open: %v", err)
+	}
+	taskPrompt := strings.Join([]string{
+		"I'm going to give you a small task. Do each step, then answer.",
+		"Step 1: take the number 7.",
+		"Step 2: multiply it by 6.",
+		"Step 3: subtract 2 from the result.",
+		"Step 4: reply with just the final number, no words, no punctuation.",
+	}, " ")
+	beforeTask := len(broker.AllMessages())
+	if _, err := broker.PostMessage("human", pmDM, taskPrompt, nil, ""); err != nil {
+		die("task post: %v", err)
+	}
+	fmt.Printf("SEND task: %q\n", truncate(taskPrompt, 200))
+	want := map[string]bool{members[0].slug: false}
+	r := waitForReplies(broker, beforeTask, want, pmDM, 60*time.Second)
+	taskReply := strings.TrimSpace(r[members[0].slug])
+	fmt.Printf("  RECV task from %s: %q\n", members[0].slug, truncate(taskReply, 160))
+	if !strings.Contains(taskReply, "40") {
+		die("task answer does not contain expected value 40 — got %q", taskReply)
+	}
+
 	fmt.Println("\nall checks passed")
 	fmt.Println("PASS")
 }

--- a/cmd/wuphf-oc-probe/pack/main.go
+++ b/cmd/wuphf-oc-probe/pack/main.go
@@ -1,0 +1,257 @@
+// wuphf-oc-probe/pack is the "pack parity" smoke test. It proves that a
+// WUPHF install with TWO OpenClaw bridge bindings behaves like a real pack:
+//
+//   - Both bridged sessions register as office members (@mentionable in #general).
+//   - A channel post that @mentions both agents fans out and each replies.
+//   - A 1:1 DM to either bridged slug is routed and the agent replies,
+//     without an @mention (DM partner is inferred from the channel members).
+//
+// Run with:
+//
+//	OPENCLAW_TOKEN=... go run ./cmd/wuphf-oc-probe/pack
+//
+// If OPENCLAW_TOKEN is unset, the token is read from ~/.openclaw/openclaw.json.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/openclaw"
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+type packMember struct {
+	slug       string
+	display    string
+	sessionKey string
+}
+
+func main() {
+	token := resolveToken()
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	realIdentityPath := config.ResolveOpenclawIdentityPath()
+	identity, err := openclaw.LoadOrCreateDeviceIdentity(realIdentityPath)
+	if err != nil {
+		die("identity: %v", err)
+	}
+
+	// Create two fresh OpenClaw sessions — each gets its own conversation
+	// history, so the two bridged slugs behave as distinct agents from the
+	// user's perspective even though they share the same model/agent.
+	conn, err := openclaw.Dial(ctx, openclaw.Config{URL: "ws://127.0.0.1:18789", Token: token, Identity: identity})
+	if err != nil {
+		die("dial openclaw: %v", err)
+	}
+	members := []packMember{
+		{slug: "pm-bot", display: "PM Bot"},
+		{slug: "eng-bot", display: "Eng Bot"},
+	}
+	runID := fmt.Sprint(time.Now().UnixNano())
+	for i, m := range members {
+		raw, err := conn.Call(ctx, "sessions.create", map[string]any{
+			"agentId": "main",
+			"label":   "wuphf-pack-" + m.slug + "-" + runID,
+		})
+		if err != nil {
+			die("sessions.create for %s: %v", m.slug, err)
+		}
+		var out struct {
+			Key string `json:"key"`
+		}
+		if err := json.Unmarshal(raw, &out); err != nil || out.Key == "" {
+			die("sessions.create for %s returned no key: %s", m.slug, string(raw))
+		}
+		members[i].sessionKey = out.Key
+		fmt.Printf("created session for %s: %s\n", m.slug, out.Key)
+	}
+	conn.Close()
+
+	// Seed a temporary WUPHF HOME so broker state doesn't clash with a real
+	// install. Point identity + token back at the paired daemon.
+	tmpHome, err := os.MkdirTemp("", "wuphf-oc-pack-*")
+	if err != nil {
+		die("tmp home: %v", err)
+	}
+	defer os.RemoveAll(tmpHome)
+	os.Setenv("HOME", tmpHome)
+	os.MkdirAll(filepath.Join(tmpHome, ".wuphf"), 0o700)
+	os.Setenv("WUPHF_OPENCLAW_IDENTITY_PATH", realIdentityPath)
+	os.Setenv("WUPHF_OPENCLAW_TOKEN", token)
+
+	bindings := make([]config.OpenclawBridgeBinding, len(members))
+	for i, m := range members {
+		bindings[i] = config.OpenclawBridgeBinding{
+			SessionKey:  m.sessionKey,
+			Slug:        m.slug,
+			DisplayName: m.display,
+		}
+	}
+	if err := config.Save(config.Config{
+		OpenclawGatewayURL: "ws://127.0.0.1:18789",
+		OpenclawBridges:    bindings,
+	}); err != nil {
+		die("save config: %v", err)
+	}
+
+	// Boot a broker + start the real bridge via the production bootstrap path.
+	broker := team.NewBroker()
+	bridge, err := team.StartOpenclawBridgeFromConfig(ctx, broker)
+	if err != nil {
+		die("start bridge: %v", err)
+	}
+	if bridge == nil {
+		die("bootstrap returned nil bridge — bindings not persisted?")
+	}
+	defer bridge.Stop()
+	// The router that forwards @mentions and DMs lives next to the bridge in
+	// production via launcher.go:3295. Start the exact same goroutine here
+	// so the probe exercises the real end-to-end routing path.
+	team.StartOpenclawRouter(ctx, broker, bridge)
+	fmt.Println("bridge + router started")
+
+	time.Sleep(500 * time.Millisecond)
+	for _, m := range members {
+		if !bridge.HasSlug(m.slug) {
+			die("bridge does not recognize slug %q", m.slug)
+		}
+	}
+
+	// 1. Office-member registration check (both agents must show up in the
+	// sidebar + @mention autocomplete).
+	gotMembers := map[string]bool{}
+	for _, om := range broker.OfficeMembers() {
+		for _, want := range members {
+			if om.Slug == want.slug {
+				fmt.Printf("  MEMBER: %q name=%q role=%q createdBy=%q\n", om.Slug, om.Name, om.Role, om.CreatedBy)
+				gotMembers[om.Slug] = true
+			}
+		}
+	}
+	for _, m := range members {
+		if !gotMembers[m.slug] {
+			die("bridged slug %q never registered as an office member", m.slug)
+		}
+	}
+
+	// 2. Channel test: post to #general tagging both agents. Both must reply.
+	channelPrompt := "hello both of you — reply with exactly the single word: pong"
+	before := len(broker.AllMessages())
+	if _, err := broker.PostMessage("human", "general", channelPrompt, []string{members[0].slug, members[1].slug}, ""); err != nil {
+		die("post to #general: %v", err)
+	}
+	fmt.Printf("\nSEND #general (@%s @%s): %q\n", members[0].slug, members[1].slug, channelPrompt)
+	channelReplies := waitForReplies(broker, before, map[string]bool{members[0].slug: false, members[1].slug: false}, "general", 30*time.Second)
+	for slug, reply := range channelReplies {
+		fmt.Printf("  RECV #general from %s: %q\n", slug, truncate(reply, 140))
+	}
+
+	// 3. DM test: open a 1:1 DM per agent, post a distinct question, expect a
+	// distinct reply. No @mentions — DM partner resolution must do the work.
+	dmPrompts := map[string]string{
+		members[0].slug: "reply with exactly the single word: alpha",
+		members[1].slug: "reply with exactly the single word: bravo",
+	}
+	for _, m := range members {
+		dmSlug, err := broker.EnsureDirectChannel(m.slug)
+		if err != nil {
+			die("open DM with %s: %v", m.slug, err)
+		}
+		beforeDM := len(broker.AllMessages())
+		prompt := dmPrompts[m.slug]
+		if _, err := broker.PostMessage("human", dmSlug, prompt, nil, ""); err != nil {
+			die("post DM to %s: %v", m.slug, err)
+		}
+		fmt.Printf("\nSEND DM→%s (%s): %q\n", m.slug, dmSlug, prompt)
+		want := map[string]bool{m.slug: false}
+		replies := waitForReplies(broker, beforeDM, want, dmSlug, 30*time.Second)
+		fmt.Printf("  RECV DM←%s: %q\n", m.slug, truncate(replies[m.slug], 140))
+	}
+
+	fmt.Println("\nall checks passed")
+	fmt.Println("PASS")
+}
+
+// waitForReplies polls broker.AllMessages() from `before` onward until each
+// slug in `want` has posted at least one message on `channel` via source
+// "openclaw". Dies on timeout. Returns the first reply content per slug.
+func waitForReplies(broker *team.Broker, before int, want map[string]bool, channel string, timeout time.Duration) map[string]string {
+	got := make(map[string]string, len(want))
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		msgs := broker.AllMessages()
+		for _, m := range msgs[before:] {
+			if m.Channel != channel {
+				continue
+			}
+			if _, tracked := want[m.From]; !tracked {
+				continue
+			}
+			if m.Source != "openclaw" {
+				continue
+			}
+			if _, seen := got[m.From]; !seen {
+				got[m.From] = m.Content
+				want[m.From] = true
+			}
+		}
+		done := true
+		for _, v := range want {
+			if !v {
+				done = false
+				break
+			}
+		}
+		if done {
+			return got
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+	die("timeout waiting for replies on %s; got=%v want=%v", channel, got, want)
+	return got
+}
+
+func resolveToken() string {
+	if t := os.Getenv("OPENCLAW_TOKEN"); t != "" {
+		return t
+	}
+	raw, err := os.ReadFile(os.ExpandEnv("$HOME/.openclaw/openclaw.json"))
+	if err != nil {
+		die("OPENCLAW_TOKEN unset and ~/.openclaw/openclaw.json unreadable: %v", err)
+	}
+	var cfg struct {
+		Gateway struct {
+			Auth struct {
+				Token string `json:"token"`
+			} `json:"auth"`
+		} `json:"gateway"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		die("parse openclaw config: %v", err)
+	}
+	if cfg.Gateway.Auth.Token == "" {
+		die("no token found in ~/.openclaw/openclaw.json")
+	}
+	return cfg.Gateway.Auth.Token
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "FAIL: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func truncate(s string, n int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > n {
+		return s[:n] + "..."
+	}
+	return s
+}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -1448,6 +1448,67 @@ func (b *Broker) EnsureBridgedMember(slug, name, createdBy string) error {
 	return nil
 }
 
+// EnsureDirectChannel opens (or returns) the 1:1 DM channel between the
+// default human member and agentSlug. Returns the canonical channel slug
+// (pair-sorted via channel.DirectSlug). Safe to call repeatedly; the DM row
+// is upserted in both the channel store and the in-memory broker table so
+// it shows up in the sidebar and findChannelLocked resolves it.
+func (b *Broker) EnsureDirectChannel(agentSlug string) (string, error) {
+	agentSlug = normalizeActorSlug(agentSlug)
+	if agentSlug == "" {
+		return "", fmt.Errorf("agent slug required")
+	}
+	if b.channelStore == nil {
+		return "", fmt.Errorf("channel store not initialized")
+	}
+	ch, err := b.channelStore.GetOrCreateDirect("human", agentSlug)
+	if err != nil {
+		return "", fmt.Errorf("channel store GetOrCreateDirect: %w", err)
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.findChannelLocked(ch.Slug) == nil {
+		now := time.Now().UTC().Format(time.RFC3339)
+		b.channels = append(b.channels, teamChannel{
+			Slug:        ch.Slug,
+			Name:        ch.Slug,
+			Type:        "dm",
+			Description: "Direct messages with " + agentSlug,
+			Members:     []string{"human", agentSlug},
+			CreatedBy:   "wuphf",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		})
+		if err := b.saveLocked(); err != nil {
+			return "", err
+		}
+	}
+	return ch.Slug, nil
+}
+
+// DMPartner returns the non-human member slug of a 1:1 DM channel. Returns
+// "" if the channel is not a DM, does not exist, or is a group DM. Used by
+// surface bridges (OpenClaw, Slack, etc.) to resolve "who is the human
+// talking to" when routing DM posts to the right agent without requiring an
+// @mention.
+func (b *Broker) DMPartner(channelSlug string) string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	ch := b.findChannelLocked(normalizeChannelSlug(channelSlug))
+	if ch == nil || !ch.isDM() {
+		return ""
+	}
+	if len(ch.Members) != 2 {
+		return ""
+	}
+	for _, m := range ch.Members {
+		if m != "human" && m != "you" {
+			return m
+		}
+	}
+	return ""
+}
+
 // PostInboundSurfaceMessage posts a message from an external surface into the broker channel.
 func (b *Broker) PostInboundSurfaceMessage(from, channel, content, provider string) (channelMessage, error) {
 	b.mu.Lock()

--- a/internal/team/openclaw.go
+++ b/internal/team/openclaw.go
@@ -36,6 +36,12 @@ type OpenclawBridge struct {
 	slugByKey map[string]string // sessionKey -> slug
 	keyBySlug map[string]string // slug -> sessionKey
 
+	// lastChannelByKey remembers where the most recent human-authored send for
+	// each session came from, so when the assistant reply arrives via the
+	// async event stream we can post it back to the same channel (DM, #general,
+	// thread, etc.) instead of always falling back to #general. Guarded by mu.
+	lastChannelByKey map[string]string
+
 	retryDelays []time.Duration // nil = use defaults
 
 	// Reconnect supervisor fields.
@@ -80,12 +86,13 @@ func NewOpenclawBridge(broker *Broker, client openclawClient, bindings []config.
 		keyBySlug[b.Slug] = b.SessionKey
 	}
 	return &OpenclawBridge{
-		broker:    broker,
-		client:    client,
-		bindings:  bindings,
-		slugByKey: slugByKey,
-		keyBySlug: keyBySlug,
-		done:      make(chan struct{}),
+		broker:           broker,
+		client:           client,
+		bindings:         bindings,
+		slugByKey:        slugByKey,
+		keyBySlug:        keyBySlug,
+		lastChannelByKey: make(map[string]string, len(bindings)),
+		done:             make(chan struct{}),
 	}
 }
 
@@ -247,7 +254,13 @@ func (b *OpenclawBridge) handleClientEvent(evt openclaw.ClientEvent) {
 			return
 		}
 		if text := evt.SessionMessage.MessageText; text != "" {
-			b.postBridgeMessage(slug, text)
+			b.mu.RLock()
+			channel := b.lastChannelByKey[evt.SessionMessage.SessionKey]
+			b.mu.RUnlock()
+			if channel == "" {
+				channel = "general"
+			}
+			b.postBridgeMessage(slug, channel, text)
 		}
 	case openclaw.EventKindChanged:
 		if evt.SessionsChanged != nil && evt.SessionsChanged.Reason == "ended" {
@@ -282,14 +295,30 @@ func (b *OpenclawBridge) retryDelaysList() []time.Duration {
 // SetRetryDelaysForTest is only used by tests.
 func (b *OpenclawBridge) SetRetryDelaysForTest(d []time.Duration) { b.retryDelays = d }
 
-// OnOfficeMessage sends an office message from user/@mention to the OpenClaw
-// agent identified by slug. Retries on transient errors with a SINGLE reused
-// idempotency key so the gateway can deduplicate.
-func (b *OpenclawBridge) OnOfficeMessage(ctx context.Context, slug, message string) error {
+// OnOfficeMessage sends a human-authored message to the OpenClaw agent
+// identified by slug. The channel argument is where the reply should land
+// (e.g. "general" for @mentions, a DM slug like "human__pm-bot" for DMs).
+// Retries on transient errors with a SINGLE reused idempotency key so the
+// gateway can deduplicate.
+//
+// Reply routing: OpenClaw streams the assistant reply via an async event.
+// We remember this channel here, keyed by the session key; handleClientEvent
+// reads it when the reply arrives. If channel is empty we fall back to
+// "general" so older callers and probes keep working.
+func (b *OpenclawBridge) OnOfficeMessage(ctx context.Context, slug, channel, message string) error {
 	key, ok := b.keyBySlug[slug]
 	if !ok {
 		return fmt.Errorf("openclaw: unknown bridged slug %q", slug)
 	}
+	if channel == "" {
+		channel = "general"
+	}
+	b.mu.Lock()
+	if b.lastChannelByKey == nil {
+		b.lastChannelByKey = make(map[string]string)
+	}
+	b.lastChannelByKey[key] = channel
+	b.mu.Unlock()
 	idem := uuid.NewString()
 	delays := b.retryDelaysList()
 	var lastErr error
@@ -322,13 +351,16 @@ func (b *OpenclawBridge) OnOfficeMessage(ctx context.Context, slug, message stri
 	return lastErr
 }
 
-// postBridgeMessage posts a bridged-agent chat message into #general via the
-// same broker entrypoint telegram.go uses for incoming chat.
-func (b *OpenclawBridge) postBridgeMessage(slug, text string) {
+// postBridgeMessage posts a bridged-agent chat message into the given channel
+// via the same broker entrypoint telegram.go uses for incoming chat.
+func (b *OpenclawBridge) postBridgeMessage(slug, channel, text string) {
 	if b.broker == nil {
 		return
 	}
-	_, _ = b.broker.PostInboundSurfaceMessage(slug, "general", text, "openclaw")
+	if channel == "" {
+		channel = "general"
+	}
+	_, _ = b.broker.PostInboundSurfaceMessage(slug, channel, text, "openclaw")
 }
 
 // postSystemMessage posts a `system`-authored notice into #general.

--- a/internal/team/openclaw_bootstrap.go
+++ b/internal/team/openclaw_bootstrap.go
@@ -53,11 +53,23 @@ func StartOpenclawBridgeFromConfig(ctx context.Context, broker *Broker) (*Opencl
 	return bridge, nil
 }
 
-// routeOpenclawMentionsLoop subscribes to broker messages and forwards every
-// human-authored @mention of a bridged slug to the OpenClaw bridge via
-// OnOfficeMessage. Agent-to-agent mentions are intentionally skipped to
-// prevent broadcast loops (mirroring the thread auto-tag decision in broker.go).
-// The loop exits when ctx is cancelled and the subscriber channel drains.
+// StartOpenclawRouter starts the mention+DM routing goroutine. Exported so
+// out-of-package callers (e.g. bridge probes) can opt into the same routing
+// behavior production WUPHF runs via launcher.go. The goroutine exits when
+// ctx is cancelled.
+func StartOpenclawRouter(ctx context.Context, broker *Broker, bridge *OpenclawBridge) {
+	go routeOpenclawMentionsLoop(ctx, broker, bridge)
+}
+
+// routeOpenclawMentionsLoop subscribes to broker messages and forwards
+// human-authored posts to the OpenClaw bridge via OnOfficeMessage in two cases:
+//
+//  1. Channel posts that @mention a bridged slug (one forward per mention).
+//  2. 1:1 DM posts whose partner slug is bridged (no @mention required).
+//
+// Agent-to-agent mentions are intentionally skipped to prevent broadcast loops
+// (mirroring the thread auto-tag decision in broker.go). The loop exits when
+// ctx is cancelled and the subscriber channel drains.
 func routeOpenclawMentionsLoop(ctx context.Context, broker *Broker, bridge *OpenclawBridge) {
 	if broker == nil || bridge == nil {
 		return
@@ -82,19 +94,27 @@ func routeOpenclawMentionsLoop(ctx context.Context, broker *Broker, bridge *Open
 			if msg.From != "you" && msg.From != "human" {
 				continue
 			}
-			if len(msg.Tagged) == 0 {
-				continue
-			}
+
+			// Collect the set of bridged slugs to forward this message to.
+			// Mentions and DM partner can both apply; dedupe so a DM that
+			// also happens to @mention the same agent isn't double-fired.
+			targets := make(map[string]struct{})
 			for _, slug := range msg.Tagged {
-				if !bridge.HasSlug(slug) {
-					continue
+				if bridge.HasSlug(slug) {
+					targets[slug] = struct{}{}
 				}
+			}
+			if partner := broker.DMPartner(msg.Channel); partner != "" && bridge.HasSlug(partner) {
+				targets[partner] = struct{}{}
+			}
+
+			for slug := range targets {
 				// Best-effort: OnOfficeMessage retries internally and posts
 				// its own system message on permanent failure, so we do
 				// not propagate the error here.
-				go func(slug string) {
-					_ = bridge.OnOfficeMessage(ctx, slug, msg.Content)
-				}(slug)
+				go func(slug, channel, content string) {
+					_ = bridge.OnOfficeMessage(ctx, slug, channel, content)
+				}(slug, msg.Channel, msg.Content)
 			}
 		}
 	}

--- a/internal/team/openclaw_e2e_test.go
+++ b/internal/team/openclaw_e2e_test.go
@@ -58,7 +58,7 @@ func TestOpenclawBridgeFullPipeline_E2E(t *testing.T) {
 	defer cancel()
 
 	// Outbound: bridge → gateway sessions.send
-	if err := bridge.OnOfficeMessage(ctx, "openclaw-demo-e2e", "hello agent"); err != nil {
+	if err := bridge.OnOfficeMessage(ctx, "openclaw-demo-e2e", "general", "hello agent"); err != nil {
 		t.Fatalf("OnOfficeMessage: %v", err)
 	}
 	waitForE2E(t, 2*time.Second, func() bool {

--- a/internal/team/openclaw_test.go
+++ b/internal/team/openclaw_test.go
@@ -173,7 +173,7 @@ func TestOnOfficeMessageSuccess(t *testing.T) {
 	b := NewOpenclawBridge(NewBroker(), fake, bindings)
 	_ = b.Start(context.Background())
 	defer b.Stop()
-	err := b.OnOfficeMessage(context.Background(), "openclaw-a", "hello")
+	err := b.OnOfficeMessage(context.Background(), "openclaw-a", "general", "hello")
 	if err != nil {
 		t.Fatalf("OnOfficeMessage: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestOnOfficeMessageRetriesTransient(t *testing.T) {
 	b.SetRetryDelaysForTest([]time.Duration{10 * time.Millisecond, 10 * time.Millisecond})
 	_ = b.Start(context.Background())
 	defer b.Stop()
-	err := b.OnOfficeMessage(context.Background(), "openclaw-a", "hello")
+	err := b.OnOfficeMessage(context.Background(), "openclaw-a", "general", "hello")
 	if err != nil {
 		t.Fatalf("expected retry to succeed: %v", err)
 	}
@@ -471,6 +471,127 @@ func TestRouteOpenclawMentionsLoopIgnoresUnrelated(t *testing.T) {
 	}
 }
 
+func TestRouteOpenclawMentionsLoopForwardsDMPost(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	fake := newFakeOC()
+	broker := NewBroker()
+	// Register the bridged agent as a real office member so a DM channel can
+	// be opened against its slug.
+	if err := broker.EnsureBridgedMember("openclaw-dm", "DM Bot", "openclaw"); err != nil {
+		t.Fatalf("ensure bridged member: %v", err)
+	}
+	dmSlug, err := broker.ChannelStore().GetOrCreateDirect("human", "openclaw-dm")
+	if err != nil {
+		t.Fatalf("open DM channel: %v", err)
+	}
+	// Mirror the DM into the broker's channel table so findChannelLocked
+	// resolves it — ensureDMConversationLocked does the same when a surface
+	// post lands first.
+	broker.mu.Lock()
+	broker.channels = append(broker.channels, teamChannel{
+		Slug:    dmSlug.Slug,
+		Name:    dmSlug.Slug,
+		Type:    "dm",
+		Members: []string{"human", "openclaw-dm"},
+	})
+	broker.mu.Unlock()
+
+	bindings := []config.OpenclawBridgeBinding{{SessionKey: "sk-dm", Slug: "openclaw-dm"}}
+	bridge := NewOpenclawBridge(broker, fake, bindings)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := bridge.Start(ctx); err != nil {
+		t.Fatalf("bridge start: %v", err)
+	}
+	defer bridge.Stop()
+
+	go routeOpenclawMentionsLoop(ctx, broker, bridge)
+	time.Sleep(20 * time.Millisecond)
+
+	broker.mu.Lock()
+	broker.counter++
+	msg := channelMessage{
+		ID:        "msg-dm-1",
+		From:      "human",
+		Channel:   dmSlug.Slug,
+		Content:   "hey, quick q",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	broker.appendMessageLocked(msg)
+	broker.mu.Unlock()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		fake.mu.Lock()
+		got := len(fake.sentKeys)
+		fake.mu.Unlock()
+		if got >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.sentKeys) != 1 {
+		t.Fatalf("expected 1 forwarded DM send, got %d: %v", len(fake.sentKeys), fake.sentKeys)
+	}
+	if !strings.HasPrefix(fake.sentKeys[0], "sk-dm|hey, quick q|") {
+		t.Fatalf("forwarded DM send has unexpected shape: %q", fake.sentKeys[0])
+	}
+}
+
+func TestRouteOpenclawMentionsLoopDedupesDMAndMention(t *testing.T) {
+	// Guards against a regression where a DM post that also happens to
+	// @mention the partner would fire OnOfficeMessage twice.
+	t.Setenv("HOME", t.TempDir())
+	fake := newFakeOC()
+	broker := NewBroker()
+	if err := broker.EnsureBridgedMember("openclaw-both", "Both Bot", "openclaw"); err != nil {
+		t.Fatalf("ensure bridged member: %v", err)
+	}
+	dm, err := broker.ChannelStore().GetOrCreateDirect("human", "openclaw-both")
+	if err != nil {
+		t.Fatalf("open DM: %v", err)
+	}
+	broker.mu.Lock()
+	broker.channels = append(broker.channels, teamChannel{
+		Slug: dm.Slug, Type: "dm", Members: []string{"human", "openclaw-both"},
+	})
+	broker.mu.Unlock()
+
+	bindings := []config.OpenclawBridgeBinding{{SessionKey: "sk-both", Slug: "openclaw-both"}}
+	bridge := NewOpenclawBridge(broker, fake, bindings)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := bridge.Start(ctx); err != nil {
+		t.Fatalf("bridge start: %v", err)
+	}
+	defer bridge.Stop()
+
+	go routeOpenclawMentionsLoop(ctx, broker, bridge)
+	time.Sleep(20 * time.Millisecond)
+
+	broker.mu.Lock()
+	broker.counter++
+	broker.appendMessageLocked(channelMessage{
+		ID:        "msg-dedupe-1",
+		From:      "human",
+		Channel:   dm.Slug,
+		Content:   "@openclaw-both hey",
+		Tagged:    []string{"openclaw-both"},
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	})
+	broker.mu.Unlock()
+
+	time.Sleep(150 * time.Millisecond)
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	if len(fake.sentKeys) != 1 {
+		t.Fatalf("expected 1 forwarded send (deduped), got %d: %v", len(fake.sentKeys), fake.sentKeys)
+	}
+}
+
 func TestSuperviseOfflineNoticeDeduped(t *testing.T) {
 	broker := NewBroker()
 	dialer := func(ctx context.Context) (openclawClient, error) {
@@ -508,7 +629,7 @@ func TestOnOfficeMessagePermanentFailurePostsSystemMessage(t *testing.T) {
 	b.SetRetryDelaysForTest([]time.Duration{5 * time.Millisecond, 5 * time.Millisecond})
 	_ = b.Start(context.Background())
 	defer b.Stop()
-	err := b.OnOfficeMessage(context.Background(), "openclaw-a", "hello")
+	err := b.OnOfficeMessage(context.Background(), "openclaw-a", "general", "hello")
 	if err == nil {
 		t.Fatal("expected permanent failure error")
 	}


### PR DESCRIPTION
## Summary

Makes OpenClaw bridged agents behave like a real WUPHF pack — addressable via **both** `@mentions` in a channel **and** 1:1 DMs, with replies landing where the human posted from.

Two gaps closed:

1. **Router didn't forward DMs.** `routeOpenclawMentionsLoop` only triggered on `msg.Tagged`. Posting to a DM channel with a bridged agent partner silently did nothing. Now the router infers the partner via a new `Broker.DMPartner(slug)` helper and forwards when it's a bridged slug. Mentions and DMs dedupe — a DM that also `@mentions` the partner fires exactly one send.
2. **Bridge always replied in #general.** `OpenclawBridge.postBridgeMessage` was hardcoded to `#general`, so DM queries got answered in the wrong place. Now the bridge tracks `lastChannelByKey` per session and `OnOfficeMessage` threads the source channel through; replies land back in the same channel.

Small supporting additions:
- `Broker.EnsureDirectChannel(agentSlug)` — upserts the 1:1 DM row in both the channel store and the broker's in-memory table. Used by the probe (and available to `/connect` flows that want to eagerly provision DMs).
- `team.StartOpenclawRouter(ctx, broker, bridge)` — exported entry for the routing goroutine so out-of-package callers (probes) run the same code path as `launcher.go:3295`.

## Receipt (live OpenClaw daemon + Codex OAuth)

```
created session for pm-bot:  agent:main:dashboard:5d26fdfb-...
created session for eng-bot: agent:main:dashboard:46a6f556-...
  MEMBER: "pm-bot"  name="PM Bot"  role="Bridged agent" createdBy="openclaw"
  MEMBER: "eng-bot" name="Eng Bot" role="Bridged agent" createdBy="openclaw"

SEND #general (@pm-bot @eng-bot): "hello both of you — reply with exactly the single word: pong"
  RECV #general from pm-bot:  "pong"
  RECV #general from eng-bot: "pong"

SEND DM→pm-bot  (human__pm-bot): "reply with exactly the single word: alpha"
  RECV DM←pm-bot:  "alpha"

SEND DM→eng-bot (eng-bot__human): "reply with exactly the single word: bravo"
  RECV DM←eng-bot: "bravo"

PASS
```

## Test plan

- [x] `go test ./internal/team/` — all routing + bridge unit tests pass (including 2 new: `TestRouteOpenclawMentionsLoopForwardsDMPost`, `TestRouteOpenclawMentionsLoopDedupesDMAndMention`)
- [x] `go test ./...` — full repo green
- [x] `go run ./cmd/wuphf-oc-probe/pack` against a live daemon — both channel and DM paths answered by the real OpenAI Codex model
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)