### PR TITLE
feat(headless): stream live output and surface agent issues

### DIFF
--- a/internal/team/agent_issue.go
+++ b/internal/team/agent_issue.go
@@ -1,0 +1,423 @@
+package team
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+)
+
+const agentIssueMessageKind = "agent_issue"
+
+var agentIssueWhitespacePattern = regexp.MustCompile(`\s+`)
+
+type agentIssueClassification struct {
+	Visible       bool
+	CapabilityGap bool
+	HumanAction   bool
+	Severity      string
+}
+
+func (b *Broker) ReportAgentIssue(agentSlug, targetChannel, replyTo, detail string) (channelMessage, agentIssueRecord, bool, error) {
+	if b == nil {
+		return channelMessage{}, agentIssueRecord{}, false, nil
+	}
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return channelMessage{}, agentIssueRecord{}, false, nil
+	}
+	classification := classifyAgentIssue(detail)
+	if !classification.Visible {
+		return channelMessage{}, agentIssueRecord{}, false, nil
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	agentSlug = strings.TrimSpace(agentSlug)
+	if agentSlug == "" {
+		agentSlug = "agent"
+	}
+	channel := normalizeChannelSlug(targetChannel)
+	if channel == "" {
+		channel = "general"
+	}
+	if b.findChannelLocked(channel) == nil {
+		if IsDMSlug(channel) {
+			if dm := b.ensureDMConversationLocked(channel); dm != nil {
+				channel = dm.Slug
+			}
+		}
+		if b.findChannelLocked(channel) == nil {
+			return channelMessage{}, agentIssueRecord{}, false, fmt.Errorf("channel not found")
+		}
+	}
+	if !b.canAccessChannelLocked(agentSlug, channel) {
+		return channelMessage{}, agentIssueRecord{}, false, fmt.Errorf("channel access denied")
+	}
+
+	taskID := b.activeTaskIDForAgentLocked(agentSlug)
+	key := normalizedAgentIssueKey(agentSlug, channel, detail)
+	now := time.Now().UTC().Format(time.RFC3339)
+	for i := range b.agentIssues {
+		issue := &b.agentIssues[i]
+		if issue.Agent != agentSlug || issue.Channel != channel || issue.NormalizedKey != key {
+			continue
+		}
+		issue.Count++
+		issue.UpdatedAt = now
+		if issue.TaskID == "" {
+			issue.TaskID = taskID
+		}
+		if classification.CapabilityGap && !classification.HumanAction {
+			b.ensureSelfHealApprovalRequestLocked(issue, classification, detail)
+		}
+		if err := b.saveLocked(); err != nil {
+			return channelMessage{}, *issue, false, err
+		}
+		return channelMessage{}, *issue, false, nil
+	}
+
+	b.counter++
+	issueID := fmt.Sprintf("issue-%d", b.counter)
+	issue := agentIssueRecord{
+		ID:            issueID,
+		Agent:         agentSlug,
+		Channel:       channel,
+		ReplyTo:       strings.TrimSpace(replyTo),
+		Detail:        detail,
+		NormalizedKey: key,
+		Severity:      classification.Severity,
+		TaskID:        taskID,
+		Count:         1,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+
+	b.counter++
+	msg := channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      agentSlug,
+		Channel:   channel,
+		Kind:      agentIssueMessageKind,
+		EventID:   issue.ID,
+		Content:   "Issue: " + truncate(detail, 600),
+		ReplyTo:   strings.TrimSpace(replyTo),
+		Timestamp: now,
+	}
+	b.agentIssues = append(b.agentIssues, issue)
+	issuePtr := &b.agentIssues[len(b.agentIssues)-1]
+	b.appendMessageLocked(msg)
+	b.appendActionLocked("agent_issue", "office", channel, agentSlug, truncateSummary(msg.Content, 140), issue.ID)
+	if classification.CapabilityGap && !classification.HumanAction {
+		b.ensureSelfHealApprovalRequestLocked(issuePtr, classification, detail)
+	}
+	if err := b.saveLocked(); err != nil {
+		return channelMessage{}, *issuePtr, false, err
+	}
+	return msg, *issuePtr, true, nil
+}
+
+func (b *Broker) AgentIssues() []agentIssueRecord {
+	if b == nil {
+		return nil
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]agentIssueRecord, len(b.agentIssues))
+	copy(out, b.agentIssues)
+	return out
+}
+
+func (b *Broker) pruneAgentIssuesByChannelLocked(channelSlug string) {
+	b.pruneAgentIssuesByChannelAndAgentLocked(channelSlug, "")
+}
+
+func (b *Broker) pruneAgentIssuesByChannelAndAgentLocked(channelSlug, agentSlug string) {
+	channelSlug = normalizeChannelSlug(channelSlug)
+	if channelSlug == "" || len(b.agentIssues) == 0 {
+		return
+	}
+	agentSlug = strings.TrimSpace(agentSlug)
+	removedRequestIDs := make(map[string]struct{})
+	filtered := b.agentIssues[:0]
+	for _, issue := range b.agentIssues {
+		if normalizeChannelSlug(issue.Channel) != channelSlug || (agentSlug != "" && strings.TrimSpace(issue.Agent) != agentSlug) {
+			filtered = append(filtered, issue)
+			continue
+		}
+		if reqID := strings.TrimSpace(issue.ApprovalRequestID); reqID != "" {
+			removedRequestIDs[reqID] = struct{}{}
+		}
+	}
+	b.agentIssues = filtered
+	if len(removedRequestIDs) == 0 {
+		return
+	}
+	requests := b.requests[:0]
+	for _, req := range b.requests {
+		if _, remove := removedRequestIDs[strings.TrimSpace(req.ID)]; !remove {
+			requests = append(requests, req)
+		}
+	}
+	b.requests = requests
+	b.pendingInterview = firstBlockingRequest(b.requests)
+}
+
+func classifyAgentIssue(detail string) agentIssueClassification {
+	trimmed := strings.TrimSpace(detail)
+	if trimmed == "" {
+		return agentIssueClassification{}
+	}
+	if looksStructuredAgentIssuePayload(trimmed) {
+		return agentIssueClassification{}
+	}
+	text := strings.ToLower(trimmed)
+	visibleSignals := []string{
+		"error", "failed", "failure", "unavailable", "not available", "not configured",
+		"not connected", "missing", "denied", "forbidden", "unauthorized", "requires",
+		"cannot", "can't", "unable", "unsupported", "timed out", "timeout",
+	}
+	visible := false
+	for _, signal := range visibleSignals {
+		if strings.Contains(text, signal) {
+			visible = true
+			break
+		}
+	}
+	if !visible {
+		return agentIssueClassification{}
+	}
+	humanAction := strings.Contains(text, "login") ||
+		strings.Contains(text, "sign in") ||
+		strings.Contains(text, "authenticate") ||
+		strings.Contains(text, "oauth") ||
+		strings.Contains(text, "two-factor") ||
+		strings.Contains(text, "2fa")
+	return agentIssueClassification{
+		Visible:       true,
+		CapabilityGap: isCapabilityGapBlocker(detail),
+		HumanAction:   humanAction,
+		Severity:      "warning",
+	}
+}
+
+func looksStructuredAgentIssuePayload(text string) bool {
+	if text == "" {
+		return false
+	}
+	if (strings.HasPrefix(text, "{") || strings.HasPrefix(text, "[")) && json.Valid([]byte(text)) {
+		return true
+	}
+	return strings.Contains(text, `":`) && json.Valid([]byte(text))
+}
+
+func normalizedAgentIssueKey(agentSlug, channel, detail string) string {
+	text := strings.ToLower(strings.TrimSpace(detail))
+	for _, prefix := range []string{"issue:", "error:", "failed:", "failure:"} {
+		text = strings.TrimSpace(strings.TrimPrefix(text, prefix))
+	}
+	text = agentIssueWhitespacePattern.ReplaceAllString(text, " ")
+	if len(text) > 180 {
+		text = text[:180]
+	}
+	return strings.Join([]string{strings.TrimSpace(agentSlug), normalizeChannelSlug(channel), text}, "|")
+}
+
+func (b *Broker) activeTaskIDForAgentLocked(agentSlug string) string {
+	agentSlug = strings.TrimSpace(agentSlug)
+	if agentSlug == "" {
+		return ""
+	}
+	for i := range b.tasks {
+		task := &b.tasks[i]
+		if strings.TrimSpace(task.Owner) != agentSlug {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(task.Status), "in_progress") {
+			return task.ID
+		}
+	}
+	return ""
+}
+
+func (b *Broker) ensureSelfHealApprovalRequestLocked(issue *agentIssueRecord, classification agentIssueClassification, detail string) {
+	if b == nil || issue == nil || issue.SelfHealTaskID != "" {
+		return
+	}
+	if req := b.findRequestByIDLocked(issue.ApprovalRequestID); req != nil {
+		if requestIsActive(*req) {
+			return
+		}
+		if req.Answered != nil {
+			if selfHealApprovalGranted(req.Answered.ChoiceID) {
+				b.maybeCreateApprovedSelfHealTaskLocked(*req)
+			}
+			return
+		}
+	}
+
+	b.counter++
+	now := time.Now().UTC().Format(time.RFC3339)
+	req := humanInterview{
+		ID:       fmt.Sprintf("request-%d", b.counter),
+		Kind:     "approval",
+		Status:   "pending",
+		From:     "system",
+		Channel:  issue.Channel,
+		Title:    "Approve self-heal",
+		Question: fmt.Sprintf("I recommend creating a self-heal task to restore @%s's missing capability. Proceed?", issue.Agent),
+		Context: strings.Join([]string{
+			"Agent issue: " + detail,
+			"Incident: " + issue.ID,
+			"Original task: " + valueOrUnknown(issue.TaskID),
+		}, "\n"),
+		Options: []interviewOption{
+			{ID: "approve", Label: "Proceed", Description: "Create the recommended self-heal task."},
+			{ID: "approve_with_note", Label: "Proceed with note", Description: "Create the task with extra constraints.", RequiresText: true, TextHint: "Type constraints or guardrails for the repair task."},
+			{ID: "reject", Label: "Dismiss", Description: "Do not create repair work for this issue."},
+			{ID: "reject_with_steer", Label: "Override", Description: "Do not use the default repair path. Provide different steering.", RequiresText: true, TextHint: "Type the alternate repair path or reason to skip."},
+		},
+		RecommendedID: "approve",
+		Blocking:      false,
+		Required:      false,
+		ReplyTo:       strings.TrimSpace(issue.ReplyTo),
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	req.Options, req.RecommendedID = normalizeRequestOptions(req.Kind, req.RecommendedID, req.Options)
+	b.scheduleRequestLifecycleLocked(&req)
+	b.requests = append(b.requests, req)
+	b.pendingInterview = firstBlockingRequest(b.requests)
+	issue.ApprovalRequestID = req.ID
+	issue.UpdatedAt = now
+	b.counter++
+	b.appendMessageLocked(channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "system",
+		Channel:   issue.Channel,
+		Kind:      "approval",
+		EventID:   req.ID,
+		Title:     req.Title,
+		Content:   req.Question,
+		Tagged:    uniqueSlugs([]string{issue.Agent}),
+		ReplyTo:   strings.TrimSpace(issue.ReplyTo),
+		Timestamp: now,
+	})
+	b.appendActionLocked("request_created", "office", issue.Channel, req.From, truncateSummary(req.Title+" "+req.Question, 140), req.ID)
+}
+
+func (b *Broker) findRequestByIDLocked(id string) *humanInterview {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil
+	}
+	for i := range b.requests {
+		if b.requests[i].ID == id {
+			return &b.requests[i]
+		}
+	}
+	return nil
+}
+
+func selfHealApprovalGranted(choiceID string) bool {
+	switch strings.TrimSpace(choiceID) {
+	case "approve", "approve_with_note", "confirm_proceed", "proceed":
+		return true
+	default:
+		return false
+	}
+}
+
+func (b *Broker) maybeCreateApprovedSelfHealTaskLocked(req humanInterview) {
+	if !selfHealApprovalGranted(req.Answered.GetChoiceID()) {
+		return
+	}
+	var issue *agentIssueRecord
+	for i := range b.agentIssues {
+		if b.agentIssues[i].ApprovalRequestID == req.ID {
+			issue = &b.agentIssues[i]
+			break
+		}
+	}
+	if issue == nil || issue.SelfHealTaskID != "" {
+		return
+	}
+	detail := issue.Detail
+	if note := strings.TrimSpace(req.Answered.GetCustomText()); note != "" {
+		detail = strings.TrimSpace(detail + "\n\nHuman constraints: " + note)
+	}
+	task, _, err := b.requestSelfHealingLocked(issue.Agent, issue.TaskID, agent.EscalationCapabilityGap, detail)
+	if err != nil {
+		log.Printf("agent-issue: create approved self-heal task for issue=%s agent=%s: %v", issue.ID, issue.Agent, err)
+		errText := strings.TrimSpace(err.Error())
+		if errText == "" {
+			errText = "unknown error"
+		}
+		alreadyReported := issue.SelfHealError == errText
+		now := time.Now().UTC().Format(time.RFC3339)
+		issue.SelfHealError = errText
+		issue.UpdatedAt = now
+		if !alreadyReported {
+			b.notifySelfHealCreationFailureLocked(issue, errText, now)
+		}
+		return
+	}
+	issue.SelfHealTaskID = task.ID
+	issue.SelfHealError = ""
+	issue.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+}
+
+func (b *Broker) notifySelfHealCreationFailureLocked(issue *agentIssueRecord, errText, now string) {
+	if b == nil || issue == nil {
+		return
+	}
+	agentSlug := strings.TrimSpace(issue.Agent)
+	if agentSlug == "" {
+		agentSlug = "agent"
+	}
+	channel := normalizeChannelSlug(issue.Channel)
+	if channel == "" {
+		channel = "general"
+	}
+	content := fmt.Sprintf("Issue: approved self-heal for @%s could not be created: %s", agentSlug, truncate(errText, 400))
+	b.counter++
+	b.appendMessageLocked(channelMessage{
+		ID:        fmt.Sprintf("msg-%d", b.counter),
+		From:      "system",
+		Channel:   channel,
+		Kind:      agentIssueMessageKind,
+		EventID:   strings.TrimSpace(issue.ID),
+		Content:   content,
+		Tagged:    uniqueSlugs([]string{agentSlug}),
+		ReplyTo:   strings.TrimSpace(issue.ReplyTo),
+		Timestamp: now,
+	})
+	b.appendActionLocked("agent_issue", "office", channel, "system", truncateSummary(content, 140), strings.TrimSpace(issue.ID))
+}
+
+func (a *interviewAnswer) GetChoiceID() string {
+	if a == nil {
+		return ""
+	}
+	return strings.TrimSpace(a.ChoiceID)
+}
+
+func (a *interviewAnswer) GetCustomText() string {
+	if a == nil {
+		return ""
+	}
+	return strings.TrimSpace(a.CustomText)
+}
+
+func valueOrUnknown(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -154,6 +154,23 @@ type channelMessage struct {
 	Reactions   []messageReaction `json:"reactions,omitempty"`
 }
 
+type agentIssueRecord struct {
+	ID                string `json:"id"`
+	Agent             string `json:"agent"`
+	Channel           string `json:"channel"`
+	ReplyTo           string `json:"reply_to,omitempty"`
+	Detail            string `json:"detail"`
+	NormalizedKey     string `json:"normalized_key"`
+	Severity          string `json:"severity,omitempty"`
+	TaskID            string `json:"task_id,omitempty"`
+	SelfHealTaskID    string `json:"self_heal_task_id,omitempty"`
+	SelfHealError     string `json:"self_heal_error,omitempty"`
+	ApprovalRequestID string `json:"approval_request_id,omitempty"`
+	Count             int    `json:"count"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+}
+
 type messageUsage struct {
 	InputTokens         int `json:"input_tokens,omitempty"`
 	OutputTokens        int `json:"output_tokens,omitempty"`
@@ -428,6 +445,7 @@ type teamSkill struct {
 type brokerState struct {
 	ChannelStore      json.RawMessage              `json:"channel_store,omitempty"`
 	Messages          []channelMessage             `json:"messages"`
+	AgentIssues       []agentIssueRecord           `json:"agent_issues,omitempty"`
 	Members           []officeMember               `json:"members,omitempty"`
 	Channels          []teamChannel                `json:"channels,omitempty"`
 	SessionMode       string                       `json:"session_mode,omitempty"`
@@ -476,6 +494,7 @@ type ipRateLimitBucket struct {
 type Broker struct {
 	channelStore            *channel.Store
 	messages                []channelMessage
+	agentIssues             []agentIssueRecord
 	members                 []officeMember
 	memberIndex             map[string]int // slug → index into members; guarded by mu
 	channels                []teamChannel
@@ -3212,6 +3231,7 @@ func (b *Broker) Reset() {
 	mode := b.sessionMode
 	agent := b.oneOnOneAgent
 	b.messages = nil
+	b.agentIssues = nil
 	b.members = defaultOfficeMembers()
 	b.channels = defaultTeamChannels()
 	b.sessionMode = mode
@@ -3276,6 +3296,7 @@ func loadBrokerStateFile(path string) (brokerState, error) {
 func brokerStateActivityScore(state brokerState) int {
 	score := 0
 	score += len(state.Messages) * 10
+	score += len(state.AgentIssues) * 8
 	score += len(state.Tasks) * 20
 	score += len(activeRequests(state.Requests)) * 10
 	score += len(state.Actions) * 4
@@ -3318,6 +3339,7 @@ func (b *Broker) loadState() error {
 		}
 	}
 	b.messages = state.Messages
+	b.agentIssues = state.AgentIssues
 	b.members = state.Members
 	b.channels = state.Channels
 	b.sessionMode = state.SessionMode
@@ -3382,7 +3404,7 @@ func (b *Broker) saveLocked() error {
 	}
 	path := b.statePath
 	snapshotPath := b.stateSnapshotPath()
-	if len(b.messages) == 0 && len(b.tasks) == 0 && len(activeRequests(b.requests)) == 0 && len(b.actions) == 0 && len(b.signals) == 0 && len(b.decisions) == 0 && len(b.watchdogs) == 0 && len(b.policies) == 0 && len(b.scheduler) == 0 && len(b.skills) == 0 && len(b.sharedMemory) == 0 && isDefaultChannelState(b.channels) && isDefaultOfficeMemberState(b.members) && b.counter == 0 && b.notificationSince == "" && b.insightsSince == "" && usageStateIsZero(b.usage) && b.sessionMode == SessionModeOffice && b.oneOnOneAgent == DefaultOneOnOneAgent {
+	if len(b.messages) == 0 && len(b.agentIssues) == 0 && len(b.tasks) == 0 && len(activeRequests(b.requests)) == 0 && len(b.actions) == 0 && len(b.signals) == 0 && len(b.decisions) == 0 && len(b.watchdogs) == 0 && len(b.policies) == 0 && len(b.scheduler) == 0 && len(b.skills) == 0 && len(b.sharedMemory) == 0 && isDefaultChannelState(b.channels) && isDefaultOfficeMemberState(b.members) && b.counter == 0 && b.notificationSince == "" && b.insightsSince == "" && usageStateIsZero(b.usage) && b.sessionMode == SessionModeOffice && b.oneOnOneAgent == DefaultOneOnOneAgent {
 		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
@@ -3403,6 +3425,7 @@ func (b *Broker) saveLocked() error {
 	state := brokerState{
 		ChannelStore:      channelStoreRaw,
 		Messages:          b.messages,
+		AgentIssues:       b.agentIssues,
 		Members:           b.members,
 		Channels:          b.channels,
 		SessionMode:       b.sessionMode,
@@ -3725,6 +3748,19 @@ func (b *Broker) normalizeLoadedStateLocked() {
 	for i := range b.messages {
 		if strings.TrimSpace(b.messages[i].Channel) == "" {
 			b.messages[i].Channel = "general"
+		}
+	}
+	for i := range b.agentIssues {
+		issueChannel := normalizeChannelSlug(channel.MigrateDMSlugString(b.agentIssues[i].Channel))
+		if issueChannel == "" {
+			issueChannel = "general"
+		}
+		b.agentIssues[i].Channel = issueChannel
+		if strings.TrimSpace(b.agentIssues[i].UpdatedAt) == "" {
+			b.agentIssues[i].UpdatedAt = b.agentIssues[i].CreatedAt
+		}
+		if b.agentIssues[i].Count <= 0 {
+			b.agentIssues[i].Count = 1
 		}
 	}
 	for i := range b.tasks {
@@ -5668,6 +5704,7 @@ func (b *Broker) handleResetDM(w http.ResponseWriter, r *http.Request) {
 		filtered = append(filtered, msg)
 	}
 	b.messages = filtered
+	b.pruneAgentIssuesByChannelAndAgentLocked(channel, agent)
 	_ = b.saveLocked()
 	b.mu.Unlock()
 
@@ -7979,6 +8016,7 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 			}
 			b.requests = filteredRequests
 			b.pendingInterview = firstBlockingRequest(b.requests)
+			b.pruneAgentIssuesByChannelLocked(slug)
 			if err := b.saveLocked(); err != nil {
 				http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
 				return
@@ -11222,6 +11260,7 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 				}
 			}
 		}
+		b.maybeCreateApprovedSelfHealTaskLocked(b.requests[i])
 
 		b.counter++
 		msg := channelMessage{

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -142,6 +142,9 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	var firstTextAt time.Time
 	var firstToolAt time.Time
 	textStarted := false
+	liveChat := newHeadlessLiveChatRelay(l, slug, firstNonEmpty(channel...), notification, func(line string) {
+		appendHeadlessClaudeLog(slug, line)
+	})
 
 	result, parseErr := provider.ReadClaudeJSONStream(teedStdout, func(event provider.ClaudeStreamEvent) {
 		if firstEventAt.IsZero() {
@@ -160,7 +163,9 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 				textStarted = true
 				l.updateHeadlessProgress(slug, "active", "text", "drafting response", metrics)
 			}
+			liveChat.OnText(event.Text)
 		case "tool_use":
+			liveChat.Flush()
 			if firstToolAt.IsZero() {
 				firstToolAt = time.Now()
 				metrics.FirstToolMs = durationMillis(startedAt, firstToolAt)
@@ -170,11 +175,14 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 		case "tool_result":
 			appendHeadlessClaudeLog(slug, "tool_result: "+truncate(event.Text, 140))
 			l.updateHeadlessProgress(slug, "active", "tool_result", truncate(event.Text, 140), metrics)
+			liveChat.ReportIssue(event.Text)
 		case "error":
 			appendHeadlessClaudeLog(slug, "stream_error: "+event.Detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(event.Detail, 180), metrics)
+			liveChat.ReportIssue(event.Detail)
 		}
 	})
+	liveChat.Flush()
 	_ = pw.Close() // signal scanner goroutine that stream is done (io.PipeWriter.Close always returns nil)
 	if err := cmd.Wait(); err != nil {
 		detail := strings.TrimSpace(firstNonEmpty(result.LastError, strings.TrimSpace(stderr.String()), err.Error()))

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -833,8 +833,7 @@ func (l *Launcher) agentPostedSubstantiveMessageSince(slug string, startedAt tim
 		if msg.From != slug {
 			continue
 		}
-		content := strings.TrimSpace(msg.Content)
-		if content == "" || strings.HasPrefix(content, "[STATUS]") {
+		if !isSubstantiveAgentProgressMessage(msg) {
 			continue
 		}
 		when, err := time.Parse(time.RFC3339, msg.Timestamp)
@@ -865,8 +864,7 @@ func (l *Launcher) agentPostedSubstantiveMessageToChannelSince(slug string, targ
 		if targetChannel != "" && normalizeChannelSlug(msg.Channel) != targetChannel {
 			continue
 		}
-		content := strings.TrimSpace(msg.Content)
-		if content == "" || strings.HasPrefix(content, "[STATUS]") {
+		if !isSubstantiveAgentProgressMessage(msg) {
 			continue
 		}
 		when, err := time.Parse(time.RFC3339, msg.Timestamp)
@@ -905,6 +903,14 @@ func (l *Launcher) postHeadlessFinalMessageIfSilent(slug string, targetChannel s
 		return channelMessage{}, false, err
 	}
 	return msg, true, nil
+}
+
+func isSubstantiveAgentProgressMessage(msg channelMessage) bool {
+	if strings.TrimSpace(msg.Kind) == agentIssueMessageKind {
+		return false
+	}
+	content := strings.TrimSpace(msg.Content)
+	return content != "" && !strings.HasPrefix(content, "[STATUS]")
 }
 
 func headlessReplyToID(notification string) string {
@@ -1289,6 +1295,9 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	var firstTextAt time.Time
 	var firstToolAt time.Time
 	textStarted := false
+	liveChat := newHeadlessLiveChatRelay(l, slug, firstNonEmpty(channel...), notification, func(line string) {
+		appendHeadlessCodexLog(slug, line)
+	})
 	result, parseErr := provider.ReadCodexJSONStream(teedStdout, func(event provider.CodexStreamEvent) {
 		if firstEventAt.IsZero() {
 			firstEventAt = time.Now()
@@ -1304,7 +1313,9 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 				textStarted = true
 				l.updateHeadlessProgress(slug, "active", "text", "drafting response", metrics)
 			}
+			liveChat.OnText(event.Text)
 		case "tool_use":
+			liveChat.Flush()
 			if firstToolAt.IsZero() {
 				firstToolAt = time.Now()
 				metrics.FirstToolMs = durationMillis(startedAt, firstToolAt)
@@ -1316,11 +1327,14 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			line := "tool_result: " + truncate(event.Text, 140)
 			appendHeadlessCodexLog(slug, line)
 			l.updateHeadlessProgress(slug, "active", "tool_result", truncate(event.Text, 140), metrics)
+			liveChat.ReportIssue(event.Text)
 		case "error":
 			appendHeadlessCodexLog(slug, "stream_error: "+event.Detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(event.Detail, 180), metrics)
+			liveChat.ReportIssue(event.Detail)
 		}
 	})
+	liveChat.Flush()
 	_ = pw.Close() // signal scanner goroutine that stream is done (io.PipeWriter.Close always returns nil)
 	if err := cmd.Wait(); err != nil {
 		detail := firstNonEmpty(result.LastError, strings.TrimSpace(stderr.String()))

--- a/internal/team/headless_live_chat_relay.go
+++ b/internal/team/headless_live_chat_relay.go
@@ -1,0 +1,130 @@
+package team
+
+import (
+	"strings"
+)
+
+const (
+	headlessLiveChatMinFlushChars = 16
+	headlessLiveChatMaxFlushChars = 480
+)
+
+type headlessLiveChatRelay struct {
+	l            *Launcher
+	slug         string
+	channel      string
+	replyTo      string
+	logf         func(string)
+	buf          strings.Builder
+	lastPosted   string
+	postFailures int
+}
+
+func newHeadlessLiveChatRelay(l *Launcher, slug string, targetChannel string, notification string, logf func(string)) *headlessLiveChatRelay {
+	if l == nil || l.broker == nil {
+		return nil
+	}
+	targetChannel = normalizeChannelSlug(targetChannel)
+	if targetChannel == "" {
+		targetChannel = "general"
+	}
+	if IsDMSlug(targetChannel) {
+		if targetAgent := DMTargetAgent(targetChannel); targetAgent != "" {
+			targetChannel = DMSlugFor(targetAgent)
+		}
+	}
+	return &headlessLiveChatRelay{
+		l:       l,
+		slug:    strings.TrimSpace(slug),
+		channel: targetChannel,
+		replyTo: headlessReplyToID(notification),
+		logf:    logf,
+	}
+}
+
+func (r *headlessLiveChatRelay) OnText(chunk string) {
+	if r == nil || chunk == "" {
+		return
+	}
+	r.buf.WriteString(chunk)
+	text := r.buf.String()
+	if len(strings.TrimSpace(text)) >= headlessLiveChatMaxFlushChars || headlessLiveChatShouldFlush(text) {
+		r.Flush()
+	}
+}
+
+func (r *headlessLiveChatRelay) Flush() {
+	if r == nil || r.l == nil || r.l.broker == nil {
+		return
+	}
+	text := strings.TrimSpace(r.buf.String())
+	r.buf.Reset()
+	r.postText(text)
+}
+
+func (r *headlessLiveChatRelay) ReportIssue(detail string) {
+	if r == nil || r.l == nil || r.l.broker == nil {
+		return
+	}
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return
+	}
+	r.Flush()
+	msg, _, posted, err := r.l.broker.ReportAgentIssue(r.slug, r.channel, r.replyTo, detail)
+	if err != nil {
+		r.postFailures++
+		if r.logf != nil && r.postFailures <= 3 {
+			r.logf("live-chat-relay-issue-error: " + err.Error())
+		}
+		return
+	}
+	if posted {
+		r.lastPosted = msg.Content
+		if r.logf != nil {
+			r.logf("live-chat-relay-post: posted streamed issue to #" + msg.Channel + " as " + msg.ID)
+		}
+	}
+}
+
+func (r *headlessLiveChatRelay) postText(text string) {
+	if r == nil || r.l == nil || r.l.broker == nil {
+		return
+	}
+	text = strings.TrimSpace(text)
+	if text == "" || text == r.lastPosted || looksUnparsedToolCall(text) {
+		return
+	}
+	msg, err := r.l.broker.PostMessage(r.slug, r.channel, text, nil, r.replyTo)
+	if err != nil {
+		r.postFailures++
+		if r.logf != nil && r.postFailures <= 3 {
+			r.logf("live-chat-relay-post-error: " + err.Error())
+		}
+		return
+	}
+	r.lastPosted = text
+	if r.logf != nil {
+		r.logf("live-chat-relay-post: posted streamed output to #" + msg.Channel + " as " + msg.ID)
+	}
+}
+
+func headlessLiveChatShouldFlush(text string) bool {
+	if strings.Contains(text, "\n\n") {
+		return len(strings.TrimSpace(text)) >= headlessLiveChatMinFlushChars
+	}
+	trimmed := strings.TrimSpace(text)
+	if len(trimmed) < headlessLiveChatMinFlushChars {
+		return false
+	}
+	switch trimmed[len(trimmed)-1] {
+	case '.', '!', '?':
+		return true
+	default:
+		return false
+	}
+}
+
+func headlessLiveChatLooksIssue(text string) bool {
+	return classifyAgentIssue(text).Visible
+}

--- a/internal/team/headless_live_chat_relay_test.go
+++ b/internal/team/headless_live_chat_relay_test.go
@@ -1,0 +1,415 @@
+package team
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHeadlessLiveChatRelayPostsStreamedTextToChannel(t *testing.T) {
+	b := newTestBroker(t)
+	root, err := b.PostMessage("you", "general", "What is happening?", nil, "")
+	if err != nil {
+		t.Fatalf("post human message: %v", err)
+	}
+	l := &Launcher{broker: b}
+	startedAt := time.Now().UTC().Add(-1 * time.Second)
+	var logs []string
+	relay := newHeadlessLiveChatRelay(
+		l,
+		"ceo",
+		"general",
+		fmt.Sprintf(`Reply using team_broadcast with reply_to_id "%s".`, root.ID),
+		func(line string) { logs = append(logs, line) },
+	)
+
+	relay.OnText("I will check the live stream now.")
+
+	msgs := b.ChannelMessages("general")
+	if len(msgs) != 2 {
+		t.Fatalf("expected human root + streamed agent message, got %d: %+v", len(msgs), msgs)
+	}
+	got := msgs[1]
+	if got.From != "ceo" || got.Content != "I will check the live stream now." || got.ReplyTo != root.ID {
+		t.Fatalf("unexpected streamed message: %+v", got)
+	}
+	if len(logs) != 1 {
+		t.Fatalf("expected relay log entry, got %+v", logs)
+	}
+
+	_, posted, err := l.postHeadlessFinalMessageIfSilent("ceo", "general", "", "late summary", startedAt)
+	if err != nil {
+		t.Fatalf("fallback post: %v", err)
+	}
+	if posted {
+		t.Fatal("expected final fallback to skip after streamed text was posted")
+	}
+}
+
+func TestOpenAICompatLiveChatRelayDoesNotPostJSONToolShape(t *testing.T) {
+	b := newTestBroker(t)
+	if _, err := b.PostMessage("you", "general", "Please do the task.", nil, ""); err != nil {
+		t.Fatalf("post human message: %v", err)
+	}
+	l := &Launcher{broker: b}
+	relay := newHeadlessLiveChatRelay(l, "ceo", "general", "", nil)
+	sinks := &fakeTurnSinks{}
+	st := newOpenAICompatTurnState(sinks, relay)
+
+	st.onText(`{"name":`)
+	st.onText(`"team_broadcast","arguments":`)
+	st.onText(`{"channel":"general","content":"hello"}}`)
+	st.onToolUseChunk("team_broadcast", `{"channel":"general"}`)
+
+	msgs := b.ChannelMessages("general")
+	if len(msgs) != 1 {
+		t.Fatalf("expected only the human root; JSON tool stream leaked to chat: %+v", msgs)
+	}
+}
+
+func TestHeadlessLiveChatRelayReportsIssueImmediately(t *testing.T) {
+	b := newTestBroker(t)
+	root, err := b.PostMessage("you", "general", "Open the browser.", nil, "")
+	if err != nil {
+		t.Fatalf("post human message: %v", err)
+	}
+	l := &Launcher{broker: b}
+	relay := newHeadlessLiveChatRelay(
+		l,
+		"ceo",
+		"general",
+		fmt.Sprintf(`Reply using team_broadcast with reply_to_id "%s".`, root.ID),
+		nil,
+	)
+
+	relay.ReportIssue("browser access is not available")
+
+	msgs := b.ChannelMessages("general")
+	if len(msgs) != 3 {
+		t.Fatalf("expected issue to post immediately, got %+v", msgs)
+	}
+	got := msgs[1]
+	if got.From != "ceo" || got.Kind != agentIssueMessageKind || got.ReplyTo != root.ID || got.Content != "Issue: browser access is not available" {
+		t.Fatalf("unexpected issue message: %+v", got)
+	}
+	if approval := msgs[2]; approval.From != "system" || approval.Kind != "approval" || approval.EventID == "" || approval.Content == "" {
+		t.Fatalf("expected inline approval recommendation, got %+v", approval)
+	}
+	if tasks := b.AllTasks(); len(tasks) != 0 {
+		t.Fatalf("expected issue report to ask before creating self-heal task, got %+v", tasks)
+	}
+	requests := b.Requests("general", false)
+	if len(requests) != 1 || requests[0].RecommendedID != "approve" {
+		t.Fatalf("expected recommended approval request, got %+v", requests)
+	}
+}
+
+func TestHeadlessLiveChatRelayFlushesBufferedTextBeforeIssue(t *testing.T) {
+	b := newTestBroker(t)
+	l := &Launcher{broker: b}
+	relay := newHeadlessLiveChatRelay(l, "ceo", "general", "", nil)
+
+	relay.OnText("I found context and will continue")
+	relay.ReportIssue("browser access is not available")
+
+	msgs := b.ChannelMessages("general")
+	if len(msgs) != 3 {
+		t.Fatalf("expected prose, issue, and approval messages, got %+v", msgs)
+	}
+	if got := msgs[0].Content; got != "I found context and will continue" {
+		t.Fatalf("expected buffered prose to post first, got %q", got)
+	}
+	if msgs[1].Kind != agentIssueMessageKind {
+		t.Fatalf("expected issue second, got %+v", msgs)
+	}
+}
+
+func TestHeadlessLiveChatRelayPreservesWhitespaceChunks(t *testing.T) {
+	b := newTestBroker(t)
+	l := &Launcher{broker: b}
+	relay := newHeadlessLiveChatRelay(l, "ceo", "general", "", nil)
+
+	relay.OnText("Starting live")
+	relay.OnText(" ")
+	relay.OnText("now.")
+
+	msgs := b.ChannelMessages("general")
+	if len(msgs) != 1 {
+		t.Fatalf("expected one flushed prose message, got %+v", msgs)
+	}
+	if got := msgs[0].Content; got != "Starting live now." {
+		t.Fatalf("expected whitespace chunk to be preserved, got %q", got)
+	}
+}
+
+func TestOpenAICompatToolErrorReportsIssueToChat(t *testing.T) {
+	b := newTestBroker(t)
+	if _, err := b.PostMessage("you", "general", "Use the browser.", nil, ""); err != nil {
+		t.Fatalf("post human message: %v", err)
+	}
+	l := &Launcher{broker: b}
+	relay := newHeadlessLiveChatRelay(l, "ceo", "general", "", nil)
+	sinks := &fakeTurnSinks{}
+	st := newOpenAICompatTurnState(sinks, relay)
+
+	st.onToolResult("browser_open", "ERROR: browser access is not available", nil)
+
+	msgs := b.ChannelMessages("general")
+	if len(msgs) != 3 {
+		t.Fatalf("expected tool error to post to chat, got %+v", msgs)
+	}
+	if got := msgs[1].Content; got != "Issue: ERROR: browser access is not available" {
+		t.Fatalf("unexpected issue content: %q", got)
+	}
+	if msgs[1].Kind != agentIssueMessageKind {
+		t.Fatalf("expected agent_issue kind, got %+v", msgs[1])
+	}
+}
+
+func TestReportAgentIssueSuppressesStructuredPayloads(t *testing.T) {
+	b := newTestBroker(t)
+
+	_, _, posted, err := b.ReportAgentIssue("ceo", "general", "", `{"error":"browser access is not available"}`)
+	if err != nil {
+		t.Fatalf("report issue: %v", err)
+	}
+	if posted {
+		t.Fatal("expected structured JSON payload to be suppressed")
+	}
+	if len(b.ChannelMessages("general")) != 0 {
+		t.Fatalf("expected no chat messages, got %+v", b.ChannelMessages("general"))
+	}
+	if len(b.AgentIssues()) != 0 {
+		t.Fatalf("expected no agent issues, got %+v", b.AgentIssues())
+	}
+}
+
+func TestReportAgentIssueDedupesRepeatedStreamIssue(t *testing.T) {
+	b := newTestBroker(t)
+	l := &Launcher{broker: b}
+	relay := newHeadlessLiveChatRelay(l, "ceo", "general", "", nil)
+
+	relay.ReportIssue("browser access is not available")
+	relay.ReportIssue("ERROR: browser access is not available")
+
+	msgs := b.ChannelMessages("general")
+	if len(msgs) != 2 {
+		t.Fatalf("expected one issue message, got %+v", msgs)
+	}
+	issues := b.AgentIssues()
+	if len(issues) != 1 || issues[0].Count != 2 {
+		t.Fatalf("expected one counted issue, got %+v", issues)
+	}
+	requests := b.Requests("general", false)
+	if len(requests) != 1 {
+		t.Fatalf("expected one approval request, got %+v", requests)
+	}
+}
+
+func TestReportAgentIssueAttachesActiveTaskAndWaitsForApproval(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "eng", "Engineer")
+	task, reused, err := b.EnsurePlannedTask(plannedTaskInput{
+		Channel:   "general",
+		Title:     "Use the browser",
+		Owner:     "eng",
+		CreatedBy: "ceo",
+		TaskType:  "feature",
+	})
+	if err != nil || reused {
+		t.Fatalf("ensure task: %v reused=%v", err, reused)
+	}
+
+	if _, _, posted, err := b.ReportAgentIssue("eng", "general", "", "browser access is not available"); err != nil || !posted {
+		t.Fatalf("report issue: posted=%v err=%v", posted, err)
+	}
+
+	issues := b.AgentIssues()
+	if len(issues) != 1 || issues[0].TaskID != task.ID {
+		t.Fatalf("expected issue attached to active task %s, got %+v", task.ID, issues)
+	}
+	var updated teamTask
+	for _, candidate := range b.AllTasks() {
+		if candidate.ID == task.ID {
+			updated = candidate
+			break
+		}
+	}
+	if updated.Blocked || updated.Status != "in_progress" {
+		t.Fatalf("expected active task not to be blocked before approval, got %+v", updated)
+	}
+	if len(b.AllTasks()) != 1 {
+		t.Fatalf("expected no self-heal task before approval, got %+v", b.AllTasks())
+	}
+}
+
+func TestApprovedAgentIssueCreatesSelfHealTask(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "eng", "Engineer")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("start broker: %v", err)
+	}
+	defer b.Stop()
+
+	if _, _, posted, err := b.ReportAgentIssue("eng", "general", "", "browser access is not available"); err != nil || !posted {
+		t.Fatalf("report issue: posted=%v err=%v", posted, err)
+	}
+	requests := b.Requests("general", false)
+	if len(requests) != 1 {
+		t.Fatalf("expected approval request, got %+v", requests)
+	}
+	body, err := json.Marshal(map[string]any{
+		"id":        requests[0].ID,
+		"choice_id": "approve",
+	})
+	if err != nil {
+		t.Fatalf("marshal request answer: %v", err)
+	}
+	req, err := http.NewRequest(http.MethodPost, "http://"+b.Addr()+"/requests/answer", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request answer: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	client := http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("answer approval: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected approval answer 200, got %d", resp.StatusCode)
+	}
+
+	var found bool
+	for _, task := range b.AllTasks() {
+		if task.Title == "Self-heal @eng runtime failure" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected approved self-heal task, got %+v", b.AllTasks())
+	}
+	issues := b.AgentIssues()
+	if len(issues) != 1 || issues[0].SelfHealTaskID == "" {
+		t.Fatalf("expected issue to record self-heal task, got %+v", issues)
+	}
+}
+
+func TestAnsweredAgentIssueApprovalDoesNotCreateDuplicateRequest(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "eng", "Engineer")
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	b.requests = append(b.requests, humanInterview{
+		ID:        "request-issue-1",
+		Kind:      "approval",
+		Status:    "answered",
+		From:      "system",
+		Channel:   "general",
+		Title:     "Approve self-heal",
+		Question:  "Proceed?",
+		CreatedAt: now,
+		UpdatedAt: now,
+		Answered:  &interviewAnswer{ChoiceID: "approve", AnsweredAt: now},
+	})
+	b.agentIssues = append(b.agentIssues, agentIssueRecord{
+		ID:                "issue-1",
+		Agent:             "eng",
+		Channel:           "general",
+		Detail:            "browser access is not available",
+		NormalizedKey:     normalizedAgentIssueKey("eng", "general", "browser access is not available"),
+		ApprovalRequestID: "request-issue-1",
+		Count:             1,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	})
+	b.ensureSelfHealApprovalRequestLocked(&b.agentIssues[0], agentIssueClassification{
+		Visible:       true,
+		CapabilityGap: true,
+		Severity:      "warning",
+	}, "browser access is not available")
+	b.mu.Unlock()
+
+	requests := b.Requests("general", true)
+	if got := len(requests); got != 1 {
+		t.Fatalf("expected answered approval to be reused, got %d requests: %+v", got, requests)
+	}
+	issues := b.AgentIssues()
+	if len(issues) != 1 || issues[0].SelfHealTaskID == "" {
+		t.Fatalf("expected answered approval to create one self-heal task, got issues=%+v tasks=%+v", issues, b.AllTasks())
+	}
+}
+
+func TestApprovedAgentIssueSelfHealFailureSurfacesToChat(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "eng", "Engineer")
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	b.channels = nil
+	b.requests = append(b.requests, humanInterview{
+		ID:        "request-issue-1",
+		Kind:      "approval",
+		Status:    "answered",
+		From:      "system",
+		Channel:   "general",
+		Title:     "Approve self-heal",
+		Question:  "Proceed?",
+		CreatedAt: now,
+		UpdatedAt: now,
+		Answered:  &interviewAnswer{ChoiceID: "approve", AnsweredAt: now},
+	})
+	b.agentIssues = append(b.agentIssues, agentIssueRecord{
+		ID:                "issue-1",
+		Agent:             "eng",
+		Channel:           "general",
+		Detail:            "browser access is not available",
+		NormalizedKey:     normalizedAgentIssueKey("eng", "general", "browser access is not available"),
+		ApprovalRequestID: "request-issue-1",
+		Count:             1,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	})
+	b.maybeCreateApprovedSelfHealTaskLocked(b.requests[0])
+	b.maybeCreateApprovedSelfHealTaskLocked(b.requests[0])
+	b.mu.Unlock()
+
+	issues := b.AgentIssues()
+	if len(issues) != 1 || issues[0].SelfHealError == "" {
+		t.Fatalf("expected self-heal creation error to be recorded, got %+v", issues)
+	}
+	msgs := b.ChannelMessages("general")
+	if len(msgs) != 1 {
+		t.Fatalf("expected one surfaced failure message, got %+v", msgs)
+	}
+	if got := msgs[0]; got.From != "system" || got.Kind != agentIssueMessageKind || !strings.Contains(got.Content, "could not be created") {
+		t.Fatalf("unexpected surfaced failure message: %+v", got)
+	}
+}
+
+func TestAgentIssueDoesNotCountAsSubstantiveProgress(t *testing.T) {
+	b := newTestBroker(t)
+	l := &Launcher{broker: b}
+	startedAt := time.Now().UTC().Add(-1 * time.Second)
+
+	if _, _, posted, err := b.ReportAgentIssue("ceo", "general", "", "browser access is not available"); err != nil || !posted {
+		t.Fatalf("report issue: posted=%v err=%v", posted, err)
+	}
+	if l.agentPostedSubstantiveMessageSince("ceo", startedAt) {
+		t.Fatal("agent_issue should not count as substantive progress")
+	}
+
+	if _, err := b.PostMessage("ceo", "general", "I can continue with the code inspection.", nil, ""); err != nil {
+		t.Fatalf("post normal message: %v", err)
+	}
+	if !l.agentPostedSubstantiveMessageSince("ceo", startedAt) {
+		t.Fatal("normal streamed prose should count as substantive progress")
+	}
+}

--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -112,6 +112,9 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	// All policy-bearing per-turn state is owned by openAICompatTurnState
 	// (see openai_compat_turn_state.go). The state machine is
 	// independently unit-tested via openai_compat_turn_state_test.go.
+	liveChat := newHeadlessLiveChatRelay(l, slug, target, notification, func(line string) {
+		appendHeadlessCodexLog(slug, line)
+	})
 	state := newOpenAICompatTurnState(&runtimeTurnSinks{
 		l:    l,
 		slug: slug,
@@ -120,7 +123,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		// machine stays oblivious.
 		stream:  agentStream,
 		metrics: &metrics,
-	})
+	}, liveChat)
 
 	// taskID is unique per turn so the Receipts panel groups each
 	// agent's turn into its own row. Format mirrors agent.nextTaskID.
@@ -155,6 +158,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	}
 
 	finalText, iterationsUsed, turnUsage, streamErr, err := loop.run(ctx, msgs)
+	state.flushLiveChat()
 	// Record token counts even on partial / errored turns: a failed turn
 	// can still have generated thousands of tokens we want surfaced in the
 	// usage panel. CostUSD stays at zero — local runtimes have no marginal

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -168,6 +168,9 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			}
 			pushStream(ev.Text)
 		case "tool_use":
+			if liveChat != nil {
+				liveChat.Flush()
+			}
 			if firstToolAt.IsZero() {
 				firstToolAt = time.Now()
 				metrics.FirstToolMs = durationMillis(startedAt, firstToolAt)

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -135,6 +135,9 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 
 	var firstEventAt, firstTextAt, firstToolAt time.Time
 	textStarted := false
+	liveChat := newHeadlessLiveChatRelay(l, slug, firstNonEmpty(channel...), notification, func(line string) {
+		appendHeadlessCodexLog(slug, line)
+	})
 	var lastError string
 	pushStream := func(line string) {
 		if agentStream != nil && strings.TrimSpace(line) != "" {
@@ -149,6 +152,9 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 		}
 		switch ev.Type {
 		case "text":
+			if liveChat != nil {
+				liveChat.OnText(ev.Text)
+			}
 			if strings.TrimSpace(ev.Text) == "" {
 				return
 			}
@@ -175,14 +181,23 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 		case "tool_result":
 			if d := strings.TrimSpace(ev.Detail); d != "" {
 				pushStream("[tool_result] " + truncate(d, 240))
+				if liveChat != nil {
+					liveChat.ReportIssue(d)
+				}
 			}
 		case "error":
 			if msg := strings.TrimSpace(ev.Detail); msg != "" {
 				lastError = msg
 				pushStream("[error] " + msg)
+				if liveChat != nil {
+					liveChat.ReportIssue(msg)
+				}
 			}
 		}
 	})
+	if liveChat != nil {
+		liveChat.Flush()
+	}
 	if scanErr != nil && errors.Is(scanErr, bufio.ErrTooLong) {
 		// A single >4 MiB line would block cmd.Wait() on pipe backpressure
 		// forever; kill the child so Wait returns promptly.

--- a/internal/team/openai_compat_turn_state.go
+++ b/internal/team/openai_compat_turn_state.go
@@ -67,7 +67,8 @@ type openAICompatTurnSinks interface {
 // (the per-turn driver), so no internal locking is needed; if we
 // ever fan-out we'll revisit.
 type openAICompatTurnState struct {
-	sinks openAICompatTurnSinks
+	sinks    openAICompatTurnSinks
+	liveChat *headlessLiveChatRelay
 
 	// Live-output suppression. Open models stream JSON tool calls
 	// chunk-by-chunk; without buffering the user watches raw JSON
@@ -91,8 +92,12 @@ type openAICompatTurnState struct {
 	tpsAnchorChrs int
 }
 
-func newOpenAICompatTurnState(sinks openAICompatTurnSinks) *openAICompatTurnState {
-	return &openAICompatTurnState{sinks: sinks}
+func newOpenAICompatTurnState(sinks openAICompatTurnSinks, liveChat ...*headlessLiveChatRelay) *openAICompatTurnState {
+	st := &openAICompatTurnState{sinks: sinks}
+	if len(liveChat) > 0 {
+		st.liveChat = liveChat[0]
+	}
+	return st
 }
 
 // onText is the per-text-chunk handler. Updates the tps readout and
@@ -143,7 +148,7 @@ func (s *openAICompatTurnState) maybeFlushLive(chunk string) {
 			s.decided = true
 			if !s.looksJSON {
 				if s.liveBuf.Len() > 0 {
-					s.sinks.pushAgentStream(s.liveBuf.String())
+					s.pushLiveText(s.liveBuf.String())
 				}
 				s.liveBuf.Reset()
 			}
@@ -154,7 +159,14 @@ func (s *openAICompatTurnState) maybeFlushLive(chunk string) {
 		s.liveBuf.WriteString(chunk)
 		return
 	}
-	s.sinks.pushAgentStream(chunk)
+	s.pushLiveText(chunk)
+}
+
+func (s *openAICompatTurnState) pushLiveText(text string) {
+	s.sinks.pushAgentStream(text)
+	if s.liveChat != nil {
+		s.liveChat.OnText(text)
+	}
 }
 
 // onToolUseChunk handles a tool_use stream chunk: discards any
@@ -169,6 +181,9 @@ func (s *openAICompatTurnState) onToolUseChunk(toolName, rawInput string) {
 	s.tpsAnchorAt = time.Time{}
 	s.tpsAnchorChrs = 0
 	s.streamedChars = 0
+	if s.liveChat != nil {
+		s.liveChat.Flush()
+	}
 	s.sinks.pushAgentStream(fmt.Sprintf("[tool_use %s] %s", toolName, rawInput))
 }
 
@@ -179,9 +194,15 @@ func (s *openAICompatTurnState) onToolUseChunk(toolName, rawInput string) {
 func (s *openAICompatTurnState) onToolResult(name, result string, err error) {
 	if err != nil {
 		s.sinks.appendLog(fmt.Sprintf("openai_compat_tool_error: %s -> %v", name, err))
+		if s.liveChat != nil {
+			s.liveChat.ReportIssue(fmt.Sprintf("%s: %v", name, err))
+		}
 		return
 	}
 	s.sinks.appendLog(fmt.Sprintf("openai_compat_tool_ok: %s -> %s", name, truncate(result, 240)))
+	if s.liveChat != nil {
+		s.liveChat.ReportIssue(result)
+	}
 	if isUserVisiblePostTool(name) {
 		s.broadcastedThisTurn = true
 	}
@@ -192,6 +213,9 @@ func (s *openAICompatTurnState) onToolResult(name, result string, err error) {
 // stall.
 func (s *openAICompatTurnState) onError(msg string) {
 	s.sinks.pushAgentStream("[error] " + msg)
+	if s.liveChat != nil {
+		s.liveChat.ReportIssue(msg)
+	}
 }
 
 // shouldPostFinalText is the post-loop predicate for "should the
@@ -201,4 +225,10 @@ func (s *openAICompatTurnState) onError(msg string) {
 // fan-out loop where the agent's own post re-fires it).
 func (s *openAICompatTurnState) shouldPostFinalText() bool {
 	return !s.broadcastedThisTurn
+}
+
+func (s *openAICompatTurnState) flushLiveChat() {
+	if s != nil && s.liveChat != nil {
+		s.liveChat.Flush()
+	}
 }


### PR DESCRIPTION
## Summary

- Stream useful headless agent output into the originating chat channel.
- Promote issue-looking stream/tool output into broker-owned `agent_issue` records with durable dedupe.
- Surface capability blockers in chat immediately and post an inline approval recommendation before creating mutating self-heal work.
- Create or reuse the self-heal task only after the human approves the recommended action.
- Ensure `agent_issue` messages do not count as substantive progress for timeout/error recovery.

## Root Cause

Live agent streams contained useful blockers, but those blockers were only visible in transient output. The self-healing path listened to task lifecycle state, so taskless stream failures such as browser access being unavailable never created a repair path. Posting `Issue: ...` as a normal chat message also risked making recovery think the agent had made substantive progress.

## Product Behavior

The default is opinionated but permissioned: WUPHF shows the issue, recommends one repair path, and asks for approval before creating/running mutating self-heal work. Repeated stream chunks update the same incident instead of spamming chat or creating duplicate repair tasks.

## Validation

- `go test ./internal/team`
- `go test ./internal/provider`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live-streaming relay for incremental agent chat with smart buffering, boundary-aware flushes, and immediate issue reporting.
  * Persistent "agent issues" tracking with deduplication, channel posting, approval workflow, and optional automated self-heal task creation.

* **Behavior Changes**
  * Tool uses, tool results, and errors are surfaced as formatted issue messages; agent-issue messages are excluded from substantive-progress counts.

* **Tests**
  * End-to-end tests covering streaming relay, issue reporting, dedupe, approval flows, and turn integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->