### PR TITLE
ci: collapse per-package go test matrix into single job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    # Single source of truth for govulncheck binary location. `go install`
+    # writes to $GOBIN if set (else $GOPATH/bin), so pinning GOBIN here
+    # keeps the cache path, install destination, and PATH lookup below
+    # locked to one literal — eliminates the silent-cache-miss class of
+    # bug if a future setup-go release shifts the default GOPATH.
+    env:
+      GOBIN: ${{ github.workspace }}/.gobin
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
@@ -81,13 +88,13 @@ jobs:
           args: --timeout=5m
       - name: Cache govulncheck binary
         # The version below is pinned, so the compiled binary at
-        # ~/go/bin/govulncheck is reusable across every CI run that
-        # doesn't bump GOVULNCHECK_VERSION. Saves ~10-15s of `go install`
+        # $GOBIN/govulncheck is reusable across every CI run that doesn't
+        # bump the govulncheck version. Saves ~10-15s of `go install`
         # (download + compile) per run on warm cache.
         id: cache-govulncheck
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5.0.5
         with:
-          path: ~/go/bin/govulncheck
+          path: ${{ env.GOBIN }}/govulncheck
           key: govulncheck-${{ runner.os }}-v1.1.4
       - name: Install govulncheck
         if: steps.cache-govulncheck.outputs.cache-hit != 'true'
@@ -98,7 +105,7 @@ jobs:
         # advisory to make noise. Pinned to an explicit version so a new
         # govulncheck release cannot flip pass/fail on the same commit.
         run: |
-          export PATH="$(go env GOPATH)/bin:$PATH"
+          export PATH="${{ env.GOBIN }}:$PATH"
           govulncheck ./...
 
   # Single test job. We previously fanned out one matrix leg per Go package
@@ -124,14 +131,22 @@ jobs:
         with:
           name: web-dist
           path: web/dist
+      # `set -euo pipefail` + the empty-package guard close a fail-open
+      # path: bash does NOT propagate failures inside `$(...)`, so a
+      # transient `go list` error or a regex tweak that drops every match
+      # would otherwise degrade the step to `go test -race -timeout 15m`
+      # against the cwd package only — green CI, every subpackage silently
+      # skipped. `pipefail` surfaces the inner failure; the guard catches
+      # an empty match list.
+      #
+      # On failure: the matrix used to give one red x per failing package
+      # in the PR checks list; collapsed, both invocations swallow per-
+      # package status into a single red x. `tee` to a log file + a
+      # `grep '^FAIL'` summary at the end of the step reclaims the per-
+      # package signal in the step's own log without bringing back the
+      # matrix overhead. Logs are uploaded as an artifact on failure for
+      # offline triage.
       - name: Tests with race detector (everything except teammcp)
-        # `set -euo pipefail` + the empty-package guard close a fail-open
-        # path: bash does NOT propagate failures inside `$(...)`, so a
-        # transient `go list` error or a regex tweak that drops every
-        # match would otherwise degrade the step to `go test -race
-        # -timeout 15m` against the cwd package only — green CI, every
-        # subpackage silently skipped. `pipefail` surfaces the inner
-        # failure; the guard catches an empty match list.
         run: |
           set -euo pipefail
           pkgs=$(go list ./... | grep -vE '/internal/teammcp($|/)')
@@ -139,7 +154,16 @@ jobs:
             echo "no packages matched — refusing to run an empty go test suite" >&2
             exit 1
           fi
-          go test -race -timeout 15m $pkgs
+          set +e
+          go test -race -timeout 15m $pkgs 2>&1 | tee go-test-race.log
+          status=${PIPESTATUS[0]}
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "::group::Failing packages (race suite)"
+            grep -E '^(FAIL|--- FAIL)' go-test-race.log || echo "(no FAIL lines parsed; see full log above)"
+            echo "::endgroup::"
+            exit "$status"
+          fi
       - name: Tests without race (internal/teammcp)
         run: |
           set -euo pipefail
@@ -148,7 +172,26 @@ jobs:
             echo "no packages matched — refusing to run an empty go test suite" >&2
             exit 1
           fi
-          go test -timeout 15m $pkgs
+          set +e
+          go test -timeout 15m $pkgs 2>&1 | tee go-test-teammcp.log
+          status=${PIPESTATUS[0]}
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "::group::Failing packages (teammcp suite)"
+            grep -E '^(FAIL|--- FAIL)' go-test-teammcp.log || echo "(no FAIL lines parsed; see full log above)"
+            echo "::endgroup::"
+            exit "$status"
+          fi
+      - name: Upload go test logs on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
+        with:
+          name: go-test-logs
+          path: |
+            go-test-race.log
+            go-test-teammcp.log
+          retention-days: 7
+          if-no-files-found: ignore
 
   # Keep a standalone vet job so config drift (a new vet check landing in
   # a Go minor bump, or an unknown //go:build tag) surfaces with its own

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,26 @@ jobs:
         with:
           version: v2.11.4
           args: --timeout=5m
+      - name: Cache govulncheck binary
+        # The version below is pinned, so the compiled binary at
+        # ~/go/bin/govulncheck is reusable across every CI run that
+        # doesn't bump GOVULNCHECK_VERSION. Saves ~10-15s of `go install`
+        # (download + compile) per run on warm cache.
+        id: cache-govulncheck
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache@v5.0.5
+        with:
+          path: ~/go/bin/govulncheck
+          key: govulncheck-${{ runner.os }}-v1.1.4
+      - name: Install govulncheck
+        if: steps.cache-govulncheck.outputs.cache-hit != 'true'
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - name: Run govulncheck
         # Catches reachable CVEs in the Go stdlib + modules. Flags us when we
         # fall behind on a Go minor bump without having to wait for a CVE
         # advisory to make noise. Pinned to an explicit version so a new
         # govulncheck release cannot flip pass/fail on the same commit.
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          export PATH="$(go env GOPATH)/bin:$PATH"
           govulncheck ./...
 
   # Single test job. We previously fanned out one matrix leg per Go package

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,54 +88,20 @@ jobs:
           go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
           govulncheck ./...
 
-  # Generates the list of Go packages for the go-test-matrix fan-out below.
-  # Separate job so the matrix can consume its output via
-  # strategy.matrix.package: ${{ fromJSON(needs.go-test-list.outputs.packages) }}.
-  # Also emits a parallel `race` flag per package: internal/teammcp opts OUT
-  # of -race until its own test-isolation cleanup lands. internal/team is
-  # in-race after the worktree-seam atomic.Pointer migration. Everything
-  # else gets -race.
-  go-test-list:
+  # Single test job. We previously fanned out one matrix leg per Go package
+  # (28 legs at peak) for nicer per-package red x's, but each leg paid
+  # ~12-15s of checkout + setup-go + download-artifact overhead for ~20-50s
+  # of actual test work — ~14 runner-minutes per CI run on overhead alone.
+  # `go test ./...` runs packages in parallel within one process up to
+  # GOMAXPROCS, so wall clock is bounded by the long-pole package
+  # (`internal/team`, ~2.5m with -race) regardless of fan-out. Collapsing
+  # gives ~80% compute reduction at no wall-clock cost. teammcp opts out
+  # of -race until its test-isolation cleanup lands; everything else gets
+  # the race detector. -timeout 15m is generous headroom over the ~3m
+  # observed locally (race instrumentation 2-3x's wall-clock).
+  go-test:
+    needs: web
     runs-on: ubuntu-latest
-    outputs:
-      packages: ${{ steps.list.outputs.packages }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-      - id: list
-        run: |
-          set -euo pipefail
-          # Emit a JSON array of {package, race} objects. Only packages with
-          # actual *_test.go files (TestGoFiles or XTestGoFiles) are emitted —
-          # spawning a matrix leg for a test-less package burns CI minutes
-          # for no signal. `jq -R -s` reads stdin as a single string; split
-          # on newlines, drop empties, then map each package to an object
-          # with the race flag (no -race for internal/teammcp; see comment
-          # above).
-          packages=$(go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... \
-            | jq -R -s -c '
-                split("\n")
-                | map(select(length > 0))
-                | map({
-                    package: .,
-                    race: (test("/internal/teammcp($|/)") | not)
-                  })
-              ')
-          echo "packages=${packages}" >> "$GITHUB_OUTPUT"
-
-  go-test-matrix:
-    needs: [web, go-test-list]
-    runs-on: ubuntu-latest
-    strategy:
-      # One flaky package shouldn't mask other real failures. Each matrix
-      # leg is independent, so let them all finish and surface their own
-      # red x's.
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.go-test-list.outputs.packages) }}
-    name: "go test ${{ matrix.package }}"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
@@ -145,16 +111,10 @@ jobs:
         with:
           name: web-dist
           path: web/dist
-      - name: Test
-        # `-timeout 5m` is a per-package margin. Race instrumentation 2-3x's
-        # wall-clock, so 5m is comfortable headroom for the slowest
-        # per-package legs (internal/team* hit ~1-2m locally without race).
-        run: |
-          if [ "${{ matrix.race }}" = "true" ]; then
-            go test -race -timeout 5m ${{ matrix.package }}
-          else
-            go test -timeout 5m ${{ matrix.package }}
-          fi
+      - name: Tests with race detector (everything except teammcp)
+        run: go test -race -timeout 15m $(go list ./... | grep -vE '/internal/teammcp($|/)')
+      - name: Tests without race (internal/teammcp)
+        run: go test -timeout 15m $(go list ./... | grep -E '/internal/teammcp($|/)')
 
   # Keep a standalone vet job so config drift (a new vet check landing in
   # a Go minor bump, or an unknown //go:build tag) surfaces with its own

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,30 @@ jobs:
           name: web-dist
           path: web/dist
       - name: Tests with race detector (everything except teammcp)
-        run: go test -race -timeout 15m $(go list ./... | grep -vE '/internal/teammcp($|/)')
+        # `set -euo pipefail` + the empty-package guard close a fail-open
+        # path: bash does NOT propagate failures inside `$(...)`, so a
+        # transient `go list` error or a regex tweak that drops every
+        # match would otherwise degrade the step to `go test -race
+        # -timeout 15m` against the cwd package only — green CI, every
+        # subpackage silently skipped. `pipefail` surfaces the inner
+        # failure; the guard catches an empty match list.
+        run: |
+          set -euo pipefail
+          pkgs=$(go list ./... | grep -vE '/internal/teammcp($|/)')
+          if [ -z "$pkgs" ]; then
+            echo "no packages matched — refusing to run an empty go test suite" >&2
+            exit 1
+          fi
+          go test -race -timeout 15m $pkgs
       - name: Tests without race (internal/teammcp)
-        run: go test -timeout 15m $(go list ./... | grep -E '/internal/teammcp($|/)')
+        run: |
+          set -euo pipefail
+          pkgs=$(go list ./... | grep -E '/internal/teammcp($|/)')
+          if [ -z "$pkgs" ]; then
+            echo "no packages matched — refusing to run an empty go test suite" >&2
+            exit 1
+          fi
+          go test -timeout 15m $pkgs
 
   # Keep a standalone vet job so config drift (a new vet check landing in
   # a Go minor bump, or an unknown //go:build tag) surfaces with its own


### PR DESCRIPTION
## Summary

CI's go-test fan-out was paying ~14 runner-minutes per run on pure overhead. Replacing the 28-leg matrix with a single \`go-test\` job collapses that to a single runner without affecting wall clock.

### Why the matrix was costing so much

From [run 24958782652](https://github.com/nex-crm/wuphf/actions/runs/24958782652) (most recent green main run before this PR):

| Slice | Compute |
|---|---|
| 28× \`go test <pkg>\` matrix legs | ~17.5 runner-minutes |
| Of that, actual \`go test\` work | ~3 minutes |
| Of that, per-leg overhead (checkout + setup-go + download-artifact) | ~14 minutes |

\`internal/team\` (151s with -race) is the long pole no matter how the suite is sliced — every other matrix leg finishes well within that window. So the matrix gave us per-package red x's at ~14 min/run of overhead with zero wall-clock benefit.

### After

One \`go-test\` job runs \`go test -race ./...\` (with \`internal/teammcp\` split off without -race, same as today). \`go test ./...\` parallelizes packages within one process up to GOMAXPROCS, so wall clock is still bounded by \`internal/team\`.

Expected: ~24 min compute → ~10 min compute, wall clock within ~30s of today.

### Branch protection

Required checks per \`gh api repos/nex-crm/wuphf/branches/main/protection\` are \`commitlint, scan, lint, vet, build, shellcheck\`. None of the matrix legs were required, so this PR doesn't change merge gating. The new \`go-test\` job inherits the same not-required posture; if we want it required, that's a separate branch-protection update.

## Test plan

- [ ] CI on this PR runs the new \`go-test\` job and it passes
- [ ] Wall clock is within ~30s of historical pre-PR baseline (\`internal/team\` long pole)
- [ ] Total compute drops materially (verify via Actions usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI caching for vulnerability tooling to reduce install times and reliably reuse cached artifacts.
* **Tests**
  * Simplified test workflow into consolidated test jobs with stricter failure behavior for empty suites, longer timeouts, captured test output, grouped failure summaries, and automatic upload of test logs as artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->