### PR TITLE
fix(install): re-sign binary on macOS to prevent SIGKILL

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,6 +60,14 @@ fi
 cp "${TMPDIR}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
 chmod +x "${INSTALL_DIR}/${BINARY}"
 
+# macOS: re-apply ad-hoc code signature.
+# goreleaser's linker-embedded signature is invalidated by the cp+chmod sequence
+# on macOS 15+, causing the kernel to SIGKILL the binary with
+# "Code Signature Invalid" / "Taskgated Invalid Signature".
+if [ "$OS" = "darwin" ] && command -v codesign >/dev/null 2>&1; then
+  codesign --force --sign - "${INSTALL_DIR}/${BINARY}" >/dev/null 2>&1 || true
+fi
+
 # Verify
 if "${INSTALL_DIR}/${BINARY}" --version >/dev/null 2>&1; then
   printf "Successfully installed %s to %s/%s\n" "$("${INSTALL_DIR}/${BINARY}" --version 2>&1)" "$INSTALL_DIR" "$BINARY"


### PR DESCRIPTION
## Summary
- Users installing via `curl | sh` on macOS get SIGKILL: `Killed: 9`
- Crash report: `Taskgated Invalid Signature` / `Code Signature Invalid`
- Goreleaser's linker ad-hoc signature is invalidated by `cp` + `chmod` in install.sh
- Fix: re-apply ad-hoc signature with `codesign --force --sign -` after copy on Darwin

## Test plan
- [x] Reproduce SIGKILL on macOS 15+ with v0.8.1 binary
- [x] Confirm crash report signal is CODESIGNING
- [x] Apply codesign fix, re-run `wuphf --version` → works
- [x] Run patched install.sh end-to-end → `Successfully installed`
- [x] Linux path unchanged (guard is `$OS = darwin`)

## Follow-up
Proper Developer ID signing + notarization in goreleaser config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)