### PR TITLE
[codex] Add web @all tagging

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -176,13 +176,15 @@ export function postMessage(
   content: string,
   channel: string,
   replyTo?: string,
+  tagged?: string[],
 ) {
-  const body: Record<string, string> = {
+  const body: Record<string, string | string[]> = {
     from: "you",
     channel: channel || "general",
     content,
   };
   if (replyTo) body.reply_to = replyTo;
+  if (tagged && tagged.length > 0) body.tagged = tagged;
   return post<Message>("/messages", body);
 }
 

--- a/web/src/components/messages/Autocomplete.test.tsx
+++ b/web/src/components/messages/Autocomplete.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { applyAutocomplete, currentTrigger } from "./Autocomplete";
+import {
+  applyAutocomplete,
+  currentTrigger,
+  mentionAutocompleteItems,
+} from "./Autocomplete";
 
 describe("currentTrigger", () => {
   describe("mention scoping — TUI parity with internal/tui/mention.go", () => {
@@ -71,5 +75,27 @@ describe("applyAutocomplete", () => {
     });
     expect(result.text).toBe("/ask ");
     expect(result.caret).toBe(5);
+  });
+});
+
+describe("mentionAutocompleteItems", () => {
+  const members = [
+    { slug: "ceo", name: "CEO" },
+    { slug: "pm", name: "Product" },
+    { slug: "human", name: "Human" },
+  ];
+
+  it("offers @all before individual agents", () => {
+    expect(mentionAutocompleteItems("", members).slice(0, 3)).toEqual([
+      { insert: "@all", label: "@all", desc: "Notify every agent", icon: "📣" },
+      { insert: "@ceo", label: "@ceo", desc: "CEO", icon: "🤖" },
+      { insert: "@pm", label: "@pm", desc: "Product", icon: "🤖" },
+    ]);
+  });
+
+  it("matches @all by prefix query", () => {
+    expect(mentionAutocompleteItems("al", members)).toEqual([
+      { insert: "@all", label: "@all", desc: "Notify every agent", icon: "📣" },
+    ]);
   });
 });

--- a/web/src/components/messages/Autocomplete.tsx
+++ b/web/src/components/messages/Autocomplete.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 
+import type { OfficeMember } from "../../api/client";
 import {
   FALLBACK_SLASH_COMMANDS,
   type SlashCommand,
@@ -25,6 +26,8 @@ export type { SlashCommand };
  * broker via useCommands; this is the offline fallback list.
  */
 export const SLASH_COMMANDS: SlashCommand[] = FALLBACK_SLASH_COMMANDS;
+
+const MAX_AUTOCOMPLETE_ITEMS = 8;
 
 interface AutocompleteProps {
   /** Current composer text. */
@@ -68,7 +71,7 @@ export function Autocomplete({
       const q = trigger.query.toLowerCase();
       return commands
         .filter((c) => c.name.slice(1).toLowerCase().startsWith(q))
-        .slice(0, 8)
+        .slice(0, MAX_AUTOCOMPLETE_ITEMS)
         .map((c) => ({
           insert: c.name,
           label: c.name,
@@ -76,23 +79,7 @@ export function Autocomplete({
           icon: c.icon,
         }));
     }
-    const q = trigger.query.toLowerCase();
-    return members
-      .filter((m) => m.slug && m.slug !== "human" && m.slug !== "you")
-      .filter((m) => {
-        if (!q) return true;
-        return (
-          (m.slug || "").toLowerCase().includes(q) ||
-          (m.name || "").toLowerCase().includes(q)
-        );
-      })
-      .slice(0, 8)
-      .map((m) => ({
-        insert: `@${m.slug}`,
-        label: `@${m.slug}`,
-        desc: m.name,
-        icon: m.emoji || "🤖",
-      }));
+    return mentionAutocompleteItems(trigger.query, members);
   }, [value, caret, members, commands]);
 
   useEffect(() => {
@@ -131,6 +118,41 @@ export function Autocomplete({
       ))}
     </div>
   );
+}
+
+export function mentionAutocompleteItems(
+  query: string,
+  members: Pick<OfficeMember, "slug" | "name" | "emoji">[],
+): AutocompleteItem[] {
+  const q = query.toLowerCase();
+  const items: AutocompleteItem[] = [];
+  if ("all".startsWith(q)) {
+    items.push({
+      insert: "@all",
+      label: "@all",
+      desc: "Notify every agent",
+      icon: "📣",
+    });
+  }
+  for (const member of members) {
+    if (!member.slug || member.slug === "human" || member.slug === "you")
+      continue;
+    if (
+      q &&
+      !member.slug.toLowerCase().includes(q) &&
+      !(member.name || "").toLowerCase().includes(q)
+    ) {
+      continue;
+    }
+    items.push({
+      insert: `@${member.slug}`,
+      label: `@${member.slug}`,
+      desc: member.name,
+      icon: member.emoji || "🤖",
+    });
+    if (items.length >= MAX_AUTOCOMPLETE_ITEMS) break;
+  }
+  return items;
 }
 
 /**

--- a/web/src/components/messages/Composer.tsx
+++ b/web/src/components/messages/Composer.tsx
@@ -11,7 +11,11 @@ import {
 } from "../../api/client";
 import { useCommands } from "../../hooks/useCommands";
 import { useOfficeMembers } from "../../hooks/useMembers";
-import { parseMentions, renderMentionTokens } from "../../lib/mentions";
+import {
+  extractTaggedMentions,
+  parseMentions,
+  renderMentionTokens,
+} from "../../lib/mentions";
 import { directChannelSlug, useAppStore } from "../../stores/app";
 import { confirm } from "../ui/ConfirmDialog";
 import { openProviderSwitcher } from "../ui/ProviderSwitcher";
@@ -92,6 +96,11 @@ interface SlashHandlers {
   leadSlug: string | undefined;
   /** Send the given text as a normal message (bypasses slash parsing). */
   sendAsMessage: (text: string) => void;
+}
+
+interface OutboundMessage {
+  content: string;
+  tagged: string[];
 }
 
 /**
@@ -368,7 +377,8 @@ export function Composer() {
   );
 
   const sendMutation = useMutation({
-    mutationFn: (content: string) => postMessage(content, currentChannel),
+    mutationFn: ({ content, tagged }: OutboundMessage) =>
+      postMessage(content, currentChannel, undefined, tagged),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["messages", currentChannel] });
     },
@@ -408,7 +418,10 @@ export function Composer() {
       const consumed = handleSlashCommand(trimmed, {
         leadSlug,
         sendAsMessage: (rewritten) => {
-          sendMutation.mutate(rewritten);
+          sendMutation.mutate({
+            content: rewritten,
+            tagged: extractTaggedMentions(rewritten, knownSlugs),
+          });
         },
       });
       if (consumed) {
@@ -421,9 +434,12 @@ export function Composer() {
     }
 
     pushHistory(currentChannel, trimmed);
-    sendMutation.mutate(trimmed);
+    sendMutation.mutate({
+      content: trimmed,
+      tagged: extractTaggedMentions(trimmed, knownSlugs),
+    });
     resetComposer();
-  }, [text, sendMutation, leadSlug, currentChannel, resetComposer]);
+  }, [text, sendMutation, leadSlug, currentChannel, resetComposer, knownSlugs]);
 
   /**
    * Walk backward through history. On first invocation, snapshot the live

--- a/web/src/components/messages/ThreadPanel.tsx
+++ b/web/src/components/messages/ThreadPanel.tsx
@@ -3,7 +3,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import type { Message } from "../../api/client";
 import { postMessage } from "../../api/client";
+import { useOfficeMembers } from "../../hooks/useMembers";
 import { useThreadMessages } from "../../hooks/useMessages";
+import { extractTaggedMentions } from "../../lib/mentions";
 import { useAppStore } from "../../stores/app";
 import { showNotice } from "../ui/Toast";
 import { MessageBubble } from "./MessageBubble";
@@ -17,6 +19,8 @@ export function ThreadPanel() {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
+  const { data: members = [] } = useOfficeMembers();
+  const knownSlugs = useMemo(() => members.map((m) => m.slug), [members]);
 
   const { data: messages = [] } = useThreadMessages(
     currentChannel,
@@ -82,7 +86,12 @@ export function ThreadPanel() {
 
   const sendReply = useMutation({
     mutationFn: (content: string) =>
-      postMessage(content, currentChannel, replyTarget),
+      postMessage(
+        content,
+        currentChannel,
+        replyTarget,
+        extractTaggedMentions(content, knownSlugs),
+      ),
     onSuccess: () => {
       setText("");
       setQuoting(null);

--- a/web/src/lib/mentions.test.ts
+++ b/web/src/lib/mentions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { parseMentions } from "./mentions";
+import { extractTaggedMentions, parseMentions } from "./mentions";
 
 describe("parseMentions", () => {
   const agents = ["pm", "ceo", "founding-engineer"];
@@ -83,6 +83,41 @@ describe("parseMentions", () => {
     expect(tokens).toEqual([
       { kind: "mention", value: "pm" },
       { kind: "text", value: " @PM" },
+    ]);
+  });
+
+  it("treats @all as a special mention chip", () => {
+    expect(parseMentions("ping @all now", agents)).toEqual([
+      { kind: "text", value: "ping " },
+      { kind: "mention", value: "all" },
+      { kind: "text", value: " now" },
+    ]);
+  });
+});
+
+describe("extractTaggedMentions", () => {
+  const agents = ["pm", "ceo", "founding-engineer", "human"];
+
+  it("returns explicit agent mentions in order", () => {
+    expect(extractTaggedMentions("ping @pm then @ceo", agents)).toEqual([
+      "pm",
+      "ceo",
+    ]);
+  });
+
+  it("expands @all to every mentionable agent slug", () => {
+    expect(extractTaggedMentions("ping @all now", agents)).toEqual([
+      "pm",
+      "ceo",
+      "founding-engineer",
+    ]);
+  });
+
+  it("deduplicates explicit mentions when @all is present", () => {
+    expect(extractTaggedMentions("ping @pm and @all", agents)).toEqual([
+      "pm",
+      "ceo",
+      "founding-engineer",
     ]);
   });
 });

--- a/web/src/lib/mentions.tsx
+++ b/web/src/lib/mentions.tsx
@@ -7,10 +7,31 @@ import type { ReactNode } from "react";
  * highlighting exactly what the backend stops routing. Keep the two in sync.
  */
 const MENTION_RE = /(?:^|[^a-zA-Z0-9_])@([a-z0-9][a-z0-9-]{1,29})\b/g;
+const SPECIAL_MENTION_SLUGS = ["all"] as const;
+const NON_MENTIONABLE_SLUGS = new Set(["human", "you", "system"]);
 
 export interface MentionToken {
   kind: "text" | "mention";
   value: string;
+}
+
+function normalizeMentionableSlugs(knownSlugs: readonly string[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const raw of knownSlugs) {
+    const slug = raw.trim().toLowerCase();
+    if (!slug || NON_MENTIONABLE_SLUGS.has(slug) || seen.has(slug)) continue;
+    seen.add(slug);
+    out.push(slug);
+  }
+  return out;
+}
+
+function knownMentionSet(knownSlugs: readonly string[]): Set<string> {
+  return new Set([
+    ...normalizeMentionableSlugs(knownSlugs),
+    ...SPECIAL_MENTION_SLUGS,
+  ]);
 }
 
 /**
@@ -27,7 +48,7 @@ export function parseMentions(
   knownSlugs: readonly string[],
 ): MentionToken[] {
   if (!content) return [];
-  const known = new Set(knownSlugs.map((s) => s.toLowerCase()));
+  const known = knownMentionSet(knownSlugs);
   const out: MentionToken[] = [];
   let lastIdx = 0;
   // matchAll over a fresh regex avoids lastIndex leaking between invocations.
@@ -49,6 +70,37 @@ export function parseMentions(
     out.push({ kind: "text", value: content.slice(lastIdx) });
   }
   return out;
+}
+
+/**
+ * Extract the agent slugs that should be sent in the broker's `tagged`
+ * payload. `@all` expands to every known agent slug because the HTTP
+ * message endpoint validates tagged members individually.
+ */
+export function extractTaggedMentions(
+  content: string,
+  knownSlugs: readonly string[],
+): string[] {
+  if (!content) return [];
+  const available = normalizeMentionableSlugs(knownSlugs);
+  const known = knownMentionSet(knownSlugs);
+  const tagged: string[] = [];
+  const seen = new Set<string>();
+  let wantsAll = false;
+  const re = new RegExp(MENTION_RE.source, "g");
+  for (const match of content.matchAll(re)) {
+    const slug = match[1]?.toLowerCase();
+    if (!slug || !known.has(slug)) continue;
+    if (slug === "all") {
+      wantsAll = true;
+      continue;
+    }
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    tagged.push(slug);
+  }
+  if (wantsAll) return available;
+  return tagged;
 }
 
 export function renderMentionTokens(tokens: MentionToken[]): ReactNode[] {


### PR DESCRIPTION
## What changed
- added `@all` as a first-class web mention in the autocomplete and mention token renderer
- taught the web client to derive an explicit `tagged` payload from typed mentions before posting messages
- expanded `@all` to all mentionable agent slugs for both the main composer and thread replies
- added tests for `@all` parsing, expansion, and autocomplete ordering

## Why
The broker already supports all-agent wakeups, but the web client only rendered mention chips and sent raw message text. That meant `@all` was missing from the web UX, and web-authored mentions were not consistently promoted into explicit tags at send time.

## Impact
Web users can now type or autocomplete `@all` and get the same broadcast behavior available in the TUI. Regular web mentions also post a concrete `tagged` array, which keeps routing aligned with the visible chips.

## Validation
- `npm run typecheck`
- `npm test`