### PR TITLE
test(channel): characterize uncovered surface before package extraction

### DIFF
--- a/cmd/wuphf/channel_broker_test.go
+++ b/cmd/wuphf/channel_broker_test.go
@@ -1,0 +1,383 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// brokerStub stands up an httptest.Server, points the broker base URL at it
+// for the test, and resets WUPHF_BROKER_BASE_URL on teardown.
+func brokerStub(t *testing.T, handler http.Handler) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Setenv("WUPHF_BROKER_BASE_URL", srv.URL)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestPollHealthSuccess(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"ok","session_mode":"office","one_on_one_agent":""}`))
+	}))
+
+	cmd := pollHealth()
+	if cmd == nil {
+		t.Fatal("pollHealth returned nil cmd")
+	}
+	msg, ok := cmd().(channelHealthMsg)
+	if !ok {
+		t.Fatalf("expected channelHealthMsg, got %T", cmd())
+	}
+	if !msg.Connected {
+		t.Fatalf("expected Connected=true, got %#v", msg)
+	}
+	if msg.SessionMode != "office" {
+		t.Fatalf("expected session mode 'office', got %q", msg.SessionMode)
+	}
+}
+
+func TestPollHealthRejectsNon200(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	cmd := pollHealth()
+	msg, ok := cmd().(channelHealthMsg)
+	if !ok {
+		t.Fatalf("expected channelHealthMsg, got %T", cmd())
+	}
+	if msg.Connected {
+		t.Fatalf("non-200 must not be reported as Connected")
+	}
+}
+
+func TestPollBrokerDecodesMessages(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/messages") {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(`{"messages":[{"id":"m1","from":"fe","content":"hi","timestamp":"2026-04-29T10:00:00Z"}]}`))
+	}))
+
+	msg, ok := pollBroker("", "office")().(channelMsg)
+	if !ok {
+		t.Fatalf("expected channelMsg, got %T", pollBroker("", "office")())
+	}
+	if len(msg.messages) != 1 || msg.messages[0].ID != "m1" {
+		t.Fatalf("expected one message m1, got %#v", msg.messages)
+	}
+}
+
+func TestPollBrokerSinceIDInQuery(t *testing.T) {
+	var seen string
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.URL.RawQuery
+		_, _ = w.Write([]byte(`{"messages":[]}`))
+	}))
+
+	pollBroker("m42", "office")()
+	if !strings.Contains(seen, "since_id=m42") {
+		t.Fatalf("expected since_id=m42 in query, got %q", seen)
+	}
+	if !strings.Contains(seen, "channel=office") {
+		t.Fatalf("expected channel=office in query, got %q", seen)
+	}
+}
+
+func TestPollMembersDecodes(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"members":[{"slug":"fe","name":"Frontend"},{"slug":"be","name":"Backend"}]}`))
+	}))
+
+	msg, ok := pollMembers("office")().(channelMembersMsg)
+	if !ok {
+		t.Fatalf("expected channelMembersMsg, got %T", pollMembers("office")())
+	}
+	if len(msg.members) != 2 || msg.members[0].Slug != "fe" {
+		t.Fatalf("expected fe + be, got %#v", msg.members)
+	}
+}
+
+func TestPollChannelsDecodes(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"channels":[{"slug":"office","name":"Office","members":["fe","be"]}]}`))
+	}))
+
+	msg, ok := pollChannels()().(channelChannelsMsg)
+	if !ok {
+		t.Fatalf("expected channelChannelsMsg, got %T", pollChannels()())
+	}
+	if len(msg.channels) != 1 || msg.channels[0].Slug != "office" {
+		t.Fatalf("expected one channel 'office', got %#v", msg.channels)
+	}
+}
+
+func TestPollUsageEnsuresAgentsMap(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"total":{"total_tokens":10}}`))
+	}))
+
+	msg, ok := pollUsage()().(channelUsageMsg)
+	if !ok {
+		t.Fatalf("expected channelUsageMsg, got %T", pollUsage()())
+	}
+	if msg.usage.Total.TotalTokens != 10 {
+		t.Fatalf("expected total tokens 10, got %#v", msg.usage)
+	}
+	if msg.usage.Agents == nil {
+		t.Fatalf("Agents map must be non-nil to be safe to read by callers")
+	}
+}
+
+func TestCreateDMChannelPostsMembers(t *testing.T) {
+	var posted struct {
+		Members []string `json:"members"`
+		Type    string   `json:"type"`
+	}
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/channels/dm" {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &posted)
+		_, _ = w.Write([]byte(`{"slug":"office__fe","name":"Frontend"}`))
+	}))
+
+	msg, ok := createDMChannel("fe")().(channelDMCreatedMsg)
+	if !ok {
+		t.Fatalf("expected channelDMCreatedMsg, got %T", createDMChannel("fe")())
+	}
+	if msg.err != nil {
+		t.Fatalf("expected no error, got %v", msg.err)
+	}
+	if msg.slug != "office__fe" || msg.name != "Frontend" || msg.agentSlug != "fe" {
+		t.Fatalf("unexpected msg: %#v", msg)
+	}
+	if posted.Type != "direct" {
+		t.Fatalf("expected type 'direct', got %q", posted.Type)
+	}
+	if len(posted.Members) != 2 || posted.Members[0] != "human" || posted.Members[1] != "fe" {
+		t.Fatalf("expected [human, fe] members, got %#v", posted.Members)
+	}
+}
+
+func TestCreateDMChannelHandlesMalformedJSON(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`not json`))
+	}))
+
+	msg, _ := createDMChannel("fe")().(channelDMCreatedMsg)
+	if msg.err == nil {
+		t.Fatalf("expected decode error to surface, got nil")
+	}
+	if msg.agentSlug != "fe" {
+		t.Fatalf("agent slug should be carried even on error, got %q", msg.agentSlug)
+	}
+}
+
+func TestMutateTaskClaimReturnsNotice(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tasks" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	msg, ok := mutateTask("claim", "task-1", "fe", "office")().(channelTaskMutationDoneMsg)
+	if !ok {
+		t.Fatalf("expected channelTaskMutationDoneMsg")
+	}
+	if msg.err != nil {
+		t.Fatalf("expected nil err, got %v", msg.err)
+	}
+	if msg.notice != "Task claimed." {
+		t.Fatalf("expected 'Task claimed.', got %q", msg.notice)
+	}
+}
+
+func TestMutateTaskUnknownActionFallsBackToGenericNotice(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	msg := mutateTask("nudge", "task-1", "fe", "office")().(channelTaskMutationDoneMsg)
+	if msg.notice != "Task updated." {
+		t.Fatalf("expected fallback notice, got %q", msg.notice)
+	}
+}
+
+func TestMutateTaskNon2xxSurfacesErrorBody(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("bad action"))
+	}))
+
+	msg := mutateTask("claim", "task-1", "fe", "office")().(channelTaskMutationDoneMsg)
+	if msg.err == nil || msg.err.Error() != "bad action" {
+		t.Fatalf("expected 'bad action' error, got %v", msg.err)
+	}
+}
+
+func TestPostHumanInterruptSucceedsOn2xx(t *testing.T) {
+	var seen map[string]any
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/requests" {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &seen)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	msg := postHumanInterrupt("office")().(channelInterruptDoneMsg)
+	if msg.err != nil {
+		t.Fatalf("expected nil err, got %v", msg.err)
+	}
+	if seen["kind"] != "interrupt" || seen["channel"] != "office" || seen["blocking"] != true {
+		t.Fatalf("unexpected interrupt payload: %#v", seen)
+	}
+}
+
+func TestCancelRequestSurfacesNon2xxBody(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte("already cancelled"))
+	}))
+
+	interview := channelInterview{ID: "req-1"}
+	msg := cancelRequest(interview)().(channelCancelDoneMsg)
+	if msg.err == nil || msg.err.Error() != "already cancelled" {
+		t.Fatalf("expected 'already cancelled' error, got %v", msg.err)
+	}
+	if msg.requestID != "req-1" {
+		t.Fatalf("expected requestID echoed back, got %q", msg.requestID)
+	}
+}
+
+func TestCancelRequestEmptyBodyUsesStatus(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	msg := cancelRequest(channelInterview{ID: "req-2"})().(channelCancelDoneMsg)
+	if msg.err == nil {
+		t.Fatalf("expected error for empty 5xx body")
+	}
+	if !strings.Contains(msg.err.Error(), "broker returned") {
+		t.Fatalf("expected fallback message containing 'broker returned', got %q", msg.err.Error())
+	}
+}
+
+func TestPostInterviewAnswerSendsChoiceAndCustomText(t *testing.T) {
+	var posted map[string]any
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/requests/answer" {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &posted)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	msg := postInterviewAnswer(channelInterview{ID: "req-7"}, "yes", "Yes", "with this twist")().(channelInterviewAnswerDoneMsg)
+	if msg.err != nil {
+		t.Fatalf("expected nil err, got %v", msg.err)
+	}
+	if posted["id"] != "req-7" || posted["choice_id"] != "yes" ||
+		posted["choice_text"] != "Yes" || posted["custom_text"] != "with this twist" {
+		t.Fatalf("unexpected answer payload: %#v", posted)
+	}
+}
+
+func TestPostInterviewAnswerSurfacesErrorBody(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("not allowed"))
+	}))
+
+	msg := postInterviewAnswer(channelInterview{ID: "req-8"}, "no", "No", "")().(channelInterviewAnswerDoneMsg)
+	if msg.err == nil || msg.err.Error() != "not allowed" {
+		t.Fatalf("expected 'not allowed' error, got %v", msg.err)
+	}
+}
+
+func TestPollActionsDecodes(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"actions":[{"id":"a1","kind":"github_pr_opened","summary":"opened"}]}`))
+	}))
+
+	msg := pollActions()().(channelActionsMsg)
+	if len(msg.actions) != 1 || msg.actions[0].ID != "a1" {
+		t.Fatalf("expected one action a1, got %#v", msg.actions)
+	}
+}
+
+func TestPollSignalsDecodes(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"signals":[{"id":"s1","content":"latency spike"}]}`))
+	}))
+
+	msg := pollSignals()().(channelSignalsMsg)
+	if len(msg.signals) != 1 || msg.signals[0].ID != "s1" {
+		t.Fatalf("expected one signal s1, got %#v", msg.signals)
+	}
+}
+
+func TestPollDecisionsDecodes(t *testing.T) {
+	brokerStub(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"decisions":[{"id":"d1","summary":"ship"}]}`))
+	}))
+
+	msg := pollDecisions()().(channelDecisionsMsg)
+	if len(msg.decisions) != 1 || msg.decisions[0].ID != "d1" {
+		t.Fatalf("expected one decision d1, got %#v", msg.decisions)
+	}
+}
+
+func TestPollOnNetworkFailuresReturnsZeroValueMessages(t *testing.T) {
+	// Server immediately closed: every poll should swallow the error and
+	// return an empty msg of its type, not panic.
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	srv.Close() // intentionally closed
+	t.Setenv("WUPHF_BROKER_BASE_URL", srv.URL)
+
+	if msg := pollBroker("", "office")().(channelMsg); len(msg.messages) != 0 {
+		t.Fatalf("expected empty channelMsg on network error, got %#v", msg)
+	}
+	if msg := pollMembers("office")().(channelMembersMsg); len(msg.members) != 0 {
+		t.Fatalf("expected empty channelMembersMsg, got %#v", msg)
+	}
+	if msg := pollChannels()().(channelChannelsMsg); len(msg.channels) != 0 {
+		t.Fatalf("expected empty channelChannelsMsg, got %#v", msg)
+	}
+}
+
+func TestNormalizeBrokerURLRewritesLocalhost(t *testing.T) {
+	t.Setenv("WUPHF_BROKER_BASE_URL", "http://broker.test:9000")
+	if got := normalizeBrokerURL("http://127.0.0.1:7890/messages"); got != "http://broker.test:9000/messages" {
+		t.Fatalf("expected 127.0.0.1 rewrite, got %q", got)
+	}
+	if got := normalizeBrokerURL("http://localhost:7890/messages"); got != "http://broker.test:9000/messages" {
+		t.Fatalf("expected localhost rewrite, got %q", got)
+	}
+}
+
+func TestBrokerURLPrefixesBase(t *testing.T) {
+	t.Setenv("WUPHF_BROKER_BASE_URL", "http://broker.test:9000")
+	if got := brokerURL("/health"); got != "http://broker.test:9000/health" {
+		t.Fatalf("expected base+path, got %q", got)
+	}
+}

--- a/cmd/wuphf/channel_confirm_test.go
+++ b/cmd/wuphf/channel_confirm_test.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestConfirmationForResetTeamMode(t *testing.T) {
+	m := channelModel{}
+	got := m.confirmationForReset()
+	if got == nil {
+		t.Fatalf("expected confirmation")
+	}
+	if got.Action != confirmActionResetTeam {
+		t.Errorf("expected action=reset_team, got %q", got.Action)
+	}
+	if !strings.Contains(strings.ToLower(got.Title), "office") {
+		t.Errorf("expected office in title for team mode, got %q", got.Title)
+	}
+}
+
+func TestConfirmationForResetOneOnOneMode(t *testing.T) {
+	m := channelModel{}
+	m.sessionMode = "1o1"
+	m.oneOnOneAgent = "fe"
+	got := m.confirmationForReset()
+	if got == nil {
+		t.Fatalf("expected confirmation")
+	}
+	if !strings.Contains(strings.ToLower(got.Title), "direct") {
+		t.Errorf("expected 'direct' in title for 1:1 mode, got %q", got.Title)
+	}
+	if got.Agent != "fe" {
+		t.Errorf("expected agent=fe, got %q", got.Agent)
+	}
+}
+
+func TestConfirmationForResetDM(t *testing.T) {
+	got := confirmationForResetDM("fe", "office__fe")
+	if got == nil || got.Action != confirmActionResetDM {
+		t.Fatalf("expected reset_dm action, got %#v", got)
+	}
+	if got.Agent != "fe" || got.Channel != "office__fe" {
+		t.Errorf("expected agent/channel echoed, got %#v", got)
+	}
+}
+
+func TestConfirmationForSessionSwitchToOneOnOne(t *testing.T) {
+	got := confirmationForSessionSwitch("1o1", "fe")
+	if got.Action != confirmActionSwitchMode {
+		t.Errorf("expected switch_mode action, got %q", got.Action)
+	}
+	if !strings.Contains(strings.ToLower(got.Title), "direct") {
+		t.Errorf("expected 'direct' in title, got %q", got.Title)
+	}
+	if got.SessionMode != "1o1" || got.Agent != "fe" {
+		t.Errorf("expected mode/agent echoed, got %#v", got)
+	}
+}
+
+func TestConfirmationForSessionSwitchToOffice(t *testing.T) {
+	got := confirmationForSessionSwitch("office", "")
+	if !strings.Contains(strings.ToLower(got.Title), "office") {
+		t.Errorf("expected 'office' in title, got %q", got.Title)
+	}
+}
+
+func TestConfirmationForInterviewAnswerWithChoiceAndCustomText(t *testing.T) {
+	interview := channelInterview{
+		ID:       "req-1",
+		Question: "Approve?",
+	}
+	option := &channelInterviewOption{ID: "yes", Label: "Approve"}
+	got := confirmationForInterviewAnswer(interview, option, "let's ship Friday")
+	if got.Action != confirmActionSubmitRequest {
+		t.Fatalf("expected submit_request action, got %q", got.Action)
+	}
+	if got.ChoiceID != "yes" || got.ChoiceText != "Approve" {
+		t.Errorf("expected choice carried, got %#v", got)
+	}
+	if !strings.Contains(got.Detail, "Approve?") {
+		t.Errorf("expected question in detail, got %q", got.Detail)
+	}
+	if !strings.Contains(got.Detail, "let's ship Friday") {
+		t.Errorf("expected custom text in detail, got %q", got.Detail)
+	}
+}
+
+func TestConfirmationForInterviewAnswerNoOptionPromptsForAnswer(t *testing.T) {
+	got := confirmationForInterviewAnswer(channelInterview{Question: "Why?"}, nil, "")
+	if !strings.Contains(got.Detail, "Type an answer before submitting") {
+		t.Fatalf("expected coaching detail when no option/text, got %q", got.Detail)
+	}
+}
+
+func TestRenderConfirmCardContainsTitleAndDetail(t *testing.T) {
+	confirm := channelConfirm{
+		Title:        "Reset Office Session",
+		Detail:       "This clears the live transcript.",
+		ConfirmLabel: "Enter",
+		CancelLabel:  "Esc",
+	}
+	got := stripANSI(renderConfirmCard(confirm, 80))
+	for _, want := range []string{"Reset Office Session", "clears the live transcript", "Enter", "Esc"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("expected %q in card, got %q", want, got)
+		}
+	}
+}
+
+func TestRenderConfirmCardEnforcesMinimumWidth(t *testing.T) {
+	confirm := channelConfirm{Title: "X", Detail: "y", ConfirmLabel: "ok", CancelLabel: "no"}
+	if got := renderConfirmCard(confirm, 10); got == "" {
+		t.Fatalf("undersized confirm card should still render")
+	}
+}
+
+func TestExecuteConfirmationSubmitRequestWithoutRequestSetsNotice(t *testing.T) {
+	m := channelModel{}
+	confirm := channelConfirm{Action: confirmActionSubmitRequest, Request: nil}
+	model, cmd := m.executeConfirmation(confirm)
+	if cmd != nil {
+		t.Errorf("expected nil cmd when request missing, got %T", cmd)
+	}
+	out, ok := model.(channelModel)
+	if !ok {
+		t.Fatalf("expected channelModel, got %T", model)
+	}
+	if out.notice == "" {
+		t.Errorf("expected notice when request is missing")
+	}
+}
+
+func TestExecuteConfirmationDefaultActionClearsConfirm(t *testing.T) {
+	m := channelModel{}
+	m.confirm = &channelConfirm{}
+	confirm := channelConfirm{Action: "unknown"}
+	model, cmd := m.executeConfirmation(confirm)
+	out := model.(channelModel)
+	if out.confirm != nil {
+		t.Errorf("expected confirm cleared on unknown action")
+	}
+	if cmd != nil {
+		t.Errorf("expected nil cmd on unknown action")
+	}
+}
+
+func TestExecuteConfirmationSwitchModeReturnsCmd(t *testing.T) {
+	m := channelModel{}
+	confirm := channelConfirm{Action: confirmActionSwitchMode, SessionMode: "office"}
+	_, cmd := m.executeConfirmation(confirm)
+	if cmd == nil {
+		t.Fatalf("expected non-nil cmd for switch_mode")
+	}
+}
+
+// Sanity: tea.Cmd returned for reset/dm actions is non-nil.
+func TestExecuteConfirmationResetReturnsCmd(t *testing.T) {
+	m := channelModel{}
+	for _, action := range []channelConfirmAction{confirmActionResetTeam, confirmActionResetDM} {
+		_, cmd := m.executeConfirmation(channelConfirm{Action: action, Agent: "fe", Channel: "office"})
+		if cmd == nil {
+			t.Errorf("action %q expected non-nil cmd", action)
+		}
+	}
+	// keep unused tea import quiet on platforms that need it
+	_ = tea.KeyMsg{}
+}

--- a/cmd/wuphf/channel_integration_test.go
+++ b/cmd/wuphf/channel_integration_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSlugifyGroupTitleAddsTgPrefix(t *testing.T) {
+	cases := map[string]string{
+		"My Team":             "tg-my-team",
+		" My!@#$Team Lounge ": "tg-my-team-lounge",
+		"---":                 "tg-telegram",
+		"":                    "tg-telegram",
+		"NUMBERS 123":         "tg-numbers-123",
+	}
+	for input, want := range cases {
+		if got := slugifyGroupTitle(input); got != want {
+			t.Errorf("slugifyGroupTitle(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestSlugifyOpenclawLabelFallsBackToSession(t *testing.T) {
+	cases := map[string]string{
+		"My Session":  "my-session",
+		"--- ---":     "session",
+		"":            "session",
+		"NUMBERS 123": "numbers-123",
+	}
+	for input, want := range cases {
+		if got := slugifyOpenclawLabel(input); got != want {
+			t.Errorf("slugifyOpenclawLabel(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestChannelIntegrationOptionsMatchesSpecs(t *testing.T) {
+	got := channelIntegrationOptions()
+	if len(got) != len(channelIntegrationSpecs) {
+		t.Fatalf("expected %d options, got %d", len(channelIntegrationSpecs), len(got))
+	}
+	for i, opt := range got {
+		spec := channelIntegrationSpecs[i]
+		if opt.Label != spec.Label || opt.Value != spec.Value || opt.Description != spec.Description {
+			t.Errorf("option %d mismatch: got %+v want %+v", i, opt, spec)
+		}
+	}
+}
+
+func TestFindChannelIntegrationKnownAndUnknown(t *testing.T) {
+	if _, ok := findChannelIntegration("nope"); ok {
+		t.Fatalf("expected miss for unknown integration")
+	}
+	if len(channelIntegrationSpecs) == 0 {
+		t.Skip("no integration specs declared, skipping known-spec lookup")
+	}
+	known := channelIntegrationSpecs[0].Value
+	spec, ok := findChannelIntegration(known)
+	if !ok {
+		t.Fatalf("expected hit for %q", known)
+	}
+	if spec.Value != known {
+		t.Errorf("expected spec.Value=%q, got %q", known, spec.Value)
+	}
+}
+
+func TestChannelIntegrationOptionsContainsKnownProvider(t *testing.T) {
+	got := channelIntegrationOptions()
+	var found bool
+	for _, opt := range got {
+		if strings.Contains(strings.ToLower(opt.Label), "google") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected at least one Google integration option, got %v", got)
+	}
+}

--- a/cmd/wuphf/channel_mailboxes_test.go
+++ b/cmd/wuphf/channel_mailboxes_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNormalizeMailboxScopeAcceptsKnownScopes(t *testing.T) {
+	cases := map[string]string{
+		"inbox":   "inbox",
+		"INBOX":   "inbox",
+		" Inbox ": "inbox",
+		"outbox":  "outbox",
+		"agent":   "agent",
+		"":        "",
+		"random":  "",
+	}
+	for input, want := range cases {
+		if got := normalizeMailboxScope(input); got != want {
+			t.Errorf("normalizeMailboxScope(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestMailboxOutboxOnlyOwnedByViewer(t *testing.T) {
+	msg := brokerMessage{ID: "m1", From: "fe", Content: "hi"}
+	if !mailboxMessageBelongsToViewerOutbox(msg, "fe") {
+		t.Fatalf("viewer's own message should be in their outbox")
+	}
+	if mailboxMessageBelongsToViewerOutbox(msg, "be") {
+		t.Fatalf("other-author message should not be in viewer outbox")
+	}
+	if mailboxMessageBelongsToViewerOutbox(msg, "") {
+		t.Fatalf("empty viewer should never match")
+	}
+}
+
+func TestMailboxInboxIncludesHumanAndDirectTags(t *testing.T) {
+	idx := map[string]brokerMessage{}
+
+	human := brokerMessage{ID: "m1", From: "human", Content: "ping"}
+	if !mailboxMessageBelongsToViewerInbox(human, "fe", idx) {
+		t.Fatalf("messages from human should land in any agent's inbox")
+	}
+
+	directTag := brokerMessage{ID: "m2", From: "ceo", Content: "do this", Tagged: []string{"fe"}}
+	if !mailboxMessageBelongsToViewerInbox(directTag, "fe", idx) {
+		t.Fatalf("messages tagging the viewer should land in their inbox")
+	}
+
+	allTag := brokerMessage{ID: "m3", From: "ceo", Content: "team-wide", Tagged: []string{"all"}}
+	if !mailboxMessageBelongsToViewerInbox(allTag, "fe", idx) {
+		t.Fatalf("messages tagged @all should land in every viewer's inbox")
+	}
+
+	own := brokerMessage{ID: "m4", From: "fe", Content: "self"}
+	if mailboxMessageBelongsToViewerInbox(own, "fe", idx) {
+		t.Fatalf("own messages must not appear in viewer's inbox lane")
+	}
+
+	other := brokerMessage{ID: "m5", From: "be", Content: "tagged elsewhere", Tagged: []string{"pm"}}
+	if mailboxMessageBelongsToViewerInbox(other, "fe", idx) {
+		t.Fatalf("messages tagging someone else should not be in viewer's inbox")
+	}
+}
+
+func TestMailboxInboxFollowsThreadReplies(t *testing.T) {
+	root := brokerMessage{ID: "root", From: "fe", Content: "viewer wrote this"}
+	reply := brokerMessage{ID: "r1", From: "be", Content: "reply", ReplyTo: "root"}
+	idx := map[string]brokerMessage{"root": root, "r1": reply}
+
+	if !mailboxMessageBelongsToViewerInbox(reply, "fe", idx) {
+		t.Fatalf("a reply to viewer's message should be inbox-bound")
+	}
+
+	// Cycle protection: msg replies to itself.
+	cycle := brokerMessage{ID: "c1", From: "be", Content: "loop", ReplyTo: "c1"}
+	cycleIdx := map[string]brokerMessage{"c1": cycle}
+	if mailboxMessageBelongsToViewerInbox(cycle, "fe", cycleIdx) {
+		t.Fatalf("self-cycle reply should not match anyone's inbox")
+	}
+}
+
+func TestFilterMessagesForViewerScopeUnknownScopeReturnsCopy(t *testing.T) {
+	msgs := []brokerMessage{{ID: "a", From: "fe"}, {ID: "b", From: "be"}}
+	got := filterMessagesForViewerScope(msgs, "fe", "")
+	if len(got) != 2 {
+		t.Fatalf("empty scope should pass everything through, got %d", len(got))
+	}
+	// Verify it returns a copy, not the same backing array.
+	got[0].ID = "mutated"
+	if msgs[0].ID == "mutated" {
+		t.Fatalf("filterMessagesForViewerScope must not share backing array")
+	}
+}
+
+func TestFilterMessagesForViewerScopeAgentMode(t *testing.T) {
+	msgs := []brokerMessage{
+		{ID: "a", From: "fe", Content: "viewer wrote"},                   // outbox
+		{ID: "b", From: "human", Content: "human ping"},                  // inbox (human)
+		{ID: "c", From: "be", Content: "tag fe", Tagged: []string{"fe"}}, // inbox (tagged)
+		{ID: "d", From: "be", Content: "for someone else", Tagged: []string{"pm"}},
+	}
+	got := filterMessagesForViewerScope(msgs, "fe", "agent")
+	ids := map[string]bool{}
+	for _, m := range got {
+		ids[m.ID] = true
+	}
+	if !ids["a"] || !ids["b"] || !ids["c"] {
+		t.Fatalf("agent scope should include outbox+inbox, got %v", ids)
+	}
+	if ids["d"] {
+		t.Fatalf("agent scope should exclude unrelated message, got %v", ids)
+	}
+}
+
+func TestBuildInboxLinesEmptyShowsCoachingCopy(t *testing.T) {
+	lines := buildInboxLines(nil, nil, 80)
+	joined := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(joined, "Inbox") {
+		t.Fatalf("inbox header missing: %q", joined)
+	}
+	if !strings.Contains(joined, "Nothing is waiting in the inbox lane") {
+		t.Fatalf("empty-state coaching copy missing: %q", joined)
+	}
+}
+
+func TestBuildInboxLinesShowsRequestsAndMessages(t *testing.T) {
+	requests := []channelInterview{{
+		ID:        "req-1",
+		Kind:      "decision",
+		From:      "ceo",
+		Question:  "Approve the launch?",
+		Context:   "Need green light",
+		CreatedAt: "2026-04-29T10:00:00Z",
+	}}
+	messages := []brokerMessage{{
+		ID:        "m1",
+		From:      "ceo",
+		Content:   "FYI here is the plan",
+		Timestamp: "2026-04-29T10:00:00Z",
+	}}
+	lines := buildInboxLines(messages, requests, 80)
+	joined := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(joined, "Open requests") {
+		t.Fatalf("expected Open requests separator, got %q", joined)
+	}
+	if !strings.Contains(joined, "Approve the launch?") {
+		t.Fatalf("expected request question to render, got %q", joined)
+	}
+	if !strings.Contains(joined, "Inbox messages") {
+		t.Fatalf("expected Inbox messages separator, got %q", joined)
+	}
+	if !strings.Contains(joined, "FYI here is the plan") {
+		t.Fatalf("expected message body to render, got %q", joined)
+	}
+}
+
+func TestBuildOutboxLinesEmptyShowsCoachingCopy(t *testing.T) {
+	lines := buildOutboxLines(nil, nil, 80)
+	joined := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(joined, "Outbox") {
+		t.Fatalf("outbox header missing: %q", joined)
+	}
+	if !strings.Contains(joined, "Nothing is in the outbox yet") {
+		t.Fatalf("empty-state coaching copy missing: %q", joined)
+	}
+}
+
+func TestBuildOutboxLinesShowsAuthoredMessagesAndActions(t *testing.T) {
+	messages := []brokerMessage{{
+		ID:        "m1",
+		From:      "fe",
+		Content:   "Shipped the homepage update",
+		Timestamp: "2026-04-29T10:00:00Z",
+	}}
+	actions := []channelAction{{
+		ID:        "a1",
+		Kind:      "github_pr_opened",
+		Summary:   "Opened PR #42",
+		Actor:     "fe",
+		Source:    "github",
+		CreatedAt: "2026-04-29T10:05:00Z",
+	}}
+	lines := buildOutboxLines(messages, actions, 80)
+	joined := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(joined, "Authored messages") {
+		t.Fatalf("expected Authored messages separator, got %q", joined)
+	}
+	if !strings.Contains(joined, "Shipped the homepage update") {
+		t.Fatalf("expected message body, got %q", joined)
+	}
+	if !strings.Contains(joined, "Recent actions") {
+		t.Fatalf("expected Recent actions separator, got %q", joined)
+	}
+	if !strings.Contains(joined, "Opened PR #42") {
+		t.Fatalf("expected action summary, got %q", joined)
+	}
+}

--- a/cmd/wuphf/channel_member_draft_test.go
+++ b/cmd/wuphf/channel_member_draft_test.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestChannelMemberDraftCurrentStepClampsBounds(t *testing.T) {
+	d := channelMemberDraft{Step: -5}
+	if got := d.currentStep(); got != "slug" {
+		t.Fatalf("negative Step should clamp to first step, got %q", got)
+	}
+	d = channelMemberDraft{Step: 99}
+	if got := d.currentStep(); got != "permission" {
+		t.Fatalf("out-of-range Step should clamp to last step, got %q", got)
+	}
+}
+
+func TestChannelMemberDraftCurrentStepProgresses(t *testing.T) {
+	want := []string{"slug", "name", "role", "expertise", "personality", "permission"}
+	for i, expected := range want {
+		got := channelMemberDraft{Step: i}.currentStep()
+		if got != expected {
+			t.Errorf("Step %d = %q, want %q", i, got, expected)
+		}
+	}
+}
+
+func TestNormalizeDraftSlugLowercasesAndDashes(t *testing.T) {
+	cases := map[string]string{
+		"Frontend":         "frontend",
+		"  Customer Ops  ": "customer-ops",
+		"data_eng":         "data-eng",
+		"FOO_BAR  Baz":     "foo-bar--baz",
+	}
+	for input, want := range cases {
+		if got := normalizeDraftSlug(input); got != want {
+			t.Errorf("normalizeDraftSlug(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestParseExpertiseInputDedupesAndTrims(t *testing.T) {
+	got := parseExpertiseInput("Go,  React, Go,  ,Postgres ,React")
+	want := []string{"Go", "React", "Postgres"}
+	if len(got) != len(want) {
+		t.Fatalf("len mismatch: got %v want %v", got, want)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("idx %d: got %q want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestParseExpertiseInputEmpty(t *testing.T) {
+	if got := parseExpertiseInput(""); len(got) != 0 {
+		t.Fatalf("empty input should yield empty slice, got %v", got)
+	}
+	if got := parseExpertiseInput("   ,  ,"); len(got) != 0 {
+		t.Fatalf("whitespace-only input should yield empty slice, got %v", got)
+	}
+}
+
+func TestMemberDraftComposerLabelByStep(t *testing.T) {
+	cases := map[string]string{
+		"slug":        "New teammate slug",
+		"name":        "New teammate name",
+		"role":        "Teammate role/title",
+		"expertise":   "Expertise list",
+		"personality": "Personality",
+		"permission":  "Permission mode",
+	}
+	for step, want := range cases {
+		idx := 0
+		for i, s := range memberDraftSteps {
+			if s == step {
+				idx = i
+			}
+		}
+		got := memberDraftComposerLabel(channelMemberDraft{Step: idx})
+		if got != want {
+			t.Errorf("step %q: got %q want %q", step, got, want)
+		}
+	}
+}
+
+func TestMemberDraftStepHintCoversAllSteps(t *testing.T) {
+	for i := range memberDraftSteps {
+		hint := memberDraftStepHint(channelMemberDraft{Step: i})
+		if strings.TrimSpace(hint) == "" {
+			t.Errorf("step %d (%s) has empty hint", i, memberDraftSteps[i])
+		}
+	}
+}
+
+func TestRenderMemberDraftCardCreateMode(t *testing.T) {
+	draft := channelMemberDraft{
+		Mode: "create",
+		Slug: "data-eng",
+		Name: "Data Engineering",
+		Step: 2,
+	}
+	got := stripANSI(renderMemberDraftCard(draft, 60))
+	if !strings.Contains(got, "New teammate") {
+		t.Fatalf("expected create-mode title, got %q", got)
+	}
+	if !strings.Contains(got, "data-eng") {
+		t.Fatalf("expected slug to render, got %q", got)
+	}
+	if !strings.Contains(got, "Data Engineering") {
+		t.Fatalf("expected name to render, got %q", got)
+	}
+}
+
+func TestRenderMemberDraftCardEditMode(t *testing.T) {
+	draft := channelMemberDraft{Mode: "edit", Slug: "fe", Name: "Frontend"}
+	got := stripANSI(renderMemberDraftCard(draft, 80))
+	if !strings.Contains(got, "Edit teammate") {
+		t.Fatalf("expected edit-mode title, got %q", got)
+	}
+}
+
+func TestRenderMemberDraftCardEnforcesMinimumWidth(t *testing.T) {
+	draft := channelMemberDraft{Mode: "create"}
+	if got := renderMemberDraftCard(draft, 10); got == "" {
+		t.Fatalf("undersized card should still render with min width")
+	}
+}
+
+func TestMutateOfficeMemberSpecErrorPathSurfacesBrokerBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/office-members" {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("slug already taken"))
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("WUPHF_BROKER_BASE_URL", srv.URL)
+
+	draft := channelMemberDraft{Mode: "create", Slug: "fe", Name: "Frontend", Role: "fe"}
+	msg, ok := mutateOfficeMemberSpec(draft, "office")().(channelMemberDraftDoneMsg)
+	if !ok {
+		t.Fatalf("expected channelMemberDraftDoneMsg")
+	}
+	if msg.err == nil || msg.err.Error() != "slug already taken" {
+		t.Fatalf("expected broker body in error, got %v", msg.err)
+	}
+}
+
+func TestMutateOfficeMemberSpecCreateSendsExpectedPayload(t *testing.T) {
+	var posted map[string]any
+	hits := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits[r.URL.Path]++
+		body, _ := io.ReadAll(r.Body)
+		if r.URL.Path == "/office-members" {
+			_ = json.Unmarshal(body, &posted)
+		}
+		// Force the post-success path to fail BEFORE team.NewLauncher is reached
+		// by returning 400 — this still exercises the JSON serialization branch.
+		// We can't realistically run team.NewLauncher in a test environment.
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("denied"))
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("WUPHF_BROKER_BASE_URL", srv.URL)
+
+	draft := channelMemberDraft{
+		Mode:           "create",
+		Slug:           "data-eng",
+		Name:           "Data Eng",
+		Role:           "Engineer",
+		Expertise:      "Go, SQL,Go",
+		Personality:    "calm",
+		PermissionMode: "auto",
+	}
+	mutateOfficeMemberSpec(draft, "office")()
+
+	if posted["action"] != "create" {
+		t.Errorf("expected action=create, got %v", posted["action"])
+	}
+	if posted["slug"] != "data-eng" {
+		t.Errorf("expected slug=data-eng, got %v", posted["slug"])
+	}
+	expertise, ok := posted["expertise"].([]any)
+	if !ok {
+		t.Fatalf("expertise should be slice, got %T", posted["expertise"])
+	}
+	if len(expertise) != 2 || expertise[0] != "Go" || expertise[1] != "SQL" {
+		t.Errorf("expected dedup'd expertise [Go, SQL], got %v", expertise)
+	}
+	if posted["permission_mode"] != "auto" {
+		t.Errorf("expected permission_mode=auto, got %v", posted["permission_mode"])
+	}
+}
+
+func TestMutateOfficeMemberSpecEditUsesUpdateAction(t *testing.T) {
+	var posted map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &posted)
+		// Force error path to skip the launcher reconfigure.
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("WUPHF_BROKER_BASE_URL", srv.URL)
+
+	draft := channelMemberDraft{Mode: "edit", Slug: "fe", Name: "Frontend"}
+	mutateOfficeMemberSpec(draft, "office")()
+	if posted["action"] != "update" {
+		t.Errorf("expected action=update, got %v", posted["action"])
+	}
+}

--- a/cmd/wuphf/channel_model_helpers_test.go
+++ b/cmd/wuphf/channel_model_helpers_test.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFilterInsightMessagesKeepsAutomationAndNex(t *testing.T) {
+	messages := []brokerMessage{
+		{ID: "m1", From: "ceo", Content: "talk", Kind: "human_decision"},
+		{ID: "m2", From: "nex", Content: "policy"},
+		{ID: "m3", From: "fe", Content: "automation tick", Kind: "automation"},
+		{ID: "m4", From: "fe", Content: "regular"},
+	}
+	got := filterInsightMessages(messages)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 insight messages, got %d (%v)", len(got), got)
+	}
+	for _, m := range got {
+		if m.From != "nex" && m.Kind != "automation" {
+			t.Errorf("unexpected message %+v", m)
+		}
+	}
+}
+
+func TestPopupActionIndexParses(t *testing.T) {
+	if idx, ok := popupActionIndex("3"); !ok || idx != 3 {
+		t.Errorf("expected (3,true), got (%d,%v)", idx, ok)
+	}
+	if _, ok := popupActionIndex("not a number"); ok {
+		t.Errorf("expected miss for non-numeric")
+	}
+	if _, ok := popupActionIndex("-5"); ok {
+		t.Errorf("expected miss for negative")
+	}
+}
+
+func TestCountUniqueAgentsExcludesYouNexAndAutomation(t *testing.T) {
+	messages := []brokerMessage{
+		{From: "fe"},
+		{From: "be"},
+		{From: "fe"}, // duplicate, should not double-count
+		{From: "you"},
+		{From: "nex"},
+		{From: "fe", Kind: "automation"},
+	}
+	if got := countUniqueAgents(messages); got != 2 {
+		t.Fatalf("expected 2 unique agents (fe, be), got %d", got)
+	}
+}
+
+func TestCountUniqueAgentsEmpty(t *testing.T) {
+	if got := countUniqueAgents(nil); got != 0 {
+		t.Fatalf("expected 0 for empty input, got %d", got)
+	}
+}
+
+func TestFormatUsdFormatsTwoDecimals(t *testing.T) {
+	cases := map[float64]string{
+		0:        "$0.00",
+		0.5:      "$0.50",
+		1.234:    "$1.23",
+		1500.999: "$1501.00",
+	}
+	for in, want := range cases {
+		if got := formatUsd(in); got != want {
+			t.Errorf("formatUsd(%g) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFormatTokenCountUnits(t *testing.T) {
+	cases := map[int]string{
+		0:         "0 tok",
+		999:       "999 tok",
+		1_500:     "1.5k tok",
+		2_000_000: "2.0M tok",
+	}
+	for in, want := range cases {
+		if got := formatTokenCount(in); got != want {
+			t.Errorf("formatTokenCount(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestRecommendedOptionIndexFindsMatch(t *testing.T) {
+	m := channelModel{}
+	m.pending = &channelInterview{
+		Options: []channelInterviewOption{
+			{ID: "yes"},
+			{ID: "no"},
+			{ID: "maybe"},
+		},
+		RecommendedID: "no",
+	}
+	if got := m.recommendedOptionIndex(); got != 1 {
+		t.Errorf("expected index 1 for 'no', got %d", got)
+	}
+
+	m.pending.RecommendedID = "missing"
+	if got := m.recommendedOptionIndex(); got != 0 {
+		t.Errorf("missing recommendation should fall back to 0, got %d", got)
+	}
+
+	m.pending = nil
+	if got := m.recommendedOptionIndex(); got != 0 {
+		t.Errorf("nil pending should be 0, got %d", got)
+	}
+}
+
+func TestInterviewOptionCountIncludesCustomAnswerSlot(t *testing.T) {
+	m := channelModel{}
+	if got := m.interviewOptionCount(); got != 0 {
+		t.Errorf("nil pending should yield 0 option count, got %d", got)
+	}
+	m.pending = &channelInterview{Options: []channelInterviewOption{{ID: "a"}, {ID: "b"}}}
+	if got := m.interviewOptionCount(); got != 3 {
+		t.Errorf("expected len(options)+1 = 3, got %d", got)
+	}
+}
+
+func TestSelectedInterviewOptionEdgeCases(t *testing.T) {
+	m := channelModel{}
+	if m.selectedInterviewOption() != nil {
+		t.Fatalf("nil pending should yield nil option")
+	}
+
+	m.pending = &channelInterview{Options: []channelInterviewOption{{ID: "a"}, {ID: "b"}}}
+	m.selectedOption = -1
+	got := m.selectedInterviewOption()
+	if got == nil || got.ID != "a" {
+		t.Errorf("negative selectedOption should default to first option, got %#v", got)
+	}
+
+	m.selectedOption = 1
+	got = m.selectedInterviewOption()
+	if got == nil || got.ID != "b" {
+		t.Errorf("expected second option, got %#v", got)
+	}
+
+	m.selectedOption = 99
+	if m.selectedInterviewOption() != nil {
+		t.Fatalf("out-of-range selectedOption should yield nil (custom slot)")
+	}
+}
+
+func TestRenderUsageStripBuildsAgentColumn(t *testing.T) {
+	usage := channelUsageState{
+		Agents: map[string]channelUsageTotals{
+			"fe":  {InputTokens: 100, OutputTokens: 50, TotalTokens: 150, CostUsd: 0.5},
+			"ceo": {InputTokens: 5, OutputTokens: 1, TotalTokens: 6},
+		},
+	}
+	members := []channelMember{{Slug: "fe", Name: "Frontend"}}
+	got := stripANSI(renderUsageStrip(usage, members, 120))
+	if got == "" {
+		t.Fatalf("expected non-empty usage strip")
+	}
+	if !strings.Contains(got, "150 tok") {
+		t.Fatalf("expected fe token total in strip, got %q", got)
+	}
+	if !strings.Contains(got, "$0.50") {
+		t.Fatalf("expected fe cost in strip, got %q", got)
+	}
+}
+
+func TestRenderUsageStripEmptyReturnsEmpty(t *testing.T) {
+	if got := renderUsageStrip(channelUsageState{}, nil, 120); got != "" {
+		t.Fatalf("empty usage should yield empty strip, got %q", got)
+	}
+	usage := channelUsageState{Agents: map[string]channelUsageTotals{"fe": {TotalTokens: 1}}}
+	if got := renderUsageStrip(usage, nil, 30); got != "" {
+		t.Fatalf("narrow width should yield empty strip, got %q", got)
+	}
+}
+
+func TestVisiblePendingRequestNilWhenNoPending(t *testing.T) {
+	m := channelModel{}
+	if got := m.visiblePendingRequest(); got != nil {
+		t.Fatalf("expected nil when no pending request, got %v", got)
+	}
+}
+
+func TestComposerTargetLabelInDirect(t *testing.T) {
+	m := channelModel{}
+	m.sessionMode = "1o1"
+	m.oneOnOneAgent = "fe"
+	got := m.composerTargetLabel()
+	if got == "" {
+		t.Fatalf("expected non-empty composer target label in 1:1")
+	}
+}
+
+func TestChannelModelInitReturnsPollCmd(t *testing.T) {
+	m := newChannelModel(false)
+	cmd := m.Init()
+	if cmd == nil {
+		t.Fatalf("expected non-nil cmd from Init()")
+	}
+}
+
+func TestCurrentAppLabelByApp(t *testing.T) {
+	cases := map[officeApp]string{
+		officeAppMessages:  "messages",
+		officeAppRecovery:  "recovery",
+		officeAppInbox:     "inbox",
+		officeAppOutbox:    "outbox",
+		officeAppTasks:     "tasks",
+		officeAppRequests:  "requests",
+		officeAppPolicies:  "policies",
+		officeAppCalendar:  "calendar",
+		officeAppArtifacts: "artifacts",
+		officeAppSkills:    "skills",
+	}
+	for app, want := range cases {
+		m := channelModel{activeApp: app}
+		if got := m.currentAppLabel(); got != want {
+			t.Errorf("currentAppLabel(%v) = %q, want %q", app, got, want)
+		}
+	}
+}
+
+func TestCurrentAppLabelOneOnOneOverridesMostApps(t *testing.T) {
+	m := channelModel{}
+	m.sessionMode = "1o1"
+	m.oneOnOneAgent = "fe"
+	m.activeApp = officeAppTasks
+	if got := m.currentAppLabel(); got != "messages" {
+		t.Errorf("1:1 mode should report 'messages' for non-mailbox apps, got %q", got)
+	}
+	// inbox/outbox/recovery still surface their own labels in 1:1 mode.
+	m.activeApp = officeAppInbox
+	if got := m.currentAppLabel(); got != "inbox" {
+		t.Errorf("1:1 mode should still surface inbox label, got %q", got)
+	}
+}
+
+func TestNextFocusCyclesAvailableAreas(t *testing.T) {
+	m := channelModel{focus: focusMain, threadPanelOpen: false, sidebarCollapsed: false}
+	if got := m.nextFocus(); got != focusSidebar {
+		t.Errorf("expected main->sidebar, got %v", got)
+	}
+	m.focus = focusSidebar
+	if got := m.nextFocus(); got != focusMain {
+		t.Errorf("expected sidebar->main when no thread, got %v", got)
+	}
+
+	// With thread open, sidebar -> thread -> main -> sidebar...
+	m.threadPanelOpen = true
+	m.focus = focusSidebar
+	if got := m.nextFocus(); got != focusThread {
+		t.Errorf("expected sidebar->thread with thread open, got %v", got)
+	}
+	m.focus = focusThread
+	if got := m.nextFocus(); got != focusMain {
+		t.Errorf("expected thread->main, got %v", got)
+	}
+}
+
+func TestNextFocusSkipsCollapsedSidebar(t *testing.T) {
+	m := channelModel{focus: focusMain, sidebarCollapsed: true, threadPanelOpen: false}
+	// Only focusMain in the cycle; should stay on main.
+	if got := m.nextFocus(); got != focusMain {
+		t.Errorf("expected main->main when sidebar collapsed and no thread, got %v", got)
+	}
+}
+
+func TestLatestHumanFacingMessageScansFromEnd(t *testing.T) {
+	messages := []brokerMessage{
+		{ID: "1", Kind: "automation"},
+		{ID: "2", Kind: "human_decision"},
+		{ID: "3", Kind: "human_action"},
+		{ID: "4", Kind: "automation"},
+	}
+	got := latestHumanFacingMessage(messages)
+	if got == nil {
+		t.Fatalf("expected to find latest human-facing message")
+	}
+	if got.ID != "3" {
+		t.Errorf("expected last human message id=3, got %s", got.ID)
+	}
+
+	if got := latestHumanFacingMessage(nil); got != nil {
+		t.Fatalf("nil input should yield nil")
+	}
+	if got := latestHumanFacingMessage([]brokerMessage{{Kind: "automation"}}); got != nil {
+		t.Fatalf("no human-facing kinds should yield nil")
+	}
+}

--- a/cmd/wuphf/channel_render_cache_test.go
+++ b/cmd/wuphf/channel_render_cache_test.go
@@ -1,0 +1,212 @@
+package main
+
+import "testing"
+
+func freshCacheStore() *channelRenderCacheStore {
+	return &channelRenderCacheStore{
+		mainLines: make(map[uint64][]renderedLine),
+		sidebars:  make(map[uint64]string),
+		markdown:  make(map[uint64]string),
+		threaded:  make(map[uint64][]threadedMessage),
+		blocks:    make(map[uint64][]renderedLine),
+	}
+}
+
+func TestCacheStoreMainLinesRoundTripIsClone(t *testing.T) {
+	c := freshCacheStore()
+	original := []renderedLine{{Text: "one"}, {Text: "two"}}
+	c.putMainLines(42, original)
+	got, ok := c.getMainLines(42)
+	if !ok || len(got) != 2 || got[0].Text != "one" {
+		t.Fatalf("expected cached lines, got %v ok=%v", got, ok)
+	}
+	got[0].Text = "mutated"
+	again, _ := c.getMainLines(42)
+	if again[0].Text != "one" {
+		t.Fatalf("cache must return a clone; mutation leaked: %v", again)
+	}
+	original[1].Text = "leaked"
+	stored, _ := c.getMainLines(42)
+	if stored[1].Text != "two" {
+		t.Fatalf("cache must clone on put too; leaked: %v", stored)
+	}
+}
+
+func TestCacheStoreMissReturnsFalse(t *testing.T) {
+	c := freshCacheStore()
+	if _, ok := c.getMainLines(7); ok {
+		t.Fatalf("missing key should report ok=false")
+	}
+	if _, ok := c.getSidebar(7); ok {
+		t.Fatalf("missing sidebar key should report ok=false")
+	}
+	if _, ok := c.getMarkdown(7); ok {
+		t.Fatalf("missing markdown key should report ok=false")
+	}
+	if _, ok := c.getThreaded(7); ok {
+		t.Fatalf("missing threaded key should report ok=false")
+	}
+	if _, ok := c.getViewportBlock(7); ok {
+		t.Fatalf("missing viewport block key should report ok=false")
+	}
+}
+
+func TestCacheStoreMainLinesEvictsAtLimit(t *testing.T) {
+	c := freshCacheStore()
+	for i := 0; i < mainLinesCacheLimit; i++ {
+		c.putMainLines(uint64(i), []renderedLine{{Text: "x"}})
+	}
+	if len(c.mainLines) != mainLinesCacheLimit {
+		t.Fatalf("expected store at limit, got %d", len(c.mainLines))
+	}
+	// Insertion at the limit triggers a wipe before storing the new key.
+	c.putMainLines(9999, []renderedLine{{Text: "fresh"}})
+	if _, ok := c.getMainLines(0); ok {
+		t.Fatalf("oldest entry should have been evicted on overflow")
+	}
+	if got, ok := c.getMainLines(9999); !ok || got[0].Text != "fresh" {
+		t.Fatalf("newest entry should remain after wipe, got %v ok=%v", got, ok)
+	}
+}
+
+func TestCacheStoreSidebarRoundTrip(t *testing.T) {
+	c := freshCacheStore()
+	c.putSidebar(1, "rendered")
+	got, ok := c.getSidebar(1)
+	if !ok || got != "rendered" {
+		t.Fatalf("expected sidebar hit, got %q ok=%v", got, ok)
+	}
+}
+
+func TestCacheStoreMarkdownEvictionAndRetrieval(t *testing.T) {
+	c := freshCacheStore()
+	for i := 0; i < markdownCacheLimit; i++ {
+		c.putMarkdown(uint64(i), "x")
+	}
+	c.putMarkdown(99999, "newest")
+	if _, ok := c.getMarkdown(0); ok {
+		t.Fatalf("oldest markdown entry should be evicted")
+	}
+	got, ok := c.getMarkdown(99999)
+	if !ok || got != "newest" {
+		t.Fatalf("newest markdown entry should be present, got %q ok=%v", got, ok)
+	}
+}
+
+func TestCacheStoreThreadedClones(t *testing.T) {
+	c := freshCacheStore()
+	original := []threadedMessage{{Message: brokerMessage{ID: "a"}, Depth: 0}}
+	c.putThreaded(1, original)
+	got, ok := c.getThreaded(1)
+	if !ok || got[0].Message.ID != "a" {
+		t.Fatalf("expected cached threaded message, got %v ok=%v", got, ok)
+	}
+	got[0].Message.ID = "mutated"
+	again, _ := c.getThreaded(1)
+	if again[0].Message.ID != "a" {
+		t.Fatalf("threaded cache must return a clone")
+	}
+}
+
+func TestMarkdownCacheKeyDistinguishesWidthAndContent(t *testing.T) {
+	a := markdownCacheKey(80, "hello")
+	b := markdownCacheKey(80, "hello")
+	c := markdownCacheKey(80, "world")
+	d := markdownCacheKey(120, "hello")
+	if a != b {
+		t.Fatalf("identical inputs must yield identical keys")
+	}
+	if a == c {
+		t.Fatalf("different content must yield different key")
+	}
+	if a == d {
+		t.Fatalf("different width must yield different key")
+	}
+}
+
+func TestStateHasherStableForSameInputs(t *testing.T) {
+	build := func() uint64 {
+		h := newStateHasher()
+		h.add("x", "y")
+		h.addInt(7)
+		h.addInt64(42)
+		h.addBool(true)
+		h.addMessages([]brokerMessage{{ID: "m1", From: "fe", Content: "hi"}})
+		h.addMembers([]channelMember{{Slug: "fe", Name: "Frontend"}})
+		h.addChannels([]channelInfo{{Slug: "office", Name: "Office", Members: []string{"fe"}}})
+		h.addTasks([]channelTask{{ID: "t1", Title: "Ship"}})
+		h.addActions([]channelAction{{ID: "a1", Kind: "k", Summary: "did it"}})
+		h.addRequests([]channelInterview{{ID: "r1", Question: "?"}})
+		h.addDecisions([]channelDecision{{ID: "d1", Summary: "yes"}})
+		h.addSignals([]channelSignal{{ID: "s1", Content: "noise"}})
+		h.addWatchdogs([]channelWatchdog{{ID: "w1", Summary: "alert"}})
+		h.addScheduler([]channelSchedulerJob{{Slug: "j1", Label: "Hourly"}})
+		h.addExpandedThreads(map[string]bool{"a": true, "b": false, "c": true})
+		return h.sum()
+	}
+	first := build()
+	second := build()
+	if first != second {
+		t.Fatalf("state hasher must be deterministic for identical inputs (got %d vs %d)", first, second)
+	}
+}
+
+func TestStateHasherChangesWithMessages(t *testing.T) {
+	h1 := newStateHasher()
+	h1.addMessages([]brokerMessage{{ID: "m1", From: "fe", Content: "hello"}})
+
+	h2 := newStateHasher()
+	h2.addMessages([]brokerMessage{{ID: "m1", From: "fe", Content: "goodbye"}})
+
+	if h1.sum() == h2.sum() {
+		t.Fatalf("changing message content must change hash")
+	}
+}
+
+func TestStateHasherExpandedThreadsOrderInsensitive(t *testing.T) {
+	h1 := newStateHasher()
+	h1.addExpandedThreads(map[string]bool{"a": true, "b": true, "c": true})
+
+	h2 := newStateHasher()
+	h2.addExpandedThreads(map[string]bool{"c": true, "a": true, "b": true})
+
+	if h1.sum() != h2.sum() {
+		t.Fatalf("expanded thread set hash must be order-independent")
+	}
+}
+
+func TestStateHasherIgnoresUnexpandedThreads(t *testing.T) {
+	h1 := newStateHasher()
+	h1.addExpandedThreads(map[string]bool{"a": true})
+
+	h2 := newStateHasher()
+	h2.addExpandedThreads(map[string]bool{"a": true, "b": false, "c": false})
+
+	if h1.sum() != h2.sum() {
+		t.Fatalf("unexpanded threads must not affect hash")
+	}
+}
+
+func TestCloneRenderedLinesIndependentOfSource(t *testing.T) {
+	src := []renderedLine{{Text: "a"}, {Text: "b"}}
+	clone := cloneRenderedLines(src)
+	clone[0].Text = "mutated"
+	if src[0].Text != "a" {
+		t.Fatalf("clone must not share storage with source")
+	}
+	if got := cloneRenderedLines(nil); got != nil {
+		t.Fatalf("nil input should clone to nil")
+	}
+}
+
+func TestCloneThreadedMessagesIndependentOfSource(t *testing.T) {
+	src := []threadedMessage{{Message: brokerMessage{ID: "x"}}}
+	clone := cloneThreadedMessages(src)
+	clone[0].Message.ID = "mutated"
+	if src[0].Message.ID != "x" {
+		t.Fatalf("clone must not share storage with source")
+	}
+	if got := cloneThreadedMessages(nil); got != nil {
+		t.Fatalf("nil input should clone to nil")
+	}
+}

--- a/cmd/wuphf/channel_render_extras_test.go
+++ b/cmd/wuphf/channel_render_extras_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildSkillLinesEmptyShowsCoachingCopy(t *testing.T) {
+	lines := buildSkillLines(nil, 80)
+	plain := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(plain, "No skills yet") {
+		t.Fatalf("expected empty-state copy, got %q", plain)
+	}
+	if !strings.Contains(plain, "/skill create") {
+		t.Fatalf("expected skill creation hint, got %q", plain)
+	}
+}
+
+func TestBuildSkillLinesRendersAllMetadata(t *testing.T) {
+	skills := []channelSkill{{
+		ID:                  "s1",
+		Name:                "summarize",
+		Title:               "Summarize PR",
+		Description:         "Boil down a pull request to its decisions.",
+		Status:              "active",
+		UsageCount:          7,
+		CreatedBy:           "ceo",
+		Tags:                []string{"writing", "code"},
+		Trigger:             "@summarize <pr>",
+		WorkflowKey:         "summarize-pr",
+		WorkflowProvider:    "anthropic",
+		WorkflowSchedule:    "0 9 * * *",
+		RelayID:             "relay-1",
+		RelayPlatform:       "github",
+		RelayEventTypes:     []string{"pull_request"},
+		LastExecutionAt:     "2026-04-29T08:00:00Z",
+		LastExecutionStatus: "success",
+	}}
+	lines := buildSkillLines(skills, 80)
+	plain := stripANSI(joinRenderedLines(lines))
+	for _, want := range []string{
+		"Summarize PR",
+		"Boil down a pull request",
+		"summarize",
+		"7 uses",
+		"writing, code",
+		"trigger: @summarize <pr>",
+		"workflow: summarize-pr via anthropic",
+		"schedule: 0 9 * * *",
+		"relay: github · pull_request · relay-1",
+		"last run: success",
+	} {
+		if !strings.Contains(plain, want) {
+			t.Errorf("expected %q in skill lines, got %q", want, plain)
+		}
+	}
+}
+
+func TestBuildSkillLinesUnknownStatusFallsBackToActive(t *testing.T) {
+	skills := []channelSkill{{ID: "s1", Title: "x", Status: ""}}
+	lines := buildSkillLines(skills, 80)
+	plain := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(plain, "active") {
+		t.Fatalf("blank status must default to active, got %q", plain)
+	}
+}
+
+func TestBuildOneOnOneMessageLinesEmptyShowsCoachingCopy(t *testing.T) {
+	lines := buildOneOnOneMessageLines(nil, nil, 80, "Frontend", "", 0)
+	plain := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(plain, "Frontend") {
+		t.Fatalf("expected agent name in empty state, got %q", plain)
+	}
+	if !strings.Contains(plain, "Suggested:") {
+		t.Fatalf("expected suggestion in empty state, got %q", plain)
+	}
+}
+
+func TestBuildOneOnOneMessageLinesPopulatedDelegatesToOffice(t *testing.T) {
+	messages := []brokerMessage{
+		{ID: "m1", From: "fe", Content: "hello", Timestamp: "2026-04-29T10:00:00Z"},
+	}
+	lines := buildOneOnOneMessageLines(messages, nil, 80, "Frontend", "", 0)
+	if len(lines) == 0 {
+		t.Fatalf("expected lines for non-empty 1:1, got nothing")
+	}
+	plain := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(plain, "hello") {
+		t.Fatalf("expected message content rendered, got %q", plain)
+	}
+}
+
+func TestRequestCalendarEventsProducesEventForEachTimeField(t *testing.T) {
+	req := channelInterview{
+		ID:         "req-1",
+		From:       "ceo",
+		Question:   "Approve?",
+		Channel:    "office",
+		Status:     "open",
+		DueAt:      "2026-04-29T10:00:00Z",
+		FollowUpAt: "2026-04-29T11:00:00Z",
+		ReminderAt: "2026-04-29T12:00:00Z",
+		RecheckAt:  "2026-04-29T13:00:00Z",
+	}
+	events := requestCalendarEvents(req, "office", nil)
+	if len(events) != 4 {
+		t.Fatalf("expected 4 calendar events from 4 time fields, got %d", len(events))
+	}
+	wantSecondaries := map[string]bool{"due": false, "follow up": false, "reminder": false, "recheck": false}
+	for _, ev := range events {
+		if ev.Kind != "request" {
+			t.Errorf("expected kind=request, got %q", ev.Kind)
+		}
+		if ev.RequestID != "req-1" {
+			t.Errorf("expected request id echoed, got %q", ev.RequestID)
+		}
+		wantSecondaries[ev.Secondary] = true
+	}
+	for label, ok := range wantSecondaries {
+		if !ok {
+			t.Errorf("missing event for %q", label)
+		}
+	}
+}
+
+func TestRequestCalendarEventsSkipsBlankTimestamps(t *testing.T) {
+	req := channelInterview{ID: "req-2", From: "ceo", Question: "x", DueAt: "2026-04-29T10:00:00Z"}
+	events := requestCalendarEvents(req, "office", nil)
+	if len(events) != 1 {
+		t.Fatalf("only DueAt set, expected 1 event, got %d", len(events))
+	}
+	if events[0].Secondary != "due" {
+		t.Fatalf("expected due-only event, got %q", events[0].Secondary)
+	}
+}
+
+func TestRequestCalendarEventsBlankStatusDefaultsToPending(t *testing.T) {
+	req := channelInterview{ID: "req-3", From: "ceo", DueAt: "2026-04-29T10:00:00Z"}
+	events := requestCalendarEvents(req, "office", nil)
+	if len(events) != 1 || events[0].Status != "pending" {
+		t.Fatalf("blank status should default to pending, got %#v", events)
+	}
+}
+
+func TestCalendarParticipantsForRequestUsesRequester(t *testing.T) {
+	members := []channelMember{
+		{Slug: "ceo", Name: "CEO"},
+		{Slug: "fe", Name: "Frontend"},
+	}
+	req := channelInterview{ID: "r1", From: "fe", Channel: "office"}
+	names := calendarParticipantsForRequest(req, "office", members)
+	if len(names) == 0 {
+		t.Fatalf("expected at least one participant name")
+	}
+	found := false
+	for _, name := range names {
+		if name == "Frontend" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected Frontend in participants, got %v", names)
+	}
+
+	slugs := calendarParticipantSlugsForRequest(req, "office", members)
+	foundSlug := false
+	for _, s := range slugs {
+		if s == "fe" {
+			foundSlug = true
+		}
+	}
+	if !foundSlug {
+		t.Fatalf("expected fe in slugs, got %v", slugs)
+	}
+}
+
+func TestCalendarParticipantsForRequestEmptyFromUsesChannelMembers(t *testing.T) {
+	members := []channelMember{
+		{Slug: "ceo", Name: "CEO"},
+		{Slug: "fe", Name: "Frontend"},
+	}
+	req := channelInterview{ID: "r1", From: "", Channel: "office"}
+	names := calendarParticipantsForRequest(req, "office", members)
+	// When req has no From, it should still produce some output (channel-wide).
+	if len(names) == 0 {
+		t.Fatalf("expected channel-wide participants when From is blank, got nothing")
+	}
+}
+
+func TestContainsStringMatchesTrimmedTarget(t *testing.T) {
+	items := []string{" fe ", "be", "ceo"}
+	if !containsString(items, "fe") {
+		t.Fatalf("expected trimmed match for fe")
+	}
+	if !containsString(items, "be") {
+		t.Fatalf("expected match for be")
+	}
+	if containsString(items, "pm") {
+		t.Fatalf("unexpected match for pm")
+	}
+	if containsString(nil, "fe") {
+		t.Fatalf("nil slice should not match")
+	}
+}
+
+func TestRenderTimingSummaryJoinsParts(t *testing.T) {
+	got := renderTimingSummary("2030-01-01T10:00:00Z", "", "", "")
+	if got == "" {
+		t.Fatalf("expected non-empty timing summary, got empty")
+	}
+	if !strings.Contains(got, "due") {
+		t.Fatalf("expected 'due' label in timing summary, got %q", got)
+	}
+}
+
+func TestRenderTimingSummaryAllBlank(t *testing.T) {
+	if got := renderTimingSummary("", "", "", ""); got != "" {
+		t.Fatalf("blank inputs should yield empty timing summary, got %q", got)
+	}
+}
+
+func TestPrettyWhenUnparsable(t *testing.T) {
+	got := prettyWhen("not-a-time", "due")
+	if !strings.Contains(got, "not-a-time") {
+		t.Fatalf("unparsable timestamps should fall through, got %q", got)
+	}
+}
+
+func TestSummarizeUnreadMessagesGroups(t *testing.T) {
+	cases := []struct {
+		messages []brokerMessage
+		want     string
+	}{
+		{nil, ""},
+		{[]brokerMessage{{From: "fe"}}, "1 new from"},
+		{[]brokerMessage{{From: "fe"}, {From: "be"}}, " and "},
+		{[]brokerMessage{{From: "fe"}, {From: "be"}, {From: "pm"}}, ", and "},
+		{[]brokerMessage{{From: ""}, {From: "  "}}, "2 new messages"},
+	}
+	for _, tc := range cases {
+		got := summarizeUnreadMessages(tc.messages)
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("messages=%v: expected %q in %q", tc.messages, tc.want, got)
+		}
+	}
+}
+
+func TestCountRepliesFollowsNestedThread(t *testing.T) {
+	messages := []brokerMessage{
+		{ID: "root", From: "ceo"},
+		{ID: "r1", From: "fe", ReplyTo: "root", Timestamp: "2026-04-29T10:00:00Z"},
+		{ID: "r2", From: "be", ReplyTo: "r1", Timestamp: "2026-04-29T10:05:00Z"},
+		{ID: "r3", From: "pm", ReplyTo: "root", Timestamp: "2026-04-29T10:10:00Z"},
+	}
+	count, last := countReplies(messages, "root")
+	if count != 3 {
+		t.Fatalf("expected 3 replies counting nested, got %d", count)
+	}
+	if last == "" {
+		t.Fatalf("expected last reply timestamp, got empty")
+	}
+}
+
+func TestCountRepliesNoReplies(t *testing.T) {
+	messages := []brokerMessage{{ID: "root"}}
+	count, last := countReplies(messages, "root")
+	if count != 0 || last != "" {
+		t.Fatalf("expected zero replies for solo message, got count=%d last=%q", count, last)
+	}
+}
+
+func TestParseTimestampHandlesInvalidString(t *testing.T) {
+	if !parseTimestamp("nope").IsZero() {
+		t.Fatalf("invalid string should yield zero time")
+	}
+}
+
+func TestFormatShortTimeFallsBackOnInvalid(t *testing.T) {
+	if got := formatShortTime("not-a-time"); got != "" {
+		t.Fatalf("expected empty for unparsable short input, got %q", got)
+	}
+	// Long enough to slice — should return raw HH:MM substring.
+	if got := formatShortTime("2026-04-29T15:30:00Z"); got == "" {
+		t.Fatalf("expected formatted time for valid RFC3339")
+	}
+}

--- a/cmd/wuphf/channel_render_test.go
+++ b/cmd/wuphf/channel_render_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDefaultHumanMessageTitleByKind(t *testing.T) {
+	cases := map[string]string{
+		"human_decision": "needs your call",
+		"human_action":   "wants you to do something",
+		"human_report":   "has an update for you",
+		"":               "has an update for you",
+	}
+	for kind, want := range cases {
+		got := defaultHumanMessageTitle(kind, "ceo")
+		if !strings.Contains(got, want) {
+			t.Errorf("defaultHumanMessageTitle(%q, ceo) = %q, want substring %q", kind, got, want)
+		}
+	}
+}
+
+func TestHumanMessageLabelByKind(t *testing.T) {
+	cases := map[string]string{
+		"human_decision": "decision",
+		"human_action":   "action",
+		"":               "report",
+		"unknown":        "report",
+	}
+	for kind, want := range cases {
+		if got := humanMessageLabel(kind); got != want {
+			t.Errorf("humanMessageLabel(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestRenderUnreadDividerIncludesCount(t *testing.T) {
+	got := stripANSI(renderUnreadDivider(60, 3))
+	if !strings.Contains(got, "3 new since you looked") {
+		t.Fatalf("expected count in divider, got %q", got)
+	}
+}
+
+func TestRenderUnreadDividerNoCountFallback(t *testing.T) {
+	got := stripANSI(renderUnreadDivider(60, 0))
+	if !strings.Contains(got, "New since you looked") {
+		t.Fatalf("expected generic divider when count is zero, got %q", got)
+	}
+}
+
+func TestRenderUnreadDividerSurvivesNarrowWidth(t *testing.T) {
+	// Width below the label length must not panic and must still produce text.
+	if got := renderUnreadDivider(4, 1); got == "" {
+		t.Fatalf("narrow divider should still render content")
+	}
+}
+
+func TestSliceRenderedLinesScrollsFromBottom(t *testing.T) {
+	lines := []renderedLine{
+		{Text: "0"}, {Text: "1"}, {Text: "2"}, {Text: "3"}, {Text: "4"},
+	}
+	visible, scroll, start, end := sliceRenderedLines(lines, 3, 0)
+	if scroll != 0 || start != 2 || end != 5 || len(visible) != 3 {
+		t.Fatalf("expected bottom 3 lines, got start=%d end=%d scroll=%d len=%d", start, end, scroll, len(visible))
+	}
+	if visible[0].Text != "2" || visible[2].Text != "4" {
+		t.Fatalf("expected lines [2..4], got %v", visible)
+	}
+}
+
+func TestSliceRenderedLinesScrollClampsToBuffer(t *testing.T) {
+	lines := []renderedLine{{Text: "a"}, {Text: "b"}, {Text: "c"}, {Text: "d"}}
+	visible, scroll, start, _ := sliceRenderedLines(lines, 2, 99)
+	// scroll clamped: total - msgH = 4 - 2 = 2
+	if scroll != 2 {
+		t.Fatalf("expected scroll clamped to 2, got %d", scroll)
+	}
+	if start != 0 {
+		t.Fatalf("expected start=0 when fully scrolled up, got %d", start)
+	}
+	if len(visible) != 2 || visible[0].Text != "a" {
+		t.Fatalf("expected top slice, got %v", visible)
+	}
+}
+
+func TestSliceRenderedLinesEmptyInput(t *testing.T) {
+	visible, scroll, start, end := sliceRenderedLines(nil, 5, 0)
+	if visible != nil || scroll != 0 || start != 0 || end != 0 {
+		t.Fatalf("empty input should return zero values, got %v %d %d %d", visible, scroll, start, end)
+	}
+}
+
+func TestBuildRequestLinesEmptyShowsCoachingCopy(t *testing.T) {
+	lines := buildRequestLines(nil, 80)
+	plain := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(plain, "No open requests") {
+		t.Fatalf("expected empty-state message, got %q", plain)
+	}
+}
+
+func TestBuildRequestLinesIncludesQuestionAndContext(t *testing.T) {
+	requests := []channelInterview{{
+		ID:            "req-1",
+		Kind:          "decision",
+		From:          "ceo",
+		Status:        "open",
+		Title:         "Launch decision",
+		Question:      "Approve the rollout?",
+		Context:       "The metrics look healthy and stable.",
+		RecommendedID: "ship",
+		Blocking:      true,
+		Required:      true,
+		CreatedAt:     "2026-04-29T09:00:00Z",
+	}}
+	lines := buildRequestLines(requests, 80)
+	plain := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(plain, "Approve the rollout?") {
+		t.Fatalf("expected question, got %q", plain)
+	}
+	if !strings.Contains(plain, "Launch decision") {
+		t.Fatalf("expected title in meta, got %q", plain)
+	}
+	if !strings.Contains(plain, "Recommended: ship") {
+		t.Fatalf("expected recommended id, got %q", plain)
+	}
+	if !strings.Contains(plain, "blocking") {
+		t.Fatalf("expected blocking marker, got %q", plain)
+	}
+	if !strings.Contains(plain, "unblocks the team") {
+		t.Fatalf("blocking requests should explain dismiss consequences, got %q", plain)
+	}
+}
+
+func TestBuildPolicyLinesEmptyShowsGuidance(t *testing.T) {
+	lines := buildPolicyLines(nil, nil, nil, nil, 80)
+	plain := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(plain, "Insights") {
+		t.Fatalf("expected Insights header, got %q", plain)
+	}
+	if !strings.Contains(plain, "No office insights yet") {
+		t.Fatalf("expected empty-state guidance, got %q", plain)
+	}
+}
+
+func TestBuildPolicyLinesShowsSignalsDecisionsWatchdogs(t *testing.T) {
+	signals := []channelSignal{{ID: "s1", Title: "Spike", Content: "Latency rising", Owner: "be"}}
+	decisions := []channelDecision{{ID: "d1", Summary: "Roll forward", Reason: "Risk acceptable", Owner: "ceo"}}
+	watchdogs := []channelWatchdog{{ID: "w1", Summary: "Build flaking", Status: "active", Kind: "ci"}}
+	lines := buildPolicyLines(signals, decisions, watchdogs, nil, 80)
+	plain := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(plain, "Spike") {
+		t.Fatalf("expected signal title, got %q", plain)
+	}
+	if !strings.Contains(plain, "Roll forward") {
+		t.Fatalf("expected decision summary, got %q", plain)
+	}
+	if !strings.Contains(plain, "Build flaking") {
+		t.Fatalf("expected watchdog summary, got %q", plain)
+	}
+}

--- a/cmd/wuphf/channel_splash_test.go
+++ b/cmd/wuphf/channel_splash_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestNewSplashModelHasMembers(t *testing.T) {
+	m := newSplashModel()
+	if len(m.members) == 0 {
+		t.Fatalf("expected non-empty member roster")
+	}
+	if m.startAt.IsZero() || m.phaseAt.IsZero() {
+		t.Fatalf("expected start/phase timestamps initialized")
+	}
+}
+
+func TestSplashViewRendersWithoutPanic(t *testing.T) {
+	m := newSplashModel()
+	m.width = 100
+	m.height = 30
+	got := m.View()
+	if got == "" {
+		t.Fatalf("expected non-empty splash view")
+	}
+}
+
+func TestSplashKeyPressTransitionsToDone(t *testing.T) {
+	m := newSplashModel()
+	model, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatalf("expected non-nil cmd on key press")
+	}
+	if _, ok := model.(splashModel); !ok {
+		t.Fatalf("expected splashModel back, got %T", model)
+	}
+	// The cmd should produce splashDoneMsg
+	msg := cmd()
+	if _, ok := msg.(splashDoneMsg); !ok {
+		t.Fatalf("expected splashDoneMsg from key press, got %T", msg)
+	}
+}
+
+func TestSplashWindowSizeUpdates(t *testing.T) {
+	m := newSplashModel()
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	out := updated.(splashModel)
+	if out.width != 120 || out.height != 40 {
+		t.Errorf("expected size 120x40, got %dx%d", out.width, out.height)
+	}
+}
+
+func TestSplashRendersTitleInTitlePhase(t *testing.T) {
+	m := newSplashModel()
+	m.width = 100
+	m.height = 30
+	m.phase = splashTitle
+	got := stripANSI(m.View())
+	if got == "" {
+		t.Fatalf("expected splash title view")
+	}
+	// The title phase shows the WUPHF brand somewhere.
+	if !strings.Contains(strings.ToUpper(got), "WUPHF") {
+		t.Logf("title view did not include 'WUPHF' literal — may use ASCII art only: %q", got)
+	}
+}
+
+func TestSplashTickAdvancesFrame(t *testing.T) {
+	m := newSplashModel()
+	m.width = 80
+	m.height = 24
+	updated, _ := m.Update(splashTickMsg{})
+	out := updated.(splashModel)
+	if out.frame != m.frame+1 {
+		t.Errorf("expected frame to advance by 1, got %d -> %d", m.frame, out.frame)
+	}
+}

--- a/cmd/wuphf/channel_styles_test.go
+++ b/cmd/wuphf/channel_styles_test.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Pure smoke tests: style constructors return non-zero, runtime-stable
+// lipgloss.Style values. Catches accidental nil returns or panics in
+// constructors that have no other test signal.
+
+func styleProducesOutput(t *testing.T, name string, style lipgloss.Style, sample string) {
+	t.Helper()
+	rendered := style.Render(sample)
+	if rendered == "" {
+		t.Fatalf("%s.Render(%q) produced empty output", name, sample)
+	}
+}
+
+func TestStylesProduceRenderableOutput(t *testing.T) {
+	styleProducesOutput(t, "sidebarStyle", sidebarStyle(20, 5), "x")
+	styleProducesOutput(t, "mainPanelStyle", mainPanelStyle(40, 10), "x")
+	styleProducesOutput(t, "threadPanelStyle", threadPanelStyle(40, 10), "x")
+	styleProducesOutput(t, "statusBarStyle", statusBarStyle(80), "x")
+	styleProducesOutput(t, "channelHeaderStyle", channelHeaderStyle(80), "x")
+	styleProducesOutput(t, "composerBorderStyle/blur", composerBorderStyle(40, false), "x")
+	styleProducesOutput(t, "composerBorderStyle/focus", composerBorderStyle(40, true), "x")
+	styleProducesOutput(t, "timestampStyle", timestampStyle(), "10:00")
+	styleProducesOutput(t, "mutedTextStyle", mutedTextStyle(), "muted")
+	styleProducesOutput(t, "agentNameStyle/known", agentNameStyle("ceo"), "CEO")
+	styleProducesOutput(t, "agentNameStyle/unknown", agentNameStyle("does-not-exist"), "x")
+	styleProducesOutput(t, "activeChannelStyle", activeChannelStyle(), "office")
+	styleProducesOutput(t, "dateSeparatorStyle", dateSeparatorStyle(), "today")
+	styleProducesOutput(t, "threadIndicatorStyle", threadIndicatorStyle(), "thread")
+}
+
+func TestAgentAvatarKnownAndUnknownSlugs(t *testing.T) {
+	cases := map[string]string{
+		"ceo":      "◆",
+		"pm":       "▣",
+		"fe":       "▤",
+		"be":       "▥",
+		"ai":       "◉",
+		"designer": "◌",
+		"cmo":      "✶",
+		"cro":      "◈",
+		"nex":      "◎",
+		"you":      "●",
+		"random":   "•",
+		"":         "•",
+	}
+	for slug, want := range cases {
+		if got := agentAvatar(slug); got != want {
+			t.Errorf("agentAvatar(%q) = %q, want %q", slug, got, want)
+		}
+	}
+}
+
+func TestMascotAccentFallsBackForUnknown(t *testing.T) {
+	if got := mascotAccent("ceo"); got != "⌐" {
+		t.Errorf("ceo accent should be ⌐, got %q", got)
+	}
+	if got := mascotAccent("does-not-exist"); got != "•" {
+		t.Errorf("unknown slug should fall back to •, got %q", got)
+	}
+}
+
+func TestMascotEyesFallsBackForUnknown(t *testing.T) {
+	l, r := mascotEyes("ceo")
+	if l != "■" || r != "■" {
+		t.Errorf("ceo eyes should be ■ ■, got %q %q", l, r)
+	}
+	l, r = mascotEyes("ai")
+	if l != "◉" || r != "◉" {
+		t.Errorf("ai eyes should be ◉ ◉, got %q %q", l, r)
+	}
+	l, r = mascotEyes("nobody")
+	if l != "•" || r != "•" {
+		t.Errorf("unknown slug eyes should be • •, got %q %q", l, r)
+	}
+}
+
+func TestMascotMouthVariesByActivityAndFrame(t *testing.T) {
+	cases := []struct {
+		activity string
+		frame    int
+		want     string
+	}{
+		{"talking", 0, "o"},
+		{"talking", 1, "ᴗ"},
+		{"shipping", 0, "⌣"},
+		{"shipping", 1, "▿"},
+		{"plotting", 0, "~"},
+		{"plotting", 1, "ˎ"},
+		{"unknown", 0, "‿"},
+		{"unknown", 1, "_"},
+	}
+	for _, tc := range cases {
+		if got := mascotMouth(tc.activity, tc.frame); got != tc.want {
+			t.Errorf("mascotMouth(%q,%d) = %q, want %q", tc.activity, tc.frame, got, tc.want)
+		}
+	}
+}
+
+func TestMascotTopVariesByActivity(t *testing.T) {
+	if got := mascotTop("talking", 0); got == "" {
+		t.Fatalf("expected mascotTop output for talking")
+	}
+	if got := mascotTop("talking", 1); got == "" {
+		t.Fatalf("expected mascotTop output for talking frame 1")
+	}
+	if got := mascotTop("plotting", 0); got == "" {
+		t.Fatalf("expected mascotTop output for plotting")
+	}
+	if got := mascotTop("idle", 0); got == "" {
+		t.Fatalf("expected mascotTop fallback")
+	}
+}

--- a/cmd/wuphf/channel_thread_test.go
+++ b/cmd/wuphf/channel_thread_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFlattenThreadRepliesNestedDepth(t *testing.T) {
+	messages := []brokerMessage{
+		{ID: "root", From: "ceo", Content: "Should we ship?"},
+		{ID: "r1", From: "fe", Content: "Yes", ReplyTo: "root"},
+		{ID: "r1a", From: "be", Content: "Agree", ReplyTo: "r1"},
+		{ID: "r2", From: "pm", Content: "Wait", ReplyTo: "root"},
+		{ID: "unrelated", From: "cmo", Content: "Different topic"},
+	}
+	out := flattenThreadReplies(messages, "root")
+	if len(out) != 3 {
+		t.Fatalf("expected 3 thread replies, got %d", len(out))
+	}
+	if out[0].Message.ID != "r1" || out[0].Depth != 0 {
+		t.Fatalf("expected first reply r1 at depth 0, got %#v", out[0])
+	}
+	if out[1].Message.ID != "r1a" || out[1].Depth != 1 || out[1].ParentLabel != "@fe" {
+		t.Fatalf("expected nested r1a depth 1 under @fe, got %#v", out[1])
+	}
+	if out[2].Message.ID != "r2" || out[2].Depth != 0 {
+		t.Fatalf("expected sibling r2 depth 0, got %#v", out[2])
+	}
+}
+
+func TestFlattenThreadRepliesUnknownParentReturnsNothing(t *testing.T) {
+	messages := []brokerMessage{
+		{ID: "a", From: "fe", Content: "hi"},
+		{ID: "b", From: "be", Content: "reply", ReplyTo: "a"},
+	}
+	out := flattenThreadReplies(messages, "missing")
+	if len(out) != 0 {
+		t.Fatalf("unknown parent should yield zero replies, got %d", len(out))
+	}
+}
+
+func TestRenderThreadReplyContainsAuthorAndBody(t *testing.T) {
+	reply := threadedMessage{
+		Message: brokerMessage{
+			ID:        "r1",
+			From:      "fe",
+			Content:   "Looks good",
+			Timestamp: "2026-04-29T10:00:00Z",
+		},
+		Depth:       1,
+		ParentLabel: "@ceo",
+	}
+	lines := renderThreadReply(reply, 60)
+	plain := stripANSI(strings.Join(lines, "\n"))
+	if !strings.Contains(strings.ToLower(plain), "frontend") {
+		t.Fatalf("expected author label in reply, got %q", plain)
+	}
+	if !strings.Contains(plain, "Looks good") {
+		t.Fatalf("expected reply body, got %q", plain)
+	}
+	if !strings.Contains(plain, "↳") {
+		t.Fatalf("expected nested reply marker, got %q", plain)
+	}
+	if !strings.Contains(plain, "reply to @ceo") {
+		t.Fatalf("expected parent label, got %q", plain)
+	}
+}
+
+func TestRenderThreadRepliesMultipleProducesLines(t *testing.T) {
+	replies := []threadedMessage{
+		{Message: brokerMessage{ID: "r1", From: "fe", Content: "A"}, Depth: 0, ParentLabel: "@ceo"},
+		{Message: brokerMessage{ID: "r2", From: "be", Content: "B"}, Depth: 0, ParentLabel: "@ceo"},
+	}
+	lines := renderThreadReplies(replies, 60)
+	if len(lines) == 0 {
+		t.Fatalf("expected lines for replies")
+	}
+	plain := stripANSI(strings.Join(lines, "\n"))
+	if !strings.Contains(plain, "A") || !strings.Contains(plain, "B") {
+		t.Fatalf("expected both reply bodies, got %q", plain)
+	}
+}
+
+func TestRenderThreadRepliesEmptyReturnsNil(t *testing.T) {
+	if got := renderThreadReplies(nil, 60); got != nil {
+		t.Fatalf("empty replies should return nil, got %v", got)
+	}
+}
+
+func TestRenderThreadMessageHasAvatarAndBody(t *testing.T) {
+	msg := brokerMessage{
+		ID:        "m1",
+		From:      "ceo",
+		Content:   "Approve the launch",
+		Timestamp: "2026-04-29T10:00:00Z",
+	}
+	lines := renderThreadMessage(msg, 60, true)
+	plain := stripANSI(strings.Join(lines, "\n"))
+	if !strings.Contains(plain, "Approve the launch") {
+		t.Fatalf("expected message body, got %q", plain)
+	}
+}
+
+func TestRenderThreadInputPlaceholderWhenEmpty(t *testing.T) {
+	got := renderThreadInput(nil, 0, 30, false, false)
+	plain := stripANSI(got)
+	if !strings.Contains(plain, "Reply") {
+		t.Fatalf("expected Reply label, got %q", plain)
+	}
+	if !strings.Contains(plain, "Reply in thread") {
+		t.Fatalf("expected placeholder copy, got %q", plain)
+	}
+}
+
+func TestRenderThreadInputRendersExistingInput(t *testing.T) {
+	input := []rune("ship it")
+	got := renderThreadInput(input, len(input), 30, true, true)
+	plain := stripANSI(got)
+	if !strings.Contains(plain, "ship it") {
+		t.Fatalf("expected user input echoed, got %q", plain)
+	}
+}
+
+func TestRenderThreadPanelMissingParentShowsNotice(t *testing.T) {
+	got := renderThreadPanel(nil, "missing", 60, 20, nil, 0, 0, "", false, false)
+	plain := stripANSI(got)
+	if !strings.Contains(plain, "Thread message not found") {
+		t.Fatalf("expected missing-parent notice, got %q", plain)
+	}
+}
+
+func TestRenderThreadPanelRendersParentAndReplies(t *testing.T) {
+	messages := []brokerMessage{
+		{ID: "root", From: "ceo", Content: "Approve?", Timestamp: "2026-04-29T10:00:00Z"},
+		{ID: "r1", From: "fe", Content: "Approved", ReplyTo: "root", Timestamp: "2026-04-29T10:01:00Z"},
+	}
+	got := renderThreadPanel(messages, "root", 60, 20, nil, 0, 0, "", true, false)
+	plain := stripANSI(got)
+	if !strings.Contains(plain, "Approve?") {
+		t.Fatalf("expected parent body, got %q", plain)
+	}
+	if !strings.Contains(plain, "Approved") {
+		t.Fatalf("expected reply body, got %q", plain)
+	}
+	if !strings.Contains(plain, "1 reply") {
+		t.Fatalf("expected reply count divider, got %q", plain)
+	}
+}
+
+func TestRenderThreadPanelTooSmallReturnsEmpty(t *testing.T) {
+	if got := renderThreadPanel(nil, "x", 4, 2, nil, 0, 0, "", false, false); got != "" {
+		t.Fatalf("undersized panel should return empty string, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

PR 0 of a planned 9-PR sequence to break apart \`cmd/wuphf/channel*\` (~25k LoC, 40 files in \`package main\`) into a dedicated \`cmd/wuphf/channelui\` package. This PR is **tests only** — no production code moves. It establishes a characterization safety net so subsequent extraction PRs can be verified by running the existing test suite at HEAD before and after each move.

- Coverage on \`cmd/wuphf\`: **42.4% → 51.9%** of statements
- Channel files alone now average **70.3%** per-function coverage
- 12 new test files, all green; \`golangci-lint\` clean; \`gofmt\` clean
- No changes to production code

## What's covered

- **Mailboxes** (\`channel_mailboxes_test.go\`) — inbox/outbox lane filtering, viewer-scope traversal with cycle protection, empty-state copy
- **Thread panel** (\`channel_thread_test.go\`) — \`flattenThreadReplies\` nesting, depth labels, parent-not-found notice, thread input rendering
- **Render cache** (\`channel_render_cache_test.go\`) — clone-on-get/put invariants, eviction at limit, deterministic FNV hashing across all \`addX\` shapes, order-insensitive expanded threads
- **Broker** (\`channel_broker_test.go\`) — \`pollHealth/pollBroker/pollMembers/pollChannels/pollUsage/pollActions/pollSignals/pollDecisions\`, \`createDMChannel\`, \`mutateTask\`, \`postHumanInterrupt\`, \`cancelRequest\`, \`postInterviewAnswer\`, network-failure swallow, \`normalizeBrokerURL\` rewrites — all via \`httptest.Server\` + \`WUPHF_BROKER_BASE_URL\` override
- **Member draft** (\`channel_member_draft_test.go\`) — step state machine, slug normalization, expertise dedup, payload serialization (create/update actions)
- **Integrations** (\`channel_integration_test.go\`) — \`slugifyGroupTitle\`, \`slugifyOpenclawLabel\`, picker-options/spec lookups
- **Render helpers** (\`channel_render_test.go\`, \`channel_render_extras_test.go\`) — \`buildSkillLines\`, \`buildOneOnOneMessageLines\`, \`buildPolicyLines\`, \`buildRequestLines\`, \`requestCalendarEvents\`, \`calendarParticipantsForRequest\`, \`renderUnreadDivider\`, \`sliceRenderedLines\`, \`prettyWhen\`, \`countReplies\`, \`summarizeUnreadMessages\`
- **Confirm dialogs** (\`channel_confirm_test.go\`) — all 5 confirmation flows + \`renderConfirmCard\` + \`executeConfirmation\`
- **Splash** (\`channel_splash_test.go\`) — smoke (\`View\` doesn't panic), key dismissal, window resize, frame advance, title phase
- **Styles** (\`channel_styles_test.go\`) — every style constructor produces renderable output, \`agentAvatar\`/\`mascotAccent\`/\`mascotEyes\`/\`mascotMouth\`/\`mascotTop\` lookups
- **Model helpers** (\`channel_model_helpers_test.go\`) — \`Init\`, \`currentAppLabel\` (1:1 vs office), \`nextFocus\` cycling with collapsed sidebar / open thread, \`filterInsightMessages\`, \`countUniqueAgents\`, \`formatUsd\`, \`formatTokenCount\`, \`recommendedOptionIndex\`, \`interviewOptionCount\`, \`selectedInterviewOption\`, \`renderUsageStrip\`, \`latestHumanFacingMessage\`, \`popupActionIndex\`

## Why now

Stacked refactor follow-ups will move \`channelModel\`, \`renderSidebar\`, \`Update\`/\`View\`, the broker cmd builders, and the cache out of \`package main\` and into \`channelui\`. The riskiest things to break silently in that move are:

- \`channelRenderCache\` invariants (cache returning shared backing slices)
- \`brokerTokenPath\` env-var fallback (already covered by existing tests, retained)
- \`tea.Cmd\` builder ↔ \`tea.Msg\` consumer pairings
- \`officeDirectory\` package-level mutable singleton
- \`onboardingChecklist\` cross-package contract

All of those are now pinned by tests at HEAD before any code moves.

## Test plan

- [x] \`bash scripts/test-go.sh\` — all 32 packages green
- [x] \`go vet ./cmd/wuphf/...\` — clean
- [x] \`golangci-lint run ./cmd/wuphf/...\` — 0 issues
- [x] \`gofmt -l\` — clean
- [x] Coverage measured: \`go test -cover ./cmd/wuphf/...\` reports 51.9% (up from 42.4%)
- [ ] CI passes on draft PR

## Follow-ups (stacked)

PR 1 will extract \`internal/avatar\` (leafmost dependency); subsequent PRs walk up the dependency graph (renderers → workspace cluster → sidebar/splash → broker/integrations → \`channelModel\` itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)