### PR TITLE
refactor(channelui): hoist broker/render data types into channelui

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -151,35 +151,6 @@ type channelHealthMsg struct {
 	OneOnOneAgent string
 }
 
-type brokerReaction struct {
-	Emoji string `json:"emoji"`
-	From  string `json:"from"`
-}
-
-type brokerMessageUsage struct {
-	InputTokens         int `json:"input_tokens,omitempty"`
-	OutputTokens        int `json:"output_tokens,omitempty"`
-	CacheReadTokens     int `json:"cache_read_tokens,omitempty"`
-	CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
-	TotalTokens         int `json:"total_tokens,omitempty"`
-}
-
-type brokerMessage struct {
-	ID          string              `json:"id"`
-	From        string              `json:"from"`
-	Kind        string              `json:"kind,omitempty"`
-	Source      string              `json:"source,omitempty"`
-	SourceLabel string              `json:"source_label,omitempty"`
-	EventID     string              `json:"event_id,omitempty"`
-	Title       string              `json:"title,omitempty"`
-	Content     string              `json:"content"`
-	Tagged      []string            `json:"tagged"`
-	ReplyTo     string              `json:"reply_to"`
-	Timestamp   string              `json:"timestamp"`
-	Usage       *brokerMessageUsage `json:"usage,omitempty"`
-	Reactions   []brokerReaction    `json:"reactions,omitempty"`
-}
-
 type channelMember struct {
 	Slug         string `json:"slug"`
 	Name         string `json:"name,omitempty"`
@@ -3436,15 +3407,6 @@ func appendWrapped(lines []string, width int, text string) []string {
 	}
 	wrapped := ansi.Wrap(text, width, "")
 	return append(lines, strings.Split(wrapped, "\n")...)
-}
-
-type threadedMessage struct {
-	Message            brokerMessage
-	Depth              int
-	ParentLabel        string
-	Collapsed          bool
-	HiddenReplies      int
-	ThreadParticipants []string
 }
 
 type sidebarItem struct {

--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -9,15 +9,6 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-type renderedLine struct {
-	Text        string
-	ThreadID    string
-	TaskID      string
-	RequestID   string
-	AgentSlug   string
-	PromptValue string
-}
-
 func buildOfficeMessageLines(messages []brokerMessage, expanded map[string]bool, contentWidth int, threadsDefaultExpand bool, unreadAnchorID string, unreadCount int) []renderedLine {
 	mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
 

--- a/cmd/wuphf/channelui/types.go
+++ b/cmd/wuphf/channelui/types.go
@@ -1,0 +1,62 @@
+package channelui
+
+// BrokerReaction is a single emoji reaction on a broker message.
+type BrokerReaction struct {
+	Emoji string `json:"emoji"`
+	From  string `json:"from"`
+}
+
+// BrokerMessageUsage counts the LLM tokens (and cache hits) attributed
+// to a single message. All fields are optional; zero values mean the
+// broker did not report that dimension for the message.
+type BrokerMessageUsage struct {
+	InputTokens         int `json:"input_tokens,omitempty"`
+	OutputTokens        int `json:"output_tokens,omitempty"`
+	CacheReadTokens     int `json:"cache_read_tokens,omitempty"`
+	CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+	TotalTokens         int `json:"total_tokens,omitempty"`
+}
+
+// BrokerMessage is a single message record as the broker returns it.
+// The shape mirrors the broker's JSON contract so it round-trips
+// directly through encoding/json without an intermediate DTO.
+type BrokerMessage struct {
+	ID          string              `json:"id"`
+	From        string              `json:"from"`
+	Kind        string              `json:"kind,omitempty"`
+	Source      string              `json:"source,omitempty"`
+	SourceLabel string              `json:"source_label,omitempty"`
+	EventID     string              `json:"event_id,omitempty"`
+	Title       string              `json:"title,omitempty"`
+	Content     string              `json:"content"`
+	Tagged      []string            `json:"tagged"`
+	ReplyTo     string              `json:"reply_to"`
+	Timestamp   string              `json:"timestamp"`
+	Usage       *BrokerMessageUsage `json:"usage,omitempty"`
+	Reactions   []BrokerReaction    `json:"reactions,omitempty"`
+}
+
+// RenderedLine is a single line of pre-styled output destined for the
+// main panel. The metadata fields (ThreadID/TaskID/…) let the mouse
+// layer route a click on the line back to the underlying entity.
+type RenderedLine struct {
+	Text        string
+	ThreadID    string
+	TaskID      string
+	RequestID   string
+	AgentSlug   string
+	PromptValue string
+}
+
+// ThreadedMessage decorates a BrokerMessage with the structural context
+// the thread-view renderer needs: how deep in the reply chain it sits,
+// the human-readable label of its parent, and whether the renderer has
+// chosen to collapse its descendants behind a "+N hidden" affordance.
+type ThreadedMessage struct {
+	Message            BrokerMessage
+	Depth              int
+	ParentLabel        string
+	Collapsed          bool
+	HiddenReplies      int
+	ThreadParticipants []string
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -1,0 +1,19 @@
+package main
+
+import "github.com/nex-crm/wuphf/cmd/wuphf/channelui"
+
+// Type aliases bridge the old package-main names to the new channelui
+// package while the channel cluster is incrementally extracted. These
+// aliases preserve every existing field access, method receiver, and
+// composite-literal usage in the rest of cmd/wuphf so each extraction
+// PR can move types without churning every callsite.
+//
+// The aliases will be removed once the channel cluster fully lives in
+// channelui (final cleanup PR).
+type (
+	brokerReaction     = channelui.BrokerReaction
+	brokerMessageUsage = channelui.BrokerMessageUsage
+	brokerMessage      = channelui.BrokerMessage
+	renderedLine       = channelui.RenderedLine
+	threadedMessage    = channelui.ThreadedMessage
+)


### PR DESCRIPTION
## Summary

PR 4 of the channel-package extraction series. **Stacked on #411** — review #405 → #408 → #411 first, then this PR shows only the type hoist.

Moves the five most heavily referenced pure-data types into \`cmd/wuphf/channelui/types.go\`:

- \`BrokerReaction\`
- \`BrokerMessageUsage\`
- \`BrokerMessage\`
- \`RenderedLine\`
- \`ThreadedMessage\`

These shapes flow through every renderer, broker cmd-builder, and test in the channel cluster. Hoisting them now unblocks the actual renderer move (next PR) without churning every callsite.

## Why aliases instead of renaming everything

\`cmd/wuphf/channelui_aliases.go\` adds:

\`\`\`go
type (
    brokerReaction     = channelui.BrokerReaction
    brokerMessageUsage = channelui.BrokerMessageUsage
    brokerMessage      = channelui.BrokerMessage
    renderedLine       = channelui.RenderedLine
    threadedMessage    = channelui.ThreadedMessage
)
\`\`\`

Type aliases share field access and method semantics with the underlying type, so every existing usage like \`brokerMessage{ID: ...}\`, \`msg.From\`, \`func(msgs []brokerMessage) ...\` continues to compile unchanged. This is the bridge mechanism the plan calls for: keep the channel cluster compiling at HEAD while the actual code physically migrates over several PRs.

The aliases are temporary. PR 9 (final cleanup) drops them once nothing references the lowercase names anymore.

## What changed

| File | Lines |
|---|---|
| \`cmd/wuphf/channelui/types.go\` (new) | +63 |
| \`cmd/wuphf/channelui_aliases.go\` (new) | +18 |
| \`cmd/wuphf/channel.go\` (deletes) | −38 |
| \`cmd/wuphf/channel_render.go\` (deletes) | −9 |

Net: 4 files, 81 insertions, 47 deletions.

## Test plan

- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go build ./cmd/wuphf\` — binary builds
- [ ] CI passes on draft PR

## Why so small

The original plan called for moving the actual renderer files in this PR (\`channel_render.go\`, \`channel_mailboxes.go\`, \`channel_thread.go\`, etc., ~3500 LoC). Splitting that into "types first, files next" gives reviewers a tractable diff and lets the next PR be a near-mechanical file move now that the type contract is stable in channelui.

## Next in stack

- PR 4b: Move \`channel_messages.go\`, \`channel_mailboxes.go\`, \`channel_thread.go\`, \`channel_layout.go\`, \`channel_composer.go\`, \`channel_window.go\`, \`channel_needs_you.go\` into channelui (small/medium leaves first)
- PR 4c: Move \`channel_render.go\` (1407 lines, split into render_office/render_calendar/render_policy/etc.)
- PR 5+: Workspace cluster, sidebar/splash, broker integrations, the model itself, cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)