### PR TITLE
fix(team): reject reserved slugs at channel-create handler

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -4066,6 +4066,19 @@ func defaultTeamChannelDescription(slug, name string) string {
 	return label + " focused work. Use this channel for discussion, decisions, and execution specific to that stream."
 }
 
+// reservedChannelSlugs are slug values that canAccessChannelLocked treats as
+// universally trusted senders. Any user-created channel sharing one of these
+// slugs would inherit that trust — every actor in the trust list could read
+// every message in that channel without an explicit Members entry. The
+// channel-create handler guards against this by rejecting create requests
+// whose slug matches this set; keep the two lists in sync.
+var reservedChannelSlugs = map[string]bool{
+	"system": true,
+	"nex":    true,
+	"you":    true,
+	"human":  true,
+}
+
 func (b *Broker) canAccessChannelLocked(slug, channel string) bool {
 	slug = normalizeActorSlug(slug)
 	channel = normalizeChannelSlug(channel)
@@ -4075,6 +4088,9 @@ func (b *Broker) canAccessChannelLocked(slug, channel string) bool {
 		}
 		return slug == b.oneOnOneAgent
 	}
+	// NOTE: any new entry added here MUST also be added to
+	// reservedChannelSlugs above so the channel-create handler keeps the
+	// invariant "no user channel can shadow a trusted sender slug".
 	if slug == "" || slug == "you" || slug == "human" || slug == "nex" || slug == "system" {
 		return true
 	}
@@ -6773,6 +6789,15 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 		case "create":
 			if slug == "" {
 				http.Error(w, "slug required", http.StatusBadRequest)
+				return
+			}
+			if reservedChannelSlugs[slug] {
+				// Reject slugs that canAccessChannelLocked treats as universally
+				// trusted senders. Without this gate, a user-created channel
+				// named e.g. "system" would let every trusted-sender slug read
+				// + post in it without an explicit Members entry — defeating
+				// the membership check the rest of the auth path relies on.
+				http.Error(w, "slug is reserved", http.StatusBadRequest)
 				return
 			}
 			if b.findChannelLocked(slug) != nil {

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -1755,6 +1755,63 @@ func TestChannelDescriptionsAreVisibleButContentStaysRestricted(t *testing.T) {
 	}
 }
 
+// TestChannelCreateRejectsReservedSlugs guards against a privilege-escalation
+// shape: canAccessChannelLocked treats a small set of slugs ("system", "nex",
+// "you", "human") as universally trusted senders. A user-created channel
+// sharing one of those slugs would let every trusted-sender slug read + post
+// in it without an explicit Members entry. The reservedChannelSlugs guard at
+// the channel-create handler prevents that; this test pins the invariant.
+func TestChannelCreateRejectsReservedSlugs(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	for _, reserved := range []string{"system", "nex", "you", "human"} {
+		t.Run(reserved, func(t *testing.T) {
+			body, _ := json.Marshal(map[string]any{
+				"action":     "create",
+				"slug":       reserved,
+				"name":       reserved,
+				"created_by": "ceo",
+			})
+			req, _ := http.NewRequest(http.MethodPost, base+"/channels", bytes.NewReader(body))
+			req.Header.Set("Authorization", "Bearer "+b.Token())
+			req.Header.Set("Content-Type", "application/json")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("create %s: %v", reserved, err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("create %s: expected 400, got %d", reserved, resp.StatusCode)
+			}
+		})
+	}
+
+	// Sanity: a non-reserved slug still creates successfully.
+	body, _ := json.Marshal(map[string]any{
+		"action":     "create",
+		"slug":       "feature-launch",
+		"name":       "Feature Launch",
+		"created_by": "ceo",
+	})
+	req, _ := http.NewRequest(http.MethodPost, base+"/channels", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create feature-launch: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create feature-launch: expected 200, got %d", resp.StatusCode)
+	}
+}
+
 func TestChannelUpdateMutatesDescriptionAndMembers(t *testing.T) {
 	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {


### PR DESCRIPTION
## Why

Audit finding from staff-reviewer's step 8 prep. PR #294 widened `canAccessChannelLocked` (broker.go:4078) to treat `slug == "system"` (plus `"nex"`, `"you"`, `"human"`, and the empty string) as universally trusted senders — needed for synthetic posts the broker itself emits. **Without a matching invariant on channel creation**, a user could `POST /channels` with `slug="system"` and the resulting channel would be implicitly readable + writable by every trusted-sender slug, defeating the membership check the rest of the auth path relies on.

The reviewer audited the persistence model and confirmed: channel state lives in-memory + serialized to `broker-state.json` — there's no SQLite/server DB, so the guard must be app-level (no schema migration applies).

## Fix

Three pieces, all in `internal/team/broker.go`:

1. New `reservedChannelSlugs` map next to `canAccessChannelLocked`, with a doc comment cross-referencing the trust list. The two lists are now explicitly paired so future contributors adding a trusted slug see the reserved-slug obligation in the same comment block.

2. Guard at `handleChannels` POST `action="create"`: reject any slug in the reserved set with `400 slug is reserved`.

3. `TestChannelCreateRejectsReservedSlugs` pins the invariant for all four reserved slugs and confirms a non-reserved slug still creates successfully (subtests + sanity check).

```diff
+var reservedChannelSlugs = map[string]bool{
+    "system": true, "nex": true, "you": true, "human": true,
+}

 func (b *Broker) canAccessChannelLocked(slug, channel string) bool {
   ...
+  // NOTE: any new entry added here MUST also be added to
+  // reservedChannelSlugs above so the channel-create handler keeps the
+  // invariant "no user channel can shadow a trusted sender slug".
   if slug == "" || slug == "you" || slug == "human" || slug == "nex" || slug == "system" {

 case "create":
   if slug == "" { ... }
+  if reservedChannelSlugs[slug] {
+    http.Error(w, "slug is reserved", http.StatusBadRequest)
+    return
+  }
   if b.findChannelLocked(slug) != nil { ... }
```

## Reviewer pre-flight (recap)

The reviewer enumerated all channel-creation paths and confirmed the only entry that accepts arbitrary user-supplied slugs is this `handleChannels` create case. `defaultTeamChannels()`, `ensureDMConversationLocked`, `handleCreateDM`, and `postTaskDMLocked` are all gated by other invariants that exclude reserved slugs by construction.

## Test plan

- [x] `go test -run TestChannelCreateRejectsReservedSlugs ./internal/team/` clean (4 subtests + sanity).
- [x] `go build ./...` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)