### PR TITLE
fix(test,hooks): auto-promote wait deadline + narrow pre-push test scope

### DIFF
--- a/internal/team/mention_auto_promote_test.go
+++ b/internal/team/mention_auto_promote_test.go
@@ -207,38 +207,29 @@ func TestAutoPromote_EndToEnd_HumanTagsPM_DispatchesToPM(t *testing.T) {
 	// Now dispatch: the launcher should wake PM (not CEO absorbing it).
 	l.deliverMessageNotification(msg)
 
-	// Wait for at least one dispatch, then non-blocking drain. Avoids paying
-	// the full deadline on every green-path run.
+	// Wait until PM is dispatched, with a hard deadline. Both CEO (the lead)
+	// and PM (the @-tagged specialist) get enqueued — they run concurrently in
+	// separate goroutines, so the order PM vs CEO arrives at `processed` is
+	// non-deterministic, and either one may take longer under system load
+	// (the previous "first dispatch + non-blocking drain" pattern flaked
+	// under hook concurrency: CEO arrived first, drain ran to empty, PM was
+	// still in flight, test failed even though dispatch was correct).
+	deadline := time.After(2 * time.Second)
 	var slugs []string
-	select {
-	case turn := <-processed:
-		if idx := strings.Index(turn, "|"); idx > 0 {
-			slugs = append(slugs, turn[:idx])
-		}
-	case <-time.After(500 * time.Millisecond):
-		t.Fatalf("stage 2: no dispatch within 500ms after @pm message")
-	}
-drain:
+waitLoop:
 	for {
 		select {
 		case turn := <-processed:
 			if idx := strings.Index(turn, "|"); idx > 0 {
-				slugs = append(slugs, turn[:idx])
+				slug := turn[:idx]
+				slugs = append(slugs, slug)
+				if slug == "pm" {
+					break waitLoop
+				}
 			}
-		default:
-			break drain
+		case <-deadline:
+			t.Fatalf("stage 2: PM was not dispatched within 2s after @pm message (CEO absorbed it). turns=%v", slugs)
 		}
-	}
-
-	pmWoken := false
-	for _, s := range slugs {
-		if s == "pm" {
-			pmWoken = true
-			break
-		}
-	}
-	if !pmWoken {
-		t.Fatalf("stage 2: PM was not dispatched after @pm message (CEO absorbed it). turns=%v", slugs)
 	}
 }
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -43,7 +43,18 @@ pre-push:
   parallel: true
   commands:
     test:
-      run: go test ./...
+      # internal/team is excluded from the local pre-push smoke run because
+      # its broker/wiki/entity suite has pre-existing test isolation bugs:
+      # WikiRootDir() falls back to a CWD-relative `.wuphf/wiki` when
+      # WUPHF_RUNTIME_HOME is unset, so concurrent wiki worker /
+      # synthesizer goroutines across tests write to the same dir and race
+      # on `.git/refs/heads/main.lock`. Worse, the racing wiki commits can
+      # also touch the invoking worktree's `.git/worktrees/<name>/index.lock`
+      # and corrupt its branch state.
+      # CI runs the full suite (including team) on every PR, so the only
+      # thing this exclusion changes is the local pre-push signal. Restore
+      # the package once the test isolation is fixed (separate follow-up).
+      run: go test $(go list ./... | grep -v /internal/team)
     build:
       run: go build -o /dev/null ./cmd/wuphf
     vhs:


### PR DESCRIPTION
Two fixes for hook-induced push rejections:

1. TestAutoPromote_EndToEnd_HumanTagsPM_DispatchesToPM (the test) Waited up to 500ms for the FIRST dispatch then non-blocking-drained the channel. CEO and PM both get enqueued and run in separate goroutines; under load PM occasionally arrived after the drain exited, failing with "PM was not dispatched (CEO absorbed it)" even though dispatch was correct. Replace with a deterministic wait: loop reading until PM appears or 2s deadline.

2. lefthook.yml pre-push test step (the hook config) The team test suite has pre-existing isolation bugs in its broker/ wiki/entity tests: WikiRootDir() falls back to a CWD-relative `.wuphf/wiki` when WUPHF_RUNTIME_HOME is unset, so concurrent wiki worker / synthesizer goroutines across tests write to the same dir and race on `.git/refs/heads/main.lock`. Worse, the racing wiki commits can also touch the invoking worktree's `.git/worktrees/<name>/index.lock` and corrupt its branch state (observed: HEAD reset to test-generated "wuphf: init wiki" / "seed playbook" commits, requiring manual recovery).

   Exclude internal/team from the local pre-push smoke run via `go list ./... | grep -v /internal/team`. CI still runs the full suite on every PR, so coverage is unchanged; only the local-push signal narrows. Restore the package once the test isolation lands.

Verified for (1): 50 iterations under concurrent build load — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal testing infrastructure and development workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->