### PR TITLE
feat(wiki): Slice 3 Thread A — predicate-indexed cluster scan eliminates ListAllFacts hot path

### DIFF
--- a/internal/team/playbook_clusters.go
+++ b/internal/team/playbook_clusters.go
@@ -14,51 +14,20 @@ package team
 // line is appended). That is the only reinforcement counter v1.2 exposes, so
 // the cluster predicate is simply "at least one reinforced fact per entity".
 //
-// Slice 2 scope (per WIKI-SLICE2-PLAN.md Thread C):
-//   - cluster detection is a full scan over ListAllFacts. Bounded by fact
-//     count (~500 at bench time). Acceptable for Slice 2; if the corpus
-//     grows past ~10k facts, introduce a (predicate, object) SQL index.
-//   - no aggregation beyond "distinct entity count per (predicate, object)".
-//     Slice 3 may expand to weighted clustering.
+// Slice 3 Thread A change:
+//   - cluster detection now uses ListReinforcedFactsByPredicate, which is
+//     index-backed on the SQLite store (idx_facts_reinforced — partial index
+//     keyed on triplet_predicate where reinforced_at IS NOT NULL). Cost
+//     scales with matching rows, not corpus size, so the previous
+//     count > threshold "consider paging" warning is no longer needed and
+//     has been retired along with its test hook.
 
 import (
 	"context"
 	"fmt"
-	"log"
 	"sort"
 	"strings"
 )
-
-// factCountWarnThreshold is the corpus size at which clusterReinforcedFacts
-// logs a heads-up that the unbounded ListAllFacts scan is past its Slice 2
-// bench-time envelope (~500 facts). Operators who see this line in the
-// broker log should schedule the Slice 3 (predicate, object) SQL index
-// rollout. Not a fail — never truncate silently at read-time.
-//
-// Easy to tune: change this single value, no plumbing. Exported as a test
-// hook via setFactCountWarnThresholdForTest so we don't need to seed 5k
-// rows in unit tests.
-const factCountWarnThreshold = 5000
-
-// factCountWarnThresholdOverride lets tests bind a smaller threshold so the
-// warning path is exercisable without materialising 5k rows. Zero means
-// "use the production constant".
-var factCountWarnThresholdOverride int
-
-// setFactCountWarnThresholdForTest swaps the active threshold and returns a
-// restore function. Test-only — production callers never touch this.
-func setFactCountWarnThresholdForTest(v int) func() {
-	prev := factCountWarnThresholdOverride
-	factCountWarnThresholdOverride = v
-	return func() { factCountWarnThresholdOverride = prev }
-}
-
-func activeFactCountWarnThreshold() int {
-	if factCountWarnThresholdOverride > 0 {
-		return factCountWarnThresholdOverride
-	}
-	return factCountWarnThreshold
-}
 
 // FactCluster is one reinforced (predicate, object) pair observed across
 // multiple distinct entities. Emitted by clusterReinforcedFacts as input to
@@ -97,13 +66,15 @@ type FactCluster struct {
 //     strongest-first, so the head slice is the most informative window.
 //     Values ≤ 0 mean "return every qualifying cluster" (unbounded).
 //
-// When the underlying fact count exceeds factCountWarnThreshold a warning is
-// logged to stderr via the broker log. We never fail or truncate — silent
-// truncation would mask corpus growth from operators.
+// Implementation: we ask the store for the predicate-narrowed reinforced
+// slice up front (ListReinforcedFactsByPredicate). On SQLite this hits the
+// idx_facts_reinforced partial index; on the in-memory backend it filters
+// linearly. Either way, the caller no longer scans the full corpus, and
+// the (ReinforcedAt != nil) + predicate guards live in the store layer.
 //
-// Facts with nil Triplet or ReinforcedAt == nil are skipped. Clusters are
-// returned sorted by (Count desc, Predicate asc, Object asc) so prompt
-// output is stable across runs.
+// Facts with nil Triplet are skipped. Clusters are returned sorted by
+// (Count desc, Predicate asc, Object asc) so prompt output is stable
+// across runs.
 func clusterReinforcedFacts(
 	ctx context.Context,
 	store FactStore,
@@ -118,20 +89,13 @@ func clusterReinforcedFacts(
 		minDistinctEntities = 2
 	}
 
-	// Observability guard for the unbounded ListAllFacts scan. CountFacts is
-	// cheap on both backends; the warning fires once per synthesis run so it
-	// flags growth without spamming the log.
-	if count, cerr := store.CountFacts(ctx); cerr != nil {
-		// CountFacts failure is non-fatal — fall through to the scan and let
-		// the underlying ListAllFacts error (if any) bubble up instead.
-		log.Printf("playbook clusters: count facts failed (continuing): %v", cerr)
-	} else if threshold := activeFactCountWarnThreshold(); count > threshold {
-		log.Printf("playbook clusters: fact count %d exceeds %d — consider paging", count, threshold)
-	}
-
-	facts, err := store.ListAllFacts(ctx)
+	// Pull only the slice we actually cluster against. The store-layer
+	// predicate + reinforced filter means we never materialise the full fact
+	// corpus into a single Go slice. ListReinforcedFactsByPredicate accepts
+	// an empty predicate to mean "every predicate".
+	facts, err := store.ListReinforcedFactsByPredicate(ctx, predicateFilter)
 	if err != nil {
-		return nil, fmt.Errorf("playbook_clusters: list all facts: %w", err)
+		return nil, fmt.Errorf("playbook_clusters: list reinforced facts: %w", err)
 	}
 
 	// Bucket reinforced facts by (predicate, object). Use a set of entity
@@ -144,15 +108,9 @@ func clusterReinforcedFacts(
 		if f.Triplet == nil {
 			continue
 		}
-		if f.ReinforcedAt == nil {
-			continue
-		}
 		predicate := strings.TrimSpace(f.Triplet.Predicate)
 		object := strings.TrimSpace(f.Triplet.Object)
 		if predicate == "" || object == "" {
-			continue
-		}
-		if predicateFilter != "" && predicate != predicateFilter {
 			continue
 		}
 		entity := strings.TrimSpace(f.EntitySlug)

--- a/internal/team/playbook_clusters_test.go
+++ b/internal/team/playbook_clusters_test.go
@@ -1,11 +1,7 @@
 package team
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"log"
-	"strings"
 	"testing"
 	"time"
 )
@@ -300,70 +296,6 @@ func stringSlicesEqual(a, b []string) bool {
 }
 
 func ptrTime(t time.Time) *time.Time { return &t }
-
-// TestClusterReinforcedFacts_LogsAboveThreshold asserts the Slice 2
-// observability guard: when the underlying fact count exceeds the
-// configurable warn threshold, clusterReinforcedFacts logs a line via the
-// shared `log` package but does NOT fail or truncate. The test lowers the
-// threshold through setFactCountWarnThresholdForTest so we do not need
-// to seed 5k rows.
-func TestClusterReinforcedFacts_LogsAboveThreshold(t *testing.T) {
-	restore := setFactCountWarnThresholdForTest(2)
-	defer restore()
-
-	// Seed 3 facts — above the lowered threshold of 2.
-	facts := make([]TypedFact, 0, 3)
-	for i := 0; i < 3; i++ {
-		facts = append(facts, reinforcedFact(fmt.Sprintf("e%d", i), "champions", "q2-pilot", true))
-	}
-	store := newClusterTestStore(t, facts)
-
-	var buf bytes.Buffer
-	origOut := log.Writer()
-	log.SetOutput(&buf)
-	defer log.SetOutput(origOut)
-
-	clusters, err := clusterReinforcedFacts(context.Background(), store, "", 2, 0)
-	if err != nil {
-		t.Fatalf("clusterReinforcedFacts: %v", err)
-	}
-	if len(clusters) == 0 {
-		t.Fatalf("expected at least one cluster; got none")
-	}
-
-	logged := buf.String()
-	if !strings.Contains(logged, "fact count 3 exceeds 2") {
-		t.Errorf("expected threshold warning in log output; got:\n%s", logged)
-	}
-	if !strings.Contains(logged, "consider paging") {
-		t.Errorf("expected 'consider paging' hint in log output; got:\n%s", logged)
-	}
-}
-
-// TestClusterReinforcedFacts_DoesNotLogBelowThreshold pins the inverse: when
-// the corpus fits the scan envelope we stay silent so the broker log does
-// not get polluted by every synthesis run.
-func TestClusterReinforcedFacts_DoesNotLogBelowThreshold(t *testing.T) {
-	restore := setFactCountWarnThresholdForTest(100)
-	defer restore()
-
-	store := newClusterTestStore(t, []TypedFact{
-		reinforcedFact("alice", "champions", "q2-pilot", true),
-		reinforcedFact("bob", "champions", "q2-pilot", true),
-	})
-
-	var buf bytes.Buffer
-	origOut := log.Writer()
-	log.SetOutput(&buf)
-	defer log.SetOutput(origOut)
-
-	if _, err := clusterReinforcedFacts(context.Background(), store, "", 2, 0); err != nil {
-		t.Fatalf("clusterReinforcedFacts: %v", err)
-	}
-	if strings.Contains(buf.String(), "fact count") {
-		t.Errorf("did not expect threshold warning under the limit; got:\n%s", buf.String())
-	}
-}
 
 // TestClusterReinforcedFacts_TopNShortCircuits verifies topN trims the output
 // after sorting — strongest-first ordering is preserved and the tail is

--- a/internal/team/wiki_index.go
+++ b/internal/team/wiki_index.go
@@ -172,6 +172,26 @@ type FactStore interface {
 	// typed-predicate graph walk and counterfactual rewrite (Slice 2 Thread A).
 	ListFactsByTriplet(ctx context.Context, subject, predicate, objectPrefix string) ([]TypedFact, error)
 
+	// ListReinforcedFactsByPredicate returns every fact with a non-nil
+	// ReinforcedAt whose triplet predicate matches `predicate` exactly. Pass
+	// "" to return all reinforced facts (no predicate filter). Result is
+	// sorted by ID ascending so consumers see deterministic ordering.
+	//
+	// Backed by idx_facts_triplet_pred_obj on the SQLite store, so the cost
+	// is O(matching facts), not O(total facts). The in-memory store filters
+	// linearly — equivalent for small corpora.
+	ListReinforcedFactsByPredicate(ctx context.Context, predicate string) ([]TypedFact, error)
+
+	// ListAllFactsPaged returns up to `limit` facts whose ID is strictly
+	// greater than `afterID`, sorted by ID ascending. Pass afterID="" to
+	// start from the beginning. Pass limit<=0 for an implementation default
+	// (suggested: 1000). The caller drives pagination by feeding the last
+	// returned ID into afterID on the next call.
+	//
+	// Use this instead of ListAllFacts when the consumer can process facts
+	// incrementally — it bounds memory regardless of corpus size.
+	ListAllFactsPaged(ctx context.Context, afterID string, limit int) ([]TypedFact, error)
+
 	// IterateEntities invokes fn for every entity row in the store. Iteration
 	// order is implementation-defined but stable within a single call.
 	// Callers use this to implement signal lookups (by email, name, domain)
@@ -1052,6 +1072,56 @@ func (s *inMemoryFactStore) CountFacts(_ context.Context) (int, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return len(s.facts), nil
+}
+
+// ListReinforcedFactsByPredicate returns reinforced facts (ReinforcedAt != nil)
+// optionally narrowed to a single predicate. Linear scan — acceptable for the
+// in-memory backend; the SQLite backend uses a partial index. Result is sorted
+// by ID ascending for parity with the SQLite ORDER BY id.
+func (s *inMemoryFactStore) ListReinforcedFactsByPredicate(_ context.Context, predicate string) ([]TypedFact, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []TypedFact
+	for _, f := range s.facts {
+		if f.ReinforcedAt == nil {
+			continue
+		}
+		if predicate != "" {
+			if f.Triplet == nil || f.Triplet.Predicate != predicate {
+				continue
+			}
+		}
+		out = append(out, f)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// ListAllFactsPaged returns up to `limit` facts with ID > afterID, sorted by
+// ID ascending. Empty afterID starts from the beginning (lexicographically
+// "" precedes every non-empty string). limit <= 0 falls back to the
+// implementation default of 1000.
+func (s *inMemoryFactStore) ListAllFactsPaged(_ context.Context, afterID string, limit int) ([]TypedFact, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids := make([]string, 0, len(s.facts))
+	for id := range s.facts {
+		if id > afterID {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	if len(ids) > limit {
+		ids = ids[:limit]
+	}
+	out := make([]TypedFact, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, s.facts[id])
+	}
+	return out, nil
 }
 
 func (s *inMemoryFactStore) IterateEntities(_ context.Context, fn func(IndexEntity) error) error {

--- a/internal/team/wiki_index_paged_test.go
+++ b/internal/team/wiki_index_paged_test.go
@@ -1,0 +1,393 @@
+package team
+
+// wiki_index_paged_test.go — coverage for the Slice 3 Thread A FactStore
+// extensions: ListReinforcedFactsByPredicate (predicate-narrowed reinforced
+// scan, index-backed on SQLite) and ListAllFactsPaged (keyset pagination).
+//
+// Each new method gets a parity test against both backends so the SQLite
+// implementation can never silently diverge from the in-memory reference.
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// reinforcedSeed builds a deterministic seed of 5 facts across mixed predicates
+// and reinforcement states. Returned in seed order so callers can assert on a
+// known shape regardless of backend storage order.
+func reinforcedSeed() []TypedFact {
+	base := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	at := func(d int) *time.Time { t := base.AddDate(0, 0, d); return &t }
+	return []TypedFact{
+		{
+			ID: "fact-001", EntitySlug: "alice",
+			Triplet:   &Triplet{Subject: "alice", Predicate: "champions", Object: "q2-pilot"},
+			Text:      "alice champions q2-pilot",
+			CreatedAt: base, CreatedBy: "test", ReinforcedAt: at(1),
+		},
+		{
+			ID: "fact-002", EntitySlug: "bob",
+			Triplet:   &Triplet{Subject: "bob", Predicate: "champions", Object: "q2-pilot"},
+			Text:      "bob champions q2-pilot",
+			CreatedAt: base, CreatedBy: "test", ReinforcedAt: at(2),
+		},
+		{
+			ID: "fact-003", EntitySlug: "carol",
+			Triplet:   &Triplet{Subject: "carol", Predicate: "works_at", Object: "acme-corp"},
+			Text:      "carol works_at acme-corp",
+			CreatedAt: base, CreatedBy: "test",
+			// NOT reinforced — should be excluded.
+		},
+		{
+			ID: "fact-004", EntitySlug: "dave",
+			Triplet:   &Triplet{Subject: "dave", Predicate: "works_at", Object: "acme-corp"},
+			Text:      "dave works_at acme-corp",
+			CreatedAt: base, CreatedBy: "test", ReinforcedAt: at(3),
+		},
+		{
+			ID: "fact-005", EntitySlug: "eve",
+			Triplet:   &Triplet{Subject: "eve", Predicate: "champions", Object: "another-pilot"},
+			Text:      "eve champions another-pilot",
+			CreatedAt: base, CreatedBy: "test", ReinforcedAt: at(4),
+		},
+	}
+}
+
+func seedStore(t *testing.T, store FactStore, facts []TypedFact) {
+	t.Helper()
+	ctx := context.Background()
+	for i, f := range facts {
+		if err := store.UpsertFact(ctx, f); err != nil {
+			t.Fatalf("seed fact %d: %v", i, err)
+		}
+	}
+}
+
+func factIDs(facts []TypedFact) []string {
+	ids := make([]string, 0, len(facts))
+	for _, f := range facts {
+		ids = append(ids, f.ID)
+	}
+	return ids
+}
+
+func sliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestListReinforcedFactsByPredicate_InMemory pins the filter contract for the
+// in-memory backend: empty predicate returns every reinforced fact; specific
+// predicate returns only the matching reinforced rows; unreinforced rows are
+// always excluded; ordering is by ID ASC.
+func TestListReinforcedFactsByPredicate_InMemory(t *testing.T) {
+	store := newInMemoryFactStore()
+	seedStore(t, store, reinforcedSeed())
+
+	ctx := context.Background()
+
+	all, err := store.ListReinforcedFactsByPredicate(ctx, "")
+	if err != nil {
+		t.Fatalf("empty predicate: %v", err)
+	}
+	wantAll := []string{"fact-001", "fact-002", "fact-004", "fact-005"}
+	if !sliceEqual(factIDs(all), wantAll) {
+		t.Fatalf("empty predicate ids:\n got:  %v\n want: %v", factIDs(all), wantAll)
+	}
+
+	champ, err := store.ListReinforcedFactsByPredicate(ctx, "champions")
+	if err != nil {
+		t.Fatalf("champions predicate: %v", err)
+	}
+	wantChamp := []string{"fact-001", "fact-002", "fact-005"}
+	if !sliceEqual(factIDs(champ), wantChamp) {
+		t.Fatalf("champions ids:\n got:  %v\n want: %v", factIDs(champ), wantChamp)
+	}
+
+	works, err := store.ListReinforcedFactsByPredicate(ctx, "works_at")
+	if err != nil {
+		t.Fatalf("works_at predicate: %v", err)
+	}
+	// fact-003 is unreinforced, fact-004 is reinforced.
+	wantWorks := []string{"fact-004"}
+	if !sliceEqual(factIDs(works), wantWorks) {
+		t.Fatalf("works_at ids:\n got:  %v\n want: %v", factIDs(works), wantWorks)
+	}
+
+	// Unknown predicate → empty slice, not error.
+	none, err := store.ListReinforcedFactsByPredicate(ctx, "no-such-predicate")
+	if err != nil {
+		t.Fatalf("unknown predicate: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("unknown predicate: expected 0 facts; got %d", len(none))
+	}
+}
+
+// TestListReinforcedFactsByPredicate_SQLite pins the same contract on the
+// SQLite backend. The partial index idx_facts_reinforced is the load-bearing
+// piece — if it is missing the query still works but linearly scans the
+// table; the parity assertion catches any logic divergence.
+func TestListReinforcedFactsByPredicate_SQLite(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSQLiteFactStore(filepath.Join(dir, "reinforced.sqlite"))
+	if err != nil {
+		t.Fatalf("NewSQLiteFactStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	seedStore(t, store, reinforcedSeed())
+
+	ctx := context.Background()
+
+	all, err := store.ListReinforcedFactsByPredicate(ctx, "")
+	if err != nil {
+		t.Fatalf("empty predicate: %v", err)
+	}
+	wantAll := []string{"fact-001", "fact-002", "fact-004", "fact-005"}
+	if !sliceEqual(factIDs(all), wantAll) {
+		t.Fatalf("empty predicate ids:\n got:  %v\n want: %v", factIDs(all), wantAll)
+	}
+
+	champ, err := store.ListReinforcedFactsByPredicate(ctx, "champions")
+	if err != nil {
+		t.Fatalf("champions predicate: %v", err)
+	}
+	wantChamp := []string{"fact-001", "fact-002", "fact-005"}
+	if !sliceEqual(factIDs(champ), wantChamp) {
+		t.Fatalf("champions ids:\n got:  %v\n want: %v", factIDs(champ), wantChamp)
+	}
+
+	works, err := store.ListReinforcedFactsByPredicate(ctx, "works_at")
+	if err != nil {
+		t.Fatalf("works_at predicate: %v", err)
+	}
+	wantWorks := []string{"fact-004"}
+	if !sliceEqual(factIDs(works), wantWorks) {
+		t.Fatalf("works_at ids:\n got:  %v\n want: %v", factIDs(works), wantWorks)
+	}
+
+	none, err := store.ListReinforcedFactsByPredicate(ctx, "no-such-predicate")
+	if err != nil {
+		t.Fatalf("unknown predicate: %v", err)
+	}
+	if len(none) != 0 {
+		t.Fatalf("unknown predicate: expected 0 facts; got %d", len(none))
+	}
+}
+
+// pagedSeed builds 50 facts with deterministic, sortable IDs. Pagination
+// tests walk this seed in slices and assert each ID appears exactly once
+// in the natural sort order.
+func pagedSeed() []TypedFact {
+	base := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	out := make([]TypedFact, 50)
+	for i := 0; i < 50; i++ {
+		// Zero-padded so lexicographic order matches numeric order.
+		id := fmt.Sprintf("paged-%03d", i)
+		out[i] = TypedFact{
+			ID:         id,
+			EntitySlug: fmt.Sprintf("entity-%03d", i),
+			Text:       fmt.Sprintf("paged fact %d", i),
+			CreatedAt:  base,
+			CreatedBy:  "test",
+		}
+	}
+	return out
+}
+
+// walkPaged drains the store via ListAllFactsPaged with the given page size and
+// returns the IDs in the order they were observed.
+func walkPaged(t *testing.T, store FactStore, pageSize int) []string {
+	t.Helper()
+	ctx := context.Background()
+	var (
+		seen    []string
+		afterID string
+	)
+	// Hard upper bound on iterations so a buggy implementation never spins.
+	for iter := 0; iter < 1000; iter++ {
+		page, err := store.ListAllFactsPaged(ctx, afterID, pageSize)
+		if err != nil {
+			t.Fatalf("ListAllFactsPaged after=%q: %v", afterID, err)
+		}
+		if len(page) == 0 {
+			return seen
+		}
+		for _, f := range page {
+			seen = append(seen, f.ID)
+		}
+		afterID = page[len(page)-1].ID
+	}
+	t.Fatalf("walkPaged: too many iterations; afterID stuck at %q", afterID)
+	return nil
+}
+
+// TestListAllFactsPaged_InMemory walks 50 seeded facts in pages of 10 and
+// asserts every fact is observed once in ID-ascending order.
+func TestListAllFactsPaged_InMemory(t *testing.T) {
+	store := newInMemoryFactStore()
+	seedStore(t, store, pagedSeed())
+
+	got := walkPaged(t, store, 10)
+	if len(got) != 50 {
+		t.Fatalf("expected 50 facts; got %d", len(got))
+	}
+	for i, id := range got {
+		want := fmt.Sprintf("paged-%03d", i)
+		if id != want {
+			t.Fatalf("fact at index %d: got %q want %q", i, id, want)
+		}
+	}
+
+	// Default limit (limit <= 0) should also produce a sane page — we have
+	// 50 facts, default cap is 1000, so a single call returns everything.
+	ctx := context.Background()
+	full, err := store.ListAllFactsPaged(ctx, "", 0)
+	if err != nil {
+		t.Fatalf("default limit: %v", err)
+	}
+	if len(full) != 50 {
+		t.Fatalf("default limit: expected 50; got %d", len(full))
+	}
+
+	// Past the end → empty page, no error.
+	tail, err := store.ListAllFactsPaged(ctx, "paged-049", 10)
+	if err != nil {
+		t.Fatalf("tail: %v", err)
+	}
+	if len(tail) != 0 {
+		t.Fatalf("tail: expected 0; got %d", len(tail))
+	}
+}
+
+// TestListAllFactsPaged_SQLite mirrors the in-memory pagination assertions
+// against the SQLite backend so the keyset query (id > ? ORDER BY id LIMIT ?)
+// stays in lockstep with the reference implementation.
+func TestListAllFactsPaged_SQLite(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewSQLiteFactStore(filepath.Join(dir, "paged.sqlite"))
+	if err != nil {
+		t.Fatalf("NewSQLiteFactStore: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	seedStore(t, store, pagedSeed())
+
+	got := walkPaged(t, store, 10)
+	if len(got) != 50 {
+		t.Fatalf("expected 50 facts; got %d", len(got))
+	}
+	for i, id := range got {
+		want := fmt.Sprintf("paged-%03d", i)
+		if id != want {
+			t.Fatalf("fact at index %d: got %q want %q", i, id, want)
+		}
+	}
+
+	ctx := context.Background()
+	full, err := store.ListAllFactsPaged(ctx, "", 0)
+	if err != nil {
+		t.Fatalf("default limit: %v", err)
+	}
+	if len(full) != 50 {
+		t.Fatalf("default limit: expected 50; got %d", len(full))
+	}
+
+	tail, err := store.ListAllFactsPaged(ctx, "paged-049", 10)
+	if err != nil {
+		t.Fatalf("tail: %v", err)
+	}
+	if len(tail) != 0 {
+		t.Fatalf("tail: expected 0; got %d", len(tail))
+	}
+}
+
+// TestFindFactClusters_UsesIndexedPath is the regression guard for the
+// rewrite: the cluster result with a predicate filter must equal the result
+// of bucketing the full ListAllFacts manually. If a future refactor
+// reintroduces post-filter logic that diverges from the predicate path,
+// this test catches it.
+func TestFindFactClusters_UsesIndexedPath(t *testing.T) {
+	store := newClusterTestStore(t, []TypedFact{
+		reinforcedFact("alice", "champions", "q2-pilot", true),
+		reinforcedFact("bob", "champions", "q2-pilot", true),
+		reinforcedFact("carol", "champions", "q2-pilot", true),
+		// Different predicate — must NOT contribute under predicate=champions.
+		reinforcedFact("alice", "works_at", "acme-corp", true),
+		reinforcedFact("bob", "works_at", "acme-corp", true),
+		// Reinforced but different object — separate cluster.
+		reinforcedFact("dave", "champions", "q3-pilot", true),
+		reinforcedFact("eve", "champions", "q3-pilot", true),
+		// Unreinforced — must be ignored.
+		reinforcedFact("frank", "champions", "q2-pilot", false),
+	})
+
+	ctx := context.Background()
+	got, err := clusterReinforcedFacts(ctx, store, "champions", 2, 0)
+	if err != nil {
+		t.Fatalf("clusterReinforcedFacts: %v", err)
+	}
+
+	// Manually bucket via ListAllFacts to derive the expected result. This
+	// is the reference implementation we replaced — running it inline keeps
+	// the parity check tied to a property of the data, not a hard-coded
+	// expectation.
+	allFacts, err := store.ListAllFacts(ctx)
+	if err != nil {
+		t.Fatalf("ListAllFacts: %v", err)
+	}
+	type pair struct{ p, o string }
+	bucket := map[pair]map[string]struct{}{}
+	for _, f := range allFacts {
+		if f.Triplet == nil || f.ReinforcedAt == nil {
+			continue
+		}
+		if f.Triplet.Predicate != "champions" {
+			continue
+		}
+		k := pair{f.Triplet.Predicate, f.Triplet.Object}
+		set, ok := bucket[k]
+		if !ok {
+			set = map[string]struct{}{}
+			bucket[k] = set
+		}
+		set[f.EntitySlug] = struct{}{}
+	}
+
+	// Build the same FactCluster shape from the manual bucket.
+	wantCount := 0
+	for _, set := range bucket {
+		if len(set) >= 2 {
+			wantCount++
+		}
+	}
+	if len(got) != wantCount {
+		t.Fatalf("cluster count: got %d want %d (clusters=%v)", len(got), wantCount, got)
+	}
+
+	// Spot-check: every emitted cluster must match the manual bucket exactly.
+	for _, c := range got {
+		set := bucket[pair{c.Predicate, c.Object}]
+		if c.Count != len(set) {
+			t.Errorf("cluster %s/%s: got count %d want %d",
+				c.Predicate, c.Object, c.Count, len(set))
+		}
+		for _, e := range c.Entities {
+			if _, ok := set[e]; !ok {
+				t.Errorf("cluster %s/%s: emitted entity %q not in manual bucket",
+					c.Predicate, c.Object, e)
+			}
+		}
+	}
+}

--- a/internal/team/wiki_index_sqlite.go
+++ b/internal/team/wiki_index_sqlite.go
@@ -77,6 +77,13 @@ CREATE TABLE IF NOT EXISTS facts (
 CREATE INDEX IF NOT EXISTS idx_facts_entity   ON facts(entity_slug);
 CREATE INDEX IF NOT EXISTS idx_facts_triplet  ON facts(triplet_subject, triplet_predicate);
 CREATE INDEX IF NOT EXISTS idx_facts_triplet_pred_obj ON facts(triplet_predicate, triplet_object);
+-- Partial index for the reinforced-only cluster scan path (Slice 3 Thread A).
+-- Narrows the predicate-filtered scan to rows that actually contribute to
+-- clustering. Safe to add to existing DBs because CREATE INDEX IF NOT EXISTS
+-- is a no-op when the index already exists.
+CREATE INDEX IF NOT EXISTS idx_facts_reinforced
+  ON facts(triplet_predicate, id)
+  WHERE reinforced_at IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS entities (
   slug                    TEXT PRIMARY KEY,
@@ -396,6 +403,75 @@ func (s *SQLiteFactStore) ListAllFacts(ctx context.Context) ([]TypedFact, error)
 		 ORDER BY id ASC`)
 	if err != nil {
 		return nil, fmt.Errorf("sqlite: list all facts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanFacts(rows)
+}
+
+// ListReinforcedFactsByPredicate returns reinforced facts (reinforced_at IS NOT
+// NULL) optionally narrowed by triplet predicate. Backed by the partial index
+// idx_facts_reinforced (triplet_predicate, id) WHERE reinforced_at IS NOT NULL,
+// so the cost is O(matching rows). Empty predicate returns every reinforced
+// fact in the store. Result is sorted by id ASC for parity with the in-memory
+// backend.
+func (s *SQLiteFactStore) ListReinforcedFactsByPredicate(ctx context.Context, predicate string) ([]TypedFact, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	if predicate == "" {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT id, entity_slug, kind, type,
+			        triplet_subject, triplet_predicate, triplet_object,
+			        text, confidence, valid_from, valid_until,
+			        supersedes, contradicts_with,
+			        source_type, source_path, sentence_offset, artifact_excerpt,
+			        created_at, created_by, reinforced_at
+			 FROM facts
+			 WHERE reinforced_at IS NOT NULL
+			 ORDER BY id ASC`)
+	} else {
+		rows, err = s.db.QueryContext(ctx,
+			`SELECT id, entity_slug, kind, type,
+			        triplet_subject, triplet_predicate, triplet_object,
+			        text, confidence, valid_from, valid_until,
+			        supersedes, contradicts_with,
+			        source_type, source_path, sentence_offset, artifact_excerpt,
+			        created_at, created_by, reinforced_at
+			 FROM facts
+			 WHERE triplet_predicate = ? AND reinforced_at IS NOT NULL
+			 ORDER BY id ASC`, predicate)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list reinforced facts: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanFacts(rows)
+}
+
+// ListAllFactsPaged returns up to `limit` facts with id > afterID, sorted by id
+// ASC. Empty afterID starts at the beginning (the empty string sorts before
+// every non-empty id). limit <= 0 falls back to the 1000-row default.
+//
+// Keyset pagination (id > ?) over the primary key is O(log N) per page, which
+// keeps memory bounded regardless of total fact count.
+func (s *SQLiteFactStore) ListAllFactsPaged(ctx context.Context, afterID string, limit int) ([]TypedFact, error) {
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, entity_slug, kind, type,
+		        triplet_subject, triplet_predicate, triplet_object,
+		        text, confidence, valid_from, valid_until,
+		        supersedes, contradicts_with,
+		        source_type, source_path, sentence_offset, artifact_excerpt,
+		        created_at, created_by, reinforced_at
+		 FROM facts
+		 WHERE id > ?
+		 ORDER BY id ASC
+		 LIMIT ?`, afterID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("sqlite: list all facts paged: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	return scanFacts(rows)


### PR DESCRIPTION
## Summary

- Extends `FactStore` with `ListReinforcedFactsByPredicate` — uses the new `idx_facts_triplet_pred_obj` index to scan only facts matching a given predicate, O(matching facts) instead of O(all facts)
- Adds `ListAllFactsPaged` with keyset pagination for safe bounded scans across large fact tables
- Adds SQLite partial index `idx_facts_reinforced ON (triplet_predicate, fact_id) WHERE reinforced_at IS NOT NULL` to back the predicate-narrowed path
- Rewrites `FindFactClusters` to use the indexed path; drops the `count > threshold` warning since the hot path is now bounded by predicate cardinality, not table size

## Test plan

- [x] `TestListReinforcedFactsByPredicate_InMemory` — in-memory parity
- [x] `TestListReinforcedFactsByPredicate_SQLite` — SQLite parity
- [x] `TestListAllFactsPaged_InMemory` — keyset pagination correctness
- [x] `TestListAllFactsPaged_SQLite` — keyset pagination on SQLite
- [x] `TestFindFactClusters_UsesIndexedPath` — cluster-path equivalence regression; confirms old O(N) and new indexed path return identical cluster sets

All 5 new tests pass. Full `internal/team` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)