### PR TITLE
fix(release): inject version + build timestamp into the binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,4 +94,15 @@ jobs:
         run: sleep 45
 
       - name: npx wuphf --version
-        run: npx --yes "wuphf@$VERSION" --version
+        run: |
+          # The binary's self-reported version must match the tag. Without
+          # this check, a goreleaser misconfiguration (missing -X ldflag on
+          # buildinfo.Version) silently ships the hardcoded fallback and no
+          # amount of `npx wuphf@latest` gets users the real release.
+          OUT=$(npx --yes "wuphf@$VERSION" --version)
+          echo "$OUT"
+          echo "$OUT" | grep -E -q " v${VERSION}(\s|$)" || {
+            echo "::error::binary self-reported version did not match tag $VERSION"
+            echo "output was: $OUT"
+            exit 1
+          }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,14 @@ builds:
     env:
       - CGO_ENABLED=0
     ldflags:
+      # Inject the release version (and build timestamp) so `wuphf --version`
+      # reports the actual release instead of the hardcoded 0.1.0 fallback in
+      # internal/buildinfo. goreleaser exposes {{.Version}} without a leading v
+      # and {{.Date}} as RFC3339 — both match what buildinfo.Current() returns
+      # to users.
       - -s -w
+      - -X github.com/nex-crm/wuphf/internal/buildinfo.Version={{.Version}}
+      - -X github.com/nex-crm/wuphf/internal/buildinfo.BuildTimestamp={{.Date}}
 
 archives:
   - formats: [tar.gz]


### PR DESCRIPTION
## Summary
Every released binary since v0.1.0 has self-reported `wuphf v0.1.0` regardless of the npm / GitHub release tag. Root cause: `.goreleaser.yml` strips symbols but never injects `buildinfo.Version`.

## Fix
1. `.goreleaser.yml` — extend ldflags with `-X github.com/nex-crm/wuphf/internal/buildinfo.Version={{.Version}}` + matching build timestamp.
2. `release.yml` — smoke test now asserts the binary's `--version` output contains the tag. Previous test was a vacuous exit-code check, which is how this bug lived through 40+ releases.

## Verified locally
```
$ go build -ldflags "-X .../buildinfo.Version=0.39.3" -o /tmp/w ./cmd/wuphf
$ /tmp/w --version
wuphf v0.39.3
```

## Scope
Users who ran `npx wuphf@latest` already had the correct code — the npm shim downloads the binary per release; the postinstall + download-binary.js path picks up whatever tag was requested. Only `--version` was lying. The next release will report honestly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)