### PR TITLE
refactor(channelui): hoist office directory + display/role labels

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -160,15 +160,6 @@ type channelMember struct {
 	LiveActivity string `json:"liveActivity,omitempty"`
 }
 
-type officeMemberInfo struct {
-	Slug        string   `json:"slug"`
-	Name        string   `json:"name"`
-	Role        string   `json:"role"`
-	Expertise   []string `json:"expertise,omitempty"`
-	Personality string   `json:"personality,omitempty"`
-	BuiltIn     bool     `json:"built_in,omitempty"`
-}
-
 type channelInfo struct {
 	Slug        string   `json:"slug"`
 	Name        string   `json:"name"`
@@ -422,7 +413,6 @@ type channelMemberDraft struct {
 var mentionPattern = regexp.MustCompile(`@([A-Za-z0-9_-]+)`)
 
 var brokerTokenPath = brokeraddr.DefaultTokenFile
-var officeDirectory = map[string]officeMemberInfo{}
 
 var channelSlashCommands = []tui.SlashCommand{
 	{Name: "init", Description: "Run setup (Ryan Howard skipped this step — don't be Ryan)", Category: "setup"},
@@ -683,10 +673,7 @@ func newChannelModelWithApp(threadsCollapsed bool, initialApp officeApp) channel
 		}
 		initialApp = officeAppMessages
 	}
-	officeDirectory = make(map[string]officeMemberInfo, len(officeMembers))
-	for _, member := range officeMembers {
-		officeDirectory[member.Slug] = member
-	}
+	channelui.SetOfficeDirectory(officeMembers)
 	m := channelModel{
 		expandedThreads:      make(map[string]bool),
 		threadsDefaultExpand: !threadsCollapsed,
@@ -1764,10 +1751,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			msg.members = officeMembersFallback(m.officeMembers)
 		}
 		m.officeMembers = msg.members
-		officeDirectory = make(map[string]officeMemberInfo, len(msg.members))
-		for _, member := range msg.members {
-			officeDirectory[member.Slug] = member
-		}
+		channelui.SetOfficeDirectory(msg.members)
 		m.updateOverlaysForCurrentInput()
 
 	case channelChannelsMsg:
@@ -3993,66 +3977,6 @@ func channelInfosFallback(existing []channelInfo) []channelInfo {
 		manifest = company.DefaultManifest()
 	}
 	return channelInfosFromManifest(manifest)
-}
-
-func displayName(slug string) string {
-	if member, ok := officeDirectory[slug]; ok && member.Name != "" {
-		return member.Name
-	}
-	switch slug {
-	case "ceo":
-		return "CEO"
-	case "pm":
-		return "Product Manager"
-	case "fe":
-		return "Frontend Engineer"
-	case "be":
-		return "Backend Engineer"
-	case "ai":
-		return "AI Engineer"
-	case "designer":
-		return "Designer"
-	case "cmo":
-		return "CMO"
-	case "cro":
-		return "CRO"
-	case "nex":
-		return "Nex"
-	case "you":
-		return "You"
-	default:
-		return "@" + slug
-	}
-}
-
-func roleLabel(slug string) string {
-	if member, ok := officeDirectory[slug]; ok && member.Role != "" {
-		return member.Role
-	}
-	switch slug {
-	case "ceo":
-		return "strategy"
-	case "pm":
-		return "product"
-	case "fe":
-		return "frontend"
-	case "be":
-		return "backend"
-	case "ai":
-		return "AI Engineer"
-	case "designer":
-		return "design"
-	case "cmo":
-		return "marketing"
-	case "cro":
-		return "revenue"
-	case "nex":
-		return "context graph"
-	case "you":
-		return "human"
-	default:
-		return "teammate"
-	}
 }
 
 func inferMood(text string) string {

--- a/cmd/wuphf/channelui/directory.go
+++ b/cmd/wuphf/channelui/directory.go
@@ -1,0 +1,109 @@
+package channelui
+
+// OfficeMember describes a member of the office roster as the broker
+// returns it. The shape mirrors the broker's JSON contract and matches
+// the official manifest spec.
+type OfficeMember struct {
+	Slug        string   `json:"slug"`
+	Name        string   `json:"name"`
+	Role        string   `json:"role"`
+	Expertise   []string `json:"expertise,omitempty"`
+	Personality string   `json:"personality,omitempty"`
+	BuiltIn     bool     `json:"built_in,omitempty"`
+}
+
+// officeDirectory is the process-wide office roster used by DisplayName
+// and RoleLabel to resolve human-friendly names. It is a singleton
+// because the channel UI assumes one workspace at a time; callers refresh
+// it via SetOfficeDirectory whenever a fresh roster arrives from the
+// broker.
+//
+// Tests can override the directory by calling SetOfficeDirectory with a
+// fixture and resetting via t.Cleanup.
+var officeDirectory = map[string]OfficeMember{}
+
+// SetOfficeDirectory replaces the singleton directory. Idempotent;
+// safe to call repeatedly with the same input.
+func SetOfficeDirectory(members []OfficeMember) {
+	dir := make(map[string]OfficeMember, len(members))
+	for _, member := range members {
+		dir[member.Slug] = member
+	}
+	officeDirectory = dir
+}
+
+// LookupMember returns the office member registered under slug, or the
+// zero value and false. Useful for callers that want raw access to the
+// roster without going through DisplayName/RoleLabel formatting.
+func LookupMember(slug string) (OfficeMember, bool) {
+	m, ok := officeDirectory[slug]
+	return m, ok
+}
+
+// DisplayName resolves a human-readable label for an agent slug.
+// Custom names from the office directory take precedence; otherwise we
+// fall back to the canonical title for one of the built-in roles, and
+// finally to "@<slug>" for unknown agents.
+func DisplayName(slug string) string {
+	if member, ok := officeDirectory[slug]; ok && member.Name != "" {
+		return member.Name
+	}
+	switch slug {
+	case "ceo":
+		return "CEO"
+	case "pm":
+		return "Product Manager"
+	case "fe":
+		return "Frontend Engineer"
+	case "be":
+		return "Backend Engineer"
+	case "ai":
+		return "AI Engineer"
+	case "designer":
+		return "Designer"
+	case "cmo":
+		return "CMO"
+	case "cro":
+		return "CRO"
+	case "nex":
+		return "Nex"
+	case "you":
+		return "You"
+	default:
+		return "@" + slug
+	}
+}
+
+// RoleLabel resolves a short role descriptor for an agent slug, used in
+// secondary metadata lines (e.g., "frontend" under the FE avatar).
+// Falls back to the canonical role for built-in slugs, then to
+// "teammate" for anything else.
+func RoleLabel(slug string) string {
+	if member, ok := officeDirectory[slug]; ok && member.Role != "" {
+		return member.Role
+	}
+	switch slug {
+	case "ceo":
+		return "strategy"
+	case "pm":
+		return "product"
+	case "fe":
+		return "frontend"
+	case "be":
+		return "backend"
+	case "ai":
+		return "AI Engineer"
+	case "designer":
+		return "design"
+	case "cmo":
+		return "marketing"
+	case "cro":
+		return "revenue"
+	case "nex":
+		return "context graph"
+	case "you":
+		return "human"
+	default:
+		return "teammate"
+	}
+}

--- a/cmd/wuphf/channelui/directory.go
+++ b/cmd/wuphf/channelui/directory.go
@@ -18,8 +18,10 @@ type OfficeMember struct {
 // it via SetOfficeDirectory whenever a fresh roster arrives from the
 // broker.
 //
-// Tests can override the directory by calling SetOfficeDirectory with a
-// fixture and resetting via t.Cleanup.
+// Tests that need to inject a fixture should call WithOfficeDirectoryForTest
+// (which captures the prior state and registers a t.Cleanup that restores
+// it). Tests that mutate the directory through SetOfficeDirectory directly
+// bypass that isolation and will leak fixture state into sibling tests.
 var officeDirectory = map[string]OfficeMember{}
 
 // SetOfficeDirectory replaces the singleton directory. Idempotent;
@@ -30,6 +32,21 @@ func SetOfficeDirectory(members []OfficeMember) {
 		dir[member.Slug] = member
 	}
 	officeDirectory = dir
+}
+
+// WithOfficeDirectoryForTest installs members as the directory for the
+// duration of the test, then restores the previous contents via a
+// t.Cleanup. The helper takes testing.TB rather than *testing.T so it
+// works inside benchmarks and table subtests without changing call
+// shape.
+func WithOfficeDirectoryForTest(t interface {
+	Cleanup(func())
+	Helper()
+}, members []OfficeMember) {
+	t.Helper()
+	prior := officeDirectory
+	SetOfficeDirectory(members)
+	t.Cleanup(func() { officeDirectory = prior })
 }
 
 // LookupMember returns the office member registered under slug, or the

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -17,6 +17,7 @@ type (
 	renderedLine       = channelui.RenderedLine
 	threadedMessage    = channelui.ThreadedMessage
 	layoutDimensions   = channelui.LayoutDimensions
+	officeMemberInfo   = channelui.OfficeMember
 )
 
 // Function aliases keep the lowercase names callable from package main
@@ -50,4 +51,7 @@ var (
 	humanMessageLabel      = channelui.HumanMessageLabel
 	renderUnreadDivider    = channelui.RenderUnreadDivider
 	displayDecisionSummary = channelui.DisplayDecisionSummary
+
+	displayName = channelui.DisplayName
+	roleLabel   = channelui.RoleLabel
 )


### PR DESCRIPTION
## Summary

PR 4f of the channel-package extraction series. **Stacked on #420**.

Moves the office-roster singleton (\`officeMemberInfo\`, \`officeDirectory\`, \`displayName\`, \`roleLabel\`) into \`cmd/wuphf/channelui/directory.go\`. The directory was the last big package-main coupling for the smaller renderers — every file that turns a slug into a label or role goes through \`displayName\`/\`roleLabel\`. With this move the leaf renderers (\`channel_thread\`, \`channel_mailboxes\`, \`channel_needs_you\`) can extract in the next PR with no further main-side dependencies beyond the channel data types themselves.

## What moved

| Was (package main) | Now (channelui) |
|---|---|
| \`officeMemberInfo\` struct | \`channelui.OfficeMember\` |
| \`officeDirectory\` map | \`channelui.officeDirectory\` (private singleton) |
| inline \`officeDirectory = make(...); for ... { ... }\` mutation | \`channelui.SetOfficeDirectory(members)\` setter |
| n/a | new \`channelui.LookupMember(slug)\` helper |
| \`displayName\` | \`channelui.DisplayName\` |
| \`roleLabel\` | \`channelui.RoleLabel\` |

## Mutation pattern

The two main-side mutation sites (\`newChannelModelWithApp\` and the \`channelOfficeMembersMsg\` handler in \`Update\`) now call \`channelui.SetOfficeDirectory\` instead of reassigning the package-level map and looping inserts. Side benefit: \`SetOfficeDirectory\` builds the new map locally and assigns once, eliminating the racy "reassign-then-loop-and-insert" pattern (the old code briefly exposed a partially-populated directory to any concurrent reader).

## Caller compatibility

| Alias | Type |
|---|---|
| \`type officeMemberInfo = channelui.OfficeMember\` | type |
| \`var displayName = channelui.DisplayName\` | function value |
| \`var roleLabel = channelui.RoleLabel\` | function value |

Zero callsite changes for \`officeMemberInfo{...}\` literals, slice/map declarations, or \`displayName(slug)\` / \`roleLabel(slug)\` calls. The 16 references identified in the PR audit all compile unchanged.

## Diff stats

- 3 files changed, 115 insertions(+), 78 deletions(-)
- 1 new file (\`channelui/directory.go\`)

## Test plan

- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go build ./cmd/wuphf\` — binary builds
- [ ] CI passes on draft PR

## Next in stack

- PR 4g: Move \`channel_needs_you.go\`, \`channel_thread.go\`, \`channel_mailboxes.go\` into channelui (now that all their helpers live there)
- PR 4h: Move \`channel_render.go\` (1407 lines) split across multiple channelui files
- PR 5+: Workspace cluster, sidebar/splash, broker integrations, the model itself, cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)