### PR TITLE
fix(web): annotate setNotebookRoute params so tsc --strict passes

### DIFF
--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -156,6 +156,6 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   notebookAgentSlug: null,
   notebookEntrySlug: null,
-  setNotebookRoute: (agentSlug, entrySlug) =>
+  setNotebookRoute: (agentSlug: string | null, entrySlug: string | null) =>
     set({ notebookAgentSlug: agentSlug, notebookEntrySlug: entrySlug }),
 }))


### PR DESCRIPTION
## Summary

`npm run build` fails on `main` with:

```
src/stores/app.ts(159,22): error TS7006: Parameter 'agentSlug' implicitly has an 'any' type.
src/stores/app.ts(159,33): error TS7006: Parameter 'entrySlug' implicitly has an 'any' type.
```

Caught while rebuilding the web bundle for a separate browser E2E. `npm run build` runs `tsc -b && vite build && touch dist/.gitkeep` — `tsc` fails under strict noImplicitAny, so `vite build` never runs. `vite build` alone still succeeds, which is why the regression landed through v1.3 without a CI signal.

## Fix

The interface declaration already says the right thing at `app.ts:89`:

```ts
setNotebookRoute: (agentSlug: string | null, entrySlug: string | null) => void
```

Annotate the implementation to match. One-line diff, zero behavior change.

## Test plan

- [x] `npm run build` green
- [ ] Web CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)