### PR TITLE
feat(wiki): Slice 2 Thread B — extractor closes §7.4 substrate guarantee via fact-log JSONL

### DIFF
--- a/docs/specs/WIKI-SCHEMA.md
+++ b/docs/specs/WIKI-SCHEMA.md
@@ -311,6 +311,12 @@ fact_id = sha256(artifact_sha + "/" + sentence_offset + "/" + norm(subject) + "/
 
 `rm -rf .wuphf/index/` → restart broker → boot reconcile runs → SQLite + bleve re-indexed from markdown. The result must be **logically identical**, not byte-identical. Logical identity means: `SELECT * FROM facts ORDER BY id` produces the same canonical hash pre- and post-rebuild.
 
+**Every code path that introduces a new fact must append it to `wiki/facts/{kind}/{slug}.jsonl` via `WikiWorker.EnqueueFactLogAppend` under the `archivist` identity.** The extraction loop, human `save_as_insight`, and any future synthesis-time fact mint all honor this contract — markdown is the source of truth, and a fact that lives only in the derived cache violates the rebuild guarantee.
+
+Reinforcement is a read-side concept: when the same `fact_id` is re-extracted, only `reinforced_at` advances in the index. No new JSONL line is appended, and the on-disk fact log remains canonical.
+
+**`ReinforcedAt` hash policy.** `CanonicalHashFacts` EXCLUDES `reinforced_at` from its input, so two extraction runs on the same artifact (the second one purely bumping `reinforced_at`) produce an identical hash. That makes `CanonicalHashFacts` the load-bearing rebuild-invariance check. `CanonicalHashAll` INCLUDES `reinforced_at` (alongside entities, edges, and redirects) and so advances whenever any layer — reinforcement included — changes. Use `CanonicalHashAll` for end-to-end drift detection and `CanonicalHashFacts` for the rebuild contract test.
+
 ---
 
 ## 8. Decay & temporal validity

--- a/docs/specs/WIKI-SCHEMA.md
+++ b/docs/specs/WIKI-SCHEMA.md
@@ -317,6 +317,8 @@ Reinforcement is a read-side concept: when the same `fact_id` is re-extracted, o
 
 **`ReinforcedAt` hash policy.** `CanonicalHashFacts` EXCLUDES `reinforced_at` from its input, so two extraction runs on the same artifact (the second one purely bumping `reinforced_at`) produce an identical hash. That makes `CanonicalHashFacts` the load-bearing rebuild-invariance check. `CanonicalHashAll` INCLUDES `reinforced_at` (alongside entities, edges, and redirects) and so advances whenever any layer — reinforcement included — changes. Use `CanonicalHashAll` for end-to-end drift detection and `CanonicalHashFacts` for the rebuild contract test.
 
+**Append-failure closure.** When `EnqueueFactLogAppend` fails (queue saturated, local I/O, git error), the failure is routed to the DLQ under the dedicated `fact_log_persist` category — NOT `provider_timeout`. The replay path retries the APPEND only, reading the current fact log and appending any missing `fact_id`s. Re-running extraction would treat the fact as reinforcement per §7.3 and never write the missing JSONL line, permanently breaking §7.4 for that fact. See §11.13 for category details.
+
 ---
 
 ## 8. Decay & temporal validity
@@ -456,14 +458,22 @@ The DLQ (`wiki/.dlq/extractions.jsonl`) holds extraction failures that are eligi
   "artifact_path": "wiki/artifacts/chat/3f9a21bc.md",
   "kind": "chat",
   "last_error": "json_parse_error: expected { got \"\`\`\`json\\n{\"",
-  "error_category": "parse | provider_timeout | validation",
+  "error_category": "parse | provider_timeout | validation | fact_log_persist",
   "retry_count": 2,
   "max_retries": 5,
   "first_failed_at": "2026-04-22T13:00:00Z",
   "last_attempted_at": "2026-04-22T15:10:00Z",
-  "next_retry_not_before": "2026-04-22T15:20:00Z"
+  "next_retry_not_before": "2026-04-22T15:20:00Z",
+  "fact_log_append": {
+    "kind": "person",
+    "slug": "sarah-chen",
+    "artifact_sha": "3f9a21bc",
+    "jsonl_lines": "{\"id\":\"a3f9b2c14e8d\",...}\n"
+  }
 }
 ```
+
+`fact_log_append` is populated only for `error_category = "fact_log_persist"`. Carries the exact state needed for the append-replay path to reconstruct the `AppendFactLog` call without re-running extraction — see the §7.4 closure guarantee below.
 
 #### Tombstone rows
 
@@ -485,6 +495,17 @@ and a full DLQ entry is written to `permanent-failures.jsonl`.
 - `error_category = "validation"` automatically sets `max_retries = 1` — programming errors are never retried past the first attempt.
 - After `max_retries` attempts the entry moves to `permanent-failures.jsonl` and is excluded from the active replay queue.
 - `ReadyForReplay` scans the full file and skips any `artifact_sha` that has a matching `resolved_at` or `promoted_at` tombstone.
+
+#### Error categories
+
+| category | source | replay path |
+|---|---|---|
+| `parse` | LLM returned malformed JSON | re-run extraction via `ExtractFromArtifact` |
+| `provider_timeout` | LLM call failed / cancelled / index mutation failed | re-run extraction via `ExtractFromArtifact` |
+| `validation` | programming-class error (bad path, template failure) | re-run extraction once, then promote |
+| `fact_log_persist` | fact-log JSONL append failed AFTER extraction succeeded | re-run APPEND only — never re-run extraction (§7.4 closure) |
+
+`fact_log_persist` is distinct from `provider_timeout` because re-running extraction is not a valid replay for an append failure. Extraction would treat the fact as reinforcement (`reinforced_at` bump only, no new JSONL line — see §7.3), and the on-disk fact log would never recover. The replay handler instead reads the current fact log, dedupes by `fact_id`, and appends any missing lines via `EnqueueFactLogAppend`. The composite DLQ key for a `fact_log_persist` entry is `factlog:{kind}:{slug}:{artifact_sha}` so concurrent append failures for different entities from the same artifact never clobber each other under the last-write-wins keying of `readLatestStateLocked`.
 
 ---
 

--- a/internal/team/entity_commit.go
+++ b/internal/team/entity_commit.go
@@ -135,7 +135,11 @@ func (r *Repo) CommitLintReport(ctx context.Context, slug, relPath, content, mes
 }
 
 // factLogPathPattern validates wiki/facts/{kind}/{slug}.jsonl paths (new schema §3).
-var factLogPathPattern = regexp.MustCompile(`^wiki/facts/[^/]+/[^/]+\.jsonl$`)
+// Mirrors entityFactPathPattern's shape: kind is lowercase letters (a starter
+// letter then alnum/dash), slug is alnum/dash starting with a non-dash
+// character. Blocks traversal, hidden files, uppercase, and other shapes
+// the resolver never produces.
+var factLogPathPattern = regexp.MustCompile(`^wiki/facts/[a-z][a-z0-9-]*/[a-z0-9][a-z0-9-]*\.jsonl$`)
 
 // CommitFactLog writes the given content to relPath inside wiki/facts/ and
 // commits it under the supplied slug. Used by ResolveContradiction to mutate
@@ -223,7 +227,11 @@ func (r *Repo) AppendFactLog(ctx context.Context, slug, relPath, additionalConte
 	}
 
 	fullPath := filepath.Join(r.root, clean)
-	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+	// Match CommitEntityFact's tighter mode (0o700 dirs / 0o600 files). The
+	// wiki repo is per-user local state; the previous 0o755/0o644 mix was
+	// unnecessarily permissive for an append-only log that may carry
+	// sensitive extraction metadata.
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o700); err != nil {
 		return "", 0, fmt.Errorf("fact append: mkdir: %w", err)
 	}
 
@@ -246,7 +254,7 @@ func (r *Repo) AppendFactLog(ctx context.Context, slug, relPath, additionalConte
 		buf = append(buf, '\n')
 	}
 
-	if err := os.WriteFile(fullPath, buf, 0o644); err != nil {
+	if err := os.WriteFile(fullPath, buf, 0o600); err != nil {
 		return "", 0, fmt.Errorf("fact append: write: %w", err)
 	}
 

--- a/internal/team/entity_commit.go
+++ b/internal/team/entity_commit.go
@@ -193,3 +193,89 @@ func (r *Repo) CommitFactLog(ctx context.Context, slug, relPath, content, messag
 	}
 	return strings.TrimSpace(sha), len(content), nil
 }
+
+// AppendFactLog appends newlineContent to the fact-log file at relPath and
+// commits the resulting bytes. The file is created if it does not exist.
+// `additionalContent` must be the raw bytes to append — the caller is
+// responsible for newline-terminating each JSONL record. A trailing newline
+// is added if missing so the final file always ends with "\n".
+//
+// Uses the repo-wide write lock so the read-modify-write sequence is safe
+// against concurrent appenders; the WikiWorker single-writer invariant
+// (§11.5, Anti-pattern 5) routes every caller through this path.
+//
+// The accepted relPath shape matches Repo.CommitFactLog: wiki/facts/**/*.jsonl
+// or team/entities/*.facts.jsonl.
+func (r *Repo) AppendFactLog(ctx context.Context, slug, relPath, additionalContent, message string) (string, int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return "", 0, fmt.Errorf("fact append: author slug is required")
+	}
+	clean := filepath.ToSlash(filepath.Clean(relPath))
+	if !factLogPathPattern.MatchString(clean) && !entityFactPathPattern.MatchString(clean) {
+		return "", 0, fmt.Errorf("fact append: path must be wiki/facts/**/*.jsonl or team/entities/*.facts.jsonl; got %q", relPath)
+	}
+	if additionalContent == "" {
+		return "", 0, fmt.Errorf("fact append: content is required")
+	}
+
+	fullPath := filepath.Join(r.root, clean)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
+		return "", 0, fmt.Errorf("fact append: mkdir: %w", err)
+	}
+
+	var existing []byte
+	if b, err := os.ReadFile(fullPath); err == nil {
+		existing = b
+	} else if !os.IsNotExist(err) {
+		return "", 0, fmt.Errorf("fact append: read existing: %w", err)
+	}
+
+	var buf []byte
+	buf = append(buf, existing...)
+	// Guarantee a newline between existing and new content.
+	if len(buf) > 0 && buf[len(buf)-1] != '\n' {
+		buf = append(buf, '\n')
+	}
+	buf = append(buf, []byte(additionalContent)...)
+	// Guarantee trailing newline so reconcile reads every line.
+	if len(buf) > 0 && buf[len(buf)-1] != '\n' {
+		buf = append(buf, '\n')
+	}
+
+	if err := os.WriteFile(fullPath, buf, 0o644); err != nil {
+		return "", 0, fmt.Errorf("fact append: write: %w", err)
+	}
+
+	if out, err := r.runGitLocked(ctx, slug, "add", "--", clean); err != nil {
+		return "", 0, fmt.Errorf("fact append: git add: %w: %s", err, out)
+	}
+
+	cachedDiff, err := r.runGitLocked(ctx, slug, "diff", "--cached", "--name-only")
+	if err != nil {
+		return "", 0, fmt.Errorf("fact append: git diff --cached: %w", err)
+	}
+	if strings.TrimSpace(cachedDiff) == "" {
+		headSha, herr := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+		if herr != nil {
+			return "", 0, fmt.Errorf("fact append: resolve HEAD: %w", herr)
+		}
+		return strings.TrimSpace(headSha), len(buf), nil
+	}
+
+	commitMsg := strings.TrimSpace(message)
+	if commitMsg == "" {
+		commitMsg = fmt.Sprintf("archivist: append fact log %s", relPath)
+	}
+	if out, err := r.runGitLocked(ctx, slug, "commit", "-q", "-m", commitMsg); err != nil {
+		return "", 0, fmt.Errorf("fact append: git commit: %w: %s", err, out)
+	}
+	sha, err := r.runGitLocked(ctx, slug, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", 0, fmt.Errorf("fact append: resolve HEAD sha: %w", err)
+	}
+	return strings.TrimSpace(sha), len(buf), nil
+}

--- a/internal/team/wiki_dlq.go
+++ b/internal/team/wiki_dlq.go
@@ -53,7 +53,46 @@ const (
 	DLQCategoryParse           DLQErrorCategory = "parse"
 	DLQCategoryProviderTimeout DLQErrorCategory = "provider_timeout"
 	DLQCategoryValidation      DLQErrorCategory = "validation"
+	// DLQCategoryFactLogPersist is the category for a fact-log JSONL append
+	// that failed AFTER the extraction LLM call succeeded and SubmitFacts
+	// applied the in-memory index mutation. These are local I/O / git /
+	// queue-saturation failures — NOT provider timeouts — so they carry
+	// their own category (different metrics bucket, same backoff curve)
+	// and a dedicated replay path that re-tries the append without
+	// re-running the LLM (which would skip reinforced rows and leave the
+	// JSONL permanently missing). See §7.4 substrate guarantee.
+	DLQCategoryFactLogPersist DLQErrorCategory = "fact_log_persist"
 )
+
+// FactLogAppendPayload carries the state needed to retry a failed fact-log
+// JSONL append without re-running extraction. Populated on entries whose
+// ErrorCategory is DLQCategoryFactLogPersist.
+//
+// The payload captures the exact JSONL lines the original append tried to
+// write (one JSON-encoded TypedFact per line, newline-terminated) along with
+// the target kind/slug and the originating artifact SHA — enough for the
+// replay handler to reconstruct the EnqueueFactLogAppend call and
+// deterministically dedupe by fact_id against the current on-disk file.
+type FactLogAppendPayload struct {
+	Kind        string `json:"kind"`
+	Slug        string `json:"slug"`
+	ArtifactSHA string `json:"artifact_sha"`
+	// JSONLLines is the raw multi-line content the append was attempting to
+	// write. Preserving the bytes verbatim keeps the content hash stable
+	// across retries.
+	JSONLLines string `json:"jsonl_lines"`
+}
+
+// FactLogAppendSHA synthesises the DLQ row key for a fact-log append failure.
+// One artifact extraction can produce append failures for multiple
+// (kind, slug) groups; using the raw artifact SHA would collide across them
+// in readLatestStateLocked. The synthesized form
+// "factlog:{kind}:{slug}:{artifactSHA}" is unique per target file, never
+// collides with an extraction-class entry, and keeps the rest of the DLQ
+// contract unchanged (tombstones, retry bookkeeping, last-write-wins).
+func FactLogAppendSHA(kind, slug, artifactSHA string) string {
+	return "factlog:" + kind + ":" + slug + ":" + artifactSHA
+}
 
 // DLQEntry is one row in wiki/.dlq/extractions.jsonl.
 // All time fields are RFC3339 UTC strings on the wire.
@@ -68,6 +107,10 @@ type DLQEntry struct {
 	FirstFailedAt      time.Time        `json:"first_failed_at"`
 	LastAttemptedAt    time.Time        `json:"last_attempted_at"`
 	NextRetryNotBefore time.Time        `json:"next_retry_not_before"`
+	// FactLogAppend is populated only when ErrorCategory is
+	// DLQCategoryFactLogPersist. Carries the state needed for the
+	// append-specific replay path; unused/nil for extraction-class entries.
+	FactLogAppend *FactLogAppendPayload `json:"fact_log_append,omitempty"`
 }
 
 // dlqTombstone is the append-only tombstone written when an entry is resolved

--- a/internal/team/wiki_extractor.go
+++ b/internal/team/wiki_extractor.go
@@ -361,7 +361,101 @@ func (e *Extractor) apply(ctx context.Context, out extractionOutput, artifactPat
 		e.queueDLQ(ctx, out.ArtifactSHA, artifactPath, kind, err, DLQCategoryProviderTimeout)
 		return err
 	}
+	// Substrate guarantee (§7.4): after in-memory submission succeeds, persist
+	// every NEW (non-reinforced) fact to the append-only JSONL log so a wipe +
+	// reconcile rebuilds to a logically-identical index. Reinforced facts only
+	// update reinforced_at in-memory; they are already in the JSONL file from
+	// the first extraction run, so re-appending would duplicate the line.
+	//
+	// Failures here never fail the caller — the artifact commit already
+	// succeeded and SubmitFacts was atomic from the caller's perspective. A
+	// persistence failure is logged + queued to the DLQ for replay.
+	e.persistFactLogs(ctx, out.ArtifactSHA, factsToWrite)
 	return nil
+}
+
+// persistFactLogs appends newly-introduced facts to wiki/facts/{kind}/{slug}.jsonl
+// under the archivist identity. Batches per-entity so one artifact with N
+// facts about the same entity results in 1 commit (not N).
+//
+// This is the §7.4 substrate-rebuild closure for the extraction path: without
+// it, the fact lives only in the derived index cache and evaporates on
+// `rm -rf .wuphf/index/`.
+//
+// Errors are logged (and routed through the DLQ for optional replay) but
+// never propagated — the in-memory submission already succeeded, so failing
+// the extractor here would cause SubmitFacts re-execution on replay and
+// break the §7.3 reinforcement invariant.
+func (e *Extractor) persistFactLogs(ctx context.Context, artifactSHA string, facts []TypedFact) {
+	if len(facts) == 0 || e.worker == nil {
+		return
+	}
+	// Group by (kind, entity_slug). Reinforced facts (ReinforcedAt != nil) are
+	// already on disk from a prior run; skip to avoid duplicate JSONL lines.
+	type groupKey struct{ kind, slug string }
+	groups := make(map[groupKey][]TypedFact)
+	for _, f := range facts {
+		if f.ReinforcedAt != nil {
+			continue
+		}
+		kind := strings.TrimSpace(f.Kind)
+		slug := strings.TrimSpace(f.EntitySlug)
+		if kind == "" || slug == "" {
+			// Missing kind/slug means we cannot deterministically locate the
+			// fact log. Log and skip — the in-memory submission already ran,
+			// so this fact is findable at query time but will be dropped on
+			// the next rebuild. Slice 3 hardens this via a resolver fallback.
+			log.Printf("wiki_extractor: persist fact log: missing kind/slug for fact %s (kind=%q slug=%q)", f.ID, kind, slug)
+			continue
+		}
+		groups[groupKey{kind: kind, slug: slug}] = append(groups[groupKey{kind: kind, slug: slug}], f)
+	}
+	if len(groups) == 0 {
+		return
+	}
+	msg := fmt.Sprintf("archivist: extract facts from %s", artifactSHA)
+	for key, batch := range groups {
+		body, err := serializeFactsAsJSONL(batch)
+		if err != nil {
+			log.Printf("wiki_extractor: serialize fact log for %s/%s: %v", key.kind, key.slug, err)
+			continue
+		}
+		if body == "" {
+			continue
+		}
+		path := factLogPath(key.kind, key.slug)
+		if _, _, err := e.worker.EnqueueFactLogAppend(ctx, ArchivistAuthor, path, body, msg); err != nil {
+			log.Printf("wiki_extractor: append fact log %s: %v", path, err)
+			// The artifact is committed and SubmitFacts succeeded. Route the
+			// append failure to the DLQ so a later ReplayDLQ call can retry,
+			// but do NOT double-fail the extractor (SubmitFacts already ran).
+			e.queueDLQ(ctx, artifactSHA, path, key.kind, fmt.Errorf("append fact log: %w", err), DLQCategoryProviderTimeout)
+		}
+	}
+}
+
+// factLogPath returns the JSONL path for an entity's fact log, matching the
+// §3 Layer-2 layout and the walker in wiki_index.go.
+func factLogPath(kind, slug string) string {
+	return "wiki/facts/" + kind + "/" + slug + ".jsonl"
+}
+
+// serializeFactsAsJSONL marshals each TypedFact as one JSON object per line,
+// terminated by '\n'. Returns "" when the input is empty.
+func serializeFactsAsJSONL(facts []TypedFact) (string, error) {
+	if len(facts) == 0 {
+		return "", nil
+	}
+	var b strings.Builder
+	for i := range facts {
+		line, err := json.Marshal(facts[i])
+		if err != nil {
+			return "", fmt.Errorf("marshal fact %s: %w", facts[i].ID, err)
+		}
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
 }
 
 // ── DLQ plumbing ──────────────────────────────────────────────────────────────

--- a/internal/team/wiki_extractor.go
+++ b/internal/team/wiki_extractor.go
@@ -63,6 +63,10 @@ type Extractor struct {
 	// now returns the current time; overridable in tests for deterministic
 	// created_at / valid_from values.
 	now func() time.Time
+	// appendFactLog is the fact-log append seam. Defaults to
+	// worker.EnqueueFactLogAppend. Tests override to simulate
+	// ErrQueueSaturated without fighting the worker's drain lifecycle.
+	appendFactLog func(ctx context.Context, slug, path, content, commitMsg string) (string, int, error)
 }
 
 // NewExtractor constructs an Extractor. All arguments except `now` are
@@ -73,7 +77,7 @@ func NewExtractor(provider QueryProvider, worker *WikiWorker, dlq *DLQ, index *W
 		// The template is embedded and known-valid; a parse error is a build-time bug.
 		panic(fmt.Sprintf("wiki_extractor: parse embedded template: %v", err))
 	}
-	return &Extractor{
+	ex := &Extractor{
 		provider: provider,
 		worker:   worker,
 		gate:     newEntityResolverGate(),
@@ -82,11 +86,22 @@ func NewExtractor(provider QueryProvider, worker *WikiWorker, dlq *DLQ, index *W
 		tmpl:     tmpl,
 		now:      func() time.Time { return time.Now().UTC() },
 	}
+	ex.appendFactLog = func(ctx context.Context, slug, path, content, commitMsg string) (string, int, error) {
+		return worker.EnqueueFactLogAppend(ctx, slug, path, content, commitMsg)
+	}
+	return ex
 }
 
 // SetNow overrides the clock used for created_at / valid_from defaults.
 // Test-only hook.
 func (e *Extractor) SetNow(now func() time.Time) { e.now = now }
+
+// setAppendFactLog overrides the fact-log append seam. Test-only — used to
+// simulate ErrQueueSaturated deterministically without racing the worker's
+// drain goroutine.
+func (e *Extractor) setAppendFactLog(fn func(ctx context.Context, slug, path, content, commitMsg string) (string, int, error)) {
+	e.appendFactLog = fn
+}
 
 // ── Prompt template context ───────────────────────────────────────────────────
 
@@ -382,10 +397,11 @@ func (e *Extractor) apply(ctx context.Context, out extractionOutput, artifactPat
 // it, the fact lives only in the derived index cache and evaporates on
 // `rm -rf .wuphf/index/`.
 //
-// Errors are logged (and routed through the DLQ for optional replay) but
-// never propagated — the in-memory submission already succeeded, so failing
-// the extractor here would cause SubmitFacts re-execution on replay and
-// break the §7.3 reinforcement invariant.
+// Errors are logged and routed through the DLQ under the dedicated
+// DLQCategoryFactLogPersist category so ReplayDLQ can retry the append
+// without re-running extraction. Re-running extraction would skip the fact
+// as reinforcement (§7.3) and the JSONL line would never be written,
+// permanently breaking §7.4 for that fact.
 func (e *Extractor) persistFactLogs(ctx context.Context, artifactSHA string, facts []TypedFact) {
 	if len(facts) == 0 || e.worker == nil {
 		return
@@ -415,21 +431,26 @@ func (e *Extractor) persistFactLogs(ctx context.Context, artifactSHA string, fac
 	}
 	msg := fmt.Sprintf("archivist: extract facts from %s", artifactSHA)
 	for key, batch := range groups {
-		body, err := serializeFactsAsJSONL(batch)
-		if err != nil {
-			log.Printf("wiki_extractor: serialize fact log for %s/%s: %v", key.kind, key.slug, err)
+		body, serErr := serializeFactsAsJSONL(batch)
+		if serErr != nil {
+			// Should be unreachable now that serializeFactsAsJSONL collects
+			// partials — but keep the guard so a future invariant change
+			// cannot silently swallow a whole batch.
+			log.Printf("wiki_extractor: serialize fact log for %s/%s: %v", key.kind, key.slug, serErr)
 			continue
 		}
 		if body == "" {
 			continue
 		}
 		path := factLogPath(key.kind, key.slug)
-		if _, _, err := e.worker.EnqueueFactLogAppend(ctx, ArchivistAuthor, path, body, msg); err != nil {
+		if _, _, err := e.appendFactLog(ctx, ArchivistAuthor, path, body, msg); err != nil {
 			log.Printf("wiki_extractor: append fact log %s: %v", path, err)
-			// The artifact is committed and SubmitFacts succeeded. Route the
-			// append failure to the DLQ so a later ReplayDLQ call can retry,
-			// but do NOT double-fail the extractor (SubmitFacts already ran).
-			e.queueDLQ(ctx, artifactSHA, path, key.kind, fmt.Errorf("append fact log: %w", err), DLQCategoryProviderTimeout)
+			// SubmitFacts already ran. Route the append failure to the DLQ
+			// under the dedicated fact-log-persist category so ReplayDLQ
+			// retries the APPEND (not the full extraction). Retrying the
+			// full extraction would treat every fact as reinforcement and
+			// never write the missing JSONL lines. See §7.4.
+			e.queueFactLogPersistDLQ(ctx, artifactSHA, key.kind, key.slug, path, body, err)
 		}
 	}
 }
@@ -442,6 +463,15 @@ func factLogPath(kind, slug string) string {
 
 // serializeFactsAsJSONL marshals each TypedFact as one JSON object per line,
 // terminated by '\n'. Returns "" when the input is empty.
+//
+// A marshal failure on any single fact is logged and that fact is skipped —
+// the remaining facts in the batch are still serialized and returned. An
+// earlier version aborted the whole batch on the first failure, silently
+// dropping every sibling fact in the same (kind, slug) group and breaking
+// the §7.4 substrate guarantee for every fact that came after the bad
+// record. That trade-off was strictly worse than losing one pathological
+// fact — TypedFact has no pointers to types that json/encoding would fail
+// on under normal operation, so the skip path is defensive only.
 func serializeFactsAsJSONL(facts []TypedFact) (string, error) {
 	if len(facts) == 0 {
 		return "", nil
@@ -450,12 +480,39 @@ func serializeFactsAsJSONL(facts []TypedFact) (string, error) {
 	for i := range facts {
 		line, err := json.Marshal(facts[i])
 		if err != nil {
-			return "", fmt.Errorf("marshal fact %s: %w", facts[i].ID, err)
+			log.Printf("wiki_extractor: skipping unmarshalable fact %s in batch: %v", facts[i].ID, err)
+			continue
 		}
 		b.Write(line)
 		b.WriteByte('\n')
 	}
 	return b.String(), nil
+}
+
+// queueFactLogPersistDLQ routes a fact-log append failure to the DLQ under
+// the dedicated DLQCategoryFactLogPersist category. The entry carries the
+// exact JSONL lines the original append tried to write so ReplayDLQ can
+// reconstruct the call without re-running extraction.
+func (e *Extractor) queueFactLogPersistDLQ(ctx context.Context, artifactSHA, kind, slug, path, body string, appendErr error) {
+	if e.dlq == nil {
+		return
+	}
+	entry := DLQEntry{
+		ArtifactSHA:   FactLogAppendSHA(kind, slug, artifactSHA),
+		ArtifactPath:  path,
+		Kind:          kind,
+		LastError:     appendErr.Error(),
+		ErrorCategory: DLQCategoryFactLogPersist,
+		FactLogAppend: &FactLogAppendPayload{
+			Kind:        kind,
+			Slug:        slug,
+			ArtifactSHA: artifactSHA,
+			JSONLLines:  body,
+		},
+	}
+	if enqErr := e.dlq.Enqueue(ctx, entry); enqErr != nil {
+		log.Printf("wiki_extractor: enqueue fact-log-persist DLQ for %s/%s: %v", kind, slug, enqErr)
+	}
 }
 
 // ── DLQ plumbing ──────────────────────────────────────────────────────────────
@@ -479,9 +536,16 @@ func (e *Extractor) queueDLQ(ctx context.Context, sha, path, kind string, err er
 	}
 }
 
-// ReplayDLQ walks the DLQ replay queue and re-runs ExtractFromArtifact on
-// each ready entry. Success → MarkResolved tombstone; failure → RecordAttempt
-// so the entry either backs off or promotes to permanent-failures.jsonl.
+// ReplayDLQ walks the DLQ replay queue and retries each ready entry. Routing
+// depends on the ErrorCategory:
+//
+//   - DLQCategoryFactLogPersist: re-attempt the JSONL append only (no
+//     extraction rerun). Re-running extraction would skip the fact as
+//     reinforcement and the append would never recover — see §7.4.
+//   - everything else: re-run ExtractFromArtifact on the artifact.
+//
+// Success → MarkResolved tombstone; failure → RecordAttempt so the entry
+// either backs off or promotes to permanent-failures.jsonl.
 //
 // Returns (processed, retired, err) where processed is the number of entries
 // attempted, retired is the count that moved out of the active queue
@@ -497,12 +561,13 @@ func (e *Extractor) ReplayDLQ(ctx context.Context) (int, int, error) {
 	var processed, retired int
 	for _, entry := range ready {
 		processed++
-		if err := e.ExtractFromArtifact(ctx, entry.ArtifactPath); err != nil {
+		retiredThis, handledErr := e.replayDLQEntry(ctx, entry)
+		if handledErr != nil {
 			cat := string(entry.ErrorCategory)
 			if cat == "" {
 				cat = string(DLQCategoryProviderTimeout)
 			}
-			if recErr := e.dlq.RecordAttempt(ctx, entry.ArtifactSHA, err, cat); recErr != nil {
+			if recErr := e.dlq.RecordAttempt(ctx, entry.ArtifactSHA, handledErr, cat); recErr != nil {
 				log.Printf("wiki_extractor: record attempt for %s: %v", entry.ArtifactSHA, recErr)
 				continue
 			}
@@ -518,8 +583,142 @@ func (e *Extractor) ReplayDLQ(ctx context.Context) (int, int, error) {
 			continue
 		}
 		retired++
+		_ = retiredThis
 	}
 	return processed, retired, nil
+}
+
+// replayDLQEntry dispatches one DLQ entry to the right retry path based on
+// its ErrorCategory. Returns (retiredImmediately, err); err != nil means the
+// retry failed and the caller should RecordAttempt.
+func (e *Extractor) replayDLQEntry(ctx context.Context, entry DLQEntry) (bool, error) {
+	if entry.ErrorCategory == DLQCategoryFactLogPersist {
+		if err := e.replayFactLogAppend(ctx, entry); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if err := e.ExtractFromArtifact(ctx, entry.ArtifactPath); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// replayFactLogAppend retries a failed fact-log JSONL append. It is
+// idempotent: the on-disk file is consulted first and any fact_id that is
+// already present is dropped from the append payload before re-enqueueing.
+// If every payload line is already on disk the retry is treated as resolved
+// with a no-op, which is the intended behaviour when the prior attempt
+// actually landed on disk but this process missed the success signal.
+func (e *Extractor) replayFactLogAppend(ctx context.Context, entry DLQEntry) error {
+	if entry.FactLogAppend == nil {
+		return fmt.Errorf("replay fact-log append: missing payload on entry %q", entry.ArtifactSHA)
+	}
+	payload := *entry.FactLogAppend
+	kind := strings.TrimSpace(payload.Kind)
+	slug := strings.TrimSpace(payload.Slug)
+	if kind == "" || slug == "" {
+		return fmt.Errorf("replay fact-log append: empty kind/slug in payload")
+	}
+	path := factLogPath(kind, slug)
+
+	// Dedupe by fact_id against the current on-disk fact log — the prior
+	// attempt may have partially landed, or a concurrent extraction may have
+	// reinforced these facts via a different code path and persisted them
+	// already. Either way, append only the fact_ids that are still missing.
+	onDisk, err := e.readFactIDsFromFactLog(path)
+	if err != nil {
+		return fmt.Errorf("replay fact-log append: read existing: %w", err)
+	}
+
+	missing, err := filterMissingJSONLLines(payload.JSONLLines, onDisk)
+	if err != nil {
+		return fmt.Errorf("replay fact-log append: filter missing: %w", err)
+	}
+	if missing == "" {
+		// Every line already present — nothing to do. Treat as success so
+		// ReplayDLQ writes the resolved tombstone and this entry leaves the
+		// active queue.
+		return nil
+	}
+
+	artifactSHA := payload.ArtifactSHA
+	if artifactSHA == "" {
+		artifactSHA = entry.ArtifactSHA
+	}
+	msg := fmt.Sprintf("archivist: replay fact-log append for %s", artifactSHA)
+	if _, _, err := e.appendFactLog(ctx, ArchivistAuthor, path, missing, msg); err != nil {
+		return fmt.Errorf("replay fact-log append %s: %w", path, err)
+	}
+	return nil
+}
+
+// readFactIDsFromFactLog reads wiki/facts/{kind}/{slug}.jsonl and returns
+// the set of fact_ids currently on disk. A missing file returns an empty
+// set (the typical first-retry case). Malformed lines are skipped with a
+// log — reconcile applies the same tolerance.
+func (e *Extractor) readFactIDsFromFactLog(relPath string) (map[string]struct{}, error) {
+	if e.worker == nil || e.worker.Repo() == nil {
+		return map[string]struct{}{}, nil
+	}
+	full := filepath.Join(e.worker.Repo().Root(), filepath.FromSlash(relPath))
+	data, err := os.ReadFile(full)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]struct{}{}, nil
+		}
+		return nil, err
+	}
+	ids := make(map[string]struct{})
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		var probe struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(trimmed), &probe); err != nil {
+			// Tolerate malformed rows — the same posture reconcile takes.
+			continue
+		}
+		if probe.ID != "" {
+			ids[probe.ID] = struct{}{}
+		}
+	}
+	return ids, nil
+}
+
+// filterMissingJSONLLines returns the subset of `lines` whose fact_id is
+// NOT already present in `onDisk`. Lines that cannot be parsed as a JSON
+// object with an `id` field are passed through unchanged — they were valid
+// in the original append attempt and the retry should carry them forward.
+func filterMissingJSONLLines(lines string, onDisk map[string]struct{}) (string, error) {
+	if lines == "" {
+		return "", nil
+	}
+	var b strings.Builder
+	for _, line := range strings.Split(lines, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		var probe struct {
+			ID string `json:"id"`
+		}
+		if err := json.Unmarshal([]byte(trimmed), &probe); err != nil {
+			// Preserve verbatim — caller validated the payload at queue time.
+			b.WriteString(line)
+			b.WriteByte('\n')
+			continue
+		}
+		if _, already := onDisk[probe.ID]; already {
+			continue
+		}
+		b.WriteString(line)
+		b.WriteByte('\n')
+	}
+	return b.String(), nil
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/internal/team/wiki_extractor_closure_test.go
+++ b/internal/team/wiki_extractor_closure_test.go
@@ -1,0 +1,390 @@
+package team
+
+// wiki_extractor_closure_test.go — Thread B coverage for the §7.4 substrate
+// guarantee. Extraction MUST append the JSONL fact log in addition to mutating
+// the in-memory index, so `rm -rf .wuphf/index/` + ReconcileFromMarkdown
+// produces a logically-identical rebuild.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// extractSecondArtifactResponse returns an extraction payload for the SAME
+// entity (sarah-chen) from a different artifact. Facts have distinct
+// sentence offsets so the deterministic fact_id (§7.3) differs from the
+// cannedResponse payload — tests of append-only JSONL can assert the file
+// grew by the expected count.
+func extractSecondArtifactResponse(sha string) string {
+	payload := extractionOutput{
+		ArtifactSHA: sha,
+		Entities: []extractedEntity{
+			{
+				Kind:         "person",
+				ProposedSlug: "sarah-chen",
+				ExistingSlug: "sarah-chen",
+				Signals: extractedSignal{
+					PersonName: "Sarah Chen",
+					JobTitle:   "VP of Sales",
+				},
+				Confidence: 0.95,
+			},
+		},
+		Facts: []extractedFact{
+			{
+				EntitySlug: "sarah-chen",
+				Type:       "observation",
+				Triplet: &Triplet{
+					Subject:   "sarah-chen",
+					Predicate: "prefers",
+					Object:    "literal:async-updates",
+				},
+				Text:           "Sarah prefers async updates over standups.",
+				Confidence:     0.9,
+				ValidFrom:      "2026-04-15",
+				SourceType:     "chat",
+				SourcePath:     "wiki/artifacts/chat/" + sha + ".md",
+				SentenceOffset: 42,
+			},
+		},
+	}
+	b, _ := json.Marshal(payload)
+	return string(b)
+}
+
+// TestExtractionSurvivesReboot is the §7.4 contract test for Thread B.
+// Extract facts from an artifact, assert BM25 finds them, wipe the in-memory
+// index, rebuild via ReconcileFromMarkdown, and assert both (a) BM25 still
+// finds the same facts, and (b) CanonicalHashAll matches pre-wipe — proving
+// the derived cache was rebuilt with logical identity.
+func TestExtractionSurvivesReboot(t *testing.T) {
+	h := newExtractHarness(t)
+	defer h.teardown()
+
+	sha := "survivr1"
+	h.provider.response = cannedResponse(sha)
+	path := h.writeArtifact(sha, "chat", "Sarah Chen was promoted to VP of Sales.\n")
+
+	ctx := context.Background()
+	if err := h.extractor.ExtractFromArtifact(ctx, path); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	h.worker.WaitForIdle()
+
+	// Sanity check: BM25 finds the fact pre-wipe.
+	preHits, err := h.index.Search(ctx, "VP of Sales", 10)
+	if err != nil {
+		t.Fatalf("pre-wipe search: %v", err)
+	}
+	if len(preHits) == 0 {
+		t.Fatal("pre-wipe search returned 0 hits; extraction did not populate the index")
+	}
+
+	preHashFacts, err := h.index.CanonicalHashFacts(ctx)
+	if err != nil {
+		t.Fatalf("pre-wipe CanonicalHashFacts: %v", err)
+	}
+
+	// Fact log must exist on disk — that is the substrate guarantee.
+	factLogRel := factLogPath("person", "sarah-chen")
+	factLogAbs := filepath.Join(h.repo.Root(), filepath.FromSlash(factLogRel))
+	if _, err := os.Stat(factLogAbs); err != nil {
+		t.Fatalf("fact log missing on disk at %s: %v", factLogRel, err)
+	}
+
+	// Wipe the index by constructing a fresh one rooted at the same repo, then
+	// reconciling from markdown. This is the equivalent of rm -rf .wuphf/index/
+	// + broker restart.
+	fresh := NewWikiIndex(h.repo.Root())
+	defer fresh.Close()
+	if err := fresh.ReconcileFromMarkdown(ctx); err != nil {
+		t.Fatalf("reconcile from markdown: %v", err)
+	}
+
+	// BM25 finds the same fact after rebuild.
+	postHits, err := fresh.Search(ctx, "VP of Sales", 10)
+	if err != nil {
+		t.Fatalf("post-wipe search: %v", err)
+	}
+	if len(postHits) == 0 {
+		t.Fatal("post-wipe search returned 0 hits; substrate guarantee (§7.4) violated")
+	}
+	wantID := ComputeFactID(sha, 0, "sarah-chen", "role_at", "company:acme-corp")
+	found := false
+	for _, hit := range postHits {
+		if hit.FactID == wantID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("post-wipe search missed fact %s; got %+v", wantID, postHits)
+	}
+
+	// CanonicalHashFacts is logically identical across the wipe — this is the
+	// load-bearing §7.4 fact-substrate contract that Thread B closes.
+	// (CanonicalHashAll also covers entities/edges/redirects; ghost entity
+	// rows minted in-memory by the extractor are not committed as briefs by
+	// Thread B and so do not round-trip through markdown reconcile. Brief
+	// writing lives in the synthesizer path; Slice 3 will unify the two so
+	// CanonicalHashAll also round-trips end-to-end through extraction alone.)
+	postHashFacts, err := fresh.CanonicalHashFacts(ctx)
+	if err != nil {
+		t.Fatalf("post-wipe CanonicalHashFacts: %v", err)
+	}
+	if preHashFacts != postHashFacts {
+		t.Errorf("§7.4 substrate drift: pre=%s post=%s", preHashFacts, postHashFacts)
+	}
+}
+
+// TestEnqueueFactLogAppendsJSONL asserts that two extractions for the same
+// entity (but different artifacts) append distinct lines to the JSONL file.
+// Re-extracting the same artifact must NOT duplicate lines — reinforcement
+// updates in-memory reinforced_at only.
+func TestEnqueueFactLogAppendsJSONL(t *testing.T) {
+	h := newExtractHarness(t)
+	defer h.teardown()
+
+	firstSHA := "append01"
+	h.provider.response = cannedResponse(firstSHA)
+	firstPath := h.writeArtifact(firstSHA, "chat", "Sarah Chen was promoted to VP of Sales.\n")
+
+	ctx := context.Background()
+	if err := h.extractor.ExtractFromArtifact(ctx, firstPath); err != nil {
+		t.Fatalf("first extract: %v", err)
+	}
+	h.worker.WaitForIdle()
+
+	factLogAbs := filepath.Join(h.repo.Root(),
+		filepath.FromSlash(factLogPath("person", "sarah-chen")))
+
+	lineCountAfterFirst := countNonEmptyLines(t, factLogAbs)
+	if lineCountAfterFirst != 1 {
+		t.Fatalf("expected 1 JSONL line after first extract; got %d", lineCountAfterFirst)
+	}
+
+	// Second artifact, different sha and sentence offset → brand-new fact_id.
+	secondSHA := "append02"
+	h.provider.mu.Lock()
+	h.provider.response = extractSecondArtifactResponse(secondSHA)
+	h.provider.mu.Unlock()
+	secondPath := h.writeArtifact(secondSHA, "chat", "Sarah prefers async updates.\n")
+	if err := h.extractor.ExtractFromArtifact(ctx, secondPath); err != nil {
+		t.Fatalf("second extract: %v", err)
+	}
+	h.worker.WaitForIdle()
+
+	lineCountAfterSecond := countNonEmptyLines(t, factLogAbs)
+	if lineCountAfterSecond != 2 {
+		t.Fatalf("expected 2 JSONL lines after second extract (distinct fact); got %d", lineCountAfterSecond)
+	}
+
+	// Third run: re-extract the FIRST artifact. Reinforcement must NOT append.
+	h.provider.mu.Lock()
+	h.provider.response = cannedResponse(firstSHA)
+	h.provider.mu.Unlock()
+	if err := h.extractor.ExtractFromArtifact(ctx, firstPath); err != nil {
+		t.Fatalf("third extract (reinforcement): %v", err)
+	}
+	h.worker.WaitForIdle()
+
+	lineCountAfterReinforce := countNonEmptyLines(t, factLogAbs)
+	if lineCountAfterReinforce != 2 {
+		t.Errorf("reinforcement must not append a JSONL line; got %d lines, want 2",
+			lineCountAfterReinforce)
+	}
+}
+
+// TestReinforcementHashInvariance asserts the two-hash contract: extracting
+// the same artifact twice produces IDENTICAL CanonicalHashFacts (because
+// reinforced_at is excluded from the hash input) and DIFFERENT CanonicalHashAll
+// (because reinforced_at advanced).
+func TestReinforcementHashInvariance(t *testing.T) {
+	h := newExtractHarness(t)
+	defer h.teardown()
+
+	sha := "reinfhsh"
+	h.provider.response = cannedResponse(sha)
+	path := h.writeArtifact(sha, "chat", "Sarah Chen was promoted to VP of Sales.\n")
+
+	ctx := context.Background()
+	if err := h.extractor.ExtractFromArtifact(ctx, path); err != nil {
+		t.Fatalf("first extract: %v", err)
+	}
+	h.worker.WaitForIdle()
+
+	hashFacts1, err := h.index.CanonicalHashFacts(ctx)
+	if err != nil {
+		t.Fatalf("CanonicalHashFacts 1: %v", err)
+	}
+	hashAll1, err := h.index.CanonicalHashAll(ctx)
+	if err != nil {
+		t.Fatalf("CanonicalHashAll 1: %v", err)
+	}
+
+	// Advance the extractor clock so reinforced_at is strictly later than the
+	// first pass. Without this, a sub-millisecond second pass could leave the
+	// timestamps identical and the test would be flaky.
+	later := time.Date(2026, 4, 23, 9, 0, 0, 0, time.UTC)
+	h.extractor.SetNow(func() time.Time { return later })
+
+	if err := h.extractor.ExtractFromArtifact(ctx, path); err != nil {
+		t.Fatalf("second extract: %v", err)
+	}
+	h.worker.WaitForIdle()
+
+	// Confirm reinforced_at was actually set — the invariance guarantees only
+	// apply when the second pass was reinforcement rather than a fresh insert.
+	wantID := ComputeFactID(sha, 0, "sarah-chen", "role_at", "company:acme-corp")
+	f, ok, err := h.index.GetFact(ctx, wantID)
+	if err != nil || !ok {
+		t.Fatalf("fact missing after reinforcement: ok=%v err=%v", ok, err)
+	}
+	if f.ReinforcedAt == nil {
+		t.Fatal("reinforced_at not set; harness precondition violated")
+	}
+
+	hashFacts2, err := h.index.CanonicalHashFacts(ctx)
+	if err != nil {
+		t.Fatalf("CanonicalHashFacts 2: %v", err)
+	}
+	hashAll2, err := h.index.CanonicalHashAll(ctx)
+	if err != nil {
+		t.Fatalf("CanonicalHashAll 2: %v", err)
+	}
+
+	if hashFacts1 != hashFacts2 {
+		t.Errorf("CanonicalHashFacts must be invariant across reinforcement: %s → %s",
+			hashFacts1, hashFacts2)
+	}
+	if hashAll1 == hashAll2 {
+		t.Errorf("CanonicalHashAll must advance when reinforced_at changes: stuck at %s",
+			hashAll1)
+	}
+}
+
+// TestExtractionBatchesFactsPerEntity asserts the extractor emits a single
+// commit per entity when multiple facts for that entity come from one
+// artifact. This caps worker-queue pressure (see the plan risk note).
+func TestExtractionBatchesFactsPerEntity(t *testing.T) {
+	h := newExtractHarness(t)
+	defer h.teardown()
+
+	sha := "batchabc"
+	payload := extractionOutput{
+		ArtifactSHA: sha,
+		Entities: []extractedEntity{
+			{
+				Kind:         "person",
+				ProposedSlug: "sarah-chen",
+				Signals:      extractedSignal{PersonName: "Sarah Chen"},
+				Confidence:   0.95,
+				Ghost:        true,
+			},
+		},
+		Facts: []extractedFact{
+			{
+				EntitySlug:     "sarah-chen",
+				Type:           "observation",
+				Triplet:        &Triplet{Subject: "sarah-chen", Predicate: "role_at", Object: "acme-corp"},
+				Text:           "Works at Acme.",
+				Confidence:     0.9,
+				SentenceOffset: 0,
+			},
+			{
+				EntitySlug:     "sarah-chen",
+				Type:           "observation",
+				Triplet:        &Triplet{Subject: "sarah-chen", Predicate: "based_in", Object: "sf"},
+				Text:           "Based in SF.",
+				Confidence:     0.9,
+				SentenceOffset: 24,
+			},
+			{
+				EntitySlug:     "sarah-chen",
+				Type:           "observation",
+				Triplet:        &Triplet{Subject: "sarah-chen", Predicate: "team", Object: "sales"},
+				Text:           "On the sales team.",
+				Confidence:     0.9,
+				SentenceOffset: 48,
+			},
+		},
+	}
+	b, _ := json.Marshal(payload)
+	h.provider.response = string(b)
+	path := h.writeArtifact(sha, "chat", "Three facts about Sarah.\n")
+
+	ctx := context.Background()
+	if err := h.extractor.ExtractFromArtifact(ctx, path); err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	h.worker.WaitForIdle()
+
+	factLogRel := factLogPath("person", "sarah-chen")
+	factLogAbs := filepath.Join(h.repo.Root(), filepath.FromSlash(factLogRel))
+	lines := countNonEmptyLines(t, factLogAbs)
+	if lines != 3 {
+		t.Fatalf("expected 3 JSONL lines (one per fact); got %d", lines)
+	}
+
+	// All three facts should live in a SINGLE commit — batch-per-entity.
+	commits := commitCountForPath(t, h.repo.Root(), factLogRel)
+	if commits != 1 {
+		t.Errorf("expected 1 commit for 3 same-entity facts (batched); got %d", commits)
+	}
+}
+
+// TestFactLogPath covers the helper that wires extraction to the markdown
+// layout (§3 Layer-2). Keep it tiny but explicit so a silent rename breaks
+// here rather than inside the reboot test.
+func TestFactLogPath(t *testing.T) {
+	cases := []struct{ kind, slug, want string }{
+		{"person", "sarah-jones", "wiki/facts/person/sarah-jones.jsonl"},
+		{"company", "acme-corp", "wiki/facts/company/acme-corp.jsonl"},
+		{"project", "q2-pilot", "wiki/facts/project/q2-pilot.jsonl"},
+	}
+	for _, tc := range cases {
+		if got := factLogPath(tc.kind, tc.slug); got != tc.want {
+			t.Errorf("factLogPath(%q, %q) = %q, want %q", tc.kind, tc.slug, got, tc.want)
+		}
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+func countNonEmptyLines(t *testing.T, path string) int {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	n := 0
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) != "" {
+			n++
+		}
+	}
+	return n
+}
+
+// commitCountForPath returns the number of commits that touched relPath.
+// Uses `git log --oneline -- <path>` so the test does not depend on any
+// internal helper.
+func commitCountForPath(t *testing.T, repoRoot, relPath string) int {
+	t.Helper()
+	cmd := exec.Command("git", "-C", repoRoot, "log", "--oneline", "--", relPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log %s: %v: %s", relPath, err, out)
+	}
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return 0
+	}
+	return strings.Count(trimmed, "\n") + 1
+}

--- a/internal/team/wiki_extractor_persist_dlq_test.go
+++ b/internal/team/wiki_extractor_persist_dlq_test.go
@@ -404,3 +404,82 @@ func TestReconcileFromMarkdownReadsFactLogJSONL(t *testing.T) {
 		t.Errorf("BM25 search missed the reconciled fact; got %+v", hits)
 	}
 }
+
+// TestReconcileFactLogPreservesInMemoryReinforcement is a regression guard
+// for the race that caused TestExtractIdempotentOnRepeat to flake on CI:
+// after the extractor appends a fact-log line, the worker fires a
+// post-commit reconcile on that JSONL path in a side goroutine. A second
+// extraction that only bumps in-memory ReinforcedAt (the §7.3 reinforcement
+// path) can land BEFORE the reconcile goroutine runs. Reconcile then reads
+// the JSONL (which never carries reinforced_at by design — it is excluded
+// from serialization so the append-only log stays immutable) and must NOT
+// clobber the in-memory ReinforcedAt back to nil.
+//
+// Breaking this invariant silently un-reinforces every fact any time the
+// index reconciles a fact-log path — the SymptomFAIL on CI was
+// "expected reinforced_at to be set after second extract" but the real
+// failure mode is any JSONL reconcile (boot, DLQ replay, external git sync)
+// erasing reinforcement.
+func TestReconcileFactLogPreservesInMemoryReinforcement(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Seed JSONL on disk WITHOUT reinforced_at — this mirrors how the
+	// extractor writes new facts: ReinforcedAt is nil on first emission and
+	// subsequent reinforcements are intentionally NOT appended.
+	fact := TypedFact{
+		ID:         "reinforce-preserve-1",
+		EntitySlug: "sarah-chen",
+		Kind:       "person",
+		Type:       "observation",
+		Triplet:    &Triplet{Subject: "sarah-chen", Predicate: "role_at", Object: "acme"},
+		Text:       "Sarah Chen is VP of Sales.",
+		Confidence: 0.9,
+		CreatedAt:  time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC),
+		CreatedBy:  ArchivistAuthor,
+	}
+	line, err := json.Marshal(fact)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	factLogRel := factLogPath("person", "sarah-chen")
+	factLogAbs := filepath.Join(root, filepath.FromSlash(factLogRel))
+	if err := os.MkdirAll(filepath.Dir(factLogAbs), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(factLogAbs, append(line, '\n'), 0o600); err != nil {
+		t.Fatalf("seed fact log: %v", err)
+	}
+
+	idx := NewWikiIndex(root)
+	defer idx.Close()
+
+	ctx := context.Background()
+
+	// Pre-load the fact into memory AS-IF SubmitFacts had just bumped
+	// reinforced_at — this is the state the extractor's §7.3 path leaves the
+	// store in after a second-run reinforcement.
+	reinforcedAt := time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC)
+	inMem := fact
+	inMem.ReinforcedAt = &reinforcedAt
+	if err := idx.store.UpsertFact(ctx, inMem); err != nil {
+		t.Fatalf("seed in-memory reinforced fact: %v", err)
+	}
+
+	// Now trigger the same reconcile path the post-commit side goroutine
+	// runs after an IsFactLogAppend commit.
+	if err := idx.ReconcilePath(ctx, factLogRel); err != nil {
+		t.Fatalf("ReconcilePath: %v", err)
+	}
+
+	got, ok, _ := idx.GetFact(ctx, fact.ID)
+	if !ok {
+		t.Fatal("fact missing after ReconcilePath")
+	}
+	if got.ReinforcedAt == nil {
+		t.Fatal("reconcile clobbered in-memory ReinforcedAt — §7.3 broken (JSONL must not un-reinforce memory)")
+	}
+	if !got.ReinforcedAt.Equal(reinforcedAt) {
+		t.Errorf("ReinforcedAt drift after reconcile: got %v, want %v", got.ReinforcedAt, reinforcedAt)
+	}
+}

--- a/internal/team/wiki_extractor_persist_dlq_test.go
+++ b/internal/team/wiki_extractor_persist_dlq_test.go
@@ -1,0 +1,406 @@
+package team
+
+// wiki_extractor_persist_dlq_test.go — coverage for the fact-log-persist
+// DLQ category and its dedicated replay path.
+//
+// The tests here target PR #254 review blockers:
+//   - Critical: ErrQueueSaturated on EnqueueFactLogAppend must NOT silently
+//     drop the JSONL line. The failure lands under DLQCategoryFactLogPersist
+//     and ReplayDLQ retries the APPEND (not full extraction), so the fact
+//     eventually reaches the on-disk substrate.
+//   - High: the DLQ entry carries the new category (not provider_timeout),
+//     so it lands in the right metrics bucket and backoff curve.
+//   - Strengthens §7.4: after replay, a fresh index + ReconcileFromMarkdown
+//     finds the fact — the substrate guarantee is closed even under queue
+//     saturation.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestExtractAppendSaturationLandsInFactLogPersistDLQ asserts that when
+// EnqueueFactLogAppend returns ErrQueueSaturated, the failure lands in the
+// DLQ under DLQCategoryFactLogPersist (not provider_timeout) with a payload
+// that carries enough state to reconstruct the append. §7.4 requires the
+// JSONL line to eventually reach disk.
+func TestExtractAppendSaturationLandsInFactLogPersistDLQ(t *testing.T) {
+	h := newExtractHarness(t)
+	defer h.teardown()
+
+	// Poison the append seam to simulate queue saturation for exactly one
+	// call. Production path uses worker.EnqueueFactLogAppend.
+	h.extractor.setAppendFactLog(func(context.Context, string, string, string, string) (string, int, error) {
+		return "", 0, ErrQueueSaturated
+	})
+
+	ctx := context.Background()
+	fact := TypedFact{
+		ID:         "sat-fact-id-01",
+		EntitySlug: "sarah-chen",
+		Kind:       "person",
+		Type:       "observation",
+		Triplet:    &Triplet{Subject: "sarah-chen", Predicate: "role_at", Object: "acme"},
+		Text:       "Synthetic fact for saturation test.",
+		CreatedAt:  time.Now().UTC(),
+		CreatedBy:  ArchivistAuthor,
+	}
+	h.extractor.persistFactLogs(ctx, "sat-artifact-sha", []TypedFact{fact})
+
+	// A DLQ entry under DLQCategoryFactLogPersist must exist.
+	ready, err := h.dlq.ReadyForReplay(ctx, time.Now().Add(10*time.Minute))
+	if err != nil {
+		t.Fatalf("ReadyForReplay: %v", err)
+	}
+	var matching *DLQEntry
+	for i := range ready {
+		if ready[i].ErrorCategory == DLQCategoryFactLogPersist {
+			matching = &ready[i]
+			break
+		}
+	}
+	if matching == nil {
+		t.Fatalf("expected a DLQCategoryFactLogPersist entry; got %+v", ready)
+	}
+	if matching.FactLogAppend == nil {
+		t.Fatal("DLQCategoryFactLogPersist entry missing FactLogAppend payload")
+	}
+	if matching.FactLogAppend.Slug != "sarah-chen" {
+		t.Errorf("payload slug = %q, want sarah-chen", matching.FactLogAppend.Slug)
+	}
+	if matching.FactLogAppend.Kind != "person" {
+		t.Errorf("payload kind = %q, want person", matching.FactLogAppend.Kind)
+	}
+	if matching.FactLogAppend.ArtifactSHA != "sat-artifact-sha" {
+		t.Errorf("payload artifact_sha = %q, want sat-artifact-sha", matching.FactLogAppend.ArtifactSHA)
+	}
+	if !strings.Contains(matching.FactLogAppend.JSONLLines, `"id":"sat-fact-id-01"`) {
+		t.Errorf("payload missing fact id line: %q", matching.FactLogAppend.JSONLLines)
+	}
+	// Explicit negative assertion: NOT provider_timeout. That is the old
+	// (wrong) category — using it would put these I/O/git/queue failures
+	// into the LLM-timeout metrics bucket with the LLM-timeout backoff.
+	if matching.ErrorCategory == DLQCategoryProviderTimeout {
+		t.Error("fact-log-persist failure must not use DLQCategoryProviderTimeout")
+	}
+	// The synthetic DLQ key must be the fact-log composite form so multiple
+	// per-entity append failures on one artifact do not clobber each other
+	// in readLatestStateLocked.
+	wantSHA := FactLogAppendSHA("person", "sarah-chen", "sat-artifact-sha")
+	if matching.ArtifactSHA != wantSHA {
+		t.Errorf("DLQ entry sha key = %q, want %q", matching.ArtifactSHA, wantSHA)
+	}
+}
+
+// TestReplayDLQRecoversFactLogAppend proves that ReplayDLQ on a
+// DLQCategoryFactLogPersist entry actually writes the missing JSONL line to
+// disk — closing the §7.4 substrate guarantee under queue saturation.
+//
+// After replay, a fresh index + ReconcileFromMarkdown finds the fact.
+func TestReplayDLQRecoversFactLogAppend(t *testing.T) {
+	h := newExtractHarness(t)
+	defer h.teardown()
+
+	ctx := context.Background()
+
+	// 1. First call saturates; subsequent calls go to the real worker.
+	var calls int32
+	h.extractor.setAppendFactLog(func(ctx context.Context, slug, path, content, commitMsg string) (string, int, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return "", 0, ErrQueueSaturated
+		}
+		return h.worker.EnqueueFactLogAppend(ctx, slug, path, content, commitMsg)
+	})
+
+	fact := TypedFact{
+		ID:         "recover-fact-01",
+		EntitySlug: "sarah-chen",
+		Kind:       "person",
+		Type:       "observation",
+		Triplet:    &Triplet{Subject: "sarah-chen", Predicate: "works_at", Object: "acme"},
+		Text:       "Sarah works at Acme (recovery test).",
+		CreatedAt:  time.Now().UTC(),
+		CreatedBy:  ArchivistAuthor,
+	}
+	h.extractor.persistFactLogs(ctx, "recover1", []TypedFact{fact})
+
+	// Fact log must NOT exist on disk yet — append was rejected.
+	factLogAbs := filepath.Join(h.repo.Root(),
+		filepath.FromSlash(factLogPath("person", "sarah-chen")))
+	if _, err := os.Stat(factLogAbs); !os.IsNotExist(err) {
+		t.Fatalf("fact log unexpectedly present pre-replay: %v", err)
+	}
+
+	// 2. ReplayDLQ must take the append path and write the line. Advance
+	// the extractor clock past the default backoff so the entry is eligible.
+	future := time.Now().Add(1 * time.Hour)
+	h.extractor.SetNow(func() time.Time { return future })
+
+	processed, retired, err := h.extractor.ReplayDLQ(ctx)
+	if err != nil {
+		t.Fatalf("ReplayDLQ: %v", err)
+	}
+	if processed == 0 {
+		t.Fatal("ReplayDLQ processed 0 entries; expected >=1")
+	}
+	if retired == 0 {
+		t.Fatal("ReplayDLQ retired 0 entries; expected >=1")
+	}
+	h.worker.WaitForIdle()
+
+	// 3. Fact log MUST now exist with the recovered line.
+	data, err := os.ReadFile(factLogAbs)
+	if err != nil {
+		t.Fatalf("fact log missing after replay: %v", err)
+	}
+	if !strings.Contains(string(data), `"id":"recover-fact-01"`) {
+		t.Fatalf("replayed fact-log does not contain the missing fact:\n%s", data)
+	}
+
+	// 4. Rebuild a fresh index from markdown — the fact must be searchable.
+	fresh := NewWikiIndex(h.repo.Root())
+	defer fresh.Close()
+	if err := fresh.ReconcileFromMarkdown(ctx); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if f, ok, _ := fresh.GetFact(ctx, "recover-fact-01"); !ok {
+		t.Fatal("recovered fact not present in rebuilt index (§7.4 violated)")
+	} else if f.Text == "" {
+		t.Error("recovered fact text missing after reconcile")
+	}
+}
+
+// TestReplayDLQFactLogAppendIsIdempotent asserts that a fact-log replay
+// which finds the line already on disk resolves cleanly without appending
+// a duplicate. Covers the case where the original append partially landed
+// (or a concurrent reinforcement path ran) before the DLQ entry's backoff
+// window expired.
+func TestReplayDLQFactLogAppendIsIdempotent(t *testing.T) {
+	h := newExtractHarness(t)
+	defer h.teardown()
+
+	ctx := context.Background()
+
+	// First call fails (simulated saturation); subsequent calls pass through.
+	var calls int32
+	h.extractor.setAppendFactLog(func(ctx context.Context, slug, path, content, commitMsg string) (string, int, error) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			return "", 0, ErrQueueSaturated
+		}
+		return h.worker.EnqueueFactLogAppend(ctx, slug, path, content, commitMsg)
+	})
+
+	fact := TypedFact{
+		ID:         "idem-fact-01",
+		EntitySlug: "sarah-chen",
+		Kind:       "person",
+		Type:       "observation",
+		Triplet:    &Triplet{Subject: "sarah-chen", Predicate: "prefers", Object: "async"},
+		Text:       "Sarah prefers async (idempotency test).",
+		CreatedAt:  time.Now().UTC(),
+		CreatedBy:  ArchivistAuthor,
+	}
+	h.extractor.persistFactLogs(ctx, "idem1", []TypedFact{fact})
+
+	// Pre-write the same fact line to simulate "prior append actually landed
+	// on disk but the failure signal was captured first" — the DLQ row is
+	// queued, so replay must be idempotent.
+	line, _ := json.Marshal(fact)
+	if _, _, err := h.worker.EnqueueFactLogAppend(
+		ctx, ArchivistAuthor,
+		factLogPath("person", "sarah-chen"),
+		string(line)+"\n",
+		"seed: pre-write the fact before replay",
+	); err != nil {
+		t.Fatalf("seed append: %v", err)
+	}
+	h.worker.WaitForIdle()
+
+	factLogAbs := filepath.Join(h.repo.Root(),
+		filepath.FromSlash(factLogPath("person", "sarah-chen")))
+	pre := countNonEmptyLines(t, factLogAbs)
+
+	// Replay. Same fact_id is present — replay should resolve as a no-op.
+	future := time.Now().Add(1 * time.Hour)
+	h.extractor.SetNow(func() time.Time { return future })
+	if _, _, err := h.extractor.ReplayDLQ(ctx); err != nil {
+		t.Fatalf("ReplayDLQ: %v", err)
+	}
+	h.worker.WaitForIdle()
+
+	post := countNonEmptyLines(t, factLogAbs)
+	if post != pre {
+		t.Errorf("replay must be idempotent: lines pre=%d post=%d", pre, post)
+	}
+}
+
+// TestExtractAppendSaturationDistinctEntitiesDoNotCollide asserts that the
+// DLQ key for fact-log-persist failures includes (kind, slug) so two
+// concurrent append failures from the SAME artifact (but different entities)
+// both survive readLatestStateLocked's last-write-wins keying.
+func TestExtractAppendSaturationDistinctEntitiesDoNotCollide(t *testing.T) {
+	h := newExtractHarness(t)
+	defer h.teardown()
+
+	// Every append fails — both entities need their own DLQ row.
+	h.extractor.setAppendFactLog(func(context.Context, string, string, string, string) (string, int, error) {
+		return "", 0, ErrQueueSaturated
+	})
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	facts := []TypedFact{
+		{
+			ID:         "collide-a",
+			EntitySlug: "sarah-chen",
+			Kind:       "person",
+			Type:       "observation",
+			Triplet:    &Triplet{Subject: "sarah-chen", Predicate: "role_at", Object: "acme"},
+			Text:       "Sarah at Acme.",
+			CreatedAt:  now,
+			CreatedBy:  ArchivistAuthor,
+		},
+		{
+			ID:         "collide-b",
+			EntitySlug: "acme-corp",
+			Kind:       "company",
+			Type:       "observation",
+			Triplet:    &Triplet{Subject: "acme-corp", Predicate: "founded", Object: "2010"},
+			Text:       "Acme founded 2010.",
+			CreatedAt:  now,
+			CreatedBy:  ArchivistAuthor,
+		},
+	}
+	h.extractor.persistFactLogs(ctx, "multi-ent", facts)
+
+	ready, err := h.dlq.ReadyForReplay(ctx, time.Now().Add(10*time.Minute))
+	if err != nil {
+		t.Fatalf("ReadyForReplay: %v", err)
+	}
+	count := 0
+	for _, e := range ready {
+		if e.ErrorCategory == DLQCategoryFactLogPersist {
+			count++
+		}
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 fact-log-persist DLQ entries (one per entity); got %d: %+v", count, ready)
+	}
+}
+
+// TestSerializeFactsAsJSONLAllGoodLines asserts every well-formed fact
+// lands as a line. The partial-recovery branch is exercised via log-only
+// defensive path (TypedFact has no unmarshalable fields under normal
+// operation), so the unit assertion is that well-formed batches are never
+// short-circuited.
+func TestSerializeFactsAsJSONLAllGoodLines(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	facts := []TypedFact{
+		{ID: "a", EntitySlug: "x", Text: "one", CreatedAt: now, CreatedBy: ArchivistAuthor},
+		{ID: "b", EntitySlug: "x", Text: "two", CreatedAt: now, CreatedBy: ArchivistAuthor},
+		{ID: "c", EntitySlug: "x", Text: "three", CreatedAt: now, CreatedBy: ArchivistAuthor},
+	}
+	body, err := serializeFactsAsJSONL(facts)
+	if err != nil {
+		t.Fatalf("serializeFactsAsJSONL: %v", err)
+	}
+	lines := 0
+	for _, line := range strings.Split(body, "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines++
+		}
+	}
+	if lines != 3 {
+		t.Errorf("expected 3 lines in batch body; got %d", lines)
+	}
+	for _, want := range []string{`"id":"a"`, `"id":"b"`, `"id":"c"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %s:\n%s", want, body)
+		}
+	}
+}
+
+// TestReconcileFromMarkdownReadsFactLogJSONL proves the §7.4 rebuild path
+// literally consumes wiki/facts/**/*.jsonl. Pre-condition: fact log exists
+// on disk with a single TypedFact line. Post-condition: a brand-new
+// WikiIndex (no in-memory state at all) exposes that fact after
+// ReconcileFromMarkdown.
+//
+// This is the §7.4 contract test the PR reviewer asked for: the reboot
+// test is only meaningful if reconcile actually walks the fact log files.
+func TestReconcileFromMarkdownReadsFactLogJSONL(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+
+	// Seed the fact log by hand — do NOT touch any worker / index path. The
+	// test has to prove the rebuild reads markdown, not that extraction
+	// wrote something into memory.
+	fact := TypedFact{
+		ID:         "reconcile-proof-1",
+		EntitySlug: "sarah-chen",
+		Kind:       "person",
+		Type:       "observation",
+		Triplet:    &Triplet{Subject: "sarah-chen", Predicate: "role_at", Object: "acme"},
+		Text:       "Sarah Chen is VP of Sales.",
+		Confidence: 0.92,
+		CreatedAt:  time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC),
+		CreatedBy:  ArchivistAuthor,
+	}
+	line, err := json.Marshal(fact)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	factLogRel := factLogPath("person", "sarah-chen")
+	factLogAbs := filepath.Join(root, filepath.FromSlash(factLogRel))
+	if err := os.MkdirAll(filepath.Dir(factLogAbs), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(factLogAbs, append(line, '\n'), 0o600); err != nil {
+		t.Fatalf("seed fact log: %v", err)
+	}
+
+	// Fresh index, no prior state whatsoever.
+	idx := NewWikiIndex(root)
+	defer idx.Close()
+
+	// Pre-assert: index is empty.
+	if _, ok, _ := idx.GetFact(context.Background(), fact.ID); ok {
+		t.Fatal("precondition: fact should not be in a fresh index")
+	}
+
+	// Rebuild — this is the §7.4 boot-reconcile step.
+	if err := idx.ReconcileFromMarkdown(context.Background()); err != nil {
+		t.Fatalf("ReconcileFromMarkdown: %v", err)
+	}
+
+	// Post-assert: the fact is findable by ID AND by BM25 search.
+	got, ok, _ := idx.GetFact(context.Background(), fact.ID)
+	if !ok {
+		t.Fatal("fact missing after ReconcileFromMarkdown — §7.4 broken: reconcile does not read the fact log")
+	}
+	if got.Text != fact.Text {
+		t.Errorf("reconciled fact text drift: got %q, want %q", got.Text, fact.Text)
+	}
+
+	hits, err := idx.Search(context.Background(), "VP of Sales", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	found := false
+	for _, hit := range hits {
+		if hit.FactID == fact.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("BM25 search missed the reconciled fact; got %+v", hits)
+	}
+}

--- a/internal/team/wiki_index.go
+++ b/internal/team/wiki_index.go
@@ -518,7 +518,7 @@ func (w *WikiIndex) CanonicalHashAll(ctx context.Context) (string, error) {
 // --- path routing helpers -------------------------------------------------
 
 var (
-	factLogNewSchema = regexp.MustCompile(`^wiki/facts/[^/]+/[^/]+\.jsonl$`)
+	factLogNewSchema = regexp.MustCompile(`^wiki/facts/[a-z][a-z0-9-]*/[a-z0-9][a-z0-9-]*\.jsonl$`)
 	factLogLegacyV12 = regexp.MustCompile(`^team/entities/[a-z]+-[a-z0-9][a-z0-9-]*\.facts\.jsonl$`)
 	entityBriefPath  = regexp.MustCompile(`^team/[^/]+/[^/]+\.md$`)
 	lintReportPath   = regexp.MustCompile(`^wiki/\.lint/report-\d{4}-\d{2}-\d{2}\.md$`)

--- a/internal/team/wiki_index.go
+++ b/internal/team/wiki_index.go
@@ -161,8 +161,17 @@ type FactStore interface {
 	// typed-predicate graph walk and counterfactual rewrite (Slice 2 Thread A).
 	ListFactsByTriplet(ctx context.Context, subject, predicate, objectPrefix string) ([]TypedFact, error)
 
-	CanonicalHashFacts(ctx context.Context) (string, error) // §7.4 rebuild check
-	CanonicalHashAll(ctx context.Context) (string, error)   // §7.4 composite: facts + entities + edges + redirects
+	// CanonicalHashFacts returns a stable hash over all indexed facts for
+	// the §7.4 rebuild contract. ReinforcedAt is EXCLUDED from the hash
+	// input so two extraction runs on the same artifact (the second one
+	// purely bumps reinforced_at) produce identical hashes. Use
+	// CanonicalHashAll for end-to-end drift detection where ReinforcedAt
+	// participates.
+	CanonicalHashFacts(ctx context.Context) (string, error)
+	// CanonicalHashAll is the composite §7.4 hash over facts + entities +
+	// edges + redirects. ReinforcedAt IS included here so the hash advances
+	// whenever any layer (including reinforcement) changes.
+	CanonicalHashAll(ctx context.Context) (string, error)
 	Close() error
 }
 
@@ -1004,7 +1013,12 @@ func (s *inMemoryFactStore) CanonicalHashFacts(_ context.Context) (string, error
 	sort.Strings(ids)
 	h := sha256.New()
 	for _, id := range ids {
-		b, err := json.Marshal(s.facts[id])
+		// ReinforcedAt is excluded from the facts hash so repeated extraction
+		// runs that only bump reinforced_at do not drift the hash. End-to-end
+		// drift detection lives in CanonicalHashAll.
+		clone := s.facts[id]
+		clone.ReinforcedAt = nil
+		b, err := json.Marshal(clone)
 		if err != nil {
 			return "", err
 		}

--- a/internal/team/wiki_index.go
+++ b/internal/team/wiki_index.go
@@ -566,6 +566,19 @@ func (w *WikiIndex) reconcileFactLog(ctx context.Context, abs, relPath string) e
 			continue // legacy rows without IDs are skipped; a later synth will re-emit them with IDs
 		}
 		_ = i
+		// Preserve the in-memory ReinforcedAt marker. It is a derived runtime
+		// signal — NOT written to the JSONL substrate by design (§7.3
+		// reinforcement bumps only the in-memory row; the original JSONL line
+		// still represents the authoritative source-of-truth for the fact's
+		// content). Reconcile is the rebuild path — it must carry forward the
+		// reinforcement bump a parallel SubmitFacts may have landed AFTER the
+		// JSONL line was written. Clobbering it would silently un-reinforce
+		// facts on every post-append reconcile side goroutine, breaking §7.3.
+		if f.ReinforcedAt == nil {
+			if existing, ok, _ := w.store.GetFact(ctx, f.ID); ok && existing.ReinforcedAt != nil {
+				f.ReinforcedAt = existing.ReinforcedAt
+			}
+		}
 		if err := w.store.UpsertFact(ctx, f); err != nil {
 			return fmt.Errorf("upsert fact %s: %w", f.ID, err)
 		}

--- a/internal/team/wiki_index_sqlite.go
+++ b/internal/team/wiki_index_sqlite.go
@@ -410,7 +410,10 @@ func (s *SQLiteFactStore) ResolveRedirect(ctx context.Context, slug string) (str
 
 // CanonicalHashFacts implements §7.4: sha256 over all fact rows sorted by ID.
 // Serialisation is identical to inMemoryFactStore so the contract test passes
-// against both backends from the same markdown corpus.
+// against both backends from the same markdown corpus. ReinforcedAt is
+// EXCLUDED from the hash input so two extraction runs on the same artifact
+// (the second one purely bumps reinforced_at) produce identical hashes.
+// End-to-end drift including reinforcement lives in CanonicalHashAll.
 func (s *SQLiteFactStore) CanonicalHashFacts(ctx context.Context) (string, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT id FROM facts ORDER BY id ASC`)
@@ -447,6 +450,7 @@ func (s *SQLiteFactStore) CanonicalHashFacts(ctx context.Context) (string, error
 		if err != nil {
 			return "", fmt.Errorf("hash scan %s: %w", id, err)
 		}
+		f.ReinforcedAt = nil
 		b, err := json.Marshal(f)
 		if err != nil {
 			return "", err

--- a/internal/team/wiki_worker.go
+++ b/internal/team/wiki_worker.go
@@ -111,6 +111,11 @@ type wikiWriteRequest struct {
 	// wiki/facts/**/*.jsonl or team/entities/*.facts.jsonl (used by lint
 	// ResolveContradiction to update supersedes/valid_until/contradicts_with).
 	IsFactLog bool
+	// IsFactLogAppend routes to Repo.AppendFactLog — append-only writes to
+	// wiki/facts/**/*.jsonl. Used by the extractor to close the substrate
+	// guarantee (§7.4): every successfully-submitted fact lands in markdown
+	// so a wipe + reconcile rebuilds to a logically-identical index.
+	IsFactLogAppend bool
 	// IsArtifact routes the request to Repo.CommitArtifact — writes the raw
 	// source artifact under wiki/artifacts/{kind}/{sha}.md. Never regens the
 	// catalog; triggers the extractor hook on success.
@@ -343,6 +348,8 @@ func (w *WikiWorker) process(ctx context.Context, req wikiWriteRequest) {
 		sha, n, err = w.repo.CommitLintReport(writeCtx, req.Slug, req.Path, req.Content, req.CommitMsg)
 	} else if req.IsFactLog {
 		sha, n, err = w.repo.CommitFactLog(writeCtx, req.Slug, req.Path, req.Content, req.CommitMsg)
+	} else if req.IsFactLogAppend {
+		sha, n, err = w.repo.AppendFactLog(writeCtx, req.Slug, req.Path, req.Content, req.CommitMsg)
 	} else if req.IsNotebook {
 		// Notebook writes do NOT regen the team wiki index. Commit target is
 		// agents/{slug}/notebook/... — scoped to the author.
@@ -1201,6 +1208,8 @@ func (w *WikiWorker) Index() *WikiIndex {
 // EnqueueFactLog submits a fact-log mutation to the shared wiki queue.
 // The path must be wiki/facts/**/*.jsonl or team/entities/*.facts.jsonl.
 // Used by lint ResolveContradiction to update supersedes/valid_until/contradicts_with.
+// `content` is the FULL replacement body for the file (not a diff).
+// Prefer EnqueueFactLogAppend for the extractor append path.
 func (w *WikiWorker) EnqueueFactLog(ctx context.Context, slug, path, content, commitMsg string) (string, int, error) {
 	if !w.running.Load() {
 		return "", 0, ErrWorkerStopped
@@ -1226,5 +1235,42 @@ func (w *WikiWorker) EnqueueFactLog(ctx context.Context, slug, path, content, co
 		return result.SHA, result.BytesWritten, result.Err
 	case <-waitCtx.Done():
 		return "", 0, fmt.Errorf("wiki: fact log write timed out after %s", wikiWriteTimeout)
+	}
+}
+
+// EnqueueFactLogAppend appends JSONL content to a fact-log file via the
+// shared single-writer queue. `content` is only the new lines — the worker
+// reads the existing file, concatenates, and commits. Used by the extractor
+// to close the §7.4 substrate guarantee: every successfully-submitted fact
+// lands in markdown so a wipe + reconcile rebuilds to a logically-identical
+// index.
+//
+// The read-modify-write happens inside the worker's repo mutex (AppendFactLog),
+// so callers MUST NOT bypass the queue — that would race two appenders.
+func (w *WikiWorker) EnqueueFactLogAppend(ctx context.Context, slug, path, content, commitMsg string) (string, int, error) {
+	if !w.running.Load() {
+		return "", 0, ErrWorkerStopped
+	}
+	req := wikiWriteRequest{
+		Slug:            slug,
+		Path:            path,
+		Content:         content,
+		Mode:            "append",
+		CommitMsg:       commitMsg,
+		IsFactLogAppend: true,
+		ReplyCh:         make(chan wikiWriteResult, 1),
+	}
+	select {
+	case w.requests <- req:
+	default:
+		return "", 0, ErrQueueSaturated
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, wikiWriteTimeout)
+	defer cancel()
+	select {
+	case result := <-req.ReplyCh:
+		return result.SHA, result.BytesWritten, result.Err
+	case <-waitCtx.Done():
+		return "", 0, fmt.Errorf("wiki: fact log append timed out after %s", wikiWriteTimeout)
 	}
 }


### PR DESCRIPTION
## Summary

- Closes the substrate-rebuild leak on the extraction path: before this PR, `rm -rf .wuphf/index/` + `ReconcileFromMarkdown` re-found zero extracted facts because the extractor wrote the index but not the markdown.
- Extraction now commits an append-only JSONL fact log (`wiki/facts/{kind}/{slug}.jsonl`) under the `archivist` git identity, batched per-entity, routed through `WikiWorker` so the single-writer invariant stays intact.
- `ReinforcedAt` excluded from `CanonicalHashFacts` (same-content hashes match across re-extractions) but included in `CanonicalHashAll` (end-to-end drift detection). §7.4 of `docs/specs/WIKI-SCHEMA.md` now documents the asymmetry.

## Files touched

- `internal/team/entity_commit.go` — new `Repo.AppendFactLog` that reads, appends, and commits a fact-log file inside the repo mutex.
- `internal/team/wiki_worker.go` — new `IsFactLogAppend` request flag + `EnqueueFactLogAppend` public method routing through the existing single-writer queue.
- `internal/team/wiki_extractor.go` — `factLogPath(kind, slug)` helper + `persistFactLogs` batching new (non-reinforced) facts per-entity and calling `EnqueueFactLogAppend` after `SubmitFacts` succeeds. Append failures go to DLQ without double-failing the extractor.
- `internal/team/wiki_index.go` + `internal/team/wiki_index_sqlite.go` — `CanonicalHashFacts` clones each fact with `ReinforcedAt=nil` before hashing, on both backends.
- `docs/specs/WIKI-SCHEMA.md` §7.4 — documents the extractor closure + hash asymmetry.
- `internal/team/wiki_extractor_closure_test.go` — `TestExtractionSurvivesReboot`, `TestExtractionAppendsJSONL`, `TestReinforcementHashInvariance`.

## Out of scope (Slice 3)

- **Ghost-entity briefs.** The extractor mints `IndexEntity` rows in-memory but doesn't commit a `team/{kind}/{slug}.md` brief — brief authorship belongs to `EntitySynthesizer`. `CanonicalHashAll` doesn't fully round-trip through extraction alone; entity briefs enter the hash only after synthesis runs. Documented in the reboot test's comment. Slice 3 should unify the two paths so `CanonicalHashAll` round-trips end-to-end.

## Verification

- `golangci-lint run --timeout=5m ./...` → 0 issues.
- `go test ./internal/team/ -count=1 -timeout 120s` passes (one pre-existing flake `TestWikiIndex_ReconcileMutexNarrow` — 50ms timing assertion under full-suite load, passes in isolation, unrelated to Thread B).
- Thread B tests at `-count=10` deterministic green.

## Test plan

- [ ] `go test ./internal/team/ -run \"TestExtractionSurvivesReboot|TestExtractionAppendsJSONL|TestReinforcementHashInvariance\"` passes
- [ ] `go test ./internal/team/ -run TestExtractionSurvivesReboot -count=10` passes deterministically
- [ ] `golangci-lint run --timeout=5m ./...` → 0 issues
- [ ] On a fresh broker: extract 5 facts, check `wiki/facts/people/<slug>.jsonl` has 5 lines, `git log --author=archivist` shows 1 commit per entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)