### PR TITLE
feat(agent): bigger compaction windows (CEO 200k, others 100k)

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -774,7 +774,7 @@ func entriesToMessages(entries []SessionEntry) []Message {
 }
 
 func (l *AgentLoop) prepareEntriesForStreaming(entries []SessionEntry) []SessionEntry {
-	if !shouldCompactEntries(entries) {
+	if !shouldCompactEntries(entries, l.state.Config.Slug) {
 		l.lastCompactionAt = 0
 		return entries
 	}

--- a/internal/agent/task_runtime.go
+++ b/internal/agent/task_runtime.go
@@ -13,7 +13,12 @@ const (
 	taskLogRootEnv          = "WUPHF_TASK_LOG_ROOT"
 	compactionTokenLimitEnv = "WUPHF_COMPACTION_TOKEN_LIMIT"
 	defaultTokenLimit       = 16000
-	compactionRatio         = 0.8
+	// CEO routes work for the whole office and burns through context faster
+	// than any specialist, so it gets a much larger working window before the
+	// loop archives older turns into an Office Insight.
+	ceoSlug         = "ceo"
+	ceoTokenLimit   = 200000
+	compactionRatio = 0.8
 )
 
 func defaultTaskLogRoot() string {
@@ -36,17 +41,17 @@ func nextTaskID(slug string) string {
 	return fmt.Sprintf("%s-%d", slug, time.Now().UnixMilli())
 }
 
-func compactionTokenLimit() int {
-	raw := strings.TrimSpace(os.Getenv(compactionTokenLimitEnv))
-	if raw == "" {
-		return defaultTokenLimit
+func compactionTokenLimit(slug string) int {
+	if raw := strings.TrimSpace(os.Getenv(compactionTokenLimitEnv)); raw != "" {
+		var limit int
+		if _, err := fmt.Sscanf(raw, "%d", &limit); err == nil && limit > 0 {
+			return limit
+		}
 	}
-
-	var limit int
-	if _, err := fmt.Sscanf(raw, "%d", &limit); err != nil || limit <= 0 {
-		return defaultTokenLimit
+	if slug == ceoSlug {
+		return ceoTokenLimit
 	}
-	return limit
+	return defaultTokenLimit
 }
 
 func estimateSessionTokens(entries []SessionEntry) int {
@@ -65,11 +70,11 @@ func estimateTextTokens(text string) int {
 	return (runes + 3) / 4
 }
 
-func shouldCompactEntries(entries []SessionEntry) bool {
+func shouldCompactEntries(entries []SessionEntry, slug string) bool {
 	if len(entries) < 8 {
 		return false
 	}
-	trigger := int(float64(compactionTokenLimit()) * compactionRatio)
+	trigger := int(float64(compactionTokenLimit(slug)) * compactionRatio)
 	return estimateSessionTokens(entries) >= trigger
 }
 

--- a/internal/agent/task_runtime.go
+++ b/internal/agent/task_runtime.go
@@ -12,7 +12,7 @@ import (
 const (
 	taskLogRootEnv          = "WUPHF_TASK_LOG_ROOT"
 	compactionTokenLimitEnv = "WUPHF_COMPACTION_TOKEN_LIMIT"
-	defaultTokenLimit       = 16000
+	defaultTokenLimit       = 100000
 	// CEO routes work for the whole office and burns through context faster
 	// than any specialist, so it gets a much larger working window before the
 	// loop archives older turns into an Office Insight.

--- a/internal/agent/task_runtime_test.go
+++ b/internal/agent/task_runtime_test.go
@@ -1,0 +1,23 @@
+package agent
+
+import "testing"
+
+func TestCompactionTokenLimitPerSlug(t *testing.T) {
+	t.Setenv(compactionTokenLimitEnv, "")
+
+	if got := compactionTokenLimit("eng"); got != defaultTokenLimit {
+		t.Errorf("specialist limit: got %d, want %d", got, defaultTokenLimit)
+	}
+	if got := compactionTokenLimit(ceoSlug); got != ceoTokenLimit {
+		t.Errorf("ceo limit: got %d, want %d", got, ceoTokenLimit)
+	}
+
+	// Env override wins for both, so operators retain control.
+	t.Setenv(compactionTokenLimitEnv, "5000")
+	if got := compactionTokenLimit("eng"); got != 5000 {
+		t.Errorf("specialist env override: got %d, want 5000", got)
+	}
+	if got := compactionTokenLimit(ceoSlug); got != 5000 {
+		t.Errorf("ceo env override: got %d, want 5000", got)
+	}
+}


### PR DESCRIPTION
## Summary
- CEO agent now compacts at 200k tokens instead of the shared 16k default — it routes work for the entire office and burns through context faster than any specialist.
- All other agents bumped from 16k → 100k, much closer to modern model context windows.
- `WUPHF_COMPACTION_TOKEN_LIMIT` env override still wins for both, so operators retain control.

## Test plan
- [x] `go test -run "TestCompactionTokenLimitPerSlug|TestStreamLLMCompactsOldContext" ./internal/agent/...` passes
- [x] New `TestCompactionTokenLimitPerSlug` pins per-slug behavior and env override precedence
- [ ] CI green

https://claude.ai/code/session_01VCMavkp5fMB9LCfzXMPQYs