### PR TITLE
feat(tasks): Won't Do column for canceled tasks

### DIFF
--- a/web/src/components/apps/TasksApp.tsx
+++ b/web/src/components/apps/TasksApp.tsx
@@ -4,17 +4,28 @@ import { getOfficeTasks, post, type Task } from '../../api/client'
 import { formatRelativeTime } from '../../lib/format'
 import { TaskDetailModal } from './TaskDetailModal'
 
-const STATUS_ORDER = ['in_progress', 'open', 'review', 'pending', 'blocked', 'done'] as const
+const STATUS_ORDER = ['in_progress', 'open', 'review', 'pending', 'blocked', 'done', 'canceled'] as const
 
 type StatusGroup = typeof STATUS_ORDER[number]
 
 const DND_MIME = 'application/x-wuphf-task-id'
 const HUMAN_SLUG = 'human'
 
+const COLUMN_LABEL: Record<StatusGroup, string> = {
+  in_progress: 'in progress',
+  open: 'open',
+  review: 'review',
+  pending: 'pending',
+  blocked: 'blocked',
+  done: 'done',
+  canceled: "won't do",
+}
+
 function normalizeStatus(raw: string): StatusGroup {
   const s = raw.toLowerCase().replace(/[\s-]+/g, '_')
   if (s === 'completed') return 'done'
   if (s === 'in_review') return 'review'
+  if (s === 'cancelled') return 'canceled'
   if ((STATUS_ORDER as readonly string[]).includes(s)) return s as StatusGroup
   return 'open'
 }
@@ -23,6 +34,7 @@ function statusBadgeClass(status: StatusGroup): string {
   if (status === 'done') return 'badge badge-green'
   if (status === 'in_progress' || status === 'review') return 'badge badge-accent'
   if (status === 'blocked') return 'badge badge-yellow'
+  if (status === 'canceled') return 'badge badge-muted'
   return 'badge badge-accent'
 }
 
@@ -34,10 +46,9 @@ function groupTasks(tasks: Task[]): Record<StatusGroup, Task[]> {
     pending: [],
     blocked: [],
     done: [],
+    canceled: [],
   }
   for (const task of tasks) {
-    const raw = task.status?.toLowerCase().replace(/[\s-]+/g, '_')
-    if (raw === 'canceled' || raw === 'cancelled') continue
     const status = normalizeStatus(task.status)
     groups[status].push(task)
   }
@@ -65,6 +76,8 @@ function buildMoveBody(task: Task, toStatus: StatusGroup): Record<string, string
       return { ...base, action: 'complete' }
     case 'blocked':
       return { ...base, action: 'block' }
+    case 'canceled':
+      return { ...base, action: 'cancel' }
     case 'pending':
       // No direct "pending" action in the broker — punted.
       return null
@@ -183,9 +196,13 @@ export function TasksApp() {
       <div className="task-board">
         {STATUS_ORDER.map((status) => {
           const column = grouped[status]
-          // Hide empty pending/blocked columns only when nothing is being dragged.
-          // While dragging, keep all 6 columns visible as drop targets.
-          if (!isDragging && column.length === 0 && (status === 'pending' || status === 'blocked')) {
+          // Hide empty pending/blocked/canceled columns only when nothing is being dragged.
+          // While dragging, keep all columns visible as drop targets.
+          if (
+            !isDragging &&
+            column.length === 0 &&
+            (status === 'pending' || status === 'blocked' || status === 'canceled')
+          ) {
             return null
           }
           const columnClass =
@@ -199,7 +216,7 @@ export function TasksApp() {
               onDrop={handleColumnDrop(status)}
             >
               <div className="task-column-header">
-                <span>{status.replace(/_/g, ' ')}</span>
+                <span>{COLUMN_LABEL[status]}</span>
                 <span className="task-column-count">{column.length}</span>
               </div>
               {column.map((task) => (
@@ -266,7 +283,7 @@ function TaskCard({ task, isDragging, onDragStart, onDragEnd, onOpen }: TaskCard
       )}
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
         <span className={statusBadgeClass(status)}>
-          {status.replace(/_/g, ' ')}
+          {COLUMN_LABEL[status]}
         </span>
         {task.owner && (
           <span className="app-card-meta">@{task.owner}</span>

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -80,6 +80,7 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 .badge-green { background: var(--green-bg); color: var(--green); }
 .badge-accent { background: var(--accent-bg); color: var(--accent); }
 .badge-yellow { background: var(--yellow-bg); color: var(--yellow); }
+.badge-muted { background: var(--bg-warm); color: var(--text-tertiary); text-decoration: line-through; }
 
 /* ─── Pixel avatars ─── */
 /* The canvas buffer is the sprite's native 14x14 grid; CSS scales it up.

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -69,7 +69,7 @@
 .app-card-meta { font-size: 11px; color: var(--text-tertiary); }
 
 /* ─── Task board (kanban) ─── */
-.task-board { display: grid; grid-template-columns: repeat(6, minmax(220px, 1fr)); gap: 12px; padding: 20px; align-content: start; overflow-x: auto; }
+.task-board { display: grid; grid-template-columns: repeat(7, minmax(200px, 1fr)); gap: 12px; padding: 20px; align-content: start; overflow-x: auto; }
 .task-column { display: flex; flex-direction: column; gap: 4px; min-height: 120px; padding: 4px; border-radius: var(--radius-md); transition: outline-color 0.15s, background 0.15s; }
 .task-column-header { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-tertiary); padding: 0 4px 8px; border-bottom: 2px solid var(--border); display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
 .task-column-count { font-family: var(--font-mono); font-size: 10px; background: var(--bg); padding: 1px 6px; border-radius: var(--radius-full); }


### PR DESCRIPTION
## Summary

Canceled tasks were being removed from view. Bring them back as a dedicated 7th kanban column so cancellations stay visible and auditable.

![Kanban now shows seven columns: in progress / open / review / pending / blocked / done / won't do]

## What changed

- **`STATUS_ORDER`** — adds `'canceled'` (rendered as "won't do" in both the column header and the card badge).
- **`normalizeStatus`** — explicit `cancelled` → `canceled` alias. Previously the British spelling fell through to the `'open'` fallback — a latent bug that would have parked cancelled cards in the Open column rather than hiding them or surfacing them correctly.
- **`groupTasks`** — removes the `if (raw === 'canceled') continue` filter; cancelled tasks now flow into the new `canceled` bucket like every other status.
- **`buildMoveBody`** — new `case 'canceled': action: 'cancel'` so drag-to-Won't-Do fires the broker `cancel` action end-to-end (channel message + owner DM, same path as the "Won't do" button inside the detail modal).
- **Empty column hiding** — extended the pending/blocked rule to canceled: hidden when empty, shown as a drop target during drag.
- **`.badge-muted`** — new badge variant in `global.css` (muted gray + line-through), reusing the exact palette the detail modal already uses for `status-canceled`.
- **`.task-board`** — 6 → 7 columns; `minmax(220px, 1fr)` → `minmax(200px, 1fr)` so the default grid still fits a 13" laptop before `overflow-x` kicks in.

## Test plan

- [ ] Kanban shows 7 columns when any cancelled task exists, 4-6 otherwise
- [ ] Dragging a card to Won't Do calls `POST /tasks { action: "cancel" }` and the card appears in the Won't Do column on the refetch
- [ ] Cancelled card shows `won't do` badge with line-through strikethrough
- [ ] Detail modal's "Won't do" button still closes the modal and lands the card in the Won't Do column (not hidden)
- [ ] British `cancelled` spelling (e.g. legacy data) groups into the Won't Do column, not Open

## Known caveats

- Same `TestHeadlessTurnCompletedDurablyRejectsCodingTurnWithoutTaskStateOrEvidence` macOS tempdir flake noted in #112. Not touched by this PR.
- Release: this is a `feat(...):` commit so auto-release will minor-bump `v0.13.0 → v0.14.0` on merge. Users on `wuphf@0.13.0` will need `npm install -g wuphf@latest` to get the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)