### PR TITLE
feat(entity): cross-entity graph — briefs auto-link related entities

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -470,6 +470,7 @@ type Broker struct {
 	reviewLog               *ReviewLog
 	reviewResolver          ReviewerResolver
 	factLog                 *FactLog
+	entityGraph             *EntityGraph
 	entitySynthesizer       *EntitySynthesizer
 	playbookSynthesizer     *PlaybookSynthesizer
 	scanTracker             *scanStatusTracker
@@ -1233,6 +1234,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/entity/brief/synthesize", b.requireAuth(b.handleEntityBriefSynthesize))
 	mux.HandleFunc("/entity/facts", b.requireAuth(b.handleEntityFactsList))
 	mux.HandleFunc("/entity/briefs", b.requireAuth(b.handleEntityBriefsList))
+	mux.HandleFunc("/entity/graph", b.requireAuth(b.handleEntityGraph))
 	mux.HandleFunc("/playbook/list", b.requireAuth(b.handlePlaybookList))
 	mux.HandleFunc("/playbook/compile", b.requireAuth(b.handlePlaybookCompile))
 	mux.HandleFunc("/playbook/execution", b.requireAuth(b.handlePlaybookExecution))

--- a/internal/team/broker_entity.go
+++ b/internal/team/broker_entity.go
@@ -118,6 +118,21 @@ func (b *Broker) FactLog() *FactLog {
 	return b.factLog
 }
 
+// EntityGraph returns the active cross-entity graph or nil.
+func (b *Broker) EntityGraph() *EntityGraph {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.entityGraph
+}
+
+// SetEntityGraph wires a graph from tests. Must be called after the wiki
+// worker is attached (graph writes ride the worker queue).
+func (b *Broker) SetEntityGraph(graph *EntityGraph) {
+	b.mu.Lock()
+	b.entityGraph = graph
+	b.mu.Unlock()
+}
+
 // ensureEntitySynthesizer initializes the fact log + synthesizer when the
 // wiki worker is online. Idempotent.
 func (b *Broker) ensureEntitySynthesizer() {
@@ -133,15 +148,18 @@ func (b *Broker) ensureEntitySynthesizer() {
 	}
 
 	factLog := NewFactLog(worker)
+	graph := NewEntityGraph(worker)
 	cfg := SynthesizerConfig{
 		Threshold: resolveThresholdFromEnv(),
 		Timeout:   resolveTimeoutFromEnv(),
+		Graph:     graph,
 	}
 	synth := NewEntitySynthesizer(worker, factLog, b, cfg)
 	synth.Start(context.Background())
 
 	b.mu.Lock()
 	b.factLog = factLog
+	b.entityGraph = graph
 	b.entitySynthesizer = synth
 	b.mu.Unlock()
 }
@@ -225,6 +243,15 @@ func (b *Broker) handleEntityFact(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
+	}
+
+	// Cross-entity graph extraction rides on every successful fact append.
+	// Failures here are logged but never block the fact_recorded response —
+	// the graph is additive intelligence, not a constraint on the fact log.
+	if graph := b.EntityGraph(); graph != nil {
+		if _, gerr := graph.RecordFactRefs(r.Context(), fact); gerr != nil {
+			log.Printf("entity graph: record refs for %s/%s fact %s: %v", kind, slug, fact.ID, gerr)
+		}
 	}
 
 	// Read back the current brief frontmatter to compute how many facts
@@ -452,4 +479,50 @@ func briefTitleFrom(body, fallback string) string {
 		return h
 	}
 	return fallback
+}
+
+// handleEntityGraph is GET /entity/graph?kind=&slug=&direction={in,out,both}.
+// Returns the coalesced edges touching the requested entity in the chosen
+// direction. Defaults to direction=out.
+func (b *Broker) handleEntityGraph(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	graph := b.EntityGraph()
+	if graph == nil {
+		writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "entity-graph backend is not active"})
+		return
+	}
+	kind := EntityKind(strings.TrimSpace(r.URL.Query().Get("kind")))
+	slug := strings.TrimSpace(r.URL.Query().Get("slug"))
+	if err := validateListInputs(kind, slug); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	dirRaw := strings.TrimSpace(r.URL.Query().Get("direction"))
+	direction := Direction(dirRaw)
+	switch direction {
+	case "", DirectionOut, DirectionIn, DirectionBoth:
+	default:
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "direction must be one of out|in|both"})
+		return
+	}
+	if direction == "" {
+		direction = DirectionOut
+	}
+	edges, err := graph.Query(kind, slug, direction)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	if edges == nil {
+		edges = []CoalescedEdge{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"kind":      kind,
+		"slug":      slug,
+		"direction": direction,
+		"edges":     edges,
+	})
 }

--- a/internal/team/broker_entity_graph_test.go
+++ b/internal/team/broker_entity_graph_test.go
@@ -1,0 +1,148 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newEntityGraphTestServer mirrors newEntityTestServer but also wires an
+// EntityGraph so /entity/graph and the fact-recorded hook are exercised
+// end-to-end.
+func newEntityGraphTestServer(t *testing.T) (*httptest.Server, *Broker, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	b := NewBroker()
+	worker := NewWikiWorker(repo, b)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+
+	pub := &entityPublisherStub{}
+	factLog := NewFactLog(worker)
+	graph := NewEntityGraph(worker)
+	synth := NewEntitySynthesizer(worker, factLog, pub, SynthesizerConfig{
+		Threshold: 99,
+		Timeout:   5 * time.Second,
+		Graph:     graph,
+		LLMCall: func(context.Context, string, string) (string, error) {
+			return "# stub\n", nil
+		},
+	})
+	synth.Start(context.Background())
+	b.SetEntitySynthesizer(factLog, synth)
+	b.SetEntityGraph(graph)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/entity/fact", b.requireAuth(b.handleEntityFact))
+	mux.HandleFunc("/entity/graph", b.requireAuth(b.handleEntityGraph))
+	srv := httptest.NewServer(mux)
+	return srv, b, func() {
+		srv.Close()
+		synth.Stop()
+		cancel()
+		worker.Stop()
+	}
+}
+
+func TestEntityGraphEndpoint_FactRecordPopulatesGraph(t *testing.T) {
+	srv, b, teardown := newEntityGraphTestServer(t)
+	defer teardown()
+
+	payload, _ := json.Marshal(map[string]any{
+		"entity_kind": "people",
+		"entity_slug": "sarah",
+		"fact":        "Works at [[companies/acme]] as PM.",
+		"recorded_by": "pm",
+	})
+	req, _ := authReq(http.MethodPost, srv.URL+"/entity/fact", bytes.NewReader(payload), b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post fact: %v", err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("fact status=%d body=%s", res.StatusCode, body)
+	}
+
+	// Out-edges from sarah should include acme.
+	req, _ = authReq(http.MethodGet, srv.URL+"/entity/graph?kind=people&slug=sarah&direction=out", nil, b.Token())
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get graph: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("graph status=%d body=%s", res.StatusCode, body)
+	}
+	var gr struct {
+		Edges []struct {
+			FromKind string `json:"from_kind"`
+			FromSlug string `json:"from_slug"`
+			ToKind   string `json:"to_kind"`
+			ToSlug   string `json:"to_slug"`
+		} `json:"edges"`
+		Direction string `json:"direction"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&gr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if gr.Direction != "out" {
+		t.Errorf("direction=%q", gr.Direction)
+	}
+	if len(gr.Edges) != 1 {
+		t.Fatalf("want 1 edge; got %d: %+v", len(gr.Edges), gr.Edges)
+	}
+	e := gr.Edges[0]
+	if e.FromKind != "people" || e.FromSlug != "sarah" || e.ToKind != "companies" || e.ToSlug != "acme" {
+		t.Errorf("edge shape wrong: %+v", e)
+	}
+}
+
+func TestEntityGraphEndpoint_ValidatesDirection(t *testing.T) {
+	srv, b, teardown := newEntityGraphTestServer(t)
+	defer teardown()
+
+	req, _ := authReq(http.MethodGet, srv.URL+"/entity/graph?kind=people&slug=x&direction=sideways", nil, b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400; got %d", res.StatusCode)
+	}
+}
+
+func TestEntityGraphEndpoint_MissingGraphReturns503(t *testing.T) {
+	b := NewBroker()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/entity/graph", b.requireAuth(b.handleEntityGraph))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	req, _ := authReq(http.MethodGet, srv.URL+"/entity/graph?kind=people&slug=x", nil, b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("http: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503; got %d", res.StatusCode)
+	}
+}

--- a/internal/team/entity_graph.go
+++ b/internal/team/entity_graph.go
@@ -1,0 +1,403 @@
+package team
+
+// entity_graph.go is the cross-entity graph built on top of the v1.2 fact log.
+//
+// Every time an agent records a fact on one entity that references another
+// entity (e.g. "Sarah works at [[companies/acme]]" logged on people/sarah),
+// we emit an edge to an append-only adjacency log at
+// team/entities/.graph.jsonl. Reads coalesce the log into a deduplicated
+// adjacency list keyed by (from_kind, from_slug, to_kind, to_slug).
+//
+// v1 parser scope:
+//   - Wikilinks: [[kind/slug]] where kind is one of people|companies|customers.
+//   - Plain [[slug]] wikilinks resolved against known entity briefs on disk,
+//     exact-match only. A slug that matches more than one kind is skipped
+//     (ambiguous — v2 will add fuzzy name resolution).
+//
+// Writes ride the shared WikiWorker queue with a new IsEntityGraph
+// discriminator so the single-writer invariant is preserved. One
+// fact_recorded hook = one batched append of every new edge (file rewrite,
+// same pattern as the fact log).
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// EntityGraphPath is the wiki-root-relative path to the graph log.
+const EntityGraphPath = "team/entities/.graph.jsonl"
+
+// ErrEntityGraphNotRunning mirrors ErrFactLogNotRunning — returned when a
+// graph operation runs without a wiki worker attached.
+var ErrEntityGraphNotRunning = errors.New("entity graph: worker is not attached")
+
+// EntityRef is one parsed reference to another entity inside a fact.
+type EntityRef struct {
+	Kind EntityKind `json:"kind"`
+	Slug string     `json:"slug"`
+}
+
+// EntityEdge is one row of the append-only adjacency log.
+type EntityEdge struct {
+	FromKind        EntityKind `json:"from_kind"`
+	FromSlug        string     `json:"from_slug"`
+	ToKind          EntityKind `json:"to_kind"`
+	ToSlug          string     `json:"to_slug"`
+	FirstSeenFactID string     `json:"first_seen_fact_id"`
+	LastSeenTS      time.Time  `json:"last_seen_ts"`
+}
+
+// CoalescedEdge is the reader's post-dedup view of an edge. Preserves the
+// first-seen fact id and the most recent timestamp so UI panels can sort by
+// recency without re-reading the full log.
+type CoalescedEdge struct {
+	FromKind        EntityKind `json:"from_kind"`
+	FromSlug        string     `json:"from_slug"`
+	ToKind          EntityKind `json:"to_kind"`
+	ToSlug          string     `json:"to_slug"`
+	FirstSeenFactID string     `json:"first_seen_fact_id"`
+	LastSeenTS      time.Time  `json:"last_seen_ts"`
+	OccurrenceCount int        `json:"occurrence_count"`
+}
+
+// EntityGraph owns all read/write access to the graph log.
+type EntityGraph struct {
+	worker *WikiWorker
+	mu     sync.Mutex
+}
+
+// NewEntityGraph constructs a graph backed by the supplied worker.
+func NewEntityGraph(worker *WikiWorker) *EntityGraph {
+	return &EntityGraph{worker: worker}
+}
+
+// Kindprefixed wikilinks: `[[people/nazz]]`, `[[companies/acme]]`, `[[customers/foo]]`.
+// Kind token is captured separately so the entity kind is verified.
+var kindedWikilinkPattern = regexp.MustCompile(`\[\[(people|companies|customers)/([a-z0-9][a-z0-9-]*)(?:\|[^\]]*)?\]\]`)
+
+// Bare `[[slug]]` wikilinks (no kind prefix, no path). Captured for
+// exact-match lookup against known entity briefs on disk.
+var bareWikilinkPattern = regexp.MustCompile(`\[\[([a-z0-9][a-z0-9-]*)(?:\|[^\]]*)?\]\]`)
+
+// ExtractRefs parses `statement` for references to entities *other than* the
+// source entity (self-references are elided). `known` supplies a closure the
+// caller can plug in to resolve bare `[[slug]]` wikilinks to a single kind;
+// return ("", false) to skip (ambiguous or unknown). Passing nil disables
+// bare-slug lookup entirely — useful in tests and when the graph is being
+// rebuilt without disk access.
+func ExtractRefs(sourceKind EntityKind, sourceSlug, statement string, known func(slug string) (EntityKind, bool)) []EntityRef {
+	seen := make(map[string]bool)
+	out := make([]EntityRef, 0, 4)
+
+	add := func(kind EntityKind, slug string) {
+		if kind == sourceKind && slug == sourceSlug {
+			return
+		}
+		key := string(kind) + "/" + slug
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, EntityRef{Kind: kind, Slug: slug})
+	}
+
+	// First pass: explicit [[kind/slug]] — always wins.
+	for _, m := range kindedWikilinkPattern.FindAllStringSubmatch(statement, -1) {
+		kind := EntityKind(m[1])
+		slug := m[2]
+		if !slugPattern.MatchString(slug) {
+			continue
+		}
+		add(kind, slug)
+	}
+
+	// Second pass: bare [[slug]] — only if `known` is provided.
+	if known != nil {
+		for _, m := range bareWikilinkPattern.FindAllStringSubmatch(statement, -1) {
+			slug := m[1]
+			// Skip forms already consumed by the kinded pass: re-matching the
+			// inner slug of `[[people/nazz]]` would double-count because the
+			// bare pattern sees `[[people/nazz]]` as not matching (there is a
+			// slash), BUT the same bare pattern does match `[[nazz]]` on its
+			// own. So the filter here only needs to guard against the slug
+			// that is literally present as a kinded target too.
+			if !slugPattern.MatchString(slug) {
+				continue
+			}
+			if containsKinded(statement, slug) {
+				continue
+			}
+			kind, ok := known(slug)
+			if !ok {
+				continue
+			}
+			add(kind, slug)
+		}
+	}
+
+	return out
+}
+
+// containsKinded reports whether the statement already contains a kinded
+// reference whose slug equals the bare slug — so we don't double-count.
+func containsKinded(statement, slug string) bool {
+	for _, m := range kindedWikilinkPattern.FindAllStringSubmatch(statement, -1) {
+		if m[2] == slug {
+			return true
+		}
+	}
+	return false
+}
+
+// knownEntityResolver returns a closure that maps a bare slug to a unique
+// entity kind by walking the on-disk team/{kind}/ directories. Ambiguous
+// slugs (present under multiple kinds) return false — v1 refuses to guess.
+func (g *EntityGraph) knownEntityResolver() func(slug string) (EntityKind, bool) {
+	if g == nil || g.worker == nil {
+		return nil
+	}
+	root := g.worker.Repo().Root()
+	// Build the index once per call — cheap for a hundred briefs, and the
+	// graph append is not on the hot path for agent turns.
+	index := make(map[string][]EntityKind)
+	for _, kind := range ValidEntityKinds() {
+		dir := filepath.Join(root, "team", string(kind))
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if !strings.HasSuffix(strings.ToLower(name), ".md") {
+				continue
+			}
+			slug := strings.TrimSuffix(name, ".md")
+			if !slugPattern.MatchString(slug) {
+				continue
+			}
+			index[slug] = append(index[slug], kind)
+		}
+	}
+	return func(slug string) (EntityKind, bool) {
+		kinds, ok := index[slug]
+		if !ok || len(kinds) != 1 {
+			return "", false
+		}
+		return kinds[0], true
+	}
+}
+
+// RecordFactRefs extracts entity references from the given fact and, when
+// any exist, appends new edges to the graph log via the wiki worker. Edges
+// that already exist in the log are still appended (the reader coalesces
+// — keeps the writer path cheap and idempotent on retries).
+func (g *EntityGraph) RecordFactRefs(ctx context.Context, fact Fact) ([]EntityRef, error) {
+	if g == nil || g.worker == nil {
+		return nil, ErrEntityGraphNotRunning
+	}
+	refs := ExtractRefs(fact.Kind, fact.Slug, fact.Text, g.knownEntityResolver())
+	if len(refs) == 0 {
+		return nil, nil
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	existing := g.readExistingLocked()
+	var buf strings.Builder
+	buf.Write(existing)
+	if len(existing) > 0 && !strings.HasSuffix(string(existing), "\n") {
+		buf.WriteString("\n")
+	}
+	for _, ref := range refs {
+		edge := EntityEdge{
+			FromKind:        fact.Kind,
+			FromSlug:        fact.Slug,
+			ToKind:          ref.Kind,
+			ToSlug:          ref.Slug,
+			FirstSeenFactID: fact.ID,
+			LastSeenTS:      fact.CreatedAt.UTC(),
+		}
+		line, err := json.Marshal(edge)
+		if err != nil {
+			return nil, fmt.Errorf("entity graph: marshal: %w", err)
+		}
+		buf.Write(line)
+		buf.WriteString("\n")
+	}
+
+	msg := fmt.Sprintf("graph: %s/%s → %d ref(s)", fact.Kind, fact.Slug, len(refs))
+	if _, _, err := g.worker.EnqueueEntityGraph(ctx, ArchivistAuthor, buf.String(), msg); err != nil {
+		return refs, fmt.Errorf("entity graph: enqueue: %w", err)
+	}
+	return refs, nil
+}
+
+// readExistingLocked returns the current graph log bytes, or nil if missing.
+// Caller holds g.mu.
+func (g *EntityGraph) readExistingLocked() []byte {
+	full := filepath.Join(g.worker.Repo().Root(), filepath.FromSlash(EntityGraphPath))
+	bytes, err := os.ReadFile(full)
+	if err != nil {
+		return nil
+	}
+	return bytes
+}
+
+// readAll streams the log and returns every parseable edge in file order.
+func (g *EntityGraph) readAll() ([]EntityEdge, error) {
+	if g == nil || g.worker == nil {
+		return nil, ErrEntityGraphNotRunning
+	}
+	full := filepath.Join(g.worker.Repo().Root(), filepath.FromSlash(EntityGraphPath))
+	f, err := os.Open(full)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("entity graph: open: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	lineNo := 0
+	edges := make([]EntityEdge, 0, 64)
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var edge EntityEdge
+		if err := json.Unmarshal([]byte(line), &edge); err != nil {
+			log.Printf("entity graph: skip malformed line %d: %v", lineNo, err)
+			continue
+		}
+		if edge.FromKind == "" || edge.FromSlug == "" || edge.ToKind == "" || edge.ToSlug == "" {
+			log.Printf("entity graph: skip underspecified line %d", lineNo)
+			continue
+		}
+		edges = append(edges, edge)
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("entity graph: scanner error after line %d: %v", lineNo, err)
+	}
+	return edges, nil
+}
+
+// coalesceKey is the dedup key used by the coalescer.
+type coalesceKey struct {
+	fromKind EntityKind
+	fromSlug string
+	toKind   EntityKind
+	toSlug   string
+}
+
+// Coalesce reads the full log, deduplicates by (from, to), and returns one
+// row per distinct edge. Newest-first by LastSeenTS.
+func (g *EntityGraph) Coalesce() ([]CoalescedEdge, error) {
+	edges, err := g.readAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(edges) == 0 {
+		return nil, nil
+	}
+	idx := make(map[coalesceKey]*CoalescedEdge, len(edges))
+	order := make([]coalesceKey, 0, len(edges))
+	for _, e := range edges {
+		k := coalesceKey{e.FromKind, e.FromSlug, e.ToKind, e.ToSlug}
+		row, ok := idx[k]
+		if !ok {
+			row = &CoalescedEdge{
+				FromKind:        e.FromKind,
+				FromSlug:        e.FromSlug,
+				ToKind:          e.ToKind,
+				ToSlug:          e.ToSlug,
+				FirstSeenFactID: e.FirstSeenFactID,
+				LastSeenTS:      e.LastSeenTS,
+				OccurrenceCount: 1,
+			}
+			idx[k] = row
+			order = append(order, k)
+			continue
+		}
+		row.OccurrenceCount++
+		if e.LastSeenTS.After(row.LastSeenTS) {
+			row.LastSeenTS = e.LastSeenTS
+		}
+	}
+	out := make([]CoalescedEdge, 0, len(order))
+	for _, k := range order {
+		out = append(out, *idx[k])
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if !out[i].LastSeenTS.Equal(out[j].LastSeenTS) {
+			return out[i].LastSeenTS.After(out[j].LastSeenTS)
+		}
+		if out[i].ToKind != out[j].ToKind {
+			return out[i].ToKind < out[j].ToKind
+		}
+		return out[i].ToSlug < out[j].ToSlug
+	})
+	return out, nil
+}
+
+// Direction describes which edge endpoints to return from Query.
+type Direction string
+
+const (
+	DirectionOut  Direction = "out"
+	DirectionIn   Direction = "in"
+	DirectionBoth Direction = "both"
+)
+
+// Query filters the coalesced graph to edges touching (kind, slug) in the
+// requested direction. Passing direction="" treats it as DirectionOut.
+func (g *EntityGraph) Query(kind EntityKind, slug string, direction Direction) ([]CoalescedEdge, error) {
+	if direction == "" {
+		direction = DirectionOut
+	}
+	all, err := g.Coalesce()
+	if err != nil {
+		return nil, err
+	}
+	if len(all) == 0 {
+		return nil, nil
+	}
+	out := make([]CoalescedEdge, 0, 16)
+	for _, e := range all {
+		matchOut := e.FromKind == kind && e.FromSlug == slug
+		matchIn := e.ToKind == kind && e.ToSlug == slug
+		switch direction {
+		case DirectionOut:
+			if matchOut {
+				out = append(out, e)
+			}
+		case DirectionIn:
+			if matchIn {
+				out = append(out, e)
+			}
+		case DirectionBoth:
+			if matchOut || matchIn {
+				out = append(out, e)
+			}
+		}
+	}
+	return out, nil
+}

--- a/internal/team/entity_graph_commit.go
+++ b/internal/team/entity_graph_commit.go
@@ -1,0 +1,71 @@
+package team
+
+// entity_graph_commit.go owns the repo-level write that rewrites the
+// cross-entity adjacency log at team/entities/.graph.jsonl. Shares the
+// same single-writer wiki goroutine as fact writes, but uses a dedicated
+// path pattern + commit method because the standard Repo.Commit path only
+// accepts .md extensions.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// CommitEntityGraph writes the full graph log to team/entities/.graph.jsonl
+// and commits under the supplied author slug. Always replace-mode — the
+// EntityGraph builder in entity_graph.go merges existing bytes with the
+// new edges before calling this.
+func (r *Repo) CommitEntityGraph(ctx context.Context, slug, content, message string) (string, int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return "", 0, fmt.Errorf("entity graph commit: author slug is required")
+	}
+	if content == "" {
+		return "", 0, fmt.Errorf("entity graph commit: content is required")
+	}
+
+	clean := filepath.ToSlash(filepath.Clean(EntityGraphPath))
+	fullPath := filepath.Join(r.root, clean)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
+		return "", 0, fmt.Errorf("entity graph commit: mkdir: %w", err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0o600); err != nil {
+		return "", 0, fmt.Errorf("entity graph commit: write: %w", err)
+	}
+
+	if out, err := r.runGitLocked(ctx, slug, "add", "--", clean); err != nil {
+		return "", 0, fmt.Errorf("entity graph commit: git add: %w: %s", err, out)
+	}
+
+	// Byte-identical rewrite → no commit. Report current HEAD.
+	cachedDiff, err := r.runGitLocked(ctx, slug, "diff", "--cached", "--name-only")
+	if err != nil {
+		return "", 0, fmt.Errorf("entity graph commit: git diff --cached: %w", err)
+	}
+	if strings.TrimSpace(cachedDiff) == "" {
+		headSha, herr := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+		if herr != nil {
+			return "", 0, fmt.Errorf("entity graph commit: resolve HEAD: %w", herr)
+		}
+		return strings.TrimSpace(headSha), len(content), nil
+	}
+
+	commitMsg := strings.TrimSpace(message)
+	if commitMsg == "" {
+		commitMsg = "graph: update " + clean
+	}
+	if out, err := r.runGitLocked(ctx, slug, "commit", "-q", "-m", commitMsg); err != nil {
+		return "", 0, fmt.Errorf("entity graph commit: git commit: %w: %s", err, out)
+	}
+	sha, err := r.runGitLocked(ctx, slug, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", 0, fmt.Errorf("entity graph commit: resolve HEAD: %w", err)
+	}
+	return strings.TrimSpace(sha), len(content), nil
+}

--- a/internal/team/entity_graph_test.go
+++ b/internal/team/entity_graph_test.go
@@ -1,0 +1,303 @@
+package team
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newGraphFixture spins up a wiki repo + worker + fact log + graph isolated
+// to t.TempDir(). Returns helpers so tests can assert on repo bytes.
+func newGraphFixture(t *testing.T) (*FactLog, *EntityGraph, *WikiWorker, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+	worker := NewWikiWorker(repo, noopPublisher{})
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	return NewFactLog(worker), NewEntityGraph(worker), worker, func() {
+		cancel()
+		worker.Stop()
+	}
+}
+
+func TestExtractRefs_KindedWikilinks(t *testing.T) {
+	refs := ExtractRefs(EntityKindPeople, "sarah", "Sarah works at [[companies/acme]].", nil)
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1: %#v", len(refs), refs)
+	}
+	if refs[0].Kind != EntityKindCompanies || refs[0].Slug != "acme" {
+		t.Fatalf("wrong ref: %#v", refs[0])
+	}
+}
+
+func TestExtractRefs_SelfReferenceElided(t *testing.T) {
+	refs := ExtractRefs(EntityKindPeople, "sarah", "Sarah is [[people/sarah]]; also [[companies/acme]].", nil)
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1: %#v", len(refs), refs)
+	}
+	if refs[0].Kind != EntityKindCompanies || refs[0].Slug != "acme" {
+		t.Fatalf("wrong ref: %#v", refs[0])
+	}
+}
+
+func TestExtractRefs_Dedupe(t *testing.T) {
+	refs := ExtractRefs(EntityKindPeople, "sarah", "[[companies/acme]] then [[companies/acme]] again.", nil)
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1 (dedup): %#v", len(refs), refs)
+	}
+}
+
+func TestExtractRefs_BareSlugResolved(t *testing.T) {
+	known := func(slug string) (EntityKind, bool) {
+		if slug == "acme" {
+			return EntityKindCompanies, true
+		}
+		return "", false
+	}
+	refs := ExtractRefs(EntityKindPeople, "sarah", "Sarah works at [[acme]].", known)
+	if len(refs) != 1 {
+		t.Fatalf("got %d refs, want 1: %#v", len(refs), refs)
+	}
+	if refs[0].Kind != EntityKindCompanies || refs[0].Slug != "acme" {
+		t.Fatalf("wrong ref: %#v", refs[0])
+	}
+}
+
+func TestExtractRefs_BareSlugAmbiguousSkipped(t *testing.T) {
+	known := func(slug string) (EntityKind, bool) {
+		// Always return false → ambiguous/unknown.
+		return "", false
+	}
+	refs := ExtractRefs(EntityKindPeople, "sarah", "See [[unknown]].", known)
+	if len(refs) != 0 {
+		t.Fatalf("expected no refs; got %#v", refs)
+	}
+}
+
+func TestExtractRefs_KindedAndBareNoDoubleCount(t *testing.T) {
+	known := func(slug string) (EntityKind, bool) {
+		if slug == "acme" {
+			return EntityKindCompanies, true
+		}
+		return "", false
+	}
+	// Both the kinded wikilink and a bare wikilink point at acme — should
+	// not produce two edges.
+	refs := ExtractRefs(EntityKindPeople, "sarah", "[[companies/acme]] and also [[acme]].", known)
+	if len(refs) != 1 {
+		t.Fatalf("expected single ref, got %d: %#v", len(refs), refs)
+	}
+}
+
+func TestRecordFactRefs_WritesEdges(t *testing.T) {
+	factLog, graph, worker, teardown := newGraphFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	fact, err := factLog.Append(ctx, EntityKindPeople, "sarah", "Works at [[companies/acme]]", "", "pm")
+	if err != nil {
+		t.Fatalf("append fact: %v", err)
+	}
+	refs, err := graph.RecordFactRefs(ctx, fact)
+	if err != nil {
+		t.Fatalf("record refs: %v", err)
+	}
+	if len(refs) != 1 || refs[0].Slug != "acme" {
+		t.Fatalf("refs: %#v", refs)
+	}
+
+	full := filepath.Join(worker.Repo().Root(), filepath.FromSlash(EntityGraphPath))
+	bytes, err := os.ReadFile(full)
+	if err != nil {
+		t.Fatalf("read graph: %v", err)
+	}
+	if len(bytes) == 0 {
+		t.Fatal("graph file is empty")
+	}
+
+	edges, err := graph.Coalesce()
+	if err != nil {
+		t.Fatalf("coalesce: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 coalesced edge, got %d", len(edges))
+	}
+	e := edges[0]
+	if e.FromKind != EntityKindPeople || e.FromSlug != "sarah" {
+		t.Errorf("from mismatch: %+v", e)
+	}
+	if e.ToKind != EntityKindCompanies || e.ToSlug != "acme" {
+		t.Errorf("to mismatch: %+v", e)
+	}
+	if e.FirstSeenFactID != fact.ID {
+		t.Errorf("first_seen_fact_id=%q, want %q", e.FirstSeenFactID, fact.ID)
+	}
+}
+
+func TestRecordFactRefs_NoRefsNoWrite(t *testing.T) {
+	factLog, graph, worker, teardown := newGraphFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	fact, err := factLog.Append(ctx, EntityKindPeople, "sarah", "No wikilinks here.", "", "pm")
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	refs, err := graph.RecordFactRefs(ctx, fact)
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Fatalf("expected 0 refs, got %d", len(refs))
+	}
+
+	full := filepath.Join(worker.Repo().Root(), filepath.FromSlash(EntityGraphPath))
+	if _, err := os.Stat(full); !os.IsNotExist(err) {
+		t.Fatalf("graph file should not exist when no refs; err=%v", err)
+	}
+}
+
+func TestEntityGraph_QueryDirections(t *testing.T) {
+	factLog, graph, _, teardown := newGraphFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	fact1, err := factLog.Append(ctx, EntityKindPeople, "sarah", "At [[companies/acme]]", "", "pm")
+	if err != nil {
+		t.Fatalf("append 1: %v", err)
+	}
+	if _, err := graph.RecordFactRefs(ctx, fact1); err != nil {
+		t.Fatalf("refs 1: %v", err)
+	}
+
+	// second fact with a different target, to make sure Query narrows by entity.
+	fact2, err := factLog.Append(ctx, EntityKindCompanies, "acme", "Employs [[people/sarah]]", "", "pm")
+	if err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+	if _, err := graph.RecordFactRefs(ctx, fact2); err != nil {
+		t.Fatalf("refs 2: %v", err)
+	}
+
+	// Out from sarah → acme.
+	out, err := graph.Query(EntityKindPeople, "sarah", DirectionOut)
+	if err != nil {
+		t.Fatalf("query out: %v", err)
+	}
+	if len(out) != 1 || out[0].ToSlug != "acme" {
+		t.Fatalf("unexpected out edges: %#v", out)
+	}
+
+	// In to sarah ← acme.
+	in, err := graph.Query(EntityKindPeople, "sarah", DirectionIn)
+	if err != nil {
+		t.Fatalf("query in: %v", err)
+	}
+	if len(in) != 1 || in[0].FromSlug != "acme" {
+		t.Fatalf("unexpected in edges: %#v", in)
+	}
+
+	// Both from sarah's vantage point.
+	both, err := graph.Query(EntityKindPeople, "sarah", DirectionBoth)
+	if err != nil {
+		t.Fatalf("query both: %v", err)
+	}
+	if len(both) != 2 {
+		t.Fatalf("expected 2 edges both ways, got %d: %#v", len(both), both)
+	}
+}
+
+func TestEntityGraph_CoalesceDedupesMultipleFacts(t *testing.T) {
+	factLog, graph, _, teardown := newGraphFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		fact, err := factLog.Append(ctx, EntityKindPeople, "sarah", "At [[companies/acme]]", "", "pm")
+		if err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+		if _, err := graph.RecordFactRefs(ctx, fact); err != nil {
+			t.Fatalf("refs %d: %v", i, err)
+		}
+		// Tiny separation so LastSeenTS comparisons can differ.
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	edges, err := graph.Coalesce()
+	if err != nil {
+		t.Fatalf("coalesce: %v", err)
+	}
+	if len(edges) != 1 {
+		t.Fatalf("expected 1 coalesced edge, got %d", len(edges))
+	}
+	if edges[0].OccurrenceCount != 3 {
+		t.Fatalf("occurrence_count=%d, want 3", edges[0].OccurrenceCount)
+	}
+}
+
+func TestStripRelatedSection(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no section", "# Title\n\nBody.\n", "# Title\n\nBody.\n"},
+		{
+			"with section",
+			"# Title\n\nBody.\n\n## Related\n\n- [[companies/acme]]\n",
+			"# Title\n\nBody.",
+		},
+		{
+			"case-insensitive",
+			"# X\n\nBody\n\n## related\n- a\n",
+			"# X\n\nBody",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripRelatedSection(tc.in)
+			if got != tc.want {
+				t.Errorf("got %q; want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderRelatedSection_AppendsFromGraph(t *testing.T) {
+	factLog, graph, worker, teardown := newGraphFixture(t)
+	defer teardown()
+	ctx := context.Background()
+
+	fact, err := factLog.Append(ctx, EntityKindPeople, "sarah", "At [[companies/acme]]", "", "pm")
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if _, err := graph.RecordFactRefs(ctx, fact); err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	synth := NewEntitySynthesizer(worker, factLog, nil, SynthesizerConfig{
+		Threshold: 1,
+		Timeout:   2 * time.Second,
+		Graph:     graph,
+		LLMCall: func(ctx context.Context, sys, user string) (string, error) {
+			return "# Sarah\n\nBody.\n", nil
+		},
+	})
+	out := synth.renderRelatedSection(EntityKindPeople, "sarah")
+	if out == "" {
+		t.Fatal("expected Related section, got empty")
+	}
+	if want := "## Related\n\n- [[companies/acme]]\n"; out != want {
+		t.Errorf("got %q; want %q", out, want)
+	}
+}

--- a/internal/team/entity_synthesizer.go
+++ b/internal/team/entity_synthesizer.go
@@ -63,7 +63,17 @@ const MaxBriefSize = 32 * 1024
 // SynthesisPromptSystem is the exact system prompt the worker sends. Wording
 // locked by project_entity_briefs_v1_2.md — do not edit without updating
 // the memo.
-const SynthesisPromptSystem = `You maintain entity briefs in a team wiki. Given an existing brief and new facts, produce an updated markdown brief that incorporates the facts. Never invent facts. Preserve the canonical structure (sections, ordering). Mark contradictions explicitly with **Contradiction:** inline callouts rather than resolving them. Output ONLY the updated markdown, no explanation.`
+//
+// The trailing "## Related" section is managed deterministically by the
+// synthesizer from the cross-entity graph log — never invent related-entity
+// bullets. If the LLM output contains a "## Related" section, it is stripped
+// before the authoritative one is appended.
+const SynthesisPromptSystem = `You maintain entity briefs in a team wiki. Given an existing brief and new facts, produce an updated markdown brief that incorporates the facts. Never invent facts. Preserve the canonical structure (sections, ordering). Mark contradictions explicitly with **Contradiction:** inline callouts rather than resolving them. Do not write a "## Related" section — that block is managed automatically from the cross-entity graph. Output ONLY the updated markdown, no explanation.`
+
+// MaxRelatedEntries bounds the number of "## Related" bullets rendered in a
+// synthesized brief. Ten was the v1 ceiling in the roadmap — enough for a
+// glance, not enough to dominate a narrow article.
+const MaxRelatedEntries = 10
 
 // ErrSynthesisQueueSaturated is returned by EnqueueSynthesis when the
 // buffered channel is full. Callers surface this as a retry-later.
@@ -122,6 +132,12 @@ type SynthesizerConfig struct {
 	// LLMCall is the pluggable shell-out used by tests. Production code
 	// leaves this nil and the worker falls back to provider.RunConfiguredOneShot.
 	LLMCall func(ctx context.Context, systemPrompt, userPrompt string) (string, error)
+
+	// Graph, when non-nil, gives the synthesizer read access to the cross-
+	// entity graph so a trailing "## Related" section can be appended
+	// deterministically after the LLM returns. Passing nil disables the
+	// section — existing briefs stay unchanged.
+	Graph *EntityGraph
 }
 
 // EntitySynthesizer is the broker-level synthesis worker.
@@ -385,6 +401,14 @@ func (s *EntitySynthesizer) synthesize(ctx context.Context, job SynthesisJob) er
 		log.Printf("entity synth: resolve HEAD failed: %v", headErr)
 	}
 
+	// Append the authoritative "## Related" section built from the graph log.
+	// Strip any LLM-generated Related block first so the auto-managed one is
+	// the single source of truth.
+	output = stripRelatedSection(output)
+	if related := s.renderRelatedSection(job.Kind, job.Slug); related != "" {
+		output = strings.TrimRight(output, "\n") + "\n\n" + related
+	}
+
 	now := time.Now().UTC()
 	factCount := len(facts)
 	newBody := applySynthesisFrontmatter(output, headSHA, now, factCount, existingBrief)
@@ -456,6 +480,56 @@ func renderFactsForPrompt(facts []Fact) string {
 		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+// renderRelatedSection builds the "## Related" markdown section from the
+// cross-entity graph, newest-first, capped at MaxRelatedEntries. Returns
+// "" when the graph is unavailable or the entity has no out-edges.
+func (s *EntitySynthesizer) renderRelatedSection(kind EntityKind, slug string) string {
+	if s == nil || s.cfg.Graph == nil {
+		return ""
+	}
+	edges, err := s.cfg.Graph.Query(kind, slug, DirectionOut)
+	if err != nil {
+		log.Printf("entity synth: render Related %s/%s: %v", kind, slug, err)
+		return ""
+	}
+	if len(edges) == 0 {
+		return ""
+	}
+	if len(edges) > MaxRelatedEntries {
+		edges = edges[:MaxRelatedEntries]
+	}
+	var b strings.Builder
+	b.WriteString("## Related\n\n")
+	for _, e := range edges {
+		b.WriteString("- [[")
+		b.WriteString(string(e.ToKind))
+		b.WriteString("/")
+		b.WriteString(e.ToSlug)
+		b.WriteString("]]\n")
+	}
+	return b.String()
+}
+
+// stripRelatedSection removes a trailing "## Related" heading and its
+// contents from body. Case-insensitive match on the heading line. Returns
+// the input unchanged when no Related section is present.
+func stripRelatedSection(body string) string {
+	lines := strings.Split(body, "\n")
+	cutIdx := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.EqualFold(trimmed, "## Related") {
+			cutIdx = i
+			break
+		}
+	}
+	if cutIdx < 0 {
+		return body
+	}
+	// Drop from the heading to EOF — the Related section is always trailing.
+	return strings.TrimRight(strings.Join(lines[:cutIdx], "\n"), "\n")
 }
 
 // Frontmatter helpers live in entity_frontmatter.go.

--- a/internal/team/wiki_worker.go
+++ b/internal/team/wiki_worker.go
@@ -88,6 +88,11 @@ type wikiWriteRequest struct {
 	// the v1.2 append-only fact log at team/entities/{kind}-{slug}.facts.jsonl
 	// — same serialization primitive, non-.md extension, no index regen.
 	IsEntityFact bool
+	// IsEntityGraph routes the request to Repo.CommitEntityGraph. Used for
+	// the cross-entity adjacency log at team/entities/.graph.jsonl.
+	// Same serialization primitive as IsEntityFact — non-.md extension,
+	// no wiki-index regen, no backlinks recompute.
+	IsEntityGraph bool
 	// IsPlaybookCompile routes to Repo.CommitPlaybookSkill — writes the
 	// compiled SKILL.md under team/playbooks/.compiled/{slug}/ without
 	// regenerating the catalog. v1.3 compounding-intelligence compiler.
@@ -259,6 +264,8 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 		sha, n, err = w.repo.CommitHuman(writeCtx, req.Path, req.Content, req.ExpectedSHA, req.CommitMsg)
 	} else if req.IsEntityFact {
 		sha, n, err = w.repo.CommitEntityFact(writeCtx, req.Slug, req.Path, req.Content, req.CommitMsg)
+	} else if req.IsEntityGraph {
+		sha, n, err = w.repo.CommitEntityGraph(writeCtx, req.Slug, req.Content, req.CommitMsg)
 	} else if req.IsPlaybookCompile {
 		sha, n, err = w.repo.CommitPlaybookSkill(writeCtx, req.Slug, req.Path, req.Content, req.CommitMsg)
 	} else if req.IsPlaybookExecution {
@@ -289,6 +296,10 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 	case req.IsEntityFact:
 		// Entity fact writes have their own SSE event (entity:fact_recorded)
 		// published by the broker handler, not by the worker. No-op here.
+	case req.IsEntityGraph:
+		// Graph log appends are internal bookkeeping triggered by fact
+		// writes — no dedicated SSE event. Subscribers that care hear
+		// entity:fact_recorded + refetch the graph read API.
 	case req.IsPlaybookCompile:
 		// Compile writes are internal — no SSE event. The trigger (the
 		// source-article commit) already published wiki:write; emitting a
@@ -448,6 +459,39 @@ func (w *WikiWorker) EnqueueEntityFact(ctx context.Context, slug, path, content,
 		return result.SHA, result.BytesWritten, result.Err
 	case <-waitCtx.Done():
 		return "", 0, fmt.Errorf("wiki: entity-fact write timed out after %s", wikiWriteTimeout)
+	}
+}
+
+// EnqueueEntityGraph submits a full rewrite of the cross-entity adjacency
+// log at team/entities/.graph.jsonl. Same single-writer queue as the fact
+// log; routed to Repo.CommitEntityGraph (which does NOT regen the wiki
+// index or backlinks). Caller (EntityGraph) owns append-merge semantics —
+// the worker just replaces the bytes.
+func (w *WikiWorker) EnqueueEntityGraph(ctx context.Context, slug, content, commitMsg string) (string, int, error) {
+	if !w.running.Load() {
+		return "", 0, ErrWorkerStopped
+	}
+	req := wikiWriteRequest{
+		Slug:          slug,
+		Path:          EntityGraphPath,
+		Content:       content,
+		Mode:          "replace",
+		CommitMsg:     commitMsg,
+		IsEntityGraph: true,
+		ReplyCh:       make(chan wikiWriteResult, 1),
+	}
+	select {
+	case w.requests <- req:
+	default:
+		return "", 0, ErrQueueSaturated
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, wikiWriteTimeout)
+	defer cancel()
+	select {
+	case result := <-req.ReplyCh:
+		return result.SHA, result.BytesWritten, result.Err
+	case <-waitCtx.Done():
+		return "", 0, fmt.Errorf("wiki: entity-graph write timed out after %s", wikiWriteTimeout)
 	}
 }
 

--- a/internal/teammcp/entity_tools.go
+++ b/internal/teammcp/entity_tools.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -34,6 +35,14 @@ type TeamEntityBriefSynthesizeArgs struct {
 	EntitySlug string `json:"entity_slug" jsonschema:"Kebab-case slug."`
 }
 
+// TeamEntityGraphQueryArgs is the contract for entity_graph_query.
+type TeamEntityGraphQueryArgs struct {
+	MySlug     string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	EntityKind string `json:"entity_kind" jsonschema:"One of: people | companies | customers"`
+	EntitySlug string `json:"entity_slug" jsonschema:"Kebab-case slug."`
+	Direction  string `json:"direction,omitempty" jsonschema:"One of: out | in | both. Defaults to 'out' (who this entity mentions)."`
+}
+
 // registerEntityTools attaches the two entity tools to the MCP server.
 // Caller (registerSharedMemoryTools, markdown branch) is responsible for
 // gating on WUPHF_MEMORY_BACKEND.
@@ -46,6 +55,10 @@ func registerEntityTools(server *mcp.Server) {
 		"entity_brief_synthesize",
 		"Explicitly request a fresh synthesis of an entity brief. Runs as a broker-level background job (no agent turn consumed). Use this when you've just recorded several facts and want the canonical brief updated now instead of at the next threshold.",
 	), handleEntityBriefSynthesize)
+	mcp.AddTool(server, readOnlyTool(
+		"entity_graph_query",
+		"Query the cross-entity adjacency graph. Returns every other entity connected to the given (kind, slug) via facts recorded in the team wiki. Use direction=out (default) to see who this entity mentions, direction=in to see who mentions it, direction=both for the full neighbourhood. Newest-first by last-seen timestamp.",
+	), handleEntityGraphQuery)
 }
 
 func handleEntityFactRecord(ctx context.Context, _ *mcp.CallToolRequest, args TeamEntityFactRecordArgs) (*mcp.CallToolResult, any, error) {
@@ -115,6 +128,45 @@ func handleEntityBriefSynthesize(ctx context.Context, _ *mcp.CallToolRequest, ar
 		"actor_slug":  slug,
 	}
 	if err := brokerPostJSON(ctx, "/entity/brief/synthesize", body, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	payload, _ := json.Marshal(result)
+	return textResult(string(payload)), nil, nil
+}
+
+func handleEntityGraphQuery(ctx context.Context, _ *mcp.CallToolRequest, args TeamEntityGraphQueryArgs) (*mcp.CallToolResult, any, error) {
+	if _, err := resolveSlug(args.MySlug); err != nil {
+		return toolError(err), nil, nil
+	}
+	kind := strings.TrimSpace(args.EntityKind)
+	slug := strings.TrimSpace(args.EntitySlug)
+	if kind == "" {
+		return toolError(fmt.Errorf("entity_kind is required")), nil, nil
+	}
+	if slug == "" {
+		return toolError(fmt.Errorf("entity_slug is required")), nil, nil
+	}
+	direction := strings.TrimSpace(args.Direction)
+	if direction == "" {
+		direction = "out"
+	}
+	switch direction {
+	case "out", "in", "both":
+	default:
+		return toolError(fmt.Errorf("direction must be one of out|in|both; got %q", direction)), nil, nil
+	}
+
+	var result struct {
+		Kind      string           `json:"kind"`
+		Slug      string           `json:"slug"`
+		Direction string           `json:"direction"`
+		Edges     []map[string]any `json:"edges"`
+	}
+	query := url.Values{}
+	query.Set("kind", kind)
+	query.Set("slug", slug)
+	query.Set("direction", direction)
+	if err := brokerGetJSON(ctx, "/entity/graph?"+query.Encode(), &result); err != nil {
 		return toolError(err), nil, nil
 	}
 	payload, _ := json.Marshal(result)

--- a/internal/teammcp/entity_tools_test.go
+++ b/internal/teammcp/entity_tools_test.go
@@ -197,8 +197,8 @@ func TestHandleEntityGraphQuery_HappyPath(t *testing.T) {
 func TestHandleEntityGraphQuery_Validation(t *testing.T) {
 	t.Setenv("WUPHF_AGENT_SLUG", "pm")
 	cases := []TeamEntityGraphQueryArgs{
-		{EntitySlug: "x"},                                       // missing kind
-		{EntityKind: "people"},                                  // missing slug
+		{EntitySlug: "x"},      // missing kind
+		{EntityKind: "people"}, // missing slug
 		{EntityKind: "people", EntitySlug: "x", Direction: "?"}, // bad direction
 	}
 	for i, args := range cases {

--- a/internal/teammcp/entity_tools_test.go
+++ b/internal/teammcp/entity_tools_test.go
@@ -141,6 +141,74 @@ func TestHandleEntityBriefSynthesize_HappyPath(t *testing.T) {
 	}
 }
 
+func TestEntityGraphQueryRegistered(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", "markdown")
+	names := listRegisteredTools(t, "general", false)
+	if !slices.Contains(names, "entity_graph_query") {
+		t.Fatalf("entity_graph_query missing; got %v", names)
+	}
+}
+
+func TestHandleEntityGraphQuery_HappyPath(t *testing.T) {
+	var seenQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenQuery = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"kind":      "people",
+			"slug":      "sarah",
+			"direction": "out",
+			"edges": []map[string]any{
+				{
+					"from_kind":          "people",
+					"from_slug":          "sarah",
+					"to_kind":            "companies",
+					"to_slug":            "acme",
+					"first_seen_fact_id": "abc",
+					"last_seen_ts":       "2026-04-21T00:00:00Z",
+					"occurrence_count":   1,
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+
+	res, _, err := handleEntityGraphQuery(context.Background(), nil, TeamEntityGraphQueryArgs{
+		EntityKind: "people",
+		EntitySlug: "sarah",
+		Direction:  "out",
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("tool error: %s", toolErrorText(res))
+	}
+	if !strings.Contains(seenQuery, "kind=people") || !strings.Contains(seenQuery, "slug=sarah") || !strings.Contains(seenQuery, "direction=out") {
+		t.Errorf("unexpected query string: %q", seenQuery)
+	}
+	out := toolErrorText(res)
+	if !strings.Contains(out, "acme") {
+		t.Errorf("missing to_slug in output: %s", out)
+	}
+}
+
+func TestHandleEntityGraphQuery_Validation(t *testing.T) {
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+	cases := []TeamEntityGraphQueryArgs{
+		{EntitySlug: "x"},                                       // missing kind
+		{EntityKind: "people"},                                  // missing slug
+		{EntityKind: "people", EntitySlug: "x", Direction: "?"}, // bad direction
+	}
+	for i, args := range cases {
+		res, _, _ := handleEntityGraphQuery(context.Background(), nil, args)
+		if !isToolError(res) {
+			t.Fatalf("case %d expected tool error; got %s", i, toolErrorText(res))
+		}
+	}
+}
+
 func TestHandleEntityBriefSynthesize_Validation(t *testing.T) {
 	t.Setenv("WUPHF_AGENT_SLUG", "pm")
 	cases := []TeamEntityBriefSynthesizeArgs{

--- a/web/src/api/entity.ts
+++ b/web/src/api/entity.ts
@@ -81,6 +81,25 @@ export interface BriefSynthesizedEvent {
   synthesized_ts: string
 }
 
+export type GraphDirection = 'out' | 'in' | 'both'
+
+export interface GraphEdge {
+  from_kind: EntityKind
+  from_slug: string
+  to_kind: EntityKind
+  to_slug: string
+  first_seen_fact_id: string
+  last_seen_ts: string
+  occurrence_count: number
+}
+
+export interface GraphQueryResponse {
+  kind: EntityKind
+  slug: string
+  direction: GraphDirection
+  edges: GraphEdge[]
+}
+
 // ── HTTP ─────────────────────────────────────────────────────────
 
 /** `GET /entity/facts?kind=&slug=` — newest-first. */
@@ -117,6 +136,28 @@ export function requestBriefSynthesis(
   req: SynthesizeRequest,
 ): Promise<SynthesizeResponse> {
   return post<SynthesizeResponse>('/entity/brief/synthesize', req)
+}
+
+/**
+ * `GET /entity/graph?kind=&slug=&direction=` — returns coalesced edges
+ * touching the given entity. `direction` defaults to `'out'` (who this
+ * entity mentions).
+ */
+export async function fetchEntityGraph(
+  kind: EntityKind,
+  slug: string,
+  direction: GraphDirection = 'out',
+): Promise<GraphEdge[]> {
+  const q = new URLSearchParams({ kind, slug, direction })
+  const res = await get<GraphQueryResponse | { edges?: GraphEdge[] }>(
+    `/entity/graph?${q.toString()}`,
+  )
+  if (!res) return []
+  if (Array.isArray((res as GraphQueryResponse).edges)) {
+    return (res as GraphQueryResponse).edges
+  }
+  const maybe = (res as { edges?: GraphEdge[] }).edges
+  return Array.isArray(maybe) ? maybe : []
 }
 
 // ── SSE ──────────────────────────────────────────────────────────

--- a/web/src/components/wiki/EntityRelatedPanel.test.tsx
+++ b/web/src/components/wiki/EntityRelatedPanel.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import EntityRelatedPanel from './EntityRelatedPanel'
+import * as api from '../../api/entity'
+
+describe('<EntityRelatedPanel>', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(api, 'subscribeEntityEvents').mockImplementation(() => () => {})
+  })
+
+  it('renders the empty state when the graph has no edges', async () => {
+    vi.spyOn(api, 'fetchEntityGraph').mockResolvedValue([])
+    render(<EntityRelatedPanel kind="people" slug="sarah" />)
+    await waitFor(() =>
+      expect(screen.getByText(/No related entities yet/i)).toBeInTheDocument(),
+    )
+    expect(screen.getByRole('heading', { name: /related/i })).toBeInTheDocument()
+  })
+
+  it('lists up to 5 out-edges as wikilinks', async () => {
+    const edges: api.GraphEdge[] = [
+      {
+        from_kind: 'people',
+        from_slug: 'sarah',
+        to_kind: 'companies',
+        to_slug: 'acme',
+        first_seen_fact_id: 'f1',
+        last_seen_ts: '2026-04-20T00:00:00Z',
+        occurrence_count: 2,
+      },
+      {
+        from_kind: 'people',
+        from_slug: 'sarah',
+        to_kind: 'customers',
+        to_slug: 'globex',
+        first_seen_fact_id: 'f2',
+        last_seen_ts: '2026-04-19T00:00:00Z',
+        occurrence_count: 1,
+      },
+    ]
+    vi.spyOn(api, 'fetchEntityGraph').mockResolvedValue(edges)
+    render(<EntityRelatedPanel kind="people" slug="sarah" />)
+    await screen.findByText('companies/acme')
+    expect(screen.getByText('customers/globex')).toBeInTheDocument()
+    // Occurrence count only shown when >1.
+    expect(screen.getByText('×2')).toBeInTheDocument()
+    expect(screen.queryByText('×1')).toBeNull()
+    // Render as a data-wikilink anchor so the wiki router can intercept.
+    const link = screen.getByText('companies/acme').closest('a')
+    expect(link).toHaveAttribute('data-wikilink', 'true')
+    expect(link?.getAttribute('href')).toContain('companies/acme.md')
+  })
+
+  it('caps the list at 5 entries', async () => {
+    const edges: api.GraphEdge[] = Array.from({ length: 8 }, (_v, i) => ({
+      from_kind: 'people' as const,
+      from_slug: 'sarah',
+      to_kind: 'companies' as const,
+      to_slug: `target-${i}`,
+      first_seen_fact_id: `f${i}`,
+      last_seen_ts: `2026-04-2${i}T00:00:00Z`,
+      occurrence_count: 1,
+    }))
+    vi.spyOn(api, 'fetchEntityGraph').mockResolvedValue(edges)
+    render(<EntityRelatedPanel kind="people" slug="sarah" />)
+    await screen.findByText('companies/target-0')
+    expect(screen.getByText('companies/target-4')).toBeInTheDocument()
+    expect(screen.queryByText('companies/target-5')).toBeNull()
+  })
+
+  it('surfaces a load error', async () => {
+    vi.spyOn(api, 'fetchEntityGraph').mockRejectedValue(new Error('boom'))
+    render(<EntityRelatedPanel kind="people" slug="sarah" />)
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
+  })
+})

--- a/web/src/components/wiki/EntityRelatedPanel.tsx
+++ b/web/src/components/wiki/EntityRelatedPanel.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react'
+import {
+  fetchEntityGraph,
+  subscribeEntityEvents,
+  type EntityKind,
+  type GraphEdge,
+} from '../../api/entity'
+
+interface EntityRelatedPanelProps {
+  kind: EntityKind
+  slug: string
+}
+
+const PANEL_LIMIT = 5
+
+/**
+ * EntityRelatedPanel — the v1 list of entities connected to (kind, slug) via
+ * the cross-entity graph. Out-edges only: "this entity mentions → X". Lives
+ * alongside FactsOnFile on wiki entity pages.
+ *
+ * The graph log is append-only and re-reads on every fact_recorded SSE event
+ * for this entity (the refs are parsed server-side). No inbound-edge rendering
+ * in v1 — that ships with the /people/X mentioned-in panel later.
+ */
+export default function EntityRelatedPanel({ kind, slug }: EntityRelatedPanelProps) {
+  const [edges, setEdges] = useState<GraphEdge[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError(null)
+    fetchEntityGraph(kind, slug, 'out')
+      .then((rows) => {
+        if (cancelled) return
+        setEdges(rows)
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : 'Failed to load related entities')
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [kind, slug])
+
+  useEffect(() => {
+    // New facts on this entity can introduce new edges. Refetch the graph on
+    // every fact_recorded to pick them up. Synthesis events do not change
+    // the graph so we ignore them here.
+    const unsubscribe = subscribeEntityEvents(
+      kind,
+      slug,
+      () => {
+        void fetchEntityGraph(kind, slug, 'out')
+          .then(setEdges)
+          .catch(() => {
+            // Keep the current list rather than blanking the panel on a
+            // transient refetch failure.
+          })
+      },
+      () => {},
+    )
+    return unsubscribe
+  }, [kind, slug])
+
+  const visible = edges.slice(0, PANEL_LIMIT)
+
+  return (
+    <aside
+      className="wk-related-panel"
+      aria-labelledby="wk-related-heading"
+      data-testid="wk-related-panel"
+    >
+      <h2 id="wk-related-heading">Related</h2>
+      {loading ? (
+        <p className="wk-related-loading">loading related entities…</p>
+      ) : error ? (
+        <p className="wk-related-error">{error}</p>
+      ) : edges.length === 0 ? (
+        <p className="wk-related-empty">
+          No related entities yet. Wikilinks in recorded facts will connect this
+          page to others.
+        </p>
+      ) : (
+        <ul className="wk-related-items">
+          {visible.map((edge) => {
+            const target = `${edge.to_kind}/${edge.to_slug}`
+            return (
+              <li key={target} className="wk-related-item">
+                <a
+                  className="wk-related-link"
+                  href={`#/wiki/team/${target}.md`}
+                  data-wikilink="true"
+                >
+                  {target}
+                </a>
+                {edge.occurrence_count > 1 && (
+                  <span className="wk-related-count" aria-label="occurrence count">
+                    ×{edge.occurrence_count}
+                  </span>
+                )}
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </aside>
+  )
+}

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -7,6 +7,7 @@ import type { PluggableList } from 'unified'
 import ArticleStatusBanner from './ArticleStatusBanner'
 import EntityBriefBar from './EntityBriefBar'
 import FactsOnFile from './FactsOnFile'
+import EntityRelatedPanel from './EntityRelatedPanel'
 import ImageEmbed from './ImageEmbed'
 import PlaybookExecutionLog from './PlaybookExecutionLog'
 import PlaybookSkillBadge from './PlaybookSkillBadge'
@@ -298,6 +299,9 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
         )}
         {entity && tab === 'article' && (
           <FactsOnFile kind={entity.kind} slug={entity.slug} />
+        )}
+        {entity && tab === 'article' && (
+          <EntityRelatedPanel kind={entity.kind} slug={entity.slug} />
         )}
         {playbook && tab === 'article' && (
           <PlaybookExecutionLog slug={playbook.slug} />

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1503,6 +1503,59 @@
   text-underline-offset: 2px;
 }
 
+/* ─── Cross-entity related panel ─── */
+.wk-related-panel {
+  margin: 24px 0;
+  font-family: var(--wk-body-serif);
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--wk-text);
+}
+.wk-related-panel h2 {
+  font-family: var(--wk-display);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin: 0 0 10px;
+  color: var(--wk-text-muted);
+  border-bottom: 1px solid var(--wk-border);
+  padding-bottom: 6px;
+}
+.wk-related-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.wk-related-item {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 4px 0;
+  border-bottom: 1px dashed var(--wk-border-light);
+}
+.wk-related-item:last-child { border-bottom: none; }
+.wk-related-link {
+  color: var(--wk-wikilink);
+  text-decoration: underline dashed;
+  text-underline-offset: 2px;
+  font-family: var(--wk-mono);
+}
+.wk-related-count {
+  font-family: var(--wk-chrome);
+  font-size: 11px;
+  color: var(--wk-text-tertiary);
+}
+.wk-related-empty,
+.wk-related-loading,
+.wk-related-error {
+  font-family: var(--wk-body-serif);
+  font-style: italic;
+  color: var(--wk-text-tertiary);
+  margin: 0;
+}
+.wk-related-error { color: var(--wk-wikilink-broken); font-style: normal; }
+
 /* ─── Playbook compilation (v1.3) ─── */
 .wk-playbook-badge {
   display: flex;


### PR DESCRIPTION
## Summary
- Parses `[[kind/slug]]` and bare `[[slug]]` wikilinks out of every fact at append time and appends to an append-only adjacency log at `team/entities/.graph.jsonl`. Reader coalesces duplicate edges.
- Extends the brief synthesizer to deterministically append a trailing `## Related` section generated from the graph (top 10 by recency). LLM prompt tells the model not to write that section manually; any Related block it emits is stripped before ours is appended.
- New `GET /entity/graph?kind=&slug=&direction={in,out,both}` endpoint powers a minimal `<EntityRelatedPanel/>` that mounts next to `FactsOnFile` on wiki entity pages (out-edges only in v1, capped at 5, refetches on `entity:fact_recorded`).
- New `entity_graph_query` MCP tool so agents can ask "who's connected to X" without reading the raw jsonl.
- Writes ride the existing WikiWorker via a new `IsEntityGraph` discriminator — same single-writer invariant as `IsEntityFact`, no wiki-index regen.

## Out of scope (per roadmap)
- Fuzzy name resolution (exact-match + wikilinks only).
- Graph visualisation (a list is fine for v1).
- Auto-contradiction detection across edges.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1` (all team + teammcp packages green, including new `entity_graph_test.go` and `broker_entity_graph_test.go`)
- [x] `go test ./internal/team/ -race -run 'EntityGraph|ExtractRefs|RecordFactRefs|StripRelated|RenderRelated'`
- [x] `go vet ./...`
- [x] `cd web && bun run build`
- [x] `cd web && bun run test` (vitest, 241 passed — includes new `EntityRelatedPanel.test.tsx`)
- [ ] Manual: record a fact like `Works at [[companies/acme]]` on `people/sarah` and confirm the Related panel shows `companies/acme` after the next synthesis.

Work worktree: `.worktrees/cross-entity-graph`. Non-overlap respected: no edits to migration, scanner, human-auth, or WikiEditor files; additive-only changes to `broker.go` and `wiki_worker.go`.