### PR TITLE
fix(wiki): exclude team/inbox from catalog and resolve bare-slug wikilinks

### DIFF
--- a/internal/team/wiki_article.go
+++ b/internal/team/wiki_article.go
@@ -95,6 +95,15 @@ func (r *Repo) BuildCatalog(ctx context.Context) ([]CatalogEntry, error) {
 			return nil
 		}
 		if d.IsDir() {
+			// team/inbox/ holds raw ingested source material (scanner dumps),
+			// not curated wiki content. Excluding it here keeps the catalog
+			// and UI focused on synthesized briefs/playbooks/decisions; the
+			// raw files are still reachable by direct path via /wiki/read
+			// for agents that want to cite them.
+			rel, relErr := filepath.Rel(r.Root(), path)
+			if relErr == nil && filepath.ToSlash(rel) == "team/inbox" {
+				return filepath.SkipDir
+			}
 			return nil
 		}
 		if !strings.HasSuffix(path, ".md") {

--- a/internal/team/wiki_article_test.go
+++ b/internal/team/wiki_article_test.go
@@ -2,9 +2,11 @@ package team
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -238,6 +240,60 @@ func TestBuildArticle_RejectsBadPath(t *testing.T) {
 		if _, err := repo.BuildArticle(context.Background(), p); err == nil {
 			t.Errorf("BuildArticle(%q): want error, got nil", p)
 		}
+	}
+}
+
+// BuildCatalog must not surface raw ingested source material under
+// team/inbox/. That directory is the scanner's dump target — files
+// there are source material, not curated wiki content, and the UI
+// would drown in them on any real scan.
+func TestBuildCatalog_ExcludesInbox(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	root := t.TempDir()
+	backup := filepath.Join(t.TempDir(), "bak")
+	repo := NewRepoAt(root, backup)
+	ctx := context.Background()
+	if err := repo.Init(ctx); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+
+	// Curated brief — must appear in the catalog.
+	if _, _, err := repo.Commit(ctx, "ceo", "team/people/nazz.md", "# Nazz\n\nFounder.\n", "create", "add nazz"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	// Simulate a scanner-written inbox file. The scanner writes these
+	// directly to disk (bypassing Commit) under team/inbox/raw/...; any
+	// equivalent on-disk path under team/inbox/ must be skipped.
+	inboxDir := filepath.Join(root, "team", "inbox", "raw", "some-source")
+	if err := os.MkdirAll(inboxDir, 0o700); err != nil {
+		t.Fatalf("mkdir inbox: %v", err)
+	}
+	inboxFile := filepath.Join(inboxDir, "episode.md")
+	if err := os.WriteFile(inboxFile, []byte("# Episode\n\nraw transcript.\n"), 0o600); err != nil {
+		t.Fatalf("write inbox file: %v", err)
+	}
+
+	entries, err := repo.BuildCatalog(ctx)
+	if err != nil {
+		t.Fatalf("BuildCatalog: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Path, "team/inbox/") {
+			t.Errorf("catalog contained inbox entry %q; inbox should be excluded", e.Path)
+		}
+	}
+	var sawBrief bool
+	for _, e := range entries {
+		if e.Path == "team/people/nazz.md" {
+			sawBrief = true
+			break
+		}
+	}
+	if !sawBrief {
+		t.Error("expected team/people/nazz.md in catalog, not found")
 	}
 }
 

--- a/web/src/api/wiki.test.ts
+++ b/web/src/api/wiki.test.ts
@@ -35,6 +35,55 @@ describe('wiki api client', () => {
     expect(result.title).toBe('Customer X')
   })
 
+  it('fetchArticle resolves a bare slug by trying the standard group dirs', async () => {
+    const article: api.WikiArticle = {
+      path: 'team/companies/stripe.md',
+      title: 'Stripe',
+      content: 'Payments infra',
+      last_edited_by: 'archivist',
+      last_edited_ts: new Date().toISOString(),
+      revisions: 1,
+      contributors: ['archivist'],
+      backlinks: [],
+      word_count: 2,
+      categories: [],
+    }
+    const spy = vi.spyOn(client, 'get')
+      // First candidate (team/people/stripe.md) misses.
+      .mockRejectedValueOnce(new Error('404'))
+      // Second candidate (team/companies/stripe.md) hits.
+      .mockResolvedValueOnce(article)
+    const result = await api.fetchArticle('stripe')
+    expect(result).toEqual(article)
+    expect(spy).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining(encodeURIComponent('team/people/stripe.md')),
+    )
+    expect(spy).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining(encodeURIComponent('team/companies/stripe.md')),
+    )
+  })
+
+  it('fetchArticle passes through a full team/ path without fanning out', async () => {
+    const article: api.WikiArticle = {
+      path: 'team/playbooks/pricing.md',
+      title: 'Pricing',
+      content: '',
+      last_edited_by: 'cro',
+      last_edited_ts: new Date().toISOString(),
+      revisions: 1,
+      contributors: ['cro'],
+      backlinks: [],
+      word_count: 0,
+      categories: [],
+    }
+    const spy = vi.spyOn(client, 'get').mockResolvedValue(article)
+    const result = await api.fetchArticle('team/playbooks/pricing.md')
+    expect(result).toEqual(article)
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
   it('fetchCatalog returns entries array on success', async () => {
     const entries: api.WikiCatalogEntry[] = [
       { path: 'a', title: 'A', author_slug: 'pm', last_edited_ts: new Date().toISOString(), group: 'people' },

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -145,12 +145,48 @@ export interface WikiEditLogEntry {
   commit_sha: string
 }
 
+/**
+ * Candidate wiki paths for a given hash slug. Wikilinks in briefs use
+ * a bare slug (e.g. `[[nazz]]`), which routes to URL `#/wiki/nazz`. The
+ * broker's `/wiki/article` endpoint requires a full `team/{group}/{slug}.md`
+ * path, so the client resolves bare slugs by trying each standard group
+ * directory in order before giving up.
+ *
+ * Full paths (`team/…`) and any input already containing a slash are
+ * passed through unchanged (with a `.md` suffix added if missing). Bare
+ * slugs fan out across the standard groups in priority order. The 404s
+ * on misses are cheap and there's no coherence risk — the first match
+ * wins.
+ */
+function candidatePaths(pathOrSlug: string): string[] {
+  const trimmed = pathOrSlug.trim().replace(/^\/+/, '').replace(/\/+$/, '')
+  if (!trimmed) return []
+  const withExt = trimmed.endsWith('.md') ? trimmed : `${trimmed}.md`
+  if (trimmed.startsWith('team/')) return [withExt]
+  if (trimmed.includes('/')) return [`team/${withExt}`]
+  const slug = withExt
+  return [
+    `team/people/${slug}`,
+    `team/companies/${slug}`,
+    `team/playbooks/${slug}`,
+    `team/decisions/${slug}`,
+    `team/projects/${slug}`,
+    `team/${slug}`,
+  ]
+}
+
 export async function fetchArticle(path: string): Promise<WikiArticle> {
-  try {
-    return await get<WikiArticle>(`/wiki/article?path=${encodeURIComponent(path)}`)
-  } catch {
-    return mockArticle(path)
+  const tried: string[] = []
+  for (const candidate of candidatePaths(path)) {
+    tried.push(candidate)
+    try {
+      return await get<WikiArticle>(`/wiki/article?path=${encodeURIComponent(candidate)}`)
+    } catch {
+      // Try next candidate. Real 404s and bare-slug misses look identical
+      // from the client — fall through and mock at the end.
+    }
   }
+  return mockArticle(tried[tried.length - 1] ?? path)
 }
 
 /**
@@ -402,7 +438,12 @@ export const MOCK_CATALOG: WikiCatalogEntry[] = [
 ]
 
 export function mockArticle(path: string): WikiArticle {
-  if (path === 'people/customer-x' || path === '' || path === 'customer-x') {
+  if (
+    path === 'people/customer-x' ||
+    path === '' ||
+    path === 'customer-x' ||
+    path === 'team/people/customer-x.md'
+  ) {
     return {
       path: 'people/customer-x',
       title: 'Customer X',


### PR DESCRIPTION
## Summary

Two related bugs that both surface as soon as the wiki has real scanned content.

### 1. Wiki catalog drowns in raw ingested source material

`BuildCatalog` walks every `.md` file under `team/`, including `team/inbox/raw/`. The scanner writes ingested source files (user-provided folders, podcast transcripts, etc.) to that path as part of its normal flow. After any non-trivial scan the wiki UI catalog ends up dominated by hundreds of flat-named dump files, with the curated briefs buried among them. That is source material, not wiki content.

Fix: `SkipDir` at `team/inbox/` in the catalog walker. Files remain on disk and are still reachable via `/wiki/read` for agents that want to cite them by direct path. Only the catalog/UI surface changes.

### 2. Bare-slug wikilinks all fall through to the mock placeholder

`lib/wikilink.ts` documents `[[slug]]` as the canonical form, and `CiteThisPagePanel` emits bare slugs. `[[nazz]]` renders as a link to `#/wiki/nazz`, which sets `wikiPath = \"nazz\"`. `fetchArticle` then sends that bare slug straight to `GET /wiki/article?path=nazz`, which fails `validateArticlePath` (requires `team/…*.md`) and returns 400. The client swallows the error and returns `mockArticle(path)`, which renders the `_Article not found in mock fixtures._` placeholder. Every bare-slug wikilink in every brief hits this path.

Fix (client-side only, no broker API change): resolve candidate paths in order before giving up.

- Full `team/…` paths and anything containing a slash pass through unchanged (with `.md` suffix appended if missing).
- Bare slugs fan out across the standard group dirs: `team/people/`, `team/companies/`, `team/playbooks/`, `team/decisions/`, `team/projects/`, then bare `team/`.
- First match wins. Remaining candidates short-circuit.

`mockArticle` picks up one extra canonical match (`team/people/customer-x.md`) so the Customer X fixture still works through the new path.

## Tests

- **`TestBuildCatalog_ExcludesInbox`** (Go) — seeds a curated brief at `team/people/nazz.md` and an inbox file at `team/inbox/raw/some-source/episode.md`, asserts the catalog contains the brief and no inbox path.
- **`fetchArticle resolves a bare slug by trying the standard group dirs`** (vitest) — first candidate rejects, second resolves; asserts ordered request sequence and returned article.
- **`fetchArticle passes through a full team/ path without fanning out`** (vitest) — locks the no-fanout behaviour so callers that already hold a canonical path pay one request, not seven.

Existing test `fetchArticle falls back to a mock on network error` kept green by the one-line extension to `mockArticle`'s exact-match list.

## Test plan

- [ ] `go test -race ./internal/team/...` passes locally
- [ ] `cd web && bun test src/api/wiki.test.ts` passes locally
- [ ] `cd web && bun run build` is clean
- [ ] Scan a folder, open the wiki — catalog is clean, no inbox entries
- [ ] Open any brief, click a bare `[[slug]]` wikilink that points at an existing `team/people/{slug}.md` — it renders the real article, not the mock placeholder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wiki article lookup now supports bare slugs (e.g., "stripe") and automatically searches multiple locations.

* **Bug Fixes**
  * Wiki catalog no longer includes inbox items, keeping only curated articles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->