### PR TITLE
chore(ci): cover web/+web/e2e/+npm/ in dependabot + scope CI permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,7 @@ updates:
       prefix: "chore"
       include: "scope"
 
+  # Root: dev-only tooling (secretlint, commitlint, @secretlint rule presets).
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
@@ -40,4 +41,54 @@ updates:
         patterns: ["*"]
     commit-message:
       prefix: "chore"
+      include: "scope"
+
+  # Web frontend (React/vite). Uses bun.lock locally; dependabot reads
+  # package.json directly. Without this entry, biome / vitest / vite /
+  # tailwind bumps land manually only.
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    groups:
+      web-dependencies:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(web)"
+      include: "scope"
+
+  # Playwright e2e harness. Self-contained workspace under web/e2e/ so
+  # @playwright/test bumps don't entangle the main web build.
+  - package-ecosystem: "npm"
+    directory: "/web/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    groups:
+      e2e-dependencies:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(e2e)"
+      include: "scope"
+
+  # npm wrapper that ships `npx wuphf` to the npm registry. Bumps here
+  # affect the public install surface — keep its own group so they get
+  # individual review, not lumped with the dev-tooling root group.
+  - package-ecosystem: "npm"
+    directory: "/npm"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    groups:
+      npm-wrapper-dependencies:
+        patterns: ["*"]
+    commit-message:
+      prefix: "chore(npm)"
       include: "scope"

--- a/.github/workflows/approve-on-comment.yml
+++ b/.github/workflows/approve-on-comment.yml
@@ -9,6 +9,12 @@ on:
   issue_comment:
     types: [created]
 
+# Top-level floor at the empty set; the actual approve job below uses a
+# minted GitHub App token with its own scoped permissions. Without this
+# block, a sibling job added later would inherit the org default of
+# `write` on every scope.
+permissions: {}
+
 jobs:
   approve:
     if: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+# Tighten the org default (`default_workflow_permissions: write`) — every
+# job in CI is read-only against the repo. The matrix legs that need to
+# upload-artifact / download-artifact rely on actions/upload-artifact's
+# self-managed temporary token and don't need write contents.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,6 +19,13 @@ on:
   push:
     branches: [main]
 
+# Belt-and-suspenders: per-job `permissions: contents: read` already
+# tightens the scan job below, but a future contributor adding a sibling
+# job (e.g. a comment-poster) without an explicit block would inherit
+# the org default of `write`. Lock the floor at `read` here.
+permissions:
+  contents: read
+
 concurrency:
   group: secret-scan-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

Two more audit items, both about closing supply-chain gaps:

1. **Dependabot directory coverage.** Audit Table D flagged \`web/package.json\` and \`npm/package.json\` as uncovered, plus \`web/e2e/package.json\` (Playwright workspace) was never covered. Adds three new dependabot entries — \`/web\`, \`/web/e2e\`, \`/npm\` — each with its own group and commit-message scope so the changelog stays readable.
2. **Workflow permissions floor.** Audit Table G #2 says \`default_workflow_permissions: write\` org-wide → every workflow without explicit \`permissions:\` runs with \`write\`. Adds top-level blocks: \`ci.yml\` and \`secret-scan.yml\` floor at \`contents: read\`, \`approve-on-comment.yml\` at \`{}\`. The org-wide flip is admin-only; locking at the per-repo level here lets that flip land later without surprising wuphf.

## Stacks cleanly with other open PRs

Independent diffs from #283 (workflow SHA-pinning, commitlint, ratchet) and #284 (CODEOWNERS, README badge). All three can merge in any order.

## Test plan

- [x] Dependabot YAML validates (schema)
- [x] ratchet lint clean on the four files touched (the 41 violations ratchet reports on this branch are all in unchanged files like \`pages.yml\` — fixed by #283)
- [x] Pre-push hook green, no \`--no-verify\`
- [ ] CI runs all checks green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)