### PR TITLE
fix: replace http.DefaultClient with timed clients in session mode handlers

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -5597,7 +5597,8 @@ func switchSessionMode(mode, agent string) tea.Cmd {
 		if err != nil {
 			return channelResetDoneMsg{err: err}
 		}
-		resp, err := http.DefaultClient.Do(req)
+		client := &http.Client{Timeout: 3 * time.Second}
+		resp, err := client.Do(req)
 		if err != nil {
 			return channelResetDoneMsg{err: err}
 		}
@@ -5651,7 +5652,8 @@ func switchFocusMode(enabled bool) tea.Cmd {
 		if err != nil {
 			return nil
 		}
-		resp, err := http.DefaultClient.Do(req)
+		client := &http.Client{Timeout: 3 * time.Second}
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil
 		}


### PR DESCRIPTION
## Summary
- Replace `http.DefaultClient` with `&http.Client{Timeout: 3 * time.Second}` in `switchSessionMode` and `switchFocusMode` in `cmd/wuphf/channel.go`

## Problem
Two session mode handler functions used `http.DefaultClient.Do(req)` without a timeout. This is inconsistent with all other HTTP calls in the codebase (`channel_broker.go`, and the rest of `channel.go`) which use properly timed clients. Without a timeout, session mode switches and focus mode toggles hang indefinitely if the broker is unresponsive.

## Test plan
- [x] Code change is consistent with the existing pattern used by all other HTTP calls in the codebase
- [ ] Manual: verify `/collab` and `/focus` commands still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)