### PR TITLE
fix(web): composer caret stays aligned when @-tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to WUPHF will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Caret no longer drifts when typing past an `@agent` chip in the composer.** The mirror-overlay treatment rendered mention chips with 4–5px horizontal padding and `font-size: 0.9em`, so each chip took more width than the raw text in the textarea behind it. The caret fell behind the typed characters by a few pixels after every chip. Composer chips now inherit the textarea's font metrics exactly (15px, no padding, `display: inline`) and only apply a background highlight — layout-neutral, so character-for-character alignment with the textarea is preserved. Message-bubble chips keep the original styled pill treatment.
+
 ### Changed
 
 - **Headless `claude --print` is now the default dispatch path for both `wuphf` (web) and `wuphf --tui`.** Anthropic re-sanctioned headless CLI reuse in the 2026-04 OpenClaw policy note, and it runs on the user's normal subscription quota — no separate extra-usage charge. Every turn now dispatches as a fresh `claude --print` invocation, matching how the Codex runtime already worked and unifying dispatch across both modes. The previous per-agent long-lived interactive tmux pane path is preserved as an internal fallback primitive (reachable if dispatch ever needs to promote to panes at runtime) but is no longer invoked at startup. tmux is still required for `--tui` since the channel-view TUI runs in tmux; the web UI no longer needs it.

--- a/web/public/themes/nex.css
+++ b/web/public/themes/nex.css
@@ -634,6 +634,25 @@ html[data-theme="nex"] .mention {
   border-radius: var(--radius-sm);
   padding: 1px 4px;
 }
+/* Composer mirror: the chip MUST use the same character metrics as the
+   textarea behind it, otherwise the caret drifts — `@pm` in the mirror
+   was rendering with 4px horizontal padding + 0.9em font size, so each
+   mention took ~10px more width than the raw text in the textarea and
+   the caret fell behind after the first tag. Background highlight only;
+   no layout-affecting properties. */
+html[data-theme="nex"] .composer-mirror .mention {
+  display: inline;
+  padding: 0;
+  font-size: inherit;
+  line-height: inherit;
+  font-weight: inherit;
+  border-radius: 0;
+  /* Use a box-shadow inset so the visual highlight stays without
+     adding any extrinsic padding. */
+  background: var(--accent-bg);
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent-bg);
+}
 
 /* Timestamps */
 html[data-theme="nex"] .message-time {

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -132,6 +132,19 @@
 
 /* ─── @mention ─── */
 .mention { display: inline-block; background: #FDF1E2; color: #D4700E; padding: 0 5px; border-radius: 3px; font-weight: 600; font-size: 0.9em; line-height: 1.4; vertical-align: baseline; }
+/* Composer mirror: the overlay text must share character metrics with
+   the textarea, otherwise padding + font-size-shrinking pushes the
+   caret out of alignment as the user types past the first tag.
+   Highlight-only treatment — no layout-affecting properties. */
+.composer-mirror .mention {
+  display: inline;
+  padding: 0;
+  font-size: inherit;
+  line-height: inherit;
+  font-weight: inherit;
+  border-radius: 0;
+  vertical-align: baseline;
+}
 
 /* ─── Reactions ─── */
 .message-reactions { display: flex; gap: 4px; margin-top: 4px; flex-wrap: wrap; }


### PR DESCRIPTION
## Summary

User observation after v0.63.1: caret position looks weird in the composer when tagging someone. Each typed character after an \`@agent\` chip sits a few pixels behind its rendered position.

## Root cause

The mirror-overlay chips picked up the same \`.mention\` CSS used in message bubbles:
- \`padding: 0 5px\` (messages.css base)
- \`padding: 1px 4px\` (nex theme override)
- \`font-size: 0.9em\`
- \`display: inline-block\`

These change the rendered horizontal width of a chip relative to the raw characters (\`@pm\` = 3 characters) in the textarea behind it. The textarea's caret is positioned by char count; the mirror positions the chip by rendered width. After every chip the two diverge by ~8–10px, and the visible caret lags typed characters.

## Fix

Composer-scoped override — \`.composer-mirror .mention\` — keeps the background highlight but strips all layout-affecting properties:
- \`display: inline\` (not \`inline-block\`)
- \`padding: 0\`
- \`font-size\`, \`line-height\`, \`font-weight\`: \`inherit\`
- \`border-radius: 0\`

Raw characters in the mirror take the exact width the textarea draws. Caret aligns character-for-character.

Message-bubble chips unchanged — the base \`.mention\` rule still applies outside the composer.

## Test plan

- [x] Type \`@planner hey\` in composer: chip shows background highlight, caret sits exactly after the typed character
- [x] Move caret mid-text with \`setSelectionRange\`: position matches visible text
- [x] Message bubble chips still render with the original styled pill treatment (verified on \`@planner are you done?\` in #general)
- [x] Computed styles: both \`.composer-input\` and \`.composer-mirror .mention\` at \`fontSize: 15px, lineHeight: 22.5px\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)