### PR TITLE
[codex] fix OpenCode onboarding detection

### DIFF
--- a/internal/onboarding/prereqs.go
+++ b/internal/onboarding/prereqs.go
@@ -1,8 +1,12 @@
 package onboarding
 
 import (
+	"context"
 	"os/exec"
 	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/runtimebin"
 )
 
 // PrereqResult describes the detection outcome for a single prerequisite binary.
@@ -56,9 +60,9 @@ func CheckAll() []PrereqResult {
 	return results
 }
 
-// CheckOne probes a single binary by name. It runs exec.LookPath to confirm
-// the binary exists on PATH, then invokes `<name> --version` to capture the
-// version string. If LookPath fails the binary is considered absent and the
+// CheckOne probes a single binary by name. It resolves from PATH plus common
+// CLI install directories, then invokes `<name> --version` to capture the
+// version string. If resolution fails the binary is considered absent and the
 // version field is left empty.
 func CheckOne(name string) PrereqResult {
 	spec := prereqSpecs[name]
@@ -68,15 +72,17 @@ func CheckOne(name string) PrereqResult {
 		InstallURL: spec.installURL,
 	}
 
-	if _, err := exec.LookPath(name); err != nil {
-		// Binary not on PATH.
+	path, err := runtimebin.LookPath(name)
+	if err != nil {
 		return r
 	}
 	r.Found = true
 	r.OK = true
 
 	// Best-effort version capture; ignore errors.
-	out, err := exec.Command(name, "--version").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, path, "--version").Output()
 	if err == nil {
 		r.Version = parseVersion(string(out))
 	}

--- a/internal/onboarding/prereqs_test.go
+++ b/internal/onboarding/prereqs_test.go
@@ -1,6 +1,9 @@
 package onboarding
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -105,5 +108,31 @@ func TestCheckOneResultFields(t *testing.T) {
 	}
 	if !r.Found && r.Version != "" {
 		t.Error("if Found is false, Version should be empty")
+	}
+}
+
+func TestCheckOneFindsOpencodeInCommonUserBinWhenPATHIsMinimal(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".opencode", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir opencode bin: %v", err)
+	}
+	opencodePath := filepath.Join(binDir, "opencode")
+	if err := os.WriteFile(opencodePath, []byte("#!/bin/sh\nprintf 'opencode 9.9.9\\n'\n"), 0o755); err != nil {
+		t.Fatalf("write fake opencode: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", filepath.Join(home, "minimal-path"))
+
+	r := CheckOne("opencode")
+	if !r.Found {
+		t.Fatal("expected fallback opencode to be found")
+	}
+	if r.Version != "opencode 9.9.9" {
+		t.Fatalf("Version: got %q, want %q", r.Version, "opencode 9.9.9")
+	}
+	if got := os.Getenv("PATH"); !strings.Contains(got, binDir) {
+		t.Fatalf("expected PATH to include discovered opencode dir, got %q", got)
 	}
 }

--- a/internal/provider/opencode.go
+++ b/internal/provider/opencode.go
@@ -13,10 +13,11 @@ import (
 
 	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/runtimebin"
 )
 
 var (
-	opencodeLookPath = exec.LookPath
+	opencodeLookPath = runtimebin.LookPath
 	opencodeCommand  = exec.Command
 	opencodeGetwd    = os.Getwd
 )

--- a/internal/runtimebin/path.go
+++ b/internal/runtimebin/path.go
@@ -1,0 +1,153 @@
+package runtimebin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var (
+	lookPathFn    = exec.LookPath
+	userHomeFn    = os.UserHomeDir
+	statFn        = os.Stat
+	getenvFn      = os.Getenv
+	setenvFn      = os.Setenv
+	evalSymlinkFn = filepath.EvalSymlinks
+)
+
+// LookPath resolves a CLI binary from PATH plus common user/package-manager
+// bin directories. macOS app/npm launches can inherit a minimal PATH that omits
+// Homebrew or user bins, so onboarding should not report installed CLIs as
+// missing just because the parent process skipped shell startup files.
+func LookPath(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("empty executable name")
+	}
+	if path, err := lookPathFn(name); err == nil {
+		return path, nil
+	}
+	if filepath.Base(name) != name {
+		return "", exec.ErrNotFound
+	}
+	for _, dir := range fallbackDirs() {
+		for _, candidate := range executableCandidates(dir, name) {
+			if isExecutable(candidate) {
+				ensureDirOnPATH(filepath.Dir(candidate))
+				return candidate, nil
+			}
+		}
+	}
+	return "", exec.ErrNotFound
+}
+
+func fallbackDirs() []string {
+	var dirs []string
+	add := func(dir string) {
+		dir = strings.TrimSpace(dir)
+		if dir == "" {
+			return
+		}
+		dirs = append(dirs, dir)
+	}
+
+	for _, dir := range filepath.SplitList(getenvFn("WUPHF_CLI_PATHS")) {
+		add(dir)
+	}
+
+	if home, err := userHomeFn(); err == nil && strings.TrimSpace(home) != "" {
+		add(filepath.Join(home, ".opencode", "bin"))
+		add(filepath.Join(home, ".local", "bin"))
+		add(filepath.Join(home, ".bun", "bin"))
+		add(filepath.Join(home, "Library", "pnpm"))
+		add(filepath.Join(home, ".npm-global", "bin"))
+		add(filepath.Join(home, ".deno", "bin"))
+		add(filepath.Join(home, ".cargo", "bin"))
+	}
+
+	add("/opt/homebrew/bin")
+	add("/usr/local/bin")
+	add("/home/linuxbrew/.linuxbrew/bin")
+
+	seen := make(map[string]bool, len(dirs))
+	out := dirs[:0]
+	for _, dir := range dirs {
+		clean := filepath.Clean(dir)
+		if seen[clean] {
+			continue
+		}
+		seen[clean] = true
+		out = append(out, clean)
+	}
+	return out
+}
+
+func executableCandidates(dir, name string) []string {
+	candidates := []string{filepath.Join(dir, name)}
+	if runtime.GOOS == "windows" && filepath.Ext(name) == "" {
+		exts := filepath.SplitList(getenvFn("PATHEXT"))
+		if len(exts) == 0 {
+			exts = []string{".exe", ".cmd", ".bat"}
+		}
+		for _, ext := range exts {
+			ext = strings.TrimSpace(ext)
+			if ext == "" {
+				continue
+			}
+			if !strings.HasPrefix(ext, ".") {
+				ext = "." + ext
+			}
+			candidates = append(candidates, filepath.Join(dir, name+ext))
+		}
+	}
+	return candidates
+}
+
+func isExecutable(path string) bool {
+	info, err := statFn(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode()&0o111 != 0
+}
+
+func ensureDirOnPATH(dir string) {
+	dir = filepath.Clean(strings.TrimSpace(dir))
+	if dir == "" {
+		return
+	}
+	current := getenvFn("PATH")
+	for _, existing := range filepath.SplitList(current) {
+		if sameDir(existing, dir) {
+			return
+		}
+	}
+	next := dir
+	if current != "" {
+		next += string(os.PathListSeparator) + current
+	}
+	_ = setenvFn("PATH", next)
+}
+
+func sameDir(a, b string) bool {
+	a = filepath.Clean(strings.TrimSpace(a))
+	b = filepath.Clean(strings.TrimSpace(b))
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	aReal, aErr := evalSymlinkFn(a)
+	bReal, bErr := evalSymlinkFn(b)
+	if aErr == nil && bErr == nil {
+		return filepath.Clean(aReal) == filepath.Clean(bReal)
+	}
+	return false
+}

--- a/internal/team/capabilities.go
+++ b/internal/team/capabilities.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/runtimebin"
 )
 
 type CapabilityLevel string
@@ -52,7 +53,7 @@ type RuntimeCapabilities struct {
 	Registry CapabilityRegistry
 }
 
-var lookPathFn = exec.LookPath
+var lookPathFn = runtimebin.LookPath
 var commandCombinedOutputFn = func(name string, args ...string) ([]byte, error) {
 	return exec.Command(name, args...).CombinedOutput()
 }

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -14,12 +14,13 @@ import (
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/runtimebin"
 )
 
 // Opencode-specific test hooks. Kept separate from the codex hooks so test
 // setups can stub one runtime without colliding with the other.
 var (
-	headlessOpencodeLookPath       = exec.LookPath
+	headlessOpencodeLookPath       = runtimebin.LookPath
 	headlessOpencodeCommandContext = exec.CommandContext
 	headlessOpencodeExecutablePath = os.Executable
 )

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -36,6 +36,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/onboarding"
 	"github.com/nex-crm/wuphf/internal/operations"
 	"github.com/nex-crm/wuphf/internal/provider"
+	"github.com/nex-crm/wuphf/internal/runtimebin"
 	"github.com/nex-crm/wuphf/internal/setup"
 )
 
@@ -255,7 +256,7 @@ func isOnboarded() bool {
 func (l *Launcher) Preflight() error {
 	if l.usesCodexRuntime() {
 		if l.usesOpencodeRuntime() {
-			if _, err := exec.LookPath("opencode"); err != nil {
+			if _, err := runtimebin.LookPath("opencode"); err != nil {
 				return fmt.Errorf("opencode not found. Install Opencode CLI (https://opencode.ai) and configure your provider credentials")
 			}
 			return nil
@@ -4572,7 +4573,7 @@ func (l *Launcher) PreflightWeb() error {
 	}
 	if l.usesCodexRuntime() {
 		if l.usesOpencodeRuntime() {
-			if _, err := exec.LookPath("opencode"); err != nil {
+			if _, err := runtimebin.LookPath("opencode"); err != nil {
 				return fmt.Errorf("opencode not found. Install Opencode CLI (https://opencode.ai) and configure your provider credentials")
 			}
 			return nil

--- a/internal/tui/init_flow.go
+++ b/internal/tui/init_flow.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -14,9 +13,10 @@ import (
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/nex"
 	"github.com/nex-crm/wuphf/internal/operations"
+	"github.com/nex-crm/wuphf/internal/runtimebin"
 )
 
-var initFlowLookPathFn = exec.LookPath
+var initFlowLookPathFn = runtimebin.LookPath
 
 type initReadinessCheck struct {
 	Label  string


### PR DESCRIPTION
## What changed

Adds a shared runtime binary resolver that checks the inherited `PATH` plus common CLI install locations such as `~/.opencode/bin`, `~/.local/bin`, `~/.bun/bin`, `~/Library/pnpm`, `/opt/homebrew/bin`, and `/usr/local/bin`.

The onboarding prerequisite endpoint now uses that resolver and captures versions with a timeout. OpenCode launch/preflight paths also use the same resolver so an onboarding-detected OpenCode binary remains runnable in the same process environment.

## Why

Prod onboarding could report OpenCode as missing when WUPHF was launched with a minimal process `PATH`, even though `opencode` was installed in a standard Homebrew or user bin directory. The setup step disables the OpenCode tile directly from `/onboarding/prereqs`, so the bad lookup prevented selecting it.

## Impact

OpenCode is detected during onboarding from standard install paths even when shell startup files did not populate `PATH`. The discovered directory is added to the running process `PATH` so subsequent OpenCode checks and launches can resolve the same CLI.

## Validation

- `go test ./internal/onboarding`
- `go test ./internal/tui ./internal/provider ./internal/team -run 'TestProviderOptions|TestCheck|TestDetectRuntimeCapabilities|TestPreflight|TestHeadlessOpencode|TestOpencode' -count=1`
- after rebase: `go test ./internal/runtimebin ./internal/onboarding ./internal/tui ./internal/provider ./internal/team -run 'TestCheckOne|TestCheckAll|TestProviderOptions|TestDetectRuntimeCapabilities|TestPreflight|TestHeadlessOpencode|TestOpencode' -count=1`
- `git diff --check`
- `npm run build` in `web`
- browser-harness assertion against stripped-`PATH` server: `/onboarding/prereqs` returned `opencode` with `found: true`
- Playwright setup-step check against stripped-`PATH` server: OpenCode tile was enabled
- `WUPHF_E2E_BASE_URL=http://localhost:7993 bunx playwright test tests/wizard.spec.ts`
- after seeding onboarding: `WUPHF_E2E_BASE_URL=http://localhost:7993 bunx playwright test tests/smoke.spec.ts`