### PR TITLE
refactor(channelui): hoist recovery leaf helpers + thread helpers

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -3609,15 +3609,6 @@ func (m *channelModel) openRequestActionPicker(req channelInterview) tea.Cmd {
 	return nil
 }
 
-func hasThreadReplies(messages []brokerMessage, id string) bool {
-	for _, msg := range messages {
-		if msg.ReplyTo == id {
-			return true
-		}
-	}
-	return false
-}
-
 func containsSlug(items []string, want string) bool {
 	for _, item := range items {
 		if item == want {

--- a/cmd/wuphf/channel_insert_search.go
+++ b/cmd/wuphf/channel_insert_search.go
@@ -246,18 +246,3 @@ func (m channelModel) recentRootMessages(limit int) []brokerMessage {
 	}
 	return out
 }
-
-func threadRootMessageID(messages []brokerMessage, messageID string) string {
-	current, ok := findMessageByID(messages, messageID)
-	if !ok {
-		return strings.TrimSpace(messageID)
-	}
-	for strings.TrimSpace(current.ReplyTo) != "" {
-		parent, ok := findMessageByID(messages, current.ReplyTo)
-		if !ok {
-			return current.ReplyTo
-		}
-		current = parent
-	}
-	return current.ID
-}

--- a/cmd/wuphf/channel_recovery.go
+++ b/cmd/wuphf/channel_recovery.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -104,26 +103,6 @@ func summarizeAwayRecovery(unreadCount int, recovery team.SessionRecovery) strin
 
 func (m channelModel) currentAwaySummary() string {
 	return m.currentWorkspaceUIState().AwaySummary
-}
-
-func trimRecoverySentence(text string) string {
-	text = strings.TrimSpace(text)
-	text = strings.TrimSuffix(text, ".")
-	return text
-}
-
-func renderAwayStrip(width, unreadCount int, summary string) string {
-	label := fmt.Sprintf("While away · %d new · /recover", unreadCount)
-	if strings.TrimSpace(summary) != "" {
-		label = fmt.Sprintf("While away · %s · /recover", strings.TrimSpace(summary))
-	}
-	label = truncateText(label, maxInt(24, width-6))
-	return "  " + lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#0F172A")).
-		Background(lipgloss.Color("#BFDBFE")).
-		Padding(0, 1).
-		Bold(true).
-		Render(label)
 }
 
 func buildRecoveryLines(workspace workspaceUIState, contentWidth int, tasks []channelTask, requests []channelInterview, messages []brokerMessage) []renderedLine {
@@ -280,163 +259,6 @@ func buildRecoverySurgeryLines(contentWidth int, tasks []channelTask, requests [
 	}
 
 	return lines
-}
-
-type recoverySurgeryOption struct {
-	Tag    string
-	Title  string
-	Body   string
-	Accent string
-	Extra  []string
-	Prompt string
-}
-
-func buildRecoverySurgeryOptions(tasks []channelTask, requests []channelInterview, messages []brokerMessage) []recoverySurgeryOption {
-	options := make([]recoverySurgeryOption, 0, 6)
-
-	for _, req := range requests {
-		if !isOpenInterviewStatus(req.Status) {
-			continue
-		}
-		options = append(options, recoverySurgeryOption{
-			Tag:    "decision brief",
-			Title:  "Draft the decision context for " + req.ID,
-			Body:   fallbackString(strings.TrimSpace(req.Context), req.TitleOrQuestion()),
-			Accent: "#B45309",
-			Extra:  []string{"Request " + req.ID, "Asked by @" + fallbackString(req.From, "unknown")},
-			Prompt: buildRecoveryPromptForRequest(req),
-		})
-		if len(options) >= 2 {
-			break
-		}
-	}
-
-	taskCount := 0
-	for _, task := range recoveryActiveTasks(tasks, 3) {
-		options = append(options, recoverySurgeryOption{
-			Tag:    "task handoff",
-			Title:  "Restore context for " + task.ID,
-			Body:   fallbackString(strings.TrimSpace(task.Details), task.Title),
-			Accent: "#2563EB",
-			Extra:  []string{"Owner @" + fallbackString(task.Owner, "unowned"), "Status " + fallbackString(strings.TrimSpace(task.Status), "open")},
-			Prompt: buildRecoveryPromptForTask(task),
-		})
-		taskCount++
-		if taskCount >= 2 {
-			break
-		}
-	}
-
-	threadCount := 0
-	for _, msg := range recoveryRecentThreads(messages, 3) {
-		options = append(options, recoverySurgeryOption{
-			Tag:    "rewind",
-			Title:  "Summarize everything since " + msg.ID,
-			Body:   truncateText(strings.TrimSpace(msg.Content), 160),
-			Accent: "#475569",
-			Extra:  []string{"Thread " + msg.ID, "Started by @" + fallbackString(msg.From, "unknown")},
-			Prompt: buildRecoveryPromptForMessage(msg),
-		})
-		threadCount++
-		if threadCount >= 2 {
-			break
-		}
-	}
-
-	return options
-}
-
-func buildRecoveryPromptForMessage(msg brokerMessage) string {
-	return fmt.Sprintf("Summarize everything since %s from @%s, focusing on decisions, blocked work, owner changes, risks, and the next concrete actions. Include what a human needs to know before replying. Message context: %s", msg.ID, fallbackString(msg.From, "unknown"), truncateText(strings.TrimSpace(msg.Content), 120))
-}
-
-func buildRecoveryPromptForRequest(req channelInterview) string {
-	return fmt.Sprintf("Draft a decision brief for request %s (%s). Summarize the arguments so far, what is blocked, the recommendation, open risks, and the smallest next action after the human answers.", req.ID, req.TitleOrQuestion())
-}
-
-func buildRecoveryPromptForTask(task channelTask) string {
-	return fmt.Sprintf("Restore context for task %s (%s). Draft a clean handoff note with current status, work already done, blockers, linked thread context, review state, and the next best move.", task.ID, task.Title)
-}
-
-func renderRecoveryActionCard(contentWidth int, header, body, accent string, extra []string) string {
-	cardWidth := maxInt(24, contentWidth-6)
-	parts := []string{header}
-	if strings.TrimSpace(body) != "" {
-		parts = append(parts, mutedText(body))
-	}
-	for _, line := range extra {
-		if strings.TrimSpace(line) != "" {
-			parts = append(parts, mutedText(line))
-		}
-	}
-	return lipgloss.NewStyle().
-		Width(cardWidth).
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color(accent)).
-		Background(lipgloss.Color("#16181E")).
-		Padding(0, 1).
-		Render(strings.Join(parts, "\n"))
-}
-
-func prefixedCardLines(lines []renderedLine, prefix string) []renderedLine {
-	out := make([]renderedLine, 0, len(lines))
-	for _, line := range lines {
-		line.Text = prefix + line.Text
-		out = append(out, line)
-	}
-	return out
-}
-
-func recoveryActiveTasks(tasks []channelTask, limit int) []channelTask {
-	filtered := make([]channelTask, 0, len(tasks))
-	for _, task := range tasks {
-		switch strings.ToLower(strings.TrimSpace(task.Status)) {
-		case "", "done", "completed", "canceled", "cancelled":
-			continue
-		default:
-			filtered = append(filtered, task)
-		}
-	}
-	sort.Slice(filtered, func(i, j int) bool {
-		left, lok := parseChannelTime(filtered[i].UpdatedAt)
-		right, rok := parseChannelTime(filtered[j].UpdatedAt)
-		switch {
-		case lok && rok:
-			return left.After(right)
-		case lok:
-			return true
-		case rok:
-			return false
-		default:
-			return filtered[i].ID > filtered[j].ID
-		}
-	})
-	if limit > 0 && len(filtered) > limit {
-		filtered = filtered[:limit]
-	}
-	return filtered
-}
-
-func recoveryRecentThreads(messages []brokerMessage, limit int) []brokerMessage {
-	roots := []brokerMessage{}
-	seen := map[string]bool{}
-	for i := len(messages) - 1; i >= 0 && len(roots) < limit; i-- {
-		msg := messages[i]
-		rootID := threadRootMessageID(messages, msg.ID)
-		if rootID == "" || seen[rootID] {
-			continue
-		}
-		if !hasThreadReplies(messages, rootID) && strings.TrimSpace(msg.ReplyTo) == "" {
-			continue
-		}
-		root, ok := findMessageByID(messages, rootID)
-		if !ok {
-			continue
-		}
-		roots = append(roots, root)
-		seen[rootID] = true
-	}
-	return roots
 }
 
 func countRunningRuntimeTasks(tasks []team.RuntimeTask) int {

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -78,6 +78,18 @@
 //     for cached snapshots) and RenderTimeBucket (per-second
 //     bucket for direct DMs and the messages app, per-30s
 //     elsewhere).
+//   - threads.go           — thread navigation helpers:
+//     ThreadRootMessageID walks ReplyTo to the root,
+//     HasThreadReplies reports whether any message replies to a
+//     given id.
+//   - recovery.go          — recovery leaf helpers:
+//     TrimRecoverySentence, RenderAwayStrip,
+//     RecoverySurgeryOption struct + BuildRecoverySurgeryOptions
+//     (cards for "draft a decision brief / restore task context /
+//     summarize since"), the BuildRecoveryPromptFor* prompt
+//     builders, RenderRecoveryActionCard (the card body styler),
+//     PrefixedCardLines, RecoveryActiveTasks (filter+sort by
+//     UpdatedAt), and RecoveryRecentThreads (newest thread roots).
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/recovery.go
+++ b/cmd/wuphf/channelui/recovery.go
@@ -1,0 +1,226 @@
+package channelui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// TrimRecoverySentence trims whitespace and a single trailing period
+// off a recovery summary fragment so concatenated sentences ("Focus.
+// Next: …") read cleanly.
+func TrimRecoverySentence(text string) string {
+	text = strings.TrimSpace(text)
+	text = strings.TrimSuffix(text, ".")
+	return text
+}
+
+// RenderAwayStrip renders the "While away · N new · /recover" pill at
+// the top of the office feed when there are unread messages or a
+// recovery summary. summary is folded into the label when set; the
+// label is truncated to fit width.
+func RenderAwayStrip(width, unreadCount int, summary string) string {
+	label := fmt.Sprintf("While away · %d new · /recover", unreadCount)
+	if strings.TrimSpace(summary) != "" {
+		label = fmt.Sprintf("While away · %s · /recover", strings.TrimSpace(summary))
+	}
+	label = TruncateText(label, MaxInt(24, width-6))
+	return "  " + lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#0F172A")).
+		Background(lipgloss.Color("#BFDBFE")).
+		Padding(0, 1).
+		Bold(true).
+		Render(label)
+}
+
+// RecoverySurgeryOption is one of the suggested "click to draft this
+// recovery action" cards rendered under the recovery summary. Prompt
+// is the suggested composer prefill when the card is clicked.
+type RecoverySurgeryOption struct {
+	Tag    string
+	Title  string
+	Body   string
+	Accent string
+	Extra  []string
+	Prompt string
+}
+
+// BuildRecoverySurgeryOptions picks up to two open requests, two
+// active tasks, and two recent threads and packages each into a
+// RecoverySurgeryOption suitable for rendering. The caller decides
+// how (and whether) to render them.
+func BuildRecoverySurgeryOptions(tasks []Task, requests []Interview, messages []BrokerMessage) []RecoverySurgeryOption {
+	options := make([]RecoverySurgeryOption, 0, 6)
+
+	for _, req := range requests {
+		if !IsOpenInterviewStatus(req.Status) {
+			continue
+		}
+		options = append(options, RecoverySurgeryOption{
+			Tag:    "decision brief",
+			Title:  "Draft the decision context for " + req.ID,
+			Body:   FallbackString(strings.TrimSpace(req.Context), req.TitleOrQuestion()),
+			Accent: "#B45309",
+			Extra:  []string{"Request " + req.ID, "Asked by @" + FallbackString(req.From, "unknown")},
+			Prompt: BuildRecoveryPromptForRequest(req),
+		})
+		if len(options) >= 2 {
+			break
+		}
+	}
+
+	taskCount := 0
+	for _, task := range RecoveryActiveTasks(tasks, 3) {
+		options = append(options, RecoverySurgeryOption{
+			Tag:    "task handoff",
+			Title:  "Restore context for " + task.ID,
+			Body:   FallbackString(strings.TrimSpace(task.Details), task.Title),
+			Accent: "#2563EB",
+			Extra:  []string{"Owner @" + FallbackString(task.Owner, "unowned"), "Status " + FallbackString(strings.TrimSpace(task.Status), "open")},
+			Prompt: BuildRecoveryPromptForTask(task),
+		})
+		taskCount++
+		if taskCount >= 2 {
+			break
+		}
+	}
+
+	threadCount := 0
+	for _, msg := range RecoveryRecentThreads(messages, 3) {
+		options = append(options, RecoverySurgeryOption{
+			Tag:    "rewind",
+			Title:  "Summarize everything since " + msg.ID,
+			Body:   TruncateText(strings.TrimSpace(msg.Content), 160),
+			Accent: "#475569",
+			Extra:  []string{"Thread " + msg.ID, "Started by @" + FallbackString(msg.From, "unknown")},
+			Prompt: BuildRecoveryPromptForMessage(msg),
+		})
+		threadCount++
+		if threadCount >= 2 {
+			break
+		}
+	}
+
+	return options
+}
+
+// BuildRecoveryPromptForMessage builds the composer prefill for the
+// "rewind" surgery option — asks the assistant to summarize everything
+// since the message, focusing on decisions, blocked work, owner
+// changes, risks, and next actions.
+func BuildRecoveryPromptForMessage(msg BrokerMessage) string {
+	return fmt.Sprintf("Summarize everything since %s from @%s, focusing on decisions, blocked work, owner changes, risks, and the next concrete actions. Include what a human needs to know before replying. Message context: %s", msg.ID, FallbackString(msg.From, "unknown"), TruncateText(strings.TrimSpace(msg.Content), 120))
+}
+
+// BuildRecoveryPromptForRequest builds the composer prefill for the
+// "decision brief" surgery option — asks the assistant to draft the
+// arguments, blockers, recommendation, risks, and next action.
+func BuildRecoveryPromptForRequest(req Interview) string {
+	return fmt.Sprintf("Draft a decision brief for request %s (%s). Summarize the arguments so far, what is blocked, the recommendation, open risks, and the smallest next action after the human answers.", req.ID, req.TitleOrQuestion())
+}
+
+// BuildRecoveryPromptForTask builds the composer prefill for the
+// "task handoff" surgery option — asks the assistant to restore
+// context with status, work done, blockers, thread context, review
+// state, and next move.
+func BuildRecoveryPromptForTask(task Task) string {
+	return fmt.Sprintf("Restore context for task %s (%s). Draft a clean handoff note with current status, work already done, blockers, linked thread context, review state, and the next best move.", task.ID, task.Title)
+}
+
+// RenderRecoveryActionCard renders a left-bordered recovery card with
+// a header row, optional body row, and any extra muted lines. accent
+// drives the border color. Returns the rendered card string ready to
+// be split by RenderedCardLines.
+func RenderRecoveryActionCard(contentWidth int, header, body, accent string, extra []string) string {
+	cardWidth := MaxInt(24, contentWidth-6)
+	parts := []string{header}
+	if strings.TrimSpace(body) != "" {
+		parts = append(parts, MutedText(body))
+	}
+	for _, line := range extra {
+		if strings.TrimSpace(line) != "" {
+			parts = append(parts, MutedText(line))
+		}
+	}
+	return lipgloss.NewStyle().
+		Width(cardWidth).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(accent)).
+		Background(lipgloss.Color("#16181E")).
+		Padding(0, 1).
+		Render(strings.Join(parts, "\n"))
+}
+
+// PrefixedCardLines returns a copy of lines with prefix prepended to
+// each Text. Used to indent recovery cards under their section
+// header without mutating the input slice.
+func PrefixedCardLines(lines []RenderedLine, prefix string) []RenderedLine {
+	out := make([]RenderedLine, 0, len(lines))
+	for _, line := range lines {
+		line.Text = prefix + line.Text
+		out = append(out, line)
+	}
+	return out
+}
+
+// RecoveryActiveTasks filters tasks to those still in flight (status
+// is not done/completed/canceled and not empty), sorted newest-first
+// by UpdatedAt and capped to limit. limit <= 0 keeps all matches.
+func RecoveryActiveTasks(tasks []Task, limit int) []Task {
+	filtered := make([]Task, 0, len(tasks))
+	for _, task := range tasks {
+		switch strings.ToLower(strings.TrimSpace(task.Status)) {
+		case "", "done", "completed", "canceled", "cancelled":
+			continue
+		default:
+			filtered = append(filtered, task)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		left, lok := ParseChannelTime(filtered[i].UpdatedAt)
+		right, rok := ParseChannelTime(filtered[j].UpdatedAt)
+		switch {
+		case lok && rok:
+			return left.After(right)
+		case lok:
+			return true
+		case rok:
+			return false
+		default:
+			return filtered[i].ID > filtered[j].ID
+		}
+	})
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered
+}
+
+// RecoveryRecentThreads returns up to limit thread roots from the
+// most recent messages (newest-first). Roots are messages that
+// either have replies or are themselves a reply (so a fresh
+// standalone message doesn't qualify). Each root is included at most
+// once.
+func RecoveryRecentThreads(messages []BrokerMessage, limit int) []BrokerMessage {
+	roots := []BrokerMessage{}
+	seen := map[string]bool{}
+	for i := len(messages) - 1; i >= 0 && len(roots) < limit; i-- {
+		msg := messages[i]
+		rootID := ThreadRootMessageID(messages, msg.ID)
+		if rootID == "" || seen[rootID] {
+			continue
+		}
+		if !HasThreadReplies(messages, rootID) && strings.TrimSpace(msg.ReplyTo) == "" {
+			continue
+		}
+		root, ok := FindMessageByID(messages, rootID)
+		if !ok {
+			continue
+		}
+		roots = append(roots, root)
+		seen[rootID] = true
+	}
+	return roots
+}

--- a/cmd/wuphf/channelui/threads.go
+++ b/cmd/wuphf/channelui/threads.go
@@ -1,0 +1,35 @@
+package channelui
+
+import "strings"
+
+// ThreadRootMessageID walks up the ReplyTo chain from messageID and
+// returns the root message's ID. Returns the input ID (trimmed) when
+// the message is not in the slice. Returns the dangling ReplyTo target
+// when an intermediate message has been pruned but the chain still
+// points to it — callers can use that as a synthetic root.
+func ThreadRootMessageID(messages []BrokerMessage, messageID string) string {
+	current, ok := FindMessageByID(messages, messageID)
+	if !ok {
+		return strings.TrimSpace(messageID)
+	}
+	for strings.TrimSpace(current.ReplyTo) != "" {
+		parent, ok := FindMessageByID(messages, current.ReplyTo)
+		if !ok {
+			return current.ReplyTo
+		}
+		current = parent
+	}
+	return current.ID
+}
+
+// HasThreadReplies reports whether any message in messages replies to
+// id (i.e. has ReplyTo == id). Cheap linear scan; the caller should
+// hoist the slice walk if testing many ids.
+func HasThreadReplies(messages []BrokerMessage, id string) bool {
+	for _, msg := range messages {
+		if msg.ReplyTo == id {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -34,6 +34,7 @@ type (
 	channelSkill           = channelui.Skill
 	calendarRange          = channelui.CalendarRange
 	calendarEvent          = channelui.CalendarEvent
+	recoverySurgeryOption  = channelui.RecoverySurgeryOption
 )
 
 // Function aliases keep the lowercase names callable from package main
@@ -136,6 +137,20 @@ var (
 	cloneRenderedLines    = channelui.CloneRenderedLines
 	cloneThreadedMessages = channelui.CloneThreadedMessages
 	renderTimeBucket      = channelui.RenderTimeBucket
+
+	threadRootMessageID = channelui.ThreadRootMessageID
+	hasThreadReplies    = channelui.HasThreadReplies
+
+	trimRecoverySentence          = channelui.TrimRecoverySentence
+	renderAwayStrip               = channelui.RenderAwayStrip
+	buildRecoverySurgeryOptions   = channelui.BuildRecoverySurgeryOptions
+	buildRecoveryPromptForMessage = channelui.BuildRecoveryPromptForMessage
+	buildRecoveryPromptForRequest = channelui.BuildRecoveryPromptForRequest
+	buildRecoveryPromptForTask    = channelui.BuildRecoveryPromptForTask
+	renderRecoveryActionCard      = channelui.RenderRecoveryActionCard
+	prefixedCardLines             = channelui.PrefixedCardLines
+	recoveryActiveTasks           = channelui.RecoveryActiveTasks
+	recoveryRecentThreads         = channelui.RecoveryRecentThreads
 )
 
 // Calendar-range typed-string consts.


### PR DESCRIPTION
## Summary

Hoists the pure recovery surgery cluster off `channel_recovery.go` and the thread-walking helpers off `channel.go` / `channel_insert_search.go` into channelui. Stacks on top of #443.

`channelui/threads.go`:
- `ThreadRootMessageID` walks `ReplyTo` up to the root, returning the dangling target when the chain points to a pruned message.
- `HasThreadReplies` reports whether any message replies to a given id.

`channelui/recovery.go`:
- `TrimRecoverySentence` — trim whitespace + a single trailing period
- `RenderAwayStrip` — "While away · N new · /recover" pill
- `RecoverySurgeryOption` struct + `BuildRecoverySurgeryOptions` — picks up to two open requests, two active tasks, and two recent threads as suggested recovery actions
- `BuildRecoveryPromptFor{Message,Request,Task}` — composer prefills
- `RenderRecoveryActionCard` — rounded-border recovery card body
- `PrefixedCardLines` — non-mutating prefix prepend
- `RecoveryActiveTasks` — filter by status, sort by UpdatedAt
- `RecoveryRecentThreads` — newest thread roots, capped

These leaf helpers do not touch \`team.*\` runtime types or \`channelModel\`, so they slot cleanly into channelui. The team-bound recovery code (\`currentRuntimeSnapshot\`, \`summarizeAwayRecovery\`, the channelModel-bound \`buildRecoveryLines\`, \`countRunning/IsolatedRuntimeTasks\`) stays in package main for now.

Aliases preserve every existing lowercase callsite — including the five package-main consumers of \`threadRootMessageID\` / \`hasThreadReplies\` across \`channel_insert_search.go\`, \`channel_switcher.go\`, \`channel_viewport_virtual.go\`, \`channel_recovery.go\`, and \`channel.go\`.

## Test plan

- [x] \`go build ./cmd/wuphf\`
- [x] \`go vet ./...\`
- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`golangci-lint run ./cmd/wuphf/...\` — 0 issues
- [x] gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)