### PR TITLE
feat(v1.2): entity briefs — auto-maintained wiki briefs from append-only fact log

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -462,9 +462,13 @@ type Broker struct {
 	wikiSubscribers     map[int]chan wikiWriteEvent
 	notebookSubscribers map[int]chan notebookWriteEvent
 	reviewSubscribers   map[int]chan ReviewStateChangeEvent
+	entitySubscribers   map[int]chan EntityBriefSynthesizedEvent
+	factSubscribers     map[int]chan EntityFactRecordedEvent
 	wikiWorker          *WikiWorker
 	reviewLog           *ReviewLog
 	reviewResolver      ReviewerResolver
+	factLog             *FactLog
+	entitySynthesizer   *EntitySynthesizer
 	scanTracker         *scanStatusTracker
 	nextSubscriberID    int
 	agentStreams        map[string]*agentStreamBuffer
@@ -857,6 +861,8 @@ func NewBroker() *Broker {
 		wikiSubscribers:     make(map[int]chan wikiWriteEvent),
 		notebookSubscribers: make(map[int]chan notebookWriteEvent),
 		reviewSubscribers:   make(map[int]chan ReviewStateChangeEvent),
+		entitySubscribers:   make(map[int]chan EntityBriefSynthesizedEvent),
+		factSubscribers:     make(map[int]chan EntityFactRecordedEvent),
 		agentStreams:        make(map[string]*agentStreamBuffer),
 		rateLimitBuckets:    make(map[string]ipRateLimitBucket),
 		rateLimitWindow:     defaultRateLimitWindow,
@@ -1128,6 +1134,7 @@ func (b *Broker) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 func (b *Broker) Start() error {
 	b.ensureWikiWorker()
 	b.ensureReviewLog()
+	b.ensureEntitySynthesizer()
 	b.startReviewExpiryLoop(context.Background())
 	return b.StartOnPort(brokeraddr.ResolvePort())
 }
@@ -1214,6 +1221,10 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/notebook/promote", b.requireAuth(b.handleNotebookPromote))
 	mux.HandleFunc("/review/list", b.requireAuth(b.handleReviewList))
 	mux.HandleFunc("/review/", b.requireAuth(b.handleReviewSubpath))
+	mux.HandleFunc("/entity/fact", b.requireAuth(b.handleEntityFact))
+	mux.HandleFunc("/entity/brief/synthesize", b.requireAuth(b.handleEntityBriefSynthesize))
+	mux.HandleFunc("/entity/facts", b.requireAuth(b.handleEntityFactsList))
+	mux.HandleFunc("/entity/briefs", b.requireAuth(b.handleEntityBriefsList))
 	mux.HandleFunc("/scan/start", b.requireAuth(b.handleScanStart))
 	mux.HandleFunc("/scan/status", b.requireAuth(b.handleScanStatus))
 	mux.HandleFunc("/studio/generate-package", b.requireAuth(b.handleStudioGeneratePackage))
@@ -1288,6 +1299,12 @@ func (b *Broker) StartOnPort(port int) error {
 func (b *Broker) Stop() {
 	if b.server != nil {
 		_ = b.server.Close()
+	}
+	b.mu.Lock()
+	synth := b.entitySynthesizer
+	b.mu.Unlock()
+	if synth != nil {
+		synth.Stop()
 	}
 }
 
@@ -1711,6 +1728,10 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 	defer unsubscribeWiki()
 	notebookEvents, unsubscribeNotebook := b.SubscribeNotebookEvents(64)
 	defer unsubscribeNotebook()
+	entityEvents, unsubscribeEntity := b.SubscribeEntityBriefEvents(64)
+	defer unsubscribeEntity()
+	factEvents, unsubscribeFacts := b.SubscribeEntityFactEvents(64)
+	defer unsubscribeFacts()
 
 	writeEvent := func(name string, payload any) error {
 		data, err := json.Marshal(payload)
@@ -1757,6 +1778,14 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		case evt, ok := <-notebookEvents:
 			if !ok || writeEvent("notebook:write", evt) != nil {
+				return
+			}
+		case evt, ok := <-entityEvents:
+			if !ok || writeEvent("entity:brief_synthesized", evt) != nil {
+				return
+			}
+		case evt, ok := <-factEvents:
+			if !ok || writeEvent("entity:fact_recorded", evt) != nil {
 				return
 			}
 		case <-heartbeat.C:

--- a/internal/team/broker_entity.go
+++ b/internal/team/broker_entity.go
@@ -1,0 +1,446 @@
+package team
+
+// broker_entity.go wires the v1.2 entity-brief surface onto the broker —
+// fact log, synthesizer worker, SSE event fanout, and HTTP handlers.
+//
+// Route map (registered in broker.go):
+//
+//	POST /entity/fact               — append one fact, maybe auto-trigger synth
+//	POST /entity/brief/synthesize   — explicit refresh, any actor
+//	GET  /entity/facts?kind=&slug=  — list facts newest-first
+//	GET  /entity/briefs             — enumerate every brief + synth status
+//
+// SSE events fanned out via /events (handleEvents subscribes):
+//
+//	entity:fact_recorded        — {kind, slug, fact_id, fact_count, threshold_crossed, ...}
+//	entity:brief_synthesized    — {kind, slug, commit_sha, fact_count, synthesized_ts}
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SubscribeEntityBriefEvents returns a channel of brief-synthesized events
+// plus an unsubscribe func.
+func (b *Broker) SubscribeEntityBriefEvents(buffer int) (<-chan EntityBriefSynthesizedEvent, func()) {
+	if buffer <= 0 {
+		buffer = 64
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.entitySubscribers == nil {
+		b.entitySubscribers = make(map[int]chan EntityBriefSynthesizedEvent)
+	}
+	id := b.nextSubscriberID
+	b.nextSubscriberID++
+	ch := make(chan EntityBriefSynthesizedEvent, buffer)
+	b.entitySubscribers[id] = ch
+	return ch, func() {
+		b.mu.Lock()
+		if existing, ok := b.entitySubscribers[id]; ok {
+			delete(b.entitySubscribers, id)
+			close(existing)
+		}
+		b.mu.Unlock()
+	}
+}
+
+// SubscribeEntityFactEvents returns a channel of fact-recorded events.
+func (b *Broker) SubscribeEntityFactEvents(buffer int) (<-chan EntityFactRecordedEvent, func()) {
+	if buffer <= 0 {
+		buffer = 64
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.factSubscribers == nil {
+		b.factSubscribers = make(map[int]chan EntityFactRecordedEvent)
+	}
+	id := b.nextSubscriberID
+	b.nextSubscriberID++
+	ch := make(chan EntityFactRecordedEvent, buffer)
+	b.factSubscribers[id] = ch
+	return ch, func() {
+		b.mu.Lock()
+		if existing, ok := b.factSubscribers[id]; ok {
+			delete(b.factSubscribers, id)
+			close(existing)
+		}
+		b.mu.Unlock()
+	}
+}
+
+// PublishEntityBriefSynthesized fans out a synthesis event. Implements the
+// entityEventPublisher interface consumed by EntitySynthesizer.
+func (b *Broker) PublishEntityBriefSynthesized(evt EntityBriefSynthesizedEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, ch := range b.entitySubscribers {
+		select {
+		case ch <- evt:
+		default:
+		}
+	}
+}
+
+// PublishEntityFactRecorded fans out a fact-recorded event.
+func (b *Broker) PublishEntityFactRecorded(evt EntityFactRecordedEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, ch := range b.factSubscribers {
+		select {
+		case ch <- evt:
+		default:
+		}
+	}
+}
+
+// EntitySynthesizer returns the active synthesizer or nil.
+func (b *Broker) EntitySynthesizer() *EntitySynthesizer {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.entitySynthesizer
+}
+
+// FactLog returns the active FactLog or nil.
+func (b *Broker) FactLog() *FactLog {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.factLog
+}
+
+// ensureEntitySynthesizer initializes the fact log + synthesizer when the
+// wiki worker is online. Idempotent.
+func (b *Broker) ensureEntitySynthesizer() {
+	b.mu.Lock()
+	if b.entitySynthesizer != nil {
+		b.mu.Unlock()
+		return
+	}
+	worker := b.wikiWorker
+	b.mu.Unlock()
+	if worker == nil {
+		return
+	}
+
+	factLog := NewFactLog(worker)
+	cfg := SynthesizerConfig{
+		Threshold: resolveThresholdFromEnv(),
+		Timeout:   resolveTimeoutFromEnv(),
+	}
+	synth := NewEntitySynthesizer(worker, factLog, b, cfg)
+	synth.Start(context.Background())
+
+	b.mu.Lock()
+	b.factLog = factLog
+	b.entitySynthesizer = synth
+	b.mu.Unlock()
+}
+
+// SetEntitySynthesizer wires a synthesizer from tests. Must be called after
+// ensureEntitySynthesizer would have run (i.e., wikiWorker already attached).
+func (b *Broker) SetEntitySynthesizer(factLog *FactLog, synth *EntitySynthesizer) {
+	b.mu.Lock()
+	b.factLog = factLog
+	b.entitySynthesizer = synth
+	b.mu.Unlock()
+}
+
+func resolveThresholdFromEnv() int {
+	raw := strings.TrimSpace(os.Getenv("WUPHF_ENTITY_BRIEF_THRESHOLD"))
+	if raw == "" {
+		return DefaultSynthesisThreshold
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return DefaultSynthesisThreshold
+	}
+	return n
+}
+
+func resolveTimeoutFromEnv() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("WUPHF_ENTITY_BRIEF_TIMEOUT"))
+	if raw == "" {
+		return DefaultSynthesisTimeout
+	}
+	secs, err := strconv.Atoi(raw)
+	if err != nil || secs <= 0 {
+		return DefaultSynthesisTimeout
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// handleEntityFact is POST /entity/fact.
+//
+//	body: { entity_kind, entity_slug, fact, source_path?, recorded_by? }
+//	resp: { fact_id, fact_count, threshold_crossed }
+func (b *Broker) handleEntityFact(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	factLog := b.FactLog()
+	synth := b.EntitySynthesizer()
+	if factLog == nil || synth == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "entity-brief backend is not active"})
+		return
+	}
+	var body struct {
+		EntityKind string `json:"entity_kind"`
+		EntitySlug string `json:"entity_slug"`
+		Fact       string `json:"fact"`
+		SourcePath string `json:"source_path"`
+		RecordedBy string `json:"recorded_by"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	recordedBy := strings.TrimSpace(body.RecordedBy)
+	if recordedBy == "" {
+		recordedBy = strings.TrimSpace(r.Header.Get(agentRateLimitHeader))
+	}
+	if recordedBy == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "recorded_by or X-WUPHF-Agent header is required"})
+		return
+	}
+
+	kind := EntityKind(strings.TrimSpace(body.EntityKind))
+	slug := strings.TrimSpace(body.EntitySlug)
+	if err := ValidateFactInput(kind, slug, body.Fact, body.SourcePath, recordedBy); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+
+	fact, err := factLog.Append(r.Context(), kind, slug, body.Fact, body.SourcePath, recordedBy)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+
+	// Read back the current brief frontmatter to compute "facts since sha".
+	briefRel := briefPath(kind, slug)
+	briefBytes, _ := readArticle(b.WikiWorker().Repo(), briefRel)
+	lastSHA, _, priorCount := parseSynthesisFrontmatter(string(briefBytes))
+
+	totalFacts, _ := factLog.CountSinceSHA(r.Context(), kind, slug, lastSHA)
+	threshold := synth.Threshold()
+	thresholdCrossed := totalFacts >= threshold
+
+	// If either new facts since last synth crosses threshold OR there's
+	// never been a synthesis (priorCount == 0 && we have >=threshold facts),
+	// enqueue automatically.
+	if thresholdCrossed {
+		if _, enqueueErr := synth.EnqueueSynthesis(kind, slug, ArchivistAuthor); enqueueErr != nil && !errors.Is(enqueueErr, ErrSynthesisQueueSaturated) {
+			// Coalesced requests return (0, nil); saturation is a soft error.
+			// Every other error is a bug — log and move on.
+		}
+	}
+	_ = priorCount
+
+	b.PublishEntityFactRecorded(EntityFactRecordedEvent{
+		Kind:             kind,
+		Slug:             slug,
+		FactID:           fact.ID,
+		RecordedBy:       recordedBy,
+		FactCount:        totalFacts,
+		ThresholdCrossed: thresholdCrossed,
+		Timestamp:        fact.CreatedAt.Format(time.RFC3339),
+	})
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"fact_id":           fact.ID,
+		"fact_count":        totalFacts,
+		"threshold_crossed": thresholdCrossed,
+	})
+}
+
+// handleEntityBriefSynthesize is POST /entity/brief/synthesize.
+//
+//	body: { entity_kind, entity_slug, actor_slug? }
+//	resp: { synthesis_id, queued_at }
+func (b *Broker) handleEntityBriefSynthesize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	synth := b.EntitySynthesizer()
+	if synth == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "entity-brief backend is not active"})
+		return
+	}
+	var body struct {
+		EntityKind string `json:"entity_kind"`
+		EntitySlug string `json:"entity_slug"`
+		ActorSlug  string `json:"actor_slug"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	kind := EntityKind(strings.TrimSpace(body.EntityKind))
+	slug := strings.TrimSpace(body.EntitySlug)
+	if err := validateListInputs(kind, slug); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	actor := strings.TrimSpace(body.ActorSlug)
+	if actor == "" {
+		actor = strings.TrimSpace(r.Header.Get(agentRateLimitHeader))
+	}
+	if actor == "" {
+		actor = "human"
+	}
+	id, err := synth.EnqueueSynthesis(kind, slug, actor)
+	if err != nil {
+		if errors.Is(err, ErrSynthesisQueueSaturated) {
+			writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"synthesis_id": id,
+		"queued_at":    time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+// handleEntityFactsList is GET /entity/facts?kind=&slug=.
+func (b *Broker) handleEntityFactsList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	factLog := b.FactLog()
+	if factLog == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "entity-brief backend is not active"})
+		return
+	}
+	kind := EntityKind(strings.TrimSpace(r.URL.Query().Get("kind")))
+	slug := strings.TrimSpace(r.URL.Query().Get("slug"))
+	if err := validateListInputs(kind, slug); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	facts, err := factLog.List(kind, slug)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if facts == nil {
+		facts = []Fact{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"facts": facts})
+}
+
+func validateListInputs(kind EntityKind, slug string) error {
+	found := false
+	for _, k := range ValidEntityKinds() {
+		if k == kind {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("kind must be one of people|companies|customers; got %q", kind)
+	}
+	if !slugPattern.MatchString(slug) {
+		return fmt.Errorf("slug must match ^[a-z0-9][a-z0-9-]*$; got %q", slug)
+	}
+	return nil
+}
+
+// BriefSummary is one row returned by GET /entity/briefs.
+type BriefSummary struct {
+	Kind               EntityKind `json:"kind"`
+	Slug               string     `json:"slug"`
+	Title              string     `json:"title"`
+	FactCount          int        `json:"fact_count"`
+	LastSynthesizedTS  string     `json:"last_synthesized_ts"`
+	LastSynthesizedSHA string     `json:"last_synthesized_sha"`
+	PendingDelta       int        `json:"pending_delta"`
+}
+
+// handleEntityBriefsList is GET /entity/briefs.
+func (b *Broker) handleEntityBriefsList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	worker := b.WikiWorker()
+	factLog := b.FactLog()
+	if worker == nil || factLog == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "entity-brief backend is not active"})
+		return
+	}
+
+	root := worker.Repo().Root()
+	rows := make([]BriefSummary, 0, 16)
+	for _, kind := range ValidEntityKinds() {
+		dir := filepath.Join(root, "team", string(kind))
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if !strings.HasSuffix(strings.ToLower(name), ".md") {
+				continue
+			}
+			slug := strings.TrimSuffix(name, ".md")
+			if !slugPattern.MatchString(slug) {
+				continue
+			}
+			bytes, err := os.ReadFile(filepath.Join(dir, name))
+			if err != nil {
+				continue
+			}
+			body := string(bytes)
+			sha, ts, factCountAtSynth := parseSynthesisFrontmatter(body)
+			tsStr := ""
+			if !ts.IsZero() {
+				tsStr = ts.Format(time.RFC3339)
+			}
+			facts, _ := factLog.List(kind, slug)
+			pending := len(facts) - factCountAtSynth
+			if pending < 0 {
+				pending = 0
+			}
+			rows = append(rows, BriefSummary{
+				Kind:               kind,
+				Slug:               slug,
+				Title:              briefTitleFrom(body, slug),
+				FactCount:          len(facts),
+				LastSynthesizedTS:  tsStr,
+				LastSynthesizedSHA: sha,
+				PendingDelta:       pending,
+			})
+		}
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Kind != rows[j].Kind {
+			return rows[i].Kind < rows[j].Kind
+		}
+		return rows[i].Slug < rows[j].Slug
+	})
+	writeJSON(w, http.StatusOK, map[string]any{"briefs": rows})
+}
+
+func briefTitleFrom(body, fallback string) string {
+	if h := headerLineFrom(stripFrontmatter(body)); h != "" {
+		return h
+	}
+	return fallback
+}

--- a/internal/team/broker_entity.go
+++ b/internal/team/broker_entity.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -249,7 +250,9 @@ func (b *Broker) handleEntityFact(w http.ResponseWriter, r *http.Request) {
 	if thresholdCrossed {
 		if _, enqueueErr := synth.EnqueueSynthesis(kind, slug, ArchivistAuthor); enqueueErr != nil && !errors.Is(enqueueErr, ErrSynthesisQueueSaturated) {
 			// Coalesced requests return (0, nil); saturation is a soft error.
-			// Every other error is a bug — log and move on.
+			// Every other error is a bug — log so ops can see it without
+			// failing the caller's fact-record request.
+			log.Printf("entity: enqueue synthesis after threshold cross for %s/%s: %v", kind, slug, enqueueErr)
 		}
 	}
 	b.PublishEntityFactRecorded(EntityFactRecordedEvent{

--- a/internal/team/broker_entity.go
+++ b/internal/team/broker_entity.go
@@ -226,14 +226,22 @@ func (b *Broker) handleEntityFact(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read back the current brief frontmatter to compute "facts since sha".
+	// Read back the current brief frontmatter to compute how many facts
+	// have landed since the last synthesis. Prefer the explicit
+	// fact_count_at_synthesis over sha-based comparison (second-precision
+	// commit timestamps race with fact appends).
 	briefRel := briefPath(kind, slug)
 	briefBytes, _ := readArticle(b.WikiWorker().Repo(), briefRel)
-	lastSHA, _, priorCount := parseSynthesisFrontmatter(string(briefBytes))
+	_, _, priorCount := parseSynthesisFrontmatter(string(briefBytes))
 
-	totalFacts, _ := factLog.CountSinceSHA(r.Context(), kind, slug, lastSHA)
+	allFacts, _ := factLog.List(kind, slug)
+	totalFacts := len(allFacts)
+	newSinceSynth := totalFacts - priorCount
+	if newSinceSynth < 0 {
+		newSinceSynth = 0
+	}
 	threshold := synth.Threshold()
-	thresholdCrossed := totalFacts >= threshold
+	thresholdCrossed := newSinceSynth >= threshold
 
 	// If either new facts since last synth crosses threshold OR there's
 	// never been a synthesis (priorCount == 0 && we have >=threshold facts),
@@ -244,8 +252,6 @@ func (b *Broker) handleEntityFact(w http.ResponseWriter, r *http.Request) {
 			// Every other error is a bug — log and move on.
 		}
 	}
-	_ = priorCount
-
 	b.PublishEntityFactRecorded(EntityFactRecordedEvent{
 		Kind:             kind,
 		Slug:             slug,

--- a/internal/team/broker_entity_test.go
+++ b/internal/team/broker_entity_test.go
@@ -1,0 +1,435 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newEntityTestServer wires a full httptest server with the four /entity/*
+// routes plus a running wiki worker and a stubbed synthesizer (so no
+// real LLM shellout happens in tests).
+func newEntityTestServer(t *testing.T, llmStub func(ctx context.Context, sys, user string) (string, error)) (*httptest.Server, *Broker, *entityPublisherStub, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	b := NewBroker()
+	worker := NewWikiWorker(repo, b)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+
+	pub := &entityPublisherStub{}
+	factLog := NewFactLog(worker)
+	if llmStub == nil {
+		llmStub = func(context.Context, string, string) (string, error) {
+			return "# Stubbed brief\n\nSynthesized.\n", nil
+		}
+	}
+	synth := NewEntitySynthesizer(worker, factLog, pub, SynthesizerConfig{
+		Threshold: 2,
+		Timeout:   5 * time.Second,
+		LLMCall:   llmStub,
+	})
+	synth.Start(context.Background())
+	b.SetEntitySynthesizer(factLog, synth)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/entity/fact", b.requireAuth(b.handleEntityFact))
+	mux.HandleFunc("/entity/brief/synthesize", b.requireAuth(b.handleEntityBriefSynthesize))
+	mux.HandleFunc("/entity/facts", b.requireAuth(b.handleEntityFactsList))
+	mux.HandleFunc("/entity/briefs", b.requireAuth(b.handleEntityBriefsList))
+	srv := httptest.NewServer(mux)
+	return srv, b, pub, func() {
+		srv.Close()
+		synth.Stop()
+		cancel()
+		worker.Stop()
+	}
+}
+
+func TestBrokerEntity_FactHappyPathPublishesEvent(t *testing.T) {
+	srv, b, pub, teardown := newEntityTestServer(t, nil)
+	defer teardown()
+
+	// Subscribe BEFORE posting so we don't miss the event.
+	events, unsub := b.SubscribeEntityFactEvents(16)
+	defer unsub()
+
+	payload, _ := json.Marshal(map[string]any{
+		"entity_kind": "people",
+		"entity_slug": "nazz",
+		"fact":        "Ex-HubSpot PM.",
+		"recorded_by": "pm",
+	})
+	req, _ := authReq(http.MethodPost, srv.URL+"/entity/fact", bytes.NewReader(payload), b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("status=%d body=%s", res.StatusCode, body)
+	}
+	var resp struct {
+		FactID           string `json:"fact_id"`
+		FactCount        int    `json:"fact_count"`
+		ThresholdCrossed bool   `json:"threshold_crossed"`
+	}
+	_ = json.NewDecoder(res.Body).Decode(&resp)
+	if resp.FactID == "" {
+		t.Fatalf("no fact_id")
+	}
+	if resp.FactCount != 1 {
+		t.Fatalf("fact_count=%d", resp.FactCount)
+	}
+	if resp.ThresholdCrossed {
+		t.Fatalf("threshold should not be crossed at count=1 (threshold=2)")
+	}
+
+	select {
+	case evt := <-events:
+		if evt.FactID != resp.FactID {
+			t.Fatalf("event fact_id mismatch: %s vs %s", evt.FactID, resp.FactID)
+		}
+		if evt.ThresholdCrossed {
+			t.Fatalf("event shouldn't flag threshold crossed yet")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected entity:fact_recorded SSE event within 2s")
+	}
+	_ = pub
+}
+
+func TestBrokerEntity_FactThresholdTriggersSynthesis(t *testing.T) {
+	var synthCalls sync.WaitGroup
+	synthCalls.Add(1)
+	once := sync.Once{}
+	srv, b, pub, teardown := newEntityTestServer(t, func(ctx context.Context, sys, user string) (string, error) {
+		once.Do(func() { synthCalls.Done() })
+		return "# Acme\n\nSynth OK.\n", nil
+	})
+	defer teardown()
+
+	// Fire two facts — threshold is 2, so the second append triggers synthesis.
+	for i := 0; i < 2; i++ {
+		payload, _ := json.Marshal(map[string]any{
+			"entity_kind": "companies",
+			"entity_slug": "acme",
+			"fact":        "fact " + string(rune('A'+i)),
+			"recorded_by": "pm",
+		})
+		req, _ := authReq(http.MethodPost, srv.URL+"/entity/fact", bytes.NewReader(payload), b.Token())
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post fact: %v", err)
+		}
+		res.Body.Close()
+	}
+
+	// Wait for synthesis to run.
+	done := make(chan struct{})
+	go func() { synthCalls.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("synthesis not triggered within 3s")
+	}
+	// Give the worker a tick to commit.
+	time.Sleep(300 * time.Millisecond)
+	if pub.briefCount() == 0 {
+		t.Fatal("expected a brief synthesis after threshold crossed")
+	}
+}
+
+func TestBrokerEntity_FactValidationErrors(t *testing.T) {
+	srv, b, _, teardown := newEntityTestServer(t, nil)
+	defer teardown()
+
+	cases := []struct {
+		name   string
+		body   map[string]any
+		status int
+	}{
+		{"bad kind", map[string]any{"entity_kind": "widgets", "entity_slug": "x", "fact": "y", "recorded_by": "pm"}, http.StatusBadRequest},
+		{"bad slug", map[string]any{"entity_kind": "people", "entity_slug": "X!", "fact": "y", "recorded_by": "pm"}, http.StatusBadRequest},
+		{"empty fact", map[string]any{"entity_kind": "people", "entity_slug": "x", "fact": "  ", "recorded_by": "pm"}, http.StatusBadRequest},
+		{"missing recorded_by", map[string]any{"entity_kind": "people", "entity_slug": "x", "fact": "y"}, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			payload, _ := json.Marshal(tc.body)
+			req, _ := authReq(http.MethodPost, srv.URL+"/entity/fact", bytes.NewReader(payload), b.Token())
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("http: %v", err)
+			}
+			defer res.Body.Close()
+			if res.StatusCode != tc.status {
+				body, _ := io.ReadAll(res.Body)
+				t.Fatalf("want %d got %d body=%s", tc.status, res.StatusCode, body)
+			}
+		})
+	}
+}
+
+func TestBrokerEntity_FactRequiresAuth(t *testing.T) {
+	srv, _, _, teardown := newEntityTestServer(t, nil)
+	defer teardown()
+	payload, _ := json.Marshal(map[string]any{"entity_kind": "people", "entity_slug": "x", "fact": "y", "recorded_by": "pm"})
+	res, err := http.Post(srv.URL+"/entity/fact", "application/json", bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401; got %d", res.StatusCode)
+	}
+}
+
+func TestBrokerEntity_FactMethodCheck(t *testing.T) {
+	srv, b, _, teardown := newEntityTestServer(t, nil)
+	defer teardown()
+	req, _ := authReq(http.MethodGet, srv.URL+"/entity/fact", nil, b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405; got %d", res.StatusCode)
+	}
+}
+
+func TestBrokerEntity_SynthesizeExplicitQueue(t *testing.T) {
+	srv, b, pub, teardown := newEntityTestServer(t, nil)
+	defer teardown()
+
+	// Append one fact first so the synth has input.
+	payload, _ := json.Marshal(map[string]any{
+		"entity_kind": "customers",
+		"entity_slug": "northstar",
+		"fact":        "Expanded contract.",
+		"recorded_by": "pm",
+	})
+	req, _ := authReq(http.MethodPost, srv.URL+"/entity/fact", bytes.NewReader(payload), b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	res.Body.Close()
+
+	// Explicit synth request.
+	synthPayload, _ := json.Marshal(map[string]any{
+		"entity_kind": "customers",
+		"entity_slug": "northstar",
+		"actor_slug":  "human",
+	})
+	req, _ = authReq(http.MethodPost, srv.URL+"/entity/brief/synthesize", bytes.NewReader(synthPayload), b.Token())
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("status=%d body=%s", res.StatusCode, body)
+	}
+	var resp struct {
+		SynthesisID uint64 `json:"synthesis_id"`
+		QueuedAt    string `json:"queued_at"`
+	}
+	_ = json.NewDecoder(res.Body).Decode(&resp)
+	if resp.QueuedAt == "" {
+		t.Fatalf("missing queued_at")
+	}
+
+	// Wait for synthesis to commit.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if pub.briefCount() >= 1 {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("synthesis did not complete within 3s")
+}
+
+func TestBrokerEntity_FactsList(t *testing.T) {
+	srv, b, _, teardown := newEntityTestServer(t, nil)
+	defer teardown()
+
+	for _, f := range []string{"A", "B", "C"} {
+		payload, _ := json.Marshal(map[string]any{
+			"entity_kind": "people", "entity_slug": "pm", "fact": f, "recorded_by": "pm",
+		})
+		req, _ := authReq(http.MethodPost, srv.URL+"/entity/fact", bytes.NewReader(payload), b.Token())
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("http: %v", err)
+		}
+		res.Body.Close()
+	}
+	req, _ := authReq(http.MethodGet, srv.URL+"/entity/facts?kind=people&slug=pm", nil, b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", res.StatusCode)
+	}
+	var resp struct {
+		Facts []Fact `json:"facts"`
+	}
+	_ = json.NewDecoder(res.Body).Decode(&resp)
+	if len(resp.Facts) != 3 {
+		t.Fatalf("want 3 facts, got %d", len(resp.Facts))
+	}
+}
+
+func TestBrokerEntity_FactsListValidation(t *testing.T) {
+	srv, b, _, teardown := newEntityTestServer(t, nil)
+	defer teardown()
+	req, _ := authReq(http.MethodGet, srv.URL+"/entity/facts?kind=invalid&slug=x", nil, b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400; got %d", res.StatusCode)
+	}
+}
+
+func TestBrokerEntity_BriefsList(t *testing.T) {
+	srv, b, pub, teardown := newEntityTestServer(t, nil)
+	defer teardown()
+
+	// Seed a brief via fact + explicit synth.
+	payload, _ := json.Marshal(map[string]any{
+		"entity_kind": "people", "entity_slug": "ceo", "fact": "Founder.", "recorded_by": "pm",
+	})
+	req, _ := authReq(http.MethodPost, srv.URL+"/entity/fact", bytes.NewReader(payload), b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	res.Body.Close()
+
+	synthP, _ := json.Marshal(map[string]any{"entity_kind": "people", "entity_slug": "ceo", "actor_slug": "human"})
+	req, _ = authReq(http.MethodPost, srv.URL+"/entity/brief/synthesize", bytes.NewReader(synthP), b.Token())
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	res.Body.Close()
+
+	// Wait for brief.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) && pub.briefCount() == 0 {
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	req, _ = authReq(http.MethodGet, srv.URL+"/entity/briefs", nil, b.Token())
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status=%d", res.StatusCode)
+	}
+	var resp struct {
+		Briefs []BriefSummary `json:"briefs"`
+	}
+	_ = json.NewDecoder(res.Body).Decode(&resp)
+	if len(resp.Briefs) == 0 {
+		t.Fatalf("expected at least 1 brief")
+	}
+	found := false
+	for _, br := range resp.Briefs {
+		if br.Kind == EntityKindPeople && br.Slug == "ceo" {
+			found = true
+			if br.FactCount < 1 {
+				t.Errorf("fact_count=%d", br.FactCount)
+			}
+			if br.LastSynthesizedTS == "" {
+				t.Errorf("missing last_synthesized_ts")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("briefs list did not contain people/ceo: %+v", resp.Briefs)
+	}
+}
+
+func TestBrokerEntity_WorkerDownReturns503(t *testing.T) {
+	b := NewBroker()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/entity/fact", b.requireAuth(b.handleEntityFact))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	payload, _ := json.Marshal(map[string]any{"entity_kind": "people", "entity_slug": "x", "fact": "y", "recorded_by": "pm"})
+	req, _ := authReq(http.MethodPost, srv.URL+"/entity/fact", bytes.NewReader(payload), b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503; got %d", res.StatusCode)
+	}
+}
+
+// Ensures X-WUPHF-Agent is the recorded_by fallback when the body omits it.
+func TestBrokerEntity_FactFallbackToAgentHeader(t *testing.T) {
+	srv, b, _, teardown := newEntityTestServer(t, nil)
+	defer teardown()
+	payload, _ := json.Marshal(map[string]any{
+		"entity_kind": "people", "entity_slug": "x", "fact": "y",
+	})
+	req, _ := authReq(http.MethodPost, srv.URL+"/entity/fact", bytes.NewReader(payload), b.Token())
+	req.Header.Set("X-WUPHF-Agent", "sales")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("status=%d body=%s", res.StatusCode, body)
+	}
+	// Confirm the fact was recorded by the header slug.
+	req, _ = authReq(http.MethodGet, srv.URL+"/entity/facts?kind=people&slug=x", nil, b.Token())
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	var r struct {
+		Facts []Fact `json:"facts"`
+	}
+	_ = json.NewDecoder(res.Body).Decode(&r)
+	if len(r.Facts) != 1 || r.Facts[0].RecordedBy != "sales" {
+		t.Fatalf("expected recorded_by=sales; got %+v", r.Facts)
+	}
+	_ = strings.TrimSpace
+}

--- a/internal/team/entity_commit.go
+++ b/internal/team/entity_commit.go
@@ -1,0 +1,76 @@
+package team
+
+// entity_commit.go owns the repo-level write that appends one fact to the
+// append-only fact log at team/entities/{kind}-{slug}.facts.jsonl. The
+// standard Repo.Commit path rejects non-.md extensions, so entity writes
+// ride their own thin method — same locking, same identity plumbing.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var entityFactPathPattern = regexp.MustCompile(`^team/entities/(people|companies|customers)-[a-z0-9][a-z0-9-]*\.facts\.jsonl$`)
+
+// CommitEntityFact writes the given content to relPath inside the wiki
+// repo and commits it under the supplied slug. Always uses "replace"
+// semantics — the caller owns the merge (the fact log appends in memory
+// and submits the full file bytes).
+func (r *Repo) CommitEntityFact(ctx context.Context, slug, relPath, content, message string) (string, int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return "", 0, fmt.Errorf("entity commit: author slug is required")
+	}
+	clean := filepath.ToSlash(filepath.Clean(relPath))
+	if !entityFactPathPattern.MatchString(clean) {
+		return "", 0, fmt.Errorf("entity commit: path must match team/entities/{kind}-{slug}.facts.jsonl; got %q", relPath)
+	}
+	if content == "" {
+		return "", 0, fmt.Errorf("entity commit: content is required")
+	}
+
+	fullPath := filepath.Join(r.root, clean)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
+		return "", 0, fmt.Errorf("entity commit: mkdir: %w", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+		return "", 0, fmt.Errorf("entity commit: write: %w", err)
+	}
+
+	if out, err := r.runGitLocked(ctx, slug, "add", "--", clean); err != nil {
+		return "", 0, fmt.Errorf("entity commit: git add: %w: %s", err, out)
+	}
+
+	// Byte-identical re-write is a no-op. Report current HEAD.
+	cachedDiff, err := r.runGitLocked(ctx, slug, "diff", "--cached", "--name-only")
+	if err != nil {
+		return "", 0, fmt.Errorf("entity commit: git diff --cached: %w", err)
+	}
+	if strings.TrimSpace(cachedDiff) == "" {
+		headSha, herr := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+		if herr != nil {
+			return "", 0, fmt.Errorf("entity commit: resolve HEAD: %w", herr)
+		}
+		return strings.TrimSpace(headSha), len(content), nil
+	}
+
+	commitMsg := strings.TrimSpace(message)
+	if commitMsg == "" {
+		commitMsg = "fact: update " + clean
+	}
+	if out, err := r.runGitLocked(ctx, slug, "commit", "-q", "-m", commitMsg); err != nil {
+		return "", 0, fmt.Errorf("entity commit: git commit: %w: %s", err, out)
+	}
+	sha, err := r.runGitLocked(ctx, slug, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", 0, fmt.Errorf("entity commit: resolve HEAD: %w", err)
+	}
+	return strings.TrimSpace(sha), len(content), nil
+}

--- a/internal/team/entity_facts.go
+++ b/internal/team/entity_facts.go
@@ -278,9 +278,14 @@ func (l *FactLog) CountSinceSHA(ctx context.Context, kind EntityKind, slug, sha 
 	if err != nil {
 		return len(facts), nil
 	}
+	// Commit timestamps are second-precision; fact CreatedAt carries
+	// sub-second precision. Compare at second resolution so a fact
+	// created in the same second as the referenced commit is NOT
+	// counted as "new."
+	refSec := ts.UTC().Unix()
 	n := 0
 	for _, f := range facts {
-		if f.CreatedAt.After(ts) {
+		if f.CreatedAt.UTC().Unix() > refSec {
 			n++
 		}
 	}

--- a/internal/team/entity_facts.go
+++ b/internal/team/entity_facts.go
@@ -65,13 +65,13 @@ var slugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
 // Fact is one atomic observation recorded by an agent.
 type Fact struct {
-	ID         string    `json:"id"`
+	ID         string     `json:"id"`
 	Kind       EntityKind `json:"kind"`
-	Slug       string    `json:"slug"`
-	Text       string    `json:"text"`
-	SourcePath string    `json:"source_path,omitempty"`
-	RecordedBy string    `json:"recorded_by"`
-	CreatedAt  time.Time `json:"created_at"`
+	Slug       string     `json:"slug"`
+	Text       string     `json:"text"`
+	SourcePath string     `json:"source_path,omitempty"`
+	RecordedBy string     `json:"recorded_by"`
+	CreatedAt  time.Time  `json:"created_at"`
 }
 
 // FactLog is the append-only log rooted in a wiki repo. It is safe to share

--- a/internal/team/entity_facts.go
+++ b/internal/team/entity_facts.go
@@ -176,7 +176,7 @@ func (l *FactLog) Append(ctx context.Context, kind EntityKind, slug, text, sourc
 	buf = append(buf, '\n')
 
 	msg := fmt.Sprintf("fact: %s/%s — %s", kind, slug, firstLine(text))
-	if _, _, err := l.worker.Enqueue(ctx, recordedBy, relPath, string(buf), "replace", msg); err != nil {
+	if _, _, err := l.worker.EnqueueEntityFact(ctx, recordedBy, relPath, string(buf), msg); err != nil {
 		return Fact{}, fmt.Errorf("entity facts: enqueue: %w", err)
 	}
 	return fact, nil

--- a/internal/team/entity_facts.go
+++ b/internal/team/entity_facts.go
@@ -1,0 +1,308 @@
+package team
+
+// entity_facts.go is the append-only fact log for v1.2 entity briefs.
+//
+// Facts live at team/entities/{kind}-{slug}.facts.jsonl inside the wiki
+// repo. Each line is one atomic observation recorded by an agent. The file
+// is append-only — wrong facts get counter-facts, not deletions (same
+// principle as git itself, see project_entity_briefs_v1_2.md).
+//
+// Writes go through the WikiWorker queue so we reuse the single-writer
+// invariant the rest of the wiki relies on. One fact = one git commit
+// authored by the recording agent. The commit message includes a short
+// preview of the fact so the audit log stays human-readable.
+//
+// Read path (List, CountSinceSHA) does NOT touch the queue — it streams
+// the jsonl directly from disk, skipping malformed lines with a warning
+// (mirrors promotion_log.go recovery posture).
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// EntityKind is the narrow set of wiki subtrees we treat as "entities" for
+// brief synthesis. Matches the existing IA — no new directories.
+type EntityKind string
+
+const (
+	EntityKindPeople    EntityKind = "people"
+	EntityKindCompanies EntityKind = "companies"
+	EntityKindCustomers EntityKind = "customers"
+)
+
+// ValidEntityKinds lists every kind the fact log accepts. Any other value is
+// rejected at the API boundary — there is no fallback to a generic "entity"
+// bucket.
+func ValidEntityKinds() []EntityKind {
+	return []EntityKind{EntityKindPeople, EntityKindCompanies, EntityKindCustomers}
+}
+
+// MaxFactTextLen is the hard cap on a single fact's text. Picked to keep
+// lines comfortable for manual review in any editor and to bound how much
+// prompt tokens a single append can cost on the next synthesis.
+const MaxFactTextLen = 4000
+
+// ErrFactLogNotRunning is returned when Append is called without a wiki
+// worker. The broker wires these together in ensureWikiWorker; tests using
+// FactLog directly must pass a worker explicitly.
+var ErrFactLogNotRunning = errors.New("entity facts: worker is not attached")
+
+var slugPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+
+// Fact is one atomic observation recorded by an agent.
+type Fact struct {
+	ID         string    `json:"id"`
+	Kind       EntityKind `json:"kind"`
+	Slug       string    `json:"slug"`
+	Text       string    `json:"text"`
+	SourcePath string    `json:"source_path,omitempty"`
+	RecordedBy string    `json:"recorded_by"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
+// FactLog is the append-only log rooted in a wiki repo. It is safe to share
+// across goroutines — every operation takes its own lock and either streams
+// directly from disk (reads) or enqueues through the WikiWorker (writes).
+type FactLog struct {
+	worker *WikiWorker
+	mu     sync.Mutex
+}
+
+// NewFactLog constructs a FactLog backed by the supplied worker. The worker
+// must be running before Append is called.
+func NewFactLog(worker *WikiWorker) *FactLog {
+	return &FactLog{worker: worker}
+}
+
+// FactLogPath returns the path, relative to the wiki root, where the
+// jsonl for a single entity is stored. Exported for tests + handlers.
+func FactLogPath(kind EntityKind, slug string) string {
+	return filepath.ToSlash(filepath.Join("team", "entities", string(kind)+"-"+slug+".facts.jsonl"))
+}
+
+// ValidateFactInput checks every field of a prospective fact. Returns nil
+// when the fact is acceptable to persist. Exported so HTTP handlers can
+// validate before they format a response.
+func ValidateFactInput(kind EntityKind, slug, text, sourcePath, recordedBy string) error {
+	found := false
+	for _, k := range ValidEntityKinds() {
+		if k == kind {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("entity_kind must be one of people|companies|customers; got %q", kind)
+	}
+	if !slugPattern.MatchString(slug) {
+		return fmt.Errorf("entity_slug must match ^[a-z0-9][a-z0-9-]*$; got %q", slug)
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return fmt.Errorf("fact text is required")
+	}
+	if len(text) > MaxFactTextLen {
+		return fmt.Errorf("fact text must be <= %d chars; got %d", MaxFactTextLen, len(text))
+	}
+	if strings.TrimSpace(recordedBy) == "" {
+		return fmt.Errorf("recorded_by is required")
+	}
+	if s := strings.TrimSpace(sourcePath); s != "" {
+		if !(strings.HasPrefix(s, "agents/") || strings.HasPrefix(s, "team/")) {
+			return fmt.Errorf("source_path must start with agents/ or team/; got %q", sourcePath)
+		}
+	}
+	return nil
+}
+
+// Append validates the inputs, serializes one Fact, and enqueues the append
+// through the wiki worker. Returns the persisted Fact on success.
+func (l *FactLog) Append(ctx context.Context, kind EntityKind, slug, text, sourcePath, recordedBy string) (Fact, error) {
+	if l == nil || l.worker == nil {
+		return Fact{}, ErrFactLogNotRunning
+	}
+	text = strings.TrimSpace(text)
+	recordedBy = strings.TrimSpace(recordedBy)
+	sourcePath = strings.TrimSpace(sourcePath)
+	if err := ValidateFactInput(kind, slug, text, sourcePath, recordedBy); err != nil {
+		return Fact{}, err
+	}
+
+	fact := Fact{
+		ID:         uuid.NewString(),
+		Kind:       kind,
+		Slug:       slug,
+		Text:       text,
+		SourcePath: sourcePath,
+		RecordedBy: recordedBy,
+		CreatedAt:  time.Now().UTC(),
+	}
+
+	line, err := json.Marshal(fact)
+	if err != nil {
+		return Fact{}, fmt.Errorf("entity facts: marshal: %w", err)
+	}
+
+	relPath := FactLogPath(kind, slug)
+	// The WikiWorker needs the full merged contents for its append mode —
+	// we serialize through the queue so we read the existing file under
+	// the same lock that commits the result.
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	existing := l.readExistingLocked(relPath)
+	buf := make([]byte, 0, len(existing)+len(line)+1)
+	if len(existing) > 0 {
+		buf = append(buf, existing...)
+		if !strings.HasSuffix(string(existing), "\n") {
+			buf = append(buf, '\n')
+		}
+	}
+	buf = append(buf, line...)
+	buf = append(buf, '\n')
+
+	msg := fmt.Sprintf("fact: %s/%s — %s", kind, slug, firstLine(text))
+	if _, _, err := l.worker.Enqueue(ctx, recordedBy, relPath, string(buf), "replace", msg); err != nil {
+		return Fact{}, fmt.Errorf("entity facts: enqueue: %w", err)
+	}
+	return fact, nil
+}
+
+// readExistingLocked reads the current bytes at relPath, or an empty slice
+// if the file does not exist. Caller holds l.mu.
+func (l *FactLog) readExistingLocked(relPath string) []byte {
+	full := filepath.Join(l.worker.Repo().Root(), filepath.FromSlash(relPath))
+	bytes, err := os.ReadFile(full)
+	if err != nil {
+		return nil
+	}
+	return bytes
+}
+
+// List returns every fact for the given entity, newest first. Malformed
+// lines are skipped with a warning. Missing file returns (nil, nil).
+func (l *FactLog) List(kind EntityKind, slug string) ([]Fact, error) {
+	if l == nil || l.worker == nil {
+		return nil, ErrFactLogNotRunning
+	}
+	if !slugPattern.MatchString(slug) {
+		return nil, fmt.Errorf("entity_slug must match ^[a-z0-9][a-z0-9-]*$; got %q", slug)
+	}
+	found := false
+	for _, k := range ValidEntityKinds() {
+		if k == kind {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("entity_kind must be one of people|companies|customers; got %q", kind)
+	}
+
+	relPath := FactLogPath(kind, slug)
+	full := filepath.Join(l.worker.Repo().Root(), filepath.FromSlash(relPath))
+	f, err := os.Open(full)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("entity facts: open: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	lineNo := 0
+	facts := make([]Fact, 0, 16)
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var fact Fact
+		if err := json.Unmarshal([]byte(line), &fact); err != nil {
+			log.Printf("entity facts: skip malformed line %d in %s: %v", lineNo, relPath, err)
+			continue
+		}
+		if fact.ID == "" || fact.Kind == "" || fact.Slug == "" {
+			log.Printf("entity facts: skip underspecified line %d in %s", lineNo, relPath)
+			continue
+		}
+		facts = append(facts, fact)
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("entity facts: scanner error in %s after line %d: %v", relPath, lineNo, err)
+	}
+
+	// Newest first.
+	sort.SliceStable(facts, func(i, j int) bool {
+		return facts[i].CreatedAt.After(facts[j].CreatedAt)
+	})
+	return facts, nil
+}
+
+// CountSinceSHA returns the number of facts recorded after the given commit
+// SHA (exclusive). When sha is empty, every fact counts. When sha does not
+// appear in the repo history (or the file predates the sha), every fact
+// counts — same semantics as "no prior synthesis."
+func (l *FactLog) CountSinceSHA(ctx context.Context, kind EntityKind, slug, sha string) (int, error) {
+	facts, err := l.List(kind, slug)
+	if err != nil {
+		return 0, err
+	}
+	sha = strings.TrimSpace(sha)
+	if sha == "" || l == nil || l.worker == nil {
+		return len(facts), nil
+	}
+
+	// Resolve the commit's timestamp. Facts with CreatedAt strictly after
+	// that timestamp are "new". If the sha doesn't resolve, return the
+	// whole count — the brief has never been synthesized cleanly.
+	ts, err := l.commitTimestamp(ctx, sha)
+	if err != nil {
+		return len(facts), nil
+	}
+	n := 0
+	for _, f := range facts {
+		if f.CreatedAt.After(ts) {
+			n++
+		}
+	}
+	return n, nil
+}
+
+// commitTimestamp looks up the commit timestamp for a given short SHA.
+func (l *FactLog) commitTimestamp(ctx context.Context, sha string) (time.Time, error) {
+	repo := l.worker.Repo()
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	out, err := repo.runGitLocked(ctx, "system", "show", "-s", "--format=%cI", sha)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("entity facts: resolve sha %s: %w: %s", sha, err, out)
+	}
+	line := strings.TrimSpace(out)
+	if line == "" {
+		return time.Time{}, fmt.Errorf("entity facts: empty timestamp for sha %s", sha)
+	}
+	ts, err := time.Parse(time.RFC3339, line)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("entity facts: parse timestamp %q: %w", line, err)
+	}
+	return ts.UTC(), nil
+}

--- a/internal/team/entity_facts_test.go
+++ b/internal/team/entity_facts_test.go
@@ -1,0 +1,232 @@
+package team
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// waitUntilNextSecond sleeps to the next wall-clock second boundary.
+// Used in tests that depend on git's second-precision commit timestamps.
+func waitUntilNextSecond(t *testing.T) {
+	t.Helper()
+	now := time.Now()
+	next := now.Truncate(time.Second).Add(time.Second).Add(10 * time.Millisecond)
+	time.Sleep(time.Until(next))
+}
+
+// newFactLogFixture spins up a wiki repo + worker + fact log isolated to
+// t.TempDir(). Caller must defer the returned teardown.
+func newFactLogFixture(t *testing.T) (*FactLog, *WikiWorker, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+	worker := NewWikiWorker(repo, noopPublisher{})
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	log := NewFactLog(worker)
+	return log, worker, func() {
+		cancel()
+		worker.Stop()
+	}
+}
+
+func TestFactLog_AppendAndListReturnsNewestFirst(t *testing.T) {
+	log, _, teardown := newFactLogFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	if _, err := log.Append(ctx, EntityKindPeople, "nazz", "First fact", "", "pm"); err != nil {
+		t.Fatalf("append 1: %v", err)
+	}
+	if _, err := log.Append(ctx, EntityKindPeople, "nazz", "Second fact", "agents/pm/notebook/retro.md", "pm"); err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+	facts, err := log.List(EntityKindPeople, "nazz")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(facts) != 2 {
+		t.Fatalf("expected 2 facts, got %d", len(facts))
+	}
+	// Newest first.
+	if !strings.Contains(facts[0].Text, "Second") {
+		t.Errorf("expected newest first; got %q", facts[0].Text)
+	}
+	if facts[1].Text != "First fact" {
+		t.Errorf("expected oldest last; got %q", facts[1].Text)
+	}
+	if facts[0].RecordedBy != "pm" {
+		t.Errorf("recorded_by=%q", facts[0].RecordedBy)
+	}
+	if facts[0].ID == "" {
+		t.Errorf("fact missing ID")
+	}
+}
+
+func TestFactLog_ValidationErrors(t *testing.T) {
+	log, _, teardown := newFactLogFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	cases := []struct {
+		name       string
+		kind       EntityKind
+		slug       string
+		text       string
+		sourcePath string
+		recordedBy string
+		wantErr    string
+	}{
+		{"bad kind", "orgs", "acme", "x", "", "pm", "entity_kind must be"},
+		{"bad slug uppercase", EntityKindPeople, "Nazz", "x", "", "pm", "entity_slug must match"},
+		{"bad slug leading dash", EntityKindPeople, "-nazz", "x", "", "pm", "entity_slug must match"},
+		{"empty text", EntityKindPeople, "nazz", "   ", "", "pm", "fact text is required"},
+		{"too long text", EntityKindPeople, "nazz", strings.Repeat("x", MaxFactTextLen+1), "", "pm", "fact text must be <="},
+		{"bad source", EntityKindPeople, "nazz", "x", "../etc/passwd", "pm", "source_path must start with"},
+		{"empty recordedBy", EntityKindPeople, "nazz", "x", "", "", "recorded_by is required"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := log.Append(ctx, tc.kind, tc.slug, tc.text, tc.sourcePath, tc.recordedBy)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error containing %q; got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestFactLog_MalformedLineRecovery(t *testing.T) {
+	log, worker, teardown := newFactLogFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	// Append one good fact so the file exists.
+	if _, err := log.Append(ctx, EntityKindCompanies, "acme", "founded-1999", "", "pm"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	// Inject a malformed line directly at the file level (bypassing the
+	// worker so the test deterministically sees the bad line).
+	fullPath := filepath.Join(worker.Repo().Root(), "team", "entities", "companies-acme.facts.jsonl")
+	existing, _ := os.ReadFile(fullPath)
+	junk := []byte("this is not json\n{\"id\":\"x\",\"kind\":\"companies\",\"slug\":\"acme\",\"text\":\"good\",\"recorded_by\":\"pm\",\"created_at\":\"2026-04-20T00:00:00Z\"}\n")
+	_ = os.WriteFile(fullPath, append(existing, junk...), 0o600)
+
+	facts, err := log.List(EntityKindCompanies, "acme")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	// Original fact + injected "good" record. Malformed line is skipped.
+	if len(facts) != 2 {
+		t.Fatalf("expected 2 facts after skipping malformed; got %d", len(facts))
+	}
+}
+
+func TestFactLog_ConcurrentAppendsAllLand(t *testing.T) {
+	log, _, teardown := newFactLogFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	const N = 10
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			agent := []string{"pm", "eng", "sales", "cs", "ceo"}[i%5]
+			_, err := log.Append(ctx, EntityKindCustomers, "northstar", "fact-"+string(rune('A'+i)), "", agent)
+			if err != nil {
+				t.Errorf("concurrent append %d: %v", i, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	facts, err := log.List(EntityKindCustomers, "northstar")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(facts) != N {
+		t.Fatalf("expected %d facts, got %d", N, len(facts))
+	}
+	// All IDs should be unique.
+	seen := map[string]bool{}
+	for _, f := range facts {
+		if seen[f.ID] {
+			t.Errorf("duplicate fact id: %s", f.ID)
+		}
+		seen[f.ID] = true
+	}
+}
+
+func TestFactLog_CountSinceSHA(t *testing.T) {
+	log, worker, teardown := newFactLogFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	if _, err := log.Append(ctx, EntityKindPeople, "ceo", "old fact", "", "pm"); err != nil {
+		t.Fatalf("append old: %v", err)
+	}
+	// Grab the head sha AFTER the first fact committed.
+	worker.Repo().mu.Lock()
+	shaOut, _ := worker.Repo().runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+	worker.Repo().mu.Unlock()
+	sha := strings.TrimSpace(shaOut)
+
+	// Git commit timestamps are second-precision. Sleep past the second
+	// boundary so the next two appends land unambiguously AFTER `sha`'s
+	// commit time.
+	waitUntilNextSecond(t)
+	if _, err := log.Append(ctx, EntityKindPeople, "ceo", "new fact 1", "", "pm"); err != nil {
+		t.Fatalf("append new 1: %v", err)
+	}
+	if _, err := log.Append(ctx, EntityKindPeople, "ceo", "new fact 2", "", "pm"); err != nil {
+		t.Fatalf("append new 2: %v", err)
+	}
+
+	n, err := log.CountSinceSHA(ctx, EntityKindPeople, "ceo", sha)
+	if err != nil {
+		t.Fatalf("count since: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 new facts since sha; got %d", n)
+	}
+
+	// Empty sha returns total.
+	total, _ := log.CountSinceSHA(ctx, EntityKindPeople, "ceo", "")
+	if total != 3 {
+		t.Fatalf("expected 3 total; got %d", total)
+	}
+
+	// Unknown sha returns everything (safe default — brief has never synthesized).
+	all, _ := log.CountSinceSHA(ctx, EntityKindPeople, "ceo", "deadbeef")
+	if all != 3 {
+		t.Fatalf("expected 3 on unknown sha; got %d", all)
+	}
+}
+
+func TestFactLog_MissingFileReturnsEmpty(t *testing.T) {
+	log, _, teardown := newFactLogFixture(t)
+	defer teardown()
+
+	facts, err := log.List(EntityKindPeople, "ghost")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(facts) != 0 {
+		t.Fatalf("expected 0 facts for missing file; got %d", len(facts))
+	}
+}

--- a/internal/team/entity_frontmatter.go
+++ b/internal/team/entity_frontmatter.go
@@ -1,0 +1,186 @@
+package team
+
+// entity_frontmatter.go owns the YAML frontmatter helpers used by the
+// synthesizer to stamp brief metadata (last synthesized sha, timestamp,
+// fact count) without disturbing other keys the authoring agents or
+// maintainers may have added.
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Frontmatter keys owned by the synthesizer. Preserved in order so
+// successive commits don't churn on reordering-only diffs.
+var (
+	lastSHAKey = "last_synthesized_sha"
+	lastTSKey  = "last_synthesized_ts"
+	factCntKey = "fact_count_at_synthesis"
+)
+
+var frontmatterKeyLine = regexp.MustCompile(`(?m)^([a-zA-Z0-9_]+):\s*(.*)$`)
+
+// parseSynthesisFrontmatter extracts the three synthesis keys from the
+// existing brief. Missing keys yield zero values. Other keys are
+// ignored — preservedFrontmatterKeys handles non-synthesis keys.
+func parseSynthesisFrontmatter(brief string) (sha string, ts time.Time, factCount int) {
+	if !strings.HasPrefix(brief, "---\n") {
+		return "", time.Time{}, 0
+	}
+	rest := brief[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return "", time.Time{}, 0
+	}
+	block := rest[:end]
+	for _, line := range strings.Split(block, "\n") {
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		key := m[1]
+		val := strings.TrimSpace(m[2])
+		switch key {
+		case lastSHAKey:
+			sha = val
+		case lastTSKey:
+			if parsed, err := time.Parse(time.RFC3339, val); err == nil {
+				ts = parsed
+			}
+		case factCntKey:
+			factCount = parseInt(val)
+		}
+	}
+	return sha, ts, factCount
+}
+
+// applySynthesisFrontmatter merges the three synthesis keys onto the LLM
+// output. When the output already has a frontmatter block we update those
+// keys in place; otherwise we prepend a fresh block that also preserves
+// any non-synthesis keys from the prior brief.
+func applySynthesisFrontmatter(body, headSHA string, ts time.Time, factCount int, prior string) string {
+	tsStr := ts.UTC().Format(time.RFC3339)
+	ours := map[string]string{
+		lastSHAKey: headSHA,
+		lastTSKey:  tsStr,
+		factCntKey: fmt.Sprintf("%d", factCount),
+	}
+
+	preserved := preservedFrontmatterKeys(prior)
+
+	if !strings.HasPrefix(body, "---\n") {
+		return buildFrontmatterPrepend(body, ours, preserved)
+	}
+
+	// Body HAS frontmatter. Rewrite only our keys + append missing ones.
+	rest := body[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		// Malformed — fall back to prepend path.
+		return applySynthesisFrontmatter(stripFrontmatter(body), headSHA, ts, factCount, prior)
+	}
+	block := rest[:end]
+	tail := rest[end+len("\n---"):]
+	lines := strings.Split(block, "\n")
+	seen := map[string]bool{}
+	for i, line := range lines {
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		key := m[1]
+		if v, ok := ours[key]; ok {
+			lines[i] = key + ": " + v
+			seen[key] = true
+		}
+	}
+	for _, key := range orderedFrontmatterKeys() {
+		if !seen[key] {
+			lines = append(lines, key+": "+ours[key])
+		}
+	}
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString(strings.Join(lines, "\n"))
+	b.WriteString("\n---")
+	b.WriteString(tail)
+	return b.String()
+}
+
+// buildFrontmatterPrepend writes a fresh frontmatter block in front of body.
+func buildFrontmatterPrepend(body string, ours map[string]string, preserved []frontmatterKV) string {
+	var b strings.Builder
+	b.WriteString("---\n")
+	for _, key := range orderedFrontmatterKeys() {
+		if v, ok := ours[key]; ok {
+			b.WriteString(key)
+			b.WriteString(": ")
+			b.WriteString(v)
+			b.WriteString("\n")
+		}
+	}
+	for _, kv := range preserved {
+		if _, mine := ours[kv.key]; mine {
+			continue
+		}
+		b.WriteString(kv.key)
+		b.WriteString(": ")
+		b.WriteString(kv.val)
+		b.WriteString("\n")
+	}
+	b.WriteString("---\n\n")
+	b.WriteString(body)
+	return b.String()
+}
+
+// orderedFrontmatterKeys returns the synthesis keys in a deterministic
+// order so commits don't churn on reorderings.
+func orderedFrontmatterKeys() []string {
+	return []string{lastSHAKey, lastTSKey, factCntKey}
+}
+
+type frontmatterKV struct {
+	key string
+	val string
+}
+
+// preservedFrontmatterKeys lifts non-synthesis keys from a prior brief so
+// we don't lose custom frontmatter when we rewrite from scratch.
+func preservedFrontmatterKeys(prior string) []frontmatterKV {
+	if !strings.HasPrefix(prior, "---\n") {
+		return nil
+	}
+	rest := prior[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return nil
+	}
+	block := rest[:end]
+	var out []frontmatterKV
+	for _, line := range strings.Split(block, "\n") {
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		key := m[1]
+		switch key {
+		case lastSHAKey, lastTSKey, factCntKey:
+			continue
+		}
+		out = append(out, frontmatterKV{key: key, val: strings.TrimSpace(m[2])})
+	}
+	return out
+}
+
+func parseInt(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}

--- a/internal/team/entity_synthesizer.go
+++ b/internal/team/entity_synthesizer.go
@@ -90,11 +90,11 @@ type SynthesisJob struct {
 // EntityBriefSynthesizedEvent is the SSE payload broadcast after every
 // successful synthesis commit.
 type EntityBriefSynthesizedEvent struct {
-	Kind           EntityKind `json:"kind"`
-	Slug           EntitySlug `json:"slug"`
-	CommitSHA      string     `json:"commit_sha"`
-	FactCount      int        `json:"fact_count"`
-	SynthesizedTS  string     `json:"synthesized_ts"`
+	Kind          EntityKind `json:"kind"`
+	Slug          EntitySlug `json:"slug"`
+	CommitSHA     string     `json:"commit_sha"`
+	FactCount     int        `json:"fact_count"`
+	SynthesizedTS string     `json:"synthesized_ts"`
 }
 
 // EntitySlug is a typed alias. Helps readers of the SSE JSON schema; string

--- a/internal/team/entity_synthesizer.go
+++ b/internal/team/entity_synthesizer.go
@@ -1,0 +1,629 @@
+package team
+
+// entity_synthesizer.go is the broker-level LLM synthesis worker for v1.2
+// entity briefs.
+//
+// Design summary (see project_entity_briefs_v1_2.md):
+//   - Synthesis is NOT an agent turn. It runs inside the broker as a
+//     dedicated goroutine consuming a buffered SynthesisJob channel.
+//   - The worker shells out to the user's configured CLI (claude-code,
+//     codex, openclaw, ...) through provider.RunConfiguredOneShot so we
+//     never carry an LLM SDK in the broker binary.
+//   - Output is committed via the WikiWorker queue under the synthetic
+//     "archivist" git identity — preserving the single-writer invariant
+//     and attribution semantics that rest of the wiki uses.
+//   - The worker coalesces re-synth requests per-entity. If a fact lands
+//     while a synthesis is running for the same entity, exactly one
+//     follow-up synthesis is queued — not one per new fact.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// defaultLLMCall shells out to the user's configured LLM CLI.
+// Extracted so tests can replace it via SynthesizerConfig.LLMCall.
+func defaultLLMCall(ctx context.Context, systemPrompt, userPrompt string) (string, error) {
+	// RunConfiguredOneShot does not take a context; we rely on the OS's
+	// process group cleanup when our ctx deadline fires. The synthesize()
+	// layer owns the deadline via context.WithTimeout.
+	_ = ctx
+	return provider.RunConfiguredOneShot(systemPrompt, userPrompt, "")
+}
+
+// ArchivistAuthor is the synthetic commit author for every brief update.
+// Not a roster member — pure git identity.
+const ArchivistAuthor = "archivist"
+
+// DefaultSynthesisThreshold is the number of new facts that must accumulate
+// before an automatic synthesis is triggered. Configurable per deployment
+// via WUPHF_ENTITY_BRIEF_THRESHOLD.
+const DefaultSynthesisThreshold = 5
+
+// DefaultSynthesisTimeout bounds a single LLM shell-out. Configurable via
+// WUPHF_ENTITY_BRIEF_TIMEOUT (seconds).
+const DefaultSynthesisTimeout = 30 * time.Second
+
+// MaxSynthesisQueue is the buffered channel size for pending jobs. Overflow
+// surfaces ErrSynthesisQueueSaturated.
+const MaxSynthesisQueue = 32
+
+// MaxBriefSize caps the LLM output bytes we are willing to commit. Any
+// larger response is treated as a malformed synthesis and dropped.
+const MaxBriefSize = 32 * 1024
+
+// SynthesisPromptSystem is the exact system prompt the worker sends. Wording
+// locked by project_entity_briefs_v1_2.md — do not edit without updating
+// the memo.
+const SynthesisPromptSystem = `You maintain entity briefs in a team wiki. Given an existing brief and new facts, produce an updated markdown brief that incorporates the facts. Never invent facts. Preserve the canonical structure (sections, ordering). Mark contradictions explicitly with **Contradiction:** inline callouts rather than resolving them. Output ONLY the updated markdown, no explanation.`
+
+// ErrSynthesisQueueSaturated is returned by EnqueueSynthesis when the
+// buffered channel is full. Callers surface this as a retry-later.
+var ErrSynthesisQueueSaturated = errors.New("entity synth: queue saturated")
+
+// ErrSynthesizerStopped is returned when EnqueueSynthesis is called after
+// the worker has been stopped.
+var ErrSynthesizerStopped = errors.New("entity synth: not running")
+
+// ErrSynthesisNoNewFacts is surfaced for observability when a job runs with
+// zero un-synthesized facts. Not a hard failure — the job simply skips.
+var ErrSynthesisNoNewFacts = errors.New("entity synth: no new facts since last synthesis")
+
+// SynthesisJob is one pending synthesis request for a specific entity.
+type SynthesisJob struct {
+	Kind       EntityKind
+	Slug       string
+	RequestBy  string
+	EnqueuedAt time.Time
+	// ID is a monotonic counter so callers can correlate responses.
+	ID uint64
+}
+
+// EntityBriefSynthesizedEvent is the SSE payload broadcast after every
+// successful synthesis commit.
+type EntityBriefSynthesizedEvent struct {
+	Kind           EntityKind `json:"kind"`
+	Slug           EntitySlug `json:"slug"`
+	CommitSHA      string     `json:"commit_sha"`
+	FactCount      int        `json:"fact_count"`
+	SynthesizedTS  string     `json:"synthesized_ts"`
+}
+
+// EntitySlug is a typed alias. Helps readers of the SSE JSON schema; string
+// at the wire level.
+type EntitySlug = string
+
+// EntityFactRecordedEvent is the SSE payload broadcast when a fact lands.
+type EntityFactRecordedEvent struct {
+	Kind             EntityKind `json:"kind"`
+	Slug             string     `json:"slug"`
+	FactID           string     `json:"fact_id"`
+	RecordedBy       string     `json:"recorded_by"`
+	FactCount        int        `json:"fact_count"`
+	ThresholdCrossed bool       `json:"threshold_crossed"`
+	Timestamp        string     `json:"timestamp"`
+}
+
+// SynthesizerConfig is the tunable knobs for the worker. All fields are
+// optional; defaults match constants above.
+type SynthesizerConfig struct {
+	Provider  string
+	Threshold int
+	Timeout   time.Duration
+
+	// LLMCall is the pluggable shell-out used by tests. Production code
+	// leaves this nil and the worker falls back to provider.RunConfiguredOneShot.
+	LLMCall func(ctx context.Context, systemPrompt, userPrompt string) (string, error)
+}
+
+// EntitySynthesizer is the broker-level synthesis worker.
+type EntitySynthesizer struct {
+	worker    *WikiWorker
+	factLog   *FactLog
+	publisher entityEventPublisher
+	cfg       SynthesizerConfig
+
+	mu       sync.Mutex
+	jobs     chan SynthesisJob
+	inflight map[string]bool // key=kind/slug — at most 1 running per entity
+	queued   map[string]bool // key=kind/slug — at most 1 pending per entity
+	running  bool
+	nextID   uint64
+	stopCh   chan struct{}
+	wg       sync.WaitGroup
+}
+
+// entityEventPublisher is the subset of Broker the synthesizer needs to
+// fan out entity-scoped SSE events.
+type entityEventPublisher interface {
+	PublishEntityBriefSynthesized(evt EntityBriefSynthesizedEvent)
+	PublishEntityFactRecorded(evt EntityFactRecordedEvent)
+}
+
+// NewEntitySynthesizer wires a synthesizer against the given worker + fact
+// log. Config may be the zero value; defaults are filled in here.
+func NewEntitySynthesizer(worker *WikiWorker, factLog *FactLog, publisher entityEventPublisher, cfg SynthesizerConfig) *EntitySynthesizer {
+	if cfg.Threshold <= 0 {
+		cfg.Threshold = DefaultSynthesisThreshold
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = DefaultSynthesisTimeout
+	}
+	return &EntitySynthesizer{
+		worker:    worker,
+		factLog:   factLog,
+		publisher: publisher,
+		cfg:       cfg,
+		jobs:      make(chan SynthesisJob, MaxSynthesisQueue),
+		inflight:  make(map[string]bool),
+		queued:    make(map[string]bool),
+	}
+}
+
+// Start launches the synthesis loop. Returns immediately. Stop via the ctx
+// or via Stop().
+func (s *EntitySynthesizer) Start(ctx context.Context) {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = true
+	s.stopCh = make(chan struct{})
+	s.mu.Unlock()
+
+	s.wg.Add(1)
+	go s.drain(ctx)
+}
+
+// Stop signals the worker to exit. Pending jobs in the buffered channel are
+// discarded — caller is responsible for only calling this at shutdown.
+func (s *EntitySynthesizer) Stop() {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = false
+	close(s.stopCh)
+	s.mu.Unlock()
+	s.wg.Wait()
+}
+
+// Threshold returns the current synthesis threshold.
+func (s *EntitySynthesizer) Threshold() int {
+	return s.cfg.Threshold
+}
+
+// entityKey is the coalesce key used by inflight/queued maps.
+func entityKey(kind EntityKind, slug string) string {
+	return string(kind) + "/" + slug
+}
+
+// EnqueueSynthesis adds a synthesis job if none is already in-flight or
+// queued for the same entity. Returns the assigned job ID (or 0 when the
+// request was coalesced into an existing queue entry).
+func (s *EntitySynthesizer) EnqueueSynthesis(kind EntityKind, slug, requestBy string) (uint64, error) {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return 0, ErrSynthesizerStopped
+	}
+	key := entityKey(kind, slug)
+	// If another job is queued for the same entity, coalesce silently.
+	if s.queued[key] {
+		s.mu.Unlock()
+		return 0, nil
+	}
+	// If a job is in-flight for the same entity, mark a single follow-up
+	// as queued — the drain loop will schedule it after the current run.
+	if s.inflight[key] {
+		s.queued[key] = true
+		s.mu.Unlock()
+		return 0, nil
+	}
+	s.nextID++
+	id := s.nextID
+	job := SynthesisJob{
+		Kind:       kind,
+		Slug:       slug,
+		RequestBy:  strings.TrimSpace(requestBy),
+		EnqueuedAt: time.Now().UTC(),
+		ID:         id,
+	}
+	s.queued[key] = true
+	s.mu.Unlock()
+
+	select {
+	case s.jobs <- job:
+		return id, nil
+	default:
+		// Queue saturated — undo the reservation so future calls can retry.
+		s.mu.Lock()
+		delete(s.queued, key)
+		s.mu.Unlock()
+		return 0, ErrSynthesisQueueSaturated
+	}
+}
+
+// drain is the single synthesis worker goroutine. Runs exactly one job at
+// a time so the WikiWorker queue never has two archivist writes racing.
+func (s *EntitySynthesizer) drain(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.stopCh:
+			return
+		case job := <-s.jobs:
+			s.runJob(ctx, job)
+		}
+	}
+}
+
+// runJob is the per-entity serialized synthesis. Marks the entity as
+// in-flight, transitions queued->idle->inflight, and after completion
+// schedules any coalesced follow-up.
+func (s *EntitySynthesizer) runJob(ctx context.Context, job SynthesisJob) {
+	key := entityKey(job.Kind, job.Slug)
+
+	s.mu.Lock()
+	s.inflight[key] = true
+	delete(s.queued, key)
+	s.mu.Unlock()
+
+	defer func() {
+		s.mu.Lock()
+		delete(s.inflight, key)
+		needsFollowup := s.queued[key]
+		running := s.running
+		s.mu.Unlock()
+		// A fact landed during this run. Enqueue a follow-up IF the
+		// synthesizer is still running — Stop() may have raced with the
+		// append, and we don't want to block on a closed channel.
+		if needsFollowup && running {
+			// Use a background context for the re-schedule — the caller's
+			// context has already returned. The follow-up will run on the
+			// next drain iteration.
+			go func() {
+				// Small delay so bursts of facts get coalesced further
+				// instead of tail-biting the follow-up immediately.
+				time.Sleep(10 * time.Millisecond)
+				_, _ = s.EnqueueSynthesis(job.Kind, job.Slug, ArchivistAuthor)
+			}()
+		}
+	}()
+
+	if err := s.synthesize(ctx, job); err != nil {
+		if errors.Is(err, ErrSynthesisNoNewFacts) {
+			// Idempotent skip — not a failure.
+			return
+		}
+		log.Printf("entity synth: %s/%s failed: %v", job.Kind, job.Slug, err)
+	}
+}
+
+// synthesize runs the full pipeline for one job. Errors here are logged by
+// runJob; we return them for tests.
+func (s *EntitySynthesizer) synthesize(ctx context.Context, job SynthesisJob) error {
+	relBrief := briefPath(job.Kind, job.Slug)
+	existingBrief, hadBrief := s.readBrief(relBrief)
+	lastSHA, _, _ := parseSynthesisFrontmatter(existingBrief)
+
+	facts, err := s.factLog.List(job.Kind, job.Slug)
+	if err != nil {
+		return fmt.Errorf("list facts: %w", err)
+	}
+	// Facts since last synthesis.
+	newFacts := facts
+	if lastSHA != "" {
+		if ts, tsErr := s.factLog.commitTimestamp(ctx, lastSHA); tsErr == nil {
+			newFacts = facts[:0:0]
+			for _, f := range facts {
+				if f.CreatedAt.After(ts) {
+					newFacts = append(newFacts, f)
+				}
+			}
+		}
+	}
+	if len(newFacts) == 0 && hadBrief {
+		return ErrSynthesisNoNewFacts
+	}
+	if len(facts) == 0 && !hadBrief {
+		return ErrSynthesisNoNewFacts
+	}
+
+	// Build prompt.
+	factListBody := renderFactsForPrompt(newFacts)
+	userPrompt := fmt.Sprintf(
+		"# Existing brief\n\n%s\n\n# New facts since last synthesis\n\n%s\n\n# Your task\nProduce the full updated brief markdown now.",
+		strings.TrimSpace(stripFrontmatter(existingBrief)),
+		factListBody,
+	)
+
+	// Shell out with a bounded timeout.
+	callCtx, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
+	defer cancel()
+	llm := s.cfg.LLMCall
+	if llm == nil {
+		llm = defaultLLMCall
+	}
+	output, llmErr := llm(callCtx, SynthesisPromptSystem, userPrompt)
+	if llmErr != nil {
+		return fmt.Errorf("llm: %w", llmErr)
+	}
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return fmt.Errorf("llm output is empty")
+	}
+	if len(output) > MaxBriefSize {
+		return fmt.Errorf("llm output exceeds %d bytes (got %d)", MaxBriefSize, len(output))
+	}
+	// Very weak tamper check — prompt leakage means the LLM echoed us
+	// back. Drop the result rather than commit garbage.
+	if strings.Contains(output, "# Your task") && strings.Contains(output, "# New facts since last synthesis") {
+		return fmt.Errorf("llm output appears to contain the prompt verbatim")
+	}
+
+	// Resolve current HEAD sha so we stamp the frontmatter with the commit
+	// that existed BEFORE we add the synthesis commit. This lets the next
+	// run know exactly which facts it hasn't seen yet.
+	headSHA, headErr := s.headSHA(ctx)
+	if headErr != nil {
+		// Non-fatal — the brief will just re-count every fact next time.
+		log.Printf("entity synth: resolve HEAD failed: %v", headErr)
+	}
+
+	now := time.Now().UTC()
+	factCount := len(facts)
+	newBody := applySynthesisFrontmatter(output, headSHA, now, factCount, existingBrief)
+
+	// Commit via the wiki queue under the archivist identity. We can't
+	// call CommitBootstrap because that's tree-wide + picks its own slug;
+	// we need an explicit slug commit. Enqueue does exactly that.
+	commitMsg := fmt.Sprintf("archivist: update %s/%s brief (%d facts)", job.Kind, job.Slug, factCount)
+	sha, _, werr := s.worker.Enqueue(ctx, ArchivistAuthor, relBrief, newBody, "replace", commitMsg)
+	if werr != nil {
+		return fmt.Errorf("commit brief: %w", werr)
+	}
+
+	if s.publisher != nil {
+		s.publisher.PublishEntityBriefSynthesized(EntityBriefSynthesizedEvent{
+			Kind:          job.Kind,
+			Slug:          job.Slug,
+			CommitSHA:     sha,
+			FactCount:     factCount,
+			SynthesizedTS: now.Format(time.RFC3339),
+		})
+	}
+	return nil
+}
+
+// readBrief returns the existing brief bytes (string) and whether a file
+// was present.
+func (s *EntitySynthesizer) readBrief(relPath string) (string, bool) {
+	repo := s.worker.Repo()
+	bytes, err := readArticle(repo, relPath)
+	if err != nil {
+		return "", false
+	}
+	return string(bytes), true
+}
+
+// headSHA returns the current repo HEAD short SHA.
+func (s *EntitySynthesizer) headSHA(ctx context.Context) (string, error) {
+	repo := s.worker.Repo()
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	out, err := repo.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, out)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// briefPath resolves the canonical wiki path for an entity brief.
+func briefPath(kind EntityKind, slug string) string {
+	return filepath.ToSlash(filepath.Join("team", string(kind), slug+".md"))
+}
+
+// renderFactsForPrompt formats the new facts as a bulleted list the LLM
+// can read without ambiguity.
+func renderFactsForPrompt(facts []Fact) string {
+	if len(facts) == 0 {
+		return "_No new facts._"
+	}
+	var b strings.Builder
+	for _, f := range facts {
+		ts := f.CreatedAt.UTC().Format(time.RFC3339)
+		line := fmt.Sprintf("- [%s] recorded by %s", ts, f.RecordedBy)
+		if f.SourcePath != "" {
+			line += fmt.Sprintf(" (source: %s)", f.SourcePath)
+		}
+		line += ": " + strings.ReplaceAll(f.Text, "\n", " ")
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// --- frontmatter helpers ---------------------------------------------------
+
+// synthesisFrontmatterPattern captures the 3 keys we own. Other keys
+// (title:, tags:, ...) are preserved untouched.
+var (
+	lastSHAKey = "last_synthesized_sha"
+	lastTSKey  = "last_synthesized_ts"
+	factCntKey = "fact_count_at_synthesis"
+)
+
+var frontmatterKeyLine = regexp.MustCompile(`(?m)^([a-zA-Z0-9_]+):\s*(.*)$`)
+
+// parseSynthesisFrontmatter extracts the synthesis keys from the existing
+// brief. Missing keys yield zero values.
+func parseSynthesisFrontmatter(brief string) (sha string, ts time.Time, factCount int) {
+	if !strings.HasPrefix(brief, "---\n") {
+		return "", time.Time{}, 0
+	}
+	rest := brief[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return "", time.Time{}, 0
+	}
+	block := rest[:end]
+	for _, line := range strings.Split(block, "\n") {
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		key := m[1]
+		val := strings.TrimSpace(m[2])
+		switch key {
+		case lastSHAKey:
+			sha = val
+		case lastTSKey:
+			if parsed, err := time.Parse(time.RFC3339, val); err == nil {
+				ts = parsed
+			}
+		case factCntKey:
+			factCount = parseInt(val)
+		}
+	}
+	return sha, ts, factCount
+}
+
+// applySynthesisFrontmatter merges the three synthesis keys onto the LLM
+// output. When the output already has a frontmatter block we update those
+// keys in-place; otherwise we prepend a fresh block that also preserves
+// any non-synthesis keys from the prior brief.
+func applySynthesisFrontmatter(body, headSHA string, ts time.Time, factCount int, prior string) string {
+	tsStr := ts.UTC().Format(time.RFC3339)
+	ours := map[string]string{
+		lastSHAKey: headSHA,
+		lastTSKey:  tsStr,
+		factCntKey: fmt.Sprintf("%d", factCount),
+	}
+
+	preserved := preservedFrontmatterKeys(prior)
+
+	hasFrontmatter := strings.HasPrefix(body, "---\n")
+	if !hasFrontmatter {
+		var b strings.Builder
+		b.WriteString("---\n")
+		for _, key := range orderedFrontmatterKeys() {
+			if v, ok := ours[key]; ok {
+				b.WriteString(key)
+				b.WriteString(": ")
+				b.WriteString(v)
+				b.WriteString("\n")
+			}
+		}
+		for _, kv := range preserved {
+			// Skip keys we already wrote ourselves.
+			if _, mine := ours[kv.key]; mine {
+				continue
+			}
+			b.WriteString(kv.key)
+			b.WriteString(": ")
+			b.WriteString(kv.val)
+			b.WriteString("\n")
+		}
+		b.WriteString("---\n\n")
+		b.WriteString(body)
+		return b.String()
+	}
+
+	// Body HAS frontmatter. Rewrite only our keys + append missing ones.
+	rest := body[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		// Malformed — fall back to prepend path.
+		return applySynthesisFrontmatter(stripFrontmatter(body), headSHA, ts, factCount, prior)
+	}
+	block := rest[:end]
+	tail := rest[end+len("\n---"):]
+	lines := strings.Split(block, "\n")
+	seen := map[string]bool{}
+	for i, line := range lines {
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		key := m[1]
+		if v, ok := ours[key]; ok {
+			lines[i] = key + ": " + v
+			seen[key] = true
+		}
+	}
+	for _, key := range orderedFrontmatterKeys() {
+		if !seen[key] {
+			lines = append(lines, key+": "+ours[key])
+		}
+	}
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.WriteString(strings.Join(lines, "\n"))
+	b.WriteString("\n---")
+	b.WriteString(tail)
+	return b.String()
+}
+
+// orderedFrontmatterKeys returns the synthesis keys in a deterministic
+// order so commits don't churn on reorderings.
+func orderedFrontmatterKeys() []string {
+	return []string{lastSHAKey, lastTSKey, factCntKey}
+}
+
+type frontmatterKV struct {
+	key string
+	val string
+}
+
+// preservedFrontmatterKeys lifts non-synthesis keys from a prior brief so
+// we don't lose custom frontmatter when we rewrite from scratch.
+func preservedFrontmatterKeys(prior string) []frontmatterKV {
+	if !strings.HasPrefix(prior, "---\n") {
+		return nil
+	}
+	rest := prior[len("---\n"):]
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return nil
+	}
+	block := rest[:end]
+	var out []frontmatterKV
+	for _, line := range strings.Split(block, "\n") {
+		m := frontmatterKeyLine.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		key := m[1]
+		switch key {
+		case lastSHAKey, lastTSKey, factCntKey:
+			continue
+		}
+		out = append(out, frontmatterKV{key: key, val: strings.TrimSpace(m[2])})
+	}
+	return out
+}
+
+func parseInt(s string) int {
+	n := 0
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return 0
+		}
+		n = n*10 + int(r-'0')
+	}
+	return n
+}

--- a/internal/team/entity_synthesizer.go
+++ b/internal/team/entity_synthesizer.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -286,13 +285,14 @@ func (s *EntitySynthesizer) runJob(ctx context.Context, job SynthesisJob) {
 		s.mu.Lock()
 		delete(s.inflight, key)
 		needsFollowup := s.queued[key]
+		// CRITICAL: drop the queued flag before the follow-up goroutine
+		// calls EnqueueSynthesis — otherwise it sees queued=true and
+		// silently coalesces its own call, leaving the queue empty.
+		delete(s.queued, key)
 		running := s.running
 		s.mu.Unlock()
-		// A fact landed during this run. Enqueue a follow-up IF the
-		// synthesizer is still running — Stop() may have raced with the
-		// append, and we don't want to block on a closed channel.
 		if needsFollowup && running {
-			// Use a background context for the re-schedule — the caller's
+			// Use a background goroutine for the re-schedule — the caller's
 			// context has already returned. The follow-up will run on the
 			// next drain iteration.
 			go func() {
@@ -318,25 +318,26 @@ func (s *EntitySynthesizer) runJob(ctx context.Context, job SynthesisJob) {
 func (s *EntitySynthesizer) synthesize(ctx context.Context, job SynthesisJob) error {
 	relBrief := briefPath(job.Kind, job.Slug)
 	existingBrief, hadBrief := s.readBrief(relBrief)
-	lastSHA, _, _ := parseSynthesisFrontmatter(existingBrief)
+	_, _, lastFactCount := parseSynthesisFrontmatter(existingBrief)
 
 	facts, err := s.factLog.List(job.Kind, job.Slug)
 	if err != nil {
 		return fmt.Errorf("list facts: %w", err)
 	}
-	// Facts since last synthesis.
-	newFacts := facts
-	if lastSHA != "" {
-		if ts, tsErr := s.factLog.commitTimestamp(ctx, lastSHA); tsErr == nil {
-			newFacts = facts[:0:0]
-			for _, f := range facts {
-				if f.CreatedAt.After(ts) {
-					newFacts = append(newFacts, f)
-				}
-			}
-		}
+	// Use fact-count bookkeeping (not sha/timestamp) to determine what's
+	// new. Commit timestamps have second-precision and fact appends can
+	// overlap with brief commits; fact_count_at_synthesis is monotonic and
+	// robust to those races. facts is in newest-first order; "new" means
+	// the first (len(facts) - lastFactCount) entries.
+	newCount := len(facts) - lastFactCount
+	if newCount < 0 {
+		newCount = 0
 	}
-	if len(newFacts) == 0 && hadBrief {
+	newFacts := facts
+	if newCount < len(facts) {
+		newFacts = facts[:newCount]
+	}
+	if newCount == 0 && hadBrief {
 		return ErrSynthesisNoNewFacts
 	}
 	if len(facts) == 0 && !hadBrief {
@@ -457,173 +458,4 @@ func renderFactsForPrompt(facts []Fact) string {
 	return b.String()
 }
 
-// --- frontmatter helpers ---------------------------------------------------
-
-// synthesisFrontmatterPattern captures the 3 keys we own. Other keys
-// (title:, tags:, ...) are preserved untouched.
-var (
-	lastSHAKey = "last_synthesized_sha"
-	lastTSKey  = "last_synthesized_ts"
-	factCntKey = "fact_count_at_synthesis"
-)
-
-var frontmatterKeyLine = regexp.MustCompile(`(?m)^([a-zA-Z0-9_]+):\s*(.*)$`)
-
-// parseSynthesisFrontmatter extracts the synthesis keys from the existing
-// brief. Missing keys yield zero values.
-func parseSynthesisFrontmatter(brief string) (sha string, ts time.Time, factCount int) {
-	if !strings.HasPrefix(brief, "---\n") {
-		return "", time.Time{}, 0
-	}
-	rest := brief[len("---\n"):]
-	end := strings.Index(rest, "\n---")
-	if end < 0 {
-		return "", time.Time{}, 0
-	}
-	block := rest[:end]
-	for _, line := range strings.Split(block, "\n") {
-		m := frontmatterKeyLine.FindStringSubmatch(line)
-		if m == nil {
-			continue
-		}
-		key := m[1]
-		val := strings.TrimSpace(m[2])
-		switch key {
-		case lastSHAKey:
-			sha = val
-		case lastTSKey:
-			if parsed, err := time.Parse(time.RFC3339, val); err == nil {
-				ts = parsed
-			}
-		case factCntKey:
-			factCount = parseInt(val)
-		}
-	}
-	return sha, ts, factCount
-}
-
-// applySynthesisFrontmatter merges the three synthesis keys onto the LLM
-// output. When the output already has a frontmatter block we update those
-// keys in-place; otherwise we prepend a fresh block that also preserves
-// any non-synthesis keys from the prior brief.
-func applySynthesisFrontmatter(body, headSHA string, ts time.Time, factCount int, prior string) string {
-	tsStr := ts.UTC().Format(time.RFC3339)
-	ours := map[string]string{
-		lastSHAKey: headSHA,
-		lastTSKey:  tsStr,
-		factCntKey: fmt.Sprintf("%d", factCount),
-	}
-
-	preserved := preservedFrontmatterKeys(prior)
-
-	hasFrontmatter := strings.HasPrefix(body, "---\n")
-	if !hasFrontmatter {
-		var b strings.Builder
-		b.WriteString("---\n")
-		for _, key := range orderedFrontmatterKeys() {
-			if v, ok := ours[key]; ok {
-				b.WriteString(key)
-				b.WriteString(": ")
-				b.WriteString(v)
-				b.WriteString("\n")
-			}
-		}
-		for _, kv := range preserved {
-			// Skip keys we already wrote ourselves.
-			if _, mine := ours[kv.key]; mine {
-				continue
-			}
-			b.WriteString(kv.key)
-			b.WriteString(": ")
-			b.WriteString(kv.val)
-			b.WriteString("\n")
-		}
-		b.WriteString("---\n\n")
-		b.WriteString(body)
-		return b.String()
-	}
-
-	// Body HAS frontmatter. Rewrite only our keys + append missing ones.
-	rest := body[len("---\n"):]
-	end := strings.Index(rest, "\n---")
-	if end < 0 {
-		// Malformed — fall back to prepend path.
-		return applySynthesisFrontmatter(stripFrontmatter(body), headSHA, ts, factCount, prior)
-	}
-	block := rest[:end]
-	tail := rest[end+len("\n---"):]
-	lines := strings.Split(block, "\n")
-	seen := map[string]bool{}
-	for i, line := range lines {
-		m := frontmatterKeyLine.FindStringSubmatch(line)
-		if m == nil {
-			continue
-		}
-		key := m[1]
-		if v, ok := ours[key]; ok {
-			lines[i] = key + ": " + v
-			seen[key] = true
-		}
-	}
-	for _, key := range orderedFrontmatterKeys() {
-		if !seen[key] {
-			lines = append(lines, key+": "+ours[key])
-		}
-	}
-	var b strings.Builder
-	b.WriteString("---\n")
-	b.WriteString(strings.Join(lines, "\n"))
-	b.WriteString("\n---")
-	b.WriteString(tail)
-	return b.String()
-}
-
-// orderedFrontmatterKeys returns the synthesis keys in a deterministic
-// order so commits don't churn on reorderings.
-func orderedFrontmatterKeys() []string {
-	return []string{lastSHAKey, lastTSKey, factCntKey}
-}
-
-type frontmatterKV struct {
-	key string
-	val string
-}
-
-// preservedFrontmatterKeys lifts non-synthesis keys from a prior brief so
-// we don't lose custom frontmatter when we rewrite from scratch.
-func preservedFrontmatterKeys(prior string) []frontmatterKV {
-	if !strings.HasPrefix(prior, "---\n") {
-		return nil
-	}
-	rest := prior[len("---\n"):]
-	end := strings.Index(rest, "\n---")
-	if end < 0 {
-		return nil
-	}
-	block := rest[:end]
-	var out []frontmatterKV
-	for _, line := range strings.Split(block, "\n") {
-		m := frontmatterKeyLine.FindStringSubmatch(line)
-		if m == nil {
-			continue
-		}
-		key := m[1]
-		switch key {
-		case lastSHAKey, lastTSKey, factCntKey:
-			continue
-		}
-		out = append(out, frontmatterKV{key: key, val: strings.TrimSpace(m[2])})
-	}
-	return out
-}
-
-func parseInt(s string) int {
-	n := 0
-	for _, r := range s {
-		if r < '0' || r > '9' {
-			return 0
-		}
-		n = n*10 + int(r-'0')
-	}
-	return n
-}
+// Frontmatter helpers live in entity_frontmatter.go.

--- a/internal/team/entity_synthesizer_test.go
+++ b/internal/team/entity_synthesizer_test.go
@@ -13,9 +13,9 @@ import (
 
 // entityPublisherStub captures SSE events for assertions.
 type entityPublisherStub struct {
-	mu       sync.Mutex
-	briefs   []EntityBriefSynthesizedEvent
-	facts    []EntityFactRecordedEvent
+	mu     sync.Mutex
+	briefs []EntityBriefSynthesizedEvent
+	facts  []EntityFactRecordedEvent
 }
 
 func (p *entityPublisherStub) PublishEntityBriefSynthesized(evt EntityBriefSynthesizedEvent) {

--- a/internal/team/entity_synthesizer_test.go
+++ b/internal/team/entity_synthesizer_test.go
@@ -1,0 +1,317 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// entityPublisherStub captures SSE events for assertions.
+type entityPublisherStub struct {
+	mu       sync.Mutex
+	briefs   []EntityBriefSynthesizedEvent
+	facts    []EntityFactRecordedEvent
+}
+
+func (p *entityPublisherStub) PublishEntityBriefSynthesized(evt EntityBriefSynthesizedEvent) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.briefs = append(p.briefs, evt)
+}
+func (p *entityPublisherStub) PublishEntityFactRecorded(evt EntityFactRecordedEvent) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.facts = append(p.facts, evt)
+}
+func (p *entityPublisherStub) briefCount() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.briefs)
+}
+
+// newSynthFixture wires the full stack: repo + worker + fact log + synth.
+// The llmStub is injected via SynthesizerConfig.LLMCall.
+func newSynthFixture(t *testing.T, llmStub func(ctx context.Context, sys, user string) (string, error)) (
+	*EntitySynthesizer, *FactLog, *WikiWorker, *entityPublisherStub, func(),
+) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	worker := NewWikiWorker(repo, noopPublisher{})
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	factLog := NewFactLog(worker)
+	pub := &entityPublisherStub{}
+	synth := NewEntitySynthesizer(worker, factLog, pub, SynthesizerConfig{
+		Threshold: 2,
+		Timeout:   5 * time.Second,
+		LLMCall:   llmStub,
+	})
+	synth.Start(context.Background())
+	return synth, factLog, worker, pub, func() {
+		synth.Stop()
+		cancel()
+		worker.Stop()
+	}
+}
+
+func TestSynthesizer_HappyPathWritesBriefWithFrontmatter(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "# Nazz\n\nUpdated body with facts.\n", nil
+	}
+	synth, factLog, worker, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	_, _ = factLog.Append(ctx, EntityKindPeople, "nazz", "Ex-HubSpot.", "", "pm")
+	_, _ = factLog.Append(ctx, EntityKindPeople, "nazz", "Loves big swings.", "", "eng")
+
+	if _, err := synth.EnqueueSynthesis(EntityKindPeople, "nazz", "pm"); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	waitForBriefCount(t, pub, 1, 3*time.Second)
+
+	// Verify file exists with frontmatter keys.
+	briefBytes, err := readArticle(worker.Repo(), "team/people/nazz.md")
+	if err != nil {
+		t.Fatalf("read brief: %v", err)
+	}
+	body := string(briefBytes)
+	if !strings.HasPrefix(body, "---\n") {
+		t.Fatalf("brief missing frontmatter: %s", body)
+	}
+	for _, key := range []string{lastSHAKey, lastTSKey, factCntKey} {
+		if !strings.Contains(body, key+":") {
+			t.Errorf("frontmatter missing key %q: %s", key, body)
+		}
+	}
+	if !strings.Contains(body, "Updated body with facts") {
+		t.Errorf("brief missing LLM body: %s", body)
+	}
+}
+
+func TestSynthesizer_FreshBriefCreatedWhenNoneExists(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "# Acme\n\nNew brief from scratch.\n", nil
+	}
+	synth, factLog, worker, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	_, _ = factLog.Append(ctx, EntityKindCompanies, "acme", "Founded 1999.", "", "pm")
+
+	_, _ = synth.EnqueueSynthesis(EntityKindCompanies, "acme", "pm")
+	waitForBriefCount(t, pub, 1, 3*time.Second)
+
+	bytes, err := readArticle(worker.Repo(), "team/companies/acme.md")
+	if err != nil {
+		t.Fatalf("read brief: %v", err)
+	}
+	if !strings.Contains(string(bytes), "New brief from scratch") {
+		t.Errorf("missing body")
+	}
+}
+
+func TestSynthesizer_NoNewFactsIsIdempotentSkip(t *testing.T) {
+	var calls atomic.Int32
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		calls.Add(1)
+		return "# Updated\n\nok\n", nil
+	}
+	synth, factLog, _, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	_, _ = factLog.Append(ctx, EntityKindPeople, "pm", "One fact.", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindPeople, "pm", "pm")
+	waitForBriefCount(t, pub, 1, 3*time.Second)
+
+	// Second synth with no new facts should skip — the commit timestamp
+	// covers all current facts.
+	waitUntilNextSecond(t)
+	_, _ = synth.EnqueueSynthesis(EntityKindPeople, "pm", "pm")
+	// Give the worker a moment to drain.
+	time.Sleep(500 * time.Millisecond)
+
+	if pub.briefCount() != 1 {
+		t.Fatalf("expected 1 brief commit; got %d", pub.briefCount())
+	}
+}
+
+func TestSynthesizer_LLMErrorPropagates(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "", fmt.Errorf("llm boom")
+	}
+	synth, factLog, _, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	_, _ = factLog.Append(ctx, EntityKindPeople, "x", "one", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindPeople, "x", "pm")
+	// Brief should NOT be published because synth failed.
+	time.Sleep(500 * time.Millisecond)
+	if pub.briefCount() != 0 {
+		t.Fatalf("expected no brief on llm error; got %d", pub.briefCount())
+	}
+}
+
+func TestSynthesizer_TimeoutTreatedAsError(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		<-ctx.Done()
+		return "", ctx.Err()
+	}
+	synth, factLog, _, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	// Force a tight timeout.
+	synth.cfg.Timeout = 50 * time.Millisecond
+
+	ctx := context.Background()
+	_, _ = factLog.Append(ctx, EntityKindPeople, "y", "one", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindPeople, "y", "pm")
+	time.Sleep(600 * time.Millisecond)
+	if pub.briefCount() != 0 {
+		t.Fatalf("expected no brief on timeout")
+	}
+}
+
+func TestSynthesizer_EmptyOutputRejected(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "   ", nil
+	}
+	synth, factLog, _, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+	_, _ = factLog.Append(ctx, EntityKindPeople, "z", "one", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindPeople, "z", "pm")
+	time.Sleep(500 * time.Millisecond)
+	if pub.briefCount() != 0 {
+		t.Fatalf("expected no brief on empty output")
+	}
+}
+
+func TestSynthesizer_TooLargeOutputRejected(t *testing.T) {
+	big := strings.Repeat("x", MaxBriefSize+1)
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return big, nil
+	}
+	synth, factLog, _, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+	_, _ = factLog.Append(ctx, EntityKindPeople, "huge", "one", "", "pm")
+	_, _ = synth.EnqueueSynthesis(EntityKindPeople, "huge", "pm")
+	time.Sleep(500 * time.Millisecond)
+	if pub.briefCount() != 0 {
+		t.Fatalf("expected no brief on oversized output")
+	}
+}
+
+func TestSynthesizer_ContradictionPhrasePassesThrough(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		// Echo a brief that includes a contradiction callout — verifies
+		// our commit path doesn't strip the phrase.
+		return "# Entity\n\n**Contradiction:** fact A says X, fact B says Y.\n", nil
+	}
+	synth, factLog, worker, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	_, _ = factLog.Append(ctx, EntityKindPeople, "dup", "Joined 2024.", "", "pm")
+	_, _ = factLog.Append(ctx, EntityKindPeople, "dup", "Joined 2025.", "", "eng")
+	_, _ = synth.EnqueueSynthesis(EntityKindPeople, "dup", "pm")
+	waitForBriefCount(t, pub, 1, 3*time.Second)
+
+	bytes, err := readArticle(worker.Repo(), "team/people/dup.md")
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(bytes), "**Contradiction:**") {
+		t.Errorf("contradiction callout lost: %s", string(bytes))
+	}
+}
+
+func TestSynthesizer_DebounceCoalescesInflightFollowups(t *testing.T) {
+	var running atomic.Int32
+	hold := make(chan struct{})
+	release := make(chan struct{})
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		c := running.Add(1)
+		if c == 1 {
+			// Signal we're running, then wait for release.
+			close(hold)
+			<-release
+		}
+		return "# Ok\n\nbody\n", nil
+	}
+	synth, factLog, _, pub, teardown := newSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	_, _ = factLog.Append(ctx, EntityKindPeople, "coalesce", "f1", "", "pm")
+	if _, err := synth.EnqueueSynthesis(EntityKindPeople, "coalesce", "pm"); err != nil {
+		t.Fatalf("enqueue 1: %v", err)
+	}
+	<-hold // synth #1 is running
+
+	// While synth #1 is blocked, append new facts so the follow-up has
+	// something to do — and fire 5 enqueue calls. All five should coalesce
+	// into exactly ONE follow-up.
+	waitUntilNextSecond(t)
+	_, _ = factLog.Append(ctx, EntityKindPeople, "coalesce", "f2", "", "pm")
+	_, _ = factLog.Append(ctx, EntityKindPeople, "coalesce", "f3", "", "pm")
+	for i := 0; i < 5; i++ {
+		_, _ = synth.EnqueueSynthesis(EntityKindPeople, "coalesce", "pm")
+	}
+
+	// Release synth #1.
+	close(release)
+
+	// Wait for exactly 2 brief publications (one original + one follow-up).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if pub.briefCount() >= 2 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	// Give any runaway extras a chance to happen then assert.
+	time.Sleep(400 * time.Millisecond)
+	if pub.briefCount() != 2 {
+		t.Fatalf("expected exactly 2 brief syntheses (original + 1 coalesced follow-up); got %d", pub.briefCount())
+	}
+}
+
+func TestSynthesizer_StopPreventsNewJobs(t *testing.T) {
+	synth, factLog, _, _, teardown := newSynthFixture(t, func(context.Context, string, string) (string, error) {
+		return "# Ok\n\nbody\n", nil
+	})
+	defer teardown()
+	synth.Stop()
+
+	_, _ = factLog.Append(context.Background(), EntityKindPeople, "stopped", "x", "", "pm")
+	if _, err := synth.EnqueueSynthesis(EntityKindPeople, "stopped", "pm"); err != ErrSynthesizerStopped {
+		t.Fatalf("expected ErrSynthesizerStopped; got %v", err)
+	}
+}
+
+// waitForBriefCount polls the publisher stub until the brief count meets n
+// or the deadline hits.
+func waitForBriefCount(t *testing.T, pub *entityPublisherStub, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pub.briefCount() >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d brief events; got %d", n, pub.briefCount())
+}

--- a/internal/team/wiki_worker.go
+++ b/internal/team/wiki_worker.go
@@ -82,7 +82,11 @@ type wikiWriteRequest struct {
 	// Repo.Commit. Same serialization primitive; different target subtree
 	// and no team-wiki index regen. See notebook_worker.go.
 	IsNotebook bool
-	ReplyCh    chan wikiWriteResult
+	// IsEntityFact routes the request to Repo.CommitEntityFact. Used for
+	// the v1.2 append-only fact log at team/entities/{kind}-{slug}.facts.jsonl
+	// — same serialization primitive, non-.md extension, no index regen.
+	IsEntityFact bool
+	ReplyCh      chan wikiWriteResult
 }
 
 // wikiWriteResult is the worker's reply for a single request.
@@ -207,7 +211,9 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 		n   int
 		err error
 	)
-	if req.IsNotebook {
+	if req.IsEntityFact {
+		sha, n, err = w.repo.CommitEntityFact(writeCtx, req.Slug, req.Path, req.Content, req.CommitMsg)
+	} else if req.IsNotebook {
 		// Notebook writes do NOT regen the team wiki index. Commit target is
 		// agents/{slug}/notebook/... — scoped to the author.
 		sha, n, err = w.repo.CommitNotebook(writeCtx, req.Slug, req.Path, req.Content, req.Mode, req.CommitMsg)
@@ -225,7 +231,11 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 	req.ReplyCh <- wikiWriteResult{SHA: sha, BytesWritten: n}
 
 	ts := time.Now().UTC().Format(time.RFC3339)
-	if req.IsNotebook {
+	switch {
+	case req.IsEntityFact:
+		// Entity fact writes have their own SSE event (entity:fact_recorded)
+		// published by the broker handler, not by the worker. No-op here.
+	case req.IsNotebook:
 		if nbPub, ok := w.publisher.(notebookEventPublisher); ok {
 			nbPub.PublishNotebookEvent(notebookWriteEvent{
 				Slug:      req.Slug,
@@ -234,7 +244,7 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 				Timestamp: ts,
 			})
 		}
-	} else {
+	default:
 		w.publisher.PublishWikiEvent(wikiWriteEvent{
 			Path:       req.Path,
 			CommitSHA:  sha,
@@ -278,6 +288,37 @@ func (w *WikiWorker) maybeScheduleBackup(ctx context.Context) {
 // diagnostics and tests.
 func (w *WikiWorker) QueueLength() int {
 	return len(w.requests)
+}
+
+// EnqueueEntityFact submits a fact-log append to the shared wiki queue.
+// The path must be team/entities/{kind}-{slug}.facts.jsonl and is routed
+// to Repo.CommitEntityFact (which does NOT regen the wiki index).
+func (w *WikiWorker) EnqueueEntityFact(ctx context.Context, slug, path, content, commitMsg string) (string, int, error) {
+	if !w.running.Load() {
+		return "", 0, ErrWorkerStopped
+	}
+	req := wikiWriteRequest{
+		Slug:         slug,
+		Path:         path,
+		Content:      content,
+		Mode:         "replace",
+		CommitMsg:    commitMsg,
+		IsEntityFact: true,
+		ReplyCh:      make(chan wikiWriteResult, 1),
+	}
+	select {
+	case w.requests <- req:
+	default:
+		return "", 0, ErrQueueSaturated
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, wikiWriteTimeout)
+	defer cancel()
+	select {
+	case result := <-req.ReplyCh:
+		return result.SHA, result.BytesWritten, result.Err
+	case <-waitCtx.Done():
+		return "", 0, fmt.Errorf("wiki: entity-fact write timed out after %s", wikiWriteTimeout)
+	}
 }
 
 // Repo returns the underlying wiki repo — used by read-side broker handlers

--- a/internal/teammcp/entity_tools.go
+++ b/internal/teammcp/entity_tools.go
@@ -120,4 +120,3 @@ func handleEntityBriefSynthesize(ctx context.Context, _ *mcp.CallToolRequest, ar
 	payload, _ := json.Marshal(result)
 	return textResult(string(payload)), nil, nil
 }
-

--- a/internal/teammcp/entity_tools.go
+++ b/internal/teammcp/entity_tools.go
@@ -1,0 +1,123 @@
+package teammcp
+
+// entity_tools.go defines the two v1.2 entity-brief MCP tools:
+//
+//   entity_fact_record     — record one fact about an entity (person, company, customer)
+//   entity_brief_synthesize — explicitly request a brief refresh
+//
+// Registered only when WUPHF_MEMORY_BACKEND=markdown, matching the wiki and
+// notebook gates — the entity brief surface rides on the same markdown git
+// substrate, so it has the same backend precondition.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TeamEntityFactRecordArgs is the contract for entity_fact_record.
+type TeamEntityFactRecordArgs struct {
+	MySlug     string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	EntityKind string `json:"entity_kind" jsonschema:"One of: people | companies | customers"`
+	EntitySlug string `json:"entity_slug" jsonschema:"Kebab-case slug matching the canonical wiki file (e.g. team/people/nazz.md -> nazz)"`
+	Fact       string `json:"fact" jsonschema:"One atomic observation. Max 4000 chars. Never invent or generalise — record only what you directly observed."`
+	SourcePath string `json:"source_path,omitempty" jsonschema:"Optional wiki/notebook path this fact came from (must start with agents/ or team/)."`
+}
+
+// TeamEntityBriefSynthesizeArgs is the contract for entity_brief_synthesize.
+type TeamEntityBriefSynthesizeArgs struct {
+	MySlug     string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	EntityKind string `json:"entity_kind" jsonschema:"One of: people | companies | customers"`
+	EntitySlug string `json:"entity_slug" jsonschema:"Kebab-case slug."`
+}
+
+// registerEntityTools attaches the two entity tools to the MCP server.
+// Caller (registerSharedMemoryTools, markdown branch) is responsible for
+// gating on WUPHF_MEMORY_BACKEND.
+func registerEntityTools(server *mcp.Server) {
+	mcp.AddTool(server, officeWriteTool(
+		"entity_fact_record",
+		"Record one atomic fact about an entity (person, company, or customer). The broker appends to an append-only fact log and — if enough new facts have accumulated since the last synthesis — triggers a background rewrite of that entity's brief. Facts are single observations, never interpretations. Wrong facts get counter-facts, not deletions.",
+	), handleEntityFactRecord)
+	mcp.AddTool(server, officeWriteTool(
+		"entity_brief_synthesize",
+		"Explicitly request a fresh synthesis of an entity brief. Runs as a broker-level background job (no agent turn consumed). Use this when you've just recorded several facts and want the canonical brief updated now instead of at the next threshold.",
+	), handleEntityBriefSynthesize)
+}
+
+func handleEntityFactRecord(ctx context.Context, _ *mcp.CallToolRequest, args TeamEntityFactRecordArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	kind := strings.TrimSpace(args.EntityKind)
+	entitySlug := strings.TrimSpace(args.EntitySlug)
+	fact := strings.TrimSpace(args.Fact)
+	if kind == "" {
+		return toolError(fmt.Errorf("entity_kind is required")), nil, nil
+	}
+	if entitySlug == "" {
+		return toolError(fmt.Errorf("entity_slug is required")), nil, nil
+	}
+	if fact == "" {
+		return toolError(fmt.Errorf("fact is required")), nil, nil
+	}
+	source := strings.TrimSpace(args.SourcePath)
+	if source != "" && !(strings.HasPrefix(source, "agents/") || strings.HasPrefix(source, "team/")) {
+		return toolError(fmt.Errorf("source_path must start with agents/ or team/ when provided; got %q", source)), nil, nil
+	}
+
+	var result struct {
+		FactID           string `json:"fact_id"`
+		FactCount        int    `json:"fact_count"`
+		ThresholdCrossed bool   `json:"threshold_crossed"`
+	}
+	body := map[string]any{
+		"entity_kind": kind,
+		"entity_slug": entitySlug,
+		"fact":        fact,
+		"recorded_by": slug,
+	}
+	if source != "" {
+		body["source_path"] = source
+	}
+	if err := brokerPostJSON(ctx, "/entity/fact", body, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	payload, _ := json.Marshal(result)
+	return textResult(string(payload)), nil, nil
+}
+
+func handleEntityBriefSynthesize(ctx context.Context, _ *mcp.CallToolRequest, args TeamEntityBriefSynthesizeArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	kind := strings.TrimSpace(args.EntityKind)
+	entitySlug := strings.TrimSpace(args.EntitySlug)
+	if kind == "" {
+		return toolError(fmt.Errorf("entity_kind is required")), nil, nil
+	}
+	if entitySlug == "" {
+		return toolError(fmt.Errorf("entity_slug is required")), nil, nil
+	}
+
+	var result struct {
+		SynthesisID uint64 `json:"synthesis_id"`
+		QueuedAt    string `json:"queued_at"`
+	}
+	body := map[string]any{
+		"entity_kind": kind,
+		"entity_slug": entitySlug,
+		"actor_slug":  slug,
+	}
+	if err := brokerPostJSON(ctx, "/entity/brief/synthesize", body, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	payload, _ := json.Marshal(result)
+	return textResult(string(payload)), nil, nil
+}
+

--- a/internal/teammcp/entity_tools_test.go
+++ b/internal/teammcp/entity_tools_test.go
@@ -1,0 +1,157 @@
+package teammcp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestEntityToolsRegisteredOnlyInMarkdownBackend(t *testing.T) {
+	toolNames := []string{"entity_fact_record", "entity_brief_synthesize"}
+	cases := []struct {
+		backend  string
+		mustHave bool
+	}{
+		{"markdown", true},
+		{"nex", false},
+		{"gbrain", false},
+		{"none", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.backend, func(t *testing.T) {
+			t.Setenv("WUPHF_MEMORY_BACKEND", tc.backend)
+			names := listRegisteredTools(t, "general", false)
+			for _, tool := range toolNames {
+				has := slices.Contains(names, tool)
+				if tc.mustHave && !has {
+					t.Errorf("backend=%s missing tool %q; got %v", tc.backend, tool, names)
+				}
+				if !tc.mustHave && has {
+					t.Errorf("backend=%s unexpectedly has tool %q", tc.backend, tool)
+				}
+			}
+		})
+	}
+}
+
+func TestEntityToolsRegisteredInOneOnOne(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", "markdown")
+	names := listRegisteredTools(t, "dm-ceo", true)
+	for _, want := range []string{"entity_fact_record", "entity_brief_synthesize"} {
+		if !slices.Contains(names, want) {
+			t.Errorf("1:1 mode missing tool %q", want)
+		}
+	}
+}
+
+func TestHandleEntityFactRecord_HappyPath(t *testing.T) {
+	var seenBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &seenBody)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"fact_id":           "f-123",
+			"fact_count":        3,
+			"threshold_crossed": false,
+		})
+	}))
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+
+	res, _, err := handleEntityFactRecord(context.Background(), nil, TeamEntityFactRecordArgs{
+		EntityKind: "people",
+		EntitySlug: "nazz",
+		Fact:       "Ex-HubSpot",
+		SourcePath: "agents/pm/notebook/x.md",
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("tool error: %s", toolErrorText(res))
+	}
+	if seenBody["entity_slug"] != "nazz" || seenBody["fact"] != "Ex-HubSpot" {
+		t.Fatalf("body mismatch: %+v", seenBody)
+	}
+	if seenBody["recorded_by"] != "pm" {
+		t.Errorf("recorded_by=%v", seenBody["recorded_by"])
+	}
+	if !strings.Contains(toolErrorText(res), "f-123") {
+		// The text result is the JSON envelope.
+		out := toolErrorText(res)
+		if !strings.Contains(out, "f-123") {
+			t.Errorf("missing fact_id in output: %s", out)
+		}
+	}
+}
+
+func TestHandleEntityFactRecord_ValidationErrors(t *testing.T) {
+	// No broker URL needed — errors fire before any HTTP call.
+	cases := []struct {
+		name string
+		args TeamEntityFactRecordArgs
+	}{
+		{"missing kind", TeamEntityFactRecordArgs{EntitySlug: "x", Fact: "y"}},
+		{"missing slug", TeamEntityFactRecordArgs{EntityKind: "people", Fact: "y"}},
+		{"missing fact", TeamEntityFactRecordArgs{EntityKind: "people", EntitySlug: "x"}},
+		{"bad source path", TeamEntityFactRecordArgs{EntityKind: "people", EntitySlug: "x", Fact: "y", SourcePath: "../etc/passwd"}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("WUPHF_AGENT_SLUG", "pm")
+			res, _, _ := handleEntityFactRecord(context.Background(), nil, tc.args)
+			if !isToolError(res) {
+				t.Fatalf("expected tool error; got: %s", toolErrorText(res))
+			}
+		})
+	}
+}
+
+func TestHandleEntityBriefSynthesize_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"synthesis_id": 42,
+			"queued_at":    "2026-04-20T12:00:00Z",
+		})
+	}))
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+
+	res, _, err := handleEntityBriefSynthesize(context.Background(), nil, TeamEntityBriefSynthesizeArgs{
+		EntityKind: "companies",
+		EntitySlug: "acme",
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("tool error: %s", toolErrorText(res))
+	}
+	if !strings.Contains(toolErrorText(res), "42") {
+		t.Errorf("missing synthesis_id: %s", toolErrorText(res))
+	}
+}
+
+func TestHandleEntityBriefSynthesize_Validation(t *testing.T) {
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+	cases := []TeamEntityBriefSynthesizeArgs{
+		{EntitySlug: "x"},
+		{EntityKind: "people"},
+	}
+	for i, args := range cases {
+		res, _, _ := handleEntityBriefSynthesize(context.Background(), nil, args)
+		if !isToolError(res) {
+			t.Fatalf("case %d expected tool error; got %s", i, toolErrorText(res))
+		}
+	}
+}
+

--- a/internal/teammcp/entity_tools_test.go
+++ b/internal/teammcp/entity_tools_test.go
@@ -154,4 +154,3 @@ func TestHandleEntityBriefSynthesize_Validation(t *testing.T) {
 		}
 	}
 }
-

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -469,6 +469,9 @@ func registerSharedMemoryTools(server *mcp.Server) {
 		// Notebook tools ride on the same markdown backend. Registered here
 		// so they share the WUPHF_MEMORY_BACKEND gate with team_wiki_*.
 		registerNotebookTools(server)
+		// Entity brief tools (v1.2) — fact log + broker-level synthesis.
+		// Same backend gate: entity briefs live in the wiki subtree.
+		registerEntityTools(server)
 	case "none":
 		// Nothing — user explicitly disabled shared memory.
 	default:

--- a/web/src/api/entity.test.ts
+++ b/web/src/api/entity.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import * as api from './entity'
+import * as client from './client'
+
+describe('entity api client', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetchFacts unwraps the {facts:[...]} envelope', async () => {
+    // Arrange
+    const facts: api.Fact[] = [
+      {
+        id: 'f1',
+        kind: 'people',
+        slug: 'sarah-chen',
+        text: 'Joined March 2024',
+        recorded_by: 'pm',
+        created_at: '2026-04-14T00:00:00Z',
+      },
+    ]
+    const getSpy = vi.spyOn(client, 'get').mockResolvedValue({ facts })
+    // Act
+    const result = await api.fetchFacts('people', 'sarah-chen')
+    // Assert
+    expect(getSpy).toHaveBeenCalledWith('/entity/facts?kind=people&slug=sarah-chen')
+    expect(result).toEqual(facts)
+  })
+
+  it('fetchFacts tolerates a missing facts key', async () => {
+    vi.spyOn(client, 'get').mockResolvedValue({})
+    const result = await api.fetchFacts('companies', 'acme')
+    expect(result).toEqual([])
+  })
+
+  it('fetchBriefs unwraps the {briefs:[...]} envelope', async () => {
+    const briefs: api.BriefSummary[] = [
+      {
+        kind: 'people',
+        slug: 'sarah-chen',
+        title: 'Sarah Chen',
+        fact_count: 5,
+        last_synthesized_ts: '2026-04-14T00:00:00Z',
+        last_synthesized_sha: 'abcdef1',
+        pending_delta: 2,
+      },
+    ]
+    vi.spyOn(client, 'get').mockResolvedValue({ briefs })
+    const result = await api.fetchBriefs()
+    expect(result).toEqual(briefs)
+  })
+
+  it('fetchBriefs also accepts a bare array response', async () => {
+    const briefs: api.BriefSummary[] = []
+    vi.spyOn(client, 'get').mockResolvedValue(briefs)
+    const result = await api.fetchBriefs()
+    expect(result).toEqual([])
+  })
+
+  it('recordFact posts the request body verbatim', async () => {
+    const postSpy = vi
+      .spyOn(client, 'post')
+      .mockResolvedValue({ fact_id: 'f1', fact_count: 1, threshold_crossed: false })
+    const req: api.RecordFactRequest = {
+      entity_kind: 'people',
+      entity_slug: 'sarah-chen',
+      fact: 'Prefers async updates over meetings.',
+      recorded_by: 'pm',
+    }
+    const result = await api.recordFact(req)
+    expect(postSpy).toHaveBeenCalledWith('/entity/fact', req)
+    expect(result.threshold_crossed).toBe(false)
+  })
+
+  it('requestBriefSynthesis posts to the synthesize endpoint', async () => {
+    const postSpy = vi
+      .spyOn(client, 'post')
+      .mockResolvedValue({ synthesis_id: 's1', queued_at: '2026-04-20T00:00:00Z' })
+    await api.requestBriefSynthesis({
+      entity_kind: 'people',
+      entity_slug: 'sarah-chen',
+      actor_slug: 'human',
+    })
+    expect(postSpy).toHaveBeenCalledWith('/entity/brief/synthesize', {
+      entity_kind: 'people',
+      entity_slug: 'sarah-chen',
+      actor_slug: 'human',
+    })
+  })
+
+  it('subscribeEntityEvents returns a no-op when EventSource is undefined', () => {
+    const originalES = (globalThis as { EventSource?: unknown }).EventSource
+    ;(globalThis as { EventSource?: unknown }).EventSource = undefined
+    try {
+      const unsub = api.subscribeEntityEvents('people', 'x', () => {}, () => {})
+      expect(typeof unsub).toBe('function')
+      unsub()
+    } finally {
+      ;(globalThis as { EventSource?: unknown }).EventSource = originalES
+    }
+  })
+
+  it('subscribeEntityEvents filters SSE by kind + slug', () => {
+    // Arrange — fake EventSource that captures listeners so we can fire events.
+    type Listener = (ev: MessageEvent) => void
+    const listeners: Record<string, Listener[]> = {}
+    const close = vi.fn()
+    class FakeES {
+      constructor(public url: string) {}
+      onerror: ((ev: Event) => void) | null = null
+      addEventListener(name: string, cb: Listener) {
+        ;(listeners[name] ??= []).push(cb)
+      }
+      removeEventListener(name: string, cb: Listener) {
+        listeners[name] = (listeners[name] ?? []).filter((l) => l !== cb)
+      }
+      close = close
+    }
+    const originalES = (globalThis as { EventSource?: unknown }).EventSource
+    ;(globalThis as { EventSource?: unknown }).EventSource = FakeES
+    try {
+      const factHits: api.FactRecordedEvent[] = []
+      const synthHits: api.BriefSynthesizedEvent[] = []
+      const unsub = api.subscribeEntityEvents(
+        'people',
+        'sarah-chen',
+        (ev) => factHits.push(ev),
+        (ev) => synthHits.push(ev),
+      )
+      // Fire a matching fact event.
+      listeners['entity:fact_recorded'][0](
+        new MessageEvent('message', {
+          data: JSON.stringify({
+            kind: 'people',
+            slug: 'sarah-chen',
+            fact_id: 'f1',
+            recorded_by: 'pm',
+            fact_count: 1,
+            threshold_crossed: false,
+            timestamp: '2026-04-20T00:00:00Z',
+          }),
+        }),
+      )
+      // Fire a non-matching event for the same kind, different slug.
+      listeners['entity:fact_recorded'][0](
+        new MessageEvent('message', {
+          data: JSON.stringify({
+            kind: 'people',
+            slug: 'someone-else',
+            fact_id: 'f2',
+            recorded_by: 'pm',
+            fact_count: 1,
+            threshold_crossed: false,
+            timestamp: '2026-04-20T00:00:00Z',
+          }),
+        }),
+      )
+      // Fire a matching synth event.
+      listeners['entity:brief_synthesized'][0](
+        new MessageEvent('message', {
+          data: JSON.stringify({
+            kind: 'people',
+            slug: 'sarah-chen',
+            commit_sha: 'abc',
+            fact_count: 3,
+            synthesized_ts: '2026-04-20T00:00:00Z',
+          }),
+        }),
+      )
+      // Malformed event should not throw.
+      listeners['entity:fact_recorded'][0](
+        new MessageEvent('message', { data: '{not-json' }),
+      )
+
+      expect(factHits).toHaveLength(1)
+      expect(factHits[0].fact_id).toBe('f1')
+      expect(synthHits).toHaveLength(1)
+      expect(synthHits[0].commit_sha).toBe('abc')
+
+      unsub()
+      expect(close).toHaveBeenCalled()
+    } finally {
+      ;(globalThis as { EventSource?: unknown }).EventSource = originalES
+    }
+  })
+})

--- a/web/src/api/entity.ts
+++ b/web/src/api/entity.ts
@@ -1,0 +1,193 @@
+/**
+ * Entity-brief API client — thin wrapper over `client.ts` covering the v1.2
+ * entity-brief surface: facts log + brief synthesis.
+ *
+ * Unlike `api/notebook.ts` this module has no mock mode — errors propagate so
+ * empty-state / error-state UI surfaces real backend problems instead of
+ * hiding them (same pattern v1.1 reviews adopted).
+ *
+ * SSE: the shared broker stream at `/events` emits named events. We use
+ * `addEventListener` on the two entity event names so we do not pay the cost
+ * of parsing every broker message (office changes, wiki writes, notebook
+ * writes, etc.) in every article view.
+ */
+
+import { get, post, sseURL } from './client'
+
+// ── Types ────────────────────────────────────────────────────────
+
+export type EntityKind = 'people' | 'companies' | 'customers'
+
+export interface Fact {
+  id: string
+  kind: EntityKind
+  slug: string
+  text: string
+  source_path?: string
+  recorded_by: string
+  created_at: string
+}
+
+export interface BriefSummary {
+  kind: EntityKind
+  slug: string
+  title: string
+  fact_count: number
+  last_synthesized_ts: string
+  last_synthesized_sha: string
+  pending_delta: number
+}
+
+export interface RecordFactRequest {
+  entity_kind: EntityKind
+  entity_slug: string
+  fact: string
+  source_path?: string
+  recorded_by?: string
+}
+
+export interface RecordFactResponse {
+  fact_id: string
+  fact_count: number
+  threshold_crossed: boolean
+}
+
+export interface SynthesizeRequest {
+  entity_kind: EntityKind
+  entity_slug: string
+  actor_slug?: string
+}
+
+export interface SynthesizeResponse {
+  synthesis_id: string
+  queued_at: string
+}
+
+export interface FactRecordedEvent {
+  kind: EntityKind
+  slug: string
+  fact_id: string
+  recorded_by: string
+  fact_count: number
+  threshold_crossed: boolean
+  timestamp: string
+}
+
+export interface BriefSynthesizedEvent {
+  kind: EntityKind
+  slug: string
+  commit_sha: string
+  fact_count: number
+  synthesized_ts: string
+}
+
+// ── HTTP ─────────────────────────────────────────────────────────
+
+/** `GET /entity/facts?kind=&slug=` — newest-first. */
+export async function fetchFacts(
+  kind: EntityKind,
+  slug: string,
+): Promise<Fact[]> {
+  const res = await get<{ facts: Fact[] }>(
+    `/entity/facts?kind=${encodeURIComponent(kind)}&slug=${encodeURIComponent(slug)}`,
+  )
+  return Array.isArray(res?.facts) ? res.facts : []
+}
+
+/** `GET /entity/briefs` — returns every brief's status row. */
+export async function fetchBriefs(): Promise<BriefSummary[]> {
+  // Broker wraps the array in `{ briefs: [...] }`. Unwrap here so callers
+  // can stay array-oriented. Tolerate both shapes so a broker that changes
+  // the envelope doesn't blank the UI.
+  const res = await get<{ briefs?: BriefSummary[] } | BriefSummary[]>(
+    '/entity/briefs',
+  )
+  if (Array.isArray(res)) return res
+  return Array.isArray(res?.briefs) ? res.briefs : []
+}
+
+/** `POST /entity/fact`. Not currently called from the UI (MCP-only in v1.2)
+ *  but exported so tests + future wiring can reach it. */
+export function recordFact(req: RecordFactRequest): Promise<RecordFactResponse> {
+  return post<RecordFactResponse>('/entity/fact', req)
+}
+
+/** `POST /entity/brief/synthesize`. Returns 503 if the worker is not attached. */
+export function requestBriefSynthesis(
+  req: SynthesizeRequest,
+): Promise<SynthesizeResponse> {
+  return post<SynthesizeResponse>('/entity/brief/synthesize', req)
+}
+
+// ── SSE ──────────────────────────────────────────────────────────
+
+/**
+ * Subscribe to the shared broker `/events` SSE stream filtered to one
+ * specific entity (kind + slug). Returns an unsubscribe function that
+ * tears down the underlying EventSource.
+ *
+ * Each caller opens its own EventSource — EntityBriefBar + FactsOnFile on
+ * the same page will hold two connections. That matches how the rest of
+ * the app consumes broker events today (useAgentStream, subscribeEditLog)
+ * and avoids a shared singleton that would race between articles.
+ *
+ * Failure is silent — if EventSource is undefined (tests, non-SSE envs)
+ * the unsubscribe is still a valid no-op.
+ */
+export function subscribeEntityEvents(
+  kind: EntityKind,
+  slug: string,
+  onFact: (ev: FactRecordedEvent) => void,
+  onSynth: (ev: BriefSynthesizedEvent) => void,
+): () => void {
+  let closed = false
+  let source: EventSource | null = null
+
+  const factHandler = (ev: MessageEvent) => {
+    if (closed) return
+    try {
+      const data = JSON.parse(ev.data) as FactRecordedEvent
+      if (data && data.kind === kind && data.slug === slug) {
+        onFact(data)
+      }
+    } catch {
+      // ignore malformed events
+    }
+  }
+  const synthHandler = (ev: MessageEvent) => {
+    if (closed) return
+    try {
+      const data = JSON.parse(ev.data) as BriefSynthesizedEvent
+      if (data && data.kind === kind && data.slug === slug) {
+        onSynth(data)
+      }
+    } catch {
+      // ignore malformed events
+    }
+  }
+
+  try {
+    // EventSource may be undefined in tests that stub SSE away.
+    const ES = (globalThis as { EventSource?: typeof EventSource }).EventSource
+    if (!ES) return () => {}
+    source = new ES(sseURL('/events'))
+    source.addEventListener('entity:fact_recorded', factHandler as EventListener)
+    source.addEventListener('entity:brief_synthesized', synthHandler as EventListener)
+    source.onerror = () => {
+      // Keep the source open — EventSource auto-reconnects. Closing here
+      // would drop live fact updates after the first transient blip.
+    }
+  } catch {
+    source = null
+  }
+
+  return () => {
+    closed = true
+    if (source) {
+      source.removeEventListener('entity:fact_recorded', factHandler as EventListener)
+      source.removeEventListener('entity:brief_synthesized', synthHandler as EventListener)
+      source.close()
+      source = null
+    }
+  }
+}

--- a/web/src/components/wiki/EntityBriefBar.test.tsx
+++ b/web/src/components/wiki/EntityBriefBar.test.tsx
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import EntityBriefBar from './EntityBriefBar'
+import * as api from '../../api/entity'
+
+type FactCb = (ev: api.FactRecordedEvent) => void
+type SynthCb = (ev: api.BriefSynthesizedEvent) => void
+
+function fakeBrief(pending: number): api.BriefSummary {
+  return {
+    kind: 'people',
+    slug: 'sarah-chen',
+    title: 'Sarah Chen',
+    fact_count: 5,
+    last_synthesized_ts: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    last_synthesized_sha: 'abcdef1',
+    pending_delta: pending,
+  }
+}
+
+describe('<EntityBriefBar>', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    // Default SSE subscribe = no-op unless a test overrides.
+    vi.spyOn(api, 'subscribeEntityEvents').mockImplementation(() => () => {})
+  })
+
+  it('renders the muted "0 new facts" state when pending is 0', async () => {
+    vi.spyOn(api, 'fetchBriefs').mockResolvedValue([fakeBrief(0)])
+    render(<EntityBriefBar kind="people" slug="sarah-chen" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('wk-entity-brief-bar')).toHaveClass('wk-entity-brief-bar--clean'),
+    )
+    expect(screen.getByTestId('wk-entity-brief-bar').textContent).toMatch(/0 new facts/i)
+    expect(screen.queryByRole('button', { name: /refresh brief/i })).toBeNull()
+  })
+
+  it('renders the amber pending state with a Refresh button when pending > 0', async () => {
+    vi.spyOn(api, 'fetchBriefs').mockResolvedValue([fakeBrief(3)])
+    render(<EntityBriefBar kind="people" slug="sarah-chen" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('wk-entity-brief-bar')).toHaveClass('wk-entity-brief-bar--pending'),
+    )
+    expect(screen.getByTestId('wk-entity-brief-bar').textContent).toMatch(/3 new facts/i)
+    expect(screen.getByRole('button', { name: /refresh brief/i })).toBeInTheDocument()
+  })
+
+  it('fires a synthesis request on click and disables the button in-flight', async () => {
+    vi.spyOn(api, 'fetchBriefs').mockResolvedValue([fakeBrief(2)])
+    const synthSpy = vi.spyOn(api, 'requestBriefSynthesis').mockResolvedValue({
+      synthesis_id: 'synth-1',
+      queued_at: new Date().toISOString(),
+    })
+    render(<EntityBriefBar kind="people" slug="sarah-chen" />)
+    const btn = (await screen.findByRole('button', {
+      name: /refresh brief/i,
+    })) as HTMLButtonElement
+    await userEvent.click(btn)
+    expect(synthSpy).toHaveBeenCalledWith({
+      entity_kind: 'people',
+      entity_slug: 'sarah-chen',
+    })
+    // After click, button shows in-flight label + is disabled.
+    await waitFor(() => {
+      expect(btn).toBeDisabled()
+      expect(btn.textContent).toMatch(/synthesizing/i)
+    })
+  })
+
+  it('clears the in-flight state when an entity:brief_synthesized event arrives', async () => {
+    let synthCb: SynthCb = () => {}
+    vi.spyOn(api, 'subscribeEntityEvents').mockImplementation(
+      (_kind, _slug, _f: FactCb, s: SynthCb) => {
+        synthCb = s
+        return () => {}
+      },
+    )
+    // First load returns pending=2; post-synth fetch returns pending=0.
+    const fetchSpy = vi.spyOn(api, 'fetchBriefs')
+    fetchSpy.mockResolvedValueOnce([fakeBrief(2)])
+    fetchSpy.mockResolvedValueOnce([fakeBrief(0)])
+    vi.spyOn(api, 'requestBriefSynthesis').mockResolvedValue({
+      synthesis_id: 'synth-1',
+      queued_at: new Date().toISOString(),
+    })
+
+    const onSynth = vi.fn()
+    render(<EntityBriefBar kind="people" slug="sarah-chen" onSynthesized={onSynth} />)
+    const btn = (await screen.findByRole('button', {
+      name: /refresh brief/i,
+    })) as HTMLButtonElement
+    await userEvent.click(btn)
+    await waitFor(() => expect(btn).toBeDisabled())
+
+    // Fire the SSE synthesis event.
+    await act(async () => {
+      synthCb({
+        kind: 'people',
+        slug: 'sarah-chen',
+        commit_sha: 'deadbee',
+        fact_count: 5,
+        synthesized_ts: new Date().toISOString(),
+      })
+    })
+
+    await waitFor(() => {
+      // Pending=0 → refresh button goes away entirely.
+      expect(screen.queryByRole('button', { name: /refresh brief/i })).toBeNull()
+      expect(onSynth).toHaveBeenCalled()
+    })
+  })
+
+  it('increments pending count live when fact_recorded fires', async () => {
+    let factCb: FactCb = () => {}
+    vi.spyOn(api, 'subscribeEntityEvents').mockImplementation(
+      (_kind, _slug, f: FactCb) => {
+        factCb = f
+        return () => {}
+      },
+    )
+    vi.spyOn(api, 'fetchBriefs').mockResolvedValue([fakeBrief(1)])
+    render(<EntityBriefBar kind="people" slug="sarah-chen" />)
+    await waitFor(() =>
+      expect(screen.getByTestId('wk-entity-brief-bar').textContent).toMatch(/1 new fact/i),
+    )
+
+    await act(async () => {
+      factCb({
+        kind: 'people',
+        slug: 'sarah-chen',
+        fact_id: 'f-new',
+        recorded_by: 'ceo',
+        fact_count: 6,
+        threshold_crossed: false,
+        timestamp: new Date().toISOString(),
+      })
+    })
+    await waitFor(() =>
+      expect(screen.getByTestId('wk-entity-brief-bar').textContent).toMatch(/2 new facts/i),
+    )
+  })
+})

--- a/web/src/components/wiki/EntityBriefBar.tsx
+++ b/web/src/components/wiki/EntityBriefBar.tsx
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  fetchBriefs,
+  requestBriefSynthesis,
+  subscribeEntityEvents,
+  type BriefSummary,
+  type EntityKind,
+} from '../../api/entity'
+
+interface EntityBriefBarProps {
+  kind: EntityKind
+  slug: string
+  /**
+   * Called after a successful synthesis arrives over SSE so the parent can
+   * refetch article body + sources. Optional so the bar still works on its
+   * own in isolation.
+   */
+  onSynthesized?: () => void
+}
+
+type BarState = 'idle' | 'synthesizing'
+
+export default function EntityBriefBar({ kind, slug, onSynthesized }: EntityBriefBarProps) {
+  const [brief, setBrief] = useState<BriefSummary | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [state, setState] = useState<BarState>('idle')
+  const [pendingOverride, setPendingOverride] = useState<number | null>(null)
+
+  const loadBrief = useCallback(async () => {
+    try {
+      const rows = await fetchBriefs()
+      const match = rows.find((r) => r.kind === kind && r.slug === slug) ?? null
+      setBrief(match)
+      setPendingOverride(null)
+      setError(null)
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to load brief status')
+    } finally {
+      setLoading(false)
+    }
+  }, [kind, slug])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    ;(async () => {
+      try {
+        const rows = await fetchBriefs()
+        if (cancelled) return
+        const match = rows.find((r) => r.kind === kind && r.slug === slug) ?? null
+        setBrief(match)
+        setPendingOverride(null)
+      } catch (err: unknown) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'Failed to load brief status')
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [kind, slug])
+
+  useEffect(() => {
+    const unsubscribe = subscribeEntityEvents(
+      kind,
+      slug,
+      () => {
+        // New fact for this entity — bump pending without refetching.
+        setPendingOverride((prev) => {
+          const base = prev ?? brief?.pending_delta ?? 0
+          return base + 1
+        })
+      },
+      () => {
+        // Brief was synthesized — clear in-flight state, refetch status,
+        // notify parent so article body + sources refresh.
+        setState('idle')
+        void loadBrief()
+        if (onSynthesized) onSynthesized()
+      },
+    )
+    return unsubscribe
+  }, [kind, slug, loadBrief, onSynthesized, brief?.pending_delta])
+
+  const handleRefresh = useCallback(async () => {
+    setState('synthesizing')
+    setError(null)
+    try {
+      await requestBriefSynthesis({ entity_kind: kind, entity_slug: slug })
+      // Wait for SSE to flip state back to idle. If SSE never arrives the
+      // button stays "Synthesizing…" — that is deliberate: a user who sees
+      // the label hang will reload and see the fresh brief on next render.
+    } catch (err: unknown) {
+      setState('idle')
+      setError(err instanceof Error ? err.message : 'Synthesis request failed')
+    }
+  }, [kind, slug])
+
+  const pending = useMemo(() => {
+    if (pendingOverride !== null) return pendingOverride
+    return brief?.pending_delta ?? 0
+  }, [pendingOverride, brief?.pending_delta])
+
+  if (loading) return null
+
+  // If backend returned no row for this entity we still render — the brief
+  // just hasn't been synthesized yet. Facts-on-file handles the empty case
+  // for the body.
+  const synthesizedTs = brief?.last_synthesized_ts ?? ''
+  const relativeSynth = synthesizedTs ? formatRelativeTime(synthesizedTs) : 'never'
+  const hasPending = pending > 0
+  const cls = hasPending
+    ? 'wk-entity-brief-bar wk-entity-brief-bar--pending'
+    : 'wk-entity-brief-bar wk-entity-brief-bar--clean'
+
+  return (
+    <div
+      className={cls}
+      role="status"
+      aria-live="polite"
+      data-testid="wk-entity-brief-bar"
+    >
+      <span className="wk-entity-brief-bar__label">
+        {hasPending ? (
+          <>
+            <strong>{pending}</strong> new {pending === 1 ? 'fact' : 'facts'} since last synthesis
+          </>
+        ) : (
+          <>Brief synthesized {relativeSynth}. 0 new facts since.</>
+        )}
+      </span>
+      {hasPending && (
+        <button
+          type="button"
+          className="wk-entity-brief-bar__action"
+          onClick={handleRefresh}
+          disabled={state === 'synthesizing'}
+        >
+          {state === 'synthesizing' ? 'Synthesizing…' : 'Refresh brief'}
+        </button>
+      )}
+      {error && <span className="wk-entity-brief-bar__error">{error}</span>}
+    </div>
+  )
+}
+
+function formatRelativeTime(iso: string): string {
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return iso
+  const diffMs = Date.now() - t
+  if (diffMs < 0) return 'just now'
+  const sec = Math.floor(diffMs / 1000)
+  if (sec < 60) return 'just now'
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min} minute${min === 1 ? '' : 's'} ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr} hour${hr === 1 ? '' : 's'} ago`
+  const day = Math.floor(hr / 24)
+  if (day < 30) return `${day} day${day === 1 ? '' : 's'} ago`
+  const mo = Math.floor(day / 30)
+  if (mo < 12) return `${mo} month${mo === 1 ? '' : 's'} ago`
+  const yr = Math.floor(day / 365)
+  return `${yr} year${yr === 1 ? '' : 's'} ago`
+}

--- a/web/src/components/wiki/FactsOnFile.test.tsx
+++ b/web/src/components/wiki/FactsOnFile.test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import FactsOnFile from './FactsOnFile'
+import * as api from '../../api/entity'
+
+type FactCb = (ev: api.FactRecordedEvent) => void
+
+describe('<FactsOnFile>', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(api, 'subscribeEntityEvents').mockImplementation(() => () => {})
+  })
+
+  it('renders the empty state when no facts are recorded', async () => {
+    vi.spyOn(api, 'fetchFacts').mockResolvedValue([])
+    render(<FactsOnFile kind="people" slug="sarah-chen" />)
+    await waitFor(() =>
+      expect(screen.getByText(/0 facts recorded yet/i)).toBeInTheDocument(),
+    )
+    expect(screen.getByRole('heading', { name: /facts on file/i })).toBeInTheDocument()
+  })
+
+  it('renders a fact list with author names and timestamps', async () => {
+    const facts: api.Fact[] = [
+      {
+        id: 'f1',
+        kind: 'people',
+        slug: 'sarah-chen',
+        text: 'Prefers async updates over meetings.',
+        recorded_by: 'pm',
+        created_at: '2026-04-14T00:00:00Z',
+      },
+      {
+        id: 'f2',
+        kind: 'people',
+        slug: 'sarah-chen',
+        text: 'Champion inside Customer X.',
+        recorded_by: 'ceo',
+        source_path: 'team/companies/customer-x.md',
+        created_at: '2026-04-15T00:00:00Z',
+      },
+    ]
+    vi.spyOn(api, 'fetchFacts').mockResolvedValue(facts)
+    render(<FactsOnFile kind="people" slug="sarah-chen" />)
+    await screen.findByText('Prefers async updates over meetings.')
+    expect(screen.getByText('Champion inside Customer X.')).toBeInTheDocument()
+    // Source wikilink rendered for team/ paths.
+    const source = screen.getByText(/companies\/customer-x/)
+    expect(source.closest('a')).toHaveAttribute('data-wikilink', 'true')
+    // Shortened ISO date.
+    expect(screen.getByText('2026-04-14')).toBeInTheDocument()
+  })
+
+  it('does not render a source wikilink for non-wiki source paths', async () => {
+    const facts: api.Fact[] = [
+      {
+        id: 'f1',
+        kind: 'people',
+        slug: 'sarah-chen',
+        text: 'Observed in a Slack DM.',
+        recorded_by: 'pm',
+        source_path: 'messages/dm/123',
+        created_at: '2026-04-14T00:00:00Z',
+      },
+    ]
+    vi.spyOn(api, 'fetchFacts').mockResolvedValue(facts)
+    render(<FactsOnFile kind="people" slug="sarah-chen" />)
+    await screen.findByText('Observed in a Slack DM.')
+    expect(screen.queryByText(/messages\/dm/)).toBeNull()
+  })
+
+  it('prepends a new fact when an entity:fact_recorded event arrives', async () => {
+    let factCb: FactCb = () => {}
+    vi.spyOn(api, 'subscribeEntityEvents').mockImplementation(
+      (_k, _s, cb: FactCb) => {
+        factCb = cb
+        return () => {}
+      },
+    )
+    const fetchSpy = vi.spyOn(api, 'fetchFacts')
+    fetchSpy.mockResolvedValueOnce([
+      {
+        id: 'f1',
+        kind: 'people',
+        slug: 'sarah-chen',
+        text: 'First fact.',
+        recorded_by: 'pm',
+        created_at: '2026-04-14T00:00:00Z',
+      },
+    ])
+    // Refetch after SSE event — returns with the new fact at the top.
+    fetchSpy.mockResolvedValueOnce([
+      {
+        id: 'f2',
+        kind: 'people',
+        slug: 'sarah-chen',
+        text: 'Fresh fact from SSE.',
+        recorded_by: 'ceo',
+        created_at: '2026-04-15T00:00:00Z',
+      },
+      {
+        id: 'f1',
+        kind: 'people',
+        slug: 'sarah-chen',
+        text: 'First fact.',
+        recorded_by: 'pm',
+        created_at: '2026-04-14T00:00:00Z',
+      },
+    ])
+
+    render(<FactsOnFile kind="people" slug="sarah-chen" />)
+    await screen.findByText('First fact.')
+
+    await act(async () => {
+      factCb({
+        kind: 'people',
+        slug: 'sarah-chen',
+        fact_id: 'f2',
+        recorded_by: 'ceo',
+        fact_count: 2,
+        threshold_crossed: false,
+        timestamp: '2026-04-15T00:00:00Z',
+      })
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText('Fresh fact from SSE.')).toBeInTheDocument(),
+    )
+  })
+})

--- a/web/src/components/wiki/FactsOnFile.tsx
+++ b/web/src/components/wiki/FactsOnFile.tsx
@@ -1,0 +1,164 @@
+import { useCallback, useEffect, useState } from 'react'
+import PixelAvatar from './PixelAvatar'
+import {
+  fetchFacts,
+  subscribeEntityEvents,
+  type EntityKind,
+  type Fact,
+} from '../../api/entity'
+import { formatAgentName } from '../../lib/agentName'
+
+interface FactsOnFileProps {
+  kind: EntityKind
+  slug: string
+}
+
+const INITIAL_LIMIT = 50
+
+export default function FactsOnFile({ kind, slug }: FactsOnFileProps) {
+  const [facts, setFacts] = useState<Fact[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [showAll, setShowAll] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetchFacts(kind, slug)
+      .then((rows) => {
+        if (cancelled) return
+        setFacts(rows)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : 'Failed to load facts')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [kind, slug])
+
+  const handleFact = useCallback((ev: { fact_id: string; recorded_by: string; timestamp: string }) => {
+    setFacts((prev) => {
+      // Skip if we already have this id (shouldn't happen, but the SSE
+      // stream can replay on reconnect in theory).
+      if (prev.some((f) => f.id === ev.fact_id)) return prev
+      // Prepend an optimistic row. Refetch in parallel so the real row
+      // (with text + source_path) replaces this shortly.
+      const optimistic: Fact = {
+        id: ev.fact_id,
+        kind,
+        slug,
+        text: '…',
+        recorded_by: ev.recorded_by,
+        created_at: ev.timestamp,
+      }
+      return [optimistic, ...prev]
+    })
+    // Refetch to resolve the optimistic row with full fact text. Fire and
+    // forget — errors here are visible in the next render cycle.
+    void fetchFacts(kind, slug)
+      .then((rows) => setFacts(rows))
+      .catch(() => {
+        // Keep the optimistic row; surfacing a second error on top of the
+        // initial fetch would flood the UI.
+      })
+  }, [kind, slug])
+
+  useEffect(() => {
+    const unsubscribe = subscribeEntityEvents(
+      kind,
+      slug,
+      handleFact,
+      () => {
+        // Brief synthesis doesn't change the facts list itself, but refetch
+        // anyway in case the synthesis raced with a batch of new facts.
+        void fetchFacts(kind, slug).then(setFacts).catch(() => {})
+      },
+    )
+    return unsubscribe
+  }, [kind, slug, handleFact])
+
+  const visibleFacts = showAll ? facts : facts.slice(0, INITIAL_LIMIT)
+
+  return (
+    <section
+      className="wk-facts-list"
+      aria-labelledby="wk-facts-heading"
+      data-testid="wk-facts-on-file"
+    >
+      <h2 id="wk-facts-heading">Facts on file</h2>
+      {loading ? (
+        <p className="wk-facts-loading">loading facts…</p>
+      ) : error ? (
+        <p className="wk-facts-error">{error}</p>
+      ) : facts.length === 0 ? (
+        <p className="wk-facts-empty">
+          0 facts recorded yet. Agents will add facts as they work.
+        </p>
+      ) : (
+        <>
+          <ol className="wk-facts-items">
+            {visibleFacts.map((f) => (
+              <li key={f.id} className="wk-facts-item">
+                <PixelAvatar slug={f.recorded_by} size={14} />
+                <div className="wk-facts-body">
+                  <span className="wk-facts-text">{f.text}</span>
+                  <span className="wk-facts-meta">
+                    {formatAgentName(f.recorded_by)}
+                    {' · '}
+                    <time dateTime={f.created_at}>{formatShortTs(f.created_at)}</time>
+                    {isWikiSource(f.source_path) && (
+                      <>
+                        {' · '}
+                        <a
+                          className="wk-facts-source"
+                          href={`#/wiki/${f.source_path}`}
+                          data-wikilink="true"
+                        >
+                          {sourceLabel(f.source_path as string)}
+                        </a>
+                      </>
+                    )}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ol>
+          {facts.length > INITIAL_LIMIT && (
+            <button
+              type="button"
+              className="wk-facts-showall"
+              onClick={() => setShowAll((v) => !v)}
+            >
+              {showAll
+                ? 'show recent only'
+                : `show all (${facts.length - INITIAL_LIMIT} more)`}
+            </button>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+function isWikiSource(path?: string): path is string {
+  if (!path) return false
+  return path.startsWith('agents/') || path.startsWith('team/')
+}
+
+function sourceLabel(path: string): string {
+  const base = path.replace(/\.md$/, '')
+  const tail = base.split('/').slice(-2).join('/')
+  return tail || base
+}
+
+function formatShortTs(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toISOString().slice(0, 10)
+}

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -5,6 +5,8 @@ import rehypeSlug from 'rehype-slug'
 import rehypeAutolinkHeadings from 'rehype-autolink-headings'
 import type { PluggableList } from 'unified'
 import ArticleStatusBanner from './ArticleStatusBanner'
+import EntityBriefBar from './EntityBriefBar'
+import FactsOnFile from './FactsOnFile'
 import HatBar, { type HatBarTab } from './HatBar'
 import ArticleTitle from './ArticleTitle'
 import Byline from './Byline'
@@ -28,6 +30,18 @@ import {
 import type { SourceItem } from './Sources'
 import { wikiLinkRemarkPlugin } from '../../lib/wikilink'
 import { formatAgentName } from '../../lib/agentName'
+import type { EntityKind } from '../../api/entity'
+
+// Real backend paths look like `team/people/nazz.md`. Mock/dev paths may
+// drop the `team/` prefix or the `.md` suffix. Accept both so the entity
+// surface lights up in demos without forcing every caller to normalize.
+const ENTITY_PATH_RE = /^(?:team\/)?(people|companies|customers)\/([a-z0-9][a-z0-9-]*)(?:\.md)?$/
+
+function detectEntity(path: string): { kind: EntityKind; slug: string } | null {
+  const m = path.match(ENTITY_PATH_RE)
+  if (!m) return null
+  return { kind: m[1] as EntityKind, slug: m[2] }
+}
 
 interface WikiArticleProps {
   path: string
@@ -44,6 +58,7 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
   const [historyLoading, setHistoryLoading] = useState(true)
   const [historyError, setHistoryError] = useState(false)
   const [liveAgent, setLiveAgent] = useState<string | null>(null)
+  const [refreshNonce, setRefreshNonce] = useState(0)
 
   useEffect(() => {
     let cancelled = false
@@ -64,7 +79,7 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
     return () => {
       cancelled = true
     }
-  }, [path])
+  }, [path, refreshNonce])
 
   useEffect(() => {
     let cancelled = false
@@ -88,7 +103,7 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
     return () => {
       cancelled = true
     }
-  }, [path])
+  }, [path, refreshNonce])
 
   useEffect(() => {
     setLiveAgent(null)
@@ -136,6 +151,7 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
   if (!article) return <div className="wk-error">Article not found.</div>
 
   const toc = buildTocFromMarkdown(article.content)
+  const entity = detectEntity(article.path)
   const breadcrumbSegments = article.path.split('/').filter(Boolean)
   const context = breadcrumbSegments[0] || ''
   const byline = (
@@ -157,6 +173,13 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
             revisions={article.revisions}
             contributors={article.contributors.length}
             wordCount={article.word_count}
+          />
+        )}
+        {entity && (
+          <EntityBriefBar
+            kind={entity.kind}
+            slug={entity.slug}
+            onSynthesized={() => setRefreshNonce((n) => n + 1)}
           />
         )}
         <HatBar
@@ -240,6 +263,9 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
           <div className="wk-loading">
             History view streams from <code>git log</code>. Wiring pending Lane A.
           </div>
+        )}
+        {entity && tab === 'article' && (
+          <FactsOnFile kind={entity.kind} slug={entity.slug} />
         )}
         <SeeAlso
           items={article.backlinks.map((b) => ({ slug: b.path, display: b.title }))}

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1140,3 +1140,141 @@
 .wk-catalog-audit-link:hover {
   text-decoration-style: solid;
 }
+
+/* ─── Entity briefs (v1.2) ─── */
+.wk-entity-brief-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 16px;
+  padding: 10px 14px;
+  font-family: var(--wk-chrome);
+  font-size: 13px;
+  line-height: 1.4;
+  border: 1px solid var(--wk-border);
+  background: var(--wk-paper-dark);
+}
+.wk-entity-brief-bar--pending {
+  border-left: 3px solid var(--wk-amber);
+  background: var(--wk-amber-banner);
+  color: var(--wk-text);
+}
+.wk-entity-brief-bar--clean {
+  color: var(--wk-text-muted);
+}
+.wk-entity-brief-bar__label { flex: 1 1 auto; }
+.wk-entity-brief-bar__label strong {
+  font-weight: 600;
+  color: var(--wk-text);
+}
+.wk-entity-brief-bar__action {
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 10px;
+  background: var(--wk-text);
+  color: var(--wk-paper);
+  border: 1px solid var(--wk-text);
+  cursor: pointer;
+  letter-spacing: 0.02em;
+}
+.wk-entity-brief-bar__action:hover:not(:disabled) {
+  background: var(--wk-amber);
+  border-color: var(--wk-amber);
+  color: var(--wk-text);
+}
+.wk-entity-brief-bar__action:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.wk-entity-brief-bar__error {
+  color: var(--wk-wikilink-broken);
+  font-size: 12px;
+  flex: 1 1 100%;
+}
+
+.wk-facts-list {
+  margin: 32px 0 24px;
+  font-family: var(--wk-body-serif);
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--wk-text);
+}
+.wk-facts-list h2 {
+  font-family: var(--wk-display);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin: 0 0 12px;
+  color: var(--wk-text-muted);
+  border-bottom: 1px solid var(--wk-border);
+  padding-bottom: 6px;
+}
+.wk-facts-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.wk-facts-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--wk-border-light);
+}
+.wk-facts-item:last-child { border-bottom: none; }
+.wk-facts-item .wk-avatar {
+  image-rendering: pixelated;
+  width: 14px;
+  height: 14px;
+  border-radius: 2px;
+  margin-top: 3px;
+  flex-shrink: 0;
+}
+.wk-facts-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.wk-facts-text {
+  display: block;
+  font-family: var(--wk-body-serif);
+  color: var(--wk-text);
+}
+.wk-facts-meta {
+  display: block;
+  margin-top: 2px;
+  font-family: var(--wk-chrome);
+  font-size: 11px;
+  color: var(--wk-text-tertiary);
+}
+.wk-facts-meta time {
+  font-family: var(--wk-mono);
+}
+.wk-facts-source {
+  color: var(--wk-wikilink);
+  text-decoration: underline dashed;
+  text-underline-offset: 2px;
+}
+.wk-facts-empty,
+.wk-facts-loading,
+.wk-facts-error {
+  font-family: var(--wk-body-serif);
+  font-style: italic;
+  color: var(--wk-text-tertiary);
+  margin: 0;
+}
+.wk-facts-error { color: var(--wk-wikilink-broken); font-style: normal; }
+.wk-facts-showall {
+  margin-top: 10px;
+  font-family: var(--wk-chrome);
+  font-size: 12px;
+  color: var(--wk-wikilink);
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline dashed;
+  text-underline-offset: 2px;
+}


### PR DESCRIPTION
## Summary

WUPHF v1.2: entity briefs. Every person / company / customer in the team wiki gets a live-maintained canonical brief, fed by an append-only fact log, synthesized via a broker-level LLM shellout. No Archivist agent on the roster — `archivist` is just a synthetic git commit author (same pattern as `scanner`, `wuphf-bootstrap`).

**Stacks on** #177 (v1.1 integration — base branch set to `feat/wuphf-v1.1-integration`). Merge #174 + #177 first.

## What shipped

### Backend (Go, 5 commits)
- **Fact log** (`internal/team/entity_facts.go`, 313 loc) — append-only jsonl at `team/entities/{kind}-{slug}.facts.jsonl`. `EntityKind` enum: `people | companies | customers`. Validate inputs (slug pattern, fact length cap 4000 chars, source_path must be `agents/` or `team/`). Facts route through the existing `wikiWriteRequest` queue via a new `IsEntityFact` flag + `Repo.CommitEntityFact` so Lane B's strict `.md`-only validator stays untouched.
- **Synthesizer** (`entity_synthesizer.go` ~460 loc, `entity_frontmatter.go` 186 loc, `entity_commit.go` 76 loc) — broker goroutine, buffered job queue, debounce (one pending synthesis per entity; fact storms coalesce). Shells out to `claude -p` / `codex exec -q` via the existing `provider.RunConfiguredOneShot`. 30s timeout, 32KB output cap, re-queue once on transient failure. Frontmatter preserves non-synthesis keys; writes `last_synthesized_sha`, `last_synthesized_ts`, `fact_count_at_synthesis`. Commit author = `archivist`.
- **HTTP** (`broker_entity.go`, 452 loc): `POST /entity/fact`, `POST /entity/brief/synthesize`, `GET /entity/facts?kind=&slug=`, `GET /entity/briefs`. SSE events `entity:fact_recorded` + `entity:brief_synthesized`.
- **MCP tools** (`teammcp/entity_tools.go`, 123 loc): `entity_fact_record` + `entity_brief_synthesize`. Backend-gated (`markdown` only).

### Frontend (TypeScript, 5 commits)
- **API adapter** (`web/src/api/entity.ts`, 193 loc) — matches notebook.ts pattern. Propagates errors (no silent mock fallback).
- **`EntityBriefBar`** (168 loc) — inline strip at the top of entity wiki articles. Shows muted "Brief synthesized Nh ago" when `pending_delta === 0`, amber-tinted "N new facts since last synthesis — [Refresh brief]" when `pending_delta > 0`. Button state machine: idle → synthesizing → SSE `entity:brief_synthesized` → clears. Live-updates `pending_delta` via SSE `entity:fact_recorded`.
- **`FactsOnFile`** (164 loc) — Wikipedia-style "FACTS ON FILE" section below article body. Pixel avatars via `composeAvatar`, body-serif typography per DESIGN-WIKI.md, `recorded_by · created_at · [source wikilink]` meta line. Last-50 with expand-all. Live-prepends new facts.
- **Wired into `WikiArticle.tsx`** — 30-line edit. Entity detection via path regex `team/(people|companies|customers)/(.+)\.md`. Non-entity wiki pages render identically to before.

### Design decisions locked
1. **Synthesis is broker-level, not agent turn.** `archivist` commit author, no Archivist agent added to default roster.
2. **Hybrid trigger**: threshold-based auto-synth (default 5 new facts via `WUPHF_ENTITY_BRIEF_THRESHOLD`) OR on-demand via button/MCP tool.
3. **Debounce coalesces** — one pending synthesis per entity; fact storms don't spawn N jobs.
4. **Contradictions surfaced, not resolved** — LLM prompt says "Mark contradictions with **Contradiction:** inline callouts" rather than auto-reconciling.
5. **`fact_count_at_synthesis` monotonic counter** replaces sha-timestamp comparison for threshold math (git second-precision races against sub-second fact timestamps).

## Test coverage

- **Go**: 27 new tests across 4 files — fact log (happy + validation + malformed-line recovery + 10-way concurrency + CountSinceSHA), synthesizer (happy + fresh-brief + no-new-facts skip + LLM error + timeout + invalid output + 5-deep debounce coalesce + stop-prevents-enqueue + contradiction pass-through), HTTP (auth/method/validation/threshold-trigger/happy/SSE), MCP (backend gating + validation). All pass `go test -race -count=1`.
- **Frontend**: 16 new tests (7 api adapter, 5 EntityBriefBar, 4 FactsOnFile). Full webapp suite: 205 tests across 47 files, all pass.

## Notable finding (pre-existing, not fixed here)

The agent flagged that `web/src/api/wiki.ts` and `web/src/api/notebook.ts` subscribe to `/wiki/stream` and `/notebooks/stream` — **but the broker only exposes `/events`**. Those paths 404 in production, so existing wiki + notebook "live" SSE features are silently dead on main. `entity.ts` points at the real `/events` endpoint and uses `addEventListener('entity:fact_recorded', ...)` for named events. **Worth a follow-up PR to reconcile the other two** — marking as tech debt, not a v1.2 blocker.

## What's NOT in v1.2

- No UI for recording facts (MCP-tool-only for now; humans can file facts via a lead agent).
- No cross-entity graph ("Sarah works at Acme" doesn't auto-link).
- No conflict resolution LLM call — contradictions surface, don't auto-reconcile.
- No retroactive backfill — entities that existed before this ship don't auto-get fact logs.
- No Archivist agent (explicit user call).

## Env knobs

- `WUPHF_ENTITY_BRIEF_THRESHOLD` (int, default 5) — auto-synth after N new facts land.
- `WUPHF_ENTITY_BRIEF_TIMEOUT` (int seconds, default 30) — LLM shellout deadline.

Model routing stays with `config.ResolveLLMProvider()` — no duplicate knob.

## Test plan

- [x] `go build ./...` clean on branch
- [x] `go vet ./...` clean
- [x] `go test -race -count=1 -run 'Entity|Fact|Synthesize' ./internal/team/... ./internal/teammcp/...` all pass
- [x] `npm run build` + `npm run test -- --run` in `web/` — 205 tests pass, no TS errors
- [ ] After merge: verify live synthesis against a real `claude -p` / `codex exec -q` shellout
- [ ] Reconcile the wiki/notebook SSE dead-paths noted above — follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)