### PR TITLE
fix(team): eliminate headless goroutine leak + close shutdown race

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  timeout: 5m
+  timeout: 10m
   tests: true
 issues:
   max-issues-per-linter: 0

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -556,6 +556,10 @@ type Broker struct {
 	lastAgentRateLimitPrune time.Time
 	agentLogRoot            string // override for tests; empty means agent.DefaultTaskLogRoot()
 
+	// nowFn is the clock used by rate-limit logic. nil means time.Now.
+	// Inject a fake clock in tests to avoid real-time sleeps.
+	nowFn func() time.Time
+
 	stopCh   chan struct{} // closed by Stop(); signals background goroutines to exit
 	stopOnce sync.Once
 
@@ -1789,6 +1793,15 @@ func writeRateLimitedResponse(w http.ResponseWriter, retryAfter time.Duration) {
 	_, _ = io.WriteString(w, `{"error":"rate_limited"}`)
 }
 
+// rateLimitNow returns the current time for rate-limit calculations.
+// Tests may override b.nowFn to advance a synthetic clock without sleeping.
+func (b *Broker) rateLimitNow() time.Time {
+	if b.nowFn != nil {
+		return b.nowFn()
+	}
+	return time.Now()
+}
+
 func (b *Broker) consumeRateLimit(clientIP string) (time.Duration, bool) {
 	limit := b.rateLimitRequests
 	if limit <= 0 {
@@ -1799,7 +1812,7 @@ func (b *Broker) consumeRateLimit(clientIP string) (time.Duration, bool) {
 		window = defaultRateLimitWindow
 	}
 
-	now := time.Now()
+	now := b.rateLimitNow()
 	key := rateLimitKey(clientIP)
 	cutoff := now.Add(-window)
 
@@ -1856,7 +1869,7 @@ func (b *Broker) consumeAgentRateLimit(agentSlug string) (time.Duration, bool) {
 		window = defaultAgentRateLimitWindow
 	}
 
-	now := time.Now()
+	now := b.rateLimitNow()
 	cutoff := now.Add(-window)
 
 	b.mu.Lock()

--- a/internal/team/broker_state_path_test.go
+++ b/internal/team/broker_state_path_test.go
@@ -103,7 +103,7 @@ func TestNewBroker_SkipStateLoadGateRespected(t *testing.T) {
 	// tests opt back into disk load via reloadedBroker(t, b). Track A
 	// must preserve this contract: a test-mode constructor must NOT
 	// auto-load.
-	statePath := leakedBrokerStatePath(t)
+	statePath := filepath.Join(t.TempDir(), "broker-state.json")
 
 	// Seed disk with a distinctive message. If the gate is broken,
 	// NewBrokerAt() will pick it up.
@@ -224,7 +224,7 @@ func TestBrokerStop_ClosesStopChannelAndPreservesState(t *testing.T) {
 	// Starts the broker via StartOnPort(0) so the HTTP listener
 	// goroutine is actually present — without that, Stop is a near-noop
 	// and the test wouldn't exercise the drain path at all.
-	statePath := leakedBrokerStatePath(t)
+	statePath := filepath.Join(t.TempDir(), "broker-state.json")
 	b := NewBrokerAt(statePath)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("StartOnPort: %v", err)

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -51,27 +51,23 @@ func TestMain(m *testing.M) {
 	brokerTokenFilePath = filepath.Join(dir, "broker-token")
 	cleanups = append(cleanups, func() { _ = os.RemoveAll(dir) })
 
-	// 2) Headless log dir: leaked headless-worker goroutines open append
-	//    files under wuphfLogDir(). WUPHF_LOG_DIR is the env hook; honored
-	//    by wuphfLogDir() in headless_codex.go. Append-only writes are
-	//    safe to share across tests (nothing reads them). Fail fast on
-	//    mktemp error for the same reason as above — and run any cleanups
-	//    already registered so the token dir doesn't leak on the error path.
+	// 2) Headless log dir: pin headless-worker log writes to a process-
+	//    stable temp dir so they don't pollute the real ~/.wuphf/logs and
+	//    so per-test t.TempDir cleanups don't race appender writes. Set
+	//    via the in-process wuphfLogDirOverride hook (the WUPHF_LOG_DIR
+	//    env var was retired — env leaks into spawned codex/claude
+	//    subprocesses, which is not what tests want).
 	logDir, err := os.MkdirTemp("", "wuphf-team-test-logs-*")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "TestMain: mktemp headless log dir: %v\n", err)
 		cleanup()
 		os.Exit(1)
 	}
-	if err := os.Setenv("WUPHF_LOG_DIR", logDir); err != nil {
-		// Silent fallback to the default log dir would reintroduce the
-		// cross-test cleanup race this setup exists to prevent.
-		fmt.Fprintf(os.Stderr, "TestMain: setenv WUPHF_LOG_DIR: %v\n", err)
+	wuphfLogDirOverride.Store(&logDir)
+	cleanups = append(cleanups, func() {
+		wuphfLogDirOverride.Store(nil)
 		_ = os.RemoveAll(logDir)
-		cleanup()
-		os.Exit(1)
-	}
-	cleanups = append(cleanups, func() { _ = os.RemoveAll(logDir) })
+	})
 
 	// 3) Stale-unanswered threshold: resume tests pre-seed broker state with
 	//    ancient timestamps (e.g. "2026-04-14T10:00:00Z") to exercise routing
@@ -110,21 +106,14 @@ func reloadedBroker(t *testing.T, b *Broker) *Broker {
 	return fresh
 }
 
-// leakedBrokerStatePath returns a per-test-unique filesystem path for a
-// broker-state.json, rooted in a temp dir OUTSIDE t.TempDir(). Callers
-// pass it to NewBrokerAt so late-arriving writes from goroutines leaked
-// by prior tests don't race t.TempDir cleanup with "unlinkat: directory
-// not empty". The returned dir is intentionally NOT registered for
-// cleanup: a handful of KB per test run leaks to /tmp, which the OS
-// reclaims on reboot or tmpfs eviction. Cheap fix for a cross-test
-// goroutine-leak hazard that a larger refactor will eventually retire.
-func leakedBrokerStatePath(t *testing.T) string {
+// waitForHeadlessIdle is a test-only join point: it stops every headless
+// worker spawned through the Launcher and blocks until each goroutine has
+// exited. Register it via t.Cleanup so no headless worker outlives the test
+// that started it (which would race t.TempDir cleanup with "unlinkat:
+// directory not empty"). Idempotent — safe to call multiple times.
+func (l *Launcher) waitForHeadlessIdle(t *testing.T) {
 	t.Helper()
-	dir, err := os.MkdirTemp("", "wuphf-test-state-*")
-	if err != nil {
-		t.Fatalf("mktemp broker state dir: %v", err)
-	}
-	return filepath.Join(dir, "broker-state.json")
+	l.stopHeadlessWorkers()
 }
 
 // setHeadlessWakeLeadFn swaps headlessWakeLeadFn under its mutex and restores
@@ -6279,8 +6268,8 @@ func TestHeadlessQueue_PopulatedAfterEnqueue(t *testing.T) {
 		headlessActive:  make(map[string]*headlessCodexActiveTurn),
 		headlessQueues:  make(map[string][]headlessCodexTurn),
 	}
-	l.headlessCtx, l.headlessCancel = context.WithCancel(context.Background())
-	defer l.headlessCancel()
+	l.headlessCtx, l.headlessCancel = context.WithCancel(t.Context())
+	t.Cleanup(func() { l.waitForHeadlessIdle(t) })
 
 	l.enqueueHeadlessCodexTurn("eng", "review the diff")
 

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -64,10 +64,12 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 	wuphfLogDirOverride.Store(&logDir)
-	cleanups = append(cleanups, func() {
-		wuphfLogDirOverride.Store(nil)
-		_ = os.RemoveAll(logDir)
-	})
+	// Intentionally do NOT clear wuphfLogDirOverride on cleanup: the process
+	// is about to exit and any goroutine that escaped a test's lifecycle
+	// (race-detector edge cases, headless workers caught mid-flush) should
+	// keep writing into the isolated temp dir, never the real ~/.wuphf/logs.
+	// The dir removal below makes those writes a no-op rather than pollution.
+	cleanups = append(cleanups, func() { _ = os.RemoveAll(logDir) })
 
 	// 3) Stale-unanswered threshold: resume tests pre-seed broker state with
 	//    ancient timestamps (e.g. "2026-04-14T10:00:00Z") to exercise routing
@@ -4597,7 +4599,7 @@ func TestBrokerGetRequestsScopeAllSeesCrossChannelBlocker(t *testing.T) {
 }
 
 func TestBrokerCancelBlockingApprovalUnblocksMessages(t *testing.T) {
-	b := NewBrokerAt(leakedBrokerStatePath(t))
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}
@@ -4686,7 +4688,7 @@ func TestBrokerCancelBlockingApprovalUnblocksMessages(t *testing.T) {
 }
 
 func TestBrokerHumanInterviewDoesNotBlockAndCancelsOnHumanMessage(t *testing.T) {
-	b := NewBrokerAt(leakedBrokerStatePath(t))
+	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
 		t.Fatalf("failed to start broker: %v", err)
 	}

--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -1166,7 +1166,14 @@ func TestBrokerAuthRejectsUnauthenticated(t *testing.T) {
 func TestBrokerRateLimitsRequestsPerIP(t *testing.T) {
 	b := newTestBroker(t)
 	b.rateLimitRequests = 100
-	b.rateLimitWindow = 1100 * time.Millisecond
+	b.rateLimitWindow = time.Second
+
+	// Synthetic clock: starts at a fixed point; advance() jumps it past the window
+	// so the test never sleeps for real.
+	fakeClock := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	b.nowFn = func() time.Time { return fakeClock }
+	advance := func(d time.Duration) { fakeClock = fakeClock.Add(d) }
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/messages", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -1205,7 +1212,8 @@ func TestBrokerRateLimitsRequestsPerIP(t *testing.T) {
 		t.Fatalf("expected sane Retry-After seconds, got %q", retryAfter)
 	}
 
-	time.Sleep(b.rateLimitWindow + 50*time.Millisecond)
+	// Advance the synthetic clock past the window — no real sleep needed.
+	advance(b.rateLimitWindow + time.Millisecond)
 
 	resp = doRequest("")
 	resp.Body.Close()

--- a/internal/team/headless_claude_test.go
+++ b/internal/team/headless_claude_test.go
@@ -144,7 +144,7 @@ func TestRunHeadlessClaudeTurn_NoResumeFlag(t *testing.T) {
 
 	// The function returns a parse error because /bin/true produces no JSON.
 	// That is expected; we only care about capturedArgs.
-	_ = l.runHeadlessClaudeTurn(context.Background(), "eng", "do the thing")
+	_ = l.runHeadlessClaudeTurn(t.Context(), "eng", "do the thing")
 
 	if len(capturedArgs) == 0 {
 		t.Fatal("no args captured; headlessClaudeCommandContext hook was not called")

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -1620,22 +1620,23 @@ func buildHeadlessCodexPrompt(systemPrompt string, prompt string) string {
 	return strings.Join(parts, "\n\n")
 }
 
+// wuphfLogDirOverride is a test hook for redirecting headless log writes to
+// an isolated path. Stored as atomic.Pointer so reads on the headless write
+// path don't take a lock; nil in production. Tests set this via TestMain so
+// log files don't pollute the user's real ~/.wuphf/logs while the suite
+// runs. The previous WUPHF_LOG_DIR environment variable was retired in
+// favour of this in-process hook — env vars leak into spawned codex/claude
+// subprocesses, which is not what tests want.
+var wuphfLogDirOverride atomic.Pointer[string]
+
 func wuphfLogDir() string {
-	// WUPHF_LOG_DIR lets tests redirect headless log writes to a
-	// process-stable path. Headless-worker goroutines routinely outlive the
-	// test that started them; if they wrote to the test's t.TempDir() they
-	// would race with go's test-scoped RemoveAll ("directory not empty" on
-	// unlinkat). Tests set this to a package-owned leaked dir so writes
-	// from leaked goroutines land harmlessly. Unset in production → HOME.
-	if override := strings.TrimSpace(os.Getenv("WUPHF_LOG_DIR")); override != "" {
-		// Fail loudly on a broken override instead of silently falling
-		// through — a misconfigured WUPHF_LOG_DIR path otherwise surfaces
-		// as confusing "file open failed" errors far from the root cause.
-		// Returning "" disables headless logging for this call (the
-		// appendHeadless*Log helpers no-op on empty dir), which matches
-		// the HOME-lookup graceful-degradation path below.
+	if p := wuphfLogDirOverride.Load(); p != nil {
+		override := strings.TrimSpace(*p)
+		if override == "" {
+			return ""
+		}
 		if err := os.MkdirAll(override, 0o700); err != nil {
-			fmt.Fprintf(os.Stderr, "wuphf: WUPHF_LOG_DIR=%q unwritable: %v — headless logging disabled\n", override, err)
+			fmt.Fprintf(os.Stderr, "wuphf: log dir override %q unwritable: %v — headless logging disabled\n", override, err)
 			return ""
 		}
 		return override

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -406,16 +406,23 @@ func (l *Launcher) stopHeadlessWorkers() {
 		close(l.headlessStopCh)
 	}
 	cancel := l.headlessCancel
+	// Collect per-turn cancels so we can fire them outside the lock.
+	// Needed when l.headlessCtx is nil (bare &Launcher{} in tests): in that
+	// case turnCtx is derived from context.Background() and canceling
+	// l.headlessCancel is a no-op, so the only way to unblock an in-flight
+	// turn is to cancel its own context directly.
+	var turnCancels []context.CancelFunc
+	for _, active := range l.headlessActive {
+		if active != nil && active.Cancel != nil {
+			turnCancels = append(turnCancels, active.Cancel)
+		}
+	}
 	l.headlessMu.Unlock()
-	// Cancel any in-flight turn so the worker doesn't sit inside
-	// headlessCodexRunTurn for the full per-turn timeout (minutes) before
-	// noticing stopHeadlessCh closed at the outer-loop tick. Without this,
-	// production-shape paths with a real provider would hang Wait() until
-	// the turn ctx times out. Tests using the headlessCodexRunTurn override
-	// already return fast, so the bug only bites when the override is the
-	// real call path — but the cost of guarding here is one nil-check.
 	if cancel != nil {
 		cancel()
+	}
+	for _, c := range turnCancels {
+		c()
 	}
 	l.headlessWorkerWg.Wait()
 }
@@ -1038,6 +1045,19 @@ func (l *Launcher) timedOutTurnAlreadyRecovered(task *teamTask, slug string, sta
 func (l *Launcher) beginHeadlessCodexTurn(slug string) (headlessCodexTurn, context.Context, time.Time, time.Duration, bool) {
 	l.headlessMu.Lock()
 	defer l.headlessMu.Unlock()
+
+	// If stopHeadlessWorkers already fired, don't start a new turn. This closes
+	// the race where a worker goroutine passed the outer stop-channel check
+	// just before stopHeadlessWorkers closed headlessStopCh, causing the worker
+	// to block in headlessCodexRunTurn with no cancel registered in headlessActive.
+	if l.headlessStopCh != nil {
+		select {
+		case <-l.headlessStopCh:
+			delete(l.headlessWorkers, slug)
+			return headlessCodexTurn{}, nil, time.Time{}, 0, false
+		default:
+		}
+	}
 
 	queue := l.headlessQueues[slug]
 	if len(queue) == 0 {

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -164,10 +164,10 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 		pack:        agent.GetPack("founding-team"),
 		cwd:         t.TempDir(),
 		broker:      newTestBroker(t),
-		headlessCtx: context.Background(),
+		headlessCtx: t.Context(),
 	}
 
-	if err := l.runHeadlessCodexTurn(context.Background(), "ceo", "You have new work in #launch."); err != nil {
+	if err := l.runHeadlessCodexTurn(t.Context(), "ceo", "You have new work in #launch."); err != nil {
 		t.Fatalf("runHeadlessCodexTurn: %v", err)
 	}
 
@@ -320,10 +320,10 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForCodingAgents(t *testing.T) {
 		pack:        agent.GetPack("founding-team"),
 		cwd:         repoRoot,
 		broker:      broker,
-		headlessCtx: context.Background(),
+		headlessCtx: t.Context(),
 	}
 
-	if err := l.runHeadlessCodexTurn(context.Background(), "eng", "Ship the automation runtime."); err != nil {
+	if err := l.runHeadlessCodexTurn(t.Context(), "eng", "Ship the automation runtime."); err != nil {
 		t.Fatalf("runHeadlessCodexTurn: %v", err)
 	}
 
@@ -436,10 +436,10 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForLocalWorktreeBuilder(t *test
 		pack:        agent.GetPack("founding-team"),
 		cwd:         repoRoot,
 		broker:      broker,
-		headlessCtx: context.Background(),
+		headlessCtx: t.Context(),
 	}
 
-	if err := l.runHeadlessCodexTurn(context.Background(), "builder", "Ship the intake packet."); err != nil {
+	if err := l.runHeadlessCodexTurn(t.Context(), "builder", "Ship the intake packet."); err != nil {
 		t.Fatalf("runHeadlessCodexTurn: %v", err)
 	}
 
@@ -494,10 +494,10 @@ func TestRunHeadlessCodexTurnPassesScopedChannelEnv(t *testing.T) {
 		pack:        agent.GetPack("founding-team"),
 		cwd:         t.TempDir(),
 		broker:      newTestBroker(t),
-		headlessCtx: context.Background(),
+		headlessCtx: t.Context(),
 	}
 
-	if err := l.runHeadlessCodexTurn(context.Background(), "eng", "Work the owned task.", "youtube-factory"); err != nil {
+	if err := l.runHeadlessCodexTurn(t.Context(), "eng", "Work the owned task.", "youtube-factory"); err != nil {
 		t.Fatalf("runHeadlessCodexTurn: %v", err)
 	}
 
@@ -860,7 +860,7 @@ func canonicalPath(path string) string {
 func newHeadlessLauncherForTest(t *testing.T) *Launcher {
 	t.Helper()
 	l := &Launcher{
-		headlessCtx:     context.Background(),
+		headlessCtx:     t.Context(),
 		headlessWorkers: make(map[string]bool),
 		headlessActive:  make(map[string]*headlessCodexActiveTurn),
 		headlessQueues:  make(map[string][]headlessCodexTurn),
@@ -881,7 +881,7 @@ func newHeadlessLauncherForTest(t *testing.T) *Launcher {
 	// CI's `-race` carve-out for internal/team. Convert those tests'
 	// `defer restore()` to `t.Cleanup(restore)` to fix the residual
 	// race; not done here to keep this PR scoped.
-	t.Cleanup(l.stopHeadlessWorkers)
+	t.Cleanup(func() { l.waitForHeadlessIdle(t) })
 	return l
 }
 
@@ -1653,12 +1653,9 @@ func TestHeadlessTurnCompletedDurablyRejectsCodingTurnWithoutTaskStateOrEvidence
 	})
 
 	// Build the task state directly instead of going through
-	// EnsurePlannedTask so we never call saveLocked — broker save
-	// goroutines spawned by this test can outlive t.TempDir cleanup and
-	// race the rename .tmp -> final step (same root cause as
-	// leakedBrokerStatePath in launcher_test.go). We don't need persistence
-	// here; we only need the task fields that headlessTurnCompletedDurably
-	// reads.
+	// EnsurePlannedTask so we never call saveLocked — we don't need
+	// persistence here; we only need the task fields that
+	// headlessTurnCompletedDurably reads.
 	b := newTestBroker(t)
 	b.mu.Lock()
 	b.tasks = []teamTask{{

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -2466,13 +2466,7 @@ func TestProcessDueTaskJobResumesRateLimitedBlockedTask(t *testing.T) {
 }
 
 func TestOfficeChangeTaskNotificationsBackfillGeneratedMemberTask(t *testing.T) {
-	// Pin the broker's state file outside t.TempDir(). Goroutines leaked
-	// by prior tests in this package may still be saving via a Broker
-	// whose statePath was captured at construction; targeting a leaked
-	// OS-temp dir prevents races with t.TempDir cleanup ("unlinkat:
-	// directory not empty"). Leaking a few KB in /tmp is the cheap fix;
-	// proper goroutine hygiene across the suite is a separate refactor.
-	b := NewBrokerAt(leakedBrokerStatePath(t))
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO"},
@@ -2526,9 +2520,7 @@ func TestOfficeChangeTaskNotificationsBackfillGeneratedMemberTask(t *testing.T) 
 }
 
 func TestOfficeChangeTaskNotificationsBackfillChannelMembershipTask(t *testing.T) {
-	// See TestOfficeChangeTaskNotificationsBackfillGeneratedMemberTask for
-	// why this test uses a leaked state dir instead of t.TempDir().
-	b := NewBrokerAt(leakedBrokerStatePath(t))
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO"},

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -2418,7 +2418,7 @@ done:
 }
 
 func TestProcessDueTaskJobResumesRateLimitedBlockedTask(t *testing.T) {
-	b := NewBrokerAt(leakedBrokerStatePath(t))
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO"},

--- a/internal/team/mention_routing_bug_test.go
+++ b/internal/team/mention_routing_bug_test.go
@@ -221,20 +221,6 @@ func TestBug_CEOTagsSpecialist_Dispatch_SpecialistReceivesTurn(t *testing.T) {
 // Scenario 3 (dispatch): human DMs fe. fe MUST receive a headless turn and
 // CEO must not.
 func TestBug_HumanDMsSpecialist_Dispatch_SpecialistReceivesTurn(t *testing.T) {
-	// Pre-existing cross-test pollution: earlier tests in the package can
-	// leak `runHeadlessCodexQueue` goroutines that outlive their Launcher.
-	// When this test replaces headlessCodexRunTurn with its own stub, a
-	// leaked goroutine fetches the new pointer on its next iteration and
-	// its `headlessCodexRunTurn(..., "ceo", ...)` call pushes into this
-	// test's `processed` channel — the observed "[fe ceo]" leak. The two
-	// adjacent scenarios (tag + CEO-tag) pass in the same suite because
-	// their stubs filter by the target slug. Skipping here rather than
-	// muting the alarm: fixing the leak needs a Launcher.Stop() teardown
-	// that this session does not scope.
-	// Tracked in nex-crm/wuphf#268 — un-skip once Launcher.Stop() drains
-	// headless worker goroutines so this test no longer inherits a leaked
-	// runHeadlessCodexQueue writer from an earlier test.
-	t.Skip("known flake: leaked headlessCodex queue goroutine from earlier test — see nex-crm/wuphf#268")
 	l, processed, cleanup := fullDispatchLauncher(t)
 	defer cleanup()
 

--- a/internal/team/resume_test.go
+++ b/internal/team/resume_test.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"context"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -529,6 +530,13 @@ func TestResumeInFlightWorkHeadlessEnqueuesLeadEvenWhenSpecialistsPresent(t *tes
 	}
 	b.mu.Unlock()
 
+	// Stub the per-turn runner so spawned workers don't shell out to a real
+	// codex binary while the test asserts queue state.
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, ctx context.Context, _, _ string, _ ...string) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
 	l := &Launcher{
 		provider: "codex", // headless path
 		broker:   b,
@@ -633,6 +641,12 @@ func TestBuildResumePacketSpecSectionMessagesLabel(t *testing.T) {
 // failed. Users restarting `wuphf --tui` with in-flight work lost resumption.
 func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
+	// Stub the per-turn runner so spawned workers don't shell out to a real
+	// codex binary while the test asserts queue state.
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, ctx context.Context, _, _ string, _ ...string) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
 
 	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
 	b.mu.Lock()
@@ -682,6 +696,12 @@ func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
 
 func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
+	// Stub the per-turn runner so spawned workers don't shell out to a real
+	// codex binary while the test asserts queue state.
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, ctx context.Context, _, _ string, _ ...string) error {
+		<-ctx.Done()
+		return ctx.Err()
+	})
 
 	var paneNotifications []string
 	setLauncherSendNotificationToPaneForTest(t, func(_ *Launcher, paneTarget, notification string) {

--- a/internal/team/resume_test.go
+++ b/internal/team/resume_test.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -543,6 +544,7 @@ func TestResumeInFlightWorkHeadlessEnqueuesLeadEvenWhenSpecialistsPresent(t *tes
 		headlessActive:  make(map[string]*headlessCodexActiveTurn),
 		headlessQueues:  make(map[string][]headlessCodexTurn),
 	}
+	t.Cleanup(func() { l.waitForHeadlessIdle(t) })
 
 	l.resumeInFlightWork()
 
@@ -630,12 +632,9 @@ func TestBuildResumePacketSpecSectionMessagesLabel(t *testing.T) {
 // verifying they exist, and the resulting tmux send-keys commands silently
 // failed. Users restarting `wuphf --tui` with in-flight work lost resumption.
 func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
-	// Leaked path (not t.TempDir) so a headless worker goroutine that
-	// outlives the test can keep writing without racing the dir cleanup
-	// and failing the test with an `unlinkat ... directory not empty`.
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
 
-	b := NewBrokerAt(leakedBrokerStatePath(t))
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
 	b.mu.Lock()
 	b.tasks = []teamTask{
 		{ID: "t1", Title: "Build login form", Owner: "fe", Status: "in_progress"},
@@ -663,6 +662,7 @@ func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
 		headlessActive:  make(map[string]*headlessCodexActiveTurn),
 		headlessQueues:  make(map[string][]headlessCodexTurn),
 	}
+	t.Cleanup(func() { l.waitForHeadlessIdle(t) })
 
 	l.resumeInFlightWork()
 
@@ -681,9 +681,6 @@ func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
 }
 
 func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
-	// Leaked path (not t.TempDir) so a headless worker goroutine that
-	// outlives the test can keep writing without racing the dir cleanup
-	// and failing the test with an `unlinkat ... directory not empty`.
 	setHeadlessWakeLeadFn(t, func(_ *Launcher, _ string) {})
 
 	var paneNotifications []string
@@ -691,7 +688,7 @@ func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 		paneNotifications = append(paneNotifications, paneTarget+"\n"+notification)
 	})
 
-	b := NewBrokerAt(leakedBrokerStatePath(t))
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO", Provider: provider.ProviderBinding{Kind: provider.KindClaudeCode}},
@@ -725,6 +722,7 @@ func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 		headlessActive: make(map[string]*headlessCodexActiveTurn),
 		headlessQueues: make(map[string][]headlessCodexTurn),
 	}
+	t.Cleanup(func() { l.waitForHeadlessIdle(t) })
 
 	l.resumeInFlightWork()
 

--- a/internal/team/skill_crud_endpoints_test.go
+++ b/internal/team/skill_crud_endpoints_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -330,7 +331,7 @@ func TestSkillPatchEndpoint_FindReplace(t *testing.T) {
 // would revert the skill to the stale status.
 func TestSkillArchiveStatusSurvivesRestart(t *testing.T) {
 	// Use a named temp dir so the state path is in scope for both brokers.
-	statePath := leakedBrokerStatePath(t)
+	statePath := filepath.Join(t.TempDir(), "broker-state.json")
 
 	b1 := NewBrokerAt(statePath)
 	mux := http.NewServeMux()

--- a/internal/team/wizard_hire_channel_access_test.go
+++ b/internal/team/wizard_hire_channel_access_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -30,13 +31,7 @@ import (
 
 func newBrokerWithPackChannels(t *testing.T, packAgents []agent.AgentConfig) *Broker {
 	t.Helper()
-	// Use leakedBrokerStatePath (not t.TempDir) because these tests go
-	// through saveLocked() — both via POST /office-members action=create
-	// and the /messages POST in the end-to-end test. Goroutines leaked by
-	// prior tests in this package can fire a late saveLocked and race
-	// t.TempDir cleanup. Same fix as the launcher_test.go pair; see
-	// broker_test.go for the helper docstring.
-	b := NewBrokerAt(leakedBrokerStatePath(t))
+	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
 	b.mu.Lock()
 	// Seed pack-like roster.
 	members := make([]officeMember, 0, len(packAgents))


### PR DESCRIPTION
## Summary

- **Stop goroutines on teardown** (`8dc3264b`): `stopHeadlessWorkers` now closes `headlessStopCh` and joins the worker WaitGroup; `TestBug_HumanDMsSpecialist_Dispatch_SpecialistReceivesTurn` is unskipped and passing.
- **Synthetic clock in rate-limit logic** (`4e700171`): injects a fake ticker into the broker's rate-limit path so tests don't sleep for real durations.
- **Close the stop-channel race** (`57258377`): a worker goroutine could slip past the `headlessStopCh` check just before `stopHeadlessWorkers` fired, then block in `headlessCodexRunTurn` with no cancel registered. Fixed by (a) collecting per-turn cancel funcs under the lock before firing them, and (b) re-checking `headlessStopCh` inside `beginHeadlessCodexTurn` under the lock so any racer bails immediately. Three resume tests that spun workers without stubbing the runner are also isolated with `setHeadlessCodexRunTurnForTest`.

## Test plan

- [ ] `go test ./internal/team/... -count=1 -timeout 120s` — full suite green
- [ ] `TestBug_HumanDMsSpecialist_Dispatch_SpecialistReceivesTurn` passes without `-skip`
- [ ] No goroutine leaks reported by test cleanup (`waitForHeadlessIdle`)
- [ ] Resume tests (`TestResumeInFlight*`) pass without exec'ing a real codex binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made rate-limiting deterministic to remove timing-related flakiness
  * Re-enabled and stabilized a routing test that previously skipped

* **Tests**
  * Scoped state to per-test temp files, bound headless tasks to test contexts, and added wait-for-idle cleanup to prevent goroutine leaks
  * Replaced real-time waits with synthetic clocks and stubs to speed and stabilize tests

* **Chores**
  * Increased linter timeout to accommodate longer runs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->