### PR TITLE
refactor(channelui): hoist interview leaf helpers

### DIFF
--- a/cmd/wuphf/channel_interview.go
+++ b/cmd/wuphf/channel_interview.go
@@ -2,46 +2,6 @@ package main
 
 import "strings"
 
-type channelInterviewPhase string
-
-const (
-	interviewPhaseChoose channelInterviewPhase = "choose"
-	interviewPhaseDraft  channelInterviewPhase = "draft"
-	interviewPhaseReview channelInterviewPhase = "review"
-)
-
-func interviewOptionRequiresText(option *channelInterviewOption) bool {
-	if option == nil {
-		return false
-	}
-	if option.RequiresText {
-		return true
-	}
-	id := strings.TrimSpace(strings.ToLower(option.ID))
-	return strings.Contains(id, "note") || strings.Contains(id, "steer")
-}
-
-func interviewOptionTextHint(option *channelInterviewOption) string {
-	if option == nil {
-		return ""
-	}
-	if strings.TrimSpace(option.TextHint) != "" {
-		return option.TextHint
-	}
-	if interviewOptionRequiresText(option) {
-		return "Type your note, rationale, or steering before submitting this choice."
-	}
-	return ""
-}
-
-func selectedInterviewOption(options []channelInterviewOption, index int) *channelInterviewOption {
-	if index < 0 || index >= len(options) {
-		return nil
-	}
-	option := options[index]
-	return &option
-}
-
 func (m channelModel) currentInterviewPhase() channelInterviewPhase {
 	if m.pending == nil {
 		return ""

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -90,6 +90,10 @@
 //     builders, RenderRecoveryActionCard (the card body styler),
 //     PrefixedCardLines, RecoveryActiveTasks (filter+sort by
 //     UpdatedAt), and RecoveryRecentThreads (newest thread roots).
+//   - interview.go         — interview-flow leaf helpers:
+//     InterviewPhase typed-string + Choose/Draft/Review consts,
+//     InterviewOptionRequiresText, InterviewOptionTextHint, and
+//     SelectedInterviewOption.
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/interview.go
+++ b/cmd/wuphf/channelui/interview.go
@@ -1,0 +1,59 @@
+package channelui
+
+import "strings"
+
+// InterviewPhase identifies which step of the request-answer flow the
+// composer is in: choose an option, draft a free-text answer, or
+// review the about-to-be-submitted answer. Empty string means there
+// is no active interview.
+type InterviewPhase string
+
+const (
+	InterviewPhaseChoose InterviewPhase = "choose"
+	InterviewPhaseDraft  InterviewPhase = "draft"
+	InterviewPhaseReview InterviewPhase = "review"
+)
+
+// InterviewOptionRequiresText reports whether the option mandates a
+// free-text answer alongside the choice. True when option.RequiresText
+// is set, or when the option ID looks like a "note" / "steer" prompt
+// (which historically required text but were not flagged explicitly).
+// Returns false for nil.
+func InterviewOptionRequiresText(option *InterviewOption) bool {
+	if option == nil {
+		return false
+	}
+	if option.RequiresText {
+		return true
+	}
+	id := strings.TrimSpace(strings.ToLower(option.ID))
+	return strings.Contains(id, "note") || strings.Contains(id, "steer")
+}
+
+// InterviewOptionTextHint returns the hint string the composer shows
+// for an option's free-text input — the option's TextHint when set,
+// otherwise a generic prompt when the option requires text, otherwise
+// "".
+func InterviewOptionTextHint(option *InterviewOption) string {
+	if option == nil {
+		return ""
+	}
+	if strings.TrimSpace(option.TextHint) != "" {
+		return option.TextHint
+	}
+	if InterviewOptionRequiresText(option) {
+		return "Type your note, rationale, or steering before submitting this choice."
+	}
+	return ""
+}
+
+// SelectedInterviewOption returns a pointer to options[index], or nil
+// when index is out of range. The returned pointer is to a copy of
+// the option so callers cannot mutate the underlying slice via it.
+func SelectedInterviewOption(options []InterviewOption, index int) *InterviewOption {
+	if index < 0 || index >= len(options) {
+		return nil
+	}
+	option := options[index]
+	return &option
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -35,6 +35,7 @@ type (
 	calendarRange          = channelui.CalendarRange
 	calendarEvent          = channelui.CalendarEvent
 	recoverySurgeryOption  = channelui.RecoverySurgeryOption
+	channelInterviewPhase  = channelui.InterviewPhase
 )
 
 // Function aliases keep the lowercase names callable from package main
@@ -151,6 +152,17 @@ var (
 	prefixedCardLines             = channelui.PrefixedCardLines
 	recoveryActiveTasks           = channelui.RecoveryActiveTasks
 	recoveryRecentThreads         = channelui.RecoveryRecentThreads
+
+	interviewOptionRequiresText = channelui.InterviewOptionRequiresText
+	interviewOptionTextHint     = channelui.InterviewOptionTextHint
+	selectedInterviewOption     = channelui.SelectedInterviewOption
+)
+
+// Interview-phase typed-string consts.
+const (
+	interviewPhaseChoose = channelui.InterviewPhaseChoose
+	interviewPhaseDraft  = channelui.InterviewPhaseDraft
+	interviewPhaseReview = channelui.InterviewPhaseReview
 )
 
 // Calendar-range typed-string consts.


### PR DESCRIPTION
## Summary

Hoists the pure interview-flow helpers off \`channel_interview.go\` into \`channelui/interview.go\`. Stacks on top of #444.

- \`InterviewPhase\` typed-string + \`InterviewPhaseChoose\` / \`Draft\` / \`Review\` consts
- \`InterviewOptionRequiresText\` — true when \`option.RequiresText\` is set or the option ID looks like a "note"/"steer" prompt
- \`InterviewOptionTextHint\` — option-supplied hint, generic prompt when text is required, "" otherwise
- \`SelectedInterviewOption\` — bounds-checked \`options[index]\` copy pointer

The channelModel-bound interview methods (\`currentInterviewPhase\`, \`interviewPhaseTitle\`, \`interviewStatusLine\`, \`selectedInterviewOption\`) stay in package main since they read \`m.pending\` / \`m.confirm\` / \`m.input\`.

Aliases preserve every existing lowercase callsite — \`channel.go\`, \`channel_test.go\`, \`channel_model_helpers_test.go\` all continue compiling against the original names.

## Test plan

- [x] \`go build ./cmd/wuphf\`
- [x] \`go vet ./...\`
- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`golangci-lint run ./cmd/wuphf/...\` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)