### PR TITLE
fix(team): unbreak main — orphan setBrokerStatePathForTest call from #307+#289 race

### DIFF
--- a/internal/team/broker_web_test.go
+++ b/internal/team/broker_web_test.go
@@ -129,12 +129,11 @@ func TestWorkspaceShredRoutePostShredBrokerAcceptsNewState(t *testing.T) {
 	t.Setenv("WUPHF_RUNTIME_HOME", home)
 
 	// Pin broker state path explicitly so the assertion doesn't depend on
-	// defaultBrokerStatePath()'s home resolution. setBrokerStatePathForTest
-	// installs an atomic override that production reads via brokerStatePath().
+	// defaultBrokerStatePath()'s home resolution. NewBrokerAt binds the
+	// path at construction (Track A.1, #289) — every save from this broker
+	// lands at statePath regardless of process-wide env state.
 	statePath := filepath.Join(home, "broker-state.json")
-	setBrokerStatePathForTest(t, func() string { return statePath })
-
-	b := NewBroker()
+	b := NewBrokerAt(statePath)
 	b.mu.Lock()
 	b.messages = []channelMessage{{
 		ID:        "pre-shred",


### PR DESCRIPTION
## Summary

Main is broken on \`b7303c22\`. \`internal/team/broker_web_test.go:135\` calls \`setBrokerStatePathForTest(t, fn)\`, which was removed by #289. The orphan reference came from #307 — it was authored against pre-#289 main, then squash-merged after #289 had already removed the helper. \`go vet ./internal/team/...\` fails on main right now.

## Fix

Migrate the call site to \`NewBrokerAt(statePath)\` — same binding semantics, just structurally bound at construction (which is what Track A.1 #289 actually intended).

## Verified

- \`go build ./...\` clean.
- \`go test ./internal/team/... -run TestWorkspaceShredRoute\` green.

## Test plan

- [x] Local build + targeted test green.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by using explicit state file paths for broker instantiation, ensuring persistence assertions check the correct file locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->