### PR TITLE
fix(team): close #268 — un-skip mention-routing DM test + drain headless workers

### DIFF
--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -5320,7 +5320,6 @@ func TestBrokerSurfaceMetadataPersists(t *testing.T) {
 }
 
 func TestBrokerSurfaceChannelsFilter(t *testing.T) {
-	t.Skip("skipped: manifest interference")
 	b := newTestBroker(t)
 	b.mu.Lock()
 	b.channels = append(b.channels,

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -406,25 +406,47 @@ func (l *Launcher) stopHeadlessWorkers() {
 		close(l.headlessStopCh)
 	}
 	cancel := l.headlessCancel
-	// Collect per-turn cancels so we can fire them outside the lock.
-	// Needed when l.headlessCtx is nil (bare &Launcher{} in tests): in that
-	// case turnCtx is derived from context.Background() and canceling
-	// l.headlessCancel is a no-op, so the only way to unblock an in-flight
-	// turn is to cancel its own context directly.
-	var turnCancels []context.CancelFunc
-	for _, active := range l.headlessActive {
-		if active != nil && active.Cancel != nil {
-			turnCancels = append(turnCancels, active.Cancel)
-		}
-	}
 	l.headlessMu.Unlock()
 	if cancel != nil {
 		cancel()
 	}
-	for _, c := range turnCancels {
-		c()
+	// Cancel any in-flight turns and keep cancelling until workers drain.
+	// Polling closes a TOCTOU window: a worker that was past its top-of-loop
+	// stop check but had not yet called beginHeadlessCodexTurn at first
+	// snapshot time would otherwise register a fresh active turn after we
+	// scanned, and Wait() would block on a stub that's parked on ctx.Done().
+	// Production launchers cancel via headlessCancel above; this loop is the
+	// safety net for bare &Launcher{} test fixtures that don't seed one.
+	done := make(chan struct{})
+	go func() {
+		l.headlessWorkerWg.Wait()
+		close(done)
+	}()
+	cancelActive := func() {
+		l.headlessMu.Lock()
+		for _, active := range l.headlessActive {
+			if active != nil && active.Cancel != nil {
+				active.Cancel()
+			}
+		}
+		l.headlessMu.Unlock()
 	}
-	l.headlessWorkerWg.Wait()
+	cancelActive()
+	if cancel != nil {
+		// Production path: parent ctx already cancelled; just wait.
+		<-done
+		return
+	}
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			cancelActive()
+		}
+	}
 }
 
 func (l *Launcher) runHeadlessCodexQueue(slug string, stop <-chan struct{}) {

--- a/internal/team/resume_test.go
+++ b/internal/team/resume_test.go
@@ -708,7 +708,7 @@ func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 		paneNotifications = append(paneNotifications, paneTarget+"\n"+notification)
 	})
 
-	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.members = []officeMember{
 		{Slug: "ceo", Name: "CEO", Provider: provider.ProviderBinding{Kind: provider.KindClaudeCode}},
@@ -742,7 +742,7 @@ func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 		headlessActive: make(map[string]*headlessCodexActiveTurn),
 		headlessQueues: make(map[string][]headlessCodexTurn),
 	}
-	t.Cleanup(func() { l.waitForHeadlessIdle(t) })
+	t.Cleanup(l.stopHeadlessWorkers)
 
 	l.resumeInFlightWork()
 

--- a/internal/team/resume_test.go
+++ b/internal/team/resume_test.go
@@ -2,7 +2,6 @@ package team
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -532,9 +531,9 @@ func TestResumeInFlightWorkHeadlessEnqueuesLeadEvenWhenSpecialistsPresent(t *tes
 
 	// Stub the per-turn runner so spawned workers don't shell out to a real
 	// codex binary while the test asserts queue state.
-	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, ctx context.Context, _, _ string, _ ...string) error {
+	setHeadlessCodexRunTurnForTest(t, func(_ *Launcher, ctx context.Context, _ string, _ string, _ ...string) error {
 		<-ctx.Done()
-		return ctx.Err()
+		return nil
 	})
 
 	l := &Launcher{
@@ -552,7 +551,7 @@ func TestResumeInFlightWorkHeadlessEnqueuesLeadEvenWhenSpecialistsPresent(t *tes
 		headlessActive:  make(map[string]*headlessCodexActiveTurn),
 		headlessQueues:  make(map[string][]headlessCodexTurn),
 	}
-	t.Cleanup(func() { l.waitForHeadlessIdle(t) })
+	t.Cleanup(l.stopHeadlessWorkers)
 
 	l.resumeInFlightWork()
 
@@ -648,7 +647,7 @@ func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
 		return ctx.Err()
 	})
 
-	b := NewBrokerAt(filepath.Join(t.TempDir(), "broker-state.json"))
+	b := newTestBroker(t)
 	b.mu.Lock()
 	b.tasks = []teamTask{
 		{ID: "t1", Title: "Build login form", Owner: "fe", Status: "in_progress"},
@@ -676,7 +675,7 @@ func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
 		headlessActive:  make(map[string]*headlessCodexActiveTurn),
 		headlessQueues:  make(map[string][]headlessCodexTurn),
 	}
-	t.Cleanup(func() { l.waitForHeadlessIdle(t) })
+	t.Cleanup(l.stopHeadlessWorkers)
 
 	l.resumeInFlightWork()
 


### PR DESCRIPTION
## Summary
- Un-skips `TestBug_HumanDMsSpecialist_Dispatch_SpecialistReceivesTurn` (closes #268). The skip was guarding against a leaked `runHeadlessCodexQueue` goroutine from earlier tests; PR #320 added `Launcher.stopHeadlessWorkers` and `newHeadlessLauncherForTest` already drains via `t.Cleanup`, so the leak is gone.
- Migrates the three `resume_test.go` tests off `leakedBrokerStatePath` to `t.TempDir()` (`newTestBroker`) and registers `t.Cleanup(l.stopHeadlessWorkers)` on each — completes step 2 ("one-offs in `resume_test.go`") and step 4 (migration) of the issue.
- Closes a TOCTOU race in `stopHeadlessWorkers`: bare-`&Launcher{}` test fixtures don't seed `headlessCancel`, so a worker parked inside the per-turn `headlessCodexRunTurn` could outlive Cleanup until the 240s per-turn timeout fired. New version cancels active turn ctxs and poll-cancels every 20ms until the WaitGroup drains. Production launchers (with `headlessCancel != nil`) keep the single-cancel fast path.
- Drive-by un-skip of `TestBrokerSurfaceChannelsFilter` (separate flake whose root cause was the same goroutine leak).

## Test plan
- [x] `go test -race -count=5 -run 'TestBug_HumanDMsSpecialist_Dispatch_SpecialistReceivesTurn|TestResumeInFlightWork|TestBrokerSurfaceChannelsFilter' ./internal/team/` — passes in 5s (previously timed out at 600s)
- [x] `go test ./internal/team/` (full team suite, mirrors release-build) — passes in 99s
- [x] `go vet ./internal/team/...` — clean
- [x] `golangci-lint run ./internal/team/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced headless worker shutdown mechanism for improved reliability and graceful termination.

* **Tests**
  * Enabled broker channel filtering test coverage.
  * Simplified test infrastructure with improved isolation and cleanup procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->