### PR TITLE
ci(release): gate npm publish behind environment + scope per-job permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,17 @@ on:
   # GITHUB_TOKEN does not fire other workflows, but workflow_dispatch does.
   workflow_dispatch:
 
+# Default to least-privilege; per-job blocks below add only what each job
+# actually needs. The release job uploads artifacts (contents: write); npm
+# publish + npx smoke only need to read the repo.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
@@ -68,6 +73,16 @@ jobs:
   publish-npm:
     needs: release
     runs-on: ubuntu-latest
+    # GitHub Environment gate: protection rules (required reviewer +
+    # branch policy `v*` tags) live on the env, so any future change to
+    # who/what can publish to npm is configured in one place rather than
+    # scattered across the workflow. NPM_TOKEN is bound to this env, not
+    # the repo, so a fork PR cannot reach it even via workflow_dispatch.
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/wuphf
+    permissions:
+      contents: read
     env:
       VERSION: ${{ needs.release.outputs.version }}
     steps:
@@ -95,6 +110,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     env:
       VERSION: ${{ needs.release.outputs.version }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,25 @@ on:
 permissions:
   contents: read
 
+# Don't cancel an in-flight release: a partially-finished goreleaser leaves
+# orphan release assets, and a partial npm publish leaves a half-shipped
+# version. Two concurrent releases for the same tag can't be valid anyway —
+# tags are immutable; the second invocation has nothing new to ship.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Env gate sits on the FIRST job that ships anything (goreleaser uploads
+    # GitHub Release artifacts). Putting it on `publish-npm` instead would
+    # leave a published GitHub Release with no corresponding npm package on
+    # rejection, requiring manual cleanup. Pausing here means the human
+    # approves once and both surfaces ship together — or nothing ships.
+    environment:
+      name: npm-publish
+      url: https://www.npmjs.com/package/wuphf
     permissions:
       contents: write
     outputs:
@@ -70,31 +86,21 @@ jobs:
           REF="${GITHUB_REF#refs/tags/}"
           echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
 
-  publish-npm:
-    needs: release
-    runs-on: ubuntu-latest
-    # GitHub Environment gate: protection rules (required reviewer +
-    # branch policy `v*` tags) live on the env, so any future change to
-    # who/what can publish to npm is configured in one place rather than
-    # scattered across the workflow. NPM_TOKEN is bound to this env, not
-    # the repo, so a fork PR cannot reach it even via workflow_dispatch.
-    environment:
-      name: npm-publish
-      url: https://www.npmjs.com/package/wuphf
-    permissions:
-      contents: read
-    env:
-      VERSION: ${{ needs.release.outputs.version }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-
+      # npm publish runs in the SAME job as goreleaser so the GitHub Release
+      # and the npm package ship atomically: either both succeed or neither
+      # leaves an artifact users can install. Splitting into two jobs would
+      # let goreleaser ship a GitHub Release that humans can download while
+      # publish-npm fails (env approval timeout, npm registry hiccup,
+      # version-already-published) — leaving the install surfaces drifted.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # ratchet:actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Set package version
+      - name: Set npm package version
         working-directory: npm
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Publish to npm
@@ -104,7 +110,7 @@ jobs:
         run: npm publish --access public
 
   smoke-test-npx:
-    needs: [release, publish-npm]
+    needs: [release]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Closes the audit's "release.yml workflow_dispatch no env gate" 🔴 from
[NEX_CRM_REPO_AUDIT_2026_04_24.md](../blob/main/NEX_CRM_REPO_AUDIT_2026_04_24.md) Table E row `wuphf`. Single file changed.

After staff-review (commit 4a22dd6f), publish-npm is **inlined into the `release` job** so the env gate produces an atomic outcome — either GitHub Release + npm both ship, or neither does. A separate `publish-npm` job would partial-fail (GH Release published, npm gate timed out) and require manual cleanup.

Final shape:
- Workflow default: `permissions: contents: read`.
- `concurrency: { group: release-${{ github.ref }}, cancel-in-progress: false }` — no half-finished release on a re-dispatch.
- `release` job: env-gated to `npm-publish`, `contents: write`, runs goreleaser + `npm publish` in sequence.
- `smoke-test-npx`: read-only, runs after `release` completes; verifies the binary's self-reported version matches the tag on Linux + macOS.

## Follow-up (admin steps, not in this PR — required for merge to be safe)

For the env gate to actually bind:

1. Create environment `npm-publish` in repo Settings → Environments.
2. Add a **required reviewer** rule (default to `@FranDias`).
3. Add a **deployment branch / tag policy**: protected refs → tag pattern `v*`. Without this, a `workflow_dispatch` against an arbitrary ref would still trigger the gate.
4. Add `NPM_TOKEN` as an **environment-scoped** secret on `npm-publish`.
5. **Delete the repo-scoped `NPM_TOKEN`** — otherwise any other workflow can still read it and the env gate is decorative.

The workflow references the env, so the gate is structural the moment this PR merges. The protection rules need a UI click before the next release fires.

## Future work (not in this PR)

- npm provenance: add `id-token: write` to the `release` job's `permissions:` block once we have a green tag through this gate. That gives the npm package a build attestation users can verify.

## Test plan

- [x] Lefthook pre-push (secretlint + commitlint + go test + build) green locally.
- [x] CI green on initial push.
- [ ] Re-verify CI green after the inline restructure (4a22dd6f).
- [ ] Post-merge: create env + reviewer rule + tag policy + move NPM_TOKEN + delete repo-scoped NPM_TOKEN. Next tagged release verifies the gate fires correctly and atomically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)