### PR TITLE
fix(web,broker): top-level replies visible + auto-tag body @mentions + Cache-Control

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -3270,6 +3270,37 @@ func memberFromSpec(spec company.MemberSpec, createdBy, createdAt string, builtI
 	}
 }
 
+// mentionPattern matches @slug tokens in free-form message text. Slugs are
+// alphanumeric plus hyphen, 2–30 chars (to dodge false positives from
+// conversational @ use). A preceding word character (e.g. email "a@b.com")
+// is excluded via the lookahead-free alternative: we anchor to start of
+// string or a non-alphanumeric rune.
+var mentionPattern = regexp.MustCompile(`(?:^|[^a-zA-Z0-9_])@([a-z0-9][a-z0-9-]{1,29})\b`)
+
+// extractMentionedSlugs pulls @-mention slugs out of body content. Duplicates
+// are removed. The caller is responsible for validating whether each slug is
+// a real office member.
+func extractMentionedSlugs(content string) []string {
+	matches := mentionPattern.FindAllStringSubmatch(strings.ToLower(content), -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(matches))
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		slug := m[1]
+		if _, ok := seen[slug]; ok {
+			continue
+		}
+		seen[slug] = struct{}{}
+		out = append(out, slug)
+	}
+	return out
+}
+
 func uniqueSlugs(items []string) []string {
 	seen := make(map[string]struct{}, len(items))
 	out := make([]string, 0, len(items))
@@ -6887,7 +6918,32 @@ func (b *Broker) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "channel access denied", http.StatusForbidden)
 		return
 	}
+	// Auto-promote @slug mentions in the body into the tagged array for
+	// agent posts. Agents routinely write "@operator please handle X" and
+	// forget to set `tagged`, which means @operator never wakes up. Human
+	// messages are left alone — humans intentionally type @-references
+	// conversationally and may not want every one to fire a notification.
 	tagged := uniqueSlugs(body.Tagged)
+	if body.From != "" && body.From != "you" && body.From != "human" && body.From != "system" {
+		for _, slug := range extractMentionedSlugs(body.Content) {
+			if slug == body.From {
+				continue
+			}
+			if b.findMemberLocked(slug) == nil {
+				continue
+			}
+			already := false
+			for _, t := range tagged {
+				if t == slug {
+					already = true
+					break
+				}
+			}
+			if !already {
+				tagged = append(tagged, slug)
+			}
+		}
+	}
 	for _, taggedSlug := range tagged {
 		switch taggedSlug {
 		case "you", "human", "system":

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -2025,12 +2025,37 @@ func (b *Broker) ServeWebUI(port int) {
 			"broker_url": brokerURL,
 		})
 	})))
-	mux.Handle("/", fileServer)
+	// Cache policy: index.html must be re-fetched every load so users pick up
+	// new JS/CSS bundle hashes immediately after an upgrade. Hashed assets
+	// under /assets/ are content-addressed and safe to cache aggressively.
+	// Without this, users stay pinned to a stale bundle for days because
+	// Chrome's heuristic cache revalidates HTML only occasionally.
+	mux.Handle("/", cacheControlMiddleware(fileServer))
 	go func() {
 		if err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), mux); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Printf("broker web UI proxy: listen on :%d: %v", port, err)
 		}
 	}()
+}
+
+// cacheControlMiddleware sets conservative cache headers on the web UI so
+// clients always receive fresh HTML and mutable assets, while long-cached
+// hashed bundles under /assets/ stay immutable for efficiency.
+func cacheControlMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case strings.HasPrefix(path, "/assets/"):
+			// Vite bundles hashed filenames; they never change for a given URL.
+			w.Header().Set("Cache-Control", "public, max-age=31536000, immutable")
+		default:
+			// Everything else (index.html, themes/*.css, favicons that share a
+			// stable path) must re-validate on each load so upgrades land
+			// immediately.
+			w.Header().Set("Cache-Control", "no-cache, must-revalidate")
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (b *Broker) webUIProxyHandler(brokerURL, stripPrefix string) http.Handler {

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -844,6 +844,22 @@ func handleTeamBroadcast(ctx context.Context, _ *mcp.CallToolRequest, args TeamB
 		}
 	}
 
+	// Auto-promote @-mentions in the body into the tagged array. Agents
+	// routinely write "@operator please handle X" without setting tagged,
+	// and the old path posted anyway + printed a warning nobody acted on
+	// (so @operator never woke up). The intent is unambiguous — honor it.
+	// The resulting post still passes through the broker's normal tagged
+	// pipeline, so lastTaggedAt, typing indicator, and notification fanout
+	// all fire correctly.
+	effectiveTagged := args.Tagged
+	var autoTagged []string
+	if !isOneOnOneMode() {
+		autoTagged = detectUntaggedMentions(args.Content, args.Tagged)
+		if len(autoTagged) > 0 {
+			effectiveTagged = append(append([]string{}, args.Tagged...), autoTagged...)
+		}
+	}
+
 	var result struct {
 		ID string `json:"id"`
 	}
@@ -851,7 +867,7 @@ func handleTeamBroadcast(ctx context.Context, _ *mcp.CallToolRequest, args TeamB
 		"channel":  channel,
 		"from":     slug,
 		"content":  args.Content,
-		"tagged":   args.Tagged,
+		"tagged":   effectiveTagged,
 		"reply_to": replyTo,
 	}, &result)
 	if err != nil {
@@ -870,18 +886,11 @@ func handleTeamBroadcast(ctx context.Context, _ *mcp.CallToolRequest, args TeamB
 	}
 	text += "."
 
-	// Warn when the message text contains @-mentions but none were passed in
-	// the `tagged` parameter. Text @-mentions are display-only — they do NOT
-	// wake agents. This is the most common CEO mistake: writing "@engineering
-	// please do X" without tagging engineering in the tool call.
-	if len(args.Tagged) == 0 && !isOneOnOneMode() {
-		if untaggedMentions := detectUntaggedMentions(args.Content, args.Tagged); len(untaggedMentions) > 0 {
-			text += fmt.Sprintf(
-				" WARNING: message text mentions %s but `tagged` is empty — those agents will NOT be woken. Re-send with tagged: %s to notify them.",
-				strings.Join(untaggedMentions, ", "),
-				strings.Join(untaggedMentions, ", "),
-			)
-		}
+	if len(autoTagged) > 0 {
+		text += fmt.Sprintf(
+			" Auto-tagged %s from the body so they get woken; pass them explicitly in `tagged` next time to avoid this note.",
+			strings.Join(autoTagged, ", "),
+		)
 	}
 
 	return textResult(text), nil, nil

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wuphf-web",
-  "version": "0.0.1",
+  "version": "0.0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wuphf-web",
-      "version": "0.0.1",
+      "version": "0.0.6.0",
       "dependencies": {
         "@tanstack/react-query": "^5.80.7",
         "@tanstack/react-router": "^1.121.3",

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -13,10 +13,12 @@ import { resolveHarness } from '../../lib/harness'
 interface MessageBubbleProps {
   message: Message
   grouped?: boolean
+  /** Direct reply to a top-level channel message — renders indented under the parent. */
+  isReply?: boolean
   onThreadClick?: (id: string) => void
 }
 
-export function MessageBubble({ message, grouped = false, onThreadClick }: MessageBubbleProps) {
+export function MessageBubble({ message, grouped = false, isReply = false, onThreadClick }: MessageBubbleProps) {
   const currentChannel = useAppStore((s) => s.currentChannel)
   const { data: members = [] } = useOfficeMembers()
   const isHuman = message.from === 'you' || message.from === 'human'
@@ -54,7 +56,7 @@ export function MessageBubble({ message, grouped = false, onThreadClick }: Messa
 
   return (
     <div
-      className={`message animate-fade${grouped ? ' message-grouped' : ''}`}
+      className={`message animate-fade${grouped ? ' message-grouped' : ''}${isReply ? ' message-reply' : ''}`}
       data-msg-id={message.id}
     >
       {/* Avatar */}

--- a/web/src/components/messages/MessageFeed.tsx
+++ b/web/src/components/messages/MessageFeed.tsx
@@ -59,11 +59,24 @@ export function MessageFeed() {
   let lastFrom = ''
   let lastTime = ''
 
+  // Index messages by id so we can tell a top-level reply (first answer to
+  // an untagged human message in the channel — parent has no reply_to)
+  // apart from a deep thread reply (reply-to-a-reply). Top-level replies
+  // must stay in the main feed; otherwise agents' first answers disappear.
+  const byId = new Map<string, typeof messages[0]>()
+  for (const m of messages) byId.set(m.id, m)
+
   for (const msg of messages) {
     // Skip status messages from main feed grouping logic
     if (msg.content?.startsWith('[STATUS]')) continue
-    // Skip reply messages in main feed
-    if (msg.reply_to) continue
+    // Thread replies (reply chain depth > 1) are hidden from the main feed —
+    // they belong to the thread view. A reply whose parent is a top-level
+    // message stays visible so the channel shows the full human↔agent
+    // exchange inline.
+    if (msg.reply_to) {
+      const parent = byId.get(msg.reply_to)
+      if (parent && parent.reply_to) continue
+    }
 
     // Date separator
     if (msg.timestamp) {

--- a/web/src/components/messages/MessageFeed.tsx
+++ b/web/src/components/messages/MessageFeed.tsx
@@ -3,11 +3,26 @@ import { useMessages } from '../../hooks/useMessages'
 import { useAppStore } from '../../stores/app'
 import { MessageBubble } from './MessageBubble'
 import { formatDateLabel } from '../../lib/format'
+import type { Message } from '../../api/client'
 
 function dateDayKey(ts: string): string {
   const d = new Date(ts)
   return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`
 }
+
+type ThreadMessage = {
+  message: Message
+  grouped: boolean
+}
+
+type FeedElement =
+  | { type: 'date'; key: string; label: string }
+  | {
+      type: 'thread'
+      key: string
+      parent: ThreadMessage
+      replies: ThreadMessage[]
+    }
 
 export function MessageFeed() {
   const currentChannel = useAppStore((s) => s.currentChannel)
@@ -53,48 +68,32 @@ export function MessageFeed() {
     )
   }
 
-  // Build message list with date separators, grouping, and inline thread
-  // nesting. Top-level messages render at full width; direct replies to a
-  // top-level message render as indented children grouped underneath it —
-  // like Slack's channel view, not like a flat Telegram feed. Replies to
-  // replies (deep thread) are hidden from the main feed; they belong in
-  // the thread panel.
-  const elements: Array<
-    | { type: 'date'; key: string; label: string }
-    | { type: 'message'; key: string; message: typeof messages[0]; grouped: boolean; isReply: boolean }
-  > = []
-  let lastDate = ''
-  let lastFrom = ''
-  let lastTime = ''
-
-  const byId = new Map<string, typeof messages[0]>()
+  // Build thread-aware element list. Top-level channel messages become thread
+  // heads; direct replies become their children; deep-thread replies stay in
+  // the side panel. Grouping by sender + 5-min window applies both to parents
+  // and to consecutive replies within the same thread so long exchanges read
+  // as one continuous block.
+  const elements: FeedElement[] = []
+  const byId = new Map<string, Message>()
   for (const m of messages) byId.set(m.id, m)
 
-  // Bucket messages by the top-level thread they belong to. A top-level
-  // message is its own bucket head; a direct reply joins its parent's
-  // bucket; a deep-thread reply is dropped.
-  const repliesByParent = new Map<string, typeof messages>()
+  const repliesByParent = new Map<string, Message[]>()
   for (const msg of messages) {
     if (msg.content?.startsWith('[STATUS]')) continue
     if (!msg.reply_to) continue
     const parent = byId.get(msg.reply_to)
     if (!parent) continue
-    if (parent.reply_to) continue // deep thread — hide
+    if (parent.reply_to) continue // deep thread lives in the side panel
     const list = repliesByParent.get(parent.id) ?? []
     list.push(msg)
     repliesByParent.set(parent.id, list)
   }
 
-  const pushMessage = (msg: typeof messages[0], isReply: boolean) => {
-    if (msg.timestamp) {
-      const dayKey = dateDayKey(msg.timestamp)
-      if (dayKey !== lastDate) {
-        elements.push({ type: 'date', key: `date-${dayKey}`, label: formatDateLabel(msg.timestamp) })
-        lastDate = dayKey
-        lastFrom = ''
-        lastTime = ''
-      }
-    }
+  let lastDate = ''
+  let lastFrom = ''
+  let lastTime = ''
+
+  const wrap = (msg: Message): ThreadMessage => {
     let grouped = false
     if (lastFrom === msg.from && msg.timestamp && lastTime) {
       const delta = new Date(msg.timestamp).getTime() - new Date(lastTime).getTime()
@@ -102,17 +101,39 @@ export function MessageFeed() {
     }
     lastFrom = msg.from
     lastTime = msg.timestamp || lastTime
-    elements.push({ type: 'message', key: msg.id, message: msg, grouped, isReply })
+    return { message: msg, grouped }
+  }
+
+  const maybeEmitDateSeparator = (msg: Message) => {
+    if (!msg.timestamp) return
+    const dayKey = dateDayKey(msg.timestamp)
+    if (dayKey === lastDate) return
+    elements.push({ type: 'date', key: `date-${dayKey}`, label: formatDateLabel(msg.timestamp) })
+    lastDate = dayKey
+    lastFrom = ''
+    lastTime = ''
   }
 
   for (const msg of messages) {
     if (msg.content?.startsWith('[STATUS]')) continue
-    if (msg.reply_to) continue // only top-level messages drive the outer loop
-    pushMessage(msg, false)
-    const replies = repliesByParent.get(msg.id)
-    if (replies) {
-      for (const r of replies) pushMessage(r, true)
+    if (msg.reply_to) continue // only top-level messages seed threads
+
+    maybeEmitDateSeparator(msg)
+    const parent = wrap(msg)
+
+    const rawReplies = repliesByParent.get(msg.id) ?? []
+    const replies: ThreadMessage[] = []
+    for (const r of rawReplies) {
+      maybeEmitDateSeparator(r)
+      replies.push(wrap(r))
     }
+
+    elements.push({
+      type: 'thread',
+      key: `thread-${msg.id}`,
+      parent,
+      replies,
+    })
   }
 
   return (
@@ -127,14 +148,31 @@ export function MessageFeed() {
             </div>
           )
         }
+        const hasReplies = el.replies.length > 0
         return (
-          <MessageBubble
+          <div
             key={el.key}
-            message={el.message}
-            grouped={el.grouped}
-            isReply={el.isReply}
-            onThreadClick={(id) => setActiveThreadId(id)}
-          />
+            className={`thread-group${hasReplies ? ' thread-group-has-replies' : ''}`}
+          >
+            <MessageBubble
+              message={el.parent.message}
+              grouped={el.parent.grouped}
+              onThreadClick={(id) => setActiveThreadId(id)}
+            />
+            {hasReplies && (
+              <div className="thread-replies">
+                {el.replies.map((r) => (
+                  <MessageBubble
+                    key={r.message.id}
+                    message={r.message}
+                    grouped={r.grouped}
+                    isReply
+                    onThreadClick={(id) => setActiveThreadId(id)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
         )
       })}
     </div>

--- a/web/src/components/messages/MessageFeed.tsx
+++ b/web/src/components/messages/MessageFeed.tsx
@@ -53,32 +53,39 @@ export function MessageFeed() {
     )
   }
 
-  // Build message list with date separators and grouping
-  const elements: Array<{ type: 'date'; key: string; label: string } | { type: 'message'; key: string; message: typeof messages[0]; grouped: boolean }> = []
+  // Build message list with date separators, grouping, and inline thread
+  // nesting. Top-level messages render at full width; direct replies to a
+  // top-level message render as indented children grouped underneath it —
+  // like Slack's channel view, not like a flat Telegram feed. Replies to
+  // replies (deep thread) are hidden from the main feed; they belong in
+  // the thread panel.
+  const elements: Array<
+    | { type: 'date'; key: string; label: string }
+    | { type: 'message'; key: string; message: typeof messages[0]; grouped: boolean; isReply: boolean }
+  > = []
   let lastDate = ''
   let lastFrom = ''
   let lastTime = ''
 
-  // Index messages by id so we can tell a top-level reply (first answer to
-  // an untagged human message in the channel — parent has no reply_to)
-  // apart from a deep thread reply (reply-to-a-reply). Top-level replies
-  // must stay in the main feed; otherwise agents' first answers disappear.
   const byId = new Map<string, typeof messages[0]>()
   for (const m of messages) byId.set(m.id, m)
 
+  // Bucket messages by the top-level thread they belong to. A top-level
+  // message is its own bucket head; a direct reply joins its parent's
+  // bucket; a deep-thread reply is dropped.
+  const repliesByParent = new Map<string, typeof messages>()
   for (const msg of messages) {
-    // Skip status messages from main feed grouping logic
     if (msg.content?.startsWith('[STATUS]')) continue
-    // Thread replies (reply chain depth > 1) are hidden from the main feed —
-    // they belong to the thread view. A reply whose parent is a top-level
-    // message stays visible so the channel shows the full human↔agent
-    // exchange inline.
-    if (msg.reply_to) {
-      const parent = byId.get(msg.reply_to)
-      if (parent && parent.reply_to) continue
-    }
+    if (!msg.reply_to) continue
+    const parent = byId.get(msg.reply_to)
+    if (!parent) continue
+    if (parent.reply_to) continue // deep thread — hide
+    const list = repliesByParent.get(parent.id) ?? []
+    list.push(msg)
+    repliesByParent.set(parent.id, list)
+  }
 
-    // Date separator
+  const pushMessage = (msg: typeof messages[0], isReply: boolean) => {
     if (msg.timestamp) {
       const dayKey = dateDayKey(msg.timestamp)
       if (dayKey !== lastDate) {
@@ -88,8 +95,6 @@ export function MessageFeed() {
         lastTime = ''
       }
     }
-
-    // Grouping: same sender within 5 minutes
     let grouped = false
     if (lastFrom === msg.from && msg.timestamp && lastTime) {
       const delta = new Date(msg.timestamp).getTime() - new Date(lastTime).getTime()
@@ -97,8 +102,17 @@ export function MessageFeed() {
     }
     lastFrom = msg.from
     lastTime = msg.timestamp || lastTime
+    elements.push({ type: 'message', key: msg.id, message: msg, grouped, isReply })
+  }
 
-    elements.push({ type: 'message', key: msg.id, message: msg, grouped })
+  for (const msg of messages) {
+    if (msg.content?.startsWith('[STATUS]')) continue
+    if (msg.reply_to) continue // only top-level messages drive the outer loop
+    pushMessage(msg, false)
+    const replies = repliesByParent.get(msg.id)
+    if (replies) {
+      for (const r of replies) pushMessage(r, true)
+    }
   }
 
   return (
@@ -118,6 +132,7 @@ export function MessageFeed() {
             key={el.key}
             message={el.message}
             grouped={el.grouped}
+            isReply={el.isReply}
             onThreadClick={(id) => setActiveThreadId(id)}
           />
         )

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -8,6 +8,39 @@
 .message-grouped .message-avatar { visibility: hidden; height: 0; }
 .message-grouped .message-header { display: none; }
 
+/* ─── Inline threaded replies ───
+   Direct replies to a top-level channel message render indented under the
+   parent, connected by a left rail, so the thread reads as a grouped
+   conversation inside the main feed. Deep-thread replies (reply-to-a-reply)
+   still live in the thread panel only. */
+.message-reply {
+  padding-left: 44px;
+  position: relative;
+  margin-top: 2px;
+}
+.message-reply::before {
+  content: "";
+  position: absolute;
+  left: 20px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--border);
+  border-radius: 2px;
+}
+.message-reply .message-avatar {
+  width: 28px;
+  height: 28px;
+  padding: 4px;
+}
+.message-reply .message-content {
+  background: var(--bg-warm);
+  border-radius: var(--radius-md);
+  padding: 8px 12px;
+  border: 1px solid var(--border-light);
+}
+.message-reply.message-grouped { margin-top: 0; padding-top: 0; }
+
 .message-avatar { width: 36px; height: 36px; padding: 6px; box-sizing: border-box; border-radius: 8px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 18px; background: var(--bg-warm); }
 .message-avatar .pixel-avatar { width: 100%; height: 100%; }
 .message-content { flex: 1; min-width: 0; }

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -8,38 +8,87 @@
 .message-grouped .message-avatar { visibility: hidden; height: 0; }
 .message-grouped .message-header { display: none; }
 
-/* ─── Inline threaded replies ───
-   Direct replies to a top-level channel message render indented under the
-   parent, connected by a left rail, so the thread reads as a grouped
-   conversation inside the main feed. Deep-thread replies (reply-to-a-reply)
-   still live in the thread panel only. */
-.message-reply {
-  padding-left: 44px;
+/* ─── Inline threaded replies ───────────────────────────────────
+   Editorial discussion-forum treatment. A top-level message and its
+   direct replies render as one unit: parent at full width, replies
+   indented under a continuous rail that reads like structure, not
+   decoration. Body text stays at full readability — subordination
+   happens through the avatar, the meta row, and the indent, not by
+   shrinking the content. Deep-thread replies (reply-to-a-reply) go
+   to the side panel, not the main feed.
+   ───────────────────────────────────────────────────────────── */
+
+.thread-group { display: flex; flex-direction: column; }
+
+/* Rail anchors at the parent avatar's center-line (24px padding + 18px
+   = 42px from message edge), starts a touch below the avatar and ends
+   just past the last reply's header so the line reads as "belongs to"
+   without running off into whitespace. */
+.thread-replies {
   position: relative;
-  margin-top: 2px;
+  margin: 2px 0 4px;
+  padding-left: 56px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
-.message-reply::before {
+.thread-replies::before {
   content: "";
   position: absolute;
-  left: 20px;
+  left: 42px;
   top: 0;
-  bottom: 0;
+  bottom: 4px;
   width: 2px;
-  background: var(--border);
+  background: var(--border-dark);
   border-radius: 2px;
+  opacity: 0.7;
+}
+.thread-group-has-replies + .thread-group { margin-top: 6px; }
+
+.message-reply {
+  position: relative;
+  gap: 10px;
+  /* Pull reply flush with the -24px page margin the nex theme puts on
+     .message so hover highlights bleed edge-to-edge like top-level
+     messages — not orphaned in a smaller box. */
+  margin-left: -56px;
+  padding-left: 56px;
 }
 .message-reply .message-avatar {
   width: 28px;
   height: 28px;
   padding: 4px;
+  border-radius: 7px;
 }
-.message-reply .message-content {
-  background: var(--bg-warm);
-  border-radius: var(--radius-md);
-  padding: 8px 12px;
-  border: 1px solid var(--border-light);
+.message-reply .message-header {
+  margin-bottom: 2px;
+  gap: 6px;
 }
+.message-reply .message-author {
+  /* Stay primary color + regular-bold weight so the agent's name
+     reads as a first-class actor. Size drops one step for subordination. */
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+.message-reply .message-time { font-size: 10.5px; }
+.message-reply .message-token-badge { font-size: 10px; padding: 0 5px; }
+.message-reply .message-text {
+  /* Readability is non-negotiable. Match parent size; tighten leading
+     one notch so the reply feels dense without being cramped. */
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+/* Consecutive replies from the same agent collapse into a tight cluster:
+   the avatar and header disappear, the body indents to line up with the
+   header above, the rail stays continuous. */
 .message-reply.message-grouped { margin-top: 0; padding-top: 0; }
+.message-reply.message-grouped .message-content {
+  /* Left-align the continuation under the header text (avatar-width +
+     gap = 28 + 10 = 38px). */
+  margin-left: 38px;
+}
 
 .message-avatar { width: 36px; height: 36px; padding: 6px; box-sizing: border-box; border-radius: 8px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; font-size: 18px; background: var(--bg-warm); }
 .message-avatar .pixel-avatar { width: 100%; height: 100%; }


### PR DESCRIPTION
Three user-reported bugs from the post-merge live test of #206:

1. **CEO replies never appeared in the channel.** \`MessageFeed.tsx\` unconditionally skipped every message with \`reply_to\`, so the first agent reply to an untagged human message (which the launcher instructs the agent to mark as \`reply_to: msg-<human>\`) was invisible in the main feed. Only replies inside a thread (reply-to-a-reply) should hide. Fix: build an id→message map and skip a reply only when its parent itself has a \`reply_to\`. Top-level replies (parent is a top-level message) stay inline.
2. **@-mentions in the body didn't wake the tagged agent.** Agents routinely write "@operator please handle X" and forget to set the \`tagged\` parameter. The broker stored the message with \`tagged=[]\`, so the notification fanout and typing indicator never fired. Fix: in both \`handlePostMessage\` and \`handleTeamBroadcast\`, auto-promote unique \`@slug\` tokens from the content body into the \`tagged\` array (agent posts only; humans are left alone since they use \`@\` conversationally). \`extractMentionedSlugs\` uses a conservative regex (alphanumeric + hyphen, 2–30 chars, word-boundary-ish) to avoid false positives like \`user@example.com\`.
3. **Users got stuck on stale bundles after an upgrade.** The broker's embedded web UI server had no \`Cache-Control\` header, so Chrome aggressively cached \`index.html\` and the old hashed JS kept loading. Fix: new \`cacheControlMiddleware\` — \`no-cache, must-revalidate\` on \`index.html\` and other mutable paths, \`max-age=31536000, immutable\` on Vite's content-addressed \`/assets/*\` bundles.

Also includes the date-grouped message feed improvement already on the branch.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./internal/team ./internal/teammcp\` passes
- [x] Live browser verified: 15 messages in broker → 9 render in main feed (msg-1, 2, 3, 4, 11, 12, 20, 26, 27), 6 hidden as deep thread replies
- [x] Auto-tag verified: POST with \`@founding-engineer and @pm\` in body and \`tagged=[]\` → broker stores \`tagged=["founding-engineer","pm"]\`, chips render in UI, targets activate in TypingIndicator
- [ ] Fresh user upgrade path: first load after new \`npx wuphf\` picks up the new bundle without a hard refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents are now automatically tagged when mentioned with @ in message content
  * Message feed now displays top-level replies while hiding nested reply threads for clearer conversation organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->