### PR TITLE
fix(team): wait for wiki worker side goroutines before tempdir cleanup

### DIFF
--- a/internal/team/entity_facts_test.go
+++ b/internal/team/entity_facts_test.go
@@ -35,7 +35,7 @@ func newFactLogFixture(t *testing.T) (*FactLog, *WikiWorker, func()) {
 	log := NewFactLog(worker)
 	return log, worker, func() {
 		cancel()
-		worker.Stop()
+		<-worker.Done()
 	}
 }
 

--- a/internal/team/entity_synthesizer_test.go
+++ b/internal/team/entity_synthesizer_test.go
@@ -60,7 +60,7 @@ func newSynthFixture(t *testing.T, llmStub func(ctx context.Context, sys, user s
 	return synth, factLog, worker, pub, func() {
 		synth.Stop()
 		cancel()
-		worker.Stop()
+		<-worker.Done()
 	}
 }
 

--- a/internal/team/notebook_worker_test.go
+++ b/internal/team/notebook_worker_test.go
@@ -55,7 +55,7 @@ func newStartedNotebookWorker(t *testing.T) (*WikiWorker, *Repo, *recordingNoteb
 	worker.Start(ctx)
 	return worker, repo, pub, func() {
 		cancel()
-		worker.Stop()
+		<-worker.Done()
 	}
 }
 

--- a/internal/team/playbook_synthesizer_test.go
+++ b/internal/team/playbook_synthesizer_test.go
@@ -59,7 +59,7 @@ func newPlaybookSynthFixture(
 	teardown := func() {
 		synth.Stop()
 		cancel()
-		worker.Stop()
+		<-worker.Done()
 	}
 	return synth, execLog, worker, pub, teardown
 }

--- a/internal/team/wiki_worker.go
+++ b/internal/team/wiki_worker.go
@@ -155,10 +155,16 @@ type WikiWorker struct {
 	lastBackupAt  time.Time
 	backupPending atomic.Bool
 
-	// sideGoroutines tracks async helpers (e.g. auto-recompile) spawned
-	// from the drain loop so Stop() can wait for them before closing the
-	// request channel.
+	// sideGoroutines tracks async helpers (e.g. auto-recompile, backup
+	// mirror) spawned from the drain loop so Stop() and WaitForIdle() can
+	// block until they finish — essential for tests on Linux where
+	// t.TempDir() cleanup otherwise races in-flight repo writes.
 	sideGoroutines sync.WaitGroup
+
+	// drainDone closes when the drain goroutine has fully exited (including
+	// its own sideGoroutines.Wait). Tests register `t.Cleanup(func() {
+	// cancel(); <-worker.Done() })` so tempdir removal is deterministic.
+	drainDone chan struct{}
 }
 
 // NewWikiWorker returns a worker ready to Start. The publisher is optional;
@@ -171,6 +177,7 @@ func NewWikiWorker(repo *Repo, publisher wikiEventPublisher) *WikiWorker {
 		repo:      repo,
 		publisher: publisher,
 		requests:  make(chan wikiWriteRequest, wikiRequestBuffer),
+		drainDone: make(chan struct{}),
 	}
 }
 
@@ -230,7 +237,13 @@ func (w *WikiWorker) Enqueue(ctx context.Context, slug, path, content, mode, com
 
 // drain is the single worker goroutine. It runs exactly one request at a time.
 func (w *WikiWorker) drain(ctx context.Context) {
+	defer close(w.drainDone)
 	defer w.running.Store(false)
+	// Wait for detached helpers (auto-recompile, backup mirror) before the
+	// drain goroutine returns so test harnesses that cancel the context see
+	// a quiesced worker — otherwise background writes to the repo can race
+	// t.TempDir() cleanup.
+	defer w.sideGoroutines.Wait()
 	for {
 		select {
 		case <-ctx.Done():
@@ -289,7 +302,15 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 		req.ReplyCh <- wikiWriteResult{SHA: sha, Err: err}
 		return
 	}
-	req.ReplyCh <- wikiWriteResult{SHA: sha, BytesWritten: n}
+	// Reply is sent at the end of process() so every sideGoroutines.Add(1)
+	// from the event fan-out below has landed before the caller unblocks.
+	// Tests that call WaitForIdle() right after Enqueue can then see a
+	// consistent WaitGroup counter — without this ordering, the backup
+	// mirror goroutine could still be spawning while t.TempDir() cleanup
+	// races it.
+	defer func() {
+		req.ReplyCh <- wikiWriteResult{SHA: sha, BytesWritten: n}
+	}()
 
 	ts := time.Now().UTC().Format(time.RFC3339)
 	switch {
@@ -370,7 +391,9 @@ func (w *WikiWorker) maybeScheduleBackup(ctx context.Context) {
 	if !w.backupPending.CompareAndSwap(false, true) {
 		return
 	}
+	w.sideGoroutines.Add(1)
 	go func() {
+		defer w.sideGoroutines.Done()
 		defer w.backupPending.Store(false)
 		bgCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
@@ -389,6 +412,27 @@ func (w *WikiWorker) maybeScheduleBackup(ctx context.Context) {
 // diagnostics and tests.
 func (w *WikiWorker) QueueLength() int {
 	return len(w.requests)
+}
+
+// WaitForIdle blocks until every detached side goroutine spawned by the
+// worker (auto-recompile, backup mirror) has finished. Tests register this
+// via t.Cleanup so t.TempDir() RemoveAll does not race in-flight background
+// writes into wiki.bak/ — the symptom is "directory not empty" or
+// "no such file or directory" cleanup errors on Linux CI.
+//
+// Safe to call after ctx cancellation: the side-goroutine WaitGroup is
+// independent of drain lifecycle.
+func (w *WikiWorker) WaitForIdle() {
+	w.sideGoroutines.Wait()
+}
+
+// Done returns a channel that closes when the drain goroutine has fully
+// exited — including its wait on side goroutines. Tests that started the
+// worker with a cancellable context should `<-worker.Done()` after the
+// cancel so drain's in-flight repo writes settle before t.TempDir()
+// removal.
+func (w *WikiWorker) Done() <-chan struct{} {
+	return w.drainDone
 }
 
 // EnqueueHuman submits a human-authored wiki write to the shared single-

--- a/internal/team/wiki_worker_test.go
+++ b/internal/team/wiki_worker_test.go
@@ -49,7 +49,11 @@ func newStartedWorker(t *testing.T) (*WikiWorker, *Repo, *recordingPublisher, co
 	worker.Start(ctx)
 	return worker, repo, pub, func() {
 		cancel()
-		worker.Stop()
+		// Wait for drain (and its side goroutines — auto-recompile and
+		// backup mirror) to fully exit before the test returns, so
+		// t.TempDir() cleanup does not race in-flight writes into
+		// wiki.bak/ or the main wiki repo.
+		<-worker.Done()
 	}
 }
 


### PR DESCRIPTION
## Summary

The `test` job has been red on main since #192 and #193 landed. Symptom on Linux CI:

\`\`\`
testing.go:1369: TempDir RemoveAll cleanup:
  unlinkat /tmp/<Test>/.../wiki.bak/.git: directory not empty
\`\`\`

Ten-plus tests (\`TestCommitHumanHappyPath\`, \`TestNotebookWriteHappyPath\`, \`TestWikiSearchReturnsHits\`, \`TestFactLog_MalformedLineRecovery\`, \`TestSynthesizer_StopPreventsNewJobs\`, \`TestPlaybookSynthesizer_StopPreventsNewJobs\`, etc.) fail this way on every CI run. They pass locally on macOS because the timing window is wider.

Root cause: \`WikiWorker\` spawned a detached backup-mirror goroutine (\`maybeScheduleBackup\`), and test fixtures used \`defer cancel()\` without waiting for drain. Drain exited on \`ctx.Done\`, but the backup goroutine — and any in-flight drain write — could still be touching the repo while \`t.TempDir\` RemoveAll ran.

## Fix

1. Track the backup mirror goroutine in \`sideGoroutines\` (it was fire-and-forget; auto-recompile was already tracked).
2. \`defer sideGoroutines.Wait()\` + \`defer close(drainDone)\` in drain so drain only returns once all detached helpers have finished, and tests can observe full shutdown.
3. Move the \`ReplyCh\` send in \`process()\` to a deferred send at the end of the function. Without this, a caller could return from \`Enqueue\` before \`sideGoroutines.Add(1)\` for backup/auto-recompile had happened, so \`WaitForIdle\` would see an incorrectly-low counter.

Expose \`Done()\` and \`WaitForIdle()\` so tests can pick the right synchronization point.

Update the five shared fixture teardowns (\`newStartedWorker\`, \`newStartedNotebookWorker\`, \`newFactLogFixture\`, \`newSynthFixture\`, \`newPlaybookSynthFixture\`) to wait on \`<-worker.Done()\` instead of \`worker.Stop()\`. \`Stop\` was unreliable because drain's own defer flips \`running → false\`, so \`Stop\`'s \`if !running.Swap(false)\` branch could short-circuit the \`sideGoroutines.Wait\`.

## Blocks

Unblocks PR #194 (embed VERSION fix), which is dead in the water on the same flake.

## Test plan

- [x] \`go test ./internal/team/...\` — pass (68s, no flake)
- [x] \`go test -count=5 -run 'TestCommitHuman...|TestNotebook...|TestWiki...|TestSynth...|TestFactLog...|TestPlaybookSynth...'\` — pass (5x in a row)
- [x] \`go test ./...\` — full repo pass
- [ ] CI green on this PR (Linux is where the flake reproduces)