### PR TITLE
refactor(team): migrate tests off brokerStatePath var + delete it (Track A.2 + A.3)

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -58,8 +58,6 @@ const defaultAgentRateLimitWindow = time.Minute
 // the value set by internal/teammcp/server.go authHeaders().
 const agentRateLimitHeader = "X-WUPHF-Agent"
 
-var brokerStatePath = defaultBrokerStatePath
-
 // studioPackageGenerator routes Studio package generation through the
 // install-wide LLM provider so opencode-only or claude-code-only setups
 // aren't forced to have `codex` installed.
@@ -544,11 +542,10 @@ type Broker struct {
 	stopOnce sync.Once
 
 	// statePath is the on-disk broker-state.json path bound at construction.
-	// NewBroker() snapshots the package-level brokerStatePath() at call time
-	// so later monkey-patches (or a late-arriving goroutine writing via a
-	// stale closure) cannot retarget this broker's saves. NewBrokerAt()
-	// takes the path explicitly and is the preferred constructor for new
-	// code / test sites migrating off the package var.
+	// NewBrokerAt(path) sets this directly; NewBroker() resolves
+	// defaultBrokerStatePath() once and pins the result. A later-arriving
+	// goroutine writing via a stale closure (or a sibling broker built at
+	// a different path) cannot retarget this broker's saves.
 	statePath string
 }
 
@@ -896,33 +893,30 @@ func (b *Broker) AgentStream(slug string) *agentStreamBuffer {
 	return s
 }
 
-// NewBroker creates a new channel broker with a random auth token.
-// skipBrokerStateLoadOnConstruct gates the lazy read of brokerStatePath()
-// inside NewBroker. Production keeps it false so the CLI resumes from disk
-// state. A *_test.go init flips it to true so tests that call NewBroker get
-// a fresh broker by default, immune to state leaked by prior tests via a
-// shared broker-state.json. Persistence tests that want the load call
-// b.loadState() explicitly after construction.
+// skipBrokerStateLoadOnConstruct gates the auto-load of disk state
+// inside NewBrokerAt. Production keeps it false so the CLI resumes from
+// disk state. A *_test.go init flips it to true so tests that call
+// NewBrokerAt / NewBroker get a fresh broker by default, immune to state
+// leaked by prior tests via a shared broker-state.json. Persistence
+// tests that want the load call b.loadState() explicitly after
+// construction (or use reloadedBroker(t, b)).
 var skipBrokerStateLoadOnConstruct = false
 
-// NewBroker constructs a Broker bound to the package-level brokerStatePath()
-// resolved at call time. Production code uses this directly so the CLI
-// resumes from the default ~/.wuphf/team/broker-state.json. Tests that
-// monkey-patch brokerStatePath before calling NewBroker still work —
-// they effectively pin the path via the package var and NewBroker snapshots
-// it into b.statePath below.
-//
-// New test sites (and any new code) should prefer NewBrokerAt, which is
-// explicit about the path and doesn't depend on the package var at all.
+// NewBroker constructs a Broker bound to defaultBrokerStatePath() resolved
+// at call time. Production code uses this so the CLI resumes from the
+// default ~/.wuphf/team/broker-state.json (or its WUPHF_BROKER_STATE_PATH /
+// WUPHF_RUNTIME_HOME override). Tests should prefer NewBrokerAt or the
+// newTestBroker(t) helper — both pin a per-test path explicitly.
 func NewBroker() *Broker {
-	return NewBrokerAt(brokerStatePath())
+	return NewBrokerAt(defaultBrokerStatePath())
 }
 
 // NewBrokerAt constructs a Broker whose state is persisted to statePath.
-// The path is bound at construction time and stored on the Broker; later
-// reassignments of the package-level brokerStatePath do NOT retarget this
-// broker's saves. Use this instead of NewBroker() everywhere that needs
-// path isolation — notably tests that want to pin state under t.TempDir.
+// The path is bound at construction time and stored on the Broker, so
+// late-arriving goroutines (or sibling brokers built at other paths in
+// the same process) cannot retarget this broker's saves. Use this instead
+// of NewBroker() everywhere that needs path isolation — notably tests
+// that want to pin state under t.TempDir.
 func NewBrokerAt(statePath string) *Broker {
 	b := &Broker{
 		channelStore:        channel.NewStore(),
@@ -3028,7 +3022,7 @@ func (b *Broker) Reset() {
 	b.sessionMode = mode
 	b.oneOnOneAgent = agent
 	_ = b.saveLocked()
-	_ = os.Remove(brokerStateSnapshotPath())
+	_ = os.Remove(b.stateSnapshotPath())
 	b.mu.Unlock()
 }
 
@@ -3046,13 +3040,8 @@ func defaultBrokerStatePath() string {
 	return filepath.Join(home, ".wuphf", "team", "broker-state.json")
 }
 
-func brokerStateSnapshotPath() string {
-	return brokerStatePath() + ".last-good"
-}
-
 // stateSnapshotPath returns the path the Broker writes its last-good
-// crash-recovery snapshot to. Bound to b.statePath (set at construction),
-// so it does not depend on the package-level brokerStatePath var.
+// crash-recovery snapshot to. Bound to b.statePath (set at construction).
 func (b *Broker) stateSnapshotPath() string {
 	return b.statePath + ".last-good"
 }
@@ -3231,11 +3220,12 @@ func (b *Broker) saveLocked() error {
 // cannot race on the source path of the rename.
 //
 // The previous fixed `<path>.tmp` filename was safe in production (one broker
-// owns one path) but broke the test suite: 22 *_test.go files override
-// brokerStatePath, plus a leaked tempdir from worktree_guard_test.go init()
-// is shared across every test that doesn't override. Two saves landing on
-// the same path could interleave like A.WriteFile / B.WriteFile / A.Rename /
-// B.Rename — and B's Rename failed with "no such file or directory" because
+// owns one path) but broke the test suite: many *_test.go files used to
+// monkey-patch the package-level state-path var and a leaked tempdir from
+// worktree_guard_test.go init() was shared across every unisolated test.
+// Two saves landing on the same path could interleave like A.WriteFile /
+// B.WriteFile / A.Rename / B.Rename — and B's Rename failed with
+// "no such file or directory" because
 // A had already renamed the shared tmp out from under it. That was the CI
 // flake on PR #281's `test` job. See broker_save_race_test.go for the
 // regression repro.

--- a/internal/team/broker_actions_test.go
+++ b/internal/team/broker_actions_test.go
@@ -4,17 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"path/filepath"
 	"testing"
 )
 
 func TestHandleActionsPostRecordsAction(t *testing.T) {
-	tmpDir := t.TempDir()
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatal(err)
 	}
@@ -49,12 +43,7 @@ func TestHandleActionsPostRecordsAction(t *testing.T) {
 }
 
 func TestHandleSchedulerPostRecordsWorkflowJob(t *testing.T) {
-	tmpDir := t.TempDir()
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/team/broker_agent_logs_test.go
+++ b/internal/team/broker_agent_logs_test.go
@@ -10,15 +10,15 @@ import (
 	"testing"
 )
 
-// newTestBroker returns a Broker backed by a temp state file.
-// It follows the same pattern used throughout broker_test.go.
+// newTestBroker returns a Broker whose state file is pinned under
+// t.TempDir(). Use this for tests that don't care about the exact
+// state path — only that the broker writes to an isolated location.
+// For tests that also need the path itself (persistence, reload), call
+// NewBrokerAt(filepath.Join(tmpDir, "broker-state.json")) directly so
+// the tmpDir is in scope.
 func newTestBroker(t *testing.T) *Broker {
 	t.Helper()
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
-	return NewBroker()
+	return NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
 }
 
 func TestHandleAgentLogs_ListsRecent(t *testing.T) {

--- a/internal/team/broker_commands_test.go
+++ b/internal/team/broker_commands_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/commands"
@@ -15,12 +14,7 @@ import (
 // authenticate their requests.
 func newCommandsHTTPTest(t *testing.T) (*httptest.Server, string) {
 	t.Helper()
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/commands", b.requireAuth(b.handleCommands))
 	ts := httptest.NewServer(mux)

--- a/internal/team/broker_onboarding_test.go
+++ b/internal/team/broker_onboarding_test.go
@@ -46,25 +46,13 @@ func ensureOperationsFallbackFS(t *testing.T) {
 	operations.SetFallbackFS(sub)
 }
 
-// withIsolatedBrokerState gives the test a broker with its own state file
-// and a clean broker state on disk, then cleans up when done.
-func withIsolatedBrokerState(t *testing.T) func() {
-	t.Helper()
-	old := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	return func() { brokerStatePath = old }
-}
-
 // TestOnboardingCompleteSeedsFromPickedBlueprint verifies that when the
 // wizard POSTs a curated blueprint id, the broker seeds the exact member
 // list from that blueprint's starter.agents — not ceo/planner/executor/
 // reviewer from DefaultManifest.
 func TestOnboardingCompleteSeedsFromPickedBlueprint(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", nil); err != nil {
 		t.Fatalf("onboardingCompleteFn: %v", err)
 	}
@@ -113,9 +101,7 @@ func TestOnboardingCompleteSeedsFromPickedBlueprint(t *testing.T) {
 // dropping the blueprint's other specialists.
 func TestOnboardingCompleteHonorsAgentFilter(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", []string{"ceo", "builder"}); err != nil {
 		t.Fatalf("onboardingCompleteFn: %v", err)
 	}
@@ -152,9 +138,7 @@ func TestOnboardingCompleteHonorsAgentFilter(t *testing.T) {
 // lead and posts a system message explaining the fallback.
 func TestOnboardingCompleteAgentsEmptySeedsLeadOnly(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", []string{}); err != nil {
 		t.Fatalf("onboardingCompleteFn: %v", err)
 	}
@@ -190,9 +174,7 @@ func TestOnboardingCompleteAgentsEmptySeedsLeadOnly(t *testing.T) {
 // seeds the resulting team — NOT the DefaultManifest roster.
 func TestOnboardingCompleteFromScratchSynthesizes(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("Build an automated customer-support operation", false, "", nil); err != nil {
 		t.Fatalf("onboardingCompleteFn: %v", err)
 	}
@@ -217,9 +199,7 @@ func TestOnboardingCompleteFromScratchSynthesizes(t *testing.T) {
 
 func TestOnboardingCompleteFromScratchHonorsSelectedFoundingAgents(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("Build an automated customer-support operation", false, "", []string{"ceo", "founding-engineer"}); err != nil {
 		t.Fatalf("onboardingCompleteFn: %v", err)
 	}
@@ -288,9 +268,7 @@ func TestBlankSlateMembersExplicitLeadOnlySelectionStaysLeadOnly(t *testing.T) {
 // seeds the team but does not post an onboarding_origin message.
 func TestOnboardingCompleteSkipTaskSeedsNoKickoff(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("", true, "niche-crm", nil); err != nil {
 		t.Fatalf("onboardingCompleteFn: %v", err)
 	}
@@ -321,15 +299,13 @@ func TestOnboardingCompleteSkipTaskSeedsNoKickoff(t *testing.T) {
 // team on the next broker restart.
 func TestOnboardingCompleteSkipTaskPersistsTeam(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("", true, "niche-crm", nil); err != nil {
 		t.Fatalf("onboardingCompleteFn: %v", err)
 	}
 
 	// Fresh broker instance re-reads state from disk.
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 	reloaded.mu.Lock()
 	slugs := make([]string, 0, len(reloaded.members))
 	for _, m := range reloaded.members {
@@ -364,9 +340,7 @@ func TestOnboardingCompleteSkipTaskPersistsTeam(t *testing.T) {
 // HTTP 500). No partial state should be seeded.
 func TestOnboardingCompleteLoadBlueprintErrorReturnsError(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	err := b.onboardingCompleteFn("go", false, "definitely-not-a-real-blueprint", nil)
 	if err == nil {
 		t.Fatalf("expected error for unknown blueprint, got nil")
@@ -382,9 +356,7 @@ func TestOnboardingCompleteLoadBlueprintErrorReturnsError(t *testing.T) {
 // broker_onboarding.go:49-53 (pre-rewrite) must survive the unified flow.
 func TestOnboardingCompleteDedupesDuplicateTaskMessage(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("hello world", false, "niche-crm", nil); err != nil {
 		t.Fatalf("first call: %v", err)
 	}
@@ -411,9 +383,7 @@ func TestOnboardingCompleteDedupesDuplicateTaskMessage(t *testing.T) {
 // "blank-slate-N" prefix, so persisted rows are self-describing.
 func TestTaskIDsUseBlueprintPrefix(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", nil); err != nil {
 		t.Fatalf("onboardingCompleteFn: %v", err)
 	}
@@ -440,9 +410,7 @@ func TestTaskIDsUseBlueprintPrefix(t *testing.T) {
 // synthesis-path contract: nil selectedAgents means no filtering applied.
 func TestSeedFromBlueprintNilAgentsKeepsFullRoster(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("go", false, "niche-crm", nil); err != nil {
 		t.Fatalf("onboardingCompleteFn: %v", err)
 	}
@@ -515,9 +483,7 @@ func TestBlankSlateOfficeChannelsFromBlueprint_RendersCommandSlug(t *testing.T) 
 // claude process — the symptom the user reported during the ui test.
 func TestOnboardingCompleteEmitsOfficeReseededEvent(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	events, unsubscribe := b.SubscribeOfficeChanges(32)
 	defer unsubscribe()
 

--- a/internal/team/broker_onboarding_wiki_test.go
+++ b/internal/team/broker_onboarding_wiki_test.go
@@ -13,14 +13,13 @@ import (
 // redirected to a temp dir so we never touch the real wiki.
 func TestOnboardingCompleteMaterializesWiki(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
 
 	// Redirect HOME so the onboarding hook writes into the test tempdir
 	// instead of ~/.wuphf. os.UserHomeDir respects $HOME on unix.
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", nil); err != nil {
 		t.Fatalf("onboardingCompleteFn: %v", err)
 	}
@@ -57,13 +56,12 @@ func TestOnboardingCompleteMaterializesWiki(t *testing.T) {
 // earlier agent notes.
 func TestOnboardingCompleteWikiIsIdempotent(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
 
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
 	// First run.
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("Stand up niche CRM", false, "niche-crm", nil); err != nil {
 		t.Fatalf("first onboardingCompleteFn: %v", err)
 	}
@@ -76,8 +74,11 @@ func TestOnboardingCompleteWikiIsIdempotent(t *testing.T) {
 		t.Fatalf("user-edit simulation: %v", err)
 	}
 
-	// Second run — e.g. the user re-picks the blueprint.
-	b2 := NewBroker()
+	// Second run — e.g. the user re-picks the blueprint. Pinning to the
+	// same broker-state.json as `b` so normalizeLoadedStateLocked observes
+	// the persistence from the first run (matches production behavior
+	// where a CLI restart reads ~/.wuphf/team/broker-state.json).
+	b2 := NewBrokerAt(b.statePath)
 	if err := b2.onboardingCompleteFn("Re-pick niche CRM", false, "niche-crm", nil); err != nil {
 		t.Fatalf("second onboardingCompleteFn: %v", err)
 	}
@@ -97,12 +98,11 @@ func TestOnboardingCompleteWikiIsIdempotent(t *testing.T) {
 // a functional empty wiki rather than a partial one.
 func TestOnboardingCompleteSynthesizedBlueprintSkipsWiki(t *testing.T) {
 	ensureOperationsFallbackFS(t)
-	defer withIsolatedBrokerState(t)()
 
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.onboardingCompleteFn("Run a bespoke operation", false, "", nil); err != nil {
 		t.Fatalf("onboardingCompleteFn (synthesized): %v", err)
 	}

--- a/internal/team/broker_providers_test.go
+++ b/internal/team/broker_providers_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -129,12 +128,7 @@ func TestHandleOfficeMembers_InvalidProviderKind(t *testing.T) {
 }
 
 func TestProviderFieldSurvivesBrokerReload(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{
 		Slug: "persist-test",
@@ -152,7 +146,7 @@ func TestProviderFieldSurvivesBrokerReload(t *testing.T) {
 	}
 	b.mu.Unlock()
 
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 	reloaded.mu.Lock()
 	got := reloaded.findMemberLocked("persist-test")
 	reloaded.mu.Unlock()
@@ -203,12 +197,7 @@ func TestRebuildMemberIndex_AfterRemove(t *testing.T) {
 // httptest server, returning the broker, the server, and the auth token.
 func newBrokerHTTPTest(t *testing.T) (*Broker, *httptest.Server, string) {
 	t.Helper()
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	// Attach a fake bridge so handleOfficeMembers can exercise openclaw
 	// create/update/remove paths without dialing a real gateway.
 	fake := newFakeOC()

--- a/internal/team/broker_restart_integration_test.go
+++ b/internal/team/broker_restart_integration_test.go
@@ -27,11 +27,7 @@ import (
 
 func TestBrokerStatePersistsAcrossReload_ChannelAndMember(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "broker-state.json")
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
-
-	b := NewBroker()
+	b := NewBrokerAt(statePath)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("StartOnPort: %v", err)
 	}
@@ -100,7 +96,7 @@ func TestBrokerStatePersistsAcrossReload_ChannelAndMember(t *testing.T) {
 	// Fresh broker on the same path, loads from disk. reloadedBroker
 	// constructs a Broker and explicitly calls loadState — the only
 	// way to opt back into disk read under the test-mode gate.
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 
 	// Channel round-tripped.
 	reloaded.mu.Lock()

--- a/internal/team/broker_save_race_test.go
+++ b/internal/team/broker_save_race_test.go
@@ -2,7 +2,7 @@ package team
 
 // Regression coverage for the test-isolation race that surfaced PR #281's
 // flaky `test` job. saveLocked used a fixed `<path>.tmp` filename, so two
-// brokers concurrently saving to the same brokerStatePath could interleave
+// brokers concurrently saving to the same state path could interleave
 // like this:
 //
 //   A.WriteFile(path.tmp, dataA)
@@ -11,11 +11,11 @@ package team
 //   B.Rename(path.tmp, path)       // FAILS: path.tmp no longer exists
 //
 // In production only one broker writes a given path, so the race is
-// invisible — but the test suite shares a single leaked tempdir from
-// worktree_guard_test.go init() across every test that does NOT override
-// brokerStatePath, plus 22 test files that DO override but leak the
-// goroutine reading the var. The TestHeadlessTurnCompletedDurably… flake
-// in CI was this race.
+// invisible — but the test suite used to share a leaked tempdir from
+// worktree_guard_test.go init() across every unisolated test, plus many
+// test files that overrode the state path and leaked goroutines reading
+// the old global. The TestHeadlessTurnCompletedDurably… flake in CI was
+// this race.
 //
 // Fix: each save uses a unique tmp filename via os.CreateTemp, so
 // concurrent saves can never race on the source of a Rename.
@@ -29,12 +29,9 @@ import (
 )
 
 func TestSaveLocked_ConcurrentBrokersSamePathDoNotRace(t *testing.T) {
-	// Pin brokerStatePath to a per-test tempdir so all N goroutines target
-	// the same path (the production failure mode).
+	// Pin every goroutine's Broker to the same per-test tempdir path so
+	// all N goroutines target the same file (the production failure mode).
 	statePath := filepath.Join(t.TempDir(), "broker-state.json")
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
 
 	const goroutines = 32
 
@@ -44,7 +41,7 @@ func TestSaveLocked_ConcurrentBrokersSamePathDoNotRace(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func(i int) {
 			defer wg.Done()
-			b := NewBroker()
+			b := NewBrokerAt(statePath)
 			// EnsurePlannedTask calls saveLocked synchronously under b.mu —
 			// each broker serializes its own saves, but two brokers do not
 			// share a mutex, so they race on the on-disk tmp filename. Vary

--- a/internal/team/broker_state_path_test.go
+++ b/internal/team/broker_state_path_test.go
@@ -1,7 +1,7 @@
 package team
 
 // Characterization tests for broker state-path resolution. Intended as
-// the floor that the "Track A" refactor (replacing the brokerStatePath
+// the floor that the "Track A" refactor (replacing the state-path
 // package-var with a Broker constructor argument) must not regress.
 //
 // The existing TestBrokerPersistsAndReloadsState + Loads… tests cover
@@ -76,18 +76,15 @@ func TestDefaultBrokerStatePath_RelativeFallbackWhenHomeMissing(t *testing.T) {
 }
 
 func TestBrokerStateSnapshotPathIsLastGoodSibling(t *testing.T) {
-	// Snapshot path is always `<brokerStatePath>.last-good` — same
-	// directory, same base name plus suffix. The load-side path (hit
-	// by TestBrokerLoadsLastGoodSnapshotWhenPrimaryStateIsClobbered)
-	// relies on this exact shape. Post-refactor, if snapshot
-	// derivation drifts to a different directory or format, recovery
-	// silently breaks.
-	oldPathFn := brokerStatePath
+	// Snapshot path is always `<statePath>.last-good` — same directory,
+	// same base name plus suffix. The load-side path (hit by
+	// TestBrokerLoadsLastGoodSnapshotWhenPrimaryStateIsClobbered) relies
+	// on this exact shape. If snapshot derivation ever drifts to a
+	// different directory or format, recovery silently breaks.
 	statePath := filepath.Join(t.TempDir(), "broker-state.json")
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	b := NewBrokerAt(statePath)
 
-	got := brokerStateSnapshotPath()
+	got := b.stateSnapshotPath()
 	want := statePath + ".last-good"
 	if got != want {
 		t.Fatalf("snapshot path drifted: got %q, want %q", got, want)
@@ -103,19 +100,16 @@ func TestBrokerStateSnapshotPathIsLastGoodSibling(t *testing.T) {
 
 func TestNewBroker_SkipStateLoadGateRespected(t *testing.T) {
 	// The TestMain in this package flips skipBrokerStateLoadOnConstruct
-	// to true so NewBroker() starts fresh and tests don't cross-
+	// to true so NewBrokerAt() starts fresh and tests don't cross-
 	// contaminate via a shared broker-state.json. Persistence-checking
-	// tests opt back into disk load via reloadedBroker(t). Track A
-	// must preserve this contract: constructor argument or not, a
-	// test-mode NewBroker() must NOT auto-load.
+	// tests opt back into disk load via reloadedBroker(t, b). Track A
+	// must preserve this contract: a test-mode constructor must NOT
+	// auto-load.
 	statePath := leakedBrokerStatePath(t)
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
 
 	// Seed disk with a distinctive message. If the gate is broken,
-	// NewBroker() will pick it up.
-	seed := NewBroker()
+	// NewBrokerAt() will pick it up.
+	seed := NewBrokerAt(statePath)
 	seed.mu.Lock()
 	seed.messages = []channelMessage{{
 		ID:        "seed-msg",
@@ -134,16 +128,16 @@ func TestNewBroker_SkipStateLoadGateRespected(t *testing.T) {
 	if !skipBrokerStateLoadOnConstruct {
 		t.Fatal("precondition: skipBrokerStateLoadOnConstruct should be true in tests")
 	}
-	gated := NewBroker()
+	gated := NewBrokerAt(statePath)
 	if got := len(gated.Messages()); got != 0 {
 		t.Fatalf("gate=true must yield 0 messages on construct; got %d", got)
 	}
 
-	// Gate OFF (production default): NewBroker() reads from disk.
+	// Gate OFF (production default): NewBrokerAt() reads from disk.
 	oldGate := skipBrokerStateLoadOnConstruct
 	skipBrokerStateLoadOnConstruct = false
 	t.Cleanup(func() { skipBrokerStateLoadOnConstruct = oldGate })
-	loaded := NewBroker()
+	loaded := NewBrokerAt(statePath)
 	msgs := loaded.Messages()
 	if len(msgs) != 1 || msgs[0].ID != "seed-msg" {
 		t.Fatalf("gate=false must auto-load seed; got %+v", msgs)
@@ -152,19 +146,19 @@ func TestNewBroker_SkipStateLoadGateRespected(t *testing.T) {
 
 func TestNewBrokerAt_PathSnapshottedAtConstruction(t *testing.T) {
 	// NewBrokerAt binds the state path to the Broker at construction so a
-	// later reassignment of the package-level brokerStatePath var (or a
-	// goroutine reading it via a stale closure) can't retarget this
-	// broker's saves. Contract: after construction, reassigning
-	// brokerStatePath must NOT move where this broker persists.
+	// later construction of a second broker at a different path can't
+	// retarget the first broker's saves. Contract: after construction,
+	// every save from this broker lands at b.statePath regardless of
+	// what other brokers (constructed later, with other paths) are doing
+	// in the same process.
 	boundPath := filepath.Join(t.TempDir(), "bound-state.json")
 	b := NewBrokerAt(boundPath)
 
-	// Retarget the package var — simulates a sibling test leaking a
-	// monkey-patch, or the pre-migration test pattern running before us.
-	oldPathFn := brokerStatePath
+	// Construct a second broker at a distinct path — simulates another
+	// test running alongside this one. Its statePath must not bleed into
+	// b's saves.
 	unboundPath := filepath.Join(t.TempDir(), "should-not-be-written.json")
-	brokerStatePath = func() string { return unboundPath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	_ = NewBrokerAt(unboundPath)
 
 	b.mu.Lock()
 	b.messages = []channelMessage{{
@@ -184,7 +178,7 @@ func TestNewBrokerAt_PathSnapshottedAtConstruction(t *testing.T) {
 		t.Fatalf("bound path missing after save: %v", err)
 	}
 	if _, err := os.Stat(unboundPath); !os.IsNotExist(err) {
-		t.Fatalf("unbound path was written (package-var leak): err=%v", err)
+		t.Fatalf("unbound path was written: err=%v", err)
 	}
 	if b.stateSnapshotPath() != boundPath+".last-good" {
 		t.Fatalf("snapshot method did not derive from bound path: got %q, want %q",
@@ -206,11 +200,7 @@ func TestBrokerStop_NoWriteAfterReturn(t *testing.T) {
 	// reads a refactored `b.statePath` via a pointer captured at Start
 	// time and continues writing after b.stopCh closes).
 	statePath := leakedBrokerStatePath(t)
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
-
-	b := NewBroker()
+	b := NewBrokerAt(statePath)
 	b.mu.Lock()
 	b.messages = []channelMessage{{
 		ID:        "pre-stop",

--- a/internal/team/broker_studio_test.go
+++ b/internal/team/broker_studio_test.go
@@ -93,12 +93,7 @@ func TestHandleStudioGeneratePackagePersistsAction(t *testing.T) {
 	}
 	defer func() { studioPackageGenerator = restore }()
 
-	tmpDir := t.TempDir()
-	prevStatePath := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = prevStatePath }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	body := map[string]any{
 		"channel": "general",
 		"actor":   "eng",
@@ -165,12 +160,7 @@ func TestHandleStudioGeneratePackagePersistsAction(t *testing.T) {
 }
 
 func TestHandleMemoryRoundTripScopedStudioRecords(t *testing.T) {
-	tmpDir := t.TempDir()
-	prevStatePath := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = prevStatePath }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 
 	writeRecord := func(namespace, key string, value any) {
 		t.Helper()
@@ -230,12 +220,7 @@ func TestHandleStudioRunWorkflowExecutesOneDraftAndUpdatesSkill(t *testing.T) {
 	t.Setenv("WUPHF_ACTION_PROVIDER", "one")
 	t.Setenv("WUPHF_ONE_BIN", writeFakeOperationOne(t))
 
-	tmpDir := t.TempDir()
-	prevStatePath := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = prevStatePath }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.skills = append(b.skills, teamSkill{
 		ID:                 "skill-sponsor-outreach-dry-run",
 		Name:               "sponsor-outreach-dry-run",
@@ -312,12 +297,7 @@ func TestHandleStudioRunWorkflowReturnsRateLimitMetadata(t *testing.T) {
 	t.Setenv("WUPHF_ACTION_PROVIDER", "one")
 	t.Setenv("WUPHF_ONE_BIN", writeRateLimitedOperationOne(t))
 
-	tmpDir := t.TempDir()
-	prevStatePath := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = prevStatePath }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.skills = append(b.skills, teamSkill{
 		ID:               "skill-consulting-live-gmail-read",
 		Name:             "consulting-live-gmail-read",

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -27,10 +27,10 @@ import (
 func TestMain(m *testing.M) {
 	// Globals that leaked background goroutines can write to after a test
 	// returns need a process-lifetime home so cleanup doesn't race the
-	// leaked writes. We pre-seed two (token file, headless log dir) and
-	// deliberately DO NOT pre-seed brokerStatePath: NewBroker auto-loads
-	// from that path, so a shared default would cross-contaminate tests
-	// that add state without their own swap.
+	// leaked writes. We pre-seed two (token file, headless log dir).
+	// Broker state paths are handled per-test via NewBrokerAt / newTestBroker,
+	// and the unisolated fallback is pinned in worktree_guard_test.go init()
+	// via WUPHF_RUNTIME_HOME.
 	var cleanups []func()
 	cleanup := func() {
 		for i := len(cleanups) - 1; i >= 0; i-- {
@@ -95,29 +95,27 @@ func TestMain(m *testing.M) {
 	os.Exit(rc)
 }
 
-// reloadedBroker constructs a Broker and replays state from brokerStatePath
-// so persistence tests can verify what a production restart would see.
-// Test-mode NewBroker skips the automatic disk load (to stop cross-test
-// state leakage via a shared broker-state.json), so any test that checks
-// persistence behavior must opt in through this helper.
-func reloadedBroker(t *testing.T) *Broker {
+// reloadedBroker constructs a Broker pinned to the same state path as b
+// and replays state from disk so persistence tests can verify what a
+// production restart would see. Test-mode NewBrokerAt skips the
+// automatic disk load (to stop cross-test state leakage via a shared
+// broker-state.json), so any test that checks persistence behavior
+// must opt in through this helper.
+func reloadedBroker(t *testing.T, b *Broker) *Broker {
 	t.Helper()
-	b := NewBroker()
-	if err := b.loadState(); err != nil {
+	fresh := NewBrokerAt(b.statePath)
+	if err := fresh.loadState(); err != nil {
 		t.Fatalf("loadState: %v", err)
 	}
-	return b
+	return fresh
 }
 
 // leakedBrokerStatePath returns a per-test-unique filesystem path for a
-// broker-state.json, rooted in a temp dir OUTSIDE t.TempDir(). Callers use
-// it to swap the package-global brokerStatePath without exposing t.TempDir
-// to late-arriving writes from goroutines leaked by prior tests. Those
-// late writes hit brokerStatePath() (resolved lazily on each call) and
-// resolve to whatever the global points at — so if it pointed into
-// t.TempDir, cleanup would race the write and fail with "unlinkat:
-// directory not empty". The returned dir is intentionally NOT registered
-// for cleanup: a handful of KB per test run leaks to /tmp, which the OS
+// broker-state.json, rooted in a temp dir OUTSIDE t.TempDir(). Callers
+// pass it to NewBrokerAt so late-arriving writes from goroutines leaked
+// by prior tests don't race t.TempDir cleanup with "unlinkat: directory
+// not empty". The returned dir is intentionally NOT registered for
+// cleanup: a handful of KB per test run leaks to /tmp, which the OS
 // reclaims on reboot or tmpfs eviction. Cheap fix for a cross-test
 // goroutine-leak hazard that a larger refactor will eventually retire.
 func leakedBrokerStatePath(t *testing.T) string {
@@ -170,12 +168,7 @@ func TestFormatChannelViewIncludesThreadReference(t *testing.T) {
 }
 
 func TestBrokerPersistsAndReloadsState(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{{ID: "msg-1", From: "ceo", Content: "Persist me", Timestamp: "2026-03-24T10:00:00Z"}}
 	b.counter = 1
@@ -185,7 +178,7 @@ func TestBrokerPersistsAndReloadsState(t *testing.T) {
 	}
 	b.mu.Unlock()
 
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 	msgs := reloaded.Messages()
 	if len(msgs) != 1 {
 		t.Fatalf("expected 1 persisted message, got %d", len(msgs))
@@ -195,19 +188,14 @@ func TestBrokerPersistsAndReloadsState(t *testing.T) {
 	}
 
 	reloaded.Reset()
-	empty := reloadedBroker(t)
+	empty := reloadedBroker(t, b)
 	if len(empty.Messages()) != 0 {
 		t.Fatalf("expected reset to clear persisted messages, got %d", len(empty.Messages()))
 	}
 }
 
 func TestBrokerLoadsLastGoodSnapshotWhenPrimaryStateIsClobbered(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{{ID: "msg-1", From: "human", Channel: "general", Content: "Run the consulting loop", Timestamp: "2026-04-16T00:00:00Z"}}
 	b.tasks = []teamTask{{ID: "task-1", Channel: "delivery", Title: "Create the client brief", Owner: "builder", Status: "in_progress", ExecutionMode: "office", CreatedBy: "operator", CreatedAt: "2026-04-16T00:00:01Z", UpdatedAt: "2026-04-16T00:00:01Z"}}
@@ -218,12 +206,12 @@ func TestBrokerLoadsLastGoodSnapshotWhenPrimaryStateIsClobbered(t *testing.T) {
 		t.Fatalf("saveLocked failed: %v", err)
 	}
 	b.mu.Unlock()
-	if _, err := os.Stat(brokerStateSnapshotPath()); err != nil {
+	if _, err := os.Stat(b.stateSnapshotPath()); err != nil {
 		t.Fatalf("expected snapshot after rich save: %v", err)
 	}
 
 	// Simulate a later clobber that keeps the custom office shell but loses live work.
-	clobbered := reloadedBroker(t)
+	clobbered := reloadedBroker(t, b)
 	clobbered.mu.Lock()
 	clobbered.messages = nil
 	clobbered.tasks = nil
@@ -242,16 +230,16 @@ func TestBrokerLoadsLastGoodSnapshotWhenPrimaryStateIsClobbered(t *testing.T) {
 		t.Fatalf("clobbered saveLocked failed: %v", err)
 	}
 	clobbered.mu.Unlock()
-	if _, err := os.Stat(brokerStateSnapshotPath()); err != nil {
+	if _, err := os.Stat(b.stateSnapshotPath()); err != nil {
 		t.Fatalf("expected snapshot to survive clobbered save: %v", err)
 	}
-	if snap, err := loadBrokerStateFile(brokerStateSnapshotPath()); err != nil {
+	if snap, err := loadBrokerStateFile(b.stateSnapshotPath()); err != nil {
 		t.Fatalf("read snapshot: %v", err)
 	} else if len(snap.Messages) != 1 || len(snap.Tasks) != 1 || len(snap.Actions) != 1 {
 		t.Fatalf("unexpected snapshot contents: %+v", snap)
 	}
 
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 	if got := len(reloaded.Messages()); got != 1 {
 		t.Fatalf("expected snapshot recovery to restore 1 message, got %d", got)
 	}
@@ -267,12 +255,7 @@ func TestBrokerLoadsLastGoodSnapshotWhenPrimaryStateIsClobbered(t *testing.T) {
 }
 
 func TestBrokerSessionModePersistsAndSurvivesReset(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{Slug: "pm", Name: "Product Manager"})
 	for i := range b.channels {
@@ -289,7 +272,7 @@ func TestBrokerSessionModePersistsAndSurvivesReset(t *testing.T) {
 		t.Fatalf("seed direct message: %v", err)
 	}
 
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 	mode, agent := reloaded.SessionModeState()
 	if mode != SessionModeOneOnOne {
 		t.Fatalf("expected persisted 1o1 mode, got %q", mode)
@@ -312,12 +295,7 @@ func TestBrokerSessionModePersistsAndSurvivesReset(t *testing.T) {
 }
 
 func TestBrokerMessageSubscribersReceivePostedMessages(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	msgs, unsubscribe := b.SubscribeMessages(4)
 	defer unsubscribe()
 
@@ -337,12 +315,7 @@ func TestBrokerMessageSubscribersReceivePostedMessages(t *testing.T) {
 }
 
 func TestBrokerCanonicalizesLegacyDMSlugs(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -482,12 +455,7 @@ func TestRecordAgentUsageAttachesToCurrentTurnMessagesOnly(t *testing.T) {
 }
 
 func TestBrokerActionSubscribersReceiveTaskLifecycle(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	actions, unsubscribe := b.SubscribeActions(4)
 	defer unsubscribe()
 
@@ -506,12 +474,7 @@ func TestBrokerActionSubscribersReceiveTaskLifecycle(t *testing.T) {
 }
 
 func TestReapStaleActivityLocked(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	now := time.Now().UTC()
 	stale := now.Add(-10 * time.Minute).Format(time.RFC3339)
 	fresh := now.Add(-1 * time.Minute).Format(time.RFC3339)
@@ -556,23 +519,13 @@ func TestReapStaleActivityLocked(t *testing.T) {
 }
 
 func TestBrokerStopIsIdempotent(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.Stop()
 	b.Stop()
 }
 
 func TestBrokerActivitySubscribersReceiveUpdates(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	updates, unsubscribe := b.SubscribeActivity(4)
 	defer unsubscribe()
 
@@ -595,12 +548,7 @@ func TestBrokerActivitySubscribersReceiveUpdates(t *testing.T) {
 }
 
 func TestBrokerEventsEndpointStreamsMessages(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.channels = []teamChannel{
 		{
 			Slug:    "general",
@@ -665,12 +613,7 @@ func TestBrokerEventsEndpointStreamsMessages(t *testing.T) {
 }
 
 func TestBrokerMessageKindAndTitleRoundTrip(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -727,12 +670,7 @@ func TestBrokerMessageKindAndTitleRoundTrip(t *testing.T) {
 }
 
 func TestBrokerMessagesCanScopeToThread(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -778,12 +716,7 @@ func TestBrokerMessagesCanScopeToThread(t *testing.T) {
 }
 
 func TestBrokerMessagesCanScopeToAgentInbox(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members,
 		officeMember{Slug: "pm", Name: "Product Manager"},
@@ -856,12 +789,7 @@ func TestBrokerMessagesCanScopeToAgentInbox(t *testing.T) {
 
 func TestNewBrokerSeedsDefaultOfficeRosterOnFreshState(t *testing.T) {
 	t.Setenv("HOME", t.TempDir()) // isolate from ~/.wuphf company.json (e.g. RevOps pack)
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	members := b.OfficeMembers()
 	if len(members) < 2 {
 		t.Fatalf("expected default office roster on fresh state, got %d members", len(members))
@@ -904,12 +832,7 @@ func TestNewBrokerSeedsBlueprintBackedOfficeRosterOnFreshState(t *testing.T) {
 		t.Fatalf("write manifest: %v", err)
 	}
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	members := b.OfficeMembers()
 	if len(members) < 2 {
 		t.Fatalf("expected blueprint-backed default office roster, got %d members", len(members))
@@ -1007,12 +930,7 @@ func TestHandleMessagesSupportsInboxAndOutboxScopes(t *testing.T) {
 }
 
 func TestOfficeMemberLifecycle(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{
 		Slug:      "growthops",
@@ -1026,36 +944,26 @@ func TestOfficeMemberLifecycle(t *testing.T) {
 	}
 	b.mu.Unlock()
 
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 	if reloaded.findMemberLocked("growthops") == nil {
 		t.Fatal("expected custom office member to persist")
 	}
 }
 
 func TestBrokerPersistsNotificationCursorWithoutMessages(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.SetNotificationCursor("2026-03-24T10:00:00Z"); err != nil {
 		t.Fatalf("SetNotificationCursor failed: %v", err)
 	}
 
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 	if got := reloaded.NotificationCursor(); got != "2026-03-24T10:00:00Z" {
 		t.Fatalf("expected persisted notification cursor, got %q", got)
 	}
 }
 
 func TestChannelMembersRejectUnknownOfficeMember(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -1086,12 +994,7 @@ func TestChannelMembersRejectUnknownOfficeMember(t *testing.T) {
 // slug was protected — blueprint teams whose lead is something else (e.g.
 // niche-crm uses "operator") could silently lose their lead from #general.
 func TestChannelMembersRejectDisableOrRemoveOfLead(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	now := time.Now().UTC().Format(time.RFC3339)
 	b.members = []officeMember{
@@ -1148,12 +1051,7 @@ func TestChannelMembersRejectDisableOrRemoveOfLead(t *testing.T) {
 }
 
 func TestBrokerAuthRejectsUnauthenticated(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.runtimeProvider = "codex"
 	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendGBrain)
 	t.Setenv("WUPHF_OPENAI_API_KEY", "sk-test-openai")
@@ -1773,11 +1671,7 @@ func TestNormalizeChannelSlugStripsLeadingHash(t *testing.T) {
 }
 
 func TestChannelDescriptionsAreVisibleButContentStaysRestricted(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -1862,12 +1756,7 @@ func TestChannelDescriptionsAreVisibleButContentStaysRestricted(t *testing.T) {
 }
 
 func TestChannelUpdateMutatesDescriptionAndMembers(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -1995,12 +1884,7 @@ func TestNormalizeLoadedStateRepopulatesGeneralFromOfficeRoster(t *testing.T) {
 }
 
 func TestTaskAndRequestViewsRejectNonMembers(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -2091,12 +1975,7 @@ func TestParseOTLPUsageEvents(t *testing.T) {
 }
 
 func TestBrokerUsageEndpointAggregatesTelemetry(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -2164,12 +2043,7 @@ func TestBrokerUsageEndpointAggregatesTelemetry(t *testing.T) {
 }
 
 func TestBrokerActionsAndSchedulerEndpoints(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.appendActionLocked("request_created", "office", "general", "ceo", "Asked for approval", "request-1")
 	b.mu.Unlock()
@@ -2204,12 +2078,7 @@ func TestBrokerActionsAndSchedulerEndpoints(t *testing.T) {
 }
 
 func TestSchedulerDueOnlyFiltersFutureJobs(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.SetSchedulerJob(schedulerJob{
 		Slug:            "task-follow-up:general:task-1",
 		Kind:            "task_follow_up",
@@ -2249,12 +2118,7 @@ func TestSchedulerDueOnlyFiltersFutureJobs(t *testing.T) {
 }
 
 func TestBrokerPostsAndDedupesNexNotifications(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -2298,12 +2162,7 @@ func TestBrokerPostsAndDedupesNexNotifications(t *testing.T) {
 }
 
 func TestBrokerTaskLifecycle(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -2396,12 +2255,7 @@ func TestBrokerTaskLifecycle(t *testing.T) {
 }
 
 func TestBrokerTaskReassignNotifies(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -2516,12 +2370,7 @@ func TestBrokerTaskReassignNotifies(t *testing.T) {
 }
 
 func TestBrokerTaskCancelNotifies(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -2630,12 +2479,7 @@ func containsAll(got, want []string) bool {
 }
 
 func TestBrokerOfficeFeatureTaskForGTMCompletesWithoutReviewAndUnblocksDependents(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -2718,12 +2562,7 @@ func TestBrokerOfficeFeatureTaskForGTMCompletesWithoutReviewAndUnblocksDependent
 }
 
 func TestBrokerTaskCreateReusesExistingOpenTask(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -2793,12 +2632,7 @@ func TestBrokerEnsurePlannedTaskKeepsScopedDuplicateTitlesDistinct(t *testing.T)
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 
 	first, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:          "general",
@@ -2853,12 +2687,7 @@ func TestBrokerEnsurePlannedTaskKeepsScopedDuplicateTitlesDistinct(t *testing.T)
 }
 
 func TestBrokerTaskCreateKeepsDistinctTasksInSameThread(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -2925,12 +2754,7 @@ func TestBrokerTaskPlanAssignsWorktreeForLocalWorktreeTask(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	if err := b.StartOnPort(0); err != nil {
@@ -2983,12 +2807,7 @@ func TestBrokerTaskPlanAssignsWorktreeForLocalWorktreeTask(t *testing.T) {
 }
 
 func TestBrokerTaskCreateAddsAssignedOwnerToChannelMembers(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "youtube-factory", "operator", "Operator")
 	if existing := b.findMemberLocked("builder"); existing == nil {
 		member := officeMember{Slug: "builder", Name: "Builder"}
@@ -3038,12 +2857,7 @@ func TestBrokerTaskCreateAddsAssignedOwnerToChannelMembers(t *testing.T) {
 }
 
 func TestBrokerResumeTaskUnblocksAndSchedulesOwnerLane(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")
 	ensureTestMemberAccess(b, "client-loop", "builder", "Builder")
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
@@ -3078,12 +2892,7 @@ func TestBrokerResumeTaskUnblocksAndSchedulesOwnerLane(t *testing.T) {
 }
 
 func TestBrokerResumeTaskQueuesBehindExistingExclusiveOwnerLane(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")
 	ensureTestMemberAccess(b, "client-loop", "builder", "Builder")
 
@@ -3133,12 +2942,7 @@ func TestBrokerResumeTaskQueuesBehindExistingExclusiveOwnerLane(t *testing.T) {
 }
 
 func TestBrokerUnblockDependentsQueuesExclusiveOwnerLanes(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "youtube-factory", "ceo", "CEO")
 	ensureTestMemberAccess(b, "youtube-factory", "executor", "Executor")
 
@@ -3220,12 +3024,7 @@ func TestBrokerUnblockDependentsQueuesExclusiveOwnerLanes(t *testing.T) {
 }
 
 func TestBrokerTaskPlanRejectsTheaterTaskInLiveDeliveryLane(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "client-delivery", "operator", "Operator")
 	ensureTestMemberAccess(b, "client-delivery", "builder", "Builder")
 	if err := b.StartOnPort(0); err != nil {
@@ -3262,12 +3061,7 @@ func TestBrokerTaskPlanRejectsTheaterTaskInLiveDeliveryLane(t *testing.T) {
 }
 
 func TestBrokerTaskCreateRejectsLiveBusinessTheater(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	if err := b.StartOnPort(0); err != nil {
@@ -3301,12 +3095,7 @@ func TestBrokerTaskCreateRejectsLiveBusinessTheater(t *testing.T) {
 }
 
 func TestBrokerTaskCompleteRejectsLiveBusinessTheater(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	if err := b.StartOnPort(0); err != nil {
@@ -3363,12 +3152,7 @@ func TestBrokerStoresLedgerAndReviewLifecycle(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -3463,12 +3247,7 @@ func TestBrokerReleaseTaskCleansWorktree(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -3534,12 +3313,7 @@ func TestBrokerApproveRetainsLocalWorktree(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -3654,12 +3428,7 @@ func TestBrokerHandlePostTaskRejectsFalseReadOnlyBlockForWritableWorktree(t *tes
 		verifyTaskWorktreeWritable = oldVerify
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "eng", "Engineer")
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
@@ -3742,12 +3511,7 @@ func TestBrokerBlockTaskRejectsFalseReadOnlyBlockForWritableWorktree(t *testing.
 		verifyTaskWorktreeWritable = oldVerify
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Implement the first runnable generator slice",
@@ -3801,12 +3565,7 @@ func TestBrokerEnsurePlannedTaskQueuesConcurrentExclusiveOwnerWork(t *testing.T)
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "executor", "Executor")
 
 	first, reused, err := b.EnsurePlannedTask(plannedTaskInput{
@@ -3849,12 +3608,7 @@ func TestBrokerEnsurePlannedTaskQueuesConcurrentExclusiveOwnerWork(t *testing.T)
 }
 
 func TestBrokerTaskPlanRoutesLiveBusinessTasksIntoRecentExecutionChannel(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	b.channels = append(b.channels, teamChannel{
 		Slug:      "client-loop",
@@ -3910,12 +3664,7 @@ func TestBrokerTaskPlanRoutesLiveBusinessTasksIntoRecentExecutionChannel(t *test
 }
 
 func TestBrokerTaskPlanReusesExistingActiveLane(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "client-loop", "builder", "Builder")
 	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")
 	for i := range b.channels {
@@ -4013,12 +3762,7 @@ func TestBrokerBlockTaskAllowsReadOnlyBlockWhenWriteProbeFails(t *testing.T) {
 		verifyTaskWorktreeWritable = oldVerify
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Implement the first runnable generator slice",
@@ -4058,12 +3802,7 @@ func TestBrokerCompleteClosesReviewTaskAndUnblocksDependents(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "eng", "Engineer")
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
@@ -4176,12 +3915,7 @@ func TestBrokerCreateTaskReusesCompletedDependencyWorktree(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
 	if err := b.StartOnPort(0); err != nil {
@@ -4345,12 +4079,7 @@ func TestBrokerNormalizeLoadedStateRepairsStaleAssignedWorktree(t *testing.T) {
 }
 
 func TestBrokerUpdatesTaskByIDAcrossChannels(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.channels = []teamChannel{
 		{
 			Slug: "general",
@@ -4425,12 +4154,7 @@ func TestBrokerCompleteAlreadyDoneTaskStaysApproved(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "eng", "Engineer")
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
@@ -4505,12 +4229,7 @@ func TestBrokerCompleteAlreadyDoneTaskStaysApproved(t *testing.T) {
 }
 
 func TestBrokerBridgeEndpointRecordsVisibleBridge(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members,
 		officeMember{Slug: "pm", Name: "Product Manager"},
@@ -4579,12 +4298,7 @@ func TestBrokerBridgeEndpointRecordsVisibleBridge(t *testing.T) {
 }
 
 func TestBrokerRequestsLifecycle(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -4682,12 +4396,7 @@ func TestBrokerRequestsLifecycle(t *testing.T) {
 // web UI only sees per-channel requests and can't render a blocker that lives
 // in another channel — leaving the human stuck: can't send, can't see why.
 func TestBrokerGetRequestsScopeAllSeesCrossChannelBlocker(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "ceo", "CEO")
 	ensureTestMemberAccess(b, "backend", "ceo", "CEO")
 	ensureTestMemberAccess(b, "backend", "human", "Human")
@@ -4765,12 +4474,7 @@ func TestBrokerGetRequestsScopeAllSeesCrossChannelBlocker(t *testing.T) {
 }
 
 func TestBrokerRequestAnswerUnblocksDependentTask(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "ceo", "CEO")
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	if err := b.StartOnPort(0); err != nil {
@@ -4894,12 +4598,7 @@ func TestBrokerRequestAnswerUnblocksDependentTask(t *testing.T) {
 }
 
 func TestBrokerDecisionRequestsDefaultToBlocking(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -4954,12 +4653,7 @@ func TestBrokerDecisionRequestsDefaultToBlocking(t *testing.T) {
 }
 
 func TestBrokerRequestAnswerRequiresCustomTextWhenOptionNeedsIt(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -5008,12 +4702,7 @@ func TestBrokerRequestAnswerRequiresCustomTextWhenOptionNeedsIt(t *testing.T) {
 }
 
 func TestQueueEndpointShowsDueJobs(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.SetSchedulerJob(schedulerJob{
 		Slug:       "request-follow-up:general:request-1",
 		Kind:       "request_follow_up",
@@ -5052,12 +4741,7 @@ func TestQueueEndpointShowsDueJobs(t *testing.T) {
 }
 
 func TestBrokerGetMessagesAgentScopeKeepsHumanAndCEOContext(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members,
 		officeMember{Slug: "pm", Name: "Product Manager"},
@@ -5203,12 +4887,7 @@ func TestLastTaggedAtSetOnPost(t *testing.T) {
 }
 
 func TestBrokerSurfaceMetadataPersists(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.channels = append(b.channels, teamChannel{
 		Slug:    "tg-ops",
@@ -5231,7 +4910,7 @@ func TestBrokerSurfaceMetadataPersists(t *testing.T) {
 	}
 	b.mu.Unlock()
 
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 	var found *teamChannel
 	for _, ch := range reloaded.channels {
 		if ch.Slug == "tg-ops" {
@@ -5264,12 +4943,7 @@ func TestBrokerSurfaceMetadataPersists(t *testing.T) {
 
 func TestBrokerSurfaceChannelsFilter(t *testing.T) {
 	t.Skip("skipped: manifest interference")
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.channels = append(b.channels,
 		teamChannel{
@@ -5312,12 +4986,7 @@ func TestBrokerSurfaceChannelsFilter(t *testing.T) {
 }
 
 func TestBrokerExternalQueueDeduplication(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.channels = append(b.channels, teamChannel{
 		Slug:    "ext",
@@ -5354,12 +5023,7 @@ func TestBrokerExternalQueueDeduplication(t *testing.T) {
 }
 
 func TestBrokerPostInboundSurfaceMessage(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.channels = append(b.channels, teamChannel{
 		Slug:    "surf",
@@ -5394,12 +5058,7 @@ func TestBrokerPostInboundSurfaceMessage(t *testing.T) {
 }
 
 func TestInFlightTasksReturnsOnlyNonTerminalOwned(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.tasks = []teamTask{
 		{ID: "t1", Title: "Active task", Owner: "fe", Status: "in_progress"},
@@ -5447,12 +5106,7 @@ func TestInFlightTasksReturnsOnlyNonTerminalOwned(t *testing.T) {
 }
 
 func TestInFlightTasksExcludesCompletedStatus(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.tasks = []teamTask{
 		{ID: "t1", Title: "Active task", Owner: "fe", Status: "in_progress"},
@@ -5477,12 +5131,7 @@ func TestInFlightTasksExcludesCompletedStatus(t *testing.T) {
 }
 
 func TestRecentHumanMessagesReturnsLastNHumanMessages(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{
 		{ID: "m1", From: "fe", Content: "agent reply 1", Timestamp: "2026-04-14T10:00:00Z"},
@@ -5508,12 +5157,7 @@ func TestRecentHumanMessagesReturnsLastNHumanMessages(t *testing.T) {
 }
 
 func TestRecentHumanMessagesLimitCapsResults(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{
 		{ID: "m1", From: "you", Content: "first", Timestamp: "2026-04-14T10:00:00Z"},
@@ -5530,12 +5174,7 @@ func TestRecentHumanMessagesLimitCapsResults(t *testing.T) {
 }
 
 func TestRecentHumanMessagesExcludesNonHuman(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{
 		{ID: "m1", From: "fe", Content: "agent", Timestamp: "2026-04-14T10:00:00Z"},
@@ -5550,12 +5189,7 @@ func TestRecentHumanMessagesExcludesNonHuman(t *testing.T) {
 }
 
 func TestRecentHumanMessagesIncludesNexSender(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{
 		{ID: "m1", From: "fe", Content: "agent msg", Timestamp: "2026-04-14T10:00:00Z"},
@@ -5746,12 +5380,7 @@ func TestParseSkillProposalParsesMultipleBlocks(t *testing.T) {
 
 // Test 7: Answering "accept" via HTTP activates the skill.
 func TestSkillProposalAcceptCallbackActivatesSkill(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -5810,12 +5439,7 @@ func TestSkillProposalAcceptCallbackActivatesSkill(t *testing.T) {
 
 // Test 8: Answering "reject" via HTTP archives the skill.
 func TestSkillProposalRejectCallbackArchivesSkill(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -5872,12 +5496,7 @@ func TestSkillProposalRejectCallbackArchivesSkill(t *testing.T) {
 }
 
 func TestRequestAnswerUnblocksReferencedTask(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -5955,12 +5574,7 @@ func TestRequestAnswerUnblocksReferencedTask(t *testing.T) {
 }
 
 func TestInvokeSkillTracksInvokerChannelAndExecutionMetadata(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.skills = append(b.skills, teamSkill{
 		ID:        "skill-youtube-factory-bootstrap",
@@ -6011,11 +5625,6 @@ func TestInvokeSkillTracksInvokerChannelAndExecutionMetadata(t *testing.T) {
 
 // Test 10: buildPrompt for the lead includes SKILL & AGENT AWARENESS section.
 func TestBuildPromptLeadIncludesSkillAwareness(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -6036,12 +5645,7 @@ func TestBuildPromptLeadIncludesSkillAwareness(t *testing.T) {
 
 // Test 10: Skill proposal and interview persist and reload correctly.
 func TestSkillProposalPersistenceRoundTrip(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = []officeMember{{Slug: "ceo", Name: "CEO", Role: "lead"}}
 	for i := range b.channels {
@@ -6062,7 +5666,7 @@ func TestSkillProposalPersistenceRoundTrip(t *testing.T) {
 	}
 	b.mu.Unlock()
 
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 	reloaded.mu.Lock()
 	skills := append([]teamSkill(nil), reloaded.skills...)
 	requests := append([]humanInterview(nil), reloaded.requests...)
@@ -6082,12 +5686,7 @@ func TestSkillProposalPersistenceRoundTrip(t *testing.T) {
 // message with the same eventID twice stores only one copy and returns the
 // existing message on the second call.
 func TestPostAutomationMessageDeduplicatesByEventID(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 
 	first, dup1, err := b.PostAutomationMessage("nex", "general", "Signal", "first post", "evt-001", "nex", "Nex", nil, "")
 	if err != nil {
@@ -6124,12 +5723,7 @@ func TestPostAutomationMessageDeduplicatesByEventID(t *testing.T) {
 // TestExternalQueueDeduplicatesByMessageID verifies that calling ExternalQueue
 // twice for a surface channel only delivers each message once.
 func TestExternalQueueDeduplicatesByMessageID(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 
 	// Register a channel with a surface so ExternalQueue has something to scan.
 	b.mu.Lock()
@@ -6172,12 +5766,7 @@ func TestExternalQueueDeduplicatesByMessageID(t *testing.T) {
 // members (ceo, eng, pm) wired into the general channel, and focus mode on.
 func makeFocusModeLauncher(t *testing.T) (*Launcher, *Broker) {
 	t.Helper()
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
-
-	b := NewBroker()
+	b := newTestBroker(t)
 
 	// Add eng and pm members to the broker so they appear in EnabledMembers.
 	b.mu.Lock()
@@ -6259,12 +5848,7 @@ func TestFocusModeRouting_TaggedSpecialistWakesSpecialistOnly(t *testing.T) {
 // TestFocusModeRouting_CollobaborativeUntaggedWakesAll verifies the contrast:
 // without focus mode, an untagged human message wakes all enabled agents.
 func TestFocusModeRouting_CollaborativeUntaggedWakesAll(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO", Role: "CEO", BuiltIn: true},
@@ -6483,12 +6067,7 @@ func TestEnsureDefaultOfficeMembersNoOpWhenNonEmpty(t *testing.T) {
 // ensureDefaultOfficeMembersLocked (called from Broker.Load() at broker.go:2260)
 // silently re-added ceo/planner/executor/reviewer.
 func TestLoadDoesNotAppendDefaultsAfterBlueprintSeed(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	now := time.Now().UTC().Format(time.RFC3339)
 	b.members = []officeMember{
@@ -6506,7 +6085,7 @@ func TestLoadDoesNotAppendDefaultsAfterBlueprintSeed(t *testing.T) {
 	}
 	b.mu.Unlock()
 
-	reloaded := reloadedBroker(t)
+	reloaded := reloadedBroker(t, b)
 	reloaded.mu.Lock()
 	slugs := make([]string, 0, len(reloaded.members))
 	for _, m := range reloaded.members {

--- a/internal/team/headless_claude_test.go
+++ b/internal/team/headless_claude_test.go
@@ -67,15 +67,9 @@ func TestHeadlessClaudeModel_OpusForLeadOnly(t *testing.T) {
 }
 
 // TestHeadlessClaudeModel_CustomLeadSlug verifies model selection when the
-// pack defines a non-"ceo" lead slug.
-// brokerStatePath is redirected to an empty temp dir so officeMembersSnapshot()
-// falls through to the pack definition instead of loading live state.
+// pack defines a non-"ceo" lead slug. No broker is constructed, so
+// officeMembersSnapshot() falls through to the pack definition.
 func TestHeadlessClaudeModel_CustomLeadSlug(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "captain",
@@ -117,10 +111,7 @@ func TestHeadlessClaudeModel_CustomLeadSlug(t *testing.T) {
 // captured args are all we need.
 func TestRunHeadlessClaudeTurn_NoResumeFlag(t *testing.T) {
 	// Redirect broker state to an isolated temp dir.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
 
 	origCommandContext := headlessClaudeCommandContext
 	origLookPath := headlessClaudeLookPath
@@ -141,7 +132,7 @@ func TestRunHeadlessClaudeTurn_NoResumeFlag(t *testing.T) {
 		return exec.CommandContext(ctx, "/bin/true")
 	}
 
-	b := NewBroker()
+	b := NewBrokerAt(filepath.Join(tmpDir, "broker-state.json"))
 	l := minimalLauncher(false)
 	l.broker = b
 	l.cwd = tmpDir

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -618,15 +618,11 @@ func TestEnqueueHeadlessCodexTurnProcessesFIFO(t *testing.T) {
 
 func TestPostHeadlessFinalMessageIfSilentPostsFinalOutput(t *testing.T) {
 	// Isolate state from the user's real ~/.wuphf/team/broker-state.json.
-	// Without this override NewBroker loads whatever prior test runs (or a
-	// real WUPHF run in ~/.wuphf/) persisted, and agentPostedSubstantiveMessageToChannelSince
-	// picks up an unrelated ceo message, making the "expected posted=true"
+	// Without isolation NewBroker could still pick up state from a shared
+	// ~/.wuphf/team/broker-state.json, and agentPostedSubstantiveMessageToChannelSince
+	// could observe an unrelated ceo message, making the "expected posted=true"
 	// assertion fail non-deterministically depending on machine history.
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	channel := DMSlugFor("ceo")
 	root, err := b.PostMessage("you", channel, "Ping the CEO.", nil, "")
 	if err != nil {
@@ -1629,11 +1625,11 @@ func TestHeadlessTurnCompletedDurablyRejectsCodingTurnWithoutTaskStateOrEvidence
 
 	// Build the task state directly instead of going through
 	// EnsurePlannedTask so we never call saveLocked — the broker-state
-	// save path races with leaked goroutines from earlier tests that
-	// read the swapped brokerStatePath global (rename .tmp -> final
-	// fails mid-flight). We don't need persistence here; we only need
-	// the task fields that headlessTurnCompletedDurably reads.
-	b := NewBroker()
+	// save path can race with leaked goroutines from earlier tests
+	// (rename .tmp -> final fails mid-flight). We don't need persistence
+	// here; we only need the task fields that headlessTurnCompletedDurably
+	// reads.
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.tasks = []teamTask{{
 		ID:            "task-1",
@@ -1922,10 +1918,7 @@ func TestBeginHeadlessCodexTurnCapturesWorktreeForLocalWorktreeBuilder(t *testin
 
 func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
 
 	oldPrepare := prepareTaskWorktree
 	oldCleanup := cleanupTaskWorktree
@@ -1940,7 +1933,7 @@ func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T
 
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
 
-	b := NewBroker()
+	b := NewBrokerAt(filepath.Join(tmpDir, "broker-state.json"))
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Implement queue mode for the YouTube factory",
@@ -2085,10 +2078,7 @@ func TestEnqueueHeadlessCodexTurnBypassesLeadHoldForReviewReadyTask(t *testing.T
 	}
 	defer func() { headlessCodexRunTurn = oldRunTurn }()
 
-	oldStatePath := brokerStatePath
 	stateDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(stateDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldStatePath }()
 
 	oldPrepare := prepareTaskWorktree
 	oldCleanup := cleanupTaskWorktree
@@ -2101,7 +2091,7 @@ func TestEnqueueHeadlessCodexTurnBypassesLeadHoldForReviewReadyTask(t *testing.T
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	b := NewBroker()
+	b := NewBrokerAt(filepath.Join(stateDir, "broker-state.json"))
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Define channel thesis and monetization system",

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -220,7 +220,7 @@ func NewLauncher(packSlug string) (*Launcher, error) {
 			fmt.Fprintf(os.Stderr, "warning: save blueprint/pack config: %v\n", err)
 		}
 		// Drop stale broker state so the new pack starts clean.
-		_ = os.Remove(brokerStatePath())
+		_ = os.Remove(defaultBrokerStatePath())
 	}
 	sessionMode, oneOnOne := loadRunningSessionMode()
 
@@ -3148,7 +3148,7 @@ func ResetBrokerState() error {
 }
 
 func ClearPersistedBrokerState() error {
-	path := brokerStatePath()
+	path := defaultBrokerStatePath()
 	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
@@ -4299,7 +4299,7 @@ func (l *Launcher) officeMembersSnapshot() []officeMember {
 			return mergePackMembers(members)
 		}
 	}
-	path := brokerStatePath()
+	path := defaultBrokerStatePath()
 	data, err := os.ReadFile(path)
 	if err == nil {
 		var state brokerState

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -32,12 +32,7 @@ func TestParseAgentPaneIndicesSkipsChannelPane(t *testing.T) {
 }
 
 func TestResetBrokerStateUsesAuthToken(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -49,12 +44,7 @@ func TestResetBrokerStateUsesAuthToken(t *testing.T) {
 }
 
 func TestResetSessionOnlyClearsOfficeState(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if _, err := b.PostMessage("you", "general", "hello", nil, ""); err != nil {
 		t.Fatalf("seed message: %v", err)
 	}
@@ -167,10 +157,8 @@ func TestAgentPaneSlugsUsesOfficeRosterNotStaticPack(t *testing.T) {
 }
 
 func TestOfficeMembersSnapshotPrefersPersistedStateOverPack(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	statePath := filepath.Join(t.TempDir(), "broker-state.json")
+	t.Setenv("WUPHF_BROKER_STATE_PATH", statePath)
 
 	state := brokerState{
 		Members: []officeMember{
@@ -183,7 +171,7 @@ func TestOfficeMembersSnapshotPrefersPersistedStateOverPack(t *testing.T) {
 	if err != nil {
 		t.Fatalf("marshal state: %v", err)
 	}
-	if err := os.WriteFile(brokerStatePath(), data, 0o600); err != nil {
+	if err := os.WriteFile(statePath, data, 0o600); err != nil {
 		t.Fatalf("write state: %v", err)
 	}
 
@@ -229,12 +217,7 @@ func TestNotificationTargetsForMessageOneOnOneWakesSelectedAgent(t *testing.T) {
 }
 
 func TestNotificationTargetsForMessageUsesMetadataBackedTaskOwner(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "operator", Name: "Operator", Role: "Lead operator", BuiltIn: true, Expertise: []string{"prioritization", "approvals"}},
@@ -330,11 +313,6 @@ func TestFormatNexFeedItem(t *testing.T) {
 }
 
 func TestFetchAndIngestNexNotificationsSeedsCursorOnColdStart(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests++
@@ -342,7 +320,7 @@ func TestFetchAndIngestNexNotificationsSeedsCursorOnColdStart(t *testing.T) {
 	}))
 	defer server.Close()
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	launcher := &Launcher{broker: b}
 	client := api.NewClient("test-key")
 	client.BaseURL = server.URL
@@ -481,11 +459,6 @@ func TestPrimeVisibleAgentsWithoutBrokerDoesNotPanic(t *testing.T) {
 }
 
 func TestNotificationTargetsForHumanMessageDirectToTaggedSpecialists(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		focusMode: true,
 		pack: &agent.PackDefinition{
@@ -533,11 +506,6 @@ func TestNotificationTargetsForHumanMessageDirectToTaggedSpecialists(t *testing.
 
 func TestNotificationTargetsForDMChannel(t *testing.T) {
 	// DMs should route only to the target agent, not to CEO or other specialists.
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		focusMode: true,
 		pack: &agent.PackDefinition{
@@ -578,11 +546,6 @@ func TestNotificationTargetsForDMChannel(t *testing.T) {
 }
 
 func TestNotificationTargetsForDMChannelCodexRuntimeUsesHeadlessTarget(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		provider: "codex",
 		pack: &agent.PackDefinition{
@@ -614,12 +577,7 @@ func TestNotificationTargetsForDMChannelCodexRuntimeUsesHeadlessTarget(t *testin
 }
 
 func TestDeliverDMMessageQueuesCodexHeadlessTurn(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	l := newHeadlessLauncherForTest()
 	l.broker = b
 	l.provider = "codex"
@@ -660,12 +618,7 @@ func TestDeliverDMMessageQueuesCodexHeadlessTurn(t *testing.T) {
 func TestNotificationTargetsForDMChannelNewSlugFormat(t *testing.T) {
 	// New-style deterministic DM slugs (e.g. "fe__human") should route the same
 	// way as legacy "dm-fe" slugs: only the target agent is notified.
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	// Override broker members so officeMembersSnapshot returns test agents.
 	b.mu.Lock()
 	b.members = []officeMember{
@@ -716,12 +669,7 @@ func TestNotificationTargetsForDMChannelNewSlugFormat(t *testing.T) {
 func TestResponseInstructionForTargetDMChannelNewSlugFormat(t *testing.T) {
 	// New-style deterministic DM slugs should produce the same "messaging you directly"
 	// instruction as legacy dm-* slugs, ensuring specialists respond in DMs.
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	// Override broker members so officeMembersSnapshot returns test agents.
 	b.mu.Lock()
 	b.members = []officeMember{
@@ -760,11 +708,6 @@ func TestResponseInstructionForTargetDMChannelNewSlugFormat(t *testing.T) {
 }
 
 func TestNotificationTargetsExplicitTagsAlwaysDeliverRegardlessOfDomain(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -793,11 +736,6 @@ func TestNotificationTargetsExplicitTagsAlwaysDeliverRegardlessOfDomain(t *testi
 }
 
 func TestNotificationTargetsTaggedSpecialistsGetImmediateDelivery(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -837,11 +775,6 @@ func TestNotificationTargetsTaggedSpecialistsGetImmediateDelivery(t *testing.T) 
 }
 
 func TestNotificationTargetsForCEOMessageNotifyTaggedOnly(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -869,11 +802,6 @@ func TestNotificationTargetsForCEOMessageNotifyTaggedOnly(t *testing.T) {
 }
 
 func TestTaskNotificationTargetsFollowOwnerAndCEOHeadStart(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -951,11 +879,6 @@ func TestTaskNotificationTargetsFollowOwnerAndCEOHeadStart(t *testing.T) {
 }
 
 func TestTaskNotificationTargetsWakeCEOWhenOwnerBlocksTask(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -1129,10 +1052,6 @@ func TestBuildTaskExecutionPacketRequiresRealExternalExecution(t *testing.T) {
 }
 
 func TestBuildPromptIncludesTaskStatusAndWorktreeGuidance(t *testing.T) {
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	l := &Launcher{
 		pack: &agent.PackDefinition{
 			LeadSlug: "ceo",
@@ -1507,12 +1426,7 @@ func TestTaskNotificationTargetsDoNotRewakeCEOForOwnCreatedTask(t *testing.T) {
 }
 
 func TestRecordPolicyDeduplicates(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	_, err := b.RecordPolicy("human_directed", "Always ask before deploying to production")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1529,12 +1443,7 @@ func TestRecordPolicyDeduplicates(t *testing.T) {
 }
 
 func TestRecordWatchdogLedgerCreatesSignalAndDecision(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	l := &Launcher{broker: b}
 
 	signalIDs, decisionID := l.recordWatchdogLedger("general", "task_stalled", "task-1", "fe", "Task is stalled.", "signal-1")
@@ -1553,12 +1462,7 @@ func TestRecordWatchdogLedgerCreatesSignalAndDecision(t *testing.T) {
 }
 
 func TestRecordPolicyPersistsAndLoads(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	_, err := b.RecordPolicy("human_directed", "Work autonomously without asking for approval")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1569,10 +1473,7 @@ func TestRecordPolicyPersistsAndLoads(t *testing.T) {
 	}
 
 	// Reload and verify persistence.
-	b2 := NewBroker()
-	if err := b2.loadState(); err != nil {
-		t.Fatalf("load failed: %v", err)
-	}
+	b2 := reloadedBroker(t, b)
 	policies := b2.ListPolicies()
 	if len(policies) != 2 {
 		t.Fatalf("expected 2 policies after reload, got %d", len(policies))
@@ -1595,12 +1496,7 @@ func TestBuildNotificationContextEmpty(t *testing.T) {
 }
 
 func TestBuildNotificationContextFormatsMessages(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1634,12 +1530,7 @@ func TestBuildNotificationContextFormatsMessages(t *testing.T) {
 }
 
 func TestBuildNotificationContextFiltersSystem(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1668,12 +1559,7 @@ func TestBuildNotificationContextFiltersSystem(t *testing.T) {
 }
 
 func TestBuildNotificationContextRespectsLimit(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1695,12 +1581,7 @@ func TestBuildNotificationContextRespectsLimit(t *testing.T) {
 }
 
 func TestBuildNotificationContextExcludesTrigger(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1729,12 +1610,7 @@ func TestBuildNotificationContextExcludesTrigger(t *testing.T) {
 func TestUltimateThreadRootFlat(t *testing.T) {
 	// Flat thread: human ask (X) → CEO reply (Y, replyTo=X).
 	// ultimateThreadRoot starting from Y should return X.
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1758,12 +1634,7 @@ func TestUltimateThreadRootFlat(t *testing.T) {
 func TestUltimateThreadRootDeep(t *testing.T) {
 	// Deep thread: X → Y (replyTo=X) → Z (replyTo=Y).
 	// ultimateThreadRoot starting from Z should return X.
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1790,12 +1661,7 @@ func TestUltimateThreadRootDeep(t *testing.T) {
 
 func TestUltimateThreadRootTopLevel(t *testing.T) {
 	// Top-level message has no replyTo: walk returns the message itself.
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1826,12 +1692,7 @@ func TestThreadMessageIDsParallelDelegation(t *testing.T) {
 	//
 	// CEO gets notified about A_reply. threadMessageIDs from ultimate root X must
 	// include B_reply so CEO knows B already acted.
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1874,12 +1735,7 @@ func TestBuildNotificationContextThreadFiltering(t *testing.T) {
 	// Verifies that when a threadRootID is given, only messages in that thread
 	// appear in the context (labeled [Recent thread]), and messages from a
 	// concurrent unrelated thread are excluded.
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1931,12 +1787,7 @@ func TestBuildNotificationContextIncludesDeepThreadMessages(t *testing.T) {
 	//
 	// Marketing agent's context should show X (root anchor) and R (research results),
 	// NOT just X and Y (which is all the old shallow filter produced).
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1984,12 +1835,7 @@ func TestBuildTaskNotificationContextCEOSeesAllChannels(t *testing.T) {
 	// CEO task context must include tasks from ALL channels, not just the channel of
 	// the message that woke the CEO. When woken from "engineering" channel, the CEO
 	// should still see tasks in "general".
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -2111,12 +1957,7 @@ func TestBuildNotificationContextFallsBackToChannelWhenThreadEmpty(t *testing.T)
 	// When threadRootID is given but the thread has no displayable messages
 	// (e.g. the trigger IS the root and no other replies exist yet), the function
 	// should fall back to recent channel messages labeled [Recent channel].
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -2152,10 +1993,7 @@ func TestRelevantTaskForTargetCrossChannel(t *testing.T) {
 	// relevantTaskForTarget must still find it. Before the AllTasks() fix, it searched
 	// only ChannelTasks("general") and returned nothing — causing work packets to omit
 	// the "Active task" line and giving specialists the wrong response instruction.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
 
 	oldPrepare := prepareTaskWorktree
 	oldCleanup := cleanupTaskWorktree
@@ -2168,7 +2006,7 @@ func TestRelevantTaskForTargetCrossChannel(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	b := NewBroker()
+	b := NewBrokerAt(filepath.Join(tmpDir, "broker-state.json"))
 
 	// Create "engineering" channel directly in broker state.
 	b.mu.Lock()
@@ -2257,12 +2095,7 @@ func TestRelevantTaskForTargetCrossChannel(t *testing.T) {
 }
 
 func TestRelevantTaskForTargetUsesRosterMetadata(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "operator", Name: "Operator", Role: "Lead operator", BuiltIn: true, Expertise: []string{"prioritization", "approvals"}},
@@ -2320,12 +2153,7 @@ func TestBlockedTaskNotificationAndUnblockFlow(t *testing.T) {
 	// 2. Marketing should NOT be woken immediately (task is blocked)
 	// 3. When research completes, a task_unblocked action fires
 	// 4. Marketing IS woken immediately via the task_unblocked notification
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -2449,12 +2277,7 @@ func TestBlockedTaskNotificationAndUnblockFlow(t *testing.T) {
 // taskNotificationTargets (called via deliverTaskNotification) would include
 // the marketing owner in immediate targets — confirming the full path is live.
 func TestActionLoopAllowsTaskUnblocked(t *testing.T) {
-	dir := t.TempDir()
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(dir, "state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -2575,12 +2398,7 @@ done:
 }
 
 func TestProcessDueTaskJobResumesRateLimitedBlockedTask(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO"},
@@ -2628,19 +2446,13 @@ func TestProcessDueTaskJobResumesRateLimitedBlockedTask(t *testing.T) {
 }
 
 func TestOfficeChangeTaskNotificationsBackfillGeneratedMemberTask(t *testing.T) {
-	// Intentionally swap brokerStatePath to a leaked OS-temp dir rather than
-	// t.TempDir(). Goroutines leaked by prior tests in this package call
-	// brokerStatePath() via saveLocked() and resolve to whatever the global
-	// currently points at — which races with t.TempDir cleanup if the target
-	// is inside the test's own tempdir ("unlinkat: directory not empty").
-	// Leaking a few KB in /tmp is the cheap fix; proper goroutine hygiene
-	// across the suite is a separate refactor.
-	oldPathFn := brokerStatePath
-	statePath := leakedBrokerStatePath(t)
-	brokerStatePath = func() string { return statePath }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	// Pin the broker's state file outside t.TempDir(). Goroutines leaked
+	// by prior tests in this package may still be saving via a Broker
+	// whose statePath was captured at construction; targeting a leaked
+	// OS-temp dir prevents races with t.TempDir cleanup ("unlinkat:
+	// directory not empty"). Leaking a few KB in /tmp is the cheap fix;
+	// proper goroutine hygiene across the suite is a separate refactor.
+	b := NewBrokerAt(leakedBrokerStatePath(t))
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO"},
@@ -2696,12 +2508,7 @@ func TestOfficeChangeTaskNotificationsBackfillGeneratedMemberTask(t *testing.T) 
 func TestOfficeChangeTaskNotificationsBackfillChannelMembershipTask(t *testing.T) {
 	// See TestOfficeChangeTaskNotificationsBackfillGeneratedMemberTask for
 	// why this test uses a leaked state dir instead of t.TempDir().
-	oldPathFn := brokerStatePath
-	statePath := leakedBrokerStatePath(t)
-	brokerStatePath = func() string { return statePath }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := NewBrokerAt(leakedBrokerStatePath(t))
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO"},

--- a/internal/team/launcher_workflow_test.go
+++ b/internal/team/launcher_workflow_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -18,11 +17,6 @@ func TestProcessDueWorkflowJobUsesComposioProvider(t *testing.T) {
 	t.Setenv("WUPHF_API_KEY", "nex-test-key")
 	t.Setenv("WUPHF_COMPOSIO_API_KEY", "cmp-test-key")
 	t.Setenv("WUPHF_COMPOSIO_USER_ID", "najmuzzaman@nex.ai")
-
-	tmpDir := t.TempDir()
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/connected_accounts/ca_123", func(w http.ResponseWriter, r *http.Request) {
@@ -131,7 +125,7 @@ func TestProcessDueWorkflowJobUsesComposioProvider(t *testing.T) {
 		t.Fatalf("create workflow: %v", err)
 	}
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.skills = append(b.skills, teamSkill{
 		Name:             "daily-digest",
 		Title:            "Daily Digest",

--- a/internal/team/mention_auto_promote_test.go
+++ b/internal/team/mention_auto_promote_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -27,12 +26,7 @@ import (
 
 func newBrokerWithPM(t *testing.T) *Broker {
 	t.Helper()
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{Slug: "pm", Name: "Product Manager"})
 	b.mu.Unlock()

--- a/internal/team/mention_routing_bug_test.go
+++ b/internal/team/mention_routing_bug_test.go
@@ -2,7 +2,6 @@ package team
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -30,10 +29,6 @@ import (
 
 func collaborativeTestLauncher(t *testing.T) *Launcher {
 	t.Helper()
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
 	return &Launcher{
 		// focusMode intentionally left false: collaborative is the default.
 		pack: &agent.PackDefinition{
@@ -124,11 +119,7 @@ func TestBug_HumanDMsSpecialist_CollaborativeMode_SpecialistIsImmediate(t *testi
 // required), which lets us deterministically observe what got enqueued.
 func fullDispatchLauncher(t *testing.T) (*Launcher, chan string, func()) {
 	t.Helper()
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO"},
@@ -163,7 +154,6 @@ func fullDispatchLauncher(t *testing.T) (*Launcher, chan string, func()) {
 
 	cleanup := func() {
 		headlessCodexRunTurn = oldRunTurn
-		brokerStatePath = oldPathFn
 	}
 	return l, processed, cleanup
 }
@@ -282,12 +272,7 @@ func hasSlug(xs []string, want string) bool {
 // -----------------------------------------------------------------------------
 
 func TestBug_FocusMode_HumanTagsWizardHiredPM_SpecialistIsImmediate(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{Slug: "pm", Name: "Product Manager"})
 	b.mu.Unlock()
@@ -327,12 +312,7 @@ func TestBug_FocusMode_HumanTagsWizardHiredPM_SpecialistIsImmediate(t *testing.T
 }
 
 func TestBug_FocusMode_CEOTagsWizardHiredPM_SpecialistIsImmediate(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{Slug: "pm", Name: "Product Manager"})
 	b.mu.Unlock()
@@ -373,12 +353,7 @@ func TestBug_FocusMode_CEOTagsWizardHiredPM_SpecialistIsImmediate(t *testing.T) 
 // -----------------------------------------------------------------------------
 
 func TestBug_DisabledMember_ExplicitTagDoesNotBypassMute(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{Slug: "pm", Name: "Product Manager"})
 	// Put pm in the channel then explicitly disable them.
@@ -451,12 +426,7 @@ func TestBug_DisabledMember_ExplicitTagDoesNotBypassMute(t *testing.T) {
 // activeSessionMembers (which is pack-gated) excludes pm, agentNotificationTargets
 // never registers pm, and DM dispatch silently returns zero targets.
 func TestBug_DMToWizardHiredPM_Dispatch(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	// Simulate the wizard flow: POST /office-members adds to b.members, but
 	// the Launcher's pack is frozen at launch time.
 	b.mu.Lock()
@@ -502,12 +472,7 @@ func TestBug_DMToWizardHiredPM_Dispatch(t *testing.T) {
 // from targetMap entirely, so even the explicit-tag bypass (just-applied fix)
 // can't save the delivery.
 func TestBug_TagWizardHiredPM_InGeneral_Dispatch(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{Slug: "pm", Name: "Product Manager"})
 	b.mu.Unlock()
@@ -554,12 +519,7 @@ func TestBug_TagWizardHiredPM_InGeneral_Dispatch(t *testing.T) {
 // allowTarget / isEnabled check silently drops the explicit mention and only
 // CEO gets notified. This is symptom 1 of the reported bug.
 func TestBug_RootCause_ChannelMembershipFilterDropsExplicitMention(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	// Add a specialist AFTER the broker has seeded default channels (this is
 	// what happens when a user hires a new agent via the wizard).
 	b.mu.Lock()

--- a/internal/team/operation_matrix_test.go
+++ b/internal/team/operation_matrix_test.go
@@ -122,8 +122,6 @@ func TestOperationBlueprintMatrixBuildsBootstrapPackage(t *testing.T) {
 
 func TestOperationBlueprintMatrixSeedsBrokerOffice(t *testing.T) {
 	repoRoot := teamTestRepoRoot(t)
-	oldPathFn := brokerStatePath
-	defer func() { brokerStatePath = oldPathFn }()
 
 	for _, id := range teamOperationFixtureIDs(t, repoRoot) {
 		t.Run(id, func(t *testing.T) {
@@ -146,15 +144,12 @@ func TestOperationBlueprintMatrixSeedsBrokerOffice(t *testing.T) {
 				t.Fatalf("write manifest: %v", err)
 			}
 
-			stateDir := t.TempDir()
-			brokerStatePath = func() string { return filepath.Join(stateDir, "broker-state.json") }
-
 			blueprint, err := operations.LoadBlueprint(repoRoot, id)
 			if err != nil {
 				t.Fatalf("load blueprint: %v", err)
 			}
 
-			b := NewBroker()
+			b := newTestBroker(t)
 			members := b.OfficeMembers()
 			if len(members) != len(blueprint.Starter.Agents) {
 				t.Fatalf("expected broker office roster to match starter agents, got %d want %d", len(members), len(blueprint.Starter.Agents))
@@ -194,8 +189,6 @@ func TestOperationBlueprintMatrixSeedsBrokerOffice(t *testing.T) {
 
 func TestOperationBlueprintMatrixServesBootstrapPackageEndpoint(t *testing.T) {
 	repoRoot := teamTestRepoRoot(t)
-	oldPathFn := brokerStatePath
-	defer func() { brokerStatePath = oldPathFn }()
 
 	for _, id := range teamOperationFixtureIDs(t, repoRoot) {
 		t.Run(id, func(t *testing.T) {
@@ -218,15 +211,12 @@ func TestOperationBlueprintMatrixServesBootstrapPackageEndpoint(t *testing.T) {
 				t.Fatalf("write manifest: %v", err)
 			}
 
-			stateDir := t.TempDir()
-			brokerStatePath = func() string { return filepath.Join(stateDir, "broker-state.json") }
-
 			blueprint, err := operations.LoadBlueprint(repoRoot, id)
 			if err != nil {
 				t.Fatalf("load blueprint: %v", err)
 			}
 
-			b := NewBroker()
+			b := newTestBroker(t)
 			req := httptest.NewRequest(http.MethodGet, "/operations/bootstrap-package", nil)
 			rec := httptest.NewRecorder()
 			b.handleOperationBootstrapPackage(rec, req)

--- a/internal/team/policy_test.go
+++ b/internal/team/policy_test.go
@@ -39,14 +39,7 @@ func TestNewOfficePolicyTrimsRule(t *testing.T) {
 }
 
 func TestBrokerRecordAndListPolicies(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	import_path := tmpDir + "/broker-state.json"
-	_ = import_path
-	brokerStatePath = func() string { return tmpDir + "/broker-state.json" }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	p1, err := b.RecordPolicy("human_directed", "Always ask before deploying to production")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -69,12 +62,7 @@ func TestBrokerRecordAndListPolicies(t *testing.T) {
 }
 
 func TestBrokerRecordPolicyDeduplicates(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return tmpDir + "/broker-state.json" }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	const rule = "Work autonomously without approval"
 	_, err := b.RecordPolicy("human_directed", rule)
 	if err != nil {
@@ -90,12 +78,7 @@ func TestBrokerRecordPolicyDeduplicates(t *testing.T) {
 }
 
 func TestBrokerDeletePolicyDeactivates(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return tmpDir + "/broker-state.json" }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	p, err := b.RecordPolicy("human_directed", "Ask before sending external emails")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -118,12 +101,7 @@ func TestBrokerDeletePolicyDeactivates(t *testing.T) {
 }
 
 func TestBrokerRecordPolicyEmptyRuleErrors(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return tmpDir + "/broker-state.json" }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	_, err := b.RecordPolicy("human_directed", "  ")
 	if err == nil {
 		t.Fatal("expected error for empty rule")

--- a/internal/team/resume_test.go
+++ b/internal/team/resume_test.go
@@ -1,7 +1,6 @@
 package team
 
 import (
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -115,11 +114,6 @@ func TestFindUnansweredMessagesNexReplyDoesNotCountAsAgentAnswer(t *testing.T) {
 
 func TestBuildResumePacketWithTasksAndMessages(t *testing.T) {
 	// Suppress broker state path for this test.
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	tasks := []teamTask{
 		{ID: "t1", Title: "Build the login page", Owner: "fe", Status: "in_progress"},
 		{ID: "t2", Title: "Design API schema", Owner: "fe", Status: "pending"},
@@ -184,12 +178,7 @@ func TestBuildResumePacketMessagesOnly(t *testing.T) {
 // --- Tests for Launcher.buildResumePackets ---
 
 func TestBuildResumePacketsTaggedMessageRoutesToTaggedAgent(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{
 		{ID: "h1", From: "you", Content: "hey @fe please build the login page", Tagged: []string{"fe"}, Timestamp: "2026-04-14T10:00:00Z"},
@@ -224,12 +213,7 @@ func TestBuildResumePacketsTaggedMessageRoutesToTaggedAgent(t *testing.T) {
 }
 
 func TestBuildResumePacketsIncludesDynamicBrokerMembersOutsideLaunchPack(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO"},
@@ -270,12 +254,7 @@ func TestBuildResumePacketsIncludesDynamicBrokerMembersOutsideLaunchPack(t *test
 }
 
 func TestBuildResumePacketsUntaggedMessageRoutesToLead(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{
 		{ID: "h1", From: "you", Content: "what should we build next?", Timestamp: "2026-04-14T10:00:00Z"},
@@ -306,12 +285,7 @@ func TestBuildResumePacketsUntaggedMessageRoutesToLead(t *testing.T) {
 }
 
 func TestBuildResumePacketsInFlightTasksIncluded(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.tasks = []teamTask{
 		{ID: "t1", Title: "Build dashboard", Owner: "fe", Status: "in_progress"},
@@ -341,12 +315,7 @@ func TestBuildResumePacketsInFlightTasksIncluded(t *testing.T) {
 }
 
 func TestBuildResumePacketsEmptyWhenNothingInFlight(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	// No tasks, no messages.
 	l := &Launcher{
 		broker: b,
@@ -372,12 +341,7 @@ func TestResumeInFlightWorkNoBrokerNoPanic(t *testing.T) {
 }
 
 func TestResumeInFlightWorkNoPackNoPanic(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{
 		{ID: "h1", From: "you", Content: "unanswered question", Timestamp: "2026-04-14T10:00:00Z"},
@@ -391,12 +355,7 @@ func TestResumeInFlightWorkNoPackNoPanic(t *testing.T) {
 }
 
 func TestBuildResumePacketsUnansweredRoutesToLead(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{
 		// answered: has a reply
@@ -435,12 +394,7 @@ func TestBuildResumePacketsUnansweredRoutesToLead(t *testing.T) {
 }
 
 func TestBuildResumePacketsSkipsAgentsNotInPack(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.tasks = []teamTask{
 		// "designer" is NOT in the pack below — their task should be skipped.
@@ -478,12 +432,7 @@ func TestBuildResumePacketsSkipsAgentsNotInPack(t *testing.T) {
 }
 
 func TestBuildResumePacketsSkipsTaggedAgentsNotInPack(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{
 		// Tagged @old-agent who is no longer in the pack.
@@ -567,12 +516,7 @@ func TestResumeInFlightWorkHeadlessEnqueuesLeadEvenWhenSpecialistsPresent(t *tes
 	// Fix: enqueue the lead first so its queue entry is set before specialists'
 	// queues are populated — the queue-hold check fires only when OTHER slugs
 	// have non-empty queues at the time of the CEO enqueue.
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	// fe has an in-flight task (specialist).
 	b.tasks = []teamTask{
@@ -689,14 +633,9 @@ func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
 	// Leaked path (not t.TempDir) so a headless worker goroutine that
 	// outlives the test can keep writing without racing the dir cleanup
 	// and failing the test with an `unlinkat ... directory not empty`.
-	oldPathFn := brokerStatePath
-	statePath := leakedBrokerStatePath(t)
-	brokerStatePath = func() string { return statePath }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
 
-	b := NewBroker()
+	b := NewBrokerAt(leakedBrokerStatePath(t))
 	b.mu.Lock()
 	b.tasks = []teamTask{
 		{ID: "t1", Title: "Build login form", Owner: "fe", Status: "in_progress"},
@@ -745,11 +684,6 @@ func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 	// Leaked path (not t.TempDir) so a headless worker goroutine that
 	// outlives the test can keep writing without racing the dir cleanup
 	// and failing the test with an `unlinkat ... directory not empty`.
-	oldPathFn := brokerStatePath
-	statePath := leakedBrokerStatePath(t)
-	brokerStatePath = func() string { return statePath }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
 
 	oldSendPane := launcherSendNotificationToPane
@@ -759,7 +693,7 @@ func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 	}
 	defer func() { launcherSendNotificationToPane = oldSendPane }()
 
-	b := NewBroker()
+	b := NewBrokerAt(leakedBrokerStatePath(t))
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO", Provider: provider.ProviderBinding{Kind: provider.KindClaudeCode}},

--- a/internal/team/telegram_test.go
+++ b/internal/team/telegram_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -14,12 +13,7 @@ import (
 
 func newTestBrokerWithTelegramChannel(t *testing.T, chatID string) *Broker {
 	t.Helper()
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.channels = append(b.channels, teamChannel{
 		Slug:    "telegram-general",
@@ -336,12 +330,7 @@ func TestTelegramStartFailsWithoutToken(t *testing.T) {
 }
 
 func TestTelegramStartFailsWithoutChannels(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	// Clear all channels so there are no telegram surfaces
 	b.mu.Lock()
 	b.channels = []teamChannel{{Slug: "general", Name: "general", Members: []string{"ceo"}}}

--- a/internal/team/token_bloat_fixes_test.go
+++ b/internal/team/token_bloat_fixes_test.go
@@ -1,7 +1,6 @@
 package team
 
 import (
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -14,12 +13,7 @@ import (
 // pattern — the prompt rule telling agents not to do that is routinely
 // ignored, so this enforces it at the persistence layer.
 func TestDuplicateAgentBroadcastIsSuppressed(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	now := time.Now().UTC().Format(time.RFC3339)
 	b.mu.Lock()
 	b.messages = []channelMessage{
@@ -62,12 +56,7 @@ func TestDuplicateAgentBroadcastIsSuppressed(t *testing.T) {
 // TestDuplicateAgentBroadcastWindowExpires verifies the dedup window is time
 // bounded — a follow-up beyond the window posts normally.
 func TestDuplicateAgentBroadcastWindowExpires(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
-	b := NewBroker()
+	b := newTestBroker(t)
 	old := time.Now().UTC().Add(-2 * duplicateBroadcastWindow).Format(time.RFC3339)
 	b.mu.Lock()
 	b.messages = []channelMessage{
@@ -86,18 +75,13 @@ func TestDuplicateAgentBroadcastWindowExpires(t *testing.T) {
 // old "@planner say hi" from hours before the restart wakes planner with
 // the wrong intent).
 func TestStaleUnansweredFilteredOnResume(t *testing.T) {
-	oldPathFn := brokerStatePath
-	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
-
 	// This test runs with the production-like threshold, not the test-suite
 	// override from TestMain. Swap locally so production semantics win here.
 	origThreshold := staleUnansweredThreshold
 	staleUnansweredThreshold = time.Hour
 	defer func() { staleUnansweredThreshold = origThreshold }()
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	stale := time.Now().UTC().Add(-90 * time.Minute).Format(time.RFC3339)
 	fresh := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
 	b.mu.Lock()

--- a/internal/team/wizard_hire_channel_access_test.go
+++ b/internal/team/wizard_hire_channel_access_test.go
@@ -36,12 +36,7 @@ func newBrokerWithPackChannels(t *testing.T, packAgents []agent.AgentConfig) *Br
 	// prior tests in this package can fire a late saveLocked and race
 	// t.TempDir cleanup. Same fix as the launcher_test.go pair; see
 	// broker_test.go for the helper docstring.
-	oldPathFn := brokerStatePath
-	statePath := leakedBrokerStatePath(t)
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
-
-	b := NewBroker()
+	b := NewBrokerAt(leakedBrokerStatePath(t))
 	b.mu.Lock()
 	// Seed pack-like roster.
 	members := make([]officeMember, 0, len(packAgents))

--- a/internal/team/worktree.go
+++ b/internal/team/worktree.go
@@ -279,7 +279,7 @@ func overlayWorkspaceChanges(sourceRoot, worktreePath string) error {
 }
 
 func overlayPersistedTaskWorktrees(worktreePath string, currentTaskID string) error {
-	raw, err := os.ReadFile(brokerStatePath())
+	raw, err := os.ReadFile(defaultBrokerStatePath())
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
@@ -425,7 +425,7 @@ func worktreeNamespaceToken(repoRoot string) string {
 }
 
 func CleanupPersistedTaskWorktrees() error {
-	path := brokerStatePath()
+	path := defaultBrokerStatePath()
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/internal/team/worktree_guard_test.go
+++ b/internal/team/worktree_guard_test.go
@@ -3,7 +3,6 @@ package team
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -36,14 +35,13 @@ func init() {
 	cleanupTaskWorktree = stubCleanupTaskWorktree
 	skipBrokerStateLoadOnConstruct = true
 
-	// Pin WUPHF_RUNTIME_HOME and the default brokerStatePath into
-	// process-lifetime leaked tempdirs so any test that constructs a
-	// Broker without its own isolation setup falls back to /tmp instead
-	// of the developer's real ~/.wuphf. Tests that override either via
-	// t.Setenv / brokerStatePath = ... take precedence locally; their
-	// deferred restore lands on these safe defaults. Leaked (not
-	// t.TempDir) so late writes from goroutines a test failed to stop
-	// don't race on a directory being deleted.
+	// Pin WUPHF_RUNTIME_HOME into a process-lifetime leaked tempdir so
+	// any test that constructs a Broker without its own isolation setup
+	// falls back to /tmp instead of the developer's real ~/.wuphf.
+	// defaultBrokerStatePath() consults this env var, so broker state
+	// files created by unisolated tests land under a leaked temp dir.
+	// Leaked (not t.TempDir) so late writes from goroutines a test
+	// failed to stop don't race on a directory being deleted.
 	runtimeHome, err := os.MkdirTemp("", "wuphf-test-runtime-home-*")
 	if err != nil {
 		panic(fmt.Sprintf("worktree_guard_test init: mktemp runtime home: %v", err))
@@ -51,13 +49,6 @@ func init() {
 	if err := os.Setenv("WUPHF_RUNTIME_HOME", runtimeHome); err != nil {
 		panic(fmt.Sprintf("worktree_guard_test init: setenv WUPHF_RUNTIME_HOME: %v", err))
 	}
-
-	stateDir, err := os.MkdirTemp("", "wuphf-test-broker-state-*")
-	if err != nil {
-		panic(fmt.Sprintf("worktree_guard_test init: mktemp broker state: %v", err))
-	}
-	defaultTestStatePath := filepath.Join(stateDir, "broker-state.json")
-	brokerStatePath = func() string { return defaultTestStatePath }
 }
 
 func stubPrepareTaskWorktree(taskID string) (string, string, error) {

--- a/internal/team/worktree_test.go
+++ b/internal/team/worktree_test.go
@@ -14,15 +14,10 @@ import (
 func TestCleanupPersistedTaskWorktreesRemovesUniqueTrackedWorktrees(t *testing.T) {
 	stateDir := t.TempDir()
 	statePath := filepath.Join(stateDir, "broker-state.json")
+	t.Setenv("WUPHF_BROKER_STATE_PATH", statePath)
 
-	oldStatePath := brokerStatePath
 	oldCleanup := cleanupTaskWorktree
-	defer func() {
-		brokerStatePath = oldStatePath
-		cleanupTaskWorktree = oldCleanup
-	}()
-
-	brokerStatePath = func() string { return statePath }
+	defer func() { cleanupTaskWorktree = oldCleanup }()
 
 	var calls []string
 	cleanupTaskWorktree = func(path, branch string) error {
@@ -58,10 +53,7 @@ func TestCleanupPersistedTaskWorktreesRemovesUniqueTrackedWorktrees(t *testing.T
 func TestCleanupPersistedTaskWorktreesMissingStateIsNoOp(t *testing.T) {
 	stateDir := t.TempDir()
 	statePath := filepath.Join(stateDir, "broker-state.json")
-
-	oldStatePath := brokerStatePath
-	defer func() { brokerStatePath = oldStatePath }()
-	brokerStatePath = func() string { return statePath }
+	t.Setenv("WUPHF_BROKER_STATE_PATH", statePath)
 
 	if err := CleanupPersistedTaskWorktrees(); err != nil {
 		t.Fatalf("expected missing state cleanup to succeed, got %v", err)
@@ -191,15 +183,11 @@ func TestDefaultPrepareTaskWorktreeOverlaysCompletedSiblingTaskWorkspace(t *test
 	}
 	defer func() { _ = os.Chdir(oldCwd) }()
 	oldTaskRoot := taskWorktreeRootDir
-	oldStatePath := brokerStatePath
-	defer func() {
-		taskWorktreeRootDir = oldTaskRoot
-		brokerStatePath = oldStatePath
-	}()
+	defer func() { taskWorktreeRootDir = oldTaskRoot }()
 	taskWorktreeRootDir = func(repoRoot string) string {
 		return filepath.Join(worktreeRoot, sanitizeWorktreeToken(filepath.Base(repoRoot)))
 	}
-	brokerStatePath = func() string { return statePath }
+	t.Setenv("WUPHF_BROKER_STATE_PATH", statePath)
 
 	run := func(dir string, args ...string) {
 		t.Helper()
@@ -294,15 +282,11 @@ func TestDefaultPrepareTaskWorktreeSkipsDuplicateAndMissingCompletedSiblingSourc
 	}
 	defer func() { _ = os.Chdir(oldCwd) }()
 	oldTaskRoot := taskWorktreeRootDir
-	oldStatePath := brokerStatePath
-	defer func() {
-		taskWorktreeRootDir = oldTaskRoot
-		brokerStatePath = oldStatePath
-	}()
+	defer func() { taskWorktreeRootDir = oldTaskRoot }()
 	taskWorktreeRootDir = func(repoRoot string) string {
 		return filepath.Join(worktreeRoot, sanitizeWorktreeToken(filepath.Base(repoRoot)))
 	}
-	brokerStatePath = func() string { return statePath }
+	t.Setenv("WUPHF_BROKER_STATE_PATH", statePath)
 
 	run := func(dir string, args ...string) {
 		t.Helper()


### PR DESCRIPTION
## Summary

- Migrates **184 monkey-patch sites across 25 internal/team test files** from
  the `oldPathFn := brokerStatePath ; brokerStatePath = func()... ; defer ...`
  pattern to direct `NewBrokerAt(path)` calls (Track A.2).
- Deletes the package-level `brokerStatePath` var + `brokerStateSnapshotPath()`
  helper (Track A.3) and migrates the 5 non-test callers in `worktree.go` and
  `launcher.go` to call `defaultBrokerStatePath()` directly.
- Stacked on #289 (`refactor/broker-statepath-ctor`); this PR's base branch
  is the A.1 branch so the diff stays scoped to the test sweep + var deletion.

## What changed

**Commit 1 — test migration (25 files):**
- `newTestBroker(t)` helper now returns `NewBrokerAt(filepath.Join(t.TempDir(),
  "broker-state.json"))` directly; no package-var assignment.
- `reloadedBroker` signature changed to `reloadedBroker(t *testing.T, b *Broker)`
  so it reuses `b.statePath`. All 13 callers updated.
- `withIsolatedBrokerState` helper deleted; its 16 callers (13 in
  `broker_onboarding_test.go`, 3 in `broker_onboarding_wiki_test.go`) call
  `newTestBroker(t)` directly.
- 4 worktree/launcher tests that exercise non-Broker disk-read code paths
  now use `t.Setenv(\"WUPHF_BROKER_STATE_PATH\", ...)` so
  `defaultBrokerStatePath()` resolves to the per-test temp dir.
- 3 `brokerStateSnapshotPath()` test sites now call `b.stateSnapshotPath()`.
- `worktree_guard_test.go` init() drops the `brokerStatePath` pre-seed; the
  `WUPHF_RUNTIME_HOME` override alone redirects unisolated brokers to a
  leaked tempdir.

**Commit 2 — package var deletion + non-test caller migration:**
- `var brokerStatePath = defaultBrokerStatePath` deleted.
- `brokerStateSnapshotPath()` deleted; only call site (Reset) now uses
  `b.stateSnapshotPath()`.
- `NewBroker()` becomes a one-liner: `return NewBrokerAt(defaultBrokerStatePath())`.
- 5 non-test caller sites swap `brokerStatePath()` for `defaultBrokerStatePath()`:
  - `worktree.go:overlayPersistedTaskWorktrees`
  - `worktree.go:CleanupPersistedTaskWorktrees`
  - `launcher.go` stale-broker-state cleanup on pack switch
  - `launcher.go:ClearPersistedBrokerState`
  - `launcher.go:officeMembersSnapshot` disk-fallback read

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -count=1 ./internal/team/` green (~80s)
- [x] `go test -count=1 ./...` green (29 packages, all PASS)
- [x] `./scripts/smoke-broker-restart.sh` PASS — `smoke-channel survived restart`
- [x] Pre-push hook (lefthook serial: smoke + go build + vhs) green
- [x] All A.1 characterization tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)