### PR TITLE
test(teammcp): migrate NewBroker() test sites + characterization

### DIFF
--- a/internal/team/broker_skill_invocation_integration_test.go
+++ b/internal/team/broker_skill_invocation_integration_test.go
@@ -1,41 +1,31 @@
-package e2e
+package team
+
+// End-to-end broker skill-invocation integration test. Exercises the
+// full lifecycle a team_skill_run / MCP skill tool flows through:
+// HTTP /skills/{name}/invoke, in-memory accessors (AllMessages,
+// Actions), action-log linkage via RelatedID, and disk persistence
+// across a broker restart.
+//
+// Sibling to TestBrokerStatePersistsAcrossReload_ChannelAndMember:
+// covers a third saveLocked call site (handleInvokeSkill), with the
+// added wrinkle of asserting per-invoker From accounting and the
+// usage_count rehydration after restart. Uses reloadedBroker(t, b)
+// for the restart leg — same opt-in-to-disk-load pattern the team
+// package's other persistence tests rely on.
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/agent"
-	"github.com/nex-crm/wuphf/internal/team"
 )
 
-// TestSkillInvocationE2E exercises the broker's skill lifecycle
-// end-to-end across the HTTP surface, the in-memory accessors, and
-// disk persistence — the same surface every team_skill_run / MCP
-// invocation flows through.
-//
-// The flow:
-//  1. Construct a broker with a bound state path (post-#316 helper
-//     pattern), seed it with a skill via SeedDefaultSkills.
-//  2. Invoke the skill twice via POST /skills/{name}/invoke,
-//     attributed to two different agent slugs.
-//  3. Assert the broker's observable state: usage_count, recorded
-//     skill_invocation messages (correct From, Channel, Kind),
-//     and the action log entries.
-//  4. Stop the broker and reconstruct a fresh one against the same
-//     state path — the persisted skill, usage count, messages, and
-//     actions must all rehydrate.
-//
-// This pins the contract every other test in the repo only exercises
-// in pieces, and asserts that the structural-isolation work (#289 +
-// #316 + this branch) didn't break the persistence path.
-func TestSkillInvocationE2E(t *testing.T) {
-	statePath := filepath.Join(t.TempDir(), "broker-state.json")
-
-	b := team.NewBrokerAt(statePath)
+func TestBrokerSkillInvocationE2E_PersistsAcrossReload(t *testing.T) {
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -57,11 +47,14 @@ func TestSkillInvocationE2E(t *testing.T) {
 
 	invoke := func(t *testing.T, invokedBy string) (skillID string, usageCount int) {
 		t.Helper()
-		body, _ := json.Marshal(map[string]string{
+		body, err := json.Marshal(map[string]string{
 			"invoked_by": invokedBy,
 			"channel":    channel,
 		})
-		req, err := http.NewRequest(http.MethodPost,
+		if err != nil {
+			t.Fatalf("marshal invoke body: %v", err)
+		}
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost,
 			"http://"+b.Addr()+"/skills/"+skillName+"/invoke", bytes.NewReader(body))
 		if err != nil {
 			t.Fatalf("build invoke request: %v", err)
@@ -123,28 +116,27 @@ func TestSkillInvocationE2E(t *testing.T) {
 	}
 
 	// Action log should also show two skill_invocation entries linked
-	// to the seeded skill ID via RelatedID.
-	var actionsForSkill int
+	// to the seeded skill ID via RelatedID, sourced from "office".
+	var actionsForSkill []officeActionLog
 	for _, a := range b.Actions() {
 		if a.Kind == "skill_invocation" && a.RelatedID == skillID {
-			actionsForSkill++
+			actionsForSkill = append(actionsForSkill, a)
 		}
 	}
-	if actionsForSkill != 2 {
-		t.Errorf("expected 2 action-log entries for skill %s, got %d (all=%+v)",
-			skillID, actionsForSkill, b.Actions())
+	if len(actionsForSkill) != 2 {
+		t.Errorf("expected 2 action-log entries for skill %s, got %d (%+v)",
+			skillID, len(actionsForSkill), actionsForSkill)
+	}
+	for _, a := range actionsForSkill {
+		if a.Source != "office" {
+			t.Errorf("skill_invocation action source=%q, want %q", a.Source, "office")
+		}
 	}
 
-	// Stop the broker before reconstructing — closes the listener and
-	// flushes any in-flight saves. Persistence must survive the
-	// restart with the same bound state path.
-	b.Stop()
-
-	b2 := team.NewBrokerAt(statePath)
-	if err := b2.StartOnPort(0); err != nil {
-		t.Fatalf("restart broker: %v", err)
-	}
-	defer b2.Stop()
+	// Restart the broker against the same state path via the documented
+	// helper — opts back in to loadState(), which test-mode NewBrokerAt
+	// otherwise skips to prevent cross-test state leakage.
+	b2 := reloadedBroker(t, b)
 
 	var rehydrated int
 	for _, m := range b2.AllMessages() {
@@ -157,7 +149,12 @@ func TestSkillInvocationE2E(t *testing.T) {
 	}
 
 	// Confirm the skill itself survived and the usage count persisted.
-	req, err := http.NewRequest(http.MethodGet,
+	if err := b2.StartOnPort(0); err != nil {
+		t.Fatalf("restart broker: %v", err)
+	}
+	defer b2.Stop()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
 		"http://"+b2.Addr()+"/skills?channel="+channel, nil)
 	if err != nil {
 		t.Fatalf("build skills request: %v", err)

--- a/internal/teammcp/actions_test.go
+++ b/internal/teammcp/actions_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/nex-crm/wuphf/internal/action"
-	"github.com/nex-crm/wuphf/internal/team"
 )
 
 type stubActionProvider struct{}
@@ -174,7 +173,7 @@ func TestRequireTeamActionApprovalBypasses(t *testing.T) {
 
 func TestHandleTeamActionExecuteLogsBrokerAction(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -215,7 +214,7 @@ func TestHandleTeamActionExecuteLogsBrokerAction(t *testing.T) {
 
 func TestHandleTeamActionWorkflowCreateMirrorsSkill(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -268,7 +267,7 @@ func TestHandleTeamActionWorkflowCreateMirrorsSkill(t *testing.T) {
 
 func TestHandleTeamActionWorkflowScheduleCreatesSchedulerJob(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -321,7 +320,7 @@ func TestHandleTeamActionWorkflowScheduleCreatesSchedulerJob(t *testing.T) {
 
 func TestHandleTeamActionWorkflowScheduleRunNowExecutesImmediately(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}

--- a/internal/teammcp/broker_construction_test.go
+++ b/internal/teammcp/broker_construction_test.go
@@ -1,0 +1,130 @@
+package teammcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// These tests pin the broker-construction invariants that every other
+// teammcp test implicitly depends on:
+//
+//  1. A freshly-constructed broker, in a teammcp test scoped by
+//     t.Setenv("HOME", t.TempDir()), starts with no skills, no actions,
+//     and no skill-invocation messages — i.e. nothing leaks in from any
+//     prior test in the package binary.
+//
+//  2. Two brokers constructed in the same test process with disjoint
+//     HOME tempdirs do not see each other's mutations. State is per-
+//     broker, not shared across constructions.
+//
+// These hold under the current `team.NewBroker()` + `t.Setenv("HOME",...)`
+// pattern. Any future migration of this package's broker construction
+// (e.g. to NewBrokerAt or a newTestBroker helper) must keep them green.
+// If they regress, the package's other tests can silently corrupt each
+// other through state leakage and the symptoms will be flaky/wrong.
+
+func TestBrokerConstructionFreshHasZeroState(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	b := team.NewBroker()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	if got := len(b.Actions()); got != 0 {
+		t.Fatalf("fresh broker should have zero actions, got %d (%+v)", got, b.Actions())
+	}
+	for _, m := range b.AllMessages() {
+		switch m.Kind {
+		case "skill_invocation", "external_action_planned":
+			t.Fatalf("fresh broker should have no skill/action messages, found %+v", m)
+		}
+	}
+	if got := len(b.Requests("general", true)); got != 0 {
+		t.Fatalf("fresh broker should have zero requests in general, got %d", got)
+	}
+	if skills := fetchSkillNames(t, b, "general"); len(skills) != 0 {
+		t.Fatalf("fresh broker should expose zero skills in general, got %v", skills)
+	}
+}
+
+func TestBrokerConstructionTwoBrokersDoNotShareState(t *testing.T) {
+	// Broker 1: scoped to its own HOME, seed a uniquely-named skill.
+	t.Setenv("HOME", t.TempDir())
+	b1 := team.NewBroker()
+	if err := b1.StartOnPort(0); err != nil {
+		t.Fatalf("start b1: %v", err)
+	}
+	defer b1.Stop()
+	b1.SeedDefaultSkills([]agent.PackSkillSpec{{
+		Name:        "iso-marker-skill",
+		Title:       "Isolation Marker",
+		Description: "If b2 sees this name, the construction-isolation invariant has regressed.",
+		Trigger:     "n/a",
+		Tags:        []string{"characterization"},
+		Content:     "n/a",
+	}})
+
+	// Sanity: b1 itself sees its own seeded skill.
+	if got := fetchSkillNames(t, b1, "general"); !sliceContains(got, "iso-marker-skill") {
+		t.Fatalf("b1 should see its own seeded skill, got %v", got)
+	}
+
+	// Broker 2: distinct HOME, freshly constructed.
+	t.Setenv("HOME", t.TempDir())
+	b2 := team.NewBroker()
+	if err := b2.StartOnPort(0); err != nil {
+		t.Fatalf("start b2: %v", err)
+	}
+	defer b2.Stop()
+
+	// b2 must NOT see b1's marker — that would mean state leaked across
+	// constructions through a shared default state path.
+	if got := fetchSkillNames(t, b2, "general"); sliceContains(got, "iso-marker-skill") {
+		t.Fatalf("b2 leaked b1's marker skill (state-isolation regression); b2 skills=%v", got)
+	}
+	for _, m := range b2.AllMessages() {
+		if m.Kind == "skill_invocation" || m.Kind == "external_action_planned" {
+			t.Fatalf("b2 should be empty but observed leaked message %+v", m)
+		}
+	}
+}
+
+func fetchSkillNames(t *testing.T, b *team.Broker, channel string) []string {
+	t.Helper()
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
+		"http://"+b.Addr()+"/skills?channel="+channel, nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get skills: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Skills []struct {
+			Name string `json:"name"`
+		} `json:"skills"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode skills: %v", err)
+	}
+	names := make([]string, 0, len(body.Skills))
+	for _, s := range body.Skills {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+func sliceContains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/teammcp/broker_construction_test.go
+++ b/internal/teammcp/broker_construction_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/agent"
@@ -13,92 +14,127 @@ import (
 // These tests pin the broker-construction invariants that every other
 // teammcp test implicitly depends on:
 //
-//  1. A freshly-constructed broker, in a teammcp test scoped by
-//     t.Setenv("HOME", t.TempDir()), starts with no skills, no actions,
-//     and no skill-invocation messages — i.e. nothing leaks in from any
+//  1. A freshly-constructed broker starts with no skills, no actions,
+//     and no skill-invocation messages — nothing leaks in from any
 //     prior test in the package binary.
 //
-//  2. Two brokers constructed in the same test process with disjoint
-//     HOME tempdirs do not see each other's mutations. State is per-
-//     broker, not shared across constructions.
+//  2. Two brokers constructed in the same test process do not see each
+//     other's mutations. State is per-broker, not shared across
+//     constructions.
 //
-// These hold under the current `team.NewBroker()` + `t.Setenv("HOME",...)`
-// pattern. Any future migration of this package's broker construction
-// (e.g. to NewBrokerAt or a newTestBroker helper) must keep them green.
-// If they regress, the package's other tests can silently corrupt each
-// other through state leakage and the symptoms will be flaky/wrong.
+// Each test runs under both construction strategies:
+//   - "legacy": `t.Setenv("HOME", t.TempDir())` + `team.NewBroker()` —
+//     the pre-#316 pattern; behavioral isolation via env shim.
+//   - "helper": `newTestBroker(t)` — calls `team.NewBrokerAt(...)` with a
+//     per-t tempdir; structural isolation via bound `b.statePath`.
+//
+// Both must pass. The legacy variant is the regression detector if a
+// future change to defaultBrokerStatePath() / RuntimeHomeDir() breaks
+// HOME-scoped isolation. The helper variant directly asserts that
+// newTestBroker(t) preserves the same invariants.
+
+type brokerCtor struct {
+	name string
+	new  func(*testing.T) *team.Broker
+}
+
+func brokerCtors() []brokerCtor {
+	return []brokerCtor{
+		{
+			name: "legacy",
+			new: func(t *testing.T) *team.Broker {
+				t.Helper()
+				t.Setenv("HOME", t.TempDir())
+				return team.NewBroker()
+			},
+		},
+		{
+			name: "helper",
+			new: func(t *testing.T) *team.Broker {
+				t.Helper()
+				return newTestBroker(t)
+			},
+		},
+	}
+}
 
 func TestBrokerConstructionFreshHasZeroState(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
-	if err := b.StartOnPort(0); err != nil {
-		t.Fatalf("start broker: %v", err)
-	}
-	defer b.Stop()
+	for _, ctor := range brokerCtors() {
+		t.Run(ctor.name, func(t *testing.T) {
+			b := ctor.new(t)
+			if err := b.StartOnPort(0); err != nil {
+				t.Fatalf("start broker: %v", err)
+			}
+			defer b.Stop()
 
-	if got := len(b.Actions()); got != 0 {
-		t.Fatalf("fresh broker should have zero actions, got %d (%+v)", got, b.Actions())
-	}
-	for _, m := range b.AllMessages() {
-		switch m.Kind {
-		case "skill_invocation", "external_action_planned":
-			t.Fatalf("fresh broker should have no skill/action messages, found %+v", m)
-		}
-	}
-	if got := len(b.Requests("general", true)); got != 0 {
-		t.Fatalf("fresh broker should have zero requests in general, got %d", got)
-	}
-	if skills := fetchSkillNames(t, b, "general"); len(skills) != 0 {
-		t.Fatalf("fresh broker should expose zero skills in general, got %v", skills)
+			if got := len(b.Actions()); got != 0 {
+				t.Fatalf("fresh broker should have zero actions, got %d (%+v)", got, b.Actions())
+			}
+			for _, m := range b.AllMessages() {
+				switch m.Kind {
+				case "skill_invocation", "external_action_planned":
+					t.Fatalf("fresh broker should have no skill/action messages, found %+v", m)
+				}
+			}
+			if got := len(b.Requests("general", true)); got != 0 {
+				t.Fatalf("fresh broker should have zero requests in general, got %d", got)
+			}
+			if skills := fetchSkillNames(t, b, "general"); len(skills) != 0 {
+				t.Fatalf("fresh broker should expose zero skills in general, got %v", skills)
+			}
+		})
 	}
 }
 
 func TestBrokerConstructionTwoBrokersDoNotShareState(t *testing.T) {
-	// Broker 1: scoped to its own HOME, seed a uniquely-named skill.
-	t.Setenv("HOME", t.TempDir())
-	b1 := team.NewBroker()
-	if err := b1.StartOnPort(0); err != nil {
-		t.Fatalf("start b1: %v", err)
-	}
-	defer b1.Stop()
-	b1.SeedDefaultSkills([]agent.PackSkillSpec{{
-		Name:        "iso-marker-skill",
-		Title:       "Isolation Marker",
-		Description: "If b2 sees this name, the construction-isolation invariant has regressed.",
-		Trigger:     "n/a",
-		Tags:        []string{"characterization"},
-		Content:     "n/a",
-	}})
+	for _, ctor := range brokerCtors() {
+		t.Run(ctor.name, func(t *testing.T) {
+			b1 := ctor.new(t)
+			if err := b1.StartOnPort(0); err != nil {
+				t.Fatalf("start b1: %v", err)
+			}
+			defer b1.Stop()
+			b1.SeedDefaultSkills([]agent.PackSkillSpec{{
+				Name:        "iso-marker-skill",
+				Title:       "Isolation Marker",
+				Description: "If b2 sees this name, the construction-isolation invariant has regressed.",
+				Trigger:     "n/a",
+				Tags:        []string{"characterization"},
+				Content:     "n/a",
+			}})
 
-	// Sanity: b1 itself sees its own seeded skill.
-	if got := fetchSkillNames(t, b1, "general"); !sliceContains(got, "iso-marker-skill") {
-		t.Fatalf("b1 should see its own seeded skill, got %v", got)
-	}
+			// Sanity: b1 itself sees its own seeded skill.
+			if got := fetchSkillNames(t, b1, "general"); !sliceContains(got, "iso-marker-skill") {
+				t.Fatalf("b1 should see its own seeded skill, got %v", got)
+			}
 
-	// Broker 2: distinct HOME, freshly constructed.
-	t.Setenv("HOME", t.TempDir())
-	b2 := team.NewBroker()
-	if err := b2.StartOnPort(0); err != nil {
-		t.Fatalf("start b2: %v", err)
-	}
-	defer b2.Stop()
+			b2 := ctor.new(t)
+			if err := b2.StartOnPort(0); err != nil {
+				t.Fatalf("start b2: %v", err)
+			}
+			defer b2.Stop()
 
-	// b2 must NOT see b1's marker — that would mean state leaked across
-	// constructions through a shared default state path.
-	if got := fetchSkillNames(t, b2, "general"); sliceContains(got, "iso-marker-skill") {
-		t.Fatalf("b2 leaked b1's marker skill (state-isolation regression); b2 skills=%v", got)
-	}
-	for _, m := range b2.AllMessages() {
-		if m.Kind == "skill_invocation" || m.Kind == "external_action_planned" {
-			t.Fatalf("b2 should be empty but observed leaked message %+v", m)
-		}
+			// b2 must NOT see b1's marker — that would mean state leaked
+			// across constructions through a shared default state path.
+			if got := fetchSkillNames(t, b2, "general"); sliceContains(got, "iso-marker-skill") {
+				t.Fatalf("b2 leaked b1's marker skill (state-isolation regression); b2 skills=%v", got)
+			}
+			for _, m := range b2.AllMessages() {
+				if m.Kind == "skill_invocation" || m.Kind == "external_action_planned" {
+					t.Fatalf("b2 should be empty but observed leaked message %+v", m)
+				}
+			}
+		})
 	}
 }
 
 func fetchSkillNames(t *testing.T, b *team.Broker, channel string) []string {
 	t.Helper()
-	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet,
-		"http://"+b.Addr()+"/skills?channel="+channel, nil)
+	skillsURL := "http://" + b.Addr() + "/skills?channel=" + url.QueryEscape(channel)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, skillsURL, nil)
+	if err != nil {
+		t.Fatalf("build skills request: %v", err)
+	}
 	req.Header.Set("Authorization", "Bearer "+b.Token())
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/teammcp/server_test.go
+++ b/internal/teammcp/server_test.go
@@ -292,7 +292,7 @@ func TestIsOneOnOneModeFromEnv(t *testing.T) {
 
 func TestHandleTeamMemberCreateTriggersReconfigure(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -336,7 +336,7 @@ func TestHandleTeamMemberCreateTriggersReconfigure(t *testing.T) {
 func TestHandleTeamChannelCreateTriggersReconfigure(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ctx := context.Background()
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -406,7 +406,7 @@ func TestHandleTeamChannelCreateRequiresExplicitSlug(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("WUPHF_CHANNEL", "general")
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -458,7 +458,7 @@ func TestHandleHumanMessageUsesDirectSessionLabelInOneOnOneMode(t *testing.T) {
 	t.Setenv("WUPHF_ONE_ON_ONE", "1")
 	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -494,7 +494,7 @@ func TestHandleHumanMessageUsesDirectSessionLabelInOneOnOneMode(t *testing.T) {
 func TestHandleTeamMemoryWriteAndQueryPrivate(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -530,7 +530,7 @@ func TestHandleTeamMemoryWriteAndQueryPrivate(t *testing.T) {
 func TestHandleTeamMemoryWriteHintsPromotionForDurableNote(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -585,7 +585,7 @@ func TestHandleTeamMemoryQueryAutoIncludesSharedNexMemory(t *testing.T) {
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -650,7 +650,7 @@ func TestHandleTeamMemoryPromoteWritesSharedNexMemory(t *testing.T) {
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -710,7 +710,7 @@ func TestHandleTeamMemoryQuerySharedSuggestsRoutingHint(t *testing.T) {
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -743,7 +743,7 @@ func TestHandleTeamPollOneOnOneHighlightsLatestHumanRequest(t *testing.T) {
 	t.Setenv("WUPHF_ONE_ON_ONE", "1")
 	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -785,7 +785,7 @@ func TestHandleTeamPollScopesMessagesForNonCEO(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ctx := context.Background()
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -863,7 +863,7 @@ func TestHandleTeamTaskStatusReportsWorktreeIsolation(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ctx := context.Background()
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -949,7 +949,7 @@ func TestHandleTeamTaskReturnsWorktreeGuidance(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ctx := context.Background()
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1020,7 +1020,7 @@ func TestHandleTeamRuntimeStateIncludesRecoveryAndCapabilities(t *testing.T) {
 	t.Setenv("WUPHF_NO_NEX", "1")
 	ctx := context.Background()
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1117,7 +1117,7 @@ func TestHandleTeamRuntimeStateIncludesRecoveryAndCapabilities(t *testing.T) {
 func TestHandleTeamRequestDefaultsApprovalOptions(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1164,7 +1164,7 @@ func TestHandleTeamPollUsesAgentScopedTranscript(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ctx := context.Background()
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1205,7 +1205,7 @@ func TestHandleTeamBroadcastDefaultsToLatestTaggedChannelAndThread(t *testing.T)
 	t.Setenv("HOME", t.TempDir())
 	ctx := context.Background()
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1266,7 +1266,7 @@ func TestHandleTeamPollDefaultsToLatestTaggedChannel(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ctx := context.Background()
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1312,7 +1312,7 @@ func TestHandleTeamTaskUsesTaskChannelWhenIDGiven(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ctx := context.Background()
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1368,7 +1368,7 @@ func TestHandleHumanMessageDefaultsToDirectReplyThreadInOneOnOneMode(t *testing.
 	t.Setenv("WUPHF_ONE_ON_ONE", "1")
 	ctx := context.Background()
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1409,7 +1409,7 @@ func TestHandleTeamInboxAndOutboxExposeOwnedTranscriptSlices(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	ctx := context.Background()
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1533,7 +1533,7 @@ func TestDetectUntaggedMentions(t *testing.T) {
 func TestHandleTeamPlanCreatesDependentBlockedTasks(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1587,7 +1587,7 @@ func TestHandleTeamPlanCreatesDependentBlockedTasks(t *testing.T) {
 func TestHandleTeamPlanPreservesTaskMetadata(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -1635,7 +1635,7 @@ func TestHandleTeamPlanPreservesTaskMetadata(t *testing.T) {
 func TestHandleTeamTaskCreatePreservesTaskMetadata(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}

--- a/internal/teammcp/skills_test.go
+++ b/internal/teammcp/skills_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/agent"
-	"github.com/nex-crm/wuphf/internal/team"
 )
 
 func TestTeamSkillCreateRegisteredForSpecialists(t *testing.T) {
@@ -36,7 +35,7 @@ func TestTeamSkillCreateRegisteredForSpecialists(t *testing.T) {
 // to the calling agent (not "you").
 func TestHandleTeamSkillRunBumpsUsageAndLogsInvocation(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -145,7 +144,7 @@ func TestHandleTeamSkillRunBumpsUsageAndLogsInvocation(t *testing.T) {
 // (so the agent sees the failure) rather than panicking.
 func TestHandleTeamSkillRunMissingSkillReturnsToolError(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -169,7 +168,7 @@ func TestHandleTeamSkillRunMissingSkillReturnsToolError(t *testing.T) {
 
 func TestHandleTeamSkillCreateProposesSkill(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -228,7 +227,7 @@ func TestHandleTeamSkillCreateProposesSkill(t *testing.T) {
 
 func TestHandleTeamSkillCreateCanActivateImmediately(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}
@@ -281,7 +280,7 @@ func TestHandleTeamSkillCreateCanActivateImmediately(t *testing.T) {
 
 func TestHandleTeamSkillCreateAllowsNonCEOProposal(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	b := team.NewBroker()
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("start broker: %v", err)
 	}

--- a/internal/teammcp/testmain_test.go
+++ b/internal/teammcp/testmain_test.go
@@ -2,6 +2,7 @@ package teammcp
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/team"
@@ -17,4 +18,15 @@ import (
 func TestMain(m *testing.M) {
 	team.DisableRealTaskWorktreeForTests()
 	os.Exit(m.Run())
+}
+
+// newTestBroker mirrors internal/team's unexported newTestBroker(t):
+// returns a Broker whose state path is pinned under t.TempDir(), so each
+// test gets its own bound statePath rather than sharing the package-var
+// default resolution. Use this for any teammcp test that constructs a
+// broker; reach for team.NewBrokerAt directly only when the test also
+// needs the path string itself.
+func newTestBroker(t *testing.T) *team.Broker {
+	t.Helper()
+	return team.NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
 }

--- a/tests/e2e/skill_invocation_test.go
+++ b/tests/e2e/skill_invocation_test.go
@@ -1,0 +1,198 @@
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// TestSkillInvocationE2E exercises the broker's skill lifecycle
+// end-to-end across the HTTP surface, the in-memory accessors, and
+// disk persistence — the same surface every team_skill_run / MCP
+// invocation flows through.
+//
+// The flow:
+//  1. Construct a broker with a bound state path (post-#316 helper
+//     pattern), seed it with a skill via SeedDefaultSkills.
+//  2. Invoke the skill twice via POST /skills/{name}/invoke,
+//     attributed to two different agent slugs.
+//  3. Assert the broker's observable state: usage_count, recorded
+//     skill_invocation messages (correct From, Channel, Kind),
+//     and the action log entries.
+//  4. Stop the broker and reconstruct a fresh one against the same
+//     state path — the persisted skill, usage count, messages, and
+//     actions must all rehydrate.
+//
+// This pins the contract every other test in the repo only exercises
+// in pieces, and asserts that the structural-isolation work (#289 +
+// #316 + this branch) didn't break the persistence path.
+func TestSkillInvocationE2E(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "broker-state.json")
+
+	b := team.NewBrokerAt(statePath)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+
+	const (
+		skillName  = "investigate"
+		skillTitle = "Investigate a Bug"
+		channel    = "general"
+	)
+
+	b.SeedDefaultSkills([]agent.PackSkillSpec{{
+		Name:        skillName,
+		Title:       skillTitle,
+		Description: "Systematic debugging with root cause analysis.",
+		Trigger:     "When a bug or error is reported",
+		Tags:        []string{"engineering", "debugging"},
+		Content:     "Step 1: Reproduce. Step 2: Isolate. Step 3: Root cause. Step 4: Fix.",
+	}})
+
+	invoke := func(t *testing.T, invokedBy string) (skillID string, usageCount int) {
+		t.Helper()
+		body, _ := json.Marshal(map[string]string{
+			"invoked_by": invokedBy,
+			"channel":    channel,
+		})
+		req, err := http.NewRequest(http.MethodPost,
+			"http://"+b.Addr()+"/skills/"+skillName+"/invoke", bytes.NewReader(body))
+		if err != nil {
+			t.Fatalf("build invoke request: %v", err)
+		}
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("invoke skill: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("invoke skill: status=%d", resp.StatusCode)
+		}
+		var out struct {
+			Skill struct {
+				ID         string `json:"id"`
+				UsageCount int    `json:"usage_count"`
+			} `json:"skill"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode invoke response: %v", err)
+		}
+		return out.Skill.ID, out.Skill.UsageCount
+	}
+
+	skillID, count := invoke(t, "eng")
+	if count != 1 {
+		t.Fatalf("first invoke: expected usage_count=1, got %d", count)
+	}
+	if skillID == "" {
+		t.Fatal("first invoke: skill ID missing from response")
+	}
+
+	if _, count2 := invoke(t, "qa"); count2 != 2 {
+		t.Fatalf("second invoke: expected usage_count=2, got %d", count2)
+	}
+
+	// Validate observable state: two skill_invocation messages with
+	// distinct From slugs, attributed to the requested channel.
+	invocations := map[string]int{}
+	for _, m := range b.AllMessages() {
+		if m.Kind != "skill_invocation" {
+			continue
+		}
+		if m.Channel != channel {
+			t.Errorf("skill_invocation in unexpected channel %q (want %q)", m.Channel, channel)
+		}
+		if m.Title != skillTitle {
+			t.Errorf("skill_invocation title=%q, want %q", m.Title, skillTitle)
+		}
+		invocations[m.From]++
+	}
+	if invocations["eng"] != 1 {
+		t.Errorf("expected exactly 1 invocation by eng, got %d", invocations["eng"])
+	}
+	if invocations["qa"] != 1 {
+		t.Errorf("expected exactly 1 invocation by qa, got %d", invocations["qa"])
+	}
+
+	// Action log should also show two skill_invocation entries linked
+	// to the seeded skill ID via RelatedID.
+	var actionsForSkill int
+	for _, a := range b.Actions() {
+		if a.Kind == "skill_invocation" && a.RelatedID == skillID {
+			actionsForSkill++
+		}
+	}
+	if actionsForSkill != 2 {
+		t.Errorf("expected 2 action-log entries for skill %s, got %d (all=%+v)",
+			skillID, actionsForSkill, b.Actions())
+	}
+
+	// Stop the broker before reconstructing — closes the listener and
+	// flushes any in-flight saves. Persistence must survive the
+	// restart with the same bound state path.
+	b.Stop()
+
+	b2 := team.NewBrokerAt(statePath)
+	if err := b2.StartOnPort(0); err != nil {
+		t.Fatalf("restart broker: %v", err)
+	}
+	defer b2.Stop()
+
+	var rehydrated int
+	for _, m := range b2.AllMessages() {
+		if m.Kind == "skill_invocation" {
+			rehydrated++
+		}
+	}
+	if rehydrated != 2 {
+		t.Errorf("expected 2 skill_invocation messages to rehydrate, got %d", rehydrated)
+	}
+
+	// Confirm the skill itself survived and the usage count persisted.
+	req, err := http.NewRequest(http.MethodGet,
+		"http://"+b2.Addr()+"/skills?channel="+channel, nil)
+	if err != nil {
+		t.Fatalf("build skills request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+b2.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("get skills: %v", err)
+	}
+	defer resp.Body.Close()
+	var skillsBody struct {
+		Skills []struct {
+			Name       string `json:"name"`
+			UsageCount int    `json:"usage_count"`
+		} `json:"skills"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&skillsBody); err != nil {
+		t.Fatalf("decode skills: %v", err)
+	}
+	var found bool
+	for _, s := range skillsBody.Skills {
+		if s.Name != skillName {
+			continue
+		}
+		found = true
+		if s.UsageCount != 2 {
+			t.Errorf("rehydrated skill usage_count=%d, want 2", s.UsageCount)
+		}
+	}
+	if !found {
+		names := make([]string, 0, len(skillsBody.Skills))
+		for _, s := range skillsBody.Skills {
+			names = append(names, s.Name)
+		}
+		t.Errorf("seeded skill %q not found after restart; skills=%s",
+			skillName, strings.Join(names, ","))
+	}
+}


### PR DESCRIPTION
## Summary

Closes the structural-isolation gap left open by [#316](https://github.com/nex-crm/wuphf/pull/316). That PR migrated the team package's own tests; this PR migrates the **33 `team.NewBroker()` call sites in `internal/teammcp` tests** that #316 explicitly flagged as out-of-scope follow-up, and lands a **characterization test floor first** (analogous to PR [#288](https://github.com/nex-crm/wuphf/pull/288)'s role for the team package's Track A refactor).

## Five commits, in order

### 1. `8d09f4d2` — characterize broker-construction isolation invariants

Adds `internal/teammcp/broker_construction_test.go` pinning the two invariants every other teammcp test silently relies on:

- **`TestBrokerConstructionFreshHasZeroState`** — a freshly-constructed broker starts with zero actions, zero skill/action messages, zero requests, zero skills via `/skills`. No leakage from prior tests.
- **`TestBrokerConstructionTwoBrokersDoNotShareState`** — two brokers in the same test process do not see each other's state. b1 seeds `iso-marker-skill`; b2 must not observe it.

### 2. `d7ce95e0` — migrate `team.NewBroker()` → `newTestBroker(t)` across 33 sites

| File | Sites |
| --- | --- |
| `actions_test.go` | 4 |
| `skills_test.go` | 5 |
| `server_test.go` | 24 |
| **Total** | **33** |

Helper added to `testmain_test.go` mirrors `internal/team`'s unexported helper:
```go
func newTestBroker(t *testing.T) *team.Broker {
    t.Helper()
    return team.NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
}
```

`b.statePath` now bound at construction — structural isolation, no reliance on `$HOME` resolution. The existing `t.Setenv("HOME", ...)` shims **stay** because they're load-bearing for non-broker paths (`RuntimeHomeDir`, agent log dirs, manifest paths).

The 3 `team.NewBroker()` references in `broker_construction_test.go` are intentional — the characterization needs the OLD pattern to remain meaningful as a regression detector.

### 3. `598f5757` — table-drive characterization over both broker constructors

Addresses staff-review nit: original characterization only exercised the legacy `team.NewBroker()` + HOME-shim pattern. Now both characterization tests table-drive over a `brokerCtors()` slice with `legacy` (pre-#316 pattern) and `helper` (`newTestBroker(t)`) strategies. Both must pass — directly asserts `newTestBroker(t)` preserves the contract instead of inferring it from migrated tests.

Also drive-by hardens `fetchSkillNames`: propagates `http.NewRequestWithContext` error and `url.QueryEscape`s the channel name.

### 4. `20108de3` — add skill-invocation lifecycle end-to-end test

New cross-cutting test exercising the broker's skill flow across HTTP, in-memory accessors, action log, and disk persistence — the same surface `team_skill_run` and the MCP skill tools flow through.

### 5. `e27f4443` — move skill-invocation test into `internal/team/`

Addresses staff-review IMPORTANT finding on commit 4: the original location in `tests/e2e/` worked only because that package doesn't trigger `internal/team/worktree_guard_test.go:init()` flipping `skipBrokerStateLoadOnConstruct = true`. The team package already has the documented helper for this seam (`reloadedBroker(t, b)` at `internal/team/broker_test.go:104`). The test now lives next to its sibling `TestBrokerStatePersistsAcrossReload_ChannelAndMember` and uses the same opt-in-to-disk-load pattern.

Drive-by review nits also applied: `http.NewRequestWithContext` for parity, explicit `json.Marshal` error check, pin `Source == "office"` on action-log entries, filter the failure diagnostic to relevant entries.

## Verification

| Check | After commit 5 |
| --- | --- |
| `go build ./internal/teammcp/...` | ✅ |
| `go vet ./internal/teammcp/...` | ✅ |
| `go test ./internal/teammcp/...` | ✅ |
| `go test ./internal/team/...` | ✅ |
| `go test -race -count=1 ./internal/team/...` | ✅ (~119s) |
| `go test -race -count=1 ./internal/teammcp/...` | ✅ |
| `go test -race -count=1 ./tests/e2e/...` | ✅ |

Both characterization tests pass under both constructors. The skill-invocation integration test exercises HTTP → save-to-disk → restart → rehydrate via the documented `reloadedBroker(t, b)` opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)