### PR TITLE
fix(team): rip dead post-shred shutdown plumbing (regression from #264)

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -535,8 +535,6 @@ type Broker struct {
 	// produce a truncated/overlaid file.
 	configMu           sync.Mutex
 	server             *http.Server
-	shutdownOnce       sync.Once
-	shutdownCh         chan struct{}
 	token              string          // shared secret for authenticating requests
 	addr               string          // actual listen address (useful when port=0)
 	webUIOrigins       []string        // allowed CORS origins for web UI (set by ServeWebUI)
@@ -922,7 +920,6 @@ func NewBroker() *Broker {
 	b := &Broker{
 		channelStore:        channel.NewStore(),
 		token:               generateToken(),
-		shutdownCh:          make(chan struct{}),
 		messageSubscribers:  make(map[int]chan channelMessage),
 		actionSubscribers:   make(map[int]chan officeActionLog),
 		activity:            make(map[string]agentActivitySnapshot),
@@ -1641,26 +1638,6 @@ func (b *Broker) Stop() {
 	if pamDisp != nil {
 		pamDisp.Stop()
 	}
-}
-
-// ShutdownRequested is closed when a destructive operation needs the launcher
-// process to stop after the HTTP response has reached the client.
-func (b *Broker) ShutdownRequested() <-chan struct{} {
-	if b.shutdownCh == nil {
-		ch := make(chan struct{})
-		close(ch)
-		return ch
-	}
-	return b.shutdownCh
-}
-
-func (b *Broker) requestShutdown() {
-	if b == nil || b.shutdownCh == nil {
-		return
-	}
-	b.shutdownOnce.Do(func() {
-		close(b.shutdownCh)
-	})
 }
 
 func (b *Broker) rateLimitMiddleware(next http.Handler) http.Handler {

--- a/internal/team/broker_web_test.go
+++ b/internal/team/broker_web_test.go
@@ -117,3 +117,100 @@ func TestWorkspaceShredRouteResetsBrokerWithoutShutdown(t *testing.T) {
 		t.Fatalf("expected 200 from /version after shred, got %d", versionResp.StatusCode)
 	}
 }
+
+// TestWorkspaceShredRoutePostShredBrokerAcceptsNewState extends the prior
+// test from "broker still serves" to "broker is fully usable" — proves the
+// post-shred broker can accept new messages and persist them, mimicking the
+// onboarding flow that re-opens after the UI shred. The pre-#264 launcher
+// path tore down the broker after shred, so this property never had test
+// coverage; the dead-code removal in #307 makes it the steady state.
+func TestWorkspaceShredRoutePostShredBrokerAcceptsNewState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+
+	// Pin broker state path explicitly so the assertion doesn't depend on
+	// defaultBrokerStatePath()'s home resolution. setBrokerStatePathForTest
+	// installs an atomic override that production reads via brokerStatePath().
+	statePath := filepath.Join(home, "broker-state.json")
+	setBrokerStatePathForTest(t, func() string { return statePath })
+
+	b := NewBroker()
+	b.mu.Lock()
+	b.messages = []channelMessage{{
+		ID:        "pre-shred",
+		From:      "human",
+		Channel:   "general",
+		Content:   "stale workspace",
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+	}}
+	if err := b.saveLocked(); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("seed save: %v", err)
+	}
+	b.mu.Unlock()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("expected broker-state.json to exist before shred: %v", err)
+	}
+
+	// Trigger shred via HTTP — same path the SettingsApp danger-zone button
+	// hits via shredWorkspace() in web/src/api/client.ts.
+	shredReq, err := http.NewRequest(http.MethodPost, "http://"+b.Addr()+"/workspace/shred", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatalf("new shred request: %v", err)
+	}
+	shredReq.Header.Set("Authorization", "Bearer "+b.Token())
+	shredReq.Header.Set("Content-Type", "application/json")
+	shredResp, err := http.DefaultClient.Do(shredReq)
+	if err != nil {
+		t.Fatalf("post shred: %v", err)
+	}
+	shredResp.Body.Close()
+	if shredResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from shred, got %d", shredResp.StatusCode)
+	}
+
+	// In-memory state cleared by Reset.
+	b.mu.Lock()
+	if len(b.messages) != 0 {
+		b.mu.Unlock()
+		t.Fatalf("expected post-shred broker to have no messages, got %d", len(b.messages))
+	}
+	b.mu.Unlock()
+
+	// Broker can accept a fresh post-shred message on the same listener,
+	// mimicking the user re-onboarding without restarting wuphf. Goes through
+	// the full /messages route + auth + persistence pipeline.
+	postBody := strings.NewReader(`{"from":"human","channel":"general","content":"post-shred kickoff"}`)
+	postReq, err := http.NewRequest(http.MethodPost, "http://"+b.Addr()+"/messages", postBody)
+	if err != nil {
+		t.Fatalf("new post-message request: %v", err)
+	}
+	postReq.Header.Set("Authorization", "Bearer "+b.Token())
+	postReq.Header.Set("Content-Type", "application/json")
+	postResp, err := http.DefaultClient.Do(postReq)
+	if err != nil {
+		t.Fatalf("post message after shred: %v", err)
+	}
+	postResp.Body.Close()
+	if postResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from post-shred /messages, got %d", postResp.StatusCode)
+	}
+
+	// Persistence flushed the new message back to disk under the broker's
+	// snapshotted statePath. Without #289's Track A.1 binding, a torn read
+	// here could land the file at the pre-shred path.
+	b.mu.Lock()
+	gotMessages := len(b.messages)
+	b.mu.Unlock()
+	if gotMessages == 0 {
+		t.Fatalf("expected post-shred broker to retain the new message in memory")
+	}
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("expected broker-state.json to be re-written after post-shred message, got: %v", err)
+	}
+}

--- a/internal/team/broker_web_test.go
+++ b/internal/team/broker_web_test.go
@@ -101,9 +101,19 @@ func TestWorkspaceShredRouteResetsBrokerWithoutShutdown(t *testing.T) {
 		t.Fatalf("expected shred route to reset broker messages, got %d", messageCount)
 	}
 
-	select {
-	case <-b.ShutdownRequested():
-		t.Fatal("expected shred route to keep broker running")
-	case <-time.After(50 * time.Millisecond):
+	// Broker stays alive after shred — follow-up HTTP request on the same
+	// listener must succeed. Pre-#264 the broker tore itself down here.
+	versionReq, err := http.NewRequest(http.MethodGet, "http://"+b.Addr()+"/version", nil)
+	if err != nil {
+		t.Fatalf("new version request: %v", err)
+	}
+	versionReq.Header.Set("Authorization", "Bearer "+b.Token())
+	versionResp, err := http.DefaultClient.Do(versionReq)
+	if err != nil {
+		t.Fatalf("expected broker to keep serving after shred, got: %v", err)
+	}
+	defer versionResp.Body.Close()
+	if versionResp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from /version after shred, got %d", versionResp.StatusCode)
 	}
 }

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -38,7 +38,6 @@ import (
 	"github.com/nex-crm/wuphf/internal/provider"
 	"github.com/nex-crm/wuphf/internal/runtimebin"
 	"github.com/nex-crm/wuphf/internal/setup"
-	"github.com/nex-crm/wuphf/internal/workspace"
 )
 
 const (
@@ -4794,21 +4793,9 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		openBrowser(webURL)
 	}
 
-	<-l.broker.ShutdownRequested()
-	fmt.Println()
-	fmt.Println("  Workspace shredded. Stopping WUPHF; relaunch to start onboarding.")
-	fmt.Println()
-	if l.headlessCancel != nil {
-		l.headlessCancel()
-	}
-	// Give the web proxy a moment to finish copying the successful shred
-	// response before the broker listener and process go away.
-	time.Sleep(300 * time.Millisecond)
-	if err := l.Kill(); err != nil {
-		return err
-	}
-	_, _ = workspace.Shred()
-	return nil
+	// Broker, web UI, and background goroutines own the process lifetime;
+	// Ctrl+C (default SIGINT) is the only exit path.
+	select {}
 }
 
 func openBrowser(url string) {


### PR DESCRIPTION
## Summary

Pre-existing main bug surfaced during staff-review of #289. After [#264](https://github.com/nex-crm/wuphf/pull/264), \`/workspace/shred\` correctly resets broker state in-place — the broker stays alive (locked in by \`TestWorkspaceShredRouteResetsBrokerWithoutShutdown\` in \`broker_web_test.go\`). But the launcher's \`LaunchWeb\` loop was still parked on \`<-b.ShutdownRequested()\`, and #264 stopped writing to \`b.shutdownCh\` from the workspace handler. Net result on main: shred succeeds in the UI, broker stays running as designed, but \`wuphf\` hangs forever in the terminal — the goodbye message never prints, the process never exits.

## What this PR does

Embraces #264's contract fully and **rips the dead plumbing** instead of re-wiring it. The launcher's wait was the only consumer of \`shutdownCh\`; with shred staying in-place, that whole exit path is dead code.

- \`launcher.go\`: replace \`<-l.broker.ShutdownRequested(); ...; l.Kill(); workspace.Shred()\` with \`select {}\`. Broker, web UI, and background goroutines own the process lifetime. Ctrl+C (default SIGINT) is the only exit path. The 300ms sleep + \`l.Kill()\` + redundant \`workspace.Shred()\` (the HTTP handler already shredded) were all unreachable.
- \`broker.go\`: delete \`shutdownCh\`, \`shutdownOnce\`, \`ShutdownRequested()\`, \`requestShutdown()\` — all unreferenced after the launcher edit.
- \`broker_web_test.go\`: update \`TestWorkspaceShredRouteResetsBrokerWithoutShutdown\` to assert the post-shred broker still **serves requests** (live \`GET /version\`) instead of asserting on the now-removed \`ShutdownRequested\` API. Stronger test — proves the broker is actually alive, not just \"didn't signal shutdown\".

## Why not wire AfterShred → requestShutdown

That was my first attempt — failed CI immediately on \`TestWorkspaceShredRouteResetsBrokerWithoutShutdown\`. #264's intent is unambiguous: shred must NOT trigger a CLI exit. Re-wiring would have re-broken the test and contradicted the design decision.

## What about Ctrl+C cleanup

Pre-#264, the only graceful exit was via shred → ShutdownRequested. After #264, that path is broken — meaning **graceful exit was already gone** on main, only Ctrl+C / SIGINT termination remained. This PR doesn't change that — it just makes the code honest about it. A future PR can wire signal-based graceful shutdown if desired (no consumers right now).

## Tests

- \`TestWorkspaceShredRouteResetsBrokerWithoutShutdown\` (renamed assertion path) — proves broker keeps serving HTTP after shred.
- \`go test ./internal/team/... ./internal/workspace/...\` green locally (modulo a pre-existing flake of \`TestTelegramHandleInbound\` unrelated to this change — passes in isolation).

## Test plan

- [x] Workspace + team test suites green locally.
- [ ] CI matrix green.
- [ ] Manual: \`wuphf\` running locally, hit \`/workspace/shred\` from the UI, verify the broker stays up and the UI's post-shred onboarding flow works.
- [ ] Manual: Ctrl+C still cleanly exits the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified shutdown handling so the broker no longer uses internal shutdown signaling; the launcher now remains running until the process is terminated (e.g., Ctrl+C).

* **Tests**
  * Health checks now verify service liveness via HTTP endpoint responses.
  * Added end-to-end shred test that confirms persisted state and in-memory messages are cleared, and that new messages can be posted and persisted afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->