### PR TITLE
fix(ci): resolve docs-link-check reusable to commit sha (v0.6.2)

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -17,4 +17,9 @@ on:
 
 jobs:
   check:
-    uses: nex-crm/.github/.github/workflows/docs-link-check.yml@34310b131f22dd1c541ea1f2aa6cf1bd531a426b # v0.6.2
+    # NOTE: 98294031… is the COMMIT sha v0.6.2 dereferences to. The
+    # earlier pin (34310b13…) was the annotated-tag-object sha — GitHub
+    # Actions cannot resolve `uses: …@<tag-object-sha>`, the workflow
+    # silently fails validation with conclusion=failure and zero jobs.
+    # Verified with: gh api repos/nex-crm/.github/git/tags/<tag-obj-sha> --jq .object.sha
+    uses: nex-crm/.github/.github/workflows/docs-link-check.yml@98294031b84bf07f8bdf227940225ba21e9d2678 # v0.6.2


### PR DESCRIPTION
## Summary

Replace the broken `@34310b13…` (annotated-tag-object sha) pin in `.github/workflows/docs-link-check.yml` with `@98294031…`, the commit sha that `v0.6.2` dereferences to.

## Why

GitHub Actions cannot resolve `uses: …@<tag-object-sha>` — workflow silently fails validation with `conclusion=failure` + zero jobs the first time a PR touches a `.md` file. Surfaced + first-fixed in [nex-cli#180](https://github.com/nex-crm/nex-cli/pull/180).

Verified with:
```sh
gh api repos/nex-crm/.github/git/tags/34310b131f22dd1c541ea1f2aa6cf1bd531a426b --jq .object.sha
# → 98294031b84bf07f8bdf227940225ba21e9d2678 (type: commit)
```

## Test plan

- [ ] CI on this PR runs `docs-link-check` to completion (not silent zero-jobs failure)
- [ ] If repo currently has open PRs touching `.md`, those will start passing once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation link validation workflow to ensure consistent and reliable link checking across documentation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->