### PR TITLE
fix(onboarding): let wuphf launch without claude/codex installed

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -34,6 +34,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/nex"
+	"github.com/nex-crm/wuphf/internal/onboarding"
 	"github.com/nex-crm/wuphf/internal/operations"
 	"github.com/nex-crm/wuphf/internal/provider"
 	"github.com/nex-crm/wuphf/internal/setup"
@@ -174,6 +175,18 @@ func NewLauncher(packSlug string) (*Launcher, error) {
 		headlessQueues:      make(map[string][]headlessCodexTurn),
 		notifyLastDelivered: make(map[string]time.Time),
 	}, nil
+}
+
+// isOnboarded reports whether the user has completed the onboarding wizard.
+// Any error loading state is treated as not-onboarded so a corrupt or
+// missing ~/.wuphf/onboarded.json still lets the web UI boot into the
+// wizard rather than failing at preflight.
+func isOnboarded() bool {
+	s, err := onboarding.Load()
+	if err != nil || s == nil {
+		return false
+	}
+	return s.Onboarded()
 }
 
 // Preflight checks that required tools are available.
@@ -3755,7 +3768,20 @@ func (l *Launcher) getAgentName(slug string) string {
 // ═══════════════════════════════════════════════════════════════
 
 // PreflightWeb checks only for claude (no tmux requirement for web mode).
+//
+// When the user has not yet completed onboarding we deliberately skip the
+// runtime-binary check: the whole point of the web-mode onboarding wizard is
+// to pick a runtime. Hard-failing here would make the binary unlaunchable
+// until the user already had the CLI they were trying to pick. A missing
+// runtime is still caught at first-dispatch time with a clear message once
+// onboarding has committed a choice to ~/.wuphf/config.json.
 func (l *Launcher) PreflightWeb() error {
+	if !isOnboarded() {
+		if _, _, note := checkGHCapability(); note != "" {
+			fmt.Fprintf(os.Stderr, "note: %s\n", note)
+		}
+		return nil
+	}
 	if l.usesCodexRuntime() {
 		if _, err := exec.LookPath("codex"); err != nil {
 			return fmt.Errorf("codex not found. Install Codex CLI and run `codex login`")

--- a/internal/team/preflight_onboarding_test.go
+++ b/internal/team/preflight_onboarding_test.go
@@ -1,0 +1,55 @@
+package team
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/onboarding"
+)
+
+// TestPreflightWebSkipsProviderCheckWhenNotOnboarded verifies that the web
+// preflight does not fail on a missing claude/codex binary when the user
+// has not yet completed onboarding. This is the whole reason `wuphf` should
+// be launchable on a clean machine — the onboarding wizard is what installs
+// and selects the runtime, so preflight cannot demand it first.
+func TestPreflightWebSkipsProviderCheckWhenNotOnboarded(t *testing.T) {
+	// Isolate onboarding state to a fresh per-test runtime home so we do
+	// not touch the developer's real ~/.wuphf/onboarded.json.
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+
+	l := &Launcher{provider: "claude-code"}
+
+	if err := l.PreflightWeb(); err != nil {
+		t.Fatalf("PreflightWeb on fresh install: got error %v, want nil", err)
+	}
+}
+
+// TestPreflightWebRequiresProviderWhenOnboarded verifies that once the user
+// has committed a runtime choice, the binary check is enforced again — this
+// catches the "you picked claude-code but never installed it" case with a
+// clear message instead of mysteriously erroring mid-turn.
+func TestPreflightWebRequiresProviderWhenOnboarded(t *testing.T) {
+	if _, err := exec.LookPath("claude"); err == nil {
+		t.Skip("claude is on PATH; cannot test the missing-binary branch")
+	}
+
+	home := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+
+	// Mark onboarding complete. We go through Save so state is written in
+	// the same format Load() expects.
+	s, err := onboarding.Load()
+	if err != nil {
+		t.Fatalf("load onboarding state: %v", err)
+	}
+	s.CompletedAt = "2026-04-17T00:00:00Z"
+	if err := onboarding.Save(s); err != nil {
+		t.Fatalf("save onboarding state: %v", err)
+	}
+
+	l := &Launcher{provider: "claude-code"}
+	err = l.PreflightWeb()
+	if err == nil {
+		t.Fatalf("PreflightWeb after onboarding with no claude: got nil, want error")
+	}
+}

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -45,6 +45,19 @@ const STEP_ORDER: readonly WizardStep[] = [
 
 const RUNTIME_OPTIONS = ['Claude Code', 'Codex', 'Cursor', 'Windsurf', 'Other'] as const
 
+// Map UI runtime labels to the provider enum the broker validates on POST /config.
+// Labels without a backend equivalent return null and are skipped on persist —
+// the broker keeps its existing default (claude-code) until the user picks a
+// supported runtime. Keeping this local to the wizard so the UI can list
+// aspirational runtimes without lying about what will actually run.
+const RUNTIME_LABEL_TO_PROVIDER: Record<string, 'claude-code' | 'codex' | null> = {
+  'Claude Code': 'claude-code',
+  Codex: 'codex',
+  Cursor: null,
+  Windsurf: null,
+  Other: null,
+}
+
 const API_KEY_FIELDS = [
   { key: 'ANTHROPIC_API_KEY', label: 'Anthropic', hint: 'Powers Claude-based agents' },
   { key: 'OPENAI_API_KEY', label: 'OpenAI', hint: 'Powers GPT-based agents' },
@@ -742,10 +755,15 @@ export function Wizard({ onComplete }: WizardProps) {
     async (skipTask: boolean) => {
       setSubmitting(true)
       try {
-        // Persist memory backend selection first so the broker reads it on
-        // next launch. Fire-and-forget — a failure here should not block
-        // completing onboarding.
+        // Persist memory backend + LLM provider selection first so the broker
+        // reads them on next launch. Fire-and-forget — a failure here should
+        // not block completing onboarding. Unsupported runtime labels (Cursor,
+        // Windsurf, Other) are skipped; only claude-code and codex are wired.
         post('/config', { memory_backend: memoryBackend }).catch(() => {})
+        const llmProvider = RUNTIME_LABEL_TO_PROVIDER[runtime]
+        if (llmProvider) {
+          post('/config', { llm_provider: llmProvider }).catch(() => {})
+        }
 
         // Post the onboarding payload. Body shape is historical; the broker
         // currently only acts on {task, skip_task} but the extra fields are


### PR DESCRIPTION
## Summary
- `PreflightWeb` no longer hard-fails on missing `claude`/`codex` when the user hasn't completed onboarding — the web UI now boots into the runtime-picker wizard on a clean machine instead of erroring out before the server starts
- Wizard now persists the selected runtime via `POST /config` on finish, mapping display labels (`Claude Code`, `Codex`) to the broker's enum (`claude-code`, `codex`); unsupported aspirational labels (Cursor / Windsurf / Other) are skipped
- Tmux `Preflight` is intentionally left strict — `--tui` is a power-user flag and its users already have a runtime

## Why
PR #56 shipped the wizard UI but the preflight block was never relaxed, so the binary still refused to start without claude on PATH. That defeats the whole point of an onboarding runtime picker.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/team/ ./internal/onboarding/ ./internal/config/`
- [x] New `TestPreflightWebSkipsProviderCheckWhenNotOnboarded` + `TestPreflightWebRequiresProviderWhenOnboarded`
- [x] `npm run typecheck` in `web/`
- [ ] Manual: launch `wuphf` with `claude` and `codex` both off PATH → wizard renders, pick Codex → `~/.wuphf/config.json` has `llm_provider: codex`, next launch preflights clean