### PR TITLE
[codex] fix launcher state wipe on blueprint restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to WUPHF will be documented in this file.
 ### Fixed
 
 - **Newly created agents now use the office avatar sprite system instead of falling back to the deprecated legacy procedural sprites.** Operation-generated slugs like `planner`, `builder`, `growth`, `reviewer`, and `operator` now resolve to generated office portraits, and arbitrary custom slugs get deterministic office-style procedural portraits in both web and TUI surfaces.
+- **Passing `--pack`/`--blueprint` no longer deletes broker state on launch.** Restarting the same office after a crash can pass the selected blueprint again; the launcher treated that as an authoritative reseed and removed `broker-state.json`, making the office look wiped even though `wuphf shred` was never run.
+- **Fresh wikis no longer warn during Stage B skill synthesis because `team/agents/` does not exist yet.** The notebook signal scanner now treats the missing agents directory as an empty signal source.
 - **Caret no longer drifts when typing past an `@agent` chip in the composer.** The mirror-overlay treatment rendered mention chips with 4–5px horizontal padding and `font-size: 0.9em`, so each chip took more width than the raw text in the textarea behind it. The caret fell behind the typed characters by a few pixels after every chip. Composer chips now inherit the textarea's font metrics exactly (15px, no padding, `display: inline`) and only apply a background highlight — layout-neutral, so character-for-character alignment with the textarea is preserved. Message-bubble chips keep the original styled pill treatment.
 
 ### Changed
@@ -152,7 +154,7 @@ All notable changes to WUPHF will be documented in this file.
 
 ### Added
 - **Shred your workspace from Settings.** New "Danger Zone" section in the web Settings with a `Shred workspace` button that deletes your team, company identity, office task receipts, and workflows, then reopens onboarding on next launch. The card lists exactly what gets deleted vs preserved, and the confirm modal requires typing `i am sure` before firing. Task worktrees, logs, sessions, LLM caches, and `config.json` are always preserved.
-- **`wuphf shred` CLI subcommand.** Full workspace wipe that reopens onboarding. Prompts for the verb to confirm, or takes `-y` for scripted teardown. `wuphf kill` kept as an alias.
+- **`wuphf shred` CLI subcommand.** Full workspace wipe that reopens onboarding. Prompts for the verb to confirm, or takes `-y` for scripted teardown.
 - **`/shred` slash command in the TUI.** Wipes the workspace in-process, then exits the session so your next `wuphf` boots clean. The existing `/reset` (clear transcript and refresh panes) is unchanged.
 
 ## [0.0.3.0] - 2026-04-14

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The examples below assume `wuphf` is on your `PATH`. If you just built the binar
 
 ```bash
 wuphf init          # First-time setup
-wuphf shred         # Kill a running session
+wuphf shred         # Delete workspace state and reopen onboarding
 wuphf --1o1         # 1:1 with the CEO
 wuphf --1o1 cro     # 1:1 with a specific agent
 ```

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -53,7 +53,7 @@ func printSubcommandHelp(sub string) {
 		fmt.Fprintln(os.Stderr, "  wuphf init")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "This writes to ~/.wuphf/config.json. Safe to re-run.")
-	case "shred", "kill":
+	case "shred":
 		fmt.Fprintln(os.Stderr, "wuphf shred — burn the whole workspace down")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Stops the running session, clears broker state, and deletes the team")
@@ -66,7 +66,6 @@ func printSubcommandHelp(sub string) {
 		fmt.Fprintln(os.Stderr, "Usage:")
 		fmt.Fprintln(os.Stderr, "  wuphf shred           Prompts before wiping")
 		fmt.Fprintln(os.Stderr, "  wuphf shred -y        Skip the confirmation")
-		fmt.Fprintln(os.Stderr, "  wuphf kill            (alias)")
 	case "import":
 		fmt.Fprintln(os.Stderr, "wuphf import — pull state from another tool")
 		fmt.Fprintln(os.Stderr, "")
@@ -269,12 +268,12 @@ func main() {
 				os.Exit(1)
 			}
 			return
-		case "shred", "kill":
+		case "shred":
 			if !confirmDestructive(args[1:], "shred", shredSummary) {
 				fmt.Println("Cancelled. The office lives to serve another day.")
 				return
 			}
-			if err := killRunningSession(selectedBlueprint); err != nil {
+			if err := stopRunningSession(selectedBlueprint); err != nil {
 				fmt.Fprintf(os.Stderr, "error: %v\n", err)
 				os.Exit(1)
 			}
@@ -514,7 +513,6 @@ func runTeam(args []string, packSlug string, unsafe bool, oneOnOne bool, opusCEO
 	fmt.Println("  Ctrl+B z         zoom a pane full-screen")
 	fmt.Println("  Ctrl+B d         detach (keeps running)")
 	fmt.Println("  /quit            exit everything")
-	fmt.Printf("  %s shred        stop from outside\n", appName)
 	fmt.Println()
 
 	if err := l.Attach(); err != nil {
@@ -697,11 +695,11 @@ func confirmDestructive(rest []string, verb, summary string) bool {
 	return strings.TrimSpace(line) == verb
 }
 
-// killRunningSession stops any running tmux or web-mode WUPHF session.
+// stopRunningSession stops any running tmux or web-mode WUPHF session.
 // Safe to call when nothing is running — Kill is a no-op in that case.
 // Tolerates NewLauncher failing (e.g. invalid blueprint) because we don't
 // want a broken config to block the user from cleaning up.
-func killRunningSession(blueprint string) error {
+func stopRunningSession(blueprint string) error {
 	l, err := team.NewLauncher(blueprint)
 	if err != nil {
 		// Launcher couldn't hydrate — likely no running session anyway.

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -219,8 +219,10 @@ func NewLauncher(packSlug string) (*Launcher, error) {
 		return nil, fmt.Errorf("unknown pack or operation blueprint: %s", packSlug)
 	}
 
-	// --pack is authoritative: when explicitly provided, reset company.json to
-	// match the pack so the broker doesn't silently load stale members.
+	// --pack is authoritative for company.json, but it must not implicitly
+	// delete broker runtime state. A restart after a crash may pass the same
+	// pack/blueprint again; wiping broker-state.json there makes the office
+	// appear to reset even though the user never requested a destructive wipe.
 	if explicitPack {
 		var err error
 		switch {
@@ -232,8 +234,6 @@ func NewLauncher(packSlug string) (*Launcher, error) {
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: save blueprint/pack config: %v\n", err)
 		}
-		// Drop stale broker state so the new pack starts clean.
-		_ = os.Remove(defaultBrokerStatePath())
 	}
 	sessionMode, oneOnOne := loadRunningSessionMode()
 

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -124,6 +124,47 @@ func TestNewLauncherFromScratchUsesGenericOffice(t *testing.T) {
 	}
 }
 
+func TestNewLauncherExplicitPackPreservesBrokerState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("WUPHF_RUNTIME_HOME", home)
+	t.Setenv("WUPHF_BROKER_TOKEN", "")
+
+	statePath := defaultBrokerStatePath()
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	state := brokerState{
+		Messages: []channelMessage{{
+			ID:        "msg-keep",
+			From:      "human",
+			Channel:   "general",
+			Content:   "preserve this office state",
+			Timestamp: time.Now().UTC().Format(time.RFC3339),
+		}},
+		Counter: 9,
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshal state: %v", err)
+	}
+	if err := os.WriteFile(statePath, raw, 0o600); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	if _, err := NewLauncher("founding-team"); err != nil {
+		t.Fatalf("NewLauncher: %v", err)
+	}
+
+	loaded, err := loadBrokerStateFile(statePath)
+	if err != nil {
+		t.Fatalf("expected broker state to survive explicit pack launch: %v", err)
+	}
+	if len(loaded.Messages) != 1 || loaded.Messages[0].ID != "msg-keep" || loaded.Counter != 9 {
+		t.Fatalf("broker state was not preserved: %+v", loaded)
+	}
+}
+
 func TestAgentPaneSlugsUsesOfficeRosterNotStaticPack(t *testing.T) {
 	l := &Launcher{
 		pack: &agent.PackDefinition{

--- a/internal/team/notebook_signal_scanner.go
+++ b/internal/team/notebook_signal_scanner.go
@@ -120,6 +120,14 @@ type notebookEntry struct {
 // files are skipped.
 func (s *NotebookSignalScanner) collectNotebookEntries(wikiRoot string) ([]notebookEntry, error) {
 	root := filepath.Join(wikiRoot, agentsDirPrefix[:len(agentsDirPrefix)-1])
+	if info, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	} else if !info.IsDir() {
+		return nil, nil
+	}
 	var out []notebookEntry
 	walkErr := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/internal/team/notebook_signal_scanner_test.go
+++ b/internal/team/notebook_signal_scanner_test.go
@@ -158,6 +158,20 @@ func TestNotebookSignalScanner_NoBrokerOrWorkerIsHarmless(t *testing.T) {
 	}
 }
 
+func TestNotebookSignalScanner_MissingAgentsDirIsHarmless(t *testing.T) {
+	b, _, teardown := newNotebookScannerHarness(t)
+	defer teardown()
+
+	scanner := NewNotebookSignalScanner(b)
+	cands, err := scanner.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 candidates with no team/agents dir, got %d", len(cands))
+	}
+}
+
 func TestTokenizeForCluster_DropsStopwordsAndShortTokens(t *testing.T) {
 	got := tokenizeForCluster("The quick BROWN fox a in")
 	for _, sw := range []string{"the", "in", "a"} {


### PR DESCRIPTION
## Summary

- Stop treating an explicit `--pack`/`--blueprint` launch as permission to delete `broker-state.json`.
- Remove the `wuphf kill` alias/surface so `wuphf shred` is the only destructive cleanup command.
- Treat a missing `team/agents/` notebook directory as an empty Stage B signal source instead of logging a warning.

## Root Cause

A restart after a killed WUPHF process can pass the active blueprint again. `NewLauncher` previously removed `~/.wuphf/team/broker-state.json` whenever a pack/blueprint argument was explicit, which made the office appear wiped even though `wuphf shred` was never invoked.

## Validation

- `go test ./cmd/wuphf`
- `go test ./internal/team`
- `go test ./internal/workspace`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restarting with `--pack` or `--blueprint` now preserves broker state instead of removing it at launch.
  * Stage B skill synthesis no longer emits warnings for fresh wikis when `team/agents/` directory is missing.

* **Documentation**
  * Updated documentation for the `wuphf shred` command to clarify behavior and removed outdated CLI alias references.

* **Tests**
  * Added regression tests for broker state preservation and missing directory handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->