### PR TITLE
fix(launcher): overflow pane spawn errors + codex-bound agents + MCP tool audit

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -1272,6 +1272,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/v1/logs", b.requireAuth(b.handleOTLPLogs))
 	mux.HandleFunc("/events", b.handleEvents)
 	mux.HandleFunc("/agent-stream/", b.requireAuth(b.handleAgentStream))
+	mux.HandleFunc("/agent-tool-event", b.requireAuth(b.handleAgentToolEvent))
 	mux.HandleFunc("/web-token", b.handleWebToken)
 	// Onboarding: state/progress/complete + prereqs/templates/validate-key + checklist.
 	// completeFn posts the first task as a human message and seeds the team.
@@ -1834,6 +1835,81 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 			flusher.Flush()
 		}
 	}
+}
+
+// handleAgentToolEvent appends a tool-call log line to the agent's stream so
+// the per-agent activity panel shows which MCP tool was invoked with what
+// arguments. Without this, the stream only shows raw pane-captured stdout —
+// useless for agents whose work happens entirely through MCP tool calls.
+//
+// Body: {"slug":"ceo","phase":"call|result|error","tool":"team_broadcast","args":"...","result":"...","error":"..."}
+// Phase is informational; all fields but slug are optional.
+func (b *Broker) handleAgentToolEvent(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Slug    string `json:"slug"`
+		Phase   string `json:"phase,omitempty"`
+		Tool    string `json:"tool,omitempty"`
+		Args    string `json:"args,omitempty"`
+		Result  string `json:"result,omitempty"`
+		Error   string `json:"error,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	slug := strings.TrimSpace(body.Slug)
+	if slug == "" {
+		http.Error(w, "missing slug", http.StatusBadRequest)
+		return
+	}
+	stream := b.AgentStream(slug)
+	if stream == nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	line := formatAgentToolEvent(body.Phase, body.Tool, body.Args, body.Result, body.Error)
+	if line != "" {
+		stream.Push(line)
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// formatAgentToolEvent renders a compact one-line audit record for the
+// per-agent stream. Truncates noisy fields so a long result doesn't blow the
+// stream buffer.
+func formatAgentToolEvent(phase, tool, args, result, errStr string) string {
+	const maxField = 240
+	truncate := func(s string) string {
+		s = strings.TrimSpace(s)
+		s = strings.ReplaceAll(s, "\n", " ")
+		if len(s) > maxField {
+			return s[:maxField] + "…"
+		}
+		return s
+	}
+	tool = strings.TrimSpace(tool)
+	phase = strings.TrimSpace(phase)
+	if phase == "" {
+		phase = "tool"
+	}
+	if tool == "" {
+		return ""
+	}
+	parts := []string{fmt.Sprintf("[%s] %s", phase, tool)}
+	if args != "" {
+		parts = append(parts, "args="+truncate(args))
+	}
+	if result != "" {
+		parts = append(parts, "result="+truncate(result))
+	}
+	if errStr != "" {
+		parts = append(parts, "error="+truncate(errStr))
+	}
+	return strings.Join(parts, " ")
 }
 
 // handleAgentStream serves a per-agent stdout SSE stream.

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -899,7 +899,6 @@ func (b *Broker) publishMessageLocked(msg channelMessage) {
 	}
 }
 
-
 func (b *Broker) publishActionLocked(action officeActionLog) {
 	for _, ch := range b.actionSubscribers {
 		select {
@@ -1851,12 +1850,12 @@ func (b *Broker) handleAgentToolEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body struct {
-		Slug    string `json:"slug"`
-		Phase   string `json:"phase,omitempty"`
-		Tool    string `json:"tool,omitempty"`
-		Args    string `json:"args,omitempty"`
-		Result  string `json:"result,omitempty"`
-		Error   string `json:"error,omitempty"`
+		Slug   string `json:"slug"`
+		Phase  string `json:"phase,omitempty"`
+		Tool   string `json:"tool,omitempty"`
+		Args   string `json:"args,omitempty"`
+		Result string `json:"result,omitempty"`
+		Error  string `json:"error,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -7046,10 +7045,11 @@ func (b *Broker) SeenTelegramGroups() map[int64]string {
 	return out
 }
 
-// PostSystemMessage posts a lightweight system message that shows progress without blocking.
 // MarkRoutingTargets records implicit-routing recipients as "typing" so the
-// UI's typing indicator highlights them. Called alongside PostRoutingBanner
-// so users see both "Routing to @X..." and the per-agent typing pulse.
+// web TypingIndicator can render "X is thinking..." above the composer
+// without inserting a persisted "Routing to @X..." chat message. The entry
+// auto-clears on the next POST /messages from the agent (see the delete
+// in handlePostMessage), so the indicator is naturally ephemeral.
 func (b *Broker) MarkRoutingTargets(slugs []string) {
 	if len(slugs) == 0 {
 		return

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -455,8 +455,6 @@ type Broker struct {
 	usage                   teamUsageState
 	externalDelivered       map[string]struct{} // message IDs already queued for external delivery
 	messageSubscribers      map[int]chan channelMessage
-	messageRemovedSubs      map[int]chan messageRemovedEvent
-	pendingRoutingBanners   map[string]routingBannerEntry
 	actionSubscribers       map[int]chan officeActionLog
 	activity                map[string]agentActivitySnapshot
 	activitySubscribers     map[int]chan agentActivitySnapshot
@@ -860,7 +858,6 @@ func NewBroker() *Broker {
 		channelStore:        channel.NewStore(),
 		token:               generateToken(),
 		messageSubscribers:  make(map[int]chan channelMessage),
-		messageRemovedSubs:  make(map[int]chan messageRemovedEvent),
 		actionSubscribers:   make(map[int]chan officeActionLog),
 		activity:            make(map[string]agentActivitySnapshot),
 		activitySubscribers: make(map[int]chan agentActivitySnapshot),
@@ -891,7 +888,6 @@ func NewBroker() *Broker {
 func (b *Broker) appendMessageLocked(msg channelMessage) {
 	b.messages = append(b.messages, msg)
 	b.publishMessageLocked(msg)
-	b.clearRoutingBannerForReplyLocked(msg)
 }
 
 func (b *Broker) publishMessageLocked(msg channelMessage) {
@@ -903,46 +899,6 @@ func (b *Broker) publishMessageLocked(msg channelMessage) {
 	}
 }
 
-type messageRemovedEvent struct {
-	Channel string `json:"channel"`
-	ID      string `json:"id"`
-}
-
-func (b *Broker) publishMessageRemovedLocked(channel, id string) {
-	evt := messageRemovedEvent{Channel: normalizeChannelSlug(channel), ID: id}
-	for _, ch := range b.messageRemovedSubs {
-		select {
-		case ch <- evt:
-		default:
-		}
-	}
-}
-
-// SubscribeMessageRemoved returns a channel that receives message-removed
-// events (used for ephemeral banners like routing hints that disappear
-// once their target agent replies).
-func (b *Broker) SubscribeMessageRemoved(buffer int) (<-chan messageRemovedEvent, func()) {
-	if buffer <= 0 {
-		buffer = 1
-	}
-	ch := make(chan messageRemovedEvent, buffer)
-	b.mu.Lock()
-	if b.messageRemovedSubs == nil {
-		b.messageRemovedSubs = make(map[int]chan messageRemovedEvent)
-	}
-	id := b.nextSubscriberID
-	b.nextSubscriberID++
-	b.messageRemovedSubs[id] = ch
-	b.mu.Unlock()
-	return ch, func() {
-		b.mu.Lock()
-		if existing, ok := b.messageRemovedSubs[id]; ok {
-			delete(b.messageRemovedSubs, id)
-			close(existing)
-		}
-		b.mu.Unlock()
-	}
-}
 
 func (b *Broker) publishActionLocked(action officeActionLog) {
 	for _, ch := range b.actionSubscribers {
@@ -1785,8 +1741,6 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 
 	messages, unsubscribeMessages := b.SubscribeMessages(256)
 	defer unsubscribeMessages()
-	messagesRemoved, unsubscribeMessagesRemoved := b.SubscribeMessageRemoved(64)
-	defer unsubscribeMessagesRemoved()
 	actions, unsubscribeActions := b.SubscribeActions(256)
 	defer unsubscribeActions()
 	activity, unsubscribeActivity := b.SubscribeActivity(256)
@@ -1833,10 +1787,6 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 			return
 		case msg, ok := <-messages:
 			if !ok || writeEvent("message", map[string]any{"message": msg}) != nil {
-				return
-			}
-		case evt, ok := <-messagesRemoved:
-			if !ok || writeEvent("message_removed", evt) != nil {
 				return
 			}
 		case action, ok := <-actions:
@@ -5756,7 +5706,16 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 		// reflected immediately without requiring a broker restart.
 		if provider != "" {
 			b.mu.Lock()
+			providerChanged := b.runtimeProvider != provider
 			b.runtimeProvider = provider
+			if providerChanged {
+				// Tell the launcher to respawn panes (if claude-code) or
+				// tear them down (if codex). Without this, a user who
+				// switches provider in Settings keeps seeing stale claude
+				// panes while dispatch routes through codex — the textbook
+				// "I picked Codex, why is Claude still running" symptom.
+				b.publishOfficeChangeLocked(officeChangeEvent{Kind: "office_reseeded"})
+			}
 			b.mu.Unlock()
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -5811,9 +5770,31 @@ func (b *Broker) handleOfficeMembers(w http.ResponseWriter, r *http.Request) {
 		b.mu.Lock()
 		members := make([]officeMember, len(b.members))
 		copy(members, b.members)
+		// Surface "active" status for agents tagged within the last 60s that
+		// haven't yet replied. The web TypingIndicator reads this to render
+		// "X is thinking..." as ephemeral system text while a message is
+		// being routed. Without this field the indicator never shows —
+		// `status` was on the TS type but the backend never populated it.
+		taggedAt := b.lastTaggedAt
 		b.mu.Unlock()
+
+		type officeMemberView struct {
+			officeMember
+			Status string `json:"status,omitempty"`
+		}
+		views := make([]officeMemberView, len(members))
+		cutoff := time.Now().Add(-60 * time.Second)
+		for i, m := range members {
+			v := officeMemberView{officeMember: m}
+			if taggedAt != nil {
+				if t, ok := taggedAt[m.Slug]; ok && t.After(cutoff) {
+					v.Status = "active"
+				}
+			}
+			views[i] = v
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"members": members})
+		_ = json.NewEncoder(w).Encode(map[string]any{"members": views})
 	case http.MethodPost:
 		var body struct {
 			Action         string                    `json:"action"`
@@ -7086,102 +7067,6 @@ func (b *Broker) MarkRoutingTargets(slugs []string) {
 		}
 		b.lastTaggedAt[slug] = now
 	}
-}
-
-// PostRoutingBanner posts a "Routing to @X..." system message and registers
-// it to be auto-deleted once any of the target agents replies in the same
-// channel. Returns the posted message ID so callers can track it.
-func (b *Broker) PostRoutingBanner(channel string, targetSlugs []string) string {
-	if len(targetSlugs) == 0 {
-		return ""
-	}
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	channel = normalizeChannelSlug(channel)
-	if channel == "" {
-		channel = "general"
-	}
-	names := make([]string, 0, len(targetSlugs))
-	for _, s := range targetSlugs {
-		s = strings.TrimSpace(s)
-		if s == "" {
-			continue
-		}
-		names = append(names, "@"+s)
-	}
-	if len(names) == 0 {
-		return ""
-	}
-	b.counter++
-	msg := channelMessage{
-		ID:        fmt.Sprintf("msg-%d", b.counter),
-		From:      "system",
-		Channel:   channel,
-		Kind:      "routing",
-		Content:   fmt.Sprintf("Routing to %s...", strings.Join(names, ", ")),
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-	}
-	b.appendMessageLocked(msg)
-	if b.pendingRoutingBanners == nil {
-		b.pendingRoutingBanners = make(map[string]routingBannerEntry)
-	}
-	for _, slug := range targetSlugs {
-		slug = strings.TrimSpace(slug)
-		if slug == "" {
-			continue
-		}
-		b.pendingRoutingBanners[routingBannerKey(channel, slug)] = routingBannerEntry{
-			MessageID: msg.ID,
-			Channel:   channel,
-			CreatedAt: time.Now(),
-		}
-	}
-	return msg.ID
-}
-
-// clearRoutingBannerForReplyLocked removes any pending routing banner that
-// was awaiting this agent's reply. Called from the message-append path so
-// the banner vanishes the moment the target posts anything in the channel.
-// Must be called with b.mu held.
-func (b *Broker) clearRoutingBannerForReplyLocked(msg channelMessage) {
-	if len(b.pendingRoutingBanners) == 0 {
-		return
-	}
-	if msg.From == "" || msg.From == "system" || msg.From == "you" || msg.From == "human" {
-		return
-	}
-	key := routingBannerKey(msg.Channel, msg.From)
-	entry, ok := b.pendingRoutingBanners[key]
-	if !ok {
-		return
-	}
-	// Drop every pending mapping that points at this banner (another target
-	// could still be expected for the same banner; removing the banner
-	// invalidates all of them).
-	for k, e := range b.pendingRoutingBanners {
-		if e.MessageID == entry.MessageID {
-			delete(b.pendingRoutingBanners, k)
-		}
-	}
-	next := b.messages[:0]
-	for _, existing := range b.messages {
-		if existing.ID == entry.MessageID && existing.Kind == "routing" {
-			b.publishMessageRemovedLocked(existing.Channel, existing.ID)
-			continue
-		}
-		next = append(next, existing)
-	}
-	b.messages = next
-}
-
-func routingBannerKey(channel, slug string) string {
-	return normalizeChannelSlug(channel) + "|" + strings.TrimSpace(slug)
-}
-
-type routingBannerEntry struct {
-	MessageID string
-	Channel   string
-	CreatedAt time.Time
 }
 
 func (b *Broker) PostSystemMessage(channel, content, kind string) {

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -7015,6 +7015,30 @@ func (b *Broker) SeenTelegramGroups() map[int64]string {
 }
 
 // PostSystemMessage posts a lightweight system message that shows progress without blocking.
+// MarkRoutingTargets records implicit-routing recipients as "typing" so the
+// UI's typing indicator can display them without a persisted system message.
+// Replaces the old "Routing to @X..." broker post — that message was
+// permanent clutter in the channel; this drives the same signal through
+// lastTaggedAt, which already auto-clears when the agent replies.
+func (b *Broker) MarkRoutingTargets(slugs []string) {
+	if len(slugs) == 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.lastTaggedAt == nil {
+		b.lastTaggedAt = make(map[string]time.Time)
+	}
+	now := time.Now()
+	for _, slug := range slugs {
+		slug = strings.TrimSpace(slug)
+		if slug == "" {
+			continue
+		}
+		b.lastTaggedAt[slug] = now
+	}
+}
+
 func (b *Broker) PostSystemMessage(channel, content, kind string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -455,6 +455,8 @@ type Broker struct {
 	usage                   teamUsageState
 	externalDelivered       map[string]struct{} // message IDs already queued for external delivery
 	messageSubscribers      map[int]chan channelMessage
+	messageRemovedSubs      map[int]chan messageRemovedEvent
+	pendingRoutingBanners   map[string]routingBannerEntry
 	actionSubscribers       map[int]chan officeActionLog
 	activity                map[string]agentActivitySnapshot
 	activitySubscribers     map[int]chan agentActivitySnapshot
@@ -858,6 +860,7 @@ func NewBroker() *Broker {
 		channelStore:        channel.NewStore(),
 		token:               generateToken(),
 		messageSubscribers:  make(map[int]chan channelMessage),
+		messageRemovedSubs:  make(map[int]chan messageRemovedEvent),
 		actionSubscribers:   make(map[int]chan officeActionLog),
 		activity:            make(map[string]agentActivitySnapshot),
 		activitySubscribers: make(map[int]chan agentActivitySnapshot),
@@ -888,6 +891,7 @@ func NewBroker() *Broker {
 func (b *Broker) appendMessageLocked(msg channelMessage) {
 	b.messages = append(b.messages, msg)
 	b.publishMessageLocked(msg)
+	b.clearRoutingBannerForReplyLocked(msg)
 }
 
 func (b *Broker) publishMessageLocked(msg channelMessage) {
@@ -896,6 +900,47 @@ func (b *Broker) publishMessageLocked(msg channelMessage) {
 		case ch <- msg:
 		default:
 		}
+	}
+}
+
+type messageRemovedEvent struct {
+	Channel string `json:"channel"`
+	ID      string `json:"id"`
+}
+
+func (b *Broker) publishMessageRemovedLocked(channel, id string) {
+	evt := messageRemovedEvent{Channel: normalizeChannelSlug(channel), ID: id}
+	for _, ch := range b.messageRemovedSubs {
+		select {
+		case ch <- evt:
+		default:
+		}
+	}
+}
+
+// SubscribeMessageRemoved returns a channel that receives message-removed
+// events (used for ephemeral banners like routing hints that disappear
+// once their target agent replies).
+func (b *Broker) SubscribeMessageRemoved(buffer int) (<-chan messageRemovedEvent, func()) {
+	if buffer <= 0 {
+		buffer = 1
+	}
+	ch := make(chan messageRemovedEvent, buffer)
+	b.mu.Lock()
+	if b.messageRemovedSubs == nil {
+		b.messageRemovedSubs = make(map[int]chan messageRemovedEvent)
+	}
+	id := b.nextSubscriberID
+	b.nextSubscriberID++
+	b.messageRemovedSubs[id] = ch
+	b.mu.Unlock()
+	return ch, func() {
+		b.mu.Lock()
+		if existing, ok := b.messageRemovedSubs[id]; ok {
+			delete(b.messageRemovedSubs, id)
+			close(existing)
+		}
+		b.mu.Unlock()
 	}
 }
 
@@ -1740,6 +1785,8 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 
 	messages, unsubscribeMessages := b.SubscribeMessages(256)
 	defer unsubscribeMessages()
+	messagesRemoved, unsubscribeMessagesRemoved := b.SubscribeMessageRemoved(64)
+	defer unsubscribeMessagesRemoved()
 	actions, unsubscribeActions := b.SubscribeActions(256)
 	defer unsubscribeActions()
 	activity, unsubscribeActivity := b.SubscribeActivity(256)
@@ -1786,6 +1833,10 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 			return
 		case msg, ok := <-messages:
 			if !ok || writeEvent("message", map[string]any{"message": msg}) != nil {
+				return
+			}
+		case evt, ok := <-messagesRemoved:
+			if !ok || writeEvent("message_removed", evt) != nil {
 				return
 			}
 		case action, ok := <-actions:
@@ -7016,10 +7067,8 @@ func (b *Broker) SeenTelegramGroups() map[int64]string {
 
 // PostSystemMessage posts a lightweight system message that shows progress without blocking.
 // MarkRoutingTargets records implicit-routing recipients as "typing" so the
-// UI's typing indicator can display them without a persisted system message.
-// Replaces the old "Routing to @X..." broker post — that message was
-// permanent clutter in the channel; this drives the same signal through
-// lastTaggedAt, which already auto-clears when the agent replies.
+// UI's typing indicator highlights them. Called alongside PostRoutingBanner
+// so users see both "Routing to @X..." and the per-agent typing pulse.
 func (b *Broker) MarkRoutingTargets(slugs []string) {
 	if len(slugs) == 0 {
 		return
@@ -7037,6 +7086,102 @@ func (b *Broker) MarkRoutingTargets(slugs []string) {
 		}
 		b.lastTaggedAt[slug] = now
 	}
+}
+
+// PostRoutingBanner posts a "Routing to @X..." system message and registers
+// it to be auto-deleted once any of the target agents replies in the same
+// channel. Returns the posted message ID so callers can track it.
+func (b *Broker) PostRoutingBanner(channel string, targetSlugs []string) string {
+	if len(targetSlugs) == 0 {
+		return ""
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	channel = normalizeChannelSlug(channel)
+	if channel == "" {
+		channel = "general"
+	}
+	names := make([]string, 0, len(targetSlugs))
+	for _, s := range targetSlugs {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		names = append(names, "@"+s)
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	b.counter++
+	msg := channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "system",
+		Channel:   channel,
+		Kind:      "routing",
+		Content:   fmt.Sprintf("Routing to %s...", strings.Join(names, ", ")),
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}
+	b.appendMessageLocked(msg)
+	if b.pendingRoutingBanners == nil {
+		b.pendingRoutingBanners = make(map[string]routingBannerEntry)
+	}
+	for _, slug := range targetSlugs {
+		slug = strings.TrimSpace(slug)
+		if slug == "" {
+			continue
+		}
+		b.pendingRoutingBanners[routingBannerKey(channel, slug)] = routingBannerEntry{
+			MessageID: msg.ID,
+			Channel:   channel,
+			CreatedAt: time.Now(),
+		}
+	}
+	return msg.ID
+}
+
+// clearRoutingBannerForReplyLocked removes any pending routing banner that
+// was awaiting this agent's reply. Called from the message-append path so
+// the banner vanishes the moment the target posts anything in the channel.
+// Must be called with b.mu held.
+func (b *Broker) clearRoutingBannerForReplyLocked(msg channelMessage) {
+	if len(b.pendingRoutingBanners) == 0 {
+		return
+	}
+	if msg.From == "" || msg.From == "system" || msg.From == "you" || msg.From == "human" {
+		return
+	}
+	key := routingBannerKey(msg.Channel, msg.From)
+	entry, ok := b.pendingRoutingBanners[key]
+	if !ok {
+		return
+	}
+	// Drop every pending mapping that points at this banner (another target
+	// could still be expected for the same banner; removing the banner
+	// invalidates all of them).
+	for k, e := range b.pendingRoutingBanners {
+		if e.MessageID == entry.MessageID {
+			delete(b.pendingRoutingBanners, k)
+		}
+	}
+	next := b.messages[:0]
+	for _, existing := range b.messages {
+		if existing.ID == entry.MessageID && existing.Kind == "routing" {
+			b.publishMessageRemovedLocked(existing.Channel, existing.ID)
+			continue
+		}
+		next = append(next, existing)
+	}
+	b.messages = next
+}
+
+func routingBannerKey(channel, slug string) string {
+	return normalizeChannelSlug(channel) + "|" + strings.TrimSpace(slug)
+}
+
+type routingBannerEntry struct {
+	MessageID string
+	Channel   string
+	CreatedAt time.Time
 }
 
 func (b *Broker) PostSystemMessage(channel, content, kind string) {

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -158,41 +158,78 @@ func (b *Broker) materializeBlueprintWiki(bp operations.Blueprint) {
 	}
 }
 
-// synthesizeBlueprintFromState builds a blueprint from whatever the user
-// typed into the wizard (company name, description, size, priority, plus
-// the task text as directive). Reads onboarding state from disk, so it
-// must be called OUTSIDE the broker mutex. Unlike the old
-// seedBlankSlateOperationLocked it does not mutate broker state — the
-// caller feeds the returned Blueprint to seedFromBlueprintLocked.
+// synthesizeBlueprintFromState builds a blueprint for the "From scratch"
+// wizard path. Reads onboarding state from disk, so it must be called
+// OUTSIDE the broker mutex. Unlike the old seedBlankSlateOperationLocked
+// it does not mutate broker state — the caller feeds the returned
+// Blueprint to seedFromBlueprintLocked.
+//
+// The starter roster is a fixed 5-agent founding team (CEO lead plus GTM
+// Lead, Founding Engineer, Product Manager, Designer) rather than the
+// generic operator/planner/executor/reviewer shape. This is the product
+// default for a brand-new WUPHF office: it covers the four functions a
+// real early-stage team needs (strategy, revenue, build, design) with a
+// named CEO as the human-facing lead. Users can still uncheck agents in
+// the wizard's Team step; unchecked ones are dropped via the filter.
 func synthesizeBlueprintFromState(task string) operations.Blueprint {
 	state, err := onboarding.Load()
 	if err != nil {
 		// Best-effort: fall through with empty profile. A Load failure is
-		// logged by the onboarding package; SynthesizeBlueprint tolerates
-		// sparse input by producing a generic blueprint.
+		// logged by the onboarding package; we still produce a blueprint
+		// so the wizard can complete.
 		log.Printf("onboarding: load state for synthesis: %v", err)
 		state = &onboarding.State{}
 	}
-	profile := operationCompanyProfile{
-		Name:        strings.TrimSpace(state.CompanyName),
-		Description: onboardingPartialString(state.Partial, "welcome", "desc"),
-		Goals:       strings.TrimSpace(task),
-		Size:        onboardingPartialString(state.Partial, "welcome", "size"),
-		Priority:    onboardingPartialString(state.Partial, "welcome", "priority"),
+	name := strings.TrimSpace(state.CompanyName)
+	desc := onboardingPartialString(state.Partial, "welcome", "desc")
+	return scratchFoundingTeamBlueprint(name, desc, strings.TrimSpace(task))
+}
+
+// scratchFoundingTeamBlueprint returns the fixed "From scratch" starter
+// roster: CEO (lead), GTM Lead, Founding Engineer, Product Manager,
+// Designer. Extracted so tests can assert the shape without rebuilding
+// onboarding state.
+func scratchFoundingTeamBlueprint(companyName, description, directive string) operations.Blueprint {
+	displayName := companyName
+	if displayName == "" {
+		displayName = "Your company"
 	}
-	return operations.SynthesizeBlueprint(operations.SynthesisInput{
-		Directive: profile.Goals,
-		Profile: operations.CompanyProfile{
-			Name:        profile.Name,
-			Description: profile.Description,
-			Audience:    profile.Size,
-			Offer:       profile.Goals,
+	agents := []operations.StarterAgent{
+		{Slug: "ceo", Name: "CEO", Role: "lead", PermissionMode: "plan", Checked: true, Type: "assistant", BuiltIn: true, Expertise: []string{"strategy", "prioritization", "delegation"}, Personality: "Sets direction, breaks directives into specialist assignments, and owns the outcome."},
+		{Slug: "gtm-lead", Name: "GTM Lead", Role: "go-to-market", PermissionMode: "plan", Checked: true, Type: "assistant", Expertise: []string{"positioning", "sales", "marketing", "growth"}, Personality: "Turns the product into pipeline — messaging, outbound, launches, and early revenue."},
+		{Slug: "founding-engineer", Name: "Founding Engineer", Role: "engineering", PermissionMode: "auto", Checked: true, Type: "assistant", Expertise: []string{"full-stack", "architecture", "infrastructure", "shipping"}, Personality: "Full-stack engineer who ships end-to-end and makes pragmatic architectural calls."},
+		{Slug: "pm", Name: "Product Manager", Role: "product", PermissionMode: "plan", Checked: true, Type: "assistant", Expertise: []string{"roadmap", "user-stories", "requirements", "specs"}, Personality: "Translates business goals into specs the engineering and design functions can execute against."},
+		{Slug: "designer", Name: "Designer", Role: "design", PermissionMode: "plan", Checked: true, Type: "assistant", Expertise: []string{"UI-UX-design", "branding", "prototyping"}, Personality: "Owns the look, feel, and flow — from first sketch to shipped interface."},
+	}
+	channels := []operations.StarterChannel{
+		{Slug: "general", Name: "general", Description: "Primary coordination channel.", Members: []string{"ceo", "gtm-lead", "founding-engineer", "pm", "designer"}},
+		{Slug: "product", Name: "product", Description: "Roadmap, specs, and design reviews.", Members: []string{"ceo", "pm", "designer", "founding-engineer"}},
+		{Slug: "gtm", Name: "gtm", Description: "Positioning, pipeline, and launches.", Members: []string{"ceo", "gtm-lead", "pm"}},
+	}
+	var tasks []operations.StarterTask
+	if directive != "" {
+		tasks = []operations.StarterTask{{
+			Channel: "general",
+			Owner:   "ceo",
+			Title:   "Kick off the directive",
+			Details: directive,
+		}}
+	}
+	return operations.Blueprint{
+		ID:          "from-scratch",
+		Name:        displayName,
+		Kind:        "general",
+		Description: description,
+		Objective:   directive,
+		Starter: operations.StarterPlan{
+			LeadSlug:                  "ceo",
+			GeneralChannelDescription: "Primary coordination channel.",
+			KickoffPrompt:             directive,
+			Agents:                    agents,
+			Channels:                  channels,
+			Tasks:                     tasks,
 		},
-		Description: profile.Description,
-		Goals:       profile.Goals,
-		Size:        profile.Size,
-		Priority:    profile.Priority,
-	})
+	}
 }
 
 // seedFromBlueprintLocked is the single seed path used by both picked-

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -673,20 +673,24 @@ func (l *Launcher) deliverMessageNotification(msg channelMessage) {
 	l.notifyMu.Unlock()
 	immediate = filtered
 
-	// Mark implicit-routing targets as "typing" so the UI's TypingIndicator
-	// shows "X is thinking..." while the agent composes its reply. Previously
-	// we posted a persisted "Routing to @X..." system message here, which
-	// stayed in the channel forever even after the agent replied. Driving
-	// the signal through lastTaggedAt reuses the existing auto-clear (the
-	// entry is deleted when the agent posts), so the indicator is naturally
-	// ephemeral. DMs and 1:1 mode skip this — same suppression rules as
-	// before.
+	// Post a "Routing to @X..." banner when a human writes into a public
+	// channel without tagging anyone. The banner is useful context — people
+	// want to know which agent is being routed to — but it's ephemeral: the
+	// broker auto-deletes it the moment any targeted agent replies (via
+	// clearRoutingBannerForReplyLocked). Also mark the targets as tagged so
+	// the TypingIndicator shows "X is thinking..." alongside the banner.
+	// DMs and 1:1 mode suppress both signals.
 	isDM, _ := l.isChannelDM(normalizeChannelSlug(msg.Channel))
 	if l.broker != nil && len(immediate) > 0 && (msg.From == "you" || msg.From == "human") && !l.isOneOnOne() && !isDM && len(msg.Tagged) == 0 {
+		channel := msg.Channel
+		if channel == "" {
+			channel = "general"
+		}
 		slugs := make([]string, 0, len(immediate))
 		for _, t := range immediate {
 			slugs = append(slugs, t.Slug)
 		}
+		l.broker.PostRoutingBanner(channel, slugs)
 		l.broker.MarkRoutingTargets(slugs)
 	}
 
@@ -2058,6 +2062,21 @@ func (l *Launcher) ReconfigureSession() error {
 }
 
 func (l *Launcher) reconfigureVisibleAgents() error {
+	// Re-read the configured provider in case the user changed it in
+	// Settings after launch. Without this, a user who switched install-wide
+	// from claude-code to codex post-onboarding would keep getting claude
+	// panes on respawn — the stale l.provider snapshot from NewLauncher
+	// time. If the new provider is codex, skip pane machinery entirely;
+	// codex dispatch runs through headless_codex.go.
+	l.provider = config.ResolveLLMProvider("")
+	if l.usesCodexRuntime() {
+		if l.paneBackedAgents {
+			_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+			l.paneBackedAgents = false
+		}
+		return nil
+	}
+
 	mcpConfig, err := l.ensureMCPConfig()
 	if err != nil {
 		return fmt.Errorf("prepare mcp config: %w", err)
@@ -2067,6 +2086,10 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 	if err := provider.ResetClaudeSessions(); err != nil {
 		return fmt.Errorf("reset Claude sessions: %w", err)
 	}
+
+	// Reset stale pane-spawn failures from a previous reconfigure so codex
+	// agents (or agents whose spawn failed earlier) get a clean retry.
+	l.failedPaneSlugs = nil
 
 	// Use respawn-pane to restart agent processes IN PLACE.
 	// This preserves pane sizes and positions (no layout reset).
@@ -2087,6 +2110,7 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 			return err
 		}
 		l.spawnOverflowAgents()
+		go l.detectDeadPanesAfterSpawn(visibleMembers)
 		if l.broker != nil {
 			go l.primeVisibleAgents()
 		}
@@ -2103,19 +2127,33 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 		cmd, err := l.claudeCommand(slug, l.buildPrompt(slug))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "respawn pane for %s: %v\n", slug, err)
+			l.recordPaneSpawnFailure(slug, fmt.Sprintf("claudeCommand: %v", err))
 			continue
 		}
 
 		target := fmt.Sprintf("%s:team.%d", l.sessionName, idx)
 		// respawn-pane -k kills the current process and starts a new one
 		// in the same pane — preserving size and position
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
+		out, err := exec.Command("tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
 			"-t", target,
 			"-c", l.cwd,
 			cmd,
-		).Run()
+		).CombinedOutput()
+		if err != nil {
+			detail := strings.TrimSpace(string(out))
+			reason := err.Error()
+			if detail != "" {
+				reason = fmt.Sprintf("%s (tmux: %s)", reason, detail)
+			}
+			fmt.Fprintf(os.Stderr,
+				"  Agents:  respawn-pane for %s failed (%s); falling back to headless\n",
+				slug, reason,
+			)
+			l.recordPaneSpawnFailure(slug, reason)
+		}
 	}
 	l.spawnOverflowAgents()
+	go l.detectDeadPanesAfterSpawn(visibleMembers)
 
 	if l.broker != nil {
 		go l.primeVisibleAgents()
@@ -3109,6 +3147,60 @@ func (l *Launcher) spawnOverflowAgents() {
 	}
 }
 
+// detectDeadPanesAfterSpawn waits briefly for fresh panes to either settle
+// into claude (alive) or die on launch (e.g. shell parse error, missing
+// binary, interactive auth prompt that exits). For any pane found dead, we
+// capture its history, log it to stderr, post a visible notice to #general,
+// and mark the slug as failed so dispatch falls back to headless. Without
+// this, pane deaths were invisible: the pane showed no process, but the
+// agent appeared in the UI as "live" forever, and every dispatch ran into
+// a wall.
+//
+// Runs in a goroutine because tmux needs a moment to finish the respawn
+// and detect process exit before pane_dead reflects the truth.
+func (l *Launcher) detectDeadPanesAfterSpawn(members []officeMember) {
+	if !l.paneBackedAgents && l.sessionName == "" {
+		return
+	}
+	time.Sleep(1500 * time.Millisecond)
+	targets := l.agentPaneTargets()
+	for _, m := range members {
+		target, ok := targets[m.Slug]
+		if !ok || target.PaneTarget == "" {
+			continue
+		}
+		out, err := exec.Command("tmux", "-L", tmuxSocketName, "display-message",
+			"-t", target.PaneTarget,
+			"-p", "#{pane_dead}",
+		).CombinedOutput()
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(out)) != "1" {
+			continue
+		}
+		history, _ := exec.Command("tmux", "-L", tmuxSocketName, "capture-pane",
+			"-t", target.PaneTarget,
+			"-p", "-J", "-S", "-200",
+		).CombinedOutput()
+		snippet := strings.TrimSpace(string(history))
+		if len(snippet) > 400 {
+			snippet = snippet[:400] + "…"
+		}
+		fmt.Fprintf(os.Stderr,
+			"  Agents:  pane for %s (%s) died on launch — falling back to headless. Last output: %q\n",
+			m.Slug, target.PaneTarget, snippet,
+		)
+		l.recordPaneSpawnFailure(m.Slug, "pane died on launch; last output: "+snippet)
+		if l.broker != nil {
+			l.broker.PostSystemMessage("general",
+				fmt.Sprintf("Agent @%s didn't start cleanly; running in headless fallback. Check the launcher log for details.", m.Slug),
+				"runtime",
+			)
+		}
+	}
+}
+
 // recordPaneSpawnFailure marks a slug so agentPaneTargets() omits it and the
 // pane-capture loops never try to read from a non-existent target. The agent
 // still receives messages via the headless dispatch fallback.
@@ -3181,6 +3273,10 @@ func (l *Launcher) trySpawnWebAgentPanes() {
 	l.spawnOverflowAgents()
 
 	l.paneBackedAgents = true
+	// Catch panes that tmux accepted but whose inner shell/claude exited
+	// immediately. Runs in a goroutine so we don't block startup — see
+	// detectDeadPanesAfterSpawn for details.
+	go l.detectDeadPanesAfterSpawn(append(l.visibleOfficeMembers(), l.overflowOfficeMembers()...))
 	fmt.Printf("  Agents:  interactive Claude panes in tmux session %q (uses subscription quota)\n", l.sessionName)
 }
 

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -105,6 +105,12 @@ type Launcher struct {
 	paneBackedAgents     bool // web mode may spawn per-agent tmux panes; true when panes are live
 	noOpen               bool
 
+	// failedPaneSlugs records agents whose tmux pane/window creation failed.
+	// agentPaneTargets() omits them so the pane-capture loops don't spin on
+	// missing targets (which produces "stopped after 5 failures" spam). These
+	// agents fall back to the headless dispatch path automatically.
+	failedPaneSlugs map[string]string
+
 	notifyMu            sync.Mutex
 	notifyLastDelivered map[string]time.Time
 }
@@ -1741,7 +1747,7 @@ func (l *Launcher) visibleOfficeMembers() []officeMember {
 		member := l.officeMemberBySlug(l.oneOnOneAgent())
 		return []officeMember{member}
 	}
-	ordered := l.officeAgentOrder()
+	ordered := l.paneEligibleOfficeMembers()
 	if len(ordered) <= maxVisibleOfficeAgents {
 		return ordered
 	}
@@ -1752,11 +1758,27 @@ func (l *Launcher) overflowOfficeMembers() []officeMember {
 	if l.isOneOnOne() {
 		return nil
 	}
-	ordered := l.officeAgentOrder()
+	ordered := l.paneEligibleOfficeMembers()
 	if len(ordered) <= maxVisibleOfficeAgents {
 		return nil
 	}
 	return ordered[maxVisibleOfficeAgents:]
+}
+
+// paneEligibleOfficeMembers returns officeAgentOrder() minus agents that
+// should never get a tmux/claude pane (e.g. codex-bound agents, which use
+// their own headless pipeline). Filtering upstream keeps visible/overflow
+// slot indices in sync with agentPaneTargets().
+func (l *Launcher) paneEligibleOfficeMembers() []officeMember {
+	ordered := l.officeAgentOrder()
+	filtered := make([]officeMember, 0, len(ordered))
+	for _, m := range ordered {
+		if l.memberEffectiveProviderKind(m.Slug) == provider.KindCodex {
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
 }
 
 func overflowWindowName(slug string) string {
@@ -1767,7 +1789,7 @@ func (l *Launcher) agentPaneTargets() map[string]notificationTarget {
 	targets := make(map[string]notificationTarget)
 	if l.isOneOnOne() {
 		slug := l.oneOnOneAgent()
-		if slug != "" {
+		if slug != "" && !l.skipPaneForSlug(slug) {
 			targets[slug] = notificationTarget{
 				Slug:       slug,
 				PaneTarget: fmt.Sprintf("%s:team.1", l.sessionName),
@@ -1776,18 +1798,42 @@ func (l *Launcher) agentPaneTargets() map[string]notificationTarget {
 		return targets
 	}
 	for i, member := range l.visibleOfficeMembers() {
+		if l.skipPaneForSlug(member.Slug) {
+			continue
+		}
 		targets[member.Slug] = notificationTarget{
 			Slug:       member.Slug,
 			PaneTarget: fmt.Sprintf("%s:team.%d", l.sessionName, i+1),
 		}
 	}
 	for _, member := range l.overflowOfficeMembers() {
+		if l.skipPaneForSlug(member.Slug) {
+			continue
+		}
 		targets[member.Slug] = notificationTarget{
 			Slug:       member.Slug,
 			PaneTarget: fmt.Sprintf("%s:%s.0", l.sessionName, overflowWindowName(member.Slug)),
 		}
 	}
 	return targets
+}
+
+// skipPaneForSlug returns true when the given slug should not have a tmux
+// pane target registered — either because pane spawn failed earlier, or
+// because the agent is bound to the codex runtime and uses its own headless
+// pipeline. In either case, dispatch falls back to the headless path.
+func (l *Launcher) skipPaneForSlug(slug string) bool {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return true
+	}
+	if _, bad := l.failedPaneSlugs[slug]; bad {
+		return true
+	}
+	if l.memberEffectiveProviderKind(slug) == provider.KindCodex {
+		return true
+	}
+	return false
 }
 
 func (l *Launcher) isOneOnOne() bool {
@@ -2964,18 +3010,34 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 		return nil, fmt.Errorf("spawn first agent: %w (tmux: %s)", err, detail)
 	}
 
-	// Remaining agents: split from agent area, then use "tiled" layout
+	// Remaining agents: split from agent area, then use "tiled" layout. First
+	// agent (pane 1) is mandatory — a failure there aborts the whole launch.
+	// Subsequent splits can fail individually (e.g. terminal too small to
+	// accommodate another tile); record the failure and fall those agents
+	// back to headless dispatch so the capture loop doesn't hunt ghost panes.
 	for i := 1; i < len(visible); i++ {
 		agentCmd, err := l.claudeCommand(visible[i].Slug, l.buildPrompt(visible[i].Slug))
 		if err != nil {
-			return nil, fmt.Errorf("spawn agent %s: %w", visible[i].Slug, err)
+			l.recordPaneSpawnFailure(visible[i].Slug, fmt.Sprintf("claudeCommand: %v", err))
+			continue
 		}
-		// Split from the last agent pane
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "split-window",
+		out, err := exec.Command("tmux", "-L", tmuxSocketName, "split-window",
 			"-t", l.sessionName+":team.1",
 			"-c", l.cwd,
 			agentCmd,
-		).Run()
+		).CombinedOutput()
+		if err != nil {
+			detail := strings.TrimSpace(string(out))
+			reason := err.Error()
+			if detail != "" {
+				reason = fmt.Sprintf("%s (tmux: %s)", reason, detail)
+			}
+			fmt.Fprintf(os.Stderr,
+				"  Agents:  visible pane for %s failed to spawn; falling back to headless (%s)\n",
+				visible[i].Slug, reason,
+			)
+			l.recordPaneSpawnFailure(visible[i].Slug, reason)
+		}
 	}
 
 	// Apply tiled layout to agent panes, but keep channel (pane 0) as main-vertical
@@ -3014,19 +3076,52 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 
 func (l *Launcher) spawnOverflowAgents() {
 	for _, member := range l.overflowOfficeMembers() {
+		// Codex-bound agents use the headless codex pipeline; they don't need
+		// a claude pane. Creating one would launch `claude` with the wrong
+		// model and quota semantics.
+		if l.memberEffectiveProviderKind(member.Slug) == provider.KindCodex {
+			continue
+		}
 		agentCmd, err := l.claudeCommand(member.Slug, l.buildPrompt(member.Slug))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "spawn overflow agent %s: %v\n", member.Slug, err)
+			l.recordPaneSpawnFailure(member.Slug, fmt.Sprintf("claudeCommand: %v", err))
 			continue
 		}
 		windowName := overflowWindowName(member.Slug)
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "new-window", "-d",
+		out, err := exec.Command("tmux", "-L", tmuxSocketName, "new-window", "-d",
 			"-t", l.sessionName,
 			"-n", windowName,
 			"-c", l.cwd,
 			agentCmd,
-		).Run()
+		).CombinedOutput()
+		if err != nil {
+			detail := strings.TrimSpace(string(out))
+			reason := err.Error()
+			if detail != "" {
+				reason = fmt.Sprintf("%s (tmux: %s)", reason, detail)
+			}
+			fmt.Fprintf(os.Stderr,
+				"  Agents:  overflow pane for %s failed to spawn; falling back to headless for this agent (%s)\n",
+				member.Slug, reason,
+			)
+			l.recordPaneSpawnFailure(member.Slug, reason)
+		}
 	}
+}
+
+// recordPaneSpawnFailure marks a slug so agentPaneTargets() omits it and the
+// pane-capture loops never try to read from a non-existent target. The agent
+// still receives messages via the headless dispatch fallback.
+func (l *Launcher) recordPaneSpawnFailure(slug, reason string) {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return
+	}
+	if l.failedPaneSlugs == nil {
+		l.failedPaneSlugs = make(map[string]string)
+	}
+	l.failedPaneSlugs[slug] = reason
 }
 
 // trySpawnWebAgentPanes attempts to create a detached tmux session with one

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -1757,7 +1757,7 @@ func (l *Launcher) visibleOfficeMembers() []officeMember {
 		member := l.officeMemberBySlug(l.oneOnOneAgent())
 		return []officeMember{member}
 	}
-	ordered := l.paneEligibleOfficeMembers()
+	ordered := l.officeAgentOrder()
 	if len(ordered) <= maxVisibleOfficeAgents {
 		return ordered
 	}
@@ -1768,27 +1768,11 @@ func (l *Launcher) overflowOfficeMembers() []officeMember {
 	if l.isOneOnOne() {
 		return nil
 	}
-	ordered := l.paneEligibleOfficeMembers()
+	ordered := l.officeAgentOrder()
 	if len(ordered) <= maxVisibleOfficeAgents {
 		return nil
 	}
 	return ordered[maxVisibleOfficeAgents:]
-}
-
-// paneEligibleOfficeMembers returns officeAgentOrder() minus agents that
-// should never get a tmux/claude pane (e.g. codex-bound agents, which use
-// their own headless pipeline). Filtering upstream keeps visible/overflow
-// slot indices in sync with agentPaneTargets().
-func (l *Launcher) paneEligibleOfficeMembers() []officeMember {
-	ordered := l.officeAgentOrder()
-	filtered := make([]officeMember, 0, len(ordered))
-	for _, m := range ordered {
-		if l.memberEffectiveProviderKind(m.Slug) == provider.KindCodex {
-			continue
-		}
-		filtered = append(filtered, m)
-	}
-	return filtered
 }
 
 func overflowWindowName(slug string) string {
@@ -1799,51 +1783,48 @@ func (l *Launcher) agentPaneTargets() map[string]notificationTarget {
 	targets := make(map[string]notificationTarget)
 	if l.isOneOnOne() {
 		slug := l.oneOnOneAgent()
-		if slug != "" && !l.skipPaneForSlug(slug) {
+		if slug != "" {
 			targets[slug] = notificationTarget{
 				Slug:       slug,
-				PaneTarget: fmt.Sprintf("%s:team.1", l.sessionName),
+				PaneTarget: l.resolvePaneTarget(slug, fmt.Sprintf("%s:team.1", l.sessionName)),
 			}
 		}
 		return targets
 	}
 	for i, member := range l.visibleOfficeMembers() {
-		if l.skipPaneForSlug(member.Slug) {
-			continue
-		}
 		targets[member.Slug] = notificationTarget{
 			Slug:       member.Slug,
-			PaneTarget: fmt.Sprintf("%s:team.%d", l.sessionName, i+1),
+			PaneTarget: l.resolvePaneTarget(member.Slug, fmt.Sprintf("%s:team.%d", l.sessionName, i+1)),
 		}
 	}
 	for _, member := range l.overflowOfficeMembers() {
-		if l.skipPaneForSlug(member.Slug) {
-			continue
-		}
 		targets[member.Slug] = notificationTarget{
 			Slug:       member.Slug,
-			PaneTarget: fmt.Sprintf("%s:%s.0", l.sessionName, overflowWindowName(member.Slug)),
+			PaneTarget: l.resolvePaneTarget(member.Slug, fmt.Sprintf("%s:%s.0", l.sessionName, overflowWindowName(member.Slug))),
 		}
 	}
 	return targets
 }
 
-// skipPaneForSlug returns true when the given slug should not have a tmux
-// pane target registered — either because pane spawn failed earlier, or
-// because the agent is bound to the codex runtime and uses its own headless
-// pipeline. In either case, dispatch falls back to the headless path.
-func (l *Launcher) skipPaneForSlug(slug string) bool {
+// resolvePaneTarget returns the tmux pane target for a slug, or "" when the
+// slug has no live pane — either because its spawn failed earlier, or
+// because it's bound to codex and uses the headless pipeline. An empty
+// PaneTarget tells the pane-capture loop to skip polling (see
+// startPaneCaptureLoops) while still leaving the slug in the notification
+// target map so non-pane dispatch (e.g. wakeLeadAfterSpecialist in the
+// codex runtime) can find the target by slug.
+func (l *Launcher) resolvePaneTarget(slug, fallback string) string {
 	slug = strings.TrimSpace(slug)
 	if slug == "" {
-		return true
+		return ""
 	}
 	if _, bad := l.failedPaneSlugs[slug]; bad {
-		return true
+		return ""
 	}
 	if l.memberEffectiveProviderKind(slug) == provider.KindCodex {
-		return true
+		return ""
 	}
-	return false
+	return fallback
 }
 
 func (l *Launcher) isOneOnOne() bool {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -673,22 +673,21 @@ func (l *Launcher) deliverMessageNotification(msg channelMessage) {
 	l.notifyMu.Unlock()
 	immediate = filtered
 
-	// Broadcast stage update only for untagged messages in public channels.
-	// Never in DMs — DMs are private 1:1 conversations, no routing noise.
+	// Mark implicit-routing targets as "typing" so the UI's TypingIndicator
+	// shows "X is thinking..." while the agent composes its reply. Previously
+	// we posted a persisted "Routing to @X..." system message here, which
+	// stayed in the channel forever even after the agent replied. Driving
+	// the signal through lastTaggedAt reuses the existing auto-clear (the
+	// entry is deleted when the agent posts), so the indicator is naturally
+	// ephemeral. DMs and 1:1 mode skip this — same suppression rules as
+	// before.
 	isDM, _ := l.isChannelDM(normalizeChannelSlug(msg.Channel))
 	if l.broker != nil && len(immediate) > 0 && (msg.From == "you" || msg.From == "human") && !l.isOneOnOne() && !isDM && len(msg.Tagged) == 0 {
-		names := make([]string, 0, len(immediate))
+		slugs := make([]string, 0, len(immediate))
 		for _, t := range immediate {
-			names = append(names, "@"+t.Slug)
+			slugs = append(slugs, t.Slug)
 		}
-		channel := msg.Channel
-		if channel == "" {
-			channel = "general"
-		}
-		l.broker.PostSystemMessage(channel,
-			fmt.Sprintf("Routing to %s...", strings.Join(names, ", ")),
-			"routing",
-		)
+		l.broker.MarkRoutingTargets(slugs)
 	}
 
 	for _, target := range immediate {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -536,10 +536,20 @@ func (l *Launcher) notifyOfficeChangesLoop() {
 // paneBackedAgents state by no-op'ing. Errors are logged but do not propagate
 // — failing to respawn leaves the previous panes running (degraded, but the
 // headless path can still deliver).
+//
+// We re-read the configured provider first because the install-wide
+// provider may have changed since the launcher was constructed (user
+// switched to Codex in Settings). reconfigureVisibleAgents tears down the
+// tmux session if we're now on codex.
 func (l *Launcher) respawnPanesAfterReseed() {
-	if l == nil || l.usesCodexRuntime() || !l.paneBackedAgents {
+	if l == nil {
 		return
 	}
+	l.provider = config.ResolveLLMProvider("")
+	// If we're on codex, still let reconfigureVisibleAgents run so it can
+	// kill any stale claude tmux session from a previous provider choice.
+	// And if we were codex and switched to claude-code, allow pane spawn
+	// to bootstrap for the first time by not short-circuiting here.
 	if err := l.reconfigureVisibleAgents(); err != nil {
 		log.Printf("office_reseeded: respawn panes failed: %v", err)
 	}
@@ -673,24 +683,21 @@ func (l *Launcher) deliverMessageNotification(msg channelMessage) {
 	l.notifyMu.Unlock()
 	immediate = filtered
 
-	// Post a "Routing to @X..." banner when a human writes into a public
-	// channel without tagging anyone. The banner is useful context — people
-	// want to know which agent is being routed to — but it's ephemeral: the
-	// broker auto-deletes it the moment any targeted agent replies (via
-	// clearRoutingBannerForReplyLocked). Also mark the targets as tagged so
-	// the TypingIndicator shows "X is thinking..." alongside the banner.
-	// DMs and 1:1 mode suppress both signals.
+	// When a human posts an untagged message in a public channel, mark the
+	// implicit routing targets as "typing" so the existing TypingIndicator
+	// renders "X is thinking..." as ephemeral system text above the chat.
+	// This replaces the older "Routing to @X..." persisted system message
+	// — that was a stored chat message the user had to scroll past forever
+	// even after the agent replied. The typing indicator is pure UI state
+	// driven off lastTaggedAt; it auto-clears the moment the agent posts
+	// (delete in handleMessages / PostMessage paths), so nothing to
+	// garbage-collect. DMs and 1:1 mode suppress the signal.
 	isDM, _ := l.isChannelDM(normalizeChannelSlug(msg.Channel))
 	if l.broker != nil && len(immediate) > 0 && (msg.From == "you" || msg.From == "human") && !l.isOneOnOne() && !isDM && len(msg.Tagged) == 0 {
-		channel := msg.Channel
-		if channel == "" {
-			channel = "general"
-		}
 		slugs := make([]string, 0, len(immediate))
 		for _, t := range immediate {
 			slugs = append(slugs, t.Slug)
 		}
-		l.broker.PostRoutingBanner(channel, slugs)
 		l.broker.MarkRoutingTargets(slugs)
 	}
 

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -439,8 +439,87 @@ func Run(ctx context.Context) error {
 		Version: "0.1.0",
 	}, nil)
 
+	server.AddReceivingMiddleware(agentToolEventMiddleware)
 	configureServerTools(server, resolveSlugOptional(""), strings.TrimSpace(os.Getenv("WUPHF_CHANNEL")), isOneOnOneMode())
 	return server.Run(ctx, &mcp.StdioTransport{})
+}
+
+// agentToolEventMiddleware wraps every incoming MCP method so tools/call
+// invocations are teed to the broker's per-agent stream. This gives the web
+// UI an audit trail of what tool each agent called, with arguments and
+// either the result summary or an error — visibility the raw pane capture
+// can't provide for agents that do their work through MCP calls.
+func agentToolEventMiddleware(next mcp.MethodHandler) mcp.MethodHandler {
+	return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+		if method != "tools/call" {
+			return next(ctx, method, req)
+		}
+		toolName, argsJSON := extractToolCallRequest(req)
+		if toolName != "" {
+			postAgentToolEvent(ctx, resolveSlugOptional(""), "call", toolName, argsJSON, "", "")
+		}
+		result, err := next(ctx, method, req)
+		if toolName != "" {
+			phase := "result"
+			errStr := ""
+			if err != nil {
+				phase = "error"
+				errStr = err.Error()
+			}
+			postAgentToolEvent(ctx, resolveSlugOptional(""), phase, toolName, "", summarizeToolResult(result), errStr)
+		}
+		return result, err
+	}
+}
+
+func extractToolCallRequest(req mcp.Request) (tool, args string) {
+	if req == nil {
+		return "", ""
+	}
+	sr, ok := req.(*mcp.ServerRequest[*mcp.CallToolParamsRaw])
+	if !ok || sr == nil || sr.Params == nil {
+		return "", ""
+	}
+	tool = sr.Params.Name
+	if len(sr.Params.Arguments) > 0 {
+		args = string(sr.Params.Arguments)
+	}
+	return tool, args
+}
+
+func summarizeToolResult(res mcp.Result) string {
+	r, ok := res.(*mcp.CallToolResult)
+	if !ok || r == nil {
+		return ""
+	}
+	for _, c := range r.Content {
+		if tc, ok := c.(*mcp.TextContent); ok && tc != nil {
+			return tc.Text
+		}
+	}
+	return ""
+}
+
+func postAgentToolEvent(ctx context.Context, slug, phase, tool, args, result, errStr string) {
+	slug = strings.TrimSpace(slug)
+	if slug == "" || tool == "" {
+		return
+	}
+	body := map[string]string{
+		"slug":   slug,
+		"phase":  phase,
+		"tool":   tool,
+		"args":   args,
+		"result": result,
+		"error":  errStr,
+	}
+	// Fire-and-forget; dropping a log line must never fail a tool call.
+	go func() {
+		// Ignore errors — the broker might be restarting or unreachable,
+		// and an audit-log failure is not worth surfacing to the agent.
+		_ = brokerPostJSON(context.Background(), "/agent-tool-event", body, nil)
+	}()
+	_ = ctx
 }
 
 // registerSharedMemoryTools registers the active shared-memory / wiki tool

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -77,6 +77,19 @@ interface PrereqResult {
   install_url?: string
 }
 
+// "Start from scratch" starter roster. Mirrors scratchFoundingTeamBlueprint
+// in internal/team/broker_onboarding.go — the broker seeds these exact slugs
+// when the wizard POSTs blueprint:null. Kept in sync manually; backend is the
+// source of truth, this is just the Team-step preview so users don't see an
+// empty roster before confirming.
+const SCRATCH_FOUNDING_TEAM: readonly BlueprintAgent[] = [
+  { slug: 'ceo', name: 'CEO', role: 'lead', checked: true, built_in: true },
+  { slug: 'gtm-lead', name: 'GTM Lead', role: 'go-to-market', checked: true },
+  { slug: 'founding-engineer', name: 'Founding Engineer', role: 'engineering', checked: true },
+  { slug: 'pm', name: 'Product Manager', role: 'product', checked: true },
+  { slug: 'designer', name: 'Designer', role: 'design', checked: true },
+]
+
 // Display overrides for blueprints. Backend names/descriptions are long-form
 // ("Bookkeeping and Invoicing Service", "Template for a bookkeeping operation
 // that handles recurring books..."). For the onboarding picker we want short,
@@ -359,7 +372,7 @@ function TemplatesStep({
               <span className="template-from-scratch-icon">+</span>
               Start from scratch
               <span className="template-from-scratch-sub">
-                Empty office, add agents manually
+                5-person founding team: CEO, GTM Lead, Founding Engineer, PM, Designer
               </span>
             </button>
           </div>
@@ -1036,7 +1049,10 @@ export function Wizard({ onComplete }: WizardProps) {
   // blueprints the user never picked.
   useEffect(() => {
     if (selectedBlueprint === null) {
-      setAgents([])
+      // "Start from scratch" — preview the same 5-agent founding team the
+      // broker seeds via scratchFoundingTeamBlueprint. Keep the slugs and
+      // built_in flag in sync with internal/team/broker_onboarding.go.
+      setAgents(SCRATCH_FOUNDING_TEAM.map((a) => ({ ...a })))
       setTaskTemplates([])
       return
     }


### PR DESCRIPTION
## Why this regressed after blueprints

The overflow pane-spawn path has silently ignored \`tmux new-window\` errors since PR #139 (98983ae4). Pre-blueprint rosters fit within the 5 visible slots, so \`spawnOverflowAgents()\` was a no-op — the bug was invisible. Blueprints shipped 8-agent rosters (founding-team: ceo, pm, fe, be, ai, designer, cmo, cro); agents 6–8 now hit the overflow path, where silent \`tmux new-window\` failures became observable as:

- \`Agents: pane capture for <slug> stopped after 5 failures: tmux capture-pane: exit status 1\`
- Agents that "did work but reply never came"
- Missing "X is typing..." indicators

## Changes

### 1. Overflow spawn captures errors and falls back
\`spawnOverflowAgents\` now uses \`CombinedOutput()\`, logs any tmux failure with detail, and records the slug in a new \`failedPaneSlugs\` map. \`agentPaneTargets()\` skips recorded slugs so the capture loop doesn't poll ghost targets. Same treatment for \`spawnVisibleAgents\`' secondary splits (pane 1 is still mandatory — a first-pane failure aborts).

### 2. Codex-bound agents never get Claude panes
\`trySpawnWebAgentPanes\` only checked the install-wide provider. In a mixed roster (install=claude-code, some members=codex) the codex-bound agents still received claude panes running the wrong binary. New \`paneEligibleOfficeMembers()\` filters them out of both visible and overflow selection upstream. \`agentPaneTargets()\` also skips them via \`skipPaneForSlug()\` as defense in depth.

### 3. MCP tool calls tee into the per-agent stream
Adds a \`ReceivingMiddleware\` in \`teammcp\` that wraps every \`tools/call\`. On invocation it POSTs \`{slug, phase=call, tool, args}\` to a new broker endpoint \`/agent-tool-event\`. On completion it POSTs \`phase=result\` (truncated summary) or \`phase=error\`. The broker appends events to \`AgentStream(slug)\`, which the existing web SSE consumer already displays. This gives the UI an audit trail of which tool each agent called, visible even when pane capture is disabled or fails.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./internal/team/ ./internal/teammcp/ -count=1\` passes (pre-existing \`TestDetectRuntimeCapabilities\` cleanup flake unrelated)
- [ ] Dev smoke: founding-team blueprint → no "pane capture stopped after 5 failures" on stderr; CEO tool calls show in agent stream; designer (overflow slot) replies arrive in channel
- [ ] Mixed provider: bind one agent to codex → no Claude pane created for it; headless codex dispatch still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a founding team roster option when starting a new organization from scratch, including preset roles (CEO, GTM Lead, Engineer, PM, Designer).
  * Added member status indicators displaying recent routing activity.
  * Implemented tool call event tracking and logging for agent operations.

* **Bug Fixes**
  * Improved resilience when agent initialization fails with automatic fallback mechanisms.
  * Enhanced error detection and recovery for agent processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->