### PR TITLE
chore(website): swap landing demo to v27 render

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1160,7 +1160,7 @@
   <p class="video-prompt">Watch the demo ↓</p>
   <div class="video-wrap">
     <video
-      src="https://github.com/user-attachments/assets/d62766ba-ebb3-4948-bc02-770ebcc51d5a"
+      src="wuphf-demo-v27.mp4"
       controls
       preload="metadata"
     ></video>


### PR DESCRIPTION
## Summary

- Adds `website/wuphf-demo-v27.mp4` (10.1 MB, 97s, 1920×1080) — new Remotion cut with the Wiki + Notebooks scene and product-matched UI (PR #219).
- Replaces the external `user-attachments` URL in `website/index.html` with a local relative path so the video ships with the GitHub Pages deploy and is easy to swap in future revs.

## Test plan

- [ ] Open `website/index.html` locally — demo video autoloads metadata and plays on click
- [ ] Verify on the deployed site once merged (nex-crm.github.io/wuphf.ai) that the new cut appears above the fold
- [ ] No layout shift in `.video-wrap` (same aspect ratio as prior)