### PR TITLE
feat(web): composer parity with TUI — /ask /search /remember /help + history + mention scoping

### DIFF
--- a/web/src/api/notebook.ts
+++ b/web/src/api/notebook.ts
@@ -110,6 +110,40 @@ export interface NotebookEvent {
   timestamp?: string
 }
 
+/**
+ * One hit from `/notebook/search`. The broker reuses the wiki hit shape,
+ * and we tag it with the agent slug the caller searched so the UI can
+ * render `<agent> · <entry>` without re-parsing the path.
+ */
+export interface NotebookSearchHit {
+  path: string
+  line: number
+  snippet: string
+  agent_slug: string
+}
+
+/**
+ * GET /notebook/search?slug=&q=... — literal substring search inside one
+ * agent's notebook. Returns [] on any error so the SearchModal can fall
+ * back to empty state without breaking.
+ */
+export async function searchNotebook(
+  agentSlug: string,
+  pattern: string,
+): Promise<NotebookSearchHit[]> {
+  const trimmed = pattern.trim()
+  if (!trimmed || !agentSlug) return []
+  try {
+    const res = await get<{ hits: Array<{ path: string; line: number; snippet: string }> }>(
+      `/notebook/search?slug=${encodeURIComponent(agentSlug)}&q=${encodeURIComponent(trimmed)}`,
+    )
+    const hits = Array.isArray(res?.hits) ? res.hits : []
+    return hits.map((h) => ({ ...h, agent_slug: agentSlug }))
+  } catch {
+    return []
+  }
+}
+
 // ── Env toggle ───────────────────────────────────────────────────
 
 function useMocks(): boolean {

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -250,6 +250,34 @@ export async function fetchCatalog(): Promise<WikiCatalogEntry[]> {
   }
 }
 
+/**
+ * One hit from `/wiki/search` — mirrors Go's `team.WikiSearchHit`.
+ * The broker returns literal substring hits (no regex), capped at 100.
+ */
+export interface WikiSearchHit {
+  path: string
+  line: number
+  snippet: string
+}
+
+/**
+ * GET /wiki/search?pattern=... — literal substring search across team/**.md.
+ * Returns [] on any error so the SearchModal can render empty state without
+ * blowing up.
+ */
+export async function searchWiki(pattern: string): Promise<WikiSearchHit[]> {
+  const trimmed = pattern.trim()
+  if (!trimmed) return []
+  try {
+    const res = await get<{ hits: WikiSearchHit[] }>(
+      `/wiki/search?pattern=${encodeURIComponent(trimmed)}`,
+    )
+    return Array.isArray(res?.hits) ? res.hits : []
+  } catch {
+    return []
+  }
+}
+
 export interface WikiAuditEntry {
   sha: string
   author_slug: string

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -7,6 +7,7 @@ import { RuntimeStrip } from './RuntimeStrip'
 import { ThreadPanel } from '../messages/ThreadPanel'
 import { AgentPanel } from '../agents/AgentPanel'
 import { SearchModal } from '../search/SearchModal'
+import { HelpModalHost } from '../ui/HelpModal'
 import { useAppStore, isDMChannel } from '../../stores/app'
 
 interface ShellProps {
@@ -32,6 +33,7 @@ export function Shell({ children }: ShellProps) {
       <ThreadPanel />
       <AgentPanel />
       <SearchModal />
+      <HelpModalHost />
     </div>
   )
 }

--- a/web/src/components/messages/Autocomplete.test.tsx
+++ b/web/src/components/messages/Autocomplete.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { currentTrigger, applyAutocomplete } from './Autocomplete'
+
+describe('currentTrigger', () => {
+  describe('mention scoping — TUI parity with internal/tui/mention.go', () => {
+    it('triggers on @ at start of input', () => {
+      const t = currentTrigger('@ce', 3)
+      expect(t).toEqual({ kind: 'mention', query: 'ce', start: 0 })
+    })
+
+    it('triggers on @ after a space', () => {
+      const t = currentTrigger('hi @ce', 6)
+      expect(t).toEqual({ kind: 'mention', query: 'ce', start: 3 })
+    })
+
+    it('triggers on @ after a newline', () => {
+      const t = currentTrigger('hi\n@ce', 6)
+      expect(t).toEqual({ kind: 'mention', query: 'ce', start: 3 })
+    })
+
+    it('does NOT trigger on @ preceded by non-whitespace (foo@bar email)', () => {
+      const t = currentTrigger('foo@bar', 7)
+      expect(t).toBeNull()
+    })
+
+    it('does NOT trigger on @ surrounded by letters', () => {
+      const t = currentTrigger('hi.foo@example.com', 18)
+      expect(t).toBeNull()
+    })
+
+    it('does not trigger when a space sits between @ and the caret', () => {
+      const t = currentTrigger('@ce and more', 12)
+      expect(t).toBeNull()
+    })
+  })
+
+  describe('slash scoping', () => {
+    it('triggers only when value starts with /', () => {
+      expect(currentTrigger('/cl', 3)).toEqual({ kind: 'slash', query: 'cl', start: 0 })
+    })
+
+    it('does not trigger for leading whitespace before /', () => {
+      expect(currentTrigger(' /cl', 4)).toBeNull()
+    })
+
+    it('does not trigger once the slash token has a space', () => {
+      expect(currentTrigger('/ask hi', 7)).toBeNull()
+    })
+  })
+})
+
+describe('applyAutocomplete', () => {
+  it('replaces an @mention prefix with the full slug', () => {
+    const result = applyAutocomplete('hi @ce', 6, {
+      insert: '@ceo',
+      label: '@ceo',
+    })
+    expect(result.text).toBe('hi @ceo ')
+    expect(result.caret).toBe(8)
+  })
+
+  it('replaces a slash prefix with the full command', () => {
+    const result = applyAutocomplete('/as', 3, {
+      insert: '/ask',
+      label: '/ask',
+    })
+    expect(result.text).toBe('/ask ')
+    expect(result.caret).toBe(5)
+  })
+})

--- a/web/src/components/messages/Autocomplete.tsx
+++ b/web/src/components/messages/Autocomplete.tsx
@@ -19,10 +19,12 @@ export interface SlashCommand {
 }
 
 export const SLASH_COMMANDS: SlashCommand[] = [
+  { name: '/ask', desc: 'Ask the team lead', icon: '\uD83D\uDCAC' },
+  { name: '/search', desc: 'Search messages + KB', icon: '\uD83D\uDD0E' },
+  { name: '/remember', desc: 'Store a fact in memory', icon: '\uD83E\uDDE0' },
+  { name: '/help', desc: 'Show all commands + keys', icon: '\u2753' },
   { name: '/clear', desc: 'Clear messages', icon: '\uD83E\uDDF9' },
-  { name: '/help', desc: 'Show all commands', icon: '\u2753' },
   { name: '/reset', desc: 'Reset the office', icon: '\uD83D\uDD04' },
-  { name: '/search', desc: 'Search messages', icon: '\uD83D\uDD0E' },
   { name: '/tasks', desc: 'Open task board', icon: '\uD83D\uDCCB' },
   { name: '/requests', desc: 'Open requests', icon: '\uD83D\uDD14' },
   { name: '/recover', desc: 'Health Check view', icon: '\uD83D\uDD01' },

--- a/web/src/components/messages/Composer.test.tsx
+++ b/web/src/components/messages/Composer.test.tsx
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { __test__ } from './Composer'
+
+const { historyKey, readHistory, pushHistory, resolveLeadSlug, askPrefix, COMPOSER_HISTORY_LIMIT } =
+  __test__
+
+beforeEach(() => {
+  sessionStorage.clear()
+  vi.restoreAllMocks()
+})
+
+describe('per-channel composer history', () => {
+  it('stores one message and recalls it', () => {
+    pushHistory('general', 'hello world')
+    expect(readHistory('general')).toEqual(['hello world'])
+  })
+
+  it('keeps channels isolated', () => {
+    pushHistory('general', 'in-general')
+    pushHistory('eng', 'in-eng')
+    expect(readHistory('general')).toEqual(['in-general'])
+    expect(readHistory('eng')).toEqual(['in-eng'])
+  })
+
+  it('caps history at COMPOSER_HISTORY_LIMIT entries', () => {
+    for (let i = 0; i < COMPOSER_HISTORY_LIMIT + 5; i++) {
+      pushHistory('general', `m${i}`)
+    }
+    const hist = readHistory('general')
+    expect(hist.length).toBe(COMPOSER_HISTORY_LIMIT)
+    // Should be the TAIL of the input, so most recent is last.
+    expect(hist[hist.length - 1]).toBe(`m${COMPOSER_HISTORY_LIMIT + 4}`)
+  })
+
+  it('skips consecutive duplicates', () => {
+    pushHistory('general', 'hi')
+    pushHistory('general', 'hi')
+    pushHistory('general', 'hi')
+    expect(readHistory('general')).toEqual(['hi'])
+  })
+
+  it('ignores empty pushes', () => {
+    pushHistory('general', '   ')
+    pushHistory('general', '')
+    expect(readHistory('general')).toEqual([])
+  })
+
+  it('uses a stable key shape', () => {
+    expect(historyKey('eng')).toBe('wuphf:composer-history:eng')
+    expect(historyKey('')).toBe('wuphf:composer-history:general')
+  })
+
+  it('handles corrupt JSON gracefully', () => {
+    sessionStorage.setItem(historyKey('general'), '{not-json')
+    expect(readHistory('general')).toEqual([])
+  })
+})
+
+describe('team-lead resolution for /ask', () => {
+  it('prefers the configured slug', () => {
+    expect(resolveLeadSlug('coo', [])).toBe('coo')
+  })
+
+  it('falls back to the first built-in agent', () => {
+    expect(
+      resolveLeadSlug('', [
+        { slug: 'pm', built_in: false },
+        { slug: 'ceo', built_in: true },
+      ]),
+    ).toBe('ceo')
+  })
+
+  it('falls back to "ceo" when nothing is known', () => {
+    expect(resolveLeadSlug(undefined, [])).toBe('ceo')
+  })
+
+  it('lowercases configured slugs', () => {
+    expect(resolveLeadSlug('CEO', [])).toBe('ceo')
+  })
+})
+
+describe('askPrefix', () => {
+  it('emits @slug with a trailing space', () => {
+    expect(askPrefix('ceo')).toBe('@ceo ')
+  })
+
+  it('defaults to @ceo', () => {
+    expect(askPrefix(undefined)).toBe('@ceo ')
+    expect(askPrefix('')).toBe('@ceo ')
+  })
+})

--- a/web/src/components/messages/Composer.tsx
+++ b/web/src/components/messages/Composer.tsx
@@ -1,17 +1,91 @@
-import { useRef, useState, useCallback } from 'react'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { createDM, postMessage, post } from '../../api/client'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { createDM, getConfig, postMessage, post, setMemory } from '../../api/client'
 import { directChannelSlug, useAppStore } from '../../stores/app'
+import { useOfficeMembers } from '../../hooks/useMembers'
 import { showNotice } from '../ui/Toast'
 import { confirm } from '../ui/ConfirmDialog'
 import { openProviderSwitcher } from '../ui/ProviderSwitcher'
 import { Autocomplete, applyAutocomplete, type AutocompleteItem } from './Autocomplete'
 
-/** Handle slash commands. Returns true if the input was a command. */
-function handleSlashCommand(input: string): boolean {
+/** How many sent messages to keep in per-channel history. */
+const COMPOSER_HISTORY_LIMIT = 20
+
+/** sessionStorage key shape: `wuphf:composer-history:<channel>`. */
+function historyKey(channel: string): string {
+  return `wuphf:composer-history:${channel || 'general'}`
+}
+
+function readHistory(channel: string): string[] {
+  try {
+    const raw = sessionStorage.getItem(historyKey(channel))
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((v): v is string => typeof v === 'string' && v.length > 0)
+  } catch {
+    return []
+  }
+}
+
+function writeHistory(channel: string, entries: string[]): void {
+  try {
+    sessionStorage.setItem(historyKey(channel), JSON.stringify(entries))
+  } catch {
+    // sessionStorage disabled / quota exceeded — silently drop history rather
+    // than blowing up the send flow. The user still sees their message land.
+  }
+}
+
+/**
+ * Append a sent message to the per-channel history, trimming to the most
+ * recent COMPOSER_HISTORY_LIMIT entries. Skips duplicates of the latest
+ * entry so rapid resends do not pollute recall.
+ */
+function pushHistory(channel: string, message: string): void {
+  const trimmed = message.trim()
+  if (!trimmed) return
+  const current = readHistory(channel)
+  if (current.length > 0 && current[current.length - 1] === trimmed) return
+  const next = [...current, trimmed].slice(-COMPOSER_HISTORY_LIMIT)
+  writeHistory(channel, next)
+}
+
+/** Routing prefix for `/ask`: mirrors TUI cmdAsk which always goes to the lead. */
+function askPrefix(leadSlug: string | undefined): string {
+  const slug = (leadSlug || 'ceo').trim().toLowerCase() || 'ceo'
+  return `@${slug} `
+}
+
+/** Pick the team-lead slug: configured first, else first built-in agent, else 'ceo'. */
+function resolveLeadSlug(
+  configured: string | undefined,
+  members: { slug?: string; built_in?: boolean }[],
+): string {
+  const explicit = (configured ?? '').trim().toLowerCase()
+  if (explicit) return explicit
+  const builtin = members.find((m) => m.built_in && m.slug && m.slug !== 'human' && m.slug !== 'you')
+  if (builtin?.slug) return builtin.slug
+  return 'ceo'
+}
+
+interface SlashHandlers {
+  /** Team lead slug used for `/ask` routing. */
+  leadSlug: string | undefined
+  /** Send the given text as a normal message (bypasses slash parsing). */
+  sendAsMessage: (text: string) => void
+}
+
+/**
+ * Handle slash commands. Returns true if the input was consumed as a command.
+ *
+ * Some commands (e.g. `/ask`) rewrite the input and invoke sendAsMessage so
+ * the broker sees a normal user message with the right @mention routing.
+ */
+function handleSlashCommand(input: string, handlers: SlashHandlers): boolean {
   const parts = input.split(/\s+/)
   const cmd = parts[0].toLowerCase()
-  const args = parts.slice(1).join(' ')
+  const args = parts.slice(1).join(' ').trim()
   const store = useAppStore.getState()
 
   switch (cmd) {
@@ -19,7 +93,7 @@ function handleSlashCommand(input: string): boolean {
       showNotice('Messages cleared', 'info')
       return true
     case '/help':
-      showNotice('Commands: /clear /help /focus /collab /requests /tasks /policies /skills /calendar /search /1o1 /task /cancel /pause /resume /reset /recover', 'info')
+      store.setComposerHelpOpen(true)
       return true
     case '/requests':
       store.setCurrentApp('requests')
@@ -47,8 +121,38 @@ function handleSlashCommand(input: string): boolean {
       openProviderSwitcher()
       return true
     case '/search':
+      store.setComposerSearchInitialQuery(args)
       store.setSearchOpen(true)
       return true
+    case '/ask': {
+      if (!args) {
+        showNotice('Usage: /ask <question>', 'info')
+        return true
+      }
+      // TUI's cmdAsk always routes to the team lead. Mirror that by
+      // prefixing an @mention so the broker's routing picks up the lead.
+      handlers.sendAsMessage(askPrefix(handlers.leadSlug) + args)
+      return true
+    }
+    case '/remember': {
+      if (!args) {
+        showNotice('Usage: /remember <fact>', 'info')
+        return true
+      }
+      // Broker /memory requires namespace + key + value. Use a stable
+      // human-owned namespace and a short timestamp key so repeated
+      // /remember calls do not collide.
+      const key = `note-${Date.now().toString(36)}`
+      setMemory('human-notes', key, args)
+        .then(() =>
+          showNotice(
+            'Stored in memory: ' + (args.length > 40 ? args.slice(0, 40) + '…' : args),
+            'success',
+          ),
+        )
+        .catch((e: Error) => showNotice('Remember failed: ' + e.message, 'error'))
+      return true
+    }
     case '/focus':
       post('/focus-mode', { focus_mode: true })
         .then(() => showNotice('Switched to delegation mode', 'success'))
@@ -128,15 +232,53 @@ function handleSlashCommand(input: string): boolean {
   }
 }
 
+/**
+ * History recall state. `draftStash` holds whatever the operator had typed
+ * before the first Ctrl+P so we can restore it when they walk forward past
+ * the end of history.
+ */
+interface HistoryState {
+  /** -1 when live, else index into the cached history array. */
+  index: number
+  /** Draft text to restore when stepping past the end. */
+  draftStash: string | null
+  /** Snapshot taken at recall start; kept so mid-recall writes don't churn it. */
+  entries: string[]
+}
+
+function emptyHistoryState(): HistoryState {
+  return { index: -1, draftStash: null, entries: [] }
+}
+
 export function Composer() {
   const currentChannel = useAppStore((s) => s.currentChannel)
-  const setCurrentApp = useAppStore((s) => s.setCurrentApp)
   const [text, setText] = useState('')
   const [caret, setCaret] = useState(0)
   const [acItems, setAcItems] = useState<AutocompleteItem[]>([])
   const [acIdx, setAcIdx] = useState(0)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const queryClient = useQueryClient()
+  const { data: cfg } = useQuery({
+    queryKey: ['config'],
+    queryFn: getConfig,
+    staleTime: 60_000,
+  })
+  const { data: members = [] } = useOfficeMembers()
+  const leadSlug = useMemo(
+    () => resolveLeadSlug(cfg?.team_lead_slug, members),
+    [cfg?.team_lead_slug, members],
+  )
+
+  const historyRef = useRef<HistoryState>(emptyHistoryState())
+
+  // Reset recall when switching channels so Ctrl+P replays *this* channel.
+  useEffect(() => {
+    historyRef.current = emptyHistoryState()
+  }, [currentChannel])
+
+  const resetRecall = useCallback(() => {
+    historyRef.current = emptyHistoryState()
+  }, [])
 
   const pickAutocomplete = useCallback((item: AutocompleteItem) => {
     const next = applyAutocomplete(text, caret, item)
@@ -153,10 +295,6 @@ export function Composer() {
   const sendMutation = useMutation({
     mutationFn: (content: string) => postMessage(content, currentChannel),
     onSuccess: () => {
-      setText('')
-      if (textareaRef.current) {
-        textareaRef.current.style.height = 'auto'
-      }
       queryClient.invalidateQueries({ queryKey: ['messages', currentChannel] })
     },
     onError: (err: unknown) => {
@@ -173,22 +311,92 @@ export function Composer() {
     },
   })
 
+  /**
+   * Clear the composer, shrink the textarea, and cancel any pending recall.
+   * Called after every successful send or consumed command.
+   */
+  const resetComposer = useCallback(() => {
+    setText('')
+    resetRecall()
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto'
+    }
+  }, [resetRecall])
+
   const handleSend = useCallback(() => {
     const trimmed = text.trim()
     if (!trimmed || sendMutation.isPending) return
 
     // Handle slash commands
     if (trimmed.startsWith('/')) {
-      if (handleSlashCommand(trimmed)) {
-        setText('')
+      const consumed = handleSlashCommand(trimmed, {
+        leadSlug,
+        sendAsMessage: (rewritten) => {
+          sendMutation.mutate(rewritten)
+        },
+      })
+      if (consumed) {
+        // Persist the *raw* command to history so Ctrl+P replays `/ask foo`,
+        // not the rewritten `@ceo foo`. Matches user expectation.
+        pushHistory(currentChannel, trimmed)
+        resetComposer()
         return
       }
     }
 
+    pushHistory(currentChannel, trimmed)
     sendMutation.mutate(trimmed)
-  }, [text, sendMutation])
+    resetComposer()
+  }, [text, sendMutation, leadSlug, currentChannel, resetComposer])
+
+  /**
+   * Walk backward through history. On first invocation, snapshot the live
+   * draft so Ctrl+N can restore it. Returns true if recall succeeded.
+   */
+  const recallPrevious = useCallback((): boolean => {
+    const state = historyRef.current
+    if (state.index === -1) {
+      const entries = readHistory(currentChannel)
+      if (entries.length === 0) return false
+      state.entries = entries
+      state.draftStash = text
+      state.index = entries.length
+    }
+    if (state.index <= 0) return false
+    state.index -= 1
+    setText(state.entries[state.index])
+    return true
+  }, [currentChannel, text])
+
+  /**
+   * Walk forward through history. When we run off the end, restore the
+   * original draft and clear recall state.
+   */
+  const recallNext = useCallback((): boolean => {
+    const state = historyRef.current
+    if (state.index === -1) return false
+    if (state.index < state.entries.length - 1) {
+      state.index += 1
+      setText(state.entries[state.index])
+      return true
+    }
+    setText(state.draftStash ?? '')
+    historyRef.current = emptyHistoryState()
+    return true
+  }, [])
+
+  const moveCaretToEnd = useCallback(() => {
+    requestAnimationFrame(() => {
+      const el = textareaRef.current
+      if (!el) return
+      const end = el.value.length
+      el.setSelectionRange(end, end)
+      setCaret(end)
+    })
+  }, [])
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // Autocomplete navigation runs first
     if (acItems.length > 0) {
       if (e.key === 'ArrowDown') {
         e.preventDefault()
@@ -212,11 +420,46 @@ export function Composer() {
         return
       }
     }
+
+    // History recall — Ctrl+P / Ctrl+N (TUI parity: internal/tui/interaction.go:56-58)
+    if (e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (e.key === 'p' || e.key === 'P') {
+        if (recallPrevious()) {
+          e.preventDefault()
+          moveCaretToEnd()
+          return
+        }
+      }
+      if (e.key === 'n' || e.key === 'N') {
+        if (recallNext()) {
+          e.preventDefault()
+          moveCaretToEnd()
+          return
+        }
+      }
+    }
+
+    // Slack-style: empty-draft ArrowUp recalls the last message.
+    if (
+      e.key === 'ArrowUp'
+      && !e.shiftKey
+      && !e.ctrlKey
+      && !e.metaKey
+      && !e.altKey
+      && text === ''
+    ) {
+      if (recallPrevious()) {
+        e.preventDefault()
+        moveCaretToEnd()
+        return
+      }
+    }
+
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault()
       handleSend()
     }
-  }, [handleSend, acItems, acIdx, pickAutocomplete])
+  }, [handleSend, acItems, acIdx, pickAutocomplete, recallPrevious, recallNext, text, moveCaretToEnd])
 
   const handleAcItems = useCallback((items: AutocompleteItem[]) => {
     setAcItems(items)
@@ -251,7 +494,15 @@ export function Composer() {
           className="composer-input"
           placeholder={`Message #${currentChannel}`}
           value={text}
-          onChange={(e) => { setText(e.target.value); setCaret(e.target.selectionStart ?? 0); handleInput() }}
+          onChange={(e) => {
+            setText(e.target.value)
+            setCaret(e.target.selectionStart ?? 0)
+            handleInput()
+            // Any manual edit cancels history recall.
+            if (historyRef.current.index !== -1) {
+              resetRecall()
+            }
+          }}
           onKeyDown={handleKeyDown}
           onKeyUp={syncCaret}
           onClick={syncCaret}
@@ -271,4 +522,15 @@ export function Composer() {
       </div>
     </div>
   )
+}
+
+// Re-export helpers for testing.
+export const __test__ = {
+  historyKey,
+  readHistory,
+  writeHistory,
+  pushHistory,
+  resolveLeadSlug,
+  askPrefix,
+  COMPOSER_HISTORY_LIMIT,
 }

--- a/web/src/components/search/SearchModal.tsx
+++ b/web/src/components/search/SearchModal.tsx
@@ -4,13 +4,15 @@ import { useAppStore } from '../../stores/app'
 import { useChannels } from '../../hooks/useChannels'
 import { useOfficeMembers } from '../../hooks/useMembers'
 import { getMessages, post, type Message } from '../../api/client'
+import { searchWiki, type WikiSearchHit } from '../../api/wiki'
+import { searchNotebook, type NotebookSearchHit } from '../../api/notebook'
 import { showNotice } from '../ui/Toast'
 import { openProviderSwitcher } from '../ui/ProviderSwitcher'
 import { SLASH_COMMANDS } from '../messages/Autocomplete'
 
 interface PaletteItem {
   id: string
-  group: 'Channels' | 'Agents' | 'Commands' | 'Messages'
+  group: 'Channels' | 'Agents' | 'Commands' | 'Messages' | 'Wiki' | 'Notebooks'
   icon: string
   label: string
   desc?: string
@@ -31,7 +33,6 @@ function formatTime(ts: string): string {
   }
 }
 
-/** Split text into alternating plain/highlighted segments using React elements. */
 function highlightMatch(text: string, query: string): ReactNode {
   if (!query) return text
   const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -44,10 +45,23 @@ function highlightMatch(text: string, query: string): ReactNode {
   })
 }
 
-/**
- * Cmd+K command palette. Searches across channels, agents, slash commands,
- * and recent messages. Mirrors the legacy IIFE behavior.
- */
+function prettyWikiPath(path: string): string {
+  return path.replace(/^team\//, '').replace(/\.md$/, '')
+}
+
+function parseNotebookPath(path: string): { agent: string; entry: string } | null {
+  // `agents/<slug>/<entry>.md` — split and validate the shape without regex
+  // capture groups that trip up some static analyzers.
+  if (!path.startsWith('agents/') || !path.endsWith('.md')) return null
+  const stripped = path.slice('agents/'.length, -3)
+  const firstSlash = stripped.indexOf('/')
+  if (firstSlash <= 0 || firstSlash === stripped.length - 1) return null
+  const agent = stripped.slice(0, firstSlash)
+  const entry = stripped.slice(firstSlash + 1)
+  if (entry.includes('/')) return null
+  return { agent, entry }
+}
+
 export function SearchModal() {
   const searchOpen = useAppStore((s) => s.searchOpen)
   const setSearchOpen = useAppStore((s) => s.setSearchOpen)
@@ -56,75 +70,114 @@ export function SearchModal() {
   const setActiveAgentSlug = useAppStore((s) => s.setActiveAgentSlug)
   const enterDM = useAppStore((s) => s.enterDM)
   const setLastMessageId = useAppStore((s) => s.setLastMessageId)
+  const setWikiPath = useAppStore((s) => s.setWikiPath)
+  const setNotebookRoute = useAppStore((s) => s.setNotebookRoute)
+  const composerSearchInitialQuery = useAppStore((s) => s.composerSearchInitialQuery)
+  const setComposerSearchInitialQuery = useAppStore((s) => s.setComposerSearchInitialQuery)
   const { data: channels = [] } = useChannels()
   const { data: members = [] } = useOfficeMembers()
 
   const [query, setQuery] = useState('')
   const [selectedIdx, setSelectedIdx] = useState(0)
   const [messageHits, setMessageHits] = useState<MessageHit[]>([])
+  const [wikiHits, setWikiHits] = useState<WikiSearchHit[]>([])
+  const [notebookHits, setNotebookHits] = useState<NotebookSearchHit[]>([])
   const [searching, setSearching] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const close = useCallback(() => setSearchOpen(false), [setSearchOpen])
 
-  // Focus input when modal opens; reset state when closing
-  useEffect(() => {
-    if (searchOpen) {
-      const t = setTimeout(() => inputRef.current?.focus(), 50)
-      return () => clearTimeout(t)
-    }
-    setQuery('')
-    setMessageHits([])
-    setSelectedIdx(0)
-  }, [searchOpen])
-
-  // Debounced message search
-  const runMessageSearch = useCallback(
-    async (q: string) => {
-      const trimmed = q.trim().toLowerCase()
-      if (trimmed.length < 2 || channels.length === 0) {
+  const runSearch = useCallback(
+    async (raw: string) => {
+      const trimmed = raw.trim()
+      const needle = trimmed.toLowerCase()
+      if (needle.length < 2 || channels.length === 0) {
         setMessageHits([])
+        setWikiHits([])
+        setNotebookHits([])
         return
       }
       setSearching(true)
       try {
-        const fetches = channels.map(async (ch) => {
-          try {
-            const { messages } = await getMessages(ch.slug, null, 100)
-            return messages
-              .filter((m) => m.content?.toLowerCase().includes(trimmed))
-              .map((m): MessageHit => ({ ...m, matchedChannel: ch.slug }))
-          } catch {
-            return [] as MessageHit[]
-          }
-        })
-        const grouped = await Promise.all(fetches)
-        const flat = grouped
-          .flat()
-          .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
-          .slice(0, 8)
-        setMessageHits(flat)
+        const messagesP = Promise.all(
+          channels.map(async (ch) => {
+            try {
+              const { messages } = await getMessages(ch.slug, null, 100)
+              return messages
+                .filter((m) => m.content?.toLowerCase().includes(needle))
+                .map((m): MessageHit => ({ ...m, matchedChannel: ch.slug }))
+            } catch {
+              return [] as MessageHit[]
+            }
+          }),
+        ).then((grouped) =>
+          grouped
+            .flat()
+            .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+            .slice(0, 8),
+        )
+
+        const wikiP = searchWiki(trimmed).then((hits) => hits.slice(0, 8))
+
+        const agentSlugs = members
+          .map((m) => m.slug)
+          .filter(
+            (s): s is string =>
+              typeof s === 'string' && s !== 'human' && s !== 'you' && s !== 'system',
+          )
+        const notebookP = Promise.all(
+          agentSlugs.map((slug) =>
+            searchNotebook(slug, trimmed).catch(() => [] as NotebookSearchHit[]),
+          ),
+        ).then((grouped) => grouped.flat().slice(0, 8))
+
+        const [msg, wiki, nb] = await Promise.all([messagesP, wikiP, notebookP])
+        setMessageHits(msg)
+        setWikiHits(wiki)
+        setNotebookHits(nb)
       } finally {
         setSearching(false)
       }
     },
-    [channels],
+    [channels, members],
   )
 
-  function handleQueryChange(value: string) {
-    setQuery(value)
-    setSelectedIdx(0)
-    if (debounceRef.current) clearTimeout(debounceRef.current)
-    debounceRef.current = setTimeout(() => runMessageSearch(value), 250)
-  }
+  const handleQueryChange = useCallback(
+    (value: string) => {
+      setQuery(value)
+      setSelectedIdx(0)
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+      debounceRef.current = setTimeout(() => runSearch(value), 250)
+    },
+    [runSearch],
+  )
 
-  // Build the flat list of items in display order
+  useEffect(() => {
+    if (searchOpen) {
+      const t = setTimeout(() => inputRef.current?.focus(), 50)
+      if (composerSearchInitialQuery) {
+        handleQueryChange(composerSearchInitialQuery)
+        setComposerSearchInitialQuery('')
+      }
+      return () => clearTimeout(t)
+    }
+    setQuery('')
+    setMessageHits([])
+    setWikiHits([])
+    setNotebookHits([])
+    setSelectedIdx(0)
+  }, [
+    searchOpen,
+    composerSearchInitialQuery,
+    handleQueryChange,
+    setComposerSearchInitialQuery,
+  ])
+
   const items = useMemo<PaletteItem[]>(() => {
     const q = query.trim().toLowerCase()
     const list: PaletteItem[] = []
 
-    // Channels
     for (const ch of channels) {
       const hay = `${ch.slug} ${ch.name ?? ''} ${ch.description ?? ''}`.toLowerCase()
       if (q && !hay.includes(q.replace(/^#/, ''))) continue
@@ -144,7 +197,6 @@ export function SearchModal() {
       })
     }
 
-    // Agents
     for (const m of members) {
       if (!m.slug || m.slug === 'human' || m.slug === 'you' || m.slug === 'system') continue
       const hay = `${m.slug} ${m.name ?? ''} ${m.role ?? ''}`.toLowerCase()
@@ -152,7 +204,7 @@ export function SearchModal() {
       list.push({
         id: 'ag:' + m.slug,
         group: 'Agents',
-        icon: m.emoji || '\uD83E\uDD16',
+        icon: m.emoji || '🤖',
         label: m.name || m.slug,
         desc: m.role,
         meta: '@' + m.slug,
@@ -163,7 +215,6 @@ export function SearchModal() {
       })
     }
 
-    // Slash commands
     for (const c of SLASH_COMMANDS) {
       const hay = `${c.name} ${c.desc}`.toLowerCase()
       if (q && !hay.includes(q.replace(/^\//, ''))) continue
@@ -174,7 +225,6 @@ export function SearchModal() {
         label: c.name,
         desc: c.desc,
         run: () => {
-          // Map command to its action via the same dispatcher the composer uses
           dispatchPaletteCommand(c.name, {
             setCurrentApp,
             setCurrentChannel,
@@ -187,14 +237,13 @@ export function SearchModal() {
       })
     }
 
-    // Message hits (only when there's a query)
     if (q.length >= 2) {
       for (const hit of messageHits) {
         const snippet = hit.content.length > 100 ? hit.content.slice(0, 100) + '...' : hit.content
         list.push({
           id: 'msg:' + hit.id + ':' + hit.matchedChannel,
           group: 'Messages',
-          icon: '\uD83D\uDCAC',
+          icon: '💬',
           label: `${hit.from}: ${snippet}`,
           desc: '#' + hit.matchedChannel + ' · ' + formatTime(hit.timestamp),
           run: () => {
@@ -205,17 +254,67 @@ export function SearchModal() {
           },
         })
       }
+
+      for (const hit of wikiHits) {
+        list.push({
+          id: 'wiki:' + hit.path + ':' + hit.line,
+          group: 'Wiki',
+          icon: '📖',
+          label: prettyWikiPath(hit.path),
+          desc: hit.snippet.trim().slice(0, 120),
+          meta: 'L' + hit.line,
+          run: () => {
+            setCurrentApp('wiki')
+            setWikiPath(hit.path)
+            close()
+          },
+        })
+      }
+
+      for (const hit of notebookHits) {
+        const parsed = parseNotebookPath(hit.path)
+        const label = parsed ? `${parsed.agent} · ${parsed.entry}` : hit.path
+        list.push({
+          id: 'nb:' + hit.path + ':' + hit.line,
+          group: 'Notebooks',
+          icon: '📓',
+          label,
+          desc: hit.snippet.trim().slice(0, 120),
+          meta: 'L' + hit.line,
+          run: () => {
+            setCurrentApp('notebooks')
+            if (parsed) {
+              setNotebookRoute(parsed.agent, parsed.entry)
+            }
+            close()
+          },
+        })
+      }
     }
 
     return list
-  }, [query, channels, members, messageHits, setCurrentApp, setCurrentChannel, setActiveAgentSlug, setLastMessageId, setSearchOpen, enterDM, close])
+  }, [
+    query,
+    channels,
+    members,
+    messageHits,
+    wikiHits,
+    notebookHits,
+    setCurrentApp,
+    setCurrentChannel,
+    setActiveAgentSlug,
+    setLastMessageId,
+    setSearchOpen,
+    setWikiPath,
+    setNotebookRoute,
+    enterDM,
+    close,
+  ])
 
-  // Clamp selection
   useEffect(() => {
     setSelectedIdx((idx) => Math.min(idx, Math.max(items.length - 1, 0)))
   }, [items.length])
 
-  // Keyboard handling
   useEffect(() => {
     if (!searchOpen) return
     function handleKeyDown(e: KeyboardEvent) {
@@ -244,7 +343,6 @@ export function SearchModal() {
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [searchOpen, items, selectedIdx, close])
 
-  // Group items for rendering, preserving the flat index for selection
   const grouped = useMemo(() => {
     const out: { group: PaletteItem['group']; items: { item: PaletteItem; flatIdx: number }[] }[] = []
     items.forEach((item, idx) => {
@@ -276,7 +374,7 @@ export function SearchModal() {
             ref={inputRef}
             className="search-input"
             type="text"
-            placeholder="Search channels, agents, commands, messages..."
+            placeholder="Search channels, agents, commands, messages, wiki, notebooks..."
             value={query}
             onChange={(e) => handleQueryChange(e.target.value)}
           />
@@ -303,10 +401,16 @@ export function SearchModal() {
                     <span className="cmd-palette-item-icon">{item.icon}</span>
                     <span className="cmd-palette-item-text">
                       <span className="cmd-palette-item-label">
-                        {item.group === 'Messages' ? highlightMatch(item.label, query.trim()) : item.label}
+                        {item.group === 'Messages' || item.group === 'Wiki' || item.group === 'Notebooks'
+                          ? highlightMatch(item.label, query.trim())
+                          : item.label}
                       </span>
                       {item.desc && (
-                        <span className="cmd-palette-item-desc">{item.desc}</span>
+                        <span className="cmd-palette-item-desc">
+                          {item.group === 'Wiki' || item.group === 'Notebooks'
+                            ? highlightMatch(item.desc, query.trim())
+                            : item.desc}
+                        </span>
                       )}
                     </span>
                     {item.meta && <span className="cmd-palette-item-meta">{item.meta}</span>}
@@ -341,8 +445,14 @@ function dispatchPaletteCommand(name: string, deps: CommandDeps) {
       showNotice('Messages cleared', 'info')
       return
     case '/help':
-      showNotice('Use the palette: type to filter, ↑↓ to move, Enter to open.', 'info')
+      useAppStore.getState().setComposerHelpOpen(true)
       return
+    case '/ask':
+    case '/remember':
+      showNotice(`${name} requires arguments — type it in the composer.`, 'info')
+      return
+    case '/search':
+      deps.setSearchOpen(true); return
     case '/requests':
       deps.setCurrentApp('requests'); return
     case '/policies':
@@ -360,8 +470,6 @@ function dispatchPaletteCommand(name: string, deps: CommandDeps) {
       deps.setCurrentApp('threads'); return
     case '/provider':
       openProviderSwitcher(); return
-    case '/search':
-      deps.setSearchOpen(true); return
     case '/focus':
       post('/focus-mode', { focus_mode: true })
         .then(() => showNotice('Switched to delegation mode', 'success'))

--- a/web/src/components/ui/HelpModal.tsx
+++ b/web/src/components/ui/HelpModal.tsx
@@ -1,0 +1,163 @@
+import { useCallback, useEffect } from 'react'
+import { useAppStore } from '../../stores/app'
+import { SLASH_COMMANDS } from '../messages/Autocomplete'
+
+/**
+ * One keyboard-shortcut row for the help modal.
+ */
+interface Keybinding {
+  keys: string[]
+  description: string
+}
+
+/**
+ * Mirrors TUI operator guidance. The composer parity PR ships Ctrl+P/N history
+ * and Esc handling; sibling PRs ship feed vim nav (j/k/g/G) and the graph app.
+ * Listing them here even before they merge gives operators one place to learn
+ * the full keymap.
+ */
+const COMPOSER_KEYS: Keybinding[] = [
+  { keys: ['Enter'], description: 'Send message' },
+  { keys: ['Shift', 'Enter'], description: 'Newline inside composer' },
+  { keys: ['Ctrl', 'P'], description: 'Recall previous message in this channel' },
+  { keys: ['Ctrl', 'N'], description: 'Forward through recalled history / restore draft' },
+  { keys: ['↑'], description: 'Recall previous when composer is empty' },
+  { keys: ['Esc'], description: 'Close autocomplete, mention, modal, or help' },
+]
+
+const NAV_KEYS: Keybinding[] = [
+  { keys: ['j'], description: 'Scroll feed down one message' },
+  { keys: ['k'], description: 'Scroll feed up one message' },
+  { keys: ['Ctrl', 'D'], description: 'Half-page down' },
+  { keys: ['Ctrl', 'U'], description: 'Half-page up' },
+  { keys: ['g', 'g'], description: 'Jump to top of feed' },
+  { keys: ['Shift', 'G'], description: 'Jump to bottom of feed' },
+  { keys: ['/'], description: 'Open search / command palette' },
+  { keys: ['?'], description: 'Toggle keyboard cheat sheet' },
+]
+
+interface HelpModalProps {
+  open: boolean
+  onClose: () => void
+}
+
+/**
+ * Full-screen help surface opened by the `/help` slash command. Renders the
+ * complete SLASH_COMMANDS list alongside composer + feed keybindings so
+ * operators never have to leave the app to find a shortcut.
+ *
+ * Intentionally separate from `KeyboardCheatSheet`: the cheat sheet is a
+ * corner popover that toggles on `?`; HelpModal is the full reference.
+ */
+export function HelpModal({ open, onClose }: HelpModalProps) {
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) onClose()
+    },
+    [onClose],
+  )
+
+  if (!open) return null
+
+  return (
+    <div
+      className="help-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Help — slash commands and keyboard shortcuts"
+      onClick={handleOverlayClick}
+    >
+      <div className="help-modal card">
+        <header className="help-header">
+          <div>
+            <h2 className="help-title">Keyboard + command reference</h2>
+            <p className="help-subtitle">Everything the composer and feed understand.</p>
+          </div>
+          <button
+            type="button"
+            className="help-close"
+            onClick={onClose}
+            aria-label="Close help"
+          >
+            Esc
+          </button>
+        </header>
+
+        <div className="help-body">
+          <section className="help-section">
+            <h3 className="help-section-title">Slash commands</h3>
+            <ul className="help-list">
+              {SLASH_COMMANDS.map((cmd) => (
+                <li key={cmd.name} className="help-row">
+                  <span className="help-cmd">
+                    <span className="help-cmd-icon" aria-hidden>
+                      {cmd.icon}
+                    </span>
+                    <code className="help-cmd-name">{cmd.name}</code>
+                  </span>
+                  <span className="help-cmd-desc">{cmd.desc}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="help-section">
+            <h3 className="help-section-title">Composer</h3>
+            <KeybindingList items={COMPOSER_KEYS} />
+          </section>
+
+          <section className="help-section">
+            <h3 className="help-section-title">Feed navigation</h3>
+            <KeybindingList items={NAV_KEYS} />
+            <p className="help-note">
+              Vim-style nav and the graph app ship in sibling PRs. This reference
+              lists them upfront so your muscle memory does not have to wait.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function KeybindingList({ items }: { items: Keybinding[] }) {
+  return (
+    <ul className="help-list">
+      {items.map((item) => (
+        <li key={item.keys.join('+') + item.description} className="help-row">
+          <span className="help-keys">
+            {item.keys.map((k, i) => (
+              <kbd key={`${k}-${i}`} className="help-kbd">
+                {k}
+              </kbd>
+            ))}
+          </span>
+          <span className="help-cmd-desc">{item.description}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+/**
+ * Convenience mount for the Shell — reads open state from the store and
+ * wires the close handler. Kept here instead of in Shell.tsx so the mount
+ * and the dialog live side-by-side.
+ */
+export function HelpModalHost() {
+  const open = useAppStore((s) => s.composerHelpOpen)
+  const setOpen = useAppStore((s) => s.setComposerHelpOpen)
+  return <HelpModal open={open} onClose={() => setOpen(false)} />
+}

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -101,6 +101,16 @@ export interface AppStore {
   // Search
   searchOpen: boolean
   setSearchOpen: (v: boolean) => void
+  /**
+   * Query to prefill in the SearchModal on next open. Set by the composer
+   * `/search <query>` command and cleared by the modal when consumed.
+   */
+  composerSearchInitialQuery: string
+  setComposerSearchInitialQuery: (q: string) => void
+
+  // Help modal — /help slash command surface
+  composerHelpOpen: boolean
+  setComposerHelpOpen: (v: boolean) => void
 
   // Onboarding
   onboardingComplete: boolean
@@ -183,6 +193,11 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   searchOpen: false,
   setSearchOpen: (v) => set({ searchOpen: v }),
+  composerSearchInitialQuery: '',
+  setComposerSearchInitialQuery: (q) => set({ composerSearchInitialQuery: q }),
+
+  composerHelpOpen: false,
+  setComposerHelpOpen: (v) => set({ composerHelpOpen: v }),
 
   onboardingComplete: false,
   setOnboardingComplete: (v) => set({ onboardingComplete: v }),

--- a/web/src/styles/search.css
+++ b/web/src/styles/search.css
@@ -353,3 +353,169 @@
     max-width: none;
   }
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Help modal — /help slash command
+   ═══════════════════════════════════════════════════════════════ */
+.help-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 8vh;
+  padding-bottom: 4vh;
+  z-index: 160;
+  animation: fadeIn 0.15s ease-out;
+  overflow-y: auto;
+}
+
+.help-modal {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.16);
+  width: min(92%, 640px);
+  max-height: none;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.help-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.help-title {
+  margin: 0 0 2px 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.help-subtitle {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--text-tertiary);
+}
+
+.help-close {
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--text-secondary);
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-family: SFMono-Regular, Menlo, monospace;
+  cursor: pointer;
+  transition: background 0.1s, color 0.1s;
+}
+.help-close:hover {
+  background: var(--accent-bg);
+  color: var(--text);
+}
+
+.help-body {
+  padding: 18px 24px 22px;
+  overflow-y: auto;
+  display: grid;
+  gap: 22px;
+}
+
+.help-section-title {
+  margin: 0 0 10px 0;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-tertiary);
+}
+
+.help-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  row-gap: 6px;
+}
+
+.help-row {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  align-items: center;
+  gap: 16px;
+  font-size: 13px;
+  color: var(--text);
+  padding: 4px 0;
+}
+
+.help-cmd {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.help-cmd-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.help-cmd-name {
+  font-family: SFMono-Regular, Menlo, monospace;
+  font-size: 12.5px;
+  color: var(--text);
+  background: var(--accent-bg);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+.help-cmd-desc {
+  color: var(--text-secondary);
+  font-size: 12.5px;
+}
+
+.help-keys {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.help-kbd {
+  font-family: SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  padding: 2px 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  color: var(--text);
+  min-width: 20px;
+  text-align: center;
+  line-height: 1.4;
+}
+
+.help-note {
+  margin: 10px 0 0 0;
+  font-size: 11.5px;
+  color: var(--text-tertiary);
+  font-style: italic;
+}
+
+@media (max-width: 640px) {
+  .help-row {
+    grid-template-columns: 1fr;
+    row-gap: 2px;
+  }
+}


### PR DESCRIPTION
## Summary

PR A of the 3-PR composer/feed parity sprint. Brings the web composer up to TUI parity so operators stop losing muscle memory between surfaces.

**Slash commands** (mirrors `internal/commands/cmd_ai.go`):
- `/ask <q>` — posts as a normal user message prefixed with the team lead's `@mention` so broker routing dispatches it to the lead
- `/search <q>` — opens the SearchModal with the query prefilled; extends search to cover the KB (wiki + notebooks), not just messages
- `/remember <fact>` — stores the fact to the broker `/memory` endpoint under a `human-notes` namespace
- `/help` — opens a new `HelpModal` listing every slash command + composer/feed keybindings (including keys owned by sibling PRs B/C)

**Composer history** (mirrors TUI `internal/tui/interaction.go:56-58` + `cmd/wuphf/channel_history.go`):
- Per-channel history in `sessionStorage`, capped at 20 entries, de-duped
- Ctrl+P walks backward; stashes the live draft so Ctrl+N can restore it
- Empty-draft ArrowUp also recalls, Slack-style
- Recall cancels on manual edits + channel switch

**Mention whitespace scoping** (mirrors TUI `internal/tui/mention.go:33-49`):
- `currentTrigger` already matched TUI logic on origin/main; this PR adds regression tests so `foo@bar` never triggers and `foo @bar` always does

## Files touched
- `web/src/components/messages/Composer.tsx` — slash dispatch + history
- `web/src/components/messages/Autocomplete.tsx` — added /ask, /remember to command list
- `web/src/components/ui/HelpModal.tsx` — new
- `web/src/components/search/SearchModal.tsx` — KB search + query prefill
- `web/src/stores/app.ts` — `composerHelpOpen`, `composerSearchInitialQuery`
- `web/src/api/wiki.ts`, `web/src/api/notebook.ts` — `searchWiki`, `searchNotebook` client wrappers
- `web/src/components/layout/Shell.tsx` — mounts HelpModalHost
- `web/src/styles/search.css` — help modal styles
- `web/src/components/messages/Autocomplete.test.tsx`, `Composer.test.tsx` — new tests

## Test plan
- [x] typecheck clean (`npm run typecheck`)
- [x] 290/290 tests passing (24 new)
- [x] `/ask hello` dispatched as `@ceo hello` — verified via broker `/messages` (msg-1)
- [x] `/search foo` opens SearchModal with "foo" prefilled + fires wiki + notebook search
- [x] `/remember another fact` stored under `human-notes` namespace — verified via broker `/memory`
- [x] `/help` opens HelpModal showing full slash + keybinding reference
- [x] Ctrl+P recalls latest sent message, repeated Ctrl+P walks back, Ctrl+N walks forward
- [x] Empty-composer ArrowUp recalls last message
- [x] `foo@bar` leaves autocomplete closed
- [x] `foo @ce` opens autocomplete panel

## Non-goals / punted
- Feed vim nav (j/k/g/G, Ctrl+D/U, gg/G) — sibling PR B owns `MessageFeed.tsx`
- Graph app — sibling PR C
- Clearer visual treatment of history recall (e.g. subtle "from history" pill) — added to follow-up list

## Screenshots
Local browse-run captures at `/tmp/wuphf-screenshots/*.png`:
- 02-help-modal.png — `/help` modal open
- 03-search-prefilled.png — `/search foo` prefill
- 04-remember-toast.png — `/remember` success toast
- 05-ask-dispatched.png — `/ask` routed to @ceo
- 06-history-ctrlp.png — Ctrl+P recall
- 07-mention-whitespace.png — autocomplete on `foo @ceo`
- 09-slash-autocomplete.png — new commands in autocomplete
- 10-search-wiki-hit.png — wiki KB hit in search modal