### PR TITLE
fix(cli): warn at startup when another wuphf binary shadows this one on PATH

### DIFF
--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -215,6 +215,17 @@ func main() {
 
 	// Handle subcommands
 	args := flag.Args()
+
+	// Warn if another wuphf binary is on PATH and may shadow this one. Interactive
+	// only — scripted and stdio-subprocess entrypoints keep their output clean.
+	firstSub := ""
+	if len(args) > 0 {
+		firstSub = args[0]
+	}
+	if shouldWarnShadow(*showVersion, *channelView, *cmd != "", isPiped(), firstSub) {
+		warnPathShadow(os.Stderr)
+	}
+
 	if len(args) > 0 {
 		sub := args[0]
 		if subcommandWantsHelp(args[1:]) {

--- a/cmd/wuphf/path_shadow.go
+++ b/cmd/wuphf/path_shadow.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// detectPathShadows returns other wuphf executables found on pathEnv besides
+// selfExec. Paths are returned in PATH order and de-duplicated by real path
+// (so a symlink pointing at the running binary is correctly ignored).
+//
+// Extracted for tests — os.Executable() and os.Getenv() are injected by the
+// caller so unit tests can drive deterministic PATH layouts.
+func detectPathShadows(selfExec, pathEnv string) []string {
+	if selfExec == "" {
+		return nil
+	}
+	selfReal, err := filepath.EvalSymlinks(selfExec)
+	if err != nil {
+		selfReal = selfExec
+	}
+	exe := "wuphf"
+	if runtime.GOOS == "windows" {
+		exe = "wuphf.exe"
+	}
+	seen := map[string]bool{selfReal: true}
+	var shadows []string
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			continue
+		}
+		cand := filepath.Join(dir, exe)
+		info, err := os.Stat(cand)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+			continue
+		}
+		real, err := filepath.EvalSymlinks(cand)
+		if err != nil {
+			real = cand
+		}
+		if seen[real] {
+			continue
+		}
+		seen[real] = true
+		shadows = append(shadows, cand)
+	}
+	return shadows
+}
+
+// warnPathShadow writes a one-time warning to w when other wuphf executables
+// are on PATH besides the currently running binary. The classic trap: a
+// hand-built copy in ~/.local/bin silently shadows a fresh npm install, so
+// upgrades appear not to take effect.
+func warnPathShadow(w io.Writer) {
+	self, err := os.Executable()
+	if err != nil {
+		return
+	}
+	shadows := detectPathShadows(self, os.Getenv("PATH"))
+	if len(shadows) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "wuphf: warning: other wuphf binaries are on PATH and may shadow this one:")
+	for _, s := range shadows {
+		fmt.Fprintf(w, "  %s\n", s)
+	}
+	fmt.Fprintf(w, "  running: %s\n", self)
+	fmt.Fprintln(w, "  If `which wuphf` picks a different path, upgrades to this binary will have no effect until the other copy is removed.")
+}
+
+// shouldWarnShadow gates the warning so it fires only on interactive launches.
+// Script-facing entrypoints (--version, --cmd, piped stdin) and internal
+// subprocesses (--channel-view, mcp-team) keep their output clean.
+func shouldWarnShadow(showVersion, channelView, cmdFlagSet, piped bool, subcmd string) bool {
+	if showVersion || channelView || cmdFlagSet || piped {
+		return false
+	}
+	if subcmd == "mcp-team" {
+		return false
+	}
+	return true
+}

--- a/cmd/wuphf/path_shadow.go
+++ b/cmd/wuphf/path_shadow.go
@@ -66,12 +66,12 @@ func warnPathShadow(w io.Writer) {
 	if len(shadows) == 0 {
 		return
 	}
-	fmt.Fprintln(w, "wuphf: warning: other wuphf binaries are on PATH and may shadow this one:")
+	_, _ = fmt.Fprintln(w, "wuphf: warning: other wuphf binaries are on PATH and may shadow this one:")
 	for _, s := range shadows {
-		fmt.Fprintf(w, "  %s\n", s)
+		_, _ = fmt.Fprintf(w, "  %s\n", s)
 	}
-	fmt.Fprintf(w, "  running: %s\n", self)
-	fmt.Fprintln(w, "  If `which wuphf` picks a different path, upgrades to this binary will have no effect until the other copy is removed.")
+	_, _ = fmt.Fprintf(w, "  running: %s\n", self)
+	_, _ = fmt.Fprintln(w, "  If `which wuphf` picks a different path, upgrades to this binary will have no effect until the other copy is removed.")
 }
 
 // shouldWarnShadow gates the warning so it fires only on interactive launches.

--- a/cmd/wuphf/path_shadow_test.go
+++ b/cmd/wuphf/path_shadow_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writeExec(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestDetectPathShadowsFindsOthers(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX exec-bit semantics")
+	}
+	root := t.TempDir()
+	selfDir := filepath.Join(root, "self")
+	otherDir := filepath.Join(root, "other")
+	if err := os.MkdirAll(selfDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	self := filepath.Join(selfDir, "wuphf")
+	other := filepath.Join(otherDir, "wuphf")
+	writeExec(t, self)
+	writeExec(t, other)
+
+	pathEnv := strings.Join([]string{selfDir, otherDir}, string(os.PathListSeparator))
+	got := detectPathShadows(self, pathEnv)
+	if len(got) != 1 || got[0] != other {
+		t.Fatalf("want [%s], got %v", other, got)
+	}
+}
+
+func TestDetectPathShadowsIgnoresSelfSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX symlink semantics")
+	}
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	linkDir := filepath.Join(root, "link")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(linkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	real := filepath.Join(realDir, "wuphf")
+	writeExec(t, real)
+	link := filepath.Join(linkDir, "wuphf")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	pathEnv := strings.Join([]string{linkDir, realDir}, string(os.PathListSeparator))
+	got := detectPathShadows(real, pathEnv)
+	if len(got) != 0 {
+		t.Fatalf("symlink to self should not shadow; got %v", got)
+	}
+}
+
+func TestDetectPathShadowsSkipsDirsAndNonExec(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX exec-bit semantics")
+	}
+	root := t.TempDir()
+	selfDir := filepath.Join(root, "self")
+	dirDir := filepath.Join(root, "dir")
+	nonExecDir := filepath.Join(root, "nonexec")
+	for _, d := range []string{selfDir, dirDir, nonExecDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	self := filepath.Join(selfDir, "wuphf")
+	writeExec(t, self)
+	// A directory literally named "wuphf".
+	if err := os.MkdirAll(filepath.Join(dirDir, "wuphf"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A non-executable regular file named "wuphf".
+	nonExec := filepath.Join(nonExecDir, "wuphf")
+	if err := os.WriteFile(nonExec, []byte("text"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pathEnv := strings.Join([]string{dirDir, nonExecDir, selfDir}, string(os.PathListSeparator))
+	got := detectPathShadows(self, pathEnv)
+	if len(got) != 0 {
+		t.Fatalf("should skip dirs and non-exec files; got %v", got)
+	}
+}
+
+func TestDetectPathShadowsEmptyPATH(t *testing.T) {
+	got := detectPathShadows("/some/path/wuphf", "")
+	if got != nil {
+		t.Fatalf("empty PATH should yield nil; got %v", got)
+	}
+}
+
+func TestDetectPathShadowsEmptySelf(t *testing.T) {
+	got := detectPathShadows("", "/usr/bin")
+	if got != nil {
+		t.Fatalf("empty self should yield nil; got %v", got)
+	}
+}
+
+func TestWarnPathShadowNoopWhenNoShadows(t *testing.T) {
+	// Point self at this test binary, use an empty PATH so nothing resolves.
+	self, err := os.Executable()
+	if err != nil {
+		t.Skip("no executable")
+	}
+	_ = self
+	oldPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", oldPath) })
+	_ = os.Setenv("PATH", "")
+	var buf bytes.Buffer
+	warnPathShadow(&buf)
+	if buf.Len() != 0 {
+		t.Fatalf("expected no output, got %q", buf.String())
+	}
+}
+
+func TestShouldWarnShadow(t *testing.T) {
+	cases := []struct {
+		name                                        string
+		showVersion, channelView, cmdFlagSet, piped bool
+		subcmd                                      string
+		want                                        bool
+	}{
+		{name: "interactive default", want: true},
+		{name: "interactive init subcommand", subcmd: "init", want: true},
+		{name: "version flag", showVersion: true, want: false},
+		{name: "channel view subprocess", channelView: true, want: false},
+		{name: "cmd flag scripted", cmdFlagSet: true, want: false},
+		{name: "piped stdin scripted", piped: true, want: false},
+		{name: "mcp-team stdio", subcmd: "mcp-team", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shouldWarnShadow(tc.showVersion, tc.channelView, tc.cmdFlagSet, tc.piped, tc.subcmd)
+			if got != tc.want {
+				t.Fatalf("want %v got %v", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- At interactive startup, `wuphf` now scans `PATH` and warns if any other `wuphf` executables exist that aren't the running binary.
- Script and stdio paths (`--version`, `--cmd`, piped stdin, `--channel-view`, `mcp-team`) stay silent so they remain parseable.

## Why

Hit this today on a "CODE RED: no agents responding" report. The user's `npm install -g wuphf@latest` correctly upgraded `/opt/homebrew/bin/wuphf` to v0.39.3, but `~/.local/bin/wuphf` (a hand-built copy from April 16) came earlier in `PATH` and silently absorbed every `wuphf` invocation. Result: all the fixes from PR #158 (codex auth surfacing) and PR #162 (version injection) were on disk but never ran. Looked like a product regression for hours; it was PATH shadowing.

The binary now detects this trap itself:

```
$ wuphf log
wuphf: warning: other wuphf binaries are on PATH and may shadow this one:
  /Users/n/.local/bin/wuphf
  running: /opt/homebrew/lib/node_modules/wuphf/bin/wuphf
  If `which wuphf` picks a different path, upgrades to this binary will have no effect until the other copy is removed.
```

Symlinks pointing at the running binary are correctly ignored (via `EvalSymlinks`), so homebrew-style `bin/wuphf -> ../Cellar/.../wuphf` layouts don't spuriously warn.

## Implementation

- `cmd/wuphf/path_shadow.go` — `detectPathShadows(selfExec, pathEnv)` walks PATH, stats each `wuphf` entry, resolves symlinks, dedupes on real path. `warnPathShadow(w)` wraps it for the main entrypoint. `shouldWarnShadow(...)` gates which modes print.
- `cmd/wuphf/main.go` — single call site right after subcommand dispatch args are parsed.
- Warning goes to `stderr` only. Never errors out, never affects exit code.

## Test plan

- [x] `go test ./cmd/wuphf -run 'PathShadow|ShouldWarnShadow' -race` — passes.
- [x] `go test ./...` — full suite green.
- [x] Live: built binary, planted a shadow at `~/.local/bin/wuphf`, ran `wuphf log` — warning fires, lists both shadows.
- [x] Live: removed the shadow — warning still correctly lists `/opt/homebrew/bin/wuphf` when running the binary from `/tmp`, confirming dedupe works on the active self path.
- [x] `wuphf --version` stays clean (script-parseable).
- [x] `mcp-team` skipped (verified via `shouldWarnShadow` table test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning system that detects when other `wuphf` executables on your system might be shadowing the currently running version and alerts you during interactive launches.

* **Tests**
  * Added comprehensive test coverage for path shadowing detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->