### PR TITLE
test(team): atomic.Pointer the remaining 5 function-pointer seams

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	wuphf "github.com/nex-crm/wuphf"
@@ -58,10 +59,25 @@ const defaultAgentRateLimitWindow = time.Minute
 // the value set by internal/teammcp/server.go authHeaders().
 const agentRateLimitHeader = "X-WUPHF-Agent"
 
+// studioPackageGeneratorFn is the test seam type swapped via
+// setStudioPackageGeneratorForTest.
+type studioPackageGeneratorFn func(systemPrompt, prompt, cwd string) (string, error)
+
 // studioPackageGenerator routes Studio package generation through the
 // install-wide LLM provider so opencode-only or claude-code-only setups
 // aren't forced to have `codex` installed.
-var studioPackageGenerator = provider.RunConfiguredOneShot
+//
+// Lives behind atomic.Pointer because broker handlers can call it from
+// goroutines that outlive a test's t.Cleanup (Studio generation is
+// fire-and-forget on the broker's HTTP path).
+var studioPackageGeneratorOverride atomic.Pointer[studioPackageGeneratorFn]
+
+func studioPackageGenerator(systemPrompt, prompt, cwd string) (string, error) {
+	if p := studioPackageGeneratorOverride.Load(); p != nil {
+		return (*p)(systemPrompt, prompt, cwd)
+	}
+	return provider.RunConfiguredOneShot(systemPrompt, prompt, cwd)
+}
 
 var externalRetryAfterPattern = regexp.MustCompile(`(?i)retry after ([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9:.+-]+Z?)`)
 

--- a/internal/team/broker_entity.go
+++ b/internal/team/broker_entity.go
@@ -28,14 +28,23 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 )
 
-// graphRecordFactRefs is the test seam for the cross-entity graph hook in
-// handleEntityFact. Production code calls graph.RecordFactRefs; tests
-// override this var to inject errors and verify the
-// "graph failure keeps fact write intact" contract.
-var graphRecordFactRefs = func(ctx context.Context, graph *EntityGraph, fact Fact) ([]EntityRef, error) {
+// graphRecordFactRefsFn is the test seam type swapped via
+// setGraphRecordFactRefsForTest. graphRecordFactRefs is read by the HTTP
+// handler goroutine in handleEntityFact, so it lives behind atomic.Pointer
+// to stay race-clean against test cleanup that fires after the handler has
+// returned but while a downstream callback is still running.
+type graphRecordFactRefsFn func(ctx context.Context, graph *EntityGraph, fact Fact) ([]EntityRef, error)
+
+var graphRecordFactRefsOverride atomic.Pointer[graphRecordFactRefsFn]
+
+func graphRecordFactRefs(ctx context.Context, graph *EntityGraph, fact Fact) ([]EntityRef, error) {
+	if p := graphRecordFactRefsOverride.Load(); p != nil {
+		return (*p)(ctx, graph, fact)
+	}
 	return graph.RecordFactRefs(ctx, fact)
 }
 

--- a/internal/team/broker_entity_graph_test.go
+++ b/internal/team/broker_entity_graph_test.go
@@ -138,11 +138,9 @@ func TestHandleEntityFact_GraphRecordFailureDoesNotBreakFactWrite(t *testing.T) 
 	defer teardown()
 
 	// Inject a failing graph recorder for the duration of this test.
-	original := graphRecordFactRefs
-	graphRecordFactRefs = func(_ context.Context, _ *EntityGraph, _ Fact) ([]EntityRef, error) {
+	setGraphRecordFactRefsForTest(t, func(_ context.Context, _ *EntityGraph, _ Fact) ([]EntityRef, error) {
 		return nil, errors.New("injected: graph record failure")
-	}
-	t.Cleanup(func() { graphRecordFactRefs = original })
+	})
 
 	payload, _ := json.Marshal(map[string]any{
 		"entity_kind": "people",

--- a/internal/team/broker_studio_test.go
+++ b/internal/team/broker_studio_test.go
@@ -87,11 +87,9 @@ func TestDecodeStudioGeneratedPackageHandlesFencedJSON(t *testing.T) {
 }
 
 func TestHandleStudioGeneratePackagePersistsAction(t *testing.T) {
-	restore := studioPackageGenerator
-	studioPackageGenerator = func(systemPrompt, prompt, cwd string) (string, error) {
+	setStudioPackageGeneratorForTest(t, func(systemPrompt, prompt, cwd string) (string, error) {
 		return `{"topic_packet":{"title":"AI automation channel"},"script_brief":{"hook":"Start with the costly mistake."},"publish_package":{"description":"Ship with affiliate CTA.","title_options":["Option A","Option B"]}}`, nil
-	}
-	defer func() { studioPackageGenerator = restore }()
+	})
 
 	b := newTestBroker(t)
 	body := map[string]any{

--- a/internal/team/headless_task_runners.go
+++ b/internal/team/headless_task_runners.go
@@ -2,16 +2,37 @@ package team
 
 import (
 	"bytes"
+	"context"
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync/atomic"
 )
 
-var listHeadlessTaskRunnerProcesses = func() ([]byte, error) {
-	return exec.Command("ps", "-axo", "pid=,command=").Output()
+// Test seams behind atomic.Pointer because killStaleHeadlessTaskRunners
+// runs at launcher startup, but tests that swap these can outlive
+// concurrent launcher constructions in race-suite parallelism.
+
+type listHeadlessTaskRunnerProcessesFn func() ([]byte, error)
+type killHeadlessTaskRunnerProcessFn func(pid int)
+
+var (
+	listHeadlessTaskRunnerProcessesOverride atomic.Pointer[listHeadlessTaskRunnerProcessesFn]
+	killHeadlessTaskRunnerProcessOverride   atomic.Pointer[killHeadlessTaskRunnerProcessFn]
+)
+
+func listHeadlessTaskRunnerProcesses() ([]byte, error) {
+	if p := listHeadlessTaskRunnerProcessesOverride.Load(); p != nil {
+		return (*p)()
+	}
+	return exec.CommandContext(context.Background(), "ps", "-axo", "pid=,command=").Output()
 }
 
-var killHeadlessTaskRunnerProcess = func(pid int) {
+func killHeadlessTaskRunnerProcess(pid int) {
+	if p := killHeadlessTaskRunnerProcessOverride.Load(); p != nil {
+		(*p)(pid)
+		return
+	}
 	terminateHeadlessProcessPID(pid)
 }
 

--- a/internal/team/headless_task_runners_test.go
+++ b/internal/team/headless_task_runners_test.go
@@ -24,20 +24,14 @@ func TestParseHeadlessTaskRunnerProcesses(t *testing.T) {
 }
 
 func TestKillStaleHeadlessTaskRunnersKillsOnlyMatchingProcesses(t *testing.T) {
-	oldList := listHeadlessTaskRunnerProcesses
-	oldKill := killHeadlessTaskRunnerProcess
-	listHeadlessTaskRunnerProcesses = func() ([]byte, error) {
+	setListHeadlessTaskRunnerProcessesForTest(t, func() ([]byte, error) {
 		return []byte("123 node /opt/homebrew/bin/codex -a never -s workspace-write exec -C /private/var/folders/x/T/wuphf-task-task-3 -c mcp_servers.wuphf-office.command=\"/tmp/wuphf\" -\n124 /opt/homebrew/bin/codex exec -C /tmp/elsewhere -\n125 node /opt/homebrew/bin/codex -a never -s workspace-write exec -C /private/var/folders/x/T/wuphf-task-task-9 -c something_else=1 -\n"), nil
-	}
-	defer func() {
-		listHeadlessTaskRunnerProcesses = oldList
-		killHeadlessTaskRunnerProcess = oldKill
-	}()
+	})
 
 	var killed []int
-	killHeadlessTaskRunnerProcess = func(pid int) {
+	setKillHeadlessTaskRunnerProcessForTest(t, func(pid int) {
 		killed = append(killed, pid)
-	}
+	})
 
 	killStaleHeadlessTaskRunners()
 

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/action"
@@ -3103,10 +3104,21 @@ func (l *Launcher) runPaneDispatchQueue(slug string) {
 	}
 }
 
-// launcherSendNotificationToPane is the package-level seam tests swap
-// out to observe dispatch ordering without shelling out to a real tmux.
-// In production it dispatches through the method on Launcher.
-var launcherSendNotificationToPane = func(l *Launcher, paneTarget, notification string) {
+// launcherSendNotificationToPaneFn is the test seam type swapped via
+// setLauncherSendNotificationToPaneForTest.
+type launcherSendNotificationToPaneFn func(l *Launcher, paneTarget, notification string)
+
+// launcherSendNotificationToPaneOverride is read by the pane-dispatch and
+// resume goroutines, so it lives behind atomic.Pointer to stay race-clean
+// against test cleanups that fire while a worker is mid-dispatch.
+// Production reads fall through to sendNotificationToPane.
+var launcherSendNotificationToPaneOverride atomic.Pointer[launcherSendNotificationToPaneFn]
+
+func launcherSendNotificationToPane(l *Launcher, paneTarget, notification string) {
+	if p := launcherSendNotificationToPaneOverride.Load(); p != nil {
+		(*p)(l, paneTarget, notification)
+		return
+	}
 	l.sendNotificationToPane(paneTarget, notification)
 }
 

--- a/internal/team/pane_dispatch_queue_test.go
+++ b/internal/team/pane_dispatch_queue_test.go
@@ -39,14 +39,12 @@ func TestQueuePaneNotification_CoalescesBurstsIntoOneDispatch(t *testing.T) {
 	var dispatches int64
 	var captured []string
 	var capturedMu sync.Mutex
-	origSend := launcherSendNotificationToPane
-	launcherSendNotificationToPane = func(_ *Launcher, _, notification string) {
+	setLauncherSendNotificationToPaneForTest(t, func(_ *Launcher, _, notification string) {
 		atomic.AddInt64(&dispatches, 1)
 		capturedMu.Lock()
 		captured = append(captured, notification)
 		capturedMu.Unlock()
-	}
-	defer func() { launcherSendNotificationToPane = origSend }()
+	})
 
 	// First enqueue dispatches immediately. Second arrives during its
 	// coalesce window and should be merged into the pending follow-up,
@@ -97,14 +95,12 @@ func TestQueuePaneNotification_SingleTagDispatchesImmediately(t *testing.T) {
 
 	l := &Launcher{}
 	dispatched := make(chan struct{}, 1)
-	origSend := launcherSendNotificationToPane
-	launcherSendNotificationToPane = func(_ *Launcher, _, _ string) {
+	setLauncherSendNotificationToPaneForTest(t, func(_ *Launcher, _, _ string) {
 		select {
 		case dispatched <- struct{}{}:
 		default:
 		}
-	}
-	defer func() { launcherSendNotificationToPane = origSend }()
+	})
 
 	startedAt := time.Now()
 	l.queuePaneNotification("pm", "team:1", "solo tag")
@@ -137,15 +133,13 @@ func TestQueuePaneNotification_DifferentSlugsRunInParallel(t *testing.T) {
 
 	l := &Launcher{}
 	var countA, countB int64
-	origSend := launcherSendNotificationToPane
-	launcherSendNotificationToPane = func(_ *Launcher, paneTarget, _ string) {
+	setLauncherSendNotificationToPaneForTest(t, func(_ *Launcher, paneTarget, _ string) {
 		if paneTarget == "team:a" {
 			atomic.AddInt64(&countA, 1)
 		} else {
 			atomic.AddInt64(&countB, 1)
 		}
-	}
-	defer func() { launcherSendNotificationToPane = origSend }()
+	})
 
 	startedAt := time.Now()
 	l.queuePaneNotification("alpha", "team:a", "first")

--- a/internal/team/resume_test.go
+++ b/internal/team/resume_test.go
@@ -686,12 +686,10 @@ func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 	// and failing the test with an `unlinkat ... directory not empty`.
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
 
-	oldSendPane := launcherSendNotificationToPane
 	var paneNotifications []string
-	launcherSendNotificationToPane = func(_ *Launcher, paneTarget, notification string) {
+	setLauncherSendNotificationToPaneForTest(t, func(_ *Launcher, paneTarget, notification string) {
 		paneNotifications = append(paneNotifications, paneTarget+"\n"+notification)
-	}
-	defer func() { launcherSendNotificationToPane = oldSendPane }()
+	})
 
 	b := NewBrokerAt(leakedBrokerStatePath(t))
 	b.mu.Lock()

--- a/internal/team/test_support.go
+++ b/internal/team/test_support.go
@@ -157,3 +157,56 @@ func setHeadlessCodexWorkspaceStatusSnapshotForTest(t *testing.T, fn headlessCod
 		headlessCodexWorkspaceStatusSnapshotOverride.Store(prior)
 	})
 }
+
+// setGraphRecordFactRefsForTest swaps the entity-graph fact-ref hook.
+// Read by the broker HTTP handler goroutine in handleEntityFact.
+func setGraphRecordFactRefsForTest(t *testing.T, fn graphRecordFactRefsFn) {
+	t.Helper()
+	prior := graphRecordFactRefsOverride.Load()
+	graphRecordFactRefsOverride.Store(&fn)
+	t.Cleanup(func() {
+		graphRecordFactRefsOverride.Store(prior)
+	})
+}
+
+// setStudioPackageGeneratorForTest swaps the Studio LLM dispatcher.
+func setStudioPackageGeneratorForTest(t *testing.T, fn studioPackageGeneratorFn) {
+	t.Helper()
+	prior := studioPackageGeneratorOverride.Load()
+	studioPackageGeneratorOverride.Store(&fn)
+	t.Cleanup(func() {
+		studioPackageGeneratorOverride.Store(prior)
+	})
+}
+
+// setLauncherSendNotificationToPaneForTest swaps the pane notification
+// dispatcher. Read by the pane-dispatch and resume goroutines.
+func setLauncherSendNotificationToPaneForTest(t *testing.T, fn launcherSendNotificationToPaneFn) {
+	t.Helper()
+	prior := launcherSendNotificationToPaneOverride.Load()
+	launcherSendNotificationToPaneOverride.Store(&fn)
+	t.Cleanup(func() {
+		launcherSendNotificationToPaneOverride.Store(prior)
+	})
+}
+
+// setListHeadlessTaskRunnerProcessesForTest swaps the ps-listing seam used
+// by killStaleHeadlessTaskRunners.
+func setListHeadlessTaskRunnerProcessesForTest(t *testing.T, fn listHeadlessTaskRunnerProcessesFn) {
+	t.Helper()
+	prior := listHeadlessTaskRunnerProcessesOverride.Load()
+	listHeadlessTaskRunnerProcessesOverride.Store(&fn)
+	t.Cleanup(func() {
+		listHeadlessTaskRunnerProcessesOverride.Store(prior)
+	})
+}
+
+// setKillHeadlessTaskRunnerProcessForTest swaps the kill-by-PID seam.
+func setKillHeadlessTaskRunnerProcessForTest(t *testing.T, fn killHeadlessTaskRunnerProcessFn) {
+	t.Helper()
+	prior := killHeadlessTaskRunnerProcessOverride.Load()
+	killHeadlessTaskRunnerProcessOverride.Store(&fn)
+	t.Cleanup(func() {
+		killHeadlessTaskRunnerProcessOverride.Store(prior)
+	})
+}


### PR DESCRIPTION
## Summary

Followup to PR #324's staff review. Migrates the last five bare-assigned package-level test seams in `internal/team` to the same `atomic.Pointer` pattern already used for `prepareTaskWorktree`, `headlessCodexRunTurnOverride`, etc.

| Seam | File | Read from |
|---|---|---|
| `graphRecordFactRefs` | `broker_entity.go` | HTTP handler goroutine in `handleEntityFact` |
| `studioPackageGenerator` | `broker.go` | Studio dispatch path |
| `launcherSendNotificationToPane` | `launcher.go` | pane-dispatch + resume goroutines |
| `listHeadlessTaskRunnerProcesses` | `headless_task_runners.go` | launcher startup |
| `killHeadlessTaskRunnerProcess` | `headless_task_runners.go` | launcher startup |

Each gets a typed `Fn` alias + `atomic.Pointer` override + thin wrapper function that falls through to the production default. Test sites converted from `oldX := X; X = ...; defer X = oldX` to `setXForTest(t, fn)`. Five new helpers in `test_support.go`.

None of these races today (no current test exercises the read path from a leaked goroutine), but with `-race` re-enabled for `internal/team` they'd be the next set to flake. Closes the followup tracked in #324's commit message.

## Verification

- `golangci-lint run --timeout=5m ./...` → 0 issues
- `go build ./...`, `go vet ./...`, `gofmt -l .` → all clean
- `go test -race -count=1 -timeout 5m ./internal/team/` → pass (148s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved test isolation mechanisms and thread-safe test substitution capabilities to ensure more reliable testing across concurrent execution scenarios.

* **Chores**
  * Refactored internal testing patterns and helper utilities to improve code maintainability and reduce redundancy across multiple test modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->