### PR TITLE
feat(web): harness badge overlay on agent avatars

### DIFF
--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -5,8 +5,11 @@ import { useOfficeMembers, useChannelMembers } from '../../hooks/useMembers'
 import { useAgentStream } from '../../hooks/useAgentStream'
 import { createDM, getAgentLogs, post } from '../../api/client'
 import { PixelAvatar } from '../ui/PixelAvatar'
+import { HarnessBadge } from '../ui/HarnessBadge'
 import { showNotice } from '../ui/Toast'
 import { confirm } from '../ui/ConfirmDialog'
+import { useDefaultHarness } from '../../hooks/useConfig'
+import { resolveHarness } from '../../lib/harness'
 import { StreamLineView } from '../messages/StreamLineView'
 import type { AgentLog, OfficeMember } from '../../api/client'
 
@@ -110,6 +113,7 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
   const [view, setView] = useState<'stream' | 'logs'>('stream')
   const [toggling, setToggling] = useState(false)
   const [removing, setRemoving] = useState(false)
+  const defaultHarness = useDefaultHarness()
 
   // Derive the per-channel enabled state. An agent is "enabled" in the current
   // channel when it appears in /members and is not flagged disabled.
@@ -199,11 +203,16 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
       {/* Header */}
       <div className="agent-panel-header">
         <div className="agent-panel-identity">
-          <div className="agent-panel-avatar">
+          <div className="agent-panel-avatar avatar-with-harness">
             <PixelAvatar
               slug={agent.slug}
               size={56}
               className="pixel-avatar-panel"
+            />
+            <HarnessBadge
+              kind={resolveHarness(agent.provider, defaultHarness)}
+              size={18}
+              className="harness-badge-on-avatar"
             />
           </div>
           <div style={{ minWidth: 0, flex: 1 }}>

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -5,7 +5,10 @@ import { useAppStore } from '../../stores/app'
 import { toggleReaction } from '../../api/client'
 import { useOfficeMembers } from '../../hooks/useMembers'
 import { PixelAvatar } from '../ui/PixelAvatar'
+import { HarnessBadge } from '../ui/HarnessBadge'
 import { showNotice } from '../ui/Toast'
+import { useDefaultHarness } from '../../hooks/useConfig'
+import { resolveHarness } from '../../lib/harness'
 
 interface MessageBubbleProps {
   message: Message
@@ -18,6 +21,8 @@ export function MessageBubble({ message, grouped = false, onThreadClick }: Messa
   const { data: members = [] } = useOfficeMembers()
   const isHuman = message.from === 'you' || message.from === 'human'
   const agent = members.find((m) => m.slug === message.from)
+  const defaultHarness = useDefaultHarness()
+  const harness = !isHuman ? resolveHarness(agent?.provider, defaultHarness) : null
 
   // Status messages — compact
   if (message.content?.startsWith('[STATUS]')) {
@@ -54,13 +59,18 @@ export function MessageBubble({ message, grouped = false, onThreadClick }: Messa
     >
       {/* Avatar */}
       <div
-        className="message-avatar"
+        className={`message-avatar${isHuman ? '' : ' avatar-with-harness'}`}
         style={isHuman ? { background: 'var(--accent)', color: 'white', fontSize: 14, fontWeight: 600 } : undefined}
       >
         {isHuman ? (
           'You'
         ) : (
-          <PixelAvatar slug={message.from} size={36} />
+          <>
+            <PixelAvatar slug={message.from} size={36} />
+            {harness && (
+              <HarnessBadge kind={harness} size={14} className="harness-badge-on-avatar" />
+            )}
+          </>
         )}
       </div>
 

--- a/web/src/components/sidebar/AgentList.tsx
+++ b/web/src/components/sidebar/AgentList.tsx
@@ -1,8 +1,11 @@
 import { useOfficeMembers } from '../../hooks/useMembers'
 import { useAppStore } from '../../stores/app'
 import { PixelAvatar } from '../ui/PixelAvatar'
+import { HarnessBadge } from '../ui/HarnessBadge'
 import { AgentWizard, useAgentWizard } from '../agents/AgentWizard'
+import { useDefaultHarness } from '../../hooks/useConfig'
 import type { OfficeMember } from '../../api/client'
+import { resolveHarness } from '../../lib/harness'
 
 function classifyActivity(member: OfficeMember | undefined) {
   if (!member) return { state: 'lurking', label: 'lurking', dotClass: 'lurking' }
@@ -24,6 +27,7 @@ export function AgentList() {
   const currentChannel = useAppStore((s) => s.currentChannel)
   const channelMeta = useAppStore((s) => s.channelMeta)
   const wizard = useAgentWizard()
+  const defaultHarness = useDefaultHarness()
 
   const agents = members.filter((m) => m.slug && m.slug !== 'human')
 
@@ -39,6 +43,7 @@ export function AgentList() {
             const ac = classifyActivity(agent)
             const meta = channelMeta[currentChannel]
             const isDMActive = meta?.type === 'D' && meta.agentSlug === agent.slug
+            const harness = resolveHarness(agent.provider, defaultHarness)
 
             return (
               <button
@@ -48,12 +53,13 @@ export function AgentList() {
                 title={`${agent.name} — ${ac.label}`}
                 onClick={() => setActiveAgentSlug(agent.slug)}
               >
-                <span className="sidebar-agent-avatar">
+                <span className="sidebar-agent-avatar avatar-with-harness">
                   <PixelAvatar
                     slug={agent.slug}
                     size={24}
                     className="pixel-avatar-sidebar"
                   />
+                  <HarnessBadge kind={harness} size={10} className="harness-badge-on-avatar" />
                 </span>
                 <div className="sidebar-agent-wrap">
                   <span className="sidebar-agent-name">{agent.name || agent.slug}</span>

--- a/web/src/components/ui/HarnessBadge.tsx
+++ b/web/src/components/ui/HarnessBadge.tsx
@@ -1,0 +1,67 @@
+import type { HarnessKind } from '../../lib/harness'
+import { harnessLabel } from '../../lib/harness'
+
+interface HarnessBadgeProps {
+  kind: HarnessKind
+  size?: number
+  className?: string
+}
+
+const PALETTE: Record<HarnessKind, { bg: string; fg: string }> = {
+  'claude-code': { bg: '#D97757', fg: '#FFFFFF' },
+  codex: { bg: '#10A37F', fg: '#FFFFFF' },
+  openclaw: { bg: '#8B5CF6', fg: '#FFFFFF' },
+}
+
+function Glyph({ kind, color }: { kind: HarnessKind; color: string }) {
+  switch (kind) {
+    case 'claude-code':
+      return (
+        <path
+          d="M12 3v18M3 12h18M5.6 5.6l12.8 12.8M18.4 5.6L5.6 18.4"
+          stroke={color}
+          strokeWidth="2.4"
+          strokeLinecap="round"
+        />
+      )
+    case 'codex':
+      return (
+        <path
+          d="M6 8l5 4-5 4M13 16h6"
+          stroke={color}
+          strokeWidth="2.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      )
+    case 'openclaw':
+      return (
+        <path
+          d="M7 5v10M12 3v12M17 5v10M6 15c0 3 3 5 6 5s6-2 6-5"
+          stroke={color}
+          strokeWidth="2.2"
+          strokeLinecap="round"
+          fill="none"
+        />
+      )
+  }
+}
+
+export function HarnessBadge({ kind, size = 12, className }: HarnessBadgeProps) {
+  const { bg, fg } = PALETTE[kind]
+  const classes = ['harness-badge', className].filter(Boolean).join(' ')
+  return (
+    <span
+      className={classes}
+      role="img"
+      aria-label={`${harnessLabel(kind)} harness`}
+      title={harnessLabel(kind)}
+      style={{ width: size, height: size, background: bg }}
+    >
+      <svg viewBox="0 0 24 24" width={size} height={size} aria-hidden="true">
+        <Glyph kind={kind} color={fg} />
+      </svg>
+    </span>
+  )
+}

--- a/web/src/hooks/useConfig.ts
+++ b/web/src/hooks/useConfig.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query'
+import { getConfig } from '../api/client'
+import type { HarnessKind } from '../lib/harness'
+
+const DEFAULT_HARNESS: HarnessKind = 'claude-code'
+
+/**
+ * Returns the install-wide default harness kind, used to render the avatar
+ * badge for agents that have no explicit provider binding.
+ */
+export function useDefaultHarness(): HarnessKind {
+  const { data } = useQuery({
+    queryKey: ['config'],
+    queryFn: getConfig,
+    staleTime: 60_000,
+  })
+  const raw = data?.llm_provider
+  if (raw === 'claude-code' || raw === 'codex') return raw
+  return DEFAULT_HARNESS
+}

--- a/web/src/lib/harness.ts
+++ b/web/src/lib/harness.ts
@@ -1,0 +1,39 @@
+import type { OfficeMember } from '../api/client'
+
+export type HarnessKind = 'claude-code' | 'codex' | 'openclaw'
+
+const VALID_KINDS: Record<string, HarnessKind> = {
+  'claude-code': 'claude-code',
+  claude: 'claude-code',
+  codex: 'codex',
+  openclaw: 'openclaw',
+}
+
+function normalize(raw: string | undefined | null): HarnessKind | null {
+  if (!raw) return null
+  return VALID_KINDS[raw.toLowerCase()] ?? null
+}
+
+export function resolveHarness(
+  provider: OfficeMember['provider'],
+  fallback: HarnessKind = 'claude-code',
+): HarnessKind {
+  if (typeof provider === 'string') {
+    return normalize(provider) ?? fallback
+  }
+  if (provider && typeof provider === 'object') {
+    return normalize(provider.kind) ?? fallback
+  }
+  return fallback
+}
+
+export function harnessLabel(kind: HarnessKind): string {
+  switch (kind) {
+    case 'claude-code':
+      return 'Claude Code'
+    case 'codex':
+      return 'Codex'
+    case 'openclaw':
+      return 'OpenClaw'
+  }
+}

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -97,6 +97,25 @@ body { background: var(--bg); color: var(--text); min-height: 100vh; }
 .pixel-avatar-sidebar { width: 24px; height: 24px; }
 .pixel-avatar-panel { width: 56px; height: 56px; }
 
+/* ─── Harness badge (overlaid on agent avatars) ─── */
+.avatar-with-harness { position: relative; }
+.harness-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1.5px var(--bg-card, #fff);
+  line-height: 0;
+  flex-shrink: 0;
+}
+.harness-badge svg { display: block; }
+.harness-badge-on-avatar {
+  position: absolute;
+  right: -3px;
+  bottom: -3px;
+  pointer-events: none;
+}
+
 /* ─── Status Dot ─── */
 .status-dot { width: 6px; height: 6px; border-radius: 50%; flex-shrink: 0; }
 .status-dot.active { background: var(--green); }


### PR DESCRIPTION
## Summary
- Overlays a small harness logo (Claude Code, Codex, or OpenClaw) on the bottom-right of each agent avatar so you can tell at a glance which runtime is backing a given agent.
- Wired into the three places the avatar shows: the sidebar agent list (10px badge), message bubbles (14px), and the agent detail panel (18px).
- Resolves the harness from the agent's `ProviderBinding.Kind`, falling back to the install-wide default from `/config.llm_provider` when an agent has no explicit binding.

## Glyphs
- **Claude Code** — amber (#D97757) asterisk burst
- **Codex** — green (#10A37F) terminal chevron (`>_`)
- **OpenClaw** — purple (#8B5CF6) three-prong claw

## Test plan
- [ ] Sidebar: each agent shows a badge in the bottom-right corner of their avatar
- [ ] DM / channel messages: the badge appears on the message author avatar (not on "You")
- [ ] Agent panel: the badge appears on the 56px portrait avatar
- [ ] Agents created without a provider show the badge matching the install-wide default (Settings → runtime)
- [ ] Switching an agent between Claude Code / Codex / OpenClaw updates the badge on next poll
- [ ] `npm run build` and `npm run typecheck` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agent harness information is now visually displayed via badges overlaid on avatars throughout the interface, including the agent panel, message bubbles, and sidebar agent list.

* **UI & Styling**
  * Added harness badge components with color-coded styling, SVG icon glyphs, and comprehensive accessibility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->