### PR TITLE
fix(team): raise Claude --max-turns so CEO can reply to untagged/DM messages

### DIFF
--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -239,7 +239,7 @@ func buildClaudeArgs(systemPrompt string, resumeID string) []string {
 		"--print", "-",
 		"--output-format", "stream-json",
 		"--verbose",
-		"--max-turns", "5",
+		"--max-turns", "20",
 		"--disable-slash-commands",
 		"--strict-mcp-config",
 		"--setting-sources", "user",

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -39,7 +39,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		"--print", "-",
 		"--output-format", "stream-json",
 		"--verbose",
-		"--max-turns", "5",
+		"--max-turns", l.headlessClaudeMaxTurns(slug),
 		"--disable-slash-commands",
 		"--setting-sources", "user",
 		"--append-system-prompt", l.buildPrompt(slug),
@@ -226,6 +226,17 @@ func (l *Launcher) headlessClaudeModel(slug string) string {
 		return "claude-opus-4-6"
 	}
 	return "claude-sonnet-4-6"
+}
+
+// headlessClaudeMaxTurns returns the turn budget for an agent. The CEO routes
+// untagged and DM messages, which typically requires looking up tasks, channel
+// members, and posting an assignment — easily more than 5 turns. Specialists
+// get a smaller budget since they focus on a single task.
+func (l *Launcher) headlessClaudeMaxTurns(slug string) string {
+	if slug == l.officeLeadSlug() {
+		return "20"
+	}
+	return "10"
 }
 
 func (l *Launcher) buildHeadlessClaudeEnv(slug string) []string {


### PR DESCRIPTION
## Summary

- CEO was hitting \`max turns reached\` on untagged channel messages and DMs, silently dropping the reply.
- Routing a typical untagged message easily needs more than 5 turns: lookup tasks → lookup channel members → decide routing → post reply → optionally create/assign a task.
- Raise the budgets:
  - Headless CEO turn: **20** (was 5)
  - Headless specialist turn: **10** (was 5)
  - Single-shot Claude provider (\`internal/provider/claude.go\`): **20** (was 5)
- CEO gets the largest budget because it is the router. Specialists stay leaner since they focus on a single task per turn.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/team/... ./internal/provider/...\`
- [ ] Manual: DM the CEO → CEO replies.
- [ ] Manual: post an untagged message in a multi-agent channel → CEO routes and replies.