### PR TITLE
fix(web): restore pixel-avatar sharpness with image-rendering: pixelated

### DIFF
--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -81,6 +81,19 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 .badge-accent { background: var(--accent-bg); color: var(--accent); }
 .badge-yellow { background: var(--yellow-bg); color: var(--yellow); }
 
+/* ─── Pixel avatars ─── */
+/* The canvas buffer is the sprite's native 14x14 grid; CSS scales it up.
+   Without `image-rendering: pixelated` the browser bilinearly smooths the
+   upscale and the sprites lose their pixel-art edges. */
+.pixel-avatar {
+  image-rendering: crisp-edges;
+  image-rendering: pixelated;
+  border-radius: 4px;
+  display: block;
+}
+.pixel-avatar-sidebar { width: 24px; height: 24px; }
+.pixel-avatar-panel { width: 56px; height: 56px; }
+
 /* ─── Status Dot ─── */
 .status-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
 .status-dot.active { background: var(--green); }


### PR DESCRIPTION
## Problem

After the React migration, agent avatars in the sidebar, message feed, and agent panel look blurry — the sharp pixel-art edges are gone.

## Cause

The legacy CSS had `image-rendering: pixelated` on `.pixel-avatar`. The PixelAvatar React component still renders a canvas at the sprite's native 14x14 buffer and relies on CSS to upscale it to 24/36/56 pixels. Without `image-rendering: pixelated`, browsers bilinearly smooth the upscale and the pixel-art illusion breaks.

## Fix

Ports the missing rules from `index.legacy.html` to `web/src/styles/global.css`:

- `image-rendering: crisp-edges; image-rendering: pixelated;` on `.pixel-avatar` — declaration order matters so `pixelated` wins in Chromium while Firefox/Safari fall back to `crisp-edges`
- `width/height` on `.pixel-avatar-sidebar` (24x24) and `.pixel-avatar-panel` (56x56) as a safety net
- `border-radius: 4px` to match the legacy treatment

## Before / After

Before: edges are smoothed, colors bleed across pixel boundaries.
After: razor-sharp pixel edges, faithful to the sprite grid.

## Test plan

- [x] `npm run build` passes
- [x] Screenshot diff on localhost confirms sharp rendering at 24px (sidebar) and 36px (messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)