### PR TITLE
feat(wiki-editor): draft autosave + live preview pane

### DIFF
--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -1,13 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
-import remarkGfm from 'remark-gfm'
-import rehypeSlug from 'rehype-slug'
-import rehypeAutolinkHeadings from 'rehype-autolink-headings'
 import type { PluggableList } from 'unified'
 import ArticleStatusBanner from './ArticleStatusBanner'
 import EntityBriefBar from './EntityBriefBar'
 import FactsOnFile from './FactsOnFile'
-import ImageEmbed from './ImageEmbed'
 import PlaybookExecutionLog from './PlaybookExecutionLog'
 import PlaybookSkillBadge from './PlaybookSkillBadge'
 import HatBar, { type HatBarTab } from './HatBar'
@@ -32,7 +28,11 @@ import {
   type WikiHistoryCommit,
 } from '../../api/wiki'
 import type { SourceItem } from './Sources'
-import { wikiLinkRemarkPlugin } from '../../lib/wikilink'
+import {
+  buildMarkdownComponents,
+  buildRehypePlugins,
+  buildRemarkPlugins,
+} from '../../lib/wikiMarkdownConfig'
 import { formatAgentName } from '../../lib/agentName'
 import type { EntityKind } from '../../api/entity'
 import { detectPlaybook } from '../../api/playbook'
@@ -143,12 +143,13 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
   )
 
   const remarkPlugins: PluggableList = useMemo(
-    () => [remarkGfm, wikiLinkRemarkPlugin(resolver)],
+    () => buildRemarkPlugins(resolver),
     [resolver],
   )
-  const rehypePlugins: PluggableList = useMemo(
-    () => [rehypeSlug, [rehypeAutolinkHeadings, { behavior: 'wrap' }]],
-    [],
+  const rehypePlugins: PluggableList = useMemo(() => buildRehypePlugins(), [])
+  const markdownComponents = useMemo(
+    () => buildMarkdownComponents({ resolver, onNavigate }),
+    [resolver, onNavigate],
   )
 
   if (loading) return <div className="wk-loading">Loading article…</div>
@@ -225,35 +226,7 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
             <ReactMarkdown
               remarkPlugins={remarkPlugins}
               rehypePlugins={rehypePlugins}
-              components={{
-                a: ({ node, ...props }) => {
-                  const isWikilink = (props as Record<string, unknown>)['data-wikilink'] === 'true'
-                  if (isWikilink) {
-                    const slug = (props as Record<string, unknown>)['data-slug'] as string | undefined
-                    return (
-                      <a
-                        {...props}
-                        onClick={(e) => {
-                          if (slug) {
-                            e.preventDefault()
-                            onNavigate(slug)
-                          }
-                        }}
-                      />
-                    )
-                  }
-                  return <a {...props} />
-                },
-                // Agents embed images as standard markdown (`![alt](https://...)`).
-                // Route them through ImageEmbed so editorial articles get
-                // lazy-loading, lightbox, and no-referrer leaks to the source host.
-                img: ({ src, alt, width, height }) => {
-                  if (!src) return null
-                  const w = typeof width === 'string' ? parseInt(width, 10) || undefined : width
-                  const h = typeof height === 'string' ? parseInt(height, 10) || undefined : height
-                  return <ImageEmbed src={String(src)} alt={alt} width={w} height={h} />
-                },
-              }}
+              components={markdownComponents}
             >
               {article.content}
             </ReactMarkdown>
@@ -264,6 +237,8 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
             path={article.path}
             initialContent={article.content}
             expectedSha={article.commit_sha ?? ''}
+            serverLastEditedTs={article.last_edited_ts}
+            catalog={catalog}
             onSaved={(newSha) => {
               // Refetch after every save — covers both happy path and
               // the conflict-then-reload path (which passes the server's

--- a/web/src/components/wiki/WikiEditor.test.tsx
+++ b/web/src/components/wiki/WikiEditor.test.tsx
@@ -1,24 +1,49 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import WikiEditor from './WikiEditor'
 import * as api from '../../api/wiki'
+
+const PATH = 'team/people/nazz.md'
+const DRAFT_KEY = `wuphf:draft:${PATH}`
+const SERVER_TS = '2026-04-20T10:00:00.000Z'
+
+function setLocalStorageDraft(
+  content: string,
+  summary: string,
+  savedAt: string,
+) {
+  window.localStorage.setItem(
+    DRAFT_KEY,
+    JSON.stringify({ content, summary, saved_at: savedAt }),
+  )
+}
 
 describe('<WikiEditor>', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it('pre-fills the textarea with the article content and the expected SHA is sent on save', async () => {
     const spy = vi
       .spyOn(api, 'writeHumanArticle')
-      .mockResolvedValue({ path: 'team/people/nazz.md', commit_sha: 'abc1234', bytes_written: 42 })
+      .mockResolvedValue({
+        path: PATH,
+        commit_sha: 'abc1234',
+        bytes_written: 42,
+      })
 
     const onSaved = vi.fn()
     render(
       <WikiEditor
-        path="team/people/nazz.md"
+        path={PATH}
         initialContent="# Nazz\n\nOriginal."
         expectedSha="deadbee"
+        serverLastEditedTs={SERVER_TS}
         onSaved={onSaved}
         onCancel={() => {}}
       />,
@@ -35,7 +60,7 @@ describe('<WikiEditor>', () => {
 
     await waitFor(() => expect(spy).toHaveBeenCalled())
     expect(spy).toHaveBeenCalledWith({
-      path: 'team/people/nazz.md',
+      path: PATH,
       content: '# Nazz\n\nEdited.',
       commitMessage: 'fix wording',
       expectedSha: 'deadbee',
@@ -53,17 +78,18 @@ describe('<WikiEditor>', () => {
 
     render(
       <WikiEditor
-        path="team/people/nazz.md"
+        path={PATH}
         initialContent="# Nazz\n\nMine."
         expectedSha="oldsha1"
+        serverLastEditedTs={SERVER_TS}
         onSaved={() => {}}
         onCancel={() => {}}
       />,
     )
     fireEvent.click(screen.getByTestId('wk-editor-save'))
 
-    const banner = await screen.findByRole('alert')
-    expect(banner.textContent).toMatch(/Someone else edited this article/)
+    const banner = await screen.findByText(/Someone else edited this article/)
+    expect(banner).toBeInTheDocument()
     expect(
       screen.getByRole('button', { name: /Reload latest & re-apply/ }),
     ).toBeInTheDocument()
@@ -73,14 +99,17 @@ describe('<WikiEditor>', () => {
     const spy = vi.spyOn(api, 'writeHumanArticle')
     render(
       <WikiEditor
-        path="team/people/nazz.md"
+        path={PATH}
         initialContent="# Nazz\n"
         expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
         onSaved={() => {}}
         onCancel={() => {}}
       />,
     )
-    fireEvent.change(screen.getByTestId('wk-editor-textarea'), { target: { value: '   ' } })
+    fireEvent.change(screen.getByTestId('wk-editor-textarea'), {
+      target: { value: '   ' },
+    })
     fireEvent.click(screen.getByTestId('wk-editor-save'))
     expect(spy).not.toHaveBeenCalled()
     expect(await screen.findByRole('alert')).toHaveTextContent(/cannot be empty/i)
@@ -90,14 +119,245 @@ describe('<WikiEditor>', () => {
     const onCancel = vi.fn()
     render(
       <WikiEditor
-        path="team/people/nazz.md"
+        path={PATH}
         initialContent="x"
         expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
         onSaved={() => {}}
         onCancel={onCancel}
       />,
     )
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
     expect(onCancel).toHaveBeenCalled()
+  })
+
+  // ── Draft autosave ─────────────────────────────────────────────────
+
+  it('writes a debounced draft to localStorage after edits', async () => {
+    vi.useFakeTimers()
+    render(
+      <WikiEditor
+        path={PATH}
+        initialContent="Original."
+        expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    fireEvent.change(screen.getByTestId('wk-editor-textarea'), {
+      target: { value: 'Edited locally.' },
+    })
+    // Before the debounce fires, nothing is persisted.
+    expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull()
+    // Advance past the debounce window.
+    await act(async () => {
+      vi.advanceTimersByTime(800)
+    })
+    const raw = window.localStorage.getItem(DRAFT_KEY)
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw as string)
+    expect(parsed.content).toBe('Edited locally.')
+  })
+
+  it('shows the draft banner when localStorage has a newer draft than the server', () => {
+    const tenMinAfterServer = new Date(
+      Date.parse(SERVER_TS) + 10 * 60 * 1000,
+    ).toISOString()
+    setLocalStorageDraft('# Nazz\n\nDraft text.', 'wip', tenMinAfterServer)
+
+    render(
+      <WikiEditor
+        path={PATH}
+        initialContent="# Nazz\n\nOriginal."
+        expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('wk-editor-draft-banner')).toBeInTheDocument()
+  })
+
+  it('restore copies the draft into the textarea and hides the banner', () => {
+    const tenMinAfter = new Date(
+      Date.parse(SERVER_TS) + 10 * 60 * 1000,
+    ).toISOString()
+    setLocalStorageDraft('# Nazz\n\nDraft text.', 'wip summary', tenMinAfter)
+
+    render(
+      <WikiEditor
+        path={PATH}
+        initialContent="# Nazz\n\nOriginal."
+        expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('wk-editor-draft-restore'))
+    const textarea = screen.getByTestId('wk-editor-textarea') as HTMLTextAreaElement
+    expect(textarea.value).toBe('# Nazz\n\nDraft text.')
+    const commit = screen.getByTestId('wk-editor-commit') as HTMLInputElement
+    expect(commit.value).toBe('wip summary')
+    expect(screen.queryByTestId('wk-editor-draft-banner')).toBeNull()
+  })
+
+  it('discard clears the draft from localStorage and hides the banner', () => {
+    const tenMinAfter = new Date(
+      Date.parse(SERVER_TS) + 10 * 60 * 1000,
+    ).toISOString()
+    setLocalStorageDraft('draft body', '', tenMinAfter)
+
+    render(
+      <WikiEditor
+        path={PATH}
+        initialContent="original body"
+        expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('wk-editor-draft-discard'))
+    expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull()
+    expect(screen.queryByTestId('wk-editor-draft-banner')).toBeNull()
+  })
+
+  it('hides the banner when the server is newer than the stored draft', () => {
+    // Draft saved before the server timestamp — the server won; draft stale.
+    const oldDraft = new Date(
+      Date.parse(SERVER_TS) - 10 * 60 * 1000,
+    ).toISOString()
+    setLocalStorageDraft('stale draft', '', oldDraft)
+
+    render(
+      <WikiEditor
+        path={PATH}
+        initialContent="server wins"
+        expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    expect(screen.queryByTestId('wk-editor-draft-banner')).toBeNull()
+    // Stale draft should also be cleared.
+    expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull()
+  })
+
+  it('successful save clears the draft from localStorage', async () => {
+    const tenMinAfter = new Date(
+      Date.parse(SERVER_TS) + 10 * 60 * 1000,
+    ).toISOString()
+    setLocalStorageDraft('edited body', 'msg', tenMinAfter)
+    vi.spyOn(api, 'writeHumanArticle').mockResolvedValue({
+      path: PATH,
+      commit_sha: 'abc1234',
+      bytes_written: 5,
+    })
+
+    render(
+      <WikiEditor
+        path={PATH}
+        initialContent="original body"
+        expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    // Restore so content is non-empty + recognized as a real draft.
+    fireEvent.click(screen.getByTestId('wk-editor-draft-restore'))
+    fireEvent.click(screen.getByTestId('wk-editor-save'))
+    await waitFor(() =>
+      expect(window.localStorage.getItem(DRAFT_KEY)).toBeNull(),
+    )
+  })
+
+  it('409 conflict keeps the draft in localStorage', async () => {
+    const tenMinAfter = new Date(
+      Date.parse(SERVER_TS) + 10 * 60 * 1000,
+    ).toISOString()
+    setLocalStorageDraft('my body', 'my summary', tenMinAfter)
+    vi.spyOn(api, 'writeHumanArticle').mockResolvedValue({
+      conflict: true,
+      error: 'wiki: article changed since it was opened',
+      current_sha: 'newsha9',
+      current_content: 'other body',
+    })
+
+    render(
+      <WikiEditor
+        path={PATH}
+        initialContent="original body"
+        expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('wk-editor-draft-restore'))
+    fireEvent.click(screen.getByTestId('wk-editor-save'))
+    await screen.findByText(/Someone else edited this article/)
+    // The draft must survive so the user's work isn't lost.
+    const raw = window.localStorage.getItem(DRAFT_KEY)
+    expect(raw).not.toBeNull()
+    expect(JSON.parse(raw as string).content).toBe('my body')
+  })
+
+  // ── Preview pane ───────────────────────────────────────────────────
+
+  it('preview toggle renders markdown with wikilinks via the shared pipeline', () => {
+    render(
+      <WikiEditor
+        path={PATH}
+        initialContent="See [[people/sarah-chen|Sarah]] for context."
+        expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
+        catalog={[
+          {
+            path: 'people/sarah-chen',
+            title: 'Sarah',
+            author_slug: 'ceo',
+            last_edited_ts: SERVER_TS,
+            group: 'people',
+          },
+        ]}
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    // Preview is off initially.
+    expect(screen.queryByTestId('wk-editor-preview')).toBeNull()
+    fireEvent.click(screen.getByTestId('wk-editor-preview-toggle'))
+    const preview = screen.getByTestId('wk-editor-preview')
+    expect(preview).toBeInTheDocument()
+    // The wikilink in the preview resolves (not broken) and carries the
+    // shared pipeline's data-wikilink attribute.
+    const link = preview.querySelector('a[data-wikilink="true"]')
+    expect(link).not.toBeNull()
+    expect(link?.getAttribute('data-broken')).toBe('false')
+    expect(link?.textContent).toBe('Sarah')
+  })
+
+  it('preview renders image markdown through ImageEmbed', () => {
+    render(
+      <WikiEditor
+        path={PATH}
+        initialContent={'![logo](https://cdn.example.com/logo.png)'}
+        expectedSha="abc"
+        serverLastEditedTs={SERVER_TS}
+        onSaved={() => {}}
+        onCancel={() => {}}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('wk-editor-preview-toggle'))
+    const preview = screen.getByTestId('wk-editor-preview')
+    // ImageEmbed wraps the <img> in a <figure class="image-embed">.
+    expect(preview.querySelector('figure.image-embed')).not.toBeNull()
+    const img = preview.querySelector('img') as HTMLImageElement | null
+    expect(img?.getAttribute('src')).toBe('https://cdn.example.com/logo.png')
+    expect(img?.getAttribute('referrerpolicy')).toBe('no-referrer')
   })
 })

--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
 import { writeHumanArticle, type WriteHumanConflict } from '../../api/wiki'
+import {
+  buildMarkdownComponents,
+  buildRehypePlugins,
+  buildRemarkPlugins,
+} from '../../lib/wikiMarkdownConfig'
+import type { WikiCatalogEntry } from '../../api/wiki'
 
 interface WikiEditorProps {
   /** Target article path, e.g. `team/people/nazz.md`. */
@@ -8,24 +15,133 @@ interface WikiEditorProps {
   initialContent: string
   /** SHA the editor opened against; sent back as expected_sha on save. */
   expectedSha: string
+  /** Server's last-edited timestamp for the article, used to decide whether
+   *  a cached localStorage draft is newer than what's on disk. */
+  serverLastEditedTs?: string
+  /** Catalog used by the preview pane to resolve wikilinks and mark
+   *  broken ones. Pass the same list WikiArticle renders against. */
+  catalog?: WikiCatalogEntry[]
   /** Called after a successful save so the parent can refetch. */
   onSaved: (newSha: string) => void
   /** Called when the user cancels. */
   onCancel: () => void
 }
 
+/** Draft envelope persisted to localStorage. */
+interface DraftPayload {
+  content: string
+  summary: string
+  saved_at: string
+}
+
+const DRAFT_KEY_PREFIX = 'wuphf:draft:'
+const AUTOSAVE_DEBOUNCE_MS = 750
+const MOBILE_BREAKPOINT_PX = 768
+
+function draftKey(path: string): string {
+  return `${DRAFT_KEY_PREFIX}${path}`
+}
+
+function readDraft(path: string): DraftPayload | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(draftKey(path))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<DraftPayload>
+    if (
+      typeof parsed.content !== 'string' ||
+      typeof parsed.saved_at !== 'string'
+    ) {
+      return null
+    }
+    return {
+      content: parsed.content,
+      summary: typeof parsed.summary === 'string' ? parsed.summary : '',
+      saved_at: parsed.saved_at,
+    }
+  } catch {
+    return null
+  }
+}
+
+function writeDraft(path: string, payload: DraftPayload): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(draftKey(path), JSON.stringify(payload))
+  } catch {
+    // Out of quota / disabled storage — silently skip, in-memory state
+    // still protects the user for the session.
+  }
+}
+
+function clearDraft(path: string): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.removeItem(draftKey(path))
+  } catch {
+    // Ignore — storage unavailable.
+  }
+}
+
+function formatAgo(isoOrMs: string): string {
+  const t =
+    typeof isoOrMs === 'string' && isoOrMs.length > 0
+      ? Date.parse(isoOrMs)
+      : NaN
+  if (!Number.isFinite(t)) return 'moments ago'
+  const deltaSec = Math.max(0, Math.round((Date.now() - t) / 1000))
+  if (deltaSec < 5) return 'just now'
+  if (deltaSec < 60) return `${deltaSec}s ago`
+  const mins = Math.floor(deltaSec / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.floor(hrs / 24)
+  return `${days}d ago`
+}
+
+/** Narrow viewport detector — mobile layout collapses split view to tabs. */
+function useIsMobileViewport(): boolean {
+  const getMatch = (): boolean => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false
+    return window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX - 1}px)`)
+      .matches
+  }
+  const [isMobile, setIsMobile] = useState<boolean>(getMatch)
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mq = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT_PX - 1}px)`)
+    const update = () => setIsMobile(mq.matches)
+    update()
+    // Safari <14 only supports addListener.
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', update)
+      return () => mq.removeEventListener('change', update)
+    }
+    mq.addListener(update)
+    return () => mq.removeListener(update)
+  }, [])
+  return isMobile
+}
+
 /**
- * Plain-markdown editor surface. Wikipedia's "Edit source" button maps
- * to this component: a textarea + commit-message input + save/cancel.
+ * Plain-markdown editor with autosaved drafts and a live preview pane.
  *
- * Rich-text preview and autosave are deferred to v1.1; this ships the
- * minimum path that lets the founder fix a typo without shelling into
- * the .wuphf directory.
+ * Autosave: debounced writes to localStorage keyed by article path. On
+ * re-open, if the stored draft is newer than the server's last_edited_ts,
+ * a yellow banner offers [Restore] / [Discard].
+ *
+ * Preview: "Preview" toggle flips into split view (desktop) or tab
+ * switcher (<768px viewport). The preview uses the same remark/rehype
+ * pipeline as `WikiArticle` so wikilinks, tables, and image embeds render
+ * identically.
  */
 export default function WikiEditor({
   path,
   initialContent,
   expectedSha,
+  serverLastEditedTs,
+  catalog = [],
   onSaved,
   onCancel,
 }: WikiEditorProps) {
@@ -34,15 +150,70 @@ export default function WikiEditor({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [conflict, setConflict] = useState<WriteHumanConflict | null>(null)
+  const [draft, setDraft] = useState<DraftPayload | null>(null)
+  const [previewOn, setPreviewOn] = useState(false)
+  const [mobileView, setMobileView] = useState<'source' | 'preview'>('source')
   const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const isMobile = useIsMobileViewport()
 
+  // On mount / when the article changes, reset editor state AND check
+  // localStorage for a draft newer than server's last_edited_ts.
   useEffect(() => {
-    // Fresh content whenever the article or opened revision changes.
     setContent(initialContent)
     setCommitMessage('')
     setError(null)
     setConflict(null)
-  }, [path, expectedSha, initialContent])
+    const stored = readDraft(path)
+    if (!stored) {
+      setDraft(null)
+      return
+    }
+    // If the server has a newer edit than the draft, the draft is stale
+    // (someone saved the article after the user left the editor); discard.
+    const serverTs = serverLastEditedTs
+      ? Date.parse(serverLastEditedTs)
+      : NaN
+    const draftTs = Date.parse(stored.saved_at)
+    if (Number.isFinite(serverTs) && Number.isFinite(draftTs) && serverTs >= draftTs) {
+      clearDraft(path)
+      setDraft(null)
+      return
+    }
+    // Only surface the banner when the draft diverges from the fresh server
+    // content; otherwise it's noise.
+    if (stored.content === initialContent) {
+      setDraft(null)
+      return
+    }
+    setDraft(stored)
+  }, [path, initialContent, serverLastEditedTs])
+
+  // Debounced autosave. Anchors on `content` + `commitMessage` and writes
+  // after AUTOSAVE_DEBOUNCE_MS of quiescence. Skip writing if nothing has
+  // diverged from the server-supplied content — no point polluting storage.
+  useEffect(() => {
+    if (content === initialContent && commitMessage === '') return
+    const handle = window.setTimeout(() => {
+      writeDraft(path, {
+        content,
+        summary: commitMessage,
+        saved_at: new Date().toISOString(),
+      })
+    }, AUTOSAVE_DEBOUNCE_MS)
+    return () => window.clearTimeout(handle)
+  }, [path, content, commitMessage, initialContent])
+
+  const handleRestoreDraft = useCallback(() => {
+    if (!draft) return
+    setContent(draft.content)
+    setCommitMessage(draft.summary)
+    setDraft(null)
+  }, [draft])
+
+  const handleDiscardDraft = useCallback(() => {
+    clearDraft(path)
+    setDraft(null)
+  }, [path])
 
   async function handleSave() {
     if (saving) return
@@ -61,9 +232,13 @@ export default function WikiEditor({
         expectedSha,
       })
       if ('conflict' in result) {
+        // Keep the draft — user's work should survive a conflict round-trip.
         setConflict(result)
         return
       }
+      // Saved OK — the draft is now redundant.
+      clearDraft(path)
+      setDraft(null)
       onSaved(result.commit_sha)
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Save failed.')
@@ -75,13 +250,59 @@ export default function WikiEditor({
   function handleReloadConflict() {
     if (!conflict) return
     setContent(conflict.current_content)
-    // Hand the new SHA back to the parent so it re-fetches and re-opens
-    // the editor against the latest article rev.
     onSaved(conflict.current_sha)
   }
 
+  const catalogSlugs = useMemo(
+    () => new Set(catalog.map((c) => c.path)),
+    [catalog],
+  )
+  const resolver = useCallback(
+    (slug: string) => catalogSlugs.has(slug),
+    [catalogSlugs],
+  )
+  const remarkPlugins = useMemo(() => buildRemarkPlugins(resolver), [resolver])
+  const rehypePlugins = useMemo(() => buildRehypePlugins(), [])
+  const markdownComponents = useMemo(
+    () => buildMarkdownComponents({ resolver }),
+    [resolver],
+  )
+
+  const showSource = !previewOn || !isMobile || mobileView === 'source'
+  const showPreview = previewOn && (!isMobile || mobileView === 'preview')
+
   return (
-    <div className="wk-editor" data-testid="wk-editor">
+    <div
+      className={
+        'wk-editor' + (previewOn ? ' wk-editor--with-preview' : '')
+      }
+      data-testid="wk-editor"
+    >
+      {draft && (
+        <div
+          className="wk-editor-banner wk-editor-banner--draft"
+          role="alert"
+          data-testid="wk-editor-draft-banner"
+        >
+          Unsaved draft from {formatAgo(draft.saved_at)}.
+          <div className="wk-editor-banner-actions">
+            <button
+              type="button"
+              onClick={handleRestoreDraft}
+              data-testid="wk-editor-draft-restore"
+            >
+              Restore draft
+            </button>
+            <button
+              type="button"
+              onClick={handleDiscardDraft}
+              data-testid="wk-editor-draft-discard"
+            >
+              Discard
+            </button>
+          </div>
+        </div>
+      )}
       {conflict && (
         <div className="wk-editor-banner wk-editor-banner--conflict" role="alert">
           <strong>Someone else edited this article.</strong> Your save was
@@ -98,19 +319,76 @@ export default function WikiEditor({
           {error}
         </div>
       )}
-      <label className="wk-editor-label" htmlFor="wk-editor-textarea">
-        Article source ({path})
-      </label>
-      <textarea
-        id="wk-editor-textarea"
-        ref={textareaRef}
-        className="wk-editor-textarea"
-        data-testid="wk-editor-textarea"
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        spellCheck
-        rows={28}
-      />
+      {previewOn && isMobile && (
+        <div
+          className="wk-editor-mobile-tabs"
+          role="tablist"
+          data-testid="wk-editor-mobile-tabs"
+        >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mobileView === 'source'}
+            className={
+              'wk-editor-mobile-tab' +
+              (mobileView === 'source' ? ' is-active' : '')
+            }
+            onClick={() => setMobileView('source')}
+            data-testid="wk-editor-mobile-source"
+          >
+            Source
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mobileView === 'preview'}
+            className={
+              'wk-editor-mobile-tab' +
+              (mobileView === 'preview' ? ' is-active' : '')
+            }
+            onClick={() => setMobileView('preview')}
+            data-testid="wk-editor-mobile-preview"
+          >
+            Preview
+          </button>
+        </div>
+      )}
+      <div className="wk-editor-panes">
+        {showSource && (
+          <div className="wk-editor-pane wk-editor-pane--source">
+            <label className="wk-editor-label" htmlFor="wk-editor-textarea">
+              Article source ({path})
+            </label>
+            <textarea
+              id="wk-editor-textarea"
+              ref={textareaRef}
+              className="wk-editor-textarea"
+              data-testid="wk-editor-textarea"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              spellCheck
+              rows={28}
+            />
+          </div>
+        )}
+        {showPreview && (
+          <div
+            className="wk-editor-pane wk-editor-pane--preview"
+            data-testid="wk-editor-preview"
+            aria-label="Live preview"
+          >
+            <div className="wk-editor-preview-body wk-article-body">
+              <ReactMarkdown
+                remarkPlugins={remarkPlugins}
+                rehypePlugins={rehypePlugins}
+                components={markdownComponents}
+              >
+                {content}
+              </ReactMarkdown>
+            </div>
+          </div>
+        )}
+      </div>
       <label className="wk-editor-label" htmlFor="wk-editor-commit-msg">
         Edit summary
       </label>
@@ -140,6 +418,17 @@ export default function WikiEditor({
           disabled={saving}
         >
           Cancel
+        </button>
+        <button
+          type="button"
+          className={
+            'wk-editor-preview-toggle' + (previewOn ? ' is-on' : '')
+          }
+          data-testid="wk-editor-preview-toggle"
+          aria-pressed={previewOn}
+          onClick={() => setPreviewOn((v) => !v)}
+        >
+          {previewOn ? 'Hide preview' : 'Preview'}
         </button>
       </div>
       <p className="wk-editor-help">

--- a/web/src/lib/wikiMarkdownConfig.tsx
+++ b/web/src/lib/wikiMarkdownConfig.tsx
@@ -1,0 +1,87 @@
+/**
+ * Shared markdown pipeline for the wiki surface.
+ *
+ * Extracted so the editor's live preview renders through the exact same
+ * remark/rehype plugins and component overrides as `WikiArticle`. Keep
+ * this file small — it's pure config, not logic.
+ */
+
+import type { ComponentProps, ReactElement } from 'react'
+import type { PluggableList } from 'unified'
+import remarkGfm from 'remark-gfm'
+import rehypeSlug from 'rehype-slug'
+import rehypeAutolinkHeadings from 'rehype-autolink-headings'
+import type { Components } from 'react-markdown'
+import ImageEmbed from '../components/wiki/ImageEmbed'
+import { wikiLinkRemarkPlugin } from './wikilink'
+
+export interface WikiMarkdownOptions {
+  /**
+   * Returns true when a wikilink slug resolves to an existing article.
+   * Used to mark broken links in red per DESIGN-WIKI.md.
+   */
+  resolver: (slug: string) => boolean
+  /**
+   * Optional navigation callback for intercepting internal wikilink clicks
+   * so they route through the hash router instead of a full page load.
+   * When omitted, links render as ordinary anchors.
+   */
+  onNavigate?: (slug: string) => void
+}
+
+/** Remark plugins — remark-gfm + wikilinks. */
+export function buildRemarkPlugins(
+  resolver: (slug: string) => boolean,
+): PluggableList {
+  return [remarkGfm, wikiLinkRemarkPlugin(resolver)]
+}
+
+/** Rehype plugins — slug + autolink headings for TOC anchors. */
+export function buildRehypePlugins(): PluggableList {
+  return [rehypeSlug, [rehypeAutolinkHeadings, { behavior: 'wrap' }]]
+}
+
+type AnchorProps = ComponentProps<'a'>
+type ImageProps = ComponentProps<'img'>
+
+/**
+ * React-markdown component overrides:
+ *  - anchors route wikilinks through onNavigate when provided
+ *  - images render through the editorial ImageEmbed (lazy, no-referrer, lightbox)
+ */
+export function buildMarkdownComponents(
+  options: WikiMarkdownOptions,
+): Partial<Components> {
+  const { onNavigate } = options
+  return {
+    a: (props: AnchorProps): ReactElement => {
+      const record = props as Record<string, unknown>
+      const isWikilink = record['data-wikilink'] === 'true'
+      if (isWikilink && onNavigate) {
+        const slug = record['data-slug'] as string | undefined
+        return (
+          <a
+            {...props}
+            onClick={(e) => {
+              if (slug) {
+                e.preventDefault()
+                onNavigate(slug)
+              }
+            }}
+          />
+        )
+      }
+      return <a {...props} />
+    },
+    img: ({ src, alt, width, height }: ImageProps): ReactElement | null => {
+      if (!src) return null
+      const w =
+        typeof width === 'string' ? parseInt(width, 10) || undefined : width
+      const h =
+        typeof height === 'string' ? parseInt(height, 10) || undefined : height
+      return (
+        <ImageEmbed src={String(src)} alt={alt ?? ''} width={w} height={h} />
+      )
+    },
+  }
+}

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1320,6 +1320,83 @@
   background: var(--wk-paper);
   cursor: pointer;
 }
+.wk-editor-banner--draft {
+  border-left: 3px solid var(--wk-amber);
+  background: var(--wk-amber-banner);
+}
+.wk-editor-panes {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.wk-editor--with-preview .wk-editor-panes {
+  flex-direction: row;
+  gap: 14px;
+  align-items: stretch;
+}
+.wk-editor-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+.wk-editor--with-preview .wk-editor-pane {
+  flex: 1 1 50%;
+}
+.wk-editor-pane--preview {
+  border: 1px solid var(--wk-border);
+  background: var(--wk-paper);
+  padding: 12px 14px;
+  overflow: auto;
+  min-height: 480px;
+}
+.wk-editor-preview-body {
+  font-family: var(--wk-serif, var(--wk-chrome));
+  color: var(--wk-text);
+  line-height: 1.6;
+}
+.wk-editor-preview-toggle {
+  font-family: var(--wk-chrome);
+  font-size: 14px;
+  padding: 8px 14px;
+  border: 1px solid var(--wk-border);
+  background: var(--wk-paper);
+  color: var(--wk-text);
+  cursor: pointer;
+  margin-left: auto;
+}
+.wk-editor-preview-toggle.is-on {
+  background: var(--wk-amber-banner);
+  border-color: var(--wk-amber);
+}
+.wk-editor-mobile-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--wk-border);
+}
+.wk-editor-mobile-tab {
+  flex: 1;
+  font-family: var(--wk-chrome);
+  font-size: 13px;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  color: var(--wk-text-muted);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+.wk-editor-mobile-tab.is-active {
+  color: var(--wk-text);
+  border-bottom-color: var(--wk-wikilink);
+}
+@media (max-width: 767px) {
+  .wk-editor--with-preview .wk-editor-panes {
+    flex-direction: column;
+  }
+  .wk-editor--with-preview .wk-editor-pane {
+    flex: 1 1 auto;
+  }
+}
 
 .wk-human-pill {
   display: inline-block;

--- a/web/tests/setup.ts
+++ b/web/tests/setup.ts
@@ -1,1 +1,39 @@
 import '@testing-library/jest-dom/vitest'
+
+// Node 25+ exposes a built-in `globalThis.localStorage` with no real Storage
+// API (empty object prototype). happy-dom's window.localStorage then gets
+// shadowed, breaking `setItem`/`getItem`/`clear`. Install a tiny in-memory
+// Storage polyfill for tests so draft-autosave logic can be exercised
+// deterministically.
+function createMemoryStorage(): Storage {
+  const data: Record<string, string> = {}
+  const storage: Storage = {
+    get length() {
+      return Object.keys(data).length
+    },
+    clear: () => {
+      for (const k of Object.keys(data)) delete data[k]
+    },
+    getItem: (key: string) =>
+      Object.prototype.hasOwnProperty.call(data, key) ? data[key] : null,
+    key: (index: number) => Object.keys(data)[index] ?? null,
+    removeItem: (key: string) => {
+      delete data[key]
+    },
+    setItem: (key: string, value: string) => {
+      data[key] = String(value)
+    },
+  }
+  return storage
+}
+
+const memoryStorage = createMemoryStorage()
+// Override on window AND globalThis so both lookup paths see the same store.
+Object.defineProperty(window, 'localStorage', {
+  configurable: true,
+  value: memoryStorage,
+})
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: memoryStorage,
+})


### PR DESCRIPTION
## Summary

Polish the v1.4 wiki editor with two quality-of-life wins.

- **Draft autosave** — debounced (750ms) writes to `localStorage` keyed by article path. On re-open, if a stored draft is newer than the server's `last_edited_ts` AND diverges from the fresh content, show a yellow banner: *"Unsaved draft from Nm ago · [Restore] [Discard]"*. Successful save clears the draft. A 409 conflict **does not** clear — the user's work lives on.
- **Live preview pane** — new Preview toggle flips into a 50/50 split view on desktop and a tab switcher below 768px. Preview reuses the exact same remark/rehype pipeline as `WikiArticle` (`remark-gfm`, wikilink plugin, slug + autolink-headings, `ImageEmbed` for remote images), so wikilinks, tables, and image embeds render identically.
- **Shared markdown config** — to keep the two surfaces from diverging, the plugin setup + component overrides are extracted into a new `web/src/lib/wikiMarkdownConfig.tsx`. `WikiArticle` is retrofitted to use it (no behavior change, same DOM, same tests green).
- **Storage polyfill for tests** — Node 25+ exposes a stub `globalThis.localStorage` that shadows happy-dom's real `Window.localStorage`, so draft-autosave specs can't exercise `setItem`/`getItem`/`clear`. Added a tiny in-memory Storage in `tests/setup.ts`.

## Scope

In: autosave + debounce, restore/discard banner, save/discard clears, 409 keeps draft, preview pane, mobile tab switcher, 13 Vitest specs.
Out: collaborative cursors (no OT/CRDT), rich-text editing (still plain markdown), offline queue (localStorage is enough).

## Test plan

- [x] `cd web && bun run build` — passes (no TS errors)
- [x] `cd web && npx vitest run` — 51 files / 246 tests pass (all 13 new WikiEditor specs green, existing WikiArticle specs still green after refactor)
- [ ] Manual: open wiki editor, type, refresh, see draft banner, Restore works
- [ ] Manual: open editor, type, click Save, refresh — no banner (draft cleared)
- [ ] Manual: click Preview, type `[[people/nazz]]` — renders as styled wikilink
- [ ] Manual: click Preview, paste `![alt](https://…png)` — renders through ImageEmbed with lightbox
- [ ] Manual (mobile 320px/375px): Preview collapses to Source/Preview tabs
- [ ] Manual: simulate 409 (stale expected_sha) — draft survives in localStorage

## Non-overlap

Four siblings running — stayed inside `WikiEditor.tsx`, new `web/src/lib/wikiMarkdownConfig.tsx`, CSS, tests. Touched `WikiArticle.tsx` only to pull in the shared config (no structural refactor) and `tests/setup.ts` for the Storage polyfill. Did not touch `Byline.tsx`, `internal/team/`, or `internal/migration/`.