### PR TITLE
refactor(team): introduce tmuxRunner + paneLifecycle, migrate read methods (C5b)

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -137,6 +137,15 @@ type Launcher struct {
 	// closure consults the package-global launcherSendNotificationToPaneOverride
 	// seam on every call so existing tests keep working unchanged.
 	dispatcher *paneDispatcher
+
+	// paneLC owns the tmux pane lifecycle (PLAN.md §C5b). Lazily
+	// constructed via panes(); the runner is resolved through the
+	// tmuxRunnerOverride seam at construction time so tests injecting a
+	// fakeTmuxRunner before Launch get their fake transparently. Today
+	// the type covers read-only methods (HasLiveSession, ListTeamPanes,
+	// ChannelPaneStatus, capture*); the spawn/clear methods migrate in
+	// follow-up PRs.
+	paneLC *paneLifecycle
 }
 
 // headlessWorkerPool groups the per-launcher headless-dispatch state
@@ -1255,15 +1264,7 @@ func (l *Launcher) watchChannelPaneLoop(channelCmd string) {
 }
 
 func (l *Launcher) channelPaneStatus() (string, error) {
-	out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "display-message",
-		"-p",
-		"-t", l.sessionName+":team.0",
-		"#{pane_dead} #{pane_dead_status} #{pane_current_command}",
-	).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("%s", strings.TrimSpace(string(out)))
-	}
-	return strings.TrimSpace(string(out)), nil
+	return l.panes().ChannelPaneStatus()
 }
 
 func (l *Launcher) captureDeadChannelPane(status string) error {
@@ -1988,6 +1989,26 @@ func (l *Launcher) paneDispatch() *paneDispatcher {
 	return l.dispatcher
 }
 
+// panes returns the per-launcher paneLifecycle (PLAN.md §C5b), lazily
+// constructing it on first access. A nil receiver returns a default
+// paneLifecycle bound to the package-level SessionName so the
+// HasLiveTmuxSession free function can route through the same path
+// without a Launcher.
+func (l *Launcher) panes() *paneLifecycle {
+	if l == nil {
+		return newPaneLifecycle(SessionName)
+	}
+	if l.paneLC != nil {
+		return l.paneLC
+	}
+	name := l.sessionName
+	if name == "" {
+		name = SessionName
+	}
+	l.paneLC = newPaneLifecycle(name)
+	return l.paneLC
+}
+
 // queuePaneNotification is a thin wrapper around paneDispatcher.Enqueue
 // (PLAN.md §C6). Kept as a Launcher method so existing call sites and
 // the pane_dispatch_queue_test.go safety net don't need a rename sweep
@@ -2042,20 +2063,17 @@ func (l *Launcher) sendNotificationToPane(paneTarget, notification string) {
 	).Run()
 }
 
+// capturePaneTargetContent / capturePaneContent / listTeamPanes /
+// channelPaneStatus delegate to paneLifecycle (PLAN.md §C5b). Thin
+// wrappers keep current callers (broker_handlers, watchdog,
+// captureDeadChannelPane, clearAgentPanes) working without a rename
+// sweep in this PR.
 func (l *Launcher) capturePaneTargetContent(target string) (string, error) {
-	out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "capture-pane",
-		"-p", "-J",
-		"-t", target,
-	).CombinedOutput()
-	if err != nil {
-		return "", err
-	}
-	return string(out), nil
+	return l.panes().CapturePaneTargetContent(target)
 }
 
 func (l *Launcher) capturePaneContent(paneIdx int) (string, error) {
-	target := fmt.Sprintf("%s:team.%d", l.sessionName, paneIdx)
-	return l.capturePaneTargetContent(target)
+	return l.panes().CapturePaneContent(paneIdx)
 }
 
 func (l *Launcher) clearAgentPanes() error {
@@ -2094,24 +2112,14 @@ func (l *Launcher) clearOverflowAgentWindows() {
 }
 
 func (l *Launcher) listTeamPanes() ([]int, error) {
-	out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "list-panes",
-		"-t", l.sessionName+":team",
-		"-F", "#{pane_index} #{pane_title}",
-	).CombinedOutput()
-	if err != nil {
-		// If the session isn't up, there's nothing to clear.
-		if isMissingTmuxSession(string(out)) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("list panes: %w", err)
-	}
-	return parseAgentPaneIndices(string(out)), nil
+	return l.panes().ListTeamPanes()
 }
 
-// HasLiveTmuxSession returns true if a wuphf-team tmux session is running.
+// HasLiveTmuxSession returns true if a wuphf-team tmux session is
+// running. Routes through paneLifecycle (PLAN.md §C5b) so tests can
+// drive it via setTmuxRunnerForTest without a real tmux server.
 func HasLiveTmuxSession() bool {
-	err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "has-session", "-t", SessionName).Run()
-	return err == nil
+	return newPaneLifecycle(SessionName).HasLiveSession()
 }
 
 func (l *Launcher) spawnVisibleAgents() ([]string, error) {

--- a/internal/team/pane_lifecycle.go
+++ b/internal/team/pane_lifecycle.go
@@ -1,12 +1,13 @@
 package team
 
-// pane_lifecycle.go owns pure pane-lifecycle helpers extracted from
-// launcher.go (PLAN.md §C5, partial). The shell-out methods (spawn*,
-// trySpawnWebAgentPanes, watchChannelPaneLoop, capturePaneContent, etc.)
-// stay on Launcher pending the tmuxRunner interface — that follow-up
-// extraction (C5b) introduces a fakeable runner so those methods become
-// testable too. Today's file is a "header split" for the helpers that
-// don't shell out and can already be exercised in tests.
+// pane_lifecycle.go owns the pane-lifecycle helpers extracted from
+// launcher.go (PLAN.md §C5). The first wave (C5a) was the pure helpers
+// (parseAgentPaneIndices, shouldPrimeClaudePane, etc.). The second wave
+// (C5b) adds the paneLifecycle type and migrates the read-only tmux
+// methods (HasLiveSession, ListTeamPanes, ChannelPaneStatus, capture*)
+// onto it through the tmuxRunner seam (tmux_runner.go). Spawn/clear/
+// respawn methods stay on Launcher pending follow-up PRs that migrate
+// them onto the same type.
 
 import (
 	"fmt"
@@ -16,6 +17,90 @@ import (
 
 	"github.com/nex-crm/wuphf/internal/config"
 )
+
+// paneLifecycle owns the tmux pane lifecycle (PLAN.md §C5). The runner
+// field is the test seam — production gets realTmuxRunner via
+// newTmuxRunner; tests inject a fakeTmuxRunner via setTmuxRunnerForTest.
+// The type is intentionally tiny in this PR (sessionName + runner) and
+// grows as the spawn/clear methods migrate over.
+type paneLifecycle struct {
+	runner      tmuxRunner
+	sessionName string
+}
+
+// newPaneLifecycle constructs a paneLifecycle bound to a specific tmux
+// session name. The runner is resolved through the package-global
+// override seam at construction time, so a test that calls
+// setTmuxRunnerForTest before constructing the launcher gets its fake
+// runner installed transparently.
+func newPaneLifecycle(sessionName string) *paneLifecycle {
+	return &paneLifecycle{
+		runner:      newTmuxRunner(),
+		sessionName: sessionName,
+	}
+}
+
+// HasLiveSession returns true when a wuphf-team tmux session is running.
+// Mirrors the historical free-function HasLiveTmuxSession but routes
+// through the runner so tests can drive it without a real tmux server.
+func (p *paneLifecycle) HasLiveSession() bool {
+	return p.runner.Run("has-session", "-t", p.sessionName) == nil
+}
+
+// CapturePaneTargetContent captures the visible content of an arbitrary
+// tmux pane target (e.g. "wuphf-team:team.0") with capture-pane's -p -J
+// flags. Returns the raw stdout (no trim) so callers can render the
+// captured pane verbatim into snapshot logs.
+func (p *paneLifecycle) CapturePaneTargetContent(target string) (string, error) {
+	out, err := p.runner.Combined("capture-pane", "-p", "-J", "-t", target)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// CapturePaneContent captures the visible content of pane <paneIdx> in
+// the "team" window. Convenience wrapper around CapturePaneTargetContent.
+func (p *paneLifecycle) CapturePaneContent(paneIdx int) (string, error) {
+	target := fmt.Sprintf("%s:team.%d", p.sessionName, paneIdx)
+	return p.CapturePaneTargetContent(target)
+}
+
+// ListTeamPanes returns the agent-pane indices in the "team" window.
+// Pane 0 (the channel observer) and any pane whose title contains
+// "channel" are filtered out by parseAgentPaneIndices. When the session
+// isn't up, returns (nil, nil) — callers treat that as "nothing to
+// clean up" rather than an error.
+func (p *paneLifecycle) ListTeamPanes() ([]int, error) {
+	out, err := p.runner.Combined("list-panes",
+		"-t", p.sessionName+":team",
+		"-F", "#{pane_index} #{pane_title}",
+	)
+	if err != nil {
+		if isMissingTmuxSession(string(out)) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("list panes: %w", err)
+	}
+	return parseAgentPaneIndices(string(out)), nil
+}
+
+// ChannelPaneStatus returns the tmux display-message status for pane 0
+// in the "team" window: "{pane_dead} {pane_dead_status}
+// {pane_current_command}". Used by the channel-pane watcher to decide
+// whether to respawn. tmux failures surface as the trimmed stderr text
+// in the returned error — callers match that text via isNoSessionError.
+func (p *paneLifecycle) ChannelPaneStatus() (string, error) {
+	out, err := p.runner.Combined("display-message",
+		"-p",
+		"-t", p.sessionName+":team.0",
+		"#{pane_dead} #{pane_dead_status} #{pane_current_command}",
+	)
+	if err != nil {
+		return "", fmt.Errorf("%s", strings.TrimSpace(string(out)))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
 
 // channelPaneNeedsRespawn parses a tmux display-message status string of
 // the form "{exit-status} {pane-pid}" and returns true when the pane has

--- a/internal/team/tmux_runner.go
+++ b/internal/team/tmux_runner.go
@@ -1,0 +1,91 @@
+package team
+
+// tmux_runner.go owns the tmux command seam (PLAN.md §3) used by
+// paneLifecycle and (in a follow-up) paneDispatcher to invoke the local
+// tmux binary. The interface is narrow on purpose — three call shapes
+// (fire-and-forget, stdout-only, combined-stdout-and-stderr) cover every
+// existing caller in launcher.go without copying flags around. Production
+// uses realTmuxRunner, which hardcodes the `-L tmuxSocketName` prefix and
+// exec.CommandContext(context.Background()) so callers don't have to.
+//
+// The override pattern follows the existing
+// launcherSendNotificationToPaneOverride seam: an atomic.Pointer that
+// tests load through setTmuxRunnerForTest. Production never touches it,
+// so the read on the hot path is a single nil check.
+
+import (
+	"context"
+	"os/exec"
+	"sync/atomic"
+	"testing"
+)
+
+// tmuxRunner is the seam for invoking the local tmux binary. Every method
+// receives the post-`-L socketname` arguments — the runner is responsible
+// for prepending the socket prefix.
+type tmuxRunner interface {
+	// Run invokes tmux fire-and-forget; the return value is the exec error
+	// (nil on success). Stdout/stderr are discarded.
+	Run(args ...string) error
+	// Output captures stdout only; stderr is discarded. Mirrors
+	// exec.Cmd.Output's contract.
+	Output(args ...string) ([]byte, error)
+	// Combined captures stdout and stderr together. Mirrors
+	// exec.Cmd.CombinedOutput's contract — used by callers that surface
+	// tmux error text from stderr in their own error messages.
+	Combined(args ...string) ([]byte, error)
+}
+
+// realTmuxRunner is the production implementation. It prepends
+// `-L tmuxSocketName` to every invocation and uses
+// exec.CommandContext(context.Background()) — matching what every
+// existing call site in launcher.go did before extraction.
+type realTmuxRunner struct{}
+
+func (realTmuxRunner) cmd(args ...string) *exec.Cmd {
+	full := make([]string, 0, len(args)+2)
+	full = append(full, "-L", tmuxSocketName)
+	full = append(full, args...)
+	return exec.CommandContext(context.Background(), "tmux", full...)
+}
+
+func (r realTmuxRunner) Run(args ...string) error {
+	return r.cmd(args...).Run()
+}
+
+func (r realTmuxRunner) Output(args ...string) ([]byte, error) {
+	return r.cmd(args...).Output()
+}
+
+func (r realTmuxRunner) Combined(args ...string) ([]byte, error) {
+	return r.cmd(args...).CombinedOutput()
+}
+
+// tmuxRunnerOverride is the test seam. Production code never writes to
+// it; tests install a fake via setTmuxRunnerForTest and rely on
+// t.Cleanup to restore the prior value. The pointer-of-pointer dance
+// matches the existing launcherSendNotificationToPaneOverride pattern
+// (PLAN.md §3) so the existing test conventions transfer wholesale.
+var tmuxRunnerOverride atomic.Pointer[tmuxRunner]
+
+// newTmuxRunner returns the override if one is installed, otherwise the
+// production realTmuxRunner. Called from constructors at type-creation
+// time, not on the hot path.
+func newTmuxRunner() tmuxRunner {
+	if p := tmuxRunnerOverride.Load(); p != nil {
+		return *p
+	}
+	return realTmuxRunner{}
+}
+
+// setTmuxRunnerForTest installs r as the package-level tmux runner for
+// the duration of the test, restoring the prior value via t.Cleanup. As
+// with every other *Override seam in this package: do not combine with
+// t.Parallel() — the override is package-global. PLAN.md §5 trap 8
+// covers the rationale for keeping it global rather than per-Launcher.
+func setTmuxRunnerForTest(t *testing.T, r tmuxRunner) {
+	t.Helper()
+	prior := tmuxRunnerOverride.Load()
+	tmuxRunnerOverride.Store(&r)
+	t.Cleanup(func() { tmuxRunnerOverride.Store(prior) })
+}

--- a/internal/team/tmux_runner_test.go
+++ b/internal/team/tmux_runner_test.go
@@ -1,0 +1,252 @@
+package team
+
+// fakeTmuxRunner + fakeTmuxCall are the reusable test double for the
+// tmuxRunner interface (PLAN.md §C5b / §3). Tests prepare canned output
+// + canned errors keyed by tmux subcommand (the first argument:
+// "list-panes", "has-session", "capture-pane", etc.), install the fake
+// via setTmuxRunnerForTest, and assert on f.callsFor("…") afterwards
+// to verify the exact args that flowed through.
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type fakeTmuxCall struct {
+	Method string   // "Run", "Output", or "Combined"
+	Args   []string // exactly the args the caller passed (no socket prefix)
+}
+
+func (c fakeTmuxCall) String() string {
+	return fmt.Sprintf("%s %s", c.Method, strings.Join(c.Args, " "))
+}
+
+type fakeTmuxRunner struct {
+	mu      sync.Mutex
+	calls   []fakeTmuxCall
+	outputs map[string][]byte
+	errors  map[string]error
+}
+
+func newFakeTmuxRunner() *fakeTmuxRunner {
+	return &fakeTmuxRunner{
+		outputs: map[string][]byte{},
+		errors:  map[string]error{},
+	}
+}
+
+func (f *fakeTmuxRunner) record(method string, args []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := make([]string, len(args))
+	copy(cp, args)
+	f.calls = append(f.calls, fakeTmuxCall{Method: method, Args: cp})
+}
+
+func (f *fakeTmuxRunner) lookup(args []string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(args) == 0 {
+		return nil, nil
+	}
+	sub := args[0]
+	return f.outputs[sub], f.errors[sub]
+}
+
+func (f *fakeTmuxRunner) Run(args ...string) error {
+	f.record("Run", args)
+	_, err := f.lookup(args)
+	return err
+}
+
+func (f *fakeTmuxRunner) Output(args ...string) ([]byte, error) {
+	f.record("Output", args)
+	return f.lookup(args)
+}
+
+func (f *fakeTmuxRunner) Combined(args ...string) ([]byte, error) {
+	f.record("Combined", args)
+	return f.lookup(args)
+}
+
+// callsFor returns args of every call whose first argument equals subcmd.
+func (f *fakeTmuxRunner) callsFor(subcmd string) [][]string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var matches [][]string
+	for _, c := range f.calls {
+		if len(c.Args) > 0 && c.Args[0] == subcmd {
+			cp := make([]string, len(c.Args))
+			copy(cp, c.Args)
+			matches = append(matches, cp)
+		}
+	}
+	return matches
+}
+
+func TestRealTmuxRunnerPrependsSocket(t *testing.T) {
+	// realTmuxRunner.cmd is package-internal, so we can't observe its
+	// args without exec'ing tmux for real. Cross-check via the override
+	// seam instead: install a fake, ask the production newTmuxRunner to
+	// give us back the active runner, and confirm we got the fake (not
+	// realTmuxRunner). This is the load-bearing contract that lets every
+	// other test in this file work.
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+	got := newTmuxRunner()
+	if got != fake {
+		t.Fatalf("newTmuxRunner returned %T, want fakeTmuxRunner", got)
+	}
+}
+
+func TestPaneLifecycle_HasLiveSession(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+	pl := newPaneLifecycle("wuphf-team")
+
+	// Default: no canned error -> Run returns nil -> session "is live".
+	if !pl.HasLiveSession() {
+		t.Fatalf("HasLiveSession on default fake = false, want true")
+	}
+
+	// Now make has-session error. The runner returns the canned error
+	// from Run, which the wrapper maps to "no session".
+	fake.errors["has-session"] = fmt.Errorf("can't find session")
+	if pl.HasLiveSession() {
+		t.Fatalf("HasLiveSession with canned error = true, want false")
+	}
+
+	calls := fake.callsFor("has-session")
+	if len(calls) != 2 {
+		t.Fatalf("has-session calls = %d, want 2", len(calls))
+	}
+	want := []string{"has-session", "-t", "wuphf-team"}
+	for i, got := range calls {
+		if !equalStrings(got, want) {
+			t.Errorf("has-session call[%d] = %v, want %v", i, got, want)
+		}
+	}
+}
+
+func TestPaneLifecycle_ListTeamPanesParsesOutput(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["list-panes"] = []byte("0 channel\n1 ceo\n2 fe\n")
+	setTmuxRunnerForTest(t, fake)
+
+	got, err := newPaneLifecycle("wuphf-team").ListTeamPanes()
+	if err != nil {
+		t.Fatalf("ListTeamPanes err = %v, want nil", err)
+	}
+	want := []int{1, 2}
+	if !equalInts(got, want) {
+		t.Fatalf("ListTeamPanes = %v, want %v", got, want)
+	}
+	calls := fake.callsFor("list-panes")
+	if len(calls) != 1 {
+		t.Fatalf("list-panes calls = %d, want 1", len(calls))
+	}
+	wantArgs := []string{"list-panes", "-t", "wuphf-team:team", "-F", "#{pane_index} #{pane_title}"}
+	if !equalStrings(calls[0], wantArgs) {
+		t.Errorf("list-panes args = %v, want %v", calls[0], wantArgs)
+	}
+}
+
+func TestPaneLifecycle_ListTeamPanesMissingSessionIsNilNil(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	// tmux's "no server" error text is what isMissingTmuxSession matches —
+	// the runner returns the canned bytes as the *output*, not as the
+	// error, because the historical CombinedOutput contract puts stderr
+	// there. We must populate both: outputs (string) for matching and
+	// errors (any non-nil) for the err branch.
+	fake.outputs["list-panes"] = []byte("no server running on /tmp/tmux-1000/wuphf")
+	fake.errors["list-panes"] = fmt.Errorf("exit status 1")
+	setTmuxRunnerForTest(t, fake)
+
+	got, err := newPaneLifecycle("wuphf-team").ListTeamPanes()
+	if err != nil {
+		t.Fatalf("ListTeamPanes(missing session) err = %v, want nil", err)
+	}
+	if got != nil {
+		t.Fatalf("ListTeamPanes(missing session) = %v, want nil", got)
+	}
+}
+
+func TestPaneLifecycle_ChannelPaneStatusTrimsOutput(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["display-message"] = []byte("  1 0 claude  \n")
+	setTmuxRunnerForTest(t, fake)
+
+	got, err := newPaneLifecycle("wuphf-team").ChannelPaneStatus()
+	if err != nil {
+		t.Fatalf("ChannelPaneStatus err = %v", err)
+	}
+	if got != "1 0 claude" {
+		t.Fatalf("ChannelPaneStatus = %q, want %q", got, "1 0 claude")
+	}
+}
+
+func TestPaneLifecycle_CapturePaneContentBuildsTarget(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["capture-pane"] = []byte("agent ready\n")
+	setTmuxRunnerForTest(t, fake)
+
+	got, err := newPaneLifecycle("wuphf-team").CapturePaneContent(2)
+	if err != nil {
+		t.Fatalf("CapturePaneContent err = %v", err)
+	}
+	if got != "agent ready\n" {
+		t.Fatalf("CapturePaneContent = %q, want %q", got, "agent ready\n")
+	}
+	calls := fake.callsFor("capture-pane")
+	if len(calls) != 1 {
+		t.Fatalf("capture-pane calls = %d, want 1", len(calls))
+	}
+	wantArgs := []string{"capture-pane", "-p", "-J", "-t", "wuphf-team:team.2"}
+	if !equalStrings(calls[0], wantArgs) {
+		t.Errorf("capture-pane args = %v, want %v", calls[0], wantArgs)
+	}
+}
+
+func TestHasLiveTmuxSessionRoutesThroughRunner(t *testing.T) {
+	// Verify the package-level free function HasLiveTmuxSession() also
+	// goes through the runner seam — the post-C5b implementation routes
+	// through newPaneLifecycle(SessionName).HasLiveSession().
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+	if !HasLiveTmuxSession() {
+		t.Fatalf("HasLiveTmuxSession on default fake = false, want true")
+	}
+	calls := fake.callsFor("has-session")
+	if len(calls) != 1 {
+		t.Fatalf("has-session calls = %d, want 1", len(calls))
+	}
+	if calls[0][0] != "has-session" || calls[0][1] != "-t" {
+		t.Errorf("unexpected call args: %v", calls[0])
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalInts(a, b []int) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

Stacked on **#439 (C8, file split)**. Foundational PR for PLAN.md §C5b:
introduces the ` + "`tmuxRunner`" + ` test seam and the ` + "`paneLifecycle`" + ` owner type,
then migrates the simplest cohort (read/inspect tmux methods) onto it.
The bigger spawn/clear/respawn cluster migrates in a stacked follow-up
so the diff stays reviewable and the seam can soak in CI before the
larger move.

## What lands here

### ` + "`tmux_runner.go`" + ` (89 lines, new)

` + "```go" + `
type tmuxRunner interface {
    Run(args ...string) error               // fire-and-forget
    Output(args ...string) ([]byte, error)  // stdout only
    Combined(args ...string) ([]byte, error)// stdout + stderr
}
` + "```" + `

* ` + "`realTmuxRunner`" + ` production impl prepends ` + "`-L tmuxSocketName`" + ` to every
  call so callers never repeat it.
* ` + "`tmuxRunnerOverride atomic.Pointer[tmuxRunner]`" + ` test seam +
  ` + "`setTmuxRunnerForTest`" + ` helper, mirroring the existing
  ` + "`launcherSendNotificationToPaneOverride`" + ` pattern (PLAN.md §3 / trap §8).

### ` + "`tmux_runner_test.go`" + ` (~210 lines, new)

* ` + "`fakeTmuxRunner`" + ` records every call (method + args), returns canned
  ` + "`outputs`/`errors`" + ` keyed by tmux subcommand. Reusable across
  paneLifecycle tests today and (in a follow-up) paneDispatcher tests.
* **6 unit tests**: HasLiveSession, ListTeamPanes (parsed + missing-
  session branches), ChannelPaneStatus, CapturePaneContent, the override
  seam, and the package-level HasLiveTmuxSession entry point. Zero
  ` + "`time.Sleep`" + `.

### Methods migrated to paneLifecycle

| Before (launcher.go) | After (pane_lifecycle.go) |
|---|---|
| ` + "`HasLiveTmuxSession()`" + ` | ` + "`(*paneLifecycle).HasLiveSession()`" + ` |
| ` + "`(*Launcher).capturePaneTargetContent`" + ` | ` + "`(*paneLifecycle).CapturePaneTargetContent`" + ` |
| ` + "`(*Launcher).capturePaneContent`" + ` | ` + "`(*paneLifecycle).CapturePaneContent`" + ` |
| ` + "`(*Launcher).listTeamPanes`" + ` | ` + "`(*paneLifecycle).ListTeamPanes`" + ` |
| ` + "`(*Launcher).channelPaneStatus`" + ` | ` + "`(*paneLifecycle).ChannelPaneStatus`" + ` |

Old launcher methods are now one-line wrappers — call sites stay
unchanged this PR (matches the C2-C7 pattern).

### Type design

` + "`paneLifecycle`" + ` is intentionally tiny in this PR: ` + "`sessionName`" + ` +
` + "`runner`" + `. It grows as spawn/clear migrate. Lazy construction via
` + "`Launcher.panes()`" + ` keeps ` + "`&Launcher{}`" + ` test fixtures nil-safe; the
nil-receiver path returns a default lifecycle bound to the package-
level ` + "`SessionName`" + ` so the free function ` + "`HasLiveTmuxSession()`" + ` routes
through the same code path without needing a Launcher.

## Coverage

| File | Coverage of new code |
|---|---|
| ` + "`pane_lifecycle.go`" + ` (migrated methods) | 75-100% per func |
| ` + "`tmux_runner.go`" + ` realTmuxRunner.{Run,Output,Combined,cmd} | 0% (by design) |
| ` + "`tmux_runner.go`" + ` newTmuxRunner / setTmuxRunnerForTest | 67% / 100% |

The realTmuxRunner methods are 0% on purpose: they shell out to the real
tmux binary and are bypassed in tests via the override seam (the whole
point of introducing the seam). Production code calls them; integration
tests + manual launches are their coverage. Adding them to the
per-file coverage gate would either require spawning real tmux from
unit tests (brittle) or carving out an exception — neither is worth it.

Package ` + "`internal/team`" + `: 63.8% → 63.9%.

## Diff shape

| File | Δ |
|---|---:|
| ` + "`launcher.go`" + ` | 3034 → 3023 (−11) |
| ` + "`pane_lifecycle.go`" + ` | +99 |
| ` + "`tmux_runner.go`" + ` | +89 (new) |
| ` + "`tmux_runner_test.go`" + ` | +210 (new) |

**Cumulative since main: 4998 → 3023 = −1975 lines (−39.5%).**

## Local CI matrix (all green)

* ` + "`gofmt -s -l`" + ` clean
* ` + "`golangci-lint run ./internal/team/...`" + ` 0 issues
* ` + "`go test -race -timeout 15m ./internal/team`" + ` 86s
* ` + "`bash scripts/test-go.sh`" + ` — **all 32 packages green**
* Cross-compile windows-amd64 + darwin-arm64 — clean
* Smoke binary OK

## Test plan

- [x] ` + "`go build ./...`" + `
- [x] All 6 new tests pass
- [x] Existing tests still green
- [x] ` + "`bash scripts/test-go.sh`" + ` (all 32 packages green)
- [ ] CI green

## What's next

Two more PRs land the rest of PLAN.md §C5:

1. **C5c — migrate the write-side tmux methods**: ` + "`clearAgentPanes`" + `,
   ` + "`clearOverflowAgentWindows`" + `, ` + "`captureDeadChannelPane`" + `,
   ` + "`watchChannelPaneLoop`" + `, ` + "`reconfigureVisibleAgents`" + `,
   ` + "`respawnPanesAfterReseed`" + ` onto ` + "`paneLifecycle`" + `. These are mechanical
   moves modulo replacing ` + "`exec.CommandContext(...).Run()`" + ` with
   ` + "`p.runner.Run(...)`" + `.
2. **C5d — migrate the spawn cluster**: ` + "`spawnVisibleAgents`" + `,
   ` + "`spawnOverflowAgents`" + `, ` + "`detectDeadPanesAfterSpawn`" + `,
   ` + "`recordPaneSpawnFailure`" + `, ` + "`trySpawnWebAgentPanes`" + `,
   ` + "`primeVisibleAgents`" + `, ` + "`reportPaneFallback`" + `. These methods need
   the ` + "`failedPaneSlugs`" + ` map + ` + "`paneBackedFlag`" + ` access patterns
   from PLAN.md §C5 / trap §1, so they get a proper review pass on
   ownership and the targeter cross-references.

Wrapper consolidation (PLAN.md §6: rename ~150 in-package call sites,
delete transitional wrappers) lands as a separate sweep PR after the
last C5 cluster.