### PR TITLE
[codex] fix workspace shred fresh start

### DIFF
--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -51,10 +51,11 @@ func printSubcommandHelp(sub string) {
 		fmt.Fprintln(os.Stderr, "wuphf shred — burn the whole workspace down")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Stops the running session, clears broker state, and deletes the team")
-		fmt.Fprintln(os.Stderr, "roster, company identity, office task receipts, and saved workflows.")
+		fmt.Fprintln(os.Stderr, "roster, company identity, office task receipts, saved workflows, logs,")
+		fmt.Fprintln(os.Stderr, "sessions, provider state, calendar, and local wiki memory.")
 		fmt.Fprintln(os.Stderr, "Next launch reopens onboarding.")
 		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "Preserved: logs, sessions, task worktrees, LLM caches, config.json.")
+		fmt.Fprintln(os.Stderr, "Preserved: task worktrees, OpenClaw device identity, config.json.")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Usage:")
 		fmt.Fprintln(os.Stderr, "  wuphf shred           Prompts before wiping")
@@ -492,9 +493,10 @@ func isPiped() bool {
 const shredSummary = `This will:
   • Stop the running WUPHF session
   • Delete your team, company identity, office task receipts, workflows
+  • Delete logs, sessions, provider state, calendar, and local wiki memory
   • Wipe broker runtime state
   • Reopen onboarding on next launch
-Preserved: logs, sessions, task worktrees, LLM caches, config.json.`
+Preserved: task worktrees, OpenClaw device identity, config.json.`
 
 // confirmDestructive gates a destructive subcommand behind a y/N prompt.
 // A "-y" / "--yes" in rest skips the prompt — useful for scripted teardown.

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -514,6 +514,8 @@ type Broker struct {
 	// produce a truncated/overlaid file.
 	configMu           sync.Mutex
 	server             *http.Server
+	shutdownOnce       sync.Once
+	shutdownCh         chan struct{}
 	token              string          // shared secret for authenticating requests
 	addr               string          // actual listen address (useful when port=0)
 	webUIOrigins       []string        // allowed CORS origins for web UI (set by ServeWebUI)
@@ -888,6 +890,7 @@ func NewBroker() *Broker {
 	b := &Broker{
 		channelStore:        channel.NewStore(),
 		token:               generateToken(),
+		shutdownCh:          make(chan struct{}),
 		messageSubscribers:  make(map[int]chan channelMessage),
 		actionSubscribers:   make(map[int]chan officeActionLog),
 		activity:            make(map[string]agentActivitySnapshot),
@@ -1361,10 +1364,16 @@ func (b *Broker) StartOnPort(port int) error {
 	// completeFn posts the first task as a human message and seeds the team.
 	onboarding.RegisterRoutes(mux, b.onboardingCompleteFn, b.packSlug, b.requireAuth)
 	// Workspace wipes: POST /workspace/reset (narrow) and /workspace/shred (full).
-	// These are disk-only; the caller reloads or re-launches to rebuild state.
+	// Shred requests launcher shutdown after the response so live in-memory
+	// broker state cannot write stale messages back onto disk.
 	// Auth-gated via requireAuth because shred permanently deletes state and
 	// must not be reachable without the broker token.
-	workspace.RegisterRoutes(mux, b.requireAuth)
+	workspace.RegisterRoutesWithOptions(mux, workspace.RouteOptions{
+		AuthMiddleware: b.requireAuth,
+		AfterShred: func(workspace.Result) {
+			b.requestShutdown()
+		},
+	})
 
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	ln, err := net.Listen("tcp", addr)
@@ -1415,6 +1424,26 @@ func (b *Broker) Stop() {
 	if pamDisp != nil {
 		pamDisp.Stop()
 	}
+}
+
+// ShutdownRequested is closed when a destructive operation needs the launcher
+// process to stop after the HTTP response has reached the client.
+func (b *Broker) ShutdownRequested() <-chan struct{} {
+	if b.shutdownCh == nil {
+		ch := make(chan struct{})
+		close(ch)
+		return ch
+	}
+	return b.shutdownCh
+}
+
+func (b *Broker) requestShutdown() {
+	if b == nil || b.shutdownCh == nil {
+		return
+	}
+	b.shutdownOnce.Do(func() {
+		close(b.shutdownCh)
+	})
 }
 
 func (b *Broker) rateLimitMiddleware(next http.Handler) http.Handler {

--- a/internal/team/broker_web_test.go
+++ b/internal/team/broker_web_test.go
@@ -4,8 +4,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestWebUIProxyHandlerForwardsOnboardingRoutes(t *testing.T) {
@@ -42,5 +45,49 @@ func TestWebUIProxyHandlerForwardsOnboardingRoutes(t *testing.T) {
 	}
 	if body := strings.TrimSpace(rec.Body.String()); body != `{"ok":true}` {
 		t.Fatalf("unexpected proxied body %q", body)
+	}
+}
+
+func TestWorkspaceShredRouteRequestsBrokerShutdown(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+
+	logPath := filepath.Join(home, ".wuphf", "logs", "channel-stderr.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath, []byte("old run"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	req, err := http.NewRequest(http.MethodPost, "http://"+b.Addr()+"/workspace/shred", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post shred: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("expected shred to remove logs, stat err=%v", err)
+	}
+
+	select {
+	case <-b.ShutdownRequested():
+	case <-time.After(time.Second):
+		t.Fatal("expected shred route to request broker shutdown")
 	}
 }

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -37,6 +37,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/operations"
 	"github.com/nex-crm/wuphf/internal/provider"
 	"github.com/nex-crm/wuphf/internal/setup"
+	"github.com/nex-crm/wuphf/internal/workspace"
 )
 
 const (
@@ -4708,7 +4709,23 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		openBrowser(webURL)
 	}
 
-	select {}
+	select {
+	case <-l.broker.ShutdownRequested():
+		fmt.Println()
+		fmt.Println("  Workspace shredded. Stopping WUPHF; relaunch to start onboarding.")
+		fmt.Println()
+		if l.headlessCancel != nil {
+			l.headlessCancel()
+		}
+		// Give the web proxy a moment to finish copying the successful shred
+		// response before the broker listener and process go away.
+		time.Sleep(300 * time.Millisecond)
+		if err := l.Kill(); err != nil {
+			return err
+		}
+		_, _ = workspace.Shred()
+		return nil
+	}
 }
 
 func openBrowser(url string) {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -4709,23 +4709,21 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		openBrowser(webURL)
 	}
 
-	select {
-	case <-l.broker.ShutdownRequested():
-		fmt.Println()
-		fmt.Println("  Workspace shredded. Stopping WUPHF; relaunch to start onboarding.")
-		fmt.Println()
-		if l.headlessCancel != nil {
-			l.headlessCancel()
-		}
-		// Give the web proxy a moment to finish copying the successful shred
-		// response before the broker listener and process go away.
-		time.Sleep(300 * time.Millisecond)
-		if err := l.Kill(); err != nil {
-			return err
-		}
-		_, _ = workspace.Shred()
-		return nil
+	<-l.broker.ShutdownRequested()
+	fmt.Println()
+	fmt.Println("  Workspace shredded. Stopping WUPHF; relaunch to start onboarding.")
+	fmt.Println()
+	if l.headlessCancel != nil {
+		l.headlessCancel()
 	}
+	// Give the web proxy a moment to finish copying the successful shred
+	// response before the broker listener and process go away.
+	time.Sleep(300 * time.Millisecond)
+	if err := l.Kill(); err != nil {
+		return err
+	}
+	_, _ = workspace.Shred()
+	return nil
 }
 
 func openBrowser(url string) {

--- a/internal/workspace/handlers.go
+++ b/internal/workspace/handlers.go
@@ -5,25 +5,40 @@ import (
 	"net/http"
 )
 
+// RouteOptions controls optional side effects around workspace wipe routes.
+type RouteOptions struct {
+	AuthMiddleware func(http.HandlerFunc) http.HandlerFunc
+	AfterShred     func(Result)
+}
+
 // RegisterRoutes attaches the two workspace wipe endpoints to mux.
 //
 //	POST /workspace/reset  — ClearRuntime (narrow: broker state only)
 //	POST /workspace/shred  — Shred (full wipe, reopens onboarding)
 //
-// Both endpoints only touch disk. They do NOT kill the running broker process,
-// so callers must surface the "restart_required" hint — the web UI reloads
-// the tab, the TUI quits the session, the CLI is already the restart path.
+// By default both endpoints only touch disk. RegisterRoutesWithOptions can add
+// process-level side effects after a successful wipe response; the web broker
+// uses that to stop itself after shred so live memory cannot repersist.
 //
 // authMiddleware wraps each handler. Pass the broker's requireAuth so local
 // scripts cannot POST without the broker token — these operations are strictly
 // more destructive than /config or /company, which are already auth-gated. Pass
 // a nil middleware only in tests — RegisterRoutes substitutes a passthrough.
 func RegisterRoutes(mux *http.ServeMux, authMiddleware func(http.HandlerFunc) http.HandlerFunc) {
+	RegisterRoutesWithOptions(mux, RouteOptions{AuthMiddleware: authMiddleware})
+}
+
+// RegisterRoutesWithOptions attaches the workspace wipe endpoints and runs any
+// configured callbacks only after a successful wipe response has been written.
+func RegisterRoutesWithOptions(mux *http.ServeMux, opts RouteOptions) {
+	authMiddleware := opts.AuthMiddleware
 	if authMiddleware == nil {
 		authMiddleware = func(h http.HandlerFunc) http.HandlerFunc { return h }
 	}
 	mux.HandleFunc("/workspace/reset", authMiddleware(handleReset))
-	mux.HandleFunc("/workspace/shred", authMiddleware(handleShred))
+	mux.HandleFunc("/workspace/shred", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		handleShredWithOptions(w, r, opts)
+	}))
 }
 
 func handleReset(w http.ResponseWriter, r *http.Request) {
@@ -36,12 +51,23 @@ func handleReset(w http.ResponseWriter, r *http.Request) {
 }
 
 func handleShred(w http.ResponseWriter, r *http.Request) {
+	handleShredWithOptions(w, r, RouteOptions{})
+}
+
+func handleShredWithOptions(w http.ResponseWriter, r *http.Request, opts RouteOptions) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	res, err := Shred()
 	writeResult(w, res, err, "/")
+	if err != nil || opts.AfterShred == nil {
+		return
+	}
+	if flusher, ok := w.(http.Flusher); ok {
+		flusher.Flush()
+	}
+	go opts.AfterShred(res)
 }
 
 func writeResult(w http.ResponseWriter, res Result, err error, redirect string) {

--- a/internal/workspace/handlers_test.go
+++ b/internal/workspace/handlers_test.go
@@ -94,8 +94,8 @@ func TestShredHandlerWipesWorkspace(t *testing.T) {
 	for _, label := range []string{"onboarded", "company", "brokerState", "officeTasks", "workflow"} {
 		assertGone(t, label, paths[label])
 	}
-	// History preserved even when we can't assert every preserved path here.
-	assertStays(t, "session", paths["session"])
+	// Runtime history is wiped, but in-flight task worktrees remain on disk.
+	assertGone(t, "session", paths["session"])
 	assertStays(t, "worktree", paths["worktree"])
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,18 +1,17 @@
 // Package workspace wipes WUPHF's on-disk state for two distinct blast radii:
 //
-//   - Reset: narrow. Clears broker runtime state and task worktrees so a stuck
-//     office can restart clean. Preserves team, company, office history, and
+//   - Reset: narrow. Clears broker runtime state so a stuck office can restart
+//     clean. Preserves task worktrees, team, company, office history, and
 //     workflows. Equivalent to what `wuphf shred` did before the verb swap.
 //
 //   - Shred: full. Everything Reset does, plus deletes the team roster, company
-//     identity, the office's task receipts, and saved workflows. The next
-//     launch shows the onboarding wizard.
+//     identity, the office's task receipts, saved workflows, logs, sessions,
+//     provider state, calendar, and local markdown memory. The next launch
+//     shows the onboarding wizard.
 //
-// Preserved in both cases: logs/, sessions/, codex-headless/, providers/,
-// openclaw/, calendar.json, config.json. In-flight work (task-worktrees/) is
-// preserved by Reset but wiped as part of Shred via its broker-runtime reset —
-// actually, task-worktrees/ is preserved by both. Branches and local changes
-// inside those worktrees remain intact.
+// Preserved in both cases: task-worktrees/, openclaw/, config.json. In-flight
+// work remains on disk so branches and local changes inside task worktrees
+// survive, and credentials/preferences stay available for the next launch.
 package workspace
 
 import (
@@ -33,10 +32,10 @@ type Result struct {
 	Errors  []string `json:"errors,omitempty"`
 }
 
-// ClearRuntime performs a narrow reset: deletes the broker state file and the
-// task-worktrees registry (the worktrees themselves stay on disk). Safe to
-// call when no broker is running. Callers that need to stop a live broker or
-// tmux session must do so separately — this package only touches the disk.
+// ClearRuntime performs a narrow reset: deletes the broker state directory.
+// Task worktrees stay on disk. Safe to call when no broker is running. Callers
+// that need to stop a live broker or tmux session must do so separately — this
+// package only touches the disk.
 func ClearRuntime() (Result, error) {
 	home, err := wuphfHome()
 	if err != nil {
@@ -51,7 +50,8 @@ func ClearRuntime() (Result, error) {
 }
 
 // Shred performs a full workspace wipe. Runs ClearRuntime first, then removes
-// onboarding state, company identity, office task receipts, and workflows.
+// onboarding state, company identity, office task receipts, workflows, logs,
+// provider session state, and local markdown memory.
 func Shred() (Result, error) {
 	home, err := wuphfHome()
 	if err != nil {
@@ -65,6 +65,13 @@ func Shred() (Result, error) {
 	res.removeIfPresent(company.ManifestPath())
 	res.removeIfPresent(filepath.Join(home, "office"))
 	res.removeIfPresent(filepath.Join(home, "workflows"))
+	res.removeIfPresent(filepath.Join(home, "logs"))
+	res.removeIfPresent(filepath.Join(home, "sessions"))
+	res.removeIfPresent(filepath.Join(home, "providers"))
+	res.removeIfPresent(filepath.Join(home, "codex-headless"))
+	res.removeIfPresent(filepath.Join(home, "wiki"))
+	res.removeIfPresent(filepath.Join(home, "wiki.bak"))
+	res.removeIfPresent(filepath.Join(home, "calendar.json"))
 	return res, nil
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -27,6 +27,8 @@ func seedWorkspace(t *testing.T, dir string) map[string]string {
 		"openclaw":    filepath.Join(base, "openclaw", "identity.json"),
 		"config":      filepath.Join(base, "config.json"),
 		"calendar":    filepath.Join(base, "calendar.json"),
+		"wiki":        filepath.Join(base, "wiki", "team", "playbooks", "starter.md"),
+		"wikiBackup":  filepath.Join(base, "wiki.bak", "team", "playbooks", "starter.md"),
 	}
 	for _, p := range paths {
 		if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
@@ -87,7 +89,7 @@ func TestClearRuntimeRemovesBrokerStateOnly(t *testing.T) {
 	}
 }
 
-func TestShredRemovesWorkspaceButPreservesHistory(t *testing.T) {
+func TestShredRemovesWorkspaceHistoryButPreservesUserWorkAndConfig(t *testing.T) {
 	dir := withRuntimeHome(t)
 	paths := seedWorkspace(t, dir)
 
@@ -102,15 +104,15 @@ func TestShredRemovesWorkspaceButPreservesHistory(t *testing.T) {
 	// Wiped by shred.
 	for _, label := range []string{
 		"onboarded", "company", "brokerState", "officePID",
-		"officeTasks", "workflow",
+		"officeTasks", "workflow", "logs", "session", "codex",
+		"providers", "calendar", "wiki", "wikiBackup",
 	} {
 		assertGone(t, label, paths[label])
 	}
 
-	// Preserved: history, in-flight work, auth caches, user prefs.
+	// Preserved: in-flight work and user credentials/preferences.
 	for _, label := range []string{
-		"logs", "session", "worktree", "codex", "providers",
-		"openclaw", "config", "calendar",
+		"worktree", "openclaw", "config",
 	} {
 		assertStays(t, label, paths[label])
 	}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -79,6 +79,35 @@ export async function post<T = unknown>(
   return r.json()
 }
 
+export async function postWithTimeout<T = unknown>(
+  path: string,
+  body: unknown,
+  timeoutMs: number,
+): Promise<T> {
+  const controller = new AbortController()
+  const timeout = globalThis.setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const r = await fetch(baseURL() + path, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    })
+    if (!r.ok) {
+      const text = (await r.text().catch(() => '')).trim()
+      throw new Error(text || `${r.status} ${r.statusText}`)
+    }
+    return r.json()
+  } catch (err) {
+    if (err instanceof Error && err.name === 'AbortError') {
+      throw new Error('Request timed out')
+    }
+    throw err
+  } finally {
+    globalThis.clearTimeout(timeout)
+  }
+}
+
 export async function del<T = unknown>(
   path: string,
   body?: unknown,
@@ -640,12 +669,12 @@ export interface WorkspaceWipeResult {
 // window.location.reload() after success so the UI picks up the empty
 // broker state.
 export function resetWorkspace() {
-  return post<WorkspaceWipeResult>('/workspace/reset', {})
+  return postWithTimeout<WorkspaceWipeResult>('/workspace/reset', {}, 20_000)
 }
 
-// shredWorkspace is the full wipe: broker runtime + team + company + office
-// + workflows. Onboarding reopens on the next load. Call window.location
-// .reload() after success.
+// shredWorkspace is the full wipe: broker runtime + team + company + office,
+// workflows, logs, sessions, provider state, and local markdown memory.
+// The broker exits after success; relaunch WUPHF to reopen onboarding.
 export function shredWorkspace() {
-  return post<WorkspaceWipeResult>('/workspace/shred', {})
+  return postWithTimeout<WorkspaceWipeResult>('/workspace/shred', {}, 20_000)
 }

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -928,6 +928,7 @@ type DangerAction = 'reset' | 'shred'
 function DangerZoneSection() {
   const [open, setOpen] = useState<DangerAction | null>(null)
   const [busy, setBusy] = useState(false)
+  const queryClient = useQueryClient()
 
   const handleReset = async () => {
     setBusy(true)
@@ -955,8 +956,10 @@ function DangerZoneSection() {
         setBusy(false)
         return
       }
-      showNotice('Workspace shredded. Returning to onboarding…', 'success')
-      setTimeout(() => window.location.reload(), 400)
+      queryClient.clear()
+      setOpen(null)
+      setBusy(false)
+      showNotice('Workspace shredded. Relaunch wuphf to start onboarding.', 'success')
     } catch (err) {
       showNotice(err instanceof Error ? err.message : 'Shred failed', 'error')
       setBusy(false)
@@ -967,10 +970,9 @@ function DangerZoneSection() {
     <div>
       <div style={styles.sectionTitle}>Danger Zone</div>
       <div style={styles.sectionDesc}>
-        Irreversible operations on this workspace. Read each card carefully — the web UI does not
-        kill the running broker process, so after either action you may need to re-launch
-        <code style={{ margin: '0 4px' }}>wuphf</code> from your terminal for the change to fully
-        take effect.
+        Irreversible operations on this workspace. Reset reloads the current broker. Shred wipes
+        local workspace history, stops WUPHF after the response returns, and requires a fresh
+        <code style={{ margin: '0 4px' }}>wuphf</code> launch.
       </div>
 
       {/* RESET — narrow: broker runtime state only */}
@@ -1011,8 +1013,8 @@ function DangerZoneSection() {
           <span>Shred workspace</span>
         </div>
         <div style={dangerStyles.cardSubtitle}>
-          Full wipe. Deletes your team, company identity, office task receipts, and saved
-          workflows, then reopens the onboarding wizard on the next load. Use this to start
+          Full wipe. Deletes your team, company identity, office task receipts, saved workflows,
+          local memory, logs, and provider session state, then stops WUPHF. Use this to start
           completely fresh or to try a different blueprint.
         </div>
         <div style={dangerStyles.listLabel}>Deletes</div>
@@ -1022,6 +1024,7 @@ function DangerZoneSection() {
           </li>
           <li>Company identity (<code>~/.wuphf/company.json</code>)</li>
           <li>Team, office, workflows directories under <code>~/.wuphf/</code></li>
+          <li>Logs, sessions, provider state, calendar, and local wiki memory</li>
           <li>Broker runtime state (same as Reset)</li>
         </ul>
         <div style={dangerStyles.listLabel}>Preserved</div>
@@ -1029,9 +1032,8 @@ function DangerZoneSection() {
           <li>
             <strong>Task worktrees</strong> — uncommitted work on branches stays on disk
           </li>
-          <li>Conversation logs and session history</li>
-          <li>LLM provider caches (codex-headless, providers/, openclaw/)</li>
           <li>Your global config (<code>config.json</code>) and API keys</li>
+          <li>OpenClaw device identity used for gateway pairing</li>
         </ul>
         <button
           type="button"
@@ -1068,8 +1070,9 @@ function DangerZoneSection() {
           intro={
             <>
               This permanently deletes your team, company identity, office task receipts, and
-              saved workflows. Onboarding will reopen on next load. Task worktrees, logs, and
-              session history are kept. <strong>This cannot be undone.</strong>
+              saved workflows, plus local logs, sessions, provider state, calendar, and wiki
+              memory. WUPHF will stop after the wipe; relaunch it to reopen onboarding. Task
+              worktrees and config are kept. <strong>This cannot be undone.</strong>
             </>
           }
           confirmLabel="Shred workspace"


### PR DESCRIPTION
## Summary

This changes workspace shred into a true fresh-start operation. The wipe now removes runtime history and local state that could repopulate stale messages: logs, sessions, provider session state, Codex headless state, calendar, local markdown wiki memory, office state, workflows, team state, onboarding, and company identity.

It still preserves user work and credentials: task worktrees, `config.json`, and OpenClaw device identity.

## Root Cause

The web shred endpoint deleted selected files on disk while the live broker and agent loops kept running with old in-memory state. Because logs and sessions were intentionally preserved, and the broker could continue after shred, old messages could remain visible or be written back after restart.

## User Impact

After shredding from Settings, WUPHF now stops after returning a successful response. Relaunching `wuphf` reopens onboarding from a clean workspace instead of carrying old messages or logs forward. The web client also uses a bounded request timeout so the UI does not spin forever if the broker fails to respond.

## Validation

- `go test ./internal/workspace ./internal/team`
- `go test ./cmd/wuphf`
- `npm run typecheck`
- `git diff --check`