### PR TITLE
test(web/e2e): close TUI-vs-Web parity gaps in Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,8 @@ jobs:
       # wuphf instance can only be in one state, so we boot twice.
       #
       # Phase 1: fresh install (wizard.spec.ts). No onboarded.json.
-      # Phase 2: seeded      (smoke.spec.ts, shell). Write onboarded.json first.
+      # Phase 2: seeded      (shell suite — smoke, chat, slash-commands, dm,
+      #                       mentions, interview). Write onboarded.json first.
       # `</dev/null` on both boots prevents isPiped() from yanking wuphf into
       # scanner mode.
       - name: Start wuphf (fresh install) for wizard tests
@@ -424,11 +425,18 @@ jobs:
           echo "wuphf failed to become ready (shell)" >&2
           cat wuphf.log >&2
           exit 1
-      - name: Run Playwright shell smoke
+      - name: Run Playwright shell suite
         working-directory: web/e2e
         env:
           WUPHF_E2E_BASE_URL: http://localhost:7891
-        run: bunx playwright test tests/smoke.spec.ts
+        run: |
+          bunx playwright test \
+            tests/smoke.spec.ts \
+            tests/chat.spec.ts \
+            tests/slash-commands.spec.ts \
+            tests/dm.spec.ts \
+            tests/mentions.spec.ts \
+            tests/interview.spec.ts
       - name: Stop wuphf (shell phase)
         if: always()
         run: |

--- a/web/e2e/tests/_helpers.ts
+++ b/web/e2e/tests/_helpers.ts
@@ -1,0 +1,75 @@
+import { type APIRequestContext, expect, type Page } from "@playwright/test";
+
+// Shared helpers for the wuphf web e2e suite. Kept under `tests/` with a
+// leading underscore so Playwright still discovers spec files in the same
+// directory but does not pick this up as a test (Playwright matches `.spec.`
+// by default — see playwright.config.ts).
+//
+// Smoke + Wizard predate this file and inline their own copies. New specs
+// (chat, slash-commands, dm, mentions, interview) import from here so the
+// React-error and shell-readiness contracts stay in one place.
+
+export function collectReactErrors(page: Page): () => string[] {
+  const errors: string[] = [];
+  page.on("pageerror", (err) => errors.push(err.message));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
+      const text = msg.text();
+      if (
+        text.includes("Minified React error") ||
+        text.includes("Error boundary")
+      ) {
+        errors.push(text);
+      }
+    }
+  });
+  return () => errors;
+}
+
+export async function waitForReactMount(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const root = document.getElementById("root");
+      if (!root) return false;
+      if (document.getElementById("skeleton")) return false;
+      return root.children.length > 0;
+    },
+    { timeout: 10_000 },
+  );
+}
+
+// Shell-ready means: React mounted, the composer is in the DOM. Avoids
+// `networkidle` (long-lived SSE keeps the page non-idle indefinitely).
+export async function waitForShellReady(page: Page): Promise<void> {
+  await waitForReactMount(page);
+  await expect(page.locator(".composer-input")).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+export async function expectNoReactErrors(
+  page: Page,
+  getErrors: () => string[],
+  context: string,
+): Promise<void> {
+  await expect(page.getByTestId("error-boundary")).toHaveCount(0);
+  const errors = getErrors();
+  expect(
+    errors,
+    `Uncaught errors ${context}:\n  ${errors.join("\n  ")}`,
+  ).toHaveLength(0);
+}
+
+// Reset broker state between tests in a file. Tests run serially in the same
+// wuphf process, so without an explicit reset earlier messages bleed into
+// later assertions. Intended for `test.afterEach(() => resetBroker(request))`.
+//
+// Uses the request fixture (NOT page) so the call works after page teardown.
+// Failure here should not fail the test that just passed — log and move on.
+export async function resetBroker(request: APIRequestContext): Promise<void> {
+  try {
+    await request.post("/api/reset", { data: {} });
+  } catch (err) {
+    console.warn("resetBroker: /api/reset failed (continuing):", err);
+  }
+}

--- a/web/e2e/tests/_helpers.ts
+++ b/web/e2e/tests/_helpers.ts
@@ -15,9 +15,15 @@ export function collectReactErrors(page: Page): () => string[] {
   page.on("console", (msg) => {
     if (msg.type() === "error") {
       const text = msg.text();
+      // The boundary's own log line is `[WUPHF ErrorBoundary]` — see
+      // web/src/App.tsx:69 (`console.error("[WUPHF ErrorBoundary]", ...)`).
+      // The earlier "Error boundary" substring (with a space) never matched
+      // and was silent dead code; the DOM check in expectNoReactErrors still
+      // caught the rendered case but the textual path is what surfaces
+      // mid-render crashes that don't unmount the tree.
       if (
         text.includes("Minified React error") ||
-        text.includes("Error boundary")
+        text.includes("WUPHF ErrorBoundary")
       ) {
         errors.push(text);
       }

--- a/web/e2e/tests/chat.spec.ts
+++ b/web/e2e/tests/chat.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  collectReactErrors,
+  expectNoReactErrors,
+  resetBroker,
+  waitForShellReady,
+} from "./_helpers";
+
+// Message round-trip parity with the TUI shell suite (tests/e2e/agent-response-e2e.sh).
+// The TUI side asserts: user can send, broker accepts, an agent reply lands in
+// the channel pane. The Web side has no equivalent — smoke.spec.ts only checks
+// that the shell renders. This file closes the gap on the web surface.
+//
+// CI runs wuphf with a stub `claude` (see ci.yml — "Install claude CLI stub"),
+// so real agent replies do not arrive. To still cover the inbound-render path,
+// the second test injects a synthetic agent message through the same broker
+// API the real CEO would use. That guards the MessageFeed render path against
+// regressions independent of LLM availability.
+//
+// Like the existing specs, this one assumes wuphf was started with
+// ~/.wuphf/onboarded.json pre-seeded so the app lands in the Shell.
+
+// Tests run serially against the same wuphf process. Reset between tests so
+// earlier sends do not pollute later assertions (especially `getByText`).
+test.afterEach(async ({ request }) => {
+  await resetBroker(request);
+});
+
+test.describe("wuphf web chat round-trip", () => {
+  test('typed message lands in the feed as a "You" bubble', async ({
+    page,
+  }) => {
+    // Mirrors the first half of agent-response-e2e.sh: human posts to the
+    // channel, broker accepts, the message becomes visible. We do not depend
+    // on an agent replying — that is covered by the inbound-render test below.
+    const getErrors = collectReactErrors(page);
+
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    // Unique payload so a stale session message can never satisfy the assertion.
+    const payload = `playwright round-trip ${Date.now()}`;
+
+    const composer = page.locator(".composer-input");
+    await composer.fill(payload);
+    await page.locator(".composer-send").click();
+
+    // Composer clears on successful send (Composer.tsx — resetComposer).
+    // If the broker rejects (e.g. 409 interview pending), the composer keeps
+    // the text and showNotice fires — that fails this assertion loud.
+    await expect(composer).toHaveValue("", { timeout: 10_000 });
+
+    // The "You" bubble carries .badge-neutral with text "human" and the typed
+    // content in .message-text. Anchor on the unique payload, not the badge,
+    // so this stays robust if seeded fixtures introduce other human messages.
+    const bubble = page.locator(".message", { hasText: payload }).first();
+    await expect(bubble).toBeVisible({ timeout: 10_000 });
+    await expect(bubble.locator(".message-author")).toHaveText("You");
+    await expect(bubble.locator(".badge-neutral")).toHaveText("human");
+
+    await expectNoReactErrors(page, getErrors, "during message send");
+  });
+
+  test("agent reply renders with role badge when broker emits one", async ({
+    page,
+    request,
+  }) => {
+    // 30s default budget is tight: cold-mount + waitForShellReady can eat
+    // 10s, then the message poll has another 15s to land.
+    test.setTimeout(45_000);
+
+    // Inbound-render guard. The broker is the source of truth for messages;
+    // the web client subscribes via SSE (see App.tsx + useMessages). This
+    // test impersonates the broker by POSTing a message attributed to a
+    // built-in agent through the same /api/messages endpoint the real broker
+    // uses internally. If MessageFeed cannot render an agent message
+    // (markdown path, role-badge lookup, avatar/harness resolution), this
+    // fails — even when no real LLM is wired up.
+    const getErrors = collectReactErrors(page);
+
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    // Pick an agent that the seeded broker is guaranteed to know about. Read
+    // the slug AND the user-facing name from the sidebar so the assertion
+    // tracks the actual seeded roster instead of hard-coding "ceo".
+    const firstAgent = page.locator("button[data-agent-slug]").first();
+    await expect(firstAgent).toBeVisible({ timeout: 10_000 });
+    const agentSlug = await firstAgent.getAttribute("data-agent-slug");
+    expect(
+      agentSlug,
+      "sidebar must expose at least one agent slug",
+    ).toBeTruthy();
+    const agentName = (
+      await firstAgent.locator(".sidebar-agent-name").textContent()
+    )?.trim();
+    expect(agentName, "sidebar agent must have a visible name").toBeTruthy();
+
+    const payload = `synthetic agent reply ${Date.now()}`;
+
+    // Same-origin proxy injects the broker token; no bearer needed from the
+    // test. Use the request fixture's baseURL (set in playwright.config.ts).
+    const resp = await request.post("/api/messages", {
+      data: { from: agentSlug, channel: "general", content: payload },
+    });
+    expect(
+      resp.ok(),
+      `broker rejected synthetic agent message: ${resp.status()} ${await resp.text()}`,
+    ).toBeTruthy();
+
+    // Positive attribution: the bubble renders with the seeded agent's name
+    // (NOT a fallback slug, NOT "You"). A regression in useOfficeMembers
+    // would render `message.from` raw and fail this exact-match assertion.
+    const bubble = page.locator(".message", { hasText: payload }).first();
+    await expect(bubble).toBeVisible({ timeout: 15_000 });
+    await expect(bubble.locator(".message-author")).toHaveText(agentName!);
+    // Agent bubbles never carry the human badge.
+    await expect(bubble.locator(".badge-neutral")).toHaveCount(0);
+
+    await expectNoReactErrors(page, getErrors, "during agent message render");
+  });
+});

--- a/web/e2e/tests/dm.spec.ts
+++ b/web/e2e/tests/dm.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  collectReactErrors,
+  expectNoReactErrors,
+  resetBroker,
+  waitForShellReady,
+} from "./_helpers";
+
+// 1:1 DM parity with tests/uat/agent-sidebar-dm-e2e.sh.
+// Flow: click an agent in the sidebar → AgentPanel mounts → click "Open DM"
+// → composer + feed switch from #general to the agent's direct channel
+// (slug shape `<agent>__human` or `human__<agent>`, see directChannelSlug
+// in stores/app.ts:15). The TUI test exercises the same sequence via the
+// agent-sidebar shortcut. Web had zero coverage of this path.
+//
+// Why this matters: DM is the steering surface — when a user wants to
+// course-correct a single agent without involving the rest of the team.
+// A regression that breaks `enterDM` or DMView leaves users without that
+// affordance, and PH-launch traffic will hit it on day one.
+
+test.afterEach(async ({ request }) => {
+  await resetBroker(request);
+});
+
+test.describe("wuphf web 1:1 DM", () => {
+  test("clicking an agent → Open DM → composer addresses the DM channel", async ({
+    page,
+  }) => {
+    test.setTimeout(45_000);
+    const getErrors = collectReactErrors(page);
+
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    // Composer placeholder reflects the active channel (Composer.tsx:548 —
+    // `Message #${currentChannel}`). Capture the pre-DM value so we can
+    // assert it actually changes.
+    const composer = page.locator(".composer-input");
+    const beforePlaceholder = await composer.getAttribute("placeholder");
+    expect(
+      beforePlaceholder,
+      "composer placeholder should reflect a channel name",
+    ).toMatch(/^Message #/);
+    expect(beforePlaceholder).not.toContain("__"); // pre-DM = #general or similar
+
+    // Click the first agent and read its slug — same selector smoke uses.
+    const firstAgent = page.locator("button[data-agent-slug]").first();
+    await expect(firstAgent).toBeVisible({ timeout: 10_000 });
+    const agentSlug = await firstAgent.getAttribute("data-agent-slug");
+    expect(
+      agentSlug,
+      "sidebar must expose at least one agent slug",
+    ).toBeTruthy();
+    await firstAgent.click();
+
+    // AgentPanel mounts → "Open DM" button is visible. The button text is
+    // literal in AgentPanel.tsx:296 and toggles to "Opening..." while the
+    // request is in flight, so anchor by role+name.
+    const openDM = page.getByRole("button", { name: "Open DM" });
+    await expect(openDM).toBeVisible({ timeout: 10_000 });
+    await openDM.click();
+
+    // After enterDM, currentChannel is the direct slug (e.g. "ceo__human"
+    // or "human__ceo" depending on lexical order — see directChannelSlug).
+    // The composer placeholder updates synchronously off the store. Match
+    // either ordering AND require the agent slug appear, so we don't pass
+    // when the placeholder happens to read "Message #human-something".
+    await expect(composer).toHaveAttribute(
+      "placeholder",
+      new RegExp(`^Message #(${agentSlug}__human|human__${agentSlug})$`),
+      { timeout: 10_000 },
+    );
+
+    // Send a DM-only message. The bubble must land in the DM feed; if
+    // routing leaks back to #general the assertion below fails because the
+    // feed swap is keyed on `currentChannel` in MessageFeed.tsx:41.
+    const payload = `dm test ${Date.now()}`;
+    await composer.fill(payload);
+    await page.locator(".composer-send").click();
+
+    await expect(composer).toHaveValue("", { timeout: 10_000 });
+    const bubble = page.locator(".message", { hasText: payload }).first();
+    await expect(bubble).toBeVisible({ timeout: 10_000 });
+    await expect(bubble.locator(".message-author")).toHaveText("You");
+
+    await expectNoReactErrors(page, getErrors, "during DM open + send");
+  });
+});

--- a/web/e2e/tests/interview.spec.ts
+++ b/web/e2e/tests/interview.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  collectReactErrors,
+  expectNoReactErrors,
+  resetBroker,
+  waitForShellReady,
+} from "./_helpers";
+
+// Human-Interview parity with tests/e2e/session-full-e2e.sh (which exercises
+// blocking signals + the TUI's Esc-to-pause flow).
+//
+// Wuphf's signature differentiator: agents can BLOCK on a human answer. The
+// broker holds a request, the web client polls /requests, and InterviewBar +
+// HumanInterviewOverlay render an actionable prompt above the composer. While
+// any blocking request is pending, /api/messages returns 409 (broker.go —
+// handlePostMessage), and Composer maps that to the "Answer the interview
+// above to send messages." toast. Zero web coverage of this loop today —
+// which is exactly the moment that wins in demos and breaks silently when
+// useRequests / answerRequest plumbing rots.
+//
+// Test strategy: synthesize a blocking request through the same /api/requests
+// endpoint the broker uses internally (handlePostRequest, broker.go:9754).
+// Drive the answer through the bar, then assert it dismisses and sends are
+// unblocked.
+
+test.afterEach(async ({ request }) => {
+  await resetBroker(request);
+});
+
+test.describe("wuphf web human interview", () => {
+  test("blocking request renders the InterviewBar and answering dismisses it", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(60_000);
+    const getErrors = collectReactErrors(page);
+
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    // Seed a blocking request via the same endpoint the broker uses to
+    // emit interviews. `from` must be a real seeded agent slug so the
+    // bar's `@<from>` chip renders against a known role.
+    const firstAgent = page.locator("button[data-agent-slug]").first();
+    await expect(firstAgent).toBeVisible({ timeout: 10_000 });
+    const agentSlug = await firstAgent.getAttribute("data-agent-slug");
+    expect(agentSlug).toBeTruthy();
+
+    const question = `should we ship feature X? (interview ${Date.now()})`;
+    const resp = await request.post("/api/requests", {
+      data: {
+        action: "create",
+        from: agentSlug,
+        channel: "general",
+        title: "Approval needed",
+        question,
+        blocking: true,
+        required: true,
+        options: [
+          { id: "yes", label: "Yes — ship it" },
+          { id: "no", label: "Hold off" },
+        ],
+        recommended_id: "yes",
+      },
+    });
+    expect(
+      resp.ok(),
+      `broker rejected synthetic interview: ${resp.status()} ${await resp.text()}`,
+    ).toBeTruthy();
+
+    // useRequests refetches every 5s (REQUEST_REFETCH_MS in useRequests.ts:10),
+    // so the bar appears within that window. Use a 12s budget to absorb one
+    // full poll cycle plus React commit.
+    const bar = page.locator('.interview-bar[role="region"]');
+    await expect(bar).toBeVisible({ timeout: 12_000 });
+
+    // Sanity-check the bar content reflects the seeded request, not stale state.
+    await expect(bar).toContainText("BLOCKING");
+    await expect(bar).toContainText(`@${agentSlug}`);
+    await expect(bar).toContainText(question);
+
+    // While blocking, the broker rejects new messages with 409 → composer
+    // surfaces "Answer the interview above..." (Composer.tsx:336). Send
+    // through the UI and assert the toast — this is the contract the TUI
+    // exercises under session-full-e2e.sh's Esc/blocking path.
+    const composer = page.locator(".composer-input");
+    await composer.fill("attempt during block");
+    await page.locator(".composer-send").click();
+    await expect(
+      page
+        .locator(".animate-fade")
+        .filter({ hasText: /answer the interview above/i })
+        .first(),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Answer the interview by clicking the recommended option.
+    await bar.getByRole("button", { name: /Yes — ship it/ }).click();
+
+    // The bar dismisses once the answer resolves and useRequests invalidates.
+    await expect(bar).toBeHidden({ timeout: 10_000 });
+
+    // Sends now succeed — the contract closes the loop.
+    const payload = `post-interview send ${Date.now()}`;
+    await composer.fill(payload);
+    await page.locator(".composer-send").click();
+    await expect(composer).toHaveValue("", { timeout: 10_000 });
+    await expect(
+      page.locator(".message", { hasText: payload }).first(),
+    ).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await expectNoReactErrors(page, getErrors, "during interview round-trip");
+  });
+});

--- a/web/e2e/tests/mentions.spec.ts
+++ b/web/e2e/tests/mentions.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  collectReactErrors,
+  expectNoReactErrors,
+  resetBroker,
+  waitForShellReady,
+} from "./_helpers";
+
+// @mention rendering parity. The TUI suite has no clean equivalent — terminal
+// "chips" are styled spans which don't survive screenshot diffs reliably.
+// Web has a deterministic DOM signal: parseMentions/renderMentionTokens
+// (web/src/lib/mentions.tsx) emits `<span class="mention">@<slug></span>` for
+// every recognised slug. If a regression collapses the chip back to plain
+// text — or fails to recognise a known slug — the visible message rendering
+// silently degrades. Worth catching before PH.
+//
+// Untagged-vs-routed broker behavior is covered (in part) by the TUI's
+// agent-response-e2e.sh; this spec focuses purely on the *render* path.
+
+test.afterEach(async ({ request }) => {
+  await resetBroker(request);
+});
+
+test.describe("wuphf web mention chips", () => {
+  test('typing "@<slug> ..." renders a mention chip in the human bubble', async ({
+    page,
+  }) => {
+    test.setTimeout(45_000);
+    const getErrors = collectReactErrors(page);
+
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    // Pull a known slug from the seeded sidebar — same idea as chat.spec.ts.
+    const firstAgent = page.locator("button[data-agent-slug]").first();
+    await expect(firstAgent).toBeVisible({ timeout: 10_000 });
+    const agentSlug = await firstAgent.getAttribute("data-agent-slug");
+    expect(
+      agentSlug,
+      "sidebar must expose at least one agent slug",
+    ).toBeTruthy();
+
+    const tail = `mention chip test ${Date.now()}`;
+    const payload = `@${agentSlug} ${tail}`;
+
+    const composer = page.locator(".composer-input");
+    await composer.fill(payload);
+    await page.locator(".composer-send").click();
+
+    await expect(composer).toHaveValue("", { timeout: 10_000 });
+
+    // Match the bubble by the unique tail so prior session messages don't
+    // satisfy the locator. The chip is a `.mention` span inside `.message-text`.
+    const bubble = page.locator(".message", { hasText: tail }).first();
+    await expect(bubble).toBeVisible({ timeout: 10_000 });
+
+    const chip = bubble.locator(".message-text .mention").first();
+    await expect(chip).toBeVisible({ timeout: 5_000 });
+    await expect(chip).toHaveText(`@${agentSlug}`);
+
+    // Negative assertion: the message-text should NOT contain the literal
+    // `@<slug>` as plain text alongside the chip — that would mean the
+    // parser ran but the renderer kept the original token too.
+    const rawText = (await bubble.locator(".message-text").textContent()) ?? "";
+    const occurrences = rawText.split(`@${agentSlug}`).length - 1;
+    expect(
+      occurrences,
+      "expected exactly one rendering of @<slug> (the chip), got duplicates",
+    ).toBe(1);
+
+    await expectNoReactErrors(page, getErrors, "during mention render");
+  });
+
+  test("a non-agent @-token stays as plain text (no chip)", async ({
+    page,
+  }) => {
+    // Negative coverage: parseMentions is whitelisted to known slugs
+    // (mentions.tsx:42 — only emits a chip when the slug is in knownSlugs).
+    // A regression that turns it into a permissive parser would render
+    // chips for arbitrary @-strings — bad for security (XSS via injected
+    // mention styles) and UX (chip styling on garbage input).
+    const getErrors = collectReactErrors(page);
+
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    const tail = `unknown mention ${Date.now()}`;
+    const payload = `@nope-not-an-agent ${tail}`;
+
+    const composer = page.locator(".composer-input");
+    await composer.fill(payload);
+    await page.locator(".composer-send").click();
+
+    await expect(composer).toHaveValue("", { timeout: 10_000 });
+    const bubble = page.locator(".message", { hasText: tail }).first();
+    await expect(bubble).toBeVisible({ timeout: 10_000 });
+
+    // No chip should render for the unknown slug.
+    await expect(bubble.locator(".message-text .mention")).toHaveCount(0);
+    // The literal text MUST still be visible to the human — this is the
+    // path where a "drop unknown @-tokens" regression would silently
+    // delete user input.
+    await expect(bubble.locator(".message-text")).toContainText(
+      "@nope-not-an-agent",
+    );
+
+    await expectNoReactErrors(page, getErrors, "during unknown mention render");
+  });
+});

--- a/web/e2e/tests/slash-commands.spec.ts
+++ b/web/e2e/tests/slash-commands.spec.ts
@@ -36,7 +36,10 @@ test.describe("wuphf web slash commands", () => {
 
     const composer = page.locator(".composer-input");
     await composer.click();
-    await composer.type("/");
+    // pressSequentially (not fill) — autocomplete is keystroke-driven; bulk
+    // fill skips the per-key trigger that opens the panel. type() works but
+    // is deprecated as of Playwright 1.38.
+    await composer.pressSequentially("/");
 
     const panel = page.locator(".autocomplete.open");
     await expect(panel).toBeVisible({ timeout: 5_000 });
@@ -48,7 +51,7 @@ test.describe("wuphf web slash commands", () => {
     expect(await items.count()).toBeGreaterThan(1);
 
     await composer.fill("");
-    await composer.type("/he");
+    await composer.pressSequentially("/he");
 
     // Wait for the panel AND for ≥1 item to render before pressing Tab.
     // toBeVisible alone is a paint check; Composer's keydown handler reads

--- a/web/e2e/tests/slash-commands.spec.ts
+++ b/web/e2e/tests/slash-commands.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  collectReactErrors,
+  expectNoReactErrors,
+  resetBroker,
+  waitForShellReady,
+} from "./_helpers";
+
+// Slash-command parity with the TUI YAML suite (tests/e2e/ac-02-slash-autocomplete.yaml,
+// ac-05-help-command.yaml). The TUI side asserts: typing "/" opens an
+// autocomplete overlay, Tab completes, /help renders help, /clear clears the
+// transcript. The web composer ships the same surface (Composer.tsx +
+// Autocomplete.tsx + HelpModal.tsx) but had zero coverage before this file.
+//
+// Subtle landmine that shaped this spec: when autocomplete items are visible,
+// Composer.tsx:429-445 intercepts Enter to *pick the highlighted item*, not
+// dispatch the slash command. So "/help\n" types Enter while acItems is
+// populated and ends up rewriting the textarea to the picked command instead
+// of opening HelpModal. Workaround: send a trailing space ("/help "), which
+// makes `currentTrigger` return null (Autocomplete.tsx — slash regex requires
+// `/^\/\S*$/`), the panel closes, and Enter falls through to the dispatcher.
+
+test.afterEach(async ({ request }) => {
+  await resetBroker(request);
+});
+
+test.describe("wuphf web slash commands", () => {
+  test('typing "/" opens the autocomplete panel; Tab completes "/he" → "/help "', async ({
+    page,
+  }) => {
+    const getErrors = collectReactErrors(page);
+
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    const composer = page.locator(".composer-input");
+    await composer.click();
+    await composer.type("/");
+
+    const panel = page.locator(".autocomplete.open");
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+
+    // useCommands falls back to FALLBACK_SLASH_COMMANDS when the broker
+    // registry is unreachable, so we always expect ≥2 items. A panel with
+    // one entry signals the fallback wiring broke.
+    const items = panel.locator(".autocomplete-item");
+    expect(await items.count()).toBeGreaterThan(1);
+
+    await composer.fill("");
+    await composer.type("/he");
+
+    // Wait for the panel AND for ≥1 item to render before pressing Tab.
+    // toBeVisible alone is a paint check; Composer's keydown handler reads
+    // `acItems`, which only flips truthy after the parent's effect commits.
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+    await expect(items.first()).toBeVisible({ timeout: 5_000 });
+
+    await composer.press("Tab");
+
+    // Exact value catches the regression where applyAutocomplete returns
+    // the raw query (`'/he '`) because the picker misfired — a substring or
+    // length-only check would silently pass that bug.
+    await expect(composer).toHaveValue("/help ", { timeout: 1_000 });
+
+    await expectNoReactErrors(page, getErrors, "during autocomplete");
+  });
+
+  test('"/help" Enter opens the help dialog', async ({ page }) => {
+    // TUI parity: ac-05 asserts /help renders help. Web side opens the
+    // HelpModal via store.setComposerHelpOpen(true) (Composer.tsx:97-99).
+    //
+    // Trailing space defeats autocomplete (see file-level comment), so Enter
+    // reaches handleSend → handleSlashCommand. handleSlashCommand splits on
+    // /\s+/, so parts[0] is still "/help" — the dispatch path matches.
+    const getErrors = collectReactErrors(page);
+
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    const composer = page.locator(".composer-input");
+    await composer.click();
+    await composer.fill("/help ");
+    await composer.press("Enter");
+
+    // Help modal: role="dialog", className="help-overlay" (HelpModal.tsx:132).
+    const dialog = page.locator('.help-overlay[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Composer must clear after a consumed command (Composer.tsx — resetComposer).
+    await expect(composer).toHaveValue("");
+
+    // Close the dialog so it does not bleed into other tests in this file.
+    await page.locator(".help-close").click();
+    await expect(dialog).toBeHidden({ timeout: 5_000 });
+
+    await expectNoReactErrors(page, getErrors, "during /help");
+  });
+
+  test('"/clear" Enter clears the composer and shows a confirmation toast', async ({
+    page,
+  }) => {
+    // The web build does not actually wipe broker history; /clear just emits
+    // a "Messages cleared" toast (Composer.tsx:94-96). Asserting the toast
+    // is the closest behavioral analogue — and the failure mode we want to
+    // catch (slash dispatch broken) is identical.
+    //
+    // SearchModal.tsx:446 emits the same toast string. Anchor the locator
+    // on the `.animate-fade` toast container so a future SearchModal that
+    // opens during shell init can't satisfy this assertion accidentally.
+    const getErrors = collectReactErrors(page);
+
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    const composer = page.locator(".composer-input");
+    await composer.click();
+    await composer.fill("/clear ");
+    await composer.press("Enter");
+
+    await expect(composer).toHaveValue("", { timeout: 5_000 });
+
+    // Toasts auto-dismiss at 4s (Toast.tsx). 3s assertion window is enough
+    // for paint and short of the dismiss horizon. Filter on the container
+    // class so the locator can't latch onto an in-feed message that happens
+    // to contain the string.
+    const toast = page
+      .locator(".animate-fade")
+      .filter({ hasText: "Messages cleared" })
+      .first();
+    await expect(toast).toBeVisible({ timeout: 3_000 });
+
+    await expectNoReactErrors(page, getErrors, "during /clear");
+  });
+});

--- a/web/e2e/tests/smoke.spec.ts
+++ b/web/e2e/tests/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { expect, type Page, test } from "@playwright/test";
 
 // Guards the class of regression that broke for users after the Garry Tan RT:
 // React render-time crash ("Minified React error #31 — Objects are not valid
@@ -11,11 +11,17 @@ import { test, expect, type Page } from '@playwright/test';
 
 function collectReactErrors(page: Page): () => string[] {
   const errors: string[] = [];
-  page.on('pageerror', (err) => errors.push(err.message));
-  page.on('console', (msg) => {
-    if (msg.type() === 'error') {
+  page.on("pageerror", (err) => errors.push(err.message));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
       const text = msg.text();
-      if (text.includes('Minified React error') || text.includes('Error boundary')) {
+      // The boundary's own log line is `[WUPHF ErrorBoundary]` (single word,
+      // no space) — see web/src/App.tsx:69. The previous "Error boundary"
+      // substring never matched and was silent dead code.
+      if (
+        text.includes("Minified React error") ||
+        text.includes("WUPHF ErrorBoundary")
+      ) {
         errors.push(text);
       }
     }
@@ -28,58 +34,64 @@ function collectReactErrors(page: Page): () => string[] {
 async function waitForReactMount(page: Page): Promise<void> {
   await page.waitForFunction(
     () => {
-      const root = document.getElementById('root');
+      const root = document.getElementById("root");
       if (!root) return false;
-      if (document.getElementById('skeleton')) return false;
+      if (document.getElementById("skeleton")) return false;
       return root.children.length > 0;
     },
     { timeout: 10_000 },
   );
 }
 
-test.describe('wuphf web UI smoke (shell)', () => {
-  test('initial page render does not trip the React error boundary', async ({ page }) => {
+test.describe("wuphf web UI smoke (shell)", () => {
+  test("initial page render does not trip the React error boundary", async ({
+    page,
+  }) => {
     const getErrors = collectReactErrors(page);
 
-    await page.goto('/');
+    await page.goto("/");
     await waitForReactMount(page);
 
     // Sidebar appearing is our "React committed and effects ran" signal.
     // networkidle does NOT work here — wuphf opens a long-lived SSE stream
     // as soon as the shell mounts, so the page is never idle.
-    await expect(page.locator('button[data-agent-slug]').first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator("button[data-agent-slug]").first()).toBeVisible({
+      timeout: 10_000,
+    });
 
-    await expect(page.getByTestId('error-boundary')).toHaveCount(0);
+    await expect(page.getByTestId("error-boundary")).toHaveCount(0);
 
     const errors = getErrors();
     expect(
       errors,
-      `Uncaught errors during initial render:\n  ${errors.join('\n  ')}`,
+      `Uncaught errors during initial render:\n  ${errors.join("\n  ")}`,
     ).toHaveLength(0);
   });
 
-  test('sidebar renders the seeded agents (broker wired)', async ({ page }) => {
+  test("sidebar renders the seeded agents (broker wired)", async ({ page }) => {
     // Hard assertion: the broker seeds default agents on every boot
     // (see internal/team — 4+ default roles). Zero agents is NEVER the
     // happy path; treating it as "skip" lets real regressions through
     // (seed broken, /api/members failing, useOfficeMembers broken, etc.).
-    await page.goto('/');
+    await page.goto("/");
     await waitForReactMount(page);
 
-    const agentButtons = page.locator('button[data-agent-slug]');
+    const agentButtons = page.locator("button[data-agent-slug]");
     await expect(agentButtons.first()).toBeVisible({ timeout: 10_000 });
     expect(await agentButtons.count()).toBeGreaterThan(0);
   });
 
-  test('clicking an agent does not crash the UI (React #31 guard)', async ({ page }) => {
+  test("clicking an agent does not crash the UI (React #31 guard)", async ({
+    page,
+  }) => {
     // The React #31 crash surfaced on first "click CEO". Reproduce that
     // path: click any agent in the sidebar and assert no crash.
     const getErrors = collectReactErrors(page);
 
-    await page.goto('/');
+    await page.goto("/");
     await waitForReactMount(page);
 
-    const agentButtons = page.locator('button[data-agent-slug]');
+    const agentButtons = page.locator("button[data-agent-slug]");
     await expect(agentButtons.first()).toBeVisible({ timeout: 10_000 });
     await agentButtons.first().click();
 
@@ -88,13 +100,15 @@ test.describe('wuphf web UI smoke (shell)', () => {
     // (see components/agents/AgentPanel.tsx). Waiting on the panel — instead
     // of networkidle, which never settles due to the live SSE stream — gives
     // the panel a cycle to render and any errors a cycle to fire.
-    await expect(page.locator('.agent-panel').first()).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByTestId('error-boundary')).toHaveCount(0);
+    await expect(page.locator(".agent-panel").first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("error-boundary")).toHaveCount(0);
 
     const errors = getErrors();
     expect(
       errors,
-      `Uncaught errors after agent click:\n  ${errors.join('\n  ')}`,
+      `Uncaught errors after agent click:\n  ${errors.join("\n  ")}`,
     ).toHaveLength(0);
   });
 });

--- a/web/e2e/tests/wizard.spec.ts
+++ b/web/e2e/tests/wizard.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { expect, type Page, test } from "@playwright/test";
 
 // Fresh-install onboarding smoke. Assumes wuphf was started WITHOUT a
 // pre-seeded ~/.wuphf/onboarded.json, so App.tsx routes to the Wizard
@@ -9,11 +9,17 @@ import { test, expect, type Page } from '@playwright/test';
 
 function collectReactErrors(page: Page): () => string[] {
   const errors: string[] = [];
-  page.on('pageerror', (err) => errors.push(err.message));
-  page.on('console', (msg) => {
-    if (msg.type() === 'error') {
+  page.on("pageerror", (err) => errors.push(err.message));
+  page.on("console", (msg) => {
+    if (msg.type() === "error") {
       const text = msg.text();
-      if (text.includes('Minified React error') || text.includes('Error boundary')) {
+      // The boundary's own log line is `[WUPHF ErrorBoundary]` (single word,
+      // no space) — see web/src/App.tsx:69. The previous "Error boundary"
+      // substring never matched and was silent dead code.
+      if (
+        text.includes("Minified React error") ||
+        text.includes("WUPHF ErrorBoundary")
+      ) {
         errors.push(text);
       }
     }
@@ -24,9 +30,9 @@ function collectReactErrors(page: Page): () => string[] {
 async function waitForReactMount(page: Page): Promise<void> {
   await page.waitForFunction(
     () => {
-      const root = document.getElementById('root');
+      const root = document.getElementById("root");
       if (!root) return false;
-      if (document.getElementById('skeleton')) return false;
+      if (document.getElementById("skeleton")) return false;
       return root.children.length > 0;
     },
     { timeout: 10_000 },
@@ -38,51 +44,64 @@ async function expectNoReactErrors(
   getErrors: () => string[],
   context: string,
 ): Promise<void> {
-  await expect(page.getByTestId('error-boundary')).toHaveCount(0);
+  await expect(page.getByTestId("error-boundary")).toHaveCount(0);
 
   // Avoid networkidle here: onboarding also opens the long-lived broker SSE
   // stream, so the page is expected to keep an active request.
   const errors = getErrors();
-  expect(errors, `Uncaught errors ${context}:\n  ${errors.join('\n  ')}`).toHaveLength(0);
+  expect(
+    errors,
+    `Uncaught errors ${context}:\n  ${errors.join("\n  ")}`,
+  ).toHaveLength(0);
 }
 
 // The wizard flow is welcome → identity → templates. Fill the two required
 // identity fields so the primary CTA enables and we can advance.
 async function advanceToTemplatesStep(page: Page): Promise<void> {
-  await expect(page.locator('.wizard-step').first()).toBeVisible({ timeout: 10_000 });
-  await page.locator('.wizard-step button.btn-primary').first().click();
-  await page.locator('#wiz-company').fill('Smoke Test Co');
-  await page.locator('#wiz-description').fill('Smoke test description');
-  await page.locator('.wizard-step button.btn-primary').first().click();
+  await expect(page.locator(".wizard-step").first()).toBeVisible({
+    timeout: 10_000,
+  });
+  await page.locator(".wizard-step button.btn-primary").first().click();
+  await page.locator("#wiz-company").fill("Smoke Test Co");
+  await page.locator("#wiz-description").fill("Smoke test description");
+  await page.locator(".wizard-step button.btn-primary").first().click();
 }
 
-test.describe('wuphf onboarding wizard smoke', () => {
-  test('fresh install lands on the welcome step without crashing', async ({ page }) => {
+test.describe("wuphf onboarding wizard smoke", () => {
+  test("fresh install lands on the welcome step without crashing", async ({
+    page,
+  }) => {
     const getErrors = collectReactErrors(page);
 
-    await page.goto('/');
+    await page.goto("/");
     await waitForReactMount(page);
 
     // The Wizard renders `.wizard-step` as its root container
     // (see web/src/components/onboarding/Wizard.tsx — WelcomeStep).
-    await expect(page.locator('.wizard-step').first()).toBeVisible({ timeout: 10_000 });
-    await expectNoReactErrors(page, getErrors, 'rendering wizard');
+    await expect(page.locator(".wizard-step").first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await expectNoReactErrors(page, getErrors, "rendering wizard");
   });
 
-  test('advancing from welcome → identity → templates step does not crash', async ({ page }) => {
+  test("advancing from welcome → identity → templates step does not crash", async ({
+    page,
+  }) => {
     // Verifies the wizard state machine actually transitions. Flow is:
     // welcome → identity (company + description required) → templates.
     // Assert via `.wizard-panel` on the templates step.
     const getErrors = collectReactErrors(page);
 
-    await page.goto('/');
+    await page.goto("/");
     await waitForReactMount(page);
 
     await advanceToTemplatesStep(page);
 
     // Templates step renders `.wizard-panel` (welcome + identity have different markers).
-    await expect(page.locator('.wizard-panel').first()).toBeVisible({ timeout: 10_000 });
-    await expectNoReactErrors(page, getErrors, 'advancing wizard');
+    await expect(page.locator(".wizard-panel").first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await expectNoReactErrors(page, getErrors, "advancing wizard");
   });
 
   test('blueprint picker shows shipped preset teams (not just "From scratch")', async ({
@@ -98,7 +117,7 @@ test.describe('wuphf onboarding wizard smoke', () => {
     // `.template-card` per blueprint plus a hardcoded "From scratch"
     // card — so we expect strictly more than 1 card and at least one
     // card whose name differs from "From scratch".
-    await page.goto('/');
+    await page.goto("/");
     await waitForReactMount(page);
 
     await advanceToTemplatesStep(page);
@@ -107,7 +126,7 @@ test.describe('wuphf onboarding wizard smoke', () => {
     // renders one grid per category group — Services, Media & Community,
     // Products — so `.template-grid` is not unique). We rely on
     // `.template-card` instead as the unit of a rendered blueprint.
-    const cards = page.locator('.template-card');
+    const cards = page.locator(".template-card");
     await expect(cards.first()).toBeVisible({ timeout: 10_000 });
 
     // The pre-embed bug rendered exactly zero preset cards — only the
@@ -118,7 +137,7 @@ test.describe('wuphf onboarding wizard smoke', () => {
     const count = await cards.count();
     expect(
       count,
-      'expected ≥1 preset blueprint card — embedded templates may have failed to load',
+      "expected ≥1 preset blueprint card — embedded templates may have failed to load",
     ).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

The Playwright suite had 5 tests across smoke + wizard. The TUI/VHS suite covers 8+ user flows (slash commands, agent reply, DMs, interviews, etc.). This PR closes the parity gap with five new web e2e specs + shared helpers.

**New specs (9 tests):**
- `chat.spec.ts` — human send round-trip + synthetic agent inbound render (decouples from CI's `claude` stub)
- `slash-commands.spec.ts` — `/` autocomplete + Tab completion + `/help` dialog + `/clear` toast
- `dm.spec.ts` — sidebar agent → Open DM → composer addresses the DM channel
- `mentions.spec.ts` — known slug renders `.mention` chip; unknown stays plain text
- `interview.spec.ts` — blocking `InterviewBar` round-trip: render → block sends → answer → unblock
- `_helpers.ts` — shared `collectReactErrors`, `waitForReactMount`, `waitForShellReady`, `resetBroker`

**One landmine worth calling out:** Composer.tsx intercepts Enter to pick the highlighted autocomplete item, NOT to dispatch the slash command. So `/help\n` types Enter while items are visible and rewrites the textarea instead of opening HelpModal. Workaround: send a trailing space (`/help `), which makes the slash trigger regex (`/^\/\S*$/`) miss, the panel closes, and Enter falls through to the dispatcher. Documented in slash-commands.spec.ts.

**CI:** "Run Playwright shell smoke" → "Run Playwright shell suite", runs all 6 specs (smoke, chat, slash-commands, dm, mentions, interview) in phase 2.

## Test plan

- [x] `bunx playwright test` — all 12 phase-2 tests green locally (9 new + 3 existing smoke)
- [x] `bunx tsc --noEmit` clean across all 7 spec files + helpers
- [x] Verified in worktree (`/Users/fd/src/nex/wuphf-web-e2e-coverage`) against fresh `go build` of wuphf on alt ports
- [ ] CI runs both phases (wizard + shell suite) green
- [ ] No regression on existing smoke/wizard timing under serial-worker config

## Coverage matrix delta

| Value moment | Before | After |
|---|---|---|
| Human → message bubble | ❌ | ✅ chat.spec.ts |
| Agent → message bubble (render) | ❌ | ✅ chat.spec.ts (synthetic) |
| Slash autocomplete + Tab | ❌ | ✅ slash-commands.spec.ts |
| `/help`, `/clear` dispatch | ❌ | ✅ slash-commands.spec.ts |
| 1:1 DM open + send | ❌ | ✅ dm.spec.ts |
| Mention chips render | ❌ | ✅ mentions.spec.ts |
| Blocking interview loop | ❌ | ✅ interview.spec.ts |

Still uncovered (P1+, follow-ups): real LLM agent reply (CI has no `claude`), `/pause`/`/resume`/`/focus`/`/collab` toggles, `/reset` confirm dialog, threading, reactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for chat, direct messages, mentions, slash commands, and interview blocking flows
  * Introduced shared E2E utilities to detect React runtime errors, wait for UI readiness, and reset test state
  * Expanded CI Phase 2 to run a consolidated shell-suite of Playwright specs (beyond the existing smoke test)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->