### PR TITLE
style: gofmt wiki_git_test.go (fixes #160 lint)

### DIFF
--- a/internal/team/wiki_git_test.go
+++ b/internal/team/wiki_git_test.go
@@ -334,7 +334,7 @@ func TestRepoCommitBootstrapAttributesToBootstrapAuthor(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 	skeletons := map[string]string{
-		"team/playbooks/renewal.md":        "# Renewal\n",
+		"team/playbooks/renewal.md":         "# Renewal\n",
 		"team/decisions/wiki-as-default.md": "# Decision\n",
 	}
 	for rel, body := range skeletons {


### PR DESCRIPTION
Single-column gofmt drift landed in PR #160's new bootstrap test. This is the 1-line fix so golangci-lint goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)