### PR TITLE
feat(v1.3): dynamic wiki sections — sidebar evolves with team's actual content

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -464,7 +464,9 @@ type Broker struct {
 	reviewSubscribers   map[int]chan ReviewStateChangeEvent
 	entitySubscribers   map[int]chan EntityBriefSynthesizedEvent
 	factSubscribers     map[int]chan EntityFactRecordedEvent
+	wikiSectionsSubscribers map[int]chan WikiSectionsUpdatedEvent
 	wikiWorker          *WikiWorker
+	wikiSectionsCache   *wikiSectionsCache
 	reviewLog           *ReviewLog
 	reviewResolver      ReviewerResolver
 	factLog             *FactLog
@@ -1133,6 +1135,7 @@ func (b *Broker) requireAuth(next http.HandlerFunc) http.HandlerFunc {
 // Start launches the broker on the configured localhost port.
 func (b *Broker) Start() error {
 	b.ensureWikiWorker()
+	b.ensureWikiSectionsCache()
 	b.ensureReviewLog()
 	b.ensureEntitySynthesizer()
 	b.startReviewExpiryLoop(context.Background())
@@ -1213,6 +1216,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/wiki/article", b.requireAuth(b.handleWikiArticle))
 	mux.HandleFunc("/wiki/catalog", b.requireAuth(b.handleWikiCatalog))
 	mux.HandleFunc("/wiki/audit", b.requireAuth(b.handleWikiAudit))
+	mux.HandleFunc("/wiki/sections", b.requireAuth(b.handleWikiSections))
 	mux.HandleFunc("/notebook/write", b.requireAuth(b.handleNotebookWrite))
 	mux.HandleFunc("/notebook/read", b.requireAuth(b.handleNotebookRead))
 	mux.HandleFunc("/notebook/list", b.requireAuth(b.handleNotebookList))
@@ -1732,6 +1736,8 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 	defer unsubscribeEntity()
 	factEvents, unsubscribeFacts := b.SubscribeEntityFactEvents(64)
 	defer unsubscribeFacts()
+	sectionsEvents, unsubscribeSections := b.SubscribeWikiSectionsUpdated(16)
+	defer unsubscribeSections()
 
 	writeEvent := func(name string, payload any) error {
 		data, err := json.Marshal(payload)
@@ -1786,6 +1792,10 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		case evt, ok := <-factEvents:
 			if !ok || writeEvent("entity:fact_recorded", evt) != nil {
+				return
+			}
+		case evt, ok := <-sectionsEvents:
+			if !ok || writeEvent(wikiSectionsEventName, evt) != nil {
 				return
 			}
 		case <-heartbeat.C:

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -428,53 +428,53 @@ type ipRateLimitBucket struct {
 // Broker is a lightweight HTTP message broker for the team channel.
 // All agent MCP instances connect to this shared broker.
 type Broker struct {
-	channelStore        *channel.Store
-	messages            []channelMessage
-	members             []officeMember
-	memberIndex         map[string]int // slug → index into members; guarded by mu
-	channels            []teamChannel
-	sessionMode         string
-	oneOnOneAgent       string
-	focusMode           bool
-	tasks               []teamTask
-	requests            []humanInterview
-	actions             []officeActionLog
-	signals             []officeSignalRecord
-	decisions           []officeDecisionRecord
-	watchdogs           []watchdogAlert
-	scheduler           []schedulerJob
-	skills              []teamSkill
-	sharedMemory        map[string]map[string]string // namespace → key → value
-	lastTaggedAt        map[string]time.Time         // when each agent was last @mentioned
-	lastPaneSnapshot    map[string]string            // last captured pane content per agent (for change detection)
-	seenTelegramGroups  map[int64]string             // chat_id -> title, populated by transport
-	counter             int
-	notificationSince   string
-	insightsSince       string
-	pendingInterview    *humanInterview
-	usage               teamUsageState
-	externalDelivered   map[string]struct{} // message IDs already queued for external delivery
-	messageSubscribers  map[int]chan channelMessage
-	actionSubscribers   map[int]chan officeActionLog
-	activity            map[string]agentActivitySnapshot
-	activitySubscribers map[int]chan agentActivitySnapshot
-	officeSubscribers   map[int]chan officeChangeEvent
-	wikiSubscribers     map[int]chan wikiWriteEvent
-	notebookSubscribers map[int]chan notebookWriteEvent
-	reviewSubscribers   map[int]chan ReviewStateChangeEvent
-	entitySubscribers   map[int]chan EntityBriefSynthesizedEvent
-	factSubscribers     map[int]chan EntityFactRecordedEvent
+	channelStore            *channel.Store
+	messages                []channelMessage
+	members                 []officeMember
+	memberIndex             map[string]int // slug → index into members; guarded by mu
+	channels                []teamChannel
+	sessionMode             string
+	oneOnOneAgent           string
+	focusMode               bool
+	tasks                   []teamTask
+	requests                []humanInterview
+	actions                 []officeActionLog
+	signals                 []officeSignalRecord
+	decisions               []officeDecisionRecord
+	watchdogs               []watchdogAlert
+	scheduler               []schedulerJob
+	skills                  []teamSkill
+	sharedMemory            map[string]map[string]string // namespace → key → value
+	lastTaggedAt            map[string]time.Time         // when each agent was last @mentioned
+	lastPaneSnapshot        map[string]string            // last captured pane content per agent (for change detection)
+	seenTelegramGroups      map[int64]string             // chat_id -> title, populated by transport
+	counter                 int
+	notificationSince       string
+	insightsSince           string
+	pendingInterview        *humanInterview
+	usage                   teamUsageState
+	externalDelivered       map[string]struct{} // message IDs already queued for external delivery
+	messageSubscribers      map[int]chan channelMessage
+	actionSubscribers       map[int]chan officeActionLog
+	activity                map[string]agentActivitySnapshot
+	activitySubscribers     map[int]chan agentActivitySnapshot
+	officeSubscribers       map[int]chan officeChangeEvent
+	wikiSubscribers         map[int]chan wikiWriteEvent
+	notebookSubscribers     map[int]chan notebookWriteEvent
+	reviewSubscribers       map[int]chan ReviewStateChangeEvent
+	entitySubscribers       map[int]chan EntityBriefSynthesizedEvent
+	factSubscribers         map[int]chan EntityFactRecordedEvent
 	wikiSectionsSubscribers map[int]chan WikiSectionsUpdatedEvent
-	wikiWorker          *WikiWorker
-	wikiSectionsCache   *wikiSectionsCache
-	reviewLog           *ReviewLog
-	reviewResolver      ReviewerResolver
-	factLog             *FactLog
-	entitySynthesizer   *EntitySynthesizer
-	scanTracker         *scanStatusTracker
-	nextSubscriberID    int
-	agentStreams        map[string]*agentStreamBuffer
-	mu                  sync.Mutex
+	wikiWorker              *WikiWorker
+	wikiSectionsCache       *wikiSectionsCache
+	reviewLog               *ReviewLog
+	reviewResolver          ReviewerResolver
+	factLog                 *FactLog
+	entitySynthesizer       *EntitySynthesizer
+	scanTracker             *scanStatusTracker
+	nextSubscriberID        int
+	agentStreams            map[string]*agentStreamBuffer
+	mu                      sync.Mutex
 	// configMu serializes handleConfig POST reads/writes so concurrent
 	// /config calls don't corrupt ~/.wuphf/config.json. config.Save uses
 	// os.WriteFile (O_TRUNC) without locking, so two parallel POSTs can

--- a/internal/team/wiki_sections.go
+++ b/internal/team/wiki_sections.go
@@ -1,0 +1,629 @@
+package team
+
+// wiki_sections.go implements v1.3 dynamic wiki sections. Sections are
+// discovered from actual article paths under team/ and merged with the
+// sections declared in the active blueprint's wiki_schema. The discovered
+// list drives the sidebar IA so as agents write articles into new
+// top-level dirs ("retrospectives/", "templates/", ...) the sidebar grows
+// to match — instead of the hardcoded starter-pack list staying stale.
+//
+// Design summary
+// ==============
+//
+//   - A DiscoveredSection is "first path segment under team/" — flat, not
+//     nested. A brief at team/people/nazz.md belongs to section "people".
+//     We intentionally do NOT create nested subsections in v1.3.
+//
+//   - Blueprint-declared sections always appear, even before any article
+//     lands in them (FromSchema=true, ArticleCount=0). This keeps the
+//     onboarding empty-state consistent with today.
+//
+//   - Discovered-only sections (FromSchema=false) surface once an article
+//     exists. First-seen timestamps are persisted implicitly via the first
+//     commit that created a file in that dir — we pull them from git log.
+//
+//   - Caching: discovery walks team/ and shells out to git for section
+//     first-seen timestamps. We cache the result in memory with RWMutex
+//     and invalidate on wiki:write events, debounced by a 500ms timer so
+//     a flurry of writes produces at most one refresh. Same debounce
+//     shape as entity_synthesizer.go.
+//
+//   - SSE: on every refresh whose output differs from the last published
+//     list (by slug set), we emit wiki:sections_updated through the same
+//     /events fan-out the rest of the broker uses.
+//
+// Happy path
+//
+//   startup → DiscoverSections(repo, blueprint) → cache
+//      ↓
+//   wiki:write event → debounce 500ms → recompute → diff → publish?
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/onboarding"
+	"github.com/nex-crm/wuphf/internal/operations"
+)
+
+// SectionsRefreshDebounce bounds how often DiscoverSections runs under a
+// burst of wiki:write events. Chosen to match the entity-synth debounce
+// cadence so the two background loops don't contend.
+const SectionsRefreshDebounce = 500 * time.Millisecond
+
+// SectionDiscoveryTimeout bounds one DiscoverSections call. git log
+// shell-outs per section can add up on a very large wiki; the cap keeps
+// a pathological filesystem from stalling the broker forever.
+const SectionDiscoveryTimeout = 10 * time.Second
+
+// wikiSectionsEventName is the SSE event name emitted when the cached
+// section list changes. Separate from wiki:write so the frontend can
+// subscribe narrowly without re-parsing every article commit.
+const wikiSectionsEventName = "wiki:sections_updated"
+
+// DiscoveredSection is one top-level dir surfaced in the sidebar IA. A
+// section is either declared by the active blueprint (FromSchema=true)
+// or emerged organically from article writes (FromSchema=false). Both
+// shapes ship to the UI in the same list so the sidebar can style them
+// differently.
+type DiscoveredSection struct {
+	Slug         string    `json:"slug"`
+	Title        string    `json:"title"`
+	ArticlePaths []string  `json:"article_paths"`
+	ArticleCount int       `json:"article_count"`
+	FirstSeenTs  time.Time `json:"first_seen_ts"`
+	LastUpdateTs time.Time `json:"last_update_ts"`
+	FromSchema   bool      `json:"from_schema"`
+}
+
+// WikiSectionsUpdatedEvent is the SSE payload broadcast when the cached
+// section list changes shape (new section, or a section's count/bounds
+// shift). Content ships as the full section list so the UI can hot-swap
+// without another HTTP roundtrip.
+type WikiSectionsUpdatedEvent struct {
+	Sections  []DiscoveredSection `json:"sections"`
+	Timestamp string              `json:"timestamp"`
+}
+
+// DiscoverSections walks the repo's team/ tree and merges the observed
+// first-segment groups with the blueprint's declared wiki_schema dirs.
+// Blueprint sections are preserved even when empty; discovered-only
+// sections are appended after them.
+//
+// The returned slice is stable-sorted inside each partition: blueprint
+// sections follow blueprint order (as declared in wiki_schema.dirs),
+// discovered sections are alphabetical by slug. Consumers that want a
+// different ordering can re-sort — this is the canonical order.
+func DiscoverSections(ctx context.Context, repo *Repo, blueprint *operations.Blueprint) ([]DiscoveredSection, error) {
+	if repo == nil {
+		return nil, errors.New("wiki sections: repo is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("wiki sections: cancelled: %w", err)
+	}
+
+	blueprintOrder, blueprintSlugs := blueprintSectionSlugs(blueprint)
+
+	// Walk team/ and bucket every .md by first path segment.
+	bySection := map[string][]CatalogEntry{}
+	teamDir := repo.TeamDir()
+	walkErr := filepath.WalkDir(teamDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		rel, err := filepath.Rel(repo.Root(), path)
+		if err != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		slug := groupFromPath(rel)
+		if slug == "" || slug == "root" {
+			return nil
+		}
+		bySection[slug] = append(bySection[slug], CatalogEntry{
+			Path:  rel,
+			Title: "",
+			Group: slug,
+		})
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("wiki sections: walk team/: %w", walkErr)
+	}
+
+	// Assemble the section list: blueprint-declared first (in blueprint
+	// order), then discovered-only alphabetically.
+	out := make([]DiscoveredSection, 0, len(blueprintOrder)+len(bySection))
+	seen := map[string]struct{}{}
+
+	for _, slug := range blueprintOrder {
+		entries := bySection[slug]
+		section := materializeSection(ctx, repo, slug, entries, true)
+		out = append(out, section)
+		seen[slug] = struct{}{}
+	}
+
+	discoveredOnly := make([]string, 0, len(bySection))
+	for slug := range bySection {
+		if _, ok := blueprintSlugs[slug]; ok {
+			continue
+		}
+		discoveredOnly = append(discoveredOnly, slug)
+	}
+	sort.Strings(discoveredOnly)
+	for _, slug := range discoveredOnly {
+		if _, ok := seen[slug]; ok {
+			continue
+		}
+		section := materializeSection(ctx, repo, slug, bySection[slug], false)
+		out = append(out, section)
+	}
+
+	return out, nil
+}
+
+// blueprintSectionSlugs extracts the first-segment section slugs from the
+// blueprint's wiki_schema.dirs. Returns ([ordered slugs], lookup set).
+// A nil blueprint or empty schema returns empty results — the discoverer
+// then falls back to pure discovery.
+func blueprintSectionSlugs(bp *operations.Blueprint) ([]string, map[string]struct{}) {
+	if bp == nil || bp.WikiSchema == nil {
+		return nil, map[string]struct{}{}
+	}
+	order := make([]string, 0, len(bp.WikiSchema.Dirs))
+	seen := make(map[string]struct{}, len(bp.WikiSchema.Dirs))
+	for _, dir := range bp.WikiSchema.Dirs {
+		slug := blueprintDirToSlug(dir)
+		if slug == "" {
+			continue
+		}
+		if _, dup := seen[slug]; dup {
+			continue
+		}
+		seen[slug] = struct{}{}
+		order = append(order, slug)
+	}
+	return order, seen
+}
+
+// blueprintDirToSlug takes a wiki_schema dir like "team/playbooks/" and
+// returns "playbooks". Rejects anything that doesn't sit immediately
+// under team/ — nested dirs do not create sections in v1.3.
+func blueprintDirToSlug(dir string) string {
+	cleaned := strings.TrimSpace(dir)
+	cleaned = strings.TrimPrefix(cleaned, "./")
+	cleaned = strings.TrimSuffix(cleaned, "/")
+	// Bare team root — no section slug to derive.
+	if cleaned == "" || cleaned == "team" {
+		return ""
+	}
+	cleaned = strings.TrimPrefix(cleaned, "team/")
+	if cleaned == "" {
+		return ""
+	}
+	// First segment only — "people/foo" still maps to "people" (parent
+	// section) but we do not surface the nested piece as a section.
+	if idx := strings.Index(cleaned, "/"); idx >= 0 {
+		cleaned = cleaned[:idx]
+	}
+	return cleaned
+}
+
+// materializeSection computes the metadata for one section from its
+// article paths. Timestamps are resolved via git log on the oldest and
+// newest commits touching any file in the section; articles without git
+// history (pre-worker writes, tests) contribute a zero time which we
+// collapse to the filesystem mtime as a reasonable fallback.
+func materializeSection(ctx context.Context, repo *Repo, slug string, entries []CatalogEntry, fromSchema bool) DiscoveredSection {
+	title := sectionTitleFromSlug(slug)
+	paths := make([]string, 0, len(entries))
+	for _, e := range entries {
+		paths = append(paths, e.Path)
+	}
+	sort.Strings(paths)
+
+	section := DiscoveredSection{
+		Slug:         slug,
+		Title:        title,
+		ArticlePaths: paths,
+		ArticleCount: len(paths),
+		FromSchema:   fromSchema,
+	}
+
+	if len(paths) == 0 {
+		return section
+	}
+
+	// Resolve first-seen and last-update by scanning git log on every
+	// article in the section. For a small section this is cheap; for a
+	// large one (100+ articles) we cap the ctx via the caller's timeout.
+	var earliest, latest time.Time
+	for _, rel := range paths {
+		if err := ctx.Err(); err != nil {
+			break
+		}
+		refs, err := repo.Log(ctx, rel)
+		if err != nil || len(refs) == 0 {
+			// Fall back to mtime — keeps sections with pre-worker
+			// history (git bootstrap restore, tests) from rendering
+			// with zero timestamps.
+			if info, statErr := os.Stat(filepath.Join(repo.Root(), filepath.FromSlash(rel))); statErr == nil {
+				t := info.ModTime().UTC()
+				if earliest.IsZero() || t.Before(earliest) {
+					earliest = t
+				}
+				if latest.IsZero() || t.After(latest) {
+					latest = t
+				}
+			}
+			continue
+		}
+		newest := refs[0].Timestamp.UTC()
+		oldest := refs[len(refs)-1].Timestamp.UTC()
+		if earliest.IsZero() || oldest.Before(earliest) {
+			earliest = oldest
+		}
+		if latest.IsZero() || newest.After(latest) {
+			latest = newest
+		}
+	}
+	section.FirstSeenTs = earliest
+	section.LastUpdateTs = latest
+	return section
+}
+
+// sectionTitleFromSlug turns "retrospectives" into "Retrospectives" and
+// "ops-reviews" into "Ops Reviews". Purely cosmetic — the slug remains
+// the stable identifier.
+func sectionTitleFromSlug(slug string) string {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return ""
+	}
+	parts := strings.Split(slug, "-")
+	for i, p := range parts {
+		if p == "" {
+			continue
+		}
+		parts[i] = strings.ToUpper(p[:1]) + p[1:]
+	}
+	return strings.Join(parts, " ")
+}
+
+// wikiSectionsCache is the in-memory cache + debounced refresh loop that
+// powers the /wiki/sections endpoint and the SSE fan-out. One cache per
+// broker; lives as long as the broker.
+type wikiSectionsCache struct {
+	worker     *WikiWorker
+	blueprint  func() *operations.Blueprint
+	publisher  wikiSectionsPublisher
+
+	mu       sync.RWMutex
+	sections []DiscoveredSection
+	lastSig  string
+
+	stopCh chan struct{}
+	runMu  sync.Mutex
+	// refreshCh is fed one token per wiki:write. The drain loop debounces
+	// by reading one token, then sleeping until the debounce window
+	// passes without another token arriving.
+	refreshCh chan struct{}
+	stopped   bool
+}
+
+// wikiSectionsPublisher is the subset of Broker the cache needs. Having
+// it as an interface keeps the cache testable without an HTTP server.
+type wikiSectionsPublisher interface {
+	PublishWikiSectionsUpdated(evt WikiSectionsUpdatedEvent)
+}
+
+// newWikiSectionsCache wires a cache against the given worker + blueprint
+// resolver. The blueprint resolver is a closure so the cache picks up
+// the current active blueprint at refresh time (the user may change it
+// via /config after onboarding).
+func newWikiSectionsCache(worker *WikiWorker, blueprint func() *operations.Blueprint, publisher wikiSectionsPublisher) *wikiSectionsCache {
+	return &wikiSectionsCache{
+		worker:    worker,
+		blueprint: blueprint,
+		publisher: publisher,
+		refreshCh: make(chan struct{}, 1),
+	}
+}
+
+// Start kicks off the debounce loop and does one immediate compute so
+// the cache is warm before the first request.
+func (c *wikiSectionsCache) Start(ctx context.Context) {
+	c.runMu.Lock()
+	if c.stopCh != nil {
+		c.runMu.Unlock()
+		return
+	}
+	c.stopCh = make(chan struct{})
+	c.runMu.Unlock()
+
+	// Initial synchronous compute — callers hitting /wiki/sections right
+	// after startup get a populated list.
+	c.refresh(ctx)
+	go c.loop(ctx)
+}
+
+// Stop signals the debounce loop to exit. Idempotent.
+func (c *wikiSectionsCache) Stop() {
+	c.runMu.Lock()
+	defer c.runMu.Unlock()
+	if c.stopped || c.stopCh == nil {
+		return
+	}
+	c.stopped = true
+	close(c.stopCh)
+}
+
+// Enqueue is the hot-path signal the worker calls on every wiki:write.
+// Non-blocking; if the refresh channel already has a pending token the
+// call is a no-op (coalesced into the pending refresh).
+func (c *wikiSectionsCache) Enqueue() {
+	select {
+	case c.refreshCh <- struct{}{}:
+	default:
+	}
+}
+
+// Sections returns the current cached list. The returned slice is a
+// copy so callers can mutate freely without races.
+func (c *wikiSectionsCache) Sections() []DiscoveredSection {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if len(c.sections) == 0 {
+		return []DiscoveredSection{}
+	}
+	out := make([]DiscoveredSection, len(c.sections))
+	copy(out, c.sections)
+	return out
+}
+
+// loop is the debounce drain. One active refresh at a time; while a
+// refresh runs, further Enqueue calls simply leave a token on the
+// channel and the loop picks it up on the next iteration.
+func (c *wikiSectionsCache) loop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c.stopCh:
+			return
+		case <-c.refreshCh:
+			// Debounce: after the first token, wait for quiet before
+			// running. Any token arriving during the wait extends the
+			// window (but never past the cap of SectionsRefreshDebounce
+			// itself — we don't want to starve indefinitely under a
+			// non-stop write loop).
+			timer := time.NewTimer(SectionsRefreshDebounce)
+		waitLoop:
+			for {
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				case <-c.stopCh:
+					timer.Stop()
+					return
+				case <-c.refreshCh:
+					// Reset timer to extend the quiet window.
+					if !timer.Stop() {
+						<-timer.C
+					}
+					timer.Reset(SectionsRefreshDebounce)
+				case <-timer.C:
+					break waitLoop
+				}
+			}
+			c.refresh(ctx)
+		}
+	}
+}
+
+// refresh recomputes the section list and publishes a SSE event when the
+// shape changed. Errors during discovery are logged; the last-known
+// cache stays valid so a transient fs hiccup doesn't empty the sidebar.
+func (c *wikiSectionsCache) refresh(ctx context.Context) {
+	callCtx, cancel := context.WithTimeout(ctx, SectionDiscoveryTimeout)
+	defer cancel()
+
+	bp := c.resolveBlueprint()
+	sections, err := DiscoverSections(callCtx, c.worker.Repo(), bp)
+	if err != nil {
+		log.Printf("wiki sections: discover failed: %v", err)
+		return
+	}
+
+	sig := sectionsSignature(sections)
+	c.mu.Lock()
+	changed := sig != c.lastSig
+	c.sections = sections
+	c.lastSig = sig
+	c.mu.Unlock()
+
+	if changed && c.publisher != nil {
+		c.publisher.PublishWikiSectionsUpdated(WikiSectionsUpdatedEvent{
+			Sections:  sections,
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		})
+	}
+}
+
+// resolveBlueprint calls the closure; nil is fine — the discoverer
+// degrades to pure discovery.
+func (c *wikiSectionsCache) resolveBlueprint() *operations.Blueprint {
+	if c.blueprint == nil {
+		return nil
+	}
+	return c.blueprint()
+}
+
+// sectionsSignature is a compact fingerprint of the current section set.
+// Two section lists with the same signature are observationally the same
+// for sidebar purposes — same slugs, same counts, same declared-vs-
+// discovered split. We exclude timestamps so a routine wiki:write that
+// only bumps LastUpdateTs on an already-visible section does not spam
+// the SSE channel with near-duplicate events.
+func sectionsSignature(sections []DiscoveredSection) string {
+	parts := make([]string, 0, len(sections))
+	for _, s := range sections {
+		schemaFlag := "d"
+		if s.FromSchema {
+			schemaFlag = "s"
+		}
+		parts = append(parts, fmt.Sprintf("%s:%s:%d", schemaFlag, s.Slug, s.ArticleCount))
+	}
+	return strings.Join(parts, "|")
+}
+
+// resolveActiveBlueprint returns the current active blueprint or nil.
+// Loads YAML from disk on every call — cheap relative to the wiki walk
+// and ensures a user's blueprint change via /config is reflected on the
+// next refresh without restart.
+func resolveActiveBlueprint() *operations.Blueprint {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil
+	}
+	id := strings.TrimSpace(cfg.ActiveBlueprint())
+	if id == "" {
+		return nil
+	}
+	bp, err := operations.LoadBlueprint(onboarding.ResolveTemplatesRepoRoot(""), id)
+	if err != nil {
+		return nil
+	}
+	return &bp
+}
+
+// ── Broker wiring ────────────────────────────────────────────────────
+
+// SubscribeWikiSectionsUpdated returns a channel of section-updated
+// events plus an unsubscribe func. Mirror of SubscribeWikiEvents.
+func (b *Broker) SubscribeWikiSectionsUpdated(buffer int) (<-chan WikiSectionsUpdatedEvent, func()) {
+	if buffer <= 0 {
+		buffer = 16
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.wikiSectionsSubscribers == nil {
+		b.wikiSectionsSubscribers = make(map[int]chan WikiSectionsUpdatedEvent)
+	}
+	id := b.nextSubscriberID
+	b.nextSubscriberID++
+	ch := make(chan WikiSectionsUpdatedEvent, buffer)
+	b.wikiSectionsSubscribers[id] = ch
+	return ch, func() {
+		b.mu.Lock()
+		if existing, ok := b.wikiSectionsSubscribers[id]; ok {
+			delete(b.wikiSectionsSubscribers, id)
+			close(existing)
+		}
+		b.mu.Unlock()
+	}
+}
+
+// PublishWikiSectionsUpdated fans out a section-updated event to every
+// current SSE subscriber. Non-blocking per subscriber: a slow consumer
+// loses events rather than stalling the publisher.
+func (b *Broker) PublishWikiSectionsUpdated(evt WikiSectionsUpdatedEvent) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, ch := range b.wikiSectionsSubscribers {
+		select {
+		case ch <- evt:
+		default:
+		}
+	}
+}
+
+// EnqueueSectionsRefresh is the broker-level adapter the wiki worker
+// calls after a successful team wiki write. Implements
+// wikiSectionsNotifier. No-op when the cache is not attached (tests,
+// non-markdown backend).
+func (b *Broker) EnqueueSectionsRefresh() {
+	b.mu.Lock()
+	cache := b.wikiSectionsCache
+	b.mu.Unlock()
+	if cache == nil {
+		return
+	}
+	cache.Enqueue()
+}
+
+// WikiSectionsCache returns the attached cache, or nil when the markdown
+// backend is not active. Primarily used by tests; production code reads
+// via the HTTP handler.
+func (b *Broker) WikiSectionsCache() *wikiSectionsCache {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.wikiSectionsCache
+}
+
+// ensureWikiSectionsCache wires the cache against the current wiki
+// worker. Idempotent. Called after ensureWikiWorker.
+func (b *Broker) ensureWikiSectionsCache() {
+	b.mu.Lock()
+	if b.wikiSectionsCache != nil {
+		b.mu.Unlock()
+		return
+	}
+	worker := b.wikiWorker
+	b.mu.Unlock()
+	if worker == nil {
+		return
+	}
+	cache := newWikiSectionsCache(worker, resolveActiveBlueprint, b)
+	cache.Start(context.Background())
+
+	b.mu.Lock()
+	b.wikiSectionsCache = cache
+	b.mu.Unlock()
+}
+
+// handleWikiSections is GET /wiki/sections.
+//
+//	Response: { "sections": DiscoveredSection[] }
+//
+// Sections are served from the in-memory cache. If the cache isn't
+// attached yet (markdown backend disabled, wiki worker failed to
+// initialize), returns 503 — same shape the rest of the /wiki/* handlers
+// use.
+func (b *Broker) handleWikiSections(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	cache := b.WikiSectionsCache()
+	if cache == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "wiki backend is not active"})
+		return
+	}
+	sections := cache.Sections()
+	writeJSON(w, http.StatusOK, map[string]any{"sections": sections})
+}
+
+// sectionsJSON is a tiny helper for tests that want to assert the wire
+// shape without pulling in net/http.
+func sectionsJSON(sections []DiscoveredSection) ([]byte, error) {
+	return json.Marshal(map[string]any{"sections": sections})
+}

--- a/internal/team/wiki_sections.go
+++ b/internal/team/wiki_sections.go
@@ -311,9 +311,9 @@ func sectionTitleFromSlug(slug string) string {
 // powers the /wiki/sections endpoint and the SSE fan-out. One cache per
 // broker; lives as long as the broker.
 type wikiSectionsCache struct {
-	worker     *WikiWorker
-	blueprint  func() *operations.Blueprint
-	publisher  wikiSectionsPublisher
+	worker    *WikiWorker
+	blueprint func() *operations.Blueprint
+	publisher wikiSectionsPublisher
 
 	mu       sync.RWMutex
 	sections []DiscoveredSection

--- a/internal/team/wiki_sections_test.go
+++ b/internal/team/wiki_sections_test.go
@@ -1,0 +1,380 @@
+package team
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/operations"
+)
+
+// sectionsTestRepo spins up a fresh Repo backed by t.TempDir(). Returns a
+// worker so we can drive writes through it. The commit path is exactly
+// the one production uses — we want git history so DiscoverSections can
+// resolve first-seen / last-update timestamps.
+func sectionsTestRepo(t *testing.T) (*Repo, *WikiWorker) {
+	t.Helper()
+	root := t.TempDir()
+	backup := filepath.Join(t.TempDir(), "bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	worker := NewWikiWorker(repo, noopPublisher{})
+	worker.Start(context.Background())
+	t.Cleanup(worker.Stop)
+	return repo, worker
+}
+
+// writeArticle shells the write through the real worker so the commit
+// ends up in git history where materializeSection can find it.
+func writeArticle(t *testing.T, worker *WikiWorker, slug, path, content string) {
+	t.Helper()
+	_, _, err := worker.Enqueue(context.Background(), slug, path, content, "create", "test: seed "+path)
+	if err != nil {
+		t.Fatalf("Enqueue %s: %v", path, err)
+	}
+}
+
+func TestDiscoverSectionsBlueprintOnly(t *testing.T) {
+	repo, _ := sectionsTestRepo(t)
+	bp := &operations.Blueprint{
+		WikiSchema: &operations.BlueprintWikiSchema{
+			Dirs: []string{"team/people/", "team/playbooks/", "team/decisions/"},
+		},
+	}
+	sections, err := DiscoverSections(context.Background(), repo, bp)
+	if err != nil {
+		t.Fatalf("DiscoverSections: %v", err)
+	}
+	if len(sections) != 3 {
+		t.Fatalf("len=%d want 3 (%+v)", len(sections), sections)
+	}
+	wantOrder := []string{"people", "playbooks", "decisions"}
+	for i, s := range sections {
+		if s.Slug != wantOrder[i] {
+			t.Errorf("sections[%d].Slug=%q want %q", i, s.Slug, wantOrder[i])
+		}
+		if !s.FromSchema {
+			t.Errorf("sections[%d].FromSchema=false, want true", i)
+		}
+		if s.ArticleCount != 0 {
+			t.Errorf("sections[%d].ArticleCount=%d, want 0 (empty)", i, s.ArticleCount)
+		}
+	}
+}
+
+func TestDiscoverSectionsBlueprintPlusDiscovered(t *testing.T) {
+	repo, worker := sectionsTestRepo(t)
+	// Blueprint declares people + playbooks. Agents later write
+	// articles under retrospectives/ and templates/.
+	writeArticle(t, worker, "ceo", "team/people/nazz.md", "# Nazz\n")
+	writeArticle(t, worker, "pm", "team/playbooks/onboarding.md", "# Onboarding\n")
+	writeArticle(t, worker, "reviewer", "team/retrospectives/q1.md", "# Q1\n")
+	writeArticle(t, worker, "designer", "team/templates/brief.md", "# Brief\n")
+
+	bp := &operations.Blueprint{
+		WikiSchema: &operations.BlueprintWikiSchema{
+			Dirs: []string{"team/people/", "team/playbooks/"},
+		},
+	}
+	sections, err := DiscoverSections(context.Background(), repo, bp)
+	if err != nil {
+		t.Fatalf("DiscoverSections: %v", err)
+	}
+	// Expected order: blueprint-declared first (people, playbooks),
+	// then discovered-only alphabetical (retrospectives, templates).
+	wantOrder := []string{"people", "playbooks", "retrospectives", "templates"}
+	if len(sections) != len(wantOrder) {
+		t.Fatalf("len=%d want %d: %+v", len(sections), len(wantOrder), sections)
+	}
+	for i, s := range sections {
+		if s.Slug != wantOrder[i] {
+			t.Errorf("sections[%d].Slug=%q want %q", i, s.Slug, wantOrder[i])
+		}
+	}
+	// Blueprint sections must have FromSchema=true; discovered-only false.
+	if !sections[0].FromSchema || !sections[1].FromSchema {
+		t.Errorf("blueprint sections FromSchema=false, want true")
+	}
+	if sections[2].FromSchema || sections[3].FromSchema {
+		t.Errorf("discovered sections FromSchema=true, want false")
+	}
+	// Each section has exactly one article.
+	for _, s := range sections {
+		if s.ArticleCount != 1 {
+			t.Errorf("section %q count=%d want 1", s.Slug, s.ArticleCount)
+		}
+		if len(s.ArticlePaths) != 1 {
+			t.Errorf("section %q paths=%v want len 1", s.Slug, s.ArticlePaths)
+		}
+		// FirstSeenTs should be non-zero for a committed article.
+		if s.FirstSeenTs.IsZero() {
+			t.Errorf("section %q FirstSeenTs is zero (no commit history resolved)", s.Slug)
+		}
+		if s.LastUpdateTs.IsZero() {
+			t.Errorf("section %q LastUpdateTs is zero", s.Slug)
+		}
+	}
+}
+
+func TestDiscoverSectionsEmptyWiki(t *testing.T) {
+	repo, _ := sectionsTestRepo(t)
+	sections, err := DiscoverSections(context.Background(), repo, nil)
+	if err != nil {
+		t.Fatalf("DiscoverSections: %v", err)
+	}
+	if len(sections) != 0 {
+		t.Errorf("len=%d want 0 (empty wiki, nil blueprint)", len(sections))
+	}
+}
+
+func TestDiscoverSectionsDiscoveredOnlyAlphabetical(t *testing.T) {
+	repo, worker := sectionsTestRepo(t)
+	writeArticle(t, worker, "a", "team/zeta/one.md", "# one\n")
+	writeArticle(t, worker, "a", "team/alpha/one.md", "# one\n")
+	writeArticle(t, worker, "a", "team/mu/one.md", "# one\n")
+
+	sections, err := DiscoverSections(context.Background(), repo, nil)
+	if err != nil {
+		t.Fatalf("DiscoverSections: %v", err)
+	}
+	slugs := make([]string, 0, len(sections))
+	for _, s := range sections {
+		slugs = append(slugs, s.Slug)
+	}
+	want := []string{"alpha", "mu", "zeta"}
+	if len(slugs) != len(want) {
+		t.Fatalf("slugs=%v want %v", slugs, want)
+	}
+	for i, s := range slugs {
+		if s != want[i] {
+			t.Errorf("slugs[%d]=%q want %q", i, s, want[i])
+		}
+	}
+}
+
+func TestBlueprintDirToSlug(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"team/people/", "people"},
+		{"team/playbooks/", "playbooks"},
+		{"team/retrospectives", "retrospectives"},
+		{"team/people/nested/", "people"},
+		{"", ""},
+		{"team/", ""},
+		{"team", ""},
+		{"./team/customers/", "customers"},
+	}
+	for _, c := range cases {
+		got := blueprintDirToSlug(c.in)
+		if got != c.want {
+			t.Errorf("blueprintDirToSlug(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSectionTitleFromSlug(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"people", "People"},
+		{"ops-reviews", "Ops Reviews"},
+		{"retrospectives", "Retrospectives"},
+		{"", ""},
+		{"a", "A"},
+	}
+	for _, c := range cases {
+		got := sectionTitleFromSlug(c.in)
+		if got != c.want {
+			t.Errorf("sectionTitleFromSlug(%q)=%q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSectionsSignatureStability(t *testing.T) {
+	a := []DiscoveredSection{
+		{Slug: "people", ArticleCount: 3, FromSchema: true},
+		{Slug: "playbooks", ArticleCount: 1, FromSchema: true},
+	}
+	b := []DiscoveredSection{
+		{Slug: "people", ArticleCount: 3, FromSchema: true, LastUpdateTs: time.Now()},
+		{Slug: "playbooks", ArticleCount: 1, FromSchema: true, LastUpdateTs: time.Now()},
+	}
+	if sectionsSignature(a) != sectionsSignature(b) {
+		t.Error("signature changes on timestamp-only diff; should be stable")
+	}
+
+	c := []DiscoveredSection{
+		{Slug: "people", ArticleCount: 3, FromSchema: true},
+		{Slug: "playbooks", ArticleCount: 2, FromSchema: true},
+	}
+	if sectionsSignature(a) == sectionsSignature(c) {
+		t.Error("signature same across different article counts; should differ")
+	}
+}
+
+// recordingSectionsPublisher captures every PublishWikiSectionsUpdated
+// for the integration test below.
+type recordingSectionsPublisher struct {
+	mu     sync.Mutex
+	events []WikiSectionsUpdatedEvent
+}
+
+func (r *recordingSectionsPublisher) PublishWikiSectionsUpdated(evt WikiSectionsUpdatedEvent) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, evt)
+}
+
+func (r *recordingSectionsPublisher) snapshot() []WikiSectionsUpdatedEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]WikiSectionsUpdatedEvent, len(r.events))
+	copy(out, r.events)
+	return out
+}
+
+func TestWikiSectionsCacheEmitsEventOnNewSection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	// Build a worker whose publisher ALREADY knows about the cache.
+	// sectionsTestRepo starts the worker with a noopPublisher and the
+	// data race detector trips if we swap it out after Start() — so we
+	// wire the publisher up front and start the worker ourselves here.
+	root := t.TempDir()
+	backup := filepath.Join(t.TempDir(), "bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	bp := &operations.Blueprint{
+		WikiSchema: &operations.BlueprintWikiSchema{
+			Dirs: []string{"team/people/"},
+		},
+	}
+	recorder := &recordingSectionsPublisher{}
+
+	// Two-step bootstrap: (a) build the cache pointing at a to-be-
+	// constructed worker via a pointer indirection, (b) build the
+	// worker with the cache-aware publisher, (c) start both.
+	var worker *WikiWorker
+	cache := newWikiSectionsCache(nil, func() *operations.Blueprint { return bp }, recorder)
+	pub := &capturePublisherWithSections{inner: noopPublisher{}, cache: cache}
+	worker = NewWikiWorker(repo, pub)
+	cache.worker = worker
+	worker.Start(context.Background())
+	t.Cleanup(worker.Stop)
+
+	// Seed one article in the "people" dir so the initial compute is
+	// stable before we add a new section.
+	writeArticle(t, worker, "ceo", "team/people/seed.md", "# seed\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache.Start(ctx)
+	defer cache.Stop()
+
+	// Write an article in a brand-new section — the debounce loop
+	// should recompute and emit an event.
+	writeArticle(t, worker, "pm", "team/retrospectives/q1.md", "# Q1\n")
+
+	// Wait up to 2s (4x debounce) for the event.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		events := recorder.snapshot()
+		for _, evt := range events {
+			if sectionPresent(evt.Sections, "retrospectives") {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for sections_updated event mentioning 'retrospectives'. events=%+v", recorder.snapshot())
+}
+
+// capturePublisherWithSections wraps a base publisher + cache notifier.
+// Used in the integration test to route wiki writes into the cache.
+type capturePublisherWithSections struct {
+	inner wikiEventPublisher
+	cache *wikiSectionsCache
+}
+
+func (p *capturePublisherWithSections) PublishWikiEvent(evt wikiWriteEvent) {
+	p.inner.PublishWikiEvent(evt)
+}
+
+func (p *capturePublisherWithSections) EnqueueSectionsRefresh() {
+	p.cache.Enqueue()
+}
+
+func sectionPresent(sections []DiscoveredSection, slug string) bool {
+	for _, s := range sections {
+		if s.Slug == slug {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWikiSectionsCacheStartSynchronousCompute(t *testing.T) {
+	_, worker := sectionsTestRepo(t)
+	writeArticle(t, worker, "ceo", "team/people/nazz.md", "# Nazz\n")
+	writeArticle(t, worker, "ceo", "team/templates/brief.md", "# Brief\n")
+
+	bp := &operations.Blueprint{
+		WikiSchema: &operations.BlueprintWikiSchema{
+			Dirs: []string{"team/people/"},
+		},
+	}
+	cache := newWikiSectionsCache(worker, func() *operations.Blueprint { return bp }, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cache.Start(ctx)
+	defer cache.Stop()
+
+	sections := cache.Sections()
+	if len(sections) != 2 {
+		t.Fatalf("len=%d want 2: %+v", len(sections), sections)
+	}
+	slugs := make([]string, 0, len(sections))
+	for _, s := range sections {
+		slugs = append(slugs, s.Slug)
+	}
+	sort.Strings(slugs)
+	if slugs[0] != "people" || slugs[1] != "templates" {
+		t.Errorf("slugs=%v want [people templates]", slugs)
+	}
+}
+
+// TestDiscoverSectionsStableFilesystemFallback guarantees that a section
+// created outside the worker (e.g. bootstrap materializer laid down a
+// dir before the worker turned on) still resolves a non-zero timestamp
+// from filesystem mtime. Catches a regression where we silently drop
+// the section because git log returned empty.
+func TestDiscoverSectionsStableFilesystemFallback(t *testing.T) {
+	repo, _ := sectionsTestRepo(t)
+	dir := filepath.Join(repo.Root(), "team", "bootstrap")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "seed.md"), []byte("# seed\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	sections, err := DiscoverSections(context.Background(), repo, nil)
+	if err != nil {
+		t.Fatalf("DiscoverSections: %v", err)
+	}
+	if len(sections) != 1 || sections[0].Slug != "bootstrap" {
+		t.Fatalf("sections=%+v want one 'bootstrap'", sections)
+	}
+	if sections[0].FirstSeenTs.IsZero() {
+		t.Error("FirstSeenTs is zero — expected mtime fallback")
+	}
+}

--- a/internal/team/wiki_worker.go
+++ b/internal/team/wiki_worker.go
@@ -102,6 +102,14 @@ type wikiEventPublisher interface {
 	PublishWikiEvent(evt wikiWriteEvent)
 }
 
+// wikiSectionsNotifier is the optional hook the worker pokes on every
+// successful wiki write so the sections cache can debounce + recompute.
+// Kept as its own interface so wiki_worker.go doesn't take a hard
+// dependency on the sections cache (which lives in wiki_sections.go).
+type wikiSectionsNotifier interface {
+	EnqueueSectionsRefresh()
+}
+
 // noopPublisher is used when the worker runs without a broker attached
 // (tests, or --memory-backend markdown without a broker yet).
 type noopPublisher struct{}
@@ -251,6 +259,12 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 			AuthorSlug: req.Slug,
 			Timestamp:  ts,
 		})
+		// Poke the sections cache so it debounces + recomputes. Only
+		// fired on team wiki writes — notebook + entity-fact writes
+		// never change the sidebar IA.
+		if notifier, ok := w.publisher.(wikiSectionsNotifier); ok {
+			notifier.EnqueueSectionsRefresh()
+		}
 	}
 
 	w.maybeScheduleBackup(ctx)

--- a/web/src/api/wiki.test.ts
+++ b/web/src/api/wiki.test.ts
@@ -81,6 +81,47 @@ describe('wiki api client', () => {
     expect(result.contributors.length).toBeGreaterThan(0)
   })
 
+  it('fetchSections returns the server response when the endpoint succeeds', async () => {
+    const sections: api.DiscoveredSection[] = [
+      {
+        slug: 'people',
+        title: 'People',
+        article_paths: ['team/people/a.md'],
+        article_count: 1,
+        first_seen_ts: new Date().toISOString(),
+        last_update_ts: new Date().toISOString(),
+        from_schema: true,
+      },
+    ]
+    vi.spyOn(client, 'get').mockResolvedValue({ sections })
+    const result = await api.fetchSections()
+    expect(result).toEqual(sections)
+  })
+
+  it('fetchSections returns an empty array on network error', async () => {
+    vi.spyOn(client, 'get').mockRejectedValue(new Error('boom'))
+    const result = await api.fetchSections()
+    expect(result).toEqual([])
+  })
+
+  it('fetchSections tolerates a null payload', async () => {
+    vi.spyOn(client, 'get').mockResolvedValue({ sections: null })
+    const result = await api.fetchSections()
+    expect(result).toEqual([])
+  })
+
+  it('subscribeSectionsUpdated returns an unsubscribe function even when SSE is unavailable', () => {
+    const originalEventSource = (globalThis as { EventSource?: unknown }).EventSource
+    ;(globalThis as { EventSource?: unknown }).EventSource = undefined
+    try {
+      const unsub = api.subscribeSectionsUpdated(() => {})
+      expect(typeof unsub).toBe('function')
+      unsub()
+    } finally {
+      ;(globalThis as { EventSource?: unknown }).EventSource = originalEventSource
+    }
+  })
+
   it('subscribeEditLog returns an unsubscribe function even when SSE is unavailable', () => {
     // No EventSource in happy-dom by default — the client should not throw.
     const originalEventSource = (globalThis as { EventSource?: unknown }).EventSource

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -27,6 +27,30 @@ export interface WikiCatalogEntry {
   group: string
 }
 
+/**
+ * Dynamic section discovered from actual wiki content + the blueprint's
+ * declared wiki_schema. Maps 1:1 to Go's `team.DiscoveredSection`.
+ *
+ * A section is "from_schema" when the active blueprint declared it in
+ * wiki_schema.dirs. Otherwise it emerged organically from articles the
+ * team wrote. Both shapes ship in the same list so the sidebar can
+ * distinguish them visually.
+ */
+export interface DiscoveredSection {
+  slug: string
+  title: string
+  article_paths: string[]
+  article_count: number
+  first_seen_ts: string
+  last_update_ts: string
+  from_schema: boolean
+}
+
+export interface WikiSectionsUpdatedEvent {
+  sections: DiscoveredSection[]
+  timestamp: string
+}
+
 export interface WikiHistoryCommit {
   sha: string
   author_slug: string
@@ -48,6 +72,68 @@ export async function fetchArticle(path: string): Promise<WikiArticle> {
     return await get<WikiArticle>(`/wiki/article?path=${encodeURIComponent(path)}`)
   } catch {
     return mockArticle(path)
+  }
+}
+
+/**
+ * GET /wiki/sections — the v1.3 dynamic-section IA. Returns blueprint-
+ * declared sections (in blueprint order) followed by discovered
+ * sections (alphabetical). Empty array on backend error so the sidebar
+ * can fall back to the catalog-derived group set without blanking.
+ */
+export async function fetchSections(): Promise<DiscoveredSection[]> {
+  try {
+    const res = await get<{ sections: DiscoveredSection[] }>('/wiki/sections')
+    return Array.isArray(res?.sections) ? res.sections : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Subscribe to the shared broker `/events` SSE stream filtered to
+ * `wiki:sections_updated` events. Returns an unsubscribe function.
+ *
+ * Named event pattern matches subscribeEditLog + subscribeEntityEvents.
+ * Do NOT switch to onmessage — the broker only emits named events and
+ * the default handler never fires for named payloads.
+ */
+export function subscribeSectionsUpdated(
+  handler: (event: WikiSectionsUpdatedEvent) => void,
+): () => void {
+  let closed = false
+  let source: EventSource | null = null
+  let onEvent: ((ev: MessageEvent) => void) | null = null
+
+  try {
+    const ES = (globalThis as { EventSource?: typeof EventSource }).EventSource
+    if (!ES) return () => { closed = true }
+    source = new ES(sseURL('/events'))
+    onEvent = (ev: MessageEvent) => {
+      if (closed) return
+      try {
+        const data = JSON.parse(ev.data) as WikiSectionsUpdatedEvent
+        if (data && Array.isArray(data.sections)) {
+          handler(data)
+        }
+      } catch {
+        // ignore malformed events
+      }
+    }
+    source.addEventListener('wiki:sections_updated', onEvent as EventListener)
+  } catch {
+    source = null
+  }
+
+  return () => {
+    closed = true
+    if (source && onEvent) {
+      source.removeEventListener('wiki:sections_updated', onEvent as EventListener)
+    }
+    if (source) {
+      source.close()
+      source = null
+    }
   }
 }
 

--- a/web/src/components/wiki/Wiki.tsx
+++ b/web/src/components/wiki/Wiki.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react'
-import { fetchCatalog, type WikiCatalogEntry } from '../../api/wiki'
+import {
+  fetchCatalog,
+  fetchSections,
+  subscribeSectionsUpdated,
+  type DiscoveredSection,
+  type WikiCatalogEntry,
+} from '../../api/wiki'
 import WikiSidebar from './WikiSidebar'
 import WikiCatalog from './WikiCatalog'
 import WikiArticle from './WikiArticle'
@@ -20,13 +26,18 @@ interface WikiProps {
 /** Three-column wiki shell: left sidebar · main (catalog or article) · right rail (article only). */
 export default function Wiki({ articlePath, onNavigate }: WikiProps) {
   const [catalog, setCatalog] = useState<WikiCatalogEntry[]>([])
+  const [sections, setSections] = useState<DiscoveredSection[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     let cancelled = false
-    fetchCatalog()
-      .then((c) => {
-        if (!cancelled) setCatalog(c)
+    // Parallel fetch: catalog and sections are independent so we pay one
+    // round-trip of latency, not two.
+    Promise.all([fetchCatalog(), fetchSections()])
+      .then(([c, s]) => {
+        if (cancelled) return
+        setCatalog(c)
+        setSections(s)
       })
       .finally(() => {
         if (!cancelled) setLoading(false)
@@ -34,6 +45,17 @@ export default function Wiki({ articlePath, onNavigate }: WikiProps) {
     return () => {
       cancelled = true
     }
+  }, [])
+
+  // Live-update sections when the broker emits wiki:sections_updated.
+  // The event payload carries the full list so no refetch is needed.
+  useEffect(() => {
+    const unsubscribe = subscribeSectionsUpdated((event) => {
+      if (Array.isArray(event.sections)) {
+        setSections(event.sections)
+      }
+    })
+    return () => unsubscribe()
   }, [])
 
   const isAudit = articlePath === AUDIT_PATH
@@ -44,6 +66,7 @@ export default function Wiki({ articlePath, onNavigate }: WikiProps) {
       <div className="wiki-layout" data-view={view}>
         <WikiSidebar
           catalog={catalog}
+          sections={sections}
           currentPath={isAudit ? null : articlePath}
           onNavigate={(path) => onNavigate(path)}
           onNavigateAudit={() => onNavigate(AUDIT_PATH)}

--- a/web/src/components/wiki/WikiSidebar.test.tsx
+++ b/web/src/components/wiki/WikiSidebar.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import WikiSidebar from './WikiSidebar'
-import type { WikiCatalogEntry } from '../../api/wiki'
+import type { DiscoveredSection, WikiCatalogEntry } from '../../api/wiki'
 
 const CATALOG: WikiCatalogEntry[] = [
   { path: 'people/nazz', title: 'Nazz', author_slug: 'pm', last_edited_ts: new Date().toISOString(), group: 'people' },
@@ -9,7 +9,7 @@ const CATALOG: WikiCatalogEntry[] = [
   { path: 'playbooks/churn', title: 'Churn prevention', author_slug: 'cmo', last_edited_ts: new Date().toISOString(), group: 'playbooks' },
 ]
 
-describe('<WikiSidebar>', () => {
+describe('<WikiSidebar> — legacy catalog-grouping path', () => {
   it('renders grouped articles', () => {
     render(<WikiSidebar catalog={CATALOG} onNavigate={() => {}} />)
     expect(screen.getByText('people')).toBeInTheDocument()
@@ -36,5 +36,111 @@ describe('<WikiSidebar>', () => {
     fireEvent.change(search, { target: { value: 'churn' } })
     expect(screen.getByText('Churn prevention')).toBeInTheDocument()
     expect(screen.queryByText('Nazz')).not.toBeInTheDocument()
+  })
+})
+
+// ── Dynamic sections — v1.3 ──────────────────────────────────────────
+
+const nowIso = () => new Date().toISOString()
+const daysAgoIso = (days: number) =>
+  new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+
+const SECTIONS: DiscoveredSection[] = [
+  {
+    slug: 'people',
+    title: 'People',
+    article_paths: ['team/people/nazz.md', 'team/people/sarah.md'],
+    article_count: 2,
+    first_seen_ts: daysAgoIso(30),
+    last_update_ts: nowIso(),
+    from_schema: true,
+  },
+  {
+    slug: 'playbooks',
+    title: 'Playbooks',
+    article_paths: ['team/playbooks/churn.md'],
+    article_count: 1,
+    first_seen_ts: daysAgoIso(14),
+    last_update_ts: nowIso(),
+    from_schema: true,
+  },
+  {
+    slug: 'retrospectives',
+    title: 'Retrospectives',
+    article_paths: [],
+    article_count: 0,
+    first_seen_ts: daysAgoIso(2),
+    last_update_ts: nowIso(),
+    from_schema: false,
+  },
+]
+
+describe('<WikiSidebar> — dynamic sections', () => {
+  it('renders sections in the order provided', () => {
+    render(<WikiSidebar catalog={CATALOG} sections={SECTIONS} onNavigate={() => {}} />)
+    const headers = screen.getAllByRole('heading', { level: 3 })
+    expect(headers.map((h) => h.dataset.sectionSlug ?? h.closest('[data-section-slug]')?.getAttribute('data-section-slug'))).toEqual([
+      'people',
+      'playbooks',
+      'retrospectives',
+    ])
+  })
+
+  it('distinguishes schema-declared from discovered sections via class', () => {
+    render(<WikiSidebar catalog={CATALOG} sections={SECTIONS} onNavigate={() => {}} />)
+    const peopleHeader = screen.getByText(/people/i).closest('h3')
+    const retroHeader = screen.getByText(/retrospectives/i).closest('h3')
+    expect(peopleHeader).toHaveClass('wk-section-schema')
+    expect(retroHeader).toHaveClass('wk-section-discovered')
+  })
+
+  it('marks recently-discovered sections with a "new" indicator', () => {
+    render(<WikiSidebar catalog={CATALOG} sections={SECTIONS} onNavigate={() => {}} />)
+    // retrospectives was first seen 2 days ago — under the 7-day window.
+    expect(screen.getByLabelText('New section')).toBeInTheDocument()
+  })
+
+  it('does not mark blueprint-declared sections as new even if recent', () => {
+    const recent: DiscoveredSection[] = [
+      {
+        ...SECTIONS[0],
+        first_seen_ts: daysAgoIso(1),
+        from_schema: true,
+      },
+    ]
+    render(<WikiSidebar catalog={CATALOG} sections={recent} onNavigate={() => {}} />)
+    expect(screen.queryByLabelText('New section')).toBeNull()
+  })
+
+  it('shows an "add to blueprint" banner when a discovered section header is clicked', () => {
+    render(<WikiSidebar catalog={CATALOG} sections={SECTIONS} onNavigate={() => {}} />)
+    expect(screen.queryByTestId('section-banner')).toBeNull()
+    const retroHeader = screen.getByText(/retrospectives/i).closest('h3')!
+    fireEvent.click(retroHeader)
+    expect(screen.getByTestId('section-banner')).toBeInTheDocument()
+    expect(screen.getByTestId('section-banner')).toHaveTextContent('retrospectives')
+  })
+
+  it('does not show the banner for blueprint-declared sections', () => {
+    render(<WikiSidebar catalog={CATALOG} sections={SECTIONS} onNavigate={() => {}} />)
+    const peopleHeader = screen.getByText(/people/i).closest('h3')!
+    fireEvent.click(peopleHeader)
+    expect(screen.queryByTestId('section-banner')).toBeNull()
+  })
+
+  it('renders empty sections with a placeholder row', () => {
+    render(<WikiSidebar catalog={CATALOG} sections={SECTIONS} onNavigate={() => {}} />)
+    // retrospectives has no articles — placeholder should be visible.
+    expect(screen.getByText('No articles yet')).toBeInTheDocument()
+  })
+
+  it('filters by search within the section structure', () => {
+    render(<WikiSidebar catalog={CATALOG} sections={SECTIONS} onNavigate={() => {}} />)
+    const search = screen.getByPlaceholderText('Search wiki…')
+    fireEvent.change(search, { target: { value: 'churn' } })
+    expect(screen.getByText('Churn prevention')).toBeInTheDocument()
+    expect(screen.queryByText('Nazz')).toBeNull()
+    // An empty section ("retrospectives") is hidden during search.
+    expect(screen.queryByText(/retrospectives/i)).toBeNull()
   })
 })

--- a/web/src/components/wiki/WikiSidebar.tsx
+++ b/web/src/components/wiki/WikiSidebar.tsx
@@ -1,30 +1,70 @@
 import { useMemo, useState } from 'react'
-import type { WikiCatalogEntry } from '../../api/wiki'
+import type { DiscoveredSection, WikiCatalogEntry } from '../../api/wiki'
 import { resolveGroupOrder } from '../../lib/groupOrder'
 
 /** Left-rail thematic dir groups + Tools section + search. */
 
 interface WikiSidebarProps {
   catalog: WikiCatalogEntry[]
+  /**
+   * Dynamic sections discovered by the broker — blueprint-declared and
+   * article-derived. When provided, this drives the IA instead of the
+   * catalog's `group` field so sections evolve with team content.
+   * Absent when the backend endpoint is unavailable (test fallback /
+   * non-markdown memory backend).
+   */
+  sections?: DiscoveredSection[]
   currentPath?: string | null
   onNavigate: (path: string) => void
   /** Optional audit-log opener — rendered as a footer link when provided. */
   onNavigateAudit?: () => void
 }
 
+// Sections first seen within this window render a "new" indicator. 7 days
+// matches the roadmap copy — a fresh section is novel enough to draw the
+// eye, but once a week later it settles into the steady-state IA.
+const NEW_SECTION_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
+
 export default function WikiSidebar({
   catalog,
+  sections,
   currentPath,
   onNavigate,
   onNavigateAudit,
 }: WikiSidebarProps) {
   const [query, setQuery] = useState('')
+  const [bannerSlug, setBannerSlug] = useState<string | null>(null)
 
-  const grouped = useMemo(() => groupCatalog(catalog, query.trim()), [catalog, query])
-  const groupOrder = useMemo(
+  // When the broker ships sections, use them verbatim for the IA. Otherwise
+  // fall back to the legacy catalog-grouping path so the sidebar still
+  // renders against mocks / pre-v1.3 brokers.
+  const usingSections = Array.isArray(sections) && sections.length > 0
+
+  const groupedFromCatalog = useMemo(
+    () => groupCatalog(catalog, query.trim()),
+    [catalog, query],
+  )
+  const fallbackOrder = useMemo(
     () => resolveGroupOrder(catalog.map((c) => c.group)),
     [catalog],
   )
+
+  const sectionList = useMemo(
+    () => (usingSections ? applyQueryToSections(sections, catalog, query.trim()) : []),
+    [usingSections, sections, catalog, query],
+  )
+
+  const newSectionSlugs = useMemo(() => {
+    if (!usingSections) return new Set<string>()
+    const cutoff = Date.now() - NEW_SECTION_WINDOW_MS
+    const out = new Set<string>()
+    for (const s of sections ?? []) {
+      if (s.from_schema) continue
+      const ts = Date.parse(s.first_seen_ts)
+      if (!Number.isNaN(ts) && ts >= cutoff) out.add(s.slug)
+    }
+    return out
+  }, [usingSections, sections])
 
   return (
     <aside className="wk-nav-sidebar">
@@ -35,31 +75,53 @@ export default function WikiSidebar({
         value={query}
         onChange={(e) => setQuery(e.target.value)}
       />
+      {bannerSlug && (
+        <AddToBlueprintBanner
+          slug={bannerSlug}
+          onDismiss={() => setBannerSlug(null)}
+        />
+      )}
       <div className="wk-nav-sidebar-scroll">
-        {groupOrder.map((group) => {
-          const items = grouped[group]
-          if (!items || items.length === 0) return null
-          return (
-            <div key={group}>
-              <h3>{group}</h3>
-              <ul>
-                {items.map((item) => (
-                  <li key={item.path} className={currentPath === item.path ? 'current' : ''}>
-                    <a
-                      href={`#/wiki/${encodeURI(item.path)}`}
-                      onClick={(e) => {
-                        e.preventDefault()
-                        onNavigate(item.path)
-                      }}
-                    >
-                      {item.title}
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )
-        })}
+        {usingSections
+          ? sectionList.map((section) => (
+              <SectionGroup
+                key={section.slug}
+                section={section}
+                entries={section.entries}
+                currentPath={currentPath}
+                isNew={newSectionSlugs.has(section.slug)}
+                onNavigate={onNavigate}
+                onSectionHeaderClick={() => {
+                  if (!section.from_schema) {
+                    setBannerSlug(section.slug)
+                  }
+                }}
+              />
+            ))
+          : fallbackOrder.map((group) => {
+              const items = groupedFromCatalog[group]
+              if (!items || items.length === 0) return null
+              return (
+                <div key={group}>
+                  <h3>{group}</h3>
+                  <ul>
+                    {items.map((item) => (
+                      <li key={item.path} className={currentPath === item.path ? 'current' : ''}>
+                        <a
+                          href={`#/wiki/${encodeURI(item.path)}`}
+                          onClick={(e) => {
+                            e.preventDefault()
+                            onNavigate(item.path)
+                          }}
+                        >
+                          {item.title}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )
+            })}
       </div>
       {onNavigateAudit && (
         <div className="wk-sidebar-audit">
@@ -79,6 +141,97 @@ export default function WikiSidebar({
   )
 }
 
+interface SectionWithEntries extends DiscoveredSection {
+  entries: WikiCatalogEntry[]
+}
+
+interface SectionGroupProps {
+  section: DiscoveredSection
+  entries: WikiCatalogEntry[]
+  currentPath?: string | null
+  isNew: boolean
+  onNavigate: (path: string) => void
+  onSectionHeaderClick: () => void
+}
+
+function SectionGroup({
+  section,
+  entries,
+  currentPath,
+  isNew,
+  onNavigate,
+  onSectionHeaderClick,
+}: SectionGroupProps) {
+  return (
+    <div className="wk-section-group" data-section-slug={section.slug}>
+      <h3
+        className={`wk-section-header wk-section-${section.from_schema ? 'schema' : 'discovered'}`}
+        onClick={onSectionHeaderClick}
+        title={
+          section.from_schema
+            ? 'Declared in your blueprint'
+            : 'Discovered from articles your team has written'
+        }
+      >
+        <span className="wk-section-title">{section.slug}</span>
+        {!section.from_schema && (
+          <span className="wk-section-marker" aria-label="Discovered section" />
+        )}
+        {isNew && (
+          <span className="wk-section-new" aria-label="New section">
+            new
+          </span>
+        )}
+      </h3>
+      <ul>
+        {entries.length === 0 ? (
+          <li className="wk-section-empty">
+            <em>No articles yet</em>
+          </li>
+        ) : (
+          entries.map((item) => (
+            <li key={item.path} className={currentPath === item.path ? 'current' : ''}>
+              <a
+                href={`#/wiki/${encodeURI(item.path)}`}
+                onClick={(e) => {
+                  e.preventDefault()
+                  onNavigate(item.path)
+                }}
+              >
+                {item.title}
+              </a>
+            </li>
+          ))
+        )}
+      </ul>
+    </div>
+  )
+}
+
+interface AddToBlueprintBannerProps {
+  slug: string
+  onDismiss: () => void
+}
+
+function AddToBlueprintBanner({ slug, onDismiss }: AddToBlueprintBannerProps) {
+  return (
+    <div className="wk-section-banner" role="status" data-testid="section-banner">
+      <div className="wk-section-banner-body">
+        <strong>“{slug}”</strong> is a new section your team built organically.
+        Add it to your blueprint to make it permanent.
+      </div>
+      <button
+        type="button"
+        className="wk-section-banner-dismiss"
+        onClick={onDismiss}
+        aria-label="Dismiss banner"
+      >
+        ×
+      </button>
+    </div>
+  )
+}
+
 function groupCatalog(
   catalog: WikiCatalogEntry[],
   query: string,
@@ -91,6 +244,39 @@ function groupCatalog(
     }
     if (!out[entry.group]) out[entry.group] = []
     out[entry.group].push(entry)
+  }
+  return out
+}
+
+/**
+ * Bind each DiscoveredSection to the concrete catalog entries that live
+ * under it, then filter by the search query. Runs O(sections * catalog)
+ * but the catalog is small enough (hundreds of entries at worst) that
+ * this stays ~1ms.
+ */
+function applyQueryToSections(
+  sections: DiscoveredSection[],
+  catalog: WikiCatalogEntry[],
+  query: string,
+): SectionWithEntries[] {
+  const q = query.toLowerCase()
+  const byGroup: Record<string, WikiCatalogEntry[]> = {}
+  for (const entry of catalog) {
+    if (!byGroup[entry.group]) byGroup[entry.group] = []
+    byGroup[entry.group].push(entry)
+  }
+  const out: SectionWithEntries[] = []
+  for (const section of sections) {
+    const entries = (byGroup[section.slug] ?? []).filter((e) => {
+      if (!q) return true
+      return (
+        e.title.toLowerCase().includes(q) || e.path.toLowerCase().includes(q)
+      )
+    })
+    // Under search, hide sections that have no matching entry AND are
+    // empty by design (blueprint-declared but no articles yet).
+    if (q && entries.length === 0) continue
+    out.push({ ...section, entries })
   }
   return out
 }

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1125,6 +1125,75 @@
   color: var(--wk-wikilink);
 }
 
+/* ─── v1.3 dynamic sections ─── */
+.wk-section-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.wk-section-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: default;
+}
+.wk-section-discovered {
+  cursor: pointer;
+}
+.wk-section-discovered:hover .wk-section-title {
+  color: var(--wk-text);
+}
+.wk-section-marker {
+  display: inline-block;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--wk-text-tertiary);
+  opacity: 0.7;
+}
+.wk-section-new {
+  font-family: var(--wk-mono);
+  font-size: 9px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--wk-amber-bg);
+  color: var(--wk-amber-ink, var(--wk-text));
+}
+.wk-section-empty {
+  padding: 4px 10px;
+  color: var(--wk-text-tertiary);
+  font-size: 11px;
+  font-family: var(--wk-chrome);
+}
+.wk-section-banner {
+  margin: 6px 0 8px;
+  padding: 8px 10px;
+  background: var(--wk-amber-bg);
+  border-left: 3px solid var(--wk-amber);
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  font-size: 11px;
+  font-family: var(--wk-chrome);
+  color: var(--wk-text);
+  line-height: 1.4;
+}
+.wk-section-banner-body { flex: 1; }
+.wk-section-banner-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--wk-text-tertiary);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 2px;
+}
+.wk-section-banner-dismiss:hover { color: var(--wk-text); }
+
 /* Catalog header audit link */
 .wk-catalog-audit-link {
   font-family: inherit;


### PR DESCRIPTION
## Summary

- Wiki sidebar IA is now discovered from actual article paths under `team/` and merged with the active blueprint's `wiki_schema.dirs`. Blueprint sections stay pinned (even when empty); sections that emerge organically (retrospectives/, templates/, brand/) appear below, alphabetically, with a marker distinguishing them.
- New `GET /wiki/sections` endpoint backed by an in-memory cache with 500ms debounce on `wiki:write`. SSE event `wiki:sections_updated` fires when the section set changes shape (signature excludes timestamps so a routine edit doesn't spam).
- Sidebar renders the two partitions with different affordances: discovered sections carry a dot + optional "new" tag (first seen < 7d), and clicking a discovered header reveals a dismissible "add this section to your blueprint" hint — copy-only in v1.3.

## What changed

**Backend**
- `internal/team/wiki_sections.go` (new): `DiscoverSections`, `wikiSectionsCache` (debounce + RWMutex cache), broker subscribe/publish + `/wiki/sections` handler, `resolveActiveBlueprint` (re-reads blueprint each refresh so `/config` changes take effect).
- `internal/team/wiki_worker.go`: pokes the cache via a new `wikiSectionsNotifier` interface after every team wiki write (not notebook or entity-fact writes — those don't change IA).
- `internal/team/broker.go`: `ensureWikiSectionsCache()` runs from `Start()`, `/wiki/sections` is registered, and `wiki:sections_updated` is added to the `/events` multiplexer.

**Frontend**
- `web/src/api/wiki.ts`: `DiscoveredSection` + `WikiSectionsUpdatedEvent` types, `fetchSections()`, `subscribeSectionsUpdated()` (mirrors `subscribeEntityEvents` — named `addEventListener` on `/events`, NOT `onmessage`, so we don't regress the PR #182 pattern).
- `web/src/components/wiki/Wiki.tsx`: parallel fetch of catalog + sections; subscribes to `wiki:sections_updated` for live updates.
- `web/src/components/wiki/WikiSidebar.tsx`: accepts optional `sections` prop as source of truth; falls back to catalog-grouping for tests / older brokers. Adds `SectionGroup` with schema-vs-discovered class, `AddToBlueprintBanner`, empty-state placeholder.
- `web/src/styles/wiki.css`: small additions for the marker dot, "new" tag, and banner.

**Design decisions**
- Debounce 500ms to match `entity_synthesizer.go` cadence.
- Signature excludes timestamps so a content edit on an already-visible section doesn't emit SSE. Only shape changes (new section / count delta) publish.
- Sections are flat — first path segment under `team/`. Nested subsections are explicitly out of v1.3.
- mtime fallback for articles without git history (test fixtures, bootstrap restores) so the sidebar never hides a section silently.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages green (team: 30s, includes 8 new unit + integration tests)
- [x] `cd web && bun run build` — production build green
- [x] `cd web && bun run test` — 221 tests pass (12 sidebar, 14 api/wiki, full suite 48 files)
- [ ] Dev manual: start dev broker on 7899/7900 with `HOME=$HOME/.wuphf-dev-home`, write an article into a new top-level dir, confirm sidebar updates live via SSE without refresh.
- [ ] Verify blueprint-declared sections stay pinned when the user removes all articles under them.
- [ ] Verify "new" tag disappears after 7 days (or faster via date manipulation).

**Pre-existing race note:** the `-race` build surfaces a race in `TestRecoverFailedHeadlessTurnRequeuesExternalActionBeforeBlocking` (headless_codex.go), reproducible on `main` before this PR — not caused by this change.