### PR TITLE
feat(avatars): procedurally compose unique avatars for unknown agent slugs

### DIFF
--- a/cmd/wuphf/avatars_procedural.go
+++ b/cmd/wuphf/avatars_procedural.go
@@ -1,0 +1,338 @@
+package main
+
+import "hash/fnv"
+
+// Procedural pixel-art avatar builder for unknown agent slugs.
+// Mirrors web/src/lib/proceduralAvatar.ts — the layer set, color pools, and
+// hash strategy match so the same slug looks identical in the CLI and browser.
+//
+// Layers are stamped in order over the shared body base:
+//   1. hair (rows 0-2)
+//   2. headwear (rows 0-2, overrides hair under a hat)
+//   3. facial feature (rows 3-5)
+//   4. neck accessory (rows 6-9)
+
+const (
+	proceduralRows = 14
+	proceduralCols = 14
+	layerNoop      = -1 // sentinel: leave the underlying pixel untouched
+)
+
+// baseBody is the always-drawn skeleton — face, torso, arms. No hair.
+var baseBody = pixelSprite{
+	{0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0},
+	{0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 1, 0, 0, 0},
+	{0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 1, 0, 0, 0},
+	{0, 0, 0, 1, 2, 1, 2, 2, 1, 2, 1, 0, 0, 0},
+	{0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 1, 0, 0, 0},
+	{0, 0, 0, 0, 1, 2, 2, 2, 2, 1, 0, 0, 0, 0},
+	{0, 0, 1, 3, 3, 3, 3, 3, 3, 3, 3, 1, 0, 0},
+	{0, 1, 2, 3, 3, 3, 3, 3, 3, 3, 3, 2, 1, 0},
+	{0, 0, 2, 2, 3, 3, 3, 3, 3, 3, 2, 2, 0, 0},
+	{0, 0, 1, 2, 1, 3, 3, 3, 3, 1, 2, 1, 0, 0},
+	{0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0},
+	{0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0},
+	{0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0},
+	{0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0},
+}
+
+type layerBuilder func() [][]int
+
+func emptyLayer() [][]int {
+	layer := make([][]int, proceduralRows)
+	for r := range layer {
+		layer[r] = make([]int, proceduralCols)
+		for c := range layer[r] {
+			layer[r][c] = layerNoop
+		}
+	}
+	return layer
+}
+
+// ── Hair ───────────────────────────────────────────────────────────────
+
+func hairClassic() [][]int {
+	l := emptyLayer()
+	for c := 4; c <= 9; c++ {
+		l[1][c] = pxHair
+	}
+	return l
+}
+
+func hairSpiky() [][]int {
+	l := emptyLayer()
+	l[0][4] = pxHair
+	l[0][6] = pxHair
+	l[0][8] = pxHair
+	for c := 4; c <= 9; c++ {
+		l[1][c] = pxHair
+	}
+	return l
+}
+
+func hairSidePart() [][]int {
+	l := emptyLayer()
+	for c := 4; c <= 9; c++ {
+		l[1][c] = pxHair
+	}
+	l[1][7] = pxSkin
+	return l
+}
+
+func hairBald() [][]int { return emptyLayer() }
+
+func hairAfro() [][]int {
+	l := emptyLayer()
+	for c := 3; c <= 10; c++ {
+		l[0][c] = pxHair
+	}
+	for c := 2; c <= 11; c++ {
+		l[1][c] = pxHair
+	}
+	l[2][3] = pxHair
+	l[2][10] = pxHair
+	return l
+}
+
+func hairMohawk() [][]int {
+	l := emptyLayer()
+	l[0][6] = pxHair
+	l[0][7] = pxHair
+	l[1][6] = pxHair
+	l[1][7] = pxHair
+	return l
+}
+
+func hairLongSides() [][]int {
+	l := emptyLayer()
+	for c := 4; c <= 9; c++ {
+		l[1][c] = pxHair
+	}
+	l[2][3] = pxHair
+	l[2][10] = pxHair
+	l[3][3] = pxHair
+	l[3][10] = pxHair
+	return l
+}
+
+var hairStyles = []layerBuilder{
+	hairClassic, hairSpiky, hairSidePart, hairBald,
+	hairAfro, hairMohawk, hairLongSides,
+}
+
+// ── Headwear ───────────────────────────────────────────────────────────
+
+func headwearNone() [][]int { return emptyLayer() }
+
+func headwearCap() [][]int {
+	l := emptyLayer()
+	for c := 3; c <= 10; c++ {
+		l[0][c] = pxProp
+		l[1][c] = pxProp
+	}
+	for c := 2; c <= 11; c++ {
+		l[2][c] = pxLine
+	}
+	return l
+}
+
+func headwearHeadband() [][]int {
+	l := emptyLayer()
+	for c := 4; c <= 9; c++ {
+		l[2][c] = pxAccent
+	}
+	return l
+}
+
+func headwearBeanie() [][]int {
+	l := emptyLayer()
+	for c := 4; c <= 9; c++ {
+		l[0][c] = pxAccent
+	}
+	for c := 3; c <= 10; c++ {
+		l[1][c] = pxAccent
+	}
+	return l
+}
+
+func headwearVisor() [][]int {
+	l := emptyLayer()
+	for c := 2; c <= 11; c++ {
+		l[2][c] = pxProp
+	}
+	return l
+}
+
+// Weight "none" more heavily so most agents aren't wearing hats.
+var headwearStyles = []layerBuilder{
+	headwearNone, headwearNone,
+	headwearCap, headwearHeadband, headwearBeanie, headwearVisor,
+}
+
+// ── Facial feature ─────────────────────────────────────────────────────
+
+func faceNone() [][]int { return emptyLayer() }
+
+func faceGlasses() [][]int {
+	l := emptyLayer()
+	l[3][4] = pxLine
+	l[3][5] = pxProp
+	l[3][6] = pxLine
+	l[3][7] = pxLine
+	l[3][8] = pxProp
+	l[3][9] = pxLine
+	return l
+}
+
+func faceMustache() [][]int {
+	l := emptyLayer()
+	for c := 5; c <= 8; c++ {
+		l[5][c] = pxHair
+	}
+	return l
+}
+
+func faceBeard() [][]int {
+	l := emptyLayer()
+	l[4][4] = pxHair
+	l[4][9] = pxHair
+	for c := 5; c <= 8; c++ {
+		l[5][c] = pxHair
+	}
+	return l
+}
+
+var faceStyles = []layerBuilder{
+	faceNone, faceNone, faceNone,
+	faceGlasses, faceMustache, faceBeard,
+}
+
+// ── Neck accessory ─────────────────────────────────────────────────────
+
+func neckNone() [][]int { return emptyLayer() }
+
+func neckTie() [][]int {
+	l := emptyLayer()
+	l[6][6] = pxHighlight
+	l[6][7] = pxHighlight
+	l[7][6] = pxHighlight
+	l[7][7] = pxHighlight
+	return l
+}
+
+func neckBadge() [][]int {
+	l := emptyLayer()
+	l[9][4] = pxHighlight
+	return l
+}
+
+var neckStyles = []layerBuilder{neckNone, neckNone, neckTie, neckBadge}
+
+// ── Color pools ────────────────────────────────────────────────────────
+
+var accentPool = []string{
+	"#E8A838", "#58A6FF", "#A371F7", "#3FB950",
+	"#D2A8FF", "#F778BA", "#FFA657", "#79C0FF",
+	"#FF7B72", "#56D4DD", "#FFD866", "#C9D1D9",
+}
+
+var hairPool = [][3]int{
+	{36, 32, 30},
+	{74, 52, 38},
+	{139, 90, 43},
+	{200, 155, 90},
+	{170, 60, 45},
+	{200, 200, 200},
+	{236, 178, 46},
+	{180, 120, 200},
+}
+
+var skinPool = [][3]int{
+	{248, 220, 190},
+	{235, 195, 160},
+	{210, 165, 125},
+	{175, 125, 90},
+	{140, 95, 65},
+	{100, 65, 45},
+}
+
+// ── Hash ───────────────────────────────────────────────────────────────
+
+func proceduralHash(slug string) uint32 {
+	if slug == "" {
+		slug = "unknown"
+	}
+	h := fnv.New32a()
+	h.Write([]byte(slug))
+	return h.Sum32()
+}
+
+// pickIndex mixes the slug hash with a salt so each layer picks independently.
+func pickIndex(hash, salt uint32, modulo int) int {
+	h := hash ^ (salt * 0x9e3779b1)
+	h ^= h >> 16
+	h *= 0x85ebca6b
+	h ^= h >> 13
+	h *= 0xc2b2ae35
+	h ^= h >> 16
+	return int(h % uint32(modulo))
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+// proceduralSpriteForSlug returns a composed sprite for a slug that has no
+// hand-designed mascot. Stable per slug.
+func proceduralSpriteForSlug(slug string) pixelSprite {
+	hash := proceduralHash(slug)
+
+	sprite := cloneSprite(baseBody)
+	layers := [][][]int{
+		hairStyles[pickIndex(hash, 1, len(hairStyles))](),
+		headwearStyles[pickIndex(hash, 2, len(headwearStyles))](),
+		faceStyles[pickIndex(hash, 3, len(faceStyles))](),
+		neckStyles[pickIndex(hash, 4, len(neckStyles))](),
+	}
+	for _, layer := range layers {
+		for r := 0; r < proceduralRows; r++ {
+			for c := 0; c < proceduralCols; c++ {
+				if layer[r][c] != layerNoop {
+					sprite[r][c] = layer[r][c]
+				}
+			}
+		}
+	}
+	return sprite
+}
+
+// proceduralPaletteForSlug returns the per-slug palette (skin, hair, accent
+// all picked independently by hash) for an agent without a mascot entry.
+func proceduralPaletteForSlug(slug string) map[int][3]int {
+	hash := proceduralHash(slug)
+	accentHex := accentPool[pickIndex(hash, 5, len(accentPool))]
+	hair := hairPool[pickIndex(hash, 6, len(hairPool))]
+	skin := skinPool[pickIndex(hash, 7, len(skinPool))]
+	return map[int][3]int{
+		pxLine:      {36, 32, 30},
+		pxSkin:      skin,
+		pxAccent:    parseHexColor(accentHex),
+		pxHair:      hair,
+		pxProp:      {180, 170, 155},
+		pxHighlight: {255, 255, 255},
+	}
+}
+
+// proceduralAccentForSlug returns the hex accent color for a procedural slug,
+// matching the one used inside proceduralPaletteForSlug.
+func proceduralAccentForSlug(slug string) string {
+	hash := proceduralHash(slug)
+	return accentPool[pickIndex(hash, 5, len(accentPool))]
+}
+
+// isProceduralSlug reports true when the slug has no hand-designed mascot.
+func isProceduralSlug(slug string) bool {
+	switch slug {
+	case "ceo", "pm", "fe", "be", "ai", "designer", "cmo", "cro":
+		return false
+	}
+	return true
+}

--- a/cmd/wuphf/avatars_procedural_test.go
+++ b/cmd/wuphf/avatars_procedural_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"testing"
+)
+
+func spriteDigest(s pixelSprite) string {
+	h := sha1.New()
+	for _, row := range s {
+		for _, v := range row {
+			fmt.Fprintf(h, "%d,", v)
+		}
+		fmt.Fprintln(h)
+	}
+	return hex.EncodeToString(h.Sum(nil))[:8]
+}
+
+func TestProceduralSpriteStableAndUnique(t *testing.T) {
+	slugs := []string{
+		"agent-1", "agent-2", "agent-3",
+		"alice", "bob", "carol",
+		"devops-1", "devops-2", "qa-lead",
+		"growth", "sre", "unknown",
+	}
+
+	seen := make(map[string]string)
+	for _, slug := range slugs {
+		a := spriteForSlug(slug, 0)
+		b := spriteForSlug(slug, 0)
+		ad := spriteDigest(a)
+		bd := spriteDigest(b)
+		if ad != bd {
+			t.Errorf("slug %q is not stable across calls: %s vs %s", slug, ad, bd)
+		}
+		if prev, ok := seen[ad]; ok {
+			t.Errorf("slug %q collides with %q on digest %s", slug, prev, ad)
+		}
+		seen[ad] = slug
+	}
+
+	if len(seen) != len(slugs) {
+		t.Errorf("expected %d unique sprites, got %d", len(slugs), len(seen))
+	}
+}
+
+func TestProceduralPaletteHasIndependentChannels(t *testing.T) {
+	// Different slugs should at least sometimes differ in skin, hair, and accent
+	// independently — not all three locked to one dimension.
+	slugs := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+	skins := make(map[[3]int]bool)
+	hairs := make(map[[3]int]bool)
+	accents := make(map[[3]int]bool)
+	for _, slug := range slugs {
+		p := proceduralPaletteForSlug(slug)
+		skins[p[pxSkin]] = true
+		hairs[p[pxHair]] = true
+		accents[p[pxAccent]] = true
+	}
+	if len(skins) < 2 {
+		t.Errorf("expected skin variation across %d slugs, got %d unique", len(slugs), len(skins))
+	}
+	if len(hairs) < 2 {
+		t.Errorf("expected hair variation across %d slugs, got %d unique", len(slugs), len(hairs))
+	}
+	if len(accents) < 2 {
+		t.Errorf("expected accent variation across %d slugs, got %d unique", len(slugs), len(accents))
+	}
+}
+
+func TestKnownSlugsUseHandDesignedSprites(t *testing.T) {
+	for _, slug := range []string{"ceo", "pm", "fe", "be", "ai", "designer", "cmo", "cro"} {
+		if isProceduralSlug(slug) {
+			t.Errorf("slug %q should not be procedural", slug)
+		}
+	}
+	for _, slug := range []string{"custom", "agent-1", "random"} {
+		if !isProceduralSlug(slug) {
+			t.Errorf("slug %q should be procedural", slug)
+		}
+	}
+}

--- a/cmd/wuphf/avatars_wuphf.go
+++ b/cmd/wuphf/avatars_wuphf.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"hash/fnv"
 	"strings"
 )
 
@@ -183,24 +182,6 @@ var spriteCRO = pixelSprite{
 	{0, 0, 0, 1, 1, 0, 0, 0, 0, 5, 5, 5, 0, 0},
 }
 
-// Generic agent — used for dynamically created agents
-var spriteGeneric = pixelSprite{
-	{0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0},
-	{0, 0, 0, 1, 4, 4, 4, 4, 4, 4, 1, 0, 0, 0},
-	{0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 1, 0, 0, 0},
-	{0, 0, 0, 1, 2, 1, 2, 2, 1, 2, 1, 0, 0, 0},
-	{0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 1, 0, 0, 0},
-	{0, 0, 0, 0, 1, 2, 2, 2, 2, 1, 0, 0, 0, 0},
-	{0, 0, 1, 3, 3, 3, 3, 3, 3, 3, 3, 1, 0, 0},
-	{0, 1, 2, 3, 3, 3, 3, 3, 3, 3, 3, 2, 1, 0},
-	{0, 0, 2, 2, 3, 3, 3, 3, 3, 3, 2, 2, 0, 0},
-	{0, 0, 1, 2, 1, 3, 3, 3, 3, 1, 2, 1, 0, 0},
-	{0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0},
-	{0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0},
-	{0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0},
-	{0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0},
-}
-
 // spriteForSlug returns the unique sprite for a known role,
 // or a seeded variation of the generic sprite for dynamic agents.
 // frame alternates 0/1 for animation.
@@ -210,33 +191,27 @@ func spriteForSlug(slug string, frame ...int) pixelSprite {
 		f = frame[0] % 2
 	}
 
-	var base pixelSprite
+	var sprite pixelSprite
 	switch slug {
 	case "ceo":
-		base = spriteCEO
+		sprite = cloneSprite(spriteCEO)
 	case "pm":
-		base = spritePM
+		sprite = cloneSprite(spritePM)
 	case "fe":
-		base = spriteFE
+		sprite = cloneSprite(spriteFE)
 	case "be":
-		base = spriteBE
+		sprite = cloneSprite(spriteBE)
 	case "ai":
-		base = spriteAI
+		sprite = cloneSprite(spriteAI)
 	case "designer":
-		base = spriteDesigner
+		sprite = cloneSprite(spriteDesigner)
 	case "cmo":
-		base = spriteCMO
+		sprite = cloneSprite(spriteCMO)
 	case "cro":
-		base = spriteCRO
+		sprite = cloneSprite(spriteCRO)
 	default:
-		base = spriteGeneric
-	}
-
-	sprite := cloneSprite(base)
-
-	if slug != "ceo" && slug != "pm" && slug != "fe" && slug != "be" &&
-		slug != "ai" && slug != "designer" && slug != "cmo" && slug != "cro" {
-		applyHairVariation(sprite, seedHash(slug))
+		// Unknown slug — compose from modular layers so every agent is unique.
+		sprite = proceduralSpriteForSlug(slug)
 	}
 
 	if f == 1 {
@@ -343,31 +318,6 @@ func animateFrame(sprite pixelSprite, slug string) {
 	}
 }
 
-func seedHash(s string) int {
-	h := fnv.New32a()
-	h.Write([]byte(s))
-	return int(h.Sum32())
-}
-
-func applyHairVariation(sprite pixelSprite, seed int) {
-	switch seed % 4 {
-	case 0: // short crop
-		sprite[0][6] = pxClear
-		sprite[0][7] = pxClear
-	case 1: // wider hair
-		sprite[1][3] = pxHair
-		sprite[1][10] = pxHair
-	case 2: // tall hair
-		if len(sprite) > 0 && len(sprite[0]) >= 10 {
-			sprite[0][5] = pxHair
-			sprite[0][8] = pxHair
-		}
-	default: // asymmetric
-		sprite[0][5] = pxClear
-		sprite[1][4] = pxHair
-	}
-}
-
 func cloneSprite(src pixelSprite) pixelSprite {
 	out := make(pixelSprite, len(src))
 	for i := range src {
@@ -391,6 +341,11 @@ func parseHexColor(hex string) [3]int {
 }
 
 func spritePaletteForSlug(slug string) map[int][3]int {
+	// Unknown slugs get a fully procedural palette (hash picks skin/hair/accent
+	// independently) to match proceduralSpriteForSlug.
+	if isProceduralSlug(slug) {
+		return proceduralPaletteForSlug(slug)
+	}
 	accent := parseHexColor(agentColorMap[slug])
 	if accent == ([3]int{}) {
 		accent = [3]int{88, 166, 255}

--- a/web/src/components/apps/TasksApp.tsx
+++ b/web/src/components/apps/TasksApp.tsx
@@ -4,17 +4,28 @@ import { getOfficeTasks, post, type Task } from '../../api/client'
 import { formatRelativeTime } from '../../lib/format'
 import { TaskDetailModal } from './TaskDetailModal'
 
-const STATUS_ORDER = ['in_progress', 'open', 'review', 'pending', 'blocked', 'done'] as const
+const STATUS_ORDER = ['in_progress', 'open', 'review', 'pending', 'blocked', 'done', 'canceled'] as const
 
 type StatusGroup = typeof STATUS_ORDER[number]
 
 const DND_MIME = 'application/x-wuphf-task-id'
 const HUMAN_SLUG = 'human'
 
+const COLUMN_LABEL: Record<StatusGroup, string> = {
+  in_progress: 'in progress',
+  open: 'open',
+  review: 'review',
+  pending: 'pending',
+  blocked: 'blocked',
+  done: 'done',
+  canceled: "won't do",
+}
+
 function normalizeStatus(raw: string): StatusGroup {
   const s = raw.toLowerCase().replace(/[\s-]+/g, '_')
   if (s === 'completed') return 'done'
   if (s === 'in_review') return 'review'
+  if (s === 'cancelled') return 'canceled'
   if ((STATUS_ORDER as readonly string[]).includes(s)) return s as StatusGroup
   return 'open'
 }
@@ -23,6 +34,7 @@ function statusBadgeClass(status: StatusGroup): string {
   if (status === 'done') return 'badge badge-green'
   if (status === 'in_progress' || status === 'review') return 'badge badge-accent'
   if (status === 'blocked') return 'badge badge-yellow'
+  if (status === 'canceled') return 'badge badge-muted'
   return 'badge badge-accent'
 }
 
@@ -34,10 +46,9 @@ function groupTasks(tasks: Task[]): Record<StatusGroup, Task[]> {
     pending: [],
     blocked: [],
     done: [],
+    canceled: [],
   }
   for (const task of tasks) {
-    const raw = task.status?.toLowerCase().replace(/[\s-]+/g, '_')
-    if (raw === 'canceled' || raw === 'cancelled') continue
     const status = normalizeStatus(task.status)
     groups[status].push(task)
   }
@@ -65,6 +76,8 @@ function buildMoveBody(task: Task, toStatus: StatusGroup): Record<string, string
       return { ...base, action: 'complete' }
     case 'blocked':
       return { ...base, action: 'block' }
+    case 'canceled':
+      return { ...base, action: 'cancel' }
     case 'pending':
       // No direct "pending" action in the broker — punted.
       return null
@@ -183,9 +196,13 @@ export function TasksApp() {
       <div className="task-board">
         {STATUS_ORDER.map((status) => {
           const column = grouped[status]
-          // Hide empty pending/blocked columns only when nothing is being dragged.
-          // While dragging, keep all 6 columns visible as drop targets.
-          if (!isDragging && column.length === 0 && (status === 'pending' || status === 'blocked')) {
+          // Hide empty pending/blocked/canceled columns only when nothing is being dragged.
+          // While dragging, keep all columns visible as drop targets.
+          if (
+            !isDragging &&
+            column.length === 0 &&
+            (status === 'pending' || status === 'blocked' || status === 'canceled')
+          ) {
             return null
           }
           const columnClass =
@@ -199,7 +216,7 @@ export function TasksApp() {
               onDrop={handleColumnDrop(status)}
             >
               <div className="task-column-header">
-                <span>{status.replace(/_/g, ' ')}</span>
+                <span>{COLUMN_LABEL[status]}</span>
                 <span className="task-column-count">{column.length}</span>
               </div>
               {column.map((task) => (
@@ -266,7 +283,7 @@ function TaskCard({ task, isDragging, onDragStart, onDragEnd, onOpen }: TaskCard
       )}
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
         <span className={statusBadgeClass(status)}>
-          {status.replace(/_/g, ' ')}
+          {COLUMN_LABEL[status]}
         </span>
         {task.owner && (
           <span className="app-card-meta">@{task.owner}</span>

--- a/web/src/lib/pixelAvatar.ts
+++ b/web/src/lib/pixelAvatar.ts
@@ -1,6 +1,10 @@
 // Pixel-art agent avatars — ported from web/index.legacy.html (feature #25).
 // Each sprite is a 14x14 grid where each cell is an index into a 6-color palette:
 //   0 = transparent, 1 = outline, 2 = skin, 3 = accent, 4 = hair, 5 = prop, 6 = highlight.
+// Hand-designed sprites in SPRITE_DATA cover the named roles; unknown slugs
+// are composed procedurally from modular layers (see proceduralAvatar.ts).
+
+import { buildProceduralSprite, getProceduralAccent } from './proceduralAvatar'
 
 export const SPRITE_DATA: Record<string, number[][]> = {
   ceo: [
@@ -173,7 +177,11 @@ const AGENT_COLORS: Record<string, string> = {
 }
 
 export function getAgentColor(slug: string): string {
-  return AGENT_COLORS[slug] ?? '#58A6FF'
+  const direct = AGENT_COLORS[slug]
+  if (direct) return direct
+  const aliased = SPRITE_SLUG_MAP[slug]
+  if (aliased && AGENT_COLORS[aliased]) return AGENT_COLORS[aliased]
+  return getProceduralAccent(slug)
 }
 
 type Rgb = readonly [number, number, number]
@@ -189,20 +197,31 @@ export function drawPixelAvatar(
   size: number,
 ): void {
   const key = SPRITE_SLUG_MAP[slug] ?? slug
-  const sprite = SPRITE_DATA[key] ?? SPRITE_GENERIC
-  const accentHex = getAgentColor(slug)
+  const hand = SPRITE_DATA[key]
 
-  const ar = parseInt(accentHex.slice(1, 3), 16)
-  const ag = parseInt(accentHex.slice(3, 5), 16)
-  const ab = parseInt(accentHex.slice(5, 7), 16)
+  let sprite: number[][]
+  let palette: Record<number, Rgb>
 
-  const palette: Record<number, Rgb> = {
-    1: [36, 32, 30],
-    2: [235, 215, 190],
-    3: [ar, ag, ab],
-    4: [Math.max(0, ar - 60), Math.max(0, ag - 60), Math.max(0, ab - 60)],
-    5: [180, 170, 155],
-    6: [255, 255, 255],
+  if (hand) {
+    // Hand-designed role sprite — keep original palette treatment.
+    sprite = hand
+    const accentHex = getAgentColor(slug)
+    const ar = parseInt(accentHex.slice(1, 3), 16)
+    const ag = parseInt(accentHex.slice(3, 5), 16)
+    const ab = parseInt(accentHex.slice(5, 7), 16)
+    palette = {
+      1: [36, 32, 30],
+      2: [235, 215, 190],
+      3: [ar, ag, ab],
+      4: [Math.max(0, ar - 60), Math.max(0, ag - 60), Math.max(0, ab - 60)],
+      5: [180, 170, 155],
+      6: [255, 255, 255],
+    }
+  } else {
+    // Unknown slug — build procedurally with a palette keyed off the slug hash.
+    const procedural = buildProceduralSprite(slug)
+    sprite = procedural.grid
+    palette = procedural.palette
   }
 
   const rows = sprite.length

--- a/web/src/lib/proceduralAvatar.ts
+++ b/web/src/lib/proceduralAvatar.ts
@@ -1,0 +1,330 @@
+// Procedural pixel-art avatar builder.
+// Composes a 14x14 sprite from modular layers — hair, headwear, facial feature,
+// neck accessory — plus per-slug palette picks (accent, hair color, skin tone).
+// Layer picks are derived from a hash of the agent slug so the same slug always
+// produces the same avatar, but different slugs get distinct looks.
+//
+// Palette slots match pixelAvatar.ts:
+//   0 = transparent, 1 = outline, 2 = skin, 3 = accent, 4 = hair,
+//   5 = prop, 6 = highlight.
+
+export type PixelGrid = number[][]
+export type Rgb = readonly [number, number, number]
+export type Palette = Record<number, Rgb>
+
+const ROWS = 14
+const COLS = 14
+
+// Base body — face, torso, arms. No hair; hair layers add it.
+const BASE: PixelGrid = [
+  [0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0],
+  [0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 1, 0, 0, 0],
+  [0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 1, 0, 0, 0],
+  [0, 0, 0, 1, 2, 1, 2, 2, 1, 2, 1, 0, 0, 0],
+  [0, 0, 0, 1, 2, 2, 2, 2, 2, 2, 1, 0, 0, 0],
+  [0, 0, 0, 0, 1, 2, 2, 2, 2, 1, 0, 0, 0, 0],
+  [0, 0, 1, 3, 3, 3, 3, 3, 3, 3, 3, 1, 0, 0],
+  [0, 1, 2, 3, 3, 3, 3, 3, 3, 3, 3, 2, 1, 0],
+  [0, 0, 2, 2, 3, 3, 3, 3, 3, 3, 2, 2, 0, 0],
+  [0, 0, 1, 2, 1, 3, 3, 3, 3, 1, 2, 1, 0, 0],
+  [0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0],
+  [0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0],
+  [0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+  [0, 0, 0, 1, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0],
+]
+
+// A layer is a sparse overlay. Cells with -1 are noop. Non-negative cells are
+// stamped onto the base (0 = transparent, 1..6 = palette index).
+const NO = -1
+type Layer = number[][]
+
+function emptyLayer(): Layer {
+  return Array.from({ length: ROWS }, () => Array.from({ length: COLS }, () => NO))
+}
+
+// ── Hair layers (rows 0–2) ──────────────────────────────────────────────
+
+function hairClassic(): Layer {
+  const l = emptyLayer()
+  for (let c = 4; c <= 9; c++) l[1][c] = 4
+  return l
+}
+
+function hairSpiky(): Layer {
+  const l = emptyLayer()
+  l[0][4] = 4
+  l[0][6] = 4
+  l[0][8] = 4
+  for (let c = 4; c <= 9; c++) l[1][c] = 4
+  return l
+}
+
+function hairSidePart(): Layer {
+  const l = emptyLayer()
+  for (let c = 4; c <= 9; c++) l[1][c] = 4
+  l[1][7] = 2 // part line shows skin
+  return l
+}
+
+function hairBald(): Layer {
+  return emptyLayer()
+}
+
+function hairAfro(): Layer {
+  const l = emptyLayer()
+  for (let c = 3; c <= 10; c++) l[0][c] = 4
+  for (let c = 2; c <= 11; c++) l[1][c] = 4
+  l[2][3] = 4
+  l[2][10] = 4
+  return l
+}
+
+function hairMohawk(): Layer {
+  const l = emptyLayer()
+  l[0][6] = 4
+  l[0][7] = 4
+  l[1][6] = 4
+  l[1][7] = 4
+  return l
+}
+
+function hairLongSides(): Layer {
+  const l = emptyLayer()
+  for (let c = 4; c <= 9; c++) l[1][c] = 4
+  l[2][3] = 4
+  l[2][10] = 4
+  l[3][3] = 4
+  l[3][10] = 4
+  return l
+}
+
+const HAIR_STYLES = [
+  hairClassic,
+  hairSpiky,
+  hairSidePart,
+  hairBald,
+  hairAfro,
+  hairMohawk,
+  hairLongSides,
+]
+
+// ── Headwear layers (rows 0–2) — stamped AFTER hair ────────────────────
+
+function headwearNone(): Layer {
+  return emptyLayer()
+}
+
+function headwearCap(): Layer {
+  const l = emptyLayer()
+  for (let c = 3; c <= 10; c++) l[0][c] = 5
+  for (let c = 3; c <= 10; c++) l[1][c] = 5
+  for (let c = 2; c <= 11; c++) l[2][c] = 1 // brim outline
+  return l
+}
+
+function headwearHeadband(): Layer {
+  const l = emptyLayer()
+  for (let c = 4; c <= 9; c++) l[2][c] = 3 // accent-colored band
+  return l
+}
+
+function headwearBeanie(): Layer {
+  const l = emptyLayer()
+  for (let c = 4; c <= 9; c++) l[0][c] = 3
+  for (let c = 3; c <= 10; c++) l[1][c] = 3
+  return l
+}
+
+function headwearVisor(): Layer {
+  const l = emptyLayer()
+  for (let c = 2; c <= 11; c++) l[2][c] = 5
+  return l
+}
+
+const HEADWEAR_STYLES = [
+  headwearNone,
+  headwearNone, // weight "none" more heavily so avatars aren't all hatted
+  headwearCap,
+  headwearHeadband,
+  headwearBeanie,
+  headwearVisor,
+]
+
+// ── Facial feature (rows 3–5) ──────────────────────────────────────────
+
+function faceNone(): Layer {
+  return emptyLayer()
+}
+
+function faceGlasses(): Layer {
+  const l = emptyLayer()
+  // Round glasses framing the eyes at cols 5 and 8.
+  l[3][4] = 1
+  l[3][5] = 5
+  l[3][6] = 1
+  l[3][7] = 1
+  l[3][8] = 5
+  l[3][9] = 1
+  return l
+}
+
+function faceMustache(): Layer {
+  const l = emptyLayer()
+  for (let c = 5; c <= 8; c++) l[5][c] = 4
+  return l
+}
+
+function faceBeard(): Layer {
+  const l = emptyLayer()
+  l[4][4] = 4
+  l[4][9] = 4
+  for (let c = 5; c <= 8; c++) l[5][c] = 4
+  return l
+}
+
+const FACE_STYLES = [
+  faceNone,
+  faceNone,
+  faceNone, // weight "none" to keep most faces clean
+  faceGlasses,
+  faceMustache,
+  faceBeard,
+]
+
+// ── Neck accessory (rows 6–9) ──────────────────────────────────────────
+
+function neckNone(): Layer {
+  return emptyLayer()
+}
+
+function neckTie(): Layer {
+  const l = emptyLayer()
+  l[6][6] = 6
+  l[6][7] = 6
+  l[7][6] = 6
+  l[7][7] = 6
+  return l
+}
+
+function neckBadge(): Layer {
+  const l = emptyLayer()
+  l[9][4] = 6
+  return l
+}
+
+const NECK_STYLES = [neckNone, neckNone, neckTie, neckBadge]
+
+// ── Palette pools ──────────────────────────────────────────────────────
+
+const ACCENT_POOL: string[] = [
+  '#E8A838', // amber
+  '#58A6FF', // blue
+  '#A371F7', // violet
+  '#3FB950', // green
+  '#D2A8FF', // lilac
+  '#F778BA', // pink
+  '#FFA657', // orange
+  '#79C0FF', // sky
+  '#FF7B72', // coral
+  '#56D4DD', // teal
+  '#FFD866', // yellow
+  '#C9D1D9', // slate
+]
+
+const HAIR_POOL: Rgb[] = [
+  [36, 32, 30], // near-black
+  [74, 52, 38], // dark brown
+  [139, 90, 43], // brown
+  [200, 155, 90], // blond
+  [170, 60, 45], // auburn
+  [200, 200, 200], // silver
+  [236, 178, 46], // amber (match brand)
+  [180, 120, 200], // lilac (fun)
+]
+
+const SKIN_POOL: Rgb[] = [
+  [248, 220, 190],
+  [235, 195, 160],
+  [210, 165, 125],
+  [175, 125, 90],
+  [140, 95, 65],
+  [100, 65, 45],
+]
+
+// ── Hash ───────────────────────────────────────────────────────────────
+
+// Deterministic FNV-1a 32-bit hash — same slug → same avatar.
+function hashSlug(slug: string): number {
+  let h = 0x811c9dc5
+  for (let i = 0; i < slug.length; i++) {
+    h ^= slug.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return h >>> 0
+}
+
+// Pull a sequence of independent indices from one hash by mixing in a salt.
+function pick(hash: number, salt: number, modulo: number): number {
+  let h = hash ^ (salt * 0x9e3779b1)
+  h = Math.imul(h ^ (h >>> 16), 0x85ebca6b)
+  h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35)
+  h ^= h >>> 16
+  return (h >>> 0) % modulo
+}
+
+// ── Hex → RGB ──────────────────────────────────────────────────────────
+
+function hexToRgb(hex: string): Rgb {
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  return [r, g, b]
+}
+
+// ── Public API ─────────────────────────────────────────────────────────
+
+export interface ProceduralSprite {
+  grid: PixelGrid
+  palette: Palette
+  accentHex: string
+}
+
+export function buildProceduralSprite(slug: string): ProceduralSprite {
+  const hash = hashSlug(slug || 'unknown')
+
+  const hairStyle = HAIR_STYLES[pick(hash, 1, HAIR_STYLES.length)]
+  const headwearStyle = HEADWEAR_STYLES[pick(hash, 2, HEADWEAR_STYLES.length)]
+  const faceStyle = FACE_STYLES[pick(hash, 3, FACE_STYLES.length)]
+  const neckStyle = NECK_STYLES[pick(hash, 4, NECK_STYLES.length)]
+
+  const accentHex = ACCENT_POOL[pick(hash, 5, ACCENT_POOL.length)]
+  const hairColor = HAIR_POOL[pick(hash, 6, HAIR_POOL.length)]
+  const skinColor = SKIN_POOL[pick(hash, 7, SKIN_POOL.length)]
+
+  const grid: PixelGrid = BASE.map((row) => row.slice())
+  const layers = [hairStyle(), headwearStyle(), faceStyle(), neckStyle()]
+  for (const layer of layers) {
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        const v = layer[r][c]
+        if (v !== NO) grid[r][c] = v
+      }
+    }
+  }
+
+  const palette: Palette = {
+    1: [36, 32, 30],
+    2: skinColor,
+    3: hexToRgb(accentHex),
+    4: hairColor,
+    5: [180, 170, 155],
+    6: [255, 255, 255],
+  }
+
+  return { grid, palette, accentHex }
+}
+
+export function getProceduralAccent(slug: string): string {
+  const hash = hashSlug(slug || 'unknown')
+  return ACCENT_POOL[pick(hash, 5, ACCENT_POOL.length)]
+}

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -80,6 +80,7 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 .badge-green { background: var(--green-bg); color: var(--green); }
 .badge-accent { background: var(--accent-bg); color: var(--accent); }
 .badge-yellow { background: var(--yellow-bg); color: var(--yellow); }
+.badge-muted { background: var(--bg-warm); color: var(--text-tertiary); text-decoration: line-through; }
 
 /* ─── Pixel avatars ─── */
 /* The canvas buffer is the sprite's native 14x14 grid; CSS scales it up.

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -69,7 +69,7 @@
 .app-card-meta { font-size: 11px; color: var(--text-tertiary); }
 
 /* ─── Task board (kanban) ─── */
-.task-board { display: grid; grid-template-columns: repeat(6, minmax(220px, 1fr)); gap: 12px; padding: 20px; align-content: start; overflow-x: auto; }
+.task-board { display: grid; grid-template-columns: repeat(7, minmax(200px, 1fr)); gap: 12px; padding: 20px; align-content: start; overflow-x: auto; }
 .task-column { display: flex; flex-direction: column; gap: 4px; min-height: 120px; padding: 4px; border-radius: var(--radius-md); transition: outline-color 0.15s, background 0.15s; }
 .task-column-header { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--text-tertiary); padding: 0 4px 8px; border-bottom: 2px solid var(--border); display: flex; align-items: center; justify-content: space-between; margin-bottom: 4px; }
 .task-column-count { font-family: var(--font-mono); font-size: 10px; background: var(--bg); padding: 1px 6px; border-radius: var(--radius-full); }


### PR DESCRIPTION
## Summary

- New modular avatar builder composes a 14×14 sprite from layers — hair, headwear, facial feature, neck accessory — plus independent skin/hair/accent color pools.
- Layer picks are derived from a FNV-1a hash of the slug, so every spawned agent looks different but stays **stable across reloads, restarts, and surfaces**.
- Ported identically to both the web canvas (`web/src/lib/proceduralAvatar.ts`) and the Go CLI ANSI renderer (`cmd/wuphf/avatars_procedural.go`) — a given slug looks the same in both places.
- Hand-designed mascots (`ceo`, `pm`, `fe`, `be`, `ai`, `designer`, `cmo`, `cro`) are **unchanged**; only unknown slugs route to the new builder.
- Removed now-dead Go helpers (`spriteGeneric`, `applyHairVariation`, `seedHash`) and the unused `hash/fnv` import from `avatars_wuphf.go`.

## Layer inventory

- 7 hair styles (classic, spiky, side-part, bald, afro, mohawk, long-sides)
- 6 headwear (none×2, cap, headband, beanie, visor)
- 6 face features (none×3, glasses, mustache, beard)
- 4 neck accessories (none×2, tie, badge)
- 12 accent colors · 8 hair colors · 6 skin tones

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./cmd/wuphf/...` clean
- [x] `go test -race ./cmd/wuphf/...` — new tests verify stability, uniqueness, and independent channel variation
- [x] TS sanity test: 18 distinct slugs produced 18 unique stable sprites
- [ ] Spawn a few agents with arbitrary slugs in the web UI and confirm each gets a distinct avatar
- [ ] Confirm CLI splash renders matching avatars for the same slugs