### PR TITLE
fix(web): tighten markdown link sanitizer + add regression tests

### DIFF
--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { formatMarkdown } from "./markdown";
+
+describe("formatMarkdown link sanitization", () => {
+  it("renders http and https URLs as links", () => {
+    expect(formatMarkdown("[x](https://example.com)")).toContain(
+      'href="https://example.com"',
+    );
+    expect(formatMarkdown("[x](http://example.com)")).toContain(
+      'href="http://example.com"',
+    );
+  });
+
+  it("rejects javascript: scheme", () => {
+    const out = formatMarkdown("[x](javascript:alert(1))");
+    expect(out).not.toContain("href=");
+    expect(out).toContain('class="msg-link"');
+  });
+
+  it("rejects data: URLs", () => {
+    const out = formatMarkdown("[x](data:text/html,hello)");
+    expect(out).not.toContain("href=");
+  });
+
+  it("rejects vbscript: scheme", () => {
+    const out = formatMarkdown("[x](vbscript:msgbox(1))");
+    expect(out).not.toContain("href=");
+  });
+
+  it("rejects leading-space + uppercased javascript:", () => {
+    const out = formatMarkdown("[x]( JAVASCRIPT:alert(1))");
+    expect(out).not.toContain("href=");
+  });
+
+  it("rejects HTML-entity encoded scheme bypass", () => {
+    // After escapeHtml, `&#x6A;avascript:` becomes `&amp;#x6A;avascript:`
+    // which doesn't match any safe prefix.
+    const out = formatMarkdown("[x](&#x6A;avascript:alert(1))");
+    expect(out).not.toContain("href=");
+  });
+
+  it("rejects protocol-relative // URLs", () => {
+    const out = formatMarkdown("[x](//evil.com/path)");
+    expect(out).not.toContain("href=");
+  });
+
+  it("renders internal absolute paths as links", () => {
+    expect(formatMarkdown("[x](/threads/abc)")).toContain(
+      'href="/threads/abc"',
+    );
+  });
+
+  it("renders hash anchors as links", () => {
+    expect(formatMarkdown("[x](#section)")).toContain('href="#section"');
+  });
+
+  it("renders mailto links (scheme accepted as safe)", () => {
+    // Note: existing @-mention regex post-processes href content, so the
+    // rendered URL contains a span around `@example`. We only assert the
+    // mailto: scheme is recognized and the result is a link, not that the
+    // mailto URL is preserved verbatim — that's a pre-existing quirk in
+    // formatInline ordering, out of scope for this PR.
+    const out = formatMarkdown("[x](mailto:hi@example.com)");
+    expect(out).toContain('class="msg-link"');
+    expect(out).toContain('href="mailto:hi');
+  });
+
+  it("emits rel='noopener noreferrer' on safe links", () => {
+    const out = formatMarkdown("[x](https://example.com)");
+    expect(out).toContain('rel="noopener noreferrer"');
+  });
+});

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -153,7 +153,7 @@ function isSafeUrl(url: string): boolean {
     trimmed.startsWith("http://") ||
     trimmed.startsWith("https://") ||
     trimmed.startsWith("mailto:") ||
-    trimmed.startsWith("/") ||
+    (trimmed.startsWith("/") && !trimmed.startsWith("//")) ||
     trimmed.startsWith("#")
   );
 }
@@ -171,7 +171,7 @@ function formatInline(text: string): string {
     /\[([^\]]+)\]\(([^)]+)\)/g,
     (_match, label: string, url: string) => {
       if (isSafeUrl(url)) {
-        return `<a class="msg-link" href="${url}" target="_blank" rel="noopener">${label}</a>`;
+        return `<a class="msg-link" href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`;
       }
       return `<span class="msg-link">${label}</span>`;
     },


### PR DESCRIPTION
## Summary

Follow-up to [#328](https://github.com/nex-crm/wuphf/pull/328). Closes the staff-review nits + adds the regression suite the new XSS-defense path needed.

- **`isSafeUrl`:** reject protocol-relative `//evil.com` (browser would resolve against the page protocol and navigate cross-origin). Single desktop-app origin so impact is small, but the existing regex was meant to whitelist *internal* paths only. Tightened from `startsWith("/")` to `startsWith("/") && !startsWith("//")`.
- **Anchor `rel`:** added `noreferrer` alongside `noopener`. Pre-existing gap; trivially fixed in the same touched line.
- **`web/src/lib/markdown.test.ts`** — 11 vitest specs covering every safe-scheme path, every dangerous-scheme rejection, the protocol-relative case, and the noreferrer guarantee. Co-located with the sibling test files (`agentName.test.ts`, `mentions.test.ts`, `wikilink.test.ts`, `groupOrder.test.ts`).

Credit to [@hobostay](https://github.com/hobostay) — built on top of #328, co-authored.

## Test plan

- [x] `bun x vitest run src/lib/markdown.test.ts` — 11/11 passing locally
- [ ] CI matrix passes
- [ ] `web` job stays green

## Out-of-scope (intentionally not addressed)

- `formatMarkdown` cognitive-complexity warning (40 vs max 15) — pre-existing biome warning, not introduced here
- `@-mention regex post-processes href content` — pre-existing quirk in `formatInline` ordering; one mailto test documents the current behavior rather than asserting the intended behavior
- `switchFocusMode` `resp.Body.Close()` without prior `io.Copy(io.Discard, ...)` — separate issue, separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Strengthened markdown link validation to prevent dangerous URL schemes and protocol-relative URLs from being rendered as clickable links
* Enhanced security attributes for external links to strengthen protection against potential attacks

## Tests
* Added comprehensive test suite validating markdown link rendering across various URL formats, schemes, and security scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->