### PR TITLE
feat: compounding intelligence loop — playbook executions synthesize back into the playbook

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -471,6 +471,7 @@ type Broker struct {
 	reviewResolver          ReviewerResolver
 	factLog                 *FactLog
 	entitySynthesizer       *EntitySynthesizer
+	playbookSynthesizer     *PlaybookSynthesizer
 	scanTracker             *scanStatusTracker
 	nextSubscriberID        int
 	agentStreams            map[string]*agentStreamBuffer
@@ -1139,6 +1140,7 @@ func (b *Broker) Start() error {
 	b.ensureReviewLog()
 	b.ensureEntitySynthesizer()
 	b.ensurePlaybookExecutionLog()
+	b.ensurePlaybookSynthesizer()
 	b.startReviewExpiryLoop(context.Background())
 	return b.StartOnPort(brokeraddr.ResolvePort())
 }
@@ -1234,6 +1236,8 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/playbook/compile", b.requireAuth(b.handlePlaybookCompile))
 	mux.HandleFunc("/playbook/execution", b.requireAuth(b.handlePlaybookExecution))
 	mux.HandleFunc("/playbook/executions", b.requireAuth(b.handlePlaybookExecutionsList))
+	mux.HandleFunc("/playbook/synthesize", b.requireAuth(b.handlePlaybookSynthesize))
+	mux.HandleFunc("/playbook/synthesis-status", b.requireAuth(b.handlePlaybookSynthesisStatus))
 	mux.HandleFunc("/scan/start", b.requireAuth(b.handleScanStart))
 	mux.HandleFunc("/scan/status", b.requireAuth(b.handleScanStatus))
 	mux.HandleFunc("/studio/generate-package", b.requireAuth(b.handleStudioGeneratePackage))
@@ -1311,9 +1315,13 @@ func (b *Broker) Stop() {
 	}
 	b.mu.Lock()
 	synth := b.entitySynthesizer
+	pbSynth := b.playbookSynthesizer
 	b.mu.Unlock()
 	if synth != nil {
 		synth.Stop()
+	}
+	if pbSynth != nil {
+		pbSynth.Stop()
 	}
 }
 
@@ -1745,6 +1753,8 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 	defer unsubscribeSections()
 	playbookEvents, unsubscribePlaybook := b.SubscribePlaybookExecutionEvents(64)
 	defer unsubscribePlaybook()
+	playbookSynthEvents, unsubscribePlaybookSynth := b.SubscribePlaybookSynthesizedEvents(64)
+	defer unsubscribePlaybookSynth()
 
 	writeEvent := func(name string, payload any) error {
 		data, err := json.Marshal(payload)
@@ -1807,6 +1817,10 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		case evt, ok := <-playbookEvents:
 			if !ok || writeEvent("playbook:execution_recorded", evt) != nil {
+				return
+			}
+		case evt, ok := <-playbookSynthEvents:
+			if !ok || writeEvent("playbook:synthesized", evt) != nil {
 				return
 			}
 		case <-heartbeat.C:

--- a/internal/team/broker_playbook.go
+++ b/internal/team/broker_playbook.go
@@ -585,4 +585,3 @@ func (b *Broker) handlePlaybookSynthesisStatus(w http.ResponseWriter, r *http.Re
 		"threshold":                       threshold,
 	})
 }
-

--- a/internal/team/broker_playbook.go
+++ b/internal/team/broker_playbook.go
@@ -15,14 +15,19 @@ package team
 //	playbook:execution_recorded      — { slug, path, commit_sha, recorded_by, timestamp }
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 // playbookSubscribersMu guards lazy init of the subscriber map. We do NOT
@@ -37,6 +42,7 @@ import (
 var (
 	playbookSubscribersMu        sync.Mutex
 	playbookSubscribersByBroker  = map[*Broker]map[int]chan PlaybookExecutionRecordedEvent{}
+	playbookSynthSubsByBroker    = map[*Broker]map[int]chan PlaybookSynthesizedEvent{}
 	playbookExecutionLogByBroker = map[*Broker]*ExecutionLog{}
 )
 
@@ -289,6 +295,14 @@ func (b *Broker) handlePlaybookExecution(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	all, _ := log.List(slug)
+
+	// Close the loop: notify the synthesizer so it can debounce + enqueue a
+	// synthesis when the threshold is crossed. Non-blocking; any errors are
+	// already logged inside OnExecutionRecorded.
+	if synth := b.PlaybookSynthesizer(); synth != nil {
+		synth.OnExecutionRecorded(slug)
+	}
+
 	writeJSON(w, http.StatusOK, map[string]any{
 		"execution_id":    entry.ID,
 		"execution_count": len(all),
@@ -322,3 +336,253 @@ func (b *Broker) handlePlaybookExecutionsList(w http.ResponseWriter, r *http.Req
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"executions": entries})
 }
+
+// ── Playbook synthesizer wiring ──────────────────────────────────────────
+//
+// The compounding-intelligence loop — executions accumulate, a broker-level
+// LLM synthesis worker periodically updates the "What we've learned"
+// section of the source playbook, and the existing auto-recompile hook
+// regenerates the SKILL.md so the next agent starts smarter.
+//
+// Kept in this file (not a new file) so the merge-surface with the parallel
+// editable-wiki branch stays additive. The synthesizer itself lives in
+// playbook_synthesizer.go.
+
+// PlaybookSynthesizer returns the active synthesizer or nil before Start
+// has wired it.
+func (b *Broker) PlaybookSynthesizer() *PlaybookSynthesizer {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.playbookSynthesizer
+}
+
+// SetPlaybookSynthesizer wires a synthesizer from tests. Must be called
+// after ensurePlaybookExecutionLog would have run.
+func (b *Broker) SetPlaybookSynthesizer(synth *PlaybookSynthesizer) {
+	b.mu.Lock()
+	b.playbookSynthesizer = synth
+	b.mu.Unlock()
+}
+
+// ensurePlaybookSynthesizer initializes the playbook synthesizer once the
+// execution log is online. Idempotent.
+func (b *Broker) ensurePlaybookSynthesizer() {
+	b.mu.Lock()
+	if b.playbookSynthesizer != nil {
+		b.mu.Unlock()
+		return
+	}
+	worker := b.wikiWorker
+	b.mu.Unlock()
+	if worker == nil {
+		return
+	}
+	execLog := b.PlaybookExecutionLog()
+	if execLog == nil {
+		return
+	}
+	cfg := PlaybookSynthesizerConfig{
+		Threshold: resolvePlaybookSynthThresholdFromEnv(),
+		Timeout:   resolvePlaybookSynthTimeoutFromEnv(),
+	}
+	synth := NewPlaybookSynthesizer(worker, execLog, b, cfg)
+	synth.Start(context.Background())
+	b.mu.Lock()
+	b.playbookSynthesizer = synth
+	b.mu.Unlock()
+}
+
+func resolvePlaybookSynthThresholdFromEnv() int {
+	raw := strings.TrimSpace(os.Getenv("WUPHF_PLAYBOOK_SYNTHESIS_THRESHOLD"))
+	if raw == "" {
+		return DefaultPlaybookSynthesisThreshold
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return DefaultPlaybookSynthesisThreshold
+	}
+	return n
+}
+
+func resolvePlaybookSynthTimeoutFromEnv() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("WUPHF_PLAYBOOK_SYNTHESIS_TIMEOUT"))
+	if raw == "" {
+		return DefaultPlaybookSynthesisTimeout
+	}
+	secs, err := strconv.Atoi(raw)
+	if err != nil || secs <= 0 {
+		return DefaultPlaybookSynthesisTimeout
+	}
+	return time.Duration(secs) * time.Second
+}
+
+// SubscribePlaybookSynthesizedEvents returns a channel of playbook-synthesis
+// events plus an unsubscribe func. Mirrors SubscribePlaybookExecutionEvents.
+func (b *Broker) SubscribePlaybookSynthesizedEvents(buffer int) (<-chan PlaybookSynthesizedEvent, func()) {
+	if buffer <= 0 {
+		buffer = 64
+	}
+	playbookSubscribersMu.Lock()
+	defer playbookSubscribersMu.Unlock()
+	subs := playbookSynthSubsByBroker[b]
+	if subs == nil {
+		subs = make(map[int]chan PlaybookSynthesizedEvent)
+		playbookSynthSubsByBroker[b] = subs
+	}
+	b.mu.Lock()
+	id := b.nextSubscriberID
+	b.nextSubscriberID++
+	b.mu.Unlock()
+	ch := make(chan PlaybookSynthesizedEvent, buffer)
+	subs[id] = ch
+	return ch, func() {
+		playbookSubscribersMu.Lock()
+		defer playbookSubscribersMu.Unlock()
+		if subs := playbookSynthSubsByBroker[b]; subs != nil {
+			if existing, ok := subs[id]; ok {
+				delete(subs, id)
+				close(existing)
+			}
+		}
+	}
+}
+
+// PublishPlaybookSynthesized fans out a synthesis event. Implements the
+// playbookSynthEventPublisher interface consumed by PlaybookSynthesizer.
+func (b *Broker) PublishPlaybookSynthesized(evt PlaybookSynthesizedEvent) {
+	playbookSubscribersMu.Lock()
+	defer playbookSubscribersMu.Unlock()
+	for _, ch := range playbookSynthSubsByBroker[b] {
+		select {
+		case ch <- evt:
+		default:
+		}
+	}
+}
+
+// handlePlaybookSynthesize is POST /playbook/synthesize.
+//
+//	body: { "slug": "churn-prevention", "actor_slug"?: "..." }
+//	resp: { "synthesis_id", "queued_at" }
+//
+// On-demand trigger for humans or agents who just landed a particularly
+// useful outcome. Always goes through the debounce/coalesce path, so
+// repeated clicks don't stack work.
+func (b *Broker) handlePlaybookSynthesize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	b.ensurePlaybookExecutionLog()
+	b.ensurePlaybookSynthesizer()
+	synth := b.PlaybookSynthesizer()
+	if synth == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "playbook synthesizer is not active"})
+		return
+	}
+	var body struct {
+		Slug      string `json:"slug"`
+		ActorSlug string `json:"actor_slug"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	slug := strings.TrimSpace(body.Slug)
+	if !slugPattern.MatchString(slug) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("slug must match ^[a-z0-9][a-z0-9-]*$; got %q", slug)})
+		return
+	}
+	actor := strings.TrimSpace(body.ActorSlug)
+	if actor == "" {
+		actor = strings.TrimSpace(r.Header.Get(agentRateLimitHeader))
+	}
+	if actor == "" {
+		actor = "human"
+	}
+	id, err := synth.SynthesizeNow(r.Context(), slug, actor)
+	if err != nil {
+		if errors.Is(err, ErrPlaybookSynthQueueSaturated) {
+			writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": err.Error()})
+			return
+		}
+		if errors.Is(err, ErrPlaybookSynthesizerStopped) {
+			writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": err.Error()})
+			return
+		}
+		log.Printf("playbook synth: on-demand enqueue for %s by %s: %v", slug, actor, err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"synthesis_id": id,
+		"queued_at":    time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+// handlePlaybookSynthesisStatus is GET /playbook/synthesis-status?slug=.
+//
+//	resp: {
+//	  "slug": "...",
+//	  "execution_count": 7,
+//	  "last_synthesized_ts": "2026-04-21T10:00:00Z",
+//	  "last_synthesized_sha": "abc1234",
+//	  "executions_since_last_synthesis": 2,
+//	  "threshold": 3,
+//	  "source_path": "team/playbooks/churn-prevention.md"
+//	}
+//
+// Powers the "Last synthesis: 2h ago · 7 executions" badge in the web UI.
+// Pulled from the frontmatter the synthesizer stamps on every commit, so
+// the status is always consistent with the source of truth on disk.
+func (b *Broker) handlePlaybookSynthesisStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	worker := b.WikiWorker()
+	if worker == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "wiki backend is not active"})
+		return
+	}
+	slug := strings.TrimSpace(r.URL.Query().Get("slug"))
+	if !slugPattern.MatchString(slug) {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("slug must match ^[a-z0-9][a-z0-9-]*$; got %q", slug)})
+		return
+	}
+	sourceRel := playbookSourceRel(slug)
+	bytes, err := readArticle(worker.Repo(), sourceRel)
+	if err != nil {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": fmt.Sprintf("source playbook %s does not exist", sourceRel)})
+		return
+	}
+	sha, ts, lastCount := parseSynthesisFrontmatter(string(bytes))
+	tsStr := ""
+	if !ts.IsZero() {
+		tsStr = ts.UTC().Format(time.RFC3339)
+	}
+	execCount := 0
+	if execLog := b.PlaybookExecutionLog(); execLog != nil {
+		if entries, err := execLog.List(slug); err == nil {
+			execCount = len(entries)
+		}
+	}
+	since := execCount - lastCount
+	if since < 0 {
+		since = 0
+	}
+	threshold := DefaultPlaybookSynthesisThreshold
+	if synth := b.PlaybookSynthesizer(); synth != nil {
+		threshold = synth.Threshold()
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"slug":                            slug,
+		"source_path":                     sourceRel,
+		"execution_count":                 execCount,
+		"last_synthesized_ts":             tsStr,
+		"last_synthesized_sha":            sha,
+		"executions_since_last_synthesis": since,
+		"threshold":                       threshold,
+	})
+}
+

--- a/internal/team/broker_playbook_synth_test.go
+++ b/internal/team/broker_playbook_synth_test.go
@@ -1,0 +1,262 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newSynthBroker wires a broker with a live wiki worker + execution log +
+// synthesizer backed by a stub LLM. Returns the broker and a teardown.
+func newSynthBroker(
+	t *testing.T,
+	llm func(ctx context.Context, sys, user string) (string, error),
+) (*Broker, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	worker := NewWikiWorker(repo, noopPublisher{})
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+
+	b.ensurePlaybookExecutionLog()
+	execLog := b.PlaybookExecutionLog()
+	if execLog == nil {
+		t.Fatalf("execution log did not initialize")
+	}
+
+	synth := NewPlaybookSynthesizer(worker, execLog, b, PlaybookSynthesizerConfig{
+		Threshold: 2,
+		Timeout:   5 * time.Second,
+		LLMCall:   llm,
+	})
+	synth.Start(context.Background())
+	b.SetPlaybookSynthesizer(synth)
+
+	teardown := func() {
+		synth.Stop()
+		cancel()
+		worker.Stop()
+	}
+	return b, teardown
+}
+
+func TestHandlePlaybookSynthesize_EnqueuesJob(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "## What we've learned\n\n- from test.\n", nil
+	}
+	b, teardown := newSynthBroker(t, stub)
+	defer teardown()
+
+	// Seed a source playbook so the synthesizer has something to update.
+	writePlaybookSource(t, b.WikiWorker(), "reactivation", seededPlaybookBody)
+	if _, err := b.PlaybookExecutionLog().Append(
+		context.Background(), "reactivation", PlaybookOutcomeSuccess, "a run.", "", "cmo",
+	); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	srv := httptest.NewServer(b.requireAuth(b.handlePlaybookSynthesize))
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"slug":       "reactivation",
+		"actor_slug": "human",
+	})
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(raw))
+	}
+	var out map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := out["synthesis_id"]; !ok {
+		t.Errorf("response missing synthesis_id: %v", out)
+	}
+	if _, ok := out["queued_at"]; !ok {
+		t.Errorf("response missing queued_at: %v", out)
+	}
+}
+
+func TestHandlePlaybookSynthesize_RejectsBadSlug(t *testing.T) {
+	b, teardown := newSynthBroker(t, func(context.Context, string, string) (string, error) {
+		return "## What we've learned\n\n- x\n", nil
+	})
+	defer teardown()
+
+	srv := httptest.NewServer(b.requireAuth(b.handlePlaybookSynthesize))
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{"slug": "Bad Slug With Spaces"})
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected 400 for bad slug; got %d", resp.StatusCode)
+	}
+}
+
+func TestHandlePlaybookSynthesisStatus_ReflectsFrontmatter(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "## What we've learned\n\n- initial synthesis.\n", nil
+	}
+	b, teardown := newSynthBroker(t, stub)
+	defer teardown()
+
+	writePlaybookSource(t, b.WikiWorker(), "status-demo", seededPlaybookBody)
+	execLog := b.PlaybookExecutionLog()
+	for i := 0; i < 3; i++ {
+		if _, err := execLog.Append(
+			context.Background(), "status-demo", PlaybookOutcomeSuccess, "run.", "", "cmo",
+		); err != nil {
+			t.Fatalf("append: %v", err)
+		}
+	}
+	// Fire a synthesis + wait for the SSE event to confirm commit landed.
+	ch, unsub := b.SubscribePlaybookSynthesizedEvents(4)
+	defer unsub()
+	if _, err := b.PlaybookSynthesizer().SynthesizeNow(
+		context.Background(), "status-demo", "human",
+	); err != nil {
+		t.Fatalf("synthesize: %v", err)
+	}
+	select {
+	case <-ch:
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for synthesis event")
+	}
+
+	srv := httptest.NewServer(b.requireAuth(b.handlePlaybookSynthesisStatus))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"?slug=status-demo", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, string(raw))
+	}
+
+	var out struct {
+		Slug                         string `json:"slug"`
+		ExecutionCount               int    `json:"execution_count"`
+		LastSynthesizedTS            string `json:"last_synthesized_ts"`
+		LastSynthesizedSHA           string `json:"last_synthesized_sha"`
+		ExecutionsSinceLastSynthesis int    `json:"executions_since_last_synthesis"`
+		Threshold                    int    `json:"threshold"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Slug != "status-demo" {
+		t.Errorf("slug = %q, want %q", out.Slug, "status-demo")
+	}
+	if out.ExecutionCount != 3 {
+		t.Errorf("execution_count = %d, want 3", out.ExecutionCount)
+	}
+	if out.LastSynthesizedTS == "" {
+		t.Errorf("last_synthesized_ts is empty; frontmatter not stamped")
+	}
+	if out.Threshold != 2 {
+		t.Errorf("threshold = %d, want 2 (fixture override)", out.Threshold)
+	}
+	if out.ExecutionsSinceLastSynthesis != 0 {
+		t.Errorf("expected 0 new executions since last synthesis; got %d", out.ExecutionsSinceLastSynthesis)
+	}
+}
+
+func TestHandlePlaybookSynthesisStatus_MissingSource404(t *testing.T) {
+	b, teardown := newSynthBroker(t, func(context.Context, string, string) (string, error) {
+		return "", nil
+	})
+	defer teardown()
+
+	srv := httptest.NewServer(b.requireAuth(b.handlePlaybookSynthesisStatus))
+	defer srv.Close()
+
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"?slug=nope", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("expected 404 for missing source; got %d", resp.StatusCode)
+	}
+}
+
+func TestOnExecutionRecorded_ThresholdCrossingViaBrokerPublishes(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "## What we've learned\n\n- synthesis fired.\n", nil
+	}
+	b, teardown := newSynthBroker(t, stub)
+	defer teardown()
+	writePlaybookSource(t, b.WikiWorker(), "auto-through-broker", seededPlaybookBody)
+
+	ch, unsub := b.SubscribePlaybookSynthesizedEvents(4)
+	defer unsub()
+
+	synth := b.PlaybookSynthesizer()
+	execLog := b.PlaybookExecutionLog()
+
+	// First execution: below threshold=2.
+	if _, err := execLog.Append(
+		context.Background(), "auto-through-broker", PlaybookOutcomeSuccess, "a.", "", "cmo",
+	); err != nil {
+		t.Fatalf("append 1: %v", err)
+	}
+	synth.OnExecutionRecorded("auto-through-broker")
+
+	// Second execution: crosses threshold.
+	if _, err := execLog.Append(
+		context.Background(), "auto-through-broker", PlaybookOutcomeSuccess, "b.", "", "cmo",
+	); err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+	synth.OnExecutionRecorded("auto-through-broker")
+
+	select {
+	case evt := <-ch:
+		if evt.Slug != "auto-through-broker" {
+			t.Errorf("wrong slug: %q", evt.Slug)
+		}
+		if evt.ExecutionCount != 2 {
+			t.Errorf("execution_count = %d, want 2", evt.ExecutionCount)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatalf("timed out waiting for synthesis event")
+	}
+}

--- a/internal/team/playbook_synthesizer.go
+++ b/internal/team/playbook_synthesizer.go
@@ -1,0 +1,598 @@
+package team
+
+// playbook_synthesizer.go is the broker-level LLM synthesis worker for v1.3
+// playbook compounding-intelligence. Mirrors entity_synthesizer.go closely:
+// same debounce + coalesce + threshold pattern. The only meaningful
+// differences are:
+//
+//  1. The "authoritative" document is a playbook body (team/playbooks/{slug}.md)
+//     rather than an entity brief. We preserve the author's main body verbatim
+//     and only append / update a trailing "## What we've learned" section.
+//  2. The input signal is the append-only execution log at
+//     team/playbooks/{slug}.executions.jsonl, not entity facts.
+//  3. Threshold default is 3 — playbooks run more often than entity facts
+//     accumulate, and early wisdom is still useful.
+//
+// The write path is a plain wikiWriteRequest for the source playbook article;
+// the existing auto-recompile hook in wiki_worker.go then regenerates the
+// SKILL.md under team/playbooks/.compiled/{slug}/SKILL.md.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultPlaybookSynthesisThreshold is the number of new executions that
+// must accumulate before an automatic synthesis is triggered. Configurable
+// per deployment via WUPHF_PLAYBOOK_SYNTHESIS_THRESHOLD.
+const DefaultPlaybookSynthesisThreshold = 3
+
+// DefaultPlaybookSynthesisTimeout bounds a single LLM shell-out.
+// Configurable via WUPHF_PLAYBOOK_SYNTHESIS_TIMEOUT (seconds).
+const DefaultPlaybookSynthesisTimeout = 45 * time.Second
+
+// MaxPlaybookSynthQueue is the buffered channel size for pending jobs.
+const MaxPlaybookSynthQueue = 32
+
+// MaxPlaybookBodySize caps the LLM output bytes we are willing to commit.
+// Playbooks can be longer than entity briefs (more structured steps), so
+// the ceiling is doubled from MaxBriefSize.
+const MaxPlaybookBodySize = 64 * 1024
+
+// MaxExecutionsForPrompt is the hard cap on how many recent execution
+// entries we feed into a single synthesis prompt. Keeps the prompt
+// bounded even when a playbook has hundreds of runs.
+const MaxExecutionsForPrompt = 20
+
+// PlaybookSynthesisPromptSystem is the system prompt sent on every call.
+// Locked here so the behavior is reviewable — do not edit casually.
+const PlaybookSynthesisPromptSystem = `You maintain playbooks in a team wiki. Each playbook has an author who specified the canonical steps. Your job is to integrate lessons from recent executions WITHOUT rewriting the author's body.
+
+Rules you MUST follow:
+1. Preserve the frontmatter (the leading --- block) exactly as given. Do not add, remove, or reorder keys.
+2. Preserve the author's main body verbatim. Do not rewrite steps, even if executions suggest changes. The author's intent is authoritative; execution learnings are advisory.
+3. At the bottom of the body, maintain a section titled exactly "## What we've learned". If it already exists, update the bullets. If it doesn't, append it. Everything else below that heading is owned by you.
+4. In "What we've learned", surface concrete lessons drawn from the provided executions: common failure modes, helpful prerequisites, shortcuts that worked, when to skip or add extra steps.
+5. When two executions disagree (e.g., skipping step X succeeded once but failed another time), record the disagreement as a "**Contradiction:**" inline callout under "What we've learned" and DO NOT resolve it. The next human editor will decide.
+6. Do not invent lessons. Every bullet must be traceable to at least one execution entry.
+7. Output ONLY the full updated markdown of the playbook file. No commentary, no code fences.`
+
+// WhatWeveLearnedHeading is the exact heading the synthesizer maintains.
+// Changing this invalidates prior-synthesis section replacement — in-flight
+// playbooks would grow a duplicate heading.
+const WhatWeveLearnedHeading = "## What we've learned"
+
+// ErrPlaybookSynthQueueSaturated is returned when the buffered channel is full.
+var ErrPlaybookSynthQueueSaturated = errors.New("playbook synth: queue saturated")
+
+// ErrPlaybookSynthesizerStopped is returned when Enqueue is called after Stop.
+var ErrPlaybookSynthesizerStopped = errors.New("playbook synth: not running")
+
+// ErrPlaybookSynthNoNewExecutions is surfaced for observability when a job
+// runs with zero un-synthesized executions. Not a hard failure — skips.
+var ErrPlaybookSynthNoNewExecutions = errors.New("playbook synth: no new executions since last synthesis")
+
+// ErrPlaybookSourceMissing is surfaced when the source article no longer
+// exists. Treat as an idempotent skip — deletion of the authored body makes
+// learnings moot.
+var ErrPlaybookSourceMissing = errors.New("playbook synth: source playbook does not exist")
+
+// PlaybookSynthesisJob is one pending synthesis request for a specific slug.
+type PlaybookSynthesisJob struct {
+	Slug       string
+	RequestBy  string
+	EnqueuedAt time.Time
+	// ID is a monotonic counter so callers can correlate responses.
+	ID uint64
+}
+
+// PlaybookSynthesizedEvent is the SSE payload broadcast after every
+// successful synthesis commit. Kept distinct from the SKILL.md compile
+// path — the UI cares about the learnings landing, not the recompile.
+type PlaybookSynthesizedEvent struct {
+	Slug            string `json:"slug"`
+	CommitSHA       string `json:"commit_sha"`
+	ExecutionCount  int    `json:"execution_count"`
+	SynthesizedTS   string `json:"synthesized_ts"`
+	SourcePath      string `json:"source_path"`
+	TriggeredByUser bool   `json:"triggered_by_user"`
+}
+
+// PlaybookSynthesizerConfig tunes the worker. Zero values -> defaults.
+type PlaybookSynthesizerConfig struct {
+	Threshold int
+	Timeout   time.Duration
+
+	// LLMCall is the pluggable shell-out used by tests. Production leaves
+	// this nil and the worker falls back to defaultLLMCall from
+	// entity_synthesizer.go (provider.RunConfiguredOneShot).
+	LLMCall func(ctx context.Context, systemPrompt, userPrompt string) (string, error)
+}
+
+// playbookSynthEventPublisher is the subset of Broker the synthesizer needs.
+type playbookSynthEventPublisher interface {
+	PublishPlaybookSynthesized(evt PlaybookSynthesizedEvent)
+}
+
+// PlaybookSynthesizer is the broker-level synthesis worker for playbook
+// learnings. Single-writer via a drain goroutine so only one archivist
+// commit is in flight at a time across the whole wiki.
+type PlaybookSynthesizer struct {
+	worker    *WikiWorker
+	execLog   *ExecutionLog
+	publisher playbookSynthEventPublisher
+	cfg       PlaybookSynthesizerConfig
+
+	mu       sync.Mutex
+	jobs     chan PlaybookSynthesisJob
+	inflight map[string]bool // slug -> at most 1 running per slug
+	queued   map[string]bool // slug -> at most 1 pending per slug
+	running  bool
+	nextID   uint64
+	stopCh   chan struct{}
+	wg       sync.WaitGroup
+}
+
+// NewPlaybookSynthesizer wires a synthesizer against the given worker +
+// execution log. Config may be zero; defaults are filled in here.
+func NewPlaybookSynthesizer(worker *WikiWorker, execLog *ExecutionLog, publisher playbookSynthEventPublisher, cfg PlaybookSynthesizerConfig) *PlaybookSynthesizer {
+	if cfg.Threshold <= 0 {
+		cfg.Threshold = DefaultPlaybookSynthesisThreshold
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = DefaultPlaybookSynthesisTimeout
+	}
+	return &PlaybookSynthesizer{
+		worker:    worker,
+		execLog:   execLog,
+		publisher: publisher,
+		cfg:       cfg,
+		jobs:      make(chan PlaybookSynthesisJob, MaxPlaybookSynthQueue),
+		inflight:  make(map[string]bool),
+		queued:    make(map[string]bool),
+	}
+}
+
+// Start launches the synthesis loop. Returns immediately. Stop via ctx or Stop().
+func (s *PlaybookSynthesizer) Start(ctx context.Context) {
+	s.mu.Lock()
+	if s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = true
+	s.stopCh = make(chan struct{})
+	s.mu.Unlock()
+
+	s.wg.Add(1)
+	go s.drain(ctx)
+}
+
+// Stop signals the worker to exit. Pending jobs are dropped.
+func (s *PlaybookSynthesizer) Stop() {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return
+	}
+	s.running = false
+	close(s.stopCh)
+	s.mu.Unlock()
+	s.wg.Wait()
+}
+
+// Threshold returns the current synthesis threshold.
+func (s *PlaybookSynthesizer) Threshold() int {
+	return s.cfg.Threshold
+}
+
+// OnExecutionRecorded is the hook the broker calls after every append to
+// the execution log. It fetches the current execution count, compares
+// against the last-synthesized count in the playbook frontmatter, and
+// enqueues a synthesis if the delta meets the threshold.
+//
+// Non-blocking: all work happens inline but returns immediately; errors
+// are logged and swallowed so the caller's /playbook/execution handler
+// stays fast.
+func (s *PlaybookSynthesizer) OnExecutionRecorded(slug string) {
+	if s == nil {
+		return
+	}
+	// Count all executions. Compare against fact_count_at_synthesis in the
+	// playbook frontmatter — same mechanism entity briefs use.
+	all, err := s.execLog.List(slug)
+	if err != nil {
+		log.Printf("playbook synth: list executions for %s: %v", slug, err)
+		return
+	}
+	total := len(all)
+	_, _, lastCount := s.readSynthesisCounters(slug)
+	since := total - lastCount
+	if since < 0 {
+		since = 0
+	}
+	if since < s.cfg.Threshold {
+		return
+	}
+	if _, err := s.EnqueueSynthesis(slug, ArchivistAuthor, false); err != nil && !errors.Is(err, ErrPlaybookSynthQueueSaturated) {
+		// Coalesced returns (0, nil); saturation is a soft error. Everything
+		// else surfaces a real bug — log so ops can see it.
+		log.Printf("playbook synth: enqueue after threshold for %s: %v", slug, err)
+	}
+}
+
+// SynthesizeNow runs a synthesis for the given slug synchronously. Used by
+// the POST /playbook/synthesize endpoint and the MCP tool for on-demand
+// refresh. Returns once the commit is in the wiki queue (not when it is
+// written — the caller can read-back to confirm).
+func (s *PlaybookSynthesizer) SynthesizeNow(ctx context.Context, slug, actor string) (uint64, error) {
+	return s.EnqueueSynthesis(slug, strings.TrimSpace(actor), true)
+}
+
+// EnqueueSynthesis adds a synthesis job if none is already in-flight or
+// queued for the same slug. Returns the assigned job ID (or 0 when the
+// request was coalesced).
+func (s *PlaybookSynthesizer) EnqueueSynthesis(slug, requestBy string, triggeredByUser bool) (uint64, error) {
+	s.mu.Lock()
+	if !s.running {
+		s.mu.Unlock()
+		return 0, ErrPlaybookSynthesizerStopped
+	}
+	if s.queued[slug] {
+		s.mu.Unlock()
+		return 0, nil
+	}
+	if s.inflight[slug] {
+		s.queued[slug] = true
+		s.mu.Unlock()
+		return 0, nil
+	}
+	s.nextID++
+	id := s.nextID
+	job := PlaybookSynthesisJob{
+		Slug:       slug,
+		RequestBy:  strings.TrimSpace(requestBy),
+		EnqueuedAt: time.Now().UTC(),
+		ID:         id,
+	}
+	s.queued[slug] = true
+	s.mu.Unlock()
+
+	select {
+	case s.jobs <- job:
+		// Record whether this was an on-demand request so the SSE event
+		// can surface it. Stored on a side map to avoid plumbing another
+		// field through the channel type.
+		s.markTriggerSource(slug, triggeredByUser)
+		return id, nil
+	default:
+		s.mu.Lock()
+		delete(s.queued, slug)
+		s.mu.Unlock()
+		return 0, ErrPlaybookSynthQueueSaturated
+	}
+}
+
+// triggerSources tracks whether the currently-queued job for each slug was
+// triggered by a user (true) vs. auto-threshold (false). Read once when the
+// job pops off the queue; deleted after the job finishes. No lock of its
+// own — we reuse s.mu to keep the hot paths aligned.
+var playbookTriggerSources = struct {
+	mu  sync.Mutex
+	src map[string]bool
+}{src: map[string]bool{}}
+
+func (s *PlaybookSynthesizer) markTriggerSource(slug string, user bool) {
+	playbookTriggerSources.mu.Lock()
+	defer playbookTriggerSources.mu.Unlock()
+	// OR-reduce: if any pending enqueue was user-triggered, treat the
+	// coalesced synthesis as user-triggered.
+	playbookTriggerSources.src[slug] = playbookTriggerSources.src[slug] || user
+}
+
+func (s *PlaybookSynthesizer) consumeTriggerSource(slug string) bool {
+	playbookTriggerSources.mu.Lock()
+	defer playbookTriggerSources.mu.Unlock()
+	v := playbookTriggerSources.src[slug]
+	delete(playbookTriggerSources.src, slug)
+	return v
+}
+
+// drain is the single synthesis worker goroutine.
+func (s *PlaybookSynthesizer) drain(ctx context.Context) {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.stopCh:
+			return
+		case job := <-s.jobs:
+			s.runJob(ctx, job)
+		}
+	}
+}
+
+// runJob is the per-slug serialized synthesis. Mirrors
+// EntitySynthesizer.runJob — mark inflight, run, schedule any coalesced
+// follow-up after we finish.
+func (s *PlaybookSynthesizer) runJob(ctx context.Context, job PlaybookSynthesisJob) {
+	s.mu.Lock()
+	s.inflight[job.Slug] = true
+	delete(s.queued, job.Slug)
+	s.mu.Unlock()
+
+	userTriggered := s.consumeTriggerSource(job.Slug)
+
+	defer func() {
+		s.mu.Lock()
+		delete(s.inflight, job.Slug)
+		needsFollowup := s.queued[job.Slug]
+		// Drop the queued flag BEFORE the follow-up goroutine re-enqueues;
+		// otherwise it sees queued=true and silently coalesces its own call.
+		delete(s.queued, job.Slug)
+		running := s.running
+		s.mu.Unlock()
+		if needsFollowup && running {
+			go func() {
+				time.Sleep(10 * time.Millisecond)
+				_, _ = s.EnqueueSynthesis(job.Slug, ArchivistAuthor, false)
+			}()
+		}
+	}()
+
+	if err := s.synthesize(ctx, job, userTriggered); err != nil {
+		if errors.Is(err, ErrPlaybookSynthNoNewExecutions) || errors.Is(err, ErrPlaybookSourceMissing) {
+			return
+		}
+		log.Printf("playbook synth: %s failed: %v", job.Slug, err)
+	}
+}
+
+// synthesize runs the full pipeline for one job.
+func (s *PlaybookSynthesizer) synthesize(ctx context.Context, job PlaybookSynthesisJob, userTriggered bool) error {
+	sourceRel := playbookSourceRel(job.Slug)
+	source, hadSource := s.readArticle(sourceRel)
+	if !hadSource {
+		return ErrPlaybookSourceMissing
+	}
+
+	all, err := s.execLog.List(job.Slug)
+	if err != nil {
+		return fmt.Errorf("list executions: %w", err)
+	}
+	total := len(all)
+	_, _, lastCount := parseSynthesisFrontmatter(source)
+	since := total - lastCount
+	if since < 0 {
+		since = 0
+	}
+	if since == 0 && total > 0 {
+		return ErrPlaybookSynthNoNewExecutions
+	}
+	if total == 0 {
+		return ErrPlaybookSynthNoNewExecutions
+	}
+
+	// Slice the most recent MaxExecutionsForPrompt entries. List returns
+	// newest-first, so a simple head-slice is the right window.
+	window := all
+	if len(window) > MaxExecutionsForPrompt {
+		window = window[:MaxExecutionsForPrompt]
+	}
+
+	userPrompt := buildPlaybookSynthUserPrompt(source, window)
+
+	callCtx, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
+	defer cancel()
+	llm := s.cfg.LLMCall
+	if llm == nil {
+		llm = defaultLLMCall
+	}
+	output, llmErr := llm(callCtx, PlaybookSynthesisPromptSystem, userPrompt)
+	if llmErr != nil {
+		return fmt.Errorf("llm: %w", llmErr)
+	}
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return fmt.Errorf("llm output is empty")
+	}
+	if len(output) > MaxPlaybookBodySize {
+		return fmt.Errorf("llm output exceeds %d bytes (got %d)", MaxPlaybookBodySize, len(output))
+	}
+	// Weak tamper check — drop obvious prompt-echo failures.
+	if strings.Contains(output, "# Existing playbook") && strings.Contains(output, "# Recent executions") {
+		return fmt.Errorf("llm output appears to contain the prompt verbatim")
+	}
+
+	// Safety net: enforce author-body preservation + frontmatter preservation.
+	// If the LLM rewrote the main body, reconstruct the file ourselves by
+	// replacing only the "What we've learned" trailing section from the LLM's
+	// draft and splicing it onto the original author body. This is defense in
+	// depth — the prompt already instructs the model not to rewrite — but we
+	// do NOT want silent body-rewrites slipping through.
+	safeBody, ok := mergePreservingAuthorBody(source, output)
+	if !ok {
+		return fmt.Errorf("llm output missing required %q heading", WhatWeveLearnedHeading)
+	}
+
+	// Stamp frontmatter counters so the next run knows what is new.
+	headSHA, headErr := s.headSHA(ctx)
+	if headErr != nil {
+		log.Printf("playbook synth: resolve HEAD failed for %s: %v", job.Slug, headErr)
+	}
+	now := time.Now().UTC()
+	stamped := applySynthesisFrontmatter(safeBody, headSHA, now, total, source)
+
+	// Commit via the standard wiki queue. The post-commit auto-recompile hook
+	// (wiki_worker.go) detects team/playbooks/{slug}.md and regenerates the
+	// SKILL.md automatically — we deliberately do not call CompilePlaybook.
+	commitMsg := fmt.Sprintf("archivist: synthesize learnings into playbook %s (%d executions)", job.Slug, total)
+	sha, _, werr := s.worker.Enqueue(ctx, ArchivistAuthor, sourceRel, stamped, "replace", commitMsg)
+	if werr != nil {
+		return fmt.Errorf("commit playbook: %w", werr)
+	}
+
+	if s.publisher != nil {
+		s.publisher.PublishPlaybookSynthesized(PlaybookSynthesizedEvent{
+			Slug:            job.Slug,
+			CommitSHA:       sha,
+			ExecutionCount:  total,
+			SynthesizedTS:   now.Format(time.RFC3339),
+			SourcePath:      sourceRel,
+			TriggeredByUser: userTriggered,
+		})
+	}
+	return nil
+}
+
+// readArticle returns the article bytes + whether the file exists.
+func (s *PlaybookSynthesizer) readArticle(relPath string) (string, bool) {
+	bytes, err := readArticle(s.worker.Repo(), relPath)
+	if err != nil {
+		return "", false
+	}
+	return string(bytes), true
+}
+
+// readSynthesisCounters returns the sha/ts/fact-count from the source
+// playbook frontmatter. Reuses the entity_frontmatter.go helpers — the
+// schema (last_synthesized_sha/ts + fact_count_at_synthesis) is identical.
+func (s *PlaybookSynthesizer) readSynthesisCounters(slug string) (string, time.Time, int) {
+	body, ok := s.readArticle(playbookSourceRel(slug))
+	if !ok {
+		return "", time.Time{}, 0
+	}
+	return parseSynthesisFrontmatter(body)
+}
+
+// headSHA returns the current repo HEAD short SHA. Same shape as
+// EntitySynthesizer.headSHA.
+func (s *PlaybookSynthesizer) headSHA(ctx context.Context) (string, error) {
+	repo := s.worker.Repo()
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	out, err := repo.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, out)
+	}
+	return strings.TrimSpace(out), nil
+}
+
+// buildPlaybookSynthUserPrompt formats the LLM user message. Keeps the
+// bounds explicit and the section headers stable so the response can be
+// parsed reliably downstream.
+func buildPlaybookSynthUserPrompt(source string, execs []Execution) string {
+	var b strings.Builder
+	b.WriteString("# Existing playbook\n\n")
+	b.WriteString(strings.TrimSpace(source))
+	b.WriteString("\n\n# Recent executions (newest first, max ")
+	fmt.Fprintf(&b, "%d", MaxExecutionsForPrompt)
+	b.WriteString(")\n\n")
+	if len(execs) == 0 {
+		b.WriteString("_No executions provided._\n")
+	} else {
+		for i, e := range execs {
+			ts := e.CreatedAt.UTC().Format(time.RFC3339)
+			fmt.Fprintf(&b, "## Execution %d — %s\n", i+1, e.Outcome)
+			fmt.Fprintf(&b, "- recorded_by: %s\n", e.RecordedBy)
+			fmt.Fprintf(&b, "- timestamp: %s\n", ts)
+			fmt.Fprintf(&b, "- summary: %s\n", oneLine(e.Summary))
+			if strings.TrimSpace(e.Notes) != "" {
+				fmt.Fprintf(&b, "- notes: %s\n", oneLine(e.Notes))
+			}
+			b.WriteString("\n")
+		}
+	}
+	b.WriteString("# Your task\n\n")
+	b.WriteString("Produce the FULL updated playbook markdown now, preserving the frontmatter and the author's body verbatim, and appending or updating the trailing \"")
+	b.WriteString(WhatWeveLearnedHeading)
+	b.WriteString("\" section with lessons drawn from the executions above.")
+	return b.String()
+}
+
+func oneLine(s string) string {
+	return strings.ReplaceAll(strings.TrimSpace(s), "\n", " ")
+}
+
+// mergePreservingAuthorBody takes the original source and the LLM draft and
+// returns a merged markdown file where:
+//   - frontmatter is taken from the ORIGINAL source
+//   - body above WhatWeveLearnedHeading is taken from the ORIGINAL source
+//   - WhatWeveLearnedHeading + everything below is taken from the LLM DRAFT
+//
+// Returns (result, true) on success. Returns ("", false) when the LLM draft
+// does not contain the required heading — the caller treats that as a
+// hard synthesis failure (we refuse to commit an output that didn't produce
+// learnings).
+//
+// Byte-identical input produces byte-identical output, so re-synthesizing a
+// stable playbook is a no-op commit.
+func mergePreservingAuthorBody(source, draft string) (string, bool) {
+	heading := WhatWeveLearnedHeading
+	// Split source into (frontmatter-and-body-above, existing-learnings).
+	// The author body above the heading is authoritative; existing learnings
+	// are replaceable.
+	origAbove := splitAboveLearnings(source)
+
+	// The LLM draft might include a frontmatter we want to throw away, plus
+	// a body that should have the heading. Strip any frontmatter first so
+	// we don't search inside it for the heading.
+	draftBody := stripFrontmatter(draft)
+	idx := strings.Index(draftBody, heading)
+	if idx < 0 {
+		return "", false
+	}
+	newLearnings := strings.TrimLeft(draftBody[idx:], " \t")
+
+	// Rejoin: frontmatter+body-above (with trailing newline separation) + new learnings.
+	above := strings.TrimRight(origAbove, "\n")
+	return above + "\n\n" + strings.TrimRight(newLearnings, " \t\n") + "\n", true
+}
+
+// splitAboveLearnings returns everything in source strictly above the
+// WhatWeveLearnedHeading, including the frontmatter. When the heading is
+// absent the whole source is considered "above".
+func splitAboveLearnings(source string) string {
+	// Consider only the body for heading detection — searching the raw
+	// source would match a heading that appeared inside frontmatter yaml
+	// comments (rare but possible).
+	fm, body := splitFrontmatterAndBody(source)
+	idx := strings.Index(body, WhatWeveLearnedHeading)
+	if idx < 0 {
+		return source
+	}
+	above := body[:idx]
+	if fm == "" {
+		return above
+	}
+	return fm + above
+}
+
+// splitFrontmatterAndBody returns (frontmatter-including-delimiters, body).
+// When there is no frontmatter, ("", source) is returned.
+func splitFrontmatterAndBody(source string) (string, string) {
+	if !strings.HasPrefix(source, "---\n") {
+		return "", source
+	}
+	rest := source[len("---\n"):]
+	idx := strings.Index(rest, "\n---")
+	if idx < 0 {
+		return "", source
+	}
+	// idx is start of "\n---"; closing line may end with "\n" or be the final line.
+	closing := idx + len("\n---")
+	tail := rest[closing:]
+	// Skip the immediate newline after the closing --- so the body starts on
+	// a clean line, but preserve leading blank lines beyond that.
+	if strings.HasPrefix(tail, "\n") {
+		tail = tail[1:]
+	}
+	fm := "---\n" + rest[:closing] + "\n"
+	return fm, tail
+}

--- a/internal/team/playbook_synthesizer.go
+++ b/internal/team/playbook_synthesizer.go
@@ -590,9 +590,7 @@ func splitFrontmatterAndBody(source string) (string, string) {
 	tail := rest[closing:]
 	// Skip the immediate newline after the closing --- so the body starts on
 	// a clean line, but preserve leading blank lines beyond that.
-	if strings.HasPrefix(tail, "\n") {
-		tail = tail[1:]
-	}
+	tail = strings.TrimPrefix(tail, "\n")
 	fm := "---\n" + rest[:closing] + "\n"
 	return fm, tail
 }

--- a/internal/team/playbook_synthesizer_test.go
+++ b/internal/team/playbook_synthesizer_test.go
@@ -1,0 +1,397 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// playbookPublisherStub captures synthesis events for assertions.
+type playbookPublisherStub struct {
+	mu     sync.Mutex
+	events []PlaybookSynthesizedEvent
+}
+
+func (p *playbookPublisherStub) PublishPlaybookSynthesized(evt PlaybookSynthesizedEvent) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.events = append(p.events, evt)
+}
+
+func (p *playbookPublisherStub) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.events)
+}
+
+// newPlaybookSynthFixture wires repo + worker + execution log + synth.
+// The llm stub is injected via PlaybookSynthesizerConfig.LLMCall.
+func newPlaybookSynthFixture(
+	t *testing.T,
+	llmStub func(ctx context.Context, sys, user string) (string, error),
+) (*PlaybookSynthesizer, *ExecutionLog, *WikiWorker, *playbookPublisherStub, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	worker := NewWikiWorker(repo, noopPublisher{})
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	execLog := NewExecutionLog(worker)
+	pub := &playbookPublisherStub{}
+	synth := NewPlaybookSynthesizer(worker, execLog, pub, PlaybookSynthesizerConfig{
+		Threshold: 2,
+		Timeout:   5 * time.Second,
+		LLMCall:   llmStub,
+	})
+	synth.Start(context.Background())
+
+	teardown := func() {
+		synth.Stop()
+		cancel()
+		worker.Stop()
+	}
+	return synth, execLog, worker, pub, teardown
+}
+
+// waitForSynthCount polls for n events.
+func waitForSynthCount(t *testing.T, pub *playbookPublisherStub, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pub.count() >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d synth events; got %d", n, pub.count())
+}
+
+const seededPlaybookBody = `---
+author: pm
+---
+
+# Churn prevention
+
+## What to do
+
+1. Pull the account's ARR.
+2. Page the CSM.
+3. Draft a save-offer DM.
+`
+
+func TestPlaybookSynthesizer_PreservesFrontmatterAndAuthorBody(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		// LLM returns a draft that includes the learnings section. The
+		// synthesizer must splice learnings onto the original body, NOT
+		// adopt the LLM's rewrite.
+		return "# I rewrote the body\n\nAll new steps.\n\n## What we've learned\n\n- The CSM is the fastest path.\n", nil
+	}
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	writePlaybookSource(t, worker, "churn-prevention", seededPlaybookBody)
+	_, err := execLog.Append(ctx, "churn-prevention", PlaybookOutcomeSuccess, "Saved the account.", "", "cmo")
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	_, err = execLog.Append(ctx, "churn-prevention", PlaybookOutcomePartial, "Blocked on legal.", "", "cmo")
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	if _, err := synth.SynthesizeNow(ctx, "churn-prevention", "human"); err != nil {
+		t.Fatalf("synthesize: %v", err)
+	}
+	waitForSynthCount(t, pub, 1, 3*time.Second)
+
+	bytes, err := readArticle(worker.Repo(), playbookSourceRel("churn-prevention"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(bytes)
+
+	// Frontmatter: original author key preserved, synthesis keys stamped.
+	if !strings.HasPrefix(got, "---\n") {
+		t.Fatalf("missing frontmatter: %s", got)
+	}
+	if !strings.Contains(got, "author: pm") {
+		t.Errorf("original author key lost: %s", got)
+	}
+	for _, key := range []string{lastSHAKey, lastTSKey, factCntKey} {
+		if !strings.Contains(got, key+":") {
+			t.Errorf("missing synth key %q: %s", key, got)
+		}
+	}
+
+	// Author body preserved verbatim.
+	if !strings.Contains(got, "1. Pull the account's ARR.") {
+		t.Errorf("author step 1 missing: %s", got)
+	}
+	if !strings.Contains(got, "3. Draft a save-offer DM.") {
+		t.Errorf("author step 3 missing: %s", got)
+	}
+	// LLM's body rewrite must NOT have replaced the author body.
+	if strings.Contains(got, "I rewrote the body") {
+		t.Errorf("author body was replaced by the LLM rewrite: %s", got)
+	}
+	// Learnings section landed.
+	if !strings.Contains(got, WhatWeveLearnedHeading) {
+		t.Errorf("missing learnings section: %s", got)
+	}
+	if !strings.Contains(got, "The CSM is the fastest path.") {
+		t.Errorf("learnings bullet missing: %s", got)
+	}
+}
+
+func TestPlaybookSynthesizer_ReplacesExistingLearningsSection(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "## What we've learned\n\n- New lesson from the latest run.\n", nil
+	}
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	seeded := seededPlaybookBody + "\n## What we've learned\n\n- Stale lesson from before.\n"
+	writePlaybookSource(t, worker, "retention", seeded)
+	_, _ = execLog.Append(ctx, "retention", PlaybookOutcomeSuccess, "closed it.", "", "cmo")
+
+	_, _ = synth.SynthesizeNow(ctx, "retention", "human")
+	waitForSynthCount(t, pub, 1, 3*time.Second)
+
+	bytes, err := readArticle(worker.Repo(), playbookSourceRel("retention"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(bytes)
+	if strings.Contains(got, "Stale lesson from before.") {
+		t.Errorf("stale learnings bullet was not replaced: %s", got)
+	}
+	if !strings.Contains(got, "New lesson from the latest run.") {
+		t.Errorf("new learnings bullet missing: %s", got)
+	}
+	// Heading appears exactly once — no duplication.
+	if c := strings.Count(got, WhatWeveLearnedHeading); c != 1 {
+		t.Errorf("expected %q heading exactly once; got %d", WhatWeveLearnedHeading, c)
+	}
+}
+
+func TestPlaybookSynthesizer_ContradictionCalloutsPassThrough(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "## What we've learned\n\n- **Contradiction:** run 1 succeeded skipping step 2; run 3 failed skipping step 2.\n", nil
+	}
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	writePlaybookSource(t, worker, "dispute", seededPlaybookBody)
+	_, _ = execLog.Append(ctx, "dispute", PlaybookOutcomeSuccess, "worked without step 2.", "", "cmo")
+	_, _ = execLog.Append(ctx, "dispute", PlaybookOutcomeAborted, "failed without step 2.", "", "ceo")
+
+	_, _ = synth.SynthesizeNow(ctx, "dispute", "human")
+	waitForSynthCount(t, pub, 1, 3*time.Second)
+
+	bytes, _ := readArticle(worker.Repo(), playbookSourceRel("dispute"))
+	if !strings.Contains(string(bytes), "**Contradiction:**") {
+		t.Errorf("contradiction callout dropped: %s", string(bytes))
+	}
+}
+
+func TestPlaybookSynthesizer_CommitAuthorIsArchivist(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "## What we've learned\n\n- ok\n", nil
+	}
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	writePlaybookSource(t, worker, "attrib", seededPlaybookBody)
+	_, _ = execLog.Append(ctx, "attrib", PlaybookOutcomeSuccess, "ran.", "", "cmo")
+
+	_, _ = synth.SynthesizeNow(ctx, "attrib", "human")
+	waitForSynthCount(t, pub, 1, 3*time.Second)
+
+	entries, err := worker.Repo().AuditLog(ctx, time.Time{}, 50)
+	if err != nil {
+		t.Fatalf("audit: %v", err)
+	}
+	// Find the synthesis commit.
+	var found bool
+	for _, e := range entries {
+		if strings.HasPrefix(e.Message, "archivist: synthesize learnings into playbook attrib") {
+			if e.Author != ArchivistAuthor {
+				t.Errorf("synth commit author = %q, want %q", e.Author, ArchivistAuthor)
+			}
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("synthesis commit not found in audit log")
+	}
+}
+
+func TestPlaybookSynthesizer_MissingSourceIsSkip(t *testing.T) {
+	var calls atomic.Int32
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		calls.Add(1)
+		return "## What we've learned\n\n- ok\n", nil
+	}
+	synth, execLog, _, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+	// Don't seed a source — jump straight to logging + synth.
+	_, _ = execLog.Append(ctx, "ghost", PlaybookOutcomeSuccess, "ran.", "", "cmo")
+	_, _ = synth.SynthesizeNow(ctx, "ghost", "human")
+	time.Sleep(300 * time.Millisecond)
+	if pub.count() != 0 {
+		t.Errorf("expected no synth event for missing source")
+	}
+	if calls.Load() != 0 {
+		t.Errorf("expected LLM to NOT be called when source is missing; got %d", calls.Load())
+	}
+}
+
+func TestPlaybookSynthesizer_NoNewExecutionsIsSkip(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "## What we've learned\n\n- ok\n", nil
+	}
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	writePlaybookSource(t, worker, "stable", seededPlaybookBody)
+	_, _ = execLog.Append(ctx, "stable", PlaybookOutcomeSuccess, "ran.", "", "cmo")
+	_, _ = synth.SynthesizeNow(ctx, "stable", "human")
+	waitForSynthCount(t, pub, 1, 3*time.Second)
+
+	// Second synth with no new executions should skip.
+	_, _ = synth.SynthesizeNow(ctx, "stable", "human")
+	time.Sleep(300 * time.Millisecond)
+	if pub.count() != 1 {
+		t.Errorf("expected exactly 1 synth event; got %d", pub.count())
+	}
+}
+
+func TestPlaybookSynthesizer_LLMErrorDoesNotCommit(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "", fmt.Errorf("llm boom")
+	}
+	synth, execLog, _, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+	_, _ = execLog.Append(ctx, "boom", PlaybookOutcomeSuccess, "ran.", "", "cmo")
+	_, _ = synth.SynthesizeNow(ctx, "boom", "human")
+	time.Sleep(300 * time.Millisecond)
+	if pub.count() != 0 {
+		t.Errorf("expected no synth event on LLM error")
+	}
+}
+
+func TestPlaybookSynthesizer_MissingHeadingRejected(t *testing.T) {
+	// LLM draft without the required heading must be rejected.
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "Just some text without the required heading.\n", nil
+	}
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+	writePlaybookSource(t, worker, "noheading", seededPlaybookBody)
+	_, _ = execLog.Append(ctx, "noheading", PlaybookOutcomeSuccess, "ran.", "", "cmo")
+	_, _ = synth.SynthesizeNow(ctx, "noheading", "human")
+	time.Sleep(300 * time.Millisecond)
+	if pub.count() != 0 {
+		t.Errorf("expected no synth event when LLM omits the required heading")
+	}
+}
+
+func TestPlaybookSynthesizer_StopPreventsNewJobs(t *testing.T) {
+	synth, execLog, _, _, teardown := newPlaybookSynthFixture(t, func(context.Context, string, string) (string, error) {
+		return "## What we've learned\n\n- ok\n", nil
+	})
+	defer teardown()
+	synth.Stop()
+
+	_, _ = execLog.Append(context.Background(), "stopped", PlaybookOutcomeSuccess, "ran.", "", "cmo")
+	if _, err := synth.SynthesizeNow(context.Background(), "stopped", "human"); err != ErrPlaybookSynthesizerStopped {
+		t.Fatalf("expected ErrPlaybookSynthesizerStopped; got %v", err)
+	}
+}
+
+func TestPlaybookSynthesizer_ThresholdAutoTriggers(t *testing.T) {
+	// When OnExecutionRecorded is called with enough executions to cross the
+	// threshold, synthesis is auto-enqueued. Fixture threshold=2.
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "## What we've learned\n\n- ok\n", nil
+	}
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+	writePlaybookSource(t, worker, "auto", seededPlaybookBody)
+
+	_, _ = execLog.Append(ctx, "auto", PlaybookOutcomeSuccess, "run 1.", "", "cmo")
+	synth.OnExecutionRecorded("auto")
+	// Threshold not crossed yet (1 < 2); no event expected.
+	time.Sleep(150 * time.Millisecond)
+	if pub.count() != 0 {
+		t.Errorf("expected 0 syntheses at count=1 < threshold=2; got %d", pub.count())
+	}
+
+	_, _ = execLog.Append(ctx, "auto", PlaybookOutcomeSuccess, "run 2.", "", "cmo")
+	synth.OnExecutionRecorded("auto")
+	waitForSynthCount(t, pub, 1, 3*time.Second)
+}
+
+// TestPlaybookSynthesizer_IntegrationTriggersAutoRecompile verifies the
+// full end-to-end loop: writing a synthesis commit to the source playbook
+// causes the existing auto-recompile hook (wired in wiki_worker.go) to
+// regenerate SKILL.md. Observable via the compiled file's mtime bumping.
+func TestPlaybookSynthesizer_IntegrationTriggersAutoRecompile(t *testing.T) {
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		return "## What we've learned\n\n- compiled again.\n", nil
+	}
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+
+	writePlaybookSource(t, worker, "recompile", seededPlaybookBody)
+	// Force an initial compile so SKILL.md exists before synthesis.
+	if _, _, err := worker.EnqueuePlaybookCompile(ctx, "recompile", ArchivistAuthor); err != nil {
+		t.Fatalf("initial compile: %v", err)
+	}
+	skillFull := filepath.Join(worker.Repo().Root(), filepath.FromSlash(CompiledSkillRelPath("recompile")))
+	initialStat, err := os.Stat(skillFull)
+	if err != nil {
+		t.Fatalf("initial stat: %v", err)
+	}
+
+	// Wait a bit so mtimes can change observably on filesystems with
+	// second precision.
+	time.Sleep(1100 * time.Millisecond)
+
+	_, _ = execLog.Append(ctx, "recompile", PlaybookOutcomeSuccess, "ran.", "", "cmo")
+	_, _ = synth.SynthesizeNow(ctx, "recompile", "human")
+	waitForSynthCount(t, pub, 1, 3*time.Second)
+
+	// Auto-recompile is async (side goroutine). Poll.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		st, err := os.Stat(skillFull)
+		if err == nil && st.ModTime().After(initialStat.ModTime()) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("auto-recompile did not bump SKILL.md mtime; initial=%s", initialStat.ModTime())
+}

--- a/internal/teammcp/playbook_tools.go
+++ b/internal/teammcp/playbook_tools.go
@@ -30,6 +30,12 @@ type TeamPlaybookCompileArgs struct {
 	Slug   string `json:"slug" jsonschema:"Kebab-case playbook slug matching team/playbooks/{slug}.md."`
 }
 
+// TeamPlaybookSynthesizeNowArgs is the contract for playbook_synthesize_now.
+type TeamPlaybookSynthesizeNowArgs struct {
+	MySlug string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	Slug   string `json:"slug" jsonschema:"Kebab-case playbook slug matching team/playbooks/{slug}.md."`
+}
+
 // TeamPlaybookExecutionRecordArgs is the contract for playbook_execution_record.
 type TeamPlaybookExecutionRecordArgs struct {
 	MySlug  string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
@@ -55,6 +61,10 @@ func registerPlaybookTools(server *mcp.Server) {
 		"playbook_execution_record",
 		"Record the outcome of a playbook run. Any agent that invokes a compiled playbook skill is expected to call this when the run finishes (success, partial, or aborted). The log is append-only — wrong outcomes are corrected by adding a new entry, never by editing.",
 	), handlePlaybookExecutionRecord)
+	mcp.AddTool(server, officeWriteTool(
+		"playbook_synthesize_now",
+		"Force the broker to synthesize the latest execution outcomes back into a playbook's 'What we've learned' section RIGHT NOW, bypassing the threshold. Call this after you just logged a particularly useful outcome (or a hard-won failure) that the next runner should see immediately. Normally synthesis happens automatically after N executions; this tool short-circuits that for urgent lessons.",
+	), handlePlaybookSynthesizeNow)
 }
 
 func handlePlaybookListTool(ctx context.Context, _ *mcp.CallToolRequest, args TeamPlaybookListArgs) (*mcp.CallToolResult, any, error) {
@@ -85,6 +95,30 @@ func handlePlaybookCompileTool(ctx context.Context, _ *mcp.CallToolRequest, args
 		CommitSHA string `json:"commit_sha"`
 	}
 	if err := brokerPostJSON(ctx, "/playbook/compile", map[string]any{"slug": slug}, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	payload, _ := json.Marshal(result)
+	return textResult(string(payload)), nil, nil
+}
+
+func handlePlaybookSynthesizeNow(ctx context.Context, _ *mcp.CallToolRequest, args TeamPlaybookSynthesizeNowArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	playbookSlug := strings.TrimSpace(args.Slug)
+	if playbookSlug == "" {
+		return toolError(fmt.Errorf("slug is required")), nil, nil
+	}
+	body := map[string]any{
+		"slug":       playbookSlug,
+		"actor_slug": slug,
+	}
+	var result struct {
+		SynthesisID uint64 `json:"synthesis_id"`
+		QueuedAt    string `json:"queued_at"`
+	}
+	if err := brokerPostJSON(ctx, "/playbook/synthesize", body, &result); err != nil {
 		return toolError(err), nil, nil
 	}
 	payload, _ := json.Marshal(result)

--- a/internal/teammcp/playbook_tools_test.go
+++ b/internal/teammcp/playbook_tools_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPlaybookToolsRegisteredOnlyInMarkdownBackend(t *testing.T) {
-	toolNames := []string{"playbook_list", "playbook_compile", "playbook_execution_record"}
+	toolNames := []string{"playbook_list", "playbook_compile", "playbook_execution_record", "playbook_synthesize_now"}
 	cases := []struct {
 		backend  string
 		mustHave bool
@@ -37,7 +37,7 @@ func TestPlaybookToolsRegisteredOnlyInMarkdownBackend(t *testing.T) {
 func TestPlaybookToolsRegisteredInOneOnOne(t *testing.T) {
 	t.Setenv("WUPHF_MEMORY_BACKEND", "markdown")
 	names := listRegisteredTools(t, "dm-ceo", true)
-	for _, want := range []string{"playbook_list", "playbook_compile", "playbook_execution_record"} {
+	for _, want := range []string{"playbook_list", "playbook_compile", "playbook_execution_record", "playbook_synthesize_now"} {
 		if !slices.Contains(names, want) {
 			t.Errorf("1:1 mode missing tool %q", want)
 		}

--- a/web/src/api/playbook.ts
+++ b/web/src/api/playbook.ts
@@ -10,7 +10,7 @@
  * message.
  */
 
-import { get, sseURL } from './client'
+import { get, post, sseURL } from './client'
 
 // ── Types ────────────────────────────────────────────────────────
 
@@ -45,6 +45,30 @@ export interface PlaybookExecutionRecordedEvent {
   timestamp: string
 }
 
+export interface PlaybookSynthesizedEvent {
+  slug: string
+  commit_sha: string
+  execution_count: number
+  synthesized_ts: string
+  source_path: string
+  triggered_by_user: boolean
+}
+
+export interface PlaybookSynthesisStatus {
+  slug: string
+  source_path: string
+  execution_count: number
+  last_synthesized_ts: string
+  last_synthesized_sha: string
+  executions_since_last_synthesis: number
+  threshold: number
+}
+
+export interface PlaybookSynthesizeResponse {
+  synthesis_id: number
+  queued_at: string
+}
+
 // ── HTTP ─────────────────────────────────────────────────────────
 
 /** `GET /playbook/list` — every source playbook + its compiled skill status. */
@@ -57,6 +81,32 @@ export async function fetchPlaybooks(): Promise<PlaybookSummary[]> {
     return Array.isArray(res?.playbooks) ? res.playbooks : []
   } catch {
     return []
+  }
+}
+
+/** `POST /playbook/synthesize` — force on-demand synthesis for one slug. */
+export async function synthesizeNow(
+  slug: string,
+): Promise<PlaybookSynthesizeResponse | null> {
+  try {
+    return await post<PlaybookSynthesizeResponse>('/playbook/synthesize', {
+      slug,
+    })
+  } catch {
+    return null
+  }
+}
+
+/** `GET /playbook/synthesis-status?slug=` — last synthesis sha + timestamp. */
+export async function fetchSynthesisStatus(
+  slug: string,
+): Promise<PlaybookSynthesisStatus | null> {
+  try {
+    return await get<PlaybookSynthesisStatus>(
+      `/playbook/synthesis-status?slug=${encodeURIComponent(slug)}`,
+    )
+  } catch {
+    return null
   }
 }
 
@@ -123,6 +173,56 @@ export function subscribePlaybookEvents(
     if (source) {
       source.removeEventListener(
         'playbook:execution_recorded',
+        handler as EventListener,
+      )
+      source.close()
+      source = null
+    }
+  }
+}
+
+/**
+ * Subscribe to `playbook:synthesized` events filtered to one slug.
+ * Returns an unsubscribe function. Synthesis events fire when the broker's
+ * compounding-intelligence loop commits a new "What we've learned" section
+ * back into the playbook source.
+ */
+export function subscribePlaybookSynthesizedEvents(
+  slug: string,
+  onSynthesized: (ev: PlaybookSynthesizedEvent) => void,
+): () => void {
+  let closed = false
+  let source: EventSource | null = null
+
+  const handler = (ev: MessageEvent) => {
+    if (closed) return
+    try {
+      const data = JSON.parse(ev.data) as PlaybookSynthesizedEvent
+      if (data && data.slug === slug) {
+        onSynthesized(data)
+      }
+    } catch {
+      // ignore malformed events
+    }
+  }
+
+  try {
+    const ES = (globalThis as { EventSource?: typeof EventSource }).EventSource
+    if (!ES) return () => {}
+    source = new ES(sseURL('/events'))
+    source.addEventListener('playbook:synthesized', handler as EventListener)
+    source.onerror = () => {
+      // Keep open; EventSource auto-reconnects.
+    }
+  } catch {
+    source = null
+  }
+
+  return () => {
+    closed = true
+    if (source) {
+      source.removeEventListener(
+        'playbook:synthesized',
         handler as EventListener,
       )
       source.close()

--- a/web/src/components/wiki/PlaybookExecutionLog.test.tsx
+++ b/web/src/components/wiki/PlaybookExecutionLog.test.tsx
@@ -7,6 +7,10 @@ describe('<PlaybookExecutionLog>', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     vi.spyOn(api, 'subscribePlaybookEvents').mockImplementation(() => () => {})
+    vi.spyOn(api, 'subscribePlaybookSynthesizedEvents').mockImplementation(
+      () => () => {},
+    )
+    vi.spyOn(api, 'fetchSynthesisStatus').mockResolvedValue(null)
   })
 
   it('renders the empty state when no executions exist', async () => {
@@ -48,6 +52,50 @@ describe('<PlaybookExecutionLog>', () => {
     // Outcome pills use uppercase labels.
     expect(screen.getByText('partial')).toBeInTheDocument()
     expect(screen.getByText('success')).toBeInTheDocument()
+  })
+
+  it('shows the last-synthesis badge when status is available', async () => {
+    vi.spyOn(api, 'fetchPlaybookExecutions').mockResolvedValue([])
+    const ts = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString() // 2h ago
+    vi.spyOn(api, 'fetchSynthesisStatus').mockResolvedValue({
+      slug: 'churn-prevention',
+      source_path: 'team/playbooks/churn-prevention.md',
+      execution_count: 7,
+      last_synthesized_ts: ts,
+      last_synthesized_sha: 'abc1234',
+      executions_since_last_synthesis: 2,
+      threshold: 3,
+    })
+    render(<PlaybookExecutionLog slug="churn-prevention" />)
+    fireEvent.click(await screen.findByRole('button', { name: /execution log/i }))
+    await waitFor(() => {
+      expect(screen.getByTestId('wk-playbook-synthesis')).toBeInTheDocument()
+    })
+    // "2h ago · 7 executions"
+    expect(screen.getByText(/2h ago · 7 executions/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(/2 new executions since last synthesis/i),
+    ).toBeInTheDocument()
+  })
+
+  it('posts to synthesizeNow when Re-synthesize is clicked', async () => {
+    vi.spyOn(api, 'fetchPlaybookExecutions').mockResolvedValue([])
+    const spy = vi
+      .spyOn(api, 'synthesizeNow')
+      .mockResolvedValue({ synthesis_id: 1, queued_at: '2026-04-21T10:00:00Z' })
+    render(<PlaybookExecutionLog slug="churn-prevention" />)
+    fireEvent.click(await screen.findByRole('button', { name: /execution log/i }))
+    const button = await screen.findByTestId('wk-playbook-synthesis-button')
+    fireEvent.click(button)
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledWith('churn-prevention')
+    })
+    // The button transitions to the pending label immediately.
+    await waitFor(() =>
+      expect(screen.getByTestId('wk-playbook-synthesis-button')).toHaveTextContent(
+        /synthesizing/i,
+      ),
+    )
   })
 
   it('exposes the count next to the heading even when collapsed', async () => {

--- a/web/src/components/wiki/PlaybookExecutionLog.tsx
+++ b/web/src/components/wiki/PlaybookExecutionLog.tsx
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useState } from 'react'
 import {
   fetchPlaybookExecutions,
+  fetchSynthesisStatus,
   subscribePlaybookEvents,
+  subscribePlaybookSynthesizedEvents,
+  synthesizeNow,
   type PlaybookExecution,
+  type PlaybookSynthesisStatus,
 } from '../../api/playbook'
 import { formatAgentName } from '../../lib/agentName'
 
@@ -12,31 +16,50 @@ interface PlaybookExecutionLogProps {
 
 const INITIAL_LIMIT = 10
 
+type SynthState = 'idle' | 'pending' | 'success' | 'error'
+
 /**
  * Collapsible execution-log panel rendered on playbook article pages.
  * Newest-first, capped at INITIAL_LIMIT by default — the full log is
  * available in `team/playbooks/{slug}.executions.jsonl` for auditing.
+ *
+ * Also hosts the compounding-intelligence surface:
+ *   - "Last synthesis" badge summarising archivist activity.
+ *   - "Re-synthesize" button that triggers POST /playbook/synthesize.
+ * The playbook article reloads automatically via the existing wiki:write
+ * SSE event when synthesis commits; this component listens for
+ * playbook:synthesized specifically to refresh its own status strip.
  */
 export default function PlaybookExecutionLog({ slug }: PlaybookExecutionLogProps) {
   const [entries, setEntries] = useState<PlaybookExecution[]>([])
   const [loading, setLoading] = useState(true)
   const [expanded, setExpanded] = useState(false)
   const [showAll, setShowAll] = useState(false)
+  const [status, setStatus] = useState<PlaybookSynthesisStatus | null>(null)
+  const [synthState, setSynthState] = useState<SynthState>('idle')
 
   const load = useCallback(() => {
     void fetchPlaybookExecutions(slug).then((rows) => setEntries(rows))
   }, [slug])
 
+  const loadStatus = useCallback(() => {
+    void fetchSynthesisStatus(slug).then((s) => setStatus(s))
+  }, [slug])
+
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    fetchPlaybookExecutions(slug)
-      .then((rows) => {
+    Promise.all([fetchPlaybookExecutions(slug), fetchSynthesisStatus(slug)])
+      .then(([rows, s]) => {
         if (cancelled) return
         setEntries(rows)
+        setStatus(s)
       })
       .catch(() => {
-        if (!cancelled) setEntries([])
+        if (!cancelled) {
+          setEntries([])
+          setStatus(null)
+        }
       })
       .finally(() => {
         if (!cancelled) setLoading(false)
@@ -47,13 +70,35 @@ export default function PlaybookExecutionLog({ slug }: PlaybookExecutionLogProps
   }, [slug])
 
   useEffect(() => {
-    const unsubscribe = subscribePlaybookEvents(slug, () => {
+    const unsubscribeExec = subscribePlaybookEvents(slug, () => {
       load()
+      loadStatus()
     })
-    return unsubscribe
-  }, [slug, load])
+    const unsubscribeSynth = subscribePlaybookSynthesizedEvents(slug, () => {
+      loadStatus()
+      setSynthState((prev) => (prev === 'pending' ? 'success' : prev))
+    })
+    return () => {
+      unsubscribeExec()
+      unsubscribeSynth()
+    }
+  }, [slug, load, loadStatus])
 
   const visible = showAll ? entries : entries.slice(0, INITIAL_LIMIT)
+
+  const handleResynthesize = async () => {
+    setSynthState('pending')
+    const result = await synthesizeNow(slug)
+    if (!result) {
+      setSynthState('error')
+      return
+    }
+    // success transitions on the playbook:synthesized event; fall back to a
+    // timer so the button doesn't get stuck if the SSE stream is dropped.
+    window.setTimeout(() => {
+      setSynthState((prev) => (prev === 'pending' ? 'success' : prev))
+    }, 8000)
+  }
 
   return (
     <section
@@ -120,14 +165,80 @@ export default function PlaybookExecutionLog({ slug }: PlaybookExecutionLogProps
               )}
             </>
           )}
+          <SynthesisFooter
+            status={status}
+            synthState={synthState}
+            onResynthesize={handleResynthesize}
+          />
         </div>
       )}
     </section>
   )
 }
 
+interface SynthesisFooterProps {
+  status: PlaybookSynthesisStatus | null
+  synthState: SynthState
+  onResynthesize: () => void
+}
+
+function SynthesisFooter({ status, synthState, onResynthesize }: SynthesisFooterProps) {
+  const lastLabel = status?.last_synthesized_ts
+    ? `Last synthesis: ${formatRelativeTs(status.last_synthesized_ts)} · ${status.execution_count} execution${status.execution_count === 1 ? '' : 's'}`
+    : 'No synthesis yet — learnings will be added after the first archivist run.'
+  const pendingLabel =
+    status && status.executions_since_last_synthesis > 0
+      ? `${status.executions_since_last_synthesis} new execution${status.executions_since_last_synthesis === 1 ? '' : 's'} since last synthesis`
+      : null
+
+  const buttonDisabled = synthState === 'pending'
+  let buttonLabel = 'Re-synthesize'
+  if (synthState === 'pending') buttonLabel = 'Synthesizing…'
+  if (synthState === 'success') buttonLabel = 'Synthesized ✓'
+  if (synthState === 'error') buttonLabel = 'Retry synthesis'
+
+  return (
+    <div
+      className="wk-playbook-synthesis"
+      data-testid="wk-playbook-synthesis"
+      data-state={synthState}
+    >
+      <div className="wk-playbook-synthesis__status">
+        <span className="wk-playbook-synthesis__badge">{lastLabel}</span>
+        {pendingLabel && (
+          <span className="wk-playbook-synthesis__pending">{pendingLabel}</span>
+        )}
+      </div>
+      <button
+        type="button"
+        className="wk-playbook-synthesis__button"
+        onClick={onResynthesize}
+        disabled={buttonDisabled}
+        data-testid="wk-playbook-synthesis-button"
+      >
+        {buttonLabel}
+      </button>
+    </div>
+  )
+}
+
 function formatShortTs(iso: string): string {
   const d = new Date(iso)
   if (Number.isNaN(d.getTime())) return iso
+  return d.toISOString().slice(0, 10)
+}
+
+function formatRelativeTs(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  const diffMs = Date.now() - d.getTime()
+  if (diffMs < 0) return 'just now'
+  const mins = Math.floor(diffMs / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 14) return `${days}d ago`
   return d.toISOString().slice(0, 10)
 }

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1511,6 +1511,65 @@
   text-decoration: underline dashed;
   text-underline-offset: 2px;
 }
+
+/* ────────────────────────────────────────────────────────────
+ * v1.3 compounding-intelligence synthesis footer — status badge
+ * + Re-synthesize button. Lives inside PlaybookExecutionLog.
+ * Motion stays on transform/opacity (see ~/.claude/rules/web/performance.md).
+ * ──────────────────────────────────────────────────────────── */
+
+.wk-playbook-synthesis {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px dashed var(--wk-rule, rgba(0, 0, 0, 0.15));
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.wk-playbook-synthesis__status {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.wk-playbook-synthesis__badge {
+  font-family: var(--wk-chrome);
+  font-size: 12px;
+  color: var(--wk-body-muted, rgba(0, 0, 0, 0.6));
+}
+.wk-playbook-synthesis__pending {
+  font-family: var(--wk-mono);
+  font-size: 11px;
+  color: #b0821c;
+}
+.wk-playbook-synthesis__button {
+  font-family: var(--wk-chrome);
+  font-size: 12px;
+  padding: 4px 10px;
+  border: 1px solid var(--wk-rule, rgba(0, 0, 0, 0.25));
+  background: transparent;
+  color: var(--wk-body, #111);
+  cursor: pointer;
+  border-radius: 2px;
+  transition: background 150ms ease, opacity 150ms ease;
+}
+.wk-playbook-synthesis__button:hover:not([disabled]) {
+  background: rgba(0, 0, 0, 0.04);
+}
+.wk-playbook-synthesis__button[disabled] {
+  opacity: 0.6;
+  cursor: progress;
+}
+.wk-playbook-synthesis[data-state='success'] .wk-playbook-synthesis__button {
+  color: #2a7d2a;
+  border-color: #2a7d2a;
+}
+.wk-playbook-synthesis[data-state='error'] .wk-playbook-synthesis__button {
+  color: #c94a4a;
+  border-color: #c94a4a;
+}
 /* ────────────────────────────────────────────────────────────
  * v1.3 Image embeds — agents embed via standard markdown
  * `![alt](https://...)`; renderer routes through ImageEmbed.


### PR DESCRIPTION
## Summary

Closes the loop on v1.3 playbooks. Today executions accumulate in the append-only jsonl log but the playbook body itself never changes — the next agent to run the playbook gets the original v1 instructions with zero accumulated wisdom. This PR adds a broker-level synthesizer that mirrors how v1.2 entity briefs work: threshold-triggered LLM synthesis rewrites the source playbook's trailing \"## What we've learned\" section, preserving the author's main body verbatim. The existing auto-recompile hook then regenerates the SKILL.md so the next agent starts smarter.

## What changed

**Backend — `internal/team/`:**
- `playbook_synthesizer.go`: new broker-level worker. Same debounce + coalesce + inflight-follow-up pattern as `entity_synthesizer.go`. Threshold env `WUPHF_PLAYBOOK_SYNTHESIS_THRESHOLD` (default 3). Timeout `WUPHF_PLAYBOOK_SYNTHESIS_TIMEOUT` (default 45s).
- `mergePreservingAuthorBody`: defense in depth — even if the LLM ignores the prompt and rewrites the body, we splice only its \"## What we've learned\" section onto the original author body.
- Commits as `archivist` via the existing wiki write queue. The auto-recompile hook in `wiki_worker.go` then regenerates `SKILL.md` with the updated body — no new plumbing needed.
- Broker wiring in `broker.go` + `broker_playbook.go`: ensure/Start/Stop lifecycle, POST `/playbook/synthesize`, GET `/playbook/synthesis-status`, `playbook:synthesized` SSE event.
- `OnExecutionRecorded(slug)` hook called from `handlePlaybookExecution` — threshold auto-trigger without a separate background scanner.

**MCP tool — `internal/teammcp/playbook_tools.go`:**
- `playbook_synthesize_now` — gated on `WUPHF_MEMORY_BACKEND=markdown`. Lets an agent force synthesis after a particularly useful outcome.

**Frontend — `web/src/`:**
- `api/playbook.ts`: `synthesizeNow`, `fetchSynthesisStatus`, `subscribePlaybookSynthesizedEvents`.
- `components/wiki/PlaybookExecutionLog.tsx`: \"Last synthesis: 2h ago · N executions\" badge + \"Re-synthesize\" button with pending/success/error states. Auto-refreshes on SSE.
- `styles/wiki.css`: footer styling uses existing wiki tokens, no new palette.

## Design decisions

- **Threshold = 3.** Playbooks run more often than entity facts accumulate; 3 is enough signal to be useful but not so many that early playbooks never get synthesized.
- **Debounce = 10ms follow-up sleep** (same as entity synthesizer). Enough to let a burst of executions coalesce into one follow-up commit.
- **Contradictions never auto-resolved.** Prompt instructs the model to emit `**Contradiction:**` inline callouts; tests verify they pass through intact. Humans decide.
- **Author body preserved twice.** Prompt says \"don't rewrite\" and `mergePreservingAuthorBody` enforces it at commit time. Hubris is expensive; author intent is cheap to keep.
- **No new SSE event for wiki:write.** Synthesis commits already fire `wiki:write` via the normal queue, which the existing article view listens for. We add `playbook:synthesized` purely for the status-strip refresh.

## Assumptions

- `WUPHF_MEMORY_BACKEND=markdown` is the only deployment target (matches the other v1.3 playbook tools).
- The existing `fact_count_at_synthesis` frontmatter key is reused — the schema is identical to entity briefs (`entity_frontmatter.go`), so no new parser.

## Non-overlap

The sibling editable-wiki branch touches `WikiArticle.tsx`, `Byline.tsx`, and write-human routes. This PR only extends `PlaybookExecutionLog.tsx` and adds new additive broker routes / SSE events / MCP tool. Merge should be conflict-free.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (228 + all Go tests green; the one `-race` failure is a pre-existing flake in `headless_codex_test.go` unrelated to this change)
- [x] `cd web && bun run build` passes
- [x] `cd web && bun run test` — 50/50 files, 228/228 tests pass (5 new tests for PlaybookExecutionLog)
- [x] Unit: synthesizer preserves frontmatter, preserves author body, replaces existing learnings section, emits contradiction callouts, commits as archivist, skips missing source + no-new-executions, rejects empty/malformed LLM output
- [x] Integration: recording N executions (N = threshold) fires synthesis and triggers auto-recompile (observable via `.compiled/SKILL.md` mtime)
- [x] Integration: broker HTTP endpoints (`/playbook/synthesize`, `/playbook/synthesis-status`) work end-to-end
- [ ] Manual QA: launch dev broker (`--broker-port 7899 --web-port 7900`), seed a playbook, record 3 executions, confirm synthesis commit lands and the web badge updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Playbook Synthesis: New AI-powered capability to synthesize learnings from playbook executions. Manually trigger synthesis on-demand, view synthesis metadata (including last synthesis timestamp and execution count), track how many new executions occurred since the last synthesis, and receive real-time notifications when synthesis completes. A dedicated panel in the execution log provides re-synthesize controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->