### PR TITLE
feat(onboarding): group blueprints, fix task-step cross-blueprint leak

### DIFF
--- a/web/e2e/tests/wizard.spec.ts
+++ b/web/e2e/tests/wizard.spec.ts
@@ -104,22 +104,22 @@ test.describe('wuphf onboarding wizard smoke', () => {
 
     await advanceToTemplatesStep(page);
 
-    // Wait for the template grid (only rendered once blueprint fetch resolves).
-    await expect(page.locator('.template-grid')).toBeVisible({ timeout: 10_000 });
-
-    // `not.toHaveCount(1)` would pass for 0 cards too, masking a total
-    // render failure. Wait for at least two cards explicitly — the
-    // pre-embed bug rendered exactly one ("From scratch").
+    // Wait for at least one template grid (the blueprint picker now
+    // renders one grid per category group — Services, Media & Community,
+    // Products — so `.template-grid` is not unique). We rely on
+    // `.template-card` instead as the unit of a rendered blueprint.
     const cards = page.locator('.template-card');
-    await expect(cards.nth(1)).toBeVisible({ timeout: 10_000 });
+    await expect(cards.first()).toBeVisible({ timeout: 10_000 });
 
-    // "From scratch" is always present; at least one card must have a
-    // different name (i.e. a shipped preset was loaded).
-    const names = await page.locator('.template-card-name').allTextContents();
-    const presets = names.filter((n) => n.trim() !== 'From scratch');
+    // The pre-embed bug rendered exactly zero preset cards — only the
+    // separate "Start from scratch" button (which is NOT a .template-card
+    // in the grouped layout). So requiring ≥1 card is the regression
+    // guard: if embedded templates fail to load, the grouped layout
+    // would still render the from-scratch button but produce zero cards.
+    const count = await cards.count();
     expect(
-      presets.length,
-      `expected ≥1 preset blueprint card, got names: ${JSON.stringify(names)}`,
+      count,
+      'expected ≥1 preset blueprint card — embedded templates may have failed to load',
     ).toBeGreaterThan(0);
   });
 });

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -77,6 +77,64 @@ interface PrereqResult {
   install_url?: string
 }
 
+// Display overrides for blueprints. Backend names/descriptions are long-form
+// ("Bookkeeping and Invoicing Service", "Template for a bookkeeping operation
+// that handles recurring books..."). For the onboarding picker we want short,
+// scannable copy and visible categorization. Overrides are keyed by blueprint
+// id (see templates/operations/*/blueprint.yaml). If a blueprint isn't in the
+// map we fall back to the backend name + description, so new blueprints still
+// render without frontend changes.
+type BlueprintCategoryKey = 'services' | 'media' | 'product'
+
+interface BlueprintDisplay {
+  category: BlueprintCategoryKey
+  shortDescription: string
+  icon: string
+}
+
+const BLUEPRINT_CATEGORIES: ReadonlyArray<{
+  key: BlueprintCategoryKey
+  label: string
+  hint: string
+}> = [
+  { key: 'services', label: 'Services', hint: 'Client work, done by your office' },
+  { key: 'media', label: 'Media & Community', hint: 'Content or community as the business' },
+  { key: 'product', label: 'Products', hint: 'Software you build and sell' },
+] as const
+
+const BLUEPRINT_DISPLAY: Record<string, BlueprintDisplay> = {
+  'bookkeeping-invoicing-service': {
+    category: 'services',
+    shortDescription: 'Books · invoices · monthly close',
+    icon: '📊',
+  },
+  'local-business-ai-package': {
+    category: 'services',
+    shortDescription: 'Intake · booking · follow-up',
+    icon: '🏪',
+  },
+  'multi-agent-workflow-consulting': {
+    category: 'services',
+    shortDescription: 'Client engagements · workflow delivery',
+    icon: '💼',
+  },
+  'niche-crm': {
+    category: 'product',
+    shortDescription: 'Build & launch a focused CRM',
+    icon: '🎯',
+  },
+  'paid-discord-community': {
+    category: 'media',
+    shortDescription: 'Moderation · onboarding · engagement',
+    icon: '💬',
+  },
+  'youtube-factory': {
+    category: 'media',
+    shortDescription: 'Script · film · publish · analyze',
+    icon: '📹',
+  },
+}
+
 const API_KEY_FIELDS = [
   { key: 'ANTHROPIC_API_KEY', label: 'Anthropic', hint: 'Powers Claude-based agents' },
   { key: 'OPENAI_API_KEY', label: 'OpenAI', hint: 'Powers GPT-based agents' },
@@ -214,53 +272,99 @@ function TemplatesStep({
   onNext,
   onBack,
 }: TemplatesStepProps) {
+  // Group templates by display category. Unknown blueprint ids (not in the
+  // frontend catalog) land in a catch-all "Other" bucket so new backend
+  // templates still render, just without the short-description and icon
+  // treatment.
+  const grouped = new Map<BlueprintCategoryKey | 'other', BlueprintTemplate[]>()
+  for (const t of templates) {
+    const display = BLUEPRINT_DISPLAY[t.id]
+    const key: BlueprintCategoryKey | 'other' = display?.category ?? 'other'
+    const list = grouped.get(key) ?? []
+    list.push(t)
+    grouped.set(key, list)
+  }
+
+  const renderTile = (t: BlueprintTemplate) => {
+    const display = BLUEPRINT_DISPLAY[t.id]
+    const icon = display?.icon ?? t.emoji
+    const desc = display?.shortDescription ?? t.description
+    return (
+      <button
+        key={t.id}
+        className={`template-card ${selected === t.id ? 'selected' : ''}`}
+        onClick={() => onSelect(t.id)}
+        type="button"
+      >
+        {icon && <div className="template-card-emoji">{icon}</div>}
+        <div className="template-card-name">{t.name}</div>
+        <div className="template-card-desc">{desc}</div>
+      </button>
+    )
+  }
+
   return (
     <div className="wizard-step">
       <div className="wizard-hero">
         <div className="wizard-eyebrow">
           <span className="status-dot active pulse" />
-          Pick the operating model the office starts with
+          Start with a preset, or build from scratch
         </div>
-        <h1 className="wizard-headline">Choose a blueprint</h1>
+        <h1 className="wizard-headline">What should your office run?</h1>
         <p className="wizard-subhead">
-          Blueprints set the team, stages, and workflows this office will run.
-          Start from a preset or from scratch.
+          Pick the shape of work. We&apos;ll assemble the team, channels, and
+          first tasks around it. You can change anything later.
         </p>
       </div>
 
-      <div className="wizard-panel">
-        {loading ? (
+      {loading ? (
+        <div className="wizard-panel">
           <div style={{ color: 'var(--text-tertiary)', fontSize: 13, textAlign: 'center', padding: 20 }}>
             Loading blueprints&hellip;
           </div>
-        ) : (
-          <div className="template-grid">
+        </div>
+      ) : (
+        <>
+          {BLUEPRINT_CATEGORIES.map((cat) => {
+            const items = grouped.get(cat.key) ?? []
+            if (items.length === 0) return null
+            return (
+              <div key={cat.key} className="wizard-panel template-group">
+                <div className="template-group-head">
+                  <p className="template-group-label">{cat.label}</p>
+                  <p className="template-group-hint">{cat.hint}</p>
+                </div>
+                <div className="template-grid">{items.map(renderTile)}</div>
+              </div>
+            )
+          })}
+
+          {(grouped.get('other') ?? []).length > 0 && (
+            <div className="wizard-panel template-group">
+              <div className="template-group-head">
+                <p className="template-group-label">Other</p>
+              </div>
+              <div className="template-grid">
+                {(grouped.get('other') ?? []).map(renderTile)}
+              </div>
+            </div>
+          )}
+
+          <div className="template-from-scratch">
             <button
-              className={`template-card ${selected === null ? 'selected' : ''}`}
+              className={`template-from-scratch-btn ${selected === null ? 'selected' : ''}`}
               onClick={() => onSelect(null)}
               type="button"
             >
-              <div className="template-card-emoji">&#x1F4DD;</div>
-              <div className="template-card-name">From scratch</div>
-              <div className="template-card-desc">
-                Start with an empty office and add agents manually.
-              </div>
+              <span className="template-from-scratch-icon">+</span>
+              Start from scratch
+              <span className="template-from-scratch-sub">
+                Empty office, add agents manually
+              </span>
             </button>
-            {templates.map((t) => (
-              <button
-                key={t.id}
-                className={`template-card ${selected === t.id ? 'selected' : ''}`}
-                onClick={() => onSelect(t.id)}
-                type="button"
-              >
-                {t.emoji && <div className="template-card-emoji">{t.emoji}</div>}
-                <div className="template-card-name">{t.name}</div>
-                <div className="template-card-desc">{t.description}</div>
-              </button>
-            ))}
           </div>
-        )}
-      </div>
+        </>
+      )}
 
       <div className="wizard-nav">
         <button className="btn btn-ghost" onClick={onBack} type="button">
@@ -721,55 +825,58 @@ function TaskStep({
 }: TaskStepProps) {
   return (
     <div className="wizard-step">
-      <div>
-        <h2
-          style={{
-            fontSize: 18,
-            fontWeight: 700,
-            textAlign: 'left',
-            marginBottom: 4,
-          }}
-        >
+      <div className="wizard-hero">
+        <h1 className="wizard-headline" style={{ fontSize: 28 }}>
           {ONBOARDING_COPY.step3_title}
-        </h2>
+        </h1>
+        {taskTemplates.length > 0 && (
+          <p className="wizard-subhead">
+            Type your own first task, or pick from the blueprint&apos;s
+            suggested sequence below.
+          </p>
+        )}
       </div>
 
-      {taskTemplates.length > 0 && (
-        <div className="template-grid">
-          {taskTemplates.map((t) => (
-            <button
-              key={t.id}
-              className={`template-card ${selectedTaskTemplate === t.id ? 'selected' : ''}`}
-              onClick={() => {
-                onSelectTaskTemplate(selectedTaskTemplate === t.id ? null : t.id)
-                if (t.prompt) onChangeTaskText(t.prompt)
-              }}
-              type="button"
-            >
-              {t.emoji && <div className="template-card-emoji">{t.emoji}</div>}
-              <div className="template-card-name">{t.name}</div>
-              <div className="template-card-desc">{t.description}</div>
-            </button>
-          ))}
-        </div>
-      )}
-
       <div>
-        <label
-          className="label"
-          htmlFor="wiz-task-input"
-          style={{ marginBottom: 8, display: 'block' }}
-        >
-          Or describe the first real business loop
-        </label>
         <textarea
-          className="task-textarea"
+          className="task-textarea task-textarea-primary"
           id="wiz-task-input"
           placeholder={ONBOARDING_COPY.step3_placeholder}
           value={taskText}
           onChange={(e) => onChangeTaskText(e.target.value)}
+          autoFocus
         />
       </div>
+
+      {taskTemplates.length > 0 && (
+        <div className="task-suggestions">
+          <p className="task-suggestions-label">
+            Suggested sequence for this blueprint
+          </p>
+          <div className="task-suggestions-list">
+            {taskTemplates.map((t, idx) => {
+              const isSelected = selectedTaskTemplate === t.id
+              return (
+                <button
+                  key={t.id}
+                  className={`task-suggestion ${isSelected ? 'selected' : ''}`}
+                  onClick={() => {
+                    const nextId = isSelected ? null : t.id
+                    onSelectTaskTemplate(nextId)
+                    if (nextId) {
+                      onChangeTaskText(t.prompt ?? t.name)
+                    }
+                  }}
+                  type="button"
+                >
+                  <span className="task-suggestion-num">{idx + 1}</span>
+                  <span className="task-suggestion-name">{t.name}</span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
 
       <div className="wizard-nav">
         <button className="btn btn-ghost" onClick={onBack} type="button">
@@ -852,18 +959,6 @@ export function Wizard({ onComplete }: WizardProps) {
         if (cancelled) return
         const tpls = data.templates ?? []
         setBlueprints(tpls)
-
-        // Also extract task templates if present
-        const tasks: TaskTemplate[] = []
-        for (const t of tpls) {
-          if ((t as unknown as Record<string, unknown>).tasks) {
-            const arr = (t as unknown as Record<string, TaskTemplate[]>).tasks
-            tasks.push(...arr)
-          }
-        }
-        if (tasks.length > 0) {
-          setTaskTemplates(tasks)
-        }
       })
       .catch(() => {
         // Endpoint may not exist yet; continue with empty list
@@ -931,10 +1026,14 @@ export function Wizard({ onComplete }: WizardProps) {
     })
   }, [])
 
-  // When a blueprint is selected, populate agents
+  // When a blueprint is selected, populate agents AND first tasks from that
+  // blueprint only. Previously we flattened tasks across every blueprint, so
+  // the task step showed ~26 tiles of unrelated work — including tasks from
+  // blueprints the user never picked.
   useEffect(() => {
     if (selectedBlueprint === null) {
       setAgents([])
+      setTaskTemplates([])
       return
     }
     const bp = blueprints.find((b) => b.id === selectedBlueprint)
@@ -948,6 +1047,17 @@ export function Wizard({ onComplete }: WizardProps) {
     } else {
       setAgents([])
     }
+    const bpTasks = (bp as unknown as { tasks?: TaskTemplate[] } | undefined)?.tasks
+    setTaskTemplates(Array.isArray(bpTasks) ? bpTasks : [])
+    // Clear any task-template selection and suggestion-derived text when the
+    // blueprint changes. Without this, switching from (say) Consulting to
+    // YouTube Factory leaves "Turn the directive..." stuck in the textarea —
+    // nonsensical in the new context. User-typed custom text is preserved,
+    // since selectedTaskTemplate is null for that path.
+    setSelectedTaskTemplate((prevSel) => {
+      if (prevSel != null) setTaskText('')
+      return null
+    })
   }, [selectedBlueprint, blueprints])
 
   // Navigation helpers

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -19,10 +19,10 @@ export const ONBOARDING_COPY = {
   step2_prereqs_title: 'First, make sure you have the tools',
   step2_keys_title: 'Connect your AI providers',
   step2_cta: 'Ready',
-  step3_title: 'What should this office do first?',
-  step3_placeholder: 'What should the office invent and start operating?',
-  step3_skip: 'Open the office without a first task',
-  step3_cta: 'Start the first loop',
+  step3_title: 'What should the team work on first?',
+  step3_placeholder: 'e.g. Sign our first three pilot customers in the next two weeks.',
+  step3_skip: 'Skip for now',
+  step3_cta: 'Get started',
 } as const
 
 export const DISCONNECT_THRESHOLD = 3

--- a/web/src/styles/onboarding.css
+++ b/web/src/styles/onboarding.css
@@ -119,7 +119,90 @@
   margin-bottom: 16px;
 }
 
-/* ─── Template Grid (Step 1 blueprints + Step 6 task templates) ─── */
+/* ─── Template Groups (blueprint picker) ─── */
+.template-group {
+  padding: 16px 20px 18px;
+}
+
+.template-group + .template-group {
+  margin-top: 12px;
+}
+
+.template-group-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.template-group-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.template-group-hint {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  margin: 0;
+}
+
+/* From-scratch escape hatch — separated from grouped presets */
+.template-from-scratch {
+  margin-top: 4px;
+  display: flex;
+  justify-content: center;
+}
+
+.template-from-scratch-btn {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 10px 16px;
+  border: 1px dashed var(--border-dark);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.template-from-scratch-btn:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.template-from-scratch-btn.selected {
+  border-style: solid;
+  border-color: var(--accent);
+  background: var(--accent-bg);
+  color: var(--text-primary);
+}
+
+.template-from-scratch-icon {
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--text-tertiary);
+}
+
+.template-from-scratch-btn.selected .template-from-scratch-icon {
+  color: var(--accent);
+}
+
+.template-from-scratch-sub {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-weight: 400;
+}
+
+/* ─── Template Grid (tiles inside a blueprint group + step 6 suggestions) ─── */
 .template-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
@@ -468,6 +551,87 @@
   line-height: 1.5;
   resize: vertical;
   box-sizing: border-box;
+}
+
+/* Primary task textarea (step 6) — promoted to top of the screen, given more
+   height and a larger hit area so it reads as the main input, not a fallback. */
+.task-textarea-primary {
+  min-height: 120px;
+  padding: 14px 16px;
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+/* ─── Task Suggestions (step 6) ─── */
+.task-suggestions {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 16px 20px 18px;
+}
+
+.task-suggestions-label {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin: 0 0 12px 0;
+}
+
+.task-suggestions-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.task-suggestion {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-sans);
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.task-suggestion:hover {
+  border-color: var(--accent);
+}
+
+.task-suggestion.selected {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+}
+
+.task-suggestion-num {
+  flex: 0 0 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--border-light);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.task-suggestion.selected .task-suggestion-num {
+  background: var(--accent);
+  color: #fff;
+}
+
+.task-suggestion-name {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text-primary);
+  line-height: 1.4;
 }
 
 .task-textarea:focus {


### PR DESCRIPTION
Two /design-review passes flagged step 3 (blueprint picker) and step 6 (first task) as the worst screens in onboarding. This PR implements the quick-wins from both.

## Step 3 — Blueprint picker

**Before:** Flat 2-column grid of 7 tiles (6 presets + "From scratch"), each with a paragraph description. No categorization, jargon title ("Choose a blueprint"), no visual anchors.

**After:** Three labeled sections (Services / Media & Community / Products) via a frontend display catalog keyed by blueprint id. Short scannable descriptions (\`Books · invoices · monthly close\`). "From scratch" demoted below grouped presets. Plain-English title (\"What should your office run?\").

Unknown blueprint ids fall back gracefully — if someone adds a new \`templates/operations/*/blueprint.yaml\` without updating the catalog, it renders under an \"Other\" bucket with the backend's name/description.

## Step 6 — First task

**Bug fix:** \`Wizard.tsx:857-866\` was flattening \`tasks\` across every blueprint, so the task step displayed work items from blueprints the user never picked. Filtering now respects \`selectedBlueprint\`. For the Consulting blueprint, this drops the list from 26 tiles to 4.

**UX rewrite:** Freeform textarea promoted to the top with autofocus. Remaining suggestions render as a numbered sequence (1/2/3/4) to make the phased nature of the playbook visible. CTAs shortened (\`\"Open the office without a first task\" → \"Skip for now\"\`). Selection clears when blueprint changes so stale task text doesn't persist across picks.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm run build\` clean
- [x] Manual: clicked every blueprint — Services/Media/Products grouping renders correctly
- [x] Manual: picked Consulting → task step shows 4 tasks (not 26)
- [x] Manual: picked YouTube Factory → task step shows YouTube's 6 tasks
- [x] Manual: switching blueprints clears suggestion-derived task text
- [x] Manual: user-typed custom text preserved across blueprint switches
- [x] Manual: mobile viewport (375px) — groups stack cleanly, task suggestions readable
- [ ] Visual: confirm in prod/staging that the grouping feels right with the actual blueprint set

## Out of scope (flagged for follow-up)

- Dropping or renaming "Multi-Agent Workflow Consulting" — this is a product-scope decision, not a design one. The self-referential framing is confusing for first-time users but we haven't decided what replaces it.
- Translating backend jargon in task descriptions ("durable artifact bundle", "evidence-backed review") — these are in the YAML templates and would benefit from a separate content pass. Current PR dropped the descriptions from the task tiles so users don't see them, but the strings remain in the API response.