### PR TITLE
ci(docs-link-check): adopt reusable workflow from nex-crm/.github

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -17,4 +17,4 @@ on:
 
 jobs:
   check:
-    uses: nex-crm/.github/.github/workflows/docs-link-check.yml@v0.6.2
+    uses: nex-crm/.github/.github/workflows/docs-link-check.yml@34310b131f22dd1c541ea1f2aa6cf1bd531a426b # v0.6.2

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,0 +1,20 @@
+name: docs-link-check
+
+# Delegates to nex-crm/.github reusable. Catches dead links in Markdown
+# + MDX before they reach customers (especially relevant on this public
+# docs site). PR runs are scoped to doc paths; the weekly cron catches
+# external-link rot.
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '**/*.mdx'
+      - 'docs/**'
+  schedule:
+    - cron: '0 9 * * 1'  # Monday 09:00 UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    uses: nex-crm/.github/.github/workflows/docs-link-check.yml@v0.6.2


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/docs-link-check.yml`, delegating to `nex-crm/.github/.github/workflows/docs-link-check.yml@v0.6.2`.
- PRs that touch `**/*.md`, `**/*.mdx`, or `docs/**` get a lychee link-check.
- Weekly cron (Monday 09:00 UTC) catches external-link rot on main.

## Why
The 2026-04-24 audit (`NEX_CRM_REPO_AUDIT_2026_04_24.md`) flagged docs-link-check as a missing org-wide control — every repo's README/docs link to other nex-crm repos and external providers, and nothing currently catches rot. This PR adopts the existing reusable; nothing custom.

## Test plan
- [ ] Workflow appears in Actions tab after merge
- [ ] Manual `workflow_dispatch` run completes (will reveal any pre-existing dead links — fix-up tracked separately if found)
- [ ] Weekly cron triggers next Monday 09:00 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)
