### PR TITLE
[codex] fix social preview logo

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -12,14 +12,14 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://wuphf.team">
 <meta property="og:site_name" content="WUPHF">
-<meta property="og:image" content="https://wuphf.team/og-image.png">
-<meta property="og:image:width" content="1024">
-<meta property="og:image:height" content="1024">
+<meta property="og:image" content="https://wuphf.team/apple-touch-icon.png">
+<meta property="og:image:width" content="180">
+<meta property="og:image:height" content="180">
 <meta property="og:image:alt" content="WUPHF logo">
-<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="WUPHF — AI employees with a shared brain">
 <meta name="twitter:description" content="A collaborative office of AI employees who build and maintain their own knowledge base to never lose context for the tasks you give them.">
-<meta name="twitter:image" content="https://wuphf.team/og-image.png">
+<meta name="twitter:image" content="https://wuphf.team/apple-touch-icon.png">
 <meta name="twitter:image:alt" content="WUPHF logo">
 <meta name="theme-color" content="#1b0d2a">
 <link rel="icon" type="image/svg+xml" href="favicon.svg">


### PR DESCRIPTION
## Summary
- Point Open Graph and Twitter preview metadata at the existing purple `apple-touch-icon.png` asset.
- Update the OG dimensions to match that existing 180x180 PNG.
- Use Twitter `summary` instead of `summary_large_image` because the existing asset is square and 180px.

## Validation
- Confirmed `https://wuphf.team/apple-touch-icon.png`, `https://wuphf.team/favicon.svg`, and `https://wuphf.team/favicon-32.png` return HTTP 200.
- Confirmed `website/apple-touch-icon.png` is tracked and 180x180.
- Confirmed the PR diff now changes only `website/index.html`; no generated or new image files.
- Ran `bunx --bun commitlint --from origin/main --to HEAD --verbose`.

Root cause: social metadata referenced `og-image.png`, which is the old yellow share image, while the existing favicon/apple-touch assets are already purple.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated social sharing metadata: the preview image was changed to the site's apple-touch icon, Open Graph image dimensions adjusted to 180×180, and the Twitter card type set to "summary" so link previews use the smaller square image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->