### PR TITLE
fix(team): env-tunable opencode/codex turn timeouts

### DIFF
--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -71,10 +71,30 @@ func headlessCodexRunTurn(l *Launcher, ctx context.Context, slug, notification s
 	return defaultHeadlessCodexRunTurn(l, ctx, slug, notification, channel...)
 }
 
+// headlessCodexTurnTimeoutEnv reads a duration from env, falling back to the
+// supplied default when the var is unset, empty, non-positive, or unparseable.
+// Accepts any input time.ParseDuration accepts (e.g. "6m", "90s", "1h").
+//
+// The defaults below are intentionally tight (4m / 10m / 12m); operators
+// running slower providers (OpenRouter pooled queues, Kimi via Venice) or
+// tool-heavy turns may need to extend them. See
+// https://github.com/nex-crm/wuphf/issues/313.
+func headlessCodexTurnTimeoutEnv(name string, fallback time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return d
+}
+
 var (
-	headlessCodexTurnTimeout              = 4 * time.Minute
-	headlessCodexOfficeLaunchTurnTimeout  = 10 * time.Minute
-	headlessCodexLocalWorktreeTurnTimeout = 12 * time.Minute
+	headlessCodexTurnTimeout              = headlessCodexTurnTimeoutEnv("WUPHF_TURN_TIMEOUT", 4*time.Minute)
+	headlessCodexOfficeLaunchTurnTimeout  = headlessCodexTurnTimeoutEnv("WUPHF_OFFICE_LAUNCH_TIMEOUT", 10*time.Minute)
+	headlessCodexLocalWorktreeTurnTimeout = headlessCodexTurnTimeoutEnv("WUPHF_WORKTREE_TIMEOUT", 12*time.Minute)
 	headlessCodexStaleCancelAfter         = 90 * time.Second
 	// Minimum age an active turn must have before an enqueue can preempt
 	// it via stale-cancel. Floors out tight re-enqueue loops where two

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -2264,3 +2264,36 @@ func TestIsCodexAuthError(t *testing.T) {
 		}
 	}
 }
+
+func TestHeadlessCodexTurnTimeoutEnv(t *testing.T) {
+	const name = "WUPHF_TURN_TIMEOUT_TEST_ONLY"
+	fallback := 4 * time.Minute
+	cases := []struct {
+		label string
+		set   bool
+		val   string
+		want  time.Duration
+	}{
+		{label: "unset falls back", set: false, want: fallback},
+		{label: "empty falls back", set: true, val: "", want: fallback},
+		{label: "whitespace falls back", set: true, val: "   ", want: fallback},
+		{label: "garbage falls back", set: true, val: "not-a-duration", want: fallback},
+		{label: "zero falls back", set: true, val: "0s", want: fallback},
+		{label: "negative falls back", set: true, val: "-30s", want: fallback},
+		{label: "minutes parsed", set: true, val: "6m", want: 6 * time.Minute},
+		{label: "seconds parsed", set: true, val: "90s", want: 90 * time.Second},
+		{label: "hours parsed", set: true, val: "1h", want: time.Hour},
+	}
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			if c.set {
+				t.Setenv(name, c.val)
+			} else {
+				os.Unsetenv(name)
+			}
+			if got := headlessCodexTurnTimeoutEnv(name, fallback); got != c.want {
+				t.Fatalf("headlessCodexTurnTimeoutEnv(%q=%q) = %s, want %s", name, c.val, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `WUPHF_TURN_TIMEOUT`, `WUPHF_OFFICE_LAUNCH_TIMEOUT`, `WUPHF_WORKTREE_TIMEOUT` env overrides for the three hardcoded headless-turn timeouts in `internal/team/headless_codex.go`.
- Defaults preserved (4m / 10m / 12m). The reader falls back when the var is unset, empty, non-positive, or unparseable.
- `var` shape preserved so existing test mutation paths (`headlessCodexTurnTimeout = 5 * time.Second` in tests) keep working.

Addresses **Finding 2** of #313. Operators on slow providers (OpenRouter pooled queues, Kimi via Venice, tool-heavy turns) currently hit a 4-minute SIGKILL with no recourse — this gives them an escape hatch while Findings 1 and 3 are in flight.

## Test plan
- [x] `go test ./internal/team/ -run TestHeadlessCodexTurnTimeoutEnv` (new table test covers unset / empty / whitespace / garbage / zero / negative / valid values)
- [x] `go test ./internal/team/ -run "TestHeadlessCodexTurnTimeoutFor|TestRecoverTimedOut"` (existing timeout tests unchanged)
- [x] go vet, gofmt, golangci-lint via lefthook pre-commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced environment variable support for timeout configuration, enabling operational flexibility to customize timeout values without code modifications.

* **Tests**
  * Added comprehensive test coverage validating timeout configuration parsing behavior, including fallback handling for missing, invalid, and edge-case inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->