### PR TITLE
fix(notebook): make .notebook-surface the scroll container

### DIFF
--- a/web/src/styles/notebook.css
+++ b/web/src/styles/notebook.css
@@ -37,7 +37,13 @@
   color: var(--nb-text);
   font-family: var(--nb-body-serif);
   line-height: 1.6;
-  min-height: 100%;
+  /* Fill the tab panel exactly and own the scroll for every notebook view.
+     Without this the nb-layout `min-height: 100vh` makes content taller than
+     `.wiki-shell-body`, which clips with overflow:hidden — leaving the image
+     uploader, drop zone, and footer unreachable. */
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
   /* Horizontal ruled-paper rhythm (28px) — matches body line-height so text
      sits ON the ruling, not crossed by it. */
   background-image:
@@ -114,7 +120,9 @@
 .notebook-surface .nb-layout {
   display: grid;
   grid-template-columns: var(--nb-sidebar-width) minmax(0, 1fr);
-  min-height: calc(100vh - var(--nb-appbar-h));
+  /* Let content size itself naturally; `.notebook-surface` is the scroller.
+     Using `100vh` here overflowed the shell and clipped the bottom. */
+  min-height: 100%;
 }
 
 /* ── Author shelf (left sidebar) ─────────────────────────────── */


### PR DESCRIPTION
## Summary

Notebook detail pages (`/notebooks/{slug}/{entry}`) could not be scrolled with a mouse wheel or trackpad. The image uploader, **Promote to wiki** button on long entries, and file-path footer were unreachable in a real browser.

Caught during the v1.3 browser E2E: `document.querySelectorAll` turned up **only** `.sidebar-agents`, `.sidebar-apps`, and (on the wiki tab) `.wk-article-col` as scrollable elements. Nothing in the notebook tab had `overflow-y: auto`, yet `.nb-layout` was 1677px tall inside a 619px `.wiki-shell-body { overflow: hidden }` container.

## Root cause

Three rules conspired:

1. `.wiki-shell-body` clamps children with `overflow: hidden`.
2. `.nb-layout` forced `min-height: calc(100vh - var(--nb-appbar-h))`, making it taller than the shell regardless of content.
3. Neither `.notebook-surface` nor `.nb-article` declared `overflow-y: auto`, so nothing claimed the scroll.

The wiki tab sidesteps this via `.wiki-layout > .wk-article-col { min-height: 0; overflow-y: auto }`. The notebook tab had no equivalent.

## Fix

- `.notebook-surface`: `height: 100%; min-height: 0; overflow-y: auto` — it now owns the scroll for every notebook view, matching the wiki tab's pattern.
- `.nb-layout`: `min-height: 100%` instead of `calc(100vh - appbar)` — content sizes naturally inside the scroller.

Ten-line diff, no JS change, no layout regression on Wiki tab (verified by eye after rebuild).

## Test plan

- [x] Load `/notebooks/pm/customer-acme-rough-notes` — mouse-wheel scroll reaches "Next steps", "Promote to wiki", footer, and the image drop zone
- [x] Load `/wiki/playbooks/churn-prevention.md` — existing wiki scroll behavior unchanged
- [x] `vite build` green
- [ ] Webapp unit tests (no new component logic; CSS-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notebook panel scrolling and layout behavior. Fixed content clipping and overflow issues by updating scroll container configuration and sizing calculations. Content now remains properly visible and accessible without viewport-based constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->