### PR TITLE
feat: add Opencode CLI as a third LLM provider

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -5673,6 +5673,9 @@ func applyTeamSetup() tea.Cmd {
 		if config.ResolveLLMProvider("") == "codex" || strings.TrimSpace(cfg.LLMProvider) == "codex" {
 			return channelInitDoneMsg{notice: notice + " Codex was saved as the LLM provider. Restart WUPHF to launch the headless Codex office runtime."}
 		}
+		if config.ResolveLLMProvider("") == "opencode" || strings.TrimSpace(cfg.LLMProvider) == "opencode" {
+			return channelInitDoneMsg{notice: notice + " Opencode was saved as the LLM provider. Restart WUPHF to launch the headless Opencode office runtime."}
+		}
 		l, err := team.NewLauncher("")
 		if err != nil {
 			return channelInitDoneMsg{err: err}
@@ -5711,7 +5714,17 @@ func applyProviderSelection(providerName string) tea.Cmd {
 			}
 			return channelInitDoneMsg{notice: "Provider switched to codex. Claude teammate panes were stopped. Restart WUPHF to launch the headless Codex office runtime."}
 		}
-		if currentProvider == "codex" {
+		if providerName == "opencode" {
+			l, err := team.NewLauncher("")
+			if err != nil {
+				return channelInitDoneMsg{err: err}
+			}
+			if err := l.ReconfigureSession(); err != nil {
+				return channelInitDoneMsg{err: err}
+			}
+			return channelInitDoneMsg{notice: "Provider switched to opencode. Claude teammate panes were stopped. Restart WUPHF to launch the headless Opencode office runtime."}
+		}
+		if currentProvider == "codex" || currentProvider == "opencode" {
 			return channelInitDoneMsg{notice: "Provider switched to " + providerName + ". Restart WUPHF to reload the office runtime with the new configuration."}
 		}
 

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -129,7 +129,7 @@ func main() {
 	blueprintFlag := flag.String("blueprint", "", "Operation blueprint ID for this run")
 	packFlag := flag.String("pack", "", "Operation blueprint ID (legacy pack alias supported)")
 	fromScratchFlag := flag.Bool("from-scratch", false, "Start without a saved blueprint and synthesize the first operation from the directive")
-	providerFlag := flag.String("provider", "", "LLM provider override for this run (claude-code, codex)")
+	providerFlag := flag.String("provider", "", "LLM provider override for this run (claude-code, codex, opencode)")
 	oneOnOne := flag.Bool("1o1", false, "Launch a direct 1:1 session with a single agent (default ceo)")
 	channelView := flag.Bool("channel-view", false, "Run as channel view (internal)")
 	channelApp := flag.String("channel-app", "", "Start channel view on a specific app (internal)")
@@ -185,10 +185,10 @@ func main() {
 	}
 	if provider := strings.TrimSpace(*providerFlag); provider != "" {
 		switch provider {
-		case "claude-code", "codex":
+		case "claude-code", "codex", "opencode":
 			_ = os.Setenv("WUPHF_LLM_PROVIDER", provider)
 		default:
-			fmt.Fprintf(os.Stderr, "error: unsupported provider %q (expected claude-code or codex)\n", provider)
+			fmt.Fprintf(os.Stderr, "error: unsupported provider %q (expected claude-code, codex, or opencode)\n", provider)
 			os.Exit(1)
 		}
 	}

--- a/cmd/wuphf/onboarding.go
+++ b/cmd/wuphf/onboarding.go
@@ -687,7 +687,7 @@ func allRequiredPrereqsOk(prereqs []prereqResult) bool {
 func hasInstalledRuntimeCLI(prereqs []prereqResult) bool {
 	for _, p := range prereqs {
 		switch p.Name {
-		case "claude", "codex", "cursor", "windsurf":
+		case "claude", "codex", "opencode", "cursor", "windsurf":
 			if p.Found {
 				return true
 			}
@@ -740,6 +740,7 @@ func defaultPrereqs() []prereqResult {
 		{Name: "git", Required: true, Found: false, InstallURL: "https://git-scm.com"},
 		{Name: "claude", Required: false, Found: false, InstallURL: "https://claude.ai/code"},
 		{Name: "codex", Required: false, Found: false, InstallURL: "https://github.com/openai/codex"},
+		{Name: "opencode", Required: false, Found: false, InstallURL: "https://opencode.ai"},
 	}
 }
 

--- a/internal/commands/cmd_system.go
+++ b/internal/commands/cmd_system.go
@@ -123,6 +123,7 @@ func cmdProvider(ctx *SlashContext, args string) error {
 	options := []PickerOption{
 		{Label: "Codex CLI", Value: "codex", Description: "Codex via codex CLI"},
 		{Label: "Claude Code", Value: "claude-code", Description: "Claude via claude-code CLI"},
+		{Label: "Opencode CLI", Value: "opencode", Description: "Opencode via opencode CLI (BYO provider)"},
 	}
 	if ctx.ShowPicker != nil {
 		ctx.ShowPicker("Switch LLM Provider", options)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	WorkspaceSlug  string `json:"workspace_slug,omitempty"`
 	LLMProvider    string `json:"llm_provider,omitempty"`
 	// LLMProviderPriority is an ordered list of provider identifiers (same
-	// vocabulary as LLMProvider — "claude-code", "codex", etc.) that agents
+	// vocabulary as LLMProvider — "claude-code", "codex", "opencode", etc.) that agents
 	// should try in order when picking a runtime. LLMProvider remains the
 	// single-value primary choice; the priority list is consulted by agent
 	// creation and fallback flows. An empty slice means "fall back to
@@ -277,6 +277,8 @@ func normalizeLLMProvider(value string) string {
 		return "claude-code"
 	case "codex":
 		return "codex"
+	case "opencode":
+		return "opencode"
 	default:
 		return ""
 	}
@@ -353,6 +355,21 @@ func codexModelFromFile(path string) string {
 		}
 	}
 	return strings.TrimSpace(value)
+}
+
+// ResolveOpencodeModel returns the effective Opencode model for the current
+// run. Resolution: WUPHF_OPENCODE_MODEL env > OPENCODE_MODEL env > empty (Opencode
+// picks its configured default). Unlike Codex, Opencode has no on-disk config
+// file layout WUPHF needs to inspect — users configure their Opencode
+// ~/.config/opencode settings directly.
+func ResolveOpencodeModel(cwd string) string {
+	if v := strings.TrimSpace(os.Getenv("WUPHF_OPENCODE_MODEL")); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv("OPENCODE_MODEL")); v != "" {
+		return v
+	}
+	return ""
 }
 
 // ResolveAPIKey resolves the API key via: flag > WUPHF_API_KEY env > NEX_API_KEY env > config file.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -361,8 +361,8 @@ func codexModelFromFile(path string) string {
 // run. Resolution: WUPHF_OPENCODE_MODEL env > OPENCODE_MODEL env > empty (Opencode
 // picks its configured default). Unlike Codex, Opencode has no on-disk config
 // file layout WUPHF needs to inspect — users configure their Opencode
-// ~/.config/opencode settings directly.
-func ResolveOpencodeModel(cwd string) string {
+// ~/.config/opencode settings directly, so there is no cwd-relative search.
+func ResolveOpencodeModel() string {
 	if v := strings.TrimSpace(os.Getenv("WUPHF_OPENCODE_MODEL")); v != "" {
 		return v
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -459,7 +459,7 @@ func TestResolveLLMProviderOpencodeFromConfig(t *testing.T) {
 
 func TestResolveOpencodeModelEnvOverride(t *testing.T) {
 	t.Setenv("WUPHF_OPENCODE_MODEL", "qwen3.6:35b-a3b")
-	if got := ResolveOpencodeModel(""); got != "qwen3.6:35b-a3b" {
+	if got := ResolveOpencodeModel(); got != "qwen3.6:35b-a3b" {
 		t.Fatalf("expected WUPHF_OPENCODE_MODEL override, got %q", got)
 	}
 }
@@ -467,7 +467,7 @@ func TestResolveOpencodeModelEnvOverride(t *testing.T) {
 func TestResolveOpencodeModelFallsBackToOpencodeEnv(t *testing.T) {
 	t.Setenv("WUPHF_OPENCODE_MODEL", "")
 	t.Setenv("OPENCODE_MODEL", "llama3.3")
-	if got := ResolveOpencodeModel(""); got != "llama3.3" {
+	if got := ResolveOpencodeModel(); got != "llama3.3" {
 		t.Fatalf("expected OPENCODE_MODEL fallback, got %q", got)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -439,6 +439,39 @@ func TestResolveLLMProviderNormalizesUnsupportedConfig(t *testing.T) {
 	})
 }
 
+func TestResolveLLMProviderAcceptsOpencode(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		t.Setenv("WUPHF_LLM_PROVIDER", "opencode")
+		if got := ResolveLLMProvider(""); got != "opencode" {
+			t.Fatalf("expected opencode env override, got %q", got)
+		}
+	})
+}
+
+func TestResolveLLMProviderOpencodeFromConfig(t *testing.T) {
+	withTempConfig(t, func(_ string) {
+		_ = Save(Config{LLMProvider: "opencode"})
+		if got := ResolveLLMProvider(""); got != "opencode" {
+			t.Fatalf("expected opencode from config, got %q", got)
+		}
+	})
+}
+
+func TestResolveOpencodeModelEnvOverride(t *testing.T) {
+	t.Setenv("WUPHF_OPENCODE_MODEL", "qwen3.6:35b-a3b")
+	if got := ResolveOpencodeModel(""); got != "qwen3.6:35b-a3b" {
+		t.Fatalf("expected WUPHF_OPENCODE_MODEL override, got %q", got)
+	}
+}
+
+func TestResolveOpencodeModelFallsBackToOpencodeEnv(t *testing.T) {
+	t.Setenv("WUPHF_OPENCODE_MODEL", "")
+	t.Setenv("OPENCODE_MODEL", "llama3.3")
+	if got := ResolveOpencodeModel(""); got != "llama3.3" {
+		t.Fatalf("expected OPENCODE_MODEL fallback, got %q", got)
+	}
+}
+
 func TestResolveCodexModelUsesEnvOverride(t *testing.T) {
 	withTempConfig(t, func(_ string) {
 		t.Setenv("WUPHF_CODEX_MODEL", "gpt-5.4")

--- a/internal/onboarding/prereqs.go
+++ b/internal/onboarding/prereqs.go
@@ -37,17 +37,18 @@ var prereqSpecs = map[string]prereqSpec{
 	"git":      {required: true, installURL: "https://git-scm.com"},
 	"claude":   {required: false, installURL: "https://claude.ai/code"},
 	"codex":    {required: false, installURL: "https://github.com/openai/codex"},
+	"opencode": {required: false, installURL: "https://opencode.ai"},
 	"cursor":   {required: false, installURL: "https://cursor.com/"},
 	"windsurf": {required: false, installURL: "https://codeium.com/windsurf"},
 }
 
 // CheckAll returns a PrereqResult for each tracked binary in a stable order:
-// node, git, claude, codex, cursor, windsurf. At least one of the CLI
-// runtimes must be present for wuphf to actually run a turn, but all are
+// node, git, claude, codex, opencode, cursor, windsurf. At least one of the
+// CLI runtimes must be present for wuphf to actually run a turn, but all are
 // marked optional here so the user can proceed with whichever runtime
 // they have.
 func CheckAll() []PrereqResult {
-	names := []string{"node", "git", "claude", "codex", "cursor", "windsurf"}
+	names := []string{"node", "git", "claude", "codex", "opencode", "cursor", "windsurf"}
 	results := make([]PrereqResult, 0, len(names))
 	for _, name := range names {
 		results = append(results, CheckOne(name))

--- a/internal/onboarding/prereqs_test.go
+++ b/internal/onboarding/prereqs_test.go
@@ -34,12 +34,12 @@ func TestCheckOneNonexistentBinary(t *testing.T) {
 	}
 }
 
-func TestCheckAllReturnsSixItems(t *testing.T) {
+func TestCheckAllReturnsSevenItems(t *testing.T) {
 	results := CheckAll()
-	if len(results) != 6 {
-		t.Fatalf("CheckAll: got %d results, want 6", len(results))
+	if len(results) != 7 {
+		t.Fatalf("CheckAll: got %d results, want 7", len(results))
 	}
-	names := []string{"node", "git", "claude", "codex", "cursor", "windsurf"}
+	names := []string{"node", "git", "claude", "codex", "opencode", "cursor", "windsurf"}
 	for i, r := range results {
 		if r.Name != names[i] {
 			t.Errorf("CheckAll[%d].Name: got %q, want %q", i, r.Name, names[i])
@@ -49,12 +49,13 @@ func TestCheckAllReturnsSixItems(t *testing.T) {
 
 func TestCheckAllRequiredFlags(t *testing.T) {
 	// node and git are required (infrastructure).
-	// claude, codex, cursor, windsurf are optional — the user picks runtime CLIs.
+	// claude, codex, opencode, cursor, windsurf are optional — the user picks runtime CLIs.
 	wantRequired := map[string]bool{
 		"node":     true,
 		"git":      true,
 		"claude":   false,
 		"codex":    false,
+		"opencode": false,
 		"cursor":   false,
 		"windsurf": false,
 	}
@@ -75,6 +76,7 @@ func TestCheckAllInstallURLs(t *testing.T) {
 		"git":      "https://git-scm.com",
 		"claude":   "https://claude.ai/code",
 		"codex":    "https://github.com/openai/codex",
+		"opencode": "https://opencode.ai",
 		"cursor":   "https://cursor.com/",
 		"windsurf": "https://codeium.com/windsurf",
 	}

--- a/internal/provider/binding.go
+++ b/internal/provider/binding.go
@@ -8,6 +8,7 @@ import "fmt"
 const (
 	KindClaudeCode = "claude-code"
 	KindCodex      = "codex"
+	KindOpencode   = "opencode"
 	KindOpenclaw   = "openclaw"
 )
 
@@ -36,11 +37,11 @@ type OpenclawProviderBinding struct {
 // The empty string is valid and means "use install-wide default."
 func ValidateKind(s string) error {
 	switch s {
-	case "", KindClaudeCode, KindCodex, KindOpenclaw:
+	case "", KindClaudeCode, KindCodex, KindOpencode, KindOpenclaw:
 		return nil
 	default:
-		return fmt.Errorf("unknown provider kind %q (valid: %s, %s, %s, or empty)",
-			s, KindClaudeCode, KindCodex, KindOpenclaw)
+		return fmt.Errorf("unknown provider kind %q (valid: %s, %s, %s, %s, or empty)",
+			s, KindClaudeCode, KindCodex, KindOpencode, KindOpenclaw)
 	}
 }
 

--- a/internal/provider/binding_test.go
+++ b/internal/provider/binding_test.go
@@ -16,6 +16,7 @@ func TestValidateKind(t *testing.T) {
 		{"empty_allowed", "", false},
 		{"claude_code", "claude-code", false},
 		{"codex", "codex", false},
+		{"opencode", "opencode", false},
 		{"openclaw", "openclaw", false},
 		{"unknown", "gemini", true},
 		{"typo", "claud-code", true},

--- a/internal/provider/oneshot.go
+++ b/internal/provider/oneshot.go
@@ -10,6 +10,8 @@ func RunConfiguredOneShot(systemPrompt, prompt, cwd string) (string, error) {
 	switch config.ResolveLLMProvider("") {
 	case "codex":
 		return RunCodexOneShot(systemPrompt, prompt, cwd)
+	case "opencode":
+		return RunOpencodeOneShot(systemPrompt, prompt, cwd)
 	default:
 		return RunClaudeOneShot(systemPrompt, prompt, cwd)
 	}

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -1,0 +1,215 @@
+package provider
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+var (
+	opencodeLookPath = exec.LookPath
+	opencodeCommand  = exec.Command
+	opencodeGetwd    = os.Getwd
+)
+
+// CreateOpencodeCLIStreamFn returns a StreamFn that runs the Opencode CLI
+// non-interactively. Each invocation is ephemeral: WUPHF owns the conversation
+// history and hands Opencode a fresh prompt every turn.
+//
+// Opencode emits plain text on stdout (no JSONL surface), so we stream stdout
+// line-by-line as text chunks rather than parsing structured events.
+func CreateOpencodeCLIStreamFn(agentSlug string) agent.StreamFn {
+	return func(msgs []agent.Message, tools []agent.AgentTool) <-chan agent.StreamChunk {
+		ch := make(chan agent.StreamChunk, 64)
+		go func() {
+			defer close(ch)
+
+			if _, err := opencodeLookPath("opencode"); err != nil {
+				ch <- agent.StreamChunk{Type: "error", Content: "Opencode CLI not found. Install opencode or use /provider to choose a different provider."}
+				return
+			}
+
+			cwd, err := opencodeGetwd()
+			if err != nil {
+				ch <- agent.StreamChunk{Type: "error", Content: fmt.Sprintf("resolve working directory: %v", err)}
+				return
+			}
+
+			systemPrompt, prompt := buildClaudePrompts(msgs)
+			if prompt == "" {
+				prompt = "Proceed with the task."
+			}
+
+			startedAt := time.Now()
+			var firstEventAt time.Time
+			var firstTextAt time.Time
+			text, err := runOpencodeOnce(systemPrompt, prompt, cwd, func(line string) {
+				if firstEventAt.IsZero() {
+					firstEventAt = time.Now()
+				}
+				if strings.TrimSpace(line) == "" {
+					return
+				}
+				if firstTextAt.IsZero() {
+					firstTextAt = time.Now()
+				}
+				ch <- agent.StreamChunk{Type: "text", Content: line}
+			})
+			if err != nil {
+				appendOpencodeLatencyLog(agentSlug, fmt.Sprintf("status=error total_ms=%d first_event_ms=%d first_text_ms=%d detail=%q",
+					time.Since(startedAt).Milliseconds(),
+					durationMillis(startedAt, firstEventAt),
+					durationMillis(startedAt, firstTextAt),
+					err.Error(),
+				))
+				ch <- agent.StreamChunk{Type: "error", Content: describeOpencodeFailure(err)}
+				return
+			}
+			appendOpencodeLatencyLog(agentSlug, fmt.Sprintf("status=ok total_ms=%d first_event_ms=%d first_text_ms=%d final_chars=%d",
+				time.Since(startedAt).Milliseconds(),
+				durationMillis(startedAt, firstEventAt),
+				durationMillis(startedAt, firstTextAt),
+				len(text),
+			))
+			if firstTextAt.IsZero() && strings.TrimSpace(text) != "" {
+				streamTextChunks(ch, text)
+			}
+		}()
+		return ch
+	}
+}
+
+// RunOpencodeOneShot runs Opencode once with the given system prompt and user
+// prompt and returns the final plain-text result.
+func RunOpencodeOneShot(systemPrompt, prompt, cwd string) (string, error) {
+	if cwd == "" {
+		var err error
+		cwd, err = opencodeGetwd()
+		if err != nil {
+			return "", err
+		}
+	}
+	return runOpencodeOnce(systemPrompt, prompt, cwd, nil)
+}
+
+// runOpencodeOnce invokes `opencode run` with the caller's prompt on stdin,
+// streams plain stdout lines via onLine (if provided), and returns the full
+// concatenated output.
+func runOpencodeOnce(systemPrompt, prompt, cwd string, onLine func(string)) (string, error) {
+	args := buildOpencodeArgs(cwd, config.ResolveOpencodeModel(cwd))
+	cmd := opencodeCommand("opencode", args...)
+	cmd.Dir = cwd
+	cmd.Env = filteredEnv(nil)
+	cmd.Stdin = strings.NewReader(buildOpencodePrompt(systemPrompt, prompt))
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("attach opencode stdout: %w", err)
+	}
+
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return "", err
+	}
+
+	output, readErr := readOpencodeStream(stdout, onLine)
+	if err := cmd.Wait(); err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if detail != "" {
+			return "", fmt.Errorf("%w: %s", err, detail)
+		}
+		return "", err
+	}
+	if readErr != nil {
+		return "", readErr
+	}
+	text := strings.TrimSpace(output)
+	if text == "" {
+		return "", fmt.Errorf("opencode returned no output")
+	}
+	return text, nil
+}
+
+// readOpencodeStream reads plain-text lines from r, forwarding each line to
+// onLine as it arrives, and returns the combined output.
+func readOpencodeStream(r io.Reader, onLine func(string)) (string, error) {
+	var sb strings.Builder
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if sb.Len() > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString(line)
+		if onLine != nil {
+			onLine(line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return sb.String(), fmt.Errorf("read opencode stream: %w", err)
+	}
+	return sb.String(), nil
+}
+
+// buildOpencodeArgs constructs the argv for a single-shot `opencode run`.
+// The prompt is fed on stdin via `-`. Model selection is optional; when unset
+// Opencode uses its configured default.
+func buildOpencodeArgs(cwd string, model string) []string {
+	args := []string{"run"}
+	if strings.TrimSpace(model) != "" {
+		args = append(args, "--model", strings.TrimSpace(model))
+	}
+	if strings.TrimSpace(cwd) != "" {
+		args = append(args, "--cwd", strings.TrimSpace(cwd))
+	}
+	args = append(args, "--quiet", "-")
+	return args
+}
+
+func buildOpencodePrompt(systemPrompt, prompt string) string {
+	var parts []string
+	if strings.TrimSpace(systemPrompt) != "" {
+		parts = append(parts, "<system>\n"+strings.TrimSpace(systemPrompt)+"\n</system>")
+	}
+	if strings.TrimSpace(prompt) != "" {
+		parts = append(parts, strings.TrimSpace(prompt))
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+func describeOpencodeFailure(err error) string {
+	text := strings.ToLower(strings.TrimSpace(err.Error()))
+	if strings.Contains(text, "login") || strings.Contains(text, "auth") || strings.Contains(text, "unauthorized") || strings.Contains(text, "api key") {
+		return "Opencode CLI is not authenticated. Configure your Opencode provider credentials or use /provider to choose a different provider."
+	}
+	return fmt.Sprintf("opencode exited with error: %v", err)
+}
+
+func appendOpencodeLatencyLog(agentSlug string, line string) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return
+	}
+	logDir := filepath.Join(home, ".wuphf", "logs")
+	if err := os.MkdirAll(logDir, 0o700); err != nil {
+		return
+	}
+	path := filepath.Join(logDir, "opencode-latency.log")
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "[%s] agent=%s %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(agentSlug), strings.TrimSpace(line))
+}

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -100,15 +100,18 @@ func RunOpencodeOneShot(systemPrompt, prompt, cwd string) (string, error) {
 	return runOpencodeOnce(systemPrompt, prompt, cwd, nil)
 }
 
-// runOpencodeOnce invokes `opencode run` with the caller's prompt on stdin,
+// runOpencodeOnce invokes `opencode run` with the caller's prompt as the final
+// variadic positional argument (Opencode has no stdin-prompt convention),
 // streams plain stdout lines via onLine (if provided), and returns the full
 // concatenated output.
 func runOpencodeOnce(systemPrompt, prompt, cwd string, onLine func(string)) (string, error) {
-	args := buildOpencodeArgs(cwd, config.ResolveOpencodeModel(cwd))
+	promptText := buildOpencodePrompt(systemPrompt, prompt)
+	args := buildOpencodeArgs(config.ResolveOpencodeModel(cwd), promptText)
 	cmd := opencodeCommand("opencode", args...)
 	cmd.Dir = cwd
-	cmd.Env = filteredEnv(nil)
-	cmd.Stdin = strings.NewReader(buildOpencodePrompt(systemPrompt, prompt))
+	// NO_COLOR suppresses ANSI decoration in Opencode's default formatted
+	// output so downstream line scanners see clean text.
+	cmd.Env = append(filteredEnv(nil), "NO_COLOR=1")
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -163,17 +166,20 @@ func readOpencodeStream(r io.Reader, onLine func(string)) (string, error) {
 }
 
 // buildOpencodeArgs constructs the argv for a single-shot `opencode run`.
-// The prompt is fed on stdin via `-`. Model selection is optional; when unset
-// Opencode uses its configured default.
-func buildOpencodeArgs(cwd string, model string) []string {
+// Opencode's CLI takes the prompt as trailing variadic positional arguments
+// (`opencode run [message..]`) rather than via stdin, so we pass the full
+// composed prompt as a single argv string. Working directory is set via
+// cmd.Dir by the caller — Opencode exposes no `--cwd` flag.
+// Model selection is optional; when unset Opencode uses its configured
+// default. Expected format: `provider/model` (e.g. "anthropic/claude-sonnet-4").
+func buildOpencodeArgs(model string, prompt string) []string {
 	args := []string{"run"}
 	if strings.TrimSpace(model) != "" {
 		args = append(args, "--model", strings.TrimSpace(model))
 	}
-	if strings.TrimSpace(cwd) != "" {
-		args = append(args, "--cwd", strings.TrimSpace(cwd))
+	if strings.TrimSpace(prompt) != "" {
+		args = append(args, prompt)
 	}
-	args = append(args, "--quiet", "-")
 	return args
 }
 

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -106,7 +107,7 @@ func RunOpencodeOneShot(systemPrompt, prompt, cwd string) (string, error) {
 // concatenated output.
 func runOpencodeOnce(systemPrompt, prompt, cwd string, onLine func(string)) (string, error) {
 	promptText := buildOpencodePrompt(systemPrompt, prompt)
-	args := buildOpencodeArgs(config.ResolveOpencodeModel(cwd), promptText)
+	args := buildOpencodeArgs(config.ResolveOpencodeModel(), promptText)
 	cmd := opencodeCommand("opencode", args...)
 	cmd.Dir = cwd
 	// NO_COLOR suppresses ANSI decoration in Opencode's default formatted
@@ -126,6 +127,12 @@ func runOpencodeOnce(systemPrompt, prompt, cwd string, onLine func(string)) (str
 	}
 
 	output, readErr := readOpencodeStream(stdout, onLine)
+	if readErr != nil && errors.Is(readErr, bufio.ErrTooLong) {
+		// A single >4 MiB line would block cmd.Wait() on pipe backpressure
+		// forever; kill the child so Wait returns and the caller sees a
+		// clean error.
+		_ = cmd.Process.Kill()
+	}
 	if err := cmd.Wait(); err != nil {
 		detail := strings.TrimSpace(stderr.String())
 		if detail != "" {
@@ -160,6 +167,9 @@ func readOpencodeStream(r io.Reader, onLine func(string)) (string, error) {
 		}
 	}
 	if err := scanner.Err(); err != nil {
+		if errors.Is(err, bufio.ErrTooLong) {
+			return sb.String(), fmt.Errorf("opencode output line exceeded 4 MiB buffer: %w", err)
+		}
 		return sb.String(), fmt.Errorf("read opencode stream: %w", err)
 	}
 	return sb.String(), nil
@@ -183,21 +193,38 @@ func buildOpencodeArgs(model string, prompt string) []string {
 	return args
 }
 
+// buildOpencodePrompt concatenates system and user text for delivery as a
+// single positional argument to `opencode run`. Any literal <system>/</system>
+// tokens inside user content are neutralised with a zero-width space so the
+// wrapper the builder adds cannot be closed or re-opened from within — belt
+// and suspenders for confused-deputy issues when untrusted text is passed in.
 func buildOpencodePrompt(systemPrompt, prompt string) string {
 	var parts []string
-	if strings.TrimSpace(systemPrompt) != "" {
-		parts = append(parts, "<system>\n"+strings.TrimSpace(systemPrompt)+"\n</system>")
+	if s := strings.TrimSpace(systemPrompt); s != "" {
+		parts = append(parts, "<system>\n"+escapeOpencodeSystemWrapper(s)+"\n</system>")
 	}
-	if strings.TrimSpace(prompt) != "" {
-		parts = append(parts, strings.TrimSpace(prompt))
+	if p := strings.TrimSpace(prompt); p != "" {
+		parts = append(parts, escapeOpencodeSystemWrapper(p))
 	}
 	return strings.Join(parts, "\n\n")
+}
+
+// escapeOpencodeSystemWrapper inserts a zero-width space inside any literal
+// <system>/</system> tag so the prompt wrapper buildOpencodePrompt adds cannot
+// be terminated from within user content.
+func escapeOpencodeSystemWrapper(s string) string {
+	s = strings.ReplaceAll(s, "</system>", "</​system>")
+	s = strings.ReplaceAll(s, "<system>", "<​system>")
+	return s
 }
 
 func describeOpencodeFailure(err error) string {
 	text := strings.ToLower(strings.TrimSpace(err.Error()))
 	if strings.Contains(text, "login") || strings.Contains(text, "auth") || strings.Contains(text, "unauthorized") || strings.Contains(text, "api key") {
 		return "Opencode CLI is not authenticated. Configure your Opencode provider credentials or use /provider to choose a different provider."
+	}
+	if strings.Contains(text, "exceeded 4 mib") {
+		return "Opencode produced a stream line larger than 4 MiB; aborted. Retry with a smaller response."
 	}
 	return fmt.Sprintf("opencode exited with error: %v", err)
 }

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -213,8 +213,8 @@ func buildOpencodePrompt(systemPrompt, prompt string) string {
 // <system>/</system> tag so the prompt wrapper buildOpencodePrompt adds cannot
 // be terminated from within user content.
 func escapeOpencodeSystemWrapper(s string) string {
-	s = strings.ReplaceAll(s, "</system>", "</​system>")
-	s = strings.ReplaceAll(s, "<system>", "<​system>")
+	s = strings.ReplaceAll(s, "</system>", "</\u200bsystem>")
+	s = strings.ReplaceAll(s, "<system>", "<\u200bsystem>")
 	return s
 }
 

--- a/internal/provider/opencode_test.go
+++ b/internal/provider/opencode_test.go
@@ -1,0 +1,208 @@
+package provider
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+)
+
+type opencodeHelperRecord struct {
+	Args  []string `json:"args"`
+	Stdin string   `json:"stdin"`
+}
+
+func TestBuildOpencodeArgsIncludesRunAndQuietAndStdin(t *testing.T) {
+	args := buildOpencodeArgs("/tmp/work", "qwen3.6:35b-a3b")
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "run") {
+		t.Fatalf("expected `run` subcommand, got %q", joined)
+	}
+	if !strings.Contains(joined, "--cwd /tmp/work") {
+		t.Fatalf("expected working directory, got %q", joined)
+	}
+	if !strings.Contains(joined, "--quiet") {
+		t.Fatalf("expected quiet flag, got %q", joined)
+	}
+	if !strings.Contains(joined, "--model qwen3.6:35b-a3b") {
+		t.Fatalf("expected explicit model flag, got %q", joined)
+	}
+	if args[len(args)-1] != "-" {
+		t.Fatalf("expected prompt to be read from stdin (last arg `-`), got %q", args[len(args)-1])
+	}
+}
+
+func TestBuildOpencodeArgsOmitsModelWhenUnset(t *testing.T) {
+	args := buildOpencodeArgs("/tmp/work", "")
+	for _, a := range args {
+		if a == "--model" {
+			t.Fatalf("did not expect --model flag when model empty, got %v", args)
+		}
+	}
+}
+
+func TestBuildOpencodePromptWrapsSystem(t *testing.T) {
+	got := buildOpencodePrompt("sys instructions", "do the thing")
+	if !strings.Contains(got, "<system>") {
+		t.Fatalf("expected system wrapper, got %q", got)
+	}
+	if !strings.Contains(got, "do the thing") {
+		t.Fatalf("expected user prompt, got %q", got)
+	}
+}
+
+func TestReadOpencodeStreamConcatenatesLines(t *testing.T) {
+	var received []string
+	out, err := readOpencodeStream(bytes.NewBufferString("line one\nline two\n"), func(s string) {
+		received = append(received, s)
+	})
+	if err != nil {
+		t.Fatalf("readOpencodeStream: %v", err)
+	}
+	if out != "line one\nline two" {
+		t.Fatalf("unexpected concatenated output: %q", out)
+	}
+	if len(received) != 2 || received[0] != "line one" || received[1] != "line two" {
+		t.Fatalf("expected onLine called per line, got %v", received)
+	}
+}
+
+func TestCreateOpencodeCLIStreamFnStreamsPlainText(t *testing.T) {
+	recordFile := t.TempDir() + "/opencode-record.jsonl"
+	cwd := t.TempDir()
+
+	restore := stubOpencodeRuntime(t, recordFile, "success", cwd)
+	defer restore()
+
+	fn := CreateOpencodeCLIStreamFn("ceo")
+	chunks := collectStreamChunks(fn([]agent.Message{
+		{Role: "system", Content: "You are the CEO."},
+		{Role: "user", Content: "Ship it."},
+	}, nil))
+
+	text := joinedChunkText(chunks)
+	if !strings.Contains(text, "shipped") {
+		t.Fatalf("expected streamed plaintext reply, got %q", text)
+	}
+
+	records := readOpencodeHelperRecords(t, recordFile)
+	if len(records) != 1 {
+		t.Fatalf("expected 1 opencode invocation, got %d", len(records))
+	}
+	if !containsArgPair(records[0].Args, "--cwd", cwd) {
+		t.Fatalf("expected opencode cwd arg, got %#v", records[0].Args)
+	}
+	if !strings.Contains(records[0].Stdin, "<system>") {
+		t.Fatalf("expected system prompt wrapper in stdin, got %q", records[0].Stdin)
+	}
+}
+
+func TestCreateOpencodeCLIStreamFnSurfacesMissingBinaryError(t *testing.T) {
+	oldLookPath := opencodeLookPath
+	opencodeLookPath = func(string) (string, error) { return "", exec.ErrNotFound }
+	defer func() { opencodeLookPath = oldLookPath }()
+
+	fn := CreateOpencodeCLIStreamFn("ceo")
+	chunks := collectStreamChunks(fn([]agent.Message{{Role: "user", Content: "hi"}}, nil))
+	if !hasErrorChunkContaining(chunks, "Opencode CLI not found") {
+		t.Fatalf("expected missing binary error, got %#v", chunks)
+	}
+}
+
+func readOpencodeHelperRecords(t *testing.T, path string) []opencodeHelperRecord {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read record file: %v", err)
+	}
+	var records []opencodeHelperRecord
+	for _, line := range strings.Split(strings.TrimSpace(string(raw)), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var record opencodeHelperRecord
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Fatalf("unmarshal helper record: %v", err)
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+func stubOpencodeRuntime(t *testing.T, recordFile string, scenario string, cwd string) func() {
+	t.Helper()
+
+	oldLookPath := opencodeLookPath
+	oldCommand := opencodeCommand
+	oldGetwd := opencodeGetwd
+	t.Setenv("GO_WANT_OPENCODE_HELPER_PROCESS", "1")
+	t.Setenv("OPENCODE_TEST_RECORD_FILE", recordFile)
+	t.Setenv("OPENCODE_TEST_SCENARIO", scenario)
+	t.Setenv("HOME", t.TempDir())
+
+	opencodeLookPath = func(file string) (string, error) {
+		return "/usr/bin/opencode", nil
+	}
+	opencodeGetwd = func() (string, error) {
+		return cwd, nil
+	}
+	opencodeCommand = func(name string, args ...string) *exec.Cmd {
+		cmdArgs := []string{"-test.run=TestOpencodeHelperProcess", "--"}
+		cmdArgs = append(cmdArgs, args...)
+		return exec.Command(os.Args[0], cmdArgs...)
+	}
+
+	return func() {
+		opencodeLookPath = oldLookPath
+		opencodeCommand = oldCommand
+		opencodeGetwd = oldGetwd
+	}
+}
+
+func TestOpencodeHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_OPENCODE_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	args := os.Args
+	doubleDash := 0
+	for i, arg := range args {
+		if arg == "--" {
+			doubleDash = i
+			break
+		}
+	}
+	opencodeArgs := append([]string(nil), args[doubleDash+1:]...)
+	stdin, _ := io.ReadAll(os.Stdin)
+
+	recordPath := os.Getenv("OPENCODE_TEST_RECORD_FILE")
+	record, _ := json.Marshal(opencodeHelperRecord{Args: opencodeArgs, Stdin: string(stdin)})
+	file, err := os.OpenFile(recordPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("open helper record file: %v", err)
+	}
+	if _, err := file.Write(append(record, '\n')); err != nil {
+		t.Fatalf("write helper record: %v", err)
+	}
+	file.Close()
+
+	if !containsArg(opencodeArgs, "--quiet") {
+		t.Fatalf("missing --quiet arg: %#v", opencodeArgs)
+	}
+
+	switch os.Getenv("OPENCODE_TEST_SCENARIO") {
+	case "success":
+		_, _ = os.Stdout.WriteString("shipped the update\n")
+		os.Exit(0)
+	case "auth-error":
+		_, _ = os.Stderr.WriteString("error: unauthorized\n")
+		os.Exit(1)
+	default:
+		t.Fatalf("unknown helper scenario: %s", os.Getenv("OPENCODE_TEST_SCENARIO"))
+	}
+}

--- a/internal/provider/opencode_test.go
+++ b/internal/provider/opencode_test.go
@@ -17,32 +17,40 @@ type opencodeHelperRecord struct {
 	Stdin string   `json:"stdin"`
 }
 
-func TestBuildOpencodeArgsIncludesRunAndQuietAndStdin(t *testing.T) {
-	args := buildOpencodeArgs("/tmp/work", "qwen3.6:35b-a3b")
+func TestBuildOpencodeArgsPassesPromptAsFinalArgAndModel(t *testing.T) {
+	args := buildOpencodeArgs("anthropic/claude-sonnet-4", "ship the thing")
+	if len(args) == 0 || args[0] != "run" {
+		t.Fatalf("expected `run` as first arg, got %v", args)
+	}
 	joined := strings.Join(args, " ")
-	if !strings.Contains(joined, "run") {
-		t.Fatalf("expected `run` subcommand, got %q", joined)
-	}
-	if !strings.Contains(joined, "--cwd /tmp/work") {
-		t.Fatalf("expected working directory, got %q", joined)
-	}
-	if !strings.Contains(joined, "--quiet") {
-		t.Fatalf("expected quiet flag, got %q", joined)
-	}
-	if !strings.Contains(joined, "--model qwen3.6:35b-a3b") {
+	if !strings.Contains(joined, "--model anthropic/claude-sonnet-4") {
 		t.Fatalf("expected explicit model flag, got %q", joined)
 	}
-	if args[len(args)-1] != "-" {
-		t.Fatalf("expected prompt to be read from stdin (last arg `-`), got %q", args[len(args)-1])
+	// Opencode's CLI has no --cwd/--quiet/- flags; working dir comes from cmd.Dir.
+	for _, a := range args {
+		if a == "--cwd" || a == "--quiet" || a == "-" {
+			t.Fatalf("unexpected flag %q: Opencode CLI does not accept it; got %v", a, args)
+		}
+	}
+	if args[len(args)-1] != "ship the thing" {
+		t.Fatalf("expected prompt as final variadic arg, got %q", args[len(args)-1])
 	}
 }
 
 func TestBuildOpencodeArgsOmitsModelWhenUnset(t *testing.T) {
-	args := buildOpencodeArgs("/tmp/work", "")
+	args := buildOpencodeArgs("", "do the thing")
 	for _, a := range args {
 		if a == "--model" {
 			t.Fatalf("did not expect --model flag when model empty, got %v", args)
 		}
+	}
+}
+
+func TestBuildOpencodeArgsOmitsPromptWhenEmpty(t *testing.T) {
+	args := buildOpencodeArgs("anthropic/claude-sonnet-4", "")
+	// With no prompt, only `run` + `--model X` should be present.
+	if len(args) != 3 {
+		t.Fatalf("expected [run --model X], got %v", args)
 	}
 }
 
@@ -94,11 +102,16 @@ func TestCreateOpencodeCLIStreamFnStreamsPlainText(t *testing.T) {
 	if len(records) != 1 {
 		t.Fatalf("expected 1 opencode invocation, got %d", len(records))
 	}
-	if !containsArgPair(records[0].Args, "--cwd", cwd) {
-		t.Fatalf("expected opencode cwd arg, got %#v", records[0].Args)
+	// Prompt is passed as the final variadic positional arg (not stdin).
+	lastArg := records[0].Args[len(records[0].Args)-1]
+	if !strings.Contains(lastArg, "<system>") || !strings.Contains(lastArg, "Ship it.") {
+		t.Fatalf("expected composed prompt as final argv arg, got %q", lastArg)
 	}
-	if !strings.Contains(records[0].Stdin, "<system>") {
-		t.Fatalf("expected system prompt wrapper in stdin, got %q", records[0].Stdin)
+	// cwd is conveyed via cmd.Dir, not a CLI flag — confirm no stale --cwd.
+	for _, a := range records[0].Args {
+		if a == "--cwd" {
+			t.Fatalf("Opencode CLI does not accept --cwd; got %#v", records[0].Args)
+		}
 	}
 }
 
@@ -191,8 +204,8 @@ func TestOpencodeHelperProcess(t *testing.T) {
 	}
 	file.Close()
 
-	if !containsArg(opencodeArgs, "--quiet") {
-		t.Fatalf("missing --quiet arg: %#v", opencodeArgs)
+	if !containsArg(opencodeArgs, "run") {
+		t.Fatalf("missing `run` subcommand: %#v", opencodeArgs)
 	}
 
 	switch os.Getenv("OPENCODE_TEST_SCENARIO") {

--- a/internal/provider/resolver.go
+++ b/internal/provider/resolver.go
@@ -14,6 +14,8 @@ func DefaultStreamFnResolver(client *api.Client) agent.StreamFnResolver {
 		switch config.ResolveLLMProvider("") {
 		case "codex":
 			return CreateCodexCLIStreamFn(agentSlug)
+		case "opencode":
+			return CreateOpencodeCLIStreamFn(agentSlug)
 		case "claude-code", "":
 			// Default to Claude Code — most capable for multi-turn orchestration
 			return CreateClaudeCodeStreamFn(agentSlug)

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -60,7 +60,10 @@ const agentRateLimitHeader = "X-WUPHF-Agent"
 
 var brokerStatePath = defaultBrokerStatePath
 
-var studioPackageGenerator = provider.RunCodexOneShot
+// studioPackageGenerator routes Studio package generation through the
+// install-wide LLM provider so opencode-only or claude-code-only setups
+// aren't forced to have `codex` installed.
+var studioPackageGenerator = provider.RunConfiguredOneShot
 
 var externalRetryAfterPattern = regexp.MustCompile(`(?i)retry after ([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)`)
 
@@ -5595,7 +5598,7 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 		if body.LLMProvider != nil {
 			provider = strings.TrimSpace(strings.ToLower(*body.LLMProvider))
 			switch provider {
-			case "claude-code", "codex":
+			case "claude-code", "codex", "opencode":
 				// ok
 			default:
 				http.Error(w, "unsupported llm_provider", http.StatusBadRequest)
@@ -5614,7 +5617,7 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				switch id {
-				case "claude-code", "codex":
+				case "claude-code", "codex", "opencode":
 					// ok
 				default:
 					http.Error(w, "unsupported entry in llm_provider_priority: "+id, http.StatusBadRequest)

--- a/internal/team/capabilities.go
+++ b/internal/team/capabilities.go
@@ -47,6 +47,7 @@ type TmuxCapability struct {
 type RuntimeCapabilities struct {
 	Tmux     TmuxCapability
 	Codex    CapabilityStatus
+	Opencode CapabilityStatus
 	Items    []CapabilityStatus
 	Registry CapabilityRegistry
 }
@@ -64,7 +65,8 @@ func DetectRuntimeCapabilitiesWithOptions(opts CapabilityProbeOptions) RuntimeCa
 	tmuxStatus, tmux := probeTmuxCapability()
 	claudeStatus := probeBinaryCapability("claude", "Install claude so WUPHF can start teammate runtime sessions.")
 	codexStatus := probeBinaryCapability("codex", "Install Codex CLI and run `codex login` so WUPHF can start the headless Codex office runtime.")
-	registry := buildCapabilityRegistry(config.ResolveLLMProvider(""), tmuxStatus, claudeStatus, codexStatus, opts)
+	opencodeStatus := probeBinaryCapability("opencode", "Install Opencode CLI (https://opencode.ai) and configure your provider credentials so WUPHF can start the headless Opencode office runtime.")
+	registry := buildCapabilityRegistry(config.ResolveLLMProvider(""), tmuxStatus, claudeStatus, codexStatus, opencodeStatus, opts)
 	summaryKeys := []string{
 		CapabilityKeyOfficeRuntime,
 		CapabilityKeyDirectRuntime,
@@ -80,6 +82,7 @@ func DetectRuntimeCapabilitiesWithOptions(opts CapabilityProbeOptions) RuntimeCa
 	return RuntimeCapabilities{
 		Tmux:     tmux,
 		Codex:    codexStatus,
+		Opencode: opencodeStatus,
 		Items:    registry.SummaryStatuses(summaryKeys...),
 		Registry: registry,
 	}

--- a/internal/team/capability_registry.go
+++ b/internal/team/capability_registry.go
@@ -36,6 +36,7 @@ const (
 	CapabilityKeyTmux          = "tmux"
 	CapabilityKeyClaude        = "claude"
 	CapabilityKeyCodex         = "codex"
+	CapabilityKeyOpencode      = "opencode"
 	CapabilityKeyOfficeRuntime = "office_runtime"
 	CapabilityKeyDirectRuntime = "direct_runtime"
 	CapabilityKeyMemory        = "memory"
@@ -120,16 +121,17 @@ func BuildCapabilityRegistry(runtime RuntimeCapabilities) CapabilityRegistry {
 	if len(runtime.Registry.Entries) > 0 {
 		return runtime.Registry
 	}
-	return buildCapabilityRegistry(config.ResolveLLMProvider(""), runtimeCapabilityStatus(runtime, "tmux"), runtimeCapabilityStatus(runtime, "claude"), runtimeCapabilityStatus(runtime, "codex"), CapabilityProbeOptions{})
+	return buildCapabilityRegistry(config.ResolveLLMProvider(""), runtimeCapabilityStatus(runtime, "tmux"), runtimeCapabilityStatus(runtime, "claude"), runtimeCapabilityStatus(runtime, "codex"), runtimeCapabilityStatus(runtime, "opencode"), CapabilityProbeOptions{})
 }
 
-func buildCapabilityRegistry(providerName string, tmuxStatus, claudeStatus, codexStatus CapabilityStatus, opts CapabilityProbeOptions) CapabilityRegistry {
+func buildCapabilityRegistry(providerName string, tmuxStatus, claudeStatus, codexStatus, opencodeStatus CapabilityStatus, opts CapabilityProbeOptions) CapabilityRegistry {
 	entries := []CapabilityDescriptor{
-		buildOfficeRuntimeDescriptor(providerName, tmuxStatus, claudeStatus, codexStatus),
-		buildDirectRuntimeDescriptor(providerName, claudeStatus, codexStatus),
+		buildOfficeRuntimeDescriptor(providerName, tmuxStatus, claudeStatus, codexStatus, opencodeStatus),
+		buildDirectRuntimeDescriptor(providerName, claudeStatus, codexStatus, opencodeStatus),
 		descriptorFromStatus(CapabilityKeyTmux, "tmux", CapabilityCategoryRuntime, tmuxStatus),
 		descriptorFromStatus(CapabilityKeyClaude, "claude", CapabilityCategoryRuntime, claudeStatus),
 		descriptorFromStatus(CapabilityKeyCodex, "codex", CapabilityCategoryRuntime, codexStatus),
+		descriptorFromStatus(CapabilityKeyOpencode, "opencode", CapabilityCategoryRuntime, opencodeStatus),
 		buildMemoryDescriptor(),
 		buildActionCapabilityDescriptor(CapabilityKeyActions, "Action execution", CapabilityCategoryAction, action.CapabilityActionExecute),
 		buildActionCapabilityDescriptor(CapabilityKeyWorkflows, "Workflow execution", CapabilityCategoryWorkflow, action.CapabilityWorkflowExecute),
@@ -157,8 +159,9 @@ func RegistryKeyForActionCapability(cap action.Capability) string {
 	}
 }
 
-func buildOfficeRuntimeDescriptor(providerName string, tmuxStatus, claudeStatus, codexStatus CapabilityStatus) CapabilityDescriptor {
-	if strings.EqualFold(strings.TrimSpace(providerName), "codex") {
+func buildOfficeRuntimeDescriptor(providerName string, tmuxStatus, claudeStatus, codexStatus, opencodeStatus CapabilityStatus) CapabilityDescriptor {
+	switch strings.ToLower(strings.TrimSpace(providerName)) {
+	case "codex":
 		level := codexStatus.Level
 		lifecycle := CapabilityLifecycleReady
 		if level != CapabilityReady {
@@ -172,6 +175,21 @@ func buildOfficeRuntimeDescriptor(providerName string, tmuxStatus, claudeStatus,
 			Lifecycle: lifecycle,
 			Detail:    codexStatus.Detail,
 			NextStep:  codexStatus.NextStep,
+		}
+	case "opencode":
+		level := opencodeStatus.Level
+		lifecycle := CapabilityLifecycleReady
+		if level != CapabilityReady {
+			lifecycle = CapabilityLifecycleNeedsSetup
+		}
+		return CapabilityDescriptor{
+			Key:       CapabilityKeyOfficeRuntime,
+			Label:     "Office runtime",
+			Category:  CapabilityCategoryOffice,
+			Level:     level,
+			Lifecycle: lifecycle,
+			Detail:    opencodeStatus.Detail,
+			NextStep:  opencodeStatus.NextStep,
 		}
 	}
 	level := CapabilityReady
@@ -193,10 +211,13 @@ func buildOfficeRuntimeDescriptor(providerName string, tmuxStatus, claudeStatus,
 	}
 }
 
-func buildDirectRuntimeDescriptor(providerName string, claudeStatus, codexStatus CapabilityStatus) CapabilityDescriptor {
+func buildDirectRuntimeDescriptor(providerName string, claudeStatus, codexStatus, opencodeStatus CapabilityStatus) CapabilityDescriptor {
 	status := claudeStatus
-	if strings.EqualFold(strings.TrimSpace(providerName), "codex") {
+	switch strings.ToLower(strings.TrimSpace(providerName)) {
+	case "codex":
 		status = codexStatus
+	case "opencode":
+		status = opencodeStatus
 	}
 	level := status.Level
 	lifecycle := CapabilityLifecycleReady
@@ -399,6 +420,13 @@ func runtimeCapabilityStatus(runtime RuntimeCapabilities, name string) Capabilit
 		status := runtime.Codex
 		if strings.TrimSpace(status.Name) == "" {
 			status.Name = "codex"
+		}
+		return status
+	}
+	if name == "opencode" && strings.TrimSpace(runtime.Opencode.Name) != "" {
+		status := runtime.Opencode
+		if strings.TrimSpace(status.Name) == "" {
+			status.Name = "opencode"
 		}
 		return status
 	}

--- a/internal/team/config_endpoint_test.go
+++ b/internal/team/config_endpoint_test.go
@@ -130,6 +130,22 @@ func TestConfigEndpointAndHealth(t *testing.T) {
 		t.Fatalf("POST /config {llm_provider:opencode} status=%d body=%s", resp.StatusCode, string(raw))
 	}
 
+	// The `llm_provider_priority` allowlist had the same bug as `llm_provider`
+	// (broker.go:5617) — regression test so both switches stay in sync.
+	body = bytes.NewBufferString(`{"llm_provider_priority":["opencode","claude-code"]}`)
+	req, _ = http.NewRequest(http.MethodPost, "http://"+b.addr+"/config", body)
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /config priority: %v", err)
+	}
+	rawPriority, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("POST /config {llm_provider_priority:[opencode,...]} status=%d body=%s", resp.StatusCode, string(rawPriority))
+	}
+
 	// Reject unsupported provider
 	body = bytes.NewBufferString(`{"llm_provider":"anthropic"}`)
 	req, _ = http.NewRequest(http.MethodPost, "http://"+b.addr+"/config", body)

--- a/internal/team/config_endpoint_test.go
+++ b/internal/team/config_endpoint_test.go
@@ -112,6 +112,24 @@ func TestConfigEndpointAndHealth(t *testing.T) {
 		t.Fatalf("config.json missing codex: %s", string(disk))
 	}
 
+	// POST /config with opencode — same flow as codex above, regression test
+	// for the broker allowlist missing "opencode" (the web UI would silently
+	// drop the switch because SettingsApp/ProviderSwitcher/Wizard all POST
+	// llm_provider=opencode).
+	body = bytes.NewBufferString(`{"llm_provider":"opencode"}`)
+	req, _ = http.NewRequest(http.MethodPost, "http://"+b.addr+"/config", body)
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /config {opencode}: %v", err)
+	}
+	raw, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("POST /config {llm_provider:opencode} status=%d body=%s", resp.StatusCode, string(raw))
+	}
+
 	// Reject unsupported provider
 	body = bytes.NewBufferString(`{"llm_provider":"anthropic"}`)
 	req, _ = http.NewRequest(http.MethodPost, "http://"+b.addr+"/config", body)

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -21,8 +21,15 @@ var (
 	headlessCodexCommandContext = exec.CommandContext
 	headlessCodexExecutablePath = os.Executable
 	headlessCodexRunTurn        = func(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error {
-		if l != nil && l.memberEffectiveProviderKind(slug) != provider.KindCodex {
-			return l.runHeadlessClaudeTurn(ctx, slug, notification, channel...)
+		if l != nil {
+			switch l.memberEffectiveProviderKind(slug) {
+			case provider.KindCodex:
+				return l.runHeadlessCodexTurn(ctx, slug, notification, channel...)
+			case provider.KindOpencode:
+				return l.runHeadlessOpencodeTurn(ctx, slug, notification, channel...)
+			default:
+				return l.runHeadlessClaudeTurn(ctx, slug, notification, channel...)
+			}
 		}
 		return l.runHeadlessCodexTurn(ctx, slug, notification, channel...)
 	}

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -41,24 +42,31 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 		workspaceDir = "."
 	}
 
-	args := buildHeadlessOpencodeArgs(workspaceDir, config.ResolveOpencodeModel(l.cwd))
+	promptText := buildHeadlessCodexPrompt(l.buildPrompt(slug), notification)
+	args := buildHeadlessOpencodeArgs(config.ResolveOpencodeModel(l.cwd), promptText)
 	cmd := headlessOpencodeCommandContext(ctx, "opencode", args...)
 	cmd.Dir = workspaceDir
 
-	// Reuse the Codex env builder — it's provider-neutral (broker token,
-	// workspace, identity, API keys) — and override only the provider tag so
-	// downstream tooling can distinguish runs.
+	// Reuse the Codex env builder for the broker/workspace/identity plumbing,
+	// then heal the Opencode-specific differences: restore the user's real
+	// HOME (Opencode reads credentials from ~/.local/share/opencode/auth.json,
+	// not from Codex's isolated runtime home), drop CODEX_HOME, and flip
+	// the provider tag. Also set NO_COLOR so Opencode's default formatted
+	// output stays ANSI-free for the broker line scanner.
 	env := l.buildHeadlessCodexEnv(slug, workspaceDir, firstNonEmpty(channel...))
 	env = setEnvValue(env, "WUPHF_HEADLESS_PROVIDER", "opencode")
+	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
+		env = setEnvValue(env, "HOME", home)
+	}
+	env = stripEnvKeys(env, []string{"CODEX_HOME"})
+	env = setEnvValue(env, "NO_COLOR", "1")
 	if workspaceDir != strings.TrimSpace(l.cwd) {
 		env = append(env, "WUPHF_WORKTREE_PATH="+workspaceDir)
 	}
 	cmd.Env = env
 
-	stdinText := buildHeadlessCodexPrompt(l.buildPrompt(slug), notification)
-	cmd.Stdin = strings.NewReader(stdinText)
 	configureHeadlessProcess(cmd)
-	dumpHeadlessCodexInvocation(slug, workspaceDir, args, cmd.Env, stdinText)
+	dumpHeadlessCodexInvocation(slug, workspaceDir, args, cmd.Env, promptText)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
@@ -208,16 +216,17 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 // buildHeadlessOpencodeArgs mirrors provider.buildOpencodeArgs but is kept
 // local so the team package doesn't need to import the provider package just
 // for argv construction (and stays consistent with how headless_codex.go
-// builds its own argv).
-func buildHeadlessOpencodeArgs(workspaceDir string, model string) []string {
+// builds its own argv). Opencode's CLI shape: `opencode run [--model X]
+// [message..]` — no --cwd, no --quiet, no stdin sentinel. Working directory
+// is set via cmd.Dir by the caller.
+func buildHeadlessOpencodeArgs(model string, prompt string) []string {
 	args := []string{"run"}
 	if strings.TrimSpace(model) != "" {
 		args = append(args, "--model", strings.TrimSpace(model))
 	}
-	if strings.TrimSpace(workspaceDir) != "" {
-		args = append(args, "--cwd", strings.TrimSpace(workspaceDir))
+	if strings.TrimSpace(prompt) != "" {
+		args = append(args, prompt)
 	}
-	args = append(args, "--quiet", "-")
 	return args
 }
 

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -1,0 +1,237 @@
+package team
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// Opencode-specific test hooks. Kept separate from the codex hooks so test
+// setups can stub one runtime without colliding with the other.
+var (
+	headlessOpencodeLookPath       = exec.LookPath
+	headlessOpencodeCommandContext = exec.CommandContext
+)
+
+// runHeadlessOpencodeTurn executes a single Opencode turn for slug, posting the
+// final text to channel (if any) via the same broker/progress machinery used
+// by the Codex runtime. Opencode emits plain text on stdout rather than
+// structured JSONL, so this path is a thinner version of runHeadlessCodexTurn
+// with no tool-event parsing and no Codex-specific auth/config layering.
+func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, notification string, channel ...string) error {
+	if _, err := headlessOpencodeLookPath("opencode"); err != nil {
+		return fmt.Errorf("opencode not found: %w", err)
+	}
+	if l == nil || l.broker == nil {
+		return fmt.Errorf("broker is not running")
+	}
+
+	workspaceDir := strings.TrimSpace(l.cwd)
+	if worktreeDir := l.headlessTaskWorkspaceDir(slug); worktreeDir != "" {
+		workspaceDir = worktreeDir
+	}
+	workspaceDir = normalizeHeadlessWorkspaceDir(workspaceDir)
+	if workspaceDir == "" {
+		workspaceDir = "."
+	}
+
+	args := buildHeadlessOpencodeArgs(workspaceDir, config.ResolveOpencodeModel(l.cwd))
+	cmd := headlessOpencodeCommandContext(ctx, "opencode", args...)
+	cmd.Dir = workspaceDir
+
+	// Reuse the Codex env builder — it's provider-neutral (broker token,
+	// workspace, identity, API keys) — and override only the provider tag so
+	// downstream tooling can distinguish runs.
+	env := l.buildHeadlessCodexEnv(slug, workspaceDir, firstNonEmpty(channel...))
+	env = setEnvValue(env, "WUPHF_HEADLESS_PROVIDER", "opencode")
+	if workspaceDir != strings.TrimSpace(l.cwd) {
+		env = append(env, "WUPHF_WORKTREE_PATH="+workspaceDir)
+	}
+	cmd.Env = env
+
+	stdinText := buildHeadlessCodexPrompt(l.buildPrompt(slug), notification)
+	cmd.Stdin = strings.NewReader(stdinText)
+	configureHeadlessProcess(cmd)
+	dumpHeadlessCodexInvocation(slug, workspaceDir, args, cmd.Env, stdinText)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("attach opencode stdout: %w", err)
+	}
+
+	var agentStream *agentStreamBuffer
+	if l.broker != nil {
+		agentStream = l.broker.AgentStream(slug)
+	}
+	pr, pw := io.Pipe()
+	teedStdout := io.TeeReader(stdout, pw)
+	go func() {
+		scanner := bufio.NewScanner(pr)
+		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if agentStream != nil && line != "" {
+				agentStream.Push(line)
+			}
+		}
+	}()
+
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Start(); err != nil {
+		_ = pw.Close()
+		return err
+	}
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			terminateHeadlessProcess(cmd)
+			_ = stdout.Close()
+			_ = pw.CloseWithError(ctx.Err())
+		case <-done:
+		}
+	}()
+
+	startedAt := time.Now()
+	metrics := headlessProgressMetrics{
+		TotalMs:      -1,
+		FirstEventMs: -1,
+		FirstTextMs:  -1,
+		FirstToolMs:  -1,
+	}
+	l.updateHeadlessProgress(slug, "active", "thinking", "reviewing work packet", metrics)
+
+	var firstEventAt, firstTextAt time.Time
+	textStarted := false
+	var outputBuf strings.Builder
+
+	scanner := bufio.NewScanner(teedStdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if firstEventAt.IsZero() {
+			firstEventAt = time.Now()
+			metrics.FirstEventMs = durationMillis(startedAt, firstEventAt)
+		}
+		if strings.TrimSpace(line) != "" {
+			if firstTextAt.IsZero() {
+				firstTextAt = time.Now()
+				metrics.FirstTextMs = durationMillis(startedAt, firstTextAt)
+			}
+			if !textStarted {
+				textStarted = true
+				l.updateHeadlessProgress(slug, "active", "text", "drafting response", metrics)
+			}
+		}
+		if outputBuf.Len() > 0 {
+			outputBuf.WriteByte('\n')
+		}
+		outputBuf.WriteString(line)
+	}
+	scanErr := scanner.Err()
+	_ = pw.Close()
+
+	if err := cmd.Wait(); err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		metrics.TotalMs = time.Since(startedAt).Milliseconds()
+		if detail != "" {
+			appendHeadlessCodexLatency(slug, fmt.Sprintf("status=error provider=opencode total_ms=%d first_event_ms=%d first_text_ms=%d detail=%q",
+				metrics.TotalMs,
+				durationMillis(startedAt, firstEventAt),
+				durationMillis(startedAt, firstTextAt),
+				detail,
+			))
+			appendHeadlessCodexLog(slug, "opencode_stderr: "+detail)
+			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
+			if isOpencodeAuthError(detail) && l.broker != nil {
+				target := firstNonEmpty(channel...)
+				if strings.TrimSpace(target) == "" {
+					target = "general"
+				}
+				l.broker.PostSystemMessage(target,
+					fmt.Sprintf("@%s hit an auth error talking to the model (%s). Configure your Opencode provider credentials and retry.", slug, truncate(detail, 180)),
+					"error",
+				)
+			}
+			return fmt.Errorf("%w: %s", err, detail)
+		}
+		appendHeadlessCodexLatency(slug, fmt.Sprintf("status=error provider=opencode total_ms=%d first_event_ms=%d first_text_ms=%d detail=%q",
+			metrics.TotalMs,
+			durationMillis(startedAt, firstEventAt),
+			durationMillis(startedAt, firstTextAt),
+			err.Error(),
+		))
+		return err
+	}
+	if scanErr != nil {
+		metrics.TotalMs = time.Since(startedAt).Milliseconds()
+		l.updateHeadlessProgress(slug, "error", "error", truncate(scanErr.Error(), 180), metrics)
+		return scanErr
+	}
+
+	metrics.TotalMs = time.Since(startedAt).Milliseconds()
+	text := strings.TrimSpace(outputBuf.String())
+	appendHeadlessCodexLatency(slug, fmt.Sprintf("status=ok provider=opencode total_ms=%d first_event_ms=%d first_text_ms=%d final_chars=%d",
+		metrics.TotalMs,
+		durationMillis(startedAt, firstEventAt),
+		durationMillis(startedAt, firstTextAt),
+		len(text),
+	))
+	summary := strings.TrimSpace(formatHeadlessLatencySummary(metrics))
+	if summary == "" {
+		summary = "reply ready"
+	} else {
+		summary = "reply ready · " + summary
+	}
+	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
+	if text != "" {
+		appendHeadlessCodexLog(slug, "opencode_result: "+text)
+		target := firstNonEmpty(channel...)
+		msg, posted, err := l.postHeadlessFinalMessageIfSilent(slug, target, notification, text, startedAt)
+		if err != nil {
+			appendHeadlessCodexLog(slug, "opencode_fallback-post-error: "+err.Error())
+		} else if posted {
+			appendHeadlessCodexLog(slug, fmt.Sprintf("opencode_fallback-post: posted final output to #%s as %s", msg.Channel, msg.ID))
+		}
+	}
+	return nil
+}
+
+// buildHeadlessOpencodeArgs mirrors provider.buildOpencodeArgs but is kept
+// local so the team package doesn't need to import the provider package just
+// for argv construction (and stays consistent with how headless_codex.go
+// builds its own argv).
+func buildHeadlessOpencodeArgs(workspaceDir string, model string) []string {
+	args := []string{"run"}
+	if strings.TrimSpace(model) != "" {
+		args = append(args, "--model", strings.TrimSpace(model))
+	}
+	if strings.TrimSpace(workspaceDir) != "" {
+		args = append(args, "--cwd", strings.TrimSpace(workspaceDir))
+	}
+	args = append(args, "--quiet", "-")
+	return args
+}
+
+// isOpencodeAuthError checks stderr detail for the shapes Opencode tends to
+// emit when credentials are missing or invalid. Conservative — prefer false
+// positives (don't nag) over nagging on every failure.
+func isOpencodeAuthError(detail string) bool {
+	d := strings.ToLower(strings.TrimSpace(detail))
+	if d == "" {
+		return false
+	}
+	return strings.Contains(d, "unauthorized") ||
+		strings.Contains(d, "api key") ||
+		strings.Contains(d, "authentication") ||
+		strings.Contains(d, "invalid token") ||
+		strings.Contains(d, "no api key")
+}

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -282,8 +282,8 @@ func buildHeadlessOpencodePrompt(systemPrompt string, prompt string) string {
 // <system>/</system> tokens inside user-provided content so the wrapper the
 // prompt builder adds cannot be terminated or reopened from within.
 func escapeHeadlessOpencodeSystemWrapper(s string) string {
-	s = strings.ReplaceAll(s, "</system>", "</​system>")
-	s = strings.ReplaceAll(s, "<system>", "<​system>")
+	s = strings.ReplaceAll(s, "</system>", "</\u200bsystem>")
+	s = strings.ReplaceAll(s, "<system>", "<\u200bsystem>")
 	return s
 }
 

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -3,10 +3,13 @@ package team
 import (
 	"bufio"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -18,7 +21,24 @@ import (
 var (
 	headlessOpencodeLookPath       = exec.LookPath
 	headlessOpencodeCommandContext = exec.CommandContext
+	headlessOpencodeExecutablePath = os.Executable
 )
+
+// headlessOpencodeSecretEnvVars lists WUPHF-managed secrets that must NOT flow
+// into the outer opencode process. Opencode is a third-party binary that
+// routes to user-configured LLM backends (OpenAI, Ollama, any OpenAI-
+// compatible endpoint) and can load plugins; leaking these broader-than-Codex
+// tokens into that process is a credential-exfiltration surface we would not
+// trust. These secrets are still available to the WUPHF MCP subprocess via
+// opencode.json's per-server `environment` block, where they are scoped to the
+// wuphf-office MCP server and never reach the model backend.
+var headlessOpencodeSecretEnvVars = []string{
+	"WUPHF_BROKER_TOKEN",
+	"WUPHF_API_KEY",
+	"WUPHF_OPENAI_API_KEY",
+	"NEX_API_KEY",
+	"ONE_SECRET",
+}
 
 // runHeadlessOpencodeTurn executes a single Opencode turn for slug, posting the
 // final text to channel (if any) via the same broker/progress machinery used
@@ -42,26 +62,32 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 		workspaceDir = "."
 	}
 
-	promptText := buildHeadlessCodexPrompt(l.buildPrompt(slug), notification)
-	args := buildHeadlessOpencodeArgs(config.ResolveOpencodeModel(l.cwd), promptText)
+	promptText := buildHeadlessOpencodePrompt(l.buildPrompt(slug), notification)
+	args := buildHeadlessOpencodeArgs(config.ResolveOpencodeModel(), promptText)
 	cmd := headlessOpencodeCommandContext(ctx, "opencode", args...)
 	cmd.Dir = workspaceDir
 
-	// Reuse the Codex env builder for the broker/workspace/identity plumbing,
-	// then heal the Opencode-specific differences: restore the user's real
-	// HOME (Opencode reads credentials from ~/.local/share/opencode/auth.json,
-	// not from Codex's isolated runtime home), drop CODEX_HOME, and flip
-	// the provider tag. Also set NO_COLOR so Opencode's default formatted
-	// output stays ANSI-free for the broker line scanner.
+	// Start from the Codex env builder (broker/workspace/identity plumbing),
+	// then apply the Opencode-specific fixups: restore the user's real HOME so
+	// opencode finds ~/.local/share/opencode/auth.json, strip secrets that
+	// should never reach the third-party opencode process, overlay WUPHF's MCP
+	// config so agents can claim tasks / post status / update wiki, and flip
+	// the provider tag + NO_COLOR.
 	env := l.buildHeadlessCodexEnv(slug, workspaceDir, firstNonEmpty(channel...))
 	env = setEnvValue(env, "WUPHF_HEADLESS_PROVIDER", "opencode")
 	if home, err := os.UserHomeDir(); err == nil && strings.TrimSpace(home) != "" {
 		env = setEnvValue(env, "HOME", home)
 	}
 	env = stripEnvKeys(env, []string{"CODEX_HOME"})
+	env = stripEnvKeys(env, headlessOpencodeSecretEnvVars)
 	env = setEnvValue(env, "NO_COLOR", "1")
 	if workspaceDir != strings.TrimSpace(l.cwd) {
 		env = append(env, "WUPHF_WORKTREE_PATH="+workspaceDir)
+	}
+	if err := l.writeHeadlessOpencodeMCPConfig(slug); err != nil {
+		// MCP failure is loud but non-fatal — opencode will still run, just
+		// without the wuphf-office tools. Log so the user can debug.
+		appendHeadlessCodexLog(slug, "opencode_mcp-config-failed: "+err.Error())
 	}
 	cmd.Env = env
 
@@ -145,6 +171,11 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 		outputBuf.WriteString(line)
 	}
 	scanErr := scanner.Err()
+	if scanErr != nil && errors.Is(scanErr, bufio.ErrTooLong) {
+		// A single >4 MiB line would block cmd.Wait() on pipe backpressure
+		// forever; kill the child so Wait returns promptly.
+		terminateHeadlessProcess(cmd)
+	}
 	_ = pw.Close()
 
 	if err := cmd.Wait(); err != nil {
@@ -182,6 +213,9 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 	if scanErr != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(scanErr.Error(), 180), metrics)
+		if errors.Is(scanErr, bufio.ErrTooLong) {
+			return fmt.Errorf("opencode output line exceeded 4 MiB buffer; aborted")
+		}
 		return scanErr
 	}
 
@@ -228,6 +262,121 @@ func buildHeadlessOpencodeArgs(model string, prompt string) []string {
 		args = append(args, prompt)
 	}
 	return args
+}
+
+// buildHeadlessOpencodePrompt concatenates system and user text into a single
+// positional argument, escaping literal <system>/</system> tokens inside user
+// content so the wrapper cannot be closed from within.
+func buildHeadlessOpencodePrompt(systemPrompt string, prompt string) string {
+	var parts []string
+	if s := strings.TrimSpace(systemPrompt); s != "" {
+		parts = append(parts, "<system>\n"+escapeHeadlessOpencodeSystemWrapper(s)+"\n</system>")
+	}
+	if p := strings.TrimSpace(prompt); p != "" {
+		parts = append(parts, escapeHeadlessOpencodeSystemWrapper(p))
+	}
+	return strings.Join(parts, "\n\n")
+}
+
+// escapeHeadlessOpencodeSystemWrapper inserts a zero-width space into literal
+// <system>/</system> tokens inside user-provided content so the wrapper the
+// prompt builder adds cannot be terminated or reopened from within.
+func escapeHeadlessOpencodeSystemWrapper(s string) string {
+	s = strings.ReplaceAll(s, "</system>", "</​system>")
+	s = strings.ReplaceAll(s, "<system>", "<​system>")
+	return s
+}
+
+// writeHeadlessOpencodeMCPConfig merges WUPHF's MCP server definition into the
+// user's $HOME/.config/opencode/opencode.json. Preserves any other top-level
+// keys (theme, provider preferences, user-configured MCP servers) and only
+// touches the wuphf-office entry under `mcp`. Secrets live in the MCP
+// subprocess's `environment` block so they never reach the model backend
+// opencode routes to.
+func (l *Launcher) writeHeadlessOpencodeMCPConfig(slug string) error {
+	wuphfBinary, err := headlessOpencodeExecutablePath()
+	if err != nil {
+		return fmt.Errorf("resolve wuphf binary: %w", err)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return fmt.Errorf("resolve user home: %w", err)
+	}
+	configPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return fmt.Errorf("mkdir opencode config dir: %w", err)
+	}
+
+	merged := map[string]any{}
+	if raw, err := os.ReadFile(configPath); err == nil && len(raw) > 0 {
+		// Best-effort: if the existing file isn't valid JSON, overwrite it
+		// rather than silently losing the WUPHF overlay.
+		_ = json.Unmarshal(raw, &merged)
+	}
+
+	mcp, _ := merged["mcp"].(map[string]any)
+	if mcp == nil {
+		mcp = map[string]any{}
+	}
+	mcp["wuphf-office"] = l.buildHeadlessOpencodeMCPEntry(wuphfBinary, slug)
+	merged["mcp"] = mcp
+	if _, ok := merged["$schema"]; !ok {
+		merged["$schema"] = "https://opencode.ai/config.json"
+	}
+
+	data, err := json.MarshalIndent(merged, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal opencode.json: %w", err)
+	}
+	if err := os.WriteFile(configPath, data, 0o600); err != nil {
+		return fmt.Errorf("write opencode.json: %w", err)
+	}
+	return nil
+}
+
+// buildHeadlessOpencodeMCPEntry constructs the `mcp.wuphf-office` block for
+// opencode.json. The WUPHF-managed secrets (broker token, identity, Nex API
+// key) live inside the MCP `environment` map — opencode forwards these only
+// to the MCP subprocess, not to the model backend. This scoping is the
+// security boundary that makes it safe to add a third-party provider like
+// opencode, which can route to arbitrary user-configured endpoints.
+func (l *Launcher) buildHeadlessOpencodeMCPEntry(wuphfBinary string, slug string) map[string]any {
+	entry := map[string]any{
+		"type":    "local",
+		"command": []string{wuphfBinary, "mcp-team"},
+		"enabled": true,
+	}
+	envMap := map[string]string{
+		"WUPHF_AGENT_SLUG":      slug,
+		"WUPHF_BROKER_BASE_URL": l.BrokerBaseURL(),
+	}
+	if l != nil && l.broker != nil {
+		envMap["WUPHF_BROKER_TOKEN"] = l.broker.Token()
+	}
+	if config.ResolveNoNex() {
+		envMap["WUPHF_NO_NEX"] = "1"
+	}
+	if l != nil && l.isOneOnOne() {
+		envMap["WUPHF_ONE_ON_ONE"] = "1"
+		if v := strings.TrimSpace(l.oneOnOneAgent()); v != "" {
+			envMap["WUPHF_ONE_ON_ONE_AGENT"] = v
+		}
+	}
+	if secret := strings.TrimSpace(config.ResolveOneSecret()); secret != "" {
+		envMap["ONE_SECRET"] = secret
+	}
+	if identity := strings.TrimSpace(config.ResolveOneIdentity()); identity != "" {
+		envMap["ONE_IDENTITY"] = identity
+		if identityType := strings.TrimSpace(config.ResolveOneIdentityType()); identityType != "" {
+			envMap["ONE_IDENTITY_TYPE"] = identityType
+		}
+	}
+	if apiKey := strings.TrimSpace(config.ResolveAPIKey("")); apiKey != "" {
+		envMap["WUPHF_API_KEY"] = apiKey
+		envMap["NEX_API_KEY"] = apiKey
+	}
+	entry["environment"] = envMap
+	return entry
 }
 
 // isOpencodeAuthError checks stderr detail for the shapes Opencode tends to

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -232,6 +232,12 @@ func isOnboarded() bool {
 // Preflight checks that required tools are available.
 func (l *Launcher) Preflight() error {
 	if l.usesCodexRuntime() {
+		if l.usesOpencodeRuntime() {
+			if _, err := exec.LookPath("opencode"); err != nil {
+				return fmt.Errorf("opencode not found. Install Opencode CLI (https://opencode.ai) and configure your provider credentials")
+			}
+			return nil
+		}
 		if _, err := exec.LookPath("codex"); err != nil {
 			return fmt.Errorf("codex not found. Install Codex CLI and run `codex login`")
 		}
@@ -1767,7 +1773,7 @@ func (l *Launcher) paneEligibleOfficeMembers() []officeMember {
 	ordered := l.officeAgentOrder()
 	filtered := make([]officeMember, 0, len(ordered))
 	for _, m := range ordered {
-		if l.memberEffectiveProviderKind(m.Slug) == provider.KindCodex {
+		if l.memberUsesHeadlessOneShotRuntime(m.Slug) {
 			continue
 		}
 		filtered = append(filtered, m)
@@ -1847,7 +1853,7 @@ func (l *Launcher) shouldUseHeadlessDispatchForSlug(slug string) bool {
 	if l.shouldUseHeadlessDispatch() {
 		return true
 	}
-	if l.memberEffectiveProviderKind(slug) == provider.KindCodex {
+	if l.memberUsesHeadlessOneShotRuntime(slug) {
 		return true
 	}
 	if _, failed := l.failedPaneSlugs[strings.TrimSpace(slug)]; failed {
@@ -1878,7 +1884,7 @@ func (l *Launcher) skipPaneForSlug(slug string) bool {
 	if _, bad := l.failedPaneSlugs[slug]; bad {
 		return true
 	}
-	if l.memberEffectiveProviderKind(slug) == provider.KindCodex {
+	if l.memberUsesHeadlessOneShotRuntime(slug) {
 		return true
 	}
 	return false
@@ -1900,8 +1906,20 @@ func (l *Launcher) oneOnOneAgent() string {
 	return NormalizeOneOnOneAgent(l.oneOnOne)
 }
 
+// usesCodexRuntime reports whether the active install-wide provider uses the
+// headless one-shot runtime (shared by Codex and Opencode — both skip the
+// tmux/claude pane infrastructure and drive a fresh CLI per turn through the
+// broker queue in headless_codex.go).
 func (l *Launcher) usesCodexRuntime() bool {
-	return strings.EqualFold(strings.TrimSpace(l.provider), "codex")
+	p := strings.TrimSpace(strings.ToLower(l.provider))
+	return p == "codex" || p == "opencode"
+}
+
+// usesOpencodeRuntime reports whether the install-wide provider is Opencode
+// specifically. Used only where the per-turn CLI invocation differs from Codex
+// (binary name, args, prompt layout).
+func (l *Launcher) usesOpencodeRuntime() bool {
+	return strings.EqualFold(strings.TrimSpace(l.provider), "opencode")
 }
 
 // memberEffectiveProviderKind returns the provider kind that should run the
@@ -1917,6 +1935,15 @@ func (l *Launcher) memberEffectiveProviderKind(slug string) string {
 	return normalizeProviderKind(l.provider)
 }
 
+// memberUsesHeadlessOneShotRuntime reports whether the given agent is bound to
+// a runtime that drives a fresh CLI per turn (Codex, Opencode). Such agents
+// skip the tmux/claude pane infrastructure in favor of the broker-driven queue
+// in headless_codex.go.
+func (l *Launcher) memberUsesHeadlessOneShotRuntime(slug string) bool {
+	kind := l.memberEffectiveProviderKind(slug)
+	return kind == provider.KindCodex || kind == provider.KindOpencode
+}
+
 // normalizeProviderKind trims and canonicalizes provider kinds while
 // preserving unknown values so dispatch code can surface explicit errors.
 func normalizeProviderKind(raw string) string {
@@ -1926,6 +1953,8 @@ func normalizeProviderKind(raw string) string {
 		return provider.KindClaudeCode
 	case "codex":
 		return provider.KindCodex
+	case "opencode":
+		return provider.KindOpencode
 	case "claude-code", "openclaw":
 		return k
 	default:
@@ -3150,10 +3179,10 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 
 func (l *Launcher) spawnOverflowAgents() {
 	for _, member := range l.overflowOfficeMembers() {
-		// Codex-bound agents use the headless codex pipeline; they don't need
-		// a claude pane. Creating one would launch `claude` with the wrong
-		// model and quota semantics.
-		if l.memberEffectiveProviderKind(member.Slug) == provider.KindCodex {
+		// Codex/Opencode-bound agents use the headless one-shot pipeline; they
+		// don't need a claude pane. Creating one would launch `claude` with
+		// the wrong model and quota semantics.
+		if l.memberUsesHeadlessOneShotRuntime(member.Slug) {
 			continue
 		}
 		agentCmd, err := l.claudeCommand(member.Slug, l.buildPrompt(member.Slug))
@@ -4272,6 +4301,12 @@ func (l *Launcher) PreflightWeb() error {
 		return nil
 	}
 	if l.usesCodexRuntime() {
+		if l.usesOpencodeRuntime() {
+			if _, err := exec.LookPath("opencode"); err != nil {
+				return fmt.Errorf("opencode not found. Install Opencode CLI (https://opencode.ai) and configure your provider credentials")
+			}
+			return nil
+		}
 		if _, err := exec.LookPath("codex"); err != nil {
 			return fmt.Errorf("codex not found. Install Codex CLI and run `codex login`")
 		}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -360,7 +360,7 @@ type TeamMemberArgs struct {
 	// install-wide default runtime. Set Provider to pick a specific runtime and
 	// (optionally) model for this agent: one team can mix Claude, Codex, and
 	// OpenClaw agents, each on its own provider.
-	Provider           string `json:"provider,omitempty" jsonschema:"LLM runtime for this agent. One of: claude-code, codex, openclaw. Empty = install default."`
+	Provider           string `json:"provider,omitempty" jsonschema:"LLM runtime for this agent. One of: claude-code, codex, opencode, openclaw. Empty = install default."`
 	Model              string `json:"model,omitempty" jsonschema:"Model name passed to the runtime (e.g. claude-sonnet-4.6, gpt-5.4, openai-codex/gpt-5.4). Free-form; runtime validates."`
 	OpenclawSessionKey string `json:"openclaw_session_key,omitempty" jsonschema:"Optional: attach to an existing OpenClaw session key (e.g. after WUPHF reinstall). Leave empty to auto-create a new session."`
 	OpenclawAgentID    string `json:"openclaw_agent_id,omitempty" jsonschema:"Optional: OpenClaw agent config name (defaults to 'main')."`

--- a/internal/tui/init_flow.go
+++ b/internal/tui/init_flow.go
@@ -309,9 +309,14 @@ func ProviderOptions() []PickerOption {
 	if _, err := initFlowLookPathFn("codex"); err != nil {
 		codexDesc = "Codex via codex CLI (not found in PATH!)"
 	}
+	opencodeDesc := "Opencode via opencode CLI (BYO provider: Claude, OpenAI, local/Ollama)"
+	if _, err := initFlowLookPathFn("opencode"); err != nil {
+		opencodeDesc = "Opencode via opencode CLI (not found in PATH!)"
+	}
 	options := []PickerOption{
 		{Label: "Claude Code (default)", Value: "claude-code", Description: claudeDesc},
 		{Label: "Codex CLI", Value: "codex", Description: codexDesc},
+		{Label: "Opencode CLI", Value: "opencode", Description: opencodeDesc},
 	}
 	return options
 }
@@ -615,6 +620,8 @@ func providerRuntimeStatus(provider string) string {
 		return readinessStatusForBool(binaryAvailable("claude"))
 	case "codex":
 		return readinessStatusForBool(binaryAvailable("codex"))
+	case "opencode":
+		return readinessStatusForBool(binaryAvailable("opencode"))
 	default:
 		return "ready"
 	}
@@ -626,6 +633,8 @@ func providerRuntimeDetail(provider string) string {
 		return binaryReadinessDetail("claude", "Claude CLI is ready for teammate sessions.", "Install claude or pick another provider.")
 	case "codex":
 		return binaryReadinessDetail("codex", "Codex CLI is ready for teammate sessions.", "Install codex or pick another provider.")
+	case "opencode":
+		return binaryReadinessDetail("opencode", "Opencode CLI is ready for teammate sessions.", "Install opencode or pick another provider.")
 	case "gemini":
 		return "Gemini uses an API key. No local CLI is required."
 	case "nex-ask":

--- a/internal/tui/init_flow_test.go
+++ b/internal/tui/init_flow_test.go
@@ -107,6 +107,16 @@ func TestProviderOptionsIncludeCodex(t *testing.T) {
 	t.Fatal("expected codex provider option")
 }
 
+func TestProviderOptionsIncludeOpencode(t *testing.T) {
+	options := ProviderOptions()
+	for _, opt := range options {
+		if opt.Value == "opencode" {
+			return
+		}
+	}
+	t.Fatal("expected opencode provider option")
+}
+
 func TestProviderOptionsOnlyExposeClaudeAndCodex(t *testing.T) {
 	options := ProviderOptions()
 	values := make([]string, 0, len(options))

--- a/internal/tui/init_flow_test.go
+++ b/internal/tui/init_flow_test.go
@@ -117,15 +117,20 @@ func TestProviderOptionsIncludeOpencode(t *testing.T) {
 	t.Fatal("expected opencode provider option")
 }
 
-func TestProviderOptionsOnlyExposeClaudeAndCodex(t *testing.T) {
+func TestProviderOptionsExcludeUnsupportedProviders(t *testing.T) {
 	options := ProviderOptions()
 	values := make([]string, 0, len(options))
 	for _, opt := range options {
 		values = append(values, opt.Value)
 	}
 	joined := strings.Join(values, ",")
-	if strings.Contains(joined, "gemini") || strings.Contains(joined, "nex-ask") {
-		t.Fatalf("expected provider options to hide gemini and nex-ask, got %q", joined)
+	// Unsupported providers must not appear. Framed as a negative invariant
+	// (rather than an exact allowlist) so adding new supported providers —
+	// opencode, openclaw, etc. — doesn't require editing this test.
+	for _, banned := range []string{"gemini", "nex-ask"} {
+		if strings.Contains(joined, banned) {
+			t.Fatalf("expected provider options to hide %q, got %q", banned, joined)
+		}
 	}
 }
 

--- a/testdata/vhs/help.txt
+++ b/testdata/vhs/help.txt
@@ -39,7 +39,7 @@ Flags:
   --pack
         Operation blueprint ID (legacy pack alias supported)
   --provider
-        LLM provider override for this run (claude-code, codex)
+        LLM provider override for this run (claude-code, codex, opencode)
   --threads-collapsed
         Start with threads collapsed (default: expanded)
   --tui

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -508,7 +508,7 @@ export function setMemory(namespace: string, key: string, value: string) {
 
 // ── Config (Settings) ──
 
-export type LLMProvider = 'claude-code' | 'codex'
+export type LLMProvider = 'claude-code' | 'codex' | 'opencode'
 export type MemoryBackend = 'nex' | 'gbrain' | 'none'
 export type ActionProvider = 'auto' | 'one' | 'composio' | ''
 

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { post, generateAgent } from '../../api/client'
 import { useQueryClient } from '@tanstack/react-query'
 
-type Provider = 'inherit' | 'claude-code' | 'codex'
+type Provider = 'inherit' | 'claude-code' | 'codex' | 'opencode'
 type WizardMode = 'describe' | 'manual'
 
 interface AgentFormData {
@@ -27,6 +27,7 @@ const PROVIDERS: { value: Provider; label: string }[] = [
   { value: 'inherit', label: 'Default runtime' },
   { value: 'codex', label: 'Codex' },
   { value: 'claude-code', label: 'Claude Code' },
+  { value: 'opencode', label: 'Opencode' },
 ]
 
 function slugify(name: string): string {

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -372,6 +372,7 @@ function GeneralSection({ cfg, save }: SectionProps) {
         <select style={styles.input} value={provider} onChange={(e) => setProvider(e.target.value as typeof provider)}>
           <option value="claude-code">Claude Code</option>
           <option value="codex">Codex</option>
+          <option value="opencode">Opencode</option>
         </select>
       </Field>
       <Field label="Memory Backend" hint="--memory-backend">
@@ -661,7 +662,7 @@ function IntervalsSection({ cfg, save }: SectionProps) {
 }
 
 const CLI_FLAGS: [string, string][] = [
-  ['--provider <name>', 'LLM provider (claude-code, codex)'],
+  ['--provider <name>', 'LLM provider (claude-code, codex, opencode)'],
   ['--memory-backend <name>', 'Memory backend (nex, gbrain, none)'],
   ['--blueprint <id>', 'Operation blueprint for this run'],
   ['--tui', 'Launch tmux TUI instead of web UI'],

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -58,12 +58,13 @@ interface RuntimeSpec {
   label: string
   binary: string
   installUrl: string
-  provider: 'claude-code' | 'codex' | null
+  provider: 'claude-code' | 'codex' | 'opencode' | null
 }
 
 const RUNTIMES: readonly RuntimeSpec[] = [
   { label: 'Claude Code', binary: 'claude', installUrl: 'https://claude.ai/code', provider: 'claude-code' },
   { label: 'Codex', binary: 'codex', installUrl: 'https://github.com/openai/codex', provider: 'codex' },
+  { label: 'Opencode', binary: 'opencode', installUrl: 'https://opencode.ai', provider: 'opencode' },
   { label: 'Cursor', binary: 'cursor', installUrl: 'https://cursor.com/', provider: null },
   { label: 'Windsurf', binary: 'windsurf', installUrl: 'https://codeium.com/windsurf', provider: null },
 ] as const
@@ -1123,13 +1124,13 @@ export function Wizard({ onComplete }: WizardProps) {
       setSubmitting(true)
       try {
         // Translate UI labels to the provider ids the broker validates. Only
-        // labels that map to a supported provider ("claude-code", "codex")
-        // are persisted — aspirational runtimes (Cursor, Windsurf) are shown
-        // in the UI but can't yet be dispatched, so we drop them from the
-        // priority list we send to the server.
+        // labels that map to a supported provider ("claude-code", "codex",
+        // "opencode") are persisted — aspirational runtimes (Cursor, Windsurf)
+        // are shown in the UI but can't yet be dispatched, so we drop them
+        // from the priority list we send to the server.
         const providerPriority = runtimePriority
           .map((label) => RUNTIMES.find((r) => r.label === label)?.provider)
-          .filter((p): p is 'claude-code' | 'codex' => p != null)
+          .filter((p): p is 'claude-code' | 'codex' | 'opencode' => p != null)
 
         // Persist memory backend + LLM provider choice + priority fallback
         // list so the broker reads them on next launch. Send as a single

--- a/web/src/components/ui/HarnessBadge.tsx
+++ b/web/src/components/ui/HarnessBadge.tsx
@@ -10,6 +10,7 @@ interface HarnessBadgeProps {
 const PALETTE: Record<HarnessKind, { bg: string; fg: string }> = {
   'claude-code': { bg: '#D97757', fg: '#FFFFFF' },
   codex: { bg: '#10A37F', fg: '#FFFFFF' },
+  opencode: { bg: '#2563EB', fg: '#FFFFFF' },
   openclaw: { bg: '#8B5CF6', fg: '#FFFFFF' },
 }
 
@@ -28,6 +29,17 @@ function Glyph({ kind, color }: { kind: HarnessKind; color: string }) {
       return (
         <path
           d="M6 8l5 4-5 4M13 16h6"
+          stroke={color}
+          strokeWidth="2.4"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          fill="none"
+        />
+      )
+    case 'opencode':
+      return (
+        <path
+          d="M9 8l-4 4 4 4M15 8l4 4-4 4"
           stroke={color}
           strokeWidth="2.4"
           strokeLinecap="round"

--- a/web/src/components/ui/ProviderSwitcher.tsx
+++ b/web/src/components/ui/ProviderSwitcher.tsx
@@ -24,6 +24,7 @@ interface ProviderOption {
 const PROVIDERS: ProviderOption[] = [
   { id: 'claude-code', name: 'Claude Code', desc: 'Anthropic Claude via Claude Code CLI' },
   { id: 'codex', name: 'Codex', desc: 'OpenAI Codex CLI agent' },
+  { id: 'opencode', name: 'Opencode', desc: 'Opencode CLI — routes to Claude, OpenAI, or local/Ollama' },
 ]
 
 export function ProviderSwitcherHost() {

--- a/web/src/hooks/useConfig.ts
+++ b/web/src/hooks/useConfig.ts
@@ -15,6 +15,6 @@ export function useDefaultHarness(): HarnessKind {
     staleTime: 60_000,
   })
   const raw = data?.llm_provider
-  if (raw === 'claude-code' || raw === 'codex') return raw
+  if (raw === 'claude-code' || raw === 'codex' || raw === 'opencode') return raw
   return DEFAULT_HARNESS
 }

--- a/web/src/lib/harness.ts
+++ b/web/src/lib/harness.ts
@@ -1,11 +1,12 @@
 import type { OfficeMember } from '../api/client'
 
-export type HarnessKind = 'claude-code' | 'codex' | 'openclaw'
+export type HarnessKind = 'claude-code' | 'codex' | 'opencode' | 'openclaw'
 
 const VALID_KINDS: Record<string, HarnessKind> = {
   'claude-code': 'claude-code',
   claude: 'claude-code',
   codex: 'codex',
+  opencode: 'opencode',
   openclaw: 'openclaw',
 }
 
@@ -33,6 +34,8 @@ export function harnessLabel(kind: HarnessKind): string {
       return 'Claude Code'
     case 'codex':
       return 'Codex'
+    case 'opencode':
+      return 'Opencode'
     case 'openclaw':
       return 'OpenClaw'
   }


### PR DESCRIPTION
## Summary

Adds Opencode (opencode.ai) as a first-class LLM provider alongside `claude-code` and `codex`. Because Opencode routes to many underlying backends (Claude, OpenAI, local/Ollama, vLLM, any OpenAI-compatible endpoint), wiring it in gives WUPHF users a path to on-prem / local models — which indirectly addresses the ask in #186 without WUPHF needing its own `LLMProvider` interface yet.

Shape mirrors the Codex integration at every layer rather than forking the 1659-line codex team runtime.

- **config**: `"opencode"` accepted in `normalizeLLMProvider`; new `ResolveOpencodeModel` honors `WUPHF_OPENCODE_MODEL` / `OPENCODE_MODEL` env
- **provider**: new `opencode.go` streams plain-text stdout (Opencode doesn't expose JSONL like Codex); `KindOpencode` in `ValidateKind`; wired into `resolver.go` and `oneshot.go`
- **team runtime**: new `runHeadlessOpencodeTurn` reuses the codex queue/broker/progress/env plumbing — only the CLI invocation differs. `usesCodexRuntime()` now covers both one-shot-per-turn runtimes
- **UX**: `--provider opencode` flag, TUI init-flow picker, `/provider` slash command, onboarding prereq probe, capability registry descriptor
- **web**: Opencode surfaces in Settings dropdown, global ProviderSwitcher modal, onboarding Wizard, AgentWizard, plus `HarnessBadge` palette + glyph and `HarnessKind` normalization

## Test plan

- [x] `go build ./...` clean
- [x] `go test -run 'Codex|Provider|Launcher|Dispatch|Headless|LLMProvider|Opencode|ValidateKind|Binding|ProviderOption|CheckAll' ./...` all pass
- [x] New unit tests: `TestResolveLLMProviderAcceptsOpencode`, `TestResolveOpencodeModelEnvOverride`, `TestValidateKind(opencode)`, `TestBuildOpencodeArgs*`, `TestReadOpencodeStreamConcatenatesLines`, `TestCreateOpencodeCLIStreamFnStreamsPlainText` (helper-subprocess end-to-end), `TestProviderOptionsIncludeOpencode`
- [x] Updated existing tests: `TestCheckAllReturnsSevenItems`, `TestCheckAllRequiredFlags`, `TestCheckAllInstallURLs`
- [x] Web: `tsc --noEmit` clean, 268 vitest tests pass, `vite build` production build clean
- [x] Dev server (vite) serves 200; transformed modules confirmed to ship Opencode entries to the browser
- [ ] **Manual browser click-through** — not verified in this sandbox (no browser available)
- [ ] **Live Opencode turn** — not verified in this sandbox (`opencode` binary not installed). `Preflight()` will reject launch with "opencode not found" until the binary is on PATH

## What's deferred

Native `--provider openai-compatible` with `--backend-endpoint` / `--model` flags (as proposed in #186) is intentionally out of scope here. For now, users route to local models via Opencode's own config.

Refs #186

https://claude.ai/code/session_01Gm9okVwYihHvP4yTa4MDT4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gm9okVwYihHvP4yTa4MDT4)_