### PR TITLE
feat(web): surface active LLM model in status bar footer

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -4228,12 +4228,32 @@ func (b *Broker) handleHealth(w http.ResponseWriter, r *http.Request) {
 		"one_on_one_agent":      agent,
 		"focus_mode":            focus,
 		"provider":              provider,
+		"provider_model":        resolveProviderModel(provider),
 		"memory_backend":        memoryStatus.SelectedKind,
 		"memory_backend_active": memoryStatus.ActiveKind,
 		"memory_backend_ready":  memoryStatus.ActiveKind != config.MemoryBackendNone,
 		"nex_connected":         memoryStatus.ActiveKind == config.MemoryBackendNex && nex.Connected(),
 		"build":                 buildinfo.Current(),
 	})
+}
+
+// resolveProviderModel returns the effective model id for the active LLM
+// provider so the web UI's status bar can show, e.g.
+// "opencode · ollama/qwen2.5-coder:1.5b". Returns "" when the provider has
+// no resolvable model (claude-code uses the CLI's bundled default unless the
+// user overrides via --model; we don't parse that out here).
+func resolveProviderModel(provider string) string {
+	switch strings.ToLower(strings.TrimSpace(provider)) {
+	case "codex":
+		// Empty cwd keeps the home-dir config lookup but skips the
+		// workspace-relative walk — Broker doesn't know which workspace the
+		// caller is in, and the status bar is a coarse indicator anyway.
+		return config.ResolveCodexModel("")
+	case "opencode":
+		return config.ResolveOpencodeModel()
+	default:
+		return ""
+	}
 }
 
 func (b *Broker) handleVersion(w http.ResponseWriter, r *http.Request) {

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -336,7 +336,12 @@ export function answerRequest(id: string, choiceId: string, customText?: string)
 // ── Health ──
 
 export function getHealth() {
-  return get<{ status: string; agents?: Record<string, unknown> }>('/health')
+  return get<{
+    status: string
+    provider?: string
+    provider_model?: string
+    agents?: Record<string, unknown>
+  }>('/health')
 }
 
 // ── Tasks ──

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -7,6 +7,7 @@ import { Kbd } from '../ui/Kbd'
 interface HealthSnapshot {
   status: string
   provider?: string
+  provider_model?: string
   agents?: Record<string, unknown>
 }
 
@@ -41,6 +42,7 @@ export function StatusBar() {
       : `# ${currentChannel}`
   const modeLabel = dm ? '1:1' : 'office'
   const provider = health?.provider
+  const providerModel = health?.provider_model?.trim()
 
   return (
     <div className="status-bar">
@@ -59,8 +61,22 @@ export function StatusBar() {
       </button>
       <span className="status-bar-item">{agentCount} agent{agentCount === 1 ? '' : 's'}</span>
       {provider && (
-        <span className="status-bar-item" title={`Runtime provider: ${provider}`}>
-          {'⚙ '}{provider}
+        <span
+          className="status-bar-item"
+          title={
+            providerModel
+              ? `Runtime: ${provider} · ${providerModel}`
+              : `Runtime provider: ${provider}`
+          }
+        >
+          {'⚙ '}
+          {provider}
+          {providerModel && (
+            <>
+              <span className="status-bar-sep"> · </span>
+              <span className="status-bar-model">{providerModel}</span>
+            </>
+          )}
         </span>
       )}
       <span


### PR DESCRIPTION
## Summary

- `GET /health` now returns `provider_model` alongside `provider`, dispatching to `config.ResolveCodexModel` / `config.ResolveOpencodeModel`.
- `StatusBar` renders `⚙ opencode · ollama/qwen2.5-coder:1.5b` when the model is known; falls back to the existing `⚙ opencode` shape when it isn't (claude-code returns `""` since its CLI uses a bundled default).
- `getHealth` typing + `HealthSnapshot` carry the new field so the UI stays type-safe.

Useful context now that Opencode lets users route to any provider/model (Anthropic, OpenAI, local Ollama, vLLM, any OpenAI-compatible endpoint) — with one WUPHF install backing a 70B cloud model and another backing a 1.5B local model, the status bar should tell you which one you're actually talking to.

## Screenshot

Footer shows `⚙ opencode · ollama/qwen2.5-coder:1.5b · connected`:
![status bar close-up](https://github.com/user-attachments/assets/placeholder-close-up)

Full UI:
![full UI](https://github.com/user-attachments/assets/placeholder-full)

## Test plan

- [x] `go build ./... && go vet ./...` clean
- [x] Focused team tests pass (`go test -run TestConfigEndpoint ./internal/team/...`)
- [x] Web build passes (`npm run build`)
- [x] Manual e2e with opencode 1.14.21 + ollama 0.21.1 + qwen2.5-coder:1.5b:
  - Status bar renders `⚙ opencode · ollama/qwen2.5-coder:1.5b`
  - `/health` returns `"provider_model":"ollama/qwen2.5-coder:1.5b"`
  - `@ceo` message in #general roundtrips; latency log shows `agent=ceo provider=opencode final_chars=398`
- [ ] Verify codex path still shows model from `~/.codex/config.toml`
- [ ] Verify claude-code hides the model separator when `provider_model=""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)