### PR TITLE
fix(web): remove accent-bg tint behind pixel avatars

### DIFF
--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -45,7 +45,6 @@
   width: 36px;
   height: 36px;
   border-radius: 8px;
-  background: var(--accent-bg);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -31,7 +31,7 @@
 
 .sidebar-channels { padding: 4px 12px; flex: 0 1 auto; min-height: 0; max-height: 28vh; overflow-y: auto; }
 .sidebar-apps { padding: 4px 12px; flex: 1 1 auto; min-height: 0; overflow-y: auto; }
-.sidebar-agent-avatar { width: 24px; height: 24px; border-radius: 6px; background: var(--accent-bg); color: var(--accent); display: inline-flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; flex-shrink: 0; }
+.sidebar-agent-avatar { width: 24px; height: 24px; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
 .sidebar-bottom { padding: 8px; border-top: 1px solid var(--border); display: flex; flex-direction: column; gap: 6px; }
 
 /* ─── Sidebar summary / hint ─── */

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -8,7 +8,7 @@
 .message-grouped .message-avatar { visibility: hidden; height: 0; }
 .message-grouped .message-header { display: none; }
 
-.message-avatar { width: 36px; height: 36px; border-radius: 8px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 18px; background: var(--accent-bg); }
+.message-avatar { width: 36px; height: 36px; border-radius: 8px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 18px; }
 .message-content { flex: 1; min-width: 0; }
 .message-header { display: flex; align-items: baseline; gap: 8px; margin-bottom: 4px; }
 .message-author { font-size: 13px; font-weight: 600; }


### PR DESCRIPTION
## Problem

After the React migration, every agent avatar has a blue/accent square behind it in the sidebar, message feed, and agent panel. The legacy UI put the pixel art directly on the page background — no tile.

## Cause

Three wrapper CSS rules carried over a \`background: var(--accent-bg)\` that made sense for emoji placeholders but not for transparent pixel-art sprites:

- \`.sidebar-agent-avatar\` (layout.css) — wrapper didn't even exist in legacy; canvas was appended directly to the \`.sidebar-agent\` button
- \`.message-avatar\` (messages.css) — legacy showed emoji text here, so the tint was invisible behind it
- \`.agent-panel-avatar\` (agents.css) — legacy overrode to \`background: transparent\` inline

## Fix

Drop the default background from all three. Human "You" messages keep their blue tile via the inline \`background: var(--accent)\` already set in MessageBubble. Also removes the now-unused text styling (\`color\`, \`font-size\`, \`font-weight\`) on \`.sidebar-agent-avatar\` since it only contains a canvas.

## Test plan

- [x] \`npm run build\` passes
- [x] Screenshot confirms avatars sit on page background in sidebar, messages, and agent panel
- [x] "You" human message tile still blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)