### PR TITLE
fix(wiki): Pam rides the tab bar — visible across the wiki, desk on the divider

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -105,6 +105,10 @@ function MainContent() {
   const notebookAgentSlug = useAppStore((s) => s.notebookAgentSlug)
   const notebookEntrySlug = useAppStore((s) => s.notebookEntrySlug)
   const setNotebookRoute = useAppStore((s) => s.setNotebookRoute)
+  // Pam's onActionDone bumps this; Wiki re-fetches article + history when
+  // the prop changes. Lifted up here because Pam lives inside the tab bar
+  // (so her desk can rest on the divider line).
+  const [articleRefreshNonce, setArticleRefreshNonce] = useState(0)
 
   if (!currentApp && isDMChannel(currentChannel, channelMeta)) {
     return <DMView />
@@ -125,13 +129,25 @@ function MainContent() {
       }
     }
 
+    // Pam only belongs on the wiki surface (notebooks + reviews are
+    // separate contexts). When we're not on the wiki tab, articlePath is
+    // null so she renders as disabled scenery without actionable state.
+    const pamArticlePath =
+      currentApp === 'wiki' ? wikiPath ?? null : null
+
     return (
       <div className="wiki-shell">
-        <WikiTabs current={currentApp} onSelect={handleTabChange} />
+        <WikiTabs
+          current={currentApp}
+          onSelect={handleTabChange}
+          pamArticlePath={pamArticlePath}
+          onPamActionDone={() => setArticleRefreshNonce((n) => n + 1)}
+        />
         <div className="wiki-shell-body">
           {currentApp === 'wiki' && (
             <Wiki
               articlePath={wikiPath}
+              externalRefreshNonce={articleRefreshNonce}
               onNavigate={(path) => {
                 if (path === null) {
                   setWikiPath(null)

--- a/web/src/components/wiki/Pam.tsx
+++ b/web/src/components/wiki/Pam.tsx
@@ -10,11 +10,16 @@ import { buildPamMenu, type PamMenuEntry } from '../../lib/pamActions'
 import '../../styles/pam.css'
 
 interface PamProps {
-  articlePath: string
   /**
-   * Called once Pam finishes an action (SSE `done`). WikiArticle uses this
-   * to bump its refreshNonce so the enriched article + history reload
-   * without a full navigation.
+   * The article Pam should act on. `null` means we're outside an article
+   * view (catalog, audit) — Pam still renders as part of the wiki chrome
+   * but article-scoped actions are disabled.
+   */
+  articlePath: string | null
+  /**
+   * Called once Pam finishes an action (SSE `done`). The Wiki shell uses
+   * this to bump an article refresh nonce so the enriched article +
+   * history reload without a full navigation.
    */
   onActionDone?: () => void
 }
@@ -28,11 +33,13 @@ type Status =
 const STATUS_CLEAR_MS = 4000
 
 /**
- * Pam — the wiki archivist, perched on top of the article column. Click Pam
- * to open her desk menu (served from GET /pam/actions so the registry stays
- * server-defined). Selecting an action POSTs to /pam/action; the dispatcher
- * spawns Pam's sub-process and fans results back via /events so we update
- * the status line without polling.
+ * Pam — the wiki archivist, perched on the divider line at the top of the
+ * wiki shell so she's visible across catalog, article, and audit views.
+ * Click Pam to open her desk menu (served from GET /pam/actions so the
+ * registry stays server-defined). Selecting an action POSTs to /pam/action;
+ * the dispatcher spawns Pam's sub-process and fans results back via /events
+ * so we update the status line without polling. Article-scoped actions
+ * disable themselves when no article is open.
  */
 export default function Pam({ articlePath, onActionDone }: PamProps) {
   const [menu, setMenu] = useState<PamMenuEntry[] | null>(null)
@@ -163,6 +170,7 @@ export default function Pam({ articlePath, onActionDone }: PamProps) {
 
   const runAction = useCallback(
     async (entry: PamMenuEntry) => {
+      if (!articlePath) return
       setMenuOpen(false)
       setStatus({ kind: 'running', label: entry.label })
       try {
@@ -237,6 +245,8 @@ export default function Pam({ articlePath, onActionDone }: PamProps) {
             </div>
           ) : menu.length === 0 ? (
             <div className="pam-menu-empty">No actions available.</div>
+          ) : !articlePath ? (
+            <div className="pam-menu-empty">Open an article to use Pam.</div>
           ) : (
             menu.map((entry) => (
               <button

--- a/web/src/components/wiki/Wiki.tsx
+++ b/web/src/components/wiki/Wiki.tsx
@@ -20,11 +20,21 @@ const AUDIT_PATH = '_audit'
 interface WikiProps {
   /** When set, renders the article view for this path; otherwise renders the catalog. */
   articlePath?: string | null
+  /**
+   * Bumped by Pam (hoisted up to the tab bar) when she finishes an action
+   * against the current article. Wiki forwards it into WikiArticle so the
+   * article + history re-fetch without a full navigation.
+   */
+  externalRefreshNonce?: number
   onNavigate: (path: string | null) => void
 }
 
 /** Three-column wiki shell: left sidebar · main (catalog or article) · right rail (article only). */
-export default function Wiki({ articlePath, onNavigate }: WikiProps) {
+export default function Wiki({
+  articlePath,
+  externalRefreshNonce = 0,
+  onNavigate,
+}: WikiProps) {
   const [catalog, setCatalog] = useState<WikiCatalogEntry[]>([])
   const [sections, setSections] = useState<DiscoveredSection[]>([])
   const [loading, setLoading] = useState(true)
@@ -78,6 +88,7 @@ export default function Wiki({ articlePath, onNavigate }: WikiProps) {
             path={articlePath}
             catalog={catalog}
             onNavigate={(path) => onNavigate(path)}
+            externalRefreshNonce={externalRefreshNonce}
           />
         ) : (
           <WikiCatalog

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import type { PluggableList } from 'unified'
 import ArticleStatusBanner from './ArticleStatusBanner'
-import Pam from './Pam'
 import EntityBriefBar from './EntityBriefBar'
 import FactsOnFile from './FactsOnFile'
 import EntityRelatedPanel from './EntityRelatedPanel'
@@ -56,9 +55,20 @@ interface WikiArticleProps {
   path: string
   catalog: WikiCatalogEntry[]
   onNavigate: (path: string) => void
+  /**
+   * Bumped by Pam (now hoisted to the Wiki shell) when an action completes,
+   * so the article + history refetch without a navigation. Treated as an
+   * additive trigger on top of the local refreshNonce used by inline edits.
+   */
+  externalRefreshNonce?: number
 }
 
-export default function WikiArticle({ path, catalog, onNavigate }: WikiArticleProps) {
+export default function WikiArticle({
+  path,
+  catalog,
+  onNavigate,
+  externalRefreshNonce = 0,
+}: WikiArticleProps) {
   const [article, setArticle] = useState<WikiArticleT | null>(null)
   const [tab, setTab] = useState<HatBarTab>('article')
   const [loading, setLoading] = useState(true)
@@ -107,7 +117,7 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
     return () => {
       cancelled = true
     }
-  }, [path, refreshNonce])
+  }, [path, refreshNonce, externalRefreshNonce])
 
   useEffect(() => {
     let cancelled = false
@@ -131,7 +141,7 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
     return () => {
       cancelled = true
     }
-  }, [path, refreshNonce])
+  }, [path, refreshNonce, externalRefreshNonce])
 
   useEffect(() => {
     setLiveAgent(null)
@@ -197,10 +207,6 @@ export default function WikiArticle({ path, catalog, onNavigate }: WikiArticlePr
   return (
     <>
       <main className="wk-article-col">
-        <Pam
-          articlePath={article.path}
-          onActionDone={() => setRefreshNonce((n) => n + 1)}
-        />
         {liveAgent && (
           <ArticleStatusBanner
             message={`${formatAgentName(liveAgent)} is editing this article right now.`}

--- a/web/src/components/wiki/WikiTabs.tsx
+++ b/web/src/components/wiki/WikiTabs.tsx
@@ -1,11 +1,21 @@
 import { useQuery } from '@tanstack/react-query'
 import { fetchReviews } from '../../api/notebook'
+import Pam from './Pam'
 
 export type WikiTab = 'wiki' | 'notebooks' | 'reviews'
 
 interface WikiTabsProps {
   current: WikiTab
   onSelect: (tab: WikiTab) => void
+  /**
+   * Pam sits inside the tab bar so her desk can rest on the bottom
+   * divider line. `pamArticlePath` is the article she should act on;
+   * pass `null` outside an article view (or outside the Wiki tab
+   * entirely) and her menu falls back to a "Open an article…" empty
+   * state.
+   */
+  pamArticlePath?: string | null
+  onPamActionDone?: () => void
 }
 
 /**
@@ -19,7 +29,12 @@ interface WikiTabsProps {
  * Lives above the per-surface design systems so it reads as app chrome,
  * not as a wiki- or notebook-themed element.
  */
-export default function WikiTabs({ current, onSelect }: WikiTabsProps) {
+export default function WikiTabs({
+  current,
+  onSelect,
+  pamArticlePath = null,
+  onPamActionDone,
+}: WikiTabsProps) {
   const { data: reviews } = useQuery({
     queryKey: ['reviews-tab-badge'],
     queryFn: fetchReviews,
@@ -58,6 +73,10 @@ export default function WikiTabs({ current, onSelect }: WikiTabsProps) {
           </button>
         )
       })}
+      {/* Pam the Archivist rides inside the tab bar so her desk can sit
+          exactly on the bottom divider line — see pam.css for the absolute
+          positioning. */}
+      <Pam articlePath={pamArticlePath} onActionDone={onPamActionDone} />
     </nav>
   )
 }

--- a/web/src/styles/pam.css
+++ b/web/src/styles/pam.css
@@ -1,19 +1,42 @@
 /* ─── Pam the Archivist ───
  *
- * Pam sits on top of the wiki article column in the upper-right. The desk
- * is the visual anchor: a wider rectangle that she peeks out from behind,
- * so she reads as a receptionist perched above the page. The wrapper uses
- * `position: absolute` inside the article column (the column is the
- * positioning context; see .wk-article-col). Idle animations fire
- * occasionally via CSS animation-iteration-count so she's alive but not
- * distracting.
+ * Pam is rendered inside the wiki tab bar (Wiki / Notebooks / Reviews)
+ * so her desk can sit flush on the tab bar's bottom divider line — she
+ * reads as a receptionist perched on the edge of the page, looking over
+ * whatever view is active underneath.
+ *
+ * Moving her inside .wiki-tabs is what fixes the "hiding behind the
+ * article" bug. The earlier placement anchored her inside the article
+ * column (.wk-article-col has overflow-y:auto), which silently clipped
+ * anything that tried to poke above the column's top edge. The tab bar
+ * has no such clip, and its bottom border IS the divider we want, so
+ * `position: absolute; bottom: 0` lands the desk's bottom exactly on
+ * that line with no magic offset math.
+ *
+ * Idle animations fire occasionally via CSS animation-iteration-count so
+ * she's alive but not distracting.
  */
+
+/* .wiki-tabs owns Pam's positioning context. The nav already has
+ * `display: flex` — position: relative doesn't disturb its flex layout;
+ * it just lets absolute children anchor to the nav's box. */
+.wiki-tabs {
+  position: relative;
+  /* The nav itself should not clip the avatar that rises above the tab
+   * text. Its flex children are laid out explicitly so overflow:visible
+   * is safe. */
+  overflow: visible;
+}
 
 .pam-wrap {
   position: absolute;
-  top: -36px;           /* lift her above the article's top edge */
-  right: 16px;
-  z-index: 40;          /* above article content; below global overlays */
+  /* Bottom of wrap sits on the tab bar's bottom edge — which is the
+   * divider line between the tab row and the wiki body. With the flex
+   * column order (avatar first, desk second) and desk being visually
+   * the lowest element, the desk's bottom rests exactly on that line. */
+  bottom: 0;
+  right: 24px;
+  z-index: 40;          /* above content; below global overlays */
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary

- **Placement**: Pam's desk now sits flush on the bottom divider line of the Wiki / Notebooks / Reviews tab bar. Previously she was absolutely positioned inside `.wk-article-col`, which has `overflow-y: auto` — that silently clipped her avatar whenever she tried to rise above the column top, which is why she looked like she was hiding behind the article.
- **Visibility**: hoisted from `WikiArticle` up to `WikiTabs` so she renders across every wiki surface (catalog, article, audit), not just article views.
- **Cross-tab behavior**: on Notebooks / Reviews tabs she renders as disabled scenery with an "Open an article to use Pam." empty state in the menu, so she reads as wiki chrome without misfiring.
- **Refresh plumbing**: article refetch after a Pam action is now App → WikiTabs (Pam host) for the callback, App → Wiki → WikiArticle for the refresh nonce. Same UX, state just lifted one level.

## Files

- `web/src/components/wiki/Pam.tsx` — `articlePath: string \| null`, disabled-state empty menu.
- `web/src/components/wiki/WikiTabs.tsx` — renders `<Pam>` inside the nav.
- `web/src/components/wiki/Wiki.tsx` — drops Pam render; accepts `externalRefreshNonce` prop.
- `web/src/components/wiki/WikiArticle.tsx` — accepts `externalRefreshNonce`, wired into the fetch effects.
- `web/src/App.tsx` — owns `articleRefreshNonce` + computes `pamArticlePath`; passes through.
- `web/src/styles/pam.css` — `.wiki-tabs` gets `position: relative; overflow: visible`; `.pam-wrap` uses `bottom: 0` so the desk's bottom sits exactly on the divider.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm test` — 302/302 web tests pass
- [x] Dev build (`wuphf-dev --broker-port 7897 --web-port 7898`, isolated `HOME`) — verified visually:
  - Pam visible on the Wiki catalog, articles, audit, Notebooks, and Reviews
  - Desk bottom sits on the tab-bar divider line
  - Menu opens; "Open an article to use Pam." shown when off the Wiki tab or on catalog/audit
  - Article enrichment action still runs and refreshes the article