### PR TITLE
test(team): characterize broker state persistence before Track A refactor

### DIFF
--- a/internal/team/broker_restart_integration_test.go
+++ b/internal/team/broker_restart_integration_test.go
@@ -1,0 +1,146 @@
+package team
+
+// End-to-end broker-restart integration test. Exercises the full
+// save-side path for two unrelated mutations (custom channel + custom
+// office member) via HTTP handlers, then reloads the state from disk
+// via reloadedBroker(t) and asserts both mutations survived.
+//
+// The existing TestBrokerPersistsAndReloadsState covers in-memory
+// saveLocked → reloadedBroker. This test covers the shape we actually
+// ship: a caller POSTs to an HTTP handler, the handler triggers
+// saveLocked as a side effect, the state file lands on disk, and a
+// fresh broker on the same path sees the mutation. This is the seam
+// Track A most easily silently breaks (e.g. the handler's closure
+// captures a stale statePath, writes to the wrong file, the next
+// construction starts fresh and the test passes in isolation but the
+// user's real state is gone).
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+func TestBrokerStatePersistsAcrossReload_ChannelAndMember(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "broker-state.json")
+	oldPathFn := brokerStatePath
+	brokerStatePath = func() string { return statePath }
+	t.Cleanup(func() { brokerStatePath = oldPathFn })
+
+	b := NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("StartOnPort: %v", err)
+	}
+
+	post := func(path string, body any) *http.Response {
+		t.Helper()
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", path, err)
+		}
+		req, err := http.NewRequest(http.MethodPost, "http://"+b.Addr()+path, bytes.NewReader(data))
+		if err != nil {
+			t.Fatalf("NewRequest %s: %v", path, err)
+		}
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST %s: %v", path, err)
+		}
+		return resp
+	}
+
+	// Create a custom channel. Explicitly empty Members so the handler
+	// doesn't try to validate against defaults; "ceo" is auto-prepended
+	// by the handler anyway.
+	channelBody := map[string]any{
+		"action":      "create",
+		"slug":        "persistence-test",
+		"name":        "Persistence Test",
+		"description": "Created by TestBrokerStatePersistsAcrossReload",
+		"created_by":  "ceo",
+	}
+	if resp := post("/channels", channelBody); resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		t.Fatalf("POST /channels: status %d", resp.StatusCode)
+	} else {
+		resp.Body.Close()
+	}
+
+	// Create a custom member on claude-code (the default provider; no
+	// openclaw bridge required). This exercises a different saveLocked
+	// call site than the channel handler.
+	memberBody := map[string]any{
+		"action": "create",
+		"slug":   "persistence-pm",
+		"name":   "Persistence PM",
+		"role":   "Product Manager",
+		"provider": map[string]any{
+			"kind":  provider.KindClaudeCode,
+			"model": "claude-sonnet-4-5",
+		},
+	}
+	if resp := post("/office-members", memberBody); resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		t.Fatalf("POST /office-members: status %d", resp.StatusCode)
+	} else {
+		resp.Body.Close()
+	}
+
+	// Stop the original broker. The HTTP handlers should have already
+	// persisted both mutations; Stop just drains goroutines and closes
+	// the server.
+	b.Stop()
+
+	// Fresh broker on the same path, loads from disk. reloadedBroker
+	// constructs a Broker and explicitly calls loadState — the only
+	// way to opt back into disk read under the test-mode gate.
+	reloaded := reloadedBroker(t)
+
+	// Channel round-tripped.
+	reloaded.mu.Lock()
+	channels := append([]teamChannel(nil), reloaded.channels...)
+	m := reloaded.findMemberLocked("persistence-pm")
+	reloaded.mu.Unlock()
+
+	foundChannel := false
+	for _, c := range channels {
+		if c.Slug == "persistence-test" {
+			foundChannel = true
+			if c.Description != "Created by TestBrokerStatePersistsAcrossReload" {
+				t.Errorf("channel description lost: %+v", c)
+			}
+			break
+		}
+	}
+	if !foundChannel {
+		t.Errorf("channel persistence-test missing after reload; got channels: %v", channelSlugs(channels))
+	}
+
+	// Member round-tripped.
+	if m == nil {
+		t.Fatalf("member persistence-pm missing after reload")
+	}
+	if m.Role != "Product Manager" {
+		t.Errorf("member role lost: got %q", m.Role)
+	}
+	if m.Provider.Kind != provider.KindClaudeCode {
+		t.Errorf("member provider kind lost: got %q", m.Provider.Kind)
+	}
+}
+
+// channelSlugs is a test-only helper so failure messages show which
+// channels a reloaded broker actually has (saves a round-trip when
+// debugging a persistence regression).
+func channelSlugs(chs []teamChannel) []string {
+	out := make([]string, 0, len(chs))
+	for _, c := range chs {
+		out = append(out, c.Slug)
+	}
+	return out
+}

--- a/internal/team/broker_state_path_test.go
+++ b/internal/team/broker_state_path_test.go
@@ -1,0 +1,212 @@
+package team
+
+// Characterization tests for broker state-path resolution. Intended as
+// the floor that the "Track A" refactor (replacing the brokerStatePath
+// package-var with a Broker constructor argument) must not regress.
+//
+// The existing TestBrokerPersistsAndReloadsState + Loads… tests cover
+// the happy save/reload path. These cover the three invariants that
+// the refactor most easily breaks:
+//
+//  1. WUPHF_BROKER_STATE_PATH env override still wins over defaults.
+//  2. .last-good snapshot path is always a sibling of the main path.
+//  3. skipBrokerStateLoadOnConstruct still gates the auto-load hook.
+//
+// Also covers: Stop() must not continue writing the state file after
+// returning. Catches a regression where a background goroutine would
+// read a refactored statePath via a stale closure and race the next
+// construction.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultBrokerStatePath_EnvOverrideWins(t *testing.T) {
+	// WUPHF_BROKER_STATE_PATH takes precedence over WUPHF_RUNTIME_HOME
+	// so probes and harnesses can pin just the broker file without
+	// remapping $HOME (which breaks Keychain lookups on macOS for
+	// bundled CLIs like Claude Code).
+	override := filepath.Join(t.TempDir(), "explicit-broker-state.json")
+	t.Setenv("WUPHF_BROKER_STATE_PATH", override)
+	t.Setenv("WUPHF_RUNTIME_HOME", "/tmp/should-be-ignored")
+
+	got := defaultBrokerStatePath()
+	if got != override {
+		t.Fatalf("env override ignored: got %q, want %q", got, override)
+	}
+}
+
+func TestDefaultBrokerStatePath_RuntimeHomeFallback(t *testing.T) {
+	// No env override, WUPHF_RUNTIME_HOME set → <home>/.wuphf/team/
+	// broker-state.json. This is the happy path prod and tests both
+	// take (tests via worktree_guard_test.go pinning WUPHF_RUNTIME_HOME
+	// to a leaked tempdir).
+	t.Setenv("WUPHF_BROKER_STATE_PATH", "")
+	home := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+
+	got := defaultBrokerStatePath()
+	want := filepath.Join(home, ".wuphf", "team", "broker-state.json")
+	if got != want {
+		t.Fatalf("home fallback wrong: got %q, want %q", got, want)
+	}
+}
+
+func TestDefaultBrokerStatePath_RelativeFallbackWhenHomeMissing(t *testing.T) {
+	// Neither env var set: fall back to a repo-relative path. Hit when
+	// config.RuntimeHomeDir() returns "" — e.g. a CI container without
+	// HOME. Must still produce a deterministic writable path rather
+	// than panicking.
+	t.Setenv("WUPHF_BROKER_STATE_PATH", "")
+	t.Setenv("WUPHF_RUNTIME_HOME", "")
+	t.Setenv("HOME", "")
+
+	got := defaultBrokerStatePath()
+	want := filepath.Join(".wuphf", "team", "broker-state.json")
+	if got != want {
+		t.Fatalf("relative fallback wrong: got %q, want %q", got, want)
+	}
+	if filepath.IsAbs(got) {
+		t.Fatalf("relative fallback must not be absolute: got %q", got)
+	}
+}
+
+func TestBrokerStateSnapshotPathIsLastGoodSibling(t *testing.T) {
+	// Snapshot path is always `<brokerStatePath>.last-good` — same
+	// directory, same base name plus suffix. The load-side path (hit
+	// by TestBrokerLoadsLastGoodSnapshotWhenPrimaryStateIsClobbered)
+	// relies on this exact shape. Post-refactor, if snapshot
+	// derivation drifts to a different directory or format, recovery
+	// silently breaks.
+	oldPathFn := brokerStatePath
+	statePath := filepath.Join(t.TempDir(), "broker-state.json")
+	brokerStatePath = func() string { return statePath }
+	t.Cleanup(func() { brokerStatePath = oldPathFn })
+
+	got := brokerStateSnapshotPath()
+	want := statePath + ".last-good"
+	if got != want {
+		t.Fatalf("snapshot path drifted: got %q, want %q", got, want)
+	}
+	if filepath.Dir(got) != filepath.Dir(statePath) {
+		t.Fatalf("snapshot must live next to state file; got dir %q want %q",
+			filepath.Dir(got), filepath.Dir(statePath))
+	}
+	if !strings.HasSuffix(got, ".last-good") {
+		t.Fatalf("snapshot suffix drifted: got %q", got)
+	}
+}
+
+func TestNewBroker_SkipStateLoadGateRespected(t *testing.T) {
+	// The TestMain in this package flips skipBrokerStateLoadOnConstruct
+	// to true so NewBroker() starts fresh and tests don't cross-
+	// contaminate via a shared broker-state.json. Persistence-checking
+	// tests opt back into disk load via reloadedBroker(t). Track A
+	// must preserve this contract: constructor argument or not, a
+	// test-mode NewBroker() must NOT auto-load.
+	statePath := leakedBrokerStatePath(t)
+	oldPathFn := brokerStatePath
+	brokerStatePath = func() string { return statePath }
+	t.Cleanup(func() { brokerStatePath = oldPathFn })
+
+	// Seed disk with a distinctive message. If the gate is broken,
+	// NewBroker() will pick it up.
+	seed := NewBroker()
+	seed.mu.Lock()
+	seed.messages = []channelMessage{{
+		ID:        "seed-msg",
+		From:      "ceo",
+		Content:   "canary from the seed broker",
+		Timestamp: "2026-04-25T00:00:00Z",
+	}}
+	seed.counter = 1
+	if err := seed.saveLocked(); err != nil {
+		seed.mu.Unlock()
+		t.Fatalf("seed saveLocked: %v", err)
+	}
+	seed.mu.Unlock()
+
+	// Gate ON (test default): fresh broker, no seed.
+	if !skipBrokerStateLoadOnConstruct {
+		t.Fatal("precondition: skipBrokerStateLoadOnConstruct should be true in tests")
+	}
+	gated := NewBroker()
+	if got := len(gated.Messages()); got != 0 {
+		t.Fatalf("gate=true must yield 0 messages on construct; got %d", got)
+	}
+
+	// Gate OFF (production default): NewBroker() reads from disk.
+	oldGate := skipBrokerStateLoadOnConstruct
+	skipBrokerStateLoadOnConstruct = false
+	t.Cleanup(func() { skipBrokerStateLoadOnConstruct = oldGate })
+	loaded := NewBroker()
+	msgs := loaded.Messages()
+	if len(msgs) != 1 || msgs[0].ID != "seed-msg" {
+		t.Fatalf("gate=false must auto-load seed; got %+v", msgs)
+	}
+}
+
+func TestBrokerStop_NoWriteAfterReturn(t *testing.T) {
+	// Regression cover for the goroutine-drain gap: if Stop() returns
+	// while a background goroutine is still holding a reference to the
+	// state path and mid-save, the next construction (or the test
+	// tempdir cleanup) can race the late write. Stop's contract must
+	// be "no further state writes after I return."
+	//
+	// Implementation note: the activity watchdog is disabled in tests,
+	// so the set of goroutines that could write post-Stop is small —
+	// but this test is cheap and catches the class of regression a
+	// Track A refactor most easily introduces (e.g. a goroutine that
+	// reads a refactored `b.statePath` via a pointer captured at Start
+	// time and continues writing after b.stopCh closes).
+	statePath := leakedBrokerStatePath(t)
+	oldPathFn := brokerStatePath
+	brokerStatePath = func() string { return statePath }
+	t.Cleanup(func() { brokerStatePath = oldPathFn })
+
+	b := NewBroker()
+	b.mu.Lock()
+	b.messages = []channelMessage{{
+		ID:        "pre-stop",
+		From:      "ceo",
+		Content:   "written before Stop",
+		Timestamp: "2026-04-25T00:00:00Z",
+	}}
+	b.counter = 1
+	if err := b.saveLocked(); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("pre-stop save: %v", err)
+	}
+	b.mu.Unlock()
+
+	beforeStat, err := os.Stat(statePath)
+	if err != nil {
+		t.Fatalf("stat before Stop: %v", err)
+	}
+
+	b.Stop()
+
+	// Give any straggler goroutine a realistic window to misbehave —
+	// the watchdog ticker, if enabled, fires once per minute; shorter
+	// loops like wiki-index reconcile use 100ms+ intervals. 250ms is
+	// long enough to catch short-interval leaks without slowing the
+	// test suite meaningfully.
+	time.Sleep(250 * time.Millisecond)
+
+	afterStat, err := os.Stat(statePath)
+	if err != nil {
+		t.Fatalf("stat after Stop: %v", err)
+	}
+	if !afterStat.ModTime().Equal(beforeStat.ModTime()) {
+		t.Fatalf("state file modified after Stop returned: before=%s after=%s",
+			beforeStat.ModTime(), afterStat.ModTime())
+	}
+	if afterStat.Size() != beforeStat.Size() {
+		t.Fatalf("state file size changed after Stop: before=%d after=%d",
+			beforeStat.Size(), afterStat.Size())
+	}
+}

--- a/scripts/smoke-broker-restart.sh
+++ b/scripts/smoke-broker-restart.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# smoke-broker-restart.sh — boot wuphf, mutate state via the real HTTP
+# API, kill the process, reboot, and verify the mutation survived. This
+# is the binary-level canary for Broker state persistence: a serialization
+# or path-resolution regression that every Go test still passes would
+# fail here because the process actually starts over.
+#
+# Runs entirely under a disposable sandbox:
+#   - WUPHF_RUNTIME_HOME → per-run tempdir (onboarded.json, broker-state.json land here)
+#   - WUPHF_BROKER_TOKEN_FILE → tempdir sibling (doesn't collide with
+#     any live wuphf using /tmp/wuphf-broker-token)
+#   - Alternate broker+web ports (27890/27891 default; override with
+#     PORT=<N> for web port, broker port = PORT-1)
+#
+# Usage:
+#   scripts/smoke-broker-restart.sh [path-to-wuphf-binary]
+#   PORT=37891 scripts/smoke-broker-restart.sh ./wuphf
+#
+# Exits 0 on pass, non-zero on any boot failure or missing mutation.
+
+set -euo pipefail
+
+BIN="${1:-$PWD/wuphf}"
+if [ ! -x "$BIN" ]; then
+  echo "[smoke] wuphf binary not executable at: $BIN" >&2
+  echo "[smoke]   build with: go build -o wuphf ./cmd/wuphf" >&2
+  exit 2
+fi
+
+web_port="${PORT:-27891}"
+broker_port="$((web_port - 1))"
+
+sandbox="$(mktemp -d -t wuphf-smoke-XXXXXX)"
+export WUPHF_RUNTIME_HOME="$sandbox/runtime"
+export WUPHF_BROKER_TOKEN_FILE="$sandbox/broker-token"
+mkdir -p "$WUPHF_RUNTIME_HOME/.wuphf"
+
+echo "[smoke] sandbox=$sandbox"
+echo "[smoke] broker=$broker_port web=$web_port"
+
+# Pre-seed onboarded.json so wuphf boots into shell mode rather than the
+# wizard. Otherwise the /channels endpoint is gated behind onboarding.
+cat > "$WUPHF_RUNTIME_HOME/.wuphf/onboarded.json" <<JSON
+{"version":1,"completed_at":"2026-01-01T00:00:00Z","company_name":"smoke-test"}
+JSON
+
+pid=""
+kill_wuphf() {
+  local p="$1"
+  [ -n "$p" ] || return 0
+  kill -0 "$p" 2>/dev/null || return 0
+  kill -TERM "$p" 2>/dev/null || true
+  for _ in $(seq 1 50); do
+    kill -0 "$p" 2>/dev/null || return 0
+    sleep 0.1
+  done
+  kill -KILL "$p" 2>/dev/null || true
+  wait "$p" 2>/dev/null || true
+}
+
+cleanup() {
+  kill_wuphf "${pid:-}"
+  rm -rf "$sandbox"
+}
+trap cleanup EXIT
+
+start_wuphf() {
+  local label="$1"
+  echo "[smoke] starting wuphf ($label)"
+  "$BIN" --no-open --broker-port "$broker_port" --web-port "$web_port" --no-nex \
+    </dev/null > "$sandbox/wuphf-$label.log" 2>&1 &
+  pid=$!
+  for _ in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:$web_port/onboarding/state" -o /dev/null; then
+      echo "[smoke] wuphf ready ($label, pid=$pid)"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "[smoke] wuphf failed to become ready ($label)" >&2
+  cat "$sandbox/wuphf-$label.log" >&2
+  exit 1
+}
+
+stop_wuphf() {
+  kill_wuphf "${pid:-}"
+  pid=""
+  # Wait for the port to free up so the reboot can rebind. /dev/tcp is a
+  # bash-only virtual device — if you ever switch the shebang to /bin/sh
+  # this loop no-ops silently.
+  for _ in $(seq 1 10); do
+    if ! (exec 3<>/dev/tcp/127.0.0.1/"$web_port") 2>/dev/null; then break; fi
+    sleep 1
+  done
+}
+
+# ── Phase 1: boot, mutate, stop ─────────────────────────────────────────
+start_wuphf first
+token="$(cat "$WUPHF_BROKER_TOKEN_FILE")"
+if [ -z "$token" ]; then
+  echo "[smoke] empty broker token" >&2
+  exit 1
+fi
+
+echo "[smoke] POST /channels create smoke-channel"
+status=$(curl -sS -o "$sandbox/post-resp.json" -w '%{http_code}' \
+  -X POST "http://127.0.0.1:$broker_port/channels" \
+  -H "Authorization: Bearer $token" \
+  -H "Content-Type: application/json" \
+  -d '{"action":"create","slug":"smoke-channel","name":"Smoke","description":"canary","created_by":"ceo"}')
+if [ "$status" != "200" ]; then
+  echo "[smoke] POST /channels failed: status=$status body=$(cat "$sandbox/post-resp.json")" >&2
+  exit 1
+fi
+
+state_file="$WUPHF_RUNTIME_HOME/.wuphf/team/broker-state.json"
+if [ ! -f "$state_file" ]; then
+  echo "[smoke] state file missing after mutation: $state_file" >&2
+  exit 1
+fi
+if ! grep -q '"smoke-channel"' "$state_file"; then
+  echo "[smoke] state file does not contain smoke-channel:" >&2
+  head -c 2000 "$state_file" >&2
+  exit 1
+fi
+
+stop_wuphf
+
+# ── Phase 2: reboot, verify survival ────────────────────────────────────
+start_wuphf second
+token="$(cat "$WUPHF_BROKER_TOKEN_FILE")"
+resp=$(curl -sSf "http://127.0.0.1:$broker_port/channels" \
+  -H "Authorization: Bearer $token")
+if ! printf '%s' "$resp" | grep -q '"smoke-channel"'; then
+  echo "[smoke] mutation lost across restart; GET /channels body:" >&2
+  printf '%s\n' "$resp" | head -c 2000 >&2
+  exit 1
+fi
+
+echo "[smoke] PASS — smoke-channel survived restart"


### PR DESCRIPTION
## Summary

Characterization-coverage PR landed **before** Track A (planned refactor: replace the \`brokerStatePath\` package-var with a \`NewBroker(statePath)\` constructor argument; ~50–80 call-sites). Three test layers, each guarding a different category of regression Track A could silently introduce.

## Layers

### 1. Unit — \`internal/team/broker_state_path_test.go\` (6 tests, ~200 LOC)

Path-resolution invariants that every Track A call-site migration must preserve:

- Env-override precedence (\`WUPHF_BROKER_STATE_PATH\` > \`WUPHF_RUNTIME_HOME\` > relative).
- \`.last-good\` snapshot is always a sibling of the main state file.
- \`skipBrokerStateLoadOnConstruct\` gate still suppresses auto-load under tests.
- \`Broker.Stop()\` contract: no writes after it returns (goroutine-drain canary; will catch a regression where a background goroutine captures a stale \`statePath\` via closure and races next construction).

Each test header documents the specific Track A regression it protects against.

### 2. Integration — \`internal/team/broker_restart_integration_test.go\` (1 test, ~150 LOC)

End-to-end save-side path via real HTTP handlers:

1. Stand up broker on an ephemeral port.
2. \`POST /channels\` (one save-side handler).
3. \`POST /office-members\` (a different save-side handler, different code path).
4. \`Broker.Stop()\`.
5. \`reloadedBroker(t)\` (fresh \`NewBroker\` + explicit \`loadState\`).
6. Assert both mutations survived with full field sets.

Existing \`TestBrokerPersistsAndReloadsState\` covers the in-memory \`saveLocked\` seam. This adds coverage for the HTTP-handler side of the graph — the seam most likely to silently break when constructor arguments replace a package-level function-pointer.

### 3. Smoke — \`scripts/smoke-broker-restart.sh\` (~140 lines bash, no Go)

Binary-level canary: builds nothing, just boots the pre-built \`./wuphf\` binary end-to-end, POSTs a mutation, kills the process with SIGTERM, reboots the binary, verifies the mutation survived. Sandboxed under a per-run tempdir (\`WUPHF_RUNTIME_HOME\` + \`WUPHF_BROKER_TOKEN_FILE\`) on alt ports (27890/27891, \`PORT=\` overridable) so it never touches the developer's real \`~/.wuphf\` state or collides with a running wuphf.

Catches the class of bug no Go test would: an \`os.Exit\` + fresh-process load regression (e.g. snapshot-path typo, init-ordering change, signal-handler drain bug).

## Verified locally

- All 6 unit tests pass.
- Integration test passes.
- Full \`go test -count=1 ./internal/team/\` — 94.7s, zero failures.
- \`scripts/smoke-broker-restart.sh\` — PASS, smoke-channel survived restart.

## Scope boundary

**This PR adds no production code.** Ships only tests. Track A itself lands as a separate PR; merging this one first means the next PR's diff is reviewable as "mechanical rename of call-sites, existing tests still green" rather than "rename + hope nothing broke."

🤖 Generated with [Claude Code](https://claude.com/claude-code)