### PR TITLE
feat(ui): dark mode with nex-dark theme and header toggle

### DIFF
--- a/web/public/themes/nex-dark.css
+++ b/web/public/themes/nex-dark.css
@@ -1,0 +1,71 @@
+/* ═══════════════════════════════════════════════════════════════
+   WUPHF Theme: Nex Dark
+   Dark variant of the Nex theme. Structural rules live in nex.css
+   (scoped with [data-theme^="nex"]) and are inherited here.
+   This file only overrides the semantic token layer.
+   ═══════════════════════════════════════════════════════════════ */
+
+@import url('./nex.css');
+
+html[data-theme="nex-dark"] {
+  /* ── Ramp overrides (reuse same palette, just reference different stops) ── */
+
+  /* ── Overlays flipped for dark surface ── */
+  --overlay-soft:         rgba(255, 255, 255, 0.04);
+  --overlay:              rgba(255, 255, 255, 0.08);
+  --overlay-strong:       rgba(255, 255, 255, 0.16);
+  --scrim:                rgba(0, 0, 0, 0.7);
+  --overlay-white-soft:   rgba(255, 255, 255, 0.06);
+  --overlay-white:        rgba(255, 255, 255, 0.12);
+  --overlay-white-strong: rgba(255, 255, 255, 0.32);
+
+  /* ── Semantic aliases ── */
+  --bg:             #111213;
+  --bg-warm:        #191a1b;
+  --bg-subtle:      #0d0e0f;
+  --bg-card:        #151617;
+  --text:           #e9eaeb;
+  --text-secondary: #aeb1b2;
+  --text-tertiary:  #686c6e;
+  --text-disabled:  #434647;
+
+  /* accent stays the same purple/tertiary */
+
+  --border:         #1e2022;
+  --border-light:   #171819;
+  --border-dark:    #2a2d2f;
+  --border-strong:  #434647;
+
+  /* ── Sidebar – keep purple but use a deeper shade ── */
+  --nex-sidebar:             #4a1f70;
+  --nex-sidebar-hover:       rgba(255, 255, 255, 0.08);
+  --nex-sidebar-active:      var(--olive-400);
+  --nex-sidebar-text:        rgba(255, 255, 255, 0.65);
+  --nex-sidebar-text-active: #FFFFFF;
+}
+
+/* ── Override hard-coded message text color (not a CSS variable in nex.css) ── */
+html[data-theme="nex-dark"] .message-text {
+  color: #c8cacc;
+}
+
+/* ── Composer inner border slightly lighter for dark bg ── */
+html[data-theme="nex-dark"] .composer-inner {
+  background: #191a1b;
+  border-color: #2a2d2f;
+}
+
+/* ── Sidebar bottom matches deeper dark ── */
+html[data-theme="nex-dark"] .sidebar-bottom {
+  background: #4a1f70;
+}
+
+/* ── Sidebar sticky header ── */
+html[data-theme="nex-dark"] .sidebar-header {
+  background: #4a1f70;
+}
+
+/* ── Message hover on dark bg ── */
+html[data-theme="nex-dark"] .message:hover {
+  background: #191a1b;
+}

--- a/web/public/themes/nex.css
+++ b/web/public/themes/nex.css
@@ -126,23 +126,23 @@ html[data-theme="nex"] {
 }
 
 /* ═══ BASE ═══ */
-html[data-theme="nex"] body {
+html[data-theme^="nex"] body {
   background: var(--bg);
   font-family: var(--font-sans);
   color: var(--text);
 }
 
 /* ═══ SCROLLBAR ═══ */
-html[data-theme="nex"] ::-webkit-scrollbar { width: 6px; height: 6px; }
-html[data-theme="nex"] ::-webkit-scrollbar-track { background: transparent; }
-html[data-theme="nex"] ::-webkit-scrollbar-thumb {
+html[data-theme^="nex"] ::-webkit-scrollbar { width: 6px; height: 6px; }
+html[data-theme^="nex"] ::-webkit-scrollbar-track { background: transparent; }
+html[data-theme^="nex"] ::-webkit-scrollbar-thumb {
   background: var(--border-dark);
   border-radius: 3px;
 }
-html[data-theme="nex"] ::-webkit-scrollbar-thumb:hover { background: var(--border-dark); }
+html[data-theme^="nex"] ::-webkit-scrollbar-thumb:hover { background: var(--border-dark); }
 
 /* ═══ SELECTION ═══ */
-html[data-theme="nex"] ::selection {
+html[data-theme^="nex"] ::selection {
   background: rgba(6, 157, 228, 0.20);
   color: var(--text);
 }
@@ -150,53 +150,53 @@ html[data-theme="nex"] ::selection {
 /* ═══════════════════════════════════════
    SIDEBAR
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .sidebar {
+html[data-theme^="nex"] .sidebar {
   background: var(--nex-sidebar);
   border-right: 1px solid rgba(0, 0, 0, 0.12);
   display: flex;
   flex-direction: column;
   overflow: hidden;
 }
-html[data-theme="nex"] .sidebar .sidebar-logo { color: #FFFFFF; }
-html[data-theme="nex"] .sidebar .sidebar-section-title { color: rgba(255, 255, 255, 0.55); }
-html[data-theme="nex"] .sidebar .sidebar-section-toggle:hover { color: #FFFFFF; }
-html[data-theme="nex"] .sidebar .sidebar-icon-btn { color: rgba(255, 255, 255, 0.78); }
-html[data-theme="nex"] .sidebar .sidebar-icon-btn:hover { background: rgba(159, 77, 191, 0.5); color: #FFFFFF; }
-html[data-theme="nex"] .sidebar .sidebar-icon-btn.active { background: rgba(255, 255, 255, 0.16); color: #FFFFFF; }
-html[data-theme="nex"] .sidebar .sidebar-icon-btn.active:hover { background: rgba(255, 255, 255, 0.22); }
-html[data-theme="nex"] .sidebar .sidebar-header { border-bottom-color: rgba(255, 255, 255, 0.08); }
-html[data-theme="nex"] .sidebar .sidebar-scroll-wrap.is-agents { border-bottom-color: rgba(255, 255, 255, 0.08); }
-html[data-theme="nex"] .sidebar .sidebar-section + .sidebar-section,
-html[data-theme="nex"] .sidebar .sidebar-agents + .sidebar-section,
-html[data-theme="nex"] .sidebar .sidebar-channels + .sidebar-section,
-html[data-theme="nex"] .sidebar .sidebar-apps + .sidebar-section { border-top-color: rgba(255, 255, 255, 0.08); }
-html[data-theme="nex"] .sidebar .sidebar-agent-task,
-html[data-theme="nex"] .sidebar .sidebar-agent-activity { color: rgba(255, 255, 255, 0.45); }
-html[data-theme="nex"] .sidebar .usage-toggle { color: rgba(255, 255, 255, 0.78); border-top-color: rgba(255, 255, 255, 0.08); }
-html[data-theme="nex"] .sidebar .usage-toggle:hover { color: #FFFFFF; background: rgba(159, 77, 191, 0.5); }
-html[data-theme="nex"] .sidebar .usage-toggle.open { background: #22d3ee; color: #0b3a44; border-top-color: rgba(0, 0, 0, 0.08); }
-html[data-theme="nex"] .sidebar .usage-toggle.open > span,
-html[data-theme="nex"] .sidebar .usage-toggle.open > svg { color: #0b3a44; stroke: #0b3a44; }
-html[data-theme="nex"] .sidebar .sidebar-add-btn { color: rgba(255, 255, 255, 0.55); }
-html[data-theme="nex"] .sidebar .sidebar-add-btn:hover { color: #FFFFFF; }
-html[data-theme="nex"] .sidebar { --sidebar-fade-color: #612a92; }
-html[data-theme="nex"] .sidebar .usage-panel { color: rgba(255, 255, 255, 0.78); }
-html[data-theme="nex"] .sidebar .usage-table th { color: rgba(255, 255, 255, 0.55); border-bottom-color: rgba(255, 255, 255, 0.12); }
-html[data-theme="nex"] .sidebar .usage-table td { color: rgba(255, 255, 255, 0.78); }
-html[data-theme="nex"] .sidebar .usage-total { color: #FFFFFF; border-top-color: rgba(255, 255, 255, 0.12); }
-html[data-theme="nex"] .sidebar .usage-total-cost { color: #FFFFFF; }
-html[data-theme="nex"] .sidebar .usage-toggle > span { color: #FFFFFF; }
-html[data-theme="nex"] .sidebar .usage-panel.open { background: #22d3ee; color: #0b3a44; }
-html[data-theme="nex"] .sidebar .usage-panel.open .usage-table th { color: rgba(11, 58, 68, 0.65); border-bottom-color: rgba(11, 58, 68, 0.18); }
-html[data-theme="nex"] .sidebar .usage-panel.open .usage-table td { color: #0b3a44; }
-html[data-theme="nex"] .sidebar .usage-panel.open .usage-total { color: #0b3a44; border-top-color: rgba(11, 58, 68, 0.18); }
-html[data-theme="nex"] .sidebar .usage-panel.open .usage-total-cost { color: #0b3a44; }
-html[data-theme="nex"] .sidebar .sidebar-summary { color: rgba(255, 255, 255, 0.55); }
-html[data-theme="nex"] .sidebar .sidebar-hint { color: rgba(255, 255, 255, 0.55); }
-html[data-theme="nex"] .sidebar .sidebar-agent-name { color: inherit; }
+html[data-theme^="nex"] .sidebar .sidebar-logo { color: #FFFFFF; }
+html[data-theme^="nex"] .sidebar .sidebar-section-title { color: rgba(255, 255, 255, 0.55); }
+html[data-theme^="nex"] .sidebar .sidebar-section-toggle:hover { color: #FFFFFF; }
+html[data-theme^="nex"] .sidebar .sidebar-icon-btn { color: rgba(255, 255, 255, 0.78); }
+html[data-theme^="nex"] .sidebar .sidebar-icon-btn:hover { background: rgba(159, 77, 191, 0.5); color: #FFFFFF; }
+html[data-theme^="nex"] .sidebar .sidebar-icon-btn.active { background: rgba(255, 255, 255, 0.16); color: #FFFFFF; }
+html[data-theme^="nex"] .sidebar .sidebar-icon-btn.active:hover { background: rgba(255, 255, 255, 0.22); }
+html[data-theme^="nex"] .sidebar .sidebar-header { border-bottom-color: rgba(255, 255, 255, 0.08); }
+html[data-theme^="nex"] .sidebar .sidebar-scroll-wrap.is-agents { border-bottom-color: rgba(255, 255, 255, 0.08); }
+html[data-theme^="nex"] .sidebar .sidebar-section + .sidebar-section,
+html[data-theme^="nex"] .sidebar .sidebar-agents + .sidebar-section,
+html[data-theme^="nex"] .sidebar .sidebar-channels + .sidebar-section,
+html[data-theme^="nex"] .sidebar .sidebar-apps + .sidebar-section { border-top-color: rgba(255, 255, 255, 0.08); }
+html[data-theme^="nex"] .sidebar .sidebar-agent-task,
+html[data-theme^="nex"] .sidebar .sidebar-agent-activity { color: rgba(255, 255, 255, 0.45); }
+html[data-theme^="nex"] .sidebar .usage-toggle { color: rgba(255, 255, 255, 0.78); border-top-color: rgba(255, 255, 255, 0.08); }
+html[data-theme^="nex"] .sidebar .usage-toggle:hover { color: #FFFFFF; background: rgba(159, 77, 191, 0.5); }
+html[data-theme^="nex"] .sidebar .usage-toggle.open { background: #22d3ee; color: #0b3a44; border-top-color: rgba(0, 0, 0, 0.08); }
+html[data-theme^="nex"] .sidebar .usage-toggle.open > span,
+html[data-theme^="nex"] .sidebar .usage-toggle.open > svg { color: #0b3a44; stroke: #0b3a44; }
+html[data-theme^="nex"] .sidebar .sidebar-add-btn { color: rgba(255, 255, 255, 0.55); }
+html[data-theme^="nex"] .sidebar .sidebar-add-btn:hover { color: #FFFFFF; }
+html[data-theme^="nex"] .sidebar { --sidebar-fade-color: #612a92; }
+html[data-theme^="nex"] .sidebar .usage-panel { color: rgba(255, 255, 255, 0.78); }
+html[data-theme^="nex"] .sidebar .usage-table th { color: rgba(255, 255, 255, 0.55); border-bottom-color: rgba(255, 255, 255, 0.12); }
+html[data-theme^="nex"] .sidebar .usage-table td { color: rgba(255, 255, 255, 0.78); }
+html[data-theme^="nex"] .sidebar .usage-total { color: #FFFFFF; border-top-color: rgba(255, 255, 255, 0.12); }
+html[data-theme^="nex"] .sidebar .usage-total-cost { color: #FFFFFF; }
+html[data-theme^="nex"] .sidebar .usage-toggle > span { color: #FFFFFF; }
+html[data-theme^="nex"] .sidebar .usage-panel.open { background: #22d3ee; color: #0b3a44; }
+html[data-theme^="nex"] .sidebar .usage-panel.open .usage-table th { color: rgba(11, 58, 68, 0.65); border-bottom-color: rgba(11, 58, 68, 0.18); }
+html[data-theme^="nex"] .sidebar .usage-panel.open .usage-table td { color: #0b3a44; }
+html[data-theme^="nex"] .sidebar .usage-panel.open .usage-total { color: #0b3a44; border-top-color: rgba(11, 58, 68, 0.18); }
+html[data-theme^="nex"] .sidebar .usage-panel.open .usage-total-cost { color: #0b3a44; }
+html[data-theme^="nex"] .sidebar .sidebar-summary { color: rgba(255, 255, 255, 0.55); }
+html[data-theme^="nex"] .sidebar .sidebar-hint { color: rgba(255, 255, 255, 0.55); }
+html[data-theme^="nex"] .sidebar .sidebar-agent-name { color: inherit; }
 
 /* ── Sticky header ── */
-html[data-theme="nex"] .sidebar-header {
+html[data-theme^="nex"] .sidebar-header {
   background: var(--nex-sidebar);
   border-bottom: 1px solid var(--border);
   padding: 12px 20px;
@@ -205,7 +205,7 @@ html[data-theme="nex"] .sidebar-header {
   z-index: 10;
   flex-shrink: 0;
 }
-html[data-theme="nex"] .sidebar-logo {
+html[data-theme^="nex"] .sidebar-logo {
   font-family: var(--font-sans);
   font-size: 17px;
   font-weight: 800;
@@ -214,27 +214,27 @@ html[data-theme="nex"] .sidebar-logo {
   letter-spacing: -0.02em;
   cursor: pointer;
 }
-html[data-theme="nex"] .sidebar-header .sidebar-btn {
+html[data-theme^="nex"] .sidebar-header .sidebar-btn {
   color: var(--nex-sidebar-text);
 }
-html[data-theme="nex"] .sidebar-header .sidebar-btn:hover {
+html[data-theme^="nex"] .sidebar-header .sidebar-btn:hover {
   background: var(--nex-sidebar-hover);
   color: var(--text);
 }
 
 /* ── Summary & hint ── */
-html[data-theme="nex"] .sidebar-summary {
+html[data-theme^="nex"] .sidebar-summary {
   padding: 6px 20px 2px;
   font-size: 11px;
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .sidebar-hint {
+html[data-theme^="nex"] .sidebar-hint {
   padding: 0 20px 6px;
   font-size: 11px;
 }
 
 /* ── Section titles ── (padding defined in layout.css) */
-html[data-theme="nex"] .sidebar-section-title {
+html[data-theme^="nex"] .sidebar-section-title {
   color: var(--text-tertiary);
   font-family: var(--font-sans);
   font-size: 11px;
@@ -248,32 +248,32 @@ html[data-theme="nex"] .sidebar-section-title {
   user-select: none;
   margin-bottom: 2px;
 }
-html[data-theme="nex"] .sidebar .sidebar-section-title:hover {
+html[data-theme^="nex"] .sidebar .sidebar-section-title:hover {
   color: #FFFFFF;
 }
 
 /* ── Scrollable middle area (layout.css owns padding + overflow) ── */
 
 /* ── Sidebar items & agents (color/typography only; layout in layout.css) ── */
-html[data-theme="nex"] .sidebar-item,
-html[data-theme="nex"] .sidebar-agent {
+html[data-theme^="nex"] .sidebar-item,
+html[data-theme^="nex"] .sidebar-agent {
   color: var(--nex-sidebar-text);
   font-family: var(--font-sans);
   transition: background 0.1s, color 0.1s;
 }
-html[data-theme="nex"] .sidebar-item:hover,
-html[data-theme="nex"] .sidebar-agent:hover {
+html[data-theme^="nex"] .sidebar-item:hover,
+html[data-theme^="nex"] .sidebar-agent:hover {
   background: var(--nex-sidebar-hover);
   color: var(--nex-sidebar-text-active);
 }
-html[data-theme="nex"] .sidebar-item.active,
-html[data-theme="nex"] .sidebar-agent.active {
+html[data-theme^="nex"] .sidebar-item.active,
+html[data-theme^="nex"] .sidebar-agent.active {
   background: var(--cyan-400);
   color: #0b3a44;
   font-weight: 600;
 }
 
-html[data-theme="nex"] .sidebar-item-icon {
+html[data-theme^="nex"] .sidebar-item-icon {
   font-size: 15px;
   font-weight: 400;
   color: inherit;
@@ -281,7 +281,7 @@ html[data-theme="nex"] .sidebar-item-icon {
   height: 16px;
   flex-shrink: 0;
 }
-html[data-theme="nex"] .sidebar-item-emoji {
+html[data-theme^="nex"] .sidebar-item-emoji {
   font-size: 15px;
   width: 20px;
   text-align: center;
@@ -289,39 +289,39 @@ html[data-theme="nex"] .sidebar-item-emoji {
 }
 
 /* ── Agent row internals (layout from layout.css) ── */
-html[data-theme="nex"] .sidebar-agent-name {
+html[data-theme^="nex"] .sidebar-agent-name {
   white-space: nowrap;
 }
-html[data-theme="nex"] .sidebar-agent-task,
-html[data-theme="nex"] .sidebar-agent-activity {
+html[data-theme^="nex"] .sidebar-agent-task,
+html[data-theme^="nex"] .sidebar-agent-activity {
   font-size: 11px;
   color: var(--text-tertiary);
   max-width: none;
 }
-html[data-theme="nex"] .sidebar-agent-stream {
+html[data-theme^="nex"] .sidebar-agent-stream {
   font-size: 11px;
   color: var(--accent);
   max-width: none;
 }
 
 /* ── Status dot ── */
-html[data-theme="nex"] .status-dot {
+html[data-theme^="nex"] .status-dot {
   width: 6px;
   height: 6px;
   flex-shrink: 0;
   margin-left: auto;
 }
-html[data-theme="nex"] .status-dot.active { background: var(--nex-presence); border: none; }
+html[data-theme^="nex"] .status-dot.active { background: var(--nex-presence); border: none; }
 /* In the purple sidebar, drop status category colors and show a single
    presence dot (green = active, translucent white = lurking). */
-html[data-theme="nex"] .sidebar-agent .status-dot { background: rgba(255, 255, 255, 0.35); }
-html[data-theme="nex"] .sidebar-agent .status-dot.active,
-html[data-theme="nex"] .sidebar-agent .status-dot.shipping,
-html[data-theme="nex"] .sidebar-agent .status-dot.plotting { background: var(--nex-presence); }
-html[data-theme="nex"] .sidebar-agent .status-dot.lurking { background: rgba(255, 255, 255, 0.35); }
+html[data-theme^="nex"] .sidebar-agent .status-dot { background: rgba(255, 255, 255, 0.35); }
+html[data-theme^="nex"] .sidebar-agent .status-dot.active,
+html[data-theme^="nex"] .sidebar-agent .status-dot.shipping,
+html[data-theme^="nex"] .sidebar-agent .status-dot.plotting { background: var(--nex-presence); }
+html[data-theme^="nex"] .sidebar-agent .status-dot.lurking { background: rgba(255, 255, 255, 0.35); }
 
 /* ── DM button on agent rows ── */
-html[data-theme="nex"] .sidebar-agent-dm-btn {
+html[data-theme^="nex"] .sidebar-agent-dm-btn {
   font-size: 10px;
   padding: 2px 6px;
   border-radius: var(--radius-sm);
@@ -330,14 +330,14 @@ html[data-theme="nex"] .sidebar-agent-dm-btn {
 }
 
 /* ── Thought indicator (inline, between name and dot) ── */
-html[data-theme="nex"] .sidebar-agent:has(.thought-bubble) {
+html[data-theme^="nex"] .sidebar-agent:has(.thought-bubble) {
   margin-top: 0;
 }
 @keyframes nex-thought-shimmer {
   0%   { left: -50%; }
   100% { left: 150%; }
 }
-html[data-theme="nex"] .thought-bubble {
+html[data-theme^="nex"] .thought-bubble {
   all: unset;
   display: block;
   position: relative;
@@ -357,7 +357,7 @@ html[data-theme="nex"] .thought-bubble {
   mask-image: linear-gradient(to right, #000 0%, #000 70%, transparent 100%);
 }
 /* Light sweep overlay via pseudo-element */
-html[data-theme="nex"] .thought-bubble::after {
+html[data-theme^="nex"] .thought-bubble::after {
   content: '';
   position: absolute;
   top: 0;
@@ -370,48 +370,48 @@ html[data-theme="nex"] .thought-bubble::after {
   animation: nex-thought-shimmer 2s linear infinite;
   mix-blend-mode: overlay;
 }
-html[data-theme="nex"] .sidebar-agent:hover .thought-bubble {
+html[data-theme^="nex"] .sidebar-agent:hover .thought-bubble {
   opacity: 0;
 }
 
 /* ── Add buttons (New Agent / New Channel) ── */
-html[data-theme="nex"] .sidebar-add-btn {
+html[data-theme^="nex"] .sidebar-add-btn {
   color: var(--text-tertiary);
   font-size: 13px;
   gap: 10px;
 }
-html[data-theme="nex"] .sidebar-add-btn:hover {
+html[data-theme^="nex"] .sidebar-add-btn:hover {
   color: var(--text-secondary);
   background: var(--nex-sidebar-hover);
 }
 
 /* ── Header button sizes ── */
-html[data-theme="nex"] .sidebar-btn-sm {
+html[data-theme^="nex"] .sidebar-btn-sm {
   width: 32px;
   height: 32px;
   border-radius: var(--radius-md);
 }
 
 /* ── Sticky bottom bar (color owned by sidebar rules above) ── */
-html[data-theme="nex"] .usage-toggle {
+html[data-theme^="nex"] .usage-toggle {
   flex-shrink: 0;
   font-size: 11px;
 }
-html[data-theme="nex"] .usage-panel {
+html[data-theme^="nex"] .usage-panel {
   flex-shrink: 0;
 }
 
-html[data-theme="nex"] .sidebar-bottom {
+html[data-theme^="nex"] .sidebar-bottom {
   background: var(--nex-sidebar);
   border-top: 1px solid var(--border);
   padding: 10px 16px;
   flex-shrink: 0;
 }
-html[data-theme="nex"] .sidebar-btn {
+html[data-theme^="nex"] .sidebar-btn {
   color: var(--nex-sidebar-text);
 }
 
-html[data-theme="nex"] #theme-switcher {
+html[data-theme^="nex"] #theme-switcher {
   background: var(--bg);
   border: 1px solid var(--border);
   color: var(--text-secondary);
@@ -421,7 +421,7 @@ html[data-theme="nex"] #theme-switcher {
 }
 
 /* ── Sidebar collapse chevron ── */
-html[data-theme="nex"] .sidebar-section-chevron {
+html[data-theme^="nex"] .sidebar-section-chevron {
   font-size: 10px;
   transition: transform 0.15s ease;
   color: inherit;
@@ -430,15 +430,15 @@ html[data-theme="nex"] .sidebar-section-chevron {
   text-align: center;
   flex-shrink: 0;
 }
-html[data-theme="nex"] .sidebar-section-chevron.collapsed { transform: rotate(0deg); }
+html[data-theme^="nex"] .sidebar-section-chevron.collapsed { transform: rotate(0deg); }
 
 /* ── Unread channel ── */
-html[data-theme="nex"] .sidebar-item.unread {
+html[data-theme^="nex"] .sidebar-item.unread {
   color: var(--nex-sidebar-text-active);
   font-weight: 600;
   position: relative;
 }
-html[data-theme="nex"] .sidebar-item.unread::before {
+html[data-theme^="nex"] .sidebar-item.unread::before {
   content: '';
   width: 5px;
   height: 5px;
@@ -451,7 +451,7 @@ html[data-theme="nex"] .sidebar-item.unread::before {
 }
 
 /* ── Workspace dropdown ── */
-html[data-theme="nex"] .workspace-dropdown {
+html[data-theme^="nex"] .workspace-dropdown {
   position: absolute;
   top: 100%;
   left: 8px;
@@ -465,8 +465,8 @@ html[data-theme="nex"] .workspace-dropdown {
   display: none;
   font-family: var(--font-sans);
 }
-html[data-theme="nex"] .workspace-dropdown.open { display: block; }
-html[data-theme="nex"] .workspace-dropdown-item {
+html[data-theme^="nex"] .workspace-dropdown.open { display: block; }
+html[data-theme^="nex"] .workspace-dropdown-item {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -480,24 +480,24 @@ html[data-theme="nex"] .workspace-dropdown-item {
   text-align: left;
   font-family: var(--font-sans);
 }
-html[data-theme="nex"] .workspace-dropdown-item:hover {
+html[data-theme^="nex"] .workspace-dropdown-item:hover {
   background: var(--accent-bg);
   color: var(--accent);
 }
-html[data-theme="nex"] .workspace-dropdown-item .ws-menu-icon {
+html[data-theme^="nex"] .workspace-dropdown-item .ws-menu-icon {
   width: 20px;
   text-align: center;
   flex-shrink: 0;
   font-size: 15px;
 }
-html[data-theme="nex"] .workspace-dropdown-sep {
+html[data-theme^="nex"] .workspace-dropdown-sep {
   height: 1px;
   background: var(--border);
   margin: 4px 0;
 }
 
 /* ── Starred channels ── */
-html[data-theme="nex"] .sidebar-star {
+html[data-theme^="nex"] .sidebar-star {
   opacity: 0;
   cursor: pointer;
   font-size: 13px;
@@ -510,14 +510,14 @@ html[data-theme="nex"] .sidebar-star {
   padding: 0 2px;
   line-height: 1;
 }
-html[data-theme="nex"] .sidebar-item:hover .sidebar-star { opacity: 1; }
-html[data-theme="nex"] .sidebar-star.starred {
+html[data-theme^="nex"] .sidebar-item:hover .sidebar-star { opacity: 1; }
+html[data-theme^="nex"] .sidebar-star.starred {
   opacity: 1;
   color: var(--yellow);
 }
 
 /* ── Sidebar badge (notification count) ── */
-html[data-theme="nex"] .sidebar-badge {
+html[data-theme^="nex"] .sidebar-badge {
   min-width: 18px;
   height: 18px;
   font-size: 10px;
@@ -525,7 +525,7 @@ html[data-theme="nex"] .sidebar-badge {
 }
 
 /* ── Pixel avatar alignment ── */
-html[data-theme="nex"] .pixel-avatar-sidebar {
+html[data-theme^="nex"] .pixel-avatar-sidebar {
   width: 24px;
   height: 24px;
   flex-shrink: 0;
@@ -534,46 +534,46 @@ html[data-theme="nex"] .pixel-avatar-sidebar {
 /* ═══════════════════════════════════════
    MAIN AREA
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .main {
+html[data-theme^="nex"] .main {
   background: var(--bg);
 }
 
 /* ── Channel header ── */
-html[data-theme="nex"] .channel-header {
+html[data-theme^="nex"] .channel-header {
   background: var(--bg);
   border-bottom: 1px solid var(--border);
   backdrop-filter: none;
   padding: 12px 24px;
   min-height: 52px;
 }
-html[data-theme="nex"] .channel-title {
+html[data-theme^="nex"] .channel-title {
   font-family: var(--font-sans);
   font-weight: 700;
   font-size: 16px;
   color: var(--text);
 }
-html[data-theme="nex"] .channel-desc {
+html[data-theme^="nex"] .channel-desc {
   font-size: 13px;
   color: var(--text-tertiary);
 }
 
 /* ── Messages ── */
-html[data-theme="nex"] .messages {
+html[data-theme^="nex"] .messages {
   background: var(--bg);
   padding: 8px 24px;
 }
-html[data-theme="nex"] .message {
+html[data-theme^="nex"] .message {
   padding: 10px 24px;
   gap: 12px;
   border-radius: var(--radius-md);
   margin: 0 -24px;
 }
-html[data-theme="nex"] .message:hover {
+html[data-theme^="nex"] .message:hover {
   background: var(--bg-warm);
 }
 
 /* Avatar */
-html[data-theme="nex"] .message-avatar {
+html[data-theme^="nex"] .message-avatar {
   width: 36px;
   height: 36px;
   border-radius: var(--radius-md);
@@ -582,7 +582,7 @@ html[data-theme="nex"] .message-avatar {
 }
 
 /* Author */
-html[data-theme="nex"] .message-author {
+html[data-theme^="nex"] .message-author {
   font-family: var(--font-sans);
   font-weight: 700;
   font-size: 15px;
@@ -590,28 +590,28 @@ html[data-theme="nex"] .message-author {
 }
 
 /* Message text */
-html[data-theme="nex"] .message-text {
+html[data-theme^="nex"] .message-text {
   font-family: var(--font-sans);
   font-size: 15px;
   line-height: 1.5;
   color: #3B3B3E;
 }
-html[data-theme="nex"] .message-text strong {
+html[data-theme^="nex"] .message-text strong {
   color: var(--text);
   font-weight: 600;
 }
 
 /* Links */
-html[data-theme="nex"] .message-text a {
+html[data-theme^="nex"] .message-text a {
   color: var(--accent);
   text-decoration: none;
 }
-html[data-theme="nex"] .message-text a:hover {
+html[data-theme^="nex"] .message-text a:hover {
   text-decoration: underline;
 }
 
 /* Inline code */
-html[data-theme="nex"] .message-text code {
+html[data-theme^="nex"] .message-text code {
   background: var(--accent-bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
@@ -622,13 +622,13 @@ html[data-theme="nex"] .message-text code {
 }
 
 /* Blockquote */
-html[data-theme="nex"] .msg-blockquote {
+html[data-theme^="nex"] .msg-blockquote {
   border-left-color: var(--border-dark);
   color: var(--text-secondary);
 }
 
 /* Mentions */
-html[data-theme="nex"] .mention {
+html[data-theme^="nex"] .mention {
   background: var(--accent-bg);
   color: var(--accent);
   border-radius: var(--radius-sm);
@@ -640,7 +640,7 @@ html[data-theme="nex"] .mention {
    mention took ~10px more width than the raw text in the textarea and
    the caret fell behind after the first tag. Background highlight only;
    no layout-affecting properties. */
-html[data-theme="nex"] .composer-mirror .mention {
+html[data-theme^="nex"] .composer-mirror .mention {
   display: inline;
   padding: 0;
   font-size: inherit;
@@ -655,7 +655,7 @@ html[data-theme="nex"] .composer-mirror .mention {
 }
 
 /* Timestamps */
-html[data-theme="nex"] .message-time {
+html[data-theme^="nex"] .message-time {
   font-family: var(--font-sans);
   font-size: 11px;
   color: var(--text-tertiary);
@@ -665,42 +665,42 @@ html[data-theme="nex"] .message-time {
 /* Badges — shape/color owned by global.css */
 
 /* System messages */
-html[data-theme="nex"] .message-system-text {
+html[data-theme^="nex"] .message-system-text {
   font-family: var(--font-sans);
   color: var(--text-tertiary);
   font-size: 13px;
 }
 
 /* ── Message action bar ── */
-html[data-theme="nex"] .message-actions {
+html[data-theme^="nex"] .message-actions {
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   padding: 4px;
   background: var(--bg);
 }
-html[data-theme="nex"] .message-action-btn {
+html[data-theme^="nex"] .message-action-btn {
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
 }
-html[data-theme="nex"] .message-action-btn:hover {
+html[data-theme^="nex"] .message-action-btn:hover {
   background: var(--bg-warm);
   color: var(--text);
 }
 
 /* ── Thread link ── */
-html[data-theme="nex"] .message-thread-link {
+html[data-theme^="nex"] .message-thread-link {
   color: var(--accent);
   font-family: var(--font-sans);
   font-size: 13px;
   font-weight: 600;
 }
-html[data-theme="nex"] .message-thread-link:hover {
+html[data-theme^="nex"] .message-thread-link:hover {
   background: var(--accent-bg);
 }
 
 /* Typing indicator */
-html[data-theme="nex"] .typing-indicator {
+html[data-theme^="nex"] .typing-indicator {
   color: var(--text-tertiary);
   font-family: var(--font-sans);
 }
@@ -708,13 +708,13 @@ html[data-theme="nex"] .typing-indicator {
 /* ═══════════════════════════════════════
    COMPOSER
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .composer {
+html[data-theme^="nex"] .composer {
   background: var(--bg);
   border-top: none;
   padding: 0 24px 24px;
 }
 
-html[data-theme="nex"] .composer-inner {
+html[data-theme^="nex"] .composer-inner {
   background: var(--bg);
   border: 1px solid var(--border-dark);
   border-radius: var(--radius-lg);
@@ -722,31 +722,31 @@ html[data-theme="nex"] .composer-inner {
   min-height: 36px;
   transition: border-color 0.15s;
 }
-html[data-theme="nex"] .composer-inner:focus-within {
+html[data-theme^="nex"] .composer-inner:focus-within {
   border-color: var(--accent);
   box-shadow: 0 0 0 1px rgba(6, 157, 228, 0.25);
 }
 /* Both surfaces — textarea + mention-chip mirror — must share font metrics
    so chip positions line up with the raw text the user is typing. */
-html[data-theme="nex"] .composer-input,
-html[data-theme="nex"] .composer-mirror {
+html[data-theme^="nex"] .composer-input,
+html[data-theme^="nex"] .composer-mirror {
   font-family: var(--font-sans);
   font-size: 15px;
   color: var(--text);
 }
-html[data-theme="nex"] .composer-input::placeholder {
+html[data-theme^="nex"] .composer-input::placeholder {
   color: var(--text-tertiary);
 }
 /* When the user has typed a recognised mention, hide the textarea's text
    layer and render chips from the mirror. Caret remains visible via
    caret-color so typing still works. */
-html[data-theme="nex"] .composer-field:has(.mention) .composer-input {
+html[data-theme^="nex"] .composer-field:has(.mention) .composer-input {
   color: transparent;
   caret-color: var(--text);
 }
 
 /* Send button */
-html[data-theme="nex"] .composer-send {
+html[data-theme^="nex"] .composer-send {
   background: var(--cyan-400);
   color: #0b3a44;
   border-radius: var(--radius-md);
@@ -754,11 +754,11 @@ html[data-theme="nex"] .composer-send {
   height: 32px;
   transition: background 0.15s, color 0.15s;
 }
-html[data-theme="nex"] .composer-send:hover:not(:disabled) {
+html[data-theme^="nex"] .composer-send:hover:not(:disabled) {
   background: var(--cyan-500);
   color: #fff;
 }
-html[data-theme="nex"] .composer-send:disabled {
+html[data-theme^="nex"] .composer-send:disabled {
   background: var(--bg-warm);
   color: var(--text-tertiary);
   opacity: 0.55;
@@ -767,59 +767,59 @@ html[data-theme="nex"] .composer-send:disabled {
 /* ═══════════════════════════════════════
    THREAD PANEL
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .thread-panel {
+html[data-theme^="nex"] .thread-panel {
   background: var(--bg);
   border-left: 1px solid var(--border);
   width: 400px;
 }
-html[data-theme="nex"] .thread-panel-header {
+html[data-theme^="nex"] .thread-panel-header {
   padding: 14px 24px;
   border-bottom: 1px solid var(--border);
 }
-html[data-theme="nex"] .thread-panel-title {
+html[data-theme^="nex"] .thread-panel-title {
   font-family: var(--font-sans);
   font-weight: 700;
   font-size: 16px;
   color: var(--text);
 }
-html[data-theme="nex"] .thread-panel-divider {
+html[data-theme^="nex"] .thread-panel-divider {
   color: var(--text-tertiary);
   font-family: var(--font-sans);
   font-weight: 600;
 }
-html[data-theme="nex"] .thread-panel-parent {
+html[data-theme^="nex"] .thread-panel-parent {
   background: var(--bg);
 }
 
 /* ═══════════════════════════════════════
    AGENT PANEL
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .agent-panel {
+html[data-theme^="nex"] .agent-panel {
   background: var(--bg);
   border-left: 1px solid var(--border);
 }
-html[data-theme="nex"] .agent-panel-header {
+html[data-theme^="nex"] .agent-panel-header {
   background: var(--bg);
   border-bottom: none;
   padding: 16px 24px 8px;
 }
-html[data-theme="nex"] .agent-panel-header span {
+html[data-theme^="nex"] .agent-panel-header span {
   font-family: var(--font-sans);
 }
-html[data-theme="nex"] .agent-panel-role {
+html[data-theme^="nex"] .agent-panel-role {
   font-weight: 400;
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .agent-panel-avatar {
+html[data-theme^="nex"] .agent-panel-avatar {
   border-radius: var(--radius-md);
   background: transparent;
 }
-html[data-theme="nex"] .agent-panel-name {
+html[data-theme^="nex"] .agent-panel-name {
   font-family: var(--font-sans);
   font-weight: 700;
   color: var(--text);
 }
-html[data-theme="nex"] .agent-panel-section-title {
+html[data-theme^="nex"] .agent-panel-section-title {
   font-family: var(--font-sans);
   font-weight: 600;
   font-size: 11px;
@@ -827,7 +827,7 @@ html[data-theme="nex"] .agent-panel-section-title {
   letter-spacing: 0.05em;
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .agent-panel-skill {
+html[data-theme^="nex"] .agent-panel-skill {
   border-radius: var(--radius-full);
   font-family: var(--font-sans);
   background: var(--bg-warm);
@@ -839,25 +839,25 @@ html[data-theme="nex"] .agent-panel-skill {
 /* ═══════════════════════════════════════
    BUTTONS
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .btn {
+html[data-theme^="nex"] .btn {
   font-family: var(--font-sans);
 }
-html[data-theme="nex"] .btn-primary {
+html[data-theme^="nex"] .btn-primary {
   background: var(--accent);
   border-radius: var(--radius-md);
   font-weight: 600;
   box-shadow: none;
   color: #FFFFFF;
 }
-html[data-theme="nex"] .btn-primary:hover { background: var(--accent-warm); }
-html[data-theme="nex"] .btn-ghost {
+html[data-theme^="nex"] .btn-primary:hover { background: var(--accent-warm); }
+html[data-theme^="nex"] .btn-ghost {
   border: 1px solid var(--border-dark);
   border-radius: var(--radius-md);
   background: var(--bg);
   color: var(--text);
   font-weight: 600;
 }
-html[data-theme="nex"] .btn-ghost:hover {
+html[data-theme^="nex"] .btn-ghost:hover {
   background: var(--bg-warm);
   border-color: var(--border-dark);
 }
@@ -865,159 +865,159 @@ html[data-theme="nex"] .btn-ghost:hover {
 /* ═══════════════════════════════════════
    ONBOARDING
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .onboarding { background: var(--bg); }
-html[data-theme="nex"] .dot-grid { background-image: none; }
-html[data-theme="nex"] .progress-dot.active { background: var(--accent); }
-html[data-theme="nex"] .progress-dot { background: var(--border-dark); }
-html[data-theme="nex"] .dict-word {
+html[data-theme^="nex"] .onboarding { background: var(--bg); }
+html[data-theme^="nex"] .dot-grid { background-image: none; }
+html[data-theme^="nex"] .progress-dot.active { background: var(--accent); }
+html[data-theme^="nex"] .progress-dot { background: var(--border-dark); }
+html[data-theme^="nex"] .dict-word {
   font-family: var(--font-sans);
   font-style: normal;
   font-weight: 800;
   color: var(--text);
 }
-html[data-theme="nex"] .welcome-tagline {
+html[data-theme^="nex"] .welcome-tagline {
   font-family: var(--font-sans);
   font-style: normal;
   font-weight: 800;
   color: var(--text);
 }
-html[data-theme="nex"] .tagline-gradient {
+html[data-theme^="nex"] .tagline-gradient {
   background: linear-gradient(135deg, var(--accent), #00CCFF);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
-html[data-theme="nex"] .step-title {
+html[data-theme^="nex"] .step-title {
   font-family: var(--font-sans);
   font-style: normal;
   color: var(--text);
 }
-html[data-theme="nex"] .step-desc {
+html[data-theme^="nex"] .step-desc {
   color: var(--text-secondary);
 }
-html[data-theme="nex"] .emoji-backdrop { display: none; }
-html[data-theme="nex"] .card {
+html[data-theme^="nex"] .emoji-backdrop { display: none; }
+html[data-theme^="nex"] .card {
   border-radius: var(--radius-lg);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
   background: var(--bg);
   border-color: var(--border);
 }
-html[data-theme="nex"] .input {
+html[data-theme^="nex"] .input {
   border-radius: var(--radius-md);
   font-family: var(--font-sans);
   background: var(--bg);
   border-color: var(--border-dark);
   color: var(--text);
 }
-html[data-theme="nex"] .input:focus {
+html[data-theme^="nex"] .input:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 1px rgba(6, 157, 228, 0.25);
 }
-html[data-theme="nex"] .label {
+html[data-theme^="nex"] .label {
   font-family: var(--font-sans);
   font-weight: 600;
   color: var(--text);
 }
 
 /* Team cards (onboarding) */
-html[data-theme="nex"] .team-card {
+html[data-theme^="nex"] .team-card {
   background: var(--bg);
   border-color: var(--border);
   color: var(--text);
   border-radius: var(--radius-lg);
 }
-html[data-theme="nex"] .team-card:hover {
+html[data-theme^="nex"] .team-card:hover {
   border-color: var(--border-dark);
 }
-html[data-theme="nex"] .team-card.selected {
+html[data-theme^="nex"] .team-card.selected {
   border-color: var(--accent);
   background: var(--accent-bg);
 }
 
 /* Size buttons (onboarding) */
-html[data-theme="nex"] .size-btn {
+html[data-theme^="nex"] .size-btn {
   background: var(--bg);
   border-color: var(--border);
   color: var(--text);
   border-radius: var(--radius-md);
 }
-html[data-theme="nex"] .size-btn.selected {
+html[data-theme^="nex"] .size-btn.selected {
   border-color: var(--accent);
   background: var(--accent-bg);
   color: var(--accent);
 }
 
 /* Launch screen */
-html[data-theme="nex"] .launch-screen { background: var(--bg-warm); }
-html[data-theme="nex"] .launch-spinner {
+html[data-theme^="nex"] .launch-screen { background: var(--bg-warm); }
+html[data-theme^="nex"] .launch-spinner {
   border-color: var(--border);
   border-top-color: var(--accent);
 }
-html[data-theme="nex"] .launch-text {
+html[data-theme^="nex"] .launch-text {
   font-family: var(--font-sans);
   font-style: normal;
   color: var(--text);
   font-weight: 800;
 }
-html[data-theme="nex"] .launch-sub { color: var(--text-tertiary); }
+html[data-theme^="nex"] .launch-sub { color: var(--text-tertiary); }
 
 /* ═══════════════════════════════════════
    COMMAND PALETTE
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .cmd-palette-overlay {
+html[data-theme^="nex"] .cmd-palette-overlay {
   background: rgba(0, 0, 0, 0.3);
 }
-html[data-theme="nex"] .cmd-palette {
+html[data-theme^="nex"] .cmd-palette {
   background: var(--bg);
   border: 1px solid var(--border);
   box-shadow: 0 20px 60px rgba(0, 0, 0, 0.15);
   border-radius: var(--radius-lg);
 }
-html[data-theme="nex"] .cmd-palette-input-wrap {
+html[data-theme^="nex"] .cmd-palette-input-wrap {
   border-bottom: 1px solid var(--border);
 }
-html[data-theme="nex"] .cmd-palette-input-wrap svg {
+html[data-theme^="nex"] .cmd-palette-input-wrap svg {
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .cmd-palette-input {
+html[data-theme^="nex"] .cmd-palette-input {
   color: var(--text);
 }
-html[data-theme="nex"] .cmd-palette-input::placeholder {
+html[data-theme^="nex"] .cmd-palette-input::placeholder {
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .cmd-palette-kbd {
+html[data-theme^="nex"] .cmd-palette-kbd {
   color: var(--text-tertiary);
   background: var(--bg-warm);
   border-color: var(--border);
   border-radius: var(--radius-sm);
 }
-html[data-theme="nex"] .cmd-palette-group-title {
+html[data-theme^="nex"] .cmd-palette-group-title {
   color: var(--text-tertiary);
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-html[data-theme="nex"] .cmd-palette-item:hover,
-html[data-theme="nex"] .cmd-palette-item.selected {
+html[data-theme^="nex"] .cmd-palette-item:hover,
+html[data-theme^="nex"] .cmd-palette-item.selected {
   background: var(--accent-bg);
 }
-html[data-theme="nex"] .cmd-palette-item-icon {
+html[data-theme^="nex"] .cmd-palette-item-icon {
   background: var(--bg-warm);
   color: var(--text-secondary);
   border-radius: var(--radius-md);
 }
-html[data-theme="nex"] .cmd-palette-item-label {
+html[data-theme^="nex"] .cmd-palette-item-label {
   color: var(--text);
 }
-html[data-theme="nex"] .cmd-palette-item-desc {
+html[data-theme^="nex"] .cmd-palette-item-desc {
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .cmd-palette-item-shortcut {
+html[data-theme^="nex"] .cmd-palette-item-shortcut {
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .cmd-palette-empty {
+html[data-theme^="nex"] .cmd-palette-empty {
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .cmd-palette-footer {
+html[data-theme^="nex"] .cmd-palette-footer {
   border-top: 1px solid var(--border);
   color: var(--text-tertiary);
 }
@@ -1025,163 +1025,163 @@ html[data-theme="nex"] .cmd-palette-footer {
 /* ═══════════════════════════════════════
    TASK BOARD
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .task-board {
+html[data-theme^="nex"] .task-board {
   background: var(--bg);
 }
-html[data-theme="nex"] .task-column-header {
+html[data-theme^="nex"] .task-column-header {
   color: var(--text-tertiary);
   border-bottom-color: var(--border);
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-html[data-theme="nex"] .task-column-count {
+html[data-theme^="nex"] .task-column-count {
   background: var(--bg-warm);
   color: var(--text-secondary);
   border-radius: var(--radius-full);
 }
-html[data-theme="nex"] .task-card {
+html[data-theme^="nex"] .task-card {
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
 }
-html[data-theme="nex"] .task-card:hover {
+html[data-theme^="nex"] .task-card:hover {
   border-color: var(--border-dark);
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
-html[data-theme="nex"] .task-card-title {
+html[data-theme^="nex"] .task-card-title {
   color: var(--text);
 }
-html[data-theme="nex"] .task-card-meta {
+html[data-theme^="nex"] .task-card-meta {
   color: var(--text-tertiary);
 }
 
 /* ═══════════════════════════════════════
    REQUEST LIST
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .request-list {
+html[data-theme^="nex"] .request-list {
   background: var(--bg);
 }
-html[data-theme="nex"] .request-list-header {
+html[data-theme^="nex"] .request-list-header {
   color: var(--text-tertiary);
   border-bottom-color: var(--border);
 }
-html[data-theme="nex"] .request-item {
+html[data-theme^="nex"] .request-item {
   background: var(--bg);
   border-color: var(--border);
   border-radius: var(--radius-lg);
 }
-html[data-theme="nex"] .request-item:hover {
+html[data-theme^="nex"] .request-item:hover {
   border-color: var(--border-dark);
 }
-html[data-theme="nex"] .request-item-from {
+html[data-theme^="nex"] .request-item-from {
   color: var(--text);
 }
-html[data-theme="nex"] .request-kind-approval { background: var(--yellow-bg); color: var(--yellow); }
-html[data-theme="nex"] .request-kind-confirm  { background: var(--accent-bg); color: var(--accent); }
-html[data-theme="nex"] .request-kind-secret   { background: var(--red-bg); color: var(--red); }
-html[data-theme="nex"] .request-kind-input    { background: var(--purple-bg); color: var(--purple); }
-html[data-theme="nex"] .request-item-question {
+html[data-theme^="nex"] .request-kind-approval { background: var(--yellow-bg); color: var(--yellow); }
+html[data-theme^="nex"] .request-kind-confirm  { background: var(--accent-bg); color: var(--accent); }
+html[data-theme^="nex"] .request-kind-secret   { background: var(--red-bg); color: var(--red); }
+html[data-theme^="nex"] .request-kind-input    { background: var(--purple-bg); color: var(--purple); }
+html[data-theme^="nex"] .request-item-question {
   color: var(--text);
 }
-html[data-theme="nex"] .request-item-timing {
+html[data-theme^="nex"] .request-item-timing {
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .request-empty {
+html[data-theme^="nex"] .request-empty {
   color: var(--text-tertiary);
 }
 
 /* ═══════════════════════════════════════
    RECOVERY VIEW
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .recovery-panel {
+html[data-theme^="nex"] .recovery-panel {
   background: var(--bg);
 }
-html[data-theme="nex"] .recovery-card {
+html[data-theme^="nex"] .recovery-card {
   background: var(--bg);
   border-color: var(--border);
   border-radius: var(--radius-lg);
 }
-html[data-theme="nex"] .recovery-card-title {
+html[data-theme^="nex"] .recovery-card-title {
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .recovery-card-body {
+html[data-theme^="nex"] .recovery-card-body {
   color: var(--text-secondary);
 }
-html[data-theme="nex"] .recovery-stat-label {
+html[data-theme^="nex"] .recovery-stat-label {
   color: var(--text-secondary);
 }
-html[data-theme="nex"] .recovery-stat-value {
+html[data-theme^="nex"] .recovery-stat-value {
   color: var(--text);
 }
-html[data-theme="nex"] .recovery-task {
+html[data-theme^="nex"] .recovery-task {
   border-bottom-color: var(--border-light);
 }
 
 /* ═══════════════════════════════════════
    CONFIRMATION DIALOG
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .confirm-overlay {
+html[data-theme^="nex"] .confirm-overlay {
   background: rgba(0, 0, 0, 0.3);
 }
-html[data-theme="nex"] .confirm-card {
+html[data-theme^="nex"] .confirm-card {
   background: var(--bg);
   border: 1px solid var(--border);
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
   border-radius: var(--radius-lg);
 }
-html[data-theme="nex"] .confirm-title {
+html[data-theme^="nex"] .confirm-title {
   color: var(--text);
 }
-html[data-theme="nex"] .confirm-message {
+html[data-theme^="nex"] .confirm-message {
   color: var(--text-secondary);
 }
 
 /* ═══════════════════════════════════════
    INTERVIEW / POLL DIALOG
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .interview-overlay {
+html[data-theme^="nex"] .interview-overlay {
   background: rgba(0, 0, 0, 0.3);
 }
-html[data-theme="nex"] .interview-card {
+html[data-theme^="nex"] .interview-card {
   background: var(--bg);
   border: 1px solid var(--border);
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
   border-radius: var(--radius-lg);
 }
-html[data-theme="nex"] .interview-title {
+html[data-theme^="nex"] .interview-title {
   color: var(--text);
 }
-html[data-theme="nex"] .interview-question {
+html[data-theme^="nex"] .interview-question {
   color: var(--text-secondary);
 }
-html[data-theme="nex"] .interview-phase {
+html[data-theme^="nex"] .interview-phase {
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .interview-option {
+html[data-theme^="nex"] .interview-option {
   background: var(--bg);
   border-color: var(--border);
   color: var(--text);
   border-radius: var(--radius-md);
 }
-html[data-theme="nex"] .interview-option:hover {
+html[data-theme^="nex"] .interview-option:hover {
   border-color: var(--border-dark);
   background: var(--bg-warm);
 }
-html[data-theme="nex"] .interview-option.selected {
+html[data-theme^="nex"] .interview-option.selected {
   border-color: var(--accent);
   background: var(--accent-bg);
 }
-html[data-theme="nex"] .interview-option-radio {
+html[data-theme^="nex"] .interview-option-radio {
   border-color: var(--border-dark);
 }
-html[data-theme="nex"] .interview-text {
+html[data-theme^="nex"] .interview-text {
   background: var(--bg);
   border-color: var(--border-dark);
   color: var(--text);
   border-radius: var(--radius-md);
 }
-html[data-theme="nex"] .interview-text:focus {
+html[data-theme^="nex"] .interview-text:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 1px rgba(6, 157, 228, 0.25);
 }
@@ -1189,27 +1189,27 @@ html[data-theme="nex"] .interview-text:focus {
 /* ═══════════════════════════════════════
    AUTOCOMPLETE
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .autocomplete {
+html[data-theme^="nex"] .autocomplete {
   background: var(--bg);
   border: 1px solid var(--border);
   box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.08);
   border-radius: var(--radius-lg);
 }
-html[data-theme="nex"] .autocomplete-item:hover,
-html[data-theme="nex"] .autocomplete-item.selected {
+html[data-theme^="nex"] .autocomplete-item:hover,
+html[data-theme^="nex"] .autocomplete-item.selected {
   background: var(--accent-bg);
 }
-html[data-theme="nex"] .autocomplete-item-label {
+html[data-theme^="nex"] .autocomplete-item-label {
   color: var(--text);
 }
-html[data-theme="nex"] .autocomplete-item-desc {
+html[data-theme^="nex"] .autocomplete-item-desc {
   color: var(--text-tertiary);
 }
 
 /* ═══════════════════════════════════════
    DISCONNECT BANNER
    ═══════════════════════════════════════ */
-html[data-theme="nex"] #disconnect-banner {
+html[data-theme^="nex"] #disconnect-banner {
   border-radius: var(--radius-md);
   background: var(--yellow-bg);
   border-color: var(--yellow);
@@ -1219,11 +1219,11 @@ html[data-theme="nex"] #disconnect-banner {
 /* ═══════════════════════════════════════
    SIDEBAR – TEAM ROW
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .sidebar-item-team {
+html[data-theme^="nex"] .sidebar-item-team {
   padding: 8px 16px;
   margin-top: 6px;
 }
-html[data-theme="nex"] .sidebar-item-team i {
+html[data-theme^="nex"] .sidebar-item-team i {
   font-size: 20px;
   color: var(--text-secondary);
 }
@@ -1231,22 +1231,22 @@ html[data-theme="nex"] .sidebar-item-team i {
 /* ═══════════════════════════════════════
    SIDEBAR – FLOATING CHECKLIST
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .sidebar-checklist-float {
+html[data-theme^="nex"] .sidebar-checklist-float {
   background: color-mix(in srgb, var(--bg-warm) 85%, transparent);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-top: 1px solid var(--border);
 }
-html[data-theme="nex"] .sidebar-checklist-float .checklist-header {
+html[data-theme^="nex"] .sidebar-checklist-float .checklist-header {
   color: var(--text);
   font-family: var(--font-sans);
   font-size: 13px;
   font-weight: 600;
 }
-html[data-theme="nex"] .sidebar-checklist-float .sidebar-btn-close {
+html[data-theme^="nex"] .sidebar-checklist-float .sidebar-btn-close {
   color: var(--text-tertiary);
 }
-html[data-theme="nex"] .sidebar-checklist-float .sidebar-btn-close:hover {
+html[data-theme^="nex"] .sidebar-checklist-float .sidebar-btn-close:hover {
   color: var(--text);
   background: var(--nex-sidebar-hover);
 }
@@ -1254,23 +1254,23 @@ html[data-theme="nex"] .sidebar-checklist-float .sidebar-btn-close:hover {
 /* ═══════════════════════════════════════
    SIDEBAR – THEME DROPDOWN
    ═══════════════════════════════════════ */
-html[data-theme="nex"] .theme-dropdown {
+html[data-theme^="nex"] .theme-dropdown {
   background: var(--bg);
   border: 1px solid var(--border);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
   border-radius: var(--radius-lg);
 }
-html[data-theme="nex"] .theme-dropdown-item {
+html[data-theme^="nex"] .theme-dropdown-item {
   font-family: var(--font-sans);
   font-size: 13px;
   color: var(--text);
   border-radius: var(--radius-sm);
   padding: 6px 12px;
 }
-html[data-theme="nex"] .theme-dropdown-item:hover {
+html[data-theme^="nex"] .theme-dropdown-item:hover {
   background: var(--bg-warm);
 }
-html[data-theme="nex"] .theme-dropdown-item.active {
+html[data-theme^="nex"] .theme-dropdown-item.active {
   background: var(--accent-bg);
   color: var(--accent);
 }

--- a/web/src/components/layout/ChannelHeader.tsx
+++ b/web/src/components/layout/ChannelHeader.tsx
@@ -5,6 +5,8 @@ export function ChannelHeader() {
   const currentChannel = useAppStore((s) => s.currentChannel);
   const currentApp = useAppStore((s) => s.currentApp);
   const setSearchOpen = useAppStore((s) => s.setSearchOpen);
+  const theme = useAppStore((s) => s.theme);
+  const setTheme = useAppStore((s) => s.setTheme);
   const { data: channels = [] } = useChannels();
 
   const channel = channels.find((c) => c.slug === currentChannel);
@@ -20,6 +22,23 @@ export function ChannelHeader() {
         {desc && <span className="channel-desc">{desc}</span>}
       </div>
       <div className="channel-actions">
+        <button
+          className="sidebar-btn"
+          title={theme === "nex-dark" ? "Light mode" : "Dark mode"}
+          aria-label={theme === "nex-dark" ? "Switch to light mode" : "Switch to dark mode"}
+          onClick={() => setTheme(theme === "nex-dark" ? "nex" : "nex-dark")}
+        >
+          {theme === "nex-dark" ? (
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="12" r="4"/>
+              <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/>
+            </svg>
+          ) : (
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+            </svg>
+          )}
+        </button>
         <button
           className="sidebar-btn"
           title="Search"

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -1,6 +1,17 @@
 import { create } from "zustand";
 
-export type Theme = "nex";
+export type Theme = "nex" | "nex-dark";
+
+const _storedTheme = ((): Theme => {
+  try {
+    const v = localStorage.getItem("wuphf-theme");
+    if (v === "nex-dark") return "nex-dark";
+  } catch {}
+  return "nex";
+})();
+if (typeof document !== "undefined") {
+  document.documentElement.setAttribute("data-theme", _storedTheme);
+}
 
 export interface ChannelMeta {
   type: "O" | "D" | "G";
@@ -160,8 +171,9 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setChannelMeta: (slug, meta) =>
     set({ channelMeta: { ...get().channelMeta, [slug]: meta } }),
 
-  theme: "nex",
+  theme: _storedTheme,
   setTheme: (t) => {
+    localStorage.setItem("wuphf-theme", t);
     document.documentElement.setAttribute("data-theme", t);
     set({ theme: t });
   },


### PR DESCRIPTION
## Summary

- Adds `nex-dark.css` theme with full dark-mode CSS variable overrides
- Adds theme toggle to `ChannelHeader` (sun/moon icon, persists via localStorage)
- Wires `app.ts` store to track and apply the active theme across sessions

## Test plan

- [ ] Toggle dark/light in the header — page switches theme instantly
- [ ] Reload the page — selected theme persists (localStorage)
- [ ] Check all major surfaces (sidebar, messages, input, modals) for contrast regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a dark theme option to the application.
  * Added a theme toggle button in the header to switch between light and dark themes.
  * Theme preference is now saved and persists across sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->