### PR TITLE
[codex] Avoid reusing terminal self-healing tasks

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -9785,7 +9785,7 @@ func (b *Broker) findReusableTaskLocked(match taskReuseMatch) *teamTask {
 		if normalizeChannelSlug(task.Channel) != channel {
 			continue
 		}
-		if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
+		if isTerminalTeamTaskStatus(task.Status) {
 			continue
 		}
 		sameTitle := title != "" && strings.EqualFold(strings.TrimSpace(task.Title), title)
@@ -9821,6 +9821,15 @@ func (b *Broker) findReusableTaskLocked(match taskReuseMatch) *teamTask {
 		return task
 	}
 	return nil
+}
+
+func isTerminalTeamTaskStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "done", "completed", "canceled", "cancelled":
+		return true
+	default:
+		return false
+	}
 }
 
 func (b *Broker) handleRequests(w http.ResponseWriter, r *http.Request) {

--- a/internal/team/launcher_escalation_test.go
+++ b/internal/team/launcher_escalation_test.go
@@ -90,6 +90,66 @@ func TestPostEscalation_ReusesSelfHealingTask(t *testing.T) {
 	}
 }
 
+func TestPostEscalation_DoesNotReuseCanceledSelfHealingTask(t *testing.T) {
+	b := newTestBroker(t)
+	l := &Launcher{broker: b}
+
+	l.postEscalation("eng", "eng-42", agent.EscalationStuck, "first stuck event")
+
+	var canceledID string
+	for _, task := range b.AllTasks() {
+		if task.Title == "Self-heal @eng on eng-42" {
+			canceledID = task.ID
+			break
+		}
+	}
+	if canceledID == "" {
+		t.Fatalf("expected initial self-healing task, got %+v", b.AllTasks())
+	}
+
+	b.mu.Lock()
+	for i := range b.tasks {
+		if b.tasks[i].ID == canceledID {
+			b.tasks[i].Status = "canceled"
+			break
+		}
+	}
+	b.mu.Unlock()
+
+	l.postEscalation("eng", "eng-42", agent.EscalationMaxRetries, "second stuck event")
+	l.postEscalation("eng", "eng-42", agent.EscalationStuck, "third stuck event")
+
+	var selfHealingTasks []teamTask
+	for _, task := range b.AllTasks() {
+		if task.Title == "Self-heal @eng on eng-42" {
+			selfHealingTasks = append(selfHealingTasks, task)
+		}
+	}
+	if len(selfHealingTasks) != 2 {
+		t.Fatalf("expected canceled task plus one active replacement, got %d tasks: %+v", len(selfHealingTasks), b.AllTasks())
+	}
+
+	var replacement teamTask
+	for _, task := range selfHealingTasks {
+		if task.ID == canceledID {
+			if task.Status != "canceled" {
+				t.Fatalf("expected original self-healing task to stay canceled, got %+v", task)
+			}
+			continue
+		}
+		replacement = task
+	}
+	if replacement.ID == "" {
+		t.Fatalf("expected replacement self-healing task, got %+v", selfHealingTasks)
+	}
+	if replacement.Status != "in_progress" {
+		t.Fatalf("expected replacement self-healing task to be actionable, got %+v", replacement)
+	}
+	if !strings.Contains(replacement.Details, "second stuck event") || !strings.Contains(replacement.Details, "third stuck event") {
+		t.Fatalf("expected replacement to collect new incident details, got %q", replacement.Details)
+	}
+}
+
 func TestPostEscalation_DoesNotNestSelfHealingTasks(t *testing.T) {
 	b := newTestBroker(t)
 	l := &Launcher{broker: b}


### PR DESCRIPTION
## Summary

- Treat terminal task statuses (`done`, `completed`, `canceled`, `cancelled`) as non-reusable in the shared reusable-task lookup.
- Add a regression test for the self-healing escalation workflow where a canceled incident is followed by matching future escalations.

## Root Cause

The reusable-task lookup only skipped `done` tasks. A canceled self-healing incident could therefore be selected again for later matching failures, causing new incident details to be appended to a non-actionable task instead of creating an active replacement.

## Validation

- `go test ./internal/team -run 'TestPostEscalation_(CreatesSelfHealingTask|ReusesSelfHealingTask|DoesNotReuseCanceledSelfHealingTask|DoesNotNestSelfHealingTasks)' -count=1`
- `go test ./internal/team -count=1`