### PR TITLE
fix(web): stop DM overlay from trapping navigation

### DIFF
--- a/web/src/components/messages/DMView.tsx
+++ b/web/src/components/messages/DMView.tsx
@@ -8,7 +8,6 @@ import { Composer } from './Composer'
 export function DMView() {
   const currentChannel = useAppStore((s) => s.currentChannel)
   const dmAgentSlug = useAppStore((s) => s.dmAgentSlug)
-  const exitDM = useAppStore((s) => s.exitDM)
   const { data: messages = [] } = useMessages(currentChannel)
   const { lines, connected } = useAgentStream(dmAgentSlug)
   const messagesRef = useRef<HTMLDivElement>(null)
@@ -30,18 +29,6 @@ export function DMView() {
 
   return (
     <>
-      {/* DM banner */}
-      <div className="dm-banner active">
-        <span>1:1 session with {dmAgentSlug}</span>
-        <button className="dm-back-btn" onClick={exitDM}>
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M19 12H5" />
-            <path d="m12 19-7-7 7-7" />
-          </svg>
-          Back to office
-        </button>
-      </div>
-
       {/* Split layout: messages left, live stream right */}
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
         {/* Left: Messages + Composer */}

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -64,9 +64,9 @@ export const useAppStore = create<AppStore>((set) => ({
   setBrokerConnected: (v) => set({ brokerConnected: v }),
 
   currentChannel: 'general',
-  setCurrentChannel: (ch) => set({ currentChannel: ch, currentApp: null }),
+  setCurrentChannel: (ch) => set({ currentChannel: ch, currentApp: null, dmMode: false, dmAgentSlug: null }),
   currentApp: null,
-  setCurrentApp: (app) => set({ currentApp: app }),
+  setCurrentApp: (app) => set({ currentApp: app, dmMode: false, dmAgentSlug: null }),
 
   channelMeta: {},
   setChannelMeta: (slug, meta) =>


### PR DESCRIPTION
## Summary
- Channel and app clicks now clear `dmMode`/`dmAgentSlug` in the store, so the DM view no longer stays pinned on top when you navigate away from it.
- Removed the redundant \"Back to office\" banner from `DMView` — sidebar clicks already switch views, making the banner dead weight.

## Why
Clicking a DM opened an overlay that only exited via the \"Back to office\" button. Channel or app clicks in the sidebar didn't switch the main view because \`setCurrentChannel\` / \`setCurrentApp\` never cleared \`dmMode\`. The primary window is supposed to be the single surface for all channels, DMs, and apps.

## Follow-up
Architectural cleanup (collapse \`dmMode\`/\`dmAgentSlug\` into \`currentChannel\` + \`channelMeta.type === 'D'\`) will land in a separate PR.

## Test plan
- [x] \`npm run build\` passes in \`web/\`
- [x] Manual: open DM with CEO → click #general → channel view renders, no banner
- [x] Manual: open DM → click Tasks app → app renders, no banner
- [x] Manual: DM view itself no longer shows \"1:1 session with ceo\" banner + Back button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed DM session header and "Back to office" button from the messages view
  * DM mode now automatically resets when switching between channels or apps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->