### PR TITLE
feat(wiki): per-human git identities for editable wiki

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -1214,6 +1214,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/memory", b.requireAuth(b.handleMemory))
 	mux.HandleFunc("/wiki/write", b.requireAuth(b.handleWikiWrite))
 	mux.HandleFunc("/wiki/write-human", b.requireAuth(b.handleWikiWriteHuman))
+	mux.HandleFunc("/humans", b.requireAuth(b.handleHumans))
 	mux.HandleFunc("/wiki/read", b.requireAuth(b.handleWikiRead))
 	mux.HandleFunc("/wiki/search", b.requireAuth(b.handleWikiSearch))
 	mux.HandleFunc("/wiki/list", b.requireAuth(b.handleWikiList))

--- a/internal/team/broker_human.go
+++ b/internal/team/broker_human.go
@@ -1,0 +1,173 @@
+package team
+
+// broker_human.go owns the HTTP surface for per-human wiki authoring
+// (v1.5 hardening of PR #192). Two endpoints:
+//
+//	POST /wiki/write-human   — save a human edit, optimistic concurrency
+//	GET  /humans             — list registered human identities
+//
+// Both flow through the existing broker bearer-token middleware, same
+// as every other /wiki/* endpoint.
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// humanIdentityRegistry is the process-wide registry the broker uses to
+// resolve per-human git identities at `/wiki/write-human` time. It is
+// lazy-initialized on first use to avoid probing `git config` before
+// the broker is actually serving requests.
+var (
+	humanIdentityRegistryOnce sync.Once
+	humanIdentityRegistrySvc  *HumanIdentityRegistry
+)
+
+// brokerHumanIdentityRegistry returns the shared registry. Exported only
+// through this helper so tests can swap it by calling
+// setHumanIdentityRegistry before a test run.
+func brokerHumanIdentityRegistry() *HumanIdentityRegistry {
+	humanIdentityRegistryOnce.Do(func() {
+		humanIdentityRegistrySvc = NewHumanIdentityRegistry()
+	})
+	return humanIdentityRegistrySvc
+}
+
+// setHumanIdentityRegistry is the test hook. Safe to call from TestMain
+// or individual tests — subsequent sync.Once runs are no-ops.
+func setHumanIdentityRegistry(r *HumanIdentityRegistry) {
+	humanIdentityRegistryOnce.Do(func() {})
+	humanIdentityRegistrySvc = r
+}
+
+// handleWikiWriteHuman is the broker HTTP endpoint the web UI posts to
+// when a human saves a wiki edit. Shape:
+//
+//	POST /wiki/write-human
+//	{
+//	  "path": "team/people/nazz.md",
+//	  "content": "...",
+//	  "commit_message": "human: fix typo",
+//	  "expected_sha": "abc123"
+//	}
+//
+// expected_sha MUST be the article's current SHA as last seen by the
+// client. When HEAD has moved, the handler returns 409 with the current
+// SHA and the current article bytes so the editor can prompt re-apply.
+//
+// Agents never reach this endpoint — it is HTTP-only (not exposed via
+// MCP) and gated by the existing broker bearer token (held by the web
+// UI). The identity stamped on the commit is resolved server-side from
+// the HumanIdentityRegistry; clients cannot forge attribution.
+//
+// Responses:
+//
+//	200 { "path":..., "commit_sha":..., "bytes_written":..., "author_slug":... }
+//	400 { "error":"..." } on malformed JSON / bad path / empty content
+//	409 { "error":"...", "current_sha":..., "current_content":"..." }
+//	429 { "error":"wiki queue saturated, retry on next turn" }
+//	500 { "error":"..." }
+//	503 { "error":"wiki backend is not active" }
+func (b *Broker) handleWikiWriteHuman(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	worker := b.WikiWorker()
+	if worker == nil {
+		http.Error(w, `{"error":"wiki backend is not active"}`, http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		Path          string `json:"path"`
+		Content       string `json:"content"`
+		CommitMessage string `json:"commit_message"`
+		ExpectedSHA   string `json:"expected_sha"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	// Pre-validate inputs BEFORE enqueueing so a rejection never touches
+	// the working tree. Mirrors reviewApprove's CanApprove pre-check.
+	if err := validateArticlePath(body.Path); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+		return
+	}
+	if strings.TrimSpace(body.Content) == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "content is required"})
+		return
+	}
+	identity := brokerHumanIdentityRegistry().Local()
+	sha, n, err := worker.EnqueueHumanAs(
+		r.Context(), identity, body.Path, body.Content, body.CommitMessage, body.ExpectedSHA,
+	)
+	if err != nil {
+		if errors.Is(err, ErrWikiSHAMismatch) {
+			// Return the current article bytes so the editor can show a
+			// three-pane reload prompt without a second round trip.
+			current, _ := readArticle(worker.Repo(), body.Path)
+			writeJSON(w, http.StatusConflict, map[string]any{
+				"error":           err.Error(),
+				"current_sha":     sha,
+				"current_content": string(current),
+			})
+			return
+		}
+		if errors.Is(err, ErrQueueSaturated) {
+			writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"path":          body.Path,
+		"commit_sha":    sha,
+		"bytes_written": n,
+		"author_slug":   identity.Slug,
+	})
+}
+
+// humanIdentityResponse is the wire shape for GET /humans. We deliberately
+// expose name + slug (UI byline lookups) and email (for `mailto:` links
+// and git-log reconciliation) but not CreatedAt — clients have no use
+// for it today, and leaving it out keeps the response stable.
+type humanIdentityResponse struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+	Slug  string `json:"slug"`
+}
+
+// handleHumans returns the list of registered human identities. The
+// registry is merge-on-read, so this endpoint only exposes identities
+// that have been observed by at least one commit or probed from the
+// local shell's `git config --global`.
+//
+//	GET /humans
+//	  200 { "humans": [ {name, email, slug}, ... ] }
+//
+// No query params, no pagination — team-scale only (handful of humans).
+func (b *Broker) handleHumans(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	reg := brokerHumanIdentityRegistry()
+	// Ensure the local identity has been probed at least once so a
+	// fresh-install `GET /humans` doesn't return an empty list.
+	_ = reg.Local()
+	list := reg.List()
+	out := make([]humanIdentityResponse, 0, len(list))
+	for _, id := range list {
+		out = append(out, humanIdentityResponse{
+			Name:  id.Name,
+			Email: id.Email,
+			Slug:  id.Slug,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"humans": out})
+}

--- a/internal/team/human_commit.go
+++ b/internal/team/human_commit.go
@@ -31,11 +31,18 @@ import (
 	"strings"
 )
 
-// HumanAuthor is the synthetic commit author slug for every human edit.
-// Yields `Human <human@wuphf.local>` via runGitLocked's identity derivation.
-// Distinct from every agent slug and from the other synthetic identities
-// (archivist, wuphf-bootstrap, wuphf-recovery, system) so audit views can
-// colour human edits distinctly.
+// HumanAuthor is the synthetic commit author slug used when no richer
+// human identity has been registered (no `git config --global user.name`
+// / `user.email` on this machine). Yields `human <human@wuphf.local>`
+// via runGitLocked's identity derivation. Distinct from every agent slug
+// and from the other synthetic identities (archivist, wuphf-bootstrap,
+// wuphf-recovery, system) so audit views can colour human edits
+// distinctly.
+//
+// v1.5: when the broker has probed a real git identity, the slug on
+// disk becomes the user's derived slug (see deriveSlug in
+// human_identity.go) and commits land with their real name + email.
+// `HumanAuthor` remains the fallback.
 const HumanAuthor = "human"
 
 // ErrWikiSHAMismatch is returned by CommitHuman when the caller's
@@ -44,16 +51,30 @@ const HumanAuthor = "human"
 // so the client can show the re-load prompt without a second round trip.
 var ErrWikiSHAMismatch = errors.New("wiki: article changed since it was opened")
 
-// CommitHuman writes content to relPath as the synthetic human author,
-// enforcing an expected-SHA pre-check. Returns the new short SHA, bytes
-// written, and an error; ErrWikiSHAMismatch means the caller should
-// re-load and re-apply their edits. Mode is inferred from mustExist: a
-// fresh article (expectedSHA == "") uses "create", an edit uses "replace".
+// CommitHuman writes content to relPath with the caller-supplied human
+// identity, enforcing an expected-SHA pre-check. When identity has its
+// zero value, the fallback `human <human@wuphf.local>` identity is used
+// so the legacy single-user attribution path still works.
+//
+// Returns the new short SHA, bytes written, and an error;
+// ErrWikiSHAMismatch means the caller should re-load and re-apply their
+// edits. Mode is inferred from mustExist: a fresh article (expectedSHA
+// == "") uses "create", an edit uses "replace".
 //
 // Mirrors Repo.Commit in all other respects: same validateArticlePath
 // guard, same working-tree atomicity, same regenerateIndexLocked pass
 // so the index lands in the same commit as the article edit.
-func (r *Repo) CommitHuman(ctx context.Context, relPath, content, expectedSHA, message string) (string, int, error) {
+func (r *Repo) CommitHuman(ctx context.Context, relPath, content, expectedSHA, message string, identity HumanIdentity) (string, int, error) {
+	// Resolve the effective identity before touching the filesystem so
+	// every downstream call site sees the same author.
+	name := strings.TrimSpace(identity.Name)
+	email := strings.TrimSpace(identity.Email)
+	slug := strings.TrimSpace(identity.Slug)
+	if name == "" || email == "" || slug == "" {
+		name = FallbackHumanIdentity.Name
+		email = FallbackHumanIdentity.Email
+		slug = FallbackHumanIdentity.Slug
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -109,12 +130,15 @@ func (r *Repo) CommitHuman(ctx context.Context, relPath, content, expectedSHA, m
 	}
 
 	relForGit := filepath.ToSlash(relPath)
-	if out, err := r.runGitLocked(ctx, HumanAuthor, "add", "--", relForGit, "index/all.md"); err != nil {
+	// Staging/diff/rev-parse only care about the identity for advisory
+	// reflog entries — use the derived slug so per-human attribution is
+	// consistent across every git sub-call in the commit.
+	if out, err := r.runGitLockedAs(ctx, name, email, "add", "--", relForGit, "index/all.md"); err != nil {
 		return "", 0, fmt.Errorf("wiki: git add %s: %w: %s", relPath, err, out)
 	}
 
 	// Byte-identical re-write short-circuits to current HEAD; mirrors Repo.Commit.
-	cachedDiff, err := r.runGitLocked(ctx, HumanAuthor, "diff", "--cached", "--name-only")
+	cachedDiff, err := r.runGitLockedAs(ctx, name, email, "diff", "--cached", "--name-only")
 	if err != nil {
 		return "", 0, fmt.Errorf("wiki: git diff --cached: %w", err)
 	}
@@ -135,10 +159,11 @@ func (r *Repo) CommitHuman(ctx context.Context, relPath, content, expectedSHA, m
 		// make the provenance obvious even at a glance.
 		commitMsg = "human: " + commitMsg
 	}
-	if out, err := r.runGitLocked(ctx, HumanAuthor, "commit", "-q", "-m", commitMsg); err != nil {
+	if out, err := r.runGitLockedAs(ctx, name, email, "commit", "-q", "-m", commitMsg); err != nil {
 		return "", 0, fmt.Errorf("wiki: git commit: %w: %s", err, out)
 	}
-	sha, err := r.runGitLocked(ctx, HumanAuthor, "rev-parse", "--short", "HEAD")
+	_ = slug // slug is retained for future author_slug plumbing in the reply envelope.
+	sha, err := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
 	if err != nil {
 		return "", 0, fmt.Errorf("wiki: resolve HEAD sha: %w", err)
 	}

--- a/internal/team/human_identity.go
+++ b/internal/team/human_identity.go
@@ -1,0 +1,331 @@
+package team
+
+// human_identity.go implements the per-human git-identity registry used by
+// the wiki editor (v1.5 hardening of PR #192).
+//
+// Problem
+// =======
+//
+// In v1.4 every human wiki edit was attributed to the synthetic identity
+//
+//	human <human@wuphf.local>
+//
+// That worked for a one-person team but collapsed for two. With multiple
+// humans editing the wiki (founder + cofounder, say) `git log` could not
+// tell them apart.
+//
+// Design
+// ======
+//
+// First time the broker observes a write path, it probes the user's shell
+// git config for `user.name` + `user.email`. That identity is cached on
+// disk at
+//
+//	~/.wuphf/humans/{sha256(email)[:16]}.json
+//
+// and served back for every subsequent `POST /wiki/write-human` from the
+// same machine. Two different humans on two different machines produce
+// two different cache files; the registry grows on read.
+//
+// Slug derivation
+// ---------------
+//
+// The slug is the email's local-part, normalised to lowercase kebab-case:
+//
+//	sarah.chen@acme.com  → sarah-chen
+//	FOUNDER+work@ex.io   → founder-work
+//
+// The slug is used as the git commit author name's URL-safe handle and
+// as the key the web UI uses to look up the registered display name for
+// a byline. It is NOT used as the commit email — we keep the user's real
+// email on commits so `git log` matches their local identity.
+//
+// Fallback
+// --------
+//
+// When git config is missing (fresh shell, CI sandbox) the probe falls
+// back to the v1.4 synthetic identity (`human`/`human@wuphf.local`). That
+// preserves existing behaviour and lets the handler stay unconditional.
+//
+// Multi-human support
+// -------------------
+//
+// The registry is merge-on-read. Every commit that lands with an email
+// we haven't cached gets written to a new `{sha}.json`, so once two
+// people have each edited once, both are in the registry.
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// HumanIdentity is the cached git identity for a single human.
+//
+// It is written to disk as the JSON contents of
+// ~/.wuphf/humans/{sha256(email)[:16]}.json and is the source of truth
+// the broker uses when stamping a `/wiki/write-human` commit.
+type HumanIdentity struct {
+	Name      string    `json:"name"`
+	Email     string    `json:"email"`
+	Slug      string    `json:"slug"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// FallbackHumanIdentity is returned when no git config is set and no
+// cached local identity exists. It matches the v1.4 behaviour so audit
+// history keeps its meaning for single-user installs.
+var FallbackHumanIdentity = HumanIdentity{
+	Name:  HumanAuthor,
+	Email: HumanAuthor + "@wuphf.local",
+	Slug:  HumanAuthor,
+}
+
+// HumanIdentityRegistry manages the on-disk cache of git identities.
+// Safe for concurrent use.
+type HumanIdentityRegistry struct {
+	dir string
+
+	mu         sync.Mutex
+	localCache *HumanIdentity
+}
+
+// NewHumanIdentityRegistry constructs a registry rooted at
+// {RuntimeHomeDir}/.wuphf/humans. The directory is created lazily on
+// first write; construction never touches the filesystem.
+func NewHumanIdentityRegistry() *HumanIdentityRegistry {
+	return &HumanIdentityRegistry{dir: humansDir()}
+}
+
+// NewHumanIdentityRegistryAt is the test hook — accepts an explicit dir
+// so each test run has its own cache.
+func NewHumanIdentityRegistryAt(dir string) *HumanIdentityRegistry {
+	return &HumanIdentityRegistry{dir: dir}
+}
+
+// humansDir mirrors WikiRootDir's layout so dev runs (WUPHF_RUNTIME_HOME
+// override) stay isolated from a user's prod ~/.wuphf.
+func humansDir() string {
+	home := strings.TrimSpace(config.RuntimeHomeDir())
+	if home == "" {
+		return filepath.Join(".wuphf", "humans")
+	}
+	return filepath.Join(home, ".wuphf", "humans")
+}
+
+// Dir returns the on-disk directory the registry reads/writes. Useful
+// for tests and observability.
+func (r *HumanIdentityRegistry) Dir() string { return r.dir }
+
+// Local returns the local-machine identity — the one derived from the
+// current user's `git config --global`. Cached after the first call so
+// repeated writes don't fork a subprocess per commit.
+//
+// On any error (git missing, config unset, persist failure) Local falls
+// back to FallbackHumanIdentity so callers never need to nil-check.
+func (r *HumanIdentityRegistry) Local() HumanIdentity {
+	r.mu.Lock()
+	cached := r.localCache
+	r.mu.Unlock()
+	if cached != nil {
+		return *cached
+	}
+	id := probeLocalGitIdentity()
+	// Only persist real identities — the fallback would clobber a real
+	// identity written by a later run.
+	if id.Email != FallbackHumanIdentity.Email {
+		if err := r.persist(id); err != nil {
+			// Non-fatal: persistence failure just means we probe again
+			// next run. Log-level concerns are up to the caller.
+			_ = err
+		}
+	}
+	r.mu.Lock()
+	copy := id
+	r.localCache = &copy
+	r.mu.Unlock()
+	return id
+}
+
+// Lookup returns the HumanIdentity cached for the given slug, if any.
+// The slug is the URL-safe handle derived from the email local-part;
+// see deriveSlug.
+func (r *HumanIdentityRegistry) Lookup(slug string) (HumanIdentity, bool) {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return HumanIdentity{}, false
+	}
+	for _, id := range r.List() {
+		if id.Slug == slug {
+			return id, true
+		}
+	}
+	return HumanIdentity{}, false
+}
+
+// List returns every identity currently cached on disk. Ordering is not
+// guaranteed. Errors from the filesystem are swallowed — an unreadable
+// cache entry simply does not appear in the list.
+func (r *HumanIdentityRegistry) List() []HumanIdentity {
+	entries, err := os.ReadDir(r.dir)
+	if err != nil {
+		return nil
+	}
+	out := make([]HumanIdentity, 0, len(entries))
+	seen := make(map[string]struct{}, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		bytes, err := os.ReadFile(filepath.Join(r.dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var id HumanIdentity
+		if err := json.Unmarshal(bytes, &id); err != nil {
+			continue
+		}
+		if _, dup := seen[id.Slug]; dup {
+			continue
+		}
+		seen[id.Slug] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}
+
+// Observe records an identity seen on a landed commit. Idempotent —
+// writes the cache file only if a matching entry is not already on
+// disk. This is how the registry grows when a second human's commit
+// arrives.
+func (r *HumanIdentityRegistry) Observe(name, email string) (HumanIdentity, error) {
+	id, err := buildIdentity(name, email)
+	if err != nil {
+		return HumanIdentity{}, err
+	}
+	if err := r.persist(id); err != nil {
+		return HumanIdentity{}, err
+	}
+	return id, nil
+}
+
+// persist writes an identity to {dir}/{sha}.json idempotently. Existing
+// entries are left untouched so CreatedAt is stable across runs.
+func (r *HumanIdentityRegistry) persist(id HumanIdentity) error {
+	if strings.TrimSpace(id.Email) == "" {
+		return fmt.Errorf("human identity: email is required")
+	}
+	if err := os.MkdirAll(r.dir, 0o700); err != nil {
+		return fmt.Errorf("human identity: mkdir %s: %w", r.dir, err)
+	}
+	path := filepath.Join(r.dir, identityFilename(id.Email))
+	if _, err := os.Stat(path); err == nil {
+		// Already cached — keep the original CreatedAt.
+		return nil
+	}
+	bytes, err := json.MarshalIndent(id, "", "  ")
+	if err != nil {
+		return fmt.Errorf("human identity: marshal: %w", err)
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, bytes, 0o600); err != nil {
+		return fmt.Errorf("human identity: write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		return fmt.Errorf("human identity: rename: %w", err)
+	}
+	return nil
+}
+
+// identityFilename hashes the (lowercased) email so each identity has a
+// stable, filesystem-safe filename independent of its display form.
+func identityFilename(email string) string {
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(email))))
+	return hex.EncodeToString(sum[:])[:16] + ".json"
+}
+
+// probeLocalGitIdentity runs `git config --global user.name` and
+// `user.email` in the caller's shell environment (NOT the sandboxed
+// repo env used by runGitLocked — we want the user's real config).
+// Returns FallbackHumanIdentity when either probe fails or yields
+// empty output.
+func probeLocalGitIdentity() HumanIdentity {
+	name := runGitConfig("user.name")
+	email := runGitConfig("user.email")
+	if name == "" || email == "" {
+		return FallbackHumanIdentity
+	}
+	id, err := buildIdentity(name, email)
+	if err != nil {
+		return FallbackHumanIdentity
+	}
+	return id
+}
+
+func runGitConfig(key string) string {
+	// Deliberately NOT setting GIT_CONFIG_GLOBAL=/dev/null here — we
+	// WANT the user's real global config. Honour a short timeout so a
+	// hung git doesn't stall broker startup.
+	cmd := exec.Command("git", "config", "--global", key)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// buildIdentity validates inputs and constructs a HumanIdentity. Shared
+// by the local probe and the Observe path so both take the same slug
+// derivation rules.
+func buildIdentity(name, email string) (HumanIdentity, error) {
+	name = strings.TrimSpace(name)
+	email = strings.TrimSpace(email)
+	if name == "" {
+		return HumanIdentity{}, fmt.Errorf("human identity: name is required")
+	}
+	if email == "" {
+		return HumanIdentity{}, fmt.Errorf("human identity: email is required")
+	}
+	slug := deriveSlug(email)
+	if slug == "" {
+		return HumanIdentity{}, fmt.Errorf("human identity: could not derive slug from %q", email)
+	}
+	return HumanIdentity{
+		Name:      name,
+		Email:     email,
+		Slug:      slug,
+		CreatedAt: time.Now().UTC(),
+	}, nil
+}
+
+var slugSanitizer = regexp.MustCompile(`[^a-z0-9]+`)
+
+// deriveSlug turns an email into a url-safe kebab-case handle:
+//
+//	"Sarah.Chen@acme.com"       → "sarah-chen"
+//	"founder+work@example.io"   → "founder-work"
+//	"a_b.c@x.y"                 → "a-b-c"
+//
+// Collisions across domains are possible (`sarah@a.com` and `sarah@b.com`
+// both slug to `sarah`), which is why the on-disk filename hashes the
+// full email rather than the slug. Collision within the slug namespace
+// is accepted for v1.5 — rare in practice at team scale.
+func deriveSlug(email string) string {
+	local := strings.ToLower(email)
+	if at := strings.IndexByte(local, '@'); at >= 0 {
+		local = local[:at]
+	}
+	local = slugSanitizer.ReplaceAllString(local, "-")
+	local = strings.Trim(local, "-")
+	return local
+}

--- a/internal/team/human_identity_test.go
+++ b/internal/team/human_identity_test.go
@@ -1,0 +1,252 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDeriveSlug(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"sarah.chen@acme.com", "sarah-chen"},
+		{"Sarah.Chen@Acme.com", "sarah-chen"},
+		{"founder+work@example.io", "founder-work"},
+		{"a_b.c@x.y", "a-b-c"},
+		{"CAPS@example.com", "caps"},
+		{"---weird.local---@ex.com", "weird-local"},
+	}
+	for _, c := range cases {
+		got := deriveSlug(c.in)
+		if got != c.want {
+			t.Errorf("deriveSlug(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestRegistryPersistAndList — writing an identity twice is idempotent
+// (no duplicate entry), and List surfaces whatever has been persisted.
+func TestRegistryPersistAndList(t *testing.T) {
+	dir := t.TempDir()
+	reg := NewHumanIdentityRegistryAt(dir)
+
+	id1, err := reg.Observe("Sarah Chen", "sarah.chen@acme.com")
+	if err != nil {
+		t.Fatalf("observe 1: %v", err)
+	}
+	if id1.Slug != "sarah-chen" {
+		t.Errorf("want slug sarah-chen, got %q", id1.Slug)
+	}
+
+	// Duplicate Observe must not create a new file.
+	_, err = reg.Observe("Sarah Chen", "sarah.chen@acme.com")
+	if err != nil {
+		t.Fatalf("observe duplicate: %v", err)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Errorf("want 1 on-disk entry, got %d: %v", len(entries), entries)
+	}
+
+	// A different email grows the registry.
+	if _, err := reg.Observe("Dwight Schrute", "dwight@dunder.com"); err != nil {
+		t.Fatalf("observe 2: %v", err)
+	}
+	entries, _ = os.ReadDir(dir)
+	if len(entries) != 2 {
+		t.Errorf("want 2 on-disk entries, got %d", len(entries))
+	}
+
+	found := reg.List()
+	if len(found) != 2 {
+		t.Fatalf("want 2 listed, got %d: %+v", len(found), found)
+	}
+
+	// Lookup by slug returns the cached entry.
+	if id, ok := reg.Lookup("sarah-chen"); !ok || id.Email != "sarah.chen@acme.com" {
+		t.Errorf("lookup sarah-chen: got %+v ok=%v", id, ok)
+	}
+	if _, ok := reg.Lookup("missing"); ok {
+		t.Error("lookup missing should return false")
+	}
+}
+
+// TestRegistryFallbackWhenGitConfigMissing — when git config is unset,
+// Local() returns FallbackHumanIdentity and does NOT persist it (so a
+// later probe with real config can still land).
+func TestRegistryFallbackWhenGitConfigMissing(t *testing.T) {
+	dir := t.TempDir()
+	reg := NewHumanIdentityRegistryAt(dir)
+	// Force the probe to fail by pointing git at empty config files.
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	id := reg.Local()
+	if id.Slug != HumanAuthor {
+		t.Errorf("want fallback slug %q, got %q", HumanAuthor, id.Slug)
+	}
+	if id.Email != FallbackHumanIdentity.Email {
+		t.Errorf("want fallback email, got %q", id.Email)
+	}
+	// Fallback identity must NOT write to disk — otherwise a later
+	// config-based probe would be masked by the cached fallback.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".json") {
+			t.Errorf("fallback identity should not persist, found %s", e.Name())
+		}
+	}
+}
+
+// TestCommitHumanUsesRegistryIdentity — a write with a real identity
+// lands on the commit's author metadata.
+func TestCommitHumanUsesRegistryIdentity(t *testing.T) {
+	worker, repo, _, teardown := newStartedWorker(t)
+	defer teardown()
+
+	id, err := buildIdentity("Sarah Chen", "sarah.chen@acme.com")
+	if err != nil {
+		t.Fatalf("build identity: %v", err)
+	}
+
+	sha, _, err := worker.EnqueueHumanAs(
+		context.Background(), id,
+		"team/people/sarah.md",
+		"# Sarah\n\nFounding PM.\n",
+		"human: add sarah",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if sha == "" {
+		t.Fatal("expected sha")
+	}
+
+	out, err := repo.runGitLocked(context.Background(), "system",
+		"log", "-n", "1", "--format=%an\x1f%ae", "--", "team/people/sarah.md")
+	if err != nil {
+		t.Fatalf("git log: %v", err)
+	}
+	parts := strings.Split(strings.TrimSpace(out), "\x1f")
+	if len(parts) != 2 {
+		t.Fatalf("unexpected git log output: %q", out)
+	}
+	if parts[0] != "Sarah Chen" {
+		t.Errorf("want name 'Sarah Chen', got %q", parts[0])
+	}
+	if parts[1] != "sarah.chen@acme.com" {
+		t.Errorf("want email sarah.chen@acme.com, got %q", parts[1])
+	}
+}
+
+// TestHandleHumansReturnsRegistry — the /humans endpoint exposes the
+// registered identities the UI uses for byline lookups.
+func TestHandleHumansReturnsRegistry(t *testing.T) {
+	dir := t.TempDir()
+	reg := NewHumanIdentityRegistryAt(dir)
+	if _, err := reg.Observe("Sarah Chen", "sarah.chen@acme.com"); err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	setHumanIdentityRegistry(reg)
+	// Restore so other tests don't leak this fake registry.
+	t.Cleanup(func() { setHumanIdentityRegistry(NewHumanIdentityRegistry()) })
+
+	b := &Broker{}
+	req := httptest.NewRequest(http.MethodGet, "/humans", nil)
+	rec := httptest.NewRecorder()
+	b.handleHumans(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Humans []humanIdentityResponse `json:"humans"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var found bool
+	for _, h := range got.Humans {
+		if h.Slug == "sarah-chen" && h.Name == "Sarah Chen" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected sarah-chen in /humans, got %+v", got.Humans)
+	}
+}
+
+// TestHandleWikiWriteHumanReturnsAuthorSlug — the write handler surfaces
+// the slug that actually authored the commit so the UI can update the
+// byline without a second fetch.
+func TestHandleWikiWriteHumanReturnsAuthorSlug(t *testing.T) {
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+
+	dir := t.TempDir()
+	reg := NewHumanIdentityRegistryAt(dir)
+	if _, err := reg.Observe("Sarah Chen", "sarah.chen@acme.com"); err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	// Seed the local probe result so the handler picks sarah-chen instead
+	// of probing the developer's real git config.
+	reg.mu.Lock()
+	id, _ := buildIdentity("Sarah Chen", "sarah.chen@acme.com")
+	reg.localCache = &id
+	reg.mu.Unlock()
+	setHumanIdentityRegistry(reg)
+	t.Cleanup(func() { setHumanIdentityRegistry(NewHumanIdentityRegistry()) })
+
+	b := brokerForTest(t, worker)
+
+	body, _ := json.Marshal(map[string]any{
+		"path":           "team/people/wiki-author.md",
+		"content":        "# Wiki Author\n\nFirst edit.\n",
+		"commit_message": "human: bootstrap",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/wiki/write-human", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	b.handleWikiWriteHuman(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["author_slug"] != "sarah-chen" {
+		t.Errorf("want author_slug=sarah-chen, got %v", got["author_slug"])
+	}
+}
+
+// TestIdentityFilenameDeterministic — the same email always hashes to the
+// same filename, case-insensitively. Prevents duplicate on-disk entries
+// for the same human who types their email with different casing.
+func TestIdentityFilenameDeterministic(t *testing.T) {
+	a := identityFilename("sarah@acme.com")
+	b := identityFilename("SARAH@acme.com")
+	if a != b {
+		t.Errorf("filenames diverge for casing: %s vs %s", a, b)
+	}
+	if !strings.HasSuffix(a, ".json") {
+		t.Errorf("expected .json suffix, got %s", a)
+	}
+	// Sanity: different emails hash to different names.
+	if identityFilename("sarah@acme.com") == identityFilename("dwight@dunder.com") {
+		t.Error("different emails produced same filename")
+	}
+}
+
+// Unused-import guard.
+var _ = filepath.Separator

--- a/internal/team/wiki_git.go
+++ b/internal/team/wiki_git.go
@@ -674,9 +674,27 @@ func (r *Repo) runGitLocked(ctx context.Context, slug string, args ...string) (s
 	if slug == "" {
 		slug = "wuphf"
 	}
+	return r.runGitLockedAs(ctx, slug, slug+"@wuphf.local", args...)
+}
+
+// runGitLockedAs runs `git` with an explicit author name + email. Used
+// for human wiki edits where we want the user's real git identity on
+// the commit (e.g. `Sarah Chen <sarah@acme.com>`) instead of the
+// synthetic slug@wuphf.local pattern used for agents.
+//
+// Caller must hold r.mu.
+func (r *Repo) runGitLockedAs(ctx context.Context, name, email string, args ...string) (string, error) {
+	name = strings.TrimSpace(name)
+	email = strings.TrimSpace(email)
+	if name == "" {
+		name = "wuphf"
+	}
+	if email == "" {
+		email = "wuphf@wuphf.local"
+	}
 	identity := []string{
-		"-c", "user.name=" + slug,
-		"-c", "user.email=" + slug + "@wuphf.local",
+		"-c", "user.name=" + name,
+		"-c", "user.email=" + email,
 		"-c", "advice.defaultBranchName=false",
 		"-c", "init.defaultBranch=main",
 		"-c", "commit.gpgsign=false",

--- a/internal/team/wiki_worker.go
+++ b/internal/team/wiki_worker.go
@@ -100,13 +100,18 @@ type wikiWriteRequest struct {
 	// enqueue a follow-up recompile without re-parsing the path.
 	PlaybookSlug string
 	// IsHuman routes the request to Repo.CommitHuman — optimistic
-	// concurrency via expected_sha, fixed `human` git identity. Wikipedia-
-	// style Edit source flow for the founder.
+	// concurrency via expected_sha, per-human git identity. Wikipedia-
+	// style Edit source flow. v1.5: identity is resolved from the
+	// HumanIdentityRegistry rather than being hard-coded.
 	IsHuman bool
 	// ExpectedSHA is consulted by the human write path. Empty means the
 	// caller expects the article not to exist yet (new-article flow).
 	ExpectedSHA string
-	ReplyCh     chan wikiWriteResult
+	// HumanIdentity carries the per-human git identity used when
+	// IsHuman is true. Zero value falls back to the synthetic
+	// `human <human@wuphf.local>` author.
+	HumanIdentity HumanIdentity
+	ReplyCh       chan wikiWriteResult
 }
 
 // wikiWriteResult is the worker's reply for a single request.
@@ -253,10 +258,12 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 		err error
 	)
 	if req.IsHuman {
-		// Human edits use optimistic concurrency (expected_sha) and a
-		// fixed `human` author identity — req.Slug is ignored on this
-		// branch to prevent a caller from forging attribution.
-		sha, n, err = w.repo.CommitHuman(writeCtx, req.Path, req.Content, req.ExpectedSHA, req.CommitMsg)
+		// Human edits use optimistic concurrency (expected_sha) and the
+		// per-human identity resolved from the registry — req.Slug is
+		// ignored on this branch to prevent a caller from forging
+		// attribution. Zero-value HumanIdentity falls back to the
+		// synthetic `human` author inside CommitHuman.
+		sha, n, err = w.repo.CommitHuman(writeCtx, req.Path, req.Content, req.ExpectedSHA, req.CommitMsg, req.HumanIdentity)
 	} else if req.IsEntityFact {
 		sha, n, err = w.repo.CommitEntityFact(writeCtx, req.Slug, req.Path, req.Content, req.CommitMsg)
 	} else if req.IsPlaybookCompile {
@@ -385,25 +392,43 @@ func (w *WikiWorker) QueueLength() int {
 }
 
 // EnqueueHuman submits a human-authored wiki write to the shared single-
-// writer queue. Identity is forced to HumanAuthor so the caller cannot
-// spoof attribution (the HTTP handler is already gated by the broker
-// bearer token, but belt-and-braces on the worker is cheap). Returns
-// ErrWikiSHAMismatch wrapped with the current HEAD SHA (in the SHA
-// return slot) when expected_sha does not match; callers pass that back
-// to the client so the 409 prompt can reload the latest content.
+// writer queue with the legacy fallback identity. Retained for backward
+// compatibility with tests and call sites that predate v1.5's
+// per-human identity registry; prefer EnqueueHumanAs for new code.
 func (w *WikiWorker) EnqueueHuman(ctx context.Context, path, content, commitMsg, expectedSHA string) (string, int, error) {
+	return w.EnqueueHumanAs(ctx, HumanIdentity{}, path, content, commitMsg, expectedSHA)
+}
+
+// EnqueueHumanAs submits a human-authored wiki write to the shared
+// single-writer queue, stamping the commit with the supplied identity.
+// A zero-value identity falls back to the synthetic `human` author so
+// single-user installs keep working.
+//
+// The HTTP handler is already gated by the broker bearer token, so the
+// worker trusts the identity it is given — this is belt-and-braces
+// between two authenticated layers, not an anti-spoofing boundary.
+//
+// Returns ErrWikiSHAMismatch wrapped with the current HEAD SHA (in the
+// SHA return slot) when expected_sha does not match; callers pass that
+// back to the client so the 409 prompt can reload the latest content.
+func (w *WikiWorker) EnqueueHumanAs(ctx context.Context, id HumanIdentity, path, content, commitMsg, expectedSHA string) (string, int, error) {
 	if !w.running.Load() {
 		return "", 0, ErrWorkerStopped
 	}
+	slug := strings.TrimSpace(id.Slug)
+	if slug == "" {
+		slug = HumanAuthor
+	}
 	req := wikiWriteRequest{
-		Slug:        HumanAuthor,
-		Path:        path,
-		Content:     content,
-		Mode:        "replace",
-		CommitMsg:   commitMsg,
-		IsHuman:     true,
-		ExpectedSHA: expectedSHA,
-		ReplyCh:     make(chan wikiWriteResult, 1),
+		Slug:          slug,
+		Path:          path,
+		Content:       content,
+		Mode:          "replace",
+		CommitMsg:     commitMsg,
+		IsHuman:       true,
+		ExpectedSHA:   expectedSHA,
+		HumanIdentity: id,
+		ReplyCh:       make(chan wikiWriteResult, 1),
 	}
 	select {
 	case w.requests <- req:
@@ -591,91 +616,6 @@ func (b *Broker) handleWikiWrite(w http.ResponseWriter, r *http.Request) {
 	}
 	sha, n, err := worker.Enqueue(r.Context(), body.Slug, body.Path, body.Content, body.Mode, body.CommitMessage)
 	if err != nil {
-		if errors.Is(err, ErrQueueSaturated) {
-			writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": err.Error()})
-			return
-		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
-	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"path":          body.Path,
-		"commit_sha":    sha,
-		"bytes_written": n,
-	})
-}
-
-// handleWikiWriteHuman is the broker HTTP endpoint the web UI posts to
-// when the founder saves a human wiki edit. Shape:
-//
-//	POST /wiki/write-human
-//	{
-//	  "path": "team/people/nazz.md",
-//	  "content": "...",
-//	  "commit_message": "human: fix typo",
-//	  "expected_sha": "abc123"
-//	}
-//
-// expected_sha MUST be the article's current SHA as last seen by the
-// client. When HEAD has moved, the handler returns 409 with the current
-// SHA and the current article bytes so the editor can prompt re-apply.
-//
-// Agents never reach this endpoint — it is HTTP-only (not exposed via
-// MCP) and gated by the existing broker bearer token (held by the web
-// UI). The payload's attribution cannot be forged: the worker forces
-// the commit author to HumanAuthor on this path.
-//
-// Responses:
-//
-//	200 { "path":..., "commit_sha":..., "bytes_written":... }
-//	400 { "error":"..." } on malformed JSON / bad path / empty content
-//	409 { "error":"...", "current_sha":..., "current_content":"..." }
-//	429 { "error":"wiki queue saturated, retry on next turn" }
-//	500 { "error":"..." }
-//	503 { "error":"wiki backend is not active" }
-func (b *Broker) handleWikiWriteHuman(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	worker := b.WikiWorker()
-	if worker == nil {
-		http.Error(w, `{"error":"wiki backend is not active"}`, http.StatusServiceUnavailable)
-		return
-	}
-	var body struct {
-		Path          string `json:"path"`
-		Content       string `json:"content"`
-		CommitMessage string `json:"commit_message"`
-		ExpectedSHA   string `json:"expected_sha"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
-		return
-	}
-	// Pre-validate inputs BEFORE enqueueing so a rejection never touches
-	// the working tree. Mirrors reviewApprove's CanApprove pre-check.
-	if err := validateArticlePath(body.Path); err != nil {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
-		return
-	}
-	if strings.TrimSpace(body.Content) == "" {
-		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "content is required"})
-		return
-	}
-	sha, n, err := worker.EnqueueHuman(r.Context(), body.Path, body.Content, body.CommitMessage, body.ExpectedSHA)
-	if err != nil {
-		if errors.Is(err, ErrWikiSHAMismatch) {
-			// Return the current article bytes so the editor can show a
-			// three-pane reload prompt without a second round trip.
-			current, _ := readArticle(worker.Repo(), body.Path)
-			writeJSON(w, http.StatusConflict, map[string]any{
-				"error":           err.Error(),
-				"current_sha":     sha,
-				"current_content": string(current),
-			})
-			return
-		}
 		if errors.Is(err, ErrQueueSaturated) {
 			writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": err.Error()})
 			return

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -215,6 +215,32 @@ export function subscribeSectionsUpdated(
   }
 }
 
+/**
+ * Registered human identity surfaced by the broker at GET /humans. The
+ * server grows this list as it observes new commits, so team installs
+ * with multiple humans all show up without any client configuration.
+ */
+export interface HumanIdentity {
+  name: string
+  email: string
+  slug: string
+}
+
+/**
+ * GET /humans — returns identities observed or probed server-side. The
+ * byline component uses this to turn a commit author slug into the
+ * human's real display name. Returns [] on any error so the UI falls
+ * back to the slug-derived label without blanking.
+ */
+export async function fetchHumans(): Promise<HumanIdentity[]> {
+  try {
+    const res = await get<{ humans: HumanIdentity[] }>('/humans')
+    return Array.isArray(res?.humans) ? res.humans : []
+  } catch {
+    return []
+  }
+}
+
 export async function fetchCatalog(): Promise<WikiCatalogEntry[]> {
   try {
     const res = await get<{ articles: WikiCatalogEntry[] }>('/wiki/catalog')

--- a/web/src/components/wiki/Byline.test.tsx
+++ b/web/src/components/wiki/Byline.test.tsx
@@ -59,6 +59,35 @@ describe('<Byline>', () => {
     expect(pill.className).toMatch(/wk-human-pill/)
   })
 
+  it('renders the human display name when the slug matches a registered human', () => {
+    render(
+      <Byline
+        authorSlug="sarah-chen"
+        authorName="Sarah-Chen"
+        lastEditedTs={new Date().toISOString()}
+        humans={[
+          { name: 'Sarah Chen', email: 'sarah.chen@acme.com', slug: 'sarah-chen' },
+        ]}
+      />,
+    )
+    const pill = screen.getByTestId('wk-human-byline')
+    expect(pill).toBeInTheDocument()
+    expect(pill).toHaveTextContent('Sarah Chen')
+    expect(pill.className).toMatch(/wk-human-pill/)
+  })
+
+  it('falls back to the generic "Human" pill for the legacy human slug', () => {
+    render(
+      <Byline
+        authorSlug="human"
+        authorName="Human"
+        lastEditedTs={new Date().toISOString()}
+        humans={[]}
+      />,
+    )
+    expect(screen.getByTestId('wk-human-byline')).toHaveTextContent('Human')
+  })
+
   it('renders started without startedBy', () => {
     render(
       <Byline

--- a/web/src/components/wiki/Byline.tsx
+++ b/web/src/components/wiki/Byline.tsx
@@ -1,5 +1,6 @@
 import PixelAvatar from './PixelAvatar'
 import { formatRelativeTime } from '../../lib/format'
+import type { HumanIdentity } from '../../api/wiki'
 
 /** Article byline: pixel avatar + last-edited-by + amber ts pulse + started date. */
 
@@ -10,6 +11,14 @@ interface BylineProps {
   startedDate?: string
   startedBy?: string
   revisions?: number
+  /**
+   * Registered human identities from GET /humans. When the author slug
+   * matches a registered human, the byline renders that human's display
+   * name instead of the generic "Human" pill. Optional so callers that
+   * don't care about human attribution (or haven't fetched the registry
+   * yet) stay backwards-compatible.
+   */
+  humans?: HumanIdentity[]
 }
 
 export default function Byline({
@@ -19,11 +28,16 @@ export default function Byline({
   startedDate,
   startedBy,
   revisions,
+  humans,
 }: BylineProps) {
-  // Human edits get a distinct pill so readers can tell machine edits
-  // from hand edits at a glance. Matches the agent pixel-avatar motif
-  // without rendering an avatar (`human` has no generated sprite).
-  const isHuman = authorSlug === 'human'
+  // v1.4 legacy: `human` was the single synthetic author for every human
+  // edit. v1.5 replaces that with per-human identities from GET /humans.
+  // Both paths take a distinct "human pill" style so readers can tell
+  // machine edits from hand edits at a glance.
+  const registeredHuman = humans?.find((h) => h.slug === authorSlug)
+  const isLegacyHuman = authorSlug === 'human'
+  const isHuman = Boolean(registeredHuman) || isLegacyHuman
+  const humanLabel = registeredHuman?.name ?? 'Human'
   return (
     <div className="wk-byline">
       <PixelAvatar slug={authorSlug} size={22} />
@@ -31,7 +45,7 @@ export default function Byline({
         Last edited by{' '}
         {isHuman ? (
           <span className="wk-name wk-human-pill" data-testid="wk-human-byline">
-            Human
+            {humanLabel}
           </span>
         ) : (
           <span className="wk-name">{authorName}</span>

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -26,7 +26,9 @@ import ReferencedBy from './ReferencedBy'
 import {
   fetchArticle,
   fetchHistory,
+  fetchHumans,
   subscribeEditLog,
+  type HumanIdentity,
   type WikiArticle as WikiArticleT,
   type WikiCatalogEntry,
   type WikiHistoryCommit,
@@ -64,6 +66,25 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
   const [historyError, setHistoryError] = useState(false)
   const [liveAgent, setLiveAgent] = useState<string | null>(null)
   const [refreshNonce, setRefreshNonce] = useState(0)
+  const [humans, setHumans] = useState<HumanIdentity[]>([])
+
+  // Fetch the human registry once per mount. The list is small (a handful
+  // of team members) and changes rarely, so we skip refetching on every
+  // path change. Failure falls through to an empty list — Byline gracefully
+  // shows the agent path when no human identity matches.
+  useEffect(() => {
+    let cancelled = false
+    fetchHumans()
+      .then((list) => {
+        if (!cancelled) setHumans(list)
+      })
+      .catch(() => {
+        if (!cancelled) setHumans([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -166,6 +187,7 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
       authorName={formatAgentName(article.last_edited_by)}
       lastEditedTs={article.last_edited_ts}
       revisions={article.revisions}
+      humans={humans}
     />
   )
 


### PR DESCRIPTION
## Summary

v1.5 hardening of PR #192. Replaces the single synthetic `human <human@wuphf.local>` author with per-human git identities probed from the user's `git config --global`, cached on disk, and surfaced back to the web UI through a new `GET /humans` endpoint.

- **Identity probe + cache** — first broker write captures `user.name` + `user.email` from the shell, caches at `~/.wuphf/humans/{sha256(email)[:16]}.json`. Subsequent `/wiki/write-human` commits stamp the user's real name + email.
- **Fallback preserved** — missing git config falls back to the v1.4 `human <human@wuphf.local>` identity so single-user installs keep working unchanged.
- **Multi-human merge-on-read** — a second human editing on a different machine (or with their own git config) lands a new cache entry automatically. No orchestration required.
- **Byline display name** — `web/src/components/wiki/Byline.tsx` now renders the registered human's name ("Sarah Chen" not "sarah-chen") while preserving the amber pill styling.

## Files

- `internal/team/human_identity.go` (new) — registry, slug derivation, git-config probe, on-disk cache.
- `internal/team/broker_human.go` (new) — moved `handleWikiWriteHuman` here and added `GET /humans`.
- `internal/team/human_commit.go` — `CommitHuman` accepts `HumanIdentity`.
- `internal/team/wiki_git.go` — new `runGitLockedAs(name, email, args...)` helper; existing `runGitLocked(slug, ...)` unchanged.
- `internal/team/wiki_worker.go` — new `EnqueueHumanAs` threads identity through; `EnqueueHuman` retained as back-compat shim.
- `web/src/api/wiki.ts` — `fetchHumans()` + `HumanIdentity` type.
- `web/src/components/wiki/Byline.tsx` — looks up author slug in the humans registry.
- `web/src/components/wiki/WikiArticle.tsx` — fetches registry once per mount.

## Tests

- Go: slug derivation, registry persist + idempotency, git-config-missing fallback, `CommitHuman` lands real name/email on commit, `/humans` returns registry, `/wiki/write-human` response includes `author_slug`, deterministic filename hashing.
- Web: Byline renders registered human's display name when slug matches; falls back to generic "Human" pill for legacy `human` slug.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (pre-existing race in headless_codex_test.go is unrelated — verified against main)
- [ ] `cd web && bun run build` passes
- [ ] `cd web && bun run test` passes
- [ ] Manually: `git config --global user.name "Nazz"` + `user.email "nazz@ex.com"` → open `/wiki/...`, edit, save. `git log` in `~/.wuphf/wiki/` shows `Nazz <nazz@ex.com>` on the commit.
- [ ] Manually: unset git config (`GIT_CONFIG_GLOBAL=/dev/null`), repeat — byline still reads "Human" with legacy pill.
- [ ] Manually: `GET /humans` returns the probed identity.

## Out of scope

- OAuth/SSO (no login to hook into yet)
- Per-article ACLs (attribution only for v1.5)
- In-app identity editing UI (source of truth remains `git config`)