### PR TITLE
fix(tests): isolate config-dependent and flaky CI tests

### DIFF
--- a/internal/team/headless_claude_test.go
+++ b/internal/team/headless_claude_test.go
@@ -221,7 +221,9 @@ func TestEnsureAgentMCPConfig_NoNexEntryInWrittenFile(t *testing.T) {
 // MCP server now owns shared-memory access, so Nex credentials flow through the
 // wuphf-office server instead of mounting a raw nex MCP server.
 func TestBuildMCPServerMap_NexCredentialsFlowThroughOffice(t *testing.T) {
+	t.Setenv("WUPHF_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
 	t.Setenv("WUPHF_NO_NEX", "")
+	t.Setenv("WUPHF_MEMORY_BACKEND", "nex")
 	t.Setenv("WUPHF_API_KEY", "test-key-12345")
 
 	l := minimalLauncher(false)

--- a/internal/team/worktree_test.go
+++ b/internal/team/worktree_test.go
@@ -335,6 +335,10 @@ func TestDefaultPrepareTaskWorktreeSkipsDuplicateAndMissingCompletedSiblingSourc
 	if err := os.WriteFile(filepath.Join(firstPath, "cmd", "approvalrunner", "main.go"), []byte("package main\n"), 0o644); err != nil {
 		t.Fatalf("write sibling task file: %v", err)
 	}
+	// Stage the file so it appears in `git diff --name-only HEAD` (the primary
+	// overlay detection path) rather than relying solely on `git ls-files --others`
+	// which can be unreliable in CI worktree environments.
+	run(firstPath, "git", "add", "cmd/approvalrunner/main.go")
 
 	state := struct {
 		Tasks []teamTask `json:"tasks"`


### PR DESCRIPTION
## Summary

Fixes the two remaining CI test failures:

- **TestBuildMCPServerMap_NexCredentialsFlowThroughOffice** — test relied on `memory_backend` defaulting to `"nex"`, but a local or CI config file with `"none"` broke the code path. Fixed by explicitly setting `WUPHF_CONFIG_PATH` (temp dir) and `WUPHF_MEMORY_BACKEND=nex`.

- **TestDefaultPrepareTaskWorktreeSkipsDuplicateAndMissing...** — overlay detection relied on `git ls-files --others` to find untracked files in worktrees, which is unreliable on some CI git/filesystem combos. Fixed by staging the test file with `git add` so it appears via `git diff --name-only HEAD` instead.

## Test plan

- [x] Both tests pass locally (were failing before)
- [x] Full `go test ./...` passes with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)