### PR TITLE
[codex] fix onboarding scratch roster selection

### DIFF
--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -380,7 +380,30 @@ func blankSlateOfficeMembersFromBlueprint(blueprint operations.Blueprint, select
 	agents := blueprint.Starter.Agents
 	leadSlug := normalizeChannelSlug(blueprint.Starter.LeadSlug)
 	filter := agentSelectionFilter(selectedAgents, leadSlug)
+	availableSlugs := starterAgentSlugSet(agents)
 
+	members := blankSlateOfficeMembersFromAgents(agents, leadSlug, filter)
+	// A stale web bundle can post scratch-team slugs from a different
+	// synthesized roster. In that case the filter keeps only the lead; prefer
+	// the full current roster over a misleading one-agent office.
+	if selectionLooksStaleForStarterAgents(selectedAgents, leadSlug, availableSlugs, members) {
+		members = blankSlateOfficeMembersFromAgents(agents, leadSlug, nil)
+	}
+	if len(members) > 0 {
+		return members
+	}
+	// Defensive fallback used only when the blueprint had zero parseable
+	// agents. Keeps the broker from crashing on empty rosters.
+	now := time.Now().UTC().Format(time.RFC3339)
+	return []officeMember{
+		{Slug: "founder", Name: "Founder", Role: "Founder", PermissionMode: "plan", BuiltIn: true, CreatedBy: "wuphf", CreatedAt: now},
+		{Slug: "operator", Name: "Operator", Role: "Operator", PermissionMode: "auto", BuiltIn: true, CreatedBy: "wuphf", CreatedAt: now},
+		{Slug: "builder", Name: "Builder", Role: "Builder", PermissionMode: "auto", CreatedBy: "wuphf", CreatedAt: now},
+		{Slug: "reviewer", Name: "Reviewer", Role: "Reviewer", PermissionMode: "plan", CreatedBy: "wuphf", CreatedAt: now},
+	}
+}
+
+func blankSlateOfficeMembersFromAgents(agents []operations.StarterAgent, leadSlug string, filter func(string) bool) []officeMember {
 	members := make([]officeMember, 0, len(agents))
 	now := time.Now().UTC().Format(time.RFC3339)
 	for _, agent := range agents {
@@ -412,17 +435,44 @@ func blankSlateOfficeMembersFromBlueprint(blueprint operations.Blueprint, select
 			BuiltIn:        agent.BuiltIn || slug == leadSlug || slug == "operator" || slug == "founder" || slug == "ceo",
 		})
 	}
-	if len(members) > 0 {
-		return members
+	return members
+}
+
+func starterAgentSlugSet(agents []operations.StarterAgent) map[string]struct{} {
+	out := make(map[string]struct{}, len(agents))
+	for _, agent := range agents {
+		slug := normalizeChannelSlug(operationFirstNonEmpty(agent.Slug, agent.EmployeeBlueprint, operationSlug(agent.Name)))
+		if slug == "" {
+			continue
+		}
+		out[slug] = struct{}{}
 	}
-	// Defensive fallback used only when the blueprint had zero parseable
-	// agents. Keeps the broker from crashing on empty rosters.
-	return []officeMember{
-		{Slug: "founder", Name: "Founder", Role: "Founder", PermissionMode: "plan", BuiltIn: true, CreatedBy: "wuphf", CreatedAt: now},
-		{Slug: "operator", Name: "Operator", Role: "Operator", PermissionMode: "auto", BuiltIn: true, CreatedBy: "wuphf", CreatedAt: now},
-		{Slug: "builder", Name: "Builder", Role: "Builder", PermissionMode: "auto", CreatedBy: "wuphf", CreatedAt: now},
-		{Slug: "reviewer", Name: "Reviewer", Role: "Reviewer", PermissionMode: "plan", CreatedBy: "wuphf", CreatedAt: now},
+	return out
+}
+
+func selectionLooksStaleForStarterAgents(selectedAgents []string, leadSlug string, availableSlugs map[string]struct{}, members []officeMember) bool {
+	if len(selectedAgents) == 0 || len(members) != 1 {
+		return false
 	}
+	if leadSlug == "" || members[0].Slug != leadSlug {
+		return false
+	}
+	hasUnknown := false
+	hasKnownNonLead := false
+	for _, raw := range selectedAgents {
+		slug := normalizeChannelSlug(raw)
+		if slug == "" {
+			continue
+		}
+		if _, ok := availableSlugs[slug]; !ok {
+			hasUnknown = true
+			continue
+		}
+		if slug != leadSlug {
+			hasKnownNonLead = true
+		}
+	}
+	return hasUnknown && !hasKnownNonLead
 }
 
 // agentSelectionFilter returns a membership predicate for the wizard's

--- a/internal/team/broker_onboarding_test.go
+++ b/internal/team/broker_onboarding_test.go
@@ -215,6 +215,75 @@ func TestOnboardingCompleteFromScratchSynthesizes(t *testing.T) {
 	}
 }
 
+func TestOnboardingCompleteFromScratchHonorsSelectedFoundingAgents(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	defer withIsolatedBrokerState(t)()
+
+	b := NewBroker()
+	if err := b.onboardingCompleteFn("Build an automated customer-support operation", false, "", []string{"ceo", "founding-engineer"}); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	b.mu.Lock()
+	slugs := make([]string, 0, len(b.members))
+	for _, m := range b.members {
+		slugs = append(slugs, m.Slug)
+	}
+	b.mu.Unlock()
+
+	want := []string{"ceo", "founding-engineer"}
+	if len(slugs) != len(want) {
+		t.Fatalf("from-scratch selected roster got %v, want %v", slugs, want)
+	}
+	for i, slug := range want {
+		if slugs[i] != slug {
+			t.Fatalf("member[%d]: got %q, want %q (all: %v)", i, slugs[i], slug, slugs)
+		}
+	}
+}
+
+func TestBlankSlateMembersStaleScratchSelectionDoesNotCollapseToOperator(t *testing.T) {
+	blueprint := operations.SynthesizeBlueprint(operations.SynthesisInput{})
+
+	members := blankSlateOfficeMembersFromBlueprint(blueprint, []string{
+		"ceo",
+		"gtm-lead",
+		"founding-engineer",
+		"pm",
+		"designer",
+	})
+
+	slugs := make([]string, 0, len(members))
+	for _, member := range members {
+		slugs = append(slugs, member.Slug)
+	}
+	if len(slugs) <= 1 {
+		t.Fatalf("stale scratch selection collapsed to lead-only roster: %v", slugs)
+	}
+	for _, want := range []string{"operator", "planner", "executor", "reviewer"} {
+		found := false
+		for _, got := range slugs {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected stale scratch selection to keep full synthesized roster; missing %q in %v", want, slugs)
+		}
+	}
+}
+
+func TestBlankSlateMembersExplicitLeadOnlySelectionStaysLeadOnly(t *testing.T) {
+	blueprint := operations.SynthesizeBlueprint(operations.SynthesisInput{})
+
+	members := blankSlateOfficeMembersFromBlueprint(blueprint, []string{"operator"})
+
+	if len(members) != 1 || members[0].Slug != "operator" {
+		t.Fatalf("explicit lead-only selection got %+v, want only operator", members)
+	}
+}
+
 // TestOnboardingCompleteSkipTaskSeedsNoKickoff verifies that skip_task=true
 // seeds the team but does not post an onboarding_origin message.
 func TestOnboardingCompleteSkipTaskSeedsNoKickoff(t *testing.T) {


### PR DESCRIPTION
## What changed

Fixes the scratch onboarding roster seeding path so selected founding agents no longer collapse to only the lead/operator when the client submits stale generated agent slugs.

## Why

Prod can serve an onboarding payload whose selected scratch-agent slugs do not line up with the backend's current scratch roster. The backend was applying that stale selection literally, so the selection filter kept only the required lead agent and seeded a one-person roster.

## Impact

Starting from scratch now seeds the intended current starter roster when the selected-agent payload is stale, while explicit lead-only selections still remain lead-only.

## Validation

- `go test ./internal/team -run 'TestOnboardingComplete|TestSeedFromBlueprint|TestBlankSlateMembers|TestBlankSlateOfficeChannelsFromBlueprint' -count=1`
- `go test ./internal/onboarding`
- `git diff --check`
- `npm run build` in `web`
- `WUPHF_E2E_BASE_URL=http://localhost:7991 bunx playwright test tests/wizard.spec.ts`
- custom browser-harness stale scratch payload check confirmed roster slugs: `ceo, gtm-lead, founding-engineer, pm, designer`
- `WUPHF_E2E_BASE_URL=http://localhost:7991 bunx playwright test tests/smoke.spec.ts`