### PR TITLE
feat: human-editable wiki — in-browser editor on /wiki/* articles

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -1211,6 +1211,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/task-plan", b.requireAuth(b.handleTaskPlan))
 	mux.HandleFunc("/memory", b.requireAuth(b.handleMemory))
 	mux.HandleFunc("/wiki/write", b.requireAuth(b.handleWikiWrite))
+	mux.HandleFunc("/wiki/write-human", b.requireAuth(b.handleWikiWriteHuman))
 	mux.HandleFunc("/wiki/read", b.requireAuth(b.handleWikiRead))
 	mux.HandleFunc("/wiki/search", b.requireAuth(b.handleWikiSearch))
 	mux.HandleFunc("/wiki/list", b.requireAuth(b.handleWikiList))

--- a/internal/team/human_commit.go
+++ b/internal/team/human_commit.go
@@ -1,0 +1,179 @@
+package team
+
+// human_commit.go owns the repo-level write path for human-authored wiki
+// edits. It mirrors Repo.Commit but adds optimistic-concurrency checks:
+// the caller must pass the SHA of the last article version they saw, and
+// the commit is rejected with ErrWikiSHAMismatch when HEAD has moved on.
+//
+// Design notes
+// ============
+//
+//   - Identity is fixed: every human write is attributed to a synthetic
+//     `human` slug, yielding commit author `Human <human@wuphf.local>`.
+//     v1 deliberately ships a single human identity — the founder. Per-user
+//     attribution is a v1.1 concern; see the PR description.
+//   - Concurrency model is optimistic, not pessimistic: we never lock the
+//     article across the editor open → save round-trip. Readers and
+//     agents keep writing freely; conflicts surface at save time and the
+//     client re-loads the latest. This mirrors Wikipedia's "edit
+//     conflict" flow, and avoids the half-typed-draft lock state that
+//     pessimistic locking would introduce.
+//   - Serialization still flows through the single-writer WikiWorker
+//     queue. This file owns the repo-level mechanics; the worker owns
+//     the scheduling primitive. Two different layers, same invariant.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// HumanAuthor is the synthetic commit author slug for every human edit.
+// Yields `Human <human@wuphf.local>` via runGitLocked's identity derivation.
+// Distinct from every agent slug and from the other synthetic identities
+// (archivist, wuphf-bootstrap, wuphf-recovery, system) so audit views can
+// colour human edits distinctly.
+const HumanAuthor = "human"
+
+// ErrWikiSHAMismatch is returned by CommitHuman when the caller's
+// expected_sha does not match the current HEAD SHA for the article. The
+// HTTP handler surfaces this as 409 Conflict + the current article body
+// so the client can show the re-load prompt without a second round trip.
+var ErrWikiSHAMismatch = errors.New("wiki: article changed since it was opened")
+
+// CommitHuman writes content to relPath as the synthetic human author,
+// enforcing an expected-SHA pre-check. Returns the new short SHA, bytes
+// written, and an error; ErrWikiSHAMismatch means the caller should
+// re-load and re-apply their edits. Mode is inferred from mustExist: a
+// fresh article (expectedSHA == "") uses "create", an edit uses "replace".
+//
+// Mirrors Repo.Commit in all other respects: same validateArticlePath
+// guard, same working-tree atomicity, same regenerateIndexLocked pass
+// so the index lands in the same commit as the article edit.
+func (r *Repo) CommitHuman(ctx context.Context, relPath, content, expectedSHA, message string) (string, int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := validateArticlePath(relPath); err != nil {
+		return "", 0, err
+	}
+	if strings.TrimSpace(content) == "" {
+		return "", 0, fmt.Errorf("wiki: content is required")
+	}
+
+	fullPath := filepath.Join(r.root, relPath)
+	exists := false
+	if _, err := os.Stat(fullPath); err == nil {
+		exists = true
+	}
+
+	// Optimistic concurrency pre-check. Runs BEFORE any filesystem mutation
+	// so a rejection leaves the working tree clean — matches the pattern
+	// used in broker_review.reviewApprove (validate, then enqueue).
+	if exists {
+		if expectedSHA == "" {
+			// Caller tried to create over an existing article; reject so
+			// they get the current SHA and can re-submit as an edit.
+			curSHA, serr := r.currentArticleSHALocked(ctx, relPath)
+			if serr != nil {
+				return "", 0, fmt.Errorf("wiki: resolve current sha: %w", serr)
+			}
+			return curSHA, 0, fmt.Errorf("%w: article exists but no expected_sha supplied", ErrWikiSHAMismatch)
+		}
+		curSHA, serr := r.currentArticleSHALocked(ctx, relPath)
+		if serr != nil {
+			return "", 0, fmt.Errorf("wiki: resolve current sha: %w", serr)
+		}
+		if !shaEquivalent(curSHA, expectedSHA) {
+			return curSHA, 0, fmt.Errorf("%w: current %s, expected %s", ErrWikiSHAMismatch, curSHA, expectedSHA)
+		}
+	} else {
+		if expectedSHA != "" {
+			return "", 0, fmt.Errorf("%w: article not found but expected_sha supplied", ErrWikiSHAMismatch)
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
+		return "", 0, fmt.Errorf("wiki: mkdir %s: %w", filepath.Dir(fullPath), err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+		return "", 0, fmt.Errorf("wiki: write article: %w", err)
+	}
+	bytesWritten := len(content)
+
+	if err := r.regenerateIndexLocked(); err != nil {
+		return "", 0, fmt.Errorf("wiki: index regen: %w", err)
+	}
+
+	relForGit := filepath.ToSlash(relPath)
+	if out, err := r.runGitLocked(ctx, HumanAuthor, "add", "--", relForGit, "index/all.md"); err != nil {
+		return "", 0, fmt.Errorf("wiki: git add %s: %w: %s", relPath, err, out)
+	}
+
+	// Byte-identical re-write short-circuits to current HEAD; mirrors Repo.Commit.
+	cachedDiff, err := r.runGitLocked(ctx, HumanAuthor, "diff", "--cached", "--name-only")
+	if err != nil {
+		return "", 0, fmt.Errorf("wiki: git diff --cached: %w", err)
+	}
+	if strings.TrimSpace(cachedDiff) == "" {
+		headSha, herr := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+		if herr != nil {
+			return "", 0, fmt.Errorf("wiki: resolve HEAD sha: %w", herr)
+		}
+		return strings.TrimSpace(headSha), bytesWritten, nil
+	}
+
+	commitMsg := strings.TrimSpace(message)
+	if commitMsg == "" {
+		commitMsg = fmt.Sprintf("human: update %s", relPath)
+	}
+	if !strings.HasPrefix(commitMsg, "human:") {
+		// Enforce a visible prefix so audit log and git log --oneline
+		// make the provenance obvious even at a glance.
+		commitMsg = "human: " + commitMsg
+	}
+	if out, err := r.runGitLocked(ctx, HumanAuthor, "commit", "-q", "-m", commitMsg); err != nil {
+		return "", 0, fmt.Errorf("wiki: git commit: %w: %s", err, out)
+	}
+	sha, err := r.runGitLocked(ctx, HumanAuthor, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", 0, fmt.Errorf("wiki: resolve HEAD sha: %w", err)
+	}
+	return strings.TrimSpace(sha), bytesWritten, nil
+}
+
+// currentArticleSHALocked returns the short SHA of the most recent commit
+// touching relPath. Caller must hold r.mu. Returns empty string without
+// error when the article has no commit history yet (bootstrap edge).
+func (r *Repo) currentArticleSHALocked(ctx context.Context, relPath string) (string, error) {
+	out, err := r.runGitLocked(
+		ctx, "system",
+		"log", "-n", "1", "--format=%h", "--", filepath.ToSlash(relPath),
+	)
+	if err != nil {
+		return "", fmt.Errorf("git log: %w: %s", err, out)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// shaEquivalent compares two git SHAs leniently: they match when one is a
+// prefix of the other. Git's `--short` varies with object count (7 chars
+// when young, 8+ later) so we cannot require exact equality between an
+// older fetched SHA and a freshly-resolved one.
+func shaEquivalent(a, b string) bool {
+	a = strings.TrimSpace(a)
+	b = strings.TrimSpace(b)
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	if len(a) < len(b) {
+		return strings.HasPrefix(b, a)
+	}
+	return strings.HasPrefix(a, b)
+}

--- a/internal/team/human_commit_test.go
+++ b/internal/team/human_commit_test.go
@@ -1,0 +1,277 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// seedWikiArticle seeds team/<rel>.md via Repo.Commit under `seed` author
+// so a follow-up human edit has something to collide with.
+func seedWikiArticle(t *testing.T, repo *Repo, rel, content string) string {
+	t.Helper()
+	sha, _, err := repo.Commit(context.Background(), "seed", rel, content, "create", "seed: "+rel)
+	if err != nil {
+		t.Fatalf("seed commit: %v", err)
+	}
+	return sha
+}
+
+func TestCommitHumanHappyPath(t *testing.T) {
+	worker, repo, _, teardown := newStartedWorker(t)
+	defer teardown()
+
+	// Seed the article as a non-human author.
+	seedSHA := seedWikiArticle(t, repo, "team/people/nazz.md", "# Nazz\n\nOriginal.\n")
+
+	sha, n, err := worker.EnqueueHuman(
+		context.Background(),
+		"team/people/nazz.md",
+		"# Nazz\n\nEdited by human.\n",
+		"human: clarify title",
+		seedSHA,
+	)
+	if err != nil {
+		t.Fatalf("human write: %v", err)
+	}
+	if sha == "" || sha == seedSHA {
+		t.Fatalf("expected new sha, got %q (seed=%q)", sha, seedSHA)
+	}
+	if n == 0 {
+		t.Fatal("expected bytes written")
+	}
+
+	// Verify author slug landed as HumanAuthor in git log.
+	out, err := repo.runGitLocked(context.Background(), "system",
+		"log", "-n", "1", "--format=%an%x1f%ae", "--", "team/people/nazz.md")
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	parts := strings.Split(strings.TrimSpace(out), "\x1f")
+	if len(parts) != 2 {
+		t.Fatalf("unexpected git log output: %q", out)
+	}
+	if parts[0] != HumanAuthor {
+		t.Errorf("want author %q, got %q", HumanAuthor, parts[0])
+	}
+	if parts[1] != "human@wuphf.local" {
+		t.Errorf("want email human@wuphf.local, got %q", parts[1])
+	}
+}
+
+func TestCommitHumanSHAMismatchRejects(t *testing.T) {
+	worker, repo, _, teardown := newStartedWorker(t)
+	defer teardown()
+
+	seedSHA := seedWikiArticle(t, repo, "team/people/alice.md", "# Alice\n")
+	// Land another edit so HEAD moves past seedSHA.
+	_, _, err := repo.Commit(context.Background(), "pm", "team/people/alice.md",
+		"# Alice\n\nUpdated.\n", "replace", "pm: update alice")
+	if err != nil {
+		t.Fatalf("second commit: %v", err)
+	}
+
+	// Human save using the original seedSHA must get 409.
+	gotSHA, _, err := worker.EnqueueHuman(
+		context.Background(),
+		"team/people/alice.md",
+		"# Alice\n\nHuman edit on stale view.\n",
+		"human: stale save",
+		seedSHA,
+	)
+	if !errors.Is(err, ErrWikiSHAMismatch) {
+		t.Fatalf("want ErrWikiSHAMismatch, got %v", err)
+	}
+	if gotSHA == "" || gotSHA == seedSHA {
+		t.Fatalf("expected current sha in reply, got %q (seed=%q)", gotSHA, seedSHA)
+	}
+}
+
+func TestCommitHumanRejectsPathOutsideTeam(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+
+	_, _, err := worker.EnqueueHuman(context.Background(), "etc/passwd.md", "x", "human: oops", "")
+	if err == nil {
+		t.Fatal("expected error for path outside team/")
+	}
+	if !strings.Contains(err.Error(), "team/") {
+		t.Errorf("want path-scope error, got %v", err)
+	}
+}
+
+func TestCommitHumanRejectsEmptyContent(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+
+	_, _, err := worker.EnqueueHuman(context.Background(), "team/people/empty.md", "   ", "human: empty", "")
+	if err == nil {
+		t.Fatal("expected error for empty content")
+	}
+}
+
+func TestCommitHumanNewArticleNoExpectedSHA(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+
+	sha, n, err := worker.EnqueueHuman(
+		context.Background(),
+		"team/people/newbie.md",
+		"# Newbie\n\nFresh article.\n",
+		"human: add newbie",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("new-article write: %v", err)
+	}
+	if sha == "" || n == 0 {
+		t.Fatalf("unexpected result sha=%q n=%d", sha, n)
+	}
+}
+
+func TestCommitHumanNewArticleAgainstExisting409(t *testing.T) {
+	worker, repo, _, teardown := newStartedWorker(t)
+	defer teardown()
+	seedWikiArticle(t, repo, "team/people/collide.md", "# Collide\n")
+
+	_, _, err := worker.EnqueueHuman(
+		context.Background(),
+		"team/people/collide.md",
+		"# Collide\n\nThink I'm new.\n",
+		"human: dup create",
+		"", // empty → caller believes article does not exist
+	)
+	if !errors.Is(err, ErrWikiSHAMismatch) {
+		t.Fatalf("want ErrWikiSHAMismatch, got %v", err)
+	}
+}
+
+// TestCommitHumanConcurrentWritesSerialized — two parallel human writes
+// against the same article must both flow through the queue; exactly one
+// wins, the other gets ErrWikiSHAMismatch.
+func TestCommitHumanConcurrentWritesSerialized(t *testing.T) {
+	worker, repo, _, teardown := newStartedWorker(t)
+	defer teardown()
+	baseSHA := seedWikiArticle(t, repo, "team/people/race.md", "# Race\n")
+
+	var wg sync.WaitGroup
+	var successes, conflicts atomic.Int32
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			content := "# Race\n\nwriter " + string(rune('A'+i)) + "\n"
+			_, _, err := worker.EnqueueHuman(context.Background(),
+				"team/people/race.md", content, "human: racing", baseSHA)
+			if err == nil {
+				successes.Add(1)
+				return
+			}
+			if errors.Is(err, ErrWikiSHAMismatch) {
+				conflicts.Add(1)
+				return
+			}
+			t.Errorf("unexpected error: %v", err)
+		}(i)
+	}
+	wg.Wait()
+
+	if successes.Load() != 1 || conflicts.Load() != 1 {
+		t.Fatalf("expected 1 success + 1 conflict, got %d + %d",
+			successes.Load(), conflicts.Load())
+	}
+}
+
+// TestHandleWikiWriteHumanReturns409WithBody — the HTTP path must put the
+// current SHA and current bytes in the response body so the client can
+// offer a reload prompt without a second fetch.
+func TestHandleWikiWriteHumanReturns409WithBody(t *testing.T) {
+	worker, repo, _, teardown := newStartedWorker(t)
+	defer teardown()
+
+	baseSHA := seedWikiArticle(t, repo, "team/people/fixture.md", "# Fixture\n")
+	// Move HEAD past baseSHA.
+	if _, _, err := repo.Commit(context.Background(), "pm", "team/people/fixture.md",
+		"# Fixture\n\nUpdated.\n", "replace", "pm: move head"); err != nil {
+		t.Fatalf("move head: %v", err)
+	}
+
+	b := brokerForTest(t, worker)
+	body := map[string]any{
+		"path":           "team/people/fixture.md",
+		"content":        "# Fixture\n\nMy edit.\n",
+		"commit_message": "human: stale",
+		"expected_sha":   baseSHA,
+	}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/wiki/write-human", bytes.NewReader(raw))
+	rec := httptest.NewRecorder()
+	b.handleWikiWriteHuman(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["current_sha"] == "" {
+		t.Errorf("missing current_sha: %v", got)
+	}
+	cur, ok := got["current_content"].(string)
+	if !ok || !strings.Contains(cur, "Updated") {
+		t.Errorf("current_content missing or stale: %v", cur)
+	}
+}
+
+func TestHandleWikiWriteHumanRejectsBadPath(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+	b := brokerForTest(t, worker)
+
+	body := map[string]any{
+		"path":           "../etc/passwd",
+		"content":        "x",
+		"commit_message": "oops",
+	}
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/wiki/write-human", bytes.NewReader(raw))
+	rec := httptest.NewRecorder()
+	b.handleWikiWriteHuman(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", rec.Code)
+	}
+}
+
+// brokerForTest builds a minimal Broker with just the WikiWorker attached.
+// The other broker dependencies are nil because handleWikiWriteHuman only
+// calls b.WikiWorker() and the worker's own methods.
+func brokerForTest(t *testing.T, worker *WikiWorker) *Broker {
+	t.Helper()
+	b := &Broker{}
+	b.wikiWorker = worker
+	return b
+}
+
+// Guard-rail: touching the broker struct shape in a follow-up PR should
+// not silently break this helper. We don't rely on sync.Once / init here;
+// if the test assumes a field path change, fail loudly.
+var _ = filepath.Separator
+var _ = time.Now
+
+// Belt-and-braces: HumanAuthor must stay a stable constant. The value
+// bakes into git author metadata — changing it rewrites audit history.
+func TestHumanAuthorIdentityIsStable(t *testing.T) {
+	if HumanAuthor != "human" {
+		t.Fatalf("HumanAuthor must remain %q; got %q", "human", HumanAuthor)
+	}
+}

--- a/internal/team/wiki_article.go
+++ b/internal/team/wiki_article.go
@@ -46,11 +46,11 @@ import (
 // ArticleMeta is the rich view sent to the UI for an article.
 // The JSON shape matches web/src/api/wiki.ts WikiArticle.
 type ArticleMeta struct {
-	Path         string     `json:"path"`
-	Title        string     `json:"title"`
-	Content      string     `json:"content"`
-	LastEditedBy string     `json:"last_edited_by"`
-	LastEditedTs string     `json:"last_edited_ts"`
+	Path         string `json:"path"`
+	Title        string `json:"title"`
+	Content      string `json:"content"`
+	LastEditedBy string `json:"last_edited_by"`
+	LastEditedTs string `json:"last_edited_ts"`
 	// CommitSHA is the short SHA of the most recent commit touching this
 	// article. The editor sends it back as expected_sha on save so the
 	// broker can detect conflicting writes that landed after the editor

--- a/internal/team/wiki_article.go
+++ b/internal/team/wiki_article.go
@@ -51,6 +51,11 @@ type ArticleMeta struct {
 	Content      string     `json:"content"`
 	LastEditedBy string     `json:"last_edited_by"`
 	LastEditedTs string     `json:"last_edited_ts"`
+	// CommitSHA is the short SHA of the most recent commit touching this
+	// article. The editor sends it back as expected_sha on save so the
+	// broker can detect conflicting writes that landed after the editor
+	// opened. Empty when the article has no commit history yet.
+	CommitSHA    string     `json:"commit_sha"`
 	Revisions    int        `json:"revisions"`
 	Contributors []string   `json:"contributors"`
 	Backlinks    []Backlink `json:"backlinks"`
@@ -171,6 +176,7 @@ func (r *Repo) BuildArticle(ctx context.Context, relPath string) (ArticleMeta, e
 		meta.Revisions = len(refs)
 		meta.LastEditedBy = refs[0].Author
 		meta.LastEditedTs = refs[0].Timestamp.Format("2006-01-02T15:04:05Z07:00")
+		meta.CommitSHA = refs[0].SHA
 		meta.Contributors = uniqueAuthors(refs)
 	}
 

--- a/internal/team/wiki_worker.go
+++ b/internal/team/wiki_worker.go
@@ -99,7 +99,14 @@ type wikiWriteRequest struct {
 	// PlaybookSlug carries the source slug so the post-write hook can
 	// enqueue a follow-up recompile without re-parsing the path.
 	PlaybookSlug string
-	ReplyCh      chan wikiWriteResult
+	// IsHuman routes the request to Repo.CommitHuman — optimistic
+	// concurrency via expected_sha, fixed `human` git identity. Wikipedia-
+	// style Edit source flow for the founder.
+	IsHuman bool
+	// ExpectedSHA is consulted by the human write path. Empty means the
+	// caller expects the article not to exist yet (new-article flow).
+	ExpectedSHA string
+	ReplyCh     chan wikiWriteResult
 }
 
 // wikiWriteResult is the worker's reply for a single request.
@@ -245,7 +252,12 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 		n   int
 		err error
 	)
-	if req.IsEntityFact {
+	if req.IsHuman {
+		// Human edits use optimistic concurrency (expected_sha) and a
+		// fixed `human` author identity — req.Slug is ignored on this
+		// branch to prevent a caller from forging attribution.
+		sha, n, err = w.repo.CommitHuman(writeCtx, req.Path, req.Content, req.ExpectedSHA, req.CommitMsg)
+	} else if req.IsEntityFact {
 		sha, n, err = w.repo.CommitEntityFact(writeCtx, req.Slug, req.Path, req.Content, req.CommitMsg)
 	} else if req.IsPlaybookCompile {
 		sha, n, err = w.repo.CommitPlaybookSkill(writeCtx, req.Slug, req.Path, req.Content, req.CommitMsg)
@@ -263,7 +275,11 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 		sha, n, err = w.repo.Commit(writeCtx, req.Slug, req.Path, req.Content, req.Mode, req.CommitMsg)
 	}
 	if err != nil {
-		req.ReplyCh <- wikiWriteResult{Err: err}
+		// On ErrWikiSHAMismatch the human path returns the current HEAD
+		// SHA alongside the error so callers can surface 409 bodies
+		// without a second round trip. For all other errors `sha` is
+		// empty and carrying it is a harmless no-op.
+		req.ReplyCh <- wikiWriteResult{SHA: sha, Err: err}
 		return
 	}
 	req.ReplyCh <- wikiWriteResult{SHA: sha, BytesWritten: n}
@@ -366,6 +382,42 @@ func (w *WikiWorker) maybeScheduleBackup(ctx context.Context) {
 // diagnostics and tests.
 func (w *WikiWorker) QueueLength() int {
 	return len(w.requests)
+}
+
+// EnqueueHuman submits a human-authored wiki write to the shared single-
+// writer queue. Identity is forced to HumanAuthor so the caller cannot
+// spoof attribution (the HTTP handler is already gated by the broker
+// bearer token, but belt-and-braces on the worker is cheap). Returns
+// ErrWikiSHAMismatch wrapped with the current HEAD SHA (in the SHA
+// return slot) when expected_sha does not match; callers pass that back
+// to the client so the 409 prompt can reload the latest content.
+func (w *WikiWorker) EnqueueHuman(ctx context.Context, path, content, commitMsg, expectedSHA string) (string, int, error) {
+	if !w.running.Load() {
+		return "", 0, ErrWorkerStopped
+	}
+	req := wikiWriteRequest{
+		Slug:        HumanAuthor,
+		Path:        path,
+		Content:     content,
+		Mode:        "replace",
+		CommitMsg:   commitMsg,
+		IsHuman:     true,
+		ExpectedSHA: expectedSHA,
+		ReplyCh:     make(chan wikiWriteResult, 1),
+	}
+	select {
+	case w.requests <- req:
+	default:
+		return "", 0, ErrQueueSaturated
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, wikiWriteTimeout)
+	defer cancel()
+	select {
+	case result := <-req.ReplyCh:
+		return result.SHA, result.BytesWritten, result.Err
+	case <-waitCtx.Done():
+		return "", 0, fmt.Errorf("wiki: human write timed out after %s", wikiWriteTimeout)
+	}
 }
 
 // EnqueueEntityFact submits a fact-log append to the shared wiki queue.
@@ -539,6 +591,91 @@ func (b *Broker) handleWikiWrite(w http.ResponseWriter, r *http.Request) {
 	}
 	sha, n, err := worker.Enqueue(r.Context(), body.Slug, body.Path, body.Content, body.Mode, body.CommitMessage)
 	if err != nil {
+		if errors.Is(err, ErrQueueSaturated) {
+			writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"path":          body.Path,
+		"commit_sha":    sha,
+		"bytes_written": n,
+	})
+}
+
+// handleWikiWriteHuman is the broker HTTP endpoint the web UI posts to
+// when the founder saves a human wiki edit. Shape:
+//
+//	POST /wiki/write-human
+//	{
+//	  "path": "team/people/nazz.md",
+//	  "content": "...",
+//	  "commit_message": "human: fix typo",
+//	  "expected_sha": "abc123"
+//	}
+//
+// expected_sha MUST be the article's current SHA as last seen by the
+// client. When HEAD has moved, the handler returns 409 with the current
+// SHA and the current article bytes so the editor can prompt re-apply.
+//
+// Agents never reach this endpoint — it is HTTP-only (not exposed via
+// MCP) and gated by the existing broker bearer token (held by the web
+// UI). The payload's attribution cannot be forged: the worker forces
+// the commit author to HumanAuthor on this path.
+//
+// Responses:
+//
+//	200 { "path":..., "commit_sha":..., "bytes_written":... }
+//	400 { "error":"..." } on malformed JSON / bad path / empty content
+//	409 { "error":"...", "current_sha":..., "current_content":"..." }
+//	429 { "error":"wiki queue saturated, retry on next turn" }
+//	500 { "error":"..." }
+//	503 { "error":"wiki backend is not active" }
+func (b *Broker) handleWikiWriteHuman(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	worker := b.WikiWorker()
+	if worker == nil {
+		http.Error(w, `{"error":"wiki backend is not active"}`, http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		Path          string `json:"path"`
+		Content       string `json:"content"`
+		CommitMessage string `json:"commit_message"`
+		ExpectedSHA   string `json:"expected_sha"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	// Pre-validate inputs BEFORE enqueueing so a rejection never touches
+	// the working tree. Mirrors reviewApprove's CanApprove pre-check.
+	if err := validateArticlePath(body.Path); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if strings.TrimSpace(body.Content) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "content is required"})
+		return
+	}
+	sha, n, err := worker.EnqueueHuman(r.Context(), body.Path, body.Content, body.CommitMessage, body.ExpectedSHA)
+	if err != nil {
+		if errors.Is(err, ErrWikiSHAMismatch) {
+			// Return the current article bytes so the editor can show a
+			// three-pane reload prompt without a second round trip.
+			current, _ := readArticle(worker.Repo(), body.Path)
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"error":           err.Error(),
+				"current_sha":     sha,
+				"current_content": string(current),
+			})
+			return
+		}
 		if errors.Is(err, ErrQueueSaturated) {
 			writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": err.Error()})
 			return

--- a/web/src/api/wiki.test.ts
+++ b/web/src/api/wiki.test.ts
@@ -122,6 +122,62 @@ describe('wiki api client', () => {
     }
   })
 
+  it('writeHumanArticle posts the expected payload and returns the ok envelope', async () => {
+    const spy = vi
+      .spyOn(client, 'post')
+      .mockResolvedValue({ path: 'team/people/x.md', commit_sha: 'abc1234', bytes_written: 10 })
+
+    const result = await api.writeHumanArticle({
+      path: 'team/people/x.md',
+      content: 'body',
+      commitMessage: 'human: fix typo',
+      expectedSha: 'deadbee',
+    })
+
+    expect(spy).toHaveBeenCalledWith('/wiki/write-human', {
+      path: 'team/people/x.md',
+      content: 'body',
+      commit_message: 'human: fix typo',
+      expected_sha: 'deadbee',
+    })
+    expect(result).toEqual({ path: 'team/people/x.md', commit_sha: 'abc1234', bytes_written: 10 })
+  })
+
+  it('writeHumanArticle parses a 409 body into a WriteHumanConflict', async () => {
+    const conflictBody = JSON.stringify({
+      error: 'wiki: article changed since it was opened',
+      current_sha: 'newsha9',
+      current_content: '# new content',
+    })
+    // The shared post() helper rethrows as Error(text). Simulate that.
+    vi.spyOn(client, 'post').mockRejectedValue(new Error(conflictBody))
+
+    const result = await api.writeHumanArticle({
+      path: 'team/people/x.md',
+      content: 'my edit',
+      commitMessage: 'human: stale',
+      expectedSha: 'oldsha1',
+    })
+
+    expect('conflict' in result && result.conflict).toBe(true)
+    if ('conflict' in result) {
+      expect(result.current_sha).toBe('newsha9')
+      expect(result.current_content).toBe('# new content')
+    }
+  })
+
+  it('writeHumanArticle rethrows unrecognized errors', async () => {
+    vi.spyOn(client, 'post').mockRejectedValue(new Error('500 Internal Server Error'))
+    await expect(
+      api.writeHumanArticle({
+        path: 'team/people/x.md',
+        content: 'x',
+        commitMessage: 'human: nope',
+        expectedSha: 'abc',
+      }),
+    ).rejects.toThrow(/500/)
+  })
+
   it('subscribeEditLog returns an unsubscribe function even when SSE is unavailable', () => {
     // No EventSource in happy-dom by default — the client should not throw.
     const originalEventSource = (globalThis as { EventSource?: unknown }).EventSource

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -287,9 +287,25 @@ export function subscribeEditLog(
       if (closed) return
       try {
         const data = JSON.parse(ev.data) as Record<string, unknown>
-        // Broker ships the full wikiWriteEvent envelope as the data
-        // payload; the edit-log UI only needs the entry fields.
-        const entry = (data.entry ?? data) as WikiEditLogEntry
+        // Broker ships `{path, commit_sha, author_slug, timestamp}` on
+        // wiki:write. The edit-log UI's WikiEditLogEntry contract uses
+        // `who`/`action`/`article_path`/`article_title`, so normalize
+        // here rather than leaving undefined fields that crash
+        // downstream consumers (e.g. EditLogFooter's
+        // entry.who.toLowerCase()).
+        const raw = (data.entry ?? data) as Record<string, unknown>
+        const path = String(raw.article_path ?? raw.path ?? '')
+        const entry: WikiEditLogEntry = {
+          who: String(raw.who ?? raw.author_slug ?? 'unknown'),
+          action:
+            (raw.action as WikiEditLogEntry['action']) ?? 'edited',
+          article_path: path,
+          article_title:
+            (raw.article_title as string) ??
+            (path.split('/').pop() ?? path).replace(/\.md$/, ''),
+          timestamp: String(raw.timestamp ?? new Date().toISOString()),
+          commit_sha: String(raw.commit_sha ?? ''),
+        }
         handler(entry)
       } catch {
         // ignore malformed events

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -4,7 +4,7 @@
  * so the UI renders during development.
  */
 
-import { get, sseURL } from './client'
+import { get, post, sseURL } from './client'
 
 export interface WikiArticle {
   path: string
@@ -12,11 +12,89 @@ export interface WikiArticle {
   content: string
   last_edited_by: string
   last_edited_ts: string
+  /**
+   * Short SHA of the most recent commit touching this article. Sent back
+   * as `expected_sha` when the editor saves so the broker can detect
+   * concurrent writes that landed after the editor opened. Empty for
+   * brand-new articles that have no commit history yet.
+   */
+  commit_sha?: string
   revisions: number
   contributors: string[]
   backlinks: { path: string; title: string; author_slug: string }[]
   word_count: number
   categories: string[]
+}
+
+/**
+ * Result envelope for a successful human wiki write.
+ */
+export interface WriteHumanOk {
+  path: string
+  commit_sha: string
+  bytes_written: number
+}
+
+/**
+ * 409 Conflict payload: returned when another write landed between the
+ * editor opening and the save. Carries the current article bytes so the
+ * editor can prompt reload without a second fetch.
+ */
+export interface WriteHumanConflict {
+  conflict: true
+  error: string
+  current_sha: string
+  current_content: string
+}
+
+export type WriteHumanResult = WriteHumanOk | WriteHumanConflict
+
+/**
+ * Submit a human-authored wiki write. The caller must pass the SHA of
+ * the article version they opened (or '' for a new article); the broker
+ * rejects the write with 409 when HEAD has moved past that SHA.
+ *
+ * Agents never hit this endpoint — it is HTTP-only, not exposed via MCP.
+ */
+export async function writeHumanArticle(params: {
+  path: string
+  content: string
+  commitMessage: string
+  expectedSha: string
+}): Promise<WriteHumanResult> {
+  try {
+    const res = await post<WriteHumanOk>('/wiki/write-human', {
+      path: params.path,
+      content: params.content,
+      commit_message: params.commitMessage,
+      expected_sha: params.expectedSha,
+    })
+    return res
+  } catch (err: unknown) {
+    // The shared post() helper surfaces non-2xx as Error(text). For 409
+    // the body is a JSON envelope — try to parse it out.
+    const message = err instanceof Error ? err.message : String(err)
+    const parsed = tryParseConflict(message)
+    if (parsed) return parsed
+    throw err
+  }
+}
+
+function tryParseConflict(text: string): WriteHumanConflict | null {
+  try {
+    const data = JSON.parse(text) as Partial<WriteHumanConflict> & { error?: string; current_sha?: string; current_content?: string }
+    if (typeof data.current_sha === 'string' && typeof data.current_content === 'string') {
+      return {
+        conflict: true,
+        error: data.error ?? 'conflict',
+        current_sha: data.current_sha,
+        current_content: data.current_content,
+      }
+    }
+  } catch {
+    // not a JSON body; fall through
+  }
+  return null
 }
 
 export interface WikiCatalogEntry {

--- a/web/src/components/wiki/Byline.test.tsx
+++ b/web/src/components/wiki/Byline.test.tsx
@@ -45,6 +45,20 @@ describe('<Byline>', () => {
     expect(screen.getByText('PM')).toBeInTheDocument()
   })
 
+  it('renders a distinct "Human" pill when the last editor is the human', () => {
+    render(
+      <Byline
+        authorSlug="human"
+        authorName="Human"
+        lastEditedTs={new Date().toISOString()}
+      />,
+    )
+    const pill = screen.getByTestId('wk-human-byline')
+    expect(pill).toBeInTheDocument()
+    expect(pill).toHaveTextContent('Human')
+    expect(pill.className).toMatch(/wk-human-pill/)
+  })
+
   it('renders started without startedBy', () => {
     render(
       <Byline

--- a/web/src/components/wiki/Byline.tsx
+++ b/web/src/components/wiki/Byline.tsx
@@ -20,11 +20,22 @@ export default function Byline({
   startedBy,
   revisions,
 }: BylineProps) {
+  // Human edits get a distinct pill so readers can tell machine edits
+  // from hand edits at a glance. Matches the agent pixel-avatar motif
+  // without rendering an avatar (`human` has no generated sprite).
+  const isHuman = authorSlug === 'human'
   return (
     <div className="wk-byline">
       <PixelAvatar slug={authorSlug} size={22} />
       <span>
-        Last edited by <span className="wk-name">{authorName}</span>
+        Last edited by{' '}
+        {isHuman ? (
+          <span className="wk-name wk-human-pill" data-testid="wk-human-byline">
+            Human
+          </span>
+        ) : (
+          <span className="wk-name">{authorName}</span>
+        )}
       </span>
       <span className="wk-ts" data-testid="wk-ts">
         {formatBylineTime(lastEditedTs)}

--- a/web/src/components/wiki/HatBar.test.tsx
+++ b/web/src/components/wiki/HatBar.test.tsx
@@ -24,6 +24,13 @@ describe('<HatBar>', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
+  it('fires onChange when the Edit source tab is clicked', () => {
+    const onChange = vi.fn()
+    render(<HatBar active="article" onChange={onChange} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Edit source' }))
+    expect(onChange).toHaveBeenCalledWith('edit')
+  })
+
   it('renders right-rail context when provided', () => {
     render(<HatBar active="article" rightRail={['Cincinnati, OH', 'Mid-market Logistics']} />)
     expect(screen.getByText(/Cincinnati, OH/)).toBeInTheDocument()

--- a/web/src/components/wiki/HatBar.tsx
+++ b/web/src/components/wiki/HatBar.tsx
@@ -1,6 +1,6 @@
-/** Wikipedia-style tabs at the top of the article (Article / Talk / History / Raw). */
+/** Wikipedia-style tabs at the top of the article (Article / Talk / Edit / History / Raw). */
 
-export type HatBarTab = 'article' | 'talk' | 'history' | 'raw'
+export type HatBarTab = 'article' | 'talk' | 'edit' | 'history' | 'raw'
 
 interface HatBarProps {
   active: HatBarTab
@@ -12,11 +12,12 @@ interface HatBarProps {
 const LABELS: Record<HatBarTab, string> = {
   article: 'Article',
   talk: 'Talk',
+  edit: 'Edit source',
   history: 'History',
   raw: 'Raw markdown',
 }
 
-const ORDER: HatBarTab[] = ['article', 'talk', 'history', 'raw']
+const ORDER: HatBarTab[] = ['article', 'talk', 'edit', 'history', 'raw']
 
 export default function HatBar({ active, onChange, rightRail, disabledTabs = ['talk'] }: HatBarProps) {
   return (

--- a/web/src/components/wiki/NewArticleModal.tsx
+++ b/web/src/components/wiki/NewArticleModal.tsx
@@ -1,0 +1,166 @@
+import { useMemo, useState } from 'react'
+import { writeHumanArticle, type WikiCatalogEntry } from '../../api/wiki'
+
+interface NewArticleModalProps {
+  catalog: WikiCatalogEntry[]
+  onCancel: () => void
+  onCreated: (path: string) => void
+}
+
+/**
+ * Modal for kicking off a brand-new wiki article. Asks for a section
+ * (existing group or free-text), a slug, and a title, then POSTs a
+ * single-line draft to `/wiki/write-human` with `expected_sha` empty
+ * so the broker commits the article as a fresh create.
+ *
+ * Intentionally minimal — the heavy lift (markdown editing, headings,
+ * wikilinks) happens in the WikiEditor once the article exists.
+ */
+export default function NewArticleModal({ catalog, onCancel, onCreated }: NewArticleModalProps) {
+  const existingGroups = useMemo(() => {
+    const set = new Set<string>()
+    for (const e of catalog) set.add(e.group)
+    return Array.from(set).sort()
+  }, [catalog])
+
+  const [group, setGroup] = useState(existingGroups[0] ?? 'people')
+  const [customGroup, setCustomGroup] = useState('')
+  const [slug, setSlug] = useState('')
+  const [title, setTitle] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const resolvedGroup = (group === '__custom__' ? customGroup : group).trim()
+  const path = resolvedGroup && slug ? `team/${resolvedGroup}/${slug}.md` : ''
+
+  async function handleCreate() {
+    setError(null)
+    const groupErr = validateSegment(resolvedGroup, 'Section')
+    if (groupErr) { setError(groupErr); return }
+    const slugErr = validateSegment(slug, 'Slug')
+    if (slugErr) { setError(slugErr); return }
+    if (!title.trim()) { setError('Title is required.'); return }
+
+    const fullPath = `team/${resolvedGroup}/${slug}.md`
+    const body = `# ${title.trim()}\n\n_Stub — write something useful here._\n`
+
+    setSubmitting(true)
+    try {
+      const result = await writeHumanArticle({
+        path: fullPath,
+        content: body,
+        commitMessage: `human: create ${fullPath}`,
+        expectedSha: '',
+      })
+      if ('conflict' in result) {
+        setError('An article already exists at that path. Pick a different slug.')
+        return
+      }
+      onCreated(fullPath)
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to create article.')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="wk-modal-backdrop"
+      data-testid="wk-new-article-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="wk-new-article-title"
+    >
+      <div className="wk-modal">
+        <h2 id="wk-new-article-title">New wiki article</h2>
+
+        <label className="wk-editor-label" htmlFor="wk-new-group">Section</label>
+        <select
+          id="wk-new-group"
+          value={group}
+          onChange={(e) => setGroup(e.target.value)}
+        >
+          {existingGroups.map((g) => (
+            <option key={g} value={g}>{g}</option>
+          ))}
+          <option value="__custom__">+ New section…</option>
+        </select>
+        {group === '__custom__' && (
+          <input
+            className="wk-editor-commit"
+            type="text"
+            placeholder="e.g. playbooks"
+            value={customGroup}
+            onChange={(e) => setCustomGroup(e.target.value)}
+          />
+        )}
+
+        <label className="wk-editor-label" htmlFor="wk-new-slug">Slug</label>
+        <input
+          id="wk-new-slug"
+          className="wk-editor-commit"
+          data-testid="wk-new-slug"
+          type="text"
+          placeholder="sarah-chen"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-'))}
+        />
+
+        <label className="wk-editor-label" htmlFor="wk-new-title">Title</label>
+        <input
+          id="wk-new-title"
+          className="wk-editor-commit"
+          type="text"
+          placeholder="Sarah Chen"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+
+        {path && (
+          <p className="wk-editor-help">
+            Will create <code>{path}</code>
+          </p>
+        )}
+
+        {error && <div className="wk-editor-banner wk-editor-banner--error" role="alert">{error}</div>}
+
+        <div className="wk-editor-actions">
+          <button
+            type="button"
+            className="wk-editor-save"
+            data-testid="wk-new-create"
+            onClick={handleCreate}
+            disabled={submitting}
+          >
+            {submitting ? 'Creating…' : 'Create article'}
+          </button>
+          <button
+            type="button"
+            className="wk-editor-cancel"
+            onClick={onCancel}
+            disabled={submitting}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Mirror of the backend validateArticlePath shape. Rejects traversal,
+ * leading slash, empty input, and non-slug characters so the user hears
+ * the error before an HTTP round-trip.
+ */
+function validateSegment(seg: string, label: string): string | null {
+  const trimmed = seg.trim()
+  if (!trimmed) return `${label} is required.`
+  if (trimmed.startsWith('.') || trimmed.includes('..')) return `${label} cannot contain "..".`
+  if (trimmed.includes('/')) return `${label} cannot contain "/".`
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(trimmed)) {
+    return `${label} must be lowercase letters, numbers, and hyphens only.`
+  }
+  return null
+}

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -13,6 +13,7 @@ import PlaybookSkillBadge from './PlaybookSkillBadge'
 import HatBar, { type HatBarTab } from './HatBar'
 import ArticleTitle from './ArticleTitle'
 import Byline from './Byline'
+import WikiEditor from './WikiEditor'
 import Hatnote from './Hatnote'
 import SeeAlso from './SeeAlso'
 import Sources from './Sources'
@@ -257,6 +258,22 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
               {article.content}
             </ReactMarkdown>
           </div>
+        )}
+        {tab === 'edit' && (
+          <WikiEditor
+            path={article.path}
+            initialContent={article.content}
+            expectedSha={article.commit_sha ?? ''}
+            onSaved={(newSha) => {
+              // Refetch after every save — covers both happy path and
+              // the conflict-then-reload path (which passes the server's
+              // current_sha back as newSha).
+              void newSha
+              setRefreshNonce((n) => n + 1)
+              setTab('article')
+            }}
+            onCancel={() => setTab('article')}
+          />
         )}
         {tab === 'raw' && (
           <pre

--- a/web/src/components/wiki/WikiCatalog.tsx
+++ b/web/src/components/wiki/WikiCatalog.tsx
@@ -1,8 +1,9 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import PixelAvatar from './PixelAvatar'
 import type { WikiCatalogEntry } from '../../api/wiki'
 import { formatRelativeTime } from '../../lib/format'
 import { resolveGroupOrder } from '../../lib/groupOrder'
+import NewArticleModal from './NewArticleModal'
 
 /** `/wiki` landing view: grid of thematic dir groups with recent articles. */
 
@@ -23,6 +24,7 @@ export default function WikiCatalog({
   commitsCount,
   agentsCount,
 }: WikiCatalogProps) {
+  const [showNew, setShowNew] = useState(false)
   const grouped = useMemo(() => groupByGroup(catalog), [catalog])
   const groupOrder = useMemo(
     () => resolveGroupOrder(catalog.map((c) => c.group)),
@@ -45,6 +47,15 @@ export default function WikiCatalog({
         <div className="wk-catalog-clone">
           Your wiki lives on your disk.{' '}
           <code>git clone ~/.wuphf/wiki</code>
+          {' · '}
+          <button
+            type="button"
+            className="wk-catalog-new-link"
+            data-testid="wk-catalog-new"
+            onClick={() => setShowNew(true)}
+          >
+            + New article
+          </button>
           {onOpenAudit && (
             <>
               {' · '}
@@ -62,6 +73,16 @@ export default function WikiCatalog({
           )}
         </div>
       </header>
+      {showNew && (
+        <NewArticleModal
+          catalog={catalog}
+          onCancel={() => setShowNew(false)}
+          onCreated={(path) => {
+            setShowNew(false)
+            onNavigate(path)
+          }}
+        />
+      )}
       <div className="wk-catalog-grid">
         {groupOrder.map((group) => {
           const items = grouped[group]

--- a/web/src/components/wiki/WikiEditor.test.tsx
+++ b/web/src/components/wiki/WikiEditor.test.tsx
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import WikiEditor from './WikiEditor'
+import * as api from '../../api/wiki'
+
+describe('<WikiEditor>', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('pre-fills the textarea with the article content and the expected SHA is sent on save', async () => {
+    const spy = vi
+      .spyOn(api, 'writeHumanArticle')
+      .mockResolvedValue({ path: 'team/people/nazz.md', commit_sha: 'abc1234', bytes_written: 42 })
+
+    const onSaved = vi.fn()
+    render(
+      <WikiEditor
+        path="team/people/nazz.md"
+        initialContent="# Nazz\n\nOriginal."
+        expectedSha="deadbee"
+        onSaved={onSaved}
+        onCancel={() => {}}
+      />,
+    )
+
+    const textarea = screen.getByTestId('wk-editor-textarea') as HTMLTextAreaElement
+    expect(textarea.value).toContain('Original.')
+
+    fireEvent.change(textarea, { target: { value: '# Nazz\n\nEdited.' } })
+    fireEvent.change(screen.getByTestId('wk-editor-commit'), {
+      target: { value: 'fix wording' },
+    })
+    fireEvent.click(screen.getByTestId('wk-editor-save'))
+
+    await waitFor(() => expect(spy).toHaveBeenCalled())
+    expect(spy).toHaveBeenCalledWith({
+      path: 'team/people/nazz.md',
+      content: '# Nazz\n\nEdited.',
+      commitMessage: 'fix wording',
+      expectedSha: 'deadbee',
+    })
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith('abc1234'))
+  })
+
+  it('shows the conflict banner when the server returns 409', async () => {
+    vi.spyOn(api, 'writeHumanArticle').mockResolvedValue({
+      conflict: true,
+      error: 'wiki: article changed since it was opened',
+      current_sha: 'newsha9',
+      current_content: '# Nazz\n\nFresh text from someone else.',
+    })
+
+    render(
+      <WikiEditor
+        path="team/people/nazz.md"
+        initialContent="# Nazz\n\nMine."
+        expectedSha="oldsha1"
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('wk-editor-save'))
+
+    const banner = await screen.findByRole('alert')
+    expect(banner.textContent).toMatch(/Someone else edited this article/)
+    expect(
+      screen.getByRole('button', { name: /Reload latest & re-apply/ }),
+    ).toBeInTheDocument()
+  })
+
+  it('blocks save when the textarea is emptied', async () => {
+    const spy = vi.spyOn(api, 'writeHumanArticle')
+    render(
+      <WikiEditor
+        path="team/people/nazz.md"
+        initialContent="# Nazz\n"
+        expectedSha="abc"
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    fireEvent.change(screen.getByTestId('wk-editor-textarea'), { target: { value: '   ' } })
+    fireEvent.click(screen.getByTestId('wk-editor-save'))
+    expect(spy).not.toHaveBeenCalled()
+    expect(await screen.findByRole('alert')).toHaveTextContent(/cannot be empty/i)
+  })
+
+  it('cancels via the Cancel button', () => {
+    const onCancel = vi.fn()
+    render(
+      <WikiEditor
+        path="team/people/nazz.md"
+        initialContent="x"
+        expectedSha="abc"
+        onSaved={() => {}}
+        onCancel={onCancel}
+      />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useRef, useState } from 'react'
+import { writeHumanArticle, type WriteHumanConflict } from '../../api/wiki'
+
+interface WikiEditorProps {
+  /** Target article path, e.g. `team/people/nazz.md`. */
+  path: string
+  /** Markdown the editor starts with (article.content when present). */
+  initialContent: string
+  /** SHA the editor opened against; sent back as expected_sha on save. */
+  expectedSha: string
+  /** Called after a successful save so the parent can refetch. */
+  onSaved: (newSha: string) => void
+  /** Called when the user cancels. */
+  onCancel: () => void
+}
+
+/**
+ * Plain-markdown editor surface. Wikipedia's "Edit source" button maps
+ * to this component: a textarea + commit-message input + save/cancel.
+ *
+ * Rich-text preview and autosave are deferred to v1.1; this ships the
+ * minimum path that lets the founder fix a typo without shelling into
+ * the .wuphf directory.
+ */
+export default function WikiEditor({
+  path,
+  initialContent,
+  expectedSha,
+  onSaved,
+  onCancel,
+}: WikiEditorProps) {
+  const [content, setContent] = useState(initialContent)
+  const [commitMessage, setCommitMessage] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [conflict, setConflict] = useState<WriteHumanConflict | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+
+  useEffect(() => {
+    // Fresh content whenever the article or opened revision changes.
+    setContent(initialContent)
+    setCommitMessage('')
+    setError(null)
+    setConflict(null)
+  }, [path, expectedSha, initialContent])
+
+  async function handleSave() {
+    if (saving) return
+    setError(null)
+    setConflict(null)
+    if (!content.trim()) {
+      setError('Article content cannot be empty.')
+      return
+    }
+    setSaving(true)
+    try {
+      const result = await writeHumanArticle({
+        path,
+        content,
+        commitMessage: commitMessage.trim() || `human: update ${path}`,
+        expectedSha,
+      })
+      if ('conflict' in result) {
+        setConflict(result)
+        return
+      }
+      onSaved(result.commit_sha)
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Save failed.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleReloadConflict() {
+    if (!conflict) return
+    setContent(conflict.current_content)
+    // Hand the new SHA back to the parent so it re-fetches and re-opens
+    // the editor against the latest article rev.
+    onSaved(conflict.current_sha)
+  }
+
+  return (
+    <div className="wk-editor" data-testid="wk-editor">
+      {conflict && (
+        <div className="wk-editor-banner wk-editor-banner--conflict" role="alert">
+          <strong>Someone else edited this article.</strong> Your save was
+          rejected because the article changed since you opened it.
+          <div className="wk-editor-banner-actions">
+            <button type="button" onClick={handleReloadConflict}>
+              Reload latest &amp; re-apply
+            </button>
+          </div>
+        </div>
+      )}
+      {error && !conflict && (
+        <div className="wk-editor-banner wk-editor-banner--error" role="alert">
+          {error}
+        </div>
+      )}
+      <label className="wk-editor-label" htmlFor="wk-editor-textarea">
+        Article source ({path})
+      </label>
+      <textarea
+        id="wk-editor-textarea"
+        ref={textareaRef}
+        className="wk-editor-textarea"
+        data-testid="wk-editor-textarea"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        spellCheck
+        rows={28}
+      />
+      <label className="wk-editor-label" htmlFor="wk-editor-commit-msg">
+        Edit summary
+      </label>
+      <input
+        id="wk-editor-commit-msg"
+        className="wk-editor-commit"
+        data-testid="wk-editor-commit"
+        type="text"
+        placeholder="human: short description of the edit"
+        value={commitMessage}
+        onChange={(e) => setCommitMessage(e.target.value)}
+      />
+      <div className="wk-editor-actions">
+        <button
+          type="button"
+          className="wk-editor-save"
+          data-testid="wk-editor-save"
+          onClick={handleSave}
+          disabled={saving}
+        >
+          {saving ? 'Saving…' : 'Save changes'}
+        </button>
+        <button
+          type="button"
+          className="wk-editor-cancel"
+          onClick={onCancel}
+          disabled={saving}
+        >
+          Cancel
+        </button>
+      </div>
+      <p className="wk-editor-help">
+        Plain markdown. <code>[[slug]]</code> creates a wikilink. Saved as
+        commit author <strong>Human &lt;human@wuphf.local&gt;</strong>.
+      </p>
+    </div>
+  )
+}

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1210,6 +1210,161 @@
   text-decoration-style: solid;
 }
 
+/* ─── New-article button + Edit source editor (v1.3 human-editable wiki) ─── */
+.wk-catalog-new-link {
+  font-family: inherit;
+  color: var(--wk-wikilink);
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-size: inherit;
+  text-decoration: underline dashed;
+  text-underline-offset: 2px;
+}
+.wk-catalog-new-link:hover { text-decoration-style: solid; }
+
+.wk-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 12px 0;
+}
+.wk-editor-label {
+  font-family: var(--wk-chrome);
+  font-size: 12px;
+  color: var(--wk-text-muted);
+  margin-top: 4px;
+}
+.wk-editor-textarea {
+  width: 100%;
+  min-height: 480px;
+  padding: 12px 14px;
+  font-family: var(--wk-mono);
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--wk-text);
+  background: var(--wk-paper);
+  border: 1px solid var(--wk-border);
+  resize: vertical;
+  box-sizing: border-box;
+}
+.wk-editor-textarea:focus {
+  outline: 2px solid var(--wk-wikilink);
+  outline-offset: -2px;
+}
+.wk-editor-commit {
+  width: 100%;
+  padding: 8px 10px;
+  font-family: var(--wk-chrome);
+  font-size: 14px;
+  border: 1px solid var(--wk-border);
+  background: var(--wk-paper);
+  color: var(--wk-text);
+  box-sizing: border-box;
+}
+.wk-editor-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+}
+.wk-editor-save,
+.wk-editor-cancel {
+  font-family: var(--wk-chrome);
+  font-size: 14px;
+  padding: 8px 18px;
+  border: 1px solid var(--wk-border);
+  cursor: pointer;
+}
+.wk-editor-save {
+  background: var(--wk-wikilink);
+  color: #fff;
+  border-color: var(--wk-wikilink);
+}
+.wk-editor-save[disabled],
+.wk-editor-cancel[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.wk-editor-cancel { background: var(--wk-paper); color: var(--wk-text); }
+.wk-editor-help {
+  font-family: var(--wk-chrome);
+  font-size: 12px;
+  color: var(--wk-text-muted);
+  margin: 0;
+}
+.wk-editor-banner {
+  padding: 10px 14px;
+  border: 1px solid var(--wk-border);
+  background: var(--wk-paper-dark);
+  font-family: var(--wk-chrome);
+  font-size: 13px;
+}
+.wk-editor-banner--conflict {
+  border-left: 3px solid var(--wk-amber);
+  background: var(--wk-amber-banner);
+}
+.wk-editor-banner--error {
+  border-left: 3px solid var(--wk-wikilink-broken);
+}
+.wk-editor-banner-actions {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+}
+.wk-editor-banner-actions button {
+  font-family: var(--wk-chrome);
+  font-size: 13px;
+  padding: 6px 12px;
+  border: 1px solid var(--wk-border);
+  background: var(--wk-paper);
+  cursor: pointer;
+}
+
+.wk-human-pill {
+  display: inline-block;
+  padding: 0 6px;
+  font-family: var(--wk-chrome);
+  border: 1px solid var(--wk-amber);
+  background: var(--wk-amber-banner);
+  color: var(--wk-text);
+  font-weight: 600;
+}
+
+.wk-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+.wk-modal {
+  background: var(--wk-paper);
+  border: 1px solid var(--wk-border);
+  width: min(480px, 92vw);
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 24px 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.wk-modal h2 {
+  margin: 0 0 6px;
+  font-family: var(--wk-display);
+  font-size: 22px;
+}
+.wk-modal select {
+  font-family: var(--wk-chrome);
+  font-size: 14px;
+  padding: 8px 10px;
+  border: 1px solid var(--wk-border);
+  background: var(--wk-paper);
+  color: var(--wk-text);
+}
+
 /* ─── Entity briefs (v1.2) ─── */
 .wk-entity-brief-bar {
   display: flex;


### PR DESCRIPTION
## Summary

Adds a Wikipedia-style **Edit source** flow to every `/wiki/*` article so the founder can draft and edit the team encyclopedia directly in the browser — no agent middleman, no terminal editor.

- New broker endpoint `POST /wiki/write-human` with **optimistic SHA-based concurrency** (409 + current bytes on conflict).
- Fixed `Human <human@wuphf.local>` git identity, mirroring the `ArchivistAuthor` pattern; reuses the single-writer `WikiWorker` queue.
- Web: **Edit source** tab on articles → plain-markdown textarea + commit message + save. Conflict banner offers one-click reload. Catalog gets a **+ New article** modal with local path validation. `Byline` shows a distinct "Human" pill when `last_edited_by === "human"`.

## What changed

**Backend**
- `internal/team/human_commit.go` — `HumanAuthor` constant, `ErrWikiSHAMismatch`, `Repo.CommitHuman` (pre-check → write → index regen → commit, atomic like `Repo.Commit`).
- `internal/team/wiki_worker.go` — new `IsHuman` + `ExpectedSHA` on `wikiWriteRequest`, `EnqueueHuman()`, `handleWikiWriteHuman` HTTP handler returning 409 with `current_sha` + `current_content`.
- `internal/team/wiki_article.go` — `ArticleMeta.CommitSHA` so the editor can round-trip expected_sha.
- `internal/team/broker.go` — register `/wiki/write-human` on the authed mux (HTTP-only; MCP never reaches it).

**Frontend**
- `web/src/api/wiki.ts` — `writeHumanArticle()` helper + `WriteHumanConflict` envelope; `WikiArticle.commit_sha` surfaced to consumers.
- `web/src/components/wiki/WikiEditor.tsx` — textarea + edit-summary + save/cancel + 409 banner.
- `web/src/components/wiki/NewArticleModal.tsx` — section + slug + title; mirrors backend `validateArticlePath` shape so users hear bad input before an HTTP round-trip.
- `web/src/components/wiki/HatBar.tsx` — new "Edit source" tab between Talk and History.
- `web/src/components/wiki/WikiArticle.tsx` — renders the editor on `tab === 'edit'`, refetches on save, returns to Article view.
- `web/src/components/wiki/Byline.tsx` — amber "Human" pill for `authorSlug === 'human'`.
- `web/src/styles/wiki.css` — editor + modal + human-pill styles (reuses existing `--wk-*` tokens).

## Design decisions

- **Optimistic over pessimistic concurrency.** Editors never hold a lock across the open→save round-trip. Conflicts surface at save time (HTTP 409 + current bytes) so readers and agents keep writing freely. Matches Wikipedia's flow and avoids half-typed-draft lock state.
- **MCP gating via surface area, not token split.** `/wiki/write-human` is registered on the HTTP mux only. Agents call `/wiki/write` via MCP; they never see the human endpoint. Keeps auth plumbing simple.
- **Single "human" identity for v1.** Per-user attribution is deferred to v1.1. Today there is one founder; commits land as `Human <human@wuphf.local>`.
- **Reuse the single-writer queue.** `IsHuman` is just another discriminator on `wikiWriteRequest` alongside `IsNotebook`/`IsEntityFact`/`IsPlaybookCompile`. No second write path, no parallel serialization story.
- **Visible provenance.** Byline shows a distinct amber pill for human edits so readers can tell machine edits from hand edits at a glance. Git author slug (`human`) is the single source of truth.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (all packages green; pre-existing race in `TestRecoverFailedHeadlessTurnRequeuesExternalActionBeforeBlocking` is unrelated to this PR and fails on `main` too).
- [x] `cd web && bun run build`
- [x] `cd web && bun run test` (51 files, 235 tests passing).
- [ ] Manual: open article → Edit source → change body → Save → toast + amber byline + SSE live strip pulses.
- [ ] Manual: open article in two tabs; save tab A; save tab B → 409 banner; "Reload latest & re-apply" swaps in fresh bytes.
- [ ] Manual: catalog → + New article → pick section, slug, title → lands on fresh article with `Human` byline.
- [ ] Manual: `/wiki/write-human` returns 400 for `etc/passwd.md`, 400 for empty content, 409 for stale `expected_sha`, 200 for fresh edit.