### PR TITLE
fix(web): guard setTheme localStorage write against private-browsing throw

### DIFF
--- a/web/src/stores/app.test.ts
+++ b/web/src/stores/app.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { directChannelSlug, isDMChannel, useAppStore } from "./app";
 
@@ -67,5 +67,40 @@ describe("DM channel helpers", () => {
       notebookAgentSlug: null,
       notebookEntrySlug: null,
     });
+  });
+});
+
+describe("setTheme", () => {
+  it("updates DOM + store even when localStorage.setItem throws", () => {
+    // Simulates Safari private browsing / sandboxed-iframe (write-only block).
+    // The previous setTheme threw uncaught here and broke the dark-mode
+    // toggle entirely; the guard makes the DOM + store update succeed and
+    // logs a breadcrumb instead.
+    const setItemSpy = vi
+      .spyOn(window.localStorage, "setItem")
+      .mockImplementation(() => {
+        throw new DOMException("QuotaExceededError", "QuotaExceededError");
+      });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      useAppStore.getState().setTheme("nex-dark");
+
+      expect(setItemSpy).toHaveBeenCalledWith("wuphf-theme", "nex-dark");
+      expect(useAppStore.getState().theme).toBe("nex-dark");
+      expect(document.documentElement.getAttribute("data-theme")).toBe(
+        "nex-dark",
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("setTheme: localStorage.setItem failed"),
+        expect.any(DOMException),
+      );
+    } finally {
+      setItemSpy.mockRestore();
+      warnSpy.mockRestore();
+      // Reset DOM + store so other tests don't inherit dark theme.
+      document.documentElement.setAttribute("data-theme", "nex");
+      useAppStore.setState({ theme: "nex" });
+    }
   });
 });

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -174,7 +174,13 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
   theme: _storedTheme,
   setTheme: (t) => {
-    localStorage.setItem("wuphf-theme", t);
+    // Same try/catch shape as the read path above. Safari private browsing
+    // and sandboxed-iframe contexts both throw on localStorage writes; the
+    // toggle should still update the DOM + store even if persistence fails,
+    // so the user gets the visible state change for the current session.
+    try {
+      localStorage.setItem("wuphf-theme", t);
+    } catch {}
     document.documentElement.setAttribute("data-theme", t);
     set({ theme: t });
   },

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -178,9 +178,16 @@ export const useAppStore = create<AppStore>((set, get) => ({
     // and sandboxed-iframe contexts both throw on localStorage writes; the
     // toggle should still update the DOM + store even if persistence fails,
     // so the user gets the visible state change for the current session.
+    // console.warn keeps a breadcrumb so a user reporting "theme doesn't
+    // stick" has something diagnosable in DevTools.
     try {
       localStorage.setItem("wuphf-theme", t);
-    } catch {}
+    } catch (err) {
+      console.warn(
+        "setTheme: localStorage.setItem failed; theme will not persist across reloads",
+        err,
+      );
+    }
     document.documentElement.setAttribute("data-theme", t);
     set({ theme: t });
   },


### PR DESCRIPTION
## Why

Surfaced by staff-reviewer audit on the dark-mode landing (#306, commit fe4d6f91). Safari private browsing and sandboxed-iframe contexts throw on `localStorage` writes. The **read path** in `web/src/stores/app.ts` already wraps `localStorage.getItem` in try/catch (line 6-9); the **write path** in `setTheme` did not, so any toggle of the dark-mode header switch in those contexts threw uncaught.

## Fix

Same try/catch shape, same intent: persistence failure shouldn't prevent the in-session DOM + store update from landing. User still gets the visible toggle for the current session — the preference just isn't remembered across reloads in storage-blocked contexts.

```diff
   setTheme: (t) => {
+    try {
       localStorage.setItem("wuphf-theme", t);
+    } catch {}
     document.documentElement.setAttribute("data-theme", t);
     set({ theme: t });
   },
```

## Test plan

- [x] `bun run typecheck` clean.
- [x] `bun run build` clean (1.28s).
- [ ] CI green.
- [ ] Manual: open Safari private window, toggle dark mode → no thrown errors, theme applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)