### PR TITLE
feat(wiki-web): Slice 2 Thread E — polish for /lookup, /lint, resolve flow

### DIFF
--- a/web/src/components/wiki/CitedAnswer.test.tsx
+++ b/web/src/components/wiki/CitedAnswer.test.tsx
@@ -1,141 +1,128 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
-import * as apiClient from "../../api/client";
-import CitedAnswer, { type QueryAnswer } from "./CitedAnswer";
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import CitedAnswer, { type QueryAnswer } from './CitedAnswer'
+import * as apiClient from '../../api/client'
 
 const STUB_ANSWER: QueryAnswer = {
-  query_class: "status",
-  answer_markdown: "Sarah Jones is VP of Sales at Acme Corp.<sup>[1]</sup>",
+  query_class: 'status',
+  answer_markdown: 'Sarah Jones is VP of Sales at Acme Corp.<sup>[1]</sup>',
   sources_cited: [1],
   sources: [
     {
-      kind: "fact",
-      slug_or_id: "people/sarah-jones",
-      title: "Sarah Jones",
-      excerpt: "Sarah Jones is VP of Sales at Acme Corp.",
-      valid_from: "2026-01-01",
+      kind: 'fact',
+      slug_or_id: 'people/sarah-jones',
+      title: 'Sarah Jones',
+      excerpt: 'Sarah Jones is VP of Sales at Acme Corp.',
+      valid_from: '2026-01-01',
       staleness: 0.1,
-      source_path: "team/people/sarah-jones.md",
+      source_path: 'team/people/sarah-jones.md',
     },
   ],
   confidence: 0.9,
-  coverage: "complete",
+  coverage: 'complete',
   latency_ms: 42,
-};
+}
 
 const STUB_GENERAL: QueryAnswer = {
-  query_class: "general",
+  query_class: 'general',
   answer_markdown: "I don't have information about that.",
   sources_cited: [],
   sources: [],
   confidence: 0.85,
-  coverage: "none",
+  coverage: 'none',
   latency_ms: 5,
-};
+}
 
-const _STUB_PARTIAL: QueryAnswer = {
+const STUB_PARTIAL: QueryAnswer = {
   ...STUB_ANSWER,
-  coverage: "partial",
+  coverage: 'partial',
   sources_cited: [],
-};
+}
 
-describe("<CitedAnswer>", () => {
+describe('<CitedAnswer>', () => {
   beforeEach(() => {
-    vi.restoreAllMocks();
-  });
+    vi.restoreAllMocks()
+  })
 
-  it("shows loading skeleton while fetching", () => {
-    vi.spyOn(apiClient, "get").mockReturnValue(new Promise(() => {}));
-    render(<CitedAnswer query="Who is Sarah Jones?" />);
-    const skeleton = document.querySelector(".wk-cited-answer--loading");
-    expect(skeleton).toBeTruthy();
-    expect(skeleton?.getAttribute("aria-busy")).toBe("true");
-    expect(skeleton?.getAttribute("role")).toBe("status");
-  });
+  it('shows "Searching the wiki…" status line while fetching', () => {
+    vi.spyOn(apiClient, 'get').mockReturnValue(new Promise(() => {}))
+    render(<CitedAnswer query="Who is Sarah Jones?" />)
+    const loadingEl = document.querySelector('.wk-cited-answer--loading')
+    expect(loadingEl).toBeTruthy()
+    expect(loadingEl?.getAttribute('aria-busy')).toBe('true')
+    expect(loadingEl?.getAttribute('role')).toBe('status')
+    // Fraunces-italic status line — no amber, no dark-mode, no skeleton blocks.
+    const status = loadingEl?.querySelector('.wk-lookup-status')
+    expect(status).toBeTruthy()
+    expect(status?.textContent).toBe('Searching the wiki…')
+  })
 
-  it("renders answer_markdown and hatnote on success", async () => {
-    vi.spyOn(apiClient, "get").mockResolvedValue(STUB_ANSWER);
-    render(<CitedAnswer query="Who is Sarah Jones?" />);
+  it('renders answer_markdown and hatnote on success', async () => {
+    vi.spyOn(apiClient, 'get').mockResolvedValue(STUB_ANSWER)
+    render(<CitedAnswer query="Who is Sarah Jones?" />)
     await waitFor(() => {
-      expect(screen.getByTestId("wk-cited-answer-body")).toBeTruthy();
-    });
+      expect(screen.getByTestId('wk-cited-answer-body')).toBeTruthy()
+    })
     // Hatnote present
-    expect(document.querySelector(".wk-hatnote")).toBeTruthy();
+    expect(document.querySelector('.wk-hatnote')).toBeTruthy()
     // Body contains the answer text
-    expect(screen.getByTestId("wk-cited-answer-body").textContent).toContain(
-      "Sarah Jones",
-    );
-  });
+    expect(screen.getByTestId('wk-cited-answer-body').textContent).toContain('Sarah Jones')
+  })
 
-  it("renders cited sources list on successful answer", async () => {
-    vi.spyOn(apiClient, "get").mockResolvedValue(STUB_ANSWER);
-    render(<CitedAnswer query="Who is Sarah Jones?" />);
+  it('renders cited sources list on successful answer', async () => {
+    vi.spyOn(apiClient, 'get').mockResolvedValue(STUB_ANSWER)
+    render(<CitedAnswer query="Who is Sarah Jones?" />)
     await waitFor(() => {
-      expect(screen.getByText(/Sources/i)).toBeTruthy();
-    });
+      expect(screen.getByText(/Sources/i)).toBeTruthy()
+    })
     // Sources section has the cited excerpt — scope to the <ol> so we don't
     // match the body text that happens to share prose with the excerpt.
-    const sourcesList = document.querySelector(".wk-sources ol");
-    expect(sourcesList).toBeTruthy();
-    expect(sourcesList?.textContent).toContain("Sarah Jones is VP");
-  });
+    const sourcesList = document.querySelector('.wk-sources ol')
+    expect(sourcesList).toBeTruthy()
+    expect(sourcesList!.textContent).toContain('Sarah Jones is VP')
+  })
 
-  it("preserves citation numbering when some sources are uncited (gap case)", async () => {
+  it('preserves citation numbering when some sources are uncited (gap case)', async () => {
     const gapped: QueryAnswer = {
       ...STUB_ANSWER,
-      answer_markdown: "First fact.<sup>[1]</sup> Third fact.<sup>[3]</sup>",
+      answer_markdown: 'First fact.<sup>[1]</sup> Third fact.<sup>[3]</sup>',
       sources_cited: [1, 3],
       sources: [
-        {
-          ...STUB_ANSWER.sources[0],
-          slug_or_id: "a",
-          excerpt: "First source excerpt.",
-        },
-        {
-          ...STUB_ANSWER.sources[0],
-          slug_or_id: "b",
-          excerpt: "Second source uncited.",
-        },
-        {
-          ...STUB_ANSWER.sources[0],
-          slug_or_id: "c",
-          excerpt: "Third source excerpt.",
-        },
+        { ...STUB_ANSWER.sources[0], slug_or_id: 'a', excerpt: 'First source excerpt.' },
+        { ...STUB_ANSWER.sources[0], slug_or_id: 'b', excerpt: 'Second source uncited.' },
+        { ...STUB_ANSWER.sources[0], slug_or_id: 'c', excerpt: 'Third source excerpt.' },
       ],
-    };
-    vi.spyOn(apiClient, "get").mockResolvedValue(gapped);
-    render(<CitedAnswer query="gap?" />);
+    }
+    vi.spyOn(apiClient, 'get').mockResolvedValue(gapped)
+    render(<CitedAnswer query="gap?" />)
     await waitFor(() => {
-      expect(document.querySelector("#ca-sources-heading")).toBeTruthy();
-    });
-    const items = document.querySelectorAll(".wk-sources ol > li");
-    expect(items.length).toBe(2);
-    expect(items[0].getAttribute("value")).toBe("1");
-    expect(items[0].getAttribute("id")).toBe("ca-s1");
-    expect(items[1].getAttribute("value")).toBe("3");
-    expect(items[1].getAttribute("id")).toBe("ca-s3");
-  });
+      expect(document.querySelector('#ca-sources-heading')).toBeTruthy()
+    })
+    const items = document.querySelectorAll('.wk-sources ol > li')
+    expect(items.length).toBe(2)
+    expect(items[0].getAttribute('value')).toBe('1')
+    expect(items[0].getAttribute('id')).toBe('ca-s1')
+    expect(items[1].getAttribute('value')).toBe('3')
+    expect(items[1].getAttribute('id')).toBe('ca-s3')
+  })
 
-  it("shows no Sources block for out-of-scope queries", async () => {
-    vi.spyOn(apiClient, "get").mockResolvedValue(STUB_GENERAL);
-    render(<CitedAnswer query="What is the weather like?" />);
+  it('shows no Sources block for out-of-scope queries', async () => {
+    vi.spyOn(apiClient, 'get').mockResolvedValue(STUB_GENERAL)
+    render(<CitedAnswer query="What is the weather like?" />)
     await waitFor(() => {
       // Out-of-scope guidance text appears
-      expect(screen.getByText(/help with questions/)).toBeTruthy();
-    });
+      expect(screen.getByText(/help with questions/)).toBeTruthy()
+    })
     // No sources section
-    expect(document.querySelector("#ca-sources-heading")).toBeNull();
-  });
+    expect(document.querySelector('#ca-sources-heading')).toBeNull()
+  })
 
-  it("shows hatnote-styled error when the API fails", async () => {
-    vi.spyOn(apiClient, "get").mockRejectedValue(
-      new Error("wiki backend is not active"),
-    );
-    render(<CitedAnswer query="Who is Sarah Jones?" />);
+  it('shows hatnote-styled error when the API fails', async () => {
+    vi.spyOn(apiClient, 'get').mockRejectedValue(new Error('wiki backend is not active'))
+    render(<CitedAnswer query="Who is Sarah Jones?" />)
     await waitFor(() => {
-      expect(document.querySelector(".wk-cited-answer--error")).toBeTruthy();
-    });
-    expect(screen.getByText(/wiki backend is not active/)).toBeTruthy();
-  });
-});
+      expect(document.querySelector('.wk-cited-answer--error')).toBeTruthy()
+    })
+    expect(screen.getByText(/wiki backend is not active/)).toBeTruthy()
+  })
+})

--- a/web/src/components/wiki/CitedAnswer.tsx
+++ b/web/src/components/wiki/CitedAnswer.tsx
@@ -94,7 +94,10 @@ export default function CitedAnswer({ query }: CitedAnswerProps) {
       });
   }, [query]);
 
-  // Loading skeleton
+  // Loading state — Fraunces-italic status line per DESIGN-WIKI.md hatnote
+  // typography (§9 typography, §5 hatnote voice). Previously we rendered
+  // skeleton blocks, but the editorial surface reads better with a single
+  // calm status line than geometric shimmer blocks.
   if (loading) {
     return (
       <div
@@ -103,12 +106,7 @@ export default function CitedAnswer({ query }: CitedAnswerProps) {
         aria-busy="true"
         aria-label="Loading cited answer…"
       >
-        <div className="wk-hatnote wk-skeleton" aria-hidden="true" />
-        <div className="wk-skeleton wk-skeleton--body" aria-hidden="true" />
-        <div
-          className="wk-skeleton wk-skeleton--body wk-skeleton--short"
-          aria-hidden="true"
-        />
+        <p className="wk-lookup-status">Searching the wiki…</p>
       </div>
     );
   }

--- a/web/src/components/wiki/ResolveContradictionModal.test.tsx
+++ b/web/src/components/wiki/ResolveContradictionModal.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import ResolveContradictionModal from './ResolveContradictionModal'
+import * as wikiApi from '../../api/wiki'
+import * as toast from '../ui/Toast'
+
+const FINDING: wikiApi.LintFinding = {
+  severity: 'critical',
+  type: 'contradictions',
+  entity_slug: 'sarah-chen',
+  fact_ids: ['f1', 'f2'],
+  summary: 'role_at predicate has two conflicting values.',
+  resolve_actions: [
+    'Fact A (id: f1): Sarah is Head of Marketing.',
+    'Fact B (id: f2): Sarah is VP of Sales.',
+    'Both',
+  ],
+}
+
+describe('<ResolveContradictionModal>', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows a spinner on the clicked button while the request is in flight', async () => {
+    // Never-resolving promise so the pending state is observable. We
+    // intentionally never settle it: the spinner-visible state *is* the
+    // assertion, and settling it after the test body returns would schedule
+    // state updates outside an awaited act() cycle (CodeRabbit #259). Test
+    // cleanup unmounts the component, which discards the pending promise.
+    vi.spyOn(wikiApi, 'resolveContradiction').mockImplementation(
+      () => new Promise(() => { /* never resolves */ }),
+    )
+
+    render(
+      <ResolveContradictionModal
+        finding={FINDING}
+        findingIdx={0}
+        reportDate="2026-04-22"
+        onClose={vi.fn()}
+        onResolved={vi.fn()}
+      />,
+    )
+
+    const pickA = screen.getByTestId('wk-resolve-pick-a')
+    const pickB = screen.getByTestId('wk-resolve-pick-b')
+    fireEvent.click(pickA)
+
+    await waitFor(() => {
+      expect(pickA.getAttribute('aria-busy')).toBe('true')
+    })
+    // Matches CitedAnswer's convention: omit aria-busy when not busy rather
+    // than write aria-busy="false". Keeps the DOM quiet for assistive tech.
+    expect(pickB.hasAttribute('aria-busy')).toBe(false)
+    // Spinner renders inside the clicked button only — siblings stay quiet.
+    expect(pickA.querySelector('.wk-spinner')).toBeTruthy()
+    expect(pickB.querySelector('.wk-spinner')).toBeNull()
+    expect(pickA.textContent).toContain('Resolving')
+    // All three pick buttons are disabled; cancel is also disabled while
+    // the request is in flight so the user can't drop the modal mid-write.
+    expect(pickA).toBeDisabled()
+    expect(pickB).toBeDisabled()
+    expect(screen.getByTestId('wk-resolve-pick-both')).toBeDisabled()
+    expect(screen.getByTestId('wk-resolve-cancel')).toBeDisabled()
+  })
+
+  it('surfaces errors inline (no toast) and re-enables the buttons', async () => {
+    vi.spyOn(wikiApi, 'resolveContradiction').mockRejectedValue(
+      new Error('broker offline'),
+    )
+    const showNoticeSpy = vi.spyOn(toast, 'showNotice')
+    const onResolved = vi.fn()
+
+    render(
+      <ResolveContradictionModal
+        finding={FINDING}
+        findingIdx={0}
+        reportDate="2026-04-22"
+        onClose={vi.fn()}
+        onResolved={onResolved}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('wk-resolve-pick-a'))
+
+    // Error string renders inline via the shared error banner, not a toast.
+    const banner = await screen.findByRole('alert')
+    expect(banner.textContent).toContain('broker offline')
+    expect(onResolved).not.toHaveBeenCalled()
+    expect(showNoticeSpy).not.toHaveBeenCalled()
+    // Buttons re-enabled after the error so the user can retry.
+    expect(screen.getByTestId('wk-resolve-pick-a')).not.toBeDisabled()
+  })
+
+  it('on success fires a short-sha success toast and calls onResolved', async () => {
+    vi.spyOn(wikiApi, 'resolveContradiction').mockResolvedValue({
+      commit_sha: 'abcdef1234567890',
+      message: 'resolved',
+    })
+    const showNoticeSpy = vi.spyOn(toast, 'showNotice')
+    const onResolved = vi.fn()
+
+    render(
+      <ResolveContradictionModal
+        finding={FINDING}
+        findingIdx={0}
+        reportDate="2026-04-22"
+        onClose={vi.fn()}
+        onResolved={onResolved}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('wk-resolve-pick-both'))
+
+    await waitFor(() => expect(onResolved).toHaveBeenCalled())
+    expect(showNoticeSpy).toHaveBeenCalledWith('Resolved. Commit abcdef1.', 'success')
+  })
+
+  it('falls back to a plain "Resolved." toast if the broker omits the sha', async () => {
+    vi.spyOn(wikiApi, 'resolveContradiction').mockResolvedValue({
+      commit_sha: '',
+      message: 'resolved',
+    })
+    const showNoticeSpy = vi.spyOn(toast, 'showNotice')
+
+    render(
+      <ResolveContradictionModal
+        finding={FINDING}
+        findingIdx={0}
+        reportDate="2026-04-22"
+        onClose={vi.fn()}
+        onResolved={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('wk-resolve-pick-a'))
+
+    await waitFor(() => expect(showNoticeSpy).toHaveBeenCalled())
+    expect(showNoticeSpy).toHaveBeenCalledWith('Resolved.', 'success')
+  })
+})

--- a/web/src/components/wiki/ResolveContradictionModal.tsx
+++ b/web/src/components/wiki/ResolveContradictionModal.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react";
-
-import { type LintFinding, resolveContradiction } from "../../api/wiki";
+import { useEffect, useRef, useState } from 'react'
+import { resolveContradiction, type LintFinding } from '../../api/wiki'
+import { showNotice } from '../ui/Toast'
 
 /**
  * ResolveContradictionModal — modal for resolving a lint contradiction finding.
@@ -18,11 +18,11 @@ import { type LintFinding, resolveContradiction } from "../../api/wiki";
  * without submitting (spec: §5 modal UX).
  */
 interface ResolveContradictionModalProps {
-  finding: LintFinding;
-  findingIdx: number;
-  reportDate: string;
-  onClose: () => void;
-  onResolved: () => void;
+  finding: LintFinding
+  findingIdx: number
+  reportDate: string
+  onClose: () => void
+  onResolved: () => void
 }
 
 export default function ResolveContradictionModal({
@@ -32,51 +32,69 @@ export default function ResolveContradictionModal({
   onClose,
   onResolved,
 }: ResolveContradictionModalProps) {
-  const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const backdropRef = useRef<HTMLDivElement>(null);
+  const [submitting, setSubmitting] = useState(false)
+  /**
+   * Which button the user clicked. Only that button shows the spinner +
+   * "Resolving…" label — the other two stay at their static label but go
+   * disabled. This prevents the "pick A" click from redrawing "Resolving…"
+   * on all three buttons, which would flash and feel confused.
+   */
+  const [pendingWinner, setPendingWinner] = useState<'A' | 'B' | 'Both' | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const backdropRef = useRef<HTMLDivElement>(null)
 
   // Escape key closes without submitting.
   useEffect(() => {
     function onKeyDown(ev: KeyboardEvent) {
-      if (ev.key === "Escape") {
-        onClose();
+      if (ev.key === 'Escape') {
+        onClose()
       }
     }
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [onClose])
 
   // Click outside (on backdrop) closes without submitting.
   function handleBackdropClick(ev: React.MouseEvent<HTMLDivElement>) {
     if (ev.target === backdropRef.current) {
-      onClose();
+      onClose()
     }
   }
 
-  async function handlePick(winner: "A" | "B" | "Both") {
-    setError(null);
-    setSubmitting(true);
+  async function handlePick(winner: 'A' | 'B' | 'Both') {
+    setError(null)
+    setSubmitting(true)
+    setPendingWinner(winner)
     try {
-      await resolveContradiction({
+      const res = await resolveContradiction({
         report_date: reportDate,
         finding_idx: findingIdx,
         finding,
         winner,
-      });
-      onResolved();
+      })
+      // There is no commit-viewer route today, so the sha rides inside the
+      // toast copy in mono-style rather than as a link (spec §4). Short
+      // sha mirrors git's default display width.
+      const shortSha = (res.commit_sha || '').slice(0, 7)
+      showNotice(
+        shortSha ? `Resolved. Commit ${shortSha}.` : 'Resolved.',
+        'success',
+      )
+      onResolved()
+      // WikiLint refreshes on success, which unmounts this modal. Return
+      // early so we don't setState on an unmounted component (React 18
+      // tolerates it today, but it's a latent footgun).
+      return
     } catch (err: unknown) {
-      setError(
-        err instanceof Error ? err.message : "Failed to resolve contradiction.",
-      );
-    } finally {
-      setSubmitting(false);
+      setError(err instanceof Error ? err.message : 'Failed to resolve contradiction.')
+      setSubmitting(false)
+      setPendingWinner(null)
     }
   }
 
   // resolve_actions is always [factAText, factBText, "Both"] for contradictions.
-  const factA = finding.resolve_actions?.[0] ?? "Fact A";
-  const factB = finding.resolve_actions?.[1] ?? "Fact B";
+  const factA = finding.resolve_actions?.[0] ?? 'Fact A'
+  const factB = finding.resolve_actions?.[1] ?? 'Fact B'
 
   return (
     <div
@@ -92,9 +110,9 @@ export default function ResolveContradictionModal({
         <h2 id="wk-resolve-title">Resolve contradiction</h2>
 
         <p className="wk-editor-help">
-          Entity: <strong>{finding.entity_slug ?? "(unknown)"}</strong>
+          Entity: <strong>{finding.entity_slug ?? '(unknown)'}</strong>
           {finding.fact_ids && finding.fact_ids.length > 0 && (
-            <> &mdash; facts: {finding.fact_ids.join(", ")}</>
+            <> &mdash; facts: {finding.fact_ids.join(', ')}</>
           )}
         </p>
 
@@ -110,10 +128,7 @@ export default function ResolveContradictionModal({
         </div>
 
         {error && (
-          <div
-            className="wk-editor-banner wk-editor-banner--error"
-            role="alert"
-          >
+          <div className="wk-editor-banner wk-editor-banner--error" role="alert">
             {error}
           </div>
         )}
@@ -128,28 +143,52 @@ export default function ResolveContradictionModal({
             type="button"
             className="wk-editor-save"
             data-testid="wk-resolve-pick-a"
-            onClick={() => handlePick("A")}
+            onClick={() => handlePick('A')}
             disabled={submitting}
+            aria-busy={pendingWinner === 'A' ? 'true' : undefined}
           >
-            {submitting ? "Resolving…" : "Fact A"}
+            {pendingWinner === 'A' ? (
+              <>
+                <span className="wk-spinner" aria-hidden="true" />
+                Resolving…
+              </>
+            ) : (
+              'Fact A'
+            )}
           </button>
           <button
             type="button"
             className="wk-editor-save"
             data-testid="wk-resolve-pick-b"
-            onClick={() => handlePick("B")}
+            onClick={() => handlePick('B')}
             disabled={submitting}
+            aria-busy={pendingWinner === 'B' ? 'true' : undefined}
           >
-            {submitting ? "Resolving…" : "Fact B"}
+            {pendingWinner === 'B' ? (
+              <>
+                <span className="wk-spinner" aria-hidden="true" />
+                Resolving…
+              </>
+            ) : (
+              'Fact B'
+            )}
           </button>
           <button
             type="button"
             className="wk-editor-save"
             data-testid="wk-resolve-pick-both"
-            onClick={() => handlePick("Both")}
+            onClick={() => handlePick('Both')}
             disabled={submitting}
+            aria-busy={pendingWinner === 'Both' ? 'true' : undefined}
           >
-            {submitting ? "Resolving…" : "Both"}
+            {pendingWinner === 'Both' ? (
+              <>
+                <span className="wk-spinner" aria-hidden="true" />
+                Resolving…
+              </>
+            ) : (
+              'Both'
+            )}
           </button>
           <button
             type="button"
@@ -163,5 +202,5 @@ export default function ResolveContradictionModal({
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/web/src/hooks/useCommands.test.ts
+++ b/web/src/hooks/useCommands.test.ts
@@ -1,104 +1,94 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest'
+import type { SlashCommandDescriptor } from '../api/client'
+import { __test__, FALLBACK_SLASH_COMMANDS } from './useCommands'
 
-import type { SlashCommandDescriptor } from "../api/client";
-import { __test__, FALLBACK_SLASH_COMMANDS } from "./useCommands";
+const { toAutocomplete, COMMAND_ICONS, DEFAULT_ICON } = __test__
 
-const { toAutocomplete, COMMAND_ICONS, DEFAULT_ICON } = __test__;
-
-describe("toAutocomplete", () => {
-  it("filters out TUI-only commands and prefixes slash to the name", () => {
+describe('toAutocomplete', () => {
+  it('filters out TUI-only commands and prefixes slash to the name', () => {
     const broker: SlashCommandDescriptor[] = [
-      { name: "ask", description: "Ask the team lead", webSupported: true },
-      { name: "object", description: "Object commands", webSupported: false },
-      { name: "clear", description: "Clear messages", webSupported: true },
-    ];
-    const mapped = toAutocomplete(broker);
-    expect(mapped.map((c) => c.name)).toEqual(["/ask", "/clear"]);
-  });
+      { name: 'ask', description: 'Ask the team lead', webSupported: true },
+      { name: 'object', description: 'Object commands', webSupported: false },
+      { name: 'clear', description: 'Clear messages', webSupported: true },
+    ]
+    const mapped = toAutocomplete(broker)
+    expect(mapped.map((c) => c.name)).toEqual(['/ask', '/clear'])
+  })
 
-  it("maps known commands to their icon", () => {
+  it('maps known commands to their icon', () => {
     const broker: SlashCommandDescriptor[] = [
-      { name: "ask", description: "Ask", webSupported: true },
-      { name: "calendar", description: "Calendar", webSupported: true },
-    ];
-    const mapped = toAutocomplete(broker);
-    expect(mapped[0].icon).toBe(COMMAND_ICONS.ask);
-    expect(mapped[1].icon).toBe(COMMAND_ICONS.calendar);
-  });
+      { name: 'ask', description: 'Ask', webSupported: true },
+      { name: 'calendar', description: 'Calendar', webSupported: true },
+    ]
+    const mapped = toAutocomplete(broker)
+    expect(mapped[0].icon).toBe(COMMAND_ICONS.ask)
+    expect(mapped[1].icon).toBe(COMMAND_ICONS.calendar)
+  })
 
-  it("assigns the default icon to unknown commands so autocomplete never shows a blank glyph", () => {
+  it('assigns the default icon to unknown commands so autocomplete never shows a blank glyph', () => {
     const broker: SlashCommandDescriptor[] = [
-      {
-        name: "brand-new-command",
-        description: "Future command",
-        webSupported: true,
-      },
-    ];
-    const mapped = toAutocomplete(broker);
-    expect(mapped[0].icon).toBe(DEFAULT_ICON);
-  });
+      { name: 'brand-new-command', description: 'Future command', webSupported: true },
+    ]
+    const mapped = toAutocomplete(broker)
+    expect(mapped[0].icon).toBe(DEFAULT_ICON)
+  })
 
-  it("preserves the broker description verbatim — broker is the source of truth", () => {
+  it('preserves the broker description verbatim — broker is the source of truth', () => {
     const broker: SlashCommandDescriptor[] = [
-      {
-        name: "ask",
-        description: "Custom override description",
-        webSupported: true,
-      },
-    ];
-    const mapped = toAutocomplete(broker);
-    expect(mapped[0].desc).toBe("Custom override description");
-  });
+      { name: 'ask', description: 'Custom override description', webSupported: true },
+    ]
+    const mapped = toAutocomplete(broker)
+    expect(mapped[0].desc).toBe('Custom override description')
+  })
 
-  it("returns an empty array when every command is TUI-only", () => {
+  it('returns an empty array when every command is TUI-only', () => {
     const broker: SlashCommandDescriptor[] = [
-      { name: "object", description: "TUI", webSupported: false },
-      { name: "record", description: "TUI", webSupported: false },
-    ];
-    expect(toAutocomplete(broker)).toEqual([]);
-  });
+      { name: 'object', description: 'TUI', webSupported: false },
+      { name: 'record', description: 'TUI', webSupported: false },
+    ]
+    expect(toAutocomplete(broker)).toEqual([])
+  })
 
-  it("returns an empty array for an empty broker response", () => {
-    expect(toAutocomplete([])).toEqual([]);
-  });
-});
+  it('returns an empty array for an empty broker response', () => {
+    expect(toAutocomplete([])).toEqual([])
+  })
+})
 
-describe("FALLBACK_SLASH_COMMANDS", () => {
+describe('FALLBACK_SLASH_COMMANDS', () => {
   // This locks in the fallback contract: if the broker is unreachable, the
   // autocomplete still populates with the web-supported command set the
   // composer knows how to execute.
-  it("covers every command the composer handler currently implements", () => {
+  it('covers every command the composer handler currently implements', () => {
     const expected = [
-      "/ask",
-      "/search",
-      "/remember",
-      "/help",
-      "/clear",
-      "/reset",
-      "/tasks",
-      "/requests",
-      "/recover",
-      "/1o1",
-      "/task",
-      "/cancel",
-      "/policies",
-      "/calendar",
-      "/skills",
-      "/focus",
-      "/collab",
-      "/pause",
-      "/resume",
-      "/threads",
-      "/provider",
-    ].sort();
-    expect(FALLBACK_SLASH_COMMANDS.map((c) => c.name).sort()).toEqual(expected);
-  });
+      '/ask', '/lookup', '/lint', '/search', '/remember', '/help', '/clear', '/reset',
+      '/tasks', '/requests', '/recover', '/1o1', '/task', '/cancel',
+      '/policies', '/calendar', '/skills', '/focus', '/collab',
+      '/pause', '/resume', '/threads', '/provider',
+    ].sort()
+    expect(FALLBACK_SLASH_COMMANDS.map((c) => c.name).sort()).toEqual(expected)
+  })
 
-  it("never ships an empty icon — every fallback entry has a glyph", () => {
+  it('never ships an empty icon — every fallback entry has a glyph', () => {
     for (const cmd of FALLBACK_SLASH_COMMANDS) {
-      expect(cmd.icon).not.toBe("");
+      expect(cmd.icon).not.toBe('')
     }
-  });
+  })
+
+  // Wiki intelligence commands ship in the fallback so the autocomplete
+  // still lists them when the broker is unreachable. Descriptions match
+  // the Slice 2 Thread E copy spec verbatim so a regression on either
+  // side (fallback drift, broker description edit) fails loudly.
+  it('includes /lookup with the expected operator-language description', () => {
+    const lookup = FALLBACK_SLASH_COMMANDS.find((c) => c.name === '/lookup')
+    expect(lookup).toBeDefined()
+    expect(lookup?.desc).toBe('Cited answer from the team wiki')
+  })
+
+  it('includes /lint with the expected operator-language description', () => {
+    const lint = FALLBACK_SLASH_COMMANDS.find((c) => c.name === '/lint')
+    expect(lint).toBeDefined()
+    expect(lint?.desc).toBe('Review wiki for contradictions and stale facts')
+  })
 
   // Real-world bug: useCommands returned a fresh array on every render, so
   // the Autocomplete effect that watches `commands` + items fired on every
@@ -107,15 +97,15 @@ describe("FALLBACK_SLASH_COMMANDS", () => {
   // array... React bailed with "Maximum update depth exceeded" and the UI
   // thrashed into unresponsiveness. Referential stability of the returned
   // list is load-bearing, not cosmetic.
-  it("toAutocomplete returns a stable result shape for identical input", () => {
+  it('toAutocomplete returns a stable result shape for identical input', () => {
     const broker: SlashCommandDescriptor[] = [
-      { name: "ask", description: "Ask the team lead", webSupported: true },
-    ];
-    const a = toAutocomplete(broker);
-    const b = toAutocomplete(broker);
+      { name: 'ask', description: 'Ask the team lead', webSupported: true },
+    ]
+    const a = toAutocomplete(broker)
+    const b = toAutocomplete(broker)
     // Same-content input → equal shape. The useMemo in useCommands takes
     // care of referential identity across renders; this pins the pure
     // helper's deterministic output contract.
-    expect(a).toEqual(b);
-  });
-});
+    expect(a).toEqual(b)
+  })
+})

--- a/web/src/hooks/useCommands.ts
+++ b/web/src/hooks/useCommands.ts
@@ -1,7 +1,6 @@
-import { useMemo } from "react";
-import { useQuery } from "@tanstack/react-query";
-
-import { fetchCommands, type SlashCommandDescriptor } from "../api/client";
+import { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { fetchCommands, type SlashCommandDescriptor } from '../api/client'
 
 /**
  * Web-autocomplete view of one slash command. Mirrors the legacy
@@ -10,9 +9,9 @@ import { fetchCommands, type SlashCommandDescriptor } from "../api/client";
  * fallback.
  */
 export interface SlashCommand {
-  name: string;
-  desc: string;
-  icon: string;
+  name: string
+  desc: string
+  icon: string
 }
 
 /**
@@ -28,28 +27,30 @@ export interface SlashCommand {
  * emoji literals in source).
  */
 export const FALLBACK_SLASH_COMMANDS: SlashCommand[] = [
-  { name: "/ask", desc: "Ask the team lead", icon: "💬" },
-  { name: "/search", desc: "Search messages + KB", icon: "🔎" },
-  { name: "/remember", desc: "Store a fact in memory", icon: "🧠" },
-  { name: "/help", desc: "Show all commands + keys", icon: "❓" },
-  { name: "/clear", desc: "Clear messages", icon: "🧹" },
-  { name: "/reset", desc: "Reset the office", icon: "🔄" },
-  { name: "/tasks", desc: "Open task board", icon: "📋" },
-  { name: "/requests", desc: "Open requests", icon: "🔔" },
-  { name: "/recover", desc: "Health Check view", icon: "🔁" },
-  { name: "/1o1", desc: "1:1 with agent", icon: "💬" },
-  { name: "/task", desc: "Task actions", icon: "✅" },
-  { name: "/cancel", desc: "Cancel a task", icon: "❌" },
-  { name: "/policies", desc: "View policies", icon: "📜" },
-  { name: "/calendar", desc: "View schedule", icon: "📅" },
-  { name: "/skills", desc: "View skills", icon: "⚡" },
-  { name: "/focus", desc: "Switch to delegation mode", icon: "🎯" },
-  { name: "/collab", desc: "Switch to collaborative mode", icon: "🤝" },
-  { name: "/pause", desc: "Pause all agents", icon: "⏸" },
-  { name: "/resume", desc: "Resume all agents", icon: "▶" },
-  { name: "/threads", desc: "See every active thread", icon: "🧵" },
-  { name: "/provider", desc: "Switch runtime provider", icon: "⚙" },
-];
+  { name: '/ask', desc: 'Ask the team lead', icon: '💬' },
+  { name: '/lookup', desc: 'Cited answer from the team wiki', icon: '📖' },
+  { name: '/lint', desc: 'Review wiki for contradictions and stale facts', icon: '🩺' },
+  { name: '/search', desc: 'Search messages + KB', icon: '🔎' },
+  { name: '/remember', desc: 'Store a fact in memory', icon: '🧠' },
+  { name: '/help', desc: 'Show all commands + keys', icon: '❓' },
+  { name: '/clear', desc: 'Clear messages', icon: '🧹' },
+  { name: '/reset', desc: 'Reset the office', icon: '🔄' },
+  { name: '/tasks', desc: 'Open task board', icon: '📋' },
+  { name: '/requests', desc: 'Open requests', icon: '🔔' },
+  { name: '/recover', desc: 'Health Check view', icon: '🔁' },
+  { name: '/1o1', desc: '1:1 with agent', icon: '💬' },
+  { name: '/task', desc: 'Task actions', icon: '✅' },
+  { name: '/cancel', desc: 'Cancel a task', icon: '❌' },
+  { name: '/policies', desc: 'View policies', icon: '📜' },
+  { name: '/calendar', desc: 'View schedule', icon: '📅' },
+  { name: '/skills', desc: 'View skills', icon: '⚡' },
+  { name: '/focus', desc: 'Switch to delegation mode', icon: '🎯' },
+  { name: '/collab', desc: 'Switch to collaborative mode', icon: '🤝' },
+  { name: '/pause', desc: 'Pause all agents', icon: '⏸' },
+  { name: '/resume', desc: 'Resume all agents', icon: '▶' },
+  { name: '/threads', desc: 'See every active thread', icon: '🧵' },
+  { name: '/provider', desc: 'Switch runtime provider', icon: '⚙' },
+]
 
 /**
  * Icon map for commands returned by the broker. Keyed by bare command name
@@ -58,30 +59,32 @@ export const FALLBACK_SLASH_COMMANDS: SlashCommand[] = [
  * and flips webSupported before updating this list.
  */
 const COMMAND_ICONS: Record<string, string> = {
-  ask: "💬",
-  search: "🔎",
-  remember: "🧠",
-  help: "❓",
-  clear: "🧹",
-  reset: "🔄",
-  tasks: "📋",
-  requests: "🔔",
-  recover: "🔁",
-  "1o1": "💬",
-  task: "✅",
-  cancel: "❌",
-  policies: "📜",
-  calendar: "📅",
-  skills: "⚡",
-  focus: "🎯",
-  collab: "🤝",
-  pause: "⏸",
-  resume: "▶",
-  threads: "🧵",
-  provider: "⚙",
-};
+  ask: '💬',
+  lookup: '📖',
+  lint: '🩺',
+  search: '🔎',
+  remember: '🧠',
+  help: '❓',
+  clear: '🧹',
+  reset: '🔄',
+  tasks: '📋',
+  requests: '🔔',
+  recover: '🔁',
+  '1o1': '💬',
+  task: '✅',
+  cancel: '❌',
+  policies: '📜',
+  calendar: '📅',
+  skills: '⚡',
+  focus: '🎯',
+  collab: '🤝',
+  pause: '⏸',
+  resume: '▶',
+  threads: '🧵',
+  provider: '⚙',
+}
 
-const DEFAULT_ICON = "›";
+const DEFAULT_ICON = '›'
 
 /**
  * Convert the broker's payload into the shape the autocomplete renderer
@@ -92,10 +95,10 @@ function toAutocomplete(commands: SlashCommandDescriptor[]): SlashCommand[] {
   return commands
     .filter((c) => c.webSupported)
     .map((c) => ({
-      name: `/${c.name}`,
+      name: '/' + c.name,
       desc: c.description,
       icon: COMMAND_ICONS[c.name] ?? DEFAULT_ICON,
-    }));
+    }))
 }
 
 /**
@@ -109,14 +112,14 @@ function toAutocomplete(commands: SlashCommandDescriptor[]): SlashCommand[] {
  */
 export function useCommands(): SlashCommand[] {
   const { data, isError } = useQuery({
-    queryKey: ["commands"],
+    queryKey: ['commands'],
     queryFn: fetchCommands,
     // Registry only changes on rebuild. Five minutes is enough to absorb a
     // dev loop without hammering the broker.
     staleTime: 5 * 60_000,
     // Failures fall through to the fallback — don't retry aggressively.
     retry: 1,
-  });
+  })
 
   // Memoize the derived view so consumers relying on the returned array as
   // a dependency (e.g. the autocomplete effect) don't see a fresh reference
@@ -126,14 +129,14 @@ export function useCommands(): SlashCommand[] {
   // "Maximum update depth exceeded."
   return useMemo(() => {
     if (isError || !data) {
-      return FALLBACK_SLASH_COMMANDS;
+      return FALLBACK_SLASH_COMMANDS
     }
-    const mapped = toAutocomplete(data);
+    const mapped = toAutocomplete(data)
     // Defensive: if the broker returns an empty webSupported set (e.g. an
     // older broker without the flag), prefer the fallback rather than an
     // empty autocomplete.
-    return mapped.length > 0 ? mapped : FALLBACK_SLASH_COMMANDS;
-  }, [data, isError]);
+    return mapped.length > 0 ? mapped : FALLBACK_SLASH_COMMANDS
+  }, [data, isError])
 }
 
 // Exported for tests.
@@ -141,4 +144,4 @@ export const __test__ = {
   toAutocomplete,
   COMMAND_ICONS,
   DEFAULT_ICON,
-};
+}

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -3,25 +3,25 @@
  * Keeps Wikipedia IA + editorial serif hierarchy for articles only.
  */
 .wiki-root {
-  --wk-paper: var(--bg);
-  --wk-paper-dark: var(--bg-warm);
-  --wk-surface: var(--bg-card);
-  --wk-text: var(--text);
-  --wk-text-muted: var(--text-secondary);
-  --wk-text-tertiary: var(--text-tertiary);
-  --wk-border: var(--border);
-  --wk-border-light: var(--border-light);
-  --wk-border-strong: var(--border-dark);
-  --wk-wikilink: var(--olive-500);
+  --wk-paper:           var(--bg);
+  --wk-paper-dark:      var(--bg-warm);
+  --wk-surface:         var(--bg-card);
+  --wk-text:            var(--text);
+  --wk-text-muted:      var(--text-secondary);
+  --wk-text-tertiary:   var(--text-tertiary);
+  --wk-border:          var(--border);
+  --wk-border-light:    var(--border-light);
+  --wk-border-strong:   var(--border-dark);
+  --wk-wikilink:        var(--olive-500);
   --wk-wikilink-broken: var(--red);
-  --wk-amber: var(--olive-500);
-  --wk-amber-bg: var(--olive-200);
-  --wk-amber-banner: var(--olive-100);
-  --wk-code-bg: var(--bg-warm);
-  --wk-display: var(--font-sans);
-  --wk-body-serif: "Source Serif 4", ui-serif, Georgia, serif;
-  --wk-chrome: var(--font-sans);
-  --wk-mono: var(--font-mono);
+  --wk-amber:           var(--olive-500);
+  --wk-amber-bg:        var(--olive-200);
+  --wk-amber-banner:    var(--olive-100);
+  --wk-code-bg:         var(--bg-warm);
+  --wk-display:    var(--font-sans);
+  --wk-body-serif: 'Source Serif 4', ui-serif, Georgia, serif;
+  --wk-chrome:     var(--font-sans);
+  --wk-mono:       var(--font-mono);
   --wk-sidebar-left: 240px;
   --wk-sidebar-right: 280px;
   --wk-article-max: 640px;
@@ -36,30 +36,20 @@
   flex-direction: column;
   min-height: 0;
 }
-.wiki-root * {
-  box-sizing: border-box;
-}
-.wiki-root a {
-  color: var(--wk-wikilink);
-  text-decoration: none;
-}
+.wiki-root * { box-sizing: border-box; }
+.wiki-root a { color: var(--wk-wikilink); text-decoration: none; }
 
 /* ─── 3-column layout ─── */
 .wiki-layout {
   display: grid;
-  grid-template-columns: var(--wk-sidebar-left) minmax(0, 1fr) var(
-      --wk-sidebar-right
-    );
+  grid-template-columns: var(--wk-sidebar-left) minmax(0, 1fr) var(--wk-sidebar-right);
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
 }
 .wiki-layout > .wk-catalog,
 .wiki-layout > .wk-article-col,
-.wiki-layout > .wk-toc-col {
-  min-height: 0;
-  overflow-y: auto;
-}
+.wiki-layout > .wk-toc-col { min-height: 0; overflow-y: auto; }
 /* Catalog has no right rail — give the main column all the remaining space. */
 .wiki-layout[data-view="catalog"] {
   grid-template-columns: var(--wk-sidebar-left) minmax(0, 1fr);
@@ -87,15 +77,8 @@
   padding: 16px 0 16px;
   scrollbar-width: none;
 }
-.wk-nav-sidebar-scroll::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-}
-.wk-nav-sidebar-scroll > div {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
+.wk-nav-sidebar-scroll::-webkit-scrollbar { width: 0; height: 0; }
+.wk-nav-sidebar-scroll > div { display: flex; flex-direction: column; gap: 2px; }
 .wk-nav-sidebar h3 {
   font-family: var(--wk-chrome);
   font-size: 10px;
@@ -106,14 +89,7 @@
   margin: 0 0 4px;
   padding: 0 10px;
 }
-.wk-nav-sidebar ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
+.wk-nav-sidebar ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; }
 .wk-nav-sidebar li a {
   display: flex;
   align-items: center;
@@ -125,10 +101,7 @@
   line-height: 1.3;
   cursor: pointer;
 }
-.wk-nav-sidebar li a:hover {
-  background: var(--wk-paper-dark);
-  color: var(--wk-text);
-}
+.wk-nav-sidebar li a:hover { background: var(--wk-paper-dark); color: var(--wk-text); }
 .wk-nav-sidebar li.current a {
   background: var(--wk-amber-bg);
   color: var(--wk-text);
@@ -146,16 +119,10 @@
   outline: none;
   transition: border-color 0.15s;
 }
-.wk-nav-sidebar .search:focus {
-  border-color: var(--wk-wikilink);
-}
-.wk-nav-sidebar .tools-sep {
-  border: 0;
-  border-top: 1px solid var(--wk-border);
-  margin: 8px 0 0;
-}
+.wk-nav-sidebar .search:focus { border-color: var(--wk-wikilink); }
+.wk-nav-sidebar .tools-sep { border: 0; border-top: 1px solid var(--wk-border); margin: 8px 0 0; }
 .wk-nav-sidebar .tools li a::before {
-  content: "→ ";
+  content: '→ ';
   color: var(--wk-text-tertiary);
   font-family: var(--wk-mono);
 }
@@ -163,10 +130,7 @@
 /* ─── CENTER article column ─── */
 /* position: relative creates the positioning context for .pam-wrap (see
  * styles/pam.css) — Pam's desk hangs off the top-right of the column. */
-.wk-article-col {
-  padding: 0 64px 120px;
-  position: relative;
-}
+.wk-article-col { padding: 0 64px 120px; position: relative; }
 
 /* ─── Status banner ─── */
 .wk-status-banner {
@@ -182,31 +146,20 @@
   gap: 12px;
 }
 .wk-status-banner .wk-icon {
-  width: 6px;
-  height: 6px;
+  width: 6px; height: 6px;
   background: var(--wk-amber);
   border-radius: 50%;
   animation: wk-pulse 1.8s ease-in-out infinite;
   flex-shrink: 0;
 }
-.wk-status-banner strong {
-  font-weight: 600;
-}
+.wk-status-banner strong { font-weight: 600; }
 .wk-status-banner .wk-meta {
   margin-left: auto;
   color: var(--wk-text-muted);
   font-family: var(--wk-mono);
   font-size: 11px;
 }
-@keyframes wk-pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.4;
-  }
-}
+@keyframes wk-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
 
 /* ─── Hat-bar ─── */
 .wk-hatbar {
@@ -236,13 +189,8 @@
   font-weight: 500;
   background: var(--wk-paper);
 }
-.wk-hatbar .wk-tab:hover:not(.active):not(:disabled) {
-  color: var(--wk-text);
-}
-.wk-hatbar .wk-tab:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
-}
+.wk-hatbar .wk-tab:hover:not(.active):not(:disabled) { color: var(--wk-text); }
+.wk-hatbar .wk-tab:disabled { opacity: 0.45; cursor: not-allowed; }
 .wk-hatbar .wk-rail-right {
   margin-left: auto;
   display: flex;
@@ -263,16 +211,9 @@
   align-items: center;
   gap: 6px;
 }
-.wk-breadcrumb a {
-  color: var(--wk-text-muted);
-  cursor: pointer;
-}
-.wk-breadcrumb a:hover {
-  color: var(--wk-wikilink);
-}
-.wk-breadcrumb .sep {
-  color: var(--wk-text-tertiary);
-}
+.wk-breadcrumb a { color: var(--wk-text-muted); cursor: pointer; }
+.wk-breadcrumb a:hover { color: var(--wk-wikilink); }
+.wk-breadcrumb .sep { color: var(--wk-text-tertiary); }
 
 /* ─── Title ─── */
 .wk-article-title {
@@ -317,10 +258,7 @@
   width: 22px;
   height: 22px;
 }
-.wk-byline .wk-name {
-  color: var(--wk-text);
-  font-weight: 500;
-}
+.wk-byline .wk-name { color: var(--wk-text); font-weight: 500; }
 .wk-byline .wk-ts {
   background: var(--wk-amber-bg);
   padding: 2px 8px;
@@ -333,7 +271,7 @@
   gap: 6px;
 }
 .wk-byline .wk-ts::before {
-  content: "";
+  content: '';
   width: 6px;
   height: 6px;
   background: var(--wk-amber);
@@ -341,12 +279,8 @@
   display: inline-block;
   animation: wk-pulse 1.8s ease-in-out infinite;
 }
-.wk-byline .wk-dot {
-  color: var(--wk-text-tertiary);
-}
-.wk-byline .wk-started-date {
-  color: var(--wk-text);
-}
+.wk-byline .wk-dot { color: var(--wk-text-tertiary); }
+.wk-byline .wk-started-date { color: var(--wk-text); }
 
 /* ─── Hatnote ─── */
 .wk-hatnote {
@@ -373,9 +307,7 @@
   color: var(--wk-text);
   max-width: var(--wk-article-max);
 }
-.wk-article-body p {
-  margin: 0 0 18px;
-}
+.wk-article-body p { margin: 0 0 18px; }
 .wk-article-body h2 {
   font-family: var(--wk-display);
   font-size: 28px;
@@ -395,17 +327,9 @@
   margin: 28px 0 10px;
   font-variation-settings: "opsz" 24;
 }
-.wk-article-body ul,
-.wk-article-body ol {
-  margin: 0 0 18px 24px;
-  padding: 0;
-}
-.wk-article-body li {
-  margin-bottom: 6px;
-}
-.wk-article-body strong {
-  font-weight: 600;
-}
+.wk-article-body ul, .wk-article-body ol { margin: 0 0 18px 24px; padding: 0; }
+.wk-article-body li { margin-bottom: 6px; }
+.wk-article-body strong { font-weight: 600; }
 .wk-article-body a.wk-wikilink,
 .wk-article-body a[data-wikilink="true"] {
   color: var(--wk-wikilink);
@@ -426,7 +350,7 @@
 }
 .wk-article-body a.wk-wikilink.wk-broken::after,
 .wk-article-body a[data-wikilink="true"][data-broken="true"]::after {
-  content: " ⚬";
+  content: ' ⚬';
   font-size: 0.7em;
   opacity: 0.6;
 }
@@ -451,17 +375,15 @@
   padding: 8px 12px;
   text-align: left;
   vertical-align: top;
-  border-bottom: 1px solid var(--wk-border, rgba(0, 0, 0, 0.08));
+  border-bottom: 1px solid var(--wk-border, rgba(0,0,0,0.08));
 }
 .wk-article-body table th {
   font-weight: 600;
   color: var(--wk-text, inherit);
-  border-bottom: 1px solid var(--wk-text, rgba(0, 0, 0, 0.35));
+  border-bottom: 1px solid var(--wk-text, rgba(0,0,0,0.35));
   background: transparent;
 }
-.wk-article-body table tbody tr:hover {
-  background: rgba(0, 0, 0, 0.02);
-}
+.wk-article-body table tbody tr:hover { background: rgba(0,0,0,0.02); }
 
 /* ─── Infobox ─── */
 .wk-infobox {
@@ -484,20 +406,14 @@
   padding: 8px 12px;
   text-align: center;
 }
-.wk-infobox .wk-ib-body {
-  padding: 12px;
-}
+.wk-infobox .wk-ib-body { padding: 12px; }
 .wk-infobox dl {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 6px 10px;
   margin: 0;
 }
-.wk-infobox dt {
-  color: var(--wk-text-muted);
-  font-family: var(--wk-chrome);
-  font-weight: 500;
-}
+.wk-infobox dt { color: var(--wk-text-muted); font-family: var(--wk-chrome); font-weight: 500; }
 .wk-infobox dd {
   color: var(--wk-text);
   font-variant-numeric: tabular-nums;
@@ -511,9 +427,7 @@
 }
 
 /* ─── See also ─── */
-.wk-see-also {
-  margin: 48px 0 24px;
-}
+.wk-see-also { margin: 48px 0 24px; }
 .wk-see-also h2 {
   font-family: var(--wk-display);
   font-size: 22px;
@@ -530,10 +444,7 @@
   font-size: 16px;
   font-style: italic;
 }
-.wk-see-also li {
-  margin-bottom: 4px;
-  line-height: 1.5;
-}
+.wk-see-also li { margin-bottom: 4px; line-height: 1.5; }
 .wk-see-also a {
   color: var(--wk-wikilink);
   text-decoration: underline;
@@ -557,23 +468,14 @@
   padding-bottom: 6px;
   color: var(--wk-text);
 }
-.wk-sources ol {
-  list-style: decimal;
-  margin: 0 0 0 24px;
-  padding: 0;
-}
-.wk-sources li {
-  margin-bottom: 6px;
-}
+.wk-sources ol { list-style: decimal; margin: 0 0 0 24px; padding: 0; }
+.wk-sources li { margin-bottom: 6px; }
 .wk-sources li a {
   color: var(--wk-wikilink);
   font-family: var(--wk-mono);
   font-size: 12px;
 }
-.wk-sources li .wk-commit-msg {
-  color: var(--wk-text);
-  font-family: var(--wk-body-serif);
-}
+.wk-sources li .wk-commit-msg { color: var(--wk-text); font-family: var(--wk-body-serif); }
 .wk-sources li .wk-agent {
   display: inline-flex;
   align-items: center;
@@ -610,11 +512,7 @@
   align-items: center;
   gap: 6px 4px;
 }
-.wk-categories .wk-label {
-  font-weight: 600;
-  margin-right: 6px;
-  color: var(--wk-text);
-}
+.wk-categories .wk-label { font-weight: 600; margin-right: 6px; color: var(--wk-text); }
 .wk-categories a {
   background: var(--wk-paper-dark);
   color: var(--wk-text);
@@ -623,9 +521,7 @@
   border: 1px solid var(--wk-border);
   font-size: 12px;
 }
-.wk-categories a:hover {
-  background: var(--wk-amber-bg);
-}
+.wk-categories a:hover { background: var(--wk-amber-bg); }
 
 /* ─── Page footer ─── */
 .wk-page-footer {
@@ -643,22 +539,10 @@
   flex-wrap: wrap;
   gap: 0 14px;
 }
-.wk-page-footer .wk-actions a {
-  color: var(--wk-wikilink);
-  cursor: pointer;
-}
-.wk-page-footer .wk-dim {
-  color: var(--wk-text-tertiary);
-  font-style: italic;
-  margin-top: 8px;
-}
-.wk-page-footer .wk-last-edit-name {
-  color: var(--wk-text);
-  font-weight: 500;
-}
-.wk-page-footer .wk-last-edit-ts {
-  color: var(--wk-text);
-}
+.wk-page-footer .wk-actions a { color: var(--wk-wikilink); cursor: pointer; }
+.wk-page-footer .wk-dim { color: var(--wk-text-tertiary); font-style: italic; margin-top: 8px; }
+.wk-page-footer .wk-last-edit-name { color: var(--wk-text); font-weight: 500; }
+.wk-page-footer .wk-last-edit-ts { color: var(--wk-text); }
 
 /* ─── RIGHT SIDEBAR ─── */
 .wk-right-sidebar {
@@ -732,23 +616,10 @@
   color: var(--wk-text);
   cursor: pointer;
 }
-.wk-toc-nested a.wk-lvl-1 {
-  font-weight: 500;
-}
-.wk-toc-nested a.wk-lvl-2 {
-  padding-left: 20px;
-  font-size: 12px;
-  color: var(--wk-text-muted);
-}
-.wk-toc-nested a.wk-lvl-3 {
-  padding-left: 36px;
-  font-size: 12px;
-  color: var(--wk-text-tertiary);
-}
-.wk-toc-nested a.wk-lvl-1:hover,
-.wk-toc-nested a.wk-lvl-2:hover {
-  color: var(--wk-wikilink);
-}
+.wk-toc-nested a.wk-lvl-1 { font-weight: 500; }
+.wk-toc-nested a.wk-lvl-2 { padding-left: 20px; font-size: 12px; color: var(--wk-text-muted); }
+.wk-toc-nested a.wk-lvl-3 { padding-left: 36px; font-size: 12px; color: var(--wk-text-tertiary); }
+.wk-toc-nested a.wk-lvl-1:hover, .wk-toc-nested a.wk-lvl-2:hover { color: var(--wk-wikilink); }
 .wk-toc-nested a .wk-num {
   color: var(--wk-text-tertiary);
   font-variant-numeric: tabular-nums;
@@ -770,10 +641,7 @@
   font-size: 12px;
   margin: 0;
 }
-.wk-stats-panel dt {
-  color: var(--wk-text-tertiary);
-  font-family: var(--wk-chrome);
-}
+.wk-stats-panel dt { color: var(--wk-text-tertiary); font-family: var(--wk-chrome); }
 .wk-stats-panel dd {
   color: var(--wk-text);
   font-family: var(--wk-mono);
@@ -800,10 +668,7 @@
   gap: 8px;
   margin-bottom: 6px;
 }
-.wk-cite-panel .wk-wikilink-code code {
-  background: transparent;
-  padding: 0;
-}
+.wk-cite-panel .wk-wikilink-code code { background: transparent; padding: 0; }
 .wk-cite-panel .wk-copy-btn {
   margin-left: auto;
   background: var(--wk-text);
@@ -832,9 +697,7 @@
   font-size: 13px;
   cursor: pointer;
 }
-.wk-backlinks a:hover {
-  color: var(--wk-wikilink);
-}
+.wk-backlinks a:hover { color: var(--wk-wikilink); }
 .wk-backlinks a .wk-avatar {
   image-rendering: pixelated;
   border-radius: 4px;
@@ -865,20 +728,10 @@
   scrollbar-width: thin;
   scrollbar-color: var(--wk-border-strong) transparent;
 }
-.wk-edit-log::-webkit-scrollbar {
-  height: 6px;
-  width: 6px;
-}
-.wk-edit-log::-webkit-scrollbar-track {
-  background: transparent;
-}
-.wk-edit-log::-webkit-scrollbar-thumb {
-  background: var(--wk-border-strong);
-  border-radius: 3px;
-}
-.wk-edit-log::-webkit-scrollbar-thumb:hover {
-  background: var(--wk-text-tertiary);
-}
+.wk-edit-log::-webkit-scrollbar { height: 6px; width: 6px; }
+.wk-edit-log::-webkit-scrollbar-track { background: transparent; }
+.wk-edit-log::-webkit-scrollbar-thumb { background: var(--wk-border-strong); border-radius: 3px; }
+.wk-edit-log::-webkit-scrollbar-thumb:hover { background: var(--wk-text-tertiary); }
 .wk-edit-log .wk-label {
   font-weight: 600;
   color: var(--wk-text-tertiary);
@@ -899,24 +752,16 @@
   width: 14px;
   height: 14px;
 }
-.wk-edit-log .wk-entry .wk-who {
-  color: var(--wk-text);
-  font-weight: 500;
-}
-.wk-edit-log .wk-entry .wk-action {
-  color: var(--wk-text-muted);
-}
-.wk-edit-log .wk-entry .wk-what {
-  color: var(--wk-wikilink);
-  cursor: pointer;
-}
+.wk-edit-log .wk-entry .wk-who { color: var(--wk-text); font-weight: 500; }
+.wk-edit-log .wk-entry .wk-action { color: var(--wk-text-muted); }
+.wk-edit-log .wk-entry .wk-what { color: var(--wk-wikilink); cursor: pointer; }
 .wk-edit-log .wk-entry .wk-when {
   color: var(--wk-text-tertiary);
   font-family: var(--wk-mono);
   font-size: 11px;
 }
 .wk-edit-log .wk-entry.wk-live::before {
-  content: "";
+  content: '';
   width: 6px;
   height: 6px;
   background: var(--wk-amber);
@@ -949,12 +794,8 @@
   padding-bottom: 14px;
   border-bottom: 1px solid var(--wk-border);
 }
-.wk-catalog-title {
-  grid-area: title;
-}
-.wk-catalog-stats {
-  grid-area: stats;
-}
+.wk-catalog-title { grid-area: title; }
+.wk-catalog-stats { grid-area: stats; }
 .wk-catalog-clone {
   grid-area: clone;
   font-size: 13px;
@@ -989,14 +830,10 @@
   gap: 24px;
 }
 @media (max-width: 1024px) {
-  .wk-catalog-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  .wk-catalog-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
 }
 @media (max-width: 720px) {
-  .wk-catalog-grid {
-    grid-template-columns: 1fr;
-  }
+  .wk-catalog-grid { grid-template-columns: 1fr; }
 }
 .wk-catalog-card {
   background: var(--wk-surface);
@@ -1023,11 +860,7 @@
   font-family: var(--wk-mono);
   font-size: 11px;
 }
-.wk-catalog-card ul {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+.wk-catalog-card ul { list-style: none; margin: 0; padding: 0; }
 .wk-catalog-card li {
   display: grid;
   grid-template-columns: 16px 1fr auto;
@@ -1038,9 +871,7 @@
   border-bottom: 1px dashed var(--wk-border-light);
   font-size: 14px;
 }
-.wk-catalog-card li:last-child {
-  border-bottom: 0;
-}
+.wk-catalog-card li:last-child { border-bottom: 0; }
 .wk-catalog-card li .wk-avatar {
   image-rendering: pixelated;
   width: 16px;
@@ -1057,9 +888,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.wk-catalog-card li .wk-title:hover {
-  color: var(--wk-wikilink);
-}
+.wk-catalog-card li .wk-title:hover { color: var(--wk-wikilink); }
 .wk-catalog-card li .wk-when {
   font-family: var(--wk-mono);
   font-size: 11px;
@@ -1068,17 +897,10 @@
 }
 /* Narrow cards: drop the timestamp so the title gets full width. */
 @container wk-cat (max-width: 200px) {
-  .wk-catalog-card li {
-    grid-template-columns: 16px 1fr;
-  }
-  .wk-catalog-card li .wk-when {
-    display: none;
-  }
+  .wk-catalog-card li { grid-template-columns: 16px 1fr; }
+  .wk-catalog-card li .wk-when { display: none; }
 }
-.wk-catalog-card {
-  container-type: inline-size;
-  container-name: wk-cat;
-}
+.wk-catalog-card { container-type: inline-size; container-name: wk-cat; }
 
 /* ─── Loading / error states ─── */
 .wk-loading,
@@ -1089,8 +911,38 @@
   font-family: var(--wk-chrome);
   font-size: 14px;
 }
-.wk-error {
-  color: var(--wk-wikilink-broken);
+.wk-error { color: var(--wk-wikilink-broken); }
+
+/* Subtle spinner used for in-flight modal actions. Sized to sit inline with
+ * 13px button text without forcing a layout reflow. Wiki-surface scoped —
+ * no amber, no accent gradient; it uses the neutral border tokens so the
+ * spinner reads as "working" without stealing attention.
+ */
+.wk-spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--wk-border);
+  border-top-color: var(--wk-text-muted);
+  border-radius: 50%;
+  animation: wk-spin 0.6s linear infinite;
+  vertical-align: -2px;
+  margin-right: 6px;
+  flex-shrink: 0;
+}
+@keyframes wk-spin { to { transform: rotate(360deg); } }
+
+/* "Searching the wiki…" status line shown below the (virtual) lookup input
+ * while the /wiki/lookup request is in flight. Fraunces-italic per
+ * DESIGN-WIKI.md hatnote typography — light mode, no amber, no dark surfaces.
+ */
+.wk-lookup-status {
+  font-family: var(--wk-body-serif);
+  font-style: italic;
+  font-size: 15px;
+  line-height: 1.5;
+  color: var(--wk-text-muted);
+  margin: 0 0 12px;
 }
 
 /* ─── Audit log view (#/wiki/_audit) ─── */
@@ -1263,10 +1115,7 @@
   padding: 1px 8px;
   margin-left: 4px;
 }
-.wk-audit-row.is-bootstrap .wk-audit-tag {
-  color: var(--wk-accent-ink);
-  border-color: var(--wk-accent);
-}
+.wk-audit-row.is-bootstrap .wk-audit-tag { color: var(--wk-accent-ink); border-color: var(--wk-accent); }
 .wk-audit-msg {
   font-family: var(--wk-body);
   font-size: 13px;
@@ -1365,16 +1214,15 @@
   opacity: 0.7;
 }
 .wk-section-new {
-  font-family:
-    Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 9px;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   padding: 1px 5px;
   border-radius: 3px;
-  background: #cff5f5;
-  color: #0f5c5c;
+  background: #CFF5F5;
+  color: #0F5C5C;
 }
 .wk-section-empty {
   padding: 4px 10px;
@@ -1396,9 +1244,7 @@
   color: var(--wk-text);
   line-height: 1.4;
 }
-.wk-section-banner-body {
-  flex: 1;
-}
+.wk-section-banner-body { flex: 1; }
 .wk-section-banner-dismiss {
   background: transparent;
   border: none;
@@ -1408,9 +1254,7 @@
   line-height: 1;
   padding: 0 2px;
 }
-.wk-section-banner-dismiss:hover {
-  color: var(--wk-text);
-}
+.wk-section-banner-dismiss:hover { color: var(--wk-text); }
 
 /* Catalog header audit link */
 .wk-catalog-audit-link {
@@ -1440,9 +1284,7 @@
   text-decoration: underline dashed;
   text-underline-offset: 2px;
 }
-.wk-catalog-new-link:hover {
-  text-decoration-style: solid;
-}
+.wk-catalog-new-link:hover { text-decoration-style: solid; }
 
 .wk-editor {
   display: flex;
@@ -1506,10 +1348,7 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
-.wk-editor-cancel {
-  background: var(--wk-paper);
-  color: var(--wk-text);
-}
+.wk-editor-cancel { background: var(--wk-paper); color: var(--wk-text); }
 .wk-editor-help {
   font-family: var(--wk-chrome);
   font-size: 12px;
@@ -1687,9 +1526,7 @@
 .wk-entity-brief-bar--clean {
   color: var(--wk-text-muted);
 }
-.wk-entity-brief-bar__label {
-  flex: 1 1 auto;
-}
+.wk-entity-brief-bar__label { flex: 1 1 auto; }
 .wk-entity-brief-bar__label strong {
   font-weight: 600;
   color: var(--wk-text);
@@ -1750,9 +1587,7 @@
   padding: 8px 0;
   border-bottom: 1px dashed var(--wk-border-light);
 }
-.wk-facts-item:last-child {
-  border-bottom: none;
-}
+.wk-facts-item:last-child { border-bottom: none; }
 .wk-facts-item .wk-avatar {
   image-rendering: pixelated;
   width: 14px;
@@ -1793,10 +1628,7 @@
   color: var(--wk-text-tertiary);
   margin: 0;
 }
-.wk-facts-error {
-  color: var(--wk-wikilink-broken);
-  font-style: normal;
-}
+.wk-facts-error { color: var(--wk-wikilink-broken); font-style: normal; }
 .wk-facts-showall {
   margin-top: 10px;
   font-family: var(--wk-chrome);
@@ -1841,9 +1673,7 @@
   padding: 4px 0;
   border-bottom: 1px dashed var(--wk-border-light);
 }
-.wk-related-item:last-child {
-  border-bottom: none;
-}
+.wk-related-item:last-child { border-bottom: none; }
 .wk-related-link {
   color: var(--wk-wikilink);
   text-decoration: underline dashed;
@@ -1863,10 +1693,7 @@
   color: var(--wk-text-tertiary);
   margin: 0;
 }
-.wk-related-error {
-  color: var(--wk-wikilink-broken);
-  font-style: normal;
-}
+.wk-related-error { color: var(--wk-wikilink-broken); font-style: normal; }
 
 /* ─── Playbook compilation (v1.3) ─── */
 .wk-playbook-badge {
@@ -1970,9 +1797,7 @@
   padding: 10px 0;
   border-bottom: 1px dashed var(--wk-border-light);
 }
-.wk-playbook-execution:last-child {
-  border-bottom: none;
-}
+.wk-playbook-execution:last-child { border-bottom: none; }
 .wk-playbook-execution__pill {
   font-family: var(--wk-chrome);
   font-size: 10px;
@@ -2020,9 +1845,7 @@
   font-size: 11px;
   color: var(--wk-text-tertiary);
 }
-.wk-playbook-execution__meta time {
-  font-family: var(--wk-mono);
-}
+.wk-playbook-execution__meta time { font-family: var(--wk-mono); }
 .wk-playbook-executions__more {
   margin-top: 10px;
   font-family: var(--wk-chrome);
@@ -2077,9 +1900,7 @@
   color: var(--wk-body, #111);
   cursor: pointer;
   border-radius: 2px;
-  transition:
-    background 150ms ease,
-    opacity 150ms ease;
+  transition: background 150ms ease, opacity 150ms ease;
 }
 .wk-playbook-synthesis__button:hover:not([disabled]) {
   background: rgba(0, 0, 0, 0.04);
@@ -2088,11 +1909,11 @@
   opacity: 0.6;
   cursor: progress;
 }
-.wk-playbook-synthesis[data-state="success"] .wk-playbook-synthesis__button {
+.wk-playbook-synthesis[data-state='success'] .wk-playbook-synthesis__button {
   color: #2a7d2a;
   border-color: #2a7d2a;
 }
-.wk-playbook-synthesis[data-state="error"] .wk-playbook-synthesis__button {
+.wk-playbook-synthesis[data-state='error'] .wk-playbook-synthesis__button {
   color: #c94a4a;
   border-color: #c94a4a;
 }
@@ -2147,12 +1968,8 @@
   }
 }
 @keyframes image-embed-fade {
-  from {
-    opacity: 0;
-  }
-  to {
-    opacity: 1;
-  }
+  from { opacity: 0; }
+  to   { opacity: 1; }
 }
 .image-embed__full {
   max-width: 90vw;


### PR DESCRIPTION
## Summary

Slice 2 Thread E of the wiki intelligence port — frontend-only polish for the Thread A–D user touch points.

- **ResolveContradictionModal pending state.** Clicked pick button shows a subtle neutral spinner + "Resolving…" label inline; all three picks + Cancel go disabled while the POST is in flight. `aria-busy` set on the pending button for a11y. No layout shift — spinner is an inline 12×12 element with margin-right for the label gap. On error, the existing inline banner surfaces the message (no error toast).
- **Post-resolve success toast with commit sha.** After `resolveContradiction` returns, fires a `success`-type toast with copy `Resolved. Commit {short_sha}.` (7-char sha, git's default width). No commit-viewer route exists yet, so sha is text in the toast body rather than a link — spec §4 explicitly allows this.
- **/lint autocomplete entry.** Extends `FALLBACK_SLASH_COMMANDS` (and the matching broker-icon map) with `/lint` and `/lookup`. Descriptions match the Thread E copy spec verbatim (`"Review wiki for contradictions and stale facts."` for lint, `"Cited answer from the team wiki"` for lookup). The broker already registers both with `webSupported=true`, so live deployments worked — this brings the offline fallback back in line.
- **/lookup loading line.** Replaces the skeleton blocks in `CitedAnswer`'s loading state with a single Fraunces-italic "Searching the wiki…" line. Matches DESIGN-WIKI.md hatnote typography (§9), preserves `role="status"` + `aria-busy`, renders via new `.wk-lookup-status` class. Light mode, no amber, no dark surfaces.

Shared primitive: scoped `.wk-spinner` in `web/src/styles/wiki.css`, neutral border + muted-text top color so it reads as "working" without stealing attention. Uses the global `@keyframes spin` that already lives in `global.css`.

## Design-system calls

- DESIGN-WIKI.md forbids amber as decoration; the spinner and status line use neutral tokens only.
- No purple, no gradients, no system-ui on body text — status line uses `var(--wk-body-serif)` italic.
- Toast reuses the existing global `showNotice` / `ToastContainer` primitive (no new UI lib).
- Operator-language preserved on severity labels ("Needs attention / Worth a look / FYI" already shipped in WikiLint; no change needed).

## Typecheck + tests

- `npm run typecheck` — clean.
- `npm test` — **68 files, 388 tests passing**. New tests:
  - `ResolveContradictionModal.test.tsx` × 4 — pending spinner, inline-error (no toast), short-sha toast, empty-sha fallback toast.
  - `useCommands.test.ts` +2 — lock in the /lookup and /lint fallback copy.
  - `CitedAnswer.test.tsx` — rewrites the skeleton assertion to assert the Fraunces-italic status line.

## Test plan

- [ ] Manually hit `/lookup who is sarah?` in the composer — confirm the `wiki-lookup` view shows "Searching the wiki…" in Fraunces italic while the request is in flight.
- [ ] Type `/l` in the composer — confirm autocomplete lists `/lookup`, `/lint`, and other `/l…` commands.
- [ ] Open the wiki health check (`/lint` → contradictions finding) → click Resolve → click Fact A. Confirm the spinner renders inline on Fact A only, Cancel is disabled, and on success a toast reads "Resolved. Commit abc1234."
- [ ] Force the resolve endpoint to fail (e.g. broker offline) — confirm the error renders inside the modal banner, not a toast, and the buttons re-enable so the user can retry.

## Skipped

- Screenshots/GIFs: running headless in a worktree without a dev server, and the task spec explicitly says to skip if we can't capture them headlessly.
- Playwright E2E for /lookup spinner > 200ms (mentioned under Thread E "Tests"): Playwright is an e2e package in `web/e2e/` — would require a running dev server and broker. Unit coverage in `CitedAnswer.test.tsx` pins the loading-state markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/lookup` and `/lint` slash commands to autocomplete.

* **UI/UX Improvements**
  * Replaced skeleton loaders with a "Searching the wiki…" status message during wiki searches.
  * Enhanced contradiction resolution modal with per-button loading states and spinners.
  * Added success toast notifications showing commit information after resolving contradictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->