### PR TITLE
chore(ci): pin workflows to SHAs + add commitlint & ratchet-check

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,7 +22,7 @@ jobs:
     # The if: expression is evaluated by GitHub, not a shell — no injection risk.
     if: "!contains(github.event.head_commit.message, '[skip-release]')"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       # Pin to full SHA: third-party action, runs on pull_request from forks
       # and can read any GITHUB_TOKEN the workflow exposes. A @v2 re-tag
       # would execute with CI privileges. Same SHA is reused in the web-e2e
@@ -28,7 +28,7 @@ jobs:
           bun install --frozen-lockfile
           bun run typecheck
           bun run build
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: web-dist
           path: web/dist
@@ -37,8 +37,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Check gofmt
@@ -88,8 +88,8 @@ jobs:
     outputs:
       packages: ${{ steps.list.outputs.packages }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - id: list
@@ -125,11 +125,11 @@ jobs:
         include: ${{ fromJSON(needs.go-test-list.outputs.packages) }}
     name: "go test ${{ matrix.package }}"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: web-dist
           path: web/dist
@@ -151,8 +151,8 @@ jobs:
   vet:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: Vet
@@ -162,11 +162,11 @@ jobs:
     needs: web
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: web-dist
           path: web/dist
@@ -183,8 +183,8 @@ jobs:
       TTYD_VERSION: "1.7.7"
       TTYD_SHA256: "8a217c968aba172e0dbf3f34447218dc015bc4d5e59bf51db2f2cd12b7be4f55"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           # VHS tracks newer Go minors than go.mod pins; use stable so
           # `go install vhs` isn't blocked by GOTOOLCHAIN=local (Go is
@@ -192,7 +192,7 @@ jobs:
           go-version: stable
       - name: Cache VHS binary
         id: cache-vhs
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5.0.5
         with:
           path: ~/go/bin/vhs
           key: vhs-${{ runner.os }}-${{ env.VHS_VERSION }}
@@ -201,7 +201,7 @@ jobs:
         run: go install github.com/charmbracelet/vhs@${{ env.VHS_VERSION }}
       - name: Cache ttyd download
         id: cache-ttyd
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5.0.5
         with:
           path: /tmp/ttyd.x86_64
           key: ttyd-${{ runner.os }}-${{ env.TTYD_VERSION }}-${{ env.TTYD_SHA256 }}
@@ -238,7 +238,7 @@ jobs:
           bash testdata/vhs/check.sh
       - name: Upload drift artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: vhs-drift
           path: testdata/vhs/*.actual
@@ -247,7 +247,7 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - name: Run shellcheck
         run: |
           sudo apt-get install -y shellcheck
@@ -261,8 +261,8 @@ jobs:
     needs: web
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
       # Pin to full SHA: third-party action, runs on every PR. A @v2 re-tag
@@ -271,7 +271,7 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: "1.1.38"
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: web-dist
           path: web/dist
@@ -282,7 +282,7 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Cache Playwright browsers
         id: cache-playwright
-        uses: actions/cache@v5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5.0.5
         with:
           path: ~/.cache/ms-playwright
           # Key on the resolved @playwright/test version via bun.lock so a
@@ -388,14 +388,14 @@ jobs:
           fi
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: playwright-report
           path: web/e2e/playwright-report
           retention-days: 7
       - name: Upload wuphf logs on failure
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: wuphf-e2e-logs
           path: |
@@ -408,17 +408,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: web
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v8
         with:
           name: web-dist
           path: web/dist
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # ratchet:goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --snapshot --clean --skip=publish

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,60 @@
+name: commitlint
+# Validates that every commit on a PR matches the conventional-commits
+# format defined in .commitlintrc.json. Mirrors the lefthook commit-msg
+# hook (lefthook.yml :: commitlint) so commits that bypass the local hook
+# (e.g. via the GitHub UI or --no-verify) are still caught at PR time.
+#
+# This is the only mandatory workflow from the org policy that wuphf was
+# missing pre-#283 (per nex-crm/.github :: org-rulesets/required-workflows).
+# Public-repo convention is to inline rather than delegate, matching
+# secret-scan.yml in this repo.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: commitlint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Need history back to the merge base so commitlint can lint
+          # every commit on the PR, not just the head.
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.10"
+
+      - name: Install commitlint
+        run: bun install --frozen-lockfile
+
+      - name: Lint commits
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            from="origin/${{ github.base_ref }}"
+            to="HEAD"
+          else
+            # push to main: lint just the new commits in this push.
+            from="${{ github.event.before }}"
+            to="${{ github.sha }}"
+            # Initial branch push has before=000…0; in that case lint
+            # only the head commit so we don't trip on pre-policy history.
+            if [ "$from" = "0000000000000000000000000000000000000000" ]; then
+              from="$(git rev-parse HEAD~1 2>/dev/null || echo HEAD)"
+            fi
+          fi
+          echo "linting $from..$to"
+          bunx --bun commitlint --from "$from" --to "$to" --verbose

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,16 +23,16 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # ratchet:actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # ratchet:actions/upload-pages-artifact@v5
         with:
           path: website/
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # ratchet:actions/deploy-pages@v5

--- a/.github/workflows/ratchet-check.yml
+++ b/.github/workflows/ratchet-check.yml
@@ -1,0 +1,59 @@
+name: ratchet-check
+# Drift gate for action SHA-pinning. Fails if any workflow under
+# .github/workflows references a third-party action by tag/branch instead
+# of a 40-char commit SHA — supply-chain hardening: a re-tagged action
+# would otherwise execute with whatever permissions the workflow has,
+# silently. ratchet (sethvargo/ratchet) checks both the file and the
+# resolution of any `# v…` trailing comments.
+#
+# Local fix when this fails:
+#   go install github.com/sethvargo/ratchet@v0.11.4
+#   ratchet pin .github/workflows/<file>.yml
+#
+# Skipped on docs-only diffs (paths filter) so docs PRs don't pay the
+# Go install cost.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ratchet-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          # No go.mod-version mode: ratchet has its own go.mod, we just
+          # need any modern Go to build it. Match the major used elsewhere
+          # in this workflow set.
+          go-version: stable
+
+      - name: Install ratchet
+        # SHA-pinned to v0.11.4. Update this commit when bumping; CI fails
+        # closed if the pin and the resolved tag drift.
+        run: go install github.com/sethvargo/ratchet@8b4ca256dbed184350608a3023620f267f0a5253 # v0.11.4
+
+      - name: ratchet check
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(.github/workflows/*.yml .github/workflows/*.yaml)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "no workflow files to check"
+            exit 0
+          fi
+          ratchet check "${files[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
           done
           test "$missing" -eq 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
 
@@ -52,7 +52,7 @@ jobs:
 
       - run: go test ./...
 
-      - uses: goreleaser/goreleaser-action@v7
+      - uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # ratchet:goreleaser/goreleaser-action@v7
         with:
           version: latest
           args: release --clean
@@ -71,9 +71,9 @@ jobs:
     env:
       VERSION: ${{ needs.release.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
@@ -98,7 +98,7 @@ jobs:
     env:
       VERSION: ${{ needs.release.outputs.version }}
     steps:
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
         with:
           node-version: "20"
 


### PR DESCRIPTION
## Summary

Three audit items from `NEX_CRM_REPO_AUDIT_2026_04_24.md` (Tables A/D/E, wuphf row):

1. **SHA-pin every third-party action.** `ratchet pin` over `ci.yml`, `release.yml`, `auto-release.yml`, `pages.yml`. Tag preserved as trailing comment. Closes the supply-chain hole where a re-tag of `actions/checkout@v6` or `goreleaser-action@v7` would silently run new code with the workflow's permissions.

2. **`ratchet-check.yml` drift gate.** Triggers on any PR touching `.github/workflows/**` and on push to main. Fails closed if a tag-only ref slips back in. `ratchet` itself is SHA-pinned to `v0.11.4`.

3. **`commitlint.yml`** — the only mandatory workflow from the org policy that wuphf was missing. Mirrors the lefthook commit-msg hook so commits via the GitHub UI or `--no-verify` are still caught at PR time.

Inlined rather than delegated, matching this repo's `secret-scan.yml` convention (audit calls it INL-GOOD) — wuphf is public and benefits from showing the full workflow shape in-tree.

## Branch protection (companion, not in this PR)

`required_status_checks` on `main` is the natural follow-up. Once these checks have run and appeared in the GitHub protection-rule UI, flip:

\`\`\`
gh api -X PUT repos/nex-crm/wuphf/branches/main/protection \\
  --input <ruleset.json>   # contexts: build,lint,vet,web,web-e2e,vhs,shellcheck,release-build,go-test-list,scan,commitlint,check
\`\`\`

I drafted the JSON during this session but the API call needs admin auth; held back so you can review the exact context list before flipping.

## Test plan

- [x] \`ratchet lint .github/workflows/*.yml\` clean
- [x] \`bunx commitlint --from origin/main~5 --to origin/main\` 0 problems
- [x] Pre-push hook green, no \`--no-verify\`
- [ ] CI runs all 12 jobs (the 10 existing + 2 new) green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)