### PR TITLE
fix(web): surface cross-channel blocker in interview UI

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -8839,13 +8839,19 @@ func (b *Broker) handleRequests(w http.ResponseWriter, r *http.Request) {
 
 func (b *Broker) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 	channel := normalizeChannelSlug(r.URL.Query().Get("channel"))
-	if channel == "" {
+	scope := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("scope")))
+	// scope=all returns requests across every channel the viewer can access. The
+	// broker's blocking check (handlePostMessage, PostMessage) is global, so the
+	// web UI's overlay/interview bar need the same cross-channel view to render
+	// what's actually blocking the human.
+	allChannels := scope == "all" || scope == "global"
+	if !allChannels && channel == "" {
 		channel = "general"
 	}
 	viewerSlug := strings.TrimSpace(r.URL.Query().Get("viewer_slug"))
 	includeResolved := strings.EqualFold(strings.TrimSpace(r.URL.Query().Get("include_resolved")), "true")
 	b.mu.Lock()
-	if !b.canAccessChannelLocked(viewerSlug, channel) {
+	if !allChannels && !b.canAccessChannelLocked(viewerSlug, channel) {
 		b.mu.Unlock()
 		http.Error(w, "channel access denied", http.StatusForbidden)
 		return
@@ -8856,7 +8862,11 @@ func (b *Broker) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 		if reqChannel == "" {
 			reqChannel = "general"
 		}
-		if reqChannel != channel {
+		if allChannels {
+			if !b.canAccessChannelLocked(viewerSlug, reqChannel) {
+				continue
+			}
+		} else if reqChannel != channel {
 			continue
 		}
 		if !includeResolved && !requestIsActive(req) {
@@ -8869,6 +8879,7 @@ func (b *Broker) handleGetRequests(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"channel":  channel,
+		"scope":    scope,
 		"requests": requests,
 		"pending":  pending,
 	})

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -4412,6 +4412,94 @@ func TestBrokerRequestsLifecycle(t *testing.T) {
 	}
 }
 
+// Regression: the broker rejects new messages with 409 whenever ANY blocking
+// request is pending (handlePostMessage uses firstBlockingRequest across all
+// channels), so GET /requests must expose a "scope=all" view. Without it, the
+// web UI only sees per-channel requests and can't render a blocker that lives
+// in another channel — leaving the human stuck: can't send, can't see why.
+func TestBrokerGetRequestsScopeAllSeesCrossChannelBlocker(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	ensureTestMemberAccess(b, "general", "ceo", "CEO")
+	ensureTestMemberAccess(b, "backend", "ceo", "CEO")
+	ensureTestMemberAccess(b, "backend", "human", "Human")
+	ensureTestMemberAccess(b, "general", "human", "Human")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	createBody, _ := json.Marshal(map[string]any{
+		"kind":     "approval",
+		"from":     "ceo",
+		"channel":  "backend",
+		"title":    "Deploy approval",
+		"question": "Ship the backend migration?",
+		"blocking": true,
+		"required": true,
+	})
+	req, _ := http.NewRequest(http.MethodPost, base+"/requests", bytes.NewReader(createBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create cross-channel request failed: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 creating backend request, got %d", resp.StatusCode)
+	}
+
+	// Per-channel view (#general) must NOT see the #backend blocker — this is
+	// the pre-fix behavior the UI was relying on and is still correct.
+	req, _ = http.NewRequest(http.MethodGet, base+"/requests?channel=general&viewer_slug=human", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("per-channel listing failed: %v", err)
+	}
+	var perChannel struct {
+		Requests []humanInterview `json:"requests"`
+		Pending  *humanInterview  `json:"pending"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&perChannel); err != nil {
+		t.Fatalf("decode per-channel response: %v", err)
+	}
+	resp.Body.Close()
+	if len(perChannel.Requests) != 0 || perChannel.Pending != nil {
+		t.Fatalf("expected #general view to hide #backend request, got %+v", perChannel)
+	}
+
+	// scope=all must include the cross-channel blocker so the overlay can show
+	// what's preventing the human from chatting anywhere.
+	req, _ = http.NewRequest(http.MethodGet, base+"/requests?scope=all&viewer_slug=human", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("scope=all listing failed: %v", err)
+	}
+	var global struct {
+		Requests []humanInterview `json:"requests"`
+		Pending  *humanInterview  `json:"pending"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&global); err != nil {
+		t.Fatalf("decode scope=all response: %v", err)
+	}
+	resp.Body.Close()
+	if len(global.Requests) != 1 {
+		t.Fatalf("expected 1 blocker across channels, got %d: %+v", len(global.Requests), global.Requests)
+	}
+	if global.Pending == nil || global.Pending.Channel != "backend" {
+		t.Fatalf("expected pending blocker from #backend, got %+v", global.Pending)
+	}
+}
+
 func TestBrokerRequestAnswerUnblocksDependentTask(t *testing.T) {
 	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -285,6 +285,16 @@ export function getRequests(channel: string) {
   })
 }
 
+// Cross-channel view. The broker's blocking check is global, so the web UI's
+// global overlay + inline interview bar need every blocking request the human
+// can answer, not just the ones in the current channel.
+export function getAllRequests() {
+  return get<{ requests: AgentRequest[] }>('/requests', {
+    scope: 'all',
+    viewer_slug: 'human',
+  })
+}
+
 export function answerRequest(id: string, choiceId: string, customText?: string) {
   const body: Record<string, string> = { id, choice_id: choiceId }
   if (customText) body.custom_text = customText

--- a/web/src/hooks/useRequests.ts
+++ b/web/src/hooks/useRequests.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { getRequests, type AgentRequest } from '../api/client'
-import { useAppStore } from '../stores/app'
+import { getAllRequests, type AgentRequest } from '../api/client'
 
 export interface RequestsState {
   all: AgentRequest[]
@@ -10,11 +9,15 @@ export interface RequestsState {
 
 const REQUEST_REFETCH_MS = 5_000
 
+// Global view of requests across every channel the human can access. The
+// broker rejects new messages with 409 whenever ANY blocking request is
+// pending, so the overlay + inline interview bar must reflect that same
+// cross-channel state — otherwise the human sees "nothing blocking" here
+// while sending stays blocked by a request in a channel they aren't viewing.
 export function useRequests(): RequestsState {
-  const currentChannel = useAppStore((s) => s.currentChannel)
   const { data } = useQuery({
-    queryKey: ['requests', currentChannel],
-    queryFn: () => getRequests(currentChannel),
+    queryKey: ['requests', 'all'],
+    queryFn: () => getAllRequests(),
     refetchInterval: REQUEST_REFETCH_MS,
   })
 


### PR DESCRIPTION
## Summary

After approving a request in the Requests app, users kept hitting a 409 "answer the interview above to send messages" with no interview visible in the channel.

### Root cause
The broker's blocking check (`handlePostMessage`, `PostMessage`) scans `b.requests` across **all** channels, but `web/src/hooks/useRequests.ts` called `getRequests(currentChannel)` — channel-scoped. A blocker in any other channel stayed invisible in `InterviewBar` and `HumanInterviewOverlay` while still rejecting every message send. The overlay's own comment already claimed "Always renders the first blocking pending request from the broker, regardless of which app/channel the user is viewing" — it just wasn't true.

### Fix
- `internal/team/broker.go` — `handleGetRequests` honors `?scope=all` and returns active requests across every channel the viewer can access (ACL still enforced per-channel).
- `web/src/api/client.ts` — new `getAllRequests()`.
- `web/src/hooks/useRequests.ts` — switches to the global scope; `queryKey: ['requests', 'all']`. The existing invalidations via `['requests']` prefix still hit both this and the per-channel `RequestsApp` query.
- `RequestsApp` stays channel-scoped — it's a per-channel view, not a "what's blocking me" view.

## Test plan
- [x] `TestBrokerGetRequestsScopeAllSeesCrossChannelBlocker` — per-channel view hides a #backend blocker; `scope=all` surfaces it.
- [x] `go test ./...` — all packages green.
- [x] `tsc --noEmit` + `vite build` — clean.
- [ ] Manual: create a blocking request in a non-general channel via MCP, navigate to #general, verify the inline interview bar renders with the source channel label and the message composer works once answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)