### PR TITLE
refactor(team): migrate write-side pane methods onto paneLifecycle (C5c)

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -1250,16 +1250,7 @@ func (l *Launcher) watchChannelPaneLoop(channelCmd string) {
 		unhealthyCount = 0
 		deadSince = time.Time{}
 		snapshotWritten = false
-		target := l.sessionName + ":team.0"
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
-			"-t", target,
-			"-c", l.cwd,
-			channelCmd,
-		).Run()
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
-			"-t", target,
-			"-T", "📢 channel",
-		).Run()
+		l.panes().RespawnChannelPane(channelCmd, l.cwd)
 	}
 }
 
@@ -1267,24 +1258,9 @@ func (l *Launcher) channelPaneStatus() (string, error) {
 	return l.panes().ChannelPaneStatus()
 }
 
+// captureDeadChannelPane delegates to paneLifecycle (PLAN.md §C5c).
 func (l *Launcher) captureDeadChannelPane(status string) error {
-	content, err := l.capturePaneContent(0)
-	if err != nil {
-		content = fmt.Sprintf("<capture failed: %v>", err)
-	}
-	path := channelPaneSnapshotPath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
-	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
-	if err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(f, "\n[%s] status=%s\n%s\n", time.Now().Format(time.RFC3339), status, content); err != nil {
-		_ = f.Close()
-		return err
-	}
-	return f.Close()
+	return l.panes().CaptureDeadChannelPane(status)
 }
 
 // primeVisibleAgents clears Claude startup interactivity in newly spawned panes and
@@ -1718,7 +1694,7 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 	l.provider = config.ResolveLLMProvider("")
 	if !l.usesPaneRuntime() {
 		if l.paneBackedAgents {
-			_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+			l.panes().KillSession()
 			l.paneBackedAgents = false
 		}
 		return nil
@@ -1776,14 +1752,9 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 			continue
 		}
 
-		target := fmt.Sprintf("%s:team.%d", l.sessionName, idx)
 		// respawn-pane -k kills the current process and starts a new one
 		// in the same pane — preserving size and position
-		out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "respawn-pane", "-k",
-			"-t", target,
-			"-c", l.cwd,
-			cmd,
-		).CombinedOutput()
+		out, err := l.panes().RespawnAgentPane(idx, l.cwd, cmd)
 		if err != nil {
 			detail := strings.TrimSpace(string(out))
 			reason := err.Error()
@@ -2076,39 +2047,14 @@ func (l *Launcher) capturePaneContent(paneIdx int) (string, error) {
 	return l.panes().CapturePaneContent(paneIdx)
 }
 
+// clearAgentPanes / clearOverflowAgentWindows delegate to paneLifecycle
+// (PLAN.md §C5c).
 func (l *Launcher) clearAgentPanes() error {
-	panes, err := l.listTeamPanes()
-	if err != nil {
-		return err
-	}
-	sort.Sort(sort.Reverse(sort.IntSlice(panes)))
-	for _, idx := range panes {
-		if idx == 0 {
-			continue // skip pane 0 (channel TUI)
-		}
-		target := fmt.Sprintf("%s:team.%d", l.sessionName, idx)
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-pane", "-t", target).Run()
-	}
-	return nil
+	return l.panes().ClearAgentPanes()
 }
 
 func (l *Launcher) clearOverflowAgentWindows() {
-	out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "list-windows",
-		"-t", l.sessionName,
-		"-F", "#{window_name}",
-	).CombinedOutput()
-	if err != nil {
-		return
-	}
-	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		name = strings.TrimSpace(name)
-		if !strings.HasPrefix(name, "agent-") {
-			continue
-		}
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-window",
-			"-t", fmt.Sprintf("%s:%s", l.sessionName, name),
-		).Run()
-	}
+	l.panes().ClearOverflowAgentWindows()
 }
 
 func (l *Launcher) listTeamPanes() ([]int, error) {

--- a/internal/team/pane_lifecycle.go
+++ b/internal/team/pane_lifecycle.go
@@ -11,9 +11,12 @@ package team
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/config"
 )
@@ -100,6 +103,125 @@ func (p *paneLifecycle) ChannelPaneStatus() (string, error) {
 		return "", fmt.Errorf("%s", strings.TrimSpace(string(out)))
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// ClearAgentPanes kills every agent pane in the "team" window
+// (preserving pane 0, the channel observer). The list is sorted in
+// reverse so kill-pane on a higher index doesn't reshuffle the lower
+// ones we still need to address. Errors from individual kill-pane calls
+// are intentionally swallowed — the caller (reconfigureVisibleAgents)
+// follows up with spawnVisibleAgents which is where actual failures
+// surface; here, the worst case is a pane that won't die which becomes
+// visible at next list-panes anyway.
+func (p *paneLifecycle) ClearAgentPanes() error {
+	panes, err := p.ListTeamPanes()
+	if err != nil {
+		return err
+	}
+	sort.Sort(sort.Reverse(sort.IntSlice(panes)))
+	for _, idx := range panes {
+		if idx == 0 {
+			continue
+		}
+		target := fmt.Sprintf("%s:team.%d", p.sessionName, idx)
+		_ = p.runner.Run("kill-pane", "-t", target)
+	}
+	return nil
+}
+
+// ClearOverflowAgentWindows enumerates the tmux windows in the session
+// and kills any whose name starts with "agent-" — the prefix used by
+// spawnOverflowAgents for agents that don't fit in the visible "team"
+// grid. A list-windows failure is treated as "nothing to clean up"
+// (tmux is probably down). Like ClearAgentPanes, individual kill-window
+// errors are swallowed — overflow windows are best-effort housekeeping.
+func (p *paneLifecycle) ClearOverflowAgentWindows() {
+	out, err := p.runner.Combined("list-windows",
+		"-t", p.sessionName,
+		"-F", "#{window_name}",
+	)
+	if err != nil {
+		return
+	}
+	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		name = strings.TrimSpace(name)
+		if !strings.HasPrefix(name, "agent-") {
+			continue
+		}
+		_ = p.runner.Run("kill-window",
+			"-t", fmt.Sprintf("%s:%s", p.sessionName, name),
+		)
+	}
+}
+
+// KillSession terminates the entire wuphf-team tmux session. Used by
+// reconfigureVisibleAgents when the runtime no longer needs panes (the
+// user switched to headless mid-session). Errors are intentionally
+// dropped — if the session is already gone, kill-session returns a "no
+// such session" error that's the desired post-condition.
+func (p *paneLifecycle) KillSession() {
+	_ = p.runner.Run("kill-session", "-t", p.sessionName)
+}
+
+// RespawnAgentPane runs `respawn-pane -k` against pane <idx> in the
+// "team" window, replacing the running process with cmd executed in
+// cwd. Returns the combined stdout/stderr so callers can surface the
+// tmux error text in their own error messages. Used by
+// reconfigureVisibleAgents to restart agent processes in place,
+// preserving pane sizes and positions.
+func (p *paneLifecycle) RespawnAgentPane(idx int, cwd, cmd string) ([]byte, error) {
+	target := fmt.Sprintf("%s:team.%d", p.sessionName, idx)
+	return p.runner.Combined("respawn-pane", "-k",
+		"-t", target,
+		"-c", cwd,
+		cmd,
+	)
+}
+
+// RespawnChannelPane respawns pane 0 (the channel observer) with the
+// given channelCmd executed in cwd, then re-applies the channel pane
+// title. Used by watchChannelPaneLoop when the channel pane has been
+// dead for at least channelRespawnDelay. Errors are swallowed —
+// watchChannelPaneLoop runs on a periodic tick and will retry on the
+// next iteration if the respawn didn't take.
+func (p *paneLifecycle) RespawnChannelPane(channelCmd, cwd string) {
+	target := p.sessionName + ":team.0"
+	_ = p.runner.Run("respawn-pane", "-k",
+		"-t", target,
+		"-c", cwd,
+		channelCmd,
+	)
+	_ = p.runner.Run("select-pane",
+		"-t", target,
+		"-T", "📢 channel",
+	)
+}
+
+// CaptureDeadChannelPane writes a timestamped snapshot of the channel
+// pane (pane 0) plus its display-message status to
+// channelPaneSnapshotPath. Used by watchChannelPaneLoop the first time
+// a dead pane is observed, so post-mortem inspection has the pane's
+// last known content even after the respawn. Capture failures degrade
+// to a "<capture failed: …>" placeholder so the snapshot file always
+// exists with the status line.
+func (p *paneLifecycle) CaptureDeadChannelPane(status string) error {
+	content, err := p.CapturePaneContent(0)
+	if err != nil {
+		content = fmt.Sprintf("<capture failed: %v>", err)
+	}
+	path := channelPaneSnapshotPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "\n[%s] status=%s\n%s\n", time.Now().Format(time.RFC3339), status, content); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
 }
 
 // channelPaneNeedsRespawn parses a tmux display-message status string of

--- a/internal/team/pane_lifecycle_write_test.go
+++ b/internal/team/pane_lifecycle_write_test.go
@@ -1,0 +1,203 @@
+package team
+
+// Tests for the C5c migration: write-side / destructive paneLifecycle
+// methods (ClearAgentPanes, ClearOverflowAgentWindows, KillSession,
+// RespawnAgentPane, RespawnChannelPane, CaptureDeadChannelPane). All
+// driven through fakeTmuxRunner via setTmuxRunnerForTest — no real
+// tmux server required, no time.Sleep in any of them.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPaneLifecycle_ClearAgentPanesKillsHigherIndicesFirst(t *testing.T) {
+	// Reverse-order kill matters: tmux renumbers panes after a kill, so
+	// killing pane 1 before pane 3 leaves the original pane 3 sitting at
+	// index 2 — and the next kill-pane targets the wrong process.
+	// ClearAgentPanes sorts descending to avoid that. This test pins the
+	// invariant.
+	fake := newFakeTmuxRunner()
+	fake.outputs["list-panes"] = []byte("0 channel\n1 ceo\n2 fe\n3 be\n")
+	setTmuxRunnerForTest(t, fake)
+
+	if err := newPaneLifecycle("wuphf-team").ClearAgentPanes(); err != nil {
+		t.Fatalf("ClearAgentPanes err = %v", err)
+	}
+
+	kills := fake.callsFor("kill-pane")
+	if len(kills) != 3 {
+		t.Fatalf("kill-pane calls = %d, want 3 (indices 1,2,3)", len(kills))
+	}
+	wantTargets := []string{"wuphf-team:team.3", "wuphf-team:team.2", "wuphf-team:team.1"}
+	for i, call := range kills {
+		// Each call's args are exactly: "kill-pane", "-t", target.
+		if len(call) != 3 || call[2] != wantTargets[i] {
+			t.Errorf("kill-pane[%d] = %v, want target=%s (descending order)", i, call, wantTargets[i])
+		}
+	}
+}
+
+func TestPaneLifecycle_ClearAgentPanesNoSessionIsNoOp(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["list-panes"] = []byte("no server running")
+	fake.errors["list-panes"] = fmt.Errorf("exit 1")
+	setTmuxRunnerForTest(t, fake)
+
+	if err := newPaneLifecycle("wuphf-team").ClearAgentPanes(); err != nil {
+		t.Fatalf("ClearAgentPanes(no session) err = %v, want nil", err)
+	}
+	if got := fake.callsFor("kill-pane"); len(got) != 0 {
+		t.Fatalf("expected zero kill-pane calls when session missing, got %d", len(got))
+	}
+}
+
+func TestPaneLifecycle_ClearOverflowAgentWindowsFiltersByPrefix(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["list-windows"] = []byte("team\nagent-fe\nlogs\nagent-be\n")
+	setTmuxRunnerForTest(t, fake)
+
+	newPaneLifecycle("wuphf-team").ClearOverflowAgentWindows()
+
+	kills := fake.callsFor("kill-window")
+	if len(kills) != 2 {
+		t.Fatalf("kill-window calls = %d, want 2 (agent-fe, agent-be)", len(kills))
+	}
+	wantTargets := []string{"wuphf-team:agent-fe", "wuphf-team:agent-be"}
+	for i, call := range kills {
+		if len(call) < 3 || call[2] != wantTargets[i] {
+			t.Errorf("kill-window[%d] = %v, want %s", i, call, wantTargets[i])
+		}
+	}
+}
+
+func TestPaneLifecycle_ClearOverflowAgentWindowsListErrorIsNoOp(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.errors["list-windows"] = fmt.Errorf("no server")
+	setTmuxRunnerForTest(t, fake)
+
+	newPaneLifecycle("wuphf-team").ClearOverflowAgentWindows()
+
+	if got := fake.callsFor("kill-window"); len(got) != 0 {
+		t.Fatalf("expected zero kill-window calls on list error, got %d", len(got))
+	}
+}
+
+func TestPaneLifecycle_KillSessionIssuesKillSession(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	newPaneLifecycle("wuphf-team").KillSession()
+
+	calls := fake.callsFor("kill-session")
+	if len(calls) != 1 {
+		t.Fatalf("kill-session calls = %d, want 1", len(calls))
+	}
+	want := []string{"kill-session", "-t", "wuphf-team"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("kill-session args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_RespawnAgentPaneSurfacesTmuxOutput(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["respawn-pane"] = []byte("tmux: pane locked\n")
+	fake.errors["respawn-pane"] = fmt.Errorf("exit 1")
+	setTmuxRunnerForTest(t, fake)
+
+	out, err := newPaneLifecycle("wuphf-team").RespawnAgentPane(2, "/tmp/cwd", "claude --print")
+	if err == nil {
+		t.Fatalf("RespawnAgentPane err = nil, want non-nil")
+	}
+	if string(out) != "tmux: pane locked\n" {
+		t.Errorf("RespawnAgentPane out = %q, want tmux stderr text", out)
+	}
+	calls := fake.callsFor("respawn-pane")
+	if len(calls) != 1 {
+		t.Fatalf("respawn-pane calls = %d, want 1", len(calls))
+	}
+	want := []string{"respawn-pane", "-k", "-t", "wuphf-team:team.2", "-c", "/tmp/cwd", "claude --print"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("respawn-pane args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_RespawnChannelPaneIssuesBothCommands(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	newPaneLifecycle("wuphf-team").RespawnChannelPane("wuphf channel", "/tmp/cwd")
+
+	respawn := fake.callsFor("respawn-pane")
+	if len(respawn) != 1 {
+		t.Fatalf("respawn-pane calls = %d, want 1", len(respawn))
+	}
+	wantRespawn := []string{"respawn-pane", "-k", "-t", "wuphf-team:team.0", "-c", "/tmp/cwd", "wuphf channel"}
+	if !equalStrings(respawn[0], wantRespawn) {
+		t.Errorf("respawn-pane args = %v, want %v", respawn[0], wantRespawn)
+	}
+
+	selectPane := fake.callsFor("select-pane")
+	if len(selectPane) != 1 {
+		t.Fatalf("select-pane calls = %d, want 1", len(selectPane))
+	}
+	// Just confirm the title and target are right; the emoji string is
+	// brittle so we don't pin its exact UTF-8 bytes.
+	if selectPane[0][2] != "wuphf-team:team.0" {
+		t.Errorf("select-pane target = %q, want wuphf-team:team.0", selectPane[0][2])
+	}
+	if !strings.Contains(selectPane[0][len(selectPane[0])-1], "channel") {
+		t.Errorf("select-pane title %q should contain 'channel'", selectPane[0][len(selectPane[0])-1])
+	}
+}
+
+func TestPaneLifecycle_CaptureDeadChannelPaneWritesSnapshot(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", tmp)
+
+	fake := newFakeTmuxRunner()
+	fake.outputs["capture-pane"] = []byte("agent: ready\nagent: dead\n")
+	setTmuxRunnerForTest(t, fake)
+
+	if err := newPaneLifecycle("wuphf-team").CaptureDeadChannelPane("1 0 claude"); err != nil {
+		t.Fatalf("CaptureDeadChannelPane err = %v", err)
+	}
+
+	path := filepath.Join(tmp, ".wuphf", "logs", "channel-pane.log")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read snapshot file %s: %v", path, err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, "status=1 0 claude") {
+		t.Errorf("snapshot missing status header: %q", got)
+	}
+	if !strings.Contains(got, "agent: ready") || !strings.Contains(got, "agent: dead") {
+		t.Errorf("snapshot missing capture-pane content: %q", got)
+	}
+}
+
+func TestPaneLifecycle_CaptureDeadChannelPaneCaptureFailureWritesPlaceholder(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("WUPHF_RUNTIME_HOME", tmp)
+
+	fake := newFakeTmuxRunner()
+	fake.errors["capture-pane"] = fmt.Errorf("pane vanished")
+	setTmuxRunnerForTest(t, fake)
+
+	if err := newPaneLifecycle("wuphf-team").CaptureDeadChannelPane("1 0 claude"); err != nil {
+		t.Fatalf("CaptureDeadChannelPane err = %v, want nil even on capture failure", err)
+	}
+
+	path := filepath.Join(tmp, ".wuphf", "logs", "channel-pane.log")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read snapshot file: %v", err)
+	}
+	if !strings.Contains(string(raw), "<capture failed: pane vanished>") {
+		t.Errorf("snapshot missing capture-failed placeholder: %q", raw)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on **#442 (C5b, runner seam)**. Continues PLAN.md §C5: moves
the destructive / respawn / snapshot tmux methods off Launcher onto
` + "`paneLifecycle`" + ` through the ` + "`tmuxRunner`" + ` seam, replacing every direct
` + "`exec.CommandContext(\"tmux\", ...)`" + ` call in this code path with
runner-routed calls that tests can drive without a real tmux server.

## Methods migrated to paneLifecycle

| Before | After |
|---|---|
| ` + "`(*Launcher).clearAgentPanes`" + ` | ` + "`(*paneLifecycle).ClearAgentPanes`" + ` |
| ` + "`(*Launcher).clearOverflowAgentWindows`" + ` | ` + "`(*paneLifecycle).ClearOverflowAgentWindows`" + ` |
| ` + "`(*Launcher).captureDeadChannelPane`" + ` | ` + "`(*paneLifecycle).CaptureDeadChannelPane`" + ` |
| inline ` + "`kill-session`" + ` in ` + "`reconfigureVisibleAgents`" + ` | ` + "`(*paneLifecycle).KillSession`" + ` |
| inline ` + "`respawn-pane`" + ` in ` + "`reconfigureVisibleAgents`" + ` | ` + "`(*paneLifecycle).RespawnAgentPane(idx, cwd, cmd)`" + ` |
| inline ` + "`respawn-pane + select-pane`" + ` in ` + "`watchChannelPaneLoop`" + ` | ` + "`(*paneLifecycle).RespawnChannelPane(cmd, cwd)`" + ` |

` + "`watchChannelPaneLoop`" + ` itself stays on Launcher (it has a 2-second
poll loop and accesses several Launcher methods); only its tmux call
pair moves. Same for ` + "`reconfigureVisibleAgents`" + `: it stays on Launcher,
but the three direct ` + "`exec`" + ` invocations inside it now route through
paneLifecycle.

## Important invariant: descending kill-pane order

` + "`ClearAgentPanes`" + ` preserves the reverse-sort from the original
implementation. tmux renumbers panes after a kill, so killing pane 1
before pane 3 leaves the original pane 3 sitting at index 2 — and the
next ` + "`kill-pane`" + ` targets the wrong process. The new
` + "`TestPaneLifecycle_ClearAgentPanesKillsHigherIndicesFirst`" + ` test pins
this invariant.

## Tests (8 new)

All driven through the existing ` + "`fakeTmuxRunner`" + ` from C5b:

* descending kill-pane order on full pane list
* ClearAgentPanes is a no-op when the session is missing
* ClearOverflowAgentWindows filters by ` + "`agent-`" + ` prefix
* ClearOverflowAgentWindows no-op on list-windows error
* KillSession args
* RespawnAgentPane surfaces tmux stderr text + correct args
* RespawnChannelPane issues both respawn-pane and select-pane
* CaptureDeadChannelPane writes the snapshot (real capture)
* CaptureDeadChannelPane writes the placeholder on capture failure

The snapshot tests use ` + "`t.Setenv(\"WUPHF_RUNTIME_HOME\", t.TempDir())`" + `
to keep the file scoped to the test. Zero ` + "`time.Sleep`" + `.

## Coverage

| Method | Coverage |
|---|---:|
| ClearAgentPanes | 80.0% |
| ClearOverflowAgentWindows | 100.0% |
| KillSession | 100.0% |
| RespawnAgentPane | 100.0% |
| RespawnChannelPane | 100.0% |
| CaptureDeadChannelPane | 69.2% |

The 69.2% on CaptureDeadChannelPane comes from the os.MkdirAll /
os.OpenFile error branches that aren't exercised when the home dir is
writable; covering them would require a read-only-temp-dir path that
adds noise without value. All migrated methods well above the 85%
floor on the average / median.

Package ` + "`internal/team`" + `: 63.9% → **64.0%**.

## Diff shape

| File | Δ |
|---|---:|
| ` + "`launcher.go`" + ` | 3023 → 2988 (−35) |
| ` + "`pane_lifecycle.go`" + ` | +122 |
| ` + "`pane_lifecycle_write_test.go`" + ` | +203 (new) |

**Cumulative since main: 4998 → 2988 = −2010 lines (−40.2%).**

## Local CI matrix (all green)

* ` + "`gofmt -s -l`" + ` clean
* ` + "`golangci-lint run ./internal/team/...`" + ` 0 issues
* ` + "`go test -race -timeout 15m ./internal/team`" + ` 78s
* ` + "`bash scripts/test-go.sh`" + ` — **all 32 packages green**
* Cross-compile windows-amd64 + darwin-arm64 — clean
* Smoke binary OK

## Test plan

- [x] ` + "`go build ./...`" + `
- [x] All 8 new tests pass
- [x] Existing tests still green
- [x] ` + "`bash scripts/test-go.sh`" + ` (all 32 packages green)
- [ ] CI green

## What's next

**C5d — migrate the spawn cluster**: ` + "`spawnVisibleAgents`" + `,
` + "`spawnOverflowAgents`" + `, ` + "`detectDeadPanesAfterSpawn`" + `,
` + "`recordPaneSpawnFailure`" + `, ` + "`trySpawnWebAgentPanes`" + `,
` + "`primeVisibleAgents`" + `, ` + "`reportPaneFallback`" + `. These methods need the
` + "`failedPaneSlugs`" + ` map + ` + "`paneBackedFlag`" + ` access patterns from
PLAN.md §C5 / trap §1, so they get a focused review pass on ownership
and the targeter cross-references when they migrate.

The wrapper-consolidation sweep (PLAN.md §6: rename ~150 in-package
call sites, delete transitional wrappers) lands as a separate sweep
PR after the last C5 cluster.