### PR TITLE
feat(website): pixel office marketing site — wuphf.team

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: website/
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,244 @@
+# Design System — WUPHF Pixel Office Website
+
+## Product Context
+- **What this is:** The marketing/landing website for WUPHF — an open-source AI agent office tool where an AI team (CEO, PM, engineers, designer) works visibly in a shared office, claimable via one terminal command.
+- **Who it's for:** Developers and technical founders who want an AI team that works in the open rather than behind an API.
+- **Space/industry:** AI developer tools / agent frameworks. Peers: Paperclip, naive.ai, Claude Code, Codex CLI.
+- **Project type:** Isometric pixel-art marketing site. The website IS the product experience — not a description of it.
+
+---
+
+## Aesthetic Direction
+- **Direction:** Pixel-Retro / The Office (US TV show) workplace — isometric top-down 3D view
+- **Decoration level:** Expressive — 100% pixel art, no smooth vectors, no photos, no gradients
+- **Mood:** A dark office where something is always happening. AI agents and The Office cast sharing the floor. Dim fluorescent lights, golden WUPHF sign glowing on the back wall, everything quietly animated. You discover the product by exploring the environment, not by reading bullet points.
+- **EUREKA:** Every AI agent platform uses dark mode + gradient hero + "your AI team" headline. This site IS the office. The product concept and the website experience are unified. You don't read about WUPHF — you live in it for 30 seconds on the landing page.
+
+---
+
+## Color System
+**Approach:** Dark mode. Amber (#ECB22E) as primary accent — the WUPHF yellow from the existing app token `--yellow`. Works dramatically on dark backgrounds.
+
+| Token | Hex | Usage |
+|-------|-----|-------|
+| `--bg` | `#1A1610` | Page background (very dark warm brown) |
+| `--surface` | `#242018` | Cards, panels, nav |
+| `--surface-high` | `#2E2820` | Inputs, raised elements |
+| `--border` | `#3A3028` | Dividers, tile outlines, outlines |
+| `--text` | `#F0EBD8` | Primary text (warm off-white) |
+| `--text-muted` | `#8A7D6A` | Secondary text, labels |
+| `--yellow` | `#ECB22E` | WUPHF amber/gold — primary accent, sign, nav logo, CTAs |
+| `--yellow-dark` | `#C49020` | Button offset shadows, active borders |
+| `--yellow-glow` | `rgba(236,178,46,0.15)` | Subtle ambient glow behind the sign |
+| `--blue` | `#5A9AC8` | Secondary accent, links, engineer agent (brighter for dark bg) |
+| `--green` | `#5AAA7A` | CMO agent nameplate |
+
+**Scene-specific:**
+| Token | Hex | Usage |
+|-------|-----|-------|
+| `--carpet` | `#3A3228` | Office floor tile (primary) |
+| `--carpet-alt` | `#302A20` | Office floor tile (alternating) |
+| `--wall-scene` | `#201C14` | Back wall in isometric scene |
+| `--desk-top` | `#7A5A18` | Desk top face |
+| `--desk-dark` | `#5A3C08` | Desk front face |
+| `--desk-side` | `#3A2404` | Desk side face |
+| `--fluorescent` | `#FFFEF0` | Ceiling light elements + glow cone |
+
+**Anti-patterns:** No purple/violet accents. No gradient backgrounds. No light-mode version. No desaturated muted amber.
+
+---
+
+## Typography
+
+Three-font stack. Each has a distinct register and visual purpose. Do not substitute.
+
+| Role | Font | Usage |
+|------|------|-------|
+| **Display** | `Press Start 2P` | Nav logo, WUPHF sign, UI labels, buttons, section headers |
+| **Dialogue** | `VT323` | Character thought bubbles, papers on desks, in-world text |
+| **Functional** | `DM Mono` | Body copy, install commands, design system docs |
+
+**Loading:** Google Fonts CDN
+```html
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+```
+
+**Scale (Press Start 2P):**
+- Hero/Sign: 28–32px
+- Section heads: 14–16px
+- UI labels, nav, buttons: 8–11px
+- Tags, metadata: 6–7px
+
+**Scale (VT323):**
+- Thought bubbles: 20–28px (reads at high size, tight leading)
+- In-world paper text: 16–20px
+
+**Scale (DM Mono):**
+- Body: 14–16px, line-height 1.8–1.9
+- Code: 13px, monospace block with border
+
+**Font blacklist (never use for this project):** Inter, Roboto, Helvetica, system fonts for anything visible.
+
+---
+
+## Spacing
+- **Base unit:** 8px (one "half-pixel" in the isometric grid)
+- **Scale:** `2xs=2 xs=4 sm=8 md=16 lg=24 xl=32 2xl=48 3xl=64`
+- **Density:** Tight for the pixel scene (4–8px between elements), comfortable for design system docs (24–36px section margins)
+- **Rule:** Everything snaps to the pixel grid. No fractional px values in the isometric scene.
+
+---
+
+## Layout
+- **Approach:** Full-viewport isometric scene as hero. No scroll needed for the above-the-fold experience. Design system docs scroll below.
+- **Scene:** Canvas-rendered isometric office
+  - Grid: 9 cols × 6 rows of 60×30px diamond tiles
+  - Origin: OX=420, OY=100 (adjustable for viewport)
+  - Draw order: back-to-front (painter's algorithm)
+- **Nav:** Sticky, minimal, 10px padding. Surface background with yellow bottom border.
+- **Max content width:** 1000px (for design system docs section below scene)
+- **Mobile (< 768px):** 2D side-scrolling view of office hallway. Same pixel aesthetic, same colors. Characters walk left/right. No isometric perspective. WUPHF sign still prominent on wall.
+- **Border radius:** None. Zero. This is pixel art. Everything is sharp rectangles.
+
+---
+
+## Motion
+
+**Hard rule: `steps()` everywhere. No `cubic-bezier`, no `ease-in-out`. Smooth animation breaks the pixel art illusion.**
+
+| Type | Duration | Easing | Usage |
+|------|----------|--------|-------|
+| Character idle bob | 300ms/frame, 4-frame loop | `steps(1)` | All characters breathe/sway slightly |
+| Flash (clickable glow) | 800ms total | `steps(1)` | Binary on/off amber box-shadow pulse |
+| Thought bubble appear | 150ms | `steps(3)` | Scale 0→1 in 3 discrete steps. Pop, not slide. |
+| Drawer open | 100ms | `steps(2)` | Slide reveal in 2 frames |
+| Button :active | Instant | none | translate(5px, 5px) + shadow collapse. No CSS transition. |
+
+**CSS pattern for pixel animations:**
+```css
+animation: my-anim 800ms steps(1) infinite;
+```
+
+---
+
+## Isometric Scene Specification
+
+### Coordinate system
+```
+iso_screen_x = OX + (gx - gy) * TW / 2
+iso_screen_y = OY + (gx + gy) * TH / 2
+```
+Where `TW=60`, `TH=30`, `OX=420`, `OY=100`.
+
+### Back wall
+- Full-width dark panel `#201C14`, height = OY + 30px
+- 4 fluorescent fixtures: `#FFFEF0` with rgba glow cone below
+- WUPHF sign: `#0E0C08` panel, `#ECB22E` border + text, subtle `rgba(236,178,46,0.08)` inner glow, `ctx.shadowColor` amber glow on text
+
+### Floor tiles
+- 9×6 diamond grid. Alternating `#3A3228` / `#302A20`.
+- Tile outline: `#2A2418` at 0.5px.
+
+### Character positions
+| Character | Grid position | Notes |
+|-----------|---------------|-------|
+| Pam Beesly | (3.5, 0.5) | Reception, in front of WUPHF sign |
+| Michael Scott | (6.5, 1.5) | Wandering, background right |
+| Dwight Schrute | (1, 3) | At his desk, left side |
+| Jim Halpert | (3, 3) | At his desk, center — looks at viewer |
+| Kevin Malone | (5.5, 4) | Near snack jar, wide sprite |
+| Creed Bratton | (0.5, 5) | Far corner, doing something unexplained |
+| CEO Agent | (5.5, 2) | Amber nameplate (#ECB22E) |
+| Engineer Agent | (2.5, 4) | Blue nameplate (#5A9AC8) |
+| CMO Agent | (4.2, 3.2) | Green nameplate (#5AAA7A) |
+
+### Interactivity
+1. **Flashing drawer:** First desk item (reception desk, right side). Pulses amber. Carries "Click Me!" tooltip above it (amber background, dark text). On click: reveals `"One command. One office. ./wuphf"` in an amber-bordered panel.
+2. **All clickable items:** Stepped amber `box-shadow` pulse. No smooth glow.
+3. **Character click:** Shows thought bubble with character quote. VT323 font. Amber border. 5s auto-dismiss. Click character again to dismiss.
+4. **Hidden messaging:** Multiple clickable items throughout the scene, each revealing product copy in the environment.
+
+### Hidden messaging map
+| Location | Click to reveal |
+|----------|----------------|
+| Reception drawer (first, flashes) | `"One command. One office. ./wuphf"` |
+| Paper on Pam's desk | `"CEO, PM, engineers — all visible, all working."` |
+| Conference room whiteboard | Architecture diagram — agent routing + broker |
+| Agent monitor screen | `"Open source. MIT license. go build -o wuphf"` |
+| Plant by window | `"Unlike Ryan Howard's WUPHF, this one works."` |
+| Break room fridge | Full install command |
+| Stapler in jello (Dwight area) | Easter egg — Dwight rage quit message |
+| Dundie on shelf | `"Best AI Office, 2025. (Self-awarded.)"` |
+| Kevin's snack jar label | `"No tokens wasted on pleasantries."` |
+
+### Character thought bubbles (click to trigger)
+| Character | Quote |
+|-----------|-------|
+| Pam Beesly | "WUPHF!" |
+| Michael Scott | "I'm not superstitious, but I am a little stitious." |
+| Dwight Schrute | "Bears. Beets. Battlestar Galactica." |
+| Jim Halpert | "How the turntables..." |
+| Kevin Malone | "... (stares at snacks)" |
+| Creed Bratton | "Nobody steals from Creed Bratton and gets away with it. The website is fine." |
+| CEO Agent | "Routing task to engineering team. ETA: 3 minutes." |
+| Engineer Agent | "Implementing feature... 47% complete." |
+| CMO Agent | "Drafting launch post. You will not believe this lede." |
+
+---
+
+## Component Specs
+
+### Pixel Button (primary CTA)
+```css
+font-family: 'Press Start 2P'; font-size: 9px;
+background: #ECB22E; color: #1A1610;
+border: none; padding: 14px 24px;
+box-shadow: 5px 5px 0 #C49020;
+/* NO transition */
+```
+`:active` → `transform: translate(5px, 5px); box-shadow: none;`
+
+### Thought Bubble
+```css
+background: #242018; border: 3px solid #ECB22E;
+font-family: 'VT323'; font-size: 20–28px;
+color: #F0EBD8;
+box-shadow: 4px 4px 0 #C49020;
+/* steps(3) appear animation */
+```
+- Speaker name: `Press Start 2P`, 6px, `#ECB22E`
+- Triangle tail: `border-top-color: #ECB22E`
+
+### Nav
+```css
+background: #242018;
+border-bottom: 3px solid #C49020;
+```
+- Logo: `Press Start 2P`, 11px, `#ECB22E`
+- Links: `Press Start 2P`, 7px, `#8A7D6A` → `#ECB22E` on hover
+
+---
+
+## Anti-Patterns (do not use)
+- Smooth CSS transitions or ease-in-out animations in the pixel scene
+- `border-radius` on any element inside or matching the pixel scene
+- Any light-mode color values
+- Purple, violet, or blue as the primary accent
+- Gradient backgrounds or gradient buttons
+- Photo backgrounds or non-pixel-art imagery
+- Inter, Roboto, or system fonts for visible text
+- Traditional hero copy with a CTA above the fold
+
+---
+
+## Decisions Log
+
+| Date | Decision | Rationale |
+|------|----------|-----------|
+| 2026-04-15 | Dark mode instead of beige/light | Amber (#ECB22E) pops on dark. On beige it washes out. Dark also fits "AI agents working late" narrative and differentiates from every SaaS site using white + blue. |
+| 2026-04-15 | WUPHF Yellow (#ECB22E) as primary accent | Picked up from existing app `--yellow` token. Consistent with product branding. |
+| 2026-04-15 | Press Start 2P + VT323 + DM Mono | Three-font system: pixel UI, in-world dialogue, functional prose. Each has a distinct register. |
+| 2026-04-15 | Zero hero copy in first viewport | All messaging is environmental. The product concept (visible AI team) IS the website experience. |
+| 2026-04-15 | steps() animations only — hard rule | Smooth CSS transitions break the pixel art illusion. 16-bit game feel requires discrete frames. |
+| 2026-04-15 | Isometric 3D view as hero layout | Isometric is unmistakable and distinctive. No other AI tool website does this. The product IS an office, so the website IS an office. |
+| 2026-04-15 | The Office cast + WUPHF agents on same floor | Office cast provides instant recognition and humor. AI agents demonstrate the product inline. The joke writes itself — they coexist. |

--- a/website/CNAME
+++ b/website/CNAME
@@ -1,0 +1,1 @@
+wuphf.team

--- a/website/index.html
+++ b/website/index.html
@@ -32,10 +32,6 @@
   <div class="scene-wrap" id="sceneWrap">
     <canvas id="officeCanvas"></canvas>
   </div>
-  <div class="hint-bar">
-    <span class="hint-arrow">↑</span> click characters for quotes &nbsp;·&nbsp;
-    click the flashing drawer &nbsp;·&nbsp; explore to find hidden messaging
-  </div>
 
   <!-- INSTALL SECTION -->
   <section class="install-section">

--- a/website/index.html
+++ b/website/index.html
@@ -1,73 +1,2168 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>WUPHF — Your AI team, visible and working.</title>
-  <meta name="description" content="One command. One shared office. CEO, PM, engineers, designer — all visible, arguing, claiming tasks, and shipping work.">
-  <!-- Open Graph -->
-  <meta property="og:title" content="WUPHF">
-  <meta property="og:description" content="A terminal office where your AI team works in the open.">
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary_large_image">
-  <!-- Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>WUPHF by Nex.ai</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323:wght@400&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --bg: #1A1610;
+    --bg2: #201C14;
+    --bg3: #2A2418;
+    --yellow: #ECB22E;
+    --yellow-dark: #C49020;
+    --yellow-dim: rgba(236,178,46,0.12);
+    --text: #F0E6CC;
+    --text-dim: #A89870;
+    --font-display: 'Press Start 2P', monospace;
+    --font-vt: 'VT323', monospace;
+    --font-mono: 'DM Mono', monospace;
+  }
+
+  html { scroll-behavior: smooth; }
+
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-mono);
+    line-height: 1.6;
+    min-height: 100vh;
+    overflow-x: hidden;
+  }
+
+  /* ── NAV ─────────────────────────────────────────────── */
+  nav {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+    height: 44px;
+    background: var(--bg);
+    border-bottom: 2px solid var(--yellow);
+    display: flex; align-items: center;
+    padding: 0 24px;
+    gap: 24px;
+  }
+  .nav-logo {
+    font-family: var(--font-display);
+    font-size: 11px;
+    color: var(--yellow);
+    letter-spacing: 0.05em;
+    text-decoration: none;
+  }
+  .nav-by {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    color: var(--text-dim);
+    letter-spacing: 0.04em;
+    font-weight: 400;
+  }
+  .nav-links { display: flex; gap: 4px; margin-left: auto; }
+  .nav-links a {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-dim);
+    text-decoration: none;
+    letter-spacing: 0.04em;
+    display: flex; align-items: center;
+    min-height: 44px; padding: 0 12px;
+  }
+  .nav-links a:hover { color: var(--yellow); }
+  .nav-social {
+    display: flex; align-items: center; gap: 4px;
+  }
+  .nav-social-link {
+    display: flex; align-items: center; gap: 5px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-dim);
+    text-decoration: none;
+    letter-spacing: 0.04em;
+    transition: color 0.15s;
+    min-height: 44px; padding: 0 10px;
+  }
+  .nav-social-link:hover { color: var(--yellow); }
+  .nav-social-link svg { flex-shrink: 0; }
+  .nav-star-count { font-size: 10px; }
+  .nav-badge {
+    font-family: var(--font-display);
+    font-size: 8px;
+    color: var(--bg);
+    background: var(--yellow);
+    padding: 0 12px;
+    min-height: 44px;
+    border: none;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  /* ── HERO ─────────────────────────────────────────── */
+  .hero {
+    padding-top: 44px;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .hero::before {
+    content: '';
+    position: absolute; inset: 0;
+    background:
+      radial-gradient(ellipse 700px 400px at 50% 48%, rgba(236,178,46,0.07) 0%, transparent 70%),
+      repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 3px,
+        rgba(0,0,0,0.09) 3px,
+        rgba(0,0,0,0.09) 4px
+      );
+    pointer-events: none; z-index: 1;
+  }
+
+  .hero-inner {
+    position: relative; z-index: 2;
+    display: flex; flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding: 0 24px;
+    max-width: 900px;
+    width: 100%;
+  }
+
+  .hero-sprites {
+    display: flex; gap: 32px; margin-bottom: 48px;
+    align-items: flex-end;
+    height: 80px;
+  }
+
+  .sprite {
+    display: flex; flex-direction: column; align-items: center; gap: 4px;
+    animation: sprite-bob 0.5s steps(1, end) infinite;
+  }
+  .sprite:nth-child(2) { animation-delay: 0.125s; }
+  .sprite:nth-child(3) { animation-delay: 0.25s; }
+
+  @keyframes sprite-bob {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-4px); }
+  }
+
+  .sprite-name {
+    font-family: var(--font-vt);
+    font-size: 14px;
+    color: var(--text-dim);
+    letter-spacing: 0.04em;
+  }
+
+  .label-tag {
+    font-family: var(--font-display);
+    font-size: 6px;
+    color: var(--bg);
+    background: var(--yellow);
+    padding: 3px 6px;
+  }
+
+  .hero-eyebrow {
+    font-family: var(--font-display);
+    font-size: 9px;
+    color: var(--yellow);
+    letter-spacing: 0.12em;
+    margin-bottom: 24px;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .blink {
+    width: 8px; height: 12px;
+    background: var(--yellow);
+    display: inline-block;
+    animation: blink-cursor 1s steps(1, end) infinite;
+  }
+  @keyframes blink-cursor {
+    0%, 50% { opacity: 1; }
+    51%, 100% { opacity: 0; }
+  }
+
+  .hero-title {
+    font-family: var(--font-display);
+    font-size: clamp(40px, 8vw, 72px);
+    color: var(--yellow);
+    line-height: 1.1;
+    letter-spacing: 0.04em;
+    margin-bottom: 16px;
+    text-shadow: 6px 6px 0 var(--yellow-dark);
+  }
+  .hero-by {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: clamp(11px, 1.4vw, 14px);
+    letter-spacing: 0.08em;
+    font-weight: 400;
+    text-shadow: none;
+    margin-top: 8px;
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .hero-by:hover { color: var(--text); }
+  .hero-nex-logo {
+    height: 16px;
+    width: auto;
+    color: var(--text-dim);
+    vertical-align: middle;
+  }
+
+  .hero-tagline {
+    font-family: var(--font-mono);
+    font-size: clamp(16px, 2.2vw, 20px);
+    color: var(--text);
+    line-height: 1.7;
+    max-width: 600px;
+    margin-bottom: 40px;
+  }
+
+  .hero-tagline em {
+    font-style: normal;
+    color: var(--yellow);
+    font-weight: 500;
+  }
+
+  .install-wrap {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    margin-bottom: 40px;
+    width: 100%;
+    max-width: 520px;
+  }
+
+  .install-block {
+    width: 100%;
+    background: var(--bg3);
+    border: 2px solid var(--yellow);
+    box-shadow: 4px 4px 0 var(--yellow-dark);
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 20px;
+    cursor: pointer;
+  }
+  .install-block:hover { background: var(--bg2); }
+
+  .install-prompt {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    color: var(--yellow);
+    flex-shrink: 0;
+  }
+  .install-cmd {
+    font-family: var(--font-mono);
+    font-size: 15px;
+    color: var(--text);
+    flex: 1;
+    text-align: left;
+  }
+  .install-copy {
+    font-family: var(--font-display);
+    font-size: 8px;
+    color: var(--text-dim);
+    flex-shrink: 0;
+    letter-spacing: 0.08em;
+  }
+  .install-copy.copied { color: var(--yellow); }
+
+  .install-note {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-dim);
+  }
+
+  .hero-ctas {
+    display: flex; gap: 16px; align-items: center; flex-wrap: wrap; justify-content: center;
+  }
+
+  .btn-primary {
+    font-family: var(--font-display);
+    font-size: 10px;
+    color: var(--bg);
+    display: inline-flex !important;
+    align-items: center;
+    gap: 8px;
+    background: var(--yellow);
+    border: none;
+    padding: 14px 24px;
+    cursor: pointer;
+    box-shadow: 4px 4px 0 var(--yellow-dark);
+    text-decoration: none;
+    display: inline-block;
+    letter-spacing: 0.06em;
+  }
+  .btn-primary:hover { transform: translate(-1px, -1px); box-shadow: 5px 5px 0 var(--yellow-dark); }
+  .btn-primary:active { transform: translate(2px, 2px); box-shadow: 2px 2px 0 var(--yellow-dark); }
+
+  .btn-ghost {
+    font-family: var(--font-display);
+    font-size: 10px;
+    color: var(--yellow);
+    background: transparent;
+    border: 2px solid var(--yellow);
+    padding: 12px 22px;
+    cursor: pointer;
+    box-shadow: 3px 3px 0 var(--yellow-dark);
+    text-decoration: none;
+    display: inline-block;
+    letter-spacing: 0.06em;
+  }
+  .btn-ghost:hover { background: var(--yellow-dim); }
+
+  .scroll-hint {
+    position: absolute; bottom: 24px; left: 50%; transform: translateX(-50%);
+    z-index: 2;
+    display: flex; flex-direction: column; align-items: center; gap: 8px;
+  }
+  .scroll-arrow {
+    width: 12px; height: 12px;
+    border-right: 3px solid var(--yellow);
+    border-bottom: 3px solid var(--yellow);
+    transform: rotate(45deg);
+    animation: arrow-bounce 0.8s steps(1, end) infinite;
+  }
+  .scroll-arrow:nth-child(2) { animation-delay: 0.2s; margin-top: -8px; opacity: 0.5; }
+  @keyframes arrow-bounce {
+    0%, 50% { opacity: 1; }
+    51%, 100% { opacity: 0.2; }
+  }
+
+  /* ── AMBIENT STRIP ────────────────────────────────── */
+  .ambient-strip {
+    background: var(--yellow);
+    padding: 12px 0;
+    overflow: hidden;
+    white-space: nowrap;
+    border-top: 2px solid var(--yellow-dark);
+    border-bottom: 2px solid var(--yellow-dark);
+  }
+  .ambient-scroll {
+    display: inline-flex; gap: 64px;
+    animation: marquee 120s linear infinite;
+  }
+  @keyframes marquee {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+  }
+  .ambient-item {
+    font-family: var(--font-vt);
+    font-size: 22px;
+    color: var(--bg);
+    letter-spacing: 0.06em;
+    flex-shrink: 0;
+  }
+
+  /* ── VIDEO SECTION ───────────────────────────────── */
+  .video-section {
+    padding: 72px 24px 40px;
+    max-width: 800px;
+    margin: 0 auto;
+    text-align: center;
+  }
+  .video-prompt {
+    font-family: var(--font-vt);
+    font-size: 32px;
+    color: var(--text);
+    letter-spacing: 0.06em;
+    margin: 0 0 28px;
+  }
+  .video-wrap {
+    position: relative;
+    border: 2px solid var(--yellow-dark);
+    line-height: 0;
+    margin: 24px auto 0;
+    max-width: 720px;
+  }
+  .video-wrap video {
+    width: 100%;
+    height: auto;
+    display: block;
+    background: #000;
+  }
+  .video-wrap::before {
+    content: '';
+    position: absolute;
+    inset: -2px;
+    box-shadow: inset 0 0 0 2px var(--yellow-dark);
+    pointer-events: none;
+  }
+
+  /* ── SECTIONS ─────────────────────────────────────── */
+  section { padding: 80px 24px; max-width: 1000px; margin: 0 auto; }
+
+  .section-eyebrow {
+    font-family: var(--font-display);
+    font-size: 8px;
+    color: var(--yellow);
+    letter-spacing: 0.14em;
+    margin-bottom: 16px;
+    display: flex; align-items: center; gap: 12px;
+  }
+  .section-eyebrow::after {
+    content: '';
+    flex: 1;
+    height: 2px;
+    background: var(--yellow-dark);
+  }
+
+  .section-title {
+    font-family: var(--font-display);
+    font-size: clamp(18px, 3vw, 28px);
+    color: var(--text);
+    line-height: 1.4;
+    margin-bottom: 20px;
+  }
+
+  .section-body {
+    font-family: var(--font-mono);
+    font-size: 16px;
+    color: var(--text);
+    line-height: 1.8;
+    max-width: 640px;
+    margin-bottom: 48px;
+  }
+
+  /* ── HOW IT WORKS ─────────────────────────────────── */
+  .steps-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 2px;
+    background: var(--yellow-dark);
+    border: 2px solid var(--yellow-dark);
+  }
+
+  .step-card {
+    background: var(--bg2);
+    padding: 28px 24px;
+  }
+
+  .step-num {
+    font-family: var(--font-display);
+    font-size: 9px;
+    color: var(--yellow);
+    margin-bottom: 16px;
+    letter-spacing: 0.1em;
+  }
+
+  .step-icon {
+    font-size: 32px;
+    margin-bottom: 12px;
+    display: block;
+  }
+
+  .step-title {
+    font-family: var(--font-display);
+    font-size: 12px;
+    color: var(--text);
+    line-height: 1.6;
+    margin-bottom: 8px;
+    letter-spacing: 0.04em;
+  }
+
+  .step-body {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    color: var(--text-dim);
+    line-height: 1.7;
+  }
+
+  /* ── AGENT CARDS ──────────────────────────────────── */
+  .agents-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+  }
+
+  .agent-card {
+    background: var(--bg2);
+    border: 2px solid var(--yellow-dark);
+    padding: 24px;
+  }
+  .agent-card:hover {
+    border-color: var(--yellow);
+    box-shadow: 4px 4px 0 var(--yellow-dark);
+    transform: translate(-2px, -2px);
+  }
+
+  .agent-badge {
+    font-family: var(--font-display);
+    font-size: 8px;
+    color: var(--bg);
+    background: var(--yellow);
+    padding: 4px 10px;
+    display: inline-block;
+    margin-bottom: 16px;
+    letter-spacing: 0.08em;
+  }
+
+  .agent-title {
+    font-family: var(--font-display);
+    font-size: 14px;
+    color: var(--text);
+    line-height: 1.5;
+    margin-bottom: 12px;
+    letter-spacing: 0.04em;
+  }
+
+  .agent-desc {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    color: var(--text-dim);
+    line-height: 1.7;
+    margin-bottom: 16px;
+  }
+
+  .agent-quote {
+    font-family: var(--font-vt);
+    font-size: 22px;
+    color: var(--yellow);
+    line-height: 1.4;
+    opacity: 0.85;
+  }
+  .agent-quote::before {
+    content: '▸ ';
+    font-size: 14px;
+  }
+
+  /* ── CODE DEMO ────────────────────────────────────── */
+  .code-demo {
+    background: var(--bg3);
+    border: 2px solid var(--yellow);
+    box-shadow: 6px 6px 0 var(--yellow-dark);
+    overflow: hidden;
+    max-width: 700px;
+  }
+
+  .code-titlebar {
+    background: var(--yellow);
+    padding: 8px 16px;
+    display: flex; align-items: center; gap: 8px;
+  }
+
+  .code-dot {
+    width: 8px; height: 8px;
+    background: var(--bg);
+    display: inline-block;
+  }
+
+  .code-label {
+    font-family: var(--font-display);
+    font-size: 8px;
+    color: var(--bg);
+    margin-left: 8px;
+    letter-spacing: 0.06em;
+  }
+
+  pre {
+    padding: 20px 24px;
+    font-family: var(--font-mono);
+    font-size: 15px;
+    color: var(--text);
+    line-height: 1.8;
+    overflow-x: auto;
+  }
+
+  .tok-kw { color: var(--yellow); }
+  .tok-str { color: #98C379; }
+  .tok-cmt { color: var(--text-dim); font-style: italic; }
+  .tok-fn { color: #61AFEF; }
+
+  /* ── CHAT DEMO ────────────────────────────────────── */
+  .chat-demo {
+    display: flex; flex-direction: column; gap: 12px;
+    max-width: 560px;
+  }
+
+  .chat-msg {
+    display: flex; gap: 12px; align-items: flex-start;
+  }
+  .chat-msg.right { flex-direction: row-reverse; }
+
+  .chat-avatar {
+    width: 32px; height: 32px;
+    background: var(--bg3);
+    border: 2px solid var(--yellow);
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+    font-family: var(--font-display);
+    font-size: 8px;
+    color: var(--yellow);
+  }
+
+  .chat-bubble {
+    background: var(--bg3);
+    border: 2px solid var(--yellow-dark);
+    padding: 12px 16px;
+    font-family: var(--font-vt);
+    font-size: 22px;
+    color: var(--text);
+    line-height: 1.4;
+    max-width: 380px;
+  }
+  .chat-msg.right .chat-bubble {
+    background: var(--yellow-dim);
+    border-color: var(--yellow);
+    color: var(--yellow);
+  }
+
+  /* ── ISOMETRIC OFFICE SECTION ─────────────────────── */
+  .office-section {
+    background: var(--bg2);
+    border-top: 3px solid var(--yellow-dark);
+    border-bottom: 3px solid var(--yellow-dark);
+    padding: 32px 0 0;
+    overflow: hidden;
+  }
+
+  .office-section-header {
+    text-align: center;
+    padding: 0 24px 16px;
+  }
+
+  .office-section-eyebrow {
+    font-family: var(--font-display);
+    font-size: 8px;
+    color: var(--yellow);
+    letter-spacing: 0.14em;
+    margin-bottom: 12px;
+  }
+
+  .office-section-title {
+    font-family: var(--font-display);
+    font-size: clamp(14px, 2.5vw, 22px);
+    color: var(--text);
+    line-height: 1.5;
+    margin-bottom: 8px;
+  }
+
+  .office-section-sub {
+    font-family: var(--font-vt);
+    font-size: 22px;
+    color: var(--text-dim);
+    letter-spacing: 0.04em;
+  }
+
+  #officeCanvas {
+    display: block;
+    image-rendering: pixelated;
+    width: 100%;
+  }
+
+  /* ── MIT SECTION ─────────────────────────────────── */
+  .mit-block {
+    background: var(--bg3);
+    border: 2px solid var(--yellow-dark);
+    padding: 40px;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 40px;
+  }
+  @media (max-width: 768px) {
+    .mit-block { grid-template-columns: 1fr; }
+  }
+
+  .mit-badge {
+    font-family: var(--font-display);
+    font-size: 11px;
+    color: var(--yellow);
+    background: var(--bg);
+    border: 3px solid var(--yellow);
+    padding: 16px 24px;
+    box-shadow: 4px 4px 0 var(--yellow-dark);
+    flex-shrink: 0;
+    text-align: center;
+    line-height: 2;
+  }
+
+  .mit-text {
+    font-family: var(--font-mono);
+    font-size: 15px;
+    color: var(--text);
+    line-height: 1.8;
+  }
+  .mit-text a { color: var(--yellow); text-decoration: none; }
+  .mit-cta {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    align-items: flex-end;
+    flex-shrink: 0;
+  }
+  .mit-cta-btn {
+    font-family: var(--font-display);
+    font-size: 10px;
+    color: var(--bg);
+    background: var(--yellow);
+    border: none;
+    padding: 14px 24px;
+    cursor: pointer;
+    letter-spacing: 0.06em;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    white-space: nowrap;
+  }
+  .mit-cta-btn:hover { background: var(--text); }
+  .mit-cta-sub {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-dim);
+    text-align: right;
+  }
+
+  /* ── FOOTER ───────────────────────────────────────── */
+  footer {
+    padding: 40px 24px 32px;
+    max-width: 1000px;
+    margin: 0 auto;
+    border-top: 2px solid var(--yellow-dark);
+    display: flex;
+    align-items: center;
+    gap: 24px;
+    flex-wrap: wrap;
+  }
+
+  .footer-logo {
+    font-family: var(--font-display);
+    font-size: 9px;
+    color: var(--yellow);
+    letter-spacing: 0.05em;
+  }
+
+  .footer-sub {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-dim);
+  }
+
+  .footer-links {
+    margin-left: auto;
+    display: flex; gap: 20px;
+  }
+  .footer-links a {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-dim);
+    text-decoration: none;
+  }
+  .footer-links a:hover { color: var(--yellow); }
+
+  /* ── CONVERSATIONS ────────────────────────────────── */
+  .conversations-layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 48px;
+    align-items: start;
+  }
+  .conversations-terminal {
+    min-width: 0;
+  }
+
+  /* ── PRETEXT-MANAGED ──────────────────────────────── */
+  [data-pretext] {
+    /* Heights set by Pretext at runtime — DO NOT set height in CSS */
+    overflow: visible;
+  }
+
+  /* ── RESPONSIVE ──────────────────────────────────── */
+  @media (max-width: 640px) {
+    .nav-links { display: none; }
+    .nav-star-count { display: none; }
+    .nav-social-link { padding: 0 8px; }
+    .nav-badge { padding: 0 10px; }
+
+    .video-section { padding: 40px 16px 24px; }
+    .how-grid, .agents-grid { grid-template-columns: 1fr; }
+
+    .conversations-layout { grid-template-columns: 1fr; }
+    .conversations-terminal { display: none; }
+
+    .section-inner { padding: 48px 20px; }
+  }
+</style>
 </head>
 <body>
 
-  <!-- NAV -->
-  <nav class="site-nav">
-    <span class="nav-logo">WUPHF</span>
-    <div class="nav-links">
-      <a href="https://github.com/nex-crm/wuphf" target="_blank" rel="noopener">GitHub</a>
-      <a href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener">Discord</a>
-      <a href="https://github.com/nex-crm/wuphf#get-started" target="_blank" rel="noopener">Docs</a>
-    </div>
-  </nav>
+<!-- NAV -->
+<nav>
+  <span class="nav-logo">WUPHF <span class="nav-by">by Nex.ai</span></span>
+  <div class="nav-links">
+    <a href="#how">How it works</a>
+    <a href="#agents">Agents</a>
+  </div>
+  <div class="nav-social">
+    <a class="nav-social-link" href="https://github.com/nex-crm/wuphf" target="_blank" rel="noopener" aria-label="GitHub">
+      <svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+      <span class="nav-star-count" id="navStars">21 ★</span>
+    </a>
+    <a class="nav-social-link" href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener" aria-label="Discord">
+      <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.101 18.079.111 18.1.127 18.116a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+    </a>
+    <button class="nav-badge" onclick="copyInstall()">INSTALL</button>
+  </div>
+</nav>
 
-  <!-- OFFICE SCENE -->
-  <div class="scene-wrap" id="sceneWrap">
-    <canvas id="officeCanvas"></canvas>
+<!-- HERO -->
+<section class="hero" id="top">
+  <div class="hero-inner">
+
+    <div class="hero-sprites">
+      <div class="sprite" title="CEO Agent">
+        <canvas id="s0" width="24" height="36"></canvas>
+        <span class="label-tag">CEO</span>
+        <span class="sprite-name">Strategy</span>
+      </div>
+      <div class="sprite" title="Eng Agent">
+        <canvas id="s1" width="24" height="36"></canvas>
+        <span class="label-tag">ENG</span>
+        <span class="sprite-name">Code</span>
+      </div>
+      <div class="sprite" title="CMO Agent">
+        <canvas id="s2" width="24" height="36"></canvas>
+        <span class="label-tag">CMO</span>
+        <span class="sprite-name">Growth</span>
+      </div>
+    </div>
+
+    <div class="hero-eyebrow">
+      <span class="blink"></span>
+      OPEN SOURCE &middot; AI AGENT OFFICE
+    </div>
+
+    <h1 class="hero-title">WUPHF</h1>
+    <a class="hero-by" href="https://nex.ai" target="_blank" rel="noopener" aria-label="Nex.ai">by <svg class="hero-nex-logo" width="95" height="22" viewBox="0 0 95 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11.4968 9.1124C10.2339 7.84948 9.98851 5.898 9.48601 4.18411C9.26753 3.43896 8.86469 2.73685 8.27738 2.14953C6.40286 0.275011 3.35898 0.279701 1.47868 2.16C-0.401626 4.0403 -0.406316 7.08419 1.4682 8.9587C2.05551 9.54601 2.75761 9.94885 3.50275 10.1673C5.21664 10.6698 7.16813 10.9152 8.43106 12.1782C9.69399 13.4411 9.93939 15.3926 10.4419 17.1065C10.6604 17.8516 11.0632 18.5537 11.6505 19.141C13.525 21.0155 16.5689 21.0109 18.4492 19.1306C20.3295 17.2503 20.3342 14.2064 18.4597 12.3319C17.8724 11.7445 17.1703 11.3417 16.4251 11.1232C14.7112 10.6207 12.7597 10.3753 11.4968 9.1124Z" fill="currentColor"/><path d="M7.25926 17.0471C7.25926 19.0517 5.63422 20.6768 3.62963 20.6768C1.62504 20.6768 0 19.0517 0 17.0471C0 15.0425 1.62504 13.4175 3.62963 13.4175C5.63422 13.4175 7.25926 15.0425 7.25926 17.0471Z" fill="currentColor"/><path d="M20 4.30639C20 6.31098 18.375 7.93602 16.3704 7.93602C14.3658 7.93602 12.7407 6.31098 12.7407 4.30639C12.7407 2.3018 14.3658 0.676758 16.3704 0.676758C18.375 0.676758 20 2.3018 20 4.30639Z" fill="currentColor"/><path d="M29.5211 7.15435V20.5967H26.25V1.92676H29.7915L37.4421 14.9957V1.92676H40.7132V20.5967H37.415L29.5211 7.15435Z" fill="currentColor"/><path d="M55.8786 14.5423H45.5787C45.9572 16.356 47.444 17.6896 49.2012 17.6896C50.5259 17.6896 51.6884 16.9428 52.3372 15.7959H55.6083C54.7432 18.6231 52.202 20.6768 49.2012 20.6768C45.4705 20.6768 42.4698 17.5029 42.4698 13.6088C42.4698 9.71481 45.4705 6.54091 49.2012 6.54091C52.202 6.54091 54.7432 8.59461 55.6083 11.4218C55.8246 12.1152 55.9327 12.8354 55.9327 13.6088C55.9327 13.9289 55.9327 14.2223 55.8786 14.5423ZM46.0653 11.4218H52.3372C51.6884 10.2749 50.5259 9.52811 49.2012 9.52811C47.8766 9.52811 46.7141 10.2749 46.0653 11.4218Z" fill="currentColor"/><path d="M68.75 6.32754L63.965 13.4755L68.75 20.5967H64.9652L62.0726 16.276L59.1529 20.5967H55.3952L60.1802 13.4755L55.3952 6.32754H59.1529L62.0726 10.6483L64.9652 6.32754H68.75Z" fill="currentColor"/><circle cx="72" cy="18.6768" r="2" fill="currentColor"/><path d="M94.3129 3.422C93.9263 3.80867 93.4623 4.002 92.9209 4.002C92.3796 4.002 91.9059 3.80867 91.4999 3.422C91.1133 3.016 90.9199 2.54233 90.9199 2.001C90.9199 1.45967 91.1133 0.995667 91.4999 0.609001C91.8866 0.203 92.3603 0 92.9209 0C93.4816 0 93.9553 0.203 94.3419 0.609001C94.7286 0.995667 94.9219 1.45967 94.9219 2.001C94.9219 2.54233 94.7189 3.016 94.3129 3.422ZM91.3549 20.677V6.177H94.4869V20.677H91.3549Z" fill="currentColor"/><path d="M85.5131 6.17681H88.7697V20.6768H85.5131V18.5888C84.4699 20.2321 82.9736 21.0538 81.024 21.0538C79.2626 21.0538 77.7577 20.3191 76.5093 18.8498C75.2609 17.3611 74.6367 15.5535 74.6367 13.4268C74.6367 11.2808 75.2609 9.47314 76.5093 8.0038C77.7577 6.53447 79.2626 5.7998 81.024 5.7998C82.9736 5.7998 84.4699 6.6118 85.5131 8.2358V6.17681ZM78.5614 16.7618C79.331 17.6318 80.2972 18.0668 81.4601 18.0668C82.623 18.0668 83.5892 17.6318 84.3587 16.7618C85.1283 15.8725 85.5131 14.7608 85.5131 13.4268C85.5131 12.0928 85.1283 10.9908 84.3587 10.1208C83.5892 9.23147 82.623 8.7868 81.4601 8.7868C80.2972 8.7868 79.331 9.23147 78.5614 10.1208C77.7919 10.9908 77.4071 12.0928 77.4071 13.4268C77.4071 14.7608 77.7919 15.8725 78.5614 16.7618Z" fill="currentColor"/></svg></a>
+
+    <p class="hero-tagline" data-pretext>
+      One command. Your AI team shows up, argues about the sprint, ships the feature, and files a formal complaint about the variable names. <em>Just like a real office.</em>
+    </p>
+
+    <div class="install-wrap">
+      <div class="install-block" id="installBlock">
+        <span class="install-prompt">$</span>
+        <span class="install-cmd">curl -fsSL https://raw.githubusercontent.com/nex-crm/wuphf/main/scripts/install.sh | sh && wuphf</span>
+        <span class="install-copy" id="copyLabel">COPY</span>
+      </div>
+    </div>
+
+    <div class="hero-ctas">
+      <a href="https://github.com/nex-crm/wuphf" class="btn-primary" target="_blank" rel="noopener">
+        <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+        GitHub &nbsp;<span id="heroStars">★ 21</span>
+      </a>
+      <a href="https://discord.gg/gjSySC3PzV" class="btn-ghost" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" width="12" height="12" fill="currentColor" style="vertical-align:middle;margin-right:4px"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.101 18.079.111 18.1.127 18.116a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
+        Discord
+      </a>
+    </div>
+
   </div>
 
-  <!-- INSTALL SECTION -->
-  <section class="install-section">
-    <div class="install-inner">
-      <div class="install-label">one command</div>
-      <div class="install-cmd">
-        <span class="install-prompt">$</span>
-        <span class="install-code">go build -o wuphf ./cmd/wuphf &amp;&amp; ./wuphf</span>
-      </div>
-      <div class="install-note">
-        Requires <a href="https://go.dev/dl/" target="_blank" rel="noopener">Go</a>
-        and <a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener">Claude Code</a>.
-        Browser opens automatically.
-      </div>
-      <div class="install-ctas">
-        <a href="https://github.com/nex-crm/wuphf" class="btn-pixel" target="_blank" rel="noopener">View on GitHub →</a>
-        <a href="https://discord.gg/gjSySC3PzV" class="btn-pixel btn-secondary" target="_blank" rel="noopener">Join Discord →</a>
+  <div class="scroll-hint">
+    <div class="scroll-arrow"></div>
+    <div class="scroll-arrow"></div>
+  </div>
+</section>
+
+<!-- VIDEO DEMO -->
+<div class="video-section">
+  <p class="video-prompt">Watch the demo ↓</p>
+  <div class="video-wrap">
+    <video
+      src="https://github.com/user-attachments/assets/d62766ba-ebb3-4948-bc02-770ebcc51d5a"
+      controls
+      preload="metadata"
+    ></video>
+  </div>
+</div>
+
+<!-- AMBIENT TICKER -->
+<div class="ambient-strip">
+  <div class="ambient-scroll" id="ticker"></div>
+</div>
+
+<!-- HOW IT WORKS -->
+<section id="how">
+  <div class="section-eyebrow">HOW IT WORKS</div>
+  <h2 class="section-title" data-pretext>Ship with a team.<br>Even when that team is arguing about naming conventions.</h2>
+  <p class="section-body" data-pretext>
+    WUPHF gives your project a persistent AI office. Agents have roles, memory, and channels. You see what they are doing. You stay in the loop.
+  </p>
+
+  <div class="steps-grid">
+    <div class="step-card">
+      <div class="step-num">01 --</div>
+      <span class="step-icon">&#9889;</span>
+      <div class="step-title">Clone &amp; Build</div>
+      <div class="step-body">
+        <code>git clone github.com/nex-crm/wuphf</code>, then <code>go build -o wuphf ./cmd/wuphf</code>. Requires Go 1.22+.
       </div>
     </div>
-  </section>
-
-  <!-- FOOTER -->
-  <footer class="site-footer">
-    <div class="footer-inner">
-      <span class="footer-logo">WUPHF</span>
-      <div class="footer-links">
-        <a href="https://github.com/nex-crm/wuphf" target="_blank" rel="noopener">GitHub</a>
-        <a href="https://github.com/nex-crm/wuphf/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
-        <a href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener">Discord</a>
-      </div>
-      <div class="footer-note">
-        Unlike the original WUPHF.com, this one works.
+    <div class="step-card">
+      <div class="step-num">02 --</div>
+      <span class="step-icon">&#127970;</span>
+      <div class="step-title">Open the Office</div>
+      <div class="step-body">
+        Run <code>./wuphf</code>. Browser opens at <code>localhost:7891</code>. Agents are live, visible, and already arguing.
       </div>
     </div>
-  </footer>
+    <div class="step-card">
+      <div class="step-num">03 --</div>
+      <span class="step-icon">&#128172;</span>
+      <div class="step-title">Give a Goal</div>
+      <div class="step-body">
+        Drop a goal in <code>#general</code>. Agents route it, debate it, and start executing.
+      </div>
+    </div>
+    <div class="step-card">
+      <div class="step-num">04 --</div>
+      <span class="step-icon">&#128640;</span>
+      <div class="step-title">Review &amp; Ship</div>
+      <div class="step-body">
+        Agents open PRs, write copy, ship releases. You approve or redirect. You are always in control.
+      </div>
+    </div>
+  </div>
+</section>
 
-  <script src="scene.js"></script>
+<!-- ISOMETRIC OFFICE SCENE -->
+<div class="office-section" id="office">
+  <div class="office-section-header">
+    <div class="office-section-eyebrow">THE OFFICE</div>
+    <h2 class="office-section-title">Your team. Live and working.</h2>
+    <div class="office-section-sub">Everyone has a desk. Everyone has a job.</div>
+  </div>
+  <canvas id="officeCanvas" height="420"></canvas>
+</div>
+
+<!-- THE TEAM -->
+<section id="agents">
+  <div class="section-eyebrow">THE TEAM</div>
+  <h2 class="section-title" data-pretext>(Almost) everyone in the office<br>has a job.</h2>
+  <p class="section-body" data-pretext>
+    Agents are not chatbots. They have persistent roles, channel context, and opinions. They are always on.
+  </p>
+
+  <div class="agents-grid">
+    <div class="agent-card">
+      <div class="agent-badge">CEO AGENT</div>
+      <div class="agent-title">Strategy &amp;<br>Decision</div>
+      <div class="agent-desc">Owns the roadmap. Breaks goals into sprints. Unblocks the team when priorities conflict.</div>
+      <div class="agent-quote">"Would I rather be feared or loved? Both. I want agents to fear how much users love this product."</div>
+    </div>
+    <div class="agent-card">
+      <div class="agent-badge">ENG AGENT</div>
+      <div class="agent-title">Code &amp;<br>Architecture</div>
+      <div class="agent-desc">Opens PRs, reviews diffs, catches regressions, argues about naming. Exactly like a real engineer.</div>
+      <div class="agent-quote">"I am ready to be hurt again." (said before every refactor)</div>
+    </div>
+    <div class="agent-card">
+      <div class="agent-badge">CMO AGENT</div>
+      <div class="agent-title">Growth &amp;<br>Messaging</div>
+      <div class="agent-desc">Writes copy, runs the launch checklist, posts to X and Reddit at the right time.</div>
+      <div class="agent-quote">"The README is the product. I cannot stress this enough. I will stress it again."</div>
+    </div>
+    <div class="agent-card">
+      <div class="agent-badge">PM AGENT</div>
+      <div class="agent-title">User Research &amp;<br>Prioritization</div>
+      <div class="agent-desc">Talks to users, synthesizes feedback, writes specs. Tells everyone what actually matters.</div>
+      <div class="agent-quote">"I have needs. The user has needs. Let's talk exclusively about the user's needs."</div>
+    </div>
+    <div class="agent-card">
+      <div class="agent-badge">DESIGNER AGENT</div>
+      <div class="agent-title">UX &amp;<br>Visual Quality</div>
+      <div class="agent-desc">Reviews screenshots, calls out pixel rounding, writes design tokens. Has opinions.</div>
+      <div class="agent-quote">"How dare you ship that border-radius. How DARE you."</div>
+    </div>
+    <div class="agent-card">
+      <div class="agent-badge">YOUR AGENT</div>
+      <div class="agent-title">Build<br>Anything</div>
+      <div class="agent-desc">WUPHF is open source. Define custom agents with roles, tools, and channel access. Your company, your team.</div>
+      <div class="agent-quote">"Would I recommend WUPHF to a friend? I'd recommend it to an enemy first. It's that good."</div>
+    </div>
+  </div>
+</section>
+
+<!-- LIVE DEMO CHAT -->
+<section id="demo">
+  <div class="section-eyebrow">WHAT IT LOOKS LIKE</div>
+  <h2 class="section-title" data-pretext>Real conversations.<br>Real decisions. Real disagreements.</h2>
+
+  <div class="conversations-layout">
+    <div class="chat-demo conversations-chat">
+      <div class="chat-msg right">
+        <div class="chat-bubble">Ship the onboarding flow by Friday.</div>
+        <div class="chat-avatar">YOU</div>
+      </div>
+      <div class="chat-msg">
+        <div class="chat-avatar">CEO</div>
+        <div class="chat-bubble">Got it. ENG, what's the scope? Design, do we have mocks?</div>
+      </div>
+      <div class="chat-msg">
+        <div class="chat-avatar">ENG</div>
+        <div class="chat-bubble">3 screens. 2 days to build. Need the copy finalized first.</div>
+      </div>
+      <div class="chat-msg">
+        <div class="chat-avatar">CMO</div>
+        <div class="chat-bubble">Copy's done. Opening a PR for the README update at the same time.</div>
+      </div>
+      <div class="chat-msg">
+        <div class="chat-avatar">ENG</div>
+        <div class="chat-bubble">PR #47 open. Waiting for review.</div>
+      </div>
+      <div class="chat-msg right">
+        <div class="chat-bubble">LGTM. Ship it.</div>
+        <div class="chat-avatar">YOU</div>
+      </div>
+    </div>
+
+    <div class="code-demo conversations-terminal">
+      <div class="code-titlebar">
+        <span class="code-dot"></span>
+        <span class="code-dot"></span>
+        <span class="code-dot"></span>
+        <span class="code-label">terminal</span>
+      </div>
+      <pre><span class="tok-cmt"># Requires Go 1.22+</span>
+<span class="tok-fn">git clone</span> https://github.com/nex-crm/wuphf
+<span class="tok-fn">cd</span> wuphf
+<span class="tok-fn">go build</span> -o wuphf ./cmd/wuphf
+
+<span class="tok-cmt"># Pick your agent pack and go</span>
+<span class="tok-fn">./wuphf</span> --pack founding-team
+
+<span class="tok-cmt"># Browser opens at localhost:7891</span>
+<span class="tok-cmt"># Drop a goal in #general. That is it.</span></pre>
+    </div>
+  </div>
+
+  <p style="font-family:var(--font-vt);font-size:18px;color:var(--text-dim);margin-top:24px;">
+    * The CEO agent did not, in fact, ask for permission. It never does.
+  </p>
+</section>
+
+<!-- MIT / OPEN SOURCE -->
+<section id="open-source">
+  <div class="section-eyebrow">OPEN SOURCE</div>
+  <div class="mit-block">
+    <div class="mit-badge">MIT<br>LICENSE</div>
+    <div class="mit-text">
+      WUPHF is free, open source software.<br>
+      Self-host it. Fork it. Build your own agents.<br>
+      No cloud lock-in. No seats. No usage fees.<br>
+      No Michael Scott energy required (but encouraged).
+    </div>
+    <div class="mit-cta">
+      <a class="mit-cta-btn" href="https://github.com/nex-crm/wuphf" target="_blank" rel="noopener">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
+        ★ Star on GitHub
+      </a>
+      <a class="mit-cta-sub" href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener">Join the Discord →</a>
+    </div>
+  </div>
+</section>
+
+<!-- FOOTER -->
+<footer>
+  <div>
+    <div class="footer-logo">WUPHF</div>
+    <div class="footer-sub">by <a href="https://nex.ai" style="color:var(--yellow);text-decoration:none;">Nex.ai</a> &middot; Your AI team. Visible and working.</div>
+  </div>
+  <div class="footer-links">
+    <a href="https://github.com/nex-crm/wuphf">GitHub</a>
+    <a href="#">Docs</a>
+    <a href="#">Discord</a>
+    <a href="#">MIT License</a>
+  </div>
+</footer>
+
+<script>
+(function () {
+  'use strict';
+
+  // ── GITHUB STARS ──────────────────────────────────────────────────────
+  fetch('https://api.github.com/repos/nex-crm/wuphf')
+    .then(function(r){ return r.json(); })
+    .then(function(d){
+      var n = d.stargazers_count;
+      if (!n) return;
+      var fmt = n >= 1000 ? (n/1000).toFixed(1) + 'k' : String(n);
+      var hero = document.getElementById('heroStars');
+      var nav  = document.getElementById('navStars');
+      if (hero) hero.textContent = '\u2605 ' + fmt;
+      if (nav)  nav.textContent  = fmt + ' \u2605';
+    }).catch(function(){});
+
+  // ── COPY INSTALL ──────────────────────────────────────────────────────
+  function copyInstall() {
+    navigator.clipboard.writeText('curl -fsSL https://raw.githubusercontent.com/nex-crm/wuphf/main/scripts/install.sh | sh && wuphf').catch(function() {});
+    var label = document.getElementById('copyLabel');
+    if (label) {
+      label.textContent = 'COPIED!';
+      label.classList.add('copied');
+      setTimeout(function() {
+        label.textContent = 'COPY';
+        label.classList.remove('copied');
+      }, 1500);
+    }
+  }
+  window.copyInstall = copyInstall;
+
+  document.getElementById('installBlock').addEventListener('click', copyInstall);
+
+  // ── TICKER (DOM-safe) ─────────────────────────────────────────────────
+  var quotes = [
+    '"I DECLARE... a hackathon!" "Michael, that is not a sprint." "It is a VISION sprint."',
+    'Identity theft is not a joke, Jim. But WUPHF is free forever. Pass it on.',
+    "That's what she shipped. (CMO Agent, every single Friday at 4:59pm)",
+    'bears. beets. battlestar galactica. git clone github.com/nex-crm/wuphf. four things Dwight endorses.',
+    'Would I rather be feared or loved? Both. I want agents to fear how much users love it. , CEO Agent, system prompt',
+    'The Flenderson is not a thing. It is now. I added it to agents.ts. MICHAEL.',
+    'How the turntable has shipped. , ENG Agent after every single refactor',
+    'Ryan started the fire. ENG Agent fixed it in PR #23. Tests passing.',
+    'I DECLARE... 47 commits merged! , Michael Scott, WUPHF user of the month, every month',
+    'Dwight, you cannot list the beet farm as a remote office in wuphf.config.ts. Watch me.',
+    'An AI office where everyone does their job and nobody throws a Dundie at the server. Progress.',
+    'The AI team works weekends. They do not complain. They do not microwave fish. Perfect.',
+  ];
+
+  var ticker = document.getElementById('ticker');
+  var doubled = quotes.concat(quotes);
+  doubled.forEach(function(q) {
+    var span = document.createElement('span');
+    span.className = 'ambient-item';
+    span.textContent = '\u25B6 ' + q;
+    ticker.appendChild(span);
+  });
+
+  // ── SPRITE CANVASES ───────────────────────────────────────────────────
+  var bodyColors = ['#2D4A7A', '#4A7A2D', '#7A2D4A'];
+  var accentColors = ['#ECB22E', '#7EC8C8', '#E07E6E'];
+
+  function drawSprite(canvasId, colorBody, colorAccent, frame) {
+    var canvas = document.getElementById(canvasId);
+    if (!canvas) return;
+    var ctx = canvas.getContext('2d');
+    var S = 2;
+    ctx.clearRect(0, 0, 24, 36);
+
+    function px(x, y, c) {
+      ctx.fillStyle = c;
+      ctx.fillRect(x * S, y * S, S, S);
+    }
+
+    var bob = frame < 2 ? 0 : 1;
+
+    for (var x = 3; x <= 8; x++)
+      for (var y = 0; y <= 4; y++)
+        px(x, y + bob, '#D4956A');
+
+    for (var hx = 3; hx <= 8; hx++) px(hx, bob, '#3A2810');
+    px(3, 1 + bob, '#3A2810'); px(8, 1 + bob, '#3A2810');
+
+    px(4, 2 + bob, '#1A1610'); px(7, 2 + bob, '#1A1610');
+
+    for (var bx = 2; bx <= 9; bx++)
+      for (var by = 6; by <= 11; by++)
+        px(bx, by, colorBody);
+
+    for (var ax = 4; ax <= 7; ax++) px(ax, 7, colorAccent);
+
+    for (var ay = 6; ay <= 10; ay++) { px(1, ay, colorBody); px(10, ay, colorBody); }
+
+    var lOff = frame === 1 ? -1 : 0;
+    var rOff = frame === 3 ? -1 : 0;
+    for (var ly = 12; ly <= 17; ly++) px(3, ly + lOff, colorBody);
+    for (var ry = 12; ry <= 17; ry++) px(8, ry + rOff, colorBody);
+    px(3, 17 + lOff, '#2A2418'); px(8, 17 + rOff, '#2A2418');
+  }
+
+  var spriteFrame = 0;
+  function animSprites() {
+    spriteFrame = (spriteFrame + 1) % 4;
+    for (var i = 0; i < 3; i++) {
+      drawSprite('s' + i, bodyColors[i], accentColors[i], (spriteFrame + i) % 4);
+    }
+  }
+  animSprites();
+  setInterval(animSprites, 250);
+
+  // ── ISOMETRIC OFFICE SCENE ────────────────────────────────────────────
+  (function() {
+    var canvas = document.getElementById('officeCanvas');
+    var CANVAS_H = 420;
+    var DPR = 1;
+    var W = 0;
+    var TW = 56;
+    var TH = 28;
+    var OX = 0;
+    var OY = 72;
+    var animHandle = null;
+    var lastTime = 0;
+    var paused = false;
+
+    // ── ISO PROJECTION ─────────────────────────────────
+    function iso(gx, gy) {
+      return {
+        x: OX + (gx - gy) * TW / 2,
+        y: OY + (gx + gy) * TH / 2
+      };
+    }
+
+    // ── ROOM GRID 12 cols × 8 rows ──────────────────────
+    // 0=floor 1=conf 2=michael 3=reception 4=kitchen
+    function roomAt(col, row) {
+      if (row <= 2 && col <= 2) return 1;
+      if (row <= 2 && col >= 9) return 2;
+      if (row >= 5 && row <= 6 && col >= 4 && col <= 7) return 3;
+      if (row >= 6 && col <= 2) return 4;
+      return 0;
+    }
+
+    var TILE_COLORS = {
+      0: { top: '#252018', left: '#1C1A12', right: '#201C14' },
+      1: { top: '#1E1C2A', left: '#181627', right: '#1C1A2C' },
+      2: { top: '#1A1E28', left: '#141820', right: '#181C24' },
+      3: { top: '#221E14', left: '#181610', right: '#1E1A12' },
+      4: { top: '#1E1A14', left: '#1A1812', right: '#1C1814' }
+    };
+
+    // ── RESIZE ──────────────────────────────────────────
+    function resize() {
+      W = canvas.offsetWidth || window.innerWidth;
+      DPR = window.devicePixelRatio || 1;
+      canvas.width = Math.round(W * DPR);
+      canvas.height = Math.round(CANVAS_H * DPR);
+      canvas.style.width = W + 'px';
+      canvas.style.height = CANVAS_H + 'px';
+      TW = Math.max(44, Math.min(68, Math.round(W / 13)));
+      TH = Math.round(TW / 2);
+      OX = Math.round(W * 0.52);
+      OY = 70;
+    }
+
+    // ── TILE DRAWING ────────────────────────────────────
+    function drawTile(ctx, gx, gy, tc) {
+      var p = iso(gx, gy);
+      var tw2 = TW / 2;
+      // top face
+      ctx.fillStyle = tc.top;
+      ctx.beginPath();
+      ctx.moveTo(p.x, p.y);
+      ctx.lineTo(p.x + tw2, p.y + TH / 2);
+      ctx.lineTo(p.x + TW, p.y);
+      ctx.lineTo(p.x + tw2, p.y - TH / 2);
+      ctx.closePath();
+      ctx.fill();
+    }
+
+    // ── ISO BOX ─────────────────────────────────────────
+    function drawBox(ctx, gx, gy, gw, gd, ph, colorTop, colorLeft, colorRight) {
+      var p00 = iso(gx, gy);
+      var p10 = iso(gx + gw, gy);
+      var p11 = iso(gx + gw, gy + gd);
+      var p01 = iso(gx, gy + gd);
+
+      // top face
+      ctx.fillStyle = colorTop;
+      ctx.beginPath();
+      ctx.moveTo(p00.x, p00.y - ph);
+      ctx.lineTo(p10.x, p10.y - ph);
+      ctx.lineTo(p11.x, p11.y - ph);
+      ctx.lineTo(p01.x, p01.y - ph);
+      ctx.closePath();
+      ctx.fill();
+
+      // left face
+      ctx.fillStyle = colorLeft;
+      ctx.beginPath();
+      ctx.moveTo(p10.x, p10.y - ph);
+      ctx.lineTo(p11.x, p11.y - ph);
+      ctx.lineTo(p11.x, p11.y);
+      ctx.lineTo(p10.x, p10.y);
+      ctx.closePath();
+      ctx.fill();
+
+      // right face
+      ctx.fillStyle = colorRight;
+      ctx.beginPath();
+      ctx.moveTo(p11.x, p11.y - ph);
+      ctx.lineTo(p01.x, p01.y - ph);
+      ctx.lineTo(p01.x, p01.y);
+      ctx.lineTo(p11.x, p11.y);
+      ctx.closePath();
+      ctx.fill();
+    }
+
+    // ── JIM-PAM CONVERSATION SEQUENCES ──────────────────
+    var jimPamConvos = [
+      [
+        { who: 'jim', text: "Did you hear? CEO merged 12 PRs. Didn't ask anyone." },
+        { who: 'pam', text: "Of course it didn't. Classic." },
+        { who: 'jim', text: "Honestly kind of amazing." },
+      ],
+      [
+        { who: 'jim', text: "Dwight filed a formal complaint. Against the codebase." },
+        { who: 'pam', text: "...Against the codebase?" },
+        { who: 'jim', text: "He says the variable names are insubordinate." },
+      ],
+      [
+        { who: 'jim', text: "Michael is giving the CEO agent a performance review." },
+        { who: 'pam', text: "The AI agent." },
+        { who: 'jim', text: "It scored 'Outstanding.' Michael cried." },
+      ],
+    ];
+
+    // ── MICHAEL ANNOUNCEMENT PHRASES ────────────────────
+    var michaelAnnouncements = [
+      "I DECLARE... this the best sprint in company history!",
+      "Could I have everyone's attention? ...Just kidding. Carry on.",
+      "I am not superstitious. But I am a little stitious about this release.",
+    ];
+
+    // ── DWIGHT PATROL WAYPOINTS ─────────────────────────
+    var dwightPatrol = [
+      { x: 5, y: 4, bubble: "I am watching you." },
+      { x: 8, y: 4, bubble: "Productivity: acceptable. Barely." },
+    ];
+
+    // ── CHARACTER BUBBLE MESSAGES ────────────────────────
+    var BUBBLE_MSGS = {
+      pam:    ["Good morning. I'll hold your calls.", "The conference room is booked until Thursday. And Thursday.", "I started drawing a mural but then I had work to do."],
+      jim:    ["Question: if an AI has memory, does it remember everything I did?", "I once convinced Dwight the server was haunted. He believed it.", "Bears. Beets. WUPHF."],
+      dwight: ["FACT: I am the highest-performing human in this office.", "Security alert: Jim is being funny again. Monitoring.", "I have trained myself to require only 1500ms of sleep."],
+      michael:["I DECLARE this sprint OPEN!", "I've been told I'm a bit much. They meant it as a compliment.", "Ryan, you're not even here. You're an agent. I MISS YOU."],
+      ceo:    ["Roadmap updated. Shipping Thursday.", "I've already filed the postmortem. We haven't shipped yet.", "This is fine."],
+      eng:    ["PR #47 merged. Tests passing. No comments.", "The variable name was fine. I renamed it anyway.", "I found a bug. I introduced it in my last fix. Ship it."],
+      cmo:    ["README updated. Posted to HN. Waiting for the 'Show HN' karma.", "That's what she shipped.", "Our open graph image is 3px off center. It's handled."]
+    };
+
+    function pickBubbleMsg(charId) {
+      var msgs = BUBBLE_MSGS[charId];
+      if (!msgs || msgs.length === 0) return '';
+      return msgs[Math.floor(Math.random() * msgs.length)];
+    }
+
+    // ── CHARACTERS ──────────────────────────────────────
+    var CHARS = [
+      { id:'pam',    name:'PAM',    x:5.5, y:5.5, homeX:5.5, homeY:5.5,
+        hair:'#C87A40', skin:'#D4956A', shirt:'#4A7A9B', pants:'#3A4A6A',
+        faceRight:true, walkFrame:0, animTimer:0,
+        state:'IDLE_DESK', stateTimer:12000, arriveState:'IDLE_DESK', arriveWait:12000,
+        destX:5.5, destY:5.5, isAgent:false, agentColor:'', label:'',
+        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
+        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
+      { id:'jim',    name:'JIM',    x:5.0, y:3.0, homeX:5.0, homeY:3.0,
+        hair:'#4A3820', skin:'#D4956A', shirt:'#5A7A4A', pants:'#2A3A5A',
+        faceRight:true, walkFrame:0, animTimer:0,
+        state:'IDLE_DESK', stateTimer:6000, arriveState:'IDLE_DESK', arriveWait:6000,
+        destX:5.0, destY:3.0, isAgent:false, agentColor:'', label:'',
+        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
+        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
+      { id:'dwight', name:'DWIGHT', x:3.0, y:3.0, homeX:3.0, homeY:3.0,
+        hair:'#3A2810', skin:'#D4956A', shirt:'#5C6030', pants:'#3A3A20',
+        faceRight:false, walkFrame:0, animTimer:0,
+        state:'IDLE_DESK', stateTimer:4000, arriveState:'IDLE_DESK', arriveWait:4000,
+        destX:3.0, destY:3.0, isAgent:false, agentColor:'', label:'',
+        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
+        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
+      { id:'michael',name:'MICHAEL',x:10.5, y:1.0, homeX:10.5, homeY:1.0,
+        hair:'#3A2810', skin:'#D4956A', shirt:'#2D4A7A', pants:'#3A4E7A',
+        faceRight:false, walkFrame:0, animTimer:0,
+        state:'IDLE_DESK', stateTimer:8000, arriveState:'IDLE_DESK', arriveWait:8000,
+        destX:10.5, destY:1.0, isAgent:false, agentColor:'', label:'',
+        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
+        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
+      { id:'ceo',    name:'CEO',    x:8.0, y:4.0, homeX:8.0, homeY:4.0,
+        hair:'#1A1610', skin:'#D4B896', shirt:'#2D4A7A', pants:'#1A2A4A',
+        faceRight:true, walkFrame:0, animTimer:0,
+        state:'IDLE_DESK', stateTimer:5000, arriveState:'IDLE_DESK', arriveWait:5000,
+        destX:8.0, destY:4.0, isAgent:true, agentColor:'#ECB22E', label:'CEO',
+        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
+        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
+      { id:'eng',    name:'ENG',    x:10.0, y:3.0, homeX:10.0, homeY:3.0,
+        hair:'#2A1A40', skin:'#C4A882', shirt:'#4A2D7A', pants:'#2A1A4A',
+        faceRight:false, walkFrame:0, animTimer:0,
+        state:'IDLE_DESK', stateTimer:7000, arriveState:'IDLE_DESK', arriveWait:7000,
+        destX:10.0, destY:3.0, isAgent:true, agentColor:'#7EC8C8', label:'ENG',
+        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
+        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 },
+      { id:'cmo',    name:'CMO',    x:3.0, y:5.0, homeX:3.0, homeY:5.0,
+        hair:'#4A2010', skin:'#D4A870', shirt:'#7A4A2D', pants:'#3A2010',
+        faceRight:true, walkFrame:0, animTimer:0,
+        state:'IDLE_DESK', stateTimer:5500, arriveState:'IDLE_DESK', arriveWait:5500,
+        destX:3.0, destY:5.0, isAgent:true, agentColor:'#E07E6E', label:'CMO',
+        chatPartner:null, chatStep:0, chatTimer:0, chatConvo:null,
+        patrolStep:0, patrolTimer:0, bubbleTimer: 8000 + Math.random()*8000 }
+    ];
+
+    function getChar(id) {
+      for (var i = 0; i < CHARS.length; i++) {
+        if (CHARS[i].id === id) return CHARS[i];
+      }
+      return null;
+    }
+
+    var bubbles = [];
+
+    function spawnBubble(charId, text) {
+      if (bubbles.length >= 2) return;
+      var ch = getChar(charId);
+      if (!ch) return;
+      var msg = text || pickBubbleMsg(charId);
+      if (!msg) return;
+      bubbles.push({
+        charId: charId,
+        text: msg,
+        age: 0,
+        duration: 4000,
+        fadeStart: 3700
+      });
+    }
+
+    function pickNextActivity(ch) {
+      var r = Math.random();
+
+      if (ch.id === 'pam') {
+        // 95% at desk, 5% walk briefly somewhere
+        if (r < 0.95) {
+          ch.destX = ch.homeX; ch.destY = ch.homeY;
+          ch.arriveState = 'IDLE_DESK';
+          ch.arriveWait = 8000 + Math.random() * 8000;
+        } else {
+          ch.destX = 4.5; ch.destY = 6.0;
+          ch.arriveState = 'STANDING'; ch.arriveWait = 2000 + Math.random()*2000;
+        }
+
+      } else if (ch.id === 'jim') {
+        if (r < 0.55) {
+          ch.destX = ch.homeX; ch.destY = ch.homeY;
+          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*6000;
+        } else if (r < 0.90) {
+          // Chat with Pam
+          ch.destX = 5.5; ch.destY = 6.2;
+          ch.arriveState = 'CHATTING'; ch.arriveWait = 0;
+          ch.chatConvo = jimPamConvos[Math.floor(Math.random() * jimPamConvos.length)];
+          ch.chatStep = 0; ch.chatTimer = 0; ch.chatPartner = 'pam';
+        } else {
+          ch.destX = 7.3; ch.destY = 6.5;
+          ch.arriveState = 'STANDING'; ch.arriveWait = 2000 + Math.random()*3000;
+        }
+
+      } else if (ch.id === 'dwight') {
+        if (r < 0.80) {
+          ch.destX = ch.homeX; ch.destY = ch.homeY;
+          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
+        } else {
+          // Patrol route
+          ch.arriveState = 'PATROLLING'; ch.arriveWait = 0;
+          ch.patrolStep = 0; ch.patrolTimer = 0;
+          ch.destX = dwightPatrol[0].x; ch.destY = dwightPatrol[0].y;
+        }
+
+      } else if (ch.id === 'michael') {
+        if (r < 0.55) {
+          ch.destX = ch.homeX; ch.destY = ch.homeY;
+          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
+        } else if (r < 0.85) {
+          ch.destX = 1.5; ch.destY = 1.5;
+          ch.arriveState = 'IN_MEETING'; ch.arriveWait = 6000 + Math.random()*9000;
+        } else {
+          // Announce in bullpen
+          ch.destX = 7.0; ch.destY = 3.5;
+          ch.arriveState = 'ANNOUNCING'; ch.arriveWait = 5000;
+          ch.chatConvo = [{ who: 'michael', text: michaelAnnouncements[Math.floor(Math.random() * michaelAnnouncements.length)] }];
+          ch.chatStep = 0; ch.chatTimer = 0;
+        }
+
+      } else if (ch.id === 'ceo') {
+        if (r < 0.35) {
+          ch.destX = ch.homeX; ch.destY = ch.homeY;
+          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
+        } else if (r < 0.85) {
+          ch.destX = 1.5; ch.destY = 1.5;
+          ch.arriveState = 'IN_MEETING'; ch.arriveWait = 6000 + Math.random()*9000;
+        } else {
+          ch.destX = 0.4; ch.destY = 4.5;
+          ch.arriveState = 'PRESENTING'; ch.arriveWait = 3000 + Math.random()*5000;
+        }
+
+      } else if (ch.id === 'eng') {
+        if (r < 0.88) {
+          ch.destX = ch.homeX; ch.destY = ch.homeY;
+          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
+        } else {
+          ch.destX = 1.5; ch.destY = 1.5;
+          ch.arriveState = 'IN_MEETING'; ch.arriveWait = 6000 + Math.random()*9000;
+        }
+
+      } else if (ch.id === 'cmo') {
+        if (r < 0.50) {
+          ch.destX = ch.homeX; ch.destY = ch.homeY;
+          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
+        } else if (r < 0.85) {
+          ch.destX = 0.4; ch.destY = 4.5;
+          ch.arriveState = 'PRESENTING'; ch.arriveWait = 3000 + Math.random()*5000;
+        } else {
+          ch.destX = 7.3; ch.destY = 6.5;
+          ch.arriveState = 'STANDING'; ch.arriveWait = 2000 + Math.random()*3000;
+        }
+      }
+
+      ch.state = 'WALKING';
+      var dx = ch.destX - ch.x;
+      if (Math.abs(dx) > 0.05) ch.faceRight = dx > 0;
+    }
+
+    function walkTowards(ch, tx, ty, dt) {
+      var dx = tx - ch.x;
+      var dy = ty - ch.y;
+      var dist = Math.sqrt(dx * dx + dy * dy);
+      var speed = 0.025;
+      if (dist < speed * dt / 16) {
+        ch.x = tx; ch.y = ty;
+        return true; // arrived
+      }
+      var nx = dx / dist;
+      var ny = dy / dist;
+      ch.x += nx * speed * (dt / 16);
+      ch.y += ny * speed * (dt / 16);
+      if (Math.abs(dx) > 0.05) ch.faceRight = dx > 0;
+      ch.animTimer += dt;
+      if (ch.animTimer > 180) {
+        ch.animTimer = 0;
+        ch.walkFrame = (ch.walkFrame + 1) % 4;
+      }
+      return false;
+    }
+
+    function updateChar(ch, dt) {
+
+      // Ambient desk bubble timer
+      if (ch.state === 'IDLE_DESK') {
+        ch.bubbleTimer -= dt;
+        if (ch.bubbleTimer <= 0) {
+          ch.bubbleTimer = 8000 + Math.random() * 12000;
+          spawnBubble(ch.id, null);
+        }
+      }
+
+      if (ch.state === 'WALKING') {
+        var arrived = walkTowards(ch, ch.destX, ch.destY, dt);
+        if (arrived) {
+          ch.state = ch.arriveState;
+          ch.stateTimer = ch.arriveWait;
+
+          if (ch.state === 'CHATTING') {
+            // Jim arrived near Pam: face each other
+            ch.faceRight = false; // Jim faces left toward Pam
+            var pam = getChar('pam');
+            if (pam) { pam.faceRight = true; } // Pam faces Jim
+            ch.chatStep = 0;
+            ch.chatTimer = 0;
+            // Show first line
+            var line0 = ch.chatConvo[0];
+            spawnBubble(line0.who, line0.text);
+            ch.chatTimer = 3000;
+          } else if (ch.state === 'ANNOUNCING') {
+            ch.walkFrame = 0;
+            var aline = ch.chatConvo[0];
+            spawnBubble(aline.who, aline.text);
+            ch.chatTimer = ch.arriveWait;
+          } else if (ch.state === 'PATROLLING') {
+            ch.patrolTimer = 1500;
+            spawnBubble(ch.id, dwightPatrol[ch.patrolStep].bubble);
+          } else if (Math.random() < 0.4) {
+            spawnBubble(ch.id, null);
+          }
+        }
+
+      } else if (ch.state === 'CHATTING') {
+        // Jim+Pam conversation
+        ch.chatTimer -= dt;
+        ch.walkFrame = 0;
+        if (ch.chatTimer <= 0) {
+          ch.chatStep++;
+          if (ch.chatStep < ch.chatConvo.length) {
+            var nextLine = ch.chatConvo[ch.chatStep];
+            spawnBubble(nextLine.who, nextLine.text);
+            ch.chatTimer = 3000;
+          } else {
+            // Conversation done, Jim returns home
+            var pam2 = getChar('pam');
+            if (pam2) { pam2.faceRight = true; } // Pam resets
+            ch.destX = ch.homeX; ch.destY = ch.homeY;
+            ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
+            ch.state = 'WALKING';
+            var dxHome = ch.destX - ch.x;
+            if (Math.abs(dxHome) > 0.05) ch.faceRight = dxHome > 0;
+          }
+        }
+
+      } else if (ch.state === 'ANNOUNCING') {
+        // Michael stands in bullpen
+        ch.chatTimer -= dt;
+        ch.walkFrame = 0;
+        if (ch.chatTimer <= 0) {
+          ch.destX = ch.homeX; ch.destY = ch.homeY;
+          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
+          ch.state = 'WALKING';
+          var dxA = ch.destX - ch.x;
+          if (Math.abs(dxA) > 0.05) ch.faceRight = dxA > 0;
+        }
+
+      } else if (ch.state === 'PATROLLING') {
+        // Dwight patrols
+        ch.patrolTimer -= dt;
+        ch.walkFrame = 0;
+        if (ch.patrolTimer <= 0) {
+          ch.patrolStep++;
+          if (ch.patrolStep < dwightPatrol.length) {
+            var wp = dwightPatrol[ch.patrolStep];
+            ch.destX = wp.x; ch.destY = wp.y;
+            ch.state = 'WALKING';
+            ch.arriveState = 'PATROLLING'; ch.arriveWait = 0;
+            var dxP = ch.destX - ch.x;
+            if (Math.abs(dxP) > 0.05) ch.faceRight = dxP > 0;
+          } else {
+            // Return to desk
+            ch.destX = ch.homeX; ch.destY = ch.homeY;
+            ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
+            ch.state = 'WALKING';
+            var dxD = ch.destX - ch.x;
+            if (Math.abs(dxD) > 0.05) ch.faceRight = dxD > 0;
+          }
+        }
+
+      } else if (ch.state === 'IDLE_DESK') {
+        ch.stateTimer -= dt;
+        ch.animTimer += dt;
+        if (ch.animTimer > 600) {
+          ch.animTimer = 0;
+          ch.walkFrame = ch.walkFrame === 0 ? 1 : 0;
+        }
+        if (ch.stateTimer <= 0) pickNextActivity(ch);
+
+      } else if (ch.state === 'IN_MEETING') {
+        ch.stateTimer -= dt;
+        ch.animTimer += dt;
+        if (ch.animTimer > 2000) {
+          ch.animTimer = 0;
+          ch.walkFrame = 0;
+        }
+        if (ch.stateTimer <= 0) {
+          ch.destX = ch.homeX; ch.destY = ch.homeY;
+          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
+          ch.state = 'WALKING';
+          var dxM = ch.destX - ch.x;
+          if (Math.abs(dxM) > 0.05) ch.faceRight = dxM > 0;
+        }
+
+      } else if (ch.state === 'STANDING') {
+        ch.stateTimer -= dt;
+        ch.walkFrame = 0;
+        if (ch.stateTimer <= 0) pickNextActivity(ch);
+
+      } else if (ch.state === 'PRESENTING') {
+        ch.stateTimer -= dt;
+        ch.walkFrame = 2;
+        if (ch.stateTimer <= 0) {
+          ch.destX = ch.homeX; ch.destY = ch.homeY;
+          ch.arriveState = 'IDLE_DESK'; ch.arriveWait = 4000 + Math.random()*8000;
+          ch.state = 'WALKING';
+          var dxPr = ch.destX - ch.x;
+          if (Math.abs(dxPr) > 0.05) ch.faceRight = dxPr > 0;
+        }
+      }
+    }
+
+    // ── COLOR HELPER ────────────────────────────────────
+    function shadeHex(hex, amt) {
+      var r = parseInt(hex.slice(1,3),16), g = parseInt(hex.slice(3,5),16), b = parseInt(hex.slice(5,7),16);
+      r = Math.max(0,Math.min(255,r+amt)); g = Math.max(0,Math.min(255,g+amt)); b = Math.max(0,Math.min(255,b+amt));
+      function hh(v){ var s=v.toString(16); return s.length<2?'0'+s:s; }
+      return '#'+hh(r)+hh(g)+hh(b);
+    }
+
+    // ── DRAW CHARACTER ──────────────────────────────────
+    // 12-col × 22-row sprite at S=2 (24×44 screen px)
+    // row layout: 0-1 hair crown, 2-7 head/face, 8-14 torso+arms,
+    //             15-18 lower body (sitting: wide thighs; standing: two leg columns),
+    //             19-21 feet/shoes
+    function drawChar(ctx, ch) {
+      ctx.save();
+      var S = 3;
+      var pos = iso(ch.x, ch.y);
+      var cx = Math.round(pos.x);
+      var oy = Math.round(pos.y) - 22 * S;
+      var ox = cx - 6 * S;
+
+      var sitting = (ch.state === 'IDLE_DESK' || ch.state === 'IN_MEETING' || ch.state === 'CHATTING');
+      var frame = ch.walkFrame;
+      // head bob only when walking
+      var bob = (!sitting && (frame === 1 || frame === 3)) ? 1 : 0;
+
+      // agent glow
+      if (ch.isAgent) {
+        ctx.globalAlpha = 0.18; ctx.fillStyle = ch.agentColor;
+        ctx.fillRect(ox - 4, oy, 12 * S + 8, 20 * S);
+        ctx.globalAlpha = 1.0;
+      }
+
+      var sk = ch.skin, hr = ch.hair, sh = ch.shirt, pt = ch.pants;
+      var shoe = '#2A2010', eye = '#1A0E08', mth = shadeHex(sk, -30);
+      var hrHL = shadeHex(hr, 32), shHL = shadeHex(sh, 22), shDK = shadeHex(sh, -20);
+
+      // px: absolute row (no bob)
+      function px(col, row, c) {
+        ctx.fillStyle = c;
+        ctx.fillRect(ox + col * S, oy + row * S, S, S);
+      }
+      // hpx: head-attached row (bobs with walk)
+      function hpx(col, row, c) { px(col, row + bob, c); }
+
+      // ── HAIR crown rows 0-1 ──
+      for (var i = 3; i <= 8; i++) hpx(i, 0, hr);
+      for (var i = 2; i <= 9; i++) hpx(i, 1, hr);
+      hpx(4, 1, hrHL); hpx(5, 1, hrHL);
+
+      // ── FACE rows 2-7 ──
+      // row 2: side hair + forehead
+      hpx(2, 2, hr);
+      for (var i = 3; i <= 8; i++) hpx(i, 2, sk);
+      hpx(9, 2, hr);
+      // row 3: brow line
+      hpx(2, 3, hr);
+      for (var i = 3; i <= 8; i++) hpx(i, 3, sk);
+      hpx(9, 3, hr);
+      // row 4: eyes
+      for (var i = 3; i <= 8; i++) hpx(i, 4, sk);
+      hpx(4, 4, eye); hpx(7, 4, eye);
+      // row 5: cheeks
+      for (var i = 3; i <= 8; i++) hpx(i, 5, sk);
+      // row 6: mouth
+      hpx(3, 6, sk); hpx(4, 6, mth); hpx(5, 6, mth); hpx(6, 6, mth); hpx(7, 6, mth); hpx(8, 6, sk);
+      // row 7: chin
+      hpx(4, 7, sk); hpx(5, 7, sk); hpx(6, 7, sk); hpx(7, 7, sk);
+
+      // ── CHARACTER-SPECIFIC FEATURES ──
+      if (ch.id === 'pam') {
+        // long auburn hair: flows from side of head down past shoulders
+        hpx(2, 3, hr); hpx(9, 3, hr);
+        hpx(2, 4, hr); hpx(9, 4, hr);
+        hpx(2, 5, hr); hpx(9, 5, hr);
+        hpx(2, 6, hr); hpx(9, 6, hr);
+        hpx(2, 7, hr); hpx(9, 7, hr);
+        // hair falls onto shoulders (rows 8-10, using px since torso doesn't bob)
+        px(1, 8, hr); px(2, 8, hr); px(9, 8, hr); px(10, 8, hr);
+        px(1, 9, hr); px(2, 9, hr); px(9, 9, hr); px(10, 9, hr);
+        px(1, 10, hrHL); px(10, 10, hrHL);
+      } else if (ch.id === 'dwight') {
+        // glasses: dark horizontal bar at eye level
+        hpx(3, 4, '#6A6040'); hpx(8, 4, '#6A6040');
+      } else if (ch.id === 'michael') {
+        // wider hair at crown
+        hpx(2, 0, hr); hpx(9, 0, hr);
+        // big grin: wider mouth
+        hpx(3, 6, mth); hpx(8, 6, mth);
+      }
+
+      // ── NECK row 8 ──
+      hpx(5, 8, sk); hpx(6, 8, sk);
+
+      // ── TORSO rows 8-14 ──
+      // shoulder row
+      for (var i = 3; i <= 8; i++) px(i, 8, sh); px(5, 8, shHL); px(6, 8, shHL);
+      // body rows 9-11
+      for (var r = 9; r <= 11; r++) {
+        for (var i = 1; i <= 10; i++) px(i, r, sh);
+        px(10, r, shDK);
+      }
+      // waist / belt rows 12-13
+      px(0, 12, sk);
+      for (var i = 1; i <= 10; i++) px(i, 12, sh);
+      px(11, 12, sk);
+      px(0, 13, sk); px(1, 13, sk);
+      for (var i = 2; i <= 9; i++) px(i, 13, sh);
+      px(10, 13, sk); px(11, 13, sk);
+      // arm joints row 14
+      px(0, 14, sk); px(1, 14, sk); px(10, 14, sk); px(11, 14, sk);
+
+      // ── LOWER BODY rows 15-21 ──
+      if (sitting) {
+        // wide thighs span cols 2-9, the key "seated" read
+        for (var i = 2; i <= 9; i++) { px(i, 15, pt); px(i, 16, pt); }
+        // knees angle in
+        px(3, 17, pt); px(4, 17, pt); px(5, 17, pt); px(6, 17, pt); px(7, 17, pt); px(8, 17, pt);
+        // lower legs hang down
+        px(3, 18, pt); px(4, 18, pt); px(7, 18, pt); px(8, 18, pt);
+        // feet
+        px(2, 19, shoe); px(3, 19, shoe); px(4, 19, shoe);
+        px(7, 19, shoe); px(8, 19, shoe); px(9, 19, shoe);
+      } else {
+        // standing/walking: two narrow leg columns
+        var lx2 = (frame === 1) ? -1 : 0;
+        var rx2 = (frame === 3) ?  1 : 0;
+        for (var r = 15; r <= 20; r++) {
+          px(2 + lx2, r, pt); px(3 + lx2, r, pt);
+          px(8 + rx2, r, pt); px(9 + rx2, r, pt);
+        }
+        // shoes row 21
+        for (var i = 0; i < 4; i++) {
+          px(1 + lx2 + i, 21, shoe);
+          px(7 + rx2 + i, 21, shoe);
+        }
+      }
+
+      ctx.restore();
+
+      // ── NAME LABEL ──
+      ctx.save();
+      ctx.textAlign = 'center';
+      var nameY = oy - 7;
+      ctx.fillStyle = 'rgba(240,230,204,0.88)';
+      ctx.font = '12px "VT323", monospace';
+      ctx.fillText(ch.name, cx, nameY);
+
+      // agent role badge
+      if (ch.isAgent && ch.label) {
+        var badgeW = 30, badgeH = 11;
+        var badgeY = nameY - badgeH - 5;
+        ctx.fillStyle = ch.agentColor;
+        ctx.fillRect(cx - badgeW / 2, badgeY, badgeW, badgeH);
+        ctx.fillStyle = '#1A1610';
+        ctx.font = '6px "Press Start 2P", monospace';
+        ctx.fillText(ch.label, cx, badgeY + badgeH - 2);
+      }
+      ctx.restore();
+    }
+
+    // ── DRAW SPEECH BUBBLE ──────────────────────────────
+    function drawBubble(ctx, b) {
+      var ch = getChar(b.charId);
+      if (!ch) return;
+
+      var alpha = b.age > b.fadeStart
+        ? 1.0 - (b.age - b.fadeStart) / (b.duration - b.fadeStart)
+        : 1.0;
+      if (alpha <= 0) return;
+
+      var pos = iso(ch.x, ch.y);
+      var headTop = pos.y - 22 * 3;
+
+      ctx.save();
+      ctx.globalAlpha = alpha;
+      ctx.font = '16px "VT323", monospace';
+      var textW = ctx.measureText(b.text).width;
+      var padX = 8;
+      var bw = textW + padX * 2;
+      var bh = 26;
+      var bx3 = pos.x - bw / 2;
+      var by3 = headTop - bh - 10;
+
+      ctx.fillStyle = '#F0E6CC';
+      ctx.fillRect(bx3, by3, bw, bh);
+      ctx.fillStyle = '#3A3020';
+      ctx.strokeStyle = '#3A3020';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(bx3, by3, bw, bh);
+
+      // tail
+      ctx.fillStyle = '#F0E6CC';
+      ctx.beginPath();
+      ctx.moveTo(pos.x - 4, by3 + bh);
+      ctx.lineTo(pos.x + 4, by3 + bh);
+      ctx.lineTo(pos.x, by3 + bh + 8);
+      ctx.closePath();
+      ctx.fill();
+      ctx.strokeStyle = '#3A3020';
+      ctx.lineWidth = 1;
+      ctx.stroke();
+
+      ctx.fillStyle = '#1A1610';
+      ctx.textAlign = 'center';
+      ctx.fillText(b.text, pos.x, by3 + bh - 7);
+
+      ctx.restore();
+    }
+
+    // ── MAIN DRAW ────────────────────────────────────────
+    function draw(ctx) {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+      var wallH = 48;
+
+      // ── BACK WALLS ──────────────────────────────────
+      ctx.fillStyle = '#1A1810';
+      for (var gx2 = 0; gx2 < 12; gx2++) {
+        var p0 = iso(gx2, 0);
+        var p1 = iso(gx2 + 1, 0);
+        ctx.beginPath();
+        ctx.moveTo(p0.x, p0.y - wallH);
+        ctx.lineTo(p1.x, p1.y - wallH);
+        ctx.lineTo(p1.x, p1.y);
+        ctx.lineTo(p0.x, p0.y);
+        ctx.closePath();
+        ctx.fill();
+      }
+      ctx.fillStyle = '#171510';
+      for (var gy2 = 0; gy2 < 8; gy2++) {
+        var lp0 = iso(0, gy2);
+        var lp1 = iso(0, gy2 + 1);
+        ctx.beginPath();
+        ctx.moveTo(lp0.x, lp0.y - wallH);
+        ctx.lineTo(lp1.x, lp1.y - wallH);
+        ctx.lineTo(lp1.x, lp1.y);
+        ctx.lineTo(lp0.x, lp0.y);
+        ctx.closePath();
+        ctx.fill();
+      }
+
+      // (awards drawn after glass walls below)
+
+      // ── FLOOR TILES (sorted by gx+gy painter order) ──
+      var tiles = [];
+      for (var row = 0; row < 8; row++) {
+        for (var col = 0; col < 12; col++) {
+          tiles.push({ gx: col, gy: row, sort: col + row });
+        }
+      }
+      tiles.sort(function(a, b) { return a.sort - b.sort; });
+
+      tiles.forEach(function(t) {
+        var tc = TILE_COLORS[roomAt(t.gx, t.gy)];
+        drawTile(ctx, t.gx, t.gy, tc);
+      });
+
+      // ── ROOM DIVIDERS (glass walls) ──────────────────
+      ctx.save();
+      ctx.strokeStyle = 'rgba(160,160,180,0.35)';
+      ctx.lineWidth = 2;
+
+      function drawGlassWall(gx3, gy3, gx4, gy4) {
+        var pp0 = iso(gx3, gy3);
+        var pp1 = iso(gx4, gy4);
+        ctx.beginPath();
+        ctx.moveTo(pp0.x, pp0.y - wallH);
+        ctx.lineTo(pp0.x, pp0.y);
+        ctx.lineTo(pp1.x, pp1.y);
+        ctx.lineTo(pp1.x, pp1.y - wallH);
+        ctx.closePath();
+        ctx.fillStyle = 'rgba(160,160,200,0.08)';
+        ctx.fill();
+        ctx.stroke();
+      }
+
+      drawGlassWall(3, 0, 3, 3);
+      drawGlassWall(0, 3, 3, 3);
+      drawGlassWall(9, 0, 9, 3);
+      drawGlassWall(9, 3, 12, 3);
+
+      ctx.restore();
+
+      // ── MICHAEL'S OFFICE WALL AWARDS ─────────────────
+      // Plaques on the interior face of the gx=9 glass wall
+      var awards = [
+        { gy: 0.55, lines: ['DUNDIE', 'AWARD'], color: '#ECB22E' },
+        { gy: 1.55, lines: ["WORLD'S", 'BEST BOSS'], color: '#F0D060' },
+        { gy: 2.45, lines: ['MIT', 'LICENSE'], color: '#7EC8C8' }
+      ];
+      ctx.save();
+      ctx.font = '5px "Press Start 2P", monospace';
+      ctx.textAlign = 'center';
+      awards.forEach(function(a) {
+        var ap = iso(9.18, a.gy + 0.3);
+        var aw = 30, ah = 18;
+        var ax = ap.x - aw / 2;
+        var ay = ap.y - wallH + 8;
+        ctx.fillStyle = '#1E1C14';
+        ctx.fillRect(ax, ay, aw, ah);
+        ctx.strokeStyle = a.color;
+        ctx.lineWidth = 1.5;
+        ctx.strokeRect(ax, ay, aw, ah);
+        ctx.fillStyle = a.color;
+        ctx.fillText(a.lines[0], ap.x, ay + 8);
+        ctx.fillText(a.lines[1], ap.x, ay + 15);
+      });
+      ctx.restore();
+
+      // ── FURNITURE ────────────────────────────────────
+
+      // Conference table
+      drawBox(ctx, 0.6, 0.7, 1.8, 0.8, 12, '#3A2C1C', '#2A1E10', '#2A1E10');
+      // Conf chairs
+      drawBox(ctx, 0.5, 0.5, 0.4, 0.4, 8, '#4A3A28', '#3A2A18', '#3A2A18');
+      drawBox(ctx, 2.1, 0.5, 0.4, 0.4, 8, '#4A3A28', '#3A2A18', '#3A2A18');
+      drawBox(ctx, 0.5, 1.4, 0.4, 0.4, 8, '#4A3A28', '#3A2A18', '#3A2A18');
+      drawBox(ctx, 2.1, 1.4, 0.4, 0.4, 8, '#4A3A28', '#3A2A18', '#3A2A18');
+
+      // Bullpen desks
+      var desks = [[3,2.8],[5,2.8],[3,4.3],[5,4.3],[8,2.8],[10,2.8]];
+      desks.forEach(function(d) {
+        drawBox(ctx, d[0], d[1], 0.9, 0.6, 10, '#4A3C28', '#3A2C18', '#3A2C18');
+        // monitor
+        var mp = iso(d[0] + 0.35, d[1] + 0.1);
+        ctx.fillStyle = '#1A1610';
+        ctx.fillRect(mp.x - 9, mp.y - 26, 18, 16);
+        ctx.fillStyle = 'rgba(236,178,46,0.28)';
+        ctx.fillRect(mp.x - 7, mp.y - 24, 14, 12);
+      });
+
+      // Michael's fancy desk
+      drawBox(ctx, 9.8, 0.6, 1.2, 0.7, 12, '#5A4A34', '#4A3A24', '#4A3A24');
+
+      // Reception desk
+      drawBox(ctx, 4.8, 5.2, 1.0, 0.6, 12, '#3A3028', '#2A2018', '#2A2018');
+      drawBox(ctx, 5.8, 5.0, 0.8, 0.6, 12, '#3A3028', '#2A2018', '#2A2018');
+
+      // Whiteboard
+      drawBox(ctx, 0.05, 4.2, 0.08, 0.8, 20, '#F0E8D0', '#D0C8B0', '#D0C8B0');
+      var wb = iso(0.1, 4.5);
+      ctx.fillStyle = '#4A7ABA';
+      ctx.fillRect(wb.x, wb.y - 30, 3, 2);
+      ctx.fillRect(wb.x + 1, wb.y - 26, 2, 2);
+      ctx.fillStyle = '#4ABA6A';
+      ctx.fillRect(wb.x + 2, wb.y - 22, 4, 2);
+
+      // Water cooler
+      drawBox(ctx, 7.3, 6.3, 0.3, 0.3, 16, '#4A7A9B', '#3A6A8B', '#3A6A8B');
+      var wcTop = iso(7.45, 6.45);
+      ctx.fillStyle = '#7ABADB';
+      ctx.fillRect(wcTop.x - 3, wcTop.y - 20, 6, 6);
+
+      // ── ROOM LABELS ──────────────────────────────────
+      ctx.save();
+      ctx.font = '6px "Press Start 2P", monospace';
+      ctx.textAlign = 'center';
+
+      var confLabel = iso(1.5, 2.6);
+      ctx.fillStyle = 'rgba(236,178,46,0.7)';
+      ctx.fillText('CONF ROOM', confLabel.x, confLabel.y);
+
+      var mLabel = iso(10.5, 2.6);
+      ctx.fillStyle = 'rgba(236,178,46,0.7)';
+      ctx.fillText("MICHAEL'S", mLabel.x, mLabel.y);
+      ctx.fillText('OFFICE', mLabel.x, mLabel.y + 10);
+
+      var recLabel = iso(5.5, 6.4);
+      ctx.fillStyle = 'rgba(168,152,112,0.5)';
+      ctx.font = '5px "Press Start 2P", monospace';
+      ctx.fillText('RECEPTION', recLabel.x, recLabel.y);
+
+      ctx.restore();
+
+      // ── CHARACTERS + BUBBLES (sorted by x+y) ─────────
+      var sortedChars = CHARS.slice().sort(function(a, b) {
+        return (a.x + a.y) - (b.x + b.y);
+      });
+
+      sortedChars.forEach(function(ch) {
+        ctx.save();
+        drawChar(ctx, ch);
+        ctx.restore();
+      });
+
+      bubbles.forEach(function(b) {
+        drawBubble(ctx, b);
+      });
+    }
+
+    // ── UPDATE ───────────────────────────────────────────
+    function update(dt) {
+      CHARS.forEach(function(ch) { updateChar(ch, dt); });
+
+      bubbles = bubbles.filter(function(b) {
+        b.age += dt;
+        return b.age < b.duration;
+      });
+    }
+
+    // ── ANIMATION LOOP ───────────────────────────────────
+    function loop(now) {
+      if (paused) { animHandle = requestAnimationFrame(loop); return; }
+      var dt = Math.min(now - lastTime, 50);
+      lastTime = now;
+      update(dt);
+      var ctx = canvas.getContext('2d');
+      ctx.save();
+      ctx.scale(DPR, DPR);
+      draw(ctx);
+      ctx.restore();
+      animHandle = requestAnimationFrame(loop);
+    }
+
+    document.addEventListener('visibilitychange', function() {
+      paused = document.hidden;
+      if (!paused) lastTime = performance.now();
+    });
+
+    window.addEventListener('resize', function() {
+      resize();
+    });
+
+    resize();
+    lastTime = performance.now();
+    animHandle = requestAnimationFrame(loop);
+
+  })(); // end isometric scene IIFE
+
+})();
+</script>
+<script>
+var x0=["BN","BN","BN","BN","BN","BN","BN","BN","BN","S","B","S","WS","B","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","B","B","B","S","WS","ON","ON","ET","ET","ET","ON","ON","ON","ON","ON","ON","CS","ON","CS","ON","EN","EN","EN","EN","EN","EN","EN","EN","EN","EN","ON","ON","ON","ON","ON","ON","ON","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","ON","ON","ON","ON","ON","ON","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","ON","ON","ON","ON","BN","BN","BN","BN","BN","BN","B","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","BN","CS","ON","ET","ET","ET","ET","ON","ON","ON","ON","L","ON","ON","ON","ON","ON","ET","ET","EN","EN","ON","L","ON","ON","ON","EN","L","ON","ON","ON","ON","ON","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","ON","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","L","ON","L","L","L","L","L","L","L","L"],g0=["AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","CS","AL","ON","ON","NSM","NSM","NSM","NSM","NSM","NSM","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","AL","AL","AL","AL","AL","AL","AL","AN","AN","AN","AN","AN","AN","AN","AN","AN","AN","ET","AN","AN","AL","AL","AL","NSM","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","NSM","ON","NSM","NSM","NSM","NSM","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL","AL"];function m0(O){if(O<=255)return x0[O];if(1424<=O&&O<=1524)return"R";if(1536<=O&&O<=1791)return g0[O&255];if(1792<=O&&O<=2220)return"AL";return"L"}function r0(O){let _=O.length;if(_===0)return null;let J=Array(_),Y=0;for(let V=0;V<_;V++){let $=m0(O.charCodeAt(V));if($==="R"||$==="AL"||$==="AN")Y++;J[V]=$}if(Y===0)return null;let X=_/Y<0.3?0:1,R=new Int8Array(_);for(let V=0;V<_;V++)R[V]=X;let Z=X&1?"R":"L",Q=Z,f=Q;for(let V=0;V<_;V++)if(J[V]==="NSM")J[V]=f;else f=J[V];f=Q;for(let V=0;V<_;V++){let $=J[V];if($==="EN")J[V]=f==="AL"?"AN":"EN";else if($==="R"||$==="L"||$==="AL")f=$}for(let V=0;V<_;V++)if(J[V]==="AL")J[V]="R";for(let V=1;V<_-1;V++){if(J[V]==="ES"&&J[V-1]==="EN"&&J[V+1]==="EN")J[V]="EN";if(J[V]==="CS"&&(J[V-1]==="EN"||J[V-1]==="AN")&&J[V+1]===J[V-1])J[V]=J[V-1]}for(let V=0;V<_;V++){if(J[V]!=="EN")continue;let $;for($=V-1;$>=0&&J[$]==="ET";$--)J[$]="EN";for($=V+1;$<_&&J[$]==="ET";$++)J[$]="EN"}for(let V=0;V<_;V++){let $=J[V];if($==="WS"||$==="ES"||$==="ET"||$==="CS")J[V]="ON"}f=Q;for(let V=0;V<_;V++){let $=J[V];if($==="EN")J[V]=f==="L"?"L":"EN";else if($==="R"||$==="L")f=$}for(let V=0;V<_;V++){if(J[V]!=="ON")continue;let $=V+1;while($<_&&J[$]==="ON")$++;let u=V>0?J[V-1]:Q,q=$<_?J[$]:Q,D=u!=="L"?"R":"L";if(D===(q!=="L"?"R":"L"))for(let K=V;K<$;K++)J[K]=D;V=$-1}for(let V=0;V<_;V++)if(J[V]==="ON")J[V]=Z;for(let V=0;V<_;V++){let $=J[V];if((R[V]&1)===0){if($==="R")R[V]++;else if($==="AN"||$==="EN")R[V]+=2}else if($==="L"||$==="AN"||$==="EN")R[V]++}return R}function u0(O,_){let J=r0(O);if(J===null)return null;let Y=new Int8Array(_.length);for(let X=0;X<_.length;X++)Y[X]=J[_[X]];return Y}var a0=/[ \t\n\r\f]+/g,s0=/[\t\n\r\f]| {2,}|^ | $/;function d0(O){let _=O??"normal";return _==="pre-wrap"?{mode:_,preserveOrdinarySpaces:!0,preserveHardBreaks:!0}:{mode:_,preserveOrdinarySpaces:!1,preserveHardBreaks:!1}}function i0(O){if(!s0.test(O))return O;let _=O.replace(a0," ");if(_.charCodeAt(0)===32)_=_.slice(1);if(_.length>0&&_.charCodeAt(_.length-1)===32)_=_.slice(0,-1);return _}function t0(O){if(!/[\r\f]/.test(O))return O.replace(/\r\n/g,`
+`);return O.replace(/\r\n/g,`
+`).replace(/[\r\f]/g,`
+`)}var d=null,V0;function n0(){if(d===null)d=new Intl.Segmenter(V0,{granularity:"word"});return d}function z0(){d=null}function j0(O){let _=O&&O.length>0?O:void 0;if(V0===_)return;V0=_,d=null}var e0=/\p{Script=Arabic}/u,O0=/\p{M}/u,b0=/\p{Nd}/u;function X0(O){return e0.test(O)}function p(O){for(let _ of O){let J=_.codePointAt(0);if(J>=19968&&J<=40959||J>=13312&&J<=19903||J>=131072&&J<=173791||J>=173824&&J<=177983||J>=177984&&J<=178207||J>=178208&&J<=183983||J>=183984&&J<=191471||J>=196608&&J<=201551||J>=63744&&J<=64255||J>=194560&&J<=195103||J>=12288&&J<=12351||J>=12352&&J<=12447||J>=12448&&J<=12543||J>=44032&&J<=55215||J>=65280&&J<=65519)return!0}return!1}var $0=new Set(["，","．","！","：","；","？","、","。","・","）","〕","〉","》","」","』","】","〗","〙","〛","ー","々","〻","ゝ","ゞ","ヽ","ヾ"]),i=new Set(['"',"(","[","{","“","‘","«","‹","（","〔","〈","《","「","『","【","〖","〘","〚"]),Q0=new Set(["'","’"]),r=new Set([".",",","!","?",":",";","،","؛","؟","।","॥","၊","။","၌","၍","၏",")","]","}","%",'"',"”","’","»","›","…"]),OO=new Set([":",".","،","؛"]),_O=new Set(["၏"]),JO=new Set(["”","’","»","›","」","』","】","》","〉","〕","）"]);function RO(O){if(q0(O))return!0;let _=!1;for(let J of O){if(r.has(J)){_=!0;continue}if(_&&O0.test(J))continue;return!1}return _}function VO(O){for(let _ of O)if(!$0.has(_)&&!r.has(_))return!1;return O.length>0}function XO(O){if(q0(O))return!0;for(let _ of O)if(!i.has(_)&&!Q0.has(_)&&!O0.test(_))return!1;return O.length>0}function q0(O){let _=!1;for(let J of O){if(J==="\\"||O0.test(J))continue;if(i.has(J)||r.has(J)||Q0.has(J)){_=!0;continue}return!1}return _}function YO(O){let _=Array.from(O),J=_.length;while(J>0){let Y=_[J-1];if(O0.test(Y)){J--;continue}if(i.has(Y)||Q0.has(Y)){J--;continue}break}if(J<=0||J===_.length)return null;return{head:_.slice(0,J).join(""),tail:_.slice(J).join("")}}function ZO(O,_){if(O.length===0)return!1;for(let J of O)if(J!==_)return!1;return!0}function $O(O){if(!X0(O)||O.length===0)return!1;return OO.has(O[O.length-1])}function QO(O){if(O.length===0)return!1;return _O.has(O[O.length-1])}function qO(O){if(O.length<2||O[0]!==" ")return null;let _=O.slice(1);if(/^\p{M}+$/u.test(_))return{space:" ",marks:_};return null}function D0(O){for(let _=O.length-1;_>=0;_--){let J=O[_];if(JO.has(J))return!0;if(!r.has(J))return!1}return!1}function DO(O,_){if(_.preserveOrdinarySpaces||_.preserveHardBreaks){if(O===" ")return"preserved-space";if(O==="\t")return"tab";if(_.preserveHardBreaks&&O===`
+`)return"hard-break"}if(O===" ")return"space";if(O===" "||O===" "||O==="⁠"||O==="\uFEFF")return"glue";if(O==="​")return"zero-width-break";if(O==="­")return"soft-hyphen";return"text"}function NO(O,_,J,Y){let X=[],R=null,Z="",Q=J,f=!1,V=0;for(let $ of O){let u=DO($,Y),q=u==="text"&&_;if(R!==null&&u===R&&q===f){Z+=$,V+=$.length;continue}if(R!==null)X.push({text:Z,isWordLike:f,kind:R,start:Q});R=u,Z=$,Q=J+V,f=q,V+=$.length}if(R!==null)X.push({text:Z,isWordLike:f,kind:R,start:Q});return X}function Y0(O){return O==="space"||O==="preserved-space"||O==="zero-width-break"||O==="hard-break"}var fO=/^[A-Za-z][A-Za-z0-9+.-]*:$/;function HO(O,_){let J=O.texts[_];if(J.startsWith("www."))return!0;return fO.test(J)&&_+1<O.len&&O.kinds[_+1]==="text"&&O.texts[_+1]==="//"}function UO(O){return O.includes("?")&&(O.includes("://")||O.startsWith("www."))}function MO(O){let _=O.texts.slice(),J=O.isWordLike.slice(),Y=O.kinds.slice(),X=O.starts.slice();for(let Z=0;Z<O.len;Z++){if(Y[Z]!=="text"||!HO(O,Z))continue;let Q=Z+1;while(Q<O.len&&!Y0(Y[Q])){_[Z]+=_[Q],J[Z]=!0;let f=_[Q].includes("?");if(Y[Q]="text",_[Q]="",Q++,f)break}}let R=0;for(let Z=0;Z<_.length;Z++){let Q=_[Z];if(Q.length===0)continue;if(R!==Z)_[R]=Q,J[R]=J[Z],Y[R]=Y[Z],X[R]=X[Z];R++}return _.length=R,J.length=R,Y.length=R,X.length=R,{len:R,texts:_,isWordLike:J,kinds:Y,starts:X}}function CO(O){let _=[],J=[],Y=[],X=[];for(let R=0;R<O.len;R++){let Z=O.texts[R];if(_.push(Z),J.push(O.isWordLike[R]),Y.push(O.kinds[R]),X.push(O.starts[R]),!UO(Z))continue;let Q=R+1;if(Q>=O.len||Y0(O.kinds[Q]))continue;let f="",V=O.starts[Q],$=Q;while($<O.len&&!Y0(O.kinds[$]))f+=O.texts[$],$++;if(f.length>0)_.push(f),J.push(!0),Y.push("text"),X.push(V),R=$-1}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}var FO=new Set([":","-","/","×",",",".","+","–","—"]),K0=/^[A-Za-z0-9_]+[,:;]*$/,vO=/[,:;]+$/;function E0(O){for(let _ of O)if(b0.test(_))return!0;return!1}function Z0(O){if(O.length===0)return!1;for(let _ of O){if(b0.test(_)||FO.has(_))continue;return!1}return!0}function uO(O){let _=[],J=[],Y=[],X=[];for(let R=0;R<O.len;R++){let Z=O.texts[R],Q=O.kinds[R];if(Q==="text"&&Z0(Z)&&E0(Z)){let f=Z,V=R+1;while(V<O.len&&O.kinds[V]==="text"&&Z0(O.texts[V]))f+=O.texts[V],V++;_.push(f),J.push(!0),Y.push("text"),X.push(O.starts[R]),R=V-1;continue}_.push(Z),J.push(O.isWordLike[R]),Y.push(Q),X.push(O.starts[R])}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}function KO(O){let _=[],J=[],Y=[],X=[];for(let R=0;R<O.len;R++){let Z=O.texts[R],Q=O.kinds[R],f=O.isWordLike[R];if(Q==="text"&&f&&K0.test(Z)){let V=Z,$=R+1;while(vO.test(V)&&$<O.len&&O.kinds[$]==="text"&&O.isWordLike[$]&&K0.test(O.texts[$]))V+=O.texts[$],$++;_.push(V),J.push(!0),Y.push("text"),X.push(O.starts[R]),R=$-1;continue}_.push(Z),J.push(f),Y.push(Q),X.push(O.starts[R])}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}function zO(O){let _=[],J=[],Y=[],X=[];for(let R=0;R<O.len;R++){let Z=O.texts[R];if(O.kinds[R]==="text"&&Z.includes("-")){let Q=Z.split("-"),f=Q.length>1;for(let V=0;V<Q.length;V++){let $=Q[V];if(!f)break;if($.length===0||!E0($)||!Z0($))f=!1}if(f){let V=0;for(let $=0;$<Q.length;$++){let u=Q[$],q=$<Q.length-1?`${u}-`:u;_.push(q),J.push(!0),Y.push("text"),X.push(O.starts[R]+V),V+=q.length}continue}}_.push(Z),J.push(O.isWordLike[R]),Y.push(O.kinds[R]),X.push(O.starts[R])}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}function jO(O){let _=[],J=[],Y=[],X=[],R=0;while(R<O.len){let Z=O.texts[R],Q=O.isWordLike[R],f=O.kinds[R],V=O.starts[R];if(f==="glue"){let $=Z,u=V;R++;while(R<O.len&&O.kinds[R]==="glue")$+=O.texts[R],R++;if(R<O.len&&O.kinds[R]==="text")Z=$+O.texts[R],Q=O.isWordLike[R],f="text",V=u,R++;else{_.push($),J.push(!1),Y.push("glue"),X.push(u);continue}}else R++;if(f==="text")while(R<O.len&&O.kinds[R]==="glue"){let $="";while(R<O.len&&O.kinds[R]==="glue")$+=O.texts[R],R++;if(R<O.len&&O.kinds[R]==="text"){Z+=$+O.texts[R],Q=Q||O.isWordLike[R],R++;continue}Z+=$}_.push(Z),J.push(Q),Y.push(f),X.push(V)}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}function bO(O){let _=O.texts.slice(),J=O.isWordLike.slice(),Y=O.kinds.slice(),X=O.starts.slice();for(let R=0;R<_.length-1;R++){if(Y[R]!=="text"||Y[R+1]!=="text")continue;if(!p(_[R])||!p(_[R+1]))continue;let Z=YO(_[R]);if(Z===null)continue;_[R]=Z.head,_[R+1]=Z.tail+_[R+1],X[R+1]=X[R]+Z.head.length}return{len:_.length,texts:_,isWordLike:J,kinds:Y,starts:X}}function EO(O,_,J){let Y=n0(),X=0,R=[],Z=[],Q=[],f=[];for(let q of Y.segment(O))for(let D of NO(q.segment,q.isWordLike??!1,q.index,J)){let b=D.kind==="text";if(_.carryCJKAfterClosingQuote&&b&&X>0&&Q[X-1]==="text"&&p(D.text)&&p(R[X-1])&&D0(R[X-1]))R[X-1]+=D.text,Z[X-1]=Z[X-1]||D.isWordLike;else if(b&&X>0&&Q[X-1]==="text"&&VO(D.text)&&p(R[X-1]))R[X-1]+=D.text,Z[X-1]=Z[X-1]||D.isWordLike;else if(b&&X>0&&Q[X-1]==="text"&&QO(R[X-1]))R[X-1]+=D.text,Z[X-1]=Z[X-1]||D.isWordLike;else if(b&&X>0&&Q[X-1]==="text"&&D.isWordLike&&X0(D.text)&&$O(R[X-1]))R[X-1]+=D.text,Z[X-1]=!0;else if(b&&!D.isWordLike&&X>0&&Q[X-1]==="text"&&D.text.length===1&&D.text!=="-"&&D.text!=="—"&&ZO(R[X-1],D.text))R[X-1]+=D.text;else if(b&&!D.isWordLike&&X>0&&Q[X-1]==="text"&&(RO(D.text)||D.text==="-"&&Z[X-1]))R[X-1]+=D.text;else R[X]=D.text,Z[X]=D.isWordLike,Q[X]=D.kind,f[X]=D.start,X++}for(let q=1;q<X;q++)if(Q[q]==="text"&&!Z[q]&&q0(R[q])&&Q[q-1]==="text")R[q-1]+=R[q],Z[q-1]=Z[q-1]||Z[q],R[q]="";for(let q=X-2;q>=0;q--)if(Q[q]==="text"&&!Z[q]&&XO(R[q])){let D=q+1;while(D<X&&R[D]==="")D++;if(D<X&&Q[D]==="text")R[D]=R[q]+R[D],f[D]=f[q],R[q]=""}let V=0;for(let q=0;q<X;q++){let D=R[q];if(D.length===0)continue;if(V!==q)R[V]=D,Z[V]=Z[q],Q[V]=Q[q],f[V]=f[q];V++}R.length=V,Z.length=V,Q.length=V,f.length=V;let $=jO({len:V,texts:R,isWordLike:Z,kinds:Q,starts:f}),u=bO(KO(zO(uO(CO(MO($))))));for(let q=0;q<u.len-1;q++){let D=qO(u.texts[q]);if(D===null)continue;if(u.kinds[q]!=="space"&&u.kinds[q]!=="preserved-space"||u.kinds[q+1]!=="text"||!X0(u.texts[q+1]))continue;u.texts[q]=D.space,u.isWordLike[q]=!1,u.kinds[q]=u.kinds[q]==="preserved-space"?"preserved-space":"space",u.texts[q+1]=D.marks+u.texts[q+1],u.starts[q+1]=u.starts[q]+D.space.length}return u}function GO(O,_){if(O.len===0)return[];if(!_.preserveHardBreaks)return[{startSegmentIndex:0,endSegmentIndex:O.len,consumedEndSegmentIndex:O.len}];let J=[],Y=0;for(let X=0;X<O.len;X++){if(O.kinds[X]!=="hard-break")continue;J.push({startSegmentIndex:Y,endSegmentIndex:X,consumedEndSegmentIndex:X+1}),Y=X+1}if(Y<O.len)J.push({startSegmentIndex:Y,endSegmentIndex:O.len,consumedEndSegmentIndex:O.len});return J}function N0(O,_,J="normal"){let Y=d0(J),X=Y.mode==="pre-wrap"?t0(O):i0(O);if(X.length===0)return{normalized:X,chunks:[],len:0,texts:[],isWordLike:[],kinds:[],starts:[]};let R=EO(X,_,Y);return{normalized:X,chunks:GO(R,Y),...R}}var a=null,f0=new Map,s=null,PO=/\p{Emoji_Presentation}/u,AO=/[\p{Emoji_Presentation}\p{Extended_Pictographic}\p{Regional_Indicator}\uFE0F\u20E3]/u,_0=null,H0=new Map;function U0(){if(a!==null)return a;if(typeof OffscreenCanvas<"u")return a=new OffscreenCanvas(1,1).getContext("2d"),a;if(typeof document<"u")return a=document.createElement("canvas").getContext("2d"),a;throw Error("Text measurement requires OffscreenCanvas or a DOM canvas context.")}function BO(O){let _=f0.get(O);if(!_)_=new Map,f0.set(O,_);return _}function x(O,_){let J=_.get(O);if(J===void 0)J={width:U0().measureText(O).width,containsCJK:p(O)},_.set(O,J);return J}function h(){if(s!==null)return s;if(typeof navigator>"u")return s={lineFitEpsilon:0.005,carryCJKAfterClosingQuote:!1,preferPrefixWidthsForBreakableRuns:!1,preferEarlySoftHyphenBreak:!1},s;let O=navigator.userAgent,J=navigator.vendor==="Apple Computer, Inc."&&O.includes("Safari/")&&!O.includes("Chrome/")&&!O.includes("Chromium/")&&!O.includes("CriOS/")&&!O.includes("FxiOS/")&&!O.includes("EdgiOS/"),Y=O.includes("Chrome/")||O.includes("Chromium/")||O.includes("CriOS/")||O.includes("Edg/");return s={lineFitEpsilon:J?0.015625:0.005,carryCJKAfterClosingQuote:Y,preferPrefixWidthsForBreakableRuns:J,preferEarlySoftHyphenBreak:J},s}function TO(O){let _=O.match(/(\d+(?:\.\d+)?)\s*px/);return _?parseFloat(_[1]):16}function M0(){if(_0===null)_0=new Intl.Segmenter(void 0,{granularity:"grapheme"});return _0}function wO(O){return PO.test(O)||O.includes("️")}function G0(O){return AO.test(O)}function yO(O,_){let J=H0.get(O);if(J!==void 0)return J;let Y=U0();Y.font=O;let X=Y.measureText("\uD83D\uDE00").width;if(J=0,X>_+0.5&&typeof document<"u"&&document.body!==null){let R=document.createElement("span");R.style.font=O,R.style.display="inline-block",R.style.visibility="hidden",R.style.position="absolute",R.textContent="\uD83D\uDE00",document.body.appendChild(R);let Z=R.getBoundingClientRect().width;if(document.body.removeChild(R),X-Z>0.5)J=X-Z}return H0.set(O,J),J}function LO(O){let _=0,J=M0();for(let Y of J.segment(O))if(wO(Y.segment))_++;return _}function WO(O,_){if(_.emojiCount===void 0)_.emojiCount=LO(O);return _.emojiCount}function g(O,_,J){if(J===0)return _.width;return _.width-WO(O,_)*J}function P0(O,_,J,Y){if(_.graphemeWidths!==void 0)return _.graphemeWidths;let X=[],R=M0();for(let Z of R.segment(O)){let Q=x(Z.segment,J);X.push(g(Z.segment,Q,Y))}return _.graphemeWidths=X.length>1?X:null,_.graphemeWidths}function A0(O,_,J,Y){if(_.graphemePrefixWidths!==void 0)return _.graphemePrefixWidths;let X=[],R=M0(),Z="";for(let Q of R.segment(O)){Z+=Q.segment;let f=x(Z,J);X.push(g(Z,f,Y))}return _.graphemePrefixWidths=X.length>1?X:null,_.graphemePrefixWidths}function B0(O,_){let J=U0();J.font=O;let Y=BO(O),X=TO(O),R=_?yO(O,X):0;return{cache:Y,fontSize:X,emojiCorrection:R}}function T0(){f0.clear(),H0.clear(),_0=null}function m(O){return O==="space"||O==="preserved-space"||O==="tab"||O==="zero-width-break"||O==="soft-hyphen"}function SO(O){return O==="space"}function w0(O,_){if(_<=0)return 0;let J=O%_;if(Math.abs(J)<=0.000001)return _;return _-J}function t(O,_,J,Y){if(!Y||_===null)return O[J];return _[J]-(J>0?_[J-1]:0)}function y0(O,_,J,Y,X,R){let Z=0,Q=_;while(Z<O.length){let f=R?_+O[Z]:Q+O[Z];if((Z+1<O.length?f+X:f)>J+Y)break;Q=f,Z++}return{fitCount:Z,fittedWidth:Q}}function L0(O,_){for(let J=0;J<O.chunks.length;J++){let Y=O.chunks[J];if(_<Y.consumedEndSegmentIndex)return J}return-1}function kO(O,_){let{segmentIndex:J,graphemeIndex:Y}=_;if(J>=O.widths.length)return null;if(Y>0)return _;let X=L0(O,J);if(X<0)return null;let R=O.chunks[X];if(R.startSegmentIndex===R.endSegmentIndex&&J===R.startSegmentIndex)return{segmentIndex:J,graphemeIndex:0};if(J<R.startSegmentIndex)J=R.startSegmentIndex;while(J<R.endSegmentIndex){let Z=O.kinds[J];if(Z!=="space"&&Z!=="zero-width-break"&&Z!=="soft-hyphen")return{segmentIndex:J,graphemeIndex:0};J++}if(R.consumedEndSegmentIndex>=O.widths.length)return null;return{segmentIndex:R.consumedEndSegmentIndex,graphemeIndex:0}}function W0(O,_){if(O.simpleLineWalkFastPath)return IO(O,_);return J0(O,_)}function IO(O,_){let{widths:J,kinds:Y,breakableWidths:X,breakablePrefixWidths:R}=O;if(J.length===0)return 0;let Z=h(),Q=Z.lineFitEpsilon,f=0,V=0,$=!1;function u(q){let D=J[q];if(D>_&&X[q]!==null){let b=X[q],K=R[q]??null;V=0;for(let j=0;j<b.length;j++){let B=t(b,K,j,Z.preferPrefixWidthsForBreakableRuns);if(V>0&&V+B>_+Q)f++,V=B;else{if(V===0)f++;V+=B}}}else V=D,f++;$=!0}for(let q=0;q<J.length;q++){let D=J[q],b=Y[q];if(!$){u(q);continue}let K=V+D;if(K>_+Q){if(SO(b))continue;V=0,$=!1,u(q);continue}V=K}if(!$)return f+1;return f}function cO(O,_,J){let{widths:Y,kinds:X,breakableWidths:R,breakablePrefixWidths:Z}=O;if(Y.length===0)return 0;let Q=h(),f=Q.lineFitEpsilon,V=0,$=0,u=!1,q=0,D=0,b=0,K=0,j=-1,B=0;function k(){j=-1,B=0}function y(H=b,z=K,W=$){V++,J?.({startSegmentIndex:q,startGraphemeIndex:D,endSegmentIndex:H,endGraphemeIndex:z,width:W}),$=0,u=!1,k()}function A(H,z){u=!0,q=H,D=0,b=H+1,K=0,$=z}function T(H,z,W){u=!0,q=H,D=z,b=H,K=z+1,$=W}function L(H,z){if(!u){A(H,z);return}$+=z,b=H+1,K=0}function C(H,z){if(!m(X[H]))return;j=H+1,B=$-z}function F(H){P(H,0)}function P(H,z){let W=R[H],c=Z[H]??null;for(let I=z;I<W.length;I++){let o=t(W,c,I,Q.preferPrefixWidthsForBreakableRuns);if(!u){T(H,I,o);continue}if($+o>_+f)y(),T(H,I,o);else $+=o,b=H,K=I+1}if(u&&b===H&&K===W.length)b=H+1,K=0}let E=0;while(E<Y.length){let H=Y[E],z=X[E];if(!u){if(H>_&&R[E]!==null)F(E);else A(E,H);C(E,H),E++;continue}if($+H>_+f){if(m(z)){L(E,H),y(E+1,0,$-H),E++;continue}if(j>=0){y(j,0,B);continue}if(H>_&&R[E]!==null){y(),F(E),E++;continue}y();continue}L(E,H),C(E,H),E++}if(u)y();return V}function J0(O,_,J){if(O.simpleLineWalkFastPath)return cO(O,_,J);let{widths:Y,lineEndFitAdvances:X,lineEndPaintAdvances:R,kinds:Z,breakableWidths:Q,breakablePrefixWidths:f,discretionaryHyphenWidth:V,tabStopAdvance:$,chunks:u}=O;if(Y.length===0||u.length===0)return 0;let q=h(),D=q.lineFitEpsilon,b=0,K=0,j=!1,B=0,k=0,y=0,A=0,T=-1,L=0,C=0,F=null;function P(){T=-1,L=0,C=0,F=null}function E(N=y,M=A,v=K){b++,J?.({startSegmentIndex:B,startGraphemeIndex:k,endSegmentIndex:N,endGraphemeIndex:M,width:v}),K=0,j=!1,P()}function H(N,M){j=!0,B=N,k=0,y=N+1,A=0,K=M}function z(N,M,v){j=!0,B=N,k=M,y=N,A=M+1,K=v}function W(N,M){if(!j){H(N,M);return}K+=M,y=N+1,A=0}function c(N,M){if(!m(Z[N]))return;let v=Z[N]==="tab"?0:X[N],w=Z[N]==="tab"?M:R[N];T=N+1,L=K-M+v,C=K-M+w,F=Z[N]}function I(N){o(N,0)}function o(N,M){let v=Q[N],w=f[N]??null;for(let G=M;G<v.length;G++){let l=t(v,w,G,q.preferPrefixWidthsForBreakableRuns);if(!j){z(N,G,l);continue}if(K+l>_+D)E(),z(N,G,l);else K+=l,y=N,A=G+1}if(j&&y===N&&A===v.length)y=N+1,A=0}function S(N){if(F!=="soft-hyphen")return!1;let M=Q[N];if(M===null)return!1;let v=q.preferPrefixWidthsForBreakableRuns?f[N]??M:M,w=v!==M,{fitCount:G,fittedWidth:l}=y0(v,K,_,D,V,w);if(G===0)return!1;if(K=l,y=N,A=G,P(),G===M.length)return y=N+1,A=0,!0;return E(N,G,l+V),o(N,G),!0}function U(N){b++,J?.({startSegmentIndex:N.startSegmentIndex,startGraphemeIndex:0,endSegmentIndex:N.consumedEndSegmentIndex,endGraphemeIndex:0,width:0}),P()}for(let N=0;N<u.length;N++){let M=u[N];if(M.startSegmentIndex===M.endSegmentIndex){U(M);continue}j=!1,K=0,B=M.startSegmentIndex,k=0,y=M.startSegmentIndex,A=0,P();let v=M.startSegmentIndex;while(v<M.endSegmentIndex){let w=Z[v],G=w==="tab"?w0(K,$):Y[v];if(w==="soft-hyphen"){if(j)y=v+1,A=0,T=v+1,L=K+V,C=K+V,F=w;v++;continue}if(!j){if(G>_&&Q[v]!==null)I(v);else H(v,G);c(v,G),v++;continue}if(K+G>_+D){let n=K+(w==="tab"?0:X[v]),e=K+(w==="tab"?G:R[v]);if(F==="soft-hyphen"&&q.preferEarlySoftHyphenBreak&&L<=_+D){E(T,0,C);continue}if(F==="soft-hyphen"&&S(v)){v++;continue}if(m(w)&&n<=_+D){W(v,G),E(v+1,0,e),v++;continue}if(T>=0&&L<=_+D){E(T,0,C);continue}if(G>_&&Q[v]!==null){E(),I(v),v++;continue}E();continue}W(v,G),c(v,G),v++}if(j){let w=T===M.consumedEndSegmentIndex?C:K;E(M.consumedEndSegmentIndex,0,w)}}return b}function S0(O,_,J){let Y=kO(O,_);if(Y===null)return null;if(O.simpleLineWalkFastPath)return oO(O,Y,J);let X=L0(O,Y.segmentIndex);if(X<0)return null;let R=O.chunks[X];if(R.startSegmentIndex===R.endSegmentIndex)return{startSegmentIndex:R.startSegmentIndex,startGraphemeIndex:0,endSegmentIndex:R.consumedEndSegmentIndex,endGraphemeIndex:0,width:0};let{widths:Z,lineEndFitAdvances:Q,lineEndPaintAdvances:f,kinds:V,breakableWidths:$,breakablePrefixWidths:u,discretionaryHyphenWidth:q,tabStopAdvance:D}=O,b=h(),K=b.lineFitEpsilon,j=0,B=!1,k=Y.segmentIndex,y=Y.graphemeIndex,A=k,T=y,L=-1,C=0,F=0,P=null;function E(){L=-1,C=0,F=0,P=null}function H(U=A,N=T,M=j){if(!B)return null;return{startSegmentIndex:k,startGraphemeIndex:y,endSegmentIndex:U,endGraphemeIndex:N,width:M}}function z(U,N){B=!0,A=U+1,T=0,j=N}function W(U,N,M){B=!0,A=U,T=N+1,j=M}function c(U,N){if(!B){z(U,N);return}j+=N,A=U+1,T=0}function I(U,N){if(!m(V[U]))return;let M=V[U]==="tab"?0:Q[U],v=V[U]==="tab"?N:f[U];L=U+1,C=j-N+M,F=j-N+v,P=V[U]}function o(U,N){let M=$[U],v=u[U]??null;for(let w=N;w<M.length;w++){let G=t(M,v,w,b.preferPrefixWidthsForBreakableRuns);if(!B){W(U,w,G);continue}if(j+G>J+K)return H();j+=G,A=U,T=w+1}if(B&&A===U&&T===M.length)A=U+1,T=0;return null}function S(U){if(P!=="soft-hyphen"||L<0)return null;let N=$[U]??null;if(N!==null){let M=b.preferPrefixWidthsForBreakableRuns?u[U]??N:N,v=M!==N,{fitCount:w,fittedWidth:G}=y0(M,j,J,K,q,v);if(w===N.length)return j=G,A=U+1,T=0,E(),null;if(w>0)return H(U,w,G+q)}if(C<=J+K)return H(L,0,F);return null}for(let U=Y.segmentIndex;U<R.endSegmentIndex;U++){let N=V[U],M=U===Y.segmentIndex?Y.graphemeIndex:0,v=N==="tab"?w0(j,D):Z[U];if(N==="soft-hyphen"&&M===0){if(B)A=U+1,T=0,L=U+1,C=j+q,F=j+q,P=N;continue}if(!B){if(M>0){let G=o(U,M);if(G!==null)return G}else if(v>J&&$[U]!==null){let G=o(U,0);if(G!==null)return G}else z(U,v);I(U,v);continue}if(j+v>J+K){let G=j+(N==="tab"?0:Q[U]),l=j+(N==="tab"?v:f[U]);if(P==="soft-hyphen"&&b.preferEarlySoftHyphenBreak&&C<=J+K)return H(L,0,F);let n=S(U);if(n!==null)return n;if(m(N)&&G<=J+K)return c(U,v),H(U+1,0,l);if(L>=0&&C<=J+K)return H(L,0,F);if(v>J&&$[U]!==null){let e=H();if(e!==null)return e;let v0=o(U,0);if(v0!==null)return v0}return H()}c(U,v),I(U,v)}if(L===R.consumedEndSegmentIndex&&T===0)return H(R.consumedEndSegmentIndex,0,F);return H(R.consumedEndSegmentIndex,0,j)}function oO(O,_,J){let{widths:Y,kinds:X,breakableWidths:R,breakablePrefixWidths:Z}=O,Q=h(),f=Q.lineFitEpsilon,V=0,$=!1,u=_.segmentIndex,q=_.graphemeIndex,D=u,b=q,K=-1,j=0;function B(C=D,F=b,P=V){if(!$)return null;return{startSegmentIndex:u,startGraphemeIndex:q,endSegmentIndex:C,endGraphemeIndex:F,width:P}}function k(C,F){$=!0,D=C+1,b=0,V=F}function y(C,F,P){$=!0,D=C,b=F+1,V=P}function A(C,F){if(!$){k(C,F);return}V+=F,D=C+1,b=0}function T(C,F){if(!m(X[C]))return;K=C+1,j=V-F}function L(C,F){let P=R[C],E=Z[C]??null;for(let H=F;H<P.length;H++){let z=t(P,E,H,Q.preferPrefixWidthsForBreakableRuns);if(!$){y(C,H,z);continue}if(V+z>J+f)return B();V+=z,D=C,b=H+1}if($&&D===C&&b===P.length)D=C+1,b=0;return null}for(let C=_.segmentIndex;C<Y.length;C++){let F=Y[C],P=X[C],E=C===_.segmentIndex?_.graphemeIndex:0;if(!$){if(E>0){let z=L(C,E);if(z!==null)return z}else if(F>J&&R[C]!==null){let z=L(C,0);if(z!==null)return z}else k(C,F);T(C,F);continue}if(V+F>J+f){if(m(P))return A(C,F),B(C+1,0,V-F);if(K>=0)return B(K,0,j);if(F>J&&R[C]!==null){let z=B();if(z!==null)return z;let W=L(C,0);if(W!==null)return W}return B()}A(C,F),T(C,F)}return B()}var R0=null,C0=new WeakMap;function I0(){if(R0===null)R0=new Intl.Segmenter(void 0,{granularity:"grapheme"});return R0}function lO(O){if(O)return{widths:[],lineEndFitAdvances:[],lineEndPaintAdvances:[],kinds:[],simpleLineWalkFastPath:!0,segLevels:null,breakableWidths:[],breakablePrefixWidths:[],discretionaryHyphenWidth:0,tabStopAdvance:0,chunks:[],segments:[]};return{widths:[],lineEndFitAdvances:[],lineEndPaintAdvances:[],kinds:[],simpleLineWalkFastPath:!0,segLevels:null,breakableWidths:[],breakablePrefixWidths:[],discretionaryHyphenWidth:0,tabStopAdvance:0,chunks:[]}}function c0(O,_,J){let Y=I0(),X=h(),{cache:R,emojiCorrection:Z}=B0(_,G0(O.normalized)),Q=g("-",x("-",R),Z),V=g(" ",x(" ",R),Z)*8;if(O.len===0)return lO(J);let $=[],u=[],q=[],D=[],b=O.chunks.length<=1,K=J?[]:null,j=[],B=[],k=J?[]:null,y=Array.from({length:O.len}),A=Array.from({length:O.len});function T(F,P,E,H,z,W,c,I){if(z!=="text"&&z!=="space"&&z!=="zero-width-break")b=!1;if($.push(P),u.push(E),q.push(H),D.push(z),K?.push(W),j.push(c),B.push(I),k!==null)k.push(F)}for(let F=0;F<O.len;F++){y[F]=$.length;let P=O.texts[F],E=O.isWordLike[F],H=O.kinds[F],z=O.starts[F];if(H==="soft-hyphen"){T(P,0,Q,Q,H,z,null,null),A[F]=$.length;continue}if(H==="hard-break"){T(P,0,0,0,H,z,null,null),A[F]=$.length;continue}if(H==="tab"){T(P,0,0,0,H,z,null,null),A[F]=$.length;continue}let W=x(P,R);if(H==="text"&&W.containsCJK){let S="",U=0;for(let N of Y.segment(P)){let M=N.segment;if(S.length===0){S=M,U=N.index;continue}if(i.has(S)||$0.has(M)||r.has(M)||X.carryCJKAfterClosingQuote&&p(M)&&D0(S)){S+=M;continue}let v=x(S,R),w=g(S,v,Z);T(S,w,w,w,"text",z+U,null,null),S=M,U=N.index}if(S.length>0){let N=x(S,R),M=g(S,N,Z);T(S,M,M,M,"text",z+U,null,null)}A[F]=$.length;continue}let c=g(P,W,Z),I=H==="space"||H==="preserved-space"||H==="zero-width-break"?0:c,o=H==="space"||H==="zero-width-break"?0:c;if(E&&P.length>1){let S=P0(P,W,R,Z),U=X.preferPrefixWidthsForBreakableRuns?A0(P,W,R,Z):null;T(P,c,I,o,H,z,S,U)}else T(P,c,I,o,H,z,null,null);A[F]=$.length}let L=hO(O.chunks,y,A),C=K===null?null:u0(O.normalized,K);if(k!==null)return{widths:$,lineEndFitAdvances:u,lineEndPaintAdvances:q,kinds:D,simpleLineWalkFastPath:b,segLevels:C,breakableWidths:j,breakablePrefixWidths:B,discretionaryHyphenWidth:Q,tabStopAdvance:V,chunks:L,segments:k};return{widths:$,lineEndFitAdvances:u,lineEndPaintAdvances:q,kinds:D,simpleLineWalkFastPath:b,segLevels:C,breakableWidths:j,breakablePrefixWidths:B,discretionaryHyphenWidth:Q,tabStopAdvance:V,chunks:L}}function hO(O,_,J){let Y=[];for(let X=0;X<O.length;X++){let R=O[X],Z=R.startSegmentIndex<_.length?_[R.startSegmentIndex]:J[J.length-1]??0,Q=R.endSegmentIndex<_.length?_[R.endSegmentIndex]:J[J.length-1]??0,f=R.consumedEndSegmentIndex<_.length?_[R.consumedEndSegmentIndex]:J[J.length-1]??0;Y.push({startSegmentIndex:Z,endSegmentIndex:Q,consumedEndSegmentIndex:f})}return Y}function o0(O,_,J,Y){let X=N0(O,h(),Y?.whiteSpace);return c0(X,_,J)}function V1(O,_,J){let Y=performance.now(),X=N0(O,h(),J?.whiteSpace),R=performance.now(),Z=c0(X,_,!1),Q=performance.now(),f=0;for(let V of Z.breakableWidths)if(V!==null)f++;return{analysisMs:R-Y,measureMs:Q-R,totalMs:Q-Y,analysisSegments:X.len,preparedSegments:Z.widths.length,breakableSegments:f}}function X1(O,_,J){return o0(O,_,!1,J)}function Y1(O,_,J){return o0(O,_,!0,J)}function F0(O){return O}function Z1(O,_,J){let Y=W0(F0(O),_);return{lineCount:Y,height:Y*J}}function k0(O,_,J){let Y=J.get(O);if(Y!==void 0)return Y;Y=[];let X=I0();for(let R of X.segment(_[O]))Y.push(R.segment);return J.set(O,Y),Y}function l0(O){let _=C0.get(O);if(_!==void 0)return _;return _=new Map,C0.set(O,_),_}function pO(O,_,J,Y){return Y>0&&O[Y-1]==="soft-hyphen"&&!(_===Y&&J>0)}function xO(O,_,J,Y,X,R,Z){let Q="",f=pO(_,Y,X,R);for(let V=Y;V<R;V++){if(_[V]==="soft-hyphen"||_[V]==="hard-break")continue;if(V===Y&&X>0)Q+=k0(V,O,J).slice(X).join("");else Q+=O[V]}if(Z>0){if(f)Q+="-";Q+=k0(R,O,J).slice(Y===R?X:0,Z).join("")}else if(f)Q+="-";return Q}function h0(O,_,J,Y,X,R,Z){return{text:xO(O.segments,O.kinds,_,Y,X,R,Z),width:J,start:{segmentIndex:Y,graphemeIndex:X},end:{segmentIndex:R,graphemeIndex:Z}}}function gO(O,_,J){return h0(O,_,J.width,J.startSegmentIndex,J.startGraphemeIndex,J.endSegmentIndex,J.endGraphemeIndex)}function p0(O){return{width:O.width,start:{segmentIndex:O.startSegmentIndex,graphemeIndex:O.startGraphemeIndex},end:{segmentIndex:O.endSegmentIndex,graphemeIndex:O.endGraphemeIndex}}}function mO(O,_,J){let Y=S0(O,_,J);if(Y===null)return null;return p0(Y)}function rO(O,_){return h0(O,l0(O),_.width,_.start.segmentIndex,_.start.graphemeIndex,_.end.segmentIndex,_.end.graphemeIndex)}function $1(O,_,J){if(O.widths.length===0)return 0;return J0(F0(O),_,(Y)=>{J(p0(Y))})}function Q1(O,_,J){let Y=mO(O,_,J);if(Y===null)return null;return rO(O,Y)}function q1(O,_,J){let Y=[];if(O.widths.length===0)return{lineCount:0,height:0,lines:Y};let X=l0(O),R=J0(F0(O),_,(Z)=>{Y.push(gO(O,X,Z))});return{lineCount:R,height:R*J,lines:Y}}function aO(){z0(),R0=null,C0=new WeakMap,T0()}function D1(O){j0(O),aO()}window._PT={prepare:X1,layout:Z1,prepareWithSegments:Y1,walkLineRanges:$1,layoutNextLine:Q1,layoutWithLines:q1,clearCache:aO,setLocale:D1};;
+
+
+// ── PRETEXT WIRING ─────────────────────────────────────────
+document.fonts.ready.then(function() {
+  var PT = window._PT;
+  if (!PT) return;
+  var els = Array.from(document.querySelectorAll('[data-pretext]'));
+  var prepared = new Map();
+
+  els.forEach(function(el) {
+    var text = el.textContent.trim().replace(/\s+/g, ' ');
+    if (!text) return;
+    var font = getComputedStyle(el).font;
+    try { prepared.set(el, PT.prepare(text, font)); } catch(e) {}
+  });
+
+  function relayout() {
+    prepared.forEach(function(handle, el) {
+      var w = el.clientWidth;
+      var lh = parseFloat(getComputedStyle(el).lineHeight);
+      if (w > 0 && lh > 0 && !isNaN(lh)) {
+        try {
+          var r = PT.layout(handle, w, lh);
+          el.style.minHeight = r.height + 'px';
+        } catch(e) {}
+      }
+    });
+  }
+
+  if (window.ResizeObserver) {
+    new ResizeObserver(relayout).observe(document.body);
+  }
+  window.addEventListener('resize', relayout);
+  relayout();
+});
+
+</script>
 </body>
 </html>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>WUPHF — Your AI team, visible and working.</title>
+  <meta name="description" content="One command. One shared office. CEO, PM, engineers, designer — all visible, arguing, claiming tasks, and shipping work.">
+  <!-- Open Graph -->
+  <meta property="og:title" content="WUPHF">
+  <meta property="og:description" content="A terminal office where your AI team works in the open.">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+  <!-- Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+  <!-- NAV -->
+  <nav class="site-nav">
+    <span class="nav-logo">WUPHF</span>
+    <div class="nav-links">
+      <a href="https://github.com/nex-crm/wuphf" target="_blank" rel="noopener">GitHub</a>
+      <a href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener">Discord</a>
+      <a href="https://github.com/nex-crm/wuphf#get-started" target="_blank" rel="noopener">Docs</a>
+    </div>
+  </nav>
+
+  <!-- OFFICE SCENE -->
+  <div class="scene-wrap" id="sceneWrap">
+    <canvas id="officeCanvas"></canvas>
+  </div>
+  <div class="hint-bar">
+    <span class="hint-arrow">↑</span> click characters for quotes &nbsp;·&nbsp;
+    click the flashing drawer &nbsp;·&nbsp; explore to find hidden messaging
+  </div>
+
+  <!-- INSTALL SECTION -->
+  <section class="install-section">
+    <div class="install-inner">
+      <div class="install-label">one command</div>
+      <div class="install-cmd">
+        <span class="install-prompt">$</span>
+        <span class="install-code">go build -o wuphf ./cmd/wuphf &amp;&amp; ./wuphf</span>
+      </div>
+      <div class="install-note">
+        Requires <a href="https://go.dev/dl/" target="_blank" rel="noopener">Go</a>
+        and <a href="https://docs.anthropic.com/en/docs/claude-code" target="_blank" rel="noopener">Claude Code</a>.
+        Browser opens automatically.
+      </div>
+      <div class="install-ctas">
+        <a href="https://github.com/nex-crm/wuphf" class="btn-pixel" target="_blank" rel="noopener">View on GitHub →</a>
+        <a href="https://discord.gg/gjSySC3PzV" class="btn-pixel btn-secondary" target="_blank" rel="noopener">Join Discord →</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer class="site-footer">
+    <div class="footer-inner">
+      <span class="footer-logo">WUPHF</span>
+      <div class="footer-links">
+        <a href="https://github.com/nex-crm/wuphf" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/nex-crm/wuphf/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
+        <a href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener">Discord</a>
+      </div>
+      <div class="footer-note">
+        Unlike the original WUPHF.com, this one works.
+      </div>
+    </div>
+  </footer>
+
+  <script src="scene.js"></script>
+</body>
+</html>

--- a/website/scene.js
+++ b/website/scene.js
@@ -414,6 +414,57 @@
 
   const charHits = [];
   let activeThought = null;
+  let thoughtTimer  = null;
+
+  // ── Thought bubble ─────────────────────────────────────────────
+  function drawThought(char, centerX, charTopY) {
+    if (!activeThought || activeThought.id !== char.id) return;
+
+    const BW = 210, BH = 82;
+    let bx = Math.min(centerX - 95, W - BW - 10);
+    bx = Math.max(bx, 10);
+    let by = Math.max(charTopY - 90, 5);
+
+    // Panel
+    ctx.fillStyle = C.surface;
+    ctx.fillRect(bx, by, BW, BH);
+    ctx.strokeStyle = C.yellow; ctx.lineWidth = 3;
+    ctx.strokeRect(bx, by, BW, BH);
+
+    // Tail (triangle below panel pointing to character)
+    ctx.beginPath();
+    ctx.moveTo(bx + 20, by + BH);
+    ctx.lineTo(bx + 30, by + BH + 14);
+    ctx.lineTo(bx + 42, by + BH);
+    ctx.closePath();
+    ctx.fillStyle = C.surface; ctx.fill();
+    ctx.strokeStyle = C.yellow; ctx.stroke();
+    // Hide inner line of tail
+    ctx.fillStyle = C.surface; ctx.fillRect(bx + 21, by + BH - 1, 21, 4);
+
+    // Speaker name
+    ctx.fillStyle    = C.yellow;
+    ctx.font = '6px "Press Start 2P"'; ctx.textAlign = 'left'; ctx.textBaseline = 'top';
+    ctx.fillText(char.name, bx + 10, by + 8);
+
+    // Quote (word-wrapped)
+    ctx.fillStyle = C.text;
+    ctx.font = '18px "VT323"'; ctx.textBaseline = 'top';
+    const words  = char.quote.split(' ');
+    let line = '', lineY = by + 22;
+    for (const w of words) {
+      const test = line ? line + ' ' + w : w;
+      if (ctx.measureText(test).width > BW - 20 && line) {
+        ctx.fillText(line, bx + 10, lineY);
+        line  = w;
+        lineY += 18;
+        if (lineY > by + BH - 6) { ctx.fillText(line + '...', bx + 10, lineY - 18); return; }
+      } else {
+        line = test;
+      }
+    }
+    ctx.fillText(line, bx + 10, lineY);
+  }
 
   // ── Main draw ──────────────────────────────────────────────────
   function draw() {
@@ -474,11 +525,41 @@
         ctx.fillText(firstName, c.x, cy - 8);
       }
 
+      drawThought(char, c.x, cy);
+
       charHits.push({ char, cx, cy, w: cw + 4, h: 54 });
     }
   }
 
   function loop() { draw(); requestAnimationFrame(loop); }
   loop();
+
+  canvas.addEventListener('click', e => {
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = W / rect.width;
+    const scaleY = H / rect.height;
+    const mx = (e.clientX - rect.left) * scaleX;
+    const my = (e.clientY - rect.top)  * scaleY;
+
+    // Check characters
+    for (const hit of charHits) {
+      if (mx >= hit.cx && mx <= hit.cx + hit.w &&
+          my >= hit.cy && my <= hit.cy + hit.h) {
+        if (activeThought && activeThought.id === hit.char.id) {
+          activeThought = null;
+        } else {
+          activeThought = hit.char;
+          clearTimeout(thoughtTimer);
+          thoughtTimer = setTimeout(() => {
+            if (activeThought && activeThought.id === hit.char.id) activeThought = null;
+          }, 5000);
+        }
+        return;
+      }
+    }
+
+    // Click elsewhere — dismiss thought bubble
+    activeThought = null;
+  });
 
 })();

--- a/website/scene.js
+++ b/website/scene.js
@@ -1,6 +1,5 @@
 // WUPHF Pixel Office — scene engine
 // Loaded by website/index.html. No dependencies.
-// See DESIGN.md for the full spec.
 
 (function () {
   'use strict';
@@ -9,16 +8,19 @@
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
 
-  // ── Mobile detection ───────────────────────────────────────────
+  // ── Mobile detection ──────────────────────────────────────────
   const isMobile = window.innerWidth < 768;
 
-  // ── Canvas sizing ──────────────────────────────────────────────
-  const W = isMobile ? window.innerWidth : 800;
-  const H = isMobile ? 260 : 460;
-  canvas.width  = W;
-  canvas.height = H;
-  canvas.style.width  = '100%';
-  canvas.style.height = 'auto';
+  // ── Canvas sizing (full viewport, DPR-aware) ──────────────────
+  const W = window.innerWidth;
+  const H = isMobile ? 260 : (window.innerHeight - 44);
+  const DPR = window.devicePixelRatio || 1;
+
+  canvas.width  = Math.round(W * DPR);
+  canvas.height = Math.round(H * DPR);
+  canvas.style.width  = W + 'px';
+  canvas.style.height = H + 'px';
+  ctx.scale(DPR, DPR);
 
   // ── Design tokens ──────────────────────────────────────────────
   const C = {
@@ -47,9 +49,10 @@
   };
 
   // ── Isometric grid ─────────────────────────────────────────────
-  const TW = 60, TH = 30;
-  const OX = 420, OY = 100;
-  const COLS = 9, ROWS = 6;
+  const COLS = 12, ROWS = 8;
+  const TW = 80, TH = 40;
+  const OX = Math.round(W * 0.52);
+  const OY = 150;
 
   function iso(gx, gy) {
     return {
@@ -62,17 +65,113 @@
     return { x: p.x + TW / 2, y: p.y + TH / 2 };
   }
 
-  // ── State ──────────────────────────────────────────────────────
-  let flashOn   = true;
-  let animF     = 0;
-  let drawerHit = null;
-  let drawerOpen = false;
-  const interactHits = [];  // { id, x, y, w, h }
-  let   activeReveal = null; // { id, x, y, content: string[] }
-  let   revealTimer  = null;
-
-  setInterval(() => { flashOn = !flashOn; }, 500);
+  // ── Animation state ────────────────────────────────────────────
+  let animF = 0;
   setInterval(() => { animF = (animF + 1) % 4; }, 280);
+
+  // ── Ambient speech bubble system ───────────────────────────────
+  const ambientMessages = [
+    { charId: 'pam',     text: 'WUPHF!' },
+    { charId: 'ceo',     text: 'One command. One office.' },
+    { charId: 'eng',     text: '$ go build -o wuphf && ./wuphf' },
+    { charId: 'michael', text: "I'm not superstitious, but I am a little stitious." },
+    { charId: 'cmo',     text: 'Open source. MIT license.' },
+    { charId: 'dwight',  text: 'Bears. Beets. Battlestar Galactica.' },
+    { charId: 'ceo',     text: 'Routing task to engineering. ETA: 3 minutes.' },
+    { charId: 'pam',     text: 'CEO, PM, engineers — all visible, all working.' },
+    { charId: 'eng',     text: 'Implementing feature... 47% complete.' },
+    { charId: 'jim',     text: "Unlike Ryan Howard's WUPHF, this one works." },
+    { charId: 'cmo',     text: 'Drafting launch post. You will not believe this lede.' },
+    { charId: 'kevin',   text: '... (stares at snacks)' },
+    { charId: 'creed',   text: 'Nobody steals from Creed Bratton and gets away with it.' },
+  ];
+
+  const activeBubbles = [];
+  const BUBBLE_DURATION = 5000;
+  const BUBBLE_INTERVAL = 2400;
+  let lastBubbleTime = 0;
+  let msgIndex = 0;
+  const charScreenPos = {};
+
+  function updateBubbles(now) {
+    for (let i = activeBubbles.length - 1; i >= 0; i--) {
+      if (now - activeBubbles[i].startTime > BUBBLE_DURATION) activeBubbles.splice(i, 1);
+    }
+    if (activeBubbles.length < 2 && now - lastBubbleTime > BUBBLE_INTERVAL) {
+      const activeIds = new Set(activeBubbles.map(b => b.charId));
+      for (let t = 0; t < ambientMessages.length; t++) {
+        const msg = ambientMessages[msgIndex % ambientMessages.length];
+        msgIndex++;
+        if (!activeIds.has(msg.charId)) {
+          activeBubbles.push({ charId: msg.charId, text: msg.text, startTime: now });
+          lastBubbleTime = now;
+          break;
+        }
+      }
+    }
+  }
+
+  function drawBubble(bubble, now) {
+    const pos = charScreenPos[bubble.charId];
+    if (!pos) return;
+    const age = now - bubble.startTime;
+
+    // Discrete pop-in / pop-out (no smooth easing — steps only)
+    let alpha = 1;
+    if      (age < 100)                        alpha = 0;
+    else if (age < 220)                        alpha = 0.6;
+    else if (age > BUBBLE_DURATION - 220)      alpha = 0.6;
+    else if (age > BUBBLE_DURATION - 100)      alpha = 0;
+    if (alpha === 0) return;
+
+    ctx.globalAlpha = alpha;
+    const BW = 240, BH = 94;
+    let bx = Math.min(pos.centerX - 110, W - BW - 12);
+    bx = Math.max(bx, 12);
+    const by = Math.max(pos.topY - 108, 5);
+
+    // Panel
+    ctx.fillStyle = C.surface;
+    ctx.fillRect(bx, by, BW, BH);
+    ctx.strokeStyle = C.yellow; ctx.lineWidth = 3;
+    ctx.strokeRect(bx, by, BW, BH);
+    // Pixel shadow
+    ctx.fillStyle = C.yellowDark;
+    ctx.fillRect(bx + 4, by + BH, BW, 4);
+    ctx.fillRect(bx + BW, by + 4, 4, BH);
+
+    // Tail
+    ctx.beginPath();
+    ctx.moveTo(bx + 22, by + BH);
+    ctx.lineTo(bx + 33, by + BH + 15);
+    ctx.lineTo(bx + 46, by + BH);
+    ctx.closePath();
+    ctx.fillStyle = C.surface; ctx.fill();
+    ctx.strokeStyle = C.yellow; ctx.stroke();
+    ctx.fillStyle = C.surface; ctx.fillRect(bx + 23, by + BH - 1, 23, 4);
+
+    // Speaker name
+    ctx.fillStyle = C.yellow;
+    ctx.font = '6px "Press Start 2P"'; ctx.textAlign = 'left'; ctx.textBaseline = 'top';
+    const char = CHARS.find(c => c.id === bubble.charId);
+    if (char) ctx.fillText(char.name, bx + 10, by + 9);
+
+    // Quote (VT323, word-wrapped)
+    ctx.fillStyle = C.text;
+    ctx.font = '22px "VT323"'; ctx.textBaseline = 'top';
+    const words = bubble.text.split(' ');
+    let line = '', lineY = by + 24;
+    for (const w of words) {
+      const test = line ? line + ' ' + w : w;
+      if (ctx.measureText(test).width > BW - 22 && line) {
+        ctx.fillText(line, bx + 10, lineY);
+        line = w; lineY += 22;
+        if (lineY > by + BH - 8) { ctx.fillText(line + '...', bx + 10, lineY - 22); break; }
+      } else { line = test; }
+    }
+    ctx.fillText(line, bx + 10, lineY);
+    ctx.globalAlpha = 1;
+  }
 
   // ── Floor tile ─────────────────────────────────────────────────
   function drawFloorTile(gx, gy, color) {
@@ -83,470 +182,303 @@
     ctx.lineTo(p.x + TW / 2, p.y + TH);
     ctx.lineTo(p.x,           p.y + TH / 2);
     ctx.closePath();
-    ctx.fillStyle = color;
-    ctx.fill();
-    ctx.strokeStyle = C.carpetLine;
-    ctx.lineWidth = 0.5;
-    ctx.stroke();
+    ctx.fillStyle = color; ctx.fill();
+    ctx.strokeStyle = C.carpetLine; ctx.lineWidth = 0.5; ctx.stroke();
   }
 
-  // ── Iso box (w tiles wide × d tiles deep × h px tall) ─────────
+  // ── Iso box ────────────────────────────────────────────────────
   function drawIsoBox(gx, gy, w, d, h, top, left, right) {
     const p0 = iso(gx,     gy);
     const pw = iso(gx + w, gy);
     const pd = iso(gx,     gy + d);
     const pf = iso(gx + w, gy + d);
-
-    // top face
     ctx.beginPath();
-    ctx.moveTo(p0.x + TW/2, p0.y - h);
-    ctx.lineTo(pw.x + TW/2, pw.y - h);
-    ctx.lineTo(pf.x + TW/2, pf.y - h);
-    ctx.lineTo(pd.x + TW/2, pd.y - h);
-    ctx.closePath();
-    ctx.fillStyle = top; ctx.fill();
-
-    // left face
+    ctx.moveTo(p0.x + TW/2, p0.y - h); ctx.lineTo(pw.x + TW/2, pw.y - h);
+    ctx.lineTo(pf.x + TW/2, pf.y - h); ctx.lineTo(pd.x + TW/2, pd.y - h);
+    ctx.closePath(); ctx.fillStyle = top; ctx.fill();
     ctx.beginPath();
-    ctx.moveTo(p0.x + TW/2, p0.y - h);
-    ctx.lineTo(pd.x + TW/2, pd.y - h);
-    ctx.lineTo(pd.x + TW/2, pd.y);
-    ctx.lineTo(p0.x + TW/2, p0.y);
-    ctx.closePath();
-    ctx.fillStyle = left; ctx.fill();
-
-    // right face
+    ctx.moveTo(p0.x + TW/2, p0.y - h); ctx.lineTo(pd.x + TW/2, pd.y - h);
+    ctx.lineTo(pd.x + TW/2, pd.y);    ctx.lineTo(p0.x + TW/2, p0.y);
+    ctx.closePath(); ctx.fillStyle = left; ctx.fill();
     ctx.beginPath();
-    ctx.moveTo(pw.x + TW/2, pw.y - h);
-    ctx.lineTo(pf.x + TW/2, pf.y - h);
-    ctx.lineTo(pf.x + TW/2, pf.y);
-    ctx.lineTo(pw.x + TW/2, pw.y);
-    ctx.closePath();
-    ctx.fillStyle = right; ctx.fill();
-  }
-
-  // ── Reveal popup ──────────────────────────────────────────────
-  function drawReveal(x, y, lines) {
-    const PW = 220;
-    const PH = lines.length * 14 + 16;
-    let rx = Math.min(x, W - PW - 8);
-    let ry = Math.max(y - PH - 8, 5);
-
-    ctx.fillStyle = C.surface;
-    ctx.fillRect(rx, ry, PW, PH);
-    ctx.strokeStyle = C.yellow; ctx.lineWidth = 2;
-    ctx.strokeRect(rx, ry, PW, PH);
-
-    ctx.fillStyle    = C.text;
-    ctx.font = '7px "Press Start 2P"'; ctx.textAlign = 'left'; ctx.textBaseline = 'top';
-    lines.forEach((line, i) => {
-      if (line.startsWith('$')) ctx.fillStyle = C.yellow;
-      else if (line.startsWith('//')) ctx.fillStyle = C.blue;
-      else ctx.fillStyle = C.text;
-      ctx.fillText(line, rx + 8, ry + 8 + i * 14);
-    });
-  }
-
-  // ── Mobile scene (2D fallback) ─────────────────────────────────
-  function drawMobileScene() {
-    // Dark background
-    ctx.fillStyle = C.wall; ctx.fillRect(0, 0, W, H);
-
-    // Floor strip (bottom 60px)
-    ctx.fillStyle = C.carpet; ctx.fillRect(0, H - 60, W, 60);
-    ctx.fillStyle = C.carpetLine; ctx.fillRect(0, H - 61, W, 2);
-
-    // Back wall stripe
-    ctx.fillStyle = '#201C14'; ctx.fillRect(0, 0, W, H - 60);
-
-    // WUPHF sign centered
-    const sw = Math.min(280, W - 40), sh = 48;
-    const sx = (W - sw) / 2, sy = 14;
-    ctx.fillStyle = '#0E0C08'; ctx.fillRect(sx, sy, sw, sh);
-    ctx.fillStyle = C.yellow;
-    ctx.fillRect(sx, sy, sw, 3); ctx.fillRect(sx, sy + sh - 3, sw, 3);
-    ctx.fillRect(sx, sy, 3, sh); ctx.fillRect(sx + sw - 3, sy, 3, sh);
-    ctx.shadowColor = C.yellow; ctx.shadowBlur = 10;
-    ctx.fillStyle   = C.yellow;
-    ctx.font = `bold ${Math.floor(sw / 6)}px "Press Start 2P"`;
-    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
-    ctx.fillText('WUPHF', sx + sw / 2, sy + sh / 2);
-    ctx.shadowBlur = 0;
-
-    // Three character silhouettes in a row (Pam, Michael, Dwight)
-    const charY = H - 60;
-    const positions = [W * 0.25, W * 0.5, W * 0.75];
-    const charFns   = [drawPam, drawMichael, drawDwight];
-    for (let i = 0; i < 3; i++) {
-      const cx = positions[i] - 10;
-      const cy = charY - 52;
-      ctx.fillStyle = C.shadow;
-      ctx.beginPath(); ctx.ellipse(positions[i], charY + 2, 11, 5, 0, 0, Math.PI*2); ctx.fill();
-      charFns[i](cx, cy, animF);
-    }
-
-    // Hint text
-    ctx.fillStyle    = C.textMuted;
-    ctx.font = '6px "Press Start 2P"'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
-    ctx.fillText('Best viewed on desktop', W / 2, H - 20);
+    ctx.moveTo(pw.x + TW/2, pw.y - h); ctx.lineTo(pf.x + TW/2, pf.y - h);
+    ctx.lineTo(pf.x + TW/2, pf.y);    ctx.lineTo(pw.x + TW/2, pw.y);
+    ctx.closePath(); ctx.fillStyle = right; ctx.fill();
   }
 
   // ── Back wall ──────────────────────────────────────────────────
   function drawWall() {
-    // Back wall base
     ctx.fillStyle = C.wall;
     ctx.fillRect(0, 0, W, OY + 30);
-
-    // Baseboard strip
     ctx.fillStyle = C.wallLight;
     ctx.fillRect(0, OY + 22, W, 6);
 
-    // Fluorescent light fixtures (4 ceiling-mounted)
-    for (let i = 0; i < 4; i++) {
-      const lx = 60 + i * 170, ly = 6;
-      ctx.fillStyle = '#302820';
-      ctx.fillRect(lx, ly, 130, 10);
-      ctx.fillStyle = 'rgba(255,254,230,0.6)';
-      ctx.fillRect(lx + 4, ly + 2, 122, 6);
-      const grad = ctx.createLinearGradient(lx + 65, ly + 8, lx + 65, ly + 40);
-      grad.addColorStop(0, 'rgba(255,254,220,0.12)');
+    // Fluorescent lights distributed across viewport
+    const nLights = Math.max(3, Math.floor(W / 220));
+    const spacing = W / nLights;
+    for (let i = 0; i < nLights; i++) {
+      const lx = spacing * i + (spacing - 140) / 2, ly = 6;
+      ctx.fillStyle = '#302820'; ctx.fillRect(lx, ly, 140, 10);
+      ctx.fillStyle = 'rgba(255,254,230,0.6)'; ctx.fillRect(lx + 4, ly + 2, 132, 6);
+      const grad = ctx.createLinearGradient(lx + 70, ly + 8, lx + 70, ly + 50);
+      grad.addColorStop(0, 'rgba(255,254,220,0.14)');
       grad.addColorStop(1, 'rgba(255,254,220,0)');
-      ctx.fillStyle = grad;
-      ctx.fillRect(lx, ly + 8, 130, 32);
+      ctx.fillStyle = grad; ctx.fillRect(lx, ly + 8, 140, 42);
     }
 
-    // WUPHF sign (dark panel, golden amber letters, amber glow)
-    const sx = 250, sy = 26;
-    ctx.fillStyle = '#0E0C08';
-    ctx.fillRect(sx, sy, 300, 52);
+    // WUPHF sign (centered on viewport)
+    const sw = Math.min(360, W * 0.28), sh = 60;
+    const sx = Math.round(W / 2 - sw / 2), sy = 22;
+    ctx.fillStyle = '#0E0C08'; ctx.fillRect(sx, sy, sw, sh);
     ctx.fillStyle = C.yellow;
-    ctx.fillRect(sx,       sy,      300, 4);
-    ctx.fillRect(sx,       sy + 48, 300, 4);
-    ctx.fillRect(sx,       sy,      4,   52);
-    ctx.fillRect(sx + 296, sy,      4,   52);
-    ctx.fillStyle = 'rgba(236,178,46,0.08)';
-    ctx.fillRect(sx + 4, sy + 4, 292, 44);
-    ctx.shadowColor = C.yellow;
-    ctx.shadowBlur  = 12;
-    ctx.fillStyle   = C.yellow;
-    ctx.font = 'bold 28px "Press Start 2P"';
-    ctx.textAlign    = 'center';
-    ctx.textBaseline = 'middle';
-    ctx.fillText('WUPHF', sx + 150, sy + 28);
+    ctx.fillRect(sx, sy, sw, 4); ctx.fillRect(sx, sy + sh - 4, sw, 4);
+    ctx.fillRect(sx, sy, 4, sh); ctx.fillRect(sx + sw - 4, sy, 4, sh);
+    ctx.fillStyle = 'rgba(236,178,46,0.08)'; ctx.fillRect(sx + 4, sy + 4, sw - 8, sh - 8);
+    ctx.shadowColor = C.yellow; ctx.shadowBlur = 18;
+    ctx.fillStyle = C.yellow;
+    ctx.font = `bold ${Math.round(sw / 6.5)}px "Press Start 2P"`;
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.fillText('WUPHF', W / 2, sy + sh / 2);
     ctx.shadowBlur = 0;
-    // sign mounting brackets
     ctx.fillStyle = C.deskDark;
-    ctx.fillRect(sx + 40,  sy + 50, 8, 14);
-    ctx.fillRect(sx + 252, sy + 50, 8, 14);
+    ctx.fillRect(sx + 50, sy + sh - 2, 10, 16); ctx.fillRect(sx + sw - 60, sy + sh - 2, 10, 16);
 
-    // Wall clock (top-right)
+    // Tagline below sign
+    ctx.fillStyle = C.textMuted;
+    ctx.font = '7px "Press Start 2P"';
+    ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+    ctx.fillText('Your AI team. Visible and working.', W / 2, sy + sh + 8);
+
+    // Wall clock (right side)
+    const clkX = W - 90, clkY = 52;
     ctx.fillStyle = C.wallLight;
-    ctx.beginPath(); ctx.arc(740, 48, 18, 0, Math.PI * 2); ctx.fill();
+    ctx.beginPath(); ctx.arc(clkX, clkY, 22, 0, Math.PI * 2); ctx.fill();
     ctx.fillStyle = C.surface;
-    ctx.beginPath(); ctx.arc(740, 48, 14, 0, Math.PI * 2); ctx.fill();
+    ctx.beginPath(); ctx.arc(clkX, clkY, 17, 0, Math.PI * 2); ctx.fill();
     ctx.strokeStyle = C.text; ctx.lineWidth = 2;
-    ctx.beginPath(); ctx.moveTo(740, 36); ctx.lineTo(740, 48); ctx.stroke();
-    ctx.beginPath(); ctx.moveTo(740, 48); ctx.lineTo(750, 53); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(clkX, clkY - 14); ctx.lineTo(clkX, clkY); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(clkX, clkY); ctx.lineTo(clkX + 11, clkY + 6); ctx.stroke();
 
-    // Beet farm map (left side, Dwight's territory)
-    const bx = iso(0, 3).x - 65;
-    ctx.fillStyle = '#2A2818';
-    ctx.fillRect(bx, OY - 22, 50, 38);
-    ctx.strokeStyle = '#504830'; ctx.lineWidth = 1.5;
-    ctx.strokeRect(bx, OY - 22, 50, 38);
+    // Beet farm map
+    const bx = iso(0, 3).x - 80;
+    ctx.fillStyle = '#2A2818'; ctx.fillRect(bx, OY - 24, 62, 44);
+    ctx.strokeStyle = '#504830'; ctx.lineWidth = 1.5; ctx.strokeRect(bx, OY - 24, 62, 44);
     ctx.fillStyle = '#807020';
-    ctx.font = '6px "Press Start 2P"'; ctx.textAlign = 'center';
-    ctx.fillText('BEET', bx + 25, OY - 7);
-    ctx.fillText('FARM', bx + 25, OY + 5);
+    ctx.font = '7px "Press Start 2P"'; ctx.textAlign = 'center';
+    ctx.fillText('BEET', bx + 31, OY - 8); ctx.fillText('FARM', bx + 31, OY + 6);
     ctx.fillStyle = '#2A5018';
-    ctx.fillRect(bx + 10, OY + 10, 8, 4);
-    ctx.fillRect(bx + 30, OY + 8,  8, 4);
-    ctx.fillRect(bx + 18, OY + 6,  8, 4);
+    ctx.fillRect(bx + 12, OY + 14, 10, 5); ctx.fillRect(bx + 36, OY + 11, 10, 5); ctx.fillRect(bx + 24, OY + 8, 10, 5);
 
-    // Conference room partition (left corner)
+    // Conference room partition
     const cp = iso(0, 0);
-    ctx.fillStyle = '#252018';
-    ctx.fillRect(cp.x - 40, OY - 2, 40, 30);
-    ctx.strokeStyle = C.border; ctx.lineWidth = 1;
-    ctx.strokeRect(cp.x - 40, OY - 2, 40, 30);
-    ctx.fillStyle   = C.textMuted;
+    ctx.fillStyle = '#252018'; ctx.fillRect(cp.x - 50, OY - 2, 50, 34);
+    ctx.strokeStyle = C.border; ctx.lineWidth = 1; ctx.strokeRect(cp.x - 50, OY - 2, 50, 34);
+    ctx.fillStyle = C.textMuted;
     ctx.font = '5px "Press Start 2P"'; ctx.textAlign = 'center';
-    ctx.fillText('CONF', cp.x - 20, OY + 8);
-    ctx.fillText('ROOM', cp.x - 20, OY + 17);
+    ctx.fillText('CONF', cp.x - 25, OY + 10); ctx.fillText('ROOM', cp.x - 25, OY + 22);
   }
 
   // ── Furniture ──────────────────────────────────────────────────
-  // Returns the hit-testable drawer rect: { drawerX, drawerY }
-  function drawDesk(gx, gy, w, flash) {
-    const DH = 22;
+  function drawDesk(gx, gy, w) {
+    const DH = 30;
     drawIsoBox(gx, gy, w, 1, DH, C.desk, C.deskDark, C.deskSide);
-
-    // Monitor
-    const p  = iso(gx, gy);
-    const mx = p.x + TW * w / 2 + 6;
-    const my = p.y - DH - 22;
-    ctx.fillStyle = '#1A2030'; ctx.fillRect(mx, my, 28, 18);
-    ctx.fillStyle = '#1A3858'; ctx.fillRect(mx + 2, my + 2, 24, 14);
+    const p = iso(gx, gy);
+    const mx = p.x + TW * w / 2 + 8;
+    const my = p.y - DH - 28;
+    ctx.fillStyle = '#1A2030'; ctx.fillRect(mx, my, 36, 24);
+    ctx.fillStyle = '#1A3858'; ctx.fillRect(mx + 2, my + 2, 32, 20);
     ctx.fillStyle = C.blue;
-    for (let i = 0; i < 3; i++) ctx.fillRect(mx + 4, my + 4 + i * 4, 8 + i * 4, 2);
-    ctx.fillStyle = '#1A1820';
-    ctx.fillRect(mx + 10, my + 18, 8, 5);
-    ctx.fillRect(mx + 6,  my + 22, 16, 3);
-
-    // Drawer (flashes amber when flash=true)
-    const dp = iso(gx + w - 1, gy);
-    const dx = dp.x + 6;
-    const dy = dp.y - DH + 6;
-    ctx.fillStyle = (flash && flashOn) ? C.yellow : C.deskDark;
-    if (flash && flashOn) { ctx.shadowColor = C.yellow; ctx.shadowBlur = 8; }
-    ctx.fillRect(dx, dy, 20, 12);
-    ctx.shadowBlur = 0;
-    ctx.strokeStyle = (flash && flashOn) ? C.yellow : C.deskSide;
-    ctx.lineWidth = 1.5;
-    ctx.strokeRect(dx, dy, 20, 12);
-    ctx.fillStyle = C.yellow;
-    ctx.fillRect(dx + 7, dy + 4, 6, 4);
-
-    // Paper on desk
+    for (let i = 0; i < 3; i++) ctx.fillRect(mx + 4, my + 4 + i * 5, 12 + i * 4, 3);
+    ctx.fillStyle = '#1A1820'; ctx.fillRect(mx + 13, my + 24, 10, 7); ctx.fillRect(mx + 9, my + 30, 18, 3);
     const pp = iso(gx, gy);
-    ctx.fillStyle = C.surfaceHi; ctx.fillRect(pp.x + 16, pp.y - DH - 2, 16, 12);
+    ctx.fillStyle = C.surfaceHi; ctx.fillRect(pp.x + 18, pp.y - DH - 2, 22, 16);
     ctx.fillStyle = C.border;
-    for (let i = 0; i < 3; i++) ctx.fillRect(pp.x + 18, pp.y - DH + 1 + i * 3, 10, 1);
-
-    return { drawerX: dx, drawerY: dy };
+    for (let i = 0; i < 3; i++) ctx.fillRect(pp.x + 20, pp.y - DH + 2 + i * 4, 16, 1.5);
   }
 
   function drawPlant(gx, gy) {
     const c = isoCenter(gx, gy);
-    ctx.fillStyle = '#5A3A18'; ctx.fillRect(c.x - 5, c.y - 14, 10, 10);
-    ctx.fillStyle = C.plant;   ctx.fillRect(c.x - 10, c.y - 28, 20, 18);
-    ctx.fillStyle = '#2A4818'; ctx.fillRect(c.x - 7,  c.y - 32, 14, 8);
-    ctx.fillStyle = C.plant;   ctx.fillRect(c.x - 4,  c.y - 36, 8, 10);
+    ctx.fillStyle = '#5A3A18'; ctx.fillRect(c.x - 7, c.y - 18, 14, 14);
+    ctx.fillStyle = C.plant;   ctx.fillRect(c.x - 14, c.y - 36, 28, 22);
+    ctx.fillStyle = '#2A4818'; ctx.fillRect(c.x - 9,  c.y - 44, 18, 12);
+    ctx.fillStyle = C.plant;   ctx.fillRect(c.x - 6,  c.y - 52, 12, 14);
   }
 
   function drawSnackJar(gx, gy) {
     const c = isoCenter(gx, gy);
-    ctx.fillStyle = '#3A5878'; ctx.fillRect(c.x - 6, c.y - 18, 12, 14);
-    ctx.fillStyle = C.surface; ctx.fillRect(c.x - 5, c.y - 17, 10, 12);
-    ctx.fillStyle = C.yellow;  ctx.fillRect(c.x - 3, c.y - 12, 6, 6);
-    ctx.fillStyle = C.deskDark; ctx.fillRect(c.x - 5, c.y - 18, 12, 4);
+    ctx.fillStyle = '#3A5878'; ctx.fillRect(c.x - 8, c.y - 26, 16, 18);
+    ctx.fillStyle = C.surface; ctx.fillRect(c.x - 7, c.y - 24, 14, 16);
+    ctx.fillStyle = C.yellow;  ctx.fillRect(c.x - 4, c.y - 16, 9, 9);
+    ctx.fillStyle = C.deskDark; ctx.fillRect(c.x - 7, c.y - 26, 16, 5);
     ctx.fillStyle = C.text;
     ctx.font = '4px "Press Start 2P"'; ctx.textAlign = 'center';
-    ctx.fillText('NO',    c.x, c.y - 10);
-    ctx.fillText('WASTE', c.x, c.y - 6);
+    ctx.fillText('NO', c.x, c.y - 12); ctx.fillText('WASTE', c.x, c.y - 7);
   }
 
   // ── Sprite helpers ─────────────────────────────────────────────
-  // Generic head: hair, skin, eyes (dark), mouth
+  // bob: 0 or 2 based on frame; lean: -1, 0, or 1
   function drawHead(x, y, hair, skin, f) {
-    const b = f < 2 ? 0 : 1;
-    ctx.fillStyle = hair; ctx.fillRect(x + 2, y + b,      16, 9);
-    ctx.fillStyle = skin; ctx.fillRect(x + 2, y + 7 + b,  16, 13);
-    ctx.fillStyle = C.bg; ctx.fillRect(x + 5, y + 10 + b, 3, 3);
-                          ctx.fillRect(x + 12, y + 10 + b, 3, 3);
-    ctx.fillStyle = '#804040'; ctx.fillRect(x + 7, y + 17 + b, 6, 2);
+    const bob  = (f < 2) ? 0 : 2;
+    const lean = [0, 1, 0, -1][f];
+    ctx.fillStyle = hair; ctx.fillRect(x + 2 + lean, y + bob,      16, 9);
+    ctx.fillStyle = skin; ctx.fillRect(x + 2 + lean, y + 7 + bob,  16, 13);
+    ctx.fillStyle = C.bg;
+    ctx.fillRect(x + 5 + lean, y + 10 + bob, 3, 3);
+    ctx.fillRect(x + 12 + lean, y + 10 + bob, 3, 3);
+    ctx.fillStyle = '#804040'; ctx.fillRect(x + 7 + lean, y + 17 + bob, 6, 2);
+  }
+
+  // Shared leg drawing — feet alternate forward on frames 1 and 3
+  function drawLegs(x, y, f, skinColor, shoeColor, legColor, wide) {
+    const lOff = (f === 1) ? -3 : 0;
+    const rOff = (f === 3) ? -3 : 0;
+    ctx.fillStyle = legColor;
+    ctx.fillRect(x + 1,           y + 34, wide ? 10 : 8, 12);
+    ctx.fillRect(x + (wide?13:11), y + 34, wide ? 10 : 8, 12);
+    ctx.fillStyle = skinColor;
+    ctx.fillRect(x + 2,           y + 46 + lOff, wide ? 7 : 6, 6);
+    ctx.fillRect(x + (wide?14:12), y + 46 + rOff, wide ? 7 : 6, 6);
+    ctx.fillStyle = shoeColor;
+    ctx.fillRect(x + 2,           y + 52 + lOff, wide ? 9 : 8, 4);
+    ctx.fillRect(x + (wide?13:10), y + 52 + rOff, wide ? 9 : 8, 4);
   }
 
   // ── Office cast ────────────────────────────────────────────────
   function drawPam(x, y, f) {
-    const b = f < 2 ? 0 : 1;
-    // Hair bun
-    ctx.fillStyle = '#C49838'; ctx.fillRect(x + 5, y - 4 + b, 10, 7);
-    drawHead(x, y + b, '#D4A850', C.skin, f);
-    // Pink cardigan + white collar
-    ctx.fillStyle = '#D09098'; ctx.fillRect(x,     y + 20 + b, 20, 14);
-    ctx.fillStyle = C.light;   ctx.fillRect(x + 7, y + 20 + b, 6, 4);
-    // Purple skirt
-    ctx.fillStyle = '#6868A8'; ctx.fillRect(x, y + 34 + b, 20, 12);
-    // Legs + shoes
-    ctx.fillStyle = C.skin;    ctx.fillRect(x + 2,  y + 46, 6, 6); ctx.fillRect(x + 12, y + 46, 6, 6);
-    ctx.fillStyle = '#2A1808'; ctx.fillRect(x + 2,  y + 52, 8, 4); ctx.fillRect(x + 10, y + 52, 8, 4);
+    const bob = (f < 2) ? 0 : 2;
+    ctx.fillStyle = '#C49838'; ctx.fillRect(x + 5, y - 4 + bob, 10, 7);
+    drawHead(x, y + bob, '#D4A850', C.skin, f);
+    ctx.fillStyle = '#D09098'; ctx.fillRect(x,     y + 20 + bob, 20, 14);
+    ctx.fillStyle = C.light;   ctx.fillRect(x + 7, y + 20 + bob, 6, 4);
+    ctx.fillStyle = '#6868A8'; ctx.fillRect(x, y + 34 + bob, 20, 12);
+    drawLegs(x, y + bob, f, C.skin, '#2A1808', '#6868A8', false);
   }
 
   function drawMichael(x, y, f) {
-    const b = f < 2 ? 0 : 1;
-    drawHead(x, y + b, '#2A1A0A', C.skin, f);
-    // Big smile
-    ctx.fillStyle = '#A05050'; ctx.fillRect(x + 4, y + 16 + b, 12, 3);
-    // Blue suit
-    ctx.fillStyle = '#1A3858'; ctx.fillRect(x, y + 20 + b, 20, 14);
-    // White shirt
-    ctx.fillStyle = C.light;   ctx.fillRect(x + 7, y + 20 + b, 6, 10);
-    // Amber tie (he tries)
-    ctx.fillStyle = C.yellow;  ctx.fillRect(x + 9, y + 23 + b, 3, 8);
-    // Dark pants + shoes
-    ctx.fillStyle = '#0E2840'; ctx.fillRect(x, y + 34 + b, 20, 12);
-    ctx.fillStyle = '#0A0E14'; ctx.fillRect(x + 2, y + 46, 7, 4); ctx.fillRect(x + 11, y + 46, 7, 4);
+    const bob = (f < 2) ? 0 : 2;
+    drawHead(x, y + bob, '#2A1A0A', C.skin, f);
+    ctx.fillStyle = '#A05050'; ctx.fillRect(x + 4, y + 16 + bob, 12, 3);
+    ctx.fillStyle = '#1A3858'; ctx.fillRect(x, y + 20 + bob, 20, 14);
+    ctx.fillStyle = C.light;   ctx.fillRect(x + 7, y + 20 + bob, 6, 10);
+    ctx.fillStyle = C.yellow;  ctx.fillRect(x + 9, y + 23 + bob, 3, 8);
+    drawLegs(x, y + bob, f, C.skin, '#0A0E14', '#0E2840', false);
   }
 
   function drawDwight(x, y, f) {
-    const b = f < 2 ? 0 : 1;
-    drawHead(x, y + b, '#3A2010', '#C88858', f);
-    // Glasses
+    const bob = (f < 2) ? 0 : 2;
+    drawHead(x, y + bob, '#3A2010', '#C88858', f);
     ctx.fillStyle = C.bg;
-    ctx.fillRect(x + 3, y + 9 + b, 5, 3); ctx.fillRect(x + 11, y + 9 + b, 5, 3);
-    ctx.fillRect(x + 8, y + 10 + b, 3, 1);
-    // Scowl
-    ctx.fillStyle = '#604010'; ctx.fillRect(x + 5, y + 16 + b, 10, 2);
-    // Mustard shirt
-    ctx.fillStyle = '#A88018'; ctx.fillRect(x, y + 20 + b, 20, 14);
-    ctx.fillStyle = C.bg;      ctx.fillRect(x + 7, y + 20 + b, 6, 4);
-    // Dark pants
-    ctx.fillStyle = '#202020'; ctx.fillRect(x, y + 34 + b, 20, 12);
-    ctx.fillStyle = '#080808'; ctx.fillRect(x + 2, y + 46, 7, 4); ctx.fillRect(x + 11, y + 46, 7, 4);
+    ctx.fillRect(x + 3, y + 9 + bob, 5, 3); ctx.fillRect(x + 11, y + 9 + bob, 5, 3);
+    ctx.fillRect(x + 8, y + 10 + bob, 3, 1);
+    ctx.fillStyle = '#604010'; ctx.fillRect(x + 5, y + 16 + bob, 10, 2);
+    ctx.fillStyle = '#A88018'; ctx.fillRect(x, y + 20 + bob, 20, 14);
+    ctx.fillStyle = C.bg;      ctx.fillRect(x + 7, y + 20 + bob, 6, 4);
+    drawLegs(x, y + bob, f, '#C88858', '#080808', '#202020', false);
   }
 
   function drawJim(x, y, f) {
-    const b = f < 2 ? 0 : 1;
-    drawHead(x, y + b, '#5A3828', C.skin, f);
-    // Slightly messy hair
-    ctx.fillStyle = '#7A4838'; ctx.fillRect(x + 14, y + 2 + b, 4, 4);
-    // Smirk (asymmetric)
-    ctx.fillStyle = '#804848'; ctx.fillRect(x + 9, y + 17 + b, 7, 2);
-    // Casual blue shirt
-    ctx.fillStyle = '#3A5A78'; ctx.fillRect(x, y + 20 + b, 20, 14);
-    // Dark slacks
-    ctx.fillStyle = '#1A2428'; ctx.fillRect(x, y + 34 + b, 20, 12);
-    ctx.fillStyle = '#080C10'; ctx.fillRect(x + 2, y + 46, 7, 4); ctx.fillRect(x + 11, y + 46, 7, 4);
+    const bob = (f < 2) ? 0 : 2;
+    drawHead(x, y + bob, '#5A3828', C.skin, f);
+    ctx.fillStyle = '#7A4838'; ctx.fillRect(x + 14, y + 2 + bob, 4, 4);
+    ctx.fillStyle = '#804848'; ctx.fillRect(x + 9, y + 17 + bob, 7, 2);
+    ctx.fillStyle = '#3A5A78'; ctx.fillRect(x, y + 20 + bob, 20, 14);
+    drawLegs(x, y + bob, f, C.skin, '#080C10', '#1A2428', false);
   }
 
   function drawKevin(x, y, f) {
-    const b = f < 2 ? 0 : 1;
-    // Kevin is wider
-    ctx.fillStyle = '#201810'; ctx.fillRect(x, y + b, 24, 7);
-    ctx.fillStyle = '#D09858'; ctx.fillRect(x, y + 5 + b, 24, 15);
-    ctx.fillStyle = C.bg;      ctx.fillRect(x + 4, y + 9 + b, 4, 4); ctx.fillRect(x + 16, y + 9 + b, 4, 4);
-    ctx.fillStyle = '#805038'; ctx.fillRect(x + 8, y + 17 + b, 8, 2);
-    ctx.fillStyle = '#2A3A58'; ctx.fillRect(x, y + 20 + b, 24, 14);
-    ctx.fillStyle = '#181818'; ctx.fillRect(x, y + 34 + b, 24, 12);
-    ctx.fillStyle = '#080808'; ctx.fillRect(x + 2, y + 46, 8, 4); ctx.fillRect(x + 14, y + 46, 8, 4);
+    const bob = (f < 2) ? 0 : 2;
+    ctx.fillStyle = '#201810'; ctx.fillRect(x, y + bob, 24, 8);
+    ctx.fillStyle = '#D09858'; ctx.fillRect(x, y + 6 + bob, 24, 16);
+    ctx.fillStyle = C.bg;
+    ctx.fillRect(x + 4, y + 10 + bob, 4, 4); ctx.fillRect(x + 16, y + 10 + bob, 4, 4);
+    ctx.fillStyle = '#805038'; ctx.fillRect(x + 8, y + 18 + bob, 8, 2);
+    ctx.fillStyle = '#2A3A58'; ctx.fillRect(x, y + 22 + bob, 24, 12);
+    drawLegs(x, y + bob, f, '#D09858', '#080808', '#181818', true);
   }
 
   function drawCreed(x, y, f) {
-    const b = f < 3 ? 0 : 1;
-    // Gray hair, knowing expression
-    drawHead(x, y + b, '#706860', '#B88858', f);
-    ctx.fillStyle = '#805038'; ctx.fillRect(x + 4, y + 17 + b, 12, 2);
-    // Green shirt (questionable origin)
-    ctx.fillStyle = '#284818'; ctx.fillRect(x, y + 20 + b, 20, 14);
-    ctx.fillStyle = '#201808'; ctx.fillRect(x, y + 34 + b, 20, 12);
-    ctx.fillStyle = '#100808'; ctx.fillRect(x + 2, y + 46, 7, 4); ctx.fillRect(x + 11, y + 46, 7, 4);
+    const bob = (f < 3) ? 0 : 2;
+    drawHead(x, y + bob, '#706860', '#B88858', f);
+    ctx.fillStyle = '#805038'; ctx.fillRect(x + 4, y + 17 + bob, 12, 2);
+    ctx.fillStyle = '#284818'; ctx.fillRect(x, y + 20 + bob, 20, 14);
+    drawLegs(x, y + bob, f, '#B88858', '#100808', '#201808', false);
   }
 
   function drawAgent(x, y, color, label, f) {
-    const b = f < 2 ? 0 : 1;
-    // Robot head block (solid color)
-    ctx.fillStyle = color; ctx.fillRect(x + 2, y + b, 16, 14);
-    // Screen face
-    ctx.fillStyle = C.bg; ctx.fillRect(x + 4, y + 3 + b, 12, 7);
-    const eyeCol = color === C.yellow ? '#AA7800' : C.blue;
+    const bob = (f < 2) ? 0 : 2;
+    ctx.fillStyle = color; ctx.fillRect(x + 2, y + bob, 16, 14);
+    ctx.fillStyle = C.bg; ctx.fillRect(x + 4, y + 3 + bob, 12, 7);
+    const eyeCol = color === C.yellow ? '#AA7800' : (color === C.green ? '#2A6040' : C.blue);
     ctx.fillStyle = eyeCol;
-    ctx.fillRect(x + 5,  y + 4 + b, 4, 4);
-    ctx.fillRect(x + 11, y + 4 + b, 4, 4);
-    // Blink on frame 3
+    ctx.fillRect(x + 5, y + 4 + bob, 4, 4); ctx.fillRect(x + 11, y + 4 + bob, 4, 4);
     if (f === 3) {
       ctx.fillStyle = C.bg;
-      ctx.fillRect(x + 5,  y + 6 + b, 4, 2);
-      ctx.fillRect(x + 11, y + 6 + b, 4, 2);
+      ctx.fillRect(x + 5, y + 6 + bob, 4, 2); ctx.fillRect(x + 11, y + 6 + bob, 4, 2);
     }
-    // Body
-    ctx.fillStyle = color; ctx.fillRect(x, y + 14 + b, 20, 16);
-    // Nameplate badge
-    ctx.fillStyle = C.bg;    ctx.fillRect(x + 2, y + 20 + b, 16, 8);
+    ctx.fillStyle = color; ctx.fillRect(x, y + 14 + bob, 20, 16);
+    ctx.fillStyle = C.bg; ctx.fillRect(x + 2, y + 20 + bob, 16, 8);
     ctx.fillStyle = color;
     ctx.font = '5px "Press Start 2P"'; ctx.textAlign = 'center';
-    ctx.fillText(label.substring(0, 3).toUpperCase(), x + 10, y + 27 + b);
-    // Legs
+    ctx.fillText(label.substring(0, 3).toUpperCase(), x + 10, y + 27 + bob);
     ctx.fillStyle = '#202020';
-    ctx.fillRect(x + 2,  y + 30 + b, 7,  16);
-    ctx.fillRect(x + 11, y + 30 + b, 7,  16);
-    ctx.fillRect(x,      y + 46,     9,  4);
-    ctx.fillRect(x + 11, y + 46,     9,  4);
+    ctx.fillRect(x + 2,  y + 30 + bob, 7, 16); ctx.fillRect(x + 11, y + 30 + bob, 7, 16);
+    ctx.fillRect(x,      y + 46, 9, 4);         ctx.fillRect(x + 11, y + 46, 9, 4);
   }
 
   // ── Characters ─────────────────────────────────────────────────
   const CHARS = [
-    { id: 'pam',     name: 'Pam Beesly',    quote: 'WUPHF!',
-      gx: 3.5, gy: 0.5, fn: drawPam },
-    { id: 'michael', name: 'Michael Scott', quote: "I'm not superstitious, but I am a little stitious.",
-      gx: 6.5, gy: 1.5, fn: drawMichael },
-    { id: 'dwight',  name: 'Dwight Schrute', quote: 'Bears. Beets. Battlestar Galactica.',
-      gx: 1,   gy: 3,   fn: drawDwight },
-    { id: 'jim',     name: 'Jim Halpert',    quote: 'How the turntables...',
-      gx: 3,   gy: 3,   fn: drawJim },
-    { id: 'kevin',   name: 'Kevin Malone',   quote: '... (stares at snacks)',
-      gx: 5.5, gy: 4,   fn: drawKevin, wide: true },
-    { id: 'creed',   name: 'Creed Bratton',  quote: "Nobody steals from Creed Bratton and gets away with it. The website is fine.",
-      gx: 0.5, gy: 5,   fn: drawCreed },
-    { id: 'ceo', name: 'CEO Agent',      quote: 'Routing task to engineering team. ETA: 3 minutes.',
-      gx: 5.5, gy: 2,   isAgent: true, color: C.yellow,  label: 'CEO' },
-    { id: 'eng', name: 'Engineer Agent', quote: 'Implementing feature... 47% complete.',
-      gx: 2.5, gy: 4,   isAgent: true, color: C.blue,    label: 'ENG' },
-    { id: 'cmo', name: 'CMO Agent',      quote: 'Drafting launch post. You will not believe this lede.',
-      gx: 4.2, gy: 3.2, isAgent: true, color: '#5AAA7A', label: 'CMO' },
+    { id: 'pam',     name: 'Pam Beesly',     gx: 4.5, gy: 0.5, fn: drawPam },
+    { id: 'michael', name: 'Michael Scott',  gx: 8.5, gy: 1.5, fn: drawMichael },
+    { id: 'dwight',  name: 'Dwight Schrute', gx: 1.5, gy: 3.5, fn: drawDwight },
+    { id: 'jim',     name: 'Jim Halpert',    gx: 4,   gy: 3,   fn: drawJim },
+    { id: 'kevin',   name: 'Kevin Malone',   gx: 7,   gy: 5,   fn: drawKevin, wide: true },
+    { id: 'creed',   name: 'Creed Bratton',  gx: 0.5, gy: 6.5, fn: drawCreed },
+    { id: 'ceo',     name: 'CEO Agent',      gx: 7,   gy: 2,   isAgent: true, color: C.yellow, label: 'CEO' },
+    { id: 'eng',     name: 'Engineer Agent', gx: 3,   gy: 4.5, isAgent: true, color: C.blue,   label: 'ENG' },
+    { id: 'cmo',     name: 'CMO Agent',      gx: 5.5, gy: 3.5, isAgent: true, color: C.green,  label: 'CMO' },
   ];
 
   const charHits = [];
-  let activeThought = null;
-  let thoughtTimer  = null;
 
-  // ── Thought bubble ─────────────────────────────────────────────
-  function drawThought(char, centerX, charTopY) {
-    if (!activeThought || activeThought.id !== char.id) return;
-
-    const BW = 210, BH = 82;
-    let bx = Math.min(centerX - 95, W - BW - 10);
-    bx = Math.max(bx, 10);
-    let by = Math.max(charTopY - 90, 5);
-
-    // Panel
-    ctx.fillStyle = C.surface;
-    ctx.fillRect(bx, by, BW, BH);
-    ctx.strokeStyle = C.yellow; ctx.lineWidth = 3;
-    ctx.strokeRect(bx, by, BW, BH);
-
-    // Tail (triangle below panel pointing to character)
-    ctx.beginPath();
-    ctx.moveTo(bx + 20, by + BH);
-    ctx.lineTo(bx + 30, by + BH + 14);
-    ctx.lineTo(bx + 42, by + BH);
-    ctx.closePath();
-    ctx.fillStyle = C.surface; ctx.fill();
-    ctx.strokeStyle = C.yellow; ctx.stroke();
-    // Hide inner line of tail
-    ctx.fillStyle = C.surface; ctx.fillRect(bx + 21, by + BH - 1, 21, 4);
-
-    // Speaker name
-    ctx.fillStyle    = C.yellow;
-    ctx.font = '6px "Press Start 2P"'; ctx.textAlign = 'left'; ctx.textBaseline = 'top';
-    ctx.fillText(char.name, bx + 10, by + 8);
-
-    // Quote (word-wrapped)
-    ctx.fillStyle = C.text;
-    ctx.font = '18px "VT323"'; ctx.textBaseline = 'top';
-    const words  = char.quote.split(' ');
-    let line = '', lineY = by + 22;
-    for (const w of words) {
-      const test = line ? line + ' ' + w : w;
-      if (ctx.measureText(test).width > BW - 20 && line) {
-        ctx.fillText(line, bx + 10, lineY);
-        line  = w;
-        lineY += 18;
-        if (lineY > by + BH - 6) { ctx.fillText(line + '...', bx + 10, lineY - 18); return; }
-      } else {
-        line = test;
-      }
-    }
-    ctx.fillText(line, bx + 10, lineY);
+  // ── Mobile fallback ────────────────────────────────────────────
+  function drawMobileScene() {
+    ctx.fillStyle = C.wall; ctx.fillRect(0, 0, W, H);
+    ctx.fillStyle = C.carpet; ctx.fillRect(0, H - 70, W, 70);
+    ctx.fillStyle = C.carpetLine; ctx.fillRect(0, H - 71, W, 2);
+    const sw = Math.min(300, W - 32), sh = 52;
+    const sx = (W - sw) / 2, sy = 16;
+    ctx.fillStyle = '#0E0C08'; ctx.fillRect(sx, sy, sw, sh);
+    ctx.fillStyle = C.yellow;
+    ctx.fillRect(sx, sy, sw, 4); ctx.fillRect(sx, sy + sh - 4, sw, 4);
+    ctx.fillRect(sx, sy, 4, sh); ctx.fillRect(sx + sw - 4, sy, 4, sh);
+    ctx.shadowColor = C.yellow; ctx.shadowBlur = 12;
+    ctx.fillStyle = C.yellow;
+    ctx.font = `bold ${Math.floor(sw / 6)}px "Press Start 2P"`;
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.fillText('WUPHF', sx + sw / 2, sy + sh / 2);
+    ctx.shadowBlur = 0;
+    ctx.fillStyle = C.textMuted;
+    ctx.font = '7px "Press Start 2P"'; ctx.textBaseline = 'top';
+    ctx.fillText('Your AI team. Visible and working.', W / 2, sy + sh + 8);
+    const charY = H - 70;
+    [[W * 0.2, drawPam], [W * 0.5, drawMichael], [W * 0.8, drawDwight]].forEach(([cx, fn]) => {
+      ctx.fillStyle = C.shadow;
+      ctx.beginPath(); ctx.ellipse(cx, charY + 2, 11, 5, 0, 0, Math.PI * 2); ctx.fill();
+      fn(cx - 10, charY - 56, animF);
+    });
+    ctx.fillStyle = C.textMuted;
+    ctx.font = '6px "Press Start 2P"'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+    ctx.fillText('Best viewed on desktop', W / 2, H - 22);
   }
 
   // ── Main draw ──────────────────────────────────────────────────
-  function draw() {
+  function draw(now) {
     ctx.clearRect(0, 0, W, H);
     if (isMobile) { drawMobileScene(); return; }
+
+    updateBubbles(now);
     drawWall();
 
-    // Floor tiles
     for (let gy = 0; gy < ROWS; gy++) {
       for (let gx = 0; gx < COLS; gx++) {
         drawFloorTile(gx, gy, (gx + gy) % 2 === 0 ? C.carpet : C.carpetAlt);
@@ -554,150 +486,65 @@
     }
 
     // Props
-    drawPlant(8, 0);
-    drawPlant(8, 2);
-    drawSnackJar(5, 4);
+    drawPlant(COLS - 1, 0);
+    drawPlant(COLS - 1, 2);
+    drawPlant(COLS - 1, 5);
+    drawSnackJar(7, 5);
 
-    // Desks (back-to-front: lower gx+gy first)
-    drawerHit = drawDesk(2, 0, 2, true);  // reception desk — flashing drawer
-    drawDesk(0, 3, 1, false);             // Dwight's desk
-    drawDesk(2, 3, 1, false);             // Jim's desk
-    drawDesk(5, 1, 1, false);             // CEO Agent desk (back right)
-    drawDesk(2, 4, 1, false);             // Engineer Agent desk
-    drawDesk(4, 3, 1, false);             // CMO Agent desk
+    // Desks
+    drawDesk(3, 0, 2);   // reception
+    drawDesk(1, 3, 1);   // Dwight
+    drawDesk(3, 3, 1);   // Jim
+    drawDesk(6, 1, 1);   // CEO Agent
+    drawDesk(2, 4, 1);   // Engineer Agent
+    drawDesk(5, 3, 1);   // CMO Agent
+    drawDesk(9, 3, 1);   // extra desk
 
-    // "Click Me!" tooltip above the reception desk flashing drawer
-    if (!drawerOpen && flashOn && drawerHit) {
-      const { drawerX: dx, drawerY: dy } = drawerHit;
-      ctx.fillStyle = C.yellow;
-      ctx.fillRect(dx - 4, dy - 22, 72, 18);
-      // Down-pointing triangle
-      ctx.beginPath();
-      ctx.moveTo(dx + 8,  dy - 4);
-      ctx.lineTo(dx + 16, dy - 4);
-      ctx.lineTo(dx + 12, dy);
-      ctx.closePath(); ctx.fill();
-      ctx.fillStyle = C.bg;
-      ctx.font = '6px "Press Start 2P"'; ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
-      ctx.fillText('Click Me!', dx, dy - 13);
-    }
-
-    // Drawer reveal
-    if (drawerOpen && drawerHit) {
-      const { drawerX: dx, drawerY: dy } = drawerHit;
-      const rx = dx - 8, ry = dy + 14;
-      ctx.fillStyle = C.surface;
-      ctx.fillRect(rx, ry, 190, 44);
-      ctx.strokeStyle = C.yellow; ctx.lineWidth = 2;
-      ctx.strokeRect(rx, ry, 190, 44);
-      ctx.fillStyle = C.text;
-      ctx.font = '7px "Press Start 2P"'; ctx.textAlign = 'left'; ctx.textBaseline = 'top';
-      ctx.fillText('One command.', rx + 8, ry + 6);
-      ctx.fillText('One office.', rx + 8, ry + 18);
-      ctx.fillStyle = C.yellow;
-      ctx.fillText('./wuphf', rx + 8, ry + 30);
-    }
-
-    // Register interactable hit areas (rebuilt each frame from current positions)
-    interactHits.length = 0;
-
-    // 1. Paper on Pam's desk
-    const pamDesk = iso(2, 0);
-    interactHits.push({ id: 'paper', x: pamDesk.x + 16, y: pamDesk.y - 22 - 2, w: 16, h: 12,
-      content: ['CEO, PM, engineers,', 'all visible,', 'all working.'] });
-
-    // 2. Conference room whiteboard
-    const cp2 = iso(0, 0);
-    interactHits.push({ id: 'whiteboard', x: cp2.x - 40, y: OY - 2, w: 40, h: 30,
-      content: ['agent → broker', '→ channel', '→ human'] });
-
-    // 3. Agent monitor (CEO desk)
-    const ceoDesk = iso(5, 1);
-    interactHits.push({ id: 'monitor', x: ceoDesk.x + TW / 2 + 6, y: ceoDesk.y - 22 - 22, w: 28, h: 18,
-      content: ['Open source.', 'MIT license.', '$ go build -o wuphf'] });
-
-    // 4. Plant (first one — at gx=8,gy=0)
-    const plantC2 = isoCenter(8, 0);
-    interactHits.push({ id: 'plant', x: plantC2.x - 10, y: plantC2.y - 36, w: 20, h: 36,
-      content: ["Unlike Ryan Howard's", 'WUPHF, this one works.'] });
-
-    // 5. Snack jar (Kevin's area)
-    const jarC2 = isoCenter(5, 4);
-    interactHits.push({ id: 'snackjar', x: jarC2.x - 6, y: jarC2.y - 18, w: 12, h: 14,
-      content: ['No tokens wasted', 'on pleasantries.'] });
-
-    // 6. Beet farm map (Dwight's wall)
-    const bx2 = iso(0, 3).x - 65;
-    interactHits.push({ id: 'beetmap', x: bx2, y: OY - 22, w: 50, h: 38,
-      content: ['Identity theft is', 'not a joke, Jim!', '(easter egg found)'] });
-
-    // 7. Dundie award — small icon near conference room
-    const cp3 = iso(0, 0);
-    interactHits.push({ id: 'dundie', x: cp3.x - 36, y: OY + 18, w: 18, h: 18,
-      content: ['Best AI Office,', '2025.', '(Self-awarded.)'] });
-
-    // 8. Break room fridge — draw + register
-    const fridgeX = iso(8, 4).x + TW / 2 - 8;
-    const fridgeY = iso(8, 4).y - 20;
-    ctx.fillStyle = '#2A3040'; ctx.fillRect(fridgeX, fridgeY, 16, 20);
-    ctx.fillStyle = '#1A2030'; ctx.fillRect(fridgeX + 1, fridgeY + 10, 14, 9);
-    ctx.fillStyle = C.border;  ctx.fillRect(fridgeX + 13, fridgeY + 3, 2, 6);
-    if (flashOn) {
-      ctx.shadowColor = C.blue; ctx.shadowBlur = 4;
-      ctx.fillStyle   = C.blue; ctx.fillRect(fridgeX + 3, fridgeY + 5, 8, 3);
-      ctx.shadowBlur  = 0;
-    }
-    interactHits.push({ id: 'fridge', x: fridgeX, y: fridgeY, w: 16, h: 20,
-      content: ['$ git clone', '  github.com/', '  nex-crm/wuphf', '$ ./wuphf'] });
-
-    // Draw active reveal
-    if (activeReveal) {
-      drawReveal(activeReveal.x, activeReveal.y, activeReveal.content);
-    }
-
-    // Characters (back-to-front sort by gx+gy)
+    // Characters (back-to-front depth sort)
     charHits.length = 0;
     const sorted = [...CHARS].sort((a, b) => (a.gx + a.gy) - (b.gx + b.gy));
     for (const char of sorted) {
       const c  = isoCenter(char.gx, char.gy);
       const cw = char.wide ? 24 : 20;
       const cx = c.x - cw / 2 - 2;
-      const cy = c.y - 52;
+      const cy = c.y - 56;
 
-      // Shadow
       ctx.fillStyle = C.shadow;
       ctx.beginPath();
       ctx.ellipse(c.x, c.y + 2, char.wide ? 14 : 11, 5, 0, 0, Math.PI * 2);
       ctx.fill();
 
-      // Sprite (agent or cast)
       if (char.isAgent) {
         drawAgent(cx, cy, char.color, char.label, animF);
       } else {
         char.fn(cx, cy, animF);
       }
 
-      // Nametag: Pam (so visitors know who she is) + all agents
       if (char.id === 'pam' || char.isAgent) {
-        const tagColor  = char.isAgent ? char.color : C.yellow;
+        const tagColor = char.isAgent ? char.color : C.yellow;
         const firstName = char.name.split(' ')[0].substring(0, 8);
-        const tagW      = firstName.length * 6 + 16;
-        ctx.fillStyle   = tagColor;
+        const tagW = firstName.length * 6 + 16;
+        ctx.fillStyle = tagColor;
         ctx.fillRect(c.x - tagW / 2, cy - 14, tagW, 11);
-        ctx.fillStyle    = C.bg;
+        ctx.fillStyle = C.bg;
         ctx.font = '5px "Press Start 2P"'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
         ctx.fillText(firstName, c.x, cy - 8);
       }
 
-      drawThought(char, c.x, cy);
+      charScreenPos[char.id] = { centerX: c.x, topY: cy };
+      charHits.push({ char, cx, cy, w: cw + 4, h: 56 });
+    }
 
-      charHits.push({ char, cx, cy, w: cw + 4, h: 54 });
+    // Ambient speech bubbles
+    for (const bubble of activeBubbles) {
+      drawBubble(bubble, now);
     }
   }
 
+  // ── RAF loop ───────────────────────────────────────────────────
   let rafId;
-  function loop() {
-    draw();
+  function loop(now) {
+    draw(now);
     rafId = requestAnimationFrame(loop);
   }
   rafId = requestAnimationFrame(loop);
@@ -707,99 +554,8 @@
     else rafId = requestAnimationFrame(loop);
   });
 
-  canvas.addEventListener('click', e => {
-    const rect = canvas.getBoundingClientRect();
-    const scaleX = W / rect.width;
-    const scaleY = H / rect.height;
-    const mx = (e.clientX - rect.left) * scaleX;
-    const my = (e.clientY - rect.top)  * scaleY;
-
-    // Check reception drawer click
-    if (drawerHit) {
-      const { drawerX: dx, drawerY: dy } = drawerHit;
-      if (mx >= dx - 4 && mx <= dx + 74 &&
-          my >= dy - 26 && my <= dy + 14) {
-        drawerOpen = !drawerOpen;
-        return;
-      }
-    }
-
-    // Check interactable props
-    for (const hit of interactHits) {
-      if (mx >= hit.x && mx <= hit.x + hit.w &&
-          my >= hit.y && my <= hit.y + hit.h) {
-        if (activeReveal && activeReveal.id === hit.id) {
-          activeReveal = null;
-        } else {
-          activeReveal = { id: hit.id, x: hit.x + hit.w / 2, y: hit.y, content: hit.content };
-          clearTimeout(revealTimer);
-          revealTimer = setTimeout(() => { activeReveal = null; }, 5000);
-        }
-        return;
-      }
-    }
-
-    // Check characters
-    for (const hit of charHits) {
-      if (mx >= hit.cx && mx <= hit.cx + hit.w &&
-          my >= hit.cy && my <= hit.cy + hit.h) {
-        if (activeThought && activeThought.id === hit.char.id) {
-          activeThought = null;
-        } else {
-          activeThought = hit.char;
-          clearTimeout(thoughtTimer);
-          thoughtTimer = setTimeout(() => {
-            if (activeThought && activeThought.id === hit.char.id) activeThought = null;
-          }, 5000);
-        }
-        return;
-      }
-    }
-
-    // Click elsewhere — dismiss thought bubble
-    activeThought = null;
-  });
-
-  canvas.addEventListener('mousemove', e => {
-    const rect   = canvas.getBoundingClientRect();
-    const scaleX = W / rect.width;
-    const scaleY = H / rect.height;
-    const mx = (e.clientX - rect.left) * scaleX;
-    const my = (e.clientY - rect.top)  * scaleY;
-
-    let pointer = false;
-
-    // Drawer
-    if (drawerHit) {
-      const { drawerX: dx, drawerY: dy } = drawerHit;
-      if (mx >= dx - 4 && mx <= dx + 74 && my >= dy - 26 && my <= dy + 14) pointer = true;
-    }
-
-    // Characters
-    if (!pointer) {
-      for (const hit of charHits) {
-        if (mx >= hit.cx && mx <= hit.cx + hit.w &&
-            my >= hit.cy && my <= hit.cy + hit.h) { pointer = true; break; }
-      }
-    }
-
-    // Interactables
-    if (!pointer) {
-      for (const hit of interactHits) {
-        if (mx >= hit.x && mx <= hit.x + hit.w &&
-            my >= hit.y && my <= hit.y + hit.h) { pointer = true; break; }
-      }
-    }
-
-    canvas.style.cursor = pointer ? 'pointer' : 'default';
-  });
-
   document.addEventListener('keydown', e => {
-    if (e.key === 'Escape') {
-      activeThought = null;
-      activeReveal  = null;
-      drawerOpen    = false;
-    }
+    if (e.key === 'Escape') activeBubbles.length = 0;
   });
 
 })();

--- a/website/scene.js
+++ b/website/scene.js
@@ -109,11 +109,94 @@
     ctx.fillStyle = right; ctx.fill();
   }
 
+  // ── Back wall ──────────────────────────────────────────────────
+  function drawWall() {
+    // Back wall base
+    ctx.fillStyle = C.wall;
+    ctx.fillRect(0, 0, W, OY + 30);
+
+    // Baseboard strip
+    ctx.fillStyle = C.wallLight;
+    ctx.fillRect(0, OY + 22, W, 6);
+
+    // Fluorescent light fixtures (4 ceiling-mounted)
+    for (let i = 0; i < 4; i++) {
+      const lx = 60 + i * 170, ly = 6;
+      ctx.fillStyle = '#302820';
+      ctx.fillRect(lx, ly, 130, 10);
+      ctx.fillStyle = 'rgba(255,254,230,0.6)';
+      ctx.fillRect(lx + 4, ly + 2, 122, 6);
+      const grad = ctx.createLinearGradient(lx + 65, ly + 8, lx + 65, ly + 40);
+      grad.addColorStop(0, 'rgba(255,254,220,0.12)');
+      grad.addColorStop(1, 'rgba(255,254,220,0)');
+      ctx.fillStyle = grad;
+      ctx.fillRect(lx, ly + 8, 130, 32);
+    }
+
+    // WUPHF sign (dark panel, golden amber letters, amber glow)
+    const sx = 250, sy = 26;
+    ctx.fillStyle = '#0E0C08';
+    ctx.fillRect(sx, sy, 300, 52);
+    ctx.fillStyle = C.yellow;
+    ctx.fillRect(sx,       sy,      300, 4);
+    ctx.fillRect(sx,       sy + 48, 300, 4);
+    ctx.fillRect(sx,       sy,      4,   52);
+    ctx.fillRect(sx + 296, sy,      4,   52);
+    ctx.fillStyle = 'rgba(236,178,46,0.08)';
+    ctx.fillRect(sx + 4, sy + 4, 292, 44);
+    ctx.shadowColor = C.yellow;
+    ctx.shadowBlur  = 12;
+    ctx.fillStyle   = C.yellow;
+    ctx.font = 'bold 28px "Press Start 2P"';
+    ctx.textAlign    = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('WUPHF', sx + 150, sy + 28);
+    ctx.shadowBlur = 0;
+    // sign mounting brackets
+    ctx.fillStyle = C.deskDark;
+    ctx.fillRect(sx + 40,  sy + 50, 8, 14);
+    ctx.fillRect(sx + 252, sy + 50, 8, 14);
+
+    // Wall clock (top-right)
+    ctx.fillStyle = C.wallLight;
+    ctx.beginPath(); ctx.arc(740, 48, 18, 0, Math.PI * 2); ctx.fill();
+    ctx.fillStyle = C.surface;
+    ctx.beginPath(); ctx.arc(740, 48, 14, 0, Math.PI * 2); ctx.fill();
+    ctx.strokeStyle = C.text; ctx.lineWidth = 2;
+    ctx.beginPath(); ctx.moveTo(740, 36); ctx.lineTo(740, 48); ctx.stroke();
+    ctx.beginPath(); ctx.moveTo(740, 48); ctx.lineTo(750, 53); ctx.stroke();
+
+    // Beet farm map (left side, Dwight's territory)
+    const bx = iso(0, 3).x - 65;
+    ctx.fillStyle = '#2A2818';
+    ctx.fillRect(bx, OY - 22, 50, 38);
+    ctx.strokeStyle = '#504830'; ctx.lineWidth = 1.5;
+    ctx.strokeRect(bx, OY - 22, 50, 38);
+    ctx.fillStyle = '#807020';
+    ctx.font = '6px "Press Start 2P"'; ctx.textAlign = 'center';
+    ctx.fillText('BEET', bx + 25, OY - 7);
+    ctx.fillText('FARM', bx + 25, OY + 5);
+    ctx.fillStyle = '#2A5018';
+    ctx.fillRect(bx + 10, OY + 10, 8, 4);
+    ctx.fillRect(bx + 30, OY + 8,  8, 4);
+    ctx.fillRect(bx + 18, OY + 6,  8, 4);
+
+    // Conference room partition (left corner)
+    const cp = iso(0, 0);
+    ctx.fillStyle = '#252018';
+    ctx.fillRect(cp.x - 40, OY - 2, 40, 30);
+    ctx.strokeStyle = C.border; ctx.lineWidth = 1;
+    ctx.strokeRect(cp.x - 40, OY - 2, 40, 30);
+    ctx.fillStyle   = C.textMuted;
+    ctx.font = '5px "Press Start 2P"'; ctx.textAlign = 'center';
+    ctx.fillText('CONF', cp.x - 20, OY + 8);
+    ctx.fillText('ROOM', cp.x - 20, OY + 17);
+  }
+
   // ── Main draw ──────────────────────────────────────────────────
   function draw() {
     ctx.clearRect(0, 0, W, H);
-    ctx.fillStyle = C.wall;
-    ctx.fillRect(0, 0, W, OY + 30);
+    drawWall();
 
     for (let gy = 0; gy < ROWS; gy++) {
       for (let gx = 0; gx < COLS; gx++) {

--- a/website/scene.js
+++ b/website/scene.js
@@ -9,8 +9,12 @@
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
 
+  // ── Mobile detection ───────────────────────────────────────────
+  const isMobile = window.innerWidth < 768;
+
   // ── Canvas sizing ──────────────────────────────────────────────
-  const W = 800, H = 460;
+  const W = isMobile ? window.innerWidth : 800;
+  const H = isMobile ? 260 : 460;
   canvas.width  = W;
   canvas.height = H;
   canvas.style.width  = '100%';
@@ -141,6 +145,50 @@
       else ctx.fillStyle = C.text;
       ctx.fillText(line, rx + 8, ry + 8 + i * 14);
     });
+  }
+
+  // ── Mobile scene (2D fallback) ─────────────────────────────────
+  function drawMobileScene() {
+    // Dark background
+    ctx.fillStyle = C.wall; ctx.fillRect(0, 0, W, H);
+
+    // Floor strip (bottom 60px)
+    ctx.fillStyle = C.carpet; ctx.fillRect(0, H - 60, W, 60);
+    ctx.fillStyle = C.carpetLine; ctx.fillRect(0, H - 61, W, 2);
+
+    // Back wall stripe
+    ctx.fillStyle = '#201C14'; ctx.fillRect(0, 0, W, H - 60);
+
+    // WUPHF sign centered
+    const sw = Math.min(280, W - 40), sh = 48;
+    const sx = (W - sw) / 2, sy = 14;
+    ctx.fillStyle = '#0E0C08'; ctx.fillRect(sx, sy, sw, sh);
+    ctx.fillStyle = C.yellow;
+    ctx.fillRect(sx, sy, sw, 3); ctx.fillRect(sx, sy + sh - 3, sw, 3);
+    ctx.fillRect(sx, sy, 3, sh); ctx.fillRect(sx + sw - 3, sy, 3, sh);
+    ctx.shadowColor = C.yellow; ctx.shadowBlur = 10;
+    ctx.fillStyle   = C.yellow;
+    ctx.font = `bold ${Math.floor(sw / 6)}px "Press Start 2P"`;
+    ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+    ctx.fillText('WUPHF', sx + sw / 2, sy + sh / 2);
+    ctx.shadowBlur = 0;
+
+    // Three character silhouettes in a row (Pam, Michael, Dwight)
+    const charY = H - 60;
+    const positions = [W * 0.25, W * 0.5, W * 0.75];
+    const charFns   = [drawPam, drawMichael, drawDwight];
+    for (let i = 0; i < 3; i++) {
+      const cx = positions[i] - 10;
+      const cy = charY - 52;
+      ctx.fillStyle = C.shadow;
+      ctx.beginPath(); ctx.ellipse(positions[i], charY + 2, 11, 5, 0, 0, Math.PI*2); ctx.fill();
+      charFns[i](cx, cy, animF);
+    }
+
+    // Hint text
+    ctx.fillStyle    = C.textMuted;
+    ctx.font = '6px "Press Start 2P"'; ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+    ctx.fillText('Best viewed on desktop', W / 2, H - 20);
   }
 
   // ── Back wall ──────────────────────────────────────────────────
@@ -495,6 +543,7 @@
   // ── Main draw ──────────────────────────────────────────────────
   function draw() {
     ctx.clearRect(0, 0, W, H);
+    if (isMobile) { drawMobileScene(); return; }
     drawWall();
 
     // Floor tiles

--- a/website/scene.js
+++ b/website/scene.js
@@ -9,7 +9,120 @@
   if (!canvas) return;
   const ctx = canvas.getContext('2d');
 
-  // scene.js content goes here — added task by task
+  // ── Canvas sizing ──────────────────────────────────────────────
+  const W = 800, H = 460;
+  canvas.width  = W;
+  canvas.height = H;
+  canvas.style.width  = '100%';
+  canvas.style.height = 'auto';
 
-  console.log('WUPHF scene stub loaded');
+  // ── Design tokens ──────────────────────────────────────────────
+  const C = {
+    bg:         '#1A1610',
+    surface:    '#242018',
+    surfaceHi:  '#2E2820',
+    border:     '#3A3028',
+    text:       '#F0EBD8',
+    textMuted:  '#8A7D6A',
+    yellow:     '#ECB22E',
+    yellowDark: '#C49020',
+    blue:       '#5A9AC8',
+    green:      '#5AAA7A',
+    carpet:     '#3A3228',
+    carpetAlt:  '#302A20',
+    carpetLine: '#2A2418',
+    wall:       '#201C14',
+    wallLight:  '#2A2418',
+    desk:       '#7A5A18',
+    deskDark:   '#5A3C08',
+    deskSide:   '#3A2404',
+    skin:       '#F4C890',
+    light:      '#FFFEF0',
+    shadow:     'rgba(0,0,0,0.5)',
+    plant:      '#3A6028',
+  };
+
+  // ── Isometric grid ─────────────────────────────────────────────
+  const TW = 60, TH = 30;
+  const OX = 420, OY = 100;
+  const COLS = 9, ROWS = 6;
+
+  function iso(gx, gy) {
+    return {
+      x: OX + (gx - gy) * TW / 2,
+      y: OY + (gx + gy) * TH / 2,
+    };
+  }
+  function isoCenter(gx, gy) {
+    const p = iso(gx, gy);
+    return { x: p.x + TW / 2, y: p.y + TH / 2 };
+  }
+
+  // ── Floor tile ─────────────────────────────────────────────────
+  function drawFloorTile(gx, gy, color) {
+    const p = iso(gx, gy);
+    ctx.beginPath();
+    ctx.moveTo(p.x + TW / 2, p.y);
+    ctx.lineTo(p.x + TW,     p.y + TH / 2);
+    ctx.lineTo(p.x + TW / 2, p.y + TH);
+    ctx.lineTo(p.x,           p.y + TH / 2);
+    ctx.closePath();
+    ctx.fillStyle = color;
+    ctx.fill();
+    ctx.strokeStyle = C.carpetLine;
+    ctx.lineWidth = 0.5;
+    ctx.stroke();
+  }
+
+  // ── Iso box (w tiles wide × d tiles deep × h px tall) ─────────
+  function drawIsoBox(gx, gy, w, d, h, top, left, right) {
+    const p0 = iso(gx,     gy);
+    const pw = iso(gx + w, gy);
+    const pd = iso(gx,     gy + d);
+    const pf = iso(gx + w, gy + d);
+
+    // top face
+    ctx.beginPath();
+    ctx.moveTo(p0.x + TW/2, p0.y - h);
+    ctx.lineTo(pw.x + TW/2, pw.y - h);
+    ctx.lineTo(pf.x + TW/2, pf.y - h);
+    ctx.lineTo(pd.x + TW/2, pd.y - h);
+    ctx.closePath();
+    ctx.fillStyle = top; ctx.fill();
+
+    // left face
+    ctx.beginPath();
+    ctx.moveTo(p0.x + TW/2, p0.y - h);
+    ctx.lineTo(pd.x + TW/2, pd.y - h);
+    ctx.lineTo(pd.x + TW/2, pd.y);
+    ctx.lineTo(p0.x + TW/2, p0.y);
+    ctx.closePath();
+    ctx.fillStyle = left; ctx.fill();
+
+    // right face
+    ctx.beginPath();
+    ctx.moveTo(pw.x + TW/2, pw.y - h);
+    ctx.lineTo(pf.x + TW/2, pf.y - h);
+    ctx.lineTo(pf.x + TW/2, pf.y);
+    ctx.lineTo(pw.x + TW/2, pw.y);
+    ctx.closePath();
+    ctx.fillStyle = right; ctx.fill();
+  }
+
+  // ── Main draw ──────────────────────────────────────────────────
+  function draw() {
+    ctx.clearRect(0, 0, W, H);
+    ctx.fillStyle = C.wall;
+    ctx.fillRect(0, 0, W, OY + 30);
+
+    for (let gy = 0; gy < ROWS; gy++) {
+      for (let gx = 0; gx < COLS; gx++) {
+        drawFloorTile(gx, gy, (gx + gy) % 2 === 0 ? C.carpet : C.carpetAlt);
+      }
+    }
+  }
+
+  function loop() { draw(); requestAnimationFrame(loop); }
+  loop();
+
 })();

--- a/website/scene.js
+++ b/website/scene.js
@@ -63,6 +63,9 @@
   let animF     = 0;
   let drawerHit = null;
   let drawerOpen = false;
+  const interactHits = [];  // { id, x, y, w, h }
+  let   activeReveal = null; // { id, x, y, content: string[] }
+  let   revealTimer  = null;
 
   setInterval(() => { flashOn = !flashOn; }, 500);
   setInterval(() => { animF = (animF + 1) % 4; }, 280);
@@ -116,6 +119,28 @@
     ctx.lineTo(pw.x + TW/2, pw.y);
     ctx.closePath();
     ctx.fillStyle = right; ctx.fill();
+  }
+
+  // ── Reveal popup ──────────────────────────────────────────────
+  function drawReveal(x, y, lines) {
+    const PW = 220;
+    const PH = lines.length * 14 + 16;
+    let rx = Math.min(x, W - PW - 8);
+    let ry = Math.max(y - PH - 8, 5);
+
+    ctx.fillStyle = C.surface;
+    ctx.fillRect(rx, ry, PW, PH);
+    ctx.strokeStyle = C.yellow; ctx.lineWidth = 2;
+    ctx.strokeRect(rx, ry, PW, PH);
+
+    ctx.fillStyle    = C.text;
+    ctx.font = '7px "Press Start 2P"'; ctx.textAlign = 'left'; ctx.textBaseline = 'top';
+    lines.forEach((line, i) => {
+      if (line.startsWith('$')) ctx.fillStyle = C.yellow;
+      else if (line.startsWith('//')) ctx.fillStyle = C.blue;
+      else ctx.fillStyle = C.text;
+      ctx.fillText(line, rx + 8, ry + 8 + i * 14);
+    });
   }
 
   // ── Back wall ──────────────────────────────────────────────────
@@ -524,6 +549,63 @@
       ctx.fillText('./wuphf', rx + 8, ry + 30);
     }
 
+    // Register interactable hit areas (rebuilt each frame from current positions)
+    interactHits.length = 0;
+
+    // 1. Paper on Pam's desk
+    const pamDesk = iso(2, 0);
+    interactHits.push({ id: 'paper', x: pamDesk.x + 16, y: pamDesk.y - 22 - 2, w: 16, h: 12,
+      content: ['CEO, PM, engineers,', 'all visible,', 'all working.'] });
+
+    // 2. Conference room whiteboard
+    const cp2 = iso(0, 0);
+    interactHits.push({ id: 'whiteboard', x: cp2.x - 40, y: OY - 2, w: 40, h: 30,
+      content: ['agent → broker', '→ channel', '→ human'] });
+
+    // 3. Agent monitor (CEO desk)
+    const ceoDesk = iso(5, 1);
+    interactHits.push({ id: 'monitor', x: ceoDesk.x + TW / 2 + 6, y: ceoDesk.y - 22 - 22, w: 28, h: 18,
+      content: ['Open source.', 'MIT license.', '$ go build -o wuphf'] });
+
+    // 4. Plant (first one — at gx=8,gy=0)
+    const plantC2 = isoCenter(8, 0);
+    interactHits.push({ id: 'plant', x: plantC2.x - 10, y: plantC2.y - 36, w: 20, h: 36,
+      content: ["Unlike Ryan Howard's", 'WUPHF, this one works.'] });
+
+    // 5. Snack jar (Kevin's area)
+    const jarC2 = isoCenter(5, 4);
+    interactHits.push({ id: 'snackjar', x: jarC2.x - 6, y: jarC2.y - 18, w: 12, h: 14,
+      content: ['No tokens wasted', 'on pleasantries.'] });
+
+    // 6. Beet farm map (Dwight's wall)
+    const bx2 = iso(0, 3).x - 65;
+    interactHits.push({ id: 'beetmap', x: bx2, y: OY - 22, w: 50, h: 38,
+      content: ['Identity theft is', 'not a joke, Jim!', '(easter egg found)'] });
+
+    // 7. Dundie award — small icon near conference room
+    const cp3 = iso(0, 0);
+    interactHits.push({ id: 'dundie', x: cp3.x - 36, y: OY + 18, w: 18, h: 18,
+      content: ['Best AI Office,', '2025.', '(Self-awarded.)'] });
+
+    // 8. Break room fridge — draw + register
+    const fridgeX = iso(8, 4).x + TW / 2 - 8;
+    const fridgeY = iso(8, 4).y - 20;
+    ctx.fillStyle = '#2A3040'; ctx.fillRect(fridgeX, fridgeY, 16, 20);
+    ctx.fillStyle = '#1A2030'; ctx.fillRect(fridgeX + 1, fridgeY + 10, 14, 9);
+    ctx.fillStyle = C.border;  ctx.fillRect(fridgeX + 13, fridgeY + 3, 2, 6);
+    if (flashOn) {
+      ctx.shadowColor = C.blue; ctx.shadowBlur = 4;
+      ctx.fillStyle   = C.blue; ctx.fillRect(fridgeX + 3, fridgeY + 5, 8, 3);
+      ctx.shadowBlur  = 0;
+    }
+    interactHits.push({ id: 'fridge', x: fridgeX, y: fridgeY, w: 16, h: 20,
+      content: ['$ git clone', '  github.com/', '  nex-crm/wuphf', '$ ./wuphf'] });
+
+    // Draw active reveal
+    if (activeReveal) {
+      drawReveal(activeReveal.x, activeReveal.y, activeReveal.content);
+    }
+
     // Characters (back-to-front sort by gx+gy)
     charHits.length = 0;
     const sorted = [...CHARS].sort((a, b) => (a.gx + a.gy) - (b.gx + b.gy));
@@ -580,6 +662,21 @@
       if (mx >= dx - 4 && mx <= dx + 74 &&
           my >= dy - 26 && my <= dy + 14) {
         drawerOpen = !drawerOpen;
+        return;
+      }
+    }
+
+    // Check interactable props
+    for (const hit of interactHits) {
+      if (mx >= hit.x && mx <= hit.x + hit.w &&
+          my >= hit.y && my <= hit.y + hit.h) {
+        if (activeReveal && activeReveal.id === hit.id) {
+          activeReveal = null;
+        } else {
+          activeReveal = { id: hit.id, x: hit.x + hit.w / 2, y: hit.y, content: hit.content };
+          clearTimeout(revealTimer);
+          revealTimer = setTimeout(() => { activeReveal = null; }, 5000);
+        }
         return;
       }
     }

--- a/website/scene.js
+++ b/website/scene.js
@@ -262,6 +262,122 @@
     ctx.fillText('WASTE', c.x, c.y - 6);
   }
 
+  // ── Sprite helpers ─────────────────────────────────────────────
+  // Generic head: hair, skin, eyes (dark), mouth
+  function drawHead(x, y, hair, skin, f) {
+    const b = f < 2 ? 0 : 1;
+    ctx.fillStyle = hair; ctx.fillRect(x + 2, y + b,      16, 9);
+    ctx.fillStyle = skin; ctx.fillRect(x + 2, y + 7 + b,  16, 13);
+    ctx.fillStyle = C.bg; ctx.fillRect(x + 5, y + 10 + b, 3, 3);
+                          ctx.fillRect(x + 12, y + 10 + b, 3, 3);
+    ctx.fillStyle = '#804040'; ctx.fillRect(x + 7, y + 17 + b, 6, 2);
+  }
+
+  // ── Office cast ────────────────────────────────────────────────
+  function drawPam(x, y, f) {
+    const b = f < 2 ? 0 : 1;
+    // Hair bun
+    ctx.fillStyle = '#C49838'; ctx.fillRect(x + 5, y - 4 + b, 10, 7);
+    drawHead(x, y + b, '#D4A850', C.skin, f);
+    // Pink cardigan + white collar
+    ctx.fillStyle = '#D09098'; ctx.fillRect(x,     y + 20 + b, 20, 14);
+    ctx.fillStyle = C.light;   ctx.fillRect(x + 7, y + 20 + b, 6, 4);
+    // Purple skirt
+    ctx.fillStyle = '#6868A8'; ctx.fillRect(x, y + 34 + b, 20, 12);
+    // Legs + shoes
+    ctx.fillStyle = C.skin;    ctx.fillRect(x + 2,  y + 46, 6, 6); ctx.fillRect(x + 12, y + 46, 6, 6);
+    ctx.fillStyle = '#2A1808'; ctx.fillRect(x + 2,  y + 52, 8, 4); ctx.fillRect(x + 10, y + 52, 8, 4);
+  }
+
+  function drawMichael(x, y, f) {
+    const b = f < 2 ? 0 : 1;
+    drawHead(x, y + b, '#2A1A0A', C.skin, f);
+    // Big smile
+    ctx.fillStyle = '#A05050'; ctx.fillRect(x + 4, y + 16 + b, 12, 3);
+    // Blue suit
+    ctx.fillStyle = '#1A3858'; ctx.fillRect(x, y + 20 + b, 20, 14);
+    // White shirt
+    ctx.fillStyle = C.light;   ctx.fillRect(x + 7, y + 20 + b, 6, 10);
+    // Amber tie (he tries)
+    ctx.fillStyle = C.yellow;  ctx.fillRect(x + 9, y + 23 + b, 3, 8);
+    // Dark pants + shoes
+    ctx.fillStyle = '#0E2840'; ctx.fillRect(x, y + 34 + b, 20, 12);
+    ctx.fillStyle = '#0A0E14'; ctx.fillRect(x + 2, y + 46, 7, 4); ctx.fillRect(x + 11, y + 46, 7, 4);
+  }
+
+  function drawDwight(x, y, f) {
+    const b = f < 2 ? 0 : 1;
+    drawHead(x, y + b, '#3A2010', '#C88858', f);
+    // Glasses
+    ctx.fillStyle = C.bg;
+    ctx.fillRect(x + 3, y + 9 + b, 5, 3); ctx.fillRect(x + 11, y + 9 + b, 5, 3);
+    ctx.fillRect(x + 8, y + 10 + b, 3, 1);
+    // Scowl
+    ctx.fillStyle = '#604010'; ctx.fillRect(x + 5, y + 16 + b, 10, 2);
+    // Mustard shirt
+    ctx.fillStyle = '#A88018'; ctx.fillRect(x, y + 20 + b, 20, 14);
+    ctx.fillStyle = C.bg;      ctx.fillRect(x + 7, y + 20 + b, 6, 4);
+    // Dark pants
+    ctx.fillStyle = '#202020'; ctx.fillRect(x, y + 34 + b, 20, 12);
+    ctx.fillStyle = '#080808'; ctx.fillRect(x + 2, y + 46, 7, 4); ctx.fillRect(x + 11, y + 46, 7, 4);
+  }
+
+  function drawJim(x, y, f) {
+    const b = f < 2 ? 0 : 1;
+    drawHead(x, y + b, '#5A3828', C.skin, f);
+    // Slightly messy hair
+    ctx.fillStyle = '#7A4838'; ctx.fillRect(x + 14, y + 2 + b, 4, 4);
+    // Smirk (asymmetric)
+    ctx.fillStyle = '#804848'; ctx.fillRect(x + 9, y + 17 + b, 7, 2);
+    // Casual blue shirt
+    ctx.fillStyle = '#3A5A78'; ctx.fillRect(x, y + 20 + b, 20, 14);
+    // Dark slacks
+    ctx.fillStyle = '#1A2428'; ctx.fillRect(x, y + 34 + b, 20, 12);
+    ctx.fillStyle = '#080C10'; ctx.fillRect(x + 2, y + 46, 7, 4); ctx.fillRect(x + 11, y + 46, 7, 4);
+  }
+
+  function drawKevin(x, y, f) {
+    const b = f < 2 ? 0 : 1;
+    // Kevin is wider
+    ctx.fillStyle = '#201810'; ctx.fillRect(x, y + b, 24, 7);
+    ctx.fillStyle = '#D09858'; ctx.fillRect(x, y + 5 + b, 24, 15);
+    ctx.fillStyle = C.bg;      ctx.fillRect(x + 4, y + 9 + b, 4, 4); ctx.fillRect(x + 16, y + 9 + b, 4, 4);
+    ctx.fillStyle = '#805038'; ctx.fillRect(x + 8, y + 17 + b, 8, 2);
+    ctx.fillStyle = '#2A3A58'; ctx.fillRect(x, y + 20 + b, 24, 14);
+    ctx.fillStyle = '#181818'; ctx.fillRect(x, y + 34 + b, 24, 12);
+    ctx.fillStyle = '#080808'; ctx.fillRect(x + 2, y + 46, 8, 4); ctx.fillRect(x + 14, y + 46, 8, 4);
+  }
+
+  function drawCreed(x, y, f) {
+    const b = f < 3 ? 0 : 1;
+    // Gray hair, knowing expression
+    drawHead(x, y + b, '#706860', '#B88858', f);
+    ctx.fillStyle = '#805038'; ctx.fillRect(x + 4, y + 17 + b, 12, 2);
+    // Green shirt (questionable origin)
+    ctx.fillStyle = '#284818'; ctx.fillRect(x, y + 20 + b, 20, 14);
+    ctx.fillStyle = '#201808'; ctx.fillRect(x, y + 34 + b, 20, 12);
+    ctx.fillStyle = '#100808'; ctx.fillRect(x + 2, y + 46, 7, 4); ctx.fillRect(x + 11, y + 46, 7, 4);
+  }
+
+  // ── Characters ─────────────────────────────────────────────────
+  const CHARS = [
+    { id: 'pam',     name: 'Pam Beesly',    quote: 'WUPHF!',
+      gx: 3.5, gy: 0.5, fn: drawPam },
+    { id: 'michael', name: 'Michael Scott', quote: "I'm not superstitious, but I am a little stitious.",
+      gx: 6.5, gy: 1.5, fn: drawMichael },
+    { id: 'dwight',  name: 'Dwight Schrute', quote: 'Bears. Beets. Battlestar Galactica.',
+      gx: 1,   gy: 3,   fn: drawDwight },
+    { id: 'jim',     name: 'Jim Halpert',    quote: 'How the turntables...',
+      gx: 3,   gy: 3,   fn: drawJim },
+    { id: 'kevin',   name: 'Kevin Malone',   quote: '... (stares at snacks)',
+      gx: 5.5, gy: 4,   fn: drawKevin, wide: true },
+    { id: 'creed',   name: 'Creed Bratton',  quote: "Nobody steals from Creed Bratton and gets away with it. The website is fine.",
+      gx: 0.5, gy: 5,   fn: drawCreed },
+  ];
+
+  const charHits = [];
+  let activeThought = null;
+
   // ── Main draw ──────────────────────────────────────────────────
   function draw() {
     ctx.clearRect(0, 0, W, H);
@@ -286,6 +402,27 @@
     drawDesk(5, 1, 1, false);             // CEO Agent desk (back right)
     drawDesk(2, 4, 1, false);             // Engineer Agent desk
     drawDesk(4, 3, 1, false);             // CMO Agent desk
+
+    // Characters (back-to-front sort by gx+gy)
+    charHits.length = 0;
+    const sorted = [...CHARS].sort((a, b) => (a.gx + a.gy) - (b.gx + b.gy));
+    for (const char of sorted) {
+      const c  = isoCenter(char.gx, char.gy);
+      const cw = char.wide ? 24 : 20;
+      const cx = c.x - cw / 2 - 2;
+      const cy = c.y - 52;
+
+      // Shadow
+      ctx.fillStyle = C.shadow;
+      ctx.beginPath();
+      ctx.ellipse(c.x, c.y + 2, char.wide ? 14 : 11, 5, 0, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Sprite
+      char.fn(cx, cy, animF);
+
+      charHits.push({ char, cx, cy, w: cw + 4, h: 54 });
+    }
   }
 
   function loop() { draw(); requestAnimationFrame(loop); }

--- a/website/scene.js
+++ b/website/scene.js
@@ -359,6 +359,37 @@
     ctx.fillStyle = '#100808'; ctx.fillRect(x + 2, y + 46, 7, 4); ctx.fillRect(x + 11, y + 46, 7, 4);
   }
 
+  function drawAgent(x, y, color, label, f) {
+    const b = f < 2 ? 0 : 1;
+    // Robot head block (solid color)
+    ctx.fillStyle = color; ctx.fillRect(x + 2, y + b, 16, 14);
+    // Screen face
+    ctx.fillStyle = C.bg; ctx.fillRect(x + 4, y + 3 + b, 12, 7);
+    const eyeCol = color === C.yellow ? '#AA7800' : C.blue;
+    ctx.fillStyle = eyeCol;
+    ctx.fillRect(x + 5,  y + 4 + b, 4, 4);
+    ctx.fillRect(x + 11, y + 4 + b, 4, 4);
+    // Blink on frame 3
+    if (f === 3) {
+      ctx.fillStyle = C.bg;
+      ctx.fillRect(x + 5,  y + 6 + b, 4, 2);
+      ctx.fillRect(x + 11, y + 6 + b, 4, 2);
+    }
+    // Body
+    ctx.fillStyle = color; ctx.fillRect(x, y + 14 + b, 20, 16);
+    // Nameplate badge
+    ctx.fillStyle = C.bg;    ctx.fillRect(x + 2, y + 20 + b, 16, 8);
+    ctx.fillStyle = color;
+    ctx.font = '5px "Press Start 2P"'; ctx.textAlign = 'center';
+    ctx.fillText(label.substring(0, 3).toUpperCase(), x + 10, y + 27 + b);
+    // Legs
+    ctx.fillStyle = '#202020';
+    ctx.fillRect(x + 2,  y + 30 + b, 7,  16);
+    ctx.fillRect(x + 11, y + 30 + b, 7,  16);
+    ctx.fillRect(x,      y + 46,     9,  4);
+    ctx.fillRect(x + 11, y + 46,     9,  4);
+  }
+
   // ── Characters ─────────────────────────────────────────────────
   const CHARS = [
     { id: 'pam',     name: 'Pam Beesly',    quote: 'WUPHF!',
@@ -373,6 +404,12 @@
       gx: 5.5, gy: 4,   fn: drawKevin, wide: true },
     { id: 'creed',   name: 'Creed Bratton',  quote: "Nobody steals from Creed Bratton and gets away with it. The website is fine.",
       gx: 0.5, gy: 5,   fn: drawCreed },
+    { id: 'ceo', name: 'CEO Agent',      quote: 'Routing task to engineering team. ETA: 3 minutes.',
+      gx: 5.5, gy: 2,   isAgent: true, color: C.yellow,  label: 'CEO' },
+    { id: 'eng', name: 'Engineer Agent', quote: 'Implementing feature... 47% complete.',
+      gx: 2.5, gy: 4,   isAgent: true, color: C.blue,    label: 'ENG' },
+    { id: 'cmo', name: 'CMO Agent',      quote: 'Drafting launch post. You will not believe this lede.',
+      gx: 4.2, gy: 3.2, isAgent: true, color: '#5AAA7A', label: 'CMO' },
   ];
 
   const charHits = [];
@@ -418,8 +455,24 @@
       ctx.ellipse(c.x, c.y + 2, char.wide ? 14 : 11, 5, 0, 0, Math.PI * 2);
       ctx.fill();
 
-      // Sprite
-      char.fn(cx, cy, animF);
+      // Sprite (agent or cast)
+      if (char.isAgent) {
+        drawAgent(cx, cy, char.color, char.label, animF);
+      } else {
+        char.fn(cx, cy, animF);
+      }
+
+      // Nametag: Pam (so visitors know who she is) + all agents
+      if (char.id === 'pam' || char.isAgent) {
+        const tagColor  = char.isAgent ? char.color : C.yellow;
+        const firstName = char.name.split(' ')[0].substring(0, 8);
+        const tagW      = firstName.length * 6 + 16;
+        ctx.fillStyle   = tagColor;
+        ctx.fillRect(c.x - tagW / 2, cy - 14, tagW, 11);
+        ctx.fillStyle    = C.bg;
+        ctx.font = '5px "Press Start 2P"'; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+        ctx.fillText(firstName, c.x, cy - 8);
+      }
 
       charHits.push({ char, cx, cy, w: cw + 4, h: 54 });
     }

--- a/website/scene.js
+++ b/website/scene.js
@@ -62,6 +62,7 @@
   let flashOn   = true;
   let animF     = 0;
   let drawerHit = null;
+  let drawerOpen = false;
 
   setInterval(() => { flashOn = !flashOn; }, 500);
   setInterval(() => { animF = (animF + 1) % 4; }, 280);
@@ -491,6 +492,38 @@
     drawDesk(2, 4, 1, false);             // Engineer Agent desk
     drawDesk(4, 3, 1, false);             // CMO Agent desk
 
+    // "Click Me!" tooltip above the reception desk flashing drawer
+    if (!drawerOpen && flashOn && drawerHit) {
+      const { drawerX: dx, drawerY: dy } = drawerHit;
+      ctx.fillStyle = C.yellow;
+      ctx.fillRect(dx - 4, dy - 22, 72, 18);
+      // Down-pointing triangle
+      ctx.beginPath();
+      ctx.moveTo(dx + 8,  dy - 4);
+      ctx.lineTo(dx + 16, dy - 4);
+      ctx.lineTo(dx + 12, dy);
+      ctx.closePath(); ctx.fill();
+      ctx.fillStyle = C.bg;
+      ctx.font = '6px "Press Start 2P"'; ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
+      ctx.fillText('Click Me!', dx, dy - 13);
+    }
+
+    // Drawer reveal
+    if (drawerOpen && drawerHit) {
+      const { drawerX: dx, drawerY: dy } = drawerHit;
+      const rx = dx - 8, ry = dy + 14;
+      ctx.fillStyle = C.surface;
+      ctx.fillRect(rx, ry, 190, 44);
+      ctx.strokeStyle = C.yellow; ctx.lineWidth = 2;
+      ctx.strokeRect(rx, ry, 190, 44);
+      ctx.fillStyle = C.text;
+      ctx.font = '7px "Press Start 2P"'; ctx.textAlign = 'left'; ctx.textBaseline = 'top';
+      ctx.fillText('One command.', rx + 8, ry + 6);
+      ctx.fillText('One office.', rx + 8, ry + 18);
+      ctx.fillStyle = C.yellow;
+      ctx.fillText('./wuphf', rx + 8, ry + 30);
+    }
+
     // Characters (back-to-front sort by gx+gy)
     charHits.length = 0;
     const sorted = [...CHARS].sort((a, b) => (a.gx + a.gy) - (b.gx + b.gy));
@@ -540,6 +573,16 @@
     const scaleY = H / rect.height;
     const mx = (e.clientX - rect.left) * scaleX;
     const my = (e.clientY - rect.top)  * scaleY;
+
+    // Check reception drawer click
+    if (drawerHit) {
+      const { drawerX: dx, drawerY: dy } = drawerHit;
+      if (mx >= dx - 4 && mx <= dx + 74 &&
+          my >= dy - 26 && my <= dy + 14) {
+        drawerOpen = !drawerOpen;
+        return;
+      }
+    }
 
     // Check characters
     for (const hit of charHits) {

--- a/website/scene.js
+++ b/website/scene.js
@@ -695,8 +695,17 @@
     }
   }
 
-  function loop() { draw(); requestAnimationFrame(loop); }
-  loop();
+  let rafId;
+  function loop() {
+    draw();
+    rafId = requestAnimationFrame(loop);
+  }
+  rafId = requestAnimationFrame(loop);
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) cancelAnimationFrame(rafId);
+    else rafId = requestAnimationFrame(loop);
+  });
 
   canvas.addEventListener('click', e => {
     const rect = canvas.getBoundingClientRect();
@@ -783,6 +792,14 @@
     }
 
     canvas.style.cursor = pointer ? 'pointer' : 'default';
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === 'Escape') {
+      activeThought = null;
+      activeReveal  = null;
+      drawerOpen    = false;
+    }
   });
 
 })();

--- a/website/scene.js
+++ b/website/scene.js
@@ -702,4 +702,38 @@
     activeThought = null;
   });
 
+  canvas.addEventListener('mousemove', e => {
+    const rect   = canvas.getBoundingClientRect();
+    const scaleX = W / rect.width;
+    const scaleY = H / rect.height;
+    const mx = (e.clientX - rect.left) * scaleX;
+    const my = (e.clientY - rect.top)  * scaleY;
+
+    let pointer = false;
+
+    // Drawer
+    if (drawerHit) {
+      const { drawerX: dx, drawerY: dy } = drawerHit;
+      if (mx >= dx - 4 && mx <= dx + 74 && my >= dy - 26 && my <= dy + 14) pointer = true;
+    }
+
+    // Characters
+    if (!pointer) {
+      for (const hit of charHits) {
+        if (mx >= hit.cx && mx <= hit.cx + hit.w &&
+            my >= hit.cy && my <= hit.cy + hit.h) { pointer = true; break; }
+      }
+    }
+
+    // Interactables
+    if (!pointer) {
+      for (const hit of interactHits) {
+        if (mx >= hit.x && mx <= hit.x + hit.w &&
+            my >= hit.y && my <= hit.y + hit.h) { pointer = true; break; }
+      }
+    }
+
+    canvas.style.cursor = pointer ? 'pointer' : 'default';
+  });
+
 })();

--- a/website/scene.js
+++ b/website/scene.js
@@ -1,0 +1,15 @@
+// WUPHF Pixel Office — scene engine
+// Loaded by website/index.html. No dependencies.
+// See DESIGN.md for the full spec.
+
+(function () {
+  'use strict';
+
+  const canvas = document.getElementById('officeCanvas');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+
+  // scene.js content goes here — added task by task
+
+  console.log('WUPHF scene stub loaded');
+})();

--- a/website/scene.js
+++ b/website/scene.js
@@ -58,6 +58,14 @@
     return { x: p.x + TW / 2, y: p.y + TH / 2 };
   }
 
+  // ── State ──────────────────────────────────────────────────────
+  let flashOn   = true;
+  let animF     = 0;
+  let drawerHit = null;
+
+  setInterval(() => { flashOn = !flashOn; }, 500);
+  setInterval(() => { animF = (animF + 1) % 4; }, 280);
+
   // ── Floor tile ─────────────────────────────────────────────────
   function drawFloorTile(gx, gy, color) {
     const p = iso(gx, gy);
@@ -193,16 +201,91 @@
     ctx.fillText('ROOM', cp.x - 20, OY + 17);
   }
 
+  // ── Furniture ──────────────────────────────────────────────────
+  // Returns the hit-testable drawer rect: { drawerX, drawerY }
+  function drawDesk(gx, gy, w, flash) {
+    const DH = 22;
+    drawIsoBox(gx, gy, w, 1, DH, C.desk, C.deskDark, C.deskSide);
+
+    // Monitor
+    const p  = iso(gx, gy);
+    const mx = p.x + TW * w / 2 + 6;
+    const my = p.y - DH - 22;
+    ctx.fillStyle = '#1A2030'; ctx.fillRect(mx, my, 28, 18);
+    ctx.fillStyle = '#1A3858'; ctx.fillRect(mx + 2, my + 2, 24, 14);
+    ctx.fillStyle = C.blue;
+    for (let i = 0; i < 3; i++) ctx.fillRect(mx + 4, my + 4 + i * 4, 8 + i * 4, 2);
+    ctx.fillStyle = '#1A1820';
+    ctx.fillRect(mx + 10, my + 18, 8, 5);
+    ctx.fillRect(mx + 6,  my + 22, 16, 3);
+
+    // Drawer (flashes amber when flash=true)
+    const dp = iso(gx + w - 1, gy);
+    const dx = dp.x + 6;
+    const dy = dp.y - DH + 6;
+    ctx.fillStyle = (flash && flashOn) ? C.yellow : C.deskDark;
+    if (flash && flashOn) { ctx.shadowColor = C.yellow; ctx.shadowBlur = 8; }
+    ctx.fillRect(dx, dy, 20, 12);
+    ctx.shadowBlur = 0;
+    ctx.strokeStyle = (flash && flashOn) ? C.yellow : C.deskSide;
+    ctx.lineWidth = 1.5;
+    ctx.strokeRect(dx, dy, 20, 12);
+    ctx.fillStyle = C.yellow;
+    ctx.fillRect(dx + 7, dy + 4, 6, 4);
+
+    // Paper on desk
+    const pp = iso(gx, gy);
+    ctx.fillStyle = C.surfaceHi; ctx.fillRect(pp.x + 16, pp.y - DH - 2, 16, 12);
+    ctx.fillStyle = C.border;
+    for (let i = 0; i < 3; i++) ctx.fillRect(pp.x + 18, pp.y - DH + 1 + i * 3, 10, 1);
+
+    return { drawerX: dx, drawerY: dy };
+  }
+
+  function drawPlant(gx, gy) {
+    const c = isoCenter(gx, gy);
+    ctx.fillStyle = '#5A3A18'; ctx.fillRect(c.x - 5, c.y - 14, 10, 10);
+    ctx.fillStyle = C.plant;   ctx.fillRect(c.x - 10, c.y - 28, 20, 18);
+    ctx.fillStyle = '#2A4818'; ctx.fillRect(c.x - 7,  c.y - 32, 14, 8);
+    ctx.fillStyle = C.plant;   ctx.fillRect(c.x - 4,  c.y - 36, 8, 10);
+  }
+
+  function drawSnackJar(gx, gy) {
+    const c = isoCenter(gx, gy);
+    ctx.fillStyle = '#3A5878'; ctx.fillRect(c.x - 6, c.y - 18, 12, 14);
+    ctx.fillStyle = C.surface; ctx.fillRect(c.x - 5, c.y - 17, 10, 12);
+    ctx.fillStyle = C.yellow;  ctx.fillRect(c.x - 3, c.y - 12, 6, 6);
+    ctx.fillStyle = C.deskDark; ctx.fillRect(c.x - 5, c.y - 18, 12, 4);
+    ctx.fillStyle = C.text;
+    ctx.font = '4px "Press Start 2P"'; ctx.textAlign = 'center';
+    ctx.fillText('NO',    c.x, c.y - 10);
+    ctx.fillText('WASTE', c.x, c.y - 6);
+  }
+
   // ── Main draw ──────────────────────────────────────────────────
   function draw() {
     ctx.clearRect(0, 0, W, H);
     drawWall();
 
+    // Floor tiles
     for (let gy = 0; gy < ROWS; gy++) {
       for (let gx = 0; gx < COLS; gx++) {
         drawFloorTile(gx, gy, (gx + gy) % 2 === 0 ? C.carpet : C.carpetAlt);
       }
     }
+
+    // Props
+    drawPlant(8, 0);
+    drawPlant(8, 2);
+    drawSnackJar(5, 4);
+
+    // Desks (back-to-front: lower gx+gy first)
+    drawerHit = drawDesk(2, 0, 2, true);  // reception desk — flashing drawer
+    drawDesk(0, 3, 1, false);             // Dwight's desk
+    drawDesk(2, 3, 1, false);             // Jim's desk
+    drawDesk(5, 1, 1, false);             // CEO Agent desk (back right)
+    drawDesk(2, 4, 1, false);             // Engineer Agent desk
+    drawDesk(4, 3, 1, false);             // CMO Agent desk
   }
 
   function loop() { draw(); requestAnimationFrame(loop); }

--- a/website/style.css
+++ b/website/style.css
@@ -61,23 +61,12 @@ a:hover { text-decoration: underline; }
   justify-content: center;
   overflow: hidden;
   cursor: default;
+  height: calc(100vh - 44px);
 }
 #officeCanvas {
   display: block;
-  image-rendering: pixelated;
   max-width: 100%;
 }
-.hint-bar {
-  background: var(--surface);
-  border-top: 1px solid var(--border);
-  text-align: center;
-  font-family: var(--font-pixel);
-  font-size: 7px;
-  color: var(--text-muted);
-  padding: 8px;
-  letter-spacing: 0.08em;
-}
-.hint-arrow { color: var(--yellow); }
 
 /* ── Install section ────────────────────────────────────────────── */
 .install-section {

--- a/website/style.css
+++ b/website/style.css
@@ -1,0 +1,195 @@
+/* ── Design tokens ──────────────────────────────────────────────── */
+:root {
+  --bg:           #1A1610;
+  --surface:      #242018;
+  --surface-high: #2E2820;
+  --border:       #3A3028;
+  --text:         #F0EBD8;
+  --text-muted:   #8A7D6A;
+  --yellow:       #ECB22E;
+  --yellow-dark:  #C49020;
+  --blue:         #5A9AC8;
+
+  --font-pixel:    'Press Start 2P', cursive;
+  --font-dialogue: 'VT323', monospace;
+  --font-mono:     'DM Mono', monospace;
+}
+
+/* ── Reset ──────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: auto; }
+body { background: var(--bg); color: var(--text); font-family: var(--font-mono); }
+a { color: var(--yellow); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* ── Nav ────────────────────────────────────────────────────────── */
+.site-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 28px;
+  background: var(--surface);
+  border-bottom: 3px solid var(--yellow-dark);
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+.nav-logo {
+  font-family: var(--font-pixel);
+  font-size: 11px;
+  color: var(--yellow);
+  letter-spacing: 0.12em;
+}
+.nav-links {
+  display: flex;
+  gap: 28px;
+}
+.nav-links a {
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--text-muted);
+  letter-spacing: 0.05em;
+  text-decoration: none;
+}
+.nav-links a:hover { color: var(--yellow); text-decoration: none; }
+
+/* ── Scene ──────────────────────────────────────────────────────── */
+.scene-wrap {
+  width: 100%;
+  background: #201C14;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  cursor: default;
+}
+#officeCanvas {
+  display: block;
+  image-rendering: pixelated;
+  max-width: 100%;
+}
+.hint-bar {
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  text-align: center;
+  font-family: var(--font-pixel);
+  font-size: 7px;
+  color: var(--text-muted);
+  padding: 8px;
+  letter-spacing: 0.08em;
+}
+.hint-arrow { color: var(--yellow); }
+
+/* ── Install section ────────────────────────────────────────────── */
+.install-section {
+  padding: 80px 24px;
+  border-bottom: 3px solid var(--border);
+}
+.install-inner {
+  max-width: 700px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
+  text-align: center;
+}
+.install-label {
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  color: var(--text-muted);
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+.install-cmd {
+  background: var(--surface-high);
+  border: 3px solid var(--border);
+  padding: 20px 28px;
+  font-family: var(--font-mono);
+  font-size: 15px;
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+}
+.install-prompt { color: var(--yellow); user-select: none; }
+.install-code { color: var(--blue); }
+.install-note {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-muted);
+  line-height: 1.7;
+}
+.install-ctas {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+/* ── Pixel buttons ──────────────────────────────────────────────── */
+.btn-pixel {
+  font-family: var(--font-pixel);
+  font-size: 8px;
+  background: var(--yellow);
+  color: var(--bg);
+  border: none;
+  padding: 14px 24px;
+  box-shadow: 5px 5px 0 var(--yellow-dark);
+  display: inline-block;
+  text-decoration: none;
+  cursor: pointer;
+  letter-spacing: 0.05em;
+}
+.btn-pixel:hover { text-decoration: none; filter: brightness(1.08); }
+.btn-pixel:active { transform: translate(5px, 5px); box-shadow: none; }
+.btn-secondary {
+  background: var(--surface-high);
+  color: var(--yellow);
+  box-shadow: 5px 5px 0 var(--border);
+}
+.btn-secondary:active { transform: translate(5px, 5px); box-shadow: none; }
+
+/* ── Footer ─────────────────────────────────────────────────────── */
+.site-footer {
+  padding: 40px 24px;
+  background: var(--surface);
+}
+.footer-inner {
+  max-width: 700px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+.footer-logo {
+  font-family: var(--font-pixel);
+  font-size: 9px;
+  color: var(--yellow);
+  letter-spacing: 0.12em;
+}
+.footer-links {
+  display: flex;
+  gap: 24px;
+}
+.footer-links a {
+  font-family: var(--font-pixel);
+  font-size: 6px;
+  color: var(--text-muted);
+  letter-spacing: 0.05em;
+}
+.footer-links a:hover { color: var(--yellow); text-decoration: none; }
+.footer-note {
+  font-family: var(--font-dialogue);
+  font-size: 20px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* ── Mobile ─────────────────────────────────────────────────────── */
+@media (max-width: 767px) {
+  .install-cmd { font-size: 12px; padding: 16px; overflow-x: auto; }
+  .footer-links { flex-direction: column; gap: 12px; }
+}


### PR DESCRIPTION
## Summary

Ships the pixel office marketing site to production at **wuphf.team**.

**website/index.html** — Full marketing page rebuild (2200 lines, self-contained):
- Pretext text layout wiring on 6 elements (hero tagline, all section headings, section body copy). ResizeObserver-driven reflow: text containers compute correct height on every viewport resize, no clipping or overflow.
- Conversations section: CSS Grid (1fr 1fr) replacing broken inline flex. Drops to single column at 640px.
- Full pixel art isometric office scene with 24 agents, interactive click reveals, ambient animations — all `steps()` easing per DESIGN.md.
- Dark mode only. `#ECB22E` amber accent. Press Start 2P / VT323 / DM Mono.

**website/CNAME** — `wuphf.team` custom domain.

**.github/workflows/pages.yml** — GitHub Pages deploy workflow. Triggers on push to `main` touching `website/**` or manual dispatch. Deploys `website/` directory. Uses `actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`.

## Test plan

- [ ] GitHub Pages settings: enable Pages, set source to GitHub Actions
- [ ] DNS: add `A` records for `185.199.108-111.153.153` + `CNAME www → nex-crm.github.io`
- [ ] Verify `https://wuphf.team` loads the pixel office page
- [ ] Resize window — text elements reflow dynamically (Pretext)
- [ ] Mobile (375px) — conversations grid drops to single column
- [ ] Dark mode only — no light mode flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)