### PR TITLE
fix(team): resolve bootstrap blueprint from manifest when no query param

### DIFF
--- a/internal/team/operation_bootstrap.go
+++ b/internal/team/operation_bootstrap.go
@@ -353,6 +353,12 @@ func (b *Broker) handleOperationBootstrapPackage(w http.ResponseWriter, r *http.
 	if blueprintID == "" {
 		blueprintID = strings.TrimSpace(r.URL.Query().Get("pack_id"))
 	}
+	if blueprintID == "" {
+		// Manifest's explicit BlueprintRef beats fuzzy-matching company config
+		// fields, which may contain onboarding noise that scores against no real
+		// blueprint and sends us to the synthesis fallback with a garbage slug.
+		blueprintID = currentOperationBlueprintRef()
+	}
 	profile := operationCompanyProfile{
 		BlueprintID: blueprintID,
 		Name:        strings.TrimSpace(cfg.CompanyName),


### PR DESCRIPTION
## Summary

`TestOperationBlueprintMatrixServesBootstrapPackageEndpoint` fails locally for anyone whose `~/.wuphf/config.json` has non-empty company fields from onboarding noise (even a single stray character).

**Root cause:**
1. `GET /operations/bootstrap-package` was passing the query's `blueprint_id` (usually empty) straight into `operationCompanyProfile`.
2. With no explicit ID, `selectOperationBlueprintFile` falls through to fuzzy-matching `profile.Name` / `Description` / `Goals` / `Size` / `Priority` against every template blueprint's metadata.
3. Those fields come from `config.Load()` — i.e. whatever the user typed during onboarding. Garbage values (e.g. `company_name: "rsre"`) score 0 against every real blueprint.
4. The existing manifest-ref fallback (lines 611-618) only runs `if query == ""`. Since garbage config makes the query non-empty, it never fires.
5. We fall through to `buildOperationSynthesizedBootstrapPackage`, which returns a synthesized blueprint whose `ID` is the slug of the garbage company name (`"rsre"` in my case).

**Fix:** when no `blueprint_id` / `pack_id` query param is present, read the explicit `BlueprintRef` from the company manifest *before* building the profile. The manifest is the authoritative signal for "which blueprint do I want bootstrapped"; config fields should only tie-break when there's no explicit selection.

## Test Coverage

`TestOperationBlueprintMatrixServesBootstrapPackageEndpoint` (all 6 subtests) already covers the exact behavior — it was the test that caught this. No new test needed.

Before: 6/6 FAIL on my workstation, 6/6 PASS in CI (where `~/.wuphf/config.json` doesn't exist).

After: 6/6 PASS locally and in CI.

## Pre-Landing Review

- Change is 6 lines in one function (`handleOperationBootstrapPackage`).
- `currentOperationBlueprintRef()` is an existing helper that reads the manifest via `company.LoadManifest()` — no new file IO path.
- Only changes behavior when the query param is missing AND the manifest has a `BlueprintRef` — both already expected states.
- No SQL, no auth, no trust boundary crossed.

## Verification Results

- `go test ./internal/team/ -run TestOperationBlueprintMatrix -count=3` — PASS (stability check)
- `go test ./...` — PASS (full suite, no regressions)
- Pre-existing race in `TestRecoverFailedHeadlessTurnRequeuesExternalActionBeforeBlocking` (confirmed on main) is unrelated — separate issue.

## TODOS

This closes the P0 in `TODOS.md` from PR #144. I'll move it to Completed once this merges.

## Test plan

- [x] Failing test reproduces locally against `main`
- [x] My 6-line change makes all 6 subtests pass
- [x] `go test ./...` clean
- [x] Fix is minimal; no scope creep

🤖 Generated with [Claude Code](https://claude.com/claude-code)