### PR TITLE
[codex] Update onboarding title copy

### DIFF
--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -17,7 +17,7 @@ export const SIDEBAR_APPS = [
 ] as const;
 
 export const ONBOARDING_COPY = {
-  step1_headline: "Slack for AI employees with a shared brain.",
+  step1_headline: "Virtual office of AI employees with a shared brain",
   step1_subhead:
     "A collaborative office where AI agents like Claude Code, Codex, and OpenClaw learn your work playbooks, build personalized skills, and execute, 24x7. Each agent backed by its own knowledge graph.",
   step1_cta: "Open the office",


### PR DESCRIPTION
## Summary

Updates the onboarding welcome headline to the requested positioning: "Virtual office of AI employees with a shared brain".

## Impact

New users see the revised onboarding title on the first wizard screen. No behavior changes.

## Validation

- `vitest run src/components/onboarding/Wizard.test.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated onboarding Step 1 headline copy for clarity and tone: replaced “Slack for AI employees with a shared brain.” with “Virtual office of AI employees with a shared brain” (removed trailing period).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->