### PR TITLE
fix(team): surface opencode base config parse errors in agent log

### DIFF
--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -316,9 +316,15 @@ func (l *Launcher) writeHeadlessOpencodeMCPConfig(slug string) (string, error) {
 
 	merged := map[string]any{}
 	if raw, err := os.ReadFile(baseConfigPath); err == nil && len(raw) > 0 {
-		// Best-effort: if the existing file isn't valid JSON, overwrite it
-		// rather than silently losing the WUPHF overlay.
-		_ = json.Unmarshal(raw, &merged)
+		// Best-effort: if the existing file isn't valid JSON, fall back to
+		// writing a minimal overlay so wuphf keeps booting — but surface the
+		// parse error in the agent log so the operator can see they have a
+		// malformed base config silently dropping their `model`/`provider`
+		// blocks from every per-agent merge. (#313 bonus #1)
+		if uerr := json.Unmarshal(raw, &merged); uerr != nil {
+			merged = map[string]any{}
+			appendHeadlessCodexLog(slug, fmt.Sprintf("opencode_base-config-parse-failed: %s: %s — per-agent config will not inherit user model/provider/MCP keys until this is fixed", baseConfigPath, uerr.Error()))
+		}
 	}
 
 	mcp, _ := merged["mcp"].(map[string]any)

--- a/internal/team/headless_opencode_test.go
+++ b/internal/team/headless_opencode_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -104,5 +105,49 @@ func TestWriteHeadlessOpencodeMCPConfigConcurrent(t *testing.T) {
 		if env["WUPHF_AGENT_SLUG"] != slug {
 			t.Fatalf("%s config has WUPHF_AGENT_SLUG=%#v", slug, env["WUPHF_AGENT_SLUG"])
 		}
+	}
+}
+
+// TestWriteHeadlessOpencodeMCPConfigLogsBaseConfigParseFailure verifies that a
+// malformed base ~/.config/opencode/opencode.json (e.g. trailing comma) causes
+// writeHeadlessOpencodeMCPConfig to surface the parse error via the agent
+// log instead of silently dropping the user's `model`/`provider` blocks. (#313)
+func TestWriteHeadlessOpencodeMCPConfigLogsBaseConfigParseFailure(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	logDir := t.TempDir()
+	t.Setenv("WUPHF_LOG_DIR", logDir)
+
+	configDir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Trailing comma — valid Opencode-side JSON5 in some hand-edited configs,
+	// but encoding/json rejects it. The legacy code silently swallowed this.
+	malformed := `{"theme":"dark","model":"openrouter/foo",}`
+	configPath := filepath.Join(configDir, "opencode.json")
+	if err := os.WriteFile(configPath, []byte(malformed), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := headlessOpencodeExecutablePath
+	headlessOpencodeExecutablePath = func() (string, error) { return "/usr/local/bin/wuphf", nil }
+	defer func() { headlessOpencodeExecutablePath = orig }()
+
+	l := &Launcher{}
+	if _, err := l.writeHeadlessOpencodeMCPConfig("ceo"); err != nil {
+		t.Fatalf("writeHeadlessOpencodeMCPConfig: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(filepath.Join(logDir, "headless-codex-ceo.log"))
+	if err != nil {
+		t.Fatalf("read agent log: %v", err)
+	}
+	logStr := string(logBytes)
+	if !strings.Contains(logStr, "opencode_base-config-parse-failed") {
+		t.Fatalf("expected opencode_base-config-parse-failed in agent log, got:\n%s", logStr)
+	}
+	if !strings.Contains(logStr, configPath) {
+		t.Fatalf("expected base config path %q in agent log, got:\n%s", configPath, logStr)
 	}
 }


### PR DESCRIPTION
## Summary
- `writeHeadlessOpencodeMCPConfig` silently swallowed `json.Unmarshal` errors on `~/.config/opencode/opencode.json`. A single trailing comma caused the merge to start from an empty map — dropping the user's `model`/`provider` blocks from every per-agent config without a trace.
- Keep the best-effort write so wuphf still boots, but log the parse failure (path + specific JSON error) via `appendHeadlessCodexLog`, so the operator has a thread to pull on.

Addresses **Bonus #1** of #313.

## Test plan
- [x] `go test ./internal/team/ -run TestWriteHeadlessOpencodeMCPConfig` (existing concurrent test + new parse-failure test, both pass)
- [x] go vet, gofmt, golangci-lint via lefthook pre-commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for configuration file parsing. When a configuration file fails to parse, diagnostic error logs are now generated with failure details, replacing the previous silent handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->