### PR TITLE
feat(team): headless claude --print as default dispatch for web and TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to WUPHF will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+
+- **Headless `claude --print` is now the default dispatch path for both `wuphf` (web) and `wuphf --tui`.** Anthropic re-sanctioned headless CLI reuse in the 2026-04 OpenClaw policy note, and it runs on the user's normal subscription quota — no separate extra-usage charge. Every turn now dispatches as a fresh `claude --print` invocation, matching how the Codex runtime already worked and unifying dispatch across both modes. The previous per-agent long-lived interactive tmux pane path is preserved as an internal fallback primitive (reachable if dispatch ever needs to promote to panes at runtime) but is no longer invoked at startup. tmux is still required for `--tui` since the channel-view TUI runs in tmux; the web UI no longer needs it.
+- **Pane-fallback messaging updated to reflect the new default.** The stderr banner and `#general` system post no longer frame headless as "extra-usage quota" — it isn't, anymore. Messaging now reads as: pane-backed fallback attempted but unavailable → continuing with the default headless path on your normal subscription.
+
 ## [0.0.7.1] - 2026-04-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ One command. One shared office. CEO, PM, engineers, designer, CMO, CRO — all v
 
 ## Get Started
 
-**Prerequisites:** one agent CLI — [Claude Code](https://docs.anthropic.com/en/docs/claude-code) by default, or [Codex CLI](https://github.com/openai/codex) when you pass `--provider codex`. [tmux](https://github.com/tmux/tmux/wiki/Installing) is only required for `--tui` mode.
+**Prerequisites:** one agent CLI — [Claude Code](https://docs.anthropic.com/en/docs/claude-code) by default, or [Codex CLI](https://github.com/openai/codex) when you pass `--provider codex`. [tmux](https://github.com/tmux/tmux/wiki/Installing) is required for `--tui` mode (the web UI runs agents headlessly by default; tmux-backed dispatch remains as an internal fallback).
 
 ```bash
 npx wuphf

--- a/internal/team/dispatch_test.go
+++ b/internal/team/dispatch_test.go
@@ -84,11 +84,15 @@ func TestShouldUseHeadlessDispatch(t *testing.T) {
 		paneBackedAgents bool
 		want             bool
 	}{
-		{"tui mode, claude → pane", "claude-code", false, false, false},
+		// Both web and TUI modes default to headless: `claude --print` per turn
+		// is the primary dispatch path; pane-backed dispatch is reserved as an
+		// internal fallback that sets paneBackedAgents=true.
+		{"tui mode, claude, no panes → headless", "claude-code", false, false, true},
 		{"tui mode, codex → headless", "codex", false, false, true},
+		{"tui mode with panes (fallback active) → pane", "claude-code", false, true, false},
 		{"web mode, no panes → headless", "claude-code", true, false, true},
-		{"web mode with panes → pane", "claude-code", true, true, false},
-		{"web mode, codex always headless even if panes flag set", "codex", true, true, true},
+		{"web mode with panes (fallback active) → pane", "claude-code", true, true, false},
+		{"web mode, codex always headless even when panes flag set", "codex", true, true, true},
 	}
 	for _, tt := range tests {
 		l := &Launcher{

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -156,6 +156,15 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	startWorker := false
 
 	l.headlessMu.Lock()
+	if l.headlessQueues == nil {
+		l.headlessQueues = make(map[string][]headlessCodexTurn)
+	}
+	if l.headlessActive == nil {
+		l.headlessActive = make(map[string]*headlessCodexActiveTurn)
+	}
+	if l.headlessWorkers == nil {
+		l.headlessWorkers = make(map[string]bool)
+	}
 	urgentLeadTurn := l.headlessLeadTurnNeedsImmediateWakeLocked(slug, turn.Prompt)
 	if turn.TaskID != "" {
 		if active := l.headlessActive[slug]; active != nil && strings.TrimSpace(active.Turn.TaskID) == turn.TaskID {
@@ -318,6 +327,7 @@ func (l *Launcher) runHeadlessCodexQueue(slug string) {
 
 			err := headlessCodexRunTurn(l, turnCtx, slug, turn.Prompt, turn.Channel)
 			ctxErr := turnCtx.Err()
+			isDurabilityError := false
 			if err == nil {
 				l.headlessMu.Lock()
 				active := l.headlessActive[slug]
@@ -325,6 +335,7 @@ func (l *Launcher) runHeadlessCodexQueue(slug string) {
 				if ok, reason := l.headlessTurnCompletedDurably(slug, active); !ok {
 					appendHeadlessCodexLog(slug, "durability-error: "+reason)
 					err = errors.New(reason)
+					isDurabilityError = true
 				}
 			}
 			switch {
@@ -336,6 +347,14 @@ func (l *Launcher) runHeadlessCodexQueue(slug string) {
 			case errors.Is(ctxErr, context.Canceled) || errors.Is(err, context.Canceled):
 				appendHeadlessCodexLog(slug, "error: headless codex turn cancelled so newer queued work can run")
 				l.updateHeadlessProgress(slug, "active", "queued", "restarting on newer queued work", headlessProgressMetrics{})
+			case isDurabilityError:
+				// The provider returned successfully but left no durable task state.
+				// Don't retry — the agent already had its turn. Block the task immediately.
+				appendHeadlessCodexLog(slug, fmt.Sprintf("error: %v", err))
+				l.updateHeadlessProgress(slug, "error", "error", truncate(err.Error(), 180), headlessProgressMetrics{})
+				exhaustedTurn := turn
+				exhaustedTurn.Attempts = headlessCodexLocalWorktreeRetryLimit
+				l.recoverFailedHeadlessTurn(slug, exhaustedTurn, startedAt, err.Error())
 			default:
 				appendHeadlessCodexLog(slug, fmt.Sprintf("error: %v", err))
 				l.updateHeadlessProgress(slug, "error", "error", truncate(err.Error(), 180), headlessProgressMetrics{})

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -851,6 +851,13 @@ func (l *Launcher) recoverTimedOutHeadlessTurn(slug string, turn headlessCodexTu
 	}
 }
 
+// isDurabilityFailure reports whether detail came from headlessTurnCompletedDurably
+// ("completed without durable task state"). These failures mean the agent ran but did
+// nothing observable — retrying produces the same result, so we block instead.
+func isDurabilityFailure(detail string) bool {
+	return strings.Contains(strings.TrimSpace(detail), "completed without durable task state")
+}
+
 func (l *Launcher) recoverFailedHeadlessTurn(slug string, turn headlessCodexTurn, startedAt time.Time, detail string) {
 	if l == nil || l.broker == nil {
 		return
@@ -864,7 +871,7 @@ func (l *Launcher) recoverFailedHeadlessTurn(slug string, turn headlessCodexTurn
 		appendHeadlessCodexLog(slug, fmt.Sprintf("error-recovery: %s already produced durable progress; leaving task state unchanged", task.ID))
 		return
 	}
-	if shouldRetryHeadlessTurn(task, turn) {
+	if shouldRetryHeadlessTurn(task, turn) && !isDurabilityFailure(detail) {
 		retryTurn := turn
 		retryTurn.Attempts++
 		retryTurn.EnqueuedAt = time.Now()

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -1915,6 +1915,10 @@ func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T
 	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
 	defer func() { brokerStatePath = oldPathFn }()
 
+	oldWakeLead := headlessWakeLeadFn
+	headlessWakeLeadFn = func(_ *Launcher, _ string) {}
+	defer func() { headlessWakeLeadFn = oldWakeLead }()
+
 	b := NewBroker()
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -286,9 +286,12 @@ func checkGHCapability() (installed bool, authed bool, note string) {
 	return true, true, ""
 }
 
-// Launch creates the tmux session with:
-//   - Window 0 "team": Channel on left, agent panes on the right
-//   - No extra windows: all team activity is visible in one place
+// Launch starts a tmux session hosting the channel-view TUI and the shared
+// broker. Agents run headlessly by default via `claude --print` per turn;
+// per-agent interactive panes are reserved as an internal fallback primitive
+// (see trySpawnWebAgentPanes) and are not spawned at startup. The user
+// attaches to tmux to drive the channel view; agent output is surfaced
+// through the channel timeline rather than a dedicated pane.
 func (l *Launcher) Launch() error {
 	if l.usesCodexRuntime() {
 		return l.launchHeadlessCodex()
@@ -379,29 +382,21 @@ func (l *Launcher) Launch() error {
 		"remain-on-exit", "on",
 	).Run()
 
-	visibleSlugs, err := l.spawnVisibleAgents()
-	if err != nil {
-		return err
-	}
-	l.spawnOverflowAgents()
-
-	// Enable pane borders with labels and visible resize handles.
+	// Pane border cosmetics — kept so the channel pane renders with a border
+	// title. Per-agent panes are not spawned in the default path; they live
+	// only as an internal fallback (see trySpawnWebAgentPanes).
 	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-status", "top",
 	).Run()
-	// Show agent name in the border; mouse drag is intentionally disabled.
 	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-format", " #{pane_title} ",
 	).Run()
-	// Make inactive border visible but subtle
 	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-style", "fg=colour240",
 	).Run()
-	// Active pane border bright so you know which pane has focus
 	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-active-border-style", "fg=colour45",
 	).Run()
-	// Use line-drawing characters for clear keyboard-focused pane boundaries.
 	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-lines", "heavy",
 	).Run()
@@ -410,20 +405,7 @@ func (l *Launcher) Launch() error {
 		"-t", l.sessionName+":team.0",
 		"-T", "📢 channel",
 	).Run()
-	for i, slug := range visibleSlugs {
-		if i == 0 {
-			i = 1
-		} else {
-			i++
-		}
-		name := l.getAgentName(slug)
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
-			"-t", fmt.Sprintf("%s:team.%d", l.sessionName, i),
-			"-T", fmt.Sprintf("🤖 %s (@%s)", name, slug),
-		).Run()
-	}
 
-	// Focus on the channel pane.
 	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-window",
 		"-t", l.sessionName+":team",
 	).Run()
@@ -431,12 +413,12 @@ func (l *Launcher) Launch() error {
 		"-t", l.sessionName+":team.0",
 	).Run()
 
-	// Headless context for per-turn Claude invocations in TUI mode.
+	// Headless context for per-turn Claude invocations. Used by both TUI and
+	// web modes since agent dispatch is headless by default.
 	l.headlessCtx, l.headlessCancel = context.WithCancel(context.Background())
+	l.resumeInFlightWork()
 
-	// Start the notification loop that pushes new messages to agent panes
 	go l.watchChannelPaneLoop(channelCmd)
-	go l.primeVisibleAgents()
 	go l.notifyAgentsLoop()
 	if !l.isOneOnOne() {
 		go l.notifyTaskActionsLoop()
@@ -2868,13 +2850,14 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 
 // shouldUseHeadlessDispatch returns true when notifications must be delivered
 // via a queued headless `claude --print` turn rather than typed into a live
-// interactive pane. Codex runtime always needs headless. Web mode uses headless
-// only when pane-backed agents could not be spawned (tmux missing or failed).
+// interactive pane. This is the default path for both web and TUI modes.
+// Codex runtime is always headless. Pane-backed interactive dispatch is only
+// used when the fallback path explicitly brought panes up (paneBackedAgents).
 func (l *Launcher) shouldUseHeadlessDispatch() bool {
 	if l.usesCodexRuntime() {
 		return true
 	}
-	return l.webMode && !l.paneBackedAgents
+	return !l.paneBackedAgents
 }
 
 // Minimum gap between two consecutive pane `/clear` + type cycles for the
@@ -3510,13 +3493,18 @@ func (l *Launcher) recordPaneSpawnFailure(slug, reason string) {
 
 // trySpawnWebAgentPanes attempts to create a detached tmux session with one
 // interactive `claude` pane per agent so message dispatch can type into a live
-// session. This avoids the per-turn `claude --print` path, which under
-// Anthropic's recent policy consumes the separate headless/extra-usage quota.
+// session. This is the internal fallback primitive for web and TUI modes —
+// the default is headless `claude --print` per turn, which Anthropic
+// re-sanctioned in the 2026-04 OpenClaw policy note and runs on the normal
+// subscription quota without a separate extra-usage charge. Nothing in the
+// startup path calls this today; it is reachable for a runtime-promotion
+// fallback (e.g. repeated headless failures) without needing to be wired in
+// advance.
 //
 // On success, l.paneBackedAgents is set to true and dispatch routes through
 // sendNotificationToPane. On any failure (tmux missing, session create failure,
 // spawn error) the method logs the tradeoff, posts a system message to
-// #general, and leaves paneBackedAgents false so the existing headless path
+// #general, and leaves paneBackedAgents false so the default headless path
 // continues to work.
 func (l *Launcher) trySpawnWebAgentPanes() {
 	if l.broker == nil {
@@ -3567,40 +3555,42 @@ func (l *Launcher) trySpawnWebAgentPanes() {
 
 	l.paneBackedAgents = true
 	go l.detectDeadPanesAfterSpawn(append(l.visibleOfficeMembers(), l.overflowOfficeMembers()...))
-	fmt.Printf("  Agents:  interactive Claude panes in tmux session %q (uses subscription quota)\n", l.sessionName)
+	fmt.Printf("  Agents:  interactive Claude panes in tmux session %q (pane-backed fallback active)\n", l.sessionName)
 }
 
 // paneFallbackMessages renders the two user-facing messages for a pane-spawn
-// fallback (stderr banner + broker #general post). The remediation advice
-// depends on whether tmux is installed:
+// fallback (stderr banner + broker #general post). Headless is the normal
+// default now, so the fallback message is neutral — it only fires when
+// something in the runtime promoted us to panes and the spawn failed.
+// Remediation advice depends on whether tmux is installed:
 //
-//   - tmuxInstalled=false → tell the user to install tmux (the old default,
-//     and still the right answer for most systems)
-//   - tmuxInstalled=true  → tmux rejected the command; telling the user to
-//     "install tmux" is actively wrong. Ask them to file a bug.
+//   - tmuxInstalled=false → install tmux if you want panes; otherwise headless
+//     is a fine default and runs on your normal subscription.
+//   - tmuxInstalled=true  → tmux rejected the command; ask the user to file a
+//     bug. Headless continues to work.
 //
 // Pure function so it can be unit-tested without touching os.Stderr or the
 // broker. Keep in sync with reportPaneFallback below.
 func paneFallbackMessages(tmuxInstalled bool, detail string) (stderrMsg, brokerMsg string) {
-	const headlessBlurb = "Falling back to headless `claude --print`, which consumes Anthropic's extra-usage quota."
-	const brokerBlurb = "Running in headless mode (%s). Agent turns will draw from the Anthropic extra-usage quota."
+	const headlessBlurb = "Continuing with the default headless path (`claude --print` per turn on your normal subscription)."
+	const brokerBlurb = "Running in headless mode (%s). Agent turns dispatch as `claude --print` on your normal subscription."
 	if !tmuxInstalled {
 		stderrMsg = fmt.Sprintf(
-			"  Agents:  pane-backed mode unavailable (%s). %s Install tmux to run agents on your normal subscription.\n",
+			"  Agents:  pane-backed fallback attempted but tmux not found (%s). %s Install tmux if you want the fallback to be available.\n",
 			detail, headlessBlurb,
 		)
 		brokerMsg = fmt.Sprintf(
-			brokerBlurb+" Install tmux and relaunch to use interactive Claude sessions on your normal subscription.",
+			brokerBlurb+" Install tmux so the pane-backed fallback is available next time.",
 			detail,
 		)
 		return
 	}
 	stderrMsg = fmt.Sprintf(
-		"  Agents:  pane-backed mode unavailable (%s). %s tmux IS installed but rejected the launch command; please file a bug with the detail above at https://github.com/nex-crm/wuphf/issues.\n",
+		"  Agents:  pane-backed fallback attempted but unavailable (%s). %s tmux IS installed but rejected the launch command; please file a bug with the detail above at https://github.com/nex-crm/wuphf/issues.\n",
 		detail, headlessBlurb,
 	)
 	brokerMsg = fmt.Sprintf(
-		brokerBlurb+" tmux is installed but rejected the launch command; please file a bug so we can fix the regression.",
+		brokerBlurb+" tmux is installed but rejected the pane-spawn command; please file a bug so we can fix the regression.",
 		detail,
 	)
 	return
@@ -4648,17 +4638,17 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	l.broker.SetGenerateChannelFn(l.GenerateChannelTemplateFromPrompt)
 	l.broker.ServeWebUI(webPort)
 
-	// Try to spawn interactive Claude sessions in tmux panes so dispatch can
-	// type into a live agent rather than spending `claude --print` quota.
-	// Falls back to the headless path if tmux is missing or pane spawn fails.
-	l.trySpawnWebAgentPanes()
+	// Default path: headless `claude --print` per turn. Anthropic re-sanctioned
+	// this invocation (OpenClaw policy note, 2026-04), so it runs on the user's
+	// normal subscription quota — no separate extra-usage quota is charged on
+	// top. The legacy interactive pane-per-agent mode remains reachable via
+	// trySpawnWebAgentPanes as an internal fallback primitive, but is not
+	// invoked at startup.
 
-	// Headless context is used for codex runtime, headless fallback, and
+	// Headless context is used for codex runtime, default dispatch, and
 	// per-turn operations that don't fit a long-lived pane session.
 	l.headlessCtx, l.headlessCancel = context.WithCancel(context.Background())
-	if !l.paneBackedAgents {
-		l.resumeInFlightWork()
-	}
+	l.resumeInFlightWork()
 
 	// Stream tmux pane output to the web UI's per-agent stream so users see
 	// live Claude TUI activity (thinking, tool calls, responses) during a

--- a/internal/team/launcher_tmux_fix_test.go
+++ b/internal/team/launcher_tmux_fix_test.go
@@ -47,7 +47,8 @@ func TestClaudeCommand_UsesFileForSystemPrompt(t *testing.T) {
 // string for every visible office member and asserts the length is comfortably
 // below any plausible tmux command-parse buffer. 4096 bytes is a safety margin
 // well below historical tmux limits. If this test fails, pane-backed spawn
-// will regress and fall back to headless claude --print (extra-usage quota).
+// will regress and the opt-in WUPHF_AGENT_MODE=panes path falls back to the
+// default headless claude --print dispatch.
 func TestClaudeCommand_StaysUnderTmuxLimit(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("WUPHF_START_FROM_SCRATCH", "1")

--- a/internal/team/resume.go
+++ b/internal/team/resume.go
@@ -177,8 +177,13 @@ func (l *Launcher) buildResumePackets() map[string]string {
 
 // resumeInFlightWork builds resume packets for all agents with pending work and
 // delivers them via the appropriate runtime:
-//   - Headless (Codex / web mode): enqueueHeadlessCodexTurn
-//   - tmux: sendNotificationToPane
+//   - Headless (Codex, or any mode without live panes): enqueueHeadlessCodexTurn
+//   - tmux pane-backed: sendNotificationToPane
+//
+// The routing key is paneBackedAgents, mirroring shouldUseHeadlessDispatch.
+// webMode alone is not sufficient: TUI mode now defaults to headless dispatch,
+// and keying on webMode would send resume packets through agentPaneTargets()
+// to pane indices that were never spawned — silently dropping resumption.
 //
 // In headless mode the lead is enqueued FIRST to avoid the queue-hold guard:
 // enqueueHeadlessCodexTurn suppresses lead notifications when any specialist
@@ -190,7 +195,7 @@ func (l *Launcher) resumeInFlightWork() {
 		return
 	}
 
-	if l.usesCodexRuntime() || l.webMode {
+	if l.usesCodexRuntime() || !l.paneBackedAgents {
 		lead := l.officeLeadSlug()
 		// Enqueue lead first to bypass the queue-hold guard.
 		if packet, ok := packets[lead]; ok {
@@ -205,7 +210,7 @@ func (l *Launcher) resumeInFlightWork() {
 		return
 	}
 
-	// tmux path — need pane targets.
+	// Pane-backed fallback path — need live pane targets.
 	paneTargets := l.agentPaneTargets()
 	for slug, packet := range packets {
 		target, ok := paneTargets[slug]

--- a/internal/team/resume_test.go
+++ b/internal/team/resume_test.go
@@ -676,3 +676,65 @@ func TestBuildResumePacketSpecSectionMessagesLabel(t *testing.T) {
 		t.Error("old section label '## Unanswered messages awaiting your response' must not appear")
 	}
 }
+
+// TestResumeInFlightWorkTUIClaudeRoutesHeadless pins the invariant that TUI
+// mode with claude-code runtime and no pane-backed agents routes resumption
+// through the headless queue, not the tmux pane branch. Before this guard,
+// resumeInFlightWork branched on webMode alone — TUI has webMode=false, so it
+// fell through to agentPaneTargets() which computes pane addresses without
+// verifying they exist, and the resulting tmux send-keys commands silently
+// failed. Users restarting `wuphf --tui` with in-flight work lost resumption.
+func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	oldWakeLead := headlessWakeLeadFn
+	headlessWakeLeadFn = func(_ *Launcher, _ string) {}
+	defer func() { headlessWakeLeadFn = oldWakeLead }()
+
+	b := NewBroker()
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{ID: "t1", Title: "Build login form", Owner: "fe", Status: "in_progress"},
+	}
+	b.messages = []channelMessage{
+		{ID: "h1", From: "you", Content: "what is the strategy?", Timestamp: "2026-04-14T10:00:00Z"},
+	}
+	b.mu.Unlock()
+
+	l := &Launcher{
+		// TUI mode: webMode=false, claude-code provider, no panes spawned.
+		provider:         "claude-code",
+		webMode:          false,
+		paneBackedAgents: false,
+		broker:           b,
+		pack: &agent.PackDefinition{
+			Slug:     "founding-team",
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend Engineer"},
+			},
+		},
+		headlessWorkers: make(map[string]bool),
+		headlessActive:  make(map[string]*headlessCodexActiveTurn),
+		headlessQueues:  make(map[string][]headlessCodexTurn),
+	}
+
+	l.resumeInFlightWork()
+
+	present := func(slug string) bool {
+		l.headlessMu.Lock()
+		defer l.headlessMu.Unlock()
+		return len(l.headlessQueues[slug]) > 0 || l.headlessActive[slug] != nil
+	}
+
+	if !present("ceo") {
+		t.Error("TUI+claude: CEO resume packet dropped — TUI must route through headless queue when paneBackedAgents=false")
+	}
+	if !present("fe") {
+		t.Error("TUI+claude: fe specialist resume packet dropped — TUI must route through headless queue when paneBackedAgents=false")
+	}
+}


### PR DESCRIPTION
## Summary

Makes headless \`claude --print\` per-turn the default dispatch path for both \`wuphf\` (web) and \`wuphf --tui\`. The legacy per-agent long-lived interactive tmux pane path is preserved as an internal fallback primitive but is no longer invoked at startup.

Motivation: Anthropic re-sanctioned headless CLI reuse in the 2026-04 OpenClaw policy note — it runs on the user's normal subscription quota with no separate extra-usage charge. Unifying dispatch across web and TUI matches how the Codex runtime already worked and removes tmux as a reliability-sensitive dependency in the common path. tmux is still required for \`--tui\` because the channel-view TUI itself lives in tmux; the web UI no longer needs it.

### Changes

- \`shouldUseHeadlessDispatch\` keys off \`paneBackedAgents\`, not \`webMode\` — TUI mode goes through the headless queue by default.
- \`Launch()\` (TUI) skips \`spawnVisibleAgents\` / \`primeVisibleAgents\` and calls \`resumeInFlightWork\` directly. The tmux session and channel-view pane still exist so the user has something to attach to.
- \`LaunchWeb\` calls \`resumeInFlightWork\` unconditionally and no longer invokes \`trySpawnWebAgentPanes\` at startup.
- \`trySpawnWebAgentPanes\` is retained as an internal fallback primitive (reachable if dispatch ever needs to promote to panes at runtime) with updated comments.
- \`resumeInFlightWork\` routing aligned with dispatch routing: keyed off \`!paneBackedAgents\` to prevent silently dropping resume packets when panes aren't up (caught via \`/review\`).
- \`enqueueHeadlessCodexTurnRecord\` lazily inits its three headless maps so test-constructed Launchers that skip \`NewLauncher\` don't panic when routed through headless.
- Durability-error path in \`runHeadlessCodexQueue\`: when the provider returns success but leaves no durable task state, block the task instead of retrying (the agent already had its turn).
- Messaging + docs updated to drop the stale "extra-usage quota" framing.

### Files

- \`internal/team/launcher.go\` — TUI + web dispatch defaults flipped, pane-spawn messaging rewritten.
- \`internal/team/headless_codex.go\` — map init, durability-error routing, \`isDurabilityError\` flag.
- \`internal/team/headless_codex_test.go\` — suppress lead-wake in queue-retry test to prevent interference.
- \`internal/team/resume.go\` — resume routing keyed off \`paneBackedAgents\`.
- \`internal/team/dispatch_test.go\` — test cases updated to match new defaults.
- \`internal/team/resume_test.go\` — regression test for TUI+claude resume routing.
- \`internal/team/launcher_tmux_fix_test.go\` — stale comment refresh.
- \`internal/config/config_test.go\` — trailing newline.
- \`README.md\` + \`CHANGELOG.md\` — documentation updates.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go vet ./...\` clean.
- [x] \`go test ./internal/config/... ./internal/team/... ./cmd/wuphf\` green (modulo two pre-existing flakes: \`TestAutoPromote_EndToEnd_HumanTagsPM_DispatchesToPM\` under \`-race\` and \`TestPlaybookSynthesizer_IntegrationTriggersAutoRecompile\` under full-suite load — both verified pre-existing against pristine tree).
- [x] New regression test \`TestResumeInFlightWorkTUIClaudeRoutesHeadless\` pins the resume-gating invariant.
- [ ] \`wuphf\` (web) manual smoke on dev ports — boots without tmux, agents respond headlessly.
- [ ] \`wuphf --tui\` manual smoke — channel pane renders, agents respond headlessly, resume works after restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)