### PR TITLE
feat(ui): thread panel parity with TUI — open, collapse, quote-reply

### DIFF
--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -15,10 +15,25 @@ interface MessageBubbleProps {
   grouped?: boolean
   /** Direct reply to a top-level channel message — renders indented under the parent. */
   isReply?: boolean
-  onThreadClick?: (id: string) => void
+  /** Count of direct replies to this message. Shows an "N replies" affordance. */
+  replyCount?: number
+  /** Open the thread panel for this message. Shown as a hover action when provided. */
+  onOpenThread?: (id: string) => void
+  /** Reply-to-this-reply inside the thread panel. Shown as a hover action when provided. */
+  onQuoteReply?: (message: Message) => void
+  /** Copy a permalink to this message. Shown as a hover action when provided. */
+  onCopyLink?: (id: string) => void
 }
 
-export function MessageBubble({ message, grouped = false, isReply = false, onThreadClick }: MessageBubbleProps) {
+export function MessageBubble({
+  message,
+  grouped = false,
+  isReply = false,
+  replyCount = 0,
+  onOpenThread,
+  onQuoteReply,
+  onCopyLink,
+}: MessageBubbleProps) {
   const currentChannel = useAppStore((s) => s.currentChannel)
   const { data: members = [] } = useOfficeMembers()
   const isHuman = message.from === 'you' || message.from === 'human'
@@ -88,7 +103,7 @@ export function MessageBubble({ message, grouped = false, isReply = false, onThr
           ) : agent?.role ? (
             <span className="badge badge-green">{agent.role}</span>
           ) : null}
-          <span className="message-time">{formatTime(message.timestamp)}</span>
+          <span className="message-time" title={message.timestamp}>{formatTime(message.timestamp)}</span>
           {usageTotal > 0 && (
             <span className="message-token-badge">{formatTokens(usageTotal)} tok</span>
           )}
@@ -124,19 +139,66 @@ export function MessageBubble({ message, grouped = false, isReply = false, onThr
           </div>
         )}
 
-        {/* Thread link */}
-        {(message.thread_count ?? 0) > 0 && onThreadClick && (
+        {/* Thread summary — shown under a parent that has replies. Clicking
+            opens the thread panel where the full chain is browsable. */}
+        {replyCount > 0 && onOpenThread && (
           <button
             className="inline-thread-toggle"
-            onClick={() => onThreadClick(message.id)}
+            onClick={() => onOpenThread(message.id)}
+            title="Open thread"
           >
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="m9 18 6-6-6-6" />
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
             </svg>
-            {message.thread_count} {message.thread_count === 1 ? 'reply' : 'replies'}
+            {replyCount} {replyCount === 1 ? 'reply' : 'replies'}
           </button>
         )}
       </div>
+
+      {/* Hover actions — reply in thread, quote, copy link. Absolutely
+          positioned so they don't change the bubble's flow layout. */}
+      {(onOpenThread || onQuoteReply || onCopyLink) && (
+        <div className="message-hover-actions" role="toolbar" aria-label="Message actions">
+          {onOpenThread && (
+            <button
+              className="message-hover-btn"
+              onClick={() => onOpenThread(message.id)}
+              title="Reply in thread"
+              aria-label="Reply in thread"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+              </svg>
+            </button>
+          )}
+          {onQuoteReply && (
+            <button
+              className="message-hover-btn"
+              onClick={() => onQuoteReply(message)}
+              title="Quote-reply"
+              aria-label="Quote-reply"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 21v-5a5 5 0 0 1 5-5h13" />
+                <path d="m16 16-5-5 5-5" />
+              </svg>
+            </button>
+          )}
+          {onCopyLink && (
+            <button
+              className="message-hover-btn"
+              onClick={() => onCopyLink(message.id)}
+              title="Copy link"
+              aria-label="Copy link"
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.71" />
+              </svg>
+            </button>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/components/messages/MessageFeed.tsx
+++ b/web/src/components/messages/MessageFeed.tsx
@@ -27,8 +27,16 @@ type FeedElement =
 export function MessageFeed() {
   const currentChannel = useAppStore((s) => s.currentChannel)
   const setActiveThreadId = useAppStore((s) => s.setActiveThreadId)
+  const collapsedThreads = useAppStore((s) => s.collapsedThreads)
+  const toggleThreadCollapsed = useAppStore((s) => s.toggleThreadCollapsed)
   const containerRef = useRef<HTMLDivElement>(null)
   const prevLengthRef = useRef(0)
+
+  const copyMessageLink = (id: string) => {
+    const url = new URL(window.location.href)
+    url.hash = `#msg-${id}`
+    navigator.clipboard?.writeText(url.toString()).catch(() => {})
+  }
 
   const { data: messages = [], isLoading } = useMessages(currentChannel)
 
@@ -149,25 +157,56 @@ export function MessageFeed() {
           )
         }
         const hasReplies = el.replies.length > 0
+        const parentId = el.parent.message.id
+        const isCollapsed = hasReplies && (collapsedThreads[parentId] ?? false)
         return (
           <div
             key={el.key}
-            className={`thread-group${hasReplies ? ' thread-group-has-replies' : ''}`}
+            className={`thread-group${hasReplies ? ' thread-group-has-replies' : ''}${isCollapsed ? ' thread-group-collapsed' : ''}`}
           >
             <MessageBubble
               message={el.parent.message}
               grouped={el.parent.grouped}
-              onThreadClick={(id) => setActiveThreadId(id)}
+              replyCount={el.replies.length}
+              onOpenThread={(id) => setActiveThreadId(id)}
+              onCopyLink={copyMessageLink}
             />
             {hasReplies && (
-              <div className="thread-replies">
+              <button
+                type="button"
+                className="thread-collapse-toggle"
+                onClick={() => toggleThreadCollapsed(parentId)}
+                aria-expanded={!isCollapsed}
+                aria-controls={`thread-${parentId}-replies`}
+              >
+                <svg
+                  className="thread-collapse-chevron"
+                  width="10"
+                  height="10"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d={isCollapsed ? 'm9 18 6-6-6-6' : 'm6 9 6 6 6-6'} />
+                </svg>
+                {isCollapsed
+                  ? `Show ${el.replies.length} ${el.replies.length === 1 ? 'reply' : 'replies'}`
+                  : 'Hide thread'}
+              </button>
+            )}
+            {hasReplies && !isCollapsed && (
+              <div className="thread-replies" id={`thread-${parentId}-replies`}>
                 {el.replies.map((r) => (
                   <MessageBubble
                     key={r.message.id}
                     message={r.message}
                     grouped={r.grouped}
                     isReply
-                    onThreadClick={(id) => setActiveThreadId(id)}
+                    onOpenThread={(id) => setActiveThreadId(id)}
+                    onCopyLink={copyMessageLink}
                   />
                 ))}
               </div>

--- a/web/src/components/messages/ThreadPanel.tsx
+++ b/web/src/components/messages/ThreadPanel.tsx
@@ -1,8 +1,9 @@
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, useMemo } from 'react'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { useThreadMessages } from '../../hooks/useMessages'
 import { useAppStore } from '../../stores/app'
 import { postMessage } from '../../api/client'
+import type { Message } from '../../api/client'
 import { showNotice } from '../ui/Toast'
 import { MessageBubble } from './MessageBubble'
 
@@ -11,23 +12,76 @@ export function ThreadPanel() {
   const setActiveThreadId = useAppStore((s) => s.setActiveThreadId)
   const currentChannel = useAppStore((s) => s.currentChannel)
   const [text, setText] = useState('')
+  const [quoting, setQuoting] = useState<Message | null>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const messagesRef = useRef<HTMLDivElement>(null)
   const queryClient = useQueryClient()
 
-  const { data: replies = [] } = useThreadMessages(currentChannel, activeThreadId)
+  const { data: messages = [] } = useThreadMessages(currentChannel, activeThreadId)
 
-  // Auto-scroll
+  // Split the thread query response into parent + replies so we can render
+  // the parent prominently at the top (like Slack's thread pane). The broker
+  // returns both in the same list because thread_id matches either id or
+  // reply_to.
+  const { parent, replies } = useMemo(() => {
+    let parent: Message | null = null
+    const replies: Message[] = []
+    for (const m of messages) {
+      if (m.id === activeThreadId) parent = m
+      else if (m.reply_to) replies.push(m)
+    }
+    return { parent, replies }
+  }, [messages, activeThreadId])
+
+  // Auto-scroll to the bottom when a new reply arrives. Anchoring at the
+  // bottom means the composer is always in context and new agent replies
+  // land where your eye already is.
   useEffect(() => {
     if (messagesRef.current) {
       messagesRef.current.scrollTop = messagesRef.current.scrollHeight
     }
   }, [replies.length])
 
+  // Reset the quote chip when the panel closes OR when the user switches
+  // to a different thread. Persisting the quote would mean a stale reply_to
+  // fires against the wrong thread on the next send.
+  useEffect(() => {
+    setQuoting(null)
+    setText('')
+  }, [activeThreadId])
+
+  // Focus the composer on open so users can start typing immediately.
+  useEffect(() => {
+    if (activeThreadId && textareaRef.current) {
+      textareaRef.current.focus()
+    }
+  }, [activeThreadId])
+
+  // Escape closes the panel — matches the close button affordance.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && activeThreadId) {
+        setActiveThreadId(null)
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [activeThreadId, setActiveThreadId])
+
+  // The thread target is the quoted reply if the user clicked "quote" on a
+  // specific reply; otherwise it's the parent. Broker thread semantics
+  // don't distinguish depth — any reply with reply_to in the chain shows up
+  // under this thread_id — so quoting-a-reply just tags the new message
+  // against that reply's id for display, while still appearing in the same
+  // thread panel.
+  const replyTarget = quoting?.id ?? activeThreadId ?? undefined
+
   const sendReply = useMutation({
-    mutationFn: (content: string) => postMessage(content, currentChannel, activeThreadId ?? undefined),
+    mutationFn: (content: string) =>
+      postMessage(content, currentChannel, replyTarget),
     onSuccess: () => {
       setText('')
+      setQuoting(null)
       queryClient.invalidateQueries({ queryKey: ['thread-messages', currentChannel, activeThreadId] })
       queryClient.invalidateQueries({ queryKey: ['messages', currentChannel] })
     },
@@ -46,13 +100,17 @@ export function ThreadPanel() {
   if (!activeThreadId) return null
 
   return (
-    <div className="thread-panel open">
+    <div className="thread-panel open" role="complementary" aria-label="Thread">
       <div className="thread-panel-header">
-        <span className="thread-panel-title">Thread</span>
+        <div className="thread-panel-title-group">
+          <span className="thread-panel-title">Thread</span>
+          <span className="thread-panel-channel">#{currentChannel}</span>
+        </div>
         <button
           className="thread-panel-close"
           onClick={() => setActiveThreadId(null)}
           aria-label="Close thread"
+          title="Close (Esc)"
         >
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
             <path d="M18 6 6 18" />
@@ -61,31 +119,80 @@ export function ThreadPanel() {
         </button>
       </div>
 
-      <div ref={messagesRef} style={{ flex: 1, overflowY: 'auto', padding: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div ref={messagesRef} className="thread-panel-body">
+        {parent && (
+          <div className="thread-panel-parent">
+            <MessageBubble message={parent} />
+          </div>
+        )}
+        {replies.length > 0 && (
+          <div className="thread-panel-replies-count">
+            {replies.length} {replies.length === 1 ? 'reply' : 'replies'}
+          </div>
+        )}
         {replies.length === 0 ? (
-          <div style={{ color: 'var(--text-tertiary)', fontSize: 13, textAlign: 'center', padding: 20 }}>
-            No replies yet
+          <div className="thread-panel-empty">
+            No replies yet. Start the conversation below.
           </div>
         ) : (
           replies.map((msg) => (
-            <MessageBubble key={msg.id} message={msg} />
+            <MessageBubble
+              key={msg.id}
+              message={msg}
+              onQuoteReply={(m) => {
+                setQuoting(m)
+                textareaRef.current?.focus()
+              }}
+            />
           ))
         )}
       </div>
 
-      {/* Thread composer */}
+      {/* Composer. If the user clicked "quote" on a reply, show a small
+          chip above the input that names who they're replying to and
+          offers a dismiss. This mirrors Slack's "Replying to …" affordance
+          and makes the active reply_to target visible. */}
       <div className="composer">
+        {quoting && (
+          <div className="thread-quote-chip">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M3 21v-5a5 5 0 0 1 5-5h13" />
+              <path d="m16 16-5-5 5-5" />
+            </svg>
+            <span className="thread-quote-label">
+              Replying to <strong>@{quoting.from}</strong>
+            </span>
+            <span className="thread-quote-preview">
+              {truncate(quoting.content, 60)}
+            </span>
+            <button
+              className="thread-quote-dismiss"
+              onClick={() => setQuoting(null)}
+              aria-label="Cancel quote"
+              title="Cancel quote"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M18 6 6 18" />
+                <path d="m6 6 12 12" />
+              </svg>
+            </button>
+          </div>
+        )}
         <div className="composer-inner">
           <textarea
             ref={textareaRef}
             className="composer-input"
-            placeholder="Reply..."
+            placeholder={quoting ? `Reply to @${quoting.from}…` : 'Reply to thread…'}
             value={text}
             onChange={(e) => setText(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter' && !e.shiftKey) {
                 e.preventDefault()
                 handleSend()
+              }
+              if (e.key === 'Escape' && quoting) {
+                e.preventDefault()
+                setQuoting(null)
               }
             }}
             rows={1}
@@ -105,4 +212,9 @@ export function ThreadPanel() {
       </div>
     </div>
   )
+}
+
+function truncate(s: string, n: number): string {
+  const oneLine = s.replace(/\s+/g, ' ').trim()
+  return oneLine.length > n ? oneLine.slice(0, n - 1) + '…' : oneLine
 }

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -59,6 +59,12 @@ export interface AppStore {
   activeThreadId: string | null
   setActiveThreadId: (id: string | null) => void
 
+  // Per-thread collapsed state in the main feed. The key is the parent
+  // message id. Default is expanded (entry absent or false); toggling
+  // stores `true` so the inline replies hide.
+  collapsedThreads: Record<string, boolean>
+  toggleThreadCollapsed: (parentId: string) => void
+
   // DM entry: opens the given DM channel and records {type: 'D', agentSlug}
   // in channelMeta so downstream views can resolve the paired agent.
   enterDM: (agentSlug: string, channelSlug: string) => void
@@ -128,6 +134,15 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   activeThreadId: null,
   setActiveThreadId: (id) => set({ activeThreadId: id }),
+
+  collapsedThreads: {},
+  toggleThreadCollapsed: (parentId) =>
+    set((s) => ({
+      collapsedThreads: {
+        ...s.collapsedThreads,
+        [parentId]: !s.collapsedThreads[parentId],
+      },
+    })),
 
   enterDM: (agentSlug, channelSlug) =>
     set((s) => ({

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -736,9 +736,22 @@ html[data-theme="nex"] .sidebar.sidebar-collapsed .sidebar-rail-bottom.active:ho
 .thread-panel { width: 380px; flex-shrink: 0; background: var(--bg-card); border-left: 1px solid var(--border); display: none; flex-direction: column; height: 100vh; overflow: hidden; }
 .thread-panel.open { display: flex; }
 .thread-panel-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; border-bottom: 1px solid var(--border); }
+.thread-panel-title-group { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
 .thread-panel-title { font-size: 15px; font-weight: 700; }
+.thread-panel-channel { font-size: 11px; color: var(--text-tertiary); font-family: var(--font-mono); }
 .thread-panel-close { width: 28px; height: 28px; border: none; background: transparent; cursor: pointer; display: flex; align-items: center; justify-content: center; border-radius: 6px; color: var(--text-secondary); }
 .thread-panel-close:hover { background: var(--bg); }
+.thread-panel-body { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+.thread-panel-parent { padding-bottom: 12px; border-bottom: 1px solid var(--border-light); margin-bottom: 4px; }
+.thread-panel-replies-count { font-size: 11px; font-weight: 600; color: var(--text-tertiary); text-transform: uppercase; letter-spacing: 0.04em; margin: 0 0 4px; padding: 0 4px; }
+.thread-panel-empty { color: var(--text-tertiary); font-size: 13px; text-align: center; padding: 20px 12px; background: var(--bg-warm); border-radius: var(--radius-md); border: 1px dashed var(--border); }
+.thread-quote-chip { display: flex; align-items: center; gap: 8px; padding: 6px 10px; margin: 0 16px 6px; background: var(--bg-warm); border: 1px solid var(--border); border-radius: var(--radius-md); font-size: 12px; color: var(--text-secondary); }
+.thread-quote-chip > svg { color: var(--accent); flex-shrink: 0; }
+.thread-quote-label { white-space: nowrap; }
+.thread-quote-label strong { color: var(--text); font-weight: 600; }
+.thread-quote-preview { color: var(--text-tertiary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; min-width: 0; font-style: italic; }
+.thread-quote-dismiss { border: none; background: transparent; cursor: pointer; display: flex; align-items: center; justify-content: center; padding: 2px; border-radius: 4px; color: var(--text-tertiary); flex-shrink: 0; }
+.thread-quote-dismiss:hover { background: var(--bg); color: var(--text); }
 
 /* ─── DM Banner ─── */
 .dm-banner { display: none; align-items: center; justify-content: space-between; min-height: var(--top-panel-h); padding: 0 20px; background: var(--accent-bg); border-bottom: 1px solid var(--border); font-size: 13px; font-weight: 600; }

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -311,3 +311,68 @@ html[data-theme] .interview-bar-actions .btn-primary:hover { background: var(--t
 /* ─── Thread toggle ─── */
 .inline-thread-toggle { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--accent); cursor: pointer; border: 1px solid var(--border); background: var(--bg); font-family: var(--font-sans); padding: 4px 8px; border-radius: 999px; margin-top: 4px; transition: background 0.15s; }
 .inline-thread-toggle:hover { background: var(--accent-bg); }
+
+/* ─── Hover actions toolbar on every message bubble ───
+   Appears on hover at the top-right of the message. Slack-style affordance
+   for thread/quote/link actions. Positioned absolutely so it doesn't
+   reflow the message layout. */
+.message { position: relative; }
+.message-hover-actions {
+  position: absolute;
+  top: -12px;
+  right: 16px;
+  display: none;
+  gap: 2px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 2px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+  z-index: 2;
+}
+.message:hover > .message-hover-actions,
+.message:focus-within > .message-hover-actions { display: inline-flex; }
+.message-hover-btn {
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background 0.12s, color 0.12s;
+}
+.message-hover-btn:hover { background: var(--bg-warm); color: var(--text); }
+.message-hover-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+/* ─── Thread collapse/expand toggle ───
+   Renders between the parent and the reply stack. Behaves like a
+   disclosure triangle — chevron rotates to indicate state, the whole
+   button is clickable and keyboard-accessible. */
+.thread-collapse-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 2px 0 2px 44px;
+  padding: 3px 10px 3px 8px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  align-self: flex-start;
+}
+.thread-collapse-toggle:hover {
+  background: var(--bg-warm);
+  border-color: var(--border);
+  color: var(--text);
+}
+.thread-collapse-toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.thread-collapse-chevron { transition: transform 0.15s ease; }
+.thread-group-collapsed .thread-collapse-toggle { color: var(--accent); }


### PR DESCRIPTION
The TUI has supported opening a thread, collapsing reply chains, and quote-replying for a while. The web UI was missing all three. This PR lands them, plus a handful of adjacent polishes the main feed was missing.

## What's new

### 1. Open a thread from any message (Slack-style)
- Hover toolbar on every `MessageBubble` — reply-in-thread, quote-reply, copy link
- Top-right absolute positioning so nothing reflows
- Appears on `:hover` AND `:focus-within` (keyboard parity)
- Parent messages with replies also get an inline "N replies" pill under the bubble

### 2. Collapse / expand inline threads
- "Hide thread" / "Show N replies" toggle between parent and replies
- Chevron rotates (down = expanded, right = collapsed)
- State lives in Zustand keyed by parent id — preserved across channel switches
- `aria-expanded` + `aria-controls` for screen readers

### 3. Quote-reply inside the thread panel
- Rewrote `ThreadPanel`: parent prominent at top → divider → "N REPLIES" eyebrow → replies → composer
- Hover a reply inside the panel, click the quote icon, composer's `reply_to` pins to that reply
- Visible "Replying to @slug <preview>" chip above the input, dismissable via X or Escape
- Placeholder reflects target ("Reply to @ceo…" vs "Reply to thread…")
- Composer auto-focuses on open; Escape closes the panel
- "Thread" header gets a channel eyebrow (`#general`) so users know where they're threading

## Backend semantics

No broker changes. Quote-replies use normal reply semantics — the new message's `reply_to` points at the quoted reply's id. The existing `/messages?thread_id=X` endpoint returns parent + everything whose `reply_to` matches, so ordinary replies and quote-replies both appear in the same thread panel.

Reply-count is computed client-side from the messages list; no `thread_count` field needed on the wire (it was defined on the TS type but never populated by the broker).

## Test plan

- [x] `go build ./...` + `npx tsc --noEmit` clean
- [x] Live browser (localhost:7900) with 18 messages in broker:
  - Click "N replies" pill → panel opens with parent + replies + focused composer
  - Click "Hide thread" → replies collapse, label becomes "Show N replies"
  - Hover a reply in thread panel → quote icon appears; click → chip pins, placeholder updates, Escape dismisses chip
  - Hover any top-level message → reply-in-thread + copy-link buttons appear top-right
  - Channel eyebrow shows `#general` under "Thread" header

Screenshots walk-through: `/tmp/wuphf-21-initial.png` through `/tmp/wuphf-26-hover-actions.png`.