### PR TITLE
feat(embedding): pluggable embedding provider + semantic clustering for Stage B

### DIFF
--- a/internal/embedding/anthropic.go
+++ b/internal/embedding/anthropic.go
@@ -97,5 +97,11 @@ func (p *voyageProvider) EmbedBatch(ctx context.Context, texts []string) ([][]fl
 // Dimension returns the underlying provider's vector length.
 func (p *voyageProvider) Dimension() int { return p.inner.Dimension() }
 
+// CacheNamespace includes the Voyage backend URL to prevent cross-backend
+// cache reuse when VOYAGE_BASE_URL changes.
+func (p *voyageProvider) CacheNamespace() string {
+	return "voyage|" + strings.TrimRight(p.inner.baseURL, "/")
+}
+
 // Name is the stable cache + telemetry identifier.
 func (p *voyageProvider) Name() string { return "voyage-" + p.model }

--- a/internal/embedding/anthropic.go
+++ b/internal/embedding/anthropic.go
@@ -1,0 +1,107 @@
+package embedding
+
+// anthropic.go is the embedding provider for users who set
+// ANTHROPIC_API_KEY. Anthropic does not currently ship a native embeddings
+// endpoint — they recommend Voyage AI as the companion provider.
+// We honour ANTHROPIC_API_KEY by routing through Voyage's compat API,
+// reusing the OpenAI-shape client so the wire details live in one place.
+//
+// Users who already have a separate Voyage key can set VOYAGE_API_KEY to
+// override; otherwise we attempt the Anthropic key as a fallback. This
+// preserves the documented preference order ("if ANTHROPIC_API_KEY is
+// set, use it") without locking out users on Voyage's free tier.
+//
+// TODO(embedding): Anthropic has signalled native embeddings on their
+// roadmap. When that endpoint ships, swap the upstream URL here without
+// breaking callers — the Provider interface stays identical.
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultVoyageBaseURL = "https://api.voyageai.com"
+	defaultVoyageModel   = "voyage-3-large"
+	// defaultVoyageDim is the published vector dimension of voyage-3-large.
+	// voyage-3-lite is 512; voyage-code-2 is 1536. Override with
+	// WUPHF_EMBEDDING_DIMENSION when switching models.
+	defaultVoyageDim = 1024
+)
+
+// newAnthropicProvider returns a Voyage-backed Provider. The function name
+// preserves the public-facing notion of "Anthropic-recommended embeddings"
+// while the implementation is OpenAI-shape Voyage today. If the user
+// supplied a dedicated VOYAGE_API_KEY we prefer it; otherwise we use the
+// Anthropic key as the bearer (Voyage accepts any non-empty bearer for
+// trial tiers — the call still authenticates correctly when the key is a
+// valid Voyage key).
+//
+// Returning the Provider interface (not the concrete struct) keeps the
+// stub fallback path uniform when the key turns out to be empty.
+func newAnthropicProvider(anthropicKey string) Provider {
+	key := strings.TrimSpace(os.Getenv("VOYAGE_API_KEY"))
+	if key == "" {
+		key = strings.TrimSpace(anthropicKey)
+	}
+	if key == "" {
+		return NewStubProvider()
+	}
+
+	baseURL := strings.TrimSpace(os.Getenv("VOYAGE_BASE_URL"))
+	if baseURL == "" {
+		baseURL = defaultVoyageBaseURL
+	}
+
+	model := strings.TrimSpace(os.Getenv("WUPHF_EMBEDDING_MODEL"))
+	if model == "" {
+		model = defaultVoyageModel
+	}
+
+	dim := openAIDimensionFromEnv()
+	if dim == defaultOpenAIDim {
+		// User did not override → use Voyage's default dim, not OpenAI's.
+		dim = defaultVoyageDim
+	}
+
+	timeout := openAITimeoutFromEnv()
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	inner := &openAIProvider{
+		apiKey:     key,
+		baseURL:    baseURL,
+		model:      model,
+		dimension:  dim,
+		httpClient: &http.Client{Timeout: timeout},
+	}
+	return &anthropicProvider{inner: inner, model: model}
+}
+
+// anthropicProvider wraps the OpenAI-compat client so Name() returns the
+// "anthropic-..." prefix. Cache rows + telemetry log this name, so it
+// matters that callers can distinguish OpenAI from Voyage.
+type anthropicProvider struct {
+	inner *openAIProvider
+	model string
+}
+
+// Embed delegates to the OpenAI-compat implementation.
+func (p *anthropicProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	return p.inner.Embed(ctx, text)
+}
+
+// EmbedBatch delegates to the OpenAI-compat implementation.
+func (p *anthropicProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	return p.inner.EmbedBatch(ctx, texts)
+}
+
+// Dimension returns the underlying provider's vector length.
+func (p *anthropicProvider) Dimension() int { return p.inner.Dimension() }
+
+// Name is the stable cache + telemetry identifier.
+func (p *anthropicProvider) Name() string { return "anthropic-" + p.model }

--- a/internal/embedding/anthropic.go
+++ b/internal/embedding/anthropic.go
@@ -1,19 +1,13 @@
 package embedding
 
-// anthropic.go is the embedding provider for users who set
-// ANTHROPIC_API_KEY. Anthropic does not currently ship a native embeddings
-// endpoint — they recommend Voyage AI as the companion provider.
-// We honour ANTHROPIC_API_KEY by routing through Voyage's compat API,
-// reusing the OpenAI-shape client so the wire details live in one place.
+// anthropic.go is the Voyage AI embedding provider, opt-in via VOYAGE_API_KEY.
+// Anthropic does not ship a native embeddings endpoint at time of writing
+// (2026-04-28); voyage-3-large is their recommended companion. To avoid
+// silently shipping ANTHROPIC_API_KEY to api.voyageai.com (third-party), we
+// require an explicit VOYAGE_API_KEY here — see newVoyageProvider.
 //
-// Users who already have a separate Voyage key can set VOYAGE_API_KEY to
-// override; otherwise we attempt the Anthropic key as a fallback. This
-// preserves the documented preference order ("if ANTHROPIC_API_KEY is
-// set, use it") without locking out users on Voyage's free tier.
-//
-// TODO(embedding): Anthropic has signalled native embeddings on their
-// roadmap. When that endpoint ships, swap the upstream URL here without
-// breaking callers — the Provider interface stays identical.
+// TODO(embedding): when Anthropic ships native embeddings, add a real
+// anthropic provider that uses ANTHROPIC_API_KEY against the Anthropic host.
 
 import (
 	"context"
@@ -32,21 +26,15 @@ const (
 	defaultVoyageDim = 1024
 )
 
-// newAnthropicProvider returns a Voyage-backed Provider. The function name
-// preserves the public-facing notion of "Anthropic-recommended embeddings"
-// while the implementation is OpenAI-shape Voyage today. If the user
-// supplied a dedicated VOYAGE_API_KEY we prefer it; otherwise we use the
-// Anthropic key as the bearer (Voyage accepts any non-empty bearer for
-// trial tiers — the call still authenticates correctly when the key is a
-// valid Voyage key).
+// newVoyageProvider returns a Voyage-backed Provider when VOYAGE_API_KEY is
+// set. Returns the stub when the key is empty (caller is responsible for
+// only invoking this when they want Voyage).
 //
-// Returning the Provider interface (not the concrete struct) keeps the
-// stub fallback path uniform when the key turns out to be empty.
-func newAnthropicProvider(anthropicKey string) Provider {
+// We deliberately do NOT accept ANTHROPIC_API_KEY as a fallback bearer:
+// Voyage is a separate company and shipping the user's Anthropic key to
+// api.voyageai.com would be a cross-provider credential leak.
+func newVoyageProvider() Provider {
 	key := strings.TrimSpace(os.Getenv("VOYAGE_API_KEY"))
-	if key == "" {
-		key = strings.TrimSpace(anthropicKey)
-	}
 	if key == "" {
 		return NewStubProvider()
 	}
@@ -79,29 +67,29 @@ func newAnthropicProvider(anthropicKey string) Provider {
 		dimension:  dim,
 		httpClient: &http.Client{Timeout: timeout},
 	}
-	return &anthropicProvider{inner: inner, model: model}
+	return &voyageProvider{inner: inner, model: model}
 }
 
-// anthropicProvider wraps the OpenAI-compat client so Name() returns the
-// "anthropic-..." prefix. Cache rows + telemetry log this name, so it
+// voyageProvider wraps the OpenAI-compat client so Name() returns the
+// "voyage-..." prefix. Cache rows + telemetry log this name, so it
 // matters that callers can distinguish OpenAI from Voyage.
-type anthropicProvider struct {
+type voyageProvider struct {
 	inner *openAIProvider
 	model string
 }
 
 // Embed delegates to the OpenAI-compat implementation.
-func (p *anthropicProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+func (p *voyageProvider) Embed(ctx context.Context, text string) ([]float32, error) {
 	return p.inner.Embed(ctx, text)
 }
 
 // EmbedBatch delegates to the OpenAI-compat implementation.
-func (p *anthropicProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+func (p *voyageProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
 	return p.inner.EmbedBatch(ctx, texts)
 }
 
 // Dimension returns the underlying provider's vector length.
-func (p *anthropicProvider) Dimension() int { return p.inner.Dimension() }
+func (p *voyageProvider) Dimension() int { return p.inner.Dimension() }
 
 // Name is the stable cache + telemetry identifier.
-func (p *anthropicProvider) Name() string { return "anthropic-" + p.model }
+func (p *voyageProvider) Name() string { return "voyage-" + p.model }

--- a/internal/embedding/anthropic.go
+++ b/internal/embedding/anthropic.go
@@ -49,10 +49,16 @@ func newVoyageProvider() Provider {
 		model = defaultVoyageModel
 	}
 
-	dim := openAIDimensionFromEnv()
-	if dim == defaultOpenAIDim {
-		// User did not override → use Voyage's default dim, not OpenAI's.
-		dim = defaultVoyageDim
+	// Voyage's voyage-3-large default is 1024 (vs OpenAI's 1536). Honour
+	// an explicit WUPHF_EMBEDDING_DIMENSION when set so users on
+	// voyage-code-2 (1536) or voyage-3-lite (512) can override; otherwise
+	// fall through to the Voyage default. Using
+	// `embeddingDimensionOverride` (which returns ok=false when unset)
+	// avoids the bug where a user explicitly setting 1536 was indistinguishable
+	// from "no override" and got silently clobbered to 1024.
+	dim := defaultVoyageDim
+	if n, ok := embeddingDimensionOverride(); ok {
+		dim = n
 	}
 
 	timeout := openAITimeoutFromEnv()

--- a/internal/embedding/cache.go
+++ b/internal/embedding/cache.go
@@ -19,6 +19,13 @@ package embedding
 // lock, writes the row, releases. We don't use os.O_APPEND because we
 // also want the size-based rotation to happen atomically with the
 // in-memory map state.
+//
+// IMPORTANT: this cache is goroutine-safe but **single-process only**.
+// Two `wuphf` processes pointed at the same JSONL will race the rotation
+// path (rename + truncate vs. open-append) and may lose rows. If you
+// need shared state across processes, run a single broker and have
+// other tools talk to it; do not point a second wuphf at the same
+// WUPHF_EMBEDDING_CACHE_PATH.
 
 import (
 	"bufio"
@@ -136,10 +143,9 @@ func (c *Cache) Set(text, model string, vector []float32) error {
 	if len(vector) == 0 {
 		return errors.New("embedding: cache: empty vector")
 	}
-	if err := c.ensureLoaded(); err != nil {
-		// Continue: a load failure leaves the in-memory map empty,
-		// which is fine for a Set call.
-	}
+	// Best-effort load: a failure leaves the in-memory map empty, which
+	// is fine for a Set call (we still write the row to disk).
+	_ = c.ensureLoaded()
 
 	key := cacheKey(text, model)
 	row := cacheRow{
@@ -216,7 +222,7 @@ func (c *Cache) ensureLoaded() error {
 		}
 		return fmt.Errorf("embedding: cache: open: %w", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if info, statErr := f.Stat(); statErr == nil {
 		c.bytesOnDisk = info.Size()

--- a/internal/embedding/cache.go
+++ b/internal/embedding/cache.go
@@ -1,8 +1,8 @@
 package embedding
 
 // cache.go is a JSONL append-only cache for embeddings. Keyed by SHA-256
-// of the input text + provider name so a model swap invalidates rows
-// without manual cleanup.
+// of the input text, provider name, backend namespace, and vector dimension
+// so provider/backend/dimension swaps invalidate rows without manual cleanup.
 //
 // The cache is intentionally "dumb": load on first miss, in-memory map
 // for hits, append the new row to disk for misses. Size is capped at
@@ -12,7 +12,7 @@ package embedding
 //
 // File layout (one JSON object per line):
 //
-//	{"sha256":"<hex>","model":"openai-text-embedding-3-small","vector":[...]}
+//	{"sha256":"<hex>","model":"openai-text-embedding-3-small","namespace":"openai|https://api.openai.com","dimension":1536,"vector":[...]}
 //
 // Concurrency: a single sync.RWMutex guards the map + file handle. The
 // underlying append is sync.OnceFunc-style: each Set takes the write
@@ -37,6 +37,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -50,9 +51,11 @@ const maxCacheBytes = 10 * 1024 * 1024
 
 // cacheRow is the JSONL record shape. Reused for both reads and writes.
 type cacheRow struct {
-	SHA256 string    `json:"sha256"`
-	Model  string    `json:"model"`
-	Vector []float32 `json:"vector"`
+	SHA256    string    `json:"sha256"`
+	Model     string    `json:"model"`
+	Namespace string    `json:"namespace,omitempty"`
+	Dimension int       `json:"dimension,omitempty"`
+	Vector    []float32 `json:"vector"`
 }
 
 // Cache is the JSONL-backed embedding cache. Construct via NewCache or
@@ -62,7 +65,7 @@ type Cache struct {
 
 	mu          sync.RWMutex
 	loaded      bool
-	rows        map[string][]float32 // key: sha256 + "@" + model
+	rows        map[string][]float32
 	bytesOnDisk int64
 }
 
@@ -108,6 +111,13 @@ func HashText(text string) string {
 // A nil receiver returns a miss — convenient for "cache is optional"
 // call sites.
 func (c *Cache) Get(text, model string) ([]float32, bool) {
+	return c.GetScoped(text, model, "", 0)
+}
+
+// GetScoped returns a cached vector for the fully-scoped cache key. Namespace
+// should identify the provider backend; dimension should be the expected vector
+// length.
+func (c *Cache) GetScoped(text, model, namespace string, dimension int) ([]float32, bool) {
 	if c == nil || c.path == "" {
 		return nil, false
 	}
@@ -117,7 +127,7 @@ func (c *Cache) Get(text, model string) ([]float32, bool) {
 		// exceed the size cap).
 		return nil, false
 	}
-	key := cacheKey(text, model)
+	key := cacheKey(text, model, namespace, dimension)
 	c.mu.RLock()
 	v, ok := c.rows[key]
 	c.mu.RUnlock()
@@ -137,6 +147,16 @@ func (c *Cache) Get(text, model string) ([]float32, bool) {
 // Errors are returned but never block the caller — the embedding
 // pipeline must keep working even when the cache file is unwritable.
 func (c *Cache) Set(text, model string, vector []float32) error {
+	return c.set(text, model, "", 0, vector)
+}
+
+// SetScoped stores vector with a backend namespace and vector-dimension
+// fingerprint so incompatible providers cannot reuse each other's rows.
+func (c *Cache) SetScoped(text, model, namespace string, vector []float32) error {
+	return c.set(text, model, namespace, len(vector), vector)
+}
+
+func (c *Cache) set(text, model, namespace string, dimension int, vector []float32) error {
 	if c == nil || c.path == "" {
 		return nil
 	}
@@ -160,11 +180,13 @@ func (c *Cache) Set(text, model string, vector []float32) error {
 		}
 	}
 
-	key := cacheKey(text, model)
+	key := cacheKey(text, model, namespace, dimension)
 	row := cacheRow{
-		SHA256: HashText(text),
-		Model:  model,
-		Vector: vector,
+		SHA256:    HashText(text),
+		Model:     model,
+		Namespace: namespace,
+		Dimension: dimension,
+		Vector:    vector,
 	}
 	raw, err := json.Marshal(row)
 	if err != nil {
@@ -255,7 +277,7 @@ func (c *Cache) ensureLoaded() error {
 		if row.SHA256 == "" || row.Model == "" || len(row.Vector) == 0 {
 			continue
 		}
-		c.rows[row.SHA256+"@"+row.Model] = row.Vector
+		c.rows[cacheKeyFromHash(row.SHA256, row.Model, row.Namespace, row.Dimension)] = row.Vector
 	}
 	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
 		return fmt.Errorf("embedding: cache: read: %w", err)
@@ -263,12 +285,15 @@ func (c *Cache) ensureLoaded() error {
 	return nil
 }
 
-// cacheKey is the in-memory map key. We keep model in the key so that
-// switching models invalidates the in-memory rows; on disk every row
-// already records its model so a re-load filters correctly even after
-// an env change.
-func cacheKey(text, model string) string {
-	return HashText(text) + "@" + model
+// cacheKey is the in-memory map key. It includes backend namespace and vector
+// dimension so OpenAI-compatible endpoints or model-dimension overrides cannot
+// reuse each other's rows.
+func cacheKey(text, model, namespace string, dimension int) string {
+	return cacheKeyFromHash(HashText(text), model, namespace, dimension)
+}
+
+func cacheKeyFromHash(hash, model, namespace string, dimension int) string {
+	return hash + "@" + model + "@" + namespace + "@" + strconv.Itoa(dimension)
 }
 
 // Stats are read-only counters useful for telemetry. Not used in the

--- a/internal/embedding/cache.go
+++ b/internal/embedding/cache.go
@@ -1,0 +1,277 @@
+package embedding
+
+// cache.go is a JSONL append-only cache for embeddings. Keyed by SHA-256
+// of the input text + provider name so a model swap invalidates rows
+// without manual cleanup.
+//
+// The cache is intentionally "dumb": load on first miss, in-memory map
+// for hits, append the new row to disk for misses. Size is capped at
+// maxCacheBytes — once exceeded we rotate the file in place (same
+// strategy as a compact log: copy to a .old suffix, start fresh). This
+// keeps the cache scaling predictable without pulling in BoltDB / LMDB.
+//
+// File layout (one JSON object per line):
+//
+//	{"sha256":"<hex>","model":"openai-text-embedding-3-small","vector":[...]}
+//
+// Concurrency: a single sync.RWMutex guards the map + file handle. The
+// underlying append is sync.OnceFunc-style: each Set takes the write
+// lock, writes the row, releases. We don't use os.O_APPEND because we
+// also want the size-based rotation to happen atomically with the
+// in-memory map state.
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// maxCacheBytes is the rotation threshold. 10MiB ≈ 5k cached entries at
+// the OpenAI text-embedding-3-small dimension (1536 floats ≈ 1.5KB each
+// after JSON encoding overhead).
+const maxCacheBytes = 10 * 1024 * 1024
+
+// cacheRow is the JSONL record shape. Reused for both reads and writes.
+type cacheRow struct {
+	SHA256 string    `json:"sha256"`
+	Model  string    `json:"model"`
+	Vector []float32 `json:"vector"`
+}
+
+// Cache is the JSONL-backed embedding cache. Construct via NewCache or
+// the package-level DefaultCache singleton. Safe for concurrent use.
+type Cache struct {
+	path string
+
+	mu          sync.RWMutex
+	loaded      bool
+	rows        map[string][]float32 // key: sha256 + "@" + model
+	bytesOnDisk int64
+}
+
+// NewCache constructs a cache at the given path. The file is created on
+// first Set call — passing a path that does not yet exist is fine.
+//
+// If path is empty, NewCache returns a no-op cache that always misses.
+// This lets the broker disable persistence (e.g. in tests, or when we're
+// running with WUPHF_EMBEDDING_CACHE=disabled).
+func NewCache(path string) *Cache {
+	return &Cache{
+		path: path,
+		rows: map[string][]float32{},
+	}
+}
+
+// DefaultCachePath resolves $WUPHF_HOME/.wuphf/cache/embeddings.jsonl.
+// Honours WUPHF_EMBEDDING_CACHE_PATH for full override and
+// WUPHF_EMBEDDING_CACHE=disabled to opt out entirely.
+func DefaultCachePath() string {
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("WUPHF_EMBEDDING_CACHE")), "disabled") {
+		return ""
+	}
+	if v := strings.TrimSpace(os.Getenv("WUPHF_EMBEDDING_CACHE_PATH")); v != "" {
+		return v
+	}
+	home := config.RuntimeHomeDir()
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".wuphf", "cache", "embeddings.jsonl")
+}
+
+// HashText computes the SHA-256 of text, hex-encoded. Exposed so tests
+// can construct expected cache keys without re-implementing the hash.
+func HashText(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return hex.EncodeToString(sum[:])
+}
+
+// Get returns (vector, true) on hit, (nil, false) on miss. Triggers a
+// one-time on-disk load so callers don't need to call Load explicitly.
+// A nil receiver returns a miss — convenient for "cache is optional"
+// call sites.
+func (c *Cache) Get(text, model string) ([]float32, bool) {
+	if c == nil || c.path == "" {
+		return nil, false
+	}
+	if err := c.ensureLoaded(); err != nil {
+		// Load failures are silently treated as a cold cache. The next
+		// Set will overwrite the corrupt file (rotation happens once we
+		// exceed the size cap).
+		return nil, false
+	}
+	key := cacheKey(text, model)
+	c.mu.RLock()
+	v, ok := c.rows[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	out := make([]float32, len(v))
+	copy(out, v)
+	return out, true
+}
+
+// Set stores vector for (text, model) and appends a JSONL row to disk.
+// If the cache file exceeds maxCacheBytes after the append, we rotate
+// in place: the existing file becomes <path>.old and a fresh file is
+// started with the current row as its first line.
+//
+// Errors are returned but never block the caller — the embedding
+// pipeline must keep working even when the cache file is unwritable.
+func (c *Cache) Set(text, model string, vector []float32) error {
+	if c == nil || c.path == "" {
+		return nil
+	}
+	if len(vector) == 0 {
+		return errors.New("embedding: cache: empty vector")
+	}
+	if err := c.ensureLoaded(); err != nil {
+		// Continue: a load failure leaves the in-memory map empty,
+		// which is fine for a Set call.
+	}
+
+	key := cacheKey(text, model)
+	row := cacheRow{
+		SHA256: HashText(text),
+		Model:  model,
+		Vector: vector,
+	}
+	raw, err := json.Marshal(row)
+	if err != nil {
+		return fmt.Errorf("embedding: cache: marshal: %w", err)
+	}
+	raw = append(raw, '\n')
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
+		return fmt.Errorf("embedding: cache: mkdir: %w", err)
+	}
+
+	// Rotation: if the next append would push us over the cap, rename
+	// the current file to .old and start fresh. We rotate BEFORE the
+	// write so the new row always lands in a non-truncated file.
+	if c.bytesOnDisk+int64(len(raw)) > maxCacheBytes {
+		_ = os.Remove(c.path + ".old")
+		if err := os.Rename(c.path, c.path+".old"); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("embedding: cache: rotate: %w", err)
+		}
+		c.bytesOnDisk = 0
+		c.rows = map[string][]float32{}
+	}
+
+	f, err := os.OpenFile(c.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return fmt.Errorf("embedding: cache: open: %w", err)
+	}
+	if _, err := f.Write(raw); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("embedding: cache: write: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("embedding: cache: close: %w", err)
+	}
+
+	c.bytesOnDisk += int64(len(raw))
+	stored := make([]float32, len(vector))
+	copy(stored, vector)
+	c.rows[key] = stored
+	return nil
+}
+
+// ensureLoaded reads the cache file once and populates the in-memory
+// map. Subsequent calls are no-ops. Sequential malformed rows are
+// skipped so a single corrupt line doesn't disable the whole cache.
+func (c *Cache) ensureLoaded() error {
+	c.mu.RLock()
+	if c.loaded {
+		c.mu.RUnlock()
+		return nil
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.loaded {
+		return nil
+	}
+	c.loaded = true
+
+	f, err := os.Open(c.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("embedding: cache: open: %w", err)
+	}
+	defer f.Close()
+
+	if info, statErr := f.Stat(); statErr == nil {
+		c.bytesOnDisk = info.Size()
+	}
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var row cacheRow
+		if err := json.Unmarshal([]byte(line), &row); err != nil {
+			continue
+		}
+		if row.SHA256 == "" || row.Model == "" || len(row.Vector) == 0 {
+			continue
+		}
+		c.rows[row.SHA256+"@"+row.Model] = row.Vector
+	}
+	if err := scanner.Err(); err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("embedding: cache: read: %w", err)
+	}
+	return nil
+}
+
+// cacheKey is the in-memory map key. We keep model in the key so that
+// switching models invalidates the in-memory rows; on disk every row
+// already records its model so a re-load filters correctly even after
+// an env change.
+func cacheKey(text, model string) string {
+	return HashText(text) + "@" + model
+}
+
+// Stats are read-only counters useful for telemetry. Not used in the
+// current code path but expose enough state for future "cache usage"
+// dashboards without leaking the rows map.
+type Stats struct {
+	Entries     int
+	BytesOnDisk int64
+	Path        string
+}
+
+// Stats returns a snapshot. Concurrent callers see consistent counters
+// (we hold the read lock for the duration of the copy).
+func (c *Cache) Stats() Stats {
+	if c == nil {
+		return Stats{}
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return Stats{
+		Entries:     len(c.rows),
+		BytesOnDisk: c.bytesOnDisk,
+		Path:        c.path,
+	}
+}

--- a/internal/embedding/cache.go
+++ b/internal/embedding/cache.go
@@ -144,8 +144,21 @@ func (c *Cache) Set(text, model string, vector []float32) error {
 		return errors.New("embedding: cache: empty vector")
 	}
 	// Best-effort load: a failure leaves the in-memory map empty, which
-	// is fine for a Set call (we still write the row to disk).
-	_ = c.ensureLoaded()
+	// is fine for a Set call (we still write the row to disk). When the
+	// load fails we still need bytesOnDisk to reflect the actual file
+	// size — otherwise the rotation check below thinks the file is
+	// empty and the cache grows unbounded on disk while in-memory state
+	// stays cold. Stat the file independently so rotation triggers
+	// regardless of whether the JSONL parse succeeded.
+	if loadErr := c.ensureLoaded(); loadErr != nil {
+		if info, statErr := os.Stat(c.path); statErr == nil {
+			c.mu.Lock()
+			if c.bytesOnDisk == 0 {
+				c.bytesOnDisk = info.Size()
+			}
+			c.mu.Unlock()
+		}
+	}
 
 	key := cacheKey(text, model)
 	row := cacheRow{

--- a/internal/embedding/cache_test.go
+++ b/internal/embedding/cache_test.go
@@ -1,6 +1,7 @@
 package embedding
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -113,6 +114,49 @@ func TestCache_RotatesOverSizeCap(t *testing.T) {
 	matches, _ := filepath.Glob(c.path + ".old")
 	if len(matches) != 1 {
 		t.Errorf("expected 1 .old file, got %d", len(matches))
+	}
+}
+
+// TestCache_RotatesEvenWhenLoadFails pins the regression: if ensureLoaded
+// fails (corrupt JSONL, partial write from a crashed wuphf), bytesOnDisk
+// must still reflect the actual file size — otherwise the rotation check
+// thinks the file is empty and the cache grows unbounded on disk while
+// the in-memory map stays cold.
+func TestCache_RotatesEvenWhenLoadFails(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "embeddings.jsonl")
+
+	// Write a sentinel file slightly under the cap so a single Set tips
+	// past it. We fill it with non-JSONL garbage so ensureLoaded() can
+	// scan it (the row parser is best-effort) but the file size is what
+	// matters for rotation. Use a content size near the cap to force the
+	// rotation branch.
+	garbage := bytes.Repeat([]byte{'x'}, maxCacheBytes-100)
+	if err := os.WriteFile(path, garbage, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	c := NewCache(path)
+
+	// Drive a Set. With the bug, bytesOnDisk would stay at 0 (load saw
+	// no parseable rows) and rotation would NOT trigger. With the fix,
+	// the post-load Stat sets bytesOnDisk to the file size, so the cap
+	// check fires and the file rotates.
+	if err := c.Set("trigger", "m", []float32{1, 2, 3}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// .old must exist — proves rotation triggered despite the load failure.
+	if _, err := os.Stat(path + ".old"); err != nil {
+		t.Fatalf("expected .old to exist after rotation, got %v", err)
+	}
+	// And the live file should be small (just the new row).
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat live: %v", err)
+	}
+	if info.Size() >= int64(maxCacheBytes-100) {
+		t.Errorf("live file should have been rotated, got size=%d", info.Size())
 	}
 }
 

--- a/internal/embedding/cache_test.go
+++ b/internal/embedding/cache_test.go
@@ -1,0 +1,176 @@
+package embedding
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCache_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	c := NewCache(filepath.Join(dir, "embeddings.jsonl"))
+
+	want := []float32{0.1, 0.2, 0.3, 0.4}
+	if err := c.Set("hello", "test-model", want); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	got, ok := c.Get("hello", "test-model")
+	if !ok {
+		t.Fatal("expected hit, got miss")
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len: got %d want %d", len(got), len(want))
+	}
+	for i, x := range want {
+		if got[i] != x {
+			t.Errorf("at %d: got %v want %v", i, got[i], x)
+		}
+	}
+}
+
+func TestCache_PersistsAcrossInstances(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "embeddings.jsonl")
+	c1 := NewCache(path)
+	want := []float32{1, 2, 3}
+	if err := c1.Set("durable", "m", want); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	// Fresh instance — should re-read the file.
+	c2 := NewCache(path)
+	got, ok := c2.Get("durable", "m")
+	if !ok {
+		t.Fatal("expected hit on fresh instance")
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len: got %d want %d", len(got), len(want))
+	}
+}
+
+func TestCache_ModelKeyedSeparately(t *testing.T) {
+	c := NewCache(filepath.Join(t.TempDir(), "embeddings.jsonl"))
+	if err := c.Set("text", "model-a", []float32{1}); err != nil {
+		t.Fatalf("set a: %v", err)
+	}
+	if err := c.Set("text", "model-b", []float32{2}); err != nil {
+		t.Fatalf("set b: %v", err)
+	}
+
+	a, okA := c.Get("text", "model-a")
+	b, okB := c.Get("text", "model-b")
+	if !okA || !okB {
+		t.Fatalf("expected both models cached, got %v / %v", okA, okB)
+	}
+	if a[0] == b[0] {
+		t.Error("expected different vectors per model")
+	}
+}
+
+func TestCache_DisabledPathIsNoOp(t *testing.T) {
+	c := NewCache("")
+	if err := c.Set("anything", "any-model", []float32{1, 2}); err != nil {
+		t.Errorf("set on disabled cache should be a no-op, got %v", err)
+	}
+	if _, ok := c.Get("anything", "any-model"); ok {
+		t.Error("disabled cache should always miss")
+	}
+}
+
+func TestCache_MissOnEmptyFile(t *testing.T) {
+	c := NewCache(filepath.Join(t.TempDir(), "embeddings.jsonl"))
+	if _, ok := c.Get("nope", "m"); ok {
+		t.Error("expected miss on empty file")
+	}
+}
+
+func TestCache_RotatesOverSizeCap(t *testing.T) {
+	// Write a row, then cheat the size accounting so the next Set
+	// triggers rotation. Keeps the test fast — exercising the real
+	// 10MiB threshold would take megabytes of inputs.
+	c := NewCache(filepath.Join(t.TempDir(), "embeddings.jsonl"))
+	if err := c.Set("first", "m", []float32{1}); err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	c.mu.Lock()
+	c.bytesOnDisk = maxCacheBytes - 1
+	c.mu.Unlock()
+
+	if err := c.Set("second", "m", []float32{2}); err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	if _, ok := c.Get("first", "m"); ok {
+		t.Error("after rotation, old rows should be gone")
+	}
+	if _, ok := c.Get("second", "m"); !ok {
+		t.Error("after rotation, new row should be present")
+	}
+
+	// .old should now exist.
+	matches, _ := filepath.Glob(c.path + ".old")
+	if len(matches) != 1 {
+		t.Errorf("expected 1 .old file, got %d", len(matches))
+	}
+}
+
+func TestCache_HashTextStable(t *testing.T) {
+	if HashText("hello") != HashText("hello") {
+		t.Error("HashText should be deterministic")
+	}
+	if HashText("hello") == HashText("world") {
+		t.Error("HashText collisions across distinct inputs")
+	}
+}
+
+func TestCache_StatsReflectInserts(t *testing.T) {
+	c := NewCache(filepath.Join(t.TempDir(), "embeddings.jsonl"))
+	if err := c.Set("a", "m", []float32{1}); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	stats := c.Stats()
+	if stats.Entries != 1 {
+		t.Errorf("entries: got %d want 1", stats.Entries)
+	}
+	if stats.BytesOnDisk == 0 {
+		t.Error("bytesOnDisk should be > 0 after Set")
+	}
+	if !strings.HasSuffix(stats.Path, "embeddings.jsonl") {
+		t.Errorf("path: got %q", stats.Path)
+	}
+}
+
+func TestCache_TolerateCorruptLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "embeddings.jsonl")
+	corrupt := []byte("not json\n{\"sha256\":\"abc\",\"model\":\"m\",\"vector\":[1,2,3]}\n")
+	if err := os.WriteFile(path, corrupt, 0o600); err != nil {
+		t.Fatalf("write corrupt: %v", err)
+	}
+
+	c := NewCache(path)
+	// Force load.
+	c.Get("anything", "anything")
+
+	stats := c.Stats()
+	if stats.Entries != 1 {
+		t.Errorf("entries after corrupt+good rows: got %d want 1", stats.Entries)
+	}
+}
+
+func TestDefaultCachePath_DisabledViaEnv(t *testing.T) {
+	t.Setenv("WUPHF_EMBEDDING_CACHE", "disabled")
+	if got := DefaultCachePath(); got != "" {
+		t.Errorf("disabled cache path: got %q want empty", got)
+	}
+}
+
+func TestDefaultCachePath_HonoursOverride(t *testing.T) {
+	t.Setenv("WUPHF_EMBEDDING_CACHE", "")
+	t.Setenv("WUPHF_EMBEDDING_CACHE_PATH", "/tmp/custom-cache.jsonl")
+	if got := DefaultCachePath(); got != "/tmp/custom-cache.jsonl" {
+		t.Errorf("override: got %q want /tmp/custom-cache.jsonl", got)
+	}
+}

--- a/internal/embedding/cache_test.go
+++ b/internal/embedding/cache_test.go
@@ -71,6 +71,35 @@ func TestCache_ModelKeyedSeparately(t *testing.T) {
 	}
 }
 
+func TestCache_ScopedByNamespaceAndDimension(t *testing.T) {
+	c := NewCache(filepath.Join(t.TempDir(), "embeddings.jsonl"))
+	if err := c.SetScoped("text", "same-model", "openai|https://api.openai.com", []float32{1, 2}); err != nil {
+		t.Fatalf("set openai: %v", err)
+	}
+	if err := c.SetScoped("text", "same-model", "openai|http://localhost:8080", []float32{3, 4}); err != nil {
+		t.Fatalf("set local: %v", err)
+	}
+	if err := c.SetScoped("text", "same-model", "openai|https://api.openai.com", []float32{5, 6, 7}); err != nil {
+		t.Fatalf("set dim: %v", err)
+	}
+
+	hosted, ok := c.GetScoped("text", "same-model", "openai|https://api.openai.com", 2)
+	if !ok {
+		t.Fatal("expected hosted dim-2 hit")
+	}
+	local, ok := c.GetScoped("text", "same-model", "openai|http://localhost:8080", 2)
+	if !ok {
+		t.Fatal("expected local dim-2 hit")
+	}
+	hostedDim3, ok := c.GetScoped("text", "same-model", "openai|https://api.openai.com", 3)
+	if !ok {
+		t.Fatal("expected hosted dim-3 hit")
+	}
+	if hosted[0] == local[0] || hosted[0] == hostedDim3[0] {
+		t.Fatalf("expected namespace and dimension to isolate cache rows, got hosted=%v local=%v hostedDim3=%v", hosted, local, hostedDim3)
+	}
+}
+
 func TestCache_DisabledPathIsNoOp(t *testing.T) {
 	c := NewCache("")
 	if err := c.Set("anything", "any-model", []float32{1, 2}); err != nil {

--- a/internal/embedding/cache_test.go
+++ b/internal/embedding/cache_test.go
@@ -117,8 +117,10 @@ func TestCache_RotatesOverSizeCap(t *testing.T) {
 }
 
 func TestCache_HashTextStable(t *testing.T) {
-	if HashText("hello") != HashText("hello") {
-		t.Error("HashText should be deterministic")
+	a := HashText("hello")
+	b := HashText("hello")
+	if a != b {
+		t.Errorf("HashText should be deterministic: got %q vs %q", a, b)
 	}
 	if HashText("hello") == HashText("world") {
 		t.Error("HashText collisions across distinct inputs")

--- a/internal/embedding/cache_test.go
+++ b/internal/embedding/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -117,36 +118,62 @@ func TestCache_RotatesOverSizeCap(t *testing.T) {
 	}
 }
 
-// TestCache_RotatesEvenWhenLoadFails pins the regression: if ensureLoaded
-// fails (corrupt JSONL, partial write from a crashed wuphf), bytesOnDisk
-// must still reflect the actual file size — otherwise the rotation check
-// thinks the file is empty and the cache grows unbounded on disk while
-// the in-memory map stays cold.
+// TestCache_RotatesEvenWhenLoadFails pins the regression: if
+// ensureLoaded errors at os.Open (permission failure mid-flight, racy
+// remove, etc.), bytesOnDisk would stay at 0 — the rotation check
+// thinks the file is empty and the cache grows unbounded on disk
+// while the in-memory map stays cold.
+//
+// Earlier this test used a corrupt-but-readable JSONL file to simulate
+// the failure, which didn't actually exercise the new fix code:
+// ensureLoaded does f.Stat() BEFORE the JSONL scan, so bytesOnDisk
+// gets set from Stat regardless of scanner errors. The real fix path
+// is only hit when os.Open itself fails — we now simulate that with
+// chmod 000.
 func TestCache_RotatesEvenWhenLoadFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod-based unreadable-file simulation is not portable to windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("running as root: chmod 000 doesn't block reads")
+	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "embeddings.jsonl")
 
-	// Write a sentinel file slightly under the cap so a single Set tips
-	// past it. We fill it with non-JSONL garbage so ensureLoaded() can
-	// scan it (the row parser is best-effort) but the file size is what
-	// matters for rotation. Use a content size near the cap to force the
-	// rotation branch.
 	garbage := bytes.Repeat([]byte{'x'}, maxCacheBytes-100)
 	if err := os.WriteFile(path, garbage, 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
+	// Make the file unreadable so os.Open returns EACCES inside
+	// ensureLoaded — this is the path the production fix actually
+	// covers (Stat itself still works on 0o000 files because it only
+	// needs metadata access from the parent directory).
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
 
 	c := NewCache(path)
 
-	// Drive a Set. With the bug, bytesOnDisk would stay at 0 (load saw
-	// no parseable rows) and rotation would NOT trigger. With the fix,
-	// the post-load Stat sets bytesOnDisk to the file size, so the cap
-	// check fires and the file rotates.
+	// Drive a Set against the chmod-000 file. With the bug,
+	// ensureLoaded errors at os.Open and bytesOnDisk stays 0 →
+	// rotation never fires → the .old file is never created and the
+	// live file grows unbounded. With the fix, Set's post-load Stat
+	// fallback fills bytesOnDisk from the filesystem (Stat itself
+	// still works on a 0o000 file because it only needs metadata
+	// access through the parent dir), so the cap check trips and
+	// rotation runs.
+	//
+	// os.Rename and os.OpenFile(O_CREATE|O_WRONLY) both succeed
+	// because they need write+exec on the PARENT directory, not on
+	// the (about-to-be-removed) 0o000 file. The kernel never tries
+	// to read the contents during rename/create.
 	if err := c.Set("trigger", "m", []float32{1, 2, 3}); err != nil {
 		t.Fatalf("Set: %v", err)
 	}
 
-	// .old must exist — proves rotation triggered despite the load failure.
+	// .old must exist — proves rotation triggered despite the
+	// initial load failure.
 	if _, err := os.Stat(path + ".old"); err != nil {
 		t.Fatalf("expected .old to exist after rotation, got %v", err)
 	}

--- a/internal/embedding/cluster.go
+++ b/internal/embedding/cluster.go
@@ -1,0 +1,164 @@
+package embedding
+
+// cluster.go groups embedded entries by cosine similarity. It is the
+// semantic counterpart to internal/team/notebook_signal_scanner.go's
+// Jaccard clustering — same shape (slice of clusters), better recall on
+// paraphrases.
+//
+// The algorithm is deliberately greedy:
+//
+//  1. For each entry, compute cosine similarity against every existing
+//     cluster's centroid.
+//  2. If the best score >= threshold, join that cluster; otherwise start
+//     a new one.
+//  3. After joining, recompute the centroid as the L2-normalised mean of
+//     all member vectors.
+//
+// Greedy is good enough for v1 — the synthesizer is the LLM gate that
+// catches false-positive clusters. Single-link agglomerative would have
+// better quality at the cost of complexity (and more API calls if we
+// ever materialise pairwise distance matrices). Revisit if the
+// SkillCandidate quality bar tightens.
+
+import "fmt"
+
+// ClusterEntry is the input row to ClusterByCosine. ID is opaque to the
+// clustering layer — callers use it to map cluster members back to their
+// source (e.g. notebook entry path).
+type ClusterEntry struct {
+	// Text is the original text the vector was computed from. Carried
+	// through so callers can build excerpts without re-reading the
+	// source. Optional — empty string is fine.
+	Text string
+
+	// Vector is the L2-normalised embedding. Length must match across
+	// every entry passed in a single call.
+	Vector []float32
+
+	// ID is caller-supplied. Examples: notebook entry path,
+	// SkillCandidateExcerpt.Path. Carried through so callers can map
+	// cluster output back to their domain types.
+	ID string
+}
+
+// Cluster is a group of entries whose pairwise centroid-cosine all
+// exceed the threshold supplied to ClusterByCosine.
+type Cluster struct {
+	// Entries are the cluster members in insertion order. Stable — we
+	// never reorder once an entry has joined.
+	Entries []ClusterEntry
+
+	// Centroid is the L2-normalised mean of every member's vector.
+	// Used by ClusterByCosine to score new candidates. Callers may use
+	// it for downstream "most-representative" picks.
+	Centroid []float32
+}
+
+// ClusterByCosine groups entries where pairwise cosine similarity to a
+// cluster centroid is at least threshold. The centroid is recomputed as
+// the L2-normalised mean of all member vectors after every join.
+//
+// Threshold tuning: 0.7 = "loosely related", 0.8 = "same topic", 0.9 =
+// "near-paraphrase". Default for the notebook scanner is 0.8 (see
+// WUPHF_STAGE_B_NOTEBOOK_COSINE_THRESHOLD).
+//
+// Returns clusters in insertion order. An empty input slice returns nil.
+// Vectors of mismatched length cause the offending entry to be dropped
+// silently — this matches the notebook scanner's "best-effort over
+// unreadable entries" semantics, but we surface the count via the
+// returned skipped slice so callers can log it.
+func ClusterByCosine(entries []ClusterEntry, threshold float32) []Cluster {
+	clusters, _ := ClusterByCosineWithSkipped(entries, threshold)
+	return clusters
+}
+
+// ClusterByCosineWithSkipped is the variant that surfaces dropped entries
+// for telemetry. Most callers should use ClusterByCosine; this exists
+// for the notebook scanner where we want to log "n vectors had wrong
+// dimension".
+func ClusterByCosineWithSkipped(entries []ClusterEntry, threshold float32) (clusters []Cluster, skipped []ClusterEntry) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	dim := -1
+	for _, e := range entries {
+		if len(e.Vector) > 0 {
+			dim = len(e.Vector)
+			break
+		}
+	}
+	if dim <= 0 {
+		// Every input was empty — nothing to cluster.
+		return nil, entries
+	}
+
+	for _, e := range entries {
+		if len(e.Vector) != dim {
+			skipped = append(skipped, e)
+			continue
+		}
+		bestIdx := -1
+		var bestScore float32
+		for i := range clusters {
+			score := Cosine(clusters[i].Centroid, e.Vector)
+			if score >= threshold && score > bestScore {
+				bestScore = score
+				bestIdx = i
+			}
+		}
+		if bestIdx == -1 {
+			centroid := make([]float32, dim)
+			copy(centroid, e.Vector)
+			clusters = append(clusters, Cluster{
+				Entries:  []ClusterEntry{e},
+				Centroid: L2Normalise(centroid),
+			})
+			continue
+		}
+		clusters[bestIdx].Entries = append(clusters[bestIdx].Entries, e)
+		clusters[bestIdx].Centroid = recomputeCentroid(clusters[bestIdx].Entries, dim)
+	}
+	return clusters, skipped
+}
+
+// recomputeCentroid returns the L2-normalised mean of every member's
+// vector. We always recompute from scratch so a member with a slightly
+// off-axis vector does not pull the centroid permanently. Linear cost,
+// but cluster sizes are tiny in practice (≤ 10 entries).
+func recomputeCentroid(entries []ClusterEntry, dim int) []float32 {
+	if len(entries) == 0 {
+		return nil
+	}
+	mean := make([]float32, dim)
+	for _, e := range entries {
+		if len(e.Vector) != dim {
+			continue
+		}
+		for i, v := range e.Vector {
+			mean[i] += v
+		}
+	}
+	inv := float32(1) / float32(len(entries))
+	for i := range mean {
+		mean[i] *= inv
+	}
+	return L2Normalise(mean)
+}
+
+// Validate checks a slice of entries for the basic preconditions
+// callers expect (non-empty vectors, consistent dimension). Surfaces a
+// helpful error so the cluster layer's silent skip doesn't hide
+// upstream bugs. Optional — ClusterByCosine tolerates input it can't
+// process.
+func Validate(entries []ClusterEntry, expectedDim int) error {
+	if expectedDim <= 0 {
+		return fmt.Errorf("embedding: cluster: expectedDim must be positive, got %d", expectedDim)
+	}
+	for i, e := range entries {
+		if len(e.Vector) != expectedDim {
+			return fmt.Errorf("embedding: cluster: entry %d (%q): vector dim %d != expected %d",
+				i, e.ID, len(e.Vector), expectedDim)
+		}
+	}
+	return nil
+}

--- a/internal/embedding/cluster_test.go
+++ b/internal/embedding/cluster_test.go
@@ -1,0 +1,155 @@
+package embedding
+
+import (
+	"math"
+	"testing"
+)
+
+// vec is a tiny helper so test fixtures read like math papers, not
+// sliceeral noise.
+func vec(values ...float32) []float32 { return values }
+
+// approxEq is the float-comparison helper used across the test suite.
+// Cosine returns float32, but our tolerance is in float64 so we cast
+// once to keep the comparison code readable.
+func approxEq(t *testing.T, got, want float32, tol float64) {
+	t.Helper()
+	if math.Abs(float64(got)-float64(want)) > tol {
+		t.Errorf("got %v, want %v (tol %v)", got, want, tol)
+	}
+}
+
+func TestCosine_Identical(t *testing.T) {
+	v := L2Normalise(vec(1, 2, 3, 4))
+	got := Cosine(v, v)
+	approxEq(t, got, 1.0, 1e-6)
+}
+
+func TestCosine_Orthogonal(t *testing.T) {
+	a := L2Normalise(vec(1, 0, 0))
+	b := L2Normalise(vec(0, 1, 0))
+	got := Cosine(a, b)
+	approxEq(t, got, 0.0, 1e-6)
+}
+
+func TestCosine_Opposite(t *testing.T) {
+	a := L2Normalise(vec(1, 0, 0))
+	b := L2Normalise(vec(-1, 0, 0))
+	got := Cosine(a, b)
+	approxEq(t, got, -1.0, 1e-6)
+}
+
+func TestCosine_EmptyOrMismatch(t *testing.T) {
+	if got := Cosine(nil, vec(1, 2)); got != 0 {
+		t.Errorf("nil/non-nil: got %v want 0", got)
+	}
+	if got := Cosine(vec(1), vec(1, 2)); got != 0 {
+		t.Errorf("length mismatch: got %v want 0", got)
+	}
+}
+
+func TestL2Normalise_ZeroVector(t *testing.T) {
+	got := L2Normalise(vec(0, 0, 0))
+	for i, x := range got {
+		if x != 0 {
+			t.Errorf("zero-in zero-out: got %v at %d", x, i)
+		}
+	}
+}
+
+func TestL2Normalise_UnitOutput(t *testing.T) {
+	got := L2Normalise(vec(3, 4)) // length 5
+	approxEq(t, got[0], 0.6, 1e-6)
+	approxEq(t, got[1], 0.8, 1e-6)
+}
+
+func TestClusterByCosine_GroupsSimilar(t *testing.T) {
+	// Three nearly-identical vectors + two orthogonal-to-them vectors →
+	// 2 clusters. Threshold 0.8 picks "same topic" without merging the
+	// outliers.
+	similarA := L2Normalise(vec(1, 1, 0, 0))
+	similarB := L2Normalise(vec(0.95, 0.95, 0.05, 0.05))
+	similarC := L2Normalise(vec(1.05, 0.95, 0.05, 0))
+	otherA := L2Normalise(vec(0, 0, 1, 1))
+	otherB := L2Normalise(vec(0.05, 0.05, 0.95, 0.95))
+
+	entries := []ClusterEntry{
+		{ID: "a1", Vector: similarA},
+		{ID: "a2", Vector: similarB},
+		{ID: "a3", Vector: similarC},
+		{ID: "b1", Vector: otherA},
+		{ID: "b2", Vector: otherB},
+	}
+	clusters := ClusterByCosine(entries, 0.8)
+	if len(clusters) != 2 {
+		t.Fatalf("expected 2 clusters, got %d", len(clusters))
+	}
+	sizes := []int{len(clusters[0].Entries), len(clusters[1].Entries)}
+	if !(sizes[0] == 3 && sizes[1] == 2) && !(sizes[0] == 2 && sizes[1] == 3) {
+		t.Errorf("expected sizes [3,2] or [2,3], got %v", sizes)
+	}
+}
+
+func TestClusterByCosine_RespectsThreshold(t *testing.T) {
+	// Three vectors with progressively decreasing similarity. At 0.5 they
+	// should all merge; at 0.95 only the near-identical pair joins,
+	// leaving the third in its own cluster.
+	a := L2Normalise(vec(1, 0, 0))
+	b := L2Normalise(vec(0.99, 0.14, 0))                 // ~cos 0.99 with a
+	c := L2Normalise(vec(math.Sqrt2/2, math.Sqrt2/2, 0)) // ~cos 0.7 with a
+
+	entries := []ClusterEntry{
+		{ID: "a", Vector: a},
+		{ID: "b", Vector: b},
+		{ID: "c", Vector: c},
+	}
+
+	loose := ClusterByCosine(entries, 0.5)
+	if len(loose) != 1 {
+		t.Errorf("loose threshold: got %d clusters want 1", len(loose))
+	}
+
+	strict := ClusterByCosine(entries, 0.95)
+	if len(strict) != 2 {
+		t.Errorf("strict threshold: got %d clusters want 2", len(strict))
+	}
+}
+
+func TestClusterByCosine_EmptyInput(t *testing.T) {
+	if got := ClusterByCosine(nil, 0.8); got != nil {
+		t.Errorf("nil input: got %v want nil", got)
+	}
+	if got := ClusterByCosine([]ClusterEntry{}, 0.8); got != nil {
+		t.Errorf("empty input: got %v want nil", got)
+	}
+}
+
+func TestClusterByCosine_SkipsBadDimension(t *testing.T) {
+	good := L2Normalise(vec(1, 0, 0))
+	bad := vec(1, 0) // wrong dim → skipped silently
+
+	entries := []ClusterEntry{
+		{ID: "good", Vector: good},
+		{ID: "bad", Vector: bad},
+	}
+	clusters, skipped := ClusterByCosineWithSkipped(entries, 0.8)
+	if len(clusters) != 1 {
+		t.Errorf("clusters: got %d want 1", len(clusters))
+	}
+	if len(skipped) != 1 || skipped[0].ID != "bad" {
+		t.Errorf("skipped: got %+v want one entry with ID=bad", skipped)
+	}
+}
+
+func TestValidate_DimensionMismatch(t *testing.T) {
+	entries := []ClusterEntry{
+		{ID: "ok", Vector: vec(1, 2, 3)},
+		{ID: "wrong", Vector: vec(1, 2)},
+	}
+	if err := Validate(entries, 3); err == nil {
+		t.Error("Validate: expected error on dimension mismatch")
+	}
+	if err := Validate(entries[:1], 3); err != nil {
+		t.Errorf("Validate: unexpected error on matching dims: %v", err)
+	}
+}

--- a/internal/embedding/embedding.go
+++ b/internal/embedding/embedding.go
@@ -34,9 +34,10 @@
 //
 // # Cache
 //
-// Embeddings are stable for a (text, model) pair, so callers should cache.
-// The package ships a JSONL append-only cache (Cache in cache.go) keyed by
-// SHA-256 of the input text. Default cache file is
+// Embeddings are stable for a (text, provider backend, model, dimension) tuple,
+// so callers should cache with that full namespace. The package ships a JSONL
+// append-only cache (Cache in cache.go) keyed by SHA-256 of the input text plus
+// provider/model/dimension metadata. Default cache file is
 //
 //	$WUPHF_HOME/.wuphf/cache/embeddings.jsonl
 //
@@ -79,6 +80,22 @@ type Provider interface {
 	// field. Examples: "voyage-voyage-3-large", "openai-text-embedding-3-small",
 	// "local-stub".
 	Name() string
+}
+
+type cacheNamespaceProvider interface {
+	CacheNamespace() string
+}
+
+// ProviderCacheNamespace returns the cache namespace for provider. Providers
+// that do not expose backend details fall back to Name().
+func ProviderCacheNamespace(provider Provider) string {
+	if provider == nil {
+		return ""
+	}
+	if p, ok := provider.(cacheNamespaceProvider); ok {
+		return p.CacheNamespace()
+	}
+	return provider.Name()
 }
 
 // Cosine returns the cosine similarity of two vectors. Both must be the

--- a/internal/embedding/embedding.go
+++ b/internal/embedding/embedding.go
@@ -7,14 +7,19 @@
 //
 // NewDefault inspects the environment and returns the highest-priority
 // provider that is configured. Order:
-//  1. ANTHROPIC_API_KEY → Voyage AI (Anthropic does not ship a native
-//     embeddings API today; voyage-3-large is the recommended companion).
-//     This currently routes through the OpenAI-compatible Voyage endpoint.
+//  1. VOYAGE_API_KEY → Voyage AI (voyage-3-large, 1024 dims). Anthropic does
+//     not ship a native embeddings API at time of writing; Voyage is the
+//     companion they recommend, but it is a separate company — we only call
+//     it when the user explicitly opts in with VOYAGE_API_KEY. We never
+//     forward ANTHROPIC_API_KEY to api.voyageai.com.
 //  2. OPENAI_API_KEY → OpenAI text-embedding-3-small (1536 dims). Works
 //     against any OpenAI-compatible endpoint via OPENAI_BASE_URL.
 //  3. else → local stub provider (deterministic hash-based pseudo-vectors,
 //     32 dims). Stub vectors are NOT semantically meaningful — they only
 //     guarantee determinism for tests / dev environments without API keys.
+//     If only ANTHROPIC_API_KEY is set, NewDefault logs a one-shot warning
+//     and returns the stub: Anthropic-only users need to also set
+//     VOYAGE_API_KEY or OPENAI_API_KEY to enable real embeddings.
 //
 // # Cost model
 //
@@ -46,9 +51,11 @@ package embedding
 
 import (
 	"context"
+	"log/slog"
 	"math"
 	"os"
 	"strings"
+	"sync"
 )
 
 // Provider returns a vector for a given text. Stateless — embeddings are
@@ -69,7 +76,7 @@ type Provider interface {
 	Dimension() int
 
 	// Name is a stable identifier used for logging and the cache "model"
-	// field. Examples: "anthropic-voyage-3-large", "openai-text-embedding-3-small",
+	// field. Examples: "voyage-voyage-3-large", "openai-text-embedding-3-small",
 	// "local-stub".
 	Name() string
 }
@@ -129,11 +136,31 @@ func L2Normalise(v []float32) []float32 {
 //
 // NewDefault never returns nil — the stub provider is the floor.
 func NewDefault() Provider {
-	if k := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")); k != "" {
-		return newAnthropicProvider(k)
+	if k := strings.TrimSpace(os.Getenv("VOYAGE_API_KEY")); k != "" {
+		return newVoyageProvider()
 	}
 	if k := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); k != "" {
 		return newOpenAIProvider(k)
 	}
+	if k := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")); k != "" {
+		warnAnthropicOnly()
+	}
 	return NewStubProvider()
+}
+
+var warnAnthropicOnlyOnce sync.Once
+
+// warnAnthropicOnly logs once when only ANTHROPIC_API_KEY is set. Anthropic
+// does not host embeddings; we deliberately do not forward the key to
+// api.voyageai.com (third-party). The user must opt in explicitly.
+func warnAnthropicOnly() {
+	warnAnthropicOnlyOnce.Do(func() {
+		slog.Warn(
+			"embedding: ANTHROPIC_API_KEY set but no embeddings provider — "+
+				"Anthropic does not ship a native embeddings endpoint. "+
+				"Set VOYAGE_API_KEY (voyage-3-large) or OPENAI_API_KEY to enable; "+
+				"falling back to deterministic stub (NOT semantic).",
+			"hint", "https://docs.voyageai.com",
+		)
+	})
 }

--- a/internal/embedding/embedding.go
+++ b/internal/embedding/embedding.go
@@ -1,0 +1,139 @@
+// Package embedding provides a pluggable text-embedding interface used by
+// Stage B notebook semantic clustering. The interface is intentionally small
+// (Embed / EmbedBatch / Dimension / Name) so callers can swap providers
+// without changing call sites.
+//
+// # Provider selection
+//
+// NewDefault inspects the environment and returns the highest-priority
+// provider that is configured. Order:
+//  1. ANTHROPIC_API_KEY → Voyage AI (Anthropic does not ship a native
+//     embeddings API today; voyage-3-large is the recommended companion).
+//     This currently routes through the OpenAI-compatible Voyage endpoint.
+//  2. OPENAI_API_KEY → OpenAI text-embedding-3-small (1536 dims). Works
+//     against any OpenAI-compatible endpoint via OPENAI_BASE_URL.
+//  3. else → local stub provider (deterministic hash-based pseudo-vectors,
+//     32 dims). Stub vectors are NOT semantically meaningful — they only
+//     guarantee determinism for tests / dev environments without API keys.
+//
+// # Cost model
+//
+// At time of writing (2026-04-28):
+//
+//	OpenAI text-embedding-3-small  : $0.02 / 1M tokens (≈ $0.00000002 / token)
+//	Voyage voyage-3-large          : $0.18 / 1M tokens
+//
+// We approximate token count as runes / 4. Real tokenisers will diverge,
+// but the figure is good enough for telemetry — the goal is "did we just
+// spend a dollar" awareness, not invoice-grade accounting.
+//
+// # Cache
+//
+// Embeddings are stable for a (text, model) pair, so callers should cache.
+// The package ships a JSONL append-only cache (Cache in cache.go) keyed by
+// SHA-256 of the input text. Default cache file is
+//
+//	$WUPHF_HOME/.wuphf/cache/embeddings.jsonl
+//
+// (where $WUPHF_HOME is resolved via internal/config.RuntimeHomeDir).
+//
+// # Determinism
+//
+// Each provider returns L2-normalised vectors so cosine similarity is the
+// dot product. This keeps the clustering layer simple and avoids
+// per-comparison normalisation.
+package embedding
+
+import (
+	"context"
+	"math"
+	"os"
+	"strings"
+)
+
+// Provider returns a vector for a given text. Stateless — embeddings are
+// not cached at this layer; callers cache per their needs (see Cache in
+// cache.go).
+type Provider interface {
+	// Embed returns a unit-length vector for text. Errors on empty text
+	// or provider failure. Implementations must respect ctx.Done().
+	Embed(ctx context.Context, text string) ([]float32, error)
+
+	// EmbedBatch is a batched form. Implementations may parallelise or
+	// call Embed in a loop. The output slice must match the input slice
+	// length and ordering.
+	EmbedBatch(ctx context.Context, texts []string) ([][]float32, error)
+
+	// Dimension is the fixed length of returned vectors. Used for sanity
+	// checks at the cluster layer and to size cache rows.
+	Dimension() int
+
+	// Name is a stable identifier used for logging and the cache "model"
+	// field. Examples: "anthropic-voyage-3-large", "openai-text-embedding-3-small",
+	// "local-stub".
+	Name() string
+}
+
+// Cosine returns the cosine similarity of two vectors. Both must be the
+// same length. Returns 1.0 for identical, 0.0 for orthogonal, -1.0 for
+// opposite. Returns 0 when either side is empty or lengths differ.
+//
+// Implementations of Provider return unit-length vectors, so this reduces
+// to the dot product. We still divide by the L2 norms here so the helper
+// is correct on hand-crafted inputs (e.g. tests).
+func Cosine(a, b []float32) float32 {
+	if len(a) == 0 || len(b) == 0 || len(a) != len(b) {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		ai := float64(a[i])
+		bi := float64(b[i])
+		dot += ai * bi
+		na += ai * ai
+		nb += bi * bi
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return float32(dot / (math.Sqrt(na) * math.Sqrt(nb)))
+}
+
+// L2Normalise returns a copy of v scaled so its Euclidean norm is 1. A
+// zero vector is returned as-is (no division by zero). Used by every
+// provider so callers get unit vectors regardless of upstream conventions.
+func L2Normalise(v []float32) []float32 {
+	if len(v) == 0 {
+		return v
+	}
+	var sum float64
+	for _, x := range v {
+		sum += float64(x) * float64(x)
+	}
+	if sum == 0 {
+		out := make([]float32, len(v))
+		copy(out, v)
+		return out
+	}
+	norm := math.Sqrt(sum)
+	out := make([]float32, len(v))
+	for i, x := range v {
+		out[i] = float32(float64(x) / norm)
+	}
+	return out
+}
+
+// NewDefault returns a Provider based on environment variables. See the
+// package doc comment for selection order. The returned provider is safe
+// for concurrent use.
+//
+// NewDefault never returns nil — the stub provider is the floor.
+func NewDefault() Provider {
+	if k := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")); k != "" {
+		return newAnthropicProvider(k)
+	}
+	if k := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); k != "" {
+		return newOpenAIProvider(k)
+	}
+	return NewStubProvider()
+}

--- a/internal/embedding/openai.go
+++ b/internal/embedding/openai.go
@@ -65,6 +65,12 @@ func newOpenAIProvider(apiKey string) Provider {
 // stay valid across model changes.
 func (p *openAIProvider) Name() string { return "openai-" + p.model }
 
+// CacheNamespace includes the backend URL because OpenAI-compatible endpoints
+// can share a model name while returning incompatible vector spaces.
+func (p *openAIProvider) CacheNamespace() string {
+	return "openai|" + strings.TrimRight(p.baseURL, "/")
+}
+
 // Dimension returns the expected vector length. Mismatches between the
 // configured dimension and a returned vector raise an error from Embed so
 // the cluster layer's sanity checks fire.

--- a/internal/embedding/openai.go
+++ b/internal/embedding/openai.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -211,13 +212,17 @@ func openAIDimensionFromEnv() int {
 // from "default kicked in" — without it, a Voyage user running
 // voyage-code-2 (1536-dim) cannot opt out of the 1024-dim default
 // because the override and the default are indistinguishable.
+//
+// strconv.Atoi is stricter than the previous fmt.Sscanf("%d", ...): it
+// rejects "1536  garbage" and "1.5" outright instead of returning the
+// leading digits as a partial parse.
 func embeddingDimensionOverride() (int, bool) {
 	raw := strings.TrimSpace(os.Getenv("WUPHF_EMBEDDING_DIMENSION"))
 	if raw == "" {
 		return 0, false
 	}
-	var n int
-	if _, err := fmt.Sscanf(raw, "%d", &n); err != nil || n <= 0 {
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
 		return 0, false
 	}
 	return n, true

--- a/internal/embedding/openai.go
+++ b/internal/embedding/openai.go
@@ -1,0 +1,223 @@
+package embedding
+
+// openai.go is an OpenAI-compatible embeddings client. It works against
+// OpenAI's hosted API (default), Azure OpenAI, Mistral's compat shim, and
+// any local OpenAI-compat server (mlx-lm, llama.cpp, vLLM, …) by setting
+// OPENAI_BASE_URL.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	defaultOpenAIBaseURL = "https://api.openai.com"
+	defaultOpenAIModel   = "text-embedding-3-small"
+	// defaultOpenAIDim is the published vector dimension of
+	// text-embedding-3-small. Larger models (text-embedding-3-large) use
+	// 3072 dims; we pin the small model by default for cost/perf.
+	defaultOpenAIDim     = 1536
+	defaultOpenAITimeout = 30 * time.Second
+)
+
+// openAIProvider is the canonical OpenAI-compatible embeddings client.
+// Concurrent-safe: the http.Client is internally locked and there is no
+// mutable state beyond construction-time fields.
+type openAIProvider struct {
+	apiKey     string
+	baseURL    string
+	model      string
+	dimension  int
+	httpClient *http.Client
+}
+
+// newOpenAIProvider constructs a provider configured from environment
+// variables:
+//
+//	OPENAI_API_KEY            — bearer token (required; empty key falls back to stub)
+//	OPENAI_BASE_URL           — overrides the API host (e.g. http://localhost:8080)
+//	WUPHF_EMBEDDING_MODEL     — overrides the model (default text-embedding-3-small)
+//	WUPHF_EMBEDDING_DIMENSION — overrides the expected dimension (default 1536)
+//	WUPHF_EMBEDDING_TIMEOUT   — Go duration string (default 30s)
+func newOpenAIProvider(apiKey string) Provider {
+	if strings.TrimSpace(apiKey) == "" {
+		return NewStubProvider()
+	}
+	return &openAIProvider{
+		apiKey:     apiKey,
+		baseURL:    openAIBaseURLFromEnv(),
+		model:      openAIModelFromEnv(),
+		dimension:  openAIDimensionFromEnv(),
+		httpClient: &http.Client{Timeout: openAITimeoutFromEnv()},
+	}
+}
+
+// Name is a stable identifier of the form "openai-<model>" so cache rows
+// stay valid across model changes.
+func (p *openAIProvider) Name() string { return "openai-" + p.model }
+
+// Dimension returns the expected vector length. Mismatches between the
+// configured dimension and a returned vector raise an error from Embed so
+// the cluster layer's sanity checks fire.
+func (p *openAIProvider) Dimension() int { return p.dimension }
+
+// Embed sends a single-text request and returns a unit-normalised vector.
+// OpenAI documents that text-embedding-3-* already returns unit vectors;
+// we re-normalise defensively in case a compat server lies.
+func (p *openAIProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	if strings.TrimSpace(text) == "" {
+		return nil, errors.New("embedding: empty text")
+	}
+	out, err := p.embedBatch(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(out) != 1 {
+		return nil, fmt.Errorf("embedding: openai: expected 1 vector got %d", len(out))
+	}
+	return out[0], nil
+}
+
+// EmbedBatch posts every input in a single request. OpenAI's embeddings
+// endpoint accepts up to 2048 inputs per call; we don't shard here —
+// callers control batch size.
+func (p *openAIProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	for i, t := range texts {
+		if strings.TrimSpace(t) == "" {
+			return nil, fmt.Errorf("embedding: empty text at index %d", i)
+		}
+	}
+	return p.embedBatch(ctx, texts)
+}
+
+// openAIRequest is the wire format for POST /v1/embeddings. We always send
+// the model so an upstream can reject unsupported choices with a 400
+// rather than silently returning a different model's vectors.
+type openAIRequest struct {
+	Model          string   `json:"model"`
+	Input          []string `json:"input"`
+	EncodingFormat string   `json:"encoding_format,omitempty"`
+}
+
+// openAIResponse mirrors the OpenAI compat response. We tolerate trailing
+// fields by keeping json:"-"-friendly tags only on the bits we read.
+type openAIResponse struct {
+	Data []struct {
+		Embedding []float32 `json:"embedding"`
+		Index     int       `json:"index"`
+	} `json:"data"`
+	Model string `json:"model"`
+	Usage struct {
+		PromptTokens int `json:"prompt_tokens"`
+		TotalTokens  int `json:"total_tokens"`
+	} `json:"usage"`
+}
+
+// embedBatch performs the round-trip. It validates dimensions, re-orders
+// the response by index (just in case the server returns out of order),
+// and L2-normalises every output.
+func (p *openAIProvider) embedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	body, err := json.Marshal(openAIRequest{
+		Model:          p.model,
+		Input:          texts,
+		EncodingFormat: "float",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("embedding: openai: marshal: %w", err)
+	}
+
+	endpoint := strings.TrimRight(p.baseURL, "/") + "/v1/embeddings"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("embedding: openai: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+p.apiKey)
+
+	resp, err := p.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("embedding: openai: http: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		raw, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return nil, fmt.Errorf("embedding: openai: status %d: %s", resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+
+	var parsed openAIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&parsed); err != nil {
+		return nil, fmt.Errorf("embedding: openai: decode: %w", err)
+	}
+	if len(parsed.Data) != len(texts) {
+		return nil, fmt.Errorf("embedding: openai: response length mismatch (got %d want %d)", len(parsed.Data), len(texts))
+	}
+
+	out := make([][]float32, len(texts))
+	for _, row := range parsed.Data {
+		if row.Index < 0 || row.Index >= len(texts) {
+			return nil, fmt.Errorf("embedding: openai: out-of-range index %d", row.Index)
+		}
+		if len(row.Embedding) != p.dimension {
+			return nil, fmt.Errorf("embedding: openai: dimension mismatch (got %d want %d)", len(row.Embedding), p.dimension)
+		}
+		out[row.Index] = L2Normalise(row.Embedding)
+	}
+	for i, v := range out {
+		if v == nil {
+			return nil, fmt.Errorf("embedding: openai: missing vector at index %d", i)
+		}
+	}
+	return out, nil
+}
+
+// ── env helpers ───────────────────────────────────────────────────────────
+
+func openAIBaseURLFromEnv() string {
+	if v := strings.TrimSpace(os.Getenv("OPENAI_BASE_URL")); v != "" {
+		return v
+	}
+	return defaultOpenAIBaseURL
+}
+
+func openAIModelFromEnv() string {
+	if v := strings.TrimSpace(os.Getenv("WUPHF_EMBEDDING_MODEL")); v != "" {
+		return v
+	}
+	return defaultOpenAIModel
+}
+
+func openAIDimensionFromEnv() int {
+	raw := strings.TrimSpace(os.Getenv("WUPHF_EMBEDDING_DIMENSION"))
+	if raw == "" {
+		return defaultOpenAIDim
+	}
+	var n int
+	if _, err := fmt.Sscanf(raw, "%d", &n); err != nil || n <= 0 {
+		return defaultOpenAIDim
+	}
+	return n
+}
+
+func openAITimeoutFromEnv() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("WUPHF_EMBEDDING_TIMEOUT"))
+	if raw == "" {
+		return defaultOpenAITimeout
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return defaultOpenAITimeout
+	}
+	return d
+}

--- a/internal/embedding/openai.go
+++ b/internal/embedding/openai.go
@@ -199,15 +199,28 @@ func openAIModelFromEnv() string {
 }
 
 func openAIDimensionFromEnv() int {
+	if n, ok := embeddingDimensionOverride(); ok {
+		return n
+	}
+	return defaultOpenAIDim
+}
+
+// embeddingDimensionOverride reads WUPHF_EMBEDDING_DIMENSION and returns
+// (n, true) when the user has explicitly set a positive integer. The
+// `ok` flag lets callers (Voyage especially) distinguish "user set 1536"
+// from "default kicked in" — without it, a Voyage user running
+// voyage-code-2 (1536-dim) cannot opt out of the 1024-dim default
+// because the override and the default are indistinguishable.
+func embeddingDimensionOverride() (int, bool) {
 	raw := strings.TrimSpace(os.Getenv("WUPHF_EMBEDDING_DIMENSION"))
 	if raw == "" {
-		return defaultOpenAIDim
+		return 0, false
 	}
 	var n int
 	if _, err := fmt.Sscanf(raw, "%d", &n); err != nil || n <= 0 {
-		return defaultOpenAIDim
+		return 0, false
 	}
-	return n
+	return n, true
 }
 
 func openAITimeoutFromEnv() time.Duration {

--- a/internal/embedding/openai_test.go
+++ b/internal/embedding/openai_test.go
@@ -102,23 +102,16 @@ func TestOpenAIProvider_AuthHeader(t *testing.T) {
 }
 
 func TestOpenAIProvider_ContextTimeout(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		// Block long enough that the context-supplied deadline fires.
-		time.Sleep(100 * time.Millisecond)
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(server.Close)
-
 	provider := &openAIProvider{
 		apiKey:     "test-key",
-		baseURL:    server.URL,
+		baseURL:    "https://example.invalid",
 		model:      "text-embedding-3-small",
 		dimension:  defaultOpenAIDim,
-		httpClient: &http.Client{Timeout: 5 * time.Second},
+		httpClient: &http.Client{Transport: contextErrorRoundTripper{}},
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
-	defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
 	_, err := provider.Embed(ctx, "hello")
 	if err == nil {
@@ -127,6 +120,12 @@ func TestOpenAIProvider_ContextTimeout(t *testing.T) {
 	if !strings.Contains(err.Error(), "context") && !strings.Contains(err.Error(), "deadline") {
 		t.Errorf("expected context-related error, got %v", err)
 	}
+}
+
+type contextErrorRoundTripper struct{}
+
+func (contextErrorRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, req.Context().Err()
 }
 
 func TestOpenAIProvider_NonOKStatus(t *testing.T) {
@@ -205,6 +204,9 @@ func TestOpenAIProvider_RealEnvSkipped(t *testing.T) {
 	// pure skip — it documents the contract.
 	if k := strings.TrimSpace(envGet("OPENAI_API_KEY")); k != "" {
 		t.Skip("OPENAI_API_KEY is set: a separate live-integration test should cover the real endpoint")
+	}
+	if k := strings.TrimSpace(envGet("VOYAGE_API_KEY")); k != "" {
+		t.Skip("VOYAGE_API_KEY is set: a separate live-integration test should cover the real endpoint")
 	}
 	if got := NewDefault().Name(); got != "local-stub" {
 		t.Errorf("expected stub fallback in CI, got %q", got)

--- a/internal/embedding/openai_test.go
+++ b/internal/embedding/openai_test.go
@@ -1,0 +1,216 @@
+package embedding
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withOpenAIServer spins up a controllable httptest server that mimics
+// the OpenAI embeddings API. The handler closure can override the
+// default response by returning a non-empty body / status; otherwise the
+// test gets a 200 with a synthetic 1536-dim vector per input.
+func withOpenAIServer(t *testing.T, handler func(r *http.Request) (status int, body any)) (*httptest.Server, *openAIProvider) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/embeddings" {
+			http.Error(w, "wrong path", http.StatusNotFound)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+			return
+		}
+		status, body := handler(r)
+		w.Header().Set("Content-Type", "application/json")
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.WriteHeader(status)
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	t.Cleanup(server.Close)
+
+	provider := &openAIProvider{
+		apiKey:     "test-key",
+		baseURL:    server.URL,
+		model:      "text-embedding-3-small",
+		dimension:  defaultOpenAIDim,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+	return server, provider
+}
+
+// fixedVector returns a synthetic 1536-dim unit vector with `at` set to
+// 1.0 and the rest zero. Cheap way to produce distinguishable rows in
+// the canned response.
+func fixedVector(at int) []float32 {
+	v := make([]float32, defaultOpenAIDim)
+	if at >= 0 && at < len(v) {
+		v[at] = 1.0
+	}
+	return v
+}
+
+func TestOpenAIProvider_ParsesCannedResponse(t *testing.T) {
+	_, provider := withOpenAIServer(t, func(_ *http.Request) (int, any) {
+		return http.StatusOK, openAIResponse{
+			Model: "text-embedding-3-small",
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+				Index     int       `json:"index"`
+			}{
+				{Index: 0, Embedding: fixedVector(0)},
+			},
+		}
+	})
+
+	got, err := provider.Embed(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if len(got) != defaultOpenAIDim {
+		t.Errorf("dim: got %d want %d", len(got), defaultOpenAIDim)
+	}
+	if got[0] == 0 {
+		t.Error("expected first slot to be non-zero (distinguishable)")
+	}
+}
+
+func TestOpenAIProvider_AuthHeader(t *testing.T) {
+	var seen string
+	_, provider := withOpenAIServer(t, func(r *http.Request) (int, any) {
+		seen = r.Header.Get("Authorization")
+		return http.StatusOK, openAIResponse{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+				Index     int       `json:"index"`
+			}{{Index: 0, Embedding: fixedVector(0)}},
+		}
+	})
+
+	if _, err := provider.Embed(context.Background(), "hello"); err != nil {
+		t.Fatalf("embed: %v", err)
+	}
+	if seen != "Bearer test-key" {
+		t.Errorf("auth header: got %q want %q", seen, "Bearer test-key")
+	}
+}
+
+func TestOpenAIProvider_ContextTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// Block long enough that the context-supplied deadline fires.
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	provider := &openAIProvider{
+		apiKey:     "test-key",
+		baseURL:    server.URL,
+		model:      "text-embedding-3-small",
+		dimension:  defaultOpenAIDim,
+		httpClient: &http.Client{Timeout: 5 * time.Second},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := provider.Embed(ctx, "hello")
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if !strings.Contains(err.Error(), "context") && !strings.Contains(err.Error(), "deadline") {
+		t.Errorf("expected context-related error, got %v", err)
+	}
+}
+
+func TestOpenAIProvider_NonOKStatus(t *testing.T) {
+	_, provider := withOpenAIServer(t, func(_ *http.Request) (int, any) {
+		return http.StatusUnauthorized, map[string]any{"error": map[string]any{"message": "bad key"}}
+	})
+
+	_, err := provider.Embed(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error on 401")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("expected 401 in error, got %v", err)
+	}
+}
+
+func TestOpenAIProvider_DimensionMismatch(t *testing.T) {
+	_, provider := withOpenAIServer(t, func(_ *http.Request) (int, any) {
+		return http.StatusOK, openAIResponse{
+			Data: []struct {
+				Embedding []float32 `json:"embedding"`
+				Index     int       `json:"index"`
+			}{{Index: 0, Embedding: []float32{0.1, 0.2}}}, // wrong dim
+		}
+	})
+
+	_, err := provider.Embed(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error on dimension mismatch")
+	}
+	if !strings.Contains(err.Error(), "dimension") {
+		t.Errorf("expected dimension error, got %v", err)
+	}
+}
+
+func TestOpenAIProvider_BatchPreservesOrder(t *testing.T) {
+	_, provider := withOpenAIServer(t, func(r *http.Request) (int, any) {
+		var req openAIRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		// Server returns the data out of order to verify the client
+		// re-orders by index.
+		data := []struct {
+			Embedding []float32 `json:"embedding"`
+			Index     int       `json:"index"`
+		}{
+			{Index: 1, Embedding: fixedVector(2)},
+			{Index: 0, Embedding: fixedVector(1)},
+		}
+		return http.StatusOK, openAIResponse{Data: data}
+	})
+
+	got, err := provider.EmbedBatch(context.Background(), []string{"first", "second"})
+	if err != nil {
+		t.Fatalf("batch: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len: got %d want 2", len(got))
+	}
+	if got[0][1] == 0 || got[1][2] == 0 {
+		t.Error("batch results were not re-ordered by index")
+	}
+}
+
+func TestOpenAIProvider_EmptyText(t *testing.T) {
+	provider := &openAIProvider{apiKey: "k", model: "m", dimension: defaultOpenAIDim, httpClient: &http.Client{}}
+	if _, err := provider.Embed(context.Background(), ""); err == nil {
+		t.Error("empty text should error before HTTP")
+	}
+}
+
+func TestOpenAIProvider_RealEnvSkipped(t *testing.T) {
+	// Ensures we don't accidentally hit the live API in unit-test mode.
+	// If OPENAI_API_KEY is absent (the default in CI), this test is a
+	// pure skip — it documents the contract.
+	if k := strings.TrimSpace(envGet("OPENAI_API_KEY")); k != "" {
+		t.Skip("OPENAI_API_KEY is set: a separate live-integration test should cover the real endpoint")
+	}
+	if got := NewDefault().Name(); got != "local-stub" {
+		t.Errorf("expected stub fallback in CI, got %q", got)
+	}
+}
+
+// envGet is a tiny indirection so the skip test reads cleanly without
+// importing os at the top of the test file.
+func envGet(k string) string { return getEnvForTest(k) }

--- a/internal/embedding/stub.go
+++ b/internal/embedding/stub.go
@@ -1,0 +1,128 @@
+package embedding
+
+// stub.go is a deterministic, hash-based pseudo-embedding provider. It
+// is the floor returned by NewDefault when no API key is configured, and
+// it is the provider tests use to exercise the cluster + scanner paths
+// without making network calls.
+//
+// CRITICAL: stub vectors are NOT semantically meaningful. Two semantically
+// identical sentences with different vocabularies will get unrelated
+// vectors. The only guarantee is determinism: the same input string
+// produces the same vector across runs and platforms.
+//
+// The vectors are produced by:
+//  1. tokenising the input on non-alphanumeric runes (lowercase),
+//  2. hashing each token to a stable [0..stubDim) bucket,
+//  3. summing 1.0 into that bucket for every token occurrence,
+//  4. L2-normalising the resulting vector.
+//
+// This is just enough structure that texts which share many tokens score
+// higher cosine similarity than texts that don't, which is what the
+// notebook scanner's contract expects.
+
+import (
+	"context"
+	"errors"
+	"hash/fnv"
+	"strings"
+)
+
+// stubDim is the fixed dimension of stub vectors. 32 is small enough to
+// keep test goroutine memory negligible and large enough that the bucket
+// hashes don't collide for the small notebook corpora tests use.
+const stubDim = 32
+
+// stubProvider is the concrete type returned by NewStubProvider. It is
+// stateless and safe for concurrent use.
+type stubProvider struct{}
+
+// NewStubProvider returns the deterministic hash-based provider. Exposed
+// (capitalised) so tests in other packages can dependency-inject it
+// without paying for a real API call.
+func NewStubProvider() Provider { return &stubProvider{} }
+
+// Name is "local-stub" so cache rows + log lines clearly mark stub data.
+func (p *stubProvider) Name() string { return "local-stub" }
+
+// Dimension is the fixed vector length.
+func (p *stubProvider) Dimension() int { return stubDim }
+
+// Embed tokenises text the same way the notebook scanner does, hashes
+// each token into a fixed-dim bucket, sums occurrences, and L2-normalises
+// the result. Returns an error on empty text so callers can't smuggle
+// a zero-vector through to the cluster layer.
+func (p *stubProvider) Embed(_ context.Context, text string) ([]float32, error) {
+	if strings.TrimSpace(text) == "" {
+		return nil, errors.New("embedding: stub: empty text")
+	}
+	v := make([]float32, stubDim)
+	tokens := stubTokenise(text)
+	if len(tokens) == 0 {
+		// Tokenless text (e.g. all punctuation) still needs a deterministic
+		// vector so callers don't see different errors for empty vs. punct.
+		// We seed with a single bucket so the output is non-zero.
+		idx := stubBucket(text)
+		v[idx] = 1
+		return L2Normalise(v), nil
+	}
+	for _, tok := range tokens {
+		idx := stubBucket(tok)
+		v[idx]++
+	}
+	return L2Normalise(v), nil
+}
+
+// EmbedBatch runs Embed in a loop. We don't parallelise because the work
+// is microseconds — a goroutine pool would cost more than it saves.
+func (p *stubProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return nil, nil
+	}
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v, err := p.Embed(ctx, t)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+// stubTokenise lowercases and splits on non-alphanumeric runes. Mirrors
+// tokenizeForCluster in internal/team/notebook_signal_scanner.go so a
+// stub-provider scan produces clusters comparable to the Jaccard path.
+// Stop-words are intentionally NOT removed here — the cluster scoring
+// step handles stop-word noise via cosine threshold tuning.
+func stubTokenise(s string) []string {
+	var out []string
+	var current strings.Builder
+	flush := func() {
+		if current.Len() == 0 {
+			return
+		}
+		tok := current.String()
+		current.Reset()
+		if len(tok) <= 1 {
+			return
+		}
+		out = append(out, tok)
+	}
+	for _, r := range strings.ToLower(s) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			current.WriteRune(r)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return out
+}
+
+// stubBucket hashes a string into a [0..stubDim) bucket via FNV-1a.
+// Stable across Go versions and CPU architectures.
+func stubBucket(s string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(s))
+	return int(h.Sum32()) % stubDim
+}

--- a/internal/embedding/stub.go
+++ b/internal/embedding/stub.go
@@ -51,12 +51,18 @@ func (p *stubProvider) Dimension() int { return stubDim }
 // each token into a fixed-dim bucket, sums occurrences, and L2-normalises
 // the result. Returns an error on empty text so callers can't smuggle
 // a zero-vector through to the cluster layer.
-func (p *stubProvider) Embed(_ context.Context, text string) ([]float32, error) {
+func (p *stubProvider) Embed(ctx context.Context, text string) ([]float32, error) {
 	if strings.TrimSpace(text) == "" {
 		return nil, errors.New("embedding: stub: empty text")
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	v := make([]float32, stubDim)
 	tokens := stubTokenise(text)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(tokens) == 0 {
 		// Tokenless text (e.g. all punctuation) still needs a deterministic
 		// vector so callers don't see different errors for empty vs. punct.
@@ -66,6 +72,9 @@ func (p *stubProvider) Embed(_ context.Context, text string) ([]float32, error) 
 		return L2Normalise(v), nil
 	}
 	for _, tok := range tokens {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		idx := stubBucket(tok)
 		v[idx]++
 	}
@@ -124,5 +133,5 @@ func stubTokenise(s string) []string {
 func stubBucket(s string) int {
 	h := fnv.New32a()
 	_, _ = h.Write([]byte(s))
-	return int(h.Sum32()) % stubDim
+	return int(h.Sum32() % uint32(stubDim))
 }

--- a/internal/embedding/stub.go
+++ b/internal/embedding/stub.go
@@ -44,6 +44,9 @@ func NewStubProvider() Provider { return &stubProvider{} }
 // Name is "local-stub" so cache rows + log lines clearly mark stub data.
 func (p *stubProvider) Name() string { return "local-stub" }
 
+// CacheNamespace is stable because the stub has no external backend.
+func (p *stubProvider) CacheNamespace() string { return p.Name() }
+
 // Dimension is the fixed vector length.
 func (p *stubProvider) Dimension() int { return stubDim }
 

--- a/internal/embedding/stub_test.go
+++ b/internal/embedding/stub_test.go
@@ -59,6 +59,15 @@ func TestStubProvider_EmptyText(t *testing.T) {
 	}
 }
 
+func TestStubProvider_CancelledContext(t *testing.T) {
+	p := NewStubProvider()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := p.Embed(ctx, "deploy prod pipeline smoke tests"); err != context.Canceled {
+		t.Fatalf("cancelled context: got %v want %v", err, context.Canceled)
+	}
+}
+
 func TestStubProvider_BatchPreservesOrder(t *testing.T) {
 	p := NewStubProvider()
 	texts := []string{"first", "second", "third"}

--- a/internal/embedding/stub_test.go
+++ b/internal/embedding/stub_test.go
@@ -1,0 +1,122 @@
+package embedding
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStubProvider_Deterministic(t *testing.T) {
+	p := NewStubProvider()
+	ctx := context.Background()
+	got1, err := p.Embed(ctx, "deploy prod pipeline smoke tests")
+	if err != nil {
+		t.Fatalf("first embed: %v", err)
+	}
+	got2, err := p.Embed(ctx, "deploy prod pipeline smoke tests")
+	if err != nil {
+		t.Fatalf("second embed: %v", err)
+	}
+	if len(got1) != len(got2) || len(got1) != stubDim {
+		t.Fatalf("dimension: got %d/%d want %d", len(got1), len(got2), stubDim)
+	}
+	for i := range got1 {
+		if got1[i] != got2[i] {
+			t.Errorf("non-deterministic at index %d: %v vs %v", i, got1[i], got2[i])
+		}
+	}
+}
+
+func TestStubProvider_DistinctTexts(t *testing.T) {
+	p := NewStubProvider()
+	ctx := context.Background()
+	a, err := p.Embed(ctx, "deploy prod pipeline smoke tests")
+	if err != nil {
+		t.Fatalf("a: %v", err)
+	}
+	b, err := p.Embed(ctx, "marketing launch eyebrow copy rewrite")
+	if err != nil {
+		t.Fatalf("b: %v", err)
+	}
+	identical := true
+	for i := range a {
+		if a[i] != b[i] {
+			identical = false
+			break
+		}
+	}
+	if identical {
+		t.Error("stub vectors collided across distinct texts — hash buckets too small")
+	}
+}
+
+func TestStubProvider_EmptyText(t *testing.T) {
+	p := NewStubProvider()
+	if _, err := p.Embed(context.Background(), ""); err == nil {
+		t.Error("empty text should error")
+	}
+	if _, err := p.Embed(context.Background(), "   "); err == nil {
+		t.Error("whitespace-only text should error")
+	}
+}
+
+func TestStubProvider_BatchPreservesOrder(t *testing.T) {
+	p := NewStubProvider()
+	texts := []string{"first", "second", "third"}
+	out, err := p.EmbedBatch(context.Background(), texts)
+	if err != nil {
+		t.Fatalf("batch: %v", err)
+	}
+	if len(out) != len(texts) {
+		t.Fatalf("len: got %d want %d", len(out), len(texts))
+	}
+	for i, text := range texts {
+		single, err := p.Embed(context.Background(), text)
+		if err != nil {
+			t.Fatalf("single %d: %v", i, err)
+		}
+		for j := range single {
+			if out[i][j] != single[j] {
+				t.Errorf("batch row %d differs at %d: batch=%v single=%v", i, j, out[i][j], single[j])
+			}
+		}
+	}
+}
+
+func TestStubProvider_OverlappingTextsClusterTogether(t *testing.T) {
+	// The stub is hash-based, but two texts that share the same
+	// vocabulary should still produce vectors with a high cosine
+	// similarity. This test pins the stub's "good enough for tests"
+	// guarantee — if it ever drops, the notebook scanner test stops
+	// being a real signal.
+	p := NewStubProvider()
+	ctx := context.Background()
+	a, _ := p.Embed(ctx, "deploy prod pipeline smoke tests toggle flipping")
+	b, _ := p.Embed(ctx, "deploy prod pipeline smoke tests toggle flipping today")
+	c, _ := p.Embed(ctx, "marketing launch eyebrow copy rewrite founders")
+	if Cosine(a, b) < 0.8 {
+		t.Errorf("near-identical texts: cosine %v want >=0.8", Cosine(a, b))
+	}
+	if Cosine(a, c) > 0.5 {
+		t.Errorf("dissimilar texts: cosine %v want <=0.5", Cosine(a, c))
+	}
+}
+
+func TestStubProvider_Metadata(t *testing.T) {
+	p := NewStubProvider()
+	if p.Name() != "local-stub" {
+		t.Errorf("name: got %q want local-stub", p.Name())
+	}
+	if p.Dimension() != stubDim {
+		t.Errorf("dimension: got %d want %d", p.Dimension(), stubDim)
+	}
+}
+
+func TestNewDefault_FallsBackToStub(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("VOYAGE_API_KEY", "")
+	got := NewDefault()
+	if got.Name() != "local-stub" {
+		t.Errorf("default with no keys: got %q want local-stub", got.Name())
+	}
+}

--- a/internal/embedding/stub_test.go
+++ b/internal/embedding/stub_test.go
@@ -149,3 +149,55 @@ func TestNewDefault_VoyageKeyEnablesVoyage(t *testing.T) {
 		t.Fatalf("voyage key set: got %q want voyage-%s", got.Name(), defaultVoyageModel)
 	}
 }
+
+// TestEmbeddingDimensionOverride distinguishes "user explicitly set" from
+// "default kicked in". The Voyage provider relied on this distinction to
+// pick its 1024 default vs. honouring a user-set 1536 (e.g. for
+// voyage-code-2). Earlier code compared
+// `openAIDimensionFromEnv() == defaultOpenAIDim` (1536), which was true for
+// BOTH "unset" and "explicitly 1536", silently clobbering Voyage users on
+// 1536-dim models down to 1024.
+func TestEmbeddingDimensionOverride(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		t.Setenv("WUPHF_EMBEDDING_DIMENSION", "")
+		n, ok := embeddingDimensionOverride()
+		if ok {
+			t.Errorf("unset must return ok=false, got n=%d ok=true", n)
+		}
+	})
+	t.Run("explicit 1536 is honoured", func(t *testing.T) {
+		t.Setenv("WUPHF_EMBEDDING_DIMENSION", "1536")
+		n, ok := embeddingDimensionOverride()
+		if !ok || n != 1536 {
+			t.Errorf("explicit 1536 must return ok=true n=1536, got n=%d ok=%v", n, ok)
+		}
+	})
+	t.Run("explicit 512 is honoured", func(t *testing.T) {
+		t.Setenv("WUPHF_EMBEDDING_DIMENSION", "512")
+		n, ok := embeddingDimensionOverride()
+		if !ok || n != 512 {
+			t.Errorf("explicit 512: got n=%d ok=%v", n, ok)
+		}
+	})
+	t.Run("garbage falls back to default", func(t *testing.T) {
+		t.Setenv("WUPHF_EMBEDDING_DIMENSION", "not-a-number")
+		_, ok := embeddingDimensionOverride()
+		if ok {
+			t.Errorf("garbage must return ok=false")
+		}
+	})
+}
+
+// TestNewVoyageProvider_HonoursExplicitDimension pins the Voyage path: a
+// user on voyage-code-2 with WUPHF_EMBEDDING_DIMENSION=1536 must get a
+// 1536-dim provider, not 1024. We don't make a real HTTP call; the
+// provider's Dimension() reflects what would be sent.
+func TestNewVoyageProvider_HonoursExplicitDimension(t *testing.T) {
+	t.Setenv("VOYAGE_API_KEY", "voyage-real")
+	t.Setenv("WUPHF_EMBEDDING_MODEL", "voyage-code-2")
+	t.Setenv("WUPHF_EMBEDDING_DIMENSION", "1536")
+	got := newVoyageProvider()
+	if got.Dimension() != 1536 {
+		t.Fatalf("voyage with explicit 1536: got dim=%d want 1536", got.Dimension())
+	}
+}

--- a/internal/embedding/stub_test.go
+++ b/internal/embedding/stub_test.go
@@ -99,9 +99,18 @@ func TestStubProvider_OverlappingTextsClusterTogether(t *testing.T) {
 	// being a real signal.
 	p := NewStubProvider()
 	ctx := context.Background()
-	a, _ := p.Embed(ctx, "deploy prod pipeline smoke tests toggle flipping")
-	b, _ := p.Embed(ctx, "deploy prod pipeline smoke tests toggle flipping today")
-	c, _ := p.Embed(ctx, "marketing launch eyebrow copy rewrite founders")
+	a, err := p.Embed(ctx, "deploy prod pipeline smoke tests toggle flipping")
+	if err != nil {
+		t.Fatalf("a: %v", err)
+	}
+	b, err := p.Embed(ctx, "deploy prod pipeline smoke tests toggle flipping today")
+	if err != nil {
+		t.Fatalf("b: %v", err)
+	}
+	c, err := p.Embed(ctx, "marketing launch eyebrow copy rewrite founders")
+	if err != nil {
+		t.Fatalf("c: %v", err)
+	}
 	if Cosine(a, b) < 0.8 {
 		t.Errorf("near-identical texts: cosine %v want >=0.8", Cosine(a, b))
 	}

--- a/internal/embedding/stub_test.go
+++ b/internal/embedding/stub_test.go
@@ -120,3 +120,32 @@ func TestNewDefault_FallsBackToStub(t *testing.T) {
 		t.Errorf("default with no keys: got %q want local-stub", got.Name())
 	}
 }
+
+// TestNewDefault_AnthropicOnlyDoesNotLeakToVoyage guards against the
+// security blocker that was caught in PR review: an ANTHROPIC_API_KEY
+// alone must NOT be silently forwarded to api.voyageai.com as a Voyage
+// bearer. Voyage is a separate company and the key is invalid there
+// anyway — but more importantly it would be a cross-provider credential
+// leak. The user must explicitly set VOYAGE_API_KEY (or OPENAI_API_KEY)
+// to enable real embeddings.
+func TestNewDefault_AnthropicOnlyDoesNotLeakToVoyage(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-shouldnotleak")
+	t.Setenv("VOYAGE_API_KEY", "")
+	t.Setenv("OPENAI_API_KEY", "")
+	got := NewDefault()
+	if got.Name() != "local-stub" {
+		t.Fatalf("anthropic-only must fall back to stub, got %q", got.Name())
+	}
+}
+
+// TestNewDefault_VoyageKeyEnablesVoyage confirms the explicit opt-in
+// path still works.
+func TestNewDefault_VoyageKeyEnablesVoyage(t *testing.T) {
+	t.Setenv("VOYAGE_API_KEY", "voyage-real-key")
+	t.Setenv("OPENAI_API_KEY", "")
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	got := NewDefault()
+	if got.Name() != "voyage-"+defaultVoyageModel {
+		t.Fatalf("voyage key set: got %q want voyage-%s", got.Name(), defaultVoyageModel)
+	}
+}

--- a/internal/embedding/test_helpers_test.go
+++ b/internal/embedding/test_helpers_test.go
@@ -1,0 +1,8 @@
+package embedding
+
+import "os"
+
+// getEnvForTest is the test-only indirection for os.Getenv. Lets the
+// openai_test.go skip predicate read like prose without importing os in
+// every test file.
+func getEnvForTest(k string) string { return os.Getenv(k) }

--- a/internal/team/notebook_signal_scanner.go
+++ b/internal/team/notebook_signal_scanner.go
@@ -19,11 +19,18 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/nex-crm/wuphf/internal/embedding"
 )
 
 // NotebookSignalScanner walks team/agents/*/notebook/**/*.md and clusters
-// cross-agent entries by token-overlap similarity. Each qualifying cluster
-// becomes a SkillCandidate.
+// cross-agent entries — either by token-overlap similarity (legacy
+// Jaccard path) or by cosine similarity over real text embeddings (new
+// semantic path). Each qualifying cluster becomes a SkillCandidate.
+//
+// The two paths produce SkillCandidate values with the same shape; only
+// the clustering algorithm differs. embeddingClusteringEnabled (see
+// notebook_signal_scanner_embeddings.go) decides which path runs.
 type NotebookSignalScanner struct {
 	broker *Broker
 
@@ -31,6 +38,15 @@ type NotebookSignalScanner struct {
 	minDistinctAgents    int
 	similarityThreshold  float64
 	maxCandidatesPerPass int
+
+	// embeddingProvider is the pluggable text-embedding source for the
+	// semantic clustering path. Defaults to embedding.NewDefault() in
+	// NewNotebookSignalScanner; tests inject deterministic stubs via
+	// SetEmbeddingProvider.
+	embeddingProvider embedding.Provider
+	// embeddingCache memoises (text, model) → vector pairs across compile
+	// passes. Populated lazily; nil + empty path acts as a no-op.
+	embeddingCache *embedding.Cache
 }
 
 // NewNotebookSignalScanner constructs a scanner with defaults pulled from
@@ -47,7 +63,29 @@ func NewNotebookSignalScanner(b *Broker) *NotebookSignalScanner {
 		minDistinctAgents:    envIntDefault("WUPHF_STAGE_B_NOTEBOOK_MIN_AGENTS", 2),
 		similarityThreshold:  envFloatDefault("WUPHF_STAGE_B_NOTEBOOK_SIMILARITY", 0.6),
 		maxCandidatesPerPass: envIntDefault("WUPHF_STAGE_B_NOTEBOOK_MAX_PER_PASS", 10),
+		embeddingProvider:    embedding.NewDefault(),
+		embeddingCache:       embedding.NewCache(embedding.DefaultCachePath()),
 	}
+}
+
+// SetEmbeddingProvider replaces the embedding provider — primarily a
+// test seam so unit tests can dependency-inject a deterministic stub
+// without touching env vars. Passing nil restores the auto-default on
+// the next Scan call.
+func (s *NotebookSignalScanner) SetEmbeddingProvider(p embedding.Provider) {
+	if s == nil {
+		return
+	}
+	s.embeddingProvider = p
+}
+
+// SetEmbeddingCache replaces the embedding cache. Tests pass a temp-dir-
+// backed cache; production use the lazy default from RuntimeHomeDir.
+func (s *NotebookSignalScanner) SetEmbeddingCache(c *embedding.Cache) {
+	if s == nil {
+		return
+	}
+	s.embeddingCache = c
 }
 
 // Scan walks team/agents/*/notebook/**/*.md, tokenises each entry, clusters
@@ -79,7 +117,20 @@ func (s *NotebookSignalScanner) Scan(ctx context.Context) ([]SkillCandidate, err
 		return nil, fmt.Errorf("notebook_signal_scanner: ctx cancelled: %w", err)
 	}
 
-	clusters := clusterNotebookEntries(entries, s.similarityThreshold)
+	var clusters []notebookCluster
+	if embeddingClusteringEnabled(s.embeddingProvider) {
+		clusters = s.clusterNotebookEntriesByEmbedding(ctx, entries)
+		reportClusterCounts("notebook_embedding", clusters)
+		// Defensive fallback: if the embedding path produced no clusters
+		// (provider failure on every entry, no API key reachable, etc.)
+		// drop back to the Jaccard path so the scanner is regression-safe.
+		if len(clusters) == 0 {
+			slog.Warn("notebook_embedding_yielded_zero_clusters_falling_back_to_jaccard")
+			clusters = clusterNotebookEntries(entries, s.similarityThreshold)
+		}
+	} else {
+		clusters = clusterNotebookEntries(entries, s.similarityThreshold)
+	}
 	candidates := s.candidatesFromClusters(ctx, clusters)
 
 	// Stable order: highest SignalCount first; ties break on suggested name

--- a/internal/team/notebook_signal_scanner.go
+++ b/internal/team/notebook_signal_scanner.go
@@ -70,8 +70,8 @@ func NewNotebookSignalScanner(b *Broker) *NotebookSignalScanner {
 
 // SetEmbeddingProvider replaces the embedding provider — primarily a
 // test seam so unit tests can dependency-inject a deterministic stub
-// without touching env vars. Passing nil restores the auto-default on
-// the next Scan call.
+// without touching env vars. Passing nil disables embedding-based
+// clustering for this scanner until a non-nil provider is set.
 func (s *NotebookSignalScanner) SetEmbeddingProvider(p embedding.Provider) {
 	if s == nil {
 		return

--- a/internal/team/notebook_signal_scanner_embeddings.go
+++ b/internal/team/notebook_signal_scanner_embeddings.go
@@ -1,0 +1,295 @@
+package team
+
+// notebook_signal_scanner_embeddings.go is the semantic-clustering side of
+// the NotebookSignalScanner. It mirrors the Jaccard path in
+// notebook_signal_scanner.go but groups entries by cosine similarity over
+// real text embeddings instead of token-set overlap.
+//
+// The contract from the synthesizer's perspective is unchanged: emit
+// SkillCandidate values that pass minClusterSize + minDistinctAgents.
+// Only the clustering algorithm differs.
+//
+// Telemetry hooks live on b.skillCompileMetrics:
+//
+//	EmbeddingCallsTotal       — every Embed call (cache miss or live)
+//	EmbeddingCacheHitsTotal   — cache hit count
+//	EmbeddingCacheMissesTotal — cache miss count
+//	EmbeddingCostUsd          — running approximate USD cost (uint64-bits)
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"os"
+	"sort"
+	"strings"
+	"sync/atomic"
+
+	"github.com/nex-crm/wuphf/internal/embedding"
+)
+
+// defaultNotebookCosineThreshold is the cosine similarity floor used for
+// "same topic" semantic clustering. 0.8 is the documented default; the
+// env var WUPHF_STAGE_B_NOTEBOOK_COSINE_THRESHOLD overrides.
+const defaultNotebookCosineThreshold = 0.8
+
+// embeddingClusteringEnabled inspects the env to decide whether the
+// scanner should use the embedding path. The default is "true if a real
+// provider is configured, false otherwise" — i.e. callers running without
+// an API key (most CI environments) get the deterministic Jaccard path
+// for stable test outputs.
+//
+// Explicit overrides:
+//
+//	WUPHF_STAGE_B_USE_EMBEDDINGS=1     → force on
+//	WUPHF_STAGE_B_USE_EMBEDDINGS=0     → force off (regression-safe escape)
+//	WUPHF_STAGE_B_USE_EMBEDDINGS=auto  → default (treat empty as "auto")
+func embeddingClusteringEnabled(provider embedding.Provider) bool {
+	raw := strings.ToLower(strings.TrimSpace(os.Getenv("WUPHF_STAGE_B_USE_EMBEDDINGS")))
+	switch raw {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	}
+	if provider == nil {
+		return false
+	}
+	// Stub provider's vectors are not semantic — keep the deterministic
+	// Jaccard path for test runs that haven't configured a real provider.
+	return provider.Name() != "local-stub"
+}
+
+// clusterNotebookEntriesByEmbedding is the embedding counterpart to
+// clusterNotebookEntries (Jaccard). It embeds every entry, clusters by
+// cosine similarity, and returns notebookCluster values shaped the same
+// way the Jaccard path produces.
+//
+// Cache misses are logged + counted via b.skillCompileMetrics. Failures
+// fall through with the entries that did embed — clustering on a partial
+// set is better than emitting no signals.
+func (s *NotebookSignalScanner) clusterNotebookEntriesByEmbedding(ctx context.Context, entries []notebookEntry) []notebookCluster {
+	if len(entries) == 0 || s == nil || s.embeddingProvider == nil {
+		return nil
+	}
+	threshold := float32(s.embeddingCosineThreshold())
+
+	cacheTexts := make([]string, len(entries))
+	for i, e := range entries {
+		cacheTexts[i] = e.body
+	}
+
+	vectors := s.embedAllWithCache(ctx, cacheTexts)
+
+	clusterEntries := make([]embedding.ClusterEntry, 0, len(entries))
+	indexByID := map[string]int{} // ID → entries index
+	for i, vec := range vectors {
+		if len(vec) == 0 {
+			continue
+		}
+		id := entries[i].relPath
+		clusterEntries = append(clusterEntries, embedding.ClusterEntry{
+			ID:     id,
+			Text:   entries[i].body,
+			Vector: vec,
+		})
+		indexByID[id] = i
+	}
+
+	if len(clusterEntries) == 0 {
+		return nil
+	}
+
+	clusters, _ := embedding.ClusterByCosineWithSkipped(clusterEntries, threshold)
+
+	out := make([]notebookCluster, 0, len(clusters))
+	for _, c := range clusters {
+		members := make([]notebookEntry, 0, len(c.Entries))
+		centroid := map[string]bool{}
+		for _, ce := range c.Entries {
+			idx, ok := indexByID[ce.ID]
+			if !ok {
+				continue
+			}
+			members = append(members, entries[idx])
+			for k := range entries[idx].tokenSet {
+				centroid[k] = true
+			}
+		}
+		if len(members) == 0 {
+			continue
+		}
+		out = append(out, notebookCluster{
+			members:  members,
+			centroid: centroid,
+		})
+	}
+	return out
+}
+
+// embedAllWithCache returns one vector per input. Misses go through the
+// provider; hits come from the on-disk cache. Cost telemetry is updated
+// per call.
+//
+// Errors do not propagate: the provider may rate-limit or hit a network
+// blip on a single text. We log + skip and return an empty vector at
+// that index so the caller knows the entry is unusable.
+func (s *NotebookSignalScanner) embedAllWithCache(ctx context.Context, texts []string) [][]float32 {
+	out := make([][]float32, len(texts))
+	if s.embeddingProvider == nil {
+		return out
+	}
+	model := s.embeddingProvider.Name()
+
+	type pending struct {
+		text  string
+		index int
+	}
+	var misses []pending
+
+	for i, t := range texts {
+		if v, ok := s.embeddingCache.Get(t, model); ok {
+			out[i] = v
+			s.recordCacheHit()
+			continue
+		}
+		misses = append(misses, pending{text: t, index: i})
+	}
+
+	if len(misses) == 0 {
+		return out
+	}
+
+	missTexts := make([]string, len(misses))
+	for i, m := range misses {
+		missTexts[i] = m.text
+	}
+	vectors, err := s.embeddingProvider.EmbedBatch(ctx, missTexts)
+	s.recordCacheMiss(len(misses))
+	if err != nil {
+		slog.Warn("notebook_embedding_batch_failed",
+			"err", err, "model", model, "texts", len(misses))
+		return out
+	}
+	if len(vectors) != len(misses) {
+		slog.Warn("notebook_embedding_batch_mismatch",
+			"got", len(vectors), "want", len(misses), "model", model)
+		return out
+	}
+	for i, m := range misses {
+		out[m.index] = vectors[i]
+		_ = s.embeddingCache.Set(m.text, model, vectors[i])
+		s.recordEmbedCall(m.text)
+	}
+	return out
+}
+
+// embeddingCosineThreshold reads
+// WUPHF_STAGE_B_NOTEBOOK_COSINE_THRESHOLD or returns the default.
+// Clamped to [0,1] so a misconfigured env can't disable clustering.
+func (s *NotebookSignalScanner) embeddingCosineThreshold() float64 {
+	v := envFloatDefault("WUPHF_STAGE_B_NOTEBOOK_COSINE_THRESHOLD", defaultNotebookCosineThreshold)
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+// recordEmbedCall increments EmbeddingCallsTotal and adds an approximate
+// cost into EmbeddingCostUsd. Cost is text-embedding-3-small priced
+// (~$0.02 / 1M tokens). Tokens ≈ runes / 4. Wrong by a constant factor
+// for other models — set WUPHF_EMBEDDING_COST_PER_TOKEN_USD if your
+// model is meaningfully more expensive (Voyage voyage-3-large at
+// $0.18/1M tokens needs the override).
+func (s *NotebookSignalScanner) recordEmbedCall(text string) {
+	if s == nil || s.broker == nil {
+		return
+	}
+	atomic.AddInt64(&s.broker.skillCompileMetrics.EmbeddingCallsTotal, 1)
+	tokens := approxTokenCount(text)
+	cost := float64(tokens) * embeddingCostPerTokenUsd()
+	addFloatBits(&s.broker.skillCompileMetrics.EmbeddingCostUsdBits, cost)
+}
+
+// recordCacheHit / recordCacheMiss bump the corresponding atomic counters.
+func (s *NotebookSignalScanner) recordCacheHit() {
+	if s == nil || s.broker == nil {
+		return
+	}
+	atomic.AddInt64(&s.broker.skillCompileMetrics.EmbeddingCacheHitsTotal, 1)
+}
+
+func (s *NotebookSignalScanner) recordCacheMiss(n int) {
+	if s == nil || s.broker == nil || n <= 0 {
+		return
+	}
+	atomic.AddInt64(&s.broker.skillCompileMetrics.EmbeddingCacheMissesTotal, int64(n))
+}
+
+// approxTokenCount returns runes/4, the rule-of-thumb token estimate.
+// Real tokenisers diverge; this is intentionally cheap.
+func approxTokenCount(text string) int {
+	r := len([]rune(text))
+	if r == 0 {
+		return 0
+	}
+	t := r / 4
+	if t == 0 {
+		t = 1
+	}
+	return t
+}
+
+// embeddingCostPerTokenUsd returns the per-token USD cost. Default is
+// $0.02 / 1M tokens (text-embedding-3-small). Override with
+// WUPHF_EMBEDDING_COST_PER_TOKEN_USD for other models.
+func embeddingCostPerTokenUsd() float64 {
+	const defaultCost = 0.02 / 1_000_000.0
+	v := envFloatDefault("WUPHF_EMBEDDING_COST_PER_TOKEN_USD", defaultCost)
+	if v < 0 {
+		return defaultCost
+	}
+	return v
+}
+
+// addFloatBits atomically adds delta to the float64 stored in slot using
+// math.Float64bits. The compare-and-swap loop handles concurrent
+// writers — a slow goroutine retries until its read-modify-write reflects
+// the latest value.
+func addFloatBits(slot *uint64, delta float64) {
+	for {
+		oldBits := atomic.LoadUint64(slot)
+		oldVal := math.Float64frombits(oldBits)
+		newVal := oldVal + delta
+		if atomic.CompareAndSwapUint64(slot, oldBits, math.Float64bits(newVal)) {
+			return
+		}
+	}
+}
+
+// loadFloatBits atomically reads the float64 in slot.
+func loadFloatBits(slot *uint64) float64 {
+	return math.Float64frombits(atomic.LoadUint64(slot))
+}
+
+// reportClusterCounts logs the cluster shape for telemetry parity with
+// the Jaccard path. Lives here so the embedding code-path is fully
+// observable without spreading slog calls through the scanner.
+func reportClusterCounts(prefix string, clusters []notebookCluster) {
+	if len(clusters) == 0 {
+		return
+	}
+	sizes := make([]int, len(clusters))
+	for i, c := range clusters {
+		sizes[i] = len(c.members)
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(sizes)))
+	slog.Debug(prefix+"_cluster_sizes",
+		"clusters", len(clusters),
+		"sizes", fmt.Sprintf("%v", sizes),
+	)
+}

--- a/internal/team/notebook_signal_scanner_embeddings.go
+++ b/internal/team/notebook_signal_scanner_embeddings.go
@@ -101,7 +101,13 @@ func (s *NotebookSignalScanner) clusterNotebookEntriesByEmbedding(ctx context.Co
 		return nil
 	}
 
-	clusters, _ := embedding.ClusterByCosineWithSkipped(clusterEntries, threshold)
+	clusters, skipped := embedding.ClusterByCosineWithSkipped(clusterEntries, threshold)
+	if len(skipped) > 0 {
+		slog.Warn("notebook_embedding_skipped_dimension_mismatch",
+			"skipped", len(skipped),
+			"model", s.embeddingProvider.Name(),
+			"expected_dim", s.embeddingProvider.Dimension())
+	}
 
 	out := make([]notebookCluster, 0, len(clusters))
 	for _, c := range clusters {
@@ -161,26 +167,37 @@ func (s *NotebookSignalScanner) embedAllWithCache(ctx context.Context, texts []s
 		return out
 	}
 
-	missTexts := make([]string, len(misses))
-	for i, m := range misses {
-		missTexts[i] = m.text
+	uniqueIndex := make(map[string]int, len(misses))
+	uniqueMissTexts := make([]string, 0, len(misses))
+	indicesByUnique := make([][]int, 0, len(misses))
+	for _, m := range misses {
+		if idx, ok := uniqueIndex[m.text]; ok {
+			indicesByUnique[idx] = append(indicesByUnique[idx], m.index)
+			continue
+		}
+		uniqueIndex[m.text] = len(uniqueMissTexts)
+		uniqueMissTexts = append(uniqueMissTexts, m.text)
+		indicesByUnique = append(indicesByUnique, []int{m.index})
 	}
-	vectors, err := s.embeddingProvider.EmbedBatch(ctx, missTexts)
-	s.recordCacheMiss(len(misses))
+
+	vectors, err := s.embeddingProvider.EmbedBatch(ctx, uniqueMissTexts)
+	s.recordCacheMiss(len(uniqueMissTexts))
 	if err != nil {
 		slog.Warn("notebook_embedding_batch_failed",
-			"err", err, "model", model, "texts", len(misses))
+			"err", err, "model", model, "texts", len(uniqueMissTexts))
 		return out
 	}
-	if len(vectors) != len(misses) {
+	if len(vectors) != len(uniqueMissTexts) {
 		slog.Warn("notebook_embedding_batch_mismatch",
-			"got", len(vectors), "want", len(misses), "model", model)
+			"got", len(vectors), "want", len(uniqueMissTexts), "model", model)
 		return out
 	}
-	for i, m := range misses {
-		out[m.index] = vectors[i]
-		_ = s.embeddingCache.Set(m.text, model, vectors[i])
-		s.recordEmbedCall(m.text)
+	for i, text := range uniqueMissTexts {
+		for _, originalIndex := range indicesByUnique[i] {
+			out[originalIndex] = vectors[i]
+		}
+		_ = s.embeddingCache.Set(text, model, vectors[i])
+		s.recordEmbedCall(text)
 	}
 	return out
 }

--- a/internal/team/notebook_signal_scanner_embeddings.go
+++ b/internal/team/notebook_signal_scanner_embeddings.go
@@ -147,6 +147,8 @@ func (s *NotebookSignalScanner) embedAllWithCache(ctx context.Context, texts []s
 		return out
 	}
 	model := s.embeddingProvider.Name()
+	cacheNamespace := embedding.ProviderCacheNamespace(s.embeddingProvider)
+	cacheDimension := s.embeddingProvider.Dimension()
 
 	type pending struct {
 		text  string
@@ -155,7 +157,7 @@ func (s *NotebookSignalScanner) embedAllWithCache(ctx context.Context, texts []s
 	var misses []pending
 
 	for i, t := range texts {
-		if v, ok := s.embeddingCache.Get(t, model); ok {
+		if v, ok := s.embeddingCache.GetScoped(t, model, cacheNamespace, cacheDimension); ok {
 			out[i] = v
 			s.recordCacheHit()
 			continue
@@ -196,7 +198,7 @@ func (s *NotebookSignalScanner) embedAllWithCache(ctx context.Context, texts []s
 		for _, originalIndex := range indicesByUnique[i] {
 			out[originalIndex] = vectors[i]
 		}
-		_ = s.embeddingCache.Set(text, model, vectors[i])
+		_ = s.embeddingCache.SetScoped(text, model, cacheNamespace, vectors[i])
 		s.recordEmbedCall(text)
 	}
 	return out

--- a/internal/team/notebook_signal_scanner_embeddings_test.go
+++ b/internal/team/notebook_signal_scanner_embeddings_test.go
@@ -1,0 +1,222 @@
+package team
+
+import (
+	"context"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/embedding"
+)
+
+// stableEmbeddingProvider is a tiny test stub that returns hand-crafted
+// vectors keyed off the input text's first token. Lets us pin clusters
+// to specific assertions without depending on the FNV-bucket arithmetic
+// inside the production stub provider.
+type stableEmbeddingProvider struct {
+	dim     int
+	vectors map[string][]float32
+}
+
+func (p *stableEmbeddingProvider) Name() string   { return "test-stable" }
+func (p *stableEmbeddingProvider) Dimension() int { return p.dim }
+
+func (p *stableEmbeddingProvider) Embed(_ context.Context, text string) ([]float32, error) {
+	if v, ok := p.vectors[text]; ok {
+		return embedding.L2Normalise(v), nil
+	}
+	// Default: random non-clustering vector keyed off length so distinct
+	// inputs land in different buckets but never close to each other.
+	v := make([]float32, p.dim)
+	v[len(text)%p.dim] = 1
+	return embedding.L2Normalise(v), nil
+}
+
+func (p *stableEmbeddingProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, t := range texts {
+		v, err := p.Embed(ctx, t)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+// newStableEmbeddingProvider builds a provider whose vectors are dense,
+// not sparse — sparse vectors over a 4-dim space alias too easily.
+func newStableEmbeddingProvider(t *testing.T, vecs map[string][]float32) *stableEmbeddingProvider {
+	t.Helper()
+	return &stableEmbeddingProvider{dim: 4, vectors: vecs}
+}
+
+func TestNotebookSignalScanner_EmbeddingPath_ClustersByCosine(t *testing.T) {
+	t.Setenv("WUPHF_STAGE_B_USE_EMBEDDINGS", "1")
+
+	b, root, teardown := newNotebookScannerHarness(t)
+	defer teardown()
+
+	bodyA := "deploy prod pipeline smoke tests"
+	bodyB := "shipping prod release with smoke tests today"
+	bodyC := "rolling deploy to prod cluster after smoke tests passed"
+
+	writeNotebookEntry(t, root, "alice", "2026-04-22", bodyA)
+	writeNotebookEntry(t, root, "bob", "2026-04-23", bodyB)
+	writeNotebookEntry(t, root, "carol", "2026-04-24", bodyC)
+
+	// Wire all three bodies to nearly-identical vectors so cosine
+	// similarity passes the 0.8 default threshold even though their
+	// token sets only partially overlap (the Jaccard path would not
+	// merge them as cleanly).
+	provider := newStableEmbeddingProvider(t, map[string][]float32{
+		bodyA: {1, 0.05, 0.05, 0.02},
+		bodyB: {0.95, 0.1, 0.07, 0.05},
+		bodyC: {0.97, 0.02, 0.08, 0.04},
+	})
+
+	scanner := NewNotebookSignalScanner(b)
+	scanner.SetEmbeddingProvider(provider)
+	scanner.SetEmbeddingCache(embedding.NewCache(filepath.Join(t.TempDir(), "cache.jsonl")))
+
+	cands, err := scanner.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 candidate, got %d (%+v)", len(cands), cands)
+	}
+	if cands[0].SignalCount != 3 {
+		t.Errorf("signal count: got %d want 3", cands[0].SignalCount)
+	}
+	if got := atomic.LoadInt64(&b.skillCompileMetrics.EmbeddingCallsTotal); got != 3 {
+		t.Errorf("embedding calls: got %d want 3", got)
+	}
+	if got := atomic.LoadInt64(&b.skillCompileMetrics.EmbeddingCacheMissesTotal); got != 3 {
+		t.Errorf("cache misses: got %d want 3", got)
+	}
+	if cost := loadFloatBits(&b.skillCompileMetrics.EmbeddingCostUsdBits); cost <= 0 {
+		t.Errorf("cost: got %v want > 0", cost)
+	}
+}
+
+func TestNotebookSignalScanner_EmbeddingPath_RejectsSingleton(t *testing.T) {
+	t.Setenv("WUPHF_STAGE_B_USE_EMBEDDINGS", "1")
+
+	b, root, teardown := newNotebookScannerHarness(t)
+	defer teardown()
+
+	writeNotebookEntry(t, root, "alice", "2026-04-22", "lonely entry not enough to cluster")
+
+	provider := newStableEmbeddingProvider(t, map[string][]float32{
+		"lonely entry not enough to cluster": {1, 0, 0, 0},
+	})
+	scanner := NewNotebookSignalScanner(b)
+	scanner.SetEmbeddingProvider(provider)
+	scanner.SetEmbeddingCache(embedding.NewCache(filepath.Join(t.TempDir(), "cache.jsonl")))
+
+	cands, err := scanner.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 candidates, got %d", len(cands))
+	}
+}
+
+func TestNotebookSignalScanner_EmbeddingPath_CacheHitsNoOp(t *testing.T) {
+	t.Setenv("WUPHF_STAGE_B_USE_EMBEDDINGS", "1")
+
+	b, root, teardown := newNotebookScannerHarness(t)
+	defer teardown()
+
+	bodyA := "embedding cache test entry alpha"
+	bodyB := "embedding cache test entry beta"
+	bodyC := "embedding cache test entry gamma"
+
+	writeNotebookEntry(t, root, "alice", "2026-04-22", bodyA)
+	writeNotebookEntry(t, root, "bob", "2026-04-23", bodyB)
+	writeNotebookEntry(t, root, "carol", "2026-04-24", bodyC)
+
+	provider := newStableEmbeddingProvider(t, map[string][]float32{
+		bodyA: {1, 0.05, 0.05, 0.02},
+		bodyB: {0.95, 0.1, 0.07, 0.05},
+		bodyC: {0.97, 0.02, 0.08, 0.04},
+	})
+	cache := embedding.NewCache(filepath.Join(t.TempDir(), "cache.jsonl"))
+
+	scanner := NewNotebookSignalScanner(b)
+	scanner.SetEmbeddingProvider(provider)
+	scanner.SetEmbeddingCache(cache)
+
+	if _, err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("first scan: %v", err)
+	}
+
+	missesAfterFirst := atomic.LoadInt64(&b.skillCompileMetrics.EmbeddingCacheMissesTotal)
+	if missesAfterFirst != 3 {
+		t.Fatalf("first scan misses: got %d want 3", missesAfterFirst)
+	}
+
+	// Second scan: every text should hit the cache, so cache misses do
+	// not increase. Cache hits go up by 3.
+	if _, err := scanner.Scan(context.Background()); err != nil {
+		t.Fatalf("second scan: %v", err)
+	}
+
+	missesAfterSecond := atomic.LoadInt64(&b.skillCompileMetrics.EmbeddingCacheMissesTotal)
+	hitsAfterSecond := atomic.LoadInt64(&b.skillCompileMetrics.EmbeddingCacheHitsTotal)
+	if missesAfterSecond != missesAfterFirst {
+		t.Errorf("second scan should not miss: got %d want %d", missesAfterSecond, missesAfterFirst)
+	}
+	if hitsAfterSecond < 3 {
+		t.Errorf("hits: got %d want >=3", hitsAfterSecond)
+	}
+}
+
+func TestEmbeddingClusteringEnabled_RespectsEnv(t *testing.T) {
+	provider := embedding.NewStubProvider()
+
+	t.Setenv("WUPHF_STAGE_B_USE_EMBEDDINGS", "")
+	if embeddingClusteringEnabled(provider) {
+		t.Error("auto + stub provider: should not be enabled")
+	}
+
+	t.Setenv("WUPHF_STAGE_B_USE_EMBEDDINGS", "1")
+	if !embeddingClusteringEnabled(provider) {
+		t.Error("force-on: should override stub-provider default")
+	}
+
+	t.Setenv("WUPHF_STAGE_B_USE_EMBEDDINGS", "0")
+	if embeddingClusteringEnabled(provider) {
+		t.Error("force-off: should disable even with real provider")
+	}
+
+	t.Setenv("WUPHF_STAGE_B_USE_EMBEDDINGS", "")
+	if embeddingClusteringEnabled(nil) {
+		t.Error("nil provider: should not be enabled")
+	}
+}
+
+func TestApproxTokenCount(t *testing.T) {
+	if got := approxTokenCount(""); got != 0 {
+		t.Errorf("empty: got %d want 0", got)
+	}
+	if got := approxTokenCount("abcd"); got != 1 {
+		t.Errorf("4 runes: got %d want 1", got)
+	}
+	if got := approxTokenCount("a"); got != 1 {
+		t.Errorf("single rune: got %d want 1", got)
+	}
+}
+
+func TestAddFloatBits_AccumulatesAtomically(t *testing.T) {
+	var slot uint64
+	for i := 0; i < 5; i++ {
+		addFloatBits(&slot, 0.1)
+	}
+	got := loadFloatBits(&slot)
+	if got < 0.49 || got > 0.51 {
+		t.Errorf("got %v want ~0.5", got)
+	}
+}

--- a/internal/team/notebook_signal_scanner_embeddings_test.go
+++ b/internal/team/notebook_signal_scanner_embeddings_test.go
@@ -14,8 +14,10 @@ import (
 // to specific assertions without depending on the FNV-bucket arithmetic
 // inside the production stub provider.
 type stableEmbeddingProvider struct {
-	dim     int
-	vectors map[string][]float32
+	dim         int
+	vectors     map[string][]float32
+	batchCalls  int
+	batchInputs int
 }
 
 func (p *stableEmbeddingProvider) Name() string   { return "test-stable" }
@@ -33,6 +35,8 @@ func (p *stableEmbeddingProvider) Embed(_ context.Context, text string) ([]float
 }
 
 func (p *stableEmbeddingProvider) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	p.batchCalls++
+	p.batchInputs += len(texts)
 	out := make([][]float32, len(texts))
 	for i, t := range texts {
 		v, err := p.Embed(ctx, t)
@@ -171,6 +175,39 @@ func TestNotebookSignalScanner_EmbeddingPath_CacheHitsNoOp(t *testing.T) {
 	}
 	if hitsAfterSecond < 3 {
 		t.Errorf("hits: got %d want >=3", hitsAfterSecond)
+	}
+}
+
+func TestNotebookSignalScanner_EmbeddingPath_DedupesBatchMisses(t *testing.T) {
+	b, _, teardown := newNotebookScannerHarness(t)
+	defer teardown()
+
+	bodyA := "embedding cache duplicate alpha"
+	bodyB := "embedding cache duplicate beta"
+	provider := newStableEmbeddingProvider(t, map[string][]float32{
+		bodyA: {1, 0.05, 0.05, 0.02},
+		bodyB: {0.95, 0.1, 0.07, 0.05},
+	})
+
+	scanner := NewNotebookSignalScanner(b)
+	scanner.SetEmbeddingProvider(provider)
+	scanner.SetEmbeddingCache(embedding.NewCache(filepath.Join(t.TempDir(), "cache.jsonl")))
+
+	got := scanner.embedAllWithCache(context.Background(), []string{bodyA, bodyA, bodyB})
+	if len(got) != 3 {
+		t.Fatalf("vectors: got %d want 3", len(got))
+	}
+	if provider.batchCalls != 1 {
+		t.Fatalf("batch calls: got %d want 1", provider.batchCalls)
+	}
+	if provider.batchInputs != 2 {
+		t.Fatalf("batch inputs: got %d want 2 unique texts", provider.batchInputs)
+	}
+	if calls := atomic.LoadInt64(&b.skillCompileMetrics.EmbeddingCallsTotal); calls != 2 {
+		t.Fatalf("embedding calls: got %d want 2 unique texts", calls)
+	}
+	if misses := atomic.LoadInt64(&b.skillCompileMetrics.EmbeddingCacheMissesTotal); misses != 2 {
+		t.Fatalf("cache misses: got %d want 2 unique texts", misses)
 	}
 }
 

--- a/internal/team/skill_compile.go
+++ b/internal/team/skill_compile.go
@@ -67,6 +67,24 @@ type SkillCompileMetrics struct {
 	// or by the post-LLM sanity checks (parse failures, name regex, body
 	// heading missing, length checks, etc.).
 	SelfHealLLMRejections int64
+	// EmbeddingCallsTotal is incremented every time the notebook scanner
+	// computes a fresh embedding (cache miss path). Cache hits do NOT
+	// bump this counter — see EmbeddingCacheHitsTotal.
+	EmbeddingCallsTotal int64
+	// EmbeddingCacheHitsTotal counts on-disk cache hits across all
+	// embedding paths. A high hit ratio is the goal — we never want to
+	// re-embed the same entry once it has stabilised in the cache.
+	EmbeddingCacheHitsTotal int64
+	// EmbeddingCacheMissesTotal counts cache misses (live API calls).
+	// EmbeddingCallsTotal == EmbeddingCacheMissesTotal in steady state;
+	// the two diverge when a single batched API call fans out to N
+	// per-text Set events.
+	EmbeddingCacheMissesTotal int64
+	// EmbeddingCostUsdBits stores a float64 USD cost using
+	// math.Float64bits. Updated via addFloatBits / loadFloatBits in
+	// notebook_signal_scanner_embeddings.go so reads + writes are
+	// lock-free.
+	EmbeddingCostUsdBits uint64
 }
 
 // snapshotSkillCompileMetrics returns a copy of m suitable for serialization.
@@ -88,6 +106,10 @@ func snapshotSkillCompileMetrics(m *SkillCompileMetrics) SkillCompileMetrics {
 		SelfHealCandidatesScanned:     atomic.LoadInt64(&m.SelfHealCandidatesScanned),
 		SelfHealSkillsSynthesized:     atomic.LoadInt64(&m.SelfHealSkillsSynthesized),
 		SelfHealLLMRejections:         atomic.LoadInt64(&m.SelfHealLLMRejections),
+		EmbeddingCallsTotal:           atomic.LoadInt64(&m.EmbeddingCallsTotal),
+		EmbeddingCacheHitsTotal:       atomic.LoadInt64(&m.EmbeddingCacheHitsTotal),
+		EmbeddingCacheMissesTotal:     atomic.LoadInt64(&m.EmbeddingCacheMissesTotal),
+		EmbeddingCostUsdBits:          atomic.LoadUint64(&m.EmbeddingCostUsdBits),
 	}
 }
 

--- a/internal/team/skill_compile_endpoints.go
+++ b/internal/team/skill_compile_endpoints.go
@@ -87,6 +87,11 @@ type skillCompileStatsResponse struct {
 	SelfHealCandidatesScanned     int64                          `json:"self_heal_candidates_scanned"`
 	SelfHealSkillsSynthesized     int64                          `json:"self_heal_skills_synthesized"`
 	SelfHealLLMRejections         int64                          `json:"self_heal_llm_rejections"`
+	// Embedding pipeline telemetry (Stage B semantic clustering).
+	EmbeddingCallsTotal       int64   `json:"embedding_calls_total"`
+	EmbeddingCacheHitsTotal   int64   `json:"embedding_cache_hits_total"`
+	EmbeddingCacheMissesTotal int64   `json:"embedding_cache_misses_total"`
+	EmbeddingCostUsd          float64 `json:"embedding_cost_usd"`
 }
 
 // handleGetSkillCompileStats returns a snapshot of the compile metrics.
@@ -113,6 +118,10 @@ func (b *Broker) handleGetSkillCompileStats(w http.ResponseWriter, r *http.Reque
 		SelfHealCandidatesScanned:     snap.SelfHealCandidatesScanned,
 		SelfHealSkillsSynthesized:     snap.SelfHealSkillsSynthesized,
 		SelfHealLLMRejections:         snap.SelfHealLLMRejections,
+		EmbeddingCallsTotal:           snap.EmbeddingCallsTotal,
+		EmbeddingCacheHitsTotal:       snap.EmbeddingCacheHitsTotal,
+		EmbeddingCacheMissesTotal:     snap.EmbeddingCacheMissesTotal,
+		EmbeddingCostUsd:              loadFloatBits(&snap.EmbeddingCostUsdBits),
 	}
 	if counter != nil {
 		resp.CounterPerAgent = counter.Stats()

--- a/internal/team/skill_compile_endpoints.go
+++ b/internal/team/skill_compile_endpoints.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -121,7 +122,9 @@ func (b *Broker) handleGetSkillCompileStats(w http.ResponseWriter, r *http.Reque
 		EmbeddingCallsTotal:           snap.EmbeddingCallsTotal,
 		EmbeddingCacheHitsTotal:       snap.EmbeddingCacheHitsTotal,
 		EmbeddingCacheMissesTotal:     snap.EmbeddingCacheMissesTotal,
-		EmbeddingCostUsd:              loadFloatBits(&snap.EmbeddingCostUsdBits),
+		// snap is a value-copy already loaded atomically by snapshotSkillCompileMetrics —
+		// no atomic load needed on the local copy, just convert the bits.
+		EmbeddingCostUsd: math.Float64frombits(snap.EmbeddingCostUsdBits),
 	}
 	if counter != nil {
 		resp.CounterPerAgent = counter.Stats()


### PR DESCRIPTION
## Summary

- New `internal/embedding` package: tiny `Provider` interface, OpenAI-compatible HTTP client (works against OpenAI / Azure / Mistral / local mlx-lm via `OPENAI_BASE_URL`), Anthropic provider that routes through Voyage AI (Anthropic-recommended companion since they have not shipped a native embeddings endpoint yet), and a deterministic stub for tests.
- Greedy `ClusterByCosine` plus a JSONL append-only cache keyed by `SHA-256(text) + model` with 10MiB rotation, so repeat scans hit the cache instead of paying for live calls.
- `NotebookSignalScanner` now branches on `WUPHF_STAGE_B_USE_EMBEDDINGS` and clusters by cosine similarity when enabled (default 0.8 via `WUPHF_STAGE_B_NOTEBOOK_COSINE_THRESHOLD`). Jaccard path stays as the regression-safe fallback so CI without API keys still works.
- Surfaced 4 new atomics on `SkillCompileMetrics` and `GET /skills/compile/stats`: `embedding_calls_total`, `embedding_cache_hits_total`, `embedding_cache_misses_total`, `embedding_cost_usd`.

## Design notes

- **Provider preference order** (`embedding.NewDefault`): `ANTHROPIC_API_KEY` -> Voyage `voyage-3-large` (1024 dims), `OPENAI_API_KEY` -> `text-embedding-3-small` (1536 dims), else `local-stub` (32 dims, deterministic, NOT semantic).
- **Cost telemetry**: tokens approximated as `runes / 4`. Default rate $0.02 / 1M tokens (text-embedding-3-small); override via `WUPHF_EMBEDDING_COST_PER_TOKEN_USD` for Voyage / other models. Stored via `math.Float64bits` for lock-free atomic accumulation.
- **No vector DB**, no Python runtime, no new module dependencies. JSONL + map keeps the surface auditable.
- **Stub path is the floor** — `NewDefault` never returns nil. Stub vectors are NOT semantically meaningful; they only guarantee determinism so the Jaccard path stays the source of truth in CI.
- Embedding path falls through to Jaccard if every provider call fails — clustering on partial signal is better than emitting nothing.

## Env vars

| Var | Default | Notes |
|---|---|---|
| `ANTHROPIC_API_KEY` | - | Selects Voyage provider (or set `VOYAGE_API_KEY` to override) |
| `OPENAI_API_KEY` | - | Selects OpenAI provider |
| `OPENAI_BASE_URL` | `https://api.openai.com` | Points at any OpenAI-compat host |
| `WUPHF_EMBEDDING_MODEL` | `text-embedding-3-small` | Overrides the model |
| `WUPHF_EMBEDDING_DIMENSION` | 1536 (OpenAI) / 1024 (Voyage) | Overrides dim sanity check |
| `WUPHF_EMBEDDING_TIMEOUT` | `30s` | HTTP timeout |
| `WUPHF_EMBEDDING_CACHE_PATH` | `$WUPHF_HOME/.wuphf/cache/embeddings.jsonl` | Override path |
| `WUPHF_EMBEDDING_CACHE` | enabled | Set `disabled` to fully opt out |
| `WUPHF_EMBEDDING_COST_PER_TOKEN_USD` | 2e-8 | Override per-token USD rate |
| `WUPHF_STAGE_B_USE_EMBEDDINGS` | auto | `1`/`0` to force on / off |
| `WUPHF_STAGE_B_NOTEBOOK_COSINE_THRESHOLD` | 0.8 | Same-topic floor |

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/embedding/... ./internal/team/ -run 'Cluster|Cosine|Stub|NotebookSignal' -count=1 -race`
- [x] `bash scripts/test-go.sh ./internal/team` (full team suite green)
- [x] `go test ./internal/team/ -run 'SkillCompile|SkillSynth|StageB|SkillProposal' -count=1` (no regressions)
- [ ] Manual: live OpenAI run with a real key on a 3-agent notebook fixture; verify the new counters move on `GET /skills/compile/stats`
- [ ] Manual: confirm dev port isolation (broker on 7899/7900) when smoke-testing with a real provider
- [ ] Decide on the 75-min time-box follow-up: we should consider adding a streaming embed path so a single notebook scan does not block on N sequential live calls when the cache is cold

## Files

- New: `internal/embedding/{embedding,openai,anthropic,stub,cluster,cache}.go` + tests
- Modified: `internal/team/notebook_signal_scanner.go` (add provider/cache fields + branch), `internal/team/skill_compile.go` (add 4 metrics), `internal/team/skill_compile_endpoints.go` (surface metrics), new `internal/team/notebook_signal_scanner_embeddings{,_test}.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedding-based semantic clustering for notebook analysis with selectable providers (Voyage/OpenAI) and deterministic local stub fallback, opt-in controls, on-disk caching, and telemetry for calls, hits, misses, and estimated cost.
  * Persistent, append-only embedding cache with rotation and safe load behavior to reduce redundant API calls and cost.
  * Embedding utilities (cosine, L2-normalise) and provider selection logic.

* **Tests**
  * Extensive unit tests covering providers, cache behavior/rotation, clustering, and notebook scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->