### PR TITLE
refactor(channelui): hoist message-render leaf helpers

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -2920,17 +2920,6 @@ func formatUsd(cost float64) string {
 	return fmt.Sprintf("$%.2f", cost)
 }
 
-func formatTokenCount(tokens int) string {
-	switch {
-	case tokens >= 1_000_000:
-		return fmt.Sprintf("%.1fM tok", float64(tokens)/1_000_000)
-	case tokens >= 1_000:
-		return fmt.Sprintf("%.1fk tok", float64(tokens)/1_000)
-	default:
-		return fmt.Sprintf("%d tok", tokens)
-	}
-}
-
 func renderUsageStrip(usage channelUsageState, members []channelMember, width int) string {
 	if len(usage.Agents) == 0 || width < 40 {
 		return ""

--- a/cmd/wuphf/channel_render.go
+++ b/cmd/wuphf/channel_render.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -31,53 +30,6 @@ func buildOfficeMessageLines(messages []brokerMessage, expanded map[string]bool,
 	return lines
 }
 
-func renderReactions(reactions []brokerReaction) string {
-	if len(reactions) == 0 {
-		return ""
-	}
-	// Group by emoji: 👍 @ceo @pm
-	groups := make(map[string][]string)
-	order := make([]string, 0)
-	for _, r := range reactions {
-		if _, exists := groups[r.Emoji]; !exists {
-			order = append(order, r.Emoji)
-		}
-		groups[r.Emoji] = append(groups[r.Emoji], r.From)
-	}
-	pillStyle := lipgloss.NewStyle().
-		Background(lipgloss.Color("#2C2D31")).
-		Foreground(lipgloss.Color("#D1D2D3")).
-		Padding(0, 1)
-	var parts []string
-	for _, emoji := range order {
-		agents := groups[emoji]
-		label := emoji + " " + fmt.Sprintf("%d", len(agents))
-		parts = append(parts, pillStyle.Render(label))
-	}
-	return strings.Join(parts, " ")
-}
-
-func messageUsageTotal(usage *brokerMessageUsage) int {
-	if usage == nil {
-		return 0
-	}
-	if usage.TotalTokens > 0 {
-		return usage.TotalTokens
-	}
-	return usage.InputTokens + usage.OutputTokens + usage.CacheReadTokens + usage.CacheCreationTokens
-}
-
-func renderMessageUsageMeta(usage *brokerMessageUsage, accent string) string {
-	total := messageUsageTotal(usage)
-	if total == 0 {
-		return ""
-	}
-	return lipgloss.NewStyle().
-		Foreground(lipgloss.Color(accent)).
-		Bold(true).
-		Render(formatTokenCount(total))
-}
-
 func buildOneOnOneMessageLines(messages []brokerMessage, expanded map[string]bool, contentWidth int, agentName string, unreadAnchorID string, unreadCount int) []renderedLine {
 	if len(messages) == 0 {
 		mutedStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted))
@@ -91,37 +43,6 @@ func buildOneOnOneMessageLines(messages []brokerMessage, expanded map[string]boo
 		}
 	}
 	return buildOfficeMessageLines(messages, expanded, contentWidth, true, unreadAnchorID, unreadCount)
-}
-
-func defaultHumanMessageTitle(kind, from string) string {
-	switch strings.TrimSpace(kind) {
-	case "human_decision":
-		return fmt.Sprintf("%s needs your call", displayName(from))
-	case "human_action":
-		return fmt.Sprintf("%s wants you to do something", displayName(from))
-	default:
-		return fmt.Sprintf("%s has an update for you", displayName(from))
-	}
-}
-
-func sliceRenderedLines(lines []renderedLine, msgH, scroll int) ([]renderedLine, int, int, int) {
-	total := len(lines)
-	scroll = clampScroll(total, msgH, scroll)
-	end := total - scroll
-	if end > total {
-		end = total
-	}
-	if end < 1 && total > 0 {
-		end = 1
-	}
-	start := end - msgH
-	if start < 0 {
-		start = 0
-	}
-	if total == 0 {
-		return nil, scroll, 0, 0
-	}
-	return lines[start:end], scroll, start, end
 }
 
 // reverseAny reverses items in place. Kept in package main (instead of

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -67,6 +67,12 @@
 //     RenderedCardLinesWithPrompt card-to-RenderedLine adapters, and
 //     NormalizeSidebarSlug (used to canonicalize channel slugs for
 //     equality).
+//   - messages_render.go   — leaf message-render helpers:
+//     RenderReactions (emoji pill row), MessageUsageTotal /
+//     RenderMessageUsageMeta (token-usage strip on assistant
+//     messages), DefaultHumanMessageTitle (fallback titles for
+//     human_* kinds), SliceRenderedLines (viewport windowing) and
+//     FormatTokenCount (compact "1.2M tok" formatter).
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/messages_render.go
+++ b/cmd/wuphf/channelui/messages_render.go
@@ -1,0 +1,120 @@
+package channelui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// RenderReactions renders a message's reactions as a row of muted
+// pills, one per emoji, showing the count of reactors. Returns "" for
+// empty input. Insertion order of distinct emojis is preserved so
+// reactions don't reorder on every redraw.
+func RenderReactions(reactions []BrokerReaction) string {
+	if len(reactions) == 0 {
+		return ""
+	}
+	groups := make(map[string][]string)
+	order := make([]string, 0)
+	for _, r := range reactions {
+		if _, exists := groups[r.Emoji]; !exists {
+			order = append(order, r.Emoji)
+		}
+		groups[r.Emoji] = append(groups[r.Emoji], r.From)
+	}
+	pillStyle := lipgloss.NewStyle().
+		Background(lipgloss.Color("#2C2D31")).
+		Foreground(lipgloss.Color("#D1D2D3")).
+		Padding(0, 1)
+	var parts []string
+	for _, emoji := range order {
+		agents := groups[emoji]
+		label := emoji + " " + fmt.Sprintf("%d", len(agents))
+		parts = append(parts, pillStyle.Render(label))
+	}
+	return strings.Join(parts, " ")
+}
+
+// MessageUsageTotal returns the total tokens spent on a message,
+// preferring TotalTokens when set and falling back to the sum of the
+// individual buckets (input + output + cache reads + cache creation).
+// Returns 0 for nil usage.
+func MessageUsageTotal(usage *BrokerMessageUsage) int {
+	if usage == nil {
+		return 0
+	}
+	if usage.TotalTokens > 0 {
+		return usage.TotalTokens
+	}
+	return usage.InputTokens + usage.OutputTokens + usage.CacheReadTokens + usage.CacheCreationTokens
+}
+
+// RenderMessageUsageMeta returns a bold accent-colored token-count
+// label suitable for inclusion in a message's meta strip. Returns ""
+// when the usage total is zero.
+func RenderMessageUsageMeta(usage *BrokerMessageUsage, accent string) string {
+	total := MessageUsageTotal(usage)
+	if total == 0 {
+		return ""
+	}
+	return lipgloss.NewStyle().
+		Foreground(lipgloss.Color(accent)).
+		Bold(true).
+		Render(FormatTokenCount(total))
+}
+
+// DefaultHumanMessageTitle returns a fallback title used when a
+// human_* message arrives without a Title set. The phrasing depends
+// on the kind: human_decision → "<from> needs your call",
+// human_action → "<from> wants you to do something", anything else →
+// "<from> has an update for you".
+func DefaultHumanMessageTitle(kind, from string) string {
+	switch strings.TrimSpace(kind) {
+	case "human_decision":
+		return fmt.Sprintf("%s needs your call", DisplayName(from))
+	case "human_action":
+		return fmt.Sprintf("%s wants you to do something", DisplayName(from))
+	default:
+		return fmt.Sprintf("%s has an update for you", DisplayName(from))
+	}
+}
+
+// SliceRenderedLines returns a windowed view of lines for a viewport
+// of height msgH at scroll offset scroll. The returned start and end
+// indices satisfy start <= end <= len(lines), and the returned scroll
+// is clamped to the valid range. The scroll value treats 0 as
+// "pinned to bottom"; positive values scroll back through history.
+func SliceRenderedLines(lines []RenderedLine, msgH, scroll int) ([]RenderedLine, int, int, int) {
+	total := len(lines)
+	scroll = ClampScroll(total, msgH, scroll)
+	end := total - scroll
+	if end > total {
+		end = total
+	}
+	if end < 1 && total > 0 {
+		end = 1
+	}
+	start := end - msgH
+	if start < 0 {
+		start = 0
+	}
+	if total == 0 {
+		return nil, scroll, 0, 0
+	}
+	return lines[start:end], scroll, start, end
+}
+
+// FormatTokenCount renders a token count as a compact label —
+// "1.2M tok" / "5.0k tok" / "42 tok" — suitable for status lines
+// where space is tight.
+func FormatTokenCount(tokens int) string {
+	switch {
+	case tokens >= 1_000_000:
+		return fmt.Sprintf("%.1fM tok", float64(tokens)/1_000_000)
+	case tokens >= 1_000:
+		return fmt.Sprintf("%.1fk tok", float64(tokens)/1_000)
+	default:
+		return fmt.Sprintf("%d tok", tokens)
+	}
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -125,6 +125,13 @@ var (
 	renderCalendarActionCard      = channelui.RenderCalendarActionCard
 	renderedCardLines             = channelui.RenderedCardLines
 	renderedCardLinesWithPrompt   = channelui.RenderedCardLinesWithPrompt
+
+	renderReactions          = channelui.RenderReactions
+	messageUsageTotal        = channelui.MessageUsageTotal
+	renderMessageUsageMeta   = channelui.RenderMessageUsageMeta
+	defaultHumanMessageTitle = channelui.DefaultHumanMessageTitle
+	sliceRenderedLines       = channelui.SliceRenderedLines
+	formatTokenCount         = channelui.FormatTokenCount
 )
 
 // Calendar-range typed-string consts.


### PR DESCRIPTION
## Summary

Hoists the leaf message-render helpers off `channel_render.go` (and `formatTokenCount` off `channel.go`) into `channelui/messages_render.go`. Stacks on top of #440.

Moved (now exported in channelui):
- `RenderReactions` — emoji pill row, preserves first-seen order
- `MessageUsageTotal` — sum-or-fallback total of token usage
- `RenderMessageUsageMeta` — accent-colored token-count meta string
- `DefaultHumanMessageTitle` — fallback titles for `human_decision` / `human_action` / generic kinds
- `SliceRenderedLines` — viewport windowing (start/end/scroll)
- `FormatTokenCount` — compact `"1.2M tok"` / `"5.0k tok"` / `"42 tok"` formatter

The thicker message-rendering functions (`buildOfficeMessageLines`, `buildOneOnOneMessageLines`, `officeThreadedMessages`, `renderOfficeMessageBlock`) stay in package main for now — they cross-call too many helpers (`highlightMentions`, `inferMood`, `cachedThreadedMessages`, `pluralizeWord`, agent-color participant resolution) that are not in channelui yet, so moving them would balloon the diff.

Aliases preserve the lowercase names so existing callers — including the model-helpers tests that exercise `formatTokenCount` — keep compiling unchanged.

## Test plan

- [x] \`go build ./cmd/wuphf\`
- [x] \`go vet ./...\`
- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`golangci-lint run ./cmd/wuphf/...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)