### PR TITLE
feat: WUPHF_BROKER_STATE_PATH + WUPHF_CONFIG_PATH env overrides

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,12 @@ type OpenclawBridgeBinding struct {
 // ConfigPath returns the absolute path to ~/.wuphf/config.json, with a legacy
 // fallback to ~/.nex/config.json when the old file already exists.
 func ConfigPath() string {
+	// Env override for test harnesses that need to isolate config state from
+	// the user's real ~/.wuphf/config.json without remapping HOME (which
+	// breaks macOS keychain-backed CLI auth).
+	if p := strings.TrimSpace(os.Getenv("WUPHF_CONFIG_PATH")); p != "" {
+		return p
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(".wuphf", "config.json")

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -1778,6 +1778,12 @@ func (b *Broker) Reset() {
 }
 
 func defaultBrokerStatePath() string {
+	// Env override lets probes and test harnesses isolate broker state from
+	// the user's real ~/.wuphf/team/ dir without needing to remap HOME (which
+	// breaks macOS keychain-backed auth for bundled CLIs like Claude Code).
+	if p := strings.TrimSpace(os.Getenv("WUPHF_BROKER_STATE_PATH")); p != "" {
+		return p
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(".wuphf", "team", "broker-state.json")


### PR DESCRIPTION
## Summary

Two small env shims for test harnesses that need to isolate WUPHF state from the user's real `~/.wuphf/` dir **without remapping `HOME`**:

- `WUPHF_BROKER_STATE_PATH` → overrides `defaultBrokerStatePath()`
- `WUPHF_CONFIG_PATH` → overrides `ConfigPath()`

## Why

While live-testing per-agent providers (PR #79), I needed an isolated WUPHF install alongside the user's daily-driver wuphf. First attempt remapped `HOME` to a temp dir. That **broke Claude Code auth** — Claude's OAuth token lives in the macOS Keychain under an ACL pinned to the real `$HOME`, so a remapped `HOME` gets back "Not logged in · Please run /login."

With these overrides, the probe runs against real `$HOME` (Claude/Codex keychain auth works) but points broker state + config at a temp dir (no production state clobbered). `WUPHF_COMPANY_FILE` already exists for manifest isolation, so the trio now covers every `HOME`-derived path WUPHF writes.

## Test plan

- [x] Full `go test ./...` green
- [x] Live multi-provider probe (`cmd/wuphf-oc-probe/multi-provider-http`) now verifies all three runtimes replying in `#general`:
  - `research-oc1` (openclaw): "I'm openclaw-main."
  - `eng-alpha` (codex): "@eng-alpha checking in."
  - `pm-alpha` (claude-code): "@pm-alpha here — product, roadmap, and scope are my lane."
  - Bonus: `ceo` (claude-code) participated contextually: "Solid. That's the call — flat structure until the service earns more directories. Ship it."

## Blast radius

12 lines added across 2 files, both behind env-var gates. Zero behavior change when env vars aren't set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)