### PR TITLE
fix(launch): combined npx wuphf cold-start + onboarding-resilience fixes (supersedes #364, #365)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,7 @@ jobs:
         working-directory: web/e2e
         env:
           WUPHF_E2E_BASE_URL: http://localhost:7891
-        run: bunx playwright test tests/wizard.spec.ts
+        run: bunx playwright test tests/wizard.spec.ts tests/wizard-error-states.spec.ts
       - name: Stop wuphf (wizard phase)
         if: always()
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 !/docs/specs/**
 !/docs/evals/
 !/docs/evals/**
+!/docs/experiments/
+!/docs/experiments/**
 !/docs/REVOPS_TEST_PLAN.md
 /termwright-artifacts/
 .worktrees/

--- a/cmd/wuphf/onboarding.go
+++ b/cmd/wuphf/onboarding.go
@@ -366,7 +366,7 @@ func (m onboardingModel) handleSetupKey(msg tea.KeyMsg) (onboardingModel, tea.Cm
 		}
 		key := strings.TrimSpace(m.anthropicKey.Value())
 		if key == "" {
-			m.err = "Anthropic API key is required (or install a runtime CLI like Claude Code or Codex)."
+			m.err = "Paste an Anthropic API key (https://console.anthropic.com/settings/keys), or install Claude Code (https://claude.com/claude-code) and rerun — no key needed."
 			return m, nil
 		}
 		// If key not yet validated, validate now.

--- a/cmd/wuphf/onboarding.go
+++ b/cmd/wuphf/onboarding.go
@@ -732,7 +732,11 @@ func detectReachableLocalRuntime() (kind, addr string) {
 				return
 			}
 			_ = resp.Body.Close()
-			if resp.StatusCode >= 200 && resp.StatusCode < 500 {
+			// Require an explicit 2xx — a 404 from some other server on the
+			// same loopback port (or a 4xx auth wall that isn't actually the
+			// runtime we expect) shouldn't be advertised as a reachable
+			// runtime. The supported runtimes all return 200 on /v1/models.
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 				hits <- hit{kind: c.kind, addr: c.base}
 				return
 			}

--- a/cmd/wuphf/onboarding.go
+++ b/cmd/wuphf/onboarding.go
@@ -725,12 +725,22 @@ var localRuntimeCandidates = []struct {
 	{kind: "exo", base: "http://127.0.0.1:52415/v1"},
 }
 
-// probeLocalRuntime checks a single OpenAI-compatible /v1/models endpoint and
-// returns true iff the response is a 2xx with an OpenAI-shaped body
-// (`{"object":"list", ...}`). This second check is load-bearing: port 8080 is
-// shared with countless dev servers, so a 200 OK on a path-permissive server
-// (devserver index, Spring Boot, Tomcat, Docker images) would otherwise
-// produce a bad "--provider mlx-lm" suggestion that fails opaquely on use.
+// probeLocalRuntime checks a single OpenAI-compatible /v1/models endpoint
+// and returns true iff the response is a 2xx with an OpenAI-shaped body —
+// `{"object":"list", "data":<array>}`. The shape check is load-bearing
+// because port 8080 is shared with countless dev servers, so a 200 OK on
+// a path-permissive server (Spring Boot, Tomcat, Docker images) would
+// otherwise produce a bad "--provider mlx-lm" suggestion that fails
+// opaquely on use.
+//
+// The `data` key must be present (not missing, not null) but MAY be an
+// empty array. Freshly-installed ollama (`ollama serve` before any
+// `ollama pull`) returns `{"object":"list","data":[]}` and is a real
+// runtime — rejecting it would silently break the most common ollama
+// state and is worse than the exotic case of an unrelated server that
+// happens to return `data:[]`. We use a pointer to []RawMessage so we
+// can distinguish "key missing or null" (Data == nil) from "key
+// present, empty array" (*Data has length 0).
 func probeLocalRuntime(ctx context.Context, client *http.Client, base string) bool {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/models", nil)
 	if err != nil {
@@ -745,7 +755,8 @@ func probeLocalRuntime(ctx context.Context, client *http.Client, base string) bo
 		return false
 	}
 	var probe struct {
-		Object string `json:"object"`
+		Object string             `json:"object"`
+		Data   *[]json.RawMessage `json:"data"`
 	}
 	// Cap the read so a misconfigured server can't stream us megabytes of
 	// HTML. Real /v1/models bodies are < 4KB even with dozens of models.
@@ -756,7 +767,7 @@ func probeLocalRuntime(ctx context.Context, client *http.Client, base string) bo
 	if err := json.Unmarshal(body, &probe); err != nil {
 		return false
 	}
-	return probe.Object == "list"
+	return probe.Object == "list" && probe.Data != nil
 }
 
 // detectReachableLocalRuntime probes the canonical loopback endpoints for the

--- a/cmd/wuphf/onboarding.go
+++ b/cmd/wuphf/onboarding.go
@@ -163,6 +163,14 @@ type templatesLoadedMsg struct{ templates []taskTemplate }
 type completeMsg struct{ err error }
 type onboardingProgressMsg struct{ err error }
 
+// localRuntimeDetectedMsg lands when the off-loop runtime probe finishes.
+// kind is empty when nothing was reachable; non-empty values are
+// "ollama"/"mlx-lm"/"exo" plus their /v1 base URL.
+type localRuntimeDetectedMsg struct {
+	kind string
+	addr string
+}
+
 // ── Model ───────────────────────────────────────────────────────
 
 type onboardingModel struct {
@@ -275,6 +283,17 @@ func (m onboardingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// progress saved, nothing to do
 		return m, nil
 
+	case localRuntimeDetectedMsg:
+		// Replace the placeholder "Detecting…" message with either the
+		// concrete --provider suggestion or the generic "paste a key"
+		// fallback, depending on what the probe found.
+		if msg.kind != "" {
+			m.err = fmt.Sprintf("Detected %s running on %s. Exit with Ctrl+C and re-run: `wuphf --provider %s`. Or paste an Anthropic key below.", msg.kind, msg.addr, msg.kind)
+		} else {
+			m.err = "Paste an Anthropic API key (https://console.anthropic.com/settings/keys), or install Claude Code (https://claude.com/claude-code) and rerun — no key needed."
+		}
+		return m, nil
+
 	case tea.KeyMsg:
 		return m.handleKey(msg)
 	}
@@ -370,12 +389,16 @@ func (m onboardingModel) handleSetupKey(msg tea.KeyMsg) (onboardingModel, tea.Cm
 			// locally. Detect that and tell them how to use it instead of
 			// nagging for a cloud API key — saves the most-engaged segment of
 			// PH visitors from a frustrating dead-end.
-			if kind, addr := detectReachableLocalRuntime(); kind != "" {
-				m.err = fmt.Sprintf("Detected %s running on %s. Exit with Ctrl+C and re-run: `wuphf --provider %s`. Or paste an Anthropic key below.", kind, addr, kind)
-				return m, nil
-			}
-			m.err = "Paste an Anthropic API key (https://console.anthropic.com/settings/keys), or install Claude Code (https://claude.com/claude-code) and rerun — no key needed."
-			return m, nil
+			//
+			// The probe is dispatched as a tea.Cmd so the bubbletea Update
+			// loop stays responsive — TCP-RST-on-firewalled-port can block
+			// for the full per-candidate timeout, and freezing the TUI right
+			// after the user pressed Enter is the worst possible UX moment.
+			// Until the probe lands we show a hold message; the
+			// localRuntimeDetectedMsg case overwrites it with either the
+			// concrete suggestion or the generic fallback.
+			m.err = "Checking for a local LLM runtime…"
+			return m, detectLocalRuntimeCmd()
 		}
 		// If key not yet validated, validate now.
 		if m.keyStatus == "idle" || m.keyStatus == "unverified" {
@@ -689,68 +712,72 @@ func allRequiredPrereqsOk(prereqs []prereqResult) bool {
 	return true
 }
 
+// localRuntimeCandidates lists the supported local OpenAI-compatible runtimes
+// in priority order. The order is the user-facing tiebreak when more than one
+// is reachable: ollama wins because it's the most common install, mlx-lm
+// second because it's Apple-Silicon-only, exo last because it's niche.
+var localRuntimeCandidates = []struct {
+	kind string
+	base string
+}{
+	{kind: "ollama", base: "http://127.0.0.1:11434/v1"},
+	{kind: "mlx-lm", base: "http://127.0.0.1:8080/v1"},
+	{kind: "exo", base: "http://127.0.0.1:52415/v1"},
+}
+
+// probeLocalRuntime checks a single OpenAI-compatible /v1/models endpoint and
+// returns true iff the response is a 2xx with an OpenAI-shaped body
+// (`{"object":"list", ...}`). This second check is load-bearing: port 8080 is
+// shared with countless dev servers, so a 200 OK on a path-permissive server
+// (devserver index, Spring Boot, Tomcat, Docker images) would otherwise
+// produce a bad "--provider mlx-lm" suggestion that fails opaquely on use.
+func probeLocalRuntime(ctx context.Context, client *http.Client, base string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/models", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false
+	}
+	var probe struct {
+		Object string `json:"object"`
+	}
+	// Cap the read so a misconfigured server can't stream us megabytes of
+	// HTML. Real /v1/models bodies are < 4KB even with dozens of models.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return false
+	}
+	if err := json.Unmarshal(body, &probe); err != nil {
+		return false
+	}
+	return probe.Object == "list"
+}
+
 // detectReachableLocalRuntime probes the canonical loopback endpoints for the
-// supported local OpenAI-compatible runtimes (ollama, mlx-lm, exo) and returns
-// the first one that answers. Used by the onboarding wizard to suggest a
-// concrete --provider flag when the user has no Anthropic key and no runtime
-// CLI installed but does have a local LLM running.
+// supported local OpenAI-compatible runtimes (ollama, mlx-lm, exo) in priority
+// order and returns the first one that answers with an OpenAI-shaped body.
+// Used by the onboarding wizard to suggest a concrete --provider flag when
+// the user has no Anthropic key and no runtime CLI installed but does have a
+// local LLM running.
 //
-// Probes are parallel with a tight 400ms-per-endpoint timeout and a 600ms
-// overall ceiling so the wizard doesn't visibly stall when nothing is
-// reachable. We hit /v1/models because both ollama and mlx-lm expose it as a
-// cheap, always-on endpoint and the OpenAI-compatible shape guarantees a 200
-// response when the server is alive.
+// Sequential (not parallel) so the suggestion is deterministic when more than
+// one runtime is up. A 250ms-per-candidate timeout keeps the worst case at
+// 750ms total when nothing is reachable; the caller dispatches this off the
+// bubbletea Update loop so the TUI stays responsive.
 func detectReachableLocalRuntime() (kind, addr string) {
-	type candidate struct {
-		kind string
-		base string
-	}
-	candidates := []candidate{
-		{kind: "ollama", base: "http://127.0.0.1:11434/v1"},
-		{kind: "mlx-lm", base: "http://127.0.0.1:8080/v1"},
-		{kind: "exo", base: "http://127.0.0.1:52415/v1"},
-	}
-	type hit struct {
-		kind string
-		addr string
-	}
-	hits := make(chan hit, len(candidates))
-	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
-	defer cancel()
-	client := &http.Client{Timeout: 400 * time.Millisecond}
-	for _, c := range candidates {
-		c := c
-		go func() {
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/models", nil)
-			if err != nil {
-				hits <- hit{}
-				return
-			}
-			resp, err := client.Do(req)
-			if err != nil {
-				hits <- hit{}
-				return
-			}
-			_ = resp.Body.Close()
-			// Require an explicit 2xx — a 404 from some other server on the
-			// same loopback port (or a 4xx auth wall that isn't actually the
-			// runtime we expect) shouldn't be advertised as a reachable
-			// runtime. The supported runtimes all return 200 on /v1/models.
-			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-				hits <- hit{kind: c.kind, addr: c.base}
-				return
-			}
-			hits <- hit{}
-		}()
-	}
-	for range candidates {
-		select {
-		case h := <-hits:
-			if h.kind != "" {
-				return h.kind, h.addr
-			}
-		case <-ctx.Done():
-			return "", ""
+	client := &http.Client{Timeout: 250 * time.Millisecond}
+	for _, c := range localRuntimeCandidates {
+		ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+		ok := probeLocalRuntime(ctx, client, c.base)
+		cancel()
+		if ok {
+			return c.kind, c.base
 		}
 	}
 	return "", ""
@@ -817,6 +844,17 @@ func defaultPrereqs() []prereqResult {
 		{Name: "claude", Required: false, Found: false, InstallURL: "https://claude.ai/code"},
 		{Name: "codex", Required: false, Found: false, InstallURL: "https://github.com/openai/codex"},
 		{Name: "opencode", Required: false, Found: false, InstallURL: "https://opencode.ai"},
+	}
+}
+
+// detectLocalRuntimeCmd runs detectReachableLocalRuntime off the bubbletea
+// Update loop and posts a localRuntimeDetectedMsg back to it. Worst-case
+// runtime is bounded by the loop in detectReachableLocalRuntime (250ms per
+// candidate × 3 candidates = 750ms), so the TUI never blocks.
+func detectLocalRuntimeCmd() tea.Cmd {
+	return func() tea.Msg {
+		kind, addr := detectReachableLocalRuntime()
+		return localRuntimeDetectedMsg{kind: kind, addr: addr}
 	}
 }
 

--- a/cmd/wuphf/onboarding.go
+++ b/cmd/wuphf/onboarding.go
@@ -725,6 +725,13 @@ func allRequiredPrereqsOk(prereqs []prereqResult) bool {
 // in priority order. The order is the user-facing tiebreak when more than one
 // is reachable: ollama wins because it's the most common install, mlx-lm
 // second because it's Apple-Silicon-only, exo last because it's niche.
+//
+// These URLs intentionally duplicate the unexported defaultXxxBaseURL constants
+// in internal/provider/{ollama,mlx_lm,exo}.go. Importing the provider package
+// for a single string per runtime would balloon the cold-start dependency graph
+// for `wuphf` first-run, which has to feel snappy on a fresh `npx` install.
+// The provider defaults change rarely (last touched when the providers were
+// added); if they do change, update both call sites.
 var localRuntimeCandidates = []struct {
 	kind string
 	base string

--- a/cmd/wuphf/onboarding.go
+++ b/cmd/wuphf/onboarding.go
@@ -366,6 +366,14 @@ func (m onboardingModel) handleSetupKey(msg tea.KeyMsg) (onboardingModel, tea.Cm
 		}
 		key := strings.TrimSpace(m.anthropicKey.Value())
 		if key == "" {
+			// Self-hosters often have ollama / mlx-lm / exo already running
+			// locally. Detect that and tell them how to use it instead of
+			// nagging for a cloud API key — saves the most-engaged segment of
+			// PH visitors from a frustrating dead-end.
+			if kind, addr := detectReachableLocalRuntime(); kind != "" {
+				m.err = fmt.Sprintf("Detected %s running on %s. Exit with Ctrl+C and re-run: `wuphf --provider %s`. Or paste an Anthropic key below.", kind, addr, kind)
+				return m, nil
+			}
 			m.err = "Paste an Anthropic API key (https://console.anthropic.com/settings/keys), or install Claude Code (https://claude.com/claude-code) and rerun — no key needed."
 			return m, nil
 		}
@@ -679,6 +687,69 @@ func allRequiredPrereqsOk(prereqs []prereqResult) bool {
 		}
 	}
 	return true
+}
+
+// detectReachableLocalRuntime probes the canonical loopback endpoints for the
+// supported local OpenAI-compatible runtimes (ollama, mlx-lm, exo) and returns
+// the first one that answers. Used by the onboarding wizard to suggest a
+// concrete --provider flag when the user has no Anthropic key and no runtime
+// CLI installed but does have a local LLM running.
+//
+// Probes are parallel with a tight 400ms-per-endpoint timeout and a 600ms
+// overall ceiling so the wizard doesn't visibly stall when nothing is
+// reachable. We hit /v1/models because both ollama and mlx-lm expose it as a
+// cheap, always-on endpoint and the OpenAI-compatible shape guarantees a 200
+// response when the server is alive.
+func detectReachableLocalRuntime() (kind, addr string) {
+	type candidate struct {
+		kind string
+		base string
+	}
+	candidates := []candidate{
+		{kind: "ollama", base: "http://127.0.0.1:11434/v1"},
+		{kind: "mlx-lm", base: "http://127.0.0.1:8080/v1"},
+		{kind: "exo", base: "http://127.0.0.1:52415/v1"},
+	}
+	type hit struct {
+		kind string
+		addr string
+	}
+	hits := make(chan hit, len(candidates))
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+	client := &http.Client{Timeout: 400 * time.Millisecond}
+	for _, c := range candidates {
+		c := c
+		go func() {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.base+"/models", nil)
+			if err != nil {
+				hits <- hit{}
+				return
+			}
+			resp, err := client.Do(req)
+			if err != nil {
+				hits <- hit{}
+				return
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 500 {
+				hits <- hit{kind: c.kind, addr: c.base}
+				return
+			}
+			hits <- hit{}
+		}()
+	}
+	for range candidates {
+		select {
+		case h := <-hits:
+			if h.kind != "" {
+				return h.kind, h.addr
+			}
+		case <-ctx.Done():
+			return "", ""
+		}
+	}
+	return "", ""
 }
 
 // hasInstalledRuntimeCLI reports whether at least one runtime CLI (claude,

--- a/cmd/wuphf/onboarding.go
+++ b/cmd/wuphf/onboarding.go
@@ -287,10 +287,19 @@ func (m onboardingModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Replace the placeholder "Detecting…" message with either the
 		// concrete --provider suggestion or the generic "paste a key"
 		// fallback, depending on what the probe found.
-		if msg.kind != "" {
-			m.err = fmt.Sprintf("Detected %s running on %s. Exit with Ctrl+C and re-run: `wuphf --provider %s`. Or paste an Anthropic key below.", msg.kind, msg.addr, msg.kind)
-		} else {
-			m.err = "Paste an Anthropic API key (https://console.anthropic.com/settings/keys), or install Claude Code (https://claude.com/claude-code) and rerun — no key needed."
+		//
+		// Guard against stale probe results: the user may have advanced
+		// past the setup step, started typing a key, or already had a
+		// validated key by the time this lands — overwriting m.err in
+		// any of those states would clobber a real error or undo the
+		// user's progress signal. Only apply when the model is still on
+		// stepSetup AND the placeholder is still the active error.
+		if m.step == stepSetup && m.err == "Checking for a local LLM runtime…" {
+			if msg.kind != "" {
+				m.err = fmt.Sprintf("Detected %s running on %s. Exit with Ctrl+C and re-run: `wuphf --provider %s`. Or paste an Anthropic key below.", msg.kind, msg.addr, msg.kind)
+			} else {
+				m.err = "Paste an Anthropic API key (https://console.anthropic.com/settings/keys), or install Claude Code (https://claude.com/claude-code) and rerun — no key needed."
+			}
 		}
 		return m, nil
 

--- a/cmd/wuphf/onboarding_runtime_probe_test.go
+++ b/cmd/wuphf/onboarding_runtime_probe_test.go
@@ -8,16 +8,33 @@ import (
 	"time"
 )
 
-// TestProbeLocalRuntimeAcceptsOpenAIShape asserts the happy path: a 200 OK
-// with `{"object":"list", "data":[…]}` is treated as a real runtime.
+// TestProbeLocalRuntimeAcceptsOpenAIShape asserts the happy path: a 200
+// OK with `{"object":"list", "data":[…]}` is treated as a real runtime.
 func TestProbeLocalRuntimeAcceptsOpenAIShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"object":"list","data":[{"id":"qwen2.5-coder:7b","object":"model"}]}`))
+	}))
+	defer srv.Close()
+
+	if !probeLocalRuntime(context.Background(), &http.Client{Timeout: time.Second}, srv.URL) {
+		t.Fatal("expected probeLocalRuntime to accept OpenAI-shaped 200 OK")
+	}
+}
+
+// TestProbeLocalRuntimeAcceptsEmptyData covers the "freshly installed
+// ollama with no models pulled yet" case. The daemon is up, /v1/models
+// returns `{"object":"list","data":[]}`, and we MUST treat it as a real
+// runtime — rejecting it would silently break the most common ollama
+// first-run state. The flip side (an unrelated server happening to
+// return `data:[]` is exotic enough to accept the false positive risk).
+func TestProbeLocalRuntimeAcceptsEmptyData(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
 	}))
 	defer srv.Close()
 
 	if !probeLocalRuntime(context.Background(), &http.Client{Timeout: time.Second}, srv.URL) {
-		t.Fatal("expected probeLocalRuntime to accept OpenAI-shaped 200 OK")
+		t.Fatal("freshly-installed ollama (data:[]) must be treated as a real runtime")
 	}
 }
 
@@ -29,9 +46,15 @@ func TestProbeLocalRuntimeRejectsArbitrary200(t *testing.T) {
 	cases := map[string]string{
 		"html":               `<!doctype html><html><body>Hello</body></html>`,
 		"unrelated_json":     `{"status":"ok"}`,
-		"object_not_list":    `{"object":"chat.completion","data":[]}`,
-		"missing_object_key": `{"data":[]}`,
+		"object_not_list":    `{"object":"chat.completion","data":[{"id":"x"}]}`,
+		"missing_object_key": `{"data":[{"id":"x"}]}`,
 		"empty":              ``,
+		// `data` key missing entirely — distinguishes a real OpenAI-shaped
+		// response (which always includes the key, even if the array is
+		// empty) from an unrelated server returning a partial JSON shape.
+		"object_list_no_data_key": `{"object":"list"}`,
+		// Explicit null — same intent: not a real /v1/models response.
+		"object_list_data_null": `{"object":"list","data":null}`,
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -68,14 +91,14 @@ func TestProbeLocalRuntimeRejectsNon2xx(t *testing.T) {
 // TestProbeLocalRuntimeBoundedReadSize asserts the LimitReader cap so a
 // misbehaving server can't stream megabytes into the wizard's hot path.
 func TestProbeLocalRuntimeBoundedReadSize(t *testing.T) {
-	// 2 MB body that nominally starts with the OpenAI shape but never
-	// terminates the JSON object — we want to confirm the limit kicks in
-	// and the probe fails gracefully (returns false) instead of hanging
-	// or buffering.
+	// 256KB body that nominally starts with the OpenAI shape but never
+	// terminates the JSON object — we want to confirm the LimitReader
+	// 64KB cap kicks in and the probe fails gracefully (returns false)
+	// instead of hanging or buffering megabytes.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		const chunk = `{"object":"list","data":[`
+		const chunk = `{"object":"list","data":[{"id":"x"`
 		_, _ = w.Write([]byte(chunk))
 		// Pad with garbage past the 64KB cap.
 		blob := make([]byte, 256*1024)

--- a/cmd/wuphf/onboarding_runtime_probe_test.go
+++ b/cmd/wuphf/onboarding_runtime_probe_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestProbeLocalRuntimeAcceptsOpenAIShape asserts the happy path: a 200 OK
+// with `{"object":"list", "data":[…]}` is treated as a real runtime.
+func TestProbeLocalRuntimeAcceptsOpenAIShape(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+	}))
+	defer srv.Close()
+
+	if !probeLocalRuntime(context.Background(), &http.Client{Timeout: time.Second}, srv.URL) {
+		t.Fatal("expected probeLocalRuntime to accept OpenAI-shaped 200 OK")
+	}
+}
+
+// TestProbeLocalRuntimeRejectsArbitrary200 covers the load-bearing case:
+// a 200 OK from any other dev server on port 8080 (Spring Boot, devserver
+// index, generic JSON) must not satisfy the probe. Without the body
+// validation, mlx-lm's port collision turns into a bad --provider hint.
+func TestProbeLocalRuntimeRejectsArbitrary200(t *testing.T) {
+	cases := map[string]string{
+		"html":               `<!doctype html><html><body>Hello</body></html>`,
+		"unrelated_json":     `{"status":"ok"}`,
+		"object_not_list":    `{"object":"chat.completion","data":[]}`,
+		"missing_object_key": `{"data":[]}`,
+		"empty":              ``,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			body := body
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(body))
+			}))
+			defer srv.Close()
+			if probeLocalRuntime(context.Background(), &http.Client{Timeout: time.Second}, srv.URL) {
+				t.Fatalf("probeLocalRuntime accepted non-OpenAI body %q", name)
+			}
+		})
+	}
+}
+
+// TestProbeLocalRuntimeRejectsNon2xx asserts the status check still fires
+// before the body decode.
+func TestProbeLocalRuntimeRejectsNon2xx(t *testing.T) {
+	for _, status := range []int{301, 401, 404, 500} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			s := status
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(s)
+				_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+			}))
+			defer srv.Close()
+			if probeLocalRuntime(context.Background(), &http.Client{Timeout: time.Second}, srv.URL) {
+				t.Fatalf("probeLocalRuntime accepted status %d", s)
+			}
+		})
+	}
+}
+
+// TestProbeLocalRuntimeBoundedReadSize asserts the LimitReader cap so a
+// misbehaving server can't stream megabytes into the wizard's hot path.
+func TestProbeLocalRuntimeBoundedReadSize(t *testing.T) {
+	// 2 MB body that nominally starts with the OpenAI shape but never
+	// terminates the JSON object — we want to confirm the limit kicks in
+	// and the probe fails gracefully (returns false) instead of hanging
+	// or buffering.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		const chunk = `{"object":"list","data":[`
+		_, _ = w.Write([]byte(chunk))
+		// Pad with garbage past the 64KB cap.
+		blob := make([]byte, 256*1024)
+		for i := range blob {
+			blob[i] = 'x'
+		}
+		_, _ = w.Write(blob)
+	}))
+	defer srv.Close()
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- probeLocalRuntime(context.Background(), &http.Client{Timeout: 2 * time.Second}, srv.URL)
+	}()
+	select {
+	case ok := <-done:
+		if ok {
+			t.Fatal("probe accepted a 256KB unterminated body")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("probe did not return within 3s on oversized body")
+	}
+}

--- a/docs/experiments/2026-04-28-opus-4.6-vs-4.7-launch-fixes.md
+++ b/docs/experiments/2026-04-28-opus-4.6-vs-4.7-launch-fixes.md
@@ -1,0 +1,89 @@
+# Opus 4.6 vs 4.7 — same prompt, two PRs
+
+**Date:** 2026-04-28 (eve of Product Hunt launch)
+**Prompt:** "Look at the npx wuphf cold-start path with fresh-user eyes. Find friction in the first 60 seconds and ship surgical fixes. PH visitors are landing tomorrow."
+**Models:** Claude Opus 4.6 and Claude Opus 4.7 (1M context). Same prompt, no other context bias, two parallel branches.
+**Verdict:** combined the best of both into [#367](https://github.com/nex-crm/wuphf/pull/367). 4.7 produced a tighter user-facing fix bundle; 4.6 produced more defensive/correctness work and more tests, with one regression.
+
+---
+
+## What each model produced
+
+| | 4.7 (PR #364) | 4.6 (PR #365) |
+|---|---|---|
+| Files | 4 | 6 |
+| +/- | 225 / 32 | 138 / 24 |
+| CI on first push | all green/pending | **commitlint + lint failing** |
+| Tests added | 0 | 1 (`TestCorruptStateFileRecovers`) |
+| Co-author trailer | `Fran Dias` only | `Co-Authored-By: Claude Opus 4.6` |
+
+### 4.7's commits (PR #364)
+
+1. **TTY-safe Nex prompt** — `fmt.Scanln` returned empty under non-interactive stdin (`npx`, Docker, CI), and the launcher silently treated that as "yes" and tried to install Nex. Detect non-TTY via `os.Stdin.Stat()` and skip with a one-liner pointing at `nex setup`.
+2. **`waitForWebReady`** — `ServeWebUI` returns immediately but the listener takes a few hundred ms to accept; auto-opening the browser before then produced `ERR_CONNECTION_REFUSED`. Added a 5s-ceiling TCP-dial poll before `openBrowser`.
+3. **Auto-detect a local runtime** — when no API key is provided, probe `ollama` / `mlx-lm` / `exo` on loopback `/v1/models` and suggest `wuphf --provider <kind>` instead of nagging for a cloud key.
+4. **Non-empty `#general`** on the `skip_task=true` path — post a system welcome plus a `Kind:"demo_seed"` lead presence line so the office feels staffed on first paint. The `demo_seed` marker is filtered from `notifyAgentsLoop` so it never wakes a real agent.
+
+### 4.6's commits (PR #365)
+
+1. **Corrupt `onboarded.json` recovery** — auto-recovers to fresh state instead of an HTTP 500 loop. With the only test in either PR.
+2. **Surface `/onboarding/complete` failures** — error + retry button instead of silently marking onboarded with an empty office.
+3. **Surface `POST /config` failures** — log a warning instead of silently swallowing via `.catch(() => {})`.
+4. **Prereqs-fetch error banner** — when CLI detection fails, show a banner and keep runtime tiles selectable so the user can proceed.
+5. **Web UI port-conflict actionable error** — `ServeWebUI` binds the port before spawning the goroutine and returns an `Is port X already in use? Try: wuphf --web-port Y` error instead of dying inside the goroutine.
+6. **Broker token-write warning** — `os.WriteFile` errors on the broker token file logged instead of `_ = …`'d.
+
+## Reviewer findings on each (CodeRabbit + staff review)
+
+**4.7 (#364)** — 5 findings, all minor-to-major:
+- `waitForWebReady` return value ignored; probe targets `127.0.0.1` while browser opens `localhost` (mismatch reproduces `ERR_CONNECTION_REFUSED` on IPv6-preferring setups). **Major.**
+- Local-runtime probe accepts `<500` so a 404 from any other dev server on port 8080 passes. **Major.** (Staff also flagged: parallel goroutines + first-hit-wins → non-deterministic; port 8080 false positives need body-shape validation.)
+- `buildNotificationContext` doesn't filter `Kind:"demo_seed"` so the cosmetic CEO line could be replayed as prompt context.
+- `leadName` fallback `"your lead"` should be capitalized in sentence position.
+- Nex install-failure path doesn't mark a session-level "Nex disabled" flag (deferred — `nex.IsInstalled()` already returns `false` after a failed install).
+
+**4.6 (#365)** — 6 findings, including a real regression:
+- **Regression:** `provider:null` runtimes (Cursor/Windsurf) satisfy `hasInstalledSelection` when `prereqsError` is set, letting onboarding finish with no `llm_provider` configured. **Major.**
+- **CI broken:** `net.Listen` directly trips the `noctx` lint rule. Should have used `(*net.ListenConfig).Listen`. **Blocker for landing as-is.**
+- **Half-fix:** corrupt-state recovery returns a fresh in-memory state but doesn't rewrite the file, so the next `Load` re-triggers the recovery branch on every call. The test only covers the in-memory fix.
+- `/config` failures are still effectively swallowed (the `console.warn` is invisible to the user — keys go missing on next launch).
+- `ServeWebUI` failure leaves the broker running and the office PID file behind.
+- `catch {}` block doesn't bind/log the error.
+
+## What the comparison says about the two models
+
+**4.7 won on user-impact-per-line.** Every fix targets a real bug a PH visitor hits in the first minute (npx hang, browser race, dead-end API-key error, empty office). The local-runtime detection is genuinely clever and high-leverage. CI green on first push.
+
+**4.6 won on defensive engineering.** It surfaces a class of silently-swallowed errors and includes the only unit test. The `ServeWebUI` bind-before-goroutine refactor is the cleanest piece of code in either PR.
+
+**4.6 lost on correctness.** The `provider:null` regression is exactly the kind of bug "permissive when something fails" patterns produce — relaxing a gate without re-checking the downstream consumer. The corrupt-state recovery without disk-write is the same pattern at a different scope: addresses the symptom in-memory without actually fixing the artifact on disk. **And** it shipped with red CI, which on launch eve is the expensive failure mode.
+
+**Both missed the same things in their own work.** Neither produced a test for their own central invariant — 4.7 has no test for "demo_seed doesn't wake an agent" (the load-bearing claim of its #4 commit); 4.6 has no test for the `provider:null` gate it introduced. Coverage of one's own deliberate behavior changes is the easiest test to write and the most predictive of correctness, and neither model produced it.
+
+**Authorship-trailer note.** 4.6 added `Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>` automatically; 4.7 did not. Not a behavioral judgment — just a defaults difference worth recording, since "did it self-attribute?" is a useful telemetry bit when sorting through retro logs.
+
+## How the combined PR (#367) resolved each finding
+
+The combined branch contains 4.7's entire fix bundle plus 4.6's resilience commit, with these additional fixes folded in:
+
+| Finding | Fix | Where |
+|---|---|---|
+| 4.7 — `waitForWebReady` result ignored, `localhost` vs `127.0.0.1` | Honor the bool; use `127.0.0.1` everywhere | `internal/team/launcher.go` |
+| 4.7 — runtime probe accepts `<500` + parallel-race + port-8080 false positives | Sequential probe, 2xx-only, `object == "list"` body validation | `cmd/wuphf/onboarding.go` |
+| 4.7 — runtime probe blocks the bubbletea Update loop | Dispatch via `tea.Cmd`, render `localRuntimeDetectedMsg` | `cmd/wuphf/onboarding.go` |
+| 4.7 — `buildNotificationContext` should filter `demo_seed` | Filter added; same filter centralized into `deliverMessageNotification` so `primeVisibleAgents` can't bypass it | `internal/team/launcher.go` |
+| 4.7 — `"your lead"` capitalization | `"Your lead"` | `internal/team/broker_onboarding.go` |
+| 4.6 — `provider:null` gate regression | Both gate sites require `spec.provider !== null` under `prereqsError` | `web/src/components/onboarding/Wizard.tsx` |
+| 4.6 — corrupt-state recovery doesn't rewrite the file | `Save(fresh)` after recovery; test verifies on-disk fix | `internal/onboarding/state.go` |
+| 4.6 — `noctx` lint failure | `(*net.ListenConfig).Listen` with `context.Background()` | `internal/team/broker.go` |
+| 4.6 — `/config` failure silently swallowed | Removed the warn-and-continue try/catch; `/config` errors now drive the same `submitError` + Retry UI as `/onboarding/complete` | `web/src/components/onboarding/Wizard.tsx` |
+| 4.6 — `ServeWebUI` bind failure leaves broker + PID file | `l.broker.Stop()` + `clearOfficePIDFile()` in the error path | `internal/team/launcher.go` |
+| 4.6 — `catch {}` doesn't log | Replaced with fatal-error UX (above), so logging is moot | n/a |
+| Both — no tests for own invariants | Added `TestSkipTaskSeedsWelcomeAndPresence`, `TestDeliverMessageNotificationSkipsDemoSeed`, `TestBuildNotificationContextExcludesDemoSeed`, `TestServeWebUIReturnsErrorOnBoundPort`, `TestWaitForWebReady{TimesOut,ReturnsTrue}`, plus `TestProbeLocalRuntime{AcceptsOpenAIShape,RejectsArbitrary200,RejectsNon2xx,BoundedReadSize}` | `internal/team/launcher_demo_seed_test.go`, `cmd/wuphf/onboarding_runtime_probe_test.go` |
+
+## Takeaways for future model-vs-model bake-offs
+
+1. **Always run the bake-off through the same lint/CI gates the human would.** 4.6's PR shipped with red CI, which would have been caught in seconds by a `golangci-lint run` step before even opening the PR. A pre-PR-open `make ci` step would have flagged the `noctx` issue and forced the model to fix it instead of leaving it for review.
+2. **Ask the model to write tests for its own central invariants.** Neither model produced this voluntarily; both would have benefited.
+3. **The "permissive when something fails" pattern is a 4.6 tell.** When 4.6 sees an error it can't immediately fix, the default reflex is "let the user proceed" — which is sometimes right (the prereqs-error banner) and sometimes a regression source (the `provider:null` gate). 4.7 was more conservative: it added paths but didn't relax existing gates.
+4. **4.7's user-empathy framing produced higher-leverage fixes.** "What does the PH visitor hit in the first 60 seconds" produced four user-visible improvements; "harden onboarding against failure modes" produced six fixes for hypothetical edge cases (broker token-write, `/config` POST) plus two real ones. The first framing front-loaded the high-impact work.

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/sahilm/fuzzy v0.1.1
 	golang.org/x/sync v0.20.0
+	golang.org/x/term v0.36.0
 	golang.org/x/text v0.36.0
 	google.golang.org/genai v1.54.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -93,7 +94,6 @@ require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240903143218-8af14fe29dc1 // indirect
 	google.golang.org/grpc v1.66.2 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect

--- a/internal/onboarding/state.go
+++ b/internal/onboarding/state.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,7 +101,11 @@ func Load() (*State, error) {
 	}
 	var s State
 	if err := json.Unmarshal(data, &s); err != nil {
-		return nil, fmt.Errorf("onboarding: parse state: %w", err)
+		log.Printf("onboarding: corrupt state file, resetting to fresh state: %v", err)
+		return &State{
+			Version:   currentStateVersion,
+			Checklist: DefaultChecklist(),
+		}, nil
 	}
 	// If the file was written by an older schema version, return a fresh state
 	// so the user re-runs onboarding rather than hitting subtle bugs.

--- a/internal/onboarding/state.go
+++ b/internal/onboarding/state.go
@@ -102,10 +102,18 @@ func Load() (*State, error) {
 	var s State
 	if err := json.Unmarshal(data, &s); err != nil {
 		log.Printf("onboarding: corrupt state file, resetting to fresh state: %v", err)
-		return &State{
+		fresh := &State{
 			Version:   currentStateVersion,
 			Checklist: DefaultChecklist(),
-		}, nil
+		}
+		// Persist the recovered state so the next Load reads valid JSON
+		// instead of triggering this branch again on every call. Best-
+		// effort: a write failure here just means we'll log+recover again
+		// next time, which is the same as the pre-fix behavior.
+		if writeErr := Save(fresh); writeErr != nil {
+			log.Printf("onboarding: failed to overwrite corrupt state file: %v", writeErr)
+		}
+		return fresh, nil
 	}
 	// If the file was written by an older schema version, return a fresh state
 	// so the user re-runs onboarding rather than hitting subtle bugs.

--- a/internal/onboarding/state_test.go
+++ b/internal/onboarding/state_test.go
@@ -197,7 +197,8 @@ func TestCorruptStateFileRecovers(t *testing.T) {
 		if err := os.MkdirAll(dir, 0o700); err != nil {
 			t.Fatalf("MkdirAll: %v", err)
 		}
-		if err := os.WriteFile(filepath.Join(dir, "onboarded.json"), []byte("{corrupt json!!!"), 0o600); err != nil {
+		path := filepath.Join(dir, "onboarded.json")
+		if err := os.WriteFile(path, []byte("{corrupt json!!!"), 0o600); err != nil {
 			t.Fatalf("WriteFile: %v", err)
 		}
 
@@ -213,6 +214,24 @@ func TestCorruptStateFileRecovers(t *testing.T) {
 		}
 		if len(s.Checklist) == 0 {
 			t.Fatal("corrupt file recovery should have default checklist")
+		}
+
+		// The corrupt file must be replaced with valid JSON so the next
+		// Load doesn't re-trigger the recovery branch on every call.
+		s2, err := Load()
+		if err != nil {
+			t.Fatalf("second Load after recovery should succeed cleanly, got: %v", err)
+		}
+		if s2.Version != currentStateVersion {
+			t.Errorf("post-recovery Version: got %d, want %d", s2.Version, currentStateVersion)
+		}
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile post-recovery: %v", err)
+		}
+		var probe State
+		if err := json.Unmarshal(raw, &probe); err != nil {
+			t.Fatalf("post-recovery file should be valid JSON, got: %v", err)
 		}
 	})
 }

--- a/internal/onboarding/state_test.go
+++ b/internal/onboarding/state_test.go
@@ -191,6 +191,32 @@ func TestSaveProgressMergesCorrectly(t *testing.T) {
 	})
 }
 
+func TestCorruptStateFileRecovers(t *testing.T) {
+	withTempHome(t, func(home string) {
+		dir := filepath.Join(home, ".wuphf")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "onboarded.json"), []byte("{corrupt json!!!"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		s, err := Load()
+		if err != nil {
+			t.Fatalf("Load should recover from corrupt file, got error: %v", err)
+		}
+		if s.Onboarded() {
+			t.Fatal("corrupt file should return onboarded=false")
+		}
+		if s.Version != currentStateVersion {
+			t.Errorf("Version: got %d, want %d", s.Version, currentStateVersion)
+		}
+		if len(s.Checklist) == 0 {
+			t.Fatal("corrupt file recovery should have default checklist")
+		}
+	})
+}
+
 func TestVersionBumpReturnsNotOnboarded(t *testing.T) {
 	withTempHome(t, func(home string) {
 		// Write a file that looks complete but with an old schema version.

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -1682,7 +1682,9 @@ func (b *Broker) StartOnPort(port int) error {
 		tokenFile = brokeraddr.ResolveTokenFile()
 	}
 	if tokenFile != "" {
-		_ = os.WriteFile(tokenFile, []byte(b.token), 0o600)
+		if err := os.WriteFile(tokenFile, []byte(b.token), 0o600); err != nil {
+			log.Printf("broker: failed to write token file %s: %v", tokenFile, err)
+		}
 	}
 
 	go func() {
@@ -2397,7 +2399,8 @@ func (b *Broker) handleAgentStream(w http.ResponseWriter, r *http.Request) {
 }
 
 // ServeWebUI starts a static file server for the web UI on the given port.
-func (b *Broker) ServeWebUI(port int) {
+// Returns an error if the port cannot be bound (e.g. already in use).
+func (b *Broker) ServeWebUI(port int) error {
 	b.webUIOrigins = []string{
 		fmt.Sprintf("http://localhost:%d", port),
 		fmt.Sprintf("http://127.0.0.1:%d", port),
@@ -2452,11 +2455,18 @@ func (b *Broker) ServeWebUI(port int) {
 	// Without this, users stay pinned to a stale bundle for days because
 	// Chrome's heuristic cache revalidates HTML only occasionally.
 	mux.Handle("/", cacheControlMiddleware(fileServer))
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("web UI: listen on %s: %w", addr, err)
+	}
+	srv := &http.Server{Handler: mux}
 	go func() {
-		if err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), mux); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Printf("broker web UI proxy: listen on :%d: %v", port, err)
+		if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Printf("broker web UI proxy: serve on :%d: %v", port, err)
 		}
 	}()
+	return nil
 }
 
 // cacheControlMiddleware sets conservative cache headers on the web UI so

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -2456,7 +2456,12 @@ func (b *Broker) ServeWebUI(port int) error {
 	// Chrome's heuristic cache revalidates HTML only occasionally.
 	mux.Handle("/", cacheControlMiddleware(fileServer))
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	ln, err := net.Listen("tcp", addr)
+	// noctx: net.Listen is the blocking primitive; the lint rule is meant
+	// for HTTP clients. Use ListenConfig.Listen with a Background context
+	// so the linter's intent (no caller-controllable cancellation lost) is
+	// satisfied without changing the actual lifecycle.
+	lc := &net.ListenConfig{}
+	ln, err := lc.Listen(context.Background(), "tcp", addr)
 	if err != nil {
 		return fmt.Errorf("web UI: listen on %s: %w", addr, err)
 	}

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -290,9 +290,11 @@ func (b *Broker) postKickoffLocked(bp operations.Blueprint, selectedAgents []str
 	if skipTask {
 		// Without a seeded task, #general would otherwise be empty (or hold
 		// only the lead-only warning) and the office looks broken on first
-		// open. Post a system welcome that names the lead and tells the user
-		// where to type so the channel always has an affordance for what to
-		// do next.
+		// open. Post a system welcome plus a presence line from the lead so
+		// the channel always has an affordance for what to do next AND feels
+		// staffed rather than abstract. The presence line is marked Kind=
+		// "demo_seed" so the launcher's notification path treats it as inert
+		// — it must not trigger an LLM dispatch.
 		b.counter++
 		b.appendMessageLocked(channelMessage{
 			ID:        fmt.Sprintf("msg-%d", b.counter),
@@ -302,6 +304,18 @@ func (b *Broker) postKickoffLocked(bp operations.Blueprint, selectedAgents []str
 			Content:   welcomeMessageForMembers(b.members),
 			Timestamp: now,
 		})
+		if leadSlug, leadName := leadSlugAndName(b.members); leadSlug != "" {
+			b.counter++
+			b.appendMessageLocked(channelMessage{
+				ID:        fmt.Sprintf("msg-%d", b.counter),
+				From:      leadSlug,
+				Channel:   "general",
+				Kind:      "demo_seed",
+				Content:   fmt.Sprintf("%s online. Drop a directive in the composer and I'll break it down and dispatch the team.", leadName),
+				Tagged:    []string{},
+				Timestamp: now,
+			})
+		}
 		// seedFromBlueprintLocked mutated b.members/channels/tasks above; we
 		// must persist that even when the user skipped the kickoff task.
 		// Returning early without saveLocked() silently loses the seeded team
@@ -370,14 +384,7 @@ func (b *Broker) postKickoffLocked(bp operations.Blueprint, selectedAgents []str
 // the user finishes onboarding without seeding a task. Names the lead so the
 // office feels staffed (not abstract) and points the user at the composer.
 func welcomeMessageForMembers(members []officeMember) string {
-	leadSlug := officeLeadSlugFromMembers(members)
-	leadName := ""
-	for _, m := range members {
-		if strings.TrimSpace(m.Slug) == leadSlug {
-			leadName = strings.TrimSpace(m.Name)
-			break
-		}
-	}
+	_, leadName := leadSlugAndName(members)
 	if leadName == "" {
 		leadName = "your lead"
 	}
@@ -385,6 +392,22 @@ func welcomeMessageForMembers(members []officeMember) string {
 		"Welcome to your office. %s and the team are online and ready. Type a directive in the composer below — they'll claim work, argue, and ship.",
 		leadName,
 	)
+}
+
+// leadSlugAndName returns the slug+display-name of the office lead. Empty
+// strings are returned when the roster has no identifiable lead — callers
+// should treat that as "skip lead-specific messaging" rather than crash.
+func leadSlugAndName(members []officeMember) (string, string) {
+	slug := officeLeadSlugFromMembers(members)
+	if slug == "" {
+		return "", ""
+	}
+	for _, m := range members {
+		if strings.TrimSpace(m.Slug) == slug {
+			return slug, strings.TrimSpace(m.Name)
+		}
+	}
+	return slug, ""
 }
 
 func onboardingPartialString(partial *onboarding.PartialProgress, step, key string) string {

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -288,6 +288,20 @@ func (b *Broker) postKickoffLocked(bp operations.Blueprint, selectedAgents []str
 	}
 
 	if skipTask {
+		// Without a seeded task, #general would otherwise be empty (or hold
+		// only the lead-only warning) and the office looks broken on first
+		// open. Post a system welcome that names the lead and tells the user
+		// where to type so the channel always has an affordance for what to
+		// do next.
+		b.counter++
+		b.appendMessageLocked(channelMessage{
+			ID:        fmt.Sprintf("msg-%d", b.counter),
+			From:      "system",
+			Channel:   "general",
+			Kind:      "system",
+			Content:   welcomeMessageForMembers(b.members),
+			Timestamp: now,
+		})
 		// seedFromBlueprintLocked mutated b.members/channels/tasks above; we
 		// must persist that even when the user skipped the kickoff task.
 		// Returning early without saveLocked() silently loses the seeded team
@@ -350,6 +364,27 @@ func (b *Broker) postKickoffLocked(bp operations.Blueprint, selectedAgents []str
 	}
 
 	return b.saveLocked()
+}
+
+// welcomeMessageForMembers builds the system welcome posted to #general when
+// the user finishes onboarding without seeding a task. Names the lead so the
+// office feels staffed (not abstract) and points the user at the composer.
+func welcomeMessageForMembers(members []officeMember) string {
+	leadSlug := officeLeadSlugFromMembers(members)
+	leadName := ""
+	for _, m := range members {
+		if strings.TrimSpace(m.Slug) == leadSlug {
+			leadName = strings.TrimSpace(m.Name)
+			break
+		}
+	}
+	if leadName == "" {
+		leadName = "your lead"
+	}
+	return fmt.Sprintf(
+		"Welcome to your office. %s and the team are online and ready. Type a directive in the composer below — they'll claim work, argue, and ship.",
+		leadName,
+	)
 }
 
 func onboardingPartialString(partial *onboarding.PartialProgress, step, key string) string {

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -386,7 +386,7 @@ func (b *Broker) postKickoffLocked(bp operations.Blueprint, selectedAgents []str
 func welcomeMessageForMembers(members []officeMember) string {
 	_, leadName := leadSlugAndName(members)
 	if leadName == "" {
-		leadName = "your lead"
+		leadName = "Your lead"
 	}
 	return fmt.Sprintf(
 		"Welcome to your office. %s and the team are online and ready. Type a directive in the composer below — they'll claim work, argue, and ship.",

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -4848,11 +4848,12 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	select {}
 }
 
-// maybeOfferNex offers to wire up Nex for memory/context when nex-cli isn't
-// already installed. Skipped silently when stdin isn't a TTY (npx, pipes, CI,
-// containers) — fmt.Scanln returns empty in that case, which the prompt would
-// have silently accepted as "yes" and tried to install. Users can rerun
-// `nex setup` later or set WUPHF_NO_NEX=1 to suppress the offer.
+// maybeOfferNex offers to wire up Nex for memory/context when nex-cli
+// isn't already installed. Prints an explicit "skipping Nex" line when
+// stdin isn't a TTY (npx, pipes, CI, containers) — fmt.Scanln returns
+// empty in that case, which the prompt would have silently accepted as
+// "yes" and tried to install. Users can rerun `nex setup` later or set
+// WUPHF_NO_NEX=1 to suppress the offer.
 func (l *Launcher) maybeOfferNex() {
 	if config.ResolveNoNex() || nex.IsInstalled() {
 		return
@@ -4911,11 +4912,13 @@ func (l *Launcher) maybeOfferNex() {
 }
 
 // waitForWebReady polls addr until a TCP dial succeeds or the timeout
-// elapses. It exists because ServeWebUI returns immediately and the listener
-// can take a few hundred ms to come up — opening the browser before then
-// produces ERR_CONNECTION_REFUSED in the user's first second of the product.
-// Returns whether the listener became reachable; the caller currently opens
-// the browser regardless so a slow listener still surfaces a real page.
+// elapses. It exists because ServeWebUI returns immediately and the
+// listener can take a few hundred ms to come up — opening the browser
+// before then produces ERR_CONNECTION_REFUSED in the user's first
+// second of the product. Returns true when the listener accepted a
+// connection within the timeout, false otherwise. LaunchWeb gates
+// openBrowser on this return value, so a never-up listener results in
+// a printed "skipping browser auto-open" line rather than a dead URL.
 func waitForWebReady(addr string, timeout time.Duration) bool {
 	dialer := &net.Dialer{Timeout: 250 * time.Millisecond}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -70,19 +71,6 @@ var (
 
 func nameWithPortSuffix(base string) string {
 	return nameWithPortSuffixForPort(base, brokeraddr.ResolvePort())
-}
-
-// isStdinInteractive reports whether stdin is connected to a real terminal.
-// Used to gate interactive prompts (e.g. the Nex install Y/n in LaunchWeb)
-// so non-interactive launches — SSH without -tt, scheduled tasks, PowerShell
-// Start-Process — don't take the empty-answer-as-yes branch and silently
-// shell out to global package installs the user never authorized.
-func isStdinInteractive() bool {
-	info, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-	return info.Mode()&os.ModeCharDevice != 0
 }
 
 func nameWithPortSuffixForPort(base string, port int) string {
@@ -4727,50 +4715,7 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	// Offer to wire Nex when the user hasn't opted out and nex-cli isn't yet
 	// installed. `nex setup` handles detection and wiring for us — we just
 	// surface the prompt.
-	//
-	// When stdin is non-interactive (SSH without -tt, PowerShell Start-Process,
-	// scheduled tasks — common on Windows), Scanln returns EOF immediately
-	// with an empty answer. The Y/n default would treat that as "yes" and
-	// silently shell out to `npm install -g @nex-ai/nex@latest`, which is a
-	// global side-effect the user never authorized. Skip the prompt entirely
-	// in that case and default to "no" (matches the explicit --no-nex path).
-	if !config.ResolveNoNex() && !nex.IsInstalled() {
-		if !isStdinInteractive() {
-			fmt.Println()
-			fmt.Println("  Skipping Nex (non-interactive stdin). Pass --nex or run interactively to opt in.")
-			fmt.Println()
-		} else {
-			fmt.Println()
-			fmt.Print("  Connect Nex for memory and context? [Y/n] ")
-			var answer string
-			_, _ = fmt.Scanln(&answer)
-			answer = strings.TrimSpace(strings.ToLower(answer))
-			if answer == "" || answer == "y" || answer == "yes" {
-				fmt.Println()
-				fmt.Println("  Nex CLI not found. Installing...")
-				if _, installErr := setup.InstallLatestCLI(context.Background()); installErr != nil {
-					fmt.Printf("  Could not install: %v\n", installErr)
-					fmt.Println("  Continuing without Nex.")
-				}
-				if nexBin := nex.BinaryPath(); nexBin != "" {
-					cmd := exec.CommandContext(context.Background(), nexBin, "setup")
-					cmd.Stdin = os.Stdin
-					cmd.Stdout = os.Stdout
-					cmd.Stderr = os.Stderr
-					if err := cmd.Run(); err != nil {
-						fmt.Printf("  Setup did not complete: %v\n", err)
-						fmt.Println("  Continuing without Nex.")
-					} else {
-						fmt.Println("  Nex connected.")
-					}
-				}
-				fmt.Println()
-			} else {
-				fmt.Println("  Skipping Nex. Agents will work without organizational memory.")
-				fmt.Println()
-			}
-		}
-	}
+	l.maybeOfferNex()
 
 	mcpConfig, err := l.ensureMCPConfig()
 	if err != nil {
@@ -4849,12 +4794,100 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	fmt.Printf("  Press Ctrl+C to stop.\n\n")
 
 	if !l.noOpen {
+		// Wait for the web server to actually accept connections before
+		// triggering the browser. Otherwise users on cold starts (and PH
+		// visitors clicking through `npx wuphf` for the first time) hit
+		// ERR_CONNECTION_REFUSED before the listener is ready. 5s is a
+		// generous ceiling: in practice the listener is up in milliseconds.
+		waitForWebReady(fmt.Sprintf("127.0.0.1:%d", webPort), 5*time.Second)
 		openBrowser(webURL)
 	}
 
 	// Broker, web UI, and background goroutines own the process lifetime;
 	// Ctrl+C (default SIGINT) is the only exit path.
 	select {}
+}
+
+// maybeOfferNex offers to wire up Nex for memory/context when nex-cli isn't
+// already installed. Skipped silently when stdin isn't a TTY (npx, pipes, CI,
+// containers) — fmt.Scanln returns empty in that case, which the prompt would
+// have silently accepted as "yes" and tried to install. Users can rerun
+// `nex setup` later or set WUPHF_NO_NEX=1 to suppress the offer.
+func (l *Launcher) maybeOfferNex() {
+	if config.ResolveNoNex() || nex.IsInstalled() {
+		return
+	}
+	if !stdinIsTTY() {
+		fmt.Println()
+		fmt.Println("  Skipping Nex (no interactive terminal). Run `nex setup` later to add memory.")
+		fmt.Println()
+		return
+	}
+	fmt.Println()
+	fmt.Print("  Connect Nex for memory and context? [Y/n] ")
+	var answer string
+	_, _ = fmt.Scanln(&answer)
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "" && answer != "y" && answer != "yes" {
+		fmt.Println("  Skipping Nex. Agents will work without organizational memory.")
+		fmt.Println()
+		return
+	}
+	fmt.Println()
+	fmt.Println("  Nex CLI not found. Installing...")
+	if _, installErr := setup.InstallLatestCLI(context.Background()); installErr != nil {
+		fmt.Printf("  Could not install: %v\n", installErr)
+		fmt.Println("  Continuing without Nex.")
+	}
+	if nexBin := nex.BinaryPath(); nexBin != "" {
+		cmd := exec.CommandContext(context.Background(), nexBin, "setup")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("  Setup did not complete: %v\n", err)
+			fmt.Println("  Continuing without Nex.")
+		} else {
+			fmt.Println("  Nex connected.")
+		}
+	}
+	fmt.Println()
+}
+
+// waitForWebReady polls addr until a TCP dial succeeds or the timeout
+// elapses. It exists because ServeWebUI returns immediately and the listener
+// can take a few hundred ms to come up — opening the browser before then
+// produces ERR_CONNECTION_REFUSED in the user's first second of the product.
+// Returns whether the listener became reachable; the caller currently opens
+// the browser regardless so a slow listener still surfaces a real page.
+func waitForWebReady(addr string, timeout time.Duration) bool {
+	dialer := &net.Dialer{Timeout: 250 * time.Millisecond}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	for {
+		conn, err := dialer.DialContext(ctx, "tcp", addr)
+		if err == nil {
+			_ = conn.Close()
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// stdinIsTTY reports whether os.Stdin is connected to a real terminal. We use
+// the stat-mode test instead of pulling in a TTY library: it's accurate enough
+// for the launcher's "is the user able to answer prompts?" question and avoids
+// touching go.mod for a launch-day fix.
+func stdinIsTTY() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) != 0
 }
 
 func openBrowser(url string) {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -2376,9 +2376,15 @@ func (l *Launcher) buildNotificationContext(channel, triggerMsgID, threadRootID 
 		return ""
 	}
 
-	// baseFilter excludes system messages, STATUS messages, and the trigger itself.
+	// baseFilter excludes system messages, STATUS messages, demo_seed posts,
+	// and the trigger itself. demo_seed lines are cosmetic onboarding-paint
+	// content (e.g. the lead presence line) and replaying them as prompt
+	// context would let agents treat fake activity as real history.
 	baseFilter := func(m channelMessage) bool {
 		if m.From == "system" {
+			return false
+		}
+		if m.Kind == "demo_seed" {
 			return false
 		}
 		if strings.TrimSpace(triggerMsgID) != "" && strings.TrimSpace(m.ID) == strings.TrimSpace(triggerMsgID) {
@@ -4795,7 +4801,13 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		go l.primeVisibleAgents()
 	}
 
-	webURL := fmt.Sprintf("http://localhost:%d", webPort)
+	// Use 127.0.0.1 in both the printed URL and the readiness probe so the
+	// dial target matches what the browser will request. localhost can
+	// resolve to ::1 first on IPv6-preferring setups, while ServeWebUI binds
+	// only to 127.0.0.1 — that mismatch reproduces ERR_CONNECTION_REFUSED
+	// even after the probe succeeds.
+	webAddr := fmt.Sprintf("127.0.0.1:%d", webPort)
+	webURL := fmt.Sprintf("http://%s", webAddr)
 	fmt.Printf("\n  Web UI:  %s\n", webURL)
 	fmt.Printf("  Broker:  %s\n", l.BrokerBaseURL())
 	fmt.Printf("  Press Ctrl+C to stop.\n\n")
@@ -4806,8 +4818,13 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		// visitors clicking through `npx wuphf` for the first time) hit
 		// ERR_CONNECTION_REFUSED before the listener is ready. 5s is a
 		// generous ceiling: in practice the listener is up in milliseconds.
-		waitForWebReady(fmt.Sprintf("127.0.0.1:%d", webPort), 5*time.Second)
-		openBrowser(webURL)
+		// Skip the open if the listener never came up — opening a dead URL
+		// just produces a confusing error page in the user's first second.
+		if waitForWebReady(webAddr, 5*time.Second) {
+			openBrowser(webURL)
+		} else {
+			fmt.Printf("  Web UI did not become reachable at %s within 5s; skipping browser auto-open.\n", webURL)
+		}
 	}
 
 	// Broker, web UI, and background goroutines own the process lifetime;

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -27,6 +28,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"golang.org/x/term"
 
 	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/agent"
@@ -4863,7 +4866,23 @@ func (l *Launcher) maybeOfferNex() {
 	fmt.Println()
 	fmt.Print("  Connect Nex for memory and context? [Y/n] ")
 	var answer string
-	_, _ = fmt.Scanln(&answer)
+	if _, err := fmt.Scanln(&answer); err != nil {
+		// fmt.Scanln has two distinct error shapes here:
+		//   - io.EOF: stdin was closed underneath us. By the time we
+		//     reach this branch stdinIsTTY() already returned true, so
+		//     EOF means the user explicitly hit Ctrl-D rather than
+		//     answering. Treat as a deliberate skip.
+		//   - any other error (most commonly "unexpected newline" from
+		//     a bare Enter): the prompt label says [Y/n], so capital-Y
+		//     is the visible default. Accept Enter as "yes" so the UX
+		//     contract matches the prompt.
+		if errors.Is(err, io.EOF) {
+			fmt.Println("  Skipping Nex. Agents will work without organizational memory.")
+			fmt.Println()
+			return
+		}
+		answer = ""
+	}
 	answer = strings.TrimSpace(strings.ToLower(answer))
 	if answer != "" && answer != "y" && answer != "yes" {
 		fmt.Println("  Skipping Nex. Agents will work without organizational memory.")
@@ -4915,16 +4934,13 @@ func waitForWebReady(addr string, timeout time.Duration) bool {
 	}
 }
 
-// stdinIsTTY reports whether os.Stdin is connected to a real terminal. We use
-// the stat-mode test instead of pulling in a TTY library: it's accurate enough
-// for the launcher's "is the user able to answer prompts?" question and avoids
-// touching go.mod for a launch-day fix.
+// stdinIsTTY reports whether os.Stdin is connected to a real terminal.
+// Uses golang.org/x/term so /dev/null (a char device but not a TTY) is
+// classified correctly — the original os.ModeCharDevice check let
+// `npx ... </dev/null` fall back to the auto-yes install path, which
+// is the cold-start bug this whole helper exists to prevent.
 func stdinIsTTY() bool {
-	stat, err := os.Stdin.Stat()
-	if err != nil {
-		return false
-	}
-	return (stat.Mode() & os.ModeCharDevice) != 0
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 func openBrowser(url string) {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -463,6 +463,11 @@ func (l *Launcher) notifyAgentsLoop() {
 		if msg.From == "system" {
 			continue
 		}
+		// demo_seed messages exist purely to make #general feel staffed on
+		// first paint; they must never wake an agent or burn an LLM call.
+		if msg.Kind == "demo_seed" {
+			continue
+		}
 		l.safeDeliverMessage(msg)
 	}
 }

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -463,11 +463,6 @@ func (l *Launcher) notifyAgentsLoop() {
 		if msg.From == "system" {
 			continue
 		}
-		// demo_seed messages exist purely to make #general feel staffed on
-		// first paint; they must never wake an agent or burn an LLM call.
-		if msg.Kind == "demo_seed" {
-			continue
-		}
 		l.safeDeliverMessage(msg)
 	}
 }
@@ -688,6 +683,17 @@ const (
 )
 
 func (l *Launcher) deliverMessageNotification(msg channelMessage) {
+	// demo_seed messages exist purely to make #general feel staffed on first
+	// paint; they must never wake an agent or burn an LLM call. Filter at
+	// the central delivery point (not just notifyAgentsLoop) so other
+	// callers — primeVisibleAgents, replays, future routes — can't bypass
+	// it. Today these don't actually route demo_seed targets because the
+	// lead is the From and Tagged is empty, but a future @all-default
+	// change would silently turn the demo seed into an LLM-burning
+	// broadcast. One filter, one place.
+	if msg.Kind == "demo_seed" {
+		return
+	}
 	immediate, delayed := l.notificationTargetsForMessage(msg)
 
 	// Debounce: use shorter cooldown for human/CEO messages, longer for agent-originated

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -4765,7 +4765,9 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 
 	l.broker.SetGenerateMemberFn(l.GenerateMemberTemplateFromPrompt)
 	l.broker.SetGenerateChannelFn(l.GenerateChannelTemplateFromPrompt)
-	l.broker.ServeWebUI(webPort)
+	if err := l.broker.ServeWebUI(webPort); err != nil {
+		return fmt.Errorf("web UI failed to start: %w\n\nIs port %d already in use? Try: wuphf --web-port %d", err, webPort, webPort+1)
+	}
 
 	// Default path: headless `claude --print` per turn. Anthropic re-sanctioned
 	// this invocation (OpenClaw policy note, 2026-04), so it runs on the user's

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -4772,6 +4772,13 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	l.broker.SetGenerateMemberFn(l.GenerateMemberTemplateFromPrompt)
 	l.broker.SetGenerateChannelFn(l.GenerateChannelTemplateFromPrompt)
 	if err := l.broker.ServeWebUI(webPort); err != nil {
+		// The broker is already running and the office PID file is on
+		// disk (above). On a port-bind failure we exit, so tear both
+		// down — leaving the broker accepting requests on a "wuphf has
+		// failed to start" path is worse than a clean exit, and a stale
+		// PID file would block the next launch attempt's writeOfficePID.
+		l.broker.Stop()
+		_ = clearOfficePIDFile()
 		return fmt.Errorf("web UI failed to start: %w\n\nIs port %d already in use? Try: wuphf --web-port %d", err, webPort, webPort+1)
 	}
 

--- a/internal/team/launcher_demo_seed_test.go
+++ b/internal/team/launcher_demo_seed_test.go
@@ -1,0 +1,178 @@
+package team
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestSkipTaskSeedsWelcomeAndPresence asserts the central onboarding
+// invariant: when the wizard finishes with skip_task=true, #general lands
+// with two messages — a system welcome and a lead presence line marked
+// Kind="demo_seed". Without coverage here a future change to
+// postKickoffLocked could silently drop one or both and the channel would
+// look empty on first paint without anything in CI catching it.
+func TestSkipTaskSeedsWelcomeAndPresence(t *testing.T) {
+	ensureOperationsFallbackFS(t)
+	b := newTestBroker(t)
+	if err := b.onboardingCompleteFn("", true, "niche-crm", nil); err != nil {
+		t.Fatalf("onboardingCompleteFn: %v", err)
+	}
+
+	msgs := b.ChannelMessages("general")
+	var welcome, presence *channelMessage
+	for i := range msgs {
+		m := &msgs[i]
+		if m.Kind == "system" && strings.Contains(m.Content, "Welcome to your office") {
+			welcome = m
+		}
+		if m.Kind == "demo_seed" {
+			presence = m
+		}
+	}
+	if welcome == nil {
+		t.Fatalf("expected system welcome in #general; got %d messages: %+v", len(msgs), msgs)
+	}
+	if presence == nil {
+		t.Fatalf("expected demo_seed presence line in #general; got %d messages: %+v", len(msgs), msgs)
+	}
+	if presence.From == "system" {
+		t.Errorf("presence line must be From=lead, not system; got From=%q", presence.From)
+	}
+	// Tagged: [] (not nil) — the empty-but-non-nil shape is what keeps
+	// content-routing from picking up the line as an implicit @mention.
+	if presence.Tagged == nil || len(presence.Tagged) != 0 {
+		t.Errorf("presence line Tagged must be []; got %#v", presence.Tagged)
+	}
+}
+
+// TestDeliverMessageNotificationSkipsDemoSeed asserts the central guard:
+// demo_seed messages must never reach notificationTargetsForMessage. The
+// filter lives in deliverMessageNotification (not notifyAgentsLoop) so any
+// caller — including primeVisibleAgents and replays — is protected.
+//
+// We assert by calling deliverMessageNotification directly with a
+// demo_seed message and confirming notifyLastDelivered stays empty: the
+// real targets path always touches that map before sending, so an empty
+// map after the call proves the early-return fired.
+func TestDeliverMessageNotificationSkipsDemoSeed(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.members = []officeMember{
+		{Slug: "ceo", Name: "CEO", Role: "Lead", BuiltIn: true},
+		{Slug: "builder", Name: "Builder", Role: "Builder"},
+	}
+	b.mu.Unlock()
+	l := &Launcher{broker: b}
+
+	l.deliverMessageNotification(channelMessage{
+		ID:      "msg-1",
+		From:    "ceo",
+		Channel: "general",
+		Kind:    "demo_seed",
+		Content: "CEO online. Drop a directive in the composer.",
+		Tagged:  []string{},
+	})
+
+	l.notifyMu.Lock()
+	delivered := len(l.notifyLastDelivered)
+	l.notifyMu.Unlock()
+	if delivered != 0 {
+		t.Fatalf("demo_seed message must not record a delivery; got %d entries: %+v", delivered, l.notifyLastDelivered)
+	}
+}
+
+// TestBuildNotificationContextExcludesDemoSeed asserts that the cosmetic
+// CEO presence line never appears in the prompt context shown to agents.
+// Without this filter, replaying a synthetic onboarding line as if it were
+// real channel history would let agents react to the seed as a directive.
+func TestBuildNotificationContextExcludesDemoSeed(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.members = []officeMember{
+		{Slug: "ceo", Name: "CEO", Role: "Lead", BuiltIn: true},
+	}
+	for i := range b.channels {
+		if b.channels[i].Slug == "general" {
+			b.channels[i].Members = []string{"ceo"}
+		}
+	}
+	b.appendMessageLocked(channelMessage{
+		ID:      "msg-seed",
+		From:    "ceo",
+		Channel: "general",
+		Kind:    "demo_seed",
+		Content: "CEO online. Drop a directive in the composer.",
+	})
+	b.appendMessageLocked(channelMessage{
+		ID:      "msg-real",
+		From:    "you",
+		Channel: "general",
+		Content: "Real human message that should appear.",
+	})
+	b.mu.Unlock()
+	l := &Launcher{broker: b}
+
+	ctx := l.buildNotificationContext("general", "", "", 5)
+	if !strings.Contains(ctx, "Real human message") {
+		t.Fatalf("expected the real human message in context; got %q", ctx)
+	}
+	if strings.Contains(ctx, "CEO online") {
+		t.Fatalf("demo_seed content leaked into prompt context: %q", ctx)
+	}
+}
+
+// TestServeWebUIReturnsErrorOnBoundPort asserts that ServeWebUI surfaces a
+// port-conflict error synchronously rather than swallowing it inside the
+// goroutine. Pre-fix this was a log.Printf that left the launcher claiming
+// success while the listener was dead.
+func TestServeWebUIReturnsErrorOnBoundPort(t *testing.T) {
+	hold, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer hold.Close()
+	port := hold.Addr().(*net.TCPAddr).Port
+
+	b := newTestBroker(t)
+	if err := b.ServeWebUI(port); err == nil {
+		t.Fatalf("ServeWebUI on busy port %d returned nil error", port)
+	}
+}
+
+// TestWaitForWebReadyTimesOutOnDeadAddr asserts the negative-path return
+// value the launcher relies on to skip openBrowser. Picks an unbound port
+// (closed-and-released) and a tight ceiling so the test stays sub-second.
+func TestWaitForWebReadyTimesOutOnDeadAddr(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	start := time.Now()
+	if waitForWebReady(addr, 200*time.Millisecond) {
+		t.Fatalf("waitForWebReady on dead %s returned true", addr)
+	}
+	if elapsed := time.Since(start); elapsed > 1*time.Second {
+		t.Fatalf("waitForWebReady took %v on dead addr; expected ≤ ~timeout", elapsed)
+	}
+}
+
+// TestWaitForWebReadyReturnsTrueOnLiveAddr asserts the positive-path
+// return so we know the bool gate distinguishes the two states (otherwise
+// "always returns false" would silently pass the negative test alone).
+func TestWaitForWebReadyReturnsTrueOnLiveAddr(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	addr := ln.Addr().String()
+
+	if !waitForWebReady(addr, 2*time.Second) {
+		t.Fatalf("waitForWebReady on live %s returned false", addr)
+	}
+}

--- a/web/e2e/.gitignore
+++ b/web/e2e/.gitignore
@@ -1,1 +1,3 @@
 bin/
+playwright-report/
+test-results/

--- a/web/e2e/run-local.sh
+++ b/web/e2e/run-local.sh
@@ -148,7 +148,7 @@ run_wizard_phase() {
   start_wuphf "wizard"
   # Wizard-phase specs: anything that needs the unseeded onboarding flow.
   echo "[run-local] running wizard-phase specs"
-  (cd web/e2e && WUPHF_E2E_BASE_URL="http://localhost:${web_port}" bunx playwright test tests/wizard.spec.ts tests/local-llm-onboarding.spec.ts)
+  (cd web/e2e && WUPHF_E2E_BASE_URL="http://localhost:${web_port}" bunx playwright test tests/wizard.spec.ts tests/wizard-error-states.spec.ts tests/local-llm-onboarding.spec.ts)
   stop_wuphf
 }
 

--- a/web/e2e/tests/wizard-error-states.spec.ts
+++ b/web/e2e/tests/wizard-error-states.spec.ts
@@ -100,6 +100,18 @@ test.describe("Wizard error states", () => {
   test("submitError alert + Retry button appear when /onboarding/complete fails, then succeed on retry", async ({
     page,
   }) => {
+    // Stub /config to a fixed 200 so the only varying surface in this
+    // test is /onboarding/complete. finishOnboarding posts /config
+    // first, and a future regression there would otherwise fail this
+    // test for the wrong reason.
+    page.route("**/config*", (route: Route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      }),
+    );
+
     // Fail /onboarding/complete on the FIRST POST, succeed on the second.
     // This exercises the full retry round-trip — banner appears, button
     // text flips to "Retry", clicking Retry re-issues the POST and

--- a/web/e2e/tests/wizard-error-states.spec.ts
+++ b/web/e2e/tests/wizard-error-states.spec.ts
@@ -1,0 +1,166 @@
+import { expect, type Page, type Route, test } from "@playwright/test";
+
+// E2E coverage for the two new wizard error UI surfaces shipped in PR #367:
+//
+//   1. prereqsError banner + selectable runtime tiles, when the
+//      /onboarding/prereqs fetch fails (broker down, schema drift, etc.)
+//   2. submitError alert + Retry button, when /onboarding/complete fails
+//      (port conflict, broker file-locked, etc.)
+//
+// Both surfaces are user-visible UX shipping in the PH window — without
+// e2e protection a future change to the Wizard control flow could silently
+// turn the banner off (back to "all tiles disabled") or swallow the submit
+// error again. Pre-existing wizard.spec.ts only covers the happy path.
+
+async function waitForReactMount(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const root = document.getElementById("root");
+      if (!root) return false;
+      if (document.getElementById("skeleton")) return false;
+      return root.children.length > 0;
+    },
+    { timeout: 10_000 },
+  );
+}
+
+// Drive the wizard from welcome through to the setup step where both
+// the prereqs banner and the runtime tile selection live. Mirrors
+// local-llm-onboarding.spec.ts::advanceToSetupStep so failures in the
+// shared path manifest the same way across both files.
+async function advanceToSetupStep(page: Page) {
+  await page.goto("/");
+  await waitForReactMount(page);
+  await expect(page.locator(".wizard-step").first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // welcome → identity
+  await page.locator(".wizard-step button.btn-primary").first().click();
+  // identity → templates (required fields)
+  await page.locator("#wiz-company").fill("E2E Error States");
+  await page.locator("#wiz-description").fill("Wizard error path test");
+  await page.locator(".wizard-step button.btn-primary").first().click();
+  // templates → team
+  const templateTile = page.locator(".blueprint-card, .template-tile").first();
+  if (await templateTile.count()) {
+    await templateTile.click();
+  }
+  await page.locator(".wizard-step button.btn-primary").first().click();
+  // team → setup
+  await page.locator(".wizard-step button.btn-primary").first().click();
+
+  // We're on setup when at least one of its known surfaces is visible.
+  await expect(
+    page.getByTestId("setup-runtime-tile-Claude Code").first(),
+  ).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe("Wizard error states", () => {
+  test("prereqsError banner appears + provider:null tiles stay disabled when /onboarding/prereqs fails", async ({
+    page,
+  }) => {
+    // Fail the prereqs endpoint BEFORE navigation. Wizard.tsx fires the
+    // fetch on mount; if we route after navigation the request might
+    // already be in flight.
+    page.route("**/onboarding/prereqs*", (route: Route) =>
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "broker unavailable" }),
+      }),
+    );
+
+    await advanceToSetupStep(page);
+
+    // 1. Banner shows up with the stable test id.
+    await expect(page.getByTestId("prereqs-error-banner")).toBeVisible();
+
+    // 2. Provider-bearing runtimes (Claude Code, Codex, Opencode) are
+    //    selectable so the user can proceed if they trust their own
+    //    install. The selectable predicate sets aria-disabled="false"
+    //    and removes the .disabled class.
+    const claudeTile = page.getByTestId("setup-runtime-tile-Claude Code");
+    await expect(claudeTile).toHaveAttribute("aria-disabled", "false");
+    await expect(claudeTile).not.toHaveClass(/disabled/);
+
+    // 3. provider:null runtimes (Cursor, Windsurf) are still selectable
+    //    BUT — and this is the regression guard — clicking one must
+    //    NOT satisfy the "install gate" alone. The Wizard's
+    //    hasInstalledSelection predicate now requires spec.provider !==
+    //    null under prereqsError, so a Cursor-only selection should
+    //    leave the primary CTA disabled. Asserted via the keyboard gate
+    //    behavior is hard to drive in e2e; instead we just confirm the
+    //    tile is reachable. The unit-test side of the gate lives in
+    //    Wizard's internal logic — covered there.
+    const cursorTile = page.getByTestId("setup-runtime-tile-Cursor");
+    await expect(cursorTile).toHaveAttribute("aria-disabled", "false");
+  });
+
+  test("submitError alert + Retry button appear when /onboarding/complete fails, then succeed on retry", async ({
+    page,
+  }) => {
+    // Fail /onboarding/complete on the FIRST POST, succeed on the second.
+    // This exercises the full retry round-trip — banner appears, button
+    // text flips to "Retry", clicking Retry re-issues the POST and
+    // finishes onboarding.
+    let firstAttempt = true;
+    page.route("**/onboarding/complete*", (route: Route) => {
+      if (firstAttempt) {
+        firstAttempt = false;
+        return route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "broker file-locked" }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    await advanceToSetupStep(page);
+
+    // setup → task: any cloud CLI installed in CI counts as
+    // "selectable"; if none are installed the test runner's prereqs
+    // request will succeed (the "happy" path here, not the prereqs
+    // failure path) but every tile will be disabled, so we paste an
+    // API key to satisfy hasAnyApiKey instead. This keeps the test
+    // resilient across CI environments.
+    const claudeKeyPaste = page.getByTestId("api-key-paste-ANTHROPIC_API_KEY");
+    if (await claudeKeyPaste.count()) {
+      await claudeKeyPaste.click();
+      const input = page.getByTestId("api-key-input-ANTHROPIC_API_KEY");
+      // Match the broker's loose anthropic-key shape: sk-ant-... is
+      // accepted by the validator's prefix check.
+      await input.fill("sk-ant-test-fixture-not-a-real-key");
+    }
+    await page.locator(".wizard-step button.btn-primary").first().click();
+
+    // task → ready (skip the freeform task)
+    await page.locator(".wizard-step button.btn-primary").first().click();
+
+    // We're on ready when the submit button is visible.
+    const submit = page.getByTestId("onboarding-submit-button");
+    await expect(submit).toBeVisible({ timeout: 10_000 });
+
+    // First click → /onboarding/complete fails → submitError banner
+    // appears, button text flips to "Retry".
+    await submit.click();
+    await expect(page.getByTestId("onboarding-submit-error")).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(submit).toHaveText(/Retry/);
+
+    // The PR #367 invariant: a retry must not be silently no-op'd.
+    // Click Retry → second /onboarding/complete returns 200 → the
+    // submitError clears (Wizard sets submitError = "" before the
+    // POST and only re-sets on rejection).
+    await submit.click();
+    await expect(page.getByTestId("onboarding-submit-error")).toHaveCount(0, {
+      timeout: 10_000,
+    });
+  });
+});

--- a/web/e2e/tests/wizard-error-states.spec.ts
+++ b/web/e2e/tests/wizard-error-states.spec.ts
@@ -41,8 +41,11 @@ async function advanceToSetupStep(page: Page) {
   await page.locator("#wiz-company").fill("E2E Error States");
   await page.locator("#wiz-description").fill("Wizard error path test");
   await page.locator(".wizard-step button.btn-primary").first().click();
-  // templates → team
-  const templateTile = page.locator(".blueprint-card, .template-tile").first();
+  // templates → team. Wizard.tsx renders one .template-card per
+  // blueprint plus a separate "From scratch" button; click the first
+  // real card so we exercise the seeded path, not the from-scratch
+  // fallback.
+  const templateTile = page.locator(".template-card").first();
   if (await templateTile.count()) {
     await templateTile.click();
   }
@@ -60,10 +63,11 @@ test.describe("Wizard error states", () => {
   test("prereqsError banner appears + provider:null tiles stay disabled when /onboarding/prereqs fails", async ({
     page,
   }) => {
-    // Fail the prereqs endpoint BEFORE navigation. Wizard.tsx fires the
-    // fetch on mount; if we route after navigation the request might
-    // already be in flight.
-    page.route("**/onboarding/prereqs*", (route: Route) =>
+    // Fail the prereqs endpoint BEFORE navigation. Wizard.tsx fires
+    // the fetch on mount, and page.route() returns a Promise — without
+    // await the interceptor can register after the navigation request
+    // is already in flight, producing a flaky pass.
+    await page.route("**/onboarding/prereqs*", (route: Route) =>
       route.fulfill({
         status: 500,
         contentType: "application/json",
@@ -104,7 +108,7 @@ test.describe("Wizard error states", () => {
     // test is /onboarding/complete. finishOnboarding posts /config
     // first, and a future regression there would otherwise fail this
     // test for the wrong reason.
-    page.route("**/config*", (route: Route) =>
+    await page.route("**/config*", (route: Route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -117,7 +121,7 @@ test.describe("Wizard error states", () => {
     // text flips to "Retry", clicking Retry re-issues the POST and
     // finishes onboarding.
     let firstAttempt = true;
-    page.route("**/onboarding/complete*", (route: Route) => {
+    await page.route("**/onboarding/complete*", (route: Route) => {
       if (firstAttempt) {
         firstAttempt = false;
         return route.fulfill({

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -1097,6 +1097,7 @@ export function ApiKeyRow({ field, value, onChange }: ApiKeyRowProps) {
 interface SetupStepProps {
   prereqs: PrereqResult[];
   prereqsLoading: boolean;
+  prereqsError: string;
   runtimePriority: string[];
   onToggleRuntime: (label: string) => void;
   onReorderRuntime: (label: string, direction: -1 | 1) => void;
@@ -1129,6 +1130,7 @@ function detectedBinary(
 function SetupStep({
   prereqs,
   prereqsLoading,
+  prereqsError,
   runtimePriority,
   onToggleRuntime,
   onReorderRuntime,
@@ -1155,10 +1157,11 @@ function SetupStep({
   const [localModeOn, setLocalModeOn] = useState<boolean>(localProvider !== "");
 
   // A runtime is usable only when its binary is actually present on PATH.
-  // "Selected and installed" drives whether we can continue without keys.
+  // When detection failed (prereqsError), trust the user's selection.
   const hasInstalledSelection = runtimePriority.some((label) => {
     const spec = RUNTIMES.find((r) => r.label === label);
     if (!spec) return false;
+    if (prereqsError) return true;
     const detection = detectedBinary(prereqs, spec.binary);
     return Boolean(detection?.found);
   });
@@ -1203,17 +1206,38 @@ function SetupStep({
           >
             Checking which CLIs are installed&hellip;
           </div>
-        ) : (
+        ) : prereqsError ? (
+          <div
+            style={{
+              fontSize: 12,
+              color: "var(--danger-500, #c33)",
+              padding: "10px 12px",
+              background: "var(--danger-50, #fee)",
+              border: "1px solid var(--danger-200, #fcc)",
+              borderRadius: 6,
+              marginBottom: 12,
+            }}
+          >
+            Could not detect installed CLIs:{" "}
+            <code style={{ fontFamily: "var(--font-mono)" }}>
+              {prereqsError}
+            </code>
+            . You can still select a runtime below or add an API key to
+            continue.
+          </div>
+        ) : null}
+        {prereqsLoading ? null : (
           <div className="runtime-grid">
             {RUNTIMES.map((spec) => {
               const detection = detectedBinary(prereqs, spec.binary);
               const installed = Boolean(detection?.found);
+              const selectable = installed || Boolean(prereqsError);
               const priorityIdx = runtimePriority.indexOf(spec.label);
               const selected = priorityIdx >= 0;
               const classes = [
                 "runtime-tile",
                 selected ? "selected" : "",
-                installed ? "" : "disabled",
+                selectable ? "" : "disabled",
               ]
                 .filter(Boolean)
                 .join(" ");
@@ -1222,19 +1246,21 @@ function SetupStep({
                   key={spec.label}
                   className={classes}
                   onClick={() => {
-                    if (!installed) return;
+                    if (!selectable) return;
                     onToggleRuntime(spec.label);
                   }}
                   type="button"
-                  disabled={!installed}
-                  aria-disabled={!installed}
+                  disabled={!selectable}
+                  aria-disabled={!selectable}
                   aria-pressed={selected}
                   title={
                     installed
                       ? detection?.version
                         ? `${spec.label} — ${detection.version}`
                         : spec.label
-                      : `${spec.label} — not installed`
+                      : prereqsError
+                        ? `${spec.label} — detection failed, select if installed`
+                        : `${spec.label} — not installed`
                   }
                 >
                   {selected && (
@@ -1259,6 +1285,8 @@ function SetupStep({
                       ) : (
                         "Installed"
                       )
+                    ) : prereqsError ? (
+                      "Select if installed"
                     ) : (
                       <>
                         Not installed{" · "}
@@ -1667,6 +1695,7 @@ interface ReadyStepProps {
   checks: ReadinessCheck[];
   taskText: string;
   submitting: boolean;
+  submitError: string;
   onSkip: () => void;
   onSubmit: () => void;
   onBack: () => void;
@@ -1681,6 +1710,7 @@ function ReadyStep({
   checks,
   taskText,
   submitting,
+  submitError,
   onSkip,
   onSubmit,
   onBack,
@@ -1722,6 +1752,24 @@ function ReadyStep({
         </ul>
       </div>
 
+      {submitError && (
+        <div
+          role="alert"
+          style={{
+            fontSize: 13,
+            color: "var(--danger-500, #c33)",
+            padding: "12px 14px",
+            background: "var(--danger-50, #fee)",
+            border: "1px solid var(--danger-200, #fcc)",
+            borderRadius: 6,
+          }}
+        >
+          <strong>Could not start the office:</strong> {submitError}. Check that
+          your CLI runtime is installed and try again, or go back to adjust your
+          setup.
+        </div>
+      )}
+
       <div className="wizard-nav">
         <button className="btn btn-ghost" onClick={onBack} type="button">
           Back
@@ -1733,7 +1781,11 @@ function ReadyStep({
             disabled={submitting}
             type="button"
           >
-            {submitting ? "Starting..." : ONBOARDING_COPY.step3_cta}
+            {submitting
+              ? "Starting..."
+              : submitError
+                ? "Retry"
+                : ONBOARDING_COPY.step3_cta}
             {!submitting && taskText.trim().length > 0 && <EnterHint />}
           </button>
         </div>
@@ -1782,6 +1834,7 @@ export function Wizard({ onComplete }: WizardProps) {
   // Step 5: setup
   const [prereqs, setPrereqs] = useState<PrereqResult[]>([]);
   const [prereqsLoading, setPrereqsLoading] = useState(true);
+  const [prereqsError, setPrereqsError] = useState("");
   // Ordered list of runtime labels (matches RUNTIMES[].label). Position in
   // the array is the fallback priority. Initially empty — we auto-populate
   // with the first installed CLI once prereqs land so the happy path still
@@ -1816,6 +1869,7 @@ export function Wizard({ onComplete }: WizardProps) {
   >(null);
   const [taskText, setTaskText] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
 
   // Fetch blueprints on mount
   useEffect(() => {
@@ -1861,9 +1915,10 @@ export function Wizard({ onComplete }: WizardProps) {
           return firstInstalled ? [firstInstalled.label] : [];
         });
       })
-      .catch(() => {
-        // Broker may not expose the endpoint yet; leave prereqs empty and
-        // the user can still add API keys to proceed.
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        const msg = err instanceof Error ? err.message : String(err);
+        setPrereqsError(msg);
       })
       .finally(() => {
         if (!cancelled) setPrereqsLoading(false);
@@ -2089,13 +2144,15 @@ export function Wizard({ onComplete }: WizardProps) {
     const primaryDetection = primarySpec
       ? detectedBinary(prereqs, primarySpec.binary)
       : undefined;
-    if (primarySpec && primaryDetection?.found) {
+    if (primarySpec && (primaryDetection?.found || prereqsError)) {
       checks.push({
         label: "LLM runtime",
         status: "ready",
-        detail: primaryDetection.version
+        detail: primaryDetection?.version
           ? `${primarySpec.label} — ${primaryDetection.version}`
-          : `${primarySpec.label} installed`,
+          : prereqsError
+            ? `${primarySpec.label} selected (detection skipped)`
+            : `${primarySpec.label} installed`,
       });
     } else if (primarySpec) {
       checks.push({
@@ -2185,6 +2242,7 @@ export function Wizard({ onComplete }: WizardProps) {
   const finishOnboarding = useCallback(
     async (skipTask: boolean) => {
       setSubmitting(true);
+      setSubmitError("");
       try {
         // Translate UI labels to the provider ids the broker validates.
         // Cloud CLI labels resolve via RUNTIMES; local labels (MLX-LM,
@@ -2257,7 +2315,13 @@ export function Wizard({ onComplete }: WizardProps) {
         if (genericGemini.length > 0) {
           configPayload.gemini_api_key = genericGemini;
         }
-        post("/config", configPayload).catch(() => {});
+        try {
+          await post("/config", configPayload);
+        } catch {
+          console.warn(
+            "wuphf: config persistence failed — settings may need to be re-entered on next launch",
+          );
+        }
 
         // Primary runtime label for the onboarding payload (best-effort;
         // the broker only acts on {task, skip_task} today, but the extra
@@ -2277,9 +2341,12 @@ export function Wizard({ onComplete }: WizardProps) {
           task: skipTask ? "" : taskText.trim(),
           skip_task: skipTask,
         });
-      } catch {
-        // Best-effort — the broker may not support this endpoint yet.
-        // Continue to mark onboarding complete locally.
+      } catch (err: unknown) {
+        const msg =
+          err instanceof Error ? err.message : "Failed to start the office";
+        setSubmitError(msg);
+        setSubmitting(false);
+        return;
       }
 
       setOnboardingComplete(true);
@@ -2336,6 +2403,7 @@ export function Wizard({ onComplete }: WizardProps) {
       const hasInstalledSelection = runtimePriority.some((label) => {
         const spec = RUNTIMES.find((r) => r.label === label);
         if (!spec) return false;
+        if (prereqsError) return true;
         return Boolean(detectedBinary(prereqs, spec.binary)?.found);
       });
       const hasAnyApiKey = Object.values(apiKeys).some(
@@ -2403,6 +2471,7 @@ export function Wizard({ onComplete }: WizardProps) {
     description,
     runtimePriority,
     prereqs,
+    prereqsError,
     apiKeys,
     memoryBackend,
     gbrainOpenAIKey,
@@ -2464,6 +2533,7 @@ export function Wizard({ onComplete }: WizardProps) {
           <SetupStep
             prereqs={prereqs}
             prereqsLoading={prereqsLoading}
+            prereqsError={prereqsError}
             runtimePriority={runtimePriority}
             onToggleRuntime={toggleRuntime}
             onReorderRuntime={reorderRuntime}
@@ -2507,6 +2577,7 @@ export function Wizard({ onComplete }: WizardProps) {
             checks={readinessChecks}
             taskText={taskText}
             submitting={submitting}
+            submitError={submitError}
             onSkip={() => finishOnboarding(true)}
             onSubmit={() => finishOnboarding(false)}
             onBack={prevStep}

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -1157,11 +1157,15 @@ function SetupStep({
   const [localModeOn, setLocalModeOn] = useState<boolean>(localProvider !== "");
 
   // A runtime is usable only when its binary is actually present on PATH.
-  // When detection failed (prereqsError), trust the user's selection.
+  // When detection failed (prereqsError), trust the user's selection — but
+  // only for runtimes that actually carry a provider id. Cursor/Windsurf
+  // have provider:null and get dropped in finishOnboarding(), so letting
+  // them satisfy the gate would let the user finish onboarding with no
+  // configured llm_provider.
   const hasInstalledSelection = runtimePriority.some((label) => {
     const spec = RUNTIMES.find((r) => r.label === label);
     if (!spec) return false;
-    if (prereqsError) return true;
+    if (prereqsError) return spec.provider !== null;
     const detection = detectedBinary(prereqs, spec.binary);
     return Boolean(detection?.found);
   });
@@ -2403,7 +2407,7 @@ export function Wizard({ onComplete }: WizardProps) {
       const hasInstalledSelection = runtimePriority.some((label) => {
         const spec = RUNTIMES.find((r) => r.label === label);
         if (!spec) return false;
-        if (prereqsError) return true;
+        if (prereqsError) return spec.provider !== null;
         return Boolean(detectedBinary(prereqs, spec.binary)?.found);
       });
       const hasAnyApiKey = Object.values(apiKeys).some(

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -129,22 +129,22 @@ interface PrereqResult {
 //
 // Rules:
 //   - Unknown labels (not in RUNTIMES) never count.
-//   - When prereqs detection succeeded, the runtime's binary must be on
-//     PATH (detection.found).
-//   - When prereqs detection FAILED (prereqsError truthy), trust the
-//     user's selection — but only for runtimes that carry a non-null
-//     provider id. Cursor/Windsurf are provider:null and
-//     finishOnboarding silently drops them from the llm_provider
-//     payload, so letting them count would let the user finish with no
-//     LLM provider configured.
+//   - Runtimes with provider:null (Cursor/Windsurf) NEVER count, in
+//     either branch. finishOnboarding silently drops them from
+//     providerPriority, so a Cursor-only selection would let the gate
+//     pass and /config would persist no llm_provider.
+//   - With a non-null provider AND prereqs detection succeeded, the
+//     runtime's binary must be on PATH (detection.found).
+//   - With a non-null provider AND prereqs detection FAILED
+//     (prereqsError truthy), trust the user's selection.
 function runtimeIsReady(
   label: string,
   prereqs: PrereqResult[],
   prereqsError: string,
 ): boolean {
   const spec = RUNTIMES.find((r) => r.label === label);
-  if (!spec) return false;
-  if (prereqsError) return spec.provider !== null;
+  if (!spec || spec.provider === null) return false;
+  if (prereqsError) return true;
   return Boolean(detectedBinary(prereqs, spec.binary)?.found);
 }
 
@@ -2174,7 +2174,17 @@ export function Wizard({ onComplete }: WizardProps) {
     // any installed entry satisfies the install gate; the readiness
     // summary should reflect what's actually about to be persisted as
     // llm_provider, which is the head of the list.
+    //
+    // The primary label can resolve to either a cloud-CLI RUNTIMES
+    // entry or a local-provider LOCAL_PROVIDER_LABELS entry; the
+    // checks below cover both. Pre-fix this block only looked at
+    // RUNTIMES, so picking MLX-LM/Ollama/Exo as primary made the
+    // summary report a missing LLM right before /config persisted a
+    // perfectly valid local provider.
     const primaryLabel = runtimePriority[0];
+    const primaryLocal = primaryLabel
+      ? LOCAL_PROVIDER_LABELS.find((m) => m.label === primaryLabel)
+      : undefined;
     const primarySpec = primaryLabel
       ? RUNTIMES.find((r) => r.label === primaryLabel)
       : undefined;
@@ -2183,7 +2193,13 @@ export function Wizard({ onComplete }: WizardProps) {
       : undefined;
     const primaryReady =
       !!primaryLabel && runtimeIsReady(primaryLabel, prereqs, prereqsError);
-    if (primarySpec && primaryReady) {
+    if (primaryLocal) {
+      checks.push({
+        label: "LLM runtime",
+        status: "ready",
+        detail: `${primaryLocal.label} selected (${primaryLocal.blurb}).`,
+      });
+    } else if (primarySpec && primaryReady) {
       checks.push({
         label: "LLM runtime",
         status: "ready",

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -2319,14 +2319,13 @@ export function Wizard({ onComplete }: WizardProps) {
         if (genericGemini.length > 0) {
           configPayload.gemini_api_key = genericGemini;
         }
-        try {
-          await post("/config", configPayload);
-        } catch (err) {
-          console.warn(
-            "wuphf: config persistence failed — settings may need to be re-entered on next launch",
-            err,
-          );
-        }
+        // /config persistence is fatal: we have to know the user's API keys
+        // are saved to disk before the first headless turn fires, otherwise
+        // agents try to authenticate with empty values and fail with opaque
+        // errors. Letting this through silently was the bug PR #365 set out
+        // to fix; leaving it as a console.warn would re-introduce it. The
+        // outer try/catch hands the error to the submitError + Retry UI.
+        await post("/config", configPayload);
 
         // Primary runtime label for the onboarding payload (best-effort;
         // the broker only acts on {task, skip_task} today, but the extra

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -121,6 +121,33 @@ interface PrereqResult {
   install_url?: string;
 }
 
+// runtimeIsReady centralizes the "should this runtime label count as a
+// configured LLM?" predicate used at the SetupStep gate, the keyboard
+// gate, and the ReadyStep summary. Three call sites had drifted apart
+// once already (see PR #367 review) — keeping the rule in one place
+// stops the next drift in its tracks.
+//
+// Rules:
+//   - Unknown labels (not in RUNTIMES) never count.
+//   - When prereqs detection succeeded, the runtime's binary must be on
+//     PATH (detection.found).
+//   - When prereqs detection FAILED (prereqsError truthy), trust the
+//     user's selection — but only for runtimes that carry a non-null
+//     provider id. Cursor/Windsurf are provider:null and
+//     finishOnboarding silently drops them from the llm_provider
+//     payload, so letting them count would let the user finish with no
+//     LLM provider configured.
+function runtimeIsReady(
+  label: string,
+  prereqs: PrereqResult[],
+  prereqsError: string,
+): boolean {
+  const spec = RUNTIMES.find((r) => r.label === label);
+  if (!spec) return false;
+  if (prereqsError) return spec.provider !== null;
+  return Boolean(detectedBinary(prereqs, spec.binary)?.found);
+}
+
 // "Start from scratch" starter roster. Mirrors scratchFoundingTeamBlueprint
 // in internal/team/broker_onboarding.go — the broker seeds these exact slugs
 // when the wizard POSTs blueprint:null. Kept in sync manually; backend is the
@@ -1156,19 +1183,10 @@ function SetupStep({
   // off clears localProvider via onSelectLocalProvider("").
   const [localModeOn, setLocalModeOn] = useState<boolean>(localProvider !== "");
 
-  // A runtime is usable only when its binary is actually present on PATH.
-  // When detection failed (prereqsError), trust the user's selection — but
-  // only for runtimes that actually carry a provider id. Cursor/Windsurf
-  // have provider:null and get dropped in finishOnboarding(), so letting
-  // them satisfy the gate would let the user finish onboarding with no
-  // configured llm_provider.
-  const hasInstalledSelection = runtimePriority.some((label) => {
-    const spec = RUNTIMES.find((r) => r.label === label);
-    if (!spec) return false;
-    if (prereqsError) return spec.provider !== null;
-    const detection = detectedBinary(prereqs, spec.binary);
-    return Boolean(detection?.found);
-  });
+  // Any priority slot that satisfies runtimeIsReady satisfies the gate.
+  const hasInstalledSelection = runtimePriority.some((label) =>
+    runtimeIsReady(label, prereqs, prereqsError),
+  );
   const hasAnyApiKey = Object.values(apiKeys).some((v) => v.trim().length > 0);
   // GBrain requires an OpenAI key to function — the TUI gates on this in
   // InitGBrainOpenAIKey (see internal/tui/init_flow.go:215). Mirror the
@@ -1213,6 +1231,7 @@ function SetupStep({
         ) : prereqsError ? (
           <div
             data-testid="prereqs-error-banner"
+            role="alert"
             style={{
               fontSize: 12,
               color: "var(--danger-500, #c33)",
@@ -2144,7 +2163,17 @@ export function Wizard({ onComplete }: WizardProps) {
       detail: "Web session. No tmux required in the browser.",
     });
 
-    // 3. LLM runtime — whatever CLI the user picked as primary, if installed.
+    // 3. LLM runtime — whatever CLI the user picked as primary, if
+    //    installed (or trusted under prereqsError). Skip provider:null
+    //    runtimes (Cursor/Windsurf) under prereqsError because
+    //    finishOnboarding drops them from the llm_provider payload —
+    //    crediting them as "ready" would tell the user the office is
+    //    configured for an LLM that's silently absent on launch.
+    // ReadyStep inspects only runtimePriority[0] — the active provider —
+    // not the full priority list. The gate sites use .some(...) because
+    // any installed entry satisfies the install gate; the readiness
+    // summary should reflect what's actually about to be persisted as
+    // llm_provider, which is the head of the list.
     const primaryLabel = runtimePriority[0];
     const primarySpec = primaryLabel
       ? RUNTIMES.find((r) => r.label === primaryLabel)
@@ -2152,7 +2181,9 @@ export function Wizard({ onComplete }: WizardProps) {
     const primaryDetection = primarySpec
       ? detectedBinary(prereqs, primarySpec.binary)
       : undefined;
-    if (primarySpec && (primaryDetection?.found || prereqsError)) {
+    const primaryReady =
+      !!primaryLabel && runtimeIsReady(primaryLabel, prereqs, prereqsError);
+    if (primarySpec && primaryReady) {
       checks.push({
         label: "LLM runtime",
         status: "ready",
@@ -2408,12 +2439,9 @@ export function Wizard({ onComplete }: WizardProps) {
 
       const canIdentityContinue =
         company.trim().length > 0 && description.trim().length > 0;
-      const hasInstalledSelection = runtimePriority.some((label) => {
-        const spec = RUNTIMES.find((r) => r.label === label);
-        if (!spec) return false;
-        if (prereqsError) return spec.provider !== null;
-        return Boolean(detectedBinary(prereqs, spec.binary)?.found);
-      });
+      const hasInstalledSelection = runtimePriority.some((label) =>
+        runtimeIsReady(label, prereqs, prereqsError),
+      );
       const hasAnyApiKey = Object.values(apiKeys).some(
         (v) => v.trim().length > 0,
       );

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -1212,6 +1212,7 @@ function SetupStep({
           </div>
         ) : prereqsError ? (
           <div
+            data-testid="prereqs-error-banner"
             style={{
               fontSize: 12,
               color: "var(--danger-500, #c33)",
@@ -1249,6 +1250,7 @@ function SetupStep({
                 <button
                   key={spec.label}
                   className={classes}
+                  data-testid={`setup-runtime-tile-${spec.label}`}
                   onClick={() => {
                     if (!selectable) return;
                     onToggleRuntime(spec.label);
@@ -1759,6 +1761,7 @@ function ReadyStep({
       {submitError && (
         <div
           role="alert"
+          data-testid="onboarding-submit-error"
           style={{
             fontSize: 13,
             color: "var(--danger-500, #c33)",
@@ -1781,6 +1784,7 @@ function ReadyStep({
         <div className="wizard-nav-right">
           <button
             className="btn btn-primary"
+            data-testid="onboarding-submit-button"
             onClick={taskText.trim().length === 0 ? onSkip : onSubmit}
             disabled={submitting}
             type="button"

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -2321,9 +2321,10 @@ export function Wizard({ onComplete }: WizardProps) {
         }
         try {
           await post("/config", configPayload);
-        } catch {
+        } catch (err) {
           console.warn(
             "wuphf: config persistence failed — settings may need to be re-entered on next launch",
+            err,
           );
         }
 


### PR DESCRIPTION
## Summary

Combines #364 (Product Hunt cold-start friction) and #365 (onboarding resilience) into a single bundle and resolves the issues each reviewer flagged. Closes both.

### From #364 — first-60-seconds friction
- **No-TTY-safe Nex prompt** (`internal/team/launcher.go`). `fmt.Scanln` returned empty under non-interactive stdin (npx pipes, Docker, CI), and we silently treated that as "yes" and tried to install Nex. Now we detect non-TTY via `os.Stdin.Stat()` and print a one-line skip pointing at `nex setup`.
- **Wait for the web listener before opening the browser** (`internal/team/launcher.go`). `ServeWebUI` returns immediately but the listener takes a few hundred ms to accept. Added `waitForWebReady` (lint-friendly `(*net.Dialer).DialContext` poll, 5s ceiling) before `openBrowser`.
- **Auto-detect a local runtime when no API key is provided** (`cmd/wuphf/onboarding.go`). Probes ollama/mlx-lm/exo on loopback (`/v1/models`) in parallel with a 600ms ceiling and suggests `wuphf --provider <kind>` instead of nagging for a cloud key.
- **No more empty `#general`** (`internal/team/broker_onboarding.go`). When onboarding completes with `skip_task=true`, post a system welcome plus a presence line from the lead. The presence line is `Kind:"demo_seed"` so the launcher's notification path treats it as inert — never wakes a real agent.

### From #365 — surface-the-failure-modes
- **Corrupt `onboarded.json` recovery** (`internal/onboarding/state.go`). Auto-recovers to fresh state instead of an HTTP 500 loop. With test.
- **`/onboarding/complete` failures show retry** (`web/src/components/onboarding/Wizard.tsx`). Previously silently marked the user onboarded with an empty office.
- **Web UI port-conflict actionable error** (`internal/team/broker.go`, `internal/team/launcher.go`). `ServeWebUI` binds the port before spawning the goroutine so a port collision returns immediately with copy that names the workaround flag.
- **Prereqs-fetch error banner** (`web/src/components/onboarding/Wizard.tsx`). When CLI detection fails, show a banner and keep runtime tiles selectable so the user can proceed if they trust their own selection.
- **Broker token-write + `/config` POST**: errors that were silently dropped now log a warning.

### Review fixes folded in (the third commit)
- **Wizard `provider:null` gate** — Cursor/Windsurf can no longer satisfy `hasInstalledSelection` when `prereqsError` is set. Without this fix, a detection failure let users finish onboarding with no `llm_provider` configured because `finishOnboarding` drops null-provider entries.
- **Corrupt-state recovery rewrites the file** — previously the recovery only returned a fresh in-memory state, so the next `Load` hit the same parse error and logged again on every call. Test updated to verify on-disk recovery.
- **`waitForWebReady` result is honored** — when the listener never comes up, skip `openBrowser` instead of opening a dead URL. Probe host (127.0.0.1) and printed URL host now match — `localhost` resolving to `::1` on IPv6-preferring setups was reproducing `ERR_CONNECTION_REFUSED` even after the probe succeeded.
- **`buildNotificationContext` filters `demo_seed`** — the cosmetic CEO presence line can't be replayed as prompt context.
- **`detectReachableLocalRuntime` requires explicit 2xx** — a 404/401 from some other server on the same loopback port no longer counts as "ollama reachable".
- **`ServeWebUI` uses `(*net.ListenConfig).Listen`** — fixes the `noctx` lint failure that broke #365's CI.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/team -count=1` (full pkg, ~100s, green)
- [x] `go test ./internal/onboarding/... ./cmd/wuphf -count=1`
- [x] `golangci-lint run --timeout=5m ./...` — 0 issues (the rule that broke #365 is now passing)
- [x] `gofmt -l .` clean
- [x] `npm run typecheck` (web) clean
- [x] `npm test` (web) — 496 tests pass across 72 files
- [ ] Manual: `npx wuphf` on a clean machine — confirm no Nex prompt hang, browser opens to live UI, `#general` shows welcome on `skip_task` path
- [ ] Manual: corrupt `~/.wuphf/onboarded.json` → wizard restarts cleanly and rewrites the file
- [ ] Manual: start two `wuphf` instances on the same port → second one prints the actionable port-conflict error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects reachable local AI runtimes during setup and offers a restart instruction or a fallback prompt for cloud key/install.
  * Seeds team channels with a welcome and demo-presence message when onboarding skip is used.

* **Bug Fixes & Improvements**
  * Recovers automatically from corrupted onboarding state files.
  * Surfaces port-bind/web-server startup errors; browser auto-open waits for server readiness on 127.0.0.1.

* **UI Enhancements**
  * Shows prereqs error banners; runtime tiles remain selectable when detection fails; onboarding submit supports Retry.

* **Tests & CI**
  * Adds unit and e2e coverage for runtime probing, onboarding error states, demo-seed handling, and web readiness.

* **Documentation & Chores**
  * New experiment doc; updated ignore/CI fixtures for e2e artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->