### PR TITLE
refactor(channelui): hoist render list helpers

### DIFF
--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -303,17 +303,6 @@ func buildPolicyLines(signals []channelSignal, decisions []channelDecision, aler
 	return lines
 }
 
-func displaySignalKind(signal channelSignal) string {
-	kind := strings.TrimSpace(signal.Kind)
-	if kind == "" {
-		return ""
-	}
-	if strings.EqualFold(kind, "directive") {
-		return "Human directive"
-	}
-	return kind
-}
-
 func buildTaskLines(tasks []channelTask, contentWidth int) []renderedLine {
 	muted := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
 	if len(tasks) == 0 {
@@ -1144,70 +1133,12 @@ func schedulerTargetThreadID(job channelSchedulerJob, tasks []channelTask, reque
 	return ""
 }
 
-func agentSlugForDisplay(name string, members []channelMember) string {
-	for _, member := range members {
-		if member.Name == name || displayName(member.Slug) == name {
-			return member.Slug
-		}
-	}
-	return ""
-}
-
-func reverseSignals(signals []channelSignal, limit int) []channelSignal {
-	if limit > 0 && len(signals) > limit {
-		signals = signals[len(signals)-limit:]
-	}
-	out := append([]channelSignal(nil), signals...)
-	reverseAny(out)
-	return out
-}
-
-func reverseDecisions(decisions []channelDecision, limit int) []channelDecision {
-	if limit > 0 && len(decisions) > limit {
-		decisions = decisions[len(decisions)-limit:]
-	}
-	out := append([]channelDecision(nil), decisions...)
-	reverseAny(out)
-	return out
-}
-
-func activeWatchdogs(alerts []channelWatchdog) []channelWatchdog {
-	var out []channelWatchdog
-	for _, alert := range alerts {
-		if strings.TrimSpace(alert.Status) == "resolved" {
-			continue
-		}
-		out = append(out, alert)
-	}
-	return out
-}
-
-func reverseWatchdogs(alerts []channelWatchdog, limit int) []channelWatchdog {
-	if limit > 0 && len(alerts) > limit {
-		alerts = alerts[len(alerts)-limit:]
-	}
-	out := append([]channelWatchdog(nil), alerts...)
-	reverseAny(out)
-	return out
-}
-
-func recentExternalActions(actions []channelAction, limit int) []channelAction {
-	var filtered []channelAction
-	for _, action := range actions {
-		kind := strings.TrimSpace(action.Kind)
-		if !strings.HasPrefix(kind, "external_") && kind != "bridge_channel" {
-			continue
-		}
-		filtered = append(filtered, action)
-	}
-	if limit > 0 && len(filtered) > limit {
-		filtered = filtered[len(filtered)-limit:]
-	}
-	out := append([]channelAction(nil), filtered...)
-	reverseAny(out)
-	return out
-}
-
+// reverseAny reverses items in place. Kept in package main (instead of
+// hoisted alongside the typed Reverse* helpers in channelui) because Go
+// does not allow taking the value of a generic function — so it cannot
+// be aliased through channelui_aliases.go. channel_artifacts.go and
+// channel_activity.go still call it directly. Removed in PR 9 once
+// those callers move into channelui.
 func reverseAny[T any](items []T) {
 	for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
 		items[i], items[j] = items[j], items[i]

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -40,6 +40,10 @@
 //     BuildReplyChildren, ParseTimestamp, FormatShortTime).
 //   - needs_you.go         — "needs your attention" strip renderer plus
 //     SelectNeedsYouRequest / IsOpenInterviewStatus selectors.
+//   - list_helpers.go      — pure list filters and reversals
+//     (ReverseSignals, ReverseDecisions, ActiveWatchdogs,
+//     ReverseWatchdogs, RecentExternalActions), plus
+//     AgentSlugForDisplay and DisplaySignalKind.
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/list_helpers.go
+++ b/cmd/wuphf/channelui/list_helpers.go
@@ -1,0 +1,108 @@
+package channelui
+
+import "strings"
+
+// ReverseSignals returns the most recent up-to-limit signals in
+// newest-first order. limit <= 0 keeps all signals. The input slice is
+// not mutated.
+func ReverseSignals(signals []Signal, limit int) []Signal {
+	if limit > 0 && len(signals) > limit {
+		signals = signals[len(signals)-limit:]
+	}
+	out := append([]Signal(nil), signals...)
+	reverseAny(out)
+	return out
+}
+
+// ReverseDecisions returns the most recent up-to-limit decisions in
+// newest-first order. limit <= 0 keeps all decisions. The input slice
+// is not mutated.
+func ReverseDecisions(decisions []Decision, limit int) []Decision {
+	if limit > 0 && len(decisions) > limit {
+		decisions = decisions[len(decisions)-limit:]
+	}
+	out := append([]Decision(nil), decisions...)
+	reverseAny(out)
+	return out
+}
+
+// ActiveWatchdogs filters out watchdogs whose Status is "resolved",
+// preserving original order. Whitespace around Status is trimmed before
+// the comparison so persisted records with stray spaces still resolve
+// correctly.
+func ActiveWatchdogs(alerts []Watchdog) []Watchdog {
+	var out []Watchdog
+	for _, alert := range alerts {
+		if strings.TrimSpace(alert.Status) == "resolved" {
+			continue
+		}
+		out = append(out, alert)
+	}
+	return out
+}
+
+// ReverseWatchdogs returns the most recent up-to-limit watchdogs in
+// newest-first order. limit <= 0 keeps all alerts. The input slice is
+// not mutated.
+func ReverseWatchdogs(alerts []Watchdog, limit int) []Watchdog {
+	if limit > 0 && len(alerts) > limit {
+		alerts = alerts[len(alerts)-limit:]
+	}
+	out := append([]Watchdog(nil), alerts...)
+	reverseAny(out)
+	return out
+}
+
+// RecentExternalActions returns the most recent up-to-limit actions
+// whose Kind starts with "external_" or equals "bridge_channel", in
+// newest-first order. limit <= 0 keeps all matching actions.
+func RecentExternalActions(actions []Action, limit int) []Action {
+	var filtered []Action
+	for _, action := range actions {
+		kind := strings.TrimSpace(action.Kind)
+		if !strings.HasPrefix(kind, "external_") && kind != "bridge_channel" {
+			continue
+		}
+		filtered = append(filtered, action)
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[len(filtered)-limit:]
+	}
+	out := append([]Action(nil), filtered...)
+	reverseAny(out)
+	return out
+}
+
+// AgentSlugForDisplay returns the slug of the member whose Name or
+// resolved display-name matches the given name. Returns "" when no
+// member matches.
+func AgentSlugForDisplay(name string, members []Member) string {
+	for _, member := range members {
+		if member.Name == name || DisplayName(member.Slug) == name {
+			return member.Slug
+		}
+	}
+	return ""
+}
+
+// DisplaySignalKind returns the user-facing label for a signal's kind:
+// "Human directive" for kind "directive" (case-insensitive), the
+// trimmed kind otherwise. Empty kinds yield "".
+func DisplaySignalKind(signal Signal) string {
+	kind := strings.TrimSpace(signal.Kind)
+	if kind == "" {
+		return ""
+	}
+	if strings.EqualFold(kind, "directive") {
+		return "Human directive"
+	}
+	return kind
+}
+
+// reverseAny reverses items in place. Generic so the typed Reverse*
+// helpers above can share one implementation.
+func reverseAny[T any](items []T) {
+	for i, j := 0, len(items)-1; i < j; i, j = i+1, j-1 {
+		items[i], items[j] = items[j], items[i]
+	}
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -78,6 +78,14 @@ var (
 	buildNeedsYouLinesForRequest = channelui.BuildNeedsYouLinesForRequest
 	selectNeedsYouRequest        = channelui.SelectNeedsYouRequest
 	isOpenInterviewStatus        = channelui.IsOpenInterviewStatus
+
+	reverseSignals        = channelui.ReverseSignals
+	reverseDecisions      = channelui.ReverseDecisions
+	activeWatchdogs       = channelui.ActiveWatchdogs
+	reverseWatchdogs      = channelui.ReverseWatchdogs
+	recentExternalActions = channelui.RecentExternalActions
+	agentSlugForDisplay   = channelui.AgentSlugForDisplay
+	displaySignalKind     = channelui.DisplaySignalKind
 )
 
 // Office-app constant aliases. Typed-string consts copy across packages


### PR DESCRIPTION
## Summary

Hoists the pure list/filter helpers used by the render-cluster off `channel_render.go` and into `channelui/list_helpers.go`. Continues the channelui extraction stack (sits on top of #434).

Moved (now exported in channelui):
- `ReverseSignals` / `ReverseDecisions` / `ReverseWatchdogs` — newest-first capped slices
- `ActiveWatchdogs` — filters out resolved watchdogs
- `RecentExternalActions` — filters + reverses `external_*` / `bridge_channel` actions
- `AgentSlugForDisplay` — member name → slug
- `DisplaySignalKind` — "directive" → "Human directive", trimmed kind otherwise

`reverseAny` stays in package main as a generic helper. Go doesn't allow taking the value of a generic function, so it can't be aliased through `channelui_aliases.go`, and `channel_artifacts.go` / `channel_activity.go` still call it directly. The shim is removed in the final cleanup PR.

## Test plan

- [x] `go build ./cmd/wuphf`
- [x] `go vet ./...`
- [x] `bash scripts/test-go.sh` — all 34 packages green
- [x] `golangci-lint run ./cmd/wuphf/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)