### PR TITLE
fix(web): resolve React error #31 when clicking agent panel

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -156,6 +156,11 @@ export function toggleReaction(msgId: string, emoji: string, channel: string) {
 
 // ── Members ──
 
+export interface ProviderBinding {
+  kind?: string
+  model?: string
+}
+
 export interface OfficeMember {
   slug: string
   name: string
@@ -164,7 +169,7 @@ export interface OfficeMember {
   status?: string
   task?: string
   channel?: string
-  provider?: string
+  provider?: ProviderBinding | string
 }
 
 export function getOfficeMembers() {

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -157,12 +157,16 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
             <span className="agent-panel-info-label">slug</span>
             <span className="agent-panel-info-value">{agent.slug}</span>
           </div>
-          {agent.provider && (
-            <div className="agent-panel-info-row">
-              <span className="agent-panel-info-label">provider</span>
-              <span className="agent-panel-info-value">{agent.provider}</span>
-            </div>
-          )}
+          {(() => {
+            const p = agent.provider
+            const label = typeof p === 'string' ? p : p?.kind
+            return label ? (
+              <div className="agent-panel-info-row">
+                <span className="agent-panel-info-label">provider</span>
+                <span className="agent-panel-info-value">{label}</span>
+              </div>
+            ) : null
+          })()}
           {agent.status && (
             <div className="agent-panel-info-row">
               <span className="agent-panel-info-label">status</span>


### PR DESCRIPTION
## Summary
- **Bug**: Clicking any agent in the sidebar opened the AgentPanel which rendered `agent.provider` (a `ProviderBinding` object from the backend) directly as JSX, causing React error #31 ("Objects are not valid as a React child — object with keys {}")
- **Root cause**: Backend serializes `provider` as a struct (`{kind, model, openclaw}`), which becomes `{}` for default-provider agents. The frontend typed it as `string` and rendered it directly.
- **Fix**: Updated `OfficeMember.provider` type to `ProviderBinding | string`, extract `provider.kind` as a string before rendering, and skip the row when no value exists.

## Test plan
- [ ] Launch `./wuphf --memory-backend none --unsafe`
- [ ] Open http://localhost:7891
- [ ] Click on any agent in the sidebar — AgentPanel should open without crashing
- [ ] Verify provider info shows correctly for agents with a configured provider
- [ ] Verify no provider row appears for agents with default/empty provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)