### PR TITLE
fix(skills): log walkFn errors instead of silently swallowing them

### DIFF
--- a/internal/team/notebook_signal_scanner.go
+++ b/internal/team/notebook_signal_scanner.go
@@ -123,11 +123,13 @@ func (s *NotebookSignalScanner) collectNotebookEntries(wikiRoot string) ([]noteb
 	var out []notebookEntry
 	walkErr := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
 		if err != nil {
-			return nil //nolint:nilerr // best-effort walk: skip unreadable entries
+			slog.Warn("notebook_signal_scanner: skipping path due to walk error", "path", p, "err", err)
+			return nil
 		}
 		rel, relErr := filepath.Rel(wikiRoot, p)
 		if relErr != nil {
-			return nil //nolint:nilerr // best-effort walk: skip unresolvable paths
+			slog.Warn("notebook_signal_scanner: skipping path with unresolvable relative", "path", p, "wiki_root", wikiRoot, "err", relErr)
+			return nil
 		}
 		rel = filepath.ToSlash(rel)
 
@@ -153,6 +155,7 @@ func (s *NotebookSignalScanner) collectNotebookEntries(wikiRoot string) ([]noteb
 
 		raw, readErr := os.ReadFile(p)
 		if readErr != nil {
+			slog.Warn("notebook_signal_scanner: skipping unreadable notebook file", "path", p, "err", readErr)
 			return nil
 		}
 

--- a/internal/team/skill_scanner.go
+++ b/internal/team/skill_scanner.go
@@ -286,11 +286,13 @@ func (s *SkillScanner) collectCandidates(walkRoot, wikiRoot string) ([]candidate
 	var out []candidate
 	walkErr := filepath.Walk(walkRoot, func(p string, info os.FileInfo, err error) error {
 		if err != nil {
-			return nil // skip-and-log via the outer slog.Warn
+			slog.Warn("skill_scanner: skipping path due to walk error", "path", p, "err", err)
+			return nil
 		}
 		// Compute wiki-relative path with forward slashes for matching.
 		rel, relErr := filepath.Rel(wikiRoot, p)
 		if relErr != nil {
+			slog.Warn("skill_scanner: skipping path with unresolvable relative", "path", p, "wiki_root", wikiRoot, "err", relErr)
 			return nil
 		}
 		rel = filepath.ToSlash(rel)
@@ -313,6 +315,7 @@ func (s *SkillScanner) collectCandidates(walkRoot, wikiRoot string) ([]candidate
 
 		raw, readErr := os.ReadFile(p)
 		if readErr != nil {
+			slog.Warn("skill_scanner: skipping unreadable file", "path", p, "err", readErr)
 			return nil
 		}
 		out = append(out, candidate{relPath: rel, content: string(raw)})


### PR DESCRIPTION
## Summary

`filepath.Walk` was returning `nil` from the walkFn on per-file errors without logging anything — silent skips in `skill_scanner.collectCandidates` and `notebook_signal_scanner.collectNotebookEntries`. Two sites had `//nolint:nilerr` to silence the linter; the third (an `os.ReadFile` failure on a notebook entry) didn't and was blocking pre-commit / CI lint on **every open PR** in this repo.

This PR:
- Replaces three silent skips in `skill_scanner.go` with `slog.Warn` calls before `return nil`.
- Replaces three silent skips (including the two existing `//nolint:nilerr` lines) in `notebook_signal_scanner.go` with the same pattern, for consistency and so unreadable notebook files leave a trace.
- Walk behaviour is unchanged; the only change is observability.

CLAUDE.md rule: *"Never suppress lint warnings with ignore comments — fix the code"* — this also drops the two pre-existing `//nolint:nilerr` annotations.

## Why now

Every PR in flight (`#361`, `#362`, `#367`, `#368`, `#372`, `#379`) was failing the `lint` job and blocked from clean rebase commits because the pre-commit hook also fails. Unblocking the gate.

## Test plan
- [x] `golangci-lint run ./internal/team/...` — 0 issues
- [x] `go vet ./...` — clean
- [x] `go test ./internal/team -run 'TestSkillScanner|TestNotebookSignalScanner|TestCollectCandidates|TestCollectNotebook' -count=1` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging in file scanning operations to provide explicit diagnostic messages when directory traversal, file access, or path computation issues occur, while maintaining non-disruptive error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->