### PR TITLE
feat(settings): restore Reset in Danger Zone + 'i can spell responsibility' confirm

### DIFF
--- a/internal/workspace/handlers.go
+++ b/internal/workspace/handlers.go
@@ -5,23 +5,34 @@ import (
 	"net/http"
 )
 
-// RegisterRoutes attaches the workspace wipe endpoint to mux.
+// RegisterRoutes attaches the two workspace wipe endpoints to mux.
 //
+//	POST /workspace/reset  — ClearRuntime (narrow: broker state only)
 //	POST /workspace/shred  — Shred (full wipe, reopens onboarding)
 //
-// Touches disk only. Does NOT kill the running broker process, so callers
-// must surface the "restart_required" hint — the web UI reloads the tab,
-// the TUI quits the session, the CLI is already the restart path.
+// Both endpoints only touch disk. They do NOT kill the running broker process,
+// so callers must surface the "restart_required" hint — the web UI reloads
+// the tab, the TUI quits the session, the CLI is already the restart path.
 //
-// authMiddleware wraps the handler. Pass the broker's requireAuth so local
-// scripts cannot POST without the broker token — shred is strictly more
-// destructive than /config or /company, which are already auth-gated. Pass
+// authMiddleware wraps each handler. Pass the broker's requireAuth so local
+// scripts cannot POST without the broker token — these operations are strictly
+// more destructive than /config or /company, which are already auth-gated. Pass
 // a nil middleware only in tests — RegisterRoutes substitutes a passthrough.
 func RegisterRoutes(mux *http.ServeMux, authMiddleware func(http.HandlerFunc) http.HandlerFunc) {
 	if authMiddleware == nil {
 		authMiddleware = func(h http.HandlerFunc) http.HandlerFunc { return h }
 	}
+	mux.HandleFunc("/workspace/reset", authMiddleware(handleReset))
 	mux.HandleFunc("/workspace/shred", authMiddleware(handleShred))
+}
+
+func handleReset(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	res, err := ClearRuntime()
+	writeResult(w, res, err, "/")
 }
 
 func handleShred(w http.ResponseWriter, r *http.Request) {

--- a/internal/workspace/handlers_test.go
+++ b/internal/workspace/handlers_test.go
@@ -28,6 +28,39 @@ func decodeBody(t *testing.T, body string) map[string]any {
 	return out
 }
 
+func TestResetHandlerRejectsNonPost(t *testing.T) {
+	withRuntimeHome(t)
+	req := httptest.NewRequest(http.MethodGet, "/workspace/reset", nil)
+	w := httptest.NewRecorder()
+	newMux().ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestResetHandlerClearsBrokerRuntimeOnly(t *testing.T) {
+	dir := withRuntimeHome(t)
+	paths := seedWorkspace(t, dir)
+
+	req := httptest.NewRequest(http.MethodPost, "/workspace/reset", nil)
+	w := httptest.NewRecorder()
+	newMux().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := decodeBody(t, w.Body.String())
+	if ok, _ := body["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true, got %v", body)
+	}
+	// Reset wipes broker runtime state...
+	assertGone(t, "brokerState", paths["brokerState"])
+	// ...but keeps everything else a Shred would have taken.
+	for _, label := range []string{"onboarded", "company", "officeTasks", "workflow", "session", "worktree"} {
+		assertStays(t, label, paths[label])
+	}
+}
+
 func TestShredHandlerRejectsNonPost(t *testing.T) {
 	withRuntimeHome(t)
 	req := httptest.NewRequest(http.MethodGet, "/workspace/shred", nil)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -598,6 +598,14 @@ export interface WorkspaceWipeResult {
   error?: string
 }
 
+// resetWorkspace is the narrow wipe: clears broker runtime state only.
+// Team roster, company identity, tasks, and workflows all survive. Call
+// window.location.reload() after success so the UI picks up the empty
+// broker state.
+export function resetWorkspace() {
+  return post<WorkspaceWipeResult>('/workspace/reset', {})
+}
+
 // shredWorkspace is the full wipe: broker runtime + team + company + office
 // + workflows. Onboarding reopens on the next load. Call window.location
 // .reload() after success.

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, type ReactNode } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   getConfig,
+  resetWorkspace,
   shredWorkspace,
   updateConfig,
   type ConfigSnapshot,
@@ -813,7 +814,7 @@ const dangerStyles = {
   }),
 }
 
-const CONFIRM_PHRASE = 'i am sure'
+const CONFIRM_PHRASE = 'i can spell responsibility'
 
 interface WipeModalProps {
   title: string
@@ -826,7 +827,7 @@ interface WipeModalProps {
 }
 
 // WipeModal gates a destructive action behind a type-the-exact-phrase confirm.
-// The placeholder and the body copy both say "i am sure" so there's no mystery
+// The placeholder and the body copy both surface the full phrase so there's no mystery
 // about what to type — we want the friction, not the guesswork.
 function WipeModal({ title, severity, intro, confirmLabel, busy, onConfirm, onCancel }: WipeModalProps) {
   const [value, setValue] = useState('')
@@ -867,11 +868,28 @@ function WipeModal({ title, severity, intro, confirmLabel, busy, onConfirm, onCa
   )
 }
 
-type DangerAction = 'shred'
+type DangerAction = 'reset' | 'shred'
 
 function DangerZoneSection() {
   const [open, setOpen] = useState<DangerAction | null>(null)
   const [busy, setBusy] = useState(false)
+
+  const handleReset = async () => {
+    setBusy(true)
+    try {
+      const result: WorkspaceWipeResult = await resetWorkspace()
+      if (!result.ok) {
+        showNotice(result.error || 'Reset failed', 'error')
+        setBusy(false)
+        return
+      }
+      showNotice('Broker state cleared. Reloading…', 'success')
+      setTimeout(() => window.location.reload(), 400)
+    } catch (err) {
+      showNotice(err instanceof Error ? err.message : 'Reset failed', 'error')
+      setBusy(false)
+    }
+  }
 
   const handleShred = async () => {
     setBusy(true)
@@ -894,10 +912,41 @@ function DangerZoneSection() {
     <div>
       <div style={styles.sectionTitle}>Danger Zone</div>
       <div style={styles.sectionDesc}>
-        Irreversible operation on this workspace. The web UI does not kill the running broker
-        process, so after shredding you may need to re-launch
+        Irreversible operations on this workspace. Read each card carefully — the web UI does not
+        kill the running broker process, so after either action you may need to re-launch
         <code style={{ margin: '0 4px' }}>wuphf</code> from your terminal for the change to fully
         take effect.
+      </div>
+
+      {/* RESET — narrow: broker runtime state only */}
+      <div style={dangerStyles.card('warn')}>
+        <div style={dangerStyles.cardTitle}>
+          <span>{'\u{1F501}'}</span>
+          <span>Reset broker state</span>
+        </div>
+        <div style={dangerStyles.cardSubtitle}>
+          Use this when something is stuck — an agent wedged, the queue won't drain, messages stop
+          flowing — and you want a clean restart without losing your team or work.
+        </div>
+        <div style={dangerStyles.listLabel}>Clears</div>
+        <ul style={dangerStyles.list}>
+          <li>Broker runtime state (<code>~/.wuphf/team/broker-state.json</code>)</li>
+          <li>Office PID file and in-memory snapshot</li>
+        </ul>
+        <div style={dangerStyles.listLabel}>Preserved</div>
+        <ul style={dangerStyles.list}>
+          <li>Your team roster, company identity, tasks, workflows</li>
+          <li>All on-disk history (logs, sessions, artifacts)</li>
+          <li>API keys and config</li>
+        </ul>
+        <button
+          type="button"
+          style={dangerStyles.button('warn')}
+          onClick={() => setOpen('reset')}
+          disabled={busy}
+        >
+          Reset broker state…
+        </button>
       </div>
 
       {/* SHRED — full wipe */}
@@ -938,6 +987,24 @@ function DangerZoneSection() {
           Shred workspace…
         </button>
       </div>
+
+      {open === 'reset' && (
+        <WipeModal
+          title="Reset broker state?"
+          severity="warn"
+          intro={
+            <>
+              This clears the broker's on-disk runtime state and reboots the office from a clean
+              slate. Your team, company, tasks, and workflows are all kept. If this doesn't
+              unblock things, try <strong>Shred workspace</strong> instead.
+            </>
+          }
+          confirmLabel="Reset broker state"
+          busy={busy}
+          onConfirm={handleReset}
+          onCancel={() => setOpen(null)}
+        />
+      )}
 
       {open === 'shred' && (
         <WipeModal


### PR DESCRIPTION
## Summary

- **Restores Reset broker state** in the Settings → Danger Zone. Removed in ce7fe748 on the premise that the in-channel `/reset` slash command already covered it — but those are different surfaces with different blast radii.
- **Updates the typed-phrase confirm** from `i am sure` to `i can spell responsibility` (still case-insensitive). Applies to both Reset and Shred.

## Why Reset is a distinct surface

- `/reset` (channel composer) → clears the live office transcript and reloads team panes
- **Reset broker state** (Danger Zone) → wipes `~/.wuphf/team/` runtime state so a wedged broker can restart clean. Team roster, company, tasks, workflows all survive.
- **Shred workspace** (Danger Zone) → full wipe. Everything Reset does, plus team/company/office/workflows/onboarded.json. Reopens the wizard on next load.

## Changes

- `internal/workspace/handlers.go` — re-add `POST /workspace/reset` (calls existing `ClearRuntime()`; was never deleted, just unexposed).
- `internal/workspace/handlers_test.go` — `TestResetHandlerRejectsNonPost`, `TestResetHandlerClearsBrokerRuntimeOnly` (verifies Reset touches broker runtime only, nothing else).
- `web/src/api/client.ts` — re-add `resetWorkspace()`.
- `web/src/components/apps/SettingsApp.tsx` — Reset card (warn severity) + Reset modal back in the Danger Zone. `CONFIRM_PHRASE` → `i can spell responsibility`.

## Visual check

Eyeballed locally on a fresh wuphf instance:
- Both Reset (yellow/warn) and Shred (red/critical) cards render
- Reset modal: title "Reset broker state?", body explains what Reset keeps vs Shred, prompt reads "Type i can spell responsibility to confirm", confirm button disabled until the phrase is typed
- Shred still reloads → Wizard (existing behavior — `Shred()` removes `onboarding.StatePath()` at workspace.go:64, and `/onboarding/state` returns `onboarded:false` on reload)

## Test plan

- [x] `go test ./internal/workspace/...` — pass
- [x] `go build ./...` — clean
- [x] `cd web && npm run typecheck` — pass
- [x] `cd web && npm run build` — pass
- [x] Visual: Reset card, Shred card, Reset modal, typed-phrase confirm all render correctly
- [ ] CI green