### PR TITLE
feat(cli): wuphf memory migrate — import Nex/GBrain into the wiki

### DIFF
--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -67,6 +67,14 @@ func printSubcommandHelp(sub string) {
 		fmt.Fprintln(os.Stderr, "  wuphf import --from legacy           Auto-detect a running external orchestrator")
 		fmt.Fprintln(os.Stderr, "  wuphf import --from <directory>      Directory with state.json")
 		fmt.Fprintln(os.Stderr, "  wuphf import --from <file.json>      Direct path to an export")
+	case "memory":
+		fmt.Fprintln(os.Stderr, "wuphf memory — manage the team wiki and legacy memory backends")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  wuphf memory migrate --from nex           Import Nex memory into ~/.wuphf/wiki/team/")
+		fmt.Fprintln(os.Stderr, "  wuphf memory migrate --from gbrain        Import GBrain pages into the wiki")
+		fmt.Fprintln(os.Stderr, "  wuphf memory migrate --from <backend> --dry-run  Preview without committing")
+		fmt.Fprintln(os.Stderr, "  wuphf memory migrate --from <backend> --limit N  Cap the number imported")
 	case "log":
 		fmt.Fprintln(os.Stderr, "wuphf log — show agent task receipts")
 		fmt.Fprintln(os.Stderr, "")
@@ -146,6 +154,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  %s shred        Burn the workspace down and reopen onboarding\n", appName)
 		fmt.Fprintf(os.Stderr, "  %s import --from legacy  Import from a running external orchestrator (auto-detect)\n", appName)
 		fmt.Fprintf(os.Stderr, "  %s log          Show what your agents actually did (task receipts)\n", appName)
+		fmt.Fprintf(os.Stderr, "  %s memory migrate --from {nex,gbrain}  Port legacy memory into the team wiki\n", appName)
 		fmt.Fprintf(os.Stderr, "  %s --cmd <cmd>  Run a command non-interactively\n", appName)
 		fmt.Fprintf(os.Stderr, "\nFlags:\n")
 		printVisibleFlags(os.Stderr)
@@ -264,6 +273,9 @@ func main() {
 			return
 		case "log":
 			runLogCmd(args[1:])
+			return
+		case "memory":
+			runMemory(args[1:])
 			return
 		}
 	}

--- a/cmd/wuphf/memory.go
+++ b/cmd/wuphf/memory.go
@@ -106,13 +106,13 @@ func runMemoryMigrate(args []string) {
 
 	if *dryRun {
 		printPlanTable(summary.Plans)
-		fmt.Fprintf(os.Stdout, "\nDry run complete. %d would create, %d would skip, %d would collision-rename.\n",
+		_, _ = fmt.Fprintf(os.Stdout, "\nDry run complete. %d would create, %d would skip, %d would collision-rename.\n",
 			countAction(summary.Plans, "create"),
 			summary.Skipped,
 			summary.Collisions)
 		return
 	}
-	fmt.Fprintf(os.Stdout, "Migrated from %s: %d written, %d skipped (identical), %d collision-renamed.\n",
+	_, _ = fmt.Fprintf(os.Stdout, "Migrated from %s: %d written, %d skipped (identical), %d collision-renamed.\n",
 		source, summary.Written, summary.Skipped, summary.Collisions)
 }
 
@@ -171,13 +171,13 @@ func openWikiWriter() (migration.WikiWriter, func(), error) {
 // output scannable when slugs are long; stdout so it's easy to diff.
 func printPlanTable(plans []migration.Plan) {
 	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	fmt.Fprintln(tw, "ACTION\tPATH\tSIZE\tAUTHOR\tSOURCE")
+	_, _ = fmt.Fprintln(tw, "ACTION\tPATH\tSIZE\tAUTHOR\tSOURCE")
 	for _, p := range plans {
 		path := p.Path
 		if p.Action == "collision-rename" && p.CollisionWith != "" {
 			path = path + " (was: " + p.CollisionWith + ")"
 		}
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n", p.Action, path, p.Bytes, p.Author, p.Source)
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n", p.Action, path, p.Bytes, p.Author, p.Source)
 	}
 	_ = tw.Flush()
 }

--- a/cmd/wuphf/memory.go
+++ b/cmd/wuphf/memory.go
@@ -1,0 +1,193 @@
+package main
+
+// memory.go hosts the `wuphf memory` subcommand family. Today it owns
+// one verb: `migrate`, which ports legacy Nex / GBrain memory into the
+// markdown wiki at ~/.wuphf/wiki/team/.
+//
+// Why a separate file
+// ===================
+//
+// main.go already routes top-level subcommands. `memory migrate` is a
+// two-word verb that carries its own flag set and exit codes, so the
+// parsing + plumbing lives here to keep main.go short.
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/nex-crm/wuphf/internal/api"
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/migration"
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// runMemory dispatches `wuphf memory <verb>`. Called from main.go when
+// args[0] == "memory".
+func runMemory(args []string) {
+	if len(args) == 0 || subcommandWantsHelp(args) {
+		printMemoryHelp()
+		return
+	}
+	verb := args[0]
+	rest := args[1:]
+	switch verb {
+	case "migrate":
+		runMemoryMigrate(rest)
+	default:
+		fmt.Fprintf(os.Stderr, "wuphf memory: unknown verb %q — run `wuphf memory --help` for the list.\n", verb)
+		os.Exit(1)
+	}
+}
+
+func printMemoryHelp() {
+	fmt.Fprintln(os.Stderr, "wuphf memory — manage the team wiki and legacy memory backends")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Verbs:")
+	fmt.Fprintln(os.Stderr, "  migrate    Port Nex or GBrain content into ~/.wuphf/wiki/team/")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Usage:")
+	fmt.Fprintln(os.Stderr, "  wuphf memory migrate --from nex [--dry-run] [--limit N]")
+	fmt.Fprintln(os.Stderr, "  wuphf memory migrate --from gbrain [--dry-run] [--limit N]")
+}
+
+// runMemoryMigrate parses flags and orchestrates the migration. On any
+// fatal error it writes to stderr and exits non-zero.
+func runMemoryMigrate(args []string) {
+	fs := flag.NewFlagSet("memory migrate", flag.ContinueOnError)
+	from := fs.String("from", "", "Source backend: nex or gbrain")
+	dryRun := fs.Bool("dry-run", false, "Print the plan without committing")
+	limit := fs.Int("limit", 0, "Cap the number of records imported (0 = unlimited)")
+	apiKeyFlag := fs.String("api-key", "", "API key for Nex authentication (overrides WUPHF_API_KEY)")
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "wuphf memory migrate — import legacy memory into the team wiki")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  wuphf memory migrate --from {nex,gbrain} [--dry-run] [--limit N]")
+		fmt.Fprintln(os.Stderr, "")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		// ContinueOnError already wrote the message.
+		os.Exit(2)
+	}
+	source := strings.ToLower(strings.TrimSpace(*from))
+	if source == "" {
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	adapter, err := buildAdapter(source, strings.TrimSpace(*apiKeyFlag))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	writer, stop, err := openWikiWriter()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	defer stop()
+
+	migrator := migration.NewMigrator(writer)
+	ctx := context.Background()
+	summary, err := migrator.Run(ctx, adapter, migration.RunOptions{
+		DryRun: *dryRun,
+		Limit:  *limit,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *dryRun {
+		printPlanTable(summary.Plans)
+		fmt.Fprintf(os.Stdout, "\nDry run complete. %d would create, %d would skip, %d would collision-rename.\n",
+			countAction(summary.Plans, "create"),
+			summary.Skipped,
+			summary.Collisions)
+		return
+	}
+	fmt.Fprintf(os.Stdout, "Migrated from %s: %d written, %d skipped (identical), %d collision-renamed.\n",
+		source, summary.Written, summary.Skipped, summary.Collisions)
+}
+
+// buildAdapter returns the concrete adapter for a source flag value.
+func buildAdapter(source, apiKeyOverride string) (migration.Adapter, error) {
+	switch source {
+	case "nex":
+		key := apiKeyOverride
+		if key == "" {
+			key = strings.TrimSpace(config.ResolveAPIKey(""))
+		}
+		if key == "" {
+			return nil, fmt.Errorf("nex adapter requires an API key (set WUPHF_API_KEY or pass --api-key)")
+		}
+		client := api.NewClient(key)
+		return migration.NewNexAdapter(client), nil
+	case "gbrain":
+		if !migration.GBrainReady() {
+			return nil, fmt.Errorf("gbrain binary not found on PATH; install GBrain before migrating")
+		}
+		return migration.NewGBrainAdapter(), nil
+	default:
+		return nil, fmt.Errorf("unsupported --from value %q (expected nex or gbrain)", source)
+	}
+}
+
+// workerWriter adapts *team.WikiWorker onto migration.WikiWriter. The
+// worker already exposes Enqueue; Root is forwarded from its Repo.
+type workerWriter struct{ w *team.WikiWorker }
+
+func (ww workerWriter) Enqueue(ctx context.Context, slug, path, content, mode, commitMsg string) (string, int, error) {
+	return ww.w.Enqueue(ctx, slug, path, content, mode, commitMsg)
+}
+func (ww workerWriter) Root() string { return ww.w.Repo().Root() }
+
+// openWikiWriter initialises the wiki repo and starts a short-lived
+// worker scoped to the CLI run. Returns the writer plus a teardown
+// callback the caller must defer.
+func openWikiWriter() (migration.WikiWriter, func(), error) {
+	repo := team.NewRepo()
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := repo.Init(ctx); err != nil {
+		cancel()
+		return nil, nil, fmt.Errorf("initialise wiki repo at %s: %w", repo.Root(), err)
+	}
+	worker := team.NewWikiWorker(repo, nil)
+	worker.Start(ctx)
+	teardown := func() {
+		cancel()
+		worker.Stop()
+	}
+	return workerWriter{w: worker}, teardown, nil
+}
+
+// printPlanTable renders a dry-run plan table. Tabwriter keeps the
+// output scannable when slugs are long; stdout so it's easy to diff.
+func printPlanTable(plans []migration.Plan) {
+	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	fmt.Fprintln(tw, "ACTION\tPATH\tSIZE\tAUTHOR\tSOURCE")
+	for _, p := range plans {
+		path := p.Path
+		if p.Action == "collision-rename" && p.CollisionWith != "" {
+			path = path + " (was: " + p.CollisionWith + ")"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n", p.Action, path, p.Bytes, p.Author, p.Source)
+	}
+	_ = tw.Flush()
+}
+
+func countAction(plans []migration.Plan, action string) int {
+	n := 0
+	for _, p := range plans {
+		if p.Action == action {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/migration/gbrain.go
+++ b/internal/migration/gbrain.go
@@ -1,0 +1,322 @@
+package migration
+
+// gbrain.go adapts the local `gbrain` CLI onto migration.Adapter.
+//
+// Discovery strategy
+// ==================
+//
+// GBrain exposes an MCP-style command surface. The adapter uses two tools:
+//
+//   - list_pages  — returns page slugs + titles + types. Used to enumerate.
+//   - get_page    — returns full page content for a single slug.
+//
+// Both are reached through the existing gbrain.Call helper (same transport
+// used by gbrainMemoryBackend.WriteShared), so there's a single place that
+// knows how to shell out to the binary. When list_pages is unavailable
+// (older GBrain builds), we fall back to a broad gbrain.Query scan which
+// surfaces page slugs via the ChunkSource field.
+//
+// Timeouts are generous: gbrain.Call defaults to 8s per call and a large
+// brain can have thousands of pages, so the adapter must accept that a
+// full migration takes minutes, not seconds.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/gbrain"
+)
+
+// gbrainListPageSize is the page size requested from list_pages. Keeping
+// it large reduces round-trips against a batch-oriented CLI.
+const gbrainListPageSize = 200
+
+// GBrainPage is the shape we expect list_pages + get_page to return. All
+// fields are optional so a sparse upstream response still yields useful
+// records.
+type GBrainPage struct {
+	Slug      string `json:"slug"`
+	Title     string `json:"title"`
+	Type      string `json:"type"`
+	Content   string `json:"content"`
+	Body      string `json:"body"`
+	UpdatedAt string `json:"updated_at"`
+	CreatedAt string `json:"created_at"`
+}
+
+// GBrainCaller is the subset of gbrain.Call we need. Split out as an
+// interface so tests inject a fake without the gbrain binary being
+// present on PATH.
+type GBrainCaller interface {
+	Call(ctx context.Context, tool string, params any) (string, error)
+}
+
+type gbrainDefaultCaller struct{}
+
+func (gbrainDefaultCaller) Call(ctx context.Context, tool string, params any) (string, error) {
+	return gbrain.Call(ctx, tool, params)
+}
+
+// GBrainAdapter iterates a GBrain brain via list_pages + get_page. When
+// list_pages is not supported, it falls back to a broad Query sweep.
+type GBrainAdapter struct {
+	caller   GBrainCaller
+	pageSize int
+	// fallbackQuery is used when list_pages returns an error; defaults to
+	// "*" which most GBrain builds interpret as "match everything".
+	fallbackQuery string
+}
+
+// GBrainOption tunes a GBrainAdapter at construction.
+type GBrainOption func(*GBrainAdapter)
+
+// WithGBrainCaller injects a custom caller (tests).
+func WithGBrainCaller(c GBrainCaller) GBrainOption {
+	return func(a *GBrainAdapter) {
+		if c != nil {
+			a.caller = c
+		}
+	}
+}
+
+// WithGBrainPageSize overrides the default list_pages batch size.
+func WithGBrainPageSize(n int) GBrainOption {
+	return func(a *GBrainAdapter) {
+		if n > 0 {
+			a.pageSize = n
+		}
+	}
+}
+
+// WithGBrainFallbackQuery overrides the default query used when
+// list_pages is not supported.
+func WithGBrainFallbackQuery(q string) GBrainOption {
+	return func(a *GBrainAdapter) {
+		q = strings.TrimSpace(q)
+		if q != "" {
+			a.fallbackQuery = q
+		}
+	}
+}
+
+// NewGBrainAdapter returns a ready-to-use GBrain adapter.
+func NewGBrainAdapter(opts ...GBrainOption) *GBrainAdapter {
+	a := &GBrainAdapter{
+		caller:        gbrainDefaultCaller{},
+		pageSize:      gbrainListPageSize,
+		fallbackQuery: "*",
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	return a
+}
+
+// Iter satisfies migration.Adapter. Emits one MigrationRecord per page.
+func (a *GBrainAdapter) Iter(ctx context.Context) (<-chan MigrationRecord, error) {
+	out := make(chan MigrationRecord, 16)
+	go func() {
+		defer close(out)
+		if err := a.iterViaList(ctx, out); err == nil {
+			return
+		}
+		// list_pages unavailable — fall back to a query scan. Best effort.
+		_ = a.iterViaQuery(ctx, out)
+	}()
+	return out, nil
+}
+
+func (a *GBrainAdapter) iterViaList(ctx context.Context, out chan<- MigrationRecord) error {
+	offset := 0
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		raw, err := a.caller.Call(ctx, "list_pages", map[string]any{
+			"limit":  a.pageSize,
+			"offset": offset,
+		})
+		if err != nil {
+			return err
+		}
+		pages, err := decodeGBrainPages(raw)
+		if err != nil {
+			return err
+		}
+		if len(pages) == 0 {
+			return nil
+		}
+		for _, p := range pages {
+			if ctx.Err() != nil {
+				return nil
+			}
+			rec, ok := a.hydratePage(ctx, p)
+			if !ok {
+				continue
+			}
+			select {
+			case out <- rec:
+			case <-ctx.Done():
+				return nil
+			}
+		}
+		if len(pages) < a.pageSize {
+			return nil
+		}
+		offset += len(pages)
+	}
+}
+
+func (a *GBrainAdapter) iterViaQuery(ctx context.Context, out chan<- MigrationRecord) error {
+	raw, err := a.caller.Call(ctx, "query", map[string]any{
+		"query":  a.fallbackQuery,
+		"limit":  a.pageSize,
+		"detail": "low",
+	})
+	if err != nil {
+		return err
+	}
+	var results []gbrain.SearchResult
+	if derr := json.Unmarshal([]byte(raw), &results); derr != nil {
+		return fmt.Errorf("gbrain adapter: decode fallback query: %w", derr)
+	}
+	seen := map[string]struct{}{}
+	for _, r := range results {
+		slug := strings.TrimSpace(r.Slug)
+		if slug == "" {
+			continue
+		}
+		if _, dup := seen[slug]; dup {
+			continue
+		}
+		seen[slug] = struct{}{}
+		rec, ok := a.hydratePage(ctx, GBrainPage{
+			Slug:  slug,
+			Title: strings.TrimSpace(r.Title),
+			Type:  strings.TrimSpace(r.Type),
+			// Fallback uses the chunk text as content; list_pages path
+			// supersedes this with the full page body.
+			Content: strings.TrimSpace(r.ChunkText),
+		})
+		if !ok {
+			continue
+		}
+		select {
+		case out <- rec:
+		case <-ctx.Done():
+			return nil
+		}
+	}
+	return nil
+}
+
+// hydratePage fetches the full content for a page when only a summary
+// was returned. Returns ok=false when the page has no usable content.
+func (a *GBrainAdapter) hydratePage(ctx context.Context, p GBrainPage) (MigrationRecord, bool) {
+	content := strings.TrimSpace(firstGBrainContent(p))
+	if content == "" && strings.TrimSpace(p.Slug) != "" {
+		raw, err := a.caller.Call(ctx, "get_page", map[string]any{"slug": p.Slug})
+		if err == nil {
+			if full, derr := decodeGBrainPage(raw); derr == nil {
+				p.Content = firstGBrainContent(full)
+				if strings.TrimSpace(p.Title) == "" {
+					p.Title = full.Title
+				}
+				if strings.TrimSpace(p.Type) == "" {
+					p.Type = full.Type
+				}
+				if strings.TrimSpace(p.UpdatedAt) == "" {
+					p.UpdatedAt = full.UpdatedAt
+				}
+			}
+		}
+		content = strings.TrimSpace(firstGBrainContent(p))
+	}
+	if content == "" {
+		return MigrationRecord{}, false
+	}
+	title := strings.TrimSpace(p.Title)
+	if title == "" {
+		title = p.Slug
+	}
+	return MigrationRecord{
+		Kind:      NormalizeKind(p.Type),
+		Slug:      slugify(p.Slug),
+		Title:     title,
+		Content:   content,
+		Source:    "gbrain",
+		Timestamp: parseNexTimestamp(firstNonEmpty(p.UpdatedAt, p.CreatedAt)),
+	}, true
+}
+
+func firstGBrainContent(p GBrainPage) string {
+	if s := strings.TrimSpace(p.Content); s != "" {
+		return s
+	}
+	return strings.TrimSpace(p.Body)
+}
+
+// decodeGBrainPages handles the half-dozen shapes list_pages has
+// emitted across GBrain releases.
+func decodeGBrainPages(raw string) ([]GBrainPage, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	// Plain array of pages.
+	if strings.HasPrefix(raw, "[") {
+		var pages []GBrainPage
+		if err := json.Unmarshal([]byte(raw), &pages); err != nil {
+			return nil, fmt.Errorf("gbrain adapter: decode list_pages array: %w", err)
+		}
+		return pages, nil
+	}
+	// Envelope — look for common keys.
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &envelope); err != nil {
+		return nil, fmt.Errorf("gbrain adapter: decode list_pages envelope: %w", err)
+	}
+	for _, key := range []string{"pages", "data", "items", "results"} {
+		if r, ok := envelope[key]; ok {
+			var pages []GBrainPage
+			if err := json.Unmarshal(r, &pages); err != nil {
+				return nil, fmt.Errorf("gbrain adapter: decode list_pages[%s]: %w", key, err)
+			}
+			return pages, nil
+		}
+	}
+	return nil, fmt.Errorf("gbrain adapter: unrecognised list_pages shape")
+}
+
+// decodeGBrainPage handles get_page responses. Accepts the page object
+// directly or wrapped in {"page":{...}}.
+func decodeGBrainPage(raw string) (GBrainPage, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return GBrainPage{}, nil
+	}
+	var p GBrainPage
+	if err := json.Unmarshal([]byte(raw), &p); err == nil && (p.Slug != "" || p.Content != "" || p.Body != "") {
+		return p, nil
+	}
+	var envelope struct {
+		Page GBrainPage `json:"page"`
+	}
+	if err := json.Unmarshal([]byte(raw), &envelope); err == nil && envelope.Page.Slug != "" {
+		return envelope.Page, nil
+	}
+	return GBrainPage{}, fmt.Errorf("gbrain adapter: unrecognised get_page shape")
+}
+
+// GBrainReady reports whether the gbrain binary is reachable on PATH.
+// Exposed so the CLI can short-circuit before launching the worker.
+func GBrainReady() bool {
+	return gbrain.IsInstalled()
+}
+
+// NexNow is the fallback timestamp when a record has none of its own.
+// Exposed so callers and tests use the same clock source.
+func NexNow() time.Time { return time.Now().UTC() }

--- a/internal/migration/gbrain_test.go
+++ b/internal/migration/gbrain_test.go
@@ -1,0 +1,126 @@
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// fakeGBrainCaller is a scriptable stand-in for the real gbrain.Call.
+// Each entry in responses matches one call in order by tool name.
+type fakeGBrainCaller struct {
+	responses map[string][]string
+	errors    map[string][]error
+	calls     map[string]int
+}
+
+func (f *fakeGBrainCaller) Call(ctx context.Context, tool string, params any) (string, error) {
+	idx := f.calls[tool]
+	f.calls[tool] = idx + 1
+	if errs, ok := f.errors[tool]; ok && idx < len(errs) && errs[idx] != nil {
+		return "", errs[idx]
+	}
+	if resps, ok := f.responses[tool]; ok && idx < len(resps) {
+		return resps[idx], nil
+	}
+	return "", nil
+}
+
+func TestDecodeGBrainPagesShapes(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want int
+	}{
+		{"bare array", `[{"slug":"a"},{"slug":"b"}]`, 2},
+		{"pages envelope", `{"pages":[{"slug":"a"}]}`, 1},
+		{"data envelope", `{"data":[{"slug":"a"},{"slug":"b"}]}`, 2},
+		{"items envelope", `{"items":[{"slug":"a"}]}`, 1},
+		{"empty string", ``, 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := decodeGBrainPages(tc.raw)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if len(got) != tc.want {
+				t.Fatalf("want %d pages, got %d", tc.want, len(got))
+			}
+		})
+	}
+}
+
+func TestGBrainAdapterListPath(t *testing.T) {
+	pages := []GBrainPage{
+		{Slug: "nazz", Title: "Nazz", Type: "person", Content: "Founder"},
+		{Slug: "hubspot", Title: "HubSpot", Type: "company", Content: "Prior life"},
+	}
+	payload, err := json.Marshal(pages)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	caller := &fakeGBrainCaller{
+		responses: map[string][]string{
+			"list_pages": {string(payload), `[]`},
+		},
+		calls: map[string]int{},
+	}
+	adapter := NewGBrainAdapter(WithGBrainCaller(caller), WithGBrainPageSize(10))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ch, err := adapter.Iter(ctx)
+	if err != nil {
+		t.Fatalf("iter: %v", err)
+	}
+	var got []MigrationRecord
+	for rec := range ch {
+		got = append(got, rec)
+	}
+	if len(got) != 2 {
+		t.Fatalf("want 2 records, got %d", len(got))
+	}
+	if got[0].Kind != KindPeople || got[0].Slug != "nazz" {
+		t.Errorf("unexpected record 0: %+v", got[0])
+	}
+	if got[1].Kind != KindCompanies || got[1].Slug != "hubspot" {
+		t.Errorf("unexpected record 1: %+v", got[1])
+	}
+	for _, r := range got {
+		if r.Source != "gbrain" {
+			t.Errorf("source=%q, want gbrain", r.Source)
+		}
+	}
+}
+
+func TestGBrainAdapterFallbackToQuery(t *testing.T) {
+	// list_pages returns an error → adapter falls back to query.
+	caller := &fakeGBrainCaller{
+		responses: map[string][]string{
+			"query": {`[{"slug":"seed","title":"Seed","type":"topic","chunk_text":"body"}]`},
+		},
+		errors: map[string][]error{
+			"list_pages": {fmt.Errorf("unsupported tool")},
+		},
+		calls: map[string]int{},
+	}
+	adapter := NewGBrainAdapter(WithGBrainCaller(caller))
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ch, err := adapter.Iter(ctx)
+	if err != nil {
+		t.Fatalf("iter: %v", err)
+	}
+	var got []MigrationRecord
+	for rec := range ch {
+		got = append(got, rec)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 record from fallback, got %d", len(got))
+	}
+	if got[0].Kind != KindTopics || got[0].Slug != "seed" {
+		t.Errorf("unexpected fallback record: %+v", got[0])
+	}
+}

--- a/internal/migration/nex.go
+++ b/internal/migration/nex.go
@@ -41,11 +41,11 @@ const nexPageSize = 100
 // NexAdapter adapts the legacy Nex HTTP records API onto the
 // migration.Adapter interface.
 type NexAdapter struct {
-	client     *api.Client
-	types      []string
-	fetchPage  func(ctx context.Context, objectType string, limit, offset int) ([]map[string]any, error)
-	pageSize   int
-	stopOnErr  bool
+	client    *api.Client
+	types     []string
+	fetchPage func(ctx context.Context, objectType string, limit, offset int) ([]map[string]any, error)
+	pageSize  int
+	stopOnErr bool
 }
 
 // NexOption configures a NexAdapter at construction.
@@ -178,7 +178,7 @@ func (a *NexAdapter) Iter(ctx context.Context) (<-chan MigrationRecord, error) {
 				if a.stopOnErr {
 					return
 				}
-				fmt.Printf("warning: %v\n", err)
+				_, _ = fmt.Printf("warning: %v\n", err)
 			}
 		}
 	}()

--- a/internal/migration/nex.go
+++ b/internal/migration/nex.go
@@ -1,0 +1,302 @@
+package migration
+
+// nex.go iterates the legacy Nex HTTP records API and emits one
+// MigrationRecord per stored record. Reuses the existing api.Client
+// (same bearer-token plumbing the /record slash commands use) so there's
+// exactly one place that knows how to talk to app.nex.ai.
+//
+// Discovery strategy
+// ==================
+//
+// Nex does not expose a single "give me everything" endpoint. Instead
+// it's object-type scoped: GET /v1/records?object_type={t}. We iterate
+// the well-known legacy types (person, company, customer, topic, note)
+// plus any extra types the caller passes via WithExtraTypes. Each type
+// is paged with limit/offset until the server returns fewer items than
+// the page size.
+//
+// The API client already handles auth + transport. This adapter only
+// handles shape translation onto MigrationRecord.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/api"
+)
+
+// DefaultNexTypes is the seed list of Nex object types the adapter walks
+// when no override is provided. Ordered to put high-signal record kinds
+// first so --limit stops on the most useful content.
+var DefaultNexTypes = []string{"person", "company", "customer", "topic", "note"}
+
+// nexPageSize bounds each /v1/records request. Matching the CLI's default
+// of 100 keeps the server's pagination code warm on the same fast path.
+const nexPageSize = 100
+
+// NexAdapter adapts the legacy Nex HTTP records API onto the
+// migration.Adapter interface.
+type NexAdapter struct {
+	client     *api.Client
+	types      []string
+	fetchPage  func(ctx context.Context, objectType string, limit, offset int) ([]map[string]any, error)
+	pageSize   int
+	stopOnErr  bool
+}
+
+// NexOption configures a NexAdapter at construction.
+type NexOption func(*NexAdapter)
+
+// WithNexTypes overrides the default set of object types walked by the
+// adapter. Useful for Nex installs with custom object schemas.
+func WithNexTypes(types ...string) NexOption {
+	return func(a *NexAdapter) {
+		if len(types) == 0 {
+			return
+		}
+		a.types = append(a.types[:0], types...)
+	}
+}
+
+// WithNexFetcher injects a custom page fetcher. Primarily for tests;
+// production code gets the default HTTP-backed implementation.
+func WithNexFetcher(f func(ctx context.Context, objectType string, limit, offset int) ([]map[string]any, error)) NexOption {
+	return func(a *NexAdapter) {
+		a.fetchPage = f
+	}
+}
+
+// WithNexPageSize overrides the default page size. Primarily for tests
+// that want to exercise the pagination loop without 100-row fixtures.
+func WithNexPageSize(n int) NexOption {
+	return func(a *NexAdapter) {
+		if n > 0 {
+			a.pageSize = n
+		}
+	}
+}
+
+// NewNexAdapter returns a ready-to-use Nex adapter. When client is nil a
+// default one is constructed from WUPHF_API_KEY / ResolveAPIKey; callers
+// that want non-default config can build their own api.Client first.
+func NewNexAdapter(client *api.Client, opts ...NexOption) *NexAdapter {
+	a := &NexAdapter{
+		client:   client,
+		types:    append([]string{}, DefaultNexTypes...),
+		pageSize: nexPageSize,
+	}
+	for _, opt := range opts {
+		opt(a)
+	}
+	if a.fetchPage == nil {
+		a.fetchPage = a.defaultFetchPage
+	}
+	return a
+}
+
+// defaultFetchPage is the production fetcher: GET /v1/records?object_type=...&limit=&offset=.
+// Returns []map[string]any so the translator can be lenient about
+// schema drift — legacy installs grew fields organically.
+func (a *NexAdapter) defaultFetchPage(ctx context.Context, objectType string, limit, offset int) ([]map[string]any, error) {
+	if a.client == nil {
+		return nil, fmt.Errorf("nex adapter: api client is required")
+	}
+	if !a.client.IsAuthenticated() {
+		return nil, fmt.Errorf("nex adapter: api client is not authenticated (set WUPHF_API_KEY or pass --api-key)")
+	}
+	q := url.Values{}
+	q.Set("object_type", objectType)
+	q.Set("limit", fmt.Sprintf("%d", limit))
+	q.Set("offset", fmt.Sprintf("%d", offset))
+	path := "/v1/records?" + q.Encode()
+	// The API returns heterogeneous shapes across installs — newer backends
+	// nest records under {"data": [...]}, older ones return the slice at
+	// the top level. Decode as any and normalise here.
+	raw, err := api.Get[any](a.client, path, 0)
+	if err != nil {
+		return nil, fmt.Errorf("nex adapter: fetch %s offset=%d: %w", objectType, offset, err)
+	}
+	return coerceNexRecordsList(raw)
+}
+
+// coerceNexRecordsList normalises the Nex /v1/records response onto
+// []map[string]any regardless of whether the server wraps it in a
+// {"data":[...]} envelope, a {"records":[...]} envelope, or returns a
+// bare list. Unknown shapes yield an empty slice — the caller treats
+// "zero records" as end-of-pagination.
+func coerceNexRecordsList(raw any) ([]map[string]any, error) {
+	switch v := raw.(type) {
+	case []any:
+		return mapEachToMap(v), nil
+	case map[string]any:
+		for _, key := range []string{"data", "records", "items", "results"} {
+			if inner, ok := v[key]; ok {
+				if list, ok := inner.([]any); ok {
+					return mapEachToMap(list), nil
+				}
+			}
+		}
+	case nil:
+		return nil, nil
+	}
+	return nil, fmt.Errorf("nex adapter: unexpected records shape %T", raw)
+}
+
+func mapEachToMap(list []any) []map[string]any {
+	out := make([]map[string]any, 0, len(list))
+	for _, item := range list {
+		if m, ok := item.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// Iter satisfies migration.Adapter. Streams records from each configured
+// object type in turn, paginating until the server runs out. The channel
+// is buffered to keep the fetcher moving while the caller writes.
+func (a *NexAdapter) Iter(ctx context.Context) (<-chan MigrationRecord, error) {
+	if len(a.types) == 0 {
+		return nil, fmt.Errorf("nex adapter: no object types configured")
+	}
+	out := make(chan MigrationRecord, 16)
+	go func() {
+		defer close(out)
+		for _, objectType := range a.types {
+			if ctx.Err() != nil {
+				return
+			}
+			if err := a.iterType(ctx, objectType, out); err != nil {
+				// Per-type failures don't abort the whole walk — a legacy
+				// install might have one broken table without the rest
+				// being unreachable. The error is already annotated with
+				// the type for triage; downgrade to a stderr-style line.
+				if a.stopOnErr {
+					return
+				}
+				fmt.Printf("warning: %v\n", err)
+			}
+		}
+	}()
+	return out, nil
+}
+
+func (a *NexAdapter) iterType(ctx context.Context, objectType string, out chan<- MigrationRecord) error {
+	offset := 0
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		page, err := a.fetchPage(ctx, objectType, a.pageSize, offset)
+		if err != nil {
+			return err
+		}
+		if len(page) == 0 {
+			return nil
+		}
+		for _, row := range page {
+			rec, ok := translateNexRecord(objectType, row)
+			if !ok {
+				continue
+			}
+			select {
+			case out <- rec:
+			case <-ctx.Done():
+				return nil
+			}
+		}
+		if len(page) < a.pageSize {
+			return nil
+		}
+		offset += len(page)
+	}
+}
+
+// translateNexRecord maps one Nex record (loose JSON) onto a
+// MigrationRecord. Missing fields fall back to sensible defaults; when
+// we can't salvage a Content field we skip the row (second return false)
+// rather than emitting an empty article.
+func translateNexRecord(objectType string, row map[string]any) (MigrationRecord, bool) {
+	slug := slugify(firstString(row, "slug", "handle", "identifier", "id"))
+	title := firstString(row, "title", "name", "display_name", "label")
+	if slug == "" {
+		slug = slugify(title)
+	}
+	if slug == "" {
+		return MigrationRecord{}, false
+	}
+	if title == "" {
+		title = slug
+	}
+	content := firstString(row, "content", "body", "description", "summary", "notes")
+	if strings.TrimSpace(content) == "" {
+		// Fall back to a full-JSON dump so no data is lost; the writer
+		// will render it as a code block inside the article.
+		if b, err := json.MarshalIndent(row, "", "  "); err == nil {
+			content = string(b)
+		}
+	}
+	if strings.TrimSpace(content) == "" {
+		return MigrationRecord{}, false
+	}
+	ts := parseNexTimestamp(firstString(row, "updated_at", "modified_at", "created_at", "timestamp"))
+	return MigrationRecord{
+		Kind:      NormalizeKind(objectType),
+		Slug:      slug,
+		Title:     title,
+		Content:   content,
+		Source:    "nex",
+		Timestamp: ts,
+	}, true
+}
+
+// firstString returns the first non-empty string-valued field found at
+// any of the provided keys. Numeric IDs coerce to string so they can
+// seed a slug without forcing adapters to pre-string-ify.
+func firstString(row map[string]any, keys ...string) string {
+	for _, k := range keys {
+		v, ok := row[k]
+		if !ok {
+			continue
+		}
+		switch s := v.(type) {
+		case string:
+			if strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		case float64:
+			return fmt.Sprintf("%v", s)
+		case int:
+			return fmt.Sprintf("%d", s)
+		case int64:
+			return fmt.Sprintf("%d", s)
+		}
+	}
+	return ""
+}
+
+// parseNexTimestamp accepts the handful of shapes legacy Nex installs
+// have produced over the years. Unparseable values yield the zero time.
+func parseNexTimestamp(s string) time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return time.Time{}
+	}
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}

--- a/internal/migration/nex_test.go
+++ b/internal/migration/nex_test.go
@@ -1,0 +1,162 @@
+package migration
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCoerceNexRecordsList(t *testing.T) {
+	tests := []struct {
+		name  string
+		raw   any
+		want  int
+		isErr bool
+	}{
+		{"bare list", []any{map[string]any{"id": "1"}, map[string]any{"id": "2"}}, 2, false},
+		{"data envelope", map[string]any{"data": []any{map[string]any{"id": "1"}}}, 1, false},
+		{"records envelope", map[string]any{"records": []any{map[string]any{"id": "1"}}}, 1, false},
+		{"items envelope", map[string]any{"items": []any{map[string]any{"id": "1"}}}, 1, false},
+		{"empty list", []any{}, 0, false},
+		{"nil", nil, 0, false},
+		{"unknown shape", "not an object", 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := coerceNexRecordsList(tc.raw)
+			if tc.isErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != tc.want {
+				t.Fatalf("want %d records, got %d (%v)", tc.want, len(got), got)
+			}
+		})
+	}
+}
+
+func TestTranslateNexRecord(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     string
+		row      map[string]any
+		wantKind Kind
+		wantSlug string
+		wantOK   bool
+	}{
+		{
+			name:     "happy path person",
+			kind:     "person",
+			row:      map[string]any{"slug": "Nazz", "name": "Nazz Mohammad", "content": "Founder"},
+			wantKind: KindPeople,
+			wantSlug: "nazz",
+			wantOK:   true,
+		},
+		{
+			name:     "slug fallback to name",
+			kind:     "company",
+			row:      map[string]any{"name": "HubSpot Inc", "description": "CRM"},
+			wantKind: KindCompanies,
+			wantSlug: "hubspot-inc",
+			wantOK:   true,
+		},
+		{
+			name:     "empty content uses json dump",
+			kind:     "note",
+			row:      map[string]any{"slug": "meeting-notes", "tags": []any{"important"}},
+			wantKind: KindNotes,
+			wantSlug: "meeting-notes",
+			wantOK:   true,
+		},
+		{
+			name:   "no slug, no title -> skip",
+			kind:   "note",
+			row:    map[string]any{"content": "something"},
+			wantOK: false,
+		},
+		{
+			name:     "unknown type falls back to misc",
+			kind:     "zonked",
+			row:      map[string]any{"slug": "z", "content": "x"},
+			wantKind: KindMisc,
+			wantSlug: "z",
+			wantOK:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rec, ok := translateNexRecord(tc.kind, tc.row)
+			if ok != tc.wantOK {
+				t.Fatalf("ok=%v, want %v (rec=%+v)", ok, tc.wantOK, rec)
+			}
+			if !ok {
+				return
+			}
+			if rec.Kind != tc.wantKind {
+				t.Errorf("kind=%q, want %q", rec.Kind, tc.wantKind)
+			}
+			if rec.Slug != tc.wantSlug {
+				t.Errorf("slug=%q, want %q", rec.Slug, tc.wantSlug)
+			}
+			if rec.Source != "nex" {
+				t.Errorf("source=%q, want nex", rec.Source)
+			}
+		})
+	}
+}
+
+func TestNexAdapterIter(t *testing.T) {
+	pages := map[string][][]map[string]any{
+		"person": {
+			{
+				{"slug": "alice", "name": "Alice", "content": "eng lead"},
+				{"slug": "bob", "name": "Bob", "content": "designer"},
+			},
+			{}, // end
+		},
+		"company": {
+			{
+				{"slug": "acme", "name": "Acme", "content": "customer"},
+			},
+			{},
+		},
+	}
+	adapter := NewNexAdapter(nil,
+		WithNexTypes("person", "company"),
+		WithNexPageSize(2),
+		WithNexFetcher(func(ctx context.Context, objectType string, limit, offset int) ([]map[string]any, error) {
+			batches := pages[objectType]
+			idx := offset / limit
+			if idx >= len(batches) {
+				return nil, nil
+			}
+			return batches[idx], nil
+		}),
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	ch, err := adapter.Iter(ctx)
+	if err != nil {
+		t.Fatalf("iter: %v", err)
+	}
+	var got []MigrationRecord
+	for rec := range ch {
+		got = append(got, rec)
+	}
+	if len(got) != 3 {
+		t.Fatalf("want 3 records, got %d: %+v", len(got), got)
+	}
+	// Order matters: persons before companies because that's how we walk.
+	if got[0].Kind != KindPeople || got[0].Slug != "alice" {
+		t.Errorf("record 0 = %+v", got[0])
+	}
+	if got[2].Kind != KindCompanies || got[2].Slug != "acme" {
+		t.Errorf("record 2 = %+v", got[2])
+	}
+}

--- a/internal/migration/types.go
+++ b/internal/migration/types.go
@@ -1,0 +1,107 @@
+// Package migration ports team knowledge out of legacy memory backends
+// (Nex, GBrain) and into the WUPHF markdown wiki at ~/.wuphf/wiki/team/.
+//
+// Why this exists
+// ===============
+//
+// Existing Nex or GBrain installs store their team knowledge in those legacy
+// backends. Moving to WUPHF's markdown wiki without a migration path means
+// walking away from that prior investment. This package closes the gap:
+// `wuphf memory migrate --from {nex,gbrain}` walks the source, converts each
+// record to a standard wiki article, and commits it via the existing wiki
+// worker so the index regenerates and SSE events fire the same way they
+// would for any other write.
+//
+// Design notes
+// ============
+//
+//   - Adapters expose a single Iter() method that returns a channel of
+//     MigrationRecord. Streaming (not a slice) so large backends don't
+//     balloon memory and errors can terminate the walk mid-stream.
+//   - The writer owns identity ("migrate" slug → `migrate <migrate@wuphf.local>`
+//     via Repo.runGitLocked), path construction, and dedup. Adapters stay
+//     ignorant of wiki conventions.
+//   - Serial by design (v1). The wiki worker is single-reader; parallel
+//     imports would just queue up behind it. Keep the code simple.
+package migration
+
+import (
+	"context"
+	"time"
+)
+
+// Kind categorises a record into a wiki subtree. New kinds can be added
+// without breaking callers; unknown kinds collapse to "misc".
+type Kind string
+
+const (
+	// KindPeople maps to team/people/{slug}.md — profile-style notes on
+	// humans and agents.
+	KindPeople Kind = "people"
+	// KindCompanies maps to team/companies/{slug}.md — external org briefs.
+	KindCompanies Kind = "companies"
+	// KindCustomers maps to team/customers/{slug}.md — customer accounts.
+	KindCustomers Kind = "customers"
+	// KindTopics maps to team/topics/{slug}.md — subject-area knowledge.
+	KindTopics Kind = "topics"
+	// KindNotes maps to team/notes/{slug}.md — general retained notes.
+	KindNotes Kind = "notes"
+	// KindMisc is the fallback when a record kind can't be classified.
+	KindMisc Kind = "misc"
+)
+
+// NormalizeKind maps a free-form type string from a source backend onto a
+// known Kind. Empty / unknown inputs collapse to KindMisc so the migration
+// can still proceed without dropping data.
+func NormalizeKind(s string) Kind {
+	switch s {
+	case "person", "people", "contact", "contacts":
+		return KindPeople
+	case "company", "companies", "organisation", "organization", "org":
+		return KindCompanies
+	case "customer", "customers", "account", "accounts":
+		return KindCustomers
+	case "topic", "topics", "subject":
+		return KindTopics
+	case "note", "notes", "memory", "memories":
+		return KindNotes
+	case "":
+		return KindNotes
+	default:
+		return KindMisc
+	}
+}
+
+// MigrationRecord is one unit of source content ready to become a wiki
+// article. All fields except Content can be derived from a fallback when
+// missing; Content is the only hard requirement.
+type MigrationRecord struct {
+	// Kind determines the wiki subtree (team/{kind}/).
+	Kind Kind
+	// Slug is the base filename (no extension). Must be a-z0-9 plus hyphen.
+	Slug string
+	// Title is the first-line heading for the article. Falls back to Slug.
+	Title string
+	// Content is the body bytes written to disk. Front-matter optional —
+	// the writer renders its own standard header regardless.
+	Content string
+	// Source identifies the originating backend ("nex" or "gbrain"). Used
+	// to disambiguate filenames on dedup collisions.
+	Source string
+	// Timestamp is when the record was last updated upstream. Zero values
+	// are tolerated (the writer stamps time.Now() into the rendered article).
+	Timestamp time.Time
+}
+
+// Adapter is the shared contract every source backend implements. Kept
+// deliberately tiny (one method) so test fakes are trivial and production
+// adapters can back onto whatever CLI / HTTP surface their upstream exposes.
+type Adapter interface {
+	// Iter streams records from the source until the channel closes. The
+	// caller is expected to drain the channel; adapters should close it
+	// when the source is exhausted or ctx is cancelled. Errors encountered
+	// mid-walk are surfaced via the error return value (for fatal startup
+	// failures) or logged and skipped (for per-record issues) — the choice
+	// is the adapter's to make based on what the upstream can tell us.
+	Iter(ctx context.Context) (<-chan MigrationRecord, error)
+}

--- a/internal/migration/writer.go
+++ b/internal/migration/writer.go
@@ -134,7 +134,7 @@ func (m *Migrator) Run(ctx context.Context, adapter Adapter, opts RunOptions) (S
 		processed++
 		plan, err := m.planRecord(rec)
 		if err != nil {
-			fmt.Fprintf(m.Stderr, "warning: skip %s/%s: %v\n", rec.Kind, rec.Slug, err)
+			_, _ = fmt.Fprintf(m.Stderr, "warning: skip %s/%s: %v\n", rec.Kind, rec.Slug, err)
 			continue
 		}
 		summary.Plans = append(summary.Plans, plan)
@@ -150,7 +150,7 @@ func (m *Migrator) Run(ctx context.Context, adapter Adapter, opts RunOptions) (S
 		}
 		commitMsg := fmt.Sprintf("migrate: import %s/%s from %s", rec.Kind, rec.Slug, rec.Source)
 		if _, _, werr := m.writer.Enqueue(ctx, MigrateAuthor, plan.Path, renderArticle(rec, m.now()), "create", commitMsg); werr != nil {
-			fmt.Fprintf(m.Stderr, "warning: write %s: %v\n", plan.Path, werr)
+			_, _ = fmt.Fprintf(m.Stderr, "warning: write %s: %v\n", plan.Path, werr)
 			continue
 		}
 		summary.Written++

--- a/internal/migration/writer.go
+++ b/internal/migration/writer.go
@@ -1,0 +1,332 @@
+package migration
+
+// writer.go owns the wiki-side half of the migration: given a stream of
+// MigrationRecord, render each into a standard article, resolve path
+// conflicts, and commit via the existing team.WikiWorker so every write
+// fires the same SSE event and index-regen pipeline a human edit would.
+//
+// Commit identity
+// ===============
+//
+// The writer passes MigrateAuthor ("migrate") as the author slug. The
+// wiki git layer derives the commit author as `migrate <migrate@wuphf.local>`
+// via runGitLocked's identity flags. That keeps migration commits visually
+// distinct from human / archivist / agent commits in audit views, and
+// matches the CLI spec without any changes to runGitLocked itself.
+//
+// Dedup
+// =====
+//
+// If team/{kind}/{slug}.md already exists with byte-identical content,
+// the record is skipped. If the existing content differs, the record is
+// written to a disambiguated path team/{kind}/{slug}-from-{source}-{ts}.md
+// and a warning is emitted so a human can reconcile later.
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// MigrateAuthor is the commit-author slug for every migrated article.
+// Yields `migrate <migrate@wuphf.local>` via Repo.runGitLocked's
+// identity derivation, in line with the HumanAuthor / ArchivistAuthor
+// pattern in internal/team/. Defined here (not in internal/team/) so
+// the migration package owns its own identity without editing files
+// reserved for sibling agents.
+const MigrateAuthor = "migrate"
+
+// WikiWriter is the slice of team.WikiWorker this package needs. Kept
+// narrow so tests can drop in an in-memory fake without spinning up the
+// full wiki git repo.
+type WikiWriter interface {
+	// Enqueue mirrors team.WikiWorker.Enqueue(slug, path, content, mode, commitMsg).
+	Enqueue(ctx context.Context, slug, path, content, mode, commitMsg string) (string, int, error)
+	// Root returns the wiki root on disk so the writer can check for
+	// existing articles (for dedup) without re-implementing the commit
+	// serialization protocol.
+	Root() string
+}
+
+// Plan is a dry-run output row. One per record that would be written.
+type Plan struct {
+	// Path is the wiki-relative path (team/{kind}/{slug}.md).
+	Path string
+	// Bytes is the rendered article size in bytes.
+	Bytes int
+	// Author is the commit author slug — always MigrateAuthor for now,
+	// but kept on the row for symmetry with the audit log output.
+	Author string
+	// Action is "create", "skip-identical", or "collision-rename".
+	Action string
+	// Source is the adapter that produced the record.
+	Source string
+	// CollisionWith is populated when Action == "collision-rename" — it
+	// carries the base path that already existed with different content.
+	CollisionWith string
+}
+
+// Migrator orchestrates adapter → writer. Zero value is not usable;
+// call NewMigrator.
+type Migrator struct {
+	writer WikiWriter
+	now    func() time.Time
+	// Stdout / Stderr streams let the CLI capture output for tests.
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewMigrator returns a Migrator wired up to the given writer.
+func NewMigrator(writer WikiWriter) *Migrator {
+	return &Migrator{
+		writer: writer,
+		now:    NexNow,
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+	}
+}
+
+// RunOptions controls a single migration run.
+type RunOptions struct {
+	// DryRun prints the plan and makes no commits.
+	DryRun bool
+	// Limit caps the number of records processed. Zero means unlimited.
+	Limit int
+}
+
+// Summary aggregates a completed migration run. Returned by Run so the
+// CLI can print a one-liner and exit with a meaningful code.
+type Summary struct {
+	Written    int
+	Skipped    int
+	Collisions int
+	Plans      []Plan
+}
+
+// Run drains the adapter, renders each record, and (unless DryRun is
+// set) commits it via the WikiWorker. Collisions are renamed with a
+// source + timestamp suffix. Per-record errors are logged and the
+// migration continues — a bad row must not block the rest.
+func (m *Migrator) Run(ctx context.Context, adapter Adapter, opts RunOptions) (Summary, error) {
+	ch, err := adapter.Iter(ctx)
+	if err != nil {
+		return Summary{}, fmt.Errorf("migrate: adapter iter: %w", err)
+	}
+	var summary Summary
+	processed := 0
+	for rec := range ch {
+		if opts.Limit > 0 && processed >= opts.Limit {
+			// Drain the rest of the channel so the adapter goroutine
+			// doesn't block on a full buffer. We ignore the dropped
+			// records — the user asked for a bounded run.
+			go func() {
+				for range ch {
+				}
+			}()
+			break
+		}
+		processed++
+		plan, err := m.planRecord(rec)
+		if err != nil {
+			fmt.Fprintf(m.Stderr, "warning: skip %s/%s: %v\n", rec.Kind, rec.Slug, err)
+			continue
+		}
+		summary.Plans = append(summary.Plans, plan)
+		switch plan.Action {
+		case "skip-identical":
+			summary.Skipped++
+			continue
+		case "collision-rename":
+			summary.Collisions++
+		}
+		if opts.DryRun {
+			continue
+		}
+		commitMsg := fmt.Sprintf("migrate: import %s/%s from %s", rec.Kind, rec.Slug, rec.Source)
+		if _, _, werr := m.writer.Enqueue(ctx, MigrateAuthor, plan.Path, renderArticle(rec, m.now()), "create", commitMsg); werr != nil {
+			fmt.Fprintf(m.Stderr, "warning: write %s: %v\n", plan.Path, werr)
+			continue
+		}
+		summary.Written++
+	}
+	return summary, nil
+}
+
+// planRecord determines the on-disk action for one record: skip, create,
+// or create-with-rename. Reads the existing article bytes directly from
+// the wiki root — the worker has exclusive write access to the repo,
+// but reads are safe here because we only take file stat + content, not
+// git metadata.
+func (m *Migrator) planRecord(rec MigrationRecord) (Plan, error) {
+	if strings.TrimSpace(rec.Slug) == "" {
+		return Plan{}, fmt.Errorf("empty slug")
+	}
+	if strings.TrimSpace(rec.Content) == "" {
+		return Plan{}, fmt.Errorf("empty content")
+	}
+	kind := rec.Kind
+	if kind == "" {
+		kind = KindMisc
+	}
+	slug := slugify(rec.Slug)
+	if slug == "" {
+		return Plan{}, fmt.Errorf("slug contains no safe characters")
+	}
+	basePath := fmt.Sprintf("team/%s/%s.md", kind, slug)
+	rendered := renderArticle(rec, m.now())
+	existing, exists, err := m.readExisting(basePath)
+	if err != nil {
+		return Plan{}, err
+	}
+	switch {
+	case !exists:
+		return Plan{
+			Path:   basePath,
+			Bytes:  len(rendered),
+			Author: MigrateAuthor,
+			Action: "create",
+			Source: rec.Source,
+		}, nil
+	case bytesEqualOrSameHash(existing, []byte(rendered)):
+		return Plan{
+			Path:   basePath,
+			Bytes:  len(rendered),
+			Author: MigrateAuthor,
+			Action: "skip-identical",
+			Source: rec.Source,
+		}, nil
+	default:
+		ts := m.now().UTC().Format("20060102-150405")
+		source := slugify(rec.Source)
+		if source == "" {
+			source = "unknown"
+		}
+		altPath := fmt.Sprintf("team/%s/%s-from-%s-%s.md", kind, slug, source, ts)
+		return Plan{
+			Path:          altPath,
+			Bytes:         len(rendered),
+			Author:        MigrateAuthor,
+			Action:        "collision-rename",
+			Source:        rec.Source,
+			CollisionWith: basePath,
+		}, nil
+	}
+}
+
+// readExisting returns the on-disk bytes for relPath plus whether the
+// file exists. A non-existent file is not an error.
+func (m *Migrator) readExisting(relPath string) ([]byte, bool, error) {
+	root := strings.TrimSpace(m.writer.Root())
+	if root == "" {
+		return nil, false, nil
+	}
+	full := filepath.Join(root, filepath.FromSlash(relPath))
+	info, err := os.Stat(full)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("stat %s: %w", relPath, err)
+	}
+	if info.IsDir() {
+		return nil, false, fmt.Errorf("%s is a directory, not an article", relPath)
+	}
+	b, err := os.ReadFile(full)
+	if err != nil {
+		return nil, false, fmt.Errorf("read %s: %w", relPath, err)
+	}
+	return b, true, nil
+}
+
+// bytesEqualOrSameHash reports whether two byte slices are equal, via
+// SHA-256 for large inputs. The hash path matters less for correctness
+// and more for memory: articles can be hundreds of KB and we do not
+// want to hold two copies of every record just to byte-compare.
+func bytesEqualOrSameHash(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	if len(a) < 64*1024 {
+		for i := range a {
+			if a[i] != b[i] {
+				return false
+			}
+		}
+		return true
+	}
+	return sha256.Sum256(a) == sha256.Sum256(b)
+}
+
+// renderArticle turns a MigrationRecord into the canonical markdown
+// body the writer commits. Keeps a simple, scannable header so humans
+// reviewing the wiki later can tell at a glance that a page came from
+// a legacy import.
+func renderArticle(rec MigrationRecord, fallbackTS time.Time) string {
+	title := strings.TrimSpace(rec.Title)
+	if title == "" {
+		title = rec.Slug
+	}
+	ts := rec.Timestamp
+	if ts.IsZero() {
+		ts = fallbackTS
+	}
+	var b strings.Builder
+	b.WriteString("# ")
+	b.WriteString(title)
+	b.WriteString("\n\n")
+	b.WriteString("> Imported from ")
+	if rec.Source != "" {
+		b.WriteString(rec.Source)
+	} else {
+		b.WriteString("legacy backend")
+	}
+	b.WriteString(" on ")
+	b.WriteString(fallbackTS.UTC().Format(time.RFC3339))
+	b.WriteString(".\n\n")
+	if !ts.IsZero() {
+		b.WriteString("Upstream last updated: ")
+		b.WriteString(ts.UTC().Format(time.RFC3339))
+		b.WriteString(".\n\n")
+	}
+	content := strings.TrimSpace(rec.Content)
+	b.WriteString(content)
+	if !strings.HasSuffix(content, "\n") {
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// slugRegex matches any character NOT allowed in a wiki slug. The wiki
+// path validator accepts lowercase a-z, 0-9 and hyphen; anything else
+// becomes a hyphen and we collapse runs.
+var slugRegex = regexp.MustCompile(`[^a-z0-9]+`)
+
+// slugify returns a filename-safe slug derived from input. Empty strings
+// yield empty strings so the caller can detect-and-reject.
+func slugify(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+	s = slugRegex.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	return s
+}
+
+// firstNonEmpty returns the first non-empty trimmed string from the
+// provided list. Used by both adapters to pick the first usable field
+// from heterogeneous upstream shapes.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if t := strings.TrimSpace(v); t != "" {
+			return t
+		}
+	}
+	return ""
+}

--- a/internal/migration/writer_test.go
+++ b/internal/migration/writer_test.go
@@ -1,0 +1,288 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// wikiWorkerWriter adapts team.WikiWorker onto WikiWriter so the
+// integration test can drive the real write path without the worker
+// needing to know about migration.WikiWriter directly.
+type wikiWorkerWriter struct{ w *team.WikiWorker }
+
+func (ww wikiWorkerWriter) Enqueue(ctx context.Context, slug, path, content, mode, commitMsg string) (string, int, error) {
+	return ww.w.Enqueue(ctx, slug, path, content, mode, commitMsg)
+}
+func (ww wikiWorkerWriter) Root() string { return ww.w.Repo().Root() }
+
+// fixedAdapter is a deterministic adapter used by the integration test.
+type fixedAdapter struct{ records []MigrationRecord }
+
+func (f *fixedAdapter) Iter(ctx context.Context) (<-chan MigrationRecord, error) {
+	ch := make(chan MigrationRecord, len(f.records))
+	for _, r := range f.records {
+		ch <- r
+	}
+	close(ch)
+	return ch, nil
+}
+
+// inMemoryWriter captures Enqueue calls without touching git. Used by
+// dry-run and plan-level tests that don't need the full wiki pipeline.
+type inMemoryWriter struct {
+	mu       sync.Mutex
+	existing map[string][]byte
+	root     string
+	calls    []inMemoryCall
+}
+
+type inMemoryCall struct {
+	Slug, Path, Content, Mode, Msg string
+}
+
+func newInMemoryWriter(t *testing.T) *inMemoryWriter {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "team"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return &inMemoryWriter{existing: map[string][]byte{}, root: root}
+}
+
+func (w *inMemoryWriter) Root() string { return w.root }
+
+func (w *inMemoryWriter) Enqueue(ctx context.Context, slug, path, content, mode, msg string) (string, int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.calls = append(w.calls, inMemoryCall{slug, path, content, mode, msg})
+	full := filepath.Join(w.root, filepath.FromSlash(path))
+	if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+		return "", 0, err
+	}
+	if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
+		return "", 0, err
+	}
+	return "abc1234", len(content), nil
+}
+
+func (w *inMemoryWriter) seedExisting(t *testing.T, relPath, content string) {
+	t.Helper()
+	full := filepath.Join(w.root, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"Nazz", "nazz"},
+		{"Nazz Mohammad!", "nazz-mohammad"},
+		{"  trim me  ", "trim-me"},
+		{"---leading---", "leading"},
+		{"emoji 👋 dropped", "emoji-dropped"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		if got := slugify(tc.in); got != tc.want {
+			t.Errorf("slugify(%q)=%q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestRenderArticleIncludesProvenanceHeader(t *testing.T) {
+	rec := MigrationRecord{
+		Kind:    KindPeople,
+		Slug:    "nazz",
+		Title:   "Nazz",
+		Content: "Founder of WUPHF.",
+		Source:  "nex",
+	}
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	got := renderArticle(rec, now)
+	if !strings.Contains(got, "# Nazz") {
+		t.Errorf("missing title heading: %q", got)
+	}
+	if !strings.Contains(got, "Imported from nex") {
+		t.Errorf("missing provenance line: %q", got)
+	}
+}
+
+func TestMigratorDryRunSkipsCommit(t *testing.T) {
+	w := newInMemoryWriter(t)
+	m := NewMigrator(w)
+	m.Stderr = &bytes.Buffer{}
+	m.now = func() time.Time { return time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC) }
+
+	adapter := &fixedAdapter{records: []MigrationRecord{
+		{Kind: KindPeople, Slug: "nazz", Title: "Nazz", Content: "founder", Source: "nex"},
+	}}
+	summary, err := m.Run(context.Background(), adapter, RunOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if len(w.calls) != 0 {
+		t.Errorf("dry run issued %d commits, want 0", len(w.calls))
+	}
+	if summary.Written != 0 {
+		t.Errorf("written=%d, want 0 on dry run", summary.Written)
+	}
+	if len(summary.Plans) != 1 {
+		t.Fatalf("plans=%d, want 1", len(summary.Plans))
+	}
+	if summary.Plans[0].Path != "team/people/nazz.md" {
+		t.Errorf("path=%q", summary.Plans[0].Path)
+	}
+	if summary.Plans[0].Action != "create" {
+		t.Errorf("action=%q", summary.Plans[0].Action)
+	}
+}
+
+func TestMigratorSkipsIdenticalContent(t *testing.T) {
+	w := newInMemoryWriter(t)
+	m := NewMigrator(w)
+	m.Stderr = &bytes.Buffer{}
+	fixedNow := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	m.now = func() time.Time { return fixedNow }
+
+	rec := MigrationRecord{Kind: KindPeople, Slug: "nazz", Title: "Nazz", Content: "founder", Source: "nex"}
+	// Pre-seed with the exact rendered output so the dedup check fires.
+	w.seedExisting(t, "team/people/nazz.md", renderArticle(rec, fixedNow))
+
+	summary, err := m.Run(context.Background(), &fixedAdapter{records: []MigrationRecord{rec}}, RunOptions{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if summary.Skipped != 1 {
+		t.Errorf("skipped=%d, want 1", summary.Skipped)
+	}
+	if summary.Written != 0 {
+		t.Errorf("written=%d, want 0", summary.Written)
+	}
+	if len(w.calls) != 0 {
+		t.Errorf("enqueued %d calls, want 0", len(w.calls))
+	}
+}
+
+func TestMigratorRenamesOnCollision(t *testing.T) {
+	w := newInMemoryWriter(t)
+	m := NewMigrator(w)
+	m.Stderr = &bytes.Buffer{}
+	fixedNow := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	m.now = func() time.Time { return fixedNow }
+
+	w.seedExisting(t, "team/people/nazz.md", "# Nazz\n\nSomething else entirely.\n")
+
+	rec := MigrationRecord{Kind: KindPeople, Slug: "nazz", Title: "Nazz", Content: "founder", Source: "gbrain"}
+	summary, err := m.Run(context.Background(), &fixedAdapter{records: []MigrationRecord{rec}}, RunOptions{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if summary.Collisions != 1 {
+		t.Errorf("collisions=%d, want 1", summary.Collisions)
+	}
+	if summary.Written != 1 {
+		t.Errorf("written=%d, want 1", summary.Written)
+	}
+	if len(w.calls) != 1 {
+		t.Fatalf("want 1 enqueue, got %d", len(w.calls))
+	}
+	got := w.calls[0].Path
+	if !strings.HasPrefix(got, "team/people/nazz-from-gbrain-") || !strings.HasSuffix(got, ".md") {
+		t.Errorf("collision path=%q, want suffixed rename", got)
+	}
+}
+
+func TestMigratorRespectsLimit(t *testing.T) {
+	w := newInMemoryWriter(t)
+	m := NewMigrator(w)
+	m.Stderr = &bytes.Buffer{}
+	m.now = func() time.Time { return time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC) }
+
+	records := []MigrationRecord{
+		{Kind: KindPeople, Slug: "a", Title: "A", Content: "a", Source: "nex"},
+		{Kind: KindPeople, Slug: "b", Title: "B", Content: "b", Source: "nex"},
+		{Kind: KindPeople, Slug: "c", Title: "C", Content: "c", Source: "nex"},
+	}
+	summary, err := m.Run(context.Background(), &fixedAdapter{records: records}, RunOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if summary.Written != 2 {
+		t.Errorf("written=%d, want 2", summary.Written)
+	}
+}
+
+// TestMigratorIntegrationWithWikiWorker verifies the migration lands in
+// the real wiki git repo with the `migrate` author identity.
+func TestMigratorIntegrationWithWikiWorker(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH, skipping integration test")
+	}
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := team.NewRepoAt(root, backup)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("init wiki: %v", err)
+	}
+	worker := team.NewWikiWorker(repo, nil)
+	worker.Start(ctx)
+	defer worker.Stop()
+
+	m := NewMigrator(wikiWorkerWriter{w: worker})
+	m.Stderr = &bytes.Buffer{}
+	m.now = func() time.Time { return time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC) }
+
+	adapter := &fixedAdapter{records: []MigrationRecord{
+		{Kind: KindPeople, Slug: "nazz", Title: "Nazz", Content: "Founder.", Source: "nex"},
+		{Kind: KindCompanies, Slug: "hubspot", Title: "HubSpot", Content: "Prior life.", Source: "gbrain"},
+	}}
+	summary, err := m.Run(ctx, adapter, RunOptions{})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if summary.Written != 2 {
+		t.Fatalf("written=%d, want 2", summary.Written)
+	}
+
+	// Wait for the async worker to flush both commits. worker.Enqueue
+	// waits for the reply, so by the time Run returns the files should
+	// be on disk — but give the OS a small buffer.
+	for _, rel := range []string{"team/people/nazz.md", "team/companies/hubspot.md"} {
+		full := filepath.Join(root, rel)
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			if _, err := os.Stat(full); err == nil {
+				break
+			}
+			time.Sleep(25 * time.Millisecond)
+		}
+		if _, err := os.Stat(full); err != nil {
+			t.Fatalf("expected article at %s: %v", full, err)
+		}
+	}
+
+	// Confirm commit author == migrate.
+	out, err := exec.Command("git", "-C", root, "log", "--format=%an <%ae>").Output()
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	if !strings.Contains(string(out), "migrate <migrate@wuphf.local>") {
+		t.Fatalf("expected migrate author in log, got:\n%s", string(out))
+	}
+}

--- a/testdata/vhs/help.txt
+++ b/testdata/vhs/help.txt
@@ -8,6 +8,7 @@ Usage:
   wuphf shred        Burn the workspace down and reopen onboarding
   wuphf import --from legacy  Import from a running external orchestrator (auto-detect)
   wuphf log          Show what your agents actually did (task receipts)
+  wuphf memory migrate --from {nex,gbrain}  Port legacy memory into the team wiki
   wuphf --cmd <cmd>  Run a command non-interactively
 
 Flags:
@@ -45,4 +46,3 @@ Flags:
         Launch with tmux TUI instead of the web UI
   --unsafe
         Bypass all agent permission checks (use for local dev only)
-  --version


### PR DESCRIPTION
## Summary

- Ports legacy Nex/GBrain memory into the markdown wiki at `~/.wuphf/wiki/team/` via a new `wuphf memory migrate --from {nex,gbrain}` subcommand.
- Adds `internal/migration/` with per-backend adapters (streaming `MigrationRecord` via `Iter()`) and a migrator that handles path layout, rendering, dedup, and collision renames.
- Commits flow through the existing `team.WikiWorker` so index regen, backup mirroring, and SSE events fire the same way they do for human/agent writes. Author is `migrate <migrate@wuphf.local>` via the new `MigrateAuthor` slug.

## Design notes

- **Adapters are narrow.** One method (`Iter`) so tests inject fakes easily and backends stay ignorant of wiki conventions. Nex pages `/v1/records` across the default types (person / company / customer / topic / note); GBrain uses `list_pages` + `get_page` with a query-based fallback for older builds.
- **Dedup is content-hash based.** If `team/{kind}/{slug}.md` already exists with identical bytes we skip. True collisions write to `team/{kind}/{slug}-from-{source}-{ts}.md` and emit a warning for manual reconcile.
- **Serial by design.** The wiki worker is single-reader, so parallel imports would just queue behind it. v1 keeps it simple.
- Non-overlap respected: no edits to scanner*, entity_*, broker_human, wiki_worker's HumanAuthor block, or WikiEditor.tsx.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/migration/... -race` (adapters + migrator + WikiWorker integration)
- [x] Full repo `go test ./...` (pre-existing flaky e2e test passes in isolation; unrelated to this change)
- [x] `wuphf memory --help` + `wuphf memory migrate --help` render correctly
- [ ] Dogfood against a real Nex install once API key is wired
- [ ] Dogfood against a real GBrain install once it's set up