### PR TITLE
refactor(channelui): hoist remaining channel data types

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -78,31 +78,6 @@ type channelSchedulerMsg struct {
 	jobs []channelSchedulerJob
 }
 
-type channelSkill struct {
-	ID                  string   `json:"id"`
-	Name                string   `json:"name"`
-	Title               string   `json:"title"`
-	Description         string   `json:"description"`
-	Content             string   `json:"content"`
-	CreatedBy           string   `json:"created_by"`
-	Channel             string   `json:"channel"`
-	Tags                []string `json:"tags"`
-	Trigger             string   `json:"trigger"`
-	WorkflowProvider    string   `json:"workflow_provider"`
-	WorkflowKey         string   `json:"workflow_key"`
-	WorkflowDefinition  string   `json:"workflow_definition"`
-	WorkflowSchedule    string   `json:"workflow_schedule"`
-	RelayID             string   `json:"relay_id"`
-	RelayPlatform       string   `json:"relay_platform"`
-	RelayEventTypes     []string `json:"relay_event_types"`
-	LastExecutionAt     string   `json:"last_execution_at"`
-	LastExecutionStatus string   `json:"last_execution_status"`
-	UsageCount          int      `json:"usage_count"`
-	Status              string   `json:"status"`
-	CreatedAt           string   `json:"created_at"`
-	UpdatedAt           string   `json:"updated_at"`
-}
-
 type channelSkillsMsg struct {
 	skills []channelSkill
 }
@@ -148,176 +123,6 @@ type channelHealthMsg struct {
 	Connected     bool
 	SessionMode   string
 	OneOnOneAgent string
-}
-
-type channelMember struct {
-	Slug         string `json:"slug"`
-	Name         string `json:"name,omitempty"`
-	Role         string `json:"role,omitempty"`
-	Disabled     bool   `json:"disabled,omitempty"`
-	LastMessage  string `json:"lastMessage"`
-	LastTime     string `json:"lastTime"`
-	LiveActivity string `json:"liveActivity,omitempty"`
-}
-
-type channelInfo struct {
-	Slug        string   `json:"slug"`
-	Name        string   `json:"name"`
-	Type        string   `json:"type,omitempty"` // "O", "D", or "G" (channel store types)
-	Description string   `json:"description,omitempty"`
-	Members     []string `json:"members"`
-	Disabled    []string `json:"disabled"`
-}
-
-func (ch channelInfo) isDM() bool {
-	return ch.Type == "D" || ch.Type == "G"
-}
-
-type channelInterviewOption struct {
-	ID           string `json:"id"`
-	Label        string `json:"label"`
-	Description  string `json:"description"`
-	RequiresText bool   `json:"requires_text,omitempty"`
-	TextHint     string `json:"text_hint,omitempty"`
-}
-
-type channelInterview struct {
-	ID            string                   `json:"id"`
-	Kind          string                   `json:"kind,omitempty"`
-	Status        string                   `json:"status,omitempty"`
-	From          string                   `json:"from"`
-	Channel       string                   `json:"channel"`
-	Title         string                   `json:"title,omitempty"`
-	Question      string                   `json:"question"`
-	Context       string                   `json:"context"`
-	Options       []channelInterviewOption `json:"options"`
-	RecommendedID string                   `json:"recommended_id"`
-	Blocking      bool                     `json:"blocking,omitempty"`
-	Required      bool                     `json:"required,omitempty"`
-	Secret        bool                     `json:"secret,omitempty"`
-	ReplyTo       string                   `json:"reply_to,omitempty"`
-	CreatedAt     string                   `json:"created_at"`
-	DueAt         string                   `json:"due_at,omitempty"`
-	FollowUpAt    string                   `json:"follow_up_at,omitempty"`
-	ReminderAt    string                   `json:"reminder_at,omitempty"`
-	RecheckAt     string                   `json:"recheck_at,omitempty"`
-}
-
-type channelUsageTotals struct {
-	InputTokens         int     `json:"input_tokens"`
-	OutputTokens        int     `json:"output_tokens"`
-	CacheReadTokens     int     `json:"cache_read_tokens"`
-	CacheCreationTokens int     `json:"cache_creation_tokens"`
-	TotalTokens         int     `json:"total_tokens"`
-	CostUsd             float64 `json:"cost_usd"`
-	Requests            int     `json:"requests"`
-}
-
-type channelUsageState struct {
-	Session channelUsageTotals            `json:"session,omitempty"`
-	Total   channelUsageTotals            `json:"total"`
-	Agents  map[string]channelUsageTotals `json:"agents"`
-	Since   string                        `json:"since,omitempty"`
-}
-
-type channelTask struct {
-	ID               string `json:"id"`
-	Channel          string `json:"channel,omitempty"`
-	Title            string `json:"title"`
-	Details          string `json:"details,omitempty"`
-	Owner            string `json:"owner,omitempty"`
-	Status           string `json:"status"`
-	CreatedBy        string `json:"created_by"`
-	ThreadID         string `json:"thread_id,omitempty"`
-	TaskType         string `json:"task_type,omitempty"`
-	PipelineID       string `json:"pipeline_id,omitempty"`
-	PipelineStage    string `json:"pipeline_stage,omitempty"`
-	ExecutionMode    string `json:"execution_mode,omitempty"`
-	ReviewState      string `json:"review_state,omitempty"`
-	SourceSignalID   string `json:"source_signal_id,omitempty"`
-	SourceDecisionID string `json:"source_decision_id,omitempty"`
-	WorktreePath     string `json:"worktree_path,omitempty"`
-	WorktreeBranch   string `json:"worktree_branch,omitempty"`
-	CreatedAt        string `json:"created_at"`
-	UpdatedAt        string `json:"updated_at"`
-	DueAt            string `json:"due_at,omitempty"`
-	FollowUpAt       string `json:"follow_up_at,omitempty"`
-	ReminderAt       string `json:"reminder_at,omitempty"`
-	RecheckAt        string `json:"recheck_at,omitempty"`
-}
-
-type channelAction struct {
-	ID         string   `json:"id"`
-	Kind       string   `json:"kind"`
-	Source     string   `json:"source,omitempty"`
-	Channel    string   `json:"channel,omitempty"`
-	Actor      string   `json:"actor,omitempty"`
-	Summary    string   `json:"summary"`
-	RelatedID  string   `json:"related_id,omitempty"`
-	SignalIDs  []string `json:"signal_ids,omitempty"`
-	DecisionID string   `json:"decision_id,omitempty"`
-	CreatedAt  string   `json:"created_at"`
-}
-
-type channelSignal struct {
-	ID            string `json:"id"`
-	Source        string `json:"source"`
-	SourceRef     string `json:"source_ref,omitempty"`
-	Kind          string `json:"kind,omitempty"`
-	Title         string `json:"title,omitempty"`
-	Content       string `json:"content"`
-	Channel       string `json:"channel,omitempty"`
-	Owner         string `json:"owner,omitempty"`
-	Confidence    string `json:"confidence,omitempty"`
-	Urgency       string `json:"urgency,omitempty"`
-	DedupeKey     string `json:"dedupe_key,omitempty"`
-	RequiresHuman bool   `json:"requires_human,omitempty"`
-	Blocking      bool   `json:"blocking,omitempty"`
-	CreatedAt     string `json:"created_at"`
-}
-
-type channelDecision struct {
-	ID            string   `json:"id"`
-	Kind          string   `json:"kind"`
-	Channel       string   `json:"channel,omitempty"`
-	Summary       string   `json:"summary"`
-	Reason        string   `json:"reason,omitempty"`
-	Owner         string   `json:"owner,omitempty"`
-	SignalIDs     []string `json:"signal_ids,omitempty"`
-	RequiresHuman bool     `json:"requires_human,omitempty"`
-	Blocking      bool     `json:"blocking,omitempty"`
-	CreatedAt     string   `json:"created_at"`
-}
-
-type channelWatchdog struct {
-	ID         string `json:"id"`
-	Kind       string `json:"kind"`
-	Channel    string `json:"channel,omitempty"`
-	TargetType string `json:"target_type,omitempty"`
-	TargetID   string `json:"target_id,omitempty"`
-	Owner      string `json:"owner,omitempty"`
-	Status     string `json:"status,omitempty"`
-	Summary    string `json:"summary"`
-	CreatedAt  string `json:"created_at"`
-	UpdatedAt  string `json:"updated_at,omitempty"`
-}
-
-type channelSchedulerJob struct {
-	Slug            string `json:"slug"`
-	Label           string `json:"label"`
-	Kind            string `json:"kind,omitempty"`
-	TargetType      string `json:"target_type,omitempty"`
-	TargetID        string `json:"target_id,omitempty"`
-	Channel         string `json:"channel,omitempty"`
-	Provider        string `json:"provider,omitempty"`
-	ScheduleExpr    string `json:"schedule_expr,omitempty"`
-	WorkflowKey     string `json:"workflow_key,omitempty"`
-	SkillName       string `json:"skill_name,omitempty"`
-	IntervalMinutes int    `json:"interval_minutes"`
-	DueAt           string `json:"due_at,omitempty"`
-	NextRun         string `json:"next_run,omitempty"`
-	LastRun         string `json:"last_run,omitempty"`
-	Status          string `json:"status,omitempty"`
 }
 
 type channelTickMsg time.Time
@@ -971,7 +776,7 @@ func (m channelModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		case "ctrl+d":
 			// Return to #general from a DM channel.
-			if chInfo := m.findChannelInfo(m.activeChannel); chInfo != nil && chInfo.isDM() {
+			if chInfo := m.findChannelInfo(m.activeChannel); chInfo != nil && chInfo.IsDM() {
 				m.activeChannel = "general"
 				m.lastID = ""
 				m.messages = nil
@@ -3084,7 +2889,7 @@ func (m channelModel) composerTargetLabel() string {
 	if m.isOneOnOne() {
 		return "1:1 with " + m.oneOnOneAgentName()
 	}
-	if chInfo := m.currentChannelInfo(); chInfo != nil && chInfo.isDM() {
+	if chInfo := m.currentChannelInfo(); chInfo != nil && chInfo.IsDM() {
 		name := chInfo.Name
 		if name == "" {
 			name = chInfo.Slug
@@ -3842,13 +3647,6 @@ func (m *channelModel) openRequestActionPicker(req channelInterview) tea.Cmd {
 	m.pickerMode = channelPickerRequestAction
 	m.notice = "Choose a request action."
 	return nil
-}
-
-func (req channelInterview) TitleOrQuestion() string {
-	if strings.TrimSpace(req.Title) != "" {
-		return req.Title
-	}
-	return req.Question
 }
 
 func hasThreadReplies(messages []brokerMessage, id string) bool {

--- a/cmd/wuphf/channelui/types.go
+++ b/cmd/wuphf/channelui/types.go
@@ -1,5 +1,7 @@
 package channelui
 
+import "strings"
+
 // BrokerReaction is a single emoji reaction on a broker message.
 type BrokerReaction struct {
 	Emoji string `json:"emoji"`
@@ -59,4 +61,241 @@ type ThreadedMessage struct {
 	Collapsed          bool
 	HiddenReplies      int
 	ThreadParticipants []string
+}
+
+// Member is a single channel member's roster entry. The lastMessage /
+// lastTime fields drive the inline activity blurb under each sidebar
+// row; LiveActivity is the broker-supplied "talking / coding / idle"
+// state used by the avatar dot.
+type Member struct {
+	Slug         string `json:"slug"`
+	Name         string `json:"name,omitempty"`
+	Role         string `json:"role,omitempty"`
+	Disabled     bool   `json:"disabled,omitempty"`
+	LastMessage  string `json:"lastMessage"`
+	LastTime     string `json:"lastTime"`
+	LiveActivity string `json:"liveActivity,omitempty"`
+}
+
+// ChannelInfo describes a single broker-side channel. Type "O" is the
+// shared office; "D" / "G" are direct or group surfaces (treat as DMs).
+type ChannelInfo struct {
+	Slug        string   `json:"slug"`
+	Name        string   `json:"name"`
+	Type        string   `json:"type,omitempty"` // "O", "D", or "G" (channel store types)
+	Description string   `json:"description,omitempty"`
+	Members     []string `json:"members"`
+	Disabled    []string `json:"disabled"`
+}
+
+// IsDM reports whether the channel is a direct or group surface (rather
+// than the shared office).
+func (ch ChannelInfo) IsDM() bool {
+	return ch.Type == "D" || ch.Type == "G"
+}
+
+// InterviewOption is a single multiple-choice option in an Interview.
+// RequiresText flips the UI into a free-form text mode after the option
+// is selected, with TextHint shown as the placeholder.
+type InterviewOption struct {
+	ID           string `json:"id"`
+	Label        string `json:"label"`
+	Description  string `json:"description"`
+	RequiresText bool   `json:"requires_text,omitempty"`
+	TextHint     string `json:"text_hint,omitempty"`
+}
+
+// Interview is a human-facing question the team has paused on. The
+// scheduling fields (DueAt, FollowUpAt, ReminderAt, RecheckAt) drive the
+// calendar view and the "needs your attention" banner.
+type Interview struct {
+	ID            string            `json:"id"`
+	Kind          string            `json:"kind,omitempty"`
+	Status        string            `json:"status,omitempty"`
+	From          string            `json:"from"`
+	Channel       string            `json:"channel"`
+	Title         string            `json:"title,omitempty"`
+	Question      string            `json:"question"`
+	Context       string            `json:"context"`
+	Options       []InterviewOption `json:"options"`
+	RecommendedID string            `json:"recommended_id"`
+	Blocking      bool              `json:"blocking,omitempty"`
+	Required      bool              `json:"required,omitempty"`
+	Secret        bool              `json:"secret,omitempty"`
+	ReplyTo       string            `json:"reply_to,omitempty"`
+	CreatedAt     string            `json:"created_at"`
+	DueAt         string            `json:"due_at,omitempty"`
+	FollowUpAt    string            `json:"follow_up_at,omitempty"`
+	ReminderAt    string            `json:"reminder_at,omitempty"`
+	RecheckAt     string            `json:"recheck_at,omitempty"`
+}
+
+// TitleOrQuestion returns Title if non-blank, else Question. Used by
+// list views that want a one-line label per interview.
+func (req Interview) TitleOrQuestion() string {
+	if strings.TrimSpace(req.Title) != "" {
+		return req.Title
+	}
+	return req.Question
+}
+
+// UsageTotals tracks token spend along the broker's accounting axes.
+type UsageTotals struct {
+	InputTokens         int     `json:"input_tokens"`
+	OutputTokens        int     `json:"output_tokens"`
+	CacheReadTokens     int     `json:"cache_read_tokens"`
+	CacheCreationTokens int     `json:"cache_creation_tokens"`
+	TotalTokens         int     `json:"total_tokens"`
+	CostUsd             float64 `json:"cost_usd"`
+	Requests            int     `json:"requests"`
+}
+
+// UsageState aggregates per-agent and rolled-up totals for the usage
+// strip. Session is the current run; Total is lifetime; Agents holds the
+// per-agent breakdown the strip renders.
+type UsageState struct {
+	Session UsageTotals            `json:"session,omitempty"`
+	Total   UsageTotals            `json:"total"`
+	Agents  map[string]UsageTotals `json:"agents"`
+	Since   string                 `json:"since,omitempty"`
+}
+
+// Task is a unit of tracked work. Pipeline / execution / review fields
+// are populated for tasks that ride a configured pipeline; everything
+// else stays blank for free-form work.
+type Task struct {
+	ID               string `json:"id"`
+	Channel          string `json:"channel,omitempty"`
+	Title            string `json:"title"`
+	Details          string `json:"details,omitempty"`
+	Owner            string `json:"owner,omitempty"`
+	Status           string `json:"status"`
+	CreatedBy        string `json:"created_by"`
+	ThreadID         string `json:"thread_id,omitempty"`
+	TaskType         string `json:"task_type,omitempty"`
+	PipelineID       string `json:"pipeline_id,omitempty"`
+	PipelineStage    string `json:"pipeline_stage,omitempty"`
+	ExecutionMode    string `json:"execution_mode,omitempty"`
+	ReviewState      string `json:"review_state,omitempty"`
+	SourceSignalID   string `json:"source_signal_id,omitempty"`
+	SourceDecisionID string `json:"source_decision_id,omitempty"`
+	WorktreePath     string `json:"worktree_path,omitempty"`
+	WorktreeBranch   string `json:"worktree_branch,omitempty"`
+	CreatedAt        string `json:"created_at"`
+	UpdatedAt        string `json:"updated_at"`
+	DueAt            string `json:"due_at,omitempty"`
+	FollowUpAt       string `json:"follow_up_at,omitempty"`
+	ReminderAt       string `json:"reminder_at,omitempty"`
+	RecheckAt        string `json:"recheck_at,omitempty"`
+}
+
+// Action describes an external event observed by the broker (a GitHub
+// PR opened, an integration ack, a workflow tick, etc.). Surfaces as
+// rows in the activity / outbox lanes.
+type Action struct {
+	ID         string   `json:"id"`
+	Kind       string   `json:"kind"`
+	Source     string   `json:"source,omitempty"`
+	Channel    string   `json:"channel,omitempty"`
+	Actor      string   `json:"actor,omitempty"`
+	Summary    string   `json:"summary"`
+	RelatedID  string   `json:"related_id,omitempty"`
+	SignalIDs  []string `json:"signal_ids,omitempty"`
+	DecisionID string   `json:"decision_id,omitempty"`
+	CreatedAt  string   `json:"created_at"`
+}
+
+// Signal is a piece of office intelligence the team has captured —
+// usually a directive, observation, or pattern worth reasoning over.
+type Signal struct {
+	ID            string `json:"id"`
+	Source        string `json:"source"`
+	SourceRef     string `json:"source_ref,omitempty"`
+	Kind          string `json:"kind,omitempty"`
+	Title         string `json:"title,omitempty"`
+	Content       string `json:"content"`
+	Channel       string `json:"channel,omitempty"`
+	Owner         string `json:"owner,omitempty"`
+	Confidence    string `json:"confidence,omitempty"`
+	Urgency       string `json:"urgency,omitempty"`
+	DedupeKey     string `json:"dedupe_key,omitempty"`
+	RequiresHuman bool   `json:"requires_human,omitempty"`
+	Blocking      bool   `json:"blocking,omitempty"`
+	CreatedAt     string `json:"created_at"`
+}
+
+// Decision records a directive the office has committed to. Reasons
+// thread back through SignalIDs for audit.
+type Decision struct {
+	ID            string   `json:"id"`
+	Kind          string   `json:"kind"`
+	Channel       string   `json:"channel,omitempty"`
+	Summary       string   `json:"summary"`
+	Reason        string   `json:"reason,omitempty"`
+	Owner         string   `json:"owner,omitempty"`
+	SignalIDs     []string `json:"signal_ids,omitempty"`
+	RequiresHuman bool     `json:"requires_human,omitempty"`
+	Blocking      bool     `json:"blocking,omitempty"`
+	CreatedAt     string   `json:"created_at"`
+}
+
+// Watchdog is an ongoing alert / monitor the office is tracking.
+type Watchdog struct {
+	ID         string `json:"id"`
+	Kind       string `json:"kind"`
+	Channel    string `json:"channel,omitempty"`
+	TargetType string `json:"target_type,omitempty"`
+	TargetID   string `json:"target_id,omitempty"`
+	Owner      string `json:"owner,omitempty"`
+	Status     string `json:"status,omitempty"`
+	Summary    string `json:"summary"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at,omitempty"`
+}
+
+// SchedulerJob is a recurring (or scheduled-once) job the broker runs.
+// Surfaces in the calendar view and in skill-execution histories.
+type SchedulerJob struct {
+	Slug            string `json:"slug"`
+	Label           string `json:"label"`
+	Kind            string `json:"kind,omitempty"`
+	TargetType      string `json:"target_type,omitempty"`
+	TargetID        string `json:"target_id,omitempty"`
+	Channel         string `json:"channel,omitempty"`
+	Provider        string `json:"provider,omitempty"`
+	ScheduleExpr    string `json:"schedule_expr,omitempty"`
+	WorkflowKey     string `json:"workflow_key,omitempty"`
+	SkillName       string `json:"skill_name,omitempty"`
+	IntervalMinutes int    `json:"interval_minutes"`
+	DueAt           string `json:"due_at,omitempty"`
+	NextRun         string `json:"next_run,omitempty"`
+	LastRun         string `json:"last_run,omitempty"`
+	Status          string `json:"status,omitempty"`
+}
+
+// Skill is a saved prompt the team has defined and may schedule against
+// a workflow / relay. Drives the "skills" pane and the /skill commands.
+type Skill struct {
+	ID                  string   `json:"id"`
+	Name                string   `json:"name"`
+	Title               string   `json:"title"`
+	Description         string   `json:"description"`
+	Content             string   `json:"content"`
+	CreatedBy           string   `json:"created_by"`
+	Channel             string   `json:"channel"`
+	Tags                []string `json:"tags"`
+	Trigger             string   `json:"trigger"`
+	WorkflowProvider    string   `json:"workflow_provider"`
+	WorkflowKey         string   `json:"workflow_key"`
+	WorkflowDefinition  string   `json:"workflow_definition"`
+	WorkflowSchedule    string   `json:"workflow_schedule"`
+	RelayID             string   `json:"relay_id"`
+	RelayPlatform       string   `json:"relay_platform"`
+	RelayEventTypes     []string `json:"relay_event_types"`
+	LastExecutionAt     string   `json:"last_execution_at"`
+	LastExecutionStatus string   `json:"last_execution_status"`
+	UsageCount          int      `json:"usage_count"`
+	Status              string   `json:"status"`
+	CreatedAt           string   `json:"created_at"`
+	UpdatedAt           string   `json:"updated_at"`
 }

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -11,13 +11,26 @@ import "github.com/nex-crm/wuphf/cmd/wuphf/channelui"
 // The aliases will be removed once the channel cluster fully lives in
 // channelui (final cleanup PR).
 type (
-	brokerReaction     = channelui.BrokerReaction
-	brokerMessageUsage = channelui.BrokerMessageUsage
-	brokerMessage      = channelui.BrokerMessage
-	renderedLine       = channelui.RenderedLine
-	threadedMessage    = channelui.ThreadedMessage
-	layoutDimensions   = channelui.LayoutDimensions
-	officeMemberInfo   = channelui.OfficeMember
+	brokerReaction         = channelui.BrokerReaction
+	brokerMessageUsage     = channelui.BrokerMessageUsage
+	brokerMessage          = channelui.BrokerMessage
+	renderedLine           = channelui.RenderedLine
+	threadedMessage        = channelui.ThreadedMessage
+	layoutDimensions       = channelui.LayoutDimensions
+	officeMemberInfo       = channelui.OfficeMember
+	channelMember          = channelui.Member
+	channelInfo            = channelui.ChannelInfo
+	channelInterviewOption = channelui.InterviewOption
+	channelInterview       = channelui.Interview
+	channelUsageTotals     = channelui.UsageTotals
+	channelUsageState      = channelui.UsageState
+	channelTask            = channelui.Task
+	channelAction          = channelui.Action
+	channelSignal          = channelui.Signal
+	channelDecision        = channelui.Decision
+	channelWatchdog        = channelui.Watchdog
+	channelSchedulerJob    = channelui.SchedulerJob
+	channelSkill           = channelui.Skill
 )
 
 // Function aliases keep the lowercase names callable from package main


### PR DESCRIPTION
## Summary

PR 4g of the channel-package extraction series. **Stacked on #422**.

Moves the 12 remaining broker-shape data types from \`channel.go\` into \`cmd/wuphf/channelui/types.go\`. With this PR, every public-shape type the channel cluster passes around lives in channelui.

## What moved

| Was (package main) | Now (channelui) |
|---|---|
| \`channelMember\` | \`channelui.Member\` |
| \`channelInfo\` (+ \`isDM\` method) | \`channelui.ChannelInfo\` (+ \`IsDM\` method) |
| \`channelInterviewOption\` | \`channelui.InterviewOption\` |
| \`channelInterview\` (+ \`TitleOrQuestion\` method) | \`channelui.Interview\` (+ \`TitleOrQuestion\` method) |
| \`channelUsageTotals\` | \`channelui.UsageTotals\` |
| \`channelUsageState\` | \`channelui.UsageState\` |
| \`channelTask\` | \`channelui.Task\` |
| \`channelAction\` | \`channelui.Action\` |
| \`channelSignal\` | \`channelui.Signal\` |
| \`channelDecision\` | \`channelui.Decision\` |
| \`channelWatchdog\` | \`channelui.Watchdog\` |
| \`channelSchedulerJob\` | \`channelui.SchedulerJob\` |
| \`channelSkill\` | \`channelui.Skill\` |

## Method exports

\`isDM\` was the only lowercase method that needed renaming for cross-package visibility — methods must be defined in the same package as the receiver type. The two callers in \`channel.go\` were updated to \`IsDM()\`. \`TitleOrQuestion\` was already PascalCase and survives unchanged.

## Caller compatibility

13 type aliases in \`channelui_aliases.go\`:

\`\`\`go
type (
    channelMember          = channelui.Member
    channelInfo            = channelui.ChannelInfo
    channelInterviewOption = channelui.InterviewOption
    channelInterview       = channelui.Interview
    ...
)
\`\`\`

Aliases share methods with the underlying type, so existing \`req.TitleOrQuestion()\` calls and field accesses (\`req.Title\`, \`req.Options[i].Label\`, \`task.Owner\`, etc.) continue to compile unchanged. Only \`.isDM()\` → \`.IsDM()\` needed touch-up (2 lines).

## Why this matters for the next PR

Before this PR, moving \`channel_thread.go\`/\`channel_mailboxes.go\`/\`channel_needs_you.go\` would have required either:
- Pulling all the data type definitions along (huge PR), or
- Importing back into \`cmd/wuphf\` from channelui (cycle)

After this PR, every type those renderers reference (\`Interview\`, \`Task\`, \`Action\`, etc.) lives in channelui already. The next PR can move the renderer files themselves with no further type hoisting.

## Diff stats

- 3 files changed, 261 insertions(+), 211 deletions(-)
- Net +50 lines from doc comments added during the move

## Test plan

- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go build ./cmd/wuphf\` — binary builds
- [ ] CI passes on draft PR

## Next in stack

- PR 4h: Move \`channel_needs_you.go\`, \`channel_thread.go\`, \`channel_mailboxes.go\` (the leaf renderers)
- PR 4i: Move \`channel_render.go\` (1407 lines, split across several channelui files)
- PR 5+: Workspace cluster, sidebar/splash, broker integrations, the model itself, cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)