### PR TITLE
Fix/theme polish wiki graph sidebar

### DIFF
--- a/web/public/themes/noir-gold.css
+++ b/web/public/themes/noir-gold.css
@@ -564,3 +564,96 @@ html[data-theme="noir-gold"] .notebook-surface .nb-review-col-empty {
   color: var(--nb-text-tertiary);
   opacity: 1;
 }
+
+/* ─── Wiki app shell — top tab bar + left nav menu buttons ─────────────
+   wiki-shell.css uses fallback aliases (--surface, --text-muted, --purple)
+   that don't exist in the global theme; in noir-gold those fall back to
+   white/blue/purple, leaving the wiki tabs visually unthemed. Override
+   them inline so the bar reads as gold-on-noir, the active tab uses the
+   gold accent, and the unread badge is gold instead of purple. */
+
+html[data-theme="noir-gold"] .wiki-tabs {
+  background: var(--bg-card);
+  border-bottom-color: var(--border);
+}
+html[data-theme="noir-gold"] .wiki-tab {
+  color: var(--text-secondary);
+}
+html[data-theme="noir-gold"] .wiki-tab:hover {
+  color: var(--gold-100);
+}
+html[data-theme="noir-gold"] .wiki-tab:focus-visible {
+  outline-color: var(--gold-400);
+}
+html[data-theme="noir-gold"] .wiki-tab.is-active {
+  color: var(--gold-100);
+  border-bottom-color: var(--gold-400);
+}
+html[data-theme="noir-gold"] .wiki-tab-badge {
+  background: var(--gold-400);
+  color: var(--gold-950);
+}
+
+/* ─── Wiki surface — left nav menu buttons + wikilinks ───────────────
+   --wk-wikilink resolves to --olive-500 which we already redirected to
+   #3d2e0a (deep oxidized) — too dark on dark bg. Re-route the wiki
+   palette to gold tones so links and the active menu button read. */
+html[data-theme="noir-gold"] .wiki-root {
+  --wk-wikilink:        var(--gold-300);
+  --wk-wikilink-broken: var(--red);
+  --wk-amber:           var(--gold-400);
+  --wk-amber-bg:        rgba(201, 162, 39, 0.10);
+  --wk-amber-banner:    rgba(201, 162, 39, 0.05);
+  --wk-code-bg:         var(--bg-warm);
+}
+html[data-theme="noir-gold"] .wk-nav-sidebar h3 {
+  color: var(--gold-300);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  font-size: 11px;
+}
+html[data-theme="noir-gold"] .wk-nav-sidebar li.current a {
+  background: rgba(201, 162, 39, 0.12);
+  color: var(--gold-100);
+}
+html[data-theme="noir-gold"] .wk-nav-sidebar .search {
+  background: var(--bg-warm);
+  border-color: var(--border-dark);
+  color: var(--text);
+}
+html[data-theme="noir-gold"] .wk-nav-sidebar .search:focus {
+  border-color: var(--gold-500);
+}
+
+/* Wiki "NEW" pill (was teal #CFF5F5/#0F5C5C — already had a partial
+   override but only for one selector). Cover the wiki-shell tab badge
+   and any other inline pills for completeness. */
+html[data-theme="noir-gold"] .wk-section-new {
+  background: var(--accent-bg);
+  color: var(--gold-200);
+  border: 1px solid rgba(201, 162, 39, 0.4);
+}
+
+/* ─── Entity-graph node palette ────────────────────────────────────
+   Default theme uses pastel Tailwind colors (lavender/sky/mint). On
+   noir those wash out as bright neon dots; redirect to gold-toned
+   variants tuned for the dark surface. */
+html[data-theme="noir-gold"] {
+  --graph-people-fill:       rgba(201, 162, 39, 0.14);
+  --graph-people-stroke:     var(--gold-300);
+  --graph-companies-fill:    rgba(136, 164, 194, 0.16);
+  --graph-companies-stroke:  #88a4c2;
+  --graph-customers-fill:    rgba(47, 170, 100, 0.15);
+  --graph-customers-stroke:  var(--green);
+  --graph-other-fill:        rgba(245, 233, 200, 0.06);
+  --graph-other-stroke:      var(--text-tertiary);
+}
+
+/* ─── Sidebar agent task / activity (the "token burn" line under each
+       team member) — was barely visible on noir at 42% cream opacity.
+       Bump to a clean readable gold so the user can actually see it. */
+html[data-theme="noir-gold"] .sidebar .sidebar-agent-task,
+html[data-theme="noir-gold"] .sidebar .sidebar-agent-activity {
+  color: var(--gold-300);
+  opacity: 1;
+}

--- a/web/src/components/apps/GraphApp.tsx
+++ b/web/src/components/apps/GraphApp.tsx
@@ -58,20 +58,20 @@ const NODE_STYLES: Record<
   { fill: string; stroke: string; icon: string; label: string }
 > = {
   people: {
-    fill: "#EDE9FE",
-    stroke: "#7C3AED",
+    fill: "var(--graph-people-fill, #EDE9FE)",
+    stroke: "var(--graph-people-stroke, #7C3AED)",
     icon: "👤", // 👤
     label: "People",
   },
   companies: {
-    fill: "#DBEAFE",
-    stroke: "#2563EB",
+    fill: "var(--graph-companies-fill, #DBEAFE)",
+    stroke: "var(--graph-companies-stroke, #2563EB)",
     icon: "🏢", // 🏢
     label: "Companies",
   },
   customers: {
-    fill: "#DCFCE7",
-    stroke: "#059669",
+    fill: "var(--graph-customers-fill, #DCFCE7)",
+    stroke: "var(--graph-customers-stroke, #059669)",
     icon: "🤝", // handshake — customer = relationship
     label: "Customers",
   },
@@ -80,8 +80,8 @@ const NODE_STYLES: Record<
 function styleFor(kind: string) {
   return (
     NODE_STYLES[kind] ?? {
-      fill: "#F3F4F6",
-      stroke: "#6B7280",
+      fill: "var(--graph-other-fill, #F3F4F6)",
+      stroke: "var(--graph-other-stroke, #6B7280)",
       icon: "◆",
       label: kind,
     }
@@ -469,14 +469,16 @@ export function GraphApp() {
                           width={120}
                           height={20}
                           rx={4}
-                          fill="var(--text)"
-                          opacity={0.9}
+                          fill="var(--bg-card)"
+                          stroke="var(--border)"
+                          strokeWidth={1}
+                          opacity={0.95}
                         />
                         <text
                           x={(x1 + x2) / 2}
                           y={(y1 + y2) / 2 + 2}
                           fontSize={10}
-                          fill="#fff"
+                          fill="var(--text)"
                           textAnchor="middle"
                           dominantBaseline="middle"
                         >

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -85,6 +85,16 @@
   --accent-warm: var(--tertiary-500);
   --accent-bg: var(--tertiary-100);
   --accent-bg-strong: rgba(159, 77, 191, 0.35);
+  /* Entity-graph node palette — Tailwind-ish pastels for the default
+     light theme. Themes can override these in their token block. */
+  --graph-people-fill:       #EDE9FE;
+  --graph-people-stroke:     #7C3AED;
+  --graph-companies-fill:    #DBEAFE;
+  --graph-companies-stroke:  #2563EB;
+  --graph-customers-fill:    #DCFCE7;
+  --graph-customers-stroke:  #059669;
+  --graph-other-fill:        #F3F4F6;
+  --graph-other-stroke:      #6B7280;
   --border: var(--neutral-100);
   --border-light: var(--neutral-50);
   --border-dark: var(--neutral-200);


### PR DESCRIPTION
  Four UI tighten-ups on the noir-gold theme (other themes untouched):          
  
  1. **Wiki top tab bar** — `wiki-shell.css` references fallback aliases        
  (`--surface`, `--text-muted`, `--purple`) that aren't in the global theme; on
  noir-gold those fell back to white/blue/purple, leaving the tab bar unthemed. 
  Inline overrides so the bar reads gold-on-noir, the active tab uses the gold
  accent, and the unread badge is gold.

  2. **Wiki left-nav menu buttons** — `--wk-wikilink` resolved to `--olive-500` 
  which is `#3d2e0a` (deep oxidized) in noir-gold — practically invisible on
  dark bg, so the active menu item couldn't be seen. Re-route the wiki palette  
  tokens (`--wk-wikilink`, `--wk-amber`, `--wk-amber-bg`, `--wk-amber-banner`)
  to gold tones inside `.wiki-root` for noir-gold only.

  3. **Entity-graph node bubbles** — `GraphApp.tsx` hardcoded literal pastel hex
   (`#EDE9FE/#7C3AED` for people, `#DBEAFE/#2563EB` for companies,
  `#DCFCE7/#059669` for customers, `#F3F4F6/#6B7280` fallback) which read as    
  bright neon on dark surfaces. Converted to CSS vars       
  (`--graph-{people,companies,customers,other}-{fill,stroke}`) with the original
   pastels as fallbacks. Added `:root` defaults in `global.css` so other themes
  are unchanged. Added noir-gold overrides tuned for dark. **Also fixed the
  edge-label rect/text** — was `--text` rect with white text which inverted
  wrong on dark; now uses `--bg-card` rect + `--text` foreground so it
  auto-themes.

  4. **Sidebar agent task / activity** — the per-agent activity line ("drafting 
  response", token-burn status, etc.) was at 42% cream opacity on noir, barely
  visible. Bumped to `var(--gold-300)` at full opacity so it reads cleanly under
   each member.                                             

  The graph-token conversion in `global.css :root` + `GraphApp.tsx` is          
  theme-agnostic and safe to land regardless of the theme verdict — those
  changes preserve current visual behavior in `nex` / `nex-dark` via the        
  fallback values.              

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-provider image generation with configurable backends and API key management
  * Introduced new "noir-gold" theme with gold accents and dark background
  * Added sidebar color customization and collapsible channel/app sections
  * Expanded agent capabilities with new productivity skills
  * Enhanced task logging with per-agent task tracking

* **User Interface**
  * Theme toggle now cycles between three themes
  * Task log view refactored for improved navigation by task ID
  * Graph visualization with themeable node colors

* **Configuration**
  * New image generation settings panel for provider and model configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- refreshed-2026-04-28 -->