### PR TITLE
chore: add CODEOWNERS and bump README Go badge to 1.25+

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,46 @@
+# wuphf code owners
+#
+# This file is currently advisory: branch protection on `main` does NOT
+# have `require_code_owner_reviews` enabled, so GitHub will auto-suggest
+# reviewers from this list but a PR can still merge without their
+# approval. The intent is that the file moves with the codebase as
+# ownership shifts; flipping branch protection to enforce is a one-line
+# admin action when the team is ready.
+#
+# Order matters in CODEOWNERS: the LAST matching pattern wins. So the
+# global default sits first, then more specific overrides.
+
+# Global default: every change pings the maintainer.
+*   @FranDias
+
+# Go service code & tests
+/cmd/                       @FranDias @nex-crm/backend
+/internal/                  @FranDias @nex-crm/backend
+/tests/                     @FranDias @nex-crm/backend
+go.mod                      @FranDias @nex-crm/backend
+go.sum                      @FranDias @nex-crm/backend
+
+# Web UI (vite + React + biome)
+/web/                       @FranDias @nex-crm/web
+
+# Build, release, and supply-chain hygiene — owners across both teams,
+# since a regression here breaks every consumer of every artifact.
+/.github/                   @FranDias @nex-crm/backend @nex-crm/web
+/scripts/                   @FranDias @nex-crm/backend
+/lefthook.yml               @FranDias @nex-crm/backend @nex-crm/web
+/.golangci.yml              @FranDias @nex-crm/backend
+/.goreleaser.yml            @FranDias @nex-crm/backend
+/.commitlintrc.json         @FranDias @nex-crm/backend @nex-crm/web
+/.secretlintrc.json         @FranDias @nex-crm/backend @nex-crm/web
+
+# Public-facing surfaces
+README.md                   @FranDias
+CHANGELOG.md                @FranDias
+DESIGN.md                   @FranDias
+DESIGN-WIKI.md              @FranDias
+DESIGN-NOTEBOOK.md          @FranDias
+DEVELOPMENT.md              @FranDias
+ARCHITECTURE.md             @FranDias
+
+# CODEOWNERS itself: only the maintainer can repoint ownership.
+/.github/CODEOWNERS         @FranDias

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Discord](https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white)](https://discord.gg/gjSySC3PzV)
 [![License: MIT](https://img.shields.io/badge/License-MIT-A87B4F)](LICENSE)
-[![Go](https://img.shields.io/badge/Go-1.22+-00ADD8?logo=go&logoColor=white)](go.mod)
+[![Go](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go&logoColor=white)](go.mod)
 
 ### Slack for AI employees with a shared brain.
 


### PR DESCRIPTION
## Summary

Two more audit items from \`NEX_CRM_REPO_AUDIT_2026_04_24.md\` (Tables B and E for wuphf), both small and independent of #283:

1. **\`.github/CODEOWNERS\`** — was flagged absent in Table B. Advisory by design (branch protection's \`require_code_owner_reviews\` is intentionally off; flipping it is a separate admin action). With the file present, GitHub auto-suggests the right reviewer set per PR.
2. **README Go badge** — Table E noted the badge claimed Go 1.22+ while \`go.mod\` says \`go 1.25.9\`. Bumped to 1.25+.

## Out of scope (intentional)

- **\`release.yml\` workflow_dispatch env gate** (audit's 🔴 risk row for wuphf). Adding \`environment: npm\` to the \`publish-npm\` job requires creating a matching GitHub Environment in repo settings *first* — otherwise the next release tag fails at runtime. Better as an admin action: create the env, optionally add required reviewers, *then* land the \`environment:\` line. Happy to ship that PR once the env exists.

## Test plan

- [x] Pre-push hook green, no \`--no-verify\`
- [x] CODEOWNERS syntax: validated by GitHub when the PR is opened (the PR's "Code owners" sidebar will populate)
- [x] README badge URL renders to a valid shields.io image (same template, only the version string changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the minimum Go version requirement to Go-1.25+ in project documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->