### PR TITLE
feat(team): stream interactive claude pane output to the web UI

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -3971,6 +3971,11 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		l.resumeInFlightWork()
 	}
 
+	// Stream tmux pane output to the web UI's per-agent stream so users see
+	// live Claude TUI activity (thinking, tool calls, responses) during a
+	// pane-backed turn. No-op when paneBackedAgents is false.
+	l.startPaneCaptureLoops(l.headlessCtx)
+
 	go l.notifyAgentsLoop()
 	go l.notifyTaskActionsLoop()
 	go l.notifyOfficeChangesLoop()

--- a/internal/team/pane_capture.go
+++ b/internal/team/pane_capture.go
@@ -1,0 +1,172 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Pane capture defaults. Values are intentionally not user-configurable:
+// 1s is a reasonable tradeoff between "feels live" and tmux CPU cost, and
+// introducing a knob would add complexity without clear wins.
+const (
+	paneCapturePollInterval   = 1 * time.Second
+	paneCaptureMaxFailures    = 5
+	paneCaptureBackoffOnError = 2 * time.Second
+	paneCaptureMaxDiffBytes   = 64 * 1024
+	paneCaptureTruncateMarker = "...[truncated]"
+	paneCaptureHistoryLines   = 200 // tmux -S: scroll back lines to include
+)
+
+// ansiEscapePattern strips ANSI escape sequences (CSI, OSC, and standalone
+// ESC-prefixed controls). It intentionally matches greedily within a single
+// sequence — tmux capture-pane -J output is line-joined so sequences do not
+// span lines in practice.
+var ansiEscapePattern = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[@-Z\\-_]`)
+
+// stripANSI removes ANSI escape sequences and common control characters that
+// tmux pane captures can leak through (carriage returns, bells).
+func stripANSI(s string) string {
+	if s == "" {
+		return s
+	}
+	s = ansiEscapePattern.ReplaceAllString(s, "")
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\a", "")
+	return s
+}
+
+// diffPaneLines returns lines present in the new capture that were not present
+// in the previous capture, preserving their order. This uses a line-set
+// comparison rather than a byte offset so claude's TUI re-renders (which
+// rewrite the entire visible region on each frame) do not produce spurious
+// duplicate pushes.
+//
+// Exact-duplicate lines that already appear in prev are skipped. Blank lines
+// are skipped entirely (they add no signal and TUI frames tend to emit many).
+func diffPaneLines(prev, next []string) []string {
+	if len(next) == 0 {
+		return nil
+	}
+	seen := make(map[string]int, len(prev))
+	for _, line := range prev {
+		seen[line]++
+	}
+	out := make([]string, 0, len(next))
+	for _, line := range next {
+		trimmed := strings.TrimRight(line, " \t")
+		if trimmed == "" {
+			continue
+		}
+		if seen[trimmed] > 0 {
+			seen[trimmed]--
+			continue
+		}
+		out = append(out, trimmed)
+	}
+	return out
+}
+
+// startPaneCaptureLoops kicks off one goroutine per pane-backed agent. Each
+// goroutine polls tmux capture-pane on an interval, strips ANSI, diffs against
+// the previous snapshot, and pushes new lines to the per-agent broker stream
+// so the web UI's "live output" pane stays in sync with the real Claude
+// session running in the tmux pane.
+//
+// Safe to call only when l.paneBackedAgents == true.
+func (l *Launcher) startPaneCaptureLoops(ctx context.Context) {
+	if !l.paneBackedAgents || l.broker == nil {
+		return
+	}
+	targets := l.agentPaneTargets()
+	for slug, target := range targets {
+		if slug == "" || target.PaneTarget == "" {
+			continue
+		}
+		go l.paneCaptureLoop(ctx, slug, target.PaneTarget)
+	}
+}
+
+// paneCaptureLoop polls a single tmux pane on a fixed interval. It stops
+// when the context is canceled or after paneCaptureMaxFailures consecutive
+// tmux errors (e.g. the pane closed permanently).
+func (l *Launcher) paneCaptureLoop(ctx context.Context, slug, paneTarget string) {
+	stream := l.broker.AgentStream(slug)
+	if stream == nil {
+		return
+	}
+
+	ticker := time.NewTicker(paneCapturePollInterval)
+	defer ticker.Stop()
+
+	var prevLines []string
+	failures := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		snapshot, err := capturePane(ctx, paneTarget)
+		if err != nil {
+			failures++
+			if failures >= paneCaptureMaxFailures {
+				fmt.Fprintf(os.Stderr,
+					"  Agents:  pane capture for %s (%s) stopped after %d failures: %v\n",
+					slug, paneTarget, failures, err,
+				)
+				return
+			}
+			// Back off briefly on errors instead of spinning on the 1s tick.
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(paneCaptureBackoffOnError):
+			}
+			continue
+		}
+		failures = 0
+
+		nextLines := strings.Split(snapshot, "\n")
+		for i, line := range nextLines {
+			nextLines[i] = stripANSI(line)
+		}
+
+		newLines := diffPaneLines(prevLines, nextLines)
+		if len(newLines) == 0 {
+			prevLines = nextLines
+			continue
+		}
+
+		for _, line := range newLines {
+			if len(line) > paneCaptureMaxDiffBytes {
+				line = line[:paneCaptureMaxDiffBytes] + paneCaptureTruncateMarker
+			}
+			stream.Push(line)
+		}
+		prevLines = nextLines
+	}
+}
+
+// capturePane shells out to tmux capture-pane with -J (join wrapped lines)
+// and -p (stdout). It returns the raw captured text on success.
+func capturePane(ctx context.Context, paneTarget string) (string, error) {
+	cmd := exec.CommandContext(ctx, "tmux",
+		"-L", tmuxSocketName,
+		"capture-pane",
+		"-p",
+		"-J",
+		"-t", paneTarget,
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux capture-pane %s: %w", paneTarget, err)
+	}
+	return string(out), nil
+}

--- a/internal/team/pane_capture_test.go
+++ b/internal/team/pane_capture_test.go
@@ -1,0 +1,158 @@
+package team
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStripANSI(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain text untouched",
+			in:   "hello world",
+			want: "hello world",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "simple color CSI",
+			in:   "\x1b[31mred\x1b[0m",
+			want: "red",
+		},
+		{
+			name: "cursor movement CSI",
+			in:   "abc\x1b[2Kclear\x1b[1;1H",
+			want: "abcclear",
+		},
+		{
+			name: "OSC terminated by BEL",
+			in:   "\x1b]0;window title\x07content",
+			want: "content",
+		},
+		{
+			name: "OSC terminated by ST",
+			in:   "\x1b]0;title\x1b\\content",
+			want: "content",
+		},
+		{
+			name: "standalone ESC control",
+			in:   "prefix\x1bMsuffix",
+			want: "prefixsuffix",
+		},
+		{
+			name: "carriage return stripped",
+			in:   "line\rmore",
+			want: "linemore",
+		},
+		{
+			name: "BEL stripped",
+			in:   "beep\aboop",
+			want: "beepboop",
+		},
+		{
+			name: "CSI with question mark prefix (private mode)",
+			in:   "\x1b[?25hvisible",
+			want: "visible",
+		},
+		{
+			name: "multiple sequences in a line",
+			in:   "\x1b[1;34mBold Blue\x1b[0m and \x1b[32mGreen\x1b[0m",
+			want: "Bold Blue and Green",
+		},
+		{
+			name: "claude thinking box",
+			in:   "\x1b[38;5;245m│ \x1b[0mthinking about the task\x1b[38;5;245m │\x1b[0m",
+			want: "│ thinking about the task │",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripANSI(tc.in)
+			if got != tc.want {
+				t.Errorf("stripANSI(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiffPaneLines(t *testing.T) {
+	tests := []struct {
+		name string
+		prev []string
+		next []string
+		want []string
+	}{
+		{
+			name: "no previous, new lines returned",
+			prev: nil,
+			next: []string{"a", "b", "c"},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "identical capture returns nothing",
+			prev: []string{"a", "b", "c"},
+			next: []string{"a", "b", "c"},
+			want: nil,
+		},
+		{
+			name: "appended lines returned",
+			prev: []string{"a", "b"},
+			next: []string{"a", "b", "c", "d"},
+			want: []string{"c", "d"},
+		},
+		{
+			name: "TUI rerender with scrolled content preserves order of new lines",
+			prev: []string{"old1", "old2", "shared1"},
+			next: []string{"shared1", "new1", "new2"},
+			want: []string{"new1", "new2"},
+		},
+		{
+			name: "blank lines always skipped",
+			prev: nil,
+			next: []string{"", "content", "   ", "\t", "more"},
+			want: []string{"content", "more"},
+		},
+		{
+			name: "trailing whitespace trimmed",
+			prev: []string{"hello"},
+			next: []string{"hello   ", "world\t"},
+			want: []string{"world"},
+		},
+		{
+			name: "duplicate line in new capture is emitted only as many times as it newly appears",
+			prev: []string{"dup"},
+			next: []string{"dup", "dup", "dup"},
+			want: []string{"dup", "dup"},
+		},
+		{
+			name: "empty next returns nil",
+			prev: []string{"a"},
+			next: nil,
+			want: nil,
+		},
+		{
+			name: "order preserved even when some shared lines interleave",
+			prev: []string{"a", "b", "c"},
+			next: []string{"a", "x", "b", "y", "c", "z"},
+			want: []string{"x", "y", "z"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := diffPaneLines(tc.prev, tc.next)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("diffPaneLines(%v, %v) = %v, want %v", tc.prev, tc.next, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #139, which spawns one interactive `claude` pane per agent in
tmux when WUPHF runs in web mode. PR #139 left the live output gap: the
web UI's per-agent stream stayed empty during a turn because the tmux
pane output was never wired into `broker.AgentStream(slug)`.

This PR adds a lightweight per-pane poller that bridges tmux to the web
UI stream:

- One goroutine per pane-backed agent. Shells out to
  `tmux -L wuphf capture-pane -p -J -t <paneTarget>` on a 1s interval.
- ANSI escape sequences and common control chars (CR, BEL) are stripped
  with a small inlined regex. No new dependencies.
- Line-level diffing against the previous snapshot. Claude's TUI
  re-renders frequently (cursor-position tricks), so the poller tracks a
  line multiset and only emits lines that appear in the new capture but
  weren't in the previous one, preserving their order. Blank lines are
  dropped.
- Pushes plain text to `AgentStream(slug).Push`, matching the existing
  headless Claude stdout convention (`internal/team/headless_claude.go`).
  The web UI's `StreamLineView` already renders raw-text lines via the
  `stream-line-raw` branch.
- Per-line cap of 64KB with a `...[truncated]` marker. Tolerates
  transient tmux errors with a 2s backoff; stops polling a pane after
  5 consecutive failures and logs once.
- Only runs when `l.paneBackedAgents == true`. TUI mode and the codex
  runtime are untouched.
- Tied to `l.headlessCtx` so shutdown cancels all pollers cleanly.

## Known limitation

Claude's TUI box-drawing characters and partial frame rewrites still
leak through as cosmetic noise. Cleaner options (stream-json, TUI-aware
post-processing) are out of scope here — this PR unblocks the "live"
feeling today.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/team/... ./internal/provider/...` — unit
  tests for `stripANSI` and `diffPaneLines` pass; pre-existing
  operation-matrix failure on main is unrelated.
- [x] `go test -race` on the new tests passes.
- [ ] Manual: launch WUPHF in web mode with tmux available, send an
  @mention, confirm the agent's stream panel starts showing live
  Claude output within ~1s.
- [ ] Manual: kill a pane mid-turn, confirm polling stops after 5
  consecutive failures and logs to stderr without spinning.