### PR TITLE
refactor(web): collapse dmMode into currentChannel + channelMeta

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { Component, useEffect, useState, type ReactNode } from 'react'
 import { initApi, get } from './api/client'
-import { useAppStore } from './stores/app'
+import { useAppStore, isDMChannel } from './stores/app'
 import { Shell } from './components/layout/Shell'
 import { MessageFeed } from './components/messages/MessageFeed'
 import { Composer } from './components/messages/Composer'
@@ -89,12 +89,13 @@ class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryStat
 
 function MainContent() {
   const currentApp = useAppStore((s) => s.currentApp)
-  const dmMode = useAppStore((s) => s.dmMode)
+  const currentChannel = useAppStore((s) => s.currentChannel)
+  const channelMeta = useAppStore((s) => s.channelMeta)
   const wikiPath = useAppStore((s) => s.wikiPath)
   const setWikiPath = useAppStore((s) => s.setWikiPath)
   const setCurrentApp = useAppStore((s) => s.setCurrentApp)
 
-  if (dmMode) {
+  if (!currentApp && isDMChannel(currentChannel, channelMeta)) {
     return <DMView />
   }
 

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -7,22 +7,25 @@ import { RuntimeStrip } from './RuntimeStrip'
 import { ThreadPanel } from '../messages/ThreadPanel'
 import { AgentPanel } from '../agents/AgentPanel'
 import { SearchModal } from '../search/SearchModal'
-import { useAppStore } from '../../stores/app'
+import { useAppStore, isDMChannel } from '../../stores/app'
 
 interface ShellProps {
   children: ReactNode
 }
 
 export function Shell({ children }: ShellProps) {
-  const dmMode = useAppStore((s) => s.dmMode)
+  const currentChannel = useAppStore((s) => s.currentChannel)
+  const currentApp = useAppStore((s) => s.currentApp)
+  const channelMeta = useAppStore((s) => s.channelMeta)
+  const inDM = !currentApp && !!isDMChannel(currentChannel, channelMeta)
 
   return (
     <div className="office">
       <Sidebar />
       <main className="main">
         <DisconnectBanner />
-        {!dmMode && <ChannelHeader />}
-        {!dmMode && <RuntimeStrip />}
+        {!inDM && <ChannelHeader />}
+        {!inDM && <RuntimeStrip />}
         {children}
         <StatusBar />
       </main>

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query'
-import { useAppStore } from '../../stores/app'
+import { useAppStore, isDMChannel } from '../../stores/app'
 import { useOfficeMembers } from '../../hooks/useMembers'
 import { getHealth } from '../../api/client'
 
@@ -16,10 +16,10 @@ interface HealthSnapshot {
 export function StatusBar() {
   const currentChannel = useAppStore((s) => s.currentChannel)
   const currentApp = useAppStore((s) => s.currentApp)
-  const dmMode = useAppStore((s) => s.dmMode)
-  const dmAgentSlug = useAppStore((s) => s.dmAgentSlug)
+  const channelMeta = useAppStore((s) => s.channelMeta)
   const brokerConnected = useAppStore((s) => s.brokerConnected)
   const { data: members = [] } = useOfficeMembers()
+  const dm = !currentApp ? isDMChannel(currentChannel, channelMeta) : null
 
   const { data: health } = useQuery<HealthSnapshot>({
     queryKey: ['health'],
@@ -34,10 +34,10 @@ export function StatusBar() {
 
   const channelLabel = currentApp
     ? currentApp
-    : dmMode && dmAgentSlug
-      ? `@${dmAgentSlug}`
+    : dm
+      ? `@${dm.agentSlug}`
       : `# ${currentChannel}`
-  const modeLabel = dmMode ? '1:1' : 'office'
+  const modeLabel = dm ? '1:1' : 'office'
   const provider = health?.provider
 
   return (

--- a/web/src/components/messages/DMView.tsx
+++ b/web/src/components/messages/DMView.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useMessages } from '../../hooks/useMessages'
 import { useAgentStream } from '../../hooks/useAgentStream'
-import { useAppStore } from '../../stores/app'
+import { useAppStore, isDMChannel } from '../../stores/app'
 import { MessageBubble } from './MessageBubble'
 import { Composer } from './Composer'
 import { InterviewBar } from './InterviewBar'
@@ -9,7 +9,9 @@ import { StreamLineView } from './StreamLineView'
 
 export function DMView() {
   const currentChannel = useAppStore((s) => s.currentChannel)
-  const dmAgentSlug = useAppStore((s) => s.dmAgentSlug)
+  const channelMeta = useAppStore((s) => s.channelMeta)
+  const dm = isDMChannel(currentChannel, channelMeta)
+  const dmAgentSlug = dm?.agentSlug ?? null
   const { data: messages = [] } = useMessages(currentChannel)
   const { lines, connected } = useAgentStream(dmAgentSlug)
   const messagesRef = useRef<HTMLDivElement>(null)

--- a/web/src/hooks/useHashRouter.ts
+++ b/web/src/hooks/useHashRouter.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useAppStore } from '../stores/app'
+import { useAppStore, isDMChannel, type ChannelMeta } from '../stores/app'
 
 type Route =
   | { view: 'channel'; channel: string }
@@ -32,8 +32,7 @@ function parseHash(hash: string): Route {
 function stateToHash(state: {
   currentApp: string | null
   currentChannel: string
-  dmMode: boolean
-  dmAgentSlug: string | null
+  channelMeta: Record<string, ChannelMeta>
   wikiPath: string | null
 }): string {
   if (state.currentApp === 'wiki') {
@@ -41,11 +40,12 @@ function stateToHash(state: {
       ? `#/wiki/${state.wikiPath.split('/').map(encodeURIComponent).join('/')}`
       : '#/wiki'
   }
-  if (state.dmMode && state.dmAgentSlug) {
-    return `#/dm/${encodeURIComponent(state.dmAgentSlug)}`
-  }
   if (state.currentApp) {
     return `#/apps/${encodeURIComponent(state.currentApp)}`
+  }
+  const dm = isDMChannel(state.currentChannel, state.channelMeta)
+  if (dm) {
+    return `#/dm/${encodeURIComponent(dm.agentSlug)}`
   }
   return `#/channels/${encodeURIComponent(state.currentChannel || 'general')}`
 }
@@ -53,9 +53,10 @@ function stateToHash(state: {
 /**
  * Two-way sync between the Zustand app store and the location hash.
  *
- *   #/channels/<slug> ↔ currentChannel, currentApp=null, dmMode=false
- *   #/dm/<agent>      ↔ dmMode=true, dmAgentSlug=<agent>
+ *   #/channels/<slug> ↔ currentChannel=<slug>, currentApp=null
+ *   #/dm/<agent>      ↔ currentChannel=dm-human-<agent>, channelMeta marked type 'D'
  *   #/apps/<id>       ↔ currentApp=<id>
+ *   #/wiki[/<path>]   ↔ currentApp='wiki', wikiPath=<path>
  *
  * Lets the user bookmark any screen and share URLs. Silent fallback to
  * the channel view if the hash is malformed.
@@ -63,12 +64,10 @@ function stateToHash(state: {
 export function useHashRouter() {
   const currentApp = useAppStore((s) => s.currentApp)
   const currentChannel = useAppStore((s) => s.currentChannel)
-  const dmMode = useAppStore((s) => s.dmMode)
-  const dmAgentSlug = useAppStore((s) => s.dmAgentSlug)
+  const channelMeta = useAppStore((s) => s.channelMeta)
   const setCurrentApp = useAppStore((s) => s.setCurrentApp)
   const setCurrentChannel = useAppStore((s) => s.setCurrentChannel)
   const enterDM = useAppStore((s) => s.enterDM)
-  const exitDM = useAppStore((s) => s.exitDM)
   const setLastMessageId = useAppStore((s) => s.setLastMessageId)
   const wikiPath = useAppStore((s) => s.wikiPath)
   const setWikiPath = useAppStore((s) => s.setWikiPath)
@@ -88,18 +87,14 @@ export function useHashRouter() {
       const route = parseHash(window.location.hash)
       ignoreNextStoreSync.current = true
       if (route.view === 'dm') {
-        // Broker may need the actual channel; reuse the dm-human-<slug>
-        // convention the server uses by default.
+        // Broker uses the dm-human-<slug> channel convention by default.
         enterDM(route.agent, `dm-human-${route.agent}`)
       } else if (route.view === 'app') {
-        exitDM()
         setCurrentApp(route.app)
       } else if (route.view === 'wiki') {
-        exitDM()
         setWikiPath(route.articlePath)
         setCurrentApp('wiki')
       } else {
-        exitDM()
         setCurrentApp(null)
         setCurrentChannel(route.channel)
         setLastMessageId(null)
@@ -109,7 +104,7 @@ export function useHashRouter() {
     applyHash()
     window.addEventListener('hashchange', applyHash)
     return () => window.removeEventListener('hashchange', applyHash)
-  }, [enterDM, exitDM, setCurrentApp, setCurrentChannel, setLastMessageId])
+  }, [enterDM, setCurrentApp, setCurrentChannel, setLastMessageId, setWikiPath])
 
   // Push store changes back into the hash
   useEffect(() => {
@@ -117,12 +112,12 @@ export function useHashRouter() {
       ignoreNextStoreSync.current = false
       return
     }
-    const next = stateToHash({ currentApp, currentChannel, dmMode, dmAgentSlug, wikiPath })
+    const next = stateToHash({ currentApp, currentChannel, channelMeta, wikiPath })
     if (next !== window.location.hash) {
       ignoreNextHashChange.current = true
       // Use replaceState for the initial sync so we don't spam history,
       // then push afterwards.
       window.history.replaceState(null, '', next)
     }
-  }, [currentApp, currentChannel, dmMode, dmAgentSlug, wikiPath])
+  }, [currentApp, currentChannel, channelMeta, wikiPath])
 }

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -9,6 +9,27 @@ export interface ChannelMeta {
   agentSlug?: string
 }
 
+const DM_SLUG_PREFIX = 'dm-human-'
+
+/**
+ * Resolve a channel slug into DM info, or null if not a DM.
+ *
+ * Prefers explicit channelMeta (written by enterDM), falls back to the
+ * server's `dm-human-<agent>` naming convention so deep-links and page
+ * reloads still classify DMs correctly before metadata is hydrated.
+ */
+export function isDMChannel(
+  slug: string,
+  meta: Record<string, ChannelMeta>,
+): { agentSlug: string } | null {
+  const m = meta[slug]
+  if (m?.type === 'D' && m.agentSlug) return { agentSlug: m.agentSlug }
+  if (slug.startsWith(DM_SLUG_PREFIX)) {
+    return { agentSlug: slug.slice(DM_SLUG_PREFIX.length) }
+  }
+  return null
+}
+
 export interface AppStore {
   // Connection
   brokerConnected: boolean
@@ -36,11 +57,9 @@ export interface AppStore {
   activeThreadId: string | null
   setActiveThreadId: (id: string | null) => void
 
-  // DM mode
-  dmMode: boolean
-  dmAgentSlug: string | null
-  enterDM: (slug: string, channel: string) => void
-  exitDM: () => void
+  // DM entry: opens the given DM channel and records {type: 'D', agentSlug}
+  // in channelMeta so downstream views can resolve the paired agent.
+  enterDM: (agentSlug: string, channelSlug: string) => void
 
   // Message polling state
   lastMessageId: string | null
@@ -68,9 +87,9 @@ export const useAppStore = create<AppStore>((set) => ({
   setBrokerConnected: (v) => set({ brokerConnected: v }),
 
   currentChannel: 'general',
-  setCurrentChannel: (ch) => set({ currentChannel: ch, currentApp: null, dmMode: false, dmAgentSlug: null }),
+  setCurrentChannel: (ch) => set({ currentChannel: ch, currentApp: null }),
   currentApp: null,
-  setCurrentApp: (app) => set({ currentApp: app, dmMode: false, dmAgentSlug: null }),
+  setCurrentApp: (app) => set({ currentApp: app }),
 
   channelMeta: {},
   setChannelMeta: (slug, meta) =>
@@ -88,10 +107,15 @@ export const useAppStore = create<AppStore>((set) => ({
   activeThreadId: null,
   setActiveThreadId: (id) => set({ activeThreadId: id }),
 
-  dmMode: false,
-  dmAgentSlug: null,
-  enterDM: (slug, channel) => set({ dmMode: true, dmAgentSlug: slug, currentChannel: channel, currentApp: null }),
-  exitDM: () => set({ dmMode: false, dmAgentSlug: null, currentChannel: 'general' }),
+  enterDM: (agentSlug, channelSlug) =>
+    set((s) => ({
+      currentChannel: channelSlug,
+      currentApp: null,
+      channelMeta: {
+        ...s.channelMeta,
+        [channelSlug]: { ...s.channelMeta[channelSlug], type: 'D', agentSlug },
+      },
+    })),
 
   lastMessageId: null,
   setLastMessageId: (id) => set({ lastMessageId: id }),


### PR DESCRIPTION
## Summary
Architectural follow-up to #168. A DM is already just a channel (\`dm-human-<agent>\`), so the separate \`dmMode\`/\`dmAgentSlug\`/\`exitDM\` flags were duplicate state.

- New \`isDMChannel(slug, channelMeta)\` helper in \`stores/app.ts\`. Prefers explicit \`channelMeta[slug].type === 'D'\` (written by \`enterDM\`); falls back to the \`dm-human-<agent>\` slug convention so deep-links + reloads still classify DMs before metadata hydrates.
- \`enterDM(agentSlug, channelSlug)\` now sets \`currentChannel\` and writes \`channelMeta[channelSlug] = { type: 'D', agentSlug }\`. Signature preserved, so \`AgentPanel\`, \`Composer\`, and \`SearchModal\` need no changes.
- \`MainContent\`, \`Shell\`, \`StatusBar\`, \`DMView\` all derive DM state via \`isDMChannel\`.
- \`useHashRouter\`: \`stateToHash\` emits \`#/dm/<agent>\` when current channel is a DM; \`#/dm/<agent>\` still calls \`enterDM\` on the way in.

Net: ~6 files touched, +70/-45 lines. No state machine for the DM/non-DM distinction — it's a single derived value.

## Test plan
- [x] \`npm run build\` passes
- [x] \`vitest run\` — 105/105 pass
- [x] Manual: open DM with agent → URL becomes \`#/dm/ceo\`, status bar shows \`@ceo 1:1\`, no banner
- [x] Manual: from DM, click #general → switches cleanly, hash \`#/channels/general\`
- [x] Manual: from DM, click Tasks → app loads, hash \`#/apps/tasks\`
- [x] Manual: hard-reload at \`#/dm/ceo\` → DM view renders correctly via slug-pattern fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)