### PR TITLE
[codex] fix agent comms visibility

### DIFF
--- a/internal/company/manifest_test.go
+++ b/internal/company/manifest_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/operations"
+	"github.com/nex-crm/wuphf/internal/provider"
 )
 
 func testRepoRoot(t *testing.T) string {
@@ -219,6 +220,11 @@ func TestMaterializeManifestBuildsRuntimeOfficeFromBlueprintRefs(t *testing.T) {
 		BlueprintRefs: []BlueprintRef{
 			{Kind: "operation", ID: "youtube-factory", Source: "test"},
 		},
+		Members: []MemberSpec{{
+			Slug:     "ceo",
+			Name:     "Stale CEO",
+			Provider: provider.ProviderBinding{Kind: provider.KindClaudeCode},
+		}},
 	}
 	resolved, ok := MaterializeManifest(manifest, testRepoRoot(t))
 	if !ok {
@@ -232,6 +238,11 @@ func TestMaterializeManifestBuildsRuntimeOfficeFromBlueprintRefs(t *testing.T) {
 	}
 	if len(resolved.Channels) == 0 || resolved.Channels[0].Slug != "general" {
 		t.Fatalf("expected general channel from blueprint, got %+v", resolved.Channels)
+	}
+	for _, member := range resolved.Members {
+		if member.Provider.Kind != "" {
+			t.Fatalf("blueprint materialization must not set member provider bindings, got %+v", member)
+		}
 	}
 }
 

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -231,26 +231,50 @@ type teamChannel struct {
 }
 
 func (ch *teamChannel) isDM() bool {
-	return ch.Type == "dm" || strings.HasPrefix(ch.Slug, "dm-")
+	return ch.Type == "dm" || IsDMSlug(ch.Slug)
 }
 
 // IsDMSlug checks whether a channel slug represents a direct message.
 func IsDMSlug(slug string) bool {
-	return strings.HasPrefix(slug, "dm-")
+	slug = normalizeChannelSlug(slug)
+	return strings.HasPrefix(slug, "dm-") || canonicalDMTargetAgent(slug) != ""
 }
 
 // DMSlugFor returns the DM channel slug for a given agent.
 func DMSlugFor(agentSlug string) string {
-	return "dm-" + agentSlug
+	agentSlug = normalizeActorSlug(agentSlug)
+	if agentSlug == "" {
+		return ""
+	}
+	return channel.DirectSlug("human", agentSlug)
 }
 
 // DMTargetAgent extracts the agent slug from a DM channel slug.
 // Returns "" if the slug is not a DM.
 func DMTargetAgent(slug string) string {
-	if !IsDMSlug(slug) {
+	slug = normalizeChannelSlug(slug)
+	if strings.HasPrefix(slug, "dm-human-") {
+		return strings.TrimPrefix(slug, "dm-human-")
+	}
+	if strings.HasPrefix(slug, "dm-") {
+		return strings.TrimPrefix(slug, "dm-")
+	}
+	return canonicalDMTargetAgent(slug)
+}
+
+func canonicalDMTargetAgent(slug string) string {
+	parts := strings.Split(normalizeChannelSlug(slug), "__")
+	if len(parts) != 2 {
 		return ""
 	}
-	return strings.TrimPrefix(slug, "dm-")
+	switch {
+	case parts[0] == "human" || parts[0] == "you":
+		return parts[1]
+	case parts[1] == "human" || parts[1] == "you":
+		return parts[0]
+	default:
+		return ""
+	}
 }
 
 type officeMember struct {
@@ -1878,19 +1902,10 @@ func (b *Broker) handleAgentToolEvent(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// formatAgentToolEvent renders a compact one-line audit record for the
-// per-agent stream. Truncates noisy fields so a long result doesn't blow the
-// stream buffer.
+// formatAgentToolEvent renders one structured audit record for the per-agent
+// stream. SSE data lines must stay single-line; JSON encoding preserves exact
+// arguments/results while escaping embedded newlines.
 func formatAgentToolEvent(phase, tool, args, result, errStr string) string {
-	const maxField = 240
-	truncate := func(s string) string {
-		s = strings.TrimSpace(s)
-		s = strings.ReplaceAll(s, "\n", " ")
-		if len(s) > maxField {
-			return s[:maxField] + "…"
-		}
-		return s
-	}
 	tool = strings.TrimSpace(tool)
 	phase = strings.TrimSpace(phase)
 	if phase == "" {
@@ -1899,17 +1914,37 @@ func formatAgentToolEvent(phase, tool, args, result, errStr string) string {
 	if tool == "" {
 		return ""
 	}
-	parts := []string{fmt.Sprintf("[%s] %s", phase, tool)}
+	payload := map[string]any{
+		"type":  "mcp_tool_event",
+		"phase": phase,
+		"tool":  tool,
+	}
 	if args != "" {
-		parts = append(parts, "args="+truncate(args))
+		payload["arguments"] = decodeToolEventField(args)
 	}
 	if result != "" {
-		parts = append(parts, "result="+truncate(result))
+		payload["result"] = decodeToolEventField(result)
 	}
 	if errStr != "" {
-		parts = append(parts, "error="+truncate(errStr))
+		payload["error"] = decodeToolEventField(errStr)
 	}
-	return strings.Join(parts, " ")
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func decodeToolEventField(raw string) any {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	var decoded any
+	if err := json.Unmarshal([]byte(raw), &decoded); err == nil {
+		return decoded
+	}
+	return raw
 }
 
 // handleAgentStream serves a per-agent stdout SSE stream.
@@ -2372,7 +2407,9 @@ func (b *Broker) PostInboundSurfaceMessage(from, channel, content, provider stri
 	}
 	if b.findChannelLocked(channel) == nil {
 		if IsDMSlug(channel) {
-			b.ensureDMConversationLocked(channel)
+			if dm := b.ensureDMConversationLocked(channel); dm != nil {
+				channel = dm.Slug
+			}
 		} else {
 			return channelMessage{}, fmt.Errorf("channel not found: %s", channel)
 		}
@@ -3169,10 +3206,13 @@ func (b *Broker) ensureDMConversationLocked(slug string) *teamChannel {
 		return nil
 	}
 	agentSlug := DMTargetAgent(slug)
+	if agentSlug == "" {
+		return nil
+	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	// Register in channelStore for proper type-based DM detection.
 	if b.channelStore != nil {
-		newSlug := channel.DirectSlug("human", agentSlug)
+		newSlug := DMSlugFor(agentSlug)
 		if _, err := b.channelStore.GetOrCreateDirect("human", agentSlug); err == nil {
 			// Update slug in broker to the new deterministic format if different.
 			if newSlug != slug {
@@ -5764,11 +5804,6 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			providerChanged := b.runtimeProvider != provider
 			b.runtimeProvider = provider
 			if providerChanged {
-				// Tell the launcher to respawn panes (if claude-code) or
-				// tear them down (if codex). Without this, a user who
-				// switches provider in Settings keeps seeing stale claude
-				// panes while dispatch routes through codex — the textbook
-				// "I picked Codex, why is Claude still running" symptom.
 				b.publishOfficeChangeLocked(officeChangeEvent{Kind: "office_reseeded"})
 			}
 			b.mu.Unlock()
@@ -5823,33 +5858,48 @@ func (b *Broker) handleOfficeMembers(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodGet:
 		b.mu.Lock()
-		members := make([]officeMember, len(b.members))
-		copy(members, b.members)
-		// Surface "active" status for agents tagged within the last 60s that
-		// haven't yet replied. The web TypingIndicator reads this to render
-		// "X is thinking..." as ephemeral system text while a message is
-		// being routed. Without this field the indicator never shows —
-		// `status` was on the TS type but the backend never populated it.
-		taggedAt := b.lastTaggedAt
-		b.mu.Unlock()
-
-		type officeMemberView struct {
+		type officeMemberResponse struct {
 			officeMember
-			Status string `json:"status,omitempty"`
+			Status       string `json:"status,omitempty"`
+			Activity     string `json:"activity,omitempty"`
+			Detail       string `json:"detail,omitempty"`
+			Task         string `json:"task,omitempty"`
+			LiveActivity string `json:"liveActivity,omitempty"`
+			LastTime     string `json:"lastTime,omitempty"`
 		}
-		views := make([]officeMemberView, len(members))
-		cutoff := time.Now().Add(-60 * time.Second)
-		for i, m := range members {
-			v := officeMemberView{officeMember: m}
-			if taggedAt != nil {
-				if t, ok := taggedAt[m.Slug]; ok && t.After(cutoff) {
-					v.Status = "active"
+		now := time.Now()
+		members := make([]officeMemberResponse, 0, len(b.members))
+		for _, member := range b.members {
+			entry := officeMemberResponse{officeMember: member}
+			if snapshot, ok := b.activity[member.Slug]; ok {
+				entry.Status = snapshot.Status
+				entry.Activity = snapshot.Activity
+				entry.Detail = snapshot.Detail
+				entry.LiveActivity = snapshot.Detail
+				entry.Task = snapshot.Detail
+				entry.LastTime = snapshot.LastTime
+			}
+			if entry.Status == "" && b.lastTaggedAt != nil {
+				if taggedAt, ok := b.lastTaggedAt[member.Slug]; ok && now.Sub(taggedAt) < 60*time.Second {
+					entry.Status = "active"
+					entry.Activity = "queued"
+					entry.Detail = "active"
+					entry.LiveActivity = "active"
+					entry.Task = "active"
+					entry.LastTime = taggedAt.UTC().Format(time.RFC3339)
 				}
 			}
-			views[i] = v
+			if entry.Status == "" {
+				entry.Status = "idle"
+			}
+			if entry.Activity == "" {
+				entry.Activity = "idle"
+			}
+			members = append(members, entry)
 		}
+		b.mu.Unlock()
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"members": views})
+		_ = json.NewEncoder(w).Encode(map[string]any{"members": members})
 	case http.MethodPost:
 		var body struct {
 			Action         string                    `json:"action"`
@@ -6445,6 +6495,30 @@ func (b *Broker) handleCreateDM(w http.ResponseWriter, r *http.Request) {
 	}
 
 	b.mu.Lock()
+	if b.findChannelLocked(ch.Slug) == nil {
+		now := time.Now().UTC().Format(time.RFC3339)
+		target := DMTargetAgent(ch.Slug)
+		description := "Group direct messages"
+		memberSlugs := append([]string(nil), body.Members...)
+		if target != "" {
+			description = "Direct messages with " + target
+			memberSlugs = []string{"human", target}
+		}
+		name := strings.TrimSpace(ch.Name)
+		if name == "" {
+			name = ch.Slug
+		}
+		b.channels = append(b.channels, teamChannel{
+			Slug:        ch.Slug,
+			Name:        name,
+			Type:        "dm",
+			Description: description,
+			Members:     uniqueSlugs(memberSlugs),
+			CreatedBy:   "human",
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		})
+	}
 	_ = b.saveLocked()
 	b.mu.Unlock()
 
@@ -6925,7 +6999,9 @@ func (b *Broker) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 	// Auto-create DM conversations on first message (like Slack's conversations.open)
 	if b.findChannelLocked(channel) == nil {
 		if IsDMSlug(channel) {
-			b.ensureDMConversationLocked(channel)
+			if dm := b.ensureDMConversationLocked(channel); dm != nil {
+				channel = dm.Slug
+			}
 		} else if b.channelStore != nil {
 			if _, ok := b.channelStore.GetBySlug(channel); !ok {
 				b.mu.Unlock()
@@ -7126,11 +7202,8 @@ func (b *Broker) SeenTelegramGroups() map[int64]string {
 	return out
 }
 
-// MarkRoutingTargets records implicit-routing recipients as "typing" so the
-// web TypingIndicator can render "X is thinking..." above the composer
-// without inserting a persisted "Routing to @X..." chat message. The entry
-// auto-clears on the next POST /messages from the agent (see the delete
-// in handlePostMessage), so the indicator is naturally ephemeral.
+// MarkRoutingTargets records implicit routing recipients as active so the UI
+// can show typing/thinking state without persisting a routing banner message.
 func (b *Broker) MarkRoutingTargets(slugs []string) {
 	if len(slugs) == 0 {
 		return
@@ -7150,6 +7223,7 @@ func (b *Broker) MarkRoutingTargets(slugs []string) {
 	}
 }
 
+// PostSystemMessage posts a lightweight system message that shows progress without blocking.
 func (b *Broker) PostSystemMessage(channel, content, kind string) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -7179,7 +7253,14 @@ func (b *Broker) PostMessage(from, channel, content string, tagged []string, rep
 		channel = "general"
 	}
 	if b.findChannelLocked(channel) == nil {
-		return channelMessage{}, fmt.Errorf("channel not found")
+		if IsDMSlug(channel) {
+			if dm := b.ensureDMConversationLocked(channel); dm != nil {
+				channel = dm.Slug
+			}
+		}
+		if b.findChannelLocked(channel) == nil {
+			return channelMessage{}, fmt.Errorf("channel not found")
+		}
 	}
 	if !b.canAccessChannelLocked(from, channel) {
 		return channelMessage{}, fmt.Errorf("channel access denied")
@@ -7323,7 +7404,9 @@ func (b *Broker) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	b.mu.Lock()
 	// Auto-create DM conversation on read (user opens DM before sending)
 	if IsDMSlug(channel) && b.findChannelLocked(channel) == nil {
-		b.ensureDMConversationLocked(channel)
+		if dm := b.ensureDMConversationLocked(channel); dm != nil {
+			channel = dm.Slug
+		}
 	}
 	if !b.canAccessChannelLocked(accessSlug, channel) {
 		b.mu.Unlock()

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -225,6 +225,93 @@ func TestBrokerMessageSubscribersReceivePostedMessages(t *testing.T) {
 	}
 }
 
+func TestBrokerCanonicalizesLegacyDMSlugs(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	postJSON := func(path string, payload map[string]any) *http.Response {
+		t.Helper()
+		body, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPost, base+path, bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST %s failed: %v", path, err)
+		}
+		return resp
+	}
+
+	resp := postJSON("/channels/dm", map[string]any{
+		"members": []string{"human", "ceo"},
+		"type":    "direct",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create dm status %d: %s", resp.StatusCode, raw)
+	}
+	var created struct {
+		Slug string `json:"slug"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create dm: %v", err)
+	}
+	wantSlug := channelDirectSlug("human", "ceo")
+	if created.Slug != wantSlug {
+		t.Fatalf("expected canonical slug %q, got %q", wantSlug, created.Slug)
+	}
+
+	msgResp := postJSON("/messages", map[string]any{
+		"from":    "human",
+		"channel": "dm-human-ceo",
+		"content": "hello ceo",
+	})
+	defer msgResp.Body.Close()
+	if msgResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(msgResp.Body)
+		t.Fatalf("post legacy dm status %d: %s", msgResp.StatusCode, raw)
+	}
+	msgs := b.Messages()
+	if len(msgs) != 1 {
+		t.Fatalf("expected one message, got %d", len(msgs))
+	}
+	if msgs[0].Channel != wantSlug {
+		t.Fatalf("expected message to land in %q, got %q", wantSlug, msgs[0].Channel)
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, base+"/messages?channel=dm-human-ceo&viewer_slug=human", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	getResp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET legacy dm failed: %v", err)
+	}
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(getResp.Body)
+		t.Fatalf("get legacy dm status %d: %s", getResp.StatusCode, raw)
+	}
+	var got struct {
+		Channel  string           `json:"channel"`
+		Messages []channelMessage `json:"messages"`
+	}
+	if err := json.NewDecoder(getResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode get dm: %v", err)
+	}
+	if got.Channel != wantSlug || len(got.Messages) != 1 {
+		t.Fatalf("expected canonical channel %q with one message, got channel=%q messages=%d", wantSlug, got.Channel, len(got.Messages))
+	}
+}
+
 func TestRecordAgentUsageAttachesToCurrentTurnMessagesOnly(t *testing.T) {
 	b := NewBroker()
 	now := time.Now().UTC()

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -20,7 +20,7 @@ var (
 	headlessClaudeCommandContext = exec.CommandContext
 )
 
-func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notification string) error {
+func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notification string, channel ...string) error {
 	if _, err := headlessClaudeLookPath("claude"); err != nil {
 		return fmt.Errorf("claude not found: %w", err)
 	}
@@ -221,6 +221,13 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	}
 	if text := strings.TrimSpace(result.FinalMessage); text != "" {
 		appendHeadlessClaudeLog(slug, "result: "+text)
+		target := firstNonEmpty(channel...)
+		msg, posted, err := l.postHeadlessFinalMessageIfSilent(slug, target, notification, text, startedAt)
+		if err != nil {
+			appendHeadlessClaudeLog(slug, "fallback-post-error: "+err.Error())
+		} else if posted {
+			appendHeadlessClaudeLog(slug, fmt.Sprintf("fallback-post: posted final output to #%s as %s", msg.Channel, msg.ID))
+		}
 	}
 	return nil
 }

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -21,8 +21,8 @@ var (
 	headlessCodexCommandContext = exec.CommandContext
 	headlessCodexExecutablePath = os.Executable
 	headlessCodexRunTurn        = func(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error {
-		if l != nil && !l.usesCodexRuntime() {
-			return l.runHeadlessClaudeTurn(ctx, slug, notification)
+		if l != nil && l.memberEffectiveProviderKind(slug) != provider.KindCodex {
+			return l.runHeadlessClaudeTurn(ctx, slug, notification, channel...)
 		}
 		return l.runHeadlessCodexTurn(ctx, slug, notification, channel...)
 	}
@@ -538,7 +538,7 @@ func (l *Launcher) wakeLeadAfterSpecialist(specialistSlug string) {
 	if lead == "" {
 		return
 	}
-	targets := l.agentPaneTargets()
+	targets := l.agentNotificationTargets()
 	target, ok := targets[lead]
 	if !ok {
 		return
@@ -641,6 +641,79 @@ func (l *Launcher) agentPostedSubstantiveMessageSince(slug string, startedAt tim
 		}
 	}
 	return false
+}
+
+func (l *Launcher) agentPostedSubstantiveMessageToChannelSince(slug string, targetChannel string, startedAt time.Time) bool {
+	if l == nil || l.broker == nil {
+		return false
+	}
+	targetChannel = normalizeChannelSlug(targetChannel)
+	if IsDMSlug(targetChannel) {
+		if targetAgent := DMTargetAgent(targetChannel); targetAgent != "" {
+			targetChannel = DMSlugFor(targetAgent)
+		}
+	}
+	for _, msg := range l.broker.AllMessages() {
+		if msg.From != slug {
+			continue
+		}
+		if targetChannel != "" && normalizeChannelSlug(msg.Channel) != targetChannel {
+			continue
+		}
+		content := strings.TrimSpace(msg.Content)
+		if content == "" || strings.HasPrefix(content, "[STATUS]") {
+			continue
+		}
+		when, err := time.Parse(time.RFC3339, msg.Timestamp)
+		if err != nil {
+			continue
+		}
+		if when.Add(time.Second).After(startedAt) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *Launcher) postHeadlessFinalMessageIfSilent(slug string, targetChannel string, notification string, text string, startedAt time.Time) (channelMessage, bool, error) {
+	if l == nil || l.broker == nil {
+		return channelMessage{}, false, nil
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return channelMessage{}, false, nil
+	}
+	targetChannel = normalizeChannelSlug(targetChannel)
+	if targetChannel == "" {
+		targetChannel = "general"
+	}
+	if IsDMSlug(targetChannel) {
+		if targetAgent := DMTargetAgent(targetChannel); targetAgent != "" {
+			targetChannel = DMSlugFor(targetAgent)
+		}
+	}
+	if l.agentPostedSubstantiveMessageToChannelSince(slug, targetChannel, startedAt) {
+		return channelMessage{}, false, nil
+	}
+	msg, err := l.broker.PostMessage(slug, targetChannel, text, nil, headlessReplyToID(notification))
+	if err != nil {
+		return channelMessage{}, false, err
+	}
+	return msg, true, nil
+}
+
+func headlessReplyToID(notification string) string {
+	const marker = `reply_to_id "`
+	idx := strings.LastIndex(notification, marker)
+	if idx == -1 {
+		return ""
+	}
+	start := idx + len(marker)
+	end := strings.Index(notification[start:], `"`)
+	if end == -1 {
+		return ""
+	}
+	return strings.TrimSpace(notification[start : start+end])
 }
 
 func (l *Launcher) timedOutTaskForTurn(slug string, turn headlessCodexTurn) *teamTask {
@@ -1081,6 +1154,13 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	}
 	if text := strings.TrimSpace(firstNonEmpty(result.FinalMessage, result.LastPlainLine)); text != "" {
 		appendHeadlessCodexLog(slug, "result: "+text)
+		target := firstNonEmpty(channel...)
+		msg, posted, err := l.postHeadlessFinalMessageIfSilent(slug, target, notification, text, startedAt)
+		if err != nil {
+			appendHeadlessCodexLog(slug, "fallback-post-error: "+err.Error())
+		} else if posted {
+			appendHeadlessCodexLog(slug, fmt.Sprintf("fallback-post: posted final output to #%s as %s", msg.Channel, msg.ID))
+		}
 	}
 	return nil
 }

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -607,6 +607,42 @@ func TestEnqueueHeadlessCodexTurnProcessesFIFO(t *testing.T) {
 	}
 }
 
+func TestPostHeadlessFinalMessageIfSilentPostsFinalOutput(t *testing.T) {
+	b := NewBroker()
+	channel := DMSlugFor("ceo")
+	root, err := b.PostMessage("you", channel, "Ping the CEO.", nil, "")
+	if err != nil {
+		t.Fatalf("post human message: %v", err)
+	}
+	l := &Launcher{broker: b}
+	startedAt := time.Now().UTC().Add(-1 * time.Second)
+
+	msg, posted, err := l.postHeadlessFinalMessageIfSilent(
+		"ceo",
+		"dm-human-ceo",
+		fmt.Sprintf(`Reply using team_broadcast with reply_to_id "%s".`, root.ID),
+		"REAL_AGENT_TYPING_OK",
+		startedAt,
+	)
+	if err != nil {
+		t.Fatalf("fallback post: %v", err)
+	}
+	if !posted {
+		t.Fatal("expected final output fallback to post")
+	}
+	if msg.From != "ceo" || msg.Channel != channel || msg.Content != "REAL_AGENT_TYPING_OK" || msg.ReplyTo != root.ID {
+		t.Fatalf("unexpected fallback message: %+v", msg)
+	}
+
+	_, posted, err = l.postHeadlessFinalMessageIfSilent("ceo", channel, "", "duplicate", startedAt)
+	if err != nil {
+		t.Fatalf("second fallback post: %v", err)
+	}
+	if posted {
+		t.Fatal("expected fallback to skip when the agent already posted to the target channel")
+	}
+}
+
 func TestSendTaskUpdatePassesTaskChannelToHeadlessTurn(t *testing.T) {
 	oldRunTurn := headlessCodexRunTurn
 	processed := make(chan processedTurn, 1)

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -536,20 +536,11 @@ func (l *Launcher) notifyOfficeChangesLoop() {
 // paneBackedAgents state by no-op'ing. Errors are logged but do not propagate
 // — failing to respawn leaves the previous panes running (degraded, but the
 // headless path can still deliver).
-//
-// We re-read the configured provider first because the install-wide
-// provider may have changed since the launcher was constructed (user
-// switched to Codex in Settings). reconfigureVisibleAgents tears down the
-// tmux session if we're now on codex.
 func (l *Launcher) respawnPanesAfterReseed() {
 	if l == nil {
 		return
 	}
 	l.provider = config.ResolveLLMProvider("")
-	// If we're on codex, still let reconfigureVisibleAgents run so it can
-	// kill any stale claude tmux session from a previous provider choice.
-	// And if we were codex and switched to claude-code, allow pane spawn
-	// to bootstrap for the first time by not short-circuiting here.
 	if err := l.reconfigureVisibleAgents(); err != nil {
 		log.Printf("office_reseeded: respawn panes failed: %v", err)
 	}
@@ -683,15 +674,8 @@ func (l *Launcher) deliverMessageNotification(msg channelMessage) {
 	l.notifyMu.Unlock()
 	immediate = filtered
 
-	// When a human posts an untagged message in a public channel, mark the
-	// implicit routing targets as "typing" so the existing TypingIndicator
-	// renders "X is thinking..." as ephemeral system text above the chat.
-	// This replaces the older "Routing to @X..." persisted system message
-	// — that was a stored chat message the user had to scroll past forever
-	// even after the agent replied. The typing indicator is pure UI state
-	// driven off lastTaggedAt; it auto-clears the moment the agent posts
-	// (delete in handleMessages / PostMessage paths), so nothing to
-	// garbage-collect. DMs and 1:1 mode suppress the signal.
+	// Mark implicit public-channel routing targets as active so the UI can show
+	// the ephemeral "X is thinking..." indicator. DMs suppress this signal.
 	isDM, _ := l.isChannelDM(normalizeChannelSlug(msg.Channel))
 	if l.broker != nil && len(immediate) > 0 && (msg.From == "you" || msg.From == "human") && !l.isOneOnOne() && !isDM && len(msg.Tagged) == 0 {
 		slugs := make([]string, 0, len(immediate))
@@ -736,7 +720,7 @@ type notificationTarget struct {
 }
 
 func (l *Launcher) taskNotificationTargets(action officeActionLog, task teamTask) (immediate []notificationTarget, delayed []notificationTarget) {
-	targetMap := l.agentPaneTargets()
+	targetMap := l.agentNotificationTargets()
 	if len(targetMap) == 0 {
 		return nil, nil
 	}
@@ -949,7 +933,7 @@ func (l *Launcher) sendTaskUpdate(target notificationTarget, action officeAction
 		channel = "general"
 	}
 	notification := l.buildTaskExecutionPacket(target.Slug, action, task, content)
-	if l.shouldUseHeadlessDispatch() {
+	if l.shouldUseHeadlessDispatchForTarget(target) {
 		l.enqueueHeadlessCodexTurn(target.Slug, headlessSandboxNote()+notification, channel)
 		return
 	}
@@ -982,7 +966,7 @@ func (l *Launcher) isChannelDM(channelSlug string) (isDM bool, agentTarget strin
 }
 
 func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate []notificationTarget, delayed []notificationTarget) {
-	targetMap := l.agentPaneTargets()
+	targetMap := l.agentNotificationTargets()
 	if len(targetMap) == 0 {
 		return nil, nil
 	}
@@ -1757,7 +1741,7 @@ func (l *Launcher) visibleOfficeMembers() []officeMember {
 		member := l.officeMemberBySlug(l.oneOnOneAgent())
 		return []officeMember{member}
 	}
-	ordered := l.officeAgentOrder()
+	ordered := l.paneEligibleOfficeMembers()
 	if len(ordered) <= maxVisibleOfficeAgents {
 		return ordered
 	}
@@ -1768,11 +1752,27 @@ func (l *Launcher) overflowOfficeMembers() []officeMember {
 	if l.isOneOnOne() {
 		return nil
 	}
-	ordered := l.officeAgentOrder()
+	ordered := l.paneEligibleOfficeMembers()
 	if len(ordered) <= maxVisibleOfficeAgents {
 		return nil
 	}
 	return ordered[maxVisibleOfficeAgents:]
+}
+
+// paneEligibleOfficeMembers returns officeAgentOrder() minus agents that
+// should never get a tmux/claude pane (e.g. codex-bound agents, which use
+// their own headless pipeline). Filtering upstream keeps visible/overflow
+// slot indices in sync with agentPaneTargets().
+func (l *Launcher) paneEligibleOfficeMembers() []officeMember {
+	ordered := l.officeAgentOrder()
+	filtered := make([]officeMember, 0, len(ordered))
+	for _, m := range ordered {
+		if l.memberEffectiveProviderKind(m.Slug) == provider.KindCodex {
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
 }
 
 func overflowWindowName(slug string) string {
@@ -1783,48 +1783,105 @@ func (l *Launcher) agentPaneTargets() map[string]notificationTarget {
 	targets := make(map[string]notificationTarget)
 	if l.isOneOnOne() {
 		slug := l.oneOnOneAgent()
-		if slug != "" {
+		if slug != "" && !l.skipPaneForSlug(slug) {
 			targets[slug] = notificationTarget{
 				Slug:       slug,
-				PaneTarget: l.resolvePaneTarget(slug, fmt.Sprintf("%s:team.1", l.sessionName)),
+				PaneTarget: fmt.Sprintf("%s:team.1", l.sessionName),
 			}
 		}
 		return targets
 	}
 	for i, member := range l.visibleOfficeMembers() {
+		if l.skipPaneForSlug(member.Slug) {
+			continue
+		}
 		targets[member.Slug] = notificationTarget{
 			Slug:       member.Slug,
-			PaneTarget: l.resolvePaneTarget(member.Slug, fmt.Sprintf("%s:team.%d", l.sessionName, i+1)),
+			PaneTarget: fmt.Sprintf("%s:team.%d", l.sessionName, i+1),
 		}
 	}
 	for _, member := range l.overflowOfficeMembers() {
+		if l.skipPaneForSlug(member.Slug) {
+			continue
+		}
 		targets[member.Slug] = notificationTarget{
 			Slug:       member.Slug,
-			PaneTarget: l.resolvePaneTarget(member.Slug, fmt.Sprintf("%s:%s.0", l.sessionName, overflowWindowName(member.Slug))),
+			PaneTarget: fmt.Sprintf("%s:%s.0", l.sessionName, overflowWindowName(member.Slug)),
 		}
 	}
 	return targets
 }
 
-// resolvePaneTarget returns the tmux pane target for a slug, or "" when the
-// slug has no live pane — either because its spawn failed earlier, or
-// because it's bound to codex and uses the headless pipeline. An empty
-// PaneTarget tells the pane-capture loop to skip polling (see
-// startPaneCaptureLoops) while still leaving the slug in the notification
-// target map so non-pane dispatch (e.g. wakeLeadAfterSpecialist in the
-// codex runtime) can find the target by slug.
-func (l *Launcher) resolvePaneTarget(slug, fallback string) string {
-	slug = strings.TrimSpace(slug)
-	if slug == "" {
-		return ""
+func (l *Launcher) agentNotificationTargets() map[string]notificationTarget {
+	targets := l.agentPaneTargets()
+	if l == nil {
+		return targets
 	}
-	if _, bad := l.failedPaneSlugs[slug]; bad {
-		return ""
+	addHeadless := func(slug string) {
+		slug = strings.TrimSpace(slug)
+		if slug == "" {
+			return
+		}
+		if _, ok := targets[slug]; ok {
+			return
+		}
+		if l.shouldUseHeadlessDispatchForSlug(slug) {
+			targets[slug] = notificationTarget{Slug: slug}
+		}
+	}
+	if l.isOneOnOne() {
+		addHeadless(l.oneOnOneAgent())
+		return targets
+	}
+	addHeadless(l.officeLeadSlug())
+	for _, member := range l.activeSessionMembers() {
+		addHeadless(member.Slug)
+	}
+	return targets
+}
+
+func (l *Launcher) shouldUseHeadlessDispatchForSlug(slug string) bool {
+	if l == nil || strings.TrimSpace(slug) == "" {
+		return false
+	}
+	if l.shouldUseHeadlessDispatch() {
+		return true
 	}
 	if l.memberEffectiveProviderKind(slug) == provider.KindCodex {
-		return ""
+		return true
 	}
-	return fallback
+	if _, failed := l.failedPaneSlugs[strings.TrimSpace(slug)]; failed {
+		return true
+	}
+	return false
+}
+
+func (l *Launcher) shouldUseHeadlessDispatchForTarget(target notificationTarget) bool {
+	if l == nil {
+		return false
+	}
+	if l.shouldUseHeadlessDispatchForSlug(target.Slug) {
+		return true
+	}
+	return strings.TrimSpace(target.PaneTarget) == ""
+}
+
+// skipPaneForSlug returns true when the given slug should not have a tmux
+// pane target registered — either because pane spawn failed earlier, or
+// because the agent is bound to the codex runtime and uses its own headless
+// pipeline. In either case, dispatch falls back to the headless path.
+func (l *Launcher) skipPaneForSlug(slug string) bool {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return true
+	}
+	if _, bad := l.failedPaneSlugs[slug]; bad {
+		return true
+	}
+	if l.memberEffectiveProviderKind(slug) == provider.KindCodex {
+		return true
+	}
+	return false
 }
 
 func (l *Launcher) isOneOnOne() bool {
@@ -2050,12 +2107,6 @@ func (l *Launcher) ReconfigureSession() error {
 }
 
 func (l *Launcher) reconfigureVisibleAgents() error {
-	// Re-read the configured provider in case the user changed it in
-	// Settings after launch. Without this, a user who switched install-wide
-	// from claude-code to codex post-onboarding would keep getting claude
-	// panes on respawn — the stale l.provider snapshot from NewLauncher
-	// time. If the new provider is codex, skip pane machinery entirely;
-	// codex dispatch runs through headless_codex.go.
 	l.provider = config.ResolveLLMProvider("")
 	if l.usesCodexRuntime() {
 		if l.paneBackedAgents {
@@ -2075,8 +2126,6 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 		return fmt.Errorf("reset Claude sessions: %w", err)
 	}
 
-	// Reset stale pane-spawn failures from a previous reconfigure so codex
-	// agents (or agents whose spawn failed earlier) get a clean retry.
 	l.failedPaneSlugs = nil
 
 	// Use respawn-pane to restart agent processes IN PLACE.
@@ -2723,7 +2772,7 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 		)
 	}
 
-	if l.shouldUseHeadlessDispatch() {
+	if l.shouldUseHeadlessDispatchForTarget(target) {
 		l.enqueueHeadlessCodexTurn(target.Slug, headlessSandboxNote()+notification, channel)
 		return
 	}
@@ -3136,18 +3185,10 @@ func (l *Launcher) spawnOverflowAgents() {
 }
 
 // detectDeadPanesAfterSpawn waits briefly for fresh panes to either settle
-// into claude (alive) or die on launch (e.g. shell parse error, missing
-// binary, interactive auth prompt that exits). For any pane found dead, we
-// capture its history, log it to stderr, post a visible notice to #general,
-// and mark the slug as failed so dispatch falls back to headless. Without
-// this, pane deaths were invisible: the pane showed no process, but the
-// agent appeared in the UI as "live" forever, and every dispatch ran into
-// a wall.
-//
-// Runs in a goroutine because tmux needs a moment to finish the respawn
-// and detect process exit before pane_dead reflects the truth.
+// into claude or die on launch. Dead panes are marked failed so subsequent
+// notifications fall back to the headless path instead of polling ghost panes.
 func (l *Launcher) detectDeadPanesAfterSpawn(members []officeMember) {
-	if !l.paneBackedAgents && l.sessionName == "" {
+	if l == nil || l.sessionName == "" {
 		return
 	}
 	time.Sleep(1500 * time.Millisecond)
@@ -3161,10 +3202,7 @@ func (l *Launcher) detectDeadPanesAfterSpawn(members []officeMember) {
 			"-t", target.PaneTarget,
 			"-p", "#{pane_dead}",
 		).CombinedOutput()
-		if err != nil {
-			continue
-		}
-		if strings.TrimSpace(string(out)) != "1" {
+		if err != nil || strings.TrimSpace(string(out)) != "1" {
 			continue
 		}
 		history, _ := exec.Command("tmux", "-L", tmuxSocketName, "capture-pane",
@@ -3173,16 +3211,16 @@ func (l *Launcher) detectDeadPanesAfterSpawn(members []officeMember) {
 		).CombinedOutput()
 		snippet := strings.TrimSpace(string(history))
 		if len(snippet) > 400 {
-			snippet = snippet[:400] + "…"
+			snippet = snippet[:400] + "..."
 		}
 		fmt.Fprintf(os.Stderr,
-			"  Agents:  pane for %s (%s) died on launch — falling back to headless. Last output: %q\n",
+			"  Agents:  pane for %s (%s) died on launch; falling back to headless. Last output: %q\n",
 			m.Slug, target.PaneTarget, snippet,
 		)
 		l.recordPaneSpawnFailure(m.Slug, "pane died on launch; last output: "+snippet)
 		if l.broker != nil {
 			l.broker.PostSystemMessage("general",
-				fmt.Sprintf("Agent @%s didn't start cleanly; running in headless fallback. Check the launcher log for details.", m.Slug),
+				fmt.Sprintf("Agent @%s did not start cleanly; running in headless fallback. Check the launcher log for details.", m.Slug),
 				"runtime",
 			)
 		}
@@ -3261,9 +3299,6 @@ func (l *Launcher) trySpawnWebAgentPanes() {
 	l.spawnOverflowAgents()
 
 	l.paneBackedAgents = true
-	// Catch panes that tmux accepted but whose inner shell/claude exited
-	// immediately. Runs in a goroutine so we don't block startup — see
-	// detectDeadPanesAfterSpawn for details.
 	go l.detectDeadPanesAfterSpawn(append(l.visibleOfficeMembers(), l.overflowOfficeMembers()...))
 	fmt.Printf("  Agents:  interactive Claude panes in tmux session %q (uses subscription quota)\n", l.sessionName)
 }

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -567,6 +568,86 @@ func TestNotificationTargetsForDMChannel(t *testing.T) {
 	})
 	if len(immediate2) != 0 {
 		t.Errorf("agent's own DM message should not echo back, got %+v", immediate2)
+	}
+}
+
+func TestNotificationTargetsForDMChannelCodexRuntimeUsesHeadlessTarget(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	l := &Launcher{
+		provider: "codex",
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend Engineer"},
+			},
+		},
+	}
+
+	immediate, delayed := l.notificationTargetsForMessage(channelMessage{
+		From:    "you",
+		Channel: "dm-fe",
+		Content: "Check this component",
+	})
+	if len(immediate) != 1 {
+		t.Fatalf("expected 1 immediate headless target for Codex DM, got %d: %+v", len(immediate), immediate)
+	}
+	if immediate[0].Slug != "fe" {
+		t.Fatalf("expected DM target fe, got %q", immediate[0].Slug)
+	}
+	if immediate[0].PaneTarget != "" {
+		t.Fatalf("expected headless target without pane, got %+v", immediate[0])
+	}
+	if len(delayed) != 0 {
+		t.Fatalf("expected no delayed targets for Codex DM, got %+v", delayed)
+	}
+}
+
+func TestDeliverDMMessageQueuesCodexHeadlessTurn(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	l := newHeadlessLauncherForTest()
+	l.broker = b
+	l.provider = "codex"
+	l.notifyLastDelivered = make(map[string]time.Time)
+
+	processed := make(chan string, 1)
+	oldRunTurn := headlessCodexRunTurn
+	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, slug, notification string, channel ...string) error {
+		targetChannel := ""
+		if len(channel) > 0 {
+			targetChannel = channel[0]
+		}
+		processed <- strings.Join([]string{slug, targetChannel, notification}, "\n---\n")
+		return nil
+	}
+	defer func() { headlessCodexRunTurn = oldRunTurn }()
+
+	dmSlug := DMSlugFor("ceo")
+	l.deliverMessageNotification(channelMessage{
+		ID:      "msg-1",
+		From:    "you",
+		Channel: dmSlug,
+		Content: "Real agent smoke test",
+	})
+
+	got := waitForString(t, processed)
+	if !strings.Contains(got, "ceo") {
+		t.Fatalf("expected ceo headless turn, got %q", got)
+	}
+	if !strings.Contains(got, dmSlug) {
+		t.Fatalf("expected DM channel %q in headless turn, got %q", dmSlug, got)
+	}
+	if !strings.Contains(got, "Context: DIRECT MESSAGE") || !strings.Contains(got, "Respond to every message") {
+		t.Fatalf("expected direct-message response instruction, got %q", got)
 	}
 }
 

--- a/web/e2e/tests/wizard.spec.ts
+++ b/web/e2e/tests/wizard.spec.ts
@@ -33,6 +33,19 @@ async function waitForReactMount(page: Page): Promise<void> {
   );
 }
 
+async function expectNoReactErrors(
+  page: Page,
+  getErrors: () => string[],
+  context: string,
+): Promise<void> {
+  await expect(page.getByTestId('error-boundary')).toHaveCount(0);
+
+  // Avoid networkidle here: onboarding also opens the long-lived broker SSE
+  // stream, so the page is expected to keep an active request.
+  const errors = getErrors();
+  expect(errors, `Uncaught errors ${context}:\n  ${errors.join('\n  ')}`).toHaveLength(0);
+}
+
 // The wizard flow is welcome → identity → templates. Fill the two required
 // identity fields so the primary CTA enables and we can advance.
 async function advanceToTemplatesStep(page: Page): Promise<void> {
@@ -53,14 +66,7 @@ test.describe('wuphf onboarding wizard smoke', () => {
     // The Wizard renders `.wizard-step` as its root container
     // (see web/src/components/onboarding/Wizard.tsx — WelcomeStep).
     await expect(page.locator('.wizard-step').first()).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByTestId('error-boundary')).toHaveCount(0);
-
-    await page.waitForLoadState('networkidle');
-    const errors = getErrors();
-    expect(
-      errors,
-      `Uncaught errors rendering wizard:\n  ${errors.join('\n  ')}`,
-    ).toHaveLength(0);
+    await expectNoReactErrors(page, getErrors, 'rendering wizard');
   });
 
   test('advancing from welcome → identity → templates step does not crash', async ({ page }) => {
@@ -76,14 +82,7 @@ test.describe('wuphf onboarding wizard smoke', () => {
 
     // Templates step renders `.wizard-panel` (welcome + identity have different markers).
     await expect(page.locator('.wizard-panel').first()).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByTestId('error-boundary')).toHaveCount(0);
-
-    await page.waitForLoadState('networkidle');
-    const errors = getErrors();
-    expect(
-      errors,
-      `Uncaught errors advancing wizard:\n  ${errors.join('\n  ')}`,
-    ).toHaveLength(0);
+    await expectNoReactErrors(page, getErrors, 'advancing wizard');
   });
 
   test('blueprint picker shows shipped preset teams (not just "From scratch")', async ({

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -32,6 +32,7 @@ import { ConfirmHost } from './components/ui/ConfirmDialog'
 import { ProviderSwitcherHost } from './components/ui/ProviderSwitcher'
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts'
 import { useHashRouter } from './hooks/useHashRouter'
+import { useBrokerEvents } from './hooks/useBrokerEvents'
 import './styles/shadcn.css'
 import './styles/global.css'
 import './styles/layout.css'
@@ -213,6 +214,7 @@ export default function App() {
 
   useKeyboardShortcuts()
   useHashRouter()
+  useBrokerEvents(apiReady)
 
   // Load theme CSS when theme changes
   useEffect(() => {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -177,6 +177,10 @@ export interface OfficeMember {
   role: string
   emoji?: string
   status?: string
+  activity?: string
+  detail?: string
+  liveActivity?: string
+  lastTime?: string
   task?: string
   channel?: string
   provider?: ProviderBinding | string
@@ -223,6 +227,11 @@ export interface Channel {
   members?: string[]
 }
 
+export interface DMChannelResponse extends Channel {
+  id?: string
+  created?: boolean
+}
+
 export function getChannels() {
   return get<{ channels: Channel[] }>('/channels')
 }
@@ -242,7 +251,7 @@ export function generateChannel(prompt: string) {
 }
 
 export function createDM(agentSlug: string) {
-  return post('/channels/dm', {
+  return post<DMChannelResponse>('/channels/dm', {
     members: ['human', agentSlug],
     type: 'direct',
   })

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Xmark } from 'iconoir-react'
 import { useQueryClient } from '@tanstack/react-query'
-import { useAppStore } from '../../stores/app'
+import { directChannelSlug, useAppStore } from '../../stores/app'
 import { useOfficeMembers, useChannelMembers } from '../../hooks/useMembers'
 import { useAgentStream } from '../../hooks/useAgentStream'
 import { createDM, getAgentLogs, post } from '../../api/client'
@@ -135,8 +135,7 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
     setDmLoading(true)
     try {
       const result = await createDM(agent.slug)
-      const channel = (result as { channel?: { slug?: string } })?.channel?.slug
-        ?? `dm-human-${agent.slug}`
+      const channel = result.slug || directChannelSlug(agent.slug)
       enterDM(agent.slug, channel)
       setActiveAgentSlug(null)
     } catch (err: unknown) {

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { post, generateAgent } from '../../api/client'
 import { useQueryClient } from '@tanstack/react-query'
 
-type Provider = 'claude' | 'openai' | 'gemini'
+type Provider = 'inherit' | 'claude-code' | 'codex'
 type WizardMode = 'describe' | 'manual'
 
 interface AgentFormData {
@@ -19,14 +19,14 @@ const INITIAL_FORM: AgentFormData = {
   slug: '',
   role: '',
   emoji: '',
-  provider: 'claude',
+  provider: 'inherit',
   expertise: '',
 }
 
 const PROVIDERS: { value: Provider; label: string }[] = [
-  { value: 'claude', label: 'Claude (Anthropic)' },
-  { value: 'openai', label: 'OpenAI' },
-  { value: 'gemini', label: 'Gemini (Google)' },
+  { value: 'inherit', label: 'Default runtime' },
+  { value: 'codex', label: 'Codex' },
+  { value: 'claude-code', label: 'Claude Code' },
 ]
 
 function slugify(name: string): string {
@@ -68,7 +68,7 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
         slug: generatedSlug,
         role: tmpl.role || '',
         emoji: tmpl.emoji || '',
-        provider: 'claude',
+        provider: 'inherit',
         expertise: (tmpl.expertise || []).join(', '),
       })
       setSlugEdited(generatedSlug.length > 0)
@@ -113,11 +113,12 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
 
     try {
       const body = {
+        action: 'create',
         slug: form.slug,
         name: form.name,
         role: form.role || undefined,
         emoji: form.emoji || undefined,
-        provider: form.provider,
+        provider: form.provider === 'inherit' ? undefined : { kind: form.provider },
         expertise: expertiseTags.length > 0 ? expertiseTags : undefined,
       }
 

--- a/web/src/components/messages/Composer.tsx
+++ b/web/src/components/messages/Composer.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, useCallback } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { postMessage, post } from '../../api/client'
-import { useAppStore } from '../../stores/app'
+import { createDM, postMessage, post } from '../../api/client'
+import { directChannelSlug, useAppStore } from '../../stores/app'
 import { showNotice } from '../ui/Toast'
 import { confirm } from '../ui/ConfirmDialog'
 import { openProviderSwitcher } from '../ui/ProviderSwitcher'
@@ -91,9 +91,9 @@ function handleSlashCommand(input: string): boolean {
         return true
       }
       const slug = args.trim().toLowerCase()
-      post<{ channel?: string }>('/channels/dm', { members: ['human', slug], type: 'direct' })
+      createDM(slug)
         .then((data) => {
-          const ch = data.channel || `dm-${slug}`
+          const ch = data.slug || directChannelSlug(slug)
           store.enterDM(slug, ch)
         })
         .catch(() => showNotice('Agent not found: ' + args.trim(), 'error'))

--- a/web/src/components/messages/DMView.tsx
+++ b/web/src/components/messages/DMView.tsx
@@ -6,6 +6,7 @@ import { MessageBubble } from './MessageBubble'
 import { Composer } from './Composer'
 import { InterviewBar } from './InterviewBar'
 import { StreamLineView } from './StreamLineView'
+import { TypingIndicator } from './TypingIndicator'
 
 export function DMView() {
   const currentChannel = useAppStore((s) => s.currentChannel)
@@ -45,6 +46,7 @@ export function DMView() {
               <MessageBubble key={msg.id} message={msg} />
             ))}
           </div>
+          <TypingIndicator />
           <InterviewBar />
           <Composer />
         </div>

--- a/web/src/components/messages/StreamLineView.test.tsx
+++ b/web/src/components/messages/StreamLineView.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { StreamLineView } from './StreamLineView'
+
+describe('<StreamLineView>', () => {
+  it('renders Claude assistant text and tool-use blocks', () => {
+    render(
+      <StreamLineView
+        line={{
+          id: 1,
+          data: '',
+          parsed: {
+            type: 'assistant',
+            message: {
+              content: [
+                { type: 'text', text: 'I am posting the update now.' },
+                { type: 'tool_use', name: 'team_broadcast', input: { channel: 'general', content: 'Done' } },
+              ],
+            },
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('I am posting the update now.')).toBeInTheDocument()
+    expect(screen.getByText('team_broadcast')).toBeInTheDocument()
+    expect(screen.getByText('Done')).toBeInTheDocument()
+  })
+
+  it('renders structured MCP tool audit events', () => {
+    render(
+      <StreamLineView
+        line={{
+          id: 1,
+          data: '',
+          parsed: {
+            type: 'mcp_tool_event',
+            phase: 'call',
+            tool: 'team_broadcast',
+            arguments: { channel: 'general', content: 'Exact content' },
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('call: team_broadcast')).toBeInTheDocument()
+    expect(screen.getByText('Exact content')).toBeInTheDocument()
+  })
+
+  it('renders Codex completed message content arrays', () => {
+    render(
+      <StreamLineView
+        line={{
+          id: 1,
+          data: '',
+          parsed: {
+            type: 'item.completed',
+            item: {
+              type: 'message',
+              content: [{ type: 'output_text', text: 'Final Codex answer' }],
+            },
+          },
+        }}
+      />,
+    )
+
+    expect(screen.getByText('Final Codex answer')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -34,13 +34,48 @@ export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
     return null
   }
 
+  if (evtType === 'mcp_tool_event') {
+    const phase = stringish(parsed.phase)
+    const tool = stringish(parsed.tool) || 'tool'
+    return (
+      <ToolCallCard
+        item={{
+          type: 'tool_call',
+          name: phase ? `${phase}: ${tool}` : tool,
+          arguments: parsed.arguments ?? parsed.args,
+          result: parsed.result,
+          error: parsed.error,
+        }}
+        compact={compact}
+      />
+    )
+  }
+
+  if (evtType === 'assistant') {
+    return <ClaudeAssistantEvent parsed={parsed} compact={compact} />
+  }
+
+  if (evtType === 'user') {
+    return <ClaudeUserEvent parsed={parsed} compact={compact} />
+  }
+
+  if (evtType === 'result') {
+    const text = stringish(parsed.result).trim()
+    if (text) return <div className="cc-thinking">{text}</div>
+  }
+
+  if (evtType === 'response.output_text.delta') {
+    const text = stringish(parsed.delta ?? parsed.text).trim()
+    if (text) return <div className="cc-thinking">{text}</div>
+  }
+
   // item.completed → agent_message / tool call
   if (evtType === 'item.completed' && parsed.item && typeof parsed.item === 'object') {
     const item = parsed.item as Record<string, unknown>
     const itemType = typeof item.type === 'string' ? item.type : ''
 
-    if (itemType === 'agent_message') {
-      const text = typeof item.text === 'string' ? item.text.trim() : ''
+    if (itemType === 'agent_message' || itemType === 'message' || itemType === 'assistant') {
+      const text = codexItemText(item)
       if (!text) return null
       const truncated = text.length > 500 ? text.slice(0, 500) + '\u2026' : text
       return <div className="cc-thinking">{truncated}</div>
@@ -56,6 +91,117 @@ export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
 
   // Fallback: structured event with type/phase/agent + detail + extras
   return <GenericEventCard parsed={parsed} compact={compact} />
+}
+
+function ClaudeAssistantEvent({ parsed, compact }: { parsed: Record<string, unknown>; compact: boolean }) {
+  const blocks = messageContentBlocks(parsed)
+  const rendered = blocks
+    .map((block, index) => {
+      const blockType = stringish(block.type)
+      if (blockType === 'text') {
+        const text = stringish(block.text).trim()
+        return text ? <div key={index} className="cc-thinking">{text}</div> : null
+      }
+      if (blockType === 'thinking') {
+        const text = stringish(block.thinking).trim()
+        return text ? <div key={index} className="stream-card-detail">{text}</div> : null
+      }
+      if (blockType === 'tool_use') {
+        return (
+          <ToolCallCard
+            key={index}
+            item={{ type: 'tool_call', name: block.name, arguments: block.input }}
+            compact={compact}
+          />
+        )
+      }
+      return null
+    })
+    .filter(Boolean)
+
+  if (rendered.length === 0) return null
+  if (rendered.length === 1) return <>{rendered[0]}</>
+  return <div className="stream-event-stack">{rendered}</div>
+}
+
+function ClaudeUserEvent({ parsed, compact }: { parsed: Record<string, unknown>; compact: boolean }) {
+  const blocks = messageContentBlocks(parsed)
+  const rendered = blocks
+    .map((block, index) => {
+      if (stringish(block.type) !== 'tool_result') return null
+      const content = block.content
+      return (
+        <div key={index} className="cc-tool-call">
+          <div className="cc-tool-section-label">Tool result</div>
+          <ToolResultContent text={stringFromToolContent(content)} compact={compact} />
+        </div>
+      )
+    })
+    .filter(Boolean)
+
+  const toolUseResult = parsed.tool_use_result
+  if (toolUseResult && typeof toolUseResult === 'object') {
+    const result = toolUseResult as Record<string, unknown>
+    const text = [stringish(result.stdout), stringish(result.stderr)].filter(Boolean).join('\n')
+    if (text) {
+      rendered.push(
+        <div key="tool-use-result" className="cc-tool-call">
+          <div className="cc-tool-section-label">Tool result</div>
+          <ToolResultContent text={text} compact={compact} />
+        </div>,
+      )
+    }
+  }
+
+  if (rendered.length === 0) return null
+  if (rendered.length === 1) return <>{rendered[0]}</>
+  return <div className="stream-event-stack">{rendered}</div>
+}
+
+function messageContentBlocks(parsed: Record<string, unknown>): Record<string, unknown>[] {
+  const message = parsed.message
+  if (!message || typeof message !== 'object') return []
+  const content = (message as Record<string, unknown>).content
+  if (!Array.isArray(content)) return []
+  return content.filter((block): block is Record<string, unknown> => !!block && typeof block === 'object')
+}
+
+function codexItemText(item: Record<string, unknown>): string {
+  const direct = stringish(item.text).trim()
+  if (direct) return direct
+  const content = item.content
+  if (!Array.isArray(content)) return ''
+  return content
+    .map((part) => {
+      if (!part || typeof part !== 'object') return ''
+      const p = part as Record<string, unknown>
+      const typ = stringish(p.type)
+      if (typ && typ !== 'output_text' && typ !== 'text') return ''
+      return stringish(p.text).trim()
+    })
+    .filter(Boolean)
+    .join('\n')
+}
+
+function stringFromToolContent(content: unknown): string {
+  if (typeof content === 'string') return content
+  if (Array.isArray(content)) {
+    return content
+      .map((item) => {
+        if (typeof item === 'string') return item
+        if (item && typeof item === 'object') {
+          const obj = item as Record<string, unknown>
+          return stringish(obj.text ?? obj.content)
+        }
+        return ''
+      })
+      .filter(Boolean)
+      .join('\n')
+  }
+  if (content && typeof content === 'object') {
+    return JSON.stringify(content)
+  }
+  return ''
 }
 
 function renderTokens(parsed: Record<string, unknown>): string | null {
@@ -100,8 +246,8 @@ const ARG_SKIP = new Set(['my_slug', 'new_topic', 'viewer_slug', 'tagged'])
 function ToolCallCard({ item, compact }: { item: Record<string, unknown>; compact: boolean }) {
   const [open, setOpen] = useState(false)
   const toolName = (item.tool as string | undefined) || (item.name as string | undefined) || 'tool'
-  const args = (item.arguments as Record<string, unknown> | undefined) || (item.args as Record<string, unknown> | undefined) || {}
-  const result = item.result as { content?: Array<{ text?: string }> } | undefined
+  const args = objectFromToolField(item.arguments ?? item.args)
+  const result = normalizeToolResult(item.result)
   const errorField = item.error
 
   const { summaryArg, summaryResult, summaryError } = useMemo(() => {
@@ -184,6 +330,35 @@ function ToolCallCard({ item, compact }: { item: Record<string, unknown>; compac
       )}
     </div>
   )
+}
+
+function objectFromToolField(value: unknown): Record<string, unknown> {
+  if (!value) return {}
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>
+      }
+    } catch {
+      // keep as scalar below
+    }
+    return { value }
+  }
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>
+  }
+  return { value }
+}
+
+function normalizeToolResult(value: unknown): { content?: Array<{ text?: string }> } | undefined {
+  if (value == null || value === '') return undefined
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    const obj = value as { content?: Array<{ text?: string }> }
+    if (Array.isArray(obj.content)) return obj
+    return { content: [{ text: JSON.stringify(value) }] }
+  }
+  return { content: [{ text: typeof value === 'string' ? value : JSON.stringify(value) }] }
 }
 
 function ToolResultContent({ text, compact }: { text?: string; compact: boolean }) {

--- a/web/src/components/messages/TypingIndicator.test.tsx
+++ b/web/src/components/messages/TypingIndicator.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TypingIndicator } from './TypingIndicator'
+import { useAppStore } from '../../stores/app'
+import { useChannelMembers, useOfficeMembers } from '../../hooks/useMembers'
+
+vi.mock('../../hooks/useMembers', () => ({
+  useOfficeMembers: vi.fn(),
+  useChannelMembers: vi.fn(),
+}))
+
+const mockUseOfficeMembers = vi.mocked(useOfficeMembers)
+const mockUseChannelMembers = vi.mocked(useChannelMembers)
+
+describe('<TypingIndicator>', () => {
+  beforeEach(() => {
+    useAppStore.setState({ currentChannel: 'general', currentApp: null, channelMeta: {} })
+    mockUseOfficeMembers.mockReturnValue({ data: [] } as unknown as ReturnType<typeof useOfficeMembers>)
+    mockUseChannelMembers.mockReturnValue({ data: [] } as unknown as ReturnType<typeof useChannelMembers>)
+  })
+
+  it('shows the active DM agent as typing', () => {
+    useAppStore.getState().enterDM('ceo', 'ceo__human')
+    mockUseOfficeMembers.mockReturnValue({
+      data: [
+        { slug: 'ceo', name: 'CEO', status: 'active' },
+        { slug: 'pm', name: 'PM', status: 'active' },
+      ],
+    } as unknown as ReturnType<typeof useOfficeMembers>)
+    mockUseChannelMembers.mockReturnValue({
+      data: [{ slug: 'ceo', name: 'CEO' }],
+    } as unknown as ReturnType<typeof useChannelMembers>)
+
+    render(<TypingIndicator />)
+
+    expect(screen.getByText('CEO is typing...')).toBeInTheDocument()
+    expect(screen.queryByText(/PM/)).not.toBeInTheDocument()
+  })
+
+  it('limits public channel typing to channel members', () => {
+    useAppStore.getState().setCurrentChannel('product')
+    mockUseOfficeMembers.mockReturnValue({
+      data: [
+        { slug: 'ceo', name: 'CEO', status: 'active' },
+        { slug: 'pm', name: 'PM', status: 'active' },
+      ],
+    } as unknown as ReturnType<typeof useOfficeMembers>)
+    mockUseChannelMembers.mockReturnValue({
+      data: [{ slug: 'pm', name: 'PM' }],
+    } as unknown as ReturnType<typeof useChannelMembers>)
+
+    render(<TypingIndicator />)
+
+    expect(screen.getByText('PM is typing...')).toBeInTheDocument()
+    expect(screen.queryByText(/CEO/)).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/messages/TypingIndicator.tsx
+++ b/web/src/components/messages/TypingIndicator.tsx
@@ -1,19 +1,28 @@
-import { useOfficeMembers } from '../../hooks/useMembers'
+import { useOfficeMembers, useChannelMembers } from '../../hooks/useMembers'
+import { isDMChannel, useAppStore } from '../../stores/app'
 
 export function TypingIndicator() {
+  const currentChannel = useAppStore((s) => s.currentChannel)
+  const channelMeta = useAppStore((s) => s.channelMeta)
   const { data: members = [] } = useOfficeMembers()
+  const { data: channelMembers = [] } = useChannelMembers(currentChannel)
+  const dm = isDMChannel(currentChannel, channelMeta)
+  const channelMemberSlugs = new Set(channelMembers.map((m) => m.slug))
 
-  // Show typing for any member with 'active' status
-  const active = members.filter((m) => m.status === 'active' && m.slug !== 'human')
+  const active = members.filter((m) => {
+    if (m.status !== 'active' || m.slug === 'human') return false
+    if (dm) return m.slug === dm.agentSlug
+    return channelMemberSlugs.size === 0 || channelMemberSlugs.has(m.slug)
+  })
 
   if (active.length === 0) return null
 
   const names = active.map((m) => m.name || m.slug)
   const label = names.length === 1
-    ? `${names[0]} is thinking...`
+    ? `${names[0]} is typing...`
     : names.length <= 3
-      ? `${names.join(', ')} are thinking...`
-      : `${names.length} agents are working...`
+      ? `${names.join(', ')} are typing...`
+      : `${names.length} agents are typing...`
 
   return (
     <div className="typing-indicator" style={{ padding: '0 20px 8px' }}>

--- a/web/src/hooks/useBrokerEvents.ts
+++ b/web/src/hooks/useBrokerEvents.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { sseURL } from '../api/client'
+import { useAppStore } from '../stores/app'
+
+export function useBrokerEvents(enabled: boolean) {
+  const queryClient = useQueryClient()
+  const setBrokerConnected = useAppStore((s) => s.setBrokerConnected)
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const ES = (globalThis as { EventSource?: typeof EventSource }).EventSource
+    if (!ES) return
+
+    const source = new ES(sseURL('/events'))
+    source.addEventListener('ready', () => setBrokerConnected(true))
+    source.addEventListener('message', () => {
+      void queryClient.invalidateQueries({ queryKey: ['messages'] })
+      void queryClient.invalidateQueries({ queryKey: ['thread-messages'] })
+      void queryClient.invalidateQueries({ queryKey: ['office-members'] })
+      void queryClient.invalidateQueries({ queryKey: ['channel-members'] })
+    })
+    source.addEventListener('activity', () => {
+      void queryClient.invalidateQueries({ queryKey: ['office-members'] })
+      void queryClient.invalidateQueries({ queryKey: ['channel-members'] })
+    })
+    source.addEventListener('office_changed', () => {
+      void queryClient.invalidateQueries({ queryKey: ['channels'] })
+      void queryClient.invalidateQueries({ queryKey: ['office-members'] })
+      void queryClient.invalidateQueries({ queryKey: ['channel-members'] })
+    })
+    source.addEventListener('action', () => {
+      void queryClient.invalidateQueries({ queryKey: ['actions'] })
+      void queryClient.invalidateQueries({ queryKey: ['office-tasks'] })
+    })
+    source.onerror = () => setBrokerConnected(false)
+
+    return () => {
+      source.close()
+    }
+  }, [enabled, queryClient, setBrokerConnected])
+}

--- a/web/src/hooks/useHashRouter.ts
+++ b/web/src/hooks/useHashRouter.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { useAppStore, isDMChannel, type ChannelMeta } from '../stores/app'
+import { useAppStore, directChannelSlug, isDMChannel, type ChannelMeta } from '../stores/app'
 
 type Route =
   | { view: 'channel'; channel: string }
@@ -77,7 +77,7 @@ function stateToHash(state: {
  * Two-way sync between the Zustand app store and the location hash.
  *
  *   #/channels/<slug>            ↔ currentChannel=<slug>, currentApp=null
- *   #/dm/<agent>                 ↔ currentChannel=dm-human-<agent>, channelMeta marked type 'D'
+ *   #/dm/<agent>                 ↔ currentChannel=<agent>__human, channelMeta marked type 'D'
  *   #/apps/<id>                  ↔ currentApp=<id>
  *   #/wiki[/<path>]              ↔ currentApp='wiki', wikiPath=<path>
  *   #/notebooks[/<agent>[/<e>]]  ↔ currentApp='notebooks', notebookAgentSlug, notebookEntrySlug
@@ -115,8 +115,7 @@ export function useHashRouter() {
       const route = parseHash(window.location.hash)
       ignoreNextStoreSync.current = true
       if (route.view === 'dm') {
-        // Broker uses the dm-human-<slug> channel convention by default.
-        enterDM(route.agent, `dm-human-${route.agent}`)
+        enterDM(route.agent, directChannelSlug(route.agent))
       } else if (route.view === 'app') {
         setCurrentApp(route.app)
       } else if (route.view === 'wiki') {

--- a/web/src/stores/app.test.ts
+++ b/web/src/stores/app.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { directChannelSlug, isDMChannel } from './app'
+
+describe('DM channel helpers', () => {
+  it('uses the broker canonical direct slug', () => {
+    expect(directChannelSlug('ceo')).toBe('ceo__human')
+    expect(directChannelSlug('pm')).toBe('human__pm')
+  })
+
+  it('recognizes canonical and legacy DM slugs', () => {
+    expect(isDMChannel('ceo__human', {})).toEqual({ agentSlug: 'ceo' })
+    expect(isDMChannel('human__pm', {})).toEqual({ agentSlug: 'pm' })
+    expect(isDMChannel('dm-ceo', {})).toEqual({ agentSlug: 'ceo' })
+    expect(isDMChannel('dm-human-ceo', {})).toEqual({ agentSlug: 'ceo' })
+  })
+})

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -9,14 +9,30 @@ export interface ChannelMeta {
   agentSlug?: string
 }
 
-const DM_SLUG_PREFIX = 'dm-human-'
+const LEGACY_DM_SLUG_PREFIX = 'dm-'
+const BROKEN_DM_SLUG_PREFIX = 'dm-human-'
+
+export function directChannelSlug(agentSlug: string, humanSlug = 'human'): string {
+  const a = humanSlug.trim().toLowerCase()
+  const b = agentSlug.trim().toLowerCase()
+  return a > b ? `${b}__${a}` : `${a}__${b}`
+}
+
+function agentFromDirectSlug(slug: string): string | null {
+  const parts = slug.split('__')
+  if (parts.length !== 2) return null
+  if (parts[0] === 'human' || parts[0] === 'you') return parts[1] || null
+  if (parts[1] === 'human' || parts[1] === 'you') return parts[0] || null
+  return null
+}
 
 /**
  * Resolve a channel slug into DM info, or null if not a DM.
  *
  * Prefers explicit channelMeta (written by enterDM), falls back to the
- * server's `dm-human-<agent>` naming convention so deep-links and page
- * reloads still classify DMs correctly before metadata is hydrated.
+ * server's canonical `<agent>__human` convention plus both legacy `dm-*`
+ * spellings so deep-links and page reloads still classify DMs correctly
+ * before metadata is hydrated.
  */
 export function isDMChannel(
   slug: string,
@@ -24,8 +40,13 @@ export function isDMChannel(
 ): { agentSlug: string } | null {
   const m = meta[slug]
   if (m?.type === 'D' && m.agentSlug) return { agentSlug: m.agentSlug }
-  if (slug.startsWith(DM_SLUG_PREFIX)) {
-    return { agentSlug: slug.slice(DM_SLUG_PREFIX.length) }
+  const directAgent = agentFromDirectSlug(slug)
+  if (directAgent) return { agentSlug: directAgent }
+  if (slug.startsWith(BROKEN_DM_SLUG_PREFIX)) {
+    return { agentSlug: slug.slice(BROKEN_DM_SLUG_PREFIX.length) }
+  }
+  if (slug.startsWith(LEGACY_DM_SLUG_PREFIX)) {
+    return { agentSlug: slug.slice(LEGACY_DM_SLUG_PREFIX.length) }
   }
   return null
 }


### PR DESCRIPTION
## Summary

PR #207 has merged into `main`; this branch is rebased on top of that merge and contains only the remaining comms fixes not covered there.

PR #207 already fixed:

- top-level agent replies being visible in the main channel feed
- auto-tagging `@agent` mentions from agent message bodies
- web UI cache-control so upgrades load fresh bundles

This PR adds the missing/better pieces:

- Codex/Claude headless final-output fallback: if an agent produces final text but does not call `team_broadcast`, post that final response into the target channel/DM once, without duplicating real broadcasts.
- DM/channel presence restoration: live office-member activity, green active dot state, and channel-aware `CEO is typing...` indicators.
- Broker SSE-driven UI refresh for messages, office members, tasks, actions, channels, and threads so agent work appears without a manual refresh.
- Structured live tool logs and Codex/Claude stream rendering in the DM live output panel.
- Canonical DM/provider routing fixes and blueprint provider inheritance tests so blueprints do not select/stick providers.

## Real Browser Evidence

Ran a real Codex CEO agent from this branch with Playwright against `http://127.0.0.1:8897/#/dm/ceo`.

Prompt sent from the browser DM composer:

```text
Do not call team_broadcast. Reply exactly NEW_PR_SCREEN_OK.
```

Observed on screen:

- Sidebar showed the CEO active/green and `1 agent active`.
- DM composer area showed `CEO is typing...`.
- Final DM feed showed a CEO message containing `NEW_PR_SCREEN_OK`.
- Live output panel also showed `NEW_PR_SCREEN_OK` and token usage.

Local screenshots captured during the smoke:

```text
output/playwright/screenshots/new-pr-agent-visible-active.png
output/playwright/screenshots/new-pr-agent-response-visible.png
```

## Validation

After rebasing on the merged #207 mainline:

- `go test ./internal/team -run 'TestPostHeadlessFinalMessageIfSilentPostsFinalOutput|TestDeliverDMMessageQueuesCodexHeadlessTurn|TestNotificationTargetsForDMChannelCodexRuntimeUsesHeadlessTarget|TestWakeLeadAfterSpecialistFallsBackToCompletedTaskUpdateWhenNoBroadcast|TestBrokerCanonicalizesLegacyDMSlugs' -count=1`
- `go test ./internal/company -run TestMaterializeManifestBuildsRuntimeOfficeFromBlueprintRefs -count=1`
- `go test ./internal/teammcp -count=1`
- `npm test -- src/components/messages/TypingIndicator.test.tsx src/components/messages/StreamLineView.test.tsx src/stores/app.test.ts`
- `npm run typecheck`
- `npm run build`
- `git diff --check origin/main..HEAD`
