### PR TITLE
ci(vhs): install libblas3 explicitly so ffmpeg warm-restores run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,12 +130,17 @@ jobs:
         # of @v1 would execute with elevated privileges on the runner.
         uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
-          packages: ffmpeg
+          # libblas3 is a transitive runtime dep of ffmpeg on ubuntu-latest.
+          # Listing it explicitly guarantees it lands in the apt cache payload
+          # alongside ffmpeg, so warm restores do not surface
+          # `ffmpeg: error while loading shared libraries: libblas.so.3`.
+          packages: ffmpeg libblas3
           # NOTE: `version` is a cache-bust token, NOT an ffmpeg version pin.
           # Bump it to force a fresh apt-get install (e.g., for a security
-          # advisory). `packages: ffmpeg` has no version constraint, so warm
-          # runs reuse whatever .deb the cold run captured.
-          version: "1"
+          # advisory, or when the dependency list above changes). `packages`
+          # has no version constraint, so warm runs reuse whatever .debs the
+          # cold run captured.
+          version: "2"
       - name: Build wuphf
         run: go build -o wuphf ./cmd/wuphf
       - name: Run VHS regression checks


### PR DESCRIPTION
## Summary

The `vhs` job has been failing intermittently with:

\`\`\`
ffmpeg: error while loading shared libraries: libblas.so.3: cannot open shared object file
\`\`\`

## Root cause

\`cache-apt-pkgs-action\` captures only the packages listed in \`packages:\`. On a cold run, \`apt-get install ffmpeg\` pulls in a chain of transitive deps (including \`libblas3\`) and the action then bundles JUST \`ffmpeg.deb\` into its cache. Warm restores unpack only \`ffmpeg.deb\`, and when the ffmpeg binary loads at runtime it can't find \`libblas.so.3\` because the transitive dep was never cached.

## Fix

- List \`libblas3\` explicitly in \`packages:\` so the cache payload contains both debs.
- Bump the cache-bust token \`version: "1"\` → \`version: "2"\` so the first run after merge captures the new package set instead of reusing the broken warm cache.

## Test plan

- [x] Cold run: new cache captures both \`ffmpeg\` and \`libblas3\`.
- [x] Warm run: ffmpeg finds \`libblas.so.3\` and VHS regression checks execute.
- [x] No behavior change for other jobs.

Observed failing on runs 24790565721 and 24791508107 (PR #218). This unblocks that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)