### PR TITLE
fix(web): AgentPanel closes instantly on click (web-e2e regression)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -8,6 +8,10 @@ go build -o wuphf ./cmd/wuphf
 
 For normal app usage you do not need Bun. The local office/team MCP tools now run from the main Go binary through the hidden `wuphf mcp-team` subcommand.
 
+## Git hooks
+
+Hooks run via [lefthook](https://github.com/evilmartians/lefthook) (`lefthook.yml`). On `pre-push` the full Go test suite and a `cmd/wuphf` build are executed; on `pre-commit` gofmt/go vet/golangci-lint run against staged Go files. Do not push with `--no-verify` — fix the underlying failure instead.
+
 ## Latest Published CLI
 
 The old standalone CLI is no longer vendored in this repo.

--- a/internal/onboarding/prereqs.go
+++ b/internal/onboarding/prereqs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/runtimebin"
@@ -51,12 +52,25 @@ var prereqSpecs = map[string]prereqSpec{
 // CLI runtimes must be present for wuphf to actually run a turn, but all are
 // marked optional here so the user can proceed with whichever runtime
 // they have.
+//
+// Probes run concurrently. CheckOne's per-probe timeout is 10s (see comment
+// there for rationale) and CheckAll is invoked from an HTTP handler with a
+// 5s client deadline at cmd/wuphf/onboarding.go; running probes serially
+// would mean worst-case wall-clock = 7 × 10s = 70s, far past any sane HTTP
+// budget. Concurrent probes cap wall-clock at max(probe), well under the
+// client timeout. Order of `names` is preserved in the returned slice.
 func CheckAll() []PrereqResult {
 	names := []string{"node", "git", "claude", "codex", "opencode", "cursor", "windsurf"}
-	results := make([]PrereqResult, 0, len(names))
-	for _, name := range names {
-		results = append(results, CheckOne(name))
+	results := make([]PrereqResult, len(names))
+	var wg sync.WaitGroup
+	wg.Add(len(names))
+	for i, name := range names {
+		go func(i int, name string) {
+			defer wg.Done()
+			results[i] = CheckOne(name)
+		}(i, name)
 	}
+	wg.Wait()
 	return results
 }
 

--- a/internal/onboarding/prereqs.go
+++ b/internal/onboarding/prereqs.go
@@ -80,7 +80,13 @@ func CheckOne(name string) PrereqResult {
 	r.OK = true
 
 	// Best-effort version capture; ignore errors.
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	//
+	// 10s (up from 3s) to keep the probe reliable when the machine is under
+	// parallel test load — `go test ./...` can stack 20+ concurrent fork+exec
+	// calls, and a 3s window was flaky on a developer laptop running the
+	// pre-push hook. This is a one-shot `--version` probe, not a hot path;
+	// the timeout is a floor on machine health, not on binary response time.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, path, "--version").Output()
 	if err == nil {

--- a/internal/team/wiki_extractor_closure_test.go
+++ b/internal/team/wiki_extractor_closure_test.go
@@ -375,9 +375,16 @@ func countNonEmptyLines(t *testing.T, path string) int {
 // commitCountForPath returns the number of commits that touched relPath.
 // Uses `git log --oneline -- <path>` so the test does not depend on any
 // internal helper.
+//
+// Clean the subprocess env so the lookup isn't hijacked by an inherited
+// GIT_DIR — when tests run under a pre-push hook, git exports GIT_DIR
+// pointing at the outer repo and `git log` would then query the outer
+// history (zero commits touching wiki/facts/**) instead of this test's
+// fixture repo. Same pattern as internal/migration/writer_test.go.
 func commitCountForPath(t *testing.T, repoRoot, relPath string) int {
 	t.Helper()
 	cmd := exec.Command("git", "-C", repoRoot, "log", "--oneline", "--", relPath)
+	cmd.Env = GitCleanEnv()
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git log %s: %v: %s", relPath, err, out)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -29,6 +29,9 @@ pre-commit:
         - "dist/**"
         - "node_modules/**"
         - "bun.lock"
+        - "web/bun.lock"
+        - "package-lock.json"
+        - "web/package-lock.json"
         - "**/*.gen.ts"
         - "**/*.gen.tsx"
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -26,6 +26,7 @@
         "zustand": "^5.0.5"
       },
       "devDependencies": {
+        "@biomejs/biome": "2.4.13",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -363,6 +364,169 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.13.tgz",
+      "integrity": "sha512-gLXOwkOBBg0tr7bDsqlkIh4uFeKuMjxvqsrb1Tukww1iDmHcfr4Uu8MoQxp0Rcte+69+osRNWXwHsu/zxT6XqA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.13",
+        "@biomejs/cli-darwin-x64": "2.4.13",
+        "@biomejs/cli-linux-arm64": "2.4.13",
+        "@biomejs/cli-linux-arm64-musl": "2.4.13",
+        "@biomejs/cli-linux-x64": "2.4.13",
+        "@biomejs/cli-linux-x64-musl": "2.4.13",
+        "@biomejs/cli-win32-arm64": "2.4.13",
+        "@biomejs/cli-win32-x64": "2.4.13"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.13.tgz",
+      "integrity": "sha512-2KImO1jhNFBa2oWConyr0x6flxbQpGKv6902uGXpYM62Xyem8U80j441SyUJ8KyngsmKbQjeIv1q2CQfDkNnYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.13.tgz",
+      "integrity": "sha512-BKrJklbaFN4p1Ts4kPBczo+PkbsHQg57kmJ+vON9u2t6uN5okYHaSr7h/MutPCWQgg2lglaWoSmm+zhYW+oOkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.13.tgz",
+      "integrity": "sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.13.tgz",
+      "integrity": "sha512-U5MsuBQW25dXaYtqWWSPM3P96H6Y+fHuja3TQpMNnylocHW0tEbtFTDlUj6oM+YJLntvEkQy4grBvQNUD4+RCg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.13.tgz",
+      "integrity": "sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.13.tgz",
+      "integrity": "sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.13.tgz",
+      "integrity": "sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.13.tgz",
+      "integrity": "sha512-tTcMkXyBrmHi9BfrD2VNHs/5rYIUKETqsBlYOvSAABwBkJhSDVb5e7wPukftsQbO3WzQkXe6kaztC6WtUOXSoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Xmark } from "iconoir-react";
 
@@ -365,18 +365,25 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
 export function AgentPanel() {
   const activeAgentSlug = useAppStore((s) => s.activeAgentSlug);
   const setActiveAgentSlug = useAppStore((s) => s.setActiveAgentSlug);
-  const _currentChannel = useAppStore((s) => s.currentChannel);
-  const _currentApp = useAppStore((s) => s.currentApp);
+  const currentChannel = useAppStore((s) => s.currentChannel);
+  const currentApp = useAppStore((s) => s.currentApp);
   const { data: members = [] } = useOfficeMembers();
   const panelRef = useRef<HTMLDivElement>(null);
 
-  const close = () => setActiveAgentSlug(null);
+  const close = useCallback(
+    () => setActiveAgentSlug(null),
+    [setActiveAgentSlug],
+  );
 
-  // Close when user navigates to a different sidebar section.
+  // Close when user navigates to a different sidebar section. The intent is
+  // "nav away from the agent panel" — driven by currentChannel / currentApp,
+  // NOT by activeAgentSlug itself. The previous version depended on
+  // activeAgentSlug and closed whenever one was set, so clicking any agent
+  // instantly un-selected it and the panel never mounted (React #31 guard
+  // e2e regression).
   useEffect(() => {
-    if (activeAgentSlug) close();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeAgentSlug, close]);
+    close();
+  }, [currentChannel, currentApp, close]);
 
   // Close on outside click — ignore clicks on sidebar agent items that would
   // just re-open the panel, and ignore clicks inside the panel itself.
@@ -393,7 +400,6 @@ export function AgentPanel() {
     };
     document.addEventListener("mousedown", onDown);
     return () => document.removeEventListener("mousedown", onDown);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeAgentSlug, close]);
 
   if (!activeAgentSlug) return null;


### PR DESCRIPTION
## Summary

Restores `web-e2e` to green. The `smoke.spec.ts › clicking an agent does not crash the UI` test has been red on every PR and on main since #276 merged. The failure is in `AgentPanel`, not in biome — it was latent and only surfaced after the biome lockfile adoption CI re-enabled the e2e on every run.

## Root cause

\`\`\`tsx
// AgentPanel.tsx (before)
useEffect(() => {
  if (activeAgentSlug) close();
  // eslint-disable-next-line react-hooks/exhaustive-deps
}, [activeAgentSlug, close]);
\`\`\`

Intent per comment: "Close when user navigates to a different sidebar section."
Implementation: close immediately whenever *any* agent becomes active.

Clicking a sidebar agent sets `activeAgentSlug = 'ceo'` → this effect fires → `close()` → `activeAgentSlug = null` → panel never mounts → `.agent-panel` locator times out after 10s. The two dead `_currentChannel` / `_currentApp` selectors at the top of the component were the intended deps (real sidebar navigation triggers) — the backwards `activeAgentSlug` trigger is what broke the loop.

Compounded by `close` not being memoized, so both effects re-ran every render. The `eslint-disable-next-line react-hooks/exhaustive-deps` comments in the original code were a smell pointing at this churn.

## Fix

1. Depend on `currentChannel` / `currentApp` (the real nav signals), not `activeAgentSlug`.
2. Memoize `close` via `useCallback` so deps are stable and effects don't re-run every render.
3. Drop the obsolete `eslint-disable` comments.

## Test plan

- [x] `web/e2e/tests/smoke.spec.ts` all 3 tests pass locally
- [x] `web/e2e/tests/wizard.spec.ts` all 3 tests pass locally (no regression)
- [x] `bun run typecheck` + `bun run build` clean
- [x] pre-push hook green, no \`--no-verify\`
- [ ] CI `web-e2e` job goes green

## Base

Based on `fix/pre-push-hooks` (PR #277) — needs the GIT_DIR test helper fix from that PR for pre-push to pass. When #277 merges, this auto-rebases. Same pattern as PRs #278/#279/#280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)