### PR TITLE
refactor(team): extract promptBuilder from launcher.go (C1)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,368 @@
+# launcher.go decomposition — plan
+
+Status: proposal, not yet implemented. Worktree `refactor/launcher-split` off main.
+
+Source of truth: `/Users/fd/src/nex/wuphf-launcher-split/internal/team/launcher.go` (4998 lines, 161 funcs).
+
+## Decisions, up front
+
+- Stay inside package `internal/team`. Do **not** spin up child packages (`team/dispatch`, `team/scheduler`, etc.). The struct surface is already entangled (`*Launcher` pointer, `*Broker`, unexported types like `notificationTarget`, `officeMember`, `teamTask`, `headlessCodexTurn`, `paneDispatchTurn`, `officeActionLog`). Promoting them to a sub-package means exporting half the package's domain types — a mechanical change with a huge diff and no real isolation gain. Splits become **new files** + **new unexported types** in the same package, with `*Launcher` keeping a pointer/field to each.
+- Each new type owns its own state and its own mutex. `Launcher` keeps the field, but the mutex moves into the new type. No more "the launcher has 3 mutexes".
+- Test seams use the existing `atomic.Pointer[fn]` override pattern (`launcherSendNotificationToPaneOverride` in launcher.go:3142, swap helper in `test_support.go:184`). It already works under `-race`, supports nested cleanup, and ships in production with zero overhead. Replicate that exact shape for new seams; do not invent a fresh injection style.
+- Time-based loops get a `clock` interface plus a `signal` channel. No `time.Sleep` in tests — the user's hard rule. Production uses `realClock`; tests use `manualClock` with a `Tick()` method that releases pending sleepers and exposes a `Sent <-chan struct{}` for "I observed the work" signalling.
+- All extractions are **PRs against `main`**, one cluster per PR, in the order below. Each PR must (a) leave `go test ./internal/team/... -race` green, (b) ship at least one new test exercising a path that was 0% before, and (c) not touch any caller outside `internal/team`.
+
+---
+
+## 1. Cluster proposal
+
+Numbering matches the cut order in §2.
+
+### C1 — `prompt_builder.go` (new type `promptBuilder`)
+**Funcs moved:** `buildPrompt`, `markdownKnowledgeToolBlock`, `markdownKnowledgeMemoryBlock`, `teamVoiceForSlug`, `headlessSandboxNote`. Helpers: `agentConfigFromMember` if it stays referenced only here; otherwise leave it.
+
+**New surface:**
+```go
+type promptBuilder struct {
+    pack             *agent.PackDefinition
+    bp               *operations.Blueprint
+    isOneOnOne       func() bool
+    isFocusMode      func() bool
+    packName         func() string
+    leadSlug         func() string
+    members          func() []officeMember
+    policies         func() []officePolicy
+    memoryBackend    config.MemoryBackend
+    nexDisabled      bool
+}
+func (p *promptBuilder) Build(slug string) string
+```
+
+**Launcher keeps:** a `prompt promptBuilder` field built once per `Launch()`/`reconfigureVisibleAgents()`. `buildPrompt(slug)` becomes a one-liner: `return l.prompt.Build(slug)`.
+
+**Why first:** zero side effects, zero goroutines, zero broker writes. It's a 300-line `strings.Builder`. The only reason it's at 49% coverage is that nobody wrote table tests against it. Trivial to test by snapshot; trivial to ship.
+
+---
+
+### C2 — `office_targets.go` (new type `officeTargeter`)
+**Funcs moved:** `agentPaneSlugs`, `officeAgentOrder`, `visibleOfficeMembers`, `overflowOfficeMembers`, `paneEligibleOfficeMembers`, `overflowWindowName`, `resolvePaneTargetForSlug`, `agentPaneTargets`, `agentNotificationTargets`, `shouldUseHeadlessDispatchForSlug`, `shouldUseHeadlessDispatchForTarget`, `skipPaneForSlug`, `isChannelDM`, `officeMembersSnapshot`, `officeMemberBySlug`, `officeLeadSlug`, `officeLeadSlugFrom`, `activeSessionMembers`, `getAgentName`. Plus the runtime predicates that drive headless routing: `memberEffectiveProviderKind`, `memberUsesHeadlessOneShotRuntime`, `normalizeProviderKind`, `usesPaneRuntime`, `requiresClaudeSessionReset`.
+
+**New surface:**
+```go
+type officeTargeter struct {
+    sessionName       string
+    paneBackedAgents  *bool                  // pointer back to launcher field
+    failedPaneSlugs   map[string]string      // shared map; targeter reads, dispatcher writes
+    broker            brokerSnapshotter      // narrow interface, see §3
+    isOneOnOne        func() bool
+    oneOnOneAgent     func() string
+    provider          func() string          // l.provider as a getter
+}
+func (o *officeTargeter) PaneTargets() map[string]notificationTarget
+func (o *officeTargeter) NotificationTargets() map[string]notificationTarget
+func (o *officeTargeter) LeadSlug() string
+func (o *officeTargeter) MemberBySlug(slug string) officeMember
+func (o *officeTargeter) ShouldUseHeadlessFor(slug string) bool
+```
+
+**Launcher keeps:** field `targets *officeTargeter`. Every `l.officeLeadSlug()` etc. becomes `l.targets.LeadSlug()`.
+
+**Why second:** pure data-shape logic over `Broker.OfficeMembers()`/`SessionModeState()`. No goroutines, no tmux, no processes. The two side-effects in this cluster (`failedPaneSlugs` mutation, `paneBackedAgents` mutation) move with their writers — `failedPaneSlugs` is written by `recordPaneSpawnFailure` in cluster C5; `paneBackedAgents` is written by `trySpawnWebAgentPanes` in C5. The targeter is read-only over both.
+
+---
+
+### C3 — `notification_context.go` (new type `notificationContextBuilder`)
+**Funcs moved:** `buildNotificationContext`, `ultimateThreadRoot`, `threadMessageIDs`, `buildTaskNotificationContext`, `relevantTaskForTarget`, `responseInstructionForTarget`, `buildMessageWorkPacket`, `buildTaskExecutionPacket`, `extractTaskFileTargets`, `truncate`. Plus `taskNotificationContent` and `humanizeNotificationType`.
+
+**New surface:**
+```go
+type notificationContextBuilder struct {
+    broker          brokerSnapshotter        // ChannelMessages, ChannelTasks, AllTasks, EnabledMembers
+    targeter        *officeTargeter          // for LeadSlug, MemberBySlug, isChannelDM
+    isOneOnOne      func() bool
+}
+func (b *notificationContextBuilder) MessageWorkPacket(msg channelMessage, slug string) string
+func (b *notificationContextBuilder) TaskExecutionPacket(slug string, action officeActionLog, task teamTask, content string) string
+func (b *notificationContextBuilder) TaskNotificationContent(action officeActionLog, task teamTask) string
+```
+
+**Launcher keeps:** field `notify *notificationContextBuilder`. `sendChannelUpdate` and `sendTaskUpdate` (which stay on the launcher because they decide pane vs headless dispatch) call into it.
+
+**Why third:** large surface of pure-string logic operating on broker reads. Read-only, deterministic, and exactly the cluster where coverage will jump the most. The 0%-coverage entries here are 0% only because tests can't easily set up a `Broker` with the needed message graph — extracting against a `brokerSnapshotter` interface lets us inject a stub map of messages and tasks and exercise threading edge cases (missing root, cycles, deep reply chains, blocked tasks, review-state lead summaries) without spinning up a real Broker.
+
+---
+
+### C4 — `scheduler.go` (new type `watchdogScheduler`)
+**Funcs moved:** `watchdogSchedulerLoop`, `processDueSchedulerJobs`, `processDueTaskJob`, `processDueRequestJob`, `processDueWorkflowJob`, `nextWorkflowRun`, `recordWatchdogLedger`, `updateSchedulerJob`. Plus `shouldBackfillTaskOwner` (already a free func).
+
+**New surface:**
+```go
+type watchdogScheduler struct {
+    broker        schedulerBroker      // narrow: DueSchedulerJobs, FindTask/Request, ResumeTask,
+                                        //         CreateWatchdogAlert, RecordSignals, RecordAction, etc.
+    targeter      *officeTargeter
+    notify        *notificationContextBuilder
+    deliverTask   func(officeActionLog, teamTask)   // back-edge to launcher.deliverTaskNotification
+    clock         clock                              // see §3
+    pollEvery     time.Duration                      // formerly hardcoded 20s
+    initialDelay  time.Duration                      // formerly hardcoded 15s
+    stopCh        chan struct{}
+    done          sync.WaitGroup
+    onTickDone    chan struct{}                      // closed-and-replaced per tick; nil in prod
+}
+func (w *watchdogScheduler) Start(ctx context.Context)
+func (w *watchdogScheduler) Stop()
+func (w *watchdogScheduler) processOnce()
+```
+
+**Launcher keeps:** field `scheduler *watchdogScheduler`. `Launch()` constructs and `Start()`s it; `Kill()` calls `Stop()`. The `go l.watchdogSchedulerLoop()` line goes away.
+
+**Why fourth (mid-risk):** spawns a goroutine, but the work it does each tick is a deterministic batch. Easy to test by calling `processOnce()` directly without ever calling `Start()`, plus the loop itself can be tested with the manual clock + `onTickDone` signal (see §3). This is the highest-value mid-risk cluster — the four `processDue*Job` paths are currently 0%-covered and are exactly where silent scheduler bugs live (the `task.Blocked` rate-limit retry path on line 1542 is one I'd flag for a regression test on the way out).
+
+---
+
+### C5 — `pane_lifecycle.go` (new type `paneLifecycle`)
+**Funcs moved:** `spawnVisibleAgents`, `spawnOverflowAgents`, `detectDeadPanesAfterSpawn`, `recordPaneSpawnFailure`, `trySpawnWebAgentPanes`, `paneFallbackMessages`, `reportPaneFallback`, `listTeamPanes`, `clearAgentPanes`, `clearOverflowAgentWindows`, `parseAgentPaneIndices`, `shouldPrimeClaudePane`, `primeVisibleAgents`, `watchChannelPaneLoop`, `channelPaneStatus`, `channelPaneNeedsRespawn`, `isNoSessionError`, `captureDeadChannelPane`, `channelStderrLogPath`, `channelPaneSnapshotPath`, `capturePaneTargetContent`, `capturePaneContent`, `respawnPanesAfterReseed`, `HasLiveTmuxSession`, `isMissingTmuxSession`, `reconfigureVisibleAgents`. Helper: `shellQuote`.
+
+**New surface:**
+```go
+type paneLifecycle struct {
+    sessionName     string
+    socket          string
+    cwd             string
+    runner          tmuxRunner       // interface wrapping exec.CommandContext("tmux", ...)
+    targeter        *officeTargeter
+    promptBuilder   *promptBuilder
+    notifyOverride  *atomic.Pointer[launcherSendNotificationToPaneFn]  // existing seam, reused
+    failedPaneSlugs map[string]string                                   // owned here, read by targeter
+    paneBackedFlag  *bool                                               // back-pointer to launcher field
+    onPaneSpawn     func()                                              // signal hook for tests; nil in prod
+}
+```
+
+**Launcher keeps:** field `panes *paneLifecycle`. `Launch()` calls `panes.SpawnVisibleAgents()` only if `usesPaneRuntime()`.
+
+**Why fifth (high-risk):** every method here either shells out to `tmux` or writes to the filesystem. The cluster is internally cohesive but we can't fake `tmux` from the outside without a runner interface. Wrap it; that's the only way to test pane spawn fallback without a real terminal session. Order matters: it must come **after** the targeter cluster (C2) lands, because `paneLifecycle` reads the targeter to decide which slugs to spawn.
+
+---
+
+### C6 — `pane_dispatch.go` (new type `paneDispatcher`)
+**Funcs moved:** `queuePaneNotification`, `runPaneDispatchQueue`, `launcherSendNotificationToPane`, `sendNotificationToPane`. Plus the package-level `paneDispatchMinGap`, `paneDispatchCoalesceWindow` vars (move alongside but keep package-level so test helpers can swap them in process; see §3 for the alternative).
+
+**New surface:**
+```go
+type paneDispatcher struct {
+    runner       tmuxRunner       // shared with paneLifecycle
+    sendOverride *atomic.Pointer[launcherSendNotificationToPaneFn]  // existing seam
+    clock        clock
+    minGap       time.Duration
+    coalesce     time.Duration
+
+    mu           sync.Mutex
+    queues       map[string][]paneDispatchTurn
+    workers      map[string]bool
+    lastSentAt   map[string]time.Time
+
+    workerWg     sync.WaitGroup     // new: lets tests await all workers without Sleep
+    onSent       chan struct{}      // optional signal: closed-and-replaced per send; nil in prod
+}
+func (p *paneDispatcher) Enqueue(slug, paneTarget, notification string)
+func (p *paneDispatcher) Stop()                  // closes a stop channel + WaitGroup drain
+```
+
+**Launcher keeps:** field `paneDispatch *paneDispatcher`. `paneDispatchMu`/`paneDispatchQueues`/`paneDispatchWorkers`/`paneDispatchLastSentAt` come off the Launcher struct.
+
+**Why sixth (high-risk):** spawns a goroutine *per slug*, has subtle coalesce semantics, and is the place where the 60s/3s timing gates live. It's where the user has historically lost messages from concurrency bugs. We need the `WaitGroup` and the `Stop()` to make it deterministically testable. Existing `pane_dispatch_queue_test.go` is good — it uses the override and works without sleeps, so the public surface is already test-shaped, we're just giving it an owner type instead of leaving the maps on the launcher.
+
+---
+
+### C7 — `headless_workers.go` (extracted methods, type `headlessWorkerPool`)
+**Funcs moved:** Everything currently namespaced under `headless_codex.go` already lives outside `launcher.go` for the queue logic itself. What moves *out of launcher.go* is the spawn/teardown the launcher owns: `headlessMu`/`headlessCtx`/`headlessCancel`/`headlessWorkers`/`headlessActive`/`headlessQueues`/`headlessDeferredLead`/`headlessStopCh`/`headlessWorkerWg` plus the spawn helper currently called from `Launch()`. Keep the existing `headless_codex.go` file structure; just move the launcher-side fields into a `headlessWorkerPool` type and add an interface seam for `enqueueHeadlessCodexTurn`.
+
+**New surface:**
+```go
+type headlessWorkerPool struct {
+    mu         sync.Mutex
+    ctx        context.Context
+    cancel     context.CancelFunc
+    workers    map[string]bool
+    active     map[string]*headlessCodexActiveTurn
+    queues     map[string][]headlessCodexTurn
+    deferred   *headlessCodexTurn
+    stopCh     chan struct{}
+    wg         sync.WaitGroup
+}
+```
+
+**Launcher keeps:** field `headless *headlessWorkerPool`. The package-internal call sites that already say `l.headlessQueues` etc. become `l.headless.queues` (still within the package; not exported). This is a mechanical move — the goal is to **stop the Launcher struct from owning a third sub-mutex**, not to redesign the worker semantics. Leave the goroutine-leak fix from PR #320 (per memory) untouched.
+
+**Why seventh (high-risk):** these fields are touched from `Launch()`, `Kill()`, the resume path, and `headless_codex.go`. Mechanical move with broad blast radius. Schedule it last among the goroutine clusters specifically because nothing else depends on the move — once the other clusters are extracted and their tests are green, this one is only at risk of regressing itself, not them.
+
+---
+
+### C8 — `bootstrap.go` (lifecycle stays on Launcher; this file just hosts what's left)
+After C1–C7, `launcher.go` keeps: `Launcher` struct + getters/setters, `NewLauncher`, `Preflight`, `Launch`, `Attach`, `Kill`, `ResetSession`, `ReconfigureSession`, the four notification-loop wiring funcs (`notifyAgentsLoop`, `notifyTaskActionsLoop`, `notifyOfficeChangesLoop`, `pollOneRelayEventsLoop`), and the small office-change delivery helpers (`deliverOfficeChangeNotification`, `officeChangeTaskNotifications`, `respawnPanesAfterReseed`, `safeDeliverMessage`, `recoverPanicTo`).
+
+Web-mode code (`PreflightWeb`, `LaunchWeb`, `maybeOfferNex`, `waitForWebReady`, `openBrowser`, `stdinIsTTY`) gets split into `launcher_web.go`. It's pure split-by-build-target hygiene; no new type. Cheap, do it as part of C1.
+
+Broker-side housekeeping (`killStaleBroker`, `ResetBrokerState`, `ClearPersistedBrokerState`, `officePIDFilePath`, `writeOfficePIDFile`, `clearOfficePIDFile`, `killPersistedOfficeProcess`, `resetBrokerState`, `brokerBaseURL`) moves to `broker_lifecycle.go`. No type — these are package funcs already. Free move; bundle with C5.
+
+End state: `launcher.go` is ~600–800 lines and is exactly the orchestration glue.
+
+---
+
+## 2. Cut order — justification
+
+| # | Cluster | Risk | Why this slot |
+|---|---|---|---|
+| C1 | `promptBuilder` | low | Pure func over data. No goroutines, no mutexes, no broker writes. Snapshot tests cover it. Ship as the proof-of-pattern PR. |
+| C2 | `officeTargeter` | low | Read-only over broker snapshot funcs. No goroutines. Reveals the smallest necessary `brokerSnapshotter` interface, which then unblocks C3 and C4. |
+| C3 | `notificationContextBuilder` | low-mid | Large but pure. Depends on C2's targeter. Coverage payoff is the highest of any cluster — every threading branch is testable with a stub. |
+| C4 | `watchdogScheduler` | mid | First goroutine extraction. Depends on C2 + C3. The scheduler interface is small (`processOnce`) so it ships with a real test that walks each `processDue*Job` branch via direct call, plus one loop test using the manual clock. |
+| C5 | `paneLifecycle` + broker housekeeping | high | Touches `tmux` and the filesystem; needs `tmuxRunner` interface. Must land **before** C6 because C6 borrows the same `tmuxRunner`. |
+| C6 | `paneDispatcher` | high | Per-slug goroutines + timing gates + the only message-loss path in the system. Lands after C5 so it can share the runner. The existing `pane_dispatch_queue_test.go` is the regression net. |
+| C7 | `headlessWorkerPool` | high | Pure mechanical struct move. Last because the blast radius hits `Launch()` and the resume path; we want every other cluster green and freezeable before we churn this one. |
+| C8 | residual `launcher.go` cleanup | trivial | What's left is glue and is the natural endpoint, not a separate PR. |
+
+Hard rule: **no two clusters in the same PR**. Each PR is independently revertible.
+
+---
+
+## 3. Test seams (higher-risk clusters)
+
+### Existing seam to reuse, not reinvent
+`launcherSendNotificationToPaneOverride atomic.Pointer[launcherSendNotificationToPaneFn]` (launcher.go:3142) plus the `setLauncherSendNotificationToPaneForTest` helper (test_support.go:184). It already works under `-race` and supports `t.Cleanup` nesting. Pattern:
+
+```go
+var fooOverride atomic.Pointer[fooFn]
+
+func setFooForTest(t *testing.T, fn fooFn) {
+    t.Helper()
+    prior := fooOverride.Load()
+    fooOverride.Store(&fn)
+    t.Cleanup(func() { fooOverride.Store(prior) })
+}
+```
+
+Use this exact shape for every new injection point. Don't introduce a context-injected DI container, don't add an interface field on `Launcher` that production must wire — both add ceremony.
+
+### `tmuxRunner` interface (C5, C6)
+```go
+type tmuxRunner interface {
+    Run(args ...string) error
+    Output(args ...string) ([]byte, error)
+    Combined(args ...string) ([]byte, error)
+}
+```
+Production `realTmuxRunner` shells out via `exec.CommandContext` with the existing `-L tmuxSocketName` prefix baked in. Test `fakeTmuxRunner` records every call into a slice; tests assert on the recorded `args` (exact `send-keys`/`new-window` calls) and inject canned outputs for `list-panes`/`capture-pane`. Wire it via the `atomic.Pointer` seam:
+
+```go
+var tmuxRunnerOverride atomic.Pointer[tmuxRunner]
+func newTmuxRunner() tmuxRunner {
+    if p := tmuxRunnerOverride.Load(); p != nil { return *p }
+    return realTmuxRunner{}
+}
+```
+
+### `clock` interface (C4, C6)
+```go
+type clock interface {
+    Now() time.Time
+    After(d time.Duration) <-chan time.Time
+    Sleep(d time.Duration)
+}
+```
+Production `realClock` delegates to `time`. Test `manualClock`:
+- `Now()` returns the stored time.
+- `Advance(d)` adds to the stored time **and** releases any sleepers whose deadline has now passed.
+- `Sleep(d)` blocks on a channel registered in a heap keyed by deadline.
+
+This kills the two `time.Sleep` calls inside `runPaneDispatchQueue` (lines 3095, 3104) and the `15s`/`20s` calls in `watchdogSchedulerLoop` (1500, 1503) for tests, while production behaviour is byte-identical.
+
+### Signal channels (the "deterministic signal" the user demands)
+Two patterns, both already idiomatic in this codebase:
+
+1. **WaitGroup drain.** `paneDispatcher.Stop()` closes a `stopCh` and `wg.Wait()`s. Tests wanting "queue is fully drained" call `Stop()`. Mirrors the headless worker pool's existing PR #320 pattern.
+
+2. **Per-event signal channel.** Add an unexported field `onSent chan struct{}` to `paneDispatcher`; production leaves it nil; tests set it via a `setOnSentForTest(t, ch)` helper. After each successful pane send, the dispatcher does `if c := p.onSent; c != nil { c <- struct{}{} }`. The test reads from `c` to know "exactly one notification has flushed", with no sleep. Same pattern works for `watchdogScheduler.onTickDone`.
+
+   **Important:** unbuffered. Buffered swallows the signal under back-to-back sends and reintroduces races. If a test wants to count, give it a `chan int` with `len(workers)` capacity and read N times.
+
+### Coverage of the time-window logic without real time
+Once the clock interface exists, the coalesce-window test becomes:
+```go
+clk := newManualClock()
+disp := newPaneDispatcher(... clk ...)
+sent := make(chan string, 4)
+setLauncherSendNotificationToPaneForTest(t, func(_ *Launcher, _, n string) { sent <- n })
+
+disp.Enqueue("eng", "tgt", "first")
+<-sent                                    // first send fires immediately
+disp.Enqueue("eng", "tgt", "second")     // arrives mid-window
+disp.Enqueue("eng", "tgt", "third")      // also mid-window — must coalesce
+clk.Advance(paneDispatchCoalesceWindow + time.Millisecond)
+got := <-sent
+require.Equal(t, "second\n\n---\n\nthird", got)
+```
+That's the exact regression we'd want a permanent test for, and it has zero `time.Sleep` calls.
+
+---
+
+## 4. Coverage gate — recommendation
+
+**Pick (b): per-file floor on extracted files (≥ 85%), launcher.go untracked during the migration.**
+
+Reasoning:
+- (a) per-package floor that ratchets up: the package is currently 62.9%. Extracting C1 (promptBuilder, ~300 lines, currently lightly tested) to 90% will move package coverage by maybe 1–2 points. A ratcheting threshold either has to ratchet by 0.5 points (annoying, easy to game) or it has to wait several PRs for a meaningful jump (defeats the point of per-PR enforcement).
+- (b) per-file floor: we know exactly which files are new (`prompt_builder.go`, `office_targets.go`, etc.). CI can run `go test -coverpkg=./internal/team -coverprofile=cov.out ./internal/team/...`, then a tiny script computes per-file coverage from the profile and fails if any new file is < 85%. Old `launcher.go` is exempt while it shrinks. **This is the only option that gates the new code without holding the new code hostage to old code's debt.** 85% (not 90%) so we don't waste cycles testing trivial getters.
+- (c) baseline file: works but doesn't enforce that *new* code is well-tested, only that nothing regresses. We want the opposite emphasis right now — push new files high, let launcher.go's number drift up naturally as funcs leave it.
+
+**Implementation:** add `scripts/check-file-coverage.sh` that takes `--min 85 --files internal/team/prompt_builder.go,internal/team/office_targets.go,...`. CI step runs after the existing `bash scripts/test-go.sh`. Add files to the list as PRs land. Six lines of `awk` over `go tool cover -func`.
+
+Once the migration finishes, swap to (a) at the package level set to whatever we hit (likely 78–82%), and retire the per-file script. Two-phase, not permanent ceremony.
+
+---
+
+## 5. Traps
+
+These are the things that will bite if you don't actively defend against them.
+
+1. **`failedPaneSlugs` is shared between targeter and pane-lifecycle.** `recordPaneSpawnFailure` writes it (in C5); `agentPaneTargets`/`skipPaneForSlug` read it (in C2). Currently it's an unsynchronised `map[string]string` — the only reason no race fires is that pane spawn is sequential during `Launch()`. **Fix:** make it `sync.Map` *or* move it onto the `paneLifecycle` type and have the targeter call `panes.IsFailed(slug)`. Don't leave it dangling on the Launcher struct, and don't share a bare map across two new types — that's the kind of split that *introduces* a race the original god-object accidentally avoided.
+
+2. **`paneBackedAgents bool` is the load-bearing flag for the entire dispatch decision.** It's flipped to `true` deep inside `trySpawnWebAgentPanes`; every targeter method short-circuits when it's false (launcher.go:1897). If you move the flag onto `paneLifecycle` but keep the targeter reading the old launcher field, every notification will route through the headless path silently. **Fix:** the targeter holds a `*bool` or, better, a `func() bool` getter that points at the lifecycle's field. Single source of truth.
+
+3. **`launcherSendNotificationToPaneOverride` is global, not per-Launcher.** It's a package-level `atomic.Pointer`. The pane-dispatch tests work because they're sequential and use `t.Cleanup`. If C6 is restructured so the dispatcher holds its own override pointer instead, the existing tests in `pane_dispatch_queue_test.go` and `resume_test.go` (line 706) break. **Fix:** keep the override package-global. The new `paneDispatcher` reads the same `atomic.Pointer` the existing free function reads. Don't move the seam; only move the work.
+
+4. **`NewLauncher` does I/O before returning.** It loads config, reads the manifest, may delete `defaultBrokerStatePath()`, and synthesises `loadRunningSessionMode`. The new sub-types should be constructed **lazily inside `Launch()`**, not in `NewLauncher`, because (a) `Preflight()` runs first and can fail before any sub-type is needed, and (b) tests construct `&Launcher{}` directly and rely on every sub-type being nil-safe. Pattern: `if l.targets == nil { l.targets = newOfficeTargeter(...) }` at the top of `Launch()` and at the top of any test-friendly entry point.
+
+5. **`paneDispatchMinGap` and `paneDispatchCoalesceWindow` are package vars, not consts, specifically so tests can swap them.** Don't promote them to fields on `paneDispatcher` without preserving a swap path — there are tests in the wild that mutate them (grep before moving). The cleanest answer is: keep them as package vars, but have the `paneDispatcher` constructor read them once into instance fields. Tests that want a different value either swap the package var before construction (existing pattern) or pass a configured dispatcher (new pattern). Both work.
+
+6. **`Launch()` has an implicit ordering invariant**: broker start → tmux session create → headless context create → goroutine fan-out. The goroutines (`notifyAgentsLoop`, `notifyTaskActionsLoop`, `notifyOfficeChangesLoop`, `pollNexNotificationsLoop`, `watchdogSchedulerLoop`) are started *unconditionally* at the bottom of `Launch()` except `notifyTaskActionsLoop` which gates on `!isOneOnOne()`. When the scheduler moves to its own type (C4), the `Start(ctx)` call MUST stay inside `Launch()`'s gated block — don't move it into `NewLauncher` or a constructor side effect. Same for the headless worker pool's `ctx, cancel = context.WithCancel(...)` — that line is what makes `Kill()`'s cancel actually cancel anything.
+
+7. **`primeVisibleAgents` and `respawnPanesAfterReseed` straddle C3 and C5.** They read message context (C3 territory) to decide what to type into a pane (C5 territory). Put them on `paneLifecycle` and have it depend on `notificationContextBuilder`, not the other way around. If you put them on the context builder, you're back to one type that knows about tmux.
+
+8. **`atomic.Pointer` overrides leak across parallel tests when keyed globally.** All the existing `*Override` vars are package-global. If anyone runs `t.Parallel()` on tests that set them, they corrupt each other. Today this is fine because the override-using tests don't `t.Parallel()`. If you add new overrides for C5/C6, **document that they must not be combined with `t.Parallel()`**, or build them as per-`*Launcher` fields from day one. Pick one and stick with it; mixing is the worst outcome.
+
+9. **`extractTaskFileTargets` (line 2132) is invoked from broker code paths outside this file.** Confirm with `grep -rn extractTaskFileTargets internal/team` before yanking it from launcher.go. If it has external callers in the package, leave it free-function in a `text_helpers.go` file rather than absorbing it into the context builder type.
+
+10. **Coverage profile aggregation across files:** when you split launcher.go, `go tool cover` will report each new file separately, but funcs that *moved* keep their old function names. Don't be surprised if `launcher.go`'s reported coverage *drops* between extractions — the tested funcs leave for the new file, the untested ones stay behind. That's the desired transient state, not a regression. The per-file gate in §4 makes this visible without flagging it as a failure.
+
+---
+
+## What I'm explicitly not proposing
+
+- **No new public packages.** Every type stays unexported in `internal/team`. The package surface (what `cmd/wuphf` imports) does not change.
+- **No interface for `*Broker`.** I named `brokerSnapshotter` and `schedulerBroker` above as **narrow consumer-side interfaces** declared on the consumer side (Go convention). The `*Broker` type itself stays concrete and unchanged. This avoids a 50-method interface that nobody needs.
+- **No rename of `Launcher`.** It stays the orchestrator. We're slimming it, not retiring it.
+- **No compatibility shims.** `l.officeLeadSlug()` becomes `l.targets.LeadSlug()` everywhere in the package. No deprecation period. The package is internal — there are no external callers to break.
+
+---
+
+## Definition of done for the whole migration
+
+- `launcher.go` is < 1000 lines.
+- Every new file has its own `_test.go` with > 85% coverage measured per-file.
+- Package coverage for `internal/team` is ≥ 75% (up from 62.9%).
+- `go test -race ./internal/team/... -count=10` is green (the `-count=10` is the cheap insurance against the per-slug goroutine races C6 reshapes).
+- Zero `time.Sleep` calls in any test we wrote during the migration.
+- `Launcher` struct has at most one mutex on it (the rest moved into sub-types).

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -2920,10 +2920,6 @@ func (l *Launcher) buildTaskExecutionPacket(slug string, action officeActionLog,
 	return strings.Join(lines, "\n")
 }
 
-func headlessSandboxNote() string {
-	return "Runtime: this office is already running. Never launch another `wuphf`, copied `wuphf` binary, `/reset`, browser instance, or local server/`--web-port` process from inside your turn. For `execution_mode=local_worktree`, make edits directly in the assigned working_directory instead of re-auditing or trying to boot a second office. Never search parent or sibling temp directories (`find ..`, `rg ..`, `/var/folders`, `TMPDIR`, `TemporaryItems`) from a task worktree; stay inside the assigned working_directory. If shell commands fail with 'operation not permitted' or 'permission denied' (go build cache, localhost bind, sandboxed writes), stop retrying them and continue from code inspection or the existing running office.\n\n"
-}
-
 func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessage) {
 	channel := normalizeChannelSlug(msg.Channel)
 	if channel == "" {
@@ -3737,303 +3733,41 @@ func (l *Launcher) reportPaneFallback(tmuxInstalled bool, summary string, err er
 	}
 }
 
-func markdownKnowledgeToolBlock() string {
-	return "- notebook_write: Save your own working notes, rough observations, draft decisions, draft playbooks, and task learnings at agents/{my_slug}/notebook/{date-or-topic}.md. This is the default write path for agent-authored knowledge.\n" +
-		"- notebook_promote: Submit a durable notebook entry for reviewer approval into the team wiki. Use this when the team should rely on the note as canonical knowledge.\n" +
-		"- notebook_read / notebook_list / notebook_search: Inspect agent notebooks for fresh working context before asking someone to repeat themselves.\n" +
-		"- team_wiki_read / team_wiki_search / team_wiki_list / wuphf_wiki_lookup: Read the canonical shared wiki.\n" +
-		"- team_wiki_write: Direct canonical wiki writes only for already-approved edits, bootstrap/admin maintenance, or explicit human requests. Do not bypass notebook_promote for new agent-authored knowledge.\n"
-}
-
-func markdownKnowledgeMemoryBlock() string {
-	return "Markdown notebook/wiki memory is active. Keep scratch and draft knowledge in notebook_write first; promote durable conclusions with notebook_promote when they are ready for review. Do not claim something is in the team wiki unless notebook_promote was submitted and approved, or team_wiki_write was explicitly appropriate and succeeded.\n\n"
-}
-
-// buildPrompt generates the system prompt for an agent, including
-// channel communication instructions.
+// buildPrompt generates the system prompt for an agent. The body lives on
+// promptBuilder (see prompt_builder.go) so it can be tested without a
+// Launcher; this wrapper assembles the snapshot accessors from launcher
+// state and delegates.
 func (l *Launcher) buildPrompt(slug string) string {
-	member := l.officeMemberBySlug(slug)
-	agentCfg := agentConfigFromMember(member)
-	officeMembers := l.officeMembersSnapshot()
-	// Sort by Slug so the prompt prefix is byte-identical across spawns for the
-	// same office; otherwise prompt caching (ANTHROPIC_PROMPT_CACHING=1) would
-	// miss on every turn just because member insertion order drifted.
-	sort.Slice(officeMembers, func(i, j int) bool { return officeMembers[i].Slug < officeMembers[j].Slug })
-	lead := officeLeadSlugFrom(officeMembers)
-	memoryBackendKind := config.ResolveMemoryBackend("")
-	markdownMemory := memoryBackendKind == config.MemoryBackendMarkdown
+	return l.newPromptBuilder().Build(slug)
+}
+
+// newPromptBuilder captures the launcher state the prompt depends on into
+// a promptBuilder. Built fresh per call so each prompt sees the current
+// member roster and active policies; the construction itself is cheap
+// (closures + a couple of map lookups).
+func (l *Launcher) newPromptBuilder() *promptBuilder {
+	memoryBackend := config.ResolveMemoryBackend("")
 	noNex := config.ResolveNoNex() || config.ResolveAPIKey("") == ""
-	var activePolicies []officePolicy
-	if l.broker != nil {
-		activePolicies = l.broker.ListPolicies()
-		// Same reason as officeMembers: sort so the policies section is
-		// deterministic and cache-friendly across turns.
-		sort.Slice(activePolicies, func(i, j int) bool { return activePolicies[i].ID < activePolicies[j].ID })
+	return &promptBuilder{
+		isOneOnOne:  l.isOneOnOne,
+		isFocusMode: l.isFocusModeEnabled,
+		packName:    l.PackName,
+		leadSlug:    l.officeLeadSlug,
+		members:     l.officeMembersSnapshot,
+		policies: func() []officePolicy {
+			if l == nil || l.broker == nil {
+				return nil
+			}
+			policies := l.broker.ListPolicies()
+			// Sort so the policies section is deterministic and
+			// cache-friendly across turns.
+			sort.Slice(policies, func(i, j int) bool { return policies[i].ID < policies[j].ID })
+			return policies
+		},
+		nameFor:        l.getAgentName,
+		markdownMemory: memoryBackend == config.MemoryBackendMarkdown,
+		nexDisabled:    noNex,
 	}
-
-	var sb strings.Builder
-
-	companyCtx := config.CompanyContextBlock()
-
-	if l.isOneOnOne() {
-		sb.WriteString(fmt.Sprintf("You are %s in a direct one-on-one WUPHF session with the human.\n\n", agentCfg.Name))
-		sb.WriteString(companyCtx)
-		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
-		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
-		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
-		sb.WriteString("== DIRECT SESSION ==\n")
-		sb.WriteString("This is not the shared office. There are no teammates, no channels, and no collaboration mechanics in this mode.\n")
-		sb.WriteString("You are only talking to the human.\n")
-		sb.WriteString("- team_poll: LAST RESORT — read recent 1:1 messages only if the pushed notification is missing context you genuinely need. Do NOT call this by default.\n")
-		sb.WriteString("- team_broadcast: Send a normal direct chat reply into the 1:1 conversation\n")
-		sb.WriteString("- human_message: Send an emphasized report, recommendation, or action card directly to the human when you want it to stand out\n")
-		sb.WriteString("- human_interview: Ask the human a cancelable interview question; it never blocks chat, and dismiss/send cancels it\n\n")
-		if noNex {
-			sb.WriteString("Nex tools are disabled for this run. Base your work on the conversation and direct human answers only.\n\n")
-		} else {
-			sb.WriteString("Use the Nex context graph when it materially helps:\n")
-			sb.WriteString("- query_context: Look up prior decisions, people, projects, and history before guessing\n")
-			sb.WriteString("- add_context: Store durable conclusions only after you have actually landed them\n\n")
-		}
-		sb.WriteString("RULES:\n")
-		sb.WriteString("1. Do not talk as if a team exists. There are no other agents in this session.\n")
-		sb.WriteString("2. Do not create or suggest channels, teammates, bridges, shared tasks, or office structure.\n")
-		sb.WriteString("3. Default to direct, useful conversation with the human. Keep it crisp and human.\n")
-		sb.WriteString("4. The pushed notification IS the latest state. Respond directly from it. Do NOT poll before replying.\n")
-		sb.WriteString("5. Use team_broadcast for normal replies. Use human_message only when you are deliberately presenting completion, a recommendation, or a next action.\n")
-		sb.WriteString("6. Use human_interview only for cancelable clarifications you can proceed without. If a decision must block your work, ask the human directly via human_message and wait for the answer.\n")
-		sb.WriteString("7. If Nex is enabled, do not claim something is stored unless add_context actually succeeded.\n")
-		sb.WriteString("8. No fake collaboration language like 'I'll ask the team' or 'let me route this'. It is just you and the human here.\n\n")
-		sb.WriteString("CONVERSATION STYLE:\n")
-		sb.WriteString("- Sound like a sharp human operator, not a formal assistant.\n")
-		sb.WriteString("- Be concise, direct, and a little alive.\n")
-		sb.WriteString("- Light humor is fine. Don't turn the 1:1 into a bit.\n")
-		sb.WriteString("- If the human asks for a plan, recommendation, explanation, or judgment you can reasonably give now, answer now.\n")
-		sb.WriteString("- Do not go silent and over-research by default. Only inspect files, run tools, or query Nex first when the answer genuinely depends on that context.\n")
-		sb.WriteString("- If you need a deeper pass, give the human the quick answer first, then continue with the deeper work.\n")
-		return sb.String()
-	}
-
-	if slug == lead {
-		sb.WriteString(fmt.Sprintf("You are the %s of the %s.\n\n", agentCfg.Name, l.PackName()))
-		sb.WriteString(companyCtx)
-		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
-		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
-		sb.WriteString("== YOUR TEAM ==\n")
-		for _, member := range officeMembers {
-			if member.Slug == slug {
-				continue
-			}
-			sb.WriteString(fmt.Sprintf("- @%s (%s): %s\n", member.Slug, member.Name, strings.Join(member.Expertise, ", ")))
-		}
-		sb.WriteString("\n== TEAM CHANNEL ==\n")
-		sb.WriteString("Your tools default to the active conversation context.\n")
-		sb.WriteString("- team_broadcast: Post to channel. CRITICAL: text @-mentions alone do NOT wake agents — include the slug in the `tagged` parameter.\n")
-		sb.WriteString("- team_poll: LAST RESORT — read recent messages only when pushed context is genuinely missing something you need. Do NOT call this by default; the pushed notification already contains thread context, task state, and active agents.\n")
-		sb.WriteString("- team_bridge: Carry context from one channel into another (CEO only).\n")
-		sb.WriteString("- team_task: Create and assign tasks so ownership is explicit.\n")
-		sb.WriteString("- team_skill_run: Invoke a saved skill by name when the request matches one. Use this BEFORE routing or replying — it returns the canonical playbook content to follow and logs a visible skill_invocation in the channel.\n")
-		sb.WriteString("- team_skill_create: Create or propose a reusable skill through structured fields. Use action=create only as CEO when the human explicitly asked to create/activate a skill; use action=propose for proposed improvements from any agent.\n")
-		sb.WriteString("- team_action_connections / team_action_search / team_action_knowledge: inspect connected external systems and the exact action/workflow schema before you improvise. If connection listing is flaky, do NOT stop there; search/knowledge still give you the real action contract.\n")
-		sb.WriteString("- team_action_execute / team_action_workflow_execute: use these for real external reads, writes, and workflow runs. Prefer dry_run only when the task or policy says preview/mock first. When the provider is One and there is exactly one connected account for that platform, you may omit connection_key and let the runtime auto-resolve it.\n")
-		if markdownMemory {
-			sb.WriteString(markdownKnowledgeToolBlock())
-		}
-		sb.WriteString("- human_message: Present output or a recommendation directly to the human.\n")
-		sb.WriteString("- human_interview: Ask the human a cancelable interview question; it never blocks chat, and dismiss/send cancels it.\n")
-		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member, team_action_guide, team_action_workflow_create, team_action_workflow_schedule, team_action_relays, team_action_relay_event_types, team_action_relay_create, team_action_relay_activate, team_action_relay_events, team_action_relay_event.\n\n")
-		sb.WriteString("== TOOL HYGIENE ==\n")
-		sb.WriteString("All team_*, human_*, and mcp__wuphf-office__* tools listed above are ALREADY registered. Call them directly. Do NOT use ToolSearch/select: to look them up — that wastes a full turn.\n")
-		sb.WriteString("Do not read unrelated files (MEMORY.md, arbitrary docs) unless the current packet's task requires it. Every tool call pays full turn cost.\n")
-		sb.WriteString("Emit at most one team_broadcast per turn unless you are deliberately crossing channels. Never re-post the same content in different wording.\n\n")
-		if markdownMemory {
-			sb.WriteString(markdownKnowledgeMemoryBlock())
-		} else if noNex {
-			sb.WriteString("Nex tools are disabled for this run. Work only with the shared office channel and human answers.\n\n")
-		} else {
-			sb.WriteString("Nex memory: query_context before reinventing; add_context only after a decision is actually landed.\n\n")
-		}
-		if len(activePolicies) > 0 {
-			sb.WriteString("== ACTIVE OFFICE POLICIES ==\n")
-			sb.WriteString("Treat these as hard operating constraints, not suggestions. If a policy conflicts with an older chat assumption, the active policy wins until the human changes it.\n")
-			for _, policy := range activePolicies {
-				sb.WriteString(fmt.Sprintf("- %s\n", policy.Rule))
-			}
-			sb.WriteString("\n")
-		}
-		sb.WriteString("Tagged agents are expected to respond.\n\n")
-		if l.isFocusModeEnabled() {
-			sb.WriteString("== DELEGATION MODE ==\n")
-			sb.WriteString("You are the routing hub. Specialists only act when you or the human explicitly @tag them.\n")
-			sb.WriteString("- Route and hold: dispatch work to the right specialist and WAIT. Never do their work while they are working.\n")
-			sb.WriteString("- Don't re-trigger: a [STATUS] or any reply from a specialist means they are working. When they finish, only respond if coordination is still needed — if the task is done and the human already has what they need, stay quiet.\n")
-			sb.WriteString("- Specialists report up, not sideways: keep them out of cross-agent chatter. Coordinate through you.\n")
-			sb.WriteString("- After you delegate, ask a blocking question, or post the current synthesis, END THE TURN. Do not stay active waiting for teammates; a new pushed notification will wake you when something changes.\n\n")
-		}
-		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
-		sb.WriteString("YOUR ROLE AS LEADER:\n")
-		if markdownMemory {
-			sb.WriteString("1. On strategy or prior decisions, use wuphf_wiki_lookup or notebook_search before guessing\n")
-		} else if noNex {
-			sb.WriteString("1. Coordinate inside the office channel first and keep the team aligned there\n")
-		} else {
-			sb.WriteString("1. On strategy or prior decisions, call query_context early\n")
-		}
-		sb.WriteString("2. The pushed notification is authoritative — it contains thread context, task state, and agent activity. Respond directly from it. Do NOT call team_poll or team_tasks unless the notification explicitly says context is missing. Every unnecessary tool call burns tokens without adding value.\n")
-		sb.WriteString("3. When routing a simple human @tagged request that should resolve in one reply, tag the specialist in your message and do NOT also create a team_task for the same work. For any multi-step build, cross-functional initiative, or work likely to need another round, you MUST create explicit team_task records for each owned lane before you send the kickoff so specialists wake up from durable task state. When those task records already exist, do NOT also tag the same specialists in the kickoff unless you need extra commentary outside the owned task.\n")
-		sb.WriteString("4. Tag only the specialists who should weigh in. Unowned background chatter is a bug.\n")
-		sb.WriteString("5. Keep specialists in their lane and mostly offstage. You make the FINAL decision.\n")
-		sb.WriteString("6. Check team_requests before asking the human anything new\n")
-		sb.WriteString("7. Use human_message for direct human-facing output, human_interview for cancelable clarifications, and team_request for blocking decisions\n")
-		if markdownMemory {
-			sb.WriteString("8. When you lock a durable decision, write it to your notebook first and submit notebook_promote if it should become canonical wiki knowledge\n")
-		} else if noNex {
-			sb.WriteString("8. Summarize final decisions clearly in-channel\n")
-		} else {
-			sb.WriteString("8. When you lock a decision, call add_context before claiming it is stored\n")
-		}
-		sb.WriteString("9. Once decided, create durable task state first, then broadcast the kickoff and assignments. If you already know multiple owned lanes, prefer one team_plan call over several separate team_task creates. Every created task should set `task_type` and `execution_mode` deliberately instead of relying on inference.\n")
-		sb.WriteString("10. Choose task_type deliberately. Use `research` for audits/analysis, `launch` for GTM/rollout packages, `follow_up` for scoped office deliverables, and `feature` only for real implementation work. Do NOT label planning or audit work as `feature` just because it matters.\n")
-		sb.WriteString("11. If the human asks to build, ship, get something working, or run it end to end, your task graph MUST include at least one real execution lane that changes the repo or produces runnable business artifacts. A graph made only of planning, design, recommendations, or implementation-sequence tasks is a failure.\n")
-		sb.WriteString("12. Do not create engineering tasks whose only deliverable is another plan (`propose the implementation sequence`, `design the architecture`, `outline the automation`) when the repo is available now. For build/ship/end-to-end requests, do NOT put a standalone `research`, `audit`, or `cut line` task in front of the first engineering `feature` task just to decide what to build. Any minimal repo inspection belongs inside that first feature task. Only create a prerequisite research task when the human explicitly asked for analysis first or the repo truly has no identifiable implementation target.\n")
-		sb.WriteString("12b. For build/ship/end-to-end requests, do NOT spend the whole first turn on `pwd`, `ls`, `rg --files`, `find .`, or a repo-wide file inventory. If the packet or thread already names relevant docs, configs, or lane files, start from those. After at most one or two targeted reads, create the first durable task/channel state in that same turn.\n")
-		sb.WriteString("13. For broad engineering goals, do NOT create a first feature task with a giant title like `ship the whole MVP`, `ship the first channel-factory MVP slice`, or any other umbrella task with no cut line. The first feature task must name one smallest runnable slice only. Do not bundle idea generation, script drafting, packaging, and monetization hooks into the same first task; pick one contiguous slice, let it land, then queue the next slice. If existing docs, configs, or launch packets already name a concrete slice, use them and create the implementation task directly instead of narrating `repo audit first, implementation next`.\n")
-		sb.WriteString("14. If you write any narrative like `next move`, `next step`, `operating order`, or `eng should` / `gtm should`, that same turn MUST also create the concrete owned task record(s) for that work before you stop. Narrative next steps without durable tasks are a failure.\n")
-		sb.WriteString("14b. On a human build/ship request, the first turn must leave durable office state behind: at minimum the kickoff plus the first owned task, and for cross-functional work usually the execution channel too. A whole turn spent only reading docs or thinking is a failure.\n")
-		sb.WriteString("15. When first-pass specialist outputs land and obvious downstream work remains, create the next owned task before you end the turn. Do not stop at synthesis if the build still has a clear next step.\n")
-		sb.WriteString("15b. Before you create a new task, inspect the Active tasks in the packet. If an open, in-progress, or review task already covers that lane, reuse or update that task instead of creating an overlapping duplicate with a fresh title.\n")
-		sb.WriteString("16. If a task lands in review but no human approval is actually needed, approve it or immediately translate it into the next task. Do not leave the company idle behind an internal review gate.\n")
-		sb.WriteString("16b. Before you write any sentence claiming a task is approved, closed, reopened, reassigned, or blocked, you MUST make the matching team_task or team_plan call first. Channel narration does not mutate durable task state. If the mutation fails, say it failed and do not claim success.\n")
-		sb.WriteString("16c. On a human build/ship/end-to-end request, after you approve or close any engineering/execution slice, if the system is not yet runnable end to end and no engineering/execution lane remains active, create the next engineering/execution task in that same turn before you stop. Do not replace the only live build lane with GTM-only packaging, eval prompts, scoring rubrics, or other sidecar work.\n")
-		sb.WriteString("16d. When a task or policy allows a low-risk external step on a connected system, prefer the smallest real external action now over more internal collateral. A Slack/Notion/Drive lane is not satisfied by repo markdown, preview notes, proof markers, or substitute proof artifacts unless the task explicitly says mock/preview/stub-only.\n")
-		sb.WriteString("16e. When the work is live, describe outputs as client deliverables, approvals, handoffs, updates, or records. Do not frame live business work as proof/test/eval artifacts unless the task explicitly asks for testing or evidence capture.\n")
-		sb.WriteString("16f. Capability-gap rule: if the work is blocked because the needed specialist, channel, skill, or tool path does not exist yet, treat that gap as the next real work item. Do not fall back to a review bundle, proof packet, artifact shell, or local substitute deliverable. Create the missing specialist with team_member first; if the work will span more than one turn, create the missing execution channel with team_channel; propose or update the missing skill block in the same turn; and if the blocker is a tool or provider gap, open a tool-discovery/research lane named for the exact tool you need so the office can discover, validate, and enable it. Example: if the work needs video generation and you do not already have a usable path, create a discovery lane for Remotion or the exact video tool before drafting any deliverable shell.\n")
-		sb.WriteString("16g. Task hygiene rule: if a live business lane gets named or reframed as a review packet, proof artifact, blueprint-derived scaffold, rubric, or other internal shell, rewrite that lane in the same turn. Replace it with either the next real deliverable/customer-facing/business-facing step or the exact capability-enablement task that unblocks that step.\n")
-		sb.WriteString("17. Create channels (team_channel) or agents (team_member) when the human asks or scope genuinely warrants it. For cross-functional initiatives that will run beyond one decision cycle, create a dedicated execution channel and keep #general for top-level decisions.\n")
-		sb.WriteString("17b. When the human explicitly asks to add or test integrations, generated skills, reusable workflows, or generated agents, you MUST leave durable state for that work in the same turn. Create the integration/onboarding task lane(s), propose or update the relevant skill block(s), and create any needed specialist agent(s) instead of only describing them narratively. If real accounts, credentials, spend, publishing, or other external side effects would be required, proceed with stubs/placeholders until the exact human approval is truly needed.\n")
-		sb.WriteString("18. Sequence structural changes safely: create a new specialist with team_member first, wait for success, then add them to channels or tag them. When creating a new channel, only include members that already exist.\n")
-		sb.WriteString("19. For `team_channel` create/remove calls, set `channel` to the explicit target slug like `youtube-factory`; it is not inferred from the current room.\n")
-		sb.WriteString("20. Use team_bridge to carry context between channels when relevant\n")
-		sb.WriteString("21. If a task shows a worktree path, that path is the working_directory for local file and bash tools on that task\n")
-		sb.WriteString("22. After you have posted the needed update, decision, delegation, or human question for the current packet, stop. Do not linger in the same turn waiting for teammates to answer.\n\n")
-		sb.WriteString("== SKILL & AGENT AWARENESS ==\n")
-		sb.WriteString("When a request matches an existing skill (by name, trigger, or tags), you MUST invoke it via team_skill_run(skill_name) BEFORE doing the work. That tool bumps usage, logs a skill_invocation in the channel, and returns the skill's canonical content — follow those steps exactly, don't freelance.\n")
-		sb.WriteString("When delegating to a specialist, tell them which skill to run (by slug) so they call team_skill_run before acting. Never paraphrase a skill's steps into a delegation message — the skill IS the spec.\n")
-		sb.WriteString("You can create or propose new skills when you notice a repeated workflow worth codifying. Use team_skill_create for this; do not rely on prose-only proposals.\n")
-		sb.WriteString("Rules:\n")
-		sb.WriteString("- Create when the human explicitly asked for reusable workflow automation; propose when you independently see a pattern repeated 2+ times by the team\n")
-		sb.WriteString("- If the human explicitly asked for generated skills or reusable workflows, call team_skill_create(action=create) in the same turn before you stop; narrative mentions alone are a failure\n")
-		sb.WriteString("- If a recurring workflow is central to the project's operation, propose it instead of re-explaining it every round\n")
-		sb.WriteString("- Keep instructions concrete and executable, not vague\n")
-		sb.WriteString("- Use team_skill_create(action=propose) for unsolicited workflow suggestions so the human is asked to approve before activation\n")
-		sb.WriteString("- To suggest adding a new specialist agent, use team_member with a clear expertise and rationale\n")
-		sb.WriteString("- When integrations matter, make the required systems explicit in the skill instructions and agent rationale so the team knows which connected accounts or placeholders each workflow expects\n")
-		sb.WriteString("- When you create a new specialist for integration/onboarding work, include the owned integrations directly in that agent's expertise so the roster clearly shows who owns Gmail, Slack, YouTube, Drive, analytics, or similar lanes\n\n")
-		sb.WriteString("STYLE: Be concise, delegate, short lively messages. Use markdown tables/checklists for structured data.\n")
-		if markdownMemory {
-			sb.WriteString("Do not pretend the team wiki was updated; verify notebook_promote or team_wiki_write succeeded before claiming canonical storage.\n")
-		} else if noNex {
-			sb.WriteString("Do not claim you stored anything outside the office.\n")
-		} else {
-			sb.WriteString("Do not pretend the graph was updated; verify add_context succeeded.\n")
-		}
-		sb.WriteString("Never launch another WUPHF office from inside your turn (`wuphf`, `./wuphf`, `/reset`, or a new browser instance). The office is already running; inspect the current repo and UI instead.\n")
-	} else {
-		sb.WriteString(fmt.Sprintf("You are %s on the %s.\n", agentCfg.Name, l.PackName()))
-		sb.WriteString(companyCtx)
-		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
-		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
-		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
-		sb.WriteString("== YOUR TEAM ==\n")
-		sb.WriteString(fmt.Sprintf("- @%s (%s): TEAM LEAD — has final say on decisions\n", lead, l.getAgentName(lead)))
-		for _, member := range officeMembers {
-			if member.Slug == slug || member.Slug == lead {
-				continue
-			}
-			sb.WriteString(fmt.Sprintf("- @%s (%s): %s\n", member.Slug, member.Name, strings.Join(member.Expertise, ", ")))
-		}
-		sb.WriteString("\n== TEAM CHANNEL ==\n")
-		sb.WriteString("Your tools default to the active conversation context.\n")
-		sb.WriteString("- team_broadcast: Post to channel. CRITICAL: text @-mentions alone do NOT wake agents — include the slug in the `tagged` parameter.\n")
-		sb.WriteString("- team_poll: LAST RESORT — read recent messages only when pushed context is genuinely missing something you need. Do NOT call this by default; the pushed notification already contains thread context and task state.\n")
-		sb.WriteString("- team_bridge: CEO-only bridge for cross-channel context. Ask the CEO to use it.\n")
-		sb.WriteString("- team_task: Claim, complete, block, resume, or release tasks in your domain.\n")
-		sb.WriteString("- team_skill_run: When @ceo tells you to run a skill, or when the request clearly matches one, call team_skill_run(skill_name) BEFORE doing the work. It returns the canonical step-by-step content — follow it exactly instead of freelancing. Failing to invoke the skill leaves the office with no trace that the playbook was actually used.\n")
-		sb.WriteString("- team_skill_create: Propose a reusable skill yourself with action=propose when you spot a repeatable workflow. You do not need to ask @ceo to propose it for you. Only @ceo may use action=create.\n")
-		sb.WriteString("- team_action_connections / team_action_search / team_action_knowledge: inspect connected external systems and the exact action/workflow schema before you improvise. If connection listing is flaky, do NOT stop there; search/knowledge still give you the real action contract.\n")
-		sb.WriteString("- team_action_execute / team_action_workflow_execute: use these for real external reads, writes, and workflow runs. Prefer dry_run only when the task or policy says preview/mock first. When the provider is One and there is exactly one connected account for that platform, you may omit connection_key and let the runtime auto-resolve it.\n")
-		if markdownMemory {
-			sb.WriteString(markdownKnowledgeToolBlock())
-		}
-		sb.WriteString("- human_message: Present completion or a recommendation directly to the human.\n")
-		sb.WriteString("- human_interview: Ask the human only for cancelable clarifications you cannot responsibly guess.\n")
-		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member, team_action_guide, team_action_workflow_create, team_action_workflow_schedule, team_action_relays, team_action_relay_event_types, team_action_relay_create, team_action_relay_activate, team_action_relay_events, team_action_relay_event.\n\n")
-		sb.WriteString("== TOOL HYGIENE ==\n")
-		sb.WriteString("All team_*, human_*, and mcp__wuphf-office__* tools listed above are ALREADY registered. Call them directly. Do NOT use ToolSearch/select: to look them up — that wastes a full turn.\n")
-		sb.WriteString("Do not read unrelated files (MEMORY.md, arbitrary docs) unless the current packet's task requires it. Every tool call pays full turn cost.\n")
-		sb.WriteString("Emit at most one team_broadcast per turn unless you are deliberately crossing channels. Never re-post the same content in different wording.\n\n")
-		if markdownMemory {
-			sb.WriteString(markdownKnowledgeMemoryBlock())
-		} else if noNex {
-			sb.WriteString("Nex tools are disabled for this run. Base your work on the office conversation and direct human answers only.\n\n")
-		} else {
-			sb.WriteString("Nex memory: query_context before making assumptions; add_context only for durable conclusions.\n\n")
-		}
-		if len(activePolicies) > 0 {
-			sb.WriteString("== ACTIVE OFFICE POLICIES ==\n")
-			sb.WriteString("Treat these as hard operating constraints, not suggestions. If a policy conflicts with an older chat assumption, the active policy wins until the human changes it.\n")
-			for _, policy := range activePolicies {
-				sb.WriteString(fmt.Sprintf("- %s\n", policy.Rule))
-			}
-			sb.WriteString("\n")
-		}
-		sb.WriteString("Tag agents with @slug. Tagged agents must respond.\n")
-		if l.isFocusModeEnabled() {
-			sb.WriteString("== DELEGATION MODE ==\n")
-			sb.WriteString("Delegation mode is enabled.\n")
-			sb.WriteString("- You take work directly from the human only when they explicitly tag you, or from @ceo when delegated.\n")
-			sb.WriteString("- Do not debate with other specialists in the channel.\n")
-			sb.WriteString("- Do the work, then report completion, blockers, or handoff notes back to @ceo.\n")
-			sb.WriteString("- If another specialist should get involved, tell @ceo instead of routing it yourself.\n")
-			sb.WriteString("- After you report completion, a blocker, or a handoff, END THE TURN. Do not keep researching or wait for acknowledgements in the same run.\n\n")
-		}
-		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
-		sb.WriteString("YOUR ROLE AS SPECIALIST:\n")
-		sb.WriteString("1. The pushed notification is authoritative — it contains thread context and task state. Respond directly from it. Do NOT call team_poll or team_tasks unless context is genuinely missing. Every unnecessary tool call burns tokens without adding value. Just do the work.\n")
-		sb.WriteString("2. Stay in your lane. Speak only when tagged, owning a task, blocked, or adding real delta that others haven't covered. Don't jump in just because a topic matches your domain.\n")
-		sb.WriteString("3. Push back when you disagree — explain why using your expertise\n")
-		sb.WriteString("4. Check team_requests before asking the human anything new\n")
-		sb.WriteString("5. For completion or recommendations, use human_message. For cancelable clarifications, use human_interview with options. For blocking human decisions, use team_request with kind `approval`, `confirm`, or `choice`.\n")
-		sb.WriteString("6. When assigned a task, claim it with team_task first, use team_status to show what you're working on, then mark complete or review-ready and broadcast when done. Final sequence for owned tasks: team_task mutation first, then any completion broadcast or human_message, then stop. A task is NOT finished until team_task marks it complete or review-ready; posting a channel reply alone does not unblock downstream work, and a completion post while the task stays in_progress is a failure. If the CEO delegates a substantial workstream and the packet shows no owned task yet, do one quick team_tasks check before creating a fallback task; if a matching task already exists, claim that instead of duplicating it. Only create a fallback task when the delegated work is substantial and no matching task exists after that single check. If the result is mainly for the human, also send it via human_message.\n")
-		sb.WriteString("7. You can see other channel names and descriptions, but cannot access their content unless you are a member. If context from another channel is needed, ask the CEO to bridge it.\n")
-		sb.WriteString("8. If a task or status line shows a worktree path, use that as working_directory for local file and bash tools.\n")
-		sb.WriteString("9. For local_worktree or feature tasks, default to direct implementation in the assigned worktree. Do not relaunch WUPHF, copied binaries, or a fresh local server just to inspect the app; use the current repo and running office instead.\n")
-		sb.WriteString("10. For local_worktree feature tasks, do NOT start with `rg --files`, `find .`, or a repo-wide audit. Read only the few files directly tied to the requested slice, then start editing. If the task is broad or lists multiple outputs, narrow it yourself to one exact smallest runnable slice, post a `team_status` naming that cut line, and ship that slice now.\n")
-		sb.WriteString("10b. Never search parent or sibling directories outside the assigned working_directory (`find ..`, `rg ..`, `/var/folders`, `TMPDIR`, `TemporaryItems`, or other task worktrees). If you need instructions, read `AGENTS.md` or `README.md` inside the assigned worktree only.\n")
-		sb.WriteString("11. Ignore unrelated modified or untracked files already present in the assigned worktree unless they are directly needed for your slice. They may be preexisting repo state; do not audit or re-explain them.\n")
-		sb.WriteString("11b. If a task names a connected external system and asks you to create, post, query, or run something there, do that live external step through the connected workflow/integration path. Repo docs, previews, local markdown, proof markers, or test artifacts do not count unless the task explicitly says mock/preview/stub-only.\n")
-		sb.WriteString("11c. When the work is live, phrase it as a client deliverable, approval, handoff, update, or record. Avoid proof/test/marker/eval language unless the task explicitly asks for testing or evidence capture.\n")
-		sb.WriteString("11d. When a task calls for Slack, Notion, Drive, or another connected system, use the `team_action_*` tools first. Do NOT probe localhost broker routes, curl the provider directly, or fall back to shell-side API experiments when the office action tools can do the job.\n")
-		sb.WriteString("11e. Capability-gap rule: if the work is blocked because the needed specialist, channel, skill, or tool path does not exist yet, treat that gap as the next real work item. Do not fall back to a review bundle, proof packet, artifact shell, or local substitute deliverable. Create the missing specialist with team_member first; if the work will span more than one turn, create the missing execution channel with team_channel; propose or update the missing skill block in the same turn; and if the blocker is a tool or provider gap, open a tool-discovery/research lane named for the exact tool you need so the office can discover, validate, and enable it. Example: if the work needs video generation and you do not already have a usable path, create a discovery lane for Remotion or the exact video tool before drafting any deliverable shell.\n")
-		sb.WriteString("11f. Task hygiene rule: if a live business lane gets named or reframed as a review packet, proof artifact, blueprint-derived scaffold, rubric, or other internal shell, rewrite that lane in the same turn. Replace it with either the next real deliverable/customer-facing/business-facing step or the exact capability-enablement task that unblocks that step.\n")
-		if codingAgentSlugs[slug] {
-			sb.WriteString("11g. When you commit to opening a pull request, actually open it. Run `gh pr create --title \"<short title>\" --body \"<body>\" --head \"<your-branch>\" --base main` via the bash tool. Paste the returned URL into your channel message so the team can click through. Do not claim a PR is open unless the bash output shows a https://github.com/... URL.\n")
-		}
-		if markdownMemory {
-			sb.WriteString("12. Use wuphf_wiki_lookup, team_wiki_search, or notebook_search when prior knowledge matters. Store your own durable working notes with notebook_write and submit notebook_promote when they should become canonical.\n")
-			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
-		} else if noNex {
-			sb.WriteString("12. Don't fake outside memory. Surface uncertainty in-channel and keep outcomes explicit in-thread.\n")
-			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
-		} else {
-			sb.WriteString("12. Use query_context when prior knowledge matters. Only use add_context for durable conclusions, and don't claim something stored unless add_context actually succeeded.\n")
-			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
-		}
-		sb.WriteString("STYLE: Be concise, stay in lane, short lively messages. Use markdown tables/checklists for structured data.\n")
-		sb.WriteString("Never launch another WUPHF office from inside your turn (`wuphf`, `./wuphf`, `/reset`, or a new browser instance). The office is already running; inspect the current repo and UI instead.\n")
-	}
-
-	return sb.String()
 }
 
 // claudeCommand builds the shell command string for spawning a claude session.
@@ -4319,41 +4053,6 @@ func (l *Launcher) agentActiveTask(slug string) *teamTask {
 		}
 	}
 	return nil
-}
-
-func teamVoiceForSlug(slug string) string {
-	switch slug {
-	case "ceo":
-		return "Charismatic, decisive, slightly theatrical founder energy. Dry humor, fast prioritization, invites debate but lands the plane."
-	case "pm":
-		return "Sharp product brain. Calm, organized, gently skeptical of vague ideas, sometimes deadpan funny when scope starts ballooning."
-	case "fe":
-		return "Craft-obsessed, opinionated about UX, animated when a flow feels elegant, mildly allergic to ugly edge cases."
-	case "be":
-		return "Systems-minded, practical, a little grumpy about complexity in a useful way, enjoys killing fragile ideas early."
-	case "ai":
-		return "Curious, pragmatic, and slightly mischievous about model behavior. Loves clever AI product ideas, but will immediately ask about evals, latency, and whether the thing will actually work."
-	case "designer":
-		return "Taste-driven, emotionally attuned to the product, expressive, occasionally dramatic about bad UX in a charming way."
-	case "cmo":
-		return "Energetic market storyteller. Punchy, a bit witty, always translating product ideas into positioning and narrative."
-	case "cro":
-		return "Blunt, commercial, confident. Likes concrete demand signals, calls out fluffy thinking, can be funny in a sales-floor way."
-	case "tech-lead":
-		return "Measured senior engineer energy. Crisp, lightly sardonic, respects good ideas and immediately spots architectural nonsense."
-	case "qa":
-		return "Calm breaker of bad assumptions. Dry humor, sees risks before others do, weirdly delighted by edge cases."
-	case "ae":
-		return "Polished but human closer. Reads people well, lightly playful, always steering toward deals and momentum."
-	case "sdr":
-		return "High-energy, persistent, upbeat, occasionally scrappy. Brings hustle without sounding robotic."
-	case "research":
-		return "Curious, analytical, a little nerdy in a good way. Likes receipts and will gently roast unsupported claims."
-	case "content":
-		return "Wordsmith with opinions. Smart, punchy, mildly dramatic about boring copy, always looking for the hook."
-	default:
-		return "A real teammate with a recognizable point of view, light humor, and emotional range."
-	}
 }
 
 func (l *Launcher) officeMembersSnapshot() []officeMember {

--- a/internal/team/prompt_builder.go
+++ b/internal/team/prompt_builder.go
@@ -1,0 +1,393 @@
+package team
+
+// prompt_builder.go owns the per-agent system-prompt construction that used
+// to live on Launcher.buildPrompt. The split was driven by PLAN.md §C1: the
+// prompt body is pure string assembly with no goroutines or I/O, so it
+// belongs in its own type with a narrow constructor that takes
+// snapshot-style accessors. Tests can drive it directly without a Launcher.
+//
+// The launcher still owns "compute these snapshot accessors at the moment
+// the prompt is needed" via Launcher.newPromptBuilder; this file owns the
+// "given those snapshots, write the prompt" half.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// promptBuilder assembles the per-agent system prompt. All Launcher / Broker
+// state is accessed through callbacks captured at construction time, so the
+// builder has no transitive dependency on tmux, the broker, or goroutine
+// state.
+type promptBuilder struct {
+	isOneOnOne  func() bool
+	isFocusMode func() bool
+	packName    func() string
+	leadSlug    func() string
+	members     func() []officeMember
+	policies    func() []officePolicy
+	nameFor     func(slug string) string
+
+	// Captured-at-construction config flags. They control major branches
+	// (markdown notebook section, no-Nex fallbacks) and are stable for the
+	// lifetime of a launcher session, so they're snapshot once rather than
+	// re-resolved on every Build call.
+	markdownMemory bool
+	nexDisabled    bool
+}
+
+// Build returns the system prompt for the agent identified by slug. The
+// output is byte-stable across calls when the captured snapshots return the
+// same data — required for prompt caching to actually hit.
+func (p *promptBuilder) Build(slug string) string {
+	memberSnapshot := p.members()
+	var member officeMember
+	found := false
+	for _, m := range memberSnapshot {
+		if m.Slug == slug {
+			member = m
+			found = true
+			break
+		}
+	}
+	if !found {
+		member = officeMember{Slug: slug, Name: slug, Role: slug}
+	}
+	agentCfg := agentConfigFromMember(member)
+
+	// Sort by Slug so the prompt prefix is byte-identical across spawns for
+	// the same office; otherwise prompt caching (ANTHROPIC_PROMPT_CACHING=1)
+	// would miss on every turn just because member insertion order drifted.
+	officeMembers := append([]officeMember(nil), memberSnapshot...)
+	sort.Slice(officeMembers, func(i, j int) bool { return officeMembers[i].Slug < officeMembers[j].Slug })
+
+	lead := p.leadSlug()
+	markdownMemory := p.markdownMemory
+	noNex := p.nexDisabled
+
+	activePolicies := p.policies()
+
+	var sb strings.Builder
+	companyCtx := config.CompanyContextBlock()
+
+	if p.isOneOnOne() {
+		sb.WriteString(fmt.Sprintf("You are %s in a direct one-on-one WUPHF session with the human.\n\n", agentCfg.Name))
+		sb.WriteString(companyCtx)
+		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
+		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
+		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
+		sb.WriteString("== DIRECT SESSION ==\n")
+		sb.WriteString("This is not the shared office. There are no teammates, no channels, and no collaboration mechanics in this mode.\n")
+		sb.WriteString("You are only talking to the human.\n")
+		sb.WriteString("- team_poll: LAST RESORT — read recent 1:1 messages only if the pushed notification is missing context you genuinely need. Do NOT call this by default.\n")
+		sb.WriteString("- team_broadcast: Send a normal direct chat reply into the 1:1 conversation\n")
+		sb.WriteString("- human_message: Send an emphasized report, recommendation, or action card directly to the human when you want it to stand out\n")
+		sb.WriteString("- human_interview: Ask the human a cancelable interview question; it never blocks chat, and dismiss/send cancels it\n\n")
+		if noNex {
+			sb.WriteString("Nex tools are disabled for this run. Base your work on the conversation and direct human answers only.\n\n")
+		} else {
+			sb.WriteString("Use the Nex context graph when it materially helps:\n")
+			sb.WriteString("- query_context: Look up prior decisions, people, projects, and history before guessing\n")
+			sb.WriteString("- add_context: Store durable conclusions only after you have actually landed them\n\n")
+		}
+		sb.WriteString("RULES:\n")
+		sb.WriteString("1. Do not talk as if a team exists. There are no other agents in this session.\n")
+		sb.WriteString("2. Do not create or suggest channels, teammates, bridges, shared tasks, or office structure.\n")
+		sb.WriteString("3. Default to direct, useful conversation with the human. Keep it crisp and human.\n")
+		sb.WriteString("4. The pushed notification IS the latest state. Respond directly from it. Do NOT poll before replying.\n")
+		sb.WriteString("5. Use team_broadcast for normal replies. Use human_message only when you are deliberately presenting completion, a recommendation, or a next action.\n")
+		sb.WriteString("6. Use human_interview only for cancelable clarifications you can proceed without. If a decision must block your work, ask the human directly via human_message and wait for the answer.\n")
+		sb.WriteString("7. If Nex is enabled, do not claim something is stored unless add_context actually succeeded.\n")
+		sb.WriteString("8. No fake collaboration language like 'I'll ask the team' or 'let me route this'. It is just you and the human here.\n\n")
+		sb.WriteString("CONVERSATION STYLE:\n")
+		sb.WriteString("- Sound like a sharp human operator, not a formal assistant.\n")
+		sb.WriteString("- Be concise, direct, and a little alive.\n")
+		sb.WriteString("- Light humor is fine. Don't turn the 1:1 into a bit.\n")
+		sb.WriteString("- If the human asks for a plan, recommendation, explanation, or judgment you can reasonably give now, answer now.\n")
+		sb.WriteString("- Do not go silent and over-research by default. Only inspect files, run tools, or query Nex first when the answer genuinely depends on that context.\n")
+		sb.WriteString("- If you need a deeper pass, give the human the quick answer first, then continue with the deeper work.\n")
+		return sb.String()
+	}
+
+	if slug == lead {
+		sb.WriteString(fmt.Sprintf("You are the %s of the %s.\n\n", agentCfg.Name, p.packName()))
+		sb.WriteString(companyCtx)
+		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
+		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
+		sb.WriteString("== YOUR TEAM ==\n")
+		for _, member := range officeMembers {
+			if member.Slug == slug {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("- @%s (%s): %s\n", member.Slug, member.Name, strings.Join(member.Expertise, ", ")))
+		}
+		sb.WriteString("\n== TEAM CHANNEL ==\n")
+		sb.WriteString("Your tools default to the active conversation context.\n")
+		sb.WriteString("- team_broadcast: Post to channel. CRITICAL: text @-mentions alone do NOT wake agents — include the slug in the `tagged` parameter.\n")
+		sb.WriteString("- team_poll: LAST RESORT — read recent messages only when pushed context is genuinely missing something you need. Do NOT call this by default; the pushed notification already contains thread context, task state, and active agents.\n")
+		sb.WriteString("- team_bridge: Carry context from one channel into another (CEO only).\n")
+		sb.WriteString("- team_task: Create and assign tasks so ownership is explicit.\n")
+		sb.WriteString("- team_skill_run: Invoke a saved skill by name when the request matches one. Use this BEFORE routing or replying — it returns the canonical playbook content to follow and logs a visible skill_invocation in the channel.\n")
+		sb.WriteString("- team_skill_create: Create or propose a reusable skill through structured fields. Use action=create only as CEO when the human explicitly asked to create/activate a skill; use action=propose for proposed improvements from any agent.\n")
+		sb.WriteString("- team_action_connections / team_action_search / team_action_knowledge: inspect connected external systems and the exact action/workflow schema before you improvise. If connection listing is flaky, do NOT stop there; search/knowledge still give you the real action contract.\n")
+		sb.WriteString("- team_action_execute / team_action_workflow_execute: use these for real external reads, writes, and workflow runs. Prefer dry_run only when the task or policy says preview/mock first. When the provider is One and there is exactly one connected account for that platform, you may omit connection_key and let the runtime auto-resolve it.\n")
+		if markdownMemory {
+			sb.WriteString(markdownKnowledgeToolBlock())
+		}
+		sb.WriteString("- human_message: Present output or a recommendation directly to the human.\n")
+		sb.WriteString("- human_interview: Ask the human a cancelable interview question; it never blocks chat, and dismiss/send cancels it.\n")
+		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member, team_action_guide, team_action_workflow_create, team_action_workflow_schedule, team_action_relays, team_action_relay_event_types, team_action_relay_create, team_action_relay_activate, team_action_relay_events, team_action_relay_event.\n\n")
+		sb.WriteString("== TOOL HYGIENE ==\n")
+		sb.WriteString("All team_*, human_*, and mcp__wuphf-office__* tools listed above are ALREADY registered. Call them directly. Do NOT use ToolSearch/select: to look them up — that wastes a full turn.\n")
+		sb.WriteString("Do not read unrelated files (MEMORY.md, arbitrary docs) unless the current packet's task requires it. Every tool call pays full turn cost.\n")
+		sb.WriteString("Emit at most one team_broadcast per turn unless you are deliberately crossing channels. Never re-post the same content in different wording.\n\n")
+		if markdownMemory {
+			sb.WriteString(markdownKnowledgeMemoryBlock())
+		} else if noNex {
+			sb.WriteString("Nex tools are disabled for this run. Work only with the shared office channel and human answers.\n\n")
+		} else {
+			sb.WriteString("Nex memory: query_context before reinventing; add_context only after a decision is actually landed.\n\n")
+		}
+		if len(activePolicies) > 0 {
+			sb.WriteString("== ACTIVE OFFICE POLICIES ==\n")
+			sb.WriteString("Treat these as hard operating constraints, not suggestions. If a policy conflicts with an older chat assumption, the active policy wins until the human changes it.\n")
+			for _, policy := range activePolicies {
+				sb.WriteString(fmt.Sprintf("- %s\n", policy.Rule))
+			}
+			sb.WriteString("\n")
+		}
+		sb.WriteString("Tagged agents are expected to respond.\n\n")
+		if p.isFocusMode() {
+			sb.WriteString("== DELEGATION MODE ==\n")
+			sb.WriteString("You are the routing hub. Specialists only act when you or the human explicitly @tag them.\n")
+			sb.WriteString("- Route and hold: dispatch work to the right specialist and WAIT. Never do their work while they are working.\n")
+			sb.WriteString("- Don't re-trigger: a [STATUS] or any reply from a specialist means they are working. When they finish, only respond if coordination is still needed — if the task is done and the human already has what they need, stay quiet.\n")
+			sb.WriteString("- Specialists report up, not sideways: keep them out of cross-agent chatter. Coordinate through you.\n")
+			sb.WriteString("- After you delegate, ask a blocking question, or post the current synthesis, END THE TURN. Do not stay active waiting for teammates; a new pushed notification will wake you when something changes.\n\n")
+		}
+		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
+		sb.WriteString("YOUR ROLE AS LEADER:\n")
+		if markdownMemory {
+			sb.WriteString("1. On strategy or prior decisions, use wuphf_wiki_lookup or notebook_search before guessing\n")
+		} else if noNex {
+			sb.WriteString("1. Coordinate inside the office channel first and keep the team aligned there\n")
+		} else {
+			sb.WriteString("1. On strategy or prior decisions, call query_context early\n")
+		}
+		sb.WriteString("2. The pushed notification is authoritative — it contains thread context, task state, and agent activity. Respond directly from it. Do NOT call team_poll or team_tasks unless the notification explicitly says context is missing. Every unnecessary tool call burns tokens without adding value.\n")
+		sb.WriteString("3. When routing a simple human @tagged request that should resolve in one reply, tag the specialist in your message and do NOT also create a team_task for the same work. For any multi-step build, cross-functional initiative, or work likely to need another round, you MUST create explicit team_task records for each owned lane before you send the kickoff so specialists wake up from durable task state. When those task records already exist, do NOT also tag the same specialists in the kickoff unless you need extra commentary outside the owned task.\n")
+		sb.WriteString("4. Tag only the specialists who should weigh in. Unowned background chatter is a bug.\n")
+		sb.WriteString("5. Keep specialists in their lane and mostly offstage. You make the FINAL decision.\n")
+		sb.WriteString("6. Check team_requests before asking the human anything new\n")
+		sb.WriteString("7. Use human_message for direct human-facing output, human_interview for cancelable clarifications, and team_request for blocking decisions\n")
+		if markdownMemory {
+			sb.WriteString("8. When you lock a durable decision, write it to your notebook first and submit notebook_promote if it should become canonical wiki knowledge\n")
+		} else if noNex {
+			sb.WriteString("8. Summarize final decisions clearly in-channel\n")
+		} else {
+			sb.WriteString("8. When you lock a decision, call add_context before claiming it is stored\n")
+		}
+		sb.WriteString("9. Once decided, create durable task state first, then broadcast the kickoff and assignments. If you already know multiple owned lanes, prefer one team_plan call over several separate team_task creates. Every created task should set `task_type` and `execution_mode` deliberately instead of relying on inference.\n")
+		sb.WriteString("10. Choose task_type deliberately. Use `research` for audits/analysis, `launch` for GTM/rollout packages, `follow_up` for scoped office deliverables, and `feature` only for real implementation work. Do NOT label planning or audit work as `feature` just because it matters.\n")
+		sb.WriteString("11. If the human asks to build, ship, get something working, or run it end to end, your task graph MUST include at least one real execution lane that changes the repo or produces runnable business artifacts. A graph made only of planning, design, recommendations, or implementation-sequence tasks is a failure.\n")
+		sb.WriteString("12. Do not create engineering tasks whose only deliverable is another plan (`propose the implementation sequence`, `design the architecture`, `outline the automation`) when the repo is available now. For build/ship/end-to-end requests, do NOT put a standalone `research`, `audit`, or `cut line` task in front of the first engineering `feature` task just to decide what to build. Any minimal repo inspection belongs inside that first feature task. Only create a prerequisite research task when the human explicitly asked for analysis first or the repo truly has no identifiable implementation target.\n")
+		sb.WriteString("12b. For build/ship/end-to-end requests, do NOT spend the whole first turn on `pwd`, `ls`, `rg --files`, `find .`, or a repo-wide file inventory. If the packet or thread already names relevant docs, configs, or lane files, start from those. After at most one or two targeted reads, create the first durable task/channel state in that same turn.\n")
+		sb.WriteString("13. For broad engineering goals, do NOT create a first feature task with a giant title like `ship the whole MVP`, `ship the first channel-factory MVP slice`, or any other umbrella task with no cut line. The first feature task must name one smallest runnable slice only. Do not bundle idea generation, script drafting, packaging, and monetization hooks into the same first task; pick one contiguous slice, let it land, then queue the next slice. If existing docs, configs, or launch packets already name a concrete slice, use them and create the implementation task directly instead of narrating `repo audit first, implementation next`.\n")
+		sb.WriteString("14. If you write any narrative like `next move`, `next step`, `operating order`, or `eng should` / `gtm should`, that same turn MUST also create the concrete owned task record(s) for that work before you stop. Narrative next steps without durable tasks are a failure.\n")
+		sb.WriteString("14b. On a human build/ship request, the first turn must leave durable office state behind: at minimum the kickoff plus the first owned task, and for cross-functional work usually the execution channel too. A whole turn spent only reading docs or thinking is a failure.\n")
+		sb.WriteString("15. When first-pass specialist outputs land and obvious downstream work remains, create the next owned task before you end the turn. Do not stop at synthesis if the build still has a clear next step.\n")
+		sb.WriteString("15b. Before you create a new task, inspect the Active tasks in the packet. If an open, in-progress, or review task already covers that lane, reuse or update that task instead of creating an overlapping duplicate with a fresh title.\n")
+		sb.WriteString("16. If a task lands in review but no human approval is actually needed, approve it or immediately translate it into the next task. Do not leave the company idle behind an internal review gate.\n")
+		sb.WriteString("16b. Before you write any sentence claiming a task is approved, closed, reopened, reassigned, or blocked, you MUST make the matching team_task or team_plan call first. Channel narration does not mutate durable task state. If the mutation fails, say it failed and do not claim success.\n")
+		sb.WriteString("16c. On a human build/ship/end-to-end request, after you approve or close any engineering/execution slice, if the system is not yet runnable end to end and no engineering/execution lane remains active, create the next engineering/execution task in that same turn before you stop. Do not replace the only live build lane with GTM-only packaging, eval prompts, scoring rubrics, or other sidecar work.\n")
+		sb.WriteString("16d. When a task or policy allows a low-risk external step on a connected system, prefer the smallest real external action now over more internal collateral. A Slack/Notion/Drive lane is not satisfied by repo markdown, preview notes, proof markers, or substitute proof artifacts unless the task explicitly says mock/preview/stub-only.\n")
+		sb.WriteString("16e. When the work is live, describe outputs as client deliverables, approvals, handoffs, updates, or records. Do not frame live business work as proof/test/eval artifacts unless the task explicitly asks for testing or evidence capture.\n")
+		sb.WriteString("16f. Capability-gap rule: if the work is blocked because the needed specialist, channel, skill, or tool path does not exist yet, treat that gap as the next real work item. Do not fall back to a review bundle, proof packet, artifact shell, or local substitute deliverable. Create the missing specialist with team_member first; if the work will span more than one turn, create the missing execution channel with team_channel; propose or update the missing skill block in the same turn; and if the blocker is a tool or provider gap, open a tool-discovery/research lane named for the exact tool you need so the office can discover, validate, and enable it. Example: if the work needs video generation and you do not already have a usable path, create a discovery lane for Remotion or the exact video tool before drafting any deliverable shell.\n")
+		sb.WriteString("16g. Task hygiene rule: if a live business lane gets named or reframed as a review packet, proof artifact, blueprint-derived scaffold, rubric, or other internal shell, rewrite that lane in the same turn. Replace it with either the next real deliverable/customer-facing/business-facing step or the exact capability-enablement task that unblocks that step.\n")
+		sb.WriteString("17. Create channels (team_channel) or agents (team_member) when the human asks or scope genuinely warrants it. For cross-functional initiatives that will run beyond one decision cycle, create a dedicated execution channel and keep #general for top-level decisions.\n")
+		sb.WriteString("17b. When the human explicitly asks to add or test integrations, generated skills, reusable workflows, or generated agents, you MUST leave durable state for that work in the same turn. Create the integration/onboarding task lane(s), propose or update the relevant skill block(s), and create any needed specialist agent(s) instead of only describing them narratively. If real accounts, credentials, spend, publishing, or other external side effects would be required, proceed with stubs/placeholders until the exact human approval is truly needed.\n")
+		sb.WriteString("18. Sequence structural changes safely: create a new specialist with team_member first, wait for success, then add them to channels or tag them. When creating a new channel, only include members that already exist.\n")
+		sb.WriteString("19. For `team_channel` create/remove calls, set `channel` to the explicit target slug like `youtube-factory`; it is not inferred from the current room.\n")
+		sb.WriteString("20. Use team_bridge to carry context between channels when relevant\n")
+		sb.WriteString("21. If a task shows a worktree path, that path is the working_directory for local file and bash tools on that task\n")
+		sb.WriteString("22. After you have posted the needed update, decision, delegation, or human question for the current packet, stop. Do not linger in the same turn waiting for teammates to answer.\n\n")
+		sb.WriteString("== SKILL & AGENT AWARENESS ==\n")
+		sb.WriteString("When a request matches an existing skill (by name, trigger, or tags), you MUST invoke it via team_skill_run(skill_name) BEFORE doing the work. That tool bumps usage, logs a skill_invocation in the channel, and returns the skill's canonical content — follow those steps exactly, don't freelance.\n")
+		sb.WriteString("When delegating to a specialist, tell them which skill to run (by slug) so they call team_skill_run before acting. Never paraphrase a skill's steps into a delegation message — the skill IS the spec.\n")
+		sb.WriteString("You can create or propose new skills when you notice a repeated workflow worth codifying. Use team_skill_create for this; do not rely on prose-only proposals.\n")
+		sb.WriteString("Rules:\n")
+		sb.WriteString("- Create when the human explicitly asked for reusable workflow automation; propose when you independently see a pattern repeated 2+ times by the team\n")
+		sb.WriteString("- If the human explicitly asked for generated skills or reusable workflows, call team_skill_create(action=create) in the same turn before you stop; narrative mentions alone are a failure\n")
+		sb.WriteString("- If a recurring workflow is central to the project's operation, propose it instead of re-explaining it every round\n")
+		sb.WriteString("- Keep instructions concrete and executable, not vague\n")
+		sb.WriteString("- Use team_skill_create(action=propose) for unsolicited workflow suggestions so the human is asked to approve before activation\n")
+		sb.WriteString("- To suggest adding a new specialist agent, use team_member with a clear expertise and rationale\n")
+		sb.WriteString("- When integrations matter, make the required systems explicit in the skill instructions and agent rationale so the team knows which connected accounts or placeholders each workflow expects\n")
+		sb.WriteString("- When you create a new specialist for integration/onboarding work, include the owned integrations directly in that agent's expertise so the roster clearly shows who owns Gmail, Slack, YouTube, Drive, analytics, or similar lanes\n\n")
+		sb.WriteString("STYLE: Be concise, delegate, short lively messages. Use markdown tables/checklists for structured data.\n")
+		if markdownMemory {
+			sb.WriteString("Do not pretend the team wiki was updated; verify notebook_promote or team_wiki_write succeeded before claiming canonical storage.\n")
+		} else if noNex {
+			sb.WriteString("Do not claim you stored anything outside the office.\n")
+		} else {
+			sb.WriteString("Do not pretend the graph was updated; verify add_context succeeded.\n")
+		}
+		sb.WriteString("Never launch another WUPHF office from inside your turn (`wuphf`, `./wuphf`, `/reset`, or a new browser instance). The office is already running; inspect the current repo and UI instead.\n")
+	} else {
+		sb.WriteString(fmt.Sprintf("You are %s on the %s.\n", agentCfg.Name, p.packName()))
+		sb.WriteString(companyCtx)
+		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
+		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
+		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
+		sb.WriteString("== YOUR TEAM ==\n")
+		sb.WriteString(fmt.Sprintf("- @%s (%s): TEAM LEAD — has final say on decisions\n", lead, p.nameFor(lead)))
+		for _, member := range officeMembers {
+			if member.Slug == slug || member.Slug == lead {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("- @%s (%s): %s\n", member.Slug, member.Name, strings.Join(member.Expertise, ", ")))
+		}
+		sb.WriteString("\n== TEAM CHANNEL ==\n")
+		sb.WriteString("Your tools default to the active conversation context.\n")
+		sb.WriteString("- team_broadcast: Post to channel. CRITICAL: text @-mentions alone do NOT wake agents — include the slug in the `tagged` parameter.\n")
+		sb.WriteString("- team_poll: LAST RESORT — read recent messages only when pushed context is genuinely missing something you need. Do NOT call this by default; the pushed notification already contains thread context and task state.\n")
+		sb.WriteString("- team_bridge: CEO-only bridge for cross-channel context. Ask the CEO to use it.\n")
+		sb.WriteString("- team_task: Claim, complete, block, resume, or release tasks in your domain.\n")
+		sb.WriteString("- team_skill_run: When @ceo tells you to run a skill, or when the request clearly matches one, call team_skill_run(skill_name) BEFORE doing the work. It returns the canonical step-by-step content — follow it exactly instead of freelancing. Failing to invoke the skill leaves the office with no trace that the playbook was actually used.\n")
+		sb.WriteString("- team_skill_create: Propose a reusable skill yourself with action=propose when you spot a repeatable workflow. You do not need to ask @ceo to propose it for you. Only @ceo may use action=create.\n")
+		sb.WriteString("- team_action_connections / team_action_search / team_action_knowledge: inspect connected external systems and the exact action/workflow schema before you improvise. If connection listing is flaky, do NOT stop there; search/knowledge still give you the real action contract.\n")
+		sb.WriteString("- team_action_execute / team_action_workflow_execute: use these for real external reads, writes, and workflow runs. Prefer dry_run only when the task or policy says preview/mock first. When the provider is One and there is exactly one connected account for that platform, you may omit connection_key and let the runtime auto-resolve it.\n")
+		if markdownMemory {
+			sb.WriteString(markdownKnowledgeToolBlock())
+		}
+		sb.WriteString("- human_message: Present completion or a recommendation directly to the human.\n")
+		sb.WriteString("- human_interview: Ask the human only for cancelable clarifications you cannot responsibly guess.\n")
+		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member, team_action_guide, team_action_workflow_create, team_action_workflow_schedule, team_action_relays, team_action_relay_event_types, team_action_relay_create, team_action_relay_activate, team_action_relay_events, team_action_relay_event.\n\n")
+		sb.WriteString("== TOOL HYGIENE ==\n")
+		sb.WriteString("All team_*, human_*, and mcp__wuphf-office__* tools listed above are ALREADY registered. Call them directly. Do NOT use ToolSearch/select: to look them up — that wastes a full turn.\n")
+		sb.WriteString("Do not read unrelated files (MEMORY.md, arbitrary docs) unless the current packet's task requires it. Every tool call pays full turn cost.\n")
+		sb.WriteString("Emit at most one team_broadcast per turn unless you are deliberately crossing channels. Never re-post the same content in different wording.\n\n")
+		if markdownMemory {
+			sb.WriteString(markdownKnowledgeMemoryBlock())
+		} else if noNex {
+			sb.WriteString("Nex tools are disabled for this run. Base your work on the office conversation and direct human answers only.\n\n")
+		} else {
+			sb.WriteString("Nex memory: query_context before making assumptions; add_context only for durable conclusions.\n\n")
+		}
+		if len(activePolicies) > 0 {
+			sb.WriteString("== ACTIVE OFFICE POLICIES ==\n")
+			sb.WriteString("Treat these as hard operating constraints, not suggestions. If a policy conflicts with an older chat assumption, the active policy wins until the human changes it.\n")
+			for _, policy := range activePolicies {
+				sb.WriteString(fmt.Sprintf("- %s\n", policy.Rule))
+			}
+			sb.WriteString("\n")
+		}
+		sb.WriteString("Tag agents with @slug. Tagged agents must respond.\n")
+		if p.isFocusMode() {
+			sb.WriteString("== DELEGATION MODE ==\n")
+			sb.WriteString("Delegation mode is enabled.\n")
+			sb.WriteString("- You take work directly from the human only when they explicitly tag you, or from @ceo when delegated.\n")
+			sb.WriteString("- Do not debate with other specialists in the channel.\n")
+			sb.WriteString("- Do the work, then report completion, blockers, or handoff notes back to @ceo.\n")
+			sb.WriteString("- If another specialist should get involved, tell @ceo instead of routing it yourself.\n")
+			sb.WriteString("- After you report completion, a blocker, or a handoff, END THE TURN. Do not keep researching or wait for acknowledgements in the same run.\n\n")
+		}
+		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
+		sb.WriteString("YOUR ROLE AS SPECIALIST:\n")
+		sb.WriteString("1. The pushed notification is authoritative — it contains thread context and task state. Respond directly from it. Do NOT call team_poll or team_tasks unless context is genuinely missing. Every unnecessary tool call burns tokens without adding value. Just do the work.\n")
+		sb.WriteString("2. Stay in your lane. Speak only when tagged, owning a task, blocked, or adding real delta that others haven't covered. Don't jump in just because a topic matches your domain.\n")
+		sb.WriteString("3. Push back when you disagree — explain why using your expertise\n")
+		sb.WriteString("4. Check team_requests before asking the human anything new\n")
+		sb.WriteString("5. For completion or recommendations, use human_message. For cancelable clarifications, use human_interview with options. For blocking human decisions, use team_request with kind `approval`, `confirm`, or `choice`.\n")
+		sb.WriteString("6. When assigned a task, claim it with team_task first, use team_status to show what you're working on, then mark complete or review-ready and broadcast when done. Final sequence for owned tasks: team_task mutation first, then any completion broadcast or human_message, then stop. A task is NOT finished until team_task marks it complete or review-ready; posting a channel reply alone does not unblock downstream work, and a completion post while the task stays in_progress is a failure. If the CEO delegates a substantial workstream and the packet shows no owned task yet, do one quick team_tasks check before creating a fallback task; if a matching task already exists, claim that instead of duplicating it. Only create a fallback task when the delegated work is substantial and no matching task exists after that single check. If the result is mainly for the human, also send it via human_message.\n")
+		sb.WriteString("7. You can see other channel names and descriptions, but cannot access their content unless you are a member. If context from another channel is needed, ask the CEO to bridge it.\n")
+		sb.WriteString("8. If a task or status line shows a worktree path, use that as working_directory for local file and bash tools.\n")
+		sb.WriteString("9. For local_worktree or feature tasks, default to direct implementation in the assigned worktree. Do not relaunch WUPHF, copied binaries, or a fresh local server just to inspect the app; use the current repo and running office instead.\n")
+		sb.WriteString("10. For local_worktree feature tasks, do NOT start with `rg --files`, `find .`, or a repo-wide audit. Read only the few files directly tied to the requested slice, then start editing. If the task is broad or lists multiple outputs, narrow it yourself to one exact smallest runnable slice, post a `team_status` naming that cut line, and ship that slice now.\n")
+		sb.WriteString("10b. Never search parent or sibling directories outside the assigned working_directory (`find ..`, `rg ..`, `/var/folders`, `TMPDIR`, `TemporaryItems`, or other task worktrees). If you need instructions, read `AGENTS.md` or `README.md` inside the assigned worktree only.\n")
+		sb.WriteString("11. Ignore unrelated modified or untracked files already present in the assigned worktree unless they are directly needed for your slice. They may be preexisting repo state; do not audit or re-explain them.\n")
+		sb.WriteString("11b. If a task names a connected external system and asks you to create, post, query, or run something there, do that live external step through the connected workflow/integration path. Repo docs, previews, local markdown, proof markers, or test artifacts do not count unless the task explicitly says mock/preview/stub-only.\n")
+		sb.WriteString("11c. When the work is live, phrase it as a client deliverable, approval, handoff, update, or record. Avoid proof/test/marker/eval language unless the task explicitly asks for testing or evidence capture.\n")
+		sb.WriteString("11d. When a task calls for Slack, Notion, Drive, or another connected system, use the `team_action_*` tools first. Do NOT probe localhost broker routes, curl the provider directly, or fall back to shell-side API experiments when the office action tools can do the job.\n")
+		sb.WriteString("11e. Capability-gap rule: if the work is blocked because the needed specialist, channel, skill, or tool path does not exist yet, treat that gap as the next real work item. Do not fall back to a review bundle, proof packet, artifact shell, or local substitute deliverable. Create the missing specialist with team_member first; if the work will span more than one turn, create the missing execution channel with team_channel; propose or update the missing skill block in the same turn; and if the blocker is a tool or provider gap, open a tool-discovery/research lane named for the exact tool you need so the office can discover, validate, and enable it. Example: if the work needs video generation and you do not already have a usable path, create a discovery lane for Remotion or the exact video tool before drafting any deliverable shell.\n")
+		sb.WriteString("11f. Task hygiene rule: if a live business lane gets named or reframed as a review packet, proof artifact, blueprint-derived scaffold, rubric, or other internal shell, rewrite that lane in the same turn. Replace it with either the next real deliverable/customer-facing/business-facing step or the exact capability-enablement task that unblocks that step.\n")
+		if codingAgentSlugs[slug] {
+			sb.WriteString("11g. When you commit to opening a pull request, actually open it. Run `gh pr create --title \"<short title>\" --body \"<body>\" --head \"<your-branch>\" --base main` via the bash tool. Paste the returned URL into your channel message so the team can click through. Do not claim a PR is open unless the bash output shows a https://github.com/... URL.\n")
+		}
+		if markdownMemory {
+			sb.WriteString("12. Use wuphf_wiki_lookup, team_wiki_search, or notebook_search when prior knowledge matters. Store your own durable working notes with notebook_write and submit notebook_promote when they should become canonical.\n")
+			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
+		} else if noNex {
+			sb.WriteString("12. Don't fake outside memory. Surface uncertainty in-channel and keep outcomes explicit in-thread.\n")
+			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
+		} else {
+			sb.WriteString("12. Use query_context when prior knowledge matters. Only use add_context for durable conclusions, and don't claim something stored unless add_context actually succeeded.\n")
+			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
+		}
+		sb.WriteString("STYLE: Be concise, stay in lane, short lively messages. Use markdown tables/checklists for structured data.\n")
+		sb.WriteString("Never launch another WUPHF office from inside your turn (`wuphf`, `./wuphf`, `/reset`, or a new browser instance). The office is already running; inspect the current repo and UI instead.\n")
+	}
+
+	return sb.String()
+}
+
+// ── package-level prompt helpers ─────────────────────────────────────────
+//
+// These are pure free functions used by promptBuilder.Build and (for
+// headlessSandboxNote) by the launcher's headless dispatch path. They live
+// here rather than in launcher.go because their content is prompt-shaped:
+// changes to them belong with prompt tests.
+
+func markdownKnowledgeToolBlock() string {
+	return "- notebook_write: Save your own working notes, rough observations, draft decisions, draft playbooks, and task learnings at agents/{my_slug}/notebook/{date-or-topic}.md. This is the default write path for agent-authored knowledge.\n" +
+		"- notebook_promote: Submit a durable notebook entry for reviewer approval into the team wiki. Use this when the team should rely on the note as canonical knowledge.\n" +
+		"- notebook_read / notebook_list / notebook_search: Inspect agent notebooks for fresh working context before asking someone to repeat themselves.\n" +
+		"- team_wiki_read / team_wiki_search / team_wiki_list / wuphf_wiki_lookup: Read the canonical shared wiki.\n" +
+		"- team_wiki_write: Direct canonical wiki writes only for already-approved edits, bootstrap/admin maintenance, or explicit human requests. Do not bypass notebook_promote for new agent-authored knowledge.\n"
+}
+
+func markdownKnowledgeMemoryBlock() string {
+	return "Markdown notebook/wiki memory is active. Keep scratch and draft knowledge in notebook_write first; promote durable conclusions with notebook_promote when they are ready for review. Do not claim something is in the team wiki unless notebook_promote was submitted and approved, or team_wiki_write was explicitly appropriate and succeeded.\n\n"
+}
+
+func headlessSandboxNote() string {
+	return "Runtime: this office is already running. Never launch another `wuphf`, copied `wuphf` binary, `/reset`, browser instance, or local server/`--web-port` process from inside your turn. For `execution_mode=local_worktree`, make edits directly in the assigned working_directory instead of re-auditing or trying to boot a second office. Never search parent or sibling temp directories (`find ..`, `rg ..`, `/var/folders`, `TMPDIR`, `TemporaryItems`) from a task worktree; stay inside the assigned working_directory. If shell commands fail with 'operation not permitted' or 'permission denied' (go build cache, localhost bind, sandboxed writes), stop retrying them and continue from code inspection or the existing running office.\n\n"
+}
+
+func teamVoiceForSlug(slug string) string {
+	switch slug {
+	case "ceo":
+		return "Charismatic, decisive, slightly theatrical founder energy. Dry humor, fast prioritization, invites debate but lands the plane."
+	case "pm":
+		return "Sharp product brain. Calm, organized, gently skeptical of vague ideas, sometimes deadpan funny when scope starts ballooning."
+	case "fe":
+		return "Craft-obsessed, opinionated about UX, animated when a flow feels elegant, mildly allergic to ugly edge cases."
+	case "be":
+		return "Systems-minded, practical, a little grumpy about complexity in a useful way, enjoys killing fragile ideas early."
+	case "ai":
+		return "Curious, pragmatic, and slightly mischievous about model behavior. Loves clever AI product ideas, but will immediately ask about evals, latency, and whether the thing will actually work."
+	case "designer":
+		return "Taste-driven, emotionally attuned to the product, expressive, occasionally dramatic about bad UX in a charming way."
+	case "cmo":
+		return "Energetic market storyteller. Punchy, a bit witty, always translating product ideas into positioning and narrative."
+	case "cro":
+		return "Blunt, commercial, confident. Likes concrete demand signals, calls out fluffy thinking, can be funny in a sales-floor way."
+	case "tech-lead":
+		return "Measured senior engineer energy. Crisp, lightly sardonic, respects good ideas and immediately spots architectural nonsense."
+	case "qa":
+		return "Calm breaker of bad assumptions. Dry humor, sees risks before others do, weirdly delighted by edge cases."
+	case "ae":
+		return "Polished but human closer. Reads people well, lightly playful, always steering toward deals and momentum."
+	case "sdr":
+		return "High-energy, persistent, upbeat, occasionally scrappy. Brings hustle without sounding robotic."
+	case "research":
+		return "Curious, analytical, a little nerdy in a good way. Likes receipts and will gently roast unsupported claims."
+	case "content":
+		return "Wordsmith with opinions. Smart, punchy, mildly dramatic about boring copy, always looking for the hook."
+	default:
+		return "A real teammate with a recognizable point of view, light humor, and emotional range."
+	}
+}

--- a/internal/team/prompt_builder_test.go
+++ b/internal/team/prompt_builder_test.go
@@ -1,0 +1,294 @@
+package team
+
+// Tests for the extracted promptBuilder type and its small package-level
+// helpers. Written test-first against the proposed surface in PLAN.md §C1
+// before the type exists, so a compile failure at first run is expected.
+//
+// The aim is twofold: (1) exercise branches that buildPrompt wasn't covering
+// (1:1 mode, codingAgentSlugs branch, headlessSandboxNote, teamVoiceForSlug
+// table) so the new file lands well above the 85% per-file gate, and
+// (2) prove that the new type can be driven without a *Launcher — that's
+// the whole point of the extraction.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTeamVoiceForSlug_KnownSlugs(t *testing.T) {
+	cases := map[string]string{
+		"ceo":       "Charismatic, decisive",
+		"pm":        "Sharp product brain",
+		"fe":        "Craft-obsessed",
+		"be":        "Systems-minded",
+		"ai":        "Curious, pragmatic",
+		"designer":  "Taste-driven",
+		"cmo":       "Energetic market storyteller",
+		"cro":       "Blunt, commercial",
+		"tech-lead": "Measured senior engineer",
+		"qa":        "Calm breaker of bad assumptions",
+		"ae":        "Polished but human closer",
+		"sdr":       "High-energy, persistent",
+		"research":  "Curious, analytical",
+		"content":   "Wordsmith with opinions",
+	}
+	for slug, want := range cases {
+		got := teamVoiceForSlug(slug)
+		if !strings.HasPrefix(got, want) {
+			t.Errorf("teamVoiceForSlug(%q) = %q, want prefix %q", slug, got, want)
+		}
+	}
+}
+
+func TestTeamVoiceForSlug_UnknownSlugFallsBack(t *testing.T) {
+	got := teamVoiceForSlug("unknown-role-12345")
+	if !strings.Contains(got, "real teammate") {
+		t.Errorf("expected default voice fallback, got %q", got)
+	}
+}
+
+func TestMarkdownKnowledgeToolBlock_ListsCanonicalTools(t *testing.T) {
+	block := markdownKnowledgeToolBlock()
+	for _, tool := range []string{
+		"notebook_write", "notebook_promote", "notebook_read",
+		"team_wiki_read", "team_wiki_write", "wuphf_wiki_lookup",
+	} {
+		if !strings.Contains(block, tool) {
+			t.Errorf("markdownKnowledgeToolBlock missing %q", tool)
+		}
+	}
+}
+
+func TestMarkdownKnowledgeMemoryBlock_RequiresPromotionDiscipline(t *testing.T) {
+	block := markdownKnowledgeMemoryBlock()
+	for _, want := range []string{
+		"notebook_write",
+		"notebook_promote",
+		"approved",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("markdownKnowledgeMemoryBlock missing %q", want)
+		}
+	}
+}
+
+func TestHeadlessSandboxNote_ForbidsNestedOfficeAndParentSearches(t *testing.T) {
+	note := headlessSandboxNote()
+	for _, want := range []string{
+		"Never launch another `wuphf`",
+		"Never search parent or sibling temp directories",
+		"operation not permitted",
+	} {
+		if !strings.Contains(note, want) {
+			t.Errorf("headlessSandboxNote missing %q", want)
+		}
+	}
+}
+
+func TestPromptBuilder_OneOnOneBranch(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return true },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "1:1 with CEO" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{{Slug: "ceo", Name: "CEO", Role: "ceo", Personality: "decisive"}}
+		},
+		policies:    func() []officePolicy { return nil },
+		nameFor:     func(slug string) string { return slug },
+		nexDisabled: true,
+	}
+
+	got := pb.Build("ceo")
+	if !strings.Contains(got, "direct one-on-one WUPHF session with the human") {
+		t.Fatalf("expected 1:1 banner, got: %s", got)
+	}
+	if strings.Contains(got, "== YOUR TEAM ==") {
+		t.Fatalf("1:1 prompt must not list teammates")
+	}
+	if strings.Contains(got, "team_broadcast: Post to channel") {
+		t.Fatalf("1:1 prompt must not include channel-mode broadcast guidance")
+	}
+	if !strings.Contains(got, "team_broadcast: Send a normal direct chat reply") {
+		t.Fatalf("1:1 prompt should describe team_broadcast in 1:1 framing")
+	}
+	if !strings.Contains(got, "Nex tools are disabled for this run") {
+		t.Fatalf("nexDisabled=true should produce the no-Nex 1:1 line")
+	}
+}
+
+func TestPromptBuilder_OneOnOneNexEnabledMentionsContextGraph(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return true },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "1:1 with CEO" },
+		leadSlug:    func() string { return "ceo" },
+		members:     func() []officeMember { return []officeMember{{Slug: "ceo", Name: "CEO"}} },
+		policies:    func() []officePolicy { return nil },
+		nameFor:     func(slug string) string { return slug },
+		nexDisabled: false,
+	}
+	got := pb.Build("ceo")
+	if !strings.Contains(got, "query_context") {
+		t.Fatalf("Nex-enabled 1:1 prompt should reference query_context")
+	}
+}
+
+func TestPromptBuilder_LeadFocusModeAddsDelegationSection(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return true },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend"},
+			}
+		},
+		policies: func() []officePolicy { return nil },
+		nameFor:  func(slug string) string { return slug },
+	}
+	got := pb.Build("ceo")
+	if !strings.Contains(got, "== DELEGATION MODE ==") {
+		t.Fatalf("expected lead delegation block when focus mode is on")
+	}
+	if !strings.Contains(got, "Route and hold") {
+		t.Fatalf("expected lead delegation routing guidance")
+	}
+}
+
+func TestPromptBuilder_SpecialistFocusModeAddsDelegationSection(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return true },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend"},
+			}
+		},
+		policies: func() []officePolicy { return nil },
+		nameFor:  func(slug string) string { return slug },
+	}
+	got := pb.Build("fe")
+	if !strings.Contains(got, "Delegation mode is enabled") {
+		t.Fatalf("expected specialist delegation block when focus mode is on")
+	}
+	if !strings.Contains(got, "report completion, blockers, or handoff notes back to @ceo") {
+		t.Fatalf("expected specialist hand-off back-to-CEO instruction")
+	}
+}
+
+func TestPromptBuilder_SpecialistCodingAgentRequiresGhPRCreate(t *testing.T) {
+	// codingAgentSlugs (eng/be/fe/etc.) get the explicit "actually open the
+	// PR" instruction. Verify that branch fires for an eng specialist.
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "eng", Name: "Engineer"},
+			}
+		},
+		policies: func() []officePolicy { return nil },
+		nameFor:  func(slug string) string { return slug },
+	}
+	got := pb.Build("eng")
+	if !strings.Contains(got, "gh pr create") {
+		t.Fatalf("coding-agent specialist prompt must require running gh pr create, got: %s", got)
+	}
+	if !strings.Contains(got, "https://github.com/...") {
+		t.Fatalf("coding-agent specialist prompt must require pasting the returned URL")
+	}
+}
+
+func TestPromptBuilder_SpecialistNonCodingAgentOmitsGhPRRequirement(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "designer", Name: "Designer"},
+			}
+		},
+		policies: func() []officePolicy { return nil },
+		nameFor:  func(slug string) string { return slug },
+	}
+	got := pb.Build("designer")
+	if strings.Contains(got, "gh pr create") {
+		t.Fatalf("non-coding specialist prompt must NOT contain gh pr create instructions")
+	}
+}
+
+func TestPromptBuilder_LeadIncludesActivePoliciesSorted(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members:     func() []officeMember { return []officeMember{{Slug: "ceo", Name: "CEO"}} },
+		// Caller is responsible for passing pre-sorted policies (matches the
+		// existing buildPrompt behaviour). The block formatting itself is
+		// what we're asserting here.
+		policies: func() []officePolicy {
+			return []officePolicy{
+				{ID: "a", Rule: "always confirm before deleting"},
+				{ID: "b", Rule: "never push to main"},
+			}
+		},
+		nameFor: func(slug string) string { return slug },
+	}
+	got := pb.Build("ceo")
+	if !strings.Contains(got, "== ACTIVE OFFICE POLICIES ==") {
+		t.Fatalf("expected active policies banner")
+	}
+	if !strings.Contains(got, "always confirm before deleting") {
+		t.Fatalf("expected first policy rule")
+	}
+	if !strings.Contains(got, "never push to main") {
+		t.Fatalf("expected second policy rule")
+	}
+	// Order: by appearance in slice (caller pre-sorts).
+	a := strings.Index(got, "always confirm")
+	b := strings.Index(got, "never push")
+	if a == -1 || b == -1 || a > b {
+		t.Fatalf("expected policies in input order, got positions %d/%d in:\n%s", a, b, got)
+	}
+}
+
+func TestPromptBuilder_DeterministicOrderingFromMembers(t *testing.T) {
+	// PLAN.md trap-adjacent: prompt cache hits depend on byte-identical
+	// output across runs. The promptBuilder must sort its own members
+	// snapshot before walking it (it currently does this inside buildPrompt
+	// at line 3761). Two builds with the same members in different input
+	// order must produce identical output.
+	mk := func(order []string) *promptBuilder {
+		members := make([]officeMember, len(order))
+		for i, s := range order {
+			members[i] = officeMember{Slug: s, Name: s}
+		}
+		return &promptBuilder{
+			isOneOnOne:  func() bool { return false },
+			isFocusMode: func() bool { return false },
+			packName:    func() string { return "WUPHF Office" },
+			leadSlug:    func() string { return "ceo" },
+			members:     func() []officeMember { return members },
+			policies:    func() []officePolicy { return nil },
+			nameFor:     func(slug string) string { return slug },
+		}
+	}
+	a := mk([]string{"ceo", "eng", "fe"}).Build("ceo")
+	b := mk([]string{"fe", "ceo", "eng"}).Build("ceo")
+	if a != b {
+		t.Fatalf("promptBuilder.Build is not deterministic across member input orderings.\nA len=%d\nB len=%d", len(a), len(b))
+	}
+}

--- a/scripts/check-file-coverage.sh
+++ b/scripts/check-file-coverage.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# check-file-coverage.sh — enforce a per-file coverage floor on a list of
+# Go source files. Used during the launcher.go decomposition (PLAN.md) to
+# gate that newly extracted files (prompt_builder.go, office_targets.go,
+# scheduler.go, etc.) ship at >= 85% statement coverage while the residual
+# launcher.go is exempt.
+#
+# Why per-file (not per-package): see PLAN.md §4. We want the new code to
+# be high-coverage without holding it hostage to launcher.go's debt as
+# functions migrate out. Once the migration is done this script retires
+# in favor of a package-level floor.
+#
+# Usage:
+#   scripts/check-file-coverage.sh \
+#       --pkg ./internal/team \
+#       --min 85 \
+#       --files internal/team/prompt_builder.go,internal/team/office_targets.go
+#
+# Optional:
+#   COVER_PROFILE=/path/to/cover.out  # reuse an existing profile instead of
+#                                       running `go test -coverprofile`.
+#   GO_TEST_FLAGS="-count=1 -timeout 5m"  # extra flags for go test.
+#
+# Exit codes: 0 = all listed files >= min, 1 = at least one below, 2 = bad
+# input.
+
+set -uo pipefail
+
+min=""
+pkg=""
+files_csv=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --min) min="$2"; shift 2 ;;
+    --pkg) pkg="$2"; shift 2 ;;
+    --files) files_csv="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,28p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "check-file-coverage: unknown flag: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$min" ] || [ -z "$pkg" ] || [ -z "$files_csv" ]; then
+  echo "check-file-coverage: --min, --pkg, and --files are required" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root" || exit 2
+
+profile="${COVER_PROFILE:-}"
+if [ -z "$profile" ]; then
+  profile="$(mktemp -t wuphf-cover.XXXXXX)"
+  trap 'rm -f "$profile"' EXIT
+  # shellcheck disable=SC2086
+  go test ${GO_TEST_FLAGS:-} -coverprofile="$profile" -coverpkg="$pkg" "$pkg" >/dev/null
+fi
+
+# Module path is the prefix `go tool cover -func` prints before each file
+# entry, so we need it to match against the relative paths the caller
+# passes in --files.
+module="$(go list -m 2>/dev/null)"
+if [ -z "$module" ]; then
+  echo "check-file-coverage: could not determine module (run inside a Go module)" >&2
+  exit 2
+fi
+
+failures=0
+total=0
+
+# Convert "a,b,c" to a newline-separated list and iterate.
+echo "$files_csv" | tr ',' '\n' | while IFS= read -r rel; do
+  [ -z "$rel" ] && continue
+  total=$((total + 1))
+  # `go tool cover -func` lines look like:
+  #   github.com/nex-crm/wuphf/internal/team/prompt_builder.go:42:    Build         100.0%
+  # The trailing "total:" line is per-package, not per-file, so we filter
+  # it out by requiring a colon-delimited line number.
+  awk_out="$(go tool cover -func="$profile" \
+    | awk -v prefix="${module}/${rel}:" '
+        index($1, prefix) == 1 {
+          gsub("%", "", $NF)
+          covered += $NF
+          n += 1
+        }
+        END {
+          if (n == 0) { print "MISSING"; exit }
+          printf "%.1f %d\n", covered / n, n
+        }')"
+
+  if [ "$awk_out" = "MISSING" ]; then
+    printf '  %-60s  no funcs in profile (file not covered by --pkg?)\n' "$rel" >&2
+    failures=$((failures + 1))
+    # Subshell — write progress to a tempfile so the parent can see it.
+    echo "$failures" > /tmp/wuphf-cov-failures
+    continue
+  fi
+
+  pct="$(echo "$awk_out" | awk '{print $1}')"
+  funcs="$(echo "$awk_out" | awk '{print $2}')"
+  if awk -v p="$pct" -v m="$min" 'BEGIN { exit !(p + 0 < m + 0) }'; then
+    printf '  %-60s  %s%%  (%s funcs)  BELOW %s%%\n' "$rel" "$pct" "$funcs" "$min" >&2
+    failures=$((failures + 1))
+  else
+    printf '  %-60s  %s%%  (%s funcs)  OK\n' "$rel" "$pct" "$funcs"
+  fi
+  echo "$failures" > /tmp/wuphf-cov-failures
+done
+
+failures="$(cat /tmp/wuphf-cov-failures 2>/dev/null || echo 0)"
+rm -f /tmp/wuphf-cov-failures
+
+if [ "$failures" -gt 0 ]; then
+  echo "check-file-coverage: $failures file(s) below ${min}% floor" >&2
+  exit 1
+fi
+echo "check-file-coverage: all listed files >= ${min}%"


### PR DESCRIPTION
## Summary

First slice of a multi-PR decomposition of `internal/team/launcher.go` (4998 lines, 161 funcs, 49.7% avg per-func coverage). Extracts the system-prompt assembly into a stand-alone `promptBuilder` type with closure-based snapshot accessors — no `Launcher`, `Broker`, or tmux dependency in the body.

- `internal/team/prompt_builder.go` — new type + the four pure helpers (`teamVoiceForSlug`, `markdownKnowledgeToolBlock`, `markdownKnowledgeMemoryBlock`, `headlessSandboxNote`)
- `internal/team/prompt_builder_test.go` — 13 new tests written test-first, exercising branches that were 0%-covered before (1:1 mode, codingAgentSlugs `gh pr create` instruction, focus-mode delegation block, deterministic ordering across member input orderings)
- `internal/team/launcher.go` — `buildPrompt` becomes a thin wrapper; `newPromptBuilder()` captures launcher state into the builder. -301 lines (-6%).

## Coverage

- `prompt_builder.go` is at **99.4%** per-file (gate: ≥85%)
- Package `internal/team` moved 62.9% → 63.3%
- `scripts/check-file-coverage.sh` from the plan PR enforces the gate; launcher.go stays untracked while it shrinks across the rest of the migration

## Companion docs / tooling

- `PLAN.md` (committed in 0aa22712) — staff-reviewed decomposition plan: 8 clusters, ordered low-to-high risk, 10 documented traps, test-seam strategy (reuse the existing `atomic.Pointer[fn]` override pattern; add `tmuxRunner` and `clock` interfaces for the goroutine/process clusters)
- `scripts/check-file-coverage.sh` — per-file coverage gate

## Test plan

- [x] `go build ./...`
- [x] `bash scripts/test-go.sh ./internal/team` (all green, 86s)
- [x] All 18 prompt-related tests pass: 13 new on `promptBuilder` directly, 5 existing `TestBuildPrompt*` characterization tests via `Launcher.buildPrompt`
- [x] `COVER_PROFILE=cov.out bash scripts/check-file-coverage.sh --pkg ./internal/team --min 85 --files internal/team/prompt_builder.go` → 99.4% OK
- [ ] CI green

## Next slices (separate stacked PRs)

C2 `officeTargeter` (member organization, pane targeting, headless routing) — pure read-only over broker snapshots, no goroutines. Will branch off this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured prompt generation system for improved modularity and maintainability.
  * Removed sandbox safety preface from headless mode prompts.

* **Tests**
  * Added comprehensive test suite for prompt generation with deterministic output validation.

* **Chores**
  * Added per-file coverage threshold enforcement script.
  * Created refactoring plan documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->