### PR TITLE
test(e2e): tighten blueprint-picker guard + fix stale comment

### DIFF
--- a/internal/operations/fs.go
+++ b/internal/operations/fs.go
@@ -51,9 +51,11 @@ func readTemplateFile(repoRoot, rel string) ([]byte, error) {
 
 // listTemplateDirs returns the subdirectory names of rel (a
 // slash-separated path like "templates/operations"), preferring the
-// filesystem at repoRoot and falling back to the embedded FS. Returns a
-// nil slice when neither location holds the directory — the callers treat
-// that as "no blueprints", consistent with the pre-embed behavior.
+// filesystem at repoRoot and falling back to the embedded FS. Returns
+// (nil, nil) when neither location holds the directory — callers treat
+// that as "no blueprints", consistent with the pre-embed behavior. When
+// the directory exists but contains no subdirectories, returns an empty
+// (non-nil) slice.
 func listTemplateDirs(repoRoot, rel string) ([]string, error) {
 	if repoRoot != "" {
 		root := filepath.Join(repoRoot, rel)

--- a/web/e2e/tests/wizard.spec.ts
+++ b/web/e2e/tests/wizard.spec.ts
@@ -100,8 +100,11 @@ test.describe('wuphf onboarding wizard smoke', () => {
     // Wait for the template grid (only rendered once blueprint fetch resolves).
     await expect(page.locator('.template-grid')).toBeVisible({ timeout: 10_000 });
 
+    // `not.toHaveCount(1)` would pass for 0 cards too, masking a total
+    // render failure. Wait for at least two cards explicitly — the
+    // pre-embed bug rendered exactly one ("From scratch").
     const cards = page.locator('.template-card');
-    await expect(cards).not.toHaveCount(1, { timeout: 10_000 });
+    await expect(cards.nth(1)).toBeVisible({ timeout: 10_000 });
 
     // "From scratch" is always present; at least one card must have a
     // different name (i.e. a shipped preset was loaded).


### PR DESCRIPTION
## Summary
Follow-ups to #125 flagged in a staff review:

- **`web/e2e/tests/wizard.spec.ts`** — `expect(cards).not.toHaveCount(1)` also passes when zero cards render, which would silently mask a total wizard breakage. Replaced with `expect(cards.nth(1)).toBeVisible()` so the assertion requires ≥2 cards (the pre-embed bug rendered exactly one: "From scratch").
- **`internal/operations/fs.go`** — doc on `listTemplateDirs` said it "returns a nil slice when neither location holds the directory", but `filterDirNames` actually returns an allocated empty slice when the directory exists with no subdirectories. Clarified both cases in the comment; behavior unchanged.

## Test plan
- [x] `go test ./internal/operations/...` — green.
- [x] `go build ./...` — clean.
- [ ] CI web-e2e stage exercises the updated Playwright assertion against a fresh-install wuphf launched from `$(mktemp -d)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)