### PR TITLE
feat(wiki): Slice 2 Thread C — playbook clusters surface reinforced patterns

### DIFF
--- a/internal/team/entity_commit.go
+++ b/internal/team/entity_commit.go
@@ -198,15 +198,21 @@ func (r *Repo) CommitFactLog(ctx context.Context, slug, relPath, content, messag
 	return strings.TrimSpace(sha), len(content), nil
 }
 
-// AppendFactLog appends newlineContent to the fact-log file at relPath and
+// AppendFactLog appends additionalContent to the fact-log file at relPath and
 // commits the resulting bytes. The file is created if it does not exist.
 // `additionalContent` must be the raw bytes to append — the caller is
 // responsible for newline-terminating each JSONL record. A trailing newline
 // is added if missing so the final file always ends with "\n".
 //
-// Uses the repo-wide write lock so the read-modify-write sequence is safe
-// against concurrent appenders; the WikiWorker single-writer invariant
-// (§11.5, Anti-pattern 5) routes every caller through this path.
+// Uses the repo-wide write lock so concurrent appenders are serialised; the
+// WikiWorker single-writer invariant (§11.5, Anti-pattern 5) routes every
+// caller through this path.
+//
+// Implementation: O_APPEND on a per-open fd. Cheaper than the earlier
+// read-modify-write for prolific entities whose JSONL files can grow past a
+// few MB — each append is O(bytesWritten) instead of O(filesize). The
+// repo-wide mutex still guarantees exclusivity for the non-atomic
+// "fstat + write" sequence we need to keep the trailing-newline invariant.
 //
 // The accepted relPath shape matches Repo.CommitFactLog: wiki/facts/**/*.jsonl
 // or team/entities/*.facts.jsonl.
@@ -235,27 +241,55 @@ func (r *Repo) AppendFactLog(ctx context.Context, slug, relPath, additionalConte
 		return "", 0, fmt.Errorf("fact append: mkdir: %w", err)
 	}
 
-	var existing []byte
-	if b, err := os.ReadFile(fullPath); err == nil {
-		existing = b
-	} else if !os.IsNotExist(err) {
-		return "", 0, fmt.Errorf("fact append: read existing: %w", err)
+	// Probe the trailing byte (if any) via a short read-only handle so we can
+	// insert a separator newline only when needed. Cheap — reads at most one
+	// byte, regardless of file size. The repo-wide mutex above guarantees no
+	// other writer can change the tail between this probe and our append.
+	// (ReadAt on an O_APPEND|O_WRONLY fd returns EBADF on macOS, so the
+	// probe uses its own short-lived read-only fd before the append fd.)
+	needsLeadingNewline := false
+	if fi, statErr := os.Stat(fullPath); statErr == nil {
+		if fi.Size() > 0 {
+			rf, rerr := os.Open(fullPath)
+			if rerr != nil {
+				return "", 0, fmt.Errorf("fact append: probe open: %w", rerr)
+			}
+			last := make([]byte, 1)
+			_, readErr := rf.ReadAt(last, fi.Size()-1)
+			_ = rf.Close()
+			if readErr != nil {
+				return "", 0, fmt.Errorf("fact append: probe tail: %w", readErr)
+			}
+			if last[0] != '\n' {
+				needsLeadingNewline = true
+			}
+		}
+	} else if !os.IsNotExist(statErr) {
+		return "", 0, fmt.Errorf("fact append: stat: %w", statErr)
 	}
 
-	var buf []byte
-	buf = append(buf, existing...)
-	// Guarantee a newline between existing and new content.
-	if len(buf) > 0 && buf[len(buf)-1] != '\n' {
+	// Build the payload: leading newline iff tail lacks one, new content, and
+	// a trailing newline if the caller didn't include one. Written in a
+	// single Write under O_APPEND so readers never observe a partial tail.
+	buf := make([]byte, 0, len(additionalContent)+2)
+	if needsLeadingNewline {
 		buf = append(buf, '\n')
 	}
 	buf = append(buf, []byte(additionalContent)...)
-	// Guarantee trailing newline so reconcile reads every line.
-	if len(buf) > 0 && buf[len(buf)-1] != '\n' {
+	if len(buf) == 0 || buf[len(buf)-1] != '\n' {
 		buf = append(buf, '\n')
 	}
 
-	if err := os.WriteFile(fullPath, buf, 0o600); err != nil {
-		return "", 0, fmt.Errorf("fact append: write: %w", err)
+	f, err := os.OpenFile(fullPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return "", 0, fmt.Errorf("fact append: open: %w", err)
+	}
+	if _, werr := f.Write(buf); werr != nil {
+		_ = f.Close()
+		return "", 0, fmt.Errorf("fact append: write: %w", werr)
+	}
+	if cerr := f.Close(); cerr != nil {
+		return "", 0, fmt.Errorf("fact append: close: %w", cerr)
 	}
 
 	if out, err := r.runGitLocked(ctx, slug, "add", "--", clean); err != nil {

--- a/internal/team/playbook_clusters.go
+++ b/internal/team/playbook_clusters.go
@@ -1,0 +1,206 @@
+package team
+
+// playbook_clusters.go implements Slice 2 Thread C of the wiki intelligence
+// port: surface "patterns across entities" in playbook synthesis by grouping
+// reinforced facts that share the same (predicate, object) pair across a
+// threshold-minimum number of distinct entities.
+//
+// Read-only consumer of the fact log (§7.4 rebuild contract). Never mutates
+// facts — enforcement of the single-writer invariant lives in WikiWorker.
+//
+// The live signal for "reinforced" is TypedFact.ReinforcedAt != nil; when the
+// same content-hashed fact is re-extracted, the indexing path in
+// wiki_extractor.go advances ReinforcedAt on the in-memory row (no new JSONL
+// line is appended). That is the only reinforcement counter v1.2 exposes, so
+// the cluster predicate is simply "at least one reinforced fact per entity".
+//
+// Slice 2 scope (per WIKI-SLICE2-PLAN.md Thread C):
+//   - cluster detection is a full scan over ListAllFacts. Bounded by fact
+//     count (~500 at bench time). Acceptable for Slice 2; if the corpus
+//     grows past ~10k facts, introduce a (predicate, object) SQL index.
+//   - no aggregation beyond "distinct entity count per (predicate, object)".
+//     Slice 3 may expand to weighted clustering.
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+)
+
+// factCountWarnThreshold is the corpus size at which clusterReinforcedFacts
+// logs a heads-up that the unbounded ListAllFacts scan is past its Slice 2
+// bench-time envelope (~500 facts). Operators who see this line in the
+// broker log should schedule the Slice 3 (predicate, object) SQL index
+// rollout. Not a fail — never truncate silently at read-time.
+//
+// Easy to tune: change this single value, no plumbing. Exported as a test
+// hook via setFactCountWarnThresholdForTest so we don't need to seed 5k
+// rows in unit tests.
+const factCountWarnThreshold = 5000
+
+// factCountWarnThresholdOverride lets tests bind a smaller threshold so the
+// warning path is exercisable without materialising 5k rows. Zero means
+// "use the production constant".
+var factCountWarnThresholdOverride int
+
+// setFactCountWarnThresholdForTest swaps the active threshold and returns a
+// restore function. Test-only — production callers never touch this.
+func setFactCountWarnThresholdForTest(v int) func() {
+	prev := factCountWarnThresholdOverride
+	factCountWarnThresholdOverride = v
+	return func() { factCountWarnThresholdOverride = prev }
+}
+
+func activeFactCountWarnThreshold() int {
+	if factCountWarnThresholdOverride > 0 {
+		return factCountWarnThresholdOverride
+	}
+	return factCountWarnThreshold
+}
+
+// FactCluster is one reinforced (predicate, object) pair observed across
+// multiple distinct entities. Emitted by clusterReinforcedFacts as input to
+// the v2 playbook synthesis prompt (§Thread C, WIKI-SLICE2-PLAN.md).
+//
+// Entities are the distinct entity slugs whose fact logs contain a reinforced
+// fact matching (Predicate, Object). Count is len(Entities), surfaced as a
+// separate field so the prompt template can print it without a template
+// function.
+//
+// Count reflects distinct entities where the fact was confirmed via
+// re-extraction (ReinforcedAt != nil), not all entities where the fact was
+// observed. Facts seen only once never enter a cluster.
+type FactCluster struct {
+	Predicate string   `json:"predicate"`
+	Object    string   `json:"object"`
+	Entities  []string `json:"entities"`
+	Count     int      `json:"count"`
+}
+
+// clusterReinforcedFacts scans the fact store and returns clusters of
+// reinforced facts that share a (predicate, object) pair across at least
+// minDistinctEntities distinct entities.
+//
+// Parameters:
+//   - store: any FactStore. The SQLite and in-memory backends both satisfy
+//     the contract. Read-only — this function never calls Upsert*.
+//   - predicateFilter: when non-empty, only facts with Triplet.Predicate
+//     equal to this value contribute to clusters. Empty string means
+//     "consider every predicate". The synthesizer uses the empty filter by
+//     default; tests pin it to single predicates for readable assertions.
+//   - minDistinctEntities: minimum count of distinct entity slugs required
+//     for a (predicate, object) pair to be emitted as a cluster. Values < 2
+//     are clamped to 2 — a single-entity "cluster" is not a pattern.
+//   - topN: cap on the number of clusters returned. Clusters are sorted
+//     strongest-first, so the head slice is the most informative window.
+//     Values ≤ 0 mean "return every qualifying cluster" (unbounded).
+//
+// When the underlying fact count exceeds factCountWarnThreshold a warning is
+// logged to stderr via the broker log. We never fail or truncate — silent
+// truncation would mask corpus growth from operators.
+//
+// Facts with nil Triplet or ReinforcedAt == nil are skipped. Clusters are
+// returned sorted by (Count desc, Predicate asc, Object asc) so prompt
+// output is stable across runs.
+func clusterReinforcedFacts(
+	ctx context.Context,
+	store FactStore,
+	predicateFilter string,
+	minDistinctEntities int,
+	topN int,
+) ([]FactCluster, error) {
+	if store == nil {
+		return nil, fmt.Errorf("playbook_clusters: nil fact store")
+	}
+	if minDistinctEntities < 2 {
+		minDistinctEntities = 2
+	}
+
+	// Observability guard for the unbounded ListAllFacts scan. CountFacts is
+	// cheap on both backends; the warning fires once per synthesis run so it
+	// flags growth without spamming the log.
+	if count, cerr := store.CountFacts(ctx); cerr != nil {
+		// CountFacts failure is non-fatal — fall through to the scan and let
+		// the underlying ListAllFacts error (if any) bubble up instead.
+		log.Printf("playbook clusters: count facts failed (continuing): %v", cerr)
+	} else if threshold := activeFactCountWarnThreshold(); count > threshold {
+		log.Printf("playbook clusters: fact count %d exceeds %d — consider paging", count, threshold)
+	}
+
+	facts, err := store.ListAllFacts(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("playbook_clusters: list all facts: %w", err)
+	}
+
+	// Bucket reinforced facts by (predicate, object). Use a set of entity
+	// slugs per bucket so a single entity reinforcing the same pair many
+	// times does not inflate the count.
+	type key struct{ predicate, object string }
+	buckets := map[key]map[string]struct{}{}
+
+	for _, f := range facts {
+		if f.Triplet == nil {
+			continue
+		}
+		if f.ReinforcedAt == nil {
+			continue
+		}
+		predicate := strings.TrimSpace(f.Triplet.Predicate)
+		object := strings.TrimSpace(f.Triplet.Object)
+		if predicate == "" || object == "" {
+			continue
+		}
+		if predicateFilter != "" && predicate != predicateFilter {
+			continue
+		}
+		entity := strings.TrimSpace(f.EntitySlug)
+		if entity == "" {
+			continue
+		}
+		k := key{predicate: predicate, object: object}
+		set, ok := buckets[k]
+		if !ok {
+			set = map[string]struct{}{}
+			buckets[k] = set
+		}
+		set[entity] = struct{}{}
+	}
+
+	var out []FactCluster
+	for k, set := range buckets {
+		if len(set) < minDistinctEntities {
+			continue
+		}
+		entities := make([]string, 0, len(set))
+		for slug := range set {
+			entities = append(entities, slug)
+		}
+		sort.Strings(entities)
+		out = append(out, FactCluster{
+			Predicate: k.predicate,
+			Object:    k.object,
+			Entities:  entities,
+			Count:     len(entities),
+		})
+	}
+
+	// Stable ordering: strongest clusters first, then lexical tiebreakers.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		if out[i].Predicate != out[j].Predicate {
+			return out[i].Predicate < out[j].Predicate
+		}
+		return out[i].Object < out[j].Object
+	})
+	// Head-slice at topN if set. Saves the downstream allocation of the
+	// tail clusters the caller would throw away anyway. topN ≤ 0 means
+	// "unbounded" — callers that want every cluster pass 0.
+	if topN > 0 && len(out) > topN {
+		out = out[:topN]
+	}
+	return out, nil
+}

--- a/internal/team/playbook_clusters_test.go
+++ b/internal/team/playbook_clusters_test.go
@@ -1,0 +1,414 @@
+package team
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newClusterTestStore builds an in-memory fact store seeded with the given
+// facts. The helper stamps CreatedAt if the caller left it zero so ordering
+// is deterministic, and honors whatever ReinforcedAt the caller set.
+func newClusterTestStore(t *testing.T, facts []TypedFact) FactStore {
+	t.Helper()
+	store := newInMemoryFactStore()
+	ctx := context.Background()
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	for i, f := range facts {
+		if f.CreatedAt.IsZero() {
+			f.CreatedAt = base.Add(time.Duration(i) * time.Hour)
+		}
+		if f.ID == "" {
+			// Deterministic ID — tests assert on (predicate, object, entity)
+			// not on IDs, but UpsertFact requires a non-empty ID to dedupe.
+			f.ID = f.EntitySlug + "-" + f.Triplet.Predicate + "-" + f.Triplet.Object
+		}
+		if err := store.UpsertFact(ctx, f); err != nil {
+			t.Fatalf("seed fact %d: %v", i, err)
+		}
+	}
+	return store
+}
+
+// reinforcedFact is a compact constructor for table-driven test fixtures.
+func reinforcedFact(entity, predicate, object string, reinforced bool) TypedFact {
+	f := TypedFact{
+		EntitySlug: entity,
+		Triplet:    &Triplet{Subject: entity, Predicate: predicate, Object: object},
+		Text:       entity + " " + predicate + " " + object,
+	}
+	if reinforced {
+		r := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+		f.ReinforcedAt = &r
+	}
+	return f
+}
+
+func TestClusterReinforcedFacts(t *testing.T) {
+	tests := []struct {
+		name            string
+		facts           []TypedFact
+		predicateFilter string
+		minEntities     int
+		wantClusters    []FactCluster
+	}{
+		{
+			name: "three entities share a reinforced pair → single cluster",
+			facts: []TypedFact{
+				reinforcedFact("alice", "champions", "q2-pilot", true),
+				reinforcedFact("bob", "champions", "q2-pilot", true),
+				reinforcedFact("carol", "champions", "q2-pilot", true),
+			},
+			minEntities: 3,
+			wantClusters: []FactCluster{
+				{
+					Predicate: "champions",
+					Object:    "q2-pilot",
+					Entities:  []string{"alice", "bob", "carol"},
+					Count:     3,
+				},
+			},
+		},
+		{
+			name: "below threshold → no clusters",
+			facts: []TypedFact{
+				reinforcedFact("alice", "champions", "q2-pilot", true),
+				reinforcedFact("bob", "champions", "q2-pilot", true),
+			},
+			minEntities:  3,
+			wantClusters: nil,
+		},
+		{
+			name: "non-reinforced facts are ignored even when shared",
+			facts: []TypedFact{
+				reinforcedFact("alice", "champions", "q2-pilot", false),
+				reinforcedFact("bob", "champions", "q2-pilot", false),
+				reinforcedFact("carol", "champions", "q2-pilot", false),
+			},
+			minEntities:  3,
+			wantClusters: nil,
+		},
+		{
+			name: "mixed reinforced + not; only entities with reinforcement count",
+			facts: []TypedFact{
+				reinforcedFact("alice", "champions", "q2-pilot", true),
+				reinforcedFact("bob", "champions", "q2-pilot", true),
+				reinforcedFact("carol", "champions", "q2-pilot", false),
+			},
+			minEntities:  3,
+			wantClusters: nil, // carol is not reinforced, so only 2 qualify
+		},
+		{
+			name: "same entity reinforcing twice does not inflate count",
+			facts: []TypedFact{
+				{
+					EntitySlug:   "alice",
+					Triplet:      &Triplet{Subject: "alice", Predicate: "champions", Object: "q2-pilot"},
+					Text:         "alice champions q2-pilot (first)",
+					ID:           "alice-champions-q2-pilot-a",
+					ReinforcedAt: ptrTime(time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)),
+				},
+				{
+					EntitySlug:   "alice",
+					Triplet:      &Triplet{Subject: "alice", Predicate: "champions", Object: "q2-pilot"},
+					Text:         "alice champions q2-pilot (second)",
+					ID:           "alice-champions-q2-pilot-b",
+					ReinforcedAt: ptrTime(time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)),
+				},
+				reinforcedFact("bob", "champions", "q2-pilot", true),
+			},
+			minEntities: 2,
+			wantClusters: []FactCluster{
+				{Predicate: "champions", Object: "q2-pilot", Entities: []string{"alice", "bob"}, Count: 2},
+			},
+		},
+		{
+			name: "predicate filter drops off-topic pairs",
+			facts: []TypedFact{
+				reinforcedFact("alice", "champions", "q2-pilot", true),
+				reinforcedFact("bob", "champions", "q2-pilot", true),
+				reinforcedFact("alice", "works_at", "acme-corp", true),
+				reinforcedFact("bob", "works_at", "acme-corp", true),
+			},
+			predicateFilter: "champions",
+			minEntities:     2,
+			wantClusters: []FactCluster{
+				{Predicate: "champions", Object: "q2-pilot", Entities: []string{"alice", "bob"}, Count: 2},
+			},
+		},
+		{
+			name: "no predicate filter → all qualifying clusters",
+			facts: []TypedFact{
+				reinforcedFact("alice", "champions", "q2-pilot", true),
+				reinforcedFact("bob", "champions", "q2-pilot", true),
+				reinforcedFact("alice", "works_at", "acme-corp", true),
+				reinforcedFact("bob", "works_at", "acme-corp", true),
+			},
+			minEntities: 2,
+			wantClusters: []FactCluster{
+				// Equal counts → sorted by predicate asc, then object asc.
+				{Predicate: "champions", Object: "q2-pilot", Entities: []string{"alice", "bob"}, Count: 2},
+				{Predicate: "works_at", Object: "acme-corp", Entities: []string{"alice", "bob"}, Count: 2},
+			},
+		},
+		{
+			name: "nil triplet facts are skipped",
+			facts: []TypedFact{
+				{
+					EntitySlug:   "alice",
+					Text:         "freeform observation without triplet",
+					ID:           "alice-freeform",
+					ReinforcedAt: ptrTime(time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)),
+				},
+				reinforcedFact("bob", "champions", "q2-pilot", true),
+				reinforcedFact("carol", "champions", "q2-pilot", true),
+			},
+			minEntities: 2,
+			wantClusters: []FactCluster{
+				{Predicate: "champions", Object: "q2-pilot", Entities: []string{"bob", "carol"}, Count: 2},
+			},
+		},
+		{
+			name: "minEntities < 2 is clamped to 2",
+			facts: []TypedFact{
+				reinforcedFact("alice", "champions", "q2-pilot", true),
+			},
+			minEntities:  1,
+			wantClusters: nil, // clamped → 2 required, only 1 entity present
+		},
+		{
+			name: "count desc ordering surfaces strongest cluster first",
+			facts: []TypedFact{
+				reinforcedFact("alice", "champions", "q2-pilot", true),
+				reinforcedFact("bob", "champions", "q2-pilot", true),
+				reinforcedFact("carol", "works_at", "acme-corp", true),
+				reinforcedFact("dave", "works_at", "acme-corp", true),
+				reinforcedFact("eve", "works_at", "acme-corp", true),
+			},
+			minEntities: 2,
+			wantClusters: []FactCluster{
+				{Predicate: "works_at", Object: "acme-corp", Entities: []string{"carol", "dave", "eve"}, Count: 3},
+				{Predicate: "champions", Object: "q2-pilot", Entities: []string{"alice", "bob"}, Count: 2},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			store := newClusterTestStore(t, tc.facts)
+			got, err := clusterReinforcedFacts(context.Background(), store, tc.predicateFilter, tc.minEntities, 0)
+			if err != nil {
+				t.Fatalf("clusterReinforcedFacts: %v", err)
+			}
+			if !equalClusters(got, tc.wantClusters) {
+				t.Fatalf("cluster mismatch\n got:  %#v\n want: %#v", got, tc.wantClusters)
+			}
+		})
+	}
+}
+
+func TestClusterReinforcedFacts_NilStore(t *testing.T) {
+	_, err := clusterReinforcedFacts(context.Background(), nil, "", 2, 0)
+	if err == nil {
+		t.Fatalf("expected error for nil store")
+	}
+}
+
+func TestClusterReinforcedFacts_SQLiteParity(t *testing.T) {
+	// The SQLite and in-memory backends must produce identical clusters from
+	// the same seed. This is the read-side complement of the §7.4 rebuild
+	// contract — cluster detection is a pure function of the fact store,
+	// regardless of backend.
+	seed := []TypedFact{
+		reinforcedFact("alice", "champions", "q2-pilot", true),
+		reinforcedFact("bob", "champions", "q2-pilot", true),
+		reinforcedFact("carol", "champions", "q2-pilot", true),
+		reinforcedFact("dave", "works_at", "acme-corp", true),
+		reinforcedFact("eve", "works_at", "acme-corp", true),
+	}
+
+	memStore := newClusterTestStore(t, seed)
+	memClusters, err := clusterReinforcedFacts(context.Background(), memStore, "", 2, 0)
+	if err != nil {
+		t.Fatalf("mem cluster: %v", err)
+	}
+
+	sqlitePath := t.TempDir() + "/cluster-parity.sqlite"
+	sqliteStore, err := NewSQLiteFactStore(sqlitePath)
+	if err != nil {
+		t.Fatalf("sqlite open: %v", err)
+	}
+	defer func() { _ = sqliteStore.Close() }()
+
+	ctx := context.Background()
+	base := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	for i, f := range seed {
+		if f.CreatedAt.IsZero() {
+			f.CreatedAt = base.Add(time.Duration(i) * time.Hour)
+		}
+		if f.ID == "" {
+			f.ID = f.EntitySlug + "-" + f.Triplet.Predicate + "-" + f.Triplet.Object
+		}
+		if err := sqliteStore.UpsertFact(ctx, f); err != nil {
+			t.Fatalf("sqlite seed %d: %v", i, err)
+		}
+	}
+
+	sqliteClusters, err := clusterReinforcedFacts(ctx, sqliteStore, "", 2, 0)
+	if err != nil {
+		t.Fatalf("sqlite cluster: %v", err)
+	}
+
+	if !equalClusters(memClusters, sqliteClusters) {
+		t.Fatalf("backend parity broken\n mem:    %#v\n sqlite: %#v", memClusters, sqliteClusters)
+	}
+}
+
+// equalClusters compares two cluster slices element-wise. Entities within a
+// cluster are already sorted by clusterReinforcedFacts, so a direct compare
+// is safe.
+func equalClusters(a, b []FactCluster) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Predicate != b[i].Predicate ||
+			a[i].Object != b[i].Object ||
+			a[i].Count != b[i].Count ||
+			!stringSlicesEqual(a[i].Entities, b[i].Entities) {
+			return false
+		}
+	}
+	return true
+}
+
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+// TestClusterReinforcedFacts_LogsAboveThreshold asserts the Slice 2
+// observability guard: when the underlying fact count exceeds the
+// configurable warn threshold, clusterReinforcedFacts logs a line via the
+// shared `log` package but does NOT fail or truncate. The test lowers the
+// threshold through setFactCountWarnThresholdForTest so we do not need
+// to seed 5k rows.
+func TestClusterReinforcedFacts_LogsAboveThreshold(t *testing.T) {
+	restore := setFactCountWarnThresholdForTest(2)
+	defer restore()
+
+	// Seed 3 facts — above the lowered threshold of 2.
+	facts := make([]TypedFact, 0, 3)
+	for i := 0; i < 3; i++ {
+		facts = append(facts, reinforcedFact(fmt.Sprintf("e%d", i), "champions", "q2-pilot", true))
+	}
+	store := newClusterTestStore(t, facts)
+
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(origOut)
+
+	clusters, err := clusterReinforcedFacts(context.Background(), store, "", 2, 0)
+	if err != nil {
+		t.Fatalf("clusterReinforcedFacts: %v", err)
+	}
+	if len(clusters) == 0 {
+		t.Fatalf("expected at least one cluster; got none")
+	}
+
+	logged := buf.String()
+	if !strings.Contains(logged, "fact count 3 exceeds 2") {
+		t.Errorf("expected threshold warning in log output; got:\n%s", logged)
+	}
+	if !strings.Contains(logged, "consider paging") {
+		t.Errorf("expected 'consider paging' hint in log output; got:\n%s", logged)
+	}
+}
+
+// TestClusterReinforcedFacts_DoesNotLogBelowThreshold pins the inverse: when
+// the corpus fits the scan envelope we stay silent so the broker log does
+// not get polluted by every synthesis run.
+func TestClusterReinforcedFacts_DoesNotLogBelowThreshold(t *testing.T) {
+	restore := setFactCountWarnThresholdForTest(100)
+	defer restore()
+
+	store := newClusterTestStore(t, []TypedFact{
+		reinforcedFact("alice", "champions", "q2-pilot", true),
+		reinforcedFact("bob", "champions", "q2-pilot", true),
+	})
+
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(origOut)
+
+	if _, err := clusterReinforcedFacts(context.Background(), store, "", 2, 0); err != nil {
+		t.Fatalf("clusterReinforcedFacts: %v", err)
+	}
+	if strings.Contains(buf.String(), "fact count") {
+		t.Errorf("did not expect threshold warning under the limit; got:\n%s", buf.String())
+	}
+}
+
+// TestClusterReinforcedFacts_TopNShortCircuits verifies topN trims the output
+// after sorting — strongest-first ordering is preserved and the tail is
+// dropped. Callers that want everything pass 0.
+func TestClusterReinforcedFacts_TopNShortCircuits(t *testing.T) {
+	store := newClusterTestStore(t, []TypedFact{
+		// Cluster A: 3 entities
+		reinforcedFact("a1", "champions", "pilot-a", true),
+		reinforcedFact("a2", "champions", "pilot-a", true),
+		reinforcedFact("a3", "champions", "pilot-a", true),
+		// Cluster B: 2 entities
+		reinforcedFact("b1", "champions", "pilot-b", true),
+		reinforcedFact("b2", "champions", "pilot-b", true),
+		// Cluster C: 2 entities
+		reinforcedFact("c1", "champions", "pilot-c", true),
+		reinforcedFact("c2", "champions", "pilot-c", true),
+	})
+
+	// Without a cap, we get all 3.
+	all, err := clusterReinforcedFacts(context.Background(), store, "", 2, 0)
+	if err != nil {
+		t.Fatalf("all clusters: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("expected 3 clusters without cap; got %d", len(all))
+	}
+
+	// topN=1 — only the strongest survives.
+	top1, err := clusterReinforcedFacts(context.Background(), store, "", 2, 1)
+	if err != nil {
+		t.Fatalf("top1: %v", err)
+	}
+	if len(top1) != 1 {
+		t.Fatalf("expected 1 cluster with topN=1; got %d", len(top1))
+	}
+	if top1[0].Object != "pilot-a" {
+		t.Errorf("expected strongest cluster first; got %q", top1[0].Object)
+	}
+
+	// topN > len(clusters) — no-op, all returned.
+	topBig, err := clusterReinforcedFacts(context.Background(), store, "", 2, 999)
+	if err != nil {
+		t.Fatalf("topBig: %v", err)
+	}
+	if len(topBig) != 3 {
+		t.Fatalf("expected 3 clusters with topN=999; got %d", len(topBig))
+	}
+}

--- a/internal/team/playbook_synthesizer.go
+++ b/internal/team/playbook_synthesizer.go
@@ -49,6 +49,17 @@ const MaxPlaybookBodySize = 64 * 1024
 // bounded even when a playbook has hundreds of runs.
 const MaxExecutionsForPrompt = 20
 
+// DefaultClusterMinEntities is the v2 prompt threshold for surfacing a
+// "pattern across entities". Mirrors WIKI-SLICE2-PLAN.md Thread C bullet 1:
+// ≥3 distinct entities sharing a reinforced (predicate, object) pair.
+const DefaultClusterMinEntities = 3
+
+// MaxClustersForPrompt caps how many clusters the v2 prompt carries. Keeps
+// the LLM input bounded when the wiki has hundreds of reinforced patterns.
+// Clusters are sorted strongest-first (count desc), so the head window is
+// the most informative slice.
+const MaxClustersForPrompt = 10
+
 // PlaybookSynthesisPromptSystem is the system prompt sent on every call.
 // Locked here so the behavior is reviewable — do not edit casually.
 const PlaybookSynthesisPromptSystem = `You maintain playbooks in a team wiki. Each playbook has an author who specified the canonical steps. Your job is to integrate lessons from recent executions WITHOUT rewriting the author's body.
@@ -112,6 +123,19 @@ type PlaybookSynthesizerConfig struct {
 	// this nil and the worker falls back to defaultLLMCall from
 	// entity_synthesizer.go (provider.RunConfiguredOneShot).
 	LLMCall func(ctx context.Context, systemPrompt, userPrompt string) (string, error)
+
+	// ClusterSource enables the Slice 2 Thread C v2 prompt. When non-nil,
+	// synthesize() queries this store for reinforced (predicate, object)
+	// pairs shared across ≥ ClusterMinEntities distinct entities and feeds
+	// them into prompts/synthesis_playbook_v2.tmpl. When nil, the v1 prompt
+	// builder runs unchanged — additive rollout, no hot-path regression.
+	ClusterSource FactStore
+
+	// ClusterMinEntities overrides DefaultClusterMinEntities. Values ≤ 0
+	// use the default. Small-workspace operators can drop this to 2 to
+	// surface patterns earlier; the default of 3 is deliberately
+	// conservative per WIKI-SLICE2-PLAN.md Thread C.
+	ClusterMinEntities int
 }
 
 // playbookSynthEventPublisher is the subset of Broker the synthesizer needs.
@@ -394,7 +418,35 @@ func (s *PlaybookSynthesizer) synthesize(ctx context.Context, job PlaybookSynthe
 		window = window[:MaxExecutionsForPrompt]
 	}
 
-	userPrompt := buildPlaybookSynthUserPrompt(source, window)
+	// Slice 2 Thread C: when a cluster source is wired, collect cross-entity
+	// patterns and render via the v2 prompt. Fall back to the v1 builder on
+	// any clustering error so the synthesis path stays live — patterns are
+	// a supplement, not a gate. An empty cluster slice with the v2 prompt is
+	// valid; the template tells the model to omit the patterns section.
+	var (
+		userPrompt string
+		clusters   []FactCluster
+	)
+	if s.cfg.ClusterSource != nil {
+		collected, cerr := s.collectReinforcedClusters(ctx)
+		if cerr != nil {
+			log.Printf("playbook synth: cluster collection for %s: %v (falling back to v1 prompt)", job.Slug, cerr)
+		} else {
+			// collectReinforcedClusters already head-slices at MaxClustersForPrompt
+			// via the topN arg to clusterReinforcedFacts, so no post-truncation
+			// is required here.
+			clusters = collected
+			rendered, rerr := buildPlaybookSynthUserPromptV2(source, window, clusters)
+			if rerr != nil {
+				log.Printf("playbook synth: v2 render for %s: %v (falling back to v1 prompt)", job.Slug, rerr)
+			} else {
+				userPrompt = rendered
+			}
+		}
+	}
+	if userPrompt == "" {
+		userPrompt = buildPlaybookSynthUserPrompt(source, window)
+	}
 
 	callCtx, cancel := context.WithTimeout(ctx, s.cfg.Timeout)
 	defer cancel()

--- a/internal/team/playbook_synthesizer_v2.go
+++ b/internal/team/playbook_synthesizer_v2.go
@@ -1,0 +1,108 @@
+package team
+
+// playbook_synthesizer_v2.go wires the Slice 2 Thread C cluster-aware prompt
+// into PlaybookSynthesizer. Additive only — when PlaybookSynthesizerConfig
+// leaves ClusterSource nil, the v1 code path in playbook_synthesizer.go is
+// unchanged and hot.
+//
+// The v2 prompt lives in prompts/synthesis_playbook_v2.tmpl. It is a strict
+// superset of v1: every v1 instruction is preserved, plus a new
+// "Reinforced patterns across entities" input section and a rule telling the
+// model to render a "## Patterns across entities" block under the learnings
+// section when clusters are provided.
+//
+// The v2 builder is package-private and referenced only from
+// PlaybookSynthesizer.synthesize when ClusterSource is wired.
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"strings"
+	"text/template"
+	"time"
+)
+
+//go:embed prompts/synthesis_playbook_v2.tmpl
+var synthesisPlaybookV2Tmpl string
+
+// playbookSynthV2 is the parsed v2 template. Parsed once at package init so
+// the hot path does not pay template parse cost per synthesis.
+var playbookSynthV2 = func() *template.Template {
+	funcs := template.FuncMap{
+		"add":       func(a, b int) int { return a + b },
+		"trimSpace": strings.TrimSpace,
+		"oneLine":   oneLine,
+		"rfc3339":   func(t time.Time) string { return t.UTC().Format(time.RFC3339) },
+		"joinEntities": func(ents []string) string {
+			// Render as a comma-joined flat list. Kept internal so the prompt
+			// output stays stable regardless of slice length.
+			return strings.Join(ents, ", ")
+		},
+	}
+	t, err := template.New("synthesis_playbook_v2").Funcs(funcs).Parse(synthesisPlaybookV2Tmpl)
+	if err != nil {
+		// Embedded template is build-time validated; a parse error is a bug.
+		panic(fmt.Sprintf("playbook synth v2 template: %v", err))
+	}
+	return t
+}()
+
+// playbookSynthV2Vars holds everything the v2 template needs to render.
+type playbookSynthV2Vars struct {
+	Source        string
+	MaxExecs      int
+	Executions    []Execution
+	Clusters      []FactCluster
+	LearningsHead string
+}
+
+// buildPlaybookSynthUserPromptV2 renders the Thread C user prompt. Caller
+// guarantees executions are newest-first and already windowed.
+//
+// When clusters is empty the template still renders, with an explicit "no
+// clusters detected" marker and the rule-4a patterns section instructed to
+// be OMITTED — the prompt stays honest even when the clustering scan comes
+// up empty.
+func buildPlaybookSynthUserPromptV2(source string, execs []Execution, clusters []FactCluster) (string, error) {
+	vars := playbookSynthV2Vars{
+		Source:        source,
+		MaxExecs:      MaxExecutionsForPrompt,
+		Executions:    execs,
+		Clusters:      clusters,
+		LearningsHead: WhatWeveLearnedHeading,
+	}
+	var b strings.Builder
+	if err := playbookSynthV2.Execute(&b, vars); err != nil {
+		return "", fmt.Errorf("render synthesis_playbook_v2: %w", err)
+	}
+	return b.String(), nil
+}
+
+// collectReinforcedClusters queries the configured ClusterSource for the
+// current cross-entity pattern set. Returns (nil, nil) when no ClusterSource
+// is wired — that is the signal to the synthesizer to fall back to the v1
+// prompt path.
+//
+// minEntities defaults to DefaultClusterMinEntities when non-positive. The
+// default mirrors the Slice 2 plan Thread C bullet 1 (≥3 entities); tests
+// and operators can tune it down for small wikis.
+func (s *PlaybookSynthesizer) collectReinforcedClusters(ctx context.Context) ([]FactCluster, error) {
+	if s == nil || s.cfg.ClusterSource == nil {
+		return nil, nil
+	}
+	minEntities := s.cfg.ClusterMinEntities
+	if minEntities <= 0 {
+		minEntities = DefaultClusterMinEntities
+	}
+	// Pass MaxClustersForPrompt as the topN cap so the cluster function
+	// short-circuits after sorting and we avoid materialising the long tail
+	// the synthesizer would slice off seconds later. The semantic
+	// equivalent of the previous post-slice truncation; the allocation
+	// savings matter once the corpus has dozens of reinforced patterns.
+	clusters, err := clusterReinforcedFacts(ctx, s.cfg.ClusterSource, "", minEntities, MaxClustersForPrompt)
+	if err != nil {
+		return nil, fmt.Errorf("collect clusters: %w", err)
+	}
+	return clusters, nil
+}

--- a/internal/team/playbook_synthesizer_v2_test.go
+++ b/internal/team/playbook_synthesizer_v2_test.go
@@ -1,0 +1,287 @@
+package team
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBuildPlaybookSynthUserPromptV2_RendersClusters asserts that a canned
+// cluster set shows up verbatim in the v2 prompt body under the
+// "# Reinforced patterns across entities" section, and that rule 4a about
+// the output "## Patterns across entities" section is present.
+func TestBuildPlaybookSynthUserPromptV2_RendersClusters(t *testing.T) {
+	source := `---
+author: pm
+---
+
+# Churn prevention
+
+1. Page the CSM.
+`
+	execs := []Execution{
+		{
+			Slug:       "churn-prevention",
+			Outcome:    PlaybookOutcomeSuccess,
+			Summary:    "Saved the account.",
+			RecordedBy: "cmo",
+			CreatedAt:  time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC),
+		},
+	}
+	clusters := []FactCluster{
+		{Predicate: "champions", Object: "q2-pilot", Entities: []string{"alice", "bob", "carol"}, Count: 3},
+		{Predicate: "works_at", Object: "acme-corp", Entities: []string{"dave", "eve"}, Count: 2},
+	}
+
+	got, err := buildPlaybookSynthUserPromptV2(source, execs, clusters)
+	if err != nil {
+		t.Fatalf("render v2: %v", err)
+	}
+
+	mustContain(t, got, "# Existing playbook")
+	mustContain(t, got, "# Recent executions (newest first, max 20)")
+	mustContain(t, got, "# Reinforced patterns across entities")
+	mustContain(t, got, "3 entities share `champions → q2-pilot`")
+	mustContain(t, got, "2 entities share `works_at → acme-corp`")
+	// Entity slugs ARE listed in the prompt input so the model has grounding,
+	// but rule 4 tells the model to cite counts only in the output.
+	mustContain(t, got, "(alice, bob, carol)")
+	mustContain(t, got, "## Patterns across entities")
+	// Contradiction-handling rule from v1 is preserved.
+	mustContain(t, got, "**Contradiction:**")
+	mustContain(t, got, WhatWeveLearnedHeading)
+}
+
+// TestBuildPlaybookSynthUserPromptV2_EmptyClusters verifies the template's
+// explicit "no clusters detected" branch so an empty cluster slice still
+// produces a valid prompt and the model is instructed to OMIT the patterns
+// section.
+func TestBuildPlaybookSynthUserPromptV2_EmptyClusters(t *testing.T) {
+	source := `---
+author: pm
+---
+
+# Churn prevention
+`
+	got, err := buildPlaybookSynthUserPromptV2(source, nil, nil)
+	if err != nil {
+		t.Fatalf("render v2 empty: %v", err)
+	}
+	mustContain(t, got, "_No cross-entity reinforced patterns were detected")
+	mustContain(t, got, "OMIT this section entirely")
+	mustContain(t, got, "_No executions provided._")
+}
+
+// TestBuildPlaybookSynthUserPromptV2_IsIdempotent asserts identical input
+// produces byte-identical output — i.e. the render is a pure function of
+// its inputs. This pins cache-key stability for upstream prompt caching.
+//
+// NOT a semantic-quality eval. Whether the prompt produces GOOD synthesis
+// output is a separate concern belonging to a golden-harness run planned
+// for Slice 3; this test only guards against accidental non-determinism
+// sneaking into the template (e.g. a map iteration in a helper).
+func TestBuildPlaybookSynthUserPromptV2_IsIdempotent(t *testing.T) {
+	source := "---\nauthor: pm\n---\n\n# Churn prevention\n"
+	execs := []Execution{
+		{Slug: "churn", Outcome: PlaybookOutcomeSuccess, Summary: "ok", RecordedBy: "cmo", CreatedAt: time.Date(2026, 4, 20, 10, 0, 0, 0, time.UTC)},
+	}
+	clusters := []FactCluster{
+		{Predicate: "champions", Object: "q2-pilot", Entities: []string{"alice", "bob", "carol"}, Count: 3},
+	}
+
+	a, err := buildPlaybookSynthUserPromptV2(source, execs, clusters)
+	if err != nil {
+		t.Fatalf("render 1: %v", err)
+	}
+	b, err := buildPlaybookSynthUserPromptV2(source, execs, clusters)
+	if err != nil {
+		t.Fatalf("render 2: %v", err)
+	}
+	if a != b {
+		t.Fatalf("prompt render is non-deterministic\n first:\n%s\n second:\n%s", a, b)
+	}
+}
+
+// TestPlaybookSynthesisWithClusters is the end-to-end check that wiring a
+// ClusterSource on PlaybookSynthesizerConfig routes the synthesis path
+// through the v2 prompt. The stub LLM asserts the user prompt contains the
+// cross-entity pattern section and returns a well-formed draft; the
+// committed playbook must include the Patterns section.
+func TestPlaybookSynthesisWithClusters(t *testing.T) {
+	// Seed a FactStore with a cross-entity reinforced cluster.
+	store := newClusterTestStore(t, []TypedFact{
+		reinforcedFact("alice", "champions", "q2-pilot", true),
+		reinforcedFact("bob", "champions", "q2-pilot", true),
+		reinforcedFact("carol", "champions", "q2-pilot", true),
+	})
+
+	var capturedPrompt string
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		capturedPrompt = user
+		return `## What we've learned
+
+- CSM pages land faster than email.
+
+## Patterns across entities
+
+- 3 entities share champions → q2-pilot. Lean on the shared champions when escalating retention plays.
+`, nil
+	}
+
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixtureWithCluster(t, stub, store, 2)
+	defer teardown()
+	ctx := context.Background()
+
+	writePlaybookSource(t, worker, "retention", seededPlaybookBody)
+	if _, err := execLog.Append(ctx, "retention", PlaybookOutcomeSuccess, "Saved.", "", "cmo"); err != nil {
+		t.Fatalf("append 1: %v", err)
+	}
+	if _, err := execLog.Append(ctx, "retention", PlaybookOutcomePartial, "Blocked on legal.", "", "cmo"); err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+
+	if _, err := synth.SynthesizeNow(ctx, "retention", "human"); err != nil {
+		t.Fatalf("synthesize: %v", err)
+	}
+	waitForSynthCount(t, pub, 1, 3*time.Second)
+
+	// Prompt assertions: the v2 body went to the LLM.
+	mustContain(t, capturedPrompt, "# Reinforced patterns across entities")
+	mustContain(t, capturedPrompt, "3 entities share `champions → q2-pilot`")
+	mustContain(t, capturedPrompt, "## Patterns across entities")
+
+	// Commit assertions: the author body survived verbatim, the learnings
+	// section landed, and the patterns section from the draft came through.
+	bytes, err := readArticle(worker.Repo(), playbookSourceRel("retention"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(bytes)
+	mustContain(t, got, "1. Pull the account's ARR.")
+	mustContain(t, got, WhatWeveLearnedHeading)
+	mustContain(t, got, "CSM pages land faster than email.")
+	mustContain(t, got, "## Patterns across entities")
+	mustContain(t, got, "3 entities share champions")
+}
+
+// TestPlaybookSynthesisFallsBackWhenClusterSourceNil verifies the additive
+// rollout guarantee: leaving ClusterSource unset runs the v1 prompt, byte-
+// for-byte identical to the pre-Thread-C code path.
+func TestPlaybookSynthesisFallsBackWhenClusterSourceNil(t *testing.T) {
+	var capturedPrompt string
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		capturedPrompt = user
+		return "## What we've learned\n\n- CSM pages land faster than email.\n", nil
+	}
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixture(t, stub)
+	defer teardown()
+	ctx := context.Background()
+	writePlaybookSource(t, worker, "no-clusters", seededPlaybookBody)
+	if _, err := execLog.Append(ctx, "no-clusters", PlaybookOutcomeSuccess, "Saved.", "", "cmo"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if _, err := execLog.Append(ctx, "no-clusters", PlaybookOutcomeSuccess, "Again.", "", "cmo"); err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+	if _, err := synth.SynthesizeNow(ctx, "no-clusters", "human"); err != nil {
+		t.Fatalf("synthesize: %v", err)
+	}
+	waitForSynthCount(t, pub, 1, 3*time.Second)
+
+	if strings.Contains(capturedPrompt, "Reinforced patterns across entities") {
+		t.Errorf("v1 fallback should NOT include the v2 pattern section; prompt was:\n%s", capturedPrompt)
+	}
+	if !strings.Contains(capturedPrompt, "# Existing playbook") {
+		t.Errorf("v1 prompt body missing; prompt was:\n%s", capturedPrompt)
+	}
+}
+
+// TestPlaybookSynthesisEmptyClusterSet routes through v2 even when the
+// scan yields zero clusters. The prompt must carry the "no patterns"
+// marker and the resulting playbook should NOT contain a
+// "## Patterns across entities" section (the model honored the OMIT rule).
+func TestPlaybookSynthesisEmptyClusterSet(t *testing.T) {
+	// FactStore with no reinforced cross-entity pairs.
+	emptyStore := newClusterTestStore(t, nil)
+
+	var capturedPrompt string
+	stub := func(ctx context.Context, sys, user string) (string, error) {
+		capturedPrompt = user
+		// Model honors the OMIT rule from the template.
+		return "## What we've learned\n\n- CSM pages land faster than email.\n", nil
+	}
+
+	synth, execLog, worker, pub, teardown := newPlaybookSynthFixtureWithCluster(t, stub, emptyStore, 2)
+	defer teardown()
+	ctx := context.Background()
+	writePlaybookSource(t, worker, "quiet", seededPlaybookBody)
+	if _, err := execLog.Append(ctx, "quiet", PlaybookOutcomeSuccess, "Saved.", "", "cmo"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if _, err := execLog.Append(ctx, "quiet", PlaybookOutcomeSuccess, "Again.", "", "cmo"); err != nil {
+		t.Fatalf("append 2: %v", err)
+	}
+	if _, err := synth.SynthesizeNow(ctx, "quiet", "human"); err != nil {
+		t.Fatalf("synthesize: %v", err)
+	}
+	waitForSynthCount(t, pub, 1, 3*time.Second)
+
+	mustContain(t, capturedPrompt, "_No cross-entity reinforced patterns were detected")
+
+	bytes, err := readArticle(worker.Repo(), playbookSourceRel("quiet"))
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(bytes)
+	if strings.Contains(got, "## Patterns across entities") {
+		t.Errorf("empty-cluster run should not land a patterns section; got:\n%s", got)
+	}
+	mustContain(t, got, WhatWeveLearnedHeading)
+}
+
+// newPlaybookSynthFixtureWithCluster mirrors newPlaybookSynthFixture but
+// injects a ClusterSource + minEntities override for Thread C tests.
+func newPlaybookSynthFixtureWithCluster(
+	t *testing.T,
+	llmStub func(ctx context.Context, sys, user string) (string, error),
+	clusterSource FactStore,
+	minEntities int,
+) (*PlaybookSynthesizer, *ExecutionLog, *WikiWorker, *playbookPublisherStub, func()) {
+	t.Helper()
+	root := fmt.Sprintf("%s/wiki", t.TempDir())
+	backup := fmt.Sprintf("%s/wiki.bak", t.TempDir())
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	worker := NewWikiWorker(repo, noopPublisher{})
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	execLog := NewExecutionLog(worker)
+	pub := &playbookPublisherStub{}
+	synth := NewPlaybookSynthesizer(worker, execLog, pub, PlaybookSynthesizerConfig{
+		Threshold:          2,
+		Timeout:            5 * time.Second,
+		LLMCall:            llmStub,
+		ClusterSource:      clusterSource,
+		ClusterMinEntities: minEntities,
+	})
+	synth.Start(context.Background())
+
+	teardown := func() {
+		synth.Stop()
+		cancel()
+		<-worker.Done()
+	}
+	return synth, execLog, worker, pub, teardown
+}
+
+func mustContain(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Errorf("expected output to contain %q; got:\n%s", want, got)
+	}
+}

--- a/internal/team/prompts/synthesis_playbook_v2.tmpl
+++ b/internal/team/prompts/synthesis_playbook_v2.tmpl
@@ -1,0 +1,58 @@
+{{/*
+  synthesis_playbook_v2.tmpl — WUPHF playbook synthesis prompt, clusters variant
+
+  Additive sibling to buildPlaybookSynthUserPrompt (v1). The v1 body is
+  preserved verbatim; the only delta is a final "## Reinforced patterns across
+  entities" input section and a rule-4a instruction telling the model to
+  surface those patterns under "## Patterns across entities" in the playbook
+  body.
+
+  Gated behind PlaybookSynthesizerConfig.ClusterSource. When the field is nil
+  the synthesizer falls back to the v1 prompt builder — existing hot-path
+  behavior is unchanged.
+
+  Template variables:
+    .Source        string           — the existing playbook markdown
+    .MaxExecs      int              — MaxExecutionsForPrompt, rendered in the
+                                      section heading for honesty
+    .Executions    []Execution      — newest-first slice, already windowed
+    .Clusters      []FactCluster    — cross-entity reinforced patterns from
+                                      playbook_clusters.go. Empty is fine; the
+                                      model is told to omit the section then.
+    .LearningsHead string           — WhatWeveLearnedHeading literal
+*/}}# Existing playbook
+
+{{trimSpace .Source}}
+
+# Recent executions (newest first, max {{.MaxExecs}})
+
+{{if .Executions}}{{range $i, $e := .Executions}}## Execution {{add $i 1}} — {{$e.Outcome}}
+- recorded_by: {{$e.RecordedBy}}
+- timestamp: {{rfc3339 $e.CreatedAt}}
+- summary: {{oneLine $e.Summary}}
+{{if trimSpace $e.Notes}}- notes: {{oneLine $e.Notes}}
+{{end}}
+{{end}}{{else}}_No executions provided._
+{{end}}
+# Reinforced patterns across entities
+
+{{if .Clusters}}Each row below is a (predicate, object) pair that has been reinforced on at least two distinct entities in the wiki. Use these to generalize the learnings — they are signals of team-wide patterns, not noise from a single relationship.
+
+{{range .Clusters}}- {{.Count}} entities share `{{.Predicate}} → {{.Object}}` ({{joinEntities .Entities}})
+{{end}}{{else}}_No cross-entity reinforced patterns were detected for this synthesis run._
+{{end}}
+# Your task
+
+Produce the FULL updated playbook markdown now. Rules:
+
+1. Preserve the frontmatter (the leading --- block) exactly as given.
+2. Preserve the author's main body verbatim.
+3. Maintain the trailing "{{.LearningsHead}}" section. If it already exists, update the bullets; if it does not, append it. Only bullets traceable to at least one execution above.
+4. When "# Reinforced patterns across entities" above is non-empty, append a single additional section titled exactly "## Patterns across entities" below "{{.LearningsHead}}". Under that heading, render one bullet per cluster in the SAME order the patterns were provided, with:
+   - the (predicate, object) pair verbatim,
+   - the entity count,
+   - one concrete, boring sentence on what the pattern means for this playbook.
+   Cite entity counts only, never individual entity slugs. If the section is empty above, OMIT this section entirely — do not emit an empty "## Patterns across entities".
+5. When two executions disagree, record the disagreement as a "**Contradiction:**" inline callout under "{{.LearningsHead}}" and DO NOT resolve it.
+6. Do not invent lessons. Every bullet must be traceable to at least one execution entry or cluster row.
+7. Output ONLY the full updated markdown of the playbook file. No commentary, no code fences.

--- a/internal/team/wiki_index.go
+++ b/internal/team/wiki_index.go
@@ -148,6 +148,17 @@ type FactStore interface {
 	GetFact(ctx context.Context, id string) (TypedFact, bool, error)
 	ListFactsForEntity(ctx context.Context, slug string) ([]TypedFact, error)
 	ListEdgesForEntity(ctx context.Context, slug string) ([]IndexEdge, error)
+	// ListAllFacts returns every indexed fact, ordered deterministically by
+	// ID. Used by cross-entity consumers (e.g. playbook cluster detection in
+	// Slice 2 Thread C) that need to scan reinforced (predicate, object)
+	// pairs across all entities. Read-only; never mutates the fact log.
+	ListAllFacts(ctx context.Context) ([]TypedFact, error)
+	// CountFacts returns the total number of indexed facts. Cheap in both
+	// backends (SELECT COUNT(*) on SQLite, len(map) on in-memory). Callers
+	// that do full scans via ListAllFacts use this as a cheap pre-check so
+	// they can log a warning when the corpus outgrows the bounded-scan
+	// assumption (no index on predicate/object yet — tracked by Slice 3).
+	CountFacts(ctx context.Context) (int, error)
 	ResolveRedirect(ctx context.Context, slug string) (string, bool, error)
 
 	// ListFactsByPredicateObject returns every fact whose triplet matches
@@ -1005,6 +1016,32 @@ func (s *inMemoryFactStore) ListEdgesForEntity(_ context.Context, slug string) (
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return append([]IndexEdge(nil), s.edgesBy[slug]...), nil
+}
+
+// ListAllFacts returns every fact in the store, sorted by ID. Deterministic
+// ordering keeps cross-entity consumers (playbook clustering) reproducible.
+func (s *inMemoryFactStore) ListAllFacts(_ context.Context) ([]TypedFact, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids := make([]string, 0, len(s.facts))
+	for id := range s.facts {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	out := make([]TypedFact, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, s.facts[id])
+	}
+	return out, nil
+}
+
+// CountFacts returns len(facts) without materialising a slice. Paired with
+// ListAllFacts so a consumer can cheaply pre-check corpus size before
+// triggering a full scan.
+func (s *inMemoryFactStore) CountFacts(_ context.Context) (int, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.facts), nil
 }
 
 func (s *inMemoryFactStore) ResolveRedirect(_ context.Context, slug string) (string, bool, error) {

--- a/internal/team/wiki_index_sqlite.go
+++ b/internal/team/wiki_index_sqlite.go
@@ -370,6 +370,37 @@ func (s *SQLiteFactStore) ListFactsByTriplet(ctx context.Context, subject, predi
 	return scanFacts(rows)
 }
 
+// CountFacts returns the total number of rows in the facts table. Cheap —
+// COUNT(*) hits the primary index on id. Used by cross-entity consumers
+// to pre-check corpus size before triggering a full scan via ListAllFacts.
+func (s *SQLiteFactStore) CountFacts(ctx context.Context) (int, error) {
+	var n int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM facts`).Scan(&n); err != nil {
+		return 0, fmt.Errorf("sqlite: count facts: %w", err)
+	}
+	return n, nil
+}
+
+// ListAllFacts returns every fact in the store sorted by ID. Matches
+// inMemoryFactStore ordering so cross-entity consumers (playbook clustering)
+// see deterministic results regardless of backend.
+func (s *SQLiteFactStore) ListAllFacts(ctx context.Context) ([]TypedFact, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, entity_slug, kind, type,
+		        triplet_subject, triplet_predicate, triplet_object,
+		        text, confidence, valid_from, valid_until,
+		        supersedes, contradicts_with,
+		        source_type, source_path, sentence_offset, artifact_excerpt,
+		        created_at, created_by, reinforced_at
+		 FROM facts
+		 ORDER BY id ASC`)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list all facts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanFacts(rows)
+}
+
 func (s *SQLiteFactStore) ListEdgesForEntity(ctx context.Context, slug string) ([]IndexEdge, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT subject, predicate, object, timestamp, source_sha


### PR DESCRIPTION
## Why

Slice 2 Thread C of the WIKI-SLICE2-PLAN: playbook synthesis currently runs per-entity. This PR extends it so clusters of reinforced facts across entities surface as cross-workspace patterns in the learnings section.

## What changed

- Added `FactStore.ListAllFacts(ctx)` with implementations on both `inMemoryFactStore` and `SQLiteFactStore`. Pure additive read-only enumeration used by cross-entity consumers; no writer path or single-writer invariant touched.
- New `internal/team/playbook_clusters.go` with `FactCluster` and `clusterReinforcedFacts(ctx, store, predicateFilter, minEntities)`. The live reinforcement signal is `TypedFact.ReinforcedAt != nil` — the extractor bumps it on re-extraction; no `reinforced_count` field exists in v1.2.
- New `internal/team/prompts/synthesis_playbook_v2.tmpl` — strict superset of the v1 programmatic prompt. Adds a `# Reinforced patterns across entities` input section and a rule-4a instruction to emit `## Patterns across entities` under the learnings heading (entity counts only, OMIT when empty).
- New `internal/team/playbook_synthesizer_v2.go` — parsed-once template + `buildPlaybookSynthUserPromptV2` + `collectReinforcedClusters`.
- `PlaybookSynthesizerConfig` gains `ClusterSource FactStore` + `ClusterMinEntities int`. When `ClusterSource` is nil, the v1 prompt path is byte-identical to pre-Thread-C behavior. Any cluster-collection or v2-render error logs and falls back to v1 — patterns are a supplement, not a gate.

## Tests

Run: `go test ./internal/team/... -run 'Cluster|Playbook' -count=1 -race`

New cases:
- `TestClusterReinforcedFacts` (table-driven): threshold boundaries, non-reinforced skip, same-entity dedup, predicate filter, nil-triplet skip, min-entities clamp, count-desc ordering.
- `TestClusterReinforcedFacts_SQLiteParity`: in-memory and SQLite backends produce identical cluster output from the same seed — read-side complement of the §7.4 rebuild contract.
- `TestClusterReinforcedFacts_NilStore`: nil store returns an error.
- `TestBuildPlaybookSynthUserPromptV2_RendersClusters` / `_EmptyClusters` / `_Deterministic`: prompt render assertions.
- `TestPlaybookSynthesisWithClusters`: end-to-end with `ClusterSource` wired — LLM stub captures the prompt, committed playbook carries the patterns section.
- `TestPlaybookSynthesisFallsBackWhenClusterSourceNil`: v1-path byte-equivalence when `ClusterSource == nil`.
- `TestPlaybookSynthesisEmptyClusterSet`: empty cluster scan still routes through v2 and the OMIT rule holds.

No evals harness exists in the codebase today, so the planned `evals/playbook_clusters.golden.json` was skipped — the deterministic template render test (`TestBuildPlaybookSynthUserPromptV2_Deterministic`) covers the same cache-key-stability property a golden would.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/team/...`
- [x] `gofmt -l internal/team/ | wc -l` → 0
- [x] `go test ./internal/team/... -run 'Cluster|Playbook' -count=1 -race` → pass

## Dependency note

This branch is stacked on #254 (Thread B). It carries Thread B's commits until that PR merges. Rebase onto main once #254 lands, before merging this PR.

## Out of scope (intentional)

- SQL indexing for `(predicate, object)`. Plan documents this as acceptable at Slice 2 (bounded by ~500 facts at bench); introduce an index when the corpus passes ~10k facts.
- Evals harness wiring — does not exist yet and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)