### PR TITLE
fix(channel): bump session/focus mode timeouts 3s → 5s

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -5598,7 +5598,7 @@ func switchSessionMode(mode, agent string) tea.Cmd {
 		if err != nil {
 			return channelResetDoneMsg{err: err}
 		}
-		client := &http.Client{Timeout: 3 * time.Second}
+		client := &http.Client{Timeout: 5 * time.Second}
 		resp, err := client.Do(req)
 		if err != nil {
 			return channelResetDoneMsg{err: err}
@@ -5653,7 +5653,7 @@ func switchFocusMode(enabled bool) tea.Cmd {
 		if err != nil {
 			return nil
 		}
-		client := &http.Client{Timeout: 3 * time.Second}
+		client := &http.Client{Timeout: 5 * time.Second}
 		resp, err := client.Do(req)
 		if err != nil {
 			return nil


### PR DESCRIPTION
## Summary

Follow-up to [#327](https://github.com/nex-crm/wuphf/pull/327). Aligns the two newly-timed clients with this file's local write-path convention.

| Helper | Timeout |
|---|---|
| `createSkill` (L5514) | 5s |
| `invokeSkill` (L5530) | 5s |
| `resetDMSession` (L5550) | 5s |
| `switchSessionMode` (L5601) — **changed** | ~~3s~~ → **5s** |
| `switchFocusMode` (L5656) — **changed** | ~~3s~~ → **5s** |

The 2s in `channel_broker.go` that #326 standardized is for read polls; carrying that interval into write paths risks spurious failures on slow brokers. `switchSessionMode` in particular triggers a non-trivial broker-side `ResetSession` + `ReconfigureSession` sequence after the response — 5s gives enough headroom while keeping bounded failure under broker hang.

Credit to [@hobostay](https://github.com/hobostay) — built on top of #327, co-authored.

## Test plan

- [x] `go build ./cmd/wuphf/...` — clean
- [x] `go test ./cmd/wuphf/...` — pass (`ok 0.826s`)
- [ ] CI matrix passes

## Out-of-scope

- `switchFocusMode` `resp.Body.Close()` without prior `io.Copy(io.Discard, resp.Body)` — keepalive nit, low impact for a single-shot user command, separate PR if it lands at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased HTTP request timeout from 3 to 5 seconds for session and focus mode operations, improving reliability during slower network conditions and reducing premature timeout failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->