### PR TITLE
feat(provider): record token usage for local OpenAI-compatible runtimes

### DIFF
--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -83,7 +83,7 @@ type Message struct {
 }
 
 // StreamChunk is one piece of streamed output from the LLM.
-// Type is one of: "text", "tool_call", "error", "thinking", "tool_use", "tool_result"
+// Type is one of: "text", "tool_call", "error", "thinking", "tool_use", "tool_result", "usage"
 type StreamChunk struct {
 	Type       string         `json:"type"`
 	Content    string         `json:"content,omitempty"`
@@ -91,6 +91,15 @@ type StreamChunk struct {
 	ToolParams map[string]any `json:"toolParams,omitempty"`
 	ToolUseID  string         `json:"toolUseId,omitempty"` // for tool_use / tool_result correlation
 	ToolInput  string         `json:"toolInput,omitempty"` // serialized tool input for display
+
+	// Token counts on Type == "usage" chunks. Providers that surface usage
+	// (Claude, OpenAI-compatible local servers with stream_options.include_usage,
+	// etc) emit a single trailing chunk per turn with these fields populated.
+	// Other chunk types leave them zero.
+	InputTokens         int `json:"inputTokens,omitempty"`
+	OutputTokens        int `json:"outputTokens,omitempty"`
+	CacheReadTokens     int `json:"cacheReadTokens,omitempty"`
+	CacheCreationTokens int `json:"cacheCreationTokens,omitempty"`
 }
 
 // StreamFn is a function that streams LLM output as a channel of chunks.

--- a/internal/provider/openai_compat.go
+++ b/internal/provider/openai_compat.go
@@ -186,6 +186,13 @@ func runOpenAICompatStream(
 		Model:    model,
 		Stream:   true,
 		Messages: agentMsgsToOpenAI(msgs),
+		// Ask the server to emit a final SSE frame containing token usage.
+		// Recognised by ollama, recent mlx_lm.server, exo, llama.cpp's
+		// server, and the canonical OpenAI API. Servers that don't
+		// implement this option ignore the unknown field, so the request
+		// stays well-formed; we just won't see usage from those servers
+		// (which is the same as today's behaviour).
+		StreamOptions: &openaiStreamOptions{IncludeUsage: true},
 	}
 	if len(tools) > 0 {
 		body.Tools = agentToolsToOpenAI(tools)
@@ -251,6 +258,23 @@ func parseOpenAISSEStream(ch chan<- agent.StreamChunk, kind string, body io.Read
 	// doesn't have to care which dialect the model picked.
 	var textBuf strings.Builder
 
+	// latestUsage holds the most recent usage frame seen this turn. With
+	// stream_options.include_usage the server sends exactly one trailing
+	// usage frame; some servers (llama.cpp's, older mlx_lm.server) instead
+	// stamp partial usage on every event, so we always take the last one.
+	var latestUsage *openaiUsage
+
+	flushUsage := func() {
+		if latestUsage == nil {
+			return
+		}
+		ch <- agent.StreamChunk{
+			Type:         "usage",
+			InputTokens:  latestUsage.PromptTokens,
+			OutputTokens: latestUsage.CompletionTokens,
+		}
+	}
+
 	flushTools := func() {
 		emittedStructured := false
 		for _, idx := range emitOrder {
@@ -310,14 +334,16 @@ func parseOpenAISSEStream(ch chan<- agent.StreamChunk, kind string, body io.Read
 				}
 				if payload == "[DONE]" {
 					flushTools()
+					flushUsage()
 					return
 				}
-				processOpenAISSEEvent(ch, kind, payload, toolAccumulators, &emitOrder, &textBuf)
+				processOpenAISSEEvent(ch, kind, payload, toolAccumulators, &emitOrder, &textBuf, &latestUsage)
 			}
 		}
 		if err != nil {
 			if err == io.EOF {
 				flushTools()
+				flushUsage()
 				return
 			}
 			ch <- agent.StreamChunk{Type: "error", Content: fmt.Sprintf("openai-compat (%s): read stream: %v", kind, err)}
@@ -549,6 +575,7 @@ func processOpenAISSEEvent(
 	toolAccumulators map[int]*toolAccum,
 	emitOrder *[]int,
 	textBuf *strings.Builder,
+	latestUsage **openaiUsage,
 ) {
 	var ev openaiStreamChunk
 	if err := json.Unmarshal([]byte(payload), &ev); err != nil {
@@ -557,6 +584,18 @@ func processOpenAISSEEvent(
 			Content: fmt.Sprintf("openai-compat (%s): malformed SSE payload: %v\nraw: %s", kind, err, payload),
 		}
 		return
+	}
+	// Capture usage from any frame that carries it. With
+	// stream_options.include_usage the canonical pattern is a single
+	// trailing frame whose `choices` is empty and `usage` is set; we
+	// still update on partial-usage frames to be tolerant of servers
+	// that stamp it earlier. We only record when both prompt and
+	// completion are populated to avoid latching a half-filled frame.
+	if ev.Usage != nil && latestUsage != nil {
+		if ev.Usage.PromptTokens > 0 || ev.Usage.CompletionTokens > 0 {
+			u := *ev.Usage
+			*latestUsage = &u
+		}
 	}
 	if len(ev.Choices) == 0 {
 		return
@@ -594,11 +633,20 @@ type toolAccum struct {
 // --- request shape ----------------------------------------------------------
 
 type openaiRequest struct {
-	Model      string          `json:"model"`
-	Messages   []openaiMessage `json:"messages"`
-	Stream     bool            `json:"stream"`
-	Tools      []openaiTool    `json:"tools,omitempty"`
-	ToolChoice string          `json:"tool_choice,omitempty"`
+	Model         string               `json:"model"`
+	Messages      []openaiMessage      `json:"messages"`
+	Stream        bool                 `json:"stream"`
+	StreamOptions *openaiStreamOptions `json:"stream_options,omitempty"`
+	Tools         []openaiTool         `json:"tools,omitempty"`
+	ToolChoice    string               `json:"tool_choice,omitempty"`
+}
+
+// openaiStreamOptions mirrors OpenAI's `stream_options` request field. We
+// only set `include_usage` today; the struct exists as a separate type
+// (rather than inlining a bool) so future options like `service_tier` can
+// be added without reshaping the request body.
+type openaiStreamOptions struct {
+	IncludeUsage bool `json:"include_usage,omitempty"`
 }
 
 type openaiMessage struct {
@@ -654,11 +702,26 @@ func agentToolsToOpenAI(tools []agent.AgentTool) []openaiTool {
 
 type openaiStreamChunk struct {
 	Choices []openaiStreamChoice `json:"choices"`
+	// Usage is populated on the final SSE frame when the server honours
+	// stream_options.include_usage. Pointer so the zero value is
+	// distinguishable from `prompt_tokens: 0` (unlikely in practice but
+	// keeps the JSON round-trip honest).
+	Usage *openaiUsage `json:"usage,omitempty"`
 }
 
 type openaiStreamChoice struct {
 	Delta        openaiStreamDelta `json:"delta"`
 	FinishReason string            `json:"finish_reason"`
+}
+
+// openaiUsage captures the token counts a local OpenAI-compatible server
+// emits in its trailing usage frame. We don't extract cost: local runs
+// have no marginal $ cost so a zero in the broker's cost_usd column is
+// the right answer.
+type openaiUsage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
 }
 
 type openaiStreamDelta struct {

--- a/internal/provider/openai_compat.go
+++ b/internal/provider/openai_compat.go
@@ -346,6 +346,13 @@ func parseOpenAISSEStream(ch chan<- agent.StreamChunk, kind string, body io.Read
 				flushUsage()
 				return
 			}
+			// Surface anything we already captured before the read
+			// failed — a long generation that broke connection mid-
+			// stream still produced real tokens the user wants
+			// counted, matching the headless runner's intent at
+			// headless_openai_compat.go's "Record token counts even
+			// on partial / errored turns" comment.
+			flushUsage()
 			ch <- agent.StreamChunk{Type: "error", Content: fmt.Sprintf("openai-compat (%s): read stream: %v", kind, err)}
 			return
 		}
@@ -587,14 +594,26 @@ func processOpenAISSEEvent(
 	}
 	// Capture usage from any frame that carries it. With
 	// stream_options.include_usage the canonical pattern is a single
-	// trailing frame whose `choices` is empty and `usage` is set; we
-	// still update on partial-usage frames to be tolerant of servers
-	// that stamp it earlier. We only record when both prompt and
-	// completion are populated to avoid latching a half-filled frame.
+	// trailing frame whose `choices` is empty and `usage` is set;
+	// llama.cpp's server stamps partial usage on every event instead.
+	//
+	// Latch policy: only overwrite when the new frame's totals are
+	// monotonically larger than what we've already seen. Prevents two
+	// real failure modes:
+	//   1. A degenerate trailing `0/0` frame from clobbering an earlier
+	//      complete count (some servers emit one on errored turns).
+	//   2. A speculative-decoding reject path where mlx_lm.server has
+	//      been observed to follow up a `prompt_tokens=N, completion=K`
+	//      frame with `prompt_tokens=N, completion=0` after rolling
+	//      back rejected tokens — without monotonic guard we'd lose K.
 	if ev.Usage != nil && latestUsage != nil {
-		if ev.Usage.PromptTokens > 0 || ev.Usage.CompletionTokens > 0 {
-			u := *ev.Usage
-			*latestUsage = &u
+		incoming := *ev.Usage
+		if *latestUsage == nil ||
+			(incoming.PromptTokens >= (*latestUsage).PromptTokens &&
+				incoming.CompletionTokens >= (*latestUsage).CompletionTokens) {
+			if incoming.PromptTokens > 0 || incoming.CompletionTokens > 0 {
+				*latestUsage = &incoming
+			}
 		}
 	}
 	if len(ev.Choices) == 0 {

--- a/internal/provider/openai_compat_test.go
+++ b/internal/provider/openai_compat_test.go
@@ -904,3 +904,66 @@ func TestParseOpenAISSEStream_NoUsageFrameStaysSilent(t *testing.T) {
 		}
 	}
 }
+
+// TestParseOpenAISSEStream_AllZeroUsageDoesNotLatch covers the latch
+// invariant separately from the no-frame-at-all case above. A frame
+// with `prompt_tokens=0, completion_tokens=0` MUST NOT fabricate a
+// usage chunk, otherwise a server that emits a degenerate empty
+// usage frame on errored turns would burn a Requests bump in the
+// broker without any real numbers attached. (Kept as its own test
+// so a future change to the latch policy can't silently regress this
+// edge by passing the broader no-usage-server test.)
+func TestParseOpenAISSEStream_AllZeroUsageDoesNotLatch(t *testing.T) {
+	body := sseBody(
+		`{"choices":[{"delta":{"content":"hi"}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		`{"choices":[],"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}`,
+	)
+
+	ch := make(chan agent.StreamChunk, 16)
+	go func() {
+		defer close(ch)
+		parseOpenAISSEStream(ch, "test", strings.NewReader(body))
+	}()
+
+	for _, c := range drainChunks(t, ch) {
+		if c.Type == "usage" {
+			t.Fatalf("zero-valued usage frame must not produce a usage chunk, got %+v", c)
+		}
+	}
+}
+
+// TestParseOpenAISSEStream_LaterPartialUsageDoesNotClobber covers the
+// monotonic-latch invariant: once we've seen a frame with real numbers
+// (e.g. prompt=42, completion=7), a later frame that's strictly smaller
+// (e.g. prompt=42, completion=0 — observed pattern from speculative-
+// decoding rejects on mlx_lm.server) must not overwrite the captured
+// count. Without this guard a turn's completion tokens would be silently
+// lost, surfacing as zero in the user's usage panel.
+func TestParseOpenAISSEStream_LaterPartialUsageDoesNotClobber(t *testing.T) {
+	body := sseBody(
+		`{"choices":[{"delta":{"content":"Hi"}}]}`,
+		`{"choices":[],"usage":{"prompt_tokens":42,"completion_tokens":7,"total_tokens":49}}`,
+		`{"choices":[],"usage":{"prompt_tokens":42,"completion_tokens":0,"total_tokens":42}}`,
+	)
+
+	ch := make(chan agent.StreamChunk, 16)
+	go func() {
+		defer close(ch)
+		parseOpenAISSEStream(ch, "test", strings.NewReader(body))
+	}()
+
+	var usage *agent.StreamChunk
+	for _, c := range drainChunks(t, ch) {
+		c := c
+		if c.Type == "usage" {
+			usage = &c
+		}
+	}
+	if usage == nil {
+		t.Fatalf("expected a usage chunk")
+	}
+	if usage.InputTokens != 42 || usage.OutputTokens != 7 {
+		t.Errorf("usage = {input:%d output:%d}, want {42, 7} (later partial frame must not clobber)", usage.InputTokens, usage.OutputTokens)
+	}
+}

--- a/internal/provider/openai_compat_test.go
+++ b/internal/provider/openai_compat_test.go
@@ -825,9 +825,82 @@ func TestOpenAICompatStreamFn_RequestBodyShape(t *testing.T) {
 		`"name":"t1"`,
 		`"role":"system"`,
 		`"role":"user"`,
+		`"stream_options":{"include_usage":true}`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("request body missing %q\nbody: %s", want, got)
+		}
+	}
+}
+
+// TestParseOpenAISSEStream_TrailingUsageFrame covers the canonical pattern
+// from `stream_options.include_usage`: a final SSE frame with empty choices
+// and a populated `usage` block. It must produce exactly one trailing
+// usage chunk carrying the prompt/completion token counts.
+func TestParseOpenAISSEStream_TrailingUsageFrame(t *testing.T) {
+	body := sseBody(
+		`{"choices":[{"delta":{"content":"Hello"}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		`{"choices":[],"usage":{"prompt_tokens":42,"completion_tokens":7,"total_tokens":49}}`,
+	)
+
+	ch := make(chan agent.StreamChunk, 16)
+	go func() {
+		defer close(ch)
+		parseOpenAISSEStream(ch, "test", strings.NewReader(body))
+	}()
+
+	chunks := drainChunks(t, ch)
+	var usage *agent.StreamChunk
+	for i := range chunks {
+		if chunks[i].Type == "usage" {
+			usage = &chunks[i]
+		}
+	}
+	if usage == nil {
+		t.Fatalf("expected a usage chunk, got %+v", chunks)
+	}
+	if usage.InputTokens != 42 || usage.OutputTokens != 7 {
+		t.Errorf("usage chunk = {input:%d output:%d}, want {42, 7}", usage.InputTokens, usage.OutputTokens)
+	}
+	// The usage chunk must come AFTER the text chunks so consumers that
+	// stream-render text don't have to special-case ordering.
+	lastTextIdx := -1
+	usageIdx := -1
+	for i, c := range chunks {
+		switch c.Type {
+		case "text":
+			lastTextIdx = i
+		case "usage":
+			usageIdx = i
+		}
+	}
+	if usageIdx <= lastTextIdx {
+		t.Errorf("usage chunk emitted at index %d, expected after last text at %d", usageIdx, lastTextIdx)
+	}
+}
+
+// TestParseOpenAISSEStream_NoUsageFrameStaysSilent verifies that when the
+// server doesn't emit a usage frame (e.g. older mlx_lm.server, servers that
+// don't implement stream_options.include_usage), the parser does NOT
+// fabricate a zero-valued usage chunk. The headless runner relies on
+// "no usage chunk → don't call RecordAgentUsage" to avoid recording empty
+// rows.
+func TestParseOpenAISSEStream_NoUsageFrameStaysSilent(t *testing.T) {
+	body := sseBody(
+		`{"choices":[{"delta":{"content":"hi"}}]}`,
+		`{"choices":[{"delta":{},"finish_reason":"stop"}]}`,
+	)
+
+	ch := make(chan agent.StreamChunk, 16)
+	go func() {
+		defer close(ch)
+		parseOpenAISSEStream(ch, "test", strings.NewReader(body))
+	}()
+
+	for _, c := range drainChunks(t, ch) {
+		if c.Type == "usage" {
+			t.Fatalf("expected no usage chunk, got %+v", c)
 		}
 	}
 }

--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -143,7 +143,14 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		},
 	}
 
-	finalText, iterationsUsed, streamErr, err := loop.run(ctx, msgs)
+	finalText, iterationsUsed, turnUsage, streamErr, err := loop.run(ctx, msgs)
+	// Record token counts even on partial / errored turns: a failed turn
+	// can still have generated thousands of tokens we want surfaced in the
+	// usage panel. CostUSD stays at zero — local runtimes have no marginal
+	// $ cost so the broker's cost_usd column correctly remains untouched.
+	if (turnUsage.InputTokens > 0 || turnUsage.OutputTokens > 0) && l.broker != nil {
+		l.broker.RecordAgentUsage(slug, kind, turnUsage)
+	}
 	if err != nil {
 		metrics.TotalMs = time.Since(startedAt).Milliseconds()
 		l.updateHeadlessProgress(slug, "error", "error", truncate(err.Error(), 180), metrics)

--- a/internal/team/headless_openai_compat_integration_test.go
+++ b/internal/team/headless_openai_compat_integration_test.go
@@ -123,7 +123,7 @@ func TestOpenAICompatBridge_E2E(t *testing.T) {
 		toolTimeout: 3 * time.Second,
 	}
 
-	final, iters, streamErr, err := loop.run(ctx, []agent.Message{
+	final, iters, _, streamErr, err := loop.run(ctx, []agent.Message{
 		{Role: "system", Content: "You're a helpful office agent."},
 		{Role: "user", Content: "Tell the team hi in #general."},
 	})

--- a/internal/team/headless_openai_compat_test.go
+++ b/internal/team/headless_openai_compat_test.go
@@ -168,7 +168,7 @@ func TestOpenAICompatToolLoop_OnToolResultFiresPerInvocation(t *testing.T) {
 			}
 		},
 	}
-	final, _, streamErr, err := loop.run(context.Background(),
+	final, _, _, streamErr, err := loop.run(context.Background(),
 		[]agent.Message{{Role: "user", Content: "x"}})
 	if err != nil || streamErr != "" {
 		t.Fatalf("unexpected: err=%v streamErr=%q", err, streamErr)
@@ -222,7 +222,7 @@ func TestOpenAICompatToolLoop_OnToolResultDoesNotFlipForReadOnlyTools(t *testing
 			}
 		},
 	}
-	final, _, _, _ := loop.run(context.Background(),
+	final, _, _, _, _ := loop.run(context.Background(),
 		[]agent.Message{{Role: "user", Content: "x"}})
 	if broadcasted {
 		t.Fatal("broadcastedThisTurn flipped for a read-only wiki tool — runner will silently drop the agent's reply")
@@ -266,7 +266,7 @@ func TestOpenAICompatToolLoop_OnToolResultErrorDoesNotFlipBroadcasted(t *testing
 			}
 		},
 	}
-	final, _, _, _ := loop.run(context.Background(),
+	final, _, _, _, _ := loop.run(context.Background(),
 		[]agent.Message{{Role: "user", Content: "x"}})
 	if broadcasted {
 		t.Error("broadcastedThisTurn flipped on tool error — user would see no reply at all")

--- a/internal/team/openai_compat_loop.go
+++ b/internal/team/openai_compat_loop.go
@@ -124,13 +124,28 @@ func (lp *openAICompatToolLoop) run(ctx context.Context, msgs []agent.Message) (
 					}
 					turnToolUses = append(turnToolUses, chunk)
 				case "usage":
-					// Sum across iterations: a tool-using turn streams
-					// the model multiple times and we want the full
-					// turn's footprint, not just the last iteration.
-					usage.InputTokens += chunk.InputTokens
+					// Output tokens are per-iteration (the tokens the
+					// model just generated this round), so summing
+					// across iterations gives the turn's total
+					// generation cost.
 					usage.OutputTokens += chunk.OutputTokens
 					usage.CacheReadTokens += chunk.CacheReadTokens
 					usage.CacheCreationTokens += chunk.CacheCreationTokens
+					// Input tokens are cumulative WITHIN each iteration
+					// (each request body includes the full prior
+					// conversation: system + user + asst_iter1 +
+					// tool_result_iter1 + ... + asst_iterN-1 +
+					// tool_result_iterN-1). Summing across iterations
+					// would double-count the system prompt N times for
+					// an N-iteration turn, making mlx-lm's panel totals
+					// 2-5× larger than equivalent Claude/Codex turns
+					// for no real reason. The last iteration's
+					// prompt_tokens is the turn's true input footprint.
+					// Use max() rather than overwrite so a server that
+					// emits a degenerate later frame can't shrink it.
+					if chunk.InputTokens > usage.InputTokens {
+						usage.InputTokens = chunk.InputTokens
+					}
 				case "error":
 					turnErr = chunk.Content
 					if lp.onError != nil {

--- a/internal/team/openai_compat_loop.go
+++ b/internal/team/openai_compat_loop.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/provider"
 )
 
 // openAICompatToolLoop is the broker-agnostic core of
@@ -50,17 +51,20 @@ type openAICompatToolLoop struct {
 //     Only the LAST iteration's text counts: the final iteration is the one
 //     that didn't fire any tools.
 //   - iterations: how many streaming turns ran. Useful for latency logs.
+//   - usage: summed token counts across every iteration this turn fired.
+//     Populated only for usage chunks the SSE parser surfaces; servers
+//     that don't honour stream_options.include_usage produce a zero value.
 //   - streamErr: a model-side or transport error reported via an "error"
 //     stream chunk. Returned as a string (not error) because it represents
 //     the model failing, not the loop itself; the caller decides whether
 //     to escalate.
 //   - err: a context cancellation or other Go-side error.
-func (lp *openAICompatToolLoop) run(ctx context.Context, msgs []agent.Message) (finalText string, iterations int, streamErr string, err error) {
+func (lp *openAICompatToolLoop) run(ctx context.Context, msgs []agent.Message) (finalText string, iterations int, usage provider.ClaudeUsage, streamErr string, err error) {
 	if lp.maxIters <= 0 {
-		return "", 0, "", fmt.Errorf("openAICompatToolLoop: maxIters must be > 0")
+		return "", 0, provider.ClaudeUsage{}, "", fmt.Errorf("openAICompatToolLoop: maxIters must be > 0")
 	}
 	if lp.toolTimeout <= 0 {
-		return "", 0, "", fmt.Errorf("openAICompatToolLoop: toolTimeout must be > 0")
+		return "", 0, provider.ClaudeUsage{}, "", fmt.Errorf("openAICompatToolLoop: toolTimeout must be > 0")
 	}
 
 	firstEventFired := false
@@ -85,7 +89,7 @@ func (lp *openAICompatToolLoop) run(ctx context.Context, msgs []agent.Message) (
 					for range ch {
 					}
 				}()
-				return "", iterations, "", ctx.Err()
+				return "", iterations, usage, "", ctx.Err()
 			case chunk, ok := <-ch:
 				if !ok {
 					break DRAIN
@@ -119,6 +123,14 @@ func (lp *openAICompatToolLoop) run(ctx context.Context, msgs []agent.Message) (
 						lp.onToolUse(chunk.ToolName, chunk.ToolInput)
 					}
 					turnToolUses = append(turnToolUses, chunk)
+				case "usage":
+					// Sum across iterations: a tool-using turn streams
+					// the model multiple times and we want the full
+					// turn's footprint, not just the last iteration.
+					usage.InputTokens += chunk.InputTokens
+					usage.OutputTokens += chunk.OutputTokens
+					usage.CacheReadTokens += chunk.CacheReadTokens
+					usage.CacheCreationTokens += chunk.CacheCreationTokens
 				case "error":
 					turnErr = chunk.Content
 					if lp.onError != nil {
@@ -129,7 +141,7 @@ func (lp *openAICompatToolLoop) run(ctx context.Context, msgs []agent.Message) (
 		}
 
 		if turnErr != "" {
-			return "", iterations, turnErr, nil
+			return "", iterations, usage, turnErr, nil
 		}
 
 		// The final reply is whichever iteration's text we last saw.
@@ -141,7 +153,7 @@ func (lp *openAICompatToolLoop) run(ctx context.Context, msgs []agent.Message) (
 		}
 
 		if len(turnToolUses) == 0 {
-			return finalText, iterations, "", nil
+			return finalText, iterations, usage, "", nil
 		}
 
 		// Encode the assistant's tool intent as a plain text turn so the
@@ -202,7 +214,7 @@ func (lp *openAICompatToolLoop) run(ctx context.Context, msgs []agent.Message) (
 	if finalText == "" {
 		finalText = fmt.Sprintf("(tool loop hit %d iterations without resolving — see latency log for details)", lp.maxIters)
 	}
-	return finalText, iterations, fmt.Sprintf("openai-compat: tool loop exceeded %d iterations without resolving", lp.maxIters), nil
+	return finalText, iterations, usage, fmt.Sprintf("openai-compat: tool loop exceeded %d iterations without resolving", lp.maxIters), nil
 }
 
 // encodeAssistantToolIntent serializes the model's tool intent as the

--- a/internal/team/openai_compat_loop_live_test.go
+++ b/internal/team/openai_compat_loop_live_test.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
@@ -71,7 +72,7 @@ func TestOpenAICompatToolLoop_LiveMLX(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
 
-	finalText, iters, streamErr, err := loop.run(ctx, []agent.Message{
+	finalText, iters, usage, streamErr, err := loop.run(ctx, []agent.Message{
 		{Role: "system", Content: "You have one tool, echo_phrase. The user wants you to call it once with the phrase 'unified-steele' and then summarize what came back in a short sentence."},
 		{Role: "user", Content: "Please call echo_phrase with phrase=\"unified-steele\" and tell me what it returned."},
 	})
@@ -84,11 +85,51 @@ func TestOpenAICompatToolLoop_LiveMLX(t *testing.T) {
 	if iters > 4 {
 		t.Errorf("iterations = %d; loop did not terminate quickly", iters)
 	}
-	t.Logf("live loop ok: iters=%d tool_calls=%d final=%q", iters, calls, finalText)
+	// stream_options.include_usage is set on every request, so a healthy
+	// mlx_lm.server (>= 0.20-ish) MUST surface non-zero usage. A zero here
+	// is the regression we shipped this PR to prevent: the issue #342
+	// symptom of "Opencode/local backends don't report usage".
+	if usage.InputTokens == 0 && usage.OutputTokens == 0 {
+		t.Errorf("usage = zero — server didn't emit a trailing usage frame, or the parser dropped it")
+	}
+	if usage.CostUSD != 0 {
+		t.Errorf("usage.CostUSD = %v, want 0 (local runs have no marginal $ cost)", usage.CostUSD)
+	}
+	t.Logf("live loop ok: iters=%d tool_calls=%d input_tokens=%d output_tokens=%d cost_usd=%.4f final=%q",
+		iters, calls, usage.InputTokens, usage.OutputTokens, usage.CostUSD, finalText)
 	// We don't insist the model called the tool — the test verifies the
 	// loop survives whichever choice the model makes. But if it called the
 	// tool, the result must echo "unified-steele".
 	if calls > 0 && !strings.Contains(strings.ToLower(finalText), "unified-steele") {
 		t.Logf("model called the tool but did not echo the phrase in final reply: %q", finalText)
+	}
+
+	// Final mile: feed the captured usage into a real Broker via the same
+	// RecordAgentUsage path the headless runner takes. This proves what
+	// the user-visible UsagePanel will show after a local-LLM turn:
+	// per-agent token counts populated, cost_usd stays at zero — which is
+	// the unambiguous "this run was local" signal.
+	b := newTestBroker(t)
+	b.RecordAgentUsage("local-llm-agent", "mlx-lm", usage)
+
+	b.mu.Lock()
+	snapshot := b.usage
+	b.mu.Unlock()
+	dump, _ := json.MarshalIndent(snapshot, "", "  ")
+	t.Logf("broker.usage after live mlx turn:\n%s", dump)
+
+	agentUsage, ok := snapshot.Agents["local-llm-agent"]
+	if !ok {
+		t.Fatal("broker did not record per-agent usage for local-llm-agent")
+	}
+	if agentUsage.InputTokens != usage.InputTokens || agentUsage.OutputTokens != usage.OutputTokens {
+		t.Errorf("broker per-agent usage = {input:%d output:%d}, want {%d, %d}",
+			agentUsage.InputTokens, agentUsage.OutputTokens, usage.InputTokens, usage.OutputTokens)
+	}
+	if agentUsage.CostUsd != 0 {
+		t.Errorf("broker per-agent cost_usd = %v, want 0 (local runs have no marginal $ cost)", agentUsage.CostUsd)
+	}
+	if agentUsage.Requests != 1 {
+		t.Errorf("broker per-agent requests = %d, want 1", agentUsage.Requests)
 	}
 }

--- a/internal/team/openai_compat_loop_test.go
+++ b/internal/team/openai_compat_loop_test.go
@@ -85,12 +85,19 @@ func TestOpenAICompatToolLoop_TextOnlyOneShot(t *testing.T) {
 	}
 }
 
-// TestOpenAICompatToolLoop_AccumulatesUsageAcrossIterations confirms that
-// when the SSE parser surfaces a usage chunk on each streaming turn, the
-// loop sums the totals into the final ClaudeUsage return — not just the
-// last turn's. This matters because a tool-using turn streams the model
-// multiple times (one per tool round-trip) and the user's usage panel
-// should reflect the whole turn's footprint.
+// TestOpenAICompatToolLoop_AccumulatesUsageAcrossIterations confirms the
+// loop's per-field accumulation policy:
+//   - OutputTokens SUMs across iterations (each iteration generates new
+//     tokens, so the turn cost is the sum).
+//   - InputTokens MAXes across iterations (each iteration's prompt is
+//     cumulative — it already contains every prior iteration's history —
+//     so summing would charge the system prompt N times for an N-
+//     iteration turn).
+//
+// In this scripted scenario iteration 1 sends 100 prompt tokens and
+// generates 20; iteration 2 sees the iter-1 history echoed back, so its
+// prompt grows to 150 (the larger value), while it generates a new 5.
+// Correct totals: {input:150, output:25} — NOT {input:250, output:25}.
 func TestOpenAICompatToolLoop_AccumulatesUsageAcrossIterations(t *testing.T) {
 	stream := &scriptedStreamFn{
 		turns: []scriptedTurn{
@@ -100,7 +107,7 @@ func TestOpenAICompatToolLoop_AccumulatesUsageAcrossIterations(t *testing.T) {
 			}},
 			{chunks: []agent.StreamChunk{
 				{Type: "text", Content: "done"},
-				{Type: "usage", InputTokens: 30, OutputTokens: 5},
+				{Type: "usage", InputTokens: 150, OutputTokens: 5},
 			}},
 		},
 	}
@@ -128,8 +135,8 @@ func TestOpenAICompatToolLoop_AccumulatesUsageAcrossIterations(t *testing.T) {
 	if final != "done" {
 		t.Errorf("finalText = %q, want %q", final, "done")
 	}
-	if usage.InputTokens != 130 || usage.OutputTokens != 25 {
-		t.Errorf("usage = {input:%d output:%d}, want {130, 25}", usage.InputTokens, usage.OutputTokens)
+	if usage.InputTokens != 150 || usage.OutputTokens != 25 {
+		t.Errorf("usage = {input:%d output:%d}, want {150, 25}", usage.InputTokens, usage.OutputTokens)
 	}
 }
 

--- a/internal/team/openai_compat_loop_test.go
+++ b/internal/team/openai_compat_loop_test.go
@@ -68,7 +68,7 @@ func TestOpenAICompatToolLoop_TextOnlyOneShot(t *testing.T) {
 		maxIters:    8,
 		toolTimeout: time.Second,
 	}
-	final, iters, streamErr, err := loop.run(context.Background(), []agent.Message{
+	final, iters, _, streamErr, err := loop.run(context.Background(), []agent.Message{
 		{Role: "user", Content: "say hi"},
 	})
 	if err != nil {
@@ -82,6 +82,78 @@ func TestOpenAICompatToolLoop_TextOnlyOneShot(t *testing.T) {
 	}
 	if final != "hello there." {
 		t.Errorf("finalText = %q, want %q", final, "hello there.")
+	}
+}
+
+// TestOpenAICompatToolLoop_AccumulatesUsageAcrossIterations confirms that
+// when the SSE parser surfaces a usage chunk on each streaming turn, the
+// loop sums the totals into the final ClaudeUsage return — not just the
+// last turn's. This matters because a tool-using turn streams the model
+// multiple times (one per tool round-trip) and the user's usage panel
+// should reflect the whole turn's footprint.
+func TestOpenAICompatToolLoop_AccumulatesUsageAcrossIterations(t *testing.T) {
+	stream := &scriptedStreamFn{
+		turns: []scriptedTurn{
+			{chunks: []agent.StreamChunk{
+				{Type: "tool_use", ToolName: "echo", ToolParams: map[string]any{"x": "1"}, ToolInput: `{"x":"1"}`},
+				{Type: "usage", InputTokens: 100, OutputTokens: 20},
+			}},
+			{chunks: []agent.StreamChunk{
+				{Type: "text", Content: "done"},
+				{Type: "usage", InputTokens: 30, OutputTokens: 5},
+			}},
+		},
+	}
+	tools := []agent.AgentTool{{
+		Name:    "echo",
+		Execute: func(_ map[string]any, _ context.Context, _ func(string)) (string, error) { return "ok", nil },
+	}}
+	loop := openAICompatToolLoop{
+		streamFn:    stream.fn(t),
+		tools:       tools,
+		toolByName:  map[string]agent.AgentTool{"echo": tools[0]},
+		maxIters:    4,
+		toolTimeout: time.Second,
+	}
+	final, iters, usage, streamErr, err := loop.run(context.Background(), []agent.Message{{Role: "user", Content: "go"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if streamErr != "" {
+		t.Fatalf("unexpected stream error: %s", streamErr)
+	}
+	if iters != 2 {
+		t.Errorf("iterations = %d, want 2", iters)
+	}
+	if final != "done" {
+		t.Errorf("finalText = %q, want %q", final, "done")
+	}
+	if usage.InputTokens != 130 || usage.OutputTokens != 25 {
+		t.Errorf("usage = {input:%d output:%d}, want {130, 25}", usage.InputTokens, usage.OutputTokens)
+	}
+}
+
+// TestOpenAICompatToolLoop_NoUsageStaysZero verifies that turns with no
+// usage chunks return a zero-valued ClaudeUsage so the headless runner can
+// gate its broker.RecordAgentUsage() call on input/output > 0 and avoid
+// recording empty rows when the server doesn't emit usage frames.
+func TestOpenAICompatToolLoop_NoUsageStaysZero(t *testing.T) {
+	stream := &scriptedStreamFn{
+		turns: []scriptedTurn{
+			{chunks: []agent.StreamChunk{{Type: "text", Content: "hi"}}},
+		},
+	}
+	loop := openAICompatToolLoop{
+		streamFn:    stream.fn(t),
+		maxIters:    4,
+		toolTimeout: time.Second,
+	}
+	_, _, usage, _, err := loop.run(context.Background(), []agent.Message{{Role: "user", Content: "go"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.InputTokens != 0 || usage.OutputTokens != 0 {
+		t.Errorf("usage = {input:%d output:%d}, want {0, 0}", usage.InputTokens, usage.OutputTokens)
 	}
 }
 
@@ -164,7 +236,7 @@ func TestOpenAICompatToolLoop_FullToolRoundTrip(t *testing.T) {
 		},
 	}
 
-	final, iters, streamErr, err := loop.run(context.Background(), []agent.Message{
+	final, iters, _, streamErr, err := loop.run(context.Background(), []agent.Message{
 		{Role: "user", Content: "What's the weather in Lisbon?"},
 	})
 	if err != nil {
@@ -224,7 +296,7 @@ func TestOpenAICompatToolLoop_UnknownToolDoesNotPanic(t *testing.T) {
 		maxIters:    4,
 		toolTimeout: time.Second,
 	}
-	final, _, streamErr, err := loop.run(context.Background(), []agent.Message{{Role: "user", Content: "do it"}})
+	final, _, _, streamErr, err := loop.run(context.Background(), []agent.Message{{Role: "user", Content: "do it"}})
 	if err != nil || streamErr != "" {
 		t.Fatalf("unexpected: err=%v streamErr=%q", err, streamErr)
 	}
@@ -268,7 +340,7 @@ func TestOpenAICompatToolLoop_ToolErrorPropagatesAsResult(t *testing.T) {
 		maxIters:    3,
 		toolTimeout: time.Second,
 	}
-	final, _, streamErr, err := loop.run(context.Background(), []agent.Message{{Role: "user", Content: "go"}})
+	final, _, _, streamErr, err := loop.run(context.Background(), []agent.Message{{Role: "user", Content: "go"}})
 	if err != nil || streamErr != "" {
 		t.Fatalf("unexpected: err=%v streamErr=%q", err, streamErr)
 	}
@@ -293,7 +365,7 @@ func TestOpenAICompatToolLoop_StreamErrorBreaksOut(t *testing.T) {
 		maxIters:    4,
 		toolTimeout: time.Second,
 	}
-	final, _, streamErr, err := loop.run(context.Background(), []agent.Message{{Role: "user", Content: "x"}})
+	final, _, _, streamErr, err := loop.run(context.Background(), []agent.Message{{Role: "user", Content: "x"}})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
@@ -329,7 +401,7 @@ func TestOpenAICompatToolLoop_MaxIterationsCap(t *testing.T) {
 		maxIters:    4,
 		toolTimeout: time.Second,
 	}
-	finalText, iters, streamErr, _ := loop.run(context.Background(), []agent.Message{{Role: "user", Content: "loop"}})
+	finalText, iters, _, streamErr, _ := loop.run(context.Background(), []agent.Message{{Role: "user", Content: "loop"}})
 	if iters != 4 {
 		t.Errorf("iterations = %d, want 4 (the cap)", iters)
 	}
@@ -398,7 +470,7 @@ func TestOpenAICompatToolLoop_BridgeDiesMidCallSurfacesAsToolError(t *testing.T)
 		maxIters:    4,
 		toolTimeout: time.Second,
 	}
-	final, _, streamErr, err := loop.run(context.Background(), []agent.Message{
+	final, _, _, streamErr, err := loop.run(context.Background(), []agent.Message{
 		{Role: "user", Content: "post hi to #general"},
 	})
 	if err != nil {
@@ -460,7 +532,7 @@ func TestOpenAICompatToolLoop_ContextCancelStopsImmediately(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before run
-	_, _, _, err := loop.run(ctx, []agent.Message{{Role: "user", Content: "x"}})
+	_, _, _, _, err := loop.run(ctx, []agent.Message{{Role: "user", Content: "x"}})
 	if err == nil {
 		t.Fatal("expected context.Canceled error")
 	}


### PR DESCRIPTION
## Summary
- mlx-lm / ollama / exo backends shipped in #329 didn't surface token usage to the broker, so the Settings `UsagePanel` showed zero for any local-LLM turn — same symptom as #342, but here it's a fixable plumbing gap (Opencode CLI usage is still upstream-blocked).
- Set `stream_options.include_usage=true` on every OpenAI-compatible request, parse the trailing usage frame, sum across tool-loop iterations, and call `broker.RecordAgentUsage` mirroring the Claude/Codex pattern.
- `CostUSD` stays at zero for local runs — that zero is the unambiguous "this turn was local" signal in the broker JSON, no extra flag needed.

## Test plan
- [x] `go test ./...` — 29 packages green
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] Live: `WUPHF_TEST_LIVE_MLX_LM=1 go test -v -run TestOpenAICompatToolLoop_LiveMLX ./internal/team/` against a real `mlx_lm.server` (Qwen2.5-Coder-32B-Instruct-4bit) — captured `iters=2 tool_calls=1 input_tokens=559 output_tokens=67 cost_usd=0`
- [x] Same test asserts the live usage round-trips through `Broker.RecordAgentUsage` and lands in `usage.Agents["local-llm-agent"]` with `cost_usd: 0`

## Out of scope
- Opencode CLI usage: `opencode run` emits unstructured stdout, so wuphf has nothing to parse. Needs either upstream structured output or a switch to OpenCode's HTTP API path.

## Closes
Partially closes #342 (local OpenAI-compatible backends only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token usage tracking and reporting for streaming operations. The system now captures and records detailed token consumption metrics, including input tokens, output tokens, and cache-related statistics, enabling better monitoring of resource utilization.

* **Tests**
  * Added comprehensive test coverage for token usage parsing, tracking, and aggregation across streaming iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->