### PR TITLE
fix(ui): quote-reply on inline thread replies opens thread panel pre-quoted

### DIFF
--- a/web/src/components/messages/MessageFeed.tsx
+++ b/web/src/components/messages/MessageFeed.tsx
@@ -27,10 +27,19 @@ type FeedElement =
 export function MessageFeed() {
   const currentChannel = useAppStore((s) => s.currentChannel)
   const setActiveThreadId = useAppStore((s) => s.setActiveThreadId)
+  const setPendingQuoteId = useAppStore((s) => s.setPendingQuoteId)
   const collapsedThreads = useAppStore((s) => s.collapsedThreads)
   const toggleThreadCollapsed = useAppStore((s) => s.toggleThreadCollapsed)
   const containerRef = useRef<HTMLDivElement>(null)
   const prevLengthRef = useRef(0)
+
+  // Quoting an inline reply pops the thread panel open on the reply's parent
+  // and tells the panel which message to pre-quote. The panel reads
+  // pendingQuoteId from the store and seeds its local `quoting` state.
+  const openThreadWithQuote = (parentId: string, quoteId: string) => {
+    setPendingQuoteId(quoteId)
+    setActiveThreadId(parentId)
+  }
 
   const copyMessageLink = (id: string) => {
     const url = new URL(window.location.href)
@@ -206,6 +215,7 @@ export function MessageFeed() {
                     grouped={r.grouped}
                     isReply
                     onOpenThread={(id) => setActiveThreadId(id)}
+                    onQuoteReply={(m) => openThreadWithQuote(parentId, m.id)}
                     onCopyLink={copyMessageLink}
                   />
                 ))}

--- a/web/src/components/messages/ThreadPanel.tsx
+++ b/web/src/components/messages/ThreadPanel.tsx
@@ -10,6 +10,8 @@ import { MessageBubble } from './MessageBubble'
 export function ThreadPanel() {
   const activeThreadId = useAppStore((s) => s.activeThreadId)
   const setActiveThreadId = useAppStore((s) => s.setActiveThreadId)
+  const pendingQuoteId = useAppStore((s) => s.pendingQuoteId)
+  const setPendingQuoteId = useAppStore((s) => s.setPendingQuoteId)
   const currentChannel = useAppStore((s) => s.currentChannel)
   const [text, setText] = useState('')
   const [quoting, setQuoting] = useState<Message | null>(null)
@@ -49,6 +51,18 @@ export function ThreadPanel() {
     setQuoting(null)
     setText('')
   }, [activeThreadId])
+
+  // Consume a pending quote set by the main feed (user clicked "quote-reply"
+  // on an inline reply). Waits until replies are loaded so we can hand
+  // setQuoting a real Message, not just an id.
+  useEffect(() => {
+    if (!pendingQuoteId) return
+    const target = replies.find((r) => r.id === pendingQuoteId)
+    if (!target) return
+    setQuoting(target)
+    setPendingQuoteId(null)
+    textareaRef.current?.focus()
+  }, [pendingQuoteId, replies, setPendingQuoteId])
 
   // Focus the composer on open so users can start typing immediately.
   useEffect(() => {

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -80,6 +80,13 @@ export interface AppStore {
   activeThreadId: string | null
   setActiveThreadId: (id: string | null) => void
 
+  // Pending quote. When a user clicks "quote-reply" on an inline reply in the
+  // main feed, we open the thread panel AND ask it to pre-populate its quote
+  // state with this message id. The thread panel consumes + clears it once
+  // the quoted message shows up in its replies list.
+  pendingQuoteId: string | null
+  setPendingQuoteId: (id: string | null) => void
+
   // Per-thread collapsed state in the main feed. The key is the parent
   // message id. Default is expanded (entry absent or false); toggling
   // stores `true` so the inline replies hide.
@@ -155,6 +162,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   activeThreadId: null,
   setActiveThreadId: (id) => set({ activeThreadId: id }),
+
+  pendingQuoteId: null,
+  setPendingQuoteId: (id) => set({ pendingQuoteId: id }),
 
   collapsedThreads: {},
   toggleThreadCollapsed: (parentId) =>


### PR DESCRIPTION
## Summary

PR #209 landed quote-reply *inside* the thread panel but missed the sibling case: **inline thread replies in the main channel feed** had hover actions for Reply-in-thread and Copy-link only, with no quote affordance. You saw a reply under a parent, hovered it, and had no way to quote it.

This wires a third `[Quote-reply]` button into the inline-reply hover toolbar. Clicking it:

1. Stores the reply id in a new `pendingQuoteId` slot on the app store.
2. Opens the thread panel on the reply's parent.
3. The panel's new `useEffect` consumes `pendingQuoteId` once its `replies` array contains the target — seeds its local `quoting` state, focuses the composer, clears the pending marker.

No broker changes, no API changes, no store schema break. The parent hover toolbar intentionally keeps Reply-in-thread only — quoting the parent is the default behavior inside the panel, so adding a button for it would be redundant.

## Files

| File | Change |
|---|---|
| `web/src/stores/app.ts` | `pendingQuoteId` + setter |
| `web/src/components/messages/MessageFeed.tsx` | `openThreadWithQuote(parentId, quoteId)` helper, passed as `onQuoteReply` on reply bubbles |
| `web/src/components/messages/ThreadPanel.tsx` | consume `pendingQuoteId` in a second effect, don't let the `activeThreadId` effect clobber it |

## Test plan

Verified in the dev build (`wuphf-dev` on :7900):

- [x] Hover an inline thread reply → toolbar shows `[Reply in thread] [Quote-reply] [Copy link]`
- [x] Click Quote-reply → thread panel opens, chip reads "Replying to @ceo We're alive…", composer placeholder = "Reply to @ceo…"
- [x] Click Reply-in-thread on the same reply → panel opens with NO quote chip, placeholder = "Reply to thread…"
- [x] Quote-reply inside the thread panel (from PR #209) still works
- [x] `tsc -b` clean, `vite build` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved quote reply interactions: Selecting "quote reply" on a message now automatically opens the parent thread and pre-selects the quoted message in the composer for streamlined conversation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->