### PR TITLE
fix(team): drain headless codex queue workers via stop channel

### DIFF
--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -228,7 +228,7 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 				appendHeadlessCodexLog(slug, "queue-replace: refreshed pending turn for same task")
 			}
 			if startWorker {
-				go l.runHeadlessCodexQueue(slug)
+				l.spawnHeadlessWorker(slug)
 			}
 			return
 		}
@@ -277,7 +277,7 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 			l.headlessMu.Unlock()
 			appendHeadlessCodexLog(slug, "queue-replace: lead queue at cap, replacing pending turn with urgent task notification")
 			if startWorker {
-				go l.runHeadlessCodexQueue(slug)
+				l.spawnHeadlessWorker(slug)
 			}
 			return
 		}
@@ -309,27 +309,7 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 		cancel()
 	}
 	if startWorker {
-		// TODO(test-isolation): this goroutine has no per-test cleanup channel,
-		// so under `go test -race ./internal/team/` it outlives the spawning
-		// test and trips DATA RACE on subsequent tests' setup of headlessActive
-		// / headlessQueues maps. Reproducible:
-		//
-		//   bash scripts/test-go.sh ./internal/team   # passes (-race carved out)
-		//   go test -race ./internal/team             # flakes
-		//
-		// The race detector trace (representative — different tests on each run):
-		//
-		//   Write at ... by goroutine N (this gowrap, after test exit):
-		//     (*Launcher).beginHeadlessCodexTurn  ← l.headlessActive[slug] = …
-		//   Previous read at ... by goroutine N-1 (test cleanup, finished):
-		//     TestRecoverFailedHeadlessTurnRequeues...  ← delete(l.headlessActive, slug)
-		//
-		// Fix shape: thread a per-test stop channel through Launcher (or
-		// reuse l.broker.stopCh) and have runHeadlessCodexQueue select on
-		// it inside its outer for-loop, so test cleanup can drain in-flight
-		// workers before the next TestMain leg starts. Tracked alongside
-		// the carve-out in .github/workflows/ci.yml (go-test-list).
-		go l.runHeadlessCodexQueue(slug)
+		l.spawnHeadlessWorker(slug)
 	}
 }
 
@@ -371,8 +351,57 @@ func (l *Launcher) headlessLeadTurnNeedsImmediateWakeLocked(slug, prompt string)
 	return false
 }
 
-func (l *Launcher) runHeadlessCodexQueue(slug string) {
+// spawnHeadlessWorker starts a runHeadlessCodexQueue goroutine and registers
+// it with l.headlessWorkerWg so stopHeadlessWorkers can drain it. Lazily
+// initialises l.headlessStopCh; safe for any Launcher (including bare
+// `&Launcher{}` literals that tests construct). All `go runHeadlessCodexQueue`
+// sites must funnel through here so no worker escapes the WaitGroup.
+func (l *Launcher) spawnHeadlessWorker(slug string) {
+	l.headlessMu.Lock()
+	if l.headlessStopCh == nil {
+		l.headlessStopCh = make(chan struct{})
+	}
+	stop := l.headlessStopCh
+	l.headlessWorkerWg.Add(1)
+	l.headlessMu.Unlock()
+	go l.runHeadlessCodexQueue(slug, stop)
+}
+
+// stopHeadlessWorkers signals every live runHeadlessCodexQueue goroutine to
+// exit at its next outer-loop tick and waits for them to drain. Idempotent —
+// safe to call multiple times. Used by tests via t.Cleanup so a queue worker
+// spawned by the current test can't outlive the test and race the next test's
+// setup of headlessActive / headlessQueues / the test t.TempDir cleanup.
+func (l *Launcher) stopHeadlessWorkers() {
+	l.headlessMu.Lock()
+	if l.headlessStopCh == nil {
+		l.headlessStopCh = make(chan struct{})
+	}
+	select {
+	case <-l.headlessStopCh:
+		// already closed; idempotent re-entry
+	default:
+		close(l.headlessStopCh)
+	}
+	l.headlessMu.Unlock()
+	l.headlessWorkerWg.Wait()
+}
+
+func (l *Launcher) runHeadlessCodexQueue(slug string, stop <-chan struct{}) {
+	defer l.headlessWorkerWg.Done()
 	for {
+		// Stop signal short-circuits the loop before grabbing more work.
+		// The check is cheap (non-blocking select) and only fires on test
+		// cleanup or graceful shutdown — production traffic never closes
+		// stop while the worker is in steady state.
+		select {
+		case <-stop:
+			l.headlessMu.Lock()
+			delete(l.headlessWorkers, slug)
+			l.headlessMu.Unlock()
+			return
+		default:
+		}
 		func() {
 			defer recoverPanicTo("runHeadlessCodexQueue", fmt.Sprintf("slug=%s", slug))
 			turn, turnCtx, startedAt, timeout, ok := l.beginHeadlessCodexTurn(slug)

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -383,7 +383,18 @@ func (l *Launcher) stopHeadlessWorkers() {
 	default:
 		close(l.headlessStopCh)
 	}
+	cancel := l.headlessCancel
 	l.headlessMu.Unlock()
+	// Cancel any in-flight turn so the worker doesn't sit inside
+	// headlessCodexRunTurn for the full per-turn timeout (minutes) before
+	// noticing stopHeadlessCh closed at the outer-loop tick. Without this,
+	// production-shape paths with a real provider would hang Wait() until
+	// the turn ctx times out. Tests using the headlessCodexRunTurn override
+	// already return fast, so the bug only bites when the override is the
+	// real call path — but the cost of guarding here is one nil-check.
+	if cancel != nil {
+		cancel()
+	}
 	l.headlessWorkerWg.Wait()
 }
 

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -600,7 +600,7 @@ func TestEnqueueHeadlessCodexTurnProcessesFIFO(t *testing.T) {
 		return nil
 	})
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 
 	// Use a specialist slug (not the lead/ceo) so the cap-at-1 and queue-hold
 	// logic for the lead agent does not interfere with this FIFO test.
@@ -665,7 +665,7 @@ func TestSendTaskUpdatePassesTaskChannelToHeadlessTurn(t *testing.T) {
 		return nil
 	})
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.provider = "codex"
 	l.pack = agent.GetPack("founding-team")
 
@@ -726,7 +726,7 @@ func TestEnqueueHeadlessCodexTurnCancelsStaleTurn(t *testing.T) {
 		return nil
 	})
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.enqueueHeadlessCodexTurn("ceo", "first")
 	waitForSignal(t, started)
 	time.Sleep(35 * time.Millisecond)
@@ -861,14 +861,32 @@ func canonicalPath(path string) string {
 	return path
 }
 
-func newHeadlessLauncherForTest() *Launcher {
-	return &Launcher{
+func newHeadlessLauncherForTest(t *testing.T) *Launcher {
+	t.Helper()
+	l := &Launcher{
 		headlessCtx:     context.Background(),
 		headlessWorkers: make(map[string]bool),
 		headlessActive:  make(map[string]*headlessCodexActiveTurn),
 		headlessQueues:  make(map[string][]headlessCodexTurn),
 		pack:            &agent.PackDefinition{LeadSlug: "ceo"}, // deterministic lead; avoids reading global broker state
 	}
+	// Drain queue workers before the test's t.TempDir cleanup runs.
+	// t.Cleanup is LIFO, and t.TempDir registers its cleanup at the
+	// moment t.TempDir() returns — which test code calls BEFORE
+	// reaching this helper. So our cleanup fires first (drains worker),
+	// then TempDir cleanup runs (RemoveAll), avoiding the
+	// "directory not empty" failure that's been red-listing
+	// release-build runs.
+	//
+	// LIMIT: tests that restore package-level overrides via classic
+	// `defer` (prepareTaskWorktree, etc.) still race the worker —
+	// defers fire BEFORE t.Cleanup, so the worker is still alive when
+	// the override restorer runs. That's pre-existing and gated by
+	// CI's `-race` carve-out for internal/team. Convert those tests'
+	// `defer restore()` to `t.Cleanup(restore)` to fix the residual
+	// race; not done here to keep this PR scoped.
+	t.Cleanup(l.stopHeadlessWorkers)
+	return l
 }
 
 func TestFinishHeadlessTurnWakesLeadWhenAllSpecialistsDone(t *testing.T) {
@@ -877,7 +895,7 @@ func TestFinishHeadlessTurnWakesLeadWhenAllSpecialistsDone(t *testing.T) {
 		woken <- specialistSlug
 	})
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 
 	// Simulate "fe" finishing with no other specialists active.
 	l.finishHeadlessTurn("fe")
@@ -894,7 +912,7 @@ func TestFinishHeadlessTurnDoesNotWakeLeadWhenOtherSpecialistsActive(t *testing.
 		woken <- specialistSlug
 	})
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	// "be" is still active while "fe" finishes.
 	l.headlessActive["be"] = &headlessCodexActiveTurn{}
 
@@ -914,7 +932,7 @@ func TestFinishHeadlessTurnDoesNotWakeLeadWhenLeadFinishes(t *testing.T) {
 		woken <- specialistSlug
 	})
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	// CEO finishes — should not self-wake.
 	l.finishHeadlessTurn("ceo")
 
@@ -932,7 +950,7 @@ func TestFinishHeadlessTurnDoesNotWakeLeadWhenLeadAlreadyQueued(t *testing.T) {
 		woken <- specialistSlug
 	})
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	// CEO already has a pending turn.
 	l.headlessQueues["ceo"] = []headlessCodexTurn{{Prompt: "pending work"}}
 
@@ -947,7 +965,7 @@ func TestFinishHeadlessTurnDoesNotWakeLeadWhenLeadAlreadyQueued(t *testing.T) {
 }
 
 func TestEnqueueHeadlessCodexTurnRecordDropsDuplicateLeadTaskWhileActive(t *testing.T) {
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
 	l.headlessActive["ceo"] = &headlessCodexActiveTurn{
 		Turn: headlessCodexTurn{
@@ -993,7 +1011,7 @@ func TestEnqueueHeadlessCodexTurnRecordQueuesUrgentLeadWakeForSameTask(t *testin
 	}
 
 	cancelled := false
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
 	l.broker = b
 	l.headlessWorkers["ceo"] = true
@@ -1023,7 +1041,7 @@ func TestEnqueueHeadlessCodexTurnRecordQueuesUrgentLeadWakeForSameTask(t *testin
 }
 
 func TestEnqueueHeadlessCodexTurnRecordDropsDuplicateAgentTaskWhileActive(t *testing.T) {
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
 	l.headlessActive["eng"] = &headlessCodexActiveTurn{
 		Turn: headlessCodexTurn{
@@ -1045,7 +1063,7 @@ func TestEnqueueHeadlessCodexTurnRecordDropsDuplicateAgentTaskWhileActive(t *tes
 }
 
 func TestEnqueueHeadlessCodexTurnRecordReplacesPendingAgentTaskTurn(t *testing.T) {
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
 	l.headlessWorkers["eng"] = true
 	l.headlessQueues["eng"] = []headlessCodexTurn{{
@@ -1072,7 +1090,7 @@ func TestEnqueueHeadlessCodexTurnRecordReplacesPendingAgentTaskTurn(t *testing.T
 }
 
 func TestEnqueueHeadlessCodexTurnRecordAllowsRetryBehindActiveAgentTask(t *testing.T) {
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
 	l.headlessWorkers["eng"] = true
 	l.headlessActive["eng"] = &headlessCodexActiveTurn{
@@ -1142,7 +1160,7 @@ func TestWakeLeadAfterSpecialistFallsBackToCompletedTaskUpdateWhenNoBroadcast(t 
 	}
 	b.mu.Unlock()
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.provider = "codex"
 	l.sessionName = "test"
@@ -1186,7 +1204,7 @@ func TestRecoverTimedOutHeadlessTurnBlocksTaskWithoutSubstantiveReply(t *testing
 		t.Fatalf("post status: %v", err)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.recoverTimedOutHeadlessTurn("cmo", headlessCodexTurn{TaskID: task.ID}, time.Now().UTC().Add(-2*time.Second), headlessCodexTurnTimeout)
 
@@ -1237,7 +1255,7 @@ func TestRecoverTimedOutHeadlessTurnLeavesTaskRunningAfterSubstantiveReply(t *te
 		t.Fatalf("post substantive message: %v", err)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.recoverTimedOutHeadlessTurn("cmo", headlessCodexTurn{TaskID: task.ID}, startedAt, headlessCodexTurnTimeout)
 
@@ -1274,7 +1292,7 @@ func TestRecoverTimedOutHeadlessTurnRetriesLocalWorktreeOnceBeforeBlocking(t *te
 		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.headlessWorkers["eng"] = true
 
@@ -1328,7 +1346,7 @@ func TestRecoverFailedHeadlessTurnRetriesLocalWorktreeOnceBeforeBlocking(t *test
 		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.headlessWorkers["eng"] = true
 
@@ -1394,7 +1412,7 @@ func TestRecoverTimedOutLocalWorktreeRetriesEvenAfterSubstantiveReplyIfTaskStill
 		Timestamp: startedAt.Add(time.Second).Format(time.RFC3339),
 	})
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.headlessWorkers["eng"] = true
 
@@ -1450,7 +1468,7 @@ func TestRecoverTimedOutLocalWorktreeLeavesReviewReadyTaskUnchanged(t *testing.T
 		break
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	l.recoverTimedOutHeadlessTurn("eng", headlessCodexTurn{
@@ -1495,7 +1513,7 @@ func TestRecoverTimedOutHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted(t *te
 		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	l.recoverTimedOutHeadlessTurn("eng", headlessCodexTurn{
@@ -1546,7 +1564,7 @@ func TestRecoverFailedHeadlessTurnBlocksLocalWorktreeAfterRetryExhausted(t *test
 		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	l.recoverFailedHeadlessTurn("eng", headlessCodexTurn{
@@ -1601,7 +1619,7 @@ func TestRecoverFailedHeadlessTurnRequeuesExternalActionBeforeBlocking(t *testin
 		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	l.recoverFailedHeadlessTurn("operator", headlessCodexTurn{
@@ -1661,7 +1679,7 @@ func TestHeadlessTurnCompletedDurablyRejectsCodingTurnWithoutTaskStateOrEvidence
 	task := b.tasks[0]
 	b.mu.Unlock()
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	ok, reason := l.headlessTurnCompletedDurably("eng", &headlessCodexActiveTurn{
@@ -1706,7 +1724,7 @@ func TestHeadlessTurnCompletedDurablyAcceptsReviewReadyTask(t *testing.T) {
 	task := b.tasks[0]
 	b.mu.Unlock()
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	ok, reason := l.headlessTurnCompletedDurably("eng", &headlessCodexActiveTurn{
@@ -1744,7 +1762,7 @@ func TestHeadlessTurnCompletedDurablyRejectsLocalWorktreeBuilderWithoutTaskState
 		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	ok, reason := l.headlessTurnCompletedDurably("builder", &headlessCodexActiveTurn{
@@ -1787,7 +1805,7 @@ func TestHeadlessTurnCompletedDurablyRejectsExternalCompletionWithoutWorkflowEvi
 		}
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	ok, reason := l.headlessTurnCompletedDurably("builder", &headlessCodexActiveTurn{
@@ -1829,7 +1847,7 @@ func TestHeadlessTurnCompletedDurablyAcceptsExternalCompletionWithWorkflowEviden
 		t.Fatalf("record action: %v", err)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	ok, reason := l.headlessTurnCompletedDurably("builder", &headlessCodexActiveTurn{
@@ -1868,7 +1886,7 @@ func TestHeadlessTurnCompletedDurablyAcceptsExternalCompletionWithActionEvidence
 		t.Fatalf("record action: %v", err)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	ok, reason := l.headlessTurnCompletedDurably("reviewer", &headlessCodexActiveTurn{
@@ -1914,7 +1932,7 @@ func TestBeginHeadlessCodexTurnCapturesWorktreeForLocalWorktreeBuilder(t *testin
 		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.headlessQueues["builder"] = []headlessCodexTurn{{TaskID: task.ID}}
 
@@ -1975,7 +1993,7 @@ func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T
 		return nil
 	})
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.headlessWorkers["eng"] = true
 	l.headlessQueues["eng"] = []headlessCodexTurn{{
@@ -1986,11 +2004,11 @@ func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T
 		EnqueuedAt: time.Now(),
 	}}
 
-	done := make(chan struct{})
-	go func() {
-		l.runHeadlessCodexQueue("eng")
-		close(done)
-	}()
+	// Drive the worker through the standard spawn helper so wg + stop channel
+	// are wired correctly; t.Cleanup (registered by newHeadlessLauncherForTest)
+	// drains it via stopHeadlessWorkers, which is the equivalent of the
+	// previous explicit `<-done` wait.
+	l.spawnHeadlessWorker("eng")
 
 	first := waitForString(t, processed)
 	second := waitForString(t, processed)
@@ -2003,7 +2021,6 @@ func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T
 	if !strings.Contains(second, "Selected model is at capacity") {
 		t.Fatalf("expected retry prompt to include provider failure, got %q", second)
 	}
-	waitForSignal(t, done)
 }
 
 func TestHeadlessCodexTurnTimeoutForLocalWorktreeTask(t *testing.T) {
@@ -2022,7 +2039,7 @@ func TestHeadlessCodexTurnTimeoutForLocalWorktreeTask(t *testing.T) {
 		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	if got := l.headlessCodexTurnTimeoutForTurn(headlessCodexTurn{TaskID: task.ID}); got != headlessCodexLocalWorktreeTurnTimeout {
@@ -2049,7 +2066,7 @@ func TestHeadlessCodexTurnTimeoutForOfficeLaunchTask(t *testing.T) {
 		t.Fatalf("ensure planned task: %v reused=%v", err, reused)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 
 	if got := l.headlessCodexTurnTimeoutForTurn(headlessCodexTurn{TaskID: task.ID}); got != headlessCodexOfficeLaunchTurnTimeout {
@@ -2067,7 +2084,7 @@ func TestEnqueueHeadlessCodexTurnDefersLeadUntilSpecialistFinishes(t *testing.T)
 		return nil
 	})
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.headlessActive["eng"] = &headlessCodexActiveTurn{}
 
 	l.enqueueHeadlessCodexTurn("ceo", "task-5 blocked after timeout")
@@ -2126,7 +2143,7 @@ func TestEnqueueHeadlessCodexTurnBypassesLeadHoldForReviewReadyTask(t *testing.T
 	}
 	b.mu.Unlock()
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.headlessActive["eng"] = &headlessCodexActiveTurn{}
 

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -102,9 +102,18 @@ type Launcher struct {
 	headlessActive       map[string]*headlessCodexActiveTurn
 	headlessQueues       map[string][]headlessCodexTurn
 	headlessDeferredLead *headlessCodexTurn
-	webMode              bool
-	paneBackedAgents     bool // web mode may spawn per-agent tmux panes; true when panes are live
-	noOpen               bool
+	// headlessStopCh is closed by stopHeadlessWorkers to tell every active
+	// runHeadlessCodexQueue goroutine to exit at its next outer-loop tick.
+	// Lazily allocated by spawnHeadlessWorker / stopHeadlessWorkers under
+	// headlessMu so the zero-value Launcher used in tests doesn't need an
+	// explicit init. headlessWorkerWg tracks live worker goroutines so the
+	// stop helper can drain them deterministically — closing the channel is
+	// a request, the WaitGroup is the proof everyone observed it.
+	headlessStopCh   chan struct{}
+	headlessWorkerWg sync.WaitGroup
+	webMode          bool
+	paneBackedAgents bool // web mode may spawn per-agent tmux panes; true when panes are live
+	noOpen           bool
 
 	// failedPaneSlugs records agents whose tmux pane/window creation failed.
 	// agentPaneTargets() omits them so the pane-capture loops don't spin on

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -578,7 +578,7 @@ func TestNotificationTargetsForDMChannelCodexRuntimeUsesHeadlessTarget(t *testin
 
 func TestDeliverDMMessageQueuesCodexHeadlessTurn(t *testing.T) {
 	b := newTestBroker(t)
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.provider = "codex"
 	l.notifyLastDelivered = make(map[string]time.Time)

--- a/internal/team/mention_auto_promote_test.go
+++ b/internal/team/mention_auto_promote_test.go
@@ -183,7 +183,7 @@ func TestAutoPromote_SystemAndSyntheticSendersSkipped(t *testing.T) {
 func TestAutoPromote_EndToEnd_HumanTagsPM_DispatchesToPM(t *testing.T) {
 	b := newBrokerWithPM(t)
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.provider = "codex"
 	l.notifyLastDelivered = make(map[string]time.Time)

--- a/internal/team/mention_routing_bug_test.go
+++ b/internal/team/mention_routing_bug_test.go
@@ -128,7 +128,7 @@ func fullDispatchLauncher(t *testing.T) (*Launcher, chan string, func()) {
 	}
 	b.mu.Unlock()
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.provider = "codex" // forces headless dispatch for every agent
 	l.notifyLastDelivered = make(map[string]time.Time)
@@ -278,7 +278,7 @@ func TestBug_FocusMode_HumanTagsWizardHiredPM_SpecialistIsImmediate(t *testing.T
 		t.Fatalf("enable focus mode: %v", err)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.provider = "codex"
 	l.focusMode = true
@@ -318,7 +318,7 @@ func TestBug_FocusMode_CEOTagsWizardHiredPM_SpecialistIsImmediate(t *testing.T) 
 		t.Fatalf("enable focus mode: %v", err)
 	}
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.provider = "codex"
 	l.focusMode = true
@@ -364,7 +364,7 @@ func TestBug_DisabledMember_ExplicitTagDoesNotBypassMute(t *testing.T) {
 	}
 	b.mu.Unlock()
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.provider = "codex"
 	l.notifyLastDelivered = make(map[string]time.Time)
@@ -431,7 +431,7 @@ func TestBug_DMToWizardHiredPM_Dispatch(t *testing.T) {
 	b.members = append(b.members, officeMember{Slug: "pm", Name: "Product Manager"})
 	b.mu.Unlock()
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.provider = "codex"
 	l.notifyLastDelivered = make(map[string]time.Time)
@@ -475,7 +475,7 @@ func TestBug_TagWizardHiredPM_InGeneral_Dispatch(t *testing.T) {
 	b.members = append(b.members, officeMember{Slug: "pm", Name: "Product Manager"})
 	b.mu.Unlock()
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.provider = "codex"
 	l.notifyLastDelivered = make(map[string]time.Time)
@@ -525,7 +525,7 @@ func TestBug_RootCause_ChannelMembershipFilterDropsExplicitMention(t *testing.T)
 	// Note: #general's ch.Members was NOT updated to include "fe".
 	b.mu.Unlock()
 
-	l := newHeadlessLauncherForTest()
+	l := newHeadlessLauncherForTest(t)
 	l.broker = b
 	l.provider = "codex"
 	l.notifyLastDelivered = make(map[string]time.Time)


### PR DESCRIPTION
## Why

The `runHeadlessCodexQueue` goroutine spawned by `enqueueHeadlessCodexTurnRecord` had no per-test cleanup channel, so under `go test ./internal/team/` it outlived the spawning test and:

- **wrote to `t.TempDir()` files while RemoveAll cleanup ran**, surfacing as `directory not empty` failures on the **release-build job** (which runs `go test ./...` *without* `-race` AND *without* the `internal/team` carve-out the CI matrix uses);
- tripped DATA RACE on subsequent tests' setup of `headlessActive` / `headlessQueues` maps under `-race` (already gated by CI carve-out).

This was the audit's 🔴 #1 blocker — auto-release was failing intermittently because of this leak. Closes that path.

## Fix shape

- Add `headlessStopCh chan struct{}` and `headlessWorkerWg sync.WaitGroup` to `Launcher`. Lazily allocated under `headlessMu` so a zero-value `Launcher` (used by ~95 test sites) stays valid.
- New `spawnHeadlessWorker(slug)` helper does `wg.Add(1)` + `go`-spawn under-lock; replaces the 3 `go runHeadlessCodexQueue(slug)` sites in `enqueueHeadlessCodexTurnRecord`.
- `runHeadlessCodexQueue` now takes a `<-chan struct{}` stop param, `defer wg.Done()`, and selects on stop in its outer loop.
- New `stopHeadlessWorkers()` method closes the stop channel and waits for all workers to drain. Idempotent.
- `newHeadlessLauncherForTest` now takes `*testing.T` and registers `t.Cleanup(l.stopHeadlessWorkers)` so any test that spawns workers drains them before the test's `t.TempDir` cleanup fires (LIFO order on `t.Cleanup` ensures this — `t.TempDir()` registers cleanup first when called earlier in the test, helper registers cleanup second, helper fires first).

## Verification

- `go test ./internal/team/` (mirrors release-build job): **green in 167s**.
- `golangci-lint run ./internal/team/...`: **0 issues**.
- v0.79.0 successfully re-cut at 02:59 UTC after the orphan tag was deleted — auto-release now landing cleanly.

## Out of scope (deliberate)

`go test -race ./internal/team/` still has a **separate, pre-existing race** on package-level test override globals (`prepareTaskWorktree`, `cleanupTaskWorktree`) where defer-style restorers race the worker. That's the same architectural shape #304 fixed for `headlessCodexRunTurn` (atomic.Pointer); same fix should be applied to those globals in a follow-up. Gated by CI's `-race` carve-out for `internal/team`.

## Test plan

- [x] `go test ./internal/team/` clean.
- [x] `golangci-lint run` clean.
- [x] Local pre-push hooks (build + smoke + vhs) green.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)