### PR TITLE
ci: add lint, install-verify, and visual regression stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,23 +78,42 @@ jobs:
 
   vhs:
     runs-on: ubuntu-latest
+    env:
+      VHS_VERSION: v0.11.0
+      TTYD_VERSION: "1.7.7"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          # VHS @latest tracks newer Go minors than go.mod pins; use stable so
-          # `go install github.com/charmbracelet/vhs@latest` doesn't get blocked
-          # by GOTOOLCHAIN=local (Go is forward-compatible for the wuphf build).
+          # VHS tracks newer Go minors than go.mod pins; use stable so
+          # `go install vhs` isn't blocked by GOTOOLCHAIN=local (Go is
+          # forward-compatible for the wuphf build in this job).
           go-version: stable
+      - name: Cache VHS binary
+        id: cache-vhs
+        uses: actions/cache@v5
+        with:
+          path: ~/go/bin/vhs
+          key: vhs-${{ runner.os }}-${{ env.VHS_VERSION }}
       - name: Install VHS
-        run: |
-          go install github.com/charmbracelet/vhs@latest
+        if: steps.cache-vhs.outputs.cache-hit != 'true'
+        run: go install github.com/charmbracelet/vhs@${{ env.VHS_VERSION }}
+      - name: Cache ttyd download
+        id: cache-ttyd
+        uses: actions/cache@v5
+        with:
+          path: /tmp/ttyd.x86_64
+          key: ttyd-${{ runner.os }}-${{ env.TTYD_VERSION }}
+      - name: Download ttyd
+        if: steps.cache-ttyd.outputs.cache-hit != 'true'
+        run: curl -fLo /tmp/ttyd.x86_64 https://github.com/tsl0922/ttyd/releases/download/${{ env.TTYD_VERSION }}/ttyd.x86_64
       - name: Install ttyd
-        run: |
-          curl -Lo ttyd.x86_64 https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.x86_64
-          sudo install ttyd.x86_64 /usr/local/bin/ttyd
+        run: sudo install /tmp/ttyd.x86_64 /usr/local/bin/ttyd
       - name: Install ffmpeg
-        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: ffmpeg
+          version: "1"
       - name: Build wuphf
         run: go build -o wuphf ./cmd/wuphf
       - name: Run VHS regression checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run shellcheck
         run: |
           sudo apt-get install -y shellcheck
-          shellcheck scripts/*.sh
+          shellcheck scripts/*.sh testdata/vhs/*.sh
 
   web-e2e:
     # Playwright smoke against the real web UI. Guards the class of regression
@@ -185,11 +185,61 @@ jobs:
         # --with-deps installs the OS-level shared libs chromium needs on
         # ubuntu-latest even when the cached browser binary is restored.
         run: bunx playwright install --with-deps chromium
-      - name: Seed onboarding state + start wuphf
-        # Pre-seeding ~/.wuphf/onboarded.json skips the wizard so the test
-        # lands in the real Shell and can exercise the agent-click path that
-        # used to crash with React #31. Redirect stdin to /dev/null so
-        # isPiped() doesn't steal our boot into scanner mode.
+      - name: Install claude CLI stub
+        # wuphf's PreflightWeb hard-requires `claude` on PATH (see
+        # internal/team/launcher.go — PreflightWeb). These smoke tests don't
+        # send messages to agents, so a no-op stub that LookPath can find is
+        # enough to get past preflight and boot the web UI.
+        run: |
+          sudo tee /usr/local/bin/claude >/dev/null <<'SH'
+          #!/bin/sh
+          # Smoke-test stub. Present only to satisfy exec.LookPath("claude").
+          echo "stub claude $*" >&2
+          exit 0
+          SH
+          sudo chmod +x /usr/local/bin/claude
+      # The suite splits into two phases because App.tsx routes on
+      # onboardingComplete: fresh install → <Wizard>, seeded → <Shell>. One
+      # wuphf instance can only be in one state, so we boot twice.
+      #
+      # Phase 1: fresh install (wizard.spec.ts). No onboarded.json.
+      # Phase 2: seeded      (smoke.spec.ts, shell). Write onboarded.json first.
+      # `</dev/null` on both boots prevents isPiped() from yanking wuphf into
+      # scanner mode.
+      - name: Start wuphf (fresh install) for wizard tests
+        run: |
+          rm -f "$HOME/.wuphf/onboarded.json"
+          ./wuphf --no-open --broker-port 7890 --web-port 7891 --no-nex </dev/null > wuphf-wizard.log 2>&1 &
+          echo $! > wuphf-wizard.pid
+          # /onboarding/state is the authoritative readiness signal (the
+          # static index.html can 200 before the broker is fully wired).
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:7891/onboarding/state -o /dev/null; then
+              echo "wuphf ready (wizard) after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "wuphf failed to become ready (wizard)" >&2
+          cat wuphf-wizard.log >&2
+          exit 1
+      - name: Run Playwright wizard smoke
+        working-directory: web/e2e
+        env:
+          WUPHF_E2E_BASE_URL: http://localhost:7891
+        run: bunx playwright test tests/wizard.spec.ts
+      - name: Stop wuphf (wizard phase)
+        if: always()
+        run: |
+          if [ -f wuphf-wizard.pid ]; then
+            kill "$(cat wuphf-wizard.pid)" 2>/dev/null || true
+          fi
+          # Wait for port 7891 to free up before Phase 2 tries to bind it.
+          for _ in $(seq 1 10); do
+            if ! (exec 3<>/dev/tcp/127.0.0.1/7891) 2>/dev/null; then break; fi
+            sleep 1
+          done
+      - name: Seed onboarding state + start wuphf for shell tests
         run: |
           mkdir -p "$HOME/.wuphf"
           cat > "$HOME/.wuphf/onboarded.json" <<'JSON'
@@ -197,24 +247,22 @@ jobs:
           JSON
           ./wuphf --no-open --broker-port 7890 --web-port 7891 --no-nex </dev/null > wuphf.log 2>&1 &
           echo $! > wuphf.pid
-          # Poll /onboarding/state as the readiness signal (authoritative;
-          # the static index.html can 200 before the broker is fully wired).
           for i in $(seq 1 30); do
             if curl -sf http://localhost:7891/onboarding/state -o /dev/null; then
-              echo "wuphf ready after ${i}s"
+              echo "wuphf ready (shell) after ${i}s"
               exit 0
             fi
             sleep 1
           done
-          echo "wuphf failed to become ready" >&2
+          echo "wuphf failed to become ready (shell)" >&2
           cat wuphf.log >&2
           exit 1
-      - name: Run Playwright smoke
+      - name: Run Playwright shell smoke
         working-directory: web/e2e
         env:
           WUPHF_E2E_BASE_URL: http://localhost:7891
-        run: bunx playwright test
-      - name: Stop wuphf
+        run: bunx playwright test tests/smoke.spec.ts
+      - name: Stop wuphf (shell phase)
         if: always()
         run: |
           if [ -f wuphf.pid ]; then
@@ -227,13 +275,16 @@ jobs:
           name: playwright-report
           path: web/e2e/playwright-report
           retention-days: 7
-      - name: Upload wuphf log on failure
+      - name: Upload wuphf logs on failure
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: wuphf-e2e-log
-          path: wuphf.log
+          name: wuphf-e2e-logs
+          path: |
+            wuphf.log
+            wuphf-wizard.log
           retention-days: 7
+          if-no-files-found: ignore
 
   release-build:
     runs-on: ubuntu-latest
@@ -253,11 +304,10 @@ jobs:
         with:
           version: latest
           args: release --snapshot --clean --skip=publish
-      - name: Smoke-test install.sh against snapshot
-        # Exercises the full installer code path (download, extract, copy,
-        # chmod, --version probe) against the goreleaser snapshot we just
-        # built. WUPHF_INSTALL_URL_OVERRIDE bypasses the GitHub releases
-        # resolver so we can feed a local file:// tarball.
+      - name: Smoke-test install.sh against snapshot (URL override)
+        # Cheap sanity path: feed install.sh a file:// tarball directly so
+        # download/extract/chmod/--version all run against the fresh snapshot.
+        # This SKIPS the redirect-parsing resolver — see next step for that.
         run: |
           set -euo pipefail
           tarball="$(ls dist/wuphf_*_linux_amd64.tar.gz | head -1)"
@@ -269,5 +319,73 @@ jobs:
           # writable — ensure either location is on PATH.
           export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
           WUPHF_INSTALL_URL_OVERRIDE="file://$PWD/$tarball" bash scripts/install.sh
+          command -v wuphf
+          wuphf --version
+      - name: Smoke-test install.sh against real resolver (mock GitHub)
+        # Guards the v0.8.1 regression: the 404 shipped to users lived in the
+        # redirect-parsing + archive-URL construction (install.sh:39-48). The
+        # URL-override step above bypasses that code entirely, so we also
+        # stand up a local HTTP server that emulates GitHub's behavior:
+        #   GET /releases/latest -> 302 /releases/tag/<tag>
+        #   GET /releases/download/<tag>/<archive> -> the snapshot tarball
+        # and point install.sh at it via WUPHF_INSTALL_REPO_BASE_URL.
+        run: |
+          set -euo pipefail
+          tarball="$(ls dist/wuphf_*_linux_amd64.tar.gz | head -1)"
+          archive="$(basename "$tarball")"
+          version="${archive#wuphf_}"
+          version="${version%_linux_amd64.tar.gz}"
+          tag="v${version}"
+
+          serve="$PWD/ci-mock-releases"
+          rm -rf "$serve"
+          mkdir -p "$serve/releases/download/${tag}"
+          cp "$tarball" "$serve/releases/download/${tag}/${archive}"
+
+          # The resolver parses VERSION from curl's url_effective by taking
+          # the last '/'-delimited field. Real GitHub redirects to
+          # /releases/tag/<tag> (no trailing slash). Python's default directory
+          # handler would 301 to '/releases/tag/<tag>/' and strip VERSION to
+          # empty — so handle the tag endpoint explicitly.
+          python3 - "$tag" "$serve" <<'PY' &
+          import http.server, socketserver, sys, os
+          tag, root = sys.argv[1], sys.argv[2]
+          os.chdir(root)
+          tag_path = f"/releases/tag/{tag}"
+          class H(http.server.SimpleHTTPRequestHandler):
+              def do_GET(self):
+                  if self.path == "/releases/latest":
+                      self.send_response(302)
+                      self.send_header("Location", tag_path)
+                      self.end_headers()
+                      return
+                  if self.path == tag_path:
+                      self.send_response(200)
+                      self.send_header("Content-Type", "text/html")
+                      self.end_headers()
+                      self.wfile.write(b"<html></html>")
+                      return
+                  super().do_GET()
+              def log_message(self, *a, **k):
+                  pass
+          with socketserver.TCPServer(("127.0.0.1", 7457), H) as srv:
+              srv.serve_forever()
+          PY
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+
+          for _ in $(seq 1 10); do
+            if curl -sf "http://127.0.0.1:7457/releases/tag/${tag}/" -o /dev/null; then
+              break
+            fi
+            sleep 1
+          done
+
+          # Wipe the binary the prior step installed so we're actually
+          # re-exercising install.sh end-to-end.
+          rm -f "$HOME/.local/bin/wuphf"
+          sudo rm -f /usr/local/bin/wuphf || true
+          export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+          WUPHF_INSTALL_REPO_BASE_URL="http://127.0.0.1:7457" bash scripts/install.sh
           command -v wuphf
           wuphf --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "20"
           cache: npm
@@ -26,23 +26,104 @@ jobs:
           npm ci
           npm run typecheck
           npm run build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: web-dist
           path: web/dist
           retention-days: 1
 
-  go:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4
+          args: --timeout=5m
+
+  test:
     needs: web
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: web-dist
           path: web/dist
       - run: go test ./...
+
+  build:
+    needs: web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: actions/download-artifact@v8
+        with:
+          name: web-dist
+          path: web/dist
       - run: go build -o wuphf ./cmd/wuphf
+      - name: Smoke test binary
+        run: |
+          ./wuphf --version
+          ./wuphf --help-all > /dev/null
+
+  vhs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          # VHS @latest tracks newer Go minors than go.mod pins; use stable so
+          # `go install github.com/charmbracelet/vhs@latest` doesn't get blocked
+          # by GOTOOLCHAIN=local (Go is forward-compatible for the wuphf build).
+          go-version: stable
+      - name: Install VHS
+        run: |
+          go install github.com/charmbracelet/vhs@latest
+      - name: Install ttyd
+        run: |
+          curl -Lo ttyd.x86_64 https://github.com/tsl0922/ttyd/releases/download/1.7.7/ttyd.x86_64
+          sudo install ttyd.x86_64 /usr/local/bin/ttyd
+      - name: Install ffmpeg
+        run: sudo apt-get update && sudo apt-get install -y ffmpeg
+      - name: Build wuphf
+        run: go build -o wuphf ./cmd/wuphf
+      - name: Run VHS regression checks
+        run: |
+          export PATH="$PWD:$PATH"
+          bash testdata/vhs/check.sh
+      - name: Upload drift artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: vhs-drift
+          path: testdata/vhs/*.actual
+          retention-days: 7
+
+  release-build:
+    runs-on: ubuntu-latest
+    needs: web
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: actions/download-artifact@v8
+        with:
+          name: web-dist
+          path: web/dist
+      - uses: goreleaser/goreleaser-action@v7
+        with:
+          version: latest
+          args: release --snapshot --clean --skip=publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,93 @@ jobs:
           sudo apt-get install -y shellcheck
           shellcheck scripts/*.sh
 
+  web-e2e:
+    # Playwright smoke against the real web UI. Guards the class of regression
+    # we kept shipping (React render crashes that only surface in a browser
+    # — e.g. "No QueryClient set", Minified React error #31 on first agent
+    # click) by booting wuphf, loading /, and walking the happy path.
+    needs: web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.1.38"
+      - uses: actions/download-artifact@v8
+        with:
+          name: web-dist
+          path: web/dist
+      - name: Build wuphf
+        run: go build -o wuphf ./cmd/wuphf
+      - name: Install e2e deps
+        working-directory: web/e2e
+        run: bun install --frozen-lockfile
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          # Key on the resolved @playwright/test version via bun.lock so a
+          # bump invalidates.
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/e2e/bun.lock') }}
+      - name: Install Playwright chromium
+        working-directory: web/e2e
+        # --with-deps installs the OS-level shared libs chromium needs on
+        # ubuntu-latest even when the cached browser binary is restored.
+        run: bunx playwright install --with-deps chromium
+      - name: Seed onboarding state + start wuphf
+        # Pre-seeding ~/.wuphf/onboarded.json skips the wizard so the test
+        # lands in the real Shell and can exercise the agent-click path that
+        # used to crash with React #31. Redirect stdin to /dev/null so
+        # isPiped() doesn't steal our boot into scanner mode.
+        run: |
+          mkdir -p "$HOME/.wuphf"
+          cat > "$HOME/.wuphf/onboarded.json" <<'JSON'
+          {"version":1,"completed_at":"2026-01-01T00:00:00Z","company_name":"e2e-ci"}
+          JSON
+          ./wuphf --no-open --broker-port 7890 --web-port 7891 --no-nex </dev/null > wuphf.log 2>&1 &
+          echo $! > wuphf.pid
+          # Poll /onboarding/state as the readiness signal (authoritative;
+          # the static index.html can 200 before the broker is fully wired).
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:7891/onboarding/state -o /dev/null; then
+              echo "wuphf ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "wuphf failed to become ready" >&2
+          cat wuphf.log >&2
+          exit 1
+      - name: Run Playwright smoke
+        working-directory: web/e2e
+        env:
+          WUPHF_E2E_BASE_URL: http://localhost:7891
+        run: bunx playwright test
+      - name: Stop wuphf
+        if: always()
+        run: |
+          if [ -f wuphf.pid ]; then
+            kill "$(cat wuphf.pid)" 2>/dev/null || true
+          fi
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-report
+          path: web/e2e/playwright-report
+          retention-days: 7
+      - name: Upload wuphf log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: wuphf-e2e-log
+          path: wuphf.log
+          retention-days: 7
+
   release-build:
     runs-on: ubuntu-latest
     needs: web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,9 @@ jobs:
   vhs:
     runs-on: ubuntu-latest
     env:
-      VHS_VERSION: v0.11.0
+      VHS_VERSION: "v0.11.0"
       TTYD_VERSION: "1.7.7"
+      TTYD_SHA256: "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
@@ -103,16 +104,26 @@ jobs:
         uses: actions/cache@v5
         with:
           path: /tmp/ttyd.x86_64
-          key: ttyd-${{ runner.os }}-${{ env.TTYD_VERSION }}
+          key: ttyd-${{ runner.os }}-${{ env.TTYD_VERSION }}-${{ env.TTYD_SHA256 }}
       - name: Download ttyd
         if: steps.cache-ttyd.outputs.cache-hit != 'true'
         run: curl -fLo /tmp/ttyd.x86_64 https://github.com/tsl0922/ttyd/releases/download/${{ env.TTYD_VERSION }}/ttyd.x86_64
+      - name: Verify ttyd integrity
+        # Verify both on cache-miss (just downloaded) and cache-hit (guard
+        # against restored corruption or a ttyd release re-tag).
+        run: echo "${{ env.TTYD_SHA256 }}  /tmp/ttyd.x86_64" | sha256sum -c -
       - name: Install ttyd
         run: sudo install /tmp/ttyd.x86_64 /usr/local/bin/ttyd
       - name: Install ffmpeg
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        # Pin to full SHA: third-party action runs `sudo apt-get`, so a re-tag
+        # of @v1 would execute with elevated privileges on the runner.
+        uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: ffmpeg
+          # NOTE: `version` is a cache-bust token, NOT an ffmpeg version pin.
+          # Bump it to force a fresh apt-get install (e.g., for a security
+          # advisory). `packages: ffmpeg` has no version constraint, so warm
+          # runs reuse whatever .deb the cold run captured.
           version: "1"
       - name: Build wuphf
         run: go build -o wuphf ./cmd/wuphf
@@ -127,6 +138,15 @@ jobs:
           name: vhs-drift
           path: testdata/vhs/*.actual
           retention-days: 7
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run shellcheck
+        run: |
+          sudo apt-get install -y shellcheck
+          shellcheck scripts/*.sh
 
   release-build:
     runs-on: ubuntu-latest
@@ -146,3 +166,21 @@ jobs:
         with:
           version: latest
           args: release --snapshot --clean --skip=publish
+      - name: Smoke-test install.sh against snapshot
+        # Exercises the full installer code path (download, extract, copy,
+        # chmod, --version probe) against the goreleaser snapshot we just
+        # built. WUPHF_INSTALL_URL_OVERRIDE bypasses the GitHub releases
+        # resolver so we can feed a local file:// tarball.
+        run: |
+          set -euo pipefail
+          tarball="$(ls dist/wuphf_*_linux_amd64.tar.gz | head -1)"
+          if [ -z "$tarball" ]; then
+            echo "no snapshot tarball found in dist/" >&2
+            exit 1
+          fi
+          # install.sh falls back to $HOME/.local/bin if /usr/local/bin isn't
+          # writable — ensure either location is on PATH.
+          export PATH="$HOME/.local/bin:/usr/local/bin:$PATH"
+          WUPHF_INSTALL_URL_OVERRIDE="file://$PWD/$tarball" bash scripts/install.sh
+          command -v wuphf
+          wuphf --version

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Go binary
 /wuphf
 /nex
+/bridge
+/wuphf-oc-probe
 
 # Local artifacts
 /docs/*
@@ -44,3 +46,9 @@ video/public/audio/bg-music-b.mp3
 video/public/audio/bg-music-c.mp3
 video/public/audio/bg-music-d.mp3
 video/public/audio/test-*.mp3
+
+# VHS visual regression artifacts — only .txt goldens are diffed;
+# .gif output and .actual drift files regenerate on every run of
+# testdata/vhs/check.sh and are not tracked in git.
+testdata/vhs/*.gif
+testdata/vhs/*.actual

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,47 @@
+version: "2"
+run:
+  timeout: 5m
+  tests: true
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - misspell
+    - unconvert
+  settings:
+    errcheck:
+      exclude-functions:
+        - (io.Closer).Close
+    staticcheck:
+      # Disable the QF* quickfix suggestions (pure style hints) and the
+      # ST1000/ST1003/ST1021 naming/comment rules (pedantic, massive scope).
+      # ST1005 (capitalized error strings) stays enabled — those are real.
+      checks:
+        - all
+        - -QF1001
+        - -QF1002
+        - -QF1003
+        - -QF1012
+        - -ST1000
+        - -ST1003
+        - -ST1021
+  exclusions:
+    generated: lax
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/nex-crm/wuphf

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,7 +16,7 @@ builds:
       - -s -w
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "wuphf_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:

--- a/cmd/wuphf-oc-probe/bridge/main.go
+++ b/cmd/wuphf-oc-probe/bridge/main.go
@@ -73,7 +73,9 @@ func main() {
 	if err != nil {
 		die("list: %v", err)
 	}
-	pre.Close()
+	if err := pre.Close(); err != nil {
+		die("pre.Close: %v", err)
+	}
 	var sessKey string
 	if len(rows) == 0 {
 		// sessions.send requires a pre-existing session, so create one.
@@ -81,7 +83,7 @@ func main() {
 		if err != nil {
 			die("create-dial: %v", err)
 		}
-		defer create.Close()
+		defer func() { _ = create.Close() }()
 		raw, err := create.Call(ctx, "sessions.create", map[string]any{"agentId": "main", "label": "wuphf-smoke"})
 		if err != nil {
 			die("sessions.create: %v", err)
@@ -106,11 +108,19 @@ func main() {
 	if err != nil {
 		die("tmp home: %v", err)
 	}
-	defer os.RemoveAll(tmpHome)
-	os.Setenv("HOME", tmpHome)
-	os.MkdirAll(filepath.Join(tmpHome, ".wuphf"), 0o700)
-	os.Setenv("WUPHF_OPENCLAW_IDENTITY_PATH", realIdentityPath)
-	os.Setenv("WUPHF_OPENCLAW_TOKEN", token)
+	defer func() { _ = os.RemoveAll(tmpHome) }()
+	if err := os.Setenv("HOME", tmpHome); err != nil {
+		die("setenv HOME: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".wuphf"), 0o700); err != nil {
+		die("mkdir .wuphf: %v", err)
+	}
+	if err := os.Setenv("WUPHF_OPENCLAW_IDENTITY_PATH", realIdentityPath); err != nil {
+		die("setenv identity path: %v", err)
+	}
+	if err := os.Setenv("WUPHF_OPENCLAW_TOKEN", token); err != nil {
+		die("setenv token: %v", err)
+	}
 	if err := config.Save(config.Config{
 		OpenclawGatewayURL: "ws://127.0.0.1:18789",
 		OpenclawBridges: []config.OpenclawBridgeBinding{

--- a/cmd/wuphf-oc-probe/main.go
+++ b/cmd/wuphf-oc-probe/main.go
@@ -44,7 +44,7 @@ func main() {
 	if err != nil {
 		die("dial: %v", err)
 	}
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	fmt.Println("dialed + handshake ok")
 
 	rows, err := client.SessionsList(ctx, openclaw.SessionsListFilter{Limit: 5, IncludeLastMessage: true})
@@ -90,7 +90,7 @@ func main() {
 	fmt.Printf("sent: runId=%s status=%s messageSeq=%d\n", res.RunID, res.Status, res.MessageSeq)
 
 	time.Sleep(5 * time.Second)
-	client.Close()
+	_ = client.Close()
 	<-done
 	fmt.Println("PASS")
 }

--- a/cmd/wuphf-oc-probe/multi-provider-http/main.go
+++ b/cmd/wuphf-oc-probe/multi-provider-http/main.go
@@ -269,7 +269,7 @@ func openDM(slug string) string {
 	}
 	var out struct {
 		Channel struct{ Slug string } `json:"channel"`
-		Slug    string                 `json:"slug"`
+		Slug    string                `json:"slug"`
 	}
 	_ = json.Unmarshal([]byte(resp), &out)
 	if out.Channel.Slug != "" {

--- a/cmd/wuphf-oc-probe/pack/main.go
+++ b/cmd/wuphf-oc-probe/pack/main.go
@@ -73,7 +73,9 @@ func main() {
 		members[i].sessionKey = out.Key
 		fmt.Printf("created session for %s: %s\n", m.slug, out.Key)
 	}
-	conn.Close()
+	if err := conn.Close(); err != nil {
+		die("conn.Close: %v", err)
+	}
 
 	// Seed a temporary WUPHF HOME so broker state doesn't clash with a real
 	// install. Point identity + token back at the paired daemon.
@@ -81,11 +83,19 @@ func main() {
 	if err != nil {
 		die("tmp home: %v", err)
 	}
-	defer os.RemoveAll(tmpHome)
-	os.Setenv("HOME", tmpHome)
-	os.MkdirAll(filepath.Join(tmpHome, ".wuphf"), 0o700)
-	os.Setenv("WUPHF_OPENCLAW_IDENTITY_PATH", realIdentityPath)
-	os.Setenv("WUPHF_OPENCLAW_TOKEN", token)
+	defer func() { _ = os.RemoveAll(tmpHome) }()
+	if err := os.Setenv("HOME", tmpHome); err != nil {
+		die("setenv HOME: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpHome, ".wuphf"), 0o700); err != nil {
+		die("mkdir .wuphf: %v", err)
+	}
+	if err := os.Setenv("WUPHF_OPENCLAW_IDENTITY_PATH", realIdentityPath); err != nil {
+		die("setenv identity path: %v", err)
+	}
+	if err := os.Setenv("WUPHF_OPENCLAW_TOKEN", token); err != nil {
+		die("setenv token: %v", err)
+	}
 
 	bindings := make([]config.OpenclawBridgeBinding, len(members))
 	for i, m := range members {

--- a/cmd/wuphf/avatars_wuphf.go
+++ b/cmd/wuphf/avatars_wuphf.go
@@ -247,14 +247,15 @@ func spriteForSlug(slug string, frame ...int) pixelSprite {
 
 // animateFrame applies micro-animations for frame 1 (frame 0 is the base).
 // Each character has a unique animation that conveys personality:
-//   CEO:      raises coffee cup (arm moves up)
-//   PM:       taps clipboard (hand shifts)
-//   FE:      screen flickers (highlight changes)
-//   BE:      tightens crossed arms
-//   AI:      antenna blinks (accent toggles)
-//   Designer: pencil moves (prop shifts position)
-//   CMO:      megaphone raised higher
-//   CRO:      briefcase swings
+//
+//	CEO:      raises coffee cup (arm moves up)
+//	PM:       taps clipboard (hand shifts)
+//	FE:      screen flickers (highlight changes)
+//	BE:      tightens crossed arms
+//	AI:      antenna blinks (accent toggles)
+//	Designer: pencil moves (prop shifts position)
+//	CMO:      megaphone raised higher
+//	CRO:      briefcase swings
 func animateFrame(sprite pixelSprite, slug string) {
 	if len(sprite) < 14 {
 		return
@@ -384,9 +385,9 @@ func parseHexColor(hex string) [3]int {
 		return [3]int{140, 140, 150}
 	}
 	r, g, b := 0, 0, 0
-	fmt.Sscanf(hex[0:2], "%x", &r)
-	fmt.Sscanf(hex[2:4], "%x", &g)
-	fmt.Sscanf(hex[4:6], "%x", &b)
+	_, _ = fmt.Sscanf(hex[0:2], "%x", &r)
+	_, _ = fmt.Sscanf(hex[2:4], "%x", &g)
+	_, _ = fmt.Sscanf(hex[4:6], "%x", &b)
 	return [3]int{r, g, b}
 }
 

--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -520,31 +520,31 @@ func buildOneOnOneSlashCommands() []tui.SlashCommand {
 type channelPickerMode string
 
 const (
-	channelPickerNone           channelPickerMode = ""
-	channelPickerInitProvider   channelPickerMode = "init_provider"
-	channelPickerInitBlueprint  channelPickerMode = "init_blueprint"
-	channelPickerInitPack       channelPickerMode = "init_pack" // legacy alias
-	channelPickerProvider       channelPickerMode = "provider"
-	channelPickerIntegrations   channelPickerMode = "integrations"
-	channelPickerRequests       channelPickerMode = "requests"
-	channelPickerTasks          channelPickerMode = "tasks"
-	channelPickerTaskAction     channelPickerMode = "task_action"
-	channelPickerRequestAction  channelPickerMode = "request_action"
-	channelPickerThreads        channelPickerMode = "threads"
-	channelPickerThreadAction   channelPickerMode = "thread_action"
-	channelPickerChannels       channelPickerMode = "channels"
-	channelPickerSwitcher       channelPickerMode = "switcher"
-	channelPickerInsert         channelPickerMode = "insert"
-	channelPickerSearch         channelPickerMode = "search"
-	channelPickerRewind         channelPickerMode = "rewind"
-	channelPickerAgents         channelPickerMode = "agents"
-	channelPickerCalendarAgent  channelPickerMode = "calendar_agent"
-	channelPickerOneOnOneMode   channelPickerMode = "one_on_one_mode"
-	channelPickerOneOnOneAgent  channelPickerMode = "one_on_one_agent"
-	channelPickerTelegramGroup  channelPickerMode = "telegram_group"
-	channelPickerConnect        channelPickerMode = "connect"
-	channelPickerTelegramToken  channelPickerMode = "telegram_token"
-	channelPickerTelegramChatID channelPickerMode = "telegram_chat_id"
+	channelPickerNone            channelPickerMode = ""
+	channelPickerInitProvider    channelPickerMode = "init_provider"
+	channelPickerInitBlueprint   channelPickerMode = "init_blueprint"
+	channelPickerInitPack        channelPickerMode = "init_pack" // legacy alias
+	channelPickerProvider        channelPickerMode = "provider"
+	channelPickerIntegrations    channelPickerMode = "integrations"
+	channelPickerRequests        channelPickerMode = "requests"
+	channelPickerTasks           channelPickerMode = "tasks"
+	channelPickerTaskAction      channelPickerMode = "task_action"
+	channelPickerRequestAction   channelPickerMode = "request_action"
+	channelPickerThreads         channelPickerMode = "threads"
+	channelPickerThreadAction    channelPickerMode = "thread_action"
+	channelPickerChannels        channelPickerMode = "channels"
+	channelPickerSwitcher        channelPickerMode = "switcher"
+	channelPickerInsert          channelPickerMode = "insert"
+	channelPickerSearch          channelPickerMode = "search"
+	channelPickerRewind          channelPickerMode = "rewind"
+	channelPickerAgents          channelPickerMode = "agents"
+	channelPickerCalendarAgent   channelPickerMode = "calendar_agent"
+	channelPickerOneOnOneMode    channelPickerMode = "one_on_one_mode"
+	channelPickerOneOnOneAgent   channelPickerMode = "one_on_one_agent"
+	channelPickerTelegramGroup   channelPickerMode = "telegram_group"
+	channelPickerConnect         channelPickerMode = "connect"
+	channelPickerTelegramToken   channelPickerMode = "telegram_token"
+	channelPickerTelegramChatID  channelPickerMode = "telegram_chat_id"
 	channelPickerOpenclawURL     channelPickerMode = "openclaw-url"
 	channelPickerOpenclawToken   channelPickerMode = "openclaw-token"
 	channelPickerOpenclawSession channelPickerMode = "openclaw-session"
@@ -2540,16 +2540,7 @@ func (m channelModel) View() string {
 	if scroll > 0 {
 		scrollHint = fmt.Sprintf("%d above", scroll)
 	}
-	focusLabel := "main"
-	if m.focus == focusSidebar {
-		focusLabel = "sidebar"
-	} else if m.focus == focusThread {
-		focusLabel = "thread"
-	}
-	statusBar := statusBarStyle(m.width).Render(fmt.Sprintf(
-		" %s %d online │ %d msgs │ focus:%s │ %s │ Ctrl+J newline │ /doctor",
-		"\u25CF", onlineCount, len(m.messages), focusLabel, scrollHint,
-	))
+	var statusBar string
 	if m.pending != nil {
 		statusText := m.interviewStatusLine()
 		if m.pending.ID == m.snoozedInterview {
@@ -2687,7 +2678,7 @@ func (m channelModel) currentHeaderMeta() string {
 		}
 		scopeCount := len(filterMessagesForViewerScope(m.messages, m.oneOnOneAgentSlug(), scopeLabel))
 		parts := []string{
-			fmt.Sprintf("%s lane for %s", strings.Title(scopeLabel), m.oneOnOneAgentName()),
+			fmt.Sprintf("%s lane for %s", titleCaser.String(scopeLabel), m.oneOnOneAgentName()),
 			fmt.Sprintf("%d visible messages", scopeCount),
 		}
 		if workspace.RunningTasks > 0 {
@@ -5565,7 +5556,7 @@ func resetDMSession(agent string, channel string) tea.Cmd {
 		var result struct {
 			Removed int `json:"removed"`
 		}
-		json.NewDecoder(resp.Body).Decode(&result)
+		_ = json.NewDecoder(resp.Body).Decode(&result)
 		return channelResetDMDoneMsg{removed: result.Removed}
 	}
 }
@@ -5781,9 +5772,11 @@ func isWindows() bool { return runtime.GOOS == "windows" }
 // killTeamSession kills the entire wuphf-team tmux session and all agent processes.
 func killTeamSession() {
 	// Kill tmux session (kills all agent processes in all panes/windows)
-	exec.Command("tmux", "-L", "wuphf", "kill-session", "-t", "wuphf-team").Run()
+	_ = exec.Command("tmux", "-L", "wuphf", "kill-session", "-t", "wuphf-team").Run()
 	// Stop the broker
-	http.Get(brokerURL("/health")) // just to check; broker stops with the process
+	if resp, err := http.Get(brokerURL("/health")); err == nil {
+		_ = resp.Body.Close()
+	}
 }
 
 func resolveInitialOfficeApp(name string) officeApp {
@@ -5858,9 +5851,11 @@ func appendChannelCrashLog(details string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	_, err = fmt.Fprintf(f, "\n[%s]\n%s\n", time.Now().Format(time.RFC3339), details)
-	return err
+	if _, err := fmt.Fprintf(f, "\n[%s]\n%s\n", time.Now().Format(time.RFC3339), details); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 func channelCrashLogPath() string {

--- a/cmd/wuphf/channel_artifacts.go
+++ b/cmd/wuphf/channel_artifacts.go
@@ -260,7 +260,7 @@ func readTaskLogArtifact(path string, info fs.FileInfo) (taskLogArtifact, bool) 
 	if err != nil {
 		return taskLogArtifact{}, false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	buf := make([]byte, 0, 128*1024)
@@ -369,7 +369,7 @@ func readWorkflowRunArtifact(path string, info fs.FileInfo) (workflowRunArtifact
 	if err != nil {
 		return workflowRunArtifact{}, false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	buf := make([]byte, 0, 128*1024)

--- a/cmd/wuphf/channel_broker.go
+++ b/cmd/wuphf/channel_broker.go
@@ -296,7 +296,7 @@ func mutateChannelMember(channel, action, slug string) tea.Cmd {
 		if err := reconfigureLiveOfficeSession(); err != nil {
 			return channelPostDoneMsg{err: err}
 		}
-		notice := fmt.Sprintf("%s @%s in #%s.", strings.Title(action), normalizeSidebarSlug(slug), normalizeSidebarSlug(channel))
+		notice := fmt.Sprintf("%s @%s in #%s.", titleCaser.String(action), normalizeSidebarSlug(slug), normalizeSidebarSlug(channel))
 		return channelPostDoneMsg{notice: notice}
 	}
 }
@@ -327,7 +327,7 @@ func mutateOfficeMember(action, slug, name string) tea.Cmd {
 		if err := reconfigureLiveOfficeSession(); err != nil {
 			return channelPostDoneMsg{err: err}
 		}
-		notice := fmt.Sprintf("%s @%s.", strings.Title(action), normalizeSidebarSlug(slug))
+		notice := fmt.Sprintf("%s @%s.", titleCaser.String(action), normalizeSidebarSlug(slug))
 		return channelPostDoneMsg{notice: notice}
 	}
 }

--- a/cmd/wuphf/channel_confirm.go
+++ b/cmd/wuphf/channel_confirm.go
@@ -68,8 +68,7 @@ func confirmationForResetDM(agent, channel string) *channelConfirm {
 func confirmationForSessionSwitch(mode, agent string) *channelConfirm {
 	mode = strings.TrimSpace(mode)
 	agent = strings.TrimSpace(agent)
-	title := "Switch Session Mode"
-	detail := "This changes how the office routes the live session."
+	var title, detail string
 	if team.NormalizeSessionMode(mode) == team.SessionModeOneOnOne {
 		name := displayName(agent)
 		if agent == "" {

--- a/cmd/wuphf/channel_integration.go
+++ b/cmd/wuphf/channel_integration.go
@@ -252,7 +252,7 @@ func connectTelegramGroup(token string, group team.TelegramGroup) tea.Cmd {
 		}
 
 		// Clear broker state so next restart picks up the manifest with surfaces
-		os.Remove(filepath.Join(os.Getenv("HOME"), ".wuphf", "team", "broker-state.json"))
+		_ = os.Remove(filepath.Join(os.Getenv("HOME"), ".wuphf", "team", "broker-state.json"))
 
 		return telegramConnectDoneMsg{
 			channelSlug: slug,
@@ -316,7 +316,7 @@ func fetchOpenclawSessions(url, token string) tea.Cmd {
 		if err != nil {
 			return openclawSessionsMsg{err: err}
 		}
-		defer client.Close()
+		defer func() { _ = client.Close() }()
 		rows, err := client.SessionsList(ctx, openclaw.SessionsListFilter{Limit: 50, IncludeLastMessage: true})
 		if err != nil {
 			return openclawSessionsMsg{err: err}

--- a/cmd/wuphf/channel_messages.go
+++ b/cmd/wuphf/channel_messages.go
@@ -5,7 +5,6 @@ import (
 	"time"
 )
 
-
 // countReplies counts replies for a given parentID from the full message list,
 // returning the count and the formatted time of the last reply.
 func countReplies(messages []brokerMessage, parentID string) (count int, lastReplyTime string) {
@@ -65,4 +64,3 @@ func formatShortTime(timestamp string) string {
 	}
 	return t.Format("3:04 PM")
 }
-

--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -840,14 +840,10 @@ func collectCalendarEvents(jobs []channelSchedulerJob, tasks []channelTask, requ
 		if task.Status == "done" {
 			continue
 		}
-		for _, ev := range taskCalendarEvents(task, activeChannel, members) {
-			events = append(events, ev)
-		}
+		events = append(events, taskCalendarEvents(task, activeChannel, members)...)
 	}
 	for _, req := range requests {
-		for _, ev := range requestCalendarEvents(req, activeChannel, members) {
-			events = append(events, ev)
-		}
+		events = append(events, requestCalendarEvents(req, activeChannel, members)...)
 	}
 	sort.SliceStable(events, func(i, j int) bool {
 		if events[i].When.Equal(events[j].When) {

--- a/cmd/wuphf/channel_sidebar.go
+++ b/cmd/wuphf/channel_sidebar.go
@@ -404,8 +404,8 @@ func renderSidebar(channels []channelInfo, members []channelMember, tasks []chan
 		Bold(true)
 	workspaceMetaStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(sidebarMuted))
-	workspaceSummaryStyle := workspaceMetaStyle.Copy()
-	workspaceHintStyle := workspaceMetaStyle.Copy()
+	workspaceSummaryStyle := workspaceMetaStyle
+	workspaceHintStyle := workspaceMetaStyle
 	activeRowStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#FFFFFF")).
 		Background(lipgloss.Color(sidebarActive)).
@@ -517,9 +517,7 @@ func renderSidebar(channels []channelInfo, members []channelMember, tasks []chan
 		if cl := checklist[0]; !cl.Dismissed {
 			clSection := renderOnboardingChecklist(cl, width)
 			if clSection != "" {
-				for _, clLine := range strings.Split(clSection, "\n") {
-					lines = append(lines, clLine)
-				}
+				lines = append(lines, strings.Split(clSection, "\n")...)
 			}
 		}
 	}

--- a/cmd/wuphf/channel_splash.go
+++ b/cmd/wuphf/channel_splash.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+
 	"github.com/nex-crm/wuphf/internal/company"
 )
 
@@ -46,7 +47,7 @@ type splashModel struct {
 	phase     int
 	shown     int
 	bells     int
-	rushX     int  // PM's X offset during rush-in (starts off-screen)
+	rushX     int // PM's X offset during rush-in (starts off-screen)
 	startAt   time.Time
 	phaseAt   time.Time // when current phase started
 	crashBell bool
@@ -492,7 +493,6 @@ func (m splashModel) renderNameLabel(slug, name string, slotW int) string {
 	}
 	return lipgloss.NewStyle().Foreground(lipgloss.Color(agentColor)).Bold(true).Render(label)
 }
-
 
 // ── CEO sprite variants for the collision gag ───────────────────
 

--- a/cmd/wuphf/channel_styles.go
+++ b/cmd/wuphf/channel_styles.go
@@ -103,7 +103,7 @@ func composerBorderStyle(width int, focused bool) lipgloss.Style {
 	}
 	return lipgloss.NewStyle().
 		Width(width).
-		MaxWidth(width + 4). // account for border + padding
+		MaxWidth(width+4). // account for border + padding
 		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(lipgloss.Color(borderColor)).
 		Background(lipgloss.Color("#17161C")).

--- a/cmd/wuphf/channel_switcher.go
+++ b/cmd/wuphf/channel_switcher.go
@@ -185,7 +185,7 @@ func (m *channelModel) applyWorkspaceSwitcherSelection(value string) tea.Cmd {
 		app := officeApp(strings.TrimSpace(strings.TrimPrefix(value, "app:")))
 		m.activeApp = app
 		m.syncSidebarCursorToActive()
-		m.notice = "Viewing " + strings.Title(string(app)) + "."
+		m.notice = "Viewing " + titleCaser.String(string(app)) + "."
 		switch app {
 		case officeAppRecovery:
 			return m.pollCurrentState()

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/team"
 	"github.com/nex-crm/wuphf/internal/tui"
@@ -2098,7 +2099,7 @@ func TestMouseClickJumpLatestClearsUnread(t *testing.T) {
 	mainX := layout.SidebarW + 1
 	headerH, _, _ := m.mainPanelGeometry(layout.MainW, layout.ContentH)
 
-	next, _ := m.Update(tea.MouseMsg{Type: tea.MouseLeft, Button: tea.MouseButtonLeft, X: mainX + 4, Y: headerH})
+	next, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: mainX + 4, Y: headerH})
 	got := next.(channelModel)
 	if got.scroll != 0 || got.unreadCount != 0 {
 		t.Fatalf("expected jump latest to clear unread and scroll, got scroll=%d unread=%d", got.scroll, got.unreadCount)
@@ -2278,7 +2279,7 @@ func TestRecoveryMouseClickInsertsPromptAndReturnsToMessages(t *testing.T) {
 		t.Fatalf("expected recovery click to draft a prompt, got %+v", action)
 	}
 
-	next, _ := m.Update(tea.MouseMsg{Type: tea.MouseLeft, Button: tea.MouseButtonLeft, X: mainX, Y: headerH + targetRow})
+	next, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: mainX, Y: headerH + targetRow})
 	got := next.(channelModel)
 	if got.activeApp != officeAppMessages {
 		t.Fatalf("expected recovery click to return to messages, got %q", got.activeApp)
@@ -2350,7 +2351,7 @@ func TestMouseClickCollapsedThreadOpensThreadPanel(t *testing.T) {
 		t.Fatal("expected collapsed thread summary row")
 	}
 
-	next, _ := m.Update(tea.MouseMsg{Type: tea.MouseLeft, Button: tea.MouseButtonLeft, X: layout.SidebarW + 5, Y: headerH + row})
+	next, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonLeft, X: layout.SidebarW + 5, Y: headerH + row})
 	got := next.(channelModel)
 	if !got.threadPanelOpen || got.threadPanelID != "msg-1" {
 		t.Fatalf("expected click to open thread panel for msg-1, got open=%v id=%q", got.threadPanelOpen, got.threadPanelID)

--- a/cmd/wuphf/channel_thread.go
+++ b/cmd/wuphf/channel_thread.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+
 	"github.com/nex-crm/wuphf/internal/tui"
 )
 

--- a/cmd/wuphf/channel_workspace_state.go
+++ b/cmd/wuphf/channel_workspace_state.go
@@ -404,9 +404,7 @@ func (m channelModel) buildOfficeIntroLines(contentWidth int) []renderedLine {
 	}
 
 	if state.NeedsYou != nil {
-		for _, line := range state.needsYouLines(contentWidth) {
-			lines = append(lines, line)
-		}
+		lines = append(lines, state.needsYouLines(contentWidth)...)
 	} else {
 		lines = append(lines, renderedLine{Text: ""})
 		lines = append(lines, renderedLine{Text: mutedStyle.Render("  Suggested: /switcher for active work, /recover for context, or tag a teammate in #general. Bears. Beets. Ship it.")})

--- a/cmd/wuphf/import.go
+++ b/cmd/wuphf/import.go
@@ -24,8 +24,8 @@ type legacyAgent struct {
 }
 
 type legacyCompany struct {
-	ID     string           `json:"id"`
-	Name   string           `json:"name"`
+	ID     string        `json:"id"`
+	Name   string        `json:"name"`
 	Agents []legacyAgent `json:"agents"`
 }
 
@@ -97,7 +97,7 @@ func runImport(args []string) {
 		fmt.Fprintf(os.Stderr, "  <file.json>       Direct path to a JSON export file\n\n")
 		fs.PrintDefaults()
 	}
-	fs.Parse(args)
+	_ = fs.Parse(args) // ExitOnError
 
 	if *fromPath == "" {
 		fs.Usage()
@@ -172,13 +172,13 @@ func importFromLegacyDB(portOverride int) (importedBrokerState, int, int, error)
 	conn, err := pgx.Connect(ctx, connStr)
 	if err != nil {
 		return importedBrokerState{}, 0, 0, fmt.Errorf(
-			"could not connect to external orchestrator Postgres (localhost:%d): %v\n\n"+
-				"Make sure external orchestrator is running before importing.\n"+
-				"If external orchestrator uses a different port, pass --port <number>.",
+			"could not connect to external orchestrator Postgres (localhost:%d): %w "+
+				"(make sure external orchestrator is running before importing; "+
+				"if it uses a different port, pass --port <number>)",
 			port, err,
 		)
 	}
-	defer conn.Close(context.Background())
+	defer func() { _ = conn.Close(context.Background()) }()
 
 	// Read companies
 	type dbCompany struct {
@@ -205,12 +205,6 @@ func importFromLegacyDB(portOverride int) (importedBrokerState, int, int, error)
 
 	if len(companies) == 0 {
 		return importedBrokerState{}, 0, 0, fmt.Errorf("no companies found in external orchestrator database")
-	}
-
-	// Collect all company IDs for filtering
-	companyIDs := make([]string, 0, len(companies))
-	for _, c := range companies {
-		companyIDs = append(companyIDs, c.ID)
 	}
 
 	// Read agents

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -103,13 +103,13 @@ func printVisibleFlags(w *os.File) {
 		if len(f.Name) > 1 {
 			prefix = "--"
 		}
-		fmt.Fprintf(w, "  %s%s\n    \t%s", prefix, f.Name, f.Usage)
+		_, _ = fmt.Fprintf(w, "  %s%s\n    \t%s", prefix, f.Name, f.Usage)
 		// Only emit a trailing (default ...) when the usage string hasn't
 		// already mentioned the default itself.
 		if f.DefValue != "" && f.DefValue != "false" && f.DefValue != "0" && !strings.Contains(f.Usage, "default") {
-			fmt.Fprintf(w, " (default %q)", f.DefValue)
+			_, _ = fmt.Fprintf(w, " (default %q)", f.DefValue)
 		}
-		fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w)
 	})
 }
 
@@ -335,7 +335,7 @@ func runTeam(args []string, packSlug string, unsafe bool, oneOnOne bool, opusCEO
 			_ = os.Setenv("WUPHF_ONE_ON_ONE", "1")
 			_ = os.Setenv("WUPHF_ONE_ON_ONE_AGENT", l.OneOnOneAgent())
 		}
-		defer l.Kill()
+		defer func() { _ = l.Kill() }()
 		runChannelView(false, resolveInitialOfficeApp(""), false)
 		return
 	}

--- a/cmd/wuphf/title.go
+++ b/cmd/wuphf/title.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// titleCaser replaces strings.Title (deprecated) for English-tagged title casing.
+var titleCaser = cases.Title(language.English)

--- a/cmd/youtube-script-packet/main.go
+++ b/cmd/youtube-script-packet/main.go
@@ -402,7 +402,7 @@ func buildSection(sceneID string, brief channelBrief, chapter chapterBeat) scrip
 		}
 	case "step_walkthrough":
 		base.Purpose = "Walk the viewer through the workflow in a way they can copy."
-		base.VoiceoverBeat = fmt.Sprintf("Break the system into concrete steps. For each step, show the input, the decision, the output, and the human check that keeps the workflow trustworthy.")
+		base.VoiceoverBeat = "Break the system into concrete steps. For each step, show the input, the decision, the output, and the human check that keeps the workflow trustworthy."
 		base.OnScreenBeats = []string{
 			"One step per screen with minimal labels",
 			"Show inputs, routing logic, and output queue",

--- a/internal/action/composio.go
+++ b/internal/action/composio.go
@@ -247,8 +247,8 @@ func (c *ComposioREST) ActionKnowledge(ctx context.Context, _ string, actionID s
 		"name":              result.Name,
 		"description":       result.Description,
 		"toolkit":           result.Toolkit.Slug,
-		"input_parameters":  json.RawMessage(result.InputParameters),
-		"output_parameters": json.RawMessage(result.OutputParameters),
+		"input_parameters":  result.InputParameters,
+		"output_parameters": result.OutputParameters,
 	}, "", "  ")
 	return KnowledgeResult{
 		Platform:  strings.TrimSpace(result.Toolkit.Slug),

--- a/internal/action/composio_test.go
+++ b/internal/action/composio_test.go
@@ -242,8 +242,8 @@ func TestComposioRESTWorkflowDigestHappyPath(t *testing.T) {
 				"insight_limit":  "{{ .inputs.insight_limit }}",
 			},
 			{
-				"id":   "email_summary",
-				"type": "template",
+				"id":       "email_summary",
+				"type":     "template",
 				"template": "Email highlights:\n{{- range $m := .steps.fetch_emails.result.data.messages }}\n- {{ $m.sender }} | {{ $m.subject }} | {{ $m.preview.body }}\n{{- end }}",
 			},
 			{
@@ -404,8 +404,8 @@ func TestComposioRESTWorkflowNormalizesHandlebarsEachSyntax(t *testing.T) {
 		"version": composioWorkflowVersion,
 		"steps": []map[string]any{
 			{
-				"id":   "email_summary",
-				"type": "template",
+				"id":       "email_summary",
+				"type":     "template",
 				"template": "Recent emails:\n{{#each steps.fetch_emails.result.data.messages}}\n- {{this.sender}} | {{this.subject}}\n{{/each}}",
 			},
 		},

--- a/internal/action/composio_workflows.go
+++ b/internal/action/composio_workflows.go
@@ -768,7 +768,7 @@ func intInput(v any) int {
 		return int(i)
 	case string:
 		var n int
-		fmt.Sscanf(strings.TrimSpace(t), "%d", &n)
+		_, _ = fmt.Sscanf(strings.TrimSpace(t), "%d", &n)
 		return n
 	default:
 		return 0

--- a/internal/action/one.go
+++ b/internal/action/one.go
@@ -228,7 +228,7 @@ func (o *OneCLI) executeActionViaFlow(ctx context.Context, req ExecuteRequest) (
 	if err != nil {
 		return ExecuteResult{}, fmt.Errorf("create temp flow dir: %w", err)
 	}
-	defer os.RemoveAll(tempRoot)
+	defer func() { _ = os.RemoveAll(tempRoot) }()
 
 	flowKey := fmt.Sprintf("wuphf-auto-action-%d", time.Now().UTC().UnixNano())
 	flowDir := filepath.Join(tempRoot, ".one", "flows", flowKey)
@@ -320,9 +320,9 @@ func buildOneActionFlowDefinition(req ExecuteRequest) map[string]any {
 		},
 		"steps": []map[string]any{
 			{
-				"id":   "execute",
-				"name": "Execute external action",
-				"type": "action",
+				"id":     "execute",
+				"name":   "Execute external action",
+				"type":   "action",
 				"action": actionStep,
 			},
 		},
@@ -677,7 +677,7 @@ func oneCLIUsesFlowWorkspace(args []string) bool {
 
 func (o *OneCLI) ensureConfigured() error {
 	if config.ResolveNoNex() {
-		return errors.New("Nex is disabled for this session (--no-nex), so WUPHF-managed integrations are unavailable")
+		return errors.New("nex is disabled for this session (--no-nex); Nex-managed integrations are unavailable")
 	}
 	return nil
 }

--- a/internal/action/types.go
+++ b/internal/action/types.go
@@ -132,13 +132,13 @@ type WorkflowCreateResult struct {
 }
 
 type WorkflowExecuteRequest struct {
-	KeyOrPath string         `json:"key_or_path"`
-	Inputs    map[string]any `json:"inputs,omitempty"`
-	DryRun    bool           `json:"dry_run,omitempty"`
-	Verbose   bool           `json:"verbose,omitempty"`
-	Mock      bool           `json:"mock,omitempty"`
-	SkipValidation bool      `json:"skip_validation,omitempty"`
-	AllowBash bool           `json:"allow_bash,omitempty"`
+	KeyOrPath      string         `json:"key_or_path"`
+	Inputs         map[string]any `json:"inputs,omitempty"`
+	DryRun         bool           `json:"dry_run,omitempty"`
+	Verbose        bool           `json:"verbose,omitempty"`
+	Mock           bool           `json:"mock,omitempty"`
+	SkipValidation bool           `json:"skip_validation,omitempty"`
+	AllowBash      bool           `json:"allow_bash,omitempty"`
 }
 
 type WorkflowExecuteResult struct {

--- a/internal/action/workflow_store.go
+++ b/internal/action/workflow_store.go
@@ -74,9 +74,11 @@ func appendWorkflowRun(provider, key string, run any) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	enc := json.NewEncoder(f)
-	return enc.Encode(run)
+	if err := json.NewEncoder(f).Encode(run); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 func listWorkflowRuns(provider, key string) (WorkflowRunsResult, error) {
@@ -88,7 +90,7 @@ func listWorkflowRuns(provider, key string) (WorkflowRunsResult, error) {
 		}
 		return WorkflowRunsResult{}, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var runs []json.RawMessage
 	scanner := bufio.NewScanner(f)

--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -119,6 +120,18 @@ func (l *AgentLoop) GetState() AgentState {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.state
+}
+
+// appendSession writes a session journal entry and logs (rather than drops)
+// any error. Best-effort: we never want a journal-write failure to stop an
+// agent turn, but silently swallowing the error has historically hidden real
+// corruption. Logging preserves "don't crash the loop" while making drift
+// debuggable after the fact.
+func (l *AgentLoop) appendSession(entry SessionEntry) {
+	if _, err := l.sessions.Append(l.state.SessionID, entry); err != nil {
+		log.Printf("agent loop: session append (session=%s type=%s): %v",
+			l.state.SessionID, entry.Type, err)
+	}
 }
 
 // CanProcess reports whether the loop is started and not paused.
@@ -383,7 +396,7 @@ func (l *AgentLoop) buildContext() error {
 		}
 	}
 	if !hasSystem && l.state.Config.Personality != "" {
-		l.sessions.Append(l.state.SessionID, SessionEntry{
+		l.appendSession(SessionEntry{
 			Type:    "system",
 			Content: l.state.Config.Personality,
 		})
@@ -391,7 +404,7 @@ func (l *AgentLoop) buildContext() error {
 
 	// Drain steer messages after the session exists so the first user task is not lost.
 	if msg, ok := l.queues.DrainSteer(slug); ok {
-		l.sessions.Append(l.state.SessionID, SessionEntry{
+		l.appendSession(SessionEntry{
 			Type:    "system",
 			Content: "[STEER] " + msg,
 		})
@@ -402,7 +415,7 @@ func (l *AgentLoop) buildContext() error {
 		l.state.CurrentTask = msg
 		l.state.TaskID = nextTaskID(slug)
 		l.lastCompactionAt = 0
-		l.sessions.Append(l.state.SessionID, SessionEntry{
+		l.appendSession(SessionEntry{
 			Type:    "user",
 			Content: msg,
 		})
@@ -442,12 +455,12 @@ func (l *AgentLoop) injectGossipInsights() {
 		score := ScoreInsight(insight, "", srcCred)
 		switch score.Decision {
 		case "adopt":
-			l.sessions.Append(l.state.SessionID, SessionEntry{
+			l.appendSession(SessionEntry{
 				Type:    "system",
 				Content: fmt.Sprintf("[GOSSIP:ADOPTED] (from %s, score=%.2f) %s", insight.Source, score.Total, insight.Content),
 			})
 		case "test":
-			l.sessions.Append(l.state.SessionID, SessionEntry{
+			l.appendSession(SessionEntry{
 				Type:    "system",
 				Content: fmt.Sprintf("[GOSSIP:TEST] (from %s, score=%.2f) %s", insight.Source, score.Total, insight.Content),
 			})
@@ -548,7 +561,7 @@ done:
 	}
 	// Append assistant text to session.
 	if fullText.Len() > 0 {
-		l.sessions.Append(l.state.SessionID, SessionEntry{
+		l.appendSession(SessionEntry{
 			Type:    "assistant",
 			Content: fullText.String(),
 		})
@@ -573,7 +586,7 @@ func (l *AgentLoop) executeTool() error {
 	tool, ok := l.tools.Get(tc.ToolName)
 	if !ok {
 		errMsg := fmt.Sprintf("unknown tool: %q", tc.ToolName)
-		l.sessions.Append(l.state.SessionID, SessionEntry{
+		l.appendSession(SessionEntry{
 			Type:    "tool_result",
 			Content: errMsg,
 			Metadata: map[string]any{
@@ -588,7 +601,7 @@ func (l *AgentLoop) executeTool() error {
 
 	if valid, errs := l.tools.Validate(tc.ToolName, tc.Params); !valid {
 		errMsg := fmt.Sprintf("invalid params for %q: %s", tc.ToolName, strings.Join(errs, "; "))
-		l.sessions.Append(l.state.SessionID, SessionEntry{
+		l.appendSession(SessionEntry{
 			Type:    "tool_result",
 			Content: errMsg,
 			Metadata: map[string]any{
@@ -602,7 +615,7 @@ func (l *AgentLoop) executeTool() error {
 	}
 
 	// Append tool_call entry.
-	l.sessions.Append(l.state.SessionID, SessionEntry{
+	l.appendSession(SessionEntry{
 		Type:    "tool_call",
 		Content: tc.ToolName,
 		Metadata: map[string]any{
@@ -631,7 +644,7 @@ func (l *AgentLoop) executeTool() error {
 	if err != nil {
 		tc.Error = err.Error()
 		l.emit(EventToolResult, err.Error())
-		l.sessions.Append(l.state.SessionID, SessionEntry{
+		l.appendSession(SessionEntry{
 			Type:    "tool_result",
 			Content: err.Error(),
 			Metadata: map[string]any{
@@ -643,7 +656,7 @@ func (l *AgentLoop) executeTool() error {
 	} else {
 		tc.Result = result
 		l.emit(EventToolResult, result)
-		l.sessions.Append(l.state.SessionID, SessionEntry{
+		l.appendSession(SessionEntry{
 			Type:    "tool_result",
 			Content: result,
 			Metadata: map[string]any{
@@ -677,7 +690,9 @@ func (l *AgentLoop) handleDone() error {
 	// Publish collected insights via gossip.
 	if l.gossipLayer != nil && len(l.collectedInsights) > 0 {
 		for _, insight := range l.collectedInsights {
-			l.gossipLayer.Publish(slug, insight, "")
+			if _, err := l.gossipLayer.Publish(slug, insight, ""); err != nil {
+				log.Printf("agent loop: gossip publish (slug=%s): %v", slug, err)
+			}
 		}
 		l.collectedInsights = nil
 	}
@@ -847,7 +862,7 @@ func (l *AgentLoop) logToolExecution(call ToolCall) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	_, _ = f.Write(append(line, '\n'))
 }

--- a/internal/agent/queues.go
+++ b/internal/agent/queues.go
@@ -4,9 +4,9 @@ import "sync"
 
 // MessageQueues manages per-agent steer and follow-up message queues.
 type MessageQueues struct {
-	mu              sync.Mutex
-	steerQueues     map[string][]string
-	followUpQueues  map[string][]string
+	mu             sync.Mutex
+	steerQueues    map[string][]string
+	followUpQueues map[string][]string
 }
 
 // NewMessageQueues creates an empty MessageQueues.

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -494,7 +494,7 @@ func (s *AgentService) UpdateConfig(slug string, updates ConfigUpdate) error {
 func (s *AgentService) notify() {
 	for _, fn := range s.listeners {
 		func() {
-			defer func() { recover() }()
+			defer func() { _ = recover() }()
 			fn()
 		}()
 	}

--- a/internal/agent/session.go
+++ b/internal/agent/session.go
@@ -62,7 +62,9 @@ func (s *SessionStore) Create(agentSlug string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("create session file: %w", err)
 	}
-	f.Close()
+	if err := f.Close(); err != nil {
+		return "", fmt.Errorf("close session file: %w", err)
+	}
 	return sessionID, nil
 }
 
@@ -85,10 +87,13 @@ func (s *SessionStore) Append(sessionID string, entry SessionEntry) (SessionEntr
 	if err != nil {
 		return SessionEntry{}, fmt.Errorf("open session file: %w", err)
 	}
-	defer f.Close()
 
 	if _, err := fmt.Fprintf(f, "%s\n", line); err != nil {
+		_ = f.Close()
 		return SessionEntry{}, fmt.Errorf("write entry: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return SessionEntry{}, fmt.Errorf("close session file: %w", err)
 	}
 
 	return entry, nil
@@ -108,7 +113,7 @@ func (s *SessionStore) GetHistory(sessionID string, limit int, fromID string) ([
 		}
 		return nil, fmt.Errorf("open session file: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var entries []SessionEntry
 	scanner := bufio.NewScanner(f)
@@ -158,7 +163,7 @@ func (s *SessionStore) Branch(sessionID, fromEntryID string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("open source session: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	var toCopy []SessionEntry
 	scanner := bufio.NewScanner(f)
@@ -191,16 +196,20 @@ func (s *SessionStore) Branch(sessionID, fromEntryID string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("create branch file: %w", err)
 	}
-	defer out.Close()
 
 	for _, entry := range toCopy {
 		line, err := json.Marshal(entry)
 		if err != nil {
+			_ = out.Close()
 			return "", fmt.Errorf("marshal branch entry: %w", err)
 		}
 		if _, err := fmt.Fprintf(out, "%s\n", line); err != nil {
+			_ = out.Close()
 			return "", fmt.Errorf("write branch entry: %w", err)
 		}
+	}
+	if err := out.Close(); err != nil {
+		return "", fmt.Errorf("close branch file: %w", err)
 	}
 
 	return newID, nil

--- a/internal/agent/task_log_reader.go
+++ b/internal/agent/task_log_reader.go
@@ -105,7 +105,7 @@ func ReadTaskLog(root, taskID string) ([]TaskLogEntry, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open task log %q: %w", taskID, err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	stat, err := f.Stat()
 	if err != nil {
@@ -142,7 +142,7 @@ func summarizeTaskLog(path, taskID string) TaskLogSummary {
 	if err != nil {
 		return s
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)

--- a/internal/agent/tools.go
+++ b/internal/agent/tools.go
@@ -323,8 +323,11 @@ func localToolDefinitions() []AgentTool {
 				if err != nil {
 					return "", err
 				}
-				defer f.Close()
 				if _, err := f.WriteString(content); err != nil {
+					_ = f.Close()
+					return "", err
+				}
+				if err := f.Close(); err != nil {
 					return "", err
 				}
 				return marshalResult(localToolResult{
@@ -437,8 +440,11 @@ func localToolDefinitions() []AgentTool {
 				if err != nil {
 					return "", err
 				}
-				defer f.Close()
 				if _, err := f.Write(append(payload, '\n')); err != nil {
+					_ = f.Close()
+					return "", err
+				}
+				if err := f.Close(); err != nil {
 					return "", err
 				}
 				return string(payload), nil

--- a/internal/calendar/cron.go
+++ b/internal/calendar/cron.go
@@ -9,11 +9,11 @@ import (
 
 // CronSchedule represents a parsed cron expression that can compute next fire times.
 type CronSchedule struct {
-	Minutes    []int // 0-59
-	Hours      []int // 0-23
+	Minutes     []int // 0-59
+	Hours       []int // 0-23
 	DaysOfMonth []int // 1-31 (empty = any)
-	Months     []int // 1-12 (empty = any)
-	DaysOfWeek []int // 0-6, 0=Sunday (empty = any)
+	Months      []int // 1-12 (empty = any)
+	DaysOfWeek  []int // 0-6, 0=Sunday (empty = any)
 }
 
 // ParseCron parses a cron expression string into a CronSchedule.

--- a/internal/calendar/types.go
+++ b/internal/calendar/types.go
@@ -5,10 +5,10 @@ import "time"
 
 // ScheduleEntry represents a recurring schedule for an agent.
 type ScheduleEntry struct {
-	AgentSlug   string `json:"agent_slug"`
-	CronExpr    string `json:"cron_expr"`
-	Description string `json:"description,omitempty"`
-	Enabled     bool   `json:"enabled"`
+	AgentSlug   string    `json:"agent_slug"`
+	CronExpr    string    `json:"cron_expr"`
+	Description string    `json:"description,omitempty"`
+	Enabled     bool      `json:"enabled"`
 	NextFire    time.Time `json:"next_fire"`
 }
 

--- a/internal/channel/slug.go
+++ b/internal/channel/slug.go
@@ -25,7 +25,7 @@ func GroupSlug(members []string) string {
 	sort.Strings(sorted)
 	h := sha1.New()
 	for _, m := range sorted {
-		io.WriteString(h, m)
+		_, _ = io.WriteString(h, m)
 	}
 	return hex.EncodeToString(h.Sum(nil))
 }

--- a/internal/channel/store.go
+++ b/internal/channel/store.go
@@ -19,9 +19,9 @@ type Store struct {
 	counter  int
 
 	// In-memory indexes (maintained on write)
-	byID     map[string]*Channel   // channel UUID → *Channel
-	bySlug   map[string]*Channel   // channel slug → *Channel
-	memberOf map[string][]string   // member slug → []channel IDs
+	byID     map[string]*Channel // channel UUID → *Channel
+	bySlug   map[string]*Channel // channel slug → *Channel
+	memberOf map[string][]string // member slug → []channel IDs
 
 	mu sync.RWMutex
 }

--- a/internal/commands/cmd_config.go
+++ b/internal/commands/cmd_config.go
@@ -155,11 +155,11 @@ func configSet(ctx *SlashContext, key, value string) error {
 		cfg.CompanySize = value
 	case "company_priority":
 		cfg.CompanyPriority = value
-		default:
-			ctx.AddMessage("system", "Unknown config key: "+key+
-				"\nValid keys: api_key, composio_api_key, action_provider, workspace_id, workspace_slug, memory_backend, llm_provider, gemini_api_key, anthropic_api_key, openai_api_key, minimax_api_key, blueprint, template, operation_template, pack (legacy alias), team_lead_slug, dev_url, default_format, company_name, company_description, company_goals, company_size, company_priority")
-			return nil
-		}
+	default:
+		ctx.AddMessage("system", "Unknown config key: "+key+
+			"\nValid keys: api_key, composio_api_key, action_provider, workspace_id, workspace_slug, memory_backend, llm_provider, gemini_api_key, anthropic_api_key, openai_api_key, minimax_api_key, blueprint, template, operation_template, pack (legacy alias), team_lead_slug, dev_url, default_format, company_name, company_description, company_goals, company_size, company_priority")
+		return nil
+	}
 
 	if err := config.Save(cfg); err != nil {
 		return fmt.Errorf("save config: %w", err)

--- a/internal/commands/helpers_test.go
+++ b/internal/commands/helpers_test.go
@@ -27,9 +27,9 @@ func TestTokenize(t *testing.T) {
 
 func TestParseFlags(t *testing.T) {
 	tests := []struct {
-		input        string
-		wantPos      []string
-		wantFlags    map[string]string
+		input     string
+		wantPos   []string
+		wantFlags map[string]string
 	}{
 		{
 			"list --limit 10 --sort name",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,20 +28,20 @@ func RuntimeHomeDir() string {
 
 // Config mirrors ~/.wuphf/config.json.
 type Config struct {
-	APIKey              string `json:"api_key,omitempty"`
-	MemoryBackend       string `json:"memory_backend,omitempty"`
-	OneAPIKey           string `json:"one_api_key,omitempty"`
-	ComposioAPIKey      string `json:"composio_api_key,omitempty"`
-	ActionProvider      string `json:"action_provider,omitempty"`
-	Email               string `json:"email,omitempty"`
-	WorkspaceID         string `json:"workspace_id,omitempty"`
-	WorkspaceSlug       string `json:"workspace_slug,omitempty"`
-	LLMProvider         string `json:"llm_provider,omitempty"`
-	GeminiAPIKey        string `json:"gemini_api_key,omitempty"`
-	AnthropicAPIKey     string `json:"anthropic_api_key,omitempty"`
-	OpenAIAPIKey        string `json:"openai_api_key,omitempty"`
-	MinimaxAPIKey       string `json:"minimax_api_key,omitempty"`
-	Blueprint           string `json:"blueprint,omitempty"`
+	APIKey          string `json:"api_key,omitempty"`
+	MemoryBackend   string `json:"memory_backend,omitempty"`
+	OneAPIKey       string `json:"one_api_key,omitempty"`
+	ComposioAPIKey  string `json:"composio_api_key,omitempty"`
+	ActionProvider  string `json:"action_provider,omitempty"`
+	Email           string `json:"email,omitempty"`
+	WorkspaceID     string `json:"workspace_id,omitempty"`
+	WorkspaceSlug   string `json:"workspace_slug,omitempty"`
+	LLMProvider     string `json:"llm_provider,omitempty"`
+	GeminiAPIKey    string `json:"gemini_api_key,omitempty"`
+	AnthropicAPIKey string `json:"anthropic_api_key,omitempty"`
+	OpenAIAPIKey    string `json:"openai_api_key,omitempty"`
+	MinimaxAPIKey   string `json:"minimax_api_key,omitempty"`
+	Blueprint       string `json:"blueprint,omitempty"`
 	// Pack is retained as a legacy alias for the active operation blueprint/template.
 	Pack                string `json:"pack,omitempty"`
 	TeamLeadSlug        string `json:"team_lead_slug,omitempty"`

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -72,7 +72,7 @@ func HandleState(w http.ResponseWriter, r *http.Request) {
 		"onboarded":           s.Onboarded(),
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(payload)
+	_ = json.NewEncoder(w).Encode(payload)
 }
 
 // HandleProgress handles POST /onboarding/progress.
@@ -102,7 +102,7 @@ func HandleProgress(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 // makeHandleComplete returns a handler for POST /onboarding/complete that
@@ -149,7 +149,7 @@ func HandleComplete(w http.ResponseWriter, r *http.Request, completeFn func(task
 	// Idempotent: already done.
 	if s.Onboarded() {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
 			"already_completed": true,
 			"redirect":          "/",
 		})
@@ -180,7 +180,7 @@ func HandleComplete(w http.ResponseWriter, r *http.Request, completeFn func(task
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
 		"ok":       true,
 		"redirect": "/",
 	})
@@ -335,7 +335,7 @@ func HandleChecklistDone(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }
 
 // HandlePrereqs handles GET /onboarding/prereqs.
@@ -347,7 +347,7 @@ func HandlePrereqs(w http.ResponseWriter, r *http.Request) {
 	}
 	results := CheckAll()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(results)
+	_ = json.NewEncoder(w).Encode(results)
 }
 
 // HandleValidateKey handles POST /onboarding/validate-key.
@@ -368,7 +368,7 @@ func HandleValidateKey(w http.ResponseWriter, r *http.Request) {
 	}
 	status := validateProviderKey(body.Provider, body.Key)
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": status})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": status})
 }
 
 // makeHandleTemplates returns a handler for GET /onboarding/templates that
@@ -389,7 +389,7 @@ func HandleTemplates(w http.ResponseWriter, r *http.Request, packSlug string) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(TemplatesForSelection("", packSlug))
+	_ = json.NewEncoder(w).Encode(TemplatesForSelection("", packSlug))
 }
 
 // blueprintSummary is the wizard-facing shape returned by HandleBlueprints.
@@ -441,7 +441,7 @@ func HandleBlueprints(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"templates": summaries})
+	_ = json.NewEncoder(w).Encode(map[string]any{"templates": summaries})
 }
 
 func summarizeBlueprint(bp operations.Blueprint) blueprintSummary {
@@ -485,5 +485,5 @@ func HandleChecklistDismiss(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 }

--- a/internal/openclaw/client.go
+++ b/internal/openclaw/client.go
@@ -73,7 +73,7 @@ func Dial(ctx context.Context, cfg Config) (*Client, error) {
 		lastSeq: make(map[string]int64),
 	}
 	if err := c.doHandshake(dctx); err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, err
 	}
 	go c.readLoop()
@@ -117,12 +117,12 @@ type connectChallengeEvent struct {
 }
 
 const (
-	clientIDBackend    = "gateway-client"
-	clientModeBackend  = "backend"
-	connectRole        = "operator"
+	clientIDBackend     = "gateway-client"
+	clientModeBackend   = "backend"
+	connectRole         = "operator"
 	connectDeviceFamily = "wuphf"
-	connectScopeAdmin  = "operator.admin"
-	supportedProtocol  = 3
+	connectScopeAdmin   = "operator.admin"
+	supportedProtocol   = 3
 )
 
 func (c *Client) doHandshake(ctx context.Context) error {

--- a/internal/operations/permission_mode_test.go
+++ b/internal/operations/permission_mode_test.go
@@ -219,7 +219,7 @@ func TestSynthesizedBlueprintPermissionModes(t *testing.T) {
 			},
 		},
 		{
-			name: "empty input fallback",
+			name:  "empty input fallback",
 			input: SynthesisInput{},
 		},
 	}

--- a/internal/orchestration/executor.go
+++ b/internal/orchestration/executor.go
@@ -30,10 +30,10 @@ type Executor struct {
 // NewExecutor returns an Executor using the provided configuration.
 func NewExecutor(config OrchestratorConfig) *Executor {
 	return &Executor{
-		config:  config,
-		tasks:   make(map[string]*TaskDefinition),
-		locks:   make(map[string]string),
-		timers:  make(map[string]*time.Timer),
+		config: config,
+		tasks:  make(map[string]*TaskDefinition),
+		locks:  make(map[string]string),
+		timers: make(map[string]*time.Timer),
 	}
 }
 

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -202,7 +202,7 @@ func appendCodexLatencyLog(agentSlug string, line string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, _ = fmt.Fprintf(f, "[%s] agent=%s %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(agentSlug), strings.TrimSpace(line))
 }
 

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -449,12 +450,12 @@ type Broker struct {
 	agentStreams        map[string]*agentStreamBuffer
 	mu                  sync.Mutex
 	server              *http.Server
-	token               string   // shared secret for authenticating requests
-	addr                string   // actual listen address (useful when port=0)
-	webUIOrigins        []string // allowed CORS origins for web UI (set by ServeWebUI)
-	runtimeProvider     string   // "codex" or "claude" — set by launcher
-	packSlug            string   // active agent pack slug ("founding-team", "revops", ...) — set by launcher
-	blankSlateLaunch    bool     // start without a saved blueprint and synthesize the first operation
+	token               string          // shared secret for authenticating requests
+	addr                string          // actual listen address (useful when port=0)
+	webUIOrigins        []string        // allowed CORS origins for web UI (set by ServeWebUI)
+	runtimeProvider     string          // "codex" or "claude" — set by launcher
+	packSlug            string          // active agent pack slug ("founding-team", "revops", ...) — set by launcher
+	blankSlateLaunch    bool            // start without a saved blueprint and synthesize the first operation
 	openclawBridge      *OpenclawBridge // nil until the bridge attaches itself; used by handleOfficeMembers for live add/remove
 	generateMemberFn    func(prompt string) (generatedMemberTemplate, error)
 	generateChannelFn   func(prompt string) (generatedChannelTemplate, error)
@@ -1135,7 +1136,7 @@ func (b *Broker) StartOnPort(port int) error {
 // Stop shuts down the broker.
 func (b *Broker) Stop() {
 	if b.server != nil {
-		b.server.Close()
+		_ = b.server.Close()
 	}
 }
 
@@ -1360,7 +1361,7 @@ func (b *Broker) handleWebToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"token": b.token})
+	_ = json.NewEncoder(w).Encode(map[string]string{"token": b.token})
 }
 
 func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
@@ -1562,7 +1563,11 @@ func (b *Broker) ServeWebUI(port int) {
 	} else {
 		mux.Handle("/", fileServer)
 	}
-	go http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), mux)
+	go func() {
+		if err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), mux); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("broker web UI proxy: listen on :%d: %v", port, err)
+		}
+	}()
 }
 
 func (b *Broker) webUIProxyHandler(brokerURL, stripPrefix string) http.Handler {
@@ -1623,7 +1628,7 @@ func (b *Broker) webUIProxyHandler(brokerURL, stripPrefix string) http.Handler {
 			}
 			return
 		}
-		io.Copy(w, resp.Body)
+		_, _ = io.Copy(w, resp.Body)
 	})
 }
 
@@ -3593,7 +3598,7 @@ func (b *Broker) handleHealth(w http.ResponseWriter, r *http.Request) {
 	memoryStatus := ResolveMemoryBackendStatus()
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"status":                "ok",
 		"session_mode":          mode,
 		"one_on_one_agent":      agent,
@@ -3610,7 +3615,7 @@ func (b *Broker) handleHealth(w http.ResponseWriter, r *http.Request) {
 func (b *Broker) handleVersion(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(buildinfo.Current())
+	_ = json.NewEncoder(w).Encode(buildinfo.Current())
 }
 
 func (b *Broker) handleSessionMode(w http.ResponseWriter, r *http.Request) {
@@ -3618,7 +3623,7 @@ func (b *Broker) handleSessionMode(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		mode, agent := b.SessionModeState()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"session_mode":     mode,
 			"one_on_one_agent": agent,
 		})
@@ -3637,7 +3642,7 @@ func (b *Broker) handleSessionMode(w http.ResponseWriter, r *http.Request) {
 		}
 		mode, agent := b.SessionModeState()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"session_mode":     mode,
 			"one_on_one_agent": agent,
 		})
@@ -3650,7 +3655,7 @@ func (b *Broker) handleFocusMode(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"focus_mode": b.FocusModeEnabled(),
 		})
 	case http.MethodPost:
@@ -3666,7 +3671,7 @@ func (b *Broker) handleFocusMode(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"focus_mode": b.FocusModeEnabled(),
 		})
 	default:
@@ -3681,7 +3686,7 @@ func (b *Broker) handleReset(w http.ResponseWriter, r *http.Request) {
 	}
 	b.Reset()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }
 
 func (b *Broker) handleResetDM(w http.ResponseWriter, r *http.Request) {
@@ -3744,7 +3749,7 @@ func (b *Broker) handleResetDM(w http.ResponseWriter, r *http.Request) {
 	go respawnAgentPane(agent)
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"ok": true, "removed": removed})
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "removed": removed})
 }
 
 // respawnAgentPane restarts an agent's Claude Code session in its tmux pane.
@@ -3760,12 +3765,12 @@ func respawnAgentPane(slug string) {
 			paneIdx := i + 1 // pane 0 is channel view
 			target := fmt.Sprintf("wuphf-team:team.%d", paneIdx)
 			// Send Ctrl+C to interrupt, then exit to terminate
-			exec.Command("tmux", "-L", "wuphf", "send-keys", "-t", target, "C-c", "").Run()
+			_ = exec.Command("tmux", "-L", "wuphf", "send-keys", "-t", target, "C-c", "").Run()
 			time.Sleep(500 * time.Millisecond)
-			exec.Command("tmux", "-L", "wuphf", "send-keys", "-t", target, "C-c", "").Run()
+			_ = exec.Command("tmux", "-L", "wuphf", "send-keys", "-t", target, "C-c", "").Run()
 			time.Sleep(500 * time.Millisecond)
 			// Respawn the pane with a fresh claude session
-			exec.Command("tmux", "-L", "wuphf", "respawn-pane", "-k", "-t", target).Run()
+			_ = exec.Command("tmux", "-L", "wuphf", "respawn-pane", "-k", "-t", target).Run()
 			return
 		}
 	}
@@ -3784,7 +3789,7 @@ func (b *Broker) handleUsage(w http.ResponseWriter, r *http.Request) {
 	b.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(usage)
+	_ = json.NewEncoder(w).Encode(usage)
 }
 
 // RecordPolicy adds a new active policy. Deduplicates by exact rule text.
@@ -3834,7 +3839,7 @@ func (b *Broker) handlePolicies(w http.ResponseWriter, r *http.Request) {
 		}
 		b.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"policies": out})
+		_ = json.NewEncoder(w).Encode(map[string]any{"policies": out})
 
 	case http.MethodPost:
 		var body struct {
@@ -3855,7 +3860,7 @@ func (b *Broker) handlePolicies(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(p)
+		_ = json.NewEncoder(w).Encode(p)
 
 	case http.MethodDelete:
 		id := strings.TrimPrefix(r.URL.Path, "/policies/")
@@ -3882,7 +3887,7 @@ func (b *Broker) handlePolicies(w http.ResponseWriter, r *http.Request) {
 		}
 		b.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -3899,7 +3904,7 @@ func (b *Broker) handleSignals(w http.ResponseWriter, r *http.Request) {
 	copy(signals, b.signals)
 	b.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"signals": signals})
+	_ = json.NewEncoder(w).Encode(map[string]any{"signals": signals})
 }
 
 func (b *Broker) handleDecisions(w http.ResponseWriter, r *http.Request) {
@@ -3912,7 +3917,7 @@ func (b *Broker) handleDecisions(w http.ResponseWriter, r *http.Request) {
 	copy(decisions, b.decisions)
 	b.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"decisions": decisions})
+	_ = json.NewEncoder(w).Encode(map[string]any{"decisions": decisions})
 }
 
 func (b *Broker) handleWatchdogs(w http.ResponseWriter, r *http.Request) {
@@ -3925,7 +3930,7 @@ func (b *Broker) handleWatchdogs(w http.ResponseWriter, r *http.Request) {
 	copy(alerts, b.watchdogs)
 	b.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"watchdogs": alerts})
+	_ = json.NewEncoder(w).Encode(map[string]any{"watchdogs": alerts})
 }
 
 func (b *Broker) handleActions(w http.ResponseWriter, r *http.Request) {
@@ -3936,7 +3941,7 @@ func (b *Broker) handleActions(w http.ResponseWriter, r *http.Request) {
 		copy(actions, b.actions)
 		b.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"actions": actions})
+		_ = json.NewEncoder(w).Encode(map[string]any{"actions": actions})
 	case http.MethodPost:
 		var body struct {
 			Kind       string   `json:"kind"`
@@ -3970,7 +3975,7 @@ func (b *Broker) handleActions(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
@@ -4272,7 +4277,7 @@ Input JSON:
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"ok":              true,
 		"package":         pkg,
 		"artifacts":       artifacts,
@@ -4656,11 +4661,11 @@ func (b *Broker) handleStudioRunWorkflow(w http.ResponseWriter, r *http.Request)
 					retryAt, rateLimited := externalWorkflowRetryAfter(err, now)
 					failKind := "external_workflow_failed"
 					failStatus := "failed"
-					failSummary := truncateSummary(fmt.Sprintf("Studio workflow %s failed via %s (%s)", workflowKey, strings.Title(providerLabel), mode), 140)
+					failSummary := truncateSummary(fmt.Sprintf("Studio workflow %s failed via %s (%s)", workflowKey, titleCaser.String(providerLabel), mode), 140)
 					if rateLimited {
 						failKind = "external_workflow_rate_limited"
 						failStatus = "rate_limited"
-						failSummary = truncateSummary(fmt.Sprintf("Studio workflow %s rate-limited via %s (%s)", workflowKey, strings.Title(providerLabel), mode), 140)
+						failSummary = truncateSummary(fmt.Sprintf("Studio workflow %s rate-limited via %s (%s)", workflowKey, titleCaser.String(providerLabel), mode), 140)
 						retryDelay := time.Until(retryAt)
 						if retryDelay < time.Second {
 							retryDelay = time.Second
@@ -4694,7 +4699,7 @@ func (b *Broker) handleStudioRunWorkflow(w http.ResponseWriter, r *http.Request)
 	if status == "" {
 		status = "completed"
 	}
-	summary := truncateSummary(fmt.Sprintf("Studio workflow %s ran via %s (%s)", workflowKey, strings.Title(providerLabel), mode), 140)
+	summary := truncateSummary(fmt.Sprintf("Studio workflow %s ran via %s (%s)", workflowKey, titleCaser.String(providerLabel), mode), 140)
 	if err := b.RecordAction("external_workflow_executed", providerLabel, channel, actor, summary, workflowKey, nil, ""); err != nil {
 		http.Error(w, "failed to record workflow action", http.StatusInternalServerError)
 		return
@@ -4705,7 +4710,7 @@ func (b *Broker) handleStudioRunWorkflow(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"ok":           true,
 		"skill_name":   skillName,
 		"workflow_key": workflowKey,
@@ -4738,7 +4743,7 @@ func (b *Broker) handleScheduler(w http.ResponseWriter, r *http.Request) {
 		}
 		b.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"jobs": jobs})
+		_ = json.NewEncoder(w).Encode(map[string]any{"jobs": jobs})
 	case http.MethodPost:
 		var body schedulerJob
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -4754,7 +4759,7 @@ func (b *Broker) handleScheduler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
@@ -4860,7 +4865,7 @@ func (b *Broker) handleBridge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"id":          msg.ID,
 		"decision_id": decision.ID,
 		"signal_ids":  signalIDs,
@@ -4873,7 +4878,7 @@ func (b *Broker) handleQueue(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(b.QueueSnapshot())
+	_ = json.NewEncoder(w).Encode(b.QueueSnapshot())
 }
 
 func (b *Broker) handleCompany(w http.ResponseWriter, r *http.Request) {
@@ -4881,7 +4886,7 @@ func (b *Broker) handleCompany(w http.ResponseWriter, r *http.Request) {
 	case http.MethodGet:
 		cfg, _ := config.Load()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"name":        cfg.CompanyName,
 			"description": cfg.CompanyDescription,
 			"goals":       cfg.CompanyGoals,
@@ -4921,7 +4926,7 @@ func (b *Broker) handleCompany(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
@@ -4940,16 +4945,16 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			// Runtime
-			"llm_provider":        config.ResolveLLMProvider(""),
-			"memory_backend":      config.ResolveMemoryBackend(""),
-			"action_provider":     config.ResolveActionProvider(),
-			"team_lead_slug":      cfg.TeamLeadSlug,
+			"llm_provider":          config.ResolveLLMProvider(""),
+			"memory_backend":        config.ResolveMemoryBackend(""),
+			"action_provider":       config.ResolveActionProvider(),
+			"team_lead_slug":        cfg.TeamLeadSlug,
 			"max_concurrent_agents": cfg.MaxConcurrent,
-			"default_format":      config.ResolveFormat(""),
-			"default_timeout":     config.ResolveTimeout(""),
-			"blueprint":           cfg.ActiveBlueprint(),
+			"default_format":        config.ResolveFormat(""),
+			"default_timeout":       config.ResolveTimeout(""),
+			"blueprint":             cfg.ActiveBlueprint(),
 			// Workspace
 			"email":          cfg.Email,
 			"workspace_id":   cfg.WorkspaceID,
@@ -4962,20 +4967,20 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			"company_size":        cfg.CompanySize,
 			"company_priority":    cfg.CompanyPriority,
 			// Polling intervals
-			"insights_poll_minutes":   config.ResolveInsightsPollInterval(),
-			"task_follow_up_minutes":  config.ResolveTaskFollowUpInterval(),
-			"task_reminder_minutes":   config.ResolveTaskReminderInterval(),
-			"task_recheck_minutes":    config.ResolveTaskRecheckInterval(),
+			"insights_poll_minutes":  config.ResolveInsightsPollInterval(),
+			"task_follow_up_minutes": config.ResolveTaskFollowUpInterval(),
+			"task_reminder_minutes":  config.ResolveTaskReminderInterval(),
+			"task_recheck_minutes":   config.ResolveTaskRecheckInterval(),
 			// Integrations — secret fields as booleans
-			"api_key_set":        config.ResolveAPIKey("") != "",
-			"openai_key_set":     config.ResolveOpenAIAPIKey() != "",
-			"anthropic_key_set":  config.ResolveAnthropicAPIKey() != "",
-			"gemini_key_set":     config.ResolveGeminiAPIKey() != "",
-			"minimax_key_set":    config.ResolveMinimaxAPIKey() != "",
-			"one_key_set":        config.ResolveOneSecret() != "",
-			"composio_key_set":   config.ResolveComposioAPIKey() != "",
-			"telegram_token_set": config.ResolveTelegramBotToken() != "",
-			"openclaw_token_set": config.ResolveOpenclawToken() != "",
+			"api_key_set":          config.ResolveAPIKey("") != "",
+			"openai_key_set":       config.ResolveOpenAIAPIKey() != "",
+			"anthropic_key_set":    config.ResolveAnthropicAPIKey() != "",
+			"gemini_key_set":       config.ResolveGeminiAPIKey() != "",
+			"minimax_key_set":      config.ResolveMinimaxAPIKey() != "",
+			"one_key_set":          config.ResolveOneSecret() != "",
+			"composio_key_set":     config.ResolveComposioAPIKey() != "",
+			"telegram_token_set":   config.ResolveTelegramBotToken() != "",
+			"openclaw_token_set":   config.ResolveOpenclawToken() != "",
 			"openclaw_gateway_url": config.ResolveOpenclawGatewayURL(),
 			// Config file path (informational)
 			"config_path": config.ConfigPath(),
@@ -5203,7 +5208,7 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			b.mu.Unlock()
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
@@ -5234,14 +5239,14 @@ func (b *Broker) handleNexRegister(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadGateway)
-		json.NewEncoder(w).Encode(map[string]any{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"status": "error",
 			"error":  err.Error(),
 		})
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"status": "ok",
 		"email":  email,
 		"output": output,
@@ -5256,7 +5261,7 @@ func (b *Broker) handleOfficeMembers(w http.ResponseWriter, r *http.Request) {
 		copy(members, b.members)
 		b.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"members": members})
+		_ = json.NewEncoder(w).Encode(map[string]any{"members": members})
 	case http.MethodPost:
 		var body struct {
 			Action         string                    `json:"action"`
@@ -5353,7 +5358,7 @@ func (b *Broker) handleOfficeMembers(w http.ResponseWriter, r *http.Request) {
 			}
 			b.publishOfficeChangeLocked(officeChangeEvent{Kind: "member_created", Slug: slug})
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"member": member})
+			_ = json.NewEncoder(w).Encode(map[string]any{"member": member})
 		case "update":
 			member := b.findMemberLocked(slug)
 			if member == nil {
@@ -5443,7 +5448,7 @@ func (b *Broker) handleOfficeMembers(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"member": member})
+			_ = json.NewEncoder(w).Encode(map[string]any{"member": member})
 		case "remove":
 			member := b.findMemberLocked(slug)
 			if member == nil {
@@ -5505,7 +5510,7 @@ func (b *Broker) handleOfficeMembers(w http.ResponseWriter, r *http.Request) {
 			}
 			b.publishOfficeChangeLocked(officeChangeEvent{Kind: "member_removed", Slug: slug})
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"ok": true})
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:
 			http.Error(w, "unknown action", http.StatusBadRequest)
 		}
@@ -5541,7 +5546,7 @@ func (b *Broker) handleGenerateMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(tmpl)
+	_ = json.NewEncoder(w).Encode(tmpl)
 }
 
 func (b *Broker) handleGenerateChannel(w http.ResponseWriter, r *http.Request) {
@@ -5571,7 +5576,7 @@ func (b *Broker) handleGenerateChannel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(tmpl)
+	_ = json.NewEncoder(w).Encode(tmpl)
 }
 
 func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
@@ -5594,7 +5599,7 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 		}
 		b.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"channels": channels})
+		_ = json.NewEncoder(w).Encode(map[string]any{"channels": channels})
 	case http.MethodPost:
 		var body struct {
 			Action      string          `json:"action"`
@@ -5672,7 +5677,7 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 			}
 			b.publishOfficeChangeLocked(officeChangeEvent{Kind: "channel_created", Slug: slug})
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"channel": ch})
+			_ = json.NewEncoder(w).Encode(map[string]any{"channel": ch})
 		case "update":
 			if slug == "" {
 				http.Error(w, "slug required", http.StatusBadRequest)
@@ -5716,7 +5721,7 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 			}
 			b.publishOfficeChangeLocked(officeChangeEvent{Kind: "channel_updated", Slug: slug})
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"channel": ch})
+			_ = json.NewEncoder(w).Encode(map[string]any{"channel": ch})
 		case "remove":
 			if slug == "" || slug == "general" {
 				http.Error(w, "cannot remove channel", http.StatusBadRequest)
@@ -5762,7 +5767,7 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 			}
 			b.publishOfficeChangeLocked(officeChangeEvent{Kind: "channel_removed", Slug: slug})
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"ok": true})
+			_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		default:
 			http.Error(w, "unknown action", http.StatusBadRequest)
 		}
@@ -5856,7 +5861,7 @@ func (b *Broker) handleCreateDM(w http.ResponseWriter, r *http.Request) {
 	b.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"id":      ch.ID,
 		"slug":    ch.Slug,
 		"type":    ch.Type,
@@ -5874,7 +5879,7 @@ func (b *Broker) handleChannelMembers(w http.ResponseWriter, r *http.Request) {
 		if ch == nil {
 			b.mu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"channel": channel, "members": []map[string]any{}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"channel": channel, "members": []map[string]any{}})
 			return
 		}
 		memberInfo := make([]map[string]any, 0, len(ch.Members))
@@ -5886,7 +5891,7 @@ func (b *Broker) handleChannelMembers(w http.ResponseWriter, r *http.Request) {
 		}
 		b.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"channel": channel, "members": memberInfo})
+		_ = json.NewEncoder(w).Encode(map[string]any{"channel": channel, "members": memberInfo})
 	case http.MethodPost:
 		var body struct {
 			Channel string `json:"channel"`
@@ -5970,7 +5975,7 @@ func (b *Broker) handleChannelMembers(w http.ResponseWriter, r *http.Request) {
 		}
 		b.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(state)
+		_ = json.NewEncoder(w).Encode(state)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
@@ -6046,7 +6051,7 @@ func (b *Broker) handleOTLPLogs(w http.ResponseWriter, r *http.Request) {
 	b.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"accepted": len(events)})
+	_ = json.NewEncoder(w).Encode(map[string]any{"accepted": len(events)})
 }
 
 func (b *Broker) handleNexNotifications(w http.ResponseWriter, r *http.Request) {
@@ -6077,7 +6082,7 @@ func (b *Broker) handleNexNotifications(w http.ResponseWriter, r *http.Request) 
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"id":        msg.ID,
 		"duplicate": duplicate,
 	})
@@ -6420,7 +6425,7 @@ func (b *Broker) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 	b.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"id":    msg.ID,
 		"total": total,
 	})
@@ -6454,7 +6459,7 @@ func (b *Broker) handleReactions(w http.ResponseWriter, r *http.Request) {
 				if r.Emoji == body.Emoji && r.From == body.From {
 					b.mu.Unlock()
 					w.Header().Set("Content-Type", "application/json")
-					json.NewEncoder(w).Encode(map[string]any{"ok": true, "duplicate": true})
+					_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "duplicate": true})
 					return
 				}
 			}
@@ -6475,7 +6480,7 @@ func (b *Broker) handleReactions(w http.ResponseWriter, r *http.Request) {
 	b.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }
 
 // RecordTelegramGroup saves a group chat ID and title seen by the transport.
@@ -6742,7 +6747,7 @@ func (b *Broker) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"channel":      channel,
 		"messages":     result,
 		"tagged_count": taggedCount,
@@ -7115,7 +7120,7 @@ func (b *Broker) handleMembers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"channel": channel, "members": list})
+	_ = json.NewEncoder(w).Encode(map[string]any{"channel": channel, "members": list})
 }
 
 func (b *Broker) handleTasks(w http.ResponseWriter, r *http.Request) {
@@ -7217,7 +7222,7 @@ func (b *Broker) handleGetTasks(w http.ResponseWriter, r *http.Request) {
 	b.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"channel": channel, "tasks": result})
+	_ = json.NewEncoder(w).Encode(map[string]any{"channel": channel, "tasks": result})
 }
 
 func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
@@ -7324,7 +7329,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"task": *existing})
+			_ = json.NewEncoder(w).Encode(map[string]any{"task": *existing})
 			return
 		}
 		b.counter++
@@ -7372,7 +7377,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"task": task})
+		_ = json.NewEncoder(w).Encode(map[string]any{"task": task})
 		return
 	}
 
@@ -7520,7 +7525,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"task": *task})
+		_ = json.NewEncoder(w).Encode(map[string]any{"task": *task})
 		return
 	}
 
@@ -7961,7 +7966,7 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"tasks": created})
+	_ = json.NewEncoder(w).Encode(map[string]any{"tasks": created})
 }
 
 func (b *Broker) handleMemory(w http.ResponseWriter, r *http.Request) {
@@ -7991,7 +7996,7 @@ func (b *Broker) handleMemory(w http.ResponseWriter, r *http.Request) {
 				if raw, ok := entries[keyFilter]; ok {
 					payload = append(payload, brokerEntryFromNote(decodePrivateMemoryNote(keyFilter, raw)))
 				}
-				json.NewEncoder(w).Encode(map[string]any{
+				_ = json.NewEncoder(w).Encode(map[string]any{
 					"namespace": namespace,
 					"entries":   payload,
 				})
@@ -8002,7 +8007,7 @@ func (b *Broker) handleMemory(w http.ResponseWriter, r *http.Request) {
 				for _, note := range matches {
 					payload = append(payload, brokerEntryFromNote(note))
 				}
-				json.NewEncoder(w).Encode(map[string]any{
+				_ = json.NewEncoder(w).Encode(map[string]any{
 					"namespace": namespace,
 					"entries":   payload,
 				})
@@ -8013,14 +8018,14 @@ func (b *Broker) handleMemory(w http.ResponseWriter, r *http.Request) {
 				for _, note := range matches {
 					payload = append(payload, brokerEntryFromNote(note))
 				}
-				json.NewEncoder(w).Encode(map[string]any{
+				_ = json.NewEncoder(w).Encode(map[string]any{
 					"namespace": namespace,
 					"entries":   payload,
 				})
 				return
 			}
 		}
-		json.NewEncoder(w).Encode(map[string]any{"memory": mem})
+		_ = json.NewEncoder(w).Encode(map[string]any{"memory": mem})
 	case http.MethodPost:
 		var body struct {
 			Namespace string `json:"namespace"`
@@ -8065,7 +8070,7 @@ func (b *Broker) handleMemory(w http.ResponseWriter, r *http.Request) {
 		}
 		b.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"ok": true, "namespace": ns, "key": key})
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "namespace": ns, "key": key})
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
@@ -8112,7 +8117,7 @@ func (b *Broker) handleTaskAck(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"task": b.tasks[i]})
+			_ = json.NewEncoder(w).Encode(map[string]any{"task": b.tasks[i]})
 			return
 		}
 	}
@@ -8524,7 +8529,7 @@ func (b *Broker) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 	pending := firstBlockingRequest(requests)
 	b.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
+	_ = json.NewEncoder(w).Encode(map[string]any{
 		"channel":  channel,
 		"requests": requests,
 		"pending":  pending,
@@ -8614,7 +8619,7 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"request": req, "id": req.ID})
+		_ = json.NewEncoder(w).Encode(map[string]any{"request": req, "id": req.ID})
 	case "cancel":
 		id := strings.TrimSpace(body.ID)
 		if id == "" {
@@ -8639,7 +8644,7 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]any{"request": b.requests[i]})
+			_ = json.NewEncoder(w).Encode(map[string]any{"request": b.requests[i]})
 			return
 		}
 		http.Error(w, "request not found", http.StatusNotFound)
@@ -8666,11 +8671,11 @@ func (b *Broker) handleGetRequestAnswer(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/json")
 	for _, req := range b.requests {
 		if req.ID == id && req.Answered != nil {
-			json.NewEncoder(w).Encode(map[string]any{"answered": req.Answered})
+			_ = json.NewEncoder(w).Encode(map[string]any{"answered": req.Answered})
 			return
 		}
 	}
-	json.NewEncoder(w).Encode(map[string]any{"answered": nil})
+	_ = json.NewEncoder(w).Encode(map[string]any{"answered": nil})
 }
 
 func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request) {
@@ -8784,7 +8789,7 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 		b.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]any{"ok": true})
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 		return
 	}
 	b.mu.Unlock()
@@ -8900,10 +8905,10 @@ func (b *Broker) handleGetInterview(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	pending := firstBlockingRequest(b.requests)
 	if pending == nil {
-		json.NewEncoder(w).Encode(map[string]any{"pending": nil})
+		_ = json.NewEncoder(w).Encode(map[string]any{"pending": nil})
 		return
 	}
-	json.NewEncoder(w).Encode(map[string]any{"pending": pending})
+	_ = json.NewEncoder(w).Encode(map[string]any{"pending": pending})
 }
 
 func (b *Broker) handleInterviewAnswer(w http.ResponseWriter, r *http.Request) {
@@ -8992,7 +8997,7 @@ func (b *Broker) handleTelegramGroups(w http.ResponseWriter, r *http.Request) {
 	}
 	b.mu.Unlock()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"groups": groups})
+	_ = json.NewEncoder(w).Encode(map[string]any{"groups": groups})
 }
 
 func (b *Broker) handleSkills(w http.ResponseWriter, r *http.Request) {
@@ -9066,7 +9071,7 @@ func (b *Broker) handleGetSkills(w http.ResponseWriter, r *http.Request) {
 	b.mu.Unlock()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"skills": result})
+	_ = json.NewEncoder(w).Encode(map[string]any{"skills": result})
 }
 
 func (b *Broker) handlePostSkill(w http.ResponseWriter, r *http.Request) {
@@ -9178,7 +9183,7 @@ func (b *Broker) handlePostSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"skill": sk})
+	_ = json.NewEncoder(w).Encode(map[string]any{"skill": sk})
 }
 
 func (b *Broker) handlePutSkill(w http.ResponseWriter, r *http.Request) {
@@ -9297,7 +9302,7 @@ func (b *Broker) handlePutSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"skill": *sk})
+	_ = json.NewEncoder(w).Encode(map[string]any{"skill": *sk})
 }
 
 func (b *Broker) handleDeleteSkill(w http.ResponseWriter, r *http.Request) {
@@ -9350,7 +9355,7 @@ func (b *Broker) handleDeleteSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
 }
 
 func (b *Broker) handleInvokeSkill(w http.ResponseWriter, r *http.Request) {
@@ -9424,7 +9429,7 @@ func (b *Broker) handleInvokeSkill(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"skill": *sk, "channel": channel})
+	_ = json.NewEncoder(w).Encode(map[string]any{"skill": *sk, "channel": channel})
 }
 
 // parseSkillProposalLocked extracts a [SKILL PROPOSAL] block from a message
@@ -9605,7 +9610,9 @@ func (b *Broker) SeedDefaultSkills(specs []agent.PackSkillSpec) {
 		}
 		b.skills = append(b.skills, sk)
 	}
-	b.saveLocked()
+	if err := b.saveLocked(); err != nil {
+		log.Printf("broker: saveLocked after seeding skills: %v", err)
+	}
 }
 
 // dirExists returns true if path exists and is a directory.

--- a/internal/team/broker_agent_logs_test.go
+++ b/internal/team/broker_agent_logs_test.go
@@ -34,7 +34,7 @@ func TestHandleAgentLogs_ListsRecent(t *testing.T) {
 
 	b := newTestBroker(t)
 	b.SetAgentLogRoot(logRoot)
-	srv := httptest.NewServer(http.HandlerFunc(b.requireAuth(b.handleAgentLogs)))
+	srv := httptest.NewServer(b.requireAuth(b.handleAgentLogs))
 	defer srv.Close()
 
 	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
@@ -77,7 +77,7 @@ func TestHandleAgentLogs_ReadsSingleTask(t *testing.T) {
 
 	b := newTestBroker(t)
 	b.SetAgentLogRoot(logRoot)
-	srv := httptest.NewServer(http.HandlerFunc(b.requireAuth(b.handleAgentLogs)))
+	srv := httptest.NewServer(b.requireAuth(b.handleAgentLogs))
 	defer srv.Close()
 
 	req, _ := http.NewRequest(http.MethodGet, srv.URL+"?task=eng-12345", nil)
@@ -106,7 +106,7 @@ func TestHandleAgentLogs_ReadsSingleTask(t *testing.T) {
 func TestHandleAgentLogs_RejectsPathTraversal(t *testing.T) {
 	b := newTestBroker(t)
 	b.SetAgentLogRoot(t.TempDir())
-	srv := httptest.NewServer(http.HandlerFunc(b.requireAuth(b.handleAgentLogs)))
+	srv := httptest.NewServer(b.requireAuth(b.handleAgentLogs))
 	defer srv.Close()
 
 	for _, bad := range []string{"../etc/passwd", "eng/../../../etc/passwd", "a/b"} {

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -168,11 +168,11 @@ func (b *Broker) postBlankSlateKickoffLocked(profile operationCompanyProfile, bl
 	}
 	b.counter++
 	b.appendMessageLocked(channelMessage{
-		ID:      fmt.Sprintf("msg-%d", b.counter),
-		From:    "system",
-		Channel: "general",
-		Kind:    "from_scratch_contract",
-		Content: "Run this as a real business workflow. If a needed specialist, channel, skill, or tooling path is missing, create it and keep going. Local proof packets, review bundles, and other internal substitute artifacts do not count when a live business step is possible.",
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "system",
+		Channel:   "general",
+		Kind:      "from_scratch_contract",
+		Content:   "Run this as a real business workflow. If a needed specialist, channel, skill, or tooling path is missing, create it and keep going. Local proof packets, review bundles, and other internal substitute artifacts do not count when a live business step is possible.",
 		Timestamp: time.Now().UTC().Format(time.RFC3339),
 	})
 	_ = profile

--- a/internal/team/dispatch_test.go
+++ b/internal/team/dispatch_test.go
@@ -11,11 +11,11 @@ func TestNormalizeProviderKind(t *testing.T) {
 	tests := []struct {
 		in, want string
 	}{
-		{"", provider.KindClaudeCode},           // empty → default to claude-code
-		{"claude", provider.KindClaudeCode},     // legacy alias
-		{"Claude", provider.KindClaudeCode},     // case-insensitive
-		{" codex ", provider.KindCodex},         // trim
-		{"CODEX", provider.KindCodex},           // uppercase
+		{"", provider.KindClaudeCode},       // empty → default to claude-code
+		{"claude", provider.KindClaudeCode}, // legacy alias
+		{"Claude", provider.KindClaudeCode}, // case-insensitive
+		{" codex ", provider.KindCodex},     // trim
+		{"CODEX", provider.KindCodex},       // uppercase
 		{"claude-code", provider.KindClaudeCode},
 		{"openclaw", provider.KindOpenclaw},
 		{"gemini", "gemini"}, // unknown passes through so dispatch can error

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -109,7 +109,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
-		pw.Close()
+		_ = pw.Close()
 		return err
 	}
 	done := make(chan struct{})
@@ -170,7 +170,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 			l.updateHeadlessProgress(slug, "error", "error", truncate(event.Detail, 180), metrics)
 		}
 	})
-	pw.Close() // signal scanner goroutine that stream is done
+	_ = pw.Close() // signal scanner goroutine that stream is done (io.PipeWriter.Close always returns nil)
 	if err := cmd.Wait(); err != nil {
 		detail := strings.TrimSpace(firstNonEmpty(result.LastError, strings.TrimSpace(stderr.String()), err.Error()))
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
@@ -283,7 +283,7 @@ func appendHeadlessClaudeLog(slug string, line string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, _ = fmt.Fprintf(f, "[%s] %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(line))
 }
 
@@ -296,6 +296,6 @@ func appendHeadlessClaudeLatency(slug string, line string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, _ = fmt.Fprintf(f, "[%s] agent=%s %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(slug), strings.TrimSpace(line))
 }

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -79,7 +79,7 @@ var headlessCodexWorkspaceStatusSnapshot = func(path string) string {
 func (l *Launcher) launchHeadlessCodex() error {
 	killStaleBroker()
 	killStaleHeadlessTaskRunners()
-	exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 
 	l.broker = NewBroker()
 	l.broker.packSlug = l.packSlug
@@ -957,7 +957,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	if err := cmd.Start(); err != nil {
-		pw.Close()
+		_ = pw.Close()
 		return err
 	}
 	done := make(chan struct{})
@@ -1016,7 +1016,7 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			l.updateHeadlessProgress(slug, "error", "error", truncate(event.Detail, 180), metrics)
 		}
 	})
-	pw.Close() // signal scanner goroutine that stream is done
+	_ = pw.Close() // signal scanner goroutine that stream is done (io.PipeWriter.Close always returns nil)
 	if err := cmd.Wait(); err != nil {
 		detail := firstNonEmpty(result.LastError, strings.TrimSpace(stderr.String()))
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
@@ -1352,7 +1352,7 @@ func appendHeadlessCodexLog(slug string, line string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, _ = fmt.Fprintf(f, "[%s] %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(line))
 }
 
@@ -1365,7 +1365,7 @@ func appendHeadlessCodexLatency(slug string, line string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, _ = fmt.Fprintf(f, "[%s] agent=%s %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(slug), strings.TrimSpace(line))
 }
 

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -248,7 +248,7 @@ func (l *Launcher) Launch() error {
 	}
 
 	// Kill any existing session
-	exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 
 	// Resolve wuphf binary path for the channel view
 	wuphfBinary, _ := os.Executable()
@@ -281,16 +281,16 @@ func (l *Launcher) Launch() error {
 
 	// Keep tmux mouse off for this session so native terminal selection/copy works.
 	// WUPHF is keyboard-first; we don't want the TUI or tmux to steal mouse events.
-	exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"mouse", "off",
 	).Run()
 
 	// Hide tmux's default status bar — our channel TUI has its own.
-	exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"status", "off",
 	).Run()
 	// Keep panes visible if a process exits so crashes don't collapse the layout.
-	exec.Command("tmux", "-L", tmuxSocketName, "set-window-option", "-t", l.sessionName+":team",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-window-option", "-t", l.sessionName+":team",
 		"remain-on-exit", "on",
 	).Run()
 
@@ -301,27 +301,27 @@ func (l *Launcher) Launch() error {
 	l.spawnOverflowAgents()
 
 	// Enable pane borders with labels and visible resize handles.
-	exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-status", "top",
 	).Run()
 	// Show agent name in the border; mouse drag is intentionally disabled.
-	exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-format", " #{pane_title} ",
 	).Run()
 	// Make inactive border visible but subtle
-	exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-style", "fg=colour240",
 	).Run()
 	// Active pane border bright so you know which pane has focus
-	exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-active-border-style", "fg=colour45",
 	).Run()
 	// Use line-drawing characters for clear keyboard-focused pane boundaries.
-	exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-lines", "heavy",
 	).Run()
 
-	exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
 		"-t", l.sessionName+":team.0",
 		"-T", "📢 channel",
 	).Run()
@@ -332,17 +332,17 @@ func (l *Launcher) Launch() error {
 			i++
 		}
 		name := l.getAgentName(slug)
-		exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", fmt.Sprintf("%s:team.%d", l.sessionName, i),
 			"-T", fmt.Sprintf("🤖 %s (@%s)", name, slug),
 		).Run()
 	}
 
 	// Focus on the channel pane.
-	exec.Command("tmux", "-L", tmuxSocketName, "select-window",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-window",
 		"-t", l.sessionName+":team",
 	).Run()
-	exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
 		"-t", l.sessionName+":team.0",
 	).Run()
 
@@ -404,8 +404,8 @@ func recoverPanicTo(site, extra string) {
 	fmt.Fprintf(os.Stderr, "panic in %s: %v\n%s\n%s\n", site, r, extra, buf[:n])
 	if home, err := os.UserHomeDir(); err == nil {
 		if f, ferr := os.OpenFile(filepath.Join(home, ".wuphf", "logs", "panics.log"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644); ferr == nil {
-			fmt.Fprintf(f, "%s panic in %s: %v\n%s\n%s\n\n", time.Now().UTC().Format(time.RFC3339), site, r, extra, buf[:n])
-			f.Close()
+			_, _ = fmt.Fprintf(f, "%s panic in %s: %v\n%s\n%s\n\n", time.Now().UTC().Format(time.RFC3339), site, r, extra, buf[:n])
+			_ = f.Close()
 		}
 	}
 }
@@ -1114,12 +1114,12 @@ func (l *Launcher) watchChannelPaneLoop(channelCmd string) {
 		deadSince = time.Time{}
 		snapshotWritten = false
 		target := l.sessionName + ":team.0"
-		exec.Command("tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
 			"-t", target,
 			"-c", l.cwd,
 			channelCmd,
 		).Run()
-		exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", target,
 			"-T", "📢 channel",
 		).Run()
@@ -1167,9 +1167,11 @@ func (l *Launcher) captureDeadChannelPane(status string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
-	_, err = fmt.Fprintf(f, "\n[%s] status=%s\n%s\n", time.Now().Format(time.RFC3339), status, content)
-	return err
+	if _, err := fmt.Fprintf(f, "\n[%s] status=%s\n%s\n", time.Now().Format(time.RFC3339), status, content); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 func channelStderrLogPath() string {
@@ -1211,7 +1213,7 @@ func (l *Launcher) primeVisibleAgents() {
 				continue
 			}
 			if shouldPrimeClaudePane(content) {
-				exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+				_ = exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
 					"-t", target.PaneTarget,
 					"Enter",
 				).Run()
@@ -1386,7 +1388,7 @@ func (l *Launcher) processDueTaskJob(job schedulerJob) {
 		return
 	}
 	alertKind := "task_stalled"
-	summary := fmt.Sprintf("Task %s in #%s is still waiting for movement.", task.Title, normalizeChannelSlug(task.Channel))
+	var summary string
 	if strings.TrimSpace(task.Owner) == "" {
 		alertKind = "task_unclaimed"
 		summary = fmt.Sprintf("Task %s in #%s still has no owner.", task.Title, normalizeChannelSlug(task.Channel))
@@ -1494,7 +1496,7 @@ func (l *Launcher) processDueWorkflowJob(job schedulerJob) {
 	now := time.Now().UTC()
 	nextRun, hasNext := nextWorkflowRun(strings.TrimSpace(payload.ScheduleExpr), now)
 	if err != nil {
-		summary := fmt.Sprintf("Scheduled workflow %s failed via %s", workflowKey, strings.Title(provider.Name()))
+		summary := fmt.Sprintf("Scheduled workflow %s failed via %s", workflowKey, titleCaser.String(provider.Name()))
 		_ = l.broker.RecordAction("external_workflow_failed", provider.Name(), channel, "scheduler", summary, workflowKey, nil, "")
 		_ = l.broker.UpdateSkillExecutionByWorkflowKey(workflowKey, "failed", now)
 		if hasNext {
@@ -1508,7 +1510,7 @@ func (l *Launcher) processDueWorkflowJob(job schedulerJob) {
 	if status == "" {
 		status = "completed"
 	}
-	summary := fmt.Sprintf("Scheduled workflow %s ran via %s", workflowKey, strings.Title(provider.Name()))
+	summary := fmt.Sprintf("Scheduled workflow %s ran via %s", workflowKey, titleCaser.String(provider.Name()))
 	_ = l.broker.RecordAction("external_workflow_executed", provider.Name(), channel, "scheduler", summary, workflowKey, nil, "")
 	_ = l.broker.UpdateSkillExecutionByWorkflowKey(workflowKey, status, now)
 	if hasNext {
@@ -1778,7 +1780,7 @@ func killStaleBroker() {
 		return
 	}
 	for _, pid := range strings.Fields(strings.TrimSpace(string(out))) {
-		exec.Command("kill", "-9", pid).Run()
+		_ = exec.Command("kill", "-9", pid).Run()
 	}
 	time.Sleep(500 * time.Millisecond)
 }
@@ -1970,7 +1972,7 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 		target := fmt.Sprintf("%s:team.%d", l.sessionName, idx)
 		// respawn-pane -k kills the current process and starts a new one
 		// in the same pane — preserving size and position
-		exec.Command("tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
 			"-t", target,
 			"-c", l.cwd,
 			cmd,
@@ -2274,10 +2276,6 @@ func (l *Launcher) relevantTaskForTarget(msg channelMessage, slug string) (teamT
 	if l.broker == nil || slug == "" {
 		return teamTask{}, false
 	}
-	channel := normalizeChannelSlug(msg.Channel)
-	if channel == "" {
-		channel = "general"
-	}
 	threadRoot := strings.TrimSpace(msg.ID)
 	if replyTo := strings.TrimSpace(msg.ReplyTo); replyTo != "" {
 		threadRoot = replyTo
@@ -2575,13 +2573,13 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 // so accumulated history is not needed and only causes drift over time.
 // --append-system-prompt is a CLI flag and survives /clear intact.
 func (l *Launcher) sendNotificationToPane(paneTarget, notification string) {
-	exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
 		"-t", paneTarget, "/clear", "Enter",
 	).Run()
-	exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
 		"-t", paneTarget, "-l", notification,
 	).Run()
-	exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
 		"-t", paneTarget, "Enter",
 	).Run()
 }
@@ -2698,7 +2696,7 @@ func (l *Launcher) clearAgentPanes() error {
 			continue // skip pane 0 (channel TUI)
 		}
 		target := fmt.Sprintf("%s:team.%d", l.sessionName, idx)
-		exec.Command("tmux", "-L", tmuxSocketName, "kill-pane", "-t", target).Run()
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-pane", "-t", target).Run()
 	}
 	return nil
 }
@@ -2716,7 +2714,7 @@ func (l *Launcher) clearOverflowAgentWindows() {
 		if !strings.HasPrefix(name, "agent-") {
 			continue
 		}
-		exec.Command("tmux", "-L", tmuxSocketName, "kill-window",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-window",
 			"-t", fmt.Sprintf("%s:%s", l.sessionName, name),
 		).Run()
 	}
@@ -2802,22 +2800,22 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 		).Run(); err != nil {
 			return nil, fmt.Errorf("spawn one-on-one agent: %w", err)
 		}
-		exec.Command("tmux", "-L", tmuxSocketName, "select-layout",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-layout",
 			"-t", l.sessionName+":team",
 			"main-vertical",
 		).Run()
-		exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", l.sessionName+":team.0",
 			"-T", "📢 direct",
 		).Run()
-		exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", fmt.Sprintf("%s:team.1", l.sessionName),
 			"-T", fmt.Sprintf("🤖 %s (@%s)", l.getAgentName(slug), slug),
 		).Run()
-		exec.Command("tmux", "-L", tmuxSocketName, "select-window",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-window",
 			"-t", l.sessionName+":team",
 		).Run()
-		exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", l.sessionName+":team.0",
 		).Run()
 		return []string{slug}, nil
@@ -2851,7 +2849,7 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 	for i := 1; i < len(visible); i++ {
 		agentCmd := l.claudeCommand(visible[i].Slug, l.buildPrompt(visible[i].Slug))
 		// Split from the last agent pane
-		exec.Command("tmux", "-L", tmuxSocketName, "split-window",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "split-window",
 			"-t", l.sessionName+":team.1",
 			"-c", l.cwd,
 			agentCmd,
@@ -2860,21 +2858,21 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 
 	// Apply tiled layout to agent panes, but keep channel (pane 0) as main-vertical
 	// Use main-vertical first to keep channel on the left
-	exec.Command("tmux", "-L", tmuxSocketName, "select-layout",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-layout",
 		"-t", l.sessionName+":team",
 		"main-vertical",
 	).Run()
 
 	// Now set pane titles
 	var visibleSlugs []string
-	exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
 		"-t", l.sessionName+":team.0",
 		"-T", "📢 channel",
 	).Run()
 	for i, a := range visible {
 		paneIdx := i + 1 // pane 0 is channel
 		name := l.getAgentName(a.Slug)
-		exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", fmt.Sprintf("%s:team.%d", l.sessionName, paneIdx),
 			"-T", fmt.Sprintf("🤖 %s (@%s)", name, a.Slug),
 		).Run()
@@ -2882,10 +2880,10 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 	}
 
 	// Focus channel pane
-	exec.Command("tmux", "-L", tmuxSocketName, "select-window",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-window",
 		"-t", l.sessionName+":team",
 	).Run()
-	exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
 		"-t", l.sessionName+":team.0",
 	).Run()
 
@@ -2896,7 +2894,7 @@ func (l *Launcher) spawnOverflowAgents() {
 	for _, member := range l.overflowOfficeMembers() {
 		agentCmd := l.claudeCommand(member.Slug, l.buildPrompt(member.Slug))
 		windowName := overflowWindowName(member.Slug)
-		exec.Command("tmux", "-L", tmuxSocketName, "new-window", "-d",
+		_ = exec.Command("tmux", "-L", tmuxSocketName, "new-window", "-d",
 			"-t", l.sessionName,
 			"-n", windowName,
 			"-c", l.cwd,
@@ -3782,7 +3780,7 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		fmt.Println()
 		fmt.Print("  Connect Nex for memory and context? [Y/n] ")
 		var answer string
-		fmt.Scanln(&answer)
+		_, _ = fmt.Scanln(&answer)
 		answer = strings.TrimSpace(strings.ToLower(answer))
 		if answer == "" || answer == "y" || answer == "yes" {
 			fmt.Println()
@@ -3922,7 +3920,10 @@ func (l *Launcher) headlessClaudeCommand(slug, systemPrompt string) string {
 // runBackgroundAgent runs a single agent as a headless OS process.
 func (l *Launcher) runBackgroundAgent(slug, cmdStr string) {
 	logDir := filepath.Join(os.TempDir(), "wuphf-agents")
-	os.MkdirAll(logDir, 0o700)
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		fmt.Fprintf(os.Stderr, "[%s] failed to create log dir %s: %v\n", slug, logDir, err)
+		return
+	}
 	logPath := filepath.Join(logDir, slug+".log")
 
 	for {
@@ -3957,8 +3958,10 @@ func (l *Launcher) runBackgroundAgent(slug, cmdStr string) {
 
 		fmt.Fprintf(os.Stderr, "[%s] agent starting (log: %s)\n", slug, logPath)
 		runErr := cmd.Run()
-		pw.Close() // signals scanner goroutine to exit
-		logFile.Close()
+		_ = pw.Close() // signals scanner goroutine to exit (io.PipeWriter.Close always returns nil)
+		if closeErr := logFile.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "[%s] log close: %v\n", slug, closeErr)
+		}
 
 		if runErr != nil {
 			fmt.Fprintf(os.Stderr, "[%s] agent exited: %v, restarting in 5s\n", slug, runErr)

--- a/internal/team/openclaw.go
+++ b/internal/team/openclaw.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/openclaw"
 )

--- a/internal/team/openclaw_e2e_test.go
+++ b/internal/team/openclaw_e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
+
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/openclaw"
 )

--- a/internal/team/openclaw_test.go
+++ b/internal/team/openclaw_test.go
@@ -13,19 +13,19 @@ import (
 )
 
 type fakeOCClient struct {
-	mu             sync.Mutex
-	sentKeys       []string
-	subscribed     []string
-	unsubscribed   []string
-	createdAgents  []string // agentID values passed to SessionsCreate
-	createdLabels  []string
-	createNextKey  string // key returned by the next SessionsCreate call; auto-incremented if empty
-	createCounter  int
-	createErr      error
-	events         chan openclaw.ClientEvent
-	sendErr        error
-	nextSendErrs   []error // drained FIFO if non-empty
-	closed         bool
+	mu            sync.Mutex
+	sentKeys      []string
+	subscribed    []string
+	unsubscribed  []string
+	createdAgents []string // agentID values passed to SessionsCreate
+	createdLabels []string
+	createNextKey string // key returned by the next SessionsCreate call; auto-incremented if empty
+	createCounter int
+	createErr     error
+	events        chan openclaw.ClientEvent
+	sendErr       error
+	nextSendErrs  []error // drained FIFO if non-empty
+	closed        bool
 }
 
 func newFakeOC() *fakeOCClient {

--- a/internal/team/operation_bootstrap.go
+++ b/internal/team/operation_bootstrap.go
@@ -11,11 +11,12 @@ import (
 	"sort"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/operations"
-	"gopkg.in/yaml.v3"
 )
 
 type operationCompanyProfile struct {
@@ -366,7 +367,7 @@ func (b *Broker) handleOperationBootstrapPackage(w http.ResponseWriter, r *http.
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{"package": pkg})
+	_ = json.NewEncoder(w).Encode(map[string]any{"package": pkg})
 }
 
 func loadOperationChannelPackFiles(rootDir string) ([]operationPackFile, error) {
@@ -1127,7 +1128,7 @@ func buildOperationAutomation(blueprint operations.Blueprint, providerName strin
 	if providerName != "" {
 		connectionMode = "Live-capable"
 		connectionStatus = "build_now"
-		connectionFooter = fmt.Sprintf("Connected systems are inspected via %s; keep mutating actions behind approval.", strings.Title(providerName))
+		connectionFooter = fmt.Sprintf("Connected systems are inspected via %s; keep mutating actions behind approval.", titleCaser.String(providerName))
 	}
 	replacements := map[string]string{
 		"connection_mode":     connectionMode,
@@ -1465,7 +1466,7 @@ func operationRuntimeIntegrationsFromConnections(runtimeConnections []action.Con
 		}
 		seen[key] = struct{}{}
 		integrations = append(integrations, operations.RuntimeIntegration{
-			Name:        operationFirstNonEmpty(strings.TrimSpace(conn.Name), strings.Title(integration)),
+			Name:        operationFirstNonEmpty(strings.TrimSpace(conn.Name), titleCaser.String(integration)),
 			Provider:    integration,
 			Status:      strings.TrimSpace(conn.State),
 			Purpose:     fmt.Sprintf("Connected %s account available for workflow planning.", integration),
@@ -1485,7 +1486,7 @@ func operationRuntimeCapabilitiesFromConnections(runtimeConnections []action.Con
 	if providerName != "" {
 		capabilities = append(capabilities, operations.RuntimeCapability{
 			Key:       operationSlug(providerName + "-connections"),
-			Name:      strings.Title(strings.TrimSpace(providerName)) + " connections",
+			Name:      titleCaser.String(strings.TrimSpace(providerName)) + " connections",
 			Category:  "integration",
 			Lifecycle: "active",
 			Detail:    "Discover connected accounts and map them into workflows.",
@@ -1498,7 +1499,7 @@ func operationRuntimeCapabilitiesFromConnections(runtimeConnections []action.Con
 		}
 		capabilities = append(capabilities, operations.RuntimeCapability{
 			Key:       operationSlug(integration),
-			Name:      strings.Title(integration),
+			Name:      titleCaser.String(integration),
 			Category:  "integration",
 			Lifecycle: strings.TrimSpace(conn.State),
 			Detail:    fmt.Sprintf("Use the connected %s account when the workflow needs it.", integration),

--- a/internal/team/policy.go
+++ b/internal/team/policy.go
@@ -27,8 +27,8 @@ type officeSignal struct {
 // or command) or "auto_detected" (inferred from a recurring working pattern).
 type officePolicy struct {
 	ID        string `json:"id"`
-	Source    string `json:"source"`   // "human_directed" | "auto_detected"
-	Rule      string `json:"rule"`     // plain-English description of the rule
+	Source    string `json:"source"` // "human_directed" | "auto_detected"
+	Rule      string `json:"rule"`   // plain-English description of the rule
 	Active    bool   `json:"active"`
 	CreatedAt string `json:"created_at"`
 }

--- a/internal/team/scoped_memory.go
+++ b/internal/team/scoped_memory.go
@@ -82,14 +82,7 @@ func decodePrivateMemoryNote(key string, raw string) privateMemoryNote {
 }
 
 func brokerEntryFromNote(note privateMemoryNote) brokerMemoryEntry {
-	return brokerMemoryEntry{
-		Key:       note.Key,
-		Title:     note.Title,
-		Content:   note.Content,
-		Author:    note.Author,
-		CreatedAt: note.CreatedAt,
-		UpdatedAt: note.UpdatedAt,
-	}
+	return brokerMemoryEntry(note)
 }
 
 func searchPrivateMemory(entries map[string]string, query string, limit int) []privateMemoryNote {

--- a/internal/team/session_memory.go
+++ b/internal/team/session_memory.go
@@ -50,9 +50,7 @@ func buildSessionRecovery(sessionMode, directAgent string, tasks []RuntimeTask, 
 		}
 	}
 
-	for _, msg := range recentHighlights(recent) {
-		recovery.Highlights = append(recovery.Highlights, msg)
-	}
+	recovery.Highlights = append(recovery.Highlights, recentHighlights(recent)...)
 
 	return recovery
 }

--- a/internal/team/session_mode_test.go
+++ b/internal/team/session_mode_test.go
@@ -4,17 +4,17 @@ import "testing"
 
 func TestNormalizeSessionMode(t *testing.T) {
 	cases := map[string]string{
-		"1o1":         SessionModeOneOnOne,
-		"1:1":         SessionModeOneOnOne,
-		"one-on-one":  SessionModeOneOnOne,
-		"one_on_one":  SessionModeOneOnOne,
-		"1on1":        SessionModeOneOnOne,
-		"solo":        SessionModeOneOnOne,
-		"  1:1  ":     SessionModeOneOnOne,
-		"1:1 ":        SessionModeOneOnOne,
-		"office":      SessionModeOffice,
-		"":            SessionModeOffice,
-		"nonsense":    SessionModeOffice,
+		"1o1":        SessionModeOneOnOne,
+		"1:1":        SessionModeOneOnOne,
+		"one-on-one": SessionModeOneOnOne,
+		"one_on_one": SessionModeOneOnOne,
+		"1on1":       SessionModeOneOnOne,
+		"solo":       SessionModeOneOnOne,
+		"  1:1  ":    SessionModeOneOnOne,
+		"1:1 ":       SessionModeOneOnOne,
+		"office":     SessionModeOffice,
+		"":           SessionModeOffice,
+		"nonsense":   SessionModeOffice,
 	}
 	for in, want := range cases {
 		if got := NormalizeSessionMode(in); got != want {

--- a/internal/team/telegram.go
+++ b/internal/team/telegram.go
@@ -13,22 +13,22 @@ import (
 )
 
 const (
-	telegramAPIBase    = "https://api.telegram.org"
+	telegramAPIBase     = "https://api.telegram.org"
 	telegramPollTimeout = 30 // seconds for long-poll
 )
 
 // telegramUpdate represents a single update from the Telegram Bot API.
 type telegramUpdate struct {
-	UpdateID int64           `json:"update_id"`
-	Message  *telegramMsg    `json:"message,omitempty"`
+	UpdateID int64        `json:"update_id"`
+	Message  *telegramMsg `json:"message,omitempty"`
 }
 
 type telegramMsg struct {
-	MessageID int64          `json:"message_id"`
-	Chat      telegramChat   `json:"chat"`
-	From      *telegramUser  `json:"from,omitempty"`
-	Text      string         `json:"text"`
-	Date      int64          `json:"date"`
+	MessageID int64         `json:"message_id"`
+	Chat      telegramChat  `json:"chat"`
+	From      *telegramUser `json:"from,omitempty"`
+	Text      string        `json:"text"`
+	Date      int64         `json:"date"`
 }
 
 type telegramChat struct {
@@ -45,9 +45,9 @@ type telegramUser struct {
 }
 
 type telegramAPIResponse struct {
-	OK     bool              `json:"ok"`
-	Result json.RawMessage   `json:"result,omitempty"`
-	Desc   string            `json:"description,omitempty"`
+	OK     bool            `json:"ok"`
+	Result json.RawMessage `json:"result,omitempty"`
+	Desc   string          `json:"description,omitempty"`
 }
 
 // TelegramTransport bridges Telegram chats with the office broker.
@@ -55,17 +55,17 @@ type telegramAPIResponse struct {
 // "telegram" surface. Inbound Telegram messages are posted to the broker;
 // outbound broker messages on surface channels are sent to Telegram.
 type TelegramTransport struct {
-	BotToken  string
-	Broker    *Broker
+	BotToken string
+	Broker   *Broker
 	// ChatMap maps telegram chat_id (as string) -> office channel slug
-	ChatMap   map[string]string
+	ChatMap map[string]string
 	// DMChannel is the office channel slug for direct messages (private chats).
 	// When set, any private message to the bot routes to this channel.
 	DMChannel string
 	// UserMap maps telegram username (lowercase) -> office member slug.
 	// If empty, display names are used verbatim as the "from" field.
-	UserMap   map[string]string
-	client    *http.Client
+	UserMap map[string]string
+	client  *http.Client
 }
 
 // NewTelegramTransport creates a transport from the broker's surface channels.

--- a/internal/team/title.go
+++ b/internal/team/title.go
@@ -1,0 +1,9 @@
+package team
+
+import (
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// titleCaser replaces strings.Title (deprecated) for English-tagged title casing.
+var titleCaser = cases.Title(language.English)

--- a/internal/teammcp/actions.go
+++ b/internal/teammcp/actions.go
@@ -9,13 +9,18 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/calendar"
 	"github.com/nex-crm/wuphf/internal/team"
 )
 
-var externalActionProvider action.Provider
+var (
+	externalActionProvider action.Provider
+	titleCaser             = cases.Title(language.English)
+)
 
 type TeamActionGuideArgs struct {
 	Topic string `json:"topic,omitempty" jsonschema:"One of: overview, actions, flows, relay, all. Defaults to all."`
@@ -265,14 +270,14 @@ func handleTeamActionExecute(ctx context.Context, _ *mcp.CallToolRequest, args T
 		DryRun:          args.DryRun,
 	})
 	if err != nil {
-		_ = brokerRecordAction(ctx, "external_action_failed", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("%s action %s on %s failed", strings.Title(provider.Name()), args.ActionID, args.Platform)), args.ActionID)
+		_ = brokerRecordAction(ctx, "external_action_failed", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("%s action %s on %s failed", titleCaser.String(provider.Name()), args.ActionID, args.Platform)), args.ActionID)
 		return toolError(err), nil, nil
 	}
 	kind := "external_action_executed"
-	summary := fallbackSummary(args.Summary, fmt.Sprintf("Executed %s on %s via %s", args.ActionID, args.Platform, strings.Title(provider.Name())))
+	summary := fallbackSummary(args.Summary, fmt.Sprintf("Executed %s on %s via %s", args.ActionID, args.Platform, titleCaser.String(provider.Name())))
 	if args.DryRun {
 		kind = "external_action_planned"
-		summary = fallbackSummary(args.Summary, fmt.Sprintf("Planned %s on %s via %s", args.ActionID, args.Platform, strings.Title(provider.Name())))
+		summary = fallbackSummary(args.Summary, fmt.Sprintf("Planned %s on %s via %s", args.ActionID, args.Platform, titleCaser.String(provider.Name())))
 	}
 	_ = brokerRecordAction(ctx, kind, provider.Name(), channel, slug, summary, args.ActionID)
 	return textResult(prettyObject(result)), nil, nil
@@ -297,7 +302,7 @@ func handleTeamActionWorkflowCreate(ctx context.Context, _ *mcp.CallToolRequest,
 		Definition: definition,
 	})
 	if err != nil {
-		_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Creating workflow %s via %s failed", args.Key, strings.Title(provider.Name()))), args.Key)
+		_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Creating workflow %s via %s failed", args.Key, titleCaser.String(provider.Name()))), args.Key)
 		return toolError(err), nil, nil
 	}
 	if strings.TrimSpace(result.Key) == "" {
@@ -306,7 +311,7 @@ func handleTeamActionWorkflowCreate(ctx context.Context, _ *mcp.CallToolRequest,
 	if err := upsertWorkflowSkill(ctx, workflowSkillSpec{
 		Name:             fallbackString(args.SkillName, result.Key),
 		Title:            fallbackString(args.SkillTitle, humanizeWorkflowKey(result.Key)),
-		Description:      fallbackString(args.SkillDescription, fmt.Sprintf("Reusable %s workflow for %s.", strings.Title(provider.Name()), humanizeWorkflowKey(result.Key))),
+		Description:      fallbackString(args.SkillDescription, fmt.Sprintf("Reusable %s workflow for %s.", titleCaser.String(provider.Name()), humanizeWorkflowKey(result.Key))),
 		Tags:             append([]string{provider.Name(), "workflow"}, args.SkillTags...),
 		Trigger:          strings.TrimSpace(args.SkillTrigger),
 		WorkflowProvider: provider.Name(),
@@ -315,10 +320,10 @@ func handleTeamActionWorkflowCreate(ctx context.Context, _ *mcp.CallToolRequest,
 		Channel:          channel,
 		CreatedBy:        slug,
 	}); err != nil {
-		_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fmt.Sprintf("Created workflow %s via %s, but failed to mirror it into Skills", result.Key, strings.Title(provider.Name())), result.Key)
+		_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fmt.Sprintf("Created workflow %s via %s, but failed to mirror it into Skills", result.Key, titleCaser.String(provider.Name())), result.Key)
 		return toolError(err), nil, nil
 	}
-	_ = brokerRecordAction(ctx, "external_workflow_created", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Created workflow %s via %s", result.Key, strings.Title(provider.Name()))), result.Key)
+	_ = brokerRecordAction(ctx, "external_workflow_created", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Created workflow %s via %s", result.Key, titleCaser.String(provider.Name()))), result.Key)
 	return textResult(prettyObject(result)), nil, nil
 }
 
@@ -341,14 +346,14 @@ func handleTeamActionWorkflowExecute(ctx context.Context, _ *mcp.CallToolRequest
 		AllowBash: args.AllowBash,
 	})
 	if err != nil {
-		_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Workflow %s via %s failed", args.KeyOrPath, strings.Title(provider.Name()))), args.KeyOrPath)
+		_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Workflow %s via %s failed", args.KeyOrPath, titleCaser.String(provider.Name()))), args.KeyOrPath)
 		return toolError(err), nil, nil
 	}
 	kind := "external_workflow_executed"
-	summary := fallbackSummary(args.Summary, fmt.Sprintf("Executed workflow %s via %s", args.KeyOrPath, strings.Title(provider.Name())))
+	summary := fallbackSummary(args.Summary, fmt.Sprintf("Executed workflow %s via %s", args.KeyOrPath, titleCaser.String(provider.Name())))
 	if args.DryRun {
 		kind = "external_workflow_planned"
-		summary = fallbackSummary(args.Summary, fmt.Sprintf("Planned workflow %s via %s", args.KeyOrPath, strings.Title(provider.Name())))
+		summary = fallbackSummary(args.Summary, fmt.Sprintf("Planned workflow %s via %s", args.KeyOrPath, titleCaser.String(provider.Name())))
 	}
 	_ = brokerRecordAction(ctx, kind, provider.Name(), channel, slug, summary, args.KeyOrPath)
 	_ = touchWorkflowSkill(ctx, args.KeyOrPath, result.Status, time.Now().UTC())
@@ -405,7 +410,7 @@ func handleTeamActionWorkflowSchedule(ctx context.Context, _ *mcp.CallToolReques
 		"payload":       string(payload),
 	}
 	if err := brokerPostJSON(ctx, "/scheduler", job, nil); err != nil {
-		_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fmt.Sprintf("Failed to schedule workflow %s via %s", args.Key, strings.Title(provider.Name())), args.Key)
+		_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fmt.Sprintf("Failed to schedule workflow %s via %s", args.Key, titleCaser.String(provider.Name())), args.Key)
 		return toolError(err), nil, nil
 	}
 	skillName := strings.TrimSpace(args.SkillName)
@@ -415,7 +420,7 @@ func handleTeamActionWorkflowSchedule(ctx context.Context, _ *mcp.CallToolReques
 	_ = upsertWorkflowSkill(ctx, workflowSkillSpec{
 		Name:             skillName,
 		Title:            fallbackString(args.SkillTitle, humanizeWorkflowKey(args.Key)),
-		Description:      fmt.Sprintf("Reusable %s workflow for %s.", strings.Title(provider.Name()), humanizeWorkflowKey(args.Key)),
+		Description:      fmt.Sprintf("Reusable %s workflow for %s.", titleCaser.String(provider.Name()), humanizeWorkflowKey(args.Key)),
 		Tags:             []string{provider.Name(), "workflow", "scheduled"},
 		WorkflowProvider: provider.Name(),
 		WorkflowKey:      strings.TrimSpace(args.Key),
@@ -423,7 +428,7 @@ func handleTeamActionWorkflowSchedule(ctx context.Context, _ *mcp.CallToolReques
 		Channel:          channel,
 		CreatedBy:        slug,
 	})
-	_ = brokerRecordAction(ctx, "external_workflow_scheduled", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Scheduled workflow %s via %s (%s)", args.Key, strings.Title(provider.Name()), args.Schedule)), args.Key)
+	_ = brokerRecordAction(ctx, "external_workflow_scheduled", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Scheduled workflow %s via %s (%s)", args.Key, titleCaser.String(provider.Name()), args.Schedule)), args.Key)
 	result := map[string]any{
 		"ok":           true,
 		"workflow_key": strings.TrimSpace(args.Key),
@@ -437,14 +442,14 @@ func handleTeamActionWorkflowSchedule(ctx context.Context, _ *mcp.CallToolReques
 			Inputs:    args.Inputs,
 		})
 		if execErr != nil {
-			_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fmt.Sprintf("Scheduled workflow %s via %s, but the immediate run failed", args.Key, strings.Title(provider.Name())), args.Key)
+			_ = brokerRecordAction(ctx, "external_workflow_failed", provider.Name(), channel, slug, fmt.Sprintf("Scheduled workflow %s via %s, but the immediate run failed", args.Key, titleCaser.String(provider.Name())), args.Key)
 			result["run_now"] = map[string]any{
 				"ok":    false,
 				"error": execErr.Error(),
 			}
 			return textResult(prettyObject(result)), nil, nil
 		}
-		_ = brokerRecordAction(ctx, "external_workflow_executed", provider.Name(), channel, slug, fmt.Sprintf("Scheduled workflow %s via %s and ran it once immediately", args.Key, strings.Title(provider.Name())), args.Key)
+		_ = brokerRecordAction(ctx, "external_workflow_executed", provider.Name(), channel, slug, fmt.Sprintf("Scheduled workflow %s via %s and ran it once immediately", args.Key, titleCaser.String(provider.Name())), args.Key)
 		_ = touchWorkflowSkill(ctx, args.Key, runResult.Status, time.Now().UTC())
 		result["run_now"] = map[string]any{
 			"ok":     true,
@@ -496,10 +501,10 @@ func handleTeamActionRelayCreate(ctx context.Context, _ *mcp.CallToolRequest, ar
 		CreateWebhook: args.CreateWebhook,
 	})
 	if err != nil {
-		_ = brokerRecordAction(ctx, "external_trigger_failed", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Creating trigger for %s via %s failed", args.ConnectionKey, strings.Title(provider.Name()))), args.ConnectionKey)
+		_ = brokerRecordAction(ctx, "external_trigger_failed", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Creating trigger for %s via %s failed", args.ConnectionKey, titleCaser.String(provider.Name()))), args.ConnectionKey)
 		return toolError(err), nil, nil
 	}
-	_ = brokerRecordAction(ctx, "external_trigger_registered", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Created trigger %s via %s", result.ID, strings.Title(provider.Name()))), result.ID)
+	_ = brokerRecordAction(ctx, "external_trigger_registered", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Created trigger %s via %s", result.ID, titleCaser.String(provider.Name()))), result.ID)
 	return textResult(prettyObject(result)), nil, nil
 }
 
@@ -523,10 +528,10 @@ func handleTeamActionRelayActivate(ctx context.Context, _ *mcp.CallToolRequest, 
 		WebhookSecret: args.WebhookSecret,
 	})
 	if err != nil {
-		_ = brokerRecordAction(ctx, "external_trigger_failed", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Activating trigger %s via %s failed", args.ID, strings.Title(provider.Name()))), args.ID)
+		_ = brokerRecordAction(ctx, "external_trigger_failed", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Activating trigger %s via %s failed", args.ID, titleCaser.String(provider.Name()))), args.ID)
 		return toolError(err), nil, nil
 	}
-	_ = brokerRecordAction(ctx, "external_trigger_registered", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Activated trigger %s via %s", result.ID, strings.Title(provider.Name()))), result.ID)
+	_ = brokerRecordAction(ctx, "external_trigger_registered", provider.Name(), channel, slug, fallbackSummary(args.Summary, fmt.Sprintf("Activated trigger %s via %s", result.ID, titleCaser.String(provider.Name()))), result.ID)
 	return textResult(prettyObject(result)), nil, nil
 }
 
@@ -641,7 +646,7 @@ func touchWorkflowSkill(ctx context.Context, workflowKey, status string, when ti
 }
 
 func workflowSkillContent(spec workflowSkillSpec) string {
-	label := strings.Title(fallbackString(spec.WorkflowProvider, "workflow"))
+	label := titleCaser.String(fallbackString(spec.WorkflowProvider, "workflow"))
 	lines := []string{
 		fmt.Sprintf("WUPHF workflow skill (%s): %s", label, humanizeWorkflowKey(fallbackString(spec.WorkflowKey, spec.Name))),
 		"Use team_action_workflow_execute to run it through WUPHF.",
@@ -679,7 +684,7 @@ func humanizeWorkflowKey(key string) string {
 		return r == '-' || r == '_' || r == ':'
 	})
 	for i := range parts {
-		parts[i] = strings.Title(parts[i])
+		parts[i] = titleCaser.String(parts[i])
 	}
 	return strings.Join(parts, " ")
 }

--- a/internal/teammcp/actions_test.go
+++ b/internal/teammcp/actions_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/team"
 )

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -360,8 +360,8 @@ type TeamMemberArgs struct {
 	// install-wide default runtime. Set Provider to pick a specific runtime and
 	// (optionally) model for this agent: one team can mix Claude, Codex, and
 	// OpenClaw agents, each on its own provider.
-	Provider         string `json:"provider,omitempty" jsonschema:"LLM runtime for this agent. One of: claude-code, codex, openclaw. Empty = install default."`
-	Model            string `json:"model,omitempty" jsonschema:"Model name passed to the runtime (e.g. claude-sonnet-4.6, gpt-5.4, openai-codex/gpt-5.4). Free-form; runtime validates."`
+	Provider           string `json:"provider,omitempty" jsonschema:"LLM runtime for this agent. One of: claude-code, codex, openclaw. Empty = install default."`
+	Model              string `json:"model,omitempty" jsonschema:"Model name passed to the runtime (e.g. claude-sonnet-4.6, gpt-5.4, openai-codex/gpt-5.4). Free-form; runtime validates."`
 	OpenclawSessionKey string `json:"openclaw_session_key,omitempty" jsonschema:"Optional: attach to an existing OpenClaw session key (e.g. after WUPHF reinstall). Leave empty to auto-create a new session."`
 	OpenclawAgentID    string `json:"openclaw_agent_id,omitempty" jsonschema:"Optional: OpenClaw agent config name (defaults to 'main')."`
 	MySlug             string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG."`
@@ -2092,7 +2092,7 @@ func handleTeamChannel(ctx context.Context, _ *mcp.CallToolRequest, args TeamCha
 	if err := reconfigureOfficeSessionFn(); err != nil {
 		return toolError(err), nil, nil
 	}
-	return textResult(fmt.Sprintf("%s channel #%s", strings.Title(strings.TrimSpace(args.Action)), channel)), nil, nil
+	return textResult(fmt.Sprintf("%s channel #%s", titleCaser.String(strings.TrimSpace(args.Action)), channel)), nil, nil
 }
 
 func handleTeamChannelMember(ctx context.Context, _ *mcp.CallToolRequest, args TeamChannelMemberArgs) (*mcp.CallToolResult, any, error) {
@@ -2115,7 +2115,7 @@ func handleTeamChannelMember(ctx context.Context, _ *mcp.CallToolRequest, args T
 	if err := reconfigureOfficeSessionFn(); err != nil {
 		return toolError(err), nil, nil
 	}
-	return textResult(fmt.Sprintf("%s @%s in #%s", strings.Title(strings.TrimSpace(args.Action)), member, channel)), nil, nil
+	return textResult(fmt.Sprintf("%s @%s in #%s", titleCaser.String(strings.TrimSpace(args.Action)), member, channel)), nil, nil
 }
 
 func handleTeamBridge(ctx context.Context, _ *mcp.CallToolRequest, args TeamBridgeArgs) (*mcp.CallToolResult, any, error) {

--- a/internal/teammcp/server_test.go
+++ b/internal/teammcp/server_test.go
@@ -6,15 +6,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"slices"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+
 	"github.com/nex-crm/wuphf/internal/team"
 )
 

--- a/internal/teammcp/skills.go
+++ b/internal/teammcp/skills.go
@@ -57,14 +57,14 @@ func handleTeamSkillRun(ctx context.Context, _ *mcp.CallToolRequest, args TeamSk
 	}
 
 	payload := map[string]any{
-		"ok":          true,
-		"skill_name":  resp.Skill.Name,
-		"title":       resp.Skill.Title,
-		"description": resp.Skill.Description,
-		"trigger":     resp.Skill.Trigger,
-		"usage_count": resp.Skill.UsageCount,
-		"channel":     resp.Skill.Channel,
-		"content":     resp.Skill.Content,
+		"ok":           true,
+		"skill_name":   resp.Skill.Name,
+		"title":        resp.Skill.Title,
+		"description":  resp.Skill.Description,
+		"trigger":      resp.Skill.Trigger,
+		"usage_count":  resp.Skill.UsageCount,
+		"channel":      resp.Skill.Channel,
+		"content":      resp.Skill.Content,
 		"instructions": "Follow the steps in `content` exactly. Do NOT freelance — this skill is the canonical playbook for this request.",
 	}
 	return textResult(prettyObject(payload)), nil, nil

--- a/internal/tui/init_flow.go
+++ b/internal/tui/init_flow.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -249,7 +250,7 @@ func (f InitFlowModel) submitTextInput(value string) (InitFlowModel, tea.Cmd) {
 		}
 		// Shell out to nex-cli register synchronously. The TUI will block
 		// briefly (nex-cli should be fast), then proceed.
-		_, err := nex.Register(nil, value)
+		_, err := nex.Register(context.Background(), value)
 		if err != nil {
 			f.keyError = "Registration failed: " + err.Error()
 			return f, nil

--- a/internal/tui/keybindings_test.go
+++ b/internal/tui/keybindings_test.go
@@ -181,8 +181,8 @@ func TestDoublePress_SecondPressWithinWindowReturnsTrue(t *testing.T) {
 
 func TestDoublePress_ResetsAfterDoublePress(t *testing.T) {
 	dp := NewDoublePress(time.Second)
-	dp.Press()  // first
-	dp.Press()  // second (detected double)
+	dp.Press() // first
+	dp.Press() // second (detected double)
 	if dp.Press() {
 		t.Error("press after reset should return false (first of new sequence)")
 	}

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -117,8 +117,7 @@ func (p PickerModel) updateTextInput(msg tea.KeyMsg) (PickerModel, tea.Cmd) {
 		if msg.Type == tea.KeyRunes {
 			p.textBuf = append(p.textBuf, msg.Runes...)
 		} else {
-			runes := []rune(msg.String())
-			for _, r := range runes {
+			for _, r := range msg.String() {
 				if r >= 32 {
 					p.textBuf = append(p.textBuf, r)
 				}

--- a/internal/tui/render/graph.go
+++ b/internal/tui/render/graph.go
@@ -23,16 +23,16 @@ type GraphEdge struct {
 // nodeIcon returns the emoji icon for a given node type.
 func nodeIcon(nodeType string) string {
 	icons := map[string]string{
-		"person":  "\U0001F464", // 👤
-		"company": "\U0001F3E2", // 🏢
-		"deal":    "\U0001F4B0", // 💰
-		"task":    "\u2611",     // ☑
-		"note":    "\U0001F4DD", // 📝
-		"email":   "\u2709",     // ✉
-		"event":   "\U0001F4C5", // 📅
-		"product": "\U0001F4E6", // 📦
-		"project": "\U0001F4CB", // 📋
-		"ticket":  "\U0001F3AB", // 🎫
+		"person":   "\U0001F464", // 👤
+		"company":  "\U0001F3E2", // 🏢
+		"deal":     "\U0001F4B0", // 💰
+		"task":     "\u2611",     // ☑
+		"note":     "\U0001F4DD", // 📝
+		"email":    "\u2709",     // ✉
+		"event":    "\U0001F4C5", // 📅
+		"product":  "\U0001F4E6", // 📦
+		"project":  "\U0001F4CB", // 📋
+		"ticket":   "\U0001F3AB", // 🎫
 		"location": "\U0001F4CD", // 📍
 	}
 	if icon, ok := icons[nodeType]; ok {

--- a/internal/workspace/handlers.go
+++ b/internal/workspace/handlers.go
@@ -44,10 +44,10 @@ func writeResult(w http.ResponseWriter, res Result, err error, redirect string) 
 		return
 	}
 	_ = json.NewEncoder(w).Encode(map[string]any{
-		"ok":                true,
-		"restart_required":  true,
-		"redirect":          redirect,
-		"removed":           res.Removed,
-		"errors":            res.Errors,
+		"ok":               true,
+		"restart_required": true,
+		"redirect":         redirect,
+		"removed":          res.Removed,
+		"errors":           res.Errors,
 	})
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -13,20 +13,20 @@ func seedWorkspace(t *testing.T, dir string) map[string]string {
 	t.Helper()
 	base := filepath.Join(dir, ".wuphf")
 	paths := map[string]string{
-		"onboarded":    filepath.Join(base, "onboarded.json"),
-		"company":      filepath.Join(base, "company.json"),
-		"brokerState":  filepath.Join(base, "team", "broker-state.json"),
-		"officePID":    filepath.Join(base, "team", "office.pid"),
-		"officeTasks":  filepath.Join(base, "office", "tasks", "t-1.json"),
-		"workflow":     filepath.Join(base, "workflows", "wf-1.json"),
-		"logs":         filepath.Join(base, "logs", "channel-stderr.log"),
-		"session":      filepath.Join(base, "sessions", "s-1.json"),
-		"worktree":     filepath.Join(base, "task-worktrees", "wt-1", "file"),
-		"codex":        filepath.Join(base, "codex-headless", "cache"),
-		"providers":    filepath.Join(base, "providers", "claude-sessions.json"),
-		"openclaw":     filepath.Join(base, "openclaw", "identity.json"),
-		"config":       filepath.Join(base, "config.json"),
-		"calendar":     filepath.Join(base, "calendar.json"),
+		"onboarded":   filepath.Join(base, "onboarded.json"),
+		"company":     filepath.Join(base, "company.json"),
+		"brokerState": filepath.Join(base, "team", "broker-state.json"),
+		"officePID":   filepath.Join(base, "team", "office.pid"),
+		"officeTasks": filepath.Join(base, "office", "tasks", "t-1.json"),
+		"workflow":    filepath.Join(base, "workflows", "wf-1.json"),
+		"logs":        filepath.Join(base, "logs", "channel-stderr.log"),
+		"session":     filepath.Join(base, "sessions", "s-1.json"),
+		"worktree":    filepath.Join(base, "task-worktrees", "wt-1", "file"),
+		"codex":       filepath.Join(base, "codex-headless", "cache"),
+		"providers":   filepath.Join(base, "providers", "claude-sessions.json"),
+		"openclaw":    filepath.Join(base, "openclaw", "identity.json"),
+		"config":      filepath.Join(base, "config.json"),
+		"calendar":    filepath.Join(base, "calendar.json"),
 	}
 	for _, p := range paths {
 		if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,55 @@
+pre-commit:
+  parallel: true
+  commands:
+    gofmt:
+      glob: "*.go"
+      run: |
+        unformatted=$(gofmt -l {staged_files})
+        if [ -n "$unformatted" ]; then
+          echo "gofmt needs to be run on:"
+          echo "$unformatted"
+          echo "Run: gofmt -w <file>"
+          exit 1
+        fi
+
+    go-vet:
+      glob: "*.go"
+      run: go vet ./...
+
+    golangci-lint:
+      glob: "*.go"
+      run: golangci-lint run ./...
+
+    no-secrets:
+      run: >
+        git diff --cached --diff-filter=ACM -U0
+        | grep -iE '(api_token|password|api_key|secret)\s*=\s*[''"][^''"]+[''"]'
+        | grep -v '.example\|.fake\|fake_\|placeholder\|your_\|os.Getenv\|environ.get'
+        && echo 'Possible secret in staged changes' && exit 1
+        || true
+
+    check-merge-conflicts:
+      glob: "*.{go,yml,yaml,md,toml,json}"
+      run: grep -lE '^(<{7}|>{7}|={7})' {staged_files} && echo "Merge conflict markers found" && exit 1 || true
+
+    no-large-files:
+      run: >
+        find {staged_files} -size +500k 2>/dev/null
+        | head -1 | grep .
+        && echo 'File too large (>500KB)' && exit 1
+        || true
+
+pre-push:
+  parallel: true
+  commands:
+    test:
+      run: go test ./...
+    build:
+      run: go build -o /dev/null ./cmd/wuphf
+    vhs:
+      run: |
+        if ! command -v vhs >/dev/null 2>&1; then
+          echo "vhs not installed — skipping visual regression check (install: brew install vhs)"
+          exit 0
+        fi
+        testdata/vhs/check.sh

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,17 +28,25 @@ case "$ARCH" in
     ;;
 esac
 
-# Resolve latest version tag from GitHub redirect
-VERSION="$(curl -sSL -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest" | rev | cut -d'/' -f1 | rev)"
-if [ -z "$VERSION" ]; then
-  printf "Error: could not determine latest version\n" >&2
-  exit 1
-fi
+# WUPHF_INSTALL_URL_OVERRIDE bypasses GitHub release resolution so CI can run
+# this script end-to-end against a snapshot tarball without a real release.
+URL="${WUPHF_INSTALL_URL_OVERRIDE:-}"
+if [ -n "$URL" ]; then
+  VERSION="${WUPHF_INSTALL_VERSION_OVERRIDE:-snapshot}"
+  ARCHIVE="$(basename "$URL")"
+else
+  # Resolve latest version tag from GitHub redirect
+  VERSION="$(curl -sSL -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest" | rev | cut -d'/' -f1 | rev)"
+  if [ -z "$VERSION" ]; then
+    printf "Error: could not determine latest version\n" >&2
+    exit 1
+  fi
 
-# goreleaser strips the leading 'v' from the tag in archive names
-VERSION_CLEAN="${VERSION#v}"
-ARCHIVE="${BINARY}_${VERSION_CLEAN}_${OS}_${ARCH}.tar.gz"
-URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
+  # goreleaser strips the leading 'v' from the tag in archive names
+  VERSION_CLEAN="${VERSION#v}"
+  ARCHIVE="${BINARY}_${VERSION_CLEAN}_${OS}_${ARCH}.tar.gz"
+  URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
+fi
 
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,15 +28,21 @@ case "$ARCH" in
     ;;
 esac
 
-# WUPHF_INSTALL_URL_OVERRIDE bypasses GitHub release resolution so CI can run
-# this script end-to-end against a snapshot tarball without a real release.
+# Two CI hooks, in order of how much of the install path they exercise:
+#   WUPHF_INSTALL_URL_OVERRIDE   — skip resolution; download a specific tarball.
+#                                  Cheap sanity check against a snapshot build.
+#   WUPHF_INSTALL_REPO_BASE_URL  — override the GitHub base URL only. Still
+#                                  runs the redirect-parsing + archive-name
+#                                  construction that shipped broken in v0.8.1.
+# Prefer the second in CI so the path that actually regressed stays covered.
+REPO_BASE_URL="${WUPHF_INSTALL_REPO_BASE_URL:-https://github.com/${REPO}}"
 URL="${WUPHF_INSTALL_URL_OVERRIDE:-}"
 if [ -n "$URL" ]; then
   VERSION="${WUPHF_INSTALL_VERSION_OVERRIDE:-snapshot}"
   ARCHIVE="$(basename "$URL")"
 else
   # Resolve latest version tag from GitHub redirect
-  VERSION="$(curl -sSL -o /dev/null -w '%{url_effective}' "https://github.com/${REPO}/releases/latest" | rev | cut -d'/' -f1 | rev)"
+  VERSION="$(curl -sSL -o /dev/null -w '%{url_effective}' "${REPO_BASE_URL}/releases/latest" | rev | cut -d'/' -f1 | rev)"
   if [ -z "$VERSION" ]; then
     printf "Error: could not determine latest version\n" >&2
     exit 1
@@ -45,7 +51,7 @@ else
   # goreleaser strips the leading 'v' from the tag in archive names
   VERSION_CLEAN="${VERSION#v}"
   ARCHIVE="${BINARY}_${VERSION_CLEAN}_${OS}_${ARCH}.tar.gz"
-  URL="https://github.com/${REPO}/releases/download/${VERSION}/${ARCHIVE}"
+  URL="${REPO_BASE_URL}/releases/download/${VERSION}/${ARCHIVE}"
 fi
 
 TMPDIR="$(mktemp -d)"

--- a/testdata/vhs/check.sh
+++ b/testdata/vhs/check.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Visual regression check for wuphf.
+#
+# Re-runs each VHS tape and fails if the generated .txt golden drifts from
+# the committed one. Pre-commit friendly — leaves the committed golden
+# untouched on drift, and saves the new render next to it as
+# <name>.txt.actual for inspection.
+#
+# Tapes covered:
+#   help.tape     — `wuphf --help` output
+#   version.tape  — `wuphf --version` output
+#
+# Only `.txt` is diffed. `.gif` files are regenerated on every run and are
+# NOT tracked in git (see .gitignore). They exist only as a human-viewable
+# byproduct of the VHS recording.
+#
+# When help.txt drifts in CI:
+#   1. Download the `vhs-drift` artifact from the failing CI run.
+#   2. Inspect testdata/vhs/<name>.txt.actual vs testdata/vhs/<name>.txt.
+#   3. If the drift is intentional, replace the golden:
+#        mv testdata/vhs/<name>.txt.actual testdata/vhs/<name>.txt
+#        git add testdata/vhs/<name>.txt
+#
+# Version bumps in cmd/wuphf/buildinfo drift version.txt — update the golden
+# as part of the version-bump commit.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+TAPES=(help version)
+
+# Compile once outside the tape so VHS recording time is just exec.
+go build -o /tmp/wuphf-vhs ./cmd/wuphf
+
+# VHS captures multiple scrollback frames separated by '────' lines.
+# The PS1 prompt ('>') at the top of each scrollback frame is captured
+# nondeterministically (sometimes blank, sometimes '>'), while the
+# final rendered frame is byte-stable. Normalize by keeping only the
+# content between the last two separators — that's the visible render
+# we actually care about.
+normalize() {
+  local f="$1"
+  if ! awk '
+    NR==FNR {
+      if (/^────/) { total++; prev_sep = last_sep; last_sep = NR }
+      next
+    }
+    FNR > prev_sep && FNR < last_sep
+    END { if (total < 2) exit 1 }
+  ' "$f" "$f" > "${f}.norm"; then
+    rm -f "${f}.norm"
+    echo "normalize: $f has fewer than 2 '────' separators — VHS output malformed?" >&2
+    return 1
+  fi
+  mv "${f}.norm" "$f"
+}
+
+check_one() {
+  local name="$1"
+  local golden_txt="testdata/vhs/${name}.txt"
+  local actual_txt="testdata/vhs/${name}.txt.actual"
+
+  if [[ ! -f "$golden_txt" ]]; then
+    echo "golden missing: $golden_txt" >&2
+    return 1
+  fi
+
+  local backup_txt
+  backup_txt="$(mktemp)"
+  cp "$golden_txt" "$backup_txt"
+
+  vhs "testdata/vhs/${name}.tape" >/dev/null
+  if ! normalize "$golden_txt"; then
+    cp "$backup_txt" "$golden_txt"
+    rm -f "$backup_txt"
+    echo "wuphf visual regression: ${name} normalize failed — golden restored" >&2
+    return 1
+  fi
+
+  if ! diff -q "$backup_txt" "$golden_txt" >/dev/null; then
+    cp "$golden_txt" "$actual_txt"
+    cp "$backup_txt" "$golden_txt"
+    rm -f "$backup_txt"
+    echo "wuphf visual regression: ${name}.txt drifted" >&2
+    diff -u "$golden_txt" "$actual_txt" >&2 || true
+    echo >&2
+    echo "To accept this drift as the new baseline:" >&2
+    echo "  mv ${actual_txt} ${golden_txt} && git add ${golden_txt}" >&2
+    echo >&2
+    echo "In CI, download the 'vhs-drift' artifact to get ${actual_txt}." >&2
+    return 1
+  fi
+
+  rm -f "$backup_txt" "$actual_txt"
+  echo "wuphf visual regression: ${name} OK"
+}
+
+for tape in "${TAPES[@]}"; do
+  check_one "$tape"
+done

--- a/testdata/vhs/help.tape
+++ b/testdata/vhs/help.tape
@@ -1,0 +1,26 @@
+# Visual regression tape for `wuphf --help`.
+#
+# Build the binary first (check.sh does this), then:
+#   vhs testdata/vhs/help.tape
+#
+# Uses the --help flag which has no state or timing and should be
+# byte-stable across runs.
+
+Output testdata/vhs/help.gif
+Output testdata/vhs/help.txt
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 900
+Set TypingSpeed 0ms
+
+Hide
+Type "clear"
+Enter
+Sleep 300ms
+Type "/tmp/wuphf-vhs --help"
+Enter
+Sleep 800ms
+Show
+Sleep 500ms

--- a/testdata/vhs/help.txt
+++ b/testdata/vhs/help.txt
@@ -1,0 +1,48 @@
+> /tmp/wuphf-vhs --help
+WUPHF v0.1.0 — the terminal office Ryan Howard always wanted.
+
+Usage:
+  wuphf              Launch multi-agent team (web UI on :7891)
+  wuphf --tui        Launch with tmux TUI instead
+  wuphf init         Install the latest CLI and save setup defaults
+  wuphf shred        Burn the workspace down and reopen onboarding
+  wuphf import --from legacy  Import from a running external orchestrator (auto-detect)
+  wuphf log          Show what your agents actually did (task receipts)
+  wuphf --cmd <cmd>  Run a command non-interactively
+
+Flags:
+  --1o1
+        Launch a direct 1:1 session with a single agent (default ceo)
+  --api-key
+        API key for authentication
+  --blueprint
+        Operation blueprint ID for this run
+  --broker-port
+        Port for the local broker (default 7890)
+  --cmd
+        Run a command non-interactively
+  --collab
+        Start in collaborative mode (all agents see all messages)
+  --format
+        Output format (text, json) (default "text")
+  --from-scratch
+        Start without a saved blueprint and synthesize the first operation from the directive
+  --memory-backend
+        Memory backend for organizational context (nex, gbrain, none)
+  --no-nex
+        Disable Nex completely for this run
+  --no-open
+        Don't open browser automatically on launch
+  --opus-ceo
+        Upgrade CEO agent from Sonnet to Opus
+  --pack
+        Operation blueprint ID (legacy pack alias supported)
+  --provider
+        LLM provider override for this run (claude-code, codex)
+  --threads-collapsed
+        Start with threads collapsed (default: expanded)
+  --tui
+        Launch with tmux TUI instead of the web UI
+  --unsafe
+        Bypass all agent permission checks (use for local dev only)
+  --version

--- a/testdata/vhs/version.tape
+++ b/testdata/vhs/version.tape
@@ -1,0 +1,25 @@
+# Visual regression tape for `wuphf --version`.
+#
+# Build the binary first (check.sh does this), then:
+#   vhs testdata/vhs/version.tape
+#
+# The --version flag prints a single deterministic line.
+
+Output testdata/vhs/version.gif
+Output testdata/vhs/version.txt
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 800
+Set Height 200
+Set TypingSpeed 0ms
+
+Hide
+Type "clear"
+Enter
+Sleep 300ms
+Type "/tmp/wuphf-vhs --version"
+Enter
+Sleep 500ms
+Show
+Sleep 500ms

--- a/testdata/vhs/version.txt
+++ b/testdata/vhs/version.txt
@@ -1,0 +1,4 @@
+> /tmp/wuphf-vhs --version
+wuphf v0.1.0
+>
+

--- a/web/e2e/.gitignore
+++ b/web/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+playwright-report/
+test-results/
+/blob-report/
+.env

--- a/web/e2e/bun.lock
+++ b/web/e2e/bun.lock
@@ -1,0 +1,21 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "wuphf-web-e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.50.0",
+      },
+    },
+  },
+  "packages": {
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+  }
+}

--- a/web/e2e/package.json
+++ b/web/e2e/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "wuphf-web-e2e",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0"
+  }
+}

--- a/web/e2e/playwright.config.ts
+++ b/web/e2e/playwright.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from '@playwright/test';
+
+// The wuphf backend serves the built web UI directly at :7891. CI boots the
+// backend externally (see .github/workflows/ci.yml:web-e2e) — we don't use
+// playwright's webServer because the backend is a Go binary the CI already
+// built. For local runs: build wuphf, launch it with --no-open, then
+// `cd web/e2e && bunx playwright test`.
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    baseURL: process.env.WUPHF_E2E_BASE_URL ?? 'http://localhost:7891',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { browserName: 'chromium' } }],
+});

--- a/web/e2e/playwright.config.ts
+++ b/web/e2e/playwright.config.ts
@@ -11,7 +11,10 @@ export default defineConfig({
   expect: { timeout: 5_000 },
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0,
+  // No retries. These are smoke tests for UI crashes — a flaky pass is
+  // exactly the failure mode we're trying to prevent. Investigate flakes,
+  // don't paper over them.
+  retries: 0,
   workers: 1,
   reporter: process.env.CI ? [['github'], ['html', { open: 'never' }]] : 'list',
   use: {

--- a/web/e2e/tests/smoke.spec.ts
+++ b/web/e2e/tests/smoke.spec.ts
@@ -4,6 +4,10 @@ import { test, expect, type Page } from '@playwright/test';
 // React render-time crash ("Minified React error #31 — Objects are not valid
 // as a React child") on first agent click. PR #101 fixed the specific bug;
 // this test makes sure the next one gets caught in CI instead of in Slack.
+//
+// Assumes wuphf was started with ~/.wuphf/onboarded.json pre-seeded so the
+// app lands in the Shell (where the React #31 crash lived) rather than the
+// onboarding Wizard. Wizard coverage lives in wizard.spec.ts.
 
 function collectReactErrors(page: Page): () => string[] {
   const errors: string[] = [];
@@ -20,37 +24,33 @@ function collectReactErrors(page: Page): () => string[] {
 }
 
 // Wait for React's first commit: the static #skeleton placeholder is gone
-// (or replaced) and the boot-timeout diagnostic hasn't fired.
+// and React has committed something into #root.
 async function waitForReactMount(page: Page): Promise<void> {
   await page.waitForFunction(
     () => {
       const root = document.getElementById('root');
       if (!root) return false;
-      // Skeleton replaced by React output, OR React has committed *something*
-      // other than the skeleton div.
-      const skeleton = document.getElementById('skeleton');
-      if (skeleton) return false;
+      if (document.getElementById('skeleton')) return false;
       return root.children.length > 0;
     },
     { timeout: 10_000 },
   );
 }
 
-test.describe('wuphf web UI smoke', () => {
+test.describe('wuphf web UI smoke (shell)', () => {
   test('initial page render does not trip the React error boundary', async ({ page }) => {
     const getErrors = collectReactErrors(page);
 
     await page.goto('/');
     await waitForReactMount(page);
 
-    // The error boundary prints this literal string on render failure
-    // (see web/src/App.tsx — ErrorBoundary component). If it's visible, a
-    // render crashed somewhere up the tree.
-    await expect(page.locator('body')).not.toContainText('Something broke in the UI');
-    await expect(page.locator('body')).not.toContainText('Minified React error');
+    // Sidebar appearing is our "React committed and effects ran" signal.
+    // networkidle does NOT work here — wuphf opens a long-lived SSE stream
+    // as soon as the shell mounts, so the page is never idle.
+    await expect(page.locator('button[data-agent-slug]').first()).toBeVisible({ timeout: 10_000 });
 
-    // Drain any lingering async render errors before asserting.
-    await page.waitForTimeout(500);
+    await expect(page.getByTestId('error-boundary')).toHaveCount(0);
+
     const errors = getErrors();
     expect(
       errors,
@@ -58,27 +58,39 @@ test.describe('wuphf web UI smoke', () => {
     ).toHaveLength(0);
   });
 
-  test('navigating into an agent channel does not crash the UI', async ({ page }) => {
+  test('sidebar renders the seeded agents (broker wired)', async ({ page }) => {
+    // Hard assertion: the broker seeds default agents on every boot
+    // (see internal/team — 4+ default roles). Zero agents is NEVER the
+    // happy path; treating it as "skip" lets real regressions through
+    // (seed broken, /api/members failing, useOfficeMembers broken, etc.).
+    await page.goto('/');
+    await waitForReactMount(page);
+
+    const agentButtons = page.locator('button[data-agent-slug]');
+    await expect(agentButtons.first()).toBeVisible({ timeout: 10_000 });
+    expect(await agentButtons.count()).toBeGreaterThan(0);
+  });
+
+  test('clicking an agent does not crash the UI (React #31 guard)', async ({ page }) => {
     // The React #31 crash surfaced on first "click CEO". Reproduce that
-    // navigation path: find any agent entry in the sidebar and click it.
+    // path: click any agent in the sidebar and assert no crash.
     const getErrors = collectReactErrors(page);
 
     await page.goto('/');
     await waitForReactMount(page);
 
-    // Agents are listed in the sidebar (AgentList.tsx renders a button with
-    // data-agent-slug for each). Pack contents vary across environments, so
-    // skip if none are present rather than flake.
     const agentButtons = page.locator('button[data-agent-slug]');
-    const agentCount = await agentButtons.count();
-    test.skip(agentCount === 0, 'no agents rendered in sidebar — onboarding or empty pack');
-
+    await expect(agentButtons.first()).toBeVisible({ timeout: 10_000 });
     await agentButtons.first().click();
 
-    await expect(page.locator('body')).not.toContainText('Something broke in the UI');
-    await expect(page.locator('body')).not.toContainText('Minified React error');
+    // Deterministic post-click signal: clicking a sidebar agent sets
+    // activeAgentSlug in the store, which mounts <AgentPanel> → `.agent-panel`
+    // (see components/agents/AgentPanel.tsx). Waiting on the panel — instead
+    // of networkidle, which never settles due to the live SSE stream — gives
+    // the panel a cycle to render and any errors a cycle to fire.
+    await expect(page.locator('.agent-panel').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('error-boundary')).toHaveCount(0);
 
-    await page.waitForTimeout(500);
     const errors = getErrors();
     expect(
       errors,

--- a/web/e2e/tests/smoke.spec.ts
+++ b/web/e2e/tests/smoke.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Guards the class of regression that broke for users after the Garry Tan RT:
+// React render-time crash ("Minified React error #31 — Objects are not valid
+// as a React child") on first agent click. PR #101 fixed the specific bug;
+// this test makes sure the next one gets caught in CI instead of in Slack.
+
+function collectReactErrors(page: Page): () => string[] {
+  const errors: string[] = [];
+  page.on('pageerror', (err) => errors.push(err.message));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      const text = msg.text();
+      if (text.includes('Minified React error') || text.includes('Error boundary')) {
+        errors.push(text);
+      }
+    }
+  });
+  return () => errors;
+}
+
+// Wait for React's first commit: the static #skeleton placeholder is gone
+// (or replaced) and the boot-timeout diagnostic hasn't fired.
+async function waitForReactMount(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const root = document.getElementById('root');
+      if (!root) return false;
+      // Skeleton replaced by React output, OR React has committed *something*
+      // other than the skeleton div.
+      const skeleton = document.getElementById('skeleton');
+      if (skeleton) return false;
+      return root.children.length > 0;
+    },
+    { timeout: 10_000 },
+  );
+}
+
+test.describe('wuphf web UI smoke', () => {
+  test('initial page render does not trip the React error boundary', async ({ page }) => {
+    const getErrors = collectReactErrors(page);
+
+    await page.goto('/');
+    await waitForReactMount(page);
+
+    // The error boundary prints this literal string on render failure
+    // (see web/src/App.tsx — ErrorBoundary component). If it's visible, a
+    // render crashed somewhere up the tree.
+    await expect(page.locator('body')).not.toContainText('Something broke in the UI');
+    await expect(page.locator('body')).not.toContainText('Minified React error');
+
+    // Drain any lingering async render errors before asserting.
+    await page.waitForTimeout(500);
+    const errors = getErrors();
+    expect(
+      errors,
+      `Uncaught errors during initial render:\n  ${errors.join('\n  ')}`,
+    ).toHaveLength(0);
+  });
+
+  test('navigating into an agent channel does not crash the UI', async ({ page }) => {
+    // The React #31 crash surfaced on first "click CEO". Reproduce that
+    // navigation path: find any agent entry in the sidebar and click it.
+    const getErrors = collectReactErrors(page);
+
+    await page.goto('/');
+    await waitForReactMount(page);
+
+    // Agents are listed in the sidebar (AgentList.tsx renders a button with
+    // data-agent-slug for each). Pack contents vary across environments, so
+    // skip if none are present rather than flake.
+    const agentButtons = page.locator('button[data-agent-slug]');
+    const agentCount = await agentButtons.count();
+    test.skip(agentCount === 0, 'no agents rendered in sidebar — onboarding or empty pack');
+
+    await agentButtons.first().click();
+
+    await expect(page.locator('body')).not.toContainText('Something broke in the UI');
+    await expect(page.locator('body')).not.toContainText('Minified React error');
+
+    await page.waitForTimeout(500);
+    const errors = getErrors();
+    expect(
+      errors,
+      `Uncaught errors after agent click:\n  ${errors.join('\n  ')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/web/e2e/tests/wizard.spec.ts
+++ b/web/e2e/tests/wizard.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Fresh-install onboarding smoke. Assumes wuphf was started WITHOUT a
+// pre-seeded ~/.wuphf/onboarded.json, so App.tsx routes to the Wizard
+// (see App.tsx — onboardingComplete=false → <Wizard>).
+//
+// This is the path Garry Tan's sudden traffic would have hit. If the
+// wizard crashes on first paint for a fresh user, they bounce.
+
+function collectReactErrors(page: Page): () => string[] {
+  const errors: string[] = [];
+  page.on('pageerror', (err) => errors.push(err.message));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') {
+      const text = msg.text();
+      if (text.includes('Minified React error') || text.includes('Error boundary')) {
+        errors.push(text);
+      }
+    }
+  });
+  return () => errors;
+}
+
+async function waitForReactMount(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const root = document.getElementById('root');
+      if (!root) return false;
+      if (document.getElementById('skeleton')) return false;
+      return root.children.length > 0;
+    },
+    { timeout: 10_000 },
+  );
+}
+
+test.describe('wuphf onboarding wizard smoke', () => {
+  test('fresh install lands on the welcome step without crashing', async ({ page }) => {
+    const getErrors = collectReactErrors(page);
+
+    await page.goto('/');
+    await waitForReactMount(page);
+
+    // The Wizard renders `.wizard-step` as its root container
+    // (see web/src/components/onboarding/Wizard.tsx — WelcomeStep).
+    await expect(page.locator('.wizard-step').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('error-boundary')).toHaveCount(0);
+
+    await page.waitForLoadState('networkidle');
+    const errors = getErrors();
+    expect(
+      errors,
+      `Uncaught errors rendering wizard:\n  ${errors.join('\n  ')}`,
+    ).toHaveLength(0);
+  });
+
+  test('advancing from welcome → templates step does not crash', async ({ page }) => {
+    // Verifies the wizard state machine actually transitions. The welcome
+    // step has a single primary CTA; clicking it should render the
+    // templates step. Assert via the progress-dot count staying > 0 and
+    // a new `.wizard-panel` (only templates step onward has panels).
+    const getErrors = collectReactErrors(page);
+
+    await page.goto('/');
+    await waitForReactMount(page);
+
+    await expect(page.locator('.wizard-step').first()).toBeVisible({ timeout: 10_000 });
+    await page.locator('.wizard-step button.btn-primary').first().click();
+
+    // Templates step renders `.wizard-panel` (welcome does not).
+    await expect(page.locator('.wizard-panel').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByTestId('error-boundary')).toHaveCount(0);
+
+    await page.waitForLoadState('networkidle');
+    const errors = getErrors();
+    expect(
+      errors,
+      `Uncaught errors advancing wizard:\n  ${errors.join('\n  ')}`,
+    ).toHaveLength(0);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,12 +51,15 @@ class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryStat
   render() {
     if (this.state.error) {
       return (
-        <div style={{
-          position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
-          background: '#fee', color: '#900', padding: 20,
-          fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
-          fontSize: 13, overflowY: 'auto', zIndex: 9999,
-        }}>
+        <div
+          data-testid="error-boundary"
+          style={{
+            position: 'fixed', top: 0, left: 0, right: 0, bottom: 0,
+            background: '#fee', color: '#900', padding: 20,
+            fontFamily: '-apple-system, BlinkMacSystemFont, sans-serif',
+            fontSize: 13, overflowY: 'auto', zIndex: 9999,
+          }}
+        >
           <h2 style={{ margin: '0 0 8px 0', fontSize: 14 }}>
             Something broke in the UI
           </h2>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,4 @@
 import { Component, useEffect, useState, type ReactNode } from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { initApi, get } from './api/client'
 import { useAppStore } from './stores/app'
 import { Shell } from './components/layout/Shell'
@@ -30,15 +29,6 @@ import './styles/layout.css'
 import './styles/messages.css'
 import './styles/agents.css'
 import './styles/search.css'
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-      staleTime: 2000,
-    },
-  },
-})
 
 // ── Error boundary ─────────────────────────────────────────────
 
@@ -234,10 +224,8 @@ export default function App() {
 
   return (
     <ErrorBoundary>
-      <QueryClientProvider client={queryClient}>
-        {body}
-        <ToastContainer />
-      </QueryClientProvider>
+      {body}
+      <ToastContainer />
     </ErrorBoundary>
   )
 }

--- a/web/src/components/sidebar/AgentList.tsx
+++ b/web/src/components/sidebar/AgentList.tsx
@@ -43,6 +43,7 @@ export function AgentList() {
             return (
               <button
                 key={agent.slug}
+                data-agent-slug={agent.slug}
                 className={`sidebar-agent${isDMActive ? ' active' : ''}`}
                 title={`${agent.name} — ${ac.label}`}
                 onClick={() => setActiveAgentSlug(agent.slug)}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,5 +1,17 @@
 import { createRoot } from 'react-dom/client'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import App from './App'
+
+// Hoisted out of App() so hooks called *during* App's render (e.g.
+// useKeyboardShortcuts → useQueryClient) find a client. Previously the
+// provider lived inside App's return tree, which meant any useQueryClient
+// call at the top of App threw "No QueryClient set" before the provider
+// got a chance to mount.
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: 1, staleTime: 2000 },
+  },
+})
 
 // Signal boot-done to the index.html fatal-error handler when main.tsx loads.
 declare global {
@@ -30,7 +42,11 @@ try {
   if (!root) {
     throw new Error('#root element not found in DOM')
   }
-  createRoot(root).render(<App />)
+  createRoot(root).render(
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>,
+  )
   // Tell the HTML-level timeout handler that we're alive.
   window.__wuphfBootDone?.()
 } catch (err) {


### PR DESCRIPTION
## Summary

Brings wuphf's automated checks up to the rigor used in nex-cli and home-automation. Three layers:

1. **Lint tooling** — `.golangci.yml` (v2) + `lefthook.yml` pre-commit/pre-push + golangci-lint step in CI.
2. **Install verification** — shellcheck on install scripts, full-matrix `goreleaser build --snapshot` (catches cross-compile breakage for all 4 release targets), and per-OS `--version` smoke test.
3. **Visual regression** — VHS-based check modeled on home-automation's `tools/dollhouse/testdata/vhs/check.sh`. Tapes cover `wuphf --help` and `wuphf --version`; drift uploads `.txt.actual` artifacts so the author can accept intentional changes.

Along the way, fixed ~70 issues the new linter surfaced — including real write-path bugs where `Close()` errors could silently lose data (session journal, chat messages, agent tool write_file, outbox).

## Notable code changes

- New `internal/textutil` package with `CapitalizeFirst` replaces 4 copy-pasted local helpers from the `strings.Title` deprecation.
- `AgentLoop.appendSession` helper replaces 11 silent `_, _ = l.sessions.Append(...)` discards with logged failures. Gossip `Publish` similarly wrapped.
- Write-path files (session.go, chat/message.go, workflow_store.go, tools.go write_file + outbox, channel crash log, broker pane snapshot) now properly check `Close()` error. Previously a failed close on the session journal would silently drop the last entry.
- Read-path and best-effort log closes converted to explicit `defer func() { _ = f.Close() }()` so intent is visible.
- `http.ListenAndServe` in `broker.go` wrapped in goroutine with error logging.
- bubbletea `MouseLeft` → `MouseActionPress` + `MouseButtonLeft` deprecation fix in tests.
- lipgloss `.Copy()` removed (Style is now a value type).

## Tooling details

**`.golangci.yml`** enables errcheck, govet, ineffassign, staticcheck, misspell, unconvert. `unused` is deliberately disabled to preserve parked/WIP features like `pollNexInsights` and `spawnBackgroundAgents`. The `Close()` exclusion is narrowed to `(io.Closer).Close` (interface static type) so concrete write-path types still get flagged.

**`lefthook.yml`**
- pre-commit: gofmt, go vet, golangci-lint, secret scan, merge-conflict scan, >500KB file guard.
- pre-push: `go test ./...`, `go build ./cmd/wuphf`, VHS visual regression (skips cleanly if `vhs` not installed).

**CI** (`.github/workflows/ci.yml`) jobs:
- `lint` — gofmt / vet / golangci-lint
- `test` — go test + go build
- `shellcheck` — install scripts + check.sh
- `vhs` — visual regression on Ubuntu (uploads drift artifacts on failure)
- `release-build` — `goreleaser build --snapshot --clean` for the full 4-target matrix (darwin/amd64, darwin/arm64, linux/amd64, linux/arm64) — catches cross-compile breakage before a real release
- `binary-smoke` — matrix (ubuntu-latest, macos-latest): builds snapshot binary and runs `--version`

**Caveat on `binary-smoke`**: does not actually invoke `scripts/install.sh` since that pulls from GitHub Releases, which can't be exercised pre-release on a PR. It validates artifact shape only. A future stage could tarball the snapshot and feed it through a modified install.sh with an `INSTALL_FROM_ARCHIVE` escape hatch.

**VHS goldens**: generated on macOS. If the first CI run on Ubuntu drifts (different vhs text-rendering), the `vhs-drift` artifact lets you accept the new golden. Only `.txt` is diffed — `.gif` files are gitignored and regenerate each run.

## Test plan

Verified locally:
- [x] `golangci-lint run --max-issues-per-linter=0 ./...` → **0 issues**
- [x] `go test ./...` → all 18 packages pass
- [x] `lefthook run pre-push --force` → all 3 parallel commands pass in 6.7s
- [x] `goreleaser build --snapshot --clean` → all 4 targets compile
- [x] `testdata/vhs/check.sh` → two back-to-back runs deterministic
- [x] Pre-commit hooks passed on the commit itself
- [x] Pre-push hooks passed on the push itself

CI should verify:
- [ ] All 6 CI jobs pass on Ubuntu / macOS runners
- [ ] VHS goldens are stable across Linux runners (if drift, artifact upload lets us accept)
- [ ] goreleaser full matrix compiles in CI (already verified locally)

## Review

Staff reviewer ran over this before commit. All high/medium findings addressed — full writeup in commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)