### PR TITLE
fix(onboarding): embed blueprint YAML so installs see shipped presets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,10 +207,20 @@ jobs:
       # `</dev/null` on both boots prevents isPiped() from yanking wuphf into
       # scanner mode.
       - name: Start wuphf (fresh install) for wizard tests
+        # Run from /tmp — NOT the checkout root. `resolveTemplatesRepoRoot`
+        # walks up from cwd looking for templates/operations/, and would
+        # find it in the checkout, masking the "no repo on disk" path that
+        # `npx wuphf` / `curl | bash` users actually take. Running from
+        # /tmp forces the blueprint loader to go through the embedded FS
+        # wired in templates_embed.go, which is exactly the regression
+        # path the wizard.spec.ts blueprint-picker test guards.
         run: |
           rm -f "$HOME/.wuphf/onboarded.json"
-          ./wuphf --no-open --broker-port 7890 --web-port 7891 --no-nex </dev/null > wuphf-wizard.log 2>&1 &
-          echo $! > wuphf-wizard.pid
+          wuphf_bin="$PWD/wuphf"
+          run_dir="$(mktemp -d)"
+          cd "$run_dir"
+          "$wuphf_bin" --no-open --broker-port 7890 --web-port 7891 --no-nex </dev/null > "$GITHUB_WORKSPACE/wuphf-wizard.log" 2>&1 &
+          echo $! > "$GITHUB_WORKSPACE/wuphf-wizard.pid"
           # /onboarding/state is the authoritative readiness signal (the
           # static index.html can 200 before the broker is fully wired).
           for i in $(seq 1 30); do
@@ -221,7 +231,7 @@ jobs:
             sleep 1
           done
           echo "wuphf failed to become ready (wizard)" >&2
-          cat wuphf-wizard.log >&2
+          cat "$GITHUB_WORKSPACE/wuphf-wizard.log" >&2
           exit 1
       - name: Run Playwright wizard smoke
         working-directory: web/e2e

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -421,22 +421,21 @@ type blueprintTaskSummary struct {
 
 // HandleBlueprints handles GET /onboarding/blueprints.
 // Returns {"templates": [...]} in the shape the Wizard expects for its
-// blueprint picker. An empty list is a valid response (fresh clone without
-// templates/operations/ gets the "From scratch" card only).
+// blueprint picker. Passes "" to ListBlueprints when the filesystem walk
+// finds no repo — the loader falls back to the binary's embedded
+// templates (wired in the root wuphf package's init), so installs without
+// a checkout still see the shipped blueprints.
 func HandleBlueprints(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	repoRoot := resolveTemplatesRepoRoot("")
 	summaries := []blueprintSummary{}
-	if repoRoot != "" {
-		blueprints, err := operations.ListBlueprints(repoRoot)
-		if err == nil {
-			for _, bp := range blueprints {
-				summaries = append(summaries, summarizeBlueprint(bp))
-			}
+	blueprints, err := operations.ListBlueprints(resolveTemplatesRepoRoot(""))
+	if err == nil {
+		for _, bp := range blueprints {
+			summaries = append(summaries, summarizeBlueprint(bp))
 		}
 	}
 

--- a/internal/operations/employee_loader.go
+++ b/internal/operations/employee_loader.go
@@ -2,8 +2,7 @@ package operations
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
+	"path"
 	"sort"
 	"strings"
 
@@ -15,8 +14,8 @@ func LoadEmployeeBlueprint(repoRoot, templateID string) (EmployeeBlueprint, erro
 	if templateID == "" {
 		return EmployeeBlueprint{}, fmt.Errorf("template id required")
 	}
-	path := filepath.Join(repoRoot, "templates", "employees", templateID, "blueprint.yaml")
-	raw, err := os.ReadFile(path)
+	rel := path.Join("templates", "employees", templateID, "blueprint.yaml")
+	raw, err := readTemplateFile(repoRoot, rel)
 	if err != nil {
 		return EmployeeBlueprint{}, err
 	}
@@ -32,20 +31,13 @@ func LoadEmployeeBlueprint(repoRoot, templateID string) (EmployeeBlueprint, erro
 }
 
 func ListEmployeeBlueprints(repoRoot string) ([]EmployeeBlueprint, error) {
-	root := filepath.Join(repoRoot, "templates", "employees")
-	entries, err := os.ReadDir(root)
+	names, err := listTemplateDirs(repoRoot, path.Join("templates", "employees"))
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
-	blueprints := make([]EmployeeBlueprint, 0, len(entries))
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		blueprint, err := LoadEmployeeBlueprint(repoRoot, entry.Name())
+	blueprints := make([]EmployeeBlueprint, 0, len(names))
+	for _, name := range names {
+		blueprint, err := LoadEmployeeBlueprint(repoRoot, name)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/operations/fs.go
+++ b/internal/operations/fs.go
@@ -1,0 +1,89 @@
+package operations
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// fallbackFS is consulted by the template loaders when a filesystem read
+// rooted at repoRoot fails (or when repoRoot is empty). Binaries built
+// with `//go:embed all:templates/…` wire this in via SetFallbackFS so
+// installs without a repo checkout (e.g. `npx wuphf`, `curl | bash`)
+// still see the shipped operations and employee blueprints.
+//
+// When both the filesystem and the fallback have the requested file, the
+// filesystem wins. This preserves the existing override pattern — a user
+// who adds their own `templates/operations/<id>/blueprint.yaml` to their
+// checkout still takes precedence over the embedded shipped blueprint
+// with the same id.
+var fallbackFS fs.FS
+
+// SetFallbackFS registers the embedded templates FS. Safe to call more
+// than once; last writer wins. Passing nil clears the fallback.
+func SetFallbackFS(f fs.FS) { fallbackFS = f }
+
+// readTemplateFile reads rel (a slash-separated path rooted at
+// "templates/…") from the filesystem at repoRoot if present, otherwise
+// from the fallback FS. Returns fs.ErrNotExist when neither holds the
+// file.
+func readTemplateFile(repoRoot, rel string) ([]byte, error) {
+	if repoRoot != "" {
+		raw, err := os.ReadFile(filepath.Join(repoRoot, rel))
+		if err == nil {
+			return raw, nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	if fallbackFS != nil {
+		raw, err := fs.ReadFile(fallbackFS, filepath.ToSlash(rel))
+		if err == nil {
+			return raw, nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	return nil, fs.ErrNotExist
+}
+
+// listTemplateDirs returns the subdirectory names of rel (a
+// slash-separated path like "templates/operations"), preferring the
+// filesystem at repoRoot and falling back to the embedded FS. Returns a
+// nil slice when neither location holds the directory — the callers treat
+// that as "no blueprints", consistent with the pre-embed behavior.
+func listTemplateDirs(repoRoot, rel string) ([]string, error) {
+	if repoRoot != "" {
+		root := filepath.Join(repoRoot, rel)
+		entries, err := os.ReadDir(root)
+		if err == nil {
+			return filterDirNames(entries), nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	if fallbackFS != nil {
+		entries, err := fs.ReadDir(fallbackFS, filepath.ToSlash(rel))
+		if err == nil {
+			return filterDirNames(entries), nil
+		}
+		if !os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+func filterDirNames(entries []fs.DirEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		out = append(out, entry.Name())
+	}
+	return out
+}

--- a/internal/operations/fs_test.go
+++ b/internal/operations/fs_test.go
@@ -1,0 +1,106 @@
+package operations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// Ensures ListBlueprints/LoadBlueprint transparently fall back to the
+// registered embed FS when repoRoot has no templates/ tree. This is the
+// behavior the wizard's /onboarding/blueprints handler depends on for
+// installs that run outside a repo checkout (`npx wuphf`, `curl | bash`).
+func TestListAndLoadBlueprintsUseFallbackFS(t *testing.T) {
+	repoRoot := findRepoRoot(t)
+
+	// Register the real on-disk tree as the fallback so the loader has
+	// something valid to hand back.
+	prev := fallbackFS
+	SetFallbackFS(os.DirFS(repoRoot))
+	t.Cleanup(func() { SetFallbackFS(prev) })
+
+	// repoRoot="" forces the fallback path.
+	blueprints, err := ListBlueprints("")
+	if err != nil {
+		t.Fatalf("ListBlueprints(\"\"): %v", err)
+	}
+	if len(blueprints) == 0 {
+		t.Fatalf("expected blueprints from fallback FS, got 0")
+	}
+
+	// Also exercise LoadBlueprint by id — the loader must be able to
+	// resolve employee_blueprint references via the same fallback tree.
+	bp, err := LoadBlueprint("", blueprints[0].ID)
+	if err != nil {
+		t.Fatalf("LoadBlueprint(\"\", %q): %v", blueprints[0].ID, err)
+	}
+	if bp.ID != blueprints[0].ID {
+		t.Fatalf("LoadBlueprint id mismatch: got %q want %q", bp.ID, blueprints[0].ID)
+	}
+}
+
+// Verifies that a filesystem repoRoot overrides the fallback (preserving
+// the escape hatch for users who drop a custom blueprint YAML into their
+// checkout).
+func TestFilesystemWinsOverFallback(t *testing.T) {
+	realRoot := findRepoRoot(t)
+
+	tmp := t.TempDir()
+	opsDir := filepath.Join(tmp, "templates", "operations")
+	if err := os.MkdirAll(opsDir, 0o755); err != nil {
+		t.Fatalf("mkdirall: %v", err)
+	}
+
+	// Register the real tree as the fallback; if filesystem precedence
+	// is broken the loader will pick up its 6 blueprints via the embed
+	// path and this test will fail with >0 entries.
+	prev := fallbackFS
+	SetFallbackFS(os.DirFS(realRoot))
+	t.Cleanup(func() { SetFallbackFS(prev) })
+
+	blueprints, err := ListBlueprints(tmp)
+	if err != nil {
+		t.Fatalf("ListBlueprints(tmp): %v", err)
+	}
+	if len(blueprints) != 0 {
+		t.Fatalf("expected 0 blueprints from empty on-disk tree, got %d — filesystem precedence broken", len(blueprints))
+	}
+}
+
+// Covers the edge case where the repoRoot tree is missing templates/ but
+// the fallback provides it. Ensures readTemplateFile / listTemplateDirs
+// fall through rather than surfacing the ENOENT from the filesystem leg.
+func TestFallbackFromIncompleteRepoRoot(t *testing.T) {
+	realRoot := findRepoRoot(t)
+	prev := fallbackFS
+	SetFallbackFS(os.DirFS(realRoot))
+	t.Cleanup(func() { SetFallbackFS(prev) })
+
+	tmp := t.TempDir() // no templates/ directory at all
+
+	blueprints, err := ListBlueprints(tmp)
+	if err != nil {
+		t.Fatalf("ListBlueprints(tmp): %v", err)
+	}
+	if len(blueprints) == 0 {
+		t.Fatalf("expected fallback to supply blueprints when repoRoot lacks templates/")
+	}
+}
+
+// Sanity: readTemplateFile returns fs.ErrNotExist when neither
+// filesystem nor fallback has the file.
+func TestReadTemplateFileMissingEverywhere(t *testing.T) {
+	prev := fallbackFS
+	SetFallbackFS(fstest.MapFS{}) // empty FS — registered but has nothing.
+	t.Cleanup(func() { SetFallbackFS(prev) })
+
+	_, err := readTemplateFile(t.TempDir(), "templates/operations/nope/blueprint.yaml")
+	if err == nil {
+		t.Fatalf("expected error when file is absent everywhere")
+	}
+	if !strings.Contains(err.Error(), "not exist") && !strings.Contains(err.Error(), "no such") {
+		t.Fatalf("expected not-exist error, got %v", err)
+	}
+}

--- a/internal/operations/loader.go
+++ b/internal/operations/loader.go
@@ -2,8 +2,7 @@ package operations
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -18,8 +17,8 @@ func LoadBlueprint(repoRoot, templateID string) (Blueprint, error) {
 	if templateID == "" {
 		return Blueprint{}, fmt.Errorf("template id required")
 	}
-	path := filepath.Join(repoRoot, "templates", "operations", templateID, "blueprint.yaml")
-	raw, err := os.ReadFile(path)
+	rel := path.Join("templates", "operations", templateID, "blueprint.yaml")
+	raw, err := readTemplateFile(repoRoot, rel)
 	if err != nil {
 		return Blueprint{}, err
 	}
@@ -35,20 +34,13 @@ func LoadBlueprint(repoRoot, templateID string) (Blueprint, error) {
 }
 
 func ListBlueprints(repoRoot string) ([]Blueprint, error) {
-	root := filepath.Join(repoRoot, "templates", "operations")
-	entries, err := os.ReadDir(root)
+	names, err := listTemplateDirs(repoRoot, path.Join("templates", "operations"))
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
-	blueprints := make([]Blueprint, 0, len(entries))
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		blueprint, err := LoadBlueprint(repoRoot, entry.Name())
+	blueprints := make([]Blueprint, 0, len(names))
+	for _, name := range names {
+		blueprint, err := LoadBlueprint(repoRoot, name)
 		if err != nil {
 			return nil, err
 		}

--- a/templates_embed.go
+++ b/templates_embed.go
@@ -1,0 +1,35 @@
+package wuphf
+
+import (
+	"embed"
+	"io/fs"
+
+	"github.com/nex-crm/wuphf/internal/operations"
+)
+
+// templatesBundle ships the blueprint YAML tree with the binary so that
+// installs without a repo checkout (`npx wuphf`, `curl | bash`) still see
+// the full operations and employee blueprint catalog. Without this embed
+// the web onboarding wizard silently degrades to "From scratch" only,
+// because resolveTemplatesRepoRoot walks the filesystem looking for a
+// templates/ directory and returns "" when run outside a checkout.
+//
+//go:embed all:templates/operations all:templates/employees
+var templatesBundle embed.FS
+
+// TemplatesFS returns the embedded templates FS rooted so callers see
+// paths like "templates/operations/<id>/blueprint.yaml" — the same layout
+// as the on-disk tree. Returns ok=false if the embed is empty (e.g. a
+// partial checkout that excludes templates/).
+func TemplatesFS() (fs.FS, bool) {
+	if _, err := fs.Stat(templatesBundle, "templates/operations"); err != nil {
+		return nil, false
+	}
+	return templatesBundle, true
+}
+
+func init() {
+	if tfs, ok := TemplatesFS(); ok {
+		operations.SetFallbackFS(tfs)
+	}
+}

--- a/templates_embed_test.go
+++ b/templates_embed_test.go
@@ -1,0 +1,36 @@
+package wuphf_test
+
+import (
+	"testing"
+
+	wuphf "github.com/nex-crm/wuphf"
+	"github.com/nex-crm/wuphf/internal/operations"
+)
+
+// Verifies the //go:embed all:templates/... directive in templates_embed.go
+// actually pulls the blueprint YAML tree into the binary, and that the
+// init() wired it into the operations loader's fallback FS. Without this
+// test, a future refactor that drops the embed or skips the init wiring
+// would silently revert the "`npx wuphf` shows only From scratch" bug.
+func TestTemplatesEmbedWiresOperationsFallback(t *testing.T) {
+	// Minimal guard against the embed going empty (e.g. someone builds
+	// with a broken working tree).
+	tfs, ok := wuphf.TemplatesFS()
+	if !ok {
+		t.Fatal("TemplatesFS() returned ok=false — embed is empty?")
+	}
+	if tfs == nil {
+		t.Fatal("TemplatesFS() returned nil fs when ok=true")
+	}
+
+	// Passing "" as repoRoot forces ListBlueprints to go through the
+	// fallback FS. If the init in templates_embed.go didn't run (or the
+	// embed is missing), this returns 0 blueprints.
+	blueprints, err := operations.ListBlueprints("")
+	if err != nil {
+		t.Fatalf("ListBlueprints(\"\"): %v", err)
+	}
+	if len(blueprints) == 0 {
+		t.Fatal("expected shipped blueprints from embed, got 0 — embed or init wiring broken")
+	}
+}

--- a/web/e2e/tests/wizard.spec.ts
+++ b/web/e2e/tests/wizard.spec.ts
@@ -77,4 +77,39 @@ test.describe('wuphf onboarding wizard smoke', () => {
       `Uncaught errors advancing wizard:\n  ${errors.join('\n  ')}`,
     ).toHaveLength(0);
   });
+
+  test('blueprint picker shows shipped preset teams (not just "From scratch")', async ({
+    page,
+  }) => {
+    // Regression guard for the bug where blueprint YAMLs were read from
+    // the filesystem only — `npx wuphf` / `curl | bash` users saw the
+    // hardcoded "From scratch" card as their only option.
+    //
+    // With embedded templates wired in (internal/operations fallback FS +
+    // root templates_embed.go), the backend's GET /onboarding/blueprints
+    // MUST return ≥1 preset regardless of cwd. The wizard renders one
+    // `.template-card` per blueprint plus a hardcoded "From scratch"
+    // card — so we expect strictly more than 1 card and at least one
+    // card whose name differs from "From scratch".
+    await page.goto('/');
+    await waitForReactMount(page);
+
+    await expect(page.locator('.wizard-step').first()).toBeVisible({ timeout: 10_000 });
+    await page.locator('.wizard-step button.btn-primary').first().click();
+
+    // Wait for the template grid (only rendered once blueprint fetch resolves).
+    await expect(page.locator('.template-grid')).toBeVisible({ timeout: 10_000 });
+
+    const cards = page.locator('.template-card');
+    await expect(cards).not.toHaveCount(1, { timeout: 10_000 });
+
+    // "From scratch" is always present; at least one card must have a
+    // different name (i.e. a shipped preset was loaded).
+    const names = await page.locator('.template-card-name').allTextContents();
+    const presets = names.filter((n) => n.trim() !== 'From scratch');
+    expect(
+      presets.length,
+      `expected ≥1 preset blueprint card, got names: ${JSON.stringify(names)}`,
+    ).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary

- `GET /onboarding/blueprints` silently returned `[]` for any install run outside a checkout (`npx wuphf`, `curl | bash`), because `resolveTemplatesRepoRoot` walks up from cwd looking for `templates/operations/` and returns empty when there's no repo. The wizard's front-end swallows that (`Wizard.tsx` `.catch(() => {})`), so users saw only the hardcoded "From scratch" card — the five shipped presets (bookkeeping, youtube-factory, niche-crm, etc.) were effectively invisible to every non-developer install.
- Embed `templates/operations/` + `templates/employees/` into the binary (`//go:embed`) and teach the `internal/operations` loaders to transparently fall back to the embed when filesystem lookup fails or `repoRoot` is empty. Filesystem wins on conflict, preserving the override path for users who drop a custom blueprint YAML into their checkout.

## Changes

- `templates_embed.go` (new, root) — `//go:embed all:templates/operations all:templates/employees`, wires `operations.SetFallbackFS` in `init()`.
- `internal/operations/fs.go` (new) — shared `readTemplateFile` / `listTemplateDirs` with filesystem-first, embed-fallback semantics.
- `internal/operations/{loader,employee_loader}.go` — routed through the new helpers.
- `internal/onboarding/handlers.go` — dropped the `if repoRoot != ""` guard so the loader's embed fallback runs when the FS walk comes up empty.
- `.github/workflows/ci.yml` — fresh-install phase now launches wuphf from `mktemp -d` (not the checkout root), otherwise `resolveTemplatesRepoRoot` finds `templates/` in the checkout and the embed path is never exercised.

## Tests

- `internal/operations/fs_test.go` — covers filesystem precedence, fallback when repoRoot is empty, fallback when repoRoot lacks `templates/`, and error surfacing when file is missing everywhere.
- `templates_embed_test.go` — end-to-end smoke that the actual `//go:embed` + `init()` wiring produces a non-empty blueprint list via `ListBlueprints("")` — guards against a future refactor that silently drops the embed.
- `web/e2e/tests/wizard.spec.ts` — new Playwright test asserting `.template-card` count > 1 and ≥1 card name other than "From scratch". CI runs this against a wuphf booted from `/tmp` so it fails if the embed path breaks.

## Test plan

- [ ] `go test ./...` green locally
- [ ] CI: `web-e2e` passes the new `wizard.spec.ts` assertion (wuphf launched from `mktemp -d`, blueprint picker shows ≥1 preset)
- [ ] Manual smoke: `npx wuphf` from a random cwd (no `templates/` on path) → wizard templates step shows 6 preset cards + "From scratch"

🤖 Generated with [Claude Code](https://claude.com/claude-code)