### PR TITLE
fix(nex): wrap shell-outs in --cmd and use setup subcommand

### DIFF
--- a/internal/nex/cli.go
+++ b/internal/nex/cli.go
@@ -76,10 +76,25 @@ func Connected() bool {
 	return IsInstalled()
 }
 
-// Run executes `nex-cli <args...>` with the given context/timeout and returns
-// stdout (trimmed) on success. A non-zero exit code, missing binary, or
-// context timeout are all returned as errors. The caller is responsible for
-// logging and falling back.
+// quoteArg wraps an argument in double quotes (escaping inner quotes and
+// backslashes) when it contains whitespace or characters the nex-cli REPL
+// parser treats as word separators. Plain tokens pass through untouched.
+func quoteArg(s string) string {
+	if s == "" {
+		return `""`
+	}
+	if !strings.ContainsAny(s, " \t\"'\\") {
+		return s
+	}
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(s, `\`, `\\`), `"`, `\"`) + `"`
+}
+
+// Run executes `nex-cli --cmd "<args...>"` with the given context/timeout and
+// returns stdout (trimmed) on success. nex-cli refuses to start without a TTY
+// unless --cmd/--script is used, so every shell-out goes through --cmd with
+// the args joined (and quoted where necessary) into a single command string.
+// A non-zero exit code, missing binary, or context timeout are all returned
+// as errors. The caller is responsible for logging and falling back.
 func Run(ctx context.Context, args ...string) (string, error) {
 	if Disabled() {
 		return "", ErrDisabled
@@ -96,33 +111,40 @@ func Run(ctx context.Context, args ...string) (string, error) {
 		ctx, cancel = context.WithTimeout(ctx, DefaultTimeout)
 		defer cancel()
 	}
-	cmd := exec.CommandContext(ctx, bin, args...)
+	quoted := make([]string, len(args))
+	for i, a := range args {
+		quoted[i] = quoteArg(a)
+	}
+	cmdStr := strings.Join(quoted, " ")
+	cmd := exec.CommandContext(ctx, bin, "--cmd", cmdStr)
 	cmd.Env = appendClientEnv(os.Environ())
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			return "", fmt.Errorf("nex-cli %s: timeout after %s", strings.Join(args, " "), DefaultTimeout)
+			return "", fmt.Errorf("nex-cli %s: timeout after %s", cmdStr, DefaultTimeout)
 		}
 		trimmed := strings.TrimSpace(stderr.String())
 		if trimmed != "" {
-			return "", fmt.Errorf("nex-cli %s: %s", strings.Join(args, " "), trimmed)
+			return "", fmt.Errorf("nex-cli %s: %s", cmdStr, trimmed)
 		}
-		return "", fmt.Errorf("nex-cli %s: %w", strings.Join(args, " "), err)
+		return "", fmt.Errorf("nex-cli %s: %w", cmdStr, err)
 	}
 	return strings.TrimSpace(stdout.String()), nil
 }
 
-// Register shells out to `nex-cli register --email <email>`. Used by the
-// WUPHF onboarding flow in place of the legacy POST to /api/v1/agents/register
-// on app.nex.ai. Blocks until the command exits (or the default timeout trips).
+// Register shells out to `nex-cli --cmd "setup <email>"`. nex-cli exposes
+// non-interactive registration as the `setup` subcommand (there is no
+// `register`). Used by the WUPHF onboarding flow in place of the legacy
+// POST to /api/v1/agents/register on app.nex.ai. Blocks until the command
+// exits (or the default timeout trips).
 func Register(ctx context.Context, email string) (string, error) {
 	email = strings.TrimSpace(email)
 	if email == "" {
 		return "", fmt.Errorf("register: email is required")
 	}
-	return Run(ctx, "register", "--email", email)
+	return Run(ctx, "setup", email)
 }
 
 // Recall shells out to `nex-cli recall <query>` and returns the trimmed

--- a/internal/nex/cli_test.go
+++ b/internal/nex/cli_test.go
@@ -70,15 +70,29 @@ func TestConnected_Happy(t *testing.T) {
 
 func TestRun_ReturnsStdout(t *testing.T) {
 	dir := withIsolatedPATH(t)
-	writeFakeNexCLI(t, dir, "nex-cli", `printf 'recall: %s\n' "$1"`)
+	// Assert nex-cli is invoked as `--cmd "<joined args>"`: $1 is --cmd,
+	// $2 is the joined command string.
+	writeFakeNexCLI(t, dir, "nex-cli", `printf '%s|%s' "$1" "$2"`)
 	t.Setenv("WUPHF_NO_NEX", "")
 	out, err := Run(context.Background(), "recall", "acme")
 	if err != nil {
 		t.Fatalf("Run: unexpected error: %v", err)
 	}
-	if out != "recall: recall" {
-		// the fake echoes the first arg, which is "recall" (subcommand)
+	if out != "--cmd|recall acme" {
 		t.Fatalf("Run: unexpected stdout %q", out)
+	}
+}
+
+func TestRun_QuotesWhitespaceArgs(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex-cli", `printf '%s' "$2"`)
+	t.Setenv("WUPHF_NO_NEX", "")
+	out, err := Run(context.Background(), "recall", "acme q3 renewal")
+	if err != nil {
+		t.Fatalf("Run: unexpected error: %v", err)
+	}
+	if out != `recall "acme q3 renewal"` {
+		t.Fatalf("Run: expected quoted multi-word arg, got %q", out)
 	}
 }
 
@@ -103,28 +117,29 @@ func TestRun_Disabled(t *testing.T) {
 
 func TestRecall_ShellsOut(t *testing.T) {
 	dir := withIsolatedPATH(t)
-	// Emit the query so we can assert it was forwarded.
+	// $2 is the full --cmd string: subcommand followed by the (quoted) query.
 	writeFakeNexCLI(t, dir, "nex-cli", `printf '%s' "$2"`)
 	t.Setenv("WUPHF_NO_NEX", "")
 	out, err := Recall(context.Background(), "acme q3 renewal")
 	if err != nil {
 		t.Fatalf("Recall: unexpected error: %v", err)
 	}
-	if out != "acme q3 renewal" {
-		t.Fatalf("Recall: expected query echoed back, got %q", out)
+	if out != `recall "acme q3 renewal"` {
+		t.Fatalf("Recall: expected quoted query in --cmd string, got %q", out)
 	}
 }
 
 func TestRegister_PassesEmail(t *testing.T) {
 	dir := withIsolatedPATH(t)
-	writeFakeNexCLI(t, dir, "nex-cli", `printf '%s' "$3"`)
+	// $2 is the --cmd string: `setup <email>` (single token, no quoting).
+	writeFakeNexCLI(t, dir, "nex-cli", `printf '%s' "$2"`)
 	t.Setenv("WUPHF_NO_NEX", "")
 	out, err := Register(context.Background(), "founder@example.com")
 	if err != nil {
 		t.Fatalf("Register: unexpected error: %v", err)
 	}
-	if out != "founder@example.com" {
-		t.Fatalf("Register: expected email forwarded, got %q", out)
+	if out != "setup founder@example.com" {
+		t.Fatalf("Register: expected `setup <email>` --cmd string, got %q", out)
 	}
 }
 

--- a/internal/nex/cli_test.go
+++ b/internal/nex/cli_test.go
@@ -162,3 +162,31 @@ func TestRun_Timeout(t *testing.T) {
 		t.Fatal("Run: expected timeout error")
 	}
 }
+
+// TestRegister_AgainstRealisticNexCLI simulates nex-cli 0.1.7's real
+// behavior: refuse non-interactive invocation unless --cmd/--script is used,
+// and recognize `setup <email>` (not `register`) as the onboarding entry
+// point. This is the exact failure mode described in issue #102 — if the
+// fix regresses, this test breaks.
+func TestRegister_AgainstRealisticNexCLI(t *testing.T) {
+	dir := withIsolatedPATH(t)
+	writeFakeNexCLI(t, dir, "nex-cli", `
+if [ "$1" != "--cmd" ] && [ "$1" != "--script" ]; then
+  echo "Error: nex requires an interactive terminal. Use --cmd or --script for non-interactive mode." >&2
+  exit 1
+fi
+case "$2" in
+  "setup "*) printf 'registered %s\n' "${2#setup }" ;;
+  "register"*) echo "Error: unknown command 'register'" >&2; exit 2 ;;
+  *) echo "Error: unknown command" >&2; exit 2 ;;
+esac
+`)
+	t.Setenv("WUPHF_NO_NEX", "")
+	out, err := Register(context.Background(), "founder@example.com")
+	if err != nil {
+		t.Fatalf("Register: unexpected error against realistic nex-cli: %v", err)
+	}
+	if out != "registered founder@example.com" {
+		t.Fatalf("Register: expected successful setup, got %q", out)
+	}
+}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -5395,7 +5395,7 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// handleNexRegister wraps `nex-cli register --email <email>` so the onboarding
+// handleNexRegister wraps `nex-cli --cmd "setup <email>"` so the onboarding
 // wizard can register a Nex identity without the user dropping to the terminal.
 // Body: {"email": "..."}. Returns whatever the CLI prints on success, or the
 // CLI's stderr on failure. Requires nex-cli to be installed and on PATH.


### PR DESCRIPTION
## Summary

Fixes #102 — every `nex-cli` shell-out from WUPHF was failing on a fresh install due to two independent bugs in `internal/nex/cli.go`:

1. **`Run()` didn't use `--cmd`.** `nex-cli` refuses to start without a TTY unless `--cmd`/`--script` is used, so `exec.Command` invocations died immediately.
2. **`register` is not a `nex-cli` subcommand.** The non-interactive registration entry point is `setup`.

## Changes

- `internal/nex/cli.go`
  - New `quoteArg` helper: wraps args containing whitespace or shell-significant characters in double quotes.
  - `Run()` now invokes `nex-cli --cmd "<joined args>"` with per-arg quoting, instead of passing args positionally.
  - `Register()` now calls `setup <email>` instead of the nonexistent `register --email <email>`.
- `internal/nex/cli_test.go`
  - Existing tests updated to assert the new `--cmd` contract (`$1 == "--cmd"`, `$2` is the joined command string).
  - Added `TestRun_QuotesWhitespaceArgs` for the quoting path.
  - Added `TestRegister_AgainstRealisticNexCLI` — an E2E-style test against a fake that faithfully simulates nex-cli 0.1.7 (rejects non-`--cmd` invocations; only recognizes `setup`). This test would fail against the pre-fix code and pins the fix.
- `internal/team/broker.go` — updated the stale doc comment on `handleNexRegister`.

## Test plan

- [x] `go test ./internal/nex/` — 11/11 passing
- [x] `go build ./...` clean
- [x] E2E-style simulation against realistic nex-cli fake passes

## Call sites verified

- `internal/tui/init_flow.go:253` (init wizard onboarding) — calls `nex.Register(ctx, email)`, unchanged callsite
- `internal/team/broker.go:5419` (`/api/nex/register` HTTP handler) — calls `nex.Register(r.Context(), email)`, unchanged callsite
- `internal/nex/cli.go` `Recall()` — also goes through the now-fixed `Run()`

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CLI argument handling to ensure proper quoting and escaping of arguments containing special characters or whitespace.
  * Updated command invocation mechanism for better shell compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->