### PR TITLE
fix: agent bugs — 404, removal, threads expanded, DM pane

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -5656,7 +5656,8 @@ func (b *Broker) handleChannelMembers(w http.ResponseWriter, r *http.Request) {
 		ch := b.findChannelLocked(channel)
 		if ch == nil {
 			b.mu.Unlock()
-			http.Error(w, "channel not found", http.StatusNotFound)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{"channel": channel, "members": []map[string]any{}})
 			return
 		}
 		memberInfo := make([]map[string]any, 0, len(ch.Members))

--- a/web/index.html
+++ b/web/index.html
@@ -5193,7 +5193,8 @@ function showOffice() {
               checked: true,
               type: m.type || 'specialist',
               expertise: m.expertise || [],
-              personality: m.personality || ''
+              personality: m.personality || '',
+              builtIn: !!m.built_in
             };
           });
         }
@@ -7482,9 +7483,14 @@ function removeThreadState(container) {
 }
 
 function setThreadReplyCount(parentId, count) {
+  var wasExpanded = !!inlineExpandedThreads[parentId];
   if (count > 0) threadReplyCounts[parentId] = count;
   else delete threadReplyCounts[parentId];
   updateThreadLink(parentId);
+  // Auto-expand inline thread when first gaining replies (expanded by default)
+  if (!wasExpanded && inlineExpandedThreads[parentId]) {
+    renderInlineThread(parentId);
+  }
   if (activeThreadId === parentId) {
     var replyCount = document.getElementById('thread-reply-count');
     if (replyCount) replyCount.textContent = threadRepliesLabel(count);
@@ -8027,12 +8033,15 @@ function appendMessageToContainer(msg, container, opts) {
 }
 
 var inlineExpandedThreads = {};
+var inlineCollapsedThreads = {};
 
 function updateThreadLink(parentId) {
   var controls = document.getElementById(threadControlsId(parentId));
   if (!controls) return;
   var count = threadReplyCounts[parentId] || 0;
-  var inlineExpanded = !!inlineExpandedThreads[parentId];
+  // Threads with replies are expanded by default unless explicitly collapsed
+  var inlineExpanded = count > 0 && !inlineCollapsedThreads[parentId];
+  if (inlineExpanded) inlineExpandedThreads[parentId] = true;
   var panelOpen = activeThreadId === parentId && isThreadPanelOpen();
 
   controls.textContent = '';
@@ -8070,12 +8079,14 @@ function toggleInlineThread(parentId) {
 
   if (inlineExpandedThreads[parentId]) {
     inlineExpandedThreads[parentId] = false;
+    inlineCollapsedThreads[parentId] = true;
     inlineContainer.hidden = true;
     updateThreadLink(parentId);
     return;
   }
 
   inlineExpandedThreads[parentId] = true;
+  delete inlineCollapsedThreads[parentId];
   updateThreadLink(parentId);
   renderInlineThread(parentId);
 }
@@ -8253,7 +8264,8 @@ function refreshOfficeSidebar() {
           checked: true,
           type: m.type || 'specialist',
           expertise: m.expertise || [],
-          personality: m.personality || ''
+          personality: m.personality || '',
+          builtIn: !!m.built_in
         };
       });
     }
@@ -9339,6 +9351,27 @@ function openAgentPanel(slug) {
   editBtn.textContent = 'Edit agent';
   editBtn.addEventListener('click', function() { closeAgentPanel(); openAgentWizard(agent); });
   actionsSection.appendChild(editBtn);
+
+  if (!agent.builtIn && agent.slug !== 'ceo') {
+    var removeBtn = document.createElement('button');
+    removeBtn.className = 'btn btn-ghost btn-sm';
+    removeBtn.style.width = '100%';
+    removeBtn.style.marginBottom = '8px';
+    removeBtn.style.color = 'var(--red, #dc2626)';
+    removeBtn.textContent = 'Remove agent';
+    removeBtn.addEventListener('click', function() {
+      if (!confirm('Remove ' + agent.name + '? This cannot be undone.')) return;
+      WuphfAPI.post('/office-members', { action: 'remove', slug: agent.slug })
+        .then(function() {
+          closeAgentPanel();
+          AGENTS = AGENTS.filter(function(a) { return a.slug !== agent.slug; });
+          renderSidebarAgents();
+          showNotice(agent.name + ' removed', 'success');
+        })
+        .catch(function(e) { showNotice('Remove failed: ' + (e.message || e), 'error'); });
+    });
+    actionsSection.appendChild(removeBtn);
+  }
 
   body.appendChild(avatar);
   body.appendChild(nameEl);
@@ -11228,6 +11261,12 @@ function onDMChannelEnter(slug) {
   // Move composer + typing into split left pane
   if (splitLeft && composer) splitLeft.appendChild(typing);
   if (splitLeft && composer) splitLeft.appendChild(composer);
+  // Restore stream pane state — expanded by default
+  var streamLines = document.getElementById('dm-stream-lines');
+  var collapseIcon = document.getElementById('dm-stream-collapse-icon');
+  var wasCollapsed = localStorage.getItem('wuphf-stream-pane-collapsed') === 'true';
+  if (streamLines) streamLines.style.display = wasCollapsed ? 'none' : '';
+  if (collapseIcon) collapseIcon.textContent = wasCollapsed ? '\u25B8' : '\u25BE';
   connectAgentStream(slug);
   renderSidebarAgents();
 }


### PR DESCRIPTION
## Summary
- **channel-members 404**: Return empty members array instead of 404 when channel not found in `GET /channel-members` (handles broker init race)
- **Agent removal**: Add "Remove agent" button to Agent Detail panel — calls existing `POST /office-members` remove action, guarded for built-in agents and CEO
- **Threads expanded by default**: Inline threads auto-expand when they have replies; user can still collapse manually and the preference is respected
- **DM pane state**: Restore live output pane collapsed/expanded state from localStorage on DM channel enter (defaults to expanded)

## Test plan
- [ ] Open Agent Detail for a non-built-in agent → "Remove agent" button visible
- [ ] Open Agent Detail for CEO → no "Remove agent" button
- [ ] Click "Remove agent" → confirm dialog → agent removed from sidebar
- [ ] Navigate to a channel with threaded replies → threads expanded inline by default
- [ ] Collapse a thread → navigate away and back → thread stays collapsed
- [ ] Open a DM → live output pane is expanded
- [ ] Collapse the pane → reopen DM → pane stays collapsed
- [ ] Fresh broker start → no 404 in console for `/api/channel-members`