### PR TITLE
test(channelui): migrate tests for hoisted helpers

### DIFF
--- a/cmd/wuphf/channel_needs_you_test.go
+++ b/cmd/wuphf/channel_needs_you_test.go
@@ -5,26 +5,6 @@ import (
 	"testing"
 )
 
-func TestBuildNeedsYouLinesPrefersBlockingRequests(t *testing.T) {
-	requests := []channelInterview{
-		{ID: "req-1", Kind: "approval", Status: "pending", Title: "Optional note", Question: "Optional note?", From: "pm"},
-		{ID: "req-2", Kind: "approval", Status: "pending", Title: "Ship launch copy", Question: "Ship launch copy?", Context: "Need approval before publishing.", From: "ceo", Blocking: true, RecommendedID: "approve"},
-	}
-
-	lines := buildNeedsYouLines(requests, 96)
-	plain := stripANSI(joinRenderedLines(lines))
-
-	if !strings.Contains(plain, "Needs attention") {
-		t.Fatalf("expected needs-attention separator, got %q", plain)
-	}
-	if !strings.Contains(plain, "Ship launch copy") {
-		t.Fatalf("expected blocking request title, got %q", plain)
-	}
-	if !strings.Contains(plain, "The team is paused until you answer.") {
-		t.Fatalf("expected blocking request guidance, got %q", plain)
-	}
-}
-
 func TestCurrentMainViewportLinesPrependsNeedsYouStrip(t *testing.T) {
 	m := newChannelModel(false)
 	m.width = 120

--- a/cmd/wuphf/channel_render_extras_test.go
+++ b/cmd/wuphf/channel_render_extras_test.go
@@ -187,45 +187,6 @@ func TestCalendarParticipantsForRequestEmptyFromUsesChannelMembers(t *testing.T)
 	}
 }
 
-func TestContainsStringMatchesTrimmedTarget(t *testing.T) {
-	items := []string{" fe ", "be", "ceo"}
-	if !containsString(items, "fe") {
-		t.Fatalf("expected trimmed match for fe")
-	}
-	if !containsString(items, "be") {
-		t.Fatalf("expected match for be")
-	}
-	if containsString(items, "pm") {
-		t.Fatalf("unexpected match for pm")
-	}
-	if containsString(nil, "fe") {
-		t.Fatalf("nil slice should not match")
-	}
-}
-
-func TestRenderTimingSummaryJoinsParts(t *testing.T) {
-	got := renderTimingSummary("2030-01-01T10:00:00Z", "", "", "")
-	if got == "" {
-		t.Fatalf("expected non-empty timing summary, got empty")
-	}
-	if !strings.Contains(got, "due") {
-		t.Fatalf("expected 'due' label in timing summary, got %q", got)
-	}
-}
-
-func TestRenderTimingSummaryAllBlank(t *testing.T) {
-	if got := renderTimingSummary("", "", "", ""); got != "" {
-		t.Fatalf("blank inputs should yield empty timing summary, got %q", got)
-	}
-}
-
-func TestPrettyWhenUnparsable(t *testing.T) {
-	got := prettyWhen("not-a-time", "due")
-	if !strings.Contains(got, "not-a-time") {
-		t.Fatalf("unparsable timestamps should fall through, got %q", got)
-	}
-}
-
 func TestSummarizeUnreadMessagesGroups(t *testing.T) {
 	cases := []struct {
 		messages []brokerMessage
@@ -242,45 +203,5 @@ func TestSummarizeUnreadMessagesGroups(t *testing.T) {
 		if !strings.Contains(got, tc.want) {
 			t.Errorf("messages=%v: expected %q in %q", tc.messages, tc.want, got)
 		}
-	}
-}
-
-func TestCountRepliesFollowsNestedThread(t *testing.T) {
-	messages := []brokerMessage{
-		{ID: "root", From: "ceo"},
-		{ID: "r1", From: "fe", ReplyTo: "root", Timestamp: "2026-04-29T10:00:00Z"},
-		{ID: "r2", From: "be", ReplyTo: "r1", Timestamp: "2026-04-29T10:05:00Z"},
-		{ID: "r3", From: "pm", ReplyTo: "root", Timestamp: "2026-04-29T10:10:00Z"},
-	}
-	count, last := countReplies(messages, "root")
-	if count != 3 {
-		t.Fatalf("expected 3 replies counting nested, got %d", count)
-	}
-	if last == "" {
-		t.Fatalf("expected last reply timestamp, got empty")
-	}
-}
-
-func TestCountRepliesNoReplies(t *testing.T) {
-	messages := []brokerMessage{{ID: "root"}}
-	count, last := countReplies(messages, "root")
-	if count != 0 || last != "" {
-		t.Fatalf("expected zero replies for solo message, got count=%d last=%q", count, last)
-	}
-}
-
-func TestParseTimestampHandlesInvalidString(t *testing.T) {
-	if !parseTimestamp("nope").IsZero() {
-		t.Fatalf("invalid string should yield zero time")
-	}
-}
-
-func TestFormatShortTimeFallsBackOnInvalid(t *testing.T) {
-	if got := formatShortTime("not-a-time"); got != "" {
-		t.Fatalf("expected empty for unparsable short input, got %q", got)
-	}
-	// Long enough to slice — should return raw HH:MM substring.
-	if got := formatShortTime("2026-04-29T15:30:00Z"); got == "" {
-		t.Fatalf("expected formatted time for valid RFC3339")
 	}
 }

--- a/cmd/wuphf/channel_render_test.go
+++ b/cmd/wuphf/channel_render_test.go
@@ -20,41 +20,6 @@ func TestDefaultHumanMessageTitleByKind(t *testing.T) {
 	}
 }
 
-func TestHumanMessageLabelByKind(t *testing.T) {
-	cases := map[string]string{
-		"human_decision": "decision",
-		"human_action":   "action",
-		"":               "report",
-		"unknown":        "report",
-	}
-	for kind, want := range cases {
-		if got := humanMessageLabel(kind); got != want {
-			t.Errorf("humanMessageLabel(%q) = %q, want %q", kind, got, want)
-		}
-	}
-}
-
-func TestRenderUnreadDividerIncludesCount(t *testing.T) {
-	got := stripANSI(renderUnreadDivider(60, 3))
-	if !strings.Contains(got, "3 new since you looked") {
-		t.Fatalf("expected count in divider, got %q", got)
-	}
-}
-
-func TestRenderUnreadDividerNoCountFallback(t *testing.T) {
-	got := stripANSI(renderUnreadDivider(60, 0))
-	if !strings.Contains(got, "New since you looked") {
-		t.Fatalf("expected generic divider when count is zero, got %q", got)
-	}
-}
-
-func TestRenderUnreadDividerSurvivesNarrowWidth(t *testing.T) {
-	// Width below the label length must not panic and must still produce text.
-	if got := renderUnreadDivider(4, 1); got == "" {
-		t.Fatalf("narrow divider should still render content")
-	}
-}
-
 func TestSliceRenderedLinesScrollsFromBottom(t *testing.T) {
 	lines := []renderedLine{
 		{Text: "0"}, {Text: "1"}, {Text: "2"}, {Text: "3"}, {Text: "4"},

--- a/cmd/wuphf/channelui/helpers_test.go
+++ b/cmd/wuphf/channelui/helpers_test.go
@@ -1,0 +1,45 @@
+package channelui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContainsStringMatchesTrimmedTarget(t *testing.T) {
+	items := []string{" fe ", "be", "ceo"}
+	if !ContainsString(items, "fe") {
+		t.Fatalf("expected trimmed match for fe")
+	}
+	if !ContainsString(items, "be") {
+		t.Fatalf("expected match for be")
+	}
+	if ContainsString(items, "pm") {
+		t.Fatalf("unexpected match for pm")
+	}
+	if ContainsString(nil, "fe") {
+		t.Fatalf("nil slice should not match")
+	}
+}
+
+func TestRenderTimingSummaryJoinsParts(t *testing.T) {
+	got := RenderTimingSummary("2030-01-01T10:00:00Z", "", "", "")
+	if got == "" {
+		t.Fatalf("expected non-empty timing summary, got empty")
+	}
+	if !strings.Contains(got, "due") {
+		t.Fatalf("expected 'due' label in timing summary, got %q", got)
+	}
+}
+
+func TestRenderTimingSummaryAllBlank(t *testing.T) {
+	if got := RenderTimingSummary("", "", "", ""); got != "" {
+		t.Fatalf("blank inputs should yield empty timing summary, got %q", got)
+	}
+}
+
+func TestPrettyWhenUnparsable(t *testing.T) {
+	got := PrettyWhen("not-a-time", "due")
+	if !strings.Contains(got, "not-a-time") {
+		t.Fatalf("unparsable timestamps should fall through, got %q", got)
+	}
+}

--- a/cmd/wuphf/channelui/messages_test.go
+++ b/cmd/wuphf/channelui/messages_test.go
@@ -1,0 +1,42 @@
+package channelui
+
+import "testing"
+
+func TestCountRepliesFollowsNestedThread(t *testing.T) {
+	messages := []BrokerMessage{
+		{ID: "root", From: "ceo"},
+		{ID: "r1", From: "fe", ReplyTo: "root", Timestamp: "2026-04-29T10:00:00Z"},
+		{ID: "r2", From: "be", ReplyTo: "r1", Timestamp: "2026-04-29T10:05:00Z"},
+		{ID: "r3", From: "pm", ReplyTo: "root", Timestamp: "2026-04-29T10:10:00Z"},
+	}
+	count, last := CountReplies(messages, "root")
+	if count != 3 {
+		t.Fatalf("expected 3 replies counting nested, got %d", count)
+	}
+	if last == "" {
+		t.Fatalf("expected last reply timestamp, got empty")
+	}
+}
+
+func TestCountRepliesNoReplies(t *testing.T) {
+	messages := []BrokerMessage{{ID: "root"}}
+	count, last := CountReplies(messages, "root")
+	if count != 0 || last != "" {
+		t.Fatalf("expected zero replies for solo message, got count=%d last=%q", count, last)
+	}
+}
+
+func TestParseTimestampHandlesInvalidString(t *testing.T) {
+	if !ParseTimestamp("nope").IsZero() {
+		t.Fatalf("invalid string should yield zero time")
+	}
+}
+
+func TestFormatShortTimeFallsBackOnInvalid(t *testing.T) {
+	if got := FormatShortTime("not-a-time"); got != "" {
+		t.Fatalf("expected empty for unparsable short input, got %q", got)
+	}
+	if got := FormatShortTime("2026-04-29T15:30:00Z"); got == "" {
+		t.Fatalf("expected formatted time for valid RFC3339")
+	}
+}

--- a/cmd/wuphf/channelui/needs_you_test.go
+++ b/cmd/wuphf/channelui/needs_you_test.go
@@ -1,0 +1,26 @@
+package channelui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildNeedsYouLinesPrefersBlockingRequests(t *testing.T) {
+	requests := []Interview{
+		{ID: "req-1", Kind: "approval", Status: "pending", Title: "Optional note", Question: "Optional note?", From: "pm"},
+		{ID: "req-2", Kind: "approval", Status: "pending", Title: "Ship launch copy", Question: "Ship launch copy?", Context: "Need approval before publishing.", From: "ceo", Blocking: true, RecommendedID: "approve"},
+	}
+
+	lines := BuildNeedsYouLines(requests, 96)
+	plain := stripANSI(joinRenderedLines(lines))
+
+	if !strings.Contains(plain, "Needs attention") {
+		t.Fatalf("expected needs-attention separator, got %q", plain)
+	}
+	if !strings.Contains(plain, "Ship launch copy") {
+		t.Fatalf("expected blocking request title, got %q", plain)
+	}
+	if !strings.Contains(plain, "The team is paused until you answer.") {
+		t.Fatalf("expected blocking request guidance, got %q", plain)
+	}
+}

--- a/cmd/wuphf/channelui/render_helpers_test.go
+++ b/cmd/wuphf/channelui/render_helpers_test.go
@@ -1,0 +1,41 @@
+package channelui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestHumanMessageLabelByKind(t *testing.T) {
+	cases := map[string]string{
+		"human_decision": "decision",
+		"human_action":   "action",
+		"":               "report",
+		"unknown":        "report",
+	}
+	for kind, want := range cases {
+		if got := HumanMessageLabel(kind); got != want {
+			t.Errorf("HumanMessageLabel(%q) = %q, want %q", kind, got, want)
+		}
+	}
+}
+
+func TestRenderUnreadDividerIncludesCount(t *testing.T) {
+	got := stripANSI(RenderUnreadDivider(60, 3))
+	if !strings.Contains(got, "3 new since you looked") {
+		t.Fatalf("expected count in divider, got %q", got)
+	}
+}
+
+func TestRenderUnreadDividerNoCountFallback(t *testing.T) {
+	got := stripANSI(RenderUnreadDivider(60, 0))
+	if !strings.Contains(got, "New since you looked") {
+		t.Fatalf("expected generic divider when count is zero, got %q", got)
+	}
+}
+
+func TestRenderUnreadDividerSurvivesNarrowWidth(t *testing.T) {
+	// Width below the label length must not panic and must still produce text.
+	if got := RenderUnreadDivider(4, 1); got == "" {
+		t.Fatalf("narrow divider should still render content")
+	}
+}

--- a/cmd/wuphf/channelui/test_helpers_test.go
+++ b/cmd/wuphf/channelui/test_helpers_test.go
@@ -1,0 +1,24 @@
+package channelui
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Test-only helpers shared across channelui's test files. The cmd/wuphf
+// package has copies of these — once the channel cluster fully migrates
+// the package-main copies disappear with the alias bridge.
+
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiPattern.ReplaceAllString(s, "")
+}
+
+func joinRenderedLines(lines []RenderedLine) string {
+	parts := make([]string, 0, len(lines))
+	for _, line := range lines {
+		parts = append(parts, line.Text)
+	}
+	return strings.Join(parts, "\n")
+}


### PR DESCRIPTION
## Summary

Course-correction PR addressing the staff review's blocker #2: tests for code that lives in channelui were accumulating in \`cmd/wuphf/\`, exercising the migrated helpers through the lowercase alias bridge instead of the canonical PascalCase API. The deferred test debt was about to make PR 9 (alias removal) a 600-LoC churn PR with subtle bridge-vs-underlying coverage gaps.

This PR migrates the cleanly-mobile tests now.

## What moved

| New file | Tests |
|---|---|
| \`channelui/helpers_test.go\` | \`TestContainsStringMatchesTrimmedTarget\`, \`TestRenderTimingSummaryJoinsParts\`, \`TestRenderTimingSummaryAllBlank\`, \`TestPrettyWhenUnparsable\` |
| \`channelui/messages_test.go\` | \`TestCountRepliesFollowsNestedThread\`, \`TestCountRepliesNoReplies\`, \`TestParseTimestampHandlesInvalidString\`, \`TestFormatShortTimeFallsBackOnInvalid\` |
| \`channelui/render_helpers_test.go\` | \`TestHumanMessageLabelByKind\`, \`TestRenderUnreadDividerIncludesCount\`, \`TestRenderUnreadDividerNoCountFallback\`, \`TestRenderUnreadDividerSurvivesNarrowWidth\` |
| \`channelui/needs_you_test.go\` | \`TestBuildNeedsYouLinesPrefersBlockingRequests\` |
| \`channelui/test_helpers_test.go\` (shared) | \`stripANSI\`, \`joinRenderedLines\` |

## What stays

Tests that exercise code *still in cmd/wuphf* keep their alias-bridge call shape and stay put. They'll migrate in lockstep with their production code:

- \`TestBuildSkillLines*\`, \`TestBuildOneOnOneMessageLines*\` — \`channel_render.go\` is still in main
- \`TestRequestCalendarEvents*\`, \`TestCalendarParticipantsForRequest*\` — calendar event helpers still in main
- \`TestSummarizeUnreadMessagesGroups\` — \`summarizeUnreadMessages\` from \`channel_unread.go\` is still in main
- \`TestDefaultHumanMessageTitleByKind\` — depends on \`displayName\` (channelui) but is itself in \`channel_render.go\`
- \`TestSliceRenderedLines*\`, \`TestBuildRequestLines*\`, \`TestBuildPolicyLines*\` — production code still in main
- All of \`channel_mailboxes_test.go\` — \`buildInboxLines\` / \`buildOutboxLines\` still in main
- All of \`channel_test.go\`, \`channel_viewport_benchmark_test.go\` — exercise \`channelModel\`

The cmd/wuphf-side \`stripANSI\` / \`joinRenderedLines\` helpers stay where they are; the channelui-side copies are local to channelui's tests.

## Why surgical, not bulk

A blanket "move every test alongside the code" approach would split mixed-residency files (e.g. \`channel_render_test.go\` has tests for both channelui and still-in-main code) and complicate review. This PR moves only the unambiguous cases. The remaining test files become easier to fully migrate in their own follow-up PRs once the surrounding production code lands in channelui.

## Diff stats

- 8 files changed, 178 insertions(+), 134 deletions(-)
- 5 new files (channelui-side test files + shared helper)
- 3 cmd/wuphf-side test files trimmed

## Test plan

- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go build ./cmd/wuphf\` — binary builds
- [ ] CI passes on draft PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)