### PR TITLE
fix: sanitize markdown link URLs to prevent javascript: scheme XSS

### DIFF
--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -147,6 +147,17 @@ export function formatMarkdown(raw: string): string {
   return result.join("");
 }
 
+function isSafeUrl(url: string): boolean {
+  const trimmed = url.trim().toLowerCase();
+  return (
+    trimmed.startsWith("http://") ||
+    trimmed.startsWith("https://") ||
+    trimmed.startsWith("mailto:") ||
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("#")
+  );
+}
+
 function formatInline(text: string): string {
   let s = escapeHtml(text);
   // Bold
@@ -155,10 +166,15 @@ function formatInline(text: string): string {
   s = s.replace(/\*(.+?)\*/g, "<em>$1</em>");
   // Inline code
   s = s.replace(/`([^`]+)`/g, "<code>$1</code>");
-  // Links
+  // Links — reject dangerous schemes (javascript:, data:, vbscript:)
   s = s.replace(
     /\[([^\]]+)\]\(([^)]+)\)/g,
-    '<a class="msg-link" href="$2" target="_blank" rel="noopener">$1</a>',
+    (_match, label: string, url: string) => {
+      if (isSafeUrl(url)) {
+        return `<a class="msg-link" href="${url}" target="_blank" rel="noopener">${label}</a>`;
+      }
+      return `<span class="msg-link">${label}</span>`;
+    },
   );
   // @mentions
   s = s.replace(/@(\w[\w-]*)/g, '<span class="mention">@$1</span>');


### PR DESCRIPTION
## Summary
- Add `isSafeUrl()` allowlist to `formatInline()` in `web/src/lib/markdown.ts`
- Only `http://`, `https://`, `mailto:`, `/`, and `#` URLs are rendered as clickable links
- Dangerous schemes (`javascript:`, `data:`, `vbscript:`) render as inert `<span>` elements

## Problem
`formatInline()` applies `escapeHtml()` before regex replacements, which prevents HTML injection. However, the markdown link regex `[text](url)` directly interpolates the URL into the `href` attribute of an `<a>` tag. A markdown link like `[click](javascript:alert(1))` passes through `escapeHtml()` unchanged (no HTML special characters) and produces a clickable XSS vector:

```html
<a class="msg-link" href="javascript:alert(1)" target="_blank" rel="noopener">click</a>
```

While agent messages are from a trusted source (the broker), defense-in-depth is important — a compromised or misconfigured agent could emit malicious markdown.

## Test plan
- [x] Verified `http://` and `https://` links still render as clickable `<a>` tags
- [x] Verified `javascript:`, `data:`, and `vbscript:` URLs render as non-clickable `<span>` elements
- [ ] Manual: post `[click](javascript:alert(1))` in the chat and verify it's not clickable
- [ ] Manual: verify normal links like `[docs](https://example.com)` still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)