### PR TITLE
test(team): address Track B review nits — parallel-marker + wrong-token cases

### DIFF
--- a/internal/team/broker_state_path_test.go
+++ b/internal/team/broker_state_path_test.go
@@ -132,6 +132,12 @@ func TestNewBroker_SkipStateLoadGateRespected(t *testing.T) {
 	}
 
 	// Gate OFF (production default): NewBrokerAt() reads from disk.
+	//
+	// Mutating skipBrokerStateLoadOnConstruct mid-test is safe today
+	// because no test in this package calls t.Parallel() — the gate is
+	// process-wide and parallel siblings would race on it. If anyone
+	// adds parallel marks here later, gate the swap behind a per-test
+	// mutex or move it to t.Setenv-style instrumentation.
 	oldGate := skipBrokerStateLoadOnConstruct
 	skipBrokerStateLoadOnConstruct = false
 	t.Cleanup(func() { skipBrokerStateLoadOnConstruct = oldGate })

--- a/internal/team/operation_routes_test.go
+++ b/internal/team/operation_routes_test.go
@@ -68,6 +68,16 @@ func TestOperationBootstrapPackageRouteRejectsUnauth(t *testing.T) {
 	// change accidentally registers the bare handler without the
 	// requireAuth wrapper, every operation route silently becomes
 	// unauthenticated. This catches that immediately.
+	//
+	// Two cases per route:
+	//   - no Authorization header (the obvious miss)
+	//   - Bearer token that's not the broker's (catches a regression
+	//     where a future "looser" auth wrapper is swapped in — e.g.
+	//     one that accepts any non-empty token without comparing).
+	//
+	// Note: the broker is constructed once and shared across the
+	// for-loop. If a future refactor splits this into per-subtest
+	// brokers, move `defer b.Stop()` inside the subtest closure.
 	statePath := filepath.Join(t.TempDir(), "broker-state.json")
 	b := NewBrokerAt(statePath)
 	if err := b.StartOnPort(0); err != nil {
@@ -76,7 +86,7 @@ func TestOperationBootstrapPackageRouteRejectsUnauth(t *testing.T) {
 	defer b.Stop()
 
 	for _, path := range []string{"/operations/bootstrap-package", "/studio/bootstrap-package"} {
-		t.Run(path, func(t *testing.T) {
+		t.Run(path+"/no-token", func(t *testing.T) {
 			req, err := http.NewRequest(http.MethodGet, "http://"+b.Addr()+path, nil)
 			if err != nil {
 				t.Fatalf("NewRequest %s: %v", path, err)
@@ -89,6 +99,26 @@ func TestOperationBootstrapPackageRouteRejectsUnauth(t *testing.T) {
 			defer resp.Body.Close()
 			if resp.StatusCode != http.StatusUnauthorized {
 				t.Fatalf("GET %s without token: expected 401, got %d", path, resp.StatusCode)
+			}
+		})
+
+		t.Run(path+"/wrong-token", func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://"+b.Addr()+path, nil)
+			if err != nil {
+				t.Fatalf("NewRequest %s: %v", path, err)
+			}
+			// A non-empty token that does not match the broker's. A
+			// regression that switches requireAuth to "any non-empty
+			// Bearer accepted" would pass the no-token case but fail
+			// here.
+			req.Header.Set("Authorization", "Bearer not-the-real-token")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("GET %s: %v", path, err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusUnauthorized {
+				t.Fatalf("GET %s with wrong token: expected 401, got %d", path, resp.StatusCode)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Three NIT items from the staff review on the Track A/B PR train, all deferred at the time and worth landing now that the train is settling.

| Item | Where | Fix |
|---|---|---|
| Parallel-marker latent issue | \`broker_state_path_test.go:135\` | Comment the \`skipBrokerStateLoadOnConstruct\` mid-test mutation: safe today (no \`t.Parallel()\` in this package), but flag the contract |
| Wrong-token auth case missing | \`operation_routes_test.go\` | Split unauth subtests into \`/no-token\` and \`/wrong-token\` so a "loose" requireAuth variant (accepts any non-empty Bearer) is also caught |
| Shared-broker defer ordering | \`operation_routes_test.go\` | Marker comment near \`defer b.Stop()\` — current shape (one broker, one defer) is correct, but a future split-per-subtest refactor must move the defer |

## Why this is one PR

All three are sub-MEDIUM annotations on tests. None changes a code path or requires re-architecture; combining them keeps the review surface tiny and avoids three two-line PRs.

## Stack

Stacked on \`refactor/extract-operation\` (#299) → \`refactor/extract-pam\` (#298) → \`chore/track-a-review-followups\` (#297) → \`refactor/broker-statepath-ctor\` (#289).

CI now fires on stacked PRs (#302 landed), so this should get the full Go test job.

## Test plan

- [x] Pre-push hook green, no \`--no-verify\`.
- [x] Affected tests: 8 subtests in \`operation_routes_test.go\` (was 6) + \`TestNewBroker_SkipStateLoadGateRespected\` — all pass in 3.5s.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)