### PR TITLE
feat(tasks): task detail modal with owner reassign + won't-do action

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -3486,7 +3486,7 @@ func (b *Broker) scheduleTaskLifecycleLocked(task *teamTask) {
 	recheckMinutes := config.ResolveTaskRecheckInterval()
 	reminderMinutes := config.ResolveTaskReminderInterval()
 	now := time.Now().UTC()
-	if strings.EqualFold(task.Status, "done") {
+	if strings.EqualFold(task.Status, "done") || strings.EqualFold(task.Status, "canceled") || strings.EqualFold(task.Status, "cancelled") {
 		task.FollowUpAt = ""
 		task.ReminderAt = ""
 		task.RecheckAt = ""
@@ -7377,6 +7377,10 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		}
 		task := &b.tasks[i]
 		taskChannel := normalizeChannelSlug(task.Channel)
+		reassignPrevOwner := ""
+		reassignTriggered := false
+		cancelTriggered := false
+		cancelPrevOwner := ""
 		switch action {
 		case "claim", "assign":
 			if strings.TrimSpace(body.Owner) == "" {
@@ -7390,6 +7394,22 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			} else {
 				task.ReviewState = "not_required"
 			}
+		case "reassign":
+			if strings.TrimSpace(body.Owner) == "" {
+				http.Error(w, "owner required", http.StatusBadRequest)
+				return
+			}
+			reassignPrevOwner = strings.TrimSpace(task.Owner)
+			newOwner := strings.TrimSpace(body.Owner)
+			task.Owner = newOwner
+			status := strings.ToLower(strings.TrimSpace(task.Status))
+			if status != "done" && status != "review" {
+				task.Status = "in_progress"
+			}
+			if taskNeedsStructuredReview(task) && strings.TrimSpace(task.ReviewState) == "" {
+				task.ReviewState = "pending_review"
+			}
+			reassignTriggered = reassignPrevOwner != newOwner
 		case "complete":
 			if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
 				if taskNeedsStructuredReview(task) {
@@ -7428,6 +7448,14 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			task.Owner = ""
 			task.Status = "open"
 			task.Blocked = false
+		case "cancel":
+			cancelPrevOwner = strings.TrimSpace(task.Owner)
+			task.Status = "canceled"
+			task.Blocked = false
+			task.FollowUpAt = ""
+			task.ReminderAt = ""
+			task.RecheckAt = ""
+			cancelTriggered = true
 		default:
 			http.Error(w, "unknown action", http.StatusBadRequest)
 			return
@@ -7475,6 +7503,12 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		b.appendActionLocked("task_updated", "office", taskChannel, strings.TrimSpace(body.CreatedBy), truncateSummary(task.Title+" ["+task.Status+"]", 140), task.ID)
+		if reassignTriggered {
+			b.postTaskReassignNotificationsLocked(strings.TrimSpace(body.CreatedBy), task, reassignPrevOwner)
+		}
+		if cancelTriggered {
+			b.postTaskCancelNotificationsLocked(strings.TrimSpace(body.CreatedBy), task, cancelPrevOwner)
+		}
 		if err := b.saveLocked(); err != nil {
 			http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
 			return
@@ -7485,6 +7519,180 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Error(w, "task not found", http.StatusNotFound)
+}
+
+// postTaskReassignNotificationsLocked posts the channel announcement plus DMs
+// to the new owner and previous owner whenever a task ownership change happens.
+// The CEO is tagged in the channel message rather than DM'd (CEO is the human
+// user; human↔ceo self-DM is not a valid DM target).
+//
+// Must be called while b.mu is held for write.
+func (b *Broker) postTaskReassignNotificationsLocked(actor string, task *teamTask, prevOwner string) {
+	if task == nil {
+		return
+	}
+	actor = strings.TrimSpace(actor)
+	if actor == "" {
+		actor = "system"
+	}
+	newOwner := strings.TrimSpace(task.Owner)
+	prevOwner = strings.TrimSpace(prevOwner)
+	if newOwner == prevOwner {
+		return
+	}
+	taskChannel := normalizeChannelSlug(task.Channel)
+	if taskChannel == "" {
+		taskChannel = "general"
+	}
+	title := strings.TrimSpace(task.Title)
+	if title == "" {
+		title = task.ID
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	newLabel := "(unassigned)"
+	if newOwner != "" {
+		newLabel = "@" + newOwner
+	}
+	prevLabel := "(unassigned)"
+	if prevOwner != "" {
+		prevLabel = "@" + prevOwner
+	}
+
+	b.counter++
+	b.appendMessageLocked(channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      actor,
+		Channel:   taskChannel,
+		Kind:      "task_reassigned",
+		Title:     title,
+		Content:   fmt.Sprintf("Task %q reassigned: %s → %s. (by @%s, cc @ceo)", title, prevLabel, newLabel, actor),
+		Tagged:    dedupeReassignTags([]string{"ceo", newOwner, prevOwner}),
+		Timestamp: now,
+	})
+
+	if isDMTargetSlug(newOwner) {
+		b.postTaskDMLocked(actor, newOwner, "task_reassigned", title,
+			fmt.Sprintf("Task %q is yours now. Details live in #%s.", title, taskChannel))
+	}
+	if isDMTargetSlug(prevOwner) && prevOwner != newOwner {
+		b.postTaskDMLocked(actor, prevOwner, "task_reassigned", title,
+			fmt.Sprintf("Task %q is off your plate — it moved to %s.", title, newLabel))
+	}
+}
+
+// postTaskCancelNotificationsLocked posts a channel announcement plus a DM
+// to the (previous) owner whenever a task is closed as "won't do".
+// Must be called while b.mu is held for write.
+func (b *Broker) postTaskCancelNotificationsLocked(actor string, task *teamTask, prevOwner string) {
+	if task == nil {
+		return
+	}
+	actor = strings.TrimSpace(actor)
+	if actor == "" {
+		actor = "system"
+	}
+	prevOwner = strings.TrimSpace(prevOwner)
+	taskChannel := normalizeChannelSlug(task.Channel)
+	if taskChannel == "" {
+		taskChannel = "general"
+	}
+	title := strings.TrimSpace(task.Title)
+	if title == "" {
+		title = task.ID
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	ownerLabel := "(no owner)"
+	if prevOwner != "" {
+		ownerLabel = "@" + prevOwner
+	}
+
+	b.counter++
+	b.appendMessageLocked(channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      actor,
+		Channel:   taskChannel,
+		Kind:      "task_canceled",
+		Title:     title,
+		Content:   fmt.Sprintf("Task %q closed as won't do. Owner was %s. (by @%s, cc @ceo)", title, ownerLabel, actor),
+		Tagged:    dedupeReassignTags([]string{"ceo", prevOwner}),
+		Timestamp: now,
+	})
+
+	if isDMTargetSlug(prevOwner) {
+		b.postTaskDMLocked(actor, prevOwner, "task_canceled", title,
+			fmt.Sprintf("Heads up — task %q was closed as won't do. Take it off your list.", title))
+	}
+}
+
+// postTaskDMLocked appends a direct-message notification to the DM channel
+// between "human" and targetSlug, creating the channel if necessary.
+// Must be called while b.mu is held for write.
+func (b *Broker) postTaskDMLocked(from, targetSlug, kind, title, content string) {
+	targetSlug = strings.TrimSpace(targetSlug)
+	if targetSlug == "" || b.channelStore == nil {
+		return
+	}
+	ch, err := b.channelStore.GetOrCreateDirect("human", targetSlug)
+	if err != nil {
+		return
+	}
+	if b.findChannelLocked(ch.Slug) == nil {
+		now := time.Now().UTC().Format(time.RFC3339)
+		b.channels = append(b.channels, teamChannel{
+			Slug:        ch.Slug,
+			Name:        ch.Slug,
+			Type:        "dm",
+			Description: "Direct messages with " + targetSlug,
+			Members:     []string{"human", targetSlug},
+			CreatedBy:   "wuphf",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		})
+	}
+	b.counter++
+	b.appendMessageLocked(channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      strings.TrimSpace(from),
+		Channel:   ch.Slug,
+		Kind:      strings.TrimSpace(kind),
+		Title:     title,
+		Content:   content,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+// isDMTargetSlug reports whether slug is a valid recipient for a human-to-agent DM.
+// The human user ("human"/"you") and the CEO seat ("ceo", which is the human)
+// are excluded because they would create self-DMs.
+func isDMTargetSlug(slug string) bool {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return false
+	}
+	switch slug {
+	case "human", "you", "ceo":
+		return false
+	}
+	return true
+}
+
+func dedupeReassignTags(tags []string) []string {
+	seen := make(map[string]struct{}, len(tags))
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	return out
 }
 
 func (b *Broker) BlockTask(taskID, actor, reason string) (teamTask, bool, error) {

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -1753,6 +1753,240 @@ func TestBrokerTaskLifecycle(t *testing.T) {
 	}
 }
 
+func TestBrokerTaskReassignNotifies(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	post := func(payload map[string]any) teamTask {
+		body, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPost, base+"/tasks", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("task post failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("unexpected status %d: %s", resp.StatusCode, raw)
+		}
+		var result struct {
+			Task teamTask `json:"task"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode task response: %v", err)
+		}
+		return result.Task
+	}
+
+	created := post(map[string]any{
+		"action":     "create",
+		"title":      "Ship reassign flow",
+		"created_by": "human",
+		"owner":      "engineering",
+	})
+	if created.Owner != "engineering" {
+		t.Fatalf("expected initial owner engineering, got %+v", created)
+	}
+
+	before := len(b.Messages())
+
+	// Reassign engineering → ops.
+	updated := post(map[string]any{
+		"action":     "reassign",
+		"id":         created.ID,
+		"owner":      "ops",
+		"created_by": "human",
+	})
+	if updated.Owner != "ops" {
+		t.Fatalf("expected owner=ops after reassign, got %q", updated.Owner)
+	}
+	if updated.Status != "in_progress" {
+		t.Fatalf("expected status=in_progress after reassign, got %q", updated.Status)
+	}
+
+	msgs := b.Messages()[before:]
+	if len(msgs) != 3 {
+		for i, m := range msgs {
+			t.Logf("msg[%d] channel=%s from=%s content=%q", i, m.Channel, m.From, m.Content)
+		}
+		t.Fatalf("expected 3 reassign messages (channel + new + prev), got %d", len(msgs))
+	}
+
+	taskChannel := normalizeChannelSlug(updated.Channel)
+	if taskChannel == "" {
+		taskChannel = "general"
+	}
+	newDM := channelDirectSlug("human", "ops")
+	prevDM := channelDirectSlug("human", "engineering")
+
+	seen := map[string]channelMessage{}
+	for _, m := range msgs {
+		seen[m.Channel] = m
+		if m.Kind != "task_reassigned" {
+			t.Fatalf("expected kind=task_reassigned, got %q", m.Kind)
+		}
+		if m.From != "human" {
+			t.Fatalf("expected from=human, got %q", m.From)
+		}
+	}
+	chMsg, ok := seen[taskChannel]
+	if !ok {
+		t.Fatalf("expected channel message in %q; saw %v", taskChannel, keys(seen))
+	}
+	if !containsAll(chMsg.Tagged, []string{"ceo", "ops", "engineering"}) {
+		t.Fatalf("expected channel message tagged ceo+ops+engineering, got %v", chMsg.Tagged)
+	}
+	if !strings.Contains(chMsg.Content, "@engineering") || !strings.Contains(chMsg.Content, "@ops") {
+		t.Fatalf("expected channel content to name both owners, got %q", chMsg.Content)
+	}
+	if _, ok := seen[newDM]; !ok {
+		t.Fatalf("expected DM to new owner in %q; saw %v", newDM, keys(seen))
+	}
+	if _, ok := seen[prevDM]; !ok {
+		t.Fatalf("expected DM to prev owner in %q; saw %v", prevDM, keys(seen))
+	}
+
+	// Re-posting with the same owner should be a no-op on notifications.
+	before2 := len(b.Messages())
+	post(map[string]any{
+		"action":     "reassign",
+		"id":         created.ID,
+		"owner":      "ops",
+		"created_by": "human",
+	})
+	after2 := b.Messages()[before2:]
+	for _, m := range after2 {
+		if m.Kind == "task_reassigned" {
+			t.Fatalf("expected no new task_reassigned messages for same-owner reassign, got %+v", m)
+		}
+	}
+}
+
+func TestBrokerTaskCancelNotifies(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	post := func(payload map[string]any) teamTask {
+		body, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPost, base+"/tasks", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("task post failed: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("unexpected status %d: %s", resp.StatusCode, raw)
+		}
+		var result struct {
+			Task teamTask `json:"task"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+			t.Fatalf("decode task response: %v", err)
+		}
+		return result.Task
+	}
+
+	created := post(map[string]any{
+		"action":     "create",
+		"title":      "Pilot the new onboarding deck",
+		"created_by": "human",
+		"owner":      "design",
+	})
+	before := len(b.Messages())
+
+	canceled := post(map[string]any{
+		"action":     "cancel",
+		"id":         created.ID,
+		"created_by": "human",
+	})
+	if canceled.Status != "canceled" {
+		t.Fatalf("expected status=canceled, got %q", canceled.Status)
+	}
+	if canceled.FollowUpAt != "" || canceled.ReminderAt != "" || canceled.RecheckAt != "" {
+		t.Fatalf("expected cleared follow-up timestamps on cancel, got %+v", canceled)
+	}
+
+	all := b.Messages()[before:]
+	msgs := make([]channelMessage, 0, len(all))
+	for _, m := range all {
+		if m.Kind == "task_canceled" {
+			msgs = append(msgs, m)
+		}
+	}
+	if len(msgs) != 2 {
+		for i, m := range all {
+			t.Logf("all[%d] channel=%s kind=%s content=%q", i, m.Channel, m.Kind, m.Content)
+		}
+		t.Fatalf("expected 2 task_canceled messages (channel + owner DM), got %d", len(msgs))
+	}
+	taskChannel := normalizeChannelSlug(canceled.Channel)
+	if taskChannel == "" {
+		taskChannel = "general"
+	}
+	ownerDM := channelDirectSlug("human", "design")
+	found := map[string]bool{}
+	for _, m := range msgs {
+		found[m.Channel] = true
+	}
+	if !found[taskChannel] {
+		t.Fatalf("missing channel cancel message in %q", taskChannel)
+	}
+	if !found[ownerDM] {
+		t.Fatalf("missing owner DM cancel message in %q", ownerDM)
+	}
+}
+
+func channelDirectSlug(a, b string) string {
+	if a > b {
+		a, b = b, a
+	}
+	return a + "__" + b
+}
+
+func keys(m map[string]channelMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func containsAll(got, want []string) bool {
+	set := make(map[string]struct{}, len(got))
+	for _, g := range got {
+		set[g] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := set[w]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
 func TestBrokerOfficeFeatureTaskForGTMCompletesWithoutReviewAndUnblocksDependents(t *testing.T) {
 	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -254,11 +254,56 @@ export interface Task {
   id: string
   title: string
   description?: string
+  details?: string
   status: string
-  assigned_to?: string
+  owner?: string
+  created_by?: string
   channel?: string
+  thread_id?: string
+  task_type?: string
+  pipeline_id?: string
+  pipeline_stage?: string
+  execution_mode?: string
+  review_state?: string
+  source_signal_id?: string
+  source_decision_id?: string
+  worktree_path?: string
+  worktree_branch?: string
+  depends_on?: string[]
+  blocked?: boolean
+  acked_at?: string
+  due_at?: string
+  follow_up_at?: string
+  reminder_at?: string
+  recheck_at?: string
   created_at?: string
   updated_at?: string
+}
+
+export function reassignTask(taskId: string, newOwner: string, channel: string, actor = 'human') {
+  return post<{ task: Task }>('/tasks', {
+    action: 'reassign',
+    id: taskId,
+    owner: newOwner,
+    channel: channel || 'general',
+    created_by: actor,
+  })
+}
+
+export type TaskStatusAction = 'release' | 'review' | 'block' | 'complete' | 'cancel'
+
+export function updateTaskStatus(
+  taskId: string,
+  action: TaskStatusAction,
+  channel: string,
+  actor = 'human',
+) {
+  return post<{ task: Task }>('/tasks', {
+    action,
+    id: taskId,
+    channel: channel || 'general',
+    created_by: actor,
+  })
 }
 
 export function getTasks(channel: string, opts?: { includeDone?: boolean; status?: string; mySlug?: string }) {

--- a/web/src/components/apps/ArtifactsApp.tsx
+++ b/web/src/components/apps/ArtifactsApp.tsx
@@ -185,7 +185,7 @@ export function ArtifactsApp() {
                   key={task.id}
                   title={task.title || task.id || 'Untitled task'}
                   body={task.description ?? ''}
-                  meta={[task.channel ? `#${task.channel}` : '', task.assigned_to ? `@${task.assigned_to}` : ''].filter(Boolean)}
+                  meta={[task.channel ? `#${task.channel}` : '', task.owner ? `@${task.owner}` : ''].filter(Boolean)}
                   kindLabel={normalizeStatus(task.status).replace(/_/g, ' ')}
                 />
               ))
@@ -244,7 +244,7 @@ export function ArtifactsApp() {
                     key={task.id}
                     title={task.title || task.id || 'Blocked task'}
                     body={task.description ?? 'Blocked lane needs operator attention.'}
-                    meta={[task.channel ? `#${task.channel}` : '', task.assigned_to ? `@${task.assigned_to}` : ''].filter(Boolean)}
+                    meta={[task.channel ? `#${task.channel}` : '', task.owner ? `@${task.owner}` : ''].filter(Boolean)}
                     kindLabel="blocked"
                   />
                 ))}

--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -1,0 +1,326 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import {
+  getOfficeMembers,
+  reassignTask,
+  updateTaskStatus,
+  type OfficeMember,
+  type Task,
+  type TaskStatusAction,
+} from '../../api/client'
+import { formatRelativeTime } from '../../lib/format'
+
+interface TaskDetailModalProps {
+  task: Task
+  onClose: () => void
+}
+
+const HUMAN_SLUG = 'human'
+
+export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
+  const queryClient = useQueryClient()
+  const { data: memberData } = useQuery({
+    queryKey: ['office-members'],
+    queryFn: getOfficeMembers,
+    staleTime: 30_000,
+  })
+
+  const currentOwner = (task.owner ?? '').trim()
+  const currentStatus = (task.status ?? '').trim().toLowerCase()
+  const [selectedOwner, setSelectedOwner] = useState<string>(currentOwner)
+  const [submitting, setSubmitting] = useState(false)
+  const [statusBusy, setStatusBusy] = useState<TaskStatusAction | null>(null)
+  const [errorMsg, setErrorMsg] = useState<string | null>(null)
+
+  useEffect(() => {
+    setSelectedOwner((task.owner ?? '').trim())
+    setErrorMsg(null)
+  }, [task.id, task.owner])
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const assignableMembers = useMemo<OfficeMember[]>(() => {
+    const members = memberData?.members ?? []
+    return members.filter((m) => {
+      const slug = m.slug?.trim().toLowerCase()
+      return slug && slug !== 'human' && slug !== 'you'
+    })
+  }, [memberData])
+
+  async function handleStatusAction(action: TaskStatusAction) {
+    setStatusBusy(action)
+    setErrorMsg(null)
+    try {
+      await updateTaskStatus(task.id, action, task.channel || 'general', HUMAN_SLUG)
+      await queryClient.invalidateQueries({ queryKey: ['office-tasks'] })
+      if (action === 'cancel' || action === 'complete') {
+        onClose()
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : `${action} failed`
+      setErrorMsg(message)
+    } finally {
+      setStatusBusy(null)
+    }
+  }
+
+  async function handleReassign() {
+    const next = selectedOwner.trim()
+    if (!next || next === currentOwner) return
+    setSubmitting(true)
+    setErrorMsg(null)
+    try {
+      await reassignTask(task.id, next, task.channel || 'general', HUMAN_SLUG)
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['office-tasks'] }),
+        queryClient.invalidateQueries({ queryKey: ['tasks'] }),
+      ])
+      onClose()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Reassign failed'
+      setErrorMsg(message)
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  function handleOverlayClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  const status = (task.status || '').replace(/_/g, ' ')
+  const reviewState = (task.review_state || '').replace(/_/g, ' ')
+  const description = task.description?.trim() || ''
+  const details = task.details?.trim() || ''
+
+  const metaRows: Array<[string, string | null | undefined]> = [
+    ['Owner', task.owner ? `@${task.owner}` : '(unassigned)'],
+    ['Channel', task.channel ? `#${task.channel}` : '—'],
+    ['Status', status || '—'],
+    ['Review state', reviewState || null],
+    ['Task type', task.task_type || null],
+    ['Execution mode', task.execution_mode || null],
+    ['Pipeline', task.pipeline_id || null],
+    ['Pipeline stage', task.pipeline_stage || null],
+    ['Worktree branch', task.worktree_branch || null],
+    ['Worktree path', task.worktree_path || null],
+    ['Source signal', task.source_signal_id || null],
+    ['Source decision', task.source_decision_id || null],
+    ['Thread', task.thread_id || null],
+    ['Created by', task.created_by ? `@${task.created_by}` : null],
+    ['Created', task.created_at ? formatRelativeTime(task.created_at) : null],
+    ['Updated', task.updated_at ? formatRelativeTime(task.updated_at) : null],
+    ['Due', task.due_at ? formatRelativeTime(task.due_at) : null],
+    ['Follow up', task.follow_up_at ? formatRelativeTime(task.follow_up_at) : null],
+    ['Reminder', task.reminder_at ? formatRelativeTime(task.reminder_at) : null],
+    ['Recheck', task.recheck_at ? formatRelativeTime(task.recheck_at) : null],
+  ]
+
+  const dependsOn = task.depends_on ?? []
+
+  const ownerChanged = selectedOwner.trim() !== currentOwner && selectedOwner.trim() !== ''
+
+  return (
+    <div
+      className="task-detail-overlay"
+      onClick={handleOverlayClick}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Task ${task.id}`}
+    >
+      <div className="task-detail-modal card">
+        <header className="task-detail-header">
+          <div>
+            <div className="task-detail-id">#{task.id}</div>
+            <h2 className="task-detail-title">{task.title || 'Untitled task'}</h2>
+          </div>
+          <button
+            type="button"
+            className="task-detail-close"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </header>
+
+        <section className="task-detail-section">
+          <div className="task-detail-label">Status</div>
+          <div className="task-detail-status">
+            <span className={`task-detail-status-badge status-${currentStatus || 'open'}`}>
+              {currentStatus ? currentStatus.replace(/_/g, ' ') : 'open'}
+            </span>
+            <div className="task-detail-status-actions">
+              <StatusButton
+                action="release"
+                label="Release"
+                busy={statusBusy}
+                disabledFor={['open']}
+                currentStatus={currentStatus}
+                onClick={handleStatusAction}
+              />
+              <StatusButton
+                action="review"
+                label="Mark review"
+                busy={statusBusy}
+                disabledFor={['review']}
+                currentStatus={currentStatus}
+                onClick={handleStatusAction}
+              />
+              <StatusButton
+                action="block"
+                label="Block"
+                busy={statusBusy}
+                disabledFor={['blocked']}
+                currentStatus={currentStatus}
+                onClick={handleStatusAction}
+              />
+              <StatusButton
+                action="complete"
+                label="Mark done"
+                busy={statusBusy}
+                disabledFor={['done']}
+                currentStatus={currentStatus}
+                onClick={handleStatusAction}
+              />
+              <StatusButton
+                action="cancel"
+                label="Won't do"
+                busy={statusBusy}
+                disabledFor={['canceled', 'cancelled']}
+                currentStatus={currentStatus}
+                onClick={handleStatusAction}
+                danger
+              />
+            </div>
+          </div>
+        </section>
+
+        <section className="task-detail-section">
+          <div className="task-detail-label">Ownership</div>
+          <div className="task-detail-ownership">
+            <div className="task-detail-owner-current">
+              <span className="task-detail-owner-badge">
+                {task.owner ? `@${task.owner}` : '(unassigned)'}
+              </span>
+              <span className="task-detail-hint">
+                Reassigning posts to #{task.channel || 'general'} and DMs both owners.
+                CEO is cc'd.
+              </span>
+            </div>
+            <div className="task-detail-owner-controls">
+              <select
+                className="task-detail-select"
+                value={selectedOwner}
+                onChange={(e) => setSelectedOwner(e.target.value)}
+                disabled={submitting}
+              >
+                <option value="">(pick an owner)</option>
+                {assignableMembers.map((m) => (
+                  <option key={m.slug} value={m.slug}>
+                    {m.name ? `${m.name} — @${m.slug}` : `@${m.slug}`}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                className="btn btn-primary btn-sm"
+                onClick={handleReassign}
+                disabled={!ownerChanged || submitting}
+              >
+                {submitting ? 'Reassigning...' : 'Reassign'}
+              </button>
+            </div>
+            {errorMsg && <div className="task-detail-error">{errorMsg}</div>}
+          </div>
+        </section>
+
+        {(description || details) && (
+          <section className="task-detail-section">
+            {description && (
+              <>
+                <div className="task-detail-label">Description</div>
+                <div className="task-detail-body">{description}</div>
+              </>
+            )}
+            {details && (
+              <>
+                <div className="task-detail-label" style={{ marginTop: description ? 12 : 0 }}>
+                  Details
+                </div>
+                <div className="task-detail-body">{details}</div>
+              </>
+            )}
+          </section>
+        )}
+
+        {dependsOn.length > 0 && (
+          <section className="task-detail-section">
+            <div className="task-detail-label">Depends on</div>
+            <ul className="task-detail-deps">
+              {dependsOn.map((dep) => (
+                <li key={dep}>#{dep}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        <section className="task-detail-section">
+          <div className="task-detail-label">Metadata</div>
+          <dl className="task-detail-meta">
+            {metaRows
+              .filter(([, value]) => value != null && value !== '')
+              .map(([key, value]) => (
+                <div key={key} className="task-detail-meta-row">
+                  <dt>{key}</dt>
+                  <dd>{value}</dd>
+                </div>
+              ))}
+          </dl>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+interface StatusButtonProps {
+  action: TaskStatusAction
+  label: string
+  busy: TaskStatusAction | null
+  disabledFor: string[]
+  currentStatus: string
+  onClick: (action: TaskStatusAction) => void
+  danger?: boolean
+}
+
+function StatusButton({
+  action,
+  label,
+  busy,
+  disabledFor,
+  currentStatus,
+  onClick,
+  danger,
+}: StatusButtonProps) {
+  const isCurrent = disabledFor.includes(currentStatus)
+  const isBusy = busy === action
+  const anyBusy = busy !== null
+  const className = 'btn btn-sm ' + (danger ? 'btn-ghost task-detail-status-btn-danger' : 'btn-ghost')
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={() => onClick(action)}
+      disabled={isCurrent || anyBusy}
+      title={isCurrent ? 'Task is already in this state' : undefined}
+    >
+      {isBusy ? '...' : label}
+    </button>
+  )
+}

--- a/web/src/components/apps/TasksApp.tsx
+++ b/web/src/components/apps/TasksApp.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState, type DragEvent } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { getOfficeTasks, post, type Task } from '../../api/client'
 import { formatRelativeTime } from '../../lib/format'
+import { TaskDetailModal } from './TaskDetailModal'
 
 const STATUS_ORDER = ['in_progress', 'open', 'review', 'pending', 'blocked', 'done'] as const
 
@@ -35,6 +36,8 @@ function groupTasks(tasks: Task[]): Record<StatusGroup, Task[]> {
     done: [],
   }
   for (const task of tasks) {
+    const raw = task.status?.toLowerCase().replace(/[\s-]+/g, '_')
+    if (raw === 'canceled' || raw === 'cancelled') continue
     const status = normalizeStatus(task.status)
     groups[status].push(task)
   }
@@ -99,6 +102,7 @@ export function TasksApp() {
   const moveTask = useTaskMove()
   const [draggingId, setDraggingId] = useState<string | null>(null)
   const [dragoverStatus, setDragoverStatus] = useState<StatusGroup | null>(null)
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null)
 
   if (isLoading) {
     return (
@@ -129,6 +133,7 @@ export function TasksApp() {
   const grouped = groupTasks(tasks)
   const tasksById = new Map(tasks.map((t) => [t.id, t]))
   const isDragging = draggingId !== null
+  const selectedTask = selectedTaskId ? tasksById.get(selectedTaskId) ?? null : null
 
   const handleDragStart = (taskId: string) => (event: DragEvent<HTMLDivElement>) => {
     event.dataTransfer.effectAllowed = 'move'
@@ -204,12 +209,19 @@ export function TasksApp() {
                   isDragging={draggingId === task.id}
                   onDragStart={handleDragStart(task.id)}
                   onDragEnd={handleDragEnd}
+                  onOpen={() => setSelectedTaskId(task.id)}
                 />
               ))}
             </div>
           )
         })}
       </div>
+      {selectedTask && (
+        <TaskDetailModal
+          task={selectedTask}
+          onClose={() => setSelectedTaskId(null)}
+        />
+      )}
     </>
   )
 }
@@ -219,12 +231,20 @@ interface TaskCardProps {
   isDragging: boolean
   onDragStart: (event: DragEvent<HTMLDivElement>) => void
   onDragEnd: (event: DragEvent<HTMLDivElement>) => void
+  onOpen: () => void
 }
 
-function TaskCard({ task, isDragging, onDragStart, onDragEnd }: TaskCardProps) {
+function TaskCard({ task, isDragging, onDragStart, onDragEnd, onOpen }: TaskCardProps) {
   const status = normalizeStatus(task.status)
   const timestamp = task.updated_at ?? task.created_at
   const className = 'app-card task-card' + (isDragging ? ' dragging' : '')
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      onOpen()
+    }
+  }
 
   return (
     <div
@@ -232,7 +252,11 @@ function TaskCard({ task, isDragging, onDragStart, onDragEnd }: TaskCardProps) {
       draggable
       onDragStart={onDragStart}
       onDragEnd={onDragEnd}
-      style={{ marginBottom: 8 }}
+      onClick={onOpen}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
+      style={{ marginBottom: 8, cursor: 'pointer' }}
     >
       <div className="app-card-title">{task.title || 'Untitled'}</div>
       {task.description && (
@@ -244,8 +268,8 @@ function TaskCard({ task, isDragging, onDragStart, onDragEnd }: TaskCardProps) {
         <span className={statusBadgeClass(status)}>
           {status.replace(/_/g, ' ')}
         </span>
-        {task.assigned_to && (
-          <span className="app-card-meta">@{task.assigned_to}</span>
+        {task.owner && (
+          <span className="app-card-meta">@{task.owner}</span>
         )}
         {task.channel && (
           <span className="app-card-meta">#{task.channel}</span>

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -85,6 +85,240 @@
   .task-board { grid-template-columns: repeat(2, minmax(200px, 1fr)); }
 }
 
+/* ─── Task detail modal ─── */
+.task-detail-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 8vh;
+  padding-bottom: 8vh;
+  z-index: 250;
+  animation: fadeIn 0.15s ease-out;
+}
+.task-detail-modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.18);
+  width: 92%;
+  max-width: 680px;
+  max-height: 84vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+.task-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 20px 20px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.task-detail-id {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.task-detail-title {
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1.3;
+  color: var(--text);
+  margin: 0;
+}
+.task-detail-close {
+  border: none;
+  background: transparent;
+  font-size: 22px;
+  line-height: 1;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  flex-shrink: 0;
+}
+.task-detail-close:hover { background: var(--bg-warm); color: var(--text); }
+.task-detail-section {
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+}
+.task-detail-section:last-child { border-bottom: none; }
+.task-detail-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-tertiary);
+  margin-bottom: 8px;
+}
+.task-detail-body {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.task-detail-ownership {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.task-detail-owner-current {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.task-detail-owner-badge {
+  display: inline-flex;
+  align-items: center;
+  background: var(--accent-bg);
+  color: var(--accent);
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+}
+.task-detail-hint {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+.task-detail-status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+.task-detail-status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: var(--radius-full);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: var(--bg);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+}
+.task-detail-status-badge.status-done {
+  background: #E7F9ED;
+  color: #0B6B2A;
+  border-color: #C6EED2;
+}
+.task-detail-status-badge.status-in_progress,
+.task-detail-status-badge.status-review {
+  background: var(--accent-bg);
+  color: var(--accent);
+  border-color: var(--accent-bg);
+}
+.task-detail-status-badge.status-blocked {
+  background: #FFF4D6;
+  color: #7A5500;
+  border-color: #F2D98A;
+}
+.task-detail-status-badge.status-canceled,
+.task-detail-status-badge.status-cancelled {
+  background: var(--bg-warm);
+  color: var(--text-tertiary);
+  border-color: var(--border);
+  text-decoration: line-through;
+}
+.task-detail-status-actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.task-detail-status-btn-danger {
+  color: var(--red);
+  border-color: var(--red-bg) !important;
+}
+.task-detail-status-btn-danger:hover:not(:disabled) {
+  background: var(--red-bg);
+}
+.task-detail-owner-controls {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.task-detail-select {
+  flex: 1;
+  min-width: 180px;
+  height: 36px;
+  padding: 0 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  font-size: 13px;
+  font-family: var(--font-sans);
+}
+.task-detail-select:disabled { opacity: 0.6; cursor: not-allowed; }
+.task-detail-error {
+  font-size: 12px;
+  color: var(--red);
+  background: var(--red-bg);
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+}
+.task-detail-deps {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.task-detail-deps li {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+}
+.task-detail-meta {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px;
+  margin: 0;
+}
+.task-detail-meta-row {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 12px;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.task-detail-meta-row dt {
+  color: var(--text-tertiary);
+  font-weight: 500;
+}
+.task-detail-meta-row dd {
+  margin: 0;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+@media (max-width: 640px) {
+  .task-detail-meta-row { grid-template-columns: 1fr; gap: 2px; }
+  .task-detail-modal { width: 96%; padding: 0; }
+}
+
 /* ─── Thread Panel ─── */
 .thread-panel { width: 380px; flex-shrink: 0; background: var(--bg-card); border-left: 1px solid var(--border); display: none; flex-direction: column; height: 100vh; overflow: hidden; }
 .thread-panel.open { display: flex; }


### PR DESCRIPTION
## Summary

Kanban cards now open a **task detail modal** with every field visible plus two live controls:

- **Ownership** — badge, member picker, and a **Reassign** button
- **Status** — badge plus Release / Mark review / Block / Mark done / **Won't do** buttons

Ownership and lifecycle changes both emit tagged channel messages and owner DMs so the CEO and all affected agents see the change in-feed.

## What changed

### Backend (`internal/team/broker.go`)
- New `action: "reassign"` on `POST /tasks` — captures prev owner, sets new owner, preserves `done`/`review` status.
- New `action: "cancel"` — sets status to `canceled`, clears follow-up/reminder/recheck timestamps; the lifecycle scheduler treats `canceled` as a terminal state (same path as `done`).
- Helpers `postTaskReassignNotificationsLocked` and `postTaskCancelNotificationsLocked` post:
  - 1 channel message in `task.Channel` tagged `@ceo`, new owner, prev owner.
  - DM to the new owner (`human↔newOwner`).
  - DM to the previous owner (`human↔prevOwner`).
  - Cancel sends 1 channel message + DM to the (previous) owner.
- CEO is tagged rather than DM'd because CEO is the human user — human↔ceo self-DM is not a valid DM target.

### Frontend
- `web/src/api/client.ts` — `Task` interface now matches the broker JSON (`owner`, plus the full schema used by the modal); new `reassignTask` and `updateTaskStatus` helpers.
- `web/src/components/apps/TaskDetailModal.tsx` — new component: id, title, status section, ownership section, description, details, dependencies, and a metadata grid. Closes on Escape or overlay click.
- `web/src/components/apps/TasksApp.tsx` — cards are now clickable / keyboard-activatable; canceled tasks are filtered out of the kanban.
- `web/src/components/apps/ArtifactsApp.tsx` — updated to the renamed `owner` field.
- Styling in `web/src/styles/layout.css` for the overlay, modal, status badge, and action buttons — reuses existing design tokens.

### Tests
- `TestBrokerTaskReassignNotifies` — asserts owner change, 3 messages (channel + both DMs), same-owner no-op.
- `TestBrokerTaskCancelNotifies` — asserts `canceled` status, cleared follow-up timestamps, 2 messages (channel + owner DM).
- Full `go test ./internal/team/` + `tsc --noEmit` + `vite build` pass locally.

## End-to-end verification

Ran against a local build on 7890/7891 (Go binary + embedded web bundle):

**Reassign (engineering → planner)**
```
general          task_reassigned  Task "Modal smoke test" reassigned: @engineering → @planner. (by @human, cc @ceo)
human__planner   task_reassigned  Task "Modal smoke test" is yours now. Details live in #general.
engineering__h.  task_reassigned  Task "Modal smoke test" is off your plate — it moved to @planner.
```

**Cancel (won't do)**
```
general          task_canceled    Task "Modal smoke test" closed as won't do. Owner was @planner. (by @human, cc @ceo)
human__planner   task_canceled    Heads up — task "Modal smoke test" was closed as won't do. Take it off your list.
```

Task status transitioned `in_progress → canceled`, `follow_up_at` / `reminder_at` / `recheck_at` all cleared, card hidden from the kanban.

## Test plan

- [ ] `go test ./internal/team/` passes
- [ ] `cd web && npm run build` passes
- [ ] Kanban card click opens the detail modal (Escape or overlay click closes)
- [ ] Reassign picker + button: owner updates, 3 messages appear (channel + new-owner DM + prev-owner DM)
- [ ] Release / Mark review / Block / Mark done buttons update status and disable the current state
- [ ] Won't do moves the task to `canceled`, hides it from the board, posts channel + owner-DM notifications
- [ ] CEO channel messages tag `@ceo` alongside new/prev owners

## Known caveat

`TestHeadlessTurnCompletedDurablyRejectsCodingTurnWithoutTaskStateOrEvidence` is intermittently flaky on macOS (tempdir `.wuphf` cleanup race). Reproduced on a clean `main` clone; not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)