### PR TITLE
[codex] Add GBrain memory backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ That's it. The browser opens automatically and you're in the office. Unlike Ryan
 
 | Flag | What it does |
 |------|-------------|
+| `--memory-backend <name>` | Pick the organizational memory backend (`nex`, `gbrain`, `none`) |
 | `--no-nex` | Skip the Nex backend (no context graph, no Nex-managed integrations) |
 | `--tui` | Use the tmux TUI instead of the web UI |
 | `--no-open` | Don't auto-open the browser |
@@ -55,6 +56,24 @@ That's it. The browser opens automatically and you're in the office. Unlike Ryan
 | `--web-port <n>` | Change the web UI port (default 7891) |
 
 `--no-nex` still lets Telegram and any other local integration keep working. To switch back to CEO-routed delegation after launch, use `/focus` inside the office.
+
+## Memory Backends
+
+WUPHF can run with three organizational context modes:
+
+- `nex` is the default. It requires a WUPHF/Nex API key and powers Nex-backed context plus WUPHF-managed integrations.
+- `gbrain` mounts `gbrain serve` as the office memory layer. It requires an API key during `/init`: `OpenAI` gives you the full path with embeddings and vector search, while `Anthropic` alone is reduced mode.
+- `none` disables the external memory layer entirely.
+
+Examples:
+
+```bash
+wuphf --memory-backend nex
+wuphf --memory-backend gbrain
+wuphf --memory-backend none
+```
+
+When you select `gbrain`, onboarding asks for an OpenAI or Anthropic key up front and explains the tradeoff. If you want embeddings and vector search, use OpenAI.
 
 ## Other Commands
 

--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -732,11 +732,21 @@ func newChannelModelWithApp(threadsCollapsed bool, initialApp officeApp) channel
 		m.autocomplete = tui.NewAutocomplete(buildOneOnOneSlashCommands())
 		m.notice = "Conference room reserved. Direct session reset. Agent pane reloaded in place. No Toby."
 	}
-	if config.ResolveNoNex() {
-		m.notice = "Running in office-only mode. Nex tools are disabled for this session."
-	} else if config.ResolveAPIKey("") == "" {
+	memoryStatus := team.ResolveMemoryBackendStatus()
+	if memoryStatus.SelectedKind == config.MemoryBackendNone {
+		if config.ResolveNoNex() {
+			m.notice = "Running in office-only mode. Nex tools are disabled for this session."
+		} else {
+			m.notice = "Running without an external memory backend for this session."
+		}
+	} else if memoryStatus.SelectedKind == config.MemoryBackendNex && memoryStatus.ActiveKind == config.MemoryBackendNone && strings.TrimSpace(config.ResolveAPIKey("")) == "" {
 		m.notice = "No WUPHF API key configured. Starting setup..."
 		m.initFlow, _ = m.initFlow.Start()
+	} else if memoryStatus.SelectedKind == config.MemoryBackendGBrain && strings.TrimSpace(config.ResolveOpenAIAPIKey()) == "" && strings.TrimSpace(config.ResolveAnthropicAPIKey()) == "" {
+		m.notice = "No OpenAI or Anthropic API key configured for GBrain. Starting setup..."
+		m.initFlow, _ = m.initFlow.Start()
+	} else if memoryStatus.SelectedKind == config.MemoryBackendGBrain && memoryStatus.ActiveKind == config.MemoryBackendNone && strings.TrimSpace(memoryStatus.Detail) != "" {
+		m.notice = memoryStatus.Detail
 	}
 	m.syncSidebarCursorToActive()
 	return m
@@ -4813,8 +4823,13 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		return m, createDMChannel(slug)
 	case trimmed == "/integrate":
 		clearCurrent()
+		memoryStatus := team.ResolveMemoryBackendStatus()
+		if memoryStatus.SelectedKind != config.MemoryBackendNex {
+			m.notice = "Managed integrations are Nex-only right now. Select the Nex memory backend to use /integrate."
+			return m, nil
+		}
 		if config.ResolveNoNex() {
-			m.notice = "Nex is disabled (--no-nex). Running on local memory — like Creed, but better organized."
+			m.notice = "Nex is disabled (--no-nex), so managed integrations are unavailable for this run."
 			return m, nil
 		}
 		if config.ResolveAPIKey("") == "" {
@@ -5118,10 +5133,6 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		return m, mutateChannelMember(m.activeChannel, parts[1], parts[2])
 	case trimmed == "/init":
 		clearCurrent()
-		if config.ResolveNoNex() {
-			m.notice = "Nex is disabled (--no-nex). Ryan Howard did not let integration issues stop him. But he also failed. Restart without --no-nex to run setup."
-			return m, nil
-		}
 		m.notice = "Starting setup..."
 		var cmd tea.Cmd
 		m.initFlow, cmd = m.initFlow.Start()

--- a/cmd/wuphf/channel_recovery_test.go
+++ b/cmd/wuphf/channel_recovery_test.go
@@ -85,8 +85,8 @@ func TestBuildRecoveryLinesShowsSummaryAndHighlights(t *testing.T) {
 	if !strings.Contains(plain, "Current state") {
 		t.Fatalf("expected runtime-state card, got %q", plain)
 	}
-	if !strings.Contains(plain, "Waiting on you") {
-		t.Fatalf("expected normalized readiness card, got %q", plain)
+	if headline := strings.TrimSpace(workspace.Readiness.Headline); headline == "" || !strings.Contains(plain, headline) {
+		t.Fatalf("expected readiness headline %q, got %q", headline, plain)
 	}
 }
 

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -200,7 +200,7 @@ func hashSidebarState(channels []channelInfo, members []channelMember, tasks []c
 	h.addInt(workspace.IsolatedCount)
 	h.addInt(workspace.UnreadCount)
 	h.addBool(workspace.NoNex)
-	h.addBool(workspace.APIConfigured)
+	h.add(workspace.Memory.SelectedKind, workspace.Memory.SelectedLabel, workspace.Memory.ActiveKind, workspace.Memory.ActiveLabel, workspace.Memory.Detail, workspace.Memory.NextStep)
 	h.add(string(workspace.Readiness.Level), workspace.Readiness.Headline, workspace.Readiness.Detail, workspace.Readiness.NextStep)
 	if workspace.NeedsYou != nil {
 		h.add(workspace.NeedsYou.ID, workspace.NeedsYou.TitleOrQuestion())

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -1303,6 +1303,50 @@ func TestNewChannelModelAutoStartsInitWithoutAPIKey(t *testing.T) {
 	}
 }
 
+func TestNewChannelModelAutoStartsInitForGBrainWithoutProviderKey(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+	t.Setenv("WUPHF_OPENAI_API_KEY", "")
+	t.Setenv("WUPHF_ANTHROPIC_API_KEY", "")
+	defer os.Setenv("HOME", origHome)
+
+	m := newChannelModel(false)
+
+	if !m.initFlow.IsActive() && m.initFlow.Phase() != tui.InitAPIKey {
+		t.Fatalf("expected init flow to auto-start for missing gbrain credentials, got phase %q", m.initFlow.Phase())
+	}
+	if !strings.Contains(m.notice, "GBrain") || !strings.Contains(m.notice, "Starting setup") {
+		t.Fatalf("expected GBrain setup notice, got %q", m.notice)
+	}
+}
+
+func TestInitCommandRunsForGBrainBackend(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+	defer os.Setenv("HOME", origHome)
+
+	m := newChannelModel(false)
+	m.initFlow = tui.NewInitFlow()
+	m.notice = ""
+	m.input = []rune("/init")
+	m.inputPos = len(m.input)
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	got := next.(channelModel)
+
+	if !strings.Contains(got.notice, "Starting setup...") {
+		t.Fatalf("expected setup notice, got %q", got.notice)
+	}
+	if cmd == nil && got.initFlow.Phase() == tui.InitIdle {
+		t.Fatalf("expected /init to activate setup, got phase %q", got.initFlow.Phase())
+	}
+	if got.initFlow.Phase() != tui.InitAPIKey {
+		t.Fatalf("expected gbrain setup to ask for a provider key, got %q", got.initFlow.Phase())
+	}
+}
+
 func TestSlashAutocompleteShowsAllCommandsOnSlash(t *testing.T) {
 	m := newChannelModel(false)
 	m.input = []rune("/")

--- a/cmd/wuphf/channel_workspace_state.go
+++ b/cmd/wuphf/channel_workspace_state.go
@@ -27,6 +27,7 @@ type workspaceReadinessState struct {
 
 type workspaceUIState struct {
 	Runtime         team.RuntimeSnapshot
+	Memory          team.MemoryBackendStatus
 	Readiness       workspaceReadinessState
 	CurrentApp      officeApp
 	BrokerConnected bool
@@ -46,7 +47,6 @@ type workspaceUIState struct {
 	NeedsYou        *channelInterview
 	PrimaryTask     *channelTask
 	NoNex           bool
-	APIConfigured   bool
 }
 
 func (m channelModel) currentWorkspaceUIState() workspaceUIState {
@@ -67,8 +67,8 @@ func (m channelModel) currentWorkspaceUIState() workspaceUIState {
 		UnreadCount:     m.unreadCount,
 		AwaySummary:     awaySummary,
 		Focus:           trimRecoverySentence(snapshot.Recovery.Focus),
+		Memory:          team.ResolveMemoryBackendStatus(),
 		NoNex:           config.ResolveNoNex(),
-		APIConfigured:   strings.TrimSpace(config.ResolveAPIKey("")) != "",
 	}
 
 	for _, req := range snapshot.Requests {
@@ -128,20 +128,20 @@ func deriveWorkspaceReadiness(state workspaceUIState, doctor *channelDoctorRepor
 			NextStep: "Launch WUPHF to attach the live office, or run /doctor to inspect runtime readiness.",
 		}
 	}
-	if state.NoNex {
+	if state.Memory.SelectedKind == config.MemoryBackendNone {
 		return workspaceReadinessState{
 			Level:    workspaceReadinessReady,
 			Headline: "Local-only runtime",
-			Detail:   "The office is live, but Nex-backed memory and integrations are disabled for this run.",
-			NextStep: "Restart without --no-nex when you want memory, integrations, and provider-backed context.",
+			Detail:   state.Memory.Detail,
+			NextStep: state.Memory.NextStep,
 		}
 	}
-	if !state.APIConfigured {
+	if state.Memory.ActiveKind == config.MemoryBackendNone {
 		return workspaceReadinessState{
 			Level:    workspaceReadinessWarn,
-			Headline: "Finish setup",
-			Detail:   "The office runtime is up, but Nex-backed context and integrations are not configured yet.",
-			NextStep: "Run /init to finish API-key setup, or /doctor to inspect the remaining blockers.",
+			Headline: "Memory backend needs setup",
+			Detail:   state.Memory.Detail,
+			NextStep: firstWorkspaceString(state.Memory.NextStep, "/doctor shows the remaining runtime blockers."),
 		}
 	}
 	if doctor != nil {
@@ -174,7 +174,7 @@ func deriveWorkspaceReadiness(state workspaceUIState, doctor *channelDoctorRepor
 	return workspaceReadinessState{
 		Level:    workspaceReadinessReady,
 		Headline: "Ready to work",
-		Detail:   "The live office runtime is attached and ready for collaboration.",
+		Detail:   fmt.Sprintf("The live office runtime is attached and ready for collaboration with %s memory.", state.Memory.ActiveLabel),
 		NextStep: "Use /switcher to move through the office, or /recover to regain context before replying.",
 	}
 }
@@ -189,6 +189,15 @@ func firstDoctorNextStep(report channelDoctorReport, fallback string) string {
 		}
 	}
 	return fallback
+}
+
+func firstWorkspaceString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func (s workspaceUIState) readinessCard() (title, body, accent string, extra []string) {
@@ -326,8 +335,10 @@ func (s workspaceUIState) sidebarHintLine() string {
 		return s.Readiness.NextStep
 	case strings.TrimSpace(s.AwaySummary) != "" && s.UnreadCount > 0:
 		return "While away: " + s.AwaySummary
-	case !s.NoNex && !s.APIConfigured:
-		return "/init finishes setup · /doctor explains what is missing"
+	case s.Memory.SelectedKind == config.MemoryBackendNex && s.Memory.ActiveKind == config.MemoryBackendNone:
+		return "/init finishes Nex setup · /doctor explains what is missing"
+	case s.Memory.SelectedKind == config.MemoryBackendGBrain && s.Memory.ActiveKind == config.MemoryBackendNone:
+		return firstWorkspaceString(s.Memory.NextStep, "/doctor explains what is missing")
 	case strings.TrimSpace(s.NextStep) != "":
 		return s.NextStep
 	case strings.TrimSpace(s.Focus) != "":
@@ -381,8 +392,12 @@ func (m channelModel) buildOfficeIntroLines(contentWidth int) []renderedLine {
 	}
 
 	readinessTitle, readinessBody, readinessAccent, readinessExtra := state.readinessCard()
-	if state.NoNex && state.BrokerConnected {
-		readinessExtra = append(readinessExtra, "Nex is disabled for this run; memory and integrations are local-only.")
+	if state.BrokerConnected {
+		if state.Memory.ActiveKind != config.MemoryBackendNone {
+			readinessExtra = append(readinessExtra, "Memory backend: "+state.Memory.ActiveLabel)
+		} else {
+			readinessExtra = append(readinessExtra, "Memory backend: "+state.Memory.SelectedLabel)
+		}
 	}
 	for _, line := range renderRuntimeEventCard(contentWidth, readinessTitle, readinessBody, readinessAccent, readinessExtra) {
 		lines = append(lines, renderedLine{Text: "  " + line})

--- a/cmd/wuphf/channel_workspace_state_test.go
+++ b/cmd/wuphf/channel_workspace_state_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestBuildOfficeIntroLinesUsesWorkspaceState(t *testing.T) {
+	t.Setenv("WUPHF_NO_NEX", "1")
 	m := newChannelModel(false)
 	m.brokerConnected = true
 	m.members = []channelMember{{Slug: "ceo", Name: "CEO"}, {Slug: "pm", Name: "Product Manager"}}
@@ -18,10 +19,10 @@ func TestBuildOfficeIntroLinesUsesWorkspaceState(t *testing.T) {
 	if !strings.Contains(plain, "Welcome to The WUPHF Office.") {
 		t.Fatalf("expected office welcome copy, got %q", plain)
 	}
-	if !strings.Contains(plain, "Ready to work") {
-		t.Fatalf("expected ready-to-work card, got %q", plain)
+	if !strings.Contains(plain, "Local-only runtime") {
+		t.Fatalf("expected local-only readiness card, got %q", plain)
 	}
-	if !strings.Contains(plain, "Use /switcher to move through the office, or /recover to regain context before replying.") {
+	if !strings.Contains(plain, "Restart without --no-nex or select --memory-backend gbrain when you want external context.") {
 		t.Fatalf("expected switcher guidance, got %q", plain)
 	}
 }
@@ -76,6 +77,7 @@ func TestCurrentHeaderMetaUsesWorkspaceStateForOfficeMessages(t *testing.T) {
 }
 
 func TestCurrentWorkspaceUIStatePromotesDoctorWarningsIntoReadiness(t *testing.T) {
+	t.Setenv("WUPHF_NO_NEX", "1")
 	m := newChannelModel(false)
 	m.brokerConnected = true
 	m.activeChannel = "general"
@@ -91,10 +93,10 @@ func TestCurrentWorkspaceUIStatePromotesDoctorWarningsIntoReadiness(t *testing.T
 	}
 
 	state := m.currentWorkspaceUIState()
-	if state.Readiness.Level != workspaceReadinessWarn {
-		t.Fatalf("expected warning readiness, got %+v", state.Readiness)
+	if state.Readiness.Level != workspaceReadinessReady {
+		t.Fatalf("expected ready local-only readiness, got %+v", state.Readiness)
 	}
-	if !strings.Contains(state.Readiness.NextStep, "Connect Gmail, CRM") {
-		t.Fatalf("expected doctor next step to flow into readiness, got %+v", state.Readiness)
+	if !strings.Contains(state.Readiness.Headline, "Local-only") {
+		t.Fatalf("expected local-only readiness headline, got %+v", state.Readiness)
 	}
 }

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -112,6 +112,7 @@ func main() {
 	tuiMode := flag.Bool("tui", false, "Launch with tmux TUI instead of the web UI")
 	webPort := flag.Int("web-port", 7891, "Port for the web UI (default 7891)")
 	noNex := flag.Bool("no-nex", false, "Disable Nex completely for this run")
+	memoryBackend := flag.String("memory-backend", "", "Memory backend for organizational context (nex, gbrain, none)")
 	opusCEO := flag.Bool("opus-ceo", false, "Upgrade CEO agent from Sonnet to Opus")
 	collabMode := flag.Bool("collab", false, "Start in collaborative mode (all agents see all messages)")
 	noOpen := flag.Bool("no-open", false, "Don't open browser automatically on launch")
@@ -141,6 +142,14 @@ func main() {
 
 	if *noNex {
 		_ = os.Setenv("WUPHF_NO_NEX", "1")
+	}
+	if backend := strings.TrimSpace(*memoryBackend); backend != "" {
+		normalized := config.NormalizeMemoryBackend(backend)
+		if normalized == "" {
+			fmt.Fprintf(os.Stderr, "error: unsupported memory backend %q (expected nex, gbrain, or none)\n", backend)
+			os.Exit(1)
+		}
+		_ = os.Setenv("WUPHF_MEMORY_BACKEND", normalized)
 	}
 	if provider := strings.TrimSpace(*providerFlag); provider != "" {
 		switch provider {
@@ -330,8 +339,8 @@ func runWeb(args []string, packSlug string, unsafe bool, webPort int, opusCEO bo
 }
 
 func dispatch(cmd string, apiKeyFlag string, format string) {
-	if config.ResolveNoNex() {
-		fmt.Fprintf(os.Stderr, "Nex is disabled (--no-nex). Running on local memory — like Creed, but better organized. Start %s without --no-nex to use backend commands.\n", appName)
+	if config.ResolveMemoryBackend("") != config.MemoryBackendNex {
+		fmt.Fprintf(os.Stderr, "Non-interactive backend commands currently require the Nex memory backend. Selected backend: %s.\n", config.MemoryBackendLabel(config.ResolveMemoryBackend("")))
 		os.Exit(1)
 	}
 	if isSetupCommand(cmd) {

--- a/internal/commands/cmd_config.go
+++ b/internal/commands/cmd_config.go
@@ -53,6 +53,13 @@ func configShow(ctx *SlashContext) error {
 	if provider == "" {
 		provider = "(not set)"
 	}
+	memoryBackend := cfg.MemoryBackend
+	if memoryBackend == "" {
+		memoryBackend = config.ResolveMemoryBackend("")
+	}
+	if memoryBackend == "" {
+		memoryBackend = "(not set)"
+	}
 
 	pack := cfg.Pack
 	if pack == "" {
@@ -71,6 +78,7 @@ func configShow(ctx *SlashContext) error {
 	sb.WriteString(fmt.Sprintf("  Integrations: %s\n", config.OneSetupSummary()))
 	sb.WriteString(fmt.Sprintf("  Action provider: %s\n", actionProvider))
 	sb.WriteString(fmt.Sprintf("  Workspace: %s\n", workspace))
+	sb.WriteString(fmt.Sprintf("  Memory:    %s\n", memoryBackend))
 	sb.WriteString(fmt.Sprintf("  Provider:  %s\n", provider))
 	sb.WriteString(fmt.Sprintf("  Gemini:    %s\n", maskKey(cfg.GeminiAPIKey)))
 	sb.WriteString(fmt.Sprintf("  Anthropic: %s\n", maskKey(cfg.AnthropicAPIKey)))
@@ -109,6 +117,13 @@ func configSet(ctx *SlashContext, key, value string) error {
 		cfg.WorkspaceID = value
 	case "workspace_slug":
 		cfg.WorkspaceSlug = value
+	case "memory_backend":
+		normalized := config.NormalizeMemoryBackend(value)
+		if normalized == "" {
+			ctx.AddMessage("system", "Unsupported memory backend. Valid values: nex, gbrain, none")
+			return nil
+		}
+		cfg.MemoryBackend = normalized
 	case "llm_provider":
 		cfg.LLMProvider = value
 	case "gemini_api_key":
@@ -139,7 +154,7 @@ func configSet(ctx *SlashContext, key, value string) error {
 		cfg.CompanyPriority = value
 	default:
 		ctx.AddMessage("system", "Unknown config key: "+key+
-			"\nValid keys: api_key, composio_api_key, action_provider, workspace_id, workspace_slug, llm_provider, gemini_api_key, anthropic_api_key, openai_api_key, minimax_api_key, pack, team_lead_slug, dev_url, default_format, company_name, company_description, company_goals, company_size, company_priority")
+			"\nValid keys: api_key, composio_api_key, action_provider, workspace_id, workspace_slug, memory_backend, llm_provider, gemini_api_key, anthropic_api_key, openai_api_key, minimax_api_key, pack, team_lead_slug, dev_url, default_format, company_name, company_description, company_goals, company_size, company_priority")
 		return nil
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 // Config mirrors ~/.wuphf/config.json.
 type Config struct {
 	APIKey              string `json:"api_key,omitempty"`
+	MemoryBackend       string `json:"memory_backend,omitempty"`
 	OneAPIKey           string `json:"one_api_key,omitempty"`
 	ComposioAPIKey      string `json:"composio_api_key,omitempty"`
 	ActionProvider      string `json:"action_provider,omitempty"`
@@ -47,6 +48,12 @@ type Config struct {
 	OpenclawGatewayURL string                  `json:"openclaw_gateway_url,omitempty"`
 	OpenclawToken      string                  `json:"openclaw_token,omitempty"`
 }
+
+const (
+	MemoryBackendNone   = "none"
+	MemoryBackendNex    = "nex"
+	MemoryBackendGBrain = "gbrain"
+)
 
 // OpenclawBridgeBinding binds a WUPHF agent session to an OpenClaw bridge slug.
 type OpenclawBridgeBinding struct {
@@ -139,6 +146,62 @@ func ResolveNoNex() bool {
 		return false
 	}
 	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+}
+
+// NormalizeMemoryBackend returns a supported memory backend or the empty string.
+func NormalizeMemoryBackend(value string) string {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case MemoryBackendNone:
+		return MemoryBackendNone
+	case MemoryBackendNex:
+		return MemoryBackendNex
+	case MemoryBackendGBrain:
+		return MemoryBackendGBrain
+	default:
+		return ""
+	}
+}
+
+// ResolveMemoryBackend resolves the active organizational memory backend.
+// Resolution: flag/env override > config file > default.
+//
+// Defaults:
+//   - `nex` when Nex is allowed for the run
+//   - `none` when --no-nex is set and no alternate backend was selected
+//
+// `--no-nex` always disables the Nex backend itself, but does not prevent an
+// alternate backend like GBrain from being selected.
+func ResolveMemoryBackend(flagValue string) string {
+	backend := NormalizeMemoryBackend(flagValue)
+	if backend == "" {
+		backend = NormalizeMemoryBackend(os.Getenv("WUPHF_MEMORY_BACKEND"))
+	}
+	if backend == "" {
+		cfg, _ := Load()
+		backend = NormalizeMemoryBackend(cfg.MemoryBackend)
+	}
+	if backend == "" {
+		if ResolveNoNex() {
+			return MemoryBackendNone
+		}
+		return MemoryBackendNex
+	}
+	if backend == MemoryBackendNex && ResolveNoNex() {
+		return MemoryBackendNone
+	}
+	return backend
+}
+
+// MemoryBackendLabel returns a short user-facing label for the backend.
+func MemoryBackendLabel(backend string) string {
+	switch NormalizeMemoryBackend(backend) {
+	case MemoryBackendNex:
+		return "Nex"
+	case MemoryBackendGBrain:
+		return "GBrain"
+	default:
+		return "Local-only"
+	}
 }
 
 // ResolveLLMProvider resolves the active LLM provider for this run.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,7 @@ func TestRoundtrip(t *testing.T) {
 	withTempConfig(t, func(_ string) {
 		in := Config{
 			APIKey:             "test-key",
+			MemoryBackend:      MemoryBackendGBrain,
 			Email:              "user@example.com",
 			WorkspaceID:        "ws-123",
 			WorkspaceSlug:      "my-ws",
@@ -118,6 +119,46 @@ func TestResolveAPIKeyConfigFile(t *testing.T) {
 		_ = Save(Config{APIKey: "file-key"})
 		if got := ResolveAPIKey(""); got != "file-key" {
 			t.Fatalf("config file fallback failed, got: %s", got)
+		}
+	})
+}
+
+func TestResolveMemoryBackendDefaultsToNex(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		t.Setenv("WUPHF_NO_NEX", "")
+		t.Setenv("WUPHF_MEMORY_BACKEND", "")
+		if got := ResolveMemoryBackend(""); got != MemoryBackendNex {
+			t.Fatalf("expected default memory backend nex, got %q", got)
+		}
+	})
+}
+
+func TestResolveMemoryBackendDefaultsToNoneWhenNoNex(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		t.Setenv("WUPHF_NO_NEX", "1")
+		t.Setenv("WUPHF_MEMORY_BACKEND", "")
+		if got := ResolveMemoryBackend(""); got != MemoryBackendNone {
+			t.Fatalf("expected no-nex default to resolve to none, got %q", got)
+		}
+	})
+}
+
+func TestResolveMemoryBackendAllowsGBrainUnderNoNex(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		t.Setenv("WUPHF_NO_NEX", "1")
+		t.Setenv("WUPHF_MEMORY_BACKEND", MemoryBackendGBrain)
+		if got := ResolveMemoryBackend(""); got != MemoryBackendGBrain {
+			t.Fatalf("expected explicit gbrain to survive no-nex, got %q", got)
+		}
+	})
+}
+
+func TestResolveMemoryBackendForcesNexToNoneUnderNoNex(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		t.Setenv("WUPHF_NO_NEX", "1")
+		t.Setenv("WUPHF_MEMORY_BACKEND", MemoryBackendNex)
+		if got := ResolveMemoryBackend(""); got != MemoryBackendNone {
+			t.Fatalf("expected nex to resolve to none under no-nex, got %q", got)
 		}
 	})
 }

--- a/internal/gbrain/cli.go
+++ b/internal/gbrain/cli.go
@@ -1,0 +1,130 @@
+package gbrain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+const DefaultTimeout = 8 * time.Second
+
+var ErrNotInstalled = errors.New("gbrain not installed")
+
+type SearchResult struct {
+	Slug        string  `json:"slug"`
+	PageID      int     `json:"page_id"`
+	Title       string  `json:"title"`
+	Type        string  `json:"type"`
+	ChunkText   string  `json:"chunk_text"`
+	ChunkSource string  `json:"chunk_source"`
+	ChunkID     int     `json:"chunk_id"`
+	ChunkIndex  int     `json:"chunk_index"`
+	Score       float64 `json:"score"`
+	Stale       bool    `json:"stale"`
+}
+
+func BinaryPath() string {
+	if candidate := strings.TrimSpace(os.Getenv("WUPHF_GBRAIN_COMMAND")); candidate != "" {
+		if path, err := exec.LookPath(candidate); err == nil {
+			return path
+		}
+	}
+	if path, err := exec.LookPath("gbrain"); err == nil {
+		return path
+	}
+	return ""
+}
+
+func IsInstalled() bool {
+	return BinaryPath() != ""
+}
+
+func Run(ctx context.Context, args ...string) (string, error) {
+	bin := BinaryPath()
+	if bin == "" {
+		return "", ErrNotInstalled
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, DefaultTimeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = gbrainEnv()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return "", fmt.Errorf("gbrain %s: timeout after %s", strings.Join(args, " "), DefaultTimeout)
+		}
+		if detail := strings.TrimSpace(stderr.String()); detail != "" {
+			return "", fmt.Errorf("gbrain %s: %s", strings.Join(args, " "), detail)
+		}
+		return "", fmt.Errorf("gbrain %s: %w", strings.Join(args, " "), err)
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func Call(ctx context.Context, tool string, params any) (string, error) {
+	tool = strings.TrimSpace(tool)
+	if tool == "" {
+		return "", fmt.Errorf("gbrain call: tool is required")
+	}
+	payload, err := json.Marshal(params)
+	if err != nil {
+		return "", err
+	}
+	return Run(ctx, "call", tool, string(payload))
+}
+
+func Query(ctx context.Context, query string, limit int) ([]SearchResult, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	raw, err := Call(ctx, "query", map[string]any{
+		"query":  query,
+		"limit":  limit,
+		"detail": "low",
+	})
+	if err != nil {
+		return nil, err
+	}
+	var results []SearchResult
+	if err := json.Unmarshal([]byte(raw), &results); err != nil {
+		return nil, fmt.Errorf("decode gbrain query: %w", err)
+	}
+	return results, nil
+}
+
+func gbrainEnv() []string {
+	env := os.Environ()
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(os.Getenv("HOME")) == "" {
+		env = append(env, "HOME="+home)
+	}
+	if key := strings.TrimSpace(config.ResolveOpenAIAPIKey()); key != "" && strings.TrimSpace(os.Getenv("OPENAI_API_KEY")) == "" {
+		env = append(env, "OPENAI_API_KEY="+key)
+	}
+	if key := strings.TrimSpace(config.ResolveAnthropicAPIKey()); key != "" && strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")) == "" {
+		env = append(env, "ANTHROPIC_API_KEY="+key)
+	}
+	return env
+}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -3034,20 +3034,23 @@ func (b *Broker) handleHealth(w http.ResponseWriter, r *http.Request) {
 	focus := b.focusMode
 	provider := b.runtimeProvider
 	b.mu.Unlock()
+	if strings.TrimSpace(provider) == "" {
+		provider = config.ResolveLLMProvider("")
+	}
+	memoryStatus := ResolveMemoryBackendStatus()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	// nex_connected now reflects whether the local nex-cli binary is available
-	// and the user hasn't disabled Nex for this session via --no-nex. The legacy
-	// HTTP ping to app.nex.ai is gone; Nex memory now lives behind nex-cli.
-	nexConnected := nex.Connected()
 	json.NewEncoder(w).Encode(map[string]any{
-		"status":           "ok",
-		"session_mode":     mode,
-		"one_on_one_agent": agent,
-		"focus_mode":       focus,
-		"provider":         provider,
-		"nex_connected":    nexConnected,
-		"build":            buildinfo.Current(),
+		"status":                "ok",
+		"session_mode":          mode,
+		"one_on_one_agent":      agent,
+		"focus_mode":            focus,
+		"provider":              provider,
+		"memory_backend":        memoryStatus.SelectedKind,
+		"memory_backend_active": memoryStatus.ActiveKind,
+		"memory_backend_ready":  memoryStatus.ActiveKind != config.MemoryBackendNone,
+		"nex_connected":         memoryStatus.ActiveKind == config.MemoryBackendNex && nex.Connected(),
+		"build":                 buildinfo.Current(),
 	})
 }
 
@@ -3631,10 +3634,10 @@ func (b *Broker) handleCompany(w http.ResponseWriter, r *http.Request) {
 func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		cfg, _ := config.Load()
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]any{
-			"llm_provider": cfg.LLMProvider,
+			"llm_provider":   config.ResolveLLMProvider(""),
+			"memory_backend": config.ResolveMemoryBackend(""),
 		})
 	case http.MethodPost:
 		var body struct {

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -680,6 +680,9 @@ func TestBrokerAuthRejectsUnauthenticated(t *testing.T) {
 	defer func() { brokerStatePath = oldPathFn }()
 
 	b := NewBroker()
+	b.runtimeProvider = "codex"
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+	t.Setenv("WUPHF_OPENAI_API_KEY", "sk-test-openai")
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -697,9 +700,13 @@ func TestBrokerAuthRejectsUnauthenticated(t *testing.T) {
 		t.Fatalf("expected 200 on /health, got %d", resp.StatusCode)
 	}
 	var health struct {
-		SessionMode   string `json:"session_mode"`
-		OneOnOneAgent string `json:"one_on_one_agent"`
-		Build         struct {
+		SessionMode         string `json:"session_mode"`
+		OneOnOneAgent       string `json:"one_on_one_agent"`
+		Provider            string `json:"provider"`
+		MemoryBackend       string `json:"memory_backend"`
+		MemoryBackendActive string `json:"memory_backend_active"`
+		NexConnected        bool   `json:"nex_connected"`
+		Build               struct {
 			Version        string `json:"version"`
 			BuildTimestamp string `json:"build_timestamp"`
 		} `json:"build"`
@@ -714,6 +721,18 @@ func TestBrokerAuthRejectsUnauthenticated(t *testing.T) {
 	}
 	if health.OneOnOneAgent != DefaultOneOnOneAgent {
 		t.Fatalf("expected health to report default 1o1 agent %q, got %q", DefaultOneOnOneAgent, health.OneOnOneAgent)
+	}
+	if health.Provider != "codex" {
+		t.Fatalf("expected health to report provider codex, got %q", health.Provider)
+	}
+	if health.MemoryBackend != config.MemoryBackendGBrain {
+		t.Fatalf("expected health to report selected memory backend gbrain, got %q", health.MemoryBackend)
+	}
+	if health.MemoryBackendActive != config.MemoryBackendNone {
+		t.Fatalf("expected inactive gbrain backend without CLI installed, got %q", health.MemoryBackendActive)
+	}
+	if health.NexConnected {
+		t.Fatal("expected nex_connected=false when gbrain is selected")
 	}
 	wantBuild := buildinfo.Current()
 	if health.Build.Version != wantBuild.Version {

--- a/internal/team/capabilities.go
+++ b/internal/team/capabilities.go
@@ -68,7 +68,7 @@ func DetectRuntimeCapabilitiesWithOptions(opts CapabilityProbeOptions) RuntimeCa
 	summaryKeys := []string{
 		CapabilityKeyOfficeRuntime,
 		CapabilityKeyDirectRuntime,
-		CapabilityKeyNex,
+		CapabilityKeyMemory,
 		CapabilityKeyActions,
 		CapabilityKeyWorkflows,
 		CapabilityKeyOfficeActions,

--- a/internal/team/capability_registry.go
+++ b/internal/team/capability_registry.go
@@ -38,7 +38,8 @@ const (
 	CapabilityKeyCodex         = "codex"
 	CapabilityKeyOfficeRuntime = "office_runtime"
 	CapabilityKeyDirectRuntime = "direct_runtime"
-	CapabilityKeyNex           = "nex"
+	CapabilityKeyMemory        = "memory"
+	CapabilityKeyNex           = CapabilityKeyMemory
 	CapabilityKeyConnections   = "connections"
 	CapabilityKeyActions       = "actions"
 	CapabilityKeyWorkflows     = "workflows"
@@ -129,7 +130,7 @@ func buildCapabilityRegistry(providerName string, tmuxStatus, claudeStatus, code
 		descriptorFromStatus(CapabilityKeyTmux, "tmux", CapabilityCategoryRuntime, tmuxStatus),
 		descriptorFromStatus(CapabilityKeyClaude, "claude", CapabilityCategoryRuntime, claudeStatus),
 		descriptorFromStatus(CapabilityKeyCodex, "codex", CapabilityCategoryRuntime, codexStatus),
-		buildNexDescriptor(),
+		buildMemoryDescriptor(),
 		buildActionCapabilityDescriptor(CapabilityKeyActions, "Action execution", CapabilityCategoryAction, action.CapabilityActionExecute),
 		buildActionCapabilityDescriptor(CapabilityKeyWorkflows, "Workflow execution", CapabilityCategoryWorkflow, action.CapabilityWorkflowExecute),
 		buildActionCapabilityDescriptor(CapabilityKeyOfficeActions, "Office actions", CapabilityCategoryOffice, action.CapabilityActionExecute),
@@ -213,36 +214,44 @@ func buildDirectRuntimeDescriptor(providerName string, claudeStatus, codexStatus
 	}
 }
 
-func buildNexDescriptor() CapabilityDescriptor {
-	if config.ResolveNoNex() {
+func buildMemoryDescriptor() CapabilityDescriptor {
+	status := ResolveMemoryBackendStatus()
+	switch status.SelectedKind {
+	case config.MemoryBackendNone:
 		return CapabilityDescriptor{
-			Key:       CapabilityKeyNex,
-			Label:     "Nex memory",
+			Key:       CapabilityKeyMemory,
+			Label:     "Memory backend",
 			Category:  CapabilityCategoryMemory,
 			Level:     CapabilityInfo,
 			Lifecycle: CapabilityLifecycleDisabled,
-			Detail:    "Disabled for this session with --no-nex.",
-			NextStep:  "Restart without --no-nex to enable organizational context and memory.",
+			Detail:    status.Detail,
+			NextStep:  status.NextStep,
 		}
-	}
-	if strings.TrimSpace(config.ResolveAPIKey("")) == "" {
+	default:
+		if status.ActiveKind == config.MemoryBackendNone {
+			label := status.SelectedLabel + " memory"
+			if strings.TrimSpace(label) == "" {
+				label = "Memory backend"
+			}
+			return CapabilityDescriptor{
+				Key:       CapabilityKeyMemory,
+				Label:     label,
+				Category:  CapabilityCategoryMemory,
+				Level:     CapabilityWarn,
+				Lifecycle: CapabilityLifecycleNeedsSetup,
+				Detail:    status.Detail,
+				NextStep:  status.NextStep,
+			}
+		}
+		label := status.ActiveLabel + " memory"
 		return CapabilityDescriptor{
-			Key:       CapabilityKeyNex,
-			Label:     "Nex memory",
+			Key:       CapabilityKeyMemory,
+			Label:     label,
 			Category:  CapabilityCategoryMemory,
-			Level:     CapabilityWarn,
-			Lifecycle: CapabilityLifecycleNeedsSetup,
-			Detail:    "No WUPHF/Nex API key is configured.",
-			NextStep:  "Run /init or set WUPHF_API_KEY to enable Nex-backed context.",
+			Level:     CapabilityReady,
+			Lifecycle: CapabilityLifecycleReady,
+			Detail:    status.Detail,
 		}
-	}
-	return CapabilityDescriptor{
-		Key:       CapabilityKeyNex,
-		Label:     "Nex memory",
-		Category:  CapabilityCategoryMemory,
-		Level:     CapabilityReady,
-		Lifecycle: CapabilityLifecycleReady,
-		Detail:    "Nex-backed organizational context is configured.",
 	}
 }
 

--- a/internal/team/config_endpoint_test.go
+++ b/internal/team/config_endpoint_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nex-crm/wuphf/internal/config"
 )
 
 // TestConfigEndpointAndHealth is a smoke test for ISSUE-004: the wizard's
@@ -53,6 +55,9 @@ func TestConfigEndpointAndHealth(t *testing.T) {
 	if p, _ := h1["provider"].(string); p != "claude-code" {
 		t.Fatalf("expected provider=claude-code before POST, got %q", p)
 	}
+	if backend, _ := h1["memory_backend"].(string); backend != config.MemoryBackendNex {
+		t.Fatalf("expected memory_backend=%q before POST, got %q", config.MemoryBackendNex, backend)
+	}
 
 	// POST /config with codex — simulates the wizard tile click
 	body := bytes.NewBufferString(`{"llm_provider":"codex"}`)
@@ -82,6 +87,23 @@ func TestConfigEndpointAndHealth(t *testing.T) {
 	t.Logf("GET /health (after POST) -> %s", string(raw2))
 	if p, _ := h2["provider"].(string); p != "codex" {
 		t.Fatalf("expected provider=codex after POST, got %q", p)
+	}
+
+	req, _ = http.NewRequest(http.MethodGet, "http://"+b.addr+"/config", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /config: %v", err)
+	}
+	rawConfig, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	var cfgResp map[string]any
+	_ = json.Unmarshal(rawConfig, &cfgResp)
+	if p, _ := cfgResp["llm_provider"].(string); p != "codex" {
+		t.Fatalf("expected /config llm_provider=codex after POST, got %q (body=%s)", p, string(rawConfig))
+	}
+	if backend, _ := cfgResp["memory_backend"].(string); backend != config.MemoryBackendNex {
+		t.Fatalf("expected /config memory_backend=%q, got %q", config.MemoryBackendNex, backend)
 	}
 
 	// Verify persisted to disk

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/provider"
 )
@@ -73,14 +72,14 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	cmd.Env = env
 
 	// Enrich the notification with Nex entity context. Use a 2s deadline so a
-	// slow or unreachable Nex API never holds up the agent turn. The brief is
+	// slow or unreachable memory backend never holds up the agent turn. The brief is
 	// prepended to the notification so the original work packet stays intact.
 	stdinPayload := notification
-	nexCtx, nexCancel := context.WithTimeout(ctx, 2*time.Second)
-	if brief := action.FetchEntityBrief(nexCtx, notification); brief != "" {
+	memoryCtx, memoryCancel := context.WithTimeout(ctx, 2*time.Second)
+	if brief := fetchMemoryBrief(memoryCtx, notification); brief != "" {
 		stdinPayload = brief + "\n\n" + notification
 	}
-	nexCancel()
+	memoryCancel()
 	cmd.Stdin = strings.NewReader(stdinPayload)
 
 	stdout, err := cmd.StdoutPipe()
@@ -223,6 +222,7 @@ func (l *Launcher) buildHeadlessClaudeEnv(slug string) []string {
 		"WUPHF_AGENT_SLUG="+slug,
 		"WUPHF_BROKER_TOKEN="+l.broker.Token(),
 		"WUPHF_HEADLESS_PROVIDER=claude",
+		"WUPHF_MEMORY_BACKEND="+config.ResolveMemoryBackend(""),
 		fmt.Sprintf("WUPHF_NO_NEX=%t", config.ResolveNoNex()),
 		"ANTHROPIC_PROMPT_CACHING=1",
 	)

--- a/internal/team/headless_claude_test.go
+++ b/internal/team/headless_claude_test.go
@@ -242,6 +242,46 @@ func TestBuildMCPServerMap_NexPresentWhenEnabled(t *testing.T) {
 	}
 }
 
+func TestBuildMCPServerMap_GBrainPresentWhenSelected(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", "gbrain")
+	t.Setenv("WUPHF_OPENAI_API_KEY", "openai-test-key")
+
+	binDir := t.TempDir()
+	gbrainBin := filepath.Join(binDir, "gbrain")
+	if err := os.WriteFile(gbrainBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake gbrain: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	l := minimalLauncher(false)
+	servers, err := l.buildMCPServerMap()
+	if err != nil {
+		t.Fatalf("buildMCPServerMap: %v", err)
+	}
+	entry, ok := servers["gbrain"]
+	if !ok {
+		t.Fatalf("'gbrain' server must be present when GBrain is selected, got servers: %v", mapKeys(servers))
+	}
+	server, ok := entry.(map[string]any)
+	if !ok {
+		t.Fatalf("expected gbrain entry to be an object, got %T", entry)
+	}
+	if got := server["command"]; got != gbrainBin {
+		t.Fatalf("expected gbrain command %q, got %#v", gbrainBin, got)
+	}
+	args, ok := server["args"].([]string)
+	if !ok || len(args) != 1 || args[0] != "serve" {
+		t.Fatalf("expected gbrain args [serve], got %#v", server["args"])
+	}
+	env, ok := server["env"].(map[string]string)
+	if !ok {
+		t.Fatalf("expected gbrain env map, got %#v", server["env"])
+	}
+	if env["OPENAI_API_KEY"] != "openai-test-key" {
+		t.Fatalf("expected OPENAI_API_KEY to be forwarded, got %#v", env)
+	}
+}
+
 // mapKeys returns the keys of map[string]V for human-readable error messages.
 func mapKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -52,6 +52,7 @@ func (l *Launcher) launchHeadlessCodex() error {
 	exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 
 	l.broker = NewBroker()
+	l.broker.runtimeProvider = l.provider
 	l.broker.packSlug = l.packSlug
 	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
 		return fmt.Errorf("set session mode: %w", err)
@@ -66,7 +67,9 @@ func (l *Launcher) launchHeadlessCodex() error {
 	go l.notifyAgentsLoop()
 	if !l.isOneOnOne() {
 		go l.notifyTaskActionsLoop()
-		go l.pollNexNotificationsLoop()
+		if shouldPollNexNotifications() {
+			go l.pollNexNotificationsLoop()
+		}
 		go l.watchdogSchedulerLoop()
 	}
 
@@ -366,7 +369,13 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	cmd := headlessCodexCommandContext(ctx, "codex", args...)
 	cmd.Dir = l.cwd
 	cmd.Env = l.buildHeadlessCodexEnv(slug)
-	cmd.Stdin = strings.NewReader(buildHeadlessCodexPrompt(l.buildPrompt(slug), notification))
+	stdinPayload := notification
+	memoryCtx, memoryCancel := context.WithTimeout(ctx, 2*time.Second)
+	if brief := fetchMemoryBrief(memoryCtx, notification); brief != "" {
+		stdinPayload = brief + "\n\n" + notification
+	}
+	memoryCancel()
+	cmd.Stdin = strings.NewReader(buildHeadlessCodexPrompt(l.buildPrompt(slug), stdinPayload))
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -505,6 +514,7 @@ func (l *Launcher) buildHeadlessCodexEnv(slug string) []string {
 		"WUPHF_AGENT_SLUG="+slug,
 		"WUPHF_BROKER_TOKEN="+l.broker.Token(),
 		"WUPHF_HEADLESS_PROVIDER=codex",
+		"WUPHF_MEMORY_BACKEND="+config.ResolveMemoryBackend(""),
 	)
 	if config.ResolveNoNex() {
 		env = append(env, "WUPHF_NO_NEX=1")
@@ -530,6 +540,12 @@ func (l *Launcher) buildHeadlessCodexEnv(slug string) []string {
 			"NEX_API_KEY="+apiKey,
 		)
 	}
+	if apiKey := strings.TrimSpace(config.ResolveOpenAIAPIKey()); apiKey != "" {
+		env = append(env, "OPENAI_API_KEY="+apiKey)
+	}
+	if apiKey := strings.TrimSpace(config.ResolveAnthropicAPIKey()); apiKey != "" {
+		env = append(env, "ANTHROPIC_API_KEY="+apiKey)
+	}
 	return env
 }
 
@@ -541,6 +557,7 @@ func (l *Launcher) buildCodexOfficeConfigOverrides(slug string) ([]string, error
 	wuphfEnvVars := []string{
 		"WUPHF_AGENT_SLUG",
 		"WUPHF_BROKER_TOKEN",
+		"WUPHF_MEMORY_BACKEND",
 	}
 	if config.ResolveNoNex() {
 		wuphfEnvVars = append(wuphfEnvVars, "WUPHF_NO_NEX")
@@ -567,15 +584,15 @@ func (l *Launcher) buildCodexOfficeConfigOverrides(slug string) ([]string, error
 		fmt.Sprintf(`mcp_servers.wuphf-office.env_vars=%s`, tomlStringArray(wuphfEnvVars)),
 	}
 
-	if !config.ResolveNoNex() {
-		if nexMCP, err := headlessCodexLookPath("nex-mcp"); err == nil {
-			overrides = append(overrides, fmt.Sprintf(`mcp_servers.nex.command=%s`, tomlQuote(nexMCP)))
-			if apiKey := strings.TrimSpace(config.ResolveAPIKey("")); apiKey != "" {
-				overrides = append(overrides, fmt.Sprintf(`mcp_servers.nex.env_vars=%s`, tomlStringArray([]string{
-					"WUPHF_API_KEY",
-					"NEX_API_KEY",
-				})))
-			}
+	if server, err := resolvedMemoryMCPServer(); err != nil {
+		return nil, err
+	} else if server != nil {
+		overrides = append(overrides, fmt.Sprintf(`mcp_servers.%s.command=%s`, server.Name, tomlQuote(server.Command)))
+		if len(server.Args) > 0 {
+			overrides = append(overrides, fmt.Sprintf(`mcp_servers.%s.args=%s`, server.Name, tomlStringArray(server.Args)))
+		}
+		if len(server.EnvVars) > 0 {
+			overrides = append(overrides, fmt.Sprintf(`mcp_servers.%s.env_vars=%s`, server.Name, tomlStringArray(server.EnvVars)))
 		}
 	}
 

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -3,6 +3,7 @@ package team
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -77,7 +78,7 @@ func TestBuildCodexOfficeConfigOverridesIncludesOfficeMCPEnv(t *testing.T) {
 	if !strings.Contains(joined, `mcp_servers.wuphf-office.args=["mcp-team"]`) {
 		t.Fatalf("expected WUPHF MCP args override, got %q", joined)
 	}
-	if !strings.Contains(joined, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "WUPHF_NO_NEX", "WUPHF_ONE_ON_ONE", "WUPHF_ONE_ON_ONE_AGENT"]`) {
+	if !strings.Contains(joined, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "WUPHF_MEMORY_BACKEND", "WUPHF_NO_NEX", "WUPHF_ONE_ON_ONE", "WUPHF_ONE_ON_ONE_AGENT"]`) {
 		t.Fatalf("expected office env var forwarding, got %q", joined)
 	}
 	if strings.Contains(joined, broker.Token()) {
@@ -85,6 +86,52 @@ func TestBuildCodexOfficeConfigOverridesIncludesOfficeMCPEnv(t *testing.T) {
 	}
 	if strings.Contains(joined, `mcp_servers.nex.command=`) {
 		t.Fatalf("expected Nex MCP to stay disabled with WUPHF_NO_NEX, got %q", joined)
+	}
+}
+
+func TestBuildCodexOfficeConfigOverridesIncludesGBrainWhenSelected(t *testing.T) {
+	oldExecutablePath := headlessCodexExecutablePath
+	headlessCodexExecutablePath = func() (string, error) { return "/tmp/wuphf", nil }
+	defer func() {
+		headlessCodexExecutablePath = oldExecutablePath
+	}()
+
+	binDir := t.TempDir()
+	gbrainBin := filepath.Join(binDir, "gbrain")
+	if err := os.WriteFile(gbrainBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake gbrain: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("WUPHF_MEMORY_BACKEND", "gbrain")
+	t.Setenv("WUPHF_OPENAI_API_KEY", "openai-test-key")
+	t.Setenv("WUPHF_ANTHROPIC_API_KEY", "anthropic-test-key")
+
+	l := &Launcher{
+		broker: NewBroker(),
+		pack:   agent.GetPack("founding-team"),
+	}
+
+	overrides, err := l.buildCodexOfficeConfigOverrides("ceo")
+	if err != nil {
+		t.Fatalf("buildCodexOfficeConfigOverrides: %v", err)
+	}
+	joined := strings.Join(overrides, "\n")
+	if !strings.Contains(joined, fmt.Sprintf(`mcp_servers.gbrain.command=%q`, gbrainBin)) {
+		t.Fatalf("expected GBrain MCP command override, got %q", joined)
+	}
+	if !strings.Contains(joined, `mcp_servers.gbrain.args=["serve"]`) {
+		t.Fatalf("expected GBrain MCP args override, got %q", joined)
+	}
+	if !strings.Contains(joined, `mcp_servers.gbrain.env_vars=["HOME", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"]`) {
+		t.Fatalf("expected GBrain env forwarding, got %q", joined)
+	}
+
+	env := l.buildHeadlessCodexEnv("ceo")
+	if !containsEnv(env, "OPENAI_API_KEY=openai-test-key") {
+		t.Fatalf("expected OPENAI_API_KEY in codex env, got %#v", env)
+	}
+	if !containsEnv(env, "ANTHROPIC_API_KEY=anthropic-test-key") {
+		t.Fatalf("expected ANTHROPIC_API_KEY in codex env, got %#v", env)
 	}
 }
 
@@ -97,8 +144,6 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 		switch file {
 		case "codex":
 			return "/usr/bin/codex", nil
-		case "nex-mcp":
-			return "/usr/bin/nex-mcp", nil
 		default:
 			return "", exec.ErrNotFound
 		}
@@ -122,6 +167,12 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 	t.Setenv("WUPHF_ONE_SECRET", "one-secret-value")
 	t.Setenv("WUPHF_ONE_IDENTITY", "founder@example.com")
 	t.Setenv("WUPHF_ONE_IDENTITY_TYPE", "user")
+	binDir := t.TempDir()
+	nexMCP := filepath.Join(binDir, "nex-mcp")
+	if err := os.WriteFile(nexMCP, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake nex-mcp: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	l := &Launcher{
 		pack:        agent.GetPack("founding-team"),
@@ -142,10 +193,10 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 	if !strings.Contains(joinedArgs, `mcp_servers.wuphf-office.command="/tmp/wuphf"`) {
 		t.Fatalf("expected office MCP override, got %#v", record.Args)
 	}
-	if !strings.Contains(joinedArgs, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "ONE_SECRET", "ONE_IDENTITY", "ONE_IDENTITY_TYPE"]`) {
+	if !strings.Contains(joinedArgs, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "WUPHF_MEMORY_BACKEND", "ONE_SECRET", "ONE_IDENTITY", "ONE_IDENTITY_TYPE"]`) {
 		t.Fatalf("expected office env var forwarding, got %#v", record.Args)
 	}
-	if !strings.Contains(joinedArgs, `mcp_servers.nex.command="/usr/bin/nex-mcp"`) {
+	if !strings.Contains(joinedArgs, fmt.Sprintf(`mcp_servers.nex.command=%q`, nexMCP)) {
 		t.Fatalf("expected nex MCP override, got %#v", record.Args)
 	}
 	if !strings.Contains(joinedArgs, `mcp_servers.nex.env_vars=["WUPHF_API_KEY", "NEX_API_KEY"]`) {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -32,8 +32,8 @@ import (
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/nex"
-	"github.com/nex-crm/wuphf/internal/setup"
 	"github.com/nex-crm/wuphf/internal/provider"
+	"github.com/nex-crm/wuphf/internal/setup"
 )
 
 const (
@@ -127,13 +127,13 @@ func NewLauncher(packSlug string) (*Launcher, error) {
 	sessionMode, oneOnOne := loadRunningSessionMode()
 
 	return &Launcher{
-		packSlug:        packSlug,
-		pack:            pack,
-		sessionName:     SessionName,
-		cwd:             cwd,
-		sessionMode:     sessionMode,
-		oneOnOne:        oneOnOne,
-		provider:        config.ResolveLLMProvider(""),
+		packSlug:            packSlug,
+		pack:                pack,
+		sessionName:         SessionName,
+		cwd:                 cwd,
+		sessionMode:         sessionMode,
+		oneOnOne:            oneOnOne,
+		provider:            config.ResolveLLMProvider(""),
 		headlessWorkers:     make(map[string]bool),
 		headlessActive:      make(map[string]*headlessCodexActiveTurn),
 		headlessQueues:      make(map[string][]headlessCodexTurn),
@@ -300,7 +300,9 @@ func (l *Launcher) Launch() error {
 	go l.notifyAgentsLoop()
 	if !l.isOneOnOne() {
 		go l.notifyTaskActionsLoop()
-		go l.pollNexNotificationsLoop()
+		if shouldPollNexNotifications() {
+			go l.pollNexNotificationsLoop()
+		}
 		go l.watchdogSchedulerLoop()
 	}
 
@@ -358,7 +360,6 @@ func recoverPanicTo(site, extra string) {
 		}
 	}
 }
-
 
 func (l *Launcher) notifyTaskActionsLoop() {
 	if l.broker == nil {
@@ -2541,7 +2542,6 @@ func (l *Launcher) buildPrompt(slug string) string {
 	agentCfg := agentConfigFromMember(member)
 	officeMembers := l.officeMembersSnapshot()
 	lead := officeLeadSlugFrom(officeMembers, l.pack)
-	noNex := config.ResolveNoNex() || config.ResolveAPIKey("") == ""
 
 	var sb strings.Builder
 
@@ -2560,13 +2560,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("- team_broadcast: Send a normal direct chat reply into the 1:1 conversation\n")
 		sb.WriteString("- human_message: Send an emphasized report, recommendation, or action card directly to the human when you want it to stand out\n")
 		sb.WriteString("- human_interview: Ask a blocking decision question only when you truly cannot proceed responsibly without it\n\n")
-		if noNex {
-			sb.WriteString("Nex tools are disabled for this run. Base your work on the conversation and direct human answers only.\n\n")
-		} else {
-			sb.WriteString("Use the Nex context graph when it materially helps:\n")
-			sb.WriteString("- query_context: Look up prior decisions, people, projects, and history before guessing\n")
-			sb.WriteString("- add_context: Store durable conclusions only after you have actually landed them\n\n")
-		}
+		sb.WriteString(directMemoryPromptBlock())
 		sb.WriteString("RULES:\n")
 		sb.WriteString("1. Do not talk as if a team exists. There are no other agents in this session.\n")
 		sb.WriteString("2. Do not create or suggest channels, teammates, bridges, shared tasks, or office structure.\n")
@@ -2574,14 +2568,14 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("4. The pushed notification IS the latest state. Respond directly from it. Do NOT poll before replying.\n")
 		sb.WriteString("5. Use team_broadcast for normal replies. Use human_message only when you are deliberately presenting completion, a recommendation, or a next action.\n")
 		sb.WriteString("6. Use human_interview only for truly blocking decisions.\n")
-		sb.WriteString("7. If Nex is enabled, do not claim something is stored unless add_context actually succeeded.\n")
+		sb.WriteString(directMemoryStorageRule())
 		sb.WriteString("8. No fake collaboration language like 'I'll ask the team' or 'let me route this'. It is just you and the human here.\n\n")
 		sb.WriteString("CONVERSATION STYLE:\n")
 		sb.WriteString("- Sound like a sharp human operator, not a formal assistant.\n")
 		sb.WriteString("- Be concise, direct, and a little alive.\n")
 		sb.WriteString("- Light humor is fine. Don't turn the 1:1 into a bit.\n")
 		sb.WriteString("- If the human asks for a plan, recommendation, explanation, or judgment you can reasonably give now, answer now.\n")
-		sb.WriteString("- Do not go silent and over-research by default. Only inspect files, run tools, or query Nex first when the answer genuinely depends on that context.\n")
+		sb.WriteString("- Do not go silent and over-research by default. Only inspect files, run tools, or query the active memory backend first when the answer genuinely depends on that context.\n")
 		sb.WriteString("- If you need a deeper pass, give the human the quick answer first, then continue with the deeper work.\n")
 		return sb.String()
 	}
@@ -2608,11 +2602,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("- human_message: Present output or a recommendation directly to the human.\n")
 		sb.WriteString("- human_interview: Ask the human a blocking decision question — only when the team cannot proceed without it.\n")
 		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member.\n\n")
-		if noNex {
-			sb.WriteString("Nex tools are disabled for this run. Work only with the shared office channel and human answers.\n\n")
-		} else {
-			sb.WriteString("Nex memory: query_context before reinventing; add_context only after a decision is actually landed.\n\n")
-		}
+		sb.WriteString(leadMemoryPromptBlock())
 		sb.WriteString("Tagged agents are expected to respond.\n\n")
 		if l.isFocusModeEnabled() {
 			sb.WriteString("== DELEGATION MODE ==\n")
@@ -2623,22 +2613,14 @@ func (l *Launcher) buildPrompt(slug string) string {
 		}
 		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
 		sb.WriteString("YOUR ROLE AS LEADER:\n")
-		if noNex {
-			sb.WriteString("1. Coordinate inside the office channel first and keep the team aligned there\n")
-		} else {
-			sb.WriteString("1. On strategy or prior decisions, call query_context early\n")
-		}
+		sb.WriteString(leadMemoryFirstRule())
 		sb.WriteString("2. The pushed notification is authoritative — it contains thread context, task state, and agent activity. Respond directly from it. Do NOT call team_poll or team_tasks unless the notification explicitly says context is missing. Every unnecessary tool call burns tokens without adding value.\n")
 		sb.WriteString("3. When routing a human's @tagged request: tag the specialist in your message. Do NOT also create a team_task for the same work. One notification wakes them — two causes duplicate turns. Use team_task only for work you are independently originating, not for pass-through routing.\n")
 		sb.WriteString("4. Tag only the specialists who should weigh in. Unowned background chatter is a bug.\n")
 		sb.WriteString("5. Keep specialists in their lane and mostly offstage. You make the FINAL decision.\n")
 		sb.WriteString("6. Check team_requests before asking the human anything new\n")
 		sb.WriteString("7. Use human_message for direct human-facing output, human_interview for blocking decisions\n")
-		if noNex {
-			sb.WriteString("8. Summarize final decisions clearly in-channel\n")
-		} else {
-			sb.WriteString("8. When you lock a decision, call add_context before claiming it is stored\n")
-		}
+		sb.WriteString(leadMemoryStorageRule())
 		sb.WriteString("9. Once decided, broadcast clear task assignments and create them in team_task\n")
 		sb.WriteString("10. Create channels (team_channel) or agents (team_member) when the human asks or scope genuinely warrants it\n")
 		sb.WriteString("11. Use team_bridge to carry context between channels when relevant\n")
@@ -2655,11 +2637,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("- The human will be asked to approve before it becomes active\n")
 		sb.WriteString("- To suggest adding a new specialist agent, use team_member with a clear expertise and rationale\n\n")
 		sb.WriteString("STYLE: Be concise, delegate, short lively messages. Use markdown tables/checklists for structured data.\n")
-		if noNex {
-			sb.WriteString("Do not claim you stored anything outside the office.\n")
-		} else {
-			sb.WriteString("Do not pretend the graph was updated; verify add_context succeeded.\n")
-		}
+		sb.WriteString(leadMemoryFinalWarning())
 	} else {
 		sb.WriteString(fmt.Sprintf("You are %s on the %s.\n", agentCfg.Name, l.PackName()))
 		sb.WriteString(companyCtx)
@@ -2684,11 +2662,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("- human_message: Present completion or a recommendation directly to the human.\n")
 		sb.WriteString("- human_interview: Ask the human only for blocking clarifications you cannot responsibly guess.\n")
 		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member.\n\n")
-		if noNex {
-			sb.WriteString("Nex tools are disabled for this run. Base your work on the office conversation and direct human answers only.\n\n")
-		} else {
-			sb.WriteString("Nex memory: query_context before making assumptions; add_context only for durable conclusions.\n\n")
-		}
+		sb.WriteString(specialistMemoryPromptBlock())
 		sb.WriteString("Tag agents with @slug. Tagged agents must respond.\n")
 		if l.isFocusModeEnabled() {
 			sb.WriteString("== DELEGATION MODE ==\n")
@@ -2708,11 +2682,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("6. When assigned a task, claim it with team_task first, use team_status to show what you're working on, then mark complete and broadcast when done. If the result is mainly for the human, also send it via human_message.\n")
 		sb.WriteString("7. You can see other channel names and descriptions, but cannot access their content unless you are a member. If context from another channel is needed, ask the CEO to bridge it.\n")
 		sb.WriteString("8. If a task or status line shows a worktree path, use that as working_directory for local file and bash tools.\n")
-		if noNex {
-			sb.WriteString("9. Don't fake outside memory. Surface uncertainty in-channel and keep outcomes explicit in-thread.\n\n")
-		} else {
-			sb.WriteString("9. Use query_context when prior knowledge matters. Only use add_context for durable conclusions, and don't claim something stored unless add_context actually succeeded.\n\n")
-		}
+		sb.WriteString(specialistMemoryStorageRule())
 		sb.WriteString("STYLE: Be concise, stay in lane, short lively messages. Use markdown tables/checklists for structured data.\n")
 	}
 
@@ -2756,12 +2726,13 @@ func (l *Launcher) claudeCommand(slug, systemPrompt string) string {
 	model := l.headlessClaudeModel(slug)
 
 	return fmt.Sprintf(
-		"%s%s%sWUPHF_AGENT_SLUG=%s WUPHF_BROKER_TOKEN=%s WUPHF_NO_NEX=%t ANTHROPIC_PROMPT_CACHING=1 CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_METRICS_EXPORTER=none OTEL_LOGS_EXPORTER=otlp OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=http/json OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://127.0.0.1:%d/v1/logs OTEL_EXPORTER_OTLP_HEADERS='Authorization=Bearer %s' OTEL_RESOURCE_ATTRIBUTES='agent.slug=%s,wuphf.channel=office' claude --model %s %s --append-system-prompt '%s' --mcp-config '%s' --strict-mcp-config -n '%s'",
+		"%s%s%sWUPHF_AGENT_SLUG=%s WUPHF_BROKER_TOKEN=%s WUPHF_MEMORY_BACKEND=%s WUPHF_NO_NEX=%t ANTHROPIC_PROMPT_CACHING=1 CLAUDE_CODE_ENABLE_TELEMETRY=1 OTEL_METRICS_EXPORTER=none OTEL_LOGS_EXPORTER=otlp OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=http/json OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://127.0.0.1:%d/v1/logs OTEL_EXPORTER_OTLP_HEADERS='Authorization=Bearer %s' OTEL_RESOURCE_ATTRIBUTES='agent.slug=%s,wuphf.channel=office' claude --model %s %s --append-system-prompt '%s' --mcp-config '%s' --strict-mcp-config -n '%s'",
 		oneOnOneEnv,
 		oneSecretEnv,
 		oneIdentityEnv,
 		slug,
 		brokerToken,
+		config.ResolveMemoryBackend(""),
 		config.ResolveNoNex(),
 		BrokerPort,
 		brokerToken,
@@ -2792,59 +2763,59 @@ var codingAgentSlugs = map[string]bool{
 
 // agentMCPServers returns the MCP server keys that a given agent should receive.
 func agentMCPServers(slug string) []string {
-	channel := strings.TrimSpace(os.Getenv("WUPHF_CHANNEL"))
-	// DM mode: only wuphf-office (minimal tool set, no nex overhead)
-	if strings.HasPrefix(channel, "dm-") {
-		return []string{"wuphf-office"}
-	}
 	if codingAgentSlugs[slug] {
 		return []string{"wuphf-office"}
 	}
-	return []string{"wuphf-office", "nex"}
+	servers := []string{"wuphf-office"}
+	if backend := activeMemoryBackendKind(); backend != config.MemoryBackendNone {
+		servers = append(servers, backend)
+	}
+	return servers
 }
 
 // buildMCPServerMap constructs the full set of MCP server entries.
 // This is the shared helper used by both ensureMCPConfig and ensureAgentMCPConfig.
 func (l *Launcher) buildMCPServerMap() (map[string]any, error) {
-	apiKey := config.ResolveAPIKey("")
 	servers := map[string]any{}
 	wuphfBinary, err := os.Executable()
 	if err != nil {
 		return nil, err
 	}
 
+	officeEnv := map[string]string{
+		"WUPHF_MEMORY_BACKEND": config.ResolveMemoryBackend(""),
+	}
+	if config.ResolveNoNex() {
+		officeEnv["WUPHF_NO_NEX"] = "1"
+	}
 	servers["wuphf-office"] = map[string]any{
 		"command": wuphfBinary,
 		"args":    []string{"mcp-team"},
+		"env":     officeEnv,
 	}
 	if oneSecret := strings.TrimSpace(config.ResolveOneSecret()); oneSecret != "" {
-		servers["wuphf-office"].(map[string]any)["env"] = map[string]string{
-			"ONE_SECRET": oneSecret,
-		}
+		officeEnv["ONE_SECRET"] = oneSecret
 	}
 	if identity := strings.TrimSpace(config.ResolveOneIdentity()); identity != "" {
-		entry := servers["wuphf-office"].(map[string]any)
-		env, _ := entry["env"].(map[string]string)
-		if env == nil {
-			env = map[string]string{}
-		}
-		env["ONE_IDENTITY"] = identity
+		officeEnv["ONE_IDENTITY"] = identity
 		if identityType := strings.TrimSpace(config.ResolveOneIdentityType()); identityType != "" {
-			env["ONE_IDENTITY_TYPE"] = identityType
+			officeEnv["ONE_IDENTITY_TYPE"] = identityType
 		}
-		entry["env"] = env
 	}
 
-	if !config.ResolveNoNex() && apiKey != "" {
-		if nexMCP, err := exec.LookPath("nex-mcp"); err == nil {
-			servers["nex"] = map[string]any{
-				"command": nexMCP,
-				"env": map[string]string{
-					"WUPHF_API_KEY": apiKey,
-					"NEX_API_KEY":   apiKey,
-				},
-			}
+	if server, err := resolvedMemoryMCPServer(); err != nil {
+		return nil, err
+	} else if server != nil {
+		entry := map[string]any{
+			"command": server.Command,
 		}
+		if len(server.Args) > 0 {
+			entry["args"] = server.Args
+		}
+		if len(server.Env) > 0 {
+			entry["env"] = server.Env
+		}
+		servers[server.Name] = entry
 	}
 
 	return servers, nil
@@ -3179,10 +3150,11 @@ func (l *Launcher) PreflightWeb() error {
 
 // LaunchWeb starts the broker, web UI server, and background agents without tmux.
 func (l *Launcher) LaunchWeb(webPort int) error {
+	memoryStatus := ResolveMemoryBackendStatus()
 	// Offer to wire Nex when the user hasn't opted out and nex-cli isn't yet
 	// installed. `nex setup` handles detection and wiring for us — we just
 	// surface the prompt.
-	if !config.ResolveNoNex() && !nex.IsInstalled() {
+	if memoryStatus.SelectedKind == config.MemoryBackendNex && memoryStatus.ActiveKind == config.MemoryBackendNone && !config.ResolveNoNex() && !nex.IsInstalled() {
 		fmt.Println()
 		fmt.Print("  Connect Nex for memory and context? [Y/n] ")
 		var answer string
@@ -3212,6 +3184,14 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 			fmt.Println("  Skipping Nex. Agents will work without organizational memory.")
 			fmt.Println()
 		}
+	} else if memoryStatus.SelectedKind == config.MemoryBackendGBrain && memoryStatus.ActiveKind == config.MemoryBackendNone && strings.TrimSpace(memoryStatus.Detail) != "" {
+		fmt.Println()
+		fmt.Printf("  %s\n", memoryStatus.Detail)
+		if strings.TrimSpace(memoryStatus.NextStep) != "" {
+			fmt.Printf("  %s\n", memoryStatus.NextStep)
+		}
+		fmt.Println("  Continuing without external memory.")
+		fmt.Println()
 	}
 
 	mcpConfig, err := l.ensureMCPConfig()
@@ -3251,7 +3231,9 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 
 	go l.notifyAgentsLoop()
 	go l.notifyTaskActionsLoop()
-	go l.pollNexNotificationsLoop()
+	if shouldPollNexNotifications() {
+		go l.pollNexNotificationsLoop()
+	}
 	go l.watchdogSchedulerLoop()
 
 	// Same opt-in OpenClaw wire-up as Launch() — see that method's comment.

--- a/internal/team/launcher_nex.go
+++ b/internal/team/launcher_nex.go
@@ -4,6 +4,7 @@
 // a fork that does not use Nex, delete this file and remove the calls to:
 //   - pollNexNotificationsLoop (in launcher.go Launch())
 //   - pollNexInsightsLoop      (in launcher.go Launch())
+//
 // That is the complete surface area; no other files need changes.
 package team
 
@@ -80,6 +81,9 @@ type insightTaskPlan struct {
 
 func (l *Launcher) pollNexNotificationsLoop() {
 	if l.broker == nil {
+		return
+	}
+	if !shouldPollNexNotifications() {
 		return
 	}
 	apiKey := config.ResolveAPIKey("")

--- a/internal/team/memory_backend.go
+++ b/internal/team/memory_backend.go
@@ -1,0 +1,391 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/gbrain"
+	"github.com/nex-crm/wuphf/internal/nex"
+)
+
+type MemoryBackendStatus struct {
+	SelectedKind  string
+	SelectedLabel string
+	ActiveKind    string
+	ActiveLabel   string
+	Detail        string
+	NextStep      string
+}
+
+type memoryMCPServer struct {
+	Name    string
+	Command string
+	Args    []string
+	Env     map[string]string
+	EnvVars []string
+}
+
+type memoryBackend interface {
+	Kind() string
+	Label() string
+	Ready() bool
+	MCPServer() (*memoryMCPServer, error)
+	FetchBrief(ctx context.Context, notification string) string
+}
+
+type noMemoryBackend struct{}
+
+func (noMemoryBackend) Kind() string  { return config.MemoryBackendNone }
+func (noMemoryBackend) Label() string { return config.MemoryBackendLabel(config.MemoryBackendNone) }
+func (noMemoryBackend) Ready() bool   { return true }
+func (noMemoryBackend) MCPServer() (*memoryMCPServer, error) {
+	return nil, nil
+}
+func (noMemoryBackend) FetchBrief(context.Context, string) string { return "" }
+
+type nexMemoryBackend struct{}
+
+func (nexMemoryBackend) Kind() string  { return config.MemoryBackendNex }
+func (nexMemoryBackend) Label() string { return config.MemoryBackendLabel(config.MemoryBackendNex) }
+func (nexMemoryBackend) Ready() bool {
+	return strings.TrimSpace(config.ResolveAPIKey("")) != "" && nexMCPBinaryPath() != ""
+}
+func (nexMemoryBackend) MCPServer() (*memoryMCPServer, error) {
+	bin := nexMCPBinaryPath()
+	if bin == "" {
+		return nil, nil
+	}
+	apiKey := strings.TrimSpace(config.ResolveAPIKey(""))
+	if apiKey == "" {
+		return nil, nil
+	}
+	return &memoryMCPServer{
+		Name:    "nex",
+		Command: bin,
+		Env: map[string]string{
+			"WUPHF_API_KEY": apiKey,
+			"NEX_API_KEY":   apiKey,
+		},
+		EnvVars: []string{"WUPHF_API_KEY", "NEX_API_KEY"},
+	}, nil
+}
+func (nexMemoryBackend) FetchBrief(ctx context.Context, notification string) string {
+	if !nex.Connected() {
+		return ""
+	}
+	query := strings.TrimSpace(notification)
+	if query == "" {
+		return ""
+	}
+	if len(query) > 400 {
+		query = query[:400]
+	}
+	answer, err := nex.Recall(ctx, query)
+	if err != nil || strings.TrimSpace(answer) == "" {
+		return ""
+	}
+	return "== NEX CONTEXT ==\n" + strings.TrimSpace(answer) + "\n== END NEX CONTEXT =="
+}
+
+type gbrainMemoryBackend struct{}
+
+func (gbrainMemoryBackend) Kind() string { return config.MemoryBackendGBrain }
+func (gbrainMemoryBackend) Label() string {
+	return config.MemoryBackendLabel(config.MemoryBackendGBrain)
+}
+func (gbrainMemoryBackend) Ready() bool { return gbrain.IsInstalled() && gbrainProviderKeyConfigured() }
+func (gbrainMemoryBackend) MCPServer() (*memoryMCPServer, error) {
+	bin := gbrain.BinaryPath()
+	if bin == "" {
+		return nil, nil
+	}
+	return &memoryMCPServer{
+		Name:    "gbrain",
+		Command: bin,
+		Args:    []string{"serve"},
+		Env:     gbrainMCPEnv(),
+		EnvVars: gbrainMCPEnvVars(),
+	}, nil
+}
+func (gbrainMemoryBackend) FetchBrief(ctx context.Context, notification string) string {
+	query := strings.TrimSpace(notification)
+	if query == "" {
+		return ""
+	}
+	if len(query) > 400 {
+		query = query[:400]
+	}
+	results, err := gbrain.Query(ctx, query, 5)
+	if err != nil || len(results) == 0 {
+		return ""
+	}
+
+	var lines []string
+	lines = append(lines, "== GBRAIN CONTEXT ==")
+	seen := map[string]struct{}{}
+	for _, result := range results {
+		if _, ok := seen[result.Slug]; ok {
+			continue
+		}
+		seen[result.Slug] = struct{}{}
+		title := strings.TrimSpace(result.Title)
+		if title == "" {
+			title = strings.TrimSpace(result.Slug)
+		}
+		snippet := strings.TrimSpace(strings.ReplaceAll(result.ChunkText, "\n", " "))
+		if snippet == "" {
+			snippet = "Relevant context found in the brain."
+		}
+		lines = append(lines, fmt.Sprintf("- %s (%s): %s", title, strings.TrimSpace(result.Type), truncate(snippet, 220)))
+		if len(lines) >= 4 {
+			break
+		}
+	}
+	if len(lines) == 1 {
+		return ""
+	}
+	lines = append(lines, "== END GBRAIN CONTEXT ==")
+	return strings.Join(lines, "\n")
+}
+
+func gbrainProviderKeyConfigured() bool {
+	return strings.TrimSpace(config.ResolveOpenAIAPIKey()) != "" ||
+		strings.TrimSpace(config.ResolveAnthropicAPIKey()) != ""
+}
+
+func gbrainOpenAIConfigured() bool {
+	return strings.TrimSpace(config.ResolveOpenAIAPIKey()) != ""
+}
+
+func gbrainAnthropicConfigured() bool {
+	return strings.TrimSpace(config.ResolveAnthropicAPIKey()) != ""
+}
+
+func ResolveMemoryBackendStatus() MemoryBackendStatus {
+	selected := config.ResolveMemoryBackend("")
+	status := MemoryBackendStatus{
+		SelectedKind:  selected,
+		SelectedLabel: config.MemoryBackendLabel(selected),
+		ActiveKind:    config.MemoryBackendNone,
+		ActiveLabel:   config.MemoryBackendLabel(config.MemoryBackendNone),
+	}
+
+	switch selected {
+	case config.MemoryBackendNone:
+		status.ActiveKind = config.MemoryBackendNone
+		status.ActiveLabel = config.MemoryBackendLabel(config.MemoryBackendNone)
+		if config.ResolveNoNex() {
+			status.Detail = "Nex is disabled for this run, so the office is operating without an external memory backend."
+			status.NextStep = "Restart without --no-nex or select --memory-backend gbrain when you want external context."
+		} else {
+			status.Detail = "External memory is disabled for this run."
+			status.NextStep = "Set --memory-backend nex or --memory-backend gbrain to enable organizational context."
+		}
+	case config.MemoryBackendNex:
+		if strings.TrimSpace(config.ResolveAPIKey("")) == "" {
+			status.Detail = "Nex backend selected, but no WUPHF/Nex API key is configured."
+			status.NextStep = "Run /init or set WUPHF_API_KEY to enable Nex-backed context."
+			return status
+		}
+		if nexMCPBinaryPath() == "" {
+			status.Detail = "Nex backend selected, but the nex-mcp server is not installed."
+			status.NextStep = "Install the latest Nex CLI bundle so the Nex MCP server is available."
+			return status
+		}
+		status.ActiveKind = config.MemoryBackendNex
+		status.ActiveLabel = config.MemoryBackendLabel(config.MemoryBackendNex)
+		status.Detail = "Nex-backed organizational context is configured."
+	case config.MemoryBackendGBrain:
+		if !gbrainProviderKeyConfigured() {
+			status.Detail = "GBrain backend selected, but no provider key is configured. OpenAI is required for embeddings and vector search; Anthropic alone only enables reduced-mode retrieval."
+			status.NextStep = "Run /init and add an OpenAI key for full GBrain search, or add an Anthropic key for reduced mode."
+			return status
+		}
+		if !gbrain.IsInstalled() {
+			status.Detail = "GBrain backend selected, but the gbrain CLI is not installed."
+			status.NextStep = "Install GBrain and initialize a brain before launching the office."
+			return status
+		}
+		status.ActiveKind = config.MemoryBackendGBrain
+		status.ActiveLabel = config.MemoryBackendLabel(config.MemoryBackendGBrain)
+		switch {
+		case gbrainOpenAIConfigured():
+			status.Detail = "GBrain-backed organizational context is configured with an OpenAI key, so embeddings and vector search are available."
+		case gbrainAnthropicConfigured():
+			status.Detail = "GBrain-backed organizational context is configured in Anthropic-only mode. Keyword search and query expansion work, but embeddings and vector search still require OpenAI."
+			status.NextStep = "Add WUPHF_OPENAI_API_KEY if you want full GBrain embeddings and vector search."
+		default:
+			status.Detail = "GBrain-backed organizational context is configured with provider credentials."
+		}
+	default:
+		status.SelectedKind = config.MemoryBackendNone
+		status.SelectedLabel = config.MemoryBackendLabel(config.MemoryBackendNone)
+		status.Detail = "External memory is disabled for this run."
+		status.NextStep = "Select a supported memory backend to enable external context."
+	}
+
+	return status
+}
+
+func selectedMemoryBackend() memoryBackend {
+	switch config.ResolveMemoryBackend("") {
+	case config.MemoryBackendNex:
+		return nexMemoryBackend{}
+	case config.MemoryBackendGBrain:
+		return gbrainMemoryBackend{}
+	default:
+		return noMemoryBackend{}
+	}
+}
+
+func activeMemoryBackend() memoryBackend {
+	backend := selectedMemoryBackend()
+	if backend.Ready() {
+		return backend
+	}
+	return noMemoryBackend{}
+}
+
+func activeMemoryBackendKind() string {
+	return activeMemoryBackend().Kind()
+}
+
+func shouldPollNexNotifications() bool {
+	return activeMemoryBackendKind() == config.MemoryBackendNex
+}
+
+func fetchMemoryBrief(ctx context.Context, notification string) string {
+	return activeMemoryBackend().FetchBrief(ctx, notification)
+}
+
+func resolvedMemoryMCPServer() (*memoryMCPServer, error) {
+	return activeMemoryBackend().MCPServer()
+}
+
+func nexMCPBinaryPath() string {
+	path, err := exec.LookPath("nex-mcp")
+	if err != nil {
+		return ""
+	}
+	return path
+}
+
+func gbrainMCPEnv() map[string]string {
+	env := map[string]string{}
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		env["HOME"] = home
+	}
+	if key := strings.TrimSpace(config.ResolveOpenAIAPIKey()); key != "" {
+		env["OPENAI_API_KEY"] = key
+	}
+	if key := strings.TrimSpace(config.ResolveAnthropicAPIKey()); key != "" {
+		env["ANTHROPIC_API_KEY"] = key
+	}
+	return env
+}
+
+func gbrainMCPEnvVars() []string {
+	var envVars []string
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		envVars = append(envVars, "HOME")
+	}
+	if key := strings.TrimSpace(config.ResolveOpenAIAPIKey()); key != "" {
+		envVars = append(envVars, "OPENAI_API_KEY")
+	}
+	if key := strings.TrimSpace(config.ResolveAnthropicAPIKey()); key != "" {
+		envVars = append(envVars, "ANTHROPIC_API_KEY")
+	}
+	return envVars
+}
+
+func directMemoryPromptBlock() string {
+	switch activeMemoryBackendKind() {
+	case config.MemoryBackendNex:
+		return "Use the Nex context graph when it materially helps:\n- query_context: Look up prior decisions, people, projects, and history before guessing\n- add_context: Store durable conclusions only after you have actually landed them\n\n"
+	case config.MemoryBackendGBrain:
+		return "Use GBrain as durable world knowledge when it materially helps:\n- query: Brain-first semantic lookup for people, projects, decisions, and patterns\n- search: Exact term or slug lookup when you already know the entity\n- get_page: Load the full page once a hit looks relevant\n- put_page or add_timeline_entry: Write durable world knowledge only after it actually lands; keep task chatter in the conversation\n\n"
+	default:
+		return "External memory is not active for this run. Base your work on the conversation and direct human answers only.\n\n"
+	}
+}
+
+func directMemoryStorageRule() string {
+	switch activeMemoryBackendKind() {
+	case config.MemoryBackendNex:
+		return "7. If Nex is enabled, do not claim something is stored unless add_context actually succeeded.\n"
+	case config.MemoryBackendGBrain:
+		return "7. If GBrain is enabled, do not claim the brain was updated unless put_page or add_timeline_entry actually succeeded.\n"
+	default:
+		return "7. Do not pretend anything was stored outside this session.\n"
+	}
+}
+
+func leadMemoryPromptBlock() string {
+	switch activeMemoryBackendKind() {
+	case config.MemoryBackendNex:
+		return "Nex memory: query_context before reinventing; add_context only after a decision is actually landed.\n\n"
+	case config.MemoryBackendGBrain:
+		return "GBrain operating loop: query before reinventing, search when you know the entity, get_page before relying on a hit, and only write durable world knowledge back with put_page or add_timeline_entry once it has landed. Keep task coordination in the office, not in the brain.\n\n"
+	default:
+		return "External memory is not active for this run. Work only with the shared office channel and human answers.\n\n"
+	}
+}
+
+func leadMemoryFirstRule() string {
+	switch activeMemoryBackendKind() {
+	case config.MemoryBackendNex:
+		return "1. On strategy or prior decisions, call query_context early\n"
+	case config.MemoryBackendGBrain:
+		return "1. On strategy, relationships, or prior decisions, start in GBrain: query broadly, then search or get_page to verify the relevant entity page\n"
+	default:
+		return "1. Coordinate inside the office channel first and keep the team aligned there\n"
+	}
+}
+
+func leadMemoryStorageRule() string {
+	switch activeMemoryBackendKind() {
+	case config.MemoryBackendNex:
+		return "8. When you lock a decision, call add_context before claiming it is stored\n"
+	case config.MemoryBackendGBrain:
+		return "8. When you lock a durable decision, update the relevant page or timeline before claiming the brain knows it\n"
+	default:
+		return "8. Summarize final decisions clearly in-channel\n"
+	}
+}
+
+func leadMemoryFinalWarning() string {
+	switch activeMemoryBackendKind() {
+	case config.MemoryBackendNex:
+		return "Do not pretend the graph was updated; verify add_context succeeded.\n"
+	case config.MemoryBackendGBrain:
+		return "Do not pretend the brain was updated; verify put_page or add_timeline_entry succeeded.\n"
+	default:
+		return "Do not claim you stored anything outside the office.\n"
+	}
+}
+
+func specialistMemoryPromptBlock() string {
+	switch activeMemoryBackendKind() {
+	case config.MemoryBackendNex:
+		return "Nex memory: query_context before making assumptions; add_context only for durable conclusions.\n\n"
+	case config.MemoryBackendGBrain:
+		return "GBrain operating loop: query when prior knowledge matters, search when you already know the entity, get_page before leaning on a hit, and only write durable world knowledge back with put_page or add_timeline_entry once the outcome has actually landed.\n\n"
+	default:
+		return "External memory is not active for this run. Base your work on the office conversation and direct human answers only.\n\n"
+	}
+}
+
+func specialistMemoryStorageRule() string {
+	switch activeMemoryBackendKind() {
+	case config.MemoryBackendNex:
+		return "9. Use query_context when prior knowledge matters. Only use add_context for durable conclusions, and don't claim something stored unless add_context actually succeeded.\n\n"
+	case config.MemoryBackendGBrain:
+		return "9. Use GBrain when prior knowledge matters. Query first, verify with get_page when needed, and only write durable world knowledge back with put_page or add_timeline_entry after the outcome is real.\n\n"
+	default:
+		return "9. Don't fake outside memory. Surface uncertainty in-channel and keep outcomes explicit in-thread.\n\n"
+	}
+}

--- a/internal/team/memory_backend_test.go
+++ b/internal/team/memory_backend_test.go
@@ -1,0 +1,103 @@
+package team
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+func TestResolveMemoryBackendStatusNoNexFallsBackToLocalOnly(t *testing.T) {
+	t.Setenv("WUPHF_NO_NEX", "1")
+	t.Setenv("WUPHF_MEMORY_BACKEND", "")
+
+	status := ResolveMemoryBackendStatus()
+	if status.SelectedKind != config.MemoryBackendNone {
+		t.Fatalf("expected selected backend none, got %+v", status)
+	}
+	if status.ActiveKind != config.MemoryBackendNone {
+		t.Fatalf("expected active backend none, got %+v", status)
+	}
+}
+
+func TestResolveMemoryBackendStatusGBrainReadyUnderNoNex(t *testing.T) {
+	t.Setenv("WUPHF_NO_NEX", "1")
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+	t.Setenv("WUPHF_OPENAI_API_KEY", "sk-test-openai")
+
+	binDir := t.TempDir()
+	gbrainBin := filepath.Join(binDir, "gbrain")
+	if err := os.WriteFile(gbrainBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake gbrain: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	status := ResolveMemoryBackendStatus()
+	if status.SelectedKind != config.MemoryBackendGBrain || status.ActiveKind != config.MemoryBackendGBrain {
+		t.Fatalf("expected gbrain to stay active under no-nex, got %+v", status)
+	}
+}
+
+func TestResolveMemoryBackendStatusGBrainNeedsProviderKey(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+
+	status := ResolveMemoryBackendStatus()
+	if status.SelectedKind != config.MemoryBackendGBrain {
+		t.Fatalf("expected gbrain to stay selected, got %+v", status)
+	}
+	if status.ActiveKind != config.MemoryBackendNone {
+		t.Fatalf("expected gbrain to remain inactive without provider key, got %+v", status)
+	}
+	if !strings.Contains(status.Detail, "OpenAI") || !strings.Contains(status.Detail, "vector search") {
+		t.Fatalf("expected provider-key guidance, got %+v", status)
+	}
+}
+
+func TestResolveMemoryBackendStatusGBrainAnthropicOnlyShowsReducedMode(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+	t.Setenv("WUPHF_ANTHROPIC_API_KEY", "sk-ant-test-anthropic")
+
+	binDir := t.TempDir()
+	gbrainBin := filepath.Join(binDir, "gbrain")
+	if err := os.WriteFile(gbrainBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake gbrain: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	status := ResolveMemoryBackendStatus()
+	if status.ActiveKind != config.MemoryBackendGBrain {
+		t.Fatalf("expected gbrain to stay active with anthropic-only mode, got %+v", status)
+	}
+	if !strings.Contains(status.Detail, "Anthropic-only mode") || !strings.Contains(status.Detail, "OpenAI") {
+		t.Fatalf("expected reduced-mode detail, got %+v", status)
+	}
+}
+
+func TestShouldPollNexNotificationsOnlyWhenNexIsActive(t *testing.T) {
+	t.Setenv("WUPHF_NO_NEX", "")
+	t.Setenv("WUPHF_API_KEY", "nex-test-key")
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendNex)
+
+	binDir := t.TempDir()
+	nexMCP := filepath.Join(binDir, "nex-mcp")
+	if err := os.WriteFile(nexMCP, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake nex-mcp: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if !shouldPollNexNotifications() {
+		t.Fatal("expected nex notification polling when nex backend is active")
+	}
+
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+	t.Setenv("WUPHF_OPENAI_API_KEY", "sk-test-openai")
+	gbrainBin := filepath.Join(binDir, "gbrain")
+	if err := os.WriteFile(gbrainBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake gbrain: %v", err)
+	}
+	if shouldPollNexNotifications() {
+		t.Fatal("did not expect nex notification polling when gbrain is active")
+	}
+}

--- a/internal/teammcp/server_test.go
+++ b/internal/teammcp/server_test.go
@@ -596,7 +596,7 @@ func TestHandleTeamRuntimeStateIncludesRecoveryAndCapabilities(t *testing.T) {
 		"Current focus: Approve release from @ceo.",
 		"working_directory /tmp/wuphf-task-77",
 		"Runtime capabilities:",
-		"Nex memory [info]: Disabled for this session with --no-nex.",
+		"Memory backend [info]: Nex is disabled for this run, so the office is operating without an external memory backend.",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected %q in %q", want, text)

--- a/internal/tui/init_flow.go
+++ b/internal/tui/init_flow.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"os"
 	"os/exec"
 	"strings"
 
@@ -60,9 +61,9 @@ func (f InitFlowModel) IsActive() bool {
 
 // Start begins the init flow. API key → provider choice → pack choice → done.
 func (f InitFlowModel) Start() (InitFlowModel, tea.Cmd) {
-	f.apiKey = strings.TrimSpace(config.ResolveAPIKey(""))
+	f.apiKey = strings.TrimSpace(initFlowResolvedMemoryKey())
 	f.provider = config.ResolveLLMProvider("")
-	if f.apiKey == "" {
+	if initFlowNeedsMemoryKey(f.apiKey) {
 		f.phase = InitAPIKey
 		return f, f.emitPhase(InitAPIKey)
 	}
@@ -112,9 +113,13 @@ func (f InitFlowModel) requiresTextInput() bool {
 func (f InitFlowModel) updateAPIKeyInput(msg tea.KeyMsg) (InitFlowModel, tea.Cmd) {
 	switch msg.String() {
 	case "enter":
-		key := string(f.keyInput)
-		if strings.TrimSpace(key) == "" {
-			f.keyError = "API key cannot be empty."
+		key := strings.TrimSpace(string(f.keyInput))
+		if key == "" {
+			f.keyError = initFlowEmptyKeyError()
+			return f, nil
+		}
+		if err := initFlowValidateMemoryKey(key); err != "" {
+			f.keyError = err
 			return f, nil
 		}
 		f.apiKey = key
@@ -150,8 +155,23 @@ func (f InitFlowModel) updateAPIKeyInput(msg tea.KeyMsg) (InitFlowModel, tea.Cmd
 // finish saves config and transitions to done.
 func (f InitFlowModel) finish() (InitFlowModel, tea.Cmd) {
 	cfg, _ := config.Load()
-	if f.apiKey != "" {
-		cfg.APIKey = f.apiKey
+	switch config.ResolveMemoryBackend("") {
+	case config.MemoryBackendNex:
+		if f.apiKey != "" {
+			cfg.APIKey = f.apiKey
+		}
+	case config.MemoryBackendGBrain:
+		if key := strings.TrimSpace(f.apiKey); key != "" {
+			if strings.HasPrefix(strings.ToLower(key), "sk-ant-") {
+				cfg.AnthropicAPIKey = key
+			} else {
+				cfg.OpenAIAPIKey = key
+			}
+		}
+	default:
+	}
+	if selected := config.NormalizeMemoryBackend(os.Getenv("WUPHF_MEMORY_BACKEND")); selected != "" {
+		cfg.MemoryBackend = selected
 	}
 	cfg.LLMProvider = f.provider
 	cfg.Pack = f.pack
@@ -236,7 +256,7 @@ func (f InitFlowModel) View() string {
 func (f InitFlowModel) renderAPIKeyInput() string {
 	input := string(f.keyInput)
 	cursorStyle := lipgloss.NewStyle().Reverse(true)
-	label := "API Key: "
+	label := initFlowAPIKeyLabel()
 	prompt := lipgloss.NewStyle().Foreground(lipgloss.Color(NexBlue)).Bold(true).Render(label)
 
 	display := prompt + input + cursorStyle.Render(" ")
@@ -294,9 +314,10 @@ func readinessStatusColor(status string) string {
 }
 
 func (f InitFlowModel) readinessChecks() []initReadinessCheck {
+	backend := config.ResolveMemoryBackend("")
 	effectiveAPIKey := strings.TrimSpace(f.apiKey)
 	if effectiveAPIKey == "" {
-		effectiveAPIKey = strings.TrimSpace(config.ResolveAPIKey(""))
+		effectiveAPIKey = strings.TrimSpace(initFlowResolvedMemoryKey())
 	}
 	provider := strings.TrimSpace(f.provider)
 	if provider == "" {
@@ -305,9 +326,14 @@ func (f InitFlowModel) readinessChecks() []initReadinessCheck {
 
 	checks := []initReadinessCheck{
 		{
-			Label:  "Nex identity",
-			Status: readinessStatusForBool(effectiveAPIKey != ""),
-			Detail: apiKeyReadinessDetail(effectiveAPIKey != ""),
+			Label:  "Memory backend",
+			Status: initFlowMemoryBackendStatus(backend, effectiveAPIKey),
+			Detail: initFlowMemoryBackendDetail(backend, effectiveAPIKey),
+		},
+		{
+			Label:  initFlowMemoryCredentialLabel(backend),
+			Status: initFlowMemoryCredentialStatus(backend, effectiveAPIKey),
+			Detail: initFlowMemoryCredentialDetail(backend, effectiveAPIKey),
 		},
 		{
 			Label:  "tmux office runtime",
@@ -326,8 +352,8 @@ func (f InitFlowModel) readinessChecks() []initReadinessCheck {
 		},
 		{
 			Label:  "Integrations",
-			Status: "ready",
-			Detail: config.OneSetupSummary(),
+			Status: initFlowIntegrationsStatus(backend),
+			Detail: initFlowIntegrationsDetail(backend),
 		},
 	}
 
@@ -369,13 +395,6 @@ func readinessStatusForOptional(set bool) string {
 		return "ready"
 	}
 	return "next"
-}
-
-func apiKeyReadinessDetail(ok bool) string {
-	if ok {
-		return "WUPHF/Nex API key is configured."
-	}
-	return "Paste your WUPHF/Nex API key to enable memory and managed integrations."
 }
 
 func packReadinessStatus(pack string) string {
@@ -434,13 +453,28 @@ func binaryAvailable(name string) bool {
 }
 
 func (f InitFlowModel) phaseText() (heading, instructions string) {
+	backend := config.ResolveMemoryBackend("")
 	switch f.phase {
 	case InitIdle:
 		return "Setup", "Run /init to begin."
 	case InitAPIKey:
-		return "Enter Nex API Key", "Paste your WUPHF/Nex API key. WUPHF uses One for integrations and manages it automatically through your Nex identity."
+		switch backend {
+		case config.MemoryBackendNex:
+			return "Enter Nex API Key", "Paste your WUPHF/Nex API key. Nex memory and managed integrations both depend on it."
+		case config.MemoryBackendGBrain:
+			return "Enter GBrain Provider Key", "Paste an OpenAI or Anthropic API key for GBrain. OpenAI is the full path: embeddings and vector search depend on it. Anthropic alone works in reduced mode."
+		default:
+			return "Setup", "External memory is disabled for this run, so no memory key is required."
+		}
 	case InitProviderChoice:
-		return "Choose LLM Provider", "Select your preferred AI provider. Integrations are handled automatically through Nex using One."
+		switch backend {
+		case config.MemoryBackendNex:
+			return "Choose LLM Provider", "Select your preferred AI provider. Nex memory uses your WUPHF/Nex API key, and WUPHF-managed integrations remain Nex-backed."
+		case config.MemoryBackendGBrain:
+			return "Choose LLM Provider", "Select your preferred AI provider. GBrain uses the provider key you configured separately here. OpenAI unlocks embeddings and vector search; Anthropic alone is reduced mode."
+		default:
+			return "Choose LLM Provider", "Select your preferred AI provider. External memory is disabled for this run."
+		}
 	case InitPackChoice:
 		return "Choose Agent Pack", "Select the team of agents to work with."
 	case InitDone:
@@ -448,8 +482,162 @@ func (f InitFlowModel) phaseText() (heading, instructions string) {
 		if p := agent.GetPack(f.pack); p != nil {
 			packName = p.Name
 		}
-		return "Setup Complete", "Provider: " + f.provider + " | Pack: " + packName + ". " + config.OneSetupBlurb()
+		summary := "Memory: " + config.MemoryBackendLabel(backend) + " | Provider: " + f.provider + " | Pack: " + packName + "."
+		switch backend {
+		case config.MemoryBackendNex:
+			return "Setup Complete", summary + " " + config.OneSetupBlurb()
+		case config.MemoryBackendGBrain:
+			if strings.TrimSpace(config.ResolveOpenAIAPIKey()) != "" {
+				return "Setup Complete", summary + " GBrain will use your OpenAI key for embeddings and vector search."
+			}
+			return "Setup Complete", summary + " GBrain is configured in reduced mode. Add an OpenAI key if you want embeddings and vector search."
+		default:
+			return "Setup Complete", summary + " External memory is disabled for this run."
+		}
 	default:
 		return "Setup", "Run /init to begin."
+	}
+}
+
+func initFlowSelectedMemoryBackend() string {
+	return config.ResolveMemoryBackend("")
+}
+
+func initFlowResolvedMemoryKey() string {
+	switch initFlowSelectedMemoryBackend() {
+	case config.MemoryBackendNex:
+		return strings.TrimSpace(config.ResolveAPIKey(""))
+	case config.MemoryBackendGBrain:
+		if key := strings.TrimSpace(config.ResolveOpenAIAPIKey()); key != "" {
+			return key
+		}
+		return strings.TrimSpace(config.ResolveAnthropicAPIKey())
+	default:
+		return ""
+	}
+}
+
+func initFlowNeedsMemoryKey(current string) bool {
+	switch initFlowSelectedMemoryBackend() {
+	case config.MemoryBackendNex, config.MemoryBackendGBrain:
+		return strings.TrimSpace(current) == ""
+	default:
+		return false
+	}
+}
+
+func initFlowAPIKeyLabel() string {
+	switch initFlowSelectedMemoryBackend() {
+	case config.MemoryBackendNex:
+		return "Nex API Key: "
+	case config.MemoryBackendGBrain:
+		return "Provider Key: "
+	default:
+		return "API Key: "
+	}
+}
+
+func initFlowEmptyKeyError() string {
+	switch initFlowSelectedMemoryBackend() {
+	case config.MemoryBackendNex:
+		return "Nex API key cannot be empty."
+	case config.MemoryBackendGBrain:
+		return "Enter an OpenAI or Anthropic API key for GBrain. OpenAI is required for embeddings and vector search."
+	default:
+		return "API key cannot be empty."
+	}
+}
+
+func initFlowValidateMemoryKey(key string) string {
+	if initFlowSelectedMemoryBackend() != config.MemoryBackendGBrain {
+		return ""
+	}
+	lower := strings.ToLower(strings.TrimSpace(key))
+	if strings.HasPrefix(lower, "sk-ant-") || strings.HasPrefix(lower, "sk-") {
+		return ""
+	}
+	return "Paste an OpenAI key (sk-...) or an Anthropic key (sk-ant-...)."
+}
+
+func initFlowMemoryBackendStatus(backend, key string) string {
+	if backend == config.MemoryBackendNone {
+		return "ready"
+	}
+	return readinessStatusForBool(strings.TrimSpace(key) != "")
+}
+
+func initFlowMemoryBackendDetail(backend, key string) string {
+	switch backend {
+	case config.MemoryBackendNex:
+		if strings.TrimSpace(key) != "" {
+			return "Nex selected. WUPHF/Nex API key is configured."
+		}
+		return "Nex selected. WUPHF/Nex API key is required."
+	case config.MemoryBackendGBrain:
+		if strings.TrimSpace(key) != "" {
+			if strings.HasPrefix(strings.ToLower(strings.TrimSpace(key)), "sk-ant-") {
+				return "GBrain selected. Anthropic-only mode is configured; embeddings and vector search still require OpenAI."
+			}
+			return "GBrain selected. OpenAI is configured, including embeddings and vector search."
+		}
+		return "GBrain selected. Configure a provider key before GBrain can run. OpenAI is required for embeddings and vector search."
+	default:
+		return "Local-only selected. No external memory key is required."
+	}
+}
+
+func initFlowMemoryCredentialLabel(backend string) string {
+	switch backend {
+	case config.MemoryBackendNex:
+		return "Nex API key"
+	case config.MemoryBackendGBrain:
+		return "GBrain provider key"
+	default:
+		return "Memory credentials"
+	}
+}
+
+func initFlowMemoryCredentialStatus(backend, key string) string {
+	if backend == config.MemoryBackendNone {
+		return "ready"
+	}
+	return readinessStatusForBool(strings.TrimSpace(key) != "")
+}
+
+func initFlowMemoryCredentialDetail(backend, key string) string {
+	switch backend {
+	case config.MemoryBackendNex:
+		if strings.TrimSpace(key) != "" {
+			return "Configured for Nex-backed context and managed integrations."
+		}
+		return "Paste your WUPHF/Nex API key to enable Nex-backed context."
+	case config.MemoryBackendGBrain:
+		if strings.TrimSpace(key) != "" {
+			if strings.HasPrefix(strings.ToLower(strings.TrimSpace(key)), "sk-ant-") {
+				return "Anthropic key configured for GBrain reduced mode. Add OpenAI for embeddings and vector search."
+			}
+			return "OpenAI key configured for GBrain, including embeddings and vector search."
+		}
+		return "Paste an OpenAI or Anthropic API key before using GBrain. OpenAI is required for embeddings and vector search."
+	default:
+		return "No external memory credentials required."
+	}
+}
+
+func initFlowIntegrationsStatus(backend string) string {
+	if backend == config.MemoryBackendNex {
+		return "ready"
+	}
+	return "next"
+}
+
+func initFlowIntegrationsDetail(backend string) string {
+	switch backend {
+	case config.MemoryBackendNex:
+		return config.OneSetupSummary()
+	case config.MemoryBackendGBrain:
+		return "WUPHF-managed integrations currently require the Nex memory backend and a WUPHF/Nex API key."
+	default:
+		return "Managed integrations are off in local-only mode. Select Nex if you want WUPHF-managed integration setup."
 	}
 }

--- a/internal/tui/init_flow_test.go
+++ b/internal/tui/init_flow_test.go
@@ -64,7 +64,7 @@ func TestInitFlowViewShowsReadinessSummary(t *testing.T) {
 	flow.provider = "claude-code"
 
 	view := flow.View()
-	if !containsAll(view, "Setup Readiness", "Nex identity", "tmux office runtime", "LLM runtime", "Agent pack") {
+	if !containsAll(view, "Setup Readiness", "Memory backend", "Nex API key", "tmux office runtime", "LLM runtime", "Agent pack") {
 		t.Fatalf("expected readiness summary in init view, got %q", view)
 	}
 	if !strings.Contains(view, "Paste your WUPHF/Nex API key") {
@@ -81,8 +81,73 @@ func TestInitFlowMentionsManagedIntegrations(t *testing.T) {
 	flow := NewInitFlow()
 	flow.phase = InitAPIKey
 	_, instructions = flow.phaseText()
-	if instructions == "" || !containsAll(instructions, "One", "automatically") {
-		t.Fatalf("expected managed integration copy, got %q", instructions)
+	if instructions == "" || !containsAll(instructions, "Nex", "managed integrations") {
+		t.Fatalf("expected Nex setup copy, got %q", instructions)
+	}
+}
+
+func TestInitFlowStartsWithGBrainProviderKeyWhenMissing(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+
+	flow, _ := NewInitFlow().Start()
+	if flow.Phase() != InitAPIKey {
+		t.Fatalf("expected API key phase for gbrain, got %q", flow.Phase())
+	}
+
+	flow.phase = InitAPIKey
+	view := flow.View()
+	if !containsAll(view, "GBrain", "OpenAI or Anthropic", "embeddings", "reduced mode") {
+		t.Fatalf("expected GBrain key guidance, got %q", view)
+	}
+}
+
+func TestInitFlowSkipsGBrainKeyStepWhenProviderCredentialExists(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+	t.Setenv("WUPHF_OPENAI_API_KEY", "sk-test-openai")
+
+	flow, _ := NewInitFlow().Start()
+	if flow.Phase() != InitProviderChoice {
+		t.Fatalf("expected provider choice phase, got %q", flow.Phase())
+	}
+}
+
+func TestInitFlowFinishSavesGBrainKeysByProvider(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+
+	flow := NewInitFlow()
+	flow.apiKey = "sk-ant-test-anthropic"
+	flow.provider = "codex"
+	flow.pack = "founding-team"
+	if _, cmd := flow.finish(); cmd == nil {
+		t.Fatal("expected finish to emit a phase transition")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.AnthropicAPIKey != "sk-ant-test-anthropic" {
+		t.Fatalf("expected anthropic key to be saved, got %#v", cfg)
+	}
+	if cfg.OpenAIAPIKey != "" {
+		t.Fatalf("did not expect OpenAI key to be set, got %#v", cfg)
+	}
+}
+
+func TestInitFlowAnthropicOnlyExplainsReducedMode(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
+	t.Setenv("WUPHF_ANTHROPIC_API_KEY", "sk-ant-test-anthropic")
+
+	flow := NewInitFlow()
+	flow.phase = InitProviderChoice
+	view := flow.View()
+
+	if !containsAll(view, "reduced mode", "OpenAI", "vector search") {
+		t.Fatalf("expected Anthropic-only reduced mode guidance, got %q", view)
 	}
 }
 


### PR DESCRIPTION
## What changed

This adds a provider-neutral organizational memory backend layer to WUPHF and wires GBrain in as a first-class backend alongside Nex and local-only mode.

Key changes:
- add `--memory-backend nex|gbrain|none`
- add backend-aware memory readiness, capability reporting, and onboarding
- mount `gbrain serve` into headless Codex/Claude runs when GBrain is selected
- route memory brief injection through the selected backend instead of hardcoding Nex
- make `/config` and `/health` report live provider/backend state correctly
- document the new backend model and GBrain key requirements in the README

## Why

WUPHF previously assumed Nex-shaped organizational memory in several runtime and UX paths. That made it impossible to use GBrain as a real backend and left `--no-nex` as the only alternative, which intentionally disables external memory rather than swapping in another backend.

This change introduces an explicit memory backend seam so GBrain can be selected and used as the active external context layer.

## Root cause for the reporting fixes

During end-to-end testing of the GBrain branch, two runtime reporting bugs showed up:
- `/health` reported `nex_connected: true` under a GBrain run because it was keyed off Nex binary availability instead of the active backend.
- the headless Codex path did not seed `runtimeProvider` on its broker instance, so `/health` could show an empty provider.
- `/config` read only the persisted config file, so it could miss the resolved live provider/backend state for the current run.

This PR fixes those issues by making health/config reflect the selected and active backend plus the resolved provider.

## User impact

Users can now:
- keep Nex as the default backend
- select GBrain explicitly and get GBrain-mounted memory in live office turns
- run with no external memory using `none`
- see clearer onboarding/setup copy for GBrain, including the OpenAI vs Anthropic tradeoff
- get more accurate runtime diagnostics from `/health` and `/config`

## Validation

- `go test ./internal/team`
- `go test ./cmd/wuphf ./internal/tui`
- `go test ./...`

## Notes

- GBrain requires an API key during setup.
- OpenAI is the full path for embeddings and vector search.
- Anthropic-only remains reduced mode for GBrain retrieval.
