### PR TITLE
[codex] fix slow DM and wiki loading

### DIFF
--- a/internal/team/wiki_article.go
+++ b/internal/team/wiki_article.go
@@ -41,6 +41,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 )
 
 // ArticleMeta is the rich view sent to the UI for an article.
@@ -82,7 +83,8 @@ type CatalogEntry struct {
 }
 
 // BuildCatalog walks team/ and returns every .md article with title + author +
-// last-edit metadata grouped by top-level thematic dir.
+// last-edit metadata grouped by top-level thematic dir. Git metadata is read
+// in one batch so catalog latency scales with repo history, not article count.
 //
 // Shape matches web/src/api/wiki.ts WikiCatalogEntry. Sorted by path for
 // reproducibility; the UI re-sorts by recency within each group.
@@ -125,10 +127,6 @@ func (r *Repo) BuildCatalog(ctx context.Context) ([]CatalogEntry, error) {
 			Title: extractTitle(content, rel),
 			Group: groupFromPath(rel),
 		}
-		if refs, err := r.Log(ctx, rel); err == nil && len(refs) > 0 {
-			entry.AuthorSlug = refs[0].Author
-			entry.LastEditedTs = refs[0].Timestamp.Format("2006-01-02T15:04:05Z07:00")
-		}
 		entries = append(entries, entry)
 		return nil
 	})
@@ -136,8 +134,50 @@ func (r *Repo) BuildCatalog(ctx context.Context) ([]CatalogEntry, error) {
 		return nil, fmt.Errorf("wiki: walk team/: %w", walkErr)
 	}
 
+	if bounds, err := r.commitBoundsByPath(ctx); err == nil {
+		for i := range entries {
+			if b, ok := bounds[entries[i].Path]; ok && b.Has {
+				entries[i].AuthorSlug = b.Latest.Author
+				entries[i].LastEditedTs = b.Latest.Timestamp.Format("2006-01-02T15:04:05Z07:00")
+			}
+		}
+	}
+
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
 	return entries, nil
+}
+
+type pathCommitBounds struct {
+	Latest CommitRef
+	Oldest CommitRef
+	Has    bool
+}
+
+func (r *Repo) commitBoundsByPath(ctx context.Context) (map[string]pathCommitBounds, error) {
+	entries, err := r.AuditLog(ctx, time.Time{}, 0)
+	if err != nil {
+		return nil, err
+	}
+	bounds := make(map[string]pathCommitBounds)
+	for _, entry := range entries {
+		for _, p := range entry.Paths {
+			p = filepath.ToSlash(p)
+			ref := CommitRef{
+				SHA:       entry.SHA,
+				Author:    entry.Author,
+				Timestamp: entry.Timestamp,
+				Message:   entry.Message,
+			}
+			b := bounds[p]
+			if !b.Has {
+				b.Latest = ref
+				b.Has = true
+			}
+			b.Oldest = ref
+			bounds[p] = b
+		}
+	}
+	return bounds, nil
 }
 
 // groupFromPath returns the first subdir under team/ (e.g. "team/people/x.md"
@@ -205,7 +245,7 @@ func (r *Repo) BuildArticle(ctx context.Context, relPath string) (ArticleMeta, e
 // Does NOT hold r.mu: read-only filesystem access, safe to race with writes
 // (the worker's commit serialization means mid-walk state is at worst one
 // article stale — acceptable for a reverse index).
-func (r *Repo) backlinksFor(_ context.Context, target string) ([]Backlink, error) {
+func (r *Repo) backlinksFor(ctx context.Context, target string) ([]Backlink, error) {
 	targetSlug := relPathToSlug(target)
 	if targetSlug == "" {
 		return nil, fmt.Errorf("wiki: target has no slug mapping: %q", target)
@@ -262,11 +302,12 @@ func (r *Repo) backlinksFor(_ context.Context, target string) ([]Backlink, error
 
 	// Fill author_slug per article from git log. Best-effort: if log fails,
 	// leave author_slug empty rather than abort.
+	commitBounds, _ := r.commitBoundsByPath(ctx)
 	backs := make([]Backlink, 0, len(hits))
 	for _, h := range hits {
 		author := ""
-		if refs, err := r.Log(context.Background(), h.relPath); err == nil && len(refs) > 0 {
-			author = refs[0].Author
+		if bounds, ok := commitBounds[h.relPath]; ok && bounds.Has {
+			author = bounds.Latest.Author
 		}
 		backs = append(backs, Backlink{
 			Path:       h.relPath,

--- a/internal/team/wiki_sections.go
+++ b/internal/team/wiki_sections.go
@@ -63,8 +63,8 @@ import (
 const SectionsRefreshDebounce = 500 * time.Millisecond
 
 // SectionDiscoveryTimeout bounds one DiscoverSections call. git log
-// shell-outs per section can add up on a very large wiki; the cap keeps
-// a pathological filesystem from stalling the broker forever.
+// discovery is bounded so a pathological filesystem or large wiki history
+// cannot stall the broker forever.
 const SectionDiscoveryTimeout = 10 * time.Second
 
 // wikiSectionsEventName is the SSE event name emitted when the cached
@@ -153,6 +153,7 @@ func DiscoverSections(ctx context.Context, repo *Repo, blueprint *operations.Blu
 	if walkErr != nil {
 		return nil, fmt.Errorf("wiki sections: walk team/: %w", walkErr)
 	}
+	commitBounds, _ := repo.commitBoundsByPath(ctx)
 
 	// Assemble the section list: blueprint-declared first (in blueprint
 	// order), then discovered-only alphabetically.
@@ -161,7 +162,7 @@ func DiscoverSections(ctx context.Context, repo *Repo, blueprint *operations.Blu
 
 	for _, slug := range blueprintOrder {
 		entries := bySection[slug]
-		section := materializeSection(ctx, repo, slug, entries, true)
+		section := materializeSection(ctx, repo, slug, entries, true, commitBounds)
 		out = append(out, section)
 		seen[slug] = struct{}{}
 	}
@@ -178,7 +179,7 @@ func DiscoverSections(ctx context.Context, repo *Repo, blueprint *operations.Blu
 		if _, ok := seen[slug]; ok {
 			continue
 		}
-		section := materializeSection(ctx, repo, slug, bySection[slug], false)
+		section := materializeSection(ctx, repo, slug, bySection[slug], false, commitBounds)
 		out = append(out, section)
 	}
 
@@ -232,12 +233,10 @@ func blueprintDirToSlug(dir string) string {
 	return cleaned
 }
 
-// materializeSection computes the metadata for one section from its
-// article paths. Timestamps are resolved via git log on the oldest and
-// newest commits touching any file in the section; articles without git
-// history (pre-worker writes, tests) contribute a zero time which we
-// collapse to the filesystem mtime as a reasonable fallback.
-func materializeSection(ctx context.Context, repo *Repo, slug string, entries []CatalogEntry, fromSchema bool) DiscoveredSection {
+// materializeSection computes the metadata for one section from its article
+// paths. Timestamps come from a batch git-log index; articles without git
+// history fall back to filesystem mtime.
+func materializeSection(ctx context.Context, repo *Repo, slug string, entries []CatalogEntry, fromSchema bool, commitBounds map[string]pathCommitBounds) DiscoveredSection {
 	title := sectionTitleFromSlug(slug)
 	paths := make([]string, 0, len(entries))
 	for _, e := range entries {
@@ -257,16 +256,14 @@ func materializeSection(ctx context.Context, repo *Repo, slug string, entries []
 		return section
 	}
 
-	// Resolve first-seen and last-update by scanning git log on every
-	// article in the section. For a small section this is cheap; for a
-	// large one (100+ articles) we cap the ctx via the caller's timeout.
+	// Resolve first-seen and last-update from the precomputed commit index.
 	var earliest, latest time.Time
 	for _, rel := range paths {
 		if err := ctx.Err(); err != nil {
 			break
 		}
-		refs, err := repo.Log(ctx, rel)
-		if err != nil || len(refs) == 0 {
+		bounds, ok := commitBounds[rel]
+		if !ok || !bounds.Has {
 			// Fall back to mtime — keeps sections with pre-worker
 			// history (git bootstrap restore, tests) from rendering
 			// with zero timestamps.
@@ -281,8 +278,8 @@ func materializeSection(ctx context.Context, repo *Repo, slug string, entries []
 			}
 			continue
 		}
-		newest := refs[0].Timestamp.UTC()
-		oldest := refs[len(refs)-1].Timestamp.UTC()
+		newest := bounds.Latest.Timestamp.UTC()
+		oldest := bounds.Oldest.Timestamp.UTC()
 		if earliest.IsZero() || oldest.Before(earliest) {
 			earliest = oldest
 		}

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -119,6 +119,9 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
   const enterDM = useAppStore((s) => s.enterDM);
   const setActiveAgentSlug = useAppStore((s) => s.setActiveAgentSlug);
   const currentChannel = useAppStore((s) => s.currentChannel);
+  const currentApp = useAppStore((s) => s.currentApp);
+  const setCurrentChannel = useAppStore((s) => s.setCurrentChannel);
+  const setCurrentApp = useAppStore((s) => s.setCurrentApp);
   const queryClient = useQueryClient();
   const [dmLoading, setDmLoading] = useState(false);
   const [view, setView] = useState<"stream" | "logs">("stream");
@@ -143,12 +146,22 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
 
   async function handleOpenDM() {
     setDmLoading(true);
+    const optimisticChannel = directChannelSlug(agent.slug);
+    enterDM(agent.slug, optimisticChannel);
+    setActiveAgentSlug(null);
     try {
       const result = await createDM(agent.slug);
-      const channel = result.slug || directChannelSlug(agent.slug);
-      enterDM(agent.slug, channel);
-      setActiveAgentSlug(null);
+      const channel = result.slug || optimisticChannel;
+      if (channel !== optimisticChannel) {
+        enterDM(agent.slug, channel);
+      }
+      void queryClient.invalidateQueries({ queryKey: ["channels"] });
     } catch (err: unknown) {
+      if (useAppStore.getState().currentChannel === optimisticChannel) {
+        setCurrentChannel(currentChannel);
+        setCurrentApp(currentApp);
+        setActiveAgentSlug(agent.slug);
+      }
       const message = err instanceof Error ? err.message : "Failed to open DM";
       showNotice(message, "error");
     } finally {


### PR DESCRIPTION
## Summary

- Open direct-message views optimistically instead of waiting for `/channels/dm` persistence to return.
- Replace per-article wiki catalog `git log` calls with a single batched commit index.
- Reuse the batched commit index for wiki section timestamps and backlink author metadata.

## Root Cause

Opening a DM was gated on `POST /channels/dm`, whose handler can persist the full broker state before responding. Wiki loads were doing repeated per-file `git log` subprocess calls while building catalog, section, and backlink metadata, so latency scaled with article count and backlink count.

## Validation

- `go test ./internal/team ./internal/channel -count=1`
- `npm run typecheck` from the temporary worktree with `web/node_modules` symlinked to the existing checkout

Synthetic timing during investigation: 400 per-file `git log` calls took about 1.7s, while one batched all-files `git log --name-only` call took about 9ms.