### PR TITLE
fix(web): ensure go build works on fresh clones and falls back cleanly

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -1512,14 +1512,20 @@ func (b *Broker) ServeWebUI(port int) {
 	}
 	var fileServer http.Handler
 	serveLegacyFallback := false
-	if distDir := filepath.Join(webDir, "dist"); dirExists(distDir) {
+	distDir := filepath.Join(webDir, "dist")
+	distIndex := filepath.Join(distDir, "index.html")
+	if _, err := os.Stat(distIndex); err == nil {
+		// Real Vite build output on disk — use it.
 		fileServer = http.FileServer(http.Dir(distDir))
 	} else if embeddedFS, ok := wuphf.WebFS(); ok {
+		// No on-disk build; use embedded assets.
 		fileServer = http.FileServer(http.FS(embeddedFS))
 	} else if _, err := os.Stat(filepath.Join(webDir, "index.legacy.html")); err == nil {
+		// Source checkout without a React build — fall back to the legacy UI.
 		fileServer = http.FileServer(http.Dir(webDir))
 		serveLegacyFallback = true
 	} else {
+		// Nothing available; serve webDir as-is so 404s come from the actual FS.
 		fileServer = http.FileServer(http.Dir(webDir))
 	}
 	mux := http.NewServeMux()

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && touch dist/.gitkeep",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/"


### PR DESCRIPTION
Three small follow-ups to #98 exposed when I tried to build from a fresh clone:

### 1. Missing \`web/dist/.gitkeep\`

\`go:embed\` requires \`web/dist/\` to exist at build time. Without a committed placeholder, a fresh \`git clone\` followed by \`go build ./cmd/wuphf\` fails:

\`\`\`
embed.go:12:12: pattern all:web/dist: no matching files found
\`\`\`

Committed an empty \`web/dist/.gitkeep\` (the \`web/.gitignore\` already had \`!dist/.gitkeep\` prepared).

### 2. Vite wipes \`.gitkeep\` on every build

\`emptyOutDir: true\` clears the whole dist directory before writing. The \`.gitkeep\` gets deleted too, so after \`npm run build\` it shows up as a local deletion in \`git status\`. Added \`touch dist/.gitkeep\` to the npm build script as a post-build step.

### 3. Fallback logic bug

\`broker.ServeWebUI\` preferred \`web/dist/\` as soon as the directory existed. When \`dist/\` only has \`.gitkeep\` (fresh clone without \`npm run build\`), that caused Go's \`http.FileServer\` to render a directory listing instead of falling through to the embedded FS or \`index.legacy.html\`. Now it checks for \`dist/index.html\` specifically.

### Verified

- [x] \`go build ./cmd/wuphf\` works from a state where dist/ only has .gitkeep
- [x] Binary with only .gitkeep in dist serves legacy HTML (HTTP 200, valid HTML)
- [x] Binary with real Vite build serves the React UI (HTTP 200, React bundle in HTML)
- [x] \`npm run build\` preserves .gitkeep across runs