### PR TITLE
refactor(team): extract headlessWorkerPool from Launcher (C7)

### DIFF
--- a/internal/team/broker_test.go
+++ b/internal/team/broker_test.go
@@ -6119,10 +6119,12 @@ func makeFocusModeLauncher(t *testing.T) (*Launcher, *Broker) {
 				{Slug: "pm", Name: "Product Manager"},
 			},
 		},
-		broker:          b,
-		headlessWorkers: make(map[string]bool),
-		headlessActive:  make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:  make(map[string][]headlessCodexTurn),
+		broker: b,
+		headless: headlessWorkerPool{
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
 	}
 	return l, b
 }
@@ -6199,10 +6201,12 @@ func TestFocusModeRouting_CollaborativeUntaggedWakesAll(t *testing.T) {
 				{Slug: "pm", Name: "Product Manager"},
 			},
 		},
-		broker:          b,
-		headlessWorkers: make(map[string]bool),
-		headlessActive:  make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:  make(map[string][]headlessCodexTurn),
+		broker: b,
+		headless: headlessWorkerPool{
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
 	}
 
 	msg := channelMessage{
@@ -6239,15 +6243,17 @@ func TestHeadlessQueue_EmptyBeforePush(t *testing.T) {
 				{Slug: "eng", Name: "Engineer"},
 			},
 		},
-		headlessWorkers: make(map[string]bool),
-		headlessActive:  make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:  make(map[string][]headlessCodexTurn),
+		headless: headlessWorkerPool{
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
 	}
 
-	l.headlessMu.Lock()
-	ceoLen := len(l.headlessQueues["ceo"])
-	engLen := len(l.headlessQueues["eng"])
-	l.headlessMu.Unlock()
+	l.headless.mu.Lock()
+	ceoLen := len(l.headless.queues["ceo"])
+	engLen := len(l.headless.queues["eng"])
+	l.headless.mu.Unlock()
 
 	if ceoLen != 0 || engLen != 0 {
 		t.Fatalf("expected empty queues before any push, got ceo=%d eng=%d", ceoLen, engLen)
@@ -6273,19 +6279,21 @@ func TestHeadlessQueue_PopulatedAfterEnqueue(t *testing.T) {
 				{Slug: "eng", Name: "Engineer"},
 			},
 		},
-		headlessWorkers: make(map[string]bool),
-		headlessActive:  make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:  make(map[string][]headlessCodexTurn),
+		headless: headlessWorkerPool{
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
 	}
-	l.headlessCtx, l.headlessCancel = context.WithCancel(t.Context())
+	l.headless.ctx, l.headless.cancel = context.WithCancel(t.Context())
 	t.Cleanup(func() { l.waitForHeadlessIdle(t) })
 
 	l.enqueueHeadlessCodexTurn("eng", "review the diff")
 
-	l.headlessMu.Lock()
-	engLen := len(l.headlessQueues["eng"])
-	ceoLen := len(l.headlessQueues["ceo"])
-	l.headlessMu.Unlock()
+	l.headless.mu.Lock()
+	engLen := len(l.headless.queues["eng"])
+	ceoLen := len(l.headless.queues["ceo"])
+	l.headless.mu.Unlock()
 
 	// The worker goroutine may have already consumed the turn from the queue —
 	// that is valid. What matters is that the queue was populated (worker started)
@@ -6293,7 +6301,7 @@ func TestHeadlessQueue_PopulatedAfterEnqueue(t *testing.T) {
 	if ceoLen != 0 {
 		t.Fatalf("expected ceo queue empty after enqueuing for eng, got %d", ceoLen)
 	}
-	if !l.headlessWorkers["eng"] {
+	if !l.headless.workers["eng"] {
 		t.Fatalf("expected eng worker to be flagged as started after enqueue")
 	}
 	// engLen may be 0 (worker consumed it) or 1 (still pending) — both are valid.
@@ -6312,24 +6320,26 @@ func TestHeadlessQueue_NoTimerDrivenWakeup(t *testing.T) {
 				{Slug: "eng", Name: "Engineer"},
 			},
 		},
-		headlessWorkers: make(map[string]bool),
-		headlessActive:  make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:  make(map[string][]headlessCodexTurn),
+		headless: headlessWorkerPool{
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
 	}
 
 	// No enqueue calls. The queues must remain empty.
-	l.headlessMu.Lock()
+	l.headless.mu.Lock()
 	totalItems := 0
-	for _, q := range l.headlessQueues {
+	for _, q := range l.headless.queues {
 		totalItems += len(q)
 	}
-	l.headlessMu.Unlock()
+	l.headless.mu.Unlock()
 
 	if totalItems != 0 {
 		t.Fatalf("expected no queued turns without an explicit enqueue, got %d", totalItems)
 	}
-	if len(l.headlessWorkers) != 0 {
-		t.Fatalf("expected no workers started without an explicit enqueue, got %v", l.headlessWorkers)
+	if len(l.headless.workers) != 0 {
+		t.Fatalf("expected no workers started without an explicit enqueue, got %v", l.headless.workers)
 	}
 }
 

--- a/internal/team/headless_claude_test.go
+++ b/internal/team/headless_claude_test.go
@@ -23,10 +23,12 @@ func minimalLauncher(opusCEO bool) *Launcher {
 				{Slug: "pm", Name: "Product Manager"},
 			},
 		},
-		opusCEO:         opusCEO,
-		headlessWorkers: make(map[string]bool),
-		headlessActive:  make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:  make(map[string][]headlessCodexTurn),
+		opusCEO: opusCEO,
+		headless: headlessWorkerPool{
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
 	}
 }
 
@@ -78,10 +80,12 @@ func TestHeadlessClaudeModel_CustomLeadSlug(t *testing.T) {
 				{Slug: "crew", Name: "Crew"},
 			},
 		},
-		opusCEO:         true,
-		headlessWorkers: make(map[string]bool),
-		headlessActive:  make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:  make(map[string][]headlessCodexTurn),
+		opusCEO: true,
+		headless: headlessWorkerPool{
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
 	}
 
 	tests := []struct {

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -184,7 +184,7 @@ func (l *Launcher) launchHeadlessCodex() error {
 		return fmt.Errorf("write office pid: %w", err)
 	}
 
-	l.headlessCtx, l.headlessCancel = context.WithCancel(context.Background())
+	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
 
 	l.resumeInFlightWork()
 	go l.notifyAgentsLoop()
@@ -235,21 +235,21 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	var staleAge time.Duration
 	startWorker := false
 
-	l.headlessMu.Lock()
-	if l.headlessQueues == nil {
-		l.headlessQueues = make(map[string][]headlessCodexTurn)
+	l.headless.mu.Lock()
+	if l.headless.queues == nil {
+		l.headless.queues = make(map[string][]headlessCodexTurn)
 	}
-	if l.headlessActive == nil {
-		l.headlessActive = make(map[string]*headlessCodexActiveTurn)
+	if l.headless.active == nil {
+		l.headless.active = make(map[string]*headlessCodexActiveTurn)
 	}
-	if l.headlessWorkers == nil {
-		l.headlessWorkers = make(map[string]bool)
+	if l.headless.workers == nil {
+		l.headless.workers = make(map[string]bool)
 	}
 	urgentLeadTurn := l.headlessLeadTurnNeedsImmediateWakeLocked(slug, turn.Prompt)
 	if turn.TaskID != "" {
-		if active := l.headlessActive[slug]; active != nil && strings.TrimSpace(active.Turn.TaskID) == turn.TaskID {
+		if active := l.headless.active[slug]; active != nil && strings.TrimSpace(active.Turn.TaskID) == turn.TaskID {
 			if !(slug == l.officeLeadSlug() && urgentLeadTurn) && turn.Attempts <= active.Turn.Attempts {
-				l.headlessMu.Unlock()
+				l.headless.mu.Unlock()
 				if slug == l.officeLeadSlug() {
 					appendHeadlessCodexLog(slug, "queue-drop: lead already handling same task")
 				} else {
@@ -259,11 +259,11 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 			}
 		}
 		if pending := l.replaceDuplicateTaskTurnLocked(slug, turn); pending {
-			if !l.headlessWorkers[slug] {
-				l.headlessWorkers[slug] = true
+			if !l.headless.workers[slug] {
+				l.headless.workers[slug] = true
 				startWorker = true
 			}
-			l.headlessMu.Unlock()
+			l.headless.mu.Unlock()
 			if slug == l.officeLeadSlug() {
 				appendHeadlessCodexLog(slug, "queue-replace: refreshed pending lead turn for same task")
 			} else {
@@ -281,24 +281,24 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	// still running. This eliminates the race condition where CEO fires after the
 	// first specialist completes and redundantly re-routes to still-running agents.
 	if slug == l.officeLeadSlug() && !urgentLeadTurn {
-		for workerSlug, queue := range l.headlessQueues {
+		for workerSlug, queue := range l.headless.queues {
 			if workerSlug == slug {
 				continue
 			}
 			if len(queue) > 0 {
-				l.headlessDeferredLead = &turn
-				l.headlessMu.Unlock()
+				l.headless.deferredLead = &turn
+				l.headless.mu.Unlock()
 				appendHeadlessCodexLog(slug, "queue-hold: specialist still queued, deferring lead notification until all work lands")
 				return
 			}
 		}
-		for workerSlug, active := range l.headlessActive {
+		for workerSlug, active := range l.headless.active {
 			if workerSlug == slug {
 				continue
 			}
 			if active != nil {
-				l.headlessDeferredLead = &turn
-				l.headlessMu.Unlock()
+				l.headless.deferredLead = &turn
+				l.headless.mu.Unlock()
 				appendHeadlessCodexLog(slug, "queue-hold: specialist still running, deferring lead notification until all work lands")
 				return
 			}
@@ -309,30 +309,30 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	// stack up redundant CEO turns that each re-route the same task. One pending
 	// turn is enough to catch the latest state; extras are dropped.
 	const leadMaxPending = 1
-	if slug == l.officeLeadSlug() && len(l.headlessQueues[slug]) >= leadMaxPending {
+	if slug == l.officeLeadSlug() && len(l.headless.queues[slug]) >= leadMaxPending {
 		if urgentLeadTurn {
-			l.headlessQueues[slug][len(l.headlessQueues[slug])-1] = turn
-			if !l.headlessWorkers[slug] {
-				l.headlessWorkers[slug] = true
+			l.headless.queues[slug][len(l.headless.queues[slug])-1] = turn
+			if !l.headless.workers[slug] {
+				l.headless.workers[slug] = true
 				startWorker = true
 			}
-			l.headlessMu.Unlock()
+			l.headless.mu.Unlock()
 			appendHeadlessCodexLog(slug, "queue-replace: lead queue at cap, replacing pending turn with urgent task notification")
 			if startWorker {
 				l.spawnHeadlessWorker(slug)
 			}
 			return
 		}
-		l.headlessMu.Unlock()
+		l.headless.mu.Unlock()
 		appendHeadlessCodexLog(slug, "queue-drop: lead queue at cap, dropping redundant notification")
 		return
 	}
-	l.headlessQueues[slug] = append(l.headlessQueues[slug], turn)
-	if !l.headlessWorkers[slug] {
-		l.headlessWorkers[slug] = true
+	l.headless.queues[slug] = append(l.headless.queues[slug], turn)
+	if !l.headless.workers[slug] {
+		l.headless.workers[slug] = true
 		startWorker = true
 	}
-	if active := l.headlessActive[slug]; active != nil && active.Cancel != nil {
+	if active := l.headless.active[slug]; active != nil && active.Cancel != nil {
 		age := time.Since(active.StartedAt)
 		// Two conditions must hold to preempt: past the configured staleness
 		// threshold AND past the minimum-turn-age floor. The floor breaks the
@@ -343,7 +343,7 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 			staleAge = age
 		}
 	}
-	l.headlessMu.Unlock()
+	l.headless.mu.Unlock()
 
 	if cancel != nil {
 		appendHeadlessCodexLog(slug, fmt.Sprintf("stale-turn: cancelling active turn after %s to process queued work", staleAge.Round(time.Second)))
@@ -356,16 +356,16 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 }
 
 func (l *Launcher) replaceDuplicateTaskTurnLocked(slug string, turn headlessCodexTurn) bool {
-	for i := range l.headlessQueues[slug] {
-		if strings.TrimSpace(l.headlessQueues[slug][i].TaskID) != turn.TaskID {
+	for i := range l.headless.queues[slug] {
+		if strings.TrimSpace(l.headless.queues[slug][i].TaskID) != turn.TaskID {
 			continue
 		}
-		l.headlessQueues[slug][i] = turn
+		l.headless.queues[slug][i] = turn
 		return true
 	}
-	if slug == l.officeLeadSlug() && l.headlessDeferredLead != nil && strings.TrimSpace(l.headlessDeferredLead.TaskID) == turn.TaskID {
+	if slug == l.officeLeadSlug() && l.headless.deferredLead != nil && strings.TrimSpace(l.headless.deferredLead.TaskID) == turn.TaskID {
 		cp := turn
-		l.headlessDeferredLead = &cp
+		l.headless.deferredLead = &cp
 		return true
 	}
 	return false
@@ -394,18 +394,18 @@ func (l *Launcher) headlessLeadTurnNeedsImmediateWakeLocked(slug, prompt string)
 }
 
 // spawnHeadlessWorker starts a runHeadlessCodexQueue goroutine and registers
-// it with l.headlessWorkerWg so stopHeadlessWorkers can drain it. Lazily
-// initialises l.headlessStopCh; safe for any Launcher (including bare
+// it with l.headless.workerWg so stopHeadlessWorkers can drain it. Lazily
+// initialises l.headless.stopCh; safe for any Launcher (including bare
 // `&Launcher{}` literals that tests construct). All `go runHeadlessCodexQueue`
 // sites must funnel through here so no worker escapes the WaitGroup.
 func (l *Launcher) spawnHeadlessWorker(slug string) {
-	l.headlessMu.Lock()
-	if l.headlessStopCh == nil {
-		l.headlessStopCh = make(chan struct{})
+	l.headless.mu.Lock()
+	if l.headless.stopCh == nil {
+		l.headless.stopCh = make(chan struct{})
 	}
-	stop := l.headlessStopCh
-	l.headlessWorkerWg.Add(1)
-	l.headlessMu.Unlock()
+	stop := l.headless.stopCh
+	l.headless.workerWg.Add(1)
+	l.headless.mu.Unlock()
 	go l.runHeadlessCodexQueue(slug, stop)
 }
 
@@ -415,18 +415,18 @@ func (l *Launcher) spawnHeadlessWorker(slug string) {
 // spawned by the current test can't outlive the test and race the next test's
 // setup of headlessActive / headlessQueues / the test t.TempDir cleanup.
 func (l *Launcher) stopHeadlessWorkers() {
-	l.headlessMu.Lock()
-	if l.headlessStopCh == nil {
-		l.headlessStopCh = make(chan struct{})
+	l.headless.mu.Lock()
+	if l.headless.stopCh == nil {
+		l.headless.stopCh = make(chan struct{})
 	}
 	select {
-	case <-l.headlessStopCh:
+	case <-l.headless.stopCh:
 		// already closed; idempotent re-entry
 	default:
-		close(l.headlessStopCh)
+		close(l.headless.stopCh)
 	}
-	cancel := l.headlessCancel
-	l.headlessMu.Unlock()
+	cancel := l.headless.cancel
+	l.headless.mu.Unlock()
 	if cancel != nil {
 		cancel()
 	}
@@ -439,17 +439,17 @@ func (l *Launcher) stopHeadlessWorkers() {
 	// safety net for bare &Launcher{} test fixtures that don't seed one.
 	done := make(chan struct{})
 	go func() {
-		l.headlessWorkerWg.Wait()
+		l.headless.workerWg.Wait()
 		close(done)
 	}()
 	cancelActive := func() {
-		l.headlessMu.Lock()
-		for _, active := range l.headlessActive {
+		l.headless.mu.Lock()
+		for _, active := range l.headless.active {
 			if active != nil && active.Cancel != nil {
 				active.Cancel()
 			}
 		}
-		l.headlessMu.Unlock()
+		l.headless.mu.Unlock()
 	}
 	cancelActive()
 	if cancel != nil {
@@ -470,7 +470,7 @@ func (l *Launcher) stopHeadlessWorkers() {
 }
 
 func (l *Launcher) runHeadlessCodexQueue(slug string, stop <-chan struct{}) {
-	defer l.headlessWorkerWg.Done()
+	defer l.headless.workerWg.Done()
 	for {
 		// Stop signal short-circuits the loop before grabbing more work.
 		// The check is cheap (non-blocking select) and only fires on test
@@ -478,9 +478,9 @@ func (l *Launcher) runHeadlessCodexQueue(slug string, stop <-chan struct{}) {
 		// stop while the worker is in steady state.
 		select {
 		case <-stop:
-			l.headlessMu.Lock()
-			delete(l.headlessWorkers, slug)
-			l.headlessMu.Unlock()
+			l.headless.mu.Lock()
+			delete(l.headless.workers, slug)
+			l.headless.mu.Unlock()
 			return
 		default:
 		}
@@ -498,9 +498,9 @@ func (l *Launcher) runHeadlessCodexQueue(slug string, stop <-chan struct{}) {
 			ctxErr := turnCtx.Err()
 			isDurabilityError := false
 			if err == nil {
-				l.headlessMu.Lock()
-				active := l.headlessActive[slug]
-				l.headlessMu.Unlock()
+				l.headless.mu.Lock()
+				active := l.headless.active[slug]
+				l.headless.mu.Unlock()
 				if ok, reason := l.headlessTurnCompletedDurably(slug, active); !ok {
 					appendHeadlessCodexLog(slug, "durability-error: "+reason)
 					err = errors.New(reason)
@@ -531,9 +531,9 @@ func (l *Launcher) runHeadlessCodexQueue(slug string, stop <-chan struct{}) {
 			}
 			l.finishHeadlessTurn(slug)
 		}()
-		l.headlessMu.Lock()
-		_, stillRunning := l.headlessWorkers[slug]
-		l.headlessMu.Unlock()
+		l.headless.mu.Lock()
+		_, stillRunning := l.headless.workers[slug]
+		l.headless.mu.Unlock()
 		if !stillRunning {
 			return
 		}
@@ -667,11 +667,11 @@ func (l *Launcher) taskHasExternalWorkflowEvidenceSince(task *teamTask, startedA
 }
 
 func (l *Launcher) finishHeadlessTurn(slug string) {
-	l.headlessMu.Lock()
-	if active := l.headlessActive[slug]; active != nil && active.Cancel != nil {
+	l.headless.mu.Lock()
+	if active := l.headless.active[slug]; active != nil && active.Cancel != nil {
 		active.Cancel()
 	}
-	delete(l.headlessActive, slug)
+	delete(l.headless.active, slug)
 	lead := l.officeLeadSlug()
 	var deferredLead *headlessCodexTurn
 	// Determine if this was a specialist finishing (not the lead), and if so whether
@@ -682,7 +682,7 @@ func (l *Launcher) finishHeadlessTurn(slug string) {
 	// process exits there is nothing else to re-trigger the CEO.
 	shouldWakeLead := slug != lead && lead != ""
 	if shouldWakeLead {
-		for workerSlug, queue := range l.headlessQueues {
+		for workerSlug, queue := range l.headless.queues {
 			if workerSlug == lead {
 				continue
 			}
@@ -693,7 +693,7 @@ func (l *Launcher) finishHeadlessTurn(slug string) {
 		}
 	}
 	if shouldWakeLead {
-		for workerSlug, active := range l.headlessActive {
+		for workerSlug, active := range l.headless.active {
 			if workerSlug == lead {
 				continue
 			}
@@ -704,16 +704,16 @@ func (l *Launcher) finishHeadlessTurn(slug string) {
 		}
 	}
 	// Check if the lead already has work queued — no need to wake it.
-	if shouldWakeLead && len(l.headlessQueues[lead]) > 0 {
+	if shouldWakeLead && len(l.headless.queues[lead]) > 0 {
 		shouldWakeLead = false
 	}
-	if shouldWakeLead && l.headlessDeferredLead != nil {
-		turn := *l.headlessDeferredLead
-		l.headlessDeferredLead = nil
+	if shouldWakeLead && l.headless.deferredLead != nil {
+		turn := *l.headless.deferredLead
+		l.headless.deferredLead = nil
 		deferredLead = &turn
 		shouldWakeLead = false
 	}
-	l.headlessMu.Unlock()
+	l.headless.mu.Unlock()
 
 	if deferredLead != nil {
 		l.enqueueHeadlessCodexTurn(lead, deferredLead.Prompt, deferredLead.Channel)
@@ -1085,41 +1085,41 @@ func (l *Launcher) timedOutTurnAlreadyRecovered(task *teamTask, slug string, sta
 }
 
 func (l *Launcher) beginHeadlessCodexTurn(slug string) (headlessCodexTurn, context.Context, time.Time, time.Duration, bool) {
-	l.headlessMu.Lock()
-	defer l.headlessMu.Unlock()
+	l.headless.mu.Lock()
+	defer l.headless.mu.Unlock()
 
 	// If stopHeadlessWorkers already fired, don't start a new turn. This closes
 	// the race where a worker goroutine passed the outer stop-channel check
 	// just before stopHeadlessWorkers closed headlessStopCh, causing the worker
 	// to block in headlessCodexRunTurn with no cancel registered in headlessActive.
-	if l.headlessStopCh != nil {
+	if l.headless.stopCh != nil {
 		select {
-		case <-l.headlessStopCh:
-			delete(l.headlessWorkers, slug)
+		case <-l.headless.stopCh:
+			delete(l.headless.workers, slug)
 			return headlessCodexTurn{}, nil, time.Time{}, 0, false
 		default:
 		}
 	}
 
-	queue := l.headlessQueues[slug]
+	queue := l.headless.queues[slug]
 	if len(queue) == 0 {
 		// Atomically mark the worker as done. This must happen while the lock is
 		// held so that any concurrent enqueueHeadlessCodexTurn will observe
 		// headlessWorkers[slug] = false and start a new goroutine rather than
 		// assuming the current one will pick up the new item.
-		delete(l.headlessWorkers, slug)
-		delete(l.headlessQueues, slug)
+		delete(l.headless.workers, slug)
+		delete(l.headless.queues, slug)
 		return headlessCodexTurn{}, nil, time.Time{}, 0, false
 	}
 
 	turn := queue[0]
 	if len(queue) == 1 {
-		delete(l.headlessQueues, slug)
+		delete(l.headless.queues, slug)
 	} else {
-		l.headlessQueues[slug] = queue[1:]
+		l.headless.queues[slug] = queue[1:]
 	}
 
-	baseCtx := l.headlessCtx
+	baseCtx := l.headless.ctx
 	if baseCtx == nil {
 		baseCtx = context.Background()
 	}
@@ -1132,7 +1132,7 @@ func (l *Launcher) beginHeadlessCodexTurn(slug string) (headlessCodexTurn, conte
 	} else if codingAgentSlugs[slug] {
 		workspaceDir = normalizeHeadlessWorkspaceDir(l.cwd)
 	}
-	l.headlessActive[slug] = &headlessCodexActiveTurn{
+	l.headless.active[slug] = &headlessCodexActiveTurn{
 		Turn:              turn,
 		StartedAt:         startedAt,
 		Timeout:           timeout,

--- a/internal/team/headless_codex_test.go
+++ b/internal/team/headless_codex_test.go
@@ -161,10 +161,10 @@ func TestRunHeadlessCodexTurnUsesHeadlessOfficeRuntime(t *testing.T) {
 	t.Setenv("WUPHF_ONE_IDENTITY_TYPE", "user")
 
 	l := &Launcher{
-		pack:        agent.GetPack("founding-team"),
-		cwd:         t.TempDir(),
-		broker:      newTestBroker(t),
-		headlessCtx: t.Context(),
+		pack:     agent.GetPack("founding-team"),
+		cwd:      t.TempDir(),
+		broker:   newTestBroker(t),
+		headless: headlessWorkerPool{ctx: t.Context()},
 	}
 
 	if err := l.runHeadlessCodexTurn(t.Context(), "ceo", "You have new work in #launch."); err != nil {
@@ -317,10 +317,10 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForCodingAgents(t *testing.T) {
 	}
 
 	l := &Launcher{
-		pack:        agent.GetPack("founding-team"),
-		cwd:         repoRoot,
-		broker:      broker,
-		headlessCtx: t.Context(),
+		pack:     agent.GetPack("founding-team"),
+		cwd:      repoRoot,
+		broker:   broker,
+		headless: headlessWorkerPool{ctx: t.Context()},
 	}
 
 	if err := l.runHeadlessCodexTurn(t.Context(), "eng", "Ship the automation runtime."); err != nil {
@@ -433,10 +433,10 @@ func TestRunHeadlessCodexTurnUsesAssignedWorktreeForLocalWorktreeBuilder(t *test
 	}
 
 	l := &Launcher{
-		pack:        agent.GetPack("founding-team"),
-		cwd:         repoRoot,
-		broker:      broker,
-		headlessCtx: t.Context(),
+		pack:     agent.GetPack("founding-team"),
+		cwd:      repoRoot,
+		broker:   broker,
+		headless: headlessWorkerPool{ctx: t.Context()},
 	}
 
 	if err := l.runHeadlessCodexTurn(t.Context(), "builder", "Ship the intake packet."); err != nil {
@@ -491,10 +491,10 @@ func TestRunHeadlessCodexTurnPassesScopedChannelEnv(t *testing.T) {
 	t.Setenv("WUPHF_CHANNEL", "general")
 
 	l := &Launcher{
-		pack:        agent.GetPack("founding-team"),
-		cwd:         t.TempDir(),
-		broker:      newTestBroker(t),
-		headlessCtx: t.Context(),
+		pack:     agent.GetPack("founding-team"),
+		cwd:      t.TempDir(),
+		broker:   newTestBroker(t),
+		headless: headlessWorkerPool{ctx: t.Context()},
 	}
 
 	if err := l.runHeadlessCodexTurn(t.Context(), "eng", "Work the owned task.", "youtube-factory"); err != nil {
@@ -860,11 +860,13 @@ func canonicalPath(path string) string {
 func newHeadlessLauncherForTest(t *testing.T) *Launcher {
 	t.Helper()
 	l := &Launcher{
-		headlessCtx:     t.Context(),
-		headlessWorkers: make(map[string]bool),
-		headlessActive:  make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:  make(map[string][]headlessCodexTurn),
-		pack:            &agent.PackDefinition{LeadSlug: "ceo"}, // deterministic lead; avoids reading global broker state
+		headless: headlessWorkerPool{
+			ctx:     t.Context(),
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
+		pack: &agent.PackDefinition{LeadSlug: "ceo"}, // deterministic lead; avoids reading global broker state
 	}
 	// Drain queue workers before the test's t.TempDir cleanup runs.
 	// t.Cleanup is LIFO, and t.TempDir registers its cleanup at the
@@ -910,7 +912,7 @@ func TestFinishHeadlessTurnDoesNotWakeLeadWhenOtherSpecialistsActive(t *testing.
 
 	l := newHeadlessLauncherForTest(t)
 	// "be" is still active while "fe" finishes.
-	l.headlessActive["be"] = &headlessCodexActiveTurn{}
+	l.headless.active["be"] = &headlessCodexActiveTurn{}
 
 	l.finishHeadlessTurn("fe")
 
@@ -948,7 +950,7 @@ func TestFinishHeadlessTurnDoesNotWakeLeadWhenLeadAlreadyQueued(t *testing.T) {
 
 	l := newHeadlessLauncherForTest(t)
 	// CEO already has a pending turn.
-	l.headlessQueues["ceo"] = []headlessCodexTurn{{Prompt: "pending work"}}
+	l.headless.queues["ceo"] = []headlessCodexTurn{{Prompt: "pending work"}}
 
 	l.finishHeadlessTurn("fe")
 
@@ -963,7 +965,7 @@ func TestFinishHeadlessTurnDoesNotWakeLeadWhenLeadAlreadyQueued(t *testing.T) {
 func TestEnqueueHeadlessCodexTurnRecordDropsDuplicateLeadTaskWhileActive(t *testing.T) {
 	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
-	l.headlessActive["ceo"] = &headlessCodexActiveTurn{
+	l.headless.active["ceo"] = &headlessCodexActiveTurn{
 		Turn: headlessCodexTurn{
 			Prompt: "first prompt about #task-3",
 			TaskID: "task-3",
@@ -977,7 +979,7 @@ func TestEnqueueHeadlessCodexTurnRecordDropsDuplicateLeadTaskWhileActive(t *test
 		EnqueuedAt: time.Now(),
 	})
 
-	if got := len(l.headlessQueues["ceo"]); got != 0 {
+	if got := len(l.headless.queues["ceo"]); got != 0 {
 		t.Fatalf("expected no queued duplicate lead turn for same task, got %d", got)
 	}
 }
@@ -1010,8 +1012,8 @@ func TestEnqueueHeadlessCodexTurnRecordQueuesUrgentLeadWakeForSameTask(t *testin
 	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
 	l.broker = b
-	l.headlessWorkers["ceo"] = true
-	l.headlessActive["ceo"] = &headlessCodexActiveTurn{
+	l.headless.workers["ceo"] = true
+	l.headless.active["ceo"] = &headlessCodexActiveTurn{
 		Turn: headlessCodexTurn{
 			Prompt: "first prompt about #" + task.ID,
 			TaskID: task.ID,
@@ -1028,7 +1030,7 @@ func TestEnqueueHeadlessCodexTurnRecordQueuesUrgentLeadWakeForSameTask(t *testin
 		EnqueuedAt: time.Now(),
 	})
 
-	if got := len(l.headlessQueues["ceo"]); got != 1 {
+	if got := len(l.headless.queues["ceo"]); got != 1 {
 		t.Fatalf("expected urgent lead wake to queue behind same task, got %d", got)
 	}
 	if !cancelled {
@@ -1039,7 +1041,7 @@ func TestEnqueueHeadlessCodexTurnRecordQueuesUrgentLeadWakeForSameTask(t *testin
 func TestEnqueueHeadlessCodexTurnRecordDropsDuplicateAgentTaskWhileActive(t *testing.T) {
 	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
-	l.headlessActive["eng"] = &headlessCodexActiveTurn{
+	l.headless.active["eng"] = &headlessCodexActiveTurn{
 		Turn: headlessCodexTurn{
 			Prompt: "first prompt about #task-11",
 			TaskID: "task-11",
@@ -1053,7 +1055,7 @@ func TestEnqueueHeadlessCodexTurnRecordDropsDuplicateAgentTaskWhileActive(t *tes
 		EnqueuedAt: time.Now(),
 	})
 
-	if got := len(l.headlessQueues["eng"]); got != 0 {
+	if got := len(l.headless.queues["eng"]); got != 0 {
 		t.Fatalf("expected no queued duplicate agent turn for same task, got %d", got)
 	}
 }
@@ -1061,8 +1063,8 @@ func TestEnqueueHeadlessCodexTurnRecordDropsDuplicateAgentTaskWhileActive(t *tes
 func TestEnqueueHeadlessCodexTurnRecordReplacesPendingAgentTaskTurn(t *testing.T) {
 	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
-	l.headlessWorkers["eng"] = true
-	l.headlessQueues["eng"] = []headlessCodexTurn{{
+	l.headless.workers["eng"] = true
+	l.headless.queues["eng"] = []headlessCodexTurn{{
 		Prompt:     "older prompt about #task-11",
 		Channel:    "youtube-factory",
 		TaskID:     "task-11",
@@ -1076,7 +1078,7 @@ func TestEnqueueHeadlessCodexTurnRecordReplacesPendingAgentTaskTurn(t *testing.T
 		EnqueuedAt: time.Now(),
 	})
 
-	queue := l.headlessQueues["eng"]
+	queue := l.headless.queues["eng"]
 	if got := len(queue); got != 1 {
 		t.Fatalf("expected single queued agent turn for same task, got %d", got)
 	}
@@ -1088,8 +1090,8 @@ func TestEnqueueHeadlessCodexTurnRecordReplacesPendingAgentTaskTurn(t *testing.T
 func TestEnqueueHeadlessCodexTurnRecordAllowsRetryBehindActiveAgentTask(t *testing.T) {
 	l := newHeadlessLauncherForTest(t)
 	l.pack = &agent.PackDefinition{LeadSlug: "ceo"}
-	l.headlessWorkers["eng"] = true
-	l.headlessActive["eng"] = &headlessCodexActiveTurn{
+	l.headless.workers["eng"] = true
+	l.headless.active["eng"] = &headlessCodexActiveTurn{
 		Turn: headlessCodexTurn{
 			Prompt:   "first prompt about #task-11",
 			TaskID:   "task-11",
@@ -1106,7 +1108,7 @@ func TestEnqueueHeadlessCodexTurnRecordAllowsRetryBehindActiveAgentTask(t *testi
 		EnqueuedAt: time.Now(),
 	})
 
-	queue := l.headlessQueues["eng"]
+	queue := l.headless.queues["eng"]
 	if got := len(queue); got != 1 {
 		t.Fatalf("expected single queued retry turn for same task, got %d", got)
 	}
@@ -1290,7 +1292,7 @@ func TestRecoverTimedOutHeadlessTurnRetriesLocalWorktreeOnceBeforeBlocking(t *te
 
 	l := newHeadlessLauncherForTest(t)
 	l.broker = b
-	l.headlessWorkers["eng"] = true
+	l.headless.workers["eng"] = true
 
 	turn := headlessCodexTurn{
 		Prompt:   "Build #task-" + strings.TrimPrefix(task.ID, "task-"),
@@ -1300,10 +1302,10 @@ func TestRecoverTimedOutHeadlessTurnRetriesLocalWorktreeOnceBeforeBlocking(t *te
 	}
 	l.recoverTimedOutHeadlessTurn("eng", turn, time.Now().UTC().Add(-2*time.Second), headlessCodexLocalWorktreeTurnTimeout)
 
-	if len(l.headlessQueues["eng"]) != 1 {
-		t.Fatalf("expected one queued retry, got %+v", l.headlessQueues["eng"])
+	if len(l.headless.queues["eng"]) != 1 {
+		t.Fatalf("expected one queued retry, got %+v", l.headless.queues["eng"])
 	}
-	retry := l.headlessQueues["eng"][0]
+	retry := l.headless.queues["eng"][0]
 	if retry.Attempts != 1 {
 		t.Fatalf("expected retry attempt 1, got %+v", retry)
 	}
@@ -1344,7 +1346,7 @@ func TestRecoverFailedHeadlessTurnRetriesLocalWorktreeOnceBeforeBlocking(t *test
 
 	l := newHeadlessLauncherForTest(t)
 	l.broker = b
-	l.headlessWorkers["eng"] = true
+	l.headless.workers["eng"] = true
 
 	turn := headlessCodexTurn{
 		Prompt:   "Build #task-" + strings.TrimPrefix(task.ID, "task-"),
@@ -1354,10 +1356,10 @@ func TestRecoverFailedHeadlessTurnRetriesLocalWorktreeOnceBeforeBlocking(t *test
 	}
 	l.recoverFailedHeadlessTurn("eng", turn, time.Now().UTC().Add(-2*time.Second), "Selected model is at capacity. Please try a different model.")
 
-	if len(l.headlessQueues["eng"]) != 1 {
-		t.Fatalf("expected one queued retry, got %+v", l.headlessQueues["eng"])
+	if len(l.headless.queues["eng"]) != 1 {
+		t.Fatalf("expected one queued retry, got %+v", l.headless.queues["eng"])
 	}
-	retry := l.headlessQueues["eng"][0]
+	retry := l.headless.queues["eng"][0]
 	if retry.Attempts != 1 {
 		t.Fatalf("expected retry attempt 1, got %+v", retry)
 	}
@@ -1410,7 +1412,7 @@ func TestRecoverTimedOutLocalWorktreeRetriesEvenAfterSubstantiveReplyIfTaskStill
 
 	l := newHeadlessLauncherForTest(t)
 	l.broker = b
-	l.headlessWorkers["eng"] = true
+	l.headless.workers["eng"] = true
 
 	l.recoverTimedOutHeadlessTurn("eng", headlessCodexTurn{
 		Prompt:   "Build #task-" + strings.TrimPrefix(task.ID, "task-"),
@@ -1419,8 +1421,8 @@ func TestRecoverTimedOutLocalWorktreeRetriesEvenAfterSubstantiveReplyIfTaskStill
 		Attempts: 0,
 	}, startedAt, headlessCodexLocalWorktreeTurnTimeout)
 
-	if len(l.headlessQueues["eng"]) != 1 {
-		t.Fatalf("expected one queued retry, got %+v", l.headlessQueues["eng"])
+	if len(l.headless.queues["eng"]) != 1 {
+		t.Fatalf("expected one queued retry, got %+v", l.headless.queues["eng"])
 	}
 
 	var updated teamTask
@@ -1474,8 +1476,8 @@ func TestRecoverTimedOutLocalWorktreeLeavesReviewReadyTaskUnchanged(t *testing.T
 		Attempts: 0,
 	}, time.Now().UTC().Add(-2*time.Second), headlessCodexLocalWorktreeTurnTimeout)
 
-	if len(l.headlessQueues["eng"]) != 0 {
-		t.Fatalf("expected no retry queue for review-ready task, got %+v", l.headlessQueues["eng"])
+	if len(l.headless.queues["eng"]) != 0 {
+		t.Fatalf("expected no retry queue for review-ready task, got %+v", l.headless.queues["eng"])
 	}
 
 	var updated teamTask
@@ -1628,9 +1630,9 @@ func TestRecoverFailedHeadlessTurnRequeuesExternalActionBeforeBlocking(t *testin
 	// Snapshot the queue under the launcher's headlessMu — the spawned worker
 	// goroutine drains headlessQueues under that mutex, so an unguarded read
 	// from the test races with the drain (caught by `go test -race`).
-	l.headlessMu.Lock()
-	queue := append([]headlessCodexTurn(nil), l.headlessQueues["operator"]...)
-	l.headlessMu.Unlock()
+	l.headless.mu.Lock()
+	queue := append([]headlessCodexTurn(nil), l.headless.queues["operator"]...)
+	l.headless.mu.Unlock()
 	if len(queue) != 1 {
 		t.Fatalf("expected one retry queued for external action, got %+v", queue)
 	}
@@ -1915,13 +1917,13 @@ func TestBeginHeadlessCodexTurnCapturesWorktreeForLocalWorktreeBuilder(t *testin
 
 	l := newHeadlessLauncherForTest(t)
 	l.broker = b
-	l.headlessQueues["builder"] = []headlessCodexTurn{{TaskID: task.ID}}
+	l.headless.queues["builder"] = []headlessCodexTurn{{TaskID: task.ID}}
 
 	_, _, _, _, ok := l.beginHeadlessCodexTurn("builder")
 	if !ok {
 		t.Fatal("expected queued builder turn to begin")
 	}
-	active := l.headlessActive["builder"]
+	active := l.headless.active["builder"]
 	if active == nil {
 		t.Fatal("expected active builder turn")
 	}
@@ -1969,8 +1971,8 @@ func TestRunHeadlessCodexQueueRetriesLocalWorktreeAfterGenericError(t *testing.T
 
 	l := newHeadlessLauncherForTest(t)
 	l.broker = b
-	l.headlessWorkers["eng"] = true
-	l.headlessQueues["eng"] = []headlessCodexTurn{{
+	l.headless.workers["eng"] = true
+	l.headless.queues["eng"] = []headlessCodexTurn{{
 		Prompt:     "Build #task-" + strings.TrimPrefix(task.ID, "task-"),
 		Channel:    "general",
 		TaskID:     task.ID,
@@ -2059,10 +2061,10 @@ func TestEnqueueHeadlessCodexTurnDefersLeadUntilSpecialistFinishes(t *testing.T)
 	})
 
 	l := newHeadlessLauncherForTest(t)
-	l.headlessActive["eng"] = &headlessCodexActiveTurn{}
+	l.headless.active["eng"] = &headlessCodexActiveTurn{}
 
 	l.enqueueHeadlessCodexTurn("ceo", "task-5 blocked after timeout")
-	if l.headlessDeferredLead == nil {
+	if l.headless.deferredLead == nil {
 		t.Fatal("expected lead work to be deferred while specialist is active")
 	}
 
@@ -2112,7 +2114,7 @@ func TestEnqueueHeadlessCodexTurnBypassesLeadHoldForReviewReadyTask(t *testing.T
 
 	l := newHeadlessLauncherForTest(t)
 	l.broker = b
-	l.headlessActive["eng"] = &headlessCodexActiveTurn{}
+	l.headless.active["eng"] = &headlessCodexActiveTurn{}
 
 	action := officeActionLog{
 		Kind:      "task_updated",
@@ -2125,7 +2127,7 @@ func TestEnqueueHeadlessCodexTurnBypassesLeadHoldForReviewReadyTask(t *testing.T
 
 	l.enqueueHeadlessCodexTurn("ceo", packet)
 
-	if l.headlessDeferredLead != nil {
+	if l.headless.deferredLead != nil {
 		t.Fatal("expected review-ready task notification to bypass lead deferral")
 	}
 	got := waitForString(t, processed)

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -100,22 +100,15 @@ type Launcher struct {
 	oneOnOne           string
 	provider           string
 
-	headlessMu           sync.Mutex
-	headlessCtx          context.Context
-	headlessCancel       context.CancelFunc
-	headlessWorkers      map[string]bool
-	headlessActive       map[string]*headlessCodexActiveTurn
-	headlessQueues       map[string][]headlessCodexTurn
-	headlessDeferredLead *headlessCodexTurn
-	// headlessStopCh is closed by stopHeadlessWorkers to tell every active
-	// runHeadlessCodexQueue goroutine to exit at its next outer-loop tick.
-	// Lazily allocated by spawnHeadlessWorker / stopHeadlessWorkers under
-	// headlessMu so the zero-value Launcher used in tests doesn't need an
-	// explicit init. headlessWorkerWg tracks live worker goroutines so the
-	// stop helper can drain them deterministically — closing the channel is
-	// a request, the WaitGroup is the proof everyone observed it.
-	headlessStopCh   chan struct{}
-	headlessWorkerWg sync.WaitGroup
+	// headless is the per-launcher headless-worker pool (PLAN.md §C7).
+	// All headless dispatch state — mutex, ctx/cancel, queues, workers,
+	// active turns, deferred lead turn, stop channel, and worker
+	// WaitGroup — is grouped here so the Launcher struct no longer owns
+	// a third sub-mutex directly. Embedded by value (not pointer) so
+	// zero-value &Launcher{} in tests still gets a usable pool with
+	// sane lazy-allocated maps; PR #320's stop-channel goroutine-leak
+	// fix is preserved via the same lazy-allocate-under-mu pattern.
+	headless         headlessWorkerPool
 	webMode          bool
 	paneBackedAgents bool // web mode may spawn per-agent tmux panes; true when panes are live
 	noOpen           bool
@@ -152,6 +145,25 @@ type Launcher struct {
 	// closure consults the package-global launcherSendNotificationToPaneOverride
 	// seam on every call so existing tests keep working unchanged.
 	dispatcher *paneDispatcher
+}
+
+// headlessWorkerPool groups the per-launcher headless-dispatch state
+// (PLAN.md §C7). All fields are lowercase package-internal — the pool is
+// never used outside `internal/team` and stays an embedded value on
+// Launcher rather than its own pointer so zero-value &Launcher{} in
+// tests gets a usable pool with sane lazy-allocated maps. PR #320's
+// goroutine-leak fix relies on stopCh being lazily allocated under mu
+// before any worker can read it; that contract is preserved here.
+type headlessWorkerPool struct {
+	mu           sync.Mutex
+	ctx          context.Context
+	cancel       context.CancelFunc
+	workers      map[string]bool
+	active       map[string]*headlessCodexActiveTurn
+	queues       map[string][]headlessCodexTurn
+	deferredLead *headlessCodexTurn
+	stopCh       chan struct{}
+	workerWg     sync.WaitGroup
 }
 
 // paneDispatchTurn is one queued notification to type into a tmux pane.
@@ -248,18 +260,20 @@ func NewLauncher(packSlug string) (*Launcher, error) {
 	sessionMode, oneOnOne := loadRunningSessionMode()
 
 	return &Launcher{
-		packSlug:            packSlug,
-		pack:                pack,
-		operationBlueprint:  loadedBlueprint,
-		blankSlateLaunch:    blankSlateLaunch,
-		sessionName:         SessionName,
-		cwd:                 cwd,
-		sessionMode:         sessionMode,
-		oneOnOne:            oneOnOne,
-		provider:            config.ResolveLLMProvider(""),
-		headlessWorkers:     make(map[string]bool),
-		headlessActive:      make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:      make(map[string][]headlessCodexTurn),
+		packSlug:           packSlug,
+		pack:               pack,
+		operationBlueprint: loadedBlueprint,
+		blankSlateLaunch:   blankSlateLaunch,
+		sessionName:        SessionName,
+		cwd:                cwd,
+		sessionMode:        sessionMode,
+		oneOnOne:           oneOnOne,
+		provider:           config.ResolveLLMProvider(""),
+		headless: headlessWorkerPool{
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
 		notifyLastDelivered: make(map[string]time.Time),
 	}, nil
 }
@@ -452,7 +466,7 @@ func (l *Launcher) Launch() error {
 
 	// Headless context for per-turn Claude invocations. Used by both TUI and
 	// web modes since agent dispatch is headless by default.
-	l.headlessCtx, l.headlessCancel = context.WithCancel(context.Background())
+	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
 	l.resumeInFlightWork()
 
 	go l.watchChannelPaneLoop(channelCmd)
@@ -1647,8 +1661,8 @@ func (l *Launcher) Attach() error {
 // removes per-agent temp files (MCP config + system prompt) so the broker
 // token and prompt content do not linger in $TMPDIR.
 func (l *Launcher) Kill() error {
-	if l.headlessCancel != nil {
-		l.headlessCancel()
+	if l.headless.cancel != nil {
+		l.headless.cancel()
 	}
 	if l.broker != nil {
 		l.broker.Stop()
@@ -1859,10 +1873,10 @@ func (l *Launcher) activeHeadlessSlugs(except string) map[string]struct{} {
 	if l == nil {
 		return nil
 	}
-	l.headlessMu.Lock()
-	defer l.headlessMu.Unlock()
+	l.headless.mu.Lock()
+	defer l.headless.mu.Unlock()
 	out := map[string]struct{}{}
-	for workerSlug, queue := range l.headlessQueues {
+	for workerSlug, queue := range l.headless.queues {
 		if workerSlug == except {
 			continue
 		}
@@ -1870,7 +1884,7 @@ func (l *Launcher) activeHeadlessSlugs(except string) map[string]struct{} {
 			out[workerSlug] = struct{}{}
 		}
 	}
-	for workerSlug, active := range l.headlessActive {
+	for workerSlug, active := range l.headless.active {
 		if workerSlug == except {
 			continue
 		}
@@ -3231,13 +3245,13 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 
 	// Headless context is used for codex runtime, default dispatch, and
 	// per-turn operations that don't fit a long-lived pane session.
-	l.headlessCtx, l.headlessCancel = context.WithCancel(context.Background())
+	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
 	l.resumeInFlightWork()
 
 	// Stream tmux pane output to the web UI's per-agent stream so users see
 	// live Claude TUI activity (thinking, tool calls, responses) during a
 	// pane-backed turn. No-op when paneBackedAgents is false.
-	l.startPaneCaptureLoops(l.headlessCtx)
+	l.startPaneCaptureLoops(l.headless.ctx)
 
 	go l.notifyAgentsLoop()
 	go l.notifyTaskActionsLoop()

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -2653,12 +2653,14 @@ func TestBuildMessageActiveAgentsSorted(t *testing.T) {
 				{Slug: "eng", Name: "Engineer"},
 			},
 		},
-		headlessActive: map[string]*headlessCodexActiveTurn{
-			"zebra": {},
-			"alpha": {},
-			"mango": {},
+		headless: headlessWorkerPool{
+			active: map[string]*headlessCodexActiveTurn{
+				"zebra": {},
+				"alpha": {},
+				"mango": {},
+			},
+			queues: make(map[string][]headlessCodexTurn),
 		},
-		headlessQueues: make(map[string][]headlessCodexTurn),
 	}
 
 	// Run multiple times — Go map iteration order is non-deterministic, so

--- a/internal/team/resume_test.go
+++ b/internal/team/resume_test.go
@@ -547,9 +547,11 @@ func TestResumeInFlightWorkHeadlessEnqueuesLeadEvenWhenSpecialistsPresent(t *tes
 				{Slug: "fe", Name: "Frontend Engineer"},
 			},
 		},
-		headlessWorkers: make(map[string]bool),
-		headlessActive:  make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:  make(map[string][]headlessCodexTurn),
+		headless: headlessWorkerPool{
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
 	}
 	t.Cleanup(l.stopHeadlessWorkers)
 
@@ -559,14 +561,14 @@ func TestResumeInFlightWorkHeadlessEnqueuesLeadEvenWhenSpecialistsPresent(t *tes
 	// Check both queue and active entries to avoid a race where the goroutine
 	// has already consumed the queue entry before we read it.
 	ceoPresent := func() bool {
-		l.headlessMu.Lock()
-		defer l.headlessMu.Unlock()
-		return len(l.headlessQueues["ceo"]) > 0 || l.headlessActive["ceo"] != nil
+		l.headless.mu.Lock()
+		defer l.headless.mu.Unlock()
+		return len(l.headless.queues["ceo"]) > 0 || l.headless.active["ceo"] != nil
 	}
 	fePresent := func() bool {
-		l.headlessMu.Lock()
-		defer l.headlessMu.Unlock()
-		return len(l.headlessQueues["fe"]) > 0 || l.headlessActive["fe"] != nil
+		l.headless.mu.Lock()
+		defer l.headless.mu.Unlock()
+		return len(l.headless.queues["fe"]) > 0 || l.headless.active["fe"] != nil
 	}
 
 	if !ceoPresent() {
@@ -671,18 +673,20 @@ func TestResumeInFlightWorkTUIClaudeRoutesHeadless(t *testing.T) {
 				{Slug: "fe", Name: "Frontend Engineer"},
 			},
 		},
-		headlessWorkers: make(map[string]bool),
-		headlessActive:  make(map[string]*headlessCodexActiveTurn),
-		headlessQueues:  make(map[string][]headlessCodexTurn),
+		headless: headlessWorkerPool{
+			workers: make(map[string]bool),
+			active:  make(map[string]*headlessCodexActiveTurn),
+			queues:  make(map[string][]headlessCodexTurn),
+		},
 	}
 	t.Cleanup(l.stopHeadlessWorkers)
 
 	l.resumeInFlightWork()
 
 	present := func(slug string) bool {
-		l.headlessMu.Lock()
-		defer l.headlessMu.Unlock()
-		return len(l.headlessQueues[slug]) > 0 || l.headlessActive[slug] != nil
+		l.headless.mu.Lock()
+		defer l.headless.mu.Unlock()
+		return len(l.headless.queues[slug]) > 0 || l.headless.active[slug] != nil
 	}
 
 	if !present("ceo") {
@@ -734,12 +738,14 @@ func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 				{Slug: "fe", Name: "Frontend Engineer"},
 			},
 		},
-		headlessWorkers: map[string]bool{
-			"ceo": true,
-			"fe":  true,
+		headless: headlessWorkerPool{
+			workers: map[string]bool{
+				"ceo": true,
+				"fe":  true,
+			},
+			active: make(map[string]*headlessCodexActiveTurn),
+			queues: make(map[string][]headlessCodexTurn),
 		},
-		headlessActive: make(map[string]*headlessCodexActiveTurn),
-		headlessQueues: make(map[string][]headlessCodexTurn),
 	}
 	t.Cleanup(l.stopHeadlessWorkers)
 
@@ -752,10 +758,10 @@ func TestResumeInFlightWorkRoutesPerAgentProviderBinding(t *testing.T) {
 		t.Fatalf("unexpected pane notification: %q", paneNotifications[0])
 	}
 
-	l.headlessMu.Lock()
-	ceoQueue := append([]headlessCodexTurn(nil), l.headlessQueues["ceo"]...)
-	feQueue := append([]headlessCodexTurn(nil), l.headlessQueues["fe"]...)
-	l.headlessMu.Unlock()
+	l.headless.mu.Lock()
+	ceoQueue := append([]headlessCodexTurn(nil), l.headless.queues["ceo"]...)
+	feQueue := append([]headlessCodexTurn(nil), l.headless.queues["fe"]...)
+	l.headless.mu.Unlock()
 
 	if len(ceoQueue) != 0 {
 		t.Fatalf("claude-bound lead should not also be enqueued headless, got %#v", ceoQueue)


### PR DESCRIPTION
## Summary

Stacked on #430 (C6, paneDispatcher). **Last cluster** per PLAN.md §C7. Mechanical struct-field move: groups the nine headless-dispatch fields off `Launcher` into a `headlessWorkerPool` embedded value, so the Launcher struct no longer owns a third sub-mutex directly.

## Field renames (package-internal)

| Old (on Launcher) | New (on headlessWorkerPool) |
|---|---|
| `headlessMu` | `headless.mu` |
| `headlessCtx` | `headless.ctx` |
| `headlessCancel` | `headless.cancel` |
| `headlessWorkers` | `headless.workers` |
| `headlessActive` | `headless.active` |
| `headlessQueues` | `headless.queues` |
| `headlessDeferredLead` | `headless.deferredLead` |
| `headlessStopCh` | `headless.stopCh` |
| `headlessWorkerWg` | `headless.workerWg` |

## Design choice: embedded by value, not pointer

The pool is embedded by value rather than as a `*headlessWorkerPool` pointer so zero-value `&Launcher{}` fixtures in tests still get a usable pool with sane lazy-allocated maps. PR #320's stop-channel goroutine-leak fix is preserved — `stopCh` and `workerWg` semantics are unchanged because the field tree is renamed, not restructured.

## Tests

No new tests in this PR — the move is mechanical and the existing test suite is the safety net. Test fixtures in `broker_test.go`, `headless_claude_test.go`, `headless_codex_test.go`, `launcher_test.go`, and `resume_test.go` get their struct literals rewritten from individual fields to nested `headless: headlessWorkerPool{...}` form. All existing tests pass unchanged otherwise.

## Coverage (unchanged)

- `prompt_builder.go` 99.4%
- `office_targets.go` 89.9%
- `notification_context.go` 89.8%
- `scheduler.go` 90.6%
- `pane_lifecycle.go` 92.0%
- `pane_dispatch.go` 94.6%
- Package `internal/team`: 63.8%

## Diff shape

- 7 files touched: ~290 insertions, ~252 deletions, net +38 lines mostly from struct fixture rewrites and the new `headlessWorkerPool` type definition + comments
- launcher.go: 3417 → 3431 lines (+14, the new type definition). **Cumulative since main: -1567 lines (-31.3%).**

## Local CI matrix (all green)

- `gofmt -s -l` clean
- `golangci-lint run ./...` 0 issues
- `go test -race -timeout 15m ./internal/team` 86s
- `go test -race -timeout 15m` for the other 42 packages — 31 ok
- `go test -timeout 15m ./internal/teammcp`
- Cross-compile windows/{amd64,arm64} + darwin/arm64
- Smoke binary OK

## Test plan

- [x] `go build ./...`
- [x] All extracted-file coverage gates still pass
- [x] Existing tests pass with renamed field access patterns
- [ ] CI green

## Migration close-out

This PR completes the seven-cluster decomposition described in PLAN.md. Next steps:
- **Residual cleanup PR (PLAN.md §C8)**: launcher.go is now ~3.4k lines; scope what remains (lifecycle methods, web mode, broker housekeeping, glue) and re-organize within file or split into `launcher_web.go` / `broker_lifecycle.go` per PLAN.md §C8.
- **Wrapper consolidation**: across C2-C6 the Launcher methods became one-line delegating wrappers (transitional). A focused follow-up PR can rename the ~150+ in-package call sites from `l.officeLeadSlug()` → `l.targets.LeadSlug()` etc., then delete the wrappers, per PLAN.md §6's "no compatibility shims" goal.
- **C5b (paneLifecycle full extraction)**: introduce `tmuxRunner` interface + `realTmuxRunner`/`fakeTmuxRunner` and move the shell-out methods into a `paneLifecycle` type, per PLAN.md §C5.