### PR TITLE
fix(team): surface commitBoundsByPath errors instead of swallowing

### DIFF
--- a/internal/team/wiki_article.go
+++ b/internal/team/wiki_article.go
@@ -36,6 +36,7 @@ package team
 import (
 	"context"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -301,8 +302,13 @@ func (r *Repo) backlinksFor(ctx context.Context, target string) ([]Backlink, err
 	sort.Slice(hits, func(i, j int) bool { return hits[i].relPath < hits[j].relPath })
 
 	// Fill author_slug per article from git log. Best-effort: if log fails,
-	// leave author_slug empty rather than abort.
-	commitBounds, _ := r.commitBoundsByPath(ctx)
+	// leave author_slug empty rather than abort. Surface the underlying
+	// error at warn level — silent swallow used to mask corrupt-repo and
+	// `git log` failures so backlinks rendered with no author + no signal.
+	commitBounds, err := r.commitBoundsByPath(ctx)
+	if err != nil {
+		log.Printf("wiki backlinks: commitBoundsByPath failed, author_slug fields will be empty: %v", err)
+	}
 	backs := make([]Backlink, 0, len(hits))
 	for _, h := range hits {
 		author := ""

--- a/internal/team/wiki_sections.go
+++ b/internal/team/wiki_sections.go
@@ -153,7 +153,14 @@ func DiscoverSections(ctx context.Context, repo *Repo, blueprint *operations.Blu
 	if walkErr != nil {
 		return nil, fmt.Errorf("wiki sections: walk team/: %w", walkErr)
 	}
-	commitBounds, _ := repo.commitBoundsByPath(ctx)
+	// Best-effort: a `git log` failure shouldn't 500 the catalog request.
+	// Surface the cause at warn level rather than swallow — sections will
+	// render with empty timestamps + author fields, but the operator gets
+	// a signal rather than guessing why the UI looks blank.
+	commitBounds, err := repo.commitBoundsByPath(ctx)
+	if err != nil {
+		log.Printf("wiki sections: commitBoundsByPath failed, section timestamps + authors will be empty: %v", err)
+	}
 
 	// Assemble the section list: blueprint-declared first (in blueprint
 	// order), then discovered-only alphabetically.


### PR DESCRIPTION
## Why

Surfaced by staff-reviewer audit on the slow-DM-and-wiki-loading PR (#312, commit 8135e2e2).

`wiki_article.go:305` (`BuildBacklinks`) and `wiki_sections.go:156` (`materializeSection`) both swallowed `commitBoundsByPath` errors with the bare-`_` pattern:

```go
commitBounds, _ := repo.commitBoundsByPath(ctx)
```

On a corrupt wiki repo or transient `git log` failure, the catalog/sections rendered with no author + no timestamps and no signal anywhere — operators got a blank-looking UI and had to guess.

## Fix

Both sites now log at warn level via the stdlib `log` package (matches `wiki_sections.go`'s existing import). The empty-map fallback is preserved so the request still completes — visible behavior on the happy path is unchanged, only error visibility improves.

```diff
-	commitBounds, _ := repo.commitBoundsByPath(ctx)
+	commitBounds, err := repo.commitBoundsByPath(ctx)
+	if err != nil {
+		log.Printf("...: commitBoundsByPath failed, ... will be empty: %v", err)
+	}
```

A third call site at `wiki_article.go:137` inside an `if bounds, err := r.commitBoundsByPath(ctx); err == nil { ... }` already handles the error correctly (falls through to the no-bounds branch). Not changed.

## Test plan

- [x] `go test -run "Wiki|Backlink|Section" ./internal/team/` clean (8.6s).
- [x] `go build ./...` clean.
- [ ] CI green.
- [ ] Manual: introduce a transient `git log` failure on a wiki repo and confirm the warn line surfaces in logs (deferred — needs corrupt-repo fixture; out of scope for this one-line surface fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)