### PR TITLE
fix(onboarding): seed the picked blueprint's team; ask identity first

### DIFF
--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -438,6 +438,11 @@ type blueprintAgentSummary struct {
 	Role    string `json:"role,omitempty"`
 	Emoji   string `json:"emoji,omitempty"`
 	Checked bool   `json:"checked"`
+	// BuiltIn marks the blueprint's lead agent (type: lead or built_in:
+	// true in the yaml). The wizard uses this to prevent the user from
+	// unchecking the lead in the Team step — downstream broker guards
+	// also refuse to disable or remove a BuiltIn member.
+	BuiltIn bool `json:"built_in,omitempty"`
 }
 
 type blueprintTaskSummary struct {
@@ -477,13 +482,19 @@ func summarizeBlueprint(bp operations.Blueprint) blueprintSummary {
 		Name:        bp.Name,
 		Description: bp.Description,
 	}
+	leadSlug := strings.TrimSpace(bp.Starter.LeadSlug)
 	for _, a := range bp.Starter.Agents {
+		// Mark the lead as BuiltIn so the wizard's Team step can disable
+		// its checkbox. We trust three signals from the blueprint yaml:
+		// explicit built_in, type=lead, or slug matching starter.lead_slug.
+		builtIn := a.BuiltIn || strings.EqualFold(strings.TrimSpace(a.Type), "lead") || (leadSlug != "" && a.Slug == leadSlug)
 		s.Agents = append(s.Agents, blueprintAgentSummary{
 			Slug:    a.Slug,
 			Name:    a.Name,
 			Role:    a.Role,
 			Emoji:   a.Emoji,
 			Checked: a.Checked,
+			BuiltIn: builtIn,
 		})
 	}
 	for _, t := range bp.Starter.Tasks {

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -3,12 +3,23 @@ package onboarding
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/operations"
 )
+
+// CompleteFunc is the side-effect hook invoked by HandleComplete when the
+// user finishes onboarding. The broker supplies a real implementation that
+// seeds the team from the picked blueprint (or synthesizes one when blueprintID
+// is empty), honors the selectedAgents filter from the wizard, and posts the
+// kickoff task. blueprintID is empty for the "from scratch" path.
+// selectedAgents is nil when no filtering is requested (internal synthesis
+// callers) and may be an empty slice when the wizard user unchecked every
+// agent.
+type CompleteFunc func(task string, skipTask bool, blueprintID string, selectedAgents []string) error
 
 // RegisterRoutes attaches all onboarding HTTP handlers to mux.
 //
@@ -35,7 +46,7 @@ import (
 //	GET  /onboarding/templates
 //	POST /onboarding/checklist/{id}/done
 //	POST /onboarding/checklist/dismiss
-func RegisterRoutes(mux *http.ServeMux, completeFn func(task string, skipTask bool) error, packSlug string, authMiddleware func(http.HandlerFunc) http.HandlerFunc) {
+func RegisterRoutes(mux *http.ServeMux, completeFn CompleteFunc, packSlug string, authMiddleware func(http.HandlerFunc) http.HandlerFunc) {
 	if authMiddleware == nil {
 		authMiddleware = func(h http.HandlerFunc) http.HandlerFunc { return h }
 	}
@@ -116,32 +127,37 @@ func HandleProgress(w http.ResponseWriter, r *http.Request) {
 // makeHandleComplete returns a handler for POST /onboarding/complete that
 // closes over completeFn. The broker should supply a non-nil completeFn to
 // seed the team and post the first message.
-func makeHandleComplete(completeFn func(task string, skipTask bool) error) http.HandlerFunc {
+func makeHandleComplete(completeFn CompleteFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		HandleComplete(w, r, completeFn)
 	}
 }
 
 // HandleComplete handles POST /onboarding/complete.
-// Body: {"task": string, "skip_task": bool}.
+// Body: {"task": string, "skip_task": bool, "blueprint": string, "agents": []string}.
+// The blueprint and agents fields are forwarded to completeFn so the broker
+// can seed the team that the wizard actually picked. A legacy client that
+// omits them is treated as "from scratch" (blueprint empty, agents nil).
 //
 // Logic:
 //  1. Load state; if already completed return 200 {"already_completed": true, "redirect": "/"}.
 //  2. If skip_task is false and task is empty, return 400.
 //  3. Call completeFn (when non-nil) — the broker wires side-effects here.
+//     If completeFn returns an error (e.g. LoadBlueprint failed), return 500
+//     with the error message so the wizard can surface it.
 //  4. Mark state as complete and persist it.
 //  5. Return 200 {"ok": true, "redirect": "/"}.
-//
-// TODO: broker wires CompleteFunc here
-func HandleComplete(w http.ResponseWriter, r *http.Request, completeFn func(task string, skipTask bool) error) {
+func HandleComplete(w http.ResponseWriter, r *http.Request, completeFn CompleteFunc) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
 	var body struct {
-		Task     string `json:"task"`
-		SkipTask bool   `json:"skip_task"`
+		Task      string   `json:"task"`
+		SkipTask  bool     `json:"skip_task"`
+		Blueprint string   `json:"blueprint"`
+		Agents    []string `json:"agents"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -170,9 +186,13 @@ func HandleComplete(w http.ResponseWriter, r *http.Request, completeFn func(task
 		return
 	}
 
-	// TODO: broker wires CompleteFunc here
 	if completeFn != nil {
-		if err := completeFn(body.Task, body.SkipTask); err != nil {
+		if err := completeFn(body.Task, body.SkipTask, strings.TrimSpace(body.Blueprint), body.Agents); err != nil {
+			// Log the full error server-side but return an opaque response to
+			// the client. completeFn may wrap filesystem paths, yaml parse
+			// messages, or other internals that should not leak to HTTP
+			// callers on a locally-bound broker.
+			log.Printf("onboarding: complete failed: %v", err)
 			http.Error(w, "complete failed", http.StatusInternalServerError)
 			return
 		}

--- a/internal/onboarding/handlers_test.go
+++ b/internal/onboarding/handlers_test.go
@@ -4,12 +4,45 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/nex-crm/wuphf/internal/operations"
 )
+
+// withOperationsFallbackFS points the operations loader at the repo's
+// templates/operations tree so HandleBlueprints can find curated yaml
+// files during tests. Without this the package-level init in the root
+// wuphf package (which wires the embed FS) never runs in onboarding
+// tests, and HandleBlueprints returns an empty list.
+func withOperationsFallbackFS(t *testing.T) {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	var repoRoot string
+	for dir := cwd; dir != "/" && dir != ""; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "templates", "operations")); err == nil {
+			repoRoot = dir
+			break
+		}
+	}
+	if repoRoot == "" {
+		t.Skip("templates/operations not reachable from test cwd; skipping")
+	}
+	sub, err := fs.Sub(os.DirFS(repoRoot), ".")
+	if err != nil {
+		t.Fatalf("sub fs: %v", err)
+	}
+	operations.SetFallbackFS(sub)
+}
 
 // TestHandleStateGETReturnsValidJSON verifies that GET /onboarding/state
 // returns HTTP 200 with a valid JSON body that can be decoded into State.
@@ -352,6 +385,67 @@ func TestHandleCompleteSkipTaskPersistsOnboardedState(t *testing.T) {
 		}
 		if !s.Onboarded() {
 			t.Error("expected Onboarded()=true after skip_task=true; wizard would reopen on next launch")
+		}
+	})
+}
+
+// TestHandleBlueprintsMarksLeadBuiltIn verifies that GET /onboarding/blueprints
+// surfaces built_in=true for the blueprint's lead agent. The wizard UI
+// uses this flag to lock the lead's checkbox so it cannot be unchecked
+// on the Team step. Without this, a user could uncheck the lead, the POST
+// body would carry an empty agents list, and the broker would fall back
+// to lead-only — the opposite of what the user asked for, silently.
+func TestHandleBlueprintsMarksLeadBuiltIn(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		withOperationsFallbackFS(t)
+
+		req := httptest.NewRequest(http.MethodGet, "/onboarding/blueprints", nil)
+		w := httptest.NewRecorder()
+		HandleBlueprints(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d\nbody: %s", w.Code, w.Body.String())
+		}
+
+		var resp struct {
+			Templates []struct {
+				ID     string `json:"id"`
+				Agents []struct {
+					Slug    string `json:"slug"`
+					BuiltIn bool   `json:"built_in"`
+				} `json:"agents"`
+			} `json:"templates"`
+		}
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+
+		// niche-crm's blueprint yaml names `operator` as type: lead with
+		// built_in: true. Any shipped blueprint must mark exactly one lead.
+		var found bool
+		for _, tpl := range resp.Templates {
+			if tpl.ID != "niche-crm" {
+				continue
+			}
+			var leadCount int
+			for _, a := range tpl.Agents {
+				if a.BuiltIn {
+					leadCount++
+					if a.Slug != "operator" {
+						t.Errorf("niche-crm lead should be operator, got %q (built_in=true)", a.Slug)
+					}
+				}
+			}
+			if leadCount == 0 {
+				t.Error("niche-crm has no built_in lead agent — wizard would allow unchecking the lead")
+			}
+			if leadCount > 1 {
+				t.Errorf("niche-crm has %d built_in leads; expected exactly 1", leadCount)
+			}
+			found = true
+		}
+		if !found {
+			t.Fatalf("niche-crm not found in response templates: %+v", resp.Templates)
 		}
 	})
 }

--- a/internal/onboarding/handlers_test.go
+++ b/internal/onboarding/handlers_test.go
@@ -3,6 +3,7 @@ package onboarding
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -213,6 +214,106 @@ func TestHandleCompletePostPersistsCompletedState(t *testing.T) {
 		}
 		if !s.Onboarded() {
 			t.Error("state should be onboarded after HandleComplete")
+		}
+	})
+}
+
+// TestHandleCompleteDecodesBlueprintAndAgents verifies that POST
+// /onboarding/complete now decodes the blueprint id and selected agent
+// slugs from the body and threads them into completeFn. Previously these
+// fields were silently dropped, causing every user's team to collapse to
+// the DefaultManifest roster regardless of what they picked in the wizard.
+func TestHandleCompleteDecodesBlueprintAndAgents(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		var gotTask, gotBlueprint string
+		var gotSkipTask bool
+		var gotAgents []string
+		captured := func(task string, skipTask bool, blueprintID string, selectedAgents []string) error {
+			gotTask = task
+			gotSkipTask = skipTask
+			gotBlueprint = blueprintID
+			gotAgents = selectedAgents
+			return nil
+		}
+
+		body := map[string]interface{}{
+			"task":      "Stand up niche CRM",
+			"skip_task": false,
+			"blueprint": "niche-crm",
+			"agents":    []string{"operator", "builder"},
+		}
+		data, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/complete", bytes.NewReader(data))
+		w := httptest.NewRecorder()
+		HandleComplete(w, req, captured)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d, want %d\nbody: %s", w.Code, http.StatusOK, w.Body.String())
+		}
+		if gotTask != "Stand up niche CRM" {
+			t.Errorf("task: got %q want %q", gotTask, "Stand up niche CRM")
+		}
+		if gotSkipTask {
+			t.Errorf("skipTask: got true want false")
+		}
+		if gotBlueprint != "niche-crm" {
+			t.Errorf("blueprint: got %q want %q", gotBlueprint, "niche-crm")
+		}
+		if len(gotAgents) != 2 || gotAgents[0] != "operator" || gotAgents[1] != "builder" {
+			t.Errorf("agents: got %v want [operator builder]", gotAgents)
+		}
+	})
+}
+
+// TestHandleCompleteBackwardCompatWithLegacyClient verifies that a POST
+// body without the new blueprint/agents fields (e.g. from an older client)
+// is still accepted, with blueprintID empty and selectedAgents nil. The
+// downstream onboardingCompleteFn must treat these as "from scratch".
+func TestHandleCompleteBackwardCompatWithLegacyClient(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		var gotBlueprint string
+		var gotAgents []string
+		captured := func(task string, skipTask bool, blueprintID string, selectedAgents []string) error {
+			gotBlueprint = blueprintID
+			gotAgents = selectedAgents
+			return nil
+		}
+
+		body := map[string]interface{}{"task": "go", "skip_task": false}
+		data, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/complete", bytes.NewReader(data))
+		w := httptest.NewRecorder()
+		HandleComplete(w, req, captured)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d, body: %s", w.Code, w.Body.String())
+		}
+		if gotBlueprint != "" {
+			t.Errorf("blueprint: got %q want empty", gotBlueprint)
+		}
+		if len(gotAgents) != 0 {
+			t.Errorf("agents: got %v want empty/nil", gotAgents)
+		}
+	})
+}
+
+// TestHandleCompleteReturns500OnCompleteFnError verifies that if
+// completeFn returns an error (e.g. LoadBlueprint failed), the handler
+// returns HTTP 500 so the wizard can surface the error to the user.
+func TestHandleCompleteReturns500OnCompleteFnError(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		failing := func(task string, skipTask bool, blueprintID string, selectedAgents []string) error {
+			return fmt.Errorf("simulated loader failure for %q", blueprintID)
+		}
+
+		body := map[string]interface{}{"task": "go", "skip_task": false, "blueprint": "bogus"}
+		data, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/complete", bytes.NewReader(data))
+		w := httptest.NewRecorder()
+		HandleComplete(w, req, failing)
+
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("status: got %d want 500\nbody: %s", w.Code, w.Body.String())
 		}
 	})
 }

--- a/internal/onboarding/handlers_test.go
+++ b/internal/onboarding/handlers_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -300,10 +301,14 @@ func TestHandleCompleteBackwardCompatWithLegacyClient(t *testing.T) {
 // TestHandleCompleteReturns500OnCompleteFnError verifies that if
 // completeFn returns an error (e.g. LoadBlueprint failed), the handler
 // returns HTTP 500 so the wizard can surface the error to the user.
+// The response body must NOT include the wrapped error detail (which can
+// carry filesystem paths, yaml parse messages, or user-supplied ids);
+// those stay server-side in logs.
 func TestHandleCompleteReturns500OnCompleteFnError(t *testing.T) {
 	withTempHome(t, func(_ string) {
+		const secretDetail = "secret-path-/etc/wuphf/state.yaml"
 		failing := func(task string, skipTask bool, blueprintID string, selectedAgents []string) error {
-			return fmt.Errorf("simulated loader failure for %q", blueprintID)
+			return fmt.Errorf("%s: simulated loader failure for %q", secretDetail, blueprintID)
 		}
 
 		body := map[string]interface{}{"task": "go", "skip_task": false, "blueprint": "bogus"}
@@ -314,6 +319,39 @@ func TestHandleCompleteReturns500OnCompleteFnError(t *testing.T) {
 
 		if w.Code != http.StatusInternalServerError {
 			t.Fatalf("status: got %d want 500\nbody: %s", w.Code, w.Body.String())
+		}
+		if strings.Contains(w.Body.String(), secretDetail) {
+			t.Errorf("500 body leaked internal error detail; body: %s", w.Body.String())
+		}
+		if strings.Contains(w.Body.String(), "bogus") {
+			t.Errorf("500 body echoed user-supplied blueprint id; body: %s", w.Body.String())
+		}
+	})
+}
+
+// TestHandleCompleteSkipTaskPersistsOnboardedState verifies that
+// skip_task=true still flips the state to onboarded on disk, so a user
+// who opts out of the first-task prompt does not re-enter the wizard on
+// next launch. This was a gap caught in review — the in-memory seeding
+// was verified but disk persistence was not.
+func TestHandleCompleteSkipTaskPersistsOnboardedState(t *testing.T) {
+	withTempHome(t, func(_ string) {
+		body := map[string]interface{}{"task": "", "skip_task": true, "blueprint": "", "agents": nil}
+		data, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/onboarding/complete", bytes.NewReader(data))
+		w := httptest.NewRecorder()
+		HandleComplete(w, req, nil)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("status: got %d\nbody: %s", w.Code, w.Body.String())
+		}
+
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if !s.Onboarded() {
+			t.Error("expected Onboarded()=true after skip_task=true; wizard would reopen on next launch")
 		}
 	})
 }

--- a/internal/onboarding/templates.go
+++ b/internal/onboarding/templates.go
@@ -134,6 +134,14 @@ func onboardingTemplateID(value string) string {
 	return strings.Trim(b.String(), "-")
 }
 
+// ResolveTemplatesRepoRoot walks up from repoRoot (or cwd if empty) until
+// it finds a templates/operations directory, returning the containing
+// path. Used by the broker to load curated blueprints when the user
+// finishes onboarding.
+func ResolveTemplatesRepoRoot(repoRoot string) string {
+	return resolveTemplatesRepoRoot(repoRoot)
+}
+
 func resolveTemplatesRepoRoot(repoRoot string) string {
 	repoRoot = strings.TrimSpace(repoRoot)
 	if repoRoot == "" {

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -2669,17 +2669,18 @@ func (b *Broker) ensureDefaultChannelsLocked() {
 	}
 }
 
+// ensureDefaultOfficeMembersLocked seeds the DefaultManifest roster ONLY when
+// no members exist. Prior implementation appended any missing default slug to
+// a non-empty roster, which caused ceo/planner/executor/reviewer to leak back
+// into blueprint-seeded teams (e.g. niche-crm) on every Broker.Load(). The
+// function is called from broker init (line 831) and post-load normalization
+// (line 2260) as a true recovery hook: if state was corrupted or never
+// seeded, fall back to defaults.
 func (b *Broker) ensureDefaultOfficeMembersLocked() {
-	if len(b.members) == 0 {
-		b.members = defaultOfficeMembers()
+	if len(b.members) > 0 {
 		return
 	}
-	defaults := defaultOfficeMembers()
-	for _, member := range defaults {
-		if b.findMemberLocked(member.Slug) == nil {
-			b.members = append(b.members, member)
-		}
-	}
+	b.members = defaultOfficeMembers()
 }
 
 func (b *Broker) normalizeLoadedStateLocked() {

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -6097,14 +6097,20 @@ func (b *Broker) handleChannelMembers(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "channel not found", http.StatusNotFound)
 			return
 		}
-		if b.findMemberLocked(member) == nil {
+		memberRecord := b.findMemberLocked(member)
+		if memberRecord == nil {
 			b.mu.Unlock()
 			http.Error(w, "member not found", http.StatusNotFound)
 			return
 		}
-		if member == "ceo" && (action == "remove" || action == "disable") {
+		// Lead agents (BuiltIn) cannot be disabled or removed from any
+		// channel. The blueprint's lead is the tag target for the onboarding
+		// kickoff and the default owner for channel membership; the UI locks
+		// these interactions too. Keeps the "ceo" literal as a legacy guard
+		// for team states that predate the BuiltIn field.
+		if (memberRecord.BuiltIn || member == "ceo") && (action == "remove" || action == "disable") {
 			b.mu.Unlock()
-			http.Error(w, "cannot remove or disable CEO", http.StatusBadRequest)
+			http.Error(w, "cannot remove or disable lead agent", http.StatusBadRequest)
 			return
 		}
 		switch action {

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -16,10 +16,20 @@ import (
 // message tagged to the office lead, and lets the existing launcher trigger
 // the lead's delegate turn.
 //
+// blueprintID and selectedAgents are threaded from the wizard via the POST
+// body. blueprintID is the curated blueprint the user picked (empty for
+// "from scratch"). selectedAgents is the user's agent-toggle state (nil for
+// back-compat clients that don't send it, or internal synthesis callers).
+// Cycle 3 of the plan will consume these to seed the real blueprint team;
+// for now they are captured but not yet used — the seeding path is
+// unchanged from previous behavior.
+//
 // Side effects happen BEFORE the onboarding package writes the completion
 // flag to disk, so a crash between this call returning and the flag write
 // re-enters the wizard — and the dedupe guard below prevents double-posting.
-func (b *Broker) onboardingCompleteFn(task string, skipTask bool) error {
+func (b *Broker) onboardingCompleteFn(task string, skipTask bool, blueprintID string, selectedAgents []string) error {
+	_ = blueprintID
+	_ = selectedAgents
 	b.mu.Lock()
 	defer b.mu.Unlock()
 

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"fmt"
+	"log"
 	"strings"
 	"time"
 
@@ -33,22 +34,7 @@ import (
 // reached via this path. It remains only as a true-recovery fallback in
 // ensureDefaultOfficeMembersLocked for corrupted/zero-member state.
 func (b *Broker) onboardingCompleteFn(task string, skipTask bool, blueprintID string, selectedAgents []string) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	task = strings.TrimSpace(task)
-
-	// Dedupe BEFORE any state mutation. If a prior call already posted this
-	// exact task as an onboarding_origin message (crash-recovery scenario),
-	// skip re-seeding and preserve the earlier team.
-	if !skipTask && task != "" {
-		for _, existing := range b.messages {
-			if existing.Channel == "general" && existing.Kind == "onboarding_origin" && existing.Content == task {
-				return b.saveLocked()
-			}
-		}
-	}
-
 	if !skipTask && task == "" {
 		return fmt.Errorf("onboarding: task is required when skip_task=false")
 	}
@@ -56,6 +42,11 @@ func (b *Broker) onboardingCompleteFn(task string, skipTask bool, blueprintID st
 	blueprintID = strings.TrimSpace(blueprintID)
 	synthesized := blueprintID == ""
 
+	// Resolve the blueprint OUTSIDE the broker lock. LoadBlueprint reads YAML
+	// from disk and runs validation; holding b.mu during that blocks every
+	// other goroutine that needs the broker. Synthesis for the from-scratch
+	// path reads onboarding state (another file) inside
+	// synthesizeBlueprintFromState — also moved out of the critical section.
 	var bp operations.Blueprint
 	if blueprintID != "" {
 		loaded, err := operations.LoadBlueprint(onboarding.ResolveTemplatesRepoRoot(""), blueprintID)
@@ -64,21 +55,40 @@ func (b *Broker) onboardingCompleteFn(task string, skipTask bool, blueprintID st
 		}
 		bp = loaded
 	} else {
-		bp = b.synthesizeBlueprintFromStateLocked(task)
+		bp = synthesizeBlueprintFromState(task)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Dedupe after we're inside the lock so the messages slice is stable.
+	// If a prior call already posted this exact task as an onboarding_origin
+	// message (crash-recovery scenario), skip re-seeding and preserve the
+	// earlier team.
+	if !skipTask && task != "" {
+		for _, existing := range b.messages {
+			if existing.Channel == "general" && existing.Kind == "onboarding_origin" && existing.Content == task {
+				return b.saveLocked()
+			}
+		}
 	}
 
 	return b.seedFromBlueprintLocked(bp, selectedAgents, task, skipTask, synthesized)
 }
 
-// synthesizeBlueprintFromStateLocked builds a blueprint from whatever the
-// user typed into the wizard (company name, description, size, priority,
-// plus the task text as directive). Mirrors the pre-rewrite
-// seedBlankSlateOperationLocked profile construction.
-func (b *Broker) synthesizeBlueprintFromStateLocked(task string) operations.Blueprint {
+// synthesizeBlueprintFromState builds a blueprint from whatever the user
+// typed into the wizard (company name, description, size, priority, plus
+// the task text as directive). Reads onboarding state from disk, so it
+// must be called OUTSIDE the broker mutex. Unlike the old
+// seedBlankSlateOperationLocked it does not mutate broker state — the
+// caller feeds the returned Blueprint to seedFromBlueprintLocked.
+func synthesizeBlueprintFromState(task string) operations.Blueprint {
 	state, err := onboarding.Load()
 	if err != nil {
-		// Best-effort: fall through with empty profile. SynthesizeBlueprint
-		// tolerates sparse input by producing a generic blueprint.
+		// Best-effort: fall through with empty profile. A Load failure is
+		// logged by the onboarding package; SynthesizeBlueprint tolerates
+		// sparse input by producing a generic blueprint.
+		log.Printf("onboarding: load state for synthesis: %v", err)
 		state = &onboarding.State{}
 	}
 	profile := operationCompanyProfile{
@@ -150,7 +160,11 @@ func (b *Broker) postKickoffLocked(bp operations.Blueprint, selectedAgents []str
 	}
 
 	if skipTask {
-		return nil
+		// seedFromBlueprintLocked mutated b.members/channels/tasks above; we
+		// must persist that even when the user skipped the kickoff task.
+		// Returning early without saveLocked() silently loses the seeded team
+		// on the next broker Load.
+		return b.saveLocked()
 	}
 
 	task = strings.TrimSpace(task)

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -2,7 +2,6 @@ package team
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -11,95 +10,76 @@ import (
 )
 
 // onboardingCompleteFn is invoked by the onboarding package when the user
-// finishes the wizard. It seeds the default team (idempotent — no-op if a
-// team already exists), posts the user's first task to #general as a human
-// message tagged to the office lead, and lets the existing launcher trigger
-// the lead's delegate turn.
+// finishes the wizard. It seeds the team from the user's picked blueprint
+// (or synthesizes one if blueprintID is empty — the "from scratch" path),
+// honors the wizard's per-agent checkbox filter, and posts the kickoff
+// task to #general tagged to the blueprint's lead agent.
 //
-// blueprintID and selectedAgents are threaded from the wizard via the POST
-// body. blueprintID is the curated blueprint the user picked (empty for
-// "from scratch"). selectedAgents is the user's agent-toggle state (nil for
-// back-compat clients that don't send it, or internal synthesis callers).
-// Cycle 3 of the plan will consume these to seed the real blueprint team;
-// for now they are captured but not yet used — the seeding path is
-// unchanged from previous behavior.
+// Contract:
+//   - blueprintID is the curated blueprint the user selected. Empty means
+//     "from scratch" — the broker synthesizes a blueprint from the
+//     onboarding-state goals.
+//   - selectedAgents mirrors the wizard's toggle state:
+//     nil   → no filtering (internal / synthesis callers, legacy client);
+//     []    → user unchecked every agent; seed lead only + system notice;
+//     [...] → keep only those slugs (plus the lead, which is unremovable).
 //
 // Side effects happen BEFORE the onboarding package writes the completion
 // flag to disk, so a crash between this call returning and the flag write
-// re-enters the wizard — and the dedupe guard below prevents double-posting.
+// re-enters the wizard. The dedupe guard below (onboarding_origin by task
+// content) prevents double-posting on crash recovery.
+//
+// The DefaultManifest roster (ceo/planner/executor/reviewer) is NEVER
+// reached via this path. It remains only as a true-recovery fallback in
+// ensureDefaultOfficeMembersLocked for corrupted/zero-member state.
 func (b *Broker) onboardingCompleteFn(task string, skipTask bool, blueprintID string, selectedAgents []string) error {
-	_ = blueprintID
-	_ = selectedAgents
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if b.blankSlateLaunch {
-		if err := b.seedBlankSlateOperationLocked(task, skipTask); err != nil {
-			return err
-		}
-		return b.saveLocked()
-	}
-
-	// Seed default team if none is configured yet. This mirrors the path
-	// taken on first boot (see ensureDefaultOfficeMembersLocked).
-	b.ensureDefaultOfficeMembersLocked()
-
-	// Skip-task path: team seeded, no first message. Caller marks onboarded.
-	if skipTask {
-		return b.saveLocked()
-	}
-
 	task = strings.TrimSpace(task)
-	if task == "" {
+
+	// Dedupe BEFORE any state mutation. If a prior call already posted this
+	// exact task as an onboarding_origin message (crash-recovery scenario),
+	// skip re-seeding and preserve the earlier team.
+	if !skipTask && task != "" {
+		for _, existing := range b.messages {
+			if existing.Channel == "general" && existing.Kind == "onboarding_origin" && existing.Content == task {
+				return b.saveLocked()
+			}
+		}
+	}
+
+	if !skipTask && task == "" {
 		return fmt.Errorf("onboarding: task is required when skip_task=false")
 	}
 
-	// Dedupe: if a prior onboarding-complete already posted this exact task
-	// (recognized via the onboarding_origin marker in Kind), skip re-posting.
-	for _, existing := range b.messages {
-		if existing.Channel == "general" && existing.Kind == "onboarding_origin" && existing.Content == task {
-			return b.saveLocked()
+	blueprintID = strings.TrimSpace(blueprintID)
+	synthesized := blueprintID == ""
+
+	var bp operations.Blueprint
+	if blueprintID != "" {
+		loaded, err := operations.LoadBlueprint(onboarding.ResolveTemplatesRepoRoot(""), blueprintID)
+		if err != nil {
+			return fmt.Errorf("onboarding: load blueprint %q: %w", blueprintID, err)
 		}
+		bp = loaded
+	} else {
+		bp = b.synthesizeBlueprintFromStateLocked(task)
 	}
 
-	lead := officeLeadSlugFrom(b.members)
-	if lead == "" {
-		lead = defaultOfficeLeadForLaunchMode()
-	}
-
-	b.counter++
-	msg := channelMessage{
-		ID:        fmt.Sprintf("msg-%d", b.counter),
-		From:      "human",
-		Channel:   "general",
-		Kind:      "onboarding_origin",
-		Content:   task,
-		Tagged:    []string{lead},
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-	}
-	b.appendMessageLocked(msg)
-
-	if b.lastTaggedAt == nil {
-		b.lastTaggedAt = make(map[string]time.Time)
-	}
-	b.lastTaggedAt[lead] = time.Now()
-
-	return b.saveLocked()
+	return b.seedFromBlueprintLocked(bp, selectedAgents, task, skipTask, synthesized)
 }
 
-func defaultOfficeLeadForLaunchMode() string {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("WUPHF_START_FROM_SCRATCH"))) {
-	case "1", "true", "yes":
-		return "founder"
-	default:
-		return "ceo"
-	}
-}
-
-func (b *Broker) seedBlankSlateOperationLocked(task string, skipTask bool) error {
+// synthesizeBlueprintFromStateLocked builds a blueprint from whatever the
+// user typed into the wizard (company name, description, size, priority,
+// plus the task text as directive). Mirrors the pre-rewrite
+// seedBlankSlateOperationLocked profile construction.
+func (b *Broker) synthesizeBlueprintFromStateLocked(task string) operations.Blueprint {
 	state, err := onboarding.Load()
 	if err != nil {
-		return err
+		// Best-effort: fall through with empty profile. SynthesizeBlueprint
+		// tolerates sparse input by producing a generic blueprint.
+		state = &onboarding.State{}
 	}
 	profile := operationCompanyProfile{
 		Name:        strings.TrimSpace(state.CompanyName),
@@ -108,85 +88,123 @@ func (b *Broker) seedBlankSlateOperationLocked(task string, skipTask bool) error
 		Size:        onboardingPartialString(state.Partial, "welcome", "size"),
 		Priority:    onboardingPartialString(state.Partial, "welcome", "priority"),
 	}
-	blueprint := operations.SynthesizeBlueprint(operations.SynthesisInput{
-		Directive:    profile.Goals,
-		Profile:      operations.CompanyProfile{Name: profile.Name, Description: profile.Description, Audience: profile.Size, Offer: profile.Goals},
-		Description:  profile.Description,
-		Goals:        profile.Goals,
-		Size:         profile.Size,
-		Priority:     profile.Priority,
-		Integrations: nil,
-		Capabilities: nil,
+	return operations.SynthesizeBlueprint(operations.SynthesisInput{
+		Directive: profile.Goals,
+		Profile: operations.CompanyProfile{
+			Name:        profile.Name,
+			Description: profile.Description,
+			Audience:    profile.Size,
+			Offer:       profile.Goals,
+		},
+		Description: profile.Description,
+		Goals:       profile.Goals,
+		Size:        profile.Size,
+		Priority:    profile.Priority,
 	})
-	b.members = blankSlateOfficeMembersFromBlueprint(blueprint)
+}
+
+// seedFromBlueprintLocked is the single seed path used by both picked-
+// blueprint and from-scratch flows. It replaces the prior dual-path code
+// (seedBlankSlateOperationLocked + ensureDefaultOfficeMembersLocked+manual
+// kickoff). selectedAgents filters the blueprint's starter roster; see the
+// onboardingCompleteFn doc comment for the three-mode contract.
+func (b *Broker) seedFromBlueprintLocked(bp operations.Blueprint, selectedAgents []string, task string, skipTask bool, synthesized bool) error {
+	b.members = blankSlateOfficeMembersFromBlueprint(bp, selectedAgents)
 	if len(b.members) == 0 {
+		// Defensive: blueprint had no parseable agents AND no lead fallback
+		// kicked in. Seed the DefaultManifest so the user has SOMETHING.
 		b.members = defaultOfficeMembers()
 	}
-	b.channels = blankSlateOfficeChannelsFromBlueprint(blueprint, b.members)
-	b.tasks = blankSlateOfficeTasksFromBlueprint(blueprint)
+	b.channels = blankSlateOfficeChannelsFromBlueprint(bp, b.members)
+	b.tasks = blankSlateOfficeTasksFromBlueprint(bp)
 	if len(b.channels) == 0 {
 		b.channels = []teamChannel{{
 			Slug:        "general",
 			Name:        "general",
-			Description: "Primary coordination channel for the blank-slate office.",
+			Description: "Primary coordination channel.",
 			Members:     memberSlugsFromMembers(b.members),
 		}}
 	}
 	b.messages = nil
 	b.counter = 0
 	b.lastTaggedAt = make(map[string]time.Time)
-	return b.postBlankSlateKickoffLocked(profile, blueprint, task, skipTask)
+	return b.postKickoffLocked(bp, selectedAgents, task, skipTask, synthesized)
 }
 
-func (b *Broker) postBlankSlateKickoffLocked(profile operationCompanyProfile, blueprint operations.Blueprint, task string, skipTask bool) error {
+func (b *Broker) postKickoffLocked(bp operations.Blueprint, selectedAgents []string, task string, skipTask bool, synthesized bool) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Lead-only warning: the wizard sent agents=[] (explicit empty = every
+	// toggle unchecked). The seed helper fell back to lead-only; surface
+	// that via a system message so the user knows the team is minimal.
+	if selectedAgents != nil && len(selectedAgents) == 0 && len(b.members) == 1 {
+		b.counter++
+		b.appendMessageLocked(channelMessage{
+			ID:        fmt.Sprintf("msg-%d", b.counter),
+			From:      "system",
+			Channel:   "general",
+			Kind:      "system",
+			Content:   "Team seeded with lead only. Add specialists from Team settings.",
+			Timestamp: now,
+		})
+	}
+
 	if skipTask {
 		return nil
 	}
+
 	task = strings.TrimSpace(task)
 	if task == "" {
 		return fmt.Errorf("onboarding: task is required when skip_task=false")
 	}
+
 	lead := officeLeadSlugFromMembers(b.members)
 	if lead == "" {
 		lead = "operator"
 	}
+
 	b.counter++
-	msg := channelMessage{
+	b.appendMessageLocked(channelMessage{
 		ID:        fmt.Sprintf("msg-%d", b.counter),
 		From:      "human",
 		Channel:   "general",
 		Kind:      "onboarding_origin",
 		Content:   task,
 		Tagged:    []string{lead},
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-	}
-	b.appendMessageLocked(msg)
+		Timestamp: now,
+	})
 	if b.lastTaggedAt == nil {
 		b.lastTaggedAt = make(map[string]time.Time)
 	}
 	b.lastTaggedAt[lead] = time.Now()
-	if strings.TrimSpace(blueprint.Name) != "" {
+
+	// Synthesized blueprints (from-scratch path) post two extra markers so
+	// the downstream agents know they are running against a just-invented
+	// operation rather than a curated one.
+	if synthesized {
+		if strings.TrimSpace(bp.Name) != "" {
+			b.counter++
+			b.appendMessageLocked(channelMessage{
+				ID:        fmt.Sprintf("msg-%d", b.counter),
+				From:      "system",
+				Channel:   "general",
+				Kind:      "synthesized_blueprint",
+				Content:   fmt.Sprintf("Synthesized operation: %s (%s)", bp.Name, bp.Kind),
+				Timestamp: now,
+			})
+		}
 		b.counter++
 		b.appendMessageLocked(channelMessage{
 			ID:        fmt.Sprintf("msg-%d", b.counter),
 			From:      "system",
 			Channel:   "general",
-			Kind:      "synthesized_blueprint",
-			Content:   fmt.Sprintf("Synthesized operation: %s (%s)", blueprint.Name, blueprint.Kind),
-			Timestamp: time.Now().UTC().Format(time.RFC3339),
+			Kind:      "from_scratch_contract",
+			Content:   "Run this as a real business workflow. If a needed specialist, channel, skill, or tooling path is missing, create it and keep going. Local proof packets, review bundles, and other internal substitute artifacts do not count when a live business step is possible.",
+			Timestamp: now,
 		})
 	}
-	b.counter++
-	b.appendMessageLocked(channelMessage{
-		ID:        fmt.Sprintf("msg-%d", b.counter),
-		From:      "system",
-		Channel:   "general",
-		Kind:      "from_scratch_contract",
-		Content:   "Run this as a real business workflow. If a needed specialist, channel, skill, or tooling path is missing, create it and keep going. Local proof packets, review bundles, and other internal substitute artifacts do not count when a live business step is possible.",
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-	})
-	_ = profile
-	return nil
+
+	return b.saveLocked()
 }
 
 func onboardingPartialString(partial *onboarding.PartialProgress, step, key string) string {
@@ -205,13 +223,27 @@ func onboardingPartialString(partial *onboarding.PartialProgress, step, key stri
 	return ""
 }
 
-func blankSlateOfficeMembersFromBlueprint(blueprint operations.Blueprint) []officeMember {
+// blankSlateOfficeMembersFromBlueprint projects a blueprint's starter
+// agent list into broker officeMembers, applying the wizard's
+// selectedAgents filter. See onboardingCompleteFn doc for the nil / empty
+// / populated contract.
+//
+// The lead agent (from blueprint.Starter.LeadSlug) is always kept,
+// regardless of the filter — removing the lead leaves downstream code with
+// no one to tag for kickoff and no BuiltIn member for channel ownership.
+func blankSlateOfficeMembersFromBlueprint(blueprint operations.Blueprint, selectedAgents []string) []officeMember {
 	agents := blueprint.Starter.Agents
+	leadSlug := normalizeChannelSlug(blueprint.Starter.LeadSlug)
+	filter := agentSelectionFilter(selectedAgents, leadSlug)
+
 	members := make([]officeMember, 0, len(agents))
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, agent := range agents {
 		slug := normalizeChannelSlug(operationFirstNonEmpty(agent.Slug, agent.EmployeeBlueprint, operationSlug(agent.Name)))
 		if slug == "" {
+			continue
+		}
+		if filter != nil && !filter(slug) {
 			continue
 		}
 		name := strings.TrimSpace(agent.Name)
@@ -232,18 +264,41 @@ func blankSlateOfficeMembersFromBlueprint(blueprint operations.Blueprint) []offi
 			AllowedTools:   nil,
 			CreatedBy:      "wuphf",
 			CreatedAt:      now,
-			BuiltIn:        agent.BuiltIn || slug == "operator" || slug == "founder" || slug == "ceo",
+			BuiltIn:        agent.BuiltIn || slug == leadSlug || slug == "operator" || slug == "founder" || slug == "ceo",
 		})
 	}
 	if len(members) > 0 {
 		return members
 	}
+	// Defensive fallback used only when the blueprint had zero parseable
+	// agents. Keeps the broker from crashing on empty rosters.
 	return []officeMember{
 		{Slug: "founder", Name: "Founder", Role: "Founder", PermissionMode: "plan", BuiltIn: true, CreatedBy: "wuphf", CreatedAt: now},
 		{Slug: "operator", Name: "Operator", Role: "Operator", PermissionMode: "auto", BuiltIn: true, CreatedBy: "wuphf", CreatedAt: now},
 		{Slug: "builder", Name: "Builder", Role: "Builder", PermissionMode: "auto", CreatedBy: "wuphf", CreatedAt: now},
 		{Slug: "reviewer", Name: "Reviewer", Role: "Reviewer", PermissionMode: "plan", CreatedBy: "wuphf", CreatedAt: now},
 	}
+}
+
+// agentSelectionFilter returns a membership predicate for the wizard's
+// selectedAgents array. nil input disables filtering (keep all); empty
+// array keeps only the lead so the team isn't empty (the caller relies on
+// len(members) == 1 to emit the lead-only system message); a populated
+// array keeps only those slugs, always including the lead.
+func agentSelectionFilter(selectedAgents []string, leadSlug string) func(string) bool {
+	if selectedAgents == nil {
+		return nil
+	}
+	allowed := make(map[string]bool, len(selectedAgents)+1)
+	for _, s := range selectedAgents {
+		if slug := normalizeChannelSlug(s); slug != "" {
+			allowed[slug] = true
+		}
+	}
+	if leadSlug != "" {
+		allowed[leadSlug] = true
+	}
+	return func(slug string) bool { return allowed[slug] }
 }
 
 func blankSlateOfficeChannelsFromBlueprint(blueprint operations.Blueprint, members []officeMember) []teamChannel {
@@ -289,6 +344,7 @@ func blankSlateOfficeChannelsFromBlueprint(blueprint operations.Blueprint, membe
 
 func blankSlateOfficeTasksFromBlueprint(blueprint operations.Blueprint) []teamTask {
 	now := time.Now().UTC().Format(time.RFC3339)
+	prefix := taskIDPrefix(blueprint)
 	tasks := make([]teamTask, 0, len(blueprint.Starter.Tasks))
 	for i, starter := range blueprint.Starter.Tasks {
 		channel := normalizeChannelSlug(starter.Channel)
@@ -297,7 +353,7 @@ func blankSlateOfficeTasksFromBlueprint(blueprint operations.Blueprint) []teamTa
 		}
 		owner := normalizeChannelSlug(starter.Owner)
 		tasks = append(tasks, teamTask{
-			ID:        fmt.Sprintf("blank-slate-%d", i+1),
+			ID:        fmt.Sprintf("%s-%d", prefix, i+1),
 			Channel:   channel,
 			Title:     strings.TrimSpace(starter.Title),
 			Details:   strings.TrimSpace(starter.Details),
@@ -309,6 +365,18 @@ func blankSlateOfficeTasksFromBlueprint(blueprint operations.Blueprint) []teamTa
 		})
 	}
 	return tasks
+}
+
+// taskIDPrefix returns a slug usable as a prefix for seeded task IDs.
+// Curated blueprints (niche-crm, youtube-factory, etc.) have an ID field
+// set by the loader; synthesized blueprints have an inferred ID too, but
+// if for any reason the blueprint has no ID we fall back to "blank-slate"
+// to preserve the legacy id shape.
+func taskIDPrefix(bp operations.Blueprint) string {
+	if id := normalizeChannelSlug(bp.ID); id != "" {
+		return id
+	}
+	return "blank-slate"
 }
 
 func blankSlatePermissionMode(kind string) string {

--- a/internal/team/broker_onboarding_test.go
+++ b/internal/team/broker_onboarding_test.go
@@ -242,6 +242,49 @@ func TestOnboardingCompleteSkipTaskSeedsNoKickoff(t *testing.T) {
 	}
 }
 
+// REGRESSION: TestOnboardingCompleteSkipTaskPersistsTeam verifies that
+// skip_task=true actually persists the seeded team to disk. The previous
+// rewrite returned nil from postKickoffLocked before saveLocked(), so a
+// user who clicked "skip first task" would lose their entire blueprint
+// team on the next broker restart.
+func TestOnboardingCompleteSkipTaskPersistsTeam(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	if err := b.onboardingCompleteFn("", true, "niche-crm", nil); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	// Fresh broker instance re-reads state from disk.
+	reloaded := NewBroker()
+	reloaded.mu.Lock()
+	slugs := make([]string, 0, len(reloaded.members))
+	for _, m := range reloaded.members {
+		slugs = append(slugs, m.Slug)
+	}
+	reloaded.mu.Unlock()
+
+	want := map[string]bool{"operator": true, "planner": true, "builder": true, "growth": true, "reviewer": true}
+	for slug := range want {
+		found := false
+		for _, got := range slugs {
+			if got == slug {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected niche-crm slug %q to persist across restart; got %v", slug, slugs)
+		}
+	}
+	for _, slug := range slugs {
+		if slug == "ceo" || slug == "executor" {
+			t.Errorf("DefaultManifest slug %q leaked into persisted roster %v", slug, slugs)
+		}
+	}
+}
+
 // TestOnboardingCompleteLoadBlueprintErrorReturnsError verifies that a bad
 // blueprint id produces a non-nil error (which HandleComplete surfaces as
 // HTTP 500). No partial state should be seeded.

--- a/internal/team/broker_onboarding_test.go
+++ b/internal/team/broker_onboarding_test.go
@@ -1,0 +1,348 @@
+package team
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/operations"
+)
+
+// locateRepoRoot walks up from the test's cwd looking for the
+// templates/operations directory, so LoadBlueprint can find curated
+// blueprint YAML on disk. Returns "" if not found — callers fall back to
+// setting up an embedded FS.
+func locateRepoRoot(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for dir := cwd; dir != "/" && dir != ""; dir = filepath.Dir(dir) {
+		if _, err := os.Stat(filepath.Join(dir, "templates", "operations")); err == nil {
+			return dir
+		}
+	}
+	return ""
+}
+
+// ensureOperationsFallbackFS points operations at the repo's
+// templates/operations tree if LoadBlueprint("", ...) would otherwise miss
+// it (the wuphf root package's init() sets this, but that init does not
+// run in team-package tests).
+func ensureOperationsFallbackFS(t *testing.T) {
+	t.Helper()
+	root := locateRepoRoot(t)
+	if root == "" {
+		t.Skip("templates/operations not reachable from test cwd; skipping")
+	}
+	sub, err := fs.Sub(os.DirFS(root), ".")
+	if err != nil {
+		t.Fatalf("sub fs: %v", err)
+	}
+	operations.SetFallbackFS(sub)
+}
+
+// withIsolatedBrokerState gives the test a broker with its own state file
+// and a clean broker state on disk, then cleans up when done.
+func withIsolatedBrokerState(t *testing.T) func() {
+	t.Helper()
+	old := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	return func() { brokerStatePath = old }
+}
+
+// TestOnboardingCompleteSeedsFromPickedBlueprint verifies that when the
+// wizard POSTs a curated blueprint id, the broker seeds the exact member
+// list from that blueprint's starter.agents — not ceo/planner/executor/
+// reviewer from DefaultManifest.
+func TestOnboardingCompleteSeedsFromPickedBlueprint(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", nil); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	want := map[string]bool{
+		"operator": true, "planner": true, "builder": true,
+		"growth": true, "reviewer": true,
+	}
+	got := map[string]bool{}
+	b.mu.Lock()
+	for _, m := range b.members {
+		got[m.Slug] = true
+	}
+	b.mu.Unlock()
+
+	for slug := range want {
+		if !got[slug] {
+			t.Errorf("expected niche-crm slug %q in roster; got %v", slug, got)
+		}
+	}
+	for slug := range got {
+		if slug == "ceo" || slug == "executor" {
+			t.Errorf("DefaultManifest slug %q leaked into blueprint roster; got %v", slug, got)
+		}
+	}
+
+	b.mu.Lock()
+	var lead string
+	for _, m := range b.members {
+		if m.BuiltIn {
+			lead = m.Slug
+			break
+		}
+	}
+	b.mu.Unlock()
+	if lead != "operator" {
+		t.Errorf("expected BuiltIn lead to be operator (blueprint's lead_slug), got %q", lead)
+	}
+}
+
+// TestOnboardingCompleteHonorsAgentFilter verifies the wizard's per-agent
+// toggle state: agents=[operator, builder] should seed only those two,
+// dropping the blueprint's other specialists.
+func TestOnboardingCompleteHonorsAgentFilter(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", []string{"operator", "builder"}); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	b.mu.Lock()
+	slugs := make([]string, 0, len(b.members))
+	for _, m := range b.members {
+		slugs = append(slugs, m.Slug)
+	}
+	b.mu.Unlock()
+
+	hasOperator := false
+	hasBuilder := false
+	for _, s := range slugs {
+		switch s {
+		case "operator":
+			hasOperator = true
+		case "builder":
+			hasBuilder = true
+		case "planner", "growth", "reviewer":
+			t.Errorf("unselected slug %q leaked into roster; got %v", s, slugs)
+		}
+	}
+	if !hasOperator {
+		t.Errorf("expected operator (selected) in roster; got %v", slugs)
+	}
+	if !hasBuilder {
+		t.Errorf("expected builder (selected) in roster; got %v", slugs)
+	}
+}
+
+// TestOnboardingCompleteAgentsEmptySeedsLeadOnly verifies that an empty
+// agents array (user unchecked every toggle) seeds only the blueprint's
+// lead and posts a system message explaining the fallback.
+func TestOnboardingCompleteAgentsEmptySeedsLeadOnly(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", []string{}); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	b.mu.Lock()
+	memberCount := len(b.members)
+	var leadSlug string
+	if memberCount == 1 {
+		leadSlug = b.members[0].Slug
+	}
+	var foundSystemMsg bool
+	for _, msg := range b.messages {
+		if msg.Kind == "system" && strings.Contains(msg.Content, "lead only") {
+			foundSystemMsg = true
+			break
+		}
+	}
+	b.mu.Unlock()
+
+	if memberCount != 1 {
+		t.Fatalf("expected lead-only roster (1 member), got %d", memberCount)
+	}
+	if leadSlug != "operator" {
+		t.Errorf("expected lead slug operator, got %q", leadSlug)
+	}
+	if !foundSystemMsg {
+		t.Errorf("expected system message explaining lead-only fallback; messages seen")
+	}
+}
+
+// TestOnboardingCompleteFromScratchSynthesizes verifies that when blueprint
+// id is empty, the broker synthesizes a blueprint from the user's goal and
+// seeds the resulting team — NOT the DefaultManifest roster.
+func TestOnboardingCompleteFromScratchSynthesizes(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	if err := b.onboardingCompleteFn("Build an automated customer-support operation", false, "", nil); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	b.mu.Lock()
+	slugs := make([]string, 0, len(b.members))
+	for _, m := range b.members {
+		slugs = append(slugs, m.Slug)
+	}
+	b.mu.Unlock()
+
+	// The synthesized team must not be the DefaultManifest roster exactly.
+	// Sanity: DefaultManifest is ceo/planner/executor/reviewer. A synthesized
+	// team should differ in composition.
+	if len(slugs) == 4 && slugs[0] == "ceo" && slugs[1] == "planner" && slugs[2] == "executor" && slugs[3] == "reviewer" {
+		t.Errorf("from-scratch produced DefaultManifest roster, not a synthesized team; got %v", slugs)
+	}
+	if len(slugs) == 0 {
+		t.Fatalf("from-scratch produced empty roster")
+	}
+}
+
+// TestOnboardingCompleteSkipTaskSeedsNoKickoff verifies that skip_task=true
+// seeds the team but does not post an onboarding_origin message.
+func TestOnboardingCompleteSkipTaskSeedsNoKickoff(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	if err := b.onboardingCompleteFn("", true, "niche-crm", nil); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	b.mu.Lock()
+	memberCount := len(b.members)
+	var kickoff bool
+	for _, msg := range b.messages {
+		if msg.Kind == "onboarding_origin" {
+			kickoff = true
+			break
+		}
+	}
+	b.mu.Unlock()
+
+	if memberCount == 0 {
+		t.Fatalf("expected team seeded even with skip_task=true, got empty members")
+	}
+	if kickoff {
+		t.Errorf("expected no onboarding_origin message with skip_task=true, found one")
+	}
+}
+
+// TestOnboardingCompleteLoadBlueprintErrorReturnsError verifies that a bad
+// blueprint id produces a non-nil error (which HandleComplete surfaces as
+// HTTP 500). No partial state should be seeded.
+func TestOnboardingCompleteLoadBlueprintErrorReturnsError(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	err := b.onboardingCompleteFn("go", false, "definitely-not-a-real-blueprint", nil)
+	if err == nil {
+		t.Fatalf("expected error for unknown blueprint, got nil")
+	}
+	if !strings.Contains(err.Error(), "definitely-not-a-real-blueprint") && !strings.Contains(err.Error(), "blueprint") {
+		t.Errorf("expected error to reference the blueprint id, got %v", err)
+	}
+}
+
+// REGRESSION: TestOnboardingCompleteDedupesDuplicateTaskMessage verifies
+// that calling onboardingCompleteFn twice with the same task only posts a
+// single onboarding_origin message — existing crash-recovery behavior at
+// broker_onboarding.go:49-53 (pre-rewrite) must survive the unified flow.
+func TestOnboardingCompleteDedupesDuplicateTaskMessage(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	if err := b.onboardingCompleteFn("hello world", false, "niche-crm", nil); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if err := b.onboardingCompleteFn("hello world", false, "niche-crm", nil); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	b.mu.Lock()
+	var count int
+	for _, msg := range b.messages {
+		if msg.Kind == "onboarding_origin" && msg.Content == "hello world" {
+			count++
+		}
+	}
+	b.mu.Unlock()
+
+	if count != 1 {
+		t.Errorf("expected dedupe to keep exactly one onboarding_origin message, got %d", count)
+	}
+}
+
+// TestTaskIDsUseBlueprintPrefix verifies that seeded tasks use a
+// blueprint-id prefix (e.g. "niche-crm-1") instead of the generic
+// "blank-slate-N" prefix, so persisted rows are self-describing.
+func TestTaskIDsUseBlueprintPrefix(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", nil); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	b.mu.Lock()
+	ids := make([]string, 0, len(b.tasks))
+	for _, tk := range b.tasks {
+		ids = append(ids, tk.ID)
+	}
+	b.mu.Unlock()
+
+	if len(ids) == 0 {
+		t.Fatalf("expected niche-crm blueprint to seed at least one task, got 0")
+	}
+	for _, id := range ids {
+		if !strings.HasPrefix(id, "niche-crm-") {
+			t.Errorf("expected task id to start with blueprint prefix; got %q (all: %v)", id, ids)
+			break
+		}
+	}
+}
+
+// TestSeedFromBlueprintNilAgentsKeepsFullRoster verifies the internal /
+// synthesis-path contract: nil selectedAgents means no filtering applied.
+func TestSeedFromBlueprintNilAgentsKeepsFullRoster(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	if err := b.onboardingCompleteFn("go", false, "niche-crm", nil); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	// niche-crm blueprint defines 5 starter agents. nil filter must keep all.
+	b.mu.Lock()
+	seen := make(map[string]bool)
+	for _, m := range b.members {
+		seen[m.Slug] = true
+	}
+	b.mu.Unlock()
+
+	for _, slug := range []string{"operator", "planner", "builder", "growth", "reviewer"} {
+		if !seen[slug] {
+			t.Errorf("nil agents filter should keep all blueprint agents; missing %q (roster: %v)", slug, seen)
+		}
+	}
+}
+
+var _ = fmt.Sprintf

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -816,6 +816,73 @@ func TestChannelMembersRejectUnknownOfficeMember(t *testing.T) {
 	}
 }
 
+// TestChannelMembersRejectDisableOrRemoveOfLead verifies that /channel-members
+// refuses to disable or remove a BuiltIn member (lead agent) from any
+// channel. Before this guard was generalized, only the hardcoded "ceo"
+// slug was protected — blueprint teams whose lead is something else (e.g.
+// niche-crm uses "operator") could silently lose their lead from #general.
+func TestChannelMembersRejectDisableOrRemoveOfLead(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	b.mu.Lock()
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.members = []officeMember{
+		{Slug: "operator", Name: "Operator", Role: "Operator", PermissionMode: "plan", BuiltIn: true, CreatedBy: "wuphf", CreatedAt: now},
+		{Slug: "builder", Name: "Builder", Role: "Builder", PermissionMode: "auto", CreatedBy: "wuphf", CreatedAt: now},
+	}
+	b.channels = []teamChannel{
+		{Slug: "general", Name: "general", Members: []string{"operator", "builder"}, CreatedBy: "wuphf", CreatedAt: now, UpdatedAt: now},
+	}
+	b.mu.Unlock()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	for _, action := range []string{"disable", "remove"} {
+		body, _ := json.Marshal(map[string]any{
+			"action":  action,
+			"channel": "general",
+			"slug":    "operator",
+		})
+		req, _ := http.NewRequest(http.MethodPost, base+"/channel-members", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Errorf("action=%s: expected 400 (cannot remove/disable lead), got %d", action, resp.StatusCode)
+		}
+	}
+
+	// After the rejected attempts, operator must still be a member of #general.
+	b.mu.Lock()
+	var found bool
+	for _, ch := range b.channels {
+		if ch.Slug == "general" {
+			for _, m := range ch.Members {
+				if m == "operator" {
+					found = true
+					break
+				}
+			}
+			break
+		}
+	}
+	b.mu.Unlock()
+	if !found {
+		t.Fatalf("expected operator to remain in #general after rejected disable/remove")
+	}
+}
+
 func TestBrokerAuthRejectsUnauthenticated(t *testing.T) {
 	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -6004,3 +6004,109 @@ func TestHeadlessQueue_NoTimerDrivenWakeup(t *testing.T) {
 		t.Fatalf("expected no workers started without an explicit enqueue, got %v", l.headlessWorkers)
 	}
 }
+
+// ensureDefaultOfficeMembersLocked must seed the full default manifest ONLY
+// when there are no existing members. Its prior behavior (append-any-missing-
+// default) was the source of the load-path leak: blueprint-seeded teams saw
+// ceo/planner/executor/reviewer re-appended on every broker Load.
+func TestEnsureDefaultOfficeMembersSeedsWhenEmpty(t *testing.T) {
+	b := NewBroker()
+	b.mu.Lock()
+	b.members = nil
+	b.ensureDefaultOfficeMembersLocked()
+	got := len(b.members)
+	b.mu.Unlock()
+	if got == 0 {
+		t.Fatalf("expected defaults to be seeded when members empty, got 0")
+	}
+	defaults := defaultOfficeMembers()
+	if len(defaults) != got {
+		t.Fatalf("expected exactly the default roster (len=%d), got len=%d", len(defaults), got)
+	}
+}
+
+// REGRESSION: if a blueprint has seeded members (e.g. operator/planner/builder/
+// growth/reviewer for niche-crm), ensureDefaultOfficeMembersLocked must NOT
+// append ceo/planner/executor/reviewer on top.
+func TestEnsureDefaultOfficeMembersNoOpWhenNonEmpty(t *testing.T) {
+	b := NewBroker()
+	b.mu.Lock()
+	b.members = []officeMember{
+		{Slug: "operator", Name: "Operator", Role: "Operator", PermissionMode: "plan", BuiltIn: true},
+		{Slug: "builder", Name: "Builder", Role: "Builder", PermissionMode: "auto"},
+	}
+	b.ensureDefaultOfficeMembersLocked()
+	got := make([]string, 0, len(b.members))
+	for _, m := range b.members {
+		got = append(got, m.Slug)
+	}
+	b.mu.Unlock()
+
+	want := []string{"operator", "builder"}
+	if len(got) != len(want) {
+		t.Fatalf("expected roster unchanged %v, got %v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected roster unchanged %v, got %v", want, got)
+		}
+	}
+	for _, m := range got {
+		if m == "ceo" || m == "planner" || m == "executor" || m == "reviewer" {
+			t.Fatalf("default slug %q appended into blueprint roster; roster=%v", m, got)
+		}
+	}
+}
+
+// REGRESSION: simulate a fully-seeded blueprint team, save to disk, load into
+// a fresh broker, confirm the team survives unchanged. This is the load-path
+// leak the design doc calls out — prior append-behavior in
+// ensureDefaultOfficeMembersLocked (called from Broker.Load() at broker.go:2260)
+// silently re-added ceo/planner/executor/reviewer.
+func TestLoadDoesNotAppendDefaultsAfterBlueprintSeed(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	b.mu.Lock()
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.members = []officeMember{
+		{Slug: "operator", Name: "Operator", Role: "Operator", PermissionMode: "plan", BuiltIn: true, CreatedBy: "wuphf", CreatedAt: now},
+		{Slug: "planner", Name: "Planner", Role: "Planner", PermissionMode: "plan", CreatedBy: "wuphf", CreatedAt: now},
+		{Slug: "builder", Name: "Builder", Role: "Builder", PermissionMode: "auto", CreatedBy: "wuphf", CreatedAt: now},
+		{Slug: "growth", Name: "Growth", Role: "Growth", PermissionMode: "auto", CreatedBy: "wuphf", CreatedAt: now},
+		{Slug: "reviewer", Name: "Reviewer", Role: "Reviewer", PermissionMode: "plan", CreatedBy: "wuphf", CreatedAt: now},
+	}
+	// Seed a task so saveLocked doesn't short-circuit on default state.
+	b.tasks = []teamTask{{ID: "niche-crm-1", Channel: "general", Title: "Choose the niche", Status: "open", CreatedBy: "wuphf", CreatedAt: now, UpdatedAt: now}}
+	if err := b.saveLocked(); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("saveLocked failed: %v", err)
+	}
+	b.mu.Unlock()
+
+	reloaded := NewBroker()
+	reloaded.mu.Lock()
+	slugs := make([]string, 0, len(reloaded.members))
+	for _, m := range reloaded.members {
+		slugs = append(slugs, m.Slug)
+	}
+	reloaded.mu.Unlock()
+
+	want := []string{"operator", "planner", "builder", "growth", "reviewer"}
+	if len(slugs) != len(want) {
+		t.Fatalf("expected blueprint roster %v to survive reload, got %v", want, slugs)
+	}
+	for i := range want {
+		if slugs[i] != want[i] {
+			t.Fatalf("expected blueprint roster %v to survive reload, got %v", want, slugs)
+		}
+	}
+	for _, s := range slugs {
+		if s == "ceo" || s == "executor" {
+			t.Fatalf("default slug %q leaked into reloaded roster: %v", s, slugs)
+		}
+	}
+}

--- a/web/e2e/tests/wizard.spec.ts
+++ b/web/e2e/tests/wizard.spec.ts
@@ -33,6 +33,16 @@ async function waitForReactMount(page: Page): Promise<void> {
   );
 }
 
+// The wizard flow is welcome → identity → templates. Fill the two required
+// identity fields so the primary CTA enables and we can advance.
+async function advanceToTemplatesStep(page: Page): Promise<void> {
+  await expect(page.locator('.wizard-step').first()).toBeVisible({ timeout: 10_000 });
+  await page.locator('.wizard-step button.btn-primary').first().click();
+  await page.locator('#wiz-company').fill('Smoke Test Co');
+  await page.locator('#wiz-description').fill('Smoke test description');
+  await page.locator('.wizard-step button.btn-primary').first().click();
+}
+
 test.describe('wuphf onboarding wizard smoke', () => {
   test('fresh install lands on the welcome step without crashing', async ({ page }) => {
     const getErrors = collectReactErrors(page);
@@ -53,20 +63,18 @@ test.describe('wuphf onboarding wizard smoke', () => {
     ).toHaveLength(0);
   });
 
-  test('advancing from welcome → templates step does not crash', async ({ page }) => {
-    // Verifies the wizard state machine actually transitions. The welcome
-    // step has a single primary CTA; clicking it should render the
-    // templates step. Assert via the progress-dot count staying > 0 and
-    // a new `.wizard-panel` (only templates step onward has panels).
+  test('advancing from welcome → identity → templates step does not crash', async ({ page }) => {
+    // Verifies the wizard state machine actually transitions. Flow is:
+    // welcome → identity (company + description required) → templates.
+    // Assert via `.wizard-panel` on the templates step.
     const getErrors = collectReactErrors(page);
 
     await page.goto('/');
     await waitForReactMount(page);
 
-    await expect(page.locator('.wizard-step').first()).toBeVisible({ timeout: 10_000 });
-    await page.locator('.wizard-step button.btn-primary').first().click();
+    await advanceToTemplatesStep(page);
 
-    // Templates step renders `.wizard-panel` (welcome does not).
+    // Templates step renders `.wizard-panel` (welcome + identity have different markers).
     await expect(page.locator('.wizard-panel').first()).toBeVisible({ timeout: 10_000 });
     await expect(page.getByTestId('error-boundary')).toHaveCount(0);
 
@@ -94,8 +102,7 @@ test.describe('wuphf onboarding wizard smoke', () => {
     await page.goto('/');
     await waitForReactMount(page);
 
-    await expect(page.locator('.wizard-step').first()).toBeVisible({ timeout: 10_000 });
-    await page.locator('.wizard-step button.btn-primary').first().click();
+    await advanceToTemplatesStep(page);
 
     // Wait for the template grid (only rendered once blueprint fetch resolves).
     await expect(page.locator('.template-grid')).toBeVisible({ timeout: 10_000 });

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -117,11 +117,14 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
   const channelEntry = channelMembers.find((m) => m.slug === agent.slug)
   const enabled = Boolean(channelEntry) && channelEntry?.disabled !== true
 
-  // Broker rejects remove on ceo and on any `built_in` member; disable on ceo.
+  // Broker rejects remove / disable for any `built_in` member (lead agent).
   // Use `!== true` (not `!agent.built_in`) so an absent field isn't silently
   // treated as "removable" — we want explicit permission, not optimistic.
-  const canRemove = agent.built_in !== true && agent.slug !== 'ceo'
-  const canToggle = agent.slug !== 'ceo'
+  // Keep the `ceo` literal as legacy fallback for stored rosters that
+  // predate the BuiltIn field getting serialized.
+  const isLead = agent.built_in === true || agent.slug === 'ceo'
+  const canRemove = !isLead
+  const canToggle = !isLead
 
   async function handleOpenDM() {
     setDmLoading(true)

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -34,10 +34,13 @@ interface TaskTemplate {
 
 type WizardStep = 'welcome' | 'templates' | 'identity' | 'team' | 'setup' | 'task'
 
+// Step order: company info before blueprint. The blueprint picker is a
+// decision about how the office starts; it makes more sense after the
+// user has anchored who they are than as the very first question.
 const STEP_ORDER: readonly WizardStep[] = [
   'welcome',
-  'templates',
   'identity',
+  'templates',
   'team',
   'setup',
   'task',
@@ -243,7 +246,7 @@ function TemplatesStep({
           Back
         </button>
         <button className="btn btn-primary" onClick={onNext} type="button">
-          Continue
+          Review the team
           <ArrowIcon />
         </button>
       </div>
@@ -329,7 +332,7 @@ function IdentityStep({
           disabled={!canContinue}
           type="button"
         >
-          Review the team
+          Choose a blueprint
           <ArrowIcon />
         </button>
       </div>
@@ -809,7 +812,7 @@ export function Wizard({ onComplete }: WizardProps) {
         <ProgressDots current={step} />
 
         {step === 'welcome' && (
-          <WelcomeStep onNext={() => goTo('templates')} />
+          <WelcomeStep onNext={() => goTo('identity')} />
         )}
 
         {step === 'templates' && (

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -22,6 +22,10 @@ interface BlueprintAgent {
   role: string
   emoji?: string
   checked?: boolean
+  // built_in marks the lead agent — always included, never removable.
+  // The backend also refuses to disable or remove a BuiltIn member, so
+  // even if someone bypassed this UI, the broker would reject the write.
+  built_in?: boolean
 }
 
 interface TaskTemplate {
@@ -366,25 +370,39 @@ function TeamStep({ agents, onToggle, onNext, onBack }: TeamStepProps) {
           </div>
         ) : (
           <div className="wiz-team-grid">
-            {agents.map((a) => (
-              <button
-                key={a.slug}
-                className={`wiz-team-tile ${a.checked ? 'selected' : ''}`}
-                onClick={() => onToggle(a.slug)}
-                type="button"
-              >
-                <div className="wiz-team-check">
-                  {a.checked && <CheckIcon />}
-                </div>
-                <div>
-                  {a.emoji && (
-                    <span style={{ marginRight: 6 }}>{a.emoji}</span>
-                  )}
-                  <span className="wiz-team-name">{a.name}</span>
-                  {a.role && <div className="wiz-team-role">{a.role}</div>}
-                </div>
-              </button>
-            ))}
+            {agents.map((a) => {
+              // Lead agent is always included and cannot be unchecked here.
+              // The backend also refuses to remove or disable any BuiltIn
+              // member, so this is UI belt + server-side braces.
+              const locked = a.built_in === true
+              return (
+                <button
+                  key={a.slug}
+                  className={`wiz-team-tile ${a.checked ? 'selected' : ''} ${locked ? 'locked' : ''}`}
+                  onClick={() => !locked && onToggle(a.slug)}
+                  type="button"
+                  disabled={locked}
+                  aria-disabled={locked}
+                  title={locked ? 'Lead agent — always included' : undefined}
+                >
+                  <div className="wiz-team-check">
+                    {a.checked && <CheckIcon />}
+                  </div>
+                  <div>
+                    {a.emoji && (
+                      <span style={{ marginRight: 6 }}>{a.emoji}</span>
+                    )}
+                    <span className="wiz-team-name">{a.name}</span>
+                    {locked && (
+                      <span className="wiz-team-lead-badge" aria-label="Lead">
+                        Lead
+                      </span>
+                    )}
+                    {a.role && <div className="wiz-team-role">{a.role}</div>}
+                  </div>
+                </button>
+              )
+            })}
           </div>
         )}
       </div>
@@ -739,12 +757,16 @@ export function Wizard({ onComplete }: WizardProps) {
     }
   }, [step])
 
-  // Toggle agent selection
+  // Toggle agent selection. The lead agent (built_in) is locked: TeamStep
+  // disables its button, and this guard prevents any programmatic path
+  // (keyboard, devtools, future bulk toggle) from unchecking it.
   const toggleAgent = useCallback((slug: string) => {
     setAgents((prev) =>
-      prev.map((a) =>
-        a.slug === slug ? { ...a, checked: !a.checked } : a,
-      ),
+      prev.map((a) => {
+        if (a.slug !== slug) return a
+        if (a.built_in === true) return a
+        return { ...a, checked: !a.checked }
+      }),
     )
   }, [])
 

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -200,6 +200,31 @@
   background: var(--accent-bg);
 }
 
+/* Lead agent — locked on. Keep the selected visual but make it obvious
+   the tile is not interactable. */
+.wiz-team-tile.locked {
+  cursor: not-allowed;
+}
+
+.wiz-team-tile.locked:hover {
+  border-color: var(--accent);
+}
+
+.wiz-team-lead-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 6px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: var(--accent-bg);
+  border: 1px solid var(--accent);
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
 .wiz-team-check {
   width: 20px;
   height: 20px;


### PR DESCRIPTION
## Summary

Two bugs fixed end to end, plus a UX reorder:

1. **Blueprint picked in wizard was silently ignored.** Every user landed on `ceo/planner/executor/reviewer` regardless of whether they picked niche-crm, youtube-factory, or anything else. Root cause: \`/onboarding/complete\` only decoded \`{task, skip_task}\` from the POST body and dropped \`blueprint\` + \`agents\` on the floor. Fixed by threading both through the handler and the broker, loading the picked blueprint via \`operations.LoadBlueprint\`, and seeding \`members/channels/tasks\` from it. From-scratch synthesizes via \`SynthesizeBlueprint\` through the same seed function, so all paths now converge on one code path.

2. **ensureDefaultOfficeMembersLocked was appending defaults on every Load.** Called from \`Broker.Load()\` post-load normalization, it iterated \`defaultOfficeMembers()\` and appended every slug missing from \`b.members\`. So even after the handler fix seeded \`operator/planner/builder/growth/reviewer\`, the next broker restart would re-add \`ceo/planner/executor/reviewer\` alongside. Fixed by early-returning when members already exist — DefaultManifest stays as a true recovery-only fallback.

3. **Identity step now comes before blueprint.** Company/project info is the anchor the blueprint decision builds on, so we ask that first. Button copy updated accordingly.

## Verification

- **Unit/integration tests:** 14 new tests (3 handler, 2 broker state, 9 broker onboarding incl. 2 regression), all green with \`-race\`.
- **Live dev smoke:** POSTed 4 different body shapes against the dev broker on port 7900 with \`HOME=~/.wuphf-dev-home\` isolation. Every one produced the correct \`members\` list in \`broker-state.json\`:
  - niche-crm full → operator/planner/builder/growth/reviewer
  - niche-crm filtered to \`[operator,builder]\` → exactly those two
  - from-scratch (blueprint="") → synthesized team (not DefaultManifest's ceo+3)
  - restart broker after seeding → roster unchanged (load-path leak fixed)
- **UI click-through:** verified welcome → identity → blueprint picker → team review → setup steps in the dev browser. Blueprint picker shows all 6 curated blueprints. Selecting niche-crm renders the 5 niche-crm agents on the team step, not the DefaultManifest.

Full design and test plan: \`~/.gstack/projects/nex-crm-wuphf/najmuzzaman-fix-blueprint-default-agents-*.md\` (local to my workstation).

## Test plan

- [ ] Fresh install (\`~/.wuphf\` wiped), pick niche-crm, confirm team in #general is operator/planner/builder/growth/reviewer with operator as BuiltIn lead
- [ ] Uncheck agents in the team step, confirm only checked agents (plus the lead) seed
- [ ] Pick "From scratch" with a real goal, confirm team is not ceo/planner/executor/reviewer
- [ ] Restart broker after onboarding, confirm team is unchanged
- [ ] Legacy client (older wizard build or direct POST without blueprint/agents fields) still completes onboarding without crash

## Known follow-up (not in this PR)

- Starter channels from blueprints leak the unresolved \`{{command_slug}}\` placeholder as a literal channel slug. Pre-existing bug in \`blankSlateOfficeChannelsFromBlueprint\` — it substitutes \`brand_name\` and \`brand_slug\` but not \`command_slug\`. Surfaced because blueprint channels now actually reach the broker. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)