### PR TITLE
ci(lint): add four zero-finding linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,10 +14,17 @@ linters:
     - staticcheck
     - misspell
     - unconvert
+    - asasalint
+    - durationcheck
+    - nakedret
+    - nolintlint
   settings:
     errcheck:
       exclude-functions:
         - (io.Closer).Close
+    nolintlint:
+      require-explanation: true
+      require-specific: true
     staticcheck:
       # Disable the QF* quickfix suggestions (pure style hints) and the
       # ST1000/ST1003/ST1021 naming/comment rules (pedantic, massive scope).

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -2217,7 +2217,7 @@ func (b *Broker) webUIProxyHandler(brokerURL, stripPrefix string) http.Handler {
 			for {
 				n, readErr := resp.Body.Read(buf)
 				if n > 0 {
-					w.Write(buf[:n]) //nolint:errcheck
+					w.Write(buf[:n]) //nolint:errcheck // SSE proxy: client disconnects surface via the next Read in this loop.
 					if canFlush {
 						flusher.Flush()
 					}


### PR DESCRIPTION
## Summary

Phase 2 of the code-quality roadmap. Ratchets current cleanliness forward by enabling four linters that report zero findings on main after the one fix below:

- `nolintlint` — every `//nolint` directive must be specific (named rule) and explain itself.
- `nakedret` — catches naked returns in long functions.
- `durationcheck` — catches `time.Duration` arithmetic mistakes (e.g. multiplying two durations).
- `asasalint` — flags passing `[]any` to a variadic-any parameter.

### One pre-existing finding fixed inline

`nolintlint` flagged a single existing suppression: `internal/team/broker.go:2220` — `w.Write(buf[:n]) //nolint:errcheck` in the SSE proxy loop. Added an inline explanation: the client-disconnect case is already handled because the next `resp.Body.Read` in the same loop surfaces the broken pipe and breaks out. No behavioral change.

## Why not funlen / gocognit / cyclop / unused / unparam?

Those were proposed in the plan but deferred:

- `funlen`, `gocognit`, `cyclop` — 33/50/50 existing violations at reasonable thresholds. Most live in the three god-files (`internal/team/broker.go`, `cmd/wuphf/channel.go`, `internal/team/launcher.go`) targeted by the decomposition followups. Enabling these before decomposition would require scoped exclusions that we'd then have to unwind.
- `unused` (50), `unparam` (64) — real findings, but batch-cleanup deserves its own review rather than piggy-backing on a config PR.
- `gosec` (196) — mostly G204 (variable `exec.Command`) and G301 (dir perms). Need per-rule triage before enabling.

Tracked as followups; will land alongside / after the decomposition phases.

## Note

Supersedes #256, which was based on a non-`main` lineage (`wiki` init branch) and would have deleted 988 files. This PR is cut fresh off `main`.

## Test plan

- [ ] CI `lint` job (golangci-lint-action) reports 0 issues.
- [ ] CI `test` / `build` / `web` jobs unchanged, still green.