### PR TITLE
feat(settings): make wuphf shred in restart banner a clickable inline button

### DIFF
--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -450,9 +450,9 @@ function GeneralSection({ cfg, save }: SectionProps) {
                 <>
                   This permanently deletes your team, company identity, office
                   task receipts, and saved workflows, plus local logs, sessions,
-                  provider state, calendar, and wiki memory. WUPHF will stop
-                  after the wipe; relaunch it to reopen onboarding. Task
-                  worktrees and config are kept.{" "}
+                  provider state (including codex-headless scratch), calendar,
+                  and wiki memory. WUPHF will stop after the wipe; relaunch it
+                  to reopen onboarding. Task worktrees and config are kept.{" "}
                   <strong>This cannot be undone.</strong>
                 </>
               ),
@@ -1641,7 +1641,8 @@ function DangerZoneSection() {
             <code>~/.wuphf/</code>
           </li>
           <li>
-            Logs, sessions, provider state, calendar, and local wiki memory
+            Logs, sessions, provider state (incl. <code>codex-headless</code>{" "}
+            scratch), calendar, and local wiki memory
           </li>
           <li>Broker runtime state (same as Reset)</li>
         </ul>
@@ -1693,8 +1694,9 @@ function DangerZoneSection() {
             <>
               This permanently deletes your team, company identity, office task
               receipts, and saved workflows, plus local logs, sessions, provider
-              state, calendar, and wiki memory. Onboarding will reopen
-              immediately. Task worktrees, config, and device identity are kept.{" "}
+              state (including codex-headless scratch), calendar, and wiki
+              memory. Onboarding will reopen immediately. Task worktrees,
+              config, and device identity are kept.{" "}
               <strong>This cannot be undone.</strong>
             </>
           }

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -30,6 +30,11 @@ import {
 } from "../../api/client";
 import { useAppStore } from "../../stores/app";
 import { InlineCommand } from "../ui/InlineCommand";
+import {
+  ShredDeletionsList,
+  ShredPreservationList,
+  ShredWarningCopy,
+} from "../ui/ShredWarning";
 import { showNotice } from "../ui/Toast";
 import { WipeModal } from "../ui/WipeModal";
 
@@ -447,14 +452,7 @@ function GeneralSection({ cfg, save }: SectionProps) {
               severity: "critical",
               confirmLabel: "Shred workspace",
               intro: (
-                <>
-                  This permanently deletes your team, company identity, office
-                  task receipts, and saved workflows, plus local logs, sessions,
-                  provider state (including codex-headless scratch), calendar,
-                  and wiki memory. WUPHF will stop after the wipe; relaunch it
-                  to reopen onboarding. Task worktrees and config are kept.{" "}
-                  <strong>This cannot be undone.</strong>
-                </>
+                <ShredWarningCopy aftermath="WUPHF will stop after the wipe; relaunch it to reopen onboarding." />
               ),
             }}
           />{" "}
@@ -1629,33 +1627,11 @@ function DangerZoneSection() {
         </div>
         <div style={dangerStyles.listLabel}>Deletes</div>
         <ul style={dangerStyles.list}>
-          <li>
-            Onboarding flag (<code>~/.wuphf/onboarded.json</code>) so the wizard
-            reopens
-          </li>
-          <li>
-            Company identity (<code>~/.wuphf/company.json</code>)
-          </li>
-          <li>
-            Team runtime state, office, and workflows under{" "}
-            <code>~/.wuphf/</code>
-          </li>
-          <li>
-            Logs, sessions, provider state (incl. <code>codex-headless</code>{" "}
-            scratch), calendar, and local wiki memory
-          </li>
-          <li>Broker runtime state (same as Reset)</li>
+          <ShredDeletionsList />
         </ul>
         <div style={dangerStyles.listLabel}>Preserved</div>
         <ul style={dangerStyles.list}>
-          <li>
-            <strong>Task worktrees</strong> — uncommitted work on branches stays
-            on disk
-          </li>
-          <li>
-            Your global config (<code>config.json</code>) and API keys
-          </li>
-          <li>OpenClaw device identity used for gateway pairing</li>
+          <ShredPreservationList />
         </ul>
         <button
           type="button"
@@ -1691,14 +1667,7 @@ function DangerZoneSection() {
           title="Shred this workspace?"
           severity="critical"
           intro={
-            <>
-              This permanently deletes your team, company identity, office task
-              receipts, and saved workflows, plus local logs, sessions, provider
-              state (including codex-headless scratch), calendar, and wiki
-              memory. Onboarding will reopen immediately. Task worktrees,
-              config, and device identity are kept.{" "}
-              <strong>This cannot be undone.</strong>
-            </>
+            <ShredWarningCopy aftermath="Onboarding will reopen immediately." />
           }
           confirmLabel="Shred workspace"
           busy={busy}

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -29,7 +29,9 @@ import {
   type WorkspaceWipeResult,
 } from "../../api/client";
 import { useAppStore } from "../../stores/app";
+import { InlineCommand } from "../ui/InlineCommand";
 import { showNotice } from "../ui/Toast";
+import { WipeModal } from "../ui/WipeModal";
 
 type SectionId =
   | "general"
@@ -387,6 +389,24 @@ function GeneralSection({ cfg, save }: SectionProps) {
   const [blueprint, setBlueprint] = useState(cfg.blueprint ?? "");
   const [email, setEmail] = useState(cfg.email ?? "");
   const [devUrl, setDevUrl] = useState(cfg.dev_url ?? "");
+  const queryClient = useQueryClient();
+
+  const runShred = async () => {
+    try {
+      const result: WorkspaceWipeResult = await shredWorkspace();
+      if (!result.ok) {
+        showNotice(result.error || "Shred failed", "error");
+        return;
+      }
+      queryClient.clear();
+      showNotice(
+        "Workspace shredded. Relaunch wuphf to start onboarding.",
+        "success",
+      );
+    } catch (err) {
+      showNotice(err instanceof Error ? err.message : "Shred failed", "error");
+    }
+  };
 
   const onSave = async () => {
     const patch: ConfigUpdate = {
@@ -419,17 +439,25 @@ function GeneralSection({ cfg, save }: SectionProps) {
           </strong>
           New values save immediately, but agents already running keep their
           launch-time settings. Run{" "}
-          <code
-            style={{
-              fontFamily: "var(--font-mono)",
-              padding: "1px 6px",
-              background: "var(--warning-200)",
-              color: "var(--warning-500)",
-              borderRadius: 3,
+          <InlineCommand
+            command="wuphf shred"
+            onRun={runShred}
+            destructive={{
+              title: "Shred this workspace?",
+              severity: "critical",
+              confirmLabel: "Shred workspace",
+              intro: (
+                <>
+                  This permanently deletes your team, company identity, office
+                  task receipts, and saved workflows, plus local logs, sessions,
+                  provider state, calendar, and wiki memory. WUPHF will stop
+                  after the wipe; relaunch it to reopen onboarding. Task
+                  worktrees and config are kept.{" "}
+                  <strong>This cannot be undone.</strong>
+                </>
+              ),
             }}
-          >
-            wuphf shred
-          </code>{" "}
+          />{" "}
           then relaunch to apply.
         </div>
       </div>
@@ -1496,159 +1524,7 @@ const dangerStyles = {
         : "var(--yellow, #e5a00d)",
     fontFamily: "var(--font-sans)",
   }),
-  modalBackdrop: {
-    position: "fixed" as const,
-    inset: 0,
-    background: "rgba(0,0,0,0.6)",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
-    zIndex: 1000,
-  },
-  modalPanel: {
-    width: "min(520px, calc(100vw - 40px))",
-    background: "var(--bg-card)",
-    border: "1px solid var(--border)",
-    borderRadius: "var(--radius-md)",
-    padding: 24,
-    boxShadow: "0 20px 60px rgba(0,0,0,0.4)",
-  } as const,
-  modalTitle: {
-    fontSize: 17,
-    fontWeight: 700,
-    color: "var(--text)",
-    marginBottom: 10,
-  } as const,
-  modalBody: {
-    fontSize: 13,
-    color: "var(--text-secondary)",
-    lineHeight: 1.55,
-    marginBottom: 16,
-  } as const,
-  modalInputLabel: {
-    fontSize: 11,
-    fontWeight: 600,
-    textTransform: "uppercase" as const,
-    letterSpacing: "0.06em",
-    color: "var(--text-tertiary)",
-    marginBottom: 6,
-    display: "block",
-  } as const,
-  modalInput: {
-    width: "100%",
-    background: "var(--bg-warm)",
-    border: "1px solid var(--border)",
-    color: "var(--text)",
-    borderRadius: "var(--radius-sm)",
-    height: 38,
-    fontSize: 14,
-    padding: "0 12px",
-    outline: "none",
-    fontFamily: "var(--font-mono)",
-  } as const,
-  modalRow: {
-    display: "flex",
-    gap: 8,
-    justifyContent: "flex-end",
-    marginTop: 18,
-  } as const,
-  modalCancel: {
-    padding: "9px 16px",
-    fontSize: 13,
-    fontWeight: 500,
-    border: "1px solid var(--border)",
-    borderRadius: "var(--radius-sm)",
-    cursor: "pointer" as const,
-    color: "var(--text)",
-    background: "transparent",
-    fontFamily: "var(--font-sans)",
-  } as const,
-  modalConfirm: (severity: "warn" | "critical", enabled: boolean) => ({
-    padding: "9px 16px",
-    fontSize: 13,
-    fontWeight: 600,
-    border: "none",
-    borderRadius: "var(--radius-sm)",
-    cursor: enabled ? "pointer" : ("not-allowed" as const),
-    color: "#fff",
-    background: enabled
-      ? severity === "critical"
-        ? "var(--red, #e5484d)"
-        : "var(--yellow, #e5a00d)"
-      : "var(--bg-warm)",
-    opacity: enabled ? 1 : 0.6,
-    fontFamily: "var(--font-sans)",
-  }),
 };
-
-const CONFIRM_PHRASE = "i can spell responsibility";
-
-interface WipeModalProps {
-  title: string;
-  severity: "warn" | "critical";
-  intro: ReactNode;
-  confirmLabel: string;
-  busy: boolean;
-  onConfirm: () => void;
-  onCancel: () => void;
-}
-
-// WipeModal gates a destructive action behind a type-the-exact-phrase confirm.
-// The placeholder and the body copy both surface the full phrase so there's no mystery
-// about what to type — we want the friction, not the guesswork.
-function WipeModal({
-  title,
-  severity,
-  intro,
-  confirmLabel,
-  busy,
-  onConfirm,
-  onCancel,
-}: WipeModalProps) {
-  const [value, setValue] = useState("");
-  const enabled = !busy && value.trim().toLowerCase() === CONFIRM_PHRASE;
-
-  return (
-    <div
-      style={dangerStyles.modalBackdrop}
-      onClick={busy ? undefined : onCancel}
-    >
-      <div style={dangerStyles.modalPanel} onClick={(e) => e.stopPropagation()}>
-        <div style={dangerStyles.modalTitle}>{title}</div>
-        <div style={dangerStyles.modalBody}>{intro}</div>
-        <label style={dangerStyles.modalInputLabel}>
-          Type <code>{CONFIRM_PHRASE}</code> to confirm
-        </label>
-        <input
-          type="text"
-          style={dangerStyles.modalInput}
-          placeholder={CONFIRM_PHRASE}
-          value={value}
-          onChange={(e) => setValue(e.target.value)}
-          disabled={busy}
-        />
-        <div style={dangerStyles.modalRow}>
-          <button
-            type="button"
-            style={dangerStyles.modalCancel}
-            onClick={onCancel}
-            disabled={busy}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            style={dangerStyles.modalConfirm(severity, enabled)}
-            onClick={enabled ? onConfirm : undefined}
-            disabled={!enabled}
-          >
-            {busy ? "Working…" : confirmLabel}
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 type DangerAction = "reset" | "shred";
 

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -31,6 +31,7 @@ import {
 import { useAppStore } from "../../stores/app";
 import { InlineCommand } from "../ui/InlineCommand";
 import {
+  ShredCardSubtitle,
   ShredDeletionsList,
   ShredPreservationList,
   ShredWarningCopy,
@@ -465,9 +466,7 @@ function GeneralSection({ cfg, save }: SectionProps) {
               title: "Shred this workspace?",
               severity: "critical",
               confirmLabel: "Shred workspace",
-              intro: (
-                <ShredWarningCopy aftermath="WUPHF will stop after the wipe; relaunch it to reopen onboarding." />
-              ),
+              intro: <ShredWarningCopy />,
             }}
           />{" "}
           then relaunch to apply.
@@ -1566,8 +1565,11 @@ function DangerZoneSection() {
   const handleShred = async () => {
     setBusy(true);
     try {
-      await shred();
-      setOpen(null);
+      // Leave the modal mounted on failure so the user can retry without
+      // having to reopen the Danger Zone and re-type the confirm phrase.
+      // useShredAction surfaces the failure toast and never throws.
+      const ok = await shred();
+      if (ok) setOpen(null);
     } finally {
       setBusy(false);
     }
@@ -1623,10 +1625,7 @@ function DangerZoneSection() {
           <span>Shred workspace</span>
         </div>
         <div style={dangerStyles.cardSubtitle}>
-          Full wipe. Deletes your team, company identity, office task receipts,
-          saved workflows, local memory, logs, and provider session state, then
-          returns you to onboarding. Use this to start completely fresh or to
-          try a different blueprint.
+          <ShredCardSubtitle />
         </div>
         <div style={dangerStyles.listLabel}>Deletes</div>
         <ul style={dangerStyles.list}>
@@ -1669,9 +1668,7 @@ function DangerZoneSection() {
         <WipeModal
           title="Shred this workspace?"
           severity="critical"
-          intro={
-            <ShredWarningCopy aftermath="Onboarding will reopen immediately." />
-          }
+          intro={<ShredWarningCopy />}
           confirmLabel="Shred workspace"
           busy={busy}
           onConfirm={handleShred}

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -380,6 +380,35 @@ interface SectionProps {
   save: (patch: ConfigUpdate) => Promise<void>;
 }
 
+// useShredAction wraps `shredWorkspace()` with the cleanup both call sites
+// (GeneralSection's inline button and DangerZoneSection's full card) need on
+// success: clear the query cache, route the user back to a sensible default
+// channel, and reset onboarding state so the wizard reopens. The broker's
+// `AfterShred` hook (`internal/team/broker.go`) calls `requestShutdown()`, so
+// the page typically re-mounts shortly after — but until it does, the user
+// shouldn't be left on a Settings tab whose `cfg` query just got invalidated.
+function useShredAction() {
+  const queryClient = useQueryClient();
+  const resetForOnboarding = useAppStore((s) => s.resetForOnboarding);
+  return async (): Promise<boolean> => {
+    try {
+      const result: WorkspaceWipeResult = await shredWorkspace();
+      if (!result.ok) {
+        showNotice(result.error || "Shred failed", "error");
+        return false;
+      }
+      queryClient.clear();
+      window.history.replaceState(null, "", "#/channels/general");
+      resetForOnboarding();
+      showNotice("Workspace shredded. Onboarding reopened.", "success");
+      return true;
+    } catch (err) {
+      showNotice(err instanceof Error ? err.message : "Shred failed", "error");
+      return false;
+    }
+  };
+}
+
 function GeneralSection({ cfg, save }: SectionProps) {
   const [provider, setProvider] = useState(cfg.llm_provider ?? "claude-code");
   const [memory, setMemory] = useState(cfg.memory_backend ?? "nex");
@@ -394,24 +423,7 @@ function GeneralSection({ cfg, save }: SectionProps) {
   const [blueprint, setBlueprint] = useState(cfg.blueprint ?? "");
   const [email, setEmail] = useState(cfg.email ?? "");
   const [devUrl, setDevUrl] = useState(cfg.dev_url ?? "");
-  const queryClient = useQueryClient();
-
-  const runShred = async () => {
-    try {
-      const result: WorkspaceWipeResult = await shredWorkspace();
-      if (!result.ok) {
-        showNotice(result.error || "Shred failed", "error");
-        return;
-      }
-      queryClient.clear();
-      showNotice(
-        "Workspace shredded. Relaunch wuphf to start onboarding.",
-        "success",
-      );
-    } catch (err) {
-      showNotice(err instanceof Error ? err.message : "Shred failed", "error");
-    }
-  };
+  const runShred = useShredAction();
 
   const onSave = async () => {
     const patch: ConfigUpdate = {
@@ -446,7 +458,9 @@ function GeneralSection({ cfg, save }: SectionProps) {
           launch-time settings. Run{" "}
           <InlineCommand
             command="wuphf shred"
-            onRun={runShred}
+            onRun={async () => {
+              await runShred();
+            }}
             destructive={{
               title: "Shred this workspace?",
               severity: "critical",
@@ -1530,7 +1544,7 @@ function DangerZoneSection() {
   const [open, setOpen] = useState<DangerAction | null>(null);
   const [busy, setBusy] = useState(false);
   const queryClient = useQueryClient();
-  const resetForOnboarding = useAppStore((s) => s.resetForOnboarding);
+  const shred = useShredAction();
 
   const handleReset = async () => {
     setBusy(true);
@@ -1552,20 +1566,9 @@ function DangerZoneSection() {
   const handleShred = async () => {
     setBusy(true);
     try {
-      const result: WorkspaceWipeResult = await shredWorkspace();
-      if (!result.ok) {
-        showNotice(result.error || "Shred failed", "error");
-        setBusy(false);
-        return;
-      }
-      queryClient.clear();
-      window.history.replaceState(null, "", "#/channels/general");
-      resetForOnboarding();
+      await shred();
       setOpen(null);
-      setBusy(false);
-      showNotice("Workspace shredded. Onboarding reopened.", "success");
-    } catch (err) {
-      showNotice(err instanceof Error ? err.message : "Shred failed", "error");
+    } finally {
       setBusy(false);
     }
   };

--- a/web/src/components/ui/InlineCommand.tsx
+++ b/web/src/components/ui/InlineCommand.tsx
@@ -1,0 +1,129 @@
+import { type CSSProperties, type ReactNode, useState } from "react";
+import { PlaySolid } from "iconoir-react";
+
+import { WipeModal, type WipeSeverity } from "./WipeModal";
+
+export type InlineCommandTone = "warning" | "neutral";
+
+export interface DestructiveConfirm {
+  title: string;
+  intro: ReactNode;
+  confirmLabel: string;
+  severity?: WipeSeverity;
+}
+
+export interface InlineCommandProps {
+  command: string;
+  onRun: () => void | Promise<void>;
+  destructive?: DestructiveConfirm;
+  tone?: InlineCommandTone;
+  ariaLabel?: string;
+  style?: CSSProperties;
+}
+
+const PALETTES: Record<
+  InlineCommandTone,
+  { bg: string; bgHover: string; fg: string; ring: string }
+> = {
+  warning: {
+    bg: "var(--warning-200)",
+    bgHover: "var(--warning-300, #f3cf90)",
+    fg: "var(--warning-500)",
+    ring: "rgba(153, 66, 0, 0.35)",
+  },
+  neutral: {
+    bg: "var(--bg-warm)",
+    bgHover: "var(--border, #d8d4cc)",
+    fg: "var(--text)",
+    ring: "rgba(0, 0, 0, 0.18)",
+  },
+};
+
+// InlineCommand renders a clickable inline chip styled like a code snippet.
+// For destructive actions, click opens a WipeModal that gates execution behind
+// the confirm phrase; otherwise click runs onRun immediately.
+export function InlineCommand({
+  command,
+  onRun,
+  destructive,
+  tone = "warning",
+  ariaLabel,
+  style,
+}: InlineCommandProps) {
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [hover, setHover] = useState(false);
+  const palette = PALETTES[tone];
+
+  const run = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await onRun();
+      setOpen(false);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleClick = () => {
+    if (busy) return;
+    if (destructive) {
+      setOpen(true);
+      return;
+    }
+    void run();
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handleClick}
+        onMouseEnter={() => setHover(true)}
+        onMouseLeave={() => setHover(false)}
+        disabled={busy}
+        title={ariaLabel || `Run ${command}`}
+        aria-label={ariaLabel || `Run ${command}`}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 5,
+          fontFamily: "var(--font-mono)",
+          fontSize: "inherit",
+          padding: "1px 8px",
+          background: hover && !busy ? palette.bgHover : palette.bg,
+          color: palette.fg,
+          border: "none",
+          borderRadius: 4,
+          cursor: busy ? "progress" : "pointer",
+          boxShadow: hover && !busy ? `0 0 0 2px ${palette.ring}` : "none",
+          transition: "background 0.12s, box-shadow 0.12s",
+          verticalAlign: "baseline",
+          lineHeight: 1.45,
+          ...style,
+        }}
+      >
+        <PlaySolid
+          width={9}
+          height={9}
+          style={{ flexShrink: 0, opacity: 0.85 }}
+        />
+        <span>{command}</span>
+      </button>
+      {open && destructive && (
+        <WipeModal
+          title={destructive.title}
+          severity={destructive.severity || "critical"}
+          intro={destructive.intro}
+          confirmLabel={destructive.confirmLabel}
+          busy={busy}
+          onConfirm={() => void run()}
+          onCancel={() => {
+            if (!busy) setOpen(false);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/web/src/components/ui/InlineCommand.tsx
+++ b/web/src/components/ui/InlineCommand.tsx
@@ -53,16 +53,29 @@ export function InlineCommand({
   const [open, setOpen] = useState(false);
   const [busy, setBusy] = useState(false);
   const [hover, setHover] = useState(false);
+  const [focus, setFocus] = useState(false);
   const palette = PALETTES[tone];
+  // Show the ring on either pointer-hover or keyboard-focus so keyboard-only
+  // users get the same affordance mouse users do — the chip lives in the
+  // middle of a paragraph, so without an explicit focus indicator a tabbed
+  // landing is invisible.
+  const ringActive = (hover || focus) && !busy;
 
   const run = async () => {
     if (busy) return;
     setBusy(true);
     try {
       await onRun();
-      setOpen(false);
+    } catch (err) {
+      // Caller-site `() => void run()` (used inside WipeModal's onConfirm)
+      // would otherwise drop a rejected promise on the floor, leaving the
+      // modal mounted with `busy` already flipped back. Surface to console
+      // and close the modal so callers don't have to wrap every onRun in a
+      // try/catch defensively.
+      console.error("[InlineCommand] onRun threw:", err);
     } finally {
       setBusy(false);
+      setOpen(false);
     }
   };
 
@@ -82,9 +95,12 @@ export function InlineCommand({
         onClick={handleClick}
         onMouseEnter={() => setHover(true)}
         onMouseLeave={() => setHover(false)}
+        onFocus={() => setFocus(true)}
+        onBlur={() => setFocus(false)}
         disabled={busy}
         title={ariaLabel || `Run ${command}`}
         aria-label={ariaLabel || `Run ${command}`}
+        aria-busy={busy}
         style={{
           display: "inline-flex",
           alignItems: "center",
@@ -92,21 +108,25 @@ export function InlineCommand({
           fontFamily: "var(--font-mono)",
           fontSize: "inherit",
           padding: "1px 8px",
-          background: hover && !busy ? palette.bgHover : palette.bg,
+          background: ringActive ? palette.bgHover : palette.bg,
           color: palette.fg,
           border: "none",
           borderRadius: 4,
           cursor: busy ? "progress" : "pointer",
-          boxShadow: hover && !busy ? `0 0 0 2px ${palette.ring}` : "none",
-          transition: "background 0.12s, box-shadow 0.12s",
+          boxShadow: ringActive ? `0 0 0 2px ${palette.ring}` : "none",
+          // Dim while busy so the non-destructive path has *some* affordance
+          // beyond `cursor: progress`; the destructive path gets the modal
+          // as a richer busy surface.
+          opacity: busy ? 0.65 : 1,
+          transition: "background 0.12s, box-shadow 0.12s, opacity 0.12s",
           verticalAlign: "baseline",
           lineHeight: 1.45,
           ...style,
         }}
       >
         <PlaySolid
-          width={9}
-          height={9}
+          width={11}
+          height={11}
           style={{ flexShrink: 0, opacity: 0.85 }}
         />
         <span>{command}</span>

--- a/web/src/components/ui/ShredWarning.tsx
+++ b/web/src/components/ui/ShredWarning.tsx
@@ -6,8 +6,11 @@ import type { ReactNode } from "react";
 // `internal/workspace/workspace.go:Shred`. When that function changes,
 // update this file (and only this file).
 
+// `internal/workspace/workspace.go:Shred` removes the entire `~/.wuphf/office`
+// directory, not just task receipts — narrowing the prose here would give
+// users the wrong impression that other office state survives.
 const DELETIONS_PROSE =
-  "your team, company identity, office task receipts, and saved workflows, plus local logs, sessions, provider state (including codex-headless scratch), calendar, and wiki memory";
+  "your team, company identity, office state, and saved workflows, plus local logs, sessions, provider state (including codex-headless scratch), calendar, and wiki memory";
 
 const PRESERVED_PROSE =
   "Task worktrees, your global config and API keys, and your OpenClaw device identity are kept.";

--- a/web/src/components/ui/ShredWarning.tsx
+++ b/web/src/components/ui/ShredWarning.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
 // Single source of truth for "what does shred actually do?". Any UI that
 // warns about shred — banner buttons, danger-zone cards, confirm modals —
 // pulls copy from here so the description never drifts from
@@ -12,24 +10,36 @@ import type { ReactNode } from "react";
 const DELETIONS_PROSE =
   "your team, company identity, office state, and saved workflows, plus local logs, sessions, provider state (including codex-headless scratch), calendar, and wiki memory";
 
+// Aftermath copy is a single canonical sentence used by every shred surface
+// (inline banner, Danger Zone modal, danger-zone card subtitle). Both call
+// sites trigger the same `/workspace/shred` → `b.Reset` flow on the broker
+// (see `internal/team/broker.go` `RouteOptions{ResetRuntime: b.Reset}`), so
+// they share user-observable behavior — the prose should match too.
+const AFTERMATH_PROSE = "Onboarding will reopen immediately.";
+
 const PRESERVED_PROSE =
   "Task worktrees, your global config and API keys, and your OpenClaw device identity are kept.";
 
-export interface ShredWarningCopyProps {
-  // Sentence describing what happens after the wipe — varies by call site
-  // (e.g. "WUPHF will stop after the wipe; relaunch it to reopen onboarding."
-  // for the inline restart banner vs. "Onboarding will reopen immediately."
-  // for the Danger Zone modal where the broker is about to keep running).
-  aftermath: ReactNode;
-}
-
 // ShredWarningCopy renders the canonical destructive-warning paragraph used
-// in confirm modals. Pass `aftermath` for the trailing context sentence.
-export function ShredWarningCopy({ aftermath }: ShredWarningCopyProps) {
+// in confirm modals. No props by design — keeping the copy uniform across
+// every shred surface is the whole point of this module.
+export function ShredWarningCopy() {
   return (
     <>
-      This permanently deletes {DELETIONS_PROSE}. {aftermath} {PRESERVED_PROSE}{" "}
-      <strong>This cannot be undone.</strong>
+      This permanently deletes {DELETIONS_PROSE}. {AFTERMATH_PROSE}{" "}
+      {PRESERVED_PROSE} <strong>This cannot be undone.</strong>
+    </>
+  );
+}
+
+// ShredCardSubtitle renders the short summary used at the top of the Danger
+// Zone shred card (above the bullet lists). Keeps the prose anchored to the
+// same source of truth as the modal intro.
+export function ShredCardSubtitle() {
+  return (
+    <>
+      Full wipe. Deletes {DELETIONS_PROSE}, then returns you to onboarding. Use
+      this to start completely fresh or to try a different blueprint.
     </>
   );
 }

--- a/web/src/components/ui/ShredWarning.tsx
+++ b/web/src/components/ui/ShredWarning.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from "react";
+
+// Single source of truth for "what does shred actually do?". Any UI that
+// warns about shred — banner buttons, danger-zone cards, confirm modals —
+// pulls copy from here so the description never drifts from
+// `internal/workspace/workspace.go:Shred`. When that function changes,
+// update this file (and only this file).
+
+const DELETIONS_PROSE =
+  "your team, company identity, office task receipts, and saved workflows, plus local logs, sessions, provider state (including codex-headless scratch), calendar, and wiki memory";
+
+const PRESERVED_PROSE =
+  "Task worktrees, your global config and API keys, and your OpenClaw device identity are kept.";
+
+export interface ShredWarningCopyProps {
+  // Sentence describing what happens after the wipe — varies by call site
+  // (e.g. "WUPHF will stop after the wipe; relaunch it to reopen onboarding."
+  // for the inline restart banner vs. "Onboarding will reopen immediately."
+  // for the Danger Zone modal where the broker is about to keep running).
+  aftermath: ReactNode;
+}
+
+// ShredWarningCopy renders the canonical destructive-warning paragraph used
+// in confirm modals. Pass `aftermath` for the trailing context sentence.
+export function ShredWarningCopy({ aftermath }: ShredWarningCopyProps) {
+  return (
+    <>
+      This permanently deletes {DELETIONS_PROSE}. {aftermath} {PRESERVED_PROSE}{" "}
+      <strong>This cannot be undone.</strong>
+    </>
+  );
+}
+
+// ShredDeletionsList renders the canonical "Deletes" bullet list — used by
+// the Danger Zone card to spell out exactly which files/dirs are removed.
+export function ShredDeletionsList() {
+  return (
+    <>
+      <li>
+        Onboarding flag (<code>~/.wuphf/onboarded.json</code>) so the wizard
+        reopens
+      </li>
+      <li>
+        Company identity (<code>~/.wuphf/company.json</code>)
+      </li>
+      <li>
+        Team runtime state, office, and workflows under <code>~/.wuphf/</code>
+      </li>
+      <li>
+        Logs, sessions, provider state (incl. <code>codex-headless</code>{" "}
+        scratch), calendar, and local wiki memory
+      </li>
+      <li>Broker runtime state (same as Reset)</li>
+    </>
+  );
+}
+
+// ShredPreservationList renders the canonical "Preserved" bullet list. Mirrors
+// the survivors documented in `internal/workspace/workspace.go` (task-worktrees,
+// config.json, openclaw/).
+export function ShredPreservationList() {
+  return (
+    <>
+      <li>
+        <strong>Task worktrees</strong> — uncommitted work on branches stays on
+        disk
+      </li>
+      <li>
+        Your global config (<code>config.json</code>) and API keys
+      </li>
+      <li>OpenClaw device identity used for gateway pairing</li>
+    </>
+  );
+}

--- a/web/src/components/ui/WipeModal.tsx
+++ b/web/src/components/ui/WipeModal.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useId, useRef, useState } from "react";
 
 export type WipeSeverity = "warn" | "critical";
 
@@ -114,16 +114,65 @@ export function WipeModal({
 }: WipeModalProps) {
   const [value, setValue] = useState("");
   const enabled = !busy && value.trim().toLowerCase() === WIPE_CONFIRM_PHRASE;
+  const titleId = useId();
+  const bodyId = useId();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  // Track where the press started so accidental drag-out from the input to
+  // the backdrop (common while selecting the displayed phrase to copy) does
+  // not dismiss the modal — `click` would otherwise fire on the backdrop and
+  // cancel.
+  const backdropPressRef = useRef(false);
+
+  // Focus the input on mount. biome's a11y/noAutofocus rule explicitly allows
+  // imperative focus via `useRef`+`useEffect` — only the JSX `autoFocus`
+  // attribute is forbidden — and the type-the-phrase friction is much worse
+  // when users have to click into the input first.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Escape closes the modal — keyboard parity with backdrop click. Skipped
+  // while busy so an in-flight wipe cannot be canceled mid-flight by a stray
+  // keypress (matches the backdrop guard on line 119).
+  useEffect(() => {
+    if (busy) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onCancel();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [busy, onCancel]);
 
   return (
-    <div style={styles.backdrop} onClick={busy ? undefined : onCancel}>
-      <div style={styles.panel} onClick={(e) => e.stopPropagation()}>
-        <div style={styles.title}>{title}</div>
-        <div style={styles.body}>{intro}</div>
+    <div
+      style={styles.backdrop}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={bodyId}
+      onMouseDown={(e) => {
+        backdropPressRef.current = e.target === e.currentTarget;
+      }}
+      onMouseUp={(e) => {
+        if (busy) return;
+        if (backdropPressRef.current && e.target === e.currentTarget) {
+          onCancel();
+        }
+        backdropPressRef.current = false;
+      }}
+    >
+      <div style={styles.panel}>
+        <div id={titleId} style={styles.title}>
+          {title}
+        </div>
+        <div id={bodyId} style={styles.body}>
+          {intro}
+        </div>
         <label style={styles.inputLabel}>
           Type <code>{WIPE_CONFIRM_PHRASE}</code> to confirm
         </label>
         <input
+          ref={inputRef}
           type="text"
           style={styles.input}
           placeholder={WIPE_CONFIRM_PHRASE}

--- a/web/src/components/ui/WipeModal.tsx
+++ b/web/src/components/ui/WipeModal.tsx
@@ -1,0 +1,155 @@
+import { type ReactNode, useState } from "react";
+
+export type WipeSeverity = "warn" | "critical";
+
+export const WIPE_CONFIRM_PHRASE = "i can spell responsibility";
+
+const styles = {
+  backdrop: {
+    position: "fixed" as const,
+    inset: 0,
+    background: "rgba(0,0,0,0.6)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    zIndex: 1000,
+  },
+  panel: {
+    width: "min(520px, calc(100vw - 40px))",
+    background: "var(--bg-card)",
+    border: "1px solid var(--border)",
+    borderRadius: "var(--radius-md)",
+    padding: 24,
+    boxShadow: "0 20px 60px rgba(0,0,0,0.4)",
+  } as const,
+  title: {
+    fontSize: 17,
+    fontWeight: 700,
+    color: "var(--text)",
+    marginBottom: 10,
+  } as const,
+  body: {
+    fontSize: 13,
+    color: "var(--text-secondary)",
+    lineHeight: 1.55,
+    marginBottom: 16,
+  } as const,
+  inputLabel: {
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: "uppercase" as const,
+    letterSpacing: "0.06em",
+    color: "var(--text-tertiary)",
+    marginBottom: 6,
+    display: "block",
+  } as const,
+  input: {
+    width: "100%",
+    background: "var(--bg-warm)",
+    border: "1px solid var(--border)",
+    color: "var(--text)",
+    borderRadius: "var(--radius-sm)",
+    height: 38,
+    fontSize: 14,
+    padding: "0 12px",
+    outline: "none",
+    fontFamily: "var(--font-mono)",
+  } as const,
+  row: {
+    display: "flex",
+    gap: 8,
+    justifyContent: "flex-end",
+    marginTop: 18,
+  } as const,
+  cancel: {
+    padding: "9px 16px",
+    fontSize: 13,
+    fontWeight: 500,
+    border: "1px solid var(--border)",
+    borderRadius: "var(--radius-sm)",
+    cursor: "pointer" as const,
+    color: "var(--text)",
+    background: "transparent",
+    fontFamily: "var(--font-sans)",
+  } as const,
+  confirm: (severity: WipeSeverity, enabled: boolean) => ({
+    padding: "9px 16px",
+    fontSize: 13,
+    fontWeight: 600,
+    border: "none",
+    borderRadius: "var(--radius-sm)",
+    cursor: enabled ? "pointer" : ("not-allowed" as const),
+    color: "#fff",
+    background: enabled
+      ? severity === "critical"
+        ? "var(--red, #e5484d)"
+        : "var(--yellow, #e5a00d)"
+      : "var(--bg-warm)",
+    opacity: enabled ? 1 : 0.6,
+    fontFamily: "var(--font-sans)",
+  }),
+};
+
+export interface WipeModalProps {
+  title: string;
+  severity: WipeSeverity;
+  intro: ReactNode;
+  confirmLabel: string;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+// WipeModal gates a destructive action behind a type-the-exact-phrase confirm.
+// The placeholder and the body copy both surface the full phrase so there's no mystery
+// about what to type — we want the friction, not the guesswork.
+export function WipeModal({
+  title,
+  severity,
+  intro,
+  confirmLabel,
+  busy,
+  onConfirm,
+  onCancel,
+}: WipeModalProps) {
+  const [value, setValue] = useState("");
+  const enabled = !busy && value.trim().toLowerCase() === WIPE_CONFIRM_PHRASE;
+
+  return (
+    <div style={styles.backdrop} onClick={busy ? undefined : onCancel}>
+      <div style={styles.panel} onClick={(e) => e.stopPropagation()}>
+        <div style={styles.title}>{title}</div>
+        <div style={styles.body}>{intro}</div>
+        <label style={styles.inputLabel}>
+          Type <code>{WIPE_CONFIRM_PHRASE}</code> to confirm
+        </label>
+        <input
+          type="text"
+          style={styles.input}
+          placeholder={WIPE_CONFIRM_PHRASE}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          disabled={busy}
+        />
+        <div style={styles.row}>
+          <button
+            type="button"
+            style={styles.cancel}
+            onClick={onCancel}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            style={styles.confirm(severity, enabled)}
+            onClick={enabled ? onConfirm : undefined}
+            disabled={!enabled}
+          >
+            {busy ? "Working…" : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The General-section banner used to tell users to "Run `wuphf shred` then relaunch" but the shred command was a static `<code>` chip — they had to copy it into a terminal. Now the chip is a real inline button: click → existing type-the-phrase confirm modal → runs the wipe directly.

Also lifts two reusable ui primitives so future "user has to run X" banners can wire the same pattern:

- `WipeModal` — extracted out of `SettingsApp` so any feature can gate a destructive action behind the existing confirm-phrase friction. Danger Zone now imports the shared one instead of carrying its own copy.
- `InlineCommand` — a clickable inline `<code>`-styled chip with a small ▶ glyph. Pass `destructive={...}` to require a `WipeModal` confirm; otherwise click runs `onRun` immediately.

## Before / After

**Before** — static `wuphf shred` text chip, no affordance:

<img src="https://raw.githubusercontent.com/nex-crm/wuphf/assets/inline-command-screenshots/before.png" width="900" alt="Before: static wuphf shred text chip" />

**After** — clickable inline button with play glyph + hover ring:

<img src="https://raw.githubusercontent.com/nex-crm/wuphf/assets/inline-command-screenshots/after.png" width="900" alt="After: clickable wuphf shred inline button" />

**Click → existing WipeModal** (same type-the-phrase confirmation that Danger Zone already uses):

<img src="https://raw.githubusercontent.com/nex-crm/wuphf/assets/inline-command-screenshots/modal.png" width="900" alt="Click opens WipeModal with type-the-phrase gate" />

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` — 412/412 passed (incl. the existing SettingsApp coverage)
- [x] `npm run build` — production bundle builds cleanly
- [x] Visual verification via Playwright against a fresh wuphf instance — idle / hover / modal-open states all render correctly (see screenshots above)
- [ ] Manual smoke: hit Settings → General, click `wuphf shred`, type the phrase, confirm wipe runs and broker exits

> Screenshots live on a separate `assets/inline-command-screenshots` orphan branch so this branch's diff stays code-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline destructive "shred" control with confirmation, busy-state handling, and success/error notices; guidance to relaunch after completion.
  * Reusable destructive confirmation dialog that requires typing an exact phrase to confirm.
  * Shared shred action that surfaces success/error toasts, resets onboarding/navigation on success, and keeps modals open on failure.

* **Refactor**
  * Unified shred/reset confirmation UI and standardized warning, deletions, and preservation lists for consistent copy and layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->