### PR TITLE
[codex] Keep broker alive during workspace shred

### DIFF
--- a/docs/specs/WIKI-SCHEMA.md
+++ b/docs/specs/WIKI-SCHEMA.md
@@ -171,7 +171,7 @@ Insights are facts that rise above the noise: status changes, decisions, pattern
   "confidence": 0.95,
   "created_at": "2026-04-22T14:32:00Z",
   "created_by": "archivist",
-  "source": "synthesis" 
+  "source": "synthesis"
 }
 ```
 

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -1557,15 +1557,13 @@ func (b *Broker) StartOnPort(port int) error {
 	// completeFn posts the first task as a human message and seeds the team.
 	onboarding.RegisterRoutes(mux, b.onboardingCompleteFn, b.packSlug, b.requireAuth)
 	// Workspace wipes: POST /workspace/reset (narrow) and /workspace/shred (full).
-	// Shred requests launcher shutdown after the response so live in-memory
-	// broker state cannot write stale messages back onto disk.
+	// These clear disk state and reset the live broker in-process so the web UI
+	// can transition straight into onboarding without killing the broker.
 	// Auth-gated via requireAuth because shred permanently deletes state and
 	// must not be reachable without the broker token.
 	workspace.RegisterRoutesWithOptions(mux, workspace.RouteOptions{
 		AuthMiddleware: b.requireAuth,
-		AfterShred: func(workspace.Result) {
-			b.requestShutdown()
-		},
+		ResetRuntime:   b.Reset,
 	})
 
 	addr := fmt.Sprintf("127.0.0.1:%d", port)

--- a/internal/team/broker_web_test.go
+++ b/internal/team/broker_web_test.go
@@ -48,7 +48,7 @@ func TestWebUIProxyHandlerForwardsOnboardingRoutes(t *testing.T) {
 	}
 }
 
-func TestWorkspaceShredRouteRequestsBrokerShutdown(t *testing.T) {
+func TestWorkspaceShredRouteResetsBrokerWithoutShutdown(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("WUPHF_RUNTIME_HOME", home)
 
@@ -61,6 +61,15 @@ func TestWorkspaceShredRouteRequestsBrokerShutdown(t *testing.T) {
 	}
 
 	b := NewBroker()
+	b.mu.Lock()
+	b.messages = []channelMessage{{
+		ID:        "stale-message",
+		From:      "human",
+		Channel:   "general",
+		Content:   "old run",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}}
+	b.mu.Unlock()
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -85,9 +94,16 @@ func TestWorkspaceShredRouteRequestsBrokerShutdown(t *testing.T) {
 		t.Fatalf("expected shred to remove logs, stat err=%v", err)
 	}
 
+	b.mu.Lock()
+	messageCount := len(b.messages)
+	b.mu.Unlock()
+	if messageCount != 0 {
+		t.Fatalf("expected shred route to reset broker messages, got %d", messageCount)
+	}
+
 	select {
 	case <-b.ShutdownRequested():
-	case <-time.After(time.Second):
-		t.Fatal("expected shred route to request broker shutdown")
+		t.Fatal("expected shred route to keep broker running")
+	case <-time.After(50 * time.Millisecond):
 	}
 }

--- a/internal/workspace/handlers.go
+++ b/internal/workspace/handlers.go
@@ -8,7 +8,7 @@ import (
 // RouteOptions controls optional side effects around workspace wipe routes.
 type RouteOptions struct {
 	AuthMiddleware func(http.HandlerFunc) http.HandlerFunc
-	AfterShred     func(Result)
+	ResetRuntime   func()
 }
 
 // RegisterRoutes attaches the two workspace wipe endpoints to mux.
@@ -17,8 +17,8 @@ type RouteOptions struct {
 //	POST /workspace/shred  — Shred (full wipe, reopens onboarding)
 //
 // By default both endpoints only touch disk. RegisterRoutesWithOptions can add
-// process-level side effects after a successful wipe response; the web broker
-// uses that to stop itself after shred so live memory cannot repersist.
+// a live runtime reset after a successful wipe so the broker stays up without
+// repersisting stale in-memory state.
 //
 // authMiddleware wraps each handler. Pass the broker's requireAuth so local
 // scripts cannot POST without the broker token — these operations are strictly
@@ -29,25 +29,34 @@ func RegisterRoutes(mux *http.ServeMux, authMiddleware func(http.HandlerFunc) ht
 }
 
 // RegisterRoutesWithOptions attaches the workspace wipe endpoints and runs any
-// configured callbacks only after a successful wipe response has been written.
+// configured callbacks after a successful disk wipe.
 func RegisterRoutesWithOptions(mux *http.ServeMux, opts RouteOptions) {
 	authMiddleware := opts.AuthMiddleware
 	if authMiddleware == nil {
 		authMiddleware = func(h http.HandlerFunc) http.HandlerFunc { return h }
 	}
-	mux.HandleFunc("/workspace/reset", authMiddleware(handleReset))
+	mux.HandleFunc("/workspace/reset", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
+		handleResetWithOptions(w, r, opts)
+	}))
 	mux.HandleFunc("/workspace/shred", authMiddleware(func(w http.ResponseWriter, r *http.Request) {
 		handleShredWithOptions(w, r, opts)
 	}))
 }
 
 func handleReset(w http.ResponseWriter, r *http.Request) {
+	handleResetWithOptions(w, r, RouteOptions{})
+}
+
+func handleResetWithOptions(w http.ResponseWriter, r *http.Request, opts RouteOptions) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	res, err := ClearRuntime()
-	writeResult(w, res, err, "/")
+	if err == nil && opts.ResetRuntime != nil {
+		opts.ResetRuntime()
+	}
+	writeResult(w, res, err, "/", opts.ResetRuntime == nil)
 }
 
 func handleShred(w http.ResponseWriter, r *http.Request) {
@@ -60,17 +69,13 @@ func handleShredWithOptions(w http.ResponseWriter, r *http.Request, opts RouteOp
 		return
 	}
 	res, err := Shred()
-	writeResult(w, res, err, "/")
-	if err != nil || opts.AfterShred == nil {
-		return
+	if err == nil && opts.ResetRuntime != nil {
+		opts.ResetRuntime()
 	}
-	if flusher, ok := w.(http.Flusher); ok {
-		flusher.Flush()
-	}
-	go opts.AfterShred(res)
+	writeResult(w, res, err, "/", opts.ResetRuntime == nil)
 }
 
-func writeResult(w http.ResponseWriter, res Result, err error, redirect string) {
+func writeResult(w http.ResponseWriter, res Result, err error, redirect string, restartRequired bool) {
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -82,7 +87,7 @@ func writeResult(w http.ResponseWriter, res Result, err error, redirect string) 
 	}
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"ok":               true,
-		"restart_required": true,
+		"restart_required": restartRequired,
 		"redirect":         redirect,
 		"removed":          res.Removed,
 		"errors":           res.Errors,

--- a/internal/workspace/handlers_test.go
+++ b/internal/workspace/handlers_test.go
@@ -147,3 +147,29 @@ func TestShredHandlerOnEmptyHomeIsOK(t *testing.T) {
 		t.Fatalf("expected 200 on empty home, got %d", w.Code)
 	}
 }
+
+func TestShredHandlerResetsLiveRuntimeWithoutRestartHint(t *testing.T) {
+	dir := withRuntimeHome(t)
+	seedWorkspace(t, dir)
+
+	var resetCalls int
+	mux := http.NewServeMux()
+	RegisterRoutesWithOptions(mux, RouteOptions{
+		ResetRuntime: func() { resetCalls++ },
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/workspace/shred", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if resetCalls != 1 {
+		t.Fatalf("expected reset callback once, got %d", resetCalls)
+	}
+	body := decodeBody(t, w.Body.String())
+	if restartRequired, _ := body["restart_required"].(bool); restartRequired {
+		t.Fatalf("expected restart_required=false when reset callback is wired, got %v", body)
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -6,12 +6,13 @@
 //
 //   - Shred: full. Everything Reset does, plus deletes the team roster, company
 //     identity, the office's task receipts, saved workflows, logs, sessions,
-//     provider state, calendar, and local markdown memory. The next launch
-//     shows the onboarding wizard.
+//     provider state, calendar, and local markdown memory. The next load shows
+//     the onboarding wizard.
 //
-// Preserved in both cases: task-worktrees/, openclaw/, config.json. In-flight
-// work remains on disk so branches and local changes inside task worktrees
-// survive, and credentials/preferences stay available for the next launch.
+// Preserved in both cases: office.pid, task-worktrees/, openclaw/, config.json.
+// In-flight work remains on disk so branches and local changes inside task
+// worktrees survive, and credentials/preferences stay available for the next
+// launch.
 package workspace
 
 import (
@@ -19,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
@@ -32,20 +34,18 @@ type Result struct {
 	Errors  []string `json:"errors,omitempty"`
 }
 
-// ClearRuntime performs a narrow reset: deletes the broker state directory.
-// Task worktrees stay on disk. Safe to call when no broker is running. Callers
-// that need to stop a live broker or tmux session must do so separately — this
-// package only touches the disk.
+// ClearRuntime performs a narrow reset: deletes the broker state file and the
+// last-good snapshot. Safe to call when no broker is running. The live broker
+// may keep using the same office.pid and team directory; callers that want to
+// clear in-memory runtime should do so separately.
 func ClearRuntime() (Result, error) {
-	home, err := wuphfHome()
+	var res Result
+	statePath, snapshotPath, err := brokerStatePaths()
 	if err != nil {
 		return Result{}, err
 	}
-	var res Result
-	// ~/.wuphf/team/ holds broker-state.json, office.pid, and the snapshot.
-	// Wiping the whole dir is simpler than enumerating and matches what
-	// the broker rebuilds on next boot.
-	res.removeIfPresent(filepath.Join(home, "team"))
+	res.removeIfPresent(statePath)
+	res.removeIfPresent(snapshotPath)
 	return res, nil
 }
 
@@ -83,6 +83,18 @@ func wuphfHome() (string, error) {
 		return "", errors.New("workspace: could not resolve home directory")
 	}
 	return filepath.Join(home, ".wuphf"), nil
+}
+
+func brokerStatePaths() (string, string, error) {
+	if p := strings.TrimSpace(os.Getenv("WUPHF_BROKER_STATE_PATH")); p != "" {
+		return p, p + ".last-good", nil
+	}
+	home, err := wuphfHome()
+	if err != nil {
+		return "", "", err
+	}
+	path := filepath.Join(home, "team", "broker-state.json")
+	return path, path + ".last-good", nil
 }
 
 func (r *Result) removeIfPresent(path string) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -13,22 +13,23 @@ func seedWorkspace(t *testing.T, dir string) map[string]string {
 	t.Helper()
 	base := filepath.Join(dir, ".wuphf")
 	paths := map[string]string{
-		"onboarded":   filepath.Join(base, "onboarded.json"),
-		"company":     filepath.Join(base, "company.json"),
-		"brokerState": filepath.Join(base, "team", "broker-state.json"),
-		"officePID":   filepath.Join(base, "team", "office.pid"),
-		"officeTasks": filepath.Join(base, "office", "tasks", "t-1.json"),
-		"workflow":    filepath.Join(base, "workflows", "wf-1.json"),
-		"logs":        filepath.Join(base, "logs", "channel-stderr.log"),
-		"session":     filepath.Join(base, "sessions", "s-1.json"),
-		"worktree":    filepath.Join(base, "task-worktrees", "wt-1", "file"),
-		"codex":       filepath.Join(base, "codex-headless", "cache"),
-		"providers":   filepath.Join(base, "providers", "claude-sessions.json"),
-		"openclaw":    filepath.Join(base, "openclaw", "identity.json"),
-		"config":      filepath.Join(base, "config.json"),
-		"calendar":    filepath.Join(base, "calendar.json"),
-		"wiki":        filepath.Join(base, "wiki", "team", "playbooks", "starter.md"),
-		"wikiBackup":  filepath.Join(base, "wiki.bak", "team", "playbooks", "starter.md"),
+		"onboarded":           filepath.Join(base, "onboarded.json"),
+		"company":             filepath.Join(base, "company.json"),
+		"brokerState":         filepath.Join(base, "team", "broker-state.json"),
+		"brokerStateSnapshot": filepath.Join(base, "team", "broker-state.json.last-good"),
+		"officePID":           filepath.Join(base, "team", "office.pid"),
+		"officeTasks":         filepath.Join(base, "office", "tasks", "t-1.json"),
+		"workflow":            filepath.Join(base, "workflows", "wf-1.json"),
+		"logs":                filepath.Join(base, "logs", "channel-stderr.log"),
+		"session":             filepath.Join(base, "sessions", "s-1.json"),
+		"worktree":            filepath.Join(base, "task-worktrees", "wt-1", "file"),
+		"codex":               filepath.Join(base, "codex-headless", "cache"),
+		"providers":           filepath.Join(base, "providers", "claude-sessions.json"),
+		"openclaw":            filepath.Join(base, "openclaw", "identity.json"),
+		"config":              filepath.Join(base, "config.json"),
+		"calendar":            filepath.Join(base, "calendar.json"),
+		"wiki":                filepath.Join(base, "wiki", "team", "playbooks", "starter.md"),
+		"wikiBackup":          filepath.Join(base, "wiki.bak", "team", "playbooks", "starter.md"),
 	}
 	for _, p := range paths {
 		if err := os.MkdirAll(filepath.Dir(p), 0o700); err != nil {
@@ -77,13 +78,13 @@ func TestClearRuntimeRemovesBrokerStateOnly(t *testing.T) {
 	}
 
 	assertGone(t, "brokerState", paths["brokerState"])
-	assertGone(t, "officePID", paths["officePID"])
+	assertGone(t, "brokerStateSnapshot", paths["brokerStateSnapshot"])
 
 	// Everything else survives a narrow reset.
 	for _, label := range []string{
 		"onboarded", "company", "officeTasks", "workflow",
 		"logs", "session", "worktree", "codex", "providers",
-		"openclaw", "config", "calendar",
+		"officePID", "openclaw", "config", "calendar",
 	} {
 		assertStays(t, label, paths[label])
 	}
@@ -103,7 +104,7 @@ func TestShredRemovesWorkspaceHistoryButPreservesUserWorkAndConfig(t *testing.T)
 
 	// Wiped by shred.
 	for _, label := range []string{
-		"onboarded", "company", "brokerState", "officePID",
+		"onboarded", "company", "brokerState", "brokerStateSnapshot",
 		"officeTasks", "workflow", "logs", "session", "codex",
 		"providers", "calendar", "wiki", "wikiBackup",
 	} {
@@ -112,7 +113,7 @@ func TestShredRemovesWorkspaceHistoryButPreservesUserWorkAndConfig(t *testing.T)
 
 	// Preserved: in-flight work and user credentials/preferences.
 	for _, label := range []string{
-		"worktree", "openclaw", "config",
+		"officePID", "worktree", "openclaw", "config",
 	} {
 		assertStays(t, label, paths[label])
 	}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -719,7 +719,7 @@ export function resetWorkspace() {
 
 // shredWorkspace is the full wipe: broker runtime + team + company + office,
 // workflows, logs, sessions, provider state, and local markdown memory.
-// The broker exits after success; relaunch WUPHF to reopen onboarding.
+// The broker resets in place after success so onboarding can reopen immediately.
 export function shredWorkspace() {
   return postWithTimeout<WorkspaceWipeResult>("/workspace/shred", {}, 20_000);
 }

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -26,6 +26,7 @@ import {
   updateConfig,
   type WorkspaceWipeResult,
 } from "../../api/client";
+import { useAppStore } from "../../stores/app";
 import { showNotice } from "../ui/Toast";
 
 type SectionId =
@@ -1197,6 +1198,7 @@ function DangerZoneSection() {
   const [open, setOpen] = useState<DangerAction | null>(null);
   const [busy, setBusy] = useState(false);
   const queryClient = useQueryClient();
+  const resetForOnboarding = useAppStore((s) => s.resetForOnboarding);
 
   const handleReset = async () => {
     setBusy(true);
@@ -1225,12 +1227,11 @@ function DangerZoneSection() {
         return;
       }
       queryClient.clear();
+      window.history.replaceState(null, "", "#/channels/general");
+      resetForOnboarding();
       setOpen(null);
       setBusy(false);
-      showNotice(
-        "Workspace shredded. Relaunch wuphf to start onboarding.",
-        "success",
-      );
+      showNotice("Workspace shredded. Onboarding reopened.", "success");
     } catch (err) {
       showNotice(err instanceof Error ? err.message : "Shred failed", "error");
       setBusy(false);
@@ -1242,9 +1243,8 @@ function DangerZoneSection() {
       <div style={styles.sectionTitle}>Danger Zone</div>
       <div style={styles.sectionDesc}>
         Irreversible operations on this workspace. Reset reloads the current
-        broker. Shred wipes local workspace history, stops WUPHF after the
-        response returns, and requires a fresh
-        <code style={{ margin: "0 4px" }}>wuphf</code> launch.
+        broker. Shred wipes local workspace history and reopens onboarding in
+        the running web UI.
       </div>
 
       {/* RESET — narrow: broker runtime state only */}
@@ -1263,7 +1263,7 @@ function DangerZoneSection() {
           <li>
             Broker runtime state (<code>~/.wuphf/team/broker-state.json</code>)
           </li>
-          <li>Office PID file and in-memory snapshot</li>
+          <li>Last-good in-memory snapshot</li>
         </ul>
         <div style={dangerStyles.listLabel}>Preserved</div>
         <ul style={dangerStyles.list}>
@@ -1290,8 +1290,8 @@ function DangerZoneSection() {
         <div style={dangerStyles.cardSubtitle}>
           Full wipe. Deletes your team, company identity, office task receipts,
           saved workflows, local memory, logs, and provider session state, then
-          stops WUPHF. Use this to start completely fresh or to try a different
-          blueprint.
+          returns you to onboarding. Use this to start completely fresh or to try
+          a different blueprint.
         </div>
         <div style={dangerStyles.listLabel}>Deletes</div>
         <ul style={dangerStyles.list}>
@@ -1303,7 +1303,8 @@ function DangerZoneSection() {
             Company identity (<code>~/.wuphf/company.json</code>)
           </li>
           <li>
-            Team, office, workflows directories under <code>~/.wuphf/</code>
+            Team runtime state, office, and workflows under{" "}
+            <code>~/.wuphf/</code>
           </li>
           <li>
             Logs, sessions, provider state, calendar, and local wiki memory
@@ -1358,9 +1359,9 @@ function DangerZoneSection() {
             <>
               This permanently deletes your team, company identity, office task
               receipts, and saved workflows, plus local logs, sessions, provider
-              state, calendar, and wiki memory. WUPHF will stop after the wipe;
-              relaunch it to reopen onboarding. Task worktrees and config are
-              kept. <strong>This cannot be undone.</strong>
+              state, calendar, and wiki memory. Onboarding will reopen
+              immediately. Task worktrees, config, and device identity are kept.{" "}
+              <strong>This cannot be undone.</strong>
             </>
           }
           confirmLabel="Shred workspace"

--- a/web/src/stores/app.test.ts
+++ b/web/src/stores/app.test.ts
@@ -1,6 +1,24 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import { directChannelSlug, isDMChannel } from "./app";
+import { directChannelSlug, isDMChannel, useAppStore } from "./app";
+
+afterEach(() => {
+  useAppStore.setState({
+    currentChannel: "general",
+    currentApp: null,
+    activeThreadId: null,
+    lastMessageId: null,
+    activeAgentSlug: null,
+    searchOpen: false,
+    composerSearchInitialQuery: "",
+    composerHelpOpen: false,
+    onboardingComplete: false,
+    wikiPath: null,
+    wikiLookupQuery: null,
+    notebookAgentSlug: null,
+    notebookEntrySlug: null,
+  });
+});
 
 describe("DM channel helpers", () => {
   it("uses the broker canonical direct slug", () => {
@@ -13,5 +31,41 @@ describe("DM channel helpers", () => {
     expect(isDMChannel("human__pm", {})).toEqual({ agentSlug: "pm" });
     expect(isDMChannel("dm-ceo", {})).toEqual({ agentSlug: "ceo" });
     expect(isDMChannel("dm-human-ceo", {})).toEqual({ agentSlug: "ceo" });
+  });
+
+  it("resets navigation and onboarding state for a shred flow", () => {
+    useAppStore.setState({
+      currentChannel: "ceo__human",
+      currentApp: "settings",
+      activeThreadId: "thread-1",
+      lastMessageId: "msg-1",
+      activeAgentSlug: "ceo",
+      searchOpen: true,
+      composerSearchInitialQuery: "stuck task",
+      composerHelpOpen: true,
+      onboardingComplete: true,
+      wikiPath: "companies/acme",
+      wikiLookupQuery: "who owns renewal?",
+      notebookAgentSlug: "ceo",
+      notebookEntrySlug: "handoff",
+    });
+
+    useAppStore.getState().resetForOnboarding();
+
+    expect(useAppStore.getState()).toMatchObject({
+      currentChannel: "general",
+      currentApp: null,
+      activeThreadId: null,
+      lastMessageId: null,
+      activeAgentSlug: null,
+      searchOpen: false,
+      composerSearchInitialQuery: "",
+      composerHelpOpen: false,
+      onboardingComplete: false,
+      wikiPath: null,
+      wikiLookupQuery: null,
+      notebookAgentSlug: null,
+      notebookEntrySlug: null,
+    });
   });
 });

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -118,6 +118,7 @@ export interface AppStore {
   // Onboarding
   onboardingComplete: boolean;
   setOnboardingComplete: (v: boolean) => void;
+  resetForOnboarding: () => void;
 
   // Wiki
   wikiPath: string | null;
@@ -211,6 +212,22 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   onboardingComplete: false,
   setOnboardingComplete: (v) => set({ onboardingComplete: v }),
+  resetForOnboarding: () =>
+    set({
+      currentChannel: "general",
+      currentApp: null,
+      activeThreadId: null,
+      lastMessageId: null,
+      activeAgentSlug: null,
+      searchOpen: false,
+      composerSearchInitialQuery: "",
+      composerHelpOpen: false,
+      onboardingComplete: false,
+      wikiPath: null,
+      wikiLookupQuery: null,
+      notebookAgentSlug: null,
+      notebookEntrySlug: null,
+    }),
 
   wikiPath: null,
   setWikiPath: (path) => set({ wikiPath: path }),


### PR DESCRIPTION
## What changed

This changes the workspace shred flow so it wipes workspace state and sends the user straight back to onboarding without taking down the running broker.

On the web side, the Settings danger-zone shred action now resets app navigation state in-process and immediately re-enters onboarding instead of showing a success alert and forcing a page reload.

On the backend, the workspace wipe path now clears the live broker runtime in-process and only removes persisted broker state files rather than deleting the whole `~/.wuphf/team` directory. That keeps the broker available while still wiping the workspace data that shred is meant to remove.

## Why

Shredding a workspace was behaving like a destructive runtime teardown. In practice that could leave the broker stopped or looking stopped, which is the wrong contract for this action.

The intended behavior is simpler: wipe the workspace, keep the broker alive, and return the user to onboarding immediately.

## Impact

Users can shred a workspace from Settings and land directly in onboarding without an extra alert/reload cycle.

The broker keeps serving the web app during and after the wipe, so the session stays live and the app can transition cleanly.

## Root cause

The shred flow depended on deleting the broader runtime directory and then reloading the web app to reconstruct state later. That coupled data wipe behavior to broker lifecycle behavior.

## Validation

- `go test ./internal/workspace`
- `go test ./internal/team -run TestWebUIProxyHandlerForwardsOnboardingRoutes -count=1`
- `npm --prefix web test -- --run src/stores/app.test.ts` could not be run in this worktree because `vitest` is not installed locally (`sh: vitest: command not found`)
