### PR TITLE
refactor(provider): Registry + capability checks — prep for local-LLM backends (#186)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,12 @@ jobs:
         with:
           name: web-dist
           path: web/dist
+      # `go vet` runs separately from `go test` so a vet failure surfaces with
+      # its own red x instead of being mixed into the test output. golangci-lint
+      # in the lint job runs vet too, but only what its govet linter enables;
+      # an explicit standalone vet step protects against config drift.
+      - name: Vet
+        run: go vet ./...
       # internal/team and internal/teammcp have known test-isolation issues
       # (WUPHF_RUNTIME_HOME, shared wiki path, worktree registration against
       # the invoking repo) tracked in the test-isolation memo. They run

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 // RuntimeHomeDir returns the home directory WUPHF should use for persisted
@@ -271,17 +272,46 @@ func ResolveLLMProvider(flagValue string) string {
 	return "claude-code"
 }
 
+// allowedLLMProviderKinds is the set of values normalizeLLMProvider accepts
+// for --provider, WUPHF_LLM_PROVIDER, and the config file. claude-code and
+// codex are baked in for backward compatibility and standalone config tests
+// (which don't import the provider package). Additional kinds are registered
+// at init() time by their provider implementation via AllowLLMProviderKind —
+// see internal/provider/registry.go.
+var (
+	allowedLLMProviderKindsMu sync.RWMutex
+	allowedLLMProviderKinds   = map[string]struct{}{
+		"claude-code": {},
+		"codex":       {},
+		"opencode":    {},
+	}
+)
+
+// AllowLLMProviderKind registers name as an acceptable provider value.
+// Provider implementations call this from init() so that
+// config.ResolveLLMProvider returns the kind for env/config values that match.
+// Idempotent: re-registering a known kind is a no-op.
+func AllowLLMProviderKind(name string) {
+	name = strings.TrimSpace(strings.ToLower(name))
+	if name == "" {
+		return
+	}
+	allowedLLMProviderKindsMu.Lock()
+	defer allowedLLMProviderKindsMu.Unlock()
+	allowedLLMProviderKinds[name] = struct{}{}
+}
+
 func normalizeLLMProvider(value string) string {
-	switch strings.TrimSpace(strings.ToLower(value)) {
-	case "claude-code":
-		return "claude-code"
-	case "codex":
-		return "codex"
-	case "opencode":
-		return "opencode"
-	default:
+	name := strings.TrimSpace(strings.ToLower(value))
+	if name == "" {
 		return ""
 	}
+	allowedLLMProviderKindsMu.RLock()
+	defer allowedLLMProviderKindsMu.RUnlock()
+	if _, ok := allowedLLMProviderKinds[name]; ok {
+		return name
+	}
+	return ""
 }
 
 var codexModelLinePattern = regexp.MustCompile(`(?m)^\s*model\s*=\s*("([^"\\]|\\.)*"|'[^']*')`)

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -68,6 +68,19 @@ type claudeAttemptResult struct {
 	loginRequired  bool
 }
 
+func init() {
+	Register(&Entry{
+		Kind:     KindClaudeCode,
+		StreamFn: CreateClaudeCodeStreamFn,
+		OneShot:  RunClaudeOneShot,
+		Capabilities: Capabilities{
+			PaneEligible:               true,
+			SupportsOneShot:            true,
+			RequiresClaudeSessionReset: true,
+		},
+	})
+}
+
 // CreateClaudeCodeStreamFn returns a StreamFn that runs the `claude` CLI and
 // parses its NDJSON stream output.
 func CreateClaudeCodeStreamFn(agentSlug string) agent.StreamFn {

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -18,6 +18,18 @@ var (
 	codexGetwd    = os.Getwd
 )
 
+func init() {
+	Register(&Entry{
+		Kind:     KindCodex,
+		StreamFn: CreateCodexCLIStreamFn,
+		OneShot:  RunCodexOneShot,
+		Capabilities: Capabilities{
+			PaneEligible:    false,
+			SupportsOneShot: true,
+		},
+	})
+}
+
 // CreateCodexCLIStreamFn returns a StreamFn that runs Codex CLI non-interactively.
 // WUPHF keeps the conversation history, so each invocation is intentionally ephemeral.
 func CreateCodexCLIStreamFn(agentSlug string) agent.StreamFn {

--- a/internal/provider/oneshot.go
+++ b/internal/provider/oneshot.go
@@ -4,15 +4,14 @@ import (
 	"github.com/nex-crm/wuphf/internal/config"
 )
 
-// RunConfiguredOneShot runs a single-shot generation using the configured LLM provider.
-// Providers without a dedicated one-shot path fall back to Claude for now.
+// RunConfiguredOneShot runs a single-shot generation using the active LLM
+// provider's OneShot implementation. Providers without a one-shot path
+// (Capabilities.SupportsOneShot == false) and unregistered kinds fall back
+// to Claude.
 func RunConfiguredOneShot(systemPrompt, prompt, cwd string) (string, error) {
-	switch config.ResolveLLMProvider("") {
-	case "codex":
-		return RunCodexOneShot(systemPrompt, prompt, cwd)
-	case "opencode":
-		return RunOpencodeOneShot(systemPrompt, prompt, cwd)
-	default:
-		return RunClaudeOneShot(systemPrompt, prompt, cwd)
+	kind := config.ResolveLLMProvider("")
+	if e := Lookup(kind); e != nil && e.Capabilities.SupportsOneShot && e.OneShot != nil {
+		return e.OneShot(systemPrompt, prompt, cwd)
 	}
+	return RunClaudeOneShot(systemPrompt, prompt, cwd)
 }

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -21,6 +21,18 @@ var (
 	opencodeGetwd    = os.Getwd
 )
 
+func init() {
+	Register(&Entry{
+		Kind:     KindOpencode,
+		StreamFn: CreateOpencodeCLIStreamFn,
+		OneShot:  RunOpencodeOneShot,
+		Capabilities: Capabilities{
+			PaneEligible:    false,
+			SupportsOneShot: true,
+		},
+	})
+}
+
 // CreateOpencodeCLIStreamFn returns a StreamFn that runs the Opencode CLI
 // non-interactively. Each invocation is ephemeral: WUPHF owns the conversation
 // history and hands Opencode a fresh prompt every turn.

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"fmt"
 	"sync"
-	"testing"
 
 	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/config"
@@ -76,6 +75,35 @@ func Register(e *Entry) {
 	config.AllowLLMProviderKind(e.Kind)
 }
 
+// RegisterTemporary installs e and returns a restore function. It is intended
+// for internal test support packages that need to inject fake providers without
+// importing testing from production provider code.
+func RegisterTemporary(e *Entry) func() {
+	if e == nil {
+		panic("provider: RegisterTemporary requires non-nil Entry")
+	}
+	if e.Kind == "" {
+		panic("provider: RegisterTemporary requires non-empty Entry.Kind")
+	}
+	if e.StreamFn == nil {
+		panic(fmt.Sprintf("provider: RegisterTemporary Kind %q requires non-nil StreamFn", e.Kind))
+	}
+	registryMu.Lock()
+	prev, hadPrev := registry[e.Kind]
+	registry[e.Kind] = e
+	registryMu.Unlock()
+	config.AllowLLMProviderKind(e.Kind)
+	return func() {
+		registryMu.Lock()
+		defer registryMu.Unlock()
+		if hadPrev {
+			registry[e.Kind] = prev
+		} else {
+			delete(registry, e.Kind)
+		}
+	}
+}
+
 // Lookup returns the registered Entry for kind, or nil if no provider with
 // that Kind has been registered. Callers that need a fallback (e.g., the
 // streaming resolver, the one-shot dispatcher) check for nil and use the
@@ -95,35 +123,4 @@ func CapabilitiesFor(kind string) Capabilities {
 		return e.Capabilities
 	}
 	return Capabilities{}
-}
-
-// RegisterForTest installs e for the duration of the test, restoring the prior
-// registration (if any) on cleanup. Use this in tests that need to inject a
-// fake provider without conflicting with init()-time registration of the
-// shipped providers.
-//
-// Like Register, this also teaches config.normalizeLLMProvider to accept
-// e.Kind so that t.Setenv("WUPHF_LLM_PROVIDER", e.Kind) round-trips through
-// config.ResolveLLMProvider. The config-side allowlist entry is permanent —
-// the kind name remains valid for the rest of the test binary's lifetime —
-// but Lookup returns the prior entry (or nil) once the test ends.
-func RegisterForTest(t testing.TB, e *Entry) {
-	t.Helper()
-	if e == nil || e.Kind == "" {
-		t.Fatal("RegisterForTest: Entry must be non-nil with non-empty Kind")
-	}
-	registryMu.Lock()
-	prev, hadPrev := registry[e.Kind]
-	registry[e.Kind] = e
-	registryMu.Unlock()
-	config.AllowLLMProviderKind(e.Kind)
-	t.Cleanup(func() {
-		registryMu.Lock()
-		defer registryMu.Unlock()
-		if hadPrev {
-			registry[e.Kind] = prev
-		} else {
-			delete(registry, e.Kind)
-		}
-	})
 }

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,0 +1,129 @@
+package provider
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// Capabilities describes how a provider integrates with the team launcher.
+//
+// Capabilities are consumed by team-side dispatch logic (pane spawning,
+// cleanup, session reset) so that adding a new provider Kind does not require
+// editing every conditional in launcher.go — instead, the provider declares
+// what it supports and the launcher reads those declarations.
+type Capabilities struct {
+	// PaneEligible reports whether the launcher should spawn an interactive
+	// tmux pane for an agent bound to this provider. True for runtimes with
+	// an interactive TUI (Claude Code). False for headless-only runtimes
+	// (Codex, OpenAI-compatible HTTP, OpenClaw bridge, etc.).
+	PaneEligible bool
+
+	// SupportsOneShot reports whether the provider implements OneShot. False
+	// providers fall back to the default one-shot path (currently Claude).
+	SupportsOneShot bool
+
+	// RequiresClaudeSessionReset reports whether switching the install-wide
+	// default away from this provider should also wipe the Claude session
+	// store. Today only Claude Code populates that store.
+	RequiresClaudeSessionReset bool
+}
+
+// Entry is a registered provider's runtime hooks plus its capabilities.
+//
+// StreamFn is required (every provider must support streaming). OneShot is
+// optional — providers without a one-shot implementation set Capabilities
+// .SupportsOneShot = false and leave OneShot nil; RunConfiguredOneShot then
+// falls back to claude-code.
+type Entry struct {
+	Kind         string
+	StreamFn     func(slug string) agent.StreamFn
+	OneShot      func(systemPrompt, prompt, cwd string) (string, error)
+	Capabilities Capabilities
+}
+
+var (
+	registryMu sync.RWMutex
+	registry   = map[string]*Entry{}
+)
+
+// Register installs a provider Entry. It also teaches the config layer to
+// accept e.Kind as a valid value for the WUPHF_LLM_PROVIDER env var, the
+// config file, and CLI --provider flags. Intended for use from package init().
+//
+// Panics if e is nil, e.Kind is empty, or e.Kind is already registered —
+// duplicate registration indicates a programming error (two init() calls for
+// the same Kind), not user input.
+func Register(e *Entry) {
+	if e == nil {
+		panic("provider: Register requires non-nil Entry")
+	}
+	if e.Kind == "" {
+		panic("provider: Register requires non-empty Entry.Kind")
+	}
+	if e.StreamFn == nil {
+		panic(fmt.Sprintf("provider: Register Kind %q requires non-nil StreamFn", e.Kind))
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if _, exists := registry[e.Kind]; exists {
+		panic(fmt.Sprintf("provider: Kind %q already registered", e.Kind))
+	}
+	registry[e.Kind] = e
+	config.AllowLLMProviderKind(e.Kind)
+}
+
+// Lookup returns the registered Entry for kind, or nil if no provider with
+// that Kind has been registered. Callers that need a fallback (e.g., the
+// streaming resolver, the one-shot dispatcher) check for nil and use the
+// claude-code default.
+func Lookup(kind string) *Entry {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	return registry[kind]
+}
+
+// CapabilitiesFor returns the capabilities for kind, or the zero value if
+// kind is not registered. The zero value (PaneEligible=false,
+// SupportsOneShot=false, RequiresClaudeSessionReset=false) is the safe default
+// — it skips pane spawning and falls back to the default one-shot path.
+func CapabilitiesFor(kind string) Capabilities {
+	if e := Lookup(kind); e != nil {
+		return e.Capabilities
+	}
+	return Capabilities{}
+}
+
+// RegisterForTest installs e for the duration of the test, restoring the prior
+// registration (if any) on cleanup. Use this in tests that need to inject a
+// fake provider without conflicting with init()-time registration of the
+// shipped providers.
+//
+// Like Register, this also teaches config.normalizeLLMProvider to accept
+// e.Kind so that t.Setenv("WUPHF_LLM_PROVIDER", e.Kind) round-trips through
+// config.ResolveLLMProvider. The config-side allowlist entry is permanent —
+// the kind name remains valid for the rest of the test binary's lifetime —
+// but Lookup returns the prior entry (or nil) once the test ends.
+func RegisterForTest(t testing.TB, e *Entry) {
+	t.Helper()
+	if e == nil || e.Kind == "" {
+		t.Fatal("RegisterForTest: Entry must be non-nil with non-empty Kind")
+	}
+	registryMu.Lock()
+	prev, hadPrev := registry[e.Kind]
+	registry[e.Kind] = e
+	registryMu.Unlock()
+	config.AllowLLMProviderKind(e.Kind)
+	t.Cleanup(func() {
+		registryMu.Lock()
+		defer registryMu.Unlock()
+		if hadPrev {
+			registry[e.Kind] = prev
+		} else {
+			delete(registry, e.Kind)
+		}
+	})
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -1,9 +1,11 @@
-package provider
+package provider_test
 
 import (
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/provider"
+	"github.com/nex-crm/wuphf/internal/providertest"
 )
 
 // TestRegistry_FakeKindRoutesEverywhere is the epicentric red test for the
@@ -22,7 +24,7 @@ func TestRegistry_FakeKindRoutesEverywhere(t *testing.T) {
 	const fakeKind = "wuphf-test-fake-provider"
 
 	var streamFnHits, oneShotHits int
-	RegisterForTest(t, &Entry{
+	providertest.RegisterForTest(t, &provider.Entry{
 		Kind: fakeKind,
 		StreamFn: func(slug string) agent.StreamFn {
 			return func([]agent.Message, []agent.AgentTool) <-chan agent.StreamChunk {
@@ -36,13 +38,13 @@ func TestRegistry_FakeKindRoutesEverywhere(t *testing.T) {
 			oneShotHits++
 			return "fake-oneshot-result", nil
 		},
-		Capabilities: Capabilities{SupportsOneShot: true},
+		Capabilities: provider.Capabilities{SupportsOneShot: true},
 	})
 
 	t.Setenv("WUPHF_LLM_PROVIDER", fakeKind)
 
 	// Path 1: streaming resolver.
-	fn := DefaultStreamFnResolver(nil, nil)("agent-slug")
+	fn := provider.DefaultStreamFnResolver(nil, nil)("agent-slug")
 	if fn == nil {
 		t.Fatal("resolver returned nil StreamFn for registered fake kind")
 	}
@@ -54,7 +56,7 @@ func TestRegistry_FakeKindRoutesEverywhere(t *testing.T) {
 	}
 
 	// Path 2: one-shot dispatch.
-	out, err := RunConfiguredOneShot("sys", "prompt", "/tmp")
+	out, err := provider.RunConfiguredOneShot("sys", "prompt", "/tmp")
 	if err != nil {
 		t.Fatalf("RunConfiguredOneShot returned error: %v", err)
 	}
@@ -70,7 +72,7 @@ func TestRegistry_FakeKindRoutesEverywhere(t *testing.T) {
 // TestRegistry_LookupReturnsNilForUnknown documents that a non-registered Kind
 // returns nil so dispatchers know to fall back to a default (claude-code).
 func TestRegistry_LookupReturnsNilForUnknown(t *testing.T) {
-	if e := Lookup("wuphf-never-registered-kind"); e != nil {
+	if e := provider.Lookup("wuphf-never-registered-kind"); e != nil {
 		t.Fatalf("Lookup returned non-nil entry %+v for unregistered kind", e)
 	}
 }
@@ -93,7 +95,7 @@ func TestStreamFnResolver_PerAgentKindOverridesInstallWide(t *testing.T) {
 	const agentKind = "wuphf-test-per-agent-kind"
 
 	var installHits, agentHits int
-	RegisterForTest(t, &Entry{
+	providertest.RegisterForTest(t, &provider.Entry{
 		Kind: installKind,
 		StreamFn: func(slug string) agent.StreamFn {
 			return func([]agent.Message, []agent.AgentTool) <-chan agent.StreamChunk {
@@ -104,7 +106,7 @@ func TestStreamFnResolver_PerAgentKindOverridesInstallWide(t *testing.T) {
 			}
 		},
 	})
-	RegisterForTest(t, &Entry{
+	providertest.RegisterForTest(t, &provider.Entry{
 		Kind: agentKind,
 		StreamFn: func(slug string) agent.StreamFn {
 			return func([]agent.Message, []agent.AgentTool) <-chan agent.StreamChunk {
@@ -125,7 +127,7 @@ func TestStreamFnResolver_PerAgentKindOverridesInstallWide(t *testing.T) {
 		return "" // empty → fall back to install-wide
 	}
 
-	resolver := DefaultStreamFnResolver(nil, kindResolver)
+	resolver := provider.DefaultStreamFnResolver(nil, kindResolver)
 
 	// Agent with a per-agent binding routes to agentKind, not installKind.
 	for range resolver("agent-on-per-agent-binding")(nil, nil) {
@@ -146,8 +148,8 @@ func TestStreamFnResolver_PerAgentKindOverridesInstallWide(t *testing.T) {
 // shipped providers so external callers (resolver, oneshot, future capability
 // checks) can rely on Lookup("claude-code") and Lookup("codex").
 func TestRegistry_BuiltinsRegistered(t *testing.T) {
-	for _, kind := range []string{KindClaudeCode, KindCodex} {
-		if e := Lookup(kind); e == nil {
+	for _, kind := range []string{provider.KindClaudeCode, provider.KindCodex} {
+		if e := provider.Lookup(kind); e == nil {
 			t.Errorf("builtin Kind %q not registered — init() missing or out of order", kind)
 		}
 	}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -42,7 +42,7 @@ func TestRegistry_FakeKindRoutesEverywhere(t *testing.T) {
 	t.Setenv("WUPHF_LLM_PROVIDER", fakeKind)
 
 	// Path 1: streaming resolver.
-	fn := DefaultStreamFnResolver(nil)("agent-slug")
+	fn := DefaultStreamFnResolver(nil, nil)("agent-slug")
 	if fn == nil {
 		t.Fatal("resolver returned nil StreamFn for registered fake kind")
 	}
@@ -72,6 +72,73 @@ func TestRegistry_FakeKindRoutesEverywhere(t *testing.T) {
 func TestRegistry_LookupReturnsNilForUnknown(t *testing.T) {
 	if e := Lookup("wuphf-never-registered-kind"); e != nil {
 		t.Fatalf("Lookup returned non-nil entry %+v for unregistered kind", e)
+	}
+}
+
+// TestStreamFnResolver_PerAgentKindOverridesInstallWide is the epicentric red
+// test for P0.3: a per-agent ProviderBinding must take priority over the
+// install-wide default when the streaming resolver routes a turn.
+//
+// Today the resolver ignores its agentSlug argument and reads only
+// config.ResolveLLMProvider, so an Ollama-bound agent on a claude-default
+// install gets routed to claude — the broker's per-agent ProviderBinding
+// data layer (broker.MemberProviderKind / memberEffectiveProviderKind in
+// the launcher) doesn't reach the StreamFn dispatch.
+//
+// The fix threads an optional ProviderKindResolver through
+// DefaultStreamFnResolver. When set, the per-agent kind wins; when nil,
+// resolution falls back to the install-wide ResolveLLMProvider.
+func TestStreamFnResolver_PerAgentKindOverridesInstallWide(t *testing.T) {
+	const installKind = "wuphf-test-install-wide-kind"
+	const agentKind = "wuphf-test-per-agent-kind"
+
+	var installHits, agentHits int
+	RegisterForTest(t, &Entry{
+		Kind: installKind,
+		StreamFn: func(slug string) agent.StreamFn {
+			return func([]agent.Message, []agent.AgentTool) <-chan agent.StreamChunk {
+				installHits++
+				ch := make(chan agent.StreamChunk)
+				close(ch)
+				return ch
+			}
+		},
+	})
+	RegisterForTest(t, &Entry{
+		Kind: agentKind,
+		StreamFn: func(slug string) agent.StreamFn {
+			return func([]agent.Message, []agent.AgentTool) <-chan agent.StreamChunk {
+				agentHits++
+				ch := make(chan agent.StreamChunk)
+				close(ch)
+				return ch
+			}
+		},
+	})
+
+	t.Setenv("WUPHF_LLM_PROVIDER", installKind)
+
+	kindResolver := func(slug string) string {
+		if slug == "agent-on-per-agent-binding" {
+			return agentKind
+		}
+		return "" // empty → fall back to install-wide
+	}
+
+	resolver := DefaultStreamFnResolver(nil, kindResolver)
+
+	// Agent with a per-agent binding routes to agentKind, not installKind.
+	for range resolver("agent-on-per-agent-binding")(nil, nil) {
+	}
+	if agentHits != 1 || installHits != 0 {
+		t.Fatalf("per-agent override did not take priority: agentHits=%d installHits=%d", agentHits, installHits)
+	}
+
+	// Agent without a per-agent binding falls back to install-wide kind.
+	for range resolver("agent-using-install-default")(nil, nil) {
+	}
+	if installHits != 1 {
+		t.Fatalf("fallback to install-wide kind did not work: installHits=%d", installHits)
 	}
 }
 

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -1,0 +1,87 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+)
+
+// TestRegistry_FakeKindRoutesEverywhere is the epicentric red test for the
+// provider Registry: register a fake Kind, set it as the active provider, and
+// confirm that BOTH the streaming resolver and the one-shot dispatcher route
+// to the fake — not to claude-code's default fallback.
+//
+// Before the Registry exists, this test fails because:
+//   - resolver.go has a hardcoded switch that knows only "claude-code"/"codex"
+//     and falls through to CreateClaudeCodeStreamFn for unknown values.
+//   - oneshot.go has the same closed switch, falling through to RunClaudeOneShot.
+//
+// After the Registry exists and resolver+oneshot dispatch through it, the fake's
+// StreamFn and OneShot are invoked and the assertions pass.
+func TestRegistry_FakeKindRoutesEverywhere(t *testing.T) {
+	const fakeKind = "wuphf-test-fake-provider"
+
+	var streamFnHits, oneShotHits int
+	RegisterForTest(t, &Entry{
+		Kind: fakeKind,
+		StreamFn: func(slug string) agent.StreamFn {
+			return func([]agent.Message, []agent.AgentTool) <-chan agent.StreamChunk {
+				streamFnHits++
+				ch := make(chan agent.StreamChunk)
+				close(ch)
+				return ch
+			}
+		},
+		OneShot: func(systemPrompt, prompt, cwd string) (string, error) {
+			oneShotHits++
+			return "fake-oneshot-result", nil
+		},
+		Capabilities: Capabilities{SupportsOneShot: true},
+	})
+
+	t.Setenv("WUPHF_LLM_PROVIDER", fakeKind)
+
+	// Path 1: streaming resolver.
+	fn := DefaultStreamFnResolver(nil)("agent-slug")
+	if fn == nil {
+		t.Fatal("resolver returned nil StreamFn for registered fake kind")
+	}
+	for range fn(nil, nil) {
+		// drain
+	}
+	if streamFnHits == 0 {
+		t.Fatal("streaming resolver did not route to fake provider via Registry — still hardcoded switch?")
+	}
+
+	// Path 2: one-shot dispatch.
+	out, err := RunConfiguredOneShot("sys", "prompt", "/tmp")
+	if err != nil {
+		t.Fatalf("RunConfiguredOneShot returned error: %v", err)
+	}
+	if out != "fake-oneshot-result" {
+		t.Fatalf("RunConfiguredOneShot returned %q, want %q — did not route to fake via Registry",
+			out, "fake-oneshot-result")
+	}
+	if oneShotHits == 0 {
+		t.Fatal("one-shot dispatcher did not route to fake provider via Registry")
+	}
+}
+
+// TestRegistry_LookupReturnsNilForUnknown documents that a non-registered Kind
+// returns nil so dispatchers know to fall back to a default (claude-code).
+func TestRegistry_LookupReturnsNilForUnknown(t *testing.T) {
+	if e := Lookup("wuphf-never-registered-kind"); e != nil {
+		t.Fatalf("Lookup returned non-nil entry %+v for unregistered kind", e)
+	}
+}
+
+// TestRegistry_BuiltinsRegistered ensures the package's init() registers the
+// shipped providers so external callers (resolver, oneshot, future capability
+// checks) can rely on Lookup("claude-code") and Lookup("codex").
+func TestRegistry_BuiltinsRegistered(t *testing.T) {
+	for _, kind := range []string{KindClaudeCode, KindCodex} {
+		if e := Lookup(kind); e == nil {
+			t.Errorf("builtin Kind %q not registered — init() missing or out of order", kind)
+		}
+	}
+}

--- a/internal/provider/resolver.go
+++ b/internal/provider/resolver.go
@@ -6,21 +6,23 @@ import (
 	"github.com/nex-crm/wuphf/internal/config"
 )
 
-// DefaultStreamFnResolver returns a StreamFnResolver that picks the right provider
-// based on the user's config (llm_provider, gemini_api_key).
-// Config is re-read on each call so runtime provider changes take effect.
+// DefaultStreamFnResolver returns a StreamFnResolver that picks a provider's
+// StreamFn factory based on the active LLM provider (config.ResolveLLMProvider).
+// Resolution goes through the Registry (registry.go), so any provider that
+// registers via init() — including future Ollama/vLLM/exo backends — is
+// reachable here without editing this file.
+//
+// Config is re-read on each call so runtime provider changes (e.g., a /provider
+// switch from the TUI) take effect on the next agent turn.
+//
+// Unknown or unregistered kinds fall back to claude-code, the most capable
+// runtime for multi-turn orchestration.
 func DefaultStreamFnResolver(client *api.Client) agent.StreamFnResolver {
 	return func(agentSlug string) agent.StreamFn {
-		switch config.ResolveLLMProvider("") {
-		case "codex":
-			return CreateCodexCLIStreamFn(agentSlug)
-		case "opencode":
-			return CreateOpencodeCLIStreamFn(agentSlug)
-		case "claude-code", "":
-			// Default to Claude Code — most capable for multi-turn orchestration
-			return CreateClaudeCodeStreamFn(agentSlug)
-		default:
-			return CreateClaudeCodeStreamFn(agentSlug)
+		kind := config.ResolveLLMProvider("")
+		if e := Lookup(kind); e != nil {
+			return e.StreamFn(agentSlug)
 		}
+		return CreateClaudeCodeStreamFn(agentSlug)
 	}
 }

--- a/internal/provider/resolver.go
+++ b/internal/provider/resolver.go
@@ -6,20 +6,34 @@ import (
 	"github.com/nex-crm/wuphf/internal/config"
 )
 
+// ProviderKindResolver maps an agent slug to its registered provider Kind.
+// Implementations consult per-agent state (e.g., broker.MemberProviderKind)
+// and return "" when the agent has no explicit binding so the resolver can
+// fall back to the install-wide default.
+type ProviderKindResolver func(agentSlug string) string
+
 // DefaultStreamFnResolver returns a StreamFnResolver that picks a provider's
-// StreamFn factory based on the active LLM provider (config.ResolveLLMProvider).
-// Resolution goes through the Registry (registry.go), so any provider that
-// registers via init() — including future Ollama/vLLM/exo backends — is
-// reachable here without editing this file.
+// StreamFn factory by Kind. Resolution order:
+//
+//  1. Per-agent kind from kindResolver (if non-nil and returns non-empty)
+//  2. Install-wide kind from config.ResolveLLMProvider
+//  3. Claude Code (default fallback for unknown / unregistered Kinds)
+//
+// kindResolver is what makes per-agent ProviderBindings (an Ollama agent
+// alongside Claude agents in the same team) actually take effect on the
+// streaming dispatch path. Pass nil to use only the install-wide default.
 //
 // Config is re-read on each call so runtime provider changes (e.g., a /provider
-// switch from the TUI) take effect on the next agent turn.
-//
-// Unknown or unregistered kinds fall back to claude-code, the most capable
-// runtime for multi-turn orchestration.
-func DefaultStreamFnResolver(client *api.Client) agent.StreamFnResolver {
+// switch from the TUI) take effect on the next agent turn without restart.
+func DefaultStreamFnResolver(client *api.Client, kindResolver ProviderKindResolver) agent.StreamFnResolver {
 	return func(agentSlug string) agent.StreamFn {
-		kind := config.ResolveLLMProvider("")
+		var kind string
+		if kindResolver != nil {
+			kind = kindResolver(agentSlug)
+		}
+		if kind == "" {
+			kind = config.ResolveLLMProvider("")
+		}
 		if e := Lookup(kind); e != nil {
 			return e.StreamFn(agentSlug)
 		}

--- a/internal/provider/resolver.go
+++ b/internal/provider/resolver.go
@@ -26,6 +26,7 @@ type ProviderKindResolver func(agentSlug string) string
 // Config is re-read on each call so runtime provider changes (e.g., a /provider
 // switch from the TUI) take effect on the next agent turn without restart.
 func DefaultStreamFnResolver(client *api.Client, kindResolver ProviderKindResolver) agent.StreamFnResolver {
+	// TODO: thread client into provider-specific StreamFn factories (see issue #186).
 	return func(agentSlug string) agent.StreamFn {
 		var kind string
 		if kindResolver != nil {

--- a/internal/provider/resolver_test.go
+++ b/internal/provider/resolver_test.go
@@ -9,7 +9,7 @@ import (
 func TestDefaultResolverUsesClaudeCode(t *testing.T) {
 	// When LLMProvider is empty, should resolve to claude-code, not nex-ask
 	cfg := config.Config{} // empty provider
-	resolver := DefaultStreamFnResolver(nil)
+	resolver := DefaultStreamFnResolver(nil, nil)
 	fn := resolver("test-agent")
 	if fn == nil {
 		t.Fatal("resolver returned nil StreamFn")

--- a/internal/provider/types.go
+++ b/internal/provider/types.go
@@ -1,9 +1,9 @@
 // Package provider implements LLM backend providers for agents.
+//
+// Each provider (claude-code, codex, future ollama/vllm/exo/openai-compatible)
+// registers itself with the Registry (registry.go) at init() time. Dispatch
+// sites — DefaultStreamFnResolver, RunConfiguredOneShot, and team-side
+// capability checks (PaneEligible, RequiresClaudeSessionReset) — look kinds
+// up through the Registry rather than hardcoded switches, so adding a new
+// provider does not require touching every dispatcher.
 package provider
-
-import "github.com/nex-crm/wuphf/internal/agent"
-
-// Provider creates a StreamFn for a given agent slug.
-type Provider interface {
-	CreateStreamFn(agentSlug string) agent.StreamFn
-}

--- a/internal/providertest/register.go
+++ b/internal/providertest/register.go
@@ -1,0 +1,20 @@
+package providertest
+
+import (
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// RegisterForTest installs e for tests that need a fake provider kind.
+//
+// Keeping this helper outside internal/provider avoids importing testing from
+// production provider code.
+func RegisterForTest(t testing.TB, e *provider.Entry) {
+	t.Helper()
+	if e == nil || e.Kind == "" {
+		t.Fatal("RegisterForTest: Entry must be non-nil with non-empty Kind")
+	}
+	restore := provider.RegisterTemporary(e)
+	t.Cleanup(restore)
+}

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -1979,6 +1979,12 @@ func (l *Launcher) oneOnOneAgent() string {
 // headless one-shot runtime (shared by Codex and Opencode — both skip the
 // tmux/claude pane infrastructure and drive a fresh CLI per turn through the
 // broker queue in headless_codex.go).
+//
+// Prefer the capability helpers (usesPaneRuntime, requiresClaudeSessionReset)
+// for new code asking "is this a non-pane runtime" — they're Registry-driven
+// and pick up future providers (Ollama, vLLM, exo, OpenAI-compatible) without
+// further edits here. usesCodexRuntime stays for codex/opencode-binary-specific
+// concerns (Preflight, launch routing).
 func (l *Launcher) usesCodexRuntime() bool {
 	p := strings.TrimSpace(strings.ToLower(l.provider))
 	return p == "codex" || p == "opencode"
@@ -1989,6 +1995,21 @@ func (l *Launcher) usesCodexRuntime() bool {
 // (binary name, args, prompt layout).
 func (l *Launcher) usesOpencodeRuntime() bool {
 	return strings.EqualFold(strings.TrimSpace(l.provider), "opencode")
+}
+
+// usesPaneRuntime reports whether the install-wide provider should run
+// agents in interactive tmux panes. Reads PaneEligible from the provider
+// Registry; an unregistered or non-pane-eligible provider returns false,
+// so dispatch falls through to the headless path.
+func (l *Launcher) usesPaneRuntime() bool {
+	return provider.CapabilitiesFor(normalizeProviderKind(l.provider)).PaneEligible
+}
+
+// requiresClaudeSessionReset reports whether the install-wide provider
+// populates the Claude session store and therefore needs provider.ResetClaudeSessions
+// to run on ResetSession / ReconfigureSession. Today only Claude Code does.
+func (l *Launcher) requiresClaudeSessionReset() bool {
+	return provider.CapabilitiesFor(normalizeProviderKind(l.provider)).RequiresClaudeSessionReset
 }
 
 // memberEffectiveProviderKind returns the provider kind that should run the
@@ -2031,8 +2052,10 @@ func normalizeProviderKind(raw string) string {
 	}
 }
 
+// UsesTmuxRuntime reports whether agents run in tmux panes. Equivalent to
+// usesPaneRuntime — exported for cmd/wuphf/main.go and tests.
 func (l *Launcher) UsesTmuxRuntime() bool {
-	return !l.usesCodexRuntime()
+	return l.usesPaneRuntime()
 }
 
 func (l *Launcher) BrokerToken() string {
@@ -2146,7 +2169,7 @@ func (l *Launcher) Kill() error {
 	// still alive to release any open handles (harmless, but principle of
 	// least surprise).
 	l.cleanupAgentTempFiles()
-	if l.usesCodexRuntime() {
+	if !l.usesPaneRuntime() {
 		if err := killPersistedOfficeProcess(); err != nil {
 			return err
 		}
@@ -2167,7 +2190,7 @@ func (l *Launcher) Kill() error {
 }
 
 func (l *Launcher) ResetSession() error {
-	if l.usesCodexRuntime() {
+	if !l.requiresClaudeSessionReset() {
 		if l != nil && l.broker != nil {
 			l.broker.Reset()
 			return nil
@@ -2191,7 +2214,7 @@ func (l *Launcher) ResetSession() error {
 }
 
 func (l *Launcher) ReconfigureSession() error {
-	if l.usesCodexRuntime() {
+	if !l.usesPaneRuntime() {
 		if err := provider.ResetClaudeSessions(); err != nil {
 			return fmt.Errorf("reset Claude sessions: %w", err)
 		}
@@ -2206,7 +2229,7 @@ func (l *Launcher) ReconfigureSession() error {
 
 func (l *Launcher) reconfigureVisibleAgents() error {
 	l.provider = config.ResolveLLMProvider("")
-	if l.usesCodexRuntime() {
+	if !l.usesPaneRuntime() {
 		if l.paneBackedAgents {
 			_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 			l.paneBackedAgents = false
@@ -2883,7 +2906,7 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 // Codex runtime is always headless. Pane-backed interactive dispatch is only
 // used when the fallback path explicitly brought panes up (paneBackedAgents).
 func (l *Launcher) shouldUseHeadlessDispatch() bool {
-	if l.usesCodexRuntime() {
+	if !l.usesPaneRuntime() {
 		return true
 	}
 	return !l.paneBackedAgents
@@ -3539,8 +3562,9 @@ func (l *Launcher) trySpawnWebAgentPanes() {
 	if l.broker == nil {
 		return
 	}
-	// Codex runtime uses its own headless pipeline; panes don't apply.
-	if l.usesCodexRuntime() {
+	// Non-pane runtimes (Codex, future Ollama/vLLM/exo/openai-compat) use the
+	// headless pipeline; panes don't apply.
+	if !l.usesPaneRuntime() {
 		return
 	}
 	if _, err := exec.LookPath("tmux"); err != nil {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -1943,7 +1943,7 @@ func (l *Launcher) shouldUseHeadlessDispatchForTarget(target notificationTarget)
 
 // skipPaneForSlug returns true when the given slug should not have a tmux
 // pane target registered — either because pane spawn failed earlier, or
-// because the agent is bound to the codex runtime and uses its own headless
+// because the agent is bound to a non-pane provider and uses its own headless
 // pipeline. In either case, dispatch falls back to the headless path.
 func (l *Launcher) skipPaneForSlug(slug string) bool {
 	slug = strings.TrimSpace(slug)
@@ -2026,12 +2026,11 @@ func (l *Launcher) memberEffectiveProviderKind(slug string) string {
 }
 
 // memberUsesHeadlessOneShotRuntime reports whether the given agent is bound to
-// a runtime that drives a fresh CLI per turn (Codex, Opencode). Such agents
-// skip the tmux/claude pane infrastructure in favor of the broker-driven queue
-// in headless_codex.go.
+// a runtime that is not pane-eligible and therefore skips the tmux/claude pane
+// infrastructure in favor of the broker-driven headless queue.
 func (l *Launcher) memberUsesHeadlessOneShotRuntime(slug string) bool {
 	kind := l.memberEffectiveProviderKind(slug)
-	return kind == provider.KindCodex || kind == provider.KindOpencode
+	return !provider.CapabilitiesFor(kind).PaneEligible
 }
 
 // normalizeProviderKind trims and canonicalizes provider kinds while

--- a/internal/team/provider_capability_test.go
+++ b/internal/team/provider_capability_test.go
@@ -1,0 +1,81 @@
+package team
+
+import (
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// TestUsesPaneRuntime_ConsultsRegistryCapabilities is the epicentric red test
+// for P0.2: install-wide pane-eligibility must come from the Registry, not
+// from the binary `provider == "codex"` predicate.
+//
+// Today UsesTmuxRuntime() returns !usesCodexRuntime(), so any non-codex value
+// (including a hypothetical "ollama" or "openai-compatible") is reported as
+// pane-eligible — wrong for runtimes that talk to an HTTP API instead of
+// running an interactive TUI in a tmux pane.
+//
+// Before the refactor: UsesTmuxRuntime() == true for the fake non-pane Kind
+//
+//	(because the fake isn't "codex"). Test FAILS.
+//
+// After the refactor:  UsesTmuxRuntime() consults provider.CapabilitiesFor
+//
+//	and returns the registered PaneEligible value. Test PASSES.
+func TestUsesPaneRuntime_ConsultsRegistryCapabilities(t *testing.T) {
+	const fakeKind = "wuphf-test-fake-non-pane"
+	provider.RegisterForTest(t, &provider.Entry{
+		Kind: fakeKind,
+		StreamFn: func(slug string) agent.StreamFn {
+			return func([]agent.Message, []agent.AgentTool) <-chan agent.StreamChunk {
+				ch := make(chan agent.StreamChunk)
+				close(ch)
+				return ch
+			}
+		},
+		Capabilities: provider.Capabilities{PaneEligible: false},
+	})
+
+	l := &Launcher{provider: fakeKind}
+	if l.UsesTmuxRuntime() {
+		t.Fatal("UsesTmuxRuntime() returned true for a non-pane-eligible provider; " +
+			"the predicate must consult provider.CapabilitiesFor, not just !codex")
+	}
+}
+
+// TestUsesPaneRuntime_PaneEligibleProviderStaysTrue confirms that pane-eligible
+// runtimes (Claude Code today, future Ollama variants if any) keep their
+// pane-runtime status after the refactor.
+func TestUsesPaneRuntime_PaneEligibleProviderStaysTrue(t *testing.T) {
+	const fakeKind = "wuphf-test-fake-pane"
+	provider.RegisterForTest(t, &provider.Entry{
+		Kind: fakeKind,
+		StreamFn: func(slug string) agent.StreamFn {
+			return func([]agent.Message, []agent.AgentTool) <-chan agent.StreamChunk {
+				ch := make(chan agent.StreamChunk)
+				close(ch)
+				return ch
+			}
+		},
+		Capabilities: provider.Capabilities{PaneEligible: true},
+	})
+
+	l := &Launcher{provider: fakeKind}
+	if !l.UsesTmuxRuntime() {
+		t.Fatal("UsesTmuxRuntime() returned false for a pane-eligible provider")
+	}
+}
+
+// TestRequiresClaudeSessionReset_OnlyTrueForClaude pins the second capability:
+// only providers that populate provider.ResetClaudeSessions's session store
+// should trigger a reset when ResetSession runs. Codex doesn't; a future
+// Ollama provider doesn't; only Claude Code does.
+func TestRequiresClaudeSessionReset_OnlyTrueForClaude(t *testing.T) {
+	if !provider.CapabilitiesFor(provider.KindClaudeCode).RequiresClaudeSessionReset {
+		t.Error("Claude Code should declare RequiresClaudeSessionReset=true")
+	}
+	if provider.CapabilitiesFor(provider.KindCodex).RequiresClaudeSessionReset {
+		t.Error("Codex should declare RequiresClaudeSessionReset=false (no Claude session state)")
+	}
+}

--- a/internal/team/provider_capability_test.go
+++ b/internal/team/provider_capability_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/provider"
+	"github.com/nex-crm/wuphf/internal/providertest"
 )
 
 // TestUsesPaneRuntime_ConsultsRegistryCapabilities is the epicentric red test
@@ -25,7 +26,7 @@ import (
 //	and returns the registered PaneEligible value. Test PASSES.
 func TestUsesPaneRuntime_ConsultsRegistryCapabilities(t *testing.T) {
 	const fakeKind = "wuphf-test-fake-non-pane"
-	provider.RegisterForTest(t, &provider.Entry{
+	providertest.RegisterForTest(t, &provider.Entry{
 		Kind: fakeKind,
 		StreamFn: func(slug string) agent.StreamFn {
 			return func([]agent.Message, []agent.AgentTool) <-chan agent.StreamChunk {
@@ -49,7 +50,7 @@ func TestUsesPaneRuntime_ConsultsRegistryCapabilities(t *testing.T) {
 // pane-runtime status after the refactor.
 func TestUsesPaneRuntime_PaneEligibleProviderStaysTrue(t *testing.T) {
 	const fakeKind = "wuphf-test-fake-pane"
-	provider.RegisterForTest(t, &provider.Entry{
+	providertest.RegisterForTest(t, &provider.Entry{
 		Kind: fakeKind,
 		StreamFn: func(slug string) agent.StreamFn {
 			return func([]agent.Message, []agent.AgentTool) <-chan agent.StreamChunk {

--- a/internal/team/resume.go
+++ b/internal/team/resume.go
@@ -177,13 +177,14 @@ func (l *Launcher) buildResumePackets() map[string]string {
 
 // resumeInFlightWork builds resume packets for all agents with pending work and
 // delivers them via the appropriate runtime:
-//   - Headless (Codex, or any mode without live panes): enqueueHeadlessCodexTurn
-//   - tmux pane-backed: sendNotificationToPane
+//   - Headless or non-pane provider: enqueueHeadlessCodexTurn
+//   - Pane-eligible provider with a live pane target: sendNotificationToPane
 //
-// The routing key is paneBackedAgents, mirroring shouldUseHeadlessDispatch.
-// webMode alone is not sufficient: TUI mode now defaults to headless dispatch,
-// and keying on webMode would send resume packets through agentPaneTargets()
-// to pane indices that were never spawned — silently dropping resumption.
+// Routing is decided per agent so ProviderBinding overrides can mix pane-backed
+// and headless runtimes in the same team. webMode alone is not sufficient: TUI
+// mode now defaults to headless dispatch, and keying on webMode would send
+// resume packets through agentPaneTargets() to pane indices that were never
+// spawned, silently dropping resumption.
 //
 // In headless mode the lead is enqueued FIRST to avoid the queue-hold guard:
 // enqueueHeadlessCodexTurn suppresses lead notifications when any specialist
@@ -195,28 +196,28 @@ func (l *Launcher) resumeInFlightWork() {
 		return
 	}
 
-	if !l.usesPaneRuntime() || !l.paneBackedAgents {
-		lead := l.officeLeadSlug()
-		// Enqueue lead first to bypass the queue-hold guard.
-		if packet, ok := packets[lead]; ok {
-			l.enqueueHeadlessCodexTurn(lead, packet)
-		}
-		for slug, packet := range packets {
-			if slug == lead {
-				continue
-			}
-			l.enqueueHeadlessCodexTurn(slug, packet)
-		}
-		return
-	}
-
-	// Pane-backed fallback path — need live pane targets.
 	paneTargets := l.agentPaneTargets()
-	for slug, packet := range packets {
+	routePacket := func(slug, packet string) {
+		if l.memberUsesHeadlessOneShotRuntime(slug) || !l.paneBackedAgents {
+			l.enqueueHeadlessCodexTurn(slug, packet)
+			return
+		}
 		target, ok := paneTargets[slug]
 		if !ok {
+			l.enqueueHeadlessCodexTurn(slug, packet)
+			return
+		}
+		launcherSendNotificationToPane(l, target.PaneTarget, packet)
+	}
+
+	lead := l.officeLeadSlug()
+	if packet, ok := packets[lead]; ok {
+		routePacket(lead, packet)
+	}
+	for slug, packet := range packets {
+		if slug == lead {
 			continue
 		}
-		l.sendNotificationToPane(target.PaneTarget, packet)
+		routePacket(slug, packet)
 	}
 }

--- a/internal/team/resume.go
+++ b/internal/team/resume.go
@@ -195,7 +195,7 @@ func (l *Launcher) resumeInFlightWork() {
 		return
 	}
 
-	if l.usesCodexRuntime() || !l.paneBackedAgents {
+	if !l.usesPaneRuntime() || !l.paneBackedAgents {
 		lead := l.officeLeadSlug()
 		// Enqueue lead first to bypass the queue-hold guard.
 		if packet, ok := packets[lead]; ok {

--- a/internal/team/resume_test.go
+++ b/internal/team/resume_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/provider"
 )
 
 // agent is used by the routing tests to construct legacy compatibility packs.
@@ -736,5 +737,79 @@ func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
 	}
 	if !present("fe") {
 		t.Error("TUI+claude: fe specialist resume packet dropped — TUI must route through headless queue when paneBackedAgents=false")
+	}
+}
+
+func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	oldWakeLead := headlessWakeLeadFn
+	headlessWakeLeadFn = func(_ *Launcher, _ string) {}
+	defer func() { headlessWakeLeadFn = oldWakeLead }()
+
+	oldSendPane := launcherSendNotificationToPane
+	var paneNotifications []string
+	launcherSendNotificationToPane = func(_ *Launcher, paneTarget, notification string) {
+		paneNotifications = append(paneNotifications, paneTarget+"\n"+notification)
+	}
+	defer func() { launcherSendNotificationToPane = oldSendPane }()
+
+	b := NewBroker()
+	b.mu.Lock()
+	b.members = []officeMember{
+		{Slug: "ceo", Name: "CEO", Provider: provider.ProviderBinding{Kind: provider.KindClaudeCode}},
+		{Slug: "fe", Name: "Frontend Engineer"},
+	}
+	b.tasks = []teamTask{
+		{ID: "t1", Title: "Build login form", Owner: "fe", Status: "in_progress"},
+	}
+	b.messages = []channelMessage{
+		{ID: "h1", From: "you", Content: "what is the strategy?", Timestamp: "2026-04-14T10:00:00Z"},
+	}
+	b.mu.Unlock()
+
+	l := &Launcher{
+		provider:         provider.KindCodex,
+		paneBackedAgents: true,
+		sessionName:      "test-session",
+		broker:           b,
+		pack: &agent.PackDefinition{
+			Slug:     "founding-team",
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend Engineer"},
+			},
+		},
+		headlessWorkers: map[string]bool{
+			"ceo": true,
+			"fe":  true,
+		},
+		headlessActive: make(map[string]*headlessCodexActiveTurn),
+		headlessQueues: make(map[string][]headlessCodexTurn),
+	}
+
+	l.resumeInFlightWork()
+
+	if len(paneNotifications) != 1 {
+		t.Fatalf("expected 1 pane notification for claude-bound lead, got %d: %#v", len(paneNotifications), paneNotifications)
+	}
+	if !strings.Contains(paneNotifications[0], "test-session:team.1") || !strings.Contains(paneNotifications[0], "strategy") {
+		t.Fatalf("unexpected pane notification: %q", paneNotifications[0])
+	}
+
+	l.headlessMu.Lock()
+	ceoQueue := append([]headlessCodexTurn(nil), l.headlessQueues["ceo"]...)
+	feQueue := append([]headlessCodexTurn(nil), l.headlessQueues["fe"]...)
+	l.headlessMu.Unlock()
+
+	if len(ceoQueue) != 0 {
+		t.Fatalf("claude-bound lead should not also be enqueued headless, got %#v", ceoQueue)
+	}
+	if len(feQueue) != 1 || !strings.Contains(feQueue[0].Prompt, "Build login form") {
+		t.Fatalf("expected codex-default specialist to resume through headless queue, got %#v", feQueue)
 	}
 }


### PR DESCRIPTION
## Summary

Four-commit prep pass that lays the foundation for issue #186 (local/on-prem LLM backends — Ollama, vLLM, exo, OpenAI-compat). No new providers in this PR; instead, this carves the abstraction so adding one is a single new file with `init() { Register(...) }`.

### Commits

- **`refactor(provider): introduce Registry for self-registering providers`** — replaces the dead `Provider` interface in `internal/provider/types.go` with a real Registry keyed by Kind. claude-code, codex, and opencode self-register via `init()` with `StreamFn`, `OneShot`, and `Capabilities` (`PaneEligible`, `SupportsOneShot`, `RequiresClaudeSessionReset`). The streaming resolver and one-shot dispatcher now look up through the Registry instead of hardcoded switches.
- **`refactor(team): replace usesCodexRuntime() with capability checks`** — six install-wide call sites in `internal/team/launcher.go` and one in `resume.go` were using `l.provider == "codex"` (later codex+opencode) as a stand-in for "is this a non-pane runtime". That breaks for any new non-codex non-pane provider. Introduces `usesPaneRuntime()` and `requiresClaudeSessionReset()` helpers backed by Registry capabilities. The legacy `usesCodexRuntime()` stays for codex/opencode-binary-specific concerns (Preflight, launch routing).
- **`feat(provider): per-agent kind override in DefaultStreamFnResolver`** — threads an optional `ProviderKindResolver` through the streaming dispatch so per-agent `ProviderBinding` (already at the data layer via `broker.MemberProviderKind`) actually takes effect. Today the streaming resolver isn't wired into production (the headless path in `headless_codex.go` is the live dispatch and already consults `memberEffectiveProviderKind`), but the seam being correct now means future wiring won't silently lose per-agent dispatch.
- **`ci: add explicit go vet step`** — splits `go vet ./...` into its own CI step so vet failures surface with their own red diff. (Race detector intentionally NOT added — local race runs surface 3 pre-existing data races in `internal/team`; that's a follow-up.)

## Red→green tests

Each refactor commit lands with an epicentric test that pins the exact bug it prevents:

- `TestRegistry_FakeKindRoutesEverywhere` — registers a fake Kind via `RegisterForTest`, sets `WUPHF_LLM_PROVIDER`, asserts both resolver and oneshot dispatch routed to the fake. Before the Registry, the test fails because resolver/oneshot fall through to claude-code for unknown values.
- `TestUsesPaneRuntime_ConsultsRegistryCapabilities` — registers a fake non-pane Kind and asserts `UsesTmuxRuntime()` returns false. Before the refactor: returns true (since the fake isn't codex), misclassifying a future Ollama/vLLM provider on every "if not codex" branch.
- `TestStreamFnResolver_PerAgentKindOverridesInstallWide` — registers two fake Kinds, sets one install-wide, and asserts an agent with a per-agent kind routes to its specific kind while an agent without a binding falls back to install-wide.

## Why this matters

WUPHF is the open-source feeder to nex.ai. Local-LLM users self-select as exactly the audience that grows into nex.ai customers — they care about persistence, tool surface, and multi-agent orchestration enough to stand up local infra. Building on a clean abstraction now means:

- Adding Ollama is a single new file (`provider/ollama.go` with `init() { Register(...) }`), not edits to four switches across the codebase.
- The new headless runner that #186 will introduce becomes the protocol contract that nex.ai eventually speaks. Designing it as "OpenAI-compat chat + MCP tool dispatch + per-agent session memory" means the same shape works for an OpenAI-compat endpoint at `nex.ai/v1`.
- Per-agent dispatch is no longer "works for headless, broken for streaming" — both paths go through the same Registry.

## Test plan

- [x] `go test ./internal/provider/...` — all green (Registry tests + existing claude/codex/opencode tests pass)
- [x] `go test ./internal/config/...` — all green (`AllowLLMProviderKind` round-trip works)
- [x] `go vet ./...` — clean
- [ ] CI green on this PR

## Follow-ups (not in this PR)

- **Issue #186 implementation** — PR-1 ships streaming-only `openai-compatible` provider against Ollama. ~600 LOC. Bulk of new code is the MCP→`tools[]`→`tool_result` translation layer.
- **Race detector in CI** — three pre-existing data races in `internal/team` (function-variable test-injection on `headlessCodexRunTurn`, `beginHeadlessCodexTurn` map race, `launcher_test.go:480` write race) need fixing before `-race -short` can be wired into the test job.
- **Test isolation in `internal/team`** — the wiki/notebook/entity test suite has isolation bugs that intermittently break local pushes (worked around in #246 by excluding the package from the pre-push hook). Detailed findings + 7-step fix plan saved for next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced CI pipeline with separated code quality checks before test execution.

* **Refactor**
  * Implemented a dynamic provider registry system enabling runtime registration and extensible provider support.
  * Updated dispatch routing and session management to be driven by provider capabilities (pane eligibility, one-shot support, session reset requirements) rather than hardcoded provider detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->