### PR TITLE
fix(team): race-safe brokerStatePath + headlessCodexRunTurn test overrides

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	wuphf "github.com/nex-crm/wuphf"
@@ -58,7 +59,27 @@ const defaultAgentRateLimitWindow = time.Minute
 // the value set by internal/teammcp/server.go authHeaders().
 const agentRateLimitHeader = "X-WUPHF-Agent"
 
-var brokerStatePath = defaultBrokerStatePath
+// brokerStatePathOverride lets tests redirect the state path to a temp dir
+// without racing with production goroutines (the headless-codex queue worker
+// spawned by resumeInFlightWork can outlive a test's deferred cleanup).
+//
+// Production reads via brokerStatePath() — a function, not a var — go through
+// the atomic. Tests must call setBrokerStatePathForTest(t, fn) instead of
+// mutating a package-level variable directly.
+var brokerStatePathOverride atomic.Pointer[func() string]
+
+// brokerStatePath returns the current state-file path. Defaults to
+// defaultBrokerStatePath; tests can override via setBrokerStatePathForTest.
+//
+// Race safety: read goes through atomic.Pointer.Load so it can interleave
+// safely with a test's override + cleanup, even if a queue worker spawned
+// before cleanup observes the swap mid-test.
+func brokerStatePath() string {
+	if p := brokerStatePathOverride.Load(); p != nil {
+		return (*p)()
+	}
+	return defaultBrokerStatePath()
+}
 
 // studioPackageGenerator routes Studio package generation through the
 // install-wide LLM provider so opencode-only or claude-code-only setups

--- a/internal/team/broker_actions_test.go
+++ b/internal/team/broker_actions_test.go
@@ -10,9 +10,7 @@ import (
 
 func TestHandleActionsPostRecordsAction(t *testing.T) {
 	tmpDir := t.TempDir()
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -50,9 +48,7 @@ func TestHandleActionsPostRecordsAction(t *testing.T) {
 
 func TestHandleSchedulerPostRecordsWorkflowJob(t *testing.T) {
 	tmpDir := t.TempDir()
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {

--- a/internal/team/broker_agent_logs_test.go
+++ b/internal/team/broker_agent_logs_test.go
@@ -14,10 +14,8 @@ import (
 // It follows the same pattern used throughout broker_test.go.
 func newTestBroker(t *testing.T) *Broker {
 	t.Helper()
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 	return NewBroker()
 }
 

--- a/internal/team/broker_commands_test.go
+++ b/internal/team/broker_commands_test.go
@@ -15,10 +15,8 @@ import (
 // authenticate their requests.
 func newCommandsHTTPTest(t *testing.T) (*httptest.Server, string) {
 	t.Helper()
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	mux := http.NewServeMux()

--- a/internal/team/broker_onboarding_test.go
+++ b/internal/team/broker_onboarding_test.go
@@ -50,10 +50,11 @@ func ensureOperationsFallbackFS(t *testing.T) {
 // and a clean broker state on disk, then cleans up when done.
 func withIsolatedBrokerState(t *testing.T) func() {
 	t.Helper()
-	old := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	return func() { brokerStatePath = old }
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
+	// setBrokerStatePathForTest registers t.Cleanup; the returned no-op
+	// preserves the legacy "call this when done" call-site shape.
+	return func() {}
 }
 
 // TestOnboardingCompleteSeedsFromPickedBlueprint verifies that when the

--- a/internal/team/broker_providers_test.go
+++ b/internal/team/broker_providers_test.go
@@ -129,10 +129,8 @@ func TestHandleOfficeMembers_InvalidProviderKind(t *testing.T) {
 }
 
 func TestProviderFieldSurvivesBrokerReload(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -203,10 +201,8 @@ func TestRebuildMemberIndex_AfterRemove(t *testing.T) {
 // httptest server, returning the broker, the server, and the auth token.
 func newBrokerHTTPTest(t *testing.T) (*Broker, *httptest.Server, string) {
 	t.Helper()
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	// Attach a fake bridge so handleOfficeMembers can exercise openclaw

--- a/internal/team/broker_restart_integration_test.go
+++ b/internal/team/broker_restart_integration_test.go
@@ -27,9 +27,7 @@ import (
 
 func TestBrokerStatePersistsAcrossReload_ChannelAndMember(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "broker-state.json")
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {

--- a/internal/team/broker_save_race_test.go
+++ b/internal/team/broker_save_race_test.go
@@ -32,9 +32,7 @@ func TestSaveLocked_ConcurrentBrokersSamePathDoNotRace(t *testing.T) {
 	// Pin brokerStatePath to a per-test tempdir so all N goroutines target
 	// the same path (the production failure mode).
 	statePath := filepath.Join(t.TempDir(), "broker-state.json")
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	const goroutines = 32
 

--- a/internal/team/broker_state_path_test.go
+++ b/internal/team/broker_state_path_test.go
@@ -82,10 +82,8 @@ func TestBrokerStateSnapshotPathIsLastGoodSibling(t *testing.T) {
 	// relies on this exact shape. Post-refactor, if snapshot
 	// derivation drifts to a different directory or format, recovery
 	// silently breaks.
-	oldPathFn := brokerStatePath
 	statePath := filepath.Join(t.TempDir(), "broker-state.json")
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	got := brokerStateSnapshotPath()
 	want := statePath + ".last-good"
@@ -109,9 +107,7 @@ func TestNewBroker_SkipStateLoadGateRespected(t *testing.T) {
 	// must preserve this contract: constructor argument or not, a
 	// test-mode NewBroker() must NOT auto-load.
 	statePath := leakedBrokerStatePath(t)
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	// Seed disk with a distinctive message. If the gate is broken,
 	// NewBroker() will pick it up.
@@ -164,9 +160,7 @@ func TestBrokerStop_NoWriteAfterReturn(t *testing.T) {
 	// reads a refactored `b.statePath` via a pointer captured at Start
 	// time and continues writing after b.stopCh closes).
 	statePath := leakedBrokerStatePath(t)
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	b := NewBroker()
 	b.mu.Lock()

--- a/internal/team/broker_studio_test.go
+++ b/internal/team/broker_studio_test.go
@@ -94,9 +94,7 @@ func TestHandleStudioGeneratePackagePersistsAction(t *testing.T) {
 	defer func() { studioPackageGenerator = restore }()
 
 	tmpDir := t.TempDir()
-	prevStatePath := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = prevStatePath }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	body := map[string]any{
@@ -166,9 +164,7 @@ func TestHandleStudioGeneratePackagePersistsAction(t *testing.T) {
 
 func TestHandleMemoryRoundTripScopedStudioRecords(t *testing.T) {
 	tmpDir := t.TempDir()
-	prevStatePath := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = prevStatePath }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 
@@ -231,9 +227,7 @@ func TestHandleStudioRunWorkflowExecutesOneDraftAndUpdatesSkill(t *testing.T) {
 	t.Setenv("WUPHF_ONE_BIN", writeFakeOperationOne(t))
 
 	tmpDir := t.TempDir()
-	prevStatePath := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = prevStatePath }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.skills = append(b.skills, teamSkill{
@@ -313,9 +307,7 @@ func TestHandleStudioRunWorkflowReturnsRateLimitMetadata(t *testing.T) {
 	t.Setenv("WUPHF_ONE_BIN", writeRateLimitedOperationOne(t))
 
 	tmpDir := t.TempDir()
-	prevStatePath := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = prevStatePath }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.skills = append(b.skills, teamSkill{

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -170,10 +170,8 @@ func TestFormatChannelViewIncludesThreadReference(t *testing.T) {
 }
 
 func TestBrokerPersistsAndReloadsState(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -202,10 +200,8 @@ func TestBrokerPersistsAndReloadsState(t *testing.T) {
 }
 
 func TestBrokerLoadsLastGoodSnapshotWhenPrimaryStateIsClobbered(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -267,10 +263,8 @@ func TestBrokerLoadsLastGoodSnapshotWhenPrimaryStateIsClobbered(t *testing.T) {
 }
 
 func TestBrokerSessionModePersistsAndSurvivesReset(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -312,10 +306,8 @@ func TestBrokerSessionModePersistsAndSurvivesReset(t *testing.T) {
 }
 
 func TestBrokerMessageSubscribersReceivePostedMessages(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	msgs, unsubscribe := b.SubscribeMessages(4)
@@ -337,10 +329,8 @@ func TestBrokerMessageSubscribersReceivePostedMessages(t *testing.T) {
 }
 
 func TestBrokerCanonicalizesLegacyDMSlugs(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -482,10 +472,8 @@ func TestRecordAgentUsageAttachesToCurrentTurnMessagesOnly(t *testing.T) {
 }
 
 func TestBrokerActionSubscribersReceiveTaskLifecycle(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	actions, unsubscribe := b.SubscribeActions(4)
@@ -506,10 +494,8 @@ func TestBrokerActionSubscribersReceiveTaskLifecycle(t *testing.T) {
 }
 
 func TestReapStaleActivityLocked(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	now := time.Now().UTC()
@@ -556,10 +542,8 @@ func TestReapStaleActivityLocked(t *testing.T) {
 }
 
 func TestBrokerStopIsIdempotent(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.Stop()
@@ -567,10 +551,8 @@ func TestBrokerStopIsIdempotent(t *testing.T) {
 }
 
 func TestBrokerActivitySubscribersReceiveUpdates(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	updates, unsubscribe := b.SubscribeActivity(4)
@@ -595,10 +577,8 @@ func TestBrokerActivitySubscribersReceiveUpdates(t *testing.T) {
 }
 
 func TestBrokerEventsEndpointStreamsMessages(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.channels = []teamChannel{
@@ -665,10 +645,8 @@ func TestBrokerEventsEndpointStreamsMessages(t *testing.T) {
 }
 
 func TestBrokerMessageKindAndTitleRoundTrip(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -727,10 +705,8 @@ func TestBrokerMessageKindAndTitleRoundTrip(t *testing.T) {
 }
 
 func TestBrokerMessagesCanScopeToThread(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -778,10 +754,8 @@ func TestBrokerMessagesCanScopeToThread(t *testing.T) {
 }
 
 func TestBrokerMessagesCanScopeToAgentInbox(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -856,10 +830,8 @@ func TestBrokerMessagesCanScopeToAgentInbox(t *testing.T) {
 
 func TestNewBrokerSeedsDefaultOfficeRosterOnFreshState(t *testing.T) {
 	t.Setenv("HOME", t.TempDir()) // isolate from ~/.wuphf company.json (e.g. RevOps pack)
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	members := b.OfficeMembers()
@@ -904,10 +876,8 @@ func TestNewBrokerSeedsBlueprintBackedOfficeRosterOnFreshState(t *testing.T) {
 		t.Fatalf("write manifest: %v", err)
 	}
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	members := b.OfficeMembers()
@@ -1007,10 +977,8 @@ func TestHandleMessagesSupportsInboxAndOutboxScopes(t *testing.T) {
 }
 
 func TestOfficeMemberLifecycle(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -1033,10 +1001,8 @@ func TestOfficeMemberLifecycle(t *testing.T) {
 }
 
 func TestBrokerPersistsNotificationCursorWithoutMessages(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.SetNotificationCursor("2026-03-24T10:00:00Z"); err != nil {
@@ -1050,10 +1016,8 @@ func TestBrokerPersistsNotificationCursorWithoutMessages(t *testing.T) {
 }
 
 func TestChannelMembersRejectUnknownOfficeMember(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1086,10 +1050,8 @@ func TestChannelMembersRejectUnknownOfficeMember(t *testing.T) {
 // slug was protected — blueprint teams whose lead is something else (e.g.
 // niche-crm uses "operator") could silently lose their lead from #general.
 func TestChannelMembersRejectDisableOrRemoveOfLead(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -1148,10 +1110,8 @@ func TestChannelMembersRejectDisableOrRemoveOfLead(t *testing.T) {
 }
 
 func TestBrokerAuthRejectsUnauthenticated(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.runtimeProvider = "codex"
@@ -1773,10 +1733,8 @@ func TestNormalizeChannelSlugStripsLeadingHash(t *testing.T) {
 }
 
 func TestChannelDescriptionsAreVisibleButContentStaysRestricted(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
@@ -1862,10 +1820,8 @@ func TestChannelDescriptionsAreVisibleButContentStaysRestricted(t *testing.T) {
 }
 
 func TestChannelUpdateMutatesDescriptionAndMembers(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1995,10 +1951,8 @@ func TestNormalizeLoadedStateRepopulatesGeneralFromOfficeRoster(t *testing.T) {
 }
 
 func TestTaskAndRequestViewsRejectNonMembers(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2091,10 +2045,8 @@ func TestParseOTLPUsageEvents(t *testing.T) {
 }
 
 func TestBrokerUsageEndpointAggregatesTelemetry(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2164,10 +2116,8 @@ func TestBrokerUsageEndpointAggregatesTelemetry(t *testing.T) {
 }
 
 func TestBrokerActionsAndSchedulerEndpoints(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -2204,10 +2154,8 @@ func TestBrokerActionsAndSchedulerEndpoints(t *testing.T) {
 }
 
 func TestSchedulerDueOnlyFiltersFutureJobs(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.SetSchedulerJob(schedulerJob{
@@ -2249,10 +2197,8 @@ func TestSchedulerDueOnlyFiltersFutureJobs(t *testing.T) {
 }
 
 func TestBrokerPostsAndDedupesNexNotifications(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2298,10 +2244,8 @@ func TestBrokerPostsAndDedupesNexNotifications(t *testing.T) {
 }
 
 func TestBrokerTaskLifecycle(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2396,10 +2340,8 @@ func TestBrokerTaskLifecycle(t *testing.T) {
 }
 
 func TestBrokerTaskReassignNotifies(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2516,10 +2458,8 @@ func TestBrokerTaskReassignNotifies(t *testing.T) {
 }
 
 func TestBrokerTaskCancelNotifies(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2630,10 +2570,8 @@ func containsAll(got, want []string) bool {
 }
 
 func TestBrokerOfficeFeatureTaskForGTMCompletesWithoutReviewAndUnblocksDependents(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2718,10 +2656,8 @@ func TestBrokerOfficeFeatureTaskForGTMCompletesWithoutReviewAndUnblocksDependent
 }
 
 func TestBrokerTaskCreateReusesExistingOpenTask(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2793,10 +2729,8 @@ func TestBrokerEnsurePlannedTaskKeepsScopedDuplicateTitlesDistinct(t *testing.T)
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 
@@ -2853,10 +2787,8 @@ func TestBrokerEnsurePlannedTaskKeepsScopedDuplicateTitlesDistinct(t *testing.T)
 }
 
 func TestBrokerTaskCreateKeepsDistinctTasksInSameThread(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2925,10 +2857,8 @@ func TestBrokerTaskPlanAssignsWorktreeForLocalWorktreeTask(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
@@ -2983,10 +2913,8 @@ func TestBrokerTaskPlanAssignsWorktreeForLocalWorktreeTask(t *testing.T) {
 }
 
 func TestBrokerTaskCreateAddsAssignedOwnerToChannelMembers(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "youtube-factory", "operator", "Operator")
@@ -3038,10 +2966,8 @@ func TestBrokerTaskCreateAddsAssignedOwnerToChannelMembers(t *testing.T) {
 }
 
 func TestBrokerResumeTaskUnblocksAndSchedulesOwnerLane(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")
@@ -3078,10 +3004,8 @@ func TestBrokerResumeTaskUnblocksAndSchedulesOwnerLane(t *testing.T) {
 }
 
 func TestBrokerResumeTaskQueuesBehindExistingExclusiveOwnerLane(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "client-loop", "operator", "Operator")
@@ -3133,10 +3057,8 @@ func TestBrokerResumeTaskQueuesBehindExistingExclusiveOwnerLane(t *testing.T) {
 }
 
 func TestBrokerUnblockDependentsQueuesExclusiveOwnerLanes(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "youtube-factory", "ceo", "CEO")
@@ -3220,10 +3142,8 @@ func TestBrokerUnblockDependentsQueuesExclusiveOwnerLanes(t *testing.T) {
 }
 
 func TestBrokerTaskPlanRejectsTheaterTaskInLiveDeliveryLane(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "client-delivery", "operator", "Operator")
@@ -3262,10 +3182,8 @@ func TestBrokerTaskPlanRejectsTheaterTaskInLiveDeliveryLane(t *testing.T) {
 }
 
 func TestBrokerTaskCreateRejectsLiveBusinessTheater(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
@@ -3301,10 +3219,8 @@ func TestBrokerTaskCreateRejectsLiveBusinessTheater(t *testing.T) {
 }
 
 func TestBrokerTaskCompleteRejectsLiveBusinessTheater(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
@@ -3363,10 +3279,8 @@ func TestBrokerStoresLedgerAndReviewLifecycle(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -3463,10 +3377,8 @@ func TestBrokerReleaseTaskCleansWorktree(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -3534,10 +3446,8 @@ func TestBrokerApproveRetainsLocalWorktree(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -3654,10 +3564,8 @@ func TestBrokerHandlePostTaskRejectsFalseReadOnlyBlockForWritableWorktree(t *tes
 		verifyTaskWorktreeWritable = oldVerify
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "eng", "Engineer")
@@ -3742,10 +3650,8 @@ func TestBrokerBlockTaskRejectsFalseReadOnlyBlockForWritableWorktree(t *testing.
 		verifyTaskWorktreeWritable = oldVerify
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
@@ -3801,10 +3707,8 @@ func TestBrokerEnsurePlannedTaskQueuesConcurrentExclusiveOwnerWork(t *testing.T)
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "executor", "Executor")
@@ -3849,10 +3753,8 @@ func TestBrokerEnsurePlannedTaskQueuesConcurrentExclusiveOwnerWork(t *testing.T)
 }
 
 func TestBrokerTaskPlanRoutesLiveBusinessTasksIntoRecentExecutionChannel(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
@@ -3910,10 +3812,8 @@ func TestBrokerTaskPlanRoutesLiveBusinessTasksIntoRecentExecutionChannel(t *test
 }
 
 func TestBrokerTaskPlanReusesExistingActiveLane(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "client-loop", "builder", "Builder")
@@ -4013,10 +3913,8 @@ func TestBrokerBlockTaskAllowsReadOnlyBlockWhenWriteProbeFails(t *testing.T) {
 		verifyTaskWorktreeWritable = oldVerify
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
@@ -4058,10 +3956,8 @@ func TestBrokerCompleteClosesReviewTaskAndUnblocksDependents(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "eng", "Engineer")
@@ -4176,10 +4072,8 @@ func TestBrokerCreateTaskReusesCompletedDependencyWorktree(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
@@ -4345,10 +4239,8 @@ func TestBrokerNormalizeLoadedStateRepairsStaleAssignedWorktree(t *testing.T) {
 }
 
 func TestBrokerUpdatesTaskByIDAcrossChannels(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.channels = []teamChannel{
@@ -4425,10 +4317,8 @@ func TestBrokerCompleteAlreadyDoneTaskStaysApproved(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "eng", "Engineer")
@@ -4505,10 +4395,8 @@ func TestBrokerCompleteAlreadyDoneTaskStaysApproved(t *testing.T) {
 }
 
 func TestBrokerBridgeEndpointRecordsVisibleBridge(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -4579,10 +4467,8 @@ func TestBrokerBridgeEndpointRecordsVisibleBridge(t *testing.T) {
 }
 
 func TestBrokerRequestsLifecycle(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -4682,10 +4568,8 @@ func TestBrokerRequestsLifecycle(t *testing.T) {
 // web UI only sees per-channel requests and can't render a blocker that lives
 // in another channel — leaving the human stuck: can't send, can't see why.
 func TestBrokerGetRequestsScopeAllSeesCrossChannelBlocker(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "ceo", "CEO")
@@ -4765,10 +4649,8 @@ func TestBrokerGetRequestsScopeAllSeesCrossChannelBlocker(t *testing.T) {
 }
 
 func TestBrokerRequestAnswerUnblocksDependentTask(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "ceo", "CEO")
@@ -4894,10 +4776,8 @@ func TestBrokerRequestAnswerUnblocksDependentTask(t *testing.T) {
 }
 
 func TestBrokerDecisionRequestsDefaultToBlocking(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -4954,10 +4834,8 @@ func TestBrokerDecisionRequestsDefaultToBlocking(t *testing.T) {
 }
 
 func TestBrokerRequestAnswerRequiresCustomTextWhenOptionNeedsIt(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -5008,10 +4886,8 @@ func TestBrokerRequestAnswerRequiresCustomTextWhenOptionNeedsIt(t *testing.T) {
 }
 
 func TestQueueEndpointShowsDueJobs(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.SetSchedulerJob(schedulerJob{
@@ -5052,10 +4928,8 @@ func TestQueueEndpointShowsDueJobs(t *testing.T) {
 }
 
 func TestBrokerGetMessagesAgentScopeKeepsHumanAndCEOContext(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5175,10 +5049,8 @@ func TestLastTaggedAtSetOnPost(t *testing.T) {
 }
 
 func TestBrokerSurfaceMetadataPersists(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5236,10 +5108,8 @@ func TestBrokerSurfaceMetadataPersists(t *testing.T) {
 
 func TestBrokerSurfaceChannelsFilter(t *testing.T) {
 	t.Skip("skipped: manifest interference")
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5284,10 +5154,8 @@ func TestBrokerSurfaceChannelsFilter(t *testing.T) {
 }
 
 func TestBrokerExternalQueueDeduplication(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5326,10 +5194,8 @@ func TestBrokerExternalQueueDeduplication(t *testing.T) {
 }
 
 func TestBrokerPostInboundSurfaceMessage(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5366,10 +5232,8 @@ func TestBrokerPostInboundSurfaceMessage(t *testing.T) {
 }
 
 func TestInFlightTasksReturnsOnlyNonTerminalOwned(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5419,10 +5283,8 @@ func TestInFlightTasksReturnsOnlyNonTerminalOwned(t *testing.T) {
 }
 
 func TestInFlightTasksExcludesCompletedStatus(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5449,10 +5311,8 @@ func TestInFlightTasksExcludesCompletedStatus(t *testing.T) {
 }
 
 func TestRecentHumanMessagesReturnsLastNHumanMessages(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5480,10 +5340,8 @@ func TestRecentHumanMessagesReturnsLastNHumanMessages(t *testing.T) {
 }
 
 func TestRecentHumanMessagesLimitCapsResults(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5502,10 +5360,8 @@ func TestRecentHumanMessagesLimitCapsResults(t *testing.T) {
 }
 
 func TestRecentHumanMessagesExcludesNonHuman(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5522,10 +5378,8 @@ func TestRecentHumanMessagesExcludesNonHuman(t *testing.T) {
 }
 
 func TestRecentHumanMessagesIncludesNexSender(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5561,10 +5415,8 @@ func TestRecentHumanMessagesIncludesNexSender(t *testing.T) {
 // --- Skill proposal system tests ---
 
 func TestPostSkillProposeCreatesApprovalRequest(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	body := bytes.NewBufferString(`{
@@ -5601,10 +5453,8 @@ func TestPostSkillProposeCreatesApprovalRequest(t *testing.T) {
 }
 
 func TestPostSkillProposeRejectsUnregisteredAgent(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	body := bytes.NewBufferString(`{
@@ -5629,10 +5479,8 @@ func TestPostSkillProposeRejectsUnregisteredAgent(t *testing.T) {
 
 // Test 1: Answering "accept" via HTTP activates the skill.
 func TestSkillProposalAcceptCallbackActivatesSkill(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -5693,10 +5541,8 @@ func TestSkillProposalAcceptCallbackActivatesSkill(t *testing.T) {
 
 // Test 8: Answering "reject" via HTTP archives the skill.
 func TestSkillProposalRejectCallbackArchivesSkill(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -5755,10 +5601,8 @@ func TestSkillProposalRejectCallbackArchivesSkill(t *testing.T) {
 }
 
 func TestRequestAnswerUnblocksReferencedTask(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -5838,10 +5682,8 @@ func TestRequestAnswerUnblocksReferencedTask(t *testing.T) {
 }
 
 func TestInvokeSkillTracksInvokerChannelAndExecutionMetadata(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5894,10 +5736,8 @@ func TestInvokeSkillTracksInvokerChannelAndExecutionMetadata(t *testing.T) {
 
 // Test 10: buildPrompt for the lead includes SKILL & AGENT AWARENESS section.
 func TestBuildPromptLeadIncludesSkillAwareness(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	l := &Launcher{
 		pack: &agent.PackDefinition{
@@ -5919,10 +5759,8 @@ func TestBuildPromptLeadIncludesSkillAwareness(t *testing.T) {
 
 // Test 10: Skill proposal and interview persist and reload correctly.
 func TestSkillProposalPersistenceRoundTrip(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -5969,10 +5807,8 @@ func TestSkillProposalPersistenceRoundTrip(t *testing.T) {
 // message with the same eventID twice stores only one copy and returns the
 // existing message on the second call.
 func TestPostAutomationMessageDeduplicatesByEventID(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 
@@ -6011,10 +5847,8 @@ func TestPostAutomationMessageDeduplicatesByEventID(t *testing.T) {
 // TestExternalQueueDeduplicatesByMessageID verifies that calling ExternalQueue
 // twice for a surface channel only delivers each message once.
 func TestExternalQueueDeduplicatesByMessageID(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 
@@ -6059,10 +5893,8 @@ func TestExternalQueueDeduplicatesByMessageID(t *testing.T) {
 // members (ceo, eng, pm) wired into the general channel, and focus mode on.
 func makeFocusModeLauncher(t *testing.T) (*Launcher, *Broker) {
 	t.Helper()
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 
@@ -6146,10 +5978,8 @@ func TestFocusModeRouting_TaggedSpecialistWakesSpecialistOnly(t *testing.T) {
 // TestFocusModeRouting_CollobaborativeUntaggedWakesAll verifies the contrast:
 // without focus mode, an untagged human message wakes all enabled agents.
 func TestFocusModeRouting_CollaborativeUntaggedWakesAll(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -6234,14 +6064,12 @@ func TestHeadlessQueue_EmptyBeforePush(t *testing.T) {
 // adds exactly one turn to the target agent's queue.
 func TestHeadlessQueue_PopulatedAfterEnqueue(t *testing.T) {
 	// Override headlessCodexRunTurn to be a no-op so no real process is started.
-	origRunTurn := headlessCodexRunTurn
-	headlessCodexRunTurn = func(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error {
 		// Block until the context is cancelled so the worker stays "active"
 		// and doesn't drain the queue during the test assertion window.
 		<-ctx.Done()
 		return ctx.Err()
-	}
-	defer func() { headlessCodexRunTurn = origRunTurn }()
+	})
 
 	l := &Launcher{
 		pack: &agent.PackDefinition{
@@ -6370,10 +6198,8 @@ func TestEnsureDefaultOfficeMembersNoOpWhenNonEmpty(t *testing.T) {
 // ensureDefaultOfficeMembersLocked (called from Broker.Load() at broker.go:2260)
 // silently re-added ceo/planner/executor/reviewer.
 func TestLoadDoesNotAppendDefaultsAfterBlueprintSeed(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()

--- a/internal/team/headless_claude_test.go
+++ b/internal/team/headless_claude_test.go
@@ -71,10 +71,8 @@ func TestHeadlessClaudeModel_OpusForLeadOnly(t *testing.T) {
 // brokerStatePath is redirected to an empty temp dir so officeMembersSnapshot()
 // falls through to the pack definition instead of loading live state.
 func TestHeadlessClaudeModel_CustomLeadSlug(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	l := &Launcher{
 		pack: &agent.PackDefinition{
@@ -117,10 +115,8 @@ func TestHeadlessClaudeModel_CustomLeadSlug(t *testing.T) {
 // captured args are all we need.
 func TestRunHeadlessClaudeTurn_NoResumeFlag(t *testing.T) {
 	// Redirect broker state to an isolated temp dir.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	origCommandContext := headlessClaudeCommandContext
 	origLookPath := headlessClaudeLookPath

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/config"
@@ -22,25 +23,49 @@ var (
 	headlessCodexLookPath       = exec.LookPath
 	headlessCodexCommandContext = exec.CommandContext
 	headlessCodexExecutablePath = os.Executable
-	headlessCodexRunTurn        = func(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error {
-		if l != nil {
-			switch l.memberEffectiveProviderKind(slug) {
-			case provider.KindCodex:
-				return l.runHeadlessCodexTurn(ctx, slug, notification, channel...)
-			case provider.KindOpencode:
-				return l.runHeadlessOpencodeTurn(ctx, slug, notification, channel...)
-			default:
-				return l.runHeadlessClaudeTurn(ctx, slug, notification, channel...)
-			}
-		}
-		return l.runHeadlessCodexTurn(ctx, slug, notification, channel...)
-	}
+
+	// headlessCodexRunTurnOverride lets tests intercept turn execution
+	// without racing with goroutines that the queue worker spawned before
+	// the test's deferred restore ran. Tests must use
+	// setHeadlessCodexRunTurnForTest(t, fn) — never assign directly.
+	//
+	// Production callers go through headlessCodexRunTurn(...) which reads
+	// the atomic and falls back to defaultHeadlessCodexRunTurn.
+	headlessCodexRunTurnOverride atomic.Pointer[func(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error]
 	// headlessWakeLeadFn is nil in production; override in tests to intercept
 	// lead wake-ups. Always access via headlessWakeLeadFnMu to avoid races
 	// with leaked goroutines from concurrent tests.
 	headlessWakeLeadFn   func(l *Launcher, specialistSlug string)
 	headlessWakeLeadFnMu sync.RWMutex
 )
+
+// defaultHeadlessCodexRunTurn is the production implementation of
+// headlessCodexRunTurn. Routes by provider kind to the codex/opencode/claude
+// turn runner. Tests substitute via setHeadlessCodexRunTurnForTest.
+func defaultHeadlessCodexRunTurn(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error {
+	if l != nil {
+		switch l.memberEffectiveProviderKind(slug) {
+		case provider.KindCodex:
+			return l.runHeadlessCodexTurn(ctx, slug, notification, channel...)
+		case provider.KindOpencode:
+			return l.runHeadlessOpencodeTurn(ctx, slug, notification, channel...)
+		default:
+			return l.runHeadlessClaudeTurn(ctx, slug, notification, channel...)
+		}
+	}
+	return l.runHeadlessCodexTurn(ctx, slug, notification, channel...)
+}
+
+// headlessCodexRunTurn dispatches a queued turn to whichever runner the
+// member's effective provider kind picks. Reads the test override via
+// atomic.Pointer.Load so a worker goroutine that spawned before a test's
+// override-restore cleanup ran cannot race against the assignment.
+func headlessCodexRunTurn(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error {
+	if p := headlessCodexRunTurnOverride.Load(); p != nil {
+		return (*p)(l, ctx, slug, notification, channel...)
+	}
+	return defaultHeadlessCodexRunTurn(l, ctx, slug, notification, channel...)
+}
 
 var (
 	headlessCodexTurnTimeout              = 4 * time.Minute

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -594,13 +594,11 @@ func TestPrepareHeadlessCodexHomeUsesDedicatedRuntimeHomeAndCopiesAuth(t *testin
 }
 
 func TestEnqueueHeadlessCodexTurnProcessesFIFO(t *testing.T) {
-	oldRunTurn := headlessCodexRunTurn
 	processed := make(chan string, 4)
-	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, _ string, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, _ string, notification string, channel ...string) error {
 		processed <- notification
 		return nil
-	}
-	defer func() { headlessCodexRunTurn = oldRunTurn }()
+	})
 
 	l := newHeadlessLauncherForTest()
 
@@ -622,9 +620,7 @@ func TestPostHeadlessFinalMessageIfSilentPostsFinalOutput(t *testing.T) {
 	// real WUPHF run in ~/.wuphf/) persisted, and agentPostedSubstantiveMessageToChannelSince
 	// picks up an unrelated ceo message, making the "expected posted=true"
 	// assertion fail non-deterministically depending on machine history.
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(t.TempDir(), "broker-state.json") })
 
 	b := NewBroker()
 	channel := DMSlugFor("ceo")
@@ -662,16 +658,14 @@ func TestPostHeadlessFinalMessageIfSilentPostsFinalOutput(t *testing.T) {
 }
 
 func TestSendTaskUpdatePassesTaskChannelToHeadlessTurn(t *testing.T) {
-	oldRunTurn := headlessCodexRunTurn
 	processed := make(chan processedTurn, 1)
-	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, _ string, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, _ string, notification string, channel ...string) error {
 		processed <- processedTurn{
 			notification: notification,
 			channel:      firstNonEmpty(channel...),
 		}
 		return nil
-	}
-	defer func() { headlessCodexRunTurn = oldRunTurn }()
+	})
 
 	l := newHeadlessLauncherForTest()
 	l.provider = "codex"
@@ -699,7 +693,6 @@ func TestSendTaskUpdatePassesTaskChannelToHeadlessTurn(t *testing.T) {
 }
 
 func TestEnqueueHeadlessCodexTurnCancelsStaleTurn(t *testing.T) {
-	oldRunTurn := headlessCodexRunTurn
 	oldTimeout := headlessCodexTurnTimeout
 	oldStale := headlessCodexStaleCancelAfter
 	oldMinAge := headlessCodexMinTurnAgeBeforeCancel
@@ -710,7 +703,6 @@ func TestEnqueueHeadlessCodexTurnCancelsStaleTurn(t *testing.T) {
 	// "cancel-old, process-new" behaviour can be exercised in milliseconds.
 	headlessCodexMinTurnAgeBeforeCancel = 10 * time.Millisecond
 	defer func() {
-		headlessCodexRunTurn = oldRunTurn
 		headlessCodexTurnTimeout = oldTimeout
 		headlessCodexStaleCancelAfter = oldStale
 		headlessCodexMinTurnAgeBeforeCancel = oldMinAge
@@ -719,7 +711,7 @@ func TestEnqueueHeadlessCodexTurnCancelsStaleTurn(t *testing.T) {
 	started := make(chan struct{}, 1)
 	cancelled := make(chan struct{}, 1)
 	processed := make(chan string, 4)
-	headlessCodexRunTurn = func(_ *Launcher, ctx context.Context, _ string, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, ctx context.Context, _ string, notification string, channel ...string) error {
 		if notification == "first" {
 			select {
 			case started <- struct{}{}:
@@ -734,7 +726,7 @@ func TestEnqueueHeadlessCodexTurnCancelsStaleTurn(t *testing.T) {
 		}
 		processed <- notification
 		return nil
-	}
+	})
 
 	l := newHeadlessLauncherForTest()
 	l.enqueueHeadlessCodexTurn("ceo", "first")
@@ -1117,15 +1109,13 @@ func TestEnqueueHeadlessCodexTurnRecordAllowsRetryBehindActiveAgentTask(t *testi
 func TestWakeLeadAfterSpecialistFallsBackToCompletedTaskUpdateWhenNoBroadcast(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	oldRunTurn := headlessCodexRunTurn
 	notifications := make(chan string, 1)
-	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, slug, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, slug, notification string, channel ...string) error {
 		if slug == "ceo" {
 			notifications <- notification
 		}
 		return nil
-	}
-	defer func() { headlessCodexRunTurn = oldRunTurn }()
+	})
 
 	b := NewBroker()
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
@@ -1603,7 +1593,12 @@ func TestRecoverFailedHeadlessTurnRequeuesExternalActionBeforeBlocking(t *testin
 		Attempts: 0,
 	}, time.Now().UTC().Add(-2*time.Second), "channel_not_found")
 
-	queue := l.headlessQueues["operator"]
+	// Snapshot the queue under the launcher's headlessMu — the spawned worker
+	// goroutine drains headlessQueues under that mutex, so an unguarded read
+	// from the test races with the drain (caught by `go test -race`).
+	l.headlessMu.Lock()
+	queue := append([]headlessCodexTurn(nil), l.headlessQueues["operator"]...)
+	l.headlessMu.Unlock()
 	if len(queue) != 1 {
 		t.Fatalf("expected one retry queued for external action, got %+v", queue)
 	}
@@ -1922,10 +1917,8 @@ func TestBeginHeadlessCodexTurnCapturesWorktreeForLocalWorktreeBuilder(t *testin
 
 func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	oldPrepare := prepareTaskWorktree
 	oldCleanup := cleanupTaskWorktree
@@ -1953,19 +1946,16 @@ func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T
 		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
 	}
 
-	oldRunTurn := headlessCodexRunTurn
-	defer func() { headlessCodexRunTurn = oldRunTurn }()
-
 	processed := make(chan string, 2)
 	attempt := 0
-	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, _ string, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, _ string, notification string, channel ...string) error {
 		attempt++
 		processed <- notification
 		if attempt == 1 {
 			return fmt.Errorf("Selected model is at capacity. Please try a different model.")
 		}
 		return nil
-	}
+	})
 
 	l := newHeadlessLauncherForTest()
 	l.broker = b
@@ -2053,13 +2043,11 @@ func TestHeadlessCodexTurnTimeoutForOfficeLaunchTask(t *testing.T) {
 }
 
 func TestEnqueueHeadlessCodexTurnDefersLeadUntilSpecialistFinishes(t *testing.T) {
-	oldRunTurn := headlessCodexRunTurn
 	processed := make(chan string, 2)
-	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, _ string, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, _ string, notification string, channel ...string) error {
 		processed <- notification
 		return nil
-	}
-	defer func() { headlessCodexRunTurn = oldRunTurn }()
+	})
 
 	l := newHeadlessLauncherForTest()
 	l.headlessActive["eng"] = &headlessCodexActiveTurn{}
@@ -2077,18 +2065,14 @@ func TestEnqueueHeadlessCodexTurnDefersLeadUntilSpecialistFinishes(t *testing.T)
 }
 
 func TestEnqueueHeadlessCodexTurnBypassesLeadHoldForReviewReadyTask(t *testing.T) {
-	oldRunTurn := headlessCodexRunTurn
 	processed := make(chan string, 1)
-	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, _ string, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, _ string, notification string, channel ...string) error {
 		processed <- notification
 		return nil
-	}
-	defer func() { headlessCodexRunTurn = oldRunTurn }()
+	})
 
-	oldStatePath := brokerStatePath
 	stateDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(stateDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldStatePath }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(stateDir, "broker-state.json") })
 
 	oldPrepare := prepareTaskWorktree
 	oldCleanup := cleanupTaskWorktree

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -32,10 +32,8 @@ func TestParseAgentPaneIndicesSkipsChannelPane(t *testing.T) {
 }
 
 func TestResetBrokerStateUsesAuthToken(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -49,10 +47,8 @@ func TestResetBrokerStateUsesAuthToken(t *testing.T) {
 }
 
 func TestResetSessionOnlyClearsOfficeState(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if _, err := b.PostMessage("you", "general", "hello", nil, ""); err != nil {
@@ -167,10 +163,8 @@ func TestAgentPaneSlugsUsesOfficeRosterNotStaticPack(t *testing.T) {
 }
 
 func TestOfficeMembersSnapshotPrefersPersistedStateOverPack(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	state := brokerState{
 		Members: []officeMember{
@@ -229,10 +223,8 @@ func TestNotificationTargetsForMessageOneOnOneWakesSelectedAgent(t *testing.T) {
 }
 
 func TestNotificationTargetsForMessageUsesMetadataBackedTaskOwner(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -330,10 +322,8 @@ func TestFormatNexFeedItem(t *testing.T) {
 }
 
 func TestFetchAndIngestNexNotificationsSeedsCursorOnColdStart(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -481,10 +471,8 @@ func TestPrimeVisibleAgentsWithoutBrokerDoesNotPanic(t *testing.T) {
 }
 
 func TestNotificationTargetsForHumanMessageDirectToTaggedSpecialists(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	l := &Launcher{
 		focusMode: true,
@@ -533,10 +521,8 @@ func TestNotificationTargetsForHumanMessageDirectToTaggedSpecialists(t *testing.
 
 func TestNotificationTargetsForDMChannel(t *testing.T) {
 	// DMs should route only to the target agent, not to CEO or other specialists.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	l := &Launcher{
 		focusMode: true,
@@ -578,10 +564,8 @@ func TestNotificationTargetsForDMChannel(t *testing.T) {
 }
 
 func TestNotificationTargetsForDMChannelCodexRuntimeUsesHeadlessTarget(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	l := &Launcher{
 		provider: "codex",
@@ -614,10 +598,8 @@ func TestNotificationTargetsForDMChannelCodexRuntimeUsesHeadlessTarget(t *testin
 }
 
 func TestDeliverDMMessageQueuesCodexHeadlessTurn(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	l := newHeadlessLauncherForTest()
@@ -626,16 +608,14 @@ func TestDeliverDMMessageQueuesCodexHeadlessTurn(t *testing.T) {
 	l.notifyLastDelivered = make(map[string]time.Time)
 
 	processed := make(chan string, 1)
-	oldRunTurn := headlessCodexRunTurn
-	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, slug, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, slug, notification string, channel ...string) error {
 		targetChannel := ""
 		if len(channel) > 0 {
 			targetChannel = channel[0]
 		}
 		processed <- strings.Join([]string{slug, targetChannel, notification}, "\n---\n")
 		return nil
-	}
-	defer func() { headlessCodexRunTurn = oldRunTurn }()
+	})
 
 	dmSlug := DMSlugFor("ceo")
 	l.deliverMessageNotification(channelMessage{
@@ -660,10 +640,8 @@ func TestDeliverDMMessageQueuesCodexHeadlessTurn(t *testing.T) {
 func TestNotificationTargetsForDMChannelNewSlugFormat(t *testing.T) {
 	// New-style deterministic DM slugs (e.g. "fe__human") should route the same
 	// way as legacy "dm-fe" slugs: only the target agent is notified.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	// Override broker members so officeMembersSnapshot returns test agents.
@@ -716,10 +694,8 @@ func TestNotificationTargetsForDMChannelNewSlugFormat(t *testing.T) {
 func TestResponseInstructionForTargetDMChannelNewSlugFormat(t *testing.T) {
 	// New-style deterministic DM slugs should produce the same "messaging you directly"
 	// instruction as legacy dm-* slugs, ensuring specialists respond in DMs.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	// Override broker members so officeMembersSnapshot returns test agents.
@@ -760,10 +736,8 @@ func TestResponseInstructionForTargetDMChannelNewSlugFormat(t *testing.T) {
 }
 
 func TestNotificationTargetsExplicitTagsAlwaysDeliverRegardlessOfDomain(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	l := &Launcher{
 		pack: &agent.PackDefinition{
@@ -793,10 +767,8 @@ func TestNotificationTargetsExplicitTagsAlwaysDeliverRegardlessOfDomain(t *testi
 }
 
 func TestNotificationTargetsTaggedSpecialistsGetImmediateDelivery(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	l := &Launcher{
 		pack: &agent.PackDefinition{
@@ -837,10 +809,8 @@ func TestNotificationTargetsTaggedSpecialistsGetImmediateDelivery(t *testing.T) 
 }
 
 func TestNotificationTargetsForCEOMessageNotifyTaggedOnly(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	l := &Launcher{
 		pack: &agent.PackDefinition{
@@ -869,10 +839,8 @@ func TestNotificationTargetsForCEOMessageNotifyTaggedOnly(t *testing.T) {
 }
 
 func TestTaskNotificationTargetsFollowOwnerAndCEOHeadStart(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	l := &Launcher{
 		pack: &agent.PackDefinition{
@@ -951,10 +919,8 @@ func TestTaskNotificationTargetsFollowOwnerAndCEOHeadStart(t *testing.T) {
 }
 
 func TestTaskNotificationTargetsWakeCEOWhenOwnerBlocksTask(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	l := &Launcher{
 		pack: &agent.PackDefinition{
@@ -1129,9 +1095,7 @@ func TestBuildTaskExecutionPacketRequiresRealExternalExecution(t *testing.T) {
 }
 
 func TestBuildPromptIncludesTaskStatusAndWorktreeGuidance(t *testing.T) {
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(t.TempDir(), "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(t.TempDir(), "broker-state.json") })
 
 	l := &Launcher{
 		pack: &agent.PackDefinition{
@@ -1536,10 +1500,8 @@ func TestTaskNotificationTargetsDoNotRewakeCEOForOwnCreatedTask(t *testing.T) {
 }
 
 func TestRecordPolicyDeduplicates(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	_, err := b.RecordPolicy("human_directed", "Always ask before deploying to production")
@@ -1558,10 +1520,8 @@ func TestRecordPolicyDeduplicates(t *testing.T) {
 }
 
 func TestRecordWatchdogLedgerCreatesSignalAndDecision(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	l := &Launcher{broker: b}
@@ -1582,10 +1542,8 @@ func TestRecordWatchdogLedgerCreatesSignalAndDecision(t *testing.T) {
 }
 
 func TestRecordPolicyPersistsAndLoads(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	_, err := b.RecordPolicy("human_directed", "Work autonomously without asking for approval")
@@ -1624,10 +1582,8 @@ func TestBuildNotificationContextEmpty(t *testing.T) {
 }
 
 func TestBuildNotificationContextFormatsMessages(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1663,10 +1619,8 @@ func TestBuildNotificationContextFormatsMessages(t *testing.T) {
 }
 
 func TestBuildNotificationContextFiltersSystem(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1697,10 +1651,8 @@ func TestBuildNotificationContextFiltersSystem(t *testing.T) {
 }
 
 func TestBuildNotificationContextRespectsLimit(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1724,10 +1676,8 @@ func TestBuildNotificationContextRespectsLimit(t *testing.T) {
 }
 
 func TestBuildNotificationContextExcludesTrigger(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1758,10 +1708,8 @@ func TestBuildNotificationContextExcludesTrigger(t *testing.T) {
 func TestUltimateThreadRootFlat(t *testing.T) {
 	// Flat thread: human ask (X) → CEO reply (Y, replyTo=X).
 	// ultimateThreadRoot starting from Y should return X.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1787,10 +1735,8 @@ func TestUltimateThreadRootFlat(t *testing.T) {
 func TestUltimateThreadRootDeep(t *testing.T) {
 	// Deep thread: X → Y (replyTo=X) → Z (replyTo=Y).
 	// ultimateThreadRoot starting from Z should return X.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1819,10 +1765,8 @@ func TestUltimateThreadRootDeep(t *testing.T) {
 
 func TestUltimateThreadRootTopLevel(t *testing.T) {
 	// Top-level message has no replyTo: walk returns the message itself.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1855,10 +1799,8 @@ func TestThreadMessageIDsParallelDelegation(t *testing.T) {
 	//
 	// CEO gets notified about A_reply. threadMessageIDs from ultimate root X must
 	// include B_reply so CEO knows B already acted.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1903,10 +1845,8 @@ func TestBuildNotificationContextThreadFiltering(t *testing.T) {
 	// Verifies that when a threadRootID is given, only messages in that thread
 	// appear in the context (labeled [Recent thread]), and messages from a
 	// concurrent unrelated thread are excluded.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -1960,10 +1900,8 @@ func TestBuildNotificationContextIncludesDeepThreadMessages(t *testing.T) {
 	//
 	// Marketing agent's context should show X (root anchor) and R (research results),
 	// NOT just X and Y (which is all the old shallow filter produced).
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2013,10 +1951,8 @@ func TestBuildTaskNotificationContextCEOSeesAllChannels(t *testing.T) {
 	// CEO task context must include tasks from ALL channels, not just the channel of
 	// the message that woke the CEO. When woken from "engineering" channel, the CEO
 	// should still see tasks in "general".
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2140,10 +2076,8 @@ func TestBuildNotificationContextFallsBackToChannelWhenThreadEmpty(t *testing.T)
 	// When threadRootID is given but the thread has no displayable messages
 	// (e.g. the trigger IS the root and no other replies exist yet), the function
 	// should fall back to recent channel messages labeled [Recent channel].
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2181,10 +2115,8 @@ func TestRelevantTaskForTargetCrossChannel(t *testing.T) {
 	// relevantTaskForTarget must still find it. Before the AllTasks() fix, it searched
 	// only ChannelTasks("general") and returned nothing — causing work packets to omit
 	// the "Active task" line and giving specialists the wrong response instruction.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	oldPrepare := prepareTaskWorktree
 	oldCleanup := cleanupTaskWorktree
@@ -2286,10 +2218,8 @@ func TestRelevantTaskForTargetCrossChannel(t *testing.T) {
 }
 
 func TestRelevantTaskForTargetUsesRosterMetadata(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -2349,10 +2279,8 @@ func TestBlockedTaskNotificationAndUnblockFlow(t *testing.T) {
 	// 2. Marketing should NOT be woken immediately (task is blocked)
 	// 3. When research completes, a task_unblocked action fires
 	// 4. Marketing IS woken immediately via the task_unblocked notification
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2479,9 +2407,7 @@ func TestBlockedTaskNotificationAndUnblockFlow(t *testing.T) {
 // the marketing owner in immediate targets — confirming the full path is live.
 func TestActionLoopAllowsTaskUnblocked(t *testing.T) {
 	dir := t.TempDir()
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(dir, "state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(dir, "state.json") })
 
 	b := NewBroker()
 	if err := b.StartOnPort(0); err != nil {
@@ -2604,10 +2530,8 @@ done:
 }
 
 func TestProcessDueTaskJobResumesRateLimitedBlockedTask(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -2664,10 +2588,8 @@ func TestOfficeChangeTaskNotificationsBackfillGeneratedMemberTask(t *testing.T) 
 	// is inside the test's own tempdir ("unlinkat: directory not empty").
 	// Leaking a few KB in /tmp is the cheap fix; proper goroutine hygiene
 	// across the suite is a separate refactor.
-	oldPathFn := brokerStatePath
 	statePath := leakedBrokerStatePath(t)
-	brokerStatePath = func() string { return statePath }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -2725,10 +2647,8 @@ func TestOfficeChangeTaskNotificationsBackfillGeneratedMemberTask(t *testing.T) 
 func TestOfficeChangeTaskNotificationsBackfillChannelMembershipTask(t *testing.T) {
 	// See TestOfficeChangeTaskNotificationsBackfillGeneratedMemberTask for
 	// why this test uses a leaked state dir instead of t.TempDir().
-	oldPathFn := brokerStatePath
 	statePath := leakedBrokerStatePath(t)
-	brokerStatePath = func() string { return statePath }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	b := NewBroker()
 	b.mu.Lock()

--- a/internal/team/launcher_workflow_test.go
+++ b/internal/team/launcher_workflow_test.go
@@ -20,9 +20,7 @@ func TestProcessDueWorkflowJobUsesComposioProvider(t *testing.T) {
 	t.Setenv("WUPHF_COMPOSIO_USER_ID", "najmuzzaman@nex.ai")
 
 	tmpDir := t.TempDir()
-	oldPathFn := brokerStatePath
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/connected_accounts/ca_123", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/team/mention_auto_promote_test.go
+++ b/internal/team/mention_auto_promote_test.go
@@ -27,10 +27,8 @@ import (
 
 func newBrokerWithPM(t *testing.T) *Broker {
 	t.Helper()
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -202,16 +200,14 @@ func TestAutoPromote_EndToEnd_HumanTagsPM_DispatchesToPM(t *testing.T) {
 	}
 
 	processed := make(chan string, 4)
-	oldRunTurn := headlessCodexRunTurn
-	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, slug, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, slug, notification string, channel ...string) error {
 		ch := ""
 		if len(channel) > 0 {
 			ch = channel[0]
 		}
 		processed <- slug + "|" + ch + "|" + notification
 		return nil
-	}
-	defer func() { headlessCodexRunTurn = oldRunTurn }()
+	})
 
 	// Simulate the user's exact flow: POST /messages with @pm in body and
 	// tagged empty (composer didn't commit a chip).

--- a/internal/team/mention_routing_bug_test.go
+++ b/internal/team/mention_routing_bug_test.go
@@ -30,10 +30,8 @@ import (
 
 func collaborativeTestLauncher(t *testing.T) *Launcher {
 	t.Helper()
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 	return &Launcher{
 		// focusMode intentionally left false: collaborative is the default.
 		pack: &agent.PackDefinition{
@@ -124,9 +122,8 @@ func TestBug_HumanDMsSpecialist_CollaborativeMode_SpecialistIsImmediate(t *testi
 // required), which lets us deterministically observe what got enqueued.
 func fullDispatchLauncher(t *testing.T) (*Launcher, chan string, func()) {
 	t.Helper()
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -151,20 +148,18 @@ func fullDispatchLauncher(t *testing.T) (*Launcher, chan string, func()) {
 	}
 
 	processed := make(chan string, 8)
-	oldRunTurn := headlessCodexRunTurn
-	headlessCodexRunTurn = func(_ *Launcher, _ context.Context, slug, notification string, channel ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, _ context.Context, slug, notification string, channel ...string) error {
 		ch := ""
 		if len(channel) > 0 {
 			ch = channel[0]
 		}
 		processed <- slug + "|" + ch + "|" + notification
 		return nil
-	}
+	})
 
-	cleanup := func() {
-		headlessCodexRunTurn = oldRunTurn
-		brokerStatePath = oldPathFn
-	}
+	// All overrides this helper installs are restored via t.Cleanup
+	// registered by setHeadlessCodexRunTurnForTest / setBrokerStatePathForTest.
+	cleanup := func() {}
 	return l, processed, cleanup
 }
 
@@ -282,10 +277,8 @@ func hasSlug(xs []string, want string) bool {
 // -----------------------------------------------------------------------------
 
 func TestBug_FocusMode_HumanTagsWizardHiredPM_SpecialistIsImmediate(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -327,10 +320,8 @@ func TestBug_FocusMode_HumanTagsWizardHiredPM_SpecialistIsImmediate(t *testing.T
 }
 
 func TestBug_FocusMode_CEOTagsWizardHiredPM_SpecialistIsImmediate(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -373,10 +364,8 @@ func TestBug_FocusMode_CEOTagsWizardHiredPM_SpecialistIsImmediate(t *testing.T) 
 // -----------------------------------------------------------------------------
 
 func TestBug_DisabledMember_ExplicitTagDoesNotBypassMute(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -451,10 +440,8 @@ func TestBug_DisabledMember_ExplicitTagDoesNotBypassMute(t *testing.T) {
 // activeSessionMembers (which is pack-gated) excludes pm, agentNotificationTargets
 // never registers pm, and DM dispatch silently returns zero targets.
 func TestBug_DMToWizardHiredPM_Dispatch(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	// Simulate the wizard flow: POST /office-members adds to b.members, but
@@ -502,10 +489,8 @@ func TestBug_DMToWizardHiredPM_Dispatch(t *testing.T) {
 // from targetMap entirely, so even the explicit-tag bypass (just-applied fix)
 // can't save the delivery.
 func TestBug_TagWizardHiredPM_InGeneral_Dispatch(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -554,10 +539,8 @@ func TestBug_TagWizardHiredPM_InGeneral_Dispatch(t *testing.T) {
 // allowTarget / isEnabled check silently drops the explicit mention and only
 // CEO gets notified. This is symptom 1 of the reported bug.
 func TestBug_RootCause_ChannelMembershipFilterDropsExplicitMention(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	// Add a specialist AFTER the broker has seeded default channels (this is

--- a/internal/team/operation_matrix_test.go
+++ b/internal/team/operation_matrix_test.go
@@ -122,8 +122,6 @@ func TestOperationBlueprintMatrixBuildsBootstrapPackage(t *testing.T) {
 
 func TestOperationBlueprintMatrixSeedsBrokerOffice(t *testing.T) {
 	repoRoot := teamTestRepoRoot(t)
-	oldPathFn := brokerStatePath
-	defer func() { brokerStatePath = oldPathFn }()
 
 	for _, id := range teamOperationFixtureIDs(t, repoRoot) {
 		t.Run(id, func(t *testing.T) {
@@ -147,7 +145,7 @@ func TestOperationBlueprintMatrixSeedsBrokerOffice(t *testing.T) {
 			}
 
 			stateDir := t.TempDir()
-			brokerStatePath = func() string { return filepath.Join(stateDir, "broker-state.json") }
+			setBrokerStatePathForTest(t, func() string { return filepath.Join(stateDir, "broker-state.json") })
 
 			blueprint, err := operations.LoadBlueprint(repoRoot, id)
 			if err != nil {
@@ -194,8 +192,6 @@ func TestOperationBlueprintMatrixSeedsBrokerOffice(t *testing.T) {
 
 func TestOperationBlueprintMatrixServesBootstrapPackageEndpoint(t *testing.T) {
 	repoRoot := teamTestRepoRoot(t)
-	oldPathFn := brokerStatePath
-	defer func() { brokerStatePath = oldPathFn }()
 
 	for _, id := range teamOperationFixtureIDs(t, repoRoot) {
 		t.Run(id, func(t *testing.T) {
@@ -219,7 +215,7 @@ func TestOperationBlueprintMatrixServesBootstrapPackageEndpoint(t *testing.T) {
 			}
 
 			stateDir := t.TempDir()
-			brokerStatePath = func() string { return filepath.Join(stateDir, "broker-state.json") }
+			setBrokerStatePathForTest(t, func() string { return filepath.Join(stateDir, "broker-state.json") })
 
 			blueprint, err := operations.LoadBlueprint(repoRoot, id)
 			if err != nil {

--- a/internal/team/policy_test.go
+++ b/internal/team/policy_test.go
@@ -39,12 +39,10 @@ func TestNewOfficePolicyTrimsRule(t *testing.T) {
 }
 
 func TestBrokerRecordAndListPolicies(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
 	import_path := tmpDir + "/broker-state.json"
 	_ = import_path
-	brokerStatePath = func() string { return tmpDir + "/broker-state.json" }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return tmpDir + "/broker-state.json" })
 
 	b := NewBroker()
 	p1, err := b.RecordPolicy("human_directed", "Always ask before deploying to production")
@@ -69,10 +67,8 @@ func TestBrokerRecordAndListPolicies(t *testing.T) {
 }
 
 func TestBrokerRecordPolicyDeduplicates(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return tmpDir + "/broker-state.json" }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return tmpDir + "/broker-state.json" })
 
 	b := NewBroker()
 	const rule = "Work autonomously without approval"
@@ -90,10 +86,8 @@ func TestBrokerRecordPolicyDeduplicates(t *testing.T) {
 }
 
 func TestBrokerDeletePolicyDeactivates(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return tmpDir + "/broker-state.json" }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return tmpDir + "/broker-state.json" })
 
 	b := NewBroker()
 	p, err := b.RecordPolicy("human_directed", "Ask before sending external emails")
@@ -118,10 +112,8 @@ func TestBrokerDeletePolicyDeactivates(t *testing.T) {
 }
 
 func TestBrokerRecordPolicyEmptyRuleErrors(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return tmpDir + "/broker-state.json" }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return tmpDir + "/broker-state.json" })
 
 	b := NewBroker()
 	_, err := b.RecordPolicy("human_directed", "  ")

--- a/internal/team/resume_test.go
+++ b/internal/team/resume_test.go
@@ -115,10 +115,8 @@ func TestFindUnansweredMessagesNexReplyDoesNotCountAsAgentAnswer(t *testing.T) {
 
 func TestBuildResumePacketWithTasksAndMessages(t *testing.T) {
 	// Suppress broker state path for this test.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	tasks := []teamTask{
 		{ID: "t1", Title: "Build the login page", Owner: "fe", Status: "in_progress"},
@@ -184,10 +182,8 @@ func TestBuildResumePacketMessagesOnly(t *testing.T) {
 // --- Tests for Launcher.buildResumePackets ---
 
 func TestBuildResumePacketsTaggedMessageRoutesToTaggedAgent(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -224,10 +220,8 @@ func TestBuildResumePacketsTaggedMessageRoutesToTaggedAgent(t *testing.T) {
 }
 
 func TestBuildResumePacketsIncludesDynamicBrokerMembersOutsideLaunchPack(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -270,10 +264,8 @@ func TestBuildResumePacketsIncludesDynamicBrokerMembersOutsideLaunchPack(t *test
 }
 
 func TestBuildResumePacketsUntaggedMessageRoutesToLead(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -306,10 +298,8 @@ func TestBuildResumePacketsUntaggedMessageRoutesToLead(t *testing.T) {
 }
 
 func TestBuildResumePacketsInFlightTasksIncluded(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -341,10 +331,8 @@ func TestBuildResumePacketsInFlightTasksIncluded(t *testing.T) {
 }
 
 func TestBuildResumePacketsEmptyWhenNothingInFlight(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	// No tasks, no messages.
@@ -372,10 +360,8 @@ func TestResumeInFlightWorkNoBrokerNoPanic(t *testing.T) {
 }
 
 func TestResumeInFlightWorkNoPackNoPanic(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -391,10 +377,8 @@ func TestResumeInFlightWorkNoPackNoPanic(t *testing.T) {
 }
 
 func TestBuildResumePacketsUnansweredRoutesToLead(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -435,10 +419,8 @@ func TestBuildResumePacketsUnansweredRoutesToLead(t *testing.T) {
 }
 
 func TestBuildResumePacketsSkipsAgentsNotInPack(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -478,10 +460,8 @@ func TestBuildResumePacketsSkipsAgentsNotInPack(t *testing.T) {
 }
 
 func TestBuildResumePacketsSkipsTaggedAgentsNotInPack(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -567,10 +547,8 @@ func TestResumeInFlightWorkHeadlessEnqueuesLeadEvenWhenSpecialistsPresent(t *tes
 	// Fix: enqueue the lead first so its queue entry is set before specialists'
 	// queues are populated — the queue-hold check fires only when OTHER slugs
 	// have non-empty queues at the time of the CEO enqueue.
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -689,10 +667,8 @@ func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
 	// Leaked path (not t.TempDir) so a headless worker goroutine that
 	// outlives the test can keep writing without racing the dir cleanup
 	// and failing the test with an `unlinkat ... directory not empty`.
-	oldPathFn := brokerStatePath
 	statePath := leakedBrokerStatePath(t)
-	brokerStatePath = func() string { return statePath }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
 
@@ -745,10 +721,8 @@ func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 	// Leaked path (not t.TempDir) so a headless worker goroutine that
 	// outlives the test can keep writing without racing the dir cleanup
 	// and failing the test with an `unlinkat ... directory not empty`.
-	oldPathFn := brokerStatePath
 	statePath := leakedBrokerStatePath(t)
-	brokerStatePath = func() string { return statePath }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
 

--- a/internal/team/telegram_test.go
+++ b/internal/team/telegram_test.go
@@ -14,10 +14,8 @@ import (
 
 func newTestBrokerWithTelegramChannel(t *testing.T, chatID string) *Broker {
 	t.Helper()
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	b.mu.Lock()
@@ -336,10 +334,8 @@ func TestTelegramStartFailsWithoutToken(t *testing.T) {
 }
 
 func TestTelegramStartFailsWithoutChannels(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	// Clear all channels so there are no telegram surfaces

--- a/internal/team/test_support.go
+++ b/internal/team/test_support.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,4 +69,48 @@ func DisableRealTaskWorktreeForTests() {
 			_ = os.Setenv("WUPHF_RUNTIME_HOME", dir)
 		}
 	}
+}
+
+// setBrokerStatePathForTest redirects brokerStatePath() to fn for the
+// duration of the test, then restores the prior override on cleanup.
+//
+// Tests previously did `oldFn := brokerStatePath; brokerStatePath = ...`
+// against a package-level var. That pattern was a data race against the
+// headless-codex queue worker spawned by resumeInFlightWork — the worker
+// could outlive the test's deferred restore and observe the swap mid-call.
+// Use this helper instead. Reads use atomic.Pointer.Load and the cleanup
+// runs via t.Cleanup so the override stays installed until ALL goroutines
+// the test spawned have either finished or panicked.
+func setBrokerStatePathForTest(t *testing.T, fn func() string) {
+	t.Helper()
+	prior := brokerStatePathOverride.Load()
+	brokerStatePathOverride.Store(&fn)
+	t.Cleanup(func() {
+		if prior == nil {
+			brokerStatePathOverride.Store(nil)
+			return
+		}
+		brokerStatePathOverride.Store(prior)
+	})
+}
+
+// setHeadlessCodexRunTurnForTest redirects headlessCodexRunTurn(...) to fn
+// for the duration of the test, then restores the prior override on cleanup.
+//
+// Tests previously did `oldFn := headlessCodexRunTurn; headlessCodexRunTurn = ...`
+// against a package-level var. That pattern was a data race against the
+// queue worker spawned by enqueueHeadlessCodexTurnRecord — the worker could
+// outlive the test's deferred restore and observe the swap mid-call. Use
+// this helper instead.
+func setHeadlessCodexRunTurnForTest(t *testing.T, fn func(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error) {
+	t.Helper()
+	prior := headlessCodexRunTurnOverride.Load()
+	headlessCodexRunTurnOverride.Store(&fn)
+	t.Cleanup(func() {
+		if prior == nil {
+			headlessCodexRunTurnOverride.Store(nil)
+			return
+		}
+		headlessCodexRunTurnOverride.Store(prior)
+	})
 }

--- a/internal/team/token_bloat_fixes_test.go
+++ b/internal/team/token_bloat_fixes_test.go
@@ -14,10 +14,8 @@ import (
 // pattern — the prompt rule telling agents not to do that is routinely
 // ignored, so this enforces it at the persistence layer.
 func TestDuplicateAgentBroadcastIsSuppressed(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -62,10 +60,8 @@ func TestDuplicateAgentBroadcastIsSuppressed(t *testing.T) {
 // TestDuplicateAgentBroadcastWindowExpires verifies the dedup window is time
 // bounded — a follow-up beyond the window posts normally.
 func TestDuplicateAgentBroadcastWindowExpires(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	b := NewBroker()
 	old := time.Now().UTC().Add(-2 * duplicateBroadcastWindow).Format(time.RFC3339)
@@ -86,10 +82,8 @@ func TestDuplicateAgentBroadcastWindowExpires(t *testing.T) {
 // old "@planner say hi" from hours before the restart wakes planner with
 // the wrong intent).
 func TestStaleUnansweredFilteredOnResume(t *testing.T) {
-	oldPathFn := brokerStatePath
 	tmpDir := t.TempDir()
-	brokerStatePath = func() string { return filepath.Join(tmpDir, "broker-state.json") }
-	defer func() { brokerStatePath = oldPathFn }()
+	setBrokerStatePathForTest(t, func() string { return filepath.Join(tmpDir, "broker-state.json") })
 
 	// This test runs with the production-like threshold, not the test-suite
 	// override from TestMain. Swap locally so production semantics win here.

--- a/internal/team/wizard_hire_channel_access_test.go
+++ b/internal/team/wizard_hire_channel_access_test.go
@@ -36,10 +36,8 @@ func newBrokerWithPackChannels(t *testing.T, packAgents []agent.AgentConfig) *Br
 	// prior tests in this package can fire a late saveLocked and race
 	// t.TempDir cleanup. Same fix as the launcher_test.go pair; see
 	// broker_test.go for the helper docstring.
-	oldPathFn := brokerStatePath
 	statePath := leakedBrokerStatePath(t)
-	brokerStatePath = func() string { return statePath }
-	t.Cleanup(func() { brokerStatePath = oldPathFn })
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	b := NewBroker()
 	b.mu.Lock()

--- a/internal/team/worktree_guard_test.go
+++ b/internal/team/worktree_guard_test.go
@@ -57,7 +57,8 @@ func init() {
 		panic(fmt.Sprintf("worktree_guard_test init: mktemp broker state: %v", err))
 	}
 	defaultTestStatePath := filepath.Join(stateDir, "broker-state.json")
-	brokerStatePath = func() string { return defaultTestStatePath }
+	defaultFn := func() string { return defaultTestStatePath }
+	brokerStatePathOverride.Store(&defaultFn)
 }
 
 func stubPrepareTaskWorktree(taskID string) (string, string, error) {

--- a/internal/team/worktree_test.go
+++ b/internal/team/worktree_test.go
@@ -15,14 +15,12 @@ func TestCleanupPersistedTaskWorktreesRemovesUniqueTrackedWorktrees(t *testing.T
 	stateDir := t.TempDir()
 	statePath := filepath.Join(stateDir, "broker-state.json")
 
-	oldStatePath := brokerStatePath
 	oldCleanup := cleanupTaskWorktree
 	defer func() {
-		brokerStatePath = oldStatePath
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	brokerStatePath = func() string { return statePath }
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	var calls []string
 	cleanupTaskWorktree = func(path, branch string) error {
@@ -59,9 +57,7 @@ func TestCleanupPersistedTaskWorktreesMissingStateIsNoOp(t *testing.T) {
 	stateDir := t.TempDir()
 	statePath := filepath.Join(stateDir, "broker-state.json")
 
-	oldStatePath := brokerStatePath
-	defer func() { brokerStatePath = oldStatePath }()
-	brokerStatePath = func() string { return statePath }
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	if err := CleanupPersistedTaskWorktrees(); err != nil {
 		t.Fatalf("expected missing state cleanup to succeed, got %v", err)
@@ -191,15 +187,13 @@ func TestDefaultPrepareTaskWorktreeOverlaysCompletedSiblingTaskWorkspace(t *test
 	}
 	defer func() { _ = os.Chdir(oldCwd) }()
 	oldTaskRoot := taskWorktreeRootDir
-	oldStatePath := brokerStatePath
 	defer func() {
 		taskWorktreeRootDir = oldTaskRoot
-		brokerStatePath = oldStatePath
 	}()
 	taskWorktreeRootDir = func(repoRoot string) string {
 		return filepath.Join(worktreeRoot, sanitizeWorktreeToken(filepath.Base(repoRoot)))
 	}
-	brokerStatePath = func() string { return statePath }
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	run := func(dir string, args ...string) {
 		t.Helper()
@@ -294,15 +288,13 @@ func TestDefaultPrepareTaskWorktreeSkipsDuplicateAndMissingCompletedSiblingSourc
 	}
 	defer func() { _ = os.Chdir(oldCwd) }()
 	oldTaskRoot := taskWorktreeRootDir
-	oldStatePath := brokerStatePath
 	defer func() {
 		taskWorktreeRootDir = oldTaskRoot
-		brokerStatePath = oldStatePath
 	}()
 	taskWorktreeRootDir = func(repoRoot string) string {
 		return filepath.Join(worktreeRoot, sanitizeWorktreeToken(filepath.Base(repoRoot)))
 	}
-	brokerStatePath = func() string { return statePath }
+	setBrokerStatePathForTest(t, func() string { return statePath })
 
 	run := func(dir string, args ...string) {
 		t.Helper()


### PR DESCRIPTION
## Summary

Closes two long-standing data races in `internal/team/` that `go test -race` surfaces intermittently. Both have the same shape: a package-level `var func(...)` is mutated from tests under `defer`/`t.Cleanup`, but read by a queue-worker goroutine that outlives the test scope.

**Symptoms today** (under `-race`, repro at `-count=10`):
- `TestRecoverFailedHeadlessTurnRequeuesExternalActionBeforeBlocking`
- `TestEnsureDefaultOfficeMembersSeedsWhenEmpty`
- `TestTelegramTransportChatMap` (innocent victim — race detector blames the next test that runs)
- `TestResumeInFlightWorkTUIClaudeRoutesHeadless`
- `TestHeadlessQueue_PopulatedAfterEnqueue`

The race is real, just usually invisible without `-race` because the worker goroutine reads stale state without surfacing it.

## Production fix

`brokerStatePath` and `headlessCodexRunTurn` go from plain `var func(...)` to atomic-pointer-backed function calls.

- The call shape is preserved: `brokerStatePath()` and `headlessCodexRunTurn(...)` still work the same way at every call site.
- The override slot is an `atomic.Pointer[func(...)]`. Lookup falls back to a `defaultX` impl when no override is installed.
- Lock-free read path, no overhead in the steady state, minimal diff in production code (51 lines added across 2 files).

## Test helpers

Two new helpers in `test_support.go` replace the four-line save-swap-restore pattern:

\`\`\`go
setBrokerStatePathForTest(t, fn)
setHeadlessCodexRunTurnForTest(t, fn)
\`\`\`

Both swap the override under `atomic.Pointer.Store` and register a `t.Cleanup` that restores the prior override. Cleanup runs after every goroutine the test spawned has finished or panicked — closing the race window the old `defer` pattern left open.

## Test rewrite

26 test files mechanically migrated from:

\`\`\`go
oldFn := X
X = customFn
defer func() { X = oldFn }()
\`\`\`

to:

\`\`\`go
setXForTest(t, customFn)
\`\`\`

Net test-side diff is −618 / +326 because the boilerplate collapses. One test (`TestRecoverFailedHeadlessTurnRequeuesExternalActionBeforeBlocking`) had a separate bug: it read `l.headlessQueues[\"operator\"]` without taking `l.headlessMu`, racing with the locked drain in `beginHeadlessCodexTurn`. Fixed with a locked snapshot read.

## Verification

| Check | Result |
|---|---|
| \`go build ./...\` | ✅ clean |
| \`gofmt -l internal/team/\` | ✅ empty |
| \`go vet ./internal/team/...\` | ✅ clean |
| \`go test ./internal/team/ -race -count=1\` (~80s) | ✅ green |
| \`go test ./internal/team/ -race -count=10\` on previously-flaky tests | ✅ green |
| \`go run ./cmd/bench-slice-1\` | ✅ 100% pass, ship gate green |

## Test plan

- [x] Local \`go test ./internal/team/ -race -count=1\` green
- [x] Local \`go test ./internal/team/ -race -count=10 -run 'TestResume|TestTelegram|TestRecover|TestHeadlessQueue|TestEnsure'\` green
- [x] Bench gate (\`bench-slice-1\`) still 100%
- [ ] CI \`-race\` lane green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)