### PR TITLE
[codex] Add self-healing incident tasks

### DIFF
--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -101,8 +101,9 @@ type StreamFn func(msgs []Message, tools []AgentTool) <-chan StreamChunk
 type EscalationReason string
 
 const (
-	EscalationStuck      EscalationReason = "stuck"       // no phase change for too many ticks
-	EscalationMaxRetries EscalationReason = "max_retries" // PhaseError seen too many times for one task
+	EscalationStuck         EscalationReason = "stuck"          // no phase change for too many ticks
+	EscalationMaxRetries    EscalationReason = "max_retries"    // PhaseError seen too many times for one task
+	EscalationCapabilityGap EscalationReason = "capability_gap" // agent identified missing capability needed to proceed
 )
 
 // Escalator is a callback invoked when an agent can't make forward progress.

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -4072,7 +4072,7 @@ func (b *Broker) canAccessChannelLocked(slug, channel string) bool {
 		}
 		return slug == b.oneOnOneAgent
 	}
-	if slug == "" || slug == "you" || slug == "human" || slug == "nex" {
+	if slug == "" || slug == "you" || slug == "human" || slug == "nex" || slug == "system" {
 		return true
 	}
 	if slug == "ceo" {
@@ -8644,6 +8644,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		}
 		task := &b.tasks[i]
 		taskChannel := normalizeChannelSlug(task.Channel)
+		appendDetails := false
 		reassignPrevOwner := ""
 		reassignTriggered := false
 		cancelTriggered := false
@@ -8711,6 +8712,18 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			}
 			task.Status = "blocked"
 			task.Blocked = true
+		case "resume":
+			if task.Blocked {
+				task.Blocked = false
+			}
+			if strings.EqualFold(strings.TrimSpace(task.Status), "blocked") {
+				if strings.TrimSpace(task.Owner) != "" {
+					task.Status = "in_progress"
+				} else {
+					task.Status = "open"
+				}
+			}
+			appendDetails = true
 		case "release":
 			task.Owner = ""
 			task.Status = "open"
@@ -8728,7 +8741,14 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if strings.TrimSpace(body.Details) != "" {
-			task.Details = strings.TrimSpace(body.Details)
+			if appendDetails {
+				if err := appendTaskDetailLocked(task, body.Details); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+			} else {
+				task.Details = strings.TrimSpace(body.Details)
+			}
 		}
 		if taskType := strings.TrimSpace(body.TaskType); taskType != "" {
 			task.TaskType = taskType
@@ -8770,6 +8790,9 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		b.appendActionLocked("task_updated", "office", taskChannel, strings.TrimSpace(body.CreatedBy), truncateSummary(task.Title+" ["+task.Status+"]", 140), task.ID)
+		if action == "block" {
+			b.requestCapabilitySelfHealingLocked(task, strings.TrimSpace(body.CreatedBy), body.Details)
+		}
 		if reassignTriggered {
 			b.postTaskReassignNotificationsLocked(strings.TrimSpace(body.CreatedBy), task, reassignPrevOwner)
 		}
@@ -9008,6 +9031,7 @@ func (b *Broker) BlockTask(taskID, actor, reason string) (teamTask, bool, error)
 			return teamTask{}, false, err
 		}
 		b.appendActionLocked("task_updated", "office", normalizeChannelSlug(task.Channel), actor, truncateSummary(task.Title+" ["+task.Status+"]", 140), task.ID)
+		b.requestCapabilitySelfHealingLocked(task, actor, reason)
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, false, err
 		}
@@ -9581,6 +9605,61 @@ func (b *Broker) EnsurePlannedTask(input plannedTaskInput) (teamTask, bool, erro
 		return teamTask{}, false, err
 	}
 	return task, false, nil
+}
+
+// AppendTaskDetail appends non-duplicate detail text to an existing task without
+// changing ownership or status.
+func (b *Broker) AppendTaskDetail(taskID, actor, detail string) (teamTask, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	id := strings.TrimSpace(taskID)
+	if id == "" {
+		return teamTask{}, fmt.Errorf("task id required")
+	}
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return teamTask{}, fmt.Errorf("detail required")
+	}
+	actor = strings.TrimSpace(actor)
+	if actor == "" {
+		actor = "system"
+	}
+
+	for i := range b.tasks {
+		task := &b.tasks[i]
+		if task.ID != id {
+			continue
+		}
+		_ = appendTaskDetailLocked(task, detail)
+		task.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		b.appendActionLocked("task_updated", "office", normalizeChannelSlug(task.Channel), actor, truncateSummary(task.Title+" [updated]", 140), task.ID)
+		if err := b.saveLocked(); err != nil {
+			return teamTask{}, err
+		}
+		return *task, nil
+	}
+
+	return teamTask{}, fmt.Errorf("task not found")
+}
+
+func appendTaskDetailLocked(task *teamTask, detail string) error {
+	if task == nil {
+		return fmt.Errorf("task required")
+	}
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return fmt.Errorf("detail required")
+	}
+	if strings.Contains(task.Details, detail) {
+		return nil
+	}
+	task.Details = strings.TrimSpace(task.Details)
+	if task.Details != "" {
+		task.Details += "\n\n"
+	}
+	task.Details += detail
+	return nil
 }
 
 // hasUnresolvedDepsLocked returns true if any of the task's dependencies are not done.

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -3629,6 +3629,179 @@ func TestBrokerHandlePostTaskRejectsFalseReadOnlyBlockForWritableWorktree(t *tes
 	}
 }
 
+func TestBrokerHandlePostTaskCapabilityGapCreatesSelfHealingTask(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "eng", "Engineer")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
+		Channel:       "general",
+		Title:         "Post client launch update to Slack",
+		Owner:         "eng",
+		CreatedBy:     "ceo",
+		TaskType:      "follow_up",
+		ExecutionMode: "office",
+	})
+	if err != nil || reused {
+		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
+	}
+
+	detail := "Unable to continue: missing Slack integration tool path for posting the client update."
+	body, _ := json.Marshal(map[string]any{
+		"action":     "block",
+		"channel":    "general",
+		"id":         task.ID,
+		"created_by": "eng",
+		"details":    detail,
+	})
+	req, _ := http.NewRequest(http.MethodPost, "http://"+b.Addr()+"/tasks", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post block task: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 blocking task, got %d: %s", resp.StatusCode, raw)
+	}
+
+	var blocked teamTask
+	var healing teamTask
+	for _, candidate := range b.AllTasks() {
+		switch candidate.ID {
+		case task.ID:
+			blocked = candidate
+		default:
+			if candidate.Title == "Self-heal @eng on "+task.ID {
+				healing = candidate
+			}
+		}
+	}
+	if !blocked.Blocked || blocked.Status != "blocked" {
+		t.Fatalf("expected original task blocked, got %+v", blocked)
+	}
+	if healing.ID == "" {
+		t.Fatalf("expected capability-gap self-healing task, got %+v", b.AllTasks())
+	}
+	if healing.Owner != "ceo" || healing.TaskType != "incident" || healing.ExecutionMode != "office" {
+		t.Fatalf("expected office incident owned by ceo, got %+v", healing)
+	}
+	if !strings.Contains(healing.Details, "capability_gap") ||
+		!strings.Contains(healing.Details, detail) ||
+		!strings.Contains(healing.Details, "Repair the missing capability first") {
+		t.Fatalf("expected capability repair loop details, got %q", healing.Details)
+	}
+}
+
+func TestBrokerHandlePostTaskNonCapabilityBlockDoesNotCreateSelfHealingTask(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "eng", "Engineer")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	task, _, err := b.EnsurePlannedTask(plannedTaskInput{
+		Channel:   "general",
+		Title:     "Wait for customer approval",
+		Owner:     "eng",
+		CreatedBy: "ceo",
+		TaskType:  "follow_up",
+	})
+	if err != nil {
+		t.Fatalf("ensure planned task: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"action":     "block",
+		"channel":    "general",
+		"id":         task.ID,
+		"created_by": "eng",
+		"details":    "Waiting on customer approval before sending the update.",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "http://"+b.Addr()+"/tasks", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post block task: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 blocking task, got %d: %s", resp.StatusCode, raw)
+	}
+
+	for _, candidate := range b.AllTasks() {
+		if isSelfHealingTaskTitle(candidate.Title) {
+			t.Fatalf("did not expect self-healing task for non-capability blocker, got %+v", candidate)
+		}
+	}
+}
+
+func TestBrokerHandlePostTaskResumeUnblocksAfterCapabilityRepair(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "eng", "Engineer")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	task, _, err := b.EnsurePlannedTask(plannedTaskInput{
+		Channel:   "general",
+		Title:     "Send the launch update",
+		Owner:     "eng",
+		CreatedBy: "ceo",
+		TaskType:  "follow_up",
+	})
+	if err != nil {
+		t.Fatalf("ensure planned task: %v", err)
+	}
+	if _, changed, err := b.BlockTask(task.ID, "eng", "Unable to continue: missing Slack integration."); err != nil || !changed {
+		t.Fatalf("block task: changed=%v err=%v", changed, err)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"action":     "resume",
+		"channel":    "general",
+		"id":         task.ID,
+		"created_by": "ceo",
+		"details":    "Capability repaired: Slack integration is available; retry the original update.",
+	})
+	req, _ := http.NewRequest(http.MethodPost, "http://"+b.Addr()+"/tasks", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post resume task: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 resuming task, got %d: %s", resp.StatusCode, raw)
+	}
+
+	var resumed teamTask
+	for _, candidate := range b.AllTasks() {
+		if candidate.ID == task.ID {
+			resumed = candidate
+			break
+		}
+	}
+	if resumed.Blocked || resumed.Status != "in_progress" {
+		t.Fatalf("expected original task resumed after repair, got %+v", resumed)
+	}
+	if !strings.Contains(resumed.Details, "missing Slack integration") ||
+		!strings.Contains(resumed.Details, "Capability repaired") {
+		t.Fatalf("expected resume detail appended, got %q", resumed.Details)
+	}
+}
+
 func TestBrokerBlockTaskRejectsFalseReadOnlyBlockForWritableWorktree(t *testing.T) {
 	oldPrepare := prepareTaskWorktree
 	oldCleanup := cleanupTaskWorktree

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/gitexec"
 	"github.com/nex-crm/wuphf/internal/provider"
@@ -908,6 +909,7 @@ func (l *Launcher) recoverTimedOutHeadlessTurn(slug string, turn headlessCodexTu
 		return
 	} else if changed {
 		appendHeadlessCodexLog(slug, fmt.Sprintf("timeout-recovery: blocked %s after empty timeout", task.ID))
+		_, _, _ = l.requestSelfHealing(slug, task.ID, agent.EscalationStuck, reason)
 	}
 }
 
@@ -954,6 +956,7 @@ func (l *Launcher) recoverFailedHeadlessTurn(slug string, turn headlessCodexTurn
 		return
 	} else if changed {
 		appendHeadlessCodexLog(slug, fmt.Sprintf("error-recovery: blocked %s after failed turn", task.ID))
+		_, _, _ = l.requestSelfHealing(slug, task.ID, agent.EscalationMaxRetries, reason)
 	}
 }
 

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -1520,6 +1520,16 @@ func TestRecoverTimedOutHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted(t *te
 	if updated.Status != "blocked" || !updated.Blocked {
 		t.Fatalf("expected task to be blocked after retry budget exhausted, got %+v", updated)
 	}
+	var healTask teamTask
+	for _, candidate := range b.AllTasks() {
+		if candidate.Title == "Self-heal @eng on "+task.ID {
+			healTask = candidate
+			break
+		}
+	}
+	if healTask.ID == "" {
+		t.Fatalf("expected self-healing task after timeout recovery, got %+v", b.AllTasks())
+	}
 }
 
 func TestRecoverFailedHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted(t *testing.T) {
@@ -1563,6 +1573,16 @@ func TestRecoverFailedHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted(t *test
 	}
 	if !strings.Contains(updated.Details, "Selected model is at capacity") {
 		t.Fatalf("expected failure detail appended, got %+v", updated)
+	}
+	var healTask teamTask
+	for _, candidate := range b.AllTasks() {
+		if candidate.Title == "Self-heal @eng on "+task.ID {
+			healTask = candidate
+			break
+		}
+	}
+	if healTask.ID == "" {
+		t.Fatalf("expected self-healing task after error recovery, got %+v", b.AllTasks())
 	}
 }
 

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -3900,7 +3900,7 @@ func (l *Launcher) buildPrompt(slug string) string {
 		sb.WriteString("- team_broadcast: Post to channel. CRITICAL: text @-mentions alone do NOT wake agents — include the slug in the `tagged` parameter.\n")
 		sb.WriteString("- team_poll: LAST RESORT — read recent messages only when pushed context is genuinely missing something you need. Do NOT call this by default; the pushed notification already contains thread context and task state.\n")
 		sb.WriteString("- team_bridge: CEO-only bridge for cross-channel context. Ask the CEO to use it.\n")
-		sb.WriteString("- team_task: Claim, complete, block, or release tasks in your domain.\n")
+		sb.WriteString("- team_task: Claim, complete, block, resume, or release tasks in your domain.\n")
 		sb.WriteString("- team_skill_run: When @ceo tells you to run a skill, or when the request clearly matches one, call team_skill_run(skill_name) BEFORE doing the work. It returns the canonical step-by-step content — follow it exactly instead of freelancing. Failing to invoke the skill leaves the office with no trace that the playbook was actually used.\n")
 		sb.WriteString("- team_skill_create: Propose a reusable skill yourself with action=propose when you spot a repeatable workflow. You do not need to ask @ceo to propose it for you. Only @ceo may use action=create.\n")
 		sb.WriteString("- team_action_connections / team_action_search / team_action_knowledge: inspect connected external systems and the exact action/workflow schema before you improvise. If connection listing is flaky, do NOT stop there; search/knowledge still give you the real action contract.\n")
@@ -4847,4 +4847,5 @@ func (l *Launcher) postEscalation(slug, taskID string, reason agent.EscalationRe
 		body = fmt.Sprintf("Heads up: %s escalation on %s: %s", who, taskID, detail)
 	}
 	l.broker.PostSystemMessage("general", body, "escalation")
+	_, _, _ = l.requestSelfHealing(slug, taskID, reason, detail)
 }

--- a/internal/team/launcher_escalation_test.go
+++ b/internal/team/launcher_escalation_test.go
@@ -37,6 +37,80 @@ func TestPostEscalation_MaxRetries_WritesToGeneralChannel(t *testing.T) {
 	t.Fatalf("expected max-retries escalation message in #general, found none; got %d messages", len(msgs))
 }
 
+func TestPostEscalation_CreatesSelfHealingTask(t *testing.T) {
+	b := newTestBroker(t)
+	l := &Launcher{broker: b}
+
+	l.postEscalation("eng", "eng-42", agent.EscalationStuck, "stuck in build_context for 20 ticks")
+
+	var found teamTask
+	for _, task := range b.AllTasks() {
+		if task.Title == "Self-heal @eng on eng-42" {
+			found = task
+			break
+		}
+	}
+	if found.ID == "" {
+		t.Fatalf("expected self-healing task, got %+v", b.AllTasks())
+	}
+	if found.Owner != "ceo" {
+		t.Fatalf("expected self-healing task owned by ceo, got %+v", found)
+	}
+	if found.TaskType != "incident" || found.PipelineID != "incident" || found.ExecutionMode != "office" {
+		t.Fatalf("expected incident office task, got %+v", found)
+	}
+	if !strings.Contains(found.Details, "Classify the blocker") || !strings.Contains(found.Details, "missing or outdated skill/playbook") {
+		t.Fatalf("expected repair-loop details, got %q", found.Details)
+	}
+}
+
+func TestPostEscalation_ReusesSelfHealingTask(t *testing.T) {
+	b := newTestBroker(t)
+	l := &Launcher{broker: b}
+
+	l.postEscalation("eng", "eng-42", agent.EscalationStuck, "first stuck event")
+	l.postEscalation("eng", "eng-42", agent.EscalationMaxRetries, "second stuck event")
+
+	var count int
+	var found teamTask
+	for _, task := range b.AllTasks() {
+		if task.Title == "Self-heal @eng on eng-42" {
+			count++
+			found = task
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected one reusable self-healing task, got %d tasks: %+v", count, b.AllTasks())
+	}
+	if !strings.Contains(found.Details, "first stuck event") || !strings.Contains(found.Details, "second stuck event") {
+		t.Fatalf("expected reused self-healing task to retain both incident details, got %q", found.Details)
+	}
+	if got := strings.Count(found.Details, "Latest incident:"); got != 1 {
+		t.Fatalf("expected one appended latest incident block, got %d in %q", got, found.Details)
+	}
+}
+
+func TestPostEscalation_DoesNotNestSelfHealingTasks(t *testing.T) {
+	b := newTestBroker(t)
+	l := &Launcher{broker: b}
+
+	task, _, err := l.requestSelfHealing("eng", "eng-42", agent.EscalationStuck, "initial incident")
+	if err != nil {
+		t.Fatalf("request self-healing: %v", err)
+	}
+	l.postEscalation("ceo", task.ID, agent.EscalationStuck, "self-healing lane stuck")
+
+	var count int
+	for _, candidate := range b.AllTasks() {
+		if isSelfHealingTaskTitle(candidate.Title) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected no nested self-healing task, got %d tasks: %+v", count, b.AllTasks())
+	}
+}
+
 func TestPostEscalation_NilBroker_DoesNotPanic(t *testing.T) {
 	l := &Launcher{broker: nil}
 	// Should be a no-op, not a panic.

--- a/internal/team/self_healing.go
+++ b/internal/team/self_healing.go
@@ -1,0 +1,286 @@
+package team
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+)
+
+const selfHealingTaskTitlePrefix = "Self-heal "
+
+func (l *Launcher) requestSelfHealing(agentSlug, taskID string, reason agent.EscalationReason, detail string) (teamTask, bool, error) {
+	if l == nil || l.broker == nil {
+		return teamTask{}, false, nil
+	}
+	return l.broker.RequestSelfHealing(agentSlug, taskID, reason, detail)
+}
+
+func (b *Broker) RequestSelfHealing(agentSlug, taskID string, reason agent.EscalationReason, detail string) (teamTask, bool, error) {
+	if b == nil {
+		return teamTask{}, false, nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.requestSelfHealingLocked(agentSlug, taskID, reason, detail)
+}
+
+func (b *Broker) requestSelfHealingLocked(agentSlug, taskID string, reason agent.EscalationReason, detail string) (teamTask, bool, error) {
+	agentSlug = strings.TrimSpace(agentSlug)
+	taskID = strings.TrimSpace(taskID)
+	if b.isSelfHealingTaskIDLocked(taskID) {
+		return teamTask{}, true, nil
+	}
+
+	owner := strings.TrimSpace(officeLeadSlugFrom(b.members))
+	if owner == "" {
+		owner = agentSlug
+	}
+	title := selfHealingTaskTitle(agentSlug, taskID)
+	details := selfHealingTaskDetails(agentSlug, taskID, reason, detail)
+	createdBy := selfHealingCreatedByForMode(b.sessionMode)
+	channel := b.preferredTaskChannelLocked("general", createdBy, owner, title, details)
+	if b.findChannelLocked(channel) == nil {
+		return teamTask{}, false, fmt.Errorf("channel not found")
+	}
+	if !b.canAccessChannelLocked(createdBy, channel) {
+		return teamTask{}, false, fmt.Errorf("channel access denied")
+	}
+
+	if existing := b.findReusableTaskLocked(taskReuseMatch{
+		Channel:    channel,
+		Title:      title,
+		Owner:      owner,
+		PipelineID: "incident",
+	}); existing != nil {
+		if existing.Details == "" {
+			existing.Details = details
+		} else if err := appendTaskDetailLocked(existing, selfHealingIncidentUpdate(reason, detail)); err != nil {
+			return teamTask{}, true, err
+		}
+		if existing.Owner == "" && owner != "" {
+			existing.Owner = owner
+			existing.Status = "in_progress"
+		}
+		if existing.TaskType == "" {
+			existing.TaskType = "incident"
+		}
+		if existing.PipelineID == "" {
+			existing.PipelineID = "incident"
+		}
+		if existing.ExecutionMode == "" {
+			existing.ExecutionMode = "office"
+		}
+		b.ensureTaskOwnerChannelMembershipLocked(channel, existing.Owner)
+		existing.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		b.queueTaskBehindActiveOwnerLaneLocked(existing)
+		if err := rejectTheaterTaskForLiveBusiness(existing); err != nil {
+			return teamTask{}, true, err
+		}
+		b.scheduleTaskLifecycleLocked(existing)
+		if err := b.syncTaskWorktreeLocked(existing); err != nil {
+			return teamTask{}, true, err
+		}
+		b.appendActionLocked("task_updated", "office", channel, createdBy, truncateSummary(existing.Title+" [updated]", 140), existing.ID)
+		if err := b.saveLocked(); err != nil {
+			return teamTask{}, true, err
+		}
+		return *existing, true, nil
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.counter++
+	task := teamTask{
+		ID:            fmt.Sprintf("task-%d", b.counter),
+		Channel:       channel,
+		Title:         title,
+		Details:       details,
+		Owner:         owner,
+		Status:        "open",
+		CreatedBy:     createdBy,
+		TaskType:      "incident",
+		PipelineID:    "incident",
+		ExecutionMode: "office",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	if task.Owner != "" {
+		task.Status = "in_progress"
+	}
+	b.ensureTaskOwnerChannelMembershipLocked(channel, task.Owner)
+	b.queueTaskBehindActiveOwnerLaneLocked(&task)
+	if err := rejectTheaterTaskForLiveBusiness(&task); err != nil {
+		return teamTask{}, false, err
+	}
+	b.scheduleTaskLifecycleLocked(&task)
+	if err := b.syncTaskWorktreeLocked(&task); err != nil {
+		return teamTask{}, false, err
+	}
+	b.tasks = append(b.tasks, task)
+	b.appendActionLocked("task_created", "office", channel, createdBy, truncateSummary(task.Title, 140), task.ID)
+	if err := b.saveLocked(); err != nil {
+		return teamTask{}, false, err
+	}
+	return task, false, nil
+}
+
+func (b *Broker) requestCapabilitySelfHealingLocked(blockedTask *teamTask, actor, detail string) {
+	if blockedTask == nil || !isCapabilityGapBlocker(detail) || isSelfHealingTaskTitle(blockedTask.Title) {
+		return
+	}
+	agentSlug := strings.TrimSpace(actor)
+	if agentSlug == "" || agentSlug == "system" {
+		agentSlug = strings.TrimSpace(blockedTask.Owner)
+	}
+	if agentSlug == "" {
+		agentSlug = "agent"
+	}
+	if _, _, err := b.requestSelfHealingLocked(agentSlug, blockedTask.ID, agent.EscalationCapabilityGap, detail); err != nil {
+		log.Printf("self-healing: create capability repair task for agent=%s task=%s: %v", agentSlug, blockedTask.ID, err)
+	}
+}
+
+func isCapabilityGapBlocker(detail string) bool {
+	text := strings.ToLower(strings.TrimSpace(detail))
+	if text == "" {
+		return false
+	}
+	if strings.Contains(text, "capability gap") || strings.Contains(text, "missing capability") {
+		return true
+	}
+	capabilityTerms := []string{
+		"specialist", "channel", "skill", "playbook", "tool", "provider", "integration",
+		"workflow", "action", "api", "connection", "connector", "credential", "credentials",
+		"permission", "access", "account", "runtime", "session",
+	}
+	positiveSignals := []string{
+		"missing", "no ", "not connected", "not configured", "not available", "unavailable",
+		"unsupported", "can't", "cannot", "unable", "need", "needs", "requires", "require",
+	}
+	for _, term := range capabilityTerms {
+		if !strings.Contains(text, term) {
+			continue
+		}
+		for _, signal := range positiveSignals {
+			if strings.Contains(text, signal) {
+				return true
+			}
+		}
+		if strings.Contains(text, "tool path") || strings.Contains(text, "provider gap") || strings.Contains(text, "integration path") {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *Launcher) selfHealingCreatedBy() string {
+	if l == nil {
+		return "system"
+	}
+	return selfHealingCreatedByForMode(l.sessionMode)
+}
+
+func selfHealingCreatedByForMode(mode string) string {
+	if NormalizeSessionMode(mode) == SessionModeOneOnOne {
+		return "you"
+	}
+	return "system"
+}
+
+func (l *Launcher) isSelfHealingTaskID(taskID string) bool {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" || l == nil || l.broker == nil {
+		return false
+	}
+	return l.broker.isSelfHealingTaskID(taskID)
+}
+
+func (b *Broker) isSelfHealingTaskID(taskID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.isSelfHealingTaskIDLocked(taskID)
+}
+
+func (b *Broker) isSelfHealingTaskIDLocked(taskID string) bool {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" || b == nil {
+		return false
+	}
+	for _, task := range b.tasks {
+		if strings.TrimSpace(task.ID) != taskID {
+			continue
+		}
+		return isSelfHealingTaskTitle(task.Title)
+	}
+	return false
+}
+
+func isSelfHealingTaskTitle(title string) bool {
+	return strings.HasPrefix(strings.TrimSpace(title), selfHealingTaskTitlePrefix)
+}
+
+func selfHealingTaskTitle(agentSlug, taskID string) string {
+	who := strings.TrimSpace(agentSlug)
+	if who == "" {
+		who = "agent"
+	}
+	if taskID = strings.TrimSpace(taskID); taskID != "" {
+		return fmt.Sprintf("%s@%s on %s", selfHealingTaskTitlePrefix, who, taskID)
+	}
+	return fmt.Sprintf("%s@%s runtime failure", selfHealingTaskTitlePrefix, who)
+}
+
+func selfHealingTaskDetails(agentSlug, taskID string, reason agent.EscalationReason, detail string) string {
+	who := strings.TrimSpace(agentSlug)
+	if who == "" {
+		who = "unknown"
+	}
+	originalTask := strings.TrimSpace(taskID)
+	if originalTask == "" {
+		originalTask = "unknown"
+	}
+	trigger := strings.TrimSpace(string(reason))
+	if trigger == "" {
+		trigger = "unknown"
+	}
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		detail = "no detail provided"
+	}
+
+	return strings.Join([]string{
+		"Automatic self-healing incident.",
+		"",
+		fmt.Sprintf("- Agent: @%s", who),
+		fmt.Sprintf("- Original task: %s", originalTask),
+		fmt.Sprintf("- Trigger: %s", trigger),
+		fmt.Sprintf("- Detail: %s", detail),
+		"",
+		"Repair loop:",
+		"1. Inspect the failed task and recent thread context. Use the pushed packet as authoritative; call team_poll or team_tasks only if context is missing.",
+		"2. Classify the blocker: missing specialist/channel, missing or outdated skill/playbook, missing tool/provider/integration, stale runtime/session, unclear human decision, or implementation bug.",
+		"3. Take the smallest reversible repair in office state. Prefer a bounded refresh/retry/requeue, reassignment, capability-check step, specialist/channel creation, skill proposal, playbook update, or exact human question before broad process changes.",
+		"4. If runtime/tool state looks stale, refresh or reconnect once and verify with a cheap health check before treating it as a human blocker.",
+		"5. Repair the missing capability first, then resume or requeue the original workflow with a concrete verification step. A self-heal that only reports the blocker is incomplete.",
+		"6. Treat learning as a post-repair review: propose a skill or update a wiki/playbook only when the workaround is durable and reusable. Include the trigger, failure signature, recovery step, verification signal, and any tool/provider/channel constraints. If nothing reusable was learned, leave skills unchanged.",
+		"7. Do not mark this self-healing task complete until the original task is unblocked, resumed/requeued with a clearer owner/cut line, or explicitly blocked behind a human decision.",
+	}, "\n")
+}
+
+func selfHealingIncidentUpdate(reason agent.EscalationReason, detail string) string {
+	trigger := strings.TrimSpace(string(reason))
+	if trigger == "" {
+		trigger = "unknown"
+	}
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		detail = "no detail provided"
+	}
+	return strings.Join([]string{
+		"Latest incident:",
+		fmt.Sprintf("- Trigger: %s", trigger),
+		fmt.Sprintf("- Detail: %s", detail),
+	}, "\n")
+}

--- a/internal/team/telegram_test.go
+++ b/internal/team/telegram_test.go
@@ -14,8 +14,8 @@ import (
 
 func newTestBrokerWithTelegramChannel(t *testing.T, chatID string) *Broker {
 	t.Helper()
-	tmpDir := t.TempDir()
-	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
+	statePath := leakedBrokerStatePath(t)
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	b := NewBroker()
 	b.mu.Lock()

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -297,7 +297,7 @@ type TeamRuntimeStateArgs struct {
 }
 
 type TeamTaskArgs struct {
-	Action        string   `json:"action" jsonschema:"One of: create, claim, assign, complete, block, release"`
+	Action        string   `json:"action" jsonschema:"One of: create, claim, assign, complete, block, resume, release"`
 	Channel       string   `json:"channel,omitempty" jsonschema:"Channel slug. Defaults to the agent's current channel or general."`
 	ID            string   `json:"id,omitempty" jsonschema:"Task ID for non-create actions"`
 	Title         string   `json:"title,omitempty" jsonschema:"Task title when creating a task"`
@@ -728,7 +728,7 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 
 	mcp.AddTool(server, officeWriteTool(
 		"team_task",
-		"Create, claim, assign, complete, block, or release a shared task in the office task list.",
+		"Create, claim, assign, complete, block, resume, or release a shared task in the office task list.",
 	), handleTeamTask)
 
 	registerSharedMemoryTools(server)


### PR DESCRIPTION
## Summary

Adds self-healing for both runtime failures and real capability gaps.

- creates or reuses a `Self-heal @agent on task` incident when an agent escalates, exhausts timeout/error recovery, or blocks a task because a required capability is missing
- detects capability-gap blockers from the actual task-block workflow (`team_task action=block` / broker `/tasks`) such as missing tools, integrations, skills, channels, providers, credentials, or access
- adds `team_task action=resume` so the repair lane can unblock and retry the original workflow after the missing capability is fixed
- records repeated failure signatures on the existing incident task instead of dropping later context
- prevents nested self-healing tasks and keeps repairs routed through office task state

## Why

The goal is not just recovering from errors. The system needs to notice “I cannot do this because a capability is missing,” make that missing capability the next real work item, repair it, and then resume the original workflow. The deeper Hermes and Browser Harness review pointed to a bounded approach: recover locally when possible, preserve failure context, and only turn a repair into durable procedure after the workaround proves reusable.

## Real Scenario Tested

Ran the capability-gap workflow through a live broker HTTP server, not a mocked function call:

1. Created a real office task: “Post client launch update to Slack.”
2. Simulated the owning agent blocking it with: “Unable to continue: missing Slack integration tool path...”
3. Verified the original task became `blocked`.
4. Verified the system created `Self-heal @eng on <task>` with trigger `capability_gap`.
5. Simulated the repair lane resuming the original task after the Slack capability became available.
6. Verified the original task returned to `in_progress` and retained both the original blocker and repair note.

## Validation

- `go test ./internal/team -run 'TestBrokerHandlePostTaskCapabilityGapCreatesSelfHealingTask|TestBrokerHandlePostTaskResumeUnblocksAfterCapabilityRepair' -count=1 -v`
- `go test ./internal/team -run 'TestBrokerHandlePostTaskCapabilityGapCreatesSelfHealingTask|TestBrokerHandlePostTaskNonCapabilityBlockDoesNotCreateSelfHealingTask|TestBrokerHandlePostTaskResumeUnblocksAfterCapabilityRepair|TestPostEscalation|TestRecoverTimedOutHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted|TestRecoverFailedHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted' -count=1`
- `go test ./internal/team -count=1`
- `go test ./internal/teammcp -count=1`
- Applied the exact staged follow-up diff to a clean temporary worktree and ran `go test ./internal/team ./internal/teammcp -count=1`
- `git diff --cached --check`