### PR TITLE
chore(lint): fix noctx findings + enable linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,13 +14,13 @@ linters:
     - govet
     - ineffassign
     - misspell
+    - noctx
     - staticcheck
     - unconvert
     # Followups (own PR each — too many existing findings to land here):
     #   - contextcheck (26 findings: ctx threading)
     #   - gocritic (40 findings: mostly diagnostic-tag style nits)
     #   - nilerr (29 findings: returning nil after non-nil err)
-    #   - noctx (95 findings: net/http and exec.Command without context)
   settings:
     errcheck:
       exclude-functions:
@@ -49,6 +49,7 @@ linters:
           - errcheck
           - bodyclose
           - errorlint
+          - noctx
       # govet's shadow check on `err` is famously noisy in idiomatic Go
       # (every nested `if err := ...; err != nil` shadows). Keep shadow on
       # for non-err identifiers (real bugs hide there) but mute the err case.

--- a/cmd/wuphf-oc-probe/multi-provider-http/main.go
+++ b/cmd/wuphf-oc-probe/multi-provider-http/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -241,7 +242,9 @@ type messageRow struct {
 }
 
 func fetchMessages() []messageRow {
-	req, _ := http.NewRequest(http.MethodGet, brokerURL+"/messages", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, brokerURL+"/messages", nil)
 	req.Header.Set("Authorization", "Bearer "+brokerToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -323,7 +326,9 @@ func mustPost(err error) {
 
 func brokerPOST(path string, body any) (string, error) {
 	data, _ := json.Marshal(body)
-	req, _ := http.NewRequest(http.MethodPost, brokerURL+path, bytes.NewReader(data))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, brokerURL+path, bytes.NewReader(data))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+brokerToken)
 	client := &http.Client{Timeout: 30 * time.Second}
@@ -342,7 +347,10 @@ func brokerPOST(path string, body any) (string, error) {
 func waitHealth(timeout time.Duration) {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		resp, err := http.Get(brokerURL + "/health")
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, brokerURL+"/health", nil)
+		resp, err := http.DefaultClient.Do(req)
+		cancel()
 		if err == nil && resp.StatusCode == http.StatusOK {
 			resp.Body.Close()
 			return

--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -4263,7 +4264,7 @@ func postToChannel(text string, replyTo string, channel string) tea.Cmd {
 			"tagged":   extractTagsFromText(text),
 			"reply_to": strings.TrimSpace(replyTo),
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/messages", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/messages", bytes.NewReader(body))
 		if err != nil {
 			return channelPostDoneMsg{err: err}
 		}
@@ -5506,7 +5507,7 @@ func createSkill(description, channel string) tea.Cmd {
 			"channel":     channel,
 		}
 		body, _ := json.Marshal(payload)
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/skills", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/skills", bytes.NewReader(body))
 		if err != nil {
 			return channelSkillsMsg{}
 		}
@@ -5523,7 +5524,7 @@ func createSkill(description, channel string) tea.Cmd {
 
 func invokeSkill(name string) tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/skills/"+name+"/invoke", nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/skills/"+name+"/invoke", nil)
 		if err != nil {
 			return channelSkillsMsg{}
 		}
@@ -5543,7 +5544,7 @@ func resetDMSession(agent string, channel string) tea.Cmd {
 			"agent":   agent,
 			"channel": channel,
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/reset-dm", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/reset-dm", bytes.NewReader(body))
 		if err != nil {
 			return channelResetDMDoneMsg{err: err}
 		}
@@ -5593,7 +5594,7 @@ func switchSessionMode(mode, agent string) tea.Cmd {
 			"mode":  mode,
 			"agent": agent,
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/session-mode", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/session-mode", bytes.NewReader(body))
 		if err != nil {
 			return channelResetDoneMsg{err: err}
 		}
@@ -5647,7 +5648,7 @@ func switchFocusMode(enabled bool) tea.Cmd {
 		body, _ := json.Marshal(map[string]any{
 			"focus_mode": enabled,
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/focus-mode", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/focus-mode", bytes.NewReader(body))
 		if err != nil {
 			return nil
 		}
@@ -5662,7 +5663,7 @@ func switchFocusMode(enabled bool) tea.Cmd {
 
 func applyTeamSetup() tea.Cmd {
 	return func() tea.Msg {
-		notice, err := setup.InstallLatestCLI()
+		notice, err := setup.InstallLatestCLI(context.Background())
 		if err != nil {
 			return channelInitDoneMsg{err: err}
 		}
@@ -5762,16 +5763,23 @@ func mapString(m map[string]any, key string) string {
 }
 
 func openBrowserURL(url string) error {
+	// openBrowserURL spawns a detached helper that hands the URL to the OS.
+	// We use context.Background() because the child must outlive this call —
+	// the user keeps interacting with the browser long after we return — and
+	// noctx's "use CommandContext" recommendation is satisfied by the
+	// background ctx. Cancellation isn't meaningful for a fire-and-forget
+	// open-in-browser handoff.
+	ctx := context.Background()
 	var cmd *exec.Cmd
 	switch {
 	case url == "":
 		return nil
 	case isDarwin():
-		cmd = exec.Command("open", url)
+		cmd = exec.CommandContext(ctx, "open", url)
 	case isLinux():
-		cmd = exec.Command("xdg-open", url)
+		cmd = exec.CommandContext(ctx, "xdg-open", url)
 	case isWindows():
-		cmd = exec.Command("cmd", "/c", "start", "", url)
+		cmd = exec.CommandContext(ctx, "cmd", "/c", "start", "", url)
 	default:
 		return fmt.Errorf("unsupported platform")
 	}
@@ -5784,10 +5792,18 @@ func isWindows() bool { return runtime.GOOS == "windows" }
 
 // killTeamSession kills the entire wuphf-team tmux session and all agent processes.
 func killTeamSession() {
+	// Best-effort cleanup at process exit; cap each step so a hung tmux or
+	// broker doesn't keep us alive forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	// Kill tmux session (kills all agent processes in all panes/windows)
-	_ = exec.Command("tmux", "-L", "wuphf", "kill-session", "-t", "wuphf-team").Run()
+	_ = exec.CommandContext(ctx, "tmux", "-L", "wuphf", "kill-session", "-t", "wuphf-team").Run()
 	// Stop the broker
-	if resp, err := http.Get(brokerURL("/health")); err == nil {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, brokerURL("/health"), nil)
+	if err != nil {
+		return
+	}
+	if resp, err := http.DefaultClient.Do(req); err == nil {
 		_ = resp.Body.Close()
 	}
 }

--- a/cmd/wuphf/channel_broker.go
+++ b/cmd/wuphf/channel_broker.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -50,8 +51,8 @@ func normalizeBrokerURL(raw string) string {
 }
 
 // newBrokerRequest creates an HTTP request with the broker auth header.
-func newBrokerRequest(method, url string, body io.Reader) (*http.Request, error) {
-	req, err := http.NewRequest(method, normalizeBrokerURL(url), body)
+func newBrokerRequest(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, normalizeBrokerURL(url), body)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +71,7 @@ func pollBroker(sinceID string, channel string) tea.Cmd {
 		if sinceID != "" {
 			url += "&since_id=" + sinceID
 		}
-		req, err := newBrokerRequest(http.MethodGet, url, nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, url, nil)
 		if err != nil {
 			return channelMsg{}
 		}
@@ -98,7 +99,7 @@ func pollBroker(sinceID string, channel string) tea.Cmd {
 
 func pollMembers(channel string) tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/members?channel="+channel, nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/members?channel="+channel, nil)
 		if err != nil {
 			return channelMembersMsg{}
 		}
@@ -126,7 +127,7 @@ func pollMembers(channel string) tea.Cmd {
 
 func pollOfficeMembers() tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/office-members", nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/office-members", nil)
 		if err != nil {
 			return channelOfficeMembersMsg{}
 		}
@@ -154,7 +155,7 @@ func pollOfficeMembers() tea.Cmd {
 
 func pollChannels() tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/channels", nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/channels", nil)
 		if err != nil {
 			return channelChannelsMsg{}
 		}
@@ -187,7 +188,7 @@ func createDMChannel(agentSlug string) tea.Cmd {
 			"members": []string{"human", agentSlug},
 			"type":    "direct",
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/channels/dm", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/channels/dm", bytes.NewReader(body))
 		if err != nil {
 			return channelDMCreatedMsg{err: err, agentSlug: agentSlug}
 		}
@@ -211,7 +212,11 @@ func createDMChannel(agentSlug string) tea.Cmd {
 func pollHealth() tea.Cmd {
 	return func() tea.Msg {
 		client := &http.Client{Timeout: 1200 * time.Millisecond}
-		resp, err := client.Get(brokerURL("/health"))
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, brokerURL("/health"), nil)
+		if err != nil {
+			return channelHealthMsg{}
+		}
+		resp, err := client.Do(req)
 		if err != nil {
 			return channelHealthMsg{}
 		}
@@ -244,7 +249,7 @@ func mutateChannel(action, slug, description string) tea.Cmd {
 			"description": description,
 			"created_by":  "you",
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/channels", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/channels", bytes.NewReader(body))
 		if err != nil {
 			return channelPostDoneMsg{err: err}
 		}
@@ -279,7 +284,7 @@ func mutateChannelMember(channel, action, slug string) tea.Cmd {
 			"channel": channel,
 			"slug":    slug,
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/channel-members", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/channel-members", bytes.NewReader(body))
 		if err != nil {
 			return channelPostDoneMsg{err: err}
 		}
@@ -310,7 +315,7 @@ func mutateOfficeMember(action, slug, name string) tea.Cmd {
 			"role":       name,
 			"created_by": "you",
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/office-members", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/office-members", bytes.NewReader(body))
 		if err != nil {
 			return channelPostDoneMsg{err: err}
 		}
@@ -349,7 +354,7 @@ func mutateTask(action, taskID, owner, channel string) tea.Cmd {
 			"owner":      owner,
 			"created_by": "you",
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/tasks", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/tasks", bytes.NewReader(body))
 		if err != nil {
 			return channelTaskMutationDoneMsg{err: err}
 		}
@@ -381,7 +386,7 @@ func mutateTask(action, taskID, owner, channel string) tea.Cmd {
 
 func pollUsage() tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/usage", nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/usage", nil)
 		if err != nil {
 			return channelUsageMsg{}
 		}
@@ -410,7 +415,7 @@ func pollUsage() tea.Cmd {
 
 func pollTasks(channel string) tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/tasks?channel="+channel, nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/tasks?channel="+channel, nil)
 		if err != nil {
 			return channelTasksMsg{}
 		}
@@ -434,7 +439,7 @@ func pollTasks(channel string) tea.Cmd {
 
 func pollSkills(channel string) tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/skills?channel="+channel, nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/skills?channel="+channel, nil)
 		if err != nil {
 			return channelSkillsMsg{}
 		}
@@ -469,7 +474,7 @@ func pollOfficeLedger() tea.Cmd {
 
 func pollActions() tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/actions", nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/actions", nil)
 		if err != nil {
 			return channelActionsMsg{}
 		}
@@ -493,7 +498,7 @@ func pollActions() tea.Cmd {
 
 func pollSignals() tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/signals", nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/signals", nil)
 		if err != nil {
 			return channelSignalsMsg{}
 		}
@@ -515,7 +520,7 @@ func pollSignals() tea.Cmd {
 
 func pollDecisions() tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/decisions", nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/decisions", nil)
 		if err != nil {
 			return channelDecisionsMsg{}
 		}
@@ -537,7 +542,7 @@ func pollDecisions() tea.Cmd {
 
 func pollWatchdogs() tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/watchdogs", nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/watchdogs", nil)
 		if err != nil {
 			return channelWatchdogsMsg{}
 		}
@@ -559,7 +564,7 @@ func pollWatchdogs() tea.Cmd {
 
 func pollScheduler() tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/scheduler", nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/scheduler", nil)
 		if err != nil {
 			return channelSchedulerMsg{}
 		}
@@ -583,7 +588,7 @@ func pollScheduler() tea.Cmd {
 
 func pollRequests(channel string) tea.Cmd {
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, "http://127.0.0.1:7890/requests?channel="+channel, nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, "http://127.0.0.1:7890/requests?channel="+channel, nil)
 		if err != nil {
 			return channelRequestsMsg{}
 		}
@@ -626,7 +631,7 @@ func postHumanInterrupt(channel string) tea.Cmd {
 				{"id": "redirect", "label": "Redirect — I'll type new instructions"},
 			},
 		})
-		req, _ := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/requests", bytes.NewReader(body))
+		req, _ := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/requests", bytes.NewReader(body))
 		client := &http.Client{Timeout: 2 * time.Second}
 		resp, err := client.Do(req)
 		if err != nil {
@@ -645,7 +650,7 @@ func postInterviewAnswer(interview channelInterview, choiceID, choiceText, custo
 			"choice_text": choiceText,
 			"custom_text": customText,
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/requests/answer", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/requests/answer", bytes.NewReader(body))
 		if err != nil {
 			return channelInterviewAnswerDoneMsg{err: err}
 		}

--- a/cmd/wuphf/channel_integration.go
+++ b/cmd/wuphf/channel_integration.go
@@ -136,7 +136,7 @@ func discoverTelegramGroups(token string) tea.Cmd {
 		for _, g := range groups {
 			seen[g.ChatID] = true
 		}
-		req, reqErr := newBrokerRequest("GET", "http://127.0.0.1:7890/telegram/groups", nil)
+		req, reqErr := newBrokerRequest(context.Background(), "GET", "http://127.0.0.1:7890/telegram/groups", nil)
 		if reqErr == nil {
 			client := &http.Client{Timeout: 2 * time.Second}
 			if resp, err := client.Do(req); err == nil {
@@ -237,7 +237,7 @@ func connectTelegramGroup(token string, group team.TelegramGroup) tea.Cmd {
 				"bot_token_env": "WUPHF_TELEGRAM_BOT_TOKEN",
 			},
 		})
-		req, reqErr := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/channels", bytes.NewReader(body))
+		req, reqErr := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/channels", bytes.NewReader(body))
 		if reqErr == nil {
 			client := &http.Client{Timeout: 3 * time.Second}
 			resp, err := client.Do(req)

--- a/cmd/wuphf/channel_member_draft.go
+++ b/cmd/wuphf/channel_member_draft.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -244,7 +245,7 @@ func mutateOfficeMemberSpec(draft channelMemberDraft, activeChannel string) tea.
 			"permission_mode": strings.TrimSpace(draft.PermissionMode),
 			"created_by":      "you",
 		})
-		req, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/office-members", bytes.NewReader(body))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/office-members", bytes.NewReader(body))
 		if err != nil {
 			return channelMemberDraftDoneMsg{err: err}
 		}
@@ -264,7 +265,7 @@ func mutateOfficeMemberSpec(draft channelMemberDraft, activeChannel string) tea.
 				"channel": activeChannel,
 				"slug":    draft.Slug,
 			})
-			addReq, err := newBrokerRequest(http.MethodPost, "http://127.0.0.1:7890/channel-members", bytes.NewReader(addBody))
+			addReq, err := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/channel-members", bytes.NewReader(addBody))
 			if err == nil {
 				addReq.Header.Set("Content-Type", "application/json")
 				if addResp, doErr := client.Do(addReq); doErr == nil {

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -47,7 +48,7 @@ func TestNewBrokerRequestUsesEnvTokenAtRequestTime(t *testing.T) {
 		t.Fatalf("set env: %v", err)
 	}
 
-	req, err := newBrokerRequest("GET", "http://127.0.0.1:7890/messages", nil)
+	req, err := newBrokerRequest(context.Background(), "GET", "http://127.0.0.1:7890/messages", nil)
 	if err != nil {
 		t.Fatalf("newBrokerRequest: %v", err)
 	}
@@ -79,7 +80,7 @@ func TestNewBrokerRequestFallsBackToTokenFile(t *testing.T) {
 	}
 	brokerTokenPath = tokenFile.Name()
 
-	req, err := newBrokerRequest("GET", "http://127.0.0.1:7890/messages", nil)
+	req, err := newBrokerRequest(context.Background(), "GET", "http://127.0.0.1:7890/messages", nil)
 	if err != nil {
 		t.Fatalf("newBrokerRequest: %v", err)
 	}

--- a/cmd/wuphf/onboarding.go
+++ b/cmd/wuphf/onboarding.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -701,7 +702,7 @@ func hasInstalledRuntimeCLI(prereqs []prereqResult) bool {
 func (m onboardingModel) fetchPrereqsCmd() tea.Cmd {
 	url := m.brokerURL + "/onboarding/prereqs"
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, url, nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, url, nil)
 		if err != nil {
 			return prereqsLoadedMsg{results: []prereqResult{
 				{Name: "git", Required: true, Found: false},
@@ -748,7 +749,7 @@ func (m onboardingModel) validateKeyCmd(key string) tea.Cmd {
 	url := m.brokerURL + "/onboarding/validate-key"
 	return func() tea.Msg {
 		payload, _ := json.Marshal(map[string]string{"key": key, "provider": "anthropic"})
-		req, err := newBrokerRequest(http.MethodPost, url, bytes.NewReader(payload))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, url, bytes.NewReader(payload))
 		if err != nil {
 			return keyValidatedMsg{status: "unverified"}
 		}
@@ -779,7 +780,7 @@ func (m onboardingModel) validateKeyCmd(key string) tea.Cmd {
 func (m onboardingModel) fetchTemplatesCmd() tea.Cmd {
 	url := m.brokerURL + "/onboarding/templates"
 	return func() tea.Msg {
-		req, err := newBrokerRequest(http.MethodGet, url, nil)
+		req, err := newBrokerRequest(context.Background(), http.MethodGet, url, nil)
 		if err != nil {
 			return templatesLoadedMsg{templates: defaultTemplates()}
 		}
@@ -824,7 +825,7 @@ func (m onboardingModel) submitProgressCmd(step string, answers map[string]inter
 			"step":    step,
 			"answers": answers,
 		})
-		req, err := newBrokerRequest(http.MethodPost, url, bytes.NewReader(payload))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, url, bytes.NewReader(payload))
 		if err != nil {
 			return onboardingProgressMsg{err: err}
 		}
@@ -845,7 +846,7 @@ func (m onboardingModel) completeOnboardingCmd(task string, skipTask bool) tea.C
 			"first_task": task,
 			"skip_task":  skipTask,
 		})
-		req, err := newBrokerRequest(http.MethodPost, url, bytes.NewReader(payload))
+		req, err := newBrokerRequest(context.Background(), http.MethodPost, url, bytes.NewReader(payload))
 		if err != nil {
 			// If broker isn't up yet, treat as complete (graceful).
 			return completeMsg{err: nil}
@@ -873,7 +874,7 @@ type onboardingState struct {
 
 func fetchOnboardingState(brokerURL string) (onboardingState, error) {
 	client := &http.Client{Timeout: 3 * time.Second}
-	req, err := newBrokerRequest(http.MethodGet, brokerURL+"/onboarding/state", nil)
+	req, err := newBrokerRequest(context.Background(), http.MethodGet, brokerURL+"/onboarding/state", nil)
 	if err != nil {
 		return onboardingState{Onboarded: true}, err
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3,6 +3,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -56,7 +57,19 @@ func request[T any](c *Client, method, path string, body any, timeout time.Durat
 		reqBody = bytes.NewReader(b)
 	}
 
-	req, err := http.NewRequest(method, path, reqBody)
+	t := c.Timeout
+	if timeout > 0 {
+		t = timeout
+	}
+	// The api.Client is invoked from many call sites that don't currently
+	// thread a context. Use a per-request background context with the
+	// configured timeout as the deadline — equivalent behaviour to the
+	// previous c.HTTPClient.Timeout but satisfies noctx and lets the request
+	// be cancelled when the deadline elapses.
+	ctx, cancel := context.WithTimeout(context.Background(), t)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, method, path, reqBody)
 	if err != nil {
 		return zero, fmt.Errorf("create request: %w", err)
 	}
@@ -68,10 +81,6 @@ func request[T any](c *Client, method, path string, body any, timeout time.Durat
 		req.Header.Set("Authorization", "Bearer "+c.APIKey)
 	}
 
-	t := c.Timeout
-	if timeout > 0 {
-		t = timeout
-	}
 	c.HTTPClient.Timeout = t
 
 	resp, err := c.HTTPClient.Do(req)
@@ -114,7 +123,10 @@ func (c *Client) getRaw(path string, timeout time.Duration) (string, error) {
 	}
 	c.HTTPClient.Timeout = t
 
-	req, err := http.NewRequest(http.MethodGet, path, nil)
+	ctx, cancel := context.WithTimeout(context.Background(), t)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -65,7 +65,10 @@ func request[T any](c *Client, method, path string, body any, timeout time.Durat
 	// thread a context. Use a per-request background context with the
 	// configured timeout as the deadline — equivalent behaviour to the
 	// previous c.HTTPClient.Timeout but satisfies noctx and lets the request
-	// be cancelled when the deadline elapses.
+	// be cancelled when the deadline elapses. Don't write to
+	// c.HTTPClient.Timeout: that's a shared field on a shared client and
+	// concurrent callers (e.g. agent.AgentService.client) would race; the
+	// per-request ctx deadline already enforces the same wall-clock bound.
 	ctx, cancel := context.WithTimeout(context.Background(), t)
 	defer cancel()
 
@@ -80,8 +83,6 @@ func request[T any](c *Client, method, path string, body any, timeout time.Durat
 	if c.APIKey != "" {
 		req.Header.Set("Authorization", "Bearer "+c.APIKey)
 	}
-
-	c.HTTPClient.Timeout = t
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
@@ -121,8 +122,9 @@ func (c *Client) getRaw(path string, timeout time.Duration) (string, error) {
 	if timeout > 0 {
 		t = timeout
 	}
-	c.HTTPClient.Timeout = t
-
+	// See comment in request[T] above: don't write c.HTTPClient.Timeout —
+	// shared client, concurrent callers would race. Per-request ctx
+	// deadline enforces the same bound.
 	ctx, cancel := context.WithTimeout(context.Background(), t)
 	defer cancel()
 

--- a/internal/commands/cmd_system.go
+++ b/internal/commands/cmd_system.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -81,7 +82,7 @@ func cmdInit(ctx *SlashContext, args string) error {
 		return err
 	}
 
-	notice, err := setup.InstallLatestCLI()
+	notice, err := setup.InstallLatestCLI(context.Background())
 	if err != nil {
 		return err
 	}

--- a/internal/onboarding/handlers.go
+++ b/internal/onboarding/handlers.go
@@ -1,6 +1,7 @@
 package onboarding
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -268,7 +269,7 @@ func onboardingPartialCompanyName(partial *PartialProgress) string {
 
 // validateProviderKey pings the provider API with a minimal request to verify
 // the key. Returns "valid", "invalid", "unreachable", or "format_error".
-func validateProviderKey(provider, key string) string {
+func validateProviderKey(ctx context.Context, provider, key string) string {
 	key = strings.TrimSpace(key)
 	if key == "" {
 		return "format_error"
@@ -278,12 +279,12 @@ func validateProviderKey(provider, key string) string {
 		if !strings.HasPrefix(key, "sk-ant-") || len(key) < 20 {
 			return "format_error"
 		}
-		return pingAnthropic(key)
+		return pingAnthropic(ctx, key)
 	case "openai":
 		if !strings.HasPrefix(key, "sk-") || len(key) < 20 {
 			return "format_error"
 		}
-		return pingOpenAI(key)
+		return pingOpenAI(ctx, key)
 	case "gemini":
 		if len(key) < 10 {
 			return "format_error"
@@ -295,10 +296,10 @@ func validateProviderKey(provider, key string) string {
 	}
 }
 
-func pingAnthropic(key string) string {
+func pingAnthropic(ctx context.Context, key string) string {
 	client := &http.Client{Timeout: 3 * time.Second}
 	body := strings.NewReader(`{"model":"claude-haiku-4-5-20251001","max_tokens":1,"messages":[{"role":"user","content":"hi"}]}`)
-	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.anthropic.com/v1/messages", body)
 	if err != nil {
 		return "unreachable"
 	}
@@ -320,9 +321,9 @@ func pingAnthropic(key string) string {
 	}
 }
 
-func pingOpenAI(key string) string {
+func pingOpenAI(ctx context.Context, key string) string {
 	client := &http.Client{Timeout: 3 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, "https://api.openai.com/v1/models", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.openai.com/v1/models", nil)
 	if err != nil {
 		return "unreachable"
 	}
@@ -394,7 +395,7 @@ func HandleValidateKey(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid json", http.StatusBadRequest)
 		return
 	}
-	status := validateProviderKey(body.Provider, body.Key)
+	status := validateProviderKey(r.Context(), body.Provider, body.Key)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]string{"status": status})
 }

--- a/internal/setup/install.go
+++ b/internal/setup/install.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,7 +12,8 @@ const defaultCLIPackage = "@nex-ai/nex"
 
 // InstallLatestCLI installs the latest published CLI from npm.
 // The package and installer binary can be overridden for tests via env vars.
-func InstallLatestCLI() (string, error) {
+// The context controls cancellation of the spawned npm install process.
+func InstallLatestCLI(ctx context.Context) (string, error) {
 	bin := strings.TrimSpace(os.Getenv("WUPHF_CLI_INSTALL_BIN"))
 	if bin == "" {
 		bin = "npm"
@@ -26,7 +28,7 @@ func InstallLatestCLI() (string, error) {
 		return "", fmt.Errorf("%s is required to install the latest CLI from npm", bin)
 	}
 
-	cmd := exec.Command(path, "install", "-g", pkg+"@latest")
+	cmd := exec.CommandContext(ctx, path, "install", "-g", pkg+"@latest")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		if trimmed := strings.TrimSpace(string(output)); trimmed != "" {

--- a/internal/setup/install_test.go
+++ b/internal/setup/install_test.go
@@ -1,6 +1,7 @@
 package setup
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,7 +21,7 @@ func TestInstallLatestCLI(t *testing.T) {
 	t.Setenv("WUPHF_CLI_INSTALL_BIN", "npm")
 	t.Setenv("WUPHF_CLI_PACKAGE", "@example/wuphf")
 
-	notice, err := InstallLatestCLI()
+	notice, err := InstallLatestCLI(context.Background())
 	if err != nil {
 		t.Fatalf("InstallLatestCLI returned error: %v", err)
 	}
@@ -51,7 +52,7 @@ func TestInstallLatestCLIReturnsHelpfulFailure(t *testing.T) {
 	t.Setenv("WUPHF_CLI_INSTALL_BIN", "npm")
 	t.Setenv("WUPHF_CLI_PACKAGE", "@example/wuphf")
 
-	_, err := InstallLatestCLI()
+	_, err := InstallLatestCLI(context.Background())
 	if err == nil {
 		t.Fatal("expected install failure")
 	}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -1594,7 +1594,8 @@ func (b *Broker) StartOnPort(port int) error {
 	})
 
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	ln, err := net.Listen("tcp", addr)
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", addr)
 	if err != nil {
 		return err
 	}
@@ -2416,7 +2417,7 @@ func (b *Broker) webUIProxyHandler(brokerURL, stripPrefix string) http.Handler {
 			target += "?" + r.URL.RawQuery
 		}
 
-		proxyReq, err := http.NewRequest(r.Method, target, r.Body)
+		proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, target, r.Body)
 		if err != nil {
 			http.Error(w, "proxy error", http.StatusBadGateway)
 			return
@@ -4758,12 +4759,13 @@ func respawnAgentPane(slug string) {
 			paneIdx := i + 1 // pane 0 is channel view
 			target := fmt.Sprintf("wuphf-team:team.%d", paneIdx)
 			// Send Ctrl+C to interrupt, then exit to terminate
-			_ = exec.Command("tmux", "-L", "wuphf", "send-keys", "-t", target, "C-c", "").Run()
+			ctx := context.Background()
+			_ = exec.CommandContext(ctx, "tmux", "-L", "wuphf", "send-keys", "-t", target, "C-c", "").Run()
 			time.Sleep(500 * time.Millisecond)
-			_ = exec.Command("tmux", "-L", "wuphf", "send-keys", "-t", target, "C-c", "").Run()
+			_ = exec.CommandContext(ctx, "tmux", "-L", "wuphf", "send-keys", "-t", target, "C-c", "").Run()
 			time.Sleep(500 * time.Millisecond)
 			// Respawn the pane with a fresh claude session
-			_ = exec.Command("tmux", "-L", "wuphf", "respawn-pane", "-k", "-t", target).Run()
+			_ = exec.CommandContext(ctx, "tmux", "-L", "wuphf", "respawn-pane", "-k", "-t", target).Run()
 			return
 		}
 	}
@@ -8211,7 +8213,7 @@ func (b *Broker) capturePaneActivity(slugOverride string) map[string]string {
 	b.mu.Unlock()
 
 	for _, check := range checks {
-		paneOut, err := exec.Command("tmux", "-L", "wuphf", "capture-pane",
+		paneOut, err := exec.CommandContext(context.Background(), "tmux", "-L", "wuphf", "capture-pane",
 			"-p", "-J",
 			"-t", check.target).CombinedOutput()
 		if err != nil {

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -146,7 +146,7 @@ func defaultHeadlessCodexWorkspaceStatusSnapshot(path string) string {
 func (l *Launcher) launchHeadlessCodex() error {
 	killStaleBroker()
 	killStaleHeadlessTaskRunners()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 
 	l.broker = NewBroker()
 	l.broker.packSlug = l.packSlug

--- a/internal/team/human_identity.go
+++ b/internal/team/human_identity.go
@@ -55,6 +55,7 @@ package team
 // people have each edited once, both are in the registry.
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -281,7 +282,9 @@ func runGitConfig(key string) string {
 	// gitexec.CleanEnv strips GIT_CONFIG_PARAMETERS and friends: when wuphf
 	// runs inside a git hook, the outer git may inject `-c` overrides
 	// via that env var which would silently override --global reads.
-	cmd := exec.Command("git", "config", "--global", key)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "config", "--global", key)
 	cmd.Env = gitexec.CleanEnv()
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -295,7 +295,7 @@ func checkGHCapability() (installed bool, authed bool, note string) {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return false, false, "gh CLI not found in PATH; agents won't be able to open real PRs. Install from https://cli.github.com."
 	}
-	cmd := exec.Command("gh", "auth", "status")
+	cmd := exec.CommandContext(context.Background(), "gh", "auth", "status")
 	if err := cmd.Run(); err != nil {
 		return true, false, "gh installed but not authenticated; run `gh auth login` so agents can open real PRs."
 	}
@@ -352,7 +352,7 @@ func (l *Launcher) Launch() error {
 	}
 
 	// Kill any existing session
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 
 	// Resolve wuphf binary path for the channel view
 	wuphfBinary, _ := os.Executable()
@@ -373,7 +373,7 @@ func (l *Launcher) Launch() error {
 		)
 	}
 	channelCmd := fmt.Sprintf("%s %s --channel-view 2>>%s", strings.Join(channelEnv, " "), wuphfBinary, shellQuote(channelStderrLogPath()))
-	err = exec.Command("tmux", "-L", tmuxSocketName, "new-session", "-d",
+	err = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "new-session", "-d",
 		"-s", l.sessionName,
 		"-n", "team",
 		"-c", l.cwd,
@@ -385,47 +385,47 @@ func (l *Launcher) Launch() error {
 
 	// Keep tmux mouse off for this session so native terminal selection/copy works.
 	// WUPHF is keyboard-first; we don't want the TUI or tmux to steal mouse events.
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"mouse", "off",
 	).Run()
 
 	// Hide tmux's default status bar — our channel TUI has its own.
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"status", "off",
 	).Run()
 	// Keep panes visible if a process exits so crashes don't collapse the layout.
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-window-option", "-t", l.sessionName+":team",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-window-option", "-t", l.sessionName+":team",
 		"remain-on-exit", "on",
 	).Run()
 
 	// Pane border cosmetics — kept so the channel pane renders with a border
 	// title. Per-agent panes are not spawned in the default path; they live
 	// only as an internal fallback (see trySpawnWebAgentPanes).
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-status", "top",
 	).Run()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-format", " #{pane_title} ",
 	).Run()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-style", "fg=colour240",
 	).Run()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-active-border-style", "fg=colour45",
 	).Run()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"pane-border-lines", "heavy",
 	).Run()
 
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
 		"-t", l.sessionName+":team.0",
 		"-T", "📢 channel",
 	).Run()
 
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-window",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-window",
 		"-t", l.sessionName+":team",
 	).Run()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
 		"-t", l.sessionName+":team.0",
 	).Run()
 
@@ -1263,12 +1263,12 @@ func (l *Launcher) watchChannelPaneLoop(channelCmd string) {
 		deadSince = time.Time{}
 		snapshotWritten = false
 		target := l.sessionName + ":team.0"
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
 			"-t", target,
 			"-c", l.cwd,
 			channelCmd,
 		).Run()
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", target,
 			"-T", "📢 channel",
 		).Run()
@@ -1276,7 +1276,7 @@ func (l *Launcher) watchChannelPaneLoop(channelCmd string) {
 }
 
 func (l *Launcher) channelPaneStatus() (string, error) {
-	out, err := exec.Command("tmux", "-L", tmuxSocketName, "display-message",
+	out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "display-message",
 		"-p",
 		"-t", l.sessionName+":team.0",
 		"#{pane_dead} #{pane_dead_status} #{pane_current_command}",
@@ -1362,7 +1362,7 @@ func (l *Launcher) primeVisibleAgents() {
 				continue
 			}
 			if shouldPrimeClaudePane(content) {
-				_ = exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+				_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
 					"-t", target.PaneTarget,
 					"Enter",
 				).Run()
@@ -2090,12 +2090,12 @@ func (l *Launcher) OneOnOneAgent() string {
 
 // killStaleBroker kills any process holding the configured broker port from a previous run.
 func killStaleBroker() {
-	out, err := exec.Command("lsof", "-i", fmt.Sprintf(":%d", brokeraddr.ResolvePort()), "-t").Output()
+	out, err := exec.CommandContext(context.Background(), "lsof", "-i", fmt.Sprintf(":%d", brokeraddr.ResolvePort()), "-t").Output()
 	if err != nil || len(out) == 0 {
 		return
 	}
 	for _, pid := range strings.Fields(strings.TrimSpace(string(out))) {
-		_ = exec.Command("kill", "-9", pid).Run()
+		_ = exec.CommandContext(context.Background(), "kill", "-9", pid).Run()
 	}
 	time.Sleep(500 * time.Millisecond)
 }
@@ -2161,9 +2161,9 @@ func (l *Launcher) Attach() error {
 	if os.Getenv("TERM_PROGRAM") == "iTerm.app" {
 		// tmux -CC mode: iTerm2 takes over window management.
 		// Creates native iTerm2 tabs/splits for each tmux window/pane.
-		cmd = exec.Command("tmux", "-L", tmuxSocketName, "-CC", "attach-session", "-t", l.sessionName)
+		cmd = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "-CC", "attach-session", "-t", l.sessionName)
 	} else {
-		cmd = exec.Command("tmux", "-L", tmuxSocketName, "attach-session", "-t", l.sessionName)
+		cmd = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "attach-session", "-t", l.sessionName)
 	}
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
@@ -2195,10 +2195,10 @@ func (l *Launcher) Kill() error {
 		_ = clearOfficePIDFile()
 		return nil
 	}
-	err := exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+	err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 	if err != nil {
 		// Check if the session simply doesn't exist
-		out, _ := exec.Command("tmux", "-L", tmuxSocketName, "list-sessions").CombinedOutput()
+		out, _ := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "list-sessions").CombinedOutput()
 		if strings.Contains(string(out), "no server") || strings.Contains(string(out), "error connecting") {
 			return nil // no session running, nothing to kill
 		}
@@ -2249,7 +2249,7 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 	l.provider = config.ResolveLLMProvider("")
 	if !l.usesPaneRuntime() {
 		if l.paneBackedAgents {
-			_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+			_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 			l.paneBackedAgents = false
 		}
 		return nil
@@ -2310,7 +2310,7 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 		target := fmt.Sprintf("%s:team.%d", l.sessionName, idx)
 		// respawn-pane -k kills the current process and starts a new one
 		// in the same pane — preserving size and position
-		out, err := exec.Command("tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
+		out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
 			"-t", target,
 			"-c", l.cwd,
 			cmd,
@@ -3120,19 +3120,19 @@ var launcherSendNotificationToPane = func(l *Launcher, paneTarget, notification 
 // type + Enter unconditionally, so rapid direct calls will race each other.
 // queuePaneNotification serializes per-slug and inserts the minimum gap.
 func (l *Launcher) sendNotificationToPane(paneTarget, notification string) {
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
 		"-t", paneTarget, "/clear", "Enter",
 	).Run()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
 		"-t", paneTarget, "-l", notification,
 	).Run()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "send-keys",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
 		"-t", paneTarget, "Enter",
 	).Run()
 }
 
 func (l *Launcher) capturePaneTargetContent(target string) (string, error) {
-	out, err := exec.Command("tmux", "-L", tmuxSocketName, "capture-pane",
+	out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "capture-pane",
 		"-p", "-J",
 		"-t", target,
 	).CombinedOutput()
@@ -3213,7 +3213,9 @@ func killPersistedOfficeProcess() error {
 }
 
 func resetBrokerState(baseURL, token string) error {
-	req, err := http.NewRequest(http.MethodPost, baseURL+"/reset", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/reset", nil)
 	if err != nil {
 		return err
 	}
@@ -3243,13 +3245,13 @@ func (l *Launcher) clearAgentPanes() error {
 			continue // skip pane 0 (channel TUI)
 		}
 		target := fmt.Sprintf("%s:team.%d", l.sessionName, idx)
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-pane", "-t", target).Run()
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-pane", "-t", target).Run()
 	}
 	return nil
 }
 
 func (l *Launcher) clearOverflowAgentWindows() {
-	out, err := exec.Command("tmux", "-L", tmuxSocketName, "list-windows",
+	out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "list-windows",
 		"-t", l.sessionName,
 		"-F", "#{window_name}",
 	).CombinedOutput()
@@ -3261,14 +3263,14 @@ func (l *Launcher) clearOverflowAgentWindows() {
 		if !strings.HasPrefix(name, "agent-") {
 			continue
 		}
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-window",
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-window",
 			"-t", fmt.Sprintf("%s:%s", l.sessionName, name),
 		).Run()
 	}
 }
 
 func (l *Launcher) listTeamPanes() ([]int, error) {
-	out, err := exec.Command("tmux", "-L", tmuxSocketName, "list-panes",
+	out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "list-panes",
 		"-t", l.sessionName+":team",
 		"-F", "#{pane_index} #{pane_title}",
 	).CombinedOutput()
@@ -3284,7 +3286,7 @@ func (l *Launcher) listTeamPanes() ([]int, error) {
 
 // HasLiveTmuxSession returns true if a wuphf-team tmux session is running.
 func HasLiveTmuxSession() bool {
-	err := exec.Command("tmux", "-L", tmuxSocketName, "has-session", "-t", SessionName).Run()
+	err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "has-session", "-t", SessionName).Run()
 	return err == nil
 }
 
@@ -3342,7 +3344,7 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		out, err := exec.Command("tmux", "-L", tmuxSocketName, "split-window", "-h",
+		out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "split-window", "-h",
 			"-t", l.sessionName+":team",
 			"-p", "65",
 			"-c", l.cwd,
@@ -3355,22 +3357,22 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 			}
 			return nil, fmt.Errorf("spawn one-on-one agent: %w (tmux: %s)", err, detail)
 		}
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-layout",
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-layout",
 			"-t", l.sessionName+":team",
 			"main-vertical",
 		).Run()
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", l.sessionName+":team.0",
 			"-T", "📢 direct",
 		).Run()
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", fmt.Sprintf("%s:team.1", l.sessionName),
 			"-T", fmt.Sprintf("🤖 %s (@%s)", l.getAgentName(slug), slug),
 		).Run()
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-window",
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-window",
 			"-t", l.sessionName+":team",
 		).Run()
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", l.sessionName+":team.0",
 		).Run()
 		return []string{slug}, nil
@@ -3394,7 +3396,7 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	out, err := exec.Command("tmux", "-L", tmuxSocketName, "split-window", "-h",
+	out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "split-window", "-h",
 		"-t", l.sessionName+":team",
 		"-p", "65",
 		"-c", l.cwd,
@@ -3419,7 +3421,7 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 			l.recordPaneSpawnFailure(visible[i].Slug, fmt.Sprintf("claudeCommand: %v", err))
 			continue
 		}
-		out, err := exec.Command("tmux", "-L", tmuxSocketName, "split-window",
+		out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "split-window",
 			"-t", l.sessionName+":team.1",
 			"-c", l.cwd,
 			agentCmd,
@@ -3440,21 +3442,21 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 
 	// Apply tiled layout to agent panes, but keep channel (pane 0) as main-vertical
 	// Use main-vertical first to keep channel on the left
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-layout",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-layout",
 		"-t", l.sessionName+":team",
 		"main-vertical",
 	).Run()
 
 	// Now set pane titles
 	var visibleSlugs []string
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
 		"-t", l.sessionName+":team.0",
 		"-T", "📢 channel",
 	).Run()
 	for i, a := range visible {
 		paneIdx := i + 1 // pane 0 is channel
 		name := l.getAgentName(a.Slug)
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
 			"-t", fmt.Sprintf("%s:team.%d", l.sessionName, paneIdx),
 			"-T", fmt.Sprintf("🤖 %s (@%s)", name, a.Slug),
 		).Run()
@@ -3462,10 +3464,10 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 	}
 
 	// Focus channel pane
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-window",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-window",
 		"-t", l.sessionName+":team",
 	).Run()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "select-pane",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
 		"-t", l.sessionName+":team.0",
 	).Run()
 
@@ -3487,7 +3489,7 @@ func (l *Launcher) spawnOverflowAgents() {
 			continue
 		}
 		windowName := overflowWindowName(member.Slug)
-		out, err := exec.Command("tmux", "-L", tmuxSocketName, "new-window", "-d",
+		out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "new-window", "-d",
 			"-t", l.sessionName,
 			"-n", windowName,
 			"-c", l.cwd,
@@ -3522,14 +3524,14 @@ func (l *Launcher) detectDeadPanesAfterSpawn(members []officeMember) {
 		if !ok || target.PaneTarget == "" {
 			continue
 		}
-		out, err := exec.Command("tmux", "-L", tmuxSocketName, "display-message",
+		out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "display-message",
 			"-t", target.PaneTarget,
 			"-p", "#{pane_dead}",
 		).CombinedOutput()
 		if err != nil || strings.TrimSpace(string(out)) != "1" {
 			continue
 		}
-		history, _ := exec.Command("tmux", "-L", tmuxSocketName, "capture-pane",
+		history, _ := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "capture-pane",
 			"-t", target.PaneTarget,
 			"-p", "-J", "-S", "-200",
 		).CombinedOutput()
@@ -3596,13 +3598,13 @@ func (l *Launcher) trySpawnWebAgentPanes() {
 
 	// Remove any stale session from a previous run. Ignore errors — the common
 	// case is "no such session".
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 
 	// Create a detached session with a placeholder pane 0. Agent panes are
 	// attached as splits afterward so agentPaneTargets() (which starts at
 	// team.1) maps correctly.
 	placeholderCmd := "sh -c 'while :; do sleep 3600; done'"
-	if err := exec.Command("tmux", "-L", tmuxSocketName, "new-session", "-d",
+	if err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "new-session", "-d",
 		"-s", l.sessionName,
 		"-n", "team",
 		"-c", l.cwd,
@@ -3611,18 +3613,18 @@ func (l *Launcher) trySpawnWebAgentPanes() {
 		l.reportPaneFallback(true, "tmux new-session failed", err)
 		return
 	}
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"mouse", "off",
 	).Run()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
 		"status", "off",
 	).Run()
-	_ = exec.Command("tmux", "-L", tmuxSocketName, "set-window-option", "-t", l.sessionName+":team",
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-window-option", "-t", l.sessionName+":team",
 		"remain-on-exit", "on",
 	).Run()
 
 	if _, err := l.spawnVisibleAgents(); err != nil {
-		_ = exec.Command("tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
 		l.reportPaneFallback(true, "spawn visible agents failed", err)
 		return
 	}
@@ -4457,7 +4459,9 @@ func loadRunningSessionMode() (string, string) {
 		return SessionModeOffice, DefaultOneOnOneAgent
 	}
 
-	req, err := http.NewRequest(http.MethodGet, brokerBaseURL()+"/session-mode", nil)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, brokerBaseURL()+"/session-mode", nil)
 	if err != nil {
 		return SessionModeOffice, DefaultOneOnOneAgent
 	}
@@ -4699,12 +4703,12 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		if answer == "" || answer == "y" || answer == "yes" {
 			fmt.Println()
 			fmt.Println("  Nex CLI not found. Installing...")
-			if _, installErr := setup.InstallLatestCLI(); installErr != nil {
+			if _, installErr := setup.InstallLatestCLI(context.Background()); installErr != nil {
 				fmt.Printf("  Could not install: %v\n", installErr)
 				fmt.Println("  Continuing without Nex.")
 			}
 			if nexBin := nex.BinaryPath(); nexBin != "" {
-				cmd := exec.Command(nexBin, "setup")
+				cmd := exec.CommandContext(context.Background(), nexBin, "setup")
 				cmd.Stdin = os.Stdin
 				cmd.Stdout = os.Stdout
 				cmd.Stderr = os.Stderr
@@ -4811,11 +4815,11 @@ func openBrowser(url string) {
 	var cmd *exec.Cmd
 	switch runtime.GOOS {
 	case "darwin":
-		cmd = exec.Command("open", url)
+		cmd = exec.CommandContext(context.Background(), "open", url)
 	case "linux":
-		cmd = exec.Command("xdg-open", url)
+		cmd = exec.CommandContext(context.Background(), "xdg-open", url)
 	case "windows":
-		cmd = exec.Command("cmd", "/c", "start", "", url)
+		cmd = exec.CommandContext(context.Background(), "cmd", "/c", "start", "", url)
 	default:
 		return
 	}

--- a/internal/team/telegram.go
+++ b/internal/team/telegram.go
@@ -426,7 +426,14 @@ func (t *TelegramTransport) sendMessageWithMode(chatID, text, parseMode string) 
 		return err
 	}
 
-	resp, err := t.client.Post(url, "application/json", bytes.NewReader(data))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("telegram send: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := t.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("telegram send: %w", err)
 	}
@@ -459,7 +466,14 @@ func SendTypingAction(token string, chatID int64) error {
 		return err
 	}
 
-	resp, err := http.Post(url, "application/json", bytes.NewReader(data))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("telegram typing: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("telegram typing: %w", err)
 	}
@@ -494,7 +508,13 @@ type TelegramGroup struct {
 // VerifyBot checks the bot token by calling getMe and returns the bot's display name.
 func VerifyBot(token string) (string, error) {
 	url := fmt.Sprintf("%s/bot%s/getMe", telegramAPIBase, token)
-	resp, err := http.Get(url)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("telegram getMe: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("telegram getMe: %w", err)
 	}
@@ -533,7 +553,13 @@ func DiscoverGroups(token string) ([]TelegramGroup, error) {
 	// Use offset=-100 to peek at recent updates without consuming them.
 	// This way the transport's pollInbound doesn't lose messages.
 	url := fmt.Sprintf("%s/bot%s/getUpdates?timeout=0&offset=-100", telegramAPIBase, token)
-	resp, err := http.Get(url)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("telegram getUpdates: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("telegram getUpdates: %w", err)
 	}
@@ -590,7 +616,14 @@ func SendTelegramMessage(token string, chatID int64, text string) error {
 	if err != nil {
 		return err
 	}
-	resp, err := http.Post(url, "application/json", bytes.NewReader(payload))
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("telegram send: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("telegram send: %w", err)
 	}
@@ -614,7 +647,13 @@ func SendTelegramMessage(token string, chatID int64, text string) error {
 // VerifyChat checks if a chat ID is valid and returns its title.
 func VerifyChat(token string, chatID int64) (string, error) {
 	url := fmt.Sprintf("%s/bot%s/getChat?chat_id=%d", telegramAPIBase, token, chatID)
-	resp, err := http.Get(url)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("telegram getChat: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("telegram getChat: %w", err)
 	}

--- a/internal/team/worktree.go
+++ b/internal/team/worktree.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/gitexec"
 )
@@ -257,7 +258,13 @@ func defaultTaskWorktreeRootDir(repoRoot string) string {
 }
 
 func runGit(dir string, args ...string) error {
-	cmd := exec.Command("git", args...)
+	// Bound each git invocation so a hung credential-helper or filesystem
+	// stall in a worktree can't pin the broker forever. 60s is generous for
+	// the longest real operations (clone, fsck) and short enough to surface
+	// hangs.
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	cmd.Env = gitexec.CleanEnv()
 	var stderr bytes.Buffer
@@ -269,7 +276,9 @@ func runGit(dir string, args ...string) error {
 }
 
 func runGitOutput(dir string, args ...string) ([]byte, error) {
-	cmd := exec.Command("git", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	cmd.Env = gitexec.CleanEnv()
 	var stdout bytes.Buffer
@@ -435,7 +444,9 @@ func copyWorkspacePath(src, dst string, info os.FileInfo) error {
 }
 
 func gitRefExists(dir, ref string) bool {
-	cmd := exec.Command("git", "show-ref", "--verify", "--quiet", ref)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "show-ref", "--verify", "--quiet", ref)
 	cmd.Dir = dir
 	cmd.Env = gitexec.CleanEnv()
 	return cmd.Run() == nil


### PR DESCRIPTION
## Summary

Replaces #330 (auto-closed when its base `improve/golangci-tighten` branch was deleted on merge). Now rebased onto `main`.

Enables the `noctx` linter and fixes 96 non-test findings:
- `http.Get`/`Post`/`NewRequest` → `http.NewRequestWithContext` + `client.Do(req)` + close body
- `os/exec.Command` → `exec.CommandContext`

`noctx` excluded for `_test.go` (httptest.NewRequest is canonical in tests).

## Findings fixed (96/96)

| File | Count |
|---|---|
| `internal/team/launcher.go` | 63 |
| `internal/team/telegram.go` | 6 |
| `internal/team/broker.go` | 6 |
| `cmd/wuphf/channel.go` | 5 |
| `internal/team/worktree.go` | 3 |
| `cmd/wuphf-oc-probe/multi-provider-http/main.go` | 3 |
| `internal/onboarding/handlers.go` | 2 |
| `internal/api/client.go` | 2 |
| `cmd/wuphf/channel_broker.go` | 2 |
| `internal/team/human_identity.go` | 1 |
| `internal/team/headless_codex.go` | 1 |
| `internal/setup/install.go` | 1 |

No `//nolint:noctx` suppressions, no path exclusions.

## Non-mechanical decisions

1. **`internal/api/client.go`** — kept `context.Background()` at the boundary inside `request[T]`/`getRaw` rather than threading ctx through 64 callers (would touch 20+ unrelated files). Per-request `context.WithTimeout(client.Timeout)` preserves prior cancellation semantics. **Also dropped redundant `c.HTTPClient.Timeout = t` writes** (per staff review — pre-existing data race for shared-client consumers like `agent.AgentService.client`, made redundant by the per-request ctx deadline).
2. **`internal/team/launcher.go`** — bulk-converted 63 `exec.Command` tmux calls to `exec.CommandContext(context.Background(), ...)` rather than threading ctx through pane-spawn helpers. Launcher already owns `headlessCtx` for long-running work; the 63 are short-lived tmux ops. Staff review flagged the asymmetry — followup PR will flip post-init paths to `l.headlessCtx`.
3. Added `context.Context` parameters to: `setup.InstallLatestCLI`, `onboarding.validateProviderKey/pingAnthropic/pingOpenAI`, `cmd/wuphf.newBrokerRequest` (~30 callers updated).
4. **`internal/team/broker.go`** — `net.Listen` → `net.ListenConfig{}.Listen(ctx, ...)`; broker proxy handler now passes `r.Context()` to upstream so client disconnects propagate.

## Followups (separate PRs, per staff review)

- `internal/team/launcher.go` — flip post-init tmux ops from `context.Background()` to `l.headlessCtx` for cancellation symmetry
- `internal/team/telegram.go` — drop fresh-Background timeouts in `sendMessageWithMode`/`SendTelegramMessage`/`SendTypingAction` and use the parent transport ctx so shutdown cancels in-flight sends

## Verification

- `golangci-lint run --timeout=5m ./...` → **0 issues**
- `go build ./...`, `go vet ./...`, `gofmt -l .` → all clean
- `go test -count=1 -timeout 5m` on touched packages (team, api, cmd/wuphf, onboarding, setup) → all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Network requests and subprocess operations now support explicit timeouts and cancellation, preventing indefinite hangs and improving responsiveness.
  * Enhanced request lifecycle management ensures operations respect timeout deadlines and respond to cancellation signals.
  * Linter configuration now enforces context-aware practices across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->