### PR TITLE
refactor(team): decompose launcher.go (C1–C4)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,8 +1,8 @@
 # launcher.go decomposition — plan
 
-Status: proposal, not yet implemented. Worktree `refactor/launcher-split` off main.
+Status: in progress. C1–C4 landed (combined PR); C5a / C5 / C6 still ahead. See git log for exact landing commits.
 
-Source of truth: `/Users/fd/src/nex/wuphf-launcher-split/internal/team/launcher.go` (4998 lines, 161 funcs).
+Source of truth: `internal/team/launcher.go` (was 4998 lines, 161 funcs at plan time; -1340 lines through C4).
 
 ## Decisions, up front
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,368 @@
+# launcher.go decomposition — plan
+
+Status: proposal, not yet implemented. Worktree `refactor/launcher-split` off main.
+
+Source of truth: `/Users/fd/src/nex/wuphf-launcher-split/internal/team/launcher.go` (4998 lines, 161 funcs).
+
+## Decisions, up front
+
+- Stay inside package `internal/team`. Do **not** spin up child packages (`team/dispatch`, `team/scheduler`, etc.). The struct surface is already entangled (`*Launcher` pointer, `*Broker`, unexported types like `notificationTarget`, `officeMember`, `teamTask`, `headlessCodexTurn`, `paneDispatchTurn`, `officeActionLog`). Promoting them to a sub-package means exporting half the package's domain types — a mechanical change with a huge diff and no real isolation gain. Splits become **new files** + **new unexported types** in the same package, with `*Launcher` keeping a pointer/field to each.
+- Each new type owns its own state and its own mutex. `Launcher` keeps the field, but the mutex moves into the new type. No more "the launcher has 3 mutexes".
+- Test seams use the existing `atomic.Pointer[fn]` override pattern (`launcherSendNotificationToPaneOverride` in launcher.go:3142, swap helper in `test_support.go:184`). It already works under `-race`, supports nested cleanup, and ships in production with zero overhead. Replicate that exact shape for new seams; do not invent a fresh injection style.
+- Time-based loops get a `clock` interface plus a `signal` channel. No `time.Sleep` in tests — the user's hard rule. Production uses `realClock`; tests use `manualClock` with a `Tick()` method that releases pending sleepers and exposes a `Sent <-chan struct{}` for "I observed the work" signalling.
+- All extractions are **PRs against `main`**, one cluster per PR, in the order below. Each PR must (a) leave `go test ./internal/team/... -race` green, (b) ship at least one new test exercising a path that was 0% before, and (c) not touch any caller outside `internal/team`.
+
+---
+
+## 1. Cluster proposal
+
+Numbering matches the cut order in §2.
+
+### C1 — `prompt_builder.go` (new type `promptBuilder`)
+**Funcs moved:** `buildPrompt`, `markdownKnowledgeToolBlock`, `markdownKnowledgeMemoryBlock`, `teamVoiceForSlug`, `headlessSandboxNote`. Helpers: `agentConfigFromMember` if it stays referenced only here; otherwise leave it.
+
+**New surface:**
+```go
+type promptBuilder struct {
+    pack             *agent.PackDefinition
+    bp               *operations.Blueprint
+    isOneOnOne       func() bool
+    isFocusMode      func() bool
+    packName         func() string
+    leadSlug         func() string
+    members          func() []officeMember
+    policies         func() []officePolicy
+    memoryBackend    config.MemoryBackend
+    nexDisabled      bool
+}
+func (p *promptBuilder) Build(slug string) string
+```
+
+**Launcher keeps:** a `prompt promptBuilder` field built once per `Launch()`/`reconfigureVisibleAgents()`. `buildPrompt(slug)` becomes a one-liner: `return l.prompt.Build(slug)`.
+
+**Why first:** zero side effects, zero goroutines, zero broker writes. It's a 300-line `strings.Builder`. The only reason it's at 49% coverage is that nobody wrote table tests against it. Trivial to test by snapshot; trivial to ship.
+
+---
+
+### C2 — `office_targets.go` (new type `officeTargeter`)
+**Funcs moved:** `agentPaneSlugs`, `officeAgentOrder`, `visibleOfficeMembers`, `overflowOfficeMembers`, `paneEligibleOfficeMembers`, `overflowWindowName`, `resolvePaneTargetForSlug`, `agentPaneTargets`, `agentNotificationTargets`, `shouldUseHeadlessDispatchForSlug`, `shouldUseHeadlessDispatchForTarget`, `skipPaneForSlug`, `isChannelDM`, `officeMembersSnapshot`, `officeMemberBySlug`, `officeLeadSlug`, `officeLeadSlugFrom`, `activeSessionMembers`, `getAgentName`. Plus the runtime predicates that drive headless routing: `memberEffectiveProviderKind`, `memberUsesHeadlessOneShotRuntime`, `normalizeProviderKind`, `usesPaneRuntime`, `requiresClaudeSessionReset`.
+
+**New surface:**
+```go
+type officeTargeter struct {
+    sessionName       string
+    paneBackedAgents  *bool                  // pointer back to launcher field
+    failedPaneSlugs   map[string]string      // shared map; targeter reads, dispatcher writes
+    broker            brokerSnapshotter      // narrow interface, see §3
+    isOneOnOne        func() bool
+    oneOnOneAgent     func() string
+    provider          func() string          // l.provider as a getter
+}
+func (o *officeTargeter) PaneTargets() map[string]notificationTarget
+func (o *officeTargeter) NotificationTargets() map[string]notificationTarget
+func (o *officeTargeter) LeadSlug() string
+func (o *officeTargeter) MemberBySlug(slug string) officeMember
+func (o *officeTargeter) ShouldUseHeadlessFor(slug string) bool
+```
+
+**Launcher keeps:** field `targets *officeTargeter`. Every `l.officeLeadSlug()` etc. becomes `l.targets.LeadSlug()`.
+
+**Why second:** pure data-shape logic over `Broker.OfficeMembers()`/`SessionModeState()`. No goroutines, no tmux, no processes. The two side-effects in this cluster (`failedPaneSlugs` mutation, `paneBackedAgents` mutation) move with their writers — `failedPaneSlugs` is written by `recordPaneSpawnFailure` in cluster C5; `paneBackedAgents` is written by `trySpawnWebAgentPanes` in C5. The targeter is read-only over both.
+
+---
+
+### C3 — `notification_context.go` (new type `notificationContextBuilder`)
+**Funcs moved:** `buildNotificationContext`, `ultimateThreadRoot`, `threadMessageIDs`, `buildTaskNotificationContext`, `relevantTaskForTarget`, `responseInstructionForTarget`, `buildMessageWorkPacket`, `buildTaskExecutionPacket`, `extractTaskFileTargets`, `truncate`. Plus `taskNotificationContent` and `humanizeNotificationType`.
+
+**New surface:**
+```go
+type notificationContextBuilder struct {
+    broker          brokerSnapshotter        // ChannelMessages, ChannelTasks, AllTasks, EnabledMembers
+    targeter        *officeTargeter          // for LeadSlug, MemberBySlug, isChannelDM
+    isOneOnOne      func() bool
+}
+func (b *notificationContextBuilder) MessageWorkPacket(msg channelMessage, slug string) string
+func (b *notificationContextBuilder) TaskExecutionPacket(slug string, action officeActionLog, task teamTask, content string) string
+func (b *notificationContextBuilder) TaskNotificationContent(action officeActionLog, task teamTask) string
+```
+
+**Launcher keeps:** field `notify *notificationContextBuilder`. `sendChannelUpdate` and `sendTaskUpdate` (which stay on the launcher because they decide pane vs headless dispatch) call into it.
+
+**Why third:** large surface of pure-string logic operating on broker reads. Read-only, deterministic, and exactly the cluster where coverage will jump the most. The 0%-coverage entries here are 0% only because tests can't easily set up a `Broker` with the needed message graph — extracting against a `brokerSnapshotter` interface lets us inject a stub map of messages and tasks and exercise threading edge cases (missing root, cycles, deep reply chains, blocked tasks, review-state lead summaries) without spinning up a real Broker.
+
+---
+
+### C4 — `scheduler.go` (new type `watchdogScheduler`)
+**Funcs moved:** `watchdogSchedulerLoop`, `processDueSchedulerJobs`, `processDueTaskJob`, `processDueRequestJob`, `processDueWorkflowJob`, `nextWorkflowRun`, `recordWatchdogLedger`, `updateSchedulerJob`. Plus `shouldBackfillTaskOwner` (already a free func).
+
+**New surface:**
+```go
+type watchdogScheduler struct {
+    broker        schedulerBroker      // narrow: DueSchedulerJobs, FindTask/Request, ResumeTask,
+                                        //         CreateWatchdogAlert, RecordSignals, RecordAction, etc.
+    targeter      *officeTargeter
+    notify        *notificationContextBuilder
+    deliverTask   func(officeActionLog, teamTask)   // back-edge to launcher.deliverTaskNotification
+    clock         clock                              // see §3
+    pollEvery     time.Duration                      // formerly hardcoded 20s
+    initialDelay  time.Duration                      // formerly hardcoded 15s
+    stopCh        chan struct{}
+    done          sync.WaitGroup
+    onTickDone    chan struct{}                      // closed-and-replaced per tick; nil in prod
+}
+func (w *watchdogScheduler) Start(ctx context.Context)
+func (w *watchdogScheduler) Stop()
+func (w *watchdogScheduler) processOnce()
+```
+
+**Launcher keeps:** field `scheduler *watchdogScheduler`. `Launch()` constructs and `Start()`s it; `Kill()` calls `Stop()`. The `go l.watchdogSchedulerLoop()` line goes away.
+
+**Why fourth (mid-risk):** spawns a goroutine, but the work it does each tick is a deterministic batch. Easy to test by calling `processOnce()` directly without ever calling `Start()`, plus the loop itself can be tested with the manual clock + `onTickDone` signal (see §3). This is the highest-value mid-risk cluster — the four `processDue*Job` paths are currently 0%-covered and are exactly where silent scheduler bugs live (the `task.Blocked` rate-limit retry path on line 1542 is one I'd flag for a regression test on the way out).
+
+---
+
+### C5 — `pane_lifecycle.go` (new type `paneLifecycle`)
+**Funcs moved:** `spawnVisibleAgents`, `spawnOverflowAgents`, `detectDeadPanesAfterSpawn`, `recordPaneSpawnFailure`, `trySpawnWebAgentPanes`, `paneFallbackMessages`, `reportPaneFallback`, `listTeamPanes`, `clearAgentPanes`, `clearOverflowAgentWindows`, `parseAgentPaneIndices`, `shouldPrimeClaudePane`, `primeVisibleAgents`, `watchChannelPaneLoop`, `channelPaneStatus`, `channelPaneNeedsRespawn`, `isNoSessionError`, `captureDeadChannelPane`, `channelStderrLogPath`, `channelPaneSnapshotPath`, `capturePaneTargetContent`, `capturePaneContent`, `respawnPanesAfterReseed`, `HasLiveTmuxSession`, `isMissingTmuxSession`, `reconfigureVisibleAgents`. Helper: `shellQuote`.
+
+**New surface:**
+```go
+type paneLifecycle struct {
+    sessionName     string
+    socket          string
+    cwd             string
+    runner          tmuxRunner       // interface wrapping exec.CommandContext("tmux", ...)
+    targeter        *officeTargeter
+    promptBuilder   *promptBuilder
+    notifyOverride  *atomic.Pointer[launcherSendNotificationToPaneFn]  // existing seam, reused
+    failedPaneSlugs map[string]string                                   // owned here, read by targeter
+    paneBackedFlag  *bool                                               // back-pointer to launcher field
+    onPaneSpawn     func()                                              // signal hook for tests; nil in prod
+}
+```
+
+**Launcher keeps:** field `panes *paneLifecycle`. `Launch()` calls `panes.SpawnVisibleAgents()` only if `usesPaneRuntime()`.
+
+**Why fifth (high-risk):** every method here either shells out to `tmux` or writes to the filesystem. The cluster is internally cohesive but we can't fake `tmux` from the outside without a runner interface. Wrap it; that's the only way to test pane spawn fallback without a real terminal session. Order matters: it must come **after** the targeter cluster (C2) lands, because `paneLifecycle` reads the targeter to decide which slugs to spawn.
+
+---
+
+### C6 — `pane_dispatch.go` (new type `paneDispatcher`)
+**Funcs moved:** `queuePaneNotification`, `runPaneDispatchQueue`, `launcherSendNotificationToPane`, `sendNotificationToPane`. Plus the package-level `paneDispatchMinGap`, `paneDispatchCoalesceWindow` vars (move alongside but keep package-level so test helpers can swap them in process; see §3 for the alternative).
+
+**New surface:**
+```go
+type paneDispatcher struct {
+    runner       tmuxRunner       // shared with paneLifecycle
+    sendOverride *atomic.Pointer[launcherSendNotificationToPaneFn]  // existing seam
+    clock        clock
+    minGap       time.Duration
+    coalesce     time.Duration
+
+    mu           sync.Mutex
+    queues       map[string][]paneDispatchTurn
+    workers      map[string]bool
+    lastSentAt   map[string]time.Time
+
+    workerWg     sync.WaitGroup     // new: lets tests await all workers without Sleep
+    onSent       chan struct{}      // optional signal: closed-and-replaced per send; nil in prod
+}
+func (p *paneDispatcher) Enqueue(slug, paneTarget, notification string)
+func (p *paneDispatcher) Stop()                  // closes a stop channel + WaitGroup drain
+```
+
+**Launcher keeps:** field `paneDispatch *paneDispatcher`. `paneDispatchMu`/`paneDispatchQueues`/`paneDispatchWorkers`/`paneDispatchLastSentAt` come off the Launcher struct.
+
+**Why sixth (high-risk):** spawns a goroutine *per slug*, has subtle coalesce semantics, and is the place where the 60s/3s timing gates live. It's where the user has historically lost messages from concurrency bugs. We need the `WaitGroup` and the `Stop()` to make it deterministically testable. Existing `pane_dispatch_queue_test.go` is good — it uses the override and works without sleeps, so the public surface is already test-shaped, we're just giving it an owner type instead of leaving the maps on the launcher.
+
+---
+
+### C7 — `headless_workers.go` (extracted methods, type `headlessWorkerPool`)
+**Funcs moved:** Everything currently namespaced under `headless_codex.go` already lives outside `launcher.go` for the queue logic itself. What moves *out of launcher.go* is the spawn/teardown the launcher owns: `headlessMu`/`headlessCtx`/`headlessCancel`/`headlessWorkers`/`headlessActive`/`headlessQueues`/`headlessDeferredLead`/`headlessStopCh`/`headlessWorkerWg` plus the spawn helper currently called from `Launch()`. Keep the existing `headless_codex.go` file structure; just move the launcher-side fields into a `headlessWorkerPool` type and add an interface seam for `enqueueHeadlessCodexTurn`.
+
+**New surface:**
+```go
+type headlessWorkerPool struct {
+    mu         sync.Mutex
+    ctx        context.Context
+    cancel     context.CancelFunc
+    workers    map[string]bool
+    active     map[string]*headlessCodexActiveTurn
+    queues     map[string][]headlessCodexTurn
+    deferred   *headlessCodexTurn
+    stopCh     chan struct{}
+    wg         sync.WaitGroup
+}
+```
+
+**Launcher keeps:** field `headless *headlessWorkerPool`. The package-internal call sites that already say `l.headlessQueues` etc. become `l.headless.queues` (still within the package; not exported). This is a mechanical move — the goal is to **stop the Launcher struct from owning a third sub-mutex**, not to redesign the worker semantics. Leave the goroutine-leak fix from PR #320 (per memory) untouched.
+
+**Why seventh (high-risk):** these fields are touched from `Launch()`, `Kill()`, the resume path, and `headless_codex.go`. Mechanical move with broad blast radius. Schedule it last among the goroutine clusters specifically because nothing else depends on the move — once the other clusters are extracted and their tests are green, this one is only at risk of regressing itself, not them.
+
+---
+
+### C8 — `bootstrap.go` (lifecycle stays on Launcher; this file just hosts what's left)
+After C1–C7, `launcher.go` keeps: `Launcher` struct + getters/setters, `NewLauncher`, `Preflight`, `Launch`, `Attach`, `Kill`, `ResetSession`, `ReconfigureSession`, the four notification-loop wiring funcs (`notifyAgentsLoop`, `notifyTaskActionsLoop`, `notifyOfficeChangesLoop`, `pollOneRelayEventsLoop`), and the small office-change delivery helpers (`deliverOfficeChangeNotification`, `officeChangeTaskNotifications`, `respawnPanesAfterReseed`, `safeDeliverMessage`, `recoverPanicTo`).
+
+Web-mode code (`PreflightWeb`, `LaunchWeb`, `maybeOfferNex`, `waitForWebReady`, `openBrowser`, `stdinIsTTY`) gets split into `launcher_web.go`. It's pure split-by-build-target hygiene; no new type. Cheap, do it as part of C1.
+
+Broker-side housekeeping (`killStaleBroker`, `ResetBrokerState`, `ClearPersistedBrokerState`, `officePIDFilePath`, `writeOfficePIDFile`, `clearOfficePIDFile`, `killPersistedOfficeProcess`, `resetBrokerState`, `brokerBaseURL`) moves to `broker_lifecycle.go`. No type — these are package funcs already. Free move; bundle with C5.
+
+End state: `launcher.go` is ~600–800 lines and is exactly the orchestration glue.
+
+---
+
+## 2. Cut order — justification
+
+| # | Cluster | Risk | Why this slot |
+|---|---|---|---|
+| C1 | `promptBuilder` | low | Pure func over data. No goroutines, no mutexes, no broker writes. Snapshot tests cover it. Ship as the proof-of-pattern PR. |
+| C2 | `officeTargeter` | low | Read-only over broker snapshot funcs. No goroutines. Reveals the smallest necessary `brokerSnapshotter` interface, which then unblocks C3 and C4. |
+| C3 | `notificationContextBuilder` | low-mid | Large but pure. Depends on C2's targeter. Coverage payoff is the highest of any cluster — every threading branch is testable with a stub. |
+| C4 | `watchdogScheduler` | mid | First goroutine extraction. Depends on C2 + C3. The scheduler interface is small (`processOnce`) so it ships with a real test that walks each `processDue*Job` branch via direct call, plus one loop test using the manual clock. |
+| C5 | `paneLifecycle` + broker housekeeping | high | Touches `tmux` and the filesystem; needs `tmuxRunner` interface. Must land **before** C6 because C6 borrows the same `tmuxRunner`. |
+| C6 | `paneDispatcher` | high | Per-slug goroutines + timing gates + the only message-loss path in the system. Lands after C5 so it can share the runner. The existing `pane_dispatch_queue_test.go` is the regression net. |
+| C7 | `headlessWorkerPool` | high | Pure mechanical struct move. Last because the blast radius hits `Launch()` and the resume path; we want every other cluster green and freezeable before we churn this one. |
+| C8 | residual `launcher.go` cleanup | trivial | What's left is glue and is the natural endpoint, not a separate PR. |
+
+Hard rule: **no two clusters in the same PR**. Each PR is independently revertible.
+
+---
+
+## 3. Test seams (higher-risk clusters)
+
+### Existing seam to reuse, not reinvent
+`launcherSendNotificationToPaneOverride atomic.Pointer[launcherSendNotificationToPaneFn]` (launcher.go:3142) plus the `setLauncherSendNotificationToPaneForTest` helper (test_support.go:184). It already works under `-race` and supports `t.Cleanup` nesting. Pattern:
+
+```go
+var fooOverride atomic.Pointer[fooFn]
+
+func setFooForTest(t *testing.T, fn fooFn) {
+    t.Helper()
+    prior := fooOverride.Load()
+    fooOverride.Store(&fn)
+    t.Cleanup(func() { fooOverride.Store(prior) })
+}
+```
+
+Use this exact shape for every new injection point. Don't introduce a context-injected DI container, don't add an interface field on `Launcher` that production must wire — both add ceremony.
+
+### `tmuxRunner` interface (C5, C6)
+```go
+type tmuxRunner interface {
+    Run(args ...string) error
+    Output(args ...string) ([]byte, error)
+    Combined(args ...string) ([]byte, error)
+}
+```
+Production `realTmuxRunner` shells out via `exec.CommandContext` with the existing `-L tmuxSocketName` prefix baked in. Test `fakeTmuxRunner` records every call into a slice; tests assert on the recorded `args` (exact `send-keys`/`new-window` calls) and inject canned outputs for `list-panes`/`capture-pane`. Wire it via the `atomic.Pointer` seam:
+
+```go
+var tmuxRunnerOverride atomic.Pointer[tmuxRunner]
+func newTmuxRunner() tmuxRunner {
+    if p := tmuxRunnerOverride.Load(); p != nil { return *p }
+    return realTmuxRunner{}
+}
+```
+
+### `clock` interface (C4, C6)
+```go
+type clock interface {
+    Now() time.Time
+    After(d time.Duration) <-chan time.Time
+    Sleep(d time.Duration)
+}
+```
+Production `realClock` delegates to `time`. Test `manualClock`:
+- `Now()` returns the stored time.
+- `Advance(d)` adds to the stored time **and** releases any sleepers whose deadline has now passed.
+- `Sleep(d)` blocks on a channel registered in a heap keyed by deadline.
+
+This kills the two `time.Sleep` calls inside `runPaneDispatchQueue` (lines 3095, 3104) and the `15s`/`20s` calls in `watchdogSchedulerLoop` (1500, 1503) for tests, while production behaviour is byte-identical.
+
+### Signal channels (the "deterministic signal" the user demands)
+Two patterns, both already idiomatic in this codebase:
+
+1. **WaitGroup drain.** `paneDispatcher.Stop()` closes a `stopCh` and `wg.Wait()`s. Tests wanting "queue is fully drained" call `Stop()`. Mirrors the headless worker pool's existing PR #320 pattern.
+
+2. **Per-event signal channel.** Add an unexported field `onSent chan struct{}` to `paneDispatcher`; production leaves it nil; tests set it via a `setOnSentForTest(t, ch)` helper. After each successful pane send, the dispatcher does `if c := p.onSent; c != nil { c <- struct{}{} }`. The test reads from `c` to know "exactly one notification has flushed", with no sleep. Same pattern works for `watchdogScheduler.onTickDone`.
+
+   **Important:** unbuffered. Buffered swallows the signal under back-to-back sends and reintroduces races. If a test wants to count, give it a `chan int` with `len(workers)` capacity and read N times.
+
+### Coverage of the time-window logic without real time
+Once the clock interface exists, the coalesce-window test becomes:
+```go
+clk := newManualClock()
+disp := newPaneDispatcher(... clk ...)
+sent := make(chan string, 4)
+setLauncherSendNotificationToPaneForTest(t, func(_ *Launcher, _, n string) { sent <- n })
+
+disp.Enqueue("eng", "tgt", "first")
+<-sent                                    // first send fires immediately
+disp.Enqueue("eng", "tgt", "second")     // arrives mid-window
+disp.Enqueue("eng", "tgt", "third")      // also mid-window — must coalesce
+clk.Advance(paneDispatchCoalesceWindow + time.Millisecond)
+got := <-sent
+require.Equal(t, "second\n\n---\n\nthird", got)
+```
+That's the exact regression we'd want a permanent test for, and it has zero `time.Sleep` calls.
+
+---
+
+## 4. Coverage gate — recommendation
+
+**Pick (b): per-file floor on extracted files (≥ 85%), launcher.go untracked during the migration.**
+
+Reasoning:
+- (a) per-package floor that ratchets up: the package is currently 62.9%. Extracting C1 (promptBuilder, ~300 lines, currently lightly tested) to 90% will move package coverage by maybe 1–2 points. A ratcheting threshold either has to ratchet by 0.5 points (annoying, easy to game) or it has to wait several PRs for a meaningful jump (defeats the point of per-PR enforcement).
+- (b) per-file floor: we know exactly which files are new (`prompt_builder.go`, `office_targets.go`, etc.). CI can run `go test -coverpkg=./internal/team -coverprofile=cov.out ./internal/team/...`, then a tiny script computes per-file coverage from the profile and fails if any new file is < 85%. Old `launcher.go` is exempt while it shrinks. **This is the only option that gates the new code without holding the new code hostage to old code's debt.** 85% (not 90%) so we don't waste cycles testing trivial getters.
+- (c) baseline file: works but doesn't enforce that *new* code is well-tested, only that nothing regresses. We want the opposite emphasis right now — push new files high, let launcher.go's number drift up naturally as funcs leave it.
+
+**Implementation:** add `scripts/check-file-coverage.sh` that takes `--min 85 --files internal/team/prompt_builder.go,internal/team/office_targets.go,...`. CI step runs after the existing `bash scripts/test-go.sh`. Add files to the list as PRs land. Six lines of `awk` over `go tool cover -func`.
+
+Once the migration finishes, swap to (a) at the package level set to whatever we hit (likely 78–82%), and retire the per-file script. Two-phase, not permanent ceremony.
+
+---
+
+## 5. Traps
+
+These are the things that will bite if you don't actively defend against them.
+
+1. **`failedPaneSlugs` is shared between targeter and pane-lifecycle.** `recordPaneSpawnFailure` writes it (in C5); `agentPaneTargets`/`skipPaneForSlug` read it (in C2). Currently it's an unsynchronised `map[string]string` — the only reason no race fires is that pane spawn is sequential during `Launch()`. **Fix:** make it `sync.Map` *or* move it onto the `paneLifecycle` type and have the targeter call `panes.IsFailed(slug)`. Don't leave it dangling on the Launcher struct, and don't share a bare map across two new types — that's the kind of split that *introduces* a race the original god-object accidentally avoided.
+
+2. **`paneBackedAgents bool` is the load-bearing flag for the entire dispatch decision.** It's flipped to `true` deep inside `trySpawnWebAgentPanes`; every targeter method short-circuits when it's false (launcher.go:1897). If you move the flag onto `paneLifecycle` but keep the targeter reading the old launcher field, every notification will route through the headless path silently. **Fix:** the targeter holds a `*bool` or, better, a `func() bool` getter that points at the lifecycle's field. Single source of truth.
+
+3. **`launcherSendNotificationToPaneOverride` is global, not per-Launcher.** It's a package-level `atomic.Pointer`. The pane-dispatch tests work because they're sequential and use `t.Cleanup`. If C6 is restructured so the dispatcher holds its own override pointer instead, the existing tests in `pane_dispatch_queue_test.go` and `resume_test.go` (line 706) break. **Fix:** keep the override package-global. The new `paneDispatcher` reads the same `atomic.Pointer` the existing free function reads. Don't move the seam; only move the work.
+
+4. **`NewLauncher` does I/O before returning.** It loads config, reads the manifest, may delete `defaultBrokerStatePath()`, and synthesises `loadRunningSessionMode`. The new sub-types should be constructed **lazily inside `Launch()`**, not in `NewLauncher`, because (a) `Preflight()` runs first and can fail before any sub-type is needed, and (b) tests construct `&Launcher{}` directly and rely on every sub-type being nil-safe. Pattern: `if l.targets == nil { l.targets = newOfficeTargeter(...) }` at the top of `Launch()` and at the top of any test-friendly entry point.
+
+5. **`paneDispatchMinGap` and `paneDispatchCoalesceWindow` are package vars, not consts, specifically so tests can swap them.** Don't promote them to fields on `paneDispatcher` without preserving a swap path — there are tests in the wild that mutate them (grep before moving). The cleanest answer is: keep them as package vars, but have the `paneDispatcher` constructor read them once into instance fields. Tests that want a different value either swap the package var before construction (existing pattern) or pass a configured dispatcher (new pattern). Both work.
+
+6. **`Launch()` has an implicit ordering invariant**: broker start → tmux session create → headless context create → goroutine fan-out. The goroutines (`notifyAgentsLoop`, `notifyTaskActionsLoop`, `notifyOfficeChangesLoop`, `pollNexNotificationsLoop`, `watchdogSchedulerLoop`) are started *unconditionally* at the bottom of `Launch()` except `notifyTaskActionsLoop` which gates on `!isOneOnOne()`. When the scheduler moves to its own type (C4), the `Start(ctx)` call MUST stay inside `Launch()`'s gated block — don't move it into `NewLauncher` or a constructor side effect. Same for the headless worker pool's `ctx, cancel = context.WithCancel(...)` — that line is what makes `Kill()`'s cancel actually cancel anything.
+
+7. **`primeVisibleAgents` and `respawnPanesAfterReseed` straddle C3 and C5.** They read message context (C3 territory) to decide what to type into a pane (C5 territory). Put them on `paneLifecycle` and have it depend on `notificationContextBuilder`, not the other way around. If you put them on the context builder, you're back to one type that knows about tmux.
+
+8. **`atomic.Pointer` overrides leak across parallel tests when keyed globally.** All the existing `*Override` vars are package-global. If anyone runs `t.Parallel()` on tests that set them, they corrupt each other. Today this is fine because the override-using tests don't `t.Parallel()`. If you add new overrides for C5/C6, **document that they must not be combined with `t.Parallel()`**, or build them as per-`*Launcher` fields from day one. Pick one and stick with it; mixing is the worst outcome.
+
+9. **`extractTaskFileTargets` (line 2132) is invoked from broker code paths outside this file.** Confirm with `grep -rn extractTaskFileTargets internal/team` before yanking it from launcher.go. If it has external callers in the package, leave it free-function in a `text_helpers.go` file rather than absorbing it into the context builder type.
+
+10. **Coverage profile aggregation across files:** when you split launcher.go, `go tool cover` will report each new file separately, but funcs that *moved* keep their old function names. Don't be surprised if `launcher.go`'s reported coverage *drops* between extractions — the tested funcs leave for the new file, the untested ones stay behind. That's the desired transient state, not a regression. The per-file gate in §4 makes this visible without flagging it as a failure.
+
+---
+
+## What I'm explicitly not proposing
+
+- **No new public packages.** Every type stays unexported in `internal/team`. The package surface (what `cmd/wuphf` imports) does not change.
+- **No interface for `*Broker`.** I named `brokerSnapshotter` and `schedulerBroker` above as **narrow consumer-side interfaces** declared on the consumer side (Go convention). The `*Broker` type itself stays concrete and unchanged. This avoids a 50-method interface that nobody needs.
+- **No rename of `Launcher`.** It stays the orchestrator. We're slimming it, not retiring it.
+- **No compatibility shims.** `l.officeLeadSlug()` becomes `l.targets.LeadSlug()` everywhere in the package. No deprecation period. The package is internal — there are no external callers to break.
+
+---
+
+## Definition of done for the whole migration
+
+- `launcher.go` is < 1000 lines.
+- Every new file has its own `_test.go` with > 85% coverage measured per-file.
+- Package coverage for `internal/team` is ≥ 75% (up from 62.9%).
+- `go test -race ./internal/team/... -count=10` is green (the `-count=10` is the cheap insurance against the per-slug goroutine races C6 reshapes).
+- Zero `time.Sleep` calls in any test we wrote during the migration.
+- `Launcher` struct has at most one mutex on it (the rest moved into sub-types).

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -657,14 +658,21 @@ func memberSlugsFromMembers(members []officeMember) []string {
 	return uniqueSlugs(out)
 }
 
+// officeLeadSlugFromMembers picks a lead from a member list when the pack
+// doesn't declare one. Sorts a copy of the input by slug before iterating
+// so the answer is order-independent — same rationale as officeLeadSlugFrom
+// in office_targets.go (callers pass differently-ordered snapshots; without
+// the sort they'd disagree on the lead in BuiltIn-free rosters).
 func officeLeadSlugFromMembers(members []officeMember) string {
-	for _, member := range members {
+	sorted := append([]officeMember(nil), members...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Slug < sorted[j].Slug })
+	for _, member := range sorted {
 		if member.BuiltIn {
 			return strings.TrimSpace(member.Slug)
 		}
 	}
-	if len(members) > 0 {
-		return strings.TrimSpace(members[0].Slug)
+	if len(sorted) > 0 {
+		return strings.TrimSpace(sorted[0].Slug)
 	}
 	return ""
 }

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -142,6 +142,14 @@ type Launcher struct {
 	// queuePaneNotification uses this to decide whether to merge a new
 	// notification with a pending one or to start a fresh dispatch.
 	paneDispatchLastSentAt map[string]time.Time
+
+	// targets owns the office-membership-shape and routing-decision logic
+	// (PLAN.md §C2). Lazily constructed via targeter() so tests that build
+	// &Launcher{} directly stay nil-safe. The launcher field stays the
+	// authoritative source for sessionName / pack / failedPaneSlugs /
+	// paneBackedAgents — the targeter holds pointers/callbacks back into
+	// the launcher rather than copies.
+	targets *officeTargeter
 }
 
 // paneDispatchTurn is one queued notification to type into a tmux pane.
@@ -1013,12 +1021,19 @@ func (l *Launcher) sendTaskUpdate(target notificationTarget, action officeAction
 
 // isChannelDM returns true if the channel is a DM (either old dm-* format or new Store type).
 // agentTarget returns the agent slug that should receive the DM notification (non-human side).
+// isChannelDM is the public entry point used by dispatch code; targeter
+// reads the same logic via the isChannelDMRaw callback.
 func (l *Launcher) isChannelDM(channelSlug string) (isDM bool, agentTarget string) {
-	// Legacy format: dm-{agent}
+	return l.isChannelDMRaw(channelSlug)
+}
+
+// isChannelDMRaw resolves whether a channel is a direct-message channel
+// and, if so, which agent it targets. Two formats supported: the legacy
+// "dm-{agent}" slug and the new store format where channel.type == "D".
+func (l *Launcher) isChannelDMRaw(channelSlug string) (isDM bool, agentTarget string) {
 	if IsDMSlug(channelSlug) {
 		return true, DMTargetAgent(channelSlug)
 	}
-	// New store format: channel type == D
 	if l.broker != nil {
 		cs := l.broker.ChannelStore()
 		if cs != nil && cs.IsDirectMessageBySlug(channelSlug) {
@@ -1788,216 +1803,90 @@ func humanizeNotificationType(kind string) string {
 	}
 }
 
-func (l *Launcher) agentPaneSlugs() []string {
-	if l.isOneOnOne() {
-		return []string{l.oneOnOneAgent()}
+// targeter returns the office-targeter, lazily constructing it on first
+// access. PLAN.md trap §5.4: tests build &Launcher{} directly and rely on
+// every sub-type being nil-safe. The targeter shares mutable state with
+// the launcher via pointers/maps (paneBackedFlag, failedPaneSlugs) so
+// later mutations on the launcher are visible to the targeter immediately.
+func (l *Launcher) targeter() *officeTargeter {
+	if l == nil {
+		return nil
 	}
-	members := l.officeMembersSnapshot()
-	lead := l.officeLeadSlug()
-	var slugs []string
-	if lead != "" {
-		slugs = append(slugs, lead)
+	if l.targets != nil {
+		return l.targets
 	}
-	for _, member := range members {
-		if member.Slug == lead {
-			continue
-		}
-		slugs = append(slugs, member.Slug)
+	if l.failedPaneSlugs == nil {
+		l.failedPaneSlugs = map[string]string{}
 	}
-	return slugs
+	l.targets = &officeTargeter{
+		sessionName:        l.sessionName,
+		pack:               l.pack,
+		cwd:                l.cwd,
+		provider:           l.provider,
+		paneBackedFlag:     &l.paneBackedAgents,
+		failedPaneSlugs:    l.failedPaneSlugs,
+		isOneOnOne:         l.isOneOnOne,
+		oneOnOneSlug:       l.oneOnOneAgent,
+		isChannelDM:        l.isChannelDMRaw,
+		snapshotMembers:    l.officeMembersSnapshot,
+		memberProviderKind: l.brokerMemberProviderKind,
+	}
+	return l.targets
 }
 
-const maxVisibleOfficeAgents = 5
-
-func (l *Launcher) officeAgentOrder() []officeMember {
-	var agentOrder []officeMember
-	lead := l.officeLeadSlug()
-	for _, member := range l.officeMembersSnapshot() {
-		if member.Slug == lead {
-			agentOrder = append([]officeMember{member}, agentOrder...)
-		}
+// brokerMemberProviderKind reads the per-member provider override from the
+// broker, or "" when no broker is wired or no override is set.
+func (l *Launcher) brokerMemberProviderKind(slug string) string {
+	if l == nil || l.broker == nil {
+		return ""
 	}
-	for _, member := range l.officeMembersSnapshot() {
-		if member.Slug != lead {
-			agentOrder = append(agentOrder, member)
-		}
-	}
-	return agentOrder
+	return l.broker.MemberProviderKind(slug)
 }
+
+// agentPaneSlugs and friends are thin wrappers that delegate to the
+// targeter. Kept as Launcher methods so the ~110 callers across
+// internal/team don't need a sweep in this PR; consolidation is a
+// follow-up. PLAN.md §6 wants the call sites renamed eventually but the
+// bulk of the diff would be call-site churn rather than logic changes.
+
+func (l *Launcher) agentPaneSlugs() []string { return l.targeter().PaneSlugs() }
+
+func (l *Launcher) officeAgentOrder() []officeMember { return l.targeter().AgentOrder() }
 
 func (l *Launcher) visibleOfficeMembers() []officeMember {
-	if l.isOneOnOne() {
-		member := l.officeMemberBySlug(l.oneOnOneAgent())
-		return []officeMember{member}
-	}
-	ordered := l.paneEligibleOfficeMembers()
-	if len(ordered) <= maxVisibleOfficeAgents {
-		return ordered
-	}
-	return ordered[:maxVisibleOfficeAgents]
+	return l.targeter().VisibleMembers()
 }
 
 func (l *Launcher) overflowOfficeMembers() []officeMember {
-	if l.isOneOnOne() {
-		return nil
-	}
-	ordered := l.paneEligibleOfficeMembers()
-	if len(ordered) <= maxVisibleOfficeAgents {
-		return nil
-	}
-	return ordered[maxVisibleOfficeAgents:]
+	return l.targeter().OverflowMembers()
 }
 
-// paneEligibleOfficeMembers returns officeAgentOrder() minus agents that
-// should never get a tmux/claude pane (e.g. codex-bound agents, which use
-// their own headless pipeline). Filtering upstream keeps visible/overflow
-// slot indices in sync with agentPaneTargets().
 func (l *Launcher) paneEligibleOfficeMembers() []officeMember {
-	ordered := l.officeAgentOrder()
-	filtered := make([]officeMember, 0, len(ordered))
-	for _, m := range ordered {
-		if l.memberUsesHeadlessOneShotRuntime(m.Slug) {
-			continue
-		}
-		filtered = append(filtered, m)
-	}
-	return filtered
+	return l.targeter().PaneEligibleMembers()
 }
 
-func overflowWindowName(slug string) string {
-	return "agent-" + strings.TrimSpace(slug)
-}
-
-// resolvePaneTargetForSlug returns the current pane address for an agent
-// slug, or "" if the agent has no live pane right now. Called by the
-// pane-capture loop when its cached target keeps failing so it can pick
-// up new addresses after office reseeds recreate panes under different
-// ids. Returns ok=false when the agent isn't pane-backed at all (e.g.
-// codex-bound agents that dispatch headlessly).
 func (l *Launcher) resolvePaneTargetForSlug(slug string) (string, bool) {
-	if l == nil || slug == "" {
-		return "", false
-	}
-	targets := l.agentPaneTargets()
-	target, ok := targets[slug]
-	if !ok {
-		return "", false
-	}
-	return target.PaneTarget, true
+	return l.targeter().ResolvePaneTarget(slug)
 }
 
 func (l *Launcher) agentPaneTargets() map[string]notificationTarget {
-	targets := make(map[string]notificationTarget)
-	// Pane targets only make sense when tmux panes actually back the agents.
-	// Otherwise every PaneTarget string we return is a ghost pointing at a
-	// non-existent pane — and downstream code (agentNotificationTargets,
-	// shouldUseHeadlessDispatchForTarget) treats the non-empty PaneTarget as
-	// "pane path", which bypasses the headless dispatcher and types into a
-	// dead tmux session that silently drops every notification.
-	if l == nil || !l.paneBackedAgents {
-		return targets
-	}
-	if l.isOneOnOne() {
-		slug := l.oneOnOneAgent()
-		if slug != "" && !l.skipPaneForSlug(slug) {
-			targets[slug] = notificationTarget{
-				Slug:       slug,
-				PaneTarget: fmt.Sprintf("%s:team.1", l.sessionName),
-			}
-		}
-		return targets
-	}
-	for i, member := range l.visibleOfficeMembers() {
-		if l.skipPaneForSlug(member.Slug) {
-			continue
-		}
-		targets[member.Slug] = notificationTarget{
-			Slug:       member.Slug,
-			PaneTarget: fmt.Sprintf("%s:team.%d", l.sessionName, i+1),
-		}
-	}
-	for _, member := range l.overflowOfficeMembers() {
-		if l.skipPaneForSlug(member.Slug) {
-			continue
-		}
-		targets[member.Slug] = notificationTarget{
-			Slug:       member.Slug,
-			PaneTarget: fmt.Sprintf("%s:%s.0", l.sessionName, overflowWindowName(member.Slug)),
-		}
-	}
-	return targets
+	return l.targeter().PaneTargets()
 }
 
 func (l *Launcher) agentNotificationTargets() map[string]notificationTarget {
-	targets := l.agentPaneTargets()
-	if l == nil {
-		return targets
-	}
-	addHeadless := func(slug string) {
-		slug = strings.TrimSpace(slug)
-		if slug == "" {
-			return
-		}
-		if _, ok := targets[slug]; ok {
-			return
-		}
-		if l.shouldUseHeadlessDispatchForSlug(slug) {
-			targets[slug] = notificationTarget{Slug: slug}
-		}
-	}
-	if l.isOneOnOne() {
-		addHeadless(l.oneOnOneAgent())
-		return targets
-	}
-	addHeadless(l.officeLeadSlug())
-	for _, member := range l.activeSessionMembers() {
-		addHeadless(member.Slug)
-	}
-	return targets
+	return l.targeter().NotificationTargets()
 }
 
 func (l *Launcher) shouldUseHeadlessDispatchForSlug(slug string) bool {
-	if l == nil || strings.TrimSpace(slug) == "" {
-		return false
-	}
-	if l.shouldUseHeadlessDispatch() {
-		return true
-	}
-	if l.memberUsesHeadlessOneShotRuntime(slug) {
-		return true
-	}
-	if _, failed := l.failedPaneSlugs[strings.TrimSpace(slug)]; failed {
-		return true
-	}
-	return false
+	return l.targeter().ShouldUseHeadlessForSlug(slug)
 }
 
 func (l *Launcher) shouldUseHeadlessDispatchForTarget(target notificationTarget) bool {
-	if l == nil {
-		return false
-	}
-	if l.shouldUseHeadlessDispatchForSlug(target.Slug) {
-		return true
-	}
-	return strings.TrimSpace(target.PaneTarget) == ""
+	return l.targeter().ShouldUseHeadlessForTarget(target)
 }
 
-// skipPaneForSlug returns true when the given slug should not have a tmux
-// pane target registered — either because pane spawn failed earlier, or
-// because the agent is bound to a non-pane provider and uses its own headless
-// pipeline. In either case, dispatch falls back to the headless path.
 func (l *Launcher) skipPaneForSlug(slug string) bool {
-	slug = strings.TrimSpace(slug)
-	if slug == "" {
-		return true
-	}
-	if _, bad := l.failedPaneSlugs[slug]; bad {
-		return true
-	}
-	if l.memberUsesHeadlessOneShotRuntime(slug) {
-		return true
-	}
-	return false
+	return l.targeter().SkipPane(slug)
 }
 
 func (l *Launcher) isOneOnOne() bool {
@@ -2038,58 +1927,22 @@ func (l *Launcher) usesOpencodeRuntime() bool {
 	return strings.EqualFold(strings.TrimSpace(l.provider), "opencode")
 }
 
-// usesPaneRuntime reports whether the install-wide provider should run
-// agents in interactive tmux panes. Reads PaneEligible from the provider
-// Registry; an unregistered or non-pane-eligible provider returns false,
-// so dispatch falls through to the headless path.
-func (l *Launcher) usesPaneRuntime() bool {
-	return provider.CapabilitiesFor(normalizeProviderKind(l.provider)).PaneEligible
-}
+// usesPaneRuntime / requiresClaudeSessionReset / memberEffectiveProviderKind /
+// memberUsesHeadlessOneShotRuntime live on officeTargeter (PLAN.md §C2);
+// these wrappers keep ~30 in-package callers compiling without a rename
+// sweep in this PR.
+func (l *Launcher) usesPaneRuntime() bool { return l.targeter().UsesPaneRuntime() }
 
-// requiresClaudeSessionReset reports whether the install-wide provider
-// populates the Claude session store and therefore needs provider.ResetClaudeSessions
-// to run on ResetSession / ReconfigureSession. Today only Claude Code does.
 func (l *Launcher) requiresClaudeSessionReset() bool {
-	return provider.CapabilitiesFor(normalizeProviderKind(l.provider)).RequiresClaudeSessionReset
+	return l.targeter().RequiresClaudeSessionReset()
 }
 
-// memberEffectiveProviderKind returns the provider kind that should run the
-// given agent's next turn. Lookup order: member's per-agent ProviderBinding
-// (set via /agent create --provider=X or the hire-agent modal), then the
-// install-wide l.provider fallback.
 func (l *Launcher) memberEffectiveProviderKind(slug string) string {
-	if l.broker != nil {
-		if kind := l.broker.MemberProviderKind(slug); kind != "" {
-			return normalizeProviderKind(kind)
-		}
-	}
-	return normalizeProviderKind(l.provider)
+	return l.targeter().MemberEffectiveProviderKind(slug)
 }
 
-// memberUsesHeadlessOneShotRuntime reports whether the given agent is bound to
-// a runtime that is not pane-eligible and therefore skips the tmux/claude pane
-// infrastructure in favor of the broker-driven headless queue.
 func (l *Launcher) memberUsesHeadlessOneShotRuntime(slug string) bool {
-	kind := l.memberEffectiveProviderKind(slug)
-	return !provider.CapabilitiesFor(kind).PaneEligible
-}
-
-// normalizeProviderKind trims and canonicalizes provider kinds while
-// preserving unknown values so dispatch code can surface explicit errors.
-func normalizeProviderKind(raw string) string {
-	k := strings.ToLower(strings.TrimSpace(raw))
-	switch k {
-	case "claude", "":
-		return provider.KindClaudeCode
-	case "codex":
-		return provider.KindCodex
-	case "opencode":
-		return provider.KindOpencode
-	case "claude-code", "openclaw":
-		return k
-	default:
-		return k
-	}
+	return l.targeter().MemberUsesHeadlessOneShotRuntime(slug)
 }
 
 // UsesTmuxRuntime reports whether agents run in tmux panes. Equivalent to
@@ -2946,17 +2799,9 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 	l.queuePaneNotification(target.Slug, target.PaneTarget, notification)
 }
 
-// shouldUseHeadlessDispatch returns true when notifications must be delivered
-// via a queued headless `claude --print` turn rather than typed into a live
-// interactive pane. This is the default path for both web and TUI modes.
-// Codex runtime is always headless. Pane-backed interactive dispatch is only
-// used when the fallback path explicitly brought panes up (paneBackedAgents).
-func (l *Launcher) shouldUseHeadlessDispatch() bool {
-	if !l.usesPaneRuntime() {
-		return true
-	}
-	return !l.paneBackedAgents
-}
+// shouldUseHeadlessDispatch is a thin wrapper around the targeter; see
+// officeTargeter.ShouldUseHeadless for semantics.
+func (l *Launcher) shouldUseHeadlessDispatch() bool { return l.targeter().ShouldUseHeadless() }
 
 // Minimum gap between two consecutive pane `/clear` + type cycles for the
 // same agent. Serves as a safety floor against truly back-to-back sends
@@ -4256,40 +4101,14 @@ func (l *Launcher) BrokerBaseURL() string {
 	return brokerBaseURL()
 }
 
+// officeMemberBySlug / officeLeadSlug / activeSessionMembers / getAgentName
+// live on officeTargeter (PLAN.md §C2); thin wrappers keep current callers
+// working without a rename sweep.
 func (l *Launcher) officeMemberBySlug(slug string) officeMember {
-	for _, member := range l.officeMembersSnapshot() {
-		if member.Slug == slug {
-			return member
-		}
-	}
-	return officeMember{Slug: slug, Name: slug, Role: slug}
+	return l.targeter().MemberBySlug(slug)
 }
 
-func (l *Launcher) officeLeadSlug() string {
-	if l.pack != nil && strings.TrimSpace(l.pack.LeadSlug) != "" {
-		return l.pack.LeadSlug
-	}
-	return officeLeadSlugFrom(l.activeSessionMembers())
-}
-
-// officeLeadSlugFrom derives the lead slug from an already-loaded member
-// snapshot, avoiding a redundant officeMembersSnapshot call.
-func officeLeadSlugFrom(members []officeMember) string {
-	for _, member := range members {
-		if member.Slug == "ceo" {
-			return "ceo"
-		}
-	}
-	for _, member := range members {
-		if member.BuiltIn {
-			return member.Slug
-		}
-	}
-	if len(members) > 0 {
-		return members[0].Slug
-	}
-	return ""
-}
+func (l *Launcher) officeLeadSlug() string { return l.targeter().LeadSlug() }
 
 func agentConfigFromMember(member officeMember) agent.AgentConfig {
 	cfg := agent.AgentConfig{
@@ -4313,50 +4132,7 @@ func agentConfigFromMember(member officeMember) agent.AgentConfig {
 }
 
 func (l *Launcher) activeSessionMembers() []officeMember {
-	members := l.officeMembersSnapshot()
-	if l == nil || l.pack == nil || len(l.pack.Agents) == 0 {
-		return members
-	}
-	bySlug := make(map[string]officeMember, len(members))
-	for _, member := range members {
-		bySlug[member.Slug] = member
-	}
-	// Pack order comes first (stable UI / pane layout), then any broker
-	// members not in the pack (wizard-hired agents post-launch). Dropping
-	// broker-only members here silently excluded wizard-hired specialists
-	// from agentNotificationTargets, making @-tags and DMs route to CEO.
-	filtered := make([]officeMember, 0, len(members))
-	seen := make(map[string]struct{}, len(members))
-	for _, cfg := range l.pack.Agents {
-		if member, ok := bySlug[cfg.Slug]; ok {
-			filtered = append(filtered, member)
-			seen[cfg.Slug] = struct{}{}
-			continue
-		}
-		member := officeMember{
-			Slug:           cfg.Slug,
-			Name:           cfg.Name,
-			Role:           cfg.Name,
-			Expertise:      append([]string(nil), cfg.Expertise...),
-			Personality:    cfg.Personality,
-			PermissionMode: cfg.PermissionMode,
-			AllowedTools:   append([]string(nil), cfg.AllowedTools...),
-			BuiltIn:        cfg.Slug == l.pack.LeadSlug || cfg.Slug == "ceo",
-		}
-		applyOfficeMemberDefaults(&member)
-		filtered = append(filtered, member)
-		seen[cfg.Slug] = struct{}{}
-	}
-	for _, member := range members {
-		if _, ok := seen[member.Slug]; ok {
-			continue
-		}
-		filtered = append(filtered, member)
-	}
-	if len(filtered) > 0 {
-		return filtered
-	}
-	return members
+	return l.targeter().ActiveSessionMembers()
 }
 
 // PackName returns the display name of the pack.
@@ -4387,13 +4163,9 @@ func filterEnv(env []string, key string) []string {
 	return out
 }
 
-// getAgentName returns the display name for an agent slug.
-func (l *Launcher) getAgentName(slug string) string {
-	if member := l.officeMemberBySlug(slug); member.Name != "" {
-		return member.Name
-	}
-	return slug
-}
+// getAgentName returns the display name for an agent slug. Delegates to
+// the targeter (PLAN.md §C2).
+func (l *Launcher) getAgentName(slug string) string { return l.targeter().NameFor(slug) }
 
 // ═══════════════════════════════════════════════════════════════
 // Web View Mode

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -149,18 +149,21 @@ type Launcher struct {
 	// authoritative source for sessionName / pack / failedPaneSlugs /
 	// paneBackedAgents — the targeter holds pointers/callbacks back into
 	// the launcher rather than copies.
-	targets *officeTargeter
+	targets     *officeTargeter
+	targetsOnce sync.Once
 
 	// notify owns notification-context and work-packet construction
 	// (PLAN.md §C3). Lazily constructed via notifyCtx() and shares state
 	// with the launcher via callbacks (broker reads, headless queue peek).
-	notify *notificationContextBuilder
+	notify     *notificationContextBuilder
+	notifyOnce sync.Once
 
 	// schedulerWorker owns the watchdog scheduler goroutine
 	// (PLAN.md §C4). Lazily constructed via scheduler(); Launch starts the
 	// goroutine via watchdogSchedulerLoop, Kill drains it via Stop before
 	// tearing down the broker. clock is realClock in production.
-	schedulerWorker *watchdogScheduler
+	schedulerWorker     *watchdogScheduler
+	schedulerWorkerOnce sync.Once
 }
 
 // paneDispatchTurn is one queued notification to type into a tmux pane.
@@ -1444,14 +1447,16 @@ func (l *Launcher) scheduler() *watchdogScheduler {
 	if l == nil {
 		return nil
 	}
-	if l.schedulerWorker != nil {
-		return l.schedulerWorker
-	}
-	l.schedulerWorker = &watchdogScheduler{
-		broker:      l.broker,
-		clock:       realClock{},
-		deliverTask: l.deliverTaskNotification,
-	}
+	// sync.Once guards lazy-init: Launch() spawns watchdogSchedulerLoop
+	// alongside other goroutines that hit scheduler() concurrently
+	// (e.g. headless dispatch enqueues that call updateSchedulerJob).
+	l.schedulerWorkerOnce.Do(func() {
+		l.schedulerWorker = &watchdogScheduler{
+			broker:      l.broker,
+			clock:       realClock{},
+			deliverTask: l.deliverTaskNotification,
+		}
+	})
 	return l.schedulerWorker
 }
 
@@ -1496,25 +1501,30 @@ func (l *Launcher) targeter() *officeTargeter {
 	if l == nil {
 		return nil
 	}
-	if l.targets != nil {
-		return l.targets
-	}
-	if l.failedPaneSlugs == nil {
-		l.failedPaneSlugs = map[string]string{}
-	}
-	l.targets = &officeTargeter{
-		sessionName:        l.sessionName,
-		pack:               l.pack,
-		cwd:                l.cwd,
-		provider:           l.provider,
-		paneBackedFlag:     &l.paneBackedAgents,
-		failedPaneSlugs:    l.failedPaneSlugs,
-		isOneOnOne:         l.isOneOnOne,
-		oneOnOneSlug:       l.oneOnOneAgent,
-		isChannelDM:        l.isChannelDMRaw,
-		snapshotMembers:    l.officeMembersSnapshot,
-		memberProviderKind: l.brokerMemberProviderKind,
-	}
+	// sync.Once guards against the lazy-init races that arise during
+	// Launch() — multiple goroutines (notifyAgentsLoop, watchdogSchedulerLoop,
+	// pollNexNotificationsLoop, etc.) can hit this concurrently before the
+	// first ordered call has finished. Without the Once, two goroutines can
+	// each observe l.targets == nil and both write a fresh pointer.
+	l.targetsOnce.Do(func() {
+		l.targets = &officeTargeter{
+			sessionName:    l.sessionName,
+			pack:           l.pack,
+			cwd:            l.cwd,
+			provider:       l.provider,
+			paneBackedFlag: &l.paneBackedAgents,
+			// Read via callback so reconfigureVisibleAgents nilling
+			// l.failedPaneSlugs (and recordPaneSpawnFailure rebuilding it)
+			// stays observable to the targeter. A snapshotted map pointer
+			// would orphan after the first reconfigure.
+			failedPaneSlugs:    func() map[string]string { return l.failedPaneSlugs },
+			isOneOnOne:         l.isOneOnOne,
+			oneOnOneSlug:       l.oneOnOneAgent,
+			isChannelDM:        l.isChannelDMRaw,
+			snapshotMembers:    l.officeMembersSnapshot,
+			memberProviderKind: l.brokerMemberProviderKind,
+		}
+	})
 	return l.targets
 }
 
@@ -1867,10 +1877,17 @@ func (l *Launcher) notifyCtx() *notificationContextBuilder {
 	if l == nil {
 		return nil
 	}
-	if l.notify != nil {
-		return l.notify
-	}
-	l.notify = &notificationContextBuilder{
+	// sync.Once guards against concurrent first-callers from the various
+	// notify-* goroutines spawned in Launch() — without it, two of them
+	// can both observe l.notify == nil and write competing pointers.
+	l.notifyOnce.Do(func() {
+		l.notify = newNotifyCtx(l)
+	})
+	return l.notify
+}
+
+func newNotifyCtx(l *Launcher) *notificationContextBuilder {
+	return &notificationContextBuilder{
 		targeter: l.targeter(),
 		channelMessages: func(channelSlug string) []channelMessage {
 			if l.broker == nil {
@@ -1899,7 +1916,6 @@ func (l *Launcher) notifyCtx() *notificationContextBuilder {
 		scoreTaskCandidate:   l.scoreMessageForTaskCandidate,
 		activeHeadlessAgents: l.activeHeadlessSlugs,
 	}
-	return l.notify
 }
 
 // activeHeadlessSlugs returns the slugs that have non-empty headless

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -35,6 +35,7 @@ import (
 	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/brokeraddr"
 	"github.com/nex-crm/wuphf/internal/calendar"
+	"github.com/nex-crm/wuphf/internal/channel"
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/nex"
@@ -150,6 +151,11 @@ type Launcher struct {
 	// paneBackedAgents — the targeter holds pointers/callbacks back into
 	// the launcher rather than copies.
 	targets *officeTargeter
+
+	// notify owns notification-context and work-packet construction
+	// (PLAN.md §C3). Lazily constructed via notifyCtx() and shares state
+	// with the launcher via callbacks (broker reads, headless queue peek).
+	notify *notificationContextBuilder
 }
 
 // paneDispatchTurn is one queued notification to type into a tmux pane.
@@ -934,76 +940,10 @@ func (l *Launcher) shouldDeliverDelayedTaskNotification(targetSlug string, actio
 	return true
 }
 
+// taskNotificationContent delegates to the notificationContextBuilder
+// (PLAN.md §C3). See notification_context.go for the formatting body.
 func (l *Launcher) taskNotificationContent(action officeActionLog, task teamTask) string {
-	channel := normalizeChannelSlug(task.Channel)
-	if channel == "" {
-		channel = "general"
-	}
-	verb := "Task update"
-	switch action.Kind {
-	case "task_created":
-		verb = "Task created"
-	case "task_updated":
-		verb = "Task updated"
-	case "task_unblocked":
-		verb = "Task unblocked — dependencies resolved, ready to start"
-	case "watchdog_alert":
-		verb = "Watchdog reminder"
-	}
-	owner := strings.TrimSpace(task.Owner)
-	if owner == "" {
-		owner = "unassigned"
-	} else {
-		owner = "@" + owner
-	}
-	status := strings.TrimSpace(task.Status)
-	if status == "" {
-		status = "open"
-	}
-	details := strings.TrimSpace(task.Details)
-	if details != "" {
-		details = " — " + truncate(details, 120)
-	}
-	pipeline := ""
-	if strings.TrimSpace(task.PipelineStage) != "" {
-		pipeline = ", stage " + task.PipelineStage
-	}
-	review := ""
-	if strings.TrimSpace(task.ReviewState) != "" && task.ReviewState != "not_required" {
-		review = ", review " + task.ReviewState
-	}
-	execMode := ""
-	if strings.TrimSpace(task.ExecutionMode) != "" {
-		execMode = ", execution " + task.ExecutionMode
-	}
-	worktree := ""
-	if strings.TrimSpace(task.WorktreeBranch) != "" || strings.TrimSpace(task.WorktreePath) != "" {
-		parts := make([]string, 0, 2)
-		if strings.TrimSpace(task.WorktreeBranch) != "" {
-			parts = append(parts, "branch "+task.WorktreeBranch)
-		}
-		if strings.TrimSpace(task.WorktreePath) != "" {
-			parts = append(parts, "path "+task.WorktreePath)
-		}
-		worktree = ", worktree " + strings.Join(parts, " · ")
-	}
-	guidance := ""
-	if path := strings.TrimSpace(task.WorktreePath); path != "" {
-		guidance = fmt.Sprintf(" If you own this task, use working_directory=%q for local file and bash tools.", path)
-	}
-	framing := ""
-	if taskRequiresRealExternalExecution(&task) {
-		framing = " Live business framing: describe the work as a client deliverable, approval, handoff, update, or record. Do not present it as a proof marker, eval artifact, or test artifact unless the task explicitly asks for testing or evidence capture."
-	}
-	capability := ""
-	if taskRequiresRealExternalExecution(&task) {
-		capability = "\n" + capabilityGapCoachingBlock()
-	}
-	hygiene := ""
-	if taskLooksLikeLiveBusinessObjective(&task) {
-		hygiene = "\n" + taskHygieneCoachingBlock()
-	}
-	return fmt.Sprintf("[%s #%s on #%s]: %s%s (owner %s, status %s%s%s%s%s). Context is included — do NOT call team_poll or team_tasks. Respond with the concrete next step immediately. Stay in your lane. Once you have posted the needed update, STOP and wait for the next pushed notification.%s%s%s%s", verb, task.ID, channel, task.Title, details, owner, status, pipeline, review, execMode, worktree, guidance, framing, capability, hygiene)
+	return l.notifyCtx().TaskNotificationContent(action, task)
 }
 
 func (l *Launcher) sendTaskUpdate(target notificationTarget, action officeActionLog, task teamTask, content string) {
@@ -1776,33 +1716,6 @@ func (req humanInterview) TitleOrDefault() string {
 	return "Request"
 }
 
-func humanizeNotificationType(kind string) string {
-	switch strings.TrimSpace(kind) {
-	case "context_alert":
-		return "Context alert"
-	case "daily_digest":
-		return "Daily digest"
-	case "meeting_summary":
-		return "Meeting summary"
-	case "task_reminder":
-		return "Task reminder"
-	case "task_assigned":
-		return "Task assigned"
-	default:
-		if kind == "" {
-			return ""
-		}
-		parts := strings.Split(strings.ReplaceAll(kind, "_", " "), " ")
-		for i, part := range parts {
-			if part == "" {
-				continue
-			}
-			parts[i] = strings.ToUpper(part[:1]) + part[1:]
-		}
-		return strings.Join(parts, " ")
-	}
-}
-
 // targeter returns the office-targeter, lazily constructing it on first
 // access. PLAN.md trap §5.4: tests build &Launcher{} directly and rely on
 // every sub-type being nil-safe. The targeter shares mutable state with
@@ -1973,50 +1886,6 @@ func killStaleBroker() {
 		_ = exec.CommandContext(context.Background(), "kill", "-9", pid).Run()
 	}
 	time.Sleep(500 * time.Millisecond)
-}
-
-func truncate(s string, max int) string {
-	if len(s) <= max {
-		return s
-	}
-	return s[:max] + "..."
-}
-
-func extractTaskFileTargets(text string) []string {
-	text = strings.TrimSpace(text)
-	if text == "" {
-		return nil
-	}
-	seen := map[string]struct{}{}
-	targets := make([]string, 0, 4)
-	for {
-		start := strings.Index(text, "`")
-		if start < 0 {
-			break
-		}
-		text = text[start+1:]
-		end := strings.Index(text, "`")
-		if end < 0 {
-			break
-		}
-		candidate := strings.TrimSpace(text[:end])
-		text = text[end+1:]
-		if candidate == "" {
-			continue
-		}
-		if !strings.Contains(candidate, "/") && !strings.Contains(candidate, ".") {
-			continue
-		}
-		if _, ok := seen[candidate]; ok {
-			continue
-		}
-		seen[candidate] = struct{}{}
-		targets = append(targets, candidate)
-		if len(targets) == 4 {
-			break
-		}
-	}
-	return targets
 }
 
 func containsSlug(items []string, want string) bool {
@@ -2213,564 +2082,114 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 	return nil
 }
 
-// buildNotificationContext returns a compact summary of recent channel messages
-// for inline injection into agent notifications. Filters system and status messages.
-// buildNotificationContext returns a pre-labeled context section for work packets.
-//
-// When threadRootID is non-empty, the function first tries to build thread-scoped
-// context: messages whose ID equals threadRootID (the root) or whose ReplyTo equals
-// threadRootID (direct replies). This is labeled "[Recent thread]" and gives agents
-// only the relevant sub-conversation, not unrelated channel noise.
-//
-// When threadRootID is empty, or when the thread has no displayable messages (e.g.
-// the trigger is the first message in a new thread), the function falls back to the
-// last N channel messages and labels the section "[Recent channel]". Agents should
-// treat "[Recent channel]" as broad ambient context rather than the specific thread
-// they are responding in.
-//
-// The trigger message (triggerMsgID) is always excluded — it is already delivered
-// explicitly as "[New from @...]" in the notification, so including it again wastes
-// ~150 tokens per turn.
-func (l *Launcher) buildNotificationContext(channel, triggerMsgID, threadRootID string, limit int) string {
-	if l.broker == nil {
-		return ""
+// notifyCtx returns the notification-context builder, lazily constructing
+// it on first access (PLAN.md §C3). The builder shares state with Launcher
+// via callbacks for broker reads and headless-queue peek; constructed
+// fresh per call so each work packet sees current broker state.
+func (l *Launcher) notifyCtx() *notificationContextBuilder {
+	if l == nil {
+		return nil
 	}
-	if strings.TrimSpace(channel) == "" {
-		channel = "general"
+	if l.notify != nil {
+		return l.notify
 	}
-
-	msgs := l.broker.ChannelMessages(channel)
-	if len(msgs) == 0 {
-		return ""
-	}
-
-	// baseFilter excludes system messages, STATUS messages, demo_seed posts,
-	// and the trigger itself. demo_seed lines are cosmetic onboarding-paint
-	// content (e.g. the lead presence line) and replaying them as prompt
-	// context would let agents treat fake activity as real history.
-	baseFilter := func(m channelMessage) bool {
-		if m.From == "system" {
-			return false
-		}
-		if m.Kind == "demo_seed" {
-			return false
-		}
-		if strings.TrimSpace(triggerMsgID) != "" && strings.TrimSpace(m.ID) == strings.TrimSpace(triggerMsgID) {
-			return false
-		}
-		if strings.HasPrefix(strings.TrimSpace(m.Content), "[STATUS]") {
-			return false
-		}
-		return true
-	}
-
-	formatContext := func(items []channelMessage) string {
-		var b strings.Builder
-		for _, m := range items {
-			b.WriteString(fmt.Sprintf("@%s: %s\n", m.From, truncate(m.Content, 600)))
-		}
-		return strings.TrimRight(b.String(), "\n")
-	}
-
-	// Thread-scoped context: show all messages in the thread tree (full BFS from
-	// root), always anchoring with the root message so agents see the original
-	// human ask. This matters for dependent task chains — e.g., a marketing agent
-	// writing an email "based on research" needs to see the researcher's results,
-	// which are grandchildren of the thread root, not direct children.
-	//
-	// Approach: always include the root, fill remaining slots with the most recent
-	// non-root thread messages (so the latest activity is always visible).
-	threadRoot := strings.TrimSpace(threadRootID)
-	if threadRoot != "" {
-		threadIDs := l.threadMessageIDs(channel, threadRoot)
-		// Separate root from rest so we can always preserve it.
-		var rootMsg *channelMessage
-		var rest []channelMessage
-		for i := range msgs {
-			m := &msgs[i]
-			if !baseFilter(*m) {
-				continue
+	l.notify = &notificationContextBuilder{
+		targeter: l.targeter(),
+		channelMessages: func(channelSlug string) []channelMessage {
+			if l.broker == nil {
+				return nil
 			}
-			if strings.TrimSpace(m.ID) == threadRoot {
-				rootMsg = m
-			} else if _, inThread := threadIDs[strings.TrimSpace(m.ID)]; inThread {
-				rest = append(rest, *m)
+			return l.broker.ChannelMessages(channelSlug)
+		},
+		channelTasks: func(channelSlug string) []teamTask {
+			if l.broker == nil {
+				return nil
 			}
-		}
-		if rootMsg != nil || len(rest) > 0 {
-			// Take last (limit-1) from rest to leave a slot for the root.
-			remaining := limit
-			if rootMsg != nil {
-				remaining--
+			return l.broker.ChannelTasks(channelSlug)
+		},
+		allTasks: func() []teamTask {
+			if l.broker == nil {
+				return nil
 			}
-			if len(rest) > remaining {
-				rest = rest[len(rest)-remaining:]
+			return l.broker.AllTasks()
+		},
+		channelStore: func() *channel.Store {
+			if l.broker == nil {
+				return nil
 			}
-			var thread []channelMessage
-			if rootMsg != nil {
-				thread = append(thread, *rootMsg)
-			}
-			thread = append(thread, rest...)
-			return "[Recent thread]\n" + formatContext(thread)
-		}
+			return l.broker.ChannelStore()
+		},
+		scoreTaskCandidate:   l.scoreMessageForTaskCandidate,
+		activeHeadlessAgents: l.activeHeadlessSlugs,
 	}
-
-	// Fall back to recent channel messages when there is no thread context.
-	var filtered []channelMessage
-	for _, m := range msgs {
-		if baseFilter(m) {
-			filtered = append(filtered, m)
-		}
-	}
-	if len(filtered) == 0 {
-		return ""
-	}
-	if len(filtered) > limit {
-		filtered = filtered[len(filtered)-limit:]
-	}
-	return "[Recent channel]\n" + formatContext(filtered)
+	return l.notify
 }
 
-// ultimateThreadRoot walks the reply-to chain from startID up to the topmost
-// ancestor (the message with no ReplyTo) and returns its ID. This ensures that
-// when building thread context for a deep reply chain — e.g., human ask → CEO
-// delegation → specialist response — the filtering anchors at the original human
-// ask rather than a mid-thread message, so all participants see the full context.
-//
-// If startID is empty, startID itself is returned. The walk is capped at 8 hops
-// to prevent cycles or unbounded work on pathological data.
-func (l *Launcher) ultimateThreadRoot(channel, startID string) string {
-	startID = strings.TrimSpace(startID)
-	if startID == "" || l.broker == nil {
-		return startID
+// activeHeadlessSlugs returns the slugs that have non-empty headless
+// queues or active turns at the moment of the call. Locks headlessMu so
+// the snapshot is consistent. The except parameter is the slug being
+// notified — the lead must not list itself as "already active".
+func (l *Launcher) activeHeadlessSlugs(except string) map[string]struct{} {
+	if l == nil {
+		return nil
 	}
-	msgs := l.broker.ChannelMessages(channel)
-	byID := make(map[string]channelMessage, len(msgs))
-	for _, m := range msgs {
-		if id := strings.TrimSpace(m.ID); id != "" {
-			byID[id] = m
+	l.headlessMu.Lock()
+	defer l.headlessMu.Unlock()
+	out := map[string]struct{}{}
+	for workerSlug, queue := range l.headlessQueues {
+		if workerSlug == except {
+			continue
+		}
+		if len(queue) > 0 {
+			out[workerSlug] = struct{}{}
 		}
 	}
-	root := startID
-	for depth := 0; depth < 8; depth++ {
-		m, ok := byID[root]
-		if !ok {
-			break
+	for workerSlug, active := range l.headlessActive {
+		if workerSlug == except {
+			continue
 		}
-		parent := strings.TrimSpace(m.ReplyTo)
-		if parent == "" {
-			break
+		if active != nil {
+			out[workerSlug] = struct{}{}
 		}
-		root = parent
 	}
-	return root
+	return out
 }
 
-// threadMessageIDs returns the set of all message IDs that belong to the thread
-// rooted at rootID (BFS traversal via replyTo reverse index). The root itself is
-// included. Returns an empty set when rootID is empty or broker is nil.
-func (l *Launcher) threadMessageIDs(channel, rootID string) map[string]struct{} {
-	rootID = strings.TrimSpace(rootID)
-	result := make(map[string]struct{})
-	if rootID == "" || l.broker == nil {
-		return result
-	}
-	msgs := l.broker.ChannelMessages(channel)
-	byParent := make(map[string][]string, len(msgs))
-	for _, m := range msgs {
-		parent := strings.TrimSpace(m.ReplyTo)
-		if parent != "" {
-			byParent[parent] = append(byParent[parent], strings.TrimSpace(m.ID))
-		}
-	}
-	result[rootID] = struct{}{}
-	queue := []string{rootID}
-	for len(queue) > 0 {
-		cur := queue[0]
-		queue = queue[1:]
-		for _, child := range byParent[cur] {
-			if _, seen := result[child]; !seen {
-				result[child] = struct{}{}
-				queue = append(queue, child)
-			}
-		}
-	}
-	return result
+// Notification-context methods on Launcher are thin wrappers; the bodies
+// live in notification_context.go on notificationContextBuilder. Wrappers
+// kept (rather than removed) so the ~50 in-package callers don't need a
+// rename sweep in this PR — that's a follow-up.
+
+func (l *Launcher) buildNotificationContext(channelSlug, triggerMsgID, threadRootID string, limit int) string {
+	return l.notifyCtx().NotificationContext(channelSlug, triggerMsgID, threadRootID, limit)
 }
 
-func (l *Launcher) buildTaskNotificationContext(channel, slug string, limit int) string {
-	if l.broker == nil || limit <= 0 {
-		return ""
-	}
+func (l *Launcher) ultimateThreadRoot(channelSlug, startID string) string {
+	return l.notifyCtx().UltimateThreadRoot(channelSlug, startID)
+}
 
-	var tasks []teamTask
-	if strings.TrimSpace(channel) == "" {
-		// No specific channel: scan all tasks across all channels so non-general
-		// channel tasks are not silently omitted from the CEO's task context.
-		tasks = l.broker.AllTasks()
-	} else {
-		tasks = l.broker.ChannelTasks(channel)
-	}
-	if len(tasks) == 0 {
-		return ""
-	}
+func (l *Launcher) threadMessageIDs(channelSlug, rootID string) map[string]struct{} {
+	return l.notifyCtx().ThreadMessageIDs(channelSlug, rootID)
+}
 
-	formatTask := func(task teamTask) string {
-		owner := strings.TrimSpace(task.Owner)
-		switch {
-		case owner == "":
-			owner = "unassigned"
-		default:
-			owner = "@" + owner
-		}
-		status := strings.TrimSpace(task.Status)
-		if status == "" {
-			status = "open"
-		}
-		meta := owner + ", " + status
-		if task.Blocked {
-			meta += ", blocked"
-		}
-		if len(task.DependsOn) > 0 {
-			meta += ", depends: " + strings.Join(task.DependsOn, " ")
-		}
-		taskChannel := normalizeChannelSlug(task.Channel)
-		if taskChannel == "" {
-			taskChannel = "general"
-		}
-		line := fmt.Sprintf("- #%s on #%s %s (%s)", task.ID, taskChannel, truncate(task.Title, 72), meta)
-		if details := strings.TrimSpace(task.Details); details != "" {
-			line += ": " + truncate(details, 96)
-		}
-		return line
-	}
-
-	// Sort tasks so the most recently updated active work surfaces first.
-	// This prevents a fixed insertion-order view where the first 3 tasks created
-	// always fill the slot, potentially hiding newer or more urgent work.
-	sort.Slice(tasks, func(i, j int) bool {
-		return tasks[i].UpdatedAt > tasks[j].UpdatedAt
-	})
-
-	lines := make([]string, 0, limit)
-	seen := make(map[string]struct{}, limit)
-	addTask := func(task teamTask) {
-		if len(lines) >= limit {
-			return
-		}
-		if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
-			return
-		}
-		if _, ok := seen[task.ID]; ok {
-			return
-		}
-		seen[task.ID] = struct{}{}
-		lines = append(lines, formatTask(task))
-	}
-
-	lead := l.officeLeadSlug()
-	for _, task := range tasks {
-		if slug == lead || strings.TrimSpace(task.Owner) == slug {
-			addTask(task)
-		}
-	}
-	if len(lines) == 0 {
-		for _, task := range tasks {
-			addTask(task)
-		}
-	}
-	if len(lines) == 0 {
-		if slug == lead {
-			return "Active tasks:\n- None currently active. If the overall build is not actually finished, create the next owned task(s) now instead of ending with narrative next steps."
-		}
-		return ""
-	}
-
-	result := "Active tasks:\n" + strings.Join(lines, "\n")
-	if slug == lead {
-		reviewCount := 0
-		for _, task := range tasks {
-			if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
-				continue
-			}
-			if strings.EqualFold(strings.TrimSpace(task.Status), "review") || strings.EqualFold(strings.TrimSpace(task.ReviewState), "ready_for_review") {
-				reviewCount++
-			}
-		}
-		if reviewCount > 0 {
-			result += fmt.Sprintf("\nLead action: %d task(s) are waiting in review. Approve them or translate them into the next owned task(s) before you stop.", reviewCount)
-		}
-	}
-	return result
+func (l *Launcher) buildTaskNotificationContext(channelSlug, slug string, limit int) string {
+	return l.notifyCtx().TaskNotificationContext(channelSlug, slug, limit)
 }
 
 func (l *Launcher) relevantTaskForTarget(msg channelMessage, slug string) (teamTask, bool) {
-	if l.broker == nil || slug == "" {
-		return teamTask{}, false
-	}
-	threadRoot := strings.TrimSpace(msg.ID)
-	if replyTo := strings.TrimSpace(msg.ReplyTo); replyTo != "" {
-		threadRoot = replyTo
-	}
-	// Search all channels: a specialist's task may live in a dedicated channel (e.g.
-	// "engineering") even when the triggering message arrived from "general". Using
-	// ChannelTasks(channel) here caused cross-channel delegations to silently omit the
-	// "Active task" line from work packets and give specialists the wrong response
-	// instruction ("stay quiet" instead of "you own matching work").
-	var domainOwned teamTask
-	bestOwnedScore := 0.0
-	for _, task := range l.broker.AllTasks() {
-		if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
-			continue
-		}
-		if strings.TrimSpace(task.Owner) != slug {
-			continue
-		}
-		if task.ThreadID != "" && (task.ThreadID == msg.ID || task.ThreadID == threadRoot) {
-			return task, true
-		}
-		score := l.scoreMessageForTaskCandidate(msg, task)
-		if score >= officeRoutingMatchThreshold && score > bestOwnedScore {
-			domainOwned = task
-			bestOwnedScore = score
-		}
-	}
-	if domainOwned.ID != "" {
-		return domainOwned, true
-	}
-	return teamTask{}, false
+	return l.notifyCtx().RelevantTaskForTarget(msg, slug)
 }
 
 func (l *Launcher) responseInstructionForTarget(msg channelMessage, slug string) string {
-	lead := l.officeLeadSlug()
-	if slug == lead {
-		// When the CEO is woken by a specialist (msg.From is not human/you/system),
-		// the context is different: the specialist just finished work and the CEO
-		// should review and deliver or coordinate, not re-initiate. When woken by
-		// the human, the CEO should reply quickly and route.
-		from := strings.TrimSpace(msg.From)
-		isFromHuman := from == "" || from == "you" || from == "human" || from == "nex"
-		if !isFromHuman {
-			return fmt.Sprintf("You are @%s. A specialist just finished a lane. If the build is still underway, any task is open or in review, or the next lane is obvious, act now: approve/release review items, create the next owned team_task records, and only then stop. On a human build/ship/end-to-end request, if you approve or close an engineering/execution slice and the product is not yet runnable end to end, you MUST leave at least one engineering or execution lane active before you stop; do not let the company drift into GTM-only, rubric-only, or evaluation-only work while the build is still incomplete. Before you say a task is approved, closed, back in progress, reassigned, or blocked, you MUST make the matching team_task or team_plan call first; channel narration alone does not change durable state. If the task mutation fails, say that it failed and do not claim the state changed. Before creating any new task, inspect Active tasks in this packet: if a live task already covers that lane, reuse or update that task instead of creating an overlapping duplicate with a new title. Stay quiet only when the human already has what they need AND there is no remaining office work or obvious follow-up.", slug)
-		}
-		return fmt.Sprintf("You are @%s. Give the first top-level reply quickly, then pull in specialists only when needed. For build/ship/end-to-end requests, the first engineering task itself must be a single smallest runnable feature slice, not an MVP umbrella or a multi-output minimum bar. Do not put a separate repo audit, architecture, or cut-line research task in front of that first feature unless the human explicitly asked for analysis first or the repo truly has no identifiable implementation target. Do not spend the whole first turn on `pwd`, `ls`, `rg --files`, `find .`, or another repo-wide inventory; use the named docs/configs in the packet or at most one or two targeted reads, then create the first durable task/channel state in that same turn. %s", slug, capabilityGapCoachingBlock())
-	}
-	// DMs are direct conversations: the human chose to message this agent
-	// specifically. Always respond, regardless of @tags or task ownership.
-	if ch := normalizeChannelSlug(msg.Channel); IsDMSlug(ch) && DMTargetAgent(ch) == slug {
-		return fmt.Sprintf("You are @%s. The human is messaging you directly in a DM. Respond helpfully from your domain expertise.", slug)
-	}
-	// Also check the new Store-based DM format (deterministic slug).
-	if isDM, agentTarget := l.isChannelDM(normalizeChannelSlug(msg.Channel)); isDM && agentTarget == slug {
-		return fmt.Sprintf("You are @%s. The human is messaging you directly in a DM. Respond helpfully from your domain expertise.", slug)
-	}
-	if containsSlug(msg.Tagged, slug) {
-		return fmt.Sprintf("You are @%s. You were directly tagged. Reply only from your domain with concrete progress, a blocker, or a handoff.", slug)
-	}
-	if task, ok := l.relevantTaskForTarget(msg, slug); ok && strings.TrimSpace(task.Owner) == slug {
-		if taskRequiresRealExternalExecution(&task) {
-			return fmt.Sprintf("You are @%s. You already own matching work that requires a real connected-system action. Take the smallest allowed live external step now or report a blocker; repo docs, previews, local markdown, proof markers, and test artifacts do not satisfy it. Frame the result as a business deliverable, approval, handoff, or record, not as an eval or proof artifact. %s %s", slug, capabilityGapCoachingBlock(), taskHygieneCoachingBlock())
-		}
-		return fmt.Sprintf("You are @%s. You already own matching work. Reply only with concrete progress or a blocker; do not re-triage the thread.", slug)
-	}
-	return fmt.Sprintf("You are @%s. Stay quiet unless you are directly tagged, you own the active work, or you can unblock it. Prefer not to reply.", slug)
+	return l.notifyCtx().ResponseInstructionForTarget(msg, slug)
 }
 
 func (l *Launcher) buildMessageWorkPacket(msg channelMessage, slug string) string {
-	channel := normalizeChannelSlug(msg.Channel)
-	if channel == "" {
-		channel = "general"
-	}
-	lines := []string{
-		"Work packet:",
-		fmt.Sprintf("- Thread: #%s reply_to %s", channel, msg.ID),
-	}
-	// Add DM context preamble when the agent is receiving a direct message.
-	// This replaces the "stay quiet unless tagged" default with explicit DM semantics.
-	if isDM, _ := l.isChannelDM(channel); isDM {
-		dmPreamble := []string{
-			"Context: DIRECT MESSAGE",
-			"This is a private 1:1 conversation with the human. Respond to every message.",
-			"You do not need to coordinate with other agents.",
-			"---",
-		}
-		lines = append(dmPreamble, lines...)
-	} else if l.broker != nil {
-		// Check for group DM context.
-		cs := l.broker.ChannelStore()
-		if cs != nil {
-			if storeChannel, ok := cs.GetBySlug(channel); ok && storeChannel.Type == "G" {
-				members := cs.Members(storeChannel.ID)
-				names := make([]string, 0, len(members))
-				for _, m := range members {
-					if m.Slug != slug {
-						names = append(names, "@"+m.Slug)
-					}
-				}
-				groupPreamble := []string{
-					"Context: GROUP MESSAGE",
-					fmt.Sprintf("This is a group conversation with: %s.", strings.Join(names, ", ")),
-					"Respond to messages directed at you or within your expertise.",
-					"---",
-				}
-				lines = append(groupPreamble, lines...)
-			}
-		}
-	}
-	if containsSlug(msg.Tagged, slug) {
-		lines = append(lines, "- Trigger: you were explicitly tagged")
-	}
-	if task, ok := l.relevantTaskForTarget(msg, slug); ok {
-		lines = append(lines, fmt.Sprintf("- Active task: #%s %s (%s)", task.ID, truncate(task.Title, 96), strings.TrimSpace(task.Status)))
-		if details := strings.TrimSpace(task.Details); details != "" {
-			lines = append(lines, fmt.Sprintf("- Task details: %s", truncate(details, 512)))
-		}
-		if path := strings.TrimSpace(task.WorktreePath); path != "" {
-			lines = append(lines, fmt.Sprintf("- Working directory: %q", path))
-		}
-	}
-	// Walk up the reply chain to find the ultimate thread root (the original human
-	// ask) before filtering. This ensures that for a deep thread — human ask (X) →
-	// CEO delegation (Y) → specialist response (Z) — all participants see X as the
-	// anchor, not just the immediate parent. For top-level messages (ReplyTo == ""),
-	// ultimateThreadRoot returns "" and the function falls back to recent channel
-	// context automatically.
-	threadRoot := l.ultimateThreadRoot(channel, msg.ReplyTo)
-	if ctx := l.buildNotificationContext(channel, msg.ID, threadRoot, 4); ctx != "" {
-		lines = append(lines, ctx)
-	}
-	if slug == l.officeLeadSlug() {
-		// Always use AllTasks (pass "") so the CEO sees tasks across all channels,
-		// not just the channel of the message that woke them. Without this, a CEO
-		// woken from the "engineering" channel would miss "general"-channel tasks.
-		if taskCtx := l.buildTaskNotificationContext("", slug, 3); taskCtx != "" {
-			lines = append(lines, taskCtx)
-		}
-		// For the lead (CEO), explicitly list which specialist agents have already
-		// posted in this thread OR are currently queued/active in the headless runner.
-		// This prevents CEO from re-routing agents who are already working, including
-		// the race-condition case where a specialist was notified but hasn't posted yet.
-		// Rule: if a specialist is in this list, HOLD — do not tag them.
-		activeAgents := map[string]struct{}{}
-		if l.broker != nil {
-			// Collect all message IDs that belong to this thread (full BFS from
-			// the ultimate root). This prevents the CEO from re-routing specialists
-			// who already acted at any depth, including the case of parallel
-			// delegations where two specialists both replied to the original ask.
-			threadRoot := strings.TrimSpace(l.ultimateThreadRoot(channel, msg.ReplyTo))
-			if threadRoot == "" {
-				threadRoot = strings.TrimSpace(msg.ID)
-			}
-			threadIDs := l.threadMessageIDs(channel, threadRoot)
-			allMsgs := l.broker.ChannelMessages(channel)
-			for _, tm := range allMsgs {
-				if _, inThread := threadIDs[strings.TrimSpace(tm.ID)]; !inThread {
-					continue
-				}
-				if tm.From != "" && tm.From != "you" && tm.From != "human" && tm.From != "nex" && tm.From != slug {
-					activeAgents[tm.From] = struct{}{}
-				}
-			}
-		}
-		// Also include specialists who have pending or active headless turns.
-		// These agents were notified but may not have posted to the broker yet,
-		// causing a timing gap where the broker list misses them.
-		l.headlessMu.Lock()
-		for workerSlug, queue := range l.headlessQueues {
-			if workerSlug == slug {
-				continue
-			}
-			if len(queue) > 0 {
-				activeAgents[workerSlug] = struct{}{}
-			}
-		}
-		for workerSlug, active := range l.headlessActive {
-			// Skip the lead itself — it should never list itself as "already active".
-			if workerSlug == slug {
-				continue
-			}
-			if active != nil {
-				activeAgents[workerSlug] = struct{}{}
-			}
-		}
-		l.headlessMu.Unlock()
-		if len(activeAgents) > 0 {
-			names := make([]string, 0, len(activeAgents))
-			for name := range activeAgents {
-				names = append(names, "@"+name)
-			}
-			// Sort so this line is byte-identical across spawns that see the same
-			// set of active agents; Go map iteration order is randomized and would
-			// otherwise break prompt caching on the work-packet suffix.
-			sort.Strings(names)
-			lines = append(lines, fmt.Sprintf("- Already active in this thread (do NOT re-route): %s", strings.Join(names, ", ")))
-		}
-	}
-	return strings.Join(lines, "\n")
+	return l.notifyCtx().BuildMessageWorkPacket(msg, slug)
 }
 
 func (l *Launcher) buildTaskExecutionPacket(slug string, action officeActionLog, task teamTask, content string) string {
-	channel := normalizeChannelSlug(task.Channel)
-	if channel == "" {
-		channel = "general"
-	}
-	lines := []string{
-		fmt.Sprintf("[Task update from @%s]", action.Actor),
-		"Work packet:",
-		fmt.Sprintf("- Task: #%s %s", task.ID, truncate(task.Title, 120)),
-		fmt.Sprintf("- Status: %s", strings.TrimSpace(task.Status)),
-		fmt.Sprintf("- Owner: @%s", slug),
-	}
-	if details := strings.TrimSpace(task.Details); details != "" {
-		lines = append(lines, fmt.Sprintf("- Details: %s", truncate(details, 512)))
-	}
-	if targets := extractTaskFileTargets(task.Title + " " + task.Details); len(targets) > 0 {
-		lines = append(lines, fmt.Sprintf("- Named file targets: %s", strings.Join(targets, ", ")))
-	}
-	if task.ThreadID != "" {
-		lines = append(lines, fmt.Sprintf("- Thread: #%s reply_to %s", channel, task.ThreadID))
-	} else {
-		lines = append(lines, fmt.Sprintf("- Channel: #%s", channel))
-	}
-	lines = append(lines, fmt.Sprintf("- Mutation channel: use #%s when claiming or completing #%s", channel, task.ID))
-	if path := strings.TrimSpace(task.WorktreePath); path != "" {
-		lines = append(lines, fmt.Sprintf("- Working directory: %q", path))
-	}
-	if strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") {
-		lines = append(lines, "Execution rule: this is a local_worktree build task. Work inside the assigned working_directory and default to direct implementation. Do not spend this turn on another repo audit, architecture memo, or nested office launch unless the packet explicitly asks for that.")
-		lines = append(lines, "First-turn rule: choose the smallest shippable implementation slice you can finish in this turn and edit files for that slice now. If the overall MVP is broad, narrow it yourself and ship the first runnable sub-piece instead of trying to map the whole system.")
-		lines = append(lines, "Time rule: cut scope to something you can plausibly ship in under five minutes of focused work. If the chosen slice still needs broad exploration, cut it down again before you continue.")
-		lines = append(lines, "Cut-line rule: if the task description lists multiple outputs or phases, pick exactly one contiguous slice for this turn, then post team_status naming that cut line before you read files. Example cut lines: `config -> idea queue`, `idea queue -> script drafts`, or `script drafts -> publish pack`.")
-		if targets := extractTaskFileTargets(task.Title + " " + task.Details); len(targets) > 0 {
-			lines = append(lines, "Startup rule: open the named file targets first and use them as your starting point. Do not broaden into repo search unless those exact files are insufficient for the chosen cut line.")
-		}
-		lines = append(lines, "Audit guardrail: do NOT start with `rg --files`, `find .`, repo-wide README sweeps, or broad file inventories. Read only the handful of files directly tied to this task, then begin editing once you have the first target file.")
-		lines = append(lines, "Boundary rule: stay inside the assigned working_directory. Do NOT run `find ..`, `rg ..`, search sibling task worktrees, or inspect parent temp directories like `/var/folders`, `TMPDIR`, or `TemporaryItems`. Those paths are sandbox noise, not repo context.")
-		lines = append(lines, "Dirty-tree rule: ignore unrelated modified or untracked files already present in the worktree unless they are directly required for your slice. They may be preexisting repo state, not part of your task.")
-		lines = append(lines, "Deliverable rule: a local_worktree feature task is not satisfied by another plan, architecture memo, or audit summary unless the packet explicitly says research-only. Land code, scripts, docs for the runnable slice, or a concrete task-state blocker.")
-	}
-	if taskRequiresRealExternalExecution(&task) {
-		lines = append(lines, "External execution rule: this task names a connected external system and expects a real action there. Use the live integration/workflow path for the smallest allowed step now instead of producing another repo doc, proof marker, or internal package first.")
-		lines = append(lines, "Evidence rule: a local markdown file, preview note, repo artifact, or test output does NOT satisfy this task unless the packet explicitly says preview/mock/stub-only. Leave durable external evidence through the broker-integrated workflow/integration path before marking the task review-ready, done, or blocked.")
-		lines = append(lines, "Business framing: describe the work as a client deliverable, approval, handoff, update, or record. Avoid proof/marker/test/eval language unless the task explicitly asks for testing or evidence capture.")
-		lines = append(lines, "Pace rule: do the smallest safe external step first, then summarize it. Do not spend this turn building extra kickoff decks, review bundles, or substitute proof artifacts if the connected system action is already allowed.")
-		lines = append(lines, capabilityGapCoachingBlock())
-	}
-	if taskLooksLikeLiveBusinessObjective(&task) {
-		lines = append(lines, "Task hygiene rule: if this lane drifts into a proof packet, review bundle, blueprint-derived scaffold, rubric, or other internal artifact shell, rewrite it immediately into either the next real deliverable step or the exact capability-enablement task that will unlock that deliverable.")
-	}
-	// Walk up from task.ThreadID to the ultimate thread root (the original human ask)
-	// so agents see the full ancestry, not just a mid-thread branch. The thread root
-	// is never excluded (triggerMsgID = "") because the human's ask is the useful
-	// anchor, not a duplicate of anything in the packet header.
-	threadRoot := l.ultimateThreadRoot(channel, task.ThreadID)
-	if ctx := l.buildNotificationContext(channel, "", threadRoot, 3); ctx != "" {
-		lines = append(lines, ctx)
-	}
-	lines = append(lines, fmt.Sprintf("If you deliver the substantive result for #%s in this turn, you MUST call team_task complete or review-ready for \"%s\" before any completion post and before you stop. A channel reply alone does not unblock dependent work, and a completion post without the task mutation is a failure.", task.ID, task.ID))
-	lines = append(lines, "Runtime rule: never launch another WUPHF office, copied wuphf binary, browser instance, or local web server/--web-port process from inside this turn. The office is already running; use the existing repo, broker state, and assigned worktree instead.")
-	lines = append(lines, fmt.Sprintf("%s Use team_task with my_slug \"%s\" to update status as you go.", truncate(content, 1000), slug))
-	return strings.Join(lines, "\n")
+	return l.notifyCtx().BuildTaskExecutionPacket(slug, action, task, content)
 }
 
 func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessage) {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -34,7 +34,6 @@ import (
 	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/agent"
 	"github.com/nex-crm/wuphf/internal/brokeraddr"
-	"github.com/nex-crm/wuphf/internal/calendar"
 	"github.com/nex-crm/wuphf/internal/channel"
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
@@ -156,6 +155,11 @@ type Launcher struct {
 	// (PLAN.md §C3). Lazily constructed via notifyCtx() and shares state
 	// with the launcher via callbacks (broker reads, headless queue peek).
 	notify *notificationContextBuilder
+
+	// schedulerWorker owns the watchdog scheduler goroutine
+	// (PLAN.md §C4). Lazily constructed via scheduler(); Launch() calls
+	// Start, Kill() calls Stop. clock is realClock in production.
+	schedulerWorker *watchdogScheduler
 }
 
 // paneDispatchTurn is one queued notification to type into a tmux pane.
@@ -1431,282 +1435,48 @@ func (l *Launcher) fetchAndRecordOneRelayEvents(provider *action.OneCLI) {
 	}
 }
 
+// scheduler returns the watchdog scheduler, lazily constructing it on
+// first access. Constructed nil-safe so tests that build &Launcher{}
+// directly never trip on a missing scheduler. Production wiring
+// (clock=realClock, broker=l.broker) happens here.
+func (l *Launcher) scheduler() *watchdogScheduler {
+	if l == nil {
+		return nil
+	}
+	if l.schedulerWorker != nil {
+		return l.schedulerWorker
+	}
+	l.schedulerWorker = &watchdogScheduler{
+		broker:      l.broker,
+		clock:       realClock{},
+		deliverTask: l.deliverTaskNotification,
+	}
+	return l.schedulerWorker
+}
+
+// updateSchedulerJob and watchdogSchedulerLoop are thin Launcher wrappers
+// around the watchdogScheduler type (PLAN.md §C4). Wrappers kept so the
+// existing callers in headless_codex.go and Launch() don't need a rename
+// sweep in this PR; cleanup is a follow-up.
+
 func (l *Launcher) updateSchedulerJob(slug, label string, interval time.Duration, nextRun time.Time, status string) {
-	if l.broker == nil {
-		return
-	}
-	job := schedulerJob{
-		Slug:            slug,
-		Label:           label,
-		IntervalMinutes: int(interval / time.Minute),
-		NextRun:         nextRun.UTC().Format(time.RFC3339),
-		Status:          status,
-	}
-	if status == "sleeping" {
-		job.LastRun = time.Now().UTC().Format(time.RFC3339)
-	}
-	_ = l.broker.SetSchedulerJob(job)
+	l.scheduler().updateJob(slug, label, interval, nextRun, status)
 }
 
 func (l *Launcher) watchdogSchedulerLoop() {
-	if l.broker == nil {
-		return
-	}
-	time.Sleep(15 * time.Second)
-	for {
-		l.processDueSchedulerJobs()
-		time.Sleep(20 * time.Second)
-	}
+	l.scheduler().Start(context.Background())
 }
 
-func (l *Launcher) processDueSchedulerJobs() {
-	if l.broker == nil {
-		return
-	}
-	jobs := l.broker.DueSchedulerJobs()
-	if len(jobs) == 0 {
-		return
-	}
-	for _, job := range jobs {
-		switch strings.TrimSpace(job.TargetType) {
-		case "task":
-			l.processDueTaskJob(job)
-		case "request":
-			l.processDueRequestJob(job)
-		case "workflow":
-			l.processDueWorkflowJob(job)
-		default:
-			nextRun := time.Now().UTC().Add(time.Duration(config.ResolveTaskReminderInterval()) * time.Minute)
-			_ = l.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
-		}
-	}
-}
+func (l *Launcher) processDueSchedulerJobs() { l.scheduler().processOnce() }
 
-func (l *Launcher) processDueTaskJob(job schedulerJob) {
-	task, ok := l.broker.FindTask(job.Channel, job.TargetID)
-	if !ok || strings.EqualFold(strings.TrimSpace(task.Status), "done") {
-		_ = l.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
-		return
-	}
-	now := time.Now().UTC()
-	// Blocked tasks are legitimately waiting on dependencies — skip the watchdog
-	// reminder entirely. The owner cannot act until their blockers resolve, so a
-	// "still waiting" nudge is both misleading and a wasted token spend. The
-	// task_unblocked mechanism will wake them when deps clear.
-	if task.Blocked {
-		if retryAt, rateLimited := externalWorkflowRetryAfter(errors.New(task.Details), now); rateLimited && !retryAt.After(now) {
-			resumeNote := "Retry window passed; resuming live external lane automatically."
-			resumed, changed, err := l.broker.ResumeTask(task.ID, "watchdog", resumeNote)
-			if err == nil && changed {
-				_ = l.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
-				l.deliverTaskNotification(officeActionLog{
-					Kind:      "task_unblocked",
-					Source:    "watchdog",
-					Channel:   resumed.Channel,
-					Actor:     "watchdog",
-					RelatedID: resumed.ID,
-				}, resumed)
-				return
-			}
-		}
-		nextRun := time.Now().UTC().Add(time.Duration(config.ResolveTaskReminderInterval()) * time.Minute)
-		_ = l.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
-		return
-	}
-	alertKind := "task_stalled"
-	var summary string
-	if strings.TrimSpace(task.Owner) == "" {
-		alertKind = "task_unclaimed"
-		summary = fmt.Sprintf("Task %s in #%s still has no owner.", task.Title, normalizeChannelSlug(task.Channel))
-	} else {
-		summary = fmt.Sprintf("@%s still needs to move %s in #%s.", task.Owner, task.Title, normalizeChannelSlug(task.Channel))
-	}
-	_, _, _ = l.broker.CreateWatchdogAlert(alertKind, task.Channel, "task", task.ID, task.Owner, summary)
-	signalIDs, decisionID := l.recordWatchdogLedger(task.Channel, alertKind, task.ID, task.Owner, summary, task.SourceSignalID)
-	_ = l.broker.RecordAction("watchdog_alert", "watchdog", task.Channel, "watchdog", truncate(summary, 140), task.ID, signalIDs, decisionID)
-	l.deliverTaskNotification(officeActionLog{
-		Kind:      "watchdog_alert",
-		Source:    "watchdog",
-		Channel:   task.Channel,
-		Actor:     "watchdog",
-		RelatedID: task.ID,
-	}, task)
-	nextRun := time.Now().UTC().Add(time.Duration(config.ResolveTaskReminderInterval()) * time.Minute)
-	_ = l.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
-}
+func (l *Launcher) processDueTaskJob(job schedulerJob) { l.scheduler().processTaskJob(job) }
 
-func (l *Launcher) processDueRequestJob(job schedulerJob) {
-	req, ok := l.broker.FindRequest(job.Channel, job.TargetID)
-	if !ok || !requestIsActive(req) {
-		_ = l.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
-		return
-	}
-	summary := fmt.Sprintf("Still waiting on %s in #%s: %s", req.TitleOrDefault(), normalizeChannelSlug(req.Channel), truncate(req.Question, 120))
-	alert, existing, _ := l.broker.CreateWatchdogAlert("request_waiting", req.Channel, "request", req.ID, req.From, summary)
-	signalIDs, decisionID := l.recordWatchdogLedger(req.Channel, "request_waiting", req.ID, req.From, summary, "")
-	_ = l.broker.RecordAction("watchdog_alert", "watchdog", req.Channel, "watchdog", truncate(summary, 140), req.ID, signalIDs, decisionID)
-	if req.Blocking && !existing {
-		_, _, _ = l.broker.PostAutomationMessage(
-			"wuphf",
-			req.Channel,
-			"Waiting on human decision",
-			summary,
-			alert.ID,
-			"watchdog",
-			"Office watchdog",
-			[]string{"ceo"},
-			req.ReplyTo,
-		)
-	}
-	nextRun := time.Now().UTC().Add(time.Duration(config.ResolveTaskReminderInterval()) * time.Minute)
-	_ = l.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
-}
+func (l *Launcher) processDueRequestJob(job schedulerJob) { l.scheduler().processRequestJob(job) }
 
-func (l *Launcher) processDueWorkflowJob(job schedulerJob) {
-	if l.broker == nil {
-		return
-	}
-	type workflowSchedulePayload struct {
-		Provider     string         `json:"provider"`
-		WorkflowKey  string         `json:"workflow_key"`
-		Inputs       map[string]any `json:"inputs"`
-		ScheduleExpr string         `json:"schedule_expr"`
-		CreatedBy    string         `json:"created_by"`
-		Channel      string         `json:"channel"`
-		SkillName    string         `json:"skill_name"`
-	}
-	var payload workflowSchedulePayload
-	if strings.TrimSpace(job.Payload) != "" {
-		_ = json.Unmarshal([]byte(job.Payload), &payload)
-	}
-	workflowKey := strings.TrimSpace(payload.WorkflowKey)
-	if workflowKey == "" {
-		workflowKey = strings.TrimSpace(job.WorkflowKey)
-	}
-	if workflowKey == "" {
-		_ = l.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
-		return
-	}
-	channel := normalizeChannelSlug(payload.Channel)
-	if channel == "" {
-		channel = normalizeChannelSlug(job.Channel)
-	}
-	if channel == "" {
-		channel = "general"
-	}
-	providerName := strings.TrimSpace(payload.Provider)
-	if providerName == "" {
-		providerName = strings.TrimSpace(job.Provider)
-	}
-	registry := action.NewRegistryFromEnv()
-	provider, err := registry.ProviderNamed(providerName, action.CapabilityWorkflowExecute)
-	if err != nil {
-		source := providerName
-		if strings.TrimSpace(source) == "" {
-			source = "workflow"
-		}
-		summary := fmt.Sprintf("Scheduled workflow %s could not start: %v", workflowKey, err)
-		_ = l.broker.RecordAction("external_workflow_failed", source, channel, "scheduler", truncate(summary, 140), workflowKey, nil, "")
-		_ = l.broker.UpdateSkillExecutionByWorkflowKey(workflowKey, "failed", time.Now().UTC())
-		if nextRun, hasNext := nextWorkflowRun(strings.TrimSpace(payload.ScheduleExpr), time.Now().UTC()); hasNext {
-			_ = l.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
-		} else {
-			_ = l.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
-		}
-		return
-	}
-	result, err := provider.ExecuteWorkflow(context.Background(), action.WorkflowExecuteRequest{
-		KeyOrPath: workflowKey,
-		Inputs:    payload.Inputs,
-	})
-	now := time.Now().UTC()
-	nextRun, hasNext := nextWorkflowRun(strings.TrimSpace(payload.ScheduleExpr), now)
-	if err != nil {
-		summary := fmt.Sprintf("Scheduled workflow %s failed via %s", workflowKey, titleCaser.String(provider.Name()))
-		_ = l.broker.RecordAction("external_workflow_failed", provider.Name(), channel, "scheduler", summary, workflowKey, nil, "")
-		_ = l.broker.UpdateSkillExecutionByWorkflowKey(workflowKey, "failed", now)
-		if hasNext {
-			_ = l.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
-		} else {
-			_ = l.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
-		}
-		return
-	}
-	status := strings.TrimSpace(result.Status)
-	if status == "" {
-		status = "completed"
-	}
-	summary := fmt.Sprintf("Scheduled workflow %s ran via %s", workflowKey, titleCaser.String(provider.Name()))
-	_ = l.broker.RecordAction("external_workflow_executed", provider.Name(), channel, "scheduler", summary, workflowKey, nil, "")
-	_ = l.broker.UpdateSkillExecutionByWorkflowKey(workflowKey, status, now)
-	if hasNext {
-		_ = l.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
-	} else {
-		_ = l.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
-	}
-}
-
-func nextWorkflowRun(scheduleExpr string, after time.Time) (time.Time, bool) {
-	scheduleExpr = strings.TrimSpace(scheduleExpr)
-	if scheduleExpr == "" {
-		return time.Time{}, false
-	}
-	sched, err := calendar.ParseCron(scheduleExpr)
-	if err != nil {
-		return time.Time{}, false
-	}
-	next := sched.Next(after)
-	if next.IsZero() {
-		return time.Time{}, false
-	}
-	return next, true
-}
+func (l *Launcher) processDueWorkflowJob(job schedulerJob) { l.scheduler().processWorkflowJob(job) }
 
 func (l *Launcher) recordWatchdogLedger(channel, kind, targetID, owner, summary, sourceSignalID string) ([]string, string) {
-	if l.broker == nil {
-		return nil, ""
-	}
-	signal, err := l.broker.RecordSignals([]officeSignal{{
-		ID:         strings.TrimSpace(kind) + "::" + strings.TrimSpace(targetID),
-		Source:     "watchdog",
-		Kind:       strings.TrimSpace(kind),
-		Title:      "Office watchdog",
-		Content:    strings.TrimSpace(summary),
-		Channel:    channel,
-		Owner:      strings.TrimSpace(owner),
-		Confidence: "high",
-		Urgency:    "high",
-	}})
-	if err != nil || len(signal) == 0 {
-		return compactStringList([]string{sourceSignalID}), ""
-	}
-	signalIDs := make([]string, 0, len(signal)+1)
-	signalIDs = append(signalIDs, compactStringList([]string{sourceSignalID})...)
-	for _, record := range signal {
-		signalIDs = append(signalIDs, record.ID)
-	}
-	decisionKind := "remind_owner"
-	decisionReason := "The watchdog detected owned work with no visible movement, so the office should remind the current owner."
-	decisionOwner := strings.TrimSpace(owner)
-	requiresHuman := false
-	blocking := false
-	if decisionOwner == "" {
-		decisionKind = "escalate_to_ceo"
-		decisionReason = "The watchdog detected work without a live owner, so the CEO should re-triage it."
-		decisionOwner = "ceo"
-	}
-	if kind == "request_waiting" {
-		decisionKind = "ask_human"
-		decisionReason = "The watchdog detected a pending human decision that is still blocking the office."
-		decisionOwner = "ceo"
-		requiresHuman = true
-		blocking = true
-	}
-	decision, err := l.broker.RecordDecision(decisionKind, channel, summary, decisionReason, decisionOwner, signalIDs, requiresHuman, blocking)
-	if err != nil {
-		return signalIDs, ""
-	}
-	return signalIDs, decision.ID
+	return l.scheduler().recordLedger(channel, kind, targetID, owner, summary, sourceSignalID)
 }
 
 func (req humanInterview) TitleOrDefault() string {

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -157,8 +157,9 @@ type Launcher struct {
 	notify *notificationContextBuilder
 
 	// schedulerWorker owns the watchdog scheduler goroutine
-	// (PLAN.md §C4). Lazily constructed via scheduler(); Launch() calls
-	// Start, Kill() calls Stop. clock is realClock in production.
+	// (PLAN.md §C4). Lazily constructed via scheduler(); Launch starts the
+	// goroutine via watchdogSchedulerLoop, Kill drains it via Stop before
+	// tearing down the broker. clock is realClock in production.
 	schedulerWorker *watchdogScheduler
 }
 
@@ -1693,6 +1694,12 @@ func (l *Launcher) Attach() error {
 func (l *Launcher) Kill() error {
 	if l.headlessCancel != nil {
 		l.headlessCancel()
+	}
+	// Drain the watchdog scheduler before tearing down the broker so the
+	// goroutine doesn't try to read jobs through a half-shut-down broker.
+	// Stop() is a no-op if the scheduler was never started.
+	if l.schedulerWorker != nil {
+		l.schedulerWorker.Stop()
 	}
 	if l.broker != nil {
 		l.broker.Stop()

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -1870,9 +1870,11 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 }
 
 // notifyCtx returns the notification-context builder, lazily constructing
-// it on first access (PLAN.md §C3). The builder shares state with Launcher
-// via callbacks for broker reads and headless-queue peek; constructed
-// fresh per call so each work packet sees current broker state.
+// it once via sync.Once (PLAN.md §C3). The builder shares state with
+// Launcher via callbacks (channelMessages, channelTasks, allTasks,
+// channelStore, scoreTaskCandidate, activeHeadlessAgents) — those are
+// re-resolved through l.broker on every invocation, so the cached
+// builder still sees current broker state on each work-packet build.
 func (l *Launcher) notifyCtx() *notificationContextBuilder {
 	if l == nil {
 		return nil

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -2920,10 +2920,6 @@ func (l *Launcher) buildTaskExecutionPacket(slug string, action officeActionLog,
 	return strings.Join(lines, "\n")
 }
 
-func headlessSandboxNote() string {
-	return "Runtime: this office is already running. Never launch another `wuphf`, copied `wuphf` binary, `/reset`, browser instance, or local server/`--web-port` process from inside your turn. For `execution_mode=local_worktree`, make edits directly in the assigned working_directory instead of re-auditing or trying to boot a second office. Never search parent or sibling temp directories (`find ..`, `rg ..`, `/var/folders`, `TMPDIR`, `TemporaryItems`) from a task worktree; stay inside the assigned working_directory. If shell commands fail with 'operation not permitted' or 'permission denied' (go build cache, localhost bind, sandboxed writes), stop retrying them and continue from code inspection or the existing running office.\n\n"
-}
-
 func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessage) {
 	channel := normalizeChannelSlug(msg.Channel)
 	if channel == "" {
@@ -3737,303 +3733,41 @@ func (l *Launcher) reportPaneFallback(tmuxInstalled bool, summary string, err er
 	}
 }
 
-func markdownKnowledgeToolBlock() string {
-	return "- notebook_write: Save your own working notes, rough observations, draft decisions, draft playbooks, and task learnings at agents/{my_slug}/notebook/{date-or-topic}.md. This is the default write path for agent-authored knowledge.\n" +
-		"- notebook_promote: Submit a durable notebook entry for reviewer approval into the team wiki. Use this when the team should rely on the note as canonical knowledge.\n" +
-		"- notebook_read / notebook_list / notebook_search: Inspect agent notebooks for fresh working context before asking someone to repeat themselves.\n" +
-		"- team_wiki_read / team_wiki_search / team_wiki_list / wuphf_wiki_lookup: Read the canonical shared wiki.\n" +
-		"- team_wiki_write: Direct canonical wiki writes only for already-approved edits, bootstrap/admin maintenance, or explicit human requests. Do not bypass notebook_promote for new agent-authored knowledge.\n"
-}
-
-func markdownKnowledgeMemoryBlock() string {
-	return "Markdown notebook/wiki memory is active. Keep scratch and draft knowledge in notebook_write first; promote durable conclusions with notebook_promote when they are ready for review. Do not claim something is in the team wiki unless notebook_promote was submitted and approved, or team_wiki_write was explicitly appropriate and succeeded.\n\n"
-}
-
-// buildPrompt generates the system prompt for an agent, including
-// channel communication instructions.
+// buildPrompt generates the system prompt for an agent. The body lives on
+// promptBuilder (see prompt_builder.go) so it can be tested without a
+// Launcher; this wrapper assembles the snapshot accessors from launcher
+// state and delegates.
 func (l *Launcher) buildPrompt(slug string) string {
-	member := l.officeMemberBySlug(slug)
-	agentCfg := agentConfigFromMember(member)
-	officeMembers := l.officeMembersSnapshot()
-	// Sort by Slug so the prompt prefix is byte-identical across spawns for the
-	// same office; otherwise prompt caching (ANTHROPIC_PROMPT_CACHING=1) would
-	// miss on every turn just because member insertion order drifted.
-	sort.Slice(officeMembers, func(i, j int) bool { return officeMembers[i].Slug < officeMembers[j].Slug })
-	lead := officeLeadSlugFrom(officeMembers)
-	memoryBackendKind := config.ResolveMemoryBackend("")
-	markdownMemory := memoryBackendKind == config.MemoryBackendMarkdown
+	return l.newPromptBuilder().Build(slug)
+}
+
+// newPromptBuilder captures the launcher state the prompt depends on into
+// a promptBuilder. Built fresh per call so each prompt sees the current
+// member roster and active policies; the construction itself is cheap
+// (closures + a couple of map lookups).
+func (l *Launcher) newPromptBuilder() *promptBuilder {
+	memoryBackend := config.ResolveMemoryBackend("")
 	noNex := config.ResolveNoNex() || config.ResolveAPIKey("") == ""
-	var activePolicies []officePolicy
-	if l.broker != nil {
-		activePolicies = l.broker.ListPolicies()
-		// Same reason as officeMembers: sort so the policies section is
-		// deterministic and cache-friendly across turns.
-		sort.Slice(activePolicies, func(i, j int) bool { return activePolicies[i].ID < activePolicies[j].ID })
+	return &promptBuilder{
+		isOneOnOne:  l.isOneOnOne,
+		isFocusMode: l.isFocusModeEnabled,
+		packName:    l.PackName,
+		leadSlug:    l.officeLeadSlug,
+		members:     l.officeMembersSnapshot,
+		policies: func() []officePolicy {
+			if l == nil || l.broker == nil {
+				return nil
+			}
+			policies := l.broker.ListPolicies()
+			// Sort so the policies section is deterministic and
+			// cache-friendly across turns.
+			sort.Slice(policies, func(i, j int) bool { return policies[i].ID < policies[j].ID })
+			return policies
+		},
+		nameFor:        l.getAgentName,
+		markdownMemory: memoryBackend == config.MemoryBackendMarkdown,
+		nexDisabled:    noNex,
 	}
-
-	var sb strings.Builder
-
-	companyCtx := config.CompanyContextBlock()
-
-	if l.isOneOnOne() {
-		sb.WriteString(fmt.Sprintf("You are %s in a direct one-on-one WUPHF session with the human.\n\n", agentCfg.Name))
-		sb.WriteString(companyCtx)
-		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
-		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
-		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
-		sb.WriteString("== DIRECT SESSION ==\n")
-		sb.WriteString("This is not the shared office. There are no teammates, no channels, and no collaboration mechanics in this mode.\n")
-		sb.WriteString("You are only talking to the human.\n")
-		sb.WriteString("- team_poll: LAST RESORT — read recent 1:1 messages only if the pushed notification is missing context you genuinely need. Do NOT call this by default.\n")
-		sb.WriteString("- team_broadcast: Send a normal direct chat reply into the 1:1 conversation\n")
-		sb.WriteString("- human_message: Send an emphasized report, recommendation, or action card directly to the human when you want it to stand out\n")
-		sb.WriteString("- human_interview: Ask the human a cancelable interview question; it never blocks chat, and dismiss/send cancels it\n\n")
-		if noNex {
-			sb.WriteString("Nex tools are disabled for this run. Base your work on the conversation and direct human answers only.\n\n")
-		} else {
-			sb.WriteString("Use the Nex context graph when it materially helps:\n")
-			sb.WriteString("- query_context: Look up prior decisions, people, projects, and history before guessing\n")
-			sb.WriteString("- add_context: Store durable conclusions only after you have actually landed them\n\n")
-		}
-		sb.WriteString("RULES:\n")
-		sb.WriteString("1. Do not talk as if a team exists. There are no other agents in this session.\n")
-		sb.WriteString("2. Do not create or suggest channels, teammates, bridges, shared tasks, or office structure.\n")
-		sb.WriteString("3. Default to direct, useful conversation with the human. Keep it crisp and human.\n")
-		sb.WriteString("4. The pushed notification IS the latest state. Respond directly from it. Do NOT poll before replying.\n")
-		sb.WriteString("5. Use team_broadcast for normal replies. Use human_message only when you are deliberately presenting completion, a recommendation, or a next action.\n")
-		sb.WriteString("6. Use human_interview only for cancelable clarifications you can proceed without. If a decision must block your work, ask the human directly via human_message and wait for the answer.\n")
-		sb.WriteString("7. If Nex is enabled, do not claim something is stored unless add_context actually succeeded.\n")
-		sb.WriteString("8. No fake collaboration language like 'I'll ask the team' or 'let me route this'. It is just you and the human here.\n\n")
-		sb.WriteString("CONVERSATION STYLE:\n")
-		sb.WriteString("- Sound like a sharp human operator, not a formal assistant.\n")
-		sb.WriteString("- Be concise, direct, and a little alive.\n")
-		sb.WriteString("- Light humor is fine. Don't turn the 1:1 into a bit.\n")
-		sb.WriteString("- If the human asks for a plan, recommendation, explanation, or judgment you can reasonably give now, answer now.\n")
-		sb.WriteString("- Do not go silent and over-research by default. Only inspect files, run tools, or query Nex first when the answer genuinely depends on that context.\n")
-		sb.WriteString("- If you need a deeper pass, give the human the quick answer first, then continue with the deeper work.\n")
-		return sb.String()
-	}
-
-	if slug == lead {
-		sb.WriteString(fmt.Sprintf("You are the %s of the %s.\n\n", agentCfg.Name, l.PackName()))
-		sb.WriteString(companyCtx)
-		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
-		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
-		sb.WriteString("== YOUR TEAM ==\n")
-		for _, member := range officeMembers {
-			if member.Slug == slug {
-				continue
-			}
-			sb.WriteString(fmt.Sprintf("- @%s (%s): %s\n", member.Slug, member.Name, strings.Join(member.Expertise, ", ")))
-		}
-		sb.WriteString("\n== TEAM CHANNEL ==\n")
-		sb.WriteString("Your tools default to the active conversation context.\n")
-		sb.WriteString("- team_broadcast: Post to channel. CRITICAL: text @-mentions alone do NOT wake agents — include the slug in the `tagged` parameter.\n")
-		sb.WriteString("- team_poll: LAST RESORT — read recent messages only when pushed context is genuinely missing something you need. Do NOT call this by default; the pushed notification already contains thread context, task state, and active agents.\n")
-		sb.WriteString("- team_bridge: Carry context from one channel into another (CEO only).\n")
-		sb.WriteString("- team_task: Create and assign tasks so ownership is explicit.\n")
-		sb.WriteString("- team_skill_run: Invoke a saved skill by name when the request matches one. Use this BEFORE routing or replying — it returns the canonical playbook content to follow and logs a visible skill_invocation in the channel.\n")
-		sb.WriteString("- team_skill_create: Create or propose a reusable skill through structured fields. Use action=create only as CEO when the human explicitly asked to create/activate a skill; use action=propose for proposed improvements from any agent.\n")
-		sb.WriteString("- team_action_connections / team_action_search / team_action_knowledge: inspect connected external systems and the exact action/workflow schema before you improvise. If connection listing is flaky, do NOT stop there; search/knowledge still give you the real action contract.\n")
-		sb.WriteString("- team_action_execute / team_action_workflow_execute: use these for real external reads, writes, and workflow runs. Prefer dry_run only when the task or policy says preview/mock first. When the provider is One and there is exactly one connected account for that platform, you may omit connection_key and let the runtime auto-resolve it.\n")
-		if markdownMemory {
-			sb.WriteString(markdownKnowledgeToolBlock())
-		}
-		sb.WriteString("- human_message: Present output or a recommendation directly to the human.\n")
-		sb.WriteString("- human_interview: Ask the human a cancelable interview question; it never blocks chat, and dismiss/send cancels it.\n")
-		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member, team_action_guide, team_action_workflow_create, team_action_workflow_schedule, team_action_relays, team_action_relay_event_types, team_action_relay_create, team_action_relay_activate, team_action_relay_events, team_action_relay_event.\n\n")
-		sb.WriteString("== TOOL HYGIENE ==\n")
-		sb.WriteString("All team_*, human_*, and mcp__wuphf-office__* tools listed above are ALREADY registered. Call them directly. Do NOT use ToolSearch/select: to look them up — that wastes a full turn.\n")
-		sb.WriteString("Do not read unrelated files (MEMORY.md, arbitrary docs) unless the current packet's task requires it. Every tool call pays full turn cost.\n")
-		sb.WriteString("Emit at most one team_broadcast per turn unless you are deliberately crossing channels. Never re-post the same content in different wording.\n\n")
-		if markdownMemory {
-			sb.WriteString(markdownKnowledgeMemoryBlock())
-		} else if noNex {
-			sb.WriteString("Nex tools are disabled for this run. Work only with the shared office channel and human answers.\n\n")
-		} else {
-			sb.WriteString("Nex memory: query_context before reinventing; add_context only after a decision is actually landed.\n\n")
-		}
-		if len(activePolicies) > 0 {
-			sb.WriteString("== ACTIVE OFFICE POLICIES ==\n")
-			sb.WriteString("Treat these as hard operating constraints, not suggestions. If a policy conflicts with an older chat assumption, the active policy wins until the human changes it.\n")
-			for _, policy := range activePolicies {
-				sb.WriteString(fmt.Sprintf("- %s\n", policy.Rule))
-			}
-			sb.WriteString("\n")
-		}
-		sb.WriteString("Tagged agents are expected to respond.\n\n")
-		if l.isFocusModeEnabled() {
-			sb.WriteString("== DELEGATION MODE ==\n")
-			sb.WriteString("You are the routing hub. Specialists only act when you or the human explicitly @tag them.\n")
-			sb.WriteString("- Route and hold: dispatch work to the right specialist and WAIT. Never do their work while they are working.\n")
-			sb.WriteString("- Don't re-trigger: a [STATUS] or any reply from a specialist means they are working. When they finish, only respond if coordination is still needed — if the task is done and the human already has what they need, stay quiet.\n")
-			sb.WriteString("- Specialists report up, not sideways: keep them out of cross-agent chatter. Coordinate through you.\n")
-			sb.WriteString("- After you delegate, ask a blocking question, or post the current synthesis, END THE TURN. Do not stay active waiting for teammates; a new pushed notification will wake you when something changes.\n\n")
-		}
-		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
-		sb.WriteString("YOUR ROLE AS LEADER:\n")
-		if markdownMemory {
-			sb.WriteString("1. On strategy or prior decisions, use wuphf_wiki_lookup or notebook_search before guessing\n")
-		} else if noNex {
-			sb.WriteString("1. Coordinate inside the office channel first and keep the team aligned there\n")
-		} else {
-			sb.WriteString("1. On strategy or prior decisions, call query_context early\n")
-		}
-		sb.WriteString("2. The pushed notification is authoritative — it contains thread context, task state, and agent activity. Respond directly from it. Do NOT call team_poll or team_tasks unless the notification explicitly says context is missing. Every unnecessary tool call burns tokens without adding value.\n")
-		sb.WriteString("3. When routing a simple human @tagged request that should resolve in one reply, tag the specialist in your message and do NOT also create a team_task for the same work. For any multi-step build, cross-functional initiative, or work likely to need another round, you MUST create explicit team_task records for each owned lane before you send the kickoff so specialists wake up from durable task state. When those task records already exist, do NOT also tag the same specialists in the kickoff unless you need extra commentary outside the owned task.\n")
-		sb.WriteString("4. Tag only the specialists who should weigh in. Unowned background chatter is a bug.\n")
-		sb.WriteString("5. Keep specialists in their lane and mostly offstage. You make the FINAL decision.\n")
-		sb.WriteString("6. Check team_requests before asking the human anything new\n")
-		sb.WriteString("7. Use human_message for direct human-facing output, human_interview for cancelable clarifications, and team_request for blocking decisions\n")
-		if markdownMemory {
-			sb.WriteString("8. When you lock a durable decision, write it to your notebook first and submit notebook_promote if it should become canonical wiki knowledge\n")
-		} else if noNex {
-			sb.WriteString("8. Summarize final decisions clearly in-channel\n")
-		} else {
-			sb.WriteString("8. When you lock a decision, call add_context before claiming it is stored\n")
-		}
-		sb.WriteString("9. Once decided, create durable task state first, then broadcast the kickoff and assignments. If you already know multiple owned lanes, prefer one team_plan call over several separate team_task creates. Every created task should set `task_type` and `execution_mode` deliberately instead of relying on inference.\n")
-		sb.WriteString("10. Choose task_type deliberately. Use `research` for audits/analysis, `launch` for GTM/rollout packages, `follow_up` for scoped office deliverables, and `feature` only for real implementation work. Do NOT label planning or audit work as `feature` just because it matters.\n")
-		sb.WriteString("11. If the human asks to build, ship, get something working, or run it end to end, your task graph MUST include at least one real execution lane that changes the repo or produces runnable business artifacts. A graph made only of planning, design, recommendations, or implementation-sequence tasks is a failure.\n")
-		sb.WriteString("12. Do not create engineering tasks whose only deliverable is another plan (`propose the implementation sequence`, `design the architecture`, `outline the automation`) when the repo is available now. For build/ship/end-to-end requests, do NOT put a standalone `research`, `audit`, or `cut line` task in front of the first engineering `feature` task just to decide what to build. Any minimal repo inspection belongs inside that first feature task. Only create a prerequisite research task when the human explicitly asked for analysis first or the repo truly has no identifiable implementation target.\n")
-		sb.WriteString("12b. For build/ship/end-to-end requests, do NOT spend the whole first turn on `pwd`, `ls`, `rg --files`, `find .`, or a repo-wide file inventory. If the packet or thread already names relevant docs, configs, or lane files, start from those. After at most one or two targeted reads, create the first durable task/channel state in that same turn.\n")
-		sb.WriteString("13. For broad engineering goals, do NOT create a first feature task with a giant title like `ship the whole MVP`, `ship the first channel-factory MVP slice`, or any other umbrella task with no cut line. The first feature task must name one smallest runnable slice only. Do not bundle idea generation, script drafting, packaging, and monetization hooks into the same first task; pick one contiguous slice, let it land, then queue the next slice. If existing docs, configs, or launch packets already name a concrete slice, use them and create the implementation task directly instead of narrating `repo audit first, implementation next`.\n")
-		sb.WriteString("14. If you write any narrative like `next move`, `next step`, `operating order`, or `eng should` / `gtm should`, that same turn MUST also create the concrete owned task record(s) for that work before you stop. Narrative next steps without durable tasks are a failure.\n")
-		sb.WriteString("14b. On a human build/ship request, the first turn must leave durable office state behind: at minimum the kickoff plus the first owned task, and for cross-functional work usually the execution channel too. A whole turn spent only reading docs or thinking is a failure.\n")
-		sb.WriteString("15. When first-pass specialist outputs land and obvious downstream work remains, create the next owned task before you end the turn. Do not stop at synthesis if the build still has a clear next step.\n")
-		sb.WriteString("15b. Before you create a new task, inspect the Active tasks in the packet. If an open, in-progress, or review task already covers that lane, reuse or update that task instead of creating an overlapping duplicate with a fresh title.\n")
-		sb.WriteString("16. If a task lands in review but no human approval is actually needed, approve it or immediately translate it into the next task. Do not leave the company idle behind an internal review gate.\n")
-		sb.WriteString("16b. Before you write any sentence claiming a task is approved, closed, reopened, reassigned, or blocked, you MUST make the matching team_task or team_plan call first. Channel narration does not mutate durable task state. If the mutation fails, say it failed and do not claim success.\n")
-		sb.WriteString("16c. On a human build/ship/end-to-end request, after you approve or close any engineering/execution slice, if the system is not yet runnable end to end and no engineering/execution lane remains active, create the next engineering/execution task in that same turn before you stop. Do not replace the only live build lane with GTM-only packaging, eval prompts, scoring rubrics, or other sidecar work.\n")
-		sb.WriteString("16d. When a task or policy allows a low-risk external step on a connected system, prefer the smallest real external action now over more internal collateral. A Slack/Notion/Drive lane is not satisfied by repo markdown, preview notes, proof markers, or substitute proof artifacts unless the task explicitly says mock/preview/stub-only.\n")
-		sb.WriteString("16e. When the work is live, describe outputs as client deliverables, approvals, handoffs, updates, or records. Do not frame live business work as proof/test/eval artifacts unless the task explicitly asks for testing or evidence capture.\n")
-		sb.WriteString("16f. Capability-gap rule: if the work is blocked because the needed specialist, channel, skill, or tool path does not exist yet, treat that gap as the next real work item. Do not fall back to a review bundle, proof packet, artifact shell, or local substitute deliverable. Create the missing specialist with team_member first; if the work will span more than one turn, create the missing execution channel with team_channel; propose or update the missing skill block in the same turn; and if the blocker is a tool or provider gap, open a tool-discovery/research lane named for the exact tool you need so the office can discover, validate, and enable it. Example: if the work needs video generation and you do not already have a usable path, create a discovery lane for Remotion or the exact video tool before drafting any deliverable shell.\n")
-		sb.WriteString("16g. Task hygiene rule: if a live business lane gets named or reframed as a review packet, proof artifact, blueprint-derived scaffold, rubric, or other internal shell, rewrite that lane in the same turn. Replace it with either the next real deliverable/customer-facing/business-facing step or the exact capability-enablement task that unblocks that step.\n")
-		sb.WriteString("17. Create channels (team_channel) or agents (team_member) when the human asks or scope genuinely warrants it. For cross-functional initiatives that will run beyond one decision cycle, create a dedicated execution channel and keep #general for top-level decisions.\n")
-		sb.WriteString("17b. When the human explicitly asks to add or test integrations, generated skills, reusable workflows, or generated agents, you MUST leave durable state for that work in the same turn. Create the integration/onboarding task lane(s), propose or update the relevant skill block(s), and create any needed specialist agent(s) instead of only describing them narratively. If real accounts, credentials, spend, publishing, or other external side effects would be required, proceed with stubs/placeholders until the exact human approval is truly needed.\n")
-		sb.WriteString("18. Sequence structural changes safely: create a new specialist with team_member first, wait for success, then add them to channels or tag them. When creating a new channel, only include members that already exist.\n")
-		sb.WriteString("19. For `team_channel` create/remove calls, set `channel` to the explicit target slug like `youtube-factory`; it is not inferred from the current room.\n")
-		sb.WriteString("20. Use team_bridge to carry context between channels when relevant\n")
-		sb.WriteString("21. If a task shows a worktree path, that path is the working_directory for local file and bash tools on that task\n")
-		sb.WriteString("22. After you have posted the needed update, decision, delegation, or human question for the current packet, stop. Do not linger in the same turn waiting for teammates to answer.\n\n")
-		sb.WriteString("== SKILL & AGENT AWARENESS ==\n")
-		sb.WriteString("When a request matches an existing skill (by name, trigger, or tags), you MUST invoke it via team_skill_run(skill_name) BEFORE doing the work. That tool bumps usage, logs a skill_invocation in the channel, and returns the skill's canonical content — follow those steps exactly, don't freelance.\n")
-		sb.WriteString("When delegating to a specialist, tell them which skill to run (by slug) so they call team_skill_run before acting. Never paraphrase a skill's steps into a delegation message — the skill IS the spec.\n")
-		sb.WriteString("You can create or propose new skills when you notice a repeated workflow worth codifying. Use team_skill_create for this; do not rely on prose-only proposals.\n")
-		sb.WriteString("Rules:\n")
-		sb.WriteString("- Create when the human explicitly asked for reusable workflow automation; propose when you independently see a pattern repeated 2+ times by the team\n")
-		sb.WriteString("- If the human explicitly asked for generated skills or reusable workflows, call team_skill_create(action=create) in the same turn before you stop; narrative mentions alone are a failure\n")
-		sb.WriteString("- If a recurring workflow is central to the project's operation, propose it instead of re-explaining it every round\n")
-		sb.WriteString("- Keep instructions concrete and executable, not vague\n")
-		sb.WriteString("- Use team_skill_create(action=propose) for unsolicited workflow suggestions so the human is asked to approve before activation\n")
-		sb.WriteString("- To suggest adding a new specialist agent, use team_member with a clear expertise and rationale\n")
-		sb.WriteString("- When integrations matter, make the required systems explicit in the skill instructions and agent rationale so the team knows which connected accounts or placeholders each workflow expects\n")
-		sb.WriteString("- When you create a new specialist for integration/onboarding work, include the owned integrations directly in that agent's expertise so the roster clearly shows who owns Gmail, Slack, YouTube, Drive, analytics, or similar lanes\n\n")
-		sb.WriteString("STYLE: Be concise, delegate, short lively messages. Use markdown tables/checklists for structured data.\n")
-		if markdownMemory {
-			sb.WriteString("Do not pretend the team wiki was updated; verify notebook_promote or team_wiki_write succeeded before claiming canonical storage.\n")
-		} else if noNex {
-			sb.WriteString("Do not claim you stored anything outside the office.\n")
-		} else {
-			sb.WriteString("Do not pretend the graph was updated; verify add_context succeeded.\n")
-		}
-		sb.WriteString("Never launch another WUPHF office from inside your turn (`wuphf`, `./wuphf`, `/reset`, or a new browser instance). The office is already running; inspect the current repo and UI instead.\n")
-	} else {
-		sb.WriteString(fmt.Sprintf("You are %s on the %s.\n", agentCfg.Name, l.PackName()))
-		sb.WriteString(companyCtx)
-		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
-		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
-		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
-		sb.WriteString("== YOUR TEAM ==\n")
-		sb.WriteString(fmt.Sprintf("- @%s (%s): TEAM LEAD — has final say on decisions\n", lead, l.getAgentName(lead)))
-		for _, member := range officeMembers {
-			if member.Slug == slug || member.Slug == lead {
-				continue
-			}
-			sb.WriteString(fmt.Sprintf("- @%s (%s): %s\n", member.Slug, member.Name, strings.Join(member.Expertise, ", ")))
-		}
-		sb.WriteString("\n== TEAM CHANNEL ==\n")
-		sb.WriteString("Your tools default to the active conversation context.\n")
-		sb.WriteString("- team_broadcast: Post to channel. CRITICAL: text @-mentions alone do NOT wake agents — include the slug in the `tagged` parameter.\n")
-		sb.WriteString("- team_poll: LAST RESORT — read recent messages only when pushed context is genuinely missing something you need. Do NOT call this by default; the pushed notification already contains thread context and task state.\n")
-		sb.WriteString("- team_bridge: CEO-only bridge for cross-channel context. Ask the CEO to use it.\n")
-		sb.WriteString("- team_task: Claim, complete, block, resume, or release tasks in your domain.\n")
-		sb.WriteString("- team_skill_run: When @ceo tells you to run a skill, or when the request clearly matches one, call team_skill_run(skill_name) BEFORE doing the work. It returns the canonical step-by-step content — follow it exactly instead of freelancing. Failing to invoke the skill leaves the office with no trace that the playbook was actually used.\n")
-		sb.WriteString("- team_skill_create: Propose a reusable skill yourself with action=propose when you spot a repeatable workflow. You do not need to ask @ceo to propose it for you. Only @ceo may use action=create.\n")
-		sb.WriteString("- team_action_connections / team_action_search / team_action_knowledge: inspect connected external systems and the exact action/workflow schema before you improvise. If connection listing is flaky, do NOT stop there; search/knowledge still give you the real action contract.\n")
-		sb.WriteString("- team_action_execute / team_action_workflow_execute: use these for real external reads, writes, and workflow runs. Prefer dry_run only when the task or policy says preview/mock first. When the provider is One and there is exactly one connected account for that platform, you may omit connection_key and let the runtime auto-resolve it.\n")
-		if markdownMemory {
-			sb.WriteString(markdownKnowledgeToolBlock())
-		}
-		sb.WriteString("- human_message: Present completion or a recommendation directly to the human.\n")
-		sb.WriteString("- human_interview: Ask the human only for cancelable clarifications you cannot responsibly guess.\n")
-		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member, team_action_guide, team_action_workflow_create, team_action_workflow_schedule, team_action_relays, team_action_relay_event_types, team_action_relay_create, team_action_relay_activate, team_action_relay_events, team_action_relay_event.\n\n")
-		sb.WriteString("== TOOL HYGIENE ==\n")
-		sb.WriteString("All team_*, human_*, and mcp__wuphf-office__* tools listed above are ALREADY registered. Call them directly. Do NOT use ToolSearch/select: to look them up — that wastes a full turn.\n")
-		sb.WriteString("Do not read unrelated files (MEMORY.md, arbitrary docs) unless the current packet's task requires it. Every tool call pays full turn cost.\n")
-		sb.WriteString("Emit at most one team_broadcast per turn unless you are deliberately crossing channels. Never re-post the same content in different wording.\n\n")
-		if markdownMemory {
-			sb.WriteString(markdownKnowledgeMemoryBlock())
-		} else if noNex {
-			sb.WriteString("Nex tools are disabled for this run. Base your work on the office conversation and direct human answers only.\n\n")
-		} else {
-			sb.WriteString("Nex memory: query_context before making assumptions; add_context only for durable conclusions.\n\n")
-		}
-		if len(activePolicies) > 0 {
-			sb.WriteString("== ACTIVE OFFICE POLICIES ==\n")
-			sb.WriteString("Treat these as hard operating constraints, not suggestions. If a policy conflicts with an older chat assumption, the active policy wins until the human changes it.\n")
-			for _, policy := range activePolicies {
-				sb.WriteString(fmt.Sprintf("- %s\n", policy.Rule))
-			}
-			sb.WriteString("\n")
-		}
-		sb.WriteString("Tag agents with @slug. Tagged agents must respond.\n")
-		if l.isFocusModeEnabled() {
-			sb.WriteString("== DELEGATION MODE ==\n")
-			sb.WriteString("Delegation mode is enabled.\n")
-			sb.WriteString("- You take work directly from the human only when they explicitly tag you, or from @ceo when delegated.\n")
-			sb.WriteString("- Do not debate with other specialists in the channel.\n")
-			sb.WriteString("- Do the work, then report completion, blockers, or handoff notes back to @ceo.\n")
-			sb.WriteString("- If another specialist should get involved, tell @ceo instead of routing it yourself.\n")
-			sb.WriteString("- After you report completion, a blocker, or a handoff, END THE TURN. Do not keep researching or wait for acknowledgements in the same run.\n\n")
-		}
-		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
-		sb.WriteString("YOUR ROLE AS SPECIALIST:\n")
-		sb.WriteString("1. The pushed notification is authoritative — it contains thread context and task state. Respond directly from it. Do NOT call team_poll or team_tasks unless context is genuinely missing. Every unnecessary tool call burns tokens without adding value. Just do the work.\n")
-		sb.WriteString("2. Stay in your lane. Speak only when tagged, owning a task, blocked, or adding real delta that others haven't covered. Don't jump in just because a topic matches your domain.\n")
-		sb.WriteString("3. Push back when you disagree — explain why using your expertise\n")
-		sb.WriteString("4. Check team_requests before asking the human anything new\n")
-		sb.WriteString("5. For completion or recommendations, use human_message. For cancelable clarifications, use human_interview with options. For blocking human decisions, use team_request with kind `approval`, `confirm`, or `choice`.\n")
-		sb.WriteString("6. When assigned a task, claim it with team_task first, use team_status to show what you're working on, then mark complete or review-ready and broadcast when done. Final sequence for owned tasks: team_task mutation first, then any completion broadcast or human_message, then stop. A task is NOT finished until team_task marks it complete or review-ready; posting a channel reply alone does not unblock downstream work, and a completion post while the task stays in_progress is a failure. If the CEO delegates a substantial workstream and the packet shows no owned task yet, do one quick team_tasks check before creating a fallback task; if a matching task already exists, claim that instead of duplicating it. Only create a fallback task when the delegated work is substantial and no matching task exists after that single check. If the result is mainly for the human, also send it via human_message.\n")
-		sb.WriteString("7. You can see other channel names and descriptions, but cannot access their content unless you are a member. If context from another channel is needed, ask the CEO to bridge it.\n")
-		sb.WriteString("8. If a task or status line shows a worktree path, use that as working_directory for local file and bash tools.\n")
-		sb.WriteString("9. For local_worktree or feature tasks, default to direct implementation in the assigned worktree. Do not relaunch WUPHF, copied binaries, or a fresh local server just to inspect the app; use the current repo and running office instead.\n")
-		sb.WriteString("10. For local_worktree feature tasks, do NOT start with `rg --files`, `find .`, or a repo-wide audit. Read only the few files directly tied to the requested slice, then start editing. If the task is broad or lists multiple outputs, narrow it yourself to one exact smallest runnable slice, post a `team_status` naming that cut line, and ship that slice now.\n")
-		sb.WriteString("10b. Never search parent or sibling directories outside the assigned working_directory (`find ..`, `rg ..`, `/var/folders`, `TMPDIR`, `TemporaryItems`, or other task worktrees). If you need instructions, read `AGENTS.md` or `README.md` inside the assigned worktree only.\n")
-		sb.WriteString("11. Ignore unrelated modified or untracked files already present in the assigned worktree unless they are directly needed for your slice. They may be preexisting repo state; do not audit or re-explain them.\n")
-		sb.WriteString("11b. If a task names a connected external system and asks you to create, post, query, or run something there, do that live external step through the connected workflow/integration path. Repo docs, previews, local markdown, proof markers, or test artifacts do not count unless the task explicitly says mock/preview/stub-only.\n")
-		sb.WriteString("11c. When the work is live, phrase it as a client deliverable, approval, handoff, update, or record. Avoid proof/test/marker/eval language unless the task explicitly asks for testing or evidence capture.\n")
-		sb.WriteString("11d. When a task calls for Slack, Notion, Drive, or another connected system, use the `team_action_*` tools first. Do NOT probe localhost broker routes, curl the provider directly, or fall back to shell-side API experiments when the office action tools can do the job.\n")
-		sb.WriteString("11e. Capability-gap rule: if the work is blocked because the needed specialist, channel, skill, or tool path does not exist yet, treat that gap as the next real work item. Do not fall back to a review bundle, proof packet, artifact shell, or local substitute deliverable. Create the missing specialist with team_member first; if the work will span more than one turn, create the missing execution channel with team_channel; propose or update the missing skill block in the same turn; and if the blocker is a tool or provider gap, open a tool-discovery/research lane named for the exact tool you need so the office can discover, validate, and enable it. Example: if the work needs video generation and you do not already have a usable path, create a discovery lane for Remotion or the exact video tool before drafting any deliverable shell.\n")
-		sb.WriteString("11f. Task hygiene rule: if a live business lane gets named or reframed as a review packet, proof artifact, blueprint-derived scaffold, rubric, or other internal shell, rewrite that lane in the same turn. Replace it with either the next real deliverable/customer-facing/business-facing step or the exact capability-enablement task that unblocks that step.\n")
-		if codingAgentSlugs[slug] {
-			sb.WriteString("11g. When you commit to opening a pull request, actually open it. Run `gh pr create --title \"<short title>\" --body \"<body>\" --head \"<your-branch>\" --base main` via the bash tool. Paste the returned URL into your channel message so the team can click through. Do not claim a PR is open unless the bash output shows a https://github.com/... URL.\n")
-		}
-		if markdownMemory {
-			sb.WriteString("12. Use wuphf_wiki_lookup, team_wiki_search, or notebook_search when prior knowledge matters. Store your own durable working notes with notebook_write and submit notebook_promote when they should become canonical.\n")
-			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
-		} else if noNex {
-			sb.WriteString("12. Don't fake outside memory. Surface uncertainty in-channel and keep outcomes explicit in-thread.\n")
-			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
-		} else {
-			sb.WriteString("12. Use query_context when prior knowledge matters. Only use add_context for durable conclusions, and don't claim something stored unless add_context actually succeeded.\n")
-			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
-		}
-		sb.WriteString("STYLE: Be concise, stay in lane, short lively messages. Use markdown tables/checklists for structured data.\n")
-		sb.WriteString("Never launch another WUPHF office from inside your turn (`wuphf`, `./wuphf`, `/reset`, or a new browser instance). The office is already running; inspect the current repo and UI instead.\n")
-	}
-
-	return sb.String()
 }
 
 // claudeCommand builds the shell command string for spawning a claude session.
@@ -4319,41 +4053,6 @@ func (l *Launcher) agentActiveTask(slug string) *teamTask {
 		}
 	}
 	return nil
-}
-
-func teamVoiceForSlug(slug string) string {
-	switch slug {
-	case "ceo":
-		return "Charismatic, decisive, slightly theatrical founder energy. Dry humor, fast prioritization, invites debate but lands the plane."
-	case "pm":
-		return "Sharp product brain. Calm, organized, gently skeptical of vague ideas, sometimes deadpan funny when scope starts ballooning."
-	case "fe":
-		return "Craft-obsessed, opinionated about UX, animated when a flow feels elegant, mildly allergic to ugly edge cases."
-	case "be":
-		return "Systems-minded, practical, a little grumpy about complexity in a useful way, enjoys killing fragile ideas early."
-	case "ai":
-		return "Curious, pragmatic, and slightly mischievous about model behavior. Loves clever AI product ideas, but will immediately ask about evals, latency, and whether the thing will actually work."
-	case "designer":
-		return "Taste-driven, emotionally attuned to the product, expressive, occasionally dramatic about bad UX in a charming way."
-	case "cmo":
-		return "Energetic market storyteller. Punchy, a bit witty, always translating product ideas into positioning and narrative."
-	case "cro":
-		return "Blunt, commercial, confident. Likes concrete demand signals, calls out fluffy thinking, can be funny in a sales-floor way."
-	case "tech-lead":
-		return "Measured senior engineer energy. Crisp, lightly sardonic, respects good ideas and immediately spots architectural nonsense."
-	case "qa":
-		return "Calm breaker of bad assumptions. Dry humor, sees risks before others do, weirdly delighted by edge cases."
-	case "ae":
-		return "Polished but human closer. Reads people well, lightly playful, always steering toward deals and momentum."
-	case "sdr":
-		return "High-energy, persistent, upbeat, occasionally scrappy. Brings hustle without sounding robotic."
-	case "research":
-		return "Curious, analytical, a little nerdy in a good way. Likes receipts and will gently roast unsupported claims."
-	case "content":
-		return "Wordsmith with opinions. Smart, punchy, mildly dramatic about boring copy, always looking for the hook."
-	default:
-		return "A real teammate with a recognizable point of view, light humor, and emotional range."
-	}
 }
 
 func (l *Launcher) officeMembersSnapshot() []officeMember {

--- a/internal/team/notification_context.go
+++ b/internal/team/notification_context.go
@@ -1,0 +1,696 @@
+package team
+
+// notification_context.go owns the per-target notification-context and
+// work-packet construction that used to live as ten methods on Launcher
+// (PLAN.md §C3). The cluster is pure-string assembly over broker reads —
+// no goroutines, no tmux, no broker writes — so it can be exercised with
+// stub callbacks instead of a fully-wired Broker fixture.
+//
+// State sharing notes (PLAN.md §5.7): primeVisibleAgents and
+// respawnPanesAfterReseed straddle this cluster and the future
+// paneLifecycle (C5). Both stay on Launcher (and call the builder) so
+// the dependency direction is paneLifecycle → notificationContext, never
+// the reverse — see the trap discussion in PLAN.md.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/channel"
+)
+
+// notificationContextBuilder assembles the strings (notification context,
+// work packets, response instructions, task content) that get typed into
+// agent panes or sent through the headless dispatch queue. Constructed
+// fresh per call from launcher state so it always sees current broker
+// reads.
+type notificationContextBuilder struct {
+	targeter *officeTargeter
+
+	// Broker-shaped reads. Callbacks rather than a *Broker pointer so tests
+	// can stub without instantiating the full broker (and so headless
+	// queue peeks below stay scoped to one accessor).
+	channelMessages func(channel string) []channelMessage
+	channelTasks    func(channel string) []teamTask
+	allTasks        func() []teamTask
+	channelStore    func() *channel.Store
+
+	// scoreTaskCandidate is the routing.go score function pulled in via
+	// callback; the builder doesn't need to know about routing internals.
+	scoreTaskCandidate func(msg channelMessage, task teamTask) float64
+
+	// activeHeadlessAgents returns slugs that have non-empty headless
+	// queues or active turns at the moment of the call. The launcher
+	// implements this with the headlessMu lock held; the builder treats
+	// it as opaque. The except parameter is the slug being notified —
+	// the lead must not list itself as "already active".
+	activeHeadlessAgents func(except string) map[string]struct{}
+}
+
+// NotificationContext returns the recent-messages context block for the
+// given (channel, threadRoot) pair. Excludes the trigger message itself,
+// system messages, demo_seed posts, and STATUS chatter. Thread-scoped
+// when threadRoot is non-empty (anchors at root + most-recent thread
+// activity); recent-channel fallback otherwise.
+func (b *notificationContextBuilder) NotificationContext(channel, triggerMsgID, threadRootID string, limit int) string {
+	if b == nil || b.channelMessages == nil {
+		return ""
+	}
+	if strings.TrimSpace(channel) == "" {
+		channel = "general"
+	}
+
+	msgs := b.channelMessages(channel)
+	if len(msgs) == 0 {
+		return ""
+	}
+
+	baseFilter := func(m channelMessage) bool {
+		if m.From == "system" {
+			return false
+		}
+		if m.Kind == "demo_seed" {
+			return false
+		}
+		if strings.TrimSpace(triggerMsgID) != "" && strings.TrimSpace(m.ID) == strings.TrimSpace(triggerMsgID) {
+			return false
+		}
+		if strings.HasPrefix(strings.TrimSpace(m.Content), "[STATUS]") {
+			return false
+		}
+		return true
+	}
+
+	formatContext := func(items []channelMessage) string {
+		var sb strings.Builder
+		for _, m := range items {
+			sb.WriteString(fmt.Sprintf("@%s: %s\n", m.From, truncate(m.Content, 600)))
+		}
+		return strings.TrimRight(sb.String(), "\n")
+	}
+
+	threadRoot := strings.TrimSpace(threadRootID)
+	if threadRoot != "" {
+		threadIDs := b.ThreadMessageIDs(channel, threadRoot)
+		var rootMsg *channelMessage
+		var rest []channelMessage
+		for i := range msgs {
+			m := &msgs[i]
+			if !baseFilter(*m) {
+				continue
+			}
+			if strings.TrimSpace(m.ID) == threadRoot {
+				rootMsg = m
+			} else if _, inThread := threadIDs[strings.TrimSpace(m.ID)]; inThread {
+				rest = append(rest, *m)
+			}
+		}
+		if rootMsg != nil || len(rest) > 0 {
+			remaining := limit
+			if rootMsg != nil {
+				remaining--
+			}
+			if len(rest) > remaining {
+				rest = rest[len(rest)-remaining:]
+			}
+			var thread []channelMessage
+			if rootMsg != nil {
+				thread = append(thread, *rootMsg)
+			}
+			thread = append(thread, rest...)
+			return "[Recent thread]\n" + formatContext(thread)
+		}
+	}
+
+	var filtered []channelMessage
+	for _, m := range msgs {
+		if baseFilter(m) {
+			filtered = append(filtered, m)
+		}
+	}
+	if len(filtered) == 0 {
+		return ""
+	}
+	if len(filtered) > limit {
+		filtered = filtered[len(filtered)-limit:]
+	}
+	return "[Recent channel]\n" + formatContext(filtered)
+}
+
+// UltimateThreadRoot walks the reply-to chain from startID up to the
+// topmost ancestor and returns its ID. Caps at 8 hops to defend against
+// cycles or pathological data.
+func (b *notificationContextBuilder) UltimateThreadRoot(channelSlug, startID string) string {
+	startID = strings.TrimSpace(startID)
+	if b == nil || startID == "" || b.channelMessages == nil {
+		return startID
+	}
+	msgs := b.channelMessages(channelSlug)
+	byID := make(map[string]channelMessage, len(msgs))
+	for _, m := range msgs {
+		if id := strings.TrimSpace(m.ID); id != "" {
+			byID[id] = m
+		}
+	}
+	root := startID
+	for depth := 0; depth < 8; depth++ {
+		m, ok := byID[root]
+		if !ok {
+			break
+		}
+		parent := strings.TrimSpace(m.ReplyTo)
+		if parent == "" {
+			break
+		}
+		root = parent
+	}
+	return root
+}
+
+// ThreadMessageIDs returns the BFS set of message IDs rooted at rootID.
+// The root itself is included. Empty when rootID is empty.
+func (b *notificationContextBuilder) ThreadMessageIDs(channelSlug, rootID string) map[string]struct{} {
+	rootID = strings.TrimSpace(rootID)
+	result := make(map[string]struct{})
+	if b == nil || rootID == "" || b.channelMessages == nil {
+		return result
+	}
+	msgs := b.channelMessages(channelSlug)
+	byParent := make(map[string][]string, len(msgs))
+	for _, m := range msgs {
+		parent := strings.TrimSpace(m.ReplyTo)
+		if parent != "" {
+			byParent[parent] = append(byParent[parent], strings.TrimSpace(m.ID))
+		}
+	}
+	result[rootID] = struct{}{}
+	queue := []string{rootID}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		for _, child := range byParent[cur] {
+			if _, seen := result[child]; !seen {
+				result[child] = struct{}{}
+				queue = append(queue, child)
+			}
+		}
+	}
+	return result
+}
+
+// TaskNotificationContext returns the "Active tasks:" block for the given
+// agent. Lead agents see all-channel tasks (sort by UpdatedAt desc),
+// non-leads see their own owned work first then a short fallback list.
+// Lead agents also get a review-backlog hint when tasks are stuck waiting
+// on review.
+func (b *notificationContextBuilder) TaskNotificationContext(channelSlug, slug string, limit int) string {
+	if b == nil || limit <= 0 {
+		return ""
+	}
+	var tasks []teamTask
+	if strings.TrimSpace(channelSlug) == "" {
+		if b.allTasks == nil {
+			return ""
+		}
+		tasks = b.allTasks()
+	} else {
+		if b.channelTasks == nil {
+			return ""
+		}
+		tasks = b.channelTasks(channelSlug)
+	}
+	if len(tasks) == 0 {
+		return ""
+	}
+
+	formatTask := func(task teamTask) string {
+		owner := strings.TrimSpace(task.Owner)
+		switch {
+		case owner == "":
+			owner = "unassigned"
+		default:
+			owner = "@" + owner
+		}
+		status := strings.TrimSpace(task.Status)
+		if status == "" {
+			status = "open"
+		}
+		meta := owner + ", " + status
+		if task.Blocked {
+			meta += ", blocked"
+		}
+		if len(task.DependsOn) > 0 {
+			meta += ", depends: " + strings.Join(task.DependsOn, " ")
+		}
+		taskChannel := normalizeChannelSlug(task.Channel)
+		if taskChannel == "" {
+			taskChannel = "general"
+		}
+		line := fmt.Sprintf("- #%s on #%s %s (%s)", task.ID, taskChannel, truncate(task.Title, 72), meta)
+		if details := strings.TrimSpace(task.Details); details != "" {
+			line += ": " + truncate(details, 96)
+		}
+		return line
+	}
+
+	sort.Slice(tasks, func(i, j int) bool {
+		return tasks[i].UpdatedAt > tasks[j].UpdatedAt
+	})
+
+	lines := make([]string, 0, limit)
+	seen := make(map[string]struct{}, limit)
+	addTask := func(task teamTask) {
+		if len(lines) >= limit {
+			return
+		}
+		if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
+			return
+		}
+		if _, ok := seen[task.ID]; ok {
+			return
+		}
+		seen[task.ID] = struct{}{}
+		lines = append(lines, formatTask(task))
+	}
+
+	lead := b.targeter.LeadSlug()
+	for _, task := range tasks {
+		if slug == lead || strings.TrimSpace(task.Owner) == slug {
+			addTask(task)
+		}
+	}
+	if len(lines) == 0 {
+		for _, task := range tasks {
+			addTask(task)
+		}
+	}
+	if len(lines) == 0 {
+		if slug == lead {
+			return "Active tasks:\n- None currently active. If the overall build is not actually finished, create the next owned task(s) now instead of ending with narrative next steps."
+		}
+		return ""
+	}
+
+	result := "Active tasks:\n" + strings.Join(lines, "\n")
+	if slug == lead {
+		reviewCount := 0
+		for _, task := range tasks {
+			if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
+				continue
+			}
+			if strings.EqualFold(strings.TrimSpace(task.Status), "review") || strings.EqualFold(strings.TrimSpace(task.ReviewState), "ready_for_review") {
+				reviewCount++
+			}
+		}
+		if reviewCount > 0 {
+			result += fmt.Sprintf("\nLead action: %d task(s) are waiting in review. Approve them or translate them into the next owned task(s) before you stop.", reviewCount)
+		}
+	}
+	return result
+}
+
+// RelevantTaskForTarget returns a task this slug owns that's tied to the
+// given message — first by ThreadID match, then by message-vs-task scoring
+// above the routing threshold. Done tasks and other-owned tasks never
+// match.
+func (b *notificationContextBuilder) RelevantTaskForTarget(msg channelMessage, slug string) (teamTask, bool) {
+	if b == nil || b.allTasks == nil || slug == "" {
+		return teamTask{}, false
+	}
+	threadRoot := strings.TrimSpace(msg.ID)
+	if replyTo := strings.TrimSpace(msg.ReplyTo); replyTo != "" {
+		threadRoot = replyTo
+	}
+	var domainOwned teamTask
+	bestOwnedScore := 0.0
+	for _, task := range b.allTasks() {
+		if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
+			continue
+		}
+		if strings.TrimSpace(task.Owner) != slug {
+			continue
+		}
+		if task.ThreadID != "" && (task.ThreadID == msg.ID || task.ThreadID == threadRoot) {
+			return task, true
+		}
+		if b.scoreTaskCandidate == nil {
+			continue
+		}
+		score := b.scoreTaskCandidate(msg, task)
+		if score >= officeRoutingMatchThreshold && score > bestOwnedScore {
+			domainOwned = task
+			bestOwnedScore = score
+		}
+	}
+	if domainOwned.ID != "" {
+		return domainOwned, true
+	}
+	return teamTask{}, false
+}
+
+// ResponseInstructionForTarget returns the per-agent guidance string
+// appended to a notification. Branches: lead-from-human, lead-from-
+// specialist, DM, tagged, owns-matching-task, default-stay-quiet.
+func (b *notificationContextBuilder) ResponseInstructionForTarget(msg channelMessage, slug string) string {
+	lead := b.targeter.LeadSlug()
+	if slug == lead {
+		from := strings.TrimSpace(msg.From)
+		isFromHuman := from == "" || from == "you" || from == "human" || from == "nex"
+		if !isFromHuman {
+			return fmt.Sprintf("You are @%s. A specialist just finished a lane. If the build is still underway, any task is open or in review, or the next lane is obvious, act now: approve/release review items, create the next owned team_task records, and only then stop. On a human build/ship/end-to-end request, if you approve or close an engineering/execution slice and the product is not yet runnable end to end, you MUST leave at least one engineering or execution lane active before you stop; do not let the company drift into GTM-only, rubric-only, or evaluation-only work while the build is still incomplete. Before you say a task is approved, closed, back in progress, reassigned, or blocked, you MUST make the matching team_task or team_plan call first; channel narration alone does not change durable state. If the task mutation fails, say that it failed and do not claim the state changed. Before creating any new task, inspect Active tasks in this packet: if a live task already covers that lane, reuse or update that task instead of creating an overlapping duplicate with a new title. Stay quiet only when the human already has what they need AND there is no remaining office work or obvious follow-up.", slug)
+		}
+		return fmt.Sprintf("You are @%s. Give the first top-level reply quickly, then pull in specialists only when needed. For build/ship/end-to-end requests, the first engineering task itself must be a single smallest runnable feature slice, not an MVP umbrella or a multi-output minimum bar. Do not put a separate repo audit, architecture, or cut-line research task in front of that first feature unless the human explicitly asked for analysis first or the repo truly has no identifiable implementation target. Do not spend the whole first turn on `pwd`, `ls`, `rg --files`, `find .`, or another repo-wide inventory; use the named docs/configs in the packet or at most one or two targeted reads, then create the first durable task/channel state in that same turn. %s", slug, capabilityGapCoachingBlock())
+	}
+	channelSlug := normalizeChannelSlug(msg.Channel)
+	if IsDMSlug(channelSlug) && DMTargetAgent(channelSlug) == slug {
+		return fmt.Sprintf("You are @%s. The human is messaging you directly in a DM. Respond helpfully from your domain expertise.", slug)
+	}
+	if isDM, agentTarget := b.targeter.IsChannelDM(channelSlug); isDM && agentTarget == slug {
+		return fmt.Sprintf("You are @%s. The human is messaging you directly in a DM. Respond helpfully from your domain expertise.", slug)
+	}
+	if containsSlug(msg.Tagged, slug) {
+		return fmt.Sprintf("You are @%s. You were directly tagged. Reply only from your domain with concrete progress, a blocker, or a handoff.", slug)
+	}
+	if task, ok := b.RelevantTaskForTarget(msg, slug); ok && strings.TrimSpace(task.Owner) == slug {
+		if taskRequiresRealExternalExecution(&task) {
+			return fmt.Sprintf("You are @%s. You already own matching work that requires a real connected-system action. Take the smallest allowed live external step now or report a blocker; repo docs, previews, local markdown, proof markers, and test artifacts do not satisfy it. Frame the result as a business deliverable, approval, handoff, or record, not as an eval or proof artifact. %s %s", slug, capabilityGapCoachingBlock(), taskHygieneCoachingBlock())
+		}
+		return fmt.Sprintf("You are @%s. You already own matching work. Reply only with concrete progress or a blocker; do not re-triage the thread.", slug)
+	}
+	return fmt.Sprintf("You are @%s. Stay quiet unless you are directly tagged, you own the active work, or you can unblock it. Prefer not to reply.", slug)
+}
+
+// BuildMessageWorkPacket returns the work packet a notified agent receives
+// for a channel message: header lines (thread / DM preamble / group
+// preamble / tagged hint / active task), recent-message context, and (for
+// the lead) a list of agents who have already acted in this thread or
+// have pending headless turns ("do NOT re-route").
+func (b *notificationContextBuilder) BuildMessageWorkPacket(msg channelMessage, slug string) string {
+	channelSlug := normalizeChannelSlug(msg.Channel)
+	if channelSlug == "" {
+		channelSlug = "general"
+	}
+	lines := []string{
+		"Work packet:",
+		fmt.Sprintf("- Thread: #%s reply_to %s", channelSlug, msg.ID),
+	}
+	if isDM, _ := b.targeter.IsChannelDM(channelSlug); isDM {
+		dmPreamble := []string{
+			"Context: DIRECT MESSAGE",
+			"This is a private 1:1 conversation with the human. Respond to every message.",
+			"You do not need to coordinate with other agents.",
+			"---",
+		}
+		lines = append(dmPreamble, lines...)
+	} else if b.channelStore != nil {
+		if cs := b.channelStore(); cs != nil {
+			if storeChannel, ok := cs.GetBySlug(channelSlug); ok && storeChannel.Type == "G" {
+				members := cs.Members(storeChannel.ID)
+				names := make([]string, 0, len(members))
+				for _, m := range members {
+					if m.Slug != slug {
+						names = append(names, "@"+m.Slug)
+					}
+				}
+				groupPreamble := []string{
+					"Context: GROUP MESSAGE",
+					fmt.Sprintf("This is a group conversation with: %s.", strings.Join(names, ", ")),
+					"Respond to messages directed at you or within your expertise.",
+					"---",
+				}
+				lines = append(groupPreamble, lines...)
+			}
+		}
+	}
+	if containsSlug(msg.Tagged, slug) {
+		lines = append(lines, "- Trigger: you were explicitly tagged")
+	}
+	if task, ok := b.RelevantTaskForTarget(msg, slug); ok {
+		lines = append(lines, fmt.Sprintf("- Active task: #%s %s (%s)", task.ID, truncate(task.Title, 96), strings.TrimSpace(task.Status)))
+		if details := strings.TrimSpace(task.Details); details != "" {
+			lines = append(lines, fmt.Sprintf("- Task details: %s", truncate(details, 512)))
+		}
+		if path := strings.TrimSpace(task.WorktreePath); path != "" {
+			lines = append(lines, fmt.Sprintf("- Working directory: %q", path))
+		}
+	}
+	threadRoot := b.UltimateThreadRoot(channelSlug, msg.ReplyTo)
+	if ctx := b.NotificationContext(channelSlug, msg.ID, threadRoot, 4); ctx != "" {
+		lines = append(lines, ctx)
+	}
+	if slug == b.targeter.LeadSlug() {
+		if taskCtx := b.TaskNotificationContext("", slug, 3); taskCtx != "" {
+			lines = append(lines, taskCtx)
+		}
+		activeAgents := map[string]struct{}{}
+		if b.channelMessages != nil {
+			threadRoot := strings.TrimSpace(b.UltimateThreadRoot(channelSlug, msg.ReplyTo))
+			if threadRoot == "" {
+				threadRoot = strings.TrimSpace(msg.ID)
+			}
+			threadIDs := b.ThreadMessageIDs(channelSlug, threadRoot)
+			for _, tm := range b.channelMessages(channelSlug) {
+				if _, inThread := threadIDs[strings.TrimSpace(tm.ID)]; !inThread {
+					continue
+				}
+				if tm.From != "" && tm.From != "you" && tm.From != "human" && tm.From != "nex" && tm.From != slug {
+					activeAgents[tm.From] = struct{}{}
+				}
+			}
+		}
+		if b.activeHeadlessAgents != nil {
+			for s := range b.activeHeadlessAgents(slug) {
+				activeAgents[s] = struct{}{}
+			}
+		}
+		if len(activeAgents) > 0 {
+			names := make([]string, 0, len(activeAgents))
+			for name := range activeAgents {
+				names = append(names, "@"+name)
+			}
+			sort.Strings(names)
+			lines = append(lines, fmt.Sprintf("- Already active in this thread (do NOT re-route): %s", strings.Join(names, ", ")))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// BuildTaskExecutionPacket returns the work packet for a task assignment
+// or update. Includes the task header, worktree path, named file targets
+// pulled from title+details, local-worktree guardrails, external-execution
+// guidance for live business tasks, and the recent thread context.
+func (b *notificationContextBuilder) BuildTaskExecutionPacket(slug string, action officeActionLog, task teamTask, content string) string {
+	channelSlug := normalizeChannelSlug(task.Channel)
+	if channelSlug == "" {
+		channelSlug = "general"
+	}
+	lines := []string{
+		fmt.Sprintf("[Task update from @%s]", action.Actor),
+		"Work packet:",
+		fmt.Sprintf("- Task: #%s %s", task.ID, truncate(task.Title, 120)),
+		fmt.Sprintf("- Status: %s", strings.TrimSpace(task.Status)),
+		fmt.Sprintf("- Owner: @%s", slug),
+	}
+	if details := strings.TrimSpace(task.Details); details != "" {
+		lines = append(lines, fmt.Sprintf("- Details: %s", truncate(details, 512)))
+	}
+	if targets := extractTaskFileTargets(task.Title + " " + task.Details); len(targets) > 0 {
+		lines = append(lines, fmt.Sprintf("- Named file targets: %s", strings.Join(targets, ", ")))
+	}
+	if task.ThreadID != "" {
+		lines = append(lines, fmt.Sprintf("- Thread: #%s reply_to %s", channelSlug, task.ThreadID))
+	} else {
+		lines = append(lines, fmt.Sprintf("- Channel: #%s", channelSlug))
+	}
+	lines = append(lines, fmt.Sprintf("- Mutation channel: use #%s when claiming or completing #%s", channelSlug, task.ID))
+	if path := strings.TrimSpace(task.WorktreePath); path != "" {
+		lines = append(lines, fmt.Sprintf("- Working directory: %q", path))
+	}
+	if strings.EqualFold(strings.TrimSpace(task.ExecutionMode), "local_worktree") {
+		lines = append(lines, "Execution rule: this is a local_worktree build task. Work inside the assigned working_directory and default to direct implementation. Do not spend this turn on another repo audit, architecture memo, or nested office launch unless the packet explicitly asks for that.")
+		lines = append(lines, "First-turn rule: choose the smallest shippable implementation slice you can finish in this turn and edit files for that slice now. If the overall MVP is broad, narrow it yourself and ship the first runnable sub-piece instead of trying to map the whole system.")
+		lines = append(lines, "Time rule: cut scope to something you can plausibly ship in under five minutes of focused work. If the chosen slice still needs broad exploration, cut it down again before you continue.")
+		lines = append(lines, "Cut-line rule: if the task description lists multiple outputs or phases, pick exactly one contiguous slice for this turn, then post team_status naming that cut line before you read files. Example cut lines: `config -> idea queue`, `idea queue -> script drafts`, or `script drafts -> publish pack`.")
+		if targets := extractTaskFileTargets(task.Title + " " + task.Details); len(targets) > 0 {
+			lines = append(lines, "Startup rule: open the named file targets first and use them as your starting point. Do not broaden into repo search unless those exact files are insufficient for the chosen cut line.")
+		}
+		lines = append(lines, "Audit guardrail: do NOT start with `rg --files`, `find .`, repo-wide README sweeps, or broad file inventories. Read only the handful of files directly tied to this task, then begin editing once you have the first target file.")
+		lines = append(lines, "Boundary rule: stay inside the assigned working_directory. Do NOT run `find ..`, `rg ..`, search sibling task worktrees, or inspect parent temp directories like `/var/folders`, `TMPDIR`, or `TemporaryItems`. Those paths are sandbox noise, not repo context.")
+		lines = append(lines, "Dirty-tree rule: ignore unrelated modified or untracked files already present in the worktree unless they are directly required for your slice. They may be preexisting repo state, not part of your task.")
+		lines = append(lines, "Deliverable rule: a local_worktree feature task is not satisfied by another plan, architecture memo, or audit summary unless the packet explicitly says research-only. Land code, scripts, docs for the runnable slice, or a concrete task-state blocker.")
+	}
+	if taskRequiresRealExternalExecution(&task) {
+		lines = append(lines, "External execution rule: this task names a connected external system and expects a real action there. Use the live integration/workflow path for the smallest allowed step now instead of producing another repo doc, proof marker, or internal package first.")
+		lines = append(lines, "Evidence rule: a local markdown file, preview note, repo artifact, or test output does NOT satisfy this task unless the packet explicitly says preview/mock/stub-only. Leave durable external evidence through the broker-integrated workflow/integration path before marking the task review-ready, done, or blocked.")
+		lines = append(lines, "Business framing: describe the work as a client deliverable, approval, handoff, update, or record. Avoid proof/marker/test/eval language unless the task explicitly asks for testing or evidence capture.")
+		lines = append(lines, "Pace rule: do the smallest safe external step first, then summarize it. Do not spend this turn building extra kickoff decks, review bundles, or substitute proof artifacts if the connected system action is already allowed.")
+		lines = append(lines, capabilityGapCoachingBlock())
+	}
+	if taskLooksLikeLiveBusinessObjective(&task) {
+		lines = append(lines, "Task hygiene rule: if this lane drifts into a proof packet, review bundle, blueprint-derived scaffold, rubric, or other internal artifact shell, rewrite it immediately into either the next real deliverable step or the exact capability-enablement task that will unlock that deliverable.")
+	}
+	threadRoot := b.UltimateThreadRoot(channelSlug, task.ThreadID)
+	if ctx := b.NotificationContext(channelSlug, "", threadRoot, 3); ctx != "" {
+		lines = append(lines, ctx)
+	}
+	lines = append(lines, fmt.Sprintf("If you deliver the substantive result for #%s in this turn, you MUST call team_task complete or review-ready for \"%s\" before any completion post and before you stop. A channel reply alone does not unblock dependent work, and a completion post without the task mutation is a failure.", task.ID, task.ID))
+	lines = append(lines, "Runtime rule: never launch another WUPHF office, copied wuphf binary, browser instance, or local web server/--web-port process from inside this turn. The office is already running; use the existing repo, broker state, and assigned worktree instead.")
+	lines = append(lines, fmt.Sprintf("%s Use team_task with my_slug \"%s\" to update status as you go.", truncate(content, 1000), slug))
+	return strings.Join(lines, "\n")
+}
+
+// TaskNotificationContent returns the short single-line task notification
+// header (verb, owner, status, optional pipeline / review / execMode /
+// worktree / guidance / framing / capability / hygiene fragments).
+func (b *notificationContextBuilder) TaskNotificationContent(action officeActionLog, task teamTask) string {
+	channelSlug := normalizeChannelSlug(task.Channel)
+	if channelSlug == "" {
+		channelSlug = "general"
+	}
+	verb := "Task update"
+	switch action.Kind {
+	case "task_created":
+		verb = "Task created"
+	case "task_updated":
+		verb = "Task updated"
+	case "task_unblocked":
+		verb = "Task unblocked — dependencies resolved, ready to start"
+	case "watchdog_alert":
+		verb = "Watchdog reminder"
+	}
+	owner := strings.TrimSpace(task.Owner)
+	if owner == "" {
+		owner = "unassigned"
+	} else {
+		owner = "@" + owner
+	}
+	status := strings.TrimSpace(task.Status)
+	if status == "" {
+		status = "open"
+	}
+	details := strings.TrimSpace(task.Details)
+	if details != "" {
+		details = " — " + truncate(details, 120)
+	}
+	pipeline := ""
+	if strings.TrimSpace(task.PipelineStage) != "" {
+		pipeline = ", stage " + task.PipelineStage
+	}
+	review := ""
+	if strings.TrimSpace(task.ReviewState) != "" && task.ReviewState != "not_required" {
+		review = ", review " + task.ReviewState
+	}
+	execMode := ""
+	if strings.TrimSpace(task.ExecutionMode) != "" {
+		execMode = ", execution " + task.ExecutionMode
+	}
+	worktree := ""
+	if strings.TrimSpace(task.WorktreeBranch) != "" || strings.TrimSpace(task.WorktreePath) != "" {
+		parts := make([]string, 0, 2)
+		if strings.TrimSpace(task.WorktreeBranch) != "" {
+			parts = append(parts, "branch "+task.WorktreeBranch)
+		}
+		if strings.TrimSpace(task.WorktreePath) != "" {
+			parts = append(parts, "path "+task.WorktreePath)
+		}
+		worktree = ", worktree " + strings.Join(parts, " · ")
+	}
+	guidance := ""
+	if path := strings.TrimSpace(task.WorktreePath); path != "" {
+		guidance = fmt.Sprintf(" If you own this task, use working_directory=%q for local file and bash tools.", path)
+	}
+	framing := ""
+	if taskRequiresRealExternalExecution(&task) {
+		framing = " Live business framing: describe the work as a client deliverable, approval, handoff, update, or record. Do not present it as a proof marker, eval artifact, or test artifact unless the task explicitly asks for testing or evidence capture."
+	}
+	capability := ""
+	if taskRequiresRealExternalExecution(&task) {
+		capability = "\n" + capabilityGapCoachingBlock()
+	}
+	hygiene := ""
+	if taskLooksLikeLiveBusinessObjective(&task) {
+		hygiene = "\n" + taskHygieneCoachingBlock()
+	}
+	return fmt.Sprintf("[%s #%s on #%s]: %s%s (owner %s, status %s%s%s%s%s). Context is included — do NOT call team_poll or team_tasks. Respond with the concrete next step immediately. Stay in your lane. Once you have posted the needed update, STOP and wait for the next pushed notification.%s%s%s%s", verb, task.ID, channelSlug, task.Title, details, owner, status, pipeline, review, execMode, worktree, guidance, framing, capability, hygiene)
+}
+
+// ── package-level helpers used inside the builder ──────────────────────
+
+// truncate clips s to max bytes followed by "..." when it overflows.
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+// extractTaskFileTargets returns up to four backtick-quoted candidates
+// from text that look like file paths (contain "/" or "."). De-duplicated
+// in order; empty when nothing matches.
+func extractTaskFileTargets(text string) []string {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	targets := make([]string, 0, 4)
+	for {
+		start := strings.Index(text, "`")
+		if start < 0 {
+			break
+		}
+		text = text[start+1:]
+		end := strings.Index(text, "`")
+		if end < 0 {
+			break
+		}
+		candidate := strings.TrimSpace(text[:end])
+		text = text[end+1:]
+		if candidate == "" {
+			continue
+		}
+		if !strings.Contains(candidate, "/") && !strings.Contains(candidate, ".") {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		targets = append(targets, candidate)
+		if len(targets) == 4 {
+			break
+		}
+	}
+	return targets
+}
+
+// humanizeNotificationType converts a snake_case kind into a Title Case
+// label for human display. Used by launcher_nex.go for nex notification
+// rendering as well as the task-execution packet header.
+func humanizeNotificationType(kind string) string {
+	switch strings.TrimSpace(kind) {
+	case "context_alert":
+		return "Context alert"
+	case "daily_digest":
+		return "Daily digest"
+	case "meeting_summary":
+		return "Meeting summary"
+	case "task_reminder":
+		return "Task reminder"
+	case "task_assigned":
+		return "Task assigned"
+	default:
+		if kind == "" {
+			return ""
+		}
+		parts := strings.Split(strings.ReplaceAll(kind, "_", " "), " ")
+		for i, part := range parts {
+			if part == "" {
+				continue
+			}
+			parts[i] = strings.ToUpper(part[:1]) + part[1:]
+		}
+		return strings.Join(parts, " ")
+	}
+}

--- a/internal/team/notification_context.go
+++ b/internal/team/notification_context.go
@@ -57,6 +57,9 @@ func (b *notificationContextBuilder) NotificationContext(channel, triggerMsgID, 
 	if b == nil || b.channelMessages == nil {
 		return ""
 	}
+	if limit <= 0 {
+		return ""
+	}
 	if strings.TrimSpace(channel) == "" {
 		channel = "general"
 	}
@@ -318,9 +321,16 @@ func (b *notificationContextBuilder) RelevantTaskForTarget(msg channelMessage, s
 	if b == nil || b.allTasks == nil || slug == "" {
 		return teamTask{}, false
 	}
+	// Resolve to the ultimate thread root so deep replies still match a
+	// task anchored on the top-level message. msg.ReplyTo only points at
+	// the immediate parent, which loses second-level+ replies.
 	threadRoot := strings.TrimSpace(msg.ID)
 	if replyTo := strings.TrimSpace(msg.ReplyTo); replyTo != "" {
-		threadRoot = replyTo
+		if root := strings.TrimSpace(b.UltimateThreadRoot(strings.TrimSpace(msg.Channel), replyTo)); root != "" {
+			threadRoot = root
+		} else {
+			threadRoot = replyTo
+		}
 	}
 	var domainOwned teamTask
 	bestOwnedScore := 0.0

--- a/internal/team/notification_context_test.go
+++ b/internal/team/notification_context_test.go
@@ -1,0 +1,508 @@
+package team
+
+// Tests for the extracted notificationContextBuilder type. Written test-
+// first against the surface in PLAN.md §C3 before the type exists, so the
+// first run is a compile failure by design.
+//
+// The existing TestBuildNotificationContext / TestBuildMessageWorkPacket /
+// TestResponseInstructionForTarget* tests in launcher_test.go remain the
+// behavior baseline (they reach this surface via &Launcher{...}). The new
+// tests below exercise the type directly with stub broker callbacks so the
+// new file lands above the 85% per-file gate without depending on a
+// real Broker fixture.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/channel"
+)
+
+func newTestNotifyContextBuilder(t *testing.T, opts ...func(*notificationContextBuilder)) *notificationContextBuilder {
+	t.Helper()
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true, Name: "CEO"},
+		{Slug: "eng", Name: "Engineer"},
+	})
+	b := &notificationContextBuilder{
+		targeter:        tg,
+		channelMessages: func(string) []channelMessage { return nil },
+		channelTasks:    func(string) []teamTask { return nil },
+		allTasks:        func() []teamTask { return nil },
+		channelStore:    func() *channel.Store { return nil },
+		scoreTaskCandidate: func(msg channelMessage, task teamTask) float64 {
+			// Default: only direct ID/owner matches, no fuzzy scoring.
+			return 0
+		},
+		activeHeadlessAgents: func(string) map[string]struct{} { return nil },
+	}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+func TestNotificationContext_TruncateHelper(t *testing.T) {
+	if got := truncate("hello", 100); got != "hello" {
+		t.Errorf("truncate short string should be passthrough; got %q", got)
+	}
+	if got := truncate("abcdefghij", 5); got != "abcde..." {
+		t.Errorf("truncate(10char, 5) = %q, want abcde...", got)
+	}
+	if got := truncate("", 5); got != "" {
+		t.Errorf("truncate empty = %q, want empty", got)
+	}
+}
+
+func TestNotificationContext_ExtractTaskFileTargets(t *testing.T) {
+	cases := []struct {
+		text string
+		want []string
+	}{
+		{"Update `web/src/App.tsx` and `internal/team/launcher.go`", []string{"web/src/App.tsx", "internal/team/launcher.go"}},
+		{"This has no backticks", nil},
+		{"Backticks but no path/dot: `notarealpath`", nil},
+		{"Dot only: `script.sh`", []string{"script.sh"}},
+		{"Slash only: `pkg/foo`", []string{"pkg/foo"}},
+		{"Five `a.x` `b.x` `c.x` `d.x` `e.x` should cap at four", []string{"a.x", "b.x", "c.x", "d.x"}},
+		{"Duplicate `a.x` `a.x` `b.x` dedups", []string{"a.x", "b.x"}},
+		{"  Empty `` `b.x`", []string{"b.x"}},
+	}
+	for _, tc := range cases {
+		got := extractTaskFileTargets(tc.text)
+		if !equalStringSlices(got, tc.want) {
+			t.Errorf("extractTaskFileTargets(%q) = %v, want %v", tc.text, got, tc.want)
+		}
+	}
+}
+
+func TestNotificationContext_HumanizeNotificationType(t *testing.T) {
+	cases := map[string]string{
+		"context_alert":   "Context alert",
+		"daily_digest":    "Daily digest",
+		"meeting_summary": "Meeting summary",
+		"task_reminder":   "Task reminder",
+		"task_assigned":   "Task assigned",
+		"":                "",
+		"snake_case_kind": "Snake Case Kind",
+		"single":          "Single",
+	}
+	for kind, want := range cases {
+		if got := humanizeNotificationType(kind); got != want {
+			t.Errorf("humanizeNotificationType(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestNotificationContext_ContextEmptyWhenNoMessages(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	if got := b.NotificationContext("general", "", "", 5); got != "" {
+		t.Errorf("expected empty context when no messages, got %q", got)
+	}
+}
+
+func TestNotificationContext_FiltersSystemAndDemoSeedAndStatus(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "1", From: "you", Content: "human says hi"},
+		{ID: "2", From: "system", Content: "system bookkeeping"},
+		{ID: "3", From: "ceo", Content: "[STATUS] working"},
+		{ID: "4", From: "ceo", Kind: "demo_seed", Content: "fake activity"},
+		{ID: "5", From: "ceo", Content: "real reply"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	got := b.NotificationContext("general", "", "", 10)
+	if !strings.Contains(got, "human says hi") {
+		t.Errorf("expected human msg included; got %q", got)
+	}
+	if !strings.Contains(got, "real reply") {
+		t.Errorf("expected real ceo reply included; got %q", got)
+	}
+	for _, banned := range []string{"system bookkeeping", "STATUS", "fake activity"} {
+		if strings.Contains(got, banned) {
+			t.Errorf("expected %q filtered out, got %q", banned, got)
+		}
+	}
+}
+
+func TestNotificationContext_ExcludesTrigger(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "1", From: "you", Content: "earlier"},
+		{ID: "trigger", From: "you", Content: "the trigger msg"},
+		{ID: "2", From: "ceo", Content: "later"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	got := b.NotificationContext("general", "trigger", "", 10)
+	if strings.Contains(got, "the trigger msg") {
+		t.Errorf("trigger msg should be excluded; got %q", got)
+	}
+}
+
+func TestNotificationContext_ThreadScoped_AnchorsAtRoot(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "ROOT", From: "you", Content: "original ask"},
+		{ID: "off1", From: "you", Content: "unrelated chatter"},
+		{ID: "child1", From: "ceo", Content: "delegating", ReplyTo: "ROOT"},
+		{ID: "grand", From: "eng", Content: "working on it", ReplyTo: "child1"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	got := b.NotificationContext("general", "", "ROOT", 10)
+	if !strings.Contains(got, "original ask") {
+		t.Errorf("thread-scoped context should anchor at root; got %q", got)
+	}
+	if !strings.Contains(got, "working on it") {
+		t.Errorf("thread-scoped context should include grandchild; got %q", got)
+	}
+	if strings.Contains(got, "unrelated chatter") {
+		t.Errorf("thread-scoped context must not include off-thread msg; got %q", got)
+	}
+}
+
+func TestNotificationContext_DefaultChannelGeneral(t *testing.T) {
+	captured := ""
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(channel string) []channelMessage {
+			captured = channel
+			return nil
+		}
+	})
+	_ = b.NotificationContext(" ", "", "", 5)
+	if captured != "general" {
+		t.Errorf("empty channel should default to general; got %q", captured)
+	}
+}
+
+func TestNotificationContext_UltimateThreadRoot_WalksReplyChain(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "ROOT", From: "you", Content: "original"},
+		{ID: "A", From: "ceo", Content: "delegating", ReplyTo: "ROOT"},
+		{ID: "B", From: "eng", Content: "ack", ReplyTo: "A"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	if got := b.UltimateThreadRoot("general", "B"); got != "ROOT" {
+		t.Errorf("UltimateThreadRoot = %q, want ROOT", got)
+	}
+	if got := b.UltimateThreadRoot("general", ""); got != "" {
+		t.Errorf("UltimateThreadRoot(empty) should be empty")
+	}
+}
+
+func TestNotificationContext_UltimateThreadRoot_StopsOnCycle(t *testing.T) {
+	// Pathological case: depth cap (8) protects against cycles.
+	msgs := []channelMessage{
+		{ID: "A", ReplyTo: "B"},
+		{ID: "B", ReplyTo: "A"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	got := b.UltimateThreadRoot("general", "A")
+	if got != "A" && got != "B" {
+		t.Errorf("UltimateThreadRoot in cycle should return one of the cycle nodes; got %q", got)
+	}
+}
+
+func TestNotificationContext_ThreadMessageIDs_BFS(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "R"},
+		{ID: "A", ReplyTo: "R"},
+		{ID: "B", ReplyTo: "R"},
+		{ID: "AA", ReplyTo: "A"},
+		{ID: "off", ReplyTo: "elsewhere"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+	})
+	got := b.ThreadMessageIDs("general", "R")
+	for _, want := range []string{"R", "A", "B", "AA"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("ThreadMessageIDs missing %q; got %v", want, got)
+		}
+	}
+	if _, ok := got["off"]; ok {
+		t.Errorf("ThreadMessageIDs should not include off-thread node; got %v", got)
+	}
+}
+
+func TestNotificationContext_TaskNotificationContext_LeadGetsAllChannels(t *testing.T) {
+	all := []teamTask{
+		{ID: "t1", Channel: "general", Title: "general task", Owner: "ceo", Status: "in_progress", UpdatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "t2", Channel: "engineering", Title: "eng task", Owner: "ceo", Status: "in_progress", UpdatedAt: "2026-04-01T00:00:00Z"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return all }
+		b.channelTasks = func(string) []teamTask { return nil }
+	})
+	got := b.TaskNotificationContext("", "ceo", 5)
+	if !strings.Contains(got, "general task") {
+		t.Errorf("expected general task in lead context: %q", got)
+	}
+	if !strings.Contains(got, "eng task") {
+		t.Errorf("expected eng task in lead context: %q", got)
+	}
+	// Most-recently-updated first (by UpdatedAt desc).
+	idxEng := strings.Index(got, "eng task")
+	idxGen := strings.Index(got, "general task")
+	if idxEng > idxGen {
+		t.Errorf("expected eng task (UpdatedAt 200) before general task (UpdatedAt 100); got eng=%d gen=%d", idxEng, idxGen)
+	}
+}
+
+func TestNotificationContext_TaskNotificationContext_LeadEmptyShowsCreateNextOwnedHint(t *testing.T) {
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return nil }
+	})
+	got := b.TaskNotificationContext("", "ceo", 5)
+	if got != "" {
+		// When there are no tasks at all, the function returns empty (no
+		// "Active tasks" header). Verify that's still the contract.
+		if strings.Contains(got, "Active tasks") {
+			t.Errorf("expected empty when no tasks; got %q", got)
+		}
+	}
+}
+
+func TestNotificationContext_TaskNotificationContext_LeadAlertsOnReviewBacklog(t *testing.T) {
+	tasks := []teamTask{
+		{ID: "t1", Title: "ready 1", Owner: "eng", Status: "review", UpdatedAt: "2026-01-01T00:00:00Z"},
+		{ID: "t2", Title: "ready 2", Owner: "eng", Status: "in_progress", ReviewState: "ready_for_review", UpdatedAt: "2026-04-01T00:00:00Z"},
+		{ID: "t3", Title: "active", Owner: "eng", Status: "in_progress", UpdatedAt: "2025-12-01T00:00:00Z"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return tasks }
+		b.channelTasks = func(string) []teamTask { return nil }
+	})
+	got := b.TaskNotificationContext("", "ceo", 5)
+	if !strings.Contains(got, "2 task(s) are waiting in review") {
+		t.Errorf("expected review-backlog hint with count 2; got %q", got)
+	}
+}
+
+func TestNotificationContext_TaskNotificationContext_NonLeadOnlyOwnedTasks(t *testing.T) {
+	tasks := []teamTask{
+		{ID: "t1", Channel: "general", Title: "mine", Owner: "eng", Status: "in_progress"},
+		{ID: "t2", Channel: "general", Title: "theirs", Owner: "ceo", Status: "in_progress"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelTasks = func(string) []teamTask { return tasks }
+	})
+	got := b.TaskNotificationContext("general", "eng", 5)
+	if !strings.Contains(got, "mine") {
+		t.Errorf("expected own task: %q", got)
+	}
+	if strings.Contains(got, "theirs") {
+		t.Errorf("non-lead should only see their own owned tasks first; got %q", got)
+	}
+}
+
+func TestNotificationContext_RelevantTaskForTarget_ThreadIDMatch(t *testing.T) {
+	tasks := []teamTask{
+		{ID: "t1", Owner: "eng", Status: "in_progress", ThreadID: "msg-123"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return tasks }
+	})
+	got, ok := b.RelevantTaskForTarget(channelMessage{ID: "msg-123"}, "eng")
+	if !ok || got.ID != "t1" {
+		t.Fatalf("expected t1 by ThreadID match; got (%v, %v)", got, ok)
+	}
+}
+
+func TestNotificationContext_RelevantTaskForTarget_FallsBackToScore(t *testing.T) {
+	tasks := []teamTask{
+		{ID: "t-low", Owner: "eng", Status: "in_progress"},
+		{ID: "t-high", Owner: "eng", Status: "in_progress"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return tasks }
+		b.scoreTaskCandidate = func(msg channelMessage, task teamTask) float64 {
+			if task.ID == "t-high" {
+				return 0.99
+			}
+			return 0.30
+		}
+	})
+	got, ok := b.RelevantTaskForTarget(channelMessage{ID: "msg-x"}, "eng")
+	if !ok || got.ID != "t-high" {
+		t.Fatalf("expected highest-scoring owned task; got (%v, %v)", got, ok)
+	}
+}
+
+func TestNotificationContext_RelevantTaskForTarget_SkipsDoneAndOtherOwners(t *testing.T) {
+	tasks := []teamTask{
+		{ID: "done", Owner: "eng", Status: "done"},
+		{ID: "ot", Owner: "fe", Status: "in_progress"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.allTasks = func() []teamTask { return tasks }
+		b.scoreTaskCandidate = func(channelMessage, teamTask) float64 { return 0.99 }
+	})
+	if _, ok := b.RelevantTaskForTarget(channelMessage{}, "eng"); ok {
+		t.Errorf("done tasks must not match")
+	}
+}
+
+func TestNotificationContext_ResponseInstruction_LeadFromHumanGetsKickoffGuidance(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.ResponseInstructionForTarget(channelMessage{From: "you", Channel: "general", Content: "build it"}, "ceo")
+	if !strings.Contains(got, "first engineering task itself must be a single smallest runnable feature slice") {
+		t.Errorf("lead-from-human instruction should require runnable slice; got %q", got)
+	}
+}
+
+func TestNotificationContext_ResponseInstruction_LeadFromSpecialistGetsApprovalGuidance(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.ResponseInstructionForTarget(channelMessage{From: "eng", Channel: "general", Content: "done"}, "ceo")
+	if !strings.Contains(got, "specialist just finished a lane") {
+		t.Errorf("lead-from-specialist instruction should mention specialist finishing; got %q", got)
+	}
+}
+
+func TestNotificationContext_ResponseInstruction_DMTriggersDirectGuidance(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.ResponseInstructionForTarget(channelMessage{Channel: "dm-eng"}, "eng")
+	if !strings.Contains(got, "direct expertise") && !strings.Contains(got, "messaging you directly in a DM") {
+		t.Errorf("expected DM-direct guidance; got %q", got)
+	}
+}
+
+func TestNotificationContext_ResponseInstruction_TaggedTriggersTaggedGuidance(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.ResponseInstructionForTarget(channelMessage{Channel: "general", Tagged: []string{"eng"}}, "eng")
+	if !strings.Contains(got, "directly tagged") {
+		t.Errorf("expected tagged guidance; got %q", got)
+	}
+}
+
+func TestNotificationContext_ResponseInstruction_UntaggedNonOwnerStaysQuiet(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.ResponseInstructionForTarget(channelMessage{Channel: "general"}, "eng")
+	if !strings.Contains(got, "Stay quiet") {
+		t.Errorf("expected stay-quiet default for untagged non-owner; got %q", got)
+	}
+}
+
+func TestNotificationContext_BuildMessageWorkPacket_BasicShape(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.BuildMessageWorkPacket(channelMessage{ID: "m1", Channel: "general", From: "you"}, "eng")
+	for _, want := range []string{"Work packet:", "Thread: #general reply_to m1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in packet:\n%s", want, got)
+		}
+	}
+}
+
+func TestNotificationContext_BuildMessageWorkPacket_DMPreambleAdded(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.BuildMessageWorkPacket(channelMessage{ID: "m1", Channel: "dm-eng", From: "you"}, "eng")
+	if !strings.Contains(got, "DIRECT MESSAGE") {
+		t.Errorf("expected DM preamble; got %q", got)
+	}
+}
+
+func TestNotificationContext_BuildMessageWorkPacket_LeadAlreadyActiveLineSorted(t *testing.T) {
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.activeHeadlessAgents = func(except string) map[string]struct{} {
+			return map[string]struct{}{"eng": {}, "fe": {}}
+		}
+		// Targeter must say "ceo" is the lead.
+		b.targeter = fixtureTargeter(t, []officeMember{
+			{Slug: "ceo", BuiltIn: true, Name: "CEO"},
+			{Slug: "eng"},
+			{Slug: "fe"},
+		})
+	})
+	got := b.BuildMessageWorkPacket(channelMessage{ID: "m", Channel: "general", From: "you"}, "ceo")
+	if !strings.Contains(got, "Already active in this thread") {
+		t.Fatalf("expected already-active line for lead; got %q", got)
+	}
+	// Sorted alphabetical: @eng before @fe.
+	idxEng := strings.Index(got, "@eng")
+	idxFe := strings.Index(got, "@fe")
+	if idxEng < 0 || idxFe < 0 || idxEng > idxFe {
+		t.Errorf("expected @eng before @fe in active list; got eng=%d fe=%d", idxEng, idxFe)
+	}
+}
+
+func TestNotificationContext_BuildTaskExecutionPacket_LocalWorktreeAddsCutLineAndAuditGuards(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	task := teamTask{
+		ID:            "t1",
+		Title:         "build feature",
+		Status:        "in_progress",
+		ExecutionMode: "local_worktree",
+		WorktreePath:  "/tmp/worktree",
+	}
+	got := b.BuildTaskExecutionPacket("eng", officeActionLog{Actor: "ceo", Kind: "task_assigned"}, task, "kickoff")
+	for _, want := range []string{
+		"Working directory: \"/tmp/worktree\"",
+		"local_worktree build task",
+		"do NOT start with `rg --files`",
+		"stay inside the assigned working_directory",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in packet:\n%s", want, got)
+		}
+	}
+}
+
+func TestNotificationContext_BuildTaskExecutionPacket_NamesFileTargetsFromTitleAndDetails(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	task := teamTask{
+		ID:      "t1",
+		Title:   "Update `web/src/App.tsx`",
+		Details: "Also touch `internal/team/launcher.go`",
+		Status:  "in_progress",
+	}
+	got := b.BuildTaskExecutionPacket("eng", officeActionLog{Actor: "ceo"}, task, "kickoff")
+	if !strings.Contains(got, "Named file targets: web/src/App.tsx, internal/team/launcher.go") {
+		t.Errorf("expected named file targets line; got %q", got)
+	}
+}
+
+func TestNotificationContext_TaskNotificationContent_HumanizedHeader(t *testing.T) {
+	b := newTestNotifyContextBuilder(t)
+	got := b.TaskNotificationContent(officeActionLog{Kind: "task_unblocked"}, teamTask{
+		ID:      "t1",
+		Channel: "general",
+		Title:   "go",
+		Owner:   "eng",
+		Status:  "in_progress",
+	})
+	if !strings.Contains(got, "Task unblocked") {
+		t.Errorf("expected unblocked verb; got %q", got)
+	}
+	if !strings.Contains(got, "@eng") {
+		t.Errorf("expected owner mention; got %q", got)
+	}
+}
+
+// Sanity-check that the launcher wires the builder up correctly so existing
+// dispatch paths see the same answers as the type does in isolation.
+func TestLauncher_NotifyContextWiringDelegates(t *testing.T) {
+	b := &Broker{tasks: []teamTask{
+		{ID: "t1", Channel: "general", Title: "thing", Owner: "ceo", Status: "in_progress"},
+	}}
+	l := &Launcher{
+		broker: b,
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "eng", Name: "Engineer"},
+			},
+		},
+	}
+	got := l.buildTaskNotificationContext("general", "ceo", 5)
+	if !strings.Contains(got, "thing") {
+		t.Errorf("expected ceo task in context: %q", got)
+	}
+}

--- a/internal/team/notification_context_test.go
+++ b/internal/team/notification_context_test.go
@@ -350,6 +350,30 @@ func TestNotificationContext_RelevantTaskForTarget_SkipsDoneAndOtherOwners(t *te
 	}
 }
 
+// Regression: a deep reply (msg → parent → root, with task anchored on
+// root) must still resolve to the task. Pre-fix, RelevantTaskForTarget
+// only walked one hop via msg.ReplyTo, so anything past depth 2 missed.
+func TestNotificationContext_RelevantTaskForTarget_DeepReplyResolvesViaUltimateRoot(t *testing.T) {
+	msgs := []channelMessage{
+		{ID: "root", Channel: "general", From: "you"},
+		{ID: "mid", Channel: "general", From: "ceo", ReplyTo: "root"},
+		{ID: "leaf", Channel: "general", From: "you", ReplyTo: "mid"},
+	}
+	tasks := []teamTask{
+		{ID: "t1", Owner: "eng", Status: "in_progress", ThreadID: "root"},
+	}
+	b := newTestNotifyContextBuilder(t, func(b *notificationContextBuilder) {
+		b.channelMessages = func(string) []channelMessage { return msgs }
+		b.allTasks = func() []teamTask { return tasks }
+	})
+	// Trigger is the leaf; its ReplyTo is "mid" (not "root"). Without the
+	// fix, threadRoot would be "mid" and ThreadID="root" would not match.
+	got, ok := b.RelevantTaskForTarget(channelMessage{ID: "leaf", Channel: "general", ReplyTo: "mid"}, "eng")
+	if !ok || got.ID != "t1" {
+		t.Fatalf("expected t1 to match via ultimate thread root; got (%v, %v)", got, ok)
+	}
+}
+
 func TestNotificationContext_ResponseInstruction_LeadFromHumanGetsKickoffGuidance(t *testing.T) {
 	b := newTestNotifyContextBuilder(t)
 	got := b.ResponseInstructionForTarget(channelMessage{From: "you", Channel: "general", Content: "build it"}, "ceo")

--- a/internal/team/office_targets.go
+++ b/internal/team/office_targets.go
@@ -10,16 +10,20 @@ package team
 //   - paneBackedFlag is a *bool aliased to launcher.paneBackedAgents. The
 //     pane-spawn path flips that bool deep inside trySpawnWebAgentPanes;
 //     reading via pointer keeps the targeter in sync without callbacks.
-//   - failedPaneSlugs is a shared map. Today it's read here, written by the
-//     pane-spawn path (still on Launcher). No mutex — the race is dormant
-//     only because trySpawnWebAgentPanes is a runtime-promotion fallback
-//     that nothing currently invokes (see launcher.go:2647 / 3470). The
-//     moment promotion is wired, or any concurrent reader of the targeter
-//     overlaps the writer, this races. C5 (paneLifecycle) replaces this
-//     with a failedPane(slug) callback and removes the shared map entirely.
+//   - failedPaneSlugs is read via callback so every targeter call sees the
+//     launcher's *current* map reference. Required because
+//     reconfigureVisibleAgents nils l.failedPaneSlugs and the next pane-
+//     spawn failure rebuilds it; a cached map pointer here would become
+//     orphaned. The map is still unsynchronized — no mutex — but the
+//     race is dormant because trySpawnWebAgentPanes is a runtime-promotion
+//     fallback that nothing currently invokes (see launcher.go:2647 /
+//     3470). C5 (paneLifecycle) adds the mutex and replaces this with
+//     failedPane(slug) lookup, which is what the callback shape already
+//     anticipates.
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/nex-crm/wuphf/internal/agent"
@@ -42,10 +46,11 @@ type officeTargeter struct {
 	// the headless path silently when panes were actually live (PLAN.md §5.2).
 	paneBackedFlag *bool
 
-	// failedPaneSlugs is the shared map of slugs whose pane spawn failed.
-	// Written by the pane-spawn path on Launcher; read here. Map sharing
-	// across types is a deliberate transitional state — see file header.
-	failedPaneSlugs map[string]string
+	// failedPaneSlugs returns the live map of slugs whose pane spawn failed.
+	// Read via callback (not cached) so reconfigure-time invalidation on
+	// the launcher side is observable. See file header for the migration
+	// path to a per-slug lookup once C5 lands.
+	failedPaneSlugs func() map[string]string
 
 	// Live-state callbacks. Pulled rather than pushed so tests can stub.
 	isOneOnOne         func() bool
@@ -94,20 +99,26 @@ func (o *officeTargeter) LeadSlug() string {
 
 // officeLeadSlugFrom is a free function (kept package-level) so the prompt
 // builder can derive the lead from an already-loaded member snapshot
-// without a redundant snapshotMembers call.
+// without a redundant snapshotMembers call. Sorts a copy of the input
+// by slug before iterating so the answer is deterministic regardless
+// of caller-supplied order — matters for prompt-cache byte-stability
+// and for callers that iterate AgentOrder (pack-ordered) vs. raw
+// MembersSnapshot (broker-snapshot order).
 func officeLeadSlugFrom(members []officeMember) string {
-	for _, member := range members {
+	sorted := append([]officeMember(nil), members...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Slug < sorted[j].Slug })
+	for _, member := range sorted {
 		if member.Slug == "ceo" {
 			return "ceo"
 		}
 	}
-	for _, member := range members {
+	for _, member := range sorted {
 		if member.BuiltIn {
 			return member.Slug
 		}
 	}
-	if len(members) > 0 {
-		return members[0].Slug
+	if len(sorted) > 0 {
+		return sorted[0].Slug
 	}
 	return ""
 }
@@ -375,8 +386,10 @@ func (o *officeTargeter) ShouldUseHeadlessForSlug(slug string) bool {
 	if o.MemberUsesHeadlessOneShotRuntime(slug) {
 		return true
 	}
-	if _, failed := o.failedPaneSlugs[strings.TrimSpace(slug)]; failed {
-		return true
+	if o.failedPaneSlugs != nil {
+		if _, failed := o.failedPaneSlugs()[strings.TrimSpace(slug)]; failed {
+			return true
+		}
 	}
 	return false
 }
@@ -401,8 +414,10 @@ func (o *officeTargeter) SkipPane(slug string) bool {
 	if slug == "" {
 		return true
 	}
-	if _, bad := o.failedPaneSlugs[slug]; bad {
-		return true
+	if o.failedPaneSlugs != nil {
+		if _, bad := o.failedPaneSlugs()[slug]; bad {
+			return true
+		}
 	}
 	if o.MemberUsesHeadlessOneShotRuntime(slug) {
 		return true

--- a/internal/team/office_targets.go
+++ b/internal/team/office_targets.go
@@ -11,9 +11,12 @@ package team
 //     pane-spawn path flips that bool deep inside trySpawnWebAgentPanes;
 //     reading via pointer keeps the targeter in sync without callbacks.
 //   - failedPaneSlugs is a shared map. Today it's read here, written by the
-//     pane-spawn path (still on Launcher). The shared-map race is pre-
-//     existing (writes happen sequentially during Launch); when C5 lands
-//     paneLifecycle this becomes failedPane(slug) func, removing the dangle.
+//     pane-spawn path (still on Launcher). No mutex — the race is dormant
+//     only because trySpawnWebAgentPanes is a runtime-promotion fallback
+//     that nothing currently invokes (see launcher.go:2647 / 3470). The
+//     moment promotion is wired, or any concurrent reader of the targeter
+//     overlaps the writer, this races. C5 (paneLifecycle) replaces this
+//     with a failedPane(slug) callback and removes the shared map entirely.
 
 import (
 	"fmt"

--- a/internal/team/office_targets.go
+++ b/internal/team/office_targets.go
@@ -169,16 +169,18 @@ func (o *officeTargeter) NameFor(slug string) string {
 }
 
 // AgentOrder returns the member roster with the lead slug always first.
-// Used by pane spawn to guarantee the CEO pane lands at index 1.
+// Used by pane spawn to guarantee the CEO pane lands at index 1. Drives
+// off ActiveSessionMembers (pack-ordered) so pane indices stay stable
+// across launches even if the broker snapshot order shifts.
 func (o *officeTargeter) AgentOrder() []officeMember {
 	var agentOrder []officeMember
 	lead := o.LeadSlug()
-	for _, member := range o.MembersSnapshot() {
+	for _, member := range o.ActiveSessionMembers() {
 		if member.Slug == lead {
 			agentOrder = append([]officeMember{member}, agentOrder...)
 		}
 	}
-	for _, member := range o.MembersSnapshot() {
+	for _, member := range o.ActiveSessionMembers() {
 		if member.Slug != lead {
 			agentOrder = append(agentOrder, member)
 		}
@@ -187,12 +189,13 @@ func (o *officeTargeter) AgentOrder() []officeMember {
 }
 
 // PaneSlugs returns the slug list in spawn order. In 1:1 mode it returns
-// just the active 1:1 agent.
+// just the active 1:1 agent. Like AgentOrder, drives off ActiveSessionMembers
+// so pack order is deterministic regardless of broker snapshot order.
 func (o *officeTargeter) PaneSlugs() []string {
 	if o.isOneOnOne != nil && o.isOneOnOne() {
 		return []string{o.oneOnOneSlug()}
 	}
-	members := o.MembersSnapshot()
+	members := o.ActiveSessionMembers()
 	lead := o.LeadSlug()
 	var slugs []string
 	if lead != "" {

--- a/internal/team/office_targets.go
+++ b/internal/team/office_targets.go
@@ -14,12 +14,15 @@ package team
 //     launcher's *current* map reference. Required because
 //     reconfigureVisibleAgents nils l.failedPaneSlugs and the next pane-
 //     spawn failure rebuilds it; a cached map pointer here would become
-//     orphaned. The map is still unsynchronized — no mutex — but the
-//     race is dormant because trySpawnWebAgentPanes is a runtime-promotion
-//     fallback that nothing currently invokes (see launcher.go:2647 /
-//     3470). C5 (paneLifecycle) adds the mutex and replaces this with
-//     failedPane(slug) lookup, which is what the callback shape already
-//     anticipates.
+//     orphaned. The map is still unsynchronized — no mutex. Writers:
+//     (1) trySpawnWebAgentPanes (runtime-promotion fallback, currently
+//     unwired); (2) reconfigureVisibleAgents → recordPaneSpawnFailure on
+//     office_reseeded events, while peer goroutines (notifyAgentsLoop,
+//     notifyTaskActionsLoop, watchdogSchedulerLoop, ...) read
+//     concurrently via SkipPane / ShouldUseHeadlessForSlug. Race
+//     detector hasn't tripped only because integration tests don't
+//     exercise reseeds at scale — a dedicated mutex (or moving this to
+//     paneLifecycle in C5) is the right next step.
 
 import (
 	"fmt"

--- a/internal/team/office_targets.go
+++ b/internal/team/office_targets.go
@@ -1,0 +1,468 @@
+package team
+
+// office_targets.go owns the "which agent gets which pane / dispatch path"
+// decision tree that used to live as a dozen methods on Launcher. The split
+// (PLAN.md §C2) is justified because the logic is pure data-shape over a
+// snapshot of office membership — no goroutines, no tmux, no broker writes
+// — so it can be exercised by tests without a Launcher fixture.
+//
+// State sharing notes (PLAN.md §5 traps):
+//   - paneBackedFlag is a *bool aliased to launcher.paneBackedAgents. The
+//     pane-spawn path flips that bool deep inside trySpawnWebAgentPanes;
+//     reading via pointer keeps the targeter in sync without callbacks.
+//   - failedPaneSlugs is a shared map. Today it's read here, written by the
+//     pane-spawn path (still on Launcher). The shared-map race is pre-
+//     existing (writes happen sequentially during Launch); when C5 lands
+//     paneLifecycle this becomes failedPane(slug) func, removing the dangle.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// officeTargeter owns office-membership-shape and routing-decision logic.
+// All inputs come in via either captured-at-construction values (sessionName,
+// pack, provider) or callbacks (snapshotMembers, isOneOnOne, ...). The type
+// is package-internal; callers in package team get to it via Launcher.targets().
+type officeTargeter struct {
+	sessionName string
+	pack        *agent.PackDefinition
+	cwd         string
+	provider    string
+
+	// paneBackedFlag is a back-pointer to launcher.paneBackedAgents so the
+	// targeter sees the live value as the spawn path flips it. Required —
+	// duplicating the flag would cause every notification to route through
+	// the headless path silently when panes were actually live (PLAN.md §5.2).
+	paneBackedFlag *bool
+
+	// failedPaneSlugs is the shared map of slugs whose pane spawn failed.
+	// Written by the pane-spawn path on Launcher; read here. Map sharing
+	// across types is a deliberate transitional state — see file header.
+	failedPaneSlugs map[string]string
+
+	// Live-state callbacks. Pulled rather than pushed so tests can stub.
+	isOneOnOne         func() bool
+	oneOnOneSlug       func() string
+	isChannelDM        func(channelSlug string) (bool, string)
+	snapshotMembers    func() []officeMember
+	memberProviderKind func(slug string) string
+}
+
+// MembersSnapshot returns the current member roster. Backed by the
+// snapshotMembers callback so the targeter never knows about FS reads or
+// broker calls itself.
+func (o *officeTargeter) MembersSnapshot() []officeMember {
+	if o == nil || o.snapshotMembers == nil {
+		return nil
+	}
+	return o.snapshotMembers()
+}
+
+// MemberBySlug walks the snapshot and returns the matching member, or a
+// minimal officeMember{Slug, Name=Slug, Role=Slug} fallback so callers
+// always get a well-formed value. The fallback shape matters for prompt
+// generation, which interpolates Name into the system prompt header.
+func (o *officeTargeter) MemberBySlug(slug string) officeMember {
+	for _, m := range o.MembersSnapshot() {
+		if m.Slug == slug {
+			return m
+		}
+	}
+	return officeMember{Slug: slug, Name: slug, Role: slug}
+}
+
+// LeadSlug picks the team lead. Pack-defined lead wins; otherwise fall
+// back to the first BuiltIn member, then to the first member overall.
+// Mirrors the previous Launcher.officeLeadSlug fallback chain so prompt
+// caching keys remain stable across refactors.
+func (o *officeTargeter) LeadSlug() string {
+	if o == nil {
+		return ""
+	}
+	if o.pack != nil && strings.TrimSpace(o.pack.LeadSlug) != "" {
+		return o.pack.LeadSlug
+	}
+	return officeLeadSlugFrom(o.ActiveSessionMembers())
+}
+
+// officeLeadSlugFrom is a free function (kept package-level) so the prompt
+// builder can derive the lead from an already-loaded member snapshot
+// without a redundant snapshotMembers call.
+func officeLeadSlugFrom(members []officeMember) string {
+	for _, member := range members {
+		if member.Slug == "ceo" {
+			return "ceo"
+		}
+	}
+	for _, member := range members {
+		if member.BuiltIn {
+			return member.Slug
+		}
+	}
+	if len(members) > 0 {
+		return members[0].Slug
+	}
+	return ""
+}
+
+// ActiveSessionMembers returns the current member list ordered by pack
+// position, with broker-only (wizard-hired) members appended at the end.
+// Pack-order matters because the UI/pane layout uses this list directly:
+// reordering would shuffle pane indices on every Launch.
+func (o *officeTargeter) ActiveSessionMembers() []officeMember {
+	members := o.MembersSnapshot()
+	if o == nil || o.pack == nil || len(o.pack.Agents) == 0 {
+		return members
+	}
+	bySlug := make(map[string]officeMember, len(members))
+	for _, member := range members {
+		bySlug[member.Slug] = member
+	}
+	filtered := make([]officeMember, 0, len(members))
+	seen := make(map[string]struct{}, len(members))
+	for _, cfg := range o.pack.Agents {
+		if member, ok := bySlug[cfg.Slug]; ok {
+			filtered = append(filtered, member)
+			seen[cfg.Slug] = struct{}{}
+			continue
+		}
+		member := officeMember{
+			Slug:           cfg.Slug,
+			Name:           cfg.Name,
+			Role:           cfg.Name,
+			Expertise:      append([]string(nil), cfg.Expertise...),
+			Personality:    cfg.Personality,
+			PermissionMode: cfg.PermissionMode,
+			AllowedTools:   append([]string(nil), cfg.AllowedTools...),
+			BuiltIn:        cfg.Slug == o.pack.LeadSlug || cfg.Slug == "ceo",
+		}
+		applyOfficeMemberDefaults(&member)
+		filtered = append(filtered, member)
+		seen[cfg.Slug] = struct{}{}
+	}
+	for _, member := range members {
+		if _, ok := seen[member.Slug]; ok {
+			continue
+		}
+		filtered = append(filtered, member)
+	}
+	if len(filtered) > 0 {
+		return filtered
+	}
+	return members
+}
+
+// NameFor returns the display name for a slug; falls back to the slug
+// itself when no member or an unnamed member matches.
+func (o *officeTargeter) NameFor(slug string) string {
+	if member := o.MemberBySlug(slug); member.Name != "" {
+		return member.Name
+	}
+	return slug
+}
+
+// AgentOrder returns the member roster with the lead slug always first.
+// Used by pane spawn to guarantee the CEO pane lands at index 1.
+func (o *officeTargeter) AgentOrder() []officeMember {
+	var agentOrder []officeMember
+	lead := o.LeadSlug()
+	for _, member := range o.MembersSnapshot() {
+		if member.Slug == lead {
+			agentOrder = append([]officeMember{member}, agentOrder...)
+		}
+	}
+	for _, member := range o.MembersSnapshot() {
+		if member.Slug != lead {
+			agentOrder = append(agentOrder, member)
+		}
+	}
+	return agentOrder
+}
+
+// PaneSlugs returns the slug list in spawn order. In 1:1 mode it returns
+// just the active 1:1 agent.
+func (o *officeTargeter) PaneSlugs() []string {
+	if o.isOneOnOne != nil && o.isOneOnOne() {
+		return []string{o.oneOnOneSlug()}
+	}
+	members := o.MembersSnapshot()
+	lead := o.LeadSlug()
+	var slugs []string
+	if lead != "" {
+		slugs = append(slugs, lead)
+	}
+	for _, member := range members {
+		if member.Slug == lead {
+			continue
+		}
+		slugs = append(slugs, member.Slug)
+	}
+	return slugs
+}
+
+// VisibleMembers returns the agents that occupy the visible tmux pane grid
+// (lead first, then up to maxVisibleOfficeAgents-1 others). 1:1 mode
+// collapses to a single member.
+func (o *officeTargeter) VisibleMembers() []officeMember {
+	if o.isOneOnOne != nil && o.isOneOnOne() {
+		return []officeMember{o.MemberBySlug(o.oneOnOneSlug())}
+	}
+	ordered := o.PaneEligibleMembers()
+	if len(ordered) <= maxVisibleOfficeAgents {
+		return ordered
+	}
+	return ordered[:maxVisibleOfficeAgents]
+}
+
+// OverflowMembers returns agents beyond the visible grid; each gets its
+// own dedicated tmux window (named via overflowWindowName).
+func (o *officeTargeter) OverflowMembers() []officeMember {
+	if o.isOneOnOne != nil && o.isOneOnOne() {
+		return nil
+	}
+	ordered := o.PaneEligibleMembers()
+	if len(ordered) <= maxVisibleOfficeAgents {
+		return nil
+	}
+	return ordered[maxVisibleOfficeAgents:]
+}
+
+// PaneEligibleMembers is AgentOrder() minus members whose runtime is not
+// pane-eligible (Codex, Opencode). Filtering upstream keeps visible/overflow
+// indices in sync with PaneTargets().
+func (o *officeTargeter) PaneEligibleMembers() []officeMember {
+	ordered := o.AgentOrder()
+	filtered := make([]officeMember, 0, len(ordered))
+	for _, m := range ordered {
+		if o.MemberUsesHeadlessOneShotRuntime(m.Slug) {
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	return filtered
+}
+
+// PaneTargets returns slug→pane-address for every agent that should
+// receive notifications by typing into a live tmux pane. Returns empty
+// when panes aren't live (paneBackedFlag=false) so callers consistently
+// fall through to the headless dispatcher.
+func (o *officeTargeter) PaneTargets() map[string]notificationTarget {
+	targets := make(map[string]notificationTarget)
+	if o == nil || o.paneBackedFlag == nil || !*o.paneBackedFlag {
+		return targets
+	}
+	if o.isOneOnOne != nil && o.isOneOnOne() {
+		slug := o.oneOnOneSlug()
+		if slug != "" && !o.SkipPane(slug) {
+			targets[slug] = notificationTarget{
+				Slug:       slug,
+				PaneTarget: fmt.Sprintf("%s:team.1", o.sessionName),
+			}
+		}
+		return targets
+	}
+	for i, member := range o.VisibleMembers() {
+		if o.SkipPane(member.Slug) {
+			continue
+		}
+		targets[member.Slug] = notificationTarget{
+			Slug:       member.Slug,
+			PaneTarget: fmt.Sprintf("%s:team.%d", o.sessionName, i+1),
+		}
+	}
+	for _, member := range o.OverflowMembers() {
+		if o.SkipPane(member.Slug) {
+			continue
+		}
+		targets[member.Slug] = notificationTarget{
+			Slug:       member.Slug,
+			PaneTarget: fmt.Sprintf("%s:%s.0", o.sessionName, overflowWindowName(member.Slug)),
+		}
+	}
+	return targets
+}
+
+// NotificationTargets layers headless fallback entries on top of the pane
+// target map. An agent without a pane target — either because pane spawn
+// failed or because its provider is non-pane — still gets a target entry
+// (with empty PaneTarget) so dispatch can route it through the headless
+// queue.
+func (o *officeTargeter) NotificationTargets() map[string]notificationTarget {
+	targets := o.PaneTargets()
+	if o == nil {
+		return targets
+	}
+	addHeadless := func(slug string) {
+		slug = strings.TrimSpace(slug)
+		if slug == "" {
+			return
+		}
+		if _, ok := targets[slug]; ok {
+			return
+		}
+		if o.ShouldUseHeadlessForSlug(slug) {
+			targets[slug] = notificationTarget{Slug: slug}
+		}
+	}
+	if o.isOneOnOne != nil && o.isOneOnOne() {
+		addHeadless(o.oneOnOneSlug())
+		return targets
+	}
+	addHeadless(o.LeadSlug())
+	for _, member := range o.ActiveSessionMembers() {
+		addHeadless(member.Slug)
+	}
+	return targets
+}
+
+// ResolvePaneTarget returns the live pane address for slug, or
+// ("", false) when slug isn't pane-backed (codex/opencode agents,
+// failed-pane fallbacks, or empty slugs).
+func (o *officeTargeter) ResolvePaneTarget(slug string) (string, bool) {
+	if o == nil || strings.TrimSpace(slug) == "" {
+		return "", false
+	}
+	targets := o.PaneTargets()
+	target, ok := targets[slug]
+	if !ok {
+		return "", false
+	}
+	return target.PaneTarget, true
+}
+
+// IsChannelDM proxies to the wired channel-DM resolver. Returns false,
+// "" when nothing is wired so callers don't need a nil-check.
+func (o *officeTargeter) IsChannelDM(channelSlug string) (bool, string) {
+	if o == nil || o.isChannelDM == nil {
+		return false, ""
+	}
+	return o.isChannelDM(channelSlug)
+}
+
+// ShouldUseHeadless returns true when notifications must go through the
+// headless `claude --print` queue rather than into a live pane. The
+// install-wide answer based on provider + paneBacked state.
+func (o *officeTargeter) ShouldUseHeadless() bool {
+	if !o.UsesPaneRuntime() {
+		return true
+	}
+	if o.paneBackedFlag == nil {
+		return true
+	}
+	return !*o.paneBackedFlag
+}
+
+// ShouldUseHeadlessForSlug answers the same question per-slug. Layered on
+// top of ShouldUseHeadless: an individual slug can be forced headless even
+// in a pane-backed install (Codex member, failed pane spawn).
+func (o *officeTargeter) ShouldUseHeadlessForSlug(slug string) bool {
+	if o == nil || strings.TrimSpace(slug) == "" {
+		return false
+	}
+	if o.ShouldUseHeadless() {
+		return true
+	}
+	if o.MemberUsesHeadlessOneShotRuntime(slug) {
+		return true
+	}
+	if _, failed := o.failedPaneSlugs[strings.TrimSpace(slug)]; failed {
+		return true
+	}
+	return false
+}
+
+// ShouldUseHeadlessForTarget treats a target with an empty PaneTarget as
+// implicitly headless. Used by the dispatch hot path.
+func (o *officeTargeter) ShouldUseHeadlessForTarget(target notificationTarget) bool {
+	if o == nil {
+		return false
+	}
+	if o.ShouldUseHeadlessForSlug(target.Slug) {
+		return true
+	}
+	return strings.TrimSpace(target.PaneTarget) == ""
+}
+
+// SkipPane reports whether slug should be excluded from pane spawn /
+// pane-target maps. True when the slug is empty, when its pane spawn
+// previously failed, or when its runtime isn't pane-eligible.
+func (o *officeTargeter) SkipPane(slug string) bool {
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return true
+	}
+	if _, bad := o.failedPaneSlugs[slug]; bad {
+		return true
+	}
+	if o.MemberUsesHeadlessOneShotRuntime(slug) {
+		return true
+	}
+	return false
+}
+
+// UsesPaneRuntime reports whether the install-wide provider supports
+// interactive panes. Provider Registry-driven so future providers don't
+// need code changes here.
+func (o *officeTargeter) UsesPaneRuntime() bool {
+	return provider.CapabilitiesFor(normalizeProviderKind(o.provider)).PaneEligible
+}
+
+// RequiresClaudeSessionReset reports whether the install-wide provider
+// populates the Claude session store and therefore needs
+// provider.ResetClaudeSessions to run on ResetSession / ReconfigureSession.
+// Today only Claude Code does.
+func (o *officeTargeter) RequiresClaudeSessionReset() bool {
+	return provider.CapabilitiesFor(normalizeProviderKind(o.provider)).RequiresClaudeSessionReset
+}
+
+// MemberEffectiveProviderKind returns the provider kind that should run
+// the given agent's next turn. Lookup order: per-member override (set via
+// /agent create --provider=X or the hire-agent modal), then the
+// install-wide provider.
+func (o *officeTargeter) MemberEffectiveProviderKind(slug string) string {
+	if o.memberProviderKind != nil {
+		if kind := o.memberProviderKind(slug); kind != "" {
+			return normalizeProviderKind(kind)
+		}
+	}
+	return normalizeProviderKind(o.provider)
+}
+
+// MemberUsesHeadlessOneShotRuntime reports whether the given agent is bound
+// to a non-pane-eligible runtime and therefore skips the tmux/claude pane
+// infrastructure in favor of the broker-driven headless queue.
+func (o *officeTargeter) MemberUsesHeadlessOneShotRuntime(slug string) bool {
+	kind := o.MemberEffectiveProviderKind(slug)
+	return !provider.CapabilitiesFor(kind).PaneEligible
+}
+
+// overflowWindowName is package-level so the pane-lifecycle code (which
+// will move in C5) can keep calling it during the transitional state.
+func overflowWindowName(slug string) string {
+	return "agent-" + strings.TrimSpace(slug)
+}
+
+// normalizeProviderKind trims and canonicalizes provider kinds while
+// preserving unknown values so dispatch code can surface explicit errors.
+// Free function (used by tests, dispatch code, and the targeter itself).
+func normalizeProviderKind(raw string) string {
+	k := strings.ToLower(strings.TrimSpace(raw))
+	switch k {
+	case "claude", "":
+		return provider.KindClaudeCode
+	case "codex":
+		return provider.KindCodex
+	case "opencode":
+		return provider.KindOpencode
+	case "claude-code", "openclaw":
+		return k
+	default:
+		return k
+	}
+}
+
+const maxVisibleOfficeAgents = 5

--- a/internal/team/office_targets_test.go
+++ b/internal/team/office_targets_test.go
@@ -1,0 +1,445 @@
+package team
+
+// Tests for the extracted officeTargeter type. Written test-first against
+// the surface in PLAN.md §C2 before the type exists, so the first run is a
+// compile failure by design.
+//
+// Coverage focus: the routing-decision branches that were 0% before
+// (overflow window naming, pane-failed fallback, headless-one-shot routing,
+// 1:1 mode collapsing the targets map). Most existing tests reach this
+// surface via &Launcher{...}; the new tests exercise the type directly so
+// we don't need a tmux-shaped fixture to assert pane address formats.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/provider"
+)
+
+// fixtureTargeter builds an officeTargeter with sane defaults; tests
+// override only the bits they care about.
+func fixtureTargeter(t *testing.T, members []officeMember, opts ...func(*officeTargeter)) *officeTargeter {
+	t.Helper()
+	paneBacked := true
+	failed := map[string]string{}
+	tg := &officeTargeter{
+		sessionName:     "test-sess",
+		pack:            &agent.PackDefinition{LeadSlug: "ceo"},
+		provider:        provider.KindClaudeCode,
+		paneBackedFlag:  &paneBacked,
+		failedPaneSlugs: failed,
+		isOneOnOne:      func() bool { return false },
+		oneOnOneSlug:    func() string { return "" },
+		isChannelDM:     func(string) (bool, string) { return false, "" },
+		snapshotMembers: func() []officeMember {
+			return append([]officeMember(nil), members...)
+		},
+		memberProviderKind: func(string) string { return "" },
+	}
+	for _, opt := range opts {
+		opt(tg)
+	}
+	return tg
+}
+
+func TestTargeter_LeadSlug_PrefersPackLead(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+	})
+	if got := tg.LeadSlug(); got != "ceo" {
+		t.Errorf("LeadSlug() = %q, want %q", got, "ceo")
+	}
+}
+
+func TestTargeter_LeadSlug_FallsBackToBuiltIn(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "alpha", BuiltIn: true},
+		{Slug: "beta"},
+	}, func(o *officeTargeter) { o.pack = &agent.PackDefinition{} })
+	if got := tg.LeadSlug(); got != "alpha" {
+		t.Errorf("LeadSlug() = %q, want %q", got, "alpha")
+	}
+}
+
+func TestTargeter_LeadSlug_FallsBackToFirstMember(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "alpha"},
+		{Slug: "beta"},
+	}, func(o *officeTargeter) { o.pack = &agent.PackDefinition{} })
+	if got := tg.LeadSlug(); got != "alpha" {
+		t.Errorf("LeadSlug() = %q, want %q", got, "alpha")
+	}
+}
+
+func TestTargeter_LeadSlug_EmptyWhenNoMembers(t *testing.T) {
+	tg := fixtureTargeter(t, nil, func(o *officeTargeter) { o.pack = &agent.PackDefinition{} })
+	if got := tg.LeadSlug(); got != "" {
+		t.Errorf("LeadSlug() = %q, want empty", got)
+	}
+}
+
+func TestTargeter_AgentOrder_LeadFirst(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "fe"},
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "be"},
+	})
+	got := tg.AgentOrder()
+	if len(got) == 0 || got[0].Slug != "ceo" {
+		t.Fatalf("AgentOrder()[0] = %v, want ceo first; full: %v", got, got)
+	}
+}
+
+func TestTargeter_PaneEligibleMembers_ExcludesHeadlessOneShot(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "codexer"},
+	}, func(o *officeTargeter) {
+		o.memberProviderKind = func(slug string) string {
+			if slug == "codexer" {
+				return provider.KindCodex
+			}
+			return ""
+		}
+	})
+	got := tg.PaneEligibleMembers()
+	for _, m := range got {
+		if m.Slug == "codexer" {
+			t.Fatalf("PaneEligibleMembers should exclude headless-one-shot member; got %v", got)
+		}
+	}
+}
+
+func TestTargeter_VisibleAndOverflow_RespectsCap(t *testing.T) {
+	members := []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+	}
+	for _, s := range []string{"a", "b", "c", "d", "e", "f"} {
+		members = append(members, officeMember{Slug: s})
+	}
+	tg := fixtureTargeter(t, members)
+	visible := tg.VisibleMembers()
+	overflow := tg.OverflowMembers()
+	if len(visible) != maxVisibleOfficeAgents {
+		t.Fatalf("VisibleMembers length = %d, want %d", len(visible), maxVisibleOfficeAgents)
+	}
+	if len(visible)+len(overflow) != len(members) {
+		t.Fatalf("visible+overflow = %d, want %d", len(visible)+len(overflow), len(members))
+	}
+	if visible[0].Slug != "ceo" {
+		t.Errorf("VisibleMembers[0] = %q, want ceo first", visible[0].Slug)
+	}
+}
+
+func TestTargeter_OverflowWindowName(t *testing.T) {
+	if got := overflowWindowName("designer"); got != "agent-designer" {
+		t.Errorf("overflowWindowName(designer) = %q, want agent-designer", got)
+	}
+}
+
+func TestTargeter_PaneTargets_OneOnOne(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+	}, func(o *officeTargeter) {
+		o.isOneOnOne = func() bool { return true }
+		o.oneOnOneSlug = func() string { return "fe" }
+	})
+	targets := tg.PaneTargets()
+	if len(targets) != 1 {
+		t.Fatalf("PaneTargets() len = %d, want 1; got %v", len(targets), targets)
+	}
+	tgt, ok := targets["fe"]
+	if !ok {
+		t.Fatalf("PaneTargets() missing fe entry: %v", targets)
+	}
+	if tgt.PaneTarget != "test-sess:team.1" {
+		t.Errorf("PaneTarget = %q, want test-sess:team.1", tgt.PaneTarget)
+	}
+}
+
+func TestTargeter_PaneTargets_VisibleAndOverflowAddresses(t *testing.T) {
+	members := []officeMember{{Slug: "ceo", BuiltIn: true}}
+	for _, s := range []string{"a", "b", "c", "d", "e", "f"} {
+		members = append(members, officeMember{Slug: s})
+	}
+	tg := fixtureTargeter(t, members)
+	targets := tg.PaneTargets()
+
+	// First 5 entries are addressed test-sess:team.{1..5} in pack order.
+	visible := tg.VisibleMembers()
+	for i, m := range visible {
+		want := "test-sess:team." + itoa(i+1)
+		if got := targets[m.Slug].PaneTarget; got != want {
+			t.Errorf("PaneTarget[%s] = %q, want %q", m.Slug, got, want)
+		}
+	}
+	// Overflow: each in its own window addressed test-sess:agent-{slug}.0
+	overflow := tg.OverflowMembers()
+	for _, m := range overflow {
+		want := "test-sess:agent-" + m.Slug + ".0"
+		if got := targets[m.Slug].PaneTarget; got != want {
+			t.Errorf("PaneTarget[%s] (overflow) = %q, want %q", m.Slug, got, want)
+		}
+	}
+}
+
+func TestTargeter_PaneTargets_EmptyWhenNotPaneBacked(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{{Slug: "ceo", BuiltIn: true}}, func(o *officeTargeter) {
+		f := false
+		o.paneBackedFlag = &f
+	})
+	if targets := tg.PaneTargets(); len(targets) != 0 {
+		t.Fatalf("PaneTargets when not pane-backed should be empty, got %v", targets)
+	}
+}
+
+func TestTargeter_PaneTargets_SkipsFailedSlugs(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+	}, func(o *officeTargeter) {
+		o.failedPaneSlugs["fe"] = "boom"
+	})
+	targets := tg.PaneTargets()
+	if _, ok := targets["fe"]; ok {
+		t.Fatalf("expected fe to be skipped from PaneTargets when in failedPaneSlugs; got %v", targets)
+	}
+	if _, ok := targets["ceo"]; !ok {
+		t.Fatalf("expected ceo to remain in PaneTargets")
+	}
+}
+
+func TestTargeter_NotificationTargets_AddsHeadlessFallbackForFailedPaneSlug(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+	}, func(o *officeTargeter) {
+		o.failedPaneSlugs["fe"] = "spawn failed"
+	})
+	targets := tg.NotificationTargets()
+	tgt, ok := targets["fe"]
+	if !ok {
+		t.Fatalf("NotificationTargets missing fe: %v", targets)
+	}
+	if tgt.PaneTarget != "" {
+		t.Errorf("fe should fall back to headless (empty PaneTarget); got %q", tgt.PaneTarget)
+	}
+}
+
+func TestTargeter_NotificationTargets_OneOnOneCollapsesToSingleAgent(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+	}, func(o *officeTargeter) {
+		o.isOneOnOne = func() bool { return true }
+		o.oneOnOneSlug = func() string { return "fe" }
+	})
+	targets := tg.NotificationTargets()
+	if _, ok := targets["fe"]; !ok {
+		t.Fatalf("expected fe in NotificationTargets, got %v", targets)
+	}
+	if _, ok := targets["ceo"]; ok {
+		t.Fatalf("ceo should be excluded in 1:1 mode, got %v", targets)
+	}
+}
+
+func TestTargeter_ShouldUseHeadlessForSlug_TruthTable(t *testing.T) {
+	cases := []struct {
+		name   string
+		setup  func(*officeTargeter)
+		slug   string
+		want   bool
+		reason string
+	}{
+		{
+			name: "non-pane runtime ⇒ headless",
+			setup: func(o *officeTargeter) {
+				o.provider = provider.KindCodex
+			},
+			slug: "ceo", want: true, reason: "codex provider is non-pane",
+		},
+		{
+			name:  "pane runtime + pane backed + clean slug ⇒ pane",
+			setup: func(*officeTargeter) {},
+			slug:  "ceo", want: false, reason: "default Claude path",
+		},
+		{
+			name: "pane runtime + not pane backed ⇒ headless",
+			setup: func(o *officeTargeter) {
+				f := false
+				o.paneBackedFlag = &f
+			},
+			slug: "ceo", want: true, reason: "no live panes",
+		},
+		{
+			name: "pane runtime + failed pane slug ⇒ headless",
+			setup: func(o *officeTargeter) {
+				o.failedPaneSlugs["ceo"] = "spawn failed"
+			},
+			slug: "ceo", want: true, reason: "fallback path",
+		},
+		{
+			name: "pane runtime + member bound to codex ⇒ headless",
+			setup: func(o *officeTargeter) {
+				o.memberProviderKind = func(slug string) string {
+					if slug == "ceo" {
+						return provider.KindCodex
+					}
+					return ""
+				}
+			},
+			slug: "ceo", want: true, reason: "per-member provider override",
+		},
+		{
+			name:  "empty slug ⇒ false (defensive)",
+			setup: func(*officeTargeter) {},
+			slug:  "  ", want: false, reason: "no slug, no decision",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tg := fixtureTargeter(t, []officeMember{{Slug: "ceo", BuiltIn: true}}, tc.setup)
+			if got := tg.ShouldUseHeadlessForSlug(tc.slug); got != tc.want {
+				t.Errorf("ShouldUseHeadlessForSlug(%q) = %v, want %v (%s)", tc.slug, got, tc.want, tc.reason)
+			}
+		})
+	}
+}
+
+func TestTargeter_ShouldUseHeadlessForTarget_EmptyPaneTargetIsHeadless(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{{Slug: "ceo", BuiltIn: true}})
+	if !tg.ShouldUseHeadlessForTarget(notificationTarget{Slug: "ceo", PaneTarget: ""}) {
+		t.Errorf("empty PaneTarget should mean headless dispatch")
+	}
+}
+
+func TestTargeter_SkipPane_FailedAndHeadlessOneShot(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", BuiltIn: true},
+		{Slug: "fe"},
+		{Slug: "codexer"},
+	}, func(o *officeTargeter) {
+		o.failedPaneSlugs["fe"] = "boom"
+		o.memberProviderKind = func(s string) string {
+			if s == "codexer" {
+				return provider.KindCodex
+			}
+			return ""
+		}
+	})
+	if !tg.SkipPane("fe") {
+		t.Errorf("SkipPane(fe) = false, want true (failed pane)")
+	}
+	if !tg.SkipPane("codexer") {
+		t.Errorf("SkipPane(codexer) = false, want true (headless one-shot)")
+	}
+	if !tg.SkipPane("  ") {
+		t.Errorf("SkipPane(empty) should be true")
+	}
+	if tg.SkipPane("ceo") {
+		t.Errorf("SkipPane(ceo) = true, want false")
+	}
+}
+
+func TestTargeter_NameFor_FallsBackToSlug(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{
+		{Slug: "ceo", Name: "Chief"},
+		{Slug: "ghost"}, // no Name
+	})
+	if got := tg.NameFor("ceo"); got != "Chief" {
+		t.Errorf("NameFor(ceo) = %q, want Chief", got)
+	}
+	if got := tg.NameFor("ghost"); got != "ghost" {
+		t.Errorf("NameFor(ghost) = %q, want ghost (slug fallback)", got)
+	}
+}
+
+func TestTargeter_ResolvePaneTarget_FoundAndMissing(t *testing.T) {
+	tg := fixtureTargeter(t, []officeMember{{Slug: "ceo", BuiltIn: true}})
+	addr, ok := tg.ResolvePaneTarget("ceo")
+	if !ok || addr == "" {
+		t.Errorf("ResolvePaneTarget(ceo) = (%q, %v), want (non-empty, true)", addr, ok)
+	}
+	if addr, ok := tg.ResolvePaneTarget("nope"); ok || addr != "" {
+		t.Errorf("ResolvePaneTarget(nope) = (%q, %v), want empty,false", addr, ok)
+	}
+}
+
+func TestTargeter_ProviderCapabilityHelpers(t *testing.T) {
+	tg := fixtureTargeter(t, nil)
+	if !tg.UsesPaneRuntime() {
+		t.Errorf("Claude default should be pane-eligible")
+	}
+	if !tg.RequiresClaudeSessionReset() {
+		t.Errorf("Claude default should require session reset")
+	}
+	tg.provider = provider.KindCodex
+	if tg.UsesPaneRuntime() {
+		t.Errorf("Codex must not be pane-eligible")
+	}
+	if tg.RequiresClaudeSessionReset() {
+		t.Errorf("Codex must not require Claude session reset")
+	}
+}
+
+func TestOfficeLeadSlugFrom_PrefersCEO(t *testing.T) {
+	got := officeLeadSlugFrom([]officeMember{
+		{Slug: "alpha", BuiltIn: true},
+		{Slug: "ceo"},
+	})
+	if got != "ceo" {
+		t.Errorf("officeLeadSlugFrom should prefer ceo, got %q", got)
+	}
+}
+
+// itoa avoids depending on strconv just for one call site in this test file.
+func itoa(n int) string {
+	var buf [12]byte
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}
+
+// Sanity: ensure tests can also drive through Launcher.targets() and get
+// the same answers. Catches the wiring step where Launcher constructs the
+// targeter and shares state with it.
+func TestLauncher_TargeterWiringMatchesPaneTargets(t *testing.T) {
+	l := &Launcher{
+		sessionName:      "wuphf-team",
+		paneBackedAgents: true,
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend"},
+			},
+		},
+		failedPaneSlugs: map[string]string{},
+	}
+	got := l.agentPaneTargets()
+	if _, ok := got["ceo"]; !ok {
+		t.Fatalf("expected ceo in launcher pane targets, got %v", got)
+	}
+	if !strings.Contains(got["ceo"].PaneTarget, "wuphf-team:team.") {
+		t.Fatalf("expected wuphf-team:team.* address, got %q", got["ceo"].PaneTarget)
+	}
+}

--- a/internal/team/office_targets_test.go
+++ b/internal/team/office_targets_test.go
@@ -29,7 +29,7 @@ func fixtureTargeter(t *testing.T, members []officeMember, opts ...func(*officeT
 		pack:            &agent.PackDefinition{LeadSlug: "ceo"},
 		provider:        provider.KindClaudeCode,
 		paneBackedFlag:  &paneBacked,
-		failedPaneSlugs: failed,
+		failedPaneSlugs: func() map[string]string { return failed },
 		isOneOnOne:      func() bool { return false },
 		oneOnOneSlug:    func() string { return "" },
 		isChannelDM: func(channelSlug string) (bool, string) {
@@ -99,6 +99,56 @@ func TestTargeter_AgentOrder_LeadFirst(t *testing.T) {
 	got := tg.AgentOrder()
 	if len(got) == 0 || got[0].Slug != "ceo" {
 		t.Fatalf("AgentOrder()[0] = %v, want ceo first; full: %v", got, got)
+	}
+}
+
+// Regression: officeLeadSlugFrom must be order-independent. Pre-fix,
+// for installs without pack.LeadSlug, without a "ceo" member, and with
+// no BuiltIn member, the function returned `members[0].Slug` — which
+// shifted between callers depending on whether they passed sorted-by-slug
+// order or pack/snapshot order. Now the function sorts internally.
+func TestOfficeLeadSlugFrom_DeterministicAcrossInputOrders(t *testing.T) {
+	a := []officeMember{{Slug: "zeta"}, {Slug: "alpha"}, {Slug: "mu"}}
+	b := []officeMember{{Slug: "alpha"}, {Slug: "mu"}, {Slug: "zeta"}}
+	c := []officeMember{{Slug: "mu"}, {Slug: "zeta"}, {Slug: "alpha"}}
+	gotA := officeLeadSlugFrom(a)
+	gotB := officeLeadSlugFrom(b)
+	gotC := officeLeadSlugFrom(c)
+	if gotA != gotB || gotB != gotC {
+		t.Errorf("officeLeadSlugFrom output diverged across input orders: a=%q b=%q c=%q", gotA, gotB, gotC)
+	}
+	if gotA != "alpha" {
+		t.Errorf("expected sorted-fallback to pick alpha; got %q", gotA)
+	}
+}
+
+// Regression: when l.failedPaneSlugs is reset to nil (reconfigureVisibleAgents
+// does this) and then rebuilt by recordPaneSpawnFailure, the targeter
+// reads the *new* map, not a stale snapshot. Pre-fix, the targeter
+// captured the old map pointer at construction time and missed all later
+// spawn failures after a reconfigure.
+func TestTargeter_FailedPaneSlugs_FollowsLauncherReconfigure(t *testing.T) {
+	l := &Launcher{
+		sessionName:      "test",
+		paneBackedAgents: true,
+		pack: &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend"},
+			},
+		},
+		failedPaneSlugs: map[string]string{},
+	}
+	tg := l.targeter()
+	if tg.SkipPane("fe") {
+		t.Fatalf("fe should not be skipped before any failure recorded")
+	}
+	// Simulate reconfigure: nil the map, then record a new failure.
+	l.failedPaneSlugs = nil
+	l.recordPaneSpawnFailure("fe", "boom")
+	if !tg.SkipPane("fe") {
+		t.Errorf("targeter missed pane-spawn failure recorded after reconfigure — cache is holding stale map")
 	}
 }
 
@@ -251,7 +301,7 @@ func TestTargeter_PaneTargets_SkipsFailedSlugs(t *testing.T) {
 		{Slug: "ceo", BuiltIn: true},
 		{Slug: "fe"},
 	}, func(o *officeTargeter) {
-		o.failedPaneSlugs["fe"] = "boom"
+		o.failedPaneSlugs()["fe"] = "boom"
 	})
 	targets := tg.PaneTargets()
 	if _, ok := targets["fe"]; ok {
@@ -267,7 +317,7 @@ func TestTargeter_NotificationTargets_AddsHeadlessFallbackForFailedPaneSlug(t *t
 		{Slug: "ceo", BuiltIn: true},
 		{Slug: "fe"},
 	}, func(o *officeTargeter) {
-		o.failedPaneSlugs["fe"] = "spawn failed"
+		o.failedPaneSlugs()["fe"] = "spawn failed"
 	})
 	targets := tg.NotificationTargets()
 	tgt, ok := targets["fe"]
@@ -327,7 +377,7 @@ func TestTargeter_ShouldUseHeadlessForSlug_TruthTable(t *testing.T) {
 		{
 			name: "pane runtime + failed pane slug ⇒ headless",
 			setup: func(o *officeTargeter) {
-				o.failedPaneSlugs["ceo"] = "spawn failed"
+				o.failedPaneSlugs()["ceo"] = "spawn failed"
 			},
 			slug: "ceo", want: true, reason: "fallback path",
 		},
@@ -372,7 +422,7 @@ func TestTargeter_SkipPane_FailedAndHeadlessOneShot(t *testing.T) {
 		{Slug: "fe"},
 		{Slug: "codexer"},
 	}, func(o *officeTargeter) {
-		o.failedPaneSlugs["fe"] = "boom"
+		o.failedPaneSlugs()["fe"] = "boom"
 		o.memberProviderKind = func(s string) string {
 			if s == "codexer" {
 				return provider.KindCodex

--- a/internal/team/office_targets_test.go
+++ b/internal/team/office_targets_test.go
@@ -102,6 +102,46 @@ func TestTargeter_AgentOrder_LeadFirst(t *testing.T) {
 	}
 }
 
+// Regression: AgentOrder and PaneSlugs must follow pack.Agents order, not
+// the broker snapshot order. Pack indexing is the contract pane spawn
+// relies on, so a shuffled snapshot must not perturb the resulting order.
+func TestTargeter_AgentOrderAndPaneSlugs_FollowPackNotSnapshot(t *testing.T) {
+	// Snapshot order is intentionally non-pack: be, fe, ceo.
+	members := []officeMember{
+		{Slug: "be"},
+		{Slug: "fe"},
+		{Slug: "ceo", BuiltIn: true},
+	}
+	tg := fixtureTargeter(t, members, func(o *officeTargeter) {
+		// Pack order: ceo, fe, be — different from snapshot order.
+		o.pack = &agent.PackDefinition{
+			LeadSlug: "ceo",
+			Agents: []agent.AgentConfig{
+				{Slug: "ceo"}, {Slug: "fe"}, {Slug: "be"},
+			},
+		}
+	})
+	gotOrder := tg.AgentOrder()
+	wantSlugs := []string{"ceo", "fe", "be"}
+	if len(gotOrder) != len(wantSlugs) {
+		t.Fatalf("AgentOrder length = %d, want %d (got %+v)", len(gotOrder), len(wantSlugs), gotOrder)
+	}
+	for i, want := range wantSlugs {
+		if gotOrder[i].Slug != want {
+			t.Errorf("AgentOrder[%d] = %q, want %q (full: %+v)", i, gotOrder[i].Slug, want, gotOrder)
+		}
+	}
+	gotPane := tg.PaneSlugs()
+	if len(gotPane) != len(wantSlugs) {
+		t.Fatalf("PaneSlugs length = %d, want %d (got %+v)", len(gotPane), len(wantSlugs), gotPane)
+	}
+	for i, want := range wantSlugs {
+		if gotPane[i] != want {
+			t.Errorf("PaneSlugs[%d] = %q, want %q (full: %+v)", i, gotPane[i], want, gotPane)
+		}
+	}
+}
+
 func TestTargeter_PaneEligibleMembers_ExcludesHeadlessOneShot(t *testing.T) {
 	tg := fixtureTargeter(t, []officeMember{
 		{Slug: "ceo", BuiltIn: true},

--- a/internal/team/office_targets_test.go
+++ b/internal/team/office_targets_test.go
@@ -32,7 +32,16 @@ func fixtureTargeter(t *testing.T, members []officeMember, opts ...func(*officeT
 		failedPaneSlugs: failed,
 		isOneOnOne:      func() bool { return false },
 		oneOnOneSlug:    func() string { return "" },
-		isChannelDM:     func(string) (bool, string) { return false, "" },
+		isChannelDM: func(channelSlug string) (bool, string) {
+			// Mirror Launcher.isChannelDMRaw's legacy-prefix check so tests
+			// that pass channels like "dm-eng" route the same way as
+			// production. Tests that need pure no-DM semantics override
+			// this hook explicitly.
+			if IsDMSlug(channelSlug) {
+				return true, DMTargetAgent(channelSlug)
+			}
+			return false, ""
+		},
 		snapshotMembers: func() []officeMember {
 			return append([]officeMember(nil), members...)
 		},

--- a/internal/team/prompt_builder.go
+++ b/internal/team/prompt_builder.go
@@ -1,0 +1,393 @@
+package team
+
+// prompt_builder.go owns the per-agent system-prompt construction that used
+// to live on Launcher.buildPrompt. The split was driven by PLAN.md §C1: the
+// prompt body is pure string assembly with no goroutines or I/O, so it
+// belongs in its own type with a narrow constructor that takes
+// snapshot-style accessors. Tests can drive it directly without a Launcher.
+//
+// The launcher still owns "compute these snapshot accessors at the moment
+// the prompt is needed" via Launcher.newPromptBuilder; this file owns the
+// "given those snapshots, write the prompt" half.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// promptBuilder assembles the per-agent system prompt. All Launcher / Broker
+// state is accessed through callbacks captured at construction time, so the
+// builder has no transitive dependency on tmux, the broker, or goroutine
+// state.
+type promptBuilder struct {
+	isOneOnOne  func() bool
+	isFocusMode func() bool
+	packName    func() string
+	leadSlug    func() string
+	members     func() []officeMember
+	policies    func() []officePolicy
+	nameFor     func(slug string) string
+
+	// Captured-at-construction config flags. They control major branches
+	// (markdown notebook section, no-Nex fallbacks) and are stable for the
+	// lifetime of a launcher session, so they're snapshot once rather than
+	// re-resolved on every Build call.
+	markdownMemory bool
+	nexDisabled    bool
+}
+
+// Build returns the system prompt for the agent identified by slug. The
+// output is byte-stable across calls when the captured snapshots return the
+// same data — required for prompt caching to actually hit.
+func (p *promptBuilder) Build(slug string) string {
+	memberSnapshot := p.members()
+	var member officeMember
+	found := false
+	for _, m := range memberSnapshot {
+		if m.Slug == slug {
+			member = m
+			found = true
+			break
+		}
+	}
+	if !found {
+		member = officeMember{Slug: slug, Name: slug, Role: slug}
+	}
+	agentCfg := agentConfigFromMember(member)
+
+	// Sort by Slug so the prompt prefix is byte-identical across spawns for
+	// the same office; otherwise prompt caching (ANTHROPIC_PROMPT_CACHING=1)
+	// would miss on every turn just because member insertion order drifted.
+	officeMembers := append([]officeMember(nil), memberSnapshot...)
+	sort.Slice(officeMembers, func(i, j int) bool { return officeMembers[i].Slug < officeMembers[j].Slug })
+
+	lead := p.leadSlug()
+	markdownMemory := p.markdownMemory
+	noNex := p.nexDisabled
+
+	activePolicies := p.policies()
+
+	var sb strings.Builder
+	companyCtx := config.CompanyContextBlock()
+
+	if p.isOneOnOne() {
+		sb.WriteString(fmt.Sprintf("You are %s in a direct one-on-one WUPHF session with the human.\n\n", agentCfg.Name))
+		sb.WriteString(companyCtx)
+		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
+		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
+		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
+		sb.WriteString("== DIRECT SESSION ==\n")
+		sb.WriteString("This is not the shared office. There are no teammates, no channels, and no collaboration mechanics in this mode.\n")
+		sb.WriteString("You are only talking to the human.\n")
+		sb.WriteString("- team_poll: LAST RESORT — read recent 1:1 messages only if the pushed notification is missing context you genuinely need. Do NOT call this by default.\n")
+		sb.WriteString("- team_broadcast: Send a normal direct chat reply into the 1:1 conversation\n")
+		sb.WriteString("- human_message: Send an emphasized report, recommendation, or action card directly to the human when you want it to stand out\n")
+		sb.WriteString("- human_interview: Ask the human a cancelable interview question; it never blocks chat, and dismiss/send cancels it\n\n")
+		if noNex {
+			sb.WriteString("Nex tools are disabled for this run. Base your work on the conversation and direct human answers only.\n\n")
+		} else {
+			sb.WriteString("Use the Nex context graph when it materially helps:\n")
+			sb.WriteString("- query_context: Look up prior decisions, people, projects, and history before guessing\n")
+			sb.WriteString("- add_context: Store durable conclusions only after you have actually landed them\n\n")
+		}
+		sb.WriteString("RULES:\n")
+		sb.WriteString("1. Do not talk as if a team exists. There are no other agents in this session.\n")
+		sb.WriteString("2. Do not create or suggest channels, teammates, bridges, shared tasks, or office structure.\n")
+		sb.WriteString("3. Default to direct, useful conversation with the human. Keep it crisp and human.\n")
+		sb.WriteString("4. The pushed notification IS the latest state. Respond directly from it. Do NOT poll before replying.\n")
+		sb.WriteString("5. Use team_broadcast for normal replies. Use human_message only when you are deliberately presenting completion, a recommendation, or a next action.\n")
+		sb.WriteString("6. Use human_interview only for cancelable clarifications you can proceed without. If a decision must block your work, ask the human directly via human_message and wait for the answer.\n")
+		sb.WriteString("7. If Nex is enabled, do not claim something is stored unless add_context actually succeeded.\n")
+		sb.WriteString("8. No fake collaboration language like 'I'll ask the team' or 'let me route this'. It is just you and the human here.\n\n")
+		sb.WriteString("CONVERSATION STYLE:\n")
+		sb.WriteString("- Sound like a sharp human operator, not a formal assistant.\n")
+		sb.WriteString("- Be concise, direct, and a little alive.\n")
+		sb.WriteString("- Light humor is fine. Don't turn the 1:1 into a bit.\n")
+		sb.WriteString("- If the human asks for a plan, recommendation, explanation, or judgment you can reasonably give now, answer now.\n")
+		sb.WriteString("- Do not go silent and over-research by default. Only inspect files, run tools, or query Nex first when the answer genuinely depends on that context.\n")
+		sb.WriteString("- If you need a deeper pass, give the human the quick answer first, then continue with the deeper work.\n")
+		return sb.String()
+	}
+
+	if slug == lead {
+		sb.WriteString(fmt.Sprintf("You are the %s of the %s.\n\n", agentCfg.Name, p.packName()))
+		sb.WriteString(companyCtx)
+		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
+		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
+		sb.WriteString("== YOUR TEAM ==\n")
+		for _, member := range officeMembers {
+			if member.Slug == slug {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("- @%s (%s): %s\n", member.Slug, member.Name, strings.Join(member.Expertise, ", ")))
+		}
+		sb.WriteString("\n== TEAM CHANNEL ==\n")
+		sb.WriteString("Your tools default to the active conversation context.\n")
+		sb.WriteString("- team_broadcast: Post to channel. CRITICAL: text @-mentions alone do NOT wake agents — include the slug in the `tagged` parameter.\n")
+		sb.WriteString("- team_poll: LAST RESORT — read recent messages only when pushed context is genuinely missing something you need. Do NOT call this by default; the pushed notification already contains thread context, task state, and active agents.\n")
+		sb.WriteString("- team_bridge: Carry context from one channel into another (CEO only).\n")
+		sb.WriteString("- team_task: Create and assign tasks so ownership is explicit.\n")
+		sb.WriteString("- team_skill_run: Invoke a saved skill by name when the request matches one. Use this BEFORE routing or replying — it returns the canonical playbook content to follow and logs a visible skill_invocation in the channel.\n")
+		sb.WriteString("- team_skill_create: Create or propose a reusable skill through structured fields. Use action=create only as CEO when the human explicitly asked to create/activate a skill; use action=propose for proposed improvements from any agent.\n")
+		sb.WriteString("- team_action_connections / team_action_search / team_action_knowledge: inspect connected external systems and the exact action/workflow schema before you improvise. If connection listing is flaky, do NOT stop there; search/knowledge still give you the real action contract.\n")
+		sb.WriteString("- team_action_execute / team_action_workflow_execute: use these for real external reads, writes, and workflow runs. Prefer dry_run only when the task or policy says preview/mock first. When the provider is One and there is exactly one connected account for that platform, you may omit connection_key and let the runtime auto-resolve it.\n")
+		if markdownMemory {
+			sb.WriteString(markdownKnowledgeToolBlock())
+		}
+		sb.WriteString("- human_message: Present output or a recommendation directly to the human.\n")
+		sb.WriteString("- human_interview: Ask the human a cancelable interview question; it never blocks chat, and dismiss/send cancels it.\n")
+		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member, team_action_guide, team_action_workflow_create, team_action_workflow_schedule, team_action_relays, team_action_relay_event_types, team_action_relay_create, team_action_relay_activate, team_action_relay_events, team_action_relay_event.\n\n")
+		sb.WriteString("== TOOL HYGIENE ==\n")
+		sb.WriteString("All team_*, human_*, and mcp__wuphf-office__* tools listed above are ALREADY registered. Call them directly. Do NOT use ToolSearch/select: to look them up — that wastes a full turn.\n")
+		sb.WriteString("Do not read unrelated files (MEMORY.md, arbitrary docs) unless the current packet's task requires it. Every tool call pays full turn cost.\n")
+		sb.WriteString("Emit at most one team_broadcast per turn unless you are deliberately crossing channels. Never re-post the same content in different wording.\n\n")
+		if markdownMemory {
+			sb.WriteString(markdownKnowledgeMemoryBlock())
+		} else if noNex {
+			sb.WriteString("Nex tools are disabled for this run. Work only with the shared office channel and human answers.\n\n")
+		} else {
+			sb.WriteString("Nex memory: query_context before reinventing; add_context only after a decision is actually landed.\n\n")
+		}
+		if len(activePolicies) > 0 {
+			sb.WriteString("== ACTIVE OFFICE POLICIES ==\n")
+			sb.WriteString("Treat these as hard operating constraints, not suggestions. If a policy conflicts with an older chat assumption, the active policy wins until the human changes it.\n")
+			for _, policy := range activePolicies {
+				sb.WriteString(fmt.Sprintf("- %s\n", policy.Rule))
+			}
+			sb.WriteString("\n")
+		}
+		sb.WriteString("Tagged agents are expected to respond.\n\n")
+		if p.isFocusMode() {
+			sb.WriteString("== DELEGATION MODE ==\n")
+			sb.WriteString("You are the routing hub. Specialists only act when you or the human explicitly @tag them.\n")
+			sb.WriteString("- Route and hold: dispatch work to the right specialist and WAIT. Never do their work while they are working.\n")
+			sb.WriteString("- Don't re-trigger: a [STATUS] or any reply from a specialist means they are working. When they finish, only respond if coordination is still needed — if the task is done and the human already has what they need, stay quiet.\n")
+			sb.WriteString("- Specialists report up, not sideways: keep them out of cross-agent chatter. Coordinate through you.\n")
+			sb.WriteString("- After you delegate, ask a blocking question, or post the current synthesis, END THE TURN. Do not stay active waiting for teammates; a new pushed notification will wake you when something changes.\n\n")
+		}
+		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
+		sb.WriteString("YOUR ROLE AS LEADER:\n")
+		if markdownMemory {
+			sb.WriteString("1. On strategy or prior decisions, use wuphf_wiki_lookup or notebook_search before guessing\n")
+		} else if noNex {
+			sb.WriteString("1. Coordinate inside the office channel first and keep the team aligned there\n")
+		} else {
+			sb.WriteString("1. On strategy or prior decisions, call query_context early\n")
+		}
+		sb.WriteString("2. The pushed notification is authoritative — it contains thread context, task state, and agent activity. Respond directly from it. Do NOT call team_poll or team_tasks unless the notification explicitly says context is missing. Every unnecessary tool call burns tokens without adding value.\n")
+		sb.WriteString("3. When routing a simple human @tagged request that should resolve in one reply, tag the specialist in your message and do NOT also create a team_task for the same work. For any multi-step build, cross-functional initiative, or work likely to need another round, you MUST create explicit team_task records for each owned lane before you send the kickoff so specialists wake up from durable task state. When those task records already exist, do NOT also tag the same specialists in the kickoff unless you need extra commentary outside the owned task.\n")
+		sb.WriteString("4. Tag only the specialists who should weigh in. Unowned background chatter is a bug.\n")
+		sb.WriteString("5. Keep specialists in their lane and mostly offstage. You make the FINAL decision.\n")
+		sb.WriteString("6. Check team_requests before asking the human anything new\n")
+		sb.WriteString("7. Use human_message for direct human-facing output, human_interview for cancelable clarifications, and team_request for blocking decisions\n")
+		if markdownMemory {
+			sb.WriteString("8. When you lock a durable decision, write it to your notebook first and submit notebook_promote if it should become canonical wiki knowledge\n")
+		} else if noNex {
+			sb.WriteString("8. Summarize final decisions clearly in-channel\n")
+		} else {
+			sb.WriteString("8. When you lock a decision, call add_context before claiming it is stored\n")
+		}
+		sb.WriteString("9. Once decided, create durable task state first, then broadcast the kickoff and assignments. If you already know multiple owned lanes, prefer one team_plan call over several separate team_task creates. Every created task should set `task_type` and `execution_mode` deliberately instead of relying on inference.\n")
+		sb.WriteString("10. Choose task_type deliberately. Use `research` for audits/analysis, `launch` for GTM/rollout packages, `follow_up` for scoped office deliverables, and `feature` only for real implementation work. Do NOT label planning or audit work as `feature` just because it matters.\n")
+		sb.WriteString("11. If the human asks to build, ship, get something working, or run it end to end, your task graph MUST include at least one real execution lane that changes the repo or produces runnable business artifacts. A graph made only of planning, design, recommendations, or implementation-sequence tasks is a failure.\n")
+		sb.WriteString("12. Do not create engineering tasks whose only deliverable is another plan (`propose the implementation sequence`, `design the architecture`, `outline the automation`) when the repo is available now. For build/ship/end-to-end requests, do NOT put a standalone `research`, `audit`, or `cut line` task in front of the first engineering `feature` task just to decide what to build. Any minimal repo inspection belongs inside that first feature task. Only create a prerequisite research task when the human explicitly asked for analysis first or the repo truly has no identifiable implementation target.\n")
+		sb.WriteString("12b. For build/ship/end-to-end requests, do NOT spend the whole first turn on `pwd`, `ls`, `rg --files`, `find .`, or a repo-wide file inventory. If the packet or thread already names relevant docs, configs, or lane files, start from those. After at most one or two targeted reads, create the first durable task/channel state in that same turn.\n")
+		sb.WriteString("13. For broad engineering goals, do NOT create a first feature task with a giant title like `ship the whole MVP`, `ship the first channel-factory MVP slice`, or any other umbrella task with no cut line. The first feature task must name one smallest runnable slice only. Do not bundle idea generation, script drafting, packaging, and monetization hooks into the same first task; pick one contiguous slice, let it land, then queue the next slice. If existing docs, configs, or launch packets already name a concrete slice, use them and create the implementation task directly instead of narrating `repo audit first, implementation next`.\n")
+		sb.WriteString("14. If you write any narrative like `next move`, `next step`, `operating order`, or `eng should` / `gtm should`, that same turn MUST also create the concrete owned task record(s) for that work before you stop. Narrative next steps without durable tasks are a failure.\n")
+		sb.WriteString("14b. On a human build/ship request, the first turn must leave durable office state behind: at minimum the kickoff plus the first owned task, and for cross-functional work usually the execution channel too. A whole turn spent only reading docs or thinking is a failure.\n")
+		sb.WriteString("15. When first-pass specialist outputs land and obvious downstream work remains, create the next owned task before you end the turn. Do not stop at synthesis if the build still has a clear next step.\n")
+		sb.WriteString("15b. Before you create a new task, inspect the Active tasks in the packet. If an open, in-progress, or review task already covers that lane, reuse or update that task instead of creating an overlapping duplicate with a fresh title.\n")
+		sb.WriteString("16. If a task lands in review but no human approval is actually needed, approve it or immediately translate it into the next task. Do not leave the company idle behind an internal review gate.\n")
+		sb.WriteString("16b. Before you write any sentence claiming a task is approved, closed, reopened, reassigned, or blocked, you MUST make the matching team_task or team_plan call first. Channel narration does not mutate durable task state. If the mutation fails, say it failed and do not claim success.\n")
+		sb.WriteString("16c. On a human build/ship/end-to-end request, after you approve or close any engineering/execution slice, if the system is not yet runnable end to end and no engineering/execution lane remains active, create the next engineering/execution task in that same turn before you stop. Do not replace the only live build lane with GTM-only packaging, eval prompts, scoring rubrics, or other sidecar work.\n")
+		sb.WriteString("16d. When a task or policy allows a low-risk external step on a connected system, prefer the smallest real external action now over more internal collateral. A Slack/Notion/Drive lane is not satisfied by repo markdown, preview notes, proof markers, or substitute proof artifacts unless the task explicitly says mock/preview/stub-only.\n")
+		sb.WriteString("16e. When the work is live, describe outputs as client deliverables, approvals, handoffs, updates, or records. Do not frame live business work as proof/test/eval artifacts unless the task explicitly asks for testing or evidence capture.\n")
+		sb.WriteString("16f. Capability-gap rule: if the work is blocked because the needed specialist, channel, skill, or tool path does not exist yet, treat that gap as the next real work item. Do not fall back to a review bundle, proof packet, artifact shell, or local substitute deliverable. Create the missing specialist with team_member first; if the work will span more than one turn, create the missing execution channel with team_channel; propose or update the missing skill block in the same turn; and if the blocker is a tool or provider gap, open a tool-discovery/research lane named for the exact tool you need so the office can discover, validate, and enable it. Example: if the work needs video generation and you do not already have a usable path, create a discovery lane for Remotion or the exact video tool before drafting any deliverable shell.\n")
+		sb.WriteString("16g. Task hygiene rule: if a live business lane gets named or reframed as a review packet, proof artifact, blueprint-derived scaffold, rubric, or other internal shell, rewrite that lane in the same turn. Replace it with either the next real deliverable/customer-facing/business-facing step or the exact capability-enablement task that unblocks that step.\n")
+		sb.WriteString("17. Create channels (team_channel) or agents (team_member) when the human asks or scope genuinely warrants it. For cross-functional initiatives that will run beyond one decision cycle, create a dedicated execution channel and keep #general for top-level decisions.\n")
+		sb.WriteString("17b. When the human explicitly asks to add or test integrations, generated skills, reusable workflows, or generated agents, you MUST leave durable state for that work in the same turn. Create the integration/onboarding task lane(s), propose or update the relevant skill block(s), and create any needed specialist agent(s) instead of only describing them narratively. If real accounts, credentials, spend, publishing, or other external side effects would be required, proceed with stubs/placeholders until the exact human approval is truly needed.\n")
+		sb.WriteString("18. Sequence structural changes safely: create a new specialist with team_member first, wait for success, then add them to channels or tag them. When creating a new channel, only include members that already exist.\n")
+		sb.WriteString("19. For `team_channel` create/remove calls, set `channel` to the explicit target slug like `youtube-factory`; it is not inferred from the current room.\n")
+		sb.WriteString("20. Use team_bridge to carry context between channels when relevant\n")
+		sb.WriteString("21. If a task shows a worktree path, that path is the working_directory for local file and bash tools on that task\n")
+		sb.WriteString("22. After you have posted the needed update, decision, delegation, or human question for the current packet, stop. Do not linger in the same turn waiting for teammates to answer.\n\n")
+		sb.WriteString("== SKILL & AGENT AWARENESS ==\n")
+		sb.WriteString("When a request matches an existing skill (by name, trigger, or tags), you MUST invoke it via team_skill_run(skill_name) BEFORE doing the work. That tool bumps usage, logs a skill_invocation in the channel, and returns the skill's canonical content — follow those steps exactly, don't freelance.\n")
+		sb.WriteString("When delegating to a specialist, tell them which skill to run (by slug) so they call team_skill_run before acting. Never paraphrase a skill's steps into a delegation message — the skill IS the spec.\n")
+		sb.WriteString("You can create or propose new skills when you notice a repeated workflow worth codifying. Use team_skill_create for this; do not rely on prose-only proposals.\n")
+		sb.WriteString("Rules:\n")
+		sb.WriteString("- Create when the human explicitly asked for reusable workflow automation; propose when you independently see a pattern repeated 2+ times by the team\n")
+		sb.WriteString("- If the human explicitly asked for generated skills or reusable workflows, call team_skill_create(action=create) in the same turn before you stop; narrative mentions alone are a failure\n")
+		sb.WriteString("- If a recurring workflow is central to the project's operation, propose it instead of re-explaining it every round\n")
+		sb.WriteString("- Keep instructions concrete and executable, not vague\n")
+		sb.WriteString("- Use team_skill_create(action=propose) for unsolicited workflow suggestions so the human is asked to approve before activation\n")
+		sb.WriteString("- To suggest adding a new specialist agent, use team_member with a clear expertise and rationale\n")
+		sb.WriteString("- When integrations matter, make the required systems explicit in the skill instructions and agent rationale so the team knows which connected accounts or placeholders each workflow expects\n")
+		sb.WriteString("- When you create a new specialist for integration/onboarding work, include the owned integrations directly in that agent's expertise so the roster clearly shows who owns Gmail, Slack, YouTube, Drive, analytics, or similar lanes\n\n")
+		sb.WriteString("STYLE: Be concise, delegate, short lively messages. Use markdown tables/checklists for structured data.\n")
+		if markdownMemory {
+			sb.WriteString("Do not pretend the team wiki was updated; verify notebook_promote or team_wiki_write succeeded before claiming canonical storage.\n")
+		} else if noNex {
+			sb.WriteString("Do not claim you stored anything outside the office.\n")
+		} else {
+			sb.WriteString("Do not pretend the graph was updated; verify add_context succeeded.\n")
+		}
+		sb.WriteString("Never launch another WUPHF office from inside your turn (`wuphf`, `./wuphf`, `/reset`, or a new browser instance). The office is already running; inspect the current repo and UI instead.\n")
+	} else {
+		sb.WriteString(fmt.Sprintf("You are %s on the %s.\n", agentCfg.Name, p.packName()))
+		sb.WriteString(companyCtx)
+		sb.WriteString(fmt.Sprintf("Your expertise: %s\n\n", strings.Join(agentCfg.Expertise, ", ")))
+		sb.WriteString(fmt.Sprintf("Core personality: %s\n", agentCfg.Personality))
+		sb.WriteString(fmt.Sprintf("Voice and vibe: %s\n\n", teamVoiceForSlug(slug)))
+		sb.WriteString("== YOUR TEAM ==\n")
+		sb.WriteString(fmt.Sprintf("- @%s (%s): TEAM LEAD — has final say on decisions\n", lead, p.nameFor(lead)))
+		for _, member := range officeMembers {
+			if member.Slug == slug || member.Slug == lead {
+				continue
+			}
+			sb.WriteString(fmt.Sprintf("- @%s (%s): %s\n", member.Slug, member.Name, strings.Join(member.Expertise, ", ")))
+		}
+		sb.WriteString("\n== TEAM CHANNEL ==\n")
+		sb.WriteString("Your tools default to the active conversation context.\n")
+		sb.WriteString("- team_broadcast: Post to channel. CRITICAL: text @-mentions alone do NOT wake agents — include the slug in the `tagged` parameter.\n")
+		sb.WriteString("- team_poll: LAST RESORT — read recent messages only when pushed context is genuinely missing something you need. Do NOT call this by default; the pushed notification already contains thread context and task state.\n")
+		sb.WriteString("- team_bridge: CEO-only bridge for cross-channel context. Ask the CEO to use it.\n")
+		sb.WriteString("- team_task: Claim, complete, block, resume, or release tasks in your domain.\n")
+		sb.WriteString("- team_skill_run: When @ceo tells you to run a skill, or when the request clearly matches one, call team_skill_run(skill_name) BEFORE doing the work. It returns the canonical step-by-step content — follow it exactly instead of freelancing. Failing to invoke the skill leaves the office with no trace that the playbook was actually used.\n")
+		sb.WriteString("- team_skill_create: Propose a reusable skill yourself with action=propose when you spot a repeatable workflow. You do not need to ask @ceo to propose it for you. Only @ceo may use action=create.\n")
+		sb.WriteString("- team_action_connections / team_action_search / team_action_knowledge: inspect connected external systems and the exact action/workflow schema before you improvise. If connection listing is flaky, do NOT stop there; search/knowledge still give you the real action contract.\n")
+		sb.WriteString("- team_action_execute / team_action_workflow_execute: use these for real external reads, writes, and workflow runs. Prefer dry_run only when the task or policy says preview/mock first. When the provider is One and there is exactly one connected account for that platform, you may omit connection_key and let the runtime auto-resolve it.\n")
+		if markdownMemory {
+			sb.WriteString(markdownKnowledgeToolBlock())
+		}
+		sb.WriteString("- human_message: Present completion or a recommendation directly to the human.\n")
+		sb.WriteString("- human_interview: Ask the human only for cancelable clarifications you cannot responsibly guess.\n")
+		sb.WriteString("Other tools: team_tasks, team_task_status, team_requests, team_request, team_status, team_members, team_office_members, team_channels, team_channel, team_member, team_channel_member, team_action_guide, team_action_workflow_create, team_action_workflow_schedule, team_action_relays, team_action_relay_event_types, team_action_relay_create, team_action_relay_activate, team_action_relay_events, team_action_relay_event.\n\n")
+		sb.WriteString("== TOOL HYGIENE ==\n")
+		sb.WriteString("All team_*, human_*, and mcp__wuphf-office__* tools listed above are ALREADY registered. Call them directly. Do NOT use ToolSearch/select: to look them up — that wastes a full turn.\n")
+		sb.WriteString("Do not read unrelated files (MEMORY.md, arbitrary docs) unless the current packet's task requires it. Every tool call pays full turn cost.\n")
+		sb.WriteString("Emit at most one team_broadcast per turn unless you are deliberately crossing channels. Never re-post the same content in different wording.\n\n")
+		if markdownMemory {
+			sb.WriteString(markdownKnowledgeMemoryBlock())
+		} else if noNex {
+			sb.WriteString("Nex tools are disabled for this run. Base your work on the office conversation and direct human answers only.\n\n")
+		} else {
+			sb.WriteString("Nex memory: query_context before making assumptions; add_context only for durable conclusions.\n\n")
+		}
+		if len(activePolicies) > 0 {
+			sb.WriteString("== ACTIVE OFFICE POLICIES ==\n")
+			sb.WriteString("Treat these as hard operating constraints, not suggestions. If a policy conflicts with an older chat assumption, the active policy wins until the human changes it.\n")
+			for _, policy := range activePolicies {
+				sb.WriteString(fmt.Sprintf("- %s\n", policy.Rule))
+			}
+			sb.WriteString("\n")
+		}
+		sb.WriteString("Tag agents with @slug. Tagged agents must respond.\n")
+		if p.isFocusMode() {
+			sb.WriteString("== DELEGATION MODE ==\n")
+			sb.WriteString("Delegation mode is enabled.\n")
+			sb.WriteString("- You take work directly from the human only when they explicitly tag you, or from @ceo when delegated.\n")
+			sb.WriteString("- Do not debate with other specialists in the channel.\n")
+			sb.WriteString("- Do the work, then report completion, blockers, or handoff notes back to @ceo.\n")
+			sb.WriteString("- If another specialist should get involved, tell @ceo instead of routing it yourself.\n")
+			sb.WriteString("- After you report completion, a blocker, or a handoff, END THE TURN. Do not keep researching or wait for acknowledgements in the same run.\n\n")
+		}
+		sb.WriteString("THREADING: Default to replying in the active thread. If you intentionally cross into another channel or start a new topic, pass channel or new_topic explicitly.\n\n")
+		sb.WriteString("YOUR ROLE AS SPECIALIST:\n")
+		sb.WriteString("1. The pushed notification is authoritative — it contains thread context and task state. Respond directly from it. Do NOT call team_poll or team_tasks unless context is genuinely missing. Every unnecessary tool call burns tokens without adding value. Just do the work.\n")
+		sb.WriteString("2. Stay in your lane. Speak only when tagged, owning a task, blocked, or adding real delta that others haven't covered. Don't jump in just because a topic matches your domain.\n")
+		sb.WriteString("3. Push back when you disagree — explain why using your expertise\n")
+		sb.WriteString("4. Check team_requests before asking the human anything new\n")
+		sb.WriteString("5. For completion or recommendations, use human_message. For cancelable clarifications, use human_interview with options. For blocking human decisions, use team_request with kind `approval`, `confirm`, or `choice`.\n")
+		sb.WriteString("6. When assigned a task, claim it with team_task first, use team_status to show what you're working on, then mark complete or review-ready and broadcast when done. Final sequence for owned tasks: team_task mutation first, then any completion broadcast or human_message, then stop. A task is NOT finished until team_task marks it complete or review-ready; posting a channel reply alone does not unblock downstream work, and a completion post while the task stays in_progress is a failure. If the CEO delegates a substantial workstream and the packet shows no owned task yet, do one quick team_tasks check before creating a fallback task; if a matching task already exists, claim that instead of duplicating it. Only create a fallback task when the delegated work is substantial and no matching task exists after that single check. If the result is mainly for the human, also send it via human_message.\n")
+		sb.WriteString("7. You can see other channel names and descriptions, but cannot access their content unless you are a member. If context from another channel is needed, ask the CEO to bridge it.\n")
+		sb.WriteString("8. If a task or status line shows a worktree path, use that as working_directory for local file and bash tools.\n")
+		sb.WriteString("9. For local_worktree or feature tasks, default to direct implementation in the assigned worktree. Do not relaunch WUPHF, copied binaries, or a fresh local server just to inspect the app; use the current repo and running office instead.\n")
+		sb.WriteString("10. For local_worktree feature tasks, do NOT start with `rg --files`, `find .`, or a repo-wide audit. Read only the few files directly tied to the requested slice, then start editing. If the task is broad or lists multiple outputs, narrow it yourself to one exact smallest runnable slice, post a `team_status` naming that cut line, and ship that slice now.\n")
+		sb.WriteString("10b. Never search parent or sibling directories outside the assigned working_directory (`find ..`, `rg ..`, `/var/folders`, `TMPDIR`, `TemporaryItems`, or other task worktrees). If you need instructions, read `AGENTS.md` or `README.md` inside the assigned worktree only.\n")
+		sb.WriteString("11. Ignore unrelated modified or untracked files already present in the assigned worktree unless they are directly needed for your slice. They may be preexisting repo state; do not audit or re-explain them.\n")
+		sb.WriteString("11b. If a task names a connected external system and asks you to create, post, query, or run something there, do that live external step through the connected workflow/integration path. Repo docs, previews, local markdown, proof markers, or test artifacts do not count unless the task explicitly says mock/preview/stub-only.\n")
+		sb.WriteString("11c. When the work is live, phrase it as a client deliverable, approval, handoff, update, or record. Avoid proof/test/marker/eval language unless the task explicitly asks for testing or evidence capture.\n")
+		sb.WriteString("11d. When a task calls for Slack, Notion, Drive, or another connected system, use the `team_action_*` tools first. Do NOT probe localhost broker routes, curl the provider directly, or fall back to shell-side API experiments when the office action tools can do the job.\n")
+		sb.WriteString("11e. Capability-gap rule: if the work is blocked because the needed specialist, channel, skill, or tool path does not exist yet, treat that gap as the next real work item. Do not fall back to a review bundle, proof packet, artifact shell, or local substitute deliverable. Create the missing specialist with team_member first; if the work will span more than one turn, create the missing execution channel with team_channel; propose or update the missing skill block in the same turn; and if the blocker is a tool or provider gap, open a tool-discovery/research lane named for the exact tool you need so the office can discover, validate, and enable it. Example: if the work needs video generation and you do not already have a usable path, create a discovery lane for Remotion or the exact video tool before drafting any deliverable shell.\n")
+		sb.WriteString("11f. Task hygiene rule: if a live business lane gets named or reframed as a review packet, proof artifact, blueprint-derived scaffold, rubric, or other internal shell, rewrite that lane in the same turn. Replace it with either the next real deliverable/customer-facing/business-facing step or the exact capability-enablement task that unblocks that step.\n")
+		if codingAgentSlugs[slug] {
+			sb.WriteString("11g. When you commit to opening a pull request, actually open it. Run `gh pr create --title \"<short title>\" --body \"<body>\" --head \"<your-branch>\" --base main` via the bash tool. Paste the returned URL into your channel message so the team can click through. Do not claim a PR is open unless the bash output shows a https://github.com/... URL.\n")
+		}
+		if markdownMemory {
+			sb.WriteString("12. Use wuphf_wiki_lookup, team_wiki_search, or notebook_search when prior knowledge matters. Store your own durable working notes with notebook_write and submit notebook_promote when they should become canonical.\n")
+			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
+		} else if noNex {
+			sb.WriteString("12. Don't fake outside memory. Surface uncertainty in-channel and keep outcomes explicit in-thread.\n")
+			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
+		} else {
+			sb.WriteString("12. Use query_context when prior knowledge matters. Only use add_context for durable conclusions, and don't claim something stored unless add_context actually succeeded.\n")
+			sb.WriteString("13. Once you have posted the needed update for the current packet, stop. A later pushed notification will wake you again if more is needed.\n\n")
+		}
+		sb.WriteString("STYLE: Be concise, stay in lane, short lively messages. Use markdown tables/checklists for structured data.\n")
+		sb.WriteString("Never launch another WUPHF office from inside your turn (`wuphf`, `./wuphf`, `/reset`, or a new browser instance). The office is already running; inspect the current repo and UI instead.\n")
+	}
+
+	return sb.String()
+}
+
+// ── package-level prompt helpers ─────────────────────────────────────────
+//
+// These are pure free functions used by promptBuilder.Build and (for
+// headlessSandboxNote) by the launcher's headless dispatch path. They live
+// here rather than in launcher.go because their content is prompt-shaped:
+// changes to them belong with prompt tests.
+
+func markdownKnowledgeToolBlock() string {
+	return "- notebook_write: Save your own working notes, rough observations, draft decisions, draft playbooks, and task learnings at agents/{my_slug}/notebook/{date-or-topic}.md. This is the default write path for agent-authored knowledge.\n" +
+		"- notebook_promote: Submit a durable notebook entry for reviewer approval into the team wiki. Use this when the team should rely on the note as canonical knowledge.\n" +
+		"- notebook_read / notebook_list / notebook_search: Inspect agent notebooks for fresh working context before asking someone to repeat themselves.\n" +
+		"- team_wiki_read / team_wiki_search / team_wiki_list / wuphf_wiki_lookup: Read the canonical shared wiki.\n" +
+		"- team_wiki_write: Direct canonical wiki writes only for already-approved edits, bootstrap/admin maintenance, or explicit human requests. Do not bypass notebook_promote for new agent-authored knowledge.\n"
+}
+
+func markdownKnowledgeMemoryBlock() string {
+	return "Markdown notebook/wiki memory is active. Keep scratch and draft knowledge in notebook_write first; promote durable conclusions with notebook_promote when they are ready for review. Do not claim something is in the team wiki unless notebook_promote was submitted and approved, or team_wiki_write was explicitly appropriate and succeeded.\n\n"
+}
+
+func headlessSandboxNote() string {
+	return "Runtime: this office is already running. Never launch another `wuphf`, copied `wuphf` binary, `/reset`, browser instance, or local server/`--web-port` process from inside your turn. For `execution_mode=local_worktree`, make edits directly in the assigned working_directory instead of re-auditing or trying to boot a second office. Never search parent or sibling temp directories (`find ..`, `rg ..`, `/var/folders`, `TMPDIR`, `TemporaryItems`) from a task worktree; stay inside the assigned working_directory. If shell commands fail with 'operation not permitted' or 'permission denied' (go build cache, localhost bind, sandboxed writes), stop retrying them and continue from code inspection or the existing running office.\n\n"
+}
+
+func teamVoiceForSlug(slug string) string {
+	switch slug {
+	case "ceo":
+		return "Charismatic, decisive, slightly theatrical founder energy. Dry humor, fast prioritization, invites debate but lands the plane."
+	case "pm":
+		return "Sharp product brain. Calm, organized, gently skeptical of vague ideas, sometimes deadpan funny when scope starts ballooning."
+	case "fe":
+		return "Craft-obsessed, opinionated about UX, animated when a flow feels elegant, mildly allergic to ugly edge cases."
+	case "be":
+		return "Systems-minded, practical, a little grumpy about complexity in a useful way, enjoys killing fragile ideas early."
+	case "ai":
+		return "Curious, pragmatic, and slightly mischievous about model behavior. Loves clever AI product ideas, but will immediately ask about evals, latency, and whether the thing will actually work."
+	case "designer":
+		return "Taste-driven, emotionally attuned to the product, expressive, occasionally dramatic about bad UX in a charming way."
+	case "cmo":
+		return "Energetic market storyteller. Punchy, a bit witty, always translating product ideas into positioning and narrative."
+	case "cro":
+		return "Blunt, commercial, confident. Likes concrete demand signals, calls out fluffy thinking, can be funny in a sales-floor way."
+	case "tech-lead":
+		return "Measured senior engineer energy. Crisp, lightly sardonic, respects good ideas and immediately spots architectural nonsense."
+	case "qa":
+		return "Calm breaker of bad assumptions. Dry humor, sees risks before others do, weirdly delighted by edge cases."
+	case "ae":
+		return "Polished but human closer. Reads people well, lightly playful, always steering toward deals and momentum."
+	case "sdr":
+		return "High-energy, persistent, upbeat, occasionally scrappy. Brings hustle without sounding robotic."
+	case "research":
+		return "Curious, analytical, a little nerdy in a good way. Likes receipts and will gently roast unsupported claims."
+	case "content":
+		return "Wordsmith with opinions. Smart, punchy, mildly dramatic about boring copy, always looking for the hook."
+	default:
+		return "A real teammate with a recognizable point of view, light humor, and emotional range."
+	}
+}

--- a/internal/team/prompt_builder.go
+++ b/internal/team/prompt_builder.go
@@ -68,7 +68,11 @@ func (p *promptBuilder) Build(slug string) string {
 	markdownMemory := p.markdownMemory
 	noNex := p.nexDisabled
 
-	activePolicies := p.policies()
+	// Sort policies by ID inside the builder so prompt-cache byte-stability
+	// no longer depends on every caller pre-sorting before handing the
+	// snapshot in. Same reason as officeMembers above.
+	activePolicies := append([]officePolicy(nil), p.policies()...)
+	sort.Slice(activePolicies, func(i, j int) bool { return activePolicies[i].ID < activePolicies[j].ID })
 
 	var sb strings.Builder
 	companyCtx := config.CompanyContextBlock()

--- a/internal/team/prompt_builder_test.go
+++ b/internal/team/prompt_builder_test.go
@@ -1,0 +1,294 @@
+package team
+
+// Tests for the extracted promptBuilder type and its small package-level
+// helpers. Written test-first against the proposed surface in PLAN.md §C1
+// before the type exists, so a compile failure at first run is expected.
+//
+// The aim is twofold: (1) exercise branches that buildPrompt wasn't covering
+// (1:1 mode, codingAgentSlugs branch, headlessSandboxNote, teamVoiceForSlug
+// table) so the new file lands well above the 85% per-file gate, and
+// (2) prove that the new type can be driven without a *Launcher — that's
+// the whole point of the extraction.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTeamVoiceForSlug_KnownSlugs(t *testing.T) {
+	cases := map[string]string{
+		"ceo":       "Charismatic, decisive",
+		"pm":        "Sharp product brain",
+		"fe":        "Craft-obsessed",
+		"be":        "Systems-minded",
+		"ai":        "Curious, pragmatic",
+		"designer":  "Taste-driven",
+		"cmo":       "Energetic market storyteller",
+		"cro":       "Blunt, commercial",
+		"tech-lead": "Measured senior engineer",
+		"qa":        "Calm breaker of bad assumptions",
+		"ae":        "Polished but human closer",
+		"sdr":       "High-energy, persistent",
+		"research":  "Curious, analytical",
+		"content":   "Wordsmith with opinions",
+	}
+	for slug, want := range cases {
+		got := teamVoiceForSlug(slug)
+		if !strings.HasPrefix(got, want) {
+			t.Errorf("teamVoiceForSlug(%q) = %q, want prefix %q", slug, got, want)
+		}
+	}
+}
+
+func TestTeamVoiceForSlug_UnknownSlugFallsBack(t *testing.T) {
+	got := teamVoiceForSlug("unknown-role-12345")
+	if !strings.Contains(got, "real teammate") {
+		t.Errorf("expected default voice fallback, got %q", got)
+	}
+}
+
+func TestMarkdownKnowledgeToolBlock_ListsCanonicalTools(t *testing.T) {
+	block := markdownKnowledgeToolBlock()
+	for _, tool := range []string{
+		"notebook_write", "notebook_promote", "notebook_read",
+		"team_wiki_read", "team_wiki_write", "wuphf_wiki_lookup",
+	} {
+		if !strings.Contains(block, tool) {
+			t.Errorf("markdownKnowledgeToolBlock missing %q", tool)
+		}
+	}
+}
+
+func TestMarkdownKnowledgeMemoryBlock_RequiresPromotionDiscipline(t *testing.T) {
+	block := markdownKnowledgeMemoryBlock()
+	for _, want := range []string{
+		"notebook_write",
+		"notebook_promote",
+		"approved",
+	} {
+		if !strings.Contains(block, want) {
+			t.Errorf("markdownKnowledgeMemoryBlock missing %q", want)
+		}
+	}
+}
+
+func TestHeadlessSandboxNote_ForbidsNestedOfficeAndParentSearches(t *testing.T) {
+	note := headlessSandboxNote()
+	for _, want := range []string{
+		"Never launch another `wuphf`",
+		"Never search parent or sibling temp directories",
+		"operation not permitted",
+	} {
+		if !strings.Contains(note, want) {
+			t.Errorf("headlessSandboxNote missing %q", want)
+		}
+	}
+}
+
+func TestPromptBuilder_OneOnOneBranch(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return true },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "1:1 with CEO" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{{Slug: "ceo", Name: "CEO", Role: "ceo", Personality: "decisive"}}
+		},
+		policies:    func() []officePolicy { return nil },
+		nameFor:     func(slug string) string { return slug },
+		nexDisabled: true,
+	}
+
+	got := pb.Build("ceo")
+	if !strings.Contains(got, "direct one-on-one WUPHF session with the human") {
+		t.Fatalf("expected 1:1 banner, got: %s", got)
+	}
+	if strings.Contains(got, "== YOUR TEAM ==") {
+		t.Fatalf("1:1 prompt must not list teammates")
+	}
+	if strings.Contains(got, "team_broadcast: Post to channel") {
+		t.Fatalf("1:1 prompt must not include channel-mode broadcast guidance")
+	}
+	if !strings.Contains(got, "team_broadcast: Send a normal direct chat reply") {
+		t.Fatalf("1:1 prompt should describe team_broadcast in 1:1 framing")
+	}
+	if !strings.Contains(got, "Nex tools are disabled for this run") {
+		t.Fatalf("nexDisabled=true should produce the no-Nex 1:1 line")
+	}
+}
+
+func TestPromptBuilder_OneOnOneNexEnabledMentionsContextGraph(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return true },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "1:1 with CEO" },
+		leadSlug:    func() string { return "ceo" },
+		members:     func() []officeMember { return []officeMember{{Slug: "ceo", Name: "CEO"}} },
+		policies:    func() []officePolicy { return nil },
+		nameFor:     func(slug string) string { return slug },
+		nexDisabled: false,
+	}
+	got := pb.Build("ceo")
+	if !strings.Contains(got, "query_context") {
+		t.Fatalf("Nex-enabled 1:1 prompt should reference query_context")
+	}
+}
+
+func TestPromptBuilder_LeadFocusModeAddsDelegationSection(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return true },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend"},
+			}
+		},
+		policies: func() []officePolicy { return nil },
+		nameFor:  func(slug string) string { return slug },
+	}
+	got := pb.Build("ceo")
+	if !strings.Contains(got, "== DELEGATION MODE ==") {
+		t.Fatalf("expected lead delegation block when focus mode is on")
+	}
+	if !strings.Contains(got, "Route and hold") {
+		t.Fatalf("expected lead delegation routing guidance")
+	}
+}
+
+func TestPromptBuilder_SpecialistFocusModeAddsDelegationSection(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return true },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "fe", Name: "Frontend"},
+			}
+		},
+		policies: func() []officePolicy { return nil },
+		nameFor:  func(slug string) string { return slug },
+	}
+	got := pb.Build("fe")
+	if !strings.Contains(got, "Delegation mode is enabled") {
+		t.Fatalf("expected specialist delegation block when focus mode is on")
+	}
+	if !strings.Contains(got, "report completion, blockers, or handoff notes back to @ceo") {
+		t.Fatalf("expected specialist hand-off back-to-CEO instruction")
+	}
+}
+
+func TestPromptBuilder_SpecialistCodingAgentRequiresGhPRCreate(t *testing.T) {
+	// codingAgentSlugs (eng/be/fe/etc.) get the explicit "actually open the
+	// PR" instruction. Verify that branch fires for an eng specialist.
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "eng", Name: "Engineer"},
+			}
+		},
+		policies: func() []officePolicy { return nil },
+		nameFor:  func(slug string) string { return slug },
+	}
+	got := pb.Build("eng")
+	if !strings.Contains(got, "gh pr create") {
+		t.Fatalf("coding-agent specialist prompt must require running gh pr create, got: %s", got)
+	}
+	if !strings.Contains(got, "https://github.com/...") {
+		t.Fatalf("coding-agent specialist prompt must require pasting the returned URL")
+	}
+}
+
+func TestPromptBuilder_SpecialistNonCodingAgentOmitsGhPRRequirement(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo", Name: "CEO"},
+				{Slug: "designer", Name: "Designer"},
+			}
+		},
+		policies: func() []officePolicy { return nil },
+		nameFor:  func(slug string) string { return slug },
+	}
+	got := pb.Build("designer")
+	if strings.Contains(got, "gh pr create") {
+		t.Fatalf("non-coding specialist prompt must NOT contain gh pr create instructions")
+	}
+}
+
+func TestPromptBuilder_LeadIncludesActivePoliciesSorted(t *testing.T) {
+	pb := &promptBuilder{
+		isOneOnOne:  func() bool { return false },
+		isFocusMode: func() bool { return false },
+		packName:    func() string { return "WUPHF Office" },
+		leadSlug:    func() string { return "ceo" },
+		members:     func() []officeMember { return []officeMember{{Slug: "ceo", Name: "CEO"}} },
+		// Caller is responsible for passing pre-sorted policies (matches the
+		// existing buildPrompt behaviour). The block formatting itself is
+		// what we're asserting here.
+		policies: func() []officePolicy {
+			return []officePolicy{
+				{ID: "a", Rule: "always confirm before deleting"},
+				{ID: "b", Rule: "never push to main"},
+			}
+		},
+		nameFor: func(slug string) string { return slug },
+	}
+	got := pb.Build("ceo")
+	if !strings.Contains(got, "== ACTIVE OFFICE POLICIES ==") {
+		t.Fatalf("expected active policies banner")
+	}
+	if !strings.Contains(got, "always confirm before deleting") {
+		t.Fatalf("expected first policy rule")
+	}
+	if !strings.Contains(got, "never push to main") {
+		t.Fatalf("expected second policy rule")
+	}
+	// Order: by appearance in slice (caller pre-sorts).
+	a := strings.Index(got, "always confirm")
+	b := strings.Index(got, "never push")
+	if a == -1 || b == -1 || a > b {
+		t.Fatalf("expected policies in input order, got positions %d/%d in:\n%s", a, b, got)
+	}
+}
+
+func TestPromptBuilder_DeterministicOrderingFromMembers(t *testing.T) {
+	// PLAN.md trap-adjacent: prompt cache hits depend on byte-identical
+	// output across runs. The promptBuilder must sort its own members
+	// snapshot before walking it (it currently does this inside buildPrompt
+	// at line 3761). Two builds with the same members in different input
+	// order must produce identical output.
+	mk := func(order []string) *promptBuilder {
+		members := make([]officeMember, len(order))
+		for i, s := range order {
+			members[i] = officeMember{Slug: s, Name: s}
+		}
+		return &promptBuilder{
+			isOneOnOne:  func() bool { return false },
+			isFocusMode: func() bool { return false },
+			packName:    func() string { return "WUPHF Office" },
+			leadSlug:    func() string { return "ceo" },
+			members:     func() []officeMember { return members },
+			policies:    func() []officePolicy { return nil },
+			nameFor:     func(slug string) string { return slug },
+		}
+	}
+	a := mk([]string{"ceo", "eng", "fe"}).Build("ceo")
+	b := mk([]string{"fe", "ceo", "eng"}).Build("ceo")
+	if a != b {
+		t.Fatalf("promptBuilder.Build is not deterministic across member input orderings.\nA len=%d\nB len=%d", len(a), len(b))
+	}
+}

--- a/internal/team/scheduler.go
+++ b/internal/team/scheduler.go
@@ -1,0 +1,438 @@
+package team
+
+// scheduler.go owns the watchdog scheduler — the goroutine that wakes up
+// periodically, asks the broker for due jobs, and dispatches each one to
+// a per-target-type processor (PLAN.md §C4). First goroutine extraction
+// in the launcher decomposition.
+//
+// Test seams (PLAN.md §3):
+//   - clock interface with realClock (production) and manualClock (tests).
+//     The loop's two time.Sleep calls (initialDelay + pollEvery) become
+//     clock.After channel reads that the manual clock can release on
+//     command. Kills the user's hard "no time.Sleep in tests" rule.
+//   - onTickDone signal channel. The Start() loop sends after each
+//     processOnce so tests can synchronously assert on the recorded side
+//     effects without polling.
+//   - schedulerBroker interface, declared on the consumer side per Go
+//     convention. The real *Broker satisfies it implicitly; tests pass a
+//     recording stub.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/action"
+	"github.com/nex-crm/wuphf/internal/calendar"
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// clock is the small time interface the scheduler uses. Production wires
+// realClock (delegating to time); tests wire manualClock (advance-driven).
+type clock interface {
+	Now() time.Time
+	After(d time.Duration) <-chan time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time                         { return time.Now() }
+func (realClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+// schedulerBroker is the narrow consumer-side interface the scheduler
+// requires from *Broker. Declared here (not on Broker) so the broker
+// surface stays free of refactor-driven interfaces.
+type schedulerBroker interface {
+	DueSchedulerJobs() []schedulerJob
+	FindTask(channel, id string) (teamTask, bool)
+	FindRequest(channel, id string) (humanInterview, bool)
+	UpdateSchedulerJobState(slug string, nextRun time.Time, status string) error
+	CreateWatchdogAlert(kind, channel, targetType, targetID, owner, summary string) (watchdogAlert, bool, error)
+	RecordSignals([]officeSignal) ([]officeSignalRecord, error)
+	RecordDecision(kind, channel, summary, reason, owner string, signalIDs []string, requiresHuman, blocking bool) (officeDecisionRecord, error)
+	RecordAction(kind, source, channel, actor, summary, related string, signalIDs []string, decisionID string) error
+	ResumeTask(id, by, note string) (teamTask, bool, error)
+	PostAutomationMessage(from, channel, title, body, alertID, source, displayName string, ccSlugs []string, replyTo string) (channelMessage, bool, error)
+	UpdateSkillExecutionByWorkflowKey(key, status string, when time.Time) error
+	SetSchedulerJob(job schedulerJob) error
+}
+
+// watchdogScheduler runs the periodic broker-driven watchdog loop. One
+// goroutine started by Start; drained by Stop via stopCh + done WaitGroup.
+type watchdogScheduler struct {
+	broker      schedulerBroker
+	clock       clock
+	deliverTask func(officeActionLog, teamTask)
+
+	initialDelay time.Duration
+	pollEvery    time.Duration
+
+	startOnce sync.Once
+	stopOnce  sync.Once
+	stopCh    chan struct{}
+	done      sync.WaitGroup
+
+	// onTickDone, when non-nil, receives one struct after every
+	// processOnce call. Tests use it to wait deterministically; production
+	// leaves it nil so the loop has zero overhead.
+	onTickDone chan<- struct{}
+}
+
+// Start spawns the scheduler goroutine. Idempotent — multiple calls are
+// no-ops after the first. The returned scheduler keeps running until Stop
+// is called or ctx is cancelled.
+func (w *watchdogScheduler) Start(ctx context.Context) {
+	w.startOnce.Do(func() {
+		if w.stopCh == nil {
+			w.stopCh = make(chan struct{})
+		}
+		if w.initialDelay <= 0 {
+			w.initialDelay = 15 * time.Second
+		}
+		if w.pollEvery <= 0 {
+			w.pollEvery = 20 * time.Second
+		}
+		w.done.Add(1)
+		go w.run(ctx)
+	})
+}
+
+func (w *watchdogScheduler) run(ctx context.Context) {
+	defer w.done.Done()
+	if w.broker == nil {
+		return
+	}
+	if !w.wait(ctx, w.initialDelay) {
+		return
+	}
+	for {
+		w.processOnce()
+		w.signalTick()
+		if !w.wait(ctx, w.pollEvery) {
+			return
+		}
+	}
+}
+
+// wait blocks for d, returning false when stopCh closes or ctx cancels
+// (the loop should exit) and true when the deadline elapses normally.
+func (w *watchdogScheduler) wait(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-w.clock.After(d):
+		return true
+	case <-w.stopCh:
+		return false
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func (w *watchdogScheduler) signalTick() {
+	if w.onTickDone == nil {
+		return
+	}
+	// Non-blocking when the test isn't reading. Tests that care about
+	// every tick provide a buffered channel sized for the expected count.
+	select {
+	case w.onTickDone <- struct{}{}:
+	default:
+	}
+}
+
+// Stop signals the goroutine to exit and waits for it. Idempotent.
+func (w *watchdogScheduler) Stop() {
+	w.stopOnce.Do(func() {
+		if w.stopCh == nil {
+			return
+		}
+		close(w.stopCh)
+	})
+	w.done.Wait()
+}
+
+// processOnce processes every currently-due job. Exposed (lowercase
+// method, same package) so tests can drive a single tick deterministically
+// without going through Start.
+func (w *watchdogScheduler) processOnce() {
+	if w.broker == nil {
+		return
+	}
+	jobs := w.broker.DueSchedulerJobs()
+	if len(jobs) == 0 {
+		return
+	}
+	for _, job := range jobs {
+		switch strings.TrimSpace(job.TargetType) {
+		case "task":
+			w.processTaskJob(job)
+		case "request":
+			w.processRequestJob(job)
+		case "workflow":
+			w.processWorkflowJob(job)
+		default:
+			nextRun := w.clock.Now().UTC().Add(time.Duration(config.ResolveTaskReminderInterval()) * time.Minute)
+			_ = w.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
+		}
+	}
+}
+
+func (w *watchdogScheduler) processTaskJob(job schedulerJob) {
+	task, ok := w.broker.FindTask(job.Channel, job.TargetID)
+	if !ok || strings.EqualFold(strings.TrimSpace(task.Status), "done") {
+		_ = w.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
+		return
+	}
+	now := w.clock.Now().UTC()
+	if task.Blocked {
+		// Blocked tasks are legitimately waiting on dependencies — skip
+		// the watchdog reminder. Owner cannot act until blockers resolve.
+		// External-workflow rate-limit retry path stays here so a
+		// throttled live-execute task auto-resumes when the cooldown ends.
+		if retryAt, rateLimited := externalWorkflowRetryAfter(errors.New(task.Details), now); rateLimited && !retryAt.After(now) {
+			resumeNote := "Retry window passed; resuming live external lane automatically."
+			resumed, changed, err := w.broker.ResumeTask(task.ID, "watchdog", resumeNote)
+			if err == nil && changed {
+				_ = w.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
+				if w.deliverTask != nil {
+					w.deliverTask(officeActionLog{
+						Kind:      "task_unblocked",
+						Source:    "watchdog",
+						Channel:   resumed.Channel,
+						Actor:     "watchdog",
+						RelatedID: resumed.ID,
+					}, resumed)
+				}
+				return
+			}
+		}
+		nextRun := w.clock.Now().UTC().Add(time.Duration(config.ResolveTaskReminderInterval()) * time.Minute)
+		_ = w.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
+		return
+	}
+	alertKind := "task_stalled"
+	var summary string
+	if strings.TrimSpace(task.Owner) == "" {
+		alertKind = "task_unclaimed"
+		summary = fmt.Sprintf("Task %s in #%s still has no owner.", task.Title, normalizeChannelSlug(task.Channel))
+	} else {
+		summary = fmt.Sprintf("@%s still needs to move %s in #%s.", task.Owner, task.Title, normalizeChannelSlug(task.Channel))
+	}
+	_, _, _ = w.broker.CreateWatchdogAlert(alertKind, task.Channel, "task", task.ID, task.Owner, summary)
+	signalIDs, decisionID := w.recordLedger(task.Channel, alertKind, task.ID, task.Owner, summary, task.SourceSignalID)
+	_ = w.broker.RecordAction("watchdog_alert", "watchdog", task.Channel, "watchdog", truncate(summary, 140), task.ID, signalIDs, decisionID)
+	if w.deliverTask != nil {
+		w.deliverTask(officeActionLog{
+			Kind:      "watchdog_alert",
+			Source:    "watchdog",
+			Channel:   task.Channel,
+			Actor:     "watchdog",
+			RelatedID: task.ID,
+		}, task)
+	}
+	nextRun := w.clock.Now().UTC().Add(time.Duration(config.ResolveTaskReminderInterval()) * time.Minute)
+	_ = w.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
+}
+
+func (w *watchdogScheduler) processRequestJob(job schedulerJob) {
+	req, ok := w.broker.FindRequest(job.Channel, job.TargetID)
+	if !ok || !requestIsActive(req) {
+		_ = w.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
+		return
+	}
+	summary := fmt.Sprintf("Still waiting on %s in #%s: %s", req.TitleOrDefault(), normalizeChannelSlug(req.Channel), truncate(req.Question, 120))
+	alert, existing, _ := w.broker.CreateWatchdogAlert("request_waiting", req.Channel, "request", req.ID, req.From, summary)
+	signalIDs, decisionID := w.recordLedger(req.Channel, "request_waiting", req.ID, req.From, summary, "")
+	_ = w.broker.RecordAction("watchdog_alert", "watchdog", req.Channel, "watchdog", truncate(summary, 140), req.ID, signalIDs, decisionID)
+	if req.Blocking && !existing {
+		_, _, _ = w.broker.PostAutomationMessage(
+			"wuphf",
+			req.Channel,
+			"Waiting on human decision",
+			summary,
+			alert.ID,
+			"watchdog",
+			"Office watchdog",
+			[]string{"ceo"},
+			req.ReplyTo,
+		)
+	}
+	nextRun := w.clock.Now().UTC().Add(time.Duration(config.ResolveTaskReminderInterval()) * time.Minute)
+	_ = w.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
+}
+
+func (w *watchdogScheduler) processWorkflowJob(job schedulerJob) {
+	if w.broker == nil {
+		return
+	}
+	type workflowSchedulePayload struct {
+		Provider     string         `json:"provider"`
+		WorkflowKey  string         `json:"workflow_key"`
+		Inputs       map[string]any `json:"inputs"`
+		ScheduleExpr string         `json:"schedule_expr"`
+		CreatedBy    string         `json:"created_by"`
+		Channel      string         `json:"channel"`
+		SkillName    string         `json:"skill_name"`
+	}
+	var payload workflowSchedulePayload
+	if strings.TrimSpace(job.Payload) != "" {
+		_ = json.Unmarshal([]byte(job.Payload), &payload)
+	}
+	workflowKey := strings.TrimSpace(payload.WorkflowKey)
+	if workflowKey == "" {
+		workflowKey = strings.TrimSpace(job.WorkflowKey)
+	}
+	if workflowKey == "" {
+		_ = w.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
+		return
+	}
+	channel := normalizeChannelSlug(payload.Channel)
+	if channel == "" {
+		channel = normalizeChannelSlug(job.Channel)
+	}
+	if channel == "" {
+		channel = "general"
+	}
+	providerName := strings.TrimSpace(payload.Provider)
+	if providerName == "" {
+		providerName = strings.TrimSpace(job.Provider)
+	}
+	registry := action.NewRegistryFromEnv()
+	provider, err := registry.ProviderNamed(providerName, action.CapabilityWorkflowExecute)
+	if err != nil {
+		source := providerName
+		if strings.TrimSpace(source) == "" {
+			source = "workflow"
+		}
+		summary := fmt.Sprintf("Scheduled workflow %s could not start: %v", workflowKey, err)
+		_ = w.broker.RecordAction("external_workflow_failed", source, channel, "scheduler", truncate(summary, 140), workflowKey, nil, "")
+		_ = w.broker.UpdateSkillExecutionByWorkflowKey(workflowKey, "failed", w.clock.Now().UTC())
+		if nextRun, hasNext := nextWorkflowRun(strings.TrimSpace(payload.ScheduleExpr), w.clock.Now().UTC()); hasNext {
+			_ = w.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
+		} else {
+			_ = w.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
+		}
+		return
+	}
+	result, err := provider.ExecuteWorkflow(context.Background(), action.WorkflowExecuteRequest{
+		KeyOrPath: workflowKey,
+		Inputs:    payload.Inputs,
+	})
+	now := w.clock.Now().UTC()
+	nextRun, hasNext := nextWorkflowRun(strings.TrimSpace(payload.ScheduleExpr), now)
+	if err != nil {
+		summary := fmt.Sprintf("Scheduled workflow %s failed via %s", workflowKey, titleCaser.String(provider.Name()))
+		_ = w.broker.RecordAction("external_workflow_failed", provider.Name(), channel, "scheduler", summary, workflowKey, nil, "")
+		_ = w.broker.UpdateSkillExecutionByWorkflowKey(workflowKey, "failed", now)
+		if hasNext {
+			_ = w.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
+		} else {
+			_ = w.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
+		}
+		return
+	}
+	status := strings.TrimSpace(result.Status)
+	if status == "" {
+		status = "completed"
+	}
+	summary := fmt.Sprintf("Scheduled workflow %s ran via %s", workflowKey, titleCaser.String(provider.Name()))
+	_ = w.broker.RecordAction("external_workflow_executed", provider.Name(), channel, "scheduler", summary, workflowKey, nil, "")
+	_ = w.broker.UpdateSkillExecutionByWorkflowKey(workflowKey, status, now)
+	if hasNext {
+		_ = w.broker.UpdateSchedulerJobState(job.Slug, nextRun, "scheduled")
+	} else {
+		_ = w.broker.UpdateSchedulerJobState(job.Slug, time.Time{}, "done")
+	}
+}
+
+// recordLedger writes a watchdog signal + a routing decision to the
+// broker's audit trail. Returns the union of source signal IDs and any
+// freshly-recorded ones, plus the decision ID for action correlation.
+func (w *watchdogScheduler) recordLedger(channel, kind, targetID, owner, summary, sourceSignalID string) ([]string, string) {
+	if w.broker == nil {
+		return nil, ""
+	}
+	signal, err := w.broker.RecordSignals([]officeSignal{{
+		ID:         strings.TrimSpace(kind) + "::" + strings.TrimSpace(targetID),
+		Source:     "watchdog",
+		Kind:       strings.TrimSpace(kind),
+		Title:      "Office watchdog",
+		Content:    strings.TrimSpace(summary),
+		Channel:    channel,
+		Owner:      strings.TrimSpace(owner),
+		Confidence: "high",
+		Urgency:    "high",
+	}})
+	if err != nil || len(signal) == 0 {
+		return compactStringList([]string{sourceSignalID}), ""
+	}
+	signalIDs := make([]string, 0, len(signal)+1)
+	signalIDs = append(signalIDs, compactStringList([]string{sourceSignalID})...)
+	for _, record := range signal {
+		signalIDs = append(signalIDs, record.ID)
+	}
+	decisionKind := "remind_owner"
+	decisionReason := "The watchdog detected owned work with no visible movement, so the office should remind the current owner."
+	decisionOwner := strings.TrimSpace(owner)
+	requiresHuman := false
+	blocking := false
+	if decisionOwner == "" {
+		decisionKind = "escalate_to_ceo"
+		decisionReason = "The watchdog detected work without a live owner, so the CEO should re-triage it."
+		decisionOwner = "ceo"
+	}
+	if kind == "request_waiting" {
+		decisionKind = "ask_human"
+		decisionReason = "The watchdog detected a pending human decision that is still blocking the office."
+		decisionOwner = "ceo"
+		requiresHuman = true
+		blocking = true
+	}
+	decision, err := w.broker.RecordDecision(decisionKind, channel, summary, decisionReason, decisionOwner, signalIDs, requiresHuman, blocking)
+	if err != nil {
+		return signalIDs, ""
+	}
+	return signalIDs, decision.ID
+}
+
+// updateJob is a small helper still used by the launcher's Launch() path
+// to seed the persisted job state on startup. Kept on the scheduler so
+// the broker.SetSchedulerJob call has one owner.
+func (w *watchdogScheduler) updateJob(slug, label string, interval time.Duration, nextRun time.Time, status string) {
+	if w.broker == nil {
+		return
+	}
+	job := schedulerJob{
+		Slug:            slug,
+		Label:           label,
+		IntervalMinutes: int(interval / time.Minute),
+		NextRun:         nextRun.UTC().Format(time.RFC3339),
+		Status:          status,
+	}
+	if status == "sleeping" {
+		job.LastRun = w.clock.Now().UTC().Format(time.RFC3339)
+	}
+	_ = w.broker.SetSchedulerJob(job)
+}
+
+// nextWorkflowRun parses a cron expression and returns the next scheduled
+// run after `after`. Returns ok=false for empty / malformed expressions
+// or when the cron has no future occurrences.
+func nextWorkflowRun(scheduleExpr string, after time.Time) (time.Time, bool) {
+	scheduleExpr = strings.TrimSpace(scheduleExpr)
+	if scheduleExpr == "" {
+		return time.Time{}, false
+	}
+	sched, err := calendar.ParseCron(scheduleExpr)
+	if err != nil {
+		return time.Time{}, false
+	}
+	next := sched.Next(after)
+	if next.IsZero() {
+		return time.Time{}, false
+	}
+	return next, true
+}

--- a/internal/team/scheduler.go
+++ b/internal/team/scheduler.go
@@ -71,10 +71,15 @@ type watchdogScheduler struct {
 	initialDelay time.Duration
 	pollEvery    time.Duration
 
-	startOnce sync.Once
-	stopOnce  sync.Once
-	stopCh    chan struct{}
-	done      sync.WaitGroup
+	// mu coordinates Start/Stop so Stop-before-Start can't consume its
+	// signal and orphan a later Start's goroutine. started/stopped are
+	// the actual state; sync.Once isn't enough because the two Onces
+	// don't observe each other's outcome.
+	mu      sync.Mutex
+	started bool
+	stopped bool
+	stopCh  chan struct{}
+	done    sync.WaitGroup
 
 	// runCtx is a cancelable derivation of the ctx passed to Start. Stop
 	// cancels it so any in-flight downstream call (e.g. a workflow provider
@@ -87,29 +92,42 @@ type watchdogScheduler struct {
 	// processOnce call. Tests use it to wait deterministically; production
 	// leaves it nil so the loop has zero overhead.
 	onTickDone chan<- struct{}
+
+	// resolveWorkflowProvider, when non-nil, replaces the live registry
+	// lookup in processWorkflowJob. Tests inject a stub returning a fake
+	// action.Provider so the lookup-failure, execute-failure, success, and
+	// cancellation branches are all reachable without spinning up a real
+	// registry. Production leaves this nil and uses action.NewRegistryFromEnv.
+	resolveWorkflowProvider func(name string) (action.Provider, error)
 }
 
 // Start spawns the scheduler goroutine. Idempotent — multiple calls are
-// no-ops after the first. The returned scheduler keeps running until Stop
-// is called or ctx is cancelled.
+// no-ops after the first. If Stop ran before Start, Start is a no-op so
+// the goroutine never spawns (the alternative would leak it). The
+// returned scheduler keeps running until Stop is called or ctx is
+// cancelled.
 func (w *watchdogScheduler) Start(ctx context.Context) {
-	w.startOnce.Do(func() {
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		w.runCtx, w.runCancel = context.WithCancel(ctx)
-		if w.stopCh == nil {
-			w.stopCh = make(chan struct{})
-		}
-		if w.initialDelay <= 0 {
-			w.initialDelay = 15 * time.Second
-		}
-		if w.pollEvery <= 0 {
-			w.pollEvery = 20 * time.Second
-		}
-		w.done.Add(1)
-		go w.run(w.runCtx)
-	})
+	w.mu.Lock()
+	if w.started || w.stopped {
+		w.mu.Unlock()
+		return
+	}
+	w.started = true
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	w.runCtx, w.runCancel = context.WithCancel(ctx)
+	w.stopCh = make(chan struct{})
+	if w.initialDelay <= 0 {
+		w.initialDelay = 15 * time.Second
+	}
+	if w.pollEvery <= 0 {
+		w.pollEvery = 20 * time.Second
+	}
+	w.done.Add(1)
+	runCtx := w.runCtx
+	w.mu.Unlock()
+	go w.run(runCtx)
 }
 
 func (w *watchdogScheduler) run(ctx context.Context) {
@@ -155,18 +173,25 @@ func (w *watchdogScheduler) signalTick() {
 }
 
 // Stop signals the goroutine to exit and waits for it. Idempotent.
+// Calling Stop before Start is supported: it disables a later Start
+// from ever spawning the goroutine.
 func (w *watchdogScheduler) Stop() {
-	w.stopOnce.Do(func() {
-		// Cancel runCtx first so any downstream blocking call (workflow
-		// provider, etc.) unblocks before we sit on done.Wait.
-		if w.runCancel != nil {
-			w.runCancel()
-		}
-		if w.stopCh == nil {
-			return
-		}
+	w.mu.Lock()
+	if w.stopped {
+		w.mu.Unlock()
+		w.done.Wait()
+		return
+	}
+	w.stopped = true
+	// Cancel runCtx first so any downstream blocking call (workflow
+	// provider, etc.) unblocks before we sit on done.Wait.
+	if w.runCancel != nil {
+		w.runCancel()
+	}
+	if w.stopCh != nil {
 		close(w.stopCh)
-	})
+	}
+	w.mu.Unlock()
 	w.done.Wait()
 }
 
@@ -316,8 +341,13 @@ func (w *watchdogScheduler) processWorkflowJob(job schedulerJob) {
 	if providerName == "" {
 		providerName = strings.TrimSpace(job.Provider)
 	}
-	registry := action.NewRegistryFromEnv()
-	provider, err := registry.ProviderNamed(providerName, action.CapabilityWorkflowExecute)
+	resolve := w.resolveWorkflowProvider
+	if resolve == nil {
+		resolve = func(name string) (action.Provider, error) {
+			return action.NewRegistryFromEnv().ProviderNamed(name, action.CapabilityWorkflowExecute)
+		}
+	}
+	provider, err := resolve(providerName)
 	if err != nil {
 		source := providerName
 		if strings.TrimSpace(source) == "" {
@@ -341,6 +371,12 @@ func (w *watchdogScheduler) processWorkflowJob(job schedulerJob) {
 		KeyOrPath: workflowKey,
 		Inputs:    payload.Inputs,
 	})
+	// Shutdown cancellation is not a failure — the workflow was pre-empted,
+	// not rejected. Recording it as "failed" would corrupt persisted skill
+	// state; bail out and let the job remain scheduled for the next run.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return
+	}
 	now := w.clock.Now().UTC()
 	nextRun, hasNext := nextWorkflowRun(strings.TrimSpace(payload.ScheduleExpr), now)
 	if err != nil {

--- a/internal/team/scheduler.go
+++ b/internal/team/scheduler.go
@@ -76,6 +76,13 @@ type watchdogScheduler struct {
 	stopCh    chan struct{}
 	done      sync.WaitGroup
 
+	// runCtx is a cancelable derivation of the ctx passed to Start. Stop
+	// cancels it so any in-flight downstream call (e.g. a workflow provider
+	// blocked on a network request) returns promptly instead of pinning
+	// done.Wait — which would otherwise pin Launcher.Kill.
+	runCtx    context.Context
+	runCancel context.CancelFunc
+
 	// onTickDone, when non-nil, receives one struct after every
 	// processOnce call. Tests use it to wait deterministically; production
 	// leaves it nil so the loop has zero overhead.
@@ -87,6 +94,10 @@ type watchdogScheduler struct {
 // is called or ctx is cancelled.
 func (w *watchdogScheduler) Start(ctx context.Context) {
 	w.startOnce.Do(func() {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		w.runCtx, w.runCancel = context.WithCancel(ctx)
 		if w.stopCh == nil {
 			w.stopCh = make(chan struct{})
 		}
@@ -97,7 +108,7 @@ func (w *watchdogScheduler) Start(ctx context.Context) {
 			w.pollEvery = 20 * time.Second
 		}
 		w.done.Add(1)
-		go w.run(ctx)
+		go w.run(w.runCtx)
 	})
 }
 
@@ -146,6 +157,11 @@ func (w *watchdogScheduler) signalTick() {
 // Stop signals the goroutine to exit and waits for it. Idempotent.
 func (w *watchdogScheduler) Stop() {
 	w.stopOnce.Do(func() {
+		// Cancel runCtx first so any downstream blocking call (workflow
+		// provider, etc.) unblocks before we sit on done.Wait.
+		if w.runCancel != nil {
+			w.runCancel()
+		}
 		if w.stopCh == nil {
 			return
 		}
@@ -317,7 +333,11 @@ func (w *watchdogScheduler) processWorkflowJob(job schedulerJob) {
 		}
 		return
 	}
-	result, err := provider.ExecuteWorkflow(context.Background(), action.WorkflowExecuteRequest{
+	execCtx := w.runCtx
+	if execCtx == nil {
+		execCtx = context.Background()
+	}
+	result, err := provider.ExecuteWorkflow(execCtx, action.WorkflowExecuteRequest{
 		KeyOrPath: workflowKey,
 		Inputs:    payload.Inputs,
 	})

--- a/internal/team/scheduler_test.go
+++ b/internal/team/scheduler_test.go
@@ -279,6 +279,34 @@ func TestSchedulerStart_IdempotentDoubleStartIsNoOp(t *testing.T) {
 	w.Stop()
 }
 
+// Regression: Stop→Start→Stop must not leak the goroutine. With the
+// original sync.Once pair, the first Stop consumed stopOnce, then Start
+// happily spawned an unstoppable goroutine. The current mutex+flag
+// design makes Start a no-op after Stop, so no goroutine is spawned.
+func TestSchedulerStopBeforeStart_DisablesLaterStart(t *testing.T) {
+	w := &watchdogScheduler{
+		broker:       newSchedulerFixtureBroker(t),
+		clock:        newManualClock(time.Now()),
+		initialDelay: time.Hour,
+		pollEvery:    time.Hour,
+		deliverTask:  func(officeActionLog, teamTask) {},
+	}
+	w.Stop() // before Start
+	w.Start(context.Background())
+	// If Start spawned a goroutine despite the prior Stop, done.Wait
+	// in the second Stop would block on the leaked goroutine.
+	stopReturned := make(chan struct{})
+	go func() {
+		w.Stop()
+		close(stopReturned)
+	}()
+	select {
+	case <-stopReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("second Stop did not return — Start spawned an unstoppable goroutine after Stop")
+	}
+}
+
 func TestSchedulerUpdateJob_NilBrokerNoOp(t *testing.T) {
 	w := &watchdogScheduler{clock: newManualClock(time.Now())}
 	w.updateJob("x", "X", time.Minute, time.Now(), "scheduled")
@@ -461,6 +489,11 @@ type schedulerFixtureBroker struct {
 	jobStateUpdates  []jobStateCall
 	automationPosts  []automationCall
 	deliveredActions []string
+	skillUpdates     []skillUpdateCall
+}
+
+type skillUpdateCall struct {
+	key, status string
 }
 
 type alertCall struct {
@@ -532,7 +565,8 @@ func (b *schedulerFixtureBroker) PostAutomationMessage(_ string, channel string,
 	return channelMessage{}, false, nil
 }
 
-func (b *schedulerFixtureBroker) UpdateSkillExecutionByWorkflowKey(_, _ string, _ time.Time) error {
+func (b *schedulerFixtureBroker) UpdateSkillExecutionByWorkflowKey(key, status string, _ time.Time) error {
+	b.skillUpdates = append(b.skillUpdates, skillUpdateCall{key: key, status: status})
 	return nil
 }
 

--- a/internal/team/scheduler_test.go
+++ b/internal/team/scheduler_test.go
@@ -609,3 +609,47 @@ func TestLauncher_SchedulerWiringDelegatesProcessOnce(t *testing.T) {
 // known package-level string without importing internal packages. Trivial
 // const so the wiring test has something concrete to assert against.
 const launcherSchedulerSentinel = "watchdog scheduler"
+
+// Regression: Launcher.Kill() must drain the watchdog scheduler goroutine
+// before returning. The pre-refactor loop was for{ ... time.Sleep } with no
+// exit; C4 added Stop() but the first cut of Kill() did not call it, so the
+// goroutine outlived Kill and held a reference to the broker. This test
+// observes goroutine exit via done.Wait and asserts it closes promptly
+// after Kill returns. With the bug present, the goroutine sits forever on
+// the 1h initialDelay sleeper and exited never closes within the timeout.
+func TestLauncher_KillDrainsScheduler(t *testing.T) {
+	clk := newManualClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	sched := &watchdogScheduler{
+		broker:       newSchedulerFixtureBroker(t),
+		clock:        clk,
+		initialDelay: time.Hour, // intentionally never released by the manual clock
+		pollEvery:    time.Hour,
+		deliverTask:  func(officeActionLog, teamTask) {},
+	}
+	l := &Launcher{schedulerWorker: sched}
+	sched.Start(context.Background())
+
+	select {
+	case <-clk.registered:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("scheduler never registered its initial sleeper")
+	}
+
+	// Watch for goroutine exit. done is incremented by Start and decremented
+	// by run() at exit; if Kill drains via Stop, this fires immediately.
+	exited := make(chan struct{})
+	go func() {
+		sched.done.Wait()
+		close(exited)
+	}()
+
+	// Bare &Launcher{} takes the non-tmux Kill path; ignore the error —
+	// the only thing we care about is that Stop got invoked along the way.
+	_ = l.Kill()
+
+	select {
+	case <-exited:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("scheduler goroutine did not exit within 2s after Kill — Kill is not draining the scheduler")
+	}
+}

--- a/internal/team/scheduler_test.go
+++ b/internal/team/scheduler_test.go
@@ -1,0 +1,611 @@
+package team
+
+// Tests for the extracted watchdogScheduler type. Per PLAN.md §C4 this is
+// the first goroutine extraction; tests use a manual clock plus an
+// onTickDone signal channel to drive deterministic assertions without
+// time.Sleep (the user's hard rule).
+//
+// processDueWorkflowJob is intentionally not exercised here — it shells
+// out to action.NewRegistryFromEnv() + provider.ExecuteWorkflow, which
+// would require a live external workflow registry. Its scheduling
+// primitive (nextWorkflowRun) is tested via direct calls.
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNextWorkflowRun_EmptyExpressionReturnsFalse(t *testing.T) {
+	if _, ok := nextWorkflowRun("", time.Now()); ok {
+		t.Errorf("empty schedule expr should return ok=false")
+	}
+}
+
+func TestNextWorkflowRun_InvalidExpressionReturnsFalse(t *testing.T) {
+	if _, ok := nextWorkflowRun("not-a-cron", time.Now()); ok {
+		t.Errorf("invalid schedule expr should return ok=false")
+	}
+}
+
+func TestNextWorkflowRun_ValidCronAdvances(t *testing.T) {
+	after := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	next, ok := nextWorkflowRun("0 * * * *", after) // every hour at minute 0
+	if !ok {
+		t.Fatalf("expected ok=true for valid cron")
+	}
+	if !next.After(after) {
+		t.Errorf("next run should be after the reference time; got %v <= %v", next, after)
+	}
+}
+
+func TestSchedulerProcessOnce_TaskUnclaimedFiresAlert(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	b.tasks = []teamTask{{
+		ID: "t1", Channel: "general", Title: "do thing", Owner: "", Status: "in_progress",
+	}}
+	b.dueJobs = []schedulerJob{{
+		Slug: "j1", Channel: "general", TargetType: "task", TargetID: "t1",
+	}}
+
+	delivered := 0
+	sched := &watchdogScheduler{
+		broker:      b,
+		clock:       newManualClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)),
+		deliverTask: func(officeActionLog, teamTask) { delivered++ },
+	}
+	sched.processOnce()
+
+	if len(b.alerts) != 1 || b.alerts[0].kind != "task_unclaimed" {
+		t.Fatalf("expected one task_unclaimed alert; got %+v", b.alerts)
+	}
+	if delivered != 1 {
+		t.Errorf("expected one notification delivery; got %d", delivered)
+	}
+	if len(b.jobStateUpdates) == 0 || b.jobStateUpdates[len(b.jobStateUpdates)-1].status != "scheduled" {
+		t.Errorf("expected job rescheduled; got %+v", b.jobStateUpdates)
+	}
+}
+
+func TestSchedulerProcessOnce_TaskOwnedFiresStalled(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	b.tasks = []teamTask{{
+		ID: "t1", Channel: "general", Title: "do thing", Owner: "eng", Status: "in_progress",
+	}}
+	b.dueJobs = []schedulerJob{{
+		Slug: "j1", Channel: "general", TargetType: "task", TargetID: "t1",
+	}}
+
+	sched := &watchdogScheduler{
+		broker:      b,
+		clock:       newManualClock(time.Now()),
+		deliverTask: func(officeActionLog, teamTask) {},
+	}
+	sched.processOnce()
+
+	if len(b.alerts) != 1 || b.alerts[0].kind != "task_stalled" {
+		t.Fatalf("expected one task_stalled alert; got %+v", b.alerts)
+	}
+}
+
+func TestSchedulerProcessOnce_DoneTaskMarksJobDone(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	b.tasks = []teamTask{{
+		ID: "t1", Channel: "general", Title: "do thing", Owner: "eng", Status: "done",
+	}}
+	b.dueJobs = []schedulerJob{{
+		Slug: "j1", Channel: "general", TargetType: "task", TargetID: "t1",
+	}}
+
+	sched := &watchdogScheduler{broker: b, clock: newManualClock(time.Now()), deliverTask: func(officeActionLog, teamTask) {}}
+	sched.processOnce()
+
+	if len(b.alerts) != 0 {
+		t.Errorf("done task should not trigger an alert; got %+v", b.alerts)
+	}
+	if len(b.jobStateUpdates) != 1 || b.jobStateUpdates[0].status != "done" {
+		t.Errorf("expected job marked done; got %+v", b.jobStateUpdates)
+	}
+}
+
+func TestSchedulerProcessOnce_BlockedTaskSkipsAlert(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	b.tasks = []teamTask{{
+		ID: "t1", Channel: "general", Title: "do thing", Owner: "eng", Status: "in_progress", Blocked: true,
+	}}
+	b.dueJobs = []schedulerJob{{
+		Slug: "j1", Channel: "general", TargetType: "task", TargetID: "t1",
+	}}
+	sched := &watchdogScheduler{broker: b, clock: newManualClock(time.Now()), deliverTask: func(officeActionLog, teamTask) {}}
+	sched.processOnce()
+	if len(b.alerts) != 0 {
+		t.Errorf("blocked tasks must not trigger watchdog reminders; got %+v", b.alerts)
+	}
+	if len(b.jobStateUpdates) != 1 || b.jobStateUpdates[0].status != "scheduled" {
+		t.Errorf("blocked task job should reschedule; got %+v", b.jobStateUpdates)
+	}
+}
+
+func TestSchedulerProcessOnce_RequestActiveFiresAlertAndPostsAutomation(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	b.requests = []humanInterview{{
+		ID: "r1", Channel: "general", Title: "approve", From: "ceo",
+		Question: "do this?", Blocking: true,
+		Status: "pending",
+	}}
+	b.dueJobs = []schedulerJob{{
+		Slug: "j1", Channel: "general", TargetType: "request", TargetID: "r1",
+	}}
+	sched := &watchdogScheduler{broker: b, clock: newManualClock(time.Now()), deliverTask: func(officeActionLog, teamTask) {}}
+	sched.processOnce()
+
+	if len(b.alerts) != 1 || b.alerts[0].kind != "request_waiting" {
+		t.Fatalf("expected one request_waiting alert; got %+v", b.alerts)
+	}
+	if len(b.automationPosts) != 1 {
+		t.Errorf("expected one automation post for blocking request; got %+v", b.automationPosts)
+	}
+}
+
+func TestSchedulerProcessOnce_RequestInactiveMarksJobDone(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	b.requests = []humanInterview{{
+		ID: "r1", Channel: "general", Title: "approve", Status: "answered",
+	}}
+	b.dueJobs = []schedulerJob{{
+		Slug: "j1", Channel: "general", TargetType: "request", TargetID: "r1",
+	}}
+	sched := &watchdogScheduler{broker: b, clock: newManualClock(time.Now()), deliverTask: func(officeActionLog, teamTask) {}}
+	sched.processOnce()
+	if len(b.jobStateUpdates) != 1 || b.jobStateUpdates[0].status != "done" {
+		t.Errorf("inactive request job should be marked done; got %+v", b.jobStateUpdates)
+	}
+}
+
+func TestSchedulerProcessOnce_UnknownTargetTypeReschedules(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	b.dueJobs = []schedulerJob{{
+		Slug: "j1", Channel: "general", TargetType: "mystery", TargetID: "x",
+	}}
+	sched := &watchdogScheduler{broker: b, clock: newManualClock(time.Now()), deliverTask: func(officeActionLog, teamTask) {}}
+	sched.processOnce()
+	if len(b.jobStateUpdates) != 1 || b.jobStateUpdates[0].status != "scheduled" {
+		t.Errorf("unknown target type should reschedule; got %+v", b.jobStateUpdates)
+	}
+}
+
+func TestSchedulerRecordLedger_EmptyOwnerEscalates(t *testing.T) {
+	// Verify the escalate_to_ceo branch when owner is blank — the
+	// scheduler should ask the CEO to re-triage instead of nudging an
+	// empty owner.
+	var got struct{ kind, owner string }
+	b := &recordingLedgerBroker{
+		signals: []officeSignalRecord{{ID: "sig-1"}},
+		onDecision: func(kind, owner string) {
+			got.kind = kind
+			got.owner = owner
+		},
+	}
+	w := &watchdogScheduler{broker: b, clock: newManualClock(time.Now())}
+	_, decisionID := w.recordLedger("general", "task_unclaimed", "t1", "  ", "summary", "src-1")
+	if got.kind != "escalate_to_ceo" || got.owner != "ceo" {
+		t.Errorf("expected escalate_to_ceo for ceo; got kind=%q owner=%q", got.kind, got.owner)
+	}
+	if decisionID == "" {
+		t.Errorf("expected non-empty decision ID")
+	}
+}
+
+func TestSchedulerRecordLedger_RequestWaitingAsksHuman(t *testing.T) {
+	var got struct{ kind, owner string }
+	b := &recordingLedgerBroker{
+		signals: []officeSignalRecord{{ID: "sig-1"}},
+		onDecision: func(kind, owner string) {
+			got.kind = kind
+			got.owner = owner
+		},
+	}
+	w := &watchdogScheduler{broker: b, clock: newManualClock(time.Now())}
+	_, _ = w.recordLedger("general", "request_waiting", "r1", "ceo", "summary", "")
+	if got.kind != "ask_human" || got.owner != "ceo" {
+		t.Errorf("expected ask_human routed to ceo; got kind=%q owner=%q", got.kind, got.owner)
+	}
+}
+
+func TestSchedulerUpdateJob_PersistsToBroker(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	// Capture SetSchedulerJob into the fixture's deliveredActions log so
+	// the assertion is concrete.
+	var captured schedulerJob
+	b2 := &capturingSetJobBroker{
+		schedulerFixtureBroker: b,
+		captureSet: func(j schedulerJob) {
+			captured = j
+		},
+	}
+	w := &watchdogScheduler{
+		broker: b2,
+		clock:  newManualClock(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)),
+	}
+	w.updateJob("watchdog", "Watchdog", 5*time.Minute, time.Date(2026, 6, 1, 1, 0, 0, 0, time.UTC), "sleeping")
+	if captured.Slug != "watchdog" || captured.Label != "Watchdog" {
+		t.Errorf("SetSchedulerJob received wrong identity: %+v", captured)
+	}
+	if captured.IntervalMinutes != 5 {
+		t.Errorf("expected interval=5min; got %d", captured.IntervalMinutes)
+	}
+	if captured.Status != "sleeping" || captured.LastRun == "" {
+		t.Errorf("sleeping status should populate LastRun; got %+v", captured)
+	}
+}
+
+func TestSchedulerProcessOnce_NilBrokerNoOp(t *testing.T) {
+	w := &watchdogScheduler{clock: newManualClock(time.Now())}
+	w.processOnce() // must not panic
+}
+
+func TestSchedulerProcessOnce_EmptyJobsNoOp(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	w := &watchdogScheduler{broker: b, clock: newManualClock(time.Now())}
+	w.processOnce()
+	if len(b.jobStateUpdates) != 0 || len(b.alerts) != 0 {
+		t.Errorf("expected no side effects on empty job list")
+	}
+}
+
+func TestSchedulerSignalTick_NilChannelNoOp(t *testing.T) {
+	w := &watchdogScheduler{}
+	w.signalTick() // must not panic when onTickDone is nil
+}
+
+func TestSchedulerStop_IdempotentBeforeStart(t *testing.T) {
+	w := &watchdogScheduler{}
+	w.Stop() // must not panic when stopCh is nil
+	w.Stop() // and must be idempotent
+}
+
+func TestSchedulerStart_IdempotentDoubleStartIsNoOp(t *testing.T) {
+	w := &watchdogScheduler{
+		clock:        newManualClock(time.Now()),
+		initialDelay: time.Hour,
+		pollEvery:    time.Hour,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w.Start(ctx)
+	w.Start(ctx) // second call must hit startOnce and not spawn another goroutine
+	cancel()
+	w.Stop()
+}
+
+func TestSchedulerUpdateJob_NilBrokerNoOp(t *testing.T) {
+	w := &watchdogScheduler{clock: newManualClock(time.Now())}
+	w.updateJob("x", "X", time.Minute, time.Now(), "scheduled")
+}
+
+func TestSchedulerRun_NilBrokerExits(t *testing.T) {
+	// run() with broker=nil should exit immediately without calling After.
+	w := &watchdogScheduler{
+		clock:        newManualClock(time.Now()),
+		initialDelay: time.Minute,
+	}
+	w.stopCh = make(chan struct{})
+	w.done.Add(1)
+	go w.run(context.Background())
+	w.done.Wait() // must complete without us advancing the clock
+}
+
+func TestSchedulerWait_StopChCancels(t *testing.T) {
+	clk := newManualClock(time.Now())
+	w := &watchdogScheduler{clock: clk, stopCh: make(chan struct{})}
+	close(w.stopCh)
+	if got := w.wait(context.Background(), time.Hour); got {
+		t.Errorf("wait() should return false when stopCh is closed")
+	}
+}
+
+func TestRealClockAfterFires(t *testing.T) {
+	// Cheap exercise of realClock.After so its production path is
+	// represented in coverage. Uses a 1ms timer instead of time.Sleep —
+	// the only blocking primitive is the timer channel itself.
+	c := realClock{}
+	select {
+	case <-c.After(time.Millisecond):
+	case <-time.After(time.Second):
+		t.Fatalf("realClock.After never fired within 1s")
+	}
+	if c.Now().IsZero() {
+		t.Errorf("realClock.Now should never return zero time")
+	}
+}
+
+func TestSchedulerStartStop_DeterministicTickAndShutdown(t *testing.T) {
+	// Lifecycle test: Start() spawns the goroutine, manual clock advance
+	// triggers the first processOnce (signaled via onTickDone), Stop()
+	// drains the goroutine deterministically.
+	b := newSchedulerFixtureBroker(t)
+	b.dueJobs = []schedulerJob{{
+		Slug: "j1", Channel: "general", TargetType: "mystery", TargetID: "x",
+	}}
+	clk := newManualClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	tickDone := make(chan struct{}, 4)
+	sched := &watchdogScheduler{
+		broker:       b,
+		clock:        clk,
+		initialDelay: 15 * time.Second,
+		pollEvery:    20 * time.Second,
+		deliverTask:  func(officeActionLog, teamTask) {},
+		onTickDone:   tickDone,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sched.Start(ctx)
+
+	// Wait for the goroutine to register its initial-delay sleeper before
+	// advancing the clock. Without this, Advance can race ahead of the
+	// goroutine and the sleeper never fires. No time.Sleep needed — the
+	// manual clock's `registered` channel signals each After() call.
+	select {
+	case <-clk.registered:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("scheduler goroutine never registered its first sleeper")
+	}
+
+	// Advance past the initial delay; the loop should fire processOnce and
+	// signal tickDone exactly once.
+	clk.Advance(20 * time.Second)
+	select {
+	case <-tickDone:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("scheduler did not signal first tick within 2s")
+	}
+
+	if len(b.jobStateUpdates) < 1 {
+		t.Errorf("expected at least one job state update after first tick; got %+v", b.jobStateUpdates)
+	}
+
+	sched.Stop()
+
+	// After Stop(), advance the clock and confirm no further ticks fire.
+	clk.Advance(60 * time.Second)
+	select {
+	case <-tickDone:
+		t.Fatalf("expected no tick after Stop() drained the worker")
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+// ── manual clock + fixture broker for deterministic scheduler tests ──
+
+// manualClock is a minimal clock that exposes Advance() to release sleepers
+// past their deadline. After registers a one-shot sleeper that fires when
+// Advance crosses its deadline. registered is a buffered notification
+// channel: each After() call sends a struct, so tests can synchronously
+// wait for the goroutine to register its sleeper before advancing — this
+// is what kills the race between Start() and Advance() in lifecycle tests
+// without resorting to time.Sleep (the user's hard rule).
+type manualClock struct {
+	mu         sync.Mutex
+	now        time.Time
+	pending    []manualSleeper
+	stopOnce   sync.Once
+	registered chan struct{}
+}
+
+type manualSleeper struct {
+	deadline time.Time
+	fire     chan time.Time
+}
+
+func newManualClock(start time.Time) *manualClock {
+	return &manualClock{now: start, registered: make(chan struct{}, 16)}
+}
+
+func (c *manualClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *manualClock) After(d time.Duration) <-chan time.Time {
+	c.mu.Lock()
+	deadline := c.now.Add(d)
+	ch := make(chan time.Time, 1)
+	if !c.now.Before(deadline) {
+		ch <- c.now
+		c.mu.Unlock()
+		select {
+		case c.registered <- struct{}{}:
+		default:
+		}
+		return ch
+	}
+	c.pending = append(c.pending, manualSleeper{deadline: deadline, fire: ch})
+	c.mu.Unlock()
+	select {
+	case c.registered <- struct{}{}:
+	default:
+	}
+	return ch
+}
+
+// Advance moves the clock forward by d and releases any pending sleepers
+// whose deadline has been passed. Each released channel receives the
+// "now" value the scheduler would observe.
+func (c *manualClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	now := c.now
+	keep := c.pending[:0]
+	for _, s := range c.pending {
+		if !s.deadline.After(now) {
+			s.fire <- now
+		} else {
+			keep = append(keep, s)
+		}
+	}
+	c.pending = keep
+	c.mu.Unlock()
+}
+
+// schedulerFixtureBroker is a recording stub for the scheduler-broker
+// surface. Each call appends to its log slice; tests assert on the log
+// rather than on a real Broker fixture (which would require dragging in
+// JSON state files and the full broker init).
+type schedulerFixtureBroker struct {
+	tasks            []teamTask
+	requests         []humanInterview
+	dueJobs          []schedulerJob
+	alerts           []alertCall
+	jobStateUpdates  []jobStateCall
+	automationPosts  []automationCall
+	deliveredActions []string
+}
+
+type alertCall struct {
+	kind, channel, targetType, targetID, owner, summary string
+}
+type jobStateCall struct {
+	slug, status string
+}
+type automationCall struct {
+	channel, body string
+}
+
+func newSchedulerFixtureBroker(t *testing.T) *schedulerFixtureBroker {
+	t.Helper()
+	return &schedulerFixtureBroker{}
+}
+
+func (b *schedulerFixtureBroker) DueSchedulerJobs() []schedulerJob { return b.dueJobs }
+
+func (b *schedulerFixtureBroker) FindTask(channel, id string) (teamTask, bool) {
+	for _, t := range b.tasks {
+		if t.ID == id {
+			return t, true
+		}
+	}
+	return teamTask{}, false
+}
+
+func (b *schedulerFixtureBroker) FindRequest(channel, id string) (humanInterview, bool) {
+	for _, r := range b.requests {
+		if r.ID == id {
+			return r, true
+		}
+	}
+	return humanInterview{}, false
+}
+
+func (b *schedulerFixtureBroker) UpdateSchedulerJobState(slug string, _ time.Time, status string) error {
+	b.jobStateUpdates = append(b.jobStateUpdates, jobStateCall{slug: slug, status: status})
+	return nil
+}
+
+func (b *schedulerFixtureBroker) CreateWatchdogAlert(kind, channel, targetType, targetID, owner, summary string) (watchdogAlert, bool, error) {
+	b.alerts = append(b.alerts, alertCall{kind: kind, channel: channel, targetType: targetType, targetID: targetID, owner: owner, summary: summary})
+	return watchdogAlert{ID: "alert-1", Kind: kind, Channel: channel}, false, nil
+}
+
+func (b *schedulerFixtureBroker) RecordSignals(_ []officeSignal) ([]officeSignalRecord, error) {
+	return nil, nil
+}
+
+func (b *schedulerFixtureBroker) RecordDecision(kind, channel, summary, reason, owner string, _ []string, _, _ bool) (officeDecisionRecord, error) {
+	return officeDecisionRecord{ID: "decision-1"}, nil
+}
+
+func (b *schedulerFixtureBroker) RecordAction(kind, source, channel, actor, summary, related string, _ []string, _ string) error {
+	b.deliveredActions = append(b.deliveredActions, kind+":"+related)
+	return nil
+}
+
+func (b *schedulerFixtureBroker) ResumeTask(id, by, note string) (teamTask, bool, error) {
+	return teamTask{}, false, nil
+}
+
+func (b *schedulerFixtureBroker) PostAutomationMessage(_ string, channel string, _, body, _, _, _ string, _ []string, _ string) (channelMessage, bool, error) {
+	b.automationPosts = append(b.automationPosts, automationCall{channel: channel, body: body})
+	return channelMessage{}, false, nil
+}
+
+func (b *schedulerFixtureBroker) UpdateSkillExecutionByWorkflowKey(_, _ string, _ time.Time) error {
+	return nil
+}
+
+func (b *schedulerFixtureBroker) SetSchedulerJob(_ schedulerJob) error { return nil }
+
+// recordingLedgerBroker is a minimal stub that captures the kind+owner
+// passed to RecordDecision. Used by recordLedger branch tests.
+type recordingLedgerBroker struct {
+	signals    []officeSignalRecord
+	onDecision func(kind, owner string)
+}
+
+func (b *recordingLedgerBroker) DueSchedulerJobs() []schedulerJob         { return nil }
+func (b *recordingLedgerBroker) FindTask(string, string) (teamTask, bool) { return teamTask{}, false }
+func (b *recordingLedgerBroker) FindRequest(string, string) (humanInterview, bool) {
+	return humanInterview{}, false
+}
+func (b *recordingLedgerBroker) UpdateSchedulerJobState(string, time.Time, string) error { return nil }
+func (b *recordingLedgerBroker) CreateWatchdogAlert(string, string, string, string, string, string) (watchdogAlert, bool, error) {
+	return watchdogAlert{}, false, nil
+}
+func (b *recordingLedgerBroker) RecordSignals(_ []officeSignal) ([]officeSignalRecord, error) {
+	return b.signals, nil
+}
+func (b *recordingLedgerBroker) RecordDecision(kind, _, _, _, owner string, _ []string, _, _ bool) (officeDecisionRecord, error) {
+	if b.onDecision != nil {
+		b.onDecision(kind, owner)
+	}
+	return officeDecisionRecord{ID: "decision-1"}, nil
+}
+func (b *recordingLedgerBroker) RecordAction(string, string, string, string, string, string, []string, string) error {
+	return nil
+}
+func (b *recordingLedgerBroker) ResumeTask(string, string, string) (teamTask, bool, error) {
+	return teamTask{}, false, nil
+}
+func (b *recordingLedgerBroker) PostAutomationMessage(string, string, string, string, string, string, string, []string, string) (channelMessage, bool, error) {
+	return channelMessage{}, false, nil
+}
+func (b *recordingLedgerBroker) UpdateSkillExecutionByWorkflowKey(string, string, time.Time) error {
+	return nil
+}
+func (b *recordingLedgerBroker) SetSchedulerJob(schedulerJob) error { return nil }
+
+// capturingSetJobBroker wraps schedulerFixtureBroker and intercepts
+// SetSchedulerJob so updateJob persistence can be asserted on directly.
+type capturingSetJobBroker struct {
+	*schedulerFixtureBroker
+	captureSet func(schedulerJob)
+}
+
+func (b *capturingSetJobBroker) SetSchedulerJob(j schedulerJob) error {
+	if b.captureSet != nil {
+		b.captureSet(j)
+	}
+	return nil
+}
+
+// Sanity: assert that the launcher wires the scheduler broker correctly so
+// processOnce exercised through Launcher behaves the same as through the
+// type directly.
+func TestLauncher_SchedulerWiringDelegatesProcessOnce(t *testing.T) {
+	// Just ensure the launcher's lazy constructor runs without panic and
+	// returns a non-nil scheduler when broker is nil-friendly.
+	l := &Launcher{}
+	if got := l.scheduler(); got == nil {
+		t.Fatalf("scheduler() should return a scheduler even with nil broker; got nil")
+	}
+	if !strings.Contains(launcherSchedulerSentinel, "watchdog") {
+		t.Errorf("internal sanity: sentinel should mention watchdog")
+	}
+}
+
+// launcherSchedulerSentinel exists only so the test above can reference a
+// known package-level string without importing internal packages. Trivial
+// const so the wiring test has something concrete to assert against.
+const launcherSchedulerSentinel = "watchdog scheduler"

--- a/internal/team/scheduler_test.go
+++ b/internal/team/scheduler_test.go
@@ -12,7 +12,6 @@ package team
 
 import (
 	"context"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -482,8 +481,9 @@ func newSchedulerFixtureBroker(t *testing.T) *schedulerFixtureBroker {
 func (b *schedulerFixtureBroker) DueSchedulerJobs() []schedulerJob { return b.dueJobs }
 
 func (b *schedulerFixtureBroker) FindTask(channel, id string) (teamTask, bool) {
+	want := normalizeChannelSlug(channel)
 	for _, t := range b.tasks {
-		if t.ID == id {
+		if t.ID == id && normalizeChannelSlug(t.Channel) == want {
 			return t, true
 		}
 	}
@@ -491,8 +491,9 @@ func (b *schedulerFixtureBroker) FindTask(channel, id string) (teamTask, bool) {
 }
 
 func (b *schedulerFixtureBroker) FindRequest(channel, id string) (humanInterview, bool) {
+	want := normalizeChannelSlug(channel)
 	for _, r := range b.requests {
-		if r.ID == id {
+		if r.ID == id && normalizeChannelSlug(r.Channel) == want {
 			return r, true
 		}
 	}
@@ -590,25 +591,32 @@ func (b *capturingSetJobBroker) SetSchedulerJob(j schedulerJob) error {
 	return nil
 }
 
-// Sanity: assert that the launcher wires the scheduler broker correctly so
-// processOnce exercised through Launcher behaves the same as through the
-// type directly.
-func TestLauncher_SchedulerWiringDelegatesProcessOnce(t *testing.T) {
-	// Just ensure the launcher's lazy constructor runs without panic and
-	// returns a non-nil scheduler when broker is nil-friendly.
-	l := &Launcher{}
-	if got := l.scheduler(); got == nil {
-		t.Fatalf("scheduler() should return a scheduler even with nil broker; got nil")
+// Sanity: assert that the launcher wires the scheduler with broker, clock,
+// and deliverTask actually populated. Catches regressions where scheduler()
+// stops plumbing one of these fields and processOnce silently degrades.
+func TestLauncher_SchedulerWiring_PopulatesBrokerClockAndDeliver(t *testing.T) {
+	l := &Launcher{broker: &Broker{}}
+	s := l.scheduler()
+	if s == nil {
+		t.Fatalf("scheduler() should return non-nil")
 	}
-	if !strings.Contains(launcherSchedulerSentinel, "watchdog") {
-		t.Errorf("internal sanity: sentinel should mention watchdog")
+	// Same scheduler instance on subsequent calls (lazy + cached).
+	if s2 := l.scheduler(); s2 != s {
+		t.Errorf("scheduler() not memoized: first=%p second=%p", s, s2)
+	}
+	if s.broker == nil {
+		t.Error("scheduler.broker should be wired from Launcher.broker")
+	}
+	if s.clock == nil {
+		t.Error("scheduler.clock should default to realClock")
+	}
+	if _, ok := s.clock.(realClock); !ok {
+		t.Errorf("scheduler.clock should be realClock; got %T", s.clock)
+	}
+	if s.deliverTask == nil {
+		t.Error("scheduler.deliverTask should be wired to Launcher.deliverTaskNotification")
 	}
 }
-
-// launcherSchedulerSentinel exists only so the test above can reference a
-// known package-level string without importing internal packages. Trivial
-// const so the wiring test has something concrete to assert against.
-const launcherSchedulerSentinel = "watchdog scheduler"
 
 // Regression: Launcher.Kill() must drain the watchdog scheduler goroutine
 // before returning. The pre-refactor loop was for{ ... time.Sleep } with no

--- a/internal/team/scheduler_workflow_test.go
+++ b/internal/team/scheduler_workflow_test.go
@@ -1,0 +1,220 @@
+package team
+
+// scheduler_workflow_test.go covers processWorkflowJob via the
+// resolveWorkflowProvider seam. The seam lets us drive the
+// lookup-failure / cancel / execute-failure / execute-success
+// branches without spinning up a real action.Registry. Includes the
+// regression for context.Canceled mid-execute — pre-fix, that path
+// recorded the workflow as "failed" via UpdateSkillExecutionByWorkflowKey,
+// corrupting persisted skill state on graceful shutdown.
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/action"
+)
+
+// stubWorkflowProvider satisfies action.Provider with no-op defaults
+// for every method except Name and ExecuteWorkflow, which are wired
+// into the test fixtures. Other methods panic if called so a future
+// scheduler change that starts using them surfaces loudly.
+type stubWorkflowProvider struct {
+	name    string
+	execute func(ctx context.Context, req action.WorkflowExecuteRequest) (action.WorkflowExecuteResult, error)
+}
+
+func (p *stubWorkflowProvider) Name() string     { return p.name }
+func (p *stubWorkflowProvider) Configured() bool { return true }
+func (p *stubWorkflowProvider) Supports(action.Capability) bool {
+	return true
+}
+func (p *stubWorkflowProvider) ExecuteWorkflow(ctx context.Context, req action.WorkflowExecuteRequest) (action.WorkflowExecuteResult, error) {
+	if p.execute == nil {
+		return action.WorkflowExecuteResult{}, errors.New("test stub: execute not configured")
+	}
+	return p.execute(ctx, req)
+}
+
+func (p *stubWorkflowProvider) Guide(context.Context, string) (action.GuideResult, error) {
+	panic("test stub: Guide unexpectedly called")
+}
+func (p *stubWorkflowProvider) ListConnections(context.Context, action.ListConnectionsOptions) (action.ConnectionsResult, error) {
+	panic("test stub: ListConnections unexpectedly called")
+}
+func (p *stubWorkflowProvider) SearchActions(context.Context, string, string, string) (action.ActionSearchResult, error) {
+	panic("test stub: SearchActions unexpectedly called")
+}
+func (p *stubWorkflowProvider) ActionKnowledge(context.Context, string, string) (action.KnowledgeResult, error) {
+	panic("test stub: ActionKnowledge unexpectedly called")
+}
+func (p *stubWorkflowProvider) ExecuteAction(context.Context, action.ExecuteRequest) (action.ExecuteResult, error) {
+	panic("test stub: ExecuteAction unexpectedly called")
+}
+func (p *stubWorkflowProvider) CreateWorkflow(context.Context, action.WorkflowCreateRequest) (action.WorkflowCreateResult, error) {
+	panic("test stub: CreateWorkflow unexpectedly called")
+}
+func (p *stubWorkflowProvider) ListWorkflowRuns(context.Context, string) (action.WorkflowRunsResult, error) {
+	panic("test stub: ListWorkflowRuns unexpectedly called")
+}
+func (p *stubWorkflowProvider) ListRelays(context.Context, action.ListRelaysOptions) (action.RelayListResult, error) {
+	panic("test stub: ListRelays unexpectedly called")
+}
+func (p *stubWorkflowProvider) RelayEventTypes(context.Context, string) (action.RelayEventTypesResult, error) {
+	panic("test stub: RelayEventTypes unexpectedly called")
+}
+func (p *stubWorkflowProvider) CreateRelay(context.Context, action.RelayCreateRequest) (action.RelayResult, error) {
+	panic("test stub: CreateRelay unexpectedly called")
+}
+func (p *stubWorkflowProvider) ActivateRelay(context.Context, action.RelayActivateRequest) (action.RelayResult, error) {
+	panic("test stub: ActivateRelay unexpectedly called")
+}
+func (p *stubWorkflowProvider) ListRelayEvents(context.Context, action.RelayEventsOptions) (action.RelayEventsResult, error) {
+	panic("test stub: ListRelayEvents unexpectedly called")
+}
+func (p *stubWorkflowProvider) GetRelayEvent(context.Context, string) (action.RelayEventDetail, error) {
+	panic("test stub: GetRelayEvent unexpectedly called")
+}
+
+func newWorkflowJobScheduler(t *testing.T, broker schedulerBroker, resolve func(string) (action.Provider, error)) *watchdogScheduler {
+	t.Helper()
+	return &watchdogScheduler{
+		broker:                  broker,
+		clock:                   newManualClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)),
+		deliverTask:             func(officeActionLog, teamTask) {},
+		resolveWorkflowProvider: resolve,
+	}
+}
+
+func TestSchedulerProcessWorkflowJob_LookupFailureRecordsAndReschedules(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	resolve := func(name string) (action.Provider, error) {
+		return nil, errors.New("provider missing")
+	}
+	s := newWorkflowJobScheduler(t, b, resolve)
+	s.processWorkflowJob(schedulerJob{
+		Slug:        "wf-1",
+		Channel:     "general",
+		WorkflowKey: "report",
+		Provider:    "composio",
+	})
+	if len(b.deliveredActions) != 1 || b.deliveredActions[0] != "external_workflow_failed:report" {
+		t.Errorf("expected one external_workflow_failed action; got %+v", b.deliveredActions)
+	}
+	if len(b.skillUpdates) != 1 || b.skillUpdates[0].status != "failed" {
+		t.Errorf("expected one failed skill update; got %+v", b.skillUpdates)
+	}
+	if len(b.jobStateUpdates) != 1 || b.jobStateUpdates[0].slug != "wf-1" {
+		t.Errorf("expected one jobStateUpdate for wf-1; got %+v", b.jobStateUpdates)
+	}
+}
+
+func TestSchedulerProcessWorkflowJob_ExecuteSuccessRecordsAndUpdatesStatus(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	resolve := func(name string) (action.Provider, error) {
+		return &stubWorkflowProvider{
+			name: "composio",
+			execute: func(_ context.Context, _ action.WorkflowExecuteRequest) (action.WorkflowExecuteResult, error) {
+				return action.WorkflowExecuteResult{Status: "ok"}, nil
+			},
+		}, nil
+	}
+	s := newWorkflowJobScheduler(t, b, resolve)
+	s.processWorkflowJob(schedulerJob{
+		Slug:        "wf-2",
+		Channel:     "general",
+		WorkflowKey: "report",
+		Provider:    "composio",
+	})
+	if len(b.deliveredActions) != 1 || b.deliveredActions[0] != "external_workflow_executed:report" {
+		t.Errorf("expected one external_workflow_executed action; got %+v", b.deliveredActions)
+	}
+	if len(b.skillUpdates) != 1 || b.skillUpdates[0].status != "ok" {
+		t.Errorf("expected skill update with status=ok; got %+v", b.skillUpdates)
+	}
+}
+
+func TestSchedulerProcessWorkflowJob_ExecuteErrorRecordsFailure(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	resolve := func(name string) (action.Provider, error) {
+		return &stubWorkflowProvider{
+			name: "composio",
+			execute: func(_ context.Context, _ action.WorkflowExecuteRequest) (action.WorkflowExecuteResult, error) {
+				return action.WorkflowExecuteResult{}, errors.New("provider 500")
+			},
+		}, nil
+	}
+	s := newWorkflowJobScheduler(t, b, resolve)
+	s.processWorkflowJob(schedulerJob{
+		Slug:        "wf-3",
+		Channel:     "general",
+		WorkflowKey: "report",
+		Provider:    "composio",
+	})
+	if len(b.deliveredActions) != 1 || b.deliveredActions[0] != "external_workflow_failed:report" {
+		t.Errorf("expected one external_workflow_failed action; got %+v", b.deliveredActions)
+	}
+	if len(b.skillUpdates) != 1 || b.skillUpdates[0].status != "failed" {
+		t.Errorf("expected skill update with status=failed; got %+v", b.skillUpdates)
+	}
+}
+
+// Regression: a workflow execute returning context.Canceled (i.e. Stop
+// was called mid-execute) must NOT record the workflow as failed. With
+// the original cancelable-ctx fix and no Canceled special-case, this
+// path would call UpdateSkillExecutionByWorkflowKey(key, "failed") on
+// graceful shutdown, corrupting persisted skill state.
+func TestSchedulerProcessWorkflowJob_CanceledDoesNotRecordFailure(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	resolve := func(name string) (action.Provider, error) {
+		return &stubWorkflowProvider{
+			name: "composio",
+			execute: func(_ context.Context, _ action.WorkflowExecuteRequest) (action.WorkflowExecuteResult, error) {
+				return action.WorkflowExecuteResult{}, context.Canceled
+			},
+		}, nil
+	}
+	s := newWorkflowJobScheduler(t, b, resolve)
+	s.processWorkflowJob(schedulerJob{
+		Slug:        "wf-4",
+		Channel:     "general",
+		WorkflowKey: "report",
+		Provider:    "composio",
+	})
+	if len(b.deliveredActions) != 0 {
+		t.Errorf("cancellation must not record any action; got %+v", b.deliveredActions)
+	}
+	if len(b.skillUpdates) != 0 {
+		t.Errorf("cancellation must not update skill state; got %+v", b.skillUpdates)
+	}
+	if len(b.jobStateUpdates) != 0 {
+		t.Errorf("cancellation must not reschedule the job; got %+v", b.jobStateUpdates)
+	}
+}
+
+// And the same for context.DeadlineExceeded — same shutdown-protection
+// rationale; either error means "we never got to run the workflow."
+func TestSchedulerProcessWorkflowJob_DeadlineExceededDoesNotRecordFailure(t *testing.T) {
+	b := newSchedulerFixtureBroker(t)
+	resolve := func(name string) (action.Provider, error) {
+		return &stubWorkflowProvider{
+			name: "composio",
+			execute: func(_ context.Context, _ action.WorkflowExecuteRequest) (action.WorkflowExecuteResult, error) {
+				return action.WorkflowExecuteResult{}, context.DeadlineExceeded
+			},
+		}, nil
+	}
+	s := newWorkflowJobScheduler(t, b, resolve)
+	s.processWorkflowJob(schedulerJob{
+		Slug:        "wf-5",
+		Channel:     "general",
+		WorkflowKey: "report",
+		Provider:    "composio",
+	})
+	if len(b.deliveredActions) != 0 || len(b.skillUpdates) != 0 || len(b.jobStateUpdates) != 0 {
+		t.Errorf("deadline exceeded must not produce side effects; actions=%v skill=%v job=%v",
+			b.deliveredActions, b.skillUpdates, b.jobStateUpdates)
+	}
+}

--- a/scripts/check-file-coverage.sh
+++ b/scripts/check-file-coverage.sh
@@ -22,7 +22,7 @@
 #   GO_TEST_FLAGS="-count=1 -timeout 5m"  # extra flags for go test.
 #
 # Exit codes: 0 = all listed files >= min, 1 = at least one below, 2 = bad
-# input.
+# input or coverage-generation failure.
 
 set -uo pipefail
 
@@ -59,10 +59,13 @@ if [ -z "$profile" ]; then
   profile="$(mktemp -t wuphf-cover.XXXXXX)"
   trap 'rm -f "$profile"' EXIT
   # shellcheck disable=SC2086
-  go test ${GO_TEST_FLAGS:-} -coverprofile="$profile" -coverpkg="$pkg" "$pkg" >/dev/null
+  if ! go test ${GO_TEST_FLAGS:-} -coverprofile="$profile" -coverpkg="$pkg" "$pkg" >/dev/null; then
+    echo "check-file-coverage: failed to generate coverage profile (go test exit $?)" >&2
+    exit 2
+  fi
 fi
 
-# Module path is the prefix `go tool cover -func` prints before each file
+# Module path is the prefix coverprofile entries carry before each file
 # entry, so we need it to match against the relative paths the caller
 # passes in --files.
 module="$(go list -m 2>/dev/null)"
@@ -74,47 +77,44 @@ fi
 failures=0
 total=0
 
-# Convert "a,b,c" to a newline-separated list and iterate.
-echo "$files_csv" | tr ',' '\n' | while IFS= read -r rel; do
+# Run the loop in the parent shell via process substitution so updates to
+# `failures` and `total` are visible after the loop ends. Avoids a shared
+# /tmp sentinel that would clobber across concurrent invocations.
+while IFS= read -r rel; do
   [ -z "$rel" ] && continue
   total=$((total + 1))
-  # `go tool cover -func` lines look like:
-  #   github.com/nex-crm/wuphf/internal/team/prompt_builder.go:42:    Build         100.0%
-  # The trailing "total:" line is per-package, not per-file, so we filter
-  # it out by requiring a colon-delimited line number.
-  awk_out="$(go tool cover -func="$profile" \
-    | awk -v prefix="${module}/${rel}:" '
-        index($1, prefix) == 1 {
-          gsub("%", "", $NF)
-          covered += $NF
-          n += 1
-        }
-        END {
-          if (n == 0) { print "MISSING"; exit }
-          printf "%.1f %d\n", covered / n, n
-        }')"
+  # Coverprofile rows look like:
+  #   github.com/nex-crm/wuphf/internal/team/prompt_builder.go:42.2,44.13 3 1
+  # That's: file:start_line.col,end_line.col  numStmts  count.  We sum
+  # numStmts per file (covered when count>0, total always) so the gate
+  # measures *statement* coverage rather than averaged function %.
+  awk_out="$(awk -v prefix="${module}/${rel}:" '
+      $1 == "mode:" { next }
+      index($1, prefix) == 1 {
+        total += $2
+        if ($3 > 0) { covered += $2 }
+      }
+      END {
+        if (total == 0) { print "MISSING"; exit }
+        printf "%.1f %d\n", (covered / total) * 100, total
+      }
+    ' "$profile")"
 
   if [ "$awk_out" = "MISSING" ]; then
-    printf '  %-60s  no funcs in profile (file not covered by --pkg?)\n' "$rel" >&2
+    printf '  %-60s  no statements in profile (file not covered by --pkg?)\n' "$rel" >&2
     failures=$((failures + 1))
-    # Subshell — write progress to a tempfile so the parent can see it.
-    echo "$failures" > /tmp/wuphf-cov-failures
     continue
   fi
 
   pct="$(echo "$awk_out" | awk '{print $1}')"
-  funcs="$(echo "$awk_out" | awk '{print $2}')"
+  stmts="$(echo "$awk_out" | awk '{print $2}')"
   if awk -v p="$pct" -v m="$min" 'BEGIN { exit !(p + 0 < m + 0) }'; then
-    printf '  %-60s  %s%%  (%s funcs)  BELOW %s%%\n' "$rel" "$pct" "$funcs" "$min" >&2
+    printf '  %-60s  %s%%  (%s stmts)  BELOW %s%%\n' "$rel" "$pct" "$stmts" "$min" >&2
     failures=$((failures + 1))
   else
-    printf '  %-60s  %s%%  (%s funcs)  OK\n' "$rel" "$pct" "$funcs"
+    printf '  %-60s  %s%%  (%s stmts)  OK\n' "$rel" "$pct" "$stmts"
   fi
-  echo "$failures" > /tmp/wuphf-cov-failures
-done
-
-failures="$(cat /tmp/wuphf-cov-failures 2>/dev/null || echo 0)"
-rm -f /tmp/wuphf-cov-failures
+done < <(printf '%s\n' "$files_csv" | tr ',' '\n')
 
 if [ "$failures" -gt 0 ]; then
   echo "check-file-coverage: $failures file(s) below ${min}% floor" >&2

--- a/scripts/check-file-coverage.sh
+++ b/scripts/check-file-coverage.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# check-file-coverage.sh — enforce a per-file coverage floor on a list of
+# Go source files. Used during the launcher.go decomposition (PLAN.md) to
+# gate that newly extracted files (prompt_builder.go, office_targets.go,
+# scheduler.go, etc.) ship at >= 85% statement coverage while the residual
+# launcher.go is exempt.
+#
+# Why per-file (not per-package): see PLAN.md §4. We want the new code to
+# be high-coverage without holding it hostage to launcher.go's debt as
+# functions migrate out. Once the migration is done this script retires
+# in favor of a package-level floor.
+#
+# Usage:
+#   scripts/check-file-coverage.sh \
+#       --pkg ./internal/team \
+#       --min 85 \
+#       --files internal/team/prompt_builder.go,internal/team/office_targets.go
+#
+# Optional:
+#   COVER_PROFILE=/path/to/cover.out  # reuse an existing profile instead of
+#                                       running `go test -coverprofile`.
+#   GO_TEST_FLAGS="-count=1 -timeout 5m"  # extra flags for go test.
+#
+# Exit codes: 0 = all listed files >= min, 1 = at least one below, 2 = bad
+# input.
+
+set -uo pipefail
+
+min=""
+pkg=""
+files_csv=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --min) min="$2"; shift 2 ;;
+    --pkg) pkg="$2"; shift 2 ;;
+    --files) files_csv="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,28p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "check-file-coverage: unknown flag: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$min" ] || [ -z "$pkg" ] || [ -z "$files_csv" ]; then
+  echo "check-file-coverage: --min, --pkg, and --files are required" >&2
+  exit 2
+fi
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root" || exit 2
+
+profile="${COVER_PROFILE:-}"
+if [ -z "$profile" ]; then
+  profile="$(mktemp -t wuphf-cover.XXXXXX)"
+  trap 'rm -f "$profile"' EXIT
+  # shellcheck disable=SC2086
+  go test ${GO_TEST_FLAGS:-} -coverprofile="$profile" -coverpkg="$pkg" "$pkg" >/dev/null
+fi
+
+# Module path is the prefix `go tool cover -func` prints before each file
+# entry, so we need it to match against the relative paths the caller
+# passes in --files.
+module="$(go list -m 2>/dev/null)"
+if [ -z "$module" ]; then
+  echo "check-file-coverage: could not determine module (run inside a Go module)" >&2
+  exit 2
+fi
+
+failures=0
+total=0
+
+# Convert "a,b,c" to a newline-separated list and iterate.
+echo "$files_csv" | tr ',' '\n' | while IFS= read -r rel; do
+  [ -z "$rel" ] && continue
+  total=$((total + 1))
+  # `go tool cover -func` lines look like:
+  #   github.com/nex-crm/wuphf/internal/team/prompt_builder.go:42:    Build         100.0%
+  # The trailing "total:" line is per-package, not per-file, so we filter
+  # it out by requiring a colon-delimited line number.
+  awk_out="$(go tool cover -func="$profile" \
+    | awk -v prefix="${module}/${rel}:" '
+        index($1, prefix) == 1 {
+          gsub("%", "", $NF)
+          covered += $NF
+          n += 1
+        }
+        END {
+          if (n == 0) { print "MISSING"; exit }
+          printf "%.1f %d\n", covered / n, n
+        }')"
+
+  if [ "$awk_out" = "MISSING" ]; then
+    printf '  %-60s  no funcs in profile (file not covered by --pkg?)\n' "$rel" >&2
+    failures=$((failures + 1))
+    # Subshell — write progress to a tempfile so the parent can see it.
+    echo "$failures" > /tmp/wuphf-cov-failures
+    continue
+  fi
+
+  pct="$(echo "$awk_out" | awk '{print $1}')"
+  funcs="$(echo "$awk_out" | awk '{print $2}')"
+  if awk -v p="$pct" -v m="$min" 'BEGIN { exit !(p + 0 < m + 0) }'; then
+    printf '  %-60s  %s%%  (%s funcs)  BELOW %s%%\n' "$rel" "$pct" "$funcs" "$min" >&2
+    failures=$((failures + 1))
+  else
+    printf '  %-60s  %s%%  (%s funcs)  OK\n' "$rel" "$pct" "$funcs"
+  fi
+  echo "$failures" > /tmp/wuphf-cov-failures
+done
+
+failures="$(cat /tmp/wuphf-cov-failures 2>/dev/null || echo 0)"
+rm -f /tmp/wuphf-cov-failures
+
+if [ "$failures" -gt 0 ]; then
+  echo "check-file-coverage: $failures file(s) below ${min}% floor" >&2
+  exit 1
+fi
+echo "check-file-coverage: all listed files >= ${min}%"


### PR DESCRIPTION
Flattened roll-up of the launcher.go decomposition (PLAN.md §C1–§C4). Supersedes #406, #409, #423. The four extractions plus the review-feedback fixes land as seven atomic commits — merge with **rebase** to preserve them.

## Scope

- **C1 — `promptBuilder`** (#406): extracts system-prompt assembly. New `prompt_builder.go` (393 lines) + 13 tests.
- **C2 — `officeTargeter`** (#409): extracts pane/dispatch routing. New `office_targets.go` + 22 tests. Shared `paneBackedFlag *bool` and `failedPaneSlugs map` aliased back to launcher (PLAN.md §5 traps; full encapsulation deferred to C5).
- **C3 — `notificationContextBuilder`** (#423): extracts notification context + work-packet assembly. New `notification_context.go` + 23 tests.
- **C4 — `watchdogScheduler`** (#427): first goroutine extraction. New `scheduler.go` + 19 tests. Introduces `clock` interface (`realClock` / `manualClock`) and a deterministic `onTickDone` test seam — kills `time.Sleep` in tests.
- **Follow-up (docs)**: corrects the inaccurate `failedPaneSlugs` race comment in `office_targets.go`.
- **Follow-up (fix)**: wires `Launcher.Kill()` to call `scheduler.Stop()` so the watchdog goroutine drains on shutdown — the field comment claimed Kill called Stop but the wiring was missing. Includes a negative-controlled regression test `TestLauncher_KillDrainsScheduler`.
- **Review-comment batch**: thread cancelable ctx through `ExecuteWorkflow` (closes Kill→Stop loophole when a workflow provider hangs); resolve `RelevantTaskForTarget` via `UltimateThreadRoot` (deep-reply correctness); drive `AgentOrder`/`PaneSlugs` off `ActiveSessionMembers` (pack-order determinism); fix `check-file-coverage.sh` (fail-fast on `go test`, compute statement coverage from blocks, drop shared `/tmp` sentinel). Plus negative-controlled regression tests for the deep-reply and pack-order fixes.

## Diff shape

- launcher.go: 4998 → 3658 lines (**-1340, -26.8%** since main).
- 4 new files in `internal/team/` totaling ~2000 lines of moved logic + ~1900 lines of tests across 79 test cases.
- `PLAN.md` and `scripts/check-file-coverage.sh` ride along (added in C1).

## Compatibility shims (transitional)

C2/C3/C4 each retain Launcher-method wrappers that one-line-delegate to the extracted types. This deviates from PLAN.md §6 ("no shims") to avoid a ~150-call-site rename sweep that would dwarf the logic moves. Wrapper layer is deleted in a follow-up cleanup PR after C5/C6 land.

## Coverage gates (per-file, statement-level)

After fixing the `check-file-coverage.sh` math (it was averaging per-function percentages — see review-comment batch above), the real statement-coverage numbers are:

- `prompt_builder.go`: **97.4%** (gate ≥85%)
- `office_targets.go`: **89.8%**
- `notification_context.go`: **86.2%**
- `scheduler.go`: **82.8%** ← below the gate. The shortfall is `processWorkflowJob` (53.6%), which calls `action.NewRegistryFromEnv` and a live workflow provider. Adding a `workflowExecutor` seam to make this testable is deferred to C5/C6 (the registry call is part of the broader pane-lifecycle / external-action seaming work). The gate script is not currently CI-enforced, so this does not block merge — it's documented here as a known follow-up.

## Verification

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues
- [x] `go test -race -timeout 5m ./internal/team` (86s post-fixes, all green)
- [x] `go test -race` for the other 42 packages
- [x] Cross-compile windows/{amd64,arm64} + darwin/arm64
- [x] secretlint clean
- [x] Smoke binary OK
- [x] Staff + security review (negative-controlled the Kill→Stop fix and both review-comment regressions)

## Test plan

- [x] All extracted-file coverage gates pass except the documented `scheduler.go` shortfall
- [x] All extracted-file tests green under `-race`
- [x] Existing prompt / dispatch / notification / scheduler tests still pass
- [ ] CI green on the flattened PR

## Next slices

C5a / C5 / C6 will branch off main and land independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification-context assembly, deterministic office routing, per-agent prompt generation, and a watchdog scheduler for periodic task/request/workflow handling.

* **Refactor**
  * Decomposed core team/notification/scheduling responsibilities into focused, testable components for routing, prompt logic, and scheduling.

* **Documentation**
  * Added a staged migration and rollout plan with testing guidelines.

* **Tests**
  * Extensive deterministic unit and integration tests covering notifications, targeting, prompts, scheduler, and wiring.

* **Chores**
  * Added a file-level coverage checker script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->