### PR TITLE
fix(team): respawn interactive agent panes after onboarding reseeds roster

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -967,7 +967,7 @@ func (b *Broker) SubscribeActivity(buffer int) (<-chan agentActivitySnapshot, fu
 }
 
 type officeChangeEvent struct {
-	Kind string `json:"kind"` // "member_created", "member_removed", "channel_created", "channel_removed"
+	Kind string `json:"kind"` // "member_created", "member_removed", "channel_created", "channel_removed", "channel_updated", "office_reseeded"
 	Slug string `json:"slug"`
 }
 

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -220,7 +220,16 @@ func (b *Broker) seedFromBlueprintLocked(bp operations.Blueprint, selectedAgents
 	b.messages = nil
 	b.counter = 0
 	b.lastTaggedAt = make(map[string]time.Time)
-	return b.postKickoffLocked(bp, selectedAgents, task, skipTask, synthesized)
+	if err := b.postKickoffLocked(bp, selectedAgents, task, skipTask, synthesized); err != nil {
+		return err
+	}
+	// Signal subscribers (the launcher) that the office roster was replaced
+	// wholesale. Individual member_created events aren't emitted by this path
+	// — seedFromBlueprintLocked rewrites b.members directly — so without this
+	// the launcher never learns the interactive tmux panes are out of sync
+	// with the new team. Subscribers should treat this as "respawn panes".
+	b.publishOfficeChangeLocked(officeChangeEvent{Kind: "office_reseeded"})
+	return nil
 }
 
 func (b *Broker) postKickoffLocked(bp operations.Blueprint, selectedAgents []string, task string, skipTask bool, synthesized bool) error {
@@ -256,7 +265,10 @@ func (b *Broker) postKickoffLocked(bp operations.Blueprint, selectedAgents []str
 
 	lead := officeLeadSlugFromMembers(b.members)
 	if lead == "" {
-		lead = "operator"
+		// Every shipped blueprint declares ceo as lead (guarded by
+		// TestAllOperationBlueprintsUseCEOLead). The fallback here only fires
+		// for malformed/synthesized blueprints with no identifiable lead.
+		lead = "ceo"
 	}
 
 	b.counter++

--- a/internal/team/broker_onboarding_test.go
+++ b/internal/team/broker_onboarding_test.go
@@ -436,3 +436,44 @@ func TestBlankSlateOfficeChannelsFromBlueprint_RendersCommandSlug(t *testing.T) 
 		t.Fatalf("expected a non-general channel rendered from the blueprint, got %+v", channels)
 	}
 }
+
+// TestOnboardingCompleteEmitsOfficeReseededEvent pins the contract the
+// launcher relies on: after the wizard picks a blueprint and the broker
+// rewrites b.members wholesale, a single "office_reseeded" event must fire so
+// the launcher knows to respawn the interactive claude panes. Without this
+// signal the panes are still bound to the default team (ceo/planner/
+// executor/reviewer) and messages sent to the new roster never reach a live
+// claude process — the symptom the user reported during the ui test.
+func TestOnboardingCompleteEmitsOfficeReseededEvent(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	events, unsubscribe := b.SubscribeOfficeChanges(32)
+	defer unsubscribe()
+
+	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", nil); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	// Drain events and look for the reseed signal. Other per-member events
+	// are NOT emitted by this path (seedFromBlueprintLocked rewrites members
+	// directly), so office_reseeded is the only way the launcher learns.
+	sawReseed := false
+	for {
+		select {
+		case evt, ok := <-events:
+			if !ok {
+				t.Fatalf("subscriber closed before office_reseeded fired")
+			}
+			if evt.Kind == "office_reseeded" {
+				sawReseed = true
+			}
+		default:
+			if !sawReseed {
+				t.Fatalf("expected office_reseeded event after seed; none fired")
+			}
+			return
+		}
+	}
+}

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -491,10 +492,35 @@ func (l *Launcher) notifyOfficeChangesLoop() {
 	defer unsubscribe()
 
 	for evt := range changes {
+		// office_reseeded fires after onboarding rewrites the whole roster
+		// (blueprint selection). The interactive claude panes were spawned
+		// from the earlier default team and now point at slugs that are no
+		// longer registered agents — messages typed into them go into a
+		// dead shell. Respawn them against the new roster, outside the
+		// interview guard so it can't be blocked by a half-complete wizard.
+		if evt.Kind == "office_reseeded" {
+			l.respawnPanesAfterReseed()
+			continue
+		}
 		if l.broker.HasPendingInterview() {
 			continue
 		}
 		l.deliverOfficeChangeNotification(evt)
+	}
+}
+
+// respawnPanesAfterReseed restarts the interactive agent panes so they match
+// the newly-seeded roster from onboarding. Best-effort: the codex runtime has
+// no interactive panes, and reconfigureVisibleAgents handles an uninitialised
+// paneBackedAgents state by no-op'ing. Errors are logged but do not propagate
+// — failing to respawn leaves the previous panes running (degraded, but the
+// headless path can still deliver).
+func (l *Launcher) respawnPanesAfterReseed() {
+	if l == nil || l.usesCodexRuntime() || !l.paneBackedAgents {
+		return
+	}
+	if err := l.reconfigureVisibleAgents(); err != nil {
+		log.Printf("office_reseeded: respawn panes failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

wuphf spawns tmux claude panes at launch time from the default manifest (`ceo / planner / executor / reviewer`). When the user then picks a blueprint in the onboarding wizard, `seedFromBlueprintLocked` rewrites `b.members` wholesale (niche-crm swaps executor for builder and adds growth). That rewrite was silent — no event fired, so the launcher's interactive panes kept running claude processes for slugs that are no longer registered agents.

End-user symptom: type a message → broker routes to `@ceo` → claude process behind that pane is the old default-team ceo which got killed during reseed, or a different slug entirely → message gets typed into a dead shell, no response. This is the second half of the "agents don't respond" report (PR #175 fixed the blueprint-layer lead inconsistency; this one fixes the pane-layer roster drift).

## Fix

- Emit a new `officeChangeEvent{Kind:"office_reseeded"}` at the end of `seedFromBlueprintLocked` so subscribers learn the roster was replaced.
- Have `notifyOfficeChangesLoop` handle it by calling the existing `reconfigureVisibleAgents`, which already knows how to respawn-pane-in-place when counts match and full-clear-and-respawn when they don't. New helper `respawnPanesAfterReseed` guards on codex runtime / uninitialised panes so non-web and headless flows no-op.
- Drop the `"operator"` fallback in `postKickoffLocked` — every shipped blueprint now declares ceo as lead (guaranteed by `TestAllOperationBlueprintsUseCEOLead` from #175), so the fallback should match that invariant.

## Tests

`TestOnboardingCompleteEmitsOfficeReseededEvent` pins the contract the launcher relies on: after onboarding rewrites members, a single `office_reseeded` event must fire so the launcher can respawn the interactive panes.

`go test ./internal/team/ -count=1 -p 1` passes locally.

## Verified end to end

Fresh niche-crm onboard through the UI on a clean dev install:
- Launch shows `4 agents` (default team: ceo/planner/executor/reviewer).
- Wizard POST `/onboarding/complete` with `blueprint=niche-crm` fires the reseed.
- Log: `office_reseeded: respawn panes failed: …` would print on error; no error seen.
- `ps` shows 5 new claude processes: `ceo, planner, builder, growth, reviewer` — no stale `executor`.
- `/api/members?channel=general` returns all five with `status=active, activity=tool_use`.
- `#general` picks up a growth `[STATUS]` broadcast and a planner `human_interview` — real agent collaboration, tokens flowing.
- UI: Remove-agent button hidden on ceo (lead), visible on planner.

## Test plan
- [ ] `go test ./internal/team/ -count=1 -p 1` passes
- [ ] Fresh onboard into niche-crm: `ps` shows ceo/planner/builder/growth/reviewer claude processes (no executor)
- [ ] Sending a message to #general gets a real CEO reply
- [ ] DM to a specialist resolves and the specialist replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)