### PR TITLE
feat(nex): tag nex-cli subprocess calls with NEX_CLIENT=wuphf/<version>

### DIFF
--- a/internal/nex/cli.go
+++ b/internal/nex/cli.go
@@ -15,10 +15,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/nex-crm/wuphf/internal/buildinfo"
 	"github.com/nex-crm/wuphf/internal/config"
 )
 
@@ -95,6 +97,7 @@ func Run(ctx context.Context, args ...string) (string, error) {
 		defer cancel()
 	}
 	cmd := exec.CommandContext(ctx, bin, args...)
+	cmd.Env = appendClientEnv(os.Environ())
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -131,4 +134,23 @@ func Recall(ctx context.Context, query string) (string, error) {
 		return "", fmt.Errorf("recall: query is required")
 	}
 	return Run(ctx, "recall", query)
+}
+
+// NexClientEnvVar is the env var nex-cli (and downstream Nex services)
+// can read to attribute a call to the client that initiated it. Exposed
+// so server-side tooling doesn't have to guess the name.
+const NexClientEnvVar = "NEX_CLIENT"
+
+// appendClientEnv adds NEX_CLIENT=wuphf/<version> unless it's already
+// set in env. Respecting an existing value lets integrators nest clients
+// (e.g. a wrapper that sets NEX_CLIENT=myapp/wuphf/<version>) without us
+// stomping on it.
+func appendClientEnv(env []string) []string {
+	prefix := NexClientEnvVar + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return env
+		}
+	}
+	return append(env, prefix+"wuphf/"+buildinfo.Current().Version)
 }

--- a/internal/nex/client_env_test.go
+++ b/internal/nex/client_env_test.go
@@ -70,3 +70,22 @@ func TestRun_PropagatesNexClientToSubprocess(t *testing.T) {
 		t.Fatalf("expected NEX_CLIENT=wuphf/<version>, got %q", got)
 	}
 }
+
+// Companion to the propagation test: when an outer wrapper already set
+// NEX_CLIENT (e.g. `NEX_CLIENT=myapp/1.0 wuphf ...`), Run() must not stomp
+// it on the way through to nex-cli. Unit coverage on appendClientEnv alone
+// wouldn't catch a refactor that ignores the env-override path.
+func TestRun_PreservesExistingNexClientEndToEnd(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	t.Setenv("WUPHF_NO_NEX", "")
+	t.Setenv(NexClientEnvVar, "myapp/1.0")
+	writeFakeNexCLI(t, dir, "nex-cli", `printf '%s' "$NEX_CLIENT"`)
+
+	got, err := Run(context.Background(), "whatever")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got != "myapp/1.0" {
+		t.Fatalf("expected preserved NEX_CLIENT=myapp/1.0, got %q", got)
+	}
+}

--- a/internal/nex/client_env_test.go
+++ b/internal/nex/client_env_test.go
@@ -1,0 +1,71 @@
+package nex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/buildinfo"
+)
+
+func TestAppendClientEnvSetsDefault(t *testing.T) {
+	env := appendClientEnv([]string{"PATH=/usr/bin", "HOME=/home/user"})
+	want := NexClientEnvVar + "=wuphf/" + buildinfo.Current().Version
+	if !contains(env, want) {
+		t.Fatalf("expected %q in env, got %v", want, env)
+	}
+	// Original env entries preserved.
+	if !contains(env, "PATH=/usr/bin") || !contains(env, "HOME=/home/user") {
+		t.Fatalf("existing env entries were dropped: %v", env)
+	}
+}
+
+func TestAppendClientEnvRespectsExistingValue(t *testing.T) {
+	// A wrapper may have already declared itself as the client — don't
+	// stomp on that. This lets integrators build chains like
+	// NEX_CLIENT=myapp/wuphf/<version> without us clobbering.
+	env := appendClientEnv([]string{NexClientEnvVar + "=myapp/1.0", "PATH=/usr/bin"})
+	if count := countPrefix(env, NexClientEnvVar+"="); count != 1 {
+		t.Fatalf("expected exactly one %s entry, got %d: %v", NexClientEnvVar, count, env)
+	}
+	if !contains(env, NexClientEnvVar+"=myapp/1.0") {
+		t.Fatalf("existing NEX_CLIENT value was overwritten: %v", env)
+	}
+}
+
+func contains(env []string, want string) bool {
+	for _, e := range env {
+		if e == want {
+			return true
+		}
+	}
+	return false
+}
+
+func countPrefix(env []string, prefix string) int {
+	n := 0
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			n++
+		}
+	}
+	return n
+}
+
+// End-to-end: asserts Run() actually propagates NEX_CLIENT to the
+// subprocess. Without this, a refactor that drops the cmd.Env line could
+// silently ship a nex-cli invocation with no client tag.
+func TestRun_PropagatesNexClientToSubprocess(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	t.Setenv("WUPHF_NO_NEX", "")
+	// The fake nex-cli writes its $NEX_CLIENT to stdout; Run() trims and
+	// returns it.
+	writeFakeNexCLI(t, dir, "nex-cli", `printf '%s' "$NEX_CLIENT"`)
+
+	got, err := Run(nil, "whatever")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.HasPrefix(got, "wuphf/") {
+		t.Fatalf("expected NEX_CLIENT=wuphf/<version>, got %q", got)
+	}
+}

--- a/internal/nex/client_env_test.go
+++ b/internal/nex/client_env_test.go
@@ -1,6 +1,7 @@
 package nex
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -61,7 +62,7 @@ func TestRun_PropagatesNexClientToSubprocess(t *testing.T) {
 	// returns it.
 	writeFakeNexCLI(t, dir, "nex-cli", `printf '%s' "$NEX_CLIENT"`)
 
-	got, err := Run(nil, "whatever")
+	got, err := Run(context.Background(), "whatever")
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}


### PR DESCRIPTION
## Summary

- Today \`internal/nex.Run\` shells out to \`nex-cli\` with no client identifier, so any server-side metrics nex-cli reports get attributed to "nex-cli" / the user's account with no way to break out what fraction of calls were actually driven by wuphf.
- Sets \`NEX_CLIENT=wuphf/<buildinfo.Version>\` on every \`Run()\` invocation. Respects an existing \`NEX_CLIENT\` in the environment so integrators can chain (e.g. \`NEX_CLIENT=myapp/wuphf/<version>\`) without us overwriting.

## Notes

- Zero coupling: nex-cli can start honoring \`NEX_CLIENT\` whenever the server side is ready; until then this is a no-op.
- Exposed \`nex.NexClientEnvVar\` constant so server-side tooling doesn't have to duplicate the name.

## Tests

- \`TestAppendClientEnvSetsDefault\` — fresh env gets the tag
- \`TestAppendClientEnvRespectsExistingValue\` — existing \`NEX_CLIENT\` is preserved, exactly one entry
- \`TestRun_PropagatesNexClientToSubprocess\` — end-to-end: a fake nex-cli echoes \`\$NEX_CLIENT\` and we assert the subprocess actually received the \`wuphf/...\` prefix. Guards against a future refactor dropping the \`cmd.Env\` line.

## Test plan

- [ ] \`go test ./internal/nex/...\` green
- [ ] Server-side: once nex-cli surfaces metrics grouped by \`NEX_CLIENT\`, confirm wuphf-driven calls show up as a distinct dimension

🤖 Generated with [Claude Code](https://claude.com/claude-code)