### PR TITLE
feat(website): add Product Hunt featured badge to hero

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1171,7 +1171,7 @@
       <a href="https://www.producthunt.com/products/wuphf-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-wuphf-2" target="_blank" rel="noopener noreferrer" class="ph-badge"><img alt="WUPHF on Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1132040&amp;theme=neutral&amp;t=1777341246811"></a>
     </div>
 
-    <a href="https://www.producthunt.com/products/wuphf-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-wuphf-by-nex-ai" target="_blank" rel="noopener noreferrer" class="ph-badge"><img alt="WUPHF by Nex.ai - AI employees who build their own knowledge base | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1132040&amp;theme=light&amp;t=1777385299660"></a>
+    <a href="https://www.producthunt.com/products/wuphf-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-wuphf-by-nex-ai" target="_blank" rel="noopener noreferrer" class="ph-badge"><img alt="Featured on Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1132040&amp;theme=light&amp;t=1777385299660"></a>
 
   </div>
 

--- a/website/index.html
+++ b/website/index.html
@@ -352,6 +352,13 @@
   .ph-badge { display: inline-flex; line-height: 0; }
   .ph-badge img { height: 48px; width: auto; display: block; }
 
+  .ph-badge {
+    display: inline-block;
+    margin-top: 20px;
+    line-height: 0;
+  }
+  .ph-badge img { display: block; }
+
   .btn-primary {
     font-family: var(--font-display);
     font-size: 10px;
@@ -1163,6 +1170,8 @@
       </a>
       <a href="https://www.producthunt.com/products/wuphf-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-wuphf-2" target="_blank" rel="noopener noreferrer" class="ph-badge"><img alt="WUPHF on Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1132040&amp;theme=neutral&amp;t=1777341246811"></a>
     </div>
+
+    <a href="https://www.producthunt.com/products/wuphf-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-wuphf-by-nex-ai" target="_blank" rel="noopener noreferrer" class="ph-badge"><img alt="WUPHF by Nex.ai - AI employees who build their own knowledge base | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1132040&amp;theme=light&amp;t=1777385299660"></a>
 
   </div>
 


### PR DESCRIPTION
## Summary
- Adds the Product Hunt "Featured" badge to the marketing site hero, directly below the GitHub / Discord CTAs.
- Links to https://www.producthunt.com/products/wuphf-2 with the embed widget image.
- Small `.ph-badge` CSS rule for spacing (`margin-top: 20px`) and clean image rendering.

## Test plan
- [ ] Open `website/index.html` locally; confirm badge renders below hero CTAs and centers correctly.
- [ ] Click badge → opens Product Hunt page in new tab.
- [ ] Verify on mobile widths (badge wraps cleanly under CTAs, no overflow).
- [ ] Confirm no layout shift (image has explicit width/height).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Product Hunt badge to the hero section with accompanying visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->