### PR TITLE
feat(skills): Hermes-style per-agent skill-review nudge counter

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -575,6 +576,13 @@ type Broker struct {
 	skillSynthesizer    *SkillSynthesizer
 	skillSynthInflight  bool
 	skillSynthCoalesced bool
+	// Hermes-style per-agent activity counter (Stage B'). Increments on
+	// every agent MCP tool call; resets on team_skill_create / team_skill_patch;
+	// fires a "skill_review_nudge" task when the threshold is crossed. Owns
+	// its own mutex so it can be hit from the tool-event hot path without
+	// blocking on b.mu. Lazily constructed by ensureSkillCounter so tests
+	// that never spawn a real agent pay no cost.
+	skillCounter *SkillCounter
 	// recentlyRejectedSkills holds in-memory snapshots of skills rejected in
 	// the last 60s so /skills/reject/undo can restore them. Keyed by undo
 	// token. Guarded by b.mu. See skill_crud_endpoints.go for GC semantics.
@@ -2279,15 +2287,116 @@ func (b *Broker) handleAgentToolEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	stream := b.AgentStream(slug)
-	if stream == nil {
-		w.WriteHeader(http.StatusOK)
+	if stream != nil {
+		line := formatAgentToolEvent(body.Phase, body.Tool, body.Args, body.Result, body.Error)
+		if line != "" {
+			stream.Push(line)
+		}
+	}
+
+	// Drive the Hermes counter. We only count once per tool call so we
+	// branch on phase=="call" — the call/result/error fan-out from a
+	// single tool invocation must NOT triple-count. team_skill_create /
+	// team_skill_patch reset the tally; everything else increments and
+	// may fire a skill_review_nudge task.
+	b.recordAgentToolEvent(slug, body.Phase, body.Tool, body.Args)
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// recordAgentToolEvent updates the broker's SkillCounter for one
+// tool-event payload. It is split out from handleAgentToolEvent so tests
+// can drive the counter directly without going through HTTP, and so the
+// b.mu acquisition for the nudge task creation is centralized in one
+// place.
+//
+// We only act on phase=="call" — the call/result/error fan-out per tool
+// invocation must not triple-count. Empty phase is treated as "call" for
+// backward compatibility; older agents that didn't tag the phase still
+// only post one event per call.
+func (b *Broker) recordAgentToolEvent(slug, phase, tool, args string) {
+	slug = strings.TrimSpace(slug)
+	tool = strings.TrimSpace(tool)
+	if slug == "" || tool == "" {
 		return
 	}
-	line := formatAgentToolEvent(body.Phase, body.Tool, body.Args, body.Result, body.Error)
-	if line != "" {
-		stream.Push(line)
+	phase = strings.TrimSpace(phase)
+	if phase != "" && phase != "call" {
+		// result / error events from the same call — already counted.
+		return
 	}
-	w.WriteHeader(http.StatusOK)
+	counter := b.ensureSkillCounter()
+	if counter == nil {
+		return
+	}
+
+	// Skill-authoring tools reset the counter (the agent just codified
+	// something). Everything else increments.
+	if IsSkillAuthoringTool(tool) {
+		counter.Reset(slug)
+		return
+	}
+
+	summary := skillCounterSummaryFromArgs(tool, args)
+	shouldNudge, _ := counter.Increment(slug, tool, summary)
+	if !shouldNudge {
+		return
+	}
+
+	b.mu.Lock()
+	taskID, err := b.fireSkillReviewNudgeLocked(slug)
+	if err == nil {
+		atomic.AddInt64(&b.skillCompileMetrics.CounterNudgesFiredTotal, 1)
+		if saveErr := b.saveLocked(); saveErr != nil {
+			slog.Warn("skill_counter_nudge_persist_failed",
+				"agent", slug, "task_id", taskID, "err", saveErr)
+		}
+	}
+	b.mu.Unlock()
+	if err != nil {
+		slog.Warn("skill_counter_nudge_create_failed",
+			"agent", slug, "err", err)
+	}
+}
+
+// ensureSkillCounter lazily constructs the SkillCounter. Like the other
+// skill-* singletons, the counter is built on first use so tests that
+// never trigger an agent tool call pay no cost.
+func (b *Broker) ensureSkillCounter() *SkillCounter {
+	b.mu.Lock()
+	if b.skillCounter != nil {
+		c := b.skillCounter
+		b.mu.Unlock()
+		return c
+	}
+	c := NewSkillCounter()
+	b.skillCounter = c
+	b.mu.Unlock()
+	return c
+}
+
+// SetSkillCounter replaces the broker's counter — used by tests to inject
+// a counter with a specific threshold / cooldown / clock without going
+// through env vars.
+func (b *Broker) SetSkillCounter(c *SkillCounter) {
+	b.mu.Lock()
+	b.skillCounter = c
+	b.mu.Unlock()
+}
+
+// skillCounterSummaryFromArgs renders a one-line summary of a tool call
+// for the per-agent ring buffer. The args field is a JSON-encoded
+// string (as posted by the MCP client), so we don't try to parse it —
+// we just trim and truncate. Real human review of the nudge task uses
+// the agent's own activity stream for full detail.
+func skillCounterSummaryFromArgs(tool, args string) string {
+	args = strings.TrimSpace(args)
+	if args == "" {
+		return tool
+	}
+	// Collapse whitespace runs so the summary stays single-line.
+	args = strings.Join(strings.Fields(args), " ")
+	return truncateSummary(args, 120)
 }
 
 // formatAgentToolEvent renders one structured audit record for the per-agent

--- a/internal/team/skill_compile.go
+++ b/internal/team/skill_compile.go
@@ -53,6 +53,10 @@ type SkillCompileMetrics struct {
 	// synthesizer (LLM-synth from candidate signals). Incremented atomically
 	// once the unified write helper accepts the proposal.
 	StageBProposalsTotal int64
+	// CounterNudgesFiredTotal counts skill_review_nudge tasks fired by the
+	// Hermes-style per-agent counter (Stage B'). Incremented atomically by
+	// the tool-event hot path each time a nudge task is appended.
+	CounterNudgesFiredTotal int64
 }
 
 // snapshotSkillCompileMetrics returns a copy of m suitable for serialization.
@@ -70,6 +74,7 @@ func snapshotSkillCompileMetrics(m *SkillCompileMetrics) SkillCompileMetrics {
 		LastTickDurationMs:            atomic.LoadInt64(&m.LastTickDurationMs),
 		LastSkillCompilePassAtNano:    atomic.LoadInt64(&m.LastSkillCompilePassAtNano),
 		StageBProposalsTotal:          atomic.LoadInt64(&m.StageBProposalsTotal),
+		CounterNudgesFiredTotal:       atomic.LoadInt64(&m.CounterNudgesFiredTotal),
 	}
 }
 

--- a/internal/team/skill_compile_endpoints.go
+++ b/internal/team/skill_compile_endpoints.go
@@ -74,14 +74,16 @@ func (b *Broker) handlePostSkillCompile(w http.ResponseWriter, r *http.Request) 
 // skillCompileStatsResponse is the JSON shape GET /skills/compile/stats
 // returns. Times are RFC3339 in UTC; durations are integer milliseconds.
 type skillCompileStatsResponse struct {
-	ManualClicksTotal             int64  `json:"manual_clicks_total"`
-	CronTicksTotal                int64  `json:"cron_ticks_total"`
-	ProposalsCreatedTotal         int64  `json:"proposals_created_total"`
-	ProposalsApprovedTotal        int64  `json:"proposals_approved_total"`
-	ProposalsRejectedByGuardTotal int64  `json:"proposals_rejected_by_guard_total"`
-	LastTickDurationMs            int64  `json:"last_tick_duration_ms"`
-	LastSkillCompilePassAt        string `json:"last_skill_compile_pass_at,omitempty"`
-	StageBProposalsTotal          int64  `json:"stage_b_proposals_total"`
+	ManualClicksTotal             int64                          `json:"manual_clicks_total"`
+	CronTicksTotal                int64                          `json:"cron_ticks_total"`
+	ProposalsCreatedTotal         int64                          `json:"proposals_created_total"`
+	ProposalsApprovedTotal        int64                          `json:"proposals_approved_total"`
+	ProposalsRejectedByGuardTotal int64                          `json:"proposals_rejected_by_guard_total"`
+	LastTickDurationMs            int64                          `json:"last_tick_duration_ms"`
+	LastSkillCompilePassAt        string                         `json:"last_skill_compile_pass_at,omitempty"`
+	StageBProposalsTotal          int64                          `json:"stage_b_proposals_total"`
+	CounterNudgesFiredTotal       int64                          `json:"counter_nudges_fired_total"`
+	CounterPerAgent               map[string]SkillCounterMetrics `json:"counter_per_agent,omitempty"`
 }
 
 // handleGetSkillCompileStats returns a snapshot of the compile metrics.
@@ -93,6 +95,7 @@ func (b *Broker) handleGetSkillCompileStats(w http.ResponseWriter, r *http.Reque
 
 	b.mu.Lock()
 	snap := snapshotSkillCompileMetrics(&b.skillCompileMetrics)
+	counter := b.skillCounter
 	b.mu.Unlock()
 
 	resp := skillCompileStatsResponse{
@@ -103,6 +106,10 @@ func (b *Broker) handleGetSkillCompileStats(w http.ResponseWriter, r *http.Reque
 		ProposalsRejectedByGuardTotal: snap.ProposalsRejectedByGuardTotal,
 		LastTickDurationMs:            snap.LastTickDurationMs,
 		StageBProposalsTotal:          snap.StageBProposalsTotal,
+		CounterNudgesFiredTotal:       snap.CounterNudgesFiredTotal,
+	}
+	if counter != nil {
+		resp.CounterPerAgent = counter.Stats()
 	}
 	if snap.LastSkillCompilePassAtNano != 0 {
 		resp.LastSkillCompilePassAt = time.Unix(0, snap.LastSkillCompilePassAtNano).UTC().Format(timeRFC3339)

--- a/internal/team/skill_counter.go
+++ b/internal/team/skill_counter.go
@@ -1,0 +1,319 @@
+package team
+
+// skill_counter.go owns the Hermes-style per-agent activity counter that
+// drives the Stage B' "skill review" nudge. The contract:
+//
+//  1. Every successful agent MCP tool call increments iters_since_skill[slug].
+//  2. team_skill_create / team_skill_patch reset the counter to 0 (the agent
+//     just codified something — the tally restarts from there).
+//  3. When the counter crosses WUPHF_SKILL_NUDGE_INTERVAL (default 10), the
+//     broker fires a "skill_review_nudge" task into the agent's lane. The
+//     agent picks the task up on its next turn and decides whether the work
+//     pattern is worth proposing as a reusable skill.
+//  4. A cooldown (WUPHF_SKILL_NUDGE_COOLDOWN, default 60m) prevents the same
+//     agent from getting nudged repeatedly while their previous nudge sits
+//     unhandled.
+//
+// The counter also keeps a small ring buffer of recent tool-call summaries
+// so the nudge body can list "here is what you have been doing" without the
+// broker having to re-query the action log.
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Default thresholds. Both are overridable via env vars; tests can also
+// override directly through the constructor or setter methods.
+const (
+	defaultSkillNudgeInterval = 10
+	defaultSkillNudgeCooldown = 60 * time.Minute
+	// recentToolCallsCap is how many recent tool-call summaries we keep
+	// per agent. The nudge body lists the last 10, so 16 gives a small
+	// cushion if a few were summarized away.
+	recentToolCallsCap = 16
+)
+
+// SkillCounterMetrics exposes per-agent telemetry suitable for serialization
+// in the /skills/compile/stats response. Returned via SkillCounter.Stats.
+type SkillCounterMetrics struct {
+	Iterations       int       `json:"iterations"`
+	LastResetAt      time.Time `json:"last_reset_at,omitempty"`
+	LastNudgedAt     time.Time `json:"last_nudged_at,omitempty"`
+	NudgesFiredTotal int64     `json:"nudges_fired_total"`
+}
+
+// recentToolCall is one entry in the per-agent ring buffer.
+type recentToolCall struct {
+	ToolName string
+	Summary  string
+	At       time.Time
+}
+
+// agentCounterState is the mutable per-agent record. The parent SkillCounter
+// guards access via its own mutex.
+type agentCounterState struct {
+	iterations       int
+	lastResetAt      time.Time
+	lastNudgedAt     time.Time
+	nudgesFiredTotal int64
+	recentCalls      []recentToolCall
+}
+
+// SkillCounter is the broker-side state for the Hermes counter pattern.
+// It owns its own mutex so callers can invoke Increment / Reset / Stats from
+// any goroutine — including the MCP tool-event hot path — without holding
+// b.mu. The threshold + cooldown are immutable post-construction; callers
+// who need to test edge cases use NewSkillCounterWith for direct overrides.
+type SkillCounter struct {
+	mu        sync.Mutex
+	perAgent  map[string]*agentCounterState
+	threshold int
+	cooldown  time.Duration
+	// nowFn is injected for deterministic tests; defaults to time.Now.
+	nowFn func() time.Time
+}
+
+// NewSkillCounter constructs a counter using the env-configured threshold
+// and cooldown. Use NewSkillCounterWith from tests that want explicit
+// thresholds.
+func NewSkillCounter() *SkillCounter {
+	return NewSkillCounterWith(skillNudgeIntervalFromEnv(), skillNudgeCooldownFromEnv())
+}
+
+// NewSkillCounterWith constructs a counter with explicit threshold +
+// cooldown. Threshold <= 0 is normalized to 1 to avoid an off-by-one in
+// callers that pass 0. Cooldown < 0 is normalized to 0 (no cooldown).
+func NewSkillCounterWith(threshold int, cooldown time.Duration) *SkillCounter {
+	if threshold <= 0 {
+		threshold = 1
+	}
+	if cooldown < 0 {
+		cooldown = 0
+	}
+	return &SkillCounter{
+		perAgent:  make(map[string]*agentCounterState),
+		threshold: threshold,
+		cooldown:  cooldown,
+		nowFn:     time.Now,
+	}
+}
+
+// SetClock replaces the counter's time source. Tests use this to drive
+// cooldown logic deterministically.
+func (c *SkillCounter) SetClock(now func() time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if now == nil {
+		c.nowFn = time.Now
+		return
+	}
+	c.nowFn = now
+}
+
+// Threshold returns the configured nudge threshold. Useful for tests and
+// telemetry.
+func (c *SkillCounter) Threshold() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.threshold
+}
+
+// Cooldown returns the configured nudge cooldown.
+func (c *SkillCounter) Cooldown() time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.cooldown
+}
+
+// Increment registers one tool call for agentSlug. Returns shouldNudge=true
+// when the counter has reached the threshold AND no nudge has fired within
+// the cooldown window. When shouldNudge is true, Increment also resets the
+// counter to 0 and stamps lastNudgedAt — treat one nudge fire as the
+// "reset event" so the next nudge requires another N tool calls.
+//
+// toolName + summary are recorded in the per-agent ring buffer so the
+// nudge task body can list recent activity. Empty toolName is allowed
+// (caller already validated) but is recorded as "(unknown)" for clarity.
+func (c *SkillCounter) Increment(agentSlug, toolName, summary string) (shouldNudge bool, iterations int) {
+	agentSlug = strings.TrimSpace(agentSlug)
+	if agentSlug == "" {
+		return false, 0
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	st := c.getOrCreateLocked(agentSlug)
+	st.iterations++
+	if toolName == "" {
+		toolName = "(unknown)"
+	}
+	st.recentCalls = append(st.recentCalls, recentToolCall{
+		ToolName: toolName,
+		Summary:  summary,
+		At:       c.nowFn(),
+	})
+	if len(st.recentCalls) > recentToolCallsCap {
+		// Drop the oldest. Allocate a fresh slice rather than re-slice in
+		// place so the underlying array shrinks; otherwise long-lived agents
+		// keep a buffer N times larger than they need.
+		cp := make([]recentToolCall, recentToolCallsCap)
+		copy(cp, st.recentCalls[len(st.recentCalls)-recentToolCallsCap:])
+		st.recentCalls = cp
+	}
+
+	if st.iterations < c.threshold {
+		return false, st.iterations
+	}
+
+	// Threshold met — check cooldown.
+	now := c.nowFn()
+	if c.cooldown > 0 && !st.lastNudgedAt.IsZero() && now.Sub(st.lastNudgedAt) < c.cooldown {
+		// Still in cooldown. Hold the iteration count steady at the
+		// threshold — we don't want to keep counting forever, but we
+		// also don't want to reset because the agent's next nudge eligibility
+		// depends on cooldown elapsing, not on N more tool calls.
+		st.iterations = c.threshold
+		return false, st.iterations
+	}
+
+	// Fire the nudge. Reset iterations and stamp lastNudgedAt.
+	st.iterations = 0
+	st.lastNudgedAt = now
+	st.lastResetAt = now
+	st.nudgesFiredTotal++
+	return true, 0
+}
+
+// Reset clears the per-agent counter without firing a nudge. Called when
+// the agent invokes team_skill_create or team_skill_patch — they just
+// codified something, so the tally restarts from zero. Reset never blocks
+// a future nudge: it only zeroes iterations + records the reset time.
+func (c *SkillCounter) Reset(agentSlug string) {
+	agentSlug = strings.TrimSpace(agentSlug)
+	if agentSlug == "" {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	st := c.getOrCreateLocked(agentSlug)
+	st.iterations = 0
+	st.lastResetAt = c.nowFn()
+}
+
+// Stats returns a copy of the per-agent metrics suitable for JSON
+// serialization. Safe to call concurrently with Increment / Reset.
+func (c *SkillCounter) Stats() map[string]SkillCounterMetrics {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.perAgent) == 0 {
+		return map[string]SkillCounterMetrics{}
+	}
+	out := make(map[string]SkillCounterMetrics, len(c.perAgent))
+	for slug, st := range c.perAgent {
+		out[slug] = SkillCounterMetrics{
+			Iterations:       st.iterations,
+			LastResetAt:      st.lastResetAt,
+			LastNudgedAt:     st.lastNudgedAt,
+			NudgesFiredTotal: st.nudgesFiredTotal,
+		}
+	}
+	return out
+}
+
+// TotalNudgesFired sums NudgesFiredTotal across all tracked agents. Used by
+// the broker for the aggregate counter_nudges_fired_total telemetry value.
+func (c *SkillCounter) TotalNudgesFired() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var total int64
+	for _, st := range c.perAgent {
+		total += st.nudgesFiredTotal
+	}
+	return total
+}
+
+// RecentToolCalls returns a snapshot of up to limit most-recent calls for
+// agentSlug, oldest-first. Returns nil if the agent has no tracked calls.
+// Used by fireSkillReviewNudgeLocked to build the task body.
+func (c *SkillCounter) RecentToolCalls(agentSlug string, limit int) []recentToolCall {
+	agentSlug = strings.TrimSpace(agentSlug)
+	if agentSlug == "" || limit <= 0 {
+		return nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	st, ok := c.perAgent[agentSlug]
+	if !ok || len(st.recentCalls) == 0 {
+		return nil
+	}
+	start := 0
+	if len(st.recentCalls) > limit {
+		start = len(st.recentCalls) - limit
+	}
+	out := make([]recentToolCall, 0, len(st.recentCalls)-start)
+	out = append(out, st.recentCalls[start:]...)
+	return out
+}
+
+// getOrCreateLocked returns the agent record, creating it if absent.
+// Caller must hold c.mu.
+func (c *SkillCounter) getOrCreateLocked(slug string) *agentCounterState {
+	if st, ok := c.perAgent[slug]; ok {
+		return st
+	}
+	st := &agentCounterState{
+		recentCalls: make([]recentToolCall, 0, recentToolCallsCap),
+	}
+	c.perAgent[slug] = st
+	return st
+}
+
+// IsSkillAuthoringTool reports whether toolName corresponds to one of the
+// skill-authoring MCP tools whose invocation should reset the counter
+// instead of incrementing it. Lives here (not in teammcp) so the broker
+// hot path stays inside the team package and avoids an import cycle.
+func IsSkillAuthoringTool(toolName string) bool {
+	switch strings.TrimSpace(toolName) {
+	case "team_skill_create", "team_skill_patch":
+		return true
+	}
+	return false
+}
+
+// ── env helpers ───────────────────────────────────────────────────────────
+
+func skillNudgeIntervalFromEnv() int {
+	raw := strings.TrimSpace(os.Getenv("WUPHF_SKILL_NUDGE_INTERVAL"))
+	if raw == "" {
+		return defaultSkillNudgeInterval
+	}
+	n := 0
+	for _, c := range raw {
+		if c < '0' || c > '9' {
+			return defaultSkillNudgeInterval
+		}
+		n = n*10 + int(c-'0')
+	}
+	if n <= 0 {
+		return defaultSkillNudgeInterval
+	}
+	return n
+}
+
+func skillNudgeCooldownFromEnv() time.Duration {
+	raw := strings.TrimSpace(os.Getenv("WUPHF_SKILL_NUDGE_COOLDOWN"))
+	if raw == "" {
+		return defaultSkillNudgeCooldown
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d < 0 {
+		return defaultSkillNudgeCooldown
+	}
+	return d
+}

--- a/internal/team/skill_counter_test.go
+++ b/internal/team/skill_counter_test.go
@@ -1,0 +1,217 @@
+package team
+
+// skill_counter_test.go covers the Hermes-style counter semantics in
+// isolation from the broker hot path: threshold, reset, cooldown, and
+// the recent-tool-call ring buffer. Broker-level wiring (the actual nudge
+// task creation) is exercised in skill_review_nudge_test.go.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSkillCounter_IncrementUnderThreshold(t *testing.T) {
+	c := NewSkillCounterWith(10, 60*time.Minute)
+	for i := 1; i <= 9; i++ {
+		fired, n := c.Increment("ceo", "team_broadcast", "hello")
+		if fired {
+			t.Fatalf("iter %d: expected no nudge, got shouldNudge=true", i)
+		}
+		if n != i {
+			t.Fatalf("iter %d: expected iterations=%d, got %d", i, i, n)
+		}
+	}
+}
+
+func TestSkillCounter_ThresholdFires(t *testing.T) {
+	c := NewSkillCounterWith(10, 60*time.Minute)
+	for i := 1; i <= 9; i++ {
+		if fired, _ := c.Increment("ceo", "team_broadcast", ""); fired {
+			t.Fatalf("iter %d: nudge fired before threshold", i)
+		}
+	}
+	fired, n := c.Increment("ceo", "team_broadcast", "")
+	if !fired {
+		t.Fatalf("threshold iter: expected shouldNudge=true, got false")
+	}
+	if n != 0 {
+		t.Fatalf("threshold iter: expected iterations reset to 0, got %d", n)
+	}
+
+	stats := c.Stats()["ceo"]
+	if stats.NudgesFiredTotal != 1 {
+		t.Fatalf("expected NudgesFiredTotal=1, got %d", stats.NudgesFiredTotal)
+	}
+}
+
+func TestSkillCounter_ResetOnSkillCreate(t *testing.T) {
+	c := NewSkillCounterWith(10, 60*time.Minute)
+
+	// 5 increments — under threshold.
+	for i := 1; i <= 5; i++ {
+		if fired, _ := c.Increment("ceo", "team_broadcast", ""); fired {
+			t.Fatalf("iter %d: unexpected nudge fired", i)
+		}
+	}
+
+	// Reset — simulates team_skill_create / team_skill_patch.
+	c.Reset("ceo")
+
+	// Another 5 increments — total is 10 cumulative but only 5 since reset.
+	for i := 1; i <= 5; i++ {
+		fired, n := c.Increment("ceo", "team_broadcast", "")
+		if fired {
+			t.Fatalf("post-reset iter %d: nudge fired despite reset", i)
+		}
+		if n != i {
+			t.Fatalf("post-reset iter %d: expected iterations=%d, got %d", i, i, n)
+		}
+	}
+}
+
+func TestSkillCounter_CooldownPreventsRespam(t *testing.T) {
+	c := NewSkillCounterWith(3, 5*time.Minute)
+	// Drive through the threshold once.
+	c.Increment("ceo", "team_broadcast", "")
+	c.Increment("ceo", "team_broadcast", "")
+	fired, _ := c.Increment("ceo", "team_broadcast", "")
+	if !fired {
+		t.Fatalf("first cycle: expected nudge to fire at threshold")
+	}
+
+	// Drive through it again immediately — cooldown must suppress.
+	c.Increment("ceo", "team_broadcast", "")
+	c.Increment("ceo", "team_broadcast", "")
+	fired2, _ := c.Increment("ceo", "team_broadcast", "")
+	if fired2 {
+		t.Fatalf("second cycle: cooldown failed to suppress respam")
+	}
+
+	stats := c.Stats()["ceo"]
+	if stats.NudgesFiredTotal != 1 {
+		t.Fatalf("expected NudgesFiredTotal=1 (cooldown blocked second), got %d", stats.NudgesFiredTotal)
+	}
+}
+
+func TestSkillCounter_CooldownExpiresAndReFires(t *testing.T) {
+	c := NewSkillCounterWith(3, 5*time.Minute)
+	now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+	c.SetClock(func() time.Time { return now })
+
+	// First cycle.
+	c.Increment("ceo", "team_broadcast", "")
+	c.Increment("ceo", "team_broadcast", "")
+	if fired, _ := c.Increment("ceo", "team_broadcast", ""); !fired {
+		t.Fatalf("first cycle: expected nudge to fire")
+	}
+
+	// Advance past cooldown.
+	now = now.Add(10 * time.Minute)
+	c.SetClock(func() time.Time { return now })
+
+	c.Increment("ceo", "team_broadcast", "")
+	c.Increment("ceo", "team_broadcast", "")
+	fired, _ := c.Increment("ceo", "team_broadcast", "")
+	if !fired {
+		t.Fatalf("second cycle after cooldown: expected nudge to fire again")
+	}
+
+	stats := c.Stats()["ceo"]
+	if stats.NudgesFiredTotal != 2 {
+		t.Fatalf("expected NudgesFiredTotal=2 across two cycles, got %d", stats.NudgesFiredTotal)
+	}
+}
+
+func TestSkillCounter_PerAgentIsolated(t *testing.T) {
+	c := NewSkillCounterWith(3, 60*time.Minute)
+	// CEO increments alone.
+	c.Increment("ceo", "team_broadcast", "")
+	c.Increment("ceo", "team_broadcast", "")
+
+	// Engineer increments — should be on its own counter.
+	if fired, n := c.Increment("eng", "team_broadcast", ""); fired || n != 1 {
+		t.Fatalf("eng first iter: expected (false, 1), got (%v, %d)", fired, n)
+	}
+
+	// CEO crosses threshold.
+	if fired, _ := c.Increment("ceo", "team_broadcast", ""); !fired {
+		t.Fatalf("ceo threshold: expected nudge")
+	}
+
+	// Engineer is still well under threshold.
+	if fired, n := c.Increment("eng", "team_broadcast", ""); fired || n != 2 {
+		t.Fatalf("eng second iter: expected (false, 2), got (%v, %d)", fired, n)
+	}
+}
+
+func TestSkillCounter_RecentToolCalls(t *testing.T) {
+	c := NewSkillCounterWith(100, 60*time.Minute)
+	for i := 0; i < 5; i++ {
+		c.Increment("ceo", "team_broadcast", "msg-"+string(rune('a'+i)))
+	}
+	calls := c.RecentToolCalls("ceo", 10)
+	if len(calls) != 5 {
+		t.Fatalf("expected 5 calls in buffer, got %d", len(calls))
+	}
+	if calls[0].Summary != "msg-a" || calls[4].Summary != "msg-e" {
+		t.Fatalf("unexpected ring buffer ordering: %+v", calls)
+	}
+}
+
+func TestSkillCounter_RecentToolCallsRingCaps(t *testing.T) {
+	c := NewSkillCounterWith(1000, 60*time.Minute)
+	for i := 0; i < 30; i++ {
+		c.Increment("ceo", "tool", "summary")
+	}
+	calls := c.RecentToolCalls("ceo", 10)
+	if len(calls) != 10 {
+		t.Fatalf("expected the limit=10 to bound returned calls, got %d", len(calls))
+	}
+	// Ring buffer cap is 16; calling RecentToolCalls(..., 10) returns
+	// the latest 10 of those 16. The buffer should never grow unbounded.
+	if total := len(c.perAgent["ceo"].recentCalls); total > recentToolCallsCap {
+		t.Fatalf("ring buffer exceeded cap: %d > %d", total, recentToolCallsCap)
+	}
+}
+
+func TestSkillCounter_EmptySlugIsNoop(t *testing.T) {
+	c := NewSkillCounterWith(3, 60*time.Minute)
+	if fired, n := c.Increment("", "team_broadcast", ""); fired || n != 0 {
+		t.Fatalf("empty slug: expected (false, 0), got (%v, %d)", fired, n)
+	}
+	c.Reset("")
+	if got := len(c.Stats()); got != 0 {
+		t.Fatalf("empty slug Reset created an entry: %d", got)
+	}
+}
+
+func TestSkillCounter_TotalNudgesFired(t *testing.T) {
+	c := NewSkillCounterWith(2, 0) // no cooldown so we can fire fast
+	c.Increment("ceo", "t", "")
+	c.Increment("ceo", "t", "") // fire #1 for ceo
+	c.Increment("eng", "t", "")
+	c.Increment("eng", "t", "") // fire #1 for eng
+	if total := c.TotalNudgesFired(); total != 2 {
+		t.Fatalf("expected total=2, got %d", total)
+	}
+}
+
+func TestIsSkillAuthoringTool(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"team_skill_create", true},
+		{"team_skill_patch", true},
+		{"team_skill_run", false},
+		{"team_broadcast", false},
+		{"  team_skill_create  ", true}, // trims
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := IsSkillAuthoringTool(tc.name)
+		if got != tc.want {
+			t.Fatalf("IsSkillAuthoringTool(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/team/skill_review_nudge.go
+++ b/internal/team/skill_review_nudge.go
@@ -1,0 +1,123 @@
+package team
+
+// skill_review_nudge.go owns the broker-side task creation that fires
+// when the per-agent SkillCounter crosses its threshold. The task lands
+// in the agent's home channel and asks them to review recent activity
+// and propose a skill if the work pattern is reusable.
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+)
+
+// skillReviewNudgeTaskType is the TaskType field stamped on the nudge
+// task. The web UI / agent dispatcher can branch on this value if it
+// later wants to render the nudge specially.
+const skillReviewNudgeTaskType = "skill_review_nudge"
+
+// fireSkillReviewNudgeLocked creates a Task in agentSlug's lane asking
+// them to review their recent tool-call activity and propose a reusable
+// skill via team_skill_create(action=propose).
+//
+// Caller must hold b.mu. The task is written through the same
+// task-creation pipeline used everywhere else in the broker, so the
+// existing dispatcher picks it up on the agent's next turn. We do NOT
+// call b.saveLocked here — the caller (the tool-event handler) is
+// responsible for persisting after appending its own audit entry, so
+// one save covers both writes.
+func (b *Broker) fireSkillReviewNudgeLocked(agentSlug string) (string, error) {
+	agentSlug = strings.TrimSpace(agentSlug)
+	if agentSlug == "" {
+		return "", fmt.Errorf("fireSkillReviewNudgeLocked: agentSlug required")
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Build the task body from the counter's ring buffer. If the counter
+	// is somehow nil or empty (race during boot, deliberate test stub),
+	// we still fire the task with a generic body — better to over-nudge
+	// than to silently drop a counter event.
+	var recent []recentToolCall
+	if b.skillCounter != nil {
+		recent = b.skillCounter.RecentToolCalls(agentSlug, 10)
+	}
+	details := buildSkillReviewNudgeBody(len(recent), recent)
+
+	channel := b.preferredTaskChannelLocked("general", agentSlug, agentSlug, skillReviewNudgeTitle, details)
+
+	b.counter++
+	task := teamTask{
+		ID:            fmt.Sprintf("task-skill-nudge-%d", b.counter),
+		Channel:       channel,
+		Title:         skillReviewNudgeTitle,
+		Details:       details,
+		Owner:         agentSlug,
+		Status:        "in_progress",
+		CreatedBy:     "system",
+		TaskType:      skillReviewNudgeTaskType,
+		PipelineID:    "skill_review",
+		ExecutionMode: "office",
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	b.ensureTaskOwnerChannelMembershipLocked(channel, task.Owner)
+	b.queueTaskBehindActiveOwnerLaneLocked(&task)
+	if err := rejectTheaterTaskForLiveBusiness(&task); err != nil {
+		return "", fmt.Errorf("rejectTheaterTask: %w", err)
+	}
+	b.scheduleTaskLifecycleLocked(&task)
+	if err := b.syncTaskWorktreeLocked(&task); err != nil {
+		return "", fmt.Errorf("syncTaskWorktree: %w", err)
+	}
+	b.tasks = append(b.tasks, task)
+	b.appendActionLocked(
+		"task_created",
+		"office",
+		channel,
+		"system",
+		truncateSummary(task.Title+" ["+agentSlug+"]", 140),
+		task.ID,
+	)
+
+	slog.Info("skill_counter_nudge_fired",
+		"agent", agentSlug,
+		"task_id", task.ID,
+		"channel", channel,
+		"recent_calls", len(recent),
+	)
+
+	return task.ID, nil
+}
+
+const skillReviewNudgeTitle = "Skill review: codify what you've been doing"
+
+// buildSkillReviewNudgeBody renders the task body. n is the count of
+// listed calls (kept separate so the prelude reads cleanly when the
+// counter ring buffer is short).
+func buildSkillReviewNudgeBody(n int, recent []recentToolCall) string {
+	var sb strings.Builder
+	if n == 0 {
+		sb.WriteString("You've made enough tool calls since your last skill_create / skill_patch to trigger a skill-review check.\n\n")
+		sb.WriteString("Survey the patterns in your recent work. ")
+	} else {
+		fmt.Fprintf(&sb, "You've made %d recent tool calls since your last skill_create / skill_patch.\n\nRecent activity:\n", n)
+		for _, r := range recent {
+			summary := strings.TrimSpace(r.Summary)
+			if summary == "" {
+				summary = "(no summary)"
+			}
+			ts := r.At.UTC().Format(time.RFC3339)
+			fmt.Fprintf(&sb, "- %s (%s) at %s\n", r.ToolName, truncateSummary(summary, 120), ts)
+		}
+		sb.WriteString("\nSurvey these patterns. ")
+	}
+	sb.WriteString("If you see a CLASS of work that's worth codifying as a reusable skill, ")
+	sb.WriteString("call `team_skill_create(action=propose)` with a class-first name ")
+	sb.WriteString("(e.g., `handle-deploy-failures`, NOT `fix-the-build-i-just-did`). ")
+	sb.WriteString("The proposal goes through the existing human-approval gate.\n\n")
+	sb.WriteString("If nothing stands out as reusable, just say \"Nothing to save\" and close this task.")
+	return sb.String()
+}

--- a/internal/team/skill_review_nudge_test.go
+++ b/internal/team/skill_review_nudge_test.go
@@ -1,0 +1,162 @@
+package team
+
+// skill_review_nudge_test.go covers the broker-level wiring: when the
+// SkillCounter crosses the threshold via the tool-event hot path, a
+// skill_review_nudge task should land in b.tasks with the agent as
+// owner and the right shape.
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestFireSkillReviewNudge_CreatesTask(t *testing.T) {
+	b := newTestBroker(t)
+	// Inject a counter with a low threshold so we don't have to spam.
+	b.SetSkillCounter(NewSkillCounterWith(3, 60*time.Minute))
+
+	// Drive 3 tool events through recordAgentToolEvent — the third should
+	// fire the nudge task.
+	b.recordAgentToolEvent("ceo", "call", "team_broadcast", `{"text":"hi"}`)
+	b.recordAgentToolEvent("ceo", "call", "team_broadcast", `{"text":"again"}`)
+	b.recordAgentToolEvent("ceo", "call", "team_broadcast", `{"text":"third"}`)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	var nudgeTask *teamTask
+	for i := range b.tasks {
+		if b.tasks[i].TaskType == skillReviewNudgeTaskType {
+			nudgeTask = &b.tasks[i]
+			break
+		}
+	}
+	if nudgeTask == nil {
+		t.Fatalf("expected a %s task, got %d tasks total", skillReviewNudgeTaskType, len(b.tasks))
+	}
+	if nudgeTask.Owner != "ceo" {
+		t.Fatalf("expected Owner=ceo, got %q", nudgeTask.Owner)
+	}
+	if nudgeTask.PipelineID != "skill_review" {
+		t.Fatalf("expected PipelineID=skill_review, got %q", nudgeTask.PipelineID)
+	}
+	if nudgeTask.ExecutionMode != "office" {
+		t.Fatalf("expected ExecutionMode=office, got %q", nudgeTask.ExecutionMode)
+	}
+	if nudgeTask.Status != "in_progress" {
+		t.Fatalf("expected Status=in_progress, got %q", nudgeTask.Status)
+	}
+	if nudgeTask.Title != skillReviewNudgeTitle {
+		t.Fatalf("unexpected Title: %q", nudgeTask.Title)
+	}
+	if !strings.Contains(nudgeTask.Details, "team_broadcast") {
+		t.Fatalf("expected task body to list recent tool calls; got:\n%s", nudgeTask.Details)
+	}
+	if !strings.Contains(nudgeTask.Details, "team_skill_create(action=propose)") {
+		t.Fatalf("expected task body to mention team_skill_create(action=propose); got:\n%s", nudgeTask.Details)
+	}
+
+	if got := atomic.LoadInt64(&b.skillCompileMetrics.CounterNudgesFiredTotal); got != 1 {
+		t.Fatalf("expected CounterNudgesFiredTotal=1, got %d", got)
+	}
+}
+
+func TestRecordAgentToolEvent_SkillCreateResetsCounter(t *testing.T) {
+	b := newTestBroker(t)
+	b.SetSkillCounter(NewSkillCounterWith(3, 60*time.Minute))
+
+	// Two calls — counter at 2, no nudge yet.
+	b.recordAgentToolEvent("ceo", "call", "team_broadcast", "")
+	b.recordAgentToolEvent("ceo", "call", "team_broadcast", "")
+
+	// team_skill_create resets, so the next two tool calls should not
+	// trigger the threshold (cumulative would have been 4 without reset).
+	b.recordAgentToolEvent("ceo", "call", "team_skill_create", "")
+	b.recordAgentToolEvent("ceo", "call", "team_broadcast", "")
+	b.recordAgentToolEvent("ceo", "call", "team_broadcast", "")
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, tk := range b.tasks {
+		if tk.TaskType == skillReviewNudgeTaskType {
+			t.Fatalf("expected NO nudge task after skill_create reset, got %s", tk.ID)
+		}
+	}
+	if got := atomic.LoadInt64(&b.skillCompileMetrics.CounterNudgesFiredTotal); got != 0 {
+		t.Fatalf("expected CounterNudgesFiredTotal=0 after reset, got %d", got)
+	}
+}
+
+func TestRecordAgentToolEvent_OnlyCallPhaseCounts(t *testing.T) {
+	b := newTestBroker(t)
+	b.SetSkillCounter(NewSkillCounterWith(3, 60*time.Minute))
+
+	// One real call — counter=1.
+	b.recordAgentToolEvent("ceo", "call", "team_broadcast", "")
+	// result + error are post-call follow-ups: must NOT increment.
+	b.recordAgentToolEvent("ceo", "result", "team_broadcast", "")
+	b.recordAgentToolEvent("ceo", "error", "team_broadcast", "")
+
+	stats := b.skillCounter.Stats()["ceo"]
+	if stats.Iterations != 1 {
+		t.Fatalf("expected iterations=1 (only call phase counts), got %d", stats.Iterations)
+	}
+}
+
+func TestRecordAgentToolEvent_EmptyPhaseTreatedAsCall(t *testing.T) {
+	// Older agents may not tag the phase. We treat empty phase as "call"
+	// so they still drive the counter. The post hot path posts call/result
+	// separately so we won't double-count from one client.
+	b := newTestBroker(t)
+	b.SetSkillCounter(NewSkillCounterWith(3, 60*time.Minute))
+
+	b.recordAgentToolEvent("ceo", "", "team_broadcast", "")
+	b.recordAgentToolEvent("ceo", "", "team_broadcast", "")
+	stats := b.skillCounter.Stats()["ceo"]
+	if stats.Iterations != 2 {
+		t.Fatalf("empty-phase increments expected to count, got iterations=%d", stats.Iterations)
+	}
+}
+
+func TestRecordAgentToolEvent_NoSlugNoEffect(t *testing.T) {
+	b := newTestBroker(t)
+	b.SetSkillCounter(NewSkillCounterWith(3, 60*time.Minute))
+
+	b.recordAgentToolEvent("", "call", "team_broadcast", "")
+	b.recordAgentToolEvent("ceo", "call", "", "")
+
+	stats := b.skillCounter.Stats()
+	if len(stats) != 0 {
+		t.Fatalf("expected no agents tracked, got %d", len(stats))
+	}
+}
+
+func TestBuildSkillReviewNudgeBody_EmptyRecent(t *testing.T) {
+	body := buildSkillReviewNudgeBody(0, nil)
+	if !strings.Contains(body, "team_skill_create(action=propose)") {
+		t.Fatalf("body missing instructions: %s", body)
+	}
+	if strings.Contains(body, "Recent activity:") {
+		t.Fatalf("empty case should NOT include the recent-activity list: %s", body)
+	}
+}
+
+func TestBuildSkillReviewNudgeBody_WithRecent(t *testing.T) {
+	now := time.Now().UTC()
+	recent := []recentToolCall{
+		{ToolName: "team_broadcast", Summary: "post a message", At: now},
+		{ToolName: "team_wiki_read", Summary: "look up an article", At: now.Add(time.Minute)},
+	}
+	body := buildSkillReviewNudgeBody(2, recent)
+	if !strings.Contains(body, "team_broadcast") {
+		t.Fatalf("body missing first tool name: %s", body)
+	}
+	if !strings.Contains(body, "team_wiki_read") {
+		t.Fatalf("body missing second tool name: %s", body)
+	}
+	if !strings.Contains(body, "Recent activity:") {
+		t.Fatalf("body missing recent-activity header: %s", body)
+	}
+}


### PR DESCRIPTION
## Summary

- **`skill_counter.go`** — `SkillCounter`: per-agent activity counter with configurable threshold (default 10, `WUPHF_SKILL_NUDGE_INTERVAL`) and cooldown (default 60m, `WUPHF_SKILL_NUDGE_COOLDOWN`). Keeps a 16-slot ring buffer of recent tool-call summaries. Fires a `skill_review_nudge` task when threshold is crossed; resets on any `team_skill_create` / `team_skill_patch` call.
- **`skill_review_nudge.go`** — broker-side task creator. Builds a nudge body listing the agent's recent tool calls and drops a `skill_review_nudge` task into the agent's lane, prompting them to call `team_skill_create(action=propose)`.
- **`skill_counter_test.go` + `skill_review_nudge_test.go`** — full unit coverage for increment/reset/cooldown/ring-buffer and nudge task shape.
- **`/skills/compile/stats`** — surfaces `SkillCounterMetrics` (iterations, last_reset_at, last_nudged_at, nudges_fired_total) per agent in the stats endpoint.

## Test plan

- [x] `go test ./internal/team/...` — passes (117s, includes race detector from CI matrix)
- [ ] Manually trigger 10+ tool calls from a test agent and verify `skill_review_nudge` task appears in the lane
- [ ] Verify cooldown: a second nudge is not fired within 60m of the first
- [ ] Verify counter resets to 0 after `team_skill_create`
- [ ] Confirm `/skills/compile/stats` returns counter metrics in the response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Skill review nudge system: automatically creates skill-review tasks for agents when per-agent tool usage crosses a configurable threshold, with cooldowns and resets for skill-authoring tools.
  * Tool activity tracking: records recent per-agent tool calls and includes summarized recent activity in nudge tasks.

* **Bug Fixes / Improvements**
  * Nudge creation is rate-limited by cooldowns and avoids duplicate counts for non-call phases.

* **Metrics**
  * Exposes total nudges fired and optional per-agent counters in compile stats.

* **Tests**
  * Added comprehensive unit and broker-level tests covering counter behavior, cooldowns, resets, and nudge task creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->