### PR TITLE
fix(web): SSE subscribers were pointed at dead paths

### DIFF
--- a/web/src/api/notebook.ts
+++ b/web/src/api/notebook.ts
@@ -348,43 +348,57 @@ export async function postReviewComment(
 // ── SSE ──────────────────────────────────────────────────────────
 
 /**
- * Subscribe to broker notebook/review events.
+ * Subscribe to broker notebook + review events on the shared `/events`
+ * SSE stream. Returns an unsubscribe function that tears down the
+ * underlying EventSource.
  *
- * Event payloads:
- *   { type: 'notebook:write', agent_slug, entry_slug, who, timestamp }
- *   { type: 'review:state_change', review_id, state, who, timestamp }
+ * Previously this subscribed to `/notebooks/stream` — a path that never
+ * existed on the broker. Live notebook and review updates were dead in
+ * production. Matches `api/entity.ts`: broker emits named events
+ * (`event: notebook:write\ndata: ...`, `event: review:state_change\ndata: ...`)
+ * so we use `addEventListener` not `onmessage`.
  *
- * Returns an unsubscribe function. Failure is silent — the UI remains
- * interactive from TanStack Query cache.
+ * Event payloads (as emitted by broker.handleEvents):
+ *   notebook:write       — `{ slug, path, commit_sha, ts, ... }`
+ *   review:state_change  — `{ id, old_state, new_state, actor_slug, timestamp }`
+ *
+ * Handler normalizes both into the NotebookEvent discriminated union so
+ * downstream components can switch on `type`.
  */
 export function subscribeNotebookEvents(
   handler: (ev: NotebookEvent) => void,
 ): () => void {
   let closed = false
   let source: EventSource | null = null
+  const listeners: Array<[string, EventListener]> = []
 
   try {
-    source = new EventSource(sseURL('/notebooks/stream'))
-    source.onmessage = (ev) => {
+    const ES = (globalThis as { EventSource?: typeof EventSource }).EventSource
+    if (!ES) return () => { closed = true }
+    source = new ES(sseURL('/events'))
+
+    const onNotebook = (ev: MessageEvent) => {
       if (closed) return
       try {
         const data = JSON.parse(ev.data) as Record<string, unknown>
-        if (
-          data &&
-          (data.type === 'notebook:write' || data.type === 'review:state_change')
-        ) {
-          handler(data as unknown as NotebookEvent)
-        }
+        handler({ type: 'notebook:write', ...data } as unknown as NotebookEvent)
       } catch {
         // ignore malformed events
       }
     }
-    source.onerror = () => {
-      if (source) {
-        source.close()
-        source = null
+    const onReview = (ev: MessageEvent) => {
+      if (closed) return
+      try {
+        const data = JSON.parse(ev.data) as Record<string, unknown>
+        handler({ type: 'review:state_change', ...data } as unknown as NotebookEvent)
+      } catch {
+        // ignore malformed events
       }
     }
+    source.addEventListener('notebook:write', onNotebook as EventListener)
+    source.addEventListener('review:state_change', onReview as EventListener)
+    listeners.push(['notebook:write', onNotebook as EventListener])
+    listeners.push(['review:state_change', onReview as EventListener])
   } catch {
     source = null
   }
@@ -392,6 +406,7 @@ export function subscribeNotebookEvents(
   return () => {
     closed = true
     if (source) {
+      for (const [name, fn] of listeners) source.removeEventListener(name, fn)
       source.close()
       source = null
     }

--- a/web/src/api/sse-dead-path.test.ts
+++ b/web/src/api/sse-dead-path.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression test for the SSE dead-path bug.
+ *
+ * Before this fix, `subscribeEditLog` and `subscribeNotebookEvents` built
+ * EventSources pointed at `/wiki/stream` and `/notebooks/stream` — paths
+ * that do NOT exist on the broker (only `/events` does). Every live
+ * update was silently dropped.
+ *
+ * These tests lock in two guarantees:
+ *   1. The subscriber URL ends in `/events` (not a per-surface stream).
+ *   2. Named-event handlers (`addEventListener('wiki:write', ...)` etc.)
+ *      get wired — broker emits `event: wiki:write` lines, not unnamed
+ *      `data:` lines, so `onmessage` would never fire.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { subscribeEditLog } from './wiki'
+import { subscribeNotebookEvents } from './notebook'
+
+class FakeEventSource {
+  static lastURL: string | null = null
+  url: string
+  closed = false
+  listeners: Record<string, EventListener[]> = {}
+  constructor(url: string) {
+    this.url = url
+    FakeEventSource.lastURL = url
+  }
+  addEventListener(name: string, fn: EventListener) {
+    ;(this.listeners[name] ??= []).push(fn)
+  }
+  removeEventListener(name: string, fn: EventListener) {
+    const arr = this.listeners[name]
+    if (!arr) return
+    this.listeners[name] = arr.filter((f) => f !== fn)
+  }
+  close() {
+    this.closed = true
+  }
+  emit(name: string, data: unknown) {
+    const fns = this.listeners[name] ?? []
+    const ev = new MessageEvent('message', { data: JSON.stringify(data) })
+    for (const fn of fns) fn(ev)
+  }
+}
+
+describe('SSE dead-path fix', () => {
+  const originalES = globalThis.EventSource
+  let created: FakeEventSource[] = []
+
+  beforeEach(() => {
+    created = []
+    ;(globalThis as { EventSource: unknown }).EventSource = class extends FakeEventSource {
+      constructor(url: string) {
+        super(url)
+        created.push(this)
+      }
+    } as unknown as typeof EventSource
+  })
+
+  afterEach(() => {
+    ;(globalThis as { EventSource: unknown }).EventSource = originalES
+  })
+
+  it('subscribeEditLog opens /events (not /wiki/stream)', () => {
+    const unsub = subscribeEditLog(() => {})
+    expect(FakeEventSource.lastURL).not.toBeNull()
+    expect(FakeEventSource.lastURL!).not.toContain('/wiki/stream')
+    expect(FakeEventSource.lastURL!).toMatch(/\/events(\?|$)/)
+    unsub()
+  })
+
+  it('subscribeEditLog uses named wiki:write listener', () => {
+    const handler = vi.fn()
+    const unsub = subscribeEditLog(handler)
+    expect(created).toHaveLength(1)
+    const src = created[0]
+    // Broker sends an onmessage for the heartbeat `ready` event — handler
+    // MUST NOT fire for that. Only the named `wiki:write` event counts.
+    src.emit('message', { type: 'ready' })
+    expect(handler).not.toHaveBeenCalled()
+    src.emit('wiki:write', { path: 'team/people/sarah.md', author_slug: 'ceo', date: '2026-04-21T10:00:00Z' })
+    expect(handler).toHaveBeenCalledTimes(1)
+    unsub()
+    expect(src.closed).toBe(true)
+  })
+
+  it('subscribeNotebookEvents opens /events (not /notebooks/stream)', () => {
+    const unsub = subscribeNotebookEvents(() => {})
+    expect(FakeEventSource.lastURL).not.toBeNull()
+    expect(FakeEventSource.lastURL!).not.toContain('/notebooks/stream')
+    expect(FakeEventSource.lastURL!).toMatch(/\/events(\?|$)/)
+    unsub()
+  })
+
+  it('subscribeNotebookEvents wires both notebook:write and review:state_change listeners', () => {
+    const handler = vi.fn()
+    const unsub = subscribeNotebookEvents(handler)
+    const src = created[0]
+    src.emit('notebook:write', { slug: 'pm', path: 'agents/pm/notebook/foo.md' })
+    src.emit('review:state_change', { id: 'r1', old_state: 'in-review', new_state: 'approved' })
+    expect(handler).toHaveBeenCalledTimes(2)
+    // Generic messages (heartbeats, entity events) must NOT fire the handler.
+    src.emit('entity:fact_recorded', { kind: 'people', slug: 'sarah' })
+    expect(handler).toHaveBeenCalledTimes(2)
+    unsub()
+    expect(src.closed).toBe(true)
+  })
+})

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -98,41 +98,49 @@ export async function fetchHistory(
 }
 
 /**
- * Subscribe to broker SSE stream filtered for `wiki:write` events.
- * Returns an unsubscribe function. Falls back to a synthetic replay of
- * the mock edit log if the stream is unavailable.
+ * Subscribe to the shared broker `/events` SSE stream filtered to
+ * `wiki:write` events. Returns an unsubscribe function that tears down
+ * the underlying EventSource.
+ *
+ * Previously this subscribed to `/wiki/stream` — a path that never
+ * existed on the broker. Every call 404'd silently and live edit-log
+ * updates were dead in production. Matches the `api/entity.ts` pattern:
+ * broker emits named SSE events (`event: wiki:write\ndata: ...`) so we
+ * use `addEventListener('wiki:write', ...)` not `onmessage`.
  */
 export function subscribeEditLog(
   handler: (entry: WikiEditLogEntry) => void,
 ): () => void {
   let closed = false
   let source: EventSource | null = null
+  let onWrite: ((ev: MessageEvent) => void) | null = null
 
   try {
-    source = new EventSource(sseURL('/wiki/stream'))
-    source.onmessage = (ev) => {
+    const ES = (globalThis as { EventSource?: typeof EventSource }).EventSource
+    if (!ES) return () => { closed = true }
+    source = new ES(sseURL('/events'))
+    onWrite = (ev: MessageEvent) => {
       if (closed) return
       try {
         const data = JSON.parse(ev.data) as Record<string, unknown>
-        if (data && data.type === 'wiki:write') {
-          handler(data.entry as WikiEditLogEntry)
-        }
+        // Broker ships the full wikiWriteEvent envelope as the data
+        // payload; the edit-log UI only needs the entry fields.
+        const entry = (data.entry ?? data) as WikiEditLogEntry
+        handler(entry)
       } catch {
         // ignore malformed events
       }
     }
-    source.onerror = () => {
-      if (source) {
-        source.close()
-        source = null
-      }
-    }
+    source.addEventListener('wiki:write', onWrite as EventListener)
   } catch {
     source = null
   }
 
   return () => {
     closed = true
+    if (source && onWrite) {
+      source.removeEventListener('wiki:write', onWrite as EventListener)
+    }
     if (source) {
       source.close()
       source = null


### PR DESCRIPTION
## Summary

`api/wiki.ts:subscribeEditLog` and `api/notebook.ts:subscribeNotebookEvents` built EventSources pointed at `/wiki/stream` and `/notebooks/stream` — URLs the broker does not expose. The only SSE endpoint is `/events`, and it ships named events (`event: wiki:write\ndata: ...`, `event: notebook:write`, `event: review:state_change`) not anonymous frames. Every subscription 404'd silently, and even if the URL had worked, the `onmessage` handler would never have matched named-event output.

Net effect on production:
- Live edit-log updates at the bottom of `/wiki` were dead
- Live entry-state changes on `/notebooks` were dead
- Live Kanban transitions on `/reviews` were dead

Pages still rendered after a reload (TanStack Query re-fetches on mount), but SSE-driven push-updates never arrived.

Surfaced during the `/review` of PR #177 by the second agent while it wired the v1.2 entity-brief SSE surface correctly at `/events + addEventListener`. Flagged as follow-up tech debt; this is the follow-up.

## Fix

Swap both subscribers to match the pattern `api/entity.ts` already ships:
- Open `new EventSource(sseURL('/events'))`
- `addEventListener('wiki:write', ...)` / `addEventListener('notebook:write', ...)` / `addEventListener('review:state_change', ...)`
- `removeEventListener` + `close()` on unsubscribe

Both subscribers also normalize their payloads into the existing TS types so call sites don't need to change.

## Test plan

New `web/src/api/sse-dead-path.test.ts` — 4 regression tests locking:
1. `subscribeEditLog` opens `/events`, NOT `/wiki/stream`
2. `subscribeEditLog` fires only on `wiki:write`, not on the broker's `ready` heartbeat or generic message events
3. `subscribeNotebookEvents` opens `/events`, NOT `/notebooks/stream`
4. `subscribeNotebookEvents` wires BOTH `notebook:write` and `review:state_change` listeners and ignores unrelated named events (e.g., `entity:fact_recorded`)

- [x] `npm run test -- --run` — 209/209 pass (48 files)
- [x] `npm run build` clean, no TS errors

No backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Server-Sent Events (SSE) subscription reliability by consolidating to a shared endpoint and using named event listeners.
  * Added safeguards for environments without EventSource support.

* **Tests**
  * Added regression test suite verifying correct event subscription and handling behavior for notebook and wiki event streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->