### PR TITLE
ci: auto-release now dispatches Release (no more ghost tags)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,6 +6,9 @@ on:
 
 permissions:
   contents: write
+  # Needed to dispatch the Release workflow after pushing the tag. Without
+  # this, gh workflow run returns HTTP 403.
+  actions: write
 
 jobs:
   release:
@@ -51,3 +54,15 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${{ steps.bump.outputs.version }}" -m "Release ${{ steps.bump.outputs.version }}"
           git push origin "${{ steps.bump.outputs.version }}"
+
+      - name: Dispatch Release workflow at the new tag
+        # Tag pushes made with GITHUB_TOKEN do not fire other workflows, so
+        # the Release workflow's `on: push: tags` trigger never activates for
+        # auto-created tags. workflow_dispatch is the documented exception —
+        # gh triggers it explicitly and passes --ref so Release runs at the
+        # newly-created tag (goreleaser reads GITHUB_REF = refs/tags/<tag>).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          gh workflow run release.yml --ref "$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     tags:
       - "v*"
+  # workflow_dispatch lets auto-release.yml trigger this workflow via
+  # `gh workflow run release.yml --ref <tag>`. A push tag event created with
+  # GITHUB_TOKEN does not fire other workflows, but workflow_dispatch does.
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
Ghost tags v0.8.2 / v0.8.3 / v0.8.4 all hit the same bug: \`auto-release.yml\` pushed a bumped tag using \`GITHUB_TOKEN\`, but GitHub **blocks GITHUB_TOKEN from triggering other workflows on push events**. So \`release.yml\` never ran, tags had no assets, and GitHub's "latest release" stayed stuck.

The documented exception is \`workflow_dispatch\` events — those **are** allowed from GITHUB_TOKEN. Fix:

- \`release.yml\`: add \`workflow_dispatch:\` trigger. Still runs on \`push: tags\` for developer PAT pushes.
- \`auto-release.yml\`: grant \`actions: write\`, then after pushing the tag, \`gh workflow run release.yml --ref <tag>\`. Goreleaser picks up \`GITHUB_REF=refs/tags/<tag>\` automatically.

## Test plan
- [ ] After merge, confirm Auto Release → Release workflow chain fires automatically for the resulting bump tag
- [ ] Verify the new tag's GitHub Release has all 4 archive assets + checksums
- [ ] Verify \`curl | sh\` installs the new version

## Follow-ups
- Delete ghost tags v0.8.2 / v0.8.3 / v0.8.4 (they have no assets and clutter \`git tag\` listings)
- Long-term: real Developer ID codesigning + notarization in goreleaser (replacing the adhoc workaround in install.sh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)