### PR TITLE
test(team): atomic.Pointer worktree seams + re-enable -race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,10 @@ jobs:
   # Generates the list of Go packages for the go-test-matrix fan-out below.
   # Separate job so the matrix can consume its output via
   # strategy.matrix.package: ${{ fromJSON(needs.go-test-list.outputs.packages) }}.
-  # Also emits a parallel `race` flag per package: internal/team and
-  # internal/teammcp (and subpackages) opt OUT of -race until the
-  # test-isolation memo's 7-step fix plan completes — the race detector
-  # trips on the very shared state that worktree_guard_test.go now guards
-  # against. Everything else gets -race.
+  # Also emits a parallel `race` flag per package: internal/teammcp opts OUT
+  # of -race until its own test-isolation cleanup lands. internal/team is
+  # in-race after the worktree-seam atomic.Pointer migration. Everything
+  # else gets -race.
   go-test-list:
     runs-on: ubuntu-latest
     outputs:
@@ -113,15 +112,15 @@ jobs:
           # spawning a matrix leg for a test-less package burns CI minutes
           # for no signal. `jq -R -s` reads stdin as a single string; split
           # on newlines, drop empties, then map each package to an object
-          # with the race flag (no -race for internal/team or
-          # internal/teammcp; see comment above).
+          # with the race flag (no -race for internal/teammcp; see comment
+          # above).
           packages=$(go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... \
             | jq -R -s -c '
                 split("\n")
                 | map(select(length > 0))
                 | map({
                     package: .,
-                    race: (test("/internal/team(mcp)?($|/)") | not)
+                    race: (test("/internal/teammcp($|/)") | not)
                   })
               ')
           echo "packages=${packages}" >> "$GITHUB_OUTPUT"

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -2678,17 +2678,10 @@ func TestBrokerTaskCreateReusesExistingOpenTask(t *testing.T) {
 }
 
 func TestBrokerEnsurePlannedTaskKeepsScopedDuplicateTitlesDistinct(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
 	b := newTestBroker(t)
 
 	first, reused, err := b.EnsurePlannedTask(plannedTaskInput{
@@ -2800,17 +2793,10 @@ func TestBrokerTaskCreateKeepsDistinctTasksInSameThread(t *testing.T) {
 }
 
 func TestBrokerTaskPlanAssignsWorktreeForLocalWorktreeTask(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
@@ -3198,17 +3184,10 @@ func TestBrokerTaskCompleteRejectsLiveBusinessTheater(t *testing.T) {
 }
 
 func TestBrokerStoresLedgerAndReviewLifecycle(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
 	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
@@ -3288,22 +3267,15 @@ func TestBrokerStoresLedgerAndReviewLifecycle(t *testing.T) {
 }
 
 func TestBrokerReleaseTaskCleansWorktree(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
 	var cleanedPath, cleanedBranch string
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error {
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error {
 		cleanedPath = path
 		cleanedBranch = branch
 		return nil
-	}
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
 	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
@@ -3352,24 +3324,17 @@ func TestBrokerReleaseTaskCleansWorktree(t *testing.T) {
 }
 
 func TestBrokerApproveRetainsLocalWorktree(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
 	cleanupCalls := 0
 	worktreeRoot := t.TempDir()
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		path := filepath.Join(worktreeRoot, "wuphf-task-"+taskID)
 		initUsableGitWorktree(t, path)
 		return path, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error {
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error {
 		cleanupCalls++
 		return nil
-	}
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
 	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
@@ -3465,26 +3430,17 @@ func ensureTestMemberAccess(b *Broker, channel, slug, name string) {
 }
 
 func TestBrokerHandlePostTaskRejectsFalseReadOnlyBlockForWritableWorktree(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	oldVerify := verifyTaskWorktreeWritable
 	worktreeDir := t.TempDir()
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return worktreeDir, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	verifyTaskWorktreeWritable = func(path string) error {
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
+	setVerifyTaskWorktreeWritableForTest(t, func(path string) error {
 		if path != worktreeDir {
 			t.Fatalf("expected probe path %q, got %q", worktreeDir, path)
 		}
 		return nil
-	}
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-		verifyTaskWorktreeWritable = oldVerify
-	}()
-
+	})
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "eng", "Engineer")
 	if err := b.StartOnPort(0); err != nil {
@@ -3721,26 +3677,17 @@ func TestBrokerHandlePostTaskResumeUnblocksAfterCapabilityRepair(t *testing.T) {
 }
 
 func TestBrokerBlockTaskRejectsFalseReadOnlyBlockForWritableWorktree(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	oldVerify := verifyTaskWorktreeWritable
 	worktreeDir := t.TempDir()
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return worktreeDir, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	verifyTaskWorktreeWritable = func(path string) error {
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
+	setVerifyTaskWorktreeWritableForTest(t, func(path string) error {
 		if path != worktreeDir {
 			t.Fatalf("expected probe path %q, got %q", worktreeDir, path)
 		}
 		return nil
-	}
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-		verifyTaskWorktreeWritable = oldVerify
-	}()
-
+	})
 	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
@@ -3784,17 +3731,10 @@ func TestBrokerBlockTaskRejectsFalseReadOnlyBlockForWritableWorktree(t *testing.
 }
 
 func TestBrokerEnsurePlannedTaskQueuesConcurrentExclusiveOwnerWork(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "executor", "Executor")
 
@@ -3972,26 +3912,17 @@ func TestBrokerTaskPlanReusesExistingActiveLane(t *testing.T) {
 }
 
 func TestBrokerBlockTaskAllowsReadOnlyBlockWhenWriteProbeFails(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	oldVerify := verifyTaskWorktreeWritable
 	worktreeDir := t.TempDir()
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return worktreeDir, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	verifyTaskWorktreeWritable = func(path string) error {
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
+	setVerifyTaskWorktreeWritableForTest(t, func(path string) error {
 		if path != worktreeDir {
 			t.Fatalf("expected probe path %q, got %q", worktreeDir, path)
 		}
 		return fmt.Errorf("permission denied")
-	}
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-		verifyTaskWorktreeWritable = oldVerify
-	}()
-
+	})
 	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",
@@ -4021,17 +3952,10 @@ func TestBrokerBlockTaskAllowsReadOnlyBlockWhenWriteProbeFails(t *testing.T) {
 }
 
 func TestBrokerCompleteClosesReviewTaskAndUnblocksDependents(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "eng", "Engineer")
 	if err := b.StartOnPort(0); err != nil {
@@ -4126,11 +4050,9 @@ func TestBrokerCompleteClosesReviewTaskAndUnblocksDependents(t *testing.T) {
 }
 
 func TestBrokerCreateTaskReusesCompletedDependencyWorktree(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
 	var prepareCalls []string
 	worktreeRoot := t.TempDir()
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		prepareCalls = append(prepareCalls, taskID)
 		if len(prepareCalls) > 1 {
 			return "", "", fmt.Errorf("unexpected prepareTaskWorktree call for %s", taskID)
@@ -4138,13 +4060,8 @@ func TestBrokerCreateTaskReusesCompletedDependencyWorktree(t *testing.T) {
 		path := filepath.Join(worktreeRoot, "wuphf-task-"+taskID)
 		initUsableGitWorktree(t, path)
 		return path, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "builder", "Builder")
 	ensureTestMemberAccess(b, "general", "operator", "Operator")
@@ -4231,23 +4148,16 @@ func TestBrokerCreateTaskReusesCompletedDependencyWorktree(t *testing.T) {
 }
 
 func TestBrokerSyncTaskWorktreeReplacesStaleAssignedPath(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
 	stalePath := t.TempDir()
 	freshPath := filepath.Join(t.TempDir(), "fresh-worktree")
 	var cleaned []string
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return freshPath, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error {
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error {
 		cleaned = append(cleaned, path+"|"+branch)
 		return nil
-	}
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
 	b := newTestBroker(t)
 	task := &teamTask{
 		ID:             "task-80",
@@ -4270,19 +4180,12 @@ func TestBrokerSyncTaskWorktreeReplacesStaleAssignedPath(t *testing.T) {
 }
 
 func TestBrokerNormalizeLoadedStateRepairsStaleAssignedWorktree(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
 	stalePath := t.TempDir()
 	freshPath := filepath.Join(t.TempDir(), "fresh-worktree")
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return freshPath, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
 	now := time.Now().UTC().Format(time.RFC3339)
 	b := newTestBroker(t)
 	b.tasks = []teamTask{{
@@ -4373,17 +4276,10 @@ func TestBrokerUpdatesTaskByIDAcrossChannels(t *testing.T) {
 }
 
 func TestBrokerCompleteAlreadyDoneTaskStaysApproved(t *testing.T) {
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(path, branch string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error { return nil })
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "eng", "Engineer")
 	if err := b.StartOnPort(0); err != nil {

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -112,7 +112,26 @@ type headlessCodexActiveTurn struct {
 	WorkspaceSnapshot string
 }
 
-var headlessCodexWorkspaceStatusSnapshot = func(path string) string {
+// headlessCodexWorkspaceStatusSnapshotFn is the seam type swapped by tests
+// via setHeadlessCodexWorkspaceStatusSnapshotForTest. Kept as a named type so
+// the atomic.Pointer below stays readable.
+type headlessCodexWorkspaceStatusSnapshotFn func(path string) string
+
+// headlessCodexWorkspaceStatusSnapshotOverride is read by the headless queue
+// worker (see runHeadlessCodexQueue → headlessTurnCompletedDurably) and by
+// recoverFailedHeadlessTurn — both run on goroutines that can outlive a
+// test's t.Cleanup. Tests must never assign directly; use
+// setHeadlessCodexWorkspaceStatusSnapshotForTest in test_support.go.
+var headlessCodexWorkspaceStatusSnapshotOverride atomic.Pointer[headlessCodexWorkspaceStatusSnapshotFn]
+
+func headlessCodexWorkspaceStatusSnapshot(path string) string {
+	if p := headlessCodexWorkspaceStatusSnapshotOverride.Load(); p != nil {
+		return (*p)(path)
+	}
+	return defaultHeadlessCodexWorkspaceStatusSnapshot(path)
+}
+
+func defaultHeadlessCodexWorkspaceStatusSnapshot(path string) string {
 	path = normalizeHeadlessWorkspaceDir(path)
 	if path == "" {
 		return ""

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -262,7 +262,6 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForCodingAgents(t *testing.T) {
 	oldLookPath := headlessCodexLookPath
 	oldExecutablePath := headlessCodexExecutablePath
 	oldCommandContext := headlessCodexCommandContext
-	oldPrepareTaskWorktree := prepareTaskWorktree
 	headlessCodexLookPath = func(file string) (string, error) {
 		switch file {
 		case "codex":
@@ -277,14 +276,13 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForCodingAgents(t *testing.T) {
 		cmdArgs = append(cmdArgs, args...)
 		return exec.CommandContext(ctx, os.Args[0], cmdArgs...)
 	}
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return worktreeDir, worktreeBranchName(taskID), nil
-	}
+	})
 	defer func() {
 		headlessCodexLookPath = oldLookPath
 		headlessCodexExecutablePath = oldExecutablePath
 		headlessCodexCommandContext = oldCommandContext
-		prepareTaskWorktree = oldPrepareTaskWorktree
 	}()
 
 	t.Setenv("GO_WANT_HEADLESS_CODEX_HELPER_PROCESS", "1")
@@ -385,7 +383,6 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForLocalWorktreeBuilder(t *test
 	oldLookPath := headlessCodexLookPath
 	oldExecutablePath := headlessCodexExecutablePath
 	oldCommandContext := headlessCodexCommandContext
-	oldPrepareTaskWorktree := prepareTaskWorktree
 	headlessCodexLookPath = func(file string) (string, error) {
 		switch file {
 		case "codex":
@@ -400,14 +397,13 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForLocalWorktreeBuilder(t *test
 		cmdArgs = append(cmdArgs, args...)
 		return exec.CommandContext(ctx, os.Args[0], cmdArgs...)
 	}
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return worktreeDir, worktreeBranchName(taskID), nil
-	}
+	})
 	defer func() {
 		headlessCodexLookPath = oldLookPath
 		headlessCodexExecutablePath = oldExecutablePath
 		headlessCodexCommandContext = oldCommandContext
-		prepareTaskWorktree = oldPrepareTaskWorktree
 	}()
 
 	t.Setenv("GO_WANT_HEADLESS_CODEX_HELPER_PROCESS", "1")
@@ -1902,11 +1898,10 @@ func TestBeginHeadlessCodexTurnCapturesWorktreeForLocalWorktreeBuilder(t *testin
 	t.Setenv("HOME", t.TempDir())
 
 	worktreeDir := t.TempDir()
-	oldPrepareTaskWorktree := prepareTaskWorktree
 	oldSnapshot := headlessCodexWorkspaceStatusSnapshot
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return worktreeDir, worktreeBranchName(taskID), nil
-	}
+	})
 	headlessCodexWorkspaceStatusSnapshot = func(path string) string {
 		if !samePath(path, worktreeDir) {
 			t.Fatalf("expected workspace snapshot to target %q, got %q", worktreeDir, path)
@@ -1914,7 +1909,6 @@ func TestBeginHeadlessCodexTurnCapturesWorktreeForLocalWorktreeBuilder(t *testin
 		return "snapshot"
 	}
 	defer func() {
-		prepareTaskWorktree = oldPrepareTaskWorktree
 		headlessCodexWorkspaceStatusSnapshot = oldSnapshot
 	}()
 
@@ -1956,17 +1950,10 @@ func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T
 	t.Setenv("HOME", t.TempDir())
 	tmpDir := t.TempDir()
 
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return filepath.Join(tmpDir, "wuphf-task-"+taskID), "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(string, string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(string, string) error { return nil })
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
 
 	b := NewBrokerAt(filepath.Join(tmpDir, "broker-state.json"))
@@ -2108,17 +2095,10 @@ func TestEnqueueHeadlessCodexTurnBypassesLeadHoldForReviewReadyTask(t *testing.T
 
 	stateDir := t.TempDir()
 
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return filepath.Join(stateDir, "wuphf-task-"+taskID), "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(string, string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(string, string) error { return nil })
 	b := NewBrokerAt(filepath.Join(stateDir, "broker-state.json"))
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
 		Channel:       "general",

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -1648,11 +1648,9 @@ func TestRecoverFailedHeadlessTurnRequeuesExternalActionBeforeBlocking(t *testin
 func TestHeadlessTurnCompletedDurablyRejectsCodingTurnWithoutTaskStateOrEvidence(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	oldSnapshot := headlessCodexWorkspaceStatusSnapshot
-	headlessCodexWorkspaceStatusSnapshot = func(string) string {
+	setHeadlessCodexWorkspaceStatusSnapshotForTest(t, func(string) string {
 		return "after-change"
-	}
-	defer func() { headlessCodexWorkspaceStatusSnapshot = oldSnapshot }()
+	})
 
 	// Build the task state directly instead of going through
 	// EnsurePlannedTask so we never call saveLocked — broker save
@@ -1697,11 +1695,9 @@ func TestHeadlessTurnCompletedDurablyRejectsCodingTurnWithoutTaskStateOrEvidence
 func TestHeadlessTurnCompletedDurablyAcceptsReviewReadyTask(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	oldSnapshot := headlessCodexWorkspaceStatusSnapshot
-	headlessCodexWorkspaceStatusSnapshot = func(string) string {
+	setHeadlessCodexWorkspaceStatusSnapshotForTest(t, func(string) string {
 		return "after-change"
-	}
-	defer func() { headlessCodexWorkspaceStatusSnapshot = oldSnapshot }()
+	})
 
 	// See TestHeadlessTurnCompletedDurablyRejectsCodingTurn... for why
 	// we build the task state directly rather than via EnsurePlannedTask.
@@ -1739,11 +1735,9 @@ func TestHeadlessTurnCompletedDurablyAcceptsReviewReadyTask(t *testing.T) {
 func TestHeadlessTurnCompletedDurablyRejectsLocalWorktreeBuilderWithoutTaskStateOrEvidence(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
-	oldSnapshot := headlessCodexWorkspaceStatusSnapshot
-	headlessCodexWorkspaceStatusSnapshot = func(string) string {
+	setHeadlessCodexWorkspaceStatusSnapshotForTest(t, func(string) string {
 		return "after-change"
-	}
-	defer func() { headlessCodexWorkspaceStatusSnapshot = oldSnapshot }()
+	})
 
 	b := newTestBroker(t)
 	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
@@ -1898,19 +1892,15 @@ func TestBeginHeadlessCodexTurnCapturesWorktreeForLocalWorktreeBuilder(t *testin
 	t.Setenv("HOME", t.TempDir())
 
 	worktreeDir := t.TempDir()
-	oldSnapshot := headlessCodexWorkspaceStatusSnapshot
 	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return worktreeDir, worktreeBranchName(taskID), nil
 	})
-	headlessCodexWorkspaceStatusSnapshot = func(path string) string {
+	setHeadlessCodexWorkspaceStatusSnapshotForTest(t, func(path string) string {
 		if !samePath(path, worktreeDir) {
 			t.Fatalf("expected workspace snapshot to target %q, got %q", worktreeDir, path)
 		}
 		return "snapshot"
-	}
-	defer func() {
-		headlessCodexWorkspaceStatusSnapshot = oldSnapshot
-	}()
+	})
 
 	b := newTestBroker(t)
 	ensureTestMemberAccess(b, "general", "builder", "Builder")

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -2022,17 +2022,10 @@ func TestRelevantTaskForTargetCrossChannel(t *testing.T) {
 	// the "Active task" line and giving specialists the wrong response instruction.
 	tmpDir := t.TempDir()
 
-	oldPrepare := prepareTaskWorktree
-	oldCleanup := cleanupTaskWorktree
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return filepath.Join(tmpDir, "wuphf-task-"+taskID), "wuphf-" + taskID, nil
-	}
-	cleanupTaskWorktree = func(string, string) error { return nil }
-	defer func() {
-		prepareTaskWorktree = oldPrepare
-		cleanupTaskWorktree = oldCleanup
-	}()
-
+	})
+	setCleanupTaskWorktreeForTest(t, func(string, string) error { return nil })
 	b := NewBrokerAt(filepath.Join(tmpDir, "broker-state.json"))
 
 	// Create "engineering" channel directly in broker state.

--- a/internal/team/test_support.go
+++ b/internal/team/test_support.go
@@ -43,20 +43,23 @@ func DisableRealTaskWorktreeForTests() {
 		panic("team: DisableRealTaskWorktreeForTests must only be called from tests " +
 			"(it mutates package-level worktree dispatch vars with no restore path)")
 	}
-	allowRealTaskWorktree = false
+	allowRealTaskWorktree.Store(false)
 	skipBrokerStateLoadOnConstruct = true
-	prepareTaskWorktree = func(taskID string) (string, string, error) {
+	prep := prepareTaskWorktreeFn(func(taskID string) (string, string, error) {
 		path, branch := stubTaskWorktreePath(taskID)
 		return path, branch, nil
-	}
-	cleanupTaskWorktree = func(string, string) error { return nil }
+	})
+	prepareTaskWorktreeOverride.Store(&prep)
+	cleanup := cleanupTaskWorktreeFn(func(string, string) error { return nil })
+	cleanupTaskWorktreeOverride.Store(&cleanup)
 	// Stub verifyTaskWorktreeWritable too: rejectFalseLocalWorktreeBlock
 	// in broker.go calls it with the stub path, which never exists on
 	// disk, so the default `os.Stat` check would fail. No tests exercise
 	// this path today, but keeping the three worktree vars stubbed
 	// together preserves the "real-worktree is off for tests" contract
 	// as defense-in-depth for future callers.
-	verifyTaskWorktreeWritable = func(string) error { return nil }
+	verify := verifyTaskWorktreeWritableFn(func(string) error { return nil })
+	verifyTaskWorktreeWritableOverride.Store(&verify)
 
 	// If the caller's test package hasn't set WUPHF_RUNTIME_HOME, point
 	// it at a process-lifetime leaked tempdir so any implicit
@@ -85,5 +88,51 @@ func setHeadlessCodexRunTurnForTest(t *testing.T, fn func(l *Launcher, ctx conte
 	headlessCodexRunTurnOverride.Store(&fn)
 	t.Cleanup(func() {
 		headlessCodexRunTurnOverride.Store(prior)
+	})
+}
+
+// setPrepareTaskWorktreeForTest swaps the prepareTaskWorktree dispatcher
+// for the duration of the test. Same race motivation as
+// setHeadlessCodexRunTurnForTest: the headless queue worker can read the
+// dispatcher after the test's deferred restore has already run.
+func setPrepareTaskWorktreeForTest(t *testing.T, fn prepareTaskWorktreeFn) {
+	t.Helper()
+	prior := prepareTaskWorktreeOverride.Load()
+	prepareTaskWorktreeOverride.Store(&fn)
+	t.Cleanup(func() {
+		prepareTaskWorktreeOverride.Store(prior)
+	})
+}
+
+// setCleanupTaskWorktreeForTest swaps the cleanupTaskWorktree dispatcher
+// for the duration of the test.
+func setCleanupTaskWorktreeForTest(t *testing.T, fn cleanupTaskWorktreeFn) {
+	t.Helper()
+	prior := cleanupTaskWorktreeOverride.Load()
+	cleanupTaskWorktreeOverride.Store(&fn)
+	t.Cleanup(func() {
+		cleanupTaskWorktreeOverride.Store(prior)
+	})
+}
+
+// setTaskWorktreeRootDirForTest swaps the taskWorktreeRootDir dispatcher
+// for the duration of the test.
+func setTaskWorktreeRootDirForTest(t *testing.T, fn taskWorktreeRootDirFn) {
+	t.Helper()
+	prior := taskWorktreeRootDirOverride.Load()
+	taskWorktreeRootDirOverride.Store(&fn)
+	t.Cleanup(func() {
+		taskWorktreeRootDirOverride.Store(prior)
+	})
+}
+
+// setVerifyTaskWorktreeWritableForTest swaps the verifyTaskWorktreeWritable
+// dispatcher for the duration of the test.
+func setVerifyTaskWorktreeWritableForTest(t *testing.T, fn verifyTaskWorktreeWritableFn) {
+	t.Helper()
+	prior := verifyTaskWorktreeWritableOverride.Load()
+	verifyTaskWorktreeWritableOverride.Store(&fn)
+	t.Cleanup(func() {
+		verifyTaskWorktreeWritableOverride.Store(prior)
 	})
 }

--- a/internal/team/test_support.go
+++ b/internal/team/test_support.go
@@ -82,6 +82,14 @@ func DisableRealTaskWorktreeForTests() {
 // queue worker spawned by enqueueHeadlessCodexTurnRecord — the worker could
 // outlive the test's deferred restore and observe the swap mid-call. Use
 // this helper instead.
+//
+// CONSTRAINT: tests using any setXForTest helper in this file must NOT call
+// t.Parallel(). The setters do an atomic Load → atomic Store pair which is
+// non-atomic AS A PAIR; parallel setters can scramble the cleanup chain (T1
+// captures prior=A, T2 captures prior=A, T1 stores B, T2 stores C, T1
+// cleanup stores A, T2 cleanup stores A — both lose). Single-test
+// race-safety against background goroutines is the goal here, not parallel
+// test composition.
 func setHeadlessCodexRunTurnForTest(t *testing.T, fn func(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error) {
 	t.Helper()
 	prior := headlessCodexRunTurnOverride.Load()
@@ -134,5 +142,18 @@ func setVerifyTaskWorktreeWritableForTest(t *testing.T, fn verifyTaskWorktreeWri
 	verifyTaskWorktreeWritableOverride.Store(&fn)
 	t.Cleanup(func() {
 		verifyTaskWorktreeWritableOverride.Store(prior)
+	})
+}
+
+// setHeadlessCodexWorkspaceStatusSnapshotForTest swaps the snapshot function
+// for the duration of the test. Same race motivation as
+// setPrepareTaskWorktreeForTest: the snapshot is read by the headless queue
+// worker on a goroutine that can outlive the test's t.Cleanup.
+func setHeadlessCodexWorkspaceStatusSnapshotForTest(t *testing.T, fn headlessCodexWorkspaceStatusSnapshotFn) {
+	t.Helper()
+	prior := headlessCodexWorkspaceStatusSnapshotOverride.Load()
+	headlessCodexWorkspaceStatusSnapshotOverride.Store(&fn)
+	t.Cleanup(func() {
+		headlessCodexWorkspaceStatusSnapshotOverride.Store(prior)
 	})
 }

--- a/internal/team/worktree.go
+++ b/internal/team/worktree.go
@@ -10,14 +10,57 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/nex-crm/wuphf/internal/gitexec"
 )
 
-var prepareTaskWorktree = defaultPrepareTaskWorktree
-var cleanupTaskWorktree = defaultCleanupTaskWorktree
-var taskWorktreeRootDir = defaultTaskWorktreeRootDir
-var verifyTaskWorktreeWritable = defaultVerifyTaskWorktreeWritable
+// Test seams for the worktree dispatch path. These read from background
+// goroutines (headless codex queue worker, launcher recovery) while tests
+// install per-test stubs, so the seams must be race-safe. Tests must use
+// the setXForTest helpers in test_support.go — never assign to the
+// override pointers directly. Same shape as headlessCodexRunTurnOverride.
+type (
+	prepareTaskWorktreeFn        func(taskID string) (string, string, error)
+	cleanupTaskWorktreeFn        func(path, branch string) error
+	taskWorktreeRootDirFn        func(repoRoot string) string
+	verifyTaskWorktreeWritableFn func(path string) error
+)
+
+var (
+	prepareTaskWorktreeOverride        atomic.Pointer[prepareTaskWorktreeFn]
+	cleanupTaskWorktreeOverride        atomic.Pointer[cleanupTaskWorktreeFn]
+	taskWorktreeRootDirOverride        atomic.Pointer[taskWorktreeRootDirFn]
+	verifyTaskWorktreeWritableOverride atomic.Pointer[verifyTaskWorktreeWritableFn]
+)
+
+func prepareTaskWorktree(taskID string) (string, string, error) {
+	if p := prepareTaskWorktreeOverride.Load(); p != nil {
+		return (*p)(taskID)
+	}
+	return defaultPrepareTaskWorktree(taskID)
+}
+
+func cleanupTaskWorktree(path, branch string) error {
+	if p := cleanupTaskWorktreeOverride.Load(); p != nil {
+		return (*p)(path, branch)
+	}
+	return defaultCleanupTaskWorktree(path, branch)
+}
+
+func taskWorktreeRootDir(repoRoot string) string {
+	if p := taskWorktreeRootDirOverride.Load(); p != nil {
+		return (*p)(repoRoot)
+	}
+	return defaultTaskWorktreeRootDir(repoRoot)
+}
+
+func verifyTaskWorktreeWritable(path string) error {
+	if p := verifyTaskWorktreeWritableOverride.Load(); p != nil {
+		return (*p)(path)
+	}
+	return defaultVerifyTaskWorktreeWritable(path)
+}
 
 // allowRealTaskWorktree gates access to the real git-worktree codepath. In
 // production it stays true; an init() in a *_test.go file in this package
@@ -25,7 +68,13 @@ var verifyTaskWorktreeWritable = defaultVerifyTaskWorktreeWritable
 // against the developer's `wuphf` repo. Tests that legitimately need the real
 // codepath (always against a tempdir-rooted repo) opt in via
 // allowRealTaskWorktreeForTest(t), which scopes the re-enable to one test.
-var allowRealTaskWorktree = true
+//
+// atomic.Bool because the production read in defaultPrepareTaskWorktree
+// happens on goroutines spawned by the headless queue worker, which can
+// outlive a test's deferred restore.
+var allowRealTaskWorktree atomic.Bool
+
+func init() { allowRealTaskWorktree.Store(true) }
 
 // errRealTaskWorktreeDisabled is returned by defaultPrepareTaskWorktree when
 // it is called from a test that has not opted into the real codepath. The
@@ -47,7 +96,7 @@ var overlaySourceWorkspaceSkipPrefixes = []string{
 }
 
 func defaultPrepareTaskWorktree(taskID string) (string, string, error) {
-	if !allowRealTaskWorktree {
+	if !allowRealTaskWorktree.Load() {
 		return "", "", errRealTaskWorktreeDisabled
 	}
 	repoRoot, err := gitRepoRoot()

--- a/internal/team/worktree_guard_test.go
+++ b/internal/team/worktree_guard_test.go
@@ -67,12 +67,18 @@ func stubCleanupTaskWorktree(string, string) error { return nil }
 // allowRealTaskWorktreeForTest opts the current test into the real
 // defaultPrepareTaskWorktree / defaultCleanupTaskWorktree codepath.
 //
-// The worktree dispatch seams are now atomic.Pointer-backed (see
-// worktree.go), so the mutate-and-restore is race-safe — but parallel
-// tests in this package STILL must not all opt in at once, because the
-// real codepath chdirs into a tempdir-scoped repo. Each current caller
-// (worktree_test.go) builds its own tempdir + chdirs into it without
-// t.Parallel().
+// Each individual Store/Load on the underlying atomic primitives is
+// race-safe, but the THREE stores together (allow + prepare override +
+// cleanup override) are not coherent as a tuple. A concurrent caller
+// observing the post-flip state may see allow=true while the override
+// pointers are still mid-update or vice versa. The current callers in
+// worktree_test.go avoid this by:
+//   - never running t.Parallel() in the opt-in test, AND
+//   - chdiring into a tempdir-scoped repo (so even if they did parallel,
+//     each would be in its own working directory).
+//
+// Future callers who need t.Parallel() must serialize the opt-in
+// (e.g. wrap the triple in a sync.Mutex) — atomic alone won't help.
 func allowRealTaskWorktreeForTest(t *testing.T) {
 	t.Helper()
 	prevAllow := allowRealTaskWorktree.Load()

--- a/internal/team/worktree_guard_test.go
+++ b/internal/team/worktree_guard_test.go
@@ -11,28 +11,31 @@ import (
 // production build. Production defaults in worktree.go remain:
 //   - allowRealTaskWorktree = true
 //   - unscopedWikiRootAllowed = true
-//   - prepareTaskWorktree = defaultPrepareTaskWorktree
-//   - cleanupTaskWorktree = defaultCleanupTaskWorktree
+//   - prepareTaskWorktreeOverride = nil  (falls through to defaultPrepareTaskWorktree)
+//   - cleanupTaskWorktreeOverride = nil  (falls through to defaultCleanupTaskWorktree)
 //
 // Under `go test`, init() below replaces all four with safe defaults:
 //   - The two guards are disabled so any test that reaches the real
 //     codepath without opting in panics / errors loudly.
-//   - The two vars are stubbed so indirect callers (e.g. EnsureTask →
-//     syncTaskWorktreeLocked → prepareTaskWorktree on a coding-agent
-//     task) get a deterministic fake path + branch instead of
-//     registering a worktree against the developer's wuphf repo.
+//   - The two override pointers are populated with stubs so indirect
+//     callers (e.g. EnsureTask → syncTaskWorktreeLocked →
+//     prepareTaskWorktree on a coding-agent task) get a deterministic
+//     fake path + branch instead of registering a worktree against the
+//     developer's wuphf repo.
 //
 // Tests that legitimately need the real prepare/cleanup codepath (the
 // three cases in worktree_test.go that build a tempdir-scoped repo and
 // chdir into it) must opt in via allowRealTaskWorktreeForTest(t) AND
 // call defaultPrepareTaskWorktree directly. Tests that want custom
-// stub behavior continue to monkey-patch prepareTaskWorktree; their
-// defer-restore lands on the stub below, not the real codepath.
+// stub behavior call setPrepareTaskWorktreeForTest(t, fn); the
+// per-test t.Cleanup restores the package-init stub.
 func init() {
-	allowRealTaskWorktree = false
+	allowRealTaskWorktree.Store(false)
 	unscopedWikiRootAllowed = false
-	prepareTaskWorktree = stubPrepareTaskWorktree
-	cleanupTaskWorktree = stubCleanupTaskWorktree
+	prep := prepareTaskWorktreeFn(stubPrepareTaskWorktree)
+	prepareTaskWorktreeOverride.Store(&prep)
+	cleanup := cleanupTaskWorktreeFn(stubCleanupTaskWorktree)
+	cleanupTaskWorktreeOverride.Store(&cleanup)
 	skipBrokerStateLoadOnConstruct = true
 
 	// Pin WUPHF_RUNTIME_HOME into a process-lifetime leaked tempdir so
@@ -62,26 +65,25 @@ func stubPrepareTaskWorktree(taskID string) (string, string, error) {
 func stubCleanupTaskWorktree(string, string) error { return nil }
 
 // allowRealTaskWorktreeForTest opts the current test into the real
-// defaultPrepareTaskWorktree / defaultCleanupTaskWorktree codepath. It
-// mutates three package-level globals (allowRealTaskWorktree,
-// prepareTaskWorktree, cleanupTaskWorktree) without synchronization and
-// restores them via t.Cleanup. Call sites MUST NOT call t.Parallel() in
-// the same test, and the test MUST NOT spawn background brokers/workers
-// that read those function pointers concurrently — both conditions hold
-// for the three current callers in worktree_test.go (no t.Parallel, no
-// Broker goroutines). If a future caller needs either, convert this to
-// a mutex-guarded swap like setHeadlessWakeLeadFn in broker_test.go.
+// defaultPrepareTaskWorktree / defaultCleanupTaskWorktree codepath.
+//
+// The worktree dispatch seams are now atomic.Pointer-backed (see
+// worktree.go), so the mutate-and-restore is race-safe — but parallel
+// tests in this package STILL must not all opt in at once, because the
+// real codepath chdirs into a tempdir-scoped repo. Each current caller
+// (worktree_test.go) builds its own tempdir + chdirs into it without
+// t.Parallel().
 func allowRealTaskWorktreeForTest(t *testing.T) {
 	t.Helper()
-	prevAllow := allowRealTaskWorktree
-	prevPrepare := prepareTaskWorktree
-	prevCleanup := cleanupTaskWorktree
-	allowRealTaskWorktree = true
-	prepareTaskWorktree = defaultPrepareTaskWorktree
-	cleanupTaskWorktree = defaultCleanupTaskWorktree
+	prevAllow := allowRealTaskWorktree.Load()
+	prevPrepare := prepareTaskWorktreeOverride.Load()
+	prevCleanup := cleanupTaskWorktreeOverride.Load()
+	allowRealTaskWorktree.Store(true)
+	prepareTaskWorktreeOverride.Store(nil)
+	cleanupTaskWorktreeOverride.Store(nil)
 	t.Cleanup(func() {
-		allowRealTaskWorktree = prevAllow
-		prepareTaskWorktree = prevPrepare
-		cleanupTaskWorktree = prevCleanup
+		allowRealTaskWorktree.Store(prevAllow)
+		prepareTaskWorktreeOverride.Store(prevPrepare)
+		cleanupTaskWorktreeOverride.Store(prevCleanup)
 	})
 }

--- a/internal/team/worktree_test.go
+++ b/internal/team/worktree_test.go
@@ -16,14 +16,11 @@ func TestCleanupPersistedTaskWorktreesRemovesUniqueTrackedWorktrees(t *testing.T
 	statePath := filepath.Join(stateDir, "broker-state.json")
 	t.Setenv("WUPHF_BROKER_STATE_PATH", statePath)
 
-	oldCleanup := cleanupTaskWorktree
-	defer func() { cleanupTaskWorktree = oldCleanup }()
-
 	var calls []string
-	cleanupTaskWorktree = func(path, branch string) error {
+	setCleanupTaskWorktreeForTest(t, func(path, branch string) error {
 		calls = append(calls, path+"|"+branch)
 		return nil
-	}
+	})
 
 	state := struct {
 		Tasks []teamTask `json:"tasks"`
@@ -69,11 +66,9 @@ func TestDefaultPrepareTaskWorktreeOverlaysDirtyWorkspace(t *testing.T) {
 		t.Fatalf("getwd: %v", err)
 	}
 	defer func() { _ = os.Chdir(oldCwd) }()
-	oldTaskRoot := taskWorktreeRootDir
-	defer func() { taskWorktreeRootDir = oldTaskRoot }()
-	taskWorktreeRootDir = func(repoRoot string) string {
+	setTaskWorktreeRootDirForTest(t, func(repoRoot string) string {
 		return filepath.Join(worktreeRoot, sanitizeWorktreeToken(filepath.Base(repoRoot)))
-	}
+	})
 
 	run := func(args ...string) {
 		t.Helper()
@@ -182,11 +177,9 @@ func TestDefaultPrepareTaskWorktreeOverlaysCompletedSiblingTaskWorkspace(t *test
 		t.Fatalf("getwd: %v", err)
 	}
 	defer func() { _ = os.Chdir(oldCwd) }()
-	oldTaskRoot := taskWorktreeRootDir
-	defer func() { taskWorktreeRootDir = oldTaskRoot }()
-	taskWorktreeRootDir = func(repoRoot string) string {
+	setTaskWorktreeRootDirForTest(t, func(repoRoot string) string {
 		return filepath.Join(worktreeRoot, sanitizeWorktreeToken(filepath.Base(repoRoot)))
-	}
+	})
 	t.Setenv("WUPHF_BROKER_STATE_PATH", statePath)
 
 	run := func(dir string, args ...string) {
@@ -281,11 +274,9 @@ func TestDefaultPrepareTaskWorktreeSkipsDuplicateAndMissingCompletedSiblingSourc
 		t.Fatalf("getwd: %v", err)
 	}
 	defer func() { _ = os.Chdir(oldCwd) }()
-	oldTaskRoot := taskWorktreeRootDir
-	defer func() { taskWorktreeRootDir = oldTaskRoot }()
-	taskWorktreeRootDir = func(repoRoot string) string {
+	setTaskWorktreeRootDirForTest(t, func(repoRoot string) string {
 		return filepath.Join(worktreeRoot, sanitizeWorktreeToken(filepath.Base(repoRoot)))
-	}
+	})
 	t.Setenv("WUPHF_BROKER_STATE_PATH", statePath)
 
 	run := func(dir string, args ...string) {
@@ -387,11 +378,9 @@ func TestDefaultPrepareTaskWorktreeSkipsDuplicateAndMissingCompletedSiblingSourc
 }
 
 func TestWorktreePathLooksSafeAllowsManagedAndLegacyRoots(t *testing.T) {
-	oldTaskRoot := taskWorktreeRootDir
-	defer func() { taskWorktreeRootDir = oldTaskRoot }()
-	taskWorktreeRootDir = func(string) string {
+	setTaskWorktreeRootDirForTest(t, func(string) string {
 		return filepath.Join(t.TempDir(), "task-worktrees", "repo")
-	}
+	})
 
 	managed := filepath.Join(taskWorktreeRootDir("repo"), "wuphf-task-task-1")
 	if !worktreePathLooksSafe(managed) {


### PR DESCRIPTION
## Summary

Worktree dispatch seams (`prepareTaskWorktree`, `cleanupTaskWorktree`, `taskWorktreeRootDir`, `verifyTaskWorktreeWritable`, `allowRealTaskWorktree`) were package-level vars that tests bare-assigned with defer-restore. Background goroutines spawned by the headless codex queue worker read those vars after a test's deferred restore had already run, racing on the function-pointer write. `go test -race` catches it on `TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError`.

This PR mirrors the existing `headlessCodexRunTurnOverride` pattern (already in `headless_codex.go`):
- Each seam becomes `atomic.Pointer[fnType]` accessed via a thin wrapper function in `worktree.go`.
- Tests migrate to `setXForTest(t, fn)` helpers in `test_support.go`. Each registers `t.Cleanup` to restore the prior override.
- `allowRealTaskWorktree` becomes `atomic.Bool`.
- CI matrix's race-flag exclusion for `internal/team` is dropped — only `internal/teammcp` remains opted-out.

## Verification

- `go test -race -timeout 5m -count=1 ./internal/team/` → **pass** (149.8s).
- `go test -race -timeout 5m -run TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError ./internal/team/` → **pass** (the original race target).
- `go vet ./...`, `gofmt -l`, `golangci-lint`, lefthook pre-commit + pre-push all clean.

## Followups (separate PRs)

- `internal/teammcp` still excluded from `-race`; it has its own shared-state path (different vars).
- Other function-pointer seams in `internal/team` (`graphRecordFactRefs`, `studioPackageGenerator`, `headlessCodexWorkspaceStatusSnapshot`, `launcherSendNotificationToPane`, `listHeadlessTaskRunnerProcesses`, `killHeadlessTaskRunnerProcess`) follow the same recipe but were not raced by any current test. Incremental sweep.

## Test plan

- [ ] CI passes including new `internal/team` race leg
- [ ] Spot-check a couple of converted tests still exercise the intended override (e.g. `TestBrokerReleaseTaskCleansWorktree` still observes the cleaned path/branch via the closure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Refactored test infrastructure to enhance thread-safety and prevent race conditions during concurrent test execution through improved helper functions.
  * Updated worktree and workspace status testing with safer, concurrent-safe override mechanisms.

* **Chores**
  * Refined CI workflow test matrix configuration to optimize race condition detection coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->