### PR TITLE
fix(codex): surface auth failures instead of silent 'exit status 1' loop

### DIFF
--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -876,6 +876,9 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	if l == nil || l.broker == nil {
 		return fmt.Errorf("broker is not running")
 	}
+	if err := l.preflightHeadlessCodexAuth(slug, firstNonEmpty(channel...)); err != nil {
+		return err
+	}
 
 	workspaceDir := strings.TrimSpace(l.cwd)
 	if worktreeDir := l.headlessTaskWorkspaceDir(slug); worktreeDir != "" {
@@ -924,8 +927,10 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	if workspaceDir != strings.TrimSpace(l.cwd) {
 		cmd.Env = append(cmd.Env, "WUPHF_WORKTREE_PATH="+workspaceDir)
 	}
-	cmd.Stdin = strings.NewReader(buildHeadlessCodexPrompt(l.buildPrompt(slug), notification))
+	stdinText := buildHeadlessCodexPrompt(l.buildPrompt(slug), notification)
+	cmd.Stdin = strings.NewReader(stdinText)
 	configureHeadlessProcess(cmd)
+	dumpHeadlessCodexInvocation(slug, workspaceDir, args, cmd.Env, stdinText)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -1030,6 +1035,16 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			))
 			appendHeadlessCodexLog(slug, "stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
+			if isCodexAuthError(detail) && l.broker != nil {
+				target := firstNonEmpty(channel...)
+				if strings.TrimSpace(target) == "" {
+					target = "general"
+				}
+				l.broker.PostSystemMessage(target,
+					fmt.Sprintf("@%s hit an auth error talking to the model (%s). Run `codex login` on this machine, or set OPENAI_API_KEY, then retry.", slug, truncate(detail, 180)),
+					"error",
+				)
+			}
 			return fmt.Errorf("%w: %s", err, detail)
 		}
 		appendHeadlessCodexLatency(slug, fmt.Sprintf("status=error total_ms=%d first_event_ms=%d first_text_ms=%d first_tool_ms=%d detail=%q",
@@ -1193,29 +1208,48 @@ func prepareHeadlessCodexHome() string {
 		sourceHome = normalizeHeadlessWorkspaceDir(headlessCodexHomeDir())
 	}
 	if sourceHome != "" && sourceHome != runtimeHome {
-		copyHeadlessCodexHomeFile(sourceHome, runtimeHome, "auth.json", 0o600)
+		if err := copyHeadlessCodexHomeFile(sourceHome, runtimeHome, "auth.json", 0o600); err != nil {
+			// Auth is load-bearing — without it codex dies with 401 after a 5s
+			// reconnect dance and nothing surfaces to the user. Log loudly.
+			// runHeadlessCodexTurn does the user-visible preflight; this log is
+			// the trail we want when debugging why that preflight fired.
+			appendHeadlessCodexLog("_setup", fmt.Sprintf(
+				"auth-copy-failed: source=%s dest=%s err=%v (run `codex login` or set OPENAI_API_KEY)",
+				filepath.Join(sourceHome, "auth.json"),
+				filepath.Join(runtimeHome, "auth.json"),
+				err,
+			))
+		}
 	}
 	if userHome := strings.TrimSpace(headlessCodexGlobalHomeDir()); userHome != "" {
-		copyHeadlessCodexHomeFile(userHome, runtimeHome, filepath.Join(".one", "config.json"), 0o600)
-		copyHeadlessCodexHomeFile(userHome, runtimeHome, filepath.Join(".one", "update-check.json"), 0o600)
+		// Best-effort — these are optional overlays, silent on miss is fine.
+		_ = copyHeadlessCodexHomeFile(userHome, runtimeHome, filepath.Join(".one", "config.json"), 0o600)
+		_ = copyHeadlessCodexHomeFile(userHome, runtimeHome, filepath.Join(".one", "update-check.json"), 0o600)
 	}
 	return runtimeHome
 }
 
-func copyHeadlessCodexHomeFile(sourceHome string, runtimeHome string, rel string, mode os.FileMode) {
+// copyHeadlessCodexHomeFile copies rel from sourceHome into runtimeHome. Returns
+// an error when the source exists but the copy failed, or when the source is
+// missing. A wholly-empty path or rel is a no-op (nil). Callers that care about
+// visibility (auth.json) check the error; best-effort overlays ignore it.
+func copyHeadlessCodexHomeFile(sourceHome string, runtimeHome string, rel string, mode os.FileMode) error {
 	if strings.TrimSpace(sourceHome) == "" || strings.TrimSpace(runtimeHome) == "" || strings.TrimSpace(rel) == "" {
-		return
+		return nil
 	}
 	sourcePath := filepath.Join(sourceHome, filepath.FromSlash(rel))
 	data, err := os.ReadFile(sourcePath)
 	if err != nil {
-		return
+		return fmt.Errorf("read %s: %w", sourcePath, err)
 	}
 	destPath := filepath.Join(runtimeHome, filepath.FromSlash(rel))
 	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-		return
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(destPath), err)
 	}
-	_ = os.WriteFile(destPath, data, mode)
+	if err := os.WriteFile(destPath, data, mode); err != nil {
+		return fmt.Errorf("write %s: %w", destPath, err)
+	}
+	return nil
 }
 
 func normalizeHeadlessWorkspaceDir(path string) string {
@@ -1367,6 +1401,109 @@ func appendHeadlessCodexLatency(slug string, line string) {
 	}
 	defer func() { _ = f.Close() }()
 	_, _ = fmt.Fprintf(f, "[%s] agent=%s %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(slug), strings.TrimSpace(line))
+}
+
+// preflightHeadlessCodexAuth verifies codex has a way to authenticate before we
+// spawn the process. Without this check, codex dies with a 401 after retrying
+// for ~10s and WUPHF's error log reads "exit status 1: exit status 1" — totally
+// undebuggable from the UI. We check the two valid auth paths: a copied
+// auth.json in the isolated CODEX_HOME (ChatGPT plan or API-key file), or an
+// OPENAI_API_KEY in the env we're about to hand codex. If neither, fail fast
+// with a message the user will actually see in the channel.
+func (l *Launcher) preflightHeadlessCodexAuth(slug string, channel string) error {
+	// Check the source codex creds that WUPHF will later copy into the isolated
+	// CODEX_HOME. If the source is missing AND there's no OPENAI_API_KEY to fall
+	// back on, fail fast so the user sees a clear message rather than a silent
+	// 5-second 401 loop.
+	sourceHome := strings.TrimSpace(headlessCodexGlobalHomeDir())
+	authPath := filepath.Join(sourceHome, ".codex", "auth.json")
+	if sourceHome != "" {
+		if _, err := os.Stat(authPath); err == nil {
+			return nil
+		}
+	}
+	// Also accept a previously-copied auth.json in the isolated runtime home —
+	// codex would still work even if the source was since removed.
+	isolatedAuth := filepath.Join(headlessCodexHomeDir(), "auth.json")
+	if _, err := os.Stat(isolatedAuth); err == nil {
+		return nil
+	}
+	if strings.TrimSpace(config.ResolveOpenAIAPIKey()) != "" {
+		return nil
+	}
+	reason := fmt.Sprintf(
+		"Codex cannot authenticate — no `auth.json` at %s and no OPENAI_API_KEY in env. Run `codex login` on this machine, or set OPENAI_API_KEY, then retry.",
+		authPath,
+	)
+	appendHeadlessCodexLog(slug, "preflight: "+reason)
+	if l != nil && l.broker != nil {
+		target := channel
+		if strings.TrimSpace(target) == "" {
+			target = "general"
+		}
+		l.broker.PostSystemMessage(target,
+			fmt.Sprintf("@%s can't run: %s", slug, reason),
+			"error",
+		)
+	}
+	return fmt.Errorf("codex auth missing: %s", reason)
+}
+
+// dumpHeadlessCodexInvocation writes the exact codex argv + env + stdin to a
+// shell script in $WUPHF_DEBUG_CODEX_DUMP when that env var is set. Off by
+// default. Used to reproduce a failing turn outside WUPHF in a few seconds.
+func dumpHeadlessCodexInvocation(slug, workspaceDir string, args []string, env []string, stdinText string) {
+	dumpDir := strings.TrimSpace(os.Getenv("WUPHF_DEBUG_CODEX_DUMP"))
+	if dumpDir == "" {
+		return
+	}
+	if err := os.MkdirAll(dumpDir, 0o700); err != nil {
+		return
+	}
+	ts := time.Now().Format("20060102-150405.000")
+	stub := filepath.Join(dumpDir, fmt.Sprintf("codex-%s-%s", slug, ts))
+	if err := os.WriteFile(stub+".stdin", []byte(stdinText), 0o600); err != nil {
+		return
+	}
+	var sh strings.Builder
+	sh.WriteString("#!/bin/bash\n")
+	fmt.Fprintf(&sh, "# Reproduces the exact codex invocation WUPHF builds for agent=%s\n", slug)
+	sh.WriteString("set -e\n")
+	fmt.Fprintf(&sh, "cd %q\n", workspaceDir)
+	for _, kv := range env {
+		if i := strings.IndexByte(kv, '='); i > 0 {
+			fmt.Fprintf(&sh, "export %s=%q\n", kv[:i], kv[i+1:])
+		}
+	}
+	sh.WriteString("codex")
+	for _, a := range args {
+		fmt.Fprintf(&sh, " %q", a)
+	}
+	fmt.Fprintf(&sh, " < %q\n", stub+".stdin")
+	if err := os.WriteFile(stub+".sh", []byte(sh.String()), 0o700); err != nil {
+		return
+	}
+	appendHeadlessCodexLog(slug, "debug-dump: wrote "+stub+".sh")
+}
+
+// isCodexAuthError reports whether the failure detail looks like an auth issue
+// (expired OAuth, bad key, missing bearer). Used to surface a clear message to
+// the channel instead of the raw "exit status 1: exit status 1" noise.
+func isCodexAuthError(detail string) bool {
+	d := strings.ToLower(detail)
+	if d == "" {
+		return false
+	}
+	if strings.Contains(d, "401") {
+		return true
+	}
+	if strings.Contains(d, "unauthorized") {
+		return true
+	}
+	if strings.Contains(d, "missing bearer") {
+		return true
+	}
+	return false
 }
 
 func durationMillis(start, mark time.Time) int64 {

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -281,6 +281,7 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForCodingAgents(t *testing.T) {
 	t.Setenv("GO_WANT_HEADLESS_CODEX_HELPER_PROCESS", "1")
 	t.Setenv("HEADLESS_CODEX_RECORD_FILE", recordFile)
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	t.Setenv("PWD", repoRoot)
 	t.Setenv("OLDPWD", "/tmp/previous")
 	t.Setenv("CODEX_THREAD_ID", "thread-from-controller")
@@ -403,6 +404,7 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForLocalWorktreeBuilder(t *test
 	t.Setenv("GO_WANT_HEADLESS_CODEX_HELPER_PROCESS", "1")
 	t.Setenv("HEADLESS_CODEX_RECORD_FILE", recordFile)
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	t.Setenv("PWD", repoRoot)
 
 	broker := NewBroker()
@@ -480,6 +482,7 @@ func TestRunHeadlessCodexTurnPassesScopedChannelEnv(t *testing.T) {
 	t.Setenv("GO_WANT_HEADLESS_CODEX_HELPER_PROCESS", "1")
 	t.Setenv("HEADLESS_CODEX_RECORD_FILE", recordFile)
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OPENAI_API_KEY", "test-key")
 	t.Setenv("WUPHF_CHANNEL", "general")
 
 	l := &Launcher{
@@ -2096,5 +2099,102 @@ func waitForProcessedTurn(t *testing.T, ch <-chan processedTurn) processedTurn {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for processed turn")
 		return processedTurn{}
+	}
+}
+
+func TestPreflightHeadlessCodexAuthFailsAndPostsSystemMessage(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WUPHF_OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	if err := config.Save(config.Config{}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	broker := NewBroker()
+	l := &Launcher{broker: broker}
+
+	err := l.preflightHeadlessCodexAuth("operator", "general")
+	if err == nil {
+		t.Fatal("expected preflight to fail with no auth available")
+	}
+	if !strings.Contains(err.Error(), "codex auth missing") {
+		t.Fatalf("expected 'codex auth missing' in error, got %v", err)
+	}
+
+	// The channel should now contain a system message naming the agent and
+	// the remediation the user needs to take. Without this the user sees
+	// nothing but "Routing..." forever.
+	messages := broker.ChannelMessages("general")
+	if len(messages) == 0 {
+		t.Fatal("expected a system message in general, got none")
+	}
+	found := false
+	for _, m := range messages {
+		if m.From == "system" && strings.Contains(m.Content, "@operator") && strings.Contains(m.Content, "codex login") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected a system message mentioning @operator and 'codex login'; got %#v", messages)
+	}
+}
+
+func TestPreflightHeadlessCodexAuthPassesWhenOpenAIKeySet(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WUPHF_OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "sk-test-key")
+	if err := config.Save(config.Config{}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	l := &Launcher{broker: NewBroker()}
+	if err := l.preflightHeadlessCodexAuth("operator", "general"); err != nil {
+		t.Fatalf("expected preflight to pass with OPENAI_API_KEY set, got %v", err)
+	}
+}
+
+func TestPreflightHeadlessCodexAuthPassesWhenAuthJSONPresent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WUPHF_OPENAI_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	if err := config.Save(config.Config{}); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+	// Seed auth.json at the source path prepareHeadlessCodexHome reads from
+	// (~/.codex/auth.json). It will copy it into the isolated runtime home.
+	srcDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "auth.json"), []byte(`{"auth_mode":"chatgpt"}`), 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+
+	l := &Launcher{broker: NewBroker()}
+	if err := l.preflightHeadlessCodexAuth("operator", "general"); err != nil {
+		t.Fatalf("expected preflight to pass when auth.json exists, got %v", err)
+	}
+}
+
+func TestIsCodexAuthError(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", false},
+		{"exit status 1", false},
+		{"unexpected status 401 Unauthorized", true},
+		{"401 Unauthorized", true},
+		{"Missing bearer or basic authentication", true},
+		{"random network error", false},
+	}
+	for _, c := range cases {
+		if got := isCodexAuthError(c.in); got != c.want {
+			t.Errorf("isCodexAuthError(%q) = %v, want %v", c.in, got, c.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Codex auth failures (no \`auth.json\`, expired ChatGPT OAuth, no \`OPENAI_API_KEY\`) produced a silent 401 retry loop and \`error: exit status 1: exit status 1\` in the log, while the channel showed \`Routing to @X...\` forever. This PR surfaces the problem to the user so they can fix it.

## Changes
- **Preflight** (\`preflightHeadlessCodexAuth\`) runs before codex spawns. Checks for \`~/.codex/auth.json\`, isolated runtime \`auth.json\`, or \`OPENAI_API_KEY\`. If none, posts a clear system message to the channel and returns an error so the dispatcher skips the turn instead of wedging the agent.
- **Loud auth-copy logs** — \`copyHeadlessCodexHomeFile\` now returns errors; \`prepareHeadlessCodexHome\` logs to \`headless-codex-_setup.log\` when the auth copy fails.
- **Runtime 401 handling** — \`isCodexAuthError\` recognizes 401/Unauthorized/missing-bearer and posts a system message to the channel when a running turn fails with auth.
- **\`WUPHF_DEBUG_CODEX_DUMP=<dir>\`** (opt-in) — writes a self-contained shell script (argv + env + stdin) per codex turn so you can re-run the exact invocation outside WUPHF. 10-minute repro vs. 3-day debug.

## How it was found
User's Operator agent was stuck on \`Routing...\` for 3 days with only \`exit status 1: exit status 1\` in logs. Ran \`WUPHF_DEBUG_CODEX_DUMP=/tmp/dump\` against a freshly seeded Niche CRM team, executed the generated repro script by hand, saw codex retrying \`wss://api.openai.com/v1/responses\` with \`401 Missing bearer or basic authentication\`.

## Test plan
- [x] \`go test ./internal/team/ -count=1 -timeout 300s\` → pass
- [x] \`go vet ./...\` → clean
- [x] \`go build ./...\` → clean
- [x] 4 new tests: TestPreflightHeadlessCodexAuthFailsAndPostsSystemMessage / WhenOpenAIKeySet / WhenAuthJSONPresent / TestIsCodexAuthError
- [x] Existing HeadlessCodex tests pass (updated to \`t.Setenv("OPENAI_API_KEY")\` since preflight now runs before their mocked command)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added authentication validation before AI model operations begin
  * Added debug dump feature for troubleshooting model invocations

* **Bug Fixes**
  * Enhanced authentication failure detection with clearer error messages and resolution guidance (instructs users to run login or configure API key)
  * Improved error handling for authentication-related runtime failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->