### PR TITLE
fix(wiki): audit-ready edit history + bootstrap + atomic writes

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -1196,6 +1196,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/wiki/list", b.requireAuth(b.handleWikiList))
 	mux.HandleFunc("/wiki/article", b.requireAuth(b.handleWikiArticle))
 	mux.HandleFunc("/wiki/catalog", b.requireAuth(b.handleWikiCatalog))
+	mux.HandleFunc("/wiki/audit", b.requireAuth(b.handleWikiAudit))
 	mux.HandleFunc("/studio/generate-package", b.requireAuth(b.handleStudioGeneratePackage))
 	mux.HandleFunc("/studio/bootstrap-package", b.requireAuth(b.handleOperationBootstrapPackage))
 	mux.HandleFunc("/operations/bootstrap-package", b.requireAuth(b.handleOperationBootstrapPackage))

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -84,20 +84,31 @@ func (b *Broker) onboardingCompleteFn(task string, skipTask bool, blueprintID st
 	}
 
 	// Materialize the blueprint's LLM wiki outside the broker lock. Lane A
-	// owns the git repo at ~/.wuphf/wiki; we just write the skeleton files
-	// and let its commit worker pick them up on the next pass. Wiki
-	// materialization is best-effort: a failure here should NOT fail
-	// onboarding (the user should land on an empty-but-functional wiki
+	// owns the git repo at ~/.wuphf/wiki; we write the skeleton files, commit
+	// them under the reserved `wuphf-bootstrap` author, then regenerate the
+	// index. Wiki materialization is best-effort: a failure here should NOT
+	// fail onboarding (the user should land on an empty-but-functional wiki
 	// rather than a broken onboarding flow). Log and move on.
-	materializeBlueprintWiki(bp)
+	b.materializeBlueprintWiki(bp)
 	return nil
 }
 
-// materializeBlueprintWiki resolves ~/.wuphf/wiki and invokes the wiki
-// materializer. Errors are logged, never returned — onboarding succeeds
-// regardless. A blueprint without a WikiSchema (e.g. a synthesized
-// from-scratch blueprint) is silently skipped.
-func materializeBlueprintWiki(bp operations.Blueprint) {
+// materializeBlueprintWiki resolves ~/.wuphf/wiki, runs the skeleton
+// materializer, commits any newly-written skeletons as `wuphf-bootstrap`,
+// then regenerates the index so a fresh install has both the files AND the
+// audit trail from day 1.
+//
+// Errors are logged, never returned — onboarding succeeds regardless. A
+// blueprint without a WikiSchema (e.g. a synthesized from-scratch
+// blueprint) is silently skipped.
+//
+// Important: this runs OUTSIDE the broker lock (see caller), and uses the
+// wiki worker's Repo for the commit so we go through the same
+// per-commit-identity plumbing as regular agent writes. If the worker is
+// not yet live (memory backend != markdown), we log and return — the
+// skeletons stay on disk untracked and will be folded into the next
+// RecoverDirtyTree pass. That's not ideal but it's the honest fallback.
+func (b *Broker) materializeBlueprintWiki(bp operations.Blueprint) {
 	if bp.WikiSchema == nil {
 		return
 	}
@@ -115,6 +126,35 @@ func materializeBlueprintWiki(bp operations.Blueprint) {
 	if len(result.ArticlesCreated) > 0 || len(result.DirsCreated) > 0 {
 		log.Printf("onboarding: wiki materialized blueprint=%s dirs=%d articles_created=%d articles_skipped=%d",
 			bp.ID, len(result.DirsCreated), len(result.ArticlesCreated), len(result.ArticlesSkipped))
+	}
+	// Nothing to commit if only existing articles were observed.
+	if len(result.ArticlesCreated) == 0 && len(result.DirsCreated) == 0 {
+		return
+	}
+	worker := b.WikiWorker()
+	if worker == nil || worker.Repo() == nil {
+		// Non-markdown backend — skeletons stay on disk, will surface via
+		// RecoverDirtyTree on the next markdown-backend launch.
+		return
+	}
+	repo := worker.Repo()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	// Regenerate the index FIRST so CommitBootstrap picks up index/all.md in
+	// the same commit as the skeletons. Leaving it untracked would cause
+	// RecoverDirtyTree on the next launch to fold it into a `wuphf-recovery`
+	// commit, which misattributes a derived artefact.
+	if err := repo.IndexRegen(ctx); err != nil {
+		log.Printf("onboarding: wiki index regen failed (continuing): %v", err)
+	}
+	bootstrapMsg := fmt.Sprintf("wuphf: materialize %s blueprint skeletons", bp.ID)
+	sha, err := repo.CommitBootstrap(ctx, bootstrapMsg)
+	if err != nil {
+		log.Printf("onboarding: wiki commit-bootstrap failed: %v", err)
+		return
+	}
+	if sha != "" {
+		log.Printf("onboarding: wiki bootstrap committed %s (blueprint=%s)", sha, bp.ID)
 	}
 }
 

--- a/internal/team/wiki_git.go
+++ b/internal/team/wiki_git.go
@@ -271,9 +271,36 @@ func (r *Repo) Commit(ctx context.Context, slug, relPath, content, mode, message
 		bytesWritten = len(content)
 	}
 
+	// Regenerate the catalog BEFORE committing so index/all.md lands in the
+	// same commit as the article. Without this, the index is repeatedly
+	// modified-but-uncommitted and every `git status` sees it as dirty —
+	// eventually RecoverDirtyTree folds it into a misattributed
+	// `wuphf-recovery` commit. Inline regen keeps the working tree clean.
+	if err := r.regenerateIndexLocked(); err != nil {
+		return "", 0, fmt.Errorf("wiki: index regen: %w", err)
+	}
+
 	relForGit := filepath.ToSlash(relPath)
-	if out, err := r.runGitLocked(ctx, slug, "add", "--", relForGit); err != nil {
+	if out, err := r.runGitLocked(ctx, slug, "add", "--", relForGit, "index/all.md"); err != nil {
 		return "", 0, fmt.Errorf("wiki: git add %s: %w: %s", relPath, err, out)
+	}
+
+	// If the content is byte-identical to what's already committed (e.g. an
+	// agent retrying with the exact same body), `git add` stages nothing new
+	// and `git commit` would fail with "nothing to commit." Detect that and
+	// return a no-op success — the caller's contract is "make the content
+	// current," which it already is. We return the current HEAD so downstream
+	// code (SSE event, response body) stays well-formed.
+	cachedDiff, err := r.runGitLocked(ctx, slug, "diff", "--cached", "--name-only")
+	if err != nil {
+		return "", 0, fmt.Errorf("wiki: git diff --cached: %w", err)
+	}
+	if strings.TrimSpace(cachedDiff) == "" {
+		headSha, err := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+		if err != nil {
+			return "", 0, fmt.Errorf("wiki: resolve HEAD sha: %w", err)
+		}
+		return strings.TrimSpace(headSha), bytesWritten, nil
 	}
 
 	commitMsg := strings.TrimSpace(message)
@@ -288,6 +315,53 @@ func (r *Repo) Commit(ctx context.Context, slug, relPath, content, mode, message
 		return "", 0, fmt.Errorf("wiki: resolve HEAD sha: %w", err)
 	}
 	return strings.TrimSpace(sha), bytesWritten, nil
+}
+
+// CommitBootstrap stages every untracked / modified path under team/ and
+// commits the whole pile as author `wuphf-bootstrap`. It is idempotent: if
+// nothing is dirty, it returns ("", nil) without creating an empty commit.
+//
+// This is the handshake between the blueprint materializer (which only
+// writes files to disk) and git. Without it, the freshly-seeded skeletons
+// are untracked — on a later crash they get folded into a `wuphf-recovery`
+// commit, which is misleading in an audit view. With it, the first commit
+// for every skeleton article is attributable to the bootstrap step, not to
+// some later recovery pass or to an agent that happened to edit the file.
+//
+// The author slug `wuphf-bootstrap` is deliberate: it is visually distinct
+// from both the per-agent slugs (operator/planner/…) and the two reserved
+// system slugs (`system`, `wuphf-recovery`). Audit views can filter or
+// colour it differently from real human / agent edits.
+func (r *Repo) CommitBootstrap(ctx context.Context, message string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// If nothing is dirty there's nothing to commit. This is the common
+	// case when the user re-picks the same blueprint — MaterializeWiki
+	// preserved existing articles, so the worktree is already clean.
+	status, err := r.runGitLocked(ctx, "system", "status", "--porcelain")
+	if err != nil {
+		return "", fmt.Errorf("wiki: git status: %w", err)
+	}
+	if strings.TrimSpace(status) == "" {
+		return "", nil
+	}
+
+	if out, err := r.runGitLocked(ctx, "wuphf-bootstrap", "add", "-A"); err != nil {
+		return "", fmt.Errorf("wiki: git add -A (bootstrap): %w: %s", err, out)
+	}
+	commitMsg := strings.TrimSpace(message)
+	if commitMsg == "" {
+		commitMsg = "wuphf: materialize blueprint skeletons"
+	}
+	if out, err := r.runGitLocked(ctx, "wuphf-bootstrap", "commit", "-q", "-m", commitMsg); err != nil {
+		return "", fmt.Errorf("wiki: git commit (bootstrap): %w: %s", err, out)
+	}
+	sha, err := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("wiki: resolve HEAD sha: %w", err)
+	}
+	return strings.TrimSpace(sha), nil
 }
 
 // Log returns the commit history for a single article, most-recent first.
@@ -328,6 +402,95 @@ func (r *Repo) Log(ctx context.Context, relPath string) ([]CommitRef, error) {
 	return refs, nil
 }
 
+// AuditEntry is a single cross-article commit surfaced by AuditLog. Unlike
+// CommitRef (which powers per-article history), this carries the list of
+// files touched by the commit so reviewers can reconstruct the full diff
+// surface without running a second `git show`.
+type AuditEntry struct {
+	SHA       string
+	Author    string
+	Timestamp time.Time
+	Message   string
+	// Paths are the git pathspecs modified in this commit, forward-slashed.
+	// Merge commits and commits that only touched index/ will appear with
+	// whatever git log --name-only reports; callers can filter as needed.
+	Paths []string
+}
+
+// AuditLog returns every commit in the wiki repo, most-recent first. This
+// is the cross-article audit trail — per-article history lives in Log().
+// Two intentional design choices:
+//
+//  1. We always include the full author slug, timestamp, and file list so
+//     downstream audit tooling (CSV export, compliance review, SOC2
+//     artefact generation, etc.) can work without re-shelling to git.
+//  2. Bootstrap (`wuphf-bootstrap`), recovery (`wuphf-recovery`), and
+//     system (`system`) authors are surfaced alongside agent slugs. Audit
+//     tools can filter them out by author, but the default feed is the
+//     complete lineage — hiding bootstrap would create a false impression
+//     that articles "appeared" at first-agent-write time.
+//
+// limit <= 0 returns everything. since.IsZero() returns everything regardless
+// of age; otherwise only commits strictly newer than `since` are returned.
+func (r *Repo) AuditLog(ctx context.Context, since time.Time, limit int) ([]AuditEntry, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	args := []string{
+		"log",
+		"--format=%h%x1f%an%x1f%aI%x1f%s",
+		"--name-only",
+		"--no-merges",
+	}
+	if !since.IsZero() {
+		args = append(args, "--since="+since.UTC().Format(time.RFC3339))
+	}
+	if limit > 0 {
+		args = append(args, fmt.Sprintf("--max-count=%d", limit))
+	}
+	out, err := r.runGitLocked(ctx, "system", args...)
+	if err != nil {
+		return nil, fmt.Errorf("wiki: audit log: %w", err)
+	}
+	return parseAuditLog(out), nil
+}
+
+// parseAuditLog splits the output of `git log --format=... --name-only`
+// into AuditEntry records. Exposed for test-side coverage.
+func parseAuditLog(raw string) []AuditEntry {
+	var out []AuditEntry
+	var cur *AuditEntry
+	for _, rawLine := range strings.Split(raw, "\n") {
+		line := strings.TrimRight(rawLine, "\r")
+		if line == "" {
+			// Blank line terminates the paths block for the current commit.
+			// Do NOT reset cur here — another header may follow immediately.
+			continue
+		}
+		// Header lines contain our unit separator 0x1f; path lines do not.
+		if strings.Contains(line, "\x1f") {
+			parts := strings.Split(line, "\x1f")
+			if len(parts) != 4 {
+				continue
+			}
+			ts, _ := time.Parse(time.RFC3339, parts[2])
+			entry := AuditEntry{
+				SHA:       parts[0],
+				Author:    parts[1],
+				Timestamp: ts,
+				Message:   parts[3],
+			}
+			out = append(out, entry)
+			cur = &out[len(out)-1]
+			continue
+		}
+		if cur != nil {
+			cur.Paths = append(cur.Paths, filepath.ToSlash(line))
+		}
+	}
+	return out
+}
+
 // Fsck runs git fsck and returns ErrRepoCorrupt if the repo is unreadable.
 func (r *Repo) Fsck(ctx context.Context) error {
 	r.mu.Lock()
@@ -347,6 +510,13 @@ func (r *Repo) Fsck(ctx context.Context) error {
 func (r *Repo) IndexRegen(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.regenerateIndexLocked()
+}
+
+// regenerateIndexLocked is the mutex-free body of IndexRegen. Called by
+// Commit which already holds r.mu so we can't re-enter. Kept in sync with
+// IndexRegen — the only difference is the lock wrap.
+func (r *Repo) regenerateIndexLocked() error {
 	teamDir := filepath.Join(r.root, "team")
 	if _, err := os.Stat(teamDir); err != nil {
 		return fmt.Errorf("wiki: team dir missing: %w", err)
@@ -704,6 +874,14 @@ func copyFile(src, dst string, mode os.FileMode) error {
 	defer func() { _ = in.Close() }()
 	if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
 		return err
+	}
+	// Git stores loose objects with mode 0o444 (read-only). On the second
+	// backup pass, os.OpenFile(dst, O_CREATE|O_WRONLY|O_TRUNC) fails with
+	// "permission denied" because the file exists and is not writable.
+	// Remove it first so we always get a fresh write. os.Remove with
+	// IsNotExist-check because the common case is a brand-new dst.
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("wiki: remove stale %s: %w", dst, err)
 	}
 	out, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {

--- a/internal/team/wiki_git_test.go
+++ b/internal/team/wiki_git_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func newTestRepo(t *testing.T) *Repo {
@@ -317,5 +318,168 @@ func TestRepoRecoverDirtyTreeCleanIsNoop(t *testing.T) {
 	// Nothing dirty — should succeed and not create a new commit
 	if err := repo.RecoverDirtyTree(ctx); err != nil {
 		t.Fatalf("recover: %v", err)
+	}
+}
+
+func TestRepoCommitBootstrapAttributesToBootstrapAuthor(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	// Simulate MaterializeWiki: drop two skeleton files under team/ without
+	// going through Commit(). CommitBootstrap should pick them up and
+	// attribute them to wuphf-bootstrap (NOT wuphf-recovery, NOT system).
+	if err := os.MkdirAll(filepath.Join(repo.Root(), "team", "playbooks"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	skeletons := map[string]string{
+		"team/playbooks/renewal.md":        "# Renewal\n",
+		"team/decisions/wiki-as-default.md": "# Decision\n",
+	}
+	for rel, body := range skeletons {
+		full := filepath.Join(repo.Root(), filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	sha, err := repo.CommitBootstrap(ctx, "wuphf: materialize test blueprint")
+	if err != nil {
+		t.Fatalf("CommitBootstrap: %v", err)
+	}
+	if sha == "" {
+		t.Fatal("expected non-empty sha")
+	}
+
+	// The most recent commit for each skeleton must be authored by wuphf-bootstrap.
+	for rel := range skeletons {
+		refs, err := repo.Log(ctx, rel)
+		if err != nil {
+			t.Fatalf("log %s: %v", rel, err)
+		}
+		if len(refs) == 0 {
+			t.Fatalf("%s: expected a commit in log", rel)
+		}
+		if refs[0].Author != "wuphf-bootstrap" {
+			t.Fatalf("%s: expected wuphf-bootstrap author, got %q", rel, refs[0].Author)
+		}
+		if !strings.Contains(refs[0].Message, "materialize test blueprint") {
+			t.Fatalf("%s: expected commit message to carry the caller's msg, got %q", rel, refs[0].Message)
+		}
+	}
+}
+
+func TestRepoCommitBootstrapIsNoopOnCleanTree(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	// Fresh init → tree is clean → no bootstrap commit should be created.
+	sha, err := repo.CommitBootstrap(ctx, "should not commit")
+	if err != nil {
+		t.Fatalf("CommitBootstrap clean: %v", err)
+	}
+	if sha != "" {
+		t.Fatalf("expected empty sha on clean tree, got %q", sha)
+	}
+}
+
+func TestRepoAuditLogCoversAllAuthors(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	// One skeleton → bootstrap commit.
+	full := filepath.Join(repo.Root(), "team", "playbooks", "renewal.md")
+	if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte("# Renewal\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := repo.CommitBootstrap(ctx, "materialize"); err != nil {
+		t.Fatalf("CommitBootstrap: %v", err)
+	}
+	// Two agent commits.
+	if _, _, err := repo.Commit(ctx, "operator", "team/people/sarah.md", "# Sarah\n", "create", "sarah"); err != nil {
+		t.Fatalf("Commit sarah: %v", err)
+	}
+	if _, _, err := repo.Commit(ctx, "planner", "team/playbooks/renewal.md", "# Renewal v2\n", "replace", "update renewal"); err != nil {
+		t.Fatalf("Commit renewal: %v", err)
+	}
+
+	entries, err := repo.AuditLog(ctx, time.Time{}, 0)
+	if err != nil {
+		t.Fatalf("AuditLog: %v", err)
+	}
+	// Expect at least 4 commits: init + bootstrap + sarah + renewal.
+	if len(entries) < 4 {
+		t.Fatalf("expected >=4 entries, got %d: %+v", len(entries), entries)
+	}
+	authors := map[string]bool{}
+	for _, e := range entries {
+		authors[e.Author] = true
+	}
+	for _, want := range []string{"system", "wuphf-bootstrap", "operator", "planner"} {
+		if !authors[want] {
+			t.Errorf("expected author %q in audit log, got authors=%v", want, authors)
+		}
+	}
+	// Newest-first ordering — first entry should be the most recent commit.
+	if entries[0].Author != "planner" {
+		t.Errorf("expected newest-first ordering with planner at top, got %q", entries[0].Author)
+	}
+	// Paths populated for at least the content commits.
+	for _, e := range entries {
+		if e.Author == "planner" && len(e.Paths) == 0 {
+			t.Errorf("expected paths to populate for planner commit, got empty")
+		}
+	}
+}
+
+func TestRepoAuditLogSinceFilter(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if _, _, err := repo.Commit(ctx, "operator", "team/people/a.md", "# A\n", "create", "a"); err != nil {
+		t.Fatalf("Commit a: %v", err)
+	}
+	// since=far-future: should return nothing
+	future := time.Now().Add(24 * time.Hour)
+	entries, err := repo.AuditLog(ctx, future, 0)
+	if err != nil {
+		t.Fatalf("AuditLog: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 entries with far-future since, got %d", len(entries))
+	}
+}
+
+func TestRepoAuditLogLimitCaps(t *testing.T) {
+	repo := newTestRepo(t)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	for i := 0; i < 5; i++ {
+		path := "team/people/" + string(rune('a'+i)) + ".md"
+		if _, _, err := repo.Commit(ctx, "operator", path, "# X\n", "create", "p"); err != nil {
+			t.Fatalf("Commit %d: %v", i, err)
+		}
+	}
+	entries, err := repo.AuditLog(ctx, time.Time{}, 2)
+	if err != nil {
+		t.Fatalf("AuditLog: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries with limit=2, got %d", len(entries))
 	}
 }

--- a/internal/team/wiki_worker.go
+++ b/internal/team/wiki_worker.go
@@ -34,6 +34,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -196,17 +197,14 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 	writeCtx, cancel := context.WithTimeout(ctx, wikiWriteTimeout)
 	defer cancel()
 
+	// Commit owns the full atomic unit: write article bytes, regenerate the
+	// catalog, stage both, commit together. That keeps the working tree
+	// clean and the index commit attributable to the same author as the
+	// article edit. No post-commit IndexRegen here.
 	sha, n, err := w.repo.Commit(writeCtx, req.Slug, req.Path, req.Content, req.Mode, req.CommitMsg)
 	if err != nil {
 		req.ReplyCh <- wikiWriteResult{Err: err}
 		return
-	}
-	// Regenerate the catalog. A regen failure is non-fatal for the caller —
-	// the article commit already landed. Log it loudly so the next run can
-	// repair things if needed. TODO(telemetry): emit regen duration and
-	// warn when p95 > 300ms once the observability hook exists.
-	if err := w.repo.IndexRegen(writeCtx); err != nil {
-		log.Printf("wiki: index regen failed after commit %s: %v", sha, err)
 	}
 	req.ReplyCh <- wikiWriteResult{SHA: sha, BytesWritten: n}
 
@@ -439,6 +437,94 @@ func (b *Broker) handleWikiArticle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, meta)
+}
+
+// handleWikiAudit returns the cross-article commit log for audit / compliance.
+// Unlike /wiki/history/<path> which scopes to one article, this feed covers
+// the whole wiki and includes bootstrap + recovery + system commits so the
+// lineage is complete.
+//
+//	GET /wiki/audit
+//	GET /wiki/audit?limit=50
+//	GET /wiki/audit?since=2026-04-01T00:00:00Z
+//
+// Response:
+//
+//	{
+//	  "entries": [
+//	    {
+//	      "sha": "...", "author_slug": "...", "timestamp": "...",
+//	      "message": "...", "paths": ["team/..."]
+//	    },
+//	    ...
+//	  ],
+//	  "total": N
+//	}
+func (b *Broker) handleWikiAudit(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	worker := b.WikiWorker()
+	if worker == nil {
+		http.Error(w, `{"error":"wiki backend is not active"}`, http.StatusServiceUnavailable)
+		return
+	}
+	// Parse limit (optional, 0 = all). Default cap keeps a runaway caller
+	// from dragging in 100k commits; explicit `limit=0` opts out of the cap.
+	const defaultLimit = 500
+	limit := defaultLimit
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "limit must be a non-negative integer"})
+			return
+		}
+		limit = v
+	}
+	var since time.Time
+	if raw := strings.TrimSpace(r.URL.Query().Get("since")); raw != "" {
+		t, err := time.Parse(time.RFC3339, raw)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "since must be RFC3339 (e.g. 2026-04-01T00:00:00Z)"})
+			return
+		}
+		since = t
+	}
+	entries, err := worker.Repo().AuditLog(r.Context(), since, limit)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	// Re-shape to snake_case for the JSON API — same convention as
+	// /wiki/catalog and /wiki/article. `paths` never serialised as null:
+	// absent paths (rare, but possible for a signed-only commit) get an
+	// empty array so consumers don't have to null-guard.
+	type wireEntry struct {
+		SHA        string   `json:"sha"`
+		AuthorSlug string   `json:"author_slug"`
+		Timestamp  string   `json:"timestamp"`
+		Message    string   `json:"message"`
+		Paths      []string `json:"paths"`
+	}
+	wire := make([]wireEntry, 0, len(entries))
+	for _, e := range entries {
+		paths := e.Paths
+		if paths == nil {
+			paths = []string{}
+		}
+		wire = append(wire, wireEntry{
+			SHA:        e.SHA,
+			AuthorSlug: e.Author,
+			Timestamp:  e.Timestamp.UTC().Format(time.RFC3339),
+			Message:    e.Message,
+			Paths:      paths,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"entries": wire,
+		"total":   len(wire),
+	})
 }
 
 func writeJSON(w http.ResponseWriter, status int, body any) {

--- a/internal/team/wiki_worker_test.go
+++ b/internal/team/wiki_worker_test.go
@@ -445,6 +445,110 @@ func TestWikiWorkerPublicAccessors(t *testing.T) {
 	}
 }
 
+func TestBrokerWikiAuditReturnsFullLineage(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	// Seed a bootstrap commit and one agent commit so the audit log has
+	// three distinct authors (system, wuphf-bootstrap, operator).
+	stub := filepath.Join(root, "team", "playbooks", "renewal.md")
+	if err := os.MkdirAll(filepath.Dir(stub), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(stub, []byte("# Renewal\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := repo.CommitBootstrap(ctx, "materialize"); err != nil {
+		t.Fatalf("CommitBootstrap: %v", err)
+	}
+	if _, _, err := repo.Commit(ctx, "operator", "team/people/nazz.md", "# Nazz\n", "create", "nazz"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	b := NewBroker()
+	worker := NewWikiWorker(repo, b)
+	workerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	worker.Start(workerCtx)
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wiki/audit", b.handleWikiAudit)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	res, err := http.Get(srv.URL + "/wiki/audit")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", res.StatusCode)
+	}
+	var body struct {
+		Entries []struct {
+			SHA        string   `json:"sha"`
+			AuthorSlug string   `json:"author_slug"`
+			Timestamp  string   `json:"timestamp"`
+			Message    string   `json:"message"`
+			Paths      []string `json:"paths"`
+		} `json:"entries"`
+		Total int `json:"total"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.Total < 3 {
+		t.Fatalf("expected total >= 3, got %d: %+v", body.Total, body.Entries)
+	}
+	seen := map[string]bool{}
+	for _, e := range body.Entries {
+		seen[e.AuthorSlug] = true
+		if e.Paths == nil {
+			t.Errorf("entry %s: paths should be [] not nil for JSON stability", e.SHA)
+		}
+	}
+	for _, want := range []string{"system", "wuphf-bootstrap", "operator"} {
+		if !seen[want] {
+			t.Errorf("expected author %q in audit feed, got %v", want, seen)
+		}
+	}
+}
+
+func TestBrokerWikiAuditRejectsBadSince(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	b := NewBroker()
+	worker := NewWikiWorker(repo, b)
+	workerCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	worker.Start(workerCtx)
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/wiki/audit", b.handleWikiAudit)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	res, err := http.Get(srv.URL + "/wiki/audit?since=not-a-timestamp")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", res.StatusCode)
+	}
+}
+
 func TestWikiPublishViaBroker(t *testing.T) {
 	b := NewBroker()
 	ch, unsubscribe := b.SubscribeWikiEvents(4)

--- a/scripts/demo-wiki-live.sh
+++ b/scripts/demo-wiki-live.sh
@@ -57,14 +57,28 @@ print(json.dumps({
   "content": sys.argv[5],
 }))
 ' "$slug" "$path" "$mode" "$msg" "$content")
-  local response
-  response=$(curl -fsS -X POST "$BROKER/wiki/write" \
+  local response http_code
+  response=$(curl -sS -w '\nHTTP=%{http_code}' -X POST "$BROKER/wiki/write" \
     -H "Authorization: Bearer $TOKEN" \
     -H "Content-Type: application/json" \
-    -d "$payload" 2>&1) || { fail "write failed: $response"; return 1; }
-  local sha
-  sha=$(printf '%s' "$response" | "$PY" -c "import sys,json;print(json.load(sys.stdin).get('commit_sha',''))" 2>/dev/null || true)
-  ok "committed ${sha}"
+    -d "$payload" 2>&1)
+  http_code=$(printf '%s' "$response" | awk -F'=' '/^HTTP=/{print $2}' | tail -1)
+  response=$(printf '%s' "$response" | sed '/^HTTP=/d')
+  case "$http_code" in
+    2*)
+      local sha
+      sha=$(printf '%s' "$response" | "$PY" -c "import sys,json;print(json.load(sys.stdin).get('commit_sha',''))" 2>/dev/null || true)
+      ok "committed ${sha}"
+      ;;
+    *)
+      local detail
+      detail=$(printf '%s' "$response" | "$PY" -c "import sys,json;print(json.load(sys.stdin).get('error',''))" 2>/dev/null || true)
+      if [ -z "$detail" ]; then detail="$response"; fi
+      fail "write failed (HTTP ${http_code}): ${detail}"
+      sleep "$DELAY"
+      return 1
+      ;;
+  esac
   sleep "$DELAY"
 }
 

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -60,6 +60,28 @@ export async function fetchCatalog(): Promise<WikiCatalogEntry[]> {
   }
 }
 
+export interface WikiAuditEntry {
+  sha: string
+  author_slug: string
+  timestamp: string
+  message: string
+  paths: string[]
+}
+
+export async function fetchAuditLog(
+  params: { limit?: number; since?: string } = {},
+): Promise<{ entries: WikiAuditEntry[]; total: number }> {
+  const qs = new URLSearchParams()
+  if (typeof params.limit === 'number') qs.set('limit', String(params.limit))
+  if (params.since) qs.set('since', params.since)
+  const url = qs.toString() ? `/wiki/audit?${qs.toString()}` : '/wiki/audit'
+  try {
+    return await get<{ entries: WikiAuditEntry[]; total: number }>(url)
+  } catch {
+    return { entries: [], total: 0 }
+  }
+}
+
 export async function fetchHistory(
   path: string,
 ): Promise<{ commits: WikiHistoryCommit[] }> {

--- a/web/src/components/wiki/Wiki.tsx
+++ b/web/src/components/wiki/Wiki.tsx
@@ -3,8 +3,13 @@ import { fetchCatalog, type WikiCatalogEntry } from '../../api/wiki'
 import WikiSidebar from './WikiSidebar'
 import WikiCatalog from './WikiCatalog'
 import WikiArticle from './WikiArticle'
+import WikiAudit from './WikiAudit'
 import EditLogFooter from './EditLogFooter'
 import '../../styles/wiki.css'
+
+// Reserved pseudo-path for the audit view. Never collides with a real
+// article because real articles must live under `team/` and end in `.md`.
+const AUDIT_PATH = '_audit'
 
 interface WikiProps {
   /** When set, renders the article view for this path; otherwise renders the catalog. */
@@ -31,24 +36,32 @@ export default function Wiki({ articlePath, onNavigate }: WikiProps) {
     }
   }, [])
 
-  const view = articlePath ? 'article' : 'catalog'
+  const isAudit = articlePath === AUDIT_PATH
+  const view = isAudit ? 'audit' : articlePath ? 'article' : 'catalog'
 
   return (
     <div className="wiki-root" data-testid="wiki-root">
       <div className="wiki-layout" data-view={view}>
         <WikiSidebar
           catalog={catalog}
-          currentPath={articlePath}
+          currentPath={isAudit ? null : articlePath}
           onNavigate={(path) => onNavigate(path)}
+          onNavigateAudit={() => onNavigate(AUDIT_PATH)}
         />
-        {articlePath ? (
+        {isAudit ? (
+          <WikiAudit onNavigate={(path) => onNavigate(path)} />
+        ) : articlePath ? (
           <WikiArticle
             path={articlePath}
             catalog={catalog}
             onNavigate={(path) => onNavigate(path)}
           />
         ) : (
-          <WikiCatalog catalog={catalog} onNavigate={(path) => onNavigate(path)} />
+          <WikiCatalog
+            catalog={catalog}
+            onNavigate={(path) => onNavigate(path)}
+            onOpenAudit={() => onNavigate(AUDIT_PATH)}
+          />
         )}
       </div>
       {!loading && <EditLogFooter onNavigate={(path) => onNavigate(path)} />}

--- a/web/src/components/wiki/WikiAudit.test.tsx
+++ b/web/src/components/wiki/WikiAudit.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import WikiAudit from './WikiAudit'
+import * as api from '../../api/wiki'
+
+const ENTRIES: api.WikiAuditEntry[] = [
+  {
+    sha: 'aaa1111',
+    author_slug: 'operator',
+    timestamp: new Date(Date.now() - 60 * 1000).toISOString(),
+    message: 'first meridian brief',
+    paths: ['team/customers/meridian-freight.md'],
+  },
+  {
+    sha: 'bbb2222',
+    author_slug: 'wuphf-bootstrap',
+    timestamp: new Date(Date.now() - 3600 * 1000).toISOString(),
+    message: 'materialize niche-crm skeletons',
+    paths: ['team/playbooks/renewal.md', 'team/decisions/product-log.md'],
+  },
+  {
+    sha: 'ccc3333',
+    author_slug: 'system',
+    timestamp: new Date(Date.now() - 7200 * 1000).toISOString(),
+    message: 'wuphf: init wiki',
+    paths: [],
+  },
+]
+
+describe('<WikiAudit>', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(api, 'fetchAuditLog').mockResolvedValue({ entries: ENTRIES, total: ENTRIES.length })
+  })
+
+  it('renders every entry with author, message, and SHA', async () => {
+    render(<WikiAudit onNavigate={() => {}} />)
+    await waitFor(() => expect(screen.getByText('first meridian brief')).toBeInTheDocument())
+    expect(screen.getByText('materialize niche-crm skeletons')).toBeInTheDocument()
+    expect(screen.getByText('wuphf: init wiki')).toBeInTheDocument()
+    expect(screen.getByText('aaa1111')).toBeInTheDocument()
+    expect(screen.getByText('bbb2222')).toBeInTheDocument()
+    expect(screen.getByText('ccc3333')).toBeInTheDocument()
+  })
+
+  it('labels system + bootstrap commits with distinguishing tags', async () => {
+    render(<WikiAudit onNavigate={() => {}} />)
+    await waitFor(() => expect(screen.getByText('first meridian brief')).toBeInTheDocument())
+    expect(screen.getByText('bootstrap')).toBeInTheDocument()
+    expect(screen.getByText('system')).toBeInTheDocument()
+  })
+
+  it('filters to agents only via the author dropdown', async () => {
+    render(<WikiAudit onNavigate={() => {}} />)
+    await waitFor(() => expect(screen.getByText('first meridian brief')).toBeInTheDocument())
+    const select = screen.getByLabelText('Author') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'agents' } })
+    expect(screen.getByText('first meridian brief')).toBeInTheDocument()
+    expect(screen.queryByText('materialize niche-crm skeletons')).not.toBeInTheDocument()
+    expect(screen.queryByText('wuphf: init wiki')).not.toBeInTheDocument()
+  })
+
+  it('filters to system only', async () => {
+    render(<WikiAudit onNavigate={() => {}} />)
+    await waitFor(() => expect(screen.getByText('first meridian brief')).toBeInTheDocument())
+    const select = screen.getByLabelText('Author') as HTMLSelectElement
+    fireEvent.change(select, { target: { value: 'system' } })
+    expect(screen.queryByText('first meridian brief')).not.toBeInTheDocument()
+    expect(screen.getByText('materialize niche-crm skeletons')).toBeInTheDocument()
+    expect(screen.getByText('wuphf: init wiki')).toBeInTheDocument()
+  })
+
+  it('search matches against message and path', async () => {
+    render(<WikiAudit onNavigate={() => {}} />)
+    await waitFor(() => expect(screen.getByText('first meridian brief')).toBeInTheDocument())
+    const search = screen.getByLabelText('Search') as HTMLInputElement
+    fireEvent.change(search, { target: { value: 'renewal' } })
+    // Only the bootstrap commit touches team/playbooks/renewal.md
+    expect(screen.queryByText('first meridian brief')).not.toBeInTheDocument()
+    expect(screen.getByText('materialize niche-crm skeletons')).toBeInTheDocument()
+  })
+
+  it('path links navigate to the article view', async () => {
+    const onNavigate = vi.fn()
+    render(<WikiAudit onNavigate={onNavigate} />)
+    await waitFor(() =>
+      expect(screen.getByText('team/customers/meridian-freight.md')).toBeInTheDocument(),
+    )
+    fireEvent.click(screen.getByText('team/customers/meridian-freight.md'))
+    expect(onNavigate).toHaveBeenCalledWith('team/customers/meridian-freight.md')
+  })
+
+  it('renders helpful empty-state when the audit log is truly empty', async () => {
+    vi.spyOn(api, 'fetchAuditLog').mockResolvedValue({ entries: [], total: 0 })
+    render(<WikiAudit onNavigate={() => {}} />)
+    await waitFor(() => expect(screen.getByText(/No edits yet/i)).toBeInTheDocument())
+  })
+})

--- a/web/src/components/wiki/WikiAudit.tsx
+++ b/web/src/components/wiki/WikiAudit.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useMemo, useState } from 'react'
+import { fetchAuditLog, type WikiAuditEntry } from '../../api/wiki'
+import { formatRelativeTime } from '../../lib/format'
+import { formatAgentName } from '../../lib/agentName'
+import PixelAvatar from './PixelAvatar'
+
+/**
+ * Audit-log view at #/wiki/_audit.
+ *
+ * This is the compliance / "who edited what when" surface — distinct from
+ * the per-article Sources panel (which scopes to one article) and the
+ * bottom EditLogFooter (which is a live pulse of recent writes only).
+ *
+ * UX goals, in priority order:
+ *   1. You can find one edit fast. Filters compose (author + path + since).
+ *   2. You can see the shape of activity at a glance. Bootstrap commits
+ *      are visually distinct from agent writes; system / recovery commits
+ *      too. No color soup — it's a serious page.
+ *   3. You can export. The CSV copy button dumps exactly what's filtered.
+ *
+ * Out of scope for v1: diff viewer, commit SHA → GitHub linking, tamper
+ * detection sidecar. These are v1.1 items (see TESTING-WIKI.md).
+ */
+interface WikiAuditProps {
+  onNavigate: (path: string | null) => void
+}
+
+type AuthorBucket = 'all' | 'agents' | 'system' | string
+
+export default function WikiAudit({ onNavigate }: WikiAuditProps) {
+  const [entries, setEntries] = useState<WikiAuditEntry[] | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [authorFilter, setAuthorFilter] = useState<AuthorBucket>('all')
+  const [pathQuery, setPathQuery] = useState('')
+  const [sinceDays, setSinceDays] = useState<number | null>(null)
+  const [limit, setLimit] = useState(200)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    const since =
+      typeof sinceDays === 'number'
+        ? new Date(Date.now() - sinceDays * 86400 * 1000).toISOString()
+        : undefined
+    fetchAuditLog({ limit, since })
+      .then((res) => {
+        if (cancelled) return
+        setEntries(res.entries ?? [])
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : 'Failed to load audit log')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [limit, sinceDays])
+
+  const knownAuthors = useMemo(() => {
+    const set = new Set<string>()
+    for (const e of entries ?? []) set.add(e.author_slug)
+    return Array.from(set).sort()
+  }, [entries])
+
+  const filtered = useMemo(() => {
+    if (!entries) return []
+    const q = pathQuery.trim().toLowerCase()
+    return entries.filter((e) => {
+      if (!passesAuthor(e.author_slug, authorFilter)) return false
+      if (q) {
+        const hit =
+          e.message.toLowerCase().includes(q) ||
+          e.paths.some((p) => p.toLowerCase().includes(q))
+        if (!hit) return false
+      }
+      return true
+    })
+  }, [entries, pathQuery, authorFilter])
+
+  const stats = useMemo(() => summarize(filtered), [filtered])
+
+  return (
+    <main className="wk-audit" data-testid="wk-audit">
+      <header className="wk-audit-header">
+        <div>
+          <h1 className="wk-audit-title">Audit log</h1>
+          <p className="wk-audit-strapline">
+            Every edit to the team wiki, newest first. Attribution comes from per-commit
+            git identity — same data `git log` would give you on disk.
+          </p>
+        </div>
+        <div className="wk-audit-stats" aria-live="polite">
+          {loading ? 'Loading…' : error ? 'Error' : `${stats.total} entries · ${stats.authors} authors · ${stats.paths} paths touched`}
+        </div>
+      </header>
+
+      <section className="wk-audit-filters" aria-label="Filters">
+        <label className="wk-audit-filter">
+          <span>Author</span>
+          <select
+            value={authorFilter}
+            onChange={(e) => setAuthorFilter(e.target.value as AuthorBucket)}
+          >
+            <option value="all">All</option>
+            <option value="agents">Agents only</option>
+            <option value="system">System (bootstrap + recovery + init)</option>
+            {knownAuthors.map((a) => (
+              <option key={a} value={a}>
+                @{a}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="wk-audit-filter">
+          <span>Search</span>
+          <input
+            type="search"
+            placeholder="Match message or path (e.g. playbooks, renewal, sarah)"
+            value={pathQuery}
+            onChange={(e) => setPathQuery(e.target.value)}
+          />
+        </label>
+        <label className="wk-audit-filter">
+          <span>Window</span>
+          <select
+            value={sinceDays ?? 'all'}
+            onChange={(e) => {
+              const v = e.target.value
+              setSinceDays(v === 'all' ? null : Number(v))
+            }}
+          >
+            <option value="all">All time</option>
+            <option value="1">Last 24 hours</option>
+            <option value="7">Last 7 days</option>
+            <option value="30">Last 30 days</option>
+            <option value="90">Last 90 days</option>
+          </select>
+        </label>
+        <label className="wk-audit-filter">
+          <span>Limit</span>
+          <select value={String(limit)} onChange={(e) => setLimit(Number(e.target.value))}>
+            <option value="50">50</option>
+            <option value="200">200</option>
+            <option value="500">500</option>
+            <option value="0">No limit</option>
+          </select>
+        </label>
+        <button
+          type="button"
+          className="wk-audit-export"
+          onClick={() => downloadCSV(filtered)}
+          disabled={filtered.length === 0}
+        >
+          Export CSV
+        </button>
+      </section>
+
+      {loading && !entries ? (
+        <div className="wk-loading">Loading audit log…</div>
+      ) : error ? (
+        <div className="wk-error">Error: {error}</div>
+      ) : filtered.length === 0 ? (
+        <div className="wk-audit-empty">
+          {entries && entries.length === 0
+            ? 'No edits yet. This page will populate as soon as any agent (or bootstrap pass) commits to the wiki.'
+            : 'No entries match your filters.'}
+        </div>
+      ) : (
+        <table className="wk-audit-table">
+          <thead>
+            <tr>
+              <th scope="col">When</th>
+              <th scope="col">Author</th>
+              <th scope="col">Message</th>
+              <th scope="col">Paths</th>
+              <th scope="col">SHA</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((e) => (
+              <tr key={e.sha} className={`wk-audit-row ${rowClass(e.author_slug)}`}>
+                <td className="wk-audit-when" title={e.timestamp}>
+                  {safeRelative(e.timestamp)}
+                </td>
+                <td className="wk-audit-author">
+                  <PixelAvatar slug={e.author_slug} size={16} />
+                  <span>{formatAgentName(e.author_slug)}</span>
+                  {authorTag(e.author_slug) && (
+                    <span className="wk-audit-tag">{authorTag(e.author_slug)}</span>
+                  )}
+                </td>
+                <td className="wk-audit-msg">{e.message}</td>
+                <td className="wk-audit-paths">
+                  {e.paths.length === 0 ? (
+                    <span className="wk-audit-paths-empty">—</span>
+                  ) : (
+                    <ul>
+                      {e.paths.map((p) => (
+                        <li key={p}>
+                          {isArticlePath(p) ? (
+                            <a
+                              href={`#/wiki/${encodeURI(p)}`}
+                              onClick={(ev) => {
+                                ev.preventDefault()
+                                onNavigate(p)
+                              }}
+                            >
+                              {p}
+                            </a>
+                          ) : (
+                            <span>{p}</span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </td>
+                <td className="wk-audit-sha">{e.sha}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </main>
+  )
+}
+
+function passesAuthor(slug: string, filter: AuthorBucket): boolean {
+  if (filter === 'all') return true
+  if (filter === 'system') return isSystemSlug(slug)
+  if (filter === 'agents') return !isSystemSlug(slug)
+  return slug === filter
+}
+
+function isSystemSlug(slug: string): boolean {
+  return slug === 'system' || slug === 'wuphf-bootstrap' || slug === 'wuphf-recovery'
+}
+
+function authorTag(slug: string): string | null {
+  if (slug === 'wuphf-bootstrap') return 'bootstrap'
+  if (slug === 'wuphf-recovery') return 'recovery'
+  if (slug === 'system') return 'system'
+  return null
+}
+
+function rowClass(slug: string): string {
+  if (slug === 'wuphf-bootstrap') return 'is-bootstrap'
+  if (slug === 'wuphf-recovery') return 'is-recovery'
+  if (slug === 'system') return 'is-system'
+  return 'is-agent'
+}
+
+function isArticlePath(p: string): boolean {
+  return p.startsWith('team/') && p.endsWith('.md')
+}
+
+function safeRelative(iso: string): string {
+  try {
+    return formatRelativeTime(iso)
+  } catch {
+    return iso
+  }
+}
+
+function summarize(entries: WikiAuditEntry[]): { total: number; authors: number; paths: number } {
+  const authors = new Set<string>()
+  const paths = new Set<string>()
+  for (const e of entries) {
+    authors.add(e.author_slug)
+    for (const p of e.paths) paths.add(p)
+  }
+  return { total: entries.length, authors: authors.size, paths: paths.size }
+}
+
+function downloadCSV(entries: WikiAuditEntry[]): void {
+  const rows: string[] = ['timestamp,author,sha,message,paths']
+  for (const e of entries) {
+    rows.push(
+      [
+        csvField(e.timestamp),
+        csvField(e.author_slug),
+        csvField(e.sha),
+        csvField(e.message),
+        csvField(e.paths.join(' | ')),
+      ].join(','),
+    )
+  }
+  const blob = new Blob([rows.join('\n') + '\n'], { type: 'text/csv' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `wuphf-wiki-audit-${new Date().toISOString().slice(0, 10)}.csv`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+function csvField(raw: string): string {
+  const s = String(raw ?? '')
+  if (/[",\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`
+  }
+  return s
+}

--- a/web/src/components/wiki/WikiCatalog.tsx
+++ b/web/src/components/wiki/WikiCatalog.tsx
@@ -9,6 +9,7 @@ import { resolveGroupOrder } from '../../lib/groupOrder'
 interface WikiCatalogProps {
   catalog: WikiCatalogEntry[]
   onNavigate: (path: string) => void
+  onOpenAudit?: () => void
   articlesCount?: number
   commitsCount?: number
   agentsCount?: number
@@ -17,6 +18,7 @@ interface WikiCatalogProps {
 export default function WikiCatalog({
   catalog,
   onNavigate,
+  onOpenAudit,
   articlesCount,
   commitsCount,
   agentsCount,
@@ -43,6 +45,21 @@ export default function WikiCatalog({
         <div className="wk-catalog-clone">
           Your wiki lives on your disk.{' '}
           <code>git clone ~/.wuphf/wiki</code>
+          {onOpenAudit && (
+            <>
+              {' · '}
+              <button
+                type="button"
+                className="wk-catalog-audit-link"
+                onClick={(e) => {
+                  e.preventDefault()
+                  onOpenAudit()
+                }}
+              >
+                Audit log
+              </button>
+            </>
+          )}
         </div>
       </header>
       <div className="wk-catalog-grid">

--- a/web/src/components/wiki/WikiSidebar.tsx
+++ b/web/src/components/wiki/WikiSidebar.tsx
@@ -8,9 +8,16 @@ interface WikiSidebarProps {
   catalog: WikiCatalogEntry[]
   currentPath?: string | null
   onNavigate: (path: string) => void
+  /** Optional audit-log opener — rendered as a footer link when provided. */
+  onNavigateAudit?: () => void
 }
 
-export default function WikiSidebar({ catalog, currentPath, onNavigate }: WikiSidebarProps) {
+export default function WikiSidebar({
+  catalog,
+  currentPath,
+  onNavigate,
+  onNavigateAudit,
+}: WikiSidebarProps) {
   const [query, setQuery] = useState('')
 
   const grouped = useMemo(() => groupCatalog(catalog, query.trim()), [catalog, query])
@@ -52,6 +59,20 @@ export default function WikiSidebar({ catalog, currentPath, onNavigate }: WikiSi
           </div>
         )
       })}
+      {onNavigateAudit && (
+        <div className="wk-sidebar-audit">
+          <button
+            type="button"
+            className="wk-sidebar-audit-link"
+            onClick={(e) => {
+              e.preventDefault()
+              onNavigateAudit()
+            }}
+          >
+            View audit log →
+          </button>
+        </div>
+      )}
     </aside>
   )
 }

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -860,3 +860,256 @@
   font-size: 14px;
 }
 .wk-error { color: var(--wk-wikilink-broken); }
+
+/* ─── Audit log view (#/wiki/_audit) ─── */
+.wk-audit {
+  max-width: 1180px;
+  padding: 40px 48px 80px;
+}
+.wk-audit-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--wk-border);
+}
+.wk-audit-title {
+  font-family: var(--wk-display);
+  font-size: 40px;
+  font-weight: 500;
+  font-variation-settings: "opsz" 100;
+  color: var(--wk-text);
+  margin: 0 0 6px;
+}
+.wk-audit-strapline {
+  font-family: var(--wk-body);
+  font-style: italic;
+  color: var(--wk-text-muted);
+  font-size: 15px;
+  margin: 0;
+  max-width: 620px;
+  line-height: 1.5;
+}
+.wk-audit-stats {
+  font-family: var(--wk-mono);
+  font-size: 12px;
+  color: var(--wk-text-muted);
+  white-space: nowrap;
+  padding-top: 6px;
+}
+.wk-audit-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  align-items: flex-end;
+  margin-bottom: 20px;
+}
+.wk-audit-filter {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-family: var(--wk-chrome);
+  font-size: 11px;
+  color: var(--wk-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.wk-audit-filter input,
+.wk-audit-filter select {
+  font-family: var(--wk-chrome);
+  font-size: 14px;
+  color: var(--wk-text);
+  background: var(--wk-surface);
+  border: 1px solid var(--wk-border);
+  border-radius: 2px;
+  padding: 6px 10px;
+  min-width: 160px;
+  text-transform: none;
+  letter-spacing: normal;
+}
+.wk-audit-filter input[type="search"] {
+  min-width: 320px;
+}
+.wk-audit-filter input:focus,
+.wk-audit-filter select:focus {
+  outline: 2px solid var(--wk-accent);
+  outline-offset: 1px;
+}
+.wk-audit-export {
+  font-family: var(--wk-chrome);
+  font-size: 13px;
+  color: var(--wk-text);
+  background: var(--wk-surface);
+  border: 1px solid var(--wk-border);
+  border-radius: 2px;
+  padding: 7px 14px;
+  cursor: pointer;
+  align-self: flex-end;
+}
+.wk-audit-export:hover:not(:disabled) {
+  background: var(--wk-surface-alt);
+  border-color: var(--wk-text-muted);
+}
+.wk-audit-export:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.wk-audit-empty {
+  padding: 60px 20px;
+  text-align: center;
+  color: var(--wk-text-muted);
+  font-family: var(--wk-body);
+  font-size: 15px;
+  font-style: italic;
+}
+
+.wk-audit-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--wk-body);
+  font-size: 14px;
+  color: var(--wk-text);
+}
+.wk-audit-table thead th {
+  text-align: left;
+  font-family: var(--wk-chrome);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--wk-text-muted);
+  padding: 8px 12px;
+  border-bottom: 2px solid var(--wk-border);
+  background: transparent;
+}
+.wk-audit-table tbody td {
+  padding: 10px 12px;
+  vertical-align: top;
+  border-bottom: 1px solid var(--wk-border);
+}
+.wk-audit-row:hover td {
+  background: var(--wk-surface-alt);
+}
+.wk-audit-row.is-bootstrap td,
+.wk-audit-row.is-recovery td,
+.wk-audit-row.is-system td {
+  background: color-mix(in oklab, var(--wk-surface-alt) 60%, transparent);
+}
+.wk-audit-when {
+  font-family: var(--wk-mono);
+  font-size: 12px;
+  color: var(--wk-text-muted);
+  white-space: nowrap;
+  width: 140px;
+}
+.wk-audit-author {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  font-weight: 500;
+  width: 220px;
+}
+.wk-audit-tag {
+  display: inline-block;
+  font-family: var(--wk-chrome);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--wk-text-muted);
+  background: var(--wk-surface-alt);
+  border: 1px solid var(--wk-border);
+  border-radius: 999px;
+  padding: 1px 8px;
+  margin-left: 4px;
+}
+.wk-audit-row.is-bootstrap .wk-audit-tag { color: var(--wk-accent-ink); border-color: var(--wk-accent); }
+.wk-audit-msg {
+  font-family: var(--wk-body);
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--wk-text);
+  min-width: 260px;
+}
+.wk-audit-paths {
+  min-width: 260px;
+}
+.wk-audit-paths ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.wk-audit-paths a {
+  font-family: var(--wk-mono);
+  font-size: 12.5px;
+  color: var(--wk-wikilink);
+  text-decoration: underline dashed;
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+.wk-audit-paths a:hover {
+  text-decoration-style: solid;
+}
+.wk-audit-paths span {
+  font-family: var(--wk-mono);
+  font-size: 12.5px;
+  color: var(--wk-text-muted);
+}
+.wk-audit-paths-empty {
+  color: var(--wk-text-muted);
+  font-family: var(--wk-mono);
+  font-size: 12px;
+}
+.wk-audit-sha {
+  font-family: var(--wk-mono);
+  font-size: 12px;
+  color: var(--wk-text-muted);
+  white-space: nowrap;
+  width: 80px;
+}
+
+/* ─── Sidebar audit link ─── */
+.wk-sidebar-audit {
+  margin-top: auto;
+  padding: 16px 0 0;
+  border-top: 1px solid var(--wk-border);
+}
+.wk-sidebar-audit-link {
+  font-family: var(--wk-chrome);
+  font-size: 13px;
+  color: var(--wk-text-muted);
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+}
+.wk-sidebar-audit-link:hover {
+  color: var(--wk-wikilink);
+}
+.wk-nav-sidebar {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Catalog header audit link */
+.wk-catalog-audit-link {
+  font-family: inherit;
+  color: var(--wk-wikilink);
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: inherit;
+  text-decoration: underline dashed;
+  text-underline-offset: 2px;
+}
+.wk-catalog-audit-link:hover {
+  text-decoration-style: solid;
+}


### PR DESCRIPTION
## Summary
Running the full `TESTING-WIKI.md` suite against main surfaced 4 real bugs. All 4 fixed here, plus a first-class audit-log view so the git-native history is usable as a compliance artefact.

## Bugs fixed
1. **Blueprint skeletons were uncommitted.** `MaterializeWiki` wrote 5 files to disk but the worker's commit queue never saw them → any `kill -9` folded them into a misattributed `wuphf-recovery` commit. Fix: new `Repo.CommitBootstrap()` stages + commits under the reserved `wuphf-bootstrap` author.
2. **`index/all.md` missing on fresh install.** Catalog file only materialized after an agent wrote. Fix: regenerate index BEFORE bootstrap commit so both land in the same commit.
3. **`copyFile` permission denied on backup mirror.** Git loose objects are 0o444; second backup pass couldn't O_TRUNC. Broker log spammed \"permission denied\" every second. Fix: `os.Remove(dst)` before write.
4. **Replace writes with identical content returned HTTP 500.** `git commit: exit status 1: no changes added`, then every subsequent write failed because IndexRegen left the tree dirty. Fix: `Commit` now owns the full atomic unit (write → regen → stage → commit). Identical-content writes become no-op successes returning current HEAD.

## Audit-ready history
- **`Repo.AuditLog(since, limit)`** — full cross-article git log with SHA, author slug, timestamp, message, paths.
- **`GET /wiki/audit?since=&limit=`** — HTTP surface, 500-entry default cap, `limit=0` opts out.
- **`WikiAudit.tsx`** at hash route `#/wiki/_audit` — per DESIGN-WIKI.md: Fraunces display, Source Serif body, Geist Mono SHAs. Filters compose (author dropdown incl. \"System only\", message/path search, time window). System + bootstrap + recovery rows get visual tags. CSV export of the filtered view. Sidebar + catalog link into it.

## Also
- `scripts/demo-wiki-live.sh` now shows actual HTTP status + error body instead of curl's opaque \"error: 500\". That's how bug #4 got found.

## Test plan
- [x] `go test ./internal/team/... ./internal/teammcp/... ./internal/operations/...` → 3× ok
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` → 105/105 across 25 files
- [x] `npm run build` succeeds
- [x] 5 new Repo tests, 2 new broker HTTP tests, 7 new WikiAudit UI tests — all green
- [x] Full `TESTING-WIKI.md` re-run: partial tasks #12 and #14 now pass cleanly; first demo run 8/8, second run 3/3 non-create writes succeed, git status stays clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a wiki audit log view displaying complete edit history with author, timestamp, commit message, and affected files.
  * Filter audit entries by author or search by message content and file paths.
  * Export audit logs as CSV.
  * New `/wiki/audit` endpoint with configurable limits and time-range filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->