### PR TITLE
refactor(team): split launcher_web.go and broker_lifecycle.go (C8)

### DIFF
--- a/internal/team/broker_lifecycle.go
+++ b/internal/team/broker_lifecycle.go
@@ -1,0 +1,148 @@
+package team
+
+// broker_lifecycle.go owns the broker-side housekeeping helpers that used
+// to sit in launcher.go (PLAN.md §C8): the office PID file (write, clear,
+// kill-by-PID), the in-memory + persisted broker-state reset endpoints,
+// the stale-broker-port killer used before LaunchWeb starts a fresh
+// broker, and the small URL accessors. These are package-level helpers
+// (no Launcher receiver) plus a single Launcher.BrokerBaseURL accessor;
+// grouping them here keeps launcher.go focused on the orchestrator and
+// lets the broker-state tests live alongside their subjects.
+//
+// No new types or behaviour changes — pure file split.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/brokeraddr"
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// killStaleBroker kills any process holding the configured broker port from a previous run.
+func killStaleBroker() {
+	out, err := exec.CommandContext(context.Background(), "lsof", "-i", fmt.Sprintf(":%d", brokeraddr.ResolvePort()), "-t").Output()
+	if err != nil || len(out) == 0 {
+		return
+	}
+	for _, pid := range strings.Fields(strings.TrimSpace(string(out))) {
+		_ = exec.CommandContext(context.Background(), "kill", "-9", pid).Run()
+	}
+	time.Sleep(500 * time.Millisecond)
+}
+
+func ResetBrokerState() error {
+	token := os.Getenv("WUPHF_BROKER_TOKEN")
+	if token == "" {
+		token = os.Getenv("NEX_BROKER_TOKEN")
+	}
+	return resetBrokerState(brokerBaseURL(), token)
+}
+
+func ClearPersistedBrokerState() error {
+	path := defaultBrokerStatePath()
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func officePIDFilePath() string {
+	home := config.RuntimeHomeDir()
+	if home == "" {
+		return filepath.Join(".wuphf", "team", "office.pid")
+	}
+	return filepath.Join(home, ".wuphf", "team", "office.pid")
+}
+
+func writeOfficePIDFile() error {
+	path := officePIDFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0o600)
+}
+
+func clearOfficePIDFile() error {
+	path := officePIDFilePath()
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}
+
+func killPersistedOfficeProcess() error {
+	raw, err := os.ReadFile(officePIDFilePath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		// Stale or corrupt PID file: there's no process to kill, just
+		// clear the file so the next launcher boots cleanly. Don't
+		// surface the parse error — the caller's intent is "shut
+		// anything down", and an unparseable PID file means there's
+		// nothing to shut down.
+		_ = clearOfficePIDFile()
+		return nil //nolint:nilerr // intentional: corrupt PID file is a no-op
+	}
+	if pid == os.Getpid() {
+		return nil
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		// On Unix os.FindProcess never errors, but cover the API
+		// contract: if it ever does, clear the stale PID file and
+		// continue — there's nothing to kill.
+		_ = clearOfficePIDFile()
+		return nil //nolint:nilerr // intentional: no process to kill, clear PID and move on
+	}
+	_ = proc.Kill()
+	return nil
+}
+
+func resetBrokerState(baseURL, token string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/reset", nil)
+	if err != nil {
+		return err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("broker reset failed: %s", resp.Status)
+	}
+	return nil
+}
+
+func brokerBaseURL() string {
+	return brokeraddr.ResolveBaseURL()
+}
+
+func (l *Launcher) BrokerBaseURL() string {
+	if l != nil && l.broker != nil {
+		if addr := strings.TrimSpace(l.broker.Addr()); addr != "" {
+			return "http://" + addr
+		}
+	}
+	return brokerBaseURL()
+}

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -12,24 +12,18 @@ package team
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"io"
 	"log"
-	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"golang.org/x/term"
 
 	"github.com/nex-crm/wuphf/internal/action"
 	"github.com/nex-crm/wuphf/internal/agent"
@@ -37,12 +31,10 @@ import (
 	"github.com/nex-crm/wuphf/internal/channel"
 	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/config"
-	"github.com/nex-crm/wuphf/internal/nex"
 	"github.com/nex-crm/wuphf/internal/onboarding"
 	"github.com/nex-crm/wuphf/internal/operations"
 	"github.com/nex-crm/wuphf/internal/provider"
 	"github.com/nex-crm/wuphf/internal/runtimebin"
-	"github.com/nex-crm/wuphf/internal/setup"
 )
 
 const (
@@ -1616,17 +1608,9 @@ func (l *Launcher) OneOnOneAgent() string {
 	return l.oneOnOneAgent()
 }
 
-// killStaleBroker kills any process holding the configured broker port from a previous run.
-func killStaleBroker() {
-	out, err := exec.CommandContext(context.Background(), "lsof", "-i", fmt.Sprintf(":%d", brokeraddr.ResolvePort()), "-t").Output()
-	if err != nil || len(out) == 0 {
-		return
-	}
-	for _, pid := range strings.Fields(strings.TrimSpace(string(out))) {
-		_ = exec.CommandContext(context.Background(), "kill", "-9", pid).Run()
-	}
-	time.Sleep(500 * time.Millisecond)
-}
+// killStaleBroker, the office-PID-file helpers, ResetBrokerState,
+// ClearPersistedBrokerState, resetBrokerState, brokerBaseURL, and
+// Launcher.BrokerBaseURL live in broker_lifecycle.go per PLAN.md §C8.
 
 func containsSlug(items []string, want string) bool {
 	for _, item := range items {
@@ -2072,101 +2056,6 @@ func (l *Launcher) capturePaneTargetContent(target string) (string, error) {
 func (l *Launcher) capturePaneContent(paneIdx int) (string, error) {
 	target := fmt.Sprintf("%s:team.%d", l.sessionName, paneIdx)
 	return l.capturePaneTargetContent(target)
-}
-
-func ResetBrokerState() error {
-	token := os.Getenv("WUPHF_BROKER_TOKEN")
-	if token == "" {
-		token = os.Getenv("NEX_BROKER_TOKEN")
-	}
-	return resetBrokerState(brokerBaseURL(), token)
-}
-
-func ClearPersistedBrokerState() error {
-	path := defaultBrokerStatePath()
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	return nil
-}
-
-func officePIDFilePath() string {
-	home := config.RuntimeHomeDir()
-	if home == "" {
-		return filepath.Join(".wuphf", "team", "office.pid")
-	}
-	return filepath.Join(home, ".wuphf", "team", "office.pid")
-}
-
-func writeOfficePIDFile() error {
-	path := officePIDFilePath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
-	}
-	return os.WriteFile(path, []byte(strconv.Itoa(os.Getpid())), 0o600)
-}
-
-func clearOfficePIDFile() error {
-	path := officePIDFilePath()
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return err
-	}
-	return nil
-}
-
-func killPersistedOfficeProcess() error {
-	raw, err := os.ReadFile(officePIDFilePath())
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
-		return err
-	}
-	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
-	if err != nil || pid <= 0 {
-		// Stale or corrupt PID file: there's no process to kill, just
-		// clear the file so the next launcher boots cleanly. Don't
-		// surface the parse error — the caller's intent is "shut
-		// anything down", and an unparseable PID file means there's
-		// nothing to shut down.
-		_ = clearOfficePIDFile()
-		return nil //nolint:nilerr // intentional: corrupt PID file is a no-op
-	}
-	if pid == os.Getpid() {
-		return nil
-	}
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		// On Unix os.FindProcess never errors, but cover the API
-		// contract: if it ever does, clear the stale PID file and
-		// continue — there's nothing to kill.
-		_ = clearOfficePIDFile()
-		return nil //nolint:nilerr // intentional: no process to kill, clear PID and move on
-	}
-	_ = proc.Kill()
-	return nil
-}
-
-func resetBrokerState(baseURL, token string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/reset", nil)
-	if err != nil {
-		return err
-	}
-	if token != "" {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-	client := &http.Client{Timeout: 5 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("broker reset failed: %s", resp.Status)
-	}
-	return nil
 }
 
 func (l *Launcher) clearAgentPanes() error {
@@ -3050,19 +2939,6 @@ func (l *Launcher) isFocusModeEnabled() bool {
 	return l.focusMode
 }
 
-func brokerBaseURL() string {
-	return brokeraddr.ResolveBaseURL()
-}
-
-func (l *Launcher) BrokerBaseURL() string {
-	if l != nil && l.broker != nil {
-		if addr := strings.TrimSpace(l.broker.Addr()); addr != "" {
-			return "http://" + addr
-		}
-	}
-	return brokerBaseURL()
-}
-
 // officeMemberBySlug / officeLeadSlug / activeSessionMembers / getAgentName
 // live on officeTargeter (PLAN.md §C2); thin wrappers keep current callers
 // working without a rename sweep.
@@ -3129,282 +3005,9 @@ func filterEnv(env []string, key string) []string {
 // the targeter (PLAN.md §C2).
 func (l *Launcher) getAgentName(slug string) string { return l.targeter().NameFor(slug) }
 
-// ═══════════════════════════════════════════════════════════════
-// Web View Mode
-// ═══════════════════════════════════════════════════════════════
-
-// PreflightWeb checks only for claude (no tmux requirement for web mode).
-//
-// When the user has not yet completed onboarding we deliberately skip the
-// runtime-binary check: the whole point of the web-mode onboarding wizard is
-// to pick a runtime. Hard-failing here would make the binary unlaunchable
-// until the user already had the CLI they were trying to pick. A missing
-// runtime is still caught at first-dispatch time with a clear message once
-// onboarding has committed a choice to ~/.wuphf/config.json.
-func (l *Launcher) PreflightWeb() error {
-	if !isOnboarded() {
-		if _, _, note := checkGHCapability(); note != "" {
-			fmt.Fprintf(os.Stderr, "note: %s\n", note)
-		}
-		return nil
-	}
-	if l.usesCodexRuntime() {
-		if l.usesOpencodeRuntime() {
-			if _, err := runtimebin.LookPath("opencode"); err != nil {
-				return fmt.Errorf("opencode not found. Install Opencode CLI (https://opencode.ai) and configure your provider credentials")
-			}
-			return nil
-		}
-		if _, err := exec.LookPath("codex"); err != nil {
-			return fmt.Errorf("codex not found. Install Codex CLI and run `codex login`")
-		}
-		return nil
-	}
-	if _, err := exec.LookPath("claude"); err != nil {
-		return fmt.Errorf("claude not found in PATH. Install Claude Code CLI first")
-	}
-	if _, _, note := checkGHCapability(); note != "" {
-		fmt.Fprintf(os.Stderr, "note: %s\n", note)
-	}
-	return nil
-}
-
-// LaunchWeb starts the broker, web UI server, and background agents without tmux.
-func (l *Launcher) LaunchWeb(webPort int) error {
-	// Offer to wire Nex when the user hasn't opted out and nex-cli isn't yet
-	// installed. `nex setup` handles detection and wiring for us — we just
-	// surface the prompt.
-	l.maybeOfferNex()
-
-	mcpConfig, err := l.ensureMCPConfig()
-	if err != nil {
-		return fmt.Errorf("prepare mcp config: %w", err)
-	}
-	l.mcpConfig = mcpConfig
-	l.webMode = true
-
-	killStaleBroker()
-
-	l.broker = NewBroker()
-	l.broker.runtimeProvider = l.provider
-	l.broker.packSlug = l.packSlug
-	l.broker.blankSlateLaunch = l.blankSlateLaunch
-	// Wire the notebook-promotion reviewer resolver from the active
-	// blueprint. Without this, every promotion falls back to "ceo"
-	// regardless of blueprint reviewer_paths. Safe on nil (packs-only
-	// launches or blank-slate runs).
-	if l.operationBlueprint != nil {
-		bp := l.operationBlueprint
-		l.broker.SetReviewerResolver(func(wikiPath string) string {
-			return bp.ResolveReviewer(wikiPath)
-		})
-	}
-	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
-		return fmt.Errorf("set session mode: %w", err)
-	}
-	if err := l.broker.SetFocusMode(l.focusMode); err != nil {
-		return fmt.Errorf("set focus mode: %w", err)
-	}
-	if err := l.broker.Start(); err != nil {
-		return fmt.Errorf("start broker: %w", err)
-	}
-	if err := writeOfficePIDFile(); err != nil {
-		return fmt.Errorf("write office pid: %w", err)
-	}
-
-	// Pre-seed any default skills declared by the pack (idempotent).
-	// Always seed the cross-cutting productivity skills (grill-me, tdd,
-	// diagnose, etc., adapted from github.com/mattpocock/skills) on top of
-	// whatever the active pack defines. They're useful for every install,
-	// not just packs that explicitly enumerate them.
-	if l.pack != nil {
-		l.broker.SeedDefaultSkills(agent.AppendProductivitySkills(l.pack.DefaultSkills))
-	} else {
-		l.broker.SeedDefaultSkills(agent.AppendProductivitySkills(nil))
-	}
-
-	l.broker.SetGenerateMemberFn(l.GenerateMemberTemplateFromPrompt)
-	l.broker.SetGenerateChannelFn(l.GenerateChannelTemplateFromPrompt)
-	if err := l.broker.ServeWebUI(webPort); err != nil {
-		// The broker is already running and the office PID file is on
-		// disk (above). On a port-bind failure we exit, so tear both
-		// down — leaving the broker accepting requests on a "wuphf has
-		// failed to start" path is worse than a clean exit, and a stale
-		// PID file would block the next launch attempt's writeOfficePID.
-		l.broker.Stop()
-		_ = clearOfficePIDFile()
-		return fmt.Errorf("web UI failed to start: %w\n\nIs port %d already in use? Try: wuphf --web-port %d", err, webPort, webPort+1)
-	}
-
-	// Default path: headless `claude --print` per turn. Anthropic re-sanctioned
-	// this invocation (OpenClaw policy note, 2026-04), so it runs on the user's
-	// normal subscription quota — no separate extra-usage quota is charged on
-	// top. The legacy interactive pane-per-agent mode remains reachable via
-	// trySpawnWebAgentPanes as an internal fallback primitive, but is not
-	// invoked at startup.
-
-	// Headless context is used for codex runtime, default dispatch, and
-	// per-turn operations that don't fit a long-lived pane session.
-	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
-	l.resumeInFlightWork()
-
-	// Stream tmux pane output to the web UI's per-agent stream so users see
-	// live Claude TUI activity (thinking, tool calls, responses) during a
-	// pane-backed turn. No-op when paneBackedAgents is false.
-	l.startPaneCaptureLoops(l.headless.ctx)
-
-	go l.notifyAgentsLoop()
-	go l.notifyTaskActionsLoop()
-	go l.notifyOfficeChangesLoop()
-	go l.pollNexNotificationsLoop()
-	go l.watchdogSchedulerLoop()
-	if l.paneBackedAgents {
-		go l.primeVisibleAgents()
-	}
-
-	// Use 127.0.0.1 in both the printed URL and the readiness probe so the
-	// dial target matches what the browser will request. localhost can
-	// resolve to ::1 first on IPv6-preferring setups, while ServeWebUI binds
-	// only to 127.0.0.1 — that mismatch reproduces ERR_CONNECTION_REFUSED
-	// even after the probe succeeds.
-	webAddr := fmt.Sprintf("127.0.0.1:%d", webPort)
-	webURL := fmt.Sprintf("http://%s", webAddr)
-	fmt.Printf("\n  Web UI:  %s\n", webURL)
-	fmt.Printf("  Broker:  %s\n", l.BrokerBaseURL())
-	fmt.Printf("  Press Ctrl+C to stop.\n\n")
-
-	if !l.noOpen {
-		// Wait for the web server to actually accept connections before
-		// triggering the browser. Otherwise users on cold starts (and PH
-		// visitors clicking through `npx wuphf` for the first time) hit
-		// ERR_CONNECTION_REFUSED before the listener is ready. 5s is a
-		// generous ceiling: in practice the listener is up in milliseconds.
-		// Skip the open if the listener never came up — opening a dead URL
-		// just produces a confusing error page in the user's first second.
-		if waitForWebReady(webAddr, 5*time.Second) {
-			openBrowser(webURL)
-		} else {
-			fmt.Printf("  Web UI did not become reachable at %s within 5s; skipping browser auto-open.\n", webURL)
-		}
-	}
-
-	// Broker, web UI, and background goroutines own the process lifetime;
-	// Ctrl+C (default SIGINT) is the only exit path.
-	select {}
-}
-
-// maybeOfferNex offers to wire up Nex for memory/context when nex-cli
-// isn't already installed. Prints an explicit "skipping Nex" line when
-// stdin isn't a TTY (npx, pipes, CI, containers) — fmt.Scanln returns
-// empty in that case, which the prompt would have silently accepted as
-// "yes" and tried to install. Users can rerun `nex setup` later or set
-// WUPHF_NO_NEX=1 to suppress the offer.
-func (l *Launcher) maybeOfferNex() {
-	if config.ResolveNoNex() || nex.IsInstalled() {
-		return
-	}
-	if !stdinIsTTY() {
-		fmt.Println()
-		fmt.Println("  Skipping Nex (no interactive terminal). Run `nex setup` later to add memory.")
-		fmt.Println()
-		return
-	}
-	fmt.Println()
-	fmt.Print("  Connect Nex for memory and context? [Y/n] ")
-	var answer string
-	if _, err := fmt.Scanln(&answer); err != nil {
-		// fmt.Scanln has two distinct error shapes here:
-		//   - io.EOF: stdin was closed underneath us. By the time we
-		//     reach this branch stdinIsTTY() already returned true, so
-		//     EOF means the user explicitly hit Ctrl-D rather than
-		//     answering. Treat as a deliberate skip.
-		//   - any other error (most commonly "unexpected newline" from
-		//     a bare Enter): the prompt label says [Y/n], so capital-Y
-		//     is the visible default. Accept Enter as "yes" so the UX
-		//     contract matches the prompt.
-		if errors.Is(err, io.EOF) {
-			fmt.Println("  Skipping Nex. Agents will work without organizational memory.")
-			fmt.Println()
-			return
-		}
-		answer = ""
-	}
-	answer = strings.TrimSpace(strings.ToLower(answer))
-	if answer != "" && answer != "y" && answer != "yes" {
-		fmt.Println("  Skipping Nex. Agents will work without organizational memory.")
-		fmt.Println()
-		return
-	}
-	fmt.Println()
-	fmt.Println("  Nex CLI not found. Installing...")
-	if _, installErr := setup.InstallLatestCLI(context.Background()); installErr != nil {
-		fmt.Printf("  Could not install: %v\n", installErr)
-		fmt.Println("  Continuing without Nex.")
-	}
-	if nexBin := nex.BinaryPath(); nexBin != "" {
-		cmd := exec.CommandContext(context.Background(), nexBin, "setup")
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			fmt.Printf("  Setup did not complete: %v\n", err)
-			fmt.Println("  Continuing without Nex.")
-		} else {
-			fmt.Println("  Nex connected.")
-		}
-	}
-	fmt.Println()
-}
-
-// waitForWebReady polls addr until a TCP dial succeeds or the timeout
-// elapses. It exists because ServeWebUI returns immediately and the
-// listener can take a few hundred ms to come up — opening the browser
-// before then produces ERR_CONNECTION_REFUSED in the user's first
-// second of the product. Returns true when the listener accepted a
-// connection within the timeout, false otherwise. LaunchWeb gates
-// openBrowser on this return value, so a never-up listener results in
-// a printed "skipping browser auto-open" line rather than a dead URL.
-func waitForWebReady(addr string, timeout time.Duration) bool {
-	dialer := &net.Dialer{Timeout: 250 * time.Millisecond}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	for {
-		conn, err := dialer.DialContext(ctx, "tcp", addr)
-		if err == nil {
-			_ = conn.Close()
-			return true
-		}
-		select {
-		case <-ctx.Done():
-			return false
-		case <-time.After(50 * time.Millisecond):
-		}
-	}
-}
-
-// stdinIsTTY reports whether os.Stdin is connected to a real terminal.
-// Uses golang.org/x/term so /dev/null (a char device but not a TTY) is
-// classified correctly — the original os.ModeCharDevice check let
-// `npx ... </dev/null` fall back to the auto-yes install path, which
-// is the cold-start bug this whole helper exists to prevent.
-func stdinIsTTY() bool {
-	return term.IsTerminal(int(os.Stdin.Fd()))
-}
-
-func openBrowser(url string) {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.CommandContext(context.Background(), "open", url)
-	case "linux":
-		cmd = exec.CommandContext(context.Background(), "xdg-open", url)
-	case "windows":
-		cmd = exec.CommandContext(context.Background(), "cmd", "/c", "start", "", url)
-	default:
-		return
-	}
-	_ = cmd.Start()
-}
+// Web-mode entry points (PreflightWeb, LaunchWeb, maybeOfferNex,
+// waitForWebReady, stdinIsTTY, openBrowser) live in launcher_web.go per
+// PLAN.md §C8.
 
 // postEscalation writes a system message to #general when an agent is stuck
 // or has blown its retry budget. The Slack-style UI renders this as a normal

--- a/internal/team/launcher_web.go
+++ b/internal/team/launcher_web.go
@@ -1,0 +1,304 @@
+package team
+
+// launcher_web.go owns the web-mode entry points (PLAN.md §C8): the
+// preflight check, the LaunchWeb path that boots the broker + web UI
+// without tmux, the optional Nex-onboarding offer, and the small
+// browser-launch helpers used only by web mode. Splitting these off
+// keeps launcher.go focused on the tmux-mode orchestrator while letting
+// web-only imports (`net`, `golang.org/x/term`, `internal/setup`,
+// `internal/nex`, `internal/runtimebin` for the opencode lookup) sit in
+// one file. No new types or behaviour changes — pure file split.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/nex-crm/wuphf/internal/agent"
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/nex"
+	"github.com/nex-crm/wuphf/internal/runtimebin"
+	"github.com/nex-crm/wuphf/internal/setup"
+)
+
+// PreflightWeb checks only for claude (no tmux requirement for web mode).
+//
+// When the user has not yet completed onboarding we deliberately skip the
+// runtime-binary check: the whole point of the web-mode onboarding wizard is
+// to pick a runtime. Hard-failing here would make the binary unlaunchable
+// until the user already had the CLI they were trying to pick. A missing
+// runtime is still caught at first-dispatch time with a clear message once
+// onboarding has committed a choice to ~/.wuphf/config.json.
+func (l *Launcher) PreflightWeb() error {
+	if !isOnboarded() {
+		if _, _, note := checkGHCapability(); note != "" {
+			fmt.Fprintf(os.Stderr, "note: %s\n", note)
+		}
+		return nil
+	}
+	if l.usesCodexRuntime() {
+		if l.usesOpencodeRuntime() {
+			if _, err := runtimebin.LookPath("opencode"); err != nil {
+				return fmt.Errorf("opencode not found. Install Opencode CLI (https://opencode.ai) and configure your provider credentials")
+			}
+			return nil
+		}
+		if _, err := exec.LookPath("codex"); err != nil {
+			return fmt.Errorf("codex not found. Install Codex CLI and run `codex login`")
+		}
+		return nil
+	}
+	if _, err := exec.LookPath("claude"); err != nil {
+		return fmt.Errorf("claude not found in PATH. Install Claude Code CLI first")
+	}
+	if _, _, note := checkGHCapability(); note != "" {
+		fmt.Fprintf(os.Stderr, "note: %s\n", note)
+	}
+	return nil
+}
+
+// LaunchWeb starts the broker, web UI server, and background agents without tmux.
+func (l *Launcher) LaunchWeb(webPort int) error {
+	// Offer to wire Nex when the user hasn't opted out and nex-cli isn't yet
+	// installed. `nex setup` handles detection and wiring for us — we just
+	// surface the prompt.
+	l.maybeOfferNex()
+
+	mcpConfig, err := l.ensureMCPConfig()
+	if err != nil {
+		return fmt.Errorf("prepare mcp config: %w", err)
+	}
+	l.mcpConfig = mcpConfig
+	l.webMode = true
+
+	killStaleBroker()
+
+	l.broker = NewBroker()
+	l.broker.runtimeProvider = l.provider
+	l.broker.packSlug = l.packSlug
+	l.broker.blankSlateLaunch = l.blankSlateLaunch
+	// Wire the notebook-promotion reviewer resolver from the active
+	// blueprint. Without this, every promotion falls back to "ceo"
+	// regardless of blueprint reviewer_paths. Safe on nil (packs-only
+	// launches or blank-slate runs).
+	if l.operationBlueprint != nil {
+		bp := l.operationBlueprint
+		l.broker.SetReviewerResolver(func(wikiPath string) string {
+			return bp.ResolveReviewer(wikiPath)
+		})
+	}
+	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
+		return fmt.Errorf("set session mode: %w", err)
+	}
+	if err := l.broker.SetFocusMode(l.focusMode); err != nil {
+		return fmt.Errorf("set focus mode: %w", err)
+	}
+	if err := l.broker.Start(); err != nil {
+		return fmt.Errorf("start broker: %w", err)
+	}
+	if err := writeOfficePIDFile(); err != nil {
+		return fmt.Errorf("write office pid: %w", err)
+	}
+
+	// Pre-seed any default skills declared by the pack (idempotent).
+	// Always seed the cross-cutting productivity skills (grill-me, tdd,
+	// diagnose, etc., adapted from github.com/mattpocock/skills) on top of
+	// whatever the active pack defines. They're useful for every install,
+	// not just packs that explicitly enumerate them.
+	if l.pack != nil {
+		l.broker.SeedDefaultSkills(agent.AppendProductivitySkills(l.pack.DefaultSkills))
+	} else {
+		l.broker.SeedDefaultSkills(agent.AppendProductivitySkills(nil))
+	}
+
+	l.broker.SetGenerateMemberFn(l.GenerateMemberTemplateFromPrompt)
+	l.broker.SetGenerateChannelFn(l.GenerateChannelTemplateFromPrompt)
+	if err := l.broker.ServeWebUI(webPort); err != nil {
+		// The broker is already running and the office PID file is on
+		// disk (above). On a port-bind failure we exit, so tear both
+		// down — leaving the broker accepting requests on a "wuphf has
+		// failed to start" path is worse than a clean exit, and a stale
+		// PID file would block the next launch attempt's writeOfficePID.
+		l.broker.Stop()
+		_ = clearOfficePIDFile()
+		return fmt.Errorf("web UI failed to start: %w\n\nIs port %d already in use? Try: wuphf --web-port %d", err, webPort, webPort+1)
+	}
+
+	// Default path: headless `claude --print` per turn. Anthropic re-sanctioned
+	// this invocation (OpenClaw policy note, 2026-04), so it runs on the user's
+	// normal subscription quota — no separate extra-usage quota is charged on
+	// top. The legacy interactive pane-per-agent mode remains reachable via
+	// trySpawnWebAgentPanes as an internal fallback primitive, but is not
+	// invoked at startup.
+
+	// Headless context is used for codex runtime, default dispatch, and
+	// per-turn operations that don't fit a long-lived pane session.
+	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
+	l.resumeInFlightWork()
+
+	// Stream tmux pane output to the web UI's per-agent stream so users see
+	// live Claude TUI activity (thinking, tool calls, responses) during a
+	// pane-backed turn. No-op when paneBackedAgents is false.
+	l.startPaneCaptureLoops(l.headless.ctx)
+
+	go l.notifyAgentsLoop()
+	go l.notifyTaskActionsLoop()
+	go l.notifyOfficeChangesLoop()
+	go l.pollNexNotificationsLoop()
+	go l.watchdogSchedulerLoop()
+	if l.paneBackedAgents {
+		go l.primeVisibleAgents()
+	}
+
+	// Use 127.0.0.1 in both the printed URL and the readiness probe so the
+	// dial target matches what the browser will request. localhost can
+	// resolve to ::1 first on IPv6-preferring setups, while ServeWebUI binds
+	// only to 127.0.0.1 — that mismatch reproduces ERR_CONNECTION_REFUSED
+	// even after the probe succeeds.
+	webAddr := fmt.Sprintf("127.0.0.1:%d", webPort)
+	webURL := fmt.Sprintf("http://%s", webAddr)
+	fmt.Printf("\n  Web UI:  %s\n", webURL)
+	fmt.Printf("  Broker:  %s\n", l.BrokerBaseURL())
+	fmt.Printf("  Press Ctrl+C to stop.\n\n")
+
+	if !l.noOpen {
+		// Wait for the web server to actually accept connections before
+		// triggering the browser. Otherwise users on cold starts (and PH
+		// visitors clicking through `npx wuphf` for the first time) hit
+		// ERR_CONNECTION_REFUSED before the listener is ready. 5s is a
+		// generous ceiling: in practice the listener is up in milliseconds.
+		// Skip the open if the listener never came up — opening a dead URL
+		// just produces a confusing error page in the user's first second.
+		if waitForWebReady(webAddr, 5*time.Second) {
+			openBrowser(webURL)
+		} else {
+			fmt.Printf("  Web UI did not become reachable at %s within 5s; skipping browser auto-open.\n", webURL)
+		}
+	}
+
+	// Broker, web UI, and background goroutines own the process lifetime;
+	// Ctrl+C (default SIGINT) is the only exit path.
+	select {}
+}
+
+// maybeOfferNex offers to wire up Nex for memory/context when nex-cli
+// isn't already installed. Prints an explicit "skipping Nex" line when
+// stdin isn't a TTY (npx, pipes, CI, containers) — fmt.Scanln returns
+// empty in that case, which the prompt would have silently accepted as
+// "yes" and tried to install. Users can rerun `nex setup` later or set
+// WUPHF_NO_NEX=1 to suppress the offer.
+func (l *Launcher) maybeOfferNex() {
+	if config.ResolveNoNex() || nex.IsInstalled() {
+		return
+	}
+	if !stdinIsTTY() {
+		fmt.Println()
+		fmt.Println("  Skipping Nex (no interactive terminal). Run `nex setup` later to add memory.")
+		fmt.Println()
+		return
+	}
+	fmt.Println()
+	fmt.Print("  Connect Nex for memory and context? [Y/n] ")
+	var answer string
+	if _, err := fmt.Scanln(&answer); err != nil {
+		// fmt.Scanln has two distinct error shapes here:
+		//   - io.EOF: stdin was closed underneath us. By the time we
+		//     reach this branch stdinIsTTY() already returned true, so
+		//     EOF means the user explicitly hit Ctrl-D rather than
+		//     answering. Treat as a deliberate skip.
+		//   - any other error (most commonly "unexpected newline" from
+		//     a bare Enter): the prompt label says [Y/n], so capital-Y
+		//     is the visible default. Accept Enter as "yes" so the UX
+		//     contract matches the prompt.
+		if errors.Is(err, io.EOF) {
+			fmt.Println("  Skipping Nex. Agents will work without organizational memory.")
+			fmt.Println()
+			return
+		}
+		answer = ""
+	}
+	answer = strings.TrimSpace(strings.ToLower(answer))
+	if answer != "" && answer != "y" && answer != "yes" {
+		fmt.Println("  Skipping Nex. Agents will work without organizational memory.")
+		fmt.Println()
+		return
+	}
+	fmt.Println()
+	fmt.Println("  Nex CLI not found. Installing...")
+	if _, installErr := setup.InstallLatestCLI(context.Background()); installErr != nil {
+		fmt.Printf("  Could not install: %v\n", installErr)
+		fmt.Println("  Continuing without Nex.")
+	}
+	if nexBin := nex.BinaryPath(); nexBin != "" {
+		cmd := exec.CommandContext(context.Background(), nexBin, "setup")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			fmt.Printf("  Setup did not complete: %v\n", err)
+			fmt.Println("  Continuing without Nex.")
+		} else {
+			fmt.Println("  Nex connected.")
+		}
+	}
+	fmt.Println()
+}
+
+// waitForWebReady polls addr until a TCP dial succeeds or the timeout
+// elapses. It exists because ServeWebUI returns immediately and the
+// listener can take a few hundred ms to come up — opening the browser
+// before then produces ERR_CONNECTION_REFUSED in the user's first
+// second of the product. Returns true when the listener accepted a
+// connection within the timeout, false otherwise. LaunchWeb gates
+// openBrowser on this return value, so a never-up listener results in
+// a printed "skipping browser auto-open" line rather than a dead URL.
+func waitForWebReady(addr string, timeout time.Duration) bool {
+	dialer := &net.Dialer{Timeout: 250 * time.Millisecond}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	for {
+		conn, err := dialer.DialContext(ctx, "tcp", addr)
+		if err == nil {
+			_ = conn.Close()
+			return true
+		}
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+// stdinIsTTY reports whether os.Stdin is connected to a real terminal.
+// Uses golang.org/x/term so /dev/null (a char device but not a TTY) is
+// classified correctly — the original os.ModeCharDevice check let
+// `npx ... </dev/null` fall back to the auto-yes install path, which
+// is the cold-start bug this whole helper exists to prevent.
+func stdinIsTTY() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+func openBrowser(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.CommandContext(context.Background(), "open", url)
+	case "linux":
+		cmd = exec.CommandContext(context.Background(), "xdg-open", url)
+	case "windows":
+		cmd = exec.CommandContext(context.Background(), "cmd", "/c", "start", "", url)
+	default:
+		return
+	}
+	_ = cmd.Start()
+}


### PR DESCRIPTION
## Summary

Stacked on **#432 (C7, headlessWorkerPool)**. Pure file split per
PLAN.md §C8 — no new types, no behaviour changes, just moves functions
out of launcher.go into themed sibling files so the orchestrator file
stops being the catch-all.

## Files moved

### `launcher_web.go` (304 lines, new) — web-mode entry points

| Function | What it does |
|---|---|
| `PreflightWeb` | claude/codex/opencode binary check + onboarding-aware skip |
| `LaunchWeb` | broker + web UI + background goroutines bootstrap (no tmux) |
| `maybeOfferNex` | TTY-gated Nex install/setup prompt |
| `waitForWebReady` | TCP probe before opening the browser |
| `stdinIsTTY` | term.IsTerminal wrapper used by maybeOfferNex |
| `openBrowser` | platform-specific URL open |

This pulls web-only imports (` + "`net`, `golang.org/x/term`, `internal/setup`, `internal/nex`" + `) out of launcher.go's import list.

### ` + "`broker_lifecycle.go`" + ` (148 lines, new) — broker housekeeping

| Function | What it does |
|---|---|
| ` + "`killStaleBroker`" + ` | lsof + kill -9 against the configured broker port |
| ` + "`ResetBrokerState`" + ` | exported: POST /reset to the running broker |
| ` + "`ClearPersistedBrokerState`" + ` | exported: rm the on-disk broker-state file |
| ` + "`officePIDFilePath`" + ` | RuntimeHomeDir() + ` + "`.wuphf/team/office.pid`" + ` |
| ` + "`writeOfficePIDFile`" + ` / ` + "`clearOfficePIDFile`" + ` | PID-file lifecycle |
| ` + "`killPersistedOfficeProcess`" + ` | read PID file, kill, clear |
| ` + "`resetBrokerState`" + ` | unexported HTTP POST /reset implementation |
| ` + "`brokerBaseURL`" + ` / ` + "`(*Launcher).BrokerBaseURL`" + ` | URL accessors |

## Diff shape

| File | Before | After | Δ |
|---|---:|---:|---:|
| ` + "`launcher.go`" + ` | 3431 | 3034 | **−397** |
| ` + "`launcher_web.go`" + ` | — | 304 | +304 |
| ` + "`broker_lifecycle.go`" + ` | — | 148 | +148 |
| **Net** | 3431 | 3486 | +55 (new file headers + import lists) |

**Cumulative since main: 4998 → 3034 lines = −1964 lines (−39.3%).**

Imports removed from launcher.go: ` + "`io`, `net`, `errors`, `strconv`, `golang.org/x/term`, `internal/nex`, `internal/setup`" + `.

## Tests

No new tests — these are existing helpers being moved file-to-file. The same tests that covered them before still cover them now (` + "`broker_state_path_test.go`" + `, ` + "`broker_web_test.go`" + `, the LaunchWeb flow tests). Per-file coverage gates for the existing extracted files (` + "`prompt_builder.go`" + ` etc.) unchanged.

## Local CI matrix (all green)

- ` + "`gofmt -s -l`" + ` clean
- ` + "`golangci-lint run ./internal/team/...`" + ` 0 issues
- ` + "`go vet ./...`" + ` clean
- ` + "`go test -race -timeout 15m ./internal/team`" + ` 86s
- ` + "`bash scripts/test-go.sh`" + ` — **all 32 packages green**
- Cross-compile windows/{amd64,arm64} + darwin/arm64 — clean
- Smoke binary OK (` + "`go build -o /tmp/wuphf ./cmd/wuphf`" + `)

## Why this PR is safe to review fast

Diff is dominated by line-for-line moves: each function appears in
exactly one place before, exactly one place after, with the same body.
The only edits to launcher.go beyond the deletions are (a) two
one-line pointer comments where the moved blocks used to be and (b)
the import list trim. Reviewers can sanity-check by running:

` + "```bash" + `
git diff main -- internal/team/launcher.go internal/team/launcher_web.go internal/team/broker_lifecycle.go | grep -E '^(\\+|-)func ' | sort
` + "```" + `

— each ` + "`+func`" + ` should match a ` + "`-func`" + `.

## Test plan

- [x] ` + "`go build ./...`" + `
- [x] ` + "`bash scripts/test-go.sh`" + ` (all 32 packages green)
- [x] Cross-compile windows{amd64,arm64} + darwin/arm64
- [ ] CI green

## Migration close-out

This PR is **PLAN.md §C8** — the residual cleanup cluster. After it
lands, the remaining decomposition follow-ups are:

- **C5b — pane-lifecycle full extraction**: introduce ` + "`tmuxRunner`" + `
  interface + ` + "`realTmuxRunner`/`fakeTmuxRunner`" + ` and move the
  shell-out methods (` + "`spawnVisibleAgents`, `trySpawnWebAgentPanes`, `watchChannelPaneLoop`, `capturePane*`" + `) onto a ` + "`paneLifecycle`" + ` type. PLAN.md §C5.
- **Wrapper consolidation sweep**: rename ~150+ in-package call sites
  from ` + "`l.officeLeadSlug()` → `l.targets.LeadSlug()`" + ` etc., then delete
  the transitional one-line wrappers introduced across C2–C6. PLAN.md §6.