### PR TITLE
fix(approver): sync inlined workflow with v1 (allow self-approve + CRLF fix)

### DIFF
--- a/.github/workflows/approve-on-comment.yml
+++ b/.github/workflows/approve-on-comment.yml
@@ -40,16 +40,6 @@ jobs:
             exit 1
           fi
 
-      - name: Reject self-approval
-        env:
-          COMMENTER: ${{ github.event.comment.user.login }}
-          PR_AUTHOR: ${{ github.event.issue.user.login }}
-        run: |
-          if [ "${COMMENTER}" = "${PR_AUTHOR}" ]; then
-            echo "::error::@${COMMENTER} cannot /approve their own PR"
-            exit 1
-          fi
-
       - name: Submit approval review
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -60,7 +50,7 @@ jobs:
         run: |
           reason="${BODY#/approve}"
           reason="${reason# }"
-          reason="${reason%%$'\n'*}"
+          reason="${reason%%[$'\r\n']*}"
           [ -z "$reason" ] && reason="(no reason provided)"
           gh pr review "${PR_NUMBER}" \
             --repo "${REPO}" \

--- a/.github/workflows/approve-on-comment.yml
+++ b/.github/workflows/approve-on-comment.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ vars.APPROVER_APP_ID }}
           private-key: ${{ secrets.APPROVER_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Closes the policy inconsistency flagged by staff review of [nex-crm/.github#32](https://github.com/nex-crm/.github/pull/32). The private reusable removed the reject-self-approval step at `@v1` but the 4 public inlined copies didn't update.

Also picks up the CRLF-reason fix from [nex-crm/.github#33](https://github.com/nex-crm/.github/pull/33).

Now byte-aligned with `nex-crm/.github@v1` (except the trigger section, which differs by design for inlined callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions approval workflow to allow self-approvals and improved handling of multi-line approval reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->