### PR TITLE
test(team): migrate remaining NewBroker() test sites to newTestBroker(t)

### DIFF
--- a/internal/team/broker_entity_graph_test.go
+++ b/internal/team/broker_entity_graph_test.go
@@ -24,7 +24,7 @@ func newEntityGraphTestServer(t *testing.T) (*httptest.Server, *Broker, func()) 
 	if err := repo.Init(context.Background()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
-	b := NewBroker()
+	b := newTestBroker(t)
 	worker := NewWikiWorker(repo, b)
 	ctx, cancel := context.WithCancel(context.Background())
 	worker.Start(ctx)
@@ -175,7 +175,7 @@ func TestHandleEntityFact_GraphRecordFailureDoesNotBreakFactWrite(t *testing.T) 
 }
 
 func TestEntityGraphEndpoint_MissingGraphReturns503(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/entity/graph", b.requireAuth(b.handleEntityGraph))
 	srv := httptest.NewServer(mux)

--- a/internal/team/broker_entity_test.go
+++ b/internal/team/broker_entity_test.go
@@ -25,7 +25,7 @@ func newEntityTestServer(t *testing.T, llmStub func(ctx context.Context, sys, us
 	if err := repo.Init(context.Background()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
-	b := NewBroker()
+	b := newTestBroker(t)
 	worker := NewWikiWorker(repo, b)
 	ctx, cancel := context.WithCancel(context.Background())
 	worker.Start(ctx)
@@ -390,7 +390,7 @@ func TestBrokerEntity_BriefsList(t *testing.T) {
 }
 
 func TestBrokerEntity_WorkerDownReturns503(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/entity/fact", b.requireAuth(b.handleEntityFact))
 	srv := httptest.NewServer(mux)

--- a/internal/team/broker_nex_register_test.go
+++ b/internal/team/broker_nex_register_test.go
@@ -50,7 +50,7 @@ func TestNexRegisterEndpoint_Success(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.token = "test-token"
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
@@ -93,7 +93,7 @@ func TestNexRegisterEndpoint_Success(t *testing.T) {
 // the payload lacks an email — the broker must reject with 400 before
 // spending an exec on nex-cli.
 func TestNexRegisterEndpoint_MissingEmail(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.token = "test-token"
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
@@ -127,7 +127,7 @@ func TestNexRegisterEndpoint_CLIMissing(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	t.Setenv("WUPHF_NO_NEX", "")
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.token = "test-token"
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
@@ -166,7 +166,7 @@ func TestNexRegisterEndpoint_CLIMissing(t *testing.T) {
 // TestNexRegisterEndpoint_RejectsGET ensures we only accept POST — a GET
 // would indicate the caller wiring the wrong verb, worth failing fast.
 func TestNexRegisterEndpoint_RejectsGET(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.token = "test-token"
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
@@ -200,7 +200,7 @@ func TestConfigEndpoint_NexAPIKeyPersists(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.token = "test-token"
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)

--- a/internal/team/broker_notebook_test.go
+++ b/internal/team/broker_notebook_test.go
@@ -22,7 +22,7 @@ func newNotebookTestServer(t *testing.T) (*httptest.Server, *Broker, func()) {
 	if err := repo.Init(context.Background()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
-	b := NewBroker()
+	b := newTestBroker(t)
 	worker := NewWikiWorker(repo, b)
 	ctx, cancel := context.WithCancel(context.Background())
 	worker.Start(ctx)
@@ -364,7 +364,7 @@ func TestBrokerNotebookSearchRequiresSlugAndPattern(t *testing.T) {
 
 func TestBrokerNotebookServiceUnavailable(t *testing.T) {
 	// No worker attached — every handler should 503.
-	b := NewBroker()
+	b := newTestBroker(t)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/notebook/write", b.handleNotebookWrite)
 	mux.HandleFunc("/notebook/read", b.handleNotebookRead)

--- a/internal/team/broker_providers_test.go
+++ b/internal/team/broker_providers_test.go
@@ -162,7 +162,7 @@ func TestProviderFieldSurvivesBrokerReload(t *testing.T) {
 }
 
 func TestRebuildMemberIndex_AfterRemove(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.members = []officeMember{

--- a/internal/team/broker_review_test.go
+++ b/internal/team/broker_review_test.go
@@ -22,7 +22,7 @@ func newReviewTestServer(t *testing.T) (*httptest.Server, *Broker, func()) {
 	if err := repo.Init(context.Background()); err != nil {
 		t.Fatalf("init repo: %v", err)
 	}
-	b := NewBroker()
+	b := newTestBroker(t)
 	worker := NewWikiWorker(repo, b)
 	ctx, cancel := context.WithCancel(context.Background())
 	worker.Start(ctx)

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -397,7 +397,7 @@ func TestBrokerCanonicalizesLegacyDMSlugs(t *testing.T) {
 }
 
 func TestRecordAgentUsageAttachesToCurrentTurnMessagesOnly(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	now := time.Now().UTC()
 	b.mu.Lock()
 	b.messages = []channelMessage{
@@ -852,7 +852,7 @@ func TestNewBrokerSeedsBlueprintBackedOfficeRosterOnFreshState(t *testing.T) {
 func TestHandleMessagesSupportsInboxAndOutboxScopes(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members,
 		officeMember{Slug: "pm", Name: "Product Manager"},
@@ -1175,7 +1175,7 @@ func TestBrokerAuthRejectsUnauthenticated(t *testing.T) {
 }
 
 func TestBrokerRateLimitsRequestsPerIP(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.rateLimitRequests = 100
 	b.rateLimitWindow = 1100 * time.Millisecond
 	mux := http.NewServeMux()
@@ -1226,7 +1226,7 @@ func TestBrokerRateLimitsRequestsPerIP(t *testing.T) {
 }
 
 func TestBrokerAuthenticatedRequestsBypassRateLimit(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.rateLimitRequests = 1
 	b.rateLimitWindow = time.Second
 	handler := b.rateLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1273,7 +1273,7 @@ func TestBrokerAuthenticatedRequestsBypassRateLimit(t *testing.T) {
 }
 
 func TestBrokerRateLimitsUsingForwardedClientIP(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.rateLimitRequests = 1
 	b.rateLimitWindow = time.Second
 	handler := b.rateLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1310,7 +1310,7 @@ func TestBrokerRateLimitsUsingForwardedClientIP(t *testing.T) {
 }
 
 func TestBrokerIgnoresForwardedClientIPFromNonLoopbackPeer(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.rateLimitRequests = 1
 	b.rateLimitWindow = time.Second
 	handler := b.rateLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1345,7 +1345,7 @@ func TestBrokerIgnoresForwardedClientIPFromNonLoopbackPeer(t *testing.T) {
 // valid Bearer token. The IP bucket alone exempts token-holders, so this is
 // the containment for runaway agent cost.
 func TestBrokerAgentRateLimitTripsOnRunawayLoop(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.agentRateLimitRequests = 5
 	b.agentRateLimitWindow = time.Second
 	handler := b.rateLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1393,7 +1393,7 @@ func TestBrokerAgentRateLimitTripsOnRunawayLoop(t *testing.T) {
 // particular agent, is not blocked by the per-agent bucket. If this breaks the
 // operator loses access to their office whenever one agent loops.
 func TestBrokerOperatorTrafficBypassesAgentRateLimit(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.agentRateLimitRequests = 1
 	b.agentRateLimitWindow = time.Second
 	handler := b.rateLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1421,7 +1421,7 @@ func TestBrokerOperatorTrafficBypassesAgentRateLimit(t *testing.T) {
 // not counted against the per-agent bucket. They do not represent loopable
 // tool calls — a single subscribe holds the connection open for minutes.
 func TestBrokerAgentRateLimitExemptsSSEPaths(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.agentRateLimitRequests = 2
 	b.agentRateLimitWindow = time.Second
 	handler := b.rateLimitMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1559,7 +1559,7 @@ func TestWebUIRebindGuard(t *testing.T) {
 // The new contract: no CORS header unless the Origin exactly matches the
 // configured web UI origin.
 func TestCORSMiddlewareDropsNullOriginWildcard(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.webUIOrigins = []string{"http://localhost:7900", "http://127.0.0.1:7900"}
 	handler := b.corsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -1598,7 +1598,7 @@ func TestCORSMiddlewareDropsNullOriginWildcard(t *testing.T) {
 // the first CEO turn) or read /onboarding/state.
 func TestBrokerOnboardingRoutesRequireAuth(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1856,7 +1856,7 @@ func createOfficeMemberForTest(t *testing.T, base, token, slug, name, role strin
 }
 
 func TestNormalizeLoadedStateRepopulatesGeneralFromOfficeRoster(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -4191,7 +4191,7 @@ func TestBrokerSyncTaskWorktreeReplacesStaleAssignedPath(t *testing.T) {
 		cleanupTaskWorktree = oldCleanup
 	}()
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task := &teamTask{
 		ID:             "task-80",
 		Title:          "Fix onboarding",
@@ -4227,7 +4227,7 @@ func TestBrokerNormalizeLoadedStateRepairsStaleAssignedWorktree(t *testing.T) {
 	}()
 
 	now := time.Now().UTC().Format(time.RFC3339)
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.tasks = []teamTask{{
 		ID:             "task-80",
 		Channel:        "youtube-factory",
@@ -6040,7 +6040,7 @@ func TestHeadlessQueue_NoTimerDrivenWakeup(t *testing.T) {
 // default) was the source of the load-path leak: blueprint-seeded teams saw
 // ceo/planner/executor/reviewer re-appended on every broker Load.
 func TestEnsureDefaultOfficeMembersSeedsWhenEmpty(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = nil
 	b.ensureDefaultOfficeMembersLocked()
@@ -6059,7 +6059,7 @@ func TestEnsureDefaultOfficeMembersSeedsWhenEmpty(t *testing.T) {
 // growth/reviewer for niche-crm), ensureDefaultOfficeMembersLocked must NOT
 // append ceo/planner/executor/reviewer on top.
 func TestEnsureDefaultOfficeMembersNoOpWhenNonEmpty(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "operator", Name: "Operator", Role: "Operator", PermissionMode: "plan", BuiltIn: true},

--- a/internal/team/broker_web_test.go
+++ b/internal/team/broker_web_test.go
@@ -25,7 +25,7 @@ func TestWebUIProxyHandlerForwardsOnboardingRoutes(t *testing.T) {
 	}))
 	defer upstream.Close()
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	req := httptest.NewRequest(http.MethodGet, "/onboarding/state?step=providers", nil)
 	rec := httptest.NewRecorder()
 
@@ -60,7 +60,7 @@ func TestWorkspaceShredRouteResetsBrokerWithoutShutdown(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.messages = []channelMessage{{
 		ID:        "stale-message",

--- a/internal/team/broker_wiki_dlq_test.go
+++ b/internal/team/broker_wiki_dlq_test.go
@@ -15,7 +15,7 @@ import (
 // It verifies the endpoint is auth-gated, returns both pending and
 // permanent-failure rows in JSON, and that a nil DLQ returns 503.
 func TestHandleWikiDLQ(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 
 	// Seed a DLQ with 2 pending + 1 promoted (via RecordAttempt past the
 	// validation max_retries ceiling).
@@ -139,7 +139,7 @@ func TestHandleWikiDLQ(t *testing.T) {
 // TestHandleWikiDLQ_NilDLQReturns503 verifies the handler degrades
 // gracefully when the worker has not been booted.
 func TestHandleWikiDLQ_NilDLQReturns503(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	// Explicitly leave b.wikiDLQ = nil.
 
 	mux := http.NewServeMux()

--- a/internal/team/config_endpoint_test.go
+++ b/internal/team/config_endpoint_test.go
@@ -33,7 +33,7 @@ func TestConfigEndpointAndHealth(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.runtimeProvider = "claude-code"
 	b.token = "test-token"
 	if err := b.StartOnPort(0); err != nil {
@@ -177,7 +177,7 @@ func TestConfigEndpointAcceptsActionProviders(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.runtimeProvider = "claude-code"
 	b.token = "test-token"
 	if err := b.StartOnPort(0); err != nil {

--- a/internal/team/dispatch_test.go
+++ b/internal/team/dispatch_test.go
@@ -28,7 +28,7 @@ func TestNormalizeProviderKind(t *testing.T) {
 }
 
 func TestMemberEffectiveProviderKind_PerAgentWins(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{
 		Slug:     "pm-codex",
@@ -45,7 +45,7 @@ func TestMemberEffectiveProviderKind_PerAgentWins(t *testing.T) {
 }
 
 func TestMemberEffectiveProviderKind_FallsBackToGlobal(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{
 		Slug: "no-binding",
@@ -66,7 +66,7 @@ func TestMemberEffectiveProviderKind_FallsBackToGlobal(t *testing.T) {
 }
 
 func TestMemberEffectiveProviderKind_DefaultsToClaudeWhenAllEmpty(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	l := &Launcher{broker: b, provider: ""}
 	// Fully empty globals fall through to claude-code. This preserves the
 	// install-default behavior that predated per-agent providers.
@@ -107,7 +107,7 @@ func TestShouldUseHeadlessDispatch(t *testing.T) {
 }
 
 func TestBrokerMemberProviderKind_Lookup(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{
 		Slug:     "eng-openclaw",

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -91,7 +91,7 @@ func TestBuildCodexOfficeConfigOverridesIncludesOfficeMCPEnv(t *testing.T) {
 
 	t.Setenv("WUPHF_NO_NEX", "1")
 
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	if err := broker.SetSessionMode(SessionModeOneOnOne, "pm"); err != nil {
 		t.Fatalf("SetSessionMode: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 	l := &Launcher{
 		pack:        agent.GetPack("founding-team"),
 		cwd:         t.TempDir(),
-		broker:      NewBroker(),
+		broker:      newTestBroker(t),
 		headlessCtx: context.Background(),
 	}
 
@@ -297,7 +297,7 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForCodingAgents(t *testing.T) {
 	t.Setenv("CODEX_TUI_RECORD_SESSION", "1")
 	t.Setenv("CODEX_TUI_SESSION_LOG_PATH", "/tmp/controller-session.jsonl")
 
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	ensureTestMemberAccess(broker, "general", "builder", "Builder")
 	ensureTestMemberAccess(broker, "general", "operator", "Operator")
 	task, _, err := broker.EnsurePlannedTask(plannedTaskInput{
@@ -416,7 +416,7 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForLocalWorktreeBuilder(t *test
 	t.Setenv("OPENAI_API_KEY", "test-key")
 	t.Setenv("PWD", repoRoot)
 
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	ensureTestMemberAccess(broker, "general", "builder", "Builder")
 	task, _, err := broker.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
@@ -497,7 +497,7 @@ func TestRunHeadlessCodexTurnPassesScopedChannelEnv(t *testing.T) {
 	l := &Launcher{
 		pack:        agent.GetPack("founding-team"),
 		cwd:         t.TempDir(),
-		broker:      NewBroker(),
+		broker:      newTestBroker(t),
 		headlessCtx: context.Background(),
 	}
 
@@ -971,7 +971,7 @@ func TestEnqueueHeadlessCodexTurnRecordDropsDuplicateLeadTaskWhileActive(t *test
 func TestEnqueueHeadlessCodexTurnRecordQueuesUrgentLeadWakeForSameTask(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Review and advance the proof lane",
@@ -1115,7 +1115,7 @@ func TestWakeLeadAfterSpecialistFallsBackToCompletedTaskUpdateWhenNoBroadcast(t 
 		return nil
 	})
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
@@ -1161,7 +1161,7 @@ func TestWakeLeadAfterSpecialistFallsBackToCompletedTaskUpdateWhenNoBroadcast(t 
 func TestRecoverTimedOutHeadlessTurnBlocksTaskWithoutSubstantiveReply(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{Slug: "cmo", Name: "Chief Marketing Officer"})
 	for i := range b.channels {
@@ -1211,7 +1211,7 @@ func TestRecoverTimedOutHeadlessTurnBlocksTaskWithoutSubstantiveReply(t *testing
 func TestRecoverTimedOutHeadlessTurnLeavesTaskRunningAfterSubstantiveReply(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = append(b.members, officeMember{Slug: "cmo", Name: "Chief Marketing Officer"})
 	for i := range b.channels {
@@ -1259,7 +1259,7 @@ func TestRecoverTimedOutHeadlessTurnLeavesTaskRunningAfterSubstantiveReply(t *te
 func TestRecoverTimedOutHeadlessTurnRetriesLocalWorktreeOnceBeforeBlocking(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
@@ -1315,7 +1315,7 @@ func TestRecoverTimedOutHeadlessTurnRetriesLocalWorktreeOnceBeforeBlocking(t *te
 func TestRecoverFailedHeadlessTurnRetriesLocalWorktreeOnceBeforeBlocking(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Implement queue mode for the YouTube factory",
@@ -1372,7 +1372,7 @@ func TestRecoverFailedHeadlessTurnRetriesLocalWorktreeOnceBeforeBlocking(t *test
 func TestRecoverTimedOutLocalWorktreeRetriesEvenAfterSubstantiveReplyIfTaskStillActive(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Implement the studio build",
@@ -1427,7 +1427,7 @@ func TestRecoverTimedOutLocalWorktreeRetriesEvenAfterSubstantiveReplyIfTaskStill
 func TestRecoverTimedOutLocalWorktreeLeavesReviewReadyTaskUnchanged(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Implement the studio build",
@@ -1482,7 +1482,7 @@ func TestRecoverTimedOutLocalWorktreeLeavesReviewReadyTaskUnchanged(t *testing.T
 func TestRecoverTimedOutHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Implement the studio build",
@@ -1533,7 +1533,7 @@ func TestRecoverTimedOutHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted(t *te
 func TestRecoverFailedHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Implement queue mode for the YouTube factory",
@@ -1587,7 +1587,7 @@ func TestRecoverFailedHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted(t *test
 func TestRecoverFailedHeadlessTurnRequeuesExternalActionBeforeBlocking(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Send a live Slack kickoff update and pivot to Notion if needed",
@@ -1691,7 +1691,7 @@ func TestHeadlessTurnCompletedDurablyAcceptsReviewReadyTask(t *testing.T) {
 
 	// See TestHeadlessTurnCompletedDurablyRejectsCodingTurn... for why
 	// we build the task state directly rather than via EnsurePlannedTask.
-	b := NewBroker()
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.tasks = []teamTask{{
 		ID:            "task-1",
@@ -1731,7 +1731,7 @@ func TestHeadlessTurnCompletedDurablyRejectsLocalWorktreeBuilderWithoutTaskState
 	}
 	defer func() { headlessCodexWorkspaceStatusSnapshot = oldSnapshot }()
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Build the dry-run intake packet",
@@ -1766,7 +1766,7 @@ func TestHeadlessTurnCompletedDurablyRejectsLocalWorktreeBuilderWithoutTaskState
 func TestHeadlessTurnCompletedDurablyRejectsExternalCompletionWithoutWorkflowEvidence(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:     "general",
 		Title:       "Create one new Notion client workspace page for the consulting engagement",
@@ -1805,7 +1805,7 @@ func TestHeadlessTurnCompletedDurablyRejectsExternalCompletionWithoutWorkflowEvi
 func TestHeadlessTurnCompletedDurablyAcceptsExternalCompletionWithWorkflowEvidence(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:     "general",
 		Title:       "Create one new Notion client workspace page for the consulting engagement",
@@ -1844,7 +1844,7 @@ func TestHeadlessTurnCompletedDurablyAcceptsExternalCompletionWithWorkflowEviden
 func TestHeadlessTurnCompletedDurablyAcceptsExternalCompletionWithActionEvidence(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:     "general",
 		Title:       "Verify the new Notion client workspace page for the consulting engagement",
@@ -1900,7 +1900,7 @@ func TestBeginHeadlessCodexTurnCapturesWorktreeForLocalWorktreeBuilder(t *testin
 		headlessCodexWorkspaceStatusSnapshot = oldSnapshot
 	}()
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
@@ -2009,7 +2009,7 @@ func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T
 func TestHeadlessCodexTurnTimeoutForLocalWorktreeTask(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Implement the studio build",
@@ -2036,7 +2036,7 @@ func TestHeadlessCodexTurnTimeoutForLocalWorktreeTask(t *testing.T) {
 func TestHeadlessCodexTurnTimeoutForOfficeLaunchTask(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
 		Title:         "Produce the launch assets and operating pack",
@@ -2190,7 +2190,7 @@ func TestPreflightHeadlessCodexAuthFailsAndPostsSystemMessage(t *testing.T) {
 		t.Fatalf("save config: %v", err)
 	}
 
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	l := &Launcher{broker: broker}
 
 	err := l.preflightHeadlessCodexAuth("operator", "general")
@@ -2229,7 +2229,7 @@ func TestPreflightHeadlessCodexAuthPassesWhenOpenAIKeySet(t *testing.T) {
 		t.Fatalf("save config: %v", err)
 	}
 
-	l := &Launcher{broker: NewBroker()}
+	l := &Launcher{broker: newTestBroker(t)}
 	if err := l.preflightHeadlessCodexAuth("operator", "general"); err != nil {
 		t.Fatalf("expected preflight to pass with OPENAI_API_KEY set, got %v", err)
 	}
@@ -2253,7 +2253,7 @@ func TestPreflightHeadlessCodexAuthPassesWhenAuthJSONPresent(t *testing.T) {
 		t.Fatalf("write auth.json: %v", err)
 	}
 
-	l := &Launcher{broker: NewBroker()}
+	l := &Launcher{broker: newTestBroker(t)}
 	if err := l.preflightHeadlessCodexAuth("operator", "general"); err != nil {
 		t.Fatalf("expected preflight to pass when auth.json exists, got %v", err)
 	}

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -1247,7 +1247,7 @@ func TestTaskNotificationContentIncludesCapabilityGapRecovery(t *testing.T) {
 }
 
 func TestBuildPromptIncludesActivePolicies(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	if err := b.SetSessionMode(SessionModeOffice, "ceo"); err != nil {
 		t.Fatalf("set session mode: %v", err)
 	}

--- a/internal/team/openclaw_e2e_test.go
+++ b/internal/team/openclaw_e2e_test.go
@@ -37,7 +37,7 @@ func TestOpenclawBridgeFullPipeline_E2E(t *testing.T) {
 		t.Fatalf("identity: %v", err)
 	}
 
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	bindings := []config.OpenclawBridgeBinding{
 		{SessionKey: "agent:e2e:demo", Slug: "openclaw-demo-e2e", DisplayName: "Demo"},
 	}

--- a/internal/team/openclaw_test.go
+++ b/internal/team/openclaw_test.go
@@ -142,7 +142,7 @@ func TestBridgeStartSubscribesAllBindings(t *testing.T) {
 // as a single session.message event — there is no delta/final split.
 func TestHandleClientEventForwardsAssistantMessage(t *testing.T) {
 	fake := newFakeOC()
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k", Slug: "openclaw-a", DisplayName: "A"}}
 	b := NewOpenclawBridge(broker, fake, bindings)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -185,7 +185,7 @@ func TestHandleClientEventForwardsAssistantMessage(t *testing.T) {
 func TestHandleClientEventSkipsUserRole(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	fake := newFakeOC()
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k", Slug: "openclaw-a"}}
 	b := NewOpenclawBridge(broker, fake, bindings)
 	_ = b.Start(context.Background())
@@ -216,7 +216,7 @@ func TestHandleClientEventSkipsUserRole(t *testing.T) {
 func TestOnOfficeMessageSuccess(t *testing.T) {
 	fake := newFakeOC()
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k", Slug: "openclaw-a"}}
-	b := NewOpenclawBridge(NewBroker(), fake, bindings)
+	b := NewOpenclawBridge(newTestBroker(t), fake, bindings)
 	_ = b.Start(context.Background())
 	defer b.Stop()
 	err := b.OnOfficeMessage(context.Background(), "openclaw-a", "general", "hello")
@@ -234,7 +234,7 @@ func TestOnOfficeMessageRetriesTransient(t *testing.T) {
 	fake := newFakeOC()
 	fake.nextSendErrs = []error{errors.New("transient 1"), errors.New("transient 2")} // first two fail, third succeeds
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k", Slug: "openclaw-a"}}
-	b := NewOpenclawBridge(NewBroker(), fake, bindings)
+	b := NewOpenclawBridge(newTestBroker(t), fake, bindings)
 	b.SetRetryDelaysForTest([]time.Duration{10 * time.Millisecond, 10 * time.Millisecond})
 	_ = b.Start(context.Background())
 	defer b.Stop()
@@ -270,7 +270,7 @@ func TestOnOfficeMessageRetriesTransient(t *testing.T) {
 // can re-prompt.
 func TestGapEventPostsSystemNotice(t *testing.T) {
 	fake := newFakeOC()
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k-gap", Slug: "openclaw-gap"}}
 	b := NewOpenclawBridge(broker, fake, bindings)
 	_ = b.Start(context.Background())
@@ -312,7 +312,7 @@ func TestReconnectOnClientClose(t *testing.T) {
 		clients = append(clients, c)
 		return c, nil
 	}
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k", Slug: "openclaw-a"}}
 	b := NewOpenclawBridgeWithDialer(broker, nil, dialer, bindings)
 	b.backoff = NewBridgeBackoff(5*time.Millisecond, 50*time.Millisecond)
@@ -345,7 +345,7 @@ func TestReconnectOnClientClose(t *testing.T) {
 func TestStartOpenclawBridgeFromConfigNoBindings(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	bridge, err := StartOpenclawBridgeFromConfig(context.Background(), broker)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -371,7 +371,7 @@ func TestStartOpenclawBridgeFromConfigWithBindings(t *testing.T) {
 	openclawBootstrapDialer = func(ctx context.Context) (openclawClient, error) { return fake, nil }
 	defer func() { openclawBootstrapDialer = nil }()
 
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	bridge, err := StartOpenclawBridgeFromConfig(context.Background(), broker)
 	if err != nil {
 		t.Fatalf("bootstrap: %v", err)
@@ -436,7 +436,7 @@ func TestStartOpenclawBridgeFromConfigWithBindings(t *testing.T) {
 
 func TestRouteOpenclawMentionsLoopForwardsHumanMention(t *testing.T) {
 	fake := newFakeOC()
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "mk", Slug: "openclaw-mentions"}}
 	bridge := NewOpenclawBridge(broker, fake, bindings)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -485,7 +485,7 @@ func TestRouteOpenclawMentionsLoopForwardsHumanMention(t *testing.T) {
 
 func TestRouteOpenclawMentionsLoopIgnoresUnrelated(t *testing.T) {
 	fake := newFakeOC()
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "mk", Slug: "openclaw-only"}}
 	bridge := NewOpenclawBridge(broker, fake, bindings)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -520,7 +520,7 @@ func TestRouteOpenclawMentionsLoopIgnoresUnrelated(t *testing.T) {
 func TestRouteOpenclawMentionsLoopForwardsDMPost(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	fake := newFakeOC()
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	// Register the bridged agent as a real office member so a DM channel can
 	// be opened against its slug.
 	if err := broker.EnsureBridgedMember("openclaw-dm", "DM Bot", "openclaw"); err != nil {
@@ -592,7 +592,7 @@ func TestRouteOpenclawMentionsLoopDedupesDMAndMention(t *testing.T) {
 	// @mention the partner would fire OnOfficeMessage twice.
 	t.Setenv("HOME", t.TempDir())
 	fake := newFakeOC()
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	if err := broker.EnsureBridgedMember("openclaw-both", "Both Bot", "openclaw"); err != nil {
 		t.Fatalf("ensure bridged member: %v", err)
 	}
@@ -639,7 +639,7 @@ func TestRouteOpenclawMentionsLoopDedupesDMAndMention(t *testing.T) {
 }
 
 func TestSuperviseOfflineNoticeDeduped(t *testing.T) {
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	dialer := func(ctx context.Context) (openclawClient, error) {
 		return nil, errors.New("dial refused")
 	}
@@ -670,7 +670,7 @@ func TestOnOfficeMessagePermanentFailurePostsSystemMessage(t *testing.T) {
 	fake := newFakeOC()
 	fake.sendErr = errors.New("forever broken")
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k", Slug: "openclaw-a"}}
-	broker := NewBroker()
+	broker := newTestBroker(t)
 	b := NewOpenclawBridge(broker, fake, bindings)
 	b.SetRetryDelaysForTest([]time.Duration{5 * time.Millisecond, 5 * time.Millisecond})
 	_ = b.Start(context.Background())

--- a/internal/team/openclaw_test.go
+++ b/internal/team/openclaw_test.go
@@ -180,8 +180,9 @@ func TestHandleClientEventForwardsAssistantMessage(t *testing.T) {
 // would boomerang back into #general as though the bridged agent had spoken.
 //
 // We snapshot the broker state before emitting the event and assert the delta
-// is zero, not that openclaw-a never appears, because NewBroker() rehydrates
-// from persisted state that may contain messages from prior runs or tests.
+// is zero rather than asserting openclaw-a never appears at all — newTestBroker(t)
+// gets a per-test tempdir, but a future helper change that rehydrates seeded
+// state would still leave the delta-based assertion correct.
 func TestHandleClientEventSkipsUserRole(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	fake := newFakeOC()

--- a/internal/team/pam_test.go
+++ b/internal/team/pam_test.go
@@ -537,7 +537,7 @@ func newPamHTTPFixture(t *testing.T) (*httptest.Server, *Broker, func()) {
 	if err := repo.Init(context.Background()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
-	b := NewBroker()
+	b := newTestBroker(t)
 	worker := NewWikiWorker(repo, b)
 	ctx, cancel := context.WithCancel(context.Background())
 	worker.Start(ctx)

--- a/internal/team/wiki_worker_test.go
+++ b/internal/team/wiki_worker_test.go
@@ -311,7 +311,7 @@ func TestBrokerWikiHandlersEndToEnd(t *testing.T) {
 	if err := repo.Init(context.Background()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
-	b := NewBroker()
+	b := newTestBroker(t)
 	worker := NewWikiWorker(repo, b)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -385,7 +385,7 @@ func TestBrokerWikiWriteRejectsBadJSON(t *testing.T) {
 	if err := repo.Init(context.Background()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
-	b := NewBroker()
+	b := newTestBroker(t)
 	worker := NewWikiWorker(repo, b)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -416,7 +416,7 @@ func TestBrokerWikiSearchRejectsEmptyPattern(t *testing.T) {
 	if err := repo.Init(context.Background()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
-	b := NewBroker()
+	b := newTestBroker(t)
 	worker := NewWikiWorker(repo, b)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -473,7 +473,7 @@ func TestBrokerWikiAuditReturnsFullLineage(t *testing.T) {
 		t.Fatalf("Commit: %v", err)
 	}
 
-	b := NewBroker()
+	b := newTestBroker(t)
 	worker := NewWikiWorker(repo, b)
 	workerCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -531,7 +531,7 @@ func TestBrokerWikiAuditRejectsBadSince(t *testing.T) {
 	if err := repo.Init(context.Background()); err != nil {
 		t.Fatalf("init: %v", err)
 	}
-	b := NewBroker()
+	b := newTestBroker(t)
 	worker := NewWikiWorker(repo, b)
 	workerCtx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -554,7 +554,7 @@ func TestBrokerWikiAuditRejectsBadSince(t *testing.T) {
 }
 
 func TestWikiPublishViaBroker(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	ch, unsubscribe := b.SubscribeWikiEvents(4)
 	defer unsubscribe()
 	evt := wikiWriteEvent{Path: "team/x.md", CommitSHA: "abc", AuthorSlug: "ceo", Timestamp: "now"}
@@ -588,7 +588,7 @@ func TestWikiRootAndBackupDirsHonorRuntimeHome(t *testing.T) {
 }
 
 func TestBrokerWikiHandlersReturn503WhenWorkerInactive(t *testing.T) {
-	b := NewBroker()
+	b := newTestBroker(t)
 	// No worker attached.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/wiki/read", b.handleWikiRead)


### PR DESCRIPTION
## Summary

Closes the structural-isolation gap left open by [#289](https://github.com/nex-crm/wuphf/pull/289). That PR migrated tests on the persistence path to `NewBrokerAt(path)` but explicitly deferred ~59 `NewBroker()` call sites in tests that were only protected behaviorally (`worktree_guard_test.go` pinning `WUPHF_RUNTIME_HOME` + `skipBrokerStateLoadOnConstruct=true`, all sharing one tempdir).

This PR migrates **all 90 remaining `NewBroker()` call sites** in `internal/team` tests across 17 files to `newTestBroker(t)`, which calls `NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))`. Each broker now gets its own bound `statePath` under a per-test tempdir — structural isolation, not behavioral.

## Files touched (17)

| Originally listed in #289 | Scope expansion |
| --- | --- |
| `broker_entity_test.go` | `broker_entity_graph_test.go` |
| `broker_nex_register_test.go` | `broker_providers_test.go` |
| `broker_notebook_test.go` | `broker_test.go` |
| `broker_review_test.go` | `broker_wiki_dlq_test.go` |
| `broker_web_test.go` | `config_endpoint_test.go` |
| `dispatch_test.go` | `launcher_test.go` |
| `headless_codex_test.go` | `openclaw_e2e_test.go` |
| `openclaw_test.go` | `pam_test.go` |
|  | `wiki_worker_test.go` |

The 9 expanded-scope files apply the same mechanical swap — they were also constructing brokers via the package-var path and getting the same shared-tempdir behavioral isolation. Treating them in the same PR keeps the migration atomic.

## What this buys

After this PR, no `internal/team` test relies on the `worktree_guard_test.go` shared-tempdir + `skipBrokerStateLoadOnConstruct` shim for state isolation. Every test broker has its own bound `statePath`. The structural invariant from #289 (`b.statePath` cannot be retargeted mid-flight, leaked goroutines write to per-broker paths) now holds for the entire test corpus.

The only remaining `NewBroker()` callers are non-test code (`broker.go` default constructor, `launcher.go`, `headless_codex.go`) and one comment in `openclaw_test.go`.

## Test plan

- [x] `go build ./internal/team/...` clean
- [x] `go vet ./internal/team/...` clean
- [x] `go test ./internal/team/...` green locally (~96s)
- [x] `go test -race -count=1 ./internal/team/...` green locally (~124s)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)