### PR TITLE
fix(team): reduce agent token bloat + dispatch reliability

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -535,7 +535,8 @@ type Broker struct {
 	lastAgentRateLimitPrune time.Time
 	agentLogRoot            string // override for tests; empty means agent.DefaultTaskLogRoot()
 
-	stopCh chan struct{} // closed by Stop(); signals background goroutines to exit
+	stopCh   chan struct{} // closed by Stop(); signals background goroutines to exit
+	stopOnce sync.Once
 }
 
 func taskNeedsLocalWorktree(task *teamTask) bool {
@@ -1531,7 +1532,9 @@ func (b *Broker) StartOnPort(port int) error {
 // Stop shuts down the broker.
 func (b *Broker) Stop() {
 	if b.stopCh != nil {
-		close(b.stopCh)
+		b.stopOnce.Do(func() {
+			close(b.stopCh)
+		})
 	}
 	if b.server != nil {
 		_ = b.server.Close()
@@ -7390,10 +7393,15 @@ func (b *Broker) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 	sender := normalizeActorSlug(body.From)
 	isHuman := sender == "" || sender == "you" || sender == "human"
 	leadSlug := officeLeadSlugFrom(b.members)
+	mentionedSlugs := extractMentionedSlugs(body.Content)
 	leadExplicitlyTagged := leadSlug != "" && containsString(tagged, leadSlug)
+	if isHuman && !leadExplicitlyTagged && leadSlug != "" && containsString(mentionedSlugs, leadSlug) && b.findMemberLocked(leadSlug) != nil {
+		tagged = append(tagged, leadSlug)
+		leadExplicitlyTagged = true
+	}
 	suppressAutoPromote := isHuman && leadExplicitlyTagged
 	if b.senderMayAutoPromoteLocked(sender) && !suppressAutoPromote {
-		for _, slug := range extractMentionedSlugs(body.Content) {
+		for _, slug := range mentionedSlugs {
 			if slug == sender {
 				continue
 			}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -913,14 +913,16 @@ func NewBroker() *Broker {
 	b.normalizeLoadedStateLocked()
 	b.mu.Unlock()
 	b.stopCh = make(chan struct{})
-	// Watchdog: reap agents stuck in "active"/"thinking" when the spawn
-	// crashed before reaching the idle transition. Stopped via b.stopCh.
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		<-b.stopCh
-		cancel()
-	}()
-	go b.runActivityWatchdog(ctx)
+	if activityWatchdogEnabled {
+		// Watchdog: reap agents stuck in "active"/"thinking" when the spawn
+		// crashed before reaching the idle transition. Stopped via b.stopCh.
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			<-b.stopCh
+			cancel()
+		}()
+		go b.runActivityWatchdog(ctx)
+	}
 	return b
 }
 
@@ -1245,6 +1247,12 @@ func uniqueWordSet(s string) map[string]struct{} {
 	}
 	return out
 }
+
+// activityWatchdogEnabled controls whether NewBroker starts the background
+// activity-watchdog goroutine. Tests that create many short-lived brokers set
+// this to false via TestMain so goroutines don't accumulate and cause
+// goleak/timeout failures. Production always runs with the default (true).
+var activityWatchdogEnabled = true
 
 // staleActivityThreshold is how long an agent can stay in a non-idle/non-error
 // activity state before the watchdog forcibly resets it to idle. Set long

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -534,6 +534,8 @@ type Broker struct {
 	agentRateLimitRequests  int
 	lastAgentRateLimitPrune time.Time
 	agentLogRoot            string // override for tests; empty means agent.DefaultTaskLogRoot()
+
+	stopCh chan struct{} // closed by Stop(); signals background goroutines to exit
 }
 
 func taskNeedsLocalWorktree(task *teamTask) bool {
@@ -910,6 +912,15 @@ func NewBroker() *Broker {
 	b.ensureDefaultChannelsLocked()
 	b.normalizeLoadedStateLocked()
 	b.mu.Unlock()
+	b.stopCh = make(chan struct{})
+	// Watchdog: reap agents stuck in "active"/"thinking" when the spawn
+	// crashed before reaching the idle transition. Stopped via b.stopCh.
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-b.stopCh
+		cancel()
+	}()
+	go b.runActivityWatchdog(ctx)
 	return b
 }
 
@@ -1135,6 +1146,168 @@ func (b *Broker) UpdateAgentActivity(update agentActivitySnapshot) {
 	b.mu.Unlock()
 }
 
+// duplicateBroadcastWindow is how recent an earlier broadcast from the same
+// agent in the same channel+thread must be to count as a duplicate. Set tight
+// so legitimate quick follow-ups still land, but tight enough to catch the
+// "same turn, paraphrased again" pattern that agents produce.
+const duplicateBroadcastWindow = 30 * time.Second
+
+// duplicateBroadcastSimilarity is the lower bound at which two messages are
+// considered near-duplicates. 1.0 means "byte-identical"; we pick 0.85 to
+// catch paraphrased restatements while letting actual new content through.
+const duplicateBroadcastSimilarity = 0.85
+
+// isDuplicateAgentBroadcastLocked returns true when the agent has already
+// posted a nearly-identical message to the same (channel, thread) pair within
+// duplicateBroadcastWindow. Must be called with b.mu held.
+func (b *Broker) isDuplicateAgentBroadcastLocked(sender, channel, replyTo, content string) bool {
+	newNorm := normalizeBroadcastContent(content)
+	if newNorm == "" {
+		return false
+	}
+	cutoff := time.Now().UTC().Add(-duplicateBroadcastWindow)
+	// Walk backwards — most recent messages are at the end.
+	for i := len(b.messages) - 1; i >= 0; i-- {
+		prev := b.messages[i]
+		ts, err := time.Parse(time.RFC3339, prev.Timestamp)
+		if err == nil && ts.Before(cutoff) {
+			break
+		}
+		if prev.From != sender {
+			continue
+		}
+		if normalizeChannelSlug(prev.Channel) != channel {
+			continue
+		}
+		if strings.TrimSpace(prev.ReplyTo) != strings.TrimSpace(replyTo) {
+			continue
+		}
+		prevNorm := normalizeBroadcastContent(prev.Content)
+		if prevNorm == "" {
+			continue
+		}
+		if jaccardWordSimilarity(newNorm, prevNorm) >= duplicateBroadcastSimilarity {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeBroadcastContent lowercases and collapses whitespace so trivial
+// formatting drift does not defeat the dedup check.
+func normalizeBroadcastContent(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	if s == "" {
+		return ""
+	}
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// jaccardWordSimilarity returns the Jaccard similarity of the two strings'
+// whitespace-split word sets. 1.0 = identical word sets; 0.0 = disjoint.
+// Cheap and good enough to catch "ship it" / "ship it 🚀" style paraphrases.
+func jaccardWordSimilarity(a, b string) float64 {
+	wa := uniqueWordSet(a)
+	wb := uniqueWordSet(b)
+	if len(wa) == 0 || len(wb) == 0 {
+		return 0
+	}
+	inter := 0
+	for w := range wa {
+		if _, ok := wb[w]; ok {
+			inter++
+		}
+	}
+	union := len(wa) + len(wb) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+func uniqueWordSet(s string) map[string]struct{} {
+	out := make(map[string]struct{})
+	for _, w := range strings.Fields(s) {
+		// Strip leading/trailing ASCII punctuation so "court," and "court"
+		// collapse to the same token for Jaccard. Keeps intra-word characters
+		// like apostrophes inside "reviewer's".
+		w = strings.TrimFunc(w, func(r rune) bool {
+			switch r {
+			case '.', ',', ';', ':', '!', '?', '—', '–', '-', '"', '\'', '(', ')', '[', ']', '`':
+				return true
+			}
+			return false
+		})
+		if w == "" {
+			continue
+		}
+		out[w] = struct{}{}
+	}
+	return out
+}
+
+// staleActivityThreshold is how long an agent can stay in a non-idle/non-error
+// activity state before the watchdog forcibly resets it to idle. Set long
+// enough to cover normal long turns (tool chains, big edits) but short enough
+// that a crashed spawn does not leave the agent looking "active" for hours —
+// which blocks the CEO's "Already active in this thread" re-route guard and
+// prevents the specialist from being dispatched again.
+const staleActivityThreshold = 5 * time.Minute
+
+// reapStaleActivityLocked transitions any agent whose LastTime is older than
+// staleActivityThreshold from "active"/"thinking"/"tool_use" back to "idle".
+// Must be called with b.mu held. Returns the slugs that were reset so the
+// caller can emit activity-change events after releasing the lock.
+func (b *Broker) reapStaleActivityLocked(now time.Time) []agentActivitySnapshot {
+	if len(b.activity) == 0 {
+		return nil
+	}
+	var reset []agentActivitySnapshot
+	for slug, snap := range b.activity {
+		status := strings.ToLower(strings.TrimSpace(snap.Status))
+		if status == "" || status == "idle" || status == "error" {
+			continue
+		}
+		lastTime, err := time.Parse(time.RFC3339, snap.LastTime)
+		if err != nil {
+			// Unparseable LastTime means we cannot age the entry safely; leave it.
+			continue
+		}
+		if now.Sub(lastTime) < staleActivityThreshold {
+			continue
+		}
+		snap.Status = "idle"
+		snap.Activity = "idle"
+		snap.Detail = "stale activity reaped (no progress for " + staleActivityThreshold.String() + ")"
+		snap.LastTime = now.UTC().Format(time.RFC3339)
+		b.activity[slug] = snap
+		reset = append(reset, snap)
+	}
+	return reset
+}
+
+// runActivityWatchdog scans the in-memory activity map every minute and
+// resets agents that have been stuck in a non-terminal state past
+// staleActivityThreshold. Stops when ctx is done so NewBroker can tear it
+// down alongside the rest of the broker's lifecycle.
+func (b *Broker) runActivityWatchdog(ctx context.Context) {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			b.mu.Lock()
+			reset := b.reapStaleActivityLocked(now)
+			for _, snap := range reset {
+				b.publishActivityLocked(snap)
+			}
+			b.mu.Unlock()
+		}
+	}
+}
+
 // Token returns the shared secret that agents must include in requests.
 func (b *Broker) Token() string {
 	return b.token
@@ -1349,6 +1522,9 @@ func (b *Broker) StartOnPort(port int) error {
 
 // Stop shuts down the broker.
 func (b *Broker) Stop() {
+	if b.stopCh != nil {
+		close(b.stopCh)
+	}
 	if b.server != nil {
 		_ = b.server.Close()
 	}
@@ -7195,9 +7371,20 @@ func (b *Broker) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 	// any registered agent slug. Everything else — "system", "nex", future
 	// synthetic senders — is excluded by default so automation posts do not
 	// accidentally wake agents on every @-reference they quote.
+	//
+	// Exception: when the human explicitly tags the lead (CEO), do not
+	// auto-promote OTHER agents mentioned in the body. Example:
+	// "@ceo ask @reviewer to ..." — the human's intent is for CEO to route,
+	// not for the broker to fan out in parallel. Without this guard the
+	// reviewer gets notified twice (by auto-promote AND later by CEO's
+	// explicit tag), spawning two turns with nearly identical answers.
 	tagged := uniqueSlugs(body.Tagged)
 	sender := normalizeActorSlug(body.From)
-	if b.senderMayAutoPromoteLocked(sender) {
+	isHuman := sender == "" || sender == "you" || sender == "human"
+	leadSlug := officeLeadSlugFrom(b.members)
+	leadExplicitlyTagged := leadSlug != "" && containsString(tagged, leadSlug)
+	suppressAutoPromote := isHuman && leadExplicitlyTagged
+	if b.senderMayAutoPromoteLocked(sender) && !suppressAutoPromote {
 		for _, slug := range extractMentionedSlugs(body.Content) {
 			if slug == sender {
 				continue
@@ -7243,6 +7430,29 @@ func (b *Broker) handlePostMessage(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		tagged = uniqueSlugs(append(tagged, threadParticipants...))
+	}
+
+	// Dedup near-identical consecutive broadcasts from the same agent in the
+	// same channel + thread within a short window. Observed symptom: a single
+	// CEO turn emits 2-3 team_broadcast calls with the same content in
+	// slightly different wording, each costing a full round-trip downstream.
+	// The prompt tells the model "at most one broadcast per turn", but that
+	// rule is routinely ignored; this is the broker-side safety net.
+	//
+	// Humans and system senders are exempt — this only fires for agent posts.
+	if !isHuman && sender != "" && sender != "system" && sender != "nex" {
+		if b.isDuplicateAgentBroadcastLocked(sender, channel, replyTo, body.Content) {
+			b.counter--
+			b.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         "",
+				"deduped":    true,
+				"total":      len(b.messages),
+				"suppressed": "duplicate broadcast from the same agent in the same thread within the dedup window",
+			})
+			return
+		}
 	}
 
 	msg := channelMessage{

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -476,7 +476,8 @@ func TestBrokerActionSubscribersReceiveTaskLifecycle(t *testing.T) {
 
 func TestReapStaleActivityLocked(t *testing.T) {
 	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
 	defer func() { brokerStatePath = oldPathFn }()
 
 	b := NewBroker()
@@ -515,9 +516,23 @@ func TestReapStaleActivityLocked(t *testing.T) {
 	if b.activity["already-idle"].Status != "idle" {
 		t.Error("already-idle should be unchanged")
 	}
+	if b.activity["already-error"].Status != "error" {
+		t.Error("already-error should be unchanged")
+	}
 	if b.activity["bad-time"].Status != "active" {
 		t.Error("unparseable LastTime should be left alone")
 	}
+}
+
+func TestBrokerStopIsIdempotent(t *testing.T) {
+	oldPathFn := brokerStatePath
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	b.Stop()
+	b.Stop()
 }
 
 func TestBrokerActivitySubscribersReceiveUpdates(t *testing.T) {

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -82,6 +82,13 @@ func TestMain(m *testing.M) {
 	staleUnansweredThreshold = 10 * 365 * 24 * time.Hour
 	cleanups = append(cleanups, func() { staleUnansweredThreshold = origStaleUnanswered })
 
+	// 4) Activity watchdog: tests create many short-lived brokers. The watchdog
+	//    goroutine fires every minute, so leaving it running accumulates
+	//    hundreds of stuck goroutines and causes timeout/goleak failures.
+	//    Disable it for the test run; production always starts with it enabled.
+	activityWatchdogEnabled = false
+	cleanups = append(cleanups, func() { activityWatchdogEnabled = true })
+
 	rc := m.Run()
 	cleanup()
 	os.Exit(rc)

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -72,6 +72,16 @@ func TestMain(m *testing.M) {
 	}
 	cleanups = append(cleanups, func() { _ = os.RemoveAll(logDir) })
 
+	// 3) Stale-unanswered threshold: resume tests pre-seed broker state with
+	//    ancient timestamps (e.g. "2026-04-14T10:00:00Z") to exercise routing
+	//    logic without fighting a clock. The production default (1 hour)
+	//    would drop those seeds. Raise the window to ~10 years during tests
+	//    so the resume-routing tests keep their fixtures while production
+	//    keeps the stale-message-dropping behavior.
+	origStaleUnanswered := staleUnansweredThreshold
+	staleUnansweredThreshold = 10 * 365 * 24 * time.Hour
+	cleanups = append(cleanups, func() { staleUnansweredThreshold = origStaleUnanswered })
+
 	rc := m.Run()
 	cleanup()
 	os.Exit(rc)
@@ -454,6 +464,52 @@ func TestBrokerActionSubscribersReceiveTaskLifecycle(t *testing.T) {
 		}
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for subscribed action")
+	}
+}
+
+func TestReapStaleActivityLocked(t *testing.T) {
+	oldPathFn := brokerStatePath
+	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	now := time.Now().UTC()
+	stale := now.Add(-10 * time.Minute).Format(time.RFC3339)
+	fresh := now.Add(-1 * time.Minute).Format(time.RFC3339)
+
+	b.activity = map[string]agentActivitySnapshot{
+		"stale-active":   {Slug: "stale-active", Status: "active", Activity: "tool_use", LastTime: stale},
+		"stale-thinking": {Slug: "stale-thinking", Status: "thinking", Activity: "thinking", LastTime: stale},
+		"fresh-active":   {Slug: "fresh-active", Status: "active", Activity: "tool_use", LastTime: fresh},
+		"already-idle":   {Slug: "already-idle", Status: "idle", Activity: "idle", LastTime: stale},
+		"already-error":  {Slug: "already-error", Status: "error", Activity: "error", LastTime: stale},
+		"bad-time":       {Slug: "bad-time", Status: "active", Activity: "tool_use", LastTime: "not-a-time"},
+	}
+
+	b.mu.Lock()
+	reset := b.reapStaleActivityLocked(now)
+	b.mu.Unlock()
+
+	if len(reset) != 2 {
+		t.Fatalf("expected 2 stale agents reaped, got %d: %+v", len(reset), reset)
+	}
+	for _, snap := range reset {
+		if snap.Status != "idle" {
+			t.Errorf("reaped agent %q should be idle, got %q", snap.Slug, snap.Status)
+		}
+		if snap.Slug != "stale-active" && snap.Slug != "stale-thinking" {
+			t.Errorf("unexpected reaped slug: %q", snap.Slug)
+		}
+	}
+
+	if b.activity["fresh-active"].Status != "active" {
+		t.Error("fresh-active should not be reaped")
+	}
+	if b.activity["already-idle"].Status != "idle" {
+		t.Error("already-idle should be unchanged")
+	}
+	if b.activity["bad-time"].Status != "active" {
+		t.Error("unparseable LastTime should be left alone")
 	}
 }
 

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -608,6 +608,15 @@ func TestEnqueueHeadlessCodexTurnProcessesFIFO(t *testing.T) {
 }
 
 func TestPostHeadlessFinalMessageIfSilentPostsFinalOutput(t *testing.T) {
+	// Isolate state from the user's real ~/.wuphf/team/broker-state.json.
+	// Without this override NewBroker loads whatever prior test runs (or a
+	// real WUPHF run in ~/.wuphf/) persisted, and agentPostedSubstantiveMessageToChannelSince
+	// picks up an unrelated ceo message, making the "expected posted=true"
+	// assertion fail non-deterministically depending on machine history.
+	oldPathFn := brokerStatePath
+	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
 	b := NewBroker()
 	channel := DMSlugFor("ceo")
 	root, err := b.PostMessage("you", channel, "Ping the CEO.", nil, "")

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -84,10 +84,13 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 	if workspaceDir != strings.TrimSpace(l.cwd) {
 		env = append(env, "WUPHF_WORKTREE_PATH="+workspaceDir)
 	}
-	if err := l.writeHeadlessOpencodeMCPConfig(slug); err != nil {
+	opencodeConfigPath, err := l.writeHeadlessOpencodeMCPConfig(slug)
+	if err != nil {
 		// MCP failure is loud but non-fatal — opencode will still run, just
 		// without the wuphf-office tools. Log so the user can debug.
 		appendHeadlessCodexLog(slug, "opencode_mcp-config-failed: "+err.Error())
+	} else {
+		env = setEnvValue(env, "OPENCODE_CONFIG", opencodeConfigPath)
 	}
 	cmd.Env = env
 
@@ -287,28 +290,31 @@ func escapeHeadlessOpencodeSystemWrapper(s string) string {
 	return s
 }
 
-// writeHeadlessOpencodeMCPConfig merges WUPHF's MCP server definition into the
-// user's $HOME/.config/opencode/opencode.json. Preserves any other top-level
-// keys (theme, provider preferences, user-configured MCP servers) and only
-// touches the wuphf-office entry under `mcp`. Secrets live in the MCP
-// subprocess's `environment` block so they never reach the model backend
-// opencode routes to.
-func (l *Launcher) writeHeadlessOpencodeMCPConfig(slug string) error {
+// writeHeadlessOpencodeMCPConfig merges WUPHF's MCP server definition into an
+// agent-scoped Opencode config derived from the user's normal
+// $HOME/.config/opencode/opencode.json. The caller passes the returned path via
+// OPENCODE_CONFIG, so concurrent agents do not race to rewrite a shared config
+// with different WUPHF_AGENT_SLUG values. Preserves other top-level user keys
+// (theme, provider preferences, user-configured MCP servers) and only touches
+// the wuphf-office entry under `mcp`. Secrets live in the MCP subprocess's
+// `environment` block so they never reach the model backend opencode routes to.
+func (l *Launcher) writeHeadlessOpencodeMCPConfig(slug string) (string, error) {
 	wuphfBinary, err := headlessOpencodeExecutablePath()
 	if err != nil {
-		return fmt.Errorf("resolve wuphf binary: %w", err)
+		return "", fmt.Errorf("resolve wuphf binary: %w", err)
 	}
 	home, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(home) == "" {
-		return fmt.Errorf("resolve user home: %w", err)
+		return "", fmt.Errorf("resolve user home: %w", err)
 	}
-	configPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	baseConfigPath := filepath.Join(home, ".config", "opencode", "opencode.json")
+	configPath := headlessOpencodeAgentConfigPath(home, slug)
 	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
-		return fmt.Errorf("mkdir opencode config dir: %w", err)
+		return "", fmt.Errorf("mkdir opencode config dir: %w", err)
 	}
 
 	merged := map[string]any{}
-	if raw, err := os.ReadFile(configPath); err == nil && len(raw) > 0 {
+	if raw, err := os.ReadFile(baseConfigPath); err == nil && len(raw) > 0 {
 		// Best-effort: if the existing file isn't valid JSON, overwrite it
 		// rather than silently losing the WUPHF overlay.
 		_ = json.Unmarshal(raw, &merged)
@@ -326,37 +332,62 @@ func (l *Launcher) writeHeadlessOpencodeMCPConfig(slug string) error {
 
 	data, err := json.MarshalIndent(merged, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal opencode.json: %w", err)
+		return "", fmt.Errorf("marshal opencode config: %w", err)
 	}
-	// Write atomically via a temp file in the same directory so that concurrent
-	// agent spawns (CEO + planner + reviewer all launch at once) never interleave
-	// their writes and produce a truncated or double-braced JSON file.
 	// os.Rename on the same filesystem is atomic (POSIX), so readers always see
 	// either the old complete file or the new complete file — never a half-write.
 	tmp, err := os.CreateTemp(filepath.Dir(configPath), ".opencode-*.json")
 	if err != nil {
-		return fmt.Errorf("create temp opencode config: %w", err)
+		return "", fmt.Errorf("create temp opencode config: %w", err)
 	}
 	tmpPath := tmp.Name()
 	if err := tmp.Chmod(0o600); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
-		return fmt.Errorf("chmod temp opencode config: %w", err)
+		return "", fmt.Errorf("chmod temp opencode config: %w", err)
 	}
 	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
-		return fmt.Errorf("write temp opencode config: %w", err)
+		return "", fmt.Errorf("write temp opencode config: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
 		_ = os.Remove(tmpPath)
-		return fmt.Errorf("close temp opencode config: %w", err)
+		return "", fmt.Errorf("close temp opencode config: %w", err)
 	}
 	if err := os.Rename(tmpPath, configPath); err != nil {
 		_ = os.Remove(tmpPath)
-		return fmt.Errorf("install opencode.json: %w", err)
+		return "", fmt.Errorf("install opencode config: %w", err)
 	}
-	return nil
+	return configPath, nil
+}
+
+func headlessOpencodeAgentConfigPath(home string, slug string) string {
+	return filepath.Join(home, ".config", "opencode", "opencode."+safeHeadlessOpencodeConfigSlug(slug)+".json")
+}
+
+func safeHeadlessOpencodeConfigSlug(slug string) string {
+	slug = normalizeActorSlug(slug)
+	if slug == "" {
+		slug = "agent"
+	}
+	var b strings.Builder
+	for _, r := range slug {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	if b.Len() == 0 {
+		return "agent"
+	}
+	return b.String()
 }
 
 // buildHeadlessOpencodeMCPEntry constructs the `mcp.wuphf-office` block for

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -328,8 +328,33 @@ func (l *Launcher) writeHeadlessOpencodeMCPConfig(slug string) error {
 	if err != nil {
 		return fmt.Errorf("marshal opencode.json: %w", err)
 	}
-	if err := os.WriteFile(configPath, data, 0o600); err != nil {
-		return fmt.Errorf("write opencode.json: %w", err)
+	// Write atomically via a temp file in the same directory so that concurrent
+	// agent spawns (CEO + planner + reviewer all launch at once) never interleave
+	// their writes and produce a truncated or double-braced JSON file.
+	// os.Rename on the same filesystem is atomic (POSIX), so readers always see
+	// either the old complete file or the new complete file — never a half-write.
+	tmp, err := os.CreateTemp(filepath.Dir(configPath), ".opencode-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp opencode config: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("chmod temp opencode config: %w", err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write temp opencode config: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp opencode config: %w", err)
+	}
+	if err := os.Rename(tmpPath, configPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("install opencode.json: %w", err)
 	}
 	return nil
 }

--- a/internal/team/headless_opencode_test.go
+++ b/internal/team/headless_opencode_test.go
@@ -10,8 +10,8 @@ import (
 
 // TestWriteHeadlessOpencodeMCPConfigConcurrent verifies that concurrent calls
 // to writeHeadlessOpencodeMCPConfig (as happen when CEO + planner + reviewer
-// all spawn at the same time) never produce a truncated or double-braced JSON
-// file. The fix is an atomic temp-file-then-rename write.
+// all spawn at the same time) write agent-scoped configs with the right MCP
+// environment instead of racing to rewrite one shared opencode.json.
 func TestWriteHeadlessOpencodeMCPConfigConcurrent(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -38,32 +38,71 @@ func TestWriteHeadlessOpencodeMCPConfigConcurrent(t *testing.T) {
 	l := &Launcher{}
 
 	const goroutines = 20
+	slugs := []string{"ceo", "planner", "reviewer"}
+	paths := make(map[string]string)
+	var pathsMu sync.Mutex
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
 	for i := 0; i < goroutines; i++ {
 		go func(slug string) {
 			defer wg.Done()
-			if err := l.writeHeadlessOpencodeMCPConfig(slug); err != nil {
+			path, err := l.writeHeadlessOpencodeMCPConfig(slug)
+			if err != nil {
 				t.Errorf("writeHeadlessOpencodeMCPConfig(%q): %v", slug, err)
+				return
 			}
-		}([]string{"ceo", "planner", "reviewer"}[i%3])
+			pathsMu.Lock()
+			paths[slug] = path
+			pathsMu.Unlock()
+		}(slugs[i%len(slugs)])
 	}
 	wg.Wait()
 
 	raw, err := os.ReadFile(configPath)
 	if err != nil {
-		t.Fatalf("read opencode.json after concurrent writes: %v", err)
+		t.Fatalf("read base opencode.json after concurrent writes: %v", err)
 	}
-	var out map[string]any
-	if err := json.Unmarshal(raw, &out); err != nil {
-		t.Fatalf("opencode.json is not valid JSON after concurrent writes: %v\n\ncontent:\n%s", err, raw)
+	var base map[string]any
+	if err := json.Unmarshal(raw, &base); err != nil {
+		t.Fatalf("base opencode.json is not valid JSON after concurrent writes: %v\n\ncontent:\n%s", err, raw)
 	}
-	// The wuphf-office MCP entry must be present.
-	mcp, _ := out["mcp"].(map[string]any)
-	if mcp == nil {
-		t.Fatal("mcp key missing from opencode.json after concurrent writes")
+	if _, ok := base["mcp"]; ok {
+		t.Fatal("base opencode.json should not be rewritten with WUPHF's agent-scoped MCP entry")
 	}
-	if _, ok := mcp["wuphf-office"]; !ok {
-		t.Fatal("mcp.wuphf-office missing from opencode.json after concurrent writes")
+
+	for _, slug := range slugs {
+		path := paths[slug]
+		if path == "" {
+			t.Fatalf("missing generated config path for %s", slug)
+		}
+		if want := headlessOpencodeAgentConfigPath(home, slug); path != want {
+			t.Fatalf("config path for %s = %q, want %q", slug, path, want)
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s config: %v", slug, err)
+		}
+		var out map[string]any
+		if err := json.Unmarshal(raw, &out); err != nil {
+			t.Fatalf("%s config is not valid JSON after concurrent writes: %v\n\ncontent:\n%s", slug, err, raw)
+		}
+		if out["theme"] != "dark" {
+			t.Fatalf("%s config did not preserve theme: %#v", slug, out["theme"])
+		}
+		mcp, _ := out["mcp"].(map[string]any)
+		if mcp == nil {
+			t.Fatalf("mcp key missing from %s config", slug)
+		}
+		wuphfOffice, _ := mcp["wuphf-office"].(map[string]any)
+		if wuphfOffice == nil {
+			t.Fatalf("mcp.wuphf-office missing from %s config", slug)
+		}
+		env, _ := wuphfOffice["environment"].(map[string]any)
+		if env == nil {
+			t.Fatalf("mcp.wuphf-office.environment missing from %s config", slug)
+		}
+		if env["WUPHF_AGENT_SLUG"] != slug {
+			t.Fatalf("%s config has WUPHF_AGENT_SLUG=%#v", slug, env["WUPHF_AGENT_SLUG"])
+		}
 	}
 }

--- a/internal/team/headless_opencode_test.go
+++ b/internal/team/headless_opencode_test.go
@@ -1,0 +1,69 @@
+package team
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// TestWriteHeadlessOpencodeMCPConfigConcurrent verifies that concurrent calls
+// to writeHeadlessOpencodeMCPConfig (as happen when CEO + planner + reviewer
+// all spawn at the same time) never produce a truncated or double-braced JSON
+// file. The fix is an atomic temp-file-then-rename write.
+func TestWriteHeadlessOpencodeMCPConfigConcurrent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	configDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed an existing opencode.json with some user content that should survive
+	// the merge (theme key is untouched by WUPHF).
+	seed := `{"$schema":"https://opencode.ai/config.json","theme":"dark","ai":{"ollama":{"type":"openai-compatible","url":"http://localhost:11434/v1"}}}`
+	configPath := filepath.Join(configDir, "opencode.json")
+	if err := os.WriteFile(configPath, []byte(seed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Point the executable-path hook at a harmless path so the launcher can
+	// construct the MCP entry without needing the real wuphf binary.
+	orig := headlessOpencodeExecutablePath
+	headlessOpencodeExecutablePath = func() (string, error) { return "/usr/local/bin/wuphf", nil }
+	defer func() { headlessOpencodeExecutablePath = orig }()
+
+	l := &Launcher{}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(slug string) {
+			defer wg.Done()
+			if err := l.writeHeadlessOpencodeMCPConfig(slug); err != nil {
+				t.Errorf("writeHeadlessOpencodeMCPConfig(%q): %v", slug, err)
+			}
+		}([]string{"ceo", "planner", "reviewer"}[i%3])
+	}
+	wg.Wait()
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read opencode.json after concurrent writes: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("opencode.json is not valid JSON after concurrent writes: %v\n\ncontent:\n%s", err, raw)
+	}
+	// The wuphf-office MCP entry must be present.
+	mcp, _ := out["mcp"].(map[string]any)
+	if mcp == nil {
+		t.Fatal("mcp key missing from opencode.json after concurrent writes")
+	}
+	if _, ok := mcp["wuphf-office"]; !ok {
+		t.Fatal("mcp.wuphf-office missing from opencode.json after concurrent writes")
+	}
+}

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -1856,6 +1856,15 @@ func (l *Launcher) resolvePaneTargetForSlug(slug string) (string, bool) {
 
 func (l *Launcher) agentPaneTargets() map[string]notificationTarget {
 	targets := make(map[string]notificationTarget)
+	// Pane targets only make sense when tmux panes actually back the agents.
+	// Otherwise every PaneTarget string we return is a ghost pointing at a
+	// non-existent pane — and downstream code (agentNotificationTargets,
+	// shouldUseHeadlessDispatchForTarget) treats the non-empty PaneTarget as
+	// "pane path", which bypasses the headless dispatcher and types into a
+	// dead tmux session that silently drops every notification.
+	if l == nil || !l.paneBackedAgents {
+		return targets
+	}
 	if l.isOneOnOne() {
 		slug := l.oneOnOneAgent()
 		if slug != "" && !l.skipPaneForSlug(slug) {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -2777,6 +2777,10 @@ func (l *Launcher) buildMessageWorkPacket(msg channelMessage, slug string) strin
 			for name := range activeAgents {
 				names = append(names, "@"+name)
 			}
+			// Sort so this line is byte-identical across spawns that see the same
+			// set of active agents; Go map iteration order is randomized and would
+			// otherwise break prompt caching on the work-packet suffix.
+			sort.Strings(names)
 			lines = append(lines, fmt.Sprintf("- Already active in this thread (do NOT re-route): %s", strings.Join(names, ", ")))
 		}
 	}
@@ -3648,11 +3652,18 @@ func (l *Launcher) buildPrompt(slug string) string {
 	member := l.officeMemberBySlug(slug)
 	agentCfg := agentConfigFromMember(member)
 	officeMembers := l.officeMembersSnapshot()
+	// Sort by Slug so the prompt prefix is byte-identical across spawns for the
+	// same office; otherwise prompt caching (ANTHROPIC_PROMPT_CACHING=1) would
+	// miss on every turn just because member insertion order drifted.
+	sort.Slice(officeMembers, func(i, j int) bool { return officeMembers[i].Slug < officeMembers[j].Slug })
 	lead := officeLeadSlugFrom(officeMembers)
 	noNex := config.ResolveNoNex() || config.ResolveAPIKey("") == ""
 	var activePolicies []officePolicy
 	if l.broker != nil {
 		activePolicies = l.broker.ListPolicies()
+		// Same reason as officeMembers: sort so the policies section is
+		// deterministic and cache-friendly across turns.
+		sort.Slice(activePolicies, func(i, j int) bool { return activePolicies[i].ID < activePolicies[j].ID })
 	}
 
 	var sb strings.Builder
@@ -3722,6 +3733,10 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("- human_message: Present output or a recommendation directly to the human.\n")
 		sb.WriteString("- human_interview: Ask the human a blocking decision question — only when the team cannot proceed without it.\n")
 		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member, team_action_guide, team_action_workflow_create, team_action_workflow_schedule, team_action_relays, team_action_relay_event_types, team_action_relay_create, team_action_relay_activate, team_action_relay_events, team_action_relay_event.\n\n")
+		sb.WriteString("== TOOL HYGIENE ==\n")
+		sb.WriteString("All team_*, human_*, and mcp__wuphf-office__* tools listed above are ALREADY registered. Call them directly. Do NOT use ToolSearch/select: to look them up — that wastes a full turn.\n")
+		sb.WriteString("Do not read unrelated files (MEMORY.md, arbitrary docs) unless the current packet's task requires it. Every tool call pays full turn cost.\n")
+		sb.WriteString("Emit at most one team_broadcast per turn unless you are deliberately crossing channels. Never re-post the same content in different wording.\n\n")
 		if noNex {
 			sb.WriteString("Nex tools are disabled for this run. Work only with the shared office channel and human answers.\n\n")
 		} else {
@@ -3834,6 +3849,10 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("- human_message: Present completion or a recommendation directly to the human.\n")
 		sb.WriteString("- human_interview: Ask the human only for blocking clarifications you cannot responsibly guess.\n")
 		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member, team_action_guide, team_action_workflow_create, team_action_workflow_schedule, team_action_relays, team_action_relay_event_types, team_action_relay_create, team_action_relay_activate, team_action_relay_events, team_action_relay_event.\n\n")
+		sb.WriteString("== TOOL HYGIENE ==\n")
+		sb.WriteString("All team_*, human_*, and mcp__wuphf-office__* tools listed above are ALREADY registered. Call them directly. Do NOT use ToolSearch/select: to look them up — that wastes a full turn.\n")
+		sb.WriteString("Do not read unrelated files (MEMORY.md, arbitrary docs) unless the current packet's task requires it. Every tool call pays full turn cost.\n")
+		sb.WriteString("Emit at most one team_broadcast per turn unless you are deliberately crossing channels. Never re-post the same content in different wording.\n\n")
 		if noNex {
 			sb.WriteString("Nex tools are disabled for this run. Base your work on the office conversation and direct human answers only.\n\n")
 		} else {

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -204,8 +204,9 @@ func TestOfficeMembersSnapshotPrefersPersistedStateOverPack(t *testing.T) {
 
 func TestNotificationTargetsForMessageOneOnOneWakesSelectedAgent(t *testing.T) {
 	l := &Launcher{
-		sessionMode: SessionModeOneOnOne,
-		oneOnOne:    "pm",
+		sessionMode:      SessionModeOneOnOne,
+		oneOnOne:         "pm",
+		paneBackedAgents: true, // test exercises the pane-target path specifically
 	}
 
 	immediate, delayed := l.notificationTargetsForMessage(channelMessage{
@@ -2647,8 +2648,9 @@ func TestOfficeChangeTaskNotificationsBackfillGeneratedMemberTask(t *testing.T) 
 	b.mu.Unlock()
 
 	l := &Launcher{
-		broker:      b,
-		sessionName: "office-test",
+		broker:           b,
+		sessionName:      "office-test",
+		paneBackedAgents: true, // test exercises the pane-target path specifically
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
 			Agents: []agent.AgentConfig{
@@ -2713,8 +2715,9 @@ func TestOfficeChangeTaskNotificationsBackfillChannelMembershipTask(t *testing.T
 	b.mu.Unlock()
 
 	l := &Launcher{
-		broker:      b,
-		sessionName: "office-test",
+		broker:           b,
+		sessionName:      "office-test",
+		paneBackedAgents: true, // test exercises the pane-target path specifically
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
 			Agents: []agent.AgentConfig{
@@ -2816,9 +2819,9 @@ func TestBuildMessageActiveAgentsSorted(t *testing.T) {
 			},
 		},
 		headlessActive: map[string]*headlessCodexActiveTurn{
-			"zebra":  {},
-			"alpha":  {},
-			"mango":  {},
+			"zebra": {},
+			"alpha": {},
+			"mango": {},
 		},
 		headlessQueues: make(map[string][]headlessCodexTurn),
 	}

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -2778,6 +2778,81 @@ func TestAllOperationBlueprintsUseCEOLead(t *testing.T) {
 	}
 }
 
+func TestBuildPromptToolHygieneSection(t *testing.T) {
+	l := &Launcher{
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "eng", Name: "Engineer"},
+			},
+		},
+	}
+
+	for _, slug := range []string{"ceo", "eng"} {
+		prompt := l.buildPrompt(slug)
+		if !strings.Contains(prompt, "== TOOL HYGIENE ==") {
+			t.Errorf("%s prompt missing TOOL HYGIENE section", slug)
+		}
+		if !strings.Contains(prompt, "ALREADY registered") {
+			t.Errorf("%s prompt missing 'ALREADY registered' line", slug)
+		}
+		if !strings.Contains(prompt, "Do not read unrelated files") {
+			t.Errorf("%s prompt missing unrelated-files guidance", slug)
+		}
+		if !strings.Contains(prompt, "Emit at most one team_broadcast per turn") {
+			t.Errorf("%s prompt missing broadcast throttle guidance", slug)
+		}
+	}
+}
+
+func TestBuildMessageActiveAgentsSorted(t *testing.T) {
+	l := &Launcher{
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "eng", Name: "Engineer"},
+			},
+		},
+		headlessActive: map[string]*headlessCodexActiveTurn{
+			"zebra":  {},
+			"alpha":  {},
+			"mango":  {},
+		},
+		headlessQueues: make(map[string][]headlessCodexTurn),
+	}
+
+	// Run multiple times — Go map iteration order is non-deterministic, so
+	// a missing sort would produce different output across iterations.
+	var first string
+	for i := 0; i < 20; i++ {
+		packet := l.buildMessageWorkPacket(channelMessage{
+			ID: "h1", From: "you", Channel: "general", Content: "ship it",
+		}, "ceo")
+		idx := strings.Index(packet, "Already active in this thread")
+		if idx == -1 {
+			t.Fatal("expected 'Already active in this thread' line in work packet")
+		}
+		rest := packet[idx:]
+		nl := strings.Index(rest, "\n")
+		var line string
+		if nl == -1 {
+			line = rest
+		} else {
+			line = rest[:nl]
+		}
+		if first == "" {
+			first = line
+		} else if line != first {
+			t.Fatalf("active-agents line is non-deterministic:\n  iter 0: %q\n  iter %d: %q", first, i, line)
+		}
+	}
+	if !strings.Contains(first, "@alpha, @mango, @zebra") {
+		t.Fatalf("active-agents line not alphabetically sorted: %q", first)
+	}
+}
+
 func TestEngineerPromptMentionsGHPRCreate(t *testing.T) {
 	l := &Launcher{
 		pack: &agent.PackDefinition{

--- a/internal/team/mention_auto_promote_test.go
+++ b/internal/team/mention_auto_promote_test.go
@@ -136,6 +136,23 @@ func TestAutoPromote_ExplicitTagRespected(t *testing.T) {
 	}
 }
 
+func TestAutoPromote_HumanTypedLeadSuppressesOtherMentions(t *testing.T) {
+	b := newBrokerWithPM(t)
+	b.mu.Lock()
+	b.members = append(b.members, officeMember{Slug: "reviewer", Name: "Reviewer"})
+	b.mu.Unlock()
+
+	msg := postMessage(t, b, "you", "general",
+		"@ceo ask @reviewer to check the PR", nil)
+
+	if !containsString(msg.Tagged, "ceo") {
+		t.Fatalf("raw @ceo should be treated as an explicit lead tag; got %+v", msg.Tagged)
+	}
+	if containsString(msg.Tagged, "reviewer") {
+		t.Fatalf("raw @ceo should suppress auto-promoting secondary mentions; got %+v", msg.Tagged)
+	}
+}
+
 // Synthetic senders (`system`, `nex`, bridges, future automation kinds) MUST
 // NOT auto-promote. A denylist approach would leak every new synthetic
 // identity — the allowlist in senderMayAutoPromoteLocked stops that.

--- a/internal/team/resume.go
+++ b/internal/team/resume.go
@@ -151,7 +151,10 @@ func (l *Launcher) buildResumePackets() map[string]string {
 		fresh := unanswered[:0]
 		for _, msg := range unanswered {
 			ts, err := time.Parse(time.RFC3339, msg.Timestamp)
-			if err == nil && ts.Before(cutoff) {
+			if err != nil {
+				continue
+			}
+			if ts.Before(cutoff) {
 				continue
 			}
 			fresh = append(fresh, msg)

--- a/internal/team/resume.go
+++ b/internal/team/resume.go
@@ -3,11 +3,20 @@ package team
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 // recentHumanMessageLimit is the number of recent human messages to consider
 // when building resume packets. The spec requires the last 50 messages.
 const recentHumanMessageLimit = 50
+
+// staleUnansweredThreshold is the oldest an unanswered human message can be
+// before it gets dropped on broker restart. Older messages are zombie work —
+// the user's intent has likely moved on, and replaying them burns a spawn per
+// agent for a turn the human didn't ask for. If the human still wants the old
+// message answered they can retag. Exposed as a var so tests that pre-seed
+// broker state with ancient timestamps can raise the threshold.
+var staleUnansweredThreshold = time.Hour
 
 // isHumanOrSystemSender reports whether a message sender is a human or system
 // source (not an agent). Only agent replies count as "answers".
@@ -132,6 +141,23 @@ func (l *Launcher) buildResumePackets() map[string]string {
 	humanMsgs := l.broker.RecentHumanMessages(recentHumanMessageLimit)
 	allMsgs := l.broker.AllMessages()
 	unanswered := findUnansweredMessages(humanMsgs, allMsgs)
+	// Drop unanswered messages older than staleUnansweredThreshold on startup.
+	// Without this, a broker that was down for hours replays every stale tag
+	// on restart — observed symptom: "@planner say hi" from 2 hours ago
+	// triggers a planner spawn that answers in the wrong context. If the human
+	// still wants the old message handled, they can retag.
+	if len(unanswered) > 0 {
+		cutoff := time.Now().UTC().Add(-staleUnansweredThreshold)
+		fresh := unanswered[:0]
+		for _, msg := range unanswered {
+			ts, err := time.Parse(time.RFC3339, msg.Timestamp)
+			if err == nil && ts.Before(cutoff) {
+				continue
+			}
+			fresh = append(fresh, msg)
+		}
+		unanswered = fresh
+	}
 
 	// Route unanswered messages: explicit tags → tagged agents; untagged → lead.
 	// Skip agents not in the current pack.

--- a/internal/team/token_bloat_fixes_test.go
+++ b/internal/team/token_bloat_fixes_test.go
@@ -15,7 +15,8 @@ import (
 // ignored, so this enforces it at the persistence layer.
 func TestDuplicateAgentBroadcastIsSuppressed(t *testing.T) {
 	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
 	defer func() { brokerStatePath = oldPathFn }()
 
 	b := NewBroker()
@@ -62,7 +63,8 @@ func TestDuplicateAgentBroadcastIsSuppressed(t *testing.T) {
 // bounded — a follow-up beyond the window posts normally.
 func TestDuplicateAgentBroadcastWindowExpires(t *testing.T) {
 	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
 	defer func() { brokerStatePath = oldPathFn }()
 
 	b := NewBroker()
@@ -85,7 +87,8 @@ func TestDuplicateAgentBroadcastWindowExpires(t *testing.T) {
 // the wrong intent).
 func TestStaleUnansweredFilteredOnResume(t *testing.T) {
 	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
+	tmpDir := t.TempDir()
+	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
 	defer func() { brokerStatePath = oldPathFn }()
 
 	// This test runs with the production-like threshold, not the test-suite
@@ -101,6 +104,7 @@ func TestStaleUnansweredFilteredOnResume(t *testing.T) {
 	b.messages = []channelMessage{
 		{ID: "h1", From: "you", Channel: "general", Content: "stale — ignore", Tagged: []string{"planner"}, Timestamp: stale},
 		{ID: "h2", From: "you", Channel: "general", Content: "fresh — answer", Tagged: []string{"planner"}, Timestamp: fresh},
+		{ID: "h3", From: "you", Channel: "general", Content: "malformed — ignore", Tagged: []string{"planner"}, Timestamp: "not-a-time"},
 	}
 	b.mu.Unlock()
 
@@ -114,6 +118,9 @@ func TestStaleUnansweredFilteredOnResume(t *testing.T) {
 	} else {
 		if strings.Contains(p, "stale — ignore") {
 			t.Error("stale message must not appear in resume packet")
+		}
+		if strings.Contains(p, "malformed — ignore") {
+			t.Error("messages with malformed timestamps must not appear in resume packet")
 		}
 		if !strings.Contains(p, "fresh — answer") {
 			t.Error("fresh message must appear in resume packet")

--- a/internal/team/token_bloat_fixes_test.go
+++ b/internal/team/token_bloat_fixes_test.go
@@ -1,0 +1,122 @@
+package team
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDuplicateAgentBroadcastIsSuppressed verifies that when the same agent
+// posts a near-identical broadcast to the same channel+thread within the
+// dedup window, the broker silently drops the duplicate. This is the
+// broker-side safety net for the "CEO emits 3 broadcasts in one turn"
+// pattern — the prompt rule telling agents not to do that is routinely
+// ignored, so this enforces it at the persistence layer.
+func TestDuplicateAgentBroadcastIsSuppressed(t *testing.T) {
+	oldPathFn := brokerStatePath
+	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	b.messages = []channelMessage{
+		{
+			ID:        "msg-1",
+			From:      "ceo",
+			Channel:   "general",
+			Content:   "Ball is in reviewer's court, shipping the PR now.",
+			ReplyTo:   "",
+			Timestamp: now,
+		},
+	}
+	b.mu.Unlock()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Byte-identical → drop.
+	if !b.isDuplicateAgentBroadcastLocked("ceo", "general", "", "Ball is in reviewer's court, shipping the PR now.") {
+		t.Error("exact duplicate should be detected")
+	}
+	// Paraphrased but same semantic content → drop (Jaccard over word set).
+	if !b.isDuplicateAgentBroadcastLocked("ceo", "general", "", "Ball is in the reviewer's court — shipping the PR now.") {
+		t.Error("near-duplicate with trivial punctuation drift should be detected")
+	}
+	// Truly different content → allow.
+	if b.isDuplicateAgentBroadcastLocked("ceo", "general", "", "Planner is blocked on a missing spec.") {
+		t.Error("distinct content must not be flagged duplicate")
+	}
+	// Different agent → allow.
+	if b.isDuplicateAgentBroadcastLocked("planner", "general", "", "Ball is in reviewer's court, shipping the PR now.") {
+		t.Error("duplicate detection must scope to the sender")
+	}
+	// Different thread → allow.
+	if b.isDuplicateAgentBroadcastLocked("ceo", "general", "msg-99", "Ball is in reviewer's court, shipping the PR now.") {
+		t.Error("duplicate detection must scope to (channel, thread)")
+	}
+}
+
+// TestDuplicateAgentBroadcastWindowExpires verifies the dedup window is time
+// bounded — a follow-up beyond the window posts normally.
+func TestDuplicateAgentBroadcastWindowExpires(t *testing.T) {
+	oldPathFn := brokerStatePath
+	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	b := NewBroker()
+	old := time.Now().UTC().Add(-2 * duplicateBroadcastWindow).Format(time.RFC3339)
+	b.mu.Lock()
+	b.messages = []channelMessage{
+		{ID: "msg-1", From: "ceo", Channel: "general", Content: "same content", Timestamp: old},
+	}
+	defer b.mu.Unlock()
+
+	if b.isDuplicateAgentBroadcastLocked("ceo", "general", "", "same content") {
+		t.Error("messages older than duplicateBroadcastWindow must not trigger dedup")
+	}
+}
+
+// TestStaleUnansweredFilteredOnResume verifies resume packets drop
+// unanswered human messages older than staleUnansweredThreshold. Without
+// this, a broker crash/restart replays zombie work (observed symptom: an
+// old "@planner say hi" from hours before the restart wakes planner with
+// the wrong intent).
+func TestStaleUnansweredFilteredOnResume(t *testing.T) {
+	oldPathFn := brokerStatePath
+	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
+	defer func() { brokerStatePath = oldPathFn }()
+
+	// This test runs with the production-like threshold, not the test-suite
+	// override from TestMain. Swap locally so production semantics win here.
+	origThreshold := staleUnansweredThreshold
+	staleUnansweredThreshold = time.Hour
+	defer func() { staleUnansweredThreshold = origThreshold }()
+
+	b := NewBroker()
+	stale := time.Now().UTC().Add(-90 * time.Minute).Format(time.RFC3339)
+	fresh := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
+	b.mu.Lock()
+	b.messages = []channelMessage{
+		{ID: "h1", From: "you", Channel: "general", Content: "stale — ignore", Tagged: []string{"planner"}, Timestamp: stale},
+		{ID: "h2", From: "you", Channel: "general", Content: "fresh — answer", Tagged: []string{"planner"}, Timestamp: fresh},
+	}
+	b.mu.Unlock()
+
+	l := Launcher{
+		broker: b,
+	}
+
+	packets := l.buildResumePackets()
+	if p, ok := packets["planner"]; !ok {
+		t.Fatal("planner should receive a packet for the fresh unanswered message")
+	} else {
+		if strings.Contains(p, "stale — ignore") {
+			t.Error("stale message must not appear in resume packet")
+		}
+		if !strings.Contains(p, "fresh — answer") {
+			t.Error("fresh message must appear in resume packet")
+		}
+	}
+}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -604,7 +604,9 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 			"Return the canonical runtime snapshot for this direct session, including tasks, pending human requests, recovery summary, and runtime capabilities.",
 		), handleTeamRuntimeState)
 
-		registerActionTools(server)
+		if hasActionProvider() {
+			registerActionTools(server)
+		}
 		return
 	}
 
@@ -637,7 +639,9 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 			"team_skill_run",
 			"Invoke a named team skill. When the human's request matches an available skill, call this BEFORE replying — do not freelance. Bumps the skill's usage, logs a skill_invocation to the channel, and returns the skill's canonical step-by-step content for you to follow.",
 		), handleTeamSkillRun)
-		registerActionTools(server)
+		if hasActionProvider() {
+			registerActionTools(server)
+		}
 		return
 	}
 

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/brokeraddr"
 	"github.com/nex-crm/wuphf/internal/team"
 )
@@ -683,26 +684,6 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 		"Open or find a direct message channel with the human. Use this when the human explicitly asks to DM an agent. Agent-to-agent DMs are not allowed — all inter-agent communication must happen in public channels.",
 	), handleTeamDMOpen)
 
-	mcp.AddTool(server, officeWriteTool(
-		"team_channel",
-		"Create or remove an office channel. When creating a channel, include a clear description of what work belongs there and the initial roster that should be in it. Only do this when the human explicitly wants channel structure.",
-	), handleTeamChannel)
-
-	mcp.AddTool(server, officeWriteTool(
-		"team_channel_member",
-		"Add, remove, disable, or enable an agent in a specific office channel.",
-	), handleTeamChannelMember)
-
-	mcp.AddTool(server, officeWriteTool(
-		"team_bridge",
-		"CEO-only tool to bridge relevant context from one channel into another and leave a visible cross-channel trail.",
-	), handleTeamBridge)
-
-	mcp.AddTool(server, officeWriteTool(
-		"team_member",
-		"Create or remove an office-wide member. Only create new members when the human explicitly wants to expand the team.",
-	), handleTeamMember)
-
 	mcp.AddTool(server, readOnlyTool(
 		"team_tasks",
 		"List the current shared tasks and who owns them so the team does not duplicate work.",
@@ -722,11 +703,6 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 		"team_task",
 		"Create, claim, assign, complete, block, or release a shared task in the office task list.",
 	), handleTeamTask)
-
-	mcp.AddTool(server, officeWriteTool(
-		"team_plan",
-		"Create a batch of tasks in one shot with optional dependency ordering. Use this instead of multiple team_task calls when you know the full plan up front.",
-	), handleTeamPlan)
 
 	registerSharedMemoryTools(server)
 
@@ -750,78 +726,60 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 		"Send a direct note to the human.",
 	), handleHumanMessage)
 	mcp.AddTool(server, officeWriteTool(
-		"human_interview",
-		"Ask the human a blocking decision question.",
-	), handleHumanInterview)
-	mcp.AddTool(server, readOnlyTool(
-		"team_tasks",
-		"List shared tasks and ownership.",
-	), handleTeamTasks)
-	mcp.AddTool(server, officeWriteTool(
 		"team_react",
 		"React to a message with an emoji.",
 	), handleTeamReact)
 	mcp.AddTool(server, officeWriteTool(
-		"team_status",
-		"Share a short status update.",
-	), handleTeamStatus)
-	mcp.AddTool(server, officeWriteTool(
 		"team_skill_run",
 		"Invoke a named team skill. When the request matches an available skill (see the skill list in your prompt), call this BEFORE doing the work — do not freelance. Bumps the skill's usage, logs a skill_invocation in the channel so the office sees you followed the playbook, and returns the skill's canonical step-by-step content for you to execute.",
 	), handleTeamSkillRun)
-	registerActionTools(server)
 
-	// Lead-only tools: CEO gets coordination, delegation, and structural tools
+	// Gate external-action tools behind a configured provider. Registering 14
+	// empty action tools inflates the MCP tool schema and pushes the total
+	// registry past Claude Code's deferred-tools threshold, which causes the
+	// model to emit a wasted ToolSearch before every call to a deferred tool.
+	// When no provider is available the tools would just return errors anyway.
+	if hasActionProvider() {
+		registerActionTools(server)
+	}
+
+	// Lead-only tools: structural + coordination tools that specialists should
+	// never invoke. Specialists still see them in the prompt's role-specific
+	// guidance, but the MCP schema omits them, so the model cannot call them
+	// and cannot waste a ToolSearch turn looking them up.
 	if isLead {
 		mcp.AddTool(server, officeWriteTool(
-			"team_task",
-			"Create, assign, complete, or block a task.",
-		), handleTeamTask)
-		mcp.AddTool(server, officeWriteTool(
 			"team_plan",
-			"Create a batch of tasks with dependency ordering.",
+			"Create a batch of tasks in one shot with optional dependency ordering. Use this instead of multiple team_task calls when you know the full plan up front.",
 		), handleTeamPlan)
 		mcp.AddTool(server, officeWriteTool(
 			"team_bridge",
-			"Bridge context from one channel to another.",
+			"CEO-only tool to bridge relevant context from one channel into another and leave a visible cross-channel trail.",
 		), handleTeamBridge)
-		mcp.AddTool(server, readOnlyTool(
-			"team_members",
-			"List channel participants and activity.",
-		), handleTeamMembers)
-		mcp.AddTool(server, readOnlyTool(
-			"team_requests",
-			"List pending human requests.",
-		), handleTeamRequests)
-		mcp.AddTool(server, officeWriteTool(
-			"team_request",
-			"Create a structured request for the human.",
-		), handleTeamRequest)
-		mcp.AddTool(server, readOnlyTool(
-			"team_runtime_state",
-			"Office runtime snapshot: tasks, requests, recovery.",
-		), handleTeamRuntimeState)
-		mcp.AddTool(server, readOnlyTool(
-			"team_office_members",
-			"List the full office roster.",
-		), handleTeamOfficeMembers)
-		mcp.AddTool(server, readOnlyTool(
-			"team_channels",
-			"List office channels and memberships.",
-		), handleTeamChannels)
 		mcp.AddTool(server, officeWriteTool(
 			"team_channel",
-			"Create or remove a channel.",
+			"Create or remove an office channel. When creating a channel, include a clear description of what work belongs there and the initial roster that should be in it. Only do this when the human explicitly wants channel structure.",
 		), handleTeamChannel)
 		mcp.AddTool(server, officeWriteTool(
 			"team_channel_member",
-			"Add or remove an agent from a channel.",
+			"Add, remove, disable, or enable an agent in a specific office channel.",
 		), handleTeamChannelMember)
 		mcp.AddTool(server, officeWriteTool(
 			"team_member",
-			"Create or remove an office member.",
+			"Create or remove an office-wide member. Only create new members when the human explicitly wants to expand the team.",
 		), handleTeamMember)
 	}
+}
+
+// hasActionProvider reports whether any external action provider is configured
+// and usable. Used to gate registerActionTools so agents in offices without a
+// connected provider do not see 14 action tools that would all return errors.
+func hasActionProvider() bool {
+	if externalActionProvider != nil {
+		return true
+	}
+	_, err := team.ResolveActionProviderForCapability(action.CapabilityGuide)
+	return err == nil
 }
 
 func handleTeamBroadcast(ctx context.Context, _ *mcp.CallToolRequest, args TeamBroadcastArgs) (*mcp.CallToolResult, any, error) {


### PR DESCRIPTION
## Summary

- **Headless by default**: removes the mandatory tmux pane spawn at startup; `claude --print` per turn runs on the user's normal subscription quota (Anthropic re-sanctioned this in the 2026-04 OpenClaw policy note)
- **Duplicate broadcast filter**: 30 s window + 0.85 similarity threshold drops paraphrased re-posts from the same agent in the same thread, cutting token burn on chatty turns
- **Prompt cache stability**: sorts `officeMembers` and `activePolicies` by slug before building the prompt so the prefix is byte-identical across spawns and prompt-cache hits land reliably
- **Tool hygiene rules in prompt**: agents are told all `team_*`/`human_*` tools are already registered — no `ToolSearch` needed — closing the most common cause of wasted turns
- **Wizard-hired agent dispatch**: `activeSessionMembers` now includes broker-only members (agents hired mid-session via the wizard) so @-tags and DMs no longer silently route to the CEO
- **Ghost pane guard**: `agentPaneTargets` returns early when `paneBackedAgents` is false, preventing ghost `PaneTarget` strings that bypass the headless dispatcher and drop messages into dead tmux sessions
- **Activity watchdog**: reaps agents stuck in `active`/`thinking` after a crash; `activityWatchdogEnabled` flag lets TestMain disable it so short-lived test brokers do not accumulate goroutines

## Test plan

- [ ] `go test ./internal/team/... -timeout 120s` passes green
- [ ] Launch office in web mode, confirm agents dispatch headless without tmux (no pane-spawn attempt at startup)
- [ ] Hire an agent via wizard mid-session, confirm @-tags reach that agent
- [ ] Confirm no ghost-pane dispatch when `paneBackedAgents = false`
- [ ] Enable prompt caching (`ANTHROPIC_PROMPT_CACHING=1`), run two sequential turns, confirm cache hit reported

🤖 Generated with [Claude Code](https://claude.com/claude-code)