### PR TITLE
[codex] Add scoped private and shared team memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Agents use WUPHF-managed memory tools instead of talking to raw backend MCP tool
 - every agent can read shared memory
 - every agent can read and write only its own private memory
 - durable conclusions can be promoted from private memory into shared memory once they are real
+- shared memory can point agents at the teammate who last recorded durable context, so they know who to ask in-channel for fresher working detail
+- private notes that look like durable decisions, preferences, or playbooks get promotion hints, but nothing is promoted automatically
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,17 @@ WUPHF can run with three organizational context modes:
 - `gbrain` mounts `gbrain serve` as the office memory layer. It requires an API key during `/init`: `OpenAI` gives you the full path with embeddings and vector search, while `Anthropic` alone is reduced mode.
 - `none` disables the external memory layer entirely.
 
+WUPHF now enforces two memory scopes above those backends:
+
+- `private` memory is per-agent and local to WUPHF. Every agent can query and write its own notes.
+- `shared` memory is workspace-wide and backed by the selected external backend (`nex` or `gbrain`).
+
+Agents use WUPHF-managed memory tools instead of talking to raw backend MCP tools directly. That gives the same scope model across both backends:
+
+- every agent can read shared memory
+- every agent can read and write only its own private memory
+- durable conclusions can be promoted from private memory into shared memory once they are real
+
 Examples:
 
 ```bash

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -5740,9 +5740,14 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 func (b *Broker) handleMemory(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
-		channel := normalizeChannelSlug(r.URL.Query().Get("channel"))
-		if channel == "" {
-			channel = "general"
+		namespace := strings.TrimSpace(r.URL.Query().Get("namespace"))
+		query := strings.TrimSpace(r.URL.Query().Get("query"))
+		keyFilter := strings.TrimSpace(r.URL.Query().Get("key"))
+		limit := 5
+		if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+			if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+				limit = parsed
+			}
 		}
 		b.mu.Lock()
 		mem := b.sharedMemory
@@ -5751,12 +5756,49 @@ func (b *Broker) handleMemory(w http.ResponseWriter, r *http.Request) {
 			mem = make(map[string]map[string]string)
 		}
 		w.Header().Set("Content-Type", "application/json")
+		if namespace != "" {
+			entries := mem[namespace]
+			switch {
+			case keyFilter != "":
+				var payload []brokerMemoryEntry
+				if raw, ok := entries[keyFilter]; ok {
+					payload = append(payload, brokerEntryFromNote(decodePrivateMemoryNote(keyFilter, raw)))
+				}
+				json.NewEncoder(w).Encode(map[string]any{
+					"namespace": namespace,
+					"entries":   payload,
+				})
+				return
+			case query != "":
+				matches := searchPrivateMemory(entries, query, limit)
+				payload := make([]brokerMemoryEntry, 0, len(matches))
+				for _, note := range matches {
+					payload = append(payload, brokerEntryFromNote(note))
+				}
+				json.NewEncoder(w).Encode(map[string]any{
+					"namespace": namespace,
+					"entries":   payload,
+				})
+				return
+			default:
+				matches := searchPrivateMemory(entries, "", len(entries))
+				payload := make([]brokerMemoryEntry, 0, len(matches))
+				for _, note := range matches {
+					payload = append(payload, brokerEntryFromNote(note))
+				}
+				json.NewEncoder(w).Encode(map[string]any{
+					"namespace": namespace,
+					"entries":   payload,
+				})
+				return
+			}
+		}
 		json.NewEncoder(w).Encode(map[string]any{"memory": mem})
 	case http.MethodPost:
 		var body struct {
 			Namespace string `json:"namespace"`
 			Key       string `json:"key"`
-			Value     string `json:"value"`
+			Value     any    `json:"value"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			http.Error(w, "invalid json", http.StatusBadRequest)
@@ -5775,7 +5817,20 @@ func (b *Broker) handleMemory(w http.ResponseWriter, r *http.Request) {
 		if b.sharedMemory[ns] == nil {
 			b.sharedMemory[ns] = make(map[string]string)
 		}
-		b.sharedMemory[ns][key] = body.Value
+		value := ""
+		switch typed := body.Value.(type) {
+		case string:
+			value = typed
+		default:
+			data, err := json.Marshal(typed)
+			if err != nil {
+				b.mu.Unlock()
+				http.Error(w, "invalid value", http.StatusBadRequest)
+				return
+			}
+			value = string(data)
+		}
+		b.sharedMemory[ns][key] = value
 		if err := b.saveLocked(); err != nil {
 			b.mu.Unlock()
 			http.Error(w, "failed to persist", http.StatusInternalServerError)

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -76,7 +76,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	// prepended to the notification so the original work packet stays intact.
 	stdinPayload := notification
 	memoryCtx, memoryCancel := context.WithTimeout(ctx, 2*time.Second)
-	if brief := fetchMemoryBrief(memoryCtx, notification); brief != "" {
+	if brief := fetchScopedMemoryBrief(memoryCtx, slug, notification, l.broker); brief != "" {
 		stdinPayload = brief + "\n\n" + notification
 	}
 	memoryCancel()

--- a/internal/team/headless_claude_test.go
+++ b/internal/team/headless_claude_test.go
@@ -217,68 +217,58 @@ func TestEnsureAgentMCPConfig_NoNexEntryInWrittenFile(t *testing.T) {
 	}
 }
 
-// TestBuildMCPServerMap_NexPresentWhenEnabled verifies that when WUPHF_NO_NEX
-// is unset and a fake nex-mcp binary exists on PATH, the "nex" key appears.
-func TestBuildMCPServerMap_NexPresentWhenEnabled(t *testing.T) {
+// TestBuildMCPServerMap_NexCredentialsFlowThroughOffice verifies that the office
+// MCP server now owns shared-memory access, so Nex credentials flow through the
+// wuphf-office server instead of mounting a raw nex MCP server.
+func TestBuildMCPServerMap_NexCredentialsFlowThroughOffice(t *testing.T) {
 	t.Setenv("WUPHF_NO_NEX", "")
 	t.Setenv("WUPHF_API_KEY", "test-key-12345")
 
-	// Inject a fake nex-mcp binary onto a prepended PATH dir.
-	binDir := t.TempDir()
-	nexBin := filepath.Join(binDir, "nex-mcp")
-	if err := os.WriteFile(nexBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("create fake nex-mcp: %v", err)
-	}
-	origPath := os.Getenv("PATH")
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+origPath)
-
 	l := minimalLauncher(false)
 	servers, err := l.buildMCPServerMap()
 	if err != nil {
 		t.Fatalf("buildMCPServerMap: %v", err)
 	}
-	if _, ok := servers["nex"]; !ok {
-		t.Fatalf("'nex' server must be present when nex-mcp is on PATH and WUPHF_NO_NEX unset, got servers: %v", mapKeys(servers))
-	}
-}
-
-func TestBuildMCPServerMap_GBrainPresentWhenSelected(t *testing.T) {
-	t.Setenv("WUPHF_MEMORY_BACKEND", "gbrain")
-	t.Setenv("WUPHF_OPENAI_API_KEY", "openai-test-key")
-
-	binDir := t.TempDir()
-	gbrainBin := filepath.Join(binDir, "gbrain")
-	if err := os.WriteFile(gbrainBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("create fake gbrain: %v", err)
-	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-
-	l := minimalLauncher(false)
-	servers, err := l.buildMCPServerMap()
-	if err != nil {
-		t.Fatalf("buildMCPServerMap: %v", err)
-	}
-	entry, ok := servers["gbrain"]
+	entry, ok := servers["wuphf-office"]
 	if !ok {
-		t.Fatalf("'gbrain' server must be present when GBrain is selected, got servers: %v", mapKeys(servers))
+		t.Fatalf("'wuphf-office' server must be present, got servers: %v", mapKeys(servers))
 	}
 	server, ok := entry.(map[string]any)
 	if !ok {
-		t.Fatalf("expected gbrain entry to be an object, got %T", entry)
-	}
-	if got := server["command"]; got != gbrainBin {
-		t.Fatalf("expected gbrain command %q, got %#v", gbrainBin, got)
-	}
-	args, ok := server["args"].([]string)
-	if !ok || len(args) != 1 || args[0] != "serve" {
-		t.Fatalf("expected gbrain args [serve], got %#v", server["args"])
+		t.Fatalf("expected wuphf-office entry to be an object, got %T", entry)
 	}
 	env, ok := server["env"].(map[string]string)
 	if !ok {
-		t.Fatalf("expected gbrain env map, got %#v", server["env"])
+		t.Fatalf("expected office env map, got %#v", server["env"])
+	}
+	if env["WUPHF_API_KEY"] != "test-key-12345" || env["NEX_API_KEY"] != "test-key-12345" {
+		t.Fatalf("expected Nex credentials on office server, got %#v", env)
+	}
+}
+
+func TestBuildMCPServerMap_GBrainCredentialsFlowThroughOffice(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", "gbrain")
+	t.Setenv("WUPHF_OPENAI_API_KEY", "openai-test-key")
+
+	l := minimalLauncher(false)
+	servers, err := l.buildMCPServerMap()
+	if err != nil {
+		t.Fatalf("buildMCPServerMap: %v", err)
+	}
+	entry, ok := servers["wuphf-office"]
+	if !ok {
+		t.Fatalf("'wuphf-office' server must be present when GBrain is selected, got servers: %v", mapKeys(servers))
+	}
+	server, ok := entry.(map[string]any)
+	if !ok {
+		t.Fatalf("expected wuphf-office entry to be an object, got %T", entry)
+	}
+	env, ok := server["env"].(map[string]string)
+	if !ok {
+		t.Fatalf("expected office env map, got %#v", server["env"])
 	}
 	if env["OPENAI_API_KEY"] != "openai-test-key" {
-		t.Fatalf("expected OPENAI_API_KEY to be forwarded, got %#v", env)
+		t.Fatalf("expected OPENAI_API_KEY to flow through office env, got %#v", env)
 	}
 }
 

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -371,7 +371,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	cmd.Env = l.buildHeadlessCodexEnv(slug)
 	stdinPayload := notification
 	memoryCtx, memoryCancel := context.WithTimeout(ctx, 2*time.Second)
-	if brief := fetchMemoryBrief(memoryCtx, notification); brief != "" {
+	if brief := fetchScopedMemoryBrief(memoryCtx, slug, notification, l.broker); brief != "" {
 		stdinPayload = brief + "\n\n" + notification
 	}
 	memoryCancel()
@@ -557,10 +557,20 @@ func (l *Launcher) buildCodexOfficeConfigOverrides(slug string) ([]string, error
 	wuphfEnvVars := []string{
 		"WUPHF_AGENT_SLUG",
 		"WUPHF_BROKER_TOKEN",
+		"HOME",
 		"WUPHF_MEMORY_BACKEND",
 	}
 	if config.ResolveNoNex() {
 		wuphfEnvVars = append(wuphfEnvVars, "WUPHF_NO_NEX")
+	}
+	if apiKey := strings.TrimSpace(config.ResolveAPIKey("")); apiKey != "" {
+		wuphfEnvVars = append(wuphfEnvVars, "WUPHF_API_KEY", "NEX_API_KEY")
+	}
+	if apiKey := strings.TrimSpace(config.ResolveOpenAIAPIKey()); apiKey != "" {
+		wuphfEnvVars = append(wuphfEnvVars, "OPENAI_API_KEY")
+	}
+	if apiKey := strings.TrimSpace(config.ResolveAnthropicAPIKey()); apiKey != "" {
+		wuphfEnvVars = append(wuphfEnvVars, "ANTHROPIC_API_KEY")
 	}
 	if l.isOneOnOne() {
 		wuphfEnvVars = append(wuphfEnvVars,
@@ -582,18 +592,6 @@ func (l *Launcher) buildCodexOfficeConfigOverrides(slug string) ([]string, error
 		fmt.Sprintf(`mcp_servers.wuphf-office.command=%s`, tomlQuote(wuphfBinary)),
 		`mcp_servers.wuphf-office.args=["mcp-team"]`,
 		fmt.Sprintf(`mcp_servers.wuphf-office.env_vars=%s`, tomlStringArray(wuphfEnvVars)),
-	}
-
-	if server, err := resolvedMemoryMCPServer(); err != nil {
-		return nil, err
-	} else if server != nil {
-		overrides = append(overrides, fmt.Sprintf(`mcp_servers.%s.command=%s`, server.Name, tomlQuote(server.Command)))
-		if len(server.Args) > 0 {
-			overrides = append(overrides, fmt.Sprintf(`mcp_servers.%s.args=%s`, server.Name, tomlStringArray(server.Args)))
-		}
-		if len(server.EnvVars) > 0 {
-			overrides = append(overrides, fmt.Sprintf(`mcp_servers.%s.env_vars=%s`, server.Name, tomlStringArray(server.EnvVars)))
-		}
 	}
 
 	return overrides, nil

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -3,7 +3,6 @@ package team
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -78,30 +77,21 @@ func TestBuildCodexOfficeConfigOverridesIncludesOfficeMCPEnv(t *testing.T) {
 	if !strings.Contains(joined, `mcp_servers.wuphf-office.args=["mcp-team"]`) {
 		t.Fatalf("expected WUPHF MCP args override, got %q", joined)
 	}
-	if !strings.Contains(joined, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "WUPHF_MEMORY_BACKEND", "WUPHF_NO_NEX", "WUPHF_ONE_ON_ONE", "WUPHF_ONE_ON_ONE_AGENT"]`) {
+	if !strings.Contains(joined, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "HOME", "WUPHF_MEMORY_BACKEND", "WUPHF_NO_NEX", "WUPHF_ONE_ON_ONE", "WUPHF_ONE_ON_ONE_AGENT"]`) {
 		t.Fatalf("expected office env var forwarding, got %q", joined)
 	}
 	if strings.Contains(joined, broker.Token()) {
 		t.Fatalf("expected broker token value to stay out of args, got %q", joined)
 	}
-	if strings.Contains(joined, `mcp_servers.nex.command=`) {
-		t.Fatalf("expected Nex MCP to stay disabled with WUPHF_NO_NEX, got %q", joined)
-	}
 }
 
-func TestBuildCodexOfficeConfigOverridesIncludesGBrainWhenSelected(t *testing.T) {
+func TestBuildCodexOfficeConfigOverridesRoutesGBrainThroughOfficeEnv(t *testing.T) {
 	oldExecutablePath := headlessCodexExecutablePath
 	headlessCodexExecutablePath = func() (string, error) { return "/tmp/wuphf", nil }
 	defer func() {
 		headlessCodexExecutablePath = oldExecutablePath
 	}()
 
-	binDir := t.TempDir()
-	gbrainBin := filepath.Join(binDir, "gbrain")
-	if err := os.WriteFile(gbrainBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("create fake gbrain: %v", err)
-	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("WUPHF_MEMORY_BACKEND", "gbrain")
 	t.Setenv("WUPHF_OPENAI_API_KEY", "openai-test-key")
 	t.Setenv("WUPHF_ANTHROPIC_API_KEY", "anthropic-test-key")
@@ -116,14 +106,8 @@ func TestBuildCodexOfficeConfigOverridesIncludesGBrainWhenSelected(t *testing.T)
 		t.Fatalf("buildCodexOfficeConfigOverrides: %v", err)
 	}
 	joined := strings.Join(overrides, "\n")
-	if !strings.Contains(joined, fmt.Sprintf(`mcp_servers.gbrain.command=%q`, gbrainBin)) {
-		t.Fatalf("expected GBrain MCP command override, got %q", joined)
-	}
-	if !strings.Contains(joined, `mcp_servers.gbrain.args=["serve"]`) {
-		t.Fatalf("expected GBrain MCP args override, got %q", joined)
-	}
-	if !strings.Contains(joined, `mcp_servers.gbrain.env_vars=["HOME", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"]`) {
-		t.Fatalf("expected GBrain env forwarding, got %q", joined)
+	if !strings.Contains(joined, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "HOME", "WUPHF_MEMORY_BACKEND", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "WUPHF_ONE_ON_ONE", "WUPHF_ONE_ON_ONE_AGENT"]`) {
+		t.Fatalf("expected GBrain credentials to flow through office env, got %q", joined)
 	}
 
 	env := l.buildHeadlessCodexEnv("ceo")
@@ -167,12 +151,6 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 	t.Setenv("WUPHF_ONE_SECRET", "one-secret-value")
 	t.Setenv("WUPHF_ONE_IDENTITY", "founder@example.com")
 	t.Setenv("WUPHF_ONE_IDENTITY_TYPE", "user")
-	binDir := t.TempDir()
-	nexMCP := filepath.Join(binDir, "nex-mcp")
-	if err := os.WriteFile(nexMCP, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("create fake nex-mcp: %v", err)
-	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	l := &Launcher{
 		pack:        agent.GetPack("founding-team"),
@@ -193,14 +171,8 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 	if !strings.Contains(joinedArgs, `mcp_servers.wuphf-office.command="/tmp/wuphf"`) {
 		t.Fatalf("expected office MCP override, got %#v", record.Args)
 	}
-	if !strings.Contains(joinedArgs, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "WUPHF_MEMORY_BACKEND", "ONE_SECRET", "ONE_IDENTITY", "ONE_IDENTITY_TYPE"]`) {
+	if !strings.Contains(joinedArgs, `mcp_servers.wuphf-office.env_vars=["WUPHF_AGENT_SLUG", "WUPHF_BROKER_TOKEN", "HOME", "WUPHF_MEMORY_BACKEND", "WUPHF_API_KEY", "NEX_API_KEY", "ONE_SECRET", "ONE_IDENTITY", "ONE_IDENTITY_TYPE"]`) {
 		t.Fatalf("expected office env var forwarding, got %#v", record.Args)
-	}
-	if !strings.Contains(joinedArgs, fmt.Sprintf(`mcp_servers.nex.command=%q`, nexMCP)) {
-		t.Fatalf("expected nex MCP override, got %#v", record.Args)
-	}
-	if !strings.Contains(joinedArgs, `mcp_servers.nex.env_vars=["WUPHF_API_KEY", "NEX_API_KEY"]`) {
-		t.Fatalf("expected nex env var forwarding, got %#v", record.Args)
 	}
 	if !containsEnv(record.Env, "WUPHF_AGENT_SLUG=ceo") {
 		t.Fatalf("expected agent env, got %#v", record.Env)

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -2763,14 +2763,7 @@ var codingAgentSlugs = map[string]bool{
 
 // agentMCPServers returns the MCP server keys that a given agent should receive.
 func agentMCPServers(slug string) []string {
-	if codingAgentSlugs[slug] {
-		return []string{"wuphf-office"}
-	}
-	servers := []string{"wuphf-office"}
-	if backend := activeMemoryBackendKind(); backend != config.MemoryBackendNone {
-		servers = append(servers, backend)
-	}
-	return servers
+	return []string{"wuphf-office"}
 }
 
 // buildMCPServerMap constructs the full set of MCP server entries.
@@ -2785,8 +2778,21 @@ func (l *Launcher) buildMCPServerMap() (map[string]any, error) {
 	officeEnv := map[string]string{
 		"WUPHF_MEMORY_BACKEND": config.ResolveMemoryBackend(""),
 	}
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		officeEnv["HOME"] = home
+	}
 	if config.ResolveNoNex() {
 		officeEnv["WUPHF_NO_NEX"] = "1"
+	}
+	if apiKey := strings.TrimSpace(config.ResolveAPIKey("")); apiKey != "" {
+		officeEnv["WUPHF_API_KEY"] = apiKey
+		officeEnv["NEX_API_KEY"] = apiKey
+	}
+	if apiKey := strings.TrimSpace(config.ResolveOpenAIAPIKey()); apiKey != "" {
+		officeEnv["OPENAI_API_KEY"] = apiKey
+	}
+	if apiKey := strings.TrimSpace(config.ResolveAnthropicAPIKey()); apiKey != "" {
+		officeEnv["ANTHROPIC_API_KEY"] = apiKey
 	}
 	servers["wuphf-office"] = map[string]any{
 		"command": wuphfBinary,
@@ -2801,21 +2807,6 @@ func (l *Launcher) buildMCPServerMap() (map[string]any, error) {
 		if identityType := strings.TrimSpace(config.ResolveOneIdentityType()); identityType != "" {
 			officeEnv["ONE_IDENTITY_TYPE"] = identityType
 		}
-	}
-
-	if server, err := resolvedMemoryMCPServer(); err != nil {
-		return nil, err
-	} else if server != nil {
-		entry := map[string]any{
-			"command": server.Command,
-		}
-		if len(server.Args) > 0 {
-			entry["args"] = server.Args
-		}
-		if len(server.Env) > 0 {
-			entry["env"] = server.Env
-		}
-		servers[server.Name] = entry
 	}
 
 	return servers, nil

--- a/internal/team/memory_backend.go
+++ b/internal/team/memory_backend.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/nex-crm/wuphf/internal/api"
 	"github.com/nex-crm/wuphf/internal/config"
@@ -47,6 +48,7 @@ type ScopedMemoryHit struct {
 	Identifier string
 	Title      string
 	Snippet    string
+	OwnerSlug  string
 }
 
 type SharedMemoryWrite struct {
@@ -135,6 +137,7 @@ func (nexMemoryBackend) QueryShared(ctx context.Context, query string, limit int
 		Identifier: "nex-context",
 		Title:      "Nex context",
 		Snippet:    strings.TrimSpace(resp.Answer),
+		OwnerSlug:  inferSharedMemoryOwner("", strings.TrimSpace(resp.Answer)),
 	}}, nil
 }
 func (nexMemoryBackend) WriteShared(ctx context.Context, note SharedMemoryWrite) (string, error) {
@@ -244,6 +247,7 @@ func (gbrainMemoryBackend) QueryShared(ctx context.Context, query string, limit 
 			Identifier: strings.TrimSpace(result.Slug),
 			Title:      title,
 			Snippet:    truncate(snippet, 220),
+			OwnerSlug:  inferSharedMemoryOwner(strings.TrimSpace(result.Slug), snippet),
 		})
 		if len(hits) >= limit && limit > 0 {
 			break
@@ -256,7 +260,8 @@ func (gbrainMemoryBackend) WriteShared(ctx context.Context, note SharedMemoryWri
 	if slug == "" {
 		slug = "shared-note"
 	}
-	slug = fmt.Sprintf("wuphf-shared-%s-%s", slug, time.Now().UTC().Format("20060102-150405"))
+	actor := slugify(firstNonEmpty(note.Actor, "wuphf"))
+	slug = fmt.Sprintf("wuphf-shared--%s--%s--%s", actor, slug, time.Now().UTC().Format("20060102-150405"))
 	raw, err := gbrain.Call(ctx, "put_page", map[string]any{
 		"slug":    slug,
 		"content": renderGBrainSharedMemoryPage(slug, note),
@@ -446,9 +451,9 @@ func gbrainMCPEnvVars() []string {
 func directMemoryPromptBlock() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "Memory scopes:\n- team_memory_query: Read your private notes (`scope=private`) or shared org memory backed by Nex (`scope=shared`)\n- team_memory_write: Store private notes by default; only write shared memory after a durable outcome is real\n- team_memory_promote: Copy one of your private notes into shared Nex memory when it becomes canonical\n\n"
+		return "Memory scopes:\n- team_memory_query: Read your private notes (`scope=private`) or shared org memory backed by Nex (`scope=shared`)\n- team_memory_write: Store private notes by default; only write shared memory after a durable outcome is real\n- team_memory_promote: Copy one of your private notes into shared Nex memory when it becomes canonical\n- If shared memory points at another agent, ask them in the office for fresher working detail instead of guessing\n\n"
 	case config.MemoryBackendGBrain:
-		return "Memory scopes:\n- team_memory_query: Read your private notes (`scope=private`) or shared org memory backed by GBrain (`scope=shared`)\n- team_memory_write: Store private notes by default; only write shared memory after a durable outcome is real\n- team_memory_promote: Copy one of your private notes into shared GBrain memory when it becomes canonical\n\n"
+		return "Memory scopes:\n- team_memory_query: Read your private notes (`scope=private`) or shared org memory backed by GBrain (`scope=shared`)\n- team_memory_write: Store private notes by default; only write shared memory after a durable outcome is real\n- team_memory_promote: Copy one of your private notes into shared GBrain memory when it becomes canonical\n- If shared memory points at another agent, ask them in the office for fresher working detail instead of guessing\n\n"
 	default:
 		return "Memory scopes:\n- team_memory_query: Your private notes still work with `scope=private`\n- team_memory_write: Store private notes for yourself\n- Shared org memory is not active for this run, so `scope=shared` and team_memory_promote are unavailable\n\n"
 	}
@@ -468,9 +473,9 @@ func directMemoryStorageRule() string {
 func leadMemoryPromptBlock() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by Nex, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge.\n\n"
+		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by Nex, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge. If shared memory points at another agent, ask them in the office for the freshest working context.\n\n"
 	case config.MemoryBackendGBrain:
-		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by GBrain, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge. Keep task coordination in the office, not in shared memory.\n\n"
+		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by GBrain, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge. If shared memory points at another agent, ask them in the office for the freshest working context. Keep task coordination in the office, not in shared memory.\n\n"
 	default:
 		return "Shared org memory is not active for this run. You can still use private notes with team_memory_query/team_memory_write scope=private.\n\n"
 	}
@@ -512,9 +517,9 @@ func leadMemoryFinalWarning() string {
 func specialistMemoryPromptBlock() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by Nex, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge.\n\n"
+		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by Nex, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge. If shared memory points at another agent, ask them in the office for the freshest working context.\n\n"
 	case config.MemoryBackendGBrain:
-		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by GBrain, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge.\n\n"
+		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by GBrain, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge. If shared memory points at another agent, ask them in the office for the freshest working context.\n\n"
 	default:
 		return "Shared org memory is not active for this run. You can still use private notes with team_memory_query/team_memory_write scope=private.\n\n"
 	}
@@ -578,7 +583,7 @@ updated_at: %s
 Recorded by @%s on %s.
 
 %s
-`,
+	`,
 		yamlTitle,
 		slugify(actor),
 		slug,
@@ -588,4 +593,62 @@ Recorded by @%s on %s.
 		now,
 		strings.TrimSpace(note.Content),
 	)
+}
+
+func inferSharedMemoryOwner(identifier string, snippet string) string {
+	if owner := parseGBrainSharedMemoryOwner(identifier); owner != "" {
+		return owner
+	}
+	for _, marker := range []string{"author: @", "recorded by @"} {
+		if owner := parseSharedMemoryOwnerAfterMarker(snippet, marker); owner != "" {
+			return owner
+		}
+	}
+	return ""
+}
+
+func parseGBrainSharedMemoryOwner(identifier string) string {
+	identifier = strings.TrimSpace(identifier)
+	if identifier == "" {
+		return ""
+	}
+	parts := strings.Split(identifier, "--")
+	if len(parts) < 4 {
+		return ""
+	}
+	if strings.TrimSpace(parts[0]) != "wuphf-shared" {
+		return ""
+	}
+	return slugify(parts[1])
+}
+
+func parseSharedMemoryOwnerAfterMarker(text string, marker string) string {
+	text = strings.TrimSpace(text)
+	marker = strings.ToLower(strings.TrimSpace(marker))
+	if text == "" || marker == "" {
+		return ""
+	}
+	lower := strings.ToLower(text)
+	idx := strings.Index(lower, marker)
+	if idx < 0 {
+		return ""
+	}
+	start := idx + len(marker)
+	if start >= len(text) {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range text[start:] {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r) || r == '-' || r == '_':
+			b.WriteRune(unicode.ToLower(r))
+		default:
+			value := slugify(b.String())
+			if value != "" {
+				return value
+			}
+			return ""
+		}
+	}
+	return slugify(b.String())
 }

--- a/internal/team/memory_backend.go
+++ b/internal/team/memory_backend.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
+	"github.com/nex-crm/wuphf/internal/api"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/gbrain"
 	"github.com/nex-crm/wuphf/internal/nex"
@@ -35,6 +37,23 @@ type memoryBackend interface {
 	Ready() bool
 	MCPServer() (*memoryMCPServer, error)
 	FetchBrief(ctx context.Context, notification string) string
+	QueryShared(ctx context.Context, query string, limit int) ([]ScopedMemoryHit, error)
+	WriteShared(ctx context.Context, note SharedMemoryWrite) (string, error)
+}
+
+type ScopedMemoryHit struct {
+	Scope      string
+	Backend    string
+	Identifier string
+	Title      string
+	Snippet    string
+}
+
+type SharedMemoryWrite struct {
+	Actor   string
+	Key     string
+	Title   string
+	Content string
 }
 
 type noMemoryBackend struct{}
@@ -46,6 +65,12 @@ func (noMemoryBackend) MCPServer() (*memoryMCPServer, error) {
 	return nil, nil
 }
 func (noMemoryBackend) FetchBrief(context.Context, string) string { return "" }
+func (noMemoryBackend) QueryShared(context.Context, string, int) ([]ScopedMemoryHit, error) {
+	return nil, nil
+}
+func (noMemoryBackend) WriteShared(context.Context, SharedMemoryWrite) (string, error) {
+	return "", fmt.Errorf("shared external memory is not active for this run")
+}
 
 type nexMemoryBackend struct{}
 
@@ -89,6 +114,48 @@ func (nexMemoryBackend) FetchBrief(ctx context.Context, notification string) str
 		return ""
 	}
 	return "== NEX CONTEXT ==\n" + strings.TrimSpace(answer) + "\n== END NEX CONTEXT =="
+}
+func (nexMemoryBackend) QueryShared(ctx context.Context, query string, limit int) ([]ScopedMemoryHit, error) {
+	client := api.NewClient(strings.TrimSpace(config.ResolveAPIKey("")))
+	if !client.IsAuthenticated() {
+		return nil, fmt.Errorf("nex is not configured")
+	}
+	type askResponse struct {
+		Answer string `json:"answer"`
+	}
+	resp, err := api.Post[askResponse](client, "/v1/context/ask", map[string]any{
+		"query": strings.TrimSpace(query),
+	}, 0)
+	if err != nil || strings.TrimSpace(resp.Answer) == "" {
+		return nil, err
+	}
+	return []ScopedMemoryHit{{
+		Scope:      "shared",
+		Backend:    config.MemoryBackendNex,
+		Identifier: "nex-context",
+		Title:      "Nex context",
+		Snippet:    strings.TrimSpace(resp.Answer),
+	}}, nil
+}
+func (nexMemoryBackend) WriteShared(ctx context.Context, note SharedMemoryWrite) (string, error) {
+	client := api.NewClient(strings.TrimSpace(config.ResolveAPIKey("")))
+	if !client.IsAuthenticated() {
+		return "", fmt.Errorf("nex is not configured")
+	}
+	content := renderNexSharedMemoryContent(note)
+	if _, err := api.Post[map[string]any](client, "/v1/context/text", map[string]any{
+		"content": content,
+	}, 0); err != nil {
+		return "", err
+	}
+	key := strings.TrimSpace(note.Key)
+	if key == "" {
+		key = slugify(firstNonEmpty(note.Title, note.Content))
+	}
+	if key == "" {
+		key = "shared-note"
+	}
+	return key, nil
 }
 
 type gbrainMemoryBackend struct{}
@@ -150,6 +217,57 @@ func (gbrainMemoryBackend) FetchBrief(ctx context.Context, notification string) 
 	}
 	lines = append(lines, "== END GBRAIN CONTEXT ==")
 	return strings.Join(lines, "\n")
+}
+func (gbrainMemoryBackend) QueryShared(ctx context.Context, query string, limit int) ([]ScopedMemoryHit, error) {
+	results, err := gbrain.Query(ctx, query, limit)
+	if err != nil {
+		return nil, err
+	}
+	hits := make([]ScopedMemoryHit, 0, len(results))
+	seen := map[string]struct{}{}
+	for _, result := range results {
+		if _, ok := seen[result.Slug]; ok {
+			continue
+		}
+		seen[result.Slug] = struct{}{}
+		title := strings.TrimSpace(result.Title)
+		if title == "" {
+			title = strings.TrimSpace(result.Slug)
+		}
+		snippet := strings.TrimSpace(strings.ReplaceAll(result.ChunkText, "\n", " "))
+		if snippet == "" {
+			snippet = "Relevant context found in the brain."
+		}
+		hits = append(hits, ScopedMemoryHit{
+			Scope:      "shared",
+			Backend:    config.MemoryBackendGBrain,
+			Identifier: strings.TrimSpace(result.Slug),
+			Title:      title,
+			Snippet:    truncate(snippet, 220),
+		})
+		if len(hits) >= limit && limit > 0 {
+			break
+		}
+	}
+	return hits, nil
+}
+func (gbrainMemoryBackend) WriteShared(ctx context.Context, note SharedMemoryWrite) (string, error) {
+	slug := slugify(firstNonEmpty(note.Key, note.Title, note.Content))
+	if slug == "" {
+		slug = "shared-note"
+	}
+	slug = fmt.Sprintf("wuphf-shared-%s-%s", slug, time.Now().UTC().Format("20060102-150405"))
+	raw, err := gbrain.Call(ctx, "put_page", map[string]any{
+		"slug":    slug,
+		"content": renderGBrainSharedMemoryPage(slug, note),
+	})
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(raw) == "" {
+		return slug, nil
+	}
+	return slug, nil
 }
 
 func gbrainProviderKeyConfigured() bool {
@@ -262,6 +380,29 @@ func fetchMemoryBrief(ctx context.Context, notification string) string {
 	return activeMemoryBackend().FetchBrief(ctx, notification)
 }
 
+func QuerySharedMemory(ctx context.Context, query string, limit int) ([]ScopedMemoryHit, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 5
+	}
+	backend := activeMemoryBackend()
+	if backend.Kind() == config.MemoryBackendNone {
+		return nil, nil
+	}
+	return backend.QueryShared(ctx, query, limit)
+}
+
+func WriteSharedMemory(ctx context.Context, note SharedMemoryWrite) (string, error) {
+	note.Content = strings.TrimSpace(note.Content)
+	if note.Content == "" {
+		return "", fmt.Errorf("content is required")
+	}
+	return activeMemoryBackend().WriteShared(ctx, note)
+}
+
 func resolvedMemoryMCPServer() (*memoryMCPServer, error) {
 	return activeMemoryBackend().MCPServer()
 }
@@ -305,87 +446,146 @@ func gbrainMCPEnvVars() []string {
 func directMemoryPromptBlock() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "Use the Nex context graph when it materially helps:\n- query_context: Look up prior decisions, people, projects, and history before guessing\n- add_context: Store durable conclusions only after you have actually landed them\n\n"
+		return "Memory scopes:\n- team_memory_query: Read your private notes (`scope=private`) or shared org memory backed by Nex (`scope=shared`)\n- team_memory_write: Store private notes by default; only write shared memory after a durable outcome is real\n- team_memory_promote: Copy one of your private notes into shared Nex memory when it becomes canonical\n\n"
 	case config.MemoryBackendGBrain:
-		return "Use GBrain as durable world knowledge when it materially helps:\n- query: Brain-first semantic lookup for people, projects, decisions, and patterns\n- search: Exact term or slug lookup when you already know the entity\n- get_page: Load the full page once a hit looks relevant\n- put_page or add_timeline_entry: Write durable world knowledge only after it actually lands; keep task chatter in the conversation\n\n"
+		return "Memory scopes:\n- team_memory_query: Read your private notes (`scope=private`) or shared org memory backed by GBrain (`scope=shared`)\n- team_memory_write: Store private notes by default; only write shared memory after a durable outcome is real\n- team_memory_promote: Copy one of your private notes into shared GBrain memory when it becomes canonical\n\n"
 	default:
-		return "External memory is not active for this run. Base your work on the conversation and direct human answers only.\n\n"
+		return "Memory scopes:\n- team_memory_query: Your private notes still work with `scope=private`\n- team_memory_write: Store private notes for yourself\n- Shared org memory is not active for this run, so `scope=shared` and team_memory_promote are unavailable\n\n"
 	}
 }
 
 func directMemoryStorageRule() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "7. If Nex is enabled, do not claim something is stored unless add_context actually succeeded.\n"
+		return "7. Keep scratch notes private by default. Only claim shared storage after team_memory_write visibility=shared or team_memory_promote actually succeeded.\n"
 	case config.MemoryBackendGBrain:
-		return "7. If GBrain is enabled, do not claim the brain was updated unless put_page or add_timeline_entry actually succeeded.\n"
+		return "7. Keep scratch notes private by default. Only claim shared storage after team_memory_write visibility=shared or team_memory_promote actually succeeded.\n"
 	default:
-		return "7. Do not pretend anything was stored outside this session.\n"
+		return "7. Do not pretend anything was stored outside your private note scope.\n"
 	}
 }
 
 func leadMemoryPromptBlock() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "Nex memory: query_context before reinventing; add_context only after a decision is actually landed.\n\n"
+		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by Nex, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge.\n\n"
 	case config.MemoryBackendGBrain:
-		return "GBrain operating loop: query before reinventing, search when you know the entity, get_page before relying on a hit, and only write durable world knowledge back with put_page or add_timeline_entry once it has landed. Keep task coordination in the office, not in the brain.\n\n"
+		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by GBrain, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge. Keep task coordination in the office, not in shared memory.\n\n"
 	default:
-		return "External memory is not active for this run. Work only with the shared office channel and human answers.\n\n"
+		return "Shared org memory is not active for this run. You can still use private notes with team_memory_query/team_memory_write scope=private.\n\n"
 	}
 }
 
 func leadMemoryFirstRule() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "1. On strategy or prior decisions, call query_context early\n"
+		return "1. On strategy or prior decisions, call team_memory_query early. Use scope=shared for org memory and scope=private for your own retained notes.\n"
 	case config.MemoryBackendGBrain:
-		return "1. On strategy, relationships, or prior decisions, start in GBrain: query broadly, then search or get_page to verify the relevant entity page\n"
+		return "1. On strategy, relationships, or prior decisions, start with team_memory_query. Use shared scope for org context and private scope for your own retained notes.\n"
 	default:
-		return "1. Coordinate inside the office channel first and keep the team aligned there\n"
+		return "1. Coordinate inside the office channel first, and use private memory only for your own scratch history.\n"
 	}
 }
 
 func leadMemoryStorageRule() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "8. When you lock a decision, call add_context before claiming it is stored\n"
+		return "8. When you lock a durable decision, promote it into shared memory before claiming it is stored\n"
 	case config.MemoryBackendGBrain:
-		return "8. When you lock a durable decision, update the relevant page or timeline before claiming the brain knows it\n"
+		return "8. When you lock a durable decision, promote it into shared memory before claiming the brain knows it\n"
 	default:
-		return "8. Summarize final decisions clearly in-channel\n"
+		return "8. Summarize final decisions clearly in-channel; shared org memory is unavailable in this run\n"
 	}
 }
 
 func leadMemoryFinalWarning() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "Do not pretend the graph was updated; verify add_context succeeded.\n"
+		return "Do not pretend shared memory was updated; verify team_memory_write visibility=shared or team_memory_promote succeeded.\n"
 	case config.MemoryBackendGBrain:
-		return "Do not pretend the brain was updated; verify put_page or add_timeline_entry succeeded.\n"
+		return "Do not pretend shared memory was updated; verify team_memory_write visibility=shared or team_memory_promote succeeded.\n"
 	default:
-		return "Do not claim you stored anything outside the office.\n"
+		return "Do not claim you stored anything outside your private notes.\n"
 	}
 }
 
 func specialistMemoryPromptBlock() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "Nex memory: query_context before making assumptions; add_context only for durable conclusions.\n\n"
+		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by Nex, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge.\n\n"
 	case config.MemoryBackendGBrain:
-		return "GBrain operating loop: query when prior knowledge matters, search when you already know the entity, get_page before leaning on a hit, and only write durable world knowledge back with put_page or add_timeline_entry once the outcome has actually landed.\n\n"
+		return "Memory scopes: use team_memory_query with scope=shared for org memory backed by GBrain, scope=private for your own notes, and team_memory_promote when a private note becomes durable shared knowledge.\n\n"
 	default:
-		return "External memory is not active for this run. Base your work on the office conversation and direct human answers only.\n\n"
+		return "Shared org memory is not active for this run. You can still use private notes with team_memory_query/team_memory_write scope=private.\n\n"
 	}
 }
 
 func specialistMemoryStorageRule() string {
 	switch activeMemoryBackendKind() {
 	case config.MemoryBackendNex:
-		return "9. Use query_context when prior knowledge matters. Only use add_context for durable conclusions, and don't claim something stored unless add_context actually succeeded.\n\n"
+		return "9. Use team_memory_query when prior knowledge matters. Keep notes private by default, and only promote durable conclusions into shared memory once they are real.\n\n"
 	case config.MemoryBackendGBrain:
-		return "9. Use GBrain when prior knowledge matters. Query first, verify with get_page when needed, and only write durable world knowledge back with put_page or add_timeline_entry after the outcome is real.\n\n"
+		return "9. Use team_memory_query when prior knowledge matters. Keep notes private by default, and only promote durable conclusions into shared memory once they are real.\n\n"
 	default:
-		return "9. Don't fake outside memory. Surface uncertainty in-channel and keep outcomes explicit in-thread.\n\n"
+		return "9. Don't fake shared memory. Surface uncertainty in-channel and keep any retained notes private.\n\n"
 	}
+}
+
+func renderNexSharedMemoryContent(note SharedMemoryWrite) string {
+	title := strings.TrimSpace(note.Title)
+	if title == "" {
+		title = firstNonEmpty(strings.TrimSpace(note.Key), "WUPHF shared memory")
+	}
+	actor := strings.TrimSpace(note.Actor)
+	if actor == "" {
+		actor = "wuphf"
+	}
+	return fmt.Sprintf("[WUPHF shared memory]\nTitle: %s\nAuthor: @%s\nRecorded at: %s\n\n%s",
+		title,
+		actor,
+		time.Now().UTC().Format(time.RFC3339),
+		strings.TrimSpace(note.Content),
+	)
+}
+
+func renderGBrainSharedMemoryPage(slug string, note SharedMemoryWrite) string {
+	title := strings.TrimSpace(note.Title)
+	if title == "" {
+		title = strings.TrimSpace(note.Key)
+	}
+	if title == "" {
+		title = "WUPHF shared memory"
+	}
+	actor := strings.TrimSpace(note.Actor)
+	if actor == "" {
+		actor = "wuphf"
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	yamlTitle := strings.ReplaceAll(title, `"`, `\"`)
+	return fmt.Sprintf(`---
+title: "%s"
+type: note
+tags:
+  - wuphf
+  - shared-memory
+  - agent-%s
+slug: %s
+updated_at: %s
+---
+
+# %s
+
+Recorded by @%s on %s.
+
+%s
+`,
+		yamlTitle,
+		slugify(actor),
+		slug,
+		now,
+		title,
+		actor,
+		now,
+		strings.TrimSpace(note.Content),
+	)
 }

--- a/internal/team/memory_backend_test.go
+++ b/internal/team/memory_backend_test.go
@@ -101,3 +101,10 @@ func TestShouldPollNexNotificationsOnlyWhenNexIsActive(t *testing.T) {
 		t.Fatal("did not expect nex notification polling when gbrain is active")
 	}
 }
+
+func TestInferSharedMemoryOwnerFromGBrainSlug(t *testing.T) {
+	owner := inferSharedMemoryOwner("wuphf-shared--pm--launch-brief--20260416-120000", "")
+	if owner != "pm" {
+		t.Fatalf("expected owner pm from gbrain slug, got %q", owner)
+	}
+}

--- a/internal/team/scoped_memory.go
+++ b/internal/team/scoped_memory.go
@@ -1,0 +1,249 @@
+package team
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	privateMemoryScope = "private"
+	sharedMemoryScope  = "shared"
+)
+
+type privateMemoryNote struct {
+	Key       string `json:"key"`
+	Title     string `json:"title,omitempty"`
+	Content   string `json:"content"`
+	Author    string `json:"author,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+type brokerMemoryEntry struct {
+	Key       string `json:"key"`
+	Title     string `json:"title,omitempty"`
+	Content   string `json:"content"`
+	Author    string `json:"author,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+func privateMemoryNamespace(slug string) string {
+	return "agent/" + strings.TrimSpace(slug)
+}
+
+func encodePrivateMemoryNote(note privateMemoryNote) string {
+	note.Key = strings.TrimSpace(note.Key)
+	note.Title = strings.TrimSpace(note.Title)
+	note.Content = strings.TrimSpace(note.Content)
+	note.Author = strings.TrimSpace(note.Author)
+	now := time.Now().UTC().Format(time.RFC3339)
+	if strings.TrimSpace(note.CreatedAt) == "" {
+		note.CreatedAt = now
+	}
+	note.UpdatedAt = now
+	data, err := json.Marshal(note)
+	if err != nil {
+		return note.Content
+	}
+	return string(data)
+}
+
+func decodePrivateMemoryNote(key string, raw string) privateMemoryNote {
+	key = strings.TrimSpace(key)
+	raw = strings.TrimSpace(raw)
+	note := privateMemoryNote{
+		Key:     key,
+		Content: raw,
+		Title:   key,
+	}
+	if raw == "" {
+		return note
+	}
+	var decoded privateMemoryNote
+	if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		return note
+	}
+	if strings.TrimSpace(decoded.Key) == "" {
+		decoded.Key = key
+	}
+	if strings.TrimSpace(decoded.Title) == "" {
+		decoded.Title = decoded.Key
+	}
+	if strings.TrimSpace(decoded.Content) == "" {
+		decoded.Content = raw
+	}
+	return decoded
+}
+
+func brokerEntryFromNote(note privateMemoryNote) brokerMemoryEntry {
+	return brokerMemoryEntry{
+		Key:       note.Key,
+		Title:     note.Title,
+		Content:   note.Content,
+		Author:    note.Author,
+		CreatedAt: note.CreatedAt,
+		UpdatedAt: note.UpdatedAt,
+	}
+}
+
+func searchPrivateMemory(entries map[string]string, query string, limit int) []privateMemoryNote {
+	if limit <= 0 {
+		limit = 5
+	}
+	query = strings.TrimSpace(strings.ToLower(query))
+	type scoredNote struct {
+		note  privateMemoryNote
+		score int
+	}
+	notes := make([]scoredNote, 0, len(entries))
+	for key, raw := range entries {
+		note := decodePrivateMemoryNote(key, raw)
+		haystack := normalizeMemorySearchText(strings.Join([]string{note.Key, note.Title, note.Content}, "\n"))
+		score := privateMemoryMatchScore(haystack, query)
+		if query != "" && score == 0 {
+			continue
+		}
+		notes = append(notes, scoredNote{note: note, score: score})
+	}
+	sort.Slice(notes, func(i, j int) bool {
+		if notes[i].score != notes[j].score {
+			return notes[i].score > notes[j].score
+		}
+		return noteTimestamp(notes[i].note).After(noteTimestamp(notes[j].note))
+	})
+	if len(notes) > limit {
+		notes = notes[:limit]
+	}
+	out := make([]privateMemoryNote, 0, len(notes))
+	for _, item := range notes {
+		out = append(out, item.note)
+	}
+	return out
+}
+
+func noteTimestamp(note privateMemoryNote) time.Time {
+	for _, candidate := range []string{note.UpdatedAt, note.CreatedAt} {
+		if parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(candidate)); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
+}
+
+func slugify(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return ""
+	}
+	var b strings.Builder
+	lastDash := false
+	for _, r := range value {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			b.WriteRune(r)
+			lastDash = false
+		case r == '-' || r == '_' || unicode.IsSpace(r):
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func normalizeMemorySearchText(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return ""
+	}
+	var b strings.Builder
+	lastSpace := false
+	for _, r := range value {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			b.WriteRune(r)
+			lastSpace = false
+		default:
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func privateMemoryMatchScore(haystack string, query string) int {
+	if query == "" {
+		return 1
+	}
+	query = normalizeMemorySearchText(query)
+	if query == "" {
+		return 1
+	}
+	score := 0
+	if strings.Contains(haystack, query) {
+		score += 100
+	}
+	for _, token := range strings.Fields(query) {
+		if strings.Contains(haystack, token) {
+			score += 10
+		}
+	}
+	return score
+}
+
+func formatPrivateMemoryBrief(slug string, entries map[string]string, query string) string {
+	if strings.TrimSpace(slug) == "" || len(entries) == 0 {
+		return ""
+	}
+	matches := searchPrivateMemory(entries, query, 2)
+	if len(matches) == 0 {
+		return ""
+	}
+	lines := []string{"== PRIVATE MEMORY =="}
+	for _, note := range matches {
+		title := strings.TrimSpace(note.Title)
+		if title == "" {
+			title = strings.TrimSpace(note.Key)
+		}
+		lines = append(lines, fmt.Sprintf("- %s: %s", title, truncate(strings.TrimSpace(strings.ReplaceAll(note.Content, "\n", " ")), 220)))
+	}
+	lines = append(lines, "== END PRIVATE MEMORY ==")
+	return strings.Join(lines, "\n")
+}
+
+func fetchScopedMemoryBrief(ctx context.Context, slug string, notification string, broker *Broker) string {
+	query := strings.TrimSpace(notification)
+	if query == "" {
+		return ""
+	}
+	var blocks []string
+	if broker != nil {
+		broker.mu.Lock()
+		entries := map[string]string{}
+		if broker.sharedMemory != nil {
+			if stored := broker.sharedMemory[privateMemoryNamespace(slug)]; stored != nil {
+				entries = make(map[string]string, len(stored))
+				for key, value := range stored {
+					entries[key] = value
+				}
+			}
+		}
+		broker.mu.Unlock()
+		if brief := formatPrivateMemoryBrief(slug, entries, query); brief != "" {
+			blocks = append(blocks, brief)
+		}
+	}
+	if brief := fetchMemoryBrief(ctx, notification); brief != "" {
+		blocks = append(blocks, brief)
+	}
+	return strings.Join(blocks, "\n\n")
+}

--- a/internal/teammcp/memory_hints.go
+++ b/internal/teammcp/memory_hints.go
@@ -1,0 +1,159 @@
+package teammcp
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+func promotionHintsForNotes(entries []brokerMemoryNote) []string {
+	hints := make([]string, 0, 2)
+	for _, entry := range entries {
+		reason := durablePrivateMemoryReason(entry)
+		if reason == "" {
+			continue
+		}
+		title := strings.TrimSpace(entry.Title)
+		if title == "" {
+			title = strings.TrimSpace(entry.Key)
+		}
+		hints = append(hints, fmt.Sprintf("- %s (%s) looks like a durable %s. If the whole workspace should rely on it, run team_memory_promote key=%s.", title, entry.Key, reason, entry.Key))
+		if len(hints) >= 2 {
+			break
+		}
+	}
+	return hints
+}
+
+func durablePrivateMemoryReason(note brokerMemoryNote) string {
+	text := normalizeMemoryHintText(strings.Join([]string{note.Title, note.Content}, "\n"))
+	if text == "" {
+		return ""
+	}
+	switch {
+	case containsAnyPhrase(text, "playbook", "runbook", "checklist", "standard operating procedure", "sop"):
+		return "playbook"
+	case containsAnyPhrase(text, "approved", "final decision", "decided", "decision", "canonical", "source of truth", "locked in"):
+		return "decision"
+	case containsAnyPhrase(text, "preference", "prefers", "always use", "never use"):
+		return "preference"
+	case containsAnyPhrase(text, "handoff", "hand off", "handover", "owner", "deadline", "eta", "ship date", "due date", "next step"):
+		return "handoff"
+	default:
+		return ""
+	}
+}
+
+func sharedMemoryRoutingHints(mySlug string, hits []team.ScopedMemoryHit, office brokerOfficeMembersResponse) []string {
+	allowed := make(map[string]struct{}, len(office.Members))
+	for _, member := range office.Members {
+		slug := strings.TrimSpace(member.Slug)
+		if slug != "" {
+			allowed[slug] = struct{}{}
+		}
+	}
+	if len(allowed) == 0 {
+		return nil
+	}
+	candidates := map[string]struct{}{}
+	for _, hit := range hits {
+		if slug := strings.TrimSpace(hit.OwnerSlug); slug != "" {
+			if _, ok := allowed[slug]; ok && slug != mySlug {
+				candidates[slug] = struct{}{}
+			}
+		}
+		text := strings.TrimSpace(hit.Title + "\n" + hit.Snippet)
+		for _, slug := range extractKnownMentionSlugs(text, allowed) {
+			if slug != mySlug {
+				candidates[slug] = struct{}{}
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+	slugs := make([]string, 0, len(candidates))
+	for slug := range candidates {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	mentions := make([]string, 0, len(slugs))
+	for _, slug := range slugs {
+		mentions = append(mentions, "@"+slug)
+	}
+	return []string{
+		fmt.Sprintf("- Shared memory points to %s. If you need fresher working context, ask in the office instead of guessing; private notes stay private.", strings.Join(mentions, ", ")),
+	}
+}
+
+func extractKnownMentionSlugs(text string, allowed map[string]struct{}) []string {
+	text = strings.TrimSpace(text)
+	if text == "" || len(allowed) == 0 {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var out []string
+	runes := []rune(text)
+	for i := 0; i < len(runes); i++ {
+		if runes[i] != '@' {
+			continue
+		}
+		var b strings.Builder
+		for j := i + 1; j < len(runes); j++ {
+			r := runes[j]
+			if unicode.IsLetter(r) || unicode.IsNumber(r) || r == '-' || r == '_' {
+				b.WriteRune(unicode.ToLower(r))
+				continue
+			}
+			break
+		}
+		slug := strings.TrimSpace(b.String())
+		if slug == "" {
+			continue
+		}
+		if _, ok := allowed[slug]; !ok {
+			continue
+		}
+		if _, ok := seen[slug]; ok {
+			continue
+		}
+		seen[slug] = struct{}{}
+		out = append(out, slug)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeMemoryHintText(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	if value == "" {
+		return ""
+	}
+	var b strings.Builder
+	lastSpace := false
+	for _, r := range value {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			b.WriteRune(r)
+			lastSpace = false
+		default:
+			if !lastSpace {
+				b.WriteByte(' ')
+				lastSpace = true
+			}
+		}
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func containsAnyPhrase(text string, phrases ...string) bool {
+	for _, phrase := range phrases {
+		if strings.Contains(text, normalizeMemoryHintText(phrase)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -428,12 +428,12 @@ func Run(ctx context.Context) error {
 
 		mcp.AddTool(server, readOnlyTool(
 			"team_memory_query",
-			"Query your private notes and, when configured, shared organizational memory.",
+			"Query your private notes and, when configured, shared organizational memory. Results may suggest which teammate to ask for fresher working context.",
 		), handleTeamMemoryQuery)
 
 		mcp.AddTool(server, officeWriteTool(
 			"team_memory_write",
-			"Store a private note by default, or write directly to shared durable memory when the result is real.",
+			"Store a private note by default, or write directly to shared durable memory when the result is real. Durable private notes may be flagged as promotion candidates.",
 		), handleTeamMemoryWrite)
 
 		mcp.AddTool(server, officeWriteTool(
@@ -479,11 +479,11 @@ func Run(ctx context.Context) error {
 		), handleHumanInterview)
 		mcp.AddTool(server, readOnlyTool(
 			"team_memory_query",
-			"Query your private notes and, when configured, shared organizational memory.",
+			"Query your private notes and, when configured, shared organizational memory. Results may suggest which teammate to ask for fresher working context.",
 		), handleTeamMemoryQuery)
 		mcp.AddTool(server, officeWriteTool(
 			"team_memory_write",
-			"Store a private note by default, or write directly to shared durable memory when the result is real.",
+			"Store a private note by default, or write directly to shared durable memory when the result is real. Durable private notes may be flagged as promotion candidates.",
 		), handleTeamMemoryWrite)
 		mcp.AddTool(server, officeWriteTool(
 			"team_memory_promote",
@@ -586,12 +586,12 @@ func Run(ctx context.Context) error {
 
 	mcp.AddTool(server, readOnlyTool(
 		"team_memory_query",
-		"Query your private notes and, when configured, shared organizational memory.",
+		"Query your private notes and, when configured, shared organizational memory. Results may suggest which teammate to ask for fresher working context.",
 	), handleTeamMemoryQuery)
 
 	mcp.AddTool(server, officeWriteTool(
 		"team_memory_write",
-		"Store a private note by default, or write directly to shared durable memory when the result is real.",
+		"Store a private note by default, or write directly to shared durable memory when the result is real. Durable private notes may be flagged as promotion candidates.",
 	), handleTeamMemoryWrite)
 
 	mcp.AddTool(server, officeWriteTool(
@@ -1527,6 +1527,8 @@ func handleTeamMemoryQuery(ctx context.Context, _ *mcp.CallToolRequest, args Tea
 	}
 
 	lines := []string{}
+	privateEntries := []brokerMemoryNote{}
+	sharedHits := []team.ScopedMemoryHit{}
 	if scope == "auto" || scope == "private" {
 		values := url.Values{}
 		values.Set("namespace", privateMemoryNamespace(mySlug))
@@ -1536,6 +1538,7 @@ func handleTeamMemoryQuery(ctx context.Context, _ *mcp.CallToolRequest, args Tea
 		if err := brokerGetJSON(ctx, "/memory?"+values.Encode(), &result); err != nil {
 			return toolError(err), nil, nil
 		}
+		privateEntries = append(privateEntries, result.Entries...)
 		if len(result.Entries) > 0 {
 			lines = append(lines, "Private memory:")
 			for _, entry := range result.Entries {
@@ -1552,6 +1555,7 @@ func handleTeamMemoryQuery(ctx context.Context, _ *mcp.CallToolRequest, args Tea
 		if err != nil {
 			return toolError(err), nil, nil
 		}
+		sharedHits = append(sharedHits, hits...)
 		if len(hits) > 0 {
 			header := "Shared memory:"
 			if scope == "shared" {
@@ -1567,6 +1571,19 @@ func handleTeamMemoryQuery(ctx context.Context, _ *mcp.CallToolRequest, args Tea
 	}
 	if len(lines) == 0 {
 		lines = append(lines, "No memory hits.")
+	}
+	if hints := promotionHintsForNotes(privateEntries); len(hints) > 0 {
+		lines = append(lines, "", "Promotion hints:")
+		lines = append(lines, hints...)
+	}
+	if len(sharedHits) > 0 {
+		var office brokerOfficeMembersResponse
+		if err := brokerGetJSON(ctx, "/office-members", &office); err == nil {
+			if hints := sharedMemoryRoutingHints(mySlug, sharedHits, office); len(hints) > 0 {
+				lines = append(lines, "", "Routing hints:")
+				lines = append(lines, hints...)
+			}
+		}
 	}
 	return textResult(strings.Join(lines, "\n")), nil, nil
 }
@@ -1610,7 +1627,16 @@ func handleTeamMemoryWrite(ctx context.Context, _ *mcp.CallToolRequest, args Tea
 	}, nil); err != nil {
 		return toolError(err), nil, nil
 	}
-	return textResult(fmt.Sprintf("Saved private note %s.", key)), nil, nil
+	lines := []string{fmt.Sprintf("Saved private note %s.", key)}
+	if hints := promotionHintsForNotes([]brokerMemoryNote{{
+		Key:     key,
+		Title:   title,
+		Content: content,
+		Author:  mySlug,
+	}}); len(hints) > 0 {
+		lines = append(lines, hints...)
+	}
+	return textResult(strings.Join(lines, "\n")), nil, nil
 }
 
 func handleTeamMemoryPromote(ctx context.Context, _ *mcp.CallToolRequest, args TeamMemoryPromoteArgs) (*mcp.CallToolResult, any, error) {

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -164,6 +164,20 @@ type brokerTasksResponse struct {
 	Tasks []brokerTaskSummary `json:"tasks"`
 }
 
+type brokerMemoryResponse struct {
+	Namespace string             `json:"namespace,omitempty"`
+	Entries   []brokerMemoryNote `json:"entries,omitempty"`
+}
+
+type brokerMemoryNote struct {
+	Key       string `json:"key"`
+	Title     string `json:"title,omitempty"`
+	Content   string `json:"content"`
+	Author    string `json:"author,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
 type brokerTaskSummary struct {
 	ID               string   `json:"id"`
 	Channel          string   `json:"channel"`
@@ -354,10 +368,25 @@ type TeamPlanArgs struct {
 	MySlug string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
 }
 
+type TeamMemoryQueryArgs struct {
+	Query  string `json:"query" jsonschema:"What you want to look up in memory"`
+	Scope  string `json:"scope,omitempty" jsonschema:"One of: auto, private, shared. Defaults to auto."`
+	Limit  int    `json:"limit,omitempty" jsonschema:"Maximum hits to return per scope (default 5)"`
+	MySlug string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
+}
+
 type TeamMemoryWriteArgs struct {
-	Key    string `json:"key" jsonschema:"Key to store under your namespace"`
-	Value  string `json:"value" jsonschema:"Value to store"`
-	MySlug string `json:"my_slug,omitempty" jsonschema:"Your agent slug (used as namespace). Defaults to WUPHF_AGENT_SLUG."`
+	Key        string `json:"key,omitempty" jsonschema:"Optional stable key. Omit to auto-generate one from the title or content."`
+	Title      string `json:"title,omitempty" jsonschema:"Optional short title for the note"`
+	Content    string `json:"content" jsonschema:"Note content to store"`
+	Visibility string `json:"visibility,omitempty" jsonschema:"One of: private, shared. Defaults to private."`
+	MySlug     string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
+}
+
+type TeamMemoryPromoteArgs struct {
+	Key    string `json:"key" jsonschema:"Private note key to promote into shared durable memory"`
+	Title  string `json:"title,omitempty" jsonschema:"Optional override title for the promoted shared note"`
+	MySlug string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
 }
 
 type TeamTaskAckArgs struct {
@@ -398,6 +427,21 @@ func Run(ctx context.Context) error {
 		), handleHumanMessage)
 
 		mcp.AddTool(server, readOnlyTool(
+			"team_memory_query",
+			"Query your private notes and, when configured, shared organizational memory.",
+		), handleTeamMemoryQuery)
+
+		mcp.AddTool(server, officeWriteTool(
+			"team_memory_write",
+			"Store a private note by default, or write directly to shared durable memory when the result is real.",
+		), handleTeamMemoryWrite)
+
+		mcp.AddTool(server, officeWriteTool(
+			"team_memory_promote",
+			"Promote one of your private notes into shared durable memory after it becomes canonical.",
+		), handleTeamMemoryPromote)
+
+		mcp.AddTool(server, readOnlyTool(
 			"team_runtime_state",
 			"Return the canonical runtime snapshot for this direct session, including tasks, pending human requests, recovery summary, and runtime capabilities.",
 		), handleTeamRuntimeState)
@@ -433,6 +477,18 @@ func Run(ctx context.Context) error {
 			"human_interview",
 			"Ask the human a blocking decision question.",
 		), handleHumanInterview)
+		mcp.AddTool(server, readOnlyTool(
+			"team_memory_query",
+			"Query your private notes and, when configured, shared organizational memory.",
+		), handleTeamMemoryQuery)
+		mcp.AddTool(server, officeWriteTool(
+			"team_memory_write",
+			"Store a private note by default, or write directly to shared durable memory when the result is real.",
+		), handleTeamMemoryWrite)
+		mcp.AddTool(server, officeWriteTool(
+			"team_memory_promote",
+			"Promote one of your private notes into shared durable memory after it becomes canonical.",
+		), handleTeamMemoryPromote)
 		mcp.AddTool(server, officeWriteTool(
 			"team_skill_run",
 			"Invoke a named team skill. When the human's request matches an available skill, call this BEFORE replying — do not freelance. Bumps the skill's usage, logs a skill_invocation to the channel, and returns the skill's canonical step-by-step content for you to follow.",
@@ -527,6 +583,21 @@ func Run(ctx context.Context) error {
 		"team_plan",
 		"Create a batch of tasks in one shot with optional dependency ordering. Use this instead of multiple team_task calls when you know the full plan up front.",
 	), handleTeamPlan)
+
+	mcp.AddTool(server, readOnlyTool(
+		"team_memory_query",
+		"Query your private notes and, when configured, shared organizational memory.",
+	), handleTeamMemoryQuery)
+
+	mcp.AddTool(server, officeWriteTool(
+		"team_memory_write",
+		"Store a private note by default, or write directly to shared durable memory when the result is real.",
+	), handleTeamMemoryWrite)
+
+	mcp.AddTool(server, officeWriteTool(
+		"team_memory_promote",
+		"Promote one of your private notes into shared durable memory after it becomes canonical.",
+	), handleTeamMemoryPromote)
 
 	mcp.AddTool(server, readOnlyTool(
 		"team_requests",
@@ -1437,23 +1508,145 @@ func handleTeamPlan(ctx context.Context, _ *mcp.CallToolRequest, args TeamPlanAr
 	return textResult(fmt.Sprintf("Created %d tasks in #%s:\n%s", len(result.Tasks), channel, strings.Join(lines, "\n"))), nil, nil
 }
 
+func handleTeamMemoryQuery(ctx context.Context, _ *mcp.CallToolRequest, args TeamMemoryQueryArgs) (*mcp.CallToolResult, any, error) {
+	mySlug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	query := strings.TrimSpace(args.Query)
+	if query == "" {
+		return toolError(fmt.Errorf("query is required")), nil, nil
+	}
+	scope, err := normalizeMemoryScope(args.Scope)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	limit := args.Limit
+	if limit <= 0 {
+		limit = 5
+	}
+
+	lines := []string{}
+	if scope == "auto" || scope == "private" {
+		values := url.Values{}
+		values.Set("namespace", privateMemoryNamespace(mySlug))
+		values.Set("query", query)
+		values.Set("limit", fmt.Sprintf("%d", limit))
+		var result brokerMemoryResponse
+		if err := brokerGetJSON(ctx, "/memory?"+values.Encode(), &result); err != nil {
+			return toolError(err), nil, nil
+		}
+		if len(result.Entries) > 0 {
+			lines = append(lines, "Private memory:")
+			for _, entry := range result.Entries {
+				title := strings.TrimSpace(entry.Title)
+				if title == "" {
+					title = strings.TrimSpace(entry.Key)
+				}
+				lines = append(lines, fmt.Sprintf("- %s (%s): %s", title, entry.Key, truncate(strings.TrimSpace(strings.ReplaceAll(entry.Content, "\n", " ")), 220)))
+			}
+		}
+	}
+	if scope == "auto" || scope == "shared" {
+		hits, err := team.QuerySharedMemory(ctx, query, limit)
+		if err != nil {
+			return toolError(err), nil, nil
+		}
+		if len(hits) > 0 {
+			header := "Shared memory:"
+			if scope == "shared" {
+				header = fmt.Sprintf("Shared %s memory:", strings.ToUpper(hits[0].Backend[:1])+hits[0].Backend[1:])
+			}
+			lines = append(lines, header)
+			for _, hit := range hits {
+				lines = append(lines, fmt.Sprintf("- %s (%s): %s", hit.Title, hit.Identifier, truncate(strings.TrimSpace(hit.Snippet), 220)))
+			}
+		} else if scope == "shared" {
+			lines = append(lines, "Shared memory: no relevant hits.")
+		}
+	}
+	if len(lines) == 0 {
+		lines = append(lines, "No memory hits.")
+	}
+	return textResult(strings.Join(lines, "\n")), nil, nil
+}
+
 func handleTeamMemoryWrite(ctx context.Context, _ *mcp.CallToolRequest, args TeamMemoryWriteArgs) (*mcp.CallToolResult, any, error) {
 	mySlug, err := resolveSlug(args.MySlug)
 	if err != nil {
 		return toolError(err), nil, nil
 	}
-	key := strings.TrimSpace(args.Key)
-	if key == "" {
-		return toolError(fmt.Errorf("key is required")), nil, nil
+	visibility, err := normalizeMemoryVisibility(args.Visibility)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	content := strings.TrimSpace(args.Content)
+	if content == "" {
+		return toolError(fmt.Errorf("content is required")), nil, nil
+	}
+	key := derivedMemoryKey(args.Key, args.Title, content)
+	title := strings.TrimSpace(args.Title)
+	if visibility == "shared" {
+		identifier, err := team.WriteSharedMemory(ctx, team.SharedMemoryWrite{
+			Actor:   mySlug,
+			Key:     key,
+			Title:   title,
+			Content: content,
+		})
+		if err != nil {
+			return toolError(err), nil, nil
+		}
+		return textResult(fmt.Sprintf("Stored shared memory %s.", strings.TrimSpace(identifier))), nil, nil
 	}
 	if err := brokerPostJSON(ctx, "/memory", map[string]any{
-		"namespace": mySlug,
+		"namespace": privateMemoryNamespace(mySlug),
 		"key":       key,
-		"value":     args.Value,
+		"value": map[string]any{
+			"key":     key,
+			"title":   title,
+			"content": content,
+			"author":  mySlug,
+		},
 	}, nil); err != nil {
 		return toolError(err), nil, nil
 	}
-	return textResult(fmt.Sprintf("Saved %s/%s to shared memory.", mySlug, key)), nil, nil
+	return textResult(fmt.Sprintf("Saved private note %s.", key)), nil, nil
+}
+
+func handleTeamMemoryPromote(ctx context.Context, _ *mcp.CallToolRequest, args TeamMemoryPromoteArgs) (*mcp.CallToolResult, any, error) {
+	mySlug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	key := normalizeMemoryKey(args.Key)
+	if key == "" {
+		return toolError(fmt.Errorf("key is required")), nil, nil
+	}
+	values := url.Values{}
+	values.Set("namespace", privateMemoryNamespace(mySlug))
+	values.Set("key", key)
+	var result brokerMemoryResponse
+	if err := brokerGetJSON(ctx, "/memory?"+values.Encode(), &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	if len(result.Entries) == 0 {
+		return toolError(fmt.Errorf("private note %q not found", key)), nil, nil
+	}
+	entry := result.Entries[0]
+	title := strings.TrimSpace(args.Title)
+	if title == "" {
+		title = strings.TrimSpace(entry.Title)
+	}
+	identifier, err := team.WriteSharedMemory(ctx, team.SharedMemoryWrite{
+		Actor:   mySlug,
+		Key:     entry.Key,
+		Title:   title,
+		Content: strings.TrimSpace(entry.Content),
+	})
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	return textResult(fmt.Sprintf("Promoted private note %s into shared memory as %s.", entry.Key, strings.TrimSpace(identifier))), nil, nil
 }
 
 func handleTeamTaskAck(ctx context.Context, _ *mcp.CallToolRequest, args TeamTaskAckArgs) (*mcp.CallToolResult, any, error) {
@@ -2421,6 +2614,69 @@ func normalizePollScope(value string) (string, error) {
 	}
 }
 
+func normalizeMemoryScope(value string) (string, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", "auto":
+		return "auto", nil
+	case "private":
+		return "private", nil
+	case "shared":
+		return "shared", nil
+	default:
+		return "", fmt.Errorf("invalid scope %q", value)
+	}
+}
+
+func normalizeMemoryVisibility(value string) (string, error) {
+	switch strings.TrimSpace(strings.ToLower(value)) {
+	case "", "private":
+		return "private", nil
+	case "shared":
+		return "shared", nil
+	default:
+		return "", fmt.Errorf("invalid visibility %q", value)
+	}
+}
+
+func privateMemoryNamespace(slug string) string {
+	return "agent/" + strings.TrimSpace(slug)
+}
+
+func normalizeMemoryKey(key string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.TrimSpace(strings.ToLower(key)) {
+		switch {
+		case unicode.IsLetter(r) || unicode.IsNumber(r):
+			b.WriteRune(r)
+			lastDash = false
+		case r == '-' || r == '_' || unicode.IsSpace(r):
+			if b.Len() > 0 && !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func derivedMemoryKey(explicit string, title string, content string) string {
+	if key := normalizeMemoryKey(explicit); key != "" {
+		return key
+	}
+	if key := normalizeMemoryKey(title); key != "" {
+		return key + "-" + time.Now().UTC().Format("20060102-150405")
+	}
+	words := strings.Fields(content)
+	if len(words) > 6 {
+		words = words[:6]
+	}
+	if key := normalizeMemoryKey(strings.Join(words, " ")); key != "" {
+		return key + "-" + time.Now().UTC().Format("20060102-150405")
+	}
+	return "note-" + time.Now().UTC().Format("20060102-150405")
+}
+
 func applyAgentMessageScope(values url.Values, slug, scope string) {
 	slug = strings.TrimSpace(slug)
 	if slug == "" || slug == "ceo" || isOneOnOneMode() {
@@ -2711,4 +2967,14 @@ func toolError(err error) *mcp.CallToolResult {
 	res := textResult(err.Error())
 	res.IsError = true
 	return res
+}
+
+func truncate(text string, max int) string {
+	if max <= 0 || len(text) <= max {
+		return text
+	}
+	if max <= 1 {
+		return text[:max]
+	}
+	return text[:max-1] + "…"
 }

--- a/internal/teammcp/server_test.go
+++ b/internal/teammcp/server_test.go
@@ -300,6 +300,37 @@ func TestHandleTeamMemoryWriteAndQueryPrivate(t *testing.T) {
 	}
 }
 
+func TestHandleTeamMemoryWriteHintsPromotionForDurableNote(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	result, _, err := handleTeamMemoryWrite(context.Background(), nil, TeamMemoryWriteArgs{
+		Key:        "launch-brief",
+		Title:      "Launch brief",
+		Content:    "Approved final launch positioning for Customer Alpha. This is the canonical story for the rollout.",
+		Visibility: "private",
+		MySlug:     "pm",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamMemoryWrite: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "Saved private note launch-brief.") {
+		t.Fatalf("expected save confirmation, got %q", text)
+	}
+	if !strings.Contains(text, "team_memory_promote key=launch-brief") {
+		t.Fatalf("expected promotion hint, got %q", text)
+	}
+}
+
 func TestHandleTeamMemoryQueryAutoIncludesSharedNexMemory(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("WUPHF_MEMORY_BACKEND", "nex")
@@ -424,6 +455,57 @@ func TestHandleTeamMemoryPromoteWritesSharedNexMemory(t *testing.T) {
 	}
 	if !strings.Contains(postedBody, "Launch brief") || !strings.Contains(postedBody, "Approved final launch positioning") {
 		t.Fatalf("expected promoted content in Nex write, got %q", postedBody)
+	}
+}
+
+func TestHandleTeamMemoryQuerySharedSuggestsRoutingHint(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_MEMORY_BACKEND", "nex")
+	t.Setenv("WUPHF_API_KEY", "nex-test-key")
+	t.Setenv("WUPHF_NO_NEX", "")
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/developers/v1/context/ask":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"answer":"Author: @pm\nApproved final launch positioning for Customer Alpha."}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer apiServer.Close()
+	t.Setenv("WUPHF_DEV_URL", apiServer.URL)
+
+	binDir := t.TempDir()
+	nexMCP := filepath.Join(binDir, "nex-mcp")
+	if err := os.WriteFile(nexMCP, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake nex-mcp: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	result, _, err := handleTeamMemoryQuery(context.Background(), nil, TeamMemoryQueryArgs{
+		Query:  "launch positioning",
+		Scope:  "shared",
+		MySlug: "fe",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamMemoryQuery: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "Shared Nex memory:") {
+		t.Fatalf("expected shared-memory section, got %q", text)
+	}
+	if !strings.Contains(text, "Routing hints:") || !strings.Contains(text, "@pm") {
+		t.Fatalf("expected routing hint toward @pm, got %q", text)
 	}
 }
 

--- a/internal/teammcp/server_test.go
+++ b/internal/teammcp/server_test.go
@@ -6,6 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -258,6 +261,169 @@ func TestHandleHumanMessageUsesDirectSessionLabelInOneOnOneMode(t *testing.T) {
 	}
 	if strings.Contains(text.Text, "#general") {
 		t.Fatalf("did not expect office channel label in %q", text.Text)
+	}
+}
+
+func TestHandleTeamMemoryWriteAndQueryPrivate(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	if _, _, err := handleTeamMemoryWrite(context.Background(), nil, TeamMemoryWriteArgs{
+		Key:        "launch-brief",
+		Title:      "Launch brief",
+		Content:    "Customer Alpha needs the launch deck cut down to one page.",
+		Visibility: "private",
+		MySlug:     "pm",
+	}); err != nil {
+		t.Fatalf("handleTeamMemoryWrite: %v", err)
+	}
+
+	result, _, err := handleTeamMemoryQuery(context.Background(), nil, TeamMemoryQueryArgs{
+		Query:  "launch deck",
+		Scope:  "private",
+		MySlug: "pm",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamMemoryQuery: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "Private memory:") || !strings.Contains(text, "launch-brief") || !strings.Contains(text, "Launch brief") {
+		t.Fatalf("expected private memory hit, got %q", text)
+	}
+}
+
+func TestHandleTeamMemoryQueryAutoIncludesSharedNexMemory(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_MEMORY_BACKEND", "nex")
+	t.Setenv("WUPHF_API_KEY", "nex-test-key")
+	t.Setenv("WUPHF_NO_NEX", "")
+
+	var askedQuery string
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/developers/v1/context/ask":
+			askedQuery = r.URL.Path
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"answer":"Shared launch history from Nex."}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer apiServer.Close()
+	t.Setenv("WUPHF_DEV_URL", apiServer.URL)
+
+	binDir := t.TempDir()
+	nexMCP := filepath.Join(binDir, "nex-mcp")
+	if err := os.WriteFile(nexMCP, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake nex-mcp: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	if _, _, err := handleTeamMemoryWrite(context.Background(), nil, TeamMemoryWriteArgs{
+		Key:        "launch-brief",
+		Title:      "Launch brief",
+		Content:    "Private note for the PM.",
+		Visibility: "private",
+		MySlug:     "pm",
+	}); err != nil {
+		t.Fatalf("handleTeamMemoryWrite: %v", err)
+	}
+
+	result, _, err := handleTeamMemoryQuery(context.Background(), nil, TeamMemoryQueryArgs{
+		Query:  "launch",
+		Scope:  "auto",
+		MySlug: "pm",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamMemoryQuery: %v", err)
+	}
+	text := textFromResult(t, result)
+	if askedQuery == "" {
+		t.Fatal("expected shared Nex query to be called")
+	}
+	if !strings.Contains(text, "Private memory:") || !strings.Contains(text, "Shared memory:") || !strings.Contains(text, "Shared launch history from Nex.") {
+		t.Fatalf("expected both private and shared memory hits, got %q", text)
+	}
+}
+
+func TestHandleTeamMemoryPromoteWritesSharedNexMemory(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_MEMORY_BACKEND", "nex")
+	t.Setenv("WUPHF_API_KEY", "nex-test-key")
+	t.Setenv("WUPHF_NO_NEX", "")
+
+	var postedBody string
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/developers/v1/context/text":
+			body := new(bytes.Buffer)
+			_, _ = body.ReadFrom(r.Body)
+			postedBody = body.String()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer apiServer.Close()
+	t.Setenv("WUPHF_DEV_URL", apiServer.URL)
+
+	binDir := t.TempDir()
+	nexMCP := filepath.Join(binDir, "nex-mcp")
+	if err := os.WriteFile(nexMCP, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("create fake nex-mcp: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	t.Setenv("WUPHF_TEAM_BROKER_URL", "http://"+b.Addr())
+	t.Setenv("WUPHF_BROKER_TOKEN", b.Token())
+
+	if _, _, err := handleTeamMemoryWrite(context.Background(), nil, TeamMemoryWriteArgs{
+		Key:        "launch-brief",
+		Title:      "Launch brief",
+		Content:    "Approved final launch positioning for Customer Alpha.",
+		Visibility: "private",
+		MySlug:     "pm",
+	}); err != nil {
+		t.Fatalf("handleTeamMemoryWrite: %v", err)
+	}
+
+	result, _, err := handleTeamMemoryPromote(context.Background(), nil, TeamMemoryPromoteArgs{
+		Key:    "launch-brief",
+		MySlug: "pm",
+	})
+	if err != nil {
+		t.Fatalf("handleTeamMemoryPromote: %v", err)
+	}
+	text := textFromResult(t, result)
+	if !strings.Contains(text, "Promoted private note launch-brief") {
+		t.Fatalf("expected promote confirmation, got %q", text)
+	}
+	if !strings.Contains(postedBody, "Launch brief") || !strings.Contains(postedBody, "Approved final launch positioning") {
+		t.Fatalf("expected promoted content in Nex write, got %q", postedBody)
 	}
 }
 


### PR DESCRIPTION
## What changed

This PR adds backend-neutral scoped team memory to WUPHF.

- introduces `private` agent memory managed inside WUPHF
- keeps `shared` workspace memory on the selected external backend (`nex` or `gbrain`)
- routes agents through WUPHF-managed memory tools instead of exposing raw backend MCP tools directly
- injects scoped memory briefs into Claude and Codex turns
- adds `team_memory_write`, `team_memory_query`, and `team_memory_promote`
- documents the private/shared model in the README

## Why

We want agents to have their own retained working context without losing a single workspace-wide source of truth. The boundary should be consistent across both Nex and GBrain:

- each agent can keep private notes
- all agents can use shared workspace memory
- durable conclusions can be promoted from private to shared once they are real

## Impact

- private agent notes are isolated by `agent/<slug>` namespace
- shared memory continues to use the active backend
- agents no longer bypass scope rules by talking directly to raw backend MCP servers
- the same memory model now applies across Nex and GBrain

## Validation

- `go test ./...`
- real end-to-end `mcp-team` exercise with private write, private query, promotion to shared, shared query, and `scope=auto` retrieval
