### PR TITLE
fix(team): bump CEO to 30 turns, specialists to 15

### DIFF
--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -234,9 +234,9 @@ func (l *Launcher) headlessClaudeModel(slug string) string {
 // get a smaller budget since they focus on a single task.
 func (l *Launcher) headlessClaudeMaxTurns(slug string) string {
 	if slug == l.officeLeadSlug() {
-		return "20"
+		return "30"
 	}
-	return "10"
+	return "15"
 }
 
 func (l *Launcher) buildHeadlessClaudeEnv(slug string) []string {


### PR DESCRIPTION
Specialists were still hitting the cap on multi-step tool flows. CEO needs more headroom for routing + task orchestration + Nex lookups.

- CEO: 20 → 30
- Specialists: 10 → 15