### PR TITLE
refactor(channelui): hoist cache leaf helpers

### DIFF
--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -172,13 +172,6 @@ func (m channelModel) hashMainLinesState(contentWidth int) uint64 {
 	return h.sum()
 }
 
-func renderTimeBucket(activeApp officeApp, direct bool) int64 {
-	if direct || activeApp == officeAppMessages {
-		return time.Now().Unix()
-	}
-	return time.Now().Unix() / 30
-}
-
 func hashSidebarState(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, workspace workspaceUIState, width, height int) uint64 {
 	h := newStateHasher()
 	h.add("sidebar")
@@ -213,24 +206,6 @@ func hashSidebarState(channels []channelInfo, members []channelMember, tasks []c
 	h.addMembers(members)
 	h.addTasks(tasks)
 	return h.sum()
-}
-
-func cloneRenderedLines(lines []renderedLine) []renderedLine {
-	if len(lines) == 0 {
-		return nil
-	}
-	out := make([]renderedLine, len(lines))
-	copy(out, lines)
-	return out
-}
-
-func cloneThreadedMessages(items []threadedMessage) []threadedMessage {
-	if len(items) == 0 {
-		return nil
-	}
-	out := make([]threadedMessage, len(items))
-	copy(out, items)
-	return out
 }
 
 func (c *channelRenderCacheStore) getMainLines(key uint64) ([]renderedLine, bool) {

--- a/cmd/wuphf/channelui/cache_helpers.go
+++ b/cmd/wuphf/channelui/cache_helpers.go
@@ -1,0 +1,38 @@
+package channelui
+
+import "time"
+
+// CloneRenderedLines returns a fresh slice with the same elements as
+// lines, or nil for empty input. Used by the render cache to hand out
+// snapshots that callers can mutate without affecting the cached
+// version. RenderedLine is a value type so a shallow copy is enough.
+func CloneRenderedLines(lines []RenderedLine) []RenderedLine {
+	if len(lines) == 0 {
+		return nil
+	}
+	out := make([]RenderedLine, len(lines))
+	copy(out, lines)
+	return out
+}
+
+// CloneThreadedMessages mirrors CloneRenderedLines for ThreadedMessage
+// slices.
+func CloneThreadedMessages(items []ThreadedMessage) []ThreadedMessage {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]ThreadedMessage, len(items))
+	copy(out, items)
+	return out
+}
+
+// RenderTimeBucket returns a coarse "now" timestamp used to scope
+// render-cache keys: per-second granularity for direct DMs and the
+// office messages app (where freshness matters), per-30-seconds
+// elsewhere (where it doesn't).
+func RenderTimeBucket(activeApp OfficeApp, direct bool) int64 {
+	if direct || activeApp == OfficeAppMessages {
+		return time.Now().Unix()
+	}
+	return time.Now().Unix() / 30
+}

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -73,6 +73,11 @@
 //     messages), DefaultHumanMessageTitle (fallback titles for
 //     human_* kinds), SliceRenderedLines (viewport windowing) and
 //     FormatTokenCount (compact "1.2M tok" formatter).
+//   - cache_helpers.go     — leaf render-cache helpers:
+//     CloneRenderedLines / CloneThreadedMessages (defensive copies
+//     for cached snapshots) and RenderTimeBucket (per-second
+//     bucket for direct DMs and the messages app, per-30s
+//     elsewhere).
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -132,6 +132,10 @@ var (
 	defaultHumanMessageTitle = channelui.DefaultHumanMessageTitle
 	sliceRenderedLines       = channelui.SliceRenderedLines
 	formatTokenCount         = channelui.FormatTokenCount
+
+	cloneRenderedLines    = channelui.CloneRenderedLines
+	cloneThreadedMessages = channelui.CloneThreadedMessages
+	renderTimeBucket      = channelui.RenderTimeBucket
 )
 
 // Calendar-range typed-string consts.


### PR DESCRIPTION
## Summary

Hoists three pure cache helpers off `channel_render_cache.go` and into `channelui/cache_helpers.go`. Stacks on top of #441.

- `CloneRenderedLines` / `CloneThreadedMessages` — defensive copies the render cache hands out so callers can mutate without affecting cached state.
- `RenderTimeBucket` — coarse "now" timestamp used in cache keys (per-second for direct DMs and the messages app, per-30s elsewhere).

The bigger render-cache pieces (`channelRenderCacheStore`, `hashSidebarState`, the channelModel-bound `cachedMainLines` / `hashMainLinesState`, and the `stateHasher` with its broker-message / channel-state `add*` methods) stay in package main for now — they have heavy dependencies on `channelModel` and types that have not been hoisted yet.

Aliases preserve the lowercase names so all eleven existing callers in `channel_viewport_virtual.go`, `channel_window.go`, the cache store methods, and the cache test continue compiling unchanged.

## Test plan

- [x] \`go build ./cmd/wuphf\`
- [x] \`go vet ./...\`
- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`golangci-lint run ./cmd/wuphf/...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)