### PR TITLE
ci: add /approve comment workflow

### DIFF
--- a/.github/workflows/approve-on-comment.yml
+++ b/.github/workflows/approve-on-comment.yml
@@ -1,74 +1,11 @@
 name: Approve on Comment
 
-# Inlined (not using private nex-crm/.github reusable) because this is a
-# public repo and public repos cannot consume private reusable workflows.
-# Keep in sync with nex-crm/.github/.github/workflows/approve-on-comment.yml
-
 on:
   issue_comment:
     types: [created]
 
 jobs:
   approve:
-    if: |
-      github.event.issue.pull_request != null &&
-      startsWith(github.event.comment.body, '/approve')
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      pull-requests: write
-      issues: write
-    steps:
-      - name: Mint GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ vars.APPROVER_APP_ID }}
-          private-key: ${{ secrets.APPROVER_APP_PRIVATE_KEY }}
-
-      - name: Verify commenter is org member
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          COMMENTER: ${{ github.event.comment.user.login }}
-          ORG: ${{ github.repository_owner }}
-        run: |
-          if ! gh api "orgs/${ORG}/members/${COMMENTER}" --silent 2>/dev/null; then
-            echo "::error::@${COMMENTER} is not a member of ${ORG} — /approve denied"
-            exit 1
-          fi
-
-      - name: Reject self-approval
-        env:
-          COMMENTER: ${{ github.event.comment.user.login }}
-          PR_AUTHOR: ${{ github.event.issue.user.login }}
-        run: |
-          if [ "${COMMENTER}" = "${PR_AUTHOR}" ]; then
-            echo "::error::@${COMMENTER} cannot /approve their own PR"
-            exit 1
-          fi
-
-      - name: Submit approval review
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-          REPO: ${{ github.repository }}
-          COMMENTER: ${{ github.event.comment.user.login }}
-          BODY: ${{ github.event.comment.body }}
-        run: |
-          reason="${BODY#/approve}"
-          reason="${reason# }"
-          [ -z "$reason" ] && reason="(no reason provided)"
-          gh pr review "${PR_NUMBER}" \
-            --repo "${REPO}" \
-            --approve \
-            --body "Approved by @${COMMENTER} via \`/approve\`: ${reason}"
-
-      - name: React to comment
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          COMMENT_ID: ${{ github.event.comment.id }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh api -X POST \
-            "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
-            -f content=+1 >/dev/null
+    uses: nex-crm/.github/.github/workflows/approve-on-comment.yml@v1
+    secrets:
+      APPROVER_APP_PRIVATE_KEY: ${{ secrets.APPROVER_APP_PRIVATE_KEY }}

--- a/.github/workflows/approve-on-comment.yml
+++ b/.github/workflows/approve-on-comment.yml
@@ -1,11 +1,78 @@
 name: Approve on Comment
 
+# Inlined (not using private nex-crm/.github reusable) because this is a
+# public repo and public repos cannot consume private reusable workflows.
+# Keep in sync with nex-crm/.github/.github/workflows/approve-on-comment.yml
+# (current canonical SHA tracked via the v1 tag on that repo).
+
 on:
   issue_comment:
     types: [created]
 
 jobs:
   approve:
-    uses: nex-crm/.github/.github/workflows/approve-on-comment.yml@v1
-    secrets:
-      APPROVER_APP_PRIVATE_KEY: ${{ secrets.APPROVER_APP_PRIVATE_KEY }}
+    if: |
+      github.event.issue.pull_request != null &&
+      (github.event.comment.body == '/approve' ||
+       startsWith(github.event.comment.body, '/approve '))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    concurrency:
+      group: approve-on-comment-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    permissions: {}
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ vars.APPROVER_APP_ID }}
+          private-key: ${{ secrets.APPROVER_APP_PRIVATE_KEY }}
+
+      - name: Verify commenter is org member
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          ORG: ${{ github.repository_owner }}
+        run: |
+          if ! gh api "orgs/${ORG}/members/${COMMENTER}" --silent; then
+            echo "::error::@${COMMENTER} is not a member of ${ORG} (or membership check failed — see above) — /approve denied"
+            exit 1
+          fi
+
+      - name: Reject self-approval
+        env:
+          COMMENTER: ${{ github.event.comment.user.login }}
+          PR_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          if [ "${COMMENTER}" = "${PR_AUTHOR}" ]; then
+            echo "::error::@${COMMENTER} cannot /approve their own PR"
+            exit 1
+          fi
+
+      - name: Submit approval review
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          reason="${BODY#/approve}"
+          reason="${reason# }"
+          reason="${reason%%$'\n'*}"
+          [ -z "$reason" ] && reason="(no reason provided)"
+          gh pr review "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --approve \
+            --body "Approved by @${COMMENTER} via \`/approve\`: ${reason}"
+
+      - name: React to comment
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X POST \
+            "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content=+1 >/dev/null

--- a/.github/workflows/approve-on-comment.yml
+++ b/.github/workflows/approve-on-comment.yml
@@ -1,0 +1,74 @@
+name: Approve on Comment
+
+# Inlined (not using private nex-crm/.github reusable) because this is a
+# public repo and public repos cannot consume private reusable workflows.
+# Keep in sync with nex-crm/.github/.github/workflows/approve-on-comment.yml
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  approve:
+    if: |
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/approve')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.APPROVER_APP_ID }}
+          private-key: ${{ secrets.APPROVER_APP_PRIVATE_KEY }}
+
+      - name: Verify commenter is org member
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          ORG: ${{ github.repository_owner }}
+        run: |
+          if ! gh api "orgs/${ORG}/members/${COMMENTER}" --silent 2>/dev/null; then
+            echo "::error::@${COMMENTER} is not a member of ${ORG} — /approve denied"
+            exit 1
+          fi
+
+      - name: Reject self-approval
+        env:
+          COMMENTER: ${{ github.event.comment.user.login }}
+          PR_AUTHOR: ${{ github.event.issue.user.login }}
+        run: |
+          if [ "${COMMENTER}" = "${PR_AUTHOR}" ]; then
+            echo "::error::@${COMMENTER} cannot /approve their own PR"
+            exit 1
+          fi
+
+      - name: Submit approval review
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          COMMENTER: ${{ github.event.comment.user.login }}
+          BODY: ${{ github.event.comment.body }}
+        run: |
+          reason="${BODY#/approve}"
+          reason="${reason# }"
+          [ -z "$reason" ] && reason="(no reason provided)"
+          gh pr review "${PR_NUMBER}" \
+            --repo "${REPO}" \
+            --approve \
+            --body "Approved by @${COMMENTER} via \`/approve\`: ${reason}"
+
+      - name: React to comment
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api -X POST \
+            "repos/${REPO}/issues/comments/${COMMENT_ID}/reactions" \
+            -f content=+1 >/dev/null


### PR DESCRIPTION
## Summary
Adds `.github/workflows/approve-on-comment.yml` so org members can approve this repo's PRs by commenting `/approve <reason>`.

Calls reusable workflow `nex-crm/.github/.github/workflows/approve-on-comment.yml@main`.

## Why
Part of the org-wide rollout to satisfy the Sprinto "Branch protection rules should be enforced for admins" control. Validated end-to-end on nex-crm/intelligence (App token, org-membership check, self-approval guard all confirmed working).

## Rollout order
1. This PR merges
2. Branch protection with 1 required review enabled on `main` (separate PR)
3. Team can approve via `/approve <reason>` comment on any PR authored by a different org member

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated pull request approvals. Organization members can now comment `/approve` on a pull request to trigger an automatic approval review, with optional reasoning included in the approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->