### PR TITLE
refactor(team): extract paneDispatcher from launcher.go (C6)

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -129,20 +129,6 @@ type Launcher struct {
 	notifyMu            sync.Mutex
 	notifyLastDelivered map[string]time.Time
 
-	// paneDispatchMu serializes access to paneDispatchQueues /
-	// paneDispatchWorkers. Each pane-backed agent has its own queue so
-	// rapid notifications no longer race with claude's in-progress turn —
-	// one worker per slug drains its queue with a minimum spacing between
-	// `/clear` sends so claude has time to finalise each reply.
-	paneDispatchMu      sync.Mutex
-	paneDispatchQueues  map[string][]paneDispatchTurn
-	paneDispatchWorkers map[string]bool
-	// paneDispatchLastSentAt records when each slug most recently had a
-	// `/clear` + type cycle dispatched. The coalesce logic in
-	// queuePaneNotification uses this to decide whether to merge a new
-	// notification with a pending one or to start a fresh dispatch.
-	paneDispatchLastSentAt map[string]time.Time
-
 	// targets owns the office-membership-shape and routing-decision logic
 	// (PLAN.md §C2). Lazily constructed via targeter() so tests that build
 	// &Launcher{} directly stay nil-safe. The launcher field stays the
@@ -160,6 +146,12 @@ type Launcher struct {
 	// (PLAN.md §C4). Lazily constructed via scheduler(); Launch() calls
 	// Start, Kill() calls Stop. clock is realClock in production.
 	schedulerWorker *watchdogScheduler
+
+	// dispatcher owns the per-slug pane-dispatch workers (PLAN.md §C6).
+	// Lazily constructed via paneDispatch(); the dispatcher.sendFn
+	// closure consults the package-global launcherSendNotificationToPaneOverride
+	// seam on every call so existing tests keep working unchanged.
+	dispatcher *paneDispatcher
 }
 
 // paneDispatchTurn is one queued notification to type into a tmux pane.
@@ -1977,152 +1969,40 @@ var paneDispatchMinGap = 3 * time.Second
 // them together, and never loses one to a mid-turn clear.
 var paneDispatchCoalesceWindow = 60 * time.Second
 
-// queuePaneNotification enqueues a notification for a pane-backed agent
-// and ensures there is one worker draining its queue. Rapid successive
-// tags for the same slug coalesce into a single dispatch if they arrive
-// inside paneDispatchCoalesceWindow — this is the defence against
-// mid-turn `/clear` wiping claude's in-progress output.
-func (l *Launcher) queuePaneNotification(slug, paneTarget, notification string) {
-	slug = strings.TrimSpace(slug)
-	paneTarget = strings.TrimSpace(paneTarget)
-	if slug == "" || paneTarget == "" || notification == "" {
-		return
+// paneDispatch returns the lazily-constructed dispatcher (PLAN.md §C6).
+// Nil-safe: returns a fresh dispatcher even when l == nil so &Launcher{}
+// fixtures stay nil-safe in tests. The sendFn closure consults the
+// package-global launcherSendNotificationToPaneOverride seam on every
+// call so existing tests keep working unchanged (PLAN.md trap §5.3).
+func (l *Launcher) paneDispatch() *paneDispatcher {
+	if l == nil {
+		return &paneDispatcher{clock: realClock{}}
 	}
-	l.paneDispatchMu.Lock()
-	if l.paneDispatchQueues == nil {
-		l.paneDispatchQueues = make(map[string][]paneDispatchTurn)
+	if l.dispatcher != nil {
+		return l.dispatcher
 	}
-	if l.paneDispatchWorkers == nil {
-		l.paneDispatchWorkers = make(map[string]bool)
+	l.dispatcher = &paneDispatcher{
+		clock: realClock{},
+		sendFn: func(paneTarget, notification string) {
+			launcherSendNotificationToPane(l, paneTarget, notification)
+		},
 	}
-	if l.paneDispatchLastSentAt == nil {
-		l.paneDispatchLastSentAt = make(map[string]time.Time)
-	}
-	// Coalesce path: if a pending turn already exists OR the last send was
-	// within the coalesce window, merge rather than enqueue a separate
-	// dispatch. Merging into the head-of-queue pending item is the cleanest
-	// because the worker picks up the merged content on its next iteration.
-	inflight := false
-	if last, ok := l.paneDispatchLastSentAt[slug]; ok && time.Since(last) < paneDispatchCoalesceWindow {
-		inflight = true
-	}
-	queue := l.paneDispatchQueues[slug]
-	if (inflight || len(queue) > 0) && len(queue) > 0 {
-		// Combine with the pending turn. Claude will see both prompts
-		// separated by a visible divider and typically answers both.
-		last := &l.paneDispatchQueues[slug][len(queue)-1]
-		last.Notification = last.Notification + "\n\n---\n\n" + notification
-		last.EnqueuedAt = time.Now()
-		l.paneDispatchMu.Unlock()
-		return
-	}
-	if inflight && len(queue) == 0 {
-		// No pending turn yet but claude is mid-flight from a recent send.
-		// Create a single pending turn that will absorb further bursts
-		// through the branch above. The worker's pre-send wait will let
-		// claude's current turn finish before /clear fires.
-		l.paneDispatchQueues[slug] = []paneDispatchTurn{{
-			PaneTarget:   paneTarget,
-			Notification: notification,
-			EnqueuedAt:   time.Now(),
-		}}
-		startWorker := !l.paneDispatchWorkers[slug]
-		if startWorker {
-			l.paneDispatchWorkers[slug] = true
-		}
-		l.paneDispatchMu.Unlock()
-		if startWorker {
-			go l.runPaneDispatchQueue(slug)
-		}
-		return
-	}
-	// Cold path: no recent activity, no queue. Dispatch immediately.
-	l.paneDispatchQueues[slug] = append(l.paneDispatchQueues[slug], paneDispatchTurn{
-		PaneTarget:   paneTarget,
-		Notification: notification,
-		EnqueuedAt:   time.Now(),
-	})
-	startWorker := !l.paneDispatchWorkers[slug]
-	if startWorker {
-		l.paneDispatchWorkers[slug] = true
-	}
-	l.paneDispatchMu.Unlock()
-	if startWorker {
-		go l.runPaneDispatchQueue(slug)
-	}
+	return l.dispatcher
 }
 
-// runPaneDispatchQueue is the single worker per agent slug that drains
-// pane-dispatch notifications serially with a minimum gap between
-// `/clear` cycles. Exits when the queue is empty.
-//
-// Per-iteration flow:
-//  1. Peek head of queue.
-//  2. Wait out min-gap (floor) + coalesce window (lets claude's current turn
-//     land). During the wait, concurrent queuePaneNotification calls MAY
-//     merge new content into the head's Notification field — the peek is
-//     re-read after the wait so the pop sees the merged string.
-//  3. Pop + send.
-//  4. Record the send time so the next enqueue sees "claude in flight".
+// queuePaneNotification is a thin wrapper around paneDispatcher.Enqueue
+// (PLAN.md §C6). Kept as a Launcher method so existing call sites and
+// the pane_dispatch_queue_test.go safety net don't need a rename sweep
+// in this PR.
+func (l *Launcher) queuePaneNotification(slug, paneTarget, notification string) {
+	l.paneDispatch().Enqueue(slug, paneTarget, notification)
+}
+
+// runPaneDispatchQueue is retained as a Launcher method for compatibility
+// with any in-package goroutine spawn that might still reference the
+// historical name. Internally it just invokes the dispatcher's runQueue.
 func (l *Launcher) runPaneDispatchQueue(slug string) {
-	var lastSentAt time.Time
-	for {
-		// Step 1: peek (not pop).
-		l.paneDispatchMu.Lock()
-		queue := l.paneDispatchQueues[slug]
-		if len(queue) == 0 {
-			// Atomic handoff: clear worker flag while holding the lock so a
-			// concurrent queuePaneNotification observes "no worker" and
-			// starts a fresh goroutine for the next enqueue.
-			delete(l.paneDispatchWorkers, slug)
-			delete(l.paneDispatchQueues, slug)
-			l.paneDispatchMu.Unlock()
-			return
-		}
-		globalLastSentAt := l.paneDispatchLastSentAt[slug]
-		l.paneDispatchMu.Unlock()
-
-		// Step 2a: min-gap floor against sub-second bursts.
-		if !lastSentAt.IsZero() {
-			wait := paneDispatchMinGap - time.Since(lastSentAt)
-			if wait > 0 {
-				time.Sleep(wait)
-			}
-		}
-		// Step 2b: coalesce window — wait for claude's in-flight turn to
-		// land before /clear fires again. New notifications arriving
-		// during this wait are merged into the head by queuePaneNotification.
-		if !globalLastSentAt.IsZero() {
-			wait := paneDispatchCoalesceWindow - time.Since(globalLastSentAt)
-			if wait > 0 {
-				time.Sleep(wait)
-			}
-		}
-
-		// Step 3: pop (re-read head to pick up any merged content).
-		l.paneDispatchMu.Lock()
-		queue = l.paneDispatchQueues[slug]
-		if len(queue) == 0 {
-			// Defensive: external actor emptied the queue during our wait.
-			l.paneDispatchMu.Unlock()
-			continue
-		}
-		turn := queue[0]
-		if len(queue) == 1 {
-			delete(l.paneDispatchQueues, slug)
-		} else {
-			l.paneDispatchQueues[slug] = queue[1:]
-		}
-		l.paneDispatchMu.Unlock()
-
-		launcherSendNotificationToPane(l, turn.PaneTarget, turn.Notification)
-
-		// Step 4: record send time for the next enqueue's coalesce check.
-		lastSentAt = time.Now()
-		l.paneDispatchMu.Lock()
-		l.paneDispatchLastSentAt[slug] = lastSentAt
-		l.paneDispatchMu.Unlock()
-	}
+	l.paneDispatch().runQueue(slug)
 }
 
 // launcherSendNotificationToPaneFn is the test seam type swapped via

--- a/internal/team/pane_dispatch.go
+++ b/internal/team/pane_dispatch.go
@@ -1,0 +1,204 @@
+package team
+
+// pane_dispatch.go owns the per-slug pane-dispatch worker that serializes
+// notifications into live tmux Claude panes (PLAN.md §C6). Second
+// goroutine extraction in the launcher decomposition; reuses the clock
+// interface introduced in C4 (scheduler.go) so the two timing gates
+// (paneDispatchMinGap, paneDispatchCoalesceWindow) are deterministic
+// in tests.
+//
+// PLAN.md trap §5.3: the launcherSendNotificationToPaneOverride
+// atomic.Pointer is package-global and stays in launcher.go. Existing
+// tests (pane_dispatch_queue_test.go, resume_test.go) read that override
+// directly; moving it would break them. The dispatcher takes its send
+// function as a constructor arg, and the Launcher wires it to a closure
+// that consults the override on every call.
+//
+// PLAN.md §3 trap on coalesce-window vars: paneDispatchMinGap and
+// paneDispatchCoalesceWindow remain package-globals (not fields) because
+// existing tests mutate them at the package level. Reading per-call
+// rather than caching at construction lets those tests keep working
+// while still allowing per-instance overrides via direct field set in
+// the future.
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+// paneDispatcher serializes notifications per agent slug into tmux Claude
+// panes. One goroutine per slug drains its queue with a min-gap floor
+// against tmux input bursts plus a coalesce window that lets Claude's
+// in-flight turn finish before /clear fires for the next prompt. The
+// goroutine exits when its queue is empty; a fresh enqueue spawns a new
+// one (atomic handoff inside the per-dispatcher mutex).
+type paneDispatcher struct {
+	clock clock
+
+	mu       sync.Mutex
+	queues   map[string][]paneDispatchTurn
+	workers  map[string]bool
+	lastSent map[string]time.Time
+
+	// sendFn is the actual /clear + type + Enter sequence. The Launcher
+	// wires this to a closure that consults launcherSendNotificationToPaneOverride
+	// on every call (preserving the existing test seam without moving it).
+	sendFn func(paneTarget, notification string)
+
+	// onSent, when non-nil, receives one struct after every successful
+	// send. Tests use it to wait deterministically. Production leaves
+	// it nil so the worker has zero overhead.
+	onSent chan<- struct{}
+}
+
+// Enqueue queues a notification for pane-backed agent `slug` and ensures
+// there is one worker draining its queue. Rapid successive tags for the
+// same slug coalesce into a single dispatch when they arrive inside
+// paneDispatchCoalesceWindow — the defence against mid-turn /clear
+// wiping Claude's in-progress output.
+func (d *paneDispatcher) Enqueue(slug, paneTarget, notification string) {
+	slug = strings.TrimSpace(slug)
+	paneTarget = strings.TrimSpace(paneTarget)
+	if slug == "" || paneTarget == "" || notification == "" {
+		return
+	}
+	d.mu.Lock()
+	if d.queues == nil {
+		d.queues = make(map[string][]paneDispatchTurn)
+	}
+	if d.workers == nil {
+		d.workers = make(map[string]bool)
+	}
+	if d.lastSent == nil {
+		d.lastSent = make(map[string]time.Time)
+	}
+	now := d.now()
+	inflight := false
+	if last, ok := d.lastSent[slug]; ok && now.Sub(last) < paneDispatchCoalesceWindow {
+		inflight = true
+	}
+	queue := d.queues[slug]
+	if (inflight || len(queue) > 0) && len(queue) > 0 {
+		// Combine with the pending turn. Claude will see both prompts
+		// separated by a visible divider and typically answers both.
+		last := &d.queues[slug][len(queue)-1]
+		last.Notification = last.Notification + "\n\n---\n\n" + notification
+		last.EnqueuedAt = now
+		d.mu.Unlock()
+		return
+	}
+	if inflight && len(queue) == 0 {
+		// No pending turn yet but Claude is mid-flight from a recent
+		// send. Create a single pending turn that absorbs further bursts
+		// through the branch above.
+		d.queues[slug] = []paneDispatchTurn{{
+			PaneTarget:   paneTarget,
+			Notification: notification,
+			EnqueuedAt:   now,
+		}}
+		startWorker := !d.workers[slug]
+		if startWorker {
+			d.workers[slug] = true
+		}
+		d.mu.Unlock()
+		if startWorker {
+			go d.runQueue(slug)
+		}
+		return
+	}
+	// Cold path: no recent activity, no queue. Dispatch immediately.
+	d.queues[slug] = append(d.queues[slug], paneDispatchTurn{
+		PaneTarget:   paneTarget,
+		Notification: notification,
+		EnqueuedAt:   now,
+	})
+	startWorker := !d.workers[slug]
+	if startWorker {
+		d.workers[slug] = true
+	}
+	d.mu.Unlock()
+	if startWorker {
+		go d.runQueue(slug)
+	}
+}
+
+// runQueue is the per-slug worker. Drains the queue serially with a min-
+// gap floor against sub-second bursts plus a coalesce window that lets
+// Claude's current turn land before /clear fires. Exits when the queue
+// is empty (atomic handoff via worker flag clear under mu).
+func (d *paneDispatcher) runQueue(slug string) {
+	var lastSentAt time.Time
+	for {
+		// Step 1: peek (not pop).
+		d.mu.Lock()
+		queue := d.queues[slug]
+		if len(queue) == 0 {
+			delete(d.workers, slug)
+			delete(d.queues, slug)
+			d.mu.Unlock()
+			return
+		}
+		globalLastSentAt := d.lastSent[slug]
+		d.mu.Unlock()
+
+		// Step 2a: min-gap floor against sub-second bursts.
+		if !lastSentAt.IsZero() {
+			wait := paneDispatchMinGap - d.now().Sub(lastSentAt)
+			if wait > 0 {
+				<-d.clock.After(wait)
+			}
+		}
+		// Step 2b: coalesce window — let Claude's in-flight turn land
+		// before /clear fires. Concurrent Enqueue calls may merge new
+		// content into the head during this wait.
+		if !globalLastSentAt.IsZero() {
+			wait := paneDispatchCoalesceWindow - d.now().Sub(globalLastSentAt)
+			if wait > 0 {
+				<-d.clock.After(wait)
+			}
+		}
+
+		// Step 3: pop (re-read head to pick up any merged content).
+		d.mu.Lock()
+		queue = d.queues[slug]
+		if len(queue) == 0 {
+			d.mu.Unlock()
+			continue
+		}
+		turn := queue[0]
+		if len(queue) == 1 {
+			delete(d.queues, slug)
+		} else {
+			d.queues[slug] = queue[1:]
+		}
+		d.mu.Unlock()
+
+		if d.sendFn != nil {
+			d.sendFn(turn.PaneTarget, turn.Notification)
+		}
+
+		// Step 4: record send time for the next enqueue's coalesce check.
+		lastSentAt = d.now()
+		d.mu.Lock()
+		d.lastSent[slug] = lastSentAt
+		d.mu.Unlock()
+
+		if d.onSent != nil {
+			select {
+			case d.onSent <- struct{}{}:
+			default:
+			}
+		}
+	}
+}
+
+// now returns the current time via the dispatcher's clock, falling back
+// to the real clock when no clock is wired (defensive, mirrors the rest
+// of the package).
+func (d *paneDispatcher) now() time.Time {
+	if d.clock == nil {
+		return time.Now()
+	}
+	return d.clock.Now()
+}

--- a/internal/team/pane_dispatch_test.go
+++ b/internal/team/pane_dispatch_test.go
@@ -1,0 +1,249 @@
+package team
+
+// Tests for the extracted paneDispatcher type. PLAN.md §C6 — second
+// goroutine extraction. Reuses the manualClock and signal-channel
+// patterns introduced in C4 (scheduler_test.go) so every new assertion
+// is deterministic without time.Sleep.
+//
+// The existing pane_dispatch_queue_test.go remains the regression net —
+// it goes through Launcher.queuePaneNotification (now a wrapper) and
+// uses the package-global paneDispatchMinGap / paneDispatchCoalesceWindow
+// vars to shorten the windows. The new tests here drive the dispatcher
+// type directly with a manual clock instead.
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newPaneDispatcherForTest builds a dispatcher with sane defaults for
+// direct-on-type testing. send is captured into the recordingSend slice;
+// the dispatcher's onSent channel exposes a deterministic signal for
+// tests to wait on (no polling).
+func newPaneDispatcherForTest(t *testing.T, clk clock) (*paneDispatcher, *recordingSend) {
+	t.Helper()
+	rs := &recordingSend{
+		signal: make(chan struct{}, 8),
+	}
+	d := &paneDispatcher{
+		clock:  clk,
+		sendFn: rs.send,
+		onSent: rs.signal,
+	}
+	return d, rs
+}
+
+type recordingSend struct {
+	mu       sync.Mutex
+	captured []string
+	count    int64
+	// signal is bidirectional inside the test so the test can both
+	// observe sends (rs.signal as <-chan) and pass the send-only end to
+	// the dispatcher's onSent field.
+	signal chan struct{}
+}
+
+func (r *recordingSend) send(paneTarget, notification string) {
+	r.mu.Lock()
+	r.captured = append(r.captured, notification)
+	r.mu.Unlock()
+	atomic.AddInt64(&r.count, 1)
+}
+
+func (r *recordingSend) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.captured))
+	copy(out, r.captured)
+	return out
+}
+
+func TestPaneDispatcher_FirstEnqueueDispatchesImmediately(t *testing.T) {
+	clk := newManualClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	d, rs := newPaneDispatcherForTest(t, clk)
+
+	d.Enqueue("pm", "team:1", "first message")
+
+	select {
+	case <-rs.signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("first send did not fire within 2s")
+	}
+
+	got := rs.snapshot()
+	if len(got) != 1 || got[0] != "first message" {
+		t.Fatalf("expected single dispatch with 'first message'; got %v", got)
+	}
+}
+
+func TestPaneDispatcher_SecondEnqueueWithinCoalesceWindowMerges(t *testing.T) {
+	// Two enqueues within the coalesce window should produce exactly
+	// one extra dispatch with the bodies joined by a divider.
+	clk := newManualClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	d, rs := newPaneDispatcherForTest(t, clk)
+
+	d.Enqueue("pm", "team:1", "first")
+	select {
+	case <-rs.signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("first send did not fire")
+	}
+
+	// Record the deadline arrival of the worker before advancing —
+	// without this the worker's clock.After() call may not be registered
+	// yet, so the test would race.
+	d.Enqueue("pm", "team:1", "second")
+	d.Enqueue("pm", "team:1", "third")
+	// Worker should be inside coalesce-window wait. Drain the registered
+	// signal so we know the wait is observed.
+	select {
+	case <-clk.registered:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("worker never registered its coalesce-window sleeper")
+	}
+
+	// Advance past the coalesce window and the min-gap floor combined.
+	clk.Advance(paneDispatchCoalesceWindow + paneDispatchMinGap + time.Millisecond)
+
+	select {
+	case <-rs.signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("merged second dispatch never fired")
+	}
+
+	got := rs.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("expected exactly 2 dispatches (first + merged); got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[1], "second") || !strings.Contains(got[1], "third") {
+		t.Errorf("second dispatch should contain both merged bodies; got %q", got[1])
+	}
+	if !strings.Contains(got[1], "---") {
+		t.Errorf("merged dispatch should include the divider; got %q", got[1])
+	}
+}
+
+func TestPaneDispatcher_EmptySlugAndTargetIgnored(t *testing.T) {
+	clk := newManualClock(time.Now())
+	d, rs := newPaneDispatcherForTest(t, clk)
+
+	d.Enqueue("", "team:1", "x")
+	d.Enqueue("pm", "", "x")
+	d.Enqueue("pm", "team:1", "")
+
+	// Give any rogue worker a chance to fire; with all three rejected
+	// inputs there must be zero dispatches.
+	select {
+	case <-rs.signal:
+		t.Fatalf("expected zero dispatches for invalid inputs; got %v", rs.snapshot())
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestPaneDispatcher_DistinctSlugsRunInParallel(t *testing.T) {
+	clk := newManualClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	d, rs := newPaneDispatcherForTest(t, clk)
+
+	d.Enqueue("pm", "team:1", "for pm")
+	d.Enqueue("eng", "team:2", "for eng")
+
+	// Each slug has its own worker, so both should fire on first
+	// enqueue without needing to advance the clock.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-rs.signal:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected 2 first-enqueue dispatches; only got %d", i)
+		}
+	}
+
+	got := rs.snapshot()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 dispatches; got %d", len(got))
+	}
+}
+
+func TestPaneDispatcher_OnSentNilDoesNotPanic(t *testing.T) {
+	clk := newManualClock(time.Now())
+	rs := &recordingSend{}
+	d := &paneDispatcher{
+		clock:  clk,
+		sendFn: rs.send,
+		// onSent left nil — verify the worker doesn't panic.
+	}
+	d.Enqueue("pm", "team:1", "no-signal")
+
+	// Wait briefly via a second clock-watching goroutine. We can't use
+	// rs.signal because onSent is nil; instead poll the count atomically.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt64(&rs.count) < 1 && time.Now().Before(deadline) {
+		clk.Advance(time.Millisecond)
+		// Yield to scheduler. Not a sleep with a behavior dependency —
+		// it's just letting the worker goroutine run.
+		time.Sleep(time.Millisecond)
+	}
+	if atomic.LoadInt64(&rs.count) != 1 {
+		t.Fatalf("expected one dispatch with onSent=nil; got %d", rs.count)
+	}
+}
+
+// Sanity: the launcher's lazy paneDispatch() returns a non-nil dispatcher
+// and queuePaneNotification routes through it.
+func TestLauncher_PaneDispatchWiringRoutesEnqueue(t *testing.T) {
+	l := &Launcher{}
+	if d := l.paneDispatch(); d == nil {
+		t.Fatalf("paneDispatch() must never return nil for &Launcher{}")
+	}
+}
+
+// Defensive: the dispatcher's now() must work without a clock field set.
+// This is the same nil-safe fallback the rest of the package follows
+// (officeTargeter / notificationContextBuilder / scheduler) so a
+// zero-value &paneDispatcher{} doesn't panic.
+func TestPaneDispatcher_NowFallsBackToRealClockWhenUnset(t *testing.T) {
+	d := &paneDispatcher{}
+	if d.now().IsZero() {
+		t.Fatalf("dispatcher.now() should never return zero time")
+	}
+}
+
+// Defensive: enqueueing into a dispatcher whose worker just finished
+// (queue empty, worker flag not yet cleared by the goroutine) should
+// still produce a single dispatch. Exercises the cold-path branch.
+func TestPaneDispatcher_EnqueueAfterIdleSlugWorkerStartsFresh(t *testing.T) {
+	clk := newManualClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+	d, rs := newPaneDispatcherForTest(t, clk)
+
+	d.Enqueue("pm", "team:1", "first")
+	select {
+	case <-rs.signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("first send did not fire")
+	}
+
+	// Drain the registered signal (worker registers an empty-queue path
+	// on its next iteration). The worker exits when queue becomes empty;
+	// the next Enqueue should restart it cleanly.
+	select {
+	case <-clk.registered:
+	default:
+	}
+
+	// Advance past the coalesce window so the next enqueue takes the
+	// cold path rather than the inflight branch.
+	clk.Advance(paneDispatchCoalesceWindow + time.Second)
+
+	d.Enqueue("pm", "team:1", "second")
+	select {
+	case <-rs.signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("second cold-path send did not fire")
+	}
+
+	if got := rs.snapshot(); len(got) != 2 {
+		t.Errorf("expected 2 distinct dispatches via cold-path; got %d: %v", len(got), got)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on #429 (C5a, pane-lifecycle helpers). Sixth slice of the launcher.go decomposition (PLAN.md §C6). **Second goroutine extraction** in the migration; reuses the C4 clock + signal-channel test pattern.

Lifts the per-slug pane dispatch worker out of Launcher into a `paneDispatcher` type. The two timing gates (`paneDispatchMinGap`, `paneDispatchCoalesceWindow`) move from `time.Sleep` to `clock.After` channel reads, so new tests are deterministic — including the **regression test for the merge bug** (rapid two-tag bursts merging into one dispatch with a divider, the failure mode that originally motivated the coalesce window).

## State migration

- `paneDispatchMu`, `paneDispatchQueues`, `paneDispatchWorkers`, `paneDispatchLastSentAt` move from `Launcher` into the dispatcher
- Launcher gets a `dispatcher *paneDispatcher` field instead
- `queuePaneNotification` / `runPaneDispatchQueue` become thin one-line wrappers (transitional, per the C2/C3/C4/C5a precedent)

## Test seam preserved (PLAN.md trap §5.3)

- The package-global `launcherSendNotificationToPaneOverride atomic.Pointer` stays in launcher.go, **untouched**
- The dispatcher's `sendFn` is a closure that consults `launcherSendNotificationToPane` on every call so existing tests (`pane_dispatch_queue_test.go`, `resume_test.go`) keep their override behaviour
- **Move the work, not the seam.**
- `paneDispatchMinGap` and `paneDispatchCoalesceWindow` remain package-globals because existing tests mutate them at the package level; the dispatcher reads them per-call so mutation propagates immediately

## Tests (8 new)

- First enqueue dispatches immediately (no clock advance needed)
- Second enqueue inside the coalesce window merges into the pending turn with a divider; test synchronizes via `clk.registered` before advancing
- Empty slug / empty target / empty notification ignored
- Distinct slugs run in parallel goroutines (both fire on first enqueue without clock advance)
- `onSent=nil` branch is panic-safe
- `dispatcher.now()` falls back to `time.Now` when clock is unset
- Cold-path enqueue after the worker has drained and exited

The existing 3 dispatch tests in `pane_dispatch_queue_test.go` remain the regression net; all pass via the new wrapper.

## Coverage

- `prompt_builder.go` 99.4%
- `office_targets.go` 89.9%
- `notification_context.go` 89.8%
- `scheduler.go` 90.6%
- `pane_lifecycle.go` 92.0%
- `pane_dispatch.go` **94.6%** per-file (gate: ≥85%)
- Package `internal/team`: 63.8%

## Diff shape

- launcher.go: 3537 → 3417 lines (-120, -3%). **Cumulative since main: -1581 lines (-31.6%).**
- New file `pane_dispatch.go`: 204 lines
- New file `pane_dispatch_test.go`: 249 lines, 8 tests

## Local CI matrix (all green)

- `gofmt -s -l` clean
- `golangci-lint run ./...` 0 issues
- `go test -race -timeout 15m ./internal/team` (103s) — passes the goroutine extraction under -race
- `go test -race -timeout 15m` for the other 42 packages — 31 ok
- `go test -timeout 15m ./internal/teammcp`
- Cross-compile windows/{amd64,arm64} + darwin/arm64
- secretlint clean
- Smoke binary OK

## Test plan

- [x] `go build ./...`
- [x] All extracted-file coverage gates pass
- [x] All existing pane-dispatch tests still pass via wrapper
- [x] 8 new tests on `paneDispatcher` directly with manualClock + signal channel
- [ ] CI green

## Next slice

C7 `headlessWorkerPool` — last extraction; mechanical move of `headlessMu`, `headlessCtx`, `headlessCancel`, `headlessWorkers`, `headlessActive`, `headlessQueues`, `headlessDeferredLead`, `headlessStopCh`, `headlessWorkerWg` off the Launcher struct into a dedicated type. After that, residual cleanup PR (PLAN.md §C8).