### PR TITLE
fix(entity-graph): post-review hardening for PR #197

### DIFF
--- a/internal/team/broker_entity.go
+++ b/internal/team/broker_entity.go
@@ -30,6 +30,14 @@ import (
 	"time"
 )
 
+// graphRecordFactRefs is the test seam for the cross-entity graph hook in
+// handleEntityFact. Production code calls graph.RecordFactRefs; tests
+// override this var to inject errors and verify the
+// "graph failure keeps fact write intact" contract.
+var graphRecordFactRefs = func(ctx context.Context, graph *EntityGraph, fact Fact) ([]EntityRef, error) {
+	return graph.RecordFactRefs(ctx, fact)
+}
+
 // SubscribeEntityBriefEvents returns a channel of brief-synthesized events
 // plus an unsubscribe func.
 func (b *Broker) SubscribeEntityBriefEvents(buffer int) (<-chan EntityBriefSynthesizedEvent, func()) {
@@ -248,8 +256,11 @@ func (b *Broker) handleEntityFact(w http.ResponseWriter, r *http.Request) {
 	// Cross-entity graph extraction rides on every successful fact append.
 	// Failures here are logged but never block the fact_recorded response —
 	// the graph is additive intelligence, not a constraint on the fact log.
+	// Indirected through graphRecordFactRefs so tests can verify the
+	// "graph failure keeps fact write intact" contract by injecting an
+	// error-returning stub.
 	if graph := b.EntityGraph(); graph != nil {
-		if _, gerr := graph.RecordFactRefs(r.Context(), fact); gerr != nil {
+		if _, gerr := graphRecordFactRefs(r.Context(), graph, fact); gerr != nil {
 			log.Printf("entity graph: record refs for %s/%s fact %s: %v", kind, slug, fact.ID, gerr)
 		}
 	}

--- a/internal/team/broker_entity_graph_test.go
+++ b/internal/team/broker_entity_graph_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -126,6 +127,50 @@ func TestEntityGraphEndpoint_ValidatesDirection(t *testing.T) {
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400; got %d", res.StatusCode)
+	}
+}
+
+// Regression for the post-review contract: if the graph hook errors
+// inside handleEntityFact, the fact write itself must still return 200.
+// The graph is additive intelligence — never a constraint on the fact log.
+func TestHandleEntityFact_GraphRecordFailureDoesNotBreakFactWrite(t *testing.T) {
+	srv, b, teardown := newEntityGraphTestServer(t)
+	defer teardown()
+
+	// Inject a failing graph recorder for the duration of this test.
+	original := graphRecordFactRefs
+	graphRecordFactRefs = func(_ context.Context, _ *EntityGraph, _ Fact) ([]EntityRef, error) {
+		return nil, errors.New("injected: graph record failure")
+	}
+	t.Cleanup(func() { graphRecordFactRefs = original })
+
+	payload, _ := json.Marshal(map[string]any{
+		"entity_kind": "people",
+		"entity_slug": "sarah",
+		"fact":        "Works at [[companies/acme]] as PM.",
+		"recorded_by": "pm",
+	})
+	req, _ := authReq(http.MethodPost, srv.URL+"/entity/fact", bytes.NewReader(payload), b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post fact: %v", err)
+	}
+	body, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+
+	// Fact write succeeded despite the graph hook failing.
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("fact write must still return 200 when graph hook errors; got %d body=%s",
+			res.StatusCode, body)
+	}
+	var envelope struct {
+		FactID string `json:"fact_id"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, body)
+	}
+	if envelope.FactID == "" {
+		t.Errorf("fact payload missing fact_id: %s", body)
 	}
 }
 

--- a/internal/team/entity_graph.go
+++ b/internal/team/entity_graph.go
@@ -214,9 +214,12 @@ func (g *EntityGraph) RecordFactRefs(ctx context.Context, fact Fact) ([]EntityRe
 		return nil, nil
 	}
 
+	// Build the new file contents under the lock — a concurrent RecordFactRefs
+	// must see this write as atomic for the read-then-append contract to hold.
+	// Release the lock BEFORE enqueuing, so a read path that takes g.mu in the
+	// future (or a full write queue) can never deadlock waiting on a worker
+	// that is waiting on us.
 	g.mu.Lock()
-	defer g.mu.Unlock()
-
 	existing := g.readExistingLocked()
 	var buf strings.Builder
 	buf.Write(existing)
@@ -234,14 +237,17 @@ func (g *EntityGraph) RecordFactRefs(ctx context.Context, fact Fact) ([]EntityRe
 		}
 		line, err := json.Marshal(edge)
 		if err != nil {
+			g.mu.Unlock()
 			return nil, fmt.Errorf("entity graph: marshal: %w", err)
 		}
 		buf.Write(line)
 		buf.WriteString("\n")
 	}
+	content := buf.String()
+	g.mu.Unlock()
 
 	msg := fmt.Sprintf("graph: %s/%s → %d ref(s)", fact.Kind, fact.Slug, len(refs))
-	if _, _, err := g.worker.EnqueueEntityGraph(ctx, ArchivistAuthor, buf.String(), msg); err != nil {
+	if _, _, err := g.worker.EnqueueEntityGraph(ctx, ArchivistAuthor, content, msg); err != nil {
 		return refs, fmt.Errorf("entity graph: enqueue: %w", err)
 	}
 	return refs, nil
@@ -295,7 +301,11 @@ func (g *EntityGraph) readAll() ([]EntityEdge, error) {
 		edges = append(edges, edge)
 	}
 	if err := scanner.Err(); err != nil {
-		log.Printf("entity graph: scanner error after line %d: %v", lineNo, err)
+		// Returning the partial slice here would let Coalesce/Query silently
+		// hand back stale results after a truncated/disk-error read. Surface
+		// the error so callers can distinguish "no edges match" from
+		// "scan aborted halfway."
+		return nil, fmt.Errorf("entity graph: scan aborted after line %d: %w", lineNo, err)
 	}
 	return edges, nil
 }

--- a/internal/team/entity_graph_test.go
+++ b/internal/team/entity_graph_test.go
@@ -251,14 +251,47 @@ func TestStripRelatedSection(t *testing.T) {
 	}{
 		{"no section", "# Title\n\nBody.\n", "# Title\n\nBody.\n"},
 		{
-			"with section",
+			// Legacy pre-sentinel briefs: shape-match the bullet-only tail.
+			"legacy trailing section — stripped",
 			"# Title\n\nBody.\n\n## Related\n\n- [[companies/acme]]\n",
 			"# Title\n\nBody.",
 		},
 		{
-			"case-insensitive",
+			"case-insensitive legacy",
 			"# X\n\nBody\n\n## related\n- a\n",
 			"# X\n\nBody",
+		},
+		{
+			// Sentinel-wrapped block (the shape the current renderer emits)
+			// is the strict path — strip regardless of surrounding content.
+			"sentinel-wrapped section — stripped",
+			"# Title\n\nBody.\n\n<!-- wuphf:related:start -->\n## Related\n\n- [[companies/acme]]\n<!-- wuphf:related:end -->\n",
+			"# Title\n\nBody.",
+		},
+		{
+			// A pathological LLM response that emits "## Related" inside a
+			// code fence must not trigger the fallback path. With sentinels
+			// absent AND the true last heading being the in-fence one, the
+			// fallback sees "## Next steps" as the last real heading and
+			// correctly leaves the body alone.
+			"## Related inside fenced code block — preserved",
+			"# X\n\n## Intro\n\nBody.\n\n```\n## Related\nnot a real section\n```\n\n## Next steps\n\nMore.\n",
+			"# X\n\n## Intro\n\nBody.\n\n```\n## Related\nnot a real section\n```\n\n## Next steps\n\nMore.\n",
+		},
+		{
+			// The critical regression case: "## Related" appears mid-document
+			// with prose under it (not bullet items). Must NOT be stripped —
+			// it doesn't match the managed-section shape.
+			"mid-document Related with prose — preserved",
+			"# X\n\n## Related\n\nSarah works on many related projects including the onboarding flow.\n\n## Contact\n\nEmail: s@x.com\n",
+			"# X\n\n## Related\n\nSarah works on many related projects including the onboarding flow.\n\n## Contact\n\nEmail: s@x.com\n",
+		},
+		{
+			// Last heading is "## Related" with only bullets under it: this
+			// IS the managed shape, so fallback strips.
+			"fallback: last heading is Related with only bullets",
+			"# X\n\n## Notes\n\nThings.\n\n## Related\n\n- [[companies/acme]]\n",
+			"# X\n\n## Notes\n\nThings.",
 		},
 	}
 	for _, tc := range cases {
@@ -297,7 +330,11 @@ func TestRenderRelatedSection_AppendsFromGraph(t *testing.T) {
 	if out == "" {
 		t.Fatal("expected Related section, got empty")
 	}
-	if want := "## Related\n\n- [[companies/acme]]\n"; out != want {
+	// Output is wrapped in the wuphf:related sentinels so stripRelatedSection
+	// can remove the managed block on the next synthesis pass without
+	// shape-matching heuristics.
+	want := relatedSentinelStart + "\n## Related\n\n- [[companies/acme]]\n" + relatedSentinelEnd + "\n"
+	if out != want {
 		t.Errorf("got %q; want %q", out, want)
 	}
 }

--- a/internal/team/entity_synthesizer.go
+++ b/internal/team/entity_synthesizer.go
@@ -500,8 +500,11 @@ func (s *EntitySynthesizer) renderRelatedSection(kind EntityKind, slug string) s
 	if len(edges) > MaxRelatedEntries {
 		edges = edges[:MaxRelatedEntries]
 	}
+	// Wrap in sentinels so the next synthesis can strip the managed block
+	// deterministically, regardless of what the LLM writes around it.
 	var b strings.Builder
-	b.WriteString("## Related\n\n")
+	b.WriteString(relatedSentinelStart)
+	b.WriteString("\n## Related\n\n")
 	for _, e := range edges {
 		b.WriteString("- [[")
 		b.WriteString(string(e.ToKind))
@@ -509,27 +512,78 @@ func (s *EntitySynthesizer) renderRelatedSection(kind EntityKind, slug string) s
 		b.WriteString(e.ToSlug)
 		b.WriteString("]]\n")
 	}
+	b.WriteString(relatedSentinelEnd)
+	b.WriteString("\n")
 	return b.String()
 }
 
-// stripRelatedSection removes a trailing "## Related" heading and its
-// contents from body. Case-insensitive match on the heading line. Returns
-// the input unchanged when no Related section is present.
+// relatedSentinelStart / relatedSentinelEnd wrap the managed "## Related"
+// block written by renderRelatedSection. Stripping is anchored to these
+// HTML comments rather than to the heading text itself, so a pathological
+// LLM response that emits a literal "## Related" heading — inline, mid-
+// document, inside a code fence, or in prose discussing a "Related"
+// project — cannot trick the stripper into truncating the brief body.
+//
+// The legacy case (pre-sentinel section emitted by earlier renderer or
+// injected directly by a model ignoring instructions) is handled by the
+// fallback path: strip only when "## Related" is the very LAST non-empty
+// heading block in the document AND all following non-empty lines look
+// like bullet items. That narrow shape matches what the renderer always
+// produced and avoids catching arbitrary prose.
+const (
+	relatedSentinelStart = "<!-- wuphf:related:start -->"
+	relatedSentinelEnd   = "<!-- wuphf:related:end -->"
+)
+
+// stripRelatedSection removes the managed "## Related" section from body.
+// Two-level match: strict sentinel block first, narrow fallback second.
+// Returns the input unchanged when no qualifying section is present.
 func stripRelatedSection(body string) string {
-	lines := strings.Split(body, "\n")
-	cutIdx := -1
-	for i, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.EqualFold(trimmed, "## Related") {
-			cutIdx = i
-			break
+	// Strict path — sentinel-wrapped section.
+	if start := strings.Index(body, relatedSentinelStart); start >= 0 {
+		after := body[start+len(relatedSentinelStart):]
+		end := strings.Index(after, relatedSentinelEnd)
+		if end >= 0 {
+			tail := after[end+len(relatedSentinelEnd):]
+			return strings.TrimRight(body[:start]+tail, "\n")
 		}
 	}
-	if cutIdx < 0 {
+	// Fallback — pre-sentinel briefs or LLM-injected sections. Only strip
+	// when "## Related" is the last top-level heading AND everything after
+	// it is bullet markers or blank lines (the shape renderRelatedSection
+	// always produced). Any prose after the heading disqualifies the match.
+	lines := strings.Split(body, "\n")
+	inFence := false
+	lastHeading := -1
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "```") || strings.HasPrefix(trimmed, "~~~") {
+			inFence = !inFence
+			continue
+		}
+		if inFence {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "## ") {
+			lastHeading = i
+		}
+	}
+	if lastHeading < 0 {
 		return body
 	}
-	// Drop from the heading to EOF — the Related section is always trailing.
-	return strings.TrimRight(strings.Join(lines[:cutIdx], "\n"), "\n")
+	if !strings.EqualFold(strings.TrimSpace(lines[lastHeading]), "## Related") {
+		return body
+	}
+	for _, line := range lines[lastHeading+1:] {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		if !(strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") || strings.HasPrefix(trimmed, "+ ")) {
+			return body
+		}
+	}
+	return strings.TrimRight(strings.Join(lines[:lastHeading], "\n"), "\n")
 }
 
 // Frontmatter helpers live in entity_frontmatter.go.

--- a/web/src/components/wiki/EntityRelatedPanel.test.tsx
+++ b/web/src/components/wiki/EntityRelatedPanel.test.tsx
@@ -74,4 +74,68 @@ describe('<EntityRelatedPanel>', () => {
     render(<EntityRelatedPanel kind="people" slug="sarah" />)
     await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument())
   })
+
+  // The panel's whole value proposition is real-time updates when agents
+  // record facts. This test captures the fact_recorded callback and fires
+  // it, then asserts the panel re-queries the graph API and re-renders
+  // with the new edge. Without this, the SSE wiring is structurally
+  // present but behaviorally unverified.
+  it('re-fetches the graph on entity:fact_recorded for this entity', async () => {
+    let capturedOnFact: (() => void) | null = null
+    let capturedKind: unknown = null
+    let capturedSlug: unknown = null
+    vi.spyOn(api, 'subscribeEntityEvents').mockImplementation(
+      (kind, slug, onFact) => {
+        capturedKind = kind
+        capturedSlug = slug
+        capturedOnFact = onFact as () => void
+        return () => {}
+      },
+    )
+
+    const initial: api.GraphEdge[] = [
+      {
+        from_kind: 'people',
+        from_slug: 'sarah',
+        to_kind: 'companies',
+        to_slug: 'acme',
+        first_seen_fact_id: 'f1',
+        last_seen_ts: '2026-04-20T00:00:00Z',
+        occurrence_count: 1,
+      },
+    ]
+    const updated: api.GraphEdge[] = [
+      ...initial,
+      {
+        from_kind: 'people',
+        from_slug: 'sarah',
+        to_kind: 'customers',
+        to_slug: 'globex',
+        first_seen_fact_id: 'f2',
+        last_seen_ts: '2026-04-21T00:00:00Z',
+        occurrence_count: 1,
+      },
+    ]
+    const fetchSpy = vi
+      .spyOn(api, 'fetchEntityGraph')
+      .mockResolvedValueOnce(initial)
+      .mockResolvedValueOnce(updated)
+
+    render(<EntityRelatedPanel kind="people" slug="sarah" />)
+    await screen.findByText('companies/acme')
+    expect(screen.queryByText('customers/globex')).toBeNull()
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+    // Confirm the subscriber was scoped to this entity's kind+slug, so the
+    // broker-side filter will only hand us events for sarah/people.
+    expect(capturedKind).toBe('people')
+    expect(capturedSlug).toBe('sarah')
+
+    // Fire the fact_recorded callback as the SSE layer would.
+    expect(capturedOnFact).not.toBeNull()
+    capturedOnFact!()
+
+    await screen.findByText('customers/globex')
+    expect(fetchSpy).toHaveBeenCalledTimes(2)
+  })
 })


### PR DESCRIPTION
## Summary

Follow-ups from the multi-perspective review after #197 landed.

## Changes

### 🔴 HIGH — `stripRelatedSection` silent data loss

**Before:** first `## Related` in the body truncated everything from that point to EOF. A pathological LLM response that emitted the heading mid-document, inside a code fence, or in a "Related projects" section silently dropped the brief body.

**Now:** the managed block is wrapped in sentinels emitted by `renderRelatedSection`:

```
<!-- wuphf:related:start -->
## Related

- [[companies/acme]]
<!-- wuphf:related:end -->
```

`stripRelatedSection` matches strictly between the sentinels (strict path). For legacy pre-sentinel briefs and LLM-injected sections, it falls back to a narrow shape match: the heading must be the LAST top-level heading, AND everything after it must be bullet items or blank lines. Any prose disqualifies the match.

### 🔴 HIGH — Latent deadlock in `RecordFactRefs`

**Before:** `g.mu` held across the blocking `EnqueueEntityGraph` call (channel send + up-to-`wikiWriteTimeout` reply wait). No current reader takes `g.mu`, so it was latent — but any future read path that acquired the same mutex would deadlock.

**Now:** build `buf` under the lock, release, then enqueue.

### 🟡 MEDIUM — `readAll()` partial-slice on scanner error

Was logging the error and returning accumulated edges with `nil` error. Now propagates the error so `Coalesce`/`Query` can surface a truncated read instead of silently returning stale results.

### 🟡 MEDIUM — Missing test coverage

- **`TestHandleEntityFact_GraphRecordFailureDoesNotBreakFactWrite`** — locks in the "graph is additive, never a constraint on the fact log" contract. Adds a `graphRecordFactRefs` test seam; overrides it with an error-returning stub; asserts POST `/entity/fact` still returns 200 with a valid fact envelope.
- **`<EntityRelatedPanel>` SSE refetch test** — captures the `subscribeEntityEvents` callback, fires it, asserts `fetchEntityGraph` is called again and the new edge renders. The SSE wiring was structurally present but behaviorally unverified (every existing test stubbed the subscriber to no-op).

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./internal/team -run "StripRelated|RecordFactRefs|EntityGraph|HandleEntityFact"` green
- `cd web && npx vitest run` — 259/259 across 53 files (5/5 on EntityRelatedPanel)
- One pre-existing race flake in `TestHeadlessTurnCompletedDurablyRejectsCodingTurnWithoutTaskStateOrEvidence` reproduces on untouched main; unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)