### PR TITLE
feat(scan): expand secret catalog + entropy heuristic

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -77,7 +77,11 @@ jobs:
           # noise. Anchored with `(^|/)...$` for bare filenames so that
           # `docs/bun.lock.md` or `tools/package-lock.json.bak` aren't
           # silently skipped. Extensions are anchored with trailing $.
-          EXCLUDE='((^|/)(bun\.lock|package-lock\.json)$|\.(png|jpe?g|gif|ico|woff2?|ttf|eot|svg|pdf)$)'
+          # Also exclude the scanner's own test fixtures — they
+          # deliberately contain structurally-valid secret shapes (Slack
+          # webhook, Postgres URI, etc.) so the scanner under test can
+          # match them. No real secrets live here.
+          EXCLUDE='((^|/)(bun\.lock|package-lock\.json)$|\.(png|jpe?g|gif|ico|woff2?|ttf|eot|svg|pdf)$|^internal/team/scanner[a-z_]*_test\.go$)'
 
           # NUL-delimited end-to-end so filenames with spaces / quotes /
           # backslashes don't get split by xargs later. `git diff -z` and

--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -1,7 +1,13 @@
 {
   "rules": [
     {
-      "id": "@secretlint/secretlint-rule-preset-recommend"
+      "id": "@secretlint/secretlint-rule-preset-recommend",
+      "options": {
+        "allows": [
+          "hooks.slack.com/services/T01234/B9876/abcdef",
+          "postgres://u:hunter2@db/app"
+        ]
+      }
     }
   ]
 }

--- a/internal/team/scanner.go
+++ b/internal/team/scanner.go
@@ -210,15 +210,21 @@ func Scan(
 			result.Skipped++
 			continue
 		}
-		redacted, matches := redactSecrets(string(raw))
-		if matches > maxRedactionsPerFile {
-			fmt.Fprintf(os.Stderr, "scanner: %s skipped — probable secrets file (%d matches)\n", f.AbsolutePath, matches)
+		redaction := redactSecretsDetailed(string(raw))
+		matches := redaction.Matches()
+		if redaction.Poisoned || matches > maxRedactionsPerFile {
+			fmt.Fprintf(
+				os.Stderr,
+				"scanner: %s skipped — probable secrets file (%d matches; %s)\n",
+				f.AbsolutePath, matches, formatRedactionReasons(redaction.Reasons),
+			)
 			result.Skipped++
 			continue
 		}
 		if matches > 0 {
 			result.Redacted++
 		}
+		redacted := redaction.Content
 		dest := filepath.Join(targetDir, safeFilename(f.RelativePath))
 		writeOps = append(writeOps, scanWriteOp{
 			absSource: f.AbsolutePath,

--- a/internal/team/scanner_detector.go
+++ b/internal/team/scanner_detector.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"regexp"
 	"strings"
 )
 
@@ -66,30 +65,132 @@ func (d *MtimeChangeDetector) HasRoot(root string) bool {
 // is treated as a probable secret file and skipped wholesale.
 const maxRedactionsPerFile = 3
 
-// secretPatterns sweep obvious token shapes before ingestion. These are
-// the same patterns documented in the v1.1 eng review. Keep the regexes
-// conservative — false positives are cheap (a [REDACTED] marker in prose)
-// but false negatives can leak credentials into the wiki forever.
-var secretPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`sk-[A-Za-z0-9_-]{20,}`),        // OpenAI-style
-	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),             // AWS access keys
-	regexp.MustCompile(`Bearer [A-Za-z0-9_.=\-]{10,}`), // Bearer tokens
-	regexp.MustCompile(`[A-Z_]+_API_KEY=\S+`),          // env-style keys
-	regexp.MustCompile(`ghp_[A-Za-z0-9]{36}`),          // GitHub PATs
+// RedactionReason records why a particular redaction fired. The scanner
+// surfaces these through the skip log so humans can trace a quarantine
+// back to the exact rule (`pattern: aws-access-key`) or heuristic
+// (`entropy: ~5.43 bits`).
+type RedactionReason struct {
+	// Kind is either "pattern" or "entropy".
+	Kind string
+	// Name is the pattern Name for Kind=="pattern", empty for entropy.
+	Name string
+	// Bits is the measured entropy for Kind=="entropy", 0 for patterns.
+	Bits float64
 }
 
-// redactSecrets returns (redacted, matches). Callers must discard the
-// file entirely when matches > maxRedactionsPerFile.
+// RedactionResult bundles the scrubbed body with everything the caller
+// needs to decide whether to ingest, skip, or log the file.
+type RedactionResult struct {
+	Content string
+	// PatternHits is the number of known-pattern matches redacted.
+	PatternHits int
+	// EntropyHits is the number of entropy-heuristic redactions.
+	EntropyHits int
+	// Poisoned is true when at least one match came from a pattern with
+	// Poison=true — the caller MUST skip the file regardless of count.
+	Poisoned bool
+	// Reasons is ordered by first appearance and deduplicated by Name
+	// (or by a synthetic "entropy" key). Useful for human-readable logs.
+	Reasons []RedactionReason
+}
+
+// Matches is the total of pattern + entropy hits. Kept for symmetry with
+// the old `redactSecrets` return, which callers use to gate the file-
+// level skip.
+func (r RedactionResult) Matches() int {
+	return r.PatternHits + r.EntropyHits
+}
+
+// redactSecrets scrubs known-format tokens first, then sweeps the
+// remainder with the Shannon-entropy heuristic. Returns the redacted
+// content, the total hit count, and a breakdown the caller can log.
+//
+// The two-pass ordering matters: pattern redaction replaces known tokens
+// with `[REDACTED]` markers BEFORE the entropy pass runs, so entropy can
+// never double-count a pattern we already caught. The markers themselves
+// are short and low-entropy so they don't trip the heuristic.
 func redactSecrets(content string) (string, int) {
-	total := 0
+	res := redactSecretsDetailed(content)
+	return res.Content, res.Matches()
+}
+
+// redactSecretsDetailed is the full-fidelity variant. See redactSecrets
+// for the caller-visible summary.
+func redactSecretsDetailed(content string) RedactionResult {
 	out := content
-	for _, re := range secretPatterns {
-		out = re.ReplaceAllStringFunc(out, func(_ string) string {
-			total++
+	var reasons []RedactionReason
+	seenPattern := map[string]struct{}{}
+	patternHits := 0
+	poisoned := false
+
+	// Pass 1: known patterns. Replace each match with `[REDACTED]` and
+	// record the first occurrence of each pattern name.
+	for _, sp := range secretPatterns {
+		p := sp
+		out = p.Pattern.ReplaceAllStringFunc(out, func(_ string) string {
+			patternHits++
+			if p.Poison {
+				poisoned = true
+			}
+			if _, seen := seenPattern[p.Name]; !seen {
+				seenPattern[p.Name] = struct{}{}
+				reasons = append(reasons, RedactionReason{Kind: "pattern", Name: p.Name})
+			}
 			return "[REDACTED]"
 		})
 	}
-	return out, total
+
+	// Pass 2: entropy. Only redact tokens that survived pass 1 — we do
+	// not want to re-flag the `[REDACTED]` marker or anything already
+	// caught. `[REDACTED]` is short enough to miss minCandidateLength
+	// anyway, but we stay defensive by keying off surviving tokens.
+	hits := detectEntropyHits(out)
+	entropyHits := 0
+	entropyReasonRecorded := false
+	for _, h := range hits {
+		// Skip anything that is literally the sentinel marker.
+		if strings.Contains(h.Token, "[REDACTED]") {
+			continue
+		}
+		out = strings.ReplaceAll(out, h.Token, "[REDACTED]")
+		entropyHits++
+		if !entropyReasonRecorded {
+			reasons = append(reasons, RedactionReason{Kind: "entropy", Bits: h.Bits})
+			entropyReasonRecorded = true
+		}
+		if entropyHits >= maxEntropyHitsPerFile {
+			// Stop further entropy redactions; the file-level skip will
+			// catch this once the caller sees Matches() over the cap.
+			break
+		}
+	}
+
+	return RedactionResult{
+		Content:     out,
+		PatternHits: patternHits,
+		EntropyHits: entropyHits,
+		Poisoned:    poisoned,
+		Reasons:     reasons,
+	}
+}
+
+// formatRedactionReasons renders Reasons as a stable, log-friendly
+// string: `pattern: openai, pattern: aws-access-key, entropy: ~5.43 bits`.
+// Empty input yields "unknown" so the log line always has a cause.
+func formatRedactionReasons(reasons []RedactionReason) string {
+	if len(reasons) == 0 {
+		return "unknown"
+	}
+	parts := make([]string, 0, len(reasons))
+	for _, r := range reasons {
+		switch r.Kind {
+		case "pattern":
+			parts = append(parts, fmt.Sprintf("pattern: %s", r.Name))
+		case "entropy":
+			parts = append(parts, fmt.Sprintf("entropy: ~%.2f bits", r.Bits))
+		}
+	}
+	return strings.Join(parts, ", ")
 }
 
 // --- Extension loader ---

--- a/internal/team/scanner_entropy.go
+++ b/internal/team/scanner_entropy.go
@@ -1,0 +1,142 @@
+package team
+
+// scanner_entropy.go provides the Shannon-entropy heuristic the redaction
+// pass uses to catch unknown-format secrets: anything that doesn't match a
+// known pattern but *looks* random enough to be a credential.
+//
+// Positioning: this is the "ML upgrade" per the v1.2 roadmap. A real
+// classifier would be heavier (model weights, entropyTokenizer, per-call cost)
+// than it's worth for a scanner that just has to decide "is this string
+// random-looking"? Shannon entropy over a high-confidence threshold is
+// cheap, dependency-free, and catches base64 / hex secrets that no regex
+// will ever match precisely.
+//
+// Tuning rationale:
+//
+//   - entropyThresholdBits = 4.0 — English prose tops out around 4.1–4.3
+//     bits/char; random base64 lands between 5.5 and 6.0. 4.0 gives us a
+//     margin above prose before flagging.
+//   - minCandidateLength = 20 — below this any short URL fragment or ID
+//     hits the threshold by accident. 20+ is the length range real keys
+//     actually live in.
+//   - tokenBoundary splits on whitespace, quotes, commas, semicolons,
+//     parentheses, and common separators. Keeps multi-token lines from
+//     smearing into a single "low-entropy" clump.
+//
+// What this deliberately does NOT do: train on a corpus, weight by
+// character class, or call out into any embedding model. Those add false
+// confidence and deployment overhead for sub-percent precision gains.
+
+import (
+	"math"
+	"strings"
+	"unicode"
+)
+
+// entropyThresholdBits is the minimum Shannon entropy (in bits per
+// character) that makes a token suspect. English prose is ≤ 4.2 bits;
+// random base64 is ≥ 5.5 bits. 4.0 is a conservative boundary.
+const entropyThresholdBits = 4.0
+
+// minCandidateLength is the shortest token the entropy pass will even
+// consider. Short strings trivially have low-entropy neighborhoods where
+// random-looking noise is indistinguishable from prose.
+const minCandidateLength = 20
+
+// maxEntropyHitsPerFile caps how many entropy-only hits we redact per
+// file. Beyond this we escalate to the file-level skip — the document is
+// almost certainly a machine-generated blob, not prose with a secret.
+const maxEntropyHitsPerFile = 5
+
+// shannonEntropy returns the Shannon entropy of s in bits-per-character,
+// or 0 for the empty string. Computed on byte frequencies (sufficient
+// for catching base64/hex-ish randomness; full rune handling buys us
+// nothing here).
+func shannonEntropy(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	var counts [256]int
+	for i := 0; i < len(s); i++ {
+		counts[s[i]]++
+	}
+	length := float64(len(s))
+	var h float64
+	for _, c := range counts {
+		if c == 0 {
+			continue
+		}
+		p := float64(c) / length
+		h -= p * math.Log2(p)
+	}
+	return h
+}
+
+// entropyTokenize splits s on whitespace and common structural punctuation so
+// each token can be scored independently. A single URL or assignment
+// often has a long boring scheme followed by a high-entropy token — we
+// want to see the token on its own.
+func entropyTokenize(s string) []string {
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		if unicode.IsSpace(r) {
+			return true
+		}
+		switch r {
+		case '"', '\'', '`', ',', ';', '(', ')', '{', '}', '[', ']', '<', '>':
+			return true
+		}
+		return false
+	})
+	return fields
+}
+
+// isPlausibleSecretCharset rejects tokens that can't be credentials
+// (e.g., English words, numeric-only IDs, hyphen-sentence fragments).
+// Real keys use a mix of letters + digits / base64 / hex.
+func isPlausibleSecretCharset(s string) bool {
+	var hasLetter, hasDigit bool
+	for _, r := range s {
+		if unicode.IsLetter(r) {
+			hasLetter = true
+		}
+		if unicode.IsDigit(r) {
+			hasDigit = true
+		}
+		// Bail out early on whitespace / structural runes that would
+		// indicate the entropyTokenizer left junk in.
+		if unicode.IsSpace(r) {
+			return false
+		}
+	}
+	return hasLetter && hasDigit
+}
+
+// EntropyHit reports a single high-entropy token plus its measured bits.
+// Exposed for tests; the main redaction path uses it through the
+// detectEntropyHits helper below.
+type EntropyHit struct {
+	Token string
+	Bits  float64
+}
+
+// detectEntropyHits returns every token in content that crosses the
+// entropy threshold *and* passes the charset plausibility filter. The
+// caller is expected to have already run the pattern catalog so known
+// formats are removed first — we do not want to double-count.
+func detectEntropyHits(content string) []EntropyHit {
+	var hits []EntropyHit
+	for _, tok := range entropyTokenize(content) {
+		if len(tok) < minCandidateLength {
+			continue
+		}
+		if !isPlausibleSecretCharset(tok) {
+			continue
+		}
+		bits := shannonEntropy(tok)
+		if bits < entropyThresholdBits {
+			continue
+		}
+		hits = append(hits, EntropyHit{Token: tok, Bits: bits})
+	}
+	return hits
+}

--- a/internal/team/scanner_entropy_test.go
+++ b/internal/team/scanner_entropy_test.go
@@ -14,10 +14,10 @@ import (
 
 func TestShannonEntropyRangeSanity(t *testing.T) {
 	cases := []struct {
-		name    string
-		input   string
-		wantLo  float64
-		wantHi  float64
+		name   string
+		input  string
+		wantLo float64
+		wantHi float64
 	}{
 		{"empty", "", 0, 0},
 		{"single-char-repeat", strings.Repeat("a", 100), 0, 0.01},

--- a/internal/team/scanner_entropy_test.go
+++ b/internal/team/scanner_entropy_test.go
@@ -1,0 +1,144 @@
+package team
+
+// scanner_entropy_test.go proves the entropy heuristic distinguishes
+// English prose (low entropy) from base64-encoded random bytes (high
+// entropy). Also covers the integration corner cases: sentinel marker
+// immunity, minimum length, and the per-file hit cap.
+
+import (
+	"encoding/base64"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestShannonEntropyRangeSanity(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantLo  float64
+		wantHi  float64
+	}{
+		{"empty", "", 0, 0},
+		{"single-char-repeat", strings.Repeat("a", 100), 0, 0.01},
+		{"two-char-alternating", strings.Repeat("ab", 50), 0.99, 1.01},
+		// "the quick brown fox ..." — English prose lands ~3.7-4.4 bits
+		// depending on character mix. Stays well below random base64
+		// (5.5+), which is what the threshold actually separates.
+		{"prose", "the quick brown fox jumps over the lazy dog repeatedly and carefully", 3.0, 4.5},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := shannonEntropy(tc.input)
+			if got < tc.wantLo || got > tc.wantHi {
+				t.Fatalf("shannonEntropy(%q) = %.3f; want in [%.2f, %.2f]", tc.input, got, tc.wantLo, tc.wantHi)
+			}
+		})
+	}
+}
+
+func TestDetectEntropyHitsIgnoresEnglishProse(t *testing.T) {
+	prose := "The scanner must not flag ordinary prose even when the paragraphs grow long and contain many varied words commas and semicolons; including technical terms like authentication, repository, configuration."
+	hits := detectEntropyHits(prose)
+	if len(hits) != 0 {
+		t.Fatalf("expected no entropy hits on prose, got %+v", hits)
+	}
+}
+
+func TestDetectEntropyHitsFlagsBase64RandomBytes(t *testing.T) {
+	// Deterministic 32 random bytes → base64 ≈ 44 chars, ~5.8+ bits.
+	r := rand.New(rand.NewSource(42))
+	buf := make([]byte, 32)
+	for i := range buf {
+		buf[i] = byte(r.Intn(256))
+	}
+	tok := base64.RawStdEncoding.EncodeToString(buf)
+	// Ensure mixed letters+digits (retry if not).
+	for !hasLetterAndDigit(tok) {
+		for i := range buf {
+			buf[i] = byte(r.Intn(256))
+		}
+		tok = base64.RawStdEncoding.EncodeToString(buf)
+	}
+	body := "Here is a suspicious token: " + tok + " and some trailing prose."
+	hits := detectEntropyHits(body)
+	if len(hits) == 0 {
+		t.Fatalf("expected entropy hit for base64 token %q, got none", tok)
+	}
+	if hits[0].Bits < entropyThresholdBits {
+		t.Fatalf("first hit below threshold: %+v", hits[0])
+	}
+	if !strings.Contains(hits[0].Token, tok) {
+		t.Fatalf("expected hit token to contain %q, got %q", tok, hits[0].Token)
+	}
+}
+
+func TestDetectEntropyHitsRespectsMinLength(t *testing.T) {
+	// 19-char random-ish token should not be flagged (below minCandidateLength).
+	body := "short: a1B2c3D4e5F6g7H8i9j"
+	if len(strings.Fields(body)[1]) >= minCandidateLength {
+		t.Skip("test fixture is not actually below the minimum length")
+	}
+	hits := detectEntropyHits(body)
+	if len(hits) != 0 {
+		t.Fatalf("expected no hits below minCandidateLength, got %+v", hits)
+	}
+}
+
+func TestRedactSecretsEntropyTopsUpBeyondPatterns(t *testing.T) {
+	// A random-looking assignment that doesn't match any known pattern.
+	// Use a high-entropy token: base64 of 40 random bytes.
+	r := rand.New(rand.NewSource(7))
+	buf := make([]byte, 40)
+	for i := range buf {
+		buf[i] = byte(r.Intn(256))
+	}
+	tok := base64.RawStdEncoding.EncodeToString(buf)
+	body := "custom_signing_key=" + tok + "\nOrdinary prose follows."
+	res := redactSecretsDetailed(body)
+	if res.EntropyHits == 0 {
+		t.Fatalf("expected at least one entropy hit on %q, got %+v", tok, res)
+	}
+	if !strings.Contains(res.Content, "[REDACTED]") {
+		t.Fatalf("expected [REDACTED] marker in scrubbed body: %q", res.Content)
+	}
+	sawEntropy := false
+	for _, r := range res.Reasons {
+		if r.Kind == "entropy" {
+			sawEntropy = true
+			if r.Bits < entropyThresholdBits {
+				t.Fatalf("recorded entropy below threshold: %+v", r)
+			}
+		}
+	}
+	if !sawEntropy {
+		t.Fatalf("expected an entropy reason, got %+v", res.Reasons)
+	}
+}
+
+func TestEntropyDoesNotReFlagRedactionMarker(t *testing.T) {
+	// After pattern redaction replaces a long token with `[REDACTED]`,
+	// the marker itself must not become a new entropy hit. The marker
+	// is short (shorter than minCandidateLength), so this is already
+	// structurally impossible — but lock it in.
+	in := "OPENAI_API_KEY=sk-" + strings.Repeat("Z", 40)
+	res := redactSecretsDetailed(in)
+	if res.EntropyHits != 0 {
+		t.Fatalf("expected zero entropy hits after pattern redaction, got %+v", res)
+	}
+}
+
+// hasLetterAndDigit is a tiny helper — keeps TestDetectEntropyHitsFlagsBase64
+// deterministic even if RNG happens to yield an all-alpha encoding.
+func hasLetterAndDigit(s string) bool {
+	var hasL, hasD bool
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' {
+			hasL = true
+		}
+		if r >= '0' && r <= '9' {
+			hasD = true
+		}
+	}
+	return hasL && hasD
+}

--- a/internal/team/scanner_patterns.go
+++ b/internal/team/scanner_patterns.go
@@ -1,0 +1,183 @@
+package team
+
+// scanner_patterns.go is the exhaustive secret-shape catalog used by the
+// scanner's redaction pass. Each entry carries a stable Name so the human-
+// facing skip log can say *why* a file was quarantined (`pattern: aws-akia`
+// beats an anonymous regex hit every time).
+//
+// The catalog is grouped by source — AI vendors, cloud providers, payment
+// processors, SSH/crypto material, JWT, and database URIs. Adding a new
+// shape is a one-liner: append a SecretPattern and add a positive + near-
+// miss case to scanner_patterns_test.go.
+//
+// Conservative-by-default rule of thumb: false positives cost one
+// [REDACTED] marker in prose. False negatives leak credentials into a
+// git-backed wiki forever. When in doubt, match.
+
+import "regexp"
+
+// SecretPattern pairs a stable identifier with its detection regex. The
+// Name is surfaced in the skip-log so humans can trace a redaction back
+// to the specific rule that fired.
+//
+// A Poison pattern triggers the file-level skip on the first hit,
+// regardless of the per-file match cap. Use it for shapes where even a
+// single occurrence is sufficient evidence of a secret-bearing file
+// (PEM private key armor, GCP service-account JSON, etc.) — the
+// surrounding body is almost certainly dangerous to ingest.
+type SecretPattern struct {
+	Name    string
+	Pattern *regexp.Regexp
+	Poison  bool
+}
+
+// secretPatterns is the full catalog. Order is not meaningful — every
+// pattern is evaluated on every pass. Keep patterns anchored tightly
+// enough that they do not eat surrounding prose.
+//
+// Sources referenced during construction:
+//   - OpenAI, Anthropic, Google, HuggingFace token format docs
+//   - AWS IAM key-id reference (AKIA / ASIA / AGPA / AIPA prefixes)
+//   - Stripe API key format (sk_live, pk_live, rk_live, sk_test, pk_test)
+//   - Slack API token format (xoxb, xoxp, xoxa, xoxr, xoxs)
+//   - OpenSSH and PEM-encoded private key armor
+//   - RFC 7519 JWT compact serialization (three base64url segments)
+//   - libpq / MongoDB connection string syntax with embedded credentials
+//   - gitleaks rules.toml (pattern shapes adopted, binary NOT required)
+var secretPatterns = []SecretPattern{
+	// --- AI vendors ---
+
+	// OpenAI legacy + project-scoped keys. `sk-` is shared across many
+	// vendors, so the length floor keeps this from eating short test
+	// tokens like `sk-test`. Project keys carry a `sk-proj-` prefix but
+	// match the same parent pattern; catalogued separately for clarity.
+	{Name: "openai", Pattern: regexp.MustCompile(`sk-(?:proj-)?[A-Za-z0-9_-]{20,}`)},
+
+	// Anthropic public-API keys. `sk-ant-` prefix is unique, followed by
+	// a long opaque body. Keep the length floor generous — Anthropic has
+	// rotated the body format before.
+	{Name: "anthropic", Pattern: regexp.MustCompile(`sk-ant-[A-Za-z0-9_-]{20,}`)},
+
+	// HuggingFace user-access tokens. `hf_` prefix + 30+ chars. Distinct
+	// from HF write tokens which share the format.
+	{Name: "huggingface", Pattern: regexp.MustCompile(`hf_[A-Za-z0-9]{30,}`)},
+
+	// Google Cloud / Gemini API keys. `AIza` prefix + exactly 35 chars.
+	// The length anchor keeps this from matching AWS AKIA-ish prose.
+	{Name: "google-api", Pattern: regexp.MustCompile(`AIza[0-9A-Za-z_-]{35}`)},
+
+	// --- Cloud providers ---
+
+	// AWS access-key IDs — AKIA (long-lived user), ASIA (STS temporary),
+	// AGPA (group), AIPA (instance profile), ANPA (managed policy), AROA
+	// (role), AIDA (user), ABIA (bucket). All 20 chars total.
+	{Name: "aws-access-key", Pattern: regexp.MustCompile(`\b(?:AKIA|ASIA|AGPA|AIPA|ANPA|AROA|AIDA|ABIA)[0-9A-Z]{16}\b`)},
+
+	// AWS secret keys have no fixed prefix, only a 40-char base64-ish
+	// body that follows an `aws_secret_access_key` assignment. Catching
+	// the assignment form keeps false positives low.
+	{Name: "aws-secret", Pattern: regexp.MustCompile(`(?i)aws_secret_access_key\s*[:=]\s*["']?[A-Za-z0-9/+=]{40}["']?`), Poison: true},
+
+	// Google service-account JSON private keys ship as a multi-line
+	// string with escaped newlines. Match the `"type": "service_account"`
+	// marker — finding it inline is a near-certain leak.
+	{Name: "gcp-service-account", Pattern: regexp.MustCompile(`"type"\s*:\s*"service_account"`), Poison: true},
+
+	// Azure storage connection strings carry `AccountKey=<base64>;` and
+	// are frequently pasted whole into docs.
+	{Name: "azure-storage", Pattern: regexp.MustCompile(`AccountKey=[A-Za-z0-9+/]{86}==`)},
+
+	// --- Source control + CI ---
+
+	// GitHub personal-access tokens (classic, 40 chars), fine-grained
+	// PATs (`github_pat_`), OAuth tokens (`gho_`), user-to-server
+	// (`ghu_`), server-to-server (`ghs_`), refresh tokens (`ghr_`).
+	{Name: "github-classic", Pattern: regexp.MustCompile(`ghp_[A-Za-z0-9]{36}`)},
+	{Name: "github-fine-grained", Pattern: regexp.MustCompile(`github_pat_[A-Za-z0-9_]{82}`)},
+	{Name: "github-oauth", Pattern: regexp.MustCompile(`gho_[A-Za-z0-9]{36}`)},
+	{Name: "github-user-server", Pattern: regexp.MustCompile(`ghu_[A-Za-z0-9]{36}`)},
+	{Name: "github-server-server", Pattern: regexp.MustCompile(`ghs_[A-Za-z0-9]{36}`)},
+	{Name: "github-refresh", Pattern: regexp.MustCompile(`ghr_[A-Za-z0-9]{36}`)},
+
+	// GitLab personal-access tokens carry a `glpat-` prefix + 20 chars.
+	{Name: "gitlab-pat", Pattern: regexp.MustCompile(`glpat-[A-Za-z0-9_-]{20}`)},
+
+	// --- Payment processors ---
+
+	// Stripe secret (live + test) keys. `rk_` is the restricted variant;
+	// it carries the same risk. `pk_live_` is publishable but disclosing
+	// it still signals account linkage so we redact it too.
+	{Name: "stripe-secret-live", Pattern: regexp.MustCompile(`sk_live_[A-Za-z0-9]{24,}`)},
+	{Name: "stripe-restricted-live", Pattern: regexp.MustCompile(`rk_live_[A-Za-z0-9]{24,}`)},
+	{Name: "stripe-publishable-live", Pattern: regexp.MustCompile(`pk_live_[A-Za-z0-9]{24,}`)},
+	{Name: "stripe-secret-test", Pattern: regexp.MustCompile(`sk_test_[A-Za-z0-9]{24,}`)},
+	{Name: "stripe-publishable-test", Pattern: regexp.MustCompile(`pk_test_[A-Za-z0-9]{24,}`)},
+
+	// Square access tokens carry an `EAAA` prefix + 60+ chars of base64.
+	{Name: "square-access", Pattern: regexp.MustCompile(`EAAA[A-Za-z0-9_-]{60,}`)},
+
+	// --- Messaging / comms ---
+
+	// Slack bot (xoxb), user (xoxp), app-level (xoxa), refresh (xoxr),
+	// workspace (xoxs) and legacy (xoxe) tokens. The suffix varies in
+	// length; 10+ chars is the conservative floor.
+	{Name: "slack-token", Pattern: regexp.MustCompile(`xox[baprse]-[A-Za-z0-9-]{10,}`)},
+
+	// Slack incoming-webhook URLs are effectively bearer tokens.
+	{Name: "slack-webhook", Pattern: regexp.MustCompile(`https://hooks\.slack\.com/services/T[A-Za-z0-9]+/B[A-Za-z0-9]+/[A-Za-z0-9]+`)},
+
+	// Discord bot tokens are three dot-separated base64 segments.
+	{Name: "discord-bot", Pattern: regexp.MustCompile(`[MN][A-Za-z0-9_-]{23}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}`)},
+
+	// Twilio account SID (`AC` + 32 hex) plus its auth-token sibling.
+	{Name: "twilio-sid", Pattern: regexp.MustCompile(`\bAC[0-9a-fA-F]{32}\b`)},
+
+	// SendGrid API keys.
+	{Name: "sendgrid", Pattern: regexp.MustCompile(`SG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}`)},
+
+	// --- SSH and crypto material ---
+
+	// Any PEM-armored private-key block. OpenSSH, RSA, DSA, EC, PGP,
+	// and encrypted variants all share the `-----BEGIN ... PRIVATE KEY`
+	// line. Presence of even one is a quarantine trigger.
+	{Name: "pem-private-key", Pattern: regexp.MustCompile(`-----BEGIN (?:OPENSSH|RSA|DSA|EC|ENCRYPTED|PGP)? ?PRIVATE KEY-----`), Poison: true},
+
+	// Putty .ppk header.
+	{Name: "ppk-private-key", Pattern: regexp.MustCompile(`PuTTY-User-Key-File-[23]:`), Poison: true},
+
+	// --- Auth / session ---
+
+	// JWT compact serialization: three base64url segments separated by
+	// dots, starting with an `eyJ` (a base64-encoded `{"`). Requires a
+	// body segment of meaningful length to avoid eating short prose.
+	{Name: "jwt", Pattern: regexp.MustCompile(`eyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}`)},
+
+	// Generic Bearer tokens in an HTTP Authorization header.
+	{Name: "bearer", Pattern: regexp.MustCompile(`Bearer [A-Za-z0-9_.=\-]{10,}`)},
+
+	// Any `*_API_KEY=...` or `*_SECRET=...` env-style assignment. Broad
+	// and noisy, but the file-level threshold keeps it from clobbering
+	// legitimate docs about env-var naming.
+	{Name: "env-api-key", Pattern: regexp.MustCompile(`[A-Z][A-Z0-9_]*_API_KEY\s*=\s*\S+`)},
+	{Name: "env-secret", Pattern: regexp.MustCompile(`[A-Z][A-Z0-9_]*_SECRET\s*=\s*\S+`)},
+	{Name: "env-token", Pattern: regexp.MustCompile(`[A-Z][A-Z0-9_]*_TOKEN\s*=\s*\S+`)},
+
+	// --- Database URIs with embedded credentials ---
+
+	// Postgres / PostgreSQL URI with user:pass@host. The password group
+	// is the sensitive bit; match the whole URI for context.
+	{Name: "postgres-uri", Pattern: regexp.MustCompile(`postgres(?:ql)?://[^\s:/@]+:[^\s@]+@[^\s/]+`)},
+
+	// MySQL connection URI.
+	{Name: "mysql-uri", Pattern: regexp.MustCompile(`mysql://[^\s:/@]+:[^\s@]+@[^\s/]+`)},
+
+	// MongoDB URI — both `mongodb://` and SRV `mongodb+srv://`.
+	{Name: "mongodb-uri", Pattern: regexp.MustCompile(`mongodb(?:\+srv)?://[^\s:/@]+:[^\s@]+@[^\s/]+`)},
+
+	// Redis URI (both plain and TLS).
+	{Name: "redis-uri", Pattern: regexp.MustCompile(`rediss?://[^\s:/@]*:[^\s@]+@[^\s/]+`)},
+
+	// Generic `password=...` and `passwd=...` assignments inside URLs
+	// or config blobs. Narrow enough to require quotes or `&`/`;`.
+	{Name: "inline-password", Pattern: regexp.MustCompile(`(?i)["']?(?:password|passwd|pwd)["']?\s*[:=]\s*["'][^"'\s]{6,}["']`)},
+}

--- a/internal/team/scanner_patterns_test.go
+++ b/internal/team/scanner_patterns_test.go
@@ -1,0 +1,129 @@
+package team
+
+// scanner_patterns_test.go asserts one positive hit + one near-miss per
+// named pattern in the secretPatterns catalog. "Near-miss" strings are
+// the kind of prose or IDs that a naive regex would eat if the pattern
+// were looser — keeping them here as regression anchors.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSecretPatternsPositiveAndNearMiss(t *testing.T) {
+	// Helper for building long GitHub-style 36-char bodies.
+	rep := func(c string, n int) string { return strings.Repeat(c, n) }
+
+	cases := []struct {
+		pattern string
+		hit     string
+		miss    string
+	}{
+		// AI vendors
+		{"openai", "api=sk-" + rep("A", 30), "note: sk-ip or sk-prefixed short"},
+		{"anthropic", "key=sk-ant-" + rep("X", 40), "sk-ant (too short, no body)"},
+		{"huggingface", "token=hf_" + rep("b", 34), "hf_short"},
+		{"google-api", "key=AIza" + rep("C", 35), "AIza short"},
+		// Cloud
+		{"aws-access-key", "id=AKIAIOSFODNN7EXAMPLE end", "AKIA is a word sometimes"},
+		{"aws-secret", `aws_secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"`, "aws_secret_access_key mentioned in prose"},
+		{"gcp-service-account", `{"type": "service_account"}`, `"type": "user"`},
+		{"azure-storage", "AccountKey=" + rep("a", 86) + "==", "AccountKey=short=="},
+		// Source control + CI
+		{"github-classic", "token=ghp_" + rep("a", 36), "ghp_short"},
+		{"github-fine-grained", "token=github_pat_" + rep("z", 82), "github_pat_abc"},
+		{"github-oauth", "gho_" + rep("a", 36), "gho_short"},
+		{"github-user-server", "ghu_" + rep("a", 36), "ghu_short"},
+		{"github-server-server", "ghs_" + rep("a", 36), "ghs_short"},
+		{"github-refresh", "ghr_" + rep("a", 36), "ghr_short"},
+		{"gitlab-pat", "token=glpat-" + rep("y", 20), "glpat-short"},
+		// Payment
+		{"stripe-secret-live", "key=sk_live_" + rep("a", 24), "sk_live_ short"},
+		{"stripe-restricted-live", "key=rk_live_" + rep("a", 24), "rk_live_ short"},
+		{"stripe-publishable-live", "key=pk_live_" + rep("a", 24), "pk_live_ short"},
+		{"stripe-secret-test", "key=sk_test_" + rep("a", 24), "sk_test_ short"},
+		{"stripe-publishable-test", "key=pk_test_" + rep("a", 24), "pk_test_ short"},
+		{"square-access", "EAAA" + rep("z", 60), "EAAA short"},
+		// Messaging
+		{"slack-token", "xoxb-" + rep("1", 20), "xox-prefix (malformed)"},
+		{"slack-webhook", "https://hooks.slack.com/services/T01234/B9876/abcdef", "https://hooks.slack.com/docs"},
+		{"discord-bot", "M" + rep("a", 23) + ".abcdef." + rep("z", 30), "M.abcdef.zzz"},
+		{"twilio-sid", "sid=AC" + rep("a", 32), "ACmentioned"},
+		{"sendgrid", "SG." + rep("a", 22) + "." + rep("b", 43), "SG.short"},
+		// SSH / crypto
+		{"pem-private-key", "-----BEGIN OPENSSH PRIVATE KEY-----", "BEGIN PUBLIC KEY mentioned"},
+		{"ppk-private-key", "PuTTY-User-Key-File-2:", "PuTTY-User-Key-File reference"},
+		// Auth / session
+		{"jwt", "token=eyJ" + rep("a", 20) + ".eyJ" + rep("b", 20) + "." + rep("c", 20), "eyJ.short"},
+		{"bearer", "Authorization: Bearer abc.def-012=345", "bearer in lowercase prose"},
+		{"env-api-key", "STRIPE_API_KEY=sk_live_whatever", "API_KEY by itself"},
+		{"env-secret", "DB_SECRET=abcdef", "SECRET mentioned in prose"},
+		{"env-token", "OAUTH_TOKEN=abc123", "TOKEN mentioned in prose"},
+		// DB URIs
+		{"postgres-uri", "DATABASE_URL=postgres://user:pass@host/db", "postgres://host/db (no creds)"},
+		{"mysql-uri", "DATABASE_URL=mysql://u:p@host/db", "mysql://host/db"},
+		{"mongodb-uri", "MONGO=mongodb+srv://u:p@cluster.mongodb.net/db", "mongodb://localhost"},
+		{"redis-uri", "REDIS=redis://:pw@host:6379", "redis://localhost:6379"},
+		{"inline-password", `cfg = {"password": "hunter2!!"}`, "password field: not set"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.pattern, func(t *testing.T) {
+			// Find the pattern in the catalog.
+			var found *SecretPattern
+			for i := range secretPatterns {
+				if secretPatterns[i].Name == tc.pattern {
+					found = &secretPatterns[i]
+					break
+				}
+			}
+			if found == nil {
+				t.Fatalf("pattern %q not in catalog", tc.pattern)
+			}
+			if !found.Pattern.MatchString(tc.hit) {
+				t.Errorf("expected hit for %q in %q", tc.pattern, tc.hit)
+			}
+			if found.Pattern.MatchString(tc.miss) {
+				t.Errorf("unexpected hit for %q in near-miss %q", tc.pattern, tc.miss)
+			}
+		})
+	}
+}
+
+func TestRedactSecretsDetailedRecordsReasons(t *testing.T) {
+	in := "Authorization: Bearer abcdef012345\n" +
+		"OPENAI_API_KEY=sk-" + strings.Repeat("a", 30) + "\n" +
+		"plain prose line"
+	res := redactSecretsDetailed(in)
+	if res.PatternHits == 0 {
+		t.Fatalf("expected pattern hits, got 0. result=%+v", res)
+	}
+	if !strings.Contains(res.Content, "[REDACTED]") {
+		t.Fatalf("expected [REDACTED] in scrubbed body, got %q", res.Content)
+	}
+	names := map[string]bool{}
+	for _, r := range res.Reasons {
+		if r.Kind == "pattern" {
+			names[r.Name] = true
+		}
+	}
+	if !names["bearer"] {
+		t.Errorf("expected a 'bearer' reason, got %+v", res.Reasons)
+	}
+}
+
+func TestFormatRedactionReasonsStableOutput(t *testing.T) {
+	reasons := []RedactionReason{
+		{Kind: "pattern", Name: "openai"},
+		{Kind: "pattern", Name: "aws-access-key"},
+		{Kind: "entropy", Bits: 5.43},
+	}
+	got := formatRedactionReasons(reasons)
+	want := "pattern: openai, pattern: aws-access-key, entropy: ~5.43 bits"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+	if formatRedactionReasons(nil) != "unknown" {
+		t.Fatalf("nil reasons should render as 'unknown'")
+	}
+}

--- a/internal/team/scanner_test.go
+++ b/internal/team/scanner_test.go
@@ -562,6 +562,65 @@ func TestScannerHasRootMatchesSubpaths(t *testing.T) {
 	}
 }
 
+// Integration: a fixture root containing a pem file + secrets.env
+// alongside innocent markdown. Only the markdown should survive to the
+// ingested set — the secret-bearing files must be skipped wholesale.
+//
+// We deliberately keep the test in scanner_test.go (not patterns_test.go)
+// so the full Scan flow is exercised end to end.
+func TestScannerScanFixtureOnlyIngestsInnocentMarkdown(t *testing.T) {
+	// Extend the default allowlist so .pem and .env are discovered by
+	// the walker. Without this, the extension allowlist alone would
+	// silently filter them out and we'd claim a win we didn't earn.
+	t.Setenv("WUPHF_SCAN_EXTENSIONS", "md,pem,env")
+
+	pemBody := "-----BEGIN OPENSSH PRIVATE KEY-----\n" +
+		strings.Repeat("AAAAB3NzaC1yc2EAAAADAQABAAABAQ", 4) + "\n" +
+		"-----END OPENSSH PRIVATE KEY-----\n"
+	envBody := strings.Join([]string{
+		"OPENAI_API_KEY=sk-" + strings.Repeat("a", 40),
+		"ANTHROPIC_API_KEY=sk-ant-" + strings.Repeat("b", 40),
+		"STRIPE_SECRET=sk_live_" + strings.Repeat("c", 40),
+		"GITHUB_TOKEN=ghp_" + strings.Repeat("d", 36),
+		"DATABASE_URL=postgres://u:hunter2@db/app",
+	}, "\n")
+	innocent := "# Onboarding\n\nWelcome to the team. Read the runbook and say hi in #general.\n"
+
+	root := setupRoot(t, map[string]string{
+		"id_rsa.pem":  pemBody,
+		"secrets.env": envBody,
+		"welcome.md":  innocent,
+	})
+	wiki := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	det, err := NewMtimeChangeDetector()
+	if err != nil {
+		t.Fatalf("detector: %v", err)
+	}
+	commit := func(_ context.Context, _, _ string) (string, error) { return "sha", nil }
+	res, _, err := Scan(context.Background(), ScanOptions{Root: root, Confirm: true}, det, wiki, commit)
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if res.Ingested != 1 {
+		t.Fatalf("expected exactly one file ingested (welcome.md), got %+v", res)
+	}
+	if res.Skipped < 2 {
+		t.Fatalf("expected at least two skipped (pem + env), got %+v", res)
+	}
+	// Confirm the ingested file is the innocent markdown by filename.
+	if len(res.IngestedPath) != 1 || !strings.Contains(res.IngestedPath[0], "welcome.md") {
+		t.Fatalf("expected welcome.md in IngestedPath, got %+v", res.IngestedPath)
+	}
+	body, err := os.ReadFile(res.IngestedPath[0])
+	if err != nil {
+		t.Fatalf("read ingested: %v", err)
+	}
+	if strings.Contains(string(body), "BEGIN OPENSSH") || strings.Contains(string(body), "sk_live_") {
+		t.Fatalf("ingested file leaked secret content: %q", body)
+	}
+}
+
 // Verify the mtime-based detector treats a touched file as changed.
 func TestScannerMtimeDetectsModification(t *testing.T) {
 	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())


### PR DESCRIPTION
## Summary

Upgrades the scanner's secret-redaction from five regexes to a ~35-pattern catalog plus a Shannon-entropy heuristic for unknown-format keys.

- **Pattern catalog** (`internal/team/scanner_patterns.go`): named patterns grouped by source — AI vendors (OpenAI, Anthropic, HuggingFace, Google), cloud (AWS AKIA/ASIA/AGPA/AIPA/ANPA/AROA/AIDA/ABIA, AWS secret, GCP service-account, Azure storage), source control (GitHub classic/fine-grained/OAuth/user-server/server-server/refresh, GitLab PAT), payment (Stripe live/test secret+publishable+restricted, Square), messaging (Slack tokens + webhooks, Discord, Twilio, SendGrid), SSH/crypto (PEM, PuTTY .ppk), auth (JWT, Bearer, env-style `*_API_KEY`/`*_SECRET`/`*_TOKEN`), and DB URIs (postgres, mysql, mongodb, redis, inline password).
- **Poison patterns** — PEM armor, GCP service-account JSON, AWS secret assignments, and `.ppk` headers trigger a wholesale file skip on first match. A single `-----BEGIN OPENSSH PRIVATE KEY-----` is not a "redact one line and move on" situation.
- **Entropy heuristic** (`internal/team/scanner_entropy.go`): after the pattern pass, any surviving token >= 20 chars that mixes letters+digits and crosses 4.0 bits/char Shannon entropy gets redacted. English prose caps near 4.3 bits; base64-encoded random bytes land 5.5+, leaving a safe margin.
- **Skip log** now reports the reason — `pattern: aws-access-key`, `entropy: ~5.43 bits` — so humans can trace a quarantine back to the specific rule.
- Kept pure-Go, no gitleaks binary dependency. Pattern shapes adopted from gitleaks rules, implementation is ours.

## Test plan

- [x] `go build ./...` green
- [x] `go vet ./...` green
- [x] `go test ./internal/team -run 'Scanner|Secret|Entropy|Redact' -count=1` — all new + existing tests pass
- [x] Full `go test ./...` — team pkg passes in isolation; one pre-existing flaky playbook test unrelated to scanner
- [x] One positive + one near-miss per named pattern (35 subtests)
- [x] Shannon entropy: prose (3.7-4.3 bits) vs base64 random bytes (5.5+ bits) cleanly separated
- [x] Fixture integration: root with `id_rsa.pem` + `secrets.env` + `welcome.md` — only `welcome.md` ingested, both secret files skipped with reasons logged
- [x] Marker immunity: `[REDACTED]` sentinel not re-flagged by entropy pass
- [ ] Manual smoke with a real secrets-heavy repo before merging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added entropy-based detection to identify high-entropy tokens as potential secrets
  * Implemented enhanced redaction with structured reason reporting for better transparency
  * Introduced file quarantine mechanism that skips files containing high-confidence secrets
  * Added configuration allowlisting to whitelist known safe patterns from scanning

* **Bug Fixes**
  * Improved filtering to exclude test fixture files from secret scanning, reducing false positives

* **Tests**
  * Expanded test coverage for secret detection and redaction workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->