### PR TITLE
refactor(team): extract officeTargeter from launcher.go (C2)

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -142,6 +142,14 @@ type Launcher struct {
 	// queuePaneNotification uses this to decide whether to merge a new
 	// notification with a pending one or to start a fresh dispatch.
 	paneDispatchLastSentAt map[string]time.Time
+
+	// targets owns the office-membership-shape and routing-decision logic
+	// (PLAN.md §C2). Lazily constructed via targeter() so tests that build
+	// &Launcher{} directly stay nil-safe. The launcher field stays the
+	// authoritative source for sessionName / pack / failedPaneSlugs /
+	// paneBackedAgents — the targeter holds pointers/callbacks back into
+	// the launcher rather than copies.
+	targets *officeTargeter
 }
 
 // paneDispatchTurn is one queued notification to type into a tmux pane.
@@ -1013,12 +1021,19 @@ func (l *Launcher) sendTaskUpdate(target notificationTarget, action officeAction
 
 // isChannelDM returns true if the channel is a DM (either old dm-* format or new Store type).
 // agentTarget returns the agent slug that should receive the DM notification (non-human side).
+// isChannelDM is the public entry point used by dispatch code; targeter
+// reads the same logic via the isChannelDMRaw callback.
 func (l *Launcher) isChannelDM(channelSlug string) (isDM bool, agentTarget string) {
-	// Legacy format: dm-{agent}
+	return l.isChannelDMRaw(channelSlug)
+}
+
+// isChannelDMRaw resolves whether a channel is a direct-message channel
+// and, if so, which agent it targets. Two formats supported: the legacy
+// "dm-{agent}" slug and the new store format where channel.type == "D".
+func (l *Launcher) isChannelDMRaw(channelSlug string) (isDM bool, agentTarget string) {
 	if IsDMSlug(channelSlug) {
 		return true, DMTargetAgent(channelSlug)
 	}
-	// New store format: channel type == D
 	if l.broker != nil {
 		cs := l.broker.ChannelStore()
 		if cs != nil && cs.IsDirectMessageBySlug(channelSlug) {
@@ -1788,216 +1803,90 @@ func humanizeNotificationType(kind string) string {
 	}
 }
 
-func (l *Launcher) agentPaneSlugs() []string {
-	if l.isOneOnOne() {
-		return []string{l.oneOnOneAgent()}
+// targeter returns the office-targeter, lazily constructing it on first
+// access. PLAN.md trap §5.4: tests build &Launcher{} directly and rely on
+// every sub-type being nil-safe. The targeter shares mutable state with
+// the launcher via pointers/maps (paneBackedFlag, failedPaneSlugs) so
+// later mutations on the launcher are visible to the targeter immediately.
+func (l *Launcher) targeter() *officeTargeter {
+	if l == nil {
+		return nil
 	}
-	members := l.officeMembersSnapshot()
-	lead := l.officeLeadSlug()
-	var slugs []string
-	if lead != "" {
-		slugs = append(slugs, lead)
+	if l.targets != nil {
+		return l.targets
 	}
-	for _, member := range members {
-		if member.Slug == lead {
-			continue
-		}
-		slugs = append(slugs, member.Slug)
+	if l.failedPaneSlugs == nil {
+		l.failedPaneSlugs = map[string]string{}
 	}
-	return slugs
+	l.targets = &officeTargeter{
+		sessionName:        l.sessionName,
+		pack:               l.pack,
+		cwd:                l.cwd,
+		provider:           l.provider,
+		paneBackedFlag:     &l.paneBackedAgents,
+		failedPaneSlugs:    l.failedPaneSlugs,
+		isOneOnOne:         l.isOneOnOne,
+		oneOnOneSlug:       l.oneOnOneAgent,
+		isChannelDM:        l.isChannelDMRaw,
+		snapshotMembers:    l.officeMembersSnapshot,
+		memberProviderKind: l.brokerMemberProviderKind,
+	}
+	return l.targets
 }
 
-const maxVisibleOfficeAgents = 5
-
-func (l *Launcher) officeAgentOrder() []officeMember {
-	var agentOrder []officeMember
-	lead := l.officeLeadSlug()
-	for _, member := range l.officeMembersSnapshot() {
-		if member.Slug == lead {
-			agentOrder = append([]officeMember{member}, agentOrder...)
-		}
+// brokerMemberProviderKind reads the per-member provider override from the
+// broker, or "" when no broker is wired or no override is set.
+func (l *Launcher) brokerMemberProviderKind(slug string) string {
+	if l == nil || l.broker == nil {
+		return ""
 	}
-	for _, member := range l.officeMembersSnapshot() {
-		if member.Slug != lead {
-			agentOrder = append(agentOrder, member)
-		}
-	}
-	return agentOrder
+	return l.broker.MemberProviderKind(slug)
 }
+
+// agentPaneSlugs and friends are thin wrappers that delegate to the
+// targeter. Kept as Launcher methods so the ~110 callers across
+// internal/team don't need a sweep in this PR; consolidation is a
+// follow-up. PLAN.md §6 wants the call sites renamed eventually but the
+// bulk of the diff would be call-site churn rather than logic changes.
+
+func (l *Launcher) agentPaneSlugs() []string { return l.targeter().PaneSlugs() }
+
+func (l *Launcher) officeAgentOrder() []officeMember { return l.targeter().AgentOrder() }
 
 func (l *Launcher) visibleOfficeMembers() []officeMember {
-	if l.isOneOnOne() {
-		member := l.officeMemberBySlug(l.oneOnOneAgent())
-		return []officeMember{member}
-	}
-	ordered := l.paneEligibleOfficeMembers()
-	if len(ordered) <= maxVisibleOfficeAgents {
-		return ordered
-	}
-	return ordered[:maxVisibleOfficeAgents]
+	return l.targeter().VisibleMembers()
 }
 
 func (l *Launcher) overflowOfficeMembers() []officeMember {
-	if l.isOneOnOne() {
-		return nil
-	}
-	ordered := l.paneEligibleOfficeMembers()
-	if len(ordered) <= maxVisibleOfficeAgents {
-		return nil
-	}
-	return ordered[maxVisibleOfficeAgents:]
+	return l.targeter().OverflowMembers()
 }
 
-// paneEligibleOfficeMembers returns officeAgentOrder() minus agents that
-// should never get a tmux/claude pane (e.g. codex-bound agents, which use
-// their own headless pipeline). Filtering upstream keeps visible/overflow
-// slot indices in sync with agentPaneTargets().
 func (l *Launcher) paneEligibleOfficeMembers() []officeMember {
-	ordered := l.officeAgentOrder()
-	filtered := make([]officeMember, 0, len(ordered))
-	for _, m := range ordered {
-		if l.memberUsesHeadlessOneShotRuntime(m.Slug) {
-			continue
-		}
-		filtered = append(filtered, m)
-	}
-	return filtered
+	return l.targeter().PaneEligibleMembers()
 }
 
-func overflowWindowName(slug string) string {
-	return "agent-" + strings.TrimSpace(slug)
-}
-
-// resolvePaneTargetForSlug returns the current pane address for an agent
-// slug, or "" if the agent has no live pane right now. Called by the
-// pane-capture loop when its cached target keeps failing so it can pick
-// up new addresses after office reseeds recreate panes under different
-// ids. Returns ok=false when the agent isn't pane-backed at all (e.g.
-// codex-bound agents that dispatch headlessly).
 func (l *Launcher) resolvePaneTargetForSlug(slug string) (string, bool) {
-	if l == nil || slug == "" {
-		return "", false
-	}
-	targets := l.agentPaneTargets()
-	target, ok := targets[slug]
-	if !ok {
-		return "", false
-	}
-	return target.PaneTarget, true
+	return l.targeter().ResolvePaneTarget(slug)
 }
 
 func (l *Launcher) agentPaneTargets() map[string]notificationTarget {
-	targets := make(map[string]notificationTarget)
-	// Pane targets only make sense when tmux panes actually back the agents.
-	// Otherwise every PaneTarget string we return is a ghost pointing at a
-	// non-existent pane — and downstream code (agentNotificationTargets,
-	// shouldUseHeadlessDispatchForTarget) treats the non-empty PaneTarget as
-	// "pane path", which bypasses the headless dispatcher and types into a
-	// dead tmux session that silently drops every notification.
-	if l == nil || !l.paneBackedAgents {
-		return targets
-	}
-	if l.isOneOnOne() {
-		slug := l.oneOnOneAgent()
-		if slug != "" && !l.skipPaneForSlug(slug) {
-			targets[slug] = notificationTarget{
-				Slug:       slug,
-				PaneTarget: fmt.Sprintf("%s:team.1", l.sessionName),
-			}
-		}
-		return targets
-	}
-	for i, member := range l.visibleOfficeMembers() {
-		if l.skipPaneForSlug(member.Slug) {
-			continue
-		}
-		targets[member.Slug] = notificationTarget{
-			Slug:       member.Slug,
-			PaneTarget: fmt.Sprintf("%s:team.%d", l.sessionName, i+1),
-		}
-	}
-	for _, member := range l.overflowOfficeMembers() {
-		if l.skipPaneForSlug(member.Slug) {
-			continue
-		}
-		targets[member.Slug] = notificationTarget{
-			Slug:       member.Slug,
-			PaneTarget: fmt.Sprintf("%s:%s.0", l.sessionName, overflowWindowName(member.Slug)),
-		}
-	}
-	return targets
+	return l.targeter().PaneTargets()
 }
 
 func (l *Launcher) agentNotificationTargets() map[string]notificationTarget {
-	targets := l.agentPaneTargets()
-	if l == nil {
-		return targets
-	}
-	addHeadless := func(slug string) {
-		slug = strings.TrimSpace(slug)
-		if slug == "" {
-			return
-		}
-		if _, ok := targets[slug]; ok {
-			return
-		}
-		if l.shouldUseHeadlessDispatchForSlug(slug) {
-			targets[slug] = notificationTarget{Slug: slug}
-		}
-	}
-	if l.isOneOnOne() {
-		addHeadless(l.oneOnOneAgent())
-		return targets
-	}
-	addHeadless(l.officeLeadSlug())
-	for _, member := range l.activeSessionMembers() {
-		addHeadless(member.Slug)
-	}
-	return targets
+	return l.targeter().NotificationTargets()
 }
 
 func (l *Launcher) shouldUseHeadlessDispatchForSlug(slug string) bool {
-	if l == nil || strings.TrimSpace(slug) == "" {
-		return false
-	}
-	if l.shouldUseHeadlessDispatch() {
-		return true
-	}
-	if l.memberUsesHeadlessOneShotRuntime(slug) {
-		return true
-	}
-	if _, failed := l.failedPaneSlugs[strings.TrimSpace(slug)]; failed {
-		return true
-	}
-	return false
+	return l.targeter().ShouldUseHeadlessForSlug(slug)
 }
 
 func (l *Launcher) shouldUseHeadlessDispatchForTarget(target notificationTarget) bool {
-	if l == nil {
-		return false
-	}
-	if l.shouldUseHeadlessDispatchForSlug(target.Slug) {
-		return true
-	}
-	return strings.TrimSpace(target.PaneTarget) == ""
+	return l.targeter().ShouldUseHeadlessForTarget(target)
 }
 
-// skipPaneForSlug returns true when the given slug should not have a tmux
-// pane target registered — either because pane spawn failed earlier, or
-// because the agent is bound to a non-pane provider and uses its own headless
-// pipeline. In either case, dispatch falls back to the headless path.
 func (l *Launcher) skipPaneForSlug(slug string) bool {
-	slug = strings.TrimSpace(slug)
-	if slug == "" {
-		return true
-	}
-	if _, bad := l.failedPaneSlugs[slug]; bad {
-		return true
-	}
-	if l.memberUsesHeadlessOneShotRuntime(slug) {
-		return true
-	}
-	return false
+	return l.targeter().SkipPane(slug)
 }
 
 func (l *Launcher) isOneOnOne() bool {
@@ -2038,58 +1927,22 @@ func (l *Launcher) usesOpencodeRuntime() bool {
 	return strings.EqualFold(strings.TrimSpace(l.provider), "opencode")
 }
 
-// usesPaneRuntime reports whether the install-wide provider should run
-// agents in interactive tmux panes. Reads PaneEligible from the provider
-// Registry; an unregistered or non-pane-eligible provider returns false,
-// so dispatch falls through to the headless path.
-func (l *Launcher) usesPaneRuntime() bool {
-	return provider.CapabilitiesFor(normalizeProviderKind(l.provider)).PaneEligible
-}
+// usesPaneRuntime / requiresClaudeSessionReset / memberEffectiveProviderKind /
+// memberUsesHeadlessOneShotRuntime live on officeTargeter (PLAN.md §C2);
+// these wrappers keep ~30 in-package callers compiling without a rename
+// sweep in this PR.
+func (l *Launcher) usesPaneRuntime() bool { return l.targeter().UsesPaneRuntime() }
 
-// requiresClaudeSessionReset reports whether the install-wide provider
-// populates the Claude session store and therefore needs provider.ResetClaudeSessions
-// to run on ResetSession / ReconfigureSession. Today only Claude Code does.
 func (l *Launcher) requiresClaudeSessionReset() bool {
-	return provider.CapabilitiesFor(normalizeProviderKind(l.provider)).RequiresClaudeSessionReset
+	return l.targeter().RequiresClaudeSessionReset()
 }
 
-// memberEffectiveProviderKind returns the provider kind that should run the
-// given agent's next turn. Lookup order: member's per-agent ProviderBinding
-// (set via /agent create --provider=X or the hire-agent modal), then the
-// install-wide l.provider fallback.
 func (l *Launcher) memberEffectiveProviderKind(slug string) string {
-	if l.broker != nil {
-		if kind := l.broker.MemberProviderKind(slug); kind != "" {
-			return normalizeProviderKind(kind)
-		}
-	}
-	return normalizeProviderKind(l.provider)
+	return l.targeter().MemberEffectiveProviderKind(slug)
 }
 
-// memberUsesHeadlessOneShotRuntime reports whether the given agent is bound to
-// a runtime that is not pane-eligible and therefore skips the tmux/claude pane
-// infrastructure in favor of the broker-driven headless queue.
 func (l *Launcher) memberUsesHeadlessOneShotRuntime(slug string) bool {
-	kind := l.memberEffectiveProviderKind(slug)
-	return !provider.CapabilitiesFor(kind).PaneEligible
-}
-
-// normalizeProviderKind trims and canonicalizes provider kinds while
-// preserving unknown values so dispatch code can surface explicit errors.
-func normalizeProviderKind(raw string) string {
-	k := strings.ToLower(strings.TrimSpace(raw))
-	switch k {
-	case "claude", "":
-		return provider.KindClaudeCode
-	case "codex":
-		return provider.KindCodex
-	case "opencode":
-		return provider.KindOpencode
-	case "claude-code", "openclaw":
-		return k
-	default:
-		return k
-	}
+	return l.targeter().MemberUsesHeadlessOneShotRuntime(slug)
 }
 
 // UsesTmuxRuntime reports whether agents run in tmux panes. Equivalent to
@@ -2946,17 +2799,9 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 	l.queuePaneNotification(target.Slug, target.PaneTarget, notification)
 }
 
-// shouldUseHeadlessDispatch returns true when notifications must be delivered
-// via a queued headless `claude --print` turn rather than typed into a live
-// interactive pane. This is the default path for both web and TUI modes.
-// Codex runtime is always headless. Pane-backed interactive dispatch is only
-// used when the fallback path explicitly brought panes up (paneBackedAgents).
-func (l *Launcher) shouldUseHeadlessDispatch() bool {
-	if !l.usesPaneRuntime() {
-		return true
-	}
-	return !l.paneBackedAgents
-}
+// shouldUseHeadlessDispatch is a thin wrapper around the targeter; see
+// officeTargeter.ShouldUseHeadless for semantics.
+func (l *Launcher) shouldUseHeadlessDispatch() bool { return l.targeter().ShouldUseHeadless() }
 
 // Minimum gap between two consecutive pane `/clear` + type cycles for the
 // same agent. Serves as a safety floor against truly back-to-back sends
@@ -4256,40 +4101,14 @@ func (l *Launcher) BrokerBaseURL() string {
 	return brokerBaseURL()
 }
 
+// officeMemberBySlug / officeLeadSlug / activeSessionMembers / getAgentName
+// live on officeTargeter (PLAN.md §C2); thin wrappers keep current callers
+// working without a rename sweep.
 func (l *Launcher) officeMemberBySlug(slug string) officeMember {
-	for _, member := range l.officeMembersSnapshot() {
-		if member.Slug == slug {
-			return member
-		}
-	}
-	return officeMember{Slug: slug, Name: slug, Role: slug}
+	return l.targeter().MemberBySlug(slug)
 }
 
-func (l *Launcher) officeLeadSlug() string {
-	if l.pack != nil && strings.TrimSpace(l.pack.LeadSlug) != "" {
-		return l.pack.LeadSlug
-	}
-	return officeLeadSlugFrom(l.activeSessionMembers())
-}
-
-// officeLeadSlugFrom derives the lead slug from an already-loaded member
-// snapshot, avoiding a redundant officeMembersSnapshot call.
-func officeLeadSlugFrom(members []officeMember) string {
-	for _, member := range members {
-		if member.Slug == "ceo" {
-			return "ceo"
-		}
-	}
-	for _, member := range members {
-		if member.BuiltIn {
-			return member.Slug
-		}
-	}
-	if len(members) > 0 {
-		return members[0].Slug
-	}
-	return ""
-}
+func (l *Launcher) officeLeadSlug() string { return l.targeter().LeadSlug() }
 
 func agentConfigFromMember(member officeMember) agent.AgentConfig {
 	cfg := agent.AgentConfig{
@@ -4313,50 +4132,7 @@ func agentConfigFromMember(member officeMember) agent.AgentConfig {
 }
 
 func (l *Launcher) activeSessionMembers() []officeMember {
-	members := l.officeMembersSnapshot()
-	if l == nil || l.pack == nil || len(l.pack.Agents) == 0 {
-		return members
-	}
-	bySlug := make(map[string]officeMember, len(members))
-	for _, member := range members {
-		bySlug[member.Slug] = member
-	}
-	// Pack order comes first (stable UI / pane layout), then any broker
-	// members not in the pack (wizard-hired agents post-launch). Dropping
-	// broker-only members here silently excluded wizard-hired specialists
-	// from agentNotificationTargets, making @-tags and DMs route to CEO.
-	filtered := make([]officeMember, 0, len(members))
-	seen := make(map[string]struct{}, len(members))
-	for _, cfg := range l.pack.Agents {
-		if member, ok := bySlug[cfg.Slug]; ok {
-			filtered = append(filtered, member)
-			seen[cfg.Slug] = struct{}{}
-			continue
-		}
-		member := officeMember{
-			Slug:           cfg.Slug,
-			Name:           cfg.Name,
-			Role:           cfg.Name,
-			Expertise:      append([]string(nil), cfg.Expertise...),
-			Personality:    cfg.Personality,
-			PermissionMode: cfg.PermissionMode,
-			AllowedTools:   append([]string(nil), cfg.AllowedTools...),
-			BuiltIn:        cfg.Slug == l.pack.LeadSlug || cfg.Slug == "ceo",
-		}
-		applyOfficeMemberDefaults(&member)
-		filtered = append(filtered, member)
-		seen[cfg.Slug] = struct{}{}
-	}
-	for _, member := range members {
-		if _, ok := seen[member.Slug]; ok {
-			continue
-		}
-		filtered = append(filtered, member)
-	}
-	if len(filtered) > 0 {
-		return filtered
-	}
-	return members
+	return l.targeter().ActiveSessionMembers()
 }
 
 // PackName returns the display name of the pack.
@@ -4387,13 +4163,9 @@ func filterEnv(env []string, key string) []string {
 	return out
 }
 
-// getAgentName returns the display name for an agent slug.
-func (l *Launcher) getAgentName(slug string) string {
-	if member := l.officeMemberBySlug(slug); member.Name != "" {
-		return member.Name
-	}
-	return slug
-}
+// getAgentName returns the display name for an agent slug. Delegates to
+// the targeter (PLAN.md §C2).
+func (l *Launcher) getAgentName(slug string) string { return l.targeter().NameFor(slug) }
 
 // ═══════════════════════════════════════════════════════════════
 // Web View Mode

--- a/internal/team/office_targets.go
+++ b/internal/team/office_targets.go
@@ -11,9 +11,12 @@ package team
 //     pane-spawn path flips that bool deep inside trySpawnWebAgentPanes;
 //     reading via pointer keeps the targeter in sync without callbacks.
 //   - failedPaneSlugs is a shared map. Today it's read here, written by the
-//     pane-spawn path (still on Launcher). The shared-map race is pre-
-//     existing (writes happen sequentially during Launch); when C5 lands
-//     paneLifecycle this becomes failedPane(slug) func, removing the dangle.
+//     pane-spawn path (still on Launcher). No mutex — the race is dormant
+//     only because trySpawnWebAgentPanes is a runtime-promotion fallback
+//     that nothing currently invokes (see launcher.go:2647 / 3470). The
+//     moment promotion is wired, or any concurrent reader of the targeter
+//     overlaps the writer, this races. C5 (paneLifecycle) replaces this
+//     with a failedPane(slug) callback and removes the shared map entirely.
 
 import (
 	"fmt"

--- a/internal/team/office_targets.go
+++ b/internal/team/office_targets.go
@@ -1,0 +1,468 @@
+package team
+
+// office_targets.go owns the "which agent gets which pane / dispatch path"
+// decision tree that used to live as a dozen methods on Launcher. The split
+// (PLAN.md §C2) is justified because the logic is pure data-shape over a
+// snapshot of office membership — no goroutines, no tmux, no broker writes
+// — so it can be exercised by tests without a Launcher fixture.
+//
+// State sharing notes (PLAN.md §5 traps):
+//   - paneBackedFlag is a *bool aliased to launcher.paneBackedAgents. The
+//     pane-spawn path flips that bool deep inside trySpawnWebAgentPanes;
+//     reading via pointer keeps the targeter in sync without callbacks.
+//   - failedPaneSlugs is a shared map. Today it's read here, written by the
+//     pane-spawn path (still on Launcher). The shared-map race is pre-
+//     existing (writes happen sequentially during Launch); when C5 lands
+//     paneLifecycle this becomes failedPane(slug) func, removing the dangle.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// officeTargeter owns office-membership-shape and routing-decision logic.
+// All inputs come in via either captured-at-construction values (sessionName,
+// pack, provider) or callbacks (snapshotMembers, isOneOnOne, ...). The type
+// is package-internal; callers in package team get to it via Launcher.targets().
+type officeTargeter struct {
+	sessionName string
+	pack        *agent.PackDefinition
+	cwd         string
+	provider    string
+
+	// paneBackedFlag is a back-pointer to launcher.paneBackedAgents so the
+	// targeter sees the live value as the spawn path flips it. Required —
+	// duplicating the flag would cause every notification to route through
+	// the headless path silently when panes were actually live (PLAN.md §5.2).
+	paneBackedFlag *bool
+
+	// failedPaneSlugs is the shared map of slugs whose pane spawn failed.
+	// Written by the pane-spawn path on Launcher; read here. Map sharing
+	// across types is a deliberate transitional state — see file header.
+	failedPaneSlugs map[string]string
+
+	// Live-state callbacks. Pulled rather than pushed so tests can stub.
+	isOneOnOne         func() bool
+	oneOnOneSlug       func() string
+	isChannelDM        func(channelSlug string) (bool, string)
+	snapshotMembers    func() []officeMember
+	memberProviderKind func(slug string) string
+}
+
+// MembersSnapshot returns the current member roster. Backed by the
+// snapshotMembers callback so the targeter never knows about FS reads or
+// broker calls itself.
+func (o *officeTargeter) MembersSnapshot() []officeMember {
+	if o == nil || o.snapshotMembers == nil {
+		return nil
+	}
+	return o.snapshotMembers()
+}
+
+// MemberBySlug walks the snapshot and returns the matching member, or a
+// minimal officeMember{Slug, Name=Slug, Role=Slug} fallback so callers
+// always get a well-formed value. The fallback shape matters for prompt
+// generation, which interpolates Name into the system prompt header.
+func (o *officeTargeter) MemberBySlug(slug string) officeMember {
+	for _, m := range o.MembersSnapshot() {
+		if m.Slug == slug {
+			return m
+		}
+	}
+	return officeMember{Slug: slug, Name: slug, Role: slug}
+}
+
+// LeadSlug picks the team lead. Pack-defined lead wins; otherwise fall
+// back to the first BuiltIn member, then to the first member overall.
+// Mirrors the previous Launcher.officeLeadSlug fallback chain so prompt
+// caching keys remain stable across refactors.
+func (o *officeTargeter) LeadSlug() string {
+	if o == nil {
+		return ""
+	}
+	if o.pack != nil && strings.TrimSpace(o.pack.LeadSlug) != "" {
+		return o.pack.LeadSlug
+	}
+	return officeLeadSlugFrom(o.ActiveSessionMembers())
+}
+
+// officeLeadSlugFrom is a free function (kept package-level) so the prompt
+// builder can derive the lead from an already-loaded member snapshot
+// without a redundant snapshotMembers call.
+func officeLeadSlugFrom(members []officeMember) string {
+	for _, member := range members {
+		if member.Slug == "ceo" {
+			return "ceo"
+		}
+	}
+	for _, member := range members {
+		if member.BuiltIn {
+			return member.Slug
+		}
+	}
+	if len(members) > 0 {
+		return members[0].Slug
+	}
+	return ""
+}
+
+// ActiveSessionMembers returns the current member list ordered by pack
+// position, with broker-only (wizard-hired) members appended at the end.
+// Pack-order matters because the UI/pane layout uses this list directly:
+// reordering would shuffle pane indices on every Launch.
+func (o *officeTargeter) ActiveSessionMembers() []officeMember {
+	members := o.MembersSnapshot()
+	if o == nil || o.pack == nil || len(o.pack.Agents) == 0 {
+		return members
+	}
+	bySlug := make(map[string]officeMember, len(members))
+	for _, member := range members {
+		bySlug[member.Slug] = member
+	}
+	filtered := make([]officeMember, 0, len(members))
+	seen := make(map[string]struct{}, len(members))
+	for _, cfg := range o.pack.Agents {
+		if member, ok := bySlug[cfg.Slug]; ok {
+			filtered = append(filtered, member)
+			seen[cfg.Slug] = struct{}{}
+			continue
+		}
+		member := officeMember{
+			Slug:           cfg.Slug,
+			Name:           cfg.Name,
+			Role:           cfg.Name,
+			Expertise:      append([]string(nil), cfg.Expertise...),
+			Personality:    cfg.Personality,
+			PermissionMode: cfg.PermissionMode,
+			AllowedTools:   append([]string(nil), cfg.AllowedTools...),
+			BuiltIn:        cfg.Slug == o.pack.LeadSlug || cfg.Slug == "ceo",
+		}
+		applyOfficeMemberDefaults(&member)
+		filtered = append(filtered, member)
+		seen[cfg.Slug] = struct{}{}
+	}
+	for _, member := range members {
+		if _, ok := seen[member.Slug]; ok {
+			continue
+		}
+		filtered = append(filtered, member)
+	}
+	if len(filtered) > 0 {
+		return filtered
+	}
+	return members
+}
+
+// NameFor returns the display name for a slug; falls back to the slug
+// itself when no member or an unnamed member matches.
+func (o *officeTargeter) NameFor(slug string) string {
+	if member := o.MemberBySlug(slug); member.Name != "" {
+		return member.Name
+	}
+	return slug
+}
+
+// AgentOrder returns the member roster with the lead slug always first.
+// Used by pane spawn to guarantee the CEO pane lands at index 1.
+func (o *officeTargeter) AgentOrder() []officeMember {
+	var agentOrder []officeMember
+	lead := o.LeadSlug()
+	for _, member := range o.MembersSnapshot() {
+		if member.Slug == lead {
+			agentOrder = append([]officeMember{member}, agentOrder...)
+		}
+	}
+	for _, member := range o.MembersSnapshot() {
+		if member.Slug != lead {
+			agentOrder = append(agentOrder, member)
+		}
+	}
+	return agentOrder
+}
+
+// PaneSlugs returns the slug list in spawn order. In 1:1 mode it returns
+// just the active 1:1 agent.
+func (o *officeTargeter) PaneSlugs() []string {
+	if o.isOneOnOne != nil && o.isOneOnOne() {
+		return []string{o.oneOnOneSlug()}
+	}
+	members := o.MembersSnapshot()
+	lead := o.LeadSlug()
+	var slugs []string
+	if lead != "" {
+		slugs = append(slugs, lead)
+	}
+	for _, member := range members {
+		if member.Slug == lead {
+			continue
+		}
+		slugs = append(slugs, member.Slug)
+	}
+	return slugs
+}
+
+// VisibleMembers returns the agents that occupy the visible tmux pane grid
+// (lead first, then up to maxVisibleOfficeAgents-1 others). 1:1 mode
+// collapses to a single member.
+func (o *officeTargeter) VisibleMembers() []officeMember {
+	if o.isOneOnOne != nil && o.isOneOnOne() {
+		return []officeMember{o.MemberBySlug(o.oneOnOneSlug())}
+	}
+	ordered := o.PaneEligibleMembers()
+	if len(ordered) <= maxVisibleOfficeAgents {
+		return ordered
+	}
+	return ordered[:maxVisibleOfficeAgents]
+}
+
+// OverflowMembers returns agents beyond the visible grid; each gets its
+// own dedicated tmux window (named via overflowWindowName).
+func (o *officeTargeter) OverflowMembers() []officeMember {
+	if o.isOneOnOne != nil && o.isOneOnOne() {
+		return nil
+	}
+	ordered := o.PaneEligibleMembers()
+	if len(ordered) <= maxVisibleOfficeAgents {
+		return nil
+	}
+	return ordered[maxVisibleOfficeAgents:]
+}
+
+// PaneEligibleMembers is AgentOrder() minus members whose runtime is not
+// pane-eligible (Codex, Opencode). Filtering upstream keeps visible/overflow
+// indices in sync with PaneTargets().
+func (o *officeTargeter) PaneEligibleMembers() []officeMember {
+	ordered := o.AgentOrder()
+	filtered := make([]officeMember, 0, len(ordered))
+	for _, m := range ordered {
+		if o.MemberUsesHeadlessOneShotRuntime(m.Slug) {
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
+}
+
+// PaneTargets returns slug→pane-address for every agent that should
+// receive notifications by typing into a live tmux pane. Returns empty
+// when panes aren't live (paneBackedFlag=false) so callers consistently
+// fall through to the headless dispatcher.
+func (o *officeTargeter) PaneTargets() map[string]notificationTarget {
+	targets := make(map[string]notificationTarget)
+	if o == nil || o.paneBackedFlag == nil || !*o.paneBackedFlag {
+		return targets
+	}
+	if o.isOneOnOne != nil && o.isOneOnOne() {
+		slug := o.oneOnOneSlug()
+		if slug != "" && !o.SkipPane(slug) {
+			targets[slug] = notificationTarget{
+				Slug:       slug,
+				PaneTarget: fmt.Sprintf("%s:team.1", o.sessionName),
+			}
+		}
+		return targets
+	}
+	for i, member := range o.VisibleMembers() {
+		if o.SkipPane(member.Slug) {
+			continue
+		}
+		targets[member.Slug] = notificationTarget{
+			Slug:       member.Slug,
+			PaneTarget: fmt.Sprintf("%s:team.%d", o.sessionName, i+1),
+		}
+	}
+	for _, member := range o.OverflowMembers() {
+		if o.SkipPane(member.Slug) {
+			continue
+		}
+		targets[member.Slug] = notificationTarget{
+			Slug:       member.Slug,
+			PaneTarget: fmt.Sprintf("%s:%s.0", o.sessionName, overflowWindowName(member.Slug)),
+		}
+	}
+	return targets
+}
+
+// NotificationTargets layers headless fallback entries on top of the pane
+// target map. An agent without a pane target — either because pane spawn
+// failed or because its provider is non-pane — still gets a target entry
+// (with empty PaneTarget) so dispatch can route it through the headless
+// queue.
+func (o *officeTargeter) NotificationTargets() map[string]notificationTarget {
+	targets := o.PaneTargets()
+	if o == nil {
+		return targets
+	}
+	addHeadless := func(slug string) {
+		slug = strings.TrimSpace(slug)
+		if slug == "" {
+			return
+		}
+		if _, ok := targets[slug]; ok {
+			return
+		}
+		if o.ShouldUseHeadlessForSlug(slug) {
+			targets[slug] = notificationTarget{Slug: slug}
+		}
+	}
+	if o.isOneOnOne != nil && o.isOneOnOne() {
+		addHeadless(o.oneOnOneSlug())
+		return targets
+	}
+	addHeadless(o.LeadSlug())
+	for _, member := range o.ActiveSessionMembers() {
+		addHeadless(member.Slug)
+	}
+	return targets
+}
+
+// ResolvePaneTarget returns the live pane address for slug, or
+// ("", false) when slug isn't pane-backed (codex/opencode agents,
+// failed-pane fallbacks, or empty slugs).
+func (o *officeTargeter) ResolvePaneTarget(slug string) (string, bool) {
+	if o == nil || strings.TrimSpace(slug) == "" {
+		return "", false
+	}
+	targets := o.PaneTargets()
+	target, ok := targets[slug]
+	if !ok {
+		return "", false
+	}
+	return target.PaneTarget, true
+}
+
+// IsChannelDM proxies to the wired channel-DM resolver. Returns false,
+// "" when nothing is wired so callers don't need a nil-check.
+func (o *officeTargeter) IsChannelDM(channelSlug string) (bool, string) {
+	if o == nil || o.isChannelDM == nil {
+		return false, ""
+	}
+	return o.isChannelDM(channelSlug)
+}
+
+// ShouldUseHeadless returns true when notifications must go through the
+// headless `claude --print` queue rather than into a live pane. The
+// install-wide answer based on provider + paneBacked state.
+func (o *officeTargeter) ShouldUseHeadless() bool {
+	if !o.UsesPaneRuntime() {
+		return true
+	}
+	if o.paneBackedFlag == nil {
+		return true
+	}
+	return !*o.paneBackedFlag
+}
+
+// ShouldUseHeadlessForSlug answers the same question per-slug. Layered on
+// top of ShouldUseHeadless: an individual slug can be forced headless even
+// in a pane-backed install (Codex member, failed pane spawn).
+func (o *officeTargeter) ShouldUseHeadlessForSlug(slug string) bool {
+	if o == nil || strings.TrimSpace(slug) == "" {
+		return false
+	}
+	if o.ShouldUseHeadless() {
+		return true
+	}
+	if o.MemberUsesHeadlessOneShotRuntime(slug) {
+		return true
+	}
+	if _, failed := o.failedPaneSlugs[strings.TrimSpace(slug)]; failed {
+		return true
+	}
+	return false
+}
+
+// ShouldUseHeadlessForTarget treats a target with an empty PaneTarget as
+// implicitly headless. Used by the dispatch hot path.
+func (o *officeTargeter) ShouldUseHeadlessForTarget(target notificationTarget) bool {
+	if o == nil {
+		return false
+	}
+	if o.ShouldUseHeadlessForSlug(target.Slug) {
+		return true
+	}
+	return strings.TrimSpace(target.PaneTarget) == ""
+}
+
+// SkipPane reports whether slug should be excluded from pane spawn /
+// pane-target maps. True when the slug is empty, when its pane spawn
+// previously failed, or when its runtime isn't pane-eligible.
+func (o *officeTargeter) SkipPane(slug string) bool {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return true
+	}
+	if _, bad := o.failedPaneSlugs[slug]; bad {
+		return true
+	}
+	if o.MemberUsesHeadlessOneShotRuntime(slug) {
+		return true
+	}
+	return false
+}
+
+// UsesPaneRuntime reports whether the install-wide provider supports
+// interactive panes. Provider Registry-driven so future providers don't
+// need code changes here.
+func (o *officeTargeter) UsesPaneRuntime() bool {
+	return provider.CapabilitiesFor(normalizeProviderKind(o.provider)).PaneEligible
+}
+
+// RequiresClaudeSessionReset reports whether the install-wide provider
+// populates the Claude session store and therefore needs
+// provider.ResetClaudeSessions to run on ResetSession / ReconfigureSession.
+// Today only Claude Code does.
+func (o *officeTargeter) RequiresClaudeSessionReset() bool {
+	return provider.CapabilitiesFor(normalizeProviderKind(o.provider)).RequiresClaudeSessionReset
+}
+
+// MemberEffectiveProviderKind returns the provider kind that should run
+// the given agent's next turn. Lookup order: per-member override (set via
+// /agent create --provider=X or the hire-agent modal), then the
+// install-wide provider.
+func (o *officeTargeter) MemberEffectiveProviderKind(slug string) string {
+	if o.memberProviderKind != nil {
+		if kind := o.memberProviderKind(slug); kind != "" {
+			return normalizeProviderKind(kind)
+		}
+	}
+	return normalizeProviderKind(o.provider)
+}
+
+// MemberUsesHeadlessOneShotRuntime reports whether the given agent is bound
+// to a non-pane-eligible runtime and therefore skips the tmux/claude pane
+// infrastructure in favor of the broker-driven headless queue.
+func (o *officeTargeter) MemberUsesHeadlessOneShotRuntime(slug string) bool {
+	kind := o.MemberEffectiveProviderKind(slug)
+	return !provider.CapabilitiesFor(kind).PaneEligible
+}
+
+// overflowWindowName is package-level so the pane-lifecycle code (which
+// will move in C5) can keep calling it during the transitional state.
+func overflowWindowName(slug string) string {
+	return "agent-" + strings.TrimSpace(slug)
+}
+
+// normalizeProviderKind trims and canonicalizes provider kinds while
+// preserving unknown values so dispatch code can surface explicit errors.
+// Free function (used by tests, dispatch code, and the targeter itself).
+func normalizeProviderKind(raw string) string {
+	k := strings.ToLower(strings.TrimSpace(raw))
+	switch k {
+	case "claude", "":
+		return provider.KindClaudeCode
+	case "codex":
+		return provider.KindCodex
+	case "opencode":
+		return provider.KindOpencode
+	case "claude-code", "openclaw":
+		return k
+	default:
+		return k
+	}
+}
+
+const maxVisibleOfficeAgents = 5

--- a/internal/team/office_targets_test.go
+++ b/internal/team/office_targets_test.go
@@ -1,0 +1,445 @@
+package team
+
+// Tests for the extracted officeTargeter type. Written test-first against
+// the surface in PLAN.md §C2 before the type exists, so the first run is a
+// compile failure by design.
+//
+// Coverage focus: the routing-decision branches that were 0% before
+// (overflow window naming, pane-failed fallback, headless-one-shot routing,
+// 1:1 mode collapsing the targets map). Most existing tests reach this
+// surface via &Launcher{...}; the new tests exercise the type directly so
+// we don't need a tmux-shaped fixture to assert pane address formats.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// fixtureTargeter builds an officeTargeter with sane defaults; tests
+// override only the bits they care about.
+func fixtureTargeter(t *testing.T, members []officeMember, opts ...func(*officeTargeter)) *officeTargeter {
+	t.Helper()
+	paneBacked := true
+	failed := map[string]string{}
+	tg := &officeTargeter{
+		sessionName:     "test-sess",
+		pack:            &agent.PackDefinition{LeadSlug: "ceo"},
+		provider:        provider.KindClaudeCode,
+		paneBackedFlag:  &paneBacked,
+		failedPaneSlugs: failed,
+		isOneOnOne:      func() bool { return false },
+		oneOnOneSlug:    func() string { return "" },
+		isChannelDM:     func(string) (bool, string) { return false, "" },
+		snapshotMembers: func() []officeMember {
+			return append([]officeMember(nil), members...)
+		},
+		memberProviderKind: func(string) string { return "" },
+	}
+	for _, opt := range opts {
+		opt(tg)
+	}
+	return tg
+}
+
+func TestTargeter_LeadSlug_PrefersPackLead(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+	})
+	if got := tg.LeadSlug(); got != "ceo" {
+		t.Errorf("LeadSlug() = %q, want %q", got, "ceo")
+	}
+}
+
+func TestTargeter_LeadSlug_FallsBackToBuiltIn(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "alpha", BuiltIn: true},
+		{Slug: "beta"},
+	}, func(o *officeTargeter) { o.pack = &agent.PackDefinition{} })
+	if got := tg.LeadSlug(); got != "alpha" {
+		t.Errorf("LeadSlug() = %q, want %q", got, "alpha")
+	}
+}
+
+func TestTargeter_LeadSlug_FallsBackToFirstMember(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "alpha"},
+		{Slug: "beta"},
+	}, func(o *officeTargeter) { o.pack = &agent.PackDefinition{} })
+	if got := tg.LeadSlug(); got != "alpha" {
+		t.Errorf("LeadSlug() = %q, want %q", got, "alpha")
+	}
+}
+
+func TestTargeter_LeadSlug_EmptyWhenNoMembers(t *testing.T) {
+	tg := fixtureTargeter(t, nil, func(o *officeTargeter) { o.pack = &agent.PackDefinition{} })
+	if got := tg.LeadSlug(); got != "" {
+		t.Errorf("LeadSlug() = %q, want empty", got)
+	}
+}
+
+func TestTargeter_AgentOrder_LeadFirst(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "fe"},
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "be"},
+	})
+	got := tg.AgentOrder()
+	if len(got) == 0 || got[0].Slug != "ceo" {
+		t.Fatalf("AgentOrder()[0] = %v, want ceo first; full: %v", got, got)
+	}
+}
+
+func TestTargeter_PaneEligibleMembers_ExcludesHeadlessOneShot(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "codexer"},
+	}, func(o *officeTargeter) {
+		o.memberProviderKind = func(slug string) string {
+			if slug == "codexer" {
+				return provider.KindCodex
+			}
+			return ""
+		}
+	})
+	got := tg.PaneEligibleMembers()
+	for _, m := range got {
+		if m.Slug == "codexer" {
+			t.Fatalf("PaneEligibleMembers should exclude headless-one-shot member; got %v", got)
+		}
+	}
+}
+
+func TestTargeter_VisibleAndOverflow_RespectsCap(t *testing.T) {
+	members := []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+	}
+	for _, s := range []string{"a", "b", "c", "d", "e", "f"} {
+		members = append(members, officeMember{Slug: s})
+	}
+	tg := fixtureTargeter(t, members)
+	visible := tg.VisibleMembers()
+	overflow := tg.OverflowMembers()
+	if len(visible) != maxVisibleOfficeAgents {
+		t.Fatalf("VisibleMembers length = %d, want %d", len(visible), maxVisibleOfficeAgents)
+	}
+	if len(visible)+len(overflow) != len(members) {
+		t.Fatalf("visible+overflow = %d, want %d", len(visible)+len(overflow), len(members))
+	}
+	if visible[0].Slug != "ceo" {
+		t.Errorf("VisibleMembers[0] = %q, want ceo first", visible[0].Slug)
+	}
+}
+
+func TestTargeter_OverflowWindowName(t *testing.T) {
+	if got := overflowWindowName("designer"); got != "agent-designer" {
+		t.Errorf("overflowWindowName(designer) = %q, want agent-designer", got)
+	}
+}
+
+func TestTargeter_PaneTargets_OneOnOne(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+	}, func(o *officeTargeter) {
+		o.isOneOnOne = func() bool { return true }
+		o.oneOnOneSlug = func() string { return "fe" }
+	})
+	targets := tg.PaneTargets()
+	if len(targets) != 1 {
+		t.Fatalf("PaneTargets() len = %d, want 1; got %v", len(targets), targets)
+	}
+	tgt, ok := targets["fe"]
+	if !ok {
+		t.Fatalf("PaneTargets() missing fe entry: %v", targets)
+	}
+	if tgt.PaneTarget != "test-sess:team.1" {
+		t.Errorf("PaneTarget = %q, want test-sess:team.1", tgt.PaneTarget)
+	}
+}
+
+func TestTargeter_PaneTargets_VisibleAndOverflowAddresses(t *testing.T) {
+	members := []officeMember{{Slug: "ceo", BuiltIn: true}}
+	for _, s := range []string{"a", "b", "c", "d", "e", "f"} {
+		members = append(members, officeMember{Slug: s})
+	}
+	tg := fixtureTargeter(t, members)
+	targets := tg.PaneTargets()
+
+	// First 5 entries are addressed test-sess:team.{1..5} in pack order.
+	visible := tg.VisibleMembers()
+	for i, m := range visible {
+		want := "test-sess:team." + itoa(i+1)
+		if got := targets[m.Slug].PaneTarget; got != want {
+			t.Errorf("PaneTarget[%s] = %q, want %q", m.Slug, got, want)
+		}
+	}
+	// Overflow: each in its own window addressed test-sess:agent-{slug}.0
+	overflow := tg.OverflowMembers()
+	for _, m := range overflow {
+		want := "test-sess:agent-" + m.Slug + ".0"
+		if got := targets[m.Slug].PaneTarget; got != want {
+			t.Errorf("PaneTarget[%s] (overflow) = %q, want %q", m.Slug, got, want)
+		}
+	}
+}
+
+func TestTargeter_PaneTargets_EmptyWhenNotPaneBacked(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{{Slug: "ceo", BuiltIn: true}}, func(o *officeTargeter) {
+		f := false
+		o.paneBackedFlag = &f
+	})
+	if targets := tg.PaneTargets(); len(targets) != 0 {
+		t.Fatalf("PaneTargets when not pane-backed should be empty, got %v", targets)
+	}
+}
+
+func TestTargeter_PaneTargets_SkipsFailedSlugs(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+	}, func(o *officeTargeter) {
+		o.failedPaneSlugs["fe"] = "boom"
+	})
+	targets := tg.PaneTargets()
+	if _, ok := targets["fe"]; ok {
+		t.Fatalf("expected fe to be skipped from PaneTargets when in failedPaneSlugs; got %v", targets)
+	}
+	if _, ok := targets["ceo"]; !ok {
+		t.Fatalf("expected ceo to remain in PaneTargets")
+	}
+}
+
+func TestTargeter_NotificationTargets_AddsHeadlessFallbackForFailedPaneSlug(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+	}, func(o *officeTargeter) {
+		o.failedPaneSlugs["fe"] = "spawn failed"
+	})
+	targets := tg.NotificationTargets()
+	tgt, ok := targets["fe"]
+	if !ok {
+		t.Fatalf("NotificationTargets missing fe: %v", targets)
+	}
+	if tgt.PaneTarget != "" {
+		t.Errorf("fe should fall back to headless (empty PaneTarget); got %q", tgt.PaneTarget)
+	}
+}
+
+func TestTargeter_NotificationTargets_OneOnOneCollapsesToSingleAgent(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+	}, func(o *officeTargeter) {
+		o.isOneOnOne = func() bool { return true }
+		o.oneOnOneSlug = func() string { return "fe" }
+	})
+	targets := tg.NotificationTargets()
+	if _, ok := targets["fe"]; !ok {
+		t.Fatalf("expected fe in NotificationTargets, got %v", targets)
+	}
+	if _, ok := targets["ceo"]; ok {
+		t.Fatalf("ceo should be excluded in 1:1 mode, got %v", targets)
+	}
+}
+
+func TestTargeter_ShouldUseHeadlessForSlug_TruthTable(t *testing.T) {
+	cases := []struct {
+		name   string
+		setup  func(*officeTargeter)
+		slug   string
+		want   bool
+		reason string
+	}{
+		{
+			name: "non-pane runtime ⇒ headless",
+			setup: func(o *officeTargeter) {
+				o.provider = provider.KindCodex
+			},
+			slug: "ceo", want: true, reason: "codex provider is non-pane",
+		},
+		{
+			name:  "pane runtime + pane backed + clean slug ⇒ pane",
+			setup: func(*officeTargeter) {},
+			slug:  "ceo", want: false, reason: "default Claude path",
+		},
+		{
+			name: "pane runtime + not pane backed ⇒ headless",
+			setup: func(o *officeTargeter) {
+				f := false
+				o.paneBackedFlag = &f
+			},
+			slug: "ceo", want: true, reason: "no live panes",
+		},
+		{
+			name: "pane runtime + failed pane slug ⇒ headless",
+			setup: func(o *officeTargeter) {
+				o.failedPaneSlugs["ceo"] = "spawn failed"
+			},
+			slug: "ceo", want: true, reason: "fallback path",
+		},
+		{
+			name: "pane runtime + member bound to codex ⇒ headless",
+			setup: func(o *officeTargeter) {
+				o.memberProviderKind = func(slug string) string {
+					if slug == "ceo" {
+						return provider.KindCodex
+					}
+					return ""
+				}
+			},
+			slug: "ceo", want: true, reason: "per-member provider override",
+		},
+		{
+			name:  "empty slug ⇒ false (defensive)",
+			setup: func(*officeTargeter) {},
+			slug:  "  ", want: false, reason: "no slug, no decision",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tg := fixtureTargeter(t, []officeMember{{Slug: "ceo", BuiltIn: true}}, tc.setup)
+			if got := tg.ShouldUseHeadlessForSlug(tc.slug); got != tc.want {
+				t.Errorf("ShouldUseHeadlessForSlug(%q) = %v, want %v (%s)", tc.slug, got, tc.want, tc.reason)
+			}
+		})
+	}
+}
+
+func TestTargeter_ShouldUseHeadlessForTarget_EmptyPaneTargetIsHeadless(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{{Slug: "ceo", BuiltIn: true}})
+	if !tg.ShouldUseHeadlessForTarget(notificationTarget{Slug: "ceo", PaneTarget: ""}) {
+		t.Errorf("empty PaneTarget should mean headless dispatch")
+	}
+}
+
+func TestTargeter_SkipPane_FailedAndHeadlessOneShot(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+		{Slug: "codexer"},
+	}, func(o *officeTargeter) {
+		o.failedPaneSlugs["fe"] = "boom"
+		o.memberProviderKind = func(s string) string {
+			if s == "codexer" {
+				return provider.KindCodex
+			}
+			return ""
+		}
+	})
+	if !tg.SkipPane("fe") {
+		t.Errorf("SkipPane(fe) = false, want true (failed pane)")
+	}
+	if !tg.SkipPane("codexer") {
+		t.Errorf("SkipPane(codexer) = false, want true (headless one-shot)")
+	}
+	if !tg.SkipPane("  ") {
+		t.Errorf("SkipPane(empty) should be true")
+	}
+	if tg.SkipPane("ceo") {
+		t.Errorf("SkipPane(ceo) = true, want false")
+	}
+}
+
+func TestTargeter_NameFor_FallsBackToSlug(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", Name: "Chief"},
+		{Slug: "ghost"}, // no Name
+	})
+	if got := tg.NameFor("ceo"); got != "Chief" {
+		t.Errorf("NameFor(ceo) = %q, want Chief", got)
+	}
+	if got := tg.NameFor("ghost"); got != "ghost" {
+		t.Errorf("NameFor(ghost) = %q, want ghost (slug fallback)", got)
+	}
+}
+
+func TestTargeter_ResolvePaneTarget_FoundAndMissing(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{{Slug: "ceo", BuiltIn: true}})
+	addr, ok := tg.ResolvePaneTarget("ceo")
+	if !ok || addr == "" {
+		t.Errorf("ResolvePaneTarget(ceo) = (%q, %v), want (non-empty, true)", addr, ok)
+	}
+	if addr, ok := tg.ResolvePaneTarget("nope"); ok || addr != "" {
+		t.Errorf("ResolvePaneTarget(nope) = (%q, %v), want empty,false", addr, ok)
+	}
+}
+
+func TestTargeter_ProviderCapabilityHelpers(t *testing.T) {
+	tg := fixtureTargeter(t, nil)
+	if !tg.UsesPaneRuntime() {
+		t.Errorf("Claude default should be pane-eligible")
+	}
+	if !tg.RequiresClaudeSessionReset() {
+		t.Errorf("Claude default should require session reset")
+	}
+	tg.provider = provider.KindCodex
+	if tg.UsesPaneRuntime() {
+		t.Errorf("Codex must not be pane-eligible")
+	}
+	if tg.RequiresClaudeSessionReset() {
+		t.Errorf("Codex must not require Claude session reset")
+	}
+}
+
+func TestOfficeLeadSlugFrom_PrefersCEO(t *testing.T) {
+	got := officeLeadSlugFrom([]officeMember{
+		{Slug: "alpha", BuiltIn: true},
+		{Slug: "ceo"},
+	})
+	if got != "ceo" {
+		t.Errorf("officeLeadSlugFrom should prefer ceo, got %q", got)
+	}
+}
+
+// itoa avoids depending on strconv just for one call site in this test file.
+func itoa(n int) string {
+	var buf [12]byte
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// Sanity: ensure tests can also drive through Launcher.targets() and get
+// the same answers. Catches the wiring step where Launcher constructs the
+// targeter and shares state with it.
+func TestLauncher_TargeterWiringMatchesPaneTargets(t *testing.T) {
+	l := &Launcher{
+		sessionName:      "wuphf-team",
+		paneBackedAgents: true,
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend"},
+			},
+		},
+		failedPaneSlugs: map[string]string{},
+	}
+	got := l.agentPaneTargets()
+	if _, ok := got["ceo"]; !ok {
+		t.Fatalf("expected ceo in launcher pane targets, got %v", got)
+	}
+	if !strings.Contains(got["ceo"].PaneTarget, "wuphf-team:team.") {
+		t.Fatalf("expected wuphf-team:team.* address, got %q", got["ceo"].PaneTarget)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #406 (C1, promptBuilder). Second slice of the launcher.go decomposition described in PLAN.md.

Lifts the office-membership-shape and routing-decision logic out of `Launcher` into a stand-alone `officeTargeter` type that drives without a Launcher fixture. The cluster answers \"which agent gets which pane / dispatch path\" — pure data-shape over a snapshot of office membership.

**Methods moved (now on officeTargeter):** PaneSlugs, AgentOrder, VisibleMembers, OverflowMembers, PaneEligibleMembers, ResolvePaneTarget, PaneTargets, NotificationTargets, ShouldUseHeadless, ShouldUseHeadlessForSlug, ShouldUseHeadlessForTarget, SkipPane, IsChannelDM, MembersSnapshot, MemberBySlug, LeadSlug, ActiveSessionMembers, NameFor, UsesPaneRuntime, RequiresClaudeSessionReset, MemberEffectiveProviderKind, MemberUsesHeadlessOneShotRuntime.

**Free functions moved:** `overflowWindowName`, `normalizeProviderKind`, `officeLeadSlugFrom`. **Const moved:** `maxVisibleOfficeAgents`.

## Shared-state design (PLAN.md §5 traps addressed)

- `paneBackedFlag *bool` aliases `launcher.paneBackedAgents` so the targeter sees pane-spawn flips live (PLAN.md trap §5.2). Duplicating the flag would route every notification through headless silently when panes are actually live.
- `failedPaneSlugs map[string]string` is shared with launcher (read by targeter, written by the pane-spawn path) (PLAN.md trap §5.1). Pre-existing pattern; collapsing it onto paneLifecycle is part of C5.

## Coverage

- `office_targets.go`: **87.3%** per-file (gate: ≥85%)
- `prompt_builder.go`: still 99.4%
- Package `internal/team`: **63.3%** (steady; new code's coverage roughly balances the deletes)

## Diff shape

- launcher.go: 4697 → 4469 lines (-228, -5%). Combined with C1: -529 lines off launcher.go since main.
- New file `office_targets.go`: 487 lines, all logic move + nil-safe defaults.
- New file `office_targets_test.go`: 22 tests, including a 6-case truth table for `ShouldUseHeadlessForSlug`.

## Compatibility shims (transitional)

The Launcher methods (`agentPaneTargets`, `officeLeadSlug`, `getAgentName`, etc.) become one-line delegating wrappers rather than removing the methods entirely. This is a deliberate deviation from PLAN.md §6 \"no compatibility shims\" — there are ~110 call sites for these methods across `internal/team` (production + tests), and renaming them all in this PR would dwarf the actual logic move with rote churn. The wrapper layer is intentionally tagged in code comments and will go in a follow-up cleanup PR after C5/C6 land.

## Test plan

- [x] `go build ./...`
- [x] `bash scripts/test-go.sh ./internal/team` (all green, 106s)
- [x] 22 new tests on `officeTargeter` directly
- [x] All existing prompt and dispatch tests still pass
- [x] `scripts/check-file-coverage.sh --pkg ./internal/team --min 85 --files internal/team/prompt_builder.go,internal/team/office_targets.go` → both OK
- [ ] CI green

## Next slice

C3 `notificationContextBuilder` — pure-string assembly over broker reads (`buildNotificationContext`, `buildMessageWorkPacket`, `buildTaskExecutionPacket`, etc.). Highest coverage payoff in the migration per PLAN.md §C3.