### PR TITLE
fix(web): show unread channel badges

### DIFF
--- a/web/src/components/sidebar/ChannelList.test.tsx
+++ b/web/src/components/sidebar/ChannelList.test.tsx
@@ -1,6 +1,7 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { useAppStore } from "../../stores/app";
 import { MOD_KEY } from "../ui/Kbd";
 import { ChannelList } from "./ChannelList";
 
@@ -31,6 +32,14 @@ vi.mock("../channels/ChannelWizard", () => ({
 import { useChannels } from "../../hooks/useChannels";
 
 const useChannelsMock = vi.mocked(useChannels);
+
+afterEach(() => {
+  useAppStore.setState({
+    currentChannel: "general",
+    currentApp: null,
+    unreadByChannel: {},
+  });
+});
 
 function setChannels(count: number) {
   useChannelsMock.mockReturnValue({
@@ -92,6 +101,26 @@ describe("<ChannelList> keyboard shortcut badges", () => {
     setChannels(3);
     const { container } = render(<ChannelList />);
     const spans = container.querySelectorAll(".sidebar-shortcut");
-    spans.forEach((s) => expect(s.getAttribute("aria-hidden")).toBe("true"));
+    for (const span of spans) {
+      expect(span.getAttribute("aria-hidden")).toBe("true");
+    }
+  });
+
+  it("renders unread counts for channels with background messages", () => {
+    setChannels(3);
+    useAppStore.setState({ unreadByChannel: { c2: 4 } });
+
+    const { getByText } = render(<ChannelList />);
+
+    expect(getByText("4").getAttribute("title")).toBe("4 unread");
+  });
+
+  it("caps large unread counts at 99+", () => {
+    setChannels(3);
+    useAppStore.setState({ unreadByChannel: { c2: 120 } });
+
+    const { getByText } = render(<ChannelList />);
+
+    expect(getByText("99+").getAttribute("title")).toBe("120 unread");
   });
 });

--- a/web/src/components/sidebar/ChannelList.tsx
+++ b/web/src/components/sidebar/ChannelList.tsx
@@ -1,15 +1,71 @@
-import { useChannels } from "../../hooks/useChannels";
+import { type Channel, useChannels } from "../../hooks/useChannels";
 import { useOverflow } from "../../hooks/useOverflow";
 import { useAppStore } from "../../stores/app";
 import { ChannelWizard, useChannelWizard } from "../channels/ChannelWizard";
 import { Kbd, MOD_KEY } from "../ui/Kbd";
 import { SidebarItemLabel } from "./SidebarItemLabel";
 
+function ChannelRow({
+  channel,
+  index,
+  active,
+  unreadCount,
+  onSelect,
+}: {
+  channel: Channel;
+  index: number;
+  active: boolean;
+  unreadCount: number;
+  onSelect: (slug: string) => void;
+}) {
+  // Only the first 9 get a Cmd+N shortcut — the global handler caps there,
+  // so advertising #10+ would be a lie.
+  const shortcutIdx = index < 9 ? index + 1 : null;
+  const name = channel.name || channel.slug;
+  const title =
+    shortcutIdx !== null ? `${name} — ${MOD_KEY}${shortcutIdx}` : name;
+  const unreadLabel = unreadCount > 99 ? "99+" : String(unreadCount);
+  const buttonLabel = unreadCount > 0 ? `${name}, ${unreadCount} unread` : name;
+
+  return (
+    <button
+      type="button"
+      className={`sidebar-item${active ? " active" : ""}`}
+      onClick={() => onSelect(channel.slug)}
+      aria-label={buttonLabel}
+      title={title}
+    >
+      <span
+        style={{
+          color: "currentColor",
+          width: 18,
+          textAlign: "center",
+          flexShrink: 0,
+        }}
+      >
+        #
+      </span>
+      <SidebarItemLabel>{name}</SidebarItemLabel>
+      {unreadCount > 0 && (
+        <span className="sidebar-badge" title={`${unreadCount} unread`}>
+          {unreadLabel}
+        </span>
+      )}
+      {shortcutIdx !== null && (
+        <span className="sidebar-shortcut" aria-hidden="true">
+          <Kbd size="sm">{`${MOD_KEY}${shortcutIdx}`}</Kbd>
+        </span>
+      )}
+    </button>
+  );
+}
+
 export function ChannelList() {
   const { data: channels = [] } = useChannels();
   const currentChannel = useAppStore((s) => s.currentChannel);
   const setCurrentChannel = useAppStore((s) => s.setCurrentChannel);
   const currentApp = useAppStore((s) => s.currentApp);
+  const unreadByChannel = useAppStore((s) => s.unreadByChannel);
   const wizard = useChannelWizard();
   const overflowRef = useOverflow<HTMLDivElement>();
 
@@ -19,40 +75,20 @@ export function ChannelList() {
         <div className="sidebar-channels" ref={overflowRef}>
           {channels.map((ch, idx) => {
             const isActive = currentChannel === ch.slug && !currentApp;
-            // Only the first 9 get a Cmd+N shortcut — the global handler
-            // caps there, so advertising #10+ would be a lie.
-            const shortcutIdx = idx < 9 ? idx + 1 : null;
-            const title =
-              shortcutIdx !== null
-                ? `${ch.name || ch.slug} — ${MOD_KEY}${shortcutIdx}`
-                : ch.name || ch.slug;
+            const unreadCount = unreadByChannel[ch.slug] ?? 0;
             return (
-              <button
+              <ChannelRow
                 key={ch.slug}
-                className={`sidebar-item${isActive ? " active" : ""}`}
-                onClick={() => setCurrentChannel(ch.slug)}
-                title={title}
-              >
-                <span
-                  style={{
-                    color: "currentColor",
-                    width: 18,
-                    textAlign: "center",
-                    flexShrink: 0,
-                  }}
-                >
-                  #
-                </span>
-                <SidebarItemLabel>{ch.name || ch.slug}</SidebarItemLabel>
-                {shortcutIdx !== null && (
-                  <span className="sidebar-shortcut" aria-hidden="true">
-                    <Kbd size="sm">{`${MOD_KEY}${shortcutIdx}`}</Kbd>
-                  </span>
-                )}
-              </button>
+                channel={ch}
+                index={idx}
+                active={isActive}
+                unreadCount={unreadCount}
+                onSelect={setCurrentChannel}
+              />
             );
           })}
           <button
+            type="button"
             className="sidebar-item sidebar-add-btn"
             onClick={wizard.show}
             title="Create a new channel"

--- a/web/src/hooks/useBrokerEvents.test.tsx
+++ b/web/src/hooks/useBrokerEvents.test.tsx
@@ -27,6 +27,11 @@ class FakeEventSource {
     const event = new MessageEvent(name, { data: JSON.stringify(data) });
     for (const fn of this.listeners[name] ?? []) fn(event);
   }
+
+  emitRaw(name: string, data: string) {
+    const event = new MessageEvent(name, { data });
+    for (const fn of this.listeners[name] ?? []) fn(event);
+  }
 }
 
 function BrokerEventsHarness() {
@@ -133,6 +138,17 @@ describe("useBrokerEvents unread counts", () => {
           id: "msg-1",
         },
       });
+    });
+
+    expect(useAppStore.getState().unreadByChannel).toEqual({});
+  });
+
+  it("ignores message events with malformed JSON", () => {
+    renderHarness();
+    const [source] = FakeEventSource.created;
+
+    act(() => {
+      source.emitRaw("message", "{not-json");
     });
 
     expect(useAppStore.getState().unreadByChannel).toEqual({});

--- a/web/src/hooks/useBrokerEvents.test.tsx
+++ b/web/src/hooks/useBrokerEvents.test.tsx
@@ -1,0 +1,125 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useAppStore } from "../stores/app";
+import { useBrokerEvents } from "./useBrokerEvents";
+
+class FakeEventSource {
+  static created: FakeEventSource[] = [];
+  listeners: Record<string, EventListener[]> = {};
+  onerror: (() => void) | null = null;
+
+  constructor(_url: string) {
+    FakeEventSource.created.push(this);
+  }
+
+  addEventListener(name: string, fn: EventListener) {
+    if (!this.listeners[name]) {
+      this.listeners[name] = [];
+    }
+    this.listeners[name].push(fn);
+  }
+
+  close() {}
+
+  emit(name: string, data: unknown) {
+    const event = new MessageEvent(name, { data: JSON.stringify(data) });
+    for (const fn of this.listeners[name] ?? []) fn(event);
+  }
+}
+
+function BrokerEventsHarness() {
+  useBrokerEvents(true);
+  return null;
+}
+
+function renderHarness() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BrokerEventsHarness />
+    </QueryClientProvider>,
+  );
+}
+
+describe("useBrokerEvents unread counts", () => {
+  const originalEventSource = globalThis.EventSource;
+
+  beforeEach(() => {
+    FakeEventSource.created = [];
+    (globalThis as { EventSource: unknown }).EventSource =
+      FakeEventSource as unknown as typeof EventSource;
+    useAppStore.setState({
+      currentChannel: "general",
+      currentApp: null,
+      unreadByChannel: {},
+    });
+  });
+
+  afterEach(() => {
+    (globalThis as { EventSource: unknown }).EventSource = originalEventSource;
+    useAppStore.setState({
+      currentChannel: "general",
+      currentApp: null,
+      unreadByChannel: {},
+      brokerConnected: false,
+    });
+  });
+
+  it("counts message events for another channel, including thread replies", () => {
+    renderHarness();
+    const [source] = FakeEventSource.created;
+
+    act(() => {
+      source.emit("message", {
+        message: {
+          id: "msg-2",
+          channel: "launch",
+          reply_to: "msg-1",
+        },
+      });
+    });
+
+    expect(useAppStore.getState().unreadByChannel.launch).toBe(1);
+  });
+
+  it("does not count messages while viewing that channel's message feed", () => {
+    renderHarness();
+    const [source] = FakeEventSource.created;
+
+    act(() => {
+      source.emit("message", {
+        message: {
+          id: "msg-1",
+          channel: "general",
+        },
+      });
+    });
+
+    expect(useAppStore.getState().unreadByChannel.general ?? 0).toBe(0);
+  });
+
+  it("counts messages for the selected channel while an app is open", () => {
+    useAppStore.setState({
+      currentChannel: "general",
+      currentApp: "tasks",
+      unreadByChannel: {},
+    });
+    renderHarness();
+    const [source] = FakeEventSource.created;
+
+    act(() => {
+      source.emit("message", {
+        message: {
+          id: "msg-1",
+          channel: "general",
+        },
+      });
+    });
+
+    expect(useAppStore.getState().unreadByChannel.general).toBe(1);
+  });
+});

--- a/web/src/hooks/useBrokerEvents.test.tsx
+++ b/web/src/hooks/useBrokerEvents.test.tsx
@@ -122,4 +122,51 @@ describe("useBrokerEvents unread counts", () => {
 
     expect(useAppStore.getState().unreadByChannel.general).toBe(1);
   });
+
+  it("ignores message events without a channel", () => {
+    renderHarness();
+    const [source] = FakeEventSource.created;
+
+    act(() => {
+      source.emit("message", {
+        message: {
+          id: "msg-1",
+        },
+      });
+    });
+
+    expect(useAppStore.getState().unreadByChannel).toEqual({});
+  });
+
+  it("ignores message events with a blank channel", () => {
+    renderHarness();
+    const [source] = FakeEventSource.created;
+
+    act(() => {
+      source.emit("message", {
+        message: {
+          id: "msg-1",
+          channel: "   ",
+        },
+      });
+    });
+
+    expect(useAppStore.getState().unreadByChannel).toEqual({});
+  });
+
+  it("ignores message events with a non-string channel", () => {
+    renderHarness();
+    const [source] = FakeEventSource.created;
+
+    act(() => {
+      source.emit("message", {
+        message: {
+          id: "msg-1",
+          channel: 42,
+        },
+      });
+    });
+
+    expect(useAppStore.getState().unreadByChannel).toEqual({});
+  });
 });

--- a/web/src/hooks/useBrokerEvents.ts
+++ b/web/src/hooks/useBrokerEvents.ts
@@ -4,6 +4,18 @@ import { useQueryClient } from "@tanstack/react-query";
 import { sseURL } from "../api/client";
 import { useAppStore } from "../stores/app";
 
+function messageChannelFromEvent(event: Event): string | null {
+  if (!("data" in event) || typeof event.data !== "string") return null;
+  try {
+    const payload = JSON.parse(event.data) as {
+      message?: { channel?: string };
+    };
+    return payload.message?.channel?.trim() || "general";
+  } catch {
+    return null;
+  }
+}
+
 export function useBrokerEvents(enabled: boolean) {
   const queryClient = useQueryClient();
   const setBrokerConnected = useAppStore((s) => s.setBrokerConnected);
@@ -16,7 +28,16 @@ export function useBrokerEvents(enabled: boolean) {
 
     const source = new ES(sseURL("/events"));
     source.addEventListener("ready", () => setBrokerConnected(true));
-    source.addEventListener("message", () => {
+    source.addEventListener("message", (event) => {
+      const channel = messageChannelFromEvent(event);
+      if (channel) {
+        const state = useAppStore.getState();
+        if (state.currentApp === null && state.currentChannel === channel) {
+          state.clearUnread(channel);
+        } else {
+          state.incrementUnread(channel);
+        }
+      }
       void queryClient.invalidateQueries({ queryKey: ["messages"] });
       void queryClient.invalidateQueries({ queryKey: ["thread-messages"] });
       void queryClient.invalidateQueries({ queryKey: ["office-members"] });

--- a/web/src/hooks/useBrokerEvents.ts
+++ b/web/src/hooks/useBrokerEvents.ts
@@ -8,9 +8,11 @@ function messageChannelFromEvent(event: Event): string | null {
   if (!("data" in event) || typeof event.data !== "string") return null;
   try {
     const payload = JSON.parse(event.data) as {
-      message?: { channel?: string };
+      message?: { channel?: unknown };
     };
-    return payload.message?.channel?.trim() || "general";
+    if (typeof payload.message?.channel !== "string") return null;
+    const channel = payload.message.channel.trim();
+    return channel.length > 0 ? channel : null;
   } catch {
     return null;
   }

--- a/web/src/stores/app.test.ts
+++ b/web/src/stores/app.test.ts
@@ -8,6 +8,7 @@ afterEach(() => {
     currentApp: null,
     activeThreadId: null,
     lastMessageId: null,
+    unreadByChannel: {},
     activeAgentSlug: null,
     searchOpen: false,
     composerSearchInitialQuery: "",
@@ -67,6 +68,55 @@ describe("DM channel helpers", () => {
       notebookAgentSlug: null,
       notebookEntrySlug: null,
     });
+  });
+});
+
+describe("channel unread state", () => {
+  it("increments and clears unread counts by channel", () => {
+    useAppStore.getState().incrementUnread("launch");
+    useAppStore.getState().incrementUnread("launch");
+    useAppStore.getState().incrementUnread("general");
+
+    expect(useAppStore.getState().unreadByChannel).toMatchObject({
+      launch: 2,
+      general: 1,
+    });
+
+    useAppStore.getState().clearUnread("launch");
+
+    expect(useAppStore.getState().unreadByChannel.launch).toBe(0);
+    expect(useAppStore.getState().unreadByChannel.general).toBe(1);
+  });
+
+  it("clears a channel when navigating to its message view", () => {
+    useAppStore.setState({
+      currentChannel: "general",
+      currentApp: "tasks",
+      unreadByChannel: { general: 2, launch: 3 },
+    });
+
+    useAppStore.getState().setCurrentChannel("launch");
+
+    expect(useAppStore.getState()).toMatchObject({
+      currentChannel: "launch",
+      currentApp: null,
+    });
+    expect(useAppStore.getState().unreadByChannel.launch).toBe(0);
+    expect(useAppStore.getState().unreadByChannel.general).toBe(2);
+  });
+
+  it("clears the current channel when returning from an app to messages", () => {
+    useAppStore.setState({
+      currentChannel: "general",
+      currentApp: "tasks",
+      unreadByChannel: { general: 4, launch: 1 },
+    });
+
+    useAppStore.getState().setCurrentApp(null);
+
+    expect(useAppStore.getState().currentApp).toBeNull();
+    expect(useAppStore.getState().unreadByChannel.general).toBe(0);
+    expect(useAppStore.getState().unreadByChannel.launch).toBe(1);
   });
 });
 

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -23,7 +23,11 @@ const SIDEBAR_SECTIONS_KEY = "wuphf-sidebar-sections";
 const SIDEBAR_BG_KEY = "wuphf-sidebar-bg";
 
 const _storedSidebarSections = ((): SidebarSectionsState => {
-  const def: SidebarSectionsState = { agents: true, channels: true, apps: true };
+  const def: SidebarSectionsState = {
+    agents: true,
+    channels: true,
+    apps: true,
+  };
   try {
     const raw = localStorage.getItem(SIDEBAR_SECTIONS_KEY);
     if (!raw) return def;
@@ -41,7 +45,7 @@ const _storedSidebarSections = ((): SidebarSectionsState => {
 const _storedSidebarBg = ((): string | null => {
   try {
     const v = localStorage.getItem(SIDEBAR_BG_KEY);
-    return v && v.trim() ? v : null;
+    return v?.trim() ? v : null;
   } catch {
     return null;
   }
@@ -153,6 +157,9 @@ export interface AppStore {
   // Message polling state
   lastMessageId: string | null;
   setLastMessageId: (id: string | null) => void;
+  unreadByChannel: Record<string, number>;
+  incrementUnread: (channel: string) => void;
+  clearUnread: (channel: string) => void;
 
   // Agent panel
   activeAgentSlug: string | null;
@@ -197,11 +204,20 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setBrokerConnected: (v) => set({ brokerConnected: v }),
 
   currentChannel: "general",
-  setCurrentChannel: (ch) => set({ currentChannel: ch, currentApp: null }),
+  setCurrentChannel: (ch) =>
+    set((state) => ({
+      currentChannel: ch,
+      currentApp: null,
+      unreadByChannel: { ...state.unreadByChannel, [ch]: 0 },
+    })),
   currentApp: null,
   setCurrentApp: (app) => {
     if (!app) {
-      set({ currentApp: null });
+      const { currentChannel, unreadByChannel } = get();
+      set({
+        currentApp: null,
+        unreadByChannel: { ...unreadByChannel, [currentChannel]: 0 },
+      });
       return;
     }
 
@@ -300,10 +316,30 @@ export const useAppStore = create<AppStore>((set, get) => ({
         ...s.channelMeta,
         [channelSlug]: { ...s.channelMeta[channelSlug], type: "D", agentSlug },
       },
+      unreadByChannel: { ...s.unreadByChannel, [channelSlug]: 0 },
     })),
 
   lastMessageId: null,
   setLastMessageId: (id) => set({ lastMessageId: id }),
+  unreadByChannel: {},
+  incrementUnread: (channel) => {
+    const ch = channel.trim() || "general";
+    set((state) => ({
+      unreadByChannel: {
+        ...state.unreadByChannel,
+        [ch]: (state.unreadByChannel[ch] ?? 0) + 1,
+      },
+    }));
+  },
+  clearUnread: (channel) => {
+    const ch = channel.trim() || "general";
+    set((state) => {
+      if ((state.unreadByChannel[ch] ?? 0) === 0) return state;
+      return {
+        unreadByChannel: { ...state.unreadByChannel, [ch]: 0 },
+      };
+    });
+  },
 
   activeAgentSlug: null,
   setActiveAgentSlug: (slug) => set({ activeAgentSlug: slug }),
@@ -322,6 +358,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     set({
       currentChannel: "general",
       currentApp: null,
+      unreadByChannel: {},
       activeThreadId: null,
       lastMessageId: null,
       activeAgentSlug: null,


### PR DESCRIPTION
## Summary
- track per-channel unread counts from broker SSE message events
- show unread badges in the web channel sidebar, capped at 99+
- clear unread counts when entering a channel message view, including DMs

## Verification
- bun run test ChannelList.test.tsx useBrokerEvents.test.tsx stores/app.test.ts
- bun run typecheck
- bunx biome check src/components/sidebar/ChannelList.tsx src/components/sidebar/ChannelList.test.tsx src/hooks/useBrokerEvents.ts src/hooks/useBrokerEvents.test.tsx src/stores/app.ts src/stores/app.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-channel unread tracking with numeric badges (display capped at 99+, tooltip/title shows full count) and a dedicated channel row UI.

* **Bug Fixes**
  * Unread counts update reliably from incoming events, incrementing for background channels and clearing when viewing or switching apps/DMs.

* **Tests**
  * Expanded test coverage for unread logic and event handling, with isolated state resets between tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->