### PR TITLE
fix(website): make nav INSTALL button scroll to install section

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -107,6 +107,9 @@
     border: none;
     cursor: pointer;
     white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
   }
 
   /* ── HERO ─────────────────────────────────────────── */
@@ -252,6 +255,7 @@
     margin-bottom: 40px;
     width: 100%;
     max-width: 560px;
+    scroll-margin-top: 60px;
   }
 
   .install-tabs {
@@ -1058,7 +1062,7 @@
     <a class="nav-social-link" href="https://discord.gg/gjSySC3PzV" target="_blank" rel="noopener" aria-label="Discord">
       <svg viewBox="0 0 24 24" width="15" height="15" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057.101 18.079.111 18.1.127 18.116a19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
     </a>
-    <button class="nav-badge" onclick="copyInstall()">INSTALL</button>
+    <a class="nav-badge" href="#install" onclick="copyInstall()">INSTALL</a>
   </div>
 </nav>
 
@@ -1096,7 +1100,7 @@
       A collaborative office of AI agents that execute your playbooks, and get better at it everyday.
     </p>
 
-    <div class="install-wrap">
+    <div class="install-wrap" id="install">
       <div class="install-tabs">
         <button class="install-tab active" onclick="switchInstallTab('npx')">NPX</button>
         <button class="install-tab" onclick="switchInstallTab('build')">CLONE + BUILD</button>
@@ -1503,7 +1507,9 @@
   }
 
   function copyInstall() {
-    navigator.clipboard.writeText('npx wuphf').catch(function() {});
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText('npx wuphf').catch(function() {});
+    }
     var label = document.getElementById('copyLabel');
     if (label) flashCopy(label);
   }


### PR DESCRIPTION
## Summary
- The nav `INSTALL` button copied `npx wuphf` to the clipboard but only flashed feedback on an element inside the hero, so clicking it from further down the page produced no visible response and felt broken.
- Convert the button to an `<a href="#install">` so it smooth-scrolls to the install block (where the `COPIED!` flash is visible), guard the clipboard call for non-secure contexts, and adjust `.nav-badge` styling so the anchor looks identical to the old button.

## Test plan
- [ ] Load the website, scroll past the hero, click `INSTALL` in the nav — page smooth-scrolls to the install block and `COPY` flashes to `COPIED!`.
- [ ] Click `INSTALL` from the top of the page — clipboard still receives `npx wuphf` and flash feedback is visible.
- [ ] Verify `.nav-badge` renders with the same appearance (yellow background, centered text, no underline).

https://claude.ai/code/session_01PU4qfYRsZCV7VLJvJgqkdD