### PR TITLE
feat(skills-publish): wuphf skills publish/install CLI (Stage P)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,26 @@ wuphf --1o1         # 1:1 with the CEO
 wuphf --1o1 cro     # 1:1 with a specific agent
 ```
 
+## Publishing skills
+
+Once a team-authored skill exists at `team/skills/<slug>.md`, you can publish it to the public agent-skill commons or pull a community skill back into your wiki. Publish opens a real PR via `gh`; install fetches a public raw `SKILL.md` and installs it as an active skill in the local team wiki.
+
+```bash
+# Publish your team's deploy skill to the Anthropic skills marketplace
+wuphf skills publish deploy-frontend --to anthropics
+
+# Dry-run the same publish to inspect the manifest + PR body without opening the PR
+wuphf skills publish deploy-frontend --to anthropics --dry-run
+
+# Publish to a custom GitHub repo (e.g. your org's private fork of anthropics/skills)
+wuphf skills publish deploy-frontend --to github:nex-crm/wuphf-skills
+
+# Pull a community skill into your team's wiki
+wuphf skills install web-research --from anthropics
+```
+
+Supported hubs: `anthropics`, `lobehub`, or any `github:owner/repo`. Publish requires `gh auth login` first; install only needs network access since it fetches public raw URLs.
+
 ## What You Should See
 
 - A browser tab at `localhost:7891` with the office

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -103,6 +103,14 @@ func printSubcommandHelp(sub string) {
 		// only touches workspace.go.
 		printWorkspaceHelp()
 		return
+	case "skills":
+		fmt.Fprintln(os.Stderr, "wuphf skills — publish/install team skills against public hubs")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  wuphf skills publish <slug-or-path> --to <hub>     Open a PR with this skill")
+		fmt.Fprintln(os.Stderr, "  wuphf skills install <name> --from <hub>           Pull a skill into your wiki")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Hubs: anthropics, lobehub, github:owner/repo")
 	case "upgrade":
 		fmt.Fprintln(os.Stderr, "wuphf upgrade — check npm for a newer wuphf and show the changelog")
 		fmt.Fprintln(os.Stderr, "")
@@ -231,6 +239,8 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  %s log          Show what your agents actually did (task receipts)\n", appName)
 		fmt.Fprintf(os.Stderr, "  %s memory migrate --from {nex,gbrain}  Port legacy memory into the team wiki\n", appName)
 		fmt.Fprintf(os.Stderr, "  %s workspace ...  Manage multiple isolated WUPHF workspaces\n", appName)
+		fmt.Fprintf(os.Stderr, "  %s skills publish <slug> --to <hub>    Publish a team skill to a public hub\n", appName)
+		fmt.Fprintf(os.Stderr, "  %s skills install <name> --from <hub>  Pull a public skill into the team wiki\n", appName)
 		fmt.Fprintf(os.Stderr, "  %s --cmd <cmd>  Run a command non-interactively\n", appName)
 		fmt.Fprintf(os.Stderr, "\nFlags:\n")
 		printVisibleFlags(os.Stderr)
@@ -337,7 +347,10 @@ func main() {
 
 	if len(args) > 0 {
 		sub := args[0]
-		if subcommandWantsHelp(args[1:]) {
+		// `skills` owns its own per-verb help routing (publish/install have
+		// flag-set-level docs), so we never short-circuit to the family
+		// help when there is a verb between `skills` and `--help`.
+		if sub != "skills" && subcommandWantsHelp(args[1:]) {
 			printSubcommandHelp(sub)
 			return
 		}
@@ -382,6 +395,8 @@ func main() {
 			return
 		case "workspace", "ws":
 			runWorkspace(args[1:])
+		case "skills":
+			runSkillsCmd(args[1:])
 			return
 		}
 	}

--- a/cmd/wuphf/skills_publish.go
+++ b/cmd/wuphf/skills_publish.go
@@ -1,0 +1,740 @@
+package main
+
+// skills_publish.go wires the public-hub publish/install loop:
+//
+//   wuphf skills publish <slug-or-path> --to <hub>     (export)
+//   wuphf skills install <name>          --from <hub>  (import)
+//
+// Publish shells out to `gh` for actual PR creation so we never roll our own
+// GitHub API client. Install is a public raw-fetch + broker POST round-trip.
+//
+// All hub URL/path knowledge lives in internal/skillpublish; this file owns
+// argument parsing, file IO, gh invocations, and HTTP plumbing.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/skillpublish"
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// skillsHTTPTimeout caps every external HTTP call (GitHub raw fetch + broker
+// POST) so a network blip never wedges the CLI. Generous enough that a slow
+// home network still works.
+const skillsHTTPTimeout = 30 * time.Second
+
+// ghCommandTimeout caps every `gh` subprocess. PR creation against GitHub
+// takes a couple of seconds in steady state; 60s leaves headroom for rebases
+// and credential prompts.
+const ghCommandTimeout = 60 * time.Second
+
+// runSkillsCmd is the dispatcher for the `wuphf skills <verb>` subcommand
+// family. Verbs are kept thin so each handler can own its own flag set.
+//
+// Help routing: bare `wuphf skills` and `wuphf skills --help` print the
+// family-level usage; per-verb help (`wuphf skills publish --help`) is
+// handled inside each verb's own FlagSet so users see flag-level docs.
+func runSkillsCmd(args []string) {
+	if len(args) == 0 {
+		printSkillsHelp()
+		os.Exit(2)
+	}
+	if isFamilyHelp(args[0]) {
+		printSkillsHelp()
+		return
+	}
+	verb, rest := args[0], args[1:]
+	switch verb {
+	case "publish":
+		runSkillsPublish(rest)
+	case "install":
+		runSkillsInstall(rest)
+	default:
+		fmt.Fprintf(os.Stderr, "wuphf skills: unknown verb %q — run `wuphf skills --help` for the list.\n", verb)
+		os.Exit(2)
+	}
+}
+
+// isFamilyHelp reports whether the first arg is a family-level help flag
+// (so `wuphf skills --help` prints the verb table, but `wuphf skills publish
+// --help` falls through to publish's own flag-set).
+func isFamilyHelp(first string) bool {
+	switch first {
+	case "-h", "--help", "-help", "help":
+		return true
+	}
+	return false
+}
+
+func printSkillsHelp() {
+	fmt.Fprintln(os.Stderr, "wuphf skills — publish/install team skills against public hubs")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Usage:")
+	fmt.Fprintln(os.Stderr, "  wuphf skills publish <slug-or-path> --to <hub>     Open a PR with this skill")
+	fmt.Fprintln(os.Stderr, "  wuphf skills install <name> --from <hub>           Pull a skill into your wiki")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Hubs: anthropics, lobehub, github:owner/repo")
+}
+
+// ── publish ────────────────────────────────────────────────────────────────
+
+// runSkillsPublish handles `wuphf skills publish`.
+//
+// Stages:
+//  1. Parse + validate args / flags.
+//  2. Resolve the skill path on disk (slug → wiki path, or literal path).
+//  3. Read + ParseSkillMarkdown to get a real frontmatter + body.
+//  4. Build the manifest.
+//  5. Either dry-run print, or shell out to `gh` to open the PR.
+func runSkillsPublish(args []string) {
+	fs := flag.NewFlagSet("skills publish", flag.ContinueOnError)
+	to := fs.String("to", "", "Destination hub: anthropics, lobehub, or github:owner/repo")
+	dryRun := fs.Bool("dry-run", false, "Print the manifest + would-be PR body, do not open the PR")
+	message := fs.String("message", "", "Optional addition to the PR body (defaults to the skill description)")
+	ghTokenFlag := fs.String("github-token", "", "Override gh's saved token; falls back to GH_TOKEN env when blank")
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "wuphf skills publish — open a PR contributing your skill to a public hub")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  wuphf skills publish <slug>          --to anthropics")
+		fmt.Fprintln(os.Stderr, "  wuphf skills publish team/skills/x.md --to lobehub")
+		fmt.Fprintln(os.Stderr, "  wuphf skills publish <slug>          --to github:owner/repo")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Flags:")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(reorderFlagsFirst(args)); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		os.Exit(2)
+	}
+	positional := fs.Args()
+	if len(positional) == 0 {
+		fs.Usage()
+		fmt.Fprintln(os.Stderr, "\nerror: provide a skill slug or markdown path")
+		os.Exit(2)
+	}
+	target := positional[0]
+	hub := strings.TrimSpace(*to)
+	if hub == "" {
+		fs.Usage()
+		fmt.Fprintln(os.Stderr, "\nerror: --to is required")
+		os.Exit(2)
+	}
+	if _, err := skillpublish.HubRepo(hub); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+
+	// Resolve the on-disk path.
+	skillPath, err := resolveSkillPath(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	content, err := os.ReadFile(skillPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: read skill %s: %v\n", skillPath, err)
+		os.Exit(1)
+	}
+	fm, body, err := team.ParseSkillMarkdown(content)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: parse %s: %v\n", skillPath, err)
+		os.Exit(1)
+	}
+	manifest, err := skillpublish.BuildManifest(skillpublishFrontmatterFromTeam(fm), body, repoSlugForSource(), time.Now().UTC())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: build manifest: %v\n", err)
+		os.Exit(1)
+	}
+
+	hubFile, err := skillpublish.HubFilePath(hub, manifest.Name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	hubRepo, _ := skillpublish.HubRepo(hub)
+	branch := skillpublish.PublishBranchName(manifest.Name, time.Now().UTC())
+	prTitle := fmt.Sprintf("Publish %s skill", manifest.Name)
+	prBody := buildPublishPRBody(manifest, *message)
+
+	if *dryRun {
+		fmt.Println("DRY RUN — would publish the following manifest + PR:")
+		fmt.Println()
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(manifest)
+		fmt.Println()
+		fmt.Printf("Target repo : %s\n", hubRepo)
+		fmt.Printf("Target file : %s\n", hubFile)
+		fmt.Printf("Branch      : %s\n", branch)
+		fmt.Printf("PR title    : %s\n", prTitle)
+		fmt.Println("PR body     :")
+		fmt.Println(indentBlock(prBody, "  "))
+		return
+	}
+
+	// Real publish — needs gh, gh auth, and a temp clone of the target repo.
+	if err := ensureGHReady(*ghTokenFlag); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+	prURL, err := publishViaGH(publishParams{
+		ctx:        ctx,
+		hub:        hub,
+		hubRepo:    hubRepo,
+		hubFile:    hubFile,
+		branch:     branch,
+		baseBranch: skillpublish.HubBaseBranch(hub),
+		prTitle:    prTitle,
+		prBody:     prBody,
+		commitMsg:  fmt.Sprintf("Add %s skill", manifest.Name),
+		fileBytes:  content, // publish the SKILL.md verbatim
+		ghToken:    strings.TrimSpace(*ghTokenFlag),
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: publish failed: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Published %s -> %s\n", manifest.Name, prURL)
+}
+
+type publishParams struct {
+	ctx        context.Context
+	hub        string
+	hubRepo    string
+	hubFile    string
+	branch     string
+	baseBranch string
+	prTitle    string
+	prBody     string
+	commitMsg  string
+	fileBytes  []byte
+	ghToken    string
+}
+
+// publishViaGH performs the actual fork/clone/commit/PR dance via the gh CLI.
+//
+// Steps:
+//  1. Fork the target hub repo into the user's account (idempotent — gh
+//     returns success if the fork already exists).
+//  2. Clone the fork into a temp dir.
+//  3. Create a fresh branch from the base.
+//  4. Write the SKILL.md to the right path.
+//  5. Commit, push, and `gh pr create` against the upstream.
+//
+// All gh invocations are timeout-bounded and inherit GH_TOKEN if the caller
+// passed --github-token.
+func publishViaGH(p publishParams) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "wuphf-skill-publish-")
+	if err != nil {
+		return "", fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	env := os.Environ()
+	if p.ghToken != "" {
+		env = append(env, "GH_TOKEN="+p.ghToken)
+	}
+
+	// 1. Fork (idempotent — re-running a publish reuses the existing fork).
+	//    gh prints to stderr when the fork already exists; we only fail on a
+	//    non-zero exit because that signals a real auth/network problem.
+	if err := runGH(p.ctx, tmpDir, env, "repo", "fork", p.hubRepo, "--clone=false"); err != nil {
+		return "", fmt.Errorf("fork %s: %w", p.hubRepo, err)
+	}
+
+	// 2. Resolve the authenticated user so we can clone the user's fork (not
+	//    the upstream — gh repo clone has no `--repo` flag and does not
+	//    auto-rewrite to the fork). Earlier versions of this code cloned
+	//    p.hubRepo directly, which silently cloned the read-only upstream
+	//    and then failed at `git push`.
+	//
+	//    A token without `read:user` scope returns either a 4xx error or a
+	//    body without `.login`. Surface enough detail so the user can
+	//    distinguish "token lacks scope" from "not logged in" — the
+	//    previous error message steered all failures toward
+	//    `gh auth login`, which is the wrong fix for token-based auth.
+	authUser, err := captureGH(p.ctx, tmpDir, env, "api", "user", "--jq", ".login // .message // empty")
+	if err != nil {
+		return "", fmt.Errorf("resolve gh auth user via `gh api user`: %w (your token may lack `read:user` scope; for fine-grained tokens, ensure the user metadata permission is enabled)", err)
+	}
+	authUser = strings.TrimSpace(authUser)
+	if authUser == "" {
+		// `gh api user --jq` returned empty stdout. Re-fetch the raw body
+		// for diagnostics so the caller can see whatever GitHub actually
+		// said (token revoked, scope missing, installation token, etc.).
+		raw, _ := captureGH(p.ctx, tmpDir, env, "api", "user")
+		return "", fmt.Errorf("gh api user did not return a `.login` field — gh response was: %s (likely missing `read:user` scope or an installation/app token)", strings.TrimSpace(raw))
+	}
+	if strings.HasPrefix(authUser, "Bad credentials") || strings.HasPrefix(authUser, "Resource not accessible") || strings.Contains(authUser, "Not Found") {
+		// `.message` came back instead of `.login` — surface verbatim.
+		return "", fmt.Errorf("gh api user failed: %s", authUser)
+	}
+	_, hubName, ok := strings.Cut(p.hubRepo, "/")
+	if !ok || hubName == "" {
+		return "", fmt.Errorf("hubRepo %q must be owner/name", p.hubRepo)
+	}
+	forkRepo := authUser + "/" + hubName
+
+	// GitHub's fork API returns before the fork is fully provisioned. Try
+	// the clone up to 3× with a 2/4/8s backoff so a brand-new fork has
+	// time to land — gh's own retry loop in `gh repo fork --clone` waits
+	// up to ~30s, so 14s of backoff plus the gh request times themselves
+	// is in the right ballpark for new orgs / first-time forks.
+	cloneDir := filepath.Join(tmpDir, "fork")
+	cloneBackoff := []time.Duration{2 * time.Second, 4 * time.Second, 8 * time.Second}
+	var cloneErr error
+	for i := 0; i < 3; i++ {
+		cloneErr = runGH(p.ctx, tmpDir, env, "repo", "clone", forkRepo, cloneDir, "--", "--depth=1", "--branch="+p.baseBranch)
+		if cloneErr == nil {
+			break
+		}
+		// Remove any partial clone before retrying so the next attempt
+		// can start fresh.
+		_ = os.RemoveAll(cloneDir)
+		// Last attempt: don't sleep, just fall through.
+		if i == 2 {
+			break
+		}
+		select {
+		case <-p.ctx.Done():
+			return "", fmt.Errorf("clone fork cancelled: %w", p.ctx.Err())
+		case <-time.After(cloneBackoff[i]):
+		}
+	}
+	if cloneErr != nil {
+		return "", fmt.Errorf("clone fork %s after 3 attempts (~14s of backoff): %w", forkRepo, cloneErr)
+	}
+
+	// 3. Branch from base.
+	if err := runGit(p.ctx, cloneDir, env, "checkout", "-b", p.branch); err != nil {
+		return "", fmt.Errorf("create branch: %w", err)
+	}
+
+	// 4. Write the SKILL.md to the hub-specific path.
+	target := filepath.Join(cloneDir, p.hubFile)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", filepath.Dir(target), err)
+	}
+	if err := os.WriteFile(target, p.fileBytes, 0o644); err != nil {
+		return "", fmt.Errorf("write %s: %w", target, err)
+	}
+
+	// 5. Commit + push + PR.
+	if err := runGit(p.ctx, cloneDir, env, "add", p.hubFile); err != nil {
+		return "", fmt.Errorf("git add: %w", err)
+	}
+	if err := runGit(p.ctx, cloneDir, env, "commit", "-m", p.commitMsg); err != nil {
+		return "", fmt.Errorf("git commit: %w", err)
+	}
+	if err := runGit(p.ctx, cloneDir, env, "push", "-u", "origin", p.branch); err != nil {
+		return "", fmt.Errorf("git push: %w", err)
+	}
+
+	prURL, err := captureGH(p.ctx, cloneDir, env,
+		"pr", "create",
+		"--repo", p.hubRepo,
+		"--base", p.baseBranch,
+		"--head", p.branch,
+		"--title", p.prTitle,
+		"--body", p.prBody,
+	)
+	if err != nil {
+		return "", fmt.Errorf("gh pr create: %w", err)
+	}
+	return strings.TrimSpace(prURL), nil
+}
+
+// runGH wraps `gh` with a timeout, dir, env, and stderr passthrough so the
+// user sees gh's own diagnostics inline. The parent ctx (from
+// signal.NotifyContext) is honoured so a Ctrl-C during a long clone /
+// push / pr-create cancels cleanly.
+func runGH(parent context.Context, dir string, env []string, args ...string) error {
+	ctx, cancel := context.WithTimeout(parent, ghCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stdout = os.Stderr // gh writes progress to stdout; surface as stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// captureGH is runGH but with stdout captured (used by `gh pr create` so we
+// can echo back the PR URL). Honours the parent ctx for cancellation.
+func captureGH(parent context.Context, dir string, env []string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(parent, ghCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stderr = os.Stderr
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}
+
+// runGit shells out to git. We rely on the user's git binary rather than
+// importing a pure-Go implementation because it inherits the user's
+// credential helper, gpg signing, etc. Honours the parent ctx for
+// cancellation so push/checkout/commit can be interrupted.
+func runGit(parent context.Context, dir string, env []string, args ...string) error {
+	ctx, cancel := context.WithTimeout(parent, ghCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Env = env
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// ensureGHReady checks that gh is installed and authenticated before we
+// start cloning. Without this check, the failure mode is a confusing git
+// error several seconds in.
+func ensureGHReady(tokenFlag string) error {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return fmt.Errorf("gh CLI not found in PATH; install from https://cli.github.com")
+	}
+	// If the caller passed --github-token (or set GH_TOKEN), gh treats that
+	// as authenticated. Skip the auth-status probe in that case so we don't
+	// noisily fail when the user is intentionally using an ephemeral token.
+	if strings.TrimSpace(tokenFlag) != "" || strings.TrimSpace(os.Getenv("GH_TOKEN")) != "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "auth", "status")
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Run(); err != nil {
+		return errors.New("gh is installed but not authenticated; run `gh auth login` first")
+	}
+	return nil
+}
+
+// resolveSkillPath turns either a literal path or a slug into an on-disk path.
+//
+// Rules:
+//   - if the input contains a "/" or ends in ".md", treat it as a literal path;
+//   - otherwise treat it as a slug and resolve to <wikiRoot>/team/skills/{slug}.md.
+func resolveSkillPath(input string) (string, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return "", errors.New("skill name or path is required")
+	}
+	if strings.Contains(input, "/") || strings.HasSuffix(input, ".md") {
+		// Literal path — accept absolute or relative.
+		if _, err := os.Stat(input); err != nil {
+			return "", fmt.Errorf("skill file not found at %s: %w", input, err)
+		}
+		abs, err := filepath.Abs(input)
+		if err != nil {
+			return "", fmt.Errorf("resolve absolute path: %w", err)
+		}
+		return abs, nil
+	}
+	// Slug — resolve under the wiki root.
+	root := team.WikiRootDir()
+	candidate := filepath.Join(root, "team", "skills", input+".md")
+	if _, err := os.Stat(candidate); err != nil {
+		return "", fmt.Errorf("skill %q not found at %s: %w", input, candidate, err)
+	}
+	return candidate, nil
+}
+
+// repoSlugForSource picks a stable provenance slug for the manifest's
+// `source` field. We use the basename of the workspace dir (cwd) so multiple
+// teams publishing from different repos still produce distinct sources.
+// Falls back to "wuphf" when cwd is unavailable.
+func repoSlugForSource() string {
+	cwd, err := os.Getwd()
+	if err != nil || strings.TrimSpace(cwd) == "" {
+		return "wuphf"
+	}
+	return filepath.Base(cwd)
+}
+
+// skillpublishFrontmatterFromTeam shrinks team.SkillFrontmatter down to the
+// minimal shape skillpublish needs. Keeping the conversion local avoids an
+// import cycle if/when team starts depending on publish helpers.
+func skillpublishFrontmatterFromTeam(fm team.SkillFrontmatter) skillpublish.FrontmatterLike {
+	return skillpublish.FrontmatterLike{
+		Name:        fm.Name,
+		Description: fm.Description,
+		Version:     fm.Version,
+		License:     fm.License,
+	}
+}
+
+// buildPublishPRBody composes the PR body. Defaults to the skill's
+// description; appends caller-provided extra prose under it.
+//
+// Provenance is captured by m.Source (sanitised to [a-z0-9-]). We do
+// NOT include the local working directory — PRs land in a public hub
+// repo and `Workspace: /Users/<name>/...` would leak the user's home
+// directory layout to anyone reading the PR.
+func buildPublishPRBody(m skillpublish.Manifest, extra string) string {
+	var b strings.Builder
+	b.WriteString(m.Description)
+	b.WriteString("\n\n")
+	b.WriteString(fmt.Sprintf("Skill: `%s` (v%s, %s)\n", m.Name, m.Version, m.License))
+	b.WriteString(fmt.Sprintf("Source: `%s` (published via WUPHF skills compiler)\n", m.Source))
+	b.WriteString(fmt.Sprintf("Published at: %s\n", m.PublishedAt))
+	if strings.TrimSpace(extra) != "" {
+		b.WriteString("\n")
+		b.WriteString(strings.TrimSpace(extra))
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func indentBlock(s, prefix string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = prefix + line
+	}
+	return strings.Join(lines, "\n")
+}
+
+// ── install ────────────────────────────────────────────────────────────────
+
+// runSkillsInstall handles `wuphf skills install`. Reverse of publish.
+func runSkillsInstall(args []string) {
+	fs := flag.NewFlagSet("skills install", flag.ContinueOnError)
+	from := fs.String("from", "", "Source hub: anthropics, lobehub, or github:owner/repo")
+	channel := fs.String("channel", "general", "Channel to log the install event into")
+	fs.SetOutput(os.Stderr)
+	fs.Usage = func() {
+		fmt.Fprintln(os.Stderr, "wuphf skills install — pull a public skill into your team's wiki")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Usage:")
+		fmt.Fprintln(os.Stderr, "  wuphf skills install <name> --from anthropics")
+		fmt.Fprintln(os.Stderr, "  wuphf skills install <name> --from github:owner/repo")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Flags:")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(reorderFlagsFirst(args)); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			os.Exit(0)
+		}
+		os.Exit(2)
+	}
+	positional := fs.Args()
+	if len(positional) == 0 {
+		fs.Usage()
+		fmt.Fprintln(os.Stderr, "\nerror: provide a skill name to install")
+		os.Exit(2)
+	}
+	name := strings.TrimSpace(positional[0])
+	hub := strings.TrimSpace(*from)
+	if hub == "" {
+		fs.Usage()
+		fmt.Fprintln(os.Stderr, "\nerror: --from is required")
+		os.Exit(2)
+	}
+
+	rawURL, err := skillpublish.HubURL(hub, name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(2)
+	}
+
+	// One ctx for the whole install so Ctrl-C cancels both the GitHub
+	// raw fetch AND the broker POST. Earlier this was set up only for
+	// the broker post, so a hung github.com fetch had to wait for the
+	// HTTP timeout.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	body, err := fetchURL(ctx, rawURL)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: fetch %s: %v\n", rawURL, err)
+		os.Exit(1)
+	}
+	fm, content, err := team.ParseSkillMarkdown(body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: parse fetched skill: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Validate the fetched name before it touches the broker payload — a
+	// hub repo could publish a SKILL.md with a path-traversal-shaped name
+	// (e.g. "../../etc/x") and we must reject it before created_by /
+	// content reach the broker.
+	if _, err := skillpublish.BuildManifest(skillpublishFrontmatterFromTeam(fm), content, "", time.Now().UTC()); err != nil {
+		fmt.Fprintf(os.Stderr, "error: fetched skill failed validation: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Post to the broker's /skills endpoint as `create`. The user invoking
+	// `wuphf skills install` IS the human approval — we don't need the
+	// proposal queue here. (Earlier this code used action=propose with
+	// `created_by="hub:..."`, which always 403'd because the broker
+	// requires created_by to resolve to a registered member for proposals.)
+	createdBy := "hub:" + sanitizeHubLabel(hub)
+	payload := map[string]any{
+		"action":      "create",
+		"name":        fm.Name,
+		"title":       fm.Name,
+		"description": fm.Description,
+		"content":     content,
+		"created_by":  createdBy,
+		"channel":     strings.TrimSpace(*channel),
+	}
+	if err := postBrokerSkill(ctx, payload); err != nil {
+		fmt.Fprintf(os.Stderr, "error: post to broker: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Installed %s from %s (status=active). Edit at /skills.\n", fm.Name, hub)
+}
+
+// fetchURL grabs a public raw URL with a bounded timeout and returns the
+// response body. 4 MiB cap is plenty for a SKILL.md and refuses gigantic
+// payloads accidentally hosted at the path.
+//
+// Redirects are restricted to GitHub's raw-content host. Without this
+// guard a malicious `github:` hub could 302 the install fetch to an
+// attacker-controlled host, and the post-install BuildManifest +
+// broker POST would then accept content from anywhere.
+func fetchURL(ctx context.Context, rawURL string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, skillsHTTPTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	client := &http.Client{
+		Timeout: skillsHTTPTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("too many redirects")
+			}
+			// Case-fold the host so "RAW.githubusercontent.com" or any
+			// other case variant from a misconfigured hub redirector
+			// still passes (Go preserves URL host case for non-IDN
+			// hosts). We deliberately do NOT accept *.githubusercontent.com
+			// subdomain shards — if GitHub ever serves raw content from a
+			// new shard, prefer reviewing the change here over silently
+			// trusting any subdomain.
+			if !strings.EqualFold(req.URL.Hostname(), "raw.githubusercontent.com") {
+				return fmt.Errorf("refusing redirect to non-raw-github host %q (a hub redirected the install fetch off-platform)", req.URL.Host)
+			}
+			return nil
+		},
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("HTTP %d from %s", res.StatusCode, rawURL)
+	}
+	return io.ReadAll(io.LimitReader(res.Body, 4*1024*1024))
+}
+
+// postBrokerSkill posts to the local broker's /skills endpoint, mirroring the
+// auth + base URL conventions used elsewhere in the CLI.
+func postBrokerSkill(ctx context.Context, payload map[string]any) error {
+	ctx, cancel := context.WithTimeout(ctx, skillsHTTPTimeout)
+	defer cancel()
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal payload: %w", err)
+	}
+	url := brokerURL("/skills")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token := currentBrokerAuthToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("broker unreachable at %s: %w (start it with `wuphf` first)", url, err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		return fmt.Errorf("broker POST /skills failed: %s %s", res.Status, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}
+
+// reorderFlagsFirst is a small ergonomic helper: Go's stdlib flag package
+// stops parsing at the first non-flag token, so `wuphf skills publish my-slug
+// --to anthropics` would otherwise treat `--to` as another positional. This
+// helper walks args, detects flag tokens (and their value-arg when not in
+// `--key=value` form), and emits them ahead of positionals.
+//
+// The reorder is deliberately conservative — anything past `--` stays in
+// place, and unknown flag-looking tokens are still treated as flags so the
+// downstream Parse can produce a friendly error message.
+func reorderFlagsFirst(args []string) []string {
+	flags := []string{}
+	positional := []string{}
+	i := 0
+	for i < len(args) {
+		a := args[i]
+		if a == "--" {
+			flags = append(flags, args[i:]...)
+			break
+		}
+		if strings.HasPrefix(a, "-") && a != "-" {
+			flags = append(flags, a)
+			// If the flag is in `--key=value` form or is a `-h` style
+			// boolean, no value-arg follows. Otherwise, eagerly consume
+			// the next token. We can't introspect the FlagSet from here,
+			// so we apply the standard heuristic: if the next token does
+			// not itself start with `-`, treat it as the value.
+			if !strings.Contains(a, "=") && i+1 < len(args) {
+				next := args[i+1]
+				if !strings.HasPrefix(next, "-") {
+					flags = append(flags, next)
+					i++
+				}
+			}
+			i++
+			continue
+		}
+		positional = append(positional, a)
+		i++
+	}
+	return append(flags, positional...)
+}
+
+// sanitizeHubLabel returns a hub label suitable for `created_by="hub:<label>"`.
+// `github:owner/repo` collapses to `github-owner-repo` so the broker sees a
+// stable identifier per source.
+func sanitizeHubLabel(hub string) string {
+	hub = strings.TrimSpace(hub)
+	hub = strings.ReplaceAll(hub, ":", "-")
+	hub = strings.ReplaceAll(hub, "/", "-")
+	return strings.ToLower(hub)
+}

--- a/cmd/wuphf/skills_publish_test.go
+++ b/cmd/wuphf/skills_publish_test.go
@@ -1,0 +1,337 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/skillpublish"
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// sampleSkillMarkdown produces a minimal but valid SKILL.md for tests. Mirrors
+// the canonical Anthropic format so RenderSkillMarkdown / ParseSkillMarkdown
+// both round-trip cleanly.
+func sampleSkillMarkdown(t *testing.T, name, desc string) []byte {
+	t.Helper()
+	fm := team.SkillFrontmatter{
+		Name:        name,
+		Description: desc,
+		Version:     "1.0.0",
+		License:     "MIT",
+	}
+	out, err := team.RenderSkillMarkdown(fm, "## Steps\n\n1. Read context\n2. Act\n")
+	if err != nil {
+		t.Fatalf("RenderSkillMarkdown: %v", err)
+	}
+	return out
+}
+
+// TestBuildManifest validates that a parsed SKILL.md produces a manifest with
+// every load-bearing field preserved. This is the primary unit test for the
+// publish path.
+func TestBuildManifest(t *testing.T) {
+	t.Parallel()
+	md := sampleSkillMarkdown(t, "deploy-frontend", "Ship the frontend.")
+	fm, body, err := team.ParseSkillMarkdown(md)
+	if err != nil {
+		t.Fatalf("ParseSkillMarkdown: %v", err)
+	}
+	manifest, err := skillpublish.BuildManifest(skillpublishFrontmatterFromTeam(fm), body, "wuphf-pr4-publish", time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	if manifest.Name != "deploy-frontend" {
+		t.Fatalf("name: got %q want deploy-frontend", manifest.Name)
+	}
+	if manifest.Description != "Ship the frontend." {
+		t.Fatalf("description: got %q", manifest.Description)
+	}
+	if manifest.Version != "1.0.0" {
+		t.Fatalf("version: got %q", manifest.Version)
+	}
+	if manifest.License != "MIT" {
+		t.Fatalf("license: got %q", manifest.License)
+	}
+	if !strings.Contains(manifest.Body, "## Steps") {
+		t.Fatalf("body should contain step block; got %q", manifest.Body)
+	}
+	if manifest.Source != "wuphf-wuphf-pr4-publish-deploy-frontend" {
+		t.Fatalf("source: got %q", manifest.Source)
+	}
+	if manifest.PublishedAt != "2026-04-28T00:00:00Z" {
+		t.Fatalf("published_at: got %q", manifest.PublishedAt)
+	}
+}
+
+// TestHubURL_Anthropics validates the canonical anthropics hub URL.
+func TestHubURL_Anthropics(t *testing.T) {
+	t.Parallel()
+	got, err := skillpublish.HubURL("anthropics", "deploy-frontend")
+	if err != nil {
+		t.Fatalf("HubURL: %v", err)
+	}
+	want := "https://raw.githubusercontent.com/anthropics/skills/main/skills/deploy-frontend/SKILL.md"
+	if got != want {
+		t.Fatalf("HubURL anthropics:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestHubURL_GithubScheme validates the github:owner/repo escape hatch.
+func TestHubURL_GithubScheme(t *testing.T) {
+	t.Parallel()
+	got, err := skillpublish.HubURL("github:nex-crm/wuphf-skills", "review-pr")
+	if err != nil {
+		t.Fatalf("HubURL: %v", err)
+	}
+	want := "https://raw.githubusercontent.com/nex-crm/wuphf-skills/main/skills/review-pr/SKILL.md"
+	if got != want {
+		t.Fatalf("HubURL github scheme:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+// TestHubURL_Unknown ensures we surface a clear error for unknown hubs.
+func TestHubURL_Unknown(t *testing.T) {
+	t.Parallel()
+	if _, err := skillpublish.HubURL("nonexistent-hub", "deploy-frontend"); err == nil {
+		t.Fatalf("expected error for unknown hub")
+	}
+}
+
+// TestResolveSkillPath_LiteralPath confirms a literal markdown path is
+// accepted as-is when it points at an existing file.
+func TestResolveSkillPath_LiteralPath(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deploy-frontend.md")
+	if err := os.WriteFile(path, sampleSkillMarkdown(t, "deploy-frontend", "ship it"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := resolveSkillPath(path)
+	if err != nil {
+		t.Fatalf("resolveSkillPath: %v", err)
+	}
+	want, _ := filepath.Abs(path)
+	if got != want {
+		t.Fatalf("resolveSkillPath: got %s want %s", got, want)
+	}
+}
+
+// TestResolveSkillPath_Slug walks the wiki resolution path: passing a bare
+// slug must surface the expected `<wikiRoot>/team/skills/<slug>.md` layout.
+// Uses t.Setenv so cannot run in parallel with TestResolveSkillPath_Missing.
+func TestResolveSkillPath_Slug(t *testing.T) {
+	wikiHome := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", wikiHome)
+	skillsDir := filepath.Join(wikiHome, ".wuphf", "wiki", "team", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	skillFile := filepath.Join(skillsDir, "daily-digest.md")
+	if err := os.WriteFile(skillFile, sampleSkillMarkdown(t, "daily-digest", "do it daily"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := resolveSkillPath("daily-digest")
+	if err != nil {
+		t.Fatalf("resolveSkillPath: %v", err)
+	}
+	if got != skillFile {
+		t.Fatalf("resolveSkillPath: got %s want %s", got, skillFile)
+	}
+}
+
+// TestResolveSkillPath_Missing surfaces a clear error when neither slug nor
+// path resolves. Uses t.Setenv so cannot run in parallel.
+func TestResolveSkillPath_Missing(t *testing.T) {
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	if _, err := resolveSkillPath("does-not-exist"); err == nil {
+		t.Fatalf("expected error for missing slug")
+	}
+	if _, err := resolveSkillPath("/tmp/wuphf-test-nope.md"); err == nil {
+		t.Fatalf("expected error for missing path")
+	}
+	if _, err := resolveSkillPath("  "); err == nil {
+		t.Fatalf("expected error for blank input")
+	}
+}
+
+// TestSanitizeHubLabel produces a stable broker-side identifier per source.
+func TestSanitizeHubLabel(t *testing.T) {
+	t.Parallel()
+	cases := []struct{ in, want string }{
+		{"anthropics", "anthropics"},
+		{"github:nex-crm/wuphf-skills", "github-nex-crm-wuphf-skills"},
+		{"  Lobehub  ", "lobehub"},
+	}
+	for _, tc := range cases {
+		got := sanitizeHubLabel(tc.in)
+		if got != tc.want {
+			t.Fatalf("sanitizeHubLabel(%q): got %q want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestBuildPublishPRBody_NoCWDLeak guards against the privacy regression:
+// the PR body lands in a public hub repo, so it must not include the
+// user's local working directory ("Workspace: /Users/<name>/...").
+// Source provenance is captured by m.Source which is sanitised to
+// [a-z0-9-].
+func TestBuildPublishPRBody_NoCWDLeak(t *testing.T) {
+	t.Parallel()
+	manifest := skillpublish.Manifest{
+		Name:        "deploy-frontend",
+		Description: "Ship the frontend.",
+		Version:     "1.0.0",
+		License:     "MIT",
+		Source:      "wuphf-team-deploy-frontend",
+		PublishedAt: "2026-04-28T00:00:00Z",
+	}
+	body := buildPublishPRBody(manifest, "")
+	if strings.Contains(body, "Workspace:") {
+		t.Errorf("PR body must not contain Workspace field (privacy: leaks cwd to public hub repo); got:\n%s", body)
+	}
+	cwd, _ := os.Getwd()
+	if cwd != "" && strings.Contains(body, cwd) {
+		t.Errorf("PR body contains the test runner's cwd %q; got:\n%s", cwd, body)
+	}
+}
+
+// TestPostBrokerSkill_RoundTrip pins the broker round-trip the install
+// path uses end-to-end. Without this, a regression like the previous
+// `action: "propose"` 403 would not be caught until manual smoke. We
+// stand up an httptest.Server that mimics the broker's POST /skills
+// endpoint, point WUPHF_BROKER_BASE_URL at it, and assert the request
+// shape the install path emits.
+func TestPostBrokerSkill_RoundTrip(t *testing.T) {
+	var captured struct {
+		method      string
+		contentType string
+		auth        string
+		payload     map[string]any
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/skills" {
+			http.Error(w, "wrong path", http.StatusNotFound)
+			return
+		}
+		captured.method = r.Method
+		captured.contentType = r.Header.Get("Content-Type")
+		captured.auth = r.Header.Get("Authorization")
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &captured.payload)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"skill-x"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("WUPHF_BROKER_BASE_URL", srv.URL)
+	t.Setenv("WUPHF_BROKER_TOKEN", "test-token")
+
+	payload := map[string]any{
+		"action":      "create",
+		"name":        "deploy-frontend",
+		"title":       "deploy-frontend",
+		"description": "Ship it.",
+		"content":     "## Steps\n",
+		"created_by":  "hub:anthropics",
+		"channel":     "skills",
+	}
+	if err := postBrokerSkill(context.Background(), payload); err != nil {
+		t.Fatalf("postBrokerSkill: %v", err)
+	}
+
+	if captured.method != http.MethodPost {
+		t.Errorf("method: got %q want POST", captured.method)
+	}
+	if captured.contentType != "application/json" {
+		t.Errorf("content-type: got %q", captured.contentType)
+	}
+	if captured.auth != "Bearer test-token" {
+		t.Errorf("auth: got %q want Bearer test-token", captured.auth)
+	}
+	if got := captured.payload["action"]; got != "create" {
+		t.Errorf("action: got %v want create (NOT propose — install IS the human approval; see PR review)", got)
+	}
+	if got := captured.payload["name"]; got != "deploy-frontend" {
+		t.Errorf("name: got %v", got)
+	}
+}
+
+// TestFetchURL_RejectsRedirectOffGitHub pins the redirect-host guard:
+// a malicious `github:` hub could 302 the raw fetch to an
+// attacker-controlled host, and the post-install BuildManifest +
+// broker POST would then accept content from anywhere. fetchURL must
+// refuse any redirect that lands off raw.githubusercontent.com.
+func TestFetchURL_RejectsRedirectOffGitHub(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://evil.example.com/SKILL.md", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	_, err := fetchURL(context.Background(), srv.URL+"/skills/x/SKILL.md")
+	if err == nil {
+		t.Fatal("expected error rejecting redirect to evil.example.com, got nil")
+	}
+	if !strings.Contains(err.Error(), "refusing redirect") {
+		t.Errorf("expected 'refusing redirect' in error, got %q", err.Error())
+	}
+}
+
+// TestPostBrokerSkill_4xxSurfacesBody pins the error-shape: a 4xx from
+// the broker should bubble up with the response body so the user can see
+// the broker's actual rejection reason (e.g. "name already exists" or
+// the propose-path 403 we used to hit).
+func TestPostBrokerSkill_4xxSurfacesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`skill with this name already exists`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("WUPHF_BROKER_BASE_URL", srv.URL)
+	t.Setenv("WUPHF_BROKER_TOKEN", "")
+
+	err := postBrokerSkill(context.Background(), map[string]any{
+		"action": "create", "name": "x", "content": "y", "created_by": "z",
+	})
+	if err == nil {
+		t.Fatal("expected error on 409, got nil")
+	}
+	if !strings.Contains(err.Error(), "skill with this name already exists") {
+		t.Errorf("expected broker body in error, got %q", err.Error())
+	}
+}
+
+// TestBuildPublishPRBody surfaces the manifest details + caller-provided
+// extra prose in a stable order.
+func TestBuildPublishPRBody(t *testing.T) {
+	t.Parallel()
+	manifest := skillpublish.Manifest{
+		Name:        "deploy-frontend",
+		Description: "Ship the frontend.",
+		Version:     "1.2.3",
+		License:     "MIT",
+		Source:      "wuphf-team-deploy-frontend",
+		PublishedAt: "2026-04-28T00:00:00Z",
+	}
+	body := buildPublishPRBody(manifest, "Cheers from team WUPHF.")
+	checks := []string{
+		"Ship the frontend.",
+		"`deploy-frontend` (v1.2.3, MIT)",
+		"`wuphf-team-deploy-frontend`",
+		"2026-04-28T00:00:00Z",
+		"Cheers from team WUPHF.",
+	}
+	for _, c := range checks {
+		if !strings.Contains(body, c) {
+			t.Fatalf("publish PR body missing %q\nbody: %s", c, body)
+		}
+	}
+}

--- a/internal/skillpublish/manifest.go
+++ b/internal/skillpublish/manifest.go
@@ -1,0 +1,285 @@
+// Package skillpublish carries the pure logic for turning a compiled WUPHF
+// skill into a publishable manifest for one of the public agent-skill hubs
+// (anthropics/skills, lobehub, or any github:owner/repo fork).
+//
+// All identifiers and URL templates live in this package so adding a new hub
+// is a single map entry plus one switch arm — no CLI plumbing required.
+//
+// The package is intentionally side-effect-free: actual PR creation is shelled
+// out to `gh` from the cmd/wuphf layer so we never roll our own GitHub API
+// client.
+package skillpublish
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Hub identifies a destination registry. Hub keys are kept short and
+// dash-free so they read well as `--to anthropics`, `--to lobehub`, etc.
+type Hub string
+
+const (
+	HubAnthropics Hub = "anthropics"
+	HubLobeHub    Hub = "lobehub"
+	// HubGitHubPrefix marks a one-off `github:owner/repo` target. The full
+	// hub string keeps the prefix attached so callers can pass it through
+	// unmodified — `IsGitHubScheme` is the canonical detector.
+	HubGitHubPrefix = "github:"
+)
+
+// KnownHubs is the closed-set of hub keys we ship out of the box. The
+// `github:` scheme is open-ended and intentionally NOT listed here; callers
+// detect it via IsGitHubScheme.
+var KnownHubs = []Hub{HubAnthropics, HubLobeHub}
+
+// IsGitHubScheme reports whether the hub string is a `github:owner/repo`
+// target rather than a named registry.
+func IsGitHubScheme(hub string) bool {
+	return strings.HasPrefix(strings.TrimSpace(hub), HubGitHubPrefix)
+}
+
+// ParseGitHubScheme splits a `github:owner/repo` hub string into (owner, repo).
+// Returns an error when the scheme is malformed.
+func ParseGitHubScheme(hub string) (owner, repo string, err error) {
+	hub = strings.TrimSpace(hub)
+	if !IsGitHubScheme(hub) {
+		return "", "", fmt.Errorf("skillpublish: not a github: scheme: %q", hub)
+	}
+	body := strings.TrimPrefix(hub, HubGitHubPrefix)
+	parts := strings.SplitN(body, "/", 2)
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", "", fmt.Errorf("skillpublish: github scheme must be github:owner/repo, got %q", hub)
+	}
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+}
+
+// Manifest is the wire-shape WUPHF emits per published skill. Frontmatter
+// fields (Name/Description/Version/License) come straight from the SKILL.md;
+// Body holds the markdown body verbatim; Source is a stable provenance string
+// of the form `wuphf-{repo}-{slug}`; PublishedAt is RFC3339 UTC.
+//
+// JSON tags are kept stable: the manifest is the durable contract a hub
+// indexer can rely on if/when WUPHF adds a hub-side companion service.
+type Manifest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+	License     string `json:"license"`
+	Body        string `json:"body"`
+	Source      string `json:"source"`
+	PublishedAt string `json:"published_at"`
+}
+
+// FrontmatterLike is the minimal shape BuildManifest needs; using a small
+// local interface keeps internal/skillpublish independent of internal/team
+// (which would otherwise create an import cycle once team starts consuming
+// publish helpers).
+type FrontmatterLike struct {
+	Name        string
+	Description string
+	Version     string
+	License     string
+}
+
+// validSkillName matches the kebab slug shape Anthropic Agent Skills accept.
+// Mirrors stageBGenericNameRegex in internal/team. We enforce it here because
+// Name reaches both filepath.Join (HubFilePath) and the broker payload, so a
+// path-traversal-shaped name (e.g. "../../etc/x") could escape the hub
+// repo's clone dir or land an attacker-controlled path on the broker.
+var validSkillName = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,63}$`)
+
+// BuildManifest assembles a Manifest from frontmatter + body. License
+// defaults to MIT when blank; Version defaults to 1.0.0 when blank.
+//
+// Both defaults match the values RenderSkillMarkdown writes when a skill is
+// first compiled, so a round-trip through the file system never changes the
+// shape of the published manifest.
+//
+// Source format `wuphf-{repo}-{slug}` is the provenance string a hub indexer
+// can use to dedupe — passing repo="" yields `wuphf-{slug}` so the prefix is
+// still recognisable when no workspace is set.
+//
+// Name is validated against `^[a-z0-9][a-z0-9-]{0,63}$`. Names outside that
+// shape are rejected because Name flows into filepath.Join (HubFilePath) and
+// into the broker payload — a name like "../../etc/x" would write outside
+// the hub clone directory and reach the broker's CRUD path with an
+// attacker-controlled identifier.
+func BuildManifest(fm FrontmatterLike, body string, repo string, publishedAt time.Time) (Manifest, error) {
+	name := strings.TrimSpace(fm.Name)
+	if name == "" {
+		return Manifest{}, errors.New("skillpublish: frontmatter name is required")
+	}
+	if !validSkillName.MatchString(name) {
+		return Manifest{}, fmt.Errorf("skillpublish: invalid skill name %q: must match ^[a-z0-9][a-z0-9-]{0,63}$ (no slashes, no dots, no spaces, no path components)", name)
+	}
+	desc := strings.TrimSpace(fm.Description)
+	if desc == "" {
+		return Manifest{}, errors.New("skillpublish: frontmatter description is required")
+	}
+	version := strings.TrimSpace(fm.Version)
+	if version == "" {
+		version = "1.0.0"
+	}
+	license := strings.TrimSpace(fm.License)
+	if license == "" {
+		license = "MIT"
+	}
+	if publishedAt.IsZero() {
+		publishedAt = time.Now().UTC()
+	}
+	source := buildSource(repo, name)
+	return Manifest{
+		Name:        name,
+		Description: desc,
+		Version:     version,
+		License:     license,
+		Body:        strings.TrimSpace(body),
+		Source:      source,
+		PublishedAt: publishedAt.UTC().Format(time.RFC3339),
+	}, nil
+}
+
+func buildSource(repo, slug string) string {
+	repo = sanitizeSourceSegment(repo)
+	slug = sanitizeSourceSegment(slug)
+	if repo == "" {
+		return "wuphf-" + slug
+	}
+	return "wuphf-" + repo + "-" + slug
+}
+
+// sanitizeSourceSegment lower-cases and strips characters that don't belong
+// in a hub-side identifier. The result is `[a-z0-9-]+`. Empty input stays
+// empty so callers can detect it.
+func sanitizeSourceSegment(in string) string {
+	in = strings.ToLower(strings.TrimSpace(in))
+	var out strings.Builder
+	for _, r := range in {
+		switch {
+		case r >= 'a' && r <= 'z':
+			out.WriteRune(r)
+		case r >= '0' && r <= '9':
+			out.WriteRune(r)
+		case r == '-' || r == '_':
+			out.WriteRune('-')
+		case r == ' ' || r == '/':
+			out.WriteRune('-')
+		}
+	}
+	return strings.Trim(out.String(), "-")
+}
+
+// HubURL returns the canonical raw-content base URL for a published skill on
+// the named hub. For the `github:owner/repo` scheme, this returns the raw
+// URL pointing at the default-branch (`main`) copy of the SKILL.md.
+//
+// The returned URL is suitable for `wuphf skills install` — drop in `name`
+// and the install path will fetch a public, unauthenticated raw markdown
+// blob from GitHub.
+func HubURL(hub, name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", errors.New("skillpublish: name is required")
+	}
+	if IsGitHubScheme(hub) {
+		owner, repo, err := ParseGitHubScheme(hub)
+		if err != nil {
+			return "", err
+		}
+		return fmt.Sprintf(
+			"https://raw.githubusercontent.com/%s/%s/main/skills/%s/SKILL.md",
+			url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(name),
+		), nil
+	}
+	switch Hub(strings.TrimSpace(hub)) {
+	case HubAnthropics:
+		return fmt.Sprintf(
+			"https://raw.githubusercontent.com/anthropics/skills/main/skills/%s/SKILL.md",
+			url.PathEscape(name),
+		), nil
+	case HubLobeHub:
+		// LobeHub's community index uses a flat agents/{name}.md layout;
+		// callers fetch the raw file the same way.
+		return fmt.Sprintf(
+			"https://raw.githubusercontent.com/lobehub/lobe-chat-agents/main/agents/%s.md",
+			url.PathEscape(name),
+		), nil
+	default:
+		return "", fmt.Errorf("skillpublish: unknown hub %q (known: anthropics, lobehub, github:owner/repo)", hub)
+	}
+}
+
+// HubFilePath returns the path within the hub repo where the skill should be
+// written by the publish PR. For most hubs this is `skills/{name}/SKILL.md`;
+// LobeHub uses the flat `agents/{name}.md` layout.
+func HubFilePath(hub, name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", errors.New("skillpublish: name is required")
+	}
+	if IsGitHubScheme(hub) {
+		// Custom github targets default to the conventional layout. Callers
+		// can override at the CLI layer if they want a different shape.
+		return fmt.Sprintf("skills/%s/SKILL.md", name), nil
+	}
+	switch Hub(strings.TrimSpace(hub)) {
+	case HubAnthropics:
+		return fmt.Sprintf("skills/%s/SKILL.md", name), nil
+	case HubLobeHub:
+		return fmt.Sprintf("agents/%s.md", name), nil
+	default:
+		return "", fmt.Errorf("skillpublish: unknown hub %q (known: anthropics, lobehub, github:owner/repo)", hub)
+	}
+}
+
+// HubRepo returns the `owner/repo` slug for the hub. Used by `gh pr create`
+// and PR-URL templates. github:owner/repo schemes round-trip unchanged.
+func HubRepo(hub string) (string, error) {
+	if IsGitHubScheme(hub) {
+		owner, repo, err := ParseGitHubScheme(hub)
+		if err != nil {
+			return "", err
+		}
+		return owner + "/" + repo, nil
+	}
+	switch Hub(strings.TrimSpace(hub)) {
+	case HubAnthropics:
+		return "anthropics/skills", nil
+	case HubLobeHub:
+		return "lobehub/lobe-chat-agents", nil
+	default:
+		return "", fmt.Errorf("skillpublish: unknown hub %q (known: anthropics, lobehub, github:owner/repo)", hub)
+	}
+}
+
+// HubBaseBranch returns the base branch the publish PR should target.
+// All known hubs target `main` today; switch on hub when that changes.
+// Earlier this was a function-of-hub that ignored its argument, which
+// made the call site look configurable when it wasn't — clearer to
+// switch when a real divergence appears.
+func HubBaseBranch(hub string) string {
+	switch Hub(hub) {
+	case HubAnthropics, HubLobeHub:
+		return "main"
+	default:
+		// github:owner/repo and any future hub: default to main; switch
+		// per-owner here when a real exception comes up.
+		return "main"
+	}
+}
+
+// PublishBranchName builds a stable branch name used for the publish PR.
+// Format: `wuphf-publish-{slug}-{unix-timestamp}`. The unix timestamp keeps
+// branches collision-free across repeated publishes.
+func PublishBranchName(slug string, t time.Time) string {
+	slug = sanitizeSourceSegment(slug)
+	if t.IsZero() {
+		t = time.Now().UTC()
+	}
+	return fmt.Sprintf("wuphf-publish-%s-%d", slug, t.UTC().Unix())
+}

--- a/internal/skillpublish/manifest_test.go
+++ b/internal/skillpublish/manifest_test.go
@@ -1,0 +1,323 @@
+package skillpublish
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildManifest_PreservesFrontmatter(t *testing.T) {
+	t.Parallel()
+	fm := FrontmatterLike{
+		Name:        "deploy-frontend",
+		Description: "Ship the web build with cache warmup.",
+		Version:     "2.4.0",
+		License:     "Apache-2.0",
+	}
+	body := "## Steps\n\n1. bun run build\n2. push to fly\n"
+	at := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+
+	got, err := BuildManifest(fm, body, "wuphf", at)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != fm.Name {
+		t.Fatalf("name: got %q want %q", got.Name, fm.Name)
+	}
+	if got.Description != fm.Description {
+		t.Fatalf("description: got %q want %q", got.Description, fm.Description)
+	}
+	if got.Version != "2.4.0" {
+		t.Fatalf("version: got %q want %q", got.Version, "2.4.0")
+	}
+	if got.License != "Apache-2.0" {
+		t.Fatalf("license: got %q want %q", got.License, "Apache-2.0")
+	}
+	if got.Body != strings.TrimSpace(body) {
+		t.Fatalf("body: got %q want %q", got.Body, strings.TrimSpace(body))
+	}
+	if got.Source != "wuphf-wuphf-deploy-frontend" {
+		t.Fatalf("source: got %q want %q", got.Source, "wuphf-wuphf-deploy-frontend")
+	}
+	if got.PublishedAt != "2026-04-28T12:00:00Z" {
+		t.Fatalf("published_at: got %q", got.PublishedAt)
+	}
+}
+
+func TestBuildManifest_DefaultsLicenseAndVersion(t *testing.T) {
+	t.Parallel()
+	fm := FrontmatterLike{Name: "x", Description: "y"}
+	got, err := BuildManifest(fm, "body", "", time.Time{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.License != "MIT" {
+		t.Fatalf("license default: got %q want MIT", got.License)
+	}
+	if got.Version != "1.0.0" {
+		t.Fatalf("version default: got %q want 1.0.0", got.Version)
+	}
+	if got.Source != "wuphf-x" {
+		t.Fatalf("source without repo: got %q want wuphf-x", got.Source)
+	}
+	if got.PublishedAt == "" {
+		t.Fatalf("published_at should be auto-stamped when zero time supplied")
+	}
+}
+
+func TestBuildManifest_RequiresNameAndDescription(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		fm   FrontmatterLike
+	}{
+		{"missing name", FrontmatterLike{Description: "desc"}},
+		{"missing description", FrontmatterLike{Name: "x"}},
+		{"whitespace name", FrontmatterLike{Name: "   ", Description: "desc"}},
+		{"whitespace description", FrontmatterLike{Name: "x", Description: "   "}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := BuildManifest(tc.fm, "body", "wuphf", time.Now()); err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+// TestBuildManifest_RejectsPathTraversalName pins the name validator
+// added to defend against path-traversal attacks. Name flows into
+// HubFilePath -> filepath.Join, so a "../../etc/x"-shaped name would
+// write outside the hub clone directory. The validator must reject
+// anything that doesn't match ^[a-z0-9][a-z0-9-]{0,63}$.
+func TestBuildManifest_RejectsPathTraversalName(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"../../etc/passwd",
+		"web/../research",
+		"web research",           // space
+		"web.research",           // dot
+		"WEB-RESEARCH",           // uppercase
+		"-leading-dash",          // leading dash
+		strings.Repeat("a", 100), // exceeds 64-char length cap
+		"name/with/slash",
+		"",
+	}
+	for _, name := range cases {
+		t.Run("reject_"+name, func(t *testing.T) {
+			fm := FrontmatterLike{Name: name, Description: "x"}
+			_, err := BuildManifest(fm, "body", "repo", time.Time{})
+			if err == nil {
+				t.Fatalf("expected error for name %q, got nil", name)
+			}
+		})
+	}
+	// And the canonical valid shape must still pass.
+	fm := FrontmatterLike{Name: "web-research", Description: "Search the web."}
+	if _, err := BuildManifest(fm, "body", "repo", time.Time{}); err != nil {
+		t.Fatalf("valid name rejected: %v", err)
+	}
+}
+
+func TestBuildManifest_RoundTrip(t *testing.T) {
+	t.Parallel()
+	fm := FrontmatterLike{
+		Name:        "web-research",
+		Description: "Search the web",
+		Version:     "1.2.3",
+		License:     "MIT",
+	}
+	at := time.Date(2026, 4, 28, 0, 0, 0, 0, time.UTC)
+	original, err := BuildManifest(fm, "do things", "myrepo", at)
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	raw, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	var roundTripped Manifest
+	if err := json.Unmarshal(raw, &roundTripped); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if roundTripped != original {
+		t.Fatalf("round trip mismatch:\noriginal: %+v\nround   : %+v", original, roundTripped)
+	}
+}
+
+func TestHubURL_Anthropics(t *testing.T) {
+	t.Parallel()
+	got, err := HubURL("anthropics", "deploy-frontend")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://raw.githubusercontent.com/anthropics/skills/main/skills/deploy-frontend/SKILL.md"
+	if got != want {
+		t.Fatalf("HubURL anthropics:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestHubURL_LobeHub(t *testing.T) {
+	t.Parallel()
+	got, err := HubURL("lobehub", "agent-foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://raw.githubusercontent.com/lobehub/lobe-chat-agents/main/agents/agent-foo.md"
+	if got != want {
+		t.Fatalf("HubURL lobehub:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestHubURL_GithubScheme(t *testing.T) {
+	t.Parallel()
+	got, err := HubURL("github:nex-crm/wuphf-skills", "review-pr")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://raw.githubusercontent.com/nex-crm/wuphf-skills/main/skills/review-pr/SKILL.md"
+	if got != want {
+		t.Fatalf("HubURL github scheme:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestHubURL_Unknown(t *testing.T) {
+	t.Parallel()
+	if _, err := HubURL("bogushub", "x"); err == nil {
+		t.Fatalf("expected error for unknown hub")
+	}
+}
+
+func TestHubURL_GithubScheme_Malformed(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"github:",
+		"github:owner",
+		"github:owner/",
+		"github:/repo",
+	}
+	for _, hub := range cases {
+		if _, err := HubURL(hub, "name"); err == nil {
+			t.Fatalf("expected error for malformed hub %q", hub)
+		}
+	}
+}
+
+func TestHubURL_RequiresName(t *testing.T) {
+	t.Parallel()
+	if _, err := HubURL("anthropics", "  "); err == nil {
+		t.Fatalf("expected error for blank name")
+	}
+}
+
+func TestHubFilePath(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		hub  string
+		skl  string
+		want string
+	}{
+		{"anthropics", "anthropics", "x", "skills/x/SKILL.md"},
+		{"lobehub", "lobehub", "x", "agents/x.md"},
+		{"github scheme", "github:foo/bar", "x", "skills/x/SKILL.md"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := HubFilePath(tc.hub, tc.skl)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("HubFilePath: got %s want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHubFilePath_Unknown(t *testing.T) {
+	t.Parallel()
+	if _, err := HubFilePath("nope", "x"); err == nil {
+		t.Fatalf("expected error for unknown hub")
+	}
+}
+
+func TestHubRepo(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		hub  string
+		want string
+	}{
+		{"anthropics", "anthropics/skills"},
+		{"lobehub", "lobehub/lobe-chat-agents"},
+		{"github:foo/bar", "foo/bar"},
+	}
+	for _, tc := range cases {
+		got, err := HubRepo(tc.hub)
+		if err != nil {
+			t.Fatalf("HubRepo(%q): unexpected error: %v", tc.hub, err)
+		}
+		if got != tc.want {
+			t.Fatalf("HubRepo(%q): got %s want %s", tc.hub, got, tc.want)
+		}
+	}
+}
+
+func TestHubRepo_Unknown(t *testing.T) {
+	t.Parallel()
+	if _, err := HubRepo("xyz"); err == nil {
+		t.Fatalf("expected error for unknown hub")
+	}
+}
+
+func TestHubBaseBranch(t *testing.T) {
+	t.Parallel()
+	if got := HubBaseBranch("anthropics"); got != "main" {
+		t.Fatalf("HubBaseBranch: got %s want main", got)
+	}
+}
+
+func TestPublishBranchName(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	got := PublishBranchName("Deploy Frontend", at)
+	want := "wuphf-publish-deploy-frontend-1777377600"
+	if got != want {
+		t.Fatalf("PublishBranchName: got %s want %s", got, want)
+	}
+}
+
+func TestIsGitHubScheme(t *testing.T) {
+	t.Parallel()
+	if !IsGitHubScheme("github:foo/bar") {
+		t.Fatalf("expected github:foo/bar to be a github scheme")
+	}
+	if IsGitHubScheme("anthropics") {
+		t.Fatalf("anthropics should not be a github scheme")
+	}
+}
+
+func TestSanitizeSourceSegment(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		in, want string
+	}{
+		{"Deploy Frontend", "deploy-frontend"},
+		{"  Trim  ", "trim"},
+		{"a/b/c", "a-b-c"},
+		{"weird!!!chars", "weirdchars"},
+		{"under_score", "under-score"},
+		{"---", ""},
+	}
+	for _, tc := range cases {
+		got := sanitizeSourceSegment(tc.in)
+		if got != tc.want {
+			t.Fatalf("sanitizeSourceSegment(%q): got %q want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/testdata/vhs/help.txt
+++ b/testdata/vhs/help.txt
@@ -11,6 +11,8 @@ Usage:
   wuphf log          Show what your agents actually did (task receipts)
   wuphf memory migrate --from {nex,gbrain}  Port legacy memory into the team wiki
   wuphf workspace ...  Manage multiple isolated WUPHF workspaces
+  wuphf skills publish <slug> --to <hub>    Publish a team skill to a public hub
+  wuphf skills install <name> --from <hub>  Pull a public skill into the team wiki
   wuphf --cmd <cmd>  Run a command non-interactively
 
 Flags:
@@ -44,5 +46,3 @@ Flags:
         LLM provider override for this run (claude-code, codex, opencode)
   --threads-collapsed
         Start with threads collapsed (default: expanded)
-  --tui
-        Launch with tmux TUI instead of the web UI


### PR DESCRIPTION
## Summary

Adds the public-hub publish/install loop on top of the wiki-skill-compile pipeline.

- `wuphf skills publish <slug-or-path> --to <hub>` — fork the hub repo via `gh`, write the SKILL.md, and open a PR against the target hub.
- `wuphf skills install <name> --from <hub>` — fetch a public raw `SKILL.md`, validate it, and install it as an active skill in the local team wiki.
- Hubs: `anthropics`, `lobehub`, or any `github:owner/repo`.

The compiled SKILL.md frontmatter already conforms to the Anthropic Agent Skills schema, so this PR is auth + CLI plumbing only — no format conversion.

## Implementation

- `internal/skillpublish/` (new): pure logic for hub URL/path/repo resolution and manifest construction. Side-effect-free, unit-tested.
- `cmd/wuphf/skills_publish.go` (new): argument parsing, `gh` fork/clone/push/PR workflow, broker install round-trip, dry-run output.
- `cmd/wuphf/main.go`: routes `wuphf skills` to the new dispatcher; preserves per-verb help routing so `wuphf skills publish --help` shows flag-level docs.
- `README.md`: new "Publishing skills" section with examples.

## Merge Refresh

- Rebased onto latest `main` (`17930cca`).
- Resolved drift with the newer `workspace` command help/dispatch.
- Removed the stale `claude-marketplace` built-in hub because `claude-marketplace/skills` is not publicly resolvable; custom marketplaces remain supported through `github:owner/repo`.
- Aligned install docs/help with implementation: install creates an active skill rather than queuing a proposal.

## Test plan

- [x] `go build -o /tmp/wuphf-pr376 ./cmd/wuphf`
- [x] `go test ./cmd/wuphf ./internal/skillpublish -count=1`
- [x] `bash scripts/test-go.sh` passed before the final doc/hub wording cleanup; targeted affected packages were rerun afterward.
- [x] Help smoke: `wuphf skills --help`, `wuphf skills publish --help`, `wuphf skills install --help`
- [x] Verified public hub repos: `anthropics/skills` and `lobehub/lobe-chat-agents` resolve; `claude-marketplace/skills` does not.

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `skills publish` (supports `--to`, `--dry-run`, custom message, token) to publish team skills to hubs (anthropics, lobehub, or github:owner/repo). Dry-run prints the manifest/PR without publishing.
  * Added `skills install` (supports `--from`, `--channel`) to fetch and install community skills into the local team wiki.
  * CLI help updated to include the new `wuphf skills` commands.

* **Documentation**
  * Added "Publishing skills" README section documenting publish/install usage, supported hubs, and auth requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->