### PR TITLE
feat(onboarding): CLI detection, multi-select, and fallback priority

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,15 +28,15 @@ func RuntimeHomeDir() string {
 
 // Config mirrors ~/.wuphf/config.json.
 type Config struct {
-	APIKey          string `json:"api_key,omitempty"`
-	MemoryBackend   string `json:"memory_backend,omitempty"`
-	OneAPIKey       string `json:"one_api_key,omitempty"`
-	ComposioAPIKey  string `json:"composio_api_key,omitempty"`
-	ActionProvider  string `json:"action_provider,omitempty"`
-	Email           string `json:"email,omitempty"`
-	WorkspaceID     string `json:"workspace_id,omitempty"`
-	WorkspaceSlug   string `json:"workspace_slug,omitempty"`
-	LLMProvider     string `json:"llm_provider,omitempty"`
+	APIKey         string `json:"api_key,omitempty"`
+	MemoryBackend  string `json:"memory_backend,omitempty"`
+	OneAPIKey      string `json:"one_api_key,omitempty"`
+	ComposioAPIKey string `json:"composio_api_key,omitempty"`
+	ActionProvider string `json:"action_provider,omitempty"`
+	Email          string `json:"email,omitempty"`
+	WorkspaceID    string `json:"workspace_id,omitempty"`
+	WorkspaceSlug  string `json:"workspace_slug,omitempty"`
+	LLMProvider    string `json:"llm_provider,omitempty"`
 	// LLMProviderPriority is an ordered list of provider identifiers (same
 	// vocabulary as LLMProvider — "claude-code", "codex", etc.) that agents
 	// should try in order when picking a runtime. LLMProvider remains the
@@ -44,11 +44,11 @@ type Config struct {
 	// creation and fallback flows. An empty slice means "fall back to
 	// LLMProvider alone", preserving legacy behavior.
 	LLMProviderPriority []string `json:"llm_provider_priority,omitempty"`
-	GeminiAPIKey    string `json:"gemini_api_key,omitempty"`
-	AnthropicAPIKey string `json:"anthropic_api_key,omitempty"`
-	OpenAIAPIKey    string `json:"openai_api_key,omitempty"`
-	MinimaxAPIKey   string `json:"minimax_api_key,omitempty"`
-	Blueprint       string `json:"blueprint,omitempty"`
+	GeminiAPIKey        string   `json:"gemini_api_key,omitempty"`
+	AnthropicAPIKey     string   `json:"anthropic_api_key,omitempty"`
+	OpenAIAPIKey        string   `json:"openai_api_key,omitempty"`
+	MinimaxAPIKey       string   `json:"minimax_api_key,omitempty"`
+	Blueprint           string   `json:"blueprint,omitempty"`
 	// Pack is retained as a legacy alias for the active operation blueprint/template.
 	Pack                string `json:"pack,omitempty"`
 	TeamLeadSlug        string `json:"team_lead_slug,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,13 @@ type Config struct {
 	WorkspaceID     string `json:"workspace_id,omitempty"`
 	WorkspaceSlug   string `json:"workspace_slug,omitempty"`
 	LLMProvider     string `json:"llm_provider,omitempty"`
+	// LLMProviderPriority is an ordered list of provider identifiers (same
+	// vocabulary as LLMProvider — "claude-code", "codex", etc.) that agents
+	// should try in order when picking a runtime. LLMProvider remains the
+	// single-value primary choice; the priority list is consulted by agent
+	// creation and fallback flows. An empty slice means "fall back to
+	// LLMProvider alone", preserving legacy behavior.
+	LLMProviderPriority []string `json:"llm_provider_priority,omitempty"`
 	GeminiAPIKey    string `json:"gemini_api_key,omitempty"`
 	AnthropicAPIKey string `json:"anthropic_api_key,omitempty"`
 	OpenAIAPIKey    string `json:"openai_api_key,omitempty"`

--- a/internal/onboarding/prereqs.go
+++ b/internal/onboarding/prereqs.go
@@ -33,18 +33,21 @@ type prereqSpec struct {
 }
 
 var prereqSpecs = map[string]prereqSpec{
-	"node":   {required: true, installURL: "https://nodejs.org"},
-	"git":    {required: true, installURL: "https://git-scm.com"},
-	"claude": {required: false, installURL: "https://claude.ai/code"},
-	"codex":  {required: false, installURL: "https://github.com/openai/codex"},
+	"node":     {required: true, installURL: "https://nodejs.org"},
+	"git":      {required: true, installURL: "https://git-scm.com"},
+	"claude":   {required: false, installURL: "https://claude.ai/code"},
+	"codex":    {required: false, installURL: "https://github.com/openai/codex"},
+	"cursor":   {required: false, installURL: "https://cursor.com/"},
+	"windsurf": {required: false, installURL: "https://codeium.com/windsurf"},
 }
 
 // CheckAll returns a PrereqResult for each tracked binary in a stable order:
-// node, git, claude, codex. At least one of claude/codex must be present
-// for wuphf to actually run a turn, but both are marked optional here so
-// the user can proceed with whichever runtime they have.
+// node, git, claude, codex, cursor, windsurf. At least one of the CLI
+// runtimes must be present for wuphf to actually run a turn, but all are
+// marked optional here so the user can proceed with whichever runtime
+// they have.
 func CheckAll() []PrereqResult {
-	names := []string{"node", "git", "claude", "codex"}
+	names := []string{"node", "git", "claude", "codex", "cursor", "windsurf"}
 	results := make([]PrereqResult, 0, len(names))
 	for _, name := range names {
 		results = append(results, CheckOne(name))

--- a/internal/onboarding/prereqs_test.go
+++ b/internal/onboarding/prereqs_test.go
@@ -34,12 +34,12 @@ func TestCheckOneNonexistentBinary(t *testing.T) {
 	}
 }
 
-func TestCheckAllReturnsFourItems(t *testing.T) {
+func TestCheckAllReturnsSixItems(t *testing.T) {
 	results := CheckAll()
-	if len(results) != 4 {
-		t.Fatalf("CheckAll: got %d results, want 4", len(results))
+	if len(results) != 6 {
+		t.Fatalf("CheckAll: got %d results, want 6", len(results))
 	}
-	names := []string{"node", "git", "claude", "codex"}
+	names := []string{"node", "git", "claude", "codex", "cursor", "windsurf"}
 	for i, r := range results {
 		if r.Name != names[i] {
 			t.Errorf("CheckAll[%d].Name: got %q, want %q", i, r.Name, names[i])
@@ -49,12 +49,14 @@ func TestCheckAllReturnsFourItems(t *testing.T) {
 
 func TestCheckAllRequiredFlags(t *testing.T) {
 	// node and git are required (infrastructure).
-	// claude and codex are optional — the user picks a runtime CLI.
+	// claude, codex, cursor, windsurf are optional — the user picks runtime CLIs.
 	wantRequired := map[string]bool{
-		"node":   true,
-		"git":    true,
-		"claude": false,
-		"codex":  false,
+		"node":     true,
+		"git":      true,
+		"claude":   false,
+		"codex":    false,
+		"cursor":   false,
+		"windsurf": false,
 	}
 	for _, r := range CheckAll() {
 		want, ok := wantRequired[r.Name]
@@ -69,10 +71,12 @@ func TestCheckAllRequiredFlags(t *testing.T) {
 
 func TestCheckAllInstallURLs(t *testing.T) {
 	wantURLs := map[string]string{
-		"node":   "https://nodejs.org",
-		"git":    "https://git-scm.com",
-		"claude": "https://claude.ai/code",
-		"codex":  "https://github.com/openai/codex",
+		"node":     "https://nodejs.org",
+		"git":      "https://git-scm.com",
+		"claude":   "https://claude.ai/code",
+		"codex":    "https://github.com/openai/codex",
+		"cursor":   "https://cursor.com/",
+		"windsurf": "https://codeium.com/windsurf",
 	}
 	for _, r := range CheckAll() {
 		want, ok := wantURLs[r.Name]

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -461,6 +461,11 @@ type Broker struct {
 	nextSubscriberID    int
 	agentStreams        map[string]*agentStreamBuffer
 	mu                  sync.Mutex
+	// configMu serializes handleConfig POST reads/writes so concurrent
+	// /config calls don't corrupt ~/.wuphf/config.json. config.Save uses
+	// os.WriteFile (O_TRUNC) without locking, so two parallel POSTs can
+	// produce a truncated/overlaid file.
+	configMu sync.Mutex
 	server              *http.Server
 	token               string          // shared secret for authenticating requests
 	addr                string          // actual listen address (useful when port=0)
@@ -5168,6 +5173,10 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			"config_path": config.ConfigPath(),
 		})
 	case http.MethodPost:
+		// Serialize POST reads/writes; config.Save is not atomic against
+		// concurrent writers and two parallel calls can corrupt the file.
+		b.configMu.Lock()
+		defer b.configMu.Unlock()
 		var body struct {
 			LLMProvider         *string   `json:"llm_provider,omitempty"`
 			LLMProviderPriority *[]string `json:"llm_provider_priority,omitempty"`

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -465,22 +465,22 @@ type Broker struct {
 	// /config calls don't corrupt ~/.wuphf/config.json. config.Save uses
 	// os.WriteFile (O_TRUNC) without locking, so two parallel POSTs can
 	// produce a truncated/overlaid file.
-	configMu sync.Mutex
-	server              *http.Server
-	token               string          // shared secret for authenticating requests
-	addr                string          // actual listen address (useful when port=0)
-	webUIOrigins        []string        // allowed CORS origins for web UI (set by ServeWebUI)
-	runtimeProvider     string          // "codex" or "claude" — set by launcher
-	packSlug            string          // active agent pack slug ("founding-team", "revops", ...) — set by launcher
-	blankSlateLaunch    bool            // start without a saved blueprint and synthesize the first operation
-	openclawBridge      *OpenclawBridge // nil until the bridge attaches itself; used by handleOfficeMembers for live add/remove
-	generateMemberFn    func(prompt string) (generatedMemberTemplate, error)
-	generateChannelFn   func(prompt string) (generatedChannelTemplate, error)
-	policies            []officePolicy // active office operating rules
-	rateLimitBuckets    map[string]ipRateLimitBucket
-	rateLimitWindow     time.Duration
-	rateLimitRequests   int
-	lastRateLimitPrune  time.Time
+	configMu           sync.Mutex
+	server             *http.Server
+	token              string          // shared secret for authenticating requests
+	addr               string          // actual listen address (useful when port=0)
+	webUIOrigins       []string        // allowed CORS origins for web UI (set by ServeWebUI)
+	runtimeProvider    string          // "codex" or "claude" — set by launcher
+	packSlug           string          // active agent pack slug ("founding-team", "revops", ...) — set by launcher
+	blankSlateLaunch   bool            // start without a saved blueprint and synthesize the first operation
+	openclawBridge     *OpenclawBridge // nil until the bridge attaches itself; used by handleOfficeMembers for live add/remove
+	generateMemberFn   func(prompt string) (generatedMemberTemplate, error)
+	generateChannelFn  func(prompt string) (generatedChannelTemplate, error)
+	policies           []officePolicy // active office operating rules
+	rateLimitBuckets   map[string]ipRateLimitBucket
+	rateLimitWindow    time.Duration
+	rateLimitRequests  int
+	lastRateLimitPrune time.Time
 
 	// Agent-scoped buckets — applied to authenticated agent traffic even though
 	// the IP-scoped bucket above exempts callers with a valid Bearer token. This
@@ -5181,23 +5181,23 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			LLMProvider         *string   `json:"llm_provider,omitempty"`
 			LLMProviderPriority *[]string `json:"llm_provider_priority,omitempty"`
 			MemoryBackend       *string   `json:"memory_backend,omitempty"`
-			ActionProvider  *string `json:"action_provider,omitempty"`
-			TeamLeadSlug    *string `json:"team_lead_slug,omitempty"`
-			MaxConcurrent   *int    `json:"max_concurrent_agents,omitempty"`
-			DefaultFormat   *string `json:"default_format,omitempty"`
-			DefaultTimeout  *int    `json:"default_timeout,omitempty"`
-			Blueprint       *string `json:"blueprint,omitempty"`
-			Email           *string `json:"email,omitempty"`
-			DevURL          *string `json:"dev_url,omitempty"`
-			CompanyName     *string `json:"company_name,omitempty"`
-			CompanyDesc     *string `json:"company_description,omitempty"`
-			CompanyGoals    *string `json:"company_goals,omitempty"`
-			CompanySize     *string `json:"company_size,omitempty"`
-			CompanyPriority *string `json:"company_priority,omitempty"`
-			InsightsPoll    *int    `json:"insights_poll_minutes,omitempty"`
-			TaskFollowUp    *int    `json:"task_follow_up_minutes,omitempty"`
-			TaskReminder    *int    `json:"task_reminder_minutes,omitempty"`
-			TaskRecheck     *int    `json:"task_recheck_minutes,omitempty"`
+			ActionProvider      *string   `json:"action_provider,omitempty"`
+			TeamLeadSlug        *string   `json:"team_lead_slug,omitempty"`
+			MaxConcurrent       *int      `json:"max_concurrent_agents,omitempty"`
+			DefaultFormat       *string   `json:"default_format,omitempty"`
+			DefaultTimeout      *int      `json:"default_timeout,omitempty"`
+			Blueprint           *string   `json:"blueprint,omitempty"`
+			Email               *string   `json:"email,omitempty"`
+			DevURL              *string   `json:"dev_url,omitempty"`
+			CompanyName         *string   `json:"company_name,omitempty"`
+			CompanyDesc         *string   `json:"company_description,omitempty"`
+			CompanyGoals        *string   `json:"company_goals,omitempty"`
+			CompanySize         *string   `json:"company_size,omitempty"`
+			CompanyPriority     *string   `json:"company_priority,omitempty"`
+			InsightsPoll        *int      `json:"insights_poll_minutes,omitempty"`
+			TaskFollowUp        *int      `json:"task_follow_up_minutes,omitempty"`
+			TaskReminder        *int      `json:"task_reminder_minutes,omitempty"`
+			TaskRecheck         *int      `json:"task_recheck_minutes,omitempty"`
 			// Secret fields
 			APIKey          *string `json:"api_key,omitempty"`
 			OpenAIAPIKey    *string `json:"openai_api_key,omitempty"`

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -5129,6 +5129,7 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			// Runtime
 			"llm_provider":          config.ResolveLLMProvider(""),
+			"llm_provider_priority": cfg.LLMProviderPriority,
 			"memory_backend":        config.ResolveMemoryBackend(""),
 			"action_provider":       config.ResolveActionProvider(),
 			"team_lead_slug":        cfg.TeamLeadSlug,
@@ -5168,8 +5169,9 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 		})
 	case http.MethodPost:
 		var body struct {
-			LLMProvider     *string `json:"llm_provider,omitempty"`
-			MemoryBackend   *string `json:"memory_backend,omitempty"`
+			LLMProvider         *string   `json:"llm_provider,omitempty"`
+			LLMProviderPriority *[]string `json:"llm_provider_priority,omitempty"`
+			MemoryBackend       *string   `json:"memory_backend,omitempty"`
 			ActionProvider  *string `json:"action_provider,omitempty"`
 			TeamLeadSlug    *string `json:"team_lead_slug,omitempty"`
 			MaxConcurrent   *int    `json:"max_concurrent_agents,omitempty"`
@@ -5216,6 +5218,31 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+		var providerPriority []string
+		if body.LLMProviderPriority != nil {
+			// Normalize + validate each entry. Unknown entries are rejected so
+			// the stored list only contains provider ids the resolver knows how
+			// to dispatch. Empty list is accepted (means "clear").
+			seen := make(map[string]bool, len(*body.LLMProviderPriority))
+			for _, raw := range *body.LLMProviderPriority {
+				id := strings.TrimSpace(strings.ToLower(raw))
+				if id == "" {
+					continue
+				}
+				switch id {
+				case "claude-code", "codex":
+					// ok
+				default:
+					http.Error(w, "unsupported entry in llm_provider_priority: "+id, http.StatusBadRequest)
+					return
+				}
+				if seen[id] {
+					continue
+				}
+				seen[id] = true
+				providerPriority = append(providerPriority, id)
+			}
+		}
 		var memory string
 		if body.MemoryBackend != nil {
 			memory = config.NormalizeMemoryBackend(*body.MemoryBackend)
@@ -5231,6 +5258,12 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 		// Enum/string fields
 		if provider != "" {
 			cfg.LLMProvider = provider
+			changed = true
+		}
+		if body.LLMProviderPriority != nil {
+			// Explicit pointer set means the client wanted to write this field,
+			// even if the final list is empty (which clears the stored order).
+			cfg.LLMProviderPriority = providerPriority
 			changed = true
 		}
 		if memory != "" {

--- a/internal/team/wiki_worker.go
+++ b/internal/team/wiki_worker.go
@@ -268,9 +268,10 @@ func (w *WikiWorker) Repo() *Repo {
 //	{ "slug":..., "path":..., "content":..., "mode":..., "commit_message":... }
 //
 // Response: 200 { "path":..., "commit_sha":..., "bytes_written":... }
-//           429 { "error":"wiki queue saturated, retry on next turn" }
-//           500 { "error":"..." }
-//           503 { "error":"..." } when worker is not running
+//
+//	429 { "error":"wiki queue saturated, retry on next turn" }
+//	500 { "error":"..." }
+//	503 { "error":"..." } when worker is not running
 func (b *Broker) handleWikiWrite(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/teammcp/server_backend_switch_test.go
+++ b/internal/teammcp/server_backend_switch_test.go
@@ -75,8 +75,8 @@ func TestConfigureServerToolsBackendMatrix(t *testing.T) {
 			commonPresent: []string{"team_broadcast", "team_poll"},
 		},
 		{
-			name:    "none/office",
-			backend: "none",
+			name:     "none/office",
+			backend:  "none",
 			mustHave: []string{},
 			mustNotHave: []string{
 				"team_memory_query",

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -997,15 +997,17 @@ export function Wizard({ onComplete }: WizardProps) {
           .filter((p): p is 'claude-code' | 'codex' => p != null)
 
         // Persist memory backend + LLM provider choice + priority fallback
-        // list so the broker reads them on next launch. Fire-and-forget —
-        // failures here should not block completing onboarding.
-        post('/config', { memory_backend: memoryBackend }).catch(() => {})
-        if (providerPriority.length > 0) {
-          post('/config', {
-            llm_provider: providerPriority[0],
-            llm_provider_priority: providerPriority,
-          }).catch(() => {})
+        // list so the broker reads them on next launch. Send as a single
+        // POST — the broker's handleConfig does a non-atomic read-mutate-
+        // write, so two parallel calls race and corrupt config.json.
+        const configPayload: Record<string, unknown> = {
+          memory_backend: memoryBackend,
         }
+        if (providerPriority.length > 0) {
+          configPayload.llm_provider = providerPriority[0]
+          configPayload.llm_provider_priority = providerPriority
+        }
+        post('/config', configPayload).catch(() => {})
 
         // Primary runtime label for the onboarding payload (best-effort;
         // the broker only acts on {task, skip_task} today, but the extra

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -50,30 +50,31 @@ const STEP_ORDER: readonly WizardStep[] = [
   'task',
 ] as const
 
-const RUNTIME_OPTIONS = ['Claude Code', 'Codex', 'Cursor', 'Windsurf', 'Other'] as const
+// Each runtime has a display label, the binary name the broker's prereqs
+// check looks for, a canonical install page to link to when missing, and
+// — for the runtimes the broker can actually dispatch agents to — the
+// provider id the broker expects on POST /config.
+interface RuntimeSpec {
+  label: string
+  binary: string
+  installUrl: string
+  provider: 'claude-code' | 'codex' | null
+}
 
-// Runtimes that authenticate agents through their own CLI login (claude login,
-// codex login, etc.). When one of these is selected, direct API keys are
-// optional — the CLI handles provider auth. Only "Other" falls back to
-// requiring a raw key.
-const RUNTIMES_WITH_OWN_AUTH: ReadonlySet<string> = new Set([
-  'Claude Code',
-  'Codex',
-  'Cursor',
-  'Windsurf',
-])
+const RUNTIMES: readonly RuntimeSpec[] = [
+  { label: 'Claude Code', binary: 'claude', installUrl: 'https://claude.ai/code', provider: 'claude-code' },
+  { label: 'Codex', binary: 'codex', installUrl: 'https://github.com/openai/codex', provider: 'codex' },
+  { label: 'Cursor', binary: 'cursor', installUrl: 'https://cursor.com/', provider: null },
+  { label: 'Windsurf', binary: 'windsurf', installUrl: 'https://codeium.com/windsurf', provider: null },
+] as const
 
-// Map UI runtime labels to the provider enum the broker validates on POST /config.
-// Labels without a backend equivalent return null and are skipped on persist —
-// the broker keeps its existing default (claude-code) until the user picks a
-// supported runtime. Keeping this local to the wizard so the UI can list
-// aspirational runtimes without lying about what will actually run.
-const RUNTIME_LABEL_TO_PROVIDER: Record<string, 'claude-code' | 'codex' | null> = {
-  'Claude Code': 'claude-code',
-  Codex: 'codex',
-  Cursor: null,
-  Windsurf: null,
-  Other: null,
+interface PrereqResult {
+  name: string
+  required: boolean
+  found: boolean
+  ok?: boolean
+  version?: string
+  install_url?: string
 }
 
 const API_KEY_FIELDS = [
@@ -434,8 +435,11 @@ function TeamStep({ agents, onToggle, onNext, onBack }: TeamStepProps) {
 /* ─── Step 5: Setup ─── */
 
 interface SetupStepProps {
-  runtime: string
-  onChangeRuntime: (v: string) => void
+  prereqs: PrereqResult[]
+  prereqsLoading: boolean
+  runtimePriority: string[]
+  onToggleRuntime: (label: string) => void
+  onReorderRuntime: (label: string, direction: -1 | 1) => void
   apiKeys: Record<string, string>
   onChangeApiKey: (key: string, value: string) => void
   memoryBackend: MemoryBackend
@@ -444,9 +448,16 @@ interface SetupStepProps {
   onBack: () => void
 }
 
+function detectedBinary(prereqs: PrereqResult[], binary: string): PrereqResult | undefined {
+  return prereqs.find((p) => p.name === binary)
+}
+
 function SetupStep({
-  runtime,
-  onChangeRuntime,
+  prereqs,
+  prereqsLoading,
+  runtimePriority,
+  onToggleRuntime,
+  onReorderRuntime,
   apiKeys,
   onChangeApiKey,
   memoryBackend,
@@ -454,68 +465,178 @@ function SetupStep({
   onNext,
   onBack,
 }: SetupStepProps) {
-  const runtimeHasOwnAuth = RUNTIMES_WITH_OWN_AUTH.has(runtime)
+  // A runtime is usable only when its binary is actually present on PATH.
+  // "Selected and installed" drives whether we can continue without keys.
+  const hasInstalledSelection = runtimePriority.some((label) => {
+    const spec = RUNTIMES.find((r) => r.label === label)
+    if (!spec) return false
+    const detection = detectedBinary(prereqs, spec.binary)
+    return Boolean(detection?.found)
+  })
   const hasAtLeastOneKey = Object.values(apiKeys).some((v) => v.trim().length > 0)
-  const canContinue = runtimeHasOwnAuth || hasAtLeastOneKey
+  const canContinue = hasInstalledSelection || hasAtLeastOneKey
 
   return (
     <div className="wizard-step">
       <div className="wizard-panel">
         <p className="wizard-panel-title">How should agents run?</p>
         <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: '-8px 0 12px 0' }}>
-          Pick the CLI you already use. Its login handles provider auth, so you
-          won&apos;t need API keys. Choose <strong>Other</strong> to plug in raw
-          keys instead.
+          Pick the CLIs you have installed. Each CLI&apos;s login handles its
+          own provider auth, so no API keys are needed. Select multiple to set
+          a fallback order — if the first one fails, agents fall through to
+          the next.
         </p>
-        <div className="runtime-grid">
-          {RUNTIME_OPTIONS.map((opt) => (
-            <button
-              key={opt}
-              className={`runtime-tile ${runtime === opt ? 'selected' : ''}`}
-              onClick={() => onChangeRuntime(opt)}
-              type="button"
-            >
-              {opt}
-            </button>
-          ))}
-        </div>
 
-        {!runtimeHasOwnAuth && (
-          <div style={{ marginTop: 16, paddingTop: 16, borderTop: '1px solid var(--border)' }}>
-            <p
-              style={{
-                fontSize: 13,
-                fontWeight: 600,
-                margin: '0 0 4px 0',
-                color: 'var(--text-primary)',
-              }}
-            >
-              {ONBOARDING_COPY.step2_keys_title}
+        {prereqsLoading ? (
+          <div style={{ color: 'var(--text-tertiary)', fontSize: 13, padding: '8px 0' }}>
+            Checking which CLIs are installed&hellip;
+          </div>
+        ) : (
+          <div className="runtime-grid">
+            {RUNTIMES.map((spec) => {
+              const detection = detectedBinary(prereqs, spec.binary)
+              const installed = Boolean(detection?.found)
+              const priorityIdx = runtimePriority.indexOf(spec.label)
+              const selected = priorityIdx >= 0
+              const classes = [
+                'runtime-tile',
+                selected ? 'selected' : '',
+                installed ? '' : 'disabled',
+              ]
+                .filter(Boolean)
+                .join(' ')
+              return (
+                <button
+                  key={spec.label}
+                  className={classes}
+                  onClick={() => {
+                    if (!installed) return
+                    onToggleRuntime(spec.label)
+                  }}
+                  type="button"
+                  disabled={!installed}
+                  aria-disabled={!installed}
+                  aria-pressed={selected}
+                  title={
+                    installed
+                      ? detection?.version
+                        ? `${spec.label} — ${detection.version}`
+                        : spec.label
+                      : `${spec.label} — not installed`
+                  }
+                >
+                  {selected && (
+                    <span className="runtime-priority-badge" aria-label={`Priority ${priorityIdx + 1}`}>
+                      {priorityIdx + 1}
+                    </span>
+                  )}
+                  <div className="runtime-tile-head">
+                    <span
+                      className={`runtime-tile-status ${installed ? 'installed' : ''}`}
+                      aria-hidden="true"
+                    />
+                    {spec.label}
+                  </div>
+                  <div className="runtime-tile-meta">
+                    {installed ? (
+                      detection?.version ? detection.version : 'Installed'
+                    ) : (
+                      <>
+                        Not installed{' · '}
+                        <a
+                          className="runtime-tile-install-link"
+                          href={spec.installUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          install
+                        </a>
+                      </>
+                    )}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        )}
+
+        {runtimePriority.length > 1 && (
+          <div className="runtime-priority-controls">
+            <p className="runtime-priority-title">Fallback order</p>
+            <p className="runtime-priority-hint">
+              Agents try these in order. Use the arrows to reorder.
             </p>
-            <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: '0 0 12px 0' }}>
-              At least one API key is needed so agents can reason. You can add
-              more later.
-            </p>
-            {API_KEY_FIELDS.map((field) => (
-              <div className="key-row" key={field.key}>
-                <div className="key-label-wrap">
-                  <span className="key-label">{field.label}</span>
-                  <span className="key-hint">{field.hint}</span>
-                </div>
-                <div className="key-input-wrap">
-                  <input
-                    className="input"
-                    type="password"
-                    placeholder={field.key}
-                    value={apiKeys[field.key] ?? ''}
-                    onChange={(e) => onChangeApiKey(field.key, e.target.value)}
-                    autoComplete="off"
-                  />
-                </div>
+            {runtimePriority.map((label, idx) => (
+              <div key={label} className="runtime-priority-row">
+                <span className="runtime-priority-row-rank">#{idx + 1}</span>
+                <span className="runtime-priority-row-label">{label}</span>
+                <button
+                  type="button"
+                  className="runtime-priority-btn"
+                  onClick={() => onReorderRuntime(label, -1)}
+                  disabled={idx === 0}
+                  aria-label={`Move ${label} up`}
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  className="runtime-priority-btn"
+                  onClick={() => onReorderRuntime(label, 1)}
+                  disabled={idx === runtimePriority.length - 1}
+                  aria-label={`Move ${label} down`}
+                >
+                  ↓
+                </button>
+                <button
+                  type="button"
+                  className="runtime-priority-btn"
+                  onClick={() => onToggleRuntime(label)}
+                  aria-label={`Remove ${label}`}
+                >
+                  ✕
+                </button>
               </div>
             ))}
           </div>
         )}
+
+        <div style={{ marginTop: 16, paddingTop: 16, borderTop: '1px solid var(--border)' }}>
+          <p
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              margin: '0 0 4px 0',
+              color: 'var(--text-primary)',
+            }}
+          >
+            API keys {hasInstalledSelection ? '(optional fallback)' : '(required)'}
+          </p>
+          <p style={{ fontSize: 12, color: 'var(--text-secondary)', margin: '0 0 12px 0' }}>
+            {hasInstalledSelection
+              ? 'Only used if every selected CLI fails. Leave blank to rely on the CLI login.'
+              : 'No installed CLI selected. Add at least one key so agents can reason.'}
+          </p>
+          {API_KEY_FIELDS.map((field) => (
+            <div className="key-row" key={field.key}>
+              <div className="key-label-wrap">
+                <span className="key-label">{field.label}</span>
+                <span className="key-hint">{field.hint}</span>
+              </div>
+              <div className="key-input-wrap">
+                <input
+                  className="input"
+                  type="password"
+                  placeholder={field.key}
+                  value={apiKeys[field.key] ?? ''}
+                  onChange={(e) => onChangeApiKey(field.key, e.target.value)}
+                  autoComplete="off"
+                />
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
 
       <div className="wizard-panel">
@@ -700,7 +821,13 @@ export function Wizard({ onComplete }: WizardProps) {
   const [agents, setAgents] = useState<BlueprintAgent[]>([])
 
   // Step 5: setup
-  const [runtime, setRuntime] = useState<string>(RUNTIME_OPTIONS[0])
+  const [prereqs, setPrereqs] = useState<PrereqResult[]>([])
+  const [prereqsLoading, setPrereqsLoading] = useState(true)
+  // Ordered list of runtime labels (matches RUNTIMES[].label). Position in
+  // the array is the fallback priority. Initially empty — we auto-populate
+  // with the first installed CLI once prereqs land so the happy path still
+  // works with zero clicks.
+  const [runtimePriority, setRuntimePriority] = useState<string[]>([])
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({})
   const [memoryBackend, setMemoryBackend] = useState<MemoryBackend>('nex')
 
@@ -743,6 +870,60 @@ export function Wizard({ onComplete }: WizardProps) {
     return () => {
       cancelled = true
     }
+  }, [])
+
+  // Fetch prereqs on mount so the runtime picker shows which CLIs are
+  // actually installed. Auto-select the first detected runtime so users
+  // with a single CLI installed don't have to click.
+  useEffect(() => {
+    let cancelled = false
+    setPrereqsLoading(true)
+
+    get<{ prereqs?: PrereqResult[] } | PrereqResult[]>('/onboarding/prereqs')
+      .then((data) => {
+        if (cancelled) return
+        const list = Array.isArray(data) ? data : data.prereqs ?? []
+        setPrereqs(list)
+        setRuntimePriority((current) => {
+          if (current.length > 0) return current
+          const firstInstalled = RUNTIMES.find((spec) => {
+            const det = list.find((p) => p.name === spec.binary)
+            return Boolean(det?.found)
+          })
+          return firstInstalled ? [firstInstalled.label] : []
+        })
+      })
+      .catch(() => {
+        // Broker may not expose the endpoint yet; leave prereqs empty and
+        // the user can still add API keys to proceed.
+      })
+      .finally(() => {
+        if (!cancelled) setPrereqsLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const toggleRuntime = useCallback((label: string) => {
+    setRuntimePriority((prev) => {
+      if (prev.includes(label)) return prev.filter((l) => l !== label)
+      return [...prev, label]
+    })
+  }, [])
+
+  const reorderRuntime = useCallback((label: string, direction: -1 | 1) => {
+    setRuntimePriority((prev) => {
+      const idx = prev.indexOf(label)
+      if (idx < 0) return prev
+      const next = idx + direction
+      if (next < 0 || next >= prev.length) return prev
+      const out = [...prev]
+      const [item] = out.splice(idx, 1)
+      out.splice(next, 0, item)
+      return out
+    })
   }, [])
 
   // When a blueprint is selected, populate agents
@@ -806,24 +987,37 @@ export function Wizard({ onComplete }: WizardProps) {
     async (skipTask: boolean) => {
       setSubmitting(true)
       try {
-        // Persist memory backend + LLM provider selection first so the broker
-        // reads them on next launch. Fire-and-forget — a failure here should
-        // not block completing onboarding. Unsupported runtime labels (Cursor,
-        // Windsurf, Other) are skipped; only claude-code and codex are wired.
+        // Translate UI labels to the provider ids the broker validates. Only
+        // labels that map to a supported provider ("claude-code", "codex")
+        // are persisted — aspirational runtimes (Cursor, Windsurf) are shown
+        // in the UI but can't yet be dispatched, so we drop them from the
+        // priority list we send to the server.
+        const providerPriority = runtimePriority
+          .map((label) => RUNTIMES.find((r) => r.label === label)?.provider)
+          .filter((p): p is 'claude-code' | 'codex' => p != null)
+
+        // Persist memory backend + LLM provider choice + priority fallback
+        // list so the broker reads them on next launch. Fire-and-forget —
+        // failures here should not block completing onboarding.
         post('/config', { memory_backend: memoryBackend }).catch(() => {})
-        const llmProvider = RUNTIME_LABEL_TO_PROVIDER[runtime]
-        if (llmProvider) {
-          post('/config', { llm_provider: llmProvider }).catch(() => {})
+        if (providerPriority.length > 0) {
+          post('/config', {
+            llm_provider: providerPriority[0],
+            llm_provider_priority: providerPriority,
+          }).catch(() => {})
         }
 
-        // Post the onboarding payload. Body shape is historical; the broker
-        // currently only acts on {task, skip_task} but the extra fields are
-        // forward-compatible.
+        // Primary runtime label for the onboarding payload (best-effort;
+        // the broker only acts on {task, skip_task} today, but the extra
+        // fields are forward-compatible).
+        const primaryRuntime = runtimePriority[0] ?? ''
+
         await post('/onboarding/complete', {
           company,
           description,
           priority,
-          runtime,
+          runtime: primaryRuntime,
+          runtime_priority: runtimePriority,
           memory_backend: memoryBackend,
           blueprint: selectedBlueprint,
           agents: agents.filter((a) => a.checked).map((a) => a.slug),
@@ -843,7 +1037,7 @@ export function Wizard({ onComplete }: WizardProps) {
       company,
       description,
       priority,
-      runtime,
+      runtimePriority,
       memoryBackend,
       selectedBlueprint,
       agents,
@@ -898,8 +1092,11 @@ export function Wizard({ onComplete }: WizardProps) {
 
         {step === 'setup' && (
           <SetupStep
-            runtime={runtime}
-            onChangeRuntime={setRuntime}
+            prereqs={prereqs}
+            prereqsLoading={prereqsLoading}
+            runtimePriority={runtimePriority}
+            onToggleRuntime={toggleRuntime}
+            onReorderRuntime={reorderRuntime}
             apiKeys={apiKeys}
             onChangeApiKey={handleApiKeyChange}
             memoryBackend={memoryBackend}

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -316,6 +316,7 @@
   text-align: center;
   font-size: 13px;
   font-weight: 500;
+  position: relative;
 }
 
 .runtime-tile:hover {
@@ -325,6 +326,132 @@
 .runtime-tile.selected {
   border-color: var(--accent);
   background: var(--accent-bg);
+}
+
+.runtime-tile.disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.runtime-tile.disabled:hover {
+  border-color: var(--border);
+}
+
+.runtime-tile-head {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.runtime-tile-status {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+  flex: 0 0 auto;
+}
+
+.runtime-tile-status.installed {
+  background: #10b981;
+}
+
+.runtime-tile-meta {
+  margin-top: 4px;
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-tertiary);
+  line-height: 1.3;
+}
+
+.runtime-tile-install-link {
+  color: var(--accent);
+  text-decoration: underline;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.runtime-priority-badge {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.runtime-priority-controls {
+  margin-top: 12px;
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+.runtime-priority-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 4px 0;
+}
+
+.runtime-priority-hint {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin: 0 0 10px 0;
+}
+
+.runtime-priority-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  margin-bottom: 6px;
+}
+
+.runtime-priority-row-label {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.runtime-priority-row-rank {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  min-width: 20px;
+}
+
+.runtime-priority-btn {
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: var(--radius-sm);
+  padding: 2px 8px;
+  font-size: 12px;
+  cursor: pointer;
+  line-height: 1.2;
+}
+
+.runtime-priority-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.runtime-priority-btn:not(:disabled):hover {
+  border-color: var(--border-dark);
+  color: var(--text-primary);
 }
 
 /* ─── Task Textarea (Step 6) ─── */


### PR DESCRIPTION
Builds on #155. Step 5 of the onboarding wizard now reflects what's actually installed on the machine and lets users set a fallback waterfall.

## Summary

**Web wizard (step 5)**
- Fetches \`/onboarding/prereqs\` on mount. Each runtime tile shows whether its binary is on PATH and, if not, links to the canonical install page. Un-installed tiles are disabled.
- Runtime picker is now an ordered multi-select. Each selected tile gets a #1/#2/… priority badge, and a \"Fallback order\" panel below the grid lets users reorder or remove entries.
- Auto-selects the first detected CLI so the single-runtime happy path stays zero-click.
- API keys section stays visible and re-labels based on state — \"optional fallback\" when an installed CLI is selected, \"required\" when nothing installed is in the list.

**Backend**
- \`internal/onboarding/prereqs.go\`: extended detection to include \`cursor\` and \`windsurf\` alongside \`claude\` and \`codex\`.
- \`internal/config/config.go\`: new \`LLMProviderPriority []string\` field. Backwards compatible — empty slice preserves old single-\`llm_provider\` behavior.
- \`internal/team/broker.go\` \`/config\`: accepts \`llm_provider_priority\` on POST with per-entry validation, returns it on GET.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/onboarding/... ./internal/config/... ./internal/team/...\` pass
- [x] \`pnpm tsc --noEmit\` (web) clean
- [ ] Manual: run dev stack with only \`claude\` installed. Verify its tile shows green dot + version, Cursor/Windsurf/Codex tiles show as disabled with install links.
- [ ] Manual: select two installed CLIs, reorder them, complete onboarding, inspect \`~/.wuphf-dev-home/.wuphf/config.json\` for \`llm_provider_priority\`.
- [ ] Manual: deselect all CLIs — verify keys section re-labels as \"(required)\" and Continue is disabled without at least one key.

## Follow-up

- Surface the stored priority list in the agent create/edit UI so users can override it per agent — closes the loop the user requested (\"when users create or change agents' providers, they have those options ready\").
- Port the multi-select affordance to the TUI onboarding flow. TUI currently only has the phase-1 unblock from #155.