### PR TITLE
feat(upgrade): click-to-run banner + content-aware show gate

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -580,6 +580,14 @@ type Broker struct {
 	// token. Guarded by b.mu. See skill_crud_endpoints.go for GC semantics.
 	recentlyRejectedSkills map[string]rejectedSkillSnapshot
 
+	// upgradeRunInFlight serialises POST /upgrade/run so two parallel
+	// clicks (or two browser tabs racing) cannot launch concurrent
+	// `npm install` against the same node_modules. npm's own lockfile
+	// usually recovers, but we've seen partial-extract corruption when
+	// two installs target the same prefix simultaneously — this guard
+	// is the cheap belt to npm's suspenders.
+	upgradeRunInFlight atomic.Bool
+
 	// statePath is the on-disk broker-state.json path bound at construction.
 	// NewBrokerAt(path) sets this directly; NewBroker() resolves
 	// defaultBrokerStatePath() once and pins the result. A later-arriving
@@ -1553,6 +1561,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/version", b.handleVersion)
 	mux.HandleFunc("/upgrade-check", b.requireAuth(b.handleUpgradeCheck))
 	mux.HandleFunc("/upgrade-changelog", b.requireAuth(b.handleUpgradeChangelog))
+	mux.HandleFunc("/upgrade/run", b.requireAuth(b.handleUpgradeRun))
 	mux.HandleFunc("/session-mode", b.requireAuth(b.handleSessionMode))
 	mux.HandleFunc("/focus-mode", b.requireAuth(b.handleFocusMode))
 	mux.HandleFunc("/messages", b.requireAuth(b.handleMessages))
@@ -4796,23 +4805,37 @@ func (b *Broker) handleUpgradeCheck(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+	// Run install detection so the banner can render the EXACT command
+	// that POST /upgrade/run would execute (global vs local). Without
+	// this, the chip showed "npm install -g wuphf@latest" universally
+	// even when the broker would actually run `npm install wuphf@latest`
+	// in a project dir — a misleading click target. Detection is
+	// filesystem-bound (one Stat for global, walk-up for local), capped
+	// in detectUpgradeInstall by upgradeRunDetectTime.
+	plan := detectUpgradeInstallFn(r.Context())
+	payload := map[string]any{
+		"current":           res.Current,
+		"latest":            res.Latest,
+		"upgrade_available": res.UpgradeAvailable,
+		"is_dev_build":      res.IsDevBuild,
+		"compare_url":       res.CompareURL,
+		// upgrade_command stays as the canonical "what we'd recommend
+		// in docs" string; install_command is what the click ACTUALLY
+		// runs on this host, so the banner can render the truthful
+		// label. They MAY differ — local installs prefer
+		// `npm install wuphf@latest`.
+		"upgrade_command": res.UpgradeCommand,
+		"install_method":  plan.Method,
+		"install_command": plan.Command,
+	}
 	if err != nil {
 		// Partial result (Current AND Latest populated, but something
 		// else failed) — degrade gracefully with 200 + error field
 		// so the banner can render nothing without a console-spamming
 		// 5xx for a non-critical check.
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"current":           res.Current,
-			"latest":            res.Latest,
-			"upgrade_available": res.UpgradeAvailable,
-			"is_dev_build":      res.IsDevBuild,
-			"compare_url":       res.CompareURL,
-			"upgrade_command":   res.UpgradeCommand,
-			"error":             err.Error(),
-		})
-		return
+		payload["error"] = err.Error()
 	}
-	_ = json.NewEncoder(w).Encode(res)
+	_ = json.NewEncoder(w).Encode(payload)
 }
 
 // handleUpgradeChangelog proxies the GitHub compare API for the same reasons
@@ -4860,6 +4883,278 @@ func (b *Broker) handleUpgradeChangelog(w http.ResponseWriter, r *http.Request) 
 // MIRRORED in web/src/components/layout/upgradeBanner.utils.ts as
 // VERSION_RE — keep them in sync so a future tightening doesn't drift.
 var upgradeVersionParam = regexp.MustCompile(`^v?\d+(\.\d+){1,3}(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$`)
+
+// ── Upgrade-run ──────────────────────────────────────────────────────────
+//
+// POST /upgrade/run executes whichever `npm install` flavour matches how the
+// running wuphf was installed:
+//
+//   • global (npm install -g wuphf)  → `npm install -g wuphf@latest`
+//   • local  (project devDep)        → `npm install wuphf@latest` in that dir
+//   • source build / standalone      → 400 with install_method="unknown"
+//
+// The detection runs `npm root -g` and walks up from the caller's cwd
+// looking for `node_modules/wuphf/package.json`, so we never lie about which
+// command we'd run. The label rendered by the banner is whatever this
+// detection picks — banner cannot drift from server reality.
+
+const (
+	upgradeRunOutputCap  = 64 << 10 // truncate captured npm output at 64 KiB to bound response size
+	upgradeRunDetectTime = 5 * time.Second
+)
+
+// upgradeRunTimeout caps the npm install at 120s. Declared as a var so
+// tests can reduce it to a few milliseconds and exercise the timed-out
+// branch deterministically; production never mutates it.
+var upgradeRunTimeout = 120 * time.Second
+
+type upgradeRunResult struct {
+	OK            bool   `json:"ok"`
+	InstallMethod string `json:"install_method"`        // "global", "local", or "unknown"
+	Command       string `json:"command,omitempty"`     // human-readable rendered cmd (e.g. "npm install -g wuphf@latest")
+	WorkingDir    string `json:"working_dir,omitempty"` // for local installs, the project dir we ran in
+	Output        string `json:"output,omitempty"`      // combined stdout+stderr, truncated
+	Error         string `json:"error,omitempty"`       // surfaces non-zero exit / spawn failure / detection failure
+	TimedOut      bool   `json:"timed_out,omitempty"`
+}
+
+// upgradeInstallPlan is what `detectUpgradeInstall` returns: the args we'd
+// hand to exec.Command and the human-readable rendering for the banner.
+type upgradeInstallPlan struct {
+	Method     string   // "global" | "local" | "unknown"
+	Args       []string // e.g. ["install", "-g", "wuphf@latest"]; empty when Method=="unknown"
+	WorkingDir string   // cwd to run npm in (project root for local installs; empty for global)
+	Command    string   // human rendering (so the banner can show exactly what runs)
+}
+
+// detectUpgradeInstallFn is the seam tests use to pin a synthetic install
+// plan without shelling out to `npm root -g`. Production points at the real
+// implementation; broker_upgrade_test.go can swap it via t.Cleanup-restored
+// assignment to drive the unknown / global / local handler paths
+// deterministically.
+var detectUpgradeInstallFn = detectUpgradeInstall
+
+// runUpgradeCmdFn is the seam tests use to drive npm-success / npm-failure /
+// npm-timeout paths without shelling out. Returns the combined stdout+stderr
+// and the underlying exec error (if any). Tests swap this to assert the
+// handler maps results to the wire shape correctly. Production runs npm.
+var runUpgradeCmdFn = runUpgradeCmd
+
+func runUpgradeCmd(ctx context.Context, plan upgradeInstallPlan) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "npm", plan.Args...)
+	if plan.WorkingDir != "" {
+		cmd.Dir = plan.WorkingDir
+	}
+	return cmd.CombinedOutput()
+}
+
+// detectUpgradeInstall figures out how wuphf is installed on this machine.
+// Order: global wins over local (most users `npm install -g`); local fallback
+// catches the project-scoped install case.
+//
+// Local-install detection is bounded: we walk up from cwd looking for the
+// FIRST ancestor with a `package.json`, treat that as the project root, and
+// only accept it as a local install if (a) it declares wuphf in
+// dependencies/devDependencies AND (b) `node_modules/wuphf/package.json`
+// exists there. Without these guards, a stray `~/node_modules/wuphf` from
+// some exotic Volta/nvm setup would have us run `npm install wuphf@latest`
+// in `$HOME` — visibly mutating the user's home directory. The guards make
+// the detection refuse to misfire instead of mis-installing.
+func detectUpgradeInstall(ctx context.Context) upgradeInstallPlan {
+	if _, err := exec.LookPath("npm"); err != nil {
+		return upgradeInstallPlan{Method: "unknown"}
+	}
+	// `npm root -g` prints the global node_modules path. Short timeout so a
+	// borked npm config can't block the whole detect for the upstream budget.
+	rootCtx, cancel := context.WithTimeout(ctx, upgradeRunDetectTime)
+	defer cancel()
+	if out, err := exec.CommandContext(rootCtx, "npm", "root", "-g").Output(); err == nil {
+		globalRoot := strings.TrimSpace(string(out))
+		if globalRoot != "" {
+			if _, err := os.Stat(filepath.Join(globalRoot, "wuphf", "package.json")); err == nil {
+				return upgradeInstallPlan{
+					Method:  "global",
+					Args:    []string{"install", "-g", "wuphf@latest"},
+					Command: "npm install -g wuphf@latest",
+				}
+			}
+		}
+	}
+	// Local install: walk up from cwd. The first ancestor that has a
+	// package.json IS the project root (npm convention). Stop there
+	// regardless of whether wuphf is in node_modules — going further
+	// would risk falsely claiming a parent project's package.json
+	// (or worse, $HOME) is the install target. The 32-level cap is a
+	// belt-and-suspenders guard against a runaway symlink loop.
+	cwd, err := os.Getwd()
+	if err == nil {
+		dir := cwd
+		for i := 0; i < 32; i++ {
+			projectPkg := filepath.Join(dir, "package.json")
+			if data, err := os.ReadFile(projectPkg); err == nil {
+				// We're at a project root. Local install only counts
+				// if THIS project declares wuphf — otherwise we'd run
+				// `npm install` in someone else's package.json, which
+				// would silently add wuphf as a new dependency.
+				if pkgDeclaresWuphf(data) {
+					candidate := filepath.Join(dir, "node_modules", "wuphf", "package.json")
+					if _, err := os.Stat(candidate); err == nil {
+						return upgradeInstallPlan{
+							Method:     "local",
+							Args:       []string{"install", "wuphf@latest"},
+							WorkingDir: dir,
+							Command:    "npm install wuphf@latest",
+						}
+					}
+				}
+				// Found a project root but it doesn't declare wuphf —
+				// stop walking. Continuing into a grandparent project
+				// would mis-attribute the install.
+				break
+			}
+			parent := filepath.Dir(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+	}
+	return upgradeInstallPlan{Method: "unknown"}
+}
+
+// pkgDeclaresWuphf reports whether the given package.json bytes declare
+// wuphf in dependencies or devDependencies. Robust to extra unknown fields
+// (peerDependencies, optionalDependencies, etc. — those do NOT count for
+// `npm install <pkg>@latest` semantics, which only updates real deps).
+func pkgDeclaresWuphf(data []byte) bool {
+	var pkg struct {
+		Dependencies    map[string]json.RawMessage `json:"dependencies"`
+		DevDependencies map[string]json.RawMessage `json:"devDependencies"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		return false
+	}
+	if _, ok := pkg.Dependencies["wuphf"]; ok {
+		return true
+	}
+	if _, ok := pkg.DevDependencies["wuphf"]; ok {
+		return true
+	}
+	return false
+}
+
+// handleUpgradeRun executes the matching install command and returns the
+// captured output. Auth-required, POST-only. Output is truncated to
+// upgradeRunOutputCap so a chatty npm log can't bloat the JSON response.
+//
+// Concurrency: a process-wide single-flight (atomic.Bool) refuses overlapping
+// runs. Two browser tabs racing to click "install" would otherwise spawn
+// concurrent `npm install` against the same node_modules and risk a partial-
+// extract corruption. The second arrival gets a JSON error and the first
+// run remains the source of truth.
+func (b *Broker) handleUpgradeRun(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// Body is required to be JSON {} by the client, but we don't read
+	// any fields from it. Still bound it so a misbehaving (authenticated)
+	// caller can't inflate broker memory by streaming a large body —
+	// MaxBytesReader trips the read at 1 KiB and returns an error to
+	// any subsequent Read. We don't actually consume the body here; the
+	// limit just caps what the HTTP server has to buffer before we
+	// respond.
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<10)
+	defer r.Body.Close()
+	w.Header().Set("Content-Type", "application/json")
+
+	// Single-flight gate. CompareAndSwap returns false if a run is
+	// already underway; the second arrival short-circuits with a 200 +
+	// error so the banner can render "another install is running" copy
+	// without breaking the .catch / non-2xx path.
+	if !b.upgradeRunInFlight.CompareAndSwap(false, true) {
+		_ = json.NewEncoder(w).Encode(upgradeRunResult{
+			OK:    false,
+			Error: "an upgrade is already running on this broker — wait for it to finish",
+		})
+		return
+	}
+	defer b.upgradeRunInFlight.Store(false)
+
+	plan := detectUpgradeInstallFn(r.Context())
+	if plan.Method == "unknown" {
+		// 200 so the banner can render the message inline without
+		// triggering a console-spamming 4xx for what is fundamentally
+		// "we can't help here, here's why."
+		_ = json.NewEncoder(w).Encode(upgradeRunResult{
+			OK:            false,
+			InstallMethod: plan.Method,
+			Error:         "Could not detect how wuphf was installed (no npm, or wuphf isn't under a global/local node_modules). Try `npm install -g wuphf@latest` from a terminal.",
+		})
+		return
+	}
+
+	// Use a broker-owned ctx so a CLIENT cancellation (page nav, tab
+	// close) does not abort npm mid-install — interrupting npm between
+	// download and rename can leave a half-extracted node_modules entry
+	// that the next launch trips over. Process-level termination
+	// (SIGKILL, OS shutdown) can still leave a partial install — npm's
+	// own atomic-rename usually recovers, but this is not a hard
+	// guarantee. The 120s ceiling caps a runaway without being so
+	// short it trips on a typical 5-30s install.
+	runCtx, cancel := context.WithTimeout(context.Background(), upgradeRunTimeout)
+	defer cancel()
+
+	// runUpgradeCmdFn merges stdout+stderr in invocation order — npm
+	// progress hits stderr, the final `+ wuphf@x.y.z` line hits stdout,
+	// and the banner shows them in the order the user would see in a
+	// terminal. Capped via slicing below so a verbose log can't bloat.
+	out, err := runUpgradeCmdFn(runCtx, plan)
+	output := truncateForJSON(string(out), upgradeRunOutputCap)
+
+	res := upgradeRunResult{
+		InstallMethod: plan.Method,
+		Command:       plan.Command,
+		WorkingDir:    plan.WorkingDir,
+		Output:        output,
+	}
+	if err != nil {
+		res.OK = false
+		// runCtx.Err() distinguishes a real timeout from the underlying
+		// process exit error — npm exits non-zero on EACCES too, and we
+		// want the banner to tell those apart so users see "needs sudo"
+		// vs "took too long" with separate copy.
+		if errors.Is(runCtx.Err(), context.DeadlineExceeded) {
+			res.TimedOut = true
+			res.Error = fmt.Sprintf("npm install timed out after %s", upgradeRunTimeout)
+		} else {
+			res.Error = err.Error()
+		}
+	} else {
+		res.OK = true
+	}
+	_ = json.NewEncoder(w).Encode(res)
+}
+
+// truncateForJSON keeps the trailing `cap` bytes of `s` (the most useful
+// diagnostic — npm puts the error line and the final `+ wuphf@x.y.z`
+// line at the bottom) and prepends a sentinel marking the truncation.
+// Rounds the cut point forward to the next valid UTF-8 sequence start so
+// we don't ship a leading orphan continuation byte that would render as
+// U+FFFD on the client.
+func truncateForJSON(s string, cap int) string {
+	if len(s) <= cap {
+		return s
+	}
+	start := len(s) - cap
+	for start < len(s) && s[start]&0xC0 == 0x80 {
+		// 10xxxxxx: continuation byte. Skip until we land on a
+		// leading byte (0xxxxxxx, 110xxxxx, 1110xxxx, 11110xxx).
+		start++
+	}
+	return "…[truncated]…\n" + s[start:]
+}
 
 // ── Upgrade-check caching ─────────────────────────────────────────────────
 //

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -4935,31 +4935,113 @@ type upgradeInstallPlan struct {
 var detectUpgradeInstallFn = detectUpgradeInstall
 
 // runUpgradeCmdFn is the seam tests use to drive npm-success / npm-failure /
-// npm-timeout paths without shelling out. Returns the combined stdout+stderr
-// and the underlying exec error (if any). Tests swap this to assert the
-// handler maps results to the wire shape correctly. Production runs npm.
+// npm-timeout paths without shelling out. Returns the trailing slice of
+// merged stdout+stderr (capped at upgradeRunOutputCap), a `truncated` flag
+// indicating whether anything was discarded ahead of that tail, and the
+// underlying exec error (if any). Tests swap this to assert the handler
+// maps results to the wire shape correctly. Production runs npm.
 var runUpgradeCmdFn = runUpgradeCmd
 
-func runUpgradeCmd(ctx context.Context, plan upgradeInstallPlan) ([]byte, error) {
+func runUpgradeCmd(ctx context.Context, plan upgradeInstallPlan) ([]byte, bool, error) {
 	cmd := exec.CommandContext(ctx, "npm", plan.Args...)
 	if plan.WorkingDir != "" {
 		cmd.Dir = plan.WorkingDir
 	}
-	return cmd.CombinedOutput()
+	// Bounded capture. CombinedOutput() (which this previously used)
+	// buffers ALL of npm's stdout+stderr in memory before returning —
+	// a verbose install (lots of warnings, integrity errors, progress
+	// frames in some configs) could grow the broker process arbitrarily
+	// even though the JSON response is later trimmed. tailBuffer caps
+	// the in-flight buffer at upgradeRunOutputCap regardless of how
+	// chatty npm gets, while preserving the tail (which is where the
+	// real error / `+ wuphf@x.y.z` line lives). Setting the same
+	// *tailBuffer for Stdout and Stderr also leans on os/exec's
+	// guarantee that "at most one goroutine at a time will call Write"
+	// when the two writers compare equal, so merge ordering matches
+	// what the user would see in a terminal.
+	buf := newTailBuffer(upgradeRunOutputCap)
+	cmd.Stdout = buf
+	cmd.Stderr = buf
+	err := cmd.Run()
+	return buf.Bytes(), buf.Truncated(), err
+}
+
+// tailBuffer is a thread-safe io.Writer that retains only the most
+// recent maxBytes of input and tracks whether anything was discarded
+// ahead of that tail. Used to bound broker memory while running npm
+// (see runUpgradeCmd) without losing the trailing diagnostic the
+// user actually needs.
+type tailBuffer struct {
+	mu        sync.Mutex
+	buf       []byte
+	maxBytes  int
+	truncated bool
+}
+
+func newTailBuffer(maxBytes int) *tailBuffer {
+	return &tailBuffer{maxBytes: maxBytes, buf: make([]byte, 0, maxBytes)}
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	n := len(p)
+	if n >= b.maxBytes {
+		// p alone fills or exceeds the cap — any prior bytes are
+		// older than the tail of p, so reset and keep p's suffix.
+		b.buf = append(b.buf[:0], p[n-b.maxBytes:]...)
+		if n > b.maxBytes {
+			b.truncated = true
+		}
+		return n, nil
+	}
+	if len(b.buf)+n <= b.maxBytes {
+		b.buf = append(b.buf, p...)
+		return n, nil
+	}
+	// Combined size would exceed cap — drop the oldest bytes to make
+	// room for p. The overlapping copy is safe per Go spec.
+	excess := len(b.buf) + n - b.maxBytes
+	copy(b.buf, b.buf[excess:])
+	b.buf = b.buf[:len(b.buf)-excess]
+	b.buf = append(b.buf, p...)
+	b.truncated = true
+	return n, nil
+}
+
+func (b *tailBuffer) Bytes() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]byte, len(b.buf))
+	copy(out, b.buf)
+	return out
+}
+
+func (b *tailBuffer) Truncated() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.truncated
 }
 
 // detectUpgradeInstall figures out how wuphf is installed on this machine.
 // Order: global wins over local (most users `npm install -g`); local fallback
 // catches the project-scoped install case.
 //
-// Local-install detection is bounded: we walk up from cwd looking for the
-// FIRST ancestor with a `package.json`, treat that as the project root, and
-// only accept it as a local install if (a) it declares wuphf in
-// dependencies/devDependencies AND (b) `node_modules/wuphf/package.json`
-// exists there. Without these guards, a stray `~/node_modules/wuphf` from
-// some exotic Volta/nvm setup would have us run `npm install wuphf@latest`
-// in `$HOME` — visibly mutating the user's home directory. The guards make
-// the detection refuse to misfire instead of mis-installing.
+// Local-install detection walks up from cwd looking for the nearest ancestor
+// that BOTH declares wuphf in dependencies/devDependencies AND has
+// `node_modules/wuphf/package.json` materialised. A non-declaring ancestor
+// (e.g. a `packages/sub/package.json` in an npm-workspace monorepo where
+// the dep lives at the workspace root) is skipped, not treated as a hard
+// stop — otherwise detection would silently fail for monorepo users. A
+// declaring ancestor whose dep is NOT yet installed (fresh clone before
+// `npm install`) IS a hard stop: walking past would risk upgrading the
+// wrong project's wuphf, and "unknown" plus the fallback copy is safer.
+//
+// The walk is bounded by:
+//   - 32-iteration cap (belt-and-suspenders for runaway symlink loops),
+//   - filesystem root (parent == dir),
+//   - $HOME — even if a `package.json` at $HOME declared wuphf, running
+//     `npm install` there would visibly mutate the user's home directory.
 //
 // Assumption: the broker process's cwd equals the user's cwd. Holds today
 // because the wuphf CLI starts the broker and inherits cwd. A future
@@ -4988,54 +5070,65 @@ func detectUpgradeInstall(ctx context.Context) upgradeInstallPlan {
 			}
 		}
 	}
-	// Local install: walk up from cwd. The first ancestor that has a
-	// package.json IS the project root (npm convention). Stop there
-	// regardless of whether wuphf is in node_modules — going further
-	// would risk falsely claiming a parent project's package.json
-	// (or worse, $HOME) is the install target. The 32-level cap is a
-	// belt-and-suspenders guard against a runaway symlink loop.
+	// Local install: walk up from cwd, skipping non-declaring ancestors so
+	// monorepos with wuphf at the workspace root still detect cleanly when
+	// cwd is inside a sub-package that doesn't declare it directly.
+	homeDir, _ := os.UserHomeDir()
 	cwd, err := os.Getwd()
-	if err == nil {
-		dir := cwd
-		for i := 0; i < 32; i++ {
-			projectPkg := filepath.Join(dir, "package.json")
-			if data, err := os.ReadFile(projectPkg); err == nil {
-				// We're at a project root. Local install only counts
-				// if THIS project declares wuphf — otherwise we'd run
-				// `npm install` in someone else's package.json, which
-				// would silently add wuphf as a new dependency.
-				if pkgDeclaresWuphf(data) {
-					candidate := filepath.Join(dir, "node_modules", "wuphf", "package.json")
-					if _, err := os.Stat(candidate); err == nil {
-						return upgradeInstallPlan{
-							Method:     "local",
-							Args:       []string{"install", "wuphf@latest"},
-							WorkingDir: dir,
-							Command:    "npm install wuphf@latest",
-						}
+	if err != nil {
+		return upgradeInstallPlan{Method: "unknown"}
+	}
+	return detectLocalInstall(cwd, homeDir)
+}
+
+// detectLocalInstall walks up from `cwd` looking for the nearest ancestor
+// that declares wuphf in package.json AND has node_modules/wuphf installed.
+// Skips ancestors that don't declare wuphf (monorepo sub-packages); stops
+// hard at a declaring-but-not-installed ancestor (fresh clone case),
+// $HOME, the filesystem root, or after 32 hops. Extracted from
+// detectUpgradeInstall so it can be unit-tested without depending on a
+// real `npm` binary or a real user $HOME.
+func detectLocalInstall(cwd, homeDir string) upgradeInstallPlan {
+	dir := cwd
+	for i := 0; i < 32; i++ {
+		// $HOME guard. Stop BEFORE inspecting a package.json at
+		// $HOME so a stray ~/package.json that happens to mention
+		// wuphf can't redirect the install into the user's home.
+		if homeDir != "" && dir == homeDir {
+			break
+		}
+		projectPkg := filepath.Join(dir, "package.json")
+		if data, err := os.ReadFile(projectPkg); err == nil {
+			if pkgDeclaresWuphf(data) {
+				candidate := filepath.Join(dir, "node_modules", "wuphf", "package.json")
+				if _, err := os.Stat(candidate); err == nil {
+					return upgradeInstallPlan{
+						Method:     "local",
+						Args:       []string{"install", "wuphf@latest"},
+						WorkingDir: dir,
+						Command:    "npm install wuphf@latest",
 					}
 				}
-				// Stop walking. Two paths land here, both intentional:
-				//   (a) the project root doesn't declare wuphf — running
-				//       npm install here would silently add wuphf as a
-				//       new dep instead of upgrading an existing one.
-				//   (b) the project DOES declare wuphf but
-				//       node_modules/wuphf/package.json is missing — the
-				//       declared dep was never installed (fresh clone,
-				//       skipped npm install). Suggesting an install in
-				//       this state is correct, but our "local install"
-				//       contract requires both signals; bail to "unknown"
-				//       so the click-to-run UI surfaces the explicit
-				//       fallback message rather than silently running
-				//       npm install with potentially wrong context.
+				// Declares wuphf but the dep isn't materialised
+				// (fresh clone, skipped `npm install`). Don't keep
+				// walking — a parent project's wuphf is NOT this
+				// project's wuphf, and silently upgrading it would
+				// be the wrong fix for "this project hasn't been
+				// installed yet." Surface "unknown" and let the
+				// click-to-run UI render its explicit fallback.
 				break
 			}
-			parent := filepath.Dir(dir)
-			if parent == dir {
-				break
-			}
-			dir = parent
+			// package.json that doesn't declare wuphf: a monorepo
+			// sub-package or an unrelated project at this level.
+			// Keep walking up — the workspace root above might be
+			// the actual install target. The $HOME guard above
+			// and the filesystem-root check below bound this.
 		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
 	}
 	return upgradeInstallPlan{Method: "unknown"}
 }
@@ -5154,9 +5247,15 @@ func (b *Broker) handleUpgradeRun(w http.ResponseWriter, r *http.Request) {
 	// runUpgradeCmdFn merges stdout+stderr in invocation order — npm
 	// progress hits stderr, the final `+ wuphf@x.y.z` line hits stdout,
 	// and the banner shows them in the order the user would see in a
-	// terminal. Capped via slicing below so a verbose log can't bloat.
-	out, err := runUpgradeCmdFn(runCtx, plan)
-	output := truncateForJSON(string(out), upgradeRunOutputCap)
+	// terminal. The capture is bounded inside runUpgradeCmdFn so a
+	// verbose log can't bloat broker memory; `truncated` tells us
+	// whether bytes were dropped ahead of the returned tail so we can
+	// surface a sentinel to the client.
+	out, truncated, err := runUpgradeCmdFn(runCtx, plan)
+	output := string(out)
+	if truncated {
+		output = withTruncationSentinel(output)
+	}
 
 	res := upgradeRunResult{
 		InstallMethod: plan.Method,
@@ -5182,40 +5281,24 @@ func (b *Broker) handleUpgradeRun(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(res)
 }
 
-// truncateForJSON keeps the trailing `tailBytes` of `s` (the most useful
-// diagnostic — npm puts the error line and the final `+ wuphf@x.y.z`
-// line at the bottom) and prepends a sentinel marking the truncation.
-// Rounds the cut point forward to the next valid UTF-8 sequence start so
-// we don't ship a leading orphan continuation byte that would render as
-// U+FFFD on the client.
-//
-// Note: the parameter is the SUFFIX size, not a hard ceiling on the
-// returned string. The sentinel ("…[truncated]…\n", 18 bytes UTF-8) is
-// added on top, so the result can be up to tailBytes+18 bytes. Safe at
-// the production cap of 64 KiB; callers picking a tight log-line budget
-// or a fixed-size ring buffer must subtract the sentinel themselves.
-func truncateForJSON(s string, tailBytes int) string {
-	// Defensive: a non-positive cap produces a negative slice index and
-	// panics. Treat it as "keep nothing" — empty input passes through
-	// (the sentinel would itself be longer than the request), otherwise
-	// emit just the sentinel so the caller still sees that truncation
-	// happened. No production caller passes <= 0 today.
-	if tailBytes <= 0 {
-		if s == "" {
-			return ""
-		}
-		return "…[truncated]…\n"
-	}
-	if len(s) <= tailBytes {
-		return s
-	}
-	start := len(s) - tailBytes
+// truncationSentinel marks the front of an output string that had earlier
+// bytes dropped (because the bounded tailBuffer threw them away). 18 bytes
+// in UTF-8.
+const truncationSentinel = "…[truncated]…\n"
+
+// withTruncationSentinel prepends truncationSentinel to s, first skipping
+// any leading UTF-8 continuation bytes so the returned string starts on a
+// complete rune. The bounded write in tailBuffer can cut mid-rune; this
+// turns that orphan continuation into a clean cut so the JSON encoder
+// doesn't replace the leading byte with U+FFFD on the client.
+func withTruncationSentinel(s string) string {
+	start := 0
 	for start < len(s) && s[start]&0xC0 == 0x80 {
 		// 10xxxxxx: continuation byte. Skip until we land on a
 		// leading byte (0xxxxxxx, 110xxxxx, 1110xxxx, 11110xxx).
 		start++
 	}
-	return "…[truncated]…\n" + s[start:]
+	return truncationSentinel + s[start:]
 }
 
 // ── Upgrade-check caching ─────────────────────────────────────────────────

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -4960,6 +4960,14 @@ func runUpgradeCmd(ctx context.Context, plan upgradeInstallPlan) ([]byte, error)
 // some exotic Volta/nvm setup would have us run `npm install wuphf@latest`
 // in `$HOME` — visibly mutating the user's home directory. The guards make
 // the detection refuse to misfire instead of mis-installing.
+//
+// Assumption: the broker process's cwd equals the user's cwd. Holds today
+// because the wuphf CLI starts the broker and inherits cwd. A future
+// long-lived daemon entry point (launchctl, systemd, sidecar container)
+// would put the broker at "/", and this detection would silently fall
+// back to "unknown" for everyone. If we add a daemon mode, plumb a
+// per-request `working_dir` from the client and prefer it over os.Getwd()
+// here, or move detection out of the broker entirely.
 func detectUpgradeInstall(ctx context.Context) upgradeInstallPlan {
 	if _, err := exec.LookPath("npm"); err != nil {
 		return upgradeInstallPlan{Method: "unknown"}
@@ -5007,9 +5015,19 @@ func detectUpgradeInstall(ctx context.Context) upgradeInstallPlan {
 						}
 					}
 				}
-				// Found a project root but it doesn't declare wuphf —
-				// stop walking. Continuing into a grandparent project
-				// would mis-attribute the install.
+				// Stop walking. Two paths land here, both intentional:
+				//   (a) the project root doesn't declare wuphf — running
+				//       npm install here would silently add wuphf as a
+				//       new dep instead of upgrading an existing one.
+				//   (b) the project DOES declare wuphf but
+				//       node_modules/wuphf/package.json is missing — the
+				//       declared dep was never installed (fresh clone,
+				//       skipped npm install). Suggesting an install in
+				//       this state is correct, but our "local install"
+				//       contract requires both signals; bail to "unknown"
+				//       so the click-to-run UI surfaces the explicit
+				//       fallback message rather than silently running
+				//       npm install with potentially wrong context.
 				break
 			}
 			parent := filepath.Dir(dir)
@@ -5059,14 +5077,20 @@ func (b *Broker) handleUpgradeRun(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Body is required to be JSON {} by the client, but we don't read
-	// any fields from it. Still bound it so a misbehaving (authenticated)
-	// caller can't inflate broker memory by streaming a large body —
-	// MaxBytesReader trips the read at 1 KiB and returns an error to
-	// any subsequent Read. We don't actually consume the body here; the
-	// limit just caps what the HTTP server has to buffer before we
-	// respond.
+	// any fields from it. Bound it AND actually read it so a
+	// misbehaving (authenticated) caller can't inflate broker memory
+	// by streaming a large body — net/http buffers headers but reads
+	// bodies on demand, so MaxBytesReader without a read attempt is a
+	// no-op (the wrapped Read is never called). io.Copy here forces
+	// MaxBytesReader to enforce the cap; if exceeded it short-circuits
+	// the connection and we surface a 413 so the client gets a clear
+	// error rather than a cryptic decode failure.
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<10)
 	defer r.Body.Close()
+	if _, err := io.Copy(io.Discard, r.Body); err != nil {
+		http.Error(w, "request body exceeds 1 KiB cap", http.StatusRequestEntityTooLarge)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 
 	// Single-flight gate. CompareAndSwap returns false if a run is
@@ -5075,8 +5099,14 @@ func (b *Broker) handleUpgradeRun(w http.ResponseWriter, r *http.Request) {
 	// without breaking the .catch / non-2xx path.
 	if !b.upgradeRunInFlight.CompareAndSwap(false, true) {
 		_ = json.NewEncoder(w).Encode(upgradeRunResult{
-			OK:    false,
-			Error: "an upgrade is already running on this broker — wait for it to finish",
+			OK: false,
+			// Set InstallMethod explicitly so the wire shape stays
+			// inside the "global"|"local"|"unknown" union the client
+			// types as. The single-flight rejection happens before we
+			// run detection, so we don't have a real method to report
+			// — "unknown" is the documented fallback for "we can't say".
+			InstallMethod: "unknown",
+			Error:         "an upgrade is already running on this broker — wait for it to finish",
 		})
 		return
 	}
@@ -5105,6 +5135,21 @@ func (b *Broker) handleUpgradeRun(w http.ResponseWriter, r *http.Request) {
 	// short it trips on a typical 5-30s install.
 	runCtx, cancel := context.WithTimeout(context.Background(), upgradeRunTimeout)
 	defer cancel()
+	// Couple to b.stopCh so a graceful broker shutdown (Stop()) cancels
+	// an in-flight install. Without this, `wuphf restart` clicked right
+	// after install-click would leave the OLD broker's npm running for
+	// up to 120s while the NEW broker spawns its own npm against the
+	// same prefix — exactly the half-extract race that the single-flight
+	// in this handler is meant to prevent. The defer-cancel above closes
+	// runCtx on normal return, which races the goroutine to the same
+	// cancel(); cancel() is documented as safe to call multiple times.
+	go func() {
+		select {
+		case <-b.stopCh:
+			cancel()
+		case <-runCtx.Done():
+		}
+	}()
 
 	// runUpgradeCmdFn merges stdout+stderr in invocation order — npm
 	// progress hits stderr, the final `+ wuphf@x.y.z` line hits stdout,
@@ -5137,17 +5182,34 @@ func (b *Broker) handleUpgradeRun(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(res)
 }
 
-// truncateForJSON keeps the trailing `cap` bytes of `s` (the most useful
+// truncateForJSON keeps the trailing `tailBytes` of `s` (the most useful
 // diagnostic — npm puts the error line and the final `+ wuphf@x.y.z`
 // line at the bottom) and prepends a sentinel marking the truncation.
 // Rounds the cut point forward to the next valid UTF-8 sequence start so
 // we don't ship a leading orphan continuation byte that would render as
 // U+FFFD on the client.
-func truncateForJSON(s string, cap int) string {
-	if len(s) <= cap {
+//
+// Note: the parameter is the SUFFIX size, not a hard ceiling on the
+// returned string. The sentinel ("…[truncated]…\n", 18 bytes UTF-8) is
+// added on top, so the result can be up to tailBytes+18 bytes. Safe at
+// the production cap of 64 KiB; callers picking a tight log-line budget
+// or a fixed-size ring buffer must subtract the sentinel themselves.
+func truncateForJSON(s string, tailBytes int) string {
+	// Defensive: a non-positive cap produces a negative slice index and
+	// panics. Treat it as "keep nothing" — empty input passes through
+	// (the sentinel would itself be longer than the request), otherwise
+	// emit just the sentinel so the caller still sees that truncation
+	// happened. No production caller passes <= 0 today.
+	if tailBytes <= 0 {
+		if s == "" {
+			return ""
+		}
+		return "…[truncated]…\n"
+	}
+	if len(s) <= tailBytes {
 		return s
 	}
-	start := len(s) - cap
+	start := len(s) - tailBytes
 	for start < len(s) && s[start]&0xC0 == 0x80 {
 		// 10xxxxxx: continuation byte. Skip until we land on a
 		// leading byte (0xxxxxxx, 110xxxxx, 1110xxxx, 11110xxx).

--- a/internal/team/broker_upgrade_test.go
+++ b/internal/team/broker_upgrade_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -419,9 +420,24 @@ func TestHandleUpgradeRun_ConcurrentRunsSinglefligted(t *testing.T) {
 		Command: "npm install -g wuphf@latest",
 	})
 	release := make(chan struct{})
+	// Buffered so a (failing) double-entry can't deadlock the producer
+	// goroutine — the test shouldn't observe that, but a bug in the
+	// single-flight gate would otherwise hang here instead of failing.
+	entered := make(chan struct{}, 2)
+	var runCalls atomic.Int32
 	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, error) {
-		<-release // hold the leader inside the handler
-		return []byte("done"), nil
+		// Only the first invocation parks on `release`. If the
+		// single-flight gate regresses and a second request reaches
+		// runUpgradeCmdFn, return immediately rather than parking —
+		// otherwise the test deadlocks on `<-results` and CI hangs
+		// instead of reporting the bug.
+		if runCalls.Add(1) == 1 {
+			entered <- struct{}{}
+			<-release
+			return []byte("done"), nil
+		}
+		entered <- struct{}{}
+		return []byte("unexpected second spawn"), nil
 	})
 
 	b := newTestBroker(t)
@@ -448,15 +464,15 @@ func TestHandleUpgradeRun_ConcurrentRunsSinglefligted(t *testing.T) {
 	}
 
 	go send()
-	// Tiny synchronisation gap: let the first request reach the
-	// runUpgradeCmdFn (where it blocks) before firing the second. We
-	// avoid time.Sleep — instead, poll the in-flight flag the handler
-	// flips on entry. This is the only deterministic signal we have
-	// short of intercepting the handler itself.
-	for !b.upgradeRunInFlight.Load() {
-		// Yield without sleeping. If the leader never sets the flag
-		// the test times out at the channel receive below — that's
-		// the right failure mode.
+	// Wait for the leader to reach runUpgradeCmdFn (where it blocks on
+	// `release`) before firing the second request. The fake handler
+	// signals on `entered` as its first action. If the first send
+	// errored before reaching the handler, we'd otherwise spin forever
+	// — fail fast with an explicit timeout instead.
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("leader never reached runUpgradeCmdFn within 5s")
 	}
 	go send()
 

--- a/internal/team/broker_upgrade_test.go
+++ b/internal/team/broker_upgrade_test.go
@@ -1,12 +1,15 @@
 package team
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/nex-crm/wuphf/internal/upgradecheck"
 )
@@ -153,6 +156,474 @@ func TestUpgradeEndpoints_RejectNonGetMethods(t *testing.T) {
 			}
 			if got := resp.Header.Get("Allow"); got != "GET" {
 				t.Errorf("expected Allow: GET, got %q", got)
+			}
+		})
+	}
+}
+
+// pinDetectInstall swaps detectUpgradeInstallFn for the duration of the
+// test. Restores the original on cleanup so concurrent tests don't observe
+// each other's pin.
+func pinDetectInstall(t *testing.T, plan upgradeInstallPlan) {
+	t.Helper()
+	prev := detectUpgradeInstallFn
+	detectUpgradeInstallFn = func(_ context.Context) upgradeInstallPlan { return plan }
+	t.Cleanup(func() { detectUpgradeInstallFn = prev })
+}
+
+func TestHandleUpgradeRun_RequiresAuth(t *testing.T) {
+	b := newTestBroker(t)
+	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("expected 401 without token, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleUpgradeRun_RejectsGet(t *testing.T) {
+	// Mirrors the read-only endpoints' method gate: /upgrade/run is
+	// state-changing and must reject GET. Without this, a proxy that
+	// re-issues a GET on a 30x could trigger an unintended install.
+	b := newTestBroker(t)
+	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Errorf("GET: expected 405, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Allow"); got != "POST" {
+		t.Errorf("expected Allow: POST, got %q", got)
+	}
+}
+
+func TestHandleUpgradeRun_UnknownInstallMethodReturns200WithGuidance(t *testing.T) {
+	// When detection can't find a global or local install (source build,
+	// standalone download, broken npm), return 200 + install_method=
+	// "unknown" + a human error message so the banner can render the
+	// fallback path inline. We deliberately do NOT 4xx this — the
+	// frontend's .catch path treats non-2xx as "broker unreachable" and
+	// hides the banner, which would swallow the user-visible reason.
+	pinDetectInstall(t, upgradeInstallPlan{Method: "unknown"})
+	b := newTestBroker(t)
+	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d body=%s", resp.StatusCode, string(body))
+	}
+	var body upgradeRunResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.OK {
+		t.Errorf("expected ok=false on unknown install method, got %+v", body)
+	}
+	if body.InstallMethod != "unknown" {
+		t.Errorf("expected install_method=unknown, got %q", body.InstallMethod)
+	}
+	if !strings.Contains(body.Error, "npm install") {
+		// Lock the documented contract: the unknown-method response
+		// MUST include a copy-pasteable command in the error message
+		// so a user without an automated path still has the manual
+		// recipe one click away.
+		t.Errorf("unknown-method error should reference npm install, got %q", body.Error)
+	}
+}
+
+// pinRunCmd swaps runUpgradeCmdFn for the duration of the test. The fake
+// receives the install plan so assertions can verify the handler passes
+// through Args/WorkingDir correctly, and returns whatever (output, err)
+// pair the test wants the handler to observe.
+func pinRunCmd(t *testing.T, fake func(ctx context.Context, plan upgradeInstallPlan) ([]byte, error)) {
+	t.Helper()
+	prev := runUpgradeCmdFn
+	runUpgradeCmdFn = fake
+	t.Cleanup(func() { runUpgradeCmdFn = prev })
+}
+
+func TestHandleUpgradeRun_SuccessReturnsOKWithOutput(t *testing.T) {
+	// Happy path: the fake npm exits 0 with characteristic + wuphf@…
+	// output. Handler must surface ok=true, the install_method/command
+	// from detection, and the trimmed output.
+	pinDetectInstall(t, upgradeInstallPlan{
+		Method:  "global",
+		Args:    []string{"install", "-g", "wuphf@latest"},
+		Command: "npm install -g wuphf@latest",
+	})
+	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, error) {
+		return []byte("added 1 package in 2s\n+ wuphf@99.0.0\n"), nil
+	})
+	b := newTestBroker(t)
+	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var body upgradeRunResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK {
+		t.Errorf("expected ok=true, got %+v", body)
+	}
+	if body.InstallMethod != "global" {
+		t.Errorf("install_method=%q want global", body.InstallMethod)
+	}
+	if body.Command != "npm install -g wuphf@latest" {
+		t.Errorf("command=%q drift", body.Command)
+	}
+	if !strings.Contains(body.Output, "wuphf@99.0.0") {
+		t.Errorf("output should pass through unchanged on success, got %q", body.Output)
+	}
+	if body.Error != "" {
+		t.Errorf("expected empty error on success, got %q", body.Error)
+	}
+}
+
+func TestHandleUpgradeRun_FailureSurfacesError(t *testing.T) {
+	// Failure path: exec returns a real error (e.g. EACCES, ENOENT, or
+	// a non-zero npm exit). Handler must set ok=false and populate
+	// `error` with the underlying message so the banner can render the
+	// "needs sudo" / "npm not installed" copy distinctively.
+	pinDetectInstall(t, upgradeInstallPlan{
+		Method:  "global",
+		Args:    []string{"install", "-g", "wuphf@latest"},
+		Command: "npm install -g wuphf@latest",
+	})
+	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, error) {
+		return []byte("npm ERR! EACCES: permission denied\n"), &execError{msg: "exit status 243"}
+	})
+	b := newTestBroker(t)
+	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	var body upgradeRunResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.OK {
+		t.Errorf("expected ok=false on exec error, got %+v", body)
+	}
+	if !strings.Contains(body.Output, "EACCES") {
+		t.Errorf("output should include npm stderr on failure, got %q", body.Output)
+	}
+	if !strings.Contains(body.Error, "exit status 243") {
+		t.Errorf("error should surface underlying exec error, got %q", body.Error)
+	}
+	if body.TimedOut {
+		t.Errorf("non-timeout failure must NOT set timed_out=true, got %+v", body)
+	}
+}
+
+func TestHandleUpgradeRun_TimeoutSetsTimedOutFlag(t *testing.T) {
+	// Timeout path: drive the broker-side runCtx to actually expire by
+	// shrinking upgradeRunTimeout to 1ms and having the fake block on
+	// the ctx until it cancels. The handler's
+	// errors.Is(runCtx.Err(), context.DeadlineExceeded) branch must
+	// then set timed_out=true and surface the timeout-specific message
+	// — distinct from a generic exec failure so the banner copy can
+	// distinguish "still running, just slow" from "outright failed."
+	prev := upgradeRunTimeout
+	upgradeRunTimeout = 1 * time.Millisecond
+	t.Cleanup(func() { upgradeRunTimeout = prev })
+
+	pinDetectInstall(t, upgradeInstallPlan{
+		Method:  "global",
+		Args:    []string{"install", "-g", "wuphf@latest"},
+		Command: "npm install -g wuphf@latest",
+	})
+	pinRunCmd(t, func(ctx context.Context, _ upgradeInstallPlan) ([]byte, error) {
+		<-ctx.Done() // honour the broker-owned ctx so runCtx.Err() trips
+		return nil, ctx.Err()
+	})
+	b := newTestBroker(t)
+	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	var body upgradeRunResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.OK {
+		t.Errorf("expected ok=false on timeout, got %+v", body)
+	}
+	if !body.TimedOut {
+		t.Errorf("expected timed_out=true, got %+v", body)
+	}
+	if !strings.Contains(body.Error, "timed out") {
+		t.Errorf("expected timeout message, got %q", body.Error)
+	}
+}
+
+// execError is a lightweight stand-in for *exec.ExitError that satisfies the
+// `error` interface. We use it instead of running a real process so tests
+// don't depend on /usr/bin/false (or its absence) on the build host. The
+// handler treats this opaquely (only calls .Error()), so the
+// non-*exec.ExitError type is fine — locks the contract that future
+// changes must NOT type-assert on *exec.ExitError without updating tests.
+type execError struct{ msg string }
+
+func (e *execError) Error() string { return e.msg }
+
+func TestHandleUpgradeRun_ConcurrentRunsSinglefligted(t *testing.T) {
+	// Two parallel POSTs to /upgrade/run must NOT both spawn npm — the
+	// first wins, the second gets an "already running" error. Without
+	// this guard, two browser tabs hammering install simultaneously
+	// could leave node_modules in a partial-extract state. Drives a
+	// fake `runUpgradeCmdFn` that blocks on a channel so the second
+	// arrival lands while the first is still in flight.
+	pinDetectInstall(t, upgradeInstallPlan{
+		Method:  "global",
+		Args:    []string{"install", "-g", "wuphf@latest"},
+		Command: "npm install -g wuphf@latest",
+	})
+	release := make(chan struct{})
+	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, error) {
+		<-release // hold the leader inside the handler
+		return []byte("done"), nil
+	})
+
+	b := newTestBroker(t)
+	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
+	defer srv.Close()
+
+	type result struct {
+		body upgradeRunResult
+		err  error
+	}
+	results := make(chan result, 2)
+	send := func() {
+		req, _ := http.NewRequest(http.MethodPost, srv.URL, strings.NewReader("{}"))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			results <- result{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		var body upgradeRunResult
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		results <- result{body: body}
+	}
+
+	go send()
+	// Tiny synchronisation gap: let the first request reach the
+	// runUpgradeCmdFn (where it blocks) before firing the second. We
+	// avoid time.Sleep — instead, poll the in-flight flag the handler
+	// flips on entry. This is the only deterministic signal we have
+	// short of intercepting the handler itself.
+	for !b.upgradeRunInFlight.Load() {
+		// Yield without sleeping. If the leader never sets the flag
+		// the test times out at the channel receive below — that's
+		// the right failure mode.
+	}
+	go send()
+
+	// Collect the loser first — it returns immediately. The leader
+	// stays blocked until we close `release`.
+	first := <-results
+	if first.err != nil {
+		t.Fatalf("loser: %v", first.err)
+	}
+	if first.body.OK {
+		t.Errorf("loser must be ok=false (got %+v)", first.body)
+	}
+	if !strings.Contains(first.body.Error, "already running") {
+		t.Errorf("loser error should mention 'already running', got %q", first.body.Error)
+	}
+	close(release) // unblock the leader
+	second := <-results
+	if second.err != nil {
+		t.Fatalf("leader: %v", second.err)
+	}
+	if !second.body.OK {
+		t.Errorf("leader must be ok=true (got %+v)", second.body)
+	}
+}
+
+func TestHandleUpgradeCheck_IncludesInstallMethod(t *testing.T) {
+	// The chip's text is set from /upgrade-check's install_command so
+	// the click target's label matches what /upgrade/run would actually
+	// execute. This test pins detection to "local" and asserts the
+	// served JSON forwards both fields. Without this, the chip silently
+	// reverts to the hard-coded `npm install -g …` fallback even when
+	// the broker would run the local-install variant.
+	resetUpgradeCaches(t)
+	pinDetectInstall(t, upgradeInstallPlan{
+		Method:     "local",
+		Command:    "npm install wuphf@latest",
+		WorkingDir: "/workspace/some-app",
+	})
+	// Pre-seed upgradecheck cache with a happy result so the handler
+	// doesn't try to hit npm during the test.
+	upgradeCheckCache.Store(&upgradeCheckCacheEntry{
+		res: upgradecheck.Result{
+			Current:          "0.83.7",
+			Latest:           "0.83.10",
+			UpgradeAvailable: true,
+			UpgradeCommand:   "npm install -g wuphf@latest",
+		},
+		storeAt: time.Now(),
+	})
+
+	b := newTestBroker(t)
+	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeCheck))
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Current        string `json:"current"`
+		Latest         string `json:"latest"`
+		InstallMethod  string `json:"install_method"`
+		InstallCommand string `json:"install_command"`
+		UpgradeCommand string `json:"upgrade_command"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.InstallMethod != "local" {
+		t.Errorf("install_method=%q want local", body.InstallMethod)
+	}
+	if body.InstallCommand != "npm install wuphf@latest" {
+		t.Errorf("install_command=%q want local-install variant", body.InstallCommand)
+	}
+	// upgrade_command stays as the canonical doc-string variant —
+	// install_command is the per-host truthful one. They MAY differ.
+	if body.UpgradeCommand != "npm install -g wuphf@latest" {
+		t.Errorf("upgrade_command should keep its canonical value, got %q", body.UpgradeCommand)
+	}
+}
+
+func TestPkgDeclaresWuphf(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want bool
+	}{
+		{
+			name: "declared in dependencies",
+			json: `{"name":"app","dependencies":{"wuphf":"^0.83.0","react":"19"}}`,
+			want: true,
+		},
+		{
+			name: "declared in devDependencies",
+			json: `{"name":"app","devDependencies":{"wuphf":"^0.83.0"}}`,
+			want: true,
+		},
+		{
+			name: "absent — must NOT misfire as local install (the $HOME risk)",
+			json: `{"name":"app","dependencies":{"react":"19"}}`,
+			want: false,
+		},
+		{
+			name: "peerDependencies do NOT count (npm install <pkg>@latest only updates real deps)",
+			json: `{"name":"app","peerDependencies":{"wuphf":"^0.83.0"}}`,
+			want: false,
+		},
+		{
+			name: "malformed package.json — refuse rather than crash",
+			json: `{not valid json`,
+			want: false,
+		},
+		{
+			name: "empty object",
+			json: `{}`,
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := pkgDeclaresWuphf([]byte(c.json)); got != c.want {
+				t.Errorf("pkgDeclaresWuphf(%q)=%v want %v", c.json, got, c.want)
+			}
+		})
+	}
+}
+
+func TestTruncateForJSON(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		cap  int
+		want string
+	}{
+		{"shorter than cap untouched", "hello", 100, "hello"},
+		{"exact cap untouched", "hello", 5, "hello"},
+		{
+			name: "longer than cap keeps tail with sentinel",
+			in:   "abcdefghij",
+			cap:  5,
+			want: "…[truncated]…\nfghij",
+		},
+		{
+			// UTF-8 boundary: "é" is 0xC3 0xA9 (two bytes). With cap=4,
+			// naive byte-slicing of "ééééé" (10 bytes) would start at
+			// byte 6 — which is the 0xA9 continuation of the second
+			// "é", producing "\xa9éé" (invalid UTF-8 leading byte).
+			// truncateForJSON must round forward to the next valid
+			// leading byte so the output starts on a complete rune.
+			name: "rounds forward past UTF-8 continuation byte",
+			in:   "ééééé", // 10 bytes
+			cap:  4,
+			want: "…[truncated]…\néé", // starts at the third "é" (byte 6→6 is start, but byte 6 is leading 0xC3 → no skip needed) — actually picks 4 trailing bytes = "éé"
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := truncateForJSON(c.in, c.cap)
+			if got != c.want {
+				t.Errorf("truncateForJSON(%q,%d)=%q want %q", c.in, c.cap, got, c.want)
+			}
+			// Round-trip: the result must always be valid UTF-8 so
+			// the JSON encoder doesn't replace bytes with U+FFFD.
+			if !utf8.ValidString(got) {
+				t.Errorf("output is not valid UTF-8: %q", got)
 			}
 		})
 	}

--- a/internal/team/broker_upgrade_test.go
+++ b/internal/team/broker_upgrade_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -252,9 +254,9 @@ func TestHandleUpgradeRun_UnknownInstallMethodReturns200WithGuidance(t *testing.
 
 // pinRunCmd swaps runUpgradeCmdFn for the duration of the test. The fake
 // receives the install plan so assertions can verify the handler passes
-// through Args/WorkingDir correctly, and returns whatever (output, err)
-// pair the test wants the handler to observe.
-func pinRunCmd(t *testing.T, fake func(ctx context.Context, plan upgradeInstallPlan) ([]byte, error)) {
+// through Args/WorkingDir correctly, and returns whatever
+// (output, truncated, err) tuple the test wants the handler to observe.
+func pinRunCmd(t *testing.T, fake func(ctx context.Context, plan upgradeInstallPlan) ([]byte, bool, error)) {
 	t.Helper()
 	prev := runUpgradeCmdFn
 	runUpgradeCmdFn = fake
@@ -270,8 +272,8 @@ func TestHandleUpgradeRun_SuccessReturnsOKWithOutput(t *testing.T) {
 		Args:    []string{"install", "-g", "wuphf@latest"},
 		Command: "npm install -g wuphf@latest",
 	})
-	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, error) {
-		return []byte("added 1 package in 2s\n+ wuphf@99.0.0\n"), nil
+	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, bool, error) {
+		return []byte("added 1 package in 2s\n+ wuphf@99.0.0\n"), false, nil
 	})
 	b := newTestBroker(t)
 	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
@@ -317,8 +319,8 @@ func TestHandleUpgradeRun_FailureSurfacesError(t *testing.T) {
 		Args:    []string{"install", "-g", "wuphf@latest"},
 		Command: "npm install -g wuphf@latest",
 	})
-	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, error) {
-		return []byte("npm ERR! EACCES: permission denied\n"), &execError{msg: "exit status 243"}
+	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, bool, error) {
+		return []byte("npm ERR! EACCES: permission denied\n"), false, &execError{msg: "exit status 243"}
 	})
 	b := newTestBroker(t)
 	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
@@ -368,9 +370,9 @@ func TestHandleUpgradeRun_TimeoutSetsTimedOutFlag(t *testing.T) {
 		Args:    []string{"install", "-g", "wuphf@latest"},
 		Command: "npm install -g wuphf@latest",
 	})
-	pinRunCmd(t, func(ctx context.Context, _ upgradeInstallPlan) ([]byte, error) {
+	pinRunCmd(t, func(ctx context.Context, _ upgradeInstallPlan) ([]byte, bool, error) {
 		<-ctx.Done() // honour the broker-owned ctx so runCtx.Err() trips
-		return nil, ctx.Err()
+		return nil, false, ctx.Err()
 	})
 	b := newTestBroker(t)
 	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
@@ -425,7 +427,7 @@ func TestHandleUpgradeRun_ConcurrentRunsSinglefligted(t *testing.T) {
 	// single-flight gate would otherwise hang here instead of failing.
 	entered := make(chan struct{}, 2)
 	var runCalls atomic.Int32
-	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, error) {
+	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, bool, error) {
 		// Only the first invocation parks on `release`. If the
 		// single-flight gate regresses and a second request reaches
 		// runUpgradeCmdFn, return immediately rather than parking —
@@ -434,10 +436,10 @@ func TestHandleUpgradeRun_ConcurrentRunsSinglefligted(t *testing.T) {
 		if runCalls.Add(1) == 1 {
 			entered <- struct{}{}
 			<-release
-			return []byte("done"), nil
+			return []byte("done"), false, nil
 		}
 		entered <- struct{}{}
-		return []byte("unexpected second spawn"), nil
+		return []byte("unexpected second spawn"), false, nil
 	})
 
 	b := newTestBroker(t)
@@ -602,46 +604,264 @@ func TestPkgDeclaresWuphf(t *testing.T) {
 	}
 }
 
-func TestTruncateForJSON(t *testing.T) {
+func TestTailBuffer(t *testing.T) {
+	t.Run("under cap retains everything, no truncation", func(t *testing.T) {
+		buf := newTailBuffer(64)
+		_, _ = buf.Write([]byte("hello"))
+		_, _ = buf.Write([]byte(" world"))
+		if got := string(buf.Bytes()); got != "hello world" {
+			t.Errorf("Bytes()=%q want %q", got, "hello world")
+		}
+		if buf.Truncated() {
+			t.Error("Truncated()=true on under-cap input")
+		}
+	})
+
+	t.Run("multi-write overflow keeps tail and flips truncated", func(t *testing.T) {
+		buf := newTailBuffer(5)
+		_, _ = buf.Write([]byte("abc"))
+		_, _ = buf.Write([]byte("defg"))
+		// Combined "abcdefg" (7 bytes) > cap (5). Keep last 5 = "cdefg".
+		if got := string(buf.Bytes()); got != "cdefg" {
+			t.Errorf("Bytes()=%q want %q", got, "cdefg")
+		}
+		if !buf.Truncated() {
+			t.Error("Truncated()=false after dropping bytes")
+		}
+	})
+
+	t.Run("single write exceeding cap keeps that tail", func(t *testing.T) {
+		buf := newTailBuffer(4)
+		_, _ = buf.Write([]byte("abcdefgh"))
+		if got := string(buf.Bytes()); got != "efgh" {
+			t.Errorf("Bytes()=%q want %q", got, "efgh")
+		}
+		if !buf.Truncated() {
+			t.Error("Truncated()=false after dropping bytes from a single write")
+		}
+	})
+
+	t.Run("single write exactly equal to cap is not flagged truncated", func(t *testing.T) {
+		// Edge case: an oversize-equal write fills the buffer without
+		// dropping any bytes. The tailBuffer must NOT advertise
+		// truncation in that case, otherwise the wire surface would
+		// claim truncation on a clean fill.
+		buf := newTailBuffer(4)
+		_, _ = buf.Write([]byte("abcd"))
+		if got := string(buf.Bytes()); got != "abcd" {
+			t.Errorf("Bytes()=%q want %q", got, "abcd")
+		}
+		if buf.Truncated() {
+			t.Error("Truncated()=true on exact-cap fill")
+		}
+	})
+
+	t.Run("memory cap is bounded — repeated overflow does not grow the underlying array", func(t *testing.T) {
+		// Pour 100x the cap through the buffer in 1 KiB chunks and
+		// assert the underlying array never exceeds maxBytes. Prevents
+		// regressions where append growth pins old allocations.
+		const maxBytes = 4 * 1024
+		buf := newTailBuffer(maxBytes)
+		chunk := make([]byte, 1024)
+		for i := range chunk {
+			chunk[i] = byte(i)
+		}
+		for i := 0; i < 100*maxBytes/len(chunk); i++ {
+			_, _ = buf.Write(chunk)
+		}
+		if got := cap(buf.buf); got > maxBytes {
+			t.Errorf("underlying cap=%d exceeds maxBytes=%d — memory not bounded", got, maxBytes)
+		}
+		if got := len(buf.Bytes()); got != maxBytes {
+			t.Errorf("Bytes() length=%d want %d", got, maxBytes)
+		}
+	})
+}
+
+func TestWithTruncationSentinel(t *testing.T) {
 	cases := []struct {
 		name string
 		in   string
-		cap  int
 		want string
 	}{
-		{"shorter than cap untouched", "hello", 100, "hello"},
-		{"exact cap untouched", "hello", 5, "hello"},
+		{"empty input", "", "…[truncated]…\n"},
+		{"clean leading byte", "fghij", "…[truncated]…\nfghij"},
 		{
-			name: "longer than cap keeps tail with sentinel",
-			in:   "abcdefghij",
-			cap:  5,
-			want: "…[truncated]…\nfghij",
-		},
-		{
-			// UTF-8 boundary: "é" is 0xC3 0xA9 (two bytes). With cap=4,
-			// naive byte-slicing of "ééééé" (10 bytes) would start at
-			// byte 6 — which is the 0xA9 continuation of the second
-			// "é", producing "\xa9éé" (invalid UTF-8 leading byte).
-			// truncateForJSON must round forward to the next valid
-			// leading byte so the output starts on a complete rune.
-			name: "rounds forward past UTF-8 continuation byte",
-			in:   "ééééé", // 10 bytes
-			cap:  4,
-			want: "…[truncated]…\néé", // starts at the third "é" (byte 6→6 is start, but byte 6 is leading 0xC3 → no skip needed) — actually picks 4 trailing bytes = "éé"
+			// "é" is 0xC3 0xA9. If the bounded write cut between the
+			// leading byte and its continuation, the captured tail
+			// would start with 0xA9 (a stray continuation byte). The
+			// sentinel helper must skip past that so the result is
+			// valid UTF-8 and the JSON encoder doesn't substitute
+			// U+FFFD on the client.
+			name: "skips orphan continuation byte at start",
+			in:   string([]byte{0xA9, 'a', 'b'}),
+			want: "…[truncated]…\nab",
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := truncateForJSON(c.in, c.cap)
+			got := withTruncationSentinel(c.in)
 			if got != c.want {
-				t.Errorf("truncateForJSON(%q,%d)=%q want %q", c.in, c.cap, got, c.want)
+				t.Errorf("withTruncationSentinel(%q)=%q want %q", c.in, got, c.want)
 			}
-			// Round-trip: the result must always be valid UTF-8 so
-			// the JSON encoder doesn't replace bytes with U+FFFD.
 			if !utf8.ValidString(got) {
 				t.Errorf("output is not valid UTF-8: %q", got)
 			}
 		})
+	}
+}
+
+func TestDetectLocalInstall(t *testing.T) {
+	// Drives detectLocalInstall against an isolated tmpdir layout so
+	// the walk logic is exercised without depending on a real `npm`,
+	// the developer's actual cwd, or their real $HOME. Exercises the
+	// monorepo-walk fix (don't bail at the first non-declaring
+	// ancestor) plus the safety stops ($HOME, declared-but-not-
+	// installed, no package.json at all).
+	writeFile := func(t *testing.T, path, contents string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	declaresWuphf := `{"dependencies":{"wuphf":"^0.83.0"}}`
+	noWuphf := `{"name":"sub"}`
+	wuphfPkg := `{"name":"wuphf","version":"0.83.0"}`
+
+	t.Run("monorepo: subpackage doesn't declare, root does — walks past sub", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "package.json"), declaresWuphf)
+		writeFile(t, filepath.Join(root, "node_modules", "wuphf", "package.json"), wuphfPkg)
+		writeFile(t, filepath.Join(root, "packages", "sub", "package.json"), noWuphf)
+		got := detectLocalInstall(filepath.Join(root, "packages", "sub"), "")
+		if got.Method != "local" {
+			t.Fatalf("Method=%q want local", got.Method)
+		}
+		if got.WorkingDir != root {
+			// Crucial: root, not the sub-package. A regression that
+			// returned `packages/sub` would silently run `npm install`
+			// in the wrong directory.
+			t.Errorf("WorkingDir=%q want %q", got.WorkingDir, root)
+		}
+	})
+
+	t.Run("declares + materialised wins immediately — does not keep walking", func(t *testing.T) {
+		// If the cwd's package.json BOTH declares wuphf AND has it
+		// installed, we accept it — even if a parent project also
+		// declares wuphf. The nearest match is the user's intent.
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "package.json"), declaresWuphf)
+		writeFile(t, filepath.Join(root, "node_modules", "wuphf", "package.json"), wuphfPkg)
+		sub := filepath.Join(root, "packages", "sub")
+		writeFile(t, filepath.Join(sub, "package.json"), declaresWuphf)
+		writeFile(t, filepath.Join(sub, "node_modules", "wuphf", "package.json"), wuphfPkg)
+		got := detectLocalInstall(sub, "")
+		if got.Method != "local" {
+			t.Fatalf("Method=%q want local", got.Method)
+		}
+		if got.WorkingDir != sub {
+			t.Errorf("WorkingDir=%q want %q (nearest match should win)", got.WorkingDir, sub)
+		}
+	})
+
+	t.Run("declared but not installed — bails to unknown without walking past", func(t *testing.T) {
+		// Fresh-clone case: package.json declares wuphf but
+		// node_modules/wuphf isn't materialised yet. Walking past to
+		// a parent project's wuphf would silently upgrade the WRONG
+		// project. Expect "unknown" so the click-to-run UI surfaces
+		// its explicit fallback copy.
+		root := t.TempDir()
+		// Parent has a fully-installed wuphf — tempting to walk to
+		// it, but we must not, because the sub-package's intent is
+		// clear: install ITS wuphf.
+		writeFile(t, filepath.Join(root, "package.json"), declaresWuphf)
+		writeFile(t, filepath.Join(root, "node_modules", "wuphf", "package.json"), wuphfPkg)
+		sub := filepath.Join(root, "packages", "sub")
+		writeFile(t, filepath.Join(sub, "package.json"), declaresWuphf)
+		got := detectLocalInstall(sub, "")
+		if got.Method != "unknown" {
+			t.Errorf("Method=%q want unknown (declared-but-not-installed must not walk past)", got.Method)
+		}
+	})
+
+	t.Run("no ancestor declares wuphf — unknown", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, "package.json"), noWuphf)
+		writeFile(t, filepath.Join(root, "packages", "sub", "package.json"), noWuphf)
+		got := detectLocalInstall(filepath.Join(root, "packages", "sub"), "")
+		if got.Method != "unknown" {
+			t.Errorf("Method=%q want unknown (no declaring ancestor)", got.Method)
+		}
+	})
+
+	t.Run("$HOME stops the walk before inspecting its package.json", func(t *testing.T) {
+		// Even if a stray ~/package.json declared wuphf and a phantom
+		// ~/node_modules/wuphf existed (some exotic Volta/nvm setup),
+		// running `npm install wuphf@latest` in $HOME would mutate
+		// the user's home directory. The $HOME guard must stop the
+		// walk BEFORE the package.json check.
+		home := t.TempDir()
+		writeFile(t, filepath.Join(home, "package.json"), declaresWuphf)
+		writeFile(t, filepath.Join(home, "node_modules", "wuphf", "package.json"), wuphfPkg)
+		sub := filepath.Join(home, "project", "sub")
+		if err := os.MkdirAll(sub, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		got := detectLocalInstall(sub, home)
+		if got.Method != "unknown" {
+			t.Errorf("Method=%q want unknown ($HOME guard must fire)", got.Method)
+		}
+	})
+
+	t.Run("filesystem-root stop terminates a deep walk cleanly", func(t *testing.T) {
+		// No package.json anywhere up the chain. The walk must reach
+		// the filesystem root (parent == dir) and bail without
+		// looping forever. Use a tmpdir as cwd; no $HOME hint so the
+		// only stop is the root.
+		got := detectLocalInstall(t.TempDir(), "")
+		if got.Method != "unknown" {
+			t.Errorf("Method=%q want unknown (no package.json on path to root)", got.Method)
+		}
+	})
+}
+
+func TestHandleUpgradeRun_BoundedOutputSurfacesTruncationSentinel(t *testing.T) {
+	// End-to-end: when runUpgradeCmdFn reports truncated=true, the
+	// handler must surface a sentinel-prefixed `output` so the banner
+	// can render the "earlier output dropped" indicator. This locks
+	// the wire contract — without it, a verbose npm install would
+	// silently appear as a clean log even though bytes were thrown
+	// away during capture.
+	pinDetectInstall(t, upgradeInstallPlan{
+		Method:  "global",
+		Args:    []string{"install", "-g", "wuphf@latest"},
+		Command: "npm install -g wuphf@latest",
+	})
+	pinRunCmd(t, func(_ context.Context, _ upgradeInstallPlan) ([]byte, bool, error) {
+		return []byte("…final lines…\n+ wuphf@99.0.0\n"), true, nil
+	})
+	b := newTestBroker(t)
+	srv := httptest.NewServer(b.requireAuth(b.handleUpgradeRun))
+	defer srv.Close()
+	req, _ := http.NewRequest(http.MethodPost, srv.URL, nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	var body upgradeRunResult
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasPrefix(body.Output, "…[truncated]…\n") {
+		t.Errorf("output should start with truncation sentinel, got %q", body.Output)
+	}
+	if !strings.Contains(body.Output, "wuphf@99.0.0") {
+		t.Errorf("output should still surface the trailing tail, got %q", body.Output)
 	}
 }
 

--- a/internal/upgradecheck/parity_test.go
+++ b/internal/upgradecheck/parity_test.go
@@ -1,0 +1,69 @@
+package upgradecheck
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestParity_NotableAndIsMajorBump locks the Go side of the upgrade-banner
+// show-gate rules against testdata/upgrade-parity.json. The same fixture
+// is read by the TS side (web/src/components/layout/upgradeBanner.utils.parity.test.ts)
+// so a unilateral tweak to either implementation fails the corresponding
+// language's test until the fixture AND the other side catch up.
+//
+// Why this exists: Notable/IsMajorBump and the version regex now live in
+// three places (this package, internal/team.upgradeVersionParam, and
+// web/src/components/layout/upgradeBanner.utils.ts). Without a shared
+// gate, the next "just tweak the regex" PR would silently desync the
+// banner from the broker; the symptom would be the banner under- or
+// over-triggering on a release with a class of commits the two sides
+// disagreed about.
+func TestParity_NotableAndIsMajorBump(t *testing.T) {
+	// Path is relative to this test file (internal/upgradecheck/) — two
+	// hops up to the repo root, then into the cross-language testdata.
+	path := filepath.Join("..", "..", "testdata", "upgrade-parity.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read parity fixture %q: %v", path, err)
+	}
+	var fix struct {
+		Notable []struct {
+			Name  string        `json:"name"`
+			Input []CommitEntry `json:"input"`
+			Want  bool          `json:"want"`
+		} `json:"notable"`
+		IsMajorBump []struct {
+			Name string `json:"name"`
+			From string `json:"from"`
+			To   string `json:"to"`
+			Want bool   `json:"want"`
+		} `json:"isMajorBump"`
+	}
+	if err := json.Unmarshal(data, &fix); err != nil {
+		t.Fatalf("decode parity fixture: %v", err)
+	}
+	if len(fix.Notable) == 0 || len(fix.IsMajorBump) == 0 {
+		// Belt and suspenders: a typo in the JSON keys would silently
+		// pass with zero cases. Force the fixture to actually carry
+		// content so this test can't accidentally become a no-op.
+		t.Fatalf("parity fixture appears empty (notable=%d, isMajorBump=%d)",
+			len(fix.Notable), len(fix.IsMajorBump))
+	}
+
+	for _, c := range fix.Notable {
+		t.Run("notable/"+c.Name, func(t *testing.T) {
+			if got := Notable(c.Input); got != c.Want {
+				t.Errorf("Notable(%+v) = %v, fixture wants %v", c.Input, got, c.Want)
+			}
+		})
+	}
+	for _, c := range fix.IsMajorBump {
+		t.Run("isMajorBump/"+c.Name, func(t *testing.T) {
+			if got := IsMajorBump(c.From, c.To); got != c.Want {
+				t.Errorf("IsMajorBump(%q,%q) = %v, fixture wants %v", c.From, c.To, got, c.Want)
+			}
+		})
+	}
+}

--- a/internal/upgradecheck/upgradecheck.go
+++ b/internal/upgradecheck/upgradecheck.go
@@ -300,6 +300,39 @@ func extractTrailingPR(s string) string {
 	return m[1]
 }
 
+// Notable reports whether entries contain at least one commit worth nagging
+// the user about. The banner uses this to gate the show-decision so a release
+// that's purely docs/chore/refactor/test/ci/style/build doesn't trigger a
+// banner. Failure-open: if the changelog couldn't be fetched at all, the
+// caller should default to showing the banner rather than swallowing an
+// upgrade silently.
+//
+// "Notable" = any commit with type ∈ {feat, fix, perf} OR Breaking=true.
+// Mirrored in web/src/components/layout/upgradeBanner.utils.ts (hasNotable).
+func Notable(entries []CommitEntry) bool {
+	for _, e := range entries {
+		if e.Breaking {
+			return true
+		}
+		switch e.Type {
+		case "feat", "fix", "perf":
+			return true
+		}
+	}
+	return false
+}
+
+// IsMajorBump reports whether the first dotted-numeric segment of `to` is
+// strictly greater than that of `from`. Used by the banner to force-show
+// across a major version line — a rule we apply manually since auto-release
+// only knows feat-vs-not (no major bump on conventional-commit `!` markers
+// today). Mirrored in web/src/components/layout/upgradeBanner.utils.ts.
+func IsMajorBump(from, to string) bool {
+	pf := splitVersion(from)
+	pt := splitVersion(to)
+	return segAt(pt, 0) > segAt(pf, 0)
+}
+
 // FormatChangelog renders entries grouped by conventional-commit type. Useful
 // for the `wuphf upgrade` subcommand. Breaking-change commits are surfaced
 // in their own group at the top regardless of their underlying type.

--- a/internal/upgradecheck/upgradecheck_test.go
+++ b/internal/upgradecheck/upgradecheck_test.go
@@ -274,3 +274,61 @@ func TestCheckOmitsCompareURLWhenVersionsEqual(t *testing.T) {
 		t.Errorf("CompareURL should be empty when up-to-date, got %q", res.CompareURL)
 	}
 }
+
+func TestNotable(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries []CommitEntry
+		want    bool
+	}{
+		{"feat is notable", []CommitEntry{{Type: "feat"}}, true},
+		{"fix is notable", []CommitEntry{{Type: "fix"}}, true},
+		{"perf is notable", []CommitEntry{{Type: "perf"}}, true},
+		// Breaking marker wins regardless of underlying type — locks the
+		// rule that the marker is the canonical signal, not the label.
+		{"breaking refactor is notable", []CommitEntry{{Type: "refactor", Breaking: true}}, true},
+		{"docs alone is not notable", []CommitEntry{{Type: "docs"}}, false},
+		{"chore alone is not notable", []CommitEntry{{Type: "chore"}}, false},
+		{"refactor without breaking is not notable", []CommitEntry{{Type: "refactor"}}, false},
+		// Mixed list with at least one notable wins — the gate is OR, not AND.
+		{"docs + fix is notable", []CommitEntry{{Type: "docs"}, {Type: "fix"}}, true},
+		// Empty list: the documented contract is `false`. Callers must
+		// failure-open separately when distinguishing "no data" from
+		// "data says nothing notable."
+		{"empty is not notable (caller failure-opens separately)", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := Notable(c.entries); got != c.want {
+				t.Errorf("Notable(%+v)=%v want %v", c.entries, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsMajorBump(t *testing.T) {
+	cases := []struct {
+		from, to string
+		want     bool
+	}{
+		{"0.83.7", "0.83.10", false},
+		{"0.83.7", "0.84.0", false}, // minor bump in 0.x is NOT major
+		{"0.83.7", "1.0.0", true},   // 0.x → 1.0 IS major
+		{"1.5.10", "2.0.0", true},   // 1.x → 2.x IS major
+		{"2.0.0", "1.5.10", false},  // downgrade isn't a bump
+		{"1.0.0-rc.1", "1.0.0", false},
+		// Pre-release stripped before comparison.
+		{"0.83.7-rc.1", "1.0.0", true},
+		// Build metadata stripped before comparison.
+		{"1.0.0", "1.0.1+build.5", false},
+	}
+	for _, c := range cases {
+		if got := IsMajorBump(c.from, c.to); got != c.want {
+			t.Errorf("IsMajorBump(%q,%q)=%v want %v", c.from, c.to, got, c.want)
+		}
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }

--- a/testdata/upgrade-parity.json
+++ b/testdata/upgrade-parity.json
@@ -1,0 +1,43 @@
+{
+  "_about": "Cross-language parity fixture for the upgrade-banner show-gate rules. Both internal/upgradecheck.Notable / IsMajorBump (Go) and web/src/components/layout/upgradeBanner.utils.ts hasNotable / isMajorBump (TS) read this file in tests. The three implementations of these rules (this fixture, the Go pair, and the TS pair) must agree — if you change one side's implementation, BOTH tests fail until the fixture and the other side catch up. This is the whole point of the parity gate.",
+
+  "notable": [
+    { "name": "empty list", "input": [], "want": false },
+    { "name": "feat alone", "input": [{ "type": "feat", "breaking": false }], "want": true },
+    { "name": "fix alone", "input": [{ "type": "fix", "breaking": false }], "want": true },
+    { "name": "perf alone", "input": [{ "type": "perf", "breaking": false }], "want": true },
+    { "name": "breaking refactor (marker overrides type)", "input": [{ "type": "refactor", "breaking": true }], "want": true },
+    { "name": "breaking docs (marker overrides type)", "input": [{ "type": "docs", "breaking": true }], "want": true },
+    { "name": "docs alone", "input": [{ "type": "docs", "breaking": false }], "want": false },
+    { "name": "chore alone", "input": [{ "type": "chore", "breaking": false }], "want": false },
+    { "name": "refactor without breaking", "input": [{ "type": "refactor", "breaking": false }], "want": false },
+    { "name": "test alone", "input": [{ "type": "test", "breaking": false }], "want": false },
+    { "name": "ci alone", "input": [{ "type": "ci", "breaking": false }], "want": false },
+    { "name": "style alone", "input": [{ "type": "style", "breaking": false }], "want": false },
+    { "name": "build alone", "input": [{ "type": "build", "breaking": false }], "want": false },
+    { "name": "all-quiet mix", "input": [
+      { "type": "docs", "breaking": false },
+      { "type": "chore", "breaking": false },
+      { "type": "refactor", "breaking": false }
+    ], "want": false },
+    { "name": "any-notable wins (notable in middle)", "input": [
+      { "type": "chore", "breaking": false },
+      { "type": "fix", "breaking": false },
+      { "type": "docs", "breaking": false }
+    ], "want": true },
+    { "name": "unknown type does not count as notable", "input": [{ "type": "totally-made-up", "breaking": false }], "want": false }
+  ],
+
+  "isMajorBump": [
+    { "name": "patch within 0.x", "from": "0.83.7", "to": "0.83.10", "want": false },
+    { "name": "minor within 0.x is not major", "from": "0.83.7", "to": "0.84.0", "want": false },
+    { "name": "0.x to 1.0", "from": "0.83.7", "to": "1.0.0", "want": true },
+    { "name": "1.x to 2.x", "from": "1.5.10", "to": "2.0.0", "want": true },
+    { "name": "downgrade is not a bump", "from": "2.0.0", "to": "1.5.10", "want": false },
+    { "name": "patch within 1.x", "from": "1.0.0", "to": "1.5.10", "want": false },
+    { "name": "v-prefix major bump", "from": "v1.0.0", "to": "v2.0.0", "want": true },
+    { "name": "pre-release across major", "from": "0.83.7-rc.1", "to": "1.0.0", "want": true },
+    { "name": "build metadata patch", "from": "1.0.0", "to": "1.0.1+build.5", "want": false },
+    { "name": "rc to release within same major", "from": "1.0.0-rc.1", "to": "1.0.0", "want": false }
+  ]
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -913,3 +913,25 @@ export function resetWorkspace() {
 export function shredWorkspace() {
   return postWithTimeout<WorkspaceWipeResult>("/workspace/shred", {}, 20_000);
 }
+
+// UpgradeRunResult mirrors broker.upgradeRunResult — keep field names in
+// sync with internal/team/broker.go so a future rename here surfaces a TS
+// error against the canonical wire shape.
+export interface UpgradeRunResult {
+  ok: boolean;
+  install_method: "global" | "local" | "unknown";
+  command?: string;
+  working_dir?: string;
+  output?: string;
+  error?: string;
+  timed_out?: boolean;
+}
+
+// runUpgrade triggers `npm install [-g] wuphf@latest` on the host that the
+// broker is running on. The 130s timeout is just above the broker-side
+// upgradeRunTimeout (120s) so the client gives the server enough room to
+// surface its own deadline error instead of failing first with a generic
+// "fetch timed out".
+export function runUpgrade() {
+  return postWithTimeout<UpgradeRunResult>("/upgrade/run", {}, 130_000);
+}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -916,10 +916,13 @@ export function shredWorkspace() {
 
 // UpgradeRunResult mirrors broker.upgradeRunResult — keep field names in
 // sync with internal/team/broker.go so a future rename here surfaces a TS
-// error against the canonical wire shape.
+// error against the canonical wire shape. install_method is optional
+// because the UI also synthesises a result on transport failure (network
+// error / timeout before reaching the broker), where no real method has
+// been observed; the broker itself always sets one of the union members.
 export interface UpgradeRunResult {
   ok: boolean;
-  install_method: "global" | "local" | "unknown";
+  install_method?: "global" | "local" | "unknown";
   command?: string;
   working_dir?: string;
   output?: string;

--- a/web/src/components/layout/UpgradeBanner.tsx
+++ b/web/src/components/layout/UpgradeBanner.tsx
@@ -353,17 +353,21 @@ export function UpgradeBanner() {
       setRun({ phase: "done", result });
     } catch (e: unknown) {
       // Network/timeout from the client side. Synthesise a result so the
-      // UI has one shape to render against.
+      // UI has one shape to render against. Don't claim install_method
+      // is "unknown" here — that would make UpgradeRunOutcome render the
+      // broker-side "couldn't detect install" guidance, which is wrong
+      // for a transport failure. Pass `command` so the user still has
+      // a copyable fallback to paste into a terminal.
       setRun({
         phase: "done",
         result: {
           ok: false,
-          install_method: "unknown",
+          command: installCommand,
           error: e instanceof Error ? e.message : String(e),
         },
       });
     }
-  }, [run.phase]);
+  }, [run.phase, installCommand]);
 
   const reload = useCallback(() => {
     window.location.reload();
@@ -480,8 +484,14 @@ export function UpgradeBanner() {
             className="upgrade-banner-dismiss"
             onClick={dismiss}
             aria-label="Dismiss"
-            disabled={forceMajor}
-            title={forceMajor ? "Major updates can't be dismissed" : "Dismiss"}
+            disabled={forceMajor || run.phase === "running"}
+            title={
+              forceMajor
+                ? "Major updates can't be dismissed"
+                : run.phase === "running"
+                  ? "Wait for install to finish"
+                  : "Dismiss"
+            }
           >
             <svg
               width="14"
@@ -607,11 +617,17 @@ function UpgradeRunOutcome({
 }) {
   const [showOutput, setShowOutput] = useState(false);
   if (result.ok) {
+    // The button only reloads the browser page — it does NOT restart
+    // the wuphf service. The user has to do that themselves (Ctrl+C in
+    // their terminal, then `wuphf` again). Promise only what the click
+    // actually does so the success state doesn't lie about behavior.
     return (
       <div className="upgrade-banner-outcome upgrade-banner-outcome--ok">
-        <span>Installed v{latest}. Restart to apply.</span>
+        <span>
+          Installed v{latest}. Reload this page after restarting wuphf.
+        </span>
         <button type="button" className="upgrade-banner-run" onClick={onReload}>
-          <code>Restart wuphf</code>
+          <code>Reload page</code>
         </button>
       </div>
     );

--- a/web/src/components/layout/UpgradeBanner.tsx
+++ b/web/src/components/layout/UpgradeBanner.tsx
@@ -7,12 +7,15 @@ import {
   useState,
 } from "react";
 
-import { get } from "../../api/client";
+import { get, runUpgrade, type UpgradeRunResult } from "../../api/client";
 import {
   type CommitEntry,
   compareVersions,
+  decideShow,
   groupCommits,
+  hasNotable,
   isDevVersion,
+  isMajorBump,
   parseCommit,
   prGitHubURL,
   readForcedPair,
@@ -23,8 +26,12 @@ import {
 } from "./upgradeBanner.utils";
 
 const REPO = "nex-crm/wuphf";
-const UPGRADE_COMMAND = "npm install -g wuphf@latest";
-const DISMISSED_KEY = "wuphf-upgrade-dismissed-version";
+// SILENT_UP_TO_KEY stores the high-water-mark of "latest version the user
+// has actively chosen to mute" — NOT just the dismissed version. This lets
+// us re-show the banner the moment a notable commit lands AFTER the user
+// last said "not now", instead of permanently muting until a new release
+// happens to be the literal-equal version they last clicked-X on.
+const SILENT_UP_TO_KEY = "wuphf-upgrade-silent-up-to";
 
 interface UpgradeCheckResponse {
   current: string;
@@ -33,6 +40,13 @@ interface UpgradeCheckResponse {
   is_dev_build: boolean;
   compare_url?: string;
   upgrade_command: string;
+  // install_method/install_command are the server's view of what
+  // POST /upgrade/run would ACTUALLY execute on this host (global vs
+  // local install). The chip renders install_command verbatim so the
+  // click target's text never lies. Older brokers omit these fields —
+  // fall back to upgrade_command.
+  install_method?: "global" | "local" | "unknown";
+  install_command?: string;
   error?: string;
 }
 
@@ -52,7 +66,17 @@ interface ChangelogState {
   loading: boolean;
   error: string | null;
   commits: CommitEntry[];
+  // ready=true means the fetch attempt has resolved — success, error, or
+  // empty response. Distinct from `loading` because the show/hide gate
+  // needs to know "have we tried yet" vs "is it in flight". Failure-open:
+  // when ready=false, we treat the gate as undecided (don't hide).
+  ready: boolean;
 }
+
+type RunState =
+  | { phase: "idle" }
+  | { phase: "running" }
+  | { phase: "done"; result: UpgradeRunResult };
 
 export function UpgradeBanner() {
   const forced = useMemo(readForcedPair, []);
@@ -69,13 +93,28 @@ export function UpgradeBanner() {
   // The URL-override path skips the server call so this stays false
   // (intentional: QA preview shouldn't be classified as dev).
   const [isDevBuildSrv, setIsDevBuildSrv] = useState(false);
-  const [dismissed, setDismissed] = useState(false);
+  // installCommand: the literal command the broker would run on
+  // /upgrade/run for this host. Falls back to the canonical
+  // `npm install -g …` doc string when the server hasn't decided yet
+  // OR sent a "unknown" install method. The chip uses this for its
+  // label so users with a local install never see the global command
+  // promised when they're actually about to get a project-scoped one.
+  const [installCommand, setInstallCommand] = useState<string>(
+    "npm install -g wuphf@latest",
+  );
+  // silentUpTo: the "high water mark" version the user has muted up to. A
+  // new release re-surfaces the banner only when there's a notable commit
+  // between this and `latest` (or when the major segment bumps — see
+  // `forceMajor` below). Read once on mount; updated by dismiss().
+  const [silentUpTo, setSilentUpTo] = useState<string | null>(() =>
+    safeLocalStorageGet(SILENT_UP_TO_KEY),
+  );
   const [expanded, setExpanded] = useState(false);
-  const [copied, setCopied] = useState(false);
   const [changelog, setChangelog] = useState<ChangelogState>({
     loading: false,
     error: null,
     commits: [],
+    ready: false,
   });
   // Per-component latch so a successful (or non-abort-failed) fetch is
   // not retried when the user toggles expanded off and on again. Set in
@@ -88,6 +127,12 @@ export function UpgradeBanner() {
   // Stable id so the toggle button's aria-controls can point at the
   // collapsible drawer for assistive tech.
   const changelogId = useId();
+
+  // Run state: idle → running → done. The chip click flips to running;
+  // the response (success/failure) sticks in `done` until the user
+  // dismisses or reloads. There's no path back to idle — once you've
+  // initiated an install, the next step is restart, not retry.
+  const [run, setRun] = useState<RunState>({ phase: "idle" });
 
   useEffect(() => {
     if (!enabled || forced) return;
@@ -104,6 +149,17 @@ export function UpgradeBanner() {
         if (res.current) setCurrent(res.current);
         if (res.latest) setLatest(res.latest);
         setIsDevBuildSrv(!!res.is_dev_build);
+        // Replace the chip label only when the server gave us a real
+        // command — for "unknown" installs we keep the canonical
+        // `npm install -g …` so the click outcome's "couldn't detect"
+        // copy still makes sense alongside the chip.
+        if (
+          res.install_command &&
+          res.install_method &&
+          res.install_method !== "unknown"
+        ) {
+          setInstallCommand(res.install_command);
+        }
       })
       .catch(() => {
         // Broker unreachable or returned a non-2xx — degrade silently.
@@ -113,36 +169,66 @@ export function UpgradeBanner() {
     };
   }, [enabled, forced]);
 
-  useEffect(() => {
-    if (!latest) return;
-    const d = safeLocalStorageGet(DISMISSED_KEY);
-    setDismissed(d === latest);
-  }, [latest]);
+  // Anchor the changelog fetch (and the notable-gate) on whichever is
+  // newer between the silently-muted version and the running build. If
+  // the user has muted up to v0.83.10 but is still on v0.83.7, "anything
+  // notable since v0.83.10" is the right question — they explicitly told
+  // us to wait until the diff exceeded their last seen state.
+  const fromVersion = useMemo(() => {
+    if (!current) return null;
+    if (!silentUpTo) return current;
+    if (!VERSION_RE.test(silentUpTo)) return current;
+    return compareVersions(silentUpTo, current) > 0 ? silentUpTo : current;
+  }, [current, silentUpTo]);
 
-  // Drive the changelog fetch from `expanded`. Same caveat as the
-  // upgrade-check effect above: the AbortController only flag-guards
-  // setState on unmount; the broker still completes the GitHub call.
-  // The "have we fetched" bit is latched in the resolution callbacks
-  // (NOT at fetch start), so a collapse-while-loading leaves the ref
-  // unset and the next expand can retry. The cleanup also resets the
-  // loading state so a re-expand doesn't render a stale "Loading
-  // changes…" caption.
+  // Eager changelog fetch (NOT gated on `expanded`) — we need the commits
+  // to compute the notable-gate before deciding whether to render. The
+  // fetch is broker-cached for an hour so this isn't expensive across
+  // tab/page reloads. Re-fires whenever `from` or `latest` changes (e.g.
+  // after the upgrade-check resolves on first mount).
   useEffect(() => {
-    if (!expanded) return;
-    if (!(current && latest)) return;
-    const fetchKey = `${current}→${latest}`;
+    // Eager (NOT gated on `expanded`) — the notable-gate needs the
+    // commits to decide whether to render the banner at all, before the
+    // user has had a chance to expand. The broker caches the response
+    // for an hour, so cost is bounded across tab/page reloads.
+    if (!(fromVersion && latest)) return;
+    if (compareVersions(fromVersion, latest) >= 0) {
+      // Short-circuit (e.g. user just dismissed: silentUpTo == latest →
+      // fromVersion == latest). Don't leave a stale "Loading changes…"
+      // status if the user had the changelog expanded when they hit
+      // dismiss — without this reset, the previous in-flight fetch's
+      // loading=true survived the cleanup and the expanded panel kept
+      // showing the loader forever.
+      setChangelog({ loading: false, error: null, commits: [], ready: true });
+      return;
+    }
+    // Per-component latch on `${fromVersion}→${latest}` so a successful
+    // (or non-abort-failed) fetch is not retried when state churns and
+    // the effect re-runs without the input pair actually changing. Set
+    // in the resolution callbacks (NOT at fetch start) so an abort
+    // leaves the ref unset and the next run can retry.
+    const fetchKey = `${fromVersion}→${latest}`;
     if (changelogFetchedRef.current === fetchKey) return;
     const ctl = new AbortController();
-    setChangelog({ loading: true, error: null, commits: [] });
+    setChangelog({ loading: true, error: null, commits: [], ready: false });
     void get<UpgradeChangelogResponse>("/upgrade-changelog", {
-      from: current,
+      from: fromVersion,
       to: latest,
     })
       .then((data) => {
         if (ctl.signal.aborted) return;
         changelogFetchedRef.current = fetchKey;
         if (data.error) {
-          setChangelog({ loading: false, error: data.error, commits: [] });
+          // Failure-open: ready=true with empty commits would close the
+          // gate. Mark ready=true so the gate decides "absence of
+          // notable signal" but combine with `error` so the higher-level
+          // decision can still failure-open if it wants to.
+          setChangelog({
+            loading: false,
+            error: data.error,
+            commits: [],
+            ready: true,
+          });
           return;
         }
         // The broker forwards entries already parsed by upgradecheck on
@@ -163,7 +249,12 @@ export function UpgradeBanner() {
               }
             : parseCommit(c.description ?? "", c.sha ?? ""),
         );
-        setChangelog({ loading: false, error: null, commits });
+        setChangelog({
+          loading: false,
+          error: null,
+          commits,
+          ready: true,
+        });
       })
       .catch((e: unknown) => {
         if (ctl.signal.aborted) return;
@@ -174,18 +265,13 @@ export function UpgradeBanner() {
           loading: false,
           error: e instanceof Error ? e.message : String(e),
           commits: [],
+          ready: true,
         });
       });
     return () => {
       ctl.abort();
-      // Cleanup-while-loading means neither .then nor .catch will run.
-      // Drop the loading caption so a re-expand doesn't show a stale
-      // "Loading changes…" while the new fetch is being kicked off.
-      setChangelog((prev) =>
-        prev.loading ? { loading: false, error: null, commits: [] } : prev,
-      );
     };
-  }, [expanded, current, latest]);
+  }, [fromVersion, latest]);
 
   const upgradeNeeded = useMemo(() => {
     if (!(current && latest)) return false;
@@ -196,48 +282,55 @@ export function UpgradeBanner() {
     return compareVersions(current, latest) < 0;
   }, [current, latest, isDevBuildSrv]);
 
+  // Major bump = first dotted segment differs between `from` and `latest`.
+  // When true, the banner force-shows (bypasses dismiss) AND the visual
+  // treatment escalates — major bumps are deliberate human decisions in
+  // our auto-release setup, so they always deserve attention.
+  const forceMajor = useMemo(() => {
+    if (!(fromVersion && latest)) return false;
+    return isMajorBump(fromVersion, latest);
+  }, [fromVersion, latest]);
+
+  // Notable-gate: hide the banner if we have a clean changelog with zero
+  // feat/fix/perf/breaking commits. Failure-open in two cases:
+  //   1. Changelog hasn't resolved yet (ready=false) — keep the banner
+  //      hidden until we know, so docs-only patches don't briefly flash.
+  //      But we ALSO use `compareUrl` etc. that need both versions; the
+  //      enclosing `upgradeNeeded` already guards.
+  //   2. Changelog errored OR returned an empty list with no error —
+  //      treat as "we don't know what's in this release" → SHOW. Better
+  //      to nag than to swallow a critical update because the GitHub
+  //      compare API blipped.
+  const notableGate = useMemo(() => {
+    if (!changelog.ready) return false; // wait for resolution
+    if (changelog.error) return true; // failure-open
+    if (changelog.commits.length === 0) return true; // empty response: don't trust
+    return hasNotable(changelog.commits);
+  }, [changelog]);
+
+  // Dismiss: silenced iff user explicitly muted up to (or past) the
+  // current latest. A future release with a NEW notable commit will
+  // re-shift `fromVersion` and re-evaluate the gate.
+  const silenced = useMemo(() => {
+    if (!latest) return false;
+    if (!silentUpTo) return false;
+    if (!VERSION_RE.test(silentUpTo)) return false;
+    return compareVersions(silentUpTo, latest) >= 0;
+  }, [silentUpTo, latest]);
+
+  // compareUrl anchors on `fromVersion` (silentUpTo or current — whichever
+  // is newer) so it matches the changelog list the user sees when they
+  // expand "What's new". Anchoring on `current` would render
+  // `<headline current → latest> + <list fromVersion..latest>`, which
+  // confuses anyone who muted up past their installed version.
   const compareUrl = useMemo(() => {
-    if (!(current && latest)) return "";
-    return `https://github.com/${REPO}/compare/v${stripV(current)}...v${stripV(latest)}`;
-  }, [current, latest]);
+    if (!(fromVersion && latest)) return "";
+    return `https://github.com/${REPO}/compare/v${stripV(fromVersion)}...v${stripV(latest)}`;
+  }, [fromVersion, latest]);
 
   const toggleExpanded = useCallback(() => {
     setExpanded((prev) => !prev);
   }, []);
-
-  // Track the "Copied!" reset timer so an unmount within 1.5s of a copy
-  // doesn't fire setCopied on a dead component (React swallows it but
-  // the timer still owns a closure on the unmounted instance).
-  const copyTimerRef = useRef<number | null>(null);
-  useEffect(
-    () => () => {
-      if (copyTimerRef.current !== null) {
-        window.clearTimeout(copyTimerRef.current);
-      }
-    },
-    [],
-  );
-
-  const copyUpgradeCommand = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(UPGRADE_COMMAND);
-      setCopied(true);
-      if (copyTimerRef.current !== null) {
-        window.clearTimeout(copyTimerRef.current);
-      }
-      copyTimerRef.current = window.setTimeout(() => {
-        copyTimerRef.current = null;
-        setCopied(false);
-      }, 1500);
-    } catch {
-      // Clipboard API unavailable; ignore.
-    }
-  }, []);
-
-  const dismiss = useCallback(() => {
-    if (latest) safeLocalStorageSet(DISMISSED_KEY, latest);
-    setDismissed(true);
-  }, [latest]);
 
   // Memoise the grouped commits so a render that doesn't change the
   // commit list (e.g. expand/collapse toggling) doesn't re-bucket.
@@ -246,23 +339,69 @@ export function UpgradeBanner() {
     [changelog.commits],
   );
 
-  if (!(enabled && upgradeNeeded) || dismissed) return null;
+  const dismiss = useCallback(() => {
+    if (!latest) return;
+    safeLocalStorageSet(SILENT_UP_TO_KEY, latest);
+    setSilentUpTo(latest);
+  }, [latest]);
+
+  const triggerRun = useCallback(async () => {
+    if (run.phase === "running") return;
+    setRun({ phase: "running" });
+    try {
+      const result = await runUpgrade();
+      setRun({ phase: "done", result });
+    } catch (e: unknown) {
+      // Network/timeout from the client side. Synthesise a result so the
+      // UI has one shape to render against.
+      setRun({
+        phase: "done",
+        result: {
+          ok: false,
+          install_method: "unknown",
+          error: e instanceof Error ? e.message : String(e),
+        },
+      });
+    }
+  }, [run.phase]);
+
+  const reload = useCallback(() => {
+    window.location.reload();
+  }, []);
+
+  // Show/hide gate: full matrix lives in `decideShow` (utils) so the
+  // logic is unit-testable without React. The carve-outs for run.phase
+  // are encoded there:
+  //   - phase==="running" pins the banner mounted regardless of dismiss.
+  //   - phase==="done" defers to the same matrix as idle, so a user who
+  //     hits dismiss after a failed install actually gets dismissed
+  //     (instead of the banner sticking until reload).
+  if (
+    !decideShow({
+      enabled,
+      runPhase: run.phase,
+      upgradeNeeded,
+      forceMajor,
+      silenced,
+      notableGate,
+    })
+  ) {
+    return null;
+  }
   // upgradeNeeded already requires both current AND latest at runtime,
   // but the useMemo body isn't visible to TS's narrowing pass — keep
   // this guard so `current` / `latest` narrow from `string | null` to
-  // `string` for the JSX below. (CodeRabbit's suggestion to drop it
-  // ignored the TS narrowing dependency.)
+  // `string` for the JSX below.
   if (!(current && latest)) return null;
+
+  const bannerClass = `upgrade-banner${forceMajor ? " upgrade-banner--major" : ""}`;
+  const runChipLabel = run.phase === "running" ? "Installing…" : null;
 
   return (
     // role="region" + an accessible name lets the banner be navigable as a
     // landmark without auto-announcing on every render the way role="status"
     // (a live region) would for what is really an interactive container.
-    <div
-      className="upgrade-banner"
-      role="region"
-      aria-label="Upgrade available"
-    >
+    <div className={bannerClass} role="region" aria-label="Upgrade available">
       <div className="upgrade-banner-row">
         <div className="upgrade-banner-content">
           <svg
@@ -281,7 +420,8 @@ export function UpgradeBanner() {
             <line x1="12" y1="3" x2="12" y2="15" />
           </svg>
           <span>
-            Update available: <strong>v{stripV(current)}</strong> →{" "}
+            {forceMajor ? "Major update available: " : "Update available: "}
+            <strong>v{stripV(fromVersion ?? current)}</strong> →{" "}
             <strong>v{stripV(latest)}</strong>
           </span>
           <button
@@ -303,22 +443,45 @@ export function UpgradeBanner() {
           </a>
         </div>
         <div className="upgrade-banner-actions">
-          <button
-            type="button"
-            className="upgrade-banner-copy"
-            onClick={copyUpgradeCommand}
-            title="Click to copy"
-          >
-            <code>{UPGRADE_COMMAND}</code>
-            <span className="upgrade-banner-copy-hint">
-              {copied ? "Copied!" : "Copy"}
-            </span>
-          </button>
+          {run.phase === "done" ? (
+            <UpgradeRunOutcome
+              result={run.result}
+              latest={stripV(latest)}
+              onReload={reload}
+            />
+          ) : (
+            <button
+              type="button"
+              className="upgrade-banner-run"
+              onClick={() => {
+                void triggerRun();
+              }}
+              disabled={run.phase === "running"}
+              aria-busy={run.phase === "running"}
+              title="Click to install"
+            >
+              {/* Play glyph mirrors InlineCommand's affordance so the
+                  "click to execute" promise reads at-a-glance. */}
+              <svg
+                width="11"
+                height="11"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+                style={{ flexShrink: 0, opacity: 0.85 }}
+              >
+                <polygon points="6,4 20,12 6,20" />
+              </svg>
+              <code>{runChipLabel ?? installCommand}</code>
+            </button>
+          )}
           <button
             type="button"
             className="upgrade-banner-dismiss"
             onClick={dismiss}
             aria-label="Dismiss"
+            disabled={forceMajor}
+            title={forceMajor ? "Major updates can't be dismissed" : "Dismiss"}
           >
             <svg
               width="14"
@@ -424,6 +587,63 @@ export function UpgradeBanner() {
           </>
         )}
       </div>
+    </div>
+  );
+}
+
+// UpgradeRunOutcome renders the post-click result. Three states map to
+// three visual treatments:
+//   • ok=true               → "Installed vX.Y.Z. Restart to apply." + reload
+//   • install_method=unknown → "Run `npm install -g …` from a terminal."
+//   • everything else        → error message + the npm command they can copy
+function UpgradeRunOutcome({
+  result,
+  latest,
+  onReload,
+}: {
+  result: UpgradeRunResult;
+  latest: string;
+  onReload: () => void;
+}) {
+  const [showOutput, setShowOutput] = useState(false);
+  if (result.ok) {
+    return (
+      <div className="upgrade-banner-outcome upgrade-banner-outcome--ok">
+        <span>Installed v{latest}. Restart to apply.</span>
+        <button type="button" className="upgrade-banner-run" onClick={onReload}>
+          <code>Restart wuphf</code>
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="upgrade-banner-outcome upgrade-banner-outcome--err">
+      <span>
+        {result.timed_out
+          ? "Install timed out."
+          : result.install_method === "unknown"
+            ? "Couldn't detect install — run from a terminal:"
+            : "Install failed:"}
+        {result.error ? (
+          <>
+            {" "}
+            <span className="upgrade-banner-outcome-msg">{result.error}</span>
+          </>
+        ) : null}
+      </span>
+      {result.command ? <code>{result.command}</code> : null}
+      {result.output ? (
+        <button
+          type="button"
+          className="upgrade-banner-link"
+          onClick={() => setShowOutput((s) => !s)}
+        >
+          {showOutput ? "Hide output" : "Show output"}
+        </button>
+      ) : null}
+      {showOutput && result.output ? (
+        <pre className="upgrade-banner-output">{result.output}</pre>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/layout/upgradeBanner.utils.parity.test.ts
+++ b/web/src/components/layout/upgradeBanner.utils.parity.test.ts
@@ -1,0 +1,82 @@
+/// <reference types="node" />
+
+import { describe, expect, it } from "vitest";
+
+import {
+  type CommitEntry,
+  hasNotable,
+  isMajorBump,
+} from "./upgradeBanner.utils";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Cross-language parity gate. The Go side
+// (internal/upgradecheck.TestParity_NotableAndIsMajorBump) reads the same
+// JSON fixture; both implementations must agree on every case. If you
+// change the rule on EITHER side without updating the fixture, the
+// other side's test fails — which is the whole point. The fixture is
+// the single source of truth across:
+//   - this file (web/src/components/layout/upgradeBanner.utils.ts: hasNotable, isMajorBump)
+//   - internal/upgradecheck (Notable, IsMajorBump)
+//   - internal/team.upgradeVersionParam regex (drift here is what surfaces
+//     as banner / broker disagreement on a given release).
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// web/src/components/layout → repo root is 4 hops up.
+const FIXTURE_PATH = path.resolve(
+  __dirname,
+  "../../../../testdata/upgrade-parity.json",
+);
+
+interface NotableCase {
+  name: string;
+  // Fixture entries carry only {type, breaking} since those are the
+  // ONLY fields hasNotable / Notable look at. Cast at use-site so we
+  // don't have to pad the fixture with fields nobody reads.
+  input: Array<{ type: string; breaking: boolean }>;
+  want: boolean;
+}
+
+interface MajorBumpCase {
+  name: string;
+  from: string;
+  to: string;
+  want: boolean;
+}
+
+interface ParityFixture {
+  notable: NotableCase[];
+  isMajorBump: MajorBumpCase[];
+}
+
+const fixture: ParityFixture = JSON.parse(readFileSync(FIXTURE_PATH, "utf8"));
+
+describe("parity: hasNotable matches fixture (mirrors Go Notable)", () => {
+  // Belt-and-suspenders: a typo in the JSON keys would silently leave
+  // this describe block with zero cases, turning the test into a no-op.
+  // Force the fixture to actually carry content so a future "fix" that
+  // accidentally renames `notable` to `notables` fails loudly.
+  it("fixture has cases", () => {
+    expect(fixture.notable.length).toBeGreaterThan(0);
+  });
+  for (const c of fixture.notable) {
+    it(`notable: ${c.name}`, () => {
+      // Cast: hasNotable's signature wants the full CommitEntry but
+      // only reads .type/.breaking. The fixture omits fields that
+      // would be noise.
+      expect(hasNotable(c.input as unknown as CommitEntry[])).toBe(c.want);
+    });
+  }
+});
+
+describe("parity: isMajorBump matches fixture (mirrors Go IsMajorBump)", () => {
+  it("fixture has cases", () => {
+    expect(fixture.isMajorBump.length).toBeGreaterThan(0);
+  });
+  for (const c of fixture.isMajorBump) {
+    it(`isMajorBump: ${c.name}`, () => {
+      expect(isMajorBump(c.from, c.to)).toBe(c.want);
+    });
+  }
+});

--- a/web/src/components/layout/upgradeBanner.utils.test.ts
+++ b/web/src/components/layout/upgradeBanner.utils.test.ts
@@ -1,13 +1,41 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  type CommitEntry,
   compareVersions,
+  decideShow,
   groupCommits,
+  hasNotable,
   isDevVersion,
+  isMajorBump,
   parseCommit,
   prGitHubURL,
   VERSION_RE,
 } from "./upgradeBanner.utils";
+
+// baseShow defines a "everything that could be true is true" matrix for
+// decideShow tests. Each test overrides one or two fields so the cause
+// of expected hide/show is the specific override, not noise.
+const baseShow = {
+  enabled: true,
+  runPhase: "idle" as const,
+  upgradeNeeded: true,
+  forceMajor: false,
+  silenced: false,
+  notableGate: true,
+};
+
+function entry(over: Partial<CommitEntry>): CommitEntry {
+  return {
+    type: "other",
+    scope: "",
+    description: "",
+    pr: null,
+    sha: "abc",
+    breaking: false,
+    ...over,
+  };
+}
 
 describe("compareVersions", () => {
   it.each([
@@ -183,6 +211,124 @@ describe("groupCommits", () => {
     ]);
     const other = grouped.find((g) => g.label === "Other changes");
     expect(other?.entries.map((e) => e.description)).toEqual(["tidy", "pin"]);
+  });
+});
+
+describe("hasNotable", () => {
+  it("true when any commit is feat/fix/perf", () => {
+    expect(hasNotable([entry({ type: "docs" }), entry({ type: "fix" })])).toBe(
+      true,
+    );
+    expect(hasNotable([entry({ type: "feat" })])).toBe(true);
+    expect(hasNotable([entry({ type: "perf" })])).toBe(true);
+  });
+  it("true when any commit carries the breaking marker", () => {
+    // Even if the type alone wouldn't qualify (e.g. refactor), `breaking`
+    // wins. Locks in the rule that the marker is the canonical signal,
+    // not the type label.
+    expect(hasNotable([entry({ type: "refactor", breaking: true })])).toBe(
+      true,
+    );
+  });
+  it("false when only docs/chore/refactor/test/style/ci/build", () => {
+    expect(
+      hasNotable([
+        entry({ type: "docs" }),
+        entry({ type: "chore" }),
+        entry({ type: "refactor" }),
+        entry({ type: "test" }),
+        entry({ type: "style" }),
+        entry({ type: "ci" }),
+        entry({ type: "build" }),
+      ]),
+    ).toBe(false);
+  });
+  it("false on empty list (caller must failure-open separately)", () => {
+    // The gate's documented contract: hasNotable([]) === false. Callers
+    // distinguish "no data fetched yet" from "fetched, found nothing"
+    // outside this function — see UpgradeBanner.notableGate.
+    expect(hasNotable([])).toBe(false);
+  });
+});
+
+describe("isMajorBump", () => {
+  it.each([
+    ["0.79.10", "0.79.15", false],
+    ["0.79.10", "0.80.0", false],
+    ["0.83.7", "1.0.0", true],
+    ["1.0.0", "1.5.10", false],
+    ["1.5.10", "2.0.0", true],
+    ["2.0.0", "1.5.10", false], // downgrade isn't a bump
+    // Pre-release suffixes stripped before comparison.
+    ["0.83.7-rc.1", "1.0.0", true],
+    ["1.0.0", "1.0.1+build.5", false],
+  ] as const)("isMajorBump(%s, %s) === %s", (from, to, want) => {
+    expect(isMajorBump(from, to)).toBe(want);
+  });
+});
+
+describe("decideShow", () => {
+  it("happy path: all signals true → show", () => {
+    expect(decideShow(baseShow)).toBe(true);
+  });
+  it("enabled=false short-circuits everything", () => {
+    expect(
+      decideShow({
+        ...baseShow,
+        enabled: false,
+        forceMajor: true, // even forceMajor can't override
+        runPhase: "running",
+      }),
+    ).toBe(false);
+  });
+  it("running phase always shows (carve-out for in-flight install)", () => {
+    expect(
+      decideShow({
+        ...baseShow,
+        runPhase: "running",
+        silenced: true, // would normally hide
+        upgradeNeeded: false, // would normally hide
+      }),
+    ).toBe(true);
+  });
+  it("done phase defers to idle matrix (so dismiss-after-failure works)", () => {
+    // The reviewer's IMPORTANT #5 case: post-install user wants out
+    // without window.location.reload(). Done state must NOT pin the
+    // banner if silenced=true.
+    expect(decideShow({ ...baseShow, runPhase: "done", silenced: true })).toBe(
+      false,
+    );
+  });
+  it("upgradeNeeded=false hides regardless of notable/major", () => {
+    expect(
+      decideShow({
+        ...baseShow,
+        upgradeNeeded: false,
+        forceMajor: true,
+        notableGate: true,
+      }),
+    ).toBe(false);
+  });
+  it("forceMajor wins over silenced", () => {
+    // Major bumps bypass dismiss because they're deliberate human
+    // actions. A silenced user still sees the banner on a major.
+    expect(decideShow({ ...baseShow, forceMajor: true, silenced: true })).toBe(
+      true,
+    );
+  });
+  it("forceMajor wins over notableGate=false", () => {
+    // Even if the diff has zero notable commits, a major bump shows.
+    // (The "major bump" itself IS the signal.)
+    expect(
+      decideShow({ ...baseShow, forceMajor: true, notableGate: false }),
+    ).toBe(true);
+  });
+  it("silenced hides when not major", () => {
+    expect(decideShow({ ...baseShow, silenced: true })).toBe(false);
+  });
+  it("notableGate=false hides when not silenced and not major", () => {
+    // Docs/chore-only release with no dismiss yet: hide.
+    expect(decideShow({ ...baseShow, notableGate: false })).toBe(false);
   });
 });
 

--- a/web/src/components/layout/upgradeBanner.utils.ts
+++ b/web/src/components/layout/upgradeBanner.utils.ts
@@ -136,6 +136,73 @@ export function parseCommit(message: string, sha: string): CommitEntry {
   };
 }
 
+// hasNotable mirrors internal/upgradecheck.Notable. Returns true iff at
+// least one commit is a feat / fix / perf or carries the breaking marker.
+// The banner uses this as the show/hide gate so a release that's purely
+// docs/chore/refactor/test/ci/style/build doesn't trigger a banner.
+//
+// Failure-open intent: callers MUST default to `true` when they couldn't
+// fetch the changelog at all — better to nag than to swallow a critical
+// update. This function is for the "we have data, what does it say" case
+// only; absence-of-data is a separate decision.
+export function hasNotable(commits: CommitEntry[]): boolean {
+  for (const c of commits) {
+    if (c.breaking) return true;
+    if (c.type === "feat" || c.type === "fix" || c.type === "perf") return true;
+  }
+  return false;
+}
+
+// isMajorBump compares the first dotted-numeric segment of from/to. Returns
+// true when `to`'s major is strictly greater. Matches
+// internal/upgradecheck.IsMajorBump. Used by the banner to force-show across
+// a major-version line — bypasses dismiss entirely.
+//
+// Note: today auto-release.yml only knows feat-vs-not (no major bump on
+// `feat!:` markers), so a major bump is a deliberate human action — exactly
+// the kind of release we want to push. When auto-release learns to bump on
+// breaking markers, this rule still does the right thing.
+export function isMajorBump(from: string, to: string): boolean {
+  const pf = splitVersion(from);
+  const pt = splitVersion(to);
+  return (pt[0] ?? 0) > (pf[0] ?? 0);
+}
+
+// decideShow centralises the banner's render gate so the matrix is
+// unit-testable in isolation. Returns true iff the banner should mount.
+//
+// Rules, in order:
+//   1. enabled=false → never show.
+//   2. runPhase==="running" → always show. The user has initiated an
+//      install; killing the banner mid-install would lose their progress
+//      surface.
+//   3. runPhase==="done" → defer to the same matrix as idle. The post-run
+//      outcome row is part of the banner; if the user dismisses after
+//      a failed install, honour that — don't keep the banner sticky just
+//      because a run completed.
+//   4. !upgradeNeeded → hide. Nothing to upgrade.
+//   5. forceMajor → show. Major bumps bypass dismiss because they're
+//      deliberate human actions in our auto-release setup (see comment
+//      block in UpgradeBanner.tsx).
+//   6. silenced → hide. User explicitly muted up to or past `latest`.
+//   7. !notableGate → hide. The diff has zero feat/fix/perf/breaking.
+//   8. Otherwise → show.
+export function decideShow(input: {
+  enabled: boolean;
+  runPhase: "idle" | "running" | "done";
+  upgradeNeeded: boolean;
+  forceMajor: boolean;
+  silenced: boolean;
+  notableGate: boolean;
+}): boolean {
+  if (!input.enabled) return false;
+  if (input.runPhase === "running") return true;
+  if (!input.upgradeNeeded) return false;
+  if (input.forceMajor) return true;
+  if (input.silenced) return false;
+  return input.notableGate;
+}
+
 export function groupCommits(commits: CommitEntry[]) {
   const buckets = new Map<string, CommitEntry[]>();
   for (const c of commits) {

--- a/web/src/styles/search.css
+++ b/web/src/styles/search.css
@@ -468,7 +468,11 @@
   flex-shrink: 0;
 }
 
-.upgrade-banner-copy {
+/* Click-to-run chip. Visually descended from `.upgrade-banner-copy` (now
+   removed) but with an InlineCommand-style play glyph and busy/disabled
+   states. The `<code>` child renders the command monospace; the chip
+   itself is the click target. */
+.upgrade-banner-run {
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -479,22 +483,82 @@
   cursor: pointer;
   color: var(--blue);
   font: inherit;
+  transition:
+    background 0.12s,
+    box-shadow 0.12s,
+    opacity 0.12s;
 }
-.upgrade-banner-copy:hover {
-  /* Theme-tinted accent — `var(--blue-bg)` survives dark mode where a
-     literal `rgba(0,0,0,…)` overlay would be invisible. */
+.upgrade-banner-run:hover:not(:disabled),
+.upgrade-banner-run:focus-visible:not(:disabled) {
   background: var(--blue-bg);
+  box-shadow: 0 0 0 2px rgba(33, 117, 255, 0.18);
+  outline: none;
 }
-.upgrade-banner-copy code {
+.upgrade-banner-run:disabled {
+  cursor: progress;
+  opacity: 0.7;
+}
+.upgrade-banner-run code {
   font-family: var(--font-mono);
   font-size: 12px;
   color: var(--text);
 }
-.upgrade-banner-copy-hint {
+
+/* Major-bump treatment: louder colors so a release that crosses a major
+   line is unmissable. Uses the warning palette — present in light AND
+   dark themes — instead of an inline rgba so it survives theme swaps. */
+.upgrade-banner.upgrade-banner--major {
+  background: var(--warning-200);
+  border-bottom-color: var(--warning-500);
+}
+.upgrade-banner.upgrade-banner--major .upgrade-banner-link,
+.upgrade-banner.upgrade-banner--major .upgrade-banner-dismiss {
+  color: var(--warning-500);
+}
+.upgrade-banner.upgrade-banner--major .upgrade-banner-run {
+  border-color: var(--warning-500);
+  color: var(--warning-500);
+}
+.upgrade-banner.upgrade-banner--major .upgrade-banner-run:hover:not(:disabled),
+.upgrade-banner.upgrade-banner--major
+  .upgrade-banner-run:focus-visible:not(:disabled) {
+  background: var(--warning-300, #f3cf90);
+  box-shadow: 0 0 0 2px rgba(153, 66, 0, 0.35);
+}
+
+/* Post-run outcome row. Replaces the chip after the user clicks install.
+   Three variants share the layout; the modifier classes pick the accent. */
+.upgrade-banner-outcome {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+.upgrade-banner-outcome code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  color: var(--text);
+}
+.upgrade-banner-outcome--err .upgrade-banner-outcome-msg {
+  color: var(--warning-500);
+}
+.upgrade-banner-output {
+  width: 100%;
+  max-height: 220px;
+  overflow: auto;
+  margin: 6px 0 0;
+  padding: 8px 10px;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: var(--font-mono);
   font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  opacity: 0.75;
+  white-space: pre-wrap;
 }
 
 .upgrade-banner-dismiss {
@@ -607,7 +671,7 @@
   .upgrade-banner-actions {
     justify-content: space-between;
   }
-  .upgrade-banner-copy code {
+  .upgrade-banner-run code {
     font-size: 11px;
   }
 }


### PR DESCRIPTION
## Summary
- **Click-to-run install**: replaces the copy-only `npm install -g wuphf@latest` chip with a button that hits a new `POST /upgrade/run` broker endpoint. Detects whether wuphf is installed globally or as a project-local dep (with strict guards against falling through to `$HOME`) and runs the matching `npm install`. Single-flight on `atomic.Bool` so two tabs racing can't corrupt node_modules. The chip label now comes from the server's detected `install_command`, so users with a local install never see a `-g` promise that the server wouldn't actually deliver.
- **Content-aware show gate**: hides the banner when the diff between current and latest contains zero `feat`/`fix`/`perf`/`breaking` commits. Major bumps force-show (warning palette, non-dismissable). Dismiss is "silent up to v<N>" — the banner re-surfaces the moment a notable commit lands AFTER the dismissed version, not just on a literal version match. No semver-magic beyond major: `auto-release.yml` only knows feat-vs-not, so commit content is the source of truth. Decision matrix extracted to `decideShow()` and unit tested.

Addresses the discussion thread that triggered this work: "in the same way we can execute shred we should be able to click and execute the update command", "don't want to be a nag but want to be present for important fixes/features".

## Test plan
- [x] Go unit tests: `Notable()`, `IsMajorBump()` (`upgradecheck`); `pkgDeclaresWuphf`, `truncateForJSON`, single-flight, success/failure/timeout/auth/method gates, `/upgrade-check` install_method surface (`team`).
- [x] TS unit tests: `hasNotable`, `isMajorBump`, `decideShow` (full matrix).
- [x] `go test ./internal/team/... ./internal/upgradecheck/...` clean.
- [x] `npx vitest run` 489/489 passing.
- [x] `npm run typecheck` clean (only error is unrelated WIP in `web/src/components/auth/`).
- [x] `biome check` clean on changed files.
- [x] `gofmt`, `go vet`, `golangci-lint` clean.
- [ ] Manual smoke: forced-pair URL override (`?upgrade-from=v0.83.7&upgrade-to=v0.83.10`) renders the chip; click runs install (or surfaces "couldn't detect" on a source build).
- [ ] Manual smoke: a docs-only release suppresses the banner.
- [ ] Manual smoke: a forced major-bump pair forces the banner with warning palette and disables the X.

## Review history
Pre-merge staff review surfaced two CRITICAL findings, both addressed in this PR:
1. No single-flight on `/upgrade/run` → added `atomic.Bool` guard + concurrent-runs test.
2. Chip label hardcoded `-g` regardless of detection → server now ships `install_command` via `/upgrade-check`, banner renders the truthful label.

Plus IMPORTANT findings (project-root walk bound, body limit, dismiss-while-loading reset, headline/compareUrl using `fromVersion`, decideShow extraction, comment correction, UTF-8 safe truncation, done-state allows dismiss). Out-of-scope: parser parity test (pre-existing drift surface), nice-to-have nursery lint cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-driven "Run upgrade" action replacing copy-to-clipboard; runs installer and streams output.
  * Banner now persists "mute until version", eagerly fetches changelog, and disables dismiss for major upgrades.
  * Banner visibility now respects notable changes and major-bump logic; shows during running installs.

* **Bug Fixes**
  * Clearer timeout vs. execution errors and truncated-safe output reporting.
  * Prevents overlapping concurrent installs.

* **Style**
  * Redesigned upgrade banner and run-action styling with outcome and scrollable output UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->