### PR TITLE
refactor(team): extract notificationContextBuilder from launcher.go (C3)

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/brokeraddr"
 	"github.com/nex-crm/wuphf/internal/calendar"
+	"github.com/nex-crm/wuphf/internal/channel"
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/nex"
@@ -150,6 +151,11 @@ type Launcher struct {
 	// paneBackedAgents — the targeter holds pointers/callbacks back into
 	// the launcher rather than copies.
 	targets *officeTargeter
+
+	// notify owns notification-context and work-packet construction
+	// (PLAN.md §C3). Lazily constructed via notifyCtx() and shares state
+	// with the launcher via callbacks (broker reads, headless queue peek).
+	notify *notificationContextBuilder
 }
 
 // paneDispatchTurn is one queued notification to type into a tmux pane.
@@ -934,76 +940,10 @@ func (l *Launcher) shouldDeliverDelayedTaskNotification(targetSlug string, actio
 	return true
 }
 
+// taskNotificationContent delegates to the notificationContextBuilder
+// (PLAN.md §C3). See notification_context.go for the formatting body.
 func (l *Launcher) taskNotificationContent(action officeActionLog, task teamTask) string {
-	channel := normalizeChannelSlug(task.Channel)
-	if channel == "" {
-		channel = "general"
-	}
-	verb := "Task update"
-	switch action.Kind {
-	case "task_created":
-		verb = "Task created"
-	case "task_updated":
-		verb = "Task updated"
-	case "task_unblocked":
-		verb = "Task unblocked — dependencies resolved, ready to start"
-	case "watchdog_alert":
-		verb = "Watchdog reminder"
-	}
-	owner := strings.TrimSpace(task.Owner)
-	if owner == "" {
-		owner = "unassigned"
-	} else {
-		owner = "@" + owner
-	}
-	status := strings.TrimSpace(task.Status)
-	if status == "" {
-		status = "open"
-	}
-	details := strings.TrimSpace(task.Details)
-	if details != "" {
-		details = " — " + truncate(details, 120)
-	}
-	pipeline := ""
-	if strings.TrimSpace(task.PipelineStage) != "" {
-		pipeline = ", stage " + task.PipelineStage
-	}
-	review := ""
-	if strings.TrimSpace(task.ReviewState) != "" && task.ReviewState != "not_required" {
-		review = ", review " + task.ReviewState
-	}
-	execMode := ""
-	if strings.TrimSpace(task.ExecutionMode) != "" {
-		execMode = ", execution " + task.ExecutionMode
-	}
-	worktree := ""
-	if strings.TrimSpace(task.WorktreeBranch) != "" || strings.TrimSpace(task.WorktreePath) != "" {
-		parts := make([]string, 0, 2)
-		if strings.TrimSpace(task.WorktreeBranch) != "" {
-			parts = append(parts, "branch "+task.WorktreeBranch)
-		}
-		if strings.TrimSpace(task.WorktreePath) != "" {
-			parts = append(parts, "path "+task.WorktreePath)
-		}
-		worktree = ", worktree " + strings.Join(parts, " · ")
-	}
-	guidance := ""
-	if path := strings.TrimSpace(task.WorktreePath); path != "" {
-		guidance = fmt.Sprintf(" If you own this task, use working_directory=%q for local file and bash tools.", path)
-	}
-	framing := ""
-	if taskRequiresRealExternalExecution(&task) {
-		framing = " Live business framing: describe the work as a client deliverable, approval, handoff, update, or record. Do not present it as a proof marker, eval artifact, or test artifact unless the task explicitly asks for testing or evidence capture."
-	}
-	capability := ""
-	if taskRequiresRealExternalExecution(&task) {
-		capability = "\n" + capabilityGapCoachingBlock()
-	}
-	hygiene := ""
-	if taskLooksLikeLiveBusinessObjective(&task) {
-		hygiene = "\n" + taskHygieneCoachingBlock()
-	}
-	return fmt.Sprintf("[%s #%s on #%s]: %s%s (owner %s, status %s%s%s%s%s). Context is included — do NOT call team_poll or team_tasks. Respond with the concrete next step immediately. Stay in your lane. Once you have posted the needed update, STOP and wait for the next pushed notification.%s%s%s%s", verb, task.ID, channel, task.Title, details, owner, status, pipeline, review, execMode, worktree, guidance, framing, capability, hygiene)
+	return l.notifyCtx().TaskNotificationContent(action, task)
 }
 
 func (l *Launcher) sendTaskUpdate(target notificationTarget, action officeActionLog, task teamTask, content string) {
@@ -1776,33 +1716,6 @@ func (req humanInterview) TitleOrDefault() string {
 	return "Request"
 }
 
-func humanizeNotificationType(kind string) string {
-	switch strings.TrimSpace(kind) {
-	case "context_alert":
-		return "Context alert"
-	case "daily_digest":
-		return "Daily digest"
-	case "meeting_summary":
-		return "Meeting summary"
-	case "task_reminder":
-		return "Task reminder"
-	case "task_assigned":
-		return "Task assigned"
-	default:
-		if kind == "" {
-			return ""
-		}
-		parts := strings.Split(strings.ReplaceAll(kind, "_", " "), " ")
-		for i, part := range parts {
-			if part == "" {
-				continue
-			}
-			parts[i] = strings.ToUpper(part[:1]) + part[1:]
-		}
-		return strings.Join(parts, " ")
-	}
-}
-
 // targeter returns the office-targeter, lazily constructing it on first
 // access. PLAN.md trap §5.4: tests build &Launcher{} directly and rely on
 // every sub-type being nil-safe. The targeter shares mutable state with
@@ -1973,50 +1886,6 @@ func killStaleBroker() {
 		_ = exec.CommandContext(context.Background(), "kill", "-9", pid).Run()
 	}
 	time.Sleep(500 * time.Millisecond)
-}
-
-func truncate(s string, max int) string {
-	if len(s) <= max {
-		return s
-	}
-	return s[:max] + "..."
-}
-
-func extractTaskFileTargets(text string) []string {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return nil
-	}
-	seen := map[string]struct{}{}
-	targets := make([]string, 0, 4)
-	for {
-		start := strings.Index(text, "`")
-		if start < 0 {
-			break
-		}
-		text = text[start+1:]
-		end := strings.Index(text, "`")
-		if end < 0 {
-			break
-		}
-		candidate := strings.TrimSpace(text[:end])
-		text = text[end+1:]
-		if candidate == "" {
-			continue
-		}
-		if !strings.Contains(candidate, "/") && !strings.Contains(candidate, ".") {
-			continue
-		}
-		if _, ok := seen[candidate]; ok {
-			continue
-		}
-		seen[candidate] = struct{}{}
-		targets = append(targets, candidate)
-		if len(targets) == 4 {
-			break
-		}
-	}
-	return targets
 }
 
 func containsSlug(items []string, want string) bool {
@@ -2213,564 +2082,114 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 	return nil
 }
 
-// buildNotificationContext returns a compact summary of recent channel messages
-// for inline injection into agent notifications. Filters system and status messages.
-// buildNotificationContext returns a pre-labeled context section for work packets.
-//
-// When threadRootID is non-empty, the function first tries to build thread-scoped
-// context: messages whose ID equals threadRootID (the root) or whose ReplyTo equals
-// threadRootID (direct replies). This is labeled "[Recent thread]" and gives agents
-// only the relevant sub-conversation, not unrelated channel noise.
-//
-// When threadRootID is empty, or when the thread has no displayable messages (e.g.
-// the trigger is the first message in a new thread), the function falls back to the
-// last N channel messages and labels the section "[Recent channel]". Agents should
-// treat "[Recent channel]" as broad ambient context rather than the specific thread
-// they are responding in.
-//
-// The trigger message (triggerMsgID) is always excluded — it is already delivered
-// explicitly as "[New from @...]" in the notification, so including it again wastes
-// ~150 tokens per turn.
-func (l *Launcher) buildNotificationContext(channel, triggerMsgID, threadRootID string, limit int) string {
-	if l.broker == nil {
-		return ""
+// notifyCtx returns the notification-context builder, lazily constructing
+// it on first access (PLAN.md §C3). The builder shares state with Launcher
+// via callbacks for broker reads and headless-queue peek; constructed
+// fresh per call so each work packet sees current broker state.
+func (l *Launcher) notifyCtx() *notificationContextBuilder {
+	if l == nil {
+		return nil
 	}
-	if strings.TrimSpace(channel) == "" {
-		channel = "general"
+	if l.notify != nil {
+		return l.notify
 	}
-
-	msgs := l.broker.ChannelMessages(channel)
-	if len(msgs) == 0 {
-		return ""
-	}
-
-	// baseFilter excludes system messages, STATUS messages, demo_seed posts,
-	// and the trigger itself. demo_seed lines are cosmetic onboarding-paint
-	// content (e.g. the lead presence line) and replaying them as prompt
-	// context would let agents treat fake activity as real history.
-	baseFilter := func(m channelMessage) bool {
-		if m.From == "system" {
-			return false
-		}
-		if m.Kind == "demo_seed" {
-			return false
-		}
-		if strings.TrimSpace(triggerMsgID) != "" && strings.TrimSpace(m.ID) == strings.TrimSpace(triggerMsgID) {
-			return false
-		}
-		if strings.HasPrefix(strings.TrimSpace(m.Content), "[STATUS]") {
-			return false
-		}
-		return true
-	}
-
-	formatContext := func(items []channelMessage) string {
-		var b strings.Builder
-		for _, m := range items {
-			b.WriteString(fmt.Sprintf("@%s: %s\n", m.From, truncate(m.Content, 600)))
-		}
-		return strings.TrimRight(b.String(), "\n")
-	}
-
-	// Thread-scoped context: show all messages in the thread tree (full BFS from
-	// root), always anchoring with the root message so agents see the original
-	// human ask. This matters for dependent task chains — e.g., a marketing agent
-	// writing an email "based on research" needs to see the researcher's results,
-	// which are grandchildren of the thread root, not direct children.
-	//
-	// Approach: always include the root, fill remaining slots with the most recent
-	// non-root thread messages (so the latest activity is always visible).
-	threadRoot := strings.TrimSpace(threadRootID)
-	if threadRoot != "" {
-		threadIDs := l.threadMessageIDs(channel, threadRoot)
-		// Separate root from rest so we can always preserve it.
-		var rootMsg *channelMessage
-		var rest []channelMessage
-		for i := range msgs {
-			m := &msgs[i]
-			if !baseFilter(*m) {
-				continue
+	l.notify = &notificationContextBuilder{
+		targeter: l.targeter(),
+		channelMessages: func(channelSlug string) []channelMessage {
+			if l.broker == nil {
+				return nil
 			}
-			if strings.TrimSpace(m.ID) == threadRoot {
-				rootMsg = m
-			} else if _, inThread := threadIDs[strings.TrimSpace(m.ID)]; inThread {
-				rest = append(rest, *m)
+			return l.broker.ChannelMessages(channelSlug)
+		},
+		channelTasks: func(channelSlug string) []teamTask {
+			if l.broker == nil {
+				return nil
 			}
-		}
-		if rootMsg != nil || len(rest) > 0 {
-			// Take last (limit-1) from rest to leave a slot for the root.
-			remaining := limit
-			if rootMsg != nil {
-				remaining--
+			return l.broker.ChannelTasks(channelSlug)
+		},
+		allTasks: func() []teamTask {
+			if l.broker == nil {
+				return nil
 			}
-			if len(rest) > remaining {
-				rest = rest[len(rest)-remaining:]
+			return l.broker.AllTasks()
+		},
+		channelStore: func() *channel.Store {
+			if l.broker == nil {
+				return nil
 			}
-			var thread []channelMessage
-			if rootMsg != nil {
-				thread = append(thread, *rootMsg)
-			}
-			thread = append(thread, rest...)
-			return "[Recent thread]\n" + formatContext(thread)
-		}
+			return l.broker.ChannelStore()
+		},
+		scoreTaskCandidate:   l.scoreMessageForTaskCandidate,
+		activeHeadlessAgents: l.activeHeadlessSlugs,
 	}
-
-	// Fall back to recent channel messages when there is no thread context.
-	var filtered []channelMessage
-	for _, m := range msgs {
-		if baseFilter(m) {
-			filtered = append(filtered, m)
-		}
-	}
-	if len(filtered) == 0 {
-		return ""
-	}
-	if len(filtered) > limit {
-		filtered = filtered[len(filtered)-limit:]
-	}
-	return "[Recent channel]\n" + formatContext(filtered)
+	return l.notify
 }
 
-// ultimateThreadRoot walks the reply-to chain from startID up to the topmost
-// ancestor (the message with no ReplyTo) and returns its ID. This ensures that
-// when building thread context for a deep reply chain — e.g., human ask → CEO
-// delegation → specialist response — the filtering anchors at the original human
-// ask rather than a mid-thread message, so all participants see the full context.
-//
-// If startID is empty, startID itself is returned. The walk is capped at 8 hops
-// to prevent cycles or unbounded work on pathological data.
-func (l *Launcher) ultimateThreadRoot(channel, startID string) string {
-	startID = strings.TrimSpace(startID)
-	if startID == "" || l.broker == nil {
-		return startID
+// activeHeadlessSlugs returns the slugs that have non-empty headless
+// queues or active turns at the moment of the call. Locks headlessMu so
+// the snapshot is consistent. The except parameter is the slug being
+// notified — the lead must not list itself as "already active".
+func (l *Launcher) activeHeadlessSlugs(except string) map[string]struct{} {
+	if l == nil {
+		return nil
 	}
-	msgs := l.broker.ChannelMessages(channel)
-	byID := make(map[string]channelMessage, len(msgs))
-	for _, m := range msgs {
-		if id := strings.TrimSpace(m.ID); id != "" {
-			byID[id] = m
+	l.headlessMu.Lock()
+	defer l.headlessMu.Unlock()
+	out := map[string]struct{}{}
+	for workerSlug, queue := range l.headlessQueues {
+		if workerSlug == except {
+			continue
+		}
+		if len(queue) > 0 {
+			out[workerSlug] = struct{}{}
 		}
 	}
-	root := startID
-	for depth := 0; depth < 8; depth++ {
-		m, ok := byID[root]
-		if !ok {
-			break
+	for workerSlug, active := range l.headlessActive {
+		if workerSlug == except {
+			continue
 		}
-		parent := strings.TrimSpace(m.ReplyTo)
-		if parent == "" {
-			break
+		if active != nil {
+			out[workerSlug] = struct{}{}
 		}
-		root = parent
 	}
-	return root
+	return out
 }
 
-// threadMessageIDs returns the set of all message IDs that belong to the thread
-// rooted at rootID (BFS traversal via replyTo reverse index). The root itself is
-// included. Returns an empty set when rootID is empty or broker is nil.
-func (l *Launcher) threadMessageIDs(channel, rootID string) map[string]struct{} {
-	rootID = strings.TrimSpace(rootID)
-	result := make(map[string]struct{})
-	if rootID == "" || l.broker == nil {
-		return result
-	}
-	msgs := l.broker.ChannelMessages(channel)
-	byParent := make(map[string][]string, len(msgs))
-	for _, m := range msgs {
-		parent := strings.TrimSpace(m.ReplyTo)
-		if parent != "" {
-			byParent[parent] = append(byParent[parent], strings.TrimSpace(m.ID))
-		}
-	}
-	result[rootID] = struct{}{}
-	queue := []string{rootID}
-	for len(queue) > 0 {
-		cur := queue[0]
-		queue = queue[1:]
-		for _, child := range byParent[cur] {
-			if _, seen := result[child]; !seen {
-				result[child] = struct{}{}
-				queue = append(queue, child)
-			}
-		}
-	}
-	return result
+// Notification-context methods on Launcher are thin wrappers; the bodies
+// live in notification_context.go on notificationContextBuilder. Wrappers
+// kept (rather than removed) so the ~50 in-package callers don't need a
+// rename sweep in this PR — that's a follow-up.
+
+func (l *Launcher) buildNotificationContext(channelSlug, triggerMsgID, threadRootID string, limit int) string {
+	return l.notifyCtx().NotificationContext(channelSlug, triggerMsgID, threadRootID, limit)
 }
 
-func (l *Launcher) buildTaskNotificationContext(channel, slug string, limit int) string {
-	if l.broker == nil || limit <= 0 {
-		return ""
-	}
+func (l *Launcher) ultimateThreadRoot(channelSlug, startID string) string {
+	return l.notifyCtx().UltimateThreadRoot(channelSlug, startID)
+}
 
-	var tasks []teamTask
-	if strings.TrimSpace(channel) == "" {
-		// No specific channel: scan all tasks across all channels so non-general
-		// channel tasks are not silently omitted from the CEO's task context.
-		tasks = l.broker.AllTasks()
-	} else {
-		tasks = l.broker.ChannelTasks(channel)
-	}
-	if len(tasks) == 0 {
-		return ""
-	}
+func (l *Launcher) threadMessageIDs(channelSlug, rootID string) map[string]struct{} {
+	return l.notifyCtx().ThreadMessageIDs(channelSlug, rootID)
+}
 
-	formatTask := func(task teamTask) string {
-		owner := strings.TrimSpace(task.Owner)
-		switch {
-		case owner == "":
-			owner = "unassigned"
-		default:
-			owner = "@" + owner
-		}
-		status := strings.TrimSpace(task.Status)
-		if status == "" {
-			status = "open"
-		}
-		meta := owner + ", " + status
-		if task.Blocked {
-			meta += ", blocked"
-		}
-		if len(task.DependsOn) > 0 {
-			meta += ", depends: " + strings.Join(task.DependsOn, " ")
-		}
-		taskChannel := normalizeChannelSlug(task.Channel)
-		if taskChannel == "" {
-			taskChannel = "general"
-		}
-		line := fmt.Sprintf("- #%s on #%s %s (%s)", task.ID, taskChannel, truncate(task.Title, 72), meta)
-		if details := strings.TrimSpace(task.Details); details != "" {
-			line += ": " + truncate(details, 96)
-		}
-		return line
-	}
-
-	// Sort tasks so the most recently updated active work surfaces first.
-	// This prevents a fixed insertion-order view where the first 3 tasks created
-	// always fill the slot, potentially hiding newer or more urgent work.
-	sort.Slice(tasks, func(i, j int) bool {
-		return tasks[i].UpdatedAt > tasks[j].UpdatedAt
-	})
-
-	lines := make([]string, 0, limit)
-	seen := make(map[string]struct{}, limit)
-	addTask := func(task teamTask) {
-		if len(lines) >= limit {
-			return
-		}
-		if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
-			return
-		}
-		if _, ok := seen[task.ID]; ok {
-			return
-		}
-		seen[task.ID] = struct{}{}
-		lines = append(lines, formatTask(task))
-	}
-
-	lead := l.officeLeadSlug()
-	for _, task := range tasks {
-		if slug == lead || strings.TrimSpace(task.Owner) == slug {
-			addTask(task)
-		}
-	}
-	if len(lines) == 0 {
-		for _, task := range tasks {
-			addTask(task)
-		}
-	}
-	if len(lines) == 0 {
-		if slug == lead {
-			return "Active tasks:\n- None currently active. If the overall build is not actually finished, create the next owned task(s) now instead of ending with narrative next steps."
-		}
-		return ""
-	}
-
-	result := "Active tasks:\n" + strings.Join(lines, "\n")
-	if slug == lead {
-		reviewCount := 0
-		for _, task := range tasks {
-			if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
-				continue
-			}
-			if strings.EqualFold(strings.TrimSpace(task.Status), "review") || strings.EqualFold(strings.TrimSpace(task.ReviewState), "ready_for_review") {
-				reviewCount++
-			}
-		}
-		if reviewCount > 0 {
-			result += fmt.Sprintf("\nLead action: %d task(s) are waiting in review. Approve them or translate them into the next owned task(s) before you stop.", reviewCount)
-		}
-	}
-	return result
+func (l *Launcher) buildTaskNotificationContext(channelSlug, slug string, limit int) string {
+	return l.notifyCtx().TaskNotificationContext(channelSlug, slug, limit)
 }
 
 func (l *Launcher) relevantTaskForTarget(msg channelMessage, slug string) (teamTask, bool) {
-	if l.broker == nil || slug == "" {
-		return teamTask{}, false
-	}
-	threadRoot := strings.TrimSpace(msg.ID)
-	if replyTo := strings.TrimSpace(msg.ReplyTo); replyTo != "" {
-		threadRoot = replyTo
-	}
-	// Search all channels: a specialist's task may live in a dedicated channel (e.g.
-	// "engineering") even when the triggering message arrived from "general". Using
-	// ChannelTasks(channel) here caused cross-channel delegations to silently omit the
-	// "Active task" line from work packets and give specialists the wrong response
-	// instruction ("stay quiet" instead of "you own matching work").
-	var domainOwned teamTask
-	bestOwnedScore := 0.0
-	for _, task := range l.broker.AllTasks() {
-		if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
-			continue
-		}
-		if strings.TrimSpace(task.Owner) != slug {
-			continue
-		}
-		if task.ThreadID != "" && (task.ThreadID == msg.ID || task.ThreadID == threadRoot) {
-			return task, true
-		}
-		score := l.scoreMessageForTaskCandidate(msg, task)
-		if score >= officeRoutingMatchThreshold && score > bestOwnedScore {
-			domainOwned = task
-			bestOwnedScore = score
-		}
-	}
-	if domainOwned.ID != "" {
-		return domainOwned, true
-	}
-	return teamTask{}, false
+	return l.notifyCtx().RelevantTaskForTarget(msg, slug)
 }
 
 func (l *Launcher) responseInstructionForTarget(msg channelMessage, slug string) string {
-	lead := l.officeLeadSlug()
-	if slug == lead {
-		// When the CEO is woken by a specialist (msg.From is not human/you/system),
-		// the context is different: the specialist just finished work and the CEO
-		// should review and deliver or coordinate, not re-initiate. When woken by
-		// the human, the CEO should reply quickly and route.
-		from := strings.TrimSpace(msg.From)
-		isFromHuman := from == "" || from == "you" || from == "human" || from == "nex"
-		if !isFromHuman {
-			return fmt.Sprintf("You are @%s. A specialist just finished a lane. If the build is still underway, any task is open or in review, or the next lane is obvious, act now: approve/release review items, create the next owned team_task records, and only then stop. On a human build/ship/end-to-end request, if you approve or close an engineering/execution slice and the product is not yet runnable end to end, you MUST leave at least one engineering or execution lane active before you stop; do not let the company drift into GTM-only, rubric-only, or evaluation-only work while the build is still incomplete. Before you say a task is approved, closed, back in progress, reassigned, or blocked, you MUST make the matching team_task or team_plan call first; channel narration alone does not change durable state. If the task mutation fails, say that it failed and do not claim the state changed. Before creating any new task, inspect Active tasks in this packet: if a live task already covers that lane, reuse or update that task instead of creating an overlapping duplicate with a new title. Stay quiet only when the human already has what they need AND there is no remaining office work or obvious follow-up.", slug)
-		}
-		return fmt.Sprintf("You are @%s. Give the first top-level reply quickly, then pull in specialists only when needed. For build/ship/end-to-end requests, the first engineering task itself must be a single smallest runnable feature slice, not an MVP umbrella or a multi-output minimum bar. Do not put a separate repo audit, architecture, or cut-line research task in front of that first feature unless the human explicitly asked for analysis first or the repo truly has no identifiable implementation target. Do not spend the whole first turn on `pwd`, `ls`, `rg --files`, `find .`, or another repo-wide inventory; use the named docs/configs in the packet or at most one or two targeted reads, then create the first durable task/channel state in that same turn. %s", slug, capabilityGapCoachingBlock())
-	}
-	// DMs are direct conversations: the human chose to message this agent
-	// specifically. Always respond, regardless of @tags or task ownership.
-	if ch := normalizeChannelSlug(msg.Channel); IsDMSlug(ch) && DMTargetAgent(ch) == slug {
-		return fmt.Sprintf("You are @%s. The human is messaging you directly in a DM. Respond helpfully from your domain expertise.", slug)
-	}
-	// Also check the new Store-based DM format (deterministic slug).
-	if isDM, agentTarget := l.isChannelDM(normalizeChannelSlug(msg.Channel)); isDM && agentTarget == slug {
-		return fmt.Sprintf("You are @%s. The human is messaging you directly in a DM. Respond helpfully from your domain expertise.", slug)
-	}
-	if containsSlug(msg.Tagged, slug) {
-		return fmt.Sprintf("You are @%s. You were directly tagged. Reply only from your domain with concrete progress, a blocker, or a handoff.", slug)
-	}
-	if task, ok := l.relevantTaskForTarget(msg, slug); ok && strings.TrimSpace(task.Owner) == slug {
-		if taskRequiresRealExternalExecution(&task) {
-			return fmt.Sprintf("You are @%s. You already own matching work that requires a real connected-system action. Take the smallest allowed live external step now or report a blocker; repo docs, previews, local markdown, proof markers, and test artifacts do not satisfy it. Frame the result as a business deliverable, approval, handoff, or record, not as an eval or proof artifact. %s %s", slug, capabilityGapCoachingBlock(), taskHygieneCoachingBlock())
-		}
-		return fmt.Sprintf("You are @%s. You already own matching work. Reply only with concrete progress or a blocker; do not re-triage the thread.", slug)
-	}
-	return fmt.Sprintf("You are @%s. Stay quiet unless you are directly tagged, you own the active work, or you can unblock it. Prefer not to reply.", slug)
+	return l.notifyCtx().ResponseInstructionForTarget(msg, slug)
 }
 
 func (l *Launcher) buildMessageWorkPacket(msg channelMessage, slug string) string {
-	channel := normalizeChannelSlug(msg.Channel)
-	if channel == "" {
-		channel = "general"
-	}
-	lines := []string{
-		"Work packet:",
-		fmt.Sprintf("- Thread: #%s reply_to %s", channel, msg.ID),
-	}
-	// Add DM context preamble when the agent is receiving a direct message.
-	// This replaces the "stay quiet unless tagged" default with explicit DM semantics.
-	if isDM, _ := l.isChannelDM(channel); isDM {
-		dmPreamble := []string{
-			"Context: DIRECT MESSAGE",
-			"This is a private 1:1 conversation with the human. Respond to every message.",
-			"You do not need to coordinate with other agents.",
-			"---",
-		}
-		lines = append(dmPreamble, lines...)
-	} else if l.broker != nil {
-		// Check for group DM context.
-		cs := l.broker.ChannelStore()
-		if cs != nil {
-			if storeChannel, ok := cs.GetBySlug(channel); ok && storeChannel.Type == "G" {
-				members := cs.Members(storeChannel.ID)
-				names := make([]string, 0, len(members))
-				for _, m := range members {
-					if m.Slug != slug {
-						names = append(names, "@"+m.Slug)
-					}
-				}
-				groupPreamble := []string{
-					"Context: GROUP MESSAGE",
-					fmt.Sprintf("This is a group conversation with: %s.", strings.Join(names, ", ")),
-					"Respond to messages directed at you or within your expertise.",
-					"---",
-				}
-				lines = append(groupPreamble, lines...)
-			}
-		}
-	}
-	if containsSlug(msg.Tagged, slug) {
-		lines = append(lines, "- Trigger: you were explicitly tagged")
-	}
-	if task, ok := l.relevantTaskForTarget(msg, slug); ok {
-		lines = append(lines, fmt.Sprintf("- Active task: #%s %s (%s)", task.ID, truncate(task.Title, 96), strings.TrimSpace(task.Status)))
-		if details := strings.TrimSpace(task.Details); details != "" {
-			lines = append(lines, fmt.Sprintf("- Task details: %s", truncate(details, 512)))
-		}
-		if path := strings.TrimSpace(task.WorktreePath); path != "" {
-			lines = append(lines, fmt.Sprintf("- Working directory: %q", path))
-		}
-	}
-	// Walk up the reply chain to find the ultimate thread root (the original human
-	// ask) before filtering. This ensures that for a deep thread — human ask (X) →
-	// CEO delegation (Y) → specialist response (Z) — all participants see X as the
-	// anchor, not just the immediate parent. For top-level messages (ReplyTo == ""),
-	// ultimateThreadRoot returns "" and the function falls back to recent channel
-	// context automatically.
-	threadRoot := l.ultimateThreadRoot(channel, msg.ReplyTo)
-	if ctx := l.buildNotificationContext(channel, msg.ID, threadRoot, 4); ctx != "" {
-		lines = append(lines, ctx)
-	}
-	if slug == l.officeLeadSlug() {
-		// Always use AllTasks (pass "") so the CEO sees tasks across all channels,
-		// not just the channel of the message that woke them. Without this, a CEO
-		// woken from the "engineering" channel would miss "general"-channel tasks.
-		if taskCtx := l.buildTaskNotificationContext("", slug, 3); taskCtx != "" {
-			lines = append(lines, taskCtx)
-		}
-		// For the lead (CEO), explicitly list which specialist agents have already
-		// posted in this thread OR are currently queued/active in the headless runner.
-		// This prevents CEO from re-routing agents who are already working, including
-		// the race-condition case where a specialist was notified but hasn't posted yet.
-		// Rule: if a specialist is in this list, HOLD — do not tag them.
-		activeAgents := map[string]struct{}{}
-		if l.broker != nil {
-			// Collect all message IDs that belong to this thread (full BFS from
-			// the ultimate root). This prevents the CEO from re-routing specialists
-			// who already acted at any depth, including the case of parallel
-			// delegations where two specialists both replied to the original ask.
-			threadRoot := strings.TrimSpace(l.ultimateThreadRoot(channel, msg.ReplyTo))
-			if threadRoot == "" {
-				threadRoot = strings.TrimSpace(msg.ID)
-			}
-			threadIDs := l.threadMessageIDs(channel, threadRoot)
-			allMsgs := l.broker.ChannelMessages(channel)
-			for _, tm := range allMsgs {
-				if _, inThread := threadIDs[strings.TrimSpace(tm.ID)]; !inThread {
-					continue
-				}
-				if tm.From != "" && tm.From != "you" && tm.From != "human" && tm.From != "nex" && tm.From != slug {
-					activeAgents[tm.From] = struct{}{}
-				}
-			}
-		}
-		// Also include specialists who have pending or active headless turns.
-		// These agents were notified but may not have posted to the broker yet,
-		// causing a timing gap where the broker list misses them.
-		l.headlessMu.Lock()
-		for workerSlug, queue := range l.headlessQueues {
-			if workerSlug == slug {
-				continue
-			}
-			if len(queue) > 0 {
-				activeAgents[workerSlug] = struct{}{}
-			}
-		}
-		for workerSlug, active := range l.headlessActive {
-			// Skip the lead itself — it should never list itself as "already active".
-			if workerSlug == slug {
-				continue
-			}
-			if active != nil {
-				activeAgents[workerSlug] = struct{}{}
-			}
-		}
-		l.headlessMu.Unlock()
-		if len(activeAgents) > 0 {
-			names := make([]string, 0, len(activeAgents))
-			for name := range activeAgents {
-				names = append(names, "@"+name)
-			}
-			// Sort so this line is byte-identical across spawns that see the same
-			// set of active agents; Go map iteration order is randomized and would
-			// otherwise break prompt caching on the work-packet suffix.
-			sort.Strings(names)
-			lines = append(lines, fmt.Sprintf("- Already active in this thread (do NOT re-route): %s", strings.Join(names, ", ")))
-		}
-	}
-	return strings.Join(lines, "\n")
+	return l.notifyCtx().BuildMessageWorkPacket(msg, slug)
 }
 
 func (l *Launcher) buildTaskExecutionPacket(slug string, action officeActionLog, task teamTask, content string) string {
-	channel := normalizeChannelSlug(task.Channel)
-	if channel == "" {
-		channel = "general"
-	}
-	lines := []string{
-		fmt.Sprintf("[Task update from @%s]", action.Actor),
-		"Work packet:",
-		fmt.Sprintf("- Task: #%s %s", task.ID, truncate(task.Title, 120)),
-		fmt.Sprintf("- Status: %s", strings.TrimSpace(task.Status)),
-		fmt.Sprintf("- Owner: @%s", slug),
-	}
-	if details := strings.TrimSpace(task.Details); details != "" {
-		lines = append(lines, fmt.Sprintf("- Details: %s", truncate(details, 512)))
-	}
-	if targets := extractTaskFileTargets(task.Title + " " + task.Details); len(targets) > 0 {
-		lines = append(lines, fmt.Sprintf("- Named file targets: %s", strings.Join(targets, ", ")))
-	}
-	if task.ThreadID != "" {
-		lines = append(lines, fmt.Sprintf("- Thread: #%s reply_to %s", channel, task.ThreadID))
-	} else {
-		lines = append(lines, fmt.Sprintf("- Channel: #%s", channel))
-	}
-	lines = append(lines, fmt.Sprintf("- Mutation channel: use #%s when claiming or completing #%s", channel, task.ID))
-	if path := strings.TrimSpace(task.WorktreePath); path != "" {
-		lines = append(lines, fmt.Sprintf("- Working directory: %q", path))
-	}
-	if strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") {
-		lines = append(lines, "Execution rule: this is a local_worktree build task. Work inside the assigned working_directory and default to direct implementation. Do not spend this turn on another repo audit, architecture memo, or nested office launch unless the packet explicitly asks for that.")
-		lines = append(lines, "First-turn rule: choose the smallest shippable implementation slice you can finish in this turn and edit files for that slice now. If the overall MVP is broad, narrow it yourself and ship the first runnable sub-piece instead of trying to map the whole system.")
-		lines = append(lines, "Time rule: cut scope to something you can plausibly ship in under five minutes of focused work. If the chosen slice still needs broad exploration, cut it down again before you continue.")
-		lines = append(lines, "Cut-line rule: if the task description lists multiple outputs or phases, pick exactly one contiguous slice for this turn, then post team_status naming that cut line before you read files. Example cut lines: `config -> idea queue`, `idea queue -> script drafts`, or `script drafts -> publish pack`.")
-		if targets := extractTaskFileTargets(task.Title + " " + task.Details); len(targets) > 0 {
-			lines = append(lines, "Startup rule: open the named file targets first and use them as your starting point. Do not broaden into repo search unless those exact files are insufficient for the chosen cut line.")
-		}
-		lines = append(lines, "Audit guardrail: do NOT start with `rg --files`, `find .`, repo-wide README sweeps, or broad file inventories. Read only the handful of files directly tied to this task, then begin editing once you have the first target file.")
-		lines = append(lines, "Boundary rule: stay inside the assigned working_directory. Do NOT run `find ..`, `rg ..`, search sibling task worktrees, or inspect parent temp directories like `/var/folders`, `TMPDIR`, or `TemporaryItems`. Those paths are sandbox noise, not repo context.")
-		lines = append(lines, "Dirty-tree rule: ignore unrelated modified or untracked files already present in the worktree unless they are directly required for your slice. They may be preexisting repo state, not part of your task.")
-		lines = append(lines, "Deliverable rule: a local_worktree feature task is not satisfied by another plan, architecture memo, or audit summary unless the packet explicitly says research-only. Land code, scripts, docs for the runnable slice, or a concrete task-state blocker.")
-	}
-	if taskRequiresRealExternalExecution(&task) {
-		lines = append(lines, "External execution rule: this task names a connected external system and expects a real action there. Use the live integration/workflow path for the smallest allowed step now instead of producing another repo doc, proof marker, or internal package first.")
-		lines = append(lines, "Evidence rule: a local markdown file, preview note, repo artifact, or test output does NOT satisfy this task unless the packet explicitly says preview/mock/stub-only. Leave durable external evidence through the broker-integrated workflow/integration path before marking the task review-ready, done, or blocked.")
-		lines = append(lines, "Business framing: describe the work as a client deliverable, approval, handoff, update, or record. Avoid proof/marker/test/eval language unless the task explicitly asks for testing or evidence capture.")
-		lines = append(lines, "Pace rule: do the smallest safe external step first, then summarize it. Do not spend this turn building extra kickoff decks, review bundles, or substitute proof artifacts if the connected system action is already allowed.")
-		lines = append(lines, capabilityGapCoachingBlock())
-	}
-	if taskLooksLikeLiveBusinessObjective(&task) {
-		lines = append(lines, "Task hygiene rule: if this lane drifts into a proof packet, review bundle, blueprint-derived scaffold, rubric, or other internal artifact shell, rewrite it immediately into either the next real deliverable step or the exact capability-enablement task that will unlock that deliverable.")
-	}
-	// Walk up from task.ThreadID to the ultimate thread root (the original human ask)
-	// so agents see the full ancestry, not just a mid-thread branch. The thread root
-	// is never excluded (triggerMsgID = "") because the human's ask is the useful
-	// anchor, not a duplicate of anything in the packet header.
-	threadRoot := l.ultimateThreadRoot(channel, task.ThreadID)
-	if ctx := l.buildNotificationContext(channel, "", threadRoot, 3); ctx != "" {
-		lines = append(lines, ctx)
-	}
-	lines = append(lines, fmt.Sprintf("If you deliver the substantive result for #%s in this turn, you MUST call team_task complete or review-ready for \"%s\" before any completion post and before you stop. A channel reply alone does not unblock dependent work, and a completion post without the task mutation is a failure.", task.ID, task.ID))
-	lines = append(lines, "Runtime rule: never launch another WUPHF office, copied wuphf binary, browser instance, or local web server/--web-port process from inside this turn. The office is already running; use the existing repo, broker state, and assigned worktree instead.")
-	lines = append(lines, fmt.Sprintf("%s Use team_task with my_slug \"%s\" to update status as you go.", truncate(content, 1000), slug))
-	return strings.Join(lines, "\n")
+	return l.notifyCtx().BuildTaskExecutionPacket(slug, action, task, content)
 }
 
 func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessage) {

--- a/internal/team/notification_context.go
+++ b/internal/team/notification_context.go
@@ -1,0 +1,696 @@
+package team
+
+// notification_context.go owns the per-target notification-context and
+// work-packet construction that used to live as ten methods on Launcher
+// (PLAN.md §C3). The cluster is pure-string assembly over broker reads —
+// no goroutines, no tmux, no broker writes — so it can be exercised with
+// stub callbacks instead of a fully-wired Broker fixture.
+//
+// State sharing notes (PLAN.md §5.7): primeVisibleAgents and
+// respawnPanesAfterReseed straddle this cluster and the future
+// paneLifecycle (C5). Both stay on Launcher (and call the builder) so
+// the dependency direction is paneLifecycle → notificationContext, never
+// the reverse — see the trap discussion in PLAN.md.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/channel"
+)
+
+// notificationContextBuilder assembles the strings (notification context,
+// work packets, response instructions, task content) that get typed into
+// agent panes or sent through the headless dispatch queue. Constructed
+// fresh per call from launcher state so it always sees current broker
+// reads.
+type notificationContextBuilder struct {
+	targeter *officeTargeter
+
+	// Broker-shaped reads. Callbacks rather than a *Broker pointer so tests
+	// can stub without instantiating the full broker (and so headless
+	// queue peeks below stay scoped to one accessor).
+	channelMessages func(channel string) []channelMessage
+	channelTasks    func(channel string) []teamTask
+	allTasks        func() []teamTask
+	channelStore    func() *channel.Store
+
+	// scoreTaskCandidate is the routing.go score function pulled in via
+	// callback; the builder doesn't need to know about routing internals.
+	scoreTaskCandidate func(msg channelMessage, task teamTask) float64
+
+	// activeHeadlessAgents returns slugs that have non-empty headless
+	// queues or active turns at the moment of the call. The launcher
+	// implements this with the headlessMu lock held; the builder treats
+	// it as opaque. The except parameter is the slug being notified —
+	// the lead must not list itself as "already active".
+	activeHeadlessAgents func(except string) map[string]struct{}
+}
+
+// NotificationContext returns the recent-messages context block for the
+// given (channel, threadRoot) pair. Excludes the trigger message itself,
+// system messages, demo_seed posts, and STATUS chatter. Thread-scoped
+// when threadRoot is non-empty (anchors at root + most-recent thread
+// activity); recent-channel fallback otherwise.
+func (b *notificationContextBuilder) NotificationContext(channel, triggerMsgID, threadRootID string, limit int) string {
+	if b == nil || b.channelMessages == nil {
+		return ""
+	}
+	if strings.TrimSpace(channel) == "" {
+		channel = "general"
+	}
+
+	msgs := b.channelMessages(channel)
+	if len(msgs) == 0 {
+		return ""
+	}
+
+	baseFilter := func(m channelMessage) bool {
+		if m.From == "system" {
+			return false
+		}
+		if m.Kind == "demo_seed" {
+			return false
+		}
+		if strings.TrimSpace(triggerMsgID) != "" && strings.TrimSpace(m.ID) == strings.TrimSpace(triggerMsgID) {
+			return false
+		}
+		if strings.HasPrefix(strings.TrimSpace(m.Content), "[STATUS]") {
+			return false
+		}
+		return true
+	}
+
+	formatContext := func(items []channelMessage) string {
+		var sb strings.Builder
+		for _, m := range items {
+			sb.WriteString(fmt.Sprintf("@%s: %s\n", m.From, truncate(m.Content, 600)))
+		}
+		return strings.TrimRight(sb.String(), "\n")
+	}
+
+	threadRoot := strings.TrimSpace(threadRootID)
+	if threadRoot != "" {
+		threadIDs := b.ThreadMessageIDs(channel, threadRoot)
+		var rootMsg *channelMessage
+		var rest []channelMessage
+		for i := range msgs {
+			m := &msgs[i]
+			if !baseFilter(*m) {
+				continue
+			}
+			if strings.TrimSpace(m.ID) == threadRoot {
+				rootMsg = m
+			} else if _, inThread := threadIDs[strings.TrimSpace(m.ID)]; inThread {
+				rest = append(rest, *m)
+			}
+		}
+		if rootMsg != nil || len(rest) > 0 {
+			remaining := limit
+			if rootMsg != nil {
+				remaining--
+			}
+			if len(rest) > remaining {
+				rest = rest[len(rest)-remaining:]
+			}
+			var thread []channelMessage
+			if rootMsg != nil {
+				thread = append(thread, *rootMsg)
+			}
+			thread = append(thread, rest...)
+			return "[Recent thread]\n" + formatContext(thread)
+		}
+	}
+
+	var filtered []channelMessage
+	for _, m := range msgs {
+		if baseFilter(m) {
+			filtered = append(filtered, m)
+		}
+	}
+	if len(filtered) == 0 {
+		return ""
+	}
+	if len(filtered) > limit {
+		filtered = filtered[len(filtered)-limit:]
+	}
+	return "[Recent channel]\n" + formatContext(filtered)
+}
+
+// UltimateThreadRoot walks the reply-to chain from startID up to the
+// topmost ancestor and returns its ID. Caps at 8 hops to defend against
+// cycles or pathological data.
+func (b *notificationContextBuilder) UltimateThreadRoot(channelSlug, startID string) string {
+	startID = strings.TrimSpace(startID)
+	if b == nil || startID == "" || b.channelMessages == nil {
+		return startID
+	}
+	msgs := b.channelMessages(channelSlug)
+	byID := make(map[string]channelMessage, len(msgs))
+	for _, m := range msgs {
+		if id := strings.TrimSpace(m.ID); id != "" {
+			byID[id] = m
+		}
+	}
+	root := startID
+	for depth := 0; depth < 8; depth++ {
+		m, ok := byID[root]
+		if !ok {
+			break
+		}
+		parent := strings.TrimSpace(m.ReplyTo)
+		if parent == "" {
+			break
+		}
+		root = parent
+	}
+	return root
+}
+
+// ThreadMessageIDs returns the BFS set of message IDs rooted at rootID.
+// The root itself is included. Empty when rootID is empty.
+func (b *notificationContextBuilder) ThreadMessageIDs(channelSlug, rootID string) map[string]struct{} {
+	rootID = strings.TrimSpace(rootID)
+	result := make(map[string]struct{})
+	if b == nil || rootID == "" || b.channelMessages == nil {
+		return result
+	}
+	msgs := b.channelMessages(channelSlug)
+	byParent := make(map[string][]string, len(msgs))
+	for _, m := range msgs {
+		parent := strings.TrimSpace(m.ReplyTo)
+		if parent != "" {
+			byParent[parent] = append(byParent[parent], strings.TrimSpace(m.ID))
+		}
+	}
+	result[rootID] = struct{}{}
+	queue := []string{rootID}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, child := range byParent[cur] {
+			if _, seen := result[child]; !seen {
+				result[child] = struct{}{}
+				queue = append(queue, child)
+			}
+		}
+	}
+	return result
+}
+
+// TaskNotificationContext returns the "Active tasks:" block for the given
+// agent. Lead agents see all-channel tasks (sort by UpdatedAt desc),
+// non-leads see their own owned work first then a short fallback list.
+// Lead agents also get a review-backlog hint when tasks are stuck waiting
+// on review.
+func (b *notificationContextBuilder) TaskNotificationContext(channelSlug, slug string, limit int) string {
+	if b == nil || limit <= 0 {
+		return ""
+	}
+	var tasks []teamTask
+	if strings.TrimSpace(channelSlug) == "" {
+		if b.allTasks == nil {
+			return ""
+		}
+		tasks = b.allTasks()
+	} else {
+		if b.channelTasks == nil {
+			return ""
+		}
+		tasks = b.channelTasks(channelSlug)
+	}
+	if len(tasks) == 0 {
+		return ""
+	}
+
+	formatTask := func(task teamTask) string {
+		owner := strings.TrimSpace(task.Owner)
+		switch {
+		case owner == "":
+			owner = "unassigned"
+		default:
+			owner = "@" + owner
+		}
+		status := strings.TrimSpace(task.Status)
+		if status == "" {
+			status = "open"
+		}
+		meta := owner + ", " + status
+		if task.Blocked {
+			meta += ", blocked"
+		}
+		if len(task.DependsOn) > 0 {
+			meta += ", depends: " + strings.Join(task.DependsOn, " ")
+		}
+		taskChannel := normalizeChannelSlug(task.Channel)
+		if taskChannel == "" {
+			taskChannel = "general"
+		}
+		line := fmt.Sprintf("- #%s on #%s %s (%s)", task.ID, taskChannel, truncate(task.Title, 72), meta)
+		if details := strings.TrimSpace(task.Details); details != "" {
+			line += ": " + truncate(details, 96)
+		}
+		return line
+	}
+
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].UpdatedAt > tasks[j].UpdatedAt
+	})
+
+	lines := make([]string, 0, limit)
+	seen := make(map[string]struct{}, limit)
+	addTask := func(task teamTask) {
+		if len(lines) >= limit {
+			return
+		}
+		if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
+			return
+		}
+		if _, ok := seen[task.ID]; ok {
+			return
+		}
+		seen[task.ID] = struct{}{}
+		lines = append(lines, formatTask(task))
+	}
+
+	lead := b.targeter.LeadSlug()
+	for _, task := range tasks {
+		if slug == lead || strings.TrimSpace(task.Owner) == slug {
+			addTask(task)
+		}
+	}
+	if len(lines) == 0 {
+		for _, task := range tasks {
+			addTask(task)
+		}
+	}
+	if len(lines) == 0 {
+		if slug == lead {
+			return "Active tasks:\n- None currently active. If the overall build is not actually finished, create the next owned task(s) now instead of ending with narrative next steps."
+		}
+		return ""
+	}
+
+	result := "Active tasks:\n" + strings.Join(lines, "\n")
+	if slug == lead {
+		reviewCount := 0
+		for _, task := range tasks {
+			if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(task.Status), "review") || strings.EqualFold(strings.TrimSpace(task.ReviewState), "ready_for_review") {
+				reviewCount++
+			}
+		}
+		if reviewCount > 0 {
+			result += fmt.Sprintf("\nLead action: %d task(s) are waiting in review. Approve them or translate them into the next owned task(s) before you stop.", reviewCount)
+		}
+	}
+	return result
+}
+
+// RelevantTaskForTarget returns a task this slug owns that's tied to the
+// given message — first by ThreadID match, then by message-vs-task scoring
+// above the routing threshold. Done tasks and other-owned tasks never
+// match.
+func (b *notificationContextBuilder) RelevantTaskForTarget(msg channelMessage, slug string) (teamTask, bool) {
+	if b == nil || b.allTasks == nil || slug == "" {
+		return teamTask{}, false
+	}
+	threadRoot := strings.TrimSpace(msg.ID)
+	if replyTo := strings.TrimSpace(msg.ReplyTo); replyTo != "" {
+		threadRoot = replyTo
+	}
+	var domainOwned teamTask
+	bestOwnedScore := 0.0
+	for _, task := range b.allTasks() {
+		if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
+			continue
+		}
+		if strings.TrimSpace(task.Owner) != slug {
+			continue
+		}
+		if task.ThreadID != "" && (task.ThreadID == msg.ID || task.ThreadID == threadRoot) {
+			return task, true
+		}
+		if b.scoreTaskCandidate == nil {
+			continue
+		}
+		score := b.scoreTaskCandidate(msg, task)
+		if score >= officeRoutingMatchThreshold && score > bestOwnedScore {
+			domainOwned = task
+			bestOwnedScore = score
+		}
+	}
+	if domainOwned.ID != "" {
+		return domainOwned, true
+	}
+	return teamTask{}, false
+}
+
+// ResponseInstructionForTarget returns the per-agent guidance string
+// appended to a notification. Branches: lead-from-human, lead-from-
+// specialist, DM, tagged, owns-matching-task, default-stay-quiet.
+func (b *notificationContextBuilder) ResponseInstructionForTarget(msg channelMessage, slug string) string {
+	lead := b.targeter.LeadSlug()
+	if slug == lead {
+		from := strings.TrimSpace(msg.From)
+		isFromHuman := from == "" || from == "you" || from == "human" || from == "nex"
+		if !isFromHuman {
+			return fmt.Sprintf("You are @%s. A specialist just finished a lane. If the build is still underway, any task is open or in review, or the next lane is obvious, act now: approve/release review items, create the next owned team_task records, and only then stop. On a human build/ship/end-to-end request, if you approve or close an engineering/execution slice and the product is not yet runnable end to end, you MUST leave at least one engineering or execution lane active before you stop; do not let the company drift into GTM-only, rubric-only, or evaluation-only work while the build is still incomplete. Before you say a task is approved, closed, back in progress, reassigned, or blocked, you MUST make the matching team_task or team_plan call first; channel narration alone does not change durable state. If the task mutation fails, say that it failed and do not claim the state changed. Before creating any new task, inspect Active tasks in this packet: if a live task already covers that lane, reuse or update that task instead of creating an overlapping duplicate with a new title. Stay quiet only when the human already has what they need AND there is no remaining office work or obvious follow-up.", slug)
+		}
+		return fmt.Sprintf("You are @%s. Give the first top-level reply quickly, then pull in specialists only when needed. For build/ship/end-to-end requests, the first engineering task itself must be a single smallest runnable feature slice, not an MVP umbrella or a multi-output minimum bar. Do not put a separate repo audit, architecture, or cut-line research task in front of that first feature unless the human explicitly asked for analysis first or the repo truly has no identifiable implementation target. Do not spend the whole first turn on `pwd`, `ls`, `rg --files`, `find .`, or another repo-wide inventory; use the named docs/configs in the packet or at most one or two targeted reads, then create the first durable task/channel state in that same turn. %s", slug, capabilityGapCoachingBlock())
+	}
+	channelSlug := normalizeChannelSlug(msg.Channel)
+	if IsDMSlug(channelSlug) && DMTargetAgent(channelSlug) == slug {
+		return fmt.Sprintf("You are @%s. The human is messaging you directly in a DM. Respond helpfully from your domain expertise.", slug)
+	}
+	if isDM, agentTarget := b.targeter.IsChannelDM(channelSlug); isDM && agentTarget == slug {
+		return fmt.Sprintf("You are @%s. The human is messaging you directly in a DM. Respond helpfully from your domain expertise.", slug)
+	}
+	if containsSlug(msg.Tagged, slug) {
+		return fmt.Sprintf("You are @%s. You were directly tagged. Reply only from your domain with concrete progress, a blocker, or a handoff.", slug)
+	}
+	if task, ok := b.RelevantTaskForTarget(msg, slug); ok && strings.TrimSpace(task.Owner) == slug {
+		if taskRequiresRealExternalExecution(&task) {
+			return fmt.Sprintf("You are @%s. You already own matching work that requires a real connected-system action. Take the smallest allowed live external step now or report a blocker; repo docs, previews, local markdown, proof markers, and test artifacts do not satisfy it. Frame the result as a business deliverable, approval, handoff, or record, not as an eval or proof artifact. %s %s", slug, capabilityGapCoachingBlock(), taskHygieneCoachingBlock())
+		}
+		return fmt.Sprintf("You are @%s. You already own matching work. Reply only with concrete progress or a blocker; do not re-triage the thread.", slug)
+	}
+	return fmt.Sprintf("You are @%s. Stay quiet unless you are directly tagged, you own the active work, or you can unblock it. Prefer not to reply.", slug)
+}
+
+// BuildMessageWorkPacket returns the work packet a notified agent receives
+// for a channel message: header lines (thread / DM preamble / group
+// preamble / tagged hint / active task), recent-message context, and (for
+// the lead) a list of agents who have already acted in this thread or
+// have pending headless turns ("do NOT re-route").
+func (b *notificationContextBuilder) BuildMessageWorkPacket(msg channelMessage, slug string) string {
+	channelSlug := normalizeChannelSlug(msg.Channel)
+	if channelSlug == "" {
+		channelSlug = "general"
+	}
+	lines := []string{
+		"Work packet:",
+		fmt.Sprintf("- Thread: #%s reply_to %s", channelSlug, msg.ID),
+	}
+	if isDM, _ := b.targeter.IsChannelDM(channelSlug); isDM {
+		dmPreamble := []string{
+			"Context: DIRECT MESSAGE",
+			"This is a private 1:1 conversation with the human. Respond to every message.",
+			"You do not need to coordinate with other agents.",
+			"---",
+		}
+		lines = append(dmPreamble, lines...)
+	} else if b.channelStore != nil {
+		if cs := b.channelStore(); cs != nil {
+			if storeChannel, ok := cs.GetBySlug(channelSlug); ok && storeChannel.Type == "G" {
+				members := cs.Members(storeChannel.ID)
+				names := make([]string, 0, len(members))
+				for _, m := range members {
+					if m.Slug != slug {
+						names = append(names, "@"+m.Slug)
+					}
+				}
+				groupPreamble := []string{
+					"Context: GROUP MESSAGE",
+					fmt.Sprintf("This is a group conversation with: %s.", strings.Join(names, ", ")),
+					"Respond to messages directed at you or within your expertise.",
+					"---",
+				}
+				lines = append(groupPreamble, lines...)
+			}
+		}
+	}
+	if containsSlug(msg.Tagged, slug) {
+		lines = append(lines, "- Trigger: you were explicitly tagged")
+	}
+	if task, ok := b.RelevantTaskForTarget(msg, slug); ok {
+		lines = append(lines, fmt.Sprintf("- Active task: #%s %s (%s)", task.ID, truncate(task.Title, 96), strings.TrimSpace(task.Status)))
+		if details := strings.TrimSpace(task.Details); details != "" {
+			lines = append(lines, fmt.Sprintf("- Task details: %s", truncate(details, 512)))
+		}
+		if path := strings.TrimSpace(task.WorktreePath); path != "" {
+			lines = append(lines, fmt.Sprintf("- Working directory: %q", path))
+		}
+	}
+	threadRoot := b.UltimateThreadRoot(channelSlug, msg.ReplyTo)
+	if ctx := b.NotificationContext(channelSlug, msg.ID, threadRoot, 4); ctx != "" {
+		lines = append(lines, ctx)
+	}
+	if slug == b.targeter.LeadSlug() {
+		if taskCtx := b.TaskNotificationContext("", slug, 3); taskCtx != "" {
+			lines = append(lines, taskCtx)
+		}
+		activeAgents := map[string]struct{}{}
+		if b.channelMessages != nil {
+			threadRoot := strings.TrimSpace(b.UltimateThreadRoot(channelSlug, msg.ReplyTo))
+			if threadRoot == "" {
+				threadRoot = strings.TrimSpace(msg.ID)
+			}
+			threadIDs := b.ThreadMessageIDs(channelSlug, threadRoot)
+			for _, tm := range b.channelMessages(channelSlug) {
+				if _, inThread := threadIDs[strings.TrimSpace(tm.ID)]; !inThread {
+					continue
+				}
+				if tm.From != "" && tm.From != "you" && tm.From != "human" && tm.From != "nex" && tm.From != slug {
+					activeAgents[tm.From] = struct{}{}
+				}
+			}
+		}
+		if b.activeHeadlessAgents != nil {
+			for s := range b.activeHeadlessAgents(slug) {
+				activeAgents[s] = struct{}{}
+			}
+		}
+		if len(activeAgents) > 0 {
+			names := make([]string, 0, len(activeAgents))
+			for name := range activeAgents {
+				names = append(names, "@"+name)
+			}
+			sort.Strings(names)
+			lines = append(lines, fmt.Sprintf("- Already active in this thread (do NOT re-route): %s", strings.Join(names, ", ")))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// BuildTaskExecutionPacket returns the work packet for a task assignment
+// or update. Includes the task header, worktree path, named file targets
+// pulled from title+details, local-worktree guardrails, external-execution
+// guidance for live business tasks, and the recent thread context.
+func (b *notificationContextBuilder) BuildTaskExecutionPacket(slug string, action officeActionLog, task teamTask, content string) string {
+	channelSlug := normalizeChannelSlug(task.Channel)
+	if channelSlug == "" {
+		channelSlug = "general"
+	}
+	lines := []string{
+		fmt.Sprintf("[Task update from @%s]", action.Actor),
+		"Work packet:",
+		fmt.Sprintf("- Task: #%s %s", task.ID, truncate(task.Title, 120)),
+		fmt.Sprintf("- Status: %s", strings.TrimSpace(task.Status)),
+		fmt.Sprintf("- Owner: @%s", slug),
+	}
+	if details := strings.TrimSpace(task.Details); details != "" {
+		lines = append(lines, fmt.Sprintf("- Details: %s", truncate(details, 512)))
+	}
+	if targets := extractTaskFileTargets(task.Title + " " + task.Details); len(targets) > 0 {
+		lines = append(lines, fmt.Sprintf("- Named file targets: %s", strings.Join(targets, ", ")))
+	}
+	if task.ThreadID != "" {
+		lines = append(lines, fmt.Sprintf("- Thread: #%s reply_to %s", channelSlug, task.ThreadID))
+	} else {
+		lines = append(lines, fmt.Sprintf("- Channel: #%s", channelSlug))
+	}
+	lines = append(lines, fmt.Sprintf("- Mutation channel: use #%s when claiming or completing #%s", channelSlug, task.ID))
+	if path := strings.TrimSpace(task.WorktreePath); path != "" {
+		lines = append(lines, fmt.Sprintf("- Working directory: %q", path))
+	}
+	if strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") {
+		lines = append(lines, "Execution rule: this is a local_worktree build task. Work inside the assigned working_directory and default to direct implementation. Do not spend this turn on another repo audit, architecture memo, or nested office launch unless the packet explicitly asks for that.")
+		lines = append(lines, "First-turn rule: choose the smallest shippable implementation slice you can finish in this turn and edit files for that slice now. If the overall MVP is broad, narrow it yourself and ship the first runnable sub-piece instead of trying to map the whole system.")
+		lines = append(lines, "Time rule: cut scope to something you can plausibly ship in under five minutes of focused work. If the chosen slice still needs broad exploration, cut it down again before you continue.")
+		lines = append(lines, "Cut-line rule: if the task description lists multiple outputs or phases, pick exactly one contiguous slice for this turn, then post team_status naming that cut line before you read files. Example cut lines: `config -> idea queue`, `idea queue -> script drafts`, or `script drafts -> publish pack`.")
+		if targets := extractTaskFileTargets(task.Title + " " + task.Details); len(targets) > 0 {
+			lines = append(lines, "Startup rule: open the named file targets first and use them as your starting point. Do not broaden into repo search unless those exact files are insufficient for the chosen cut line.")
+		}
+		lines = append(lines, "Audit guardrail: do NOT start with `rg --files`, `find .`, repo-wide README sweeps, or broad file inventories. Read only the handful of files directly tied to this task, then begin editing once you have the first target file.")
+		lines = append(lines, "Boundary rule: stay inside the assigned working_directory. Do NOT run `find ..`, `rg ..`, search sibling task worktrees, or inspect parent temp directories like `/var/folders`, `TMPDIR`, or `TemporaryItems`. Those paths are sandbox noise, not repo context.")
+		lines = append(lines, "Dirty-tree rule: ignore unrelated modified or untracked files already present in the worktree unless they are directly required for your slice. They may be preexisting repo state, not part of your task.")
+		lines = append(lines, "Deliverable rule: a local_worktree feature task is not satisfied by another plan, architecture memo, or audit summary unless the packet explicitly says research-only. Land code, scripts, docs for the runnable slice, or a concrete task-state blocker.")
+	}
+	if taskRequiresRealExternalExecution(&task) {
+		lines = append(lines, "External execution rule: this task names a connected external system and expects a real action there. Use the live integration/workflow path for the smallest allowed step now instead of producing another repo doc, proof marker, or internal package first.")
+		lines = append(lines, "Evidence rule: a local markdown file, preview note, repo artifact, or test output does NOT satisfy this task unless the packet explicitly says preview/mock/stub-only. Leave durable external evidence through the broker-integrated workflow/integration path before marking the task review-ready, done, or blocked.")
+		lines = append(lines, "Business framing: describe the work as a client deliverable, approval, handoff, update, or record. Avoid proof/marker/test/eval language unless the task explicitly asks for testing or evidence capture.")
+		lines = append(lines, "Pace rule: do the smallest safe external step first, then summarize it. Do not spend this turn building extra kickoff decks, review bundles, or substitute proof artifacts if the connected system action is already allowed.")
+		lines = append(lines, capabilityGapCoachingBlock())
+	}
+	if taskLooksLikeLiveBusinessObjective(&task) {
+		lines = append(lines, "Task hygiene rule: if this lane drifts into a proof packet, review bundle, blueprint-derived scaffold, rubric, or other internal artifact shell, rewrite it immediately into either the next real deliverable step or the exact capability-enablement task that will unlock that deliverable.")
+	}
+	threadRoot := b.UltimateThreadRoot(channelSlug, task.ThreadID)
+	if ctx := b.NotificationContext(channelSlug, "", threadRoot, 3); ctx != "" {
+		lines = append(lines, ctx)
+	}
+	lines = append(lines, fmt.Sprintf("If you deliver the substantive result for #%s in this turn, you MUST call team_task complete or review-ready for \"%s\" before any completion post and before you stop. A channel reply alone does not unblock dependent work, and a completion post without the task mutation is a failure.", task.ID, task.ID))
+	lines = append(lines, "Runtime rule: never launch another WUPHF office, copied wuphf binary, browser instance, or local web server/--web-port process from inside this turn. The office is already running; use the existing repo, broker state, and assigned worktree instead.")
+	lines = append(lines, fmt.Sprintf("%s Use team_task with my_slug \"%s\" to update status as you go.", truncate(content, 1000), slug))
+	return strings.Join(lines, "\n")
+}
+
+// TaskNotificationContent returns the short single-line task notification
+// header (verb, owner, status, optional pipeline / review / execMode /
+// worktree / guidance / framing / capability / hygiene fragments).
+func (b *notificationContextBuilder) TaskNotificationContent(action officeActionLog, task teamTask) string {
+	channelSlug := normalizeChannelSlug(task.Channel)
+	if channelSlug == "" {
+		channelSlug = "general"
+	}
+	verb := "Task update"
+	switch action.Kind {
+	case "task_created":
+		verb = "Task created"
+	case "task_updated":
+		verb = "Task updated"
+	case "task_unblocked":
+		verb = "Task unblocked — dependencies resolved, ready to start"
+	case "watchdog_alert":
+		verb = "Watchdog reminder"
+	}
+	owner := strings.TrimSpace(task.Owner)
+	if owner == "" {
+		owner = "unassigned"
+	} else {
+		owner = "@" + owner
+	}
+	status := strings.TrimSpace(task.Status)
+	if status == "" {
+		status = "open"
+	}
+	details := strings.TrimSpace(task.Details)
+	if details != "" {
+		details = " — " + truncate(details, 120)
+	}
+	pipeline := ""
+	if strings.TrimSpace(task.PipelineStage) != "" {
+		pipeline = ", stage " + task.PipelineStage
+	}
+	review := ""
+	if strings.TrimSpace(task.ReviewState) != "" && task.ReviewState != "not_required" {
+		review = ", review " + task.ReviewState
+	}
+	execMode := ""
+	if strings.TrimSpace(task.ExecutionMode) != "" {
+		execMode = ", execution " + task.ExecutionMode
+	}
+	worktree := ""
+	if strings.TrimSpace(task.WorktreeBranch) != "" || strings.TrimSpace(task.WorktreePath) != "" {
+		parts := make([]string, 0, 2)
+		if strings.TrimSpace(task.WorktreeBranch) != "" {
+			parts = append(parts, "branch "+task.WorktreeBranch)
+		}
+		if strings.TrimSpace(task.WorktreePath) != "" {
+			parts = append(parts, "path "+task.WorktreePath)
+		}
+		worktree = ", worktree " + strings.Join(parts, " · ")
+	}
+	guidance := ""
+	if path := strings.TrimSpace(task.WorktreePath); path != "" {
+		guidance = fmt.Sprintf(" If you own this task, use working_directory=%q for local file and bash tools.", path)
+	}
+	framing := ""
+	if taskRequiresRealExternalExecution(&task) {
+		framing = " Live business framing: describe the work as a client deliverable, approval, handoff, update, or record. Do not present it as a proof marker, eval artifact, or test artifact unless the task explicitly asks for testing or evidence capture."
+	}
+	capability := ""
+	if taskRequiresRealExternalExecution(&task) {
+		capability = "\n" + capabilityGapCoachingBlock()
+	}
+	hygiene := ""
+	if taskLooksLikeLiveBusinessObjective(&task) {
+		hygiene = "\n" + taskHygieneCoachingBlock()
+	}
+	return fmt.Sprintf("[%s #%s on #%s]: %s%s (owner %s, status %s%s%s%s%s). Context is included — do NOT call team_poll or team_tasks. Respond with the concrete next step immediately. Stay in your lane. Once you have posted the needed update, STOP and wait for the next pushed notification.%s%s%s%s", verb, task.ID, channelSlug, task.Title, details, owner, status, pipeline, review, execMode, worktree, guidance, framing, capability, hygiene)
+}
+
+// ── package-level helpers used inside the builder ──────────────────────
+
+// truncate clips s to max bytes followed by "..." when it overflows.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+// extractTaskFileTargets returns up to four backtick-quoted candidates
+// from text that look like file paths (contain "/" or "."). De-duplicated
+// in order; empty when nothing matches.
+func extractTaskFileTargets(text string) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	targets := make([]string, 0, 4)
+	for {
+		start := strings.Index(text, "`")
+		if start < 0 {
+			break
+		}
+		text = text[start+1:]
+		end := strings.Index(text, "`")
+		if end < 0 {
+			break
+		}
+		candidate := strings.TrimSpace(text[:end])
+		text = text[end+1:]
+		if candidate == "" {
+			continue
+		}
+		if !strings.Contains(candidate, "/") && !strings.Contains(candidate, ".") {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		targets = append(targets, candidate)
+		if len(targets) == 4 {
+			break
+		}
+	}
+	return targets
+}
+
+// humanizeNotificationType converts a snake_case kind into a Title Case
+// label for human display. Used by launcher_nex.go for nex notification
+// rendering as well as the task-execution packet header.
+func humanizeNotificationType(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case "context_alert":
+		return "Context alert"
+	case "daily_digest":
+		return "Daily digest"
+	case "meeting_summary":
+		return "Meeting summary"
+	case "task_reminder":
+		return "Task reminder"
+	case "task_assigned":
+		return "Task assigned"
+	default:
+		if kind == "" {
+			return ""
+		}
+		parts := strings.Split(strings.ReplaceAll(kind, "_", " "), " ")
+		for i, part := range parts {
+			if part == "" {
+				continue
+			}
+			parts[i] = strings.ToUpper(part[:1]) + part[1:]
+		}
+		return strings.Join(parts, " ")
+	}
+}

--- a/internal/team/notification_context_test.go
+++ b/internal/team/notification_context_test.go
@@ -1,0 +1,508 @@
+package team
+
+// Tests for the extracted notificationContextBuilder type. Written test-
+// first against the surface in PLAN.md §C3 before the type exists, so the
+// first run is a compile failure by design.
+//
+// The existing TestBuildNotificationContext / TestBuildMessageWorkPacket /
+// TestResponseInstructionForTarget* tests in launcher_test.go remain the
+// behavior baseline (they reach this surface via &Launcher{...}). The new
+// tests below exercise the type directly with stub broker callbacks so the
+// new file lands above the 85% per-file gate without depending on a
+// real Broker fixture.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/channel"
+)
+
+func newTestNotifyContextBuilder(t *testing.T, opts ...func(*notificationContextBuilder)) *notificationContextBuilder {
+	t.Helper()
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true, Name: "CEO"},
+		{Slug: "eng", Name: "Engineer"},
+	})
+	b := &notificationContextBuilder{
+		targeter:        tg,
+		channelMessages: func(string) []channelMessage { return nil },
+		channelTasks:    func(string) []teamTask { return nil },
+		allTasks:        func() []teamTask { return nil },
+		channelStore:    func() *channel.Store { return nil },
+		scoreTaskCandidate: func(msg channelMessage, task teamTask) float64 {
+			// Default: only direct ID/owner matches, no fuzzy scoring.
+			return 0
+		},
+		activeHeadlessAgents: func(string) map[string]struct{} { return nil },
+	}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+func TestNotificationContext_TruncateHelper(t *testing.T) {
+	if got := truncate("hello", 100); got != "hello" {
+		t.Errorf("truncate short string should be passthrough; got %q", got)
+	}
+	if got := truncate("abcdefghij", 5); got != "abcde..." {
+		t.Errorf("truncate(10char, 5) = %q, want abcde...", got)
+	}
+	if got := truncate("", 5); got != "" {
+		t.Errorf("truncate empty = %q, want empty", got)
+	}
+}
+
+func TestNotificationContext_ExtractTaskFileTargets(t *testing.T) {
+	cases := []struct {
+		text string
+		want []string
+	}{
+		{"Update `web/src/App.tsx` and `internal/team/launcher.go`", []string{"web/src/App.tsx", "internal/team/launcher.go"}},
+		{"This has no backticks", nil},
+		{"Backticks but no path/dot: `notarealpath`", nil},
+		{"Dot only: `script.sh`", []string{"script.sh"}},
+		{"Slash only: `pkg/foo`", []string{"pkg/foo"}},
+		{"Five `a.x` `b.x` `c.x` `d.x` `e.x` should cap at four", []string{"a.x", "b.x", "c.x", "d.x"}},
+		{"Duplicate `a.x` `a.x` `b.x` dedups", []string{"a.x", "b.x"}},
+		{"  Empty `` `b.x`", []string{"b.x"}},
+	}
+	for _, tc := range cases {
+		got := extractTaskFileTargets(tc.text)
+		if !equalStringSlices(got, tc.want) {
+			t.Errorf("extractTaskFileTargets(%q) = %v, want %v", tc.text, got, tc.want)
+		}
+	}
+}
+
+func TestNotificationContext_HumanizeNotificationType(t *testing.T) {
+	cases := map[string]string{
+		"context_alert":   "Context alert",
+		"daily_digest":    "Daily digest",
+		"meeting_summary": "Meeting summary",
+		"task_reminder":   "Task reminder",
+		"task_assigned":   "Task assigned",
+		"":                "",
+		"snake_case_kind": "Snake Case Kind",
+		"single":          "Single",
+	}
+	for kind, want := range cases {
+		if got := humanizeNotificationType(kind); got != want {
+			t.Errorf("humanizeNotificationType(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestNotificationContext_ContextEmptyWhenNoMessages(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	if got := b.NotificationContext("general", "", "", 5); got != "" {
+		t.Errorf("expected empty context when no messages, got %q", got)
+	}
+}
+
+func TestNotificationContext_FiltersSystemAndDemoSeedAndStatus(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "1", From: "you", Content: "human says hi"},
+		{ID: "2", From: "system", Content: "system bookkeeping"},
+		{ID: "3", From: "ceo", Content: "[STATUS] working"},
+		{ID: "4", From: "ceo", Kind: "demo_seed", Content: "fake activity"},
+		{ID: "5", From: "ceo", Content: "real reply"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	got := b.NotificationContext("general", "", "", 10)
+	if !strings.Contains(got, "human says hi") {
+		t.Errorf("expected human msg included; got %q", got)
+	}
+	if !strings.Contains(got, "real reply") {
+		t.Errorf("expected real ceo reply included; got %q", got)
+	}
+	for _, banned := range []string{"system bookkeeping", "STATUS", "fake activity"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("expected %q filtered out, got %q", banned, got)
+		}
+	}
+}
+
+func TestNotificationContext_ExcludesTrigger(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "1", From: "you", Content: "earlier"},
+		{ID: "trigger", From: "you", Content: "the trigger msg"},
+		{ID: "2", From: "ceo", Content: "later"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	got := b.NotificationContext("general", "trigger", "", 10)
+	if strings.Contains(got, "the trigger msg") {
+		t.Errorf("trigger msg should be excluded; got %q", got)
+	}
+}
+
+func TestNotificationContext_ThreadScoped_AnchorsAtRoot(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "ROOT", From: "you", Content: "original ask"},
+		{ID: "off1", From: "you", Content: "unrelated chatter"},
+		{ID: "child1", From: "ceo", Content: "delegating", ReplyTo: "ROOT"},
+		{ID: "grand", From: "eng", Content: "working on it", ReplyTo: "child1"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	got := b.NotificationContext("general", "", "ROOT", 10)
+	if !strings.Contains(got, "original ask") {
+		t.Errorf("thread-scoped context should anchor at root; got %q", got)
+	}
+	if !strings.Contains(got, "working on it") {
+		t.Errorf("thread-scoped context should include grandchild; got %q", got)
+	}
+	if strings.Contains(got, "unrelated chatter") {
+		t.Errorf("thread-scoped context must not include off-thread msg; got %q", got)
+	}
+}
+
+func TestNotificationContext_DefaultChannelGeneral(t *testing.T) {
+	captured := ""
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(channel string) []channelMessage {
+			captured = channel
+			return nil
+		}
+	})
+	_ = b.NotificationContext(" ", "", "", 5)
+	if captured != "general" {
+		t.Errorf("empty channel should default to general; got %q", captured)
+	}
+}
+
+func TestNotificationContext_UltimateThreadRoot_WalksReplyChain(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "ROOT", From: "you", Content: "original"},
+		{ID: "A", From: "ceo", Content: "delegating", ReplyTo: "ROOT"},
+		{ID: "B", From: "eng", Content: "ack", ReplyTo: "A"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	if got := b.UltimateThreadRoot("general", "B"); got != "ROOT" {
+		t.Errorf("UltimateThreadRoot = %q, want ROOT", got)
+	}
+	if got := b.UltimateThreadRoot("general", ""); got != "" {
+		t.Errorf("UltimateThreadRoot(empty) should be empty")
+	}
+}
+
+func TestNotificationContext_UltimateThreadRoot_StopsOnCycle(t *testing.T) {
+	// Pathological case: depth cap (8) protects against cycles.
+	msgs := []channelMessage{
+		{ID: "A", ReplyTo: "B"},
+		{ID: "B", ReplyTo: "A"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	got := b.UltimateThreadRoot("general", "A")
+	if got != "A" && got != "B" {
+		t.Errorf("UltimateThreadRoot in cycle should return one of the cycle nodes; got %q", got)
+	}
+}
+
+func TestNotificationContext_ThreadMessageIDs_BFS(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "R"},
+		{ID: "A", ReplyTo: "R"},
+		{ID: "B", ReplyTo: "R"},
+		{ID: "AA", ReplyTo: "A"},
+		{ID: "off", ReplyTo: "elsewhere"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	got := b.ThreadMessageIDs("general", "R")
+	for _, want := range []string{"R", "A", "B", "AA"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("ThreadMessageIDs missing %q; got %v", want, got)
+		}
+	}
+	if _, ok := got["off"]; ok {
+		t.Errorf("ThreadMessageIDs should not include off-thread node; got %v", got)
+	}
+}
+
+func TestNotificationContext_TaskNotificationContext_LeadGetsAllChannels(t *testing.T) {
+	all := []teamTask{
+		{ID: "t1", Channel: "general", Title: "general task", Owner: "ceo", Status: "in_progress", UpdatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "t2", Channel: "engineering", Title: "eng task", Owner: "ceo", Status: "in_progress", UpdatedAt: "2026-04-01T00:00:00Z"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return all }
+		b.channelTasks = func(string) []teamTask { return nil }
+	})
+	got := b.TaskNotificationContext("", "ceo", 5)
+	if !strings.Contains(got, "general task") {
+		t.Errorf("expected general task in lead context: %q", got)
+	}
+	if !strings.Contains(got, "eng task") {
+		t.Errorf("expected eng task in lead context: %q", got)
+	}
+	// Most-recently-updated first (by UpdatedAt desc).
+	idxEng := strings.Index(got, "eng task")
+	idxGen := strings.Index(got, "general task")
+	if idxEng > idxGen {
+		t.Errorf("expected eng task (UpdatedAt 200) before general task (UpdatedAt 100); got eng=%d gen=%d", idxEng, idxGen)
+	}
+}
+
+func TestNotificationContext_TaskNotificationContext_LeadEmptyShowsCreateNextOwnedHint(t *testing.T) {
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return nil }
+	})
+	got := b.TaskNotificationContext("", "ceo", 5)
+	if got != "" {
+		// When there are no tasks at all, the function returns empty (no
+		// "Active tasks" header). Verify that's still the contract.
+		if strings.Contains(got, "Active tasks") {
+			t.Errorf("expected empty when no tasks; got %q", got)
+		}
+	}
+}
+
+func TestNotificationContext_TaskNotificationContext_LeadAlertsOnReviewBacklog(t *testing.T) {
+	tasks := []teamTask{
+		{ID: "t1", Title: "ready 1", Owner: "eng", Status: "review", UpdatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "t2", Title: "ready 2", Owner: "eng", Status: "in_progress", ReviewState: "ready_for_review", UpdatedAt: "2026-04-01T00:00:00Z"},
+		{ID: "t3", Title: "active", Owner: "eng", Status: "in_progress", UpdatedAt: "2025-12-01T00:00:00Z"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return tasks }
+		b.channelTasks = func(string) []teamTask { return nil }
+	})
+	got := b.TaskNotificationContext("", "ceo", 5)
+	if !strings.Contains(got, "2 task(s) are waiting in review") {
+		t.Errorf("expected review-backlog hint with count 2; got %q", got)
+	}
+}
+
+func TestNotificationContext_TaskNotificationContext_NonLeadOnlyOwnedTasks(t *testing.T) {
+	tasks := []teamTask{
+		{ID: "t1", Channel: "general", Title: "mine", Owner: "eng", Status: "in_progress"},
+		{ID: "t2", Channel: "general", Title: "theirs", Owner: "ceo", Status: "in_progress"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelTasks = func(string) []teamTask { return tasks }
+	})
+	got := b.TaskNotificationContext("general", "eng", 5)
+	if !strings.Contains(got, "mine") {
+		t.Errorf("expected own task: %q", got)
+	}
+	if strings.Contains(got, "theirs") {
+		t.Errorf("non-lead should only see their own owned tasks first; got %q", got)
+	}
+}
+
+func TestNotificationContext_RelevantTaskForTarget_ThreadIDMatch(t *testing.T) {
+	tasks := []teamTask{
+		{ID: "t1", Owner: "eng", Status: "in_progress", ThreadID: "msg-123"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return tasks }
+	})
+	got, ok := b.RelevantTaskForTarget(channelMessage{ID: "msg-123"}, "eng")
+	if !ok || got.ID != "t1" {
+		t.Fatalf("expected t1 by ThreadID match; got (%v, %v)", got, ok)
+	}
+}
+
+func TestNotificationContext_RelevantTaskForTarget_FallsBackToScore(t *testing.T) {
+	tasks := []teamTask{
+		{ID: "t-low", Owner: "eng", Status: "in_progress"},
+		{ID: "t-high", Owner: "eng", Status: "in_progress"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return tasks }
+		b.scoreTaskCandidate = func(msg channelMessage, task teamTask) float64 {
+			if task.ID == "t-high" {
+				return 0.99
+			}
+			return 0.30
+		}
+	})
+	got, ok := b.RelevantTaskForTarget(channelMessage{ID: "msg-x"}, "eng")
+	if !ok || got.ID != "t-high" {
+		t.Fatalf("expected highest-scoring owned task; got (%v, %v)", got, ok)
+	}
+}
+
+func TestNotificationContext_RelevantTaskForTarget_SkipsDoneAndOtherOwners(t *testing.T) {
+	tasks := []teamTask{
+		{ID: "done", Owner: "eng", Status: "done"},
+		{ID: "ot", Owner: "fe", Status: "in_progress"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return tasks }
+		b.scoreTaskCandidate = func(channelMessage, teamTask) float64 { return 0.99 }
+	})
+	if _, ok := b.RelevantTaskForTarget(channelMessage{}, "eng"); ok {
+		t.Errorf("done tasks must not match")
+	}
+}
+
+func TestNotificationContext_ResponseInstruction_LeadFromHumanGetsKickoffGuidance(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.ResponseInstructionForTarget(channelMessage{From: "you", Channel: "general", Content: "build it"}, "ceo")
+	if !strings.Contains(got, "first engineering task itself must be a single smallest runnable feature slice") {
+		t.Errorf("lead-from-human instruction should require runnable slice; got %q", got)
+	}
+}
+
+func TestNotificationContext_ResponseInstruction_LeadFromSpecialistGetsApprovalGuidance(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.ResponseInstructionForTarget(channelMessage{From: "eng", Channel: "general", Content: "done"}, "ceo")
+	if !strings.Contains(got, "specialist just finished a lane") {
+		t.Errorf("lead-from-specialist instruction should mention specialist finishing; got %q", got)
+	}
+}
+
+func TestNotificationContext_ResponseInstruction_DMTriggersDirectGuidance(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.ResponseInstructionForTarget(channelMessage{Channel: "dm-eng"}, "eng")
+	if !strings.Contains(got, "direct expertise") && !strings.Contains(got, "messaging you directly in a DM") {
+		t.Errorf("expected DM-direct guidance; got %q", got)
+	}
+}
+
+func TestNotificationContext_ResponseInstruction_TaggedTriggersTaggedGuidance(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.ResponseInstructionForTarget(channelMessage{Channel: "general", Tagged: []string{"eng"}}, "eng")
+	if !strings.Contains(got, "directly tagged") {
+		t.Errorf("expected tagged guidance; got %q", got)
+	}
+}
+
+func TestNotificationContext_ResponseInstruction_UntaggedNonOwnerStaysQuiet(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.ResponseInstructionForTarget(channelMessage{Channel: "general"}, "eng")
+	if !strings.Contains(got, "Stay quiet") {
+		t.Errorf("expected stay-quiet default for untagged non-owner; got %q", got)
+	}
+}
+
+func TestNotificationContext_BuildMessageWorkPacket_BasicShape(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.BuildMessageWorkPacket(channelMessage{ID: "m1", Channel: "general", From: "you"}, "eng")
+	for _, want := range []string{"Work packet:", "Thread: #general reply_to m1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in packet:\n%s", want, got)
+		}
+	}
+}
+
+func TestNotificationContext_BuildMessageWorkPacket_DMPreambleAdded(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.BuildMessageWorkPacket(channelMessage{ID: "m1", Channel: "dm-eng", From: "you"}, "eng")
+	if !strings.Contains(got, "DIRECT MESSAGE") {
+		t.Errorf("expected DM preamble; got %q", got)
+	}
+}
+
+func TestNotificationContext_BuildMessageWorkPacket_LeadAlreadyActiveLineSorted(t *testing.T) {
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.activeHeadlessAgents = func(except string) map[string]struct{} {
+			return map[string]struct{}{"eng": {}, "fe": {}}
+		}
+		// Targeter must say "ceo" is the lead.
+		b.targeter = fixtureTargeter(t, []officeMember{
+			{Slug: "ceo", BuiltIn: true, Name: "CEO"},
+			{Slug: "eng"},
+			{Slug: "fe"},
+		})
+	})
+	got := b.BuildMessageWorkPacket(channelMessage{ID: "m", Channel: "general", From: "you"}, "ceo")
+	if !strings.Contains(got, "Already active in this thread") {
+		t.Fatalf("expected already-active line for lead; got %q", got)
+	}
+	// Sorted alphabetical: @eng before @fe.
+	idxEng := strings.Index(got, "@eng")
+	idxFe := strings.Index(got, "@fe")
+	if idxEng < 0 || idxFe < 0 || idxEng > idxFe {
+		t.Errorf("expected @eng before @fe in active list; got eng=%d fe=%d", idxEng, idxFe)
+	}
+}
+
+func TestNotificationContext_BuildTaskExecutionPacket_LocalWorktreeAddsCutLineAndAuditGuards(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	task := teamTask{
+		ID:            "t1",
+		Title:         "build feature",
+		Status:        "in_progress",
+		ExecutionMode: "local_worktree",
+		WorktreePath:  "/tmp/worktree",
+	}
+	got := b.BuildTaskExecutionPacket("eng", officeActionLog{Actor: "ceo", Kind: "task_assigned"}, task, "kickoff")
+	for _, want := range []string{
+		"Working directory: \"/tmp/worktree\"",
+		"local_worktree build task",
+		"do NOT start with `rg --files`",
+		"stay inside the assigned working_directory",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in packet:\n%s", want, got)
+		}
+	}
+}
+
+func TestNotificationContext_BuildTaskExecutionPacket_NamesFileTargetsFromTitleAndDetails(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	task := teamTask{
+		ID:      "t1",
+		Title:   "Update `web/src/App.tsx`",
+		Details: "Also touch `internal/team/launcher.go`",
+		Status:  "in_progress",
+	}
+	got := b.BuildTaskExecutionPacket("eng", officeActionLog{Actor: "ceo"}, task, "kickoff")
+	if !strings.Contains(got, "Named file targets: web/src/App.tsx, internal/team/launcher.go") {
+		t.Errorf("expected named file targets line; got %q", got)
+	}
+}
+
+func TestNotificationContext_TaskNotificationContent_HumanizedHeader(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.TaskNotificationContent(officeActionLog{Kind: "task_unblocked"}, teamTask{
+		ID:      "t1",
+		Channel: "general",
+		Title:   "go",
+		Owner:   "eng",
+		Status:  "in_progress",
+	})
+	if !strings.Contains(got, "Task unblocked") {
+		t.Errorf("expected unblocked verb; got %q", got)
+	}
+	if !strings.Contains(got, "@eng") {
+		t.Errorf("expected owner mention; got %q", got)
+	}
+}
+
+// Sanity-check that the launcher wires the builder up correctly so existing
+// dispatch paths see the same answers as the type does in isolation.
+func TestLauncher_NotifyContextWiringDelegates(t *testing.T) {
+	b := &Broker{tasks: []teamTask{
+		{ID: "t1", Channel: "general", Title: "thing", Owner: "ceo", Status: "in_progress"},
+	}}
+	l := &Launcher{
+		broker: b,
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "eng", Name: "Engineer"},
+			},
+		},
+	}
+	got := l.buildTaskNotificationContext("general", "ceo", 5)
+	if !strings.Contains(got, "thing") {
+		t.Errorf("expected ceo task in context: %q", got)
+	}
+}

--- a/internal/team/office_targets_test.go
+++ b/internal/team/office_targets_test.go
@@ -32,7 +32,16 @@ func fixtureTargeter(t *testing.T, members []officeMember, opts ...func(*officeT
 		failedPaneSlugs: failed,
 		isOneOnOne:      func() bool { return false },
 		oneOnOneSlug:    func() string { return "" },
-		isChannelDM:     func(string) (bool, string) { return false, "" },
+		isChannelDM: func(channelSlug string) (bool, string) {
+			// Mirror Launcher.isChannelDMRaw's legacy-prefix check so tests
+			// that pass channels like "dm-eng" route the same way as
+			// production. Tests that need pure no-DM semantics override
+			// this hook explicitly.
+			if IsDMSlug(channelSlug) {
+				return true, DMTargetAgent(channelSlug)
+			}
+			return false, ""
+		},
 		snapshotMembers: func() []officeMember {
 			return append([]officeMember(nil), members...)
 		},


### PR DESCRIPTION
## Summary

Stacked on #409 (C2, officeTargeter). Third slice of the launcher.go decomposition (PLAN.md §C3).

Lifts the per-target notification-context and work-packet construction out of Launcher into a stand-alone `notificationContextBuilder` that drives without a Launcher fixture. The cluster is pure-string assembly over broker reads — exactly the cluster PLAN.md flagged as the **highest coverage payoff** in the migration, because every threading branch becomes testable with a stub map of messages and tasks.

**Methods moved (now on `notificationContextBuilder`):**
NotificationContext, UltimateThreadRoot, ThreadMessageIDs, TaskNotificationContext, RelevantTaskForTarget, ResponseInstructionForTarget, BuildMessageWorkPacket, BuildTaskExecutionPacket, TaskNotificationContent.

**Free functions moved:** `truncate`, `extractTaskFileTargets`, `humanizeNotificationType` (last one still has external callers in `launcher_nex.go` so it stays package-level).

## Design

Builder pulls every Launcher/Broker dep through callbacks:
- `channelMessages`, `channelTasks`, `allTasks`, `channelStore` — broker reads
- `scoreTaskCandidate` — routing.go scoring (used by `RelevantTaskForTarget`)
- `activeHeadlessAgents(except)` — Launcher takes `headlessMu`, returns a snapshot of slugs with non-empty queues or active turns; builder treats opaque

This keeps the headless mutex hidden inside Launcher and lets tests bypass the broker / locks entirely.

## Coverage

- `prompt_builder.go`: 99.4% (no change)
- `office_targets.go`: **89.9%** (was 87.3% — bumped because the new builder exercises a few more targeter paths)
- `notification_context.go`: **89.8%** per-file (gate: ≥85%)
- Package `internal/team`: **63.5%** (was 63.3%)

## Diff shape

- launcher.go: 4469 → 3888 lines (-581, -13%). Cumulative since main: **-1110 lines (-22.2%)**.
- New file `notification_context.go`: 696 lines.
- New file `notification_context_test.go`: 23 tests, including a thread-anchored context test for deep grandchildren, cycle-defended `UltimateThreadRoot` walk, lead review-backlog hint, owned-task fallback to score, and lead "already active" line sorted alphabetically.

## Local CI matrix (all green)

- `gofmt -s -l` clean
- `golangci-lint run ./...` 0 issues
- `/tmp` and unix-only `exec.Command` Windows guards clean
- `go test -race -timeout 15m ./internal/team` (98s)
- `go test -race -timeout 15m` for the other 42 packages
- `go test -timeout 15m ./internal/teammcp`
- Cross-compile windows/{amd64,arm64} + darwin/arm64
- web typecheck + build
- `secretlint` on PR-changed files
- Smoke binary (`./wuphf --version`, `./wuphf --help-all`)

## Compatibility shims (transitional, per C2 precedent)

The Launcher methods (`buildMessageWorkPacket`, `buildTaskExecutionPacket`, `responseInstructionForTarget`, etc.) become one-line delegating wrappers rather than removing the methods entirely. Same call-out as #409: ~50 in-package callers; renaming would dwarf the logic move with rote churn. Wrapper layer is deleted in a follow-up cleanup PR.

## Test plan

- [x] `go build ./...`
- [x] All extracted-file coverage gates pass
- [x] All existing notification/dispatch tests still pass
- [x] 23 new tests on `notificationContextBuilder` directly
- [ ] CI green

## Next slice

C4 `watchdogScheduler` — first goroutine extraction. Manual-clock-friendly and gives us a deterministic test path for the four `processDue*Job` branches that are currently 0%-covered (PLAN.md §C4).