### PR TITLE
refactor(team): route spawn-cluster tmux calls through paneLifecycle (C5d)

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -1273,19 +1273,17 @@ func (l *Launcher) primeVisibleAgents() {
 		return
 	}
 
+	panes := l.panes()
 	for attempt := 0; attempt < 3; attempt++ {
 		allReady := true
 		for _, target := range targets {
-			content, err := l.capturePaneTargetContent(target.PaneTarget)
+			content, err := panes.CapturePaneTargetContent(target.PaneTarget)
 			if err != nil {
 				allReady = false
 				continue
 			}
 			if shouldPrimeClaudePane(content) {
-				_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
-					"-t", target.PaneTarget,
-					"Enter",
-				).Run()
+				panes.SendEnter(target.PaneTarget)
 				allReady = false
 			}
 		}
@@ -2069,18 +2067,15 @@ func HasLiveTmuxSession() bool {
 }
 
 func (l *Launcher) spawnVisibleAgents() ([]string, error) {
+	panes := l.panes()
+	channelPane := l.sessionName + ":team.0"
 	if l.isOneOnOne() {
 		slug := l.oneOnOneAgent()
 		firstCmd, err := l.claudeCommand(slug, l.buildPrompt(slug))
 		if err != nil {
 			return nil, err
 		}
-		out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "split-window", "-h",
-			"-t", l.sessionName+":team",
-			"-p", "65",
-			"-c", l.cwd,
-			firstCmd,
-		).CombinedOutput()
+		out, err := panes.SplitFirstAgent(l.cwd, firstCmd)
 		if err != nil {
 			detail := strings.TrimSpace(string(out))
 			if detail == "" {
@@ -2088,24 +2083,13 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 			}
 			return nil, fmt.Errorf("spawn one-on-one agent: %w (tmux: %s)", err, detail)
 		}
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-layout",
-			"-t", l.sessionName+":team",
-			"main-vertical",
-		).Run()
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
-			"-t", l.sessionName+":team.0",
-			"-T", "📢 direct",
-		).Run()
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
-			"-t", fmt.Sprintf("%s:team.1", l.sessionName),
-			"-T", fmt.Sprintf("🤖 %s (@%s)", l.getAgentName(slug), slug),
-		).Run()
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-window",
-			"-t", l.sessionName+":team",
-		).Run()
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
-			"-t", l.sessionName+":team.0",
-		).Run()
+		panes.ApplyMainVerticalLayout()
+		panes.SetPaneTitle(channelPane, "📢 direct")
+		panes.SetPaneTitle(fmt.Sprintf("%s:team.1", l.sessionName),
+			fmt.Sprintf("🤖 %s (@%s)", l.getAgentName(slug), slug),
+		)
+		panes.SelectTeamWindow()
+		panes.FocusPane(channelPane)
 		return []string{slug}, nil
 	}
 
@@ -2127,12 +2111,7 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "split-window", "-h",
-		"-t", l.sessionName+":team",
-		"-p", "65",
-		"-c", l.cwd,
-		firstCmd,
-	).CombinedOutput()
+	out, err := panes.SplitFirstAgent(l.cwd, firstCmd)
 	if err != nil {
 		detail := strings.TrimSpace(string(out))
 		if detail == "" {
@@ -2152,11 +2131,7 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 			l.recordPaneSpawnFailure(visible[i].Slug, fmt.Sprintf("claudeCommand: %v", err))
 			continue
 		}
-		out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "split-window",
-			"-t", l.sessionName+":team.1",
-			"-c", l.cwd,
-			agentCmd,
-		).CombinedOutput()
+		out, err := panes.SplitAdditionalAgent(l.cwd, agentCmd)
 		if err != nil {
 			detail := strings.TrimSpace(string(out))
 			reason := err.Error()
@@ -2173,39 +2148,30 @@ func (l *Launcher) spawnVisibleAgents() ([]string, error) {
 
 	// Apply tiled layout to agent panes, but keep channel (pane 0) as main-vertical
 	// Use main-vertical first to keep channel on the left
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-layout",
-		"-t", l.sessionName+":team",
-		"main-vertical",
-	).Run()
+	panes.ApplyMainVerticalLayout()
 
 	// Now set pane titles
 	var visibleSlugs []string
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
-		"-t", l.sessionName+":team.0",
-		"-T", "📢 channel",
-	).Run()
+	panes.SetPaneTitle(channelPane, "📢 channel")
 	for i, a := range visible {
 		paneIdx := i + 1 // pane 0 is channel
 		name := l.getAgentName(a.Slug)
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
-			"-t", fmt.Sprintf("%s:team.%d", l.sessionName, paneIdx),
-			"-T", fmt.Sprintf("🤖 %s (@%s)", name, a.Slug),
-		).Run()
+		panes.SetPaneTitle(
+			fmt.Sprintf("%s:team.%d", l.sessionName, paneIdx),
+			fmt.Sprintf("🤖 %s (@%s)", name, a.Slug),
+		)
 		visibleSlugs = append(visibleSlugs, a.Slug)
 	}
 
 	// Focus channel pane
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-window",
-		"-t", l.sessionName+":team",
-	).Run()
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "select-pane",
-		"-t", l.sessionName+":team.0",
-	).Run()
+	panes.SelectTeamWindow()
+	panes.FocusPane(channelPane)
 
 	return visibleSlugs, nil
 }
 
 func (l *Launcher) spawnOverflowAgents() {
+	panes := l.panes()
 	for _, member := range l.overflowOfficeMembers() {
 		// Codex/Opencode-bound agents use the headless one-shot pipeline; they
 		// don't need a claude pane. Creating one would launch `claude` with
@@ -2220,12 +2186,7 @@ func (l *Launcher) spawnOverflowAgents() {
 			continue
 		}
 		windowName := overflowWindowName(member.Slug)
-		out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "new-window", "-d",
-			"-t", l.sessionName,
-			"-n", windowName,
-			"-c", l.cwd,
-			agentCmd,
-		).CombinedOutput()
+		out, err := panes.NewOverflowWindow(windowName, l.cwd, agentCmd)
 		if err != nil {
 			detail := strings.TrimSpace(string(out))
 			reason := err.Error()
@@ -2249,24 +2210,19 @@ func (l *Launcher) detectDeadPanesAfterSpawn(members []officeMember) {
 		return
 	}
 	time.Sleep(1500 * time.Millisecond)
+	panes := l.panes()
 	targets := l.agentPaneTargets()
 	for _, m := range members {
 		target, ok := targets[m.Slug]
 		if !ok || target.PaneTarget == "" {
 			continue
 		}
-		out, err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "display-message",
-			"-t", target.PaneTarget,
-			"-p", "#{pane_dead}",
-		).CombinedOutput()
-		if err != nil || strings.TrimSpace(string(out)) != "1" {
+		dead, err := panes.IsPaneDead(target.PaneTarget)
+		if err != nil || !dead {
 			continue
 		}
-		history, _ := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "capture-pane",
-			"-t", target.PaneTarget,
-			"-p", "-J", "-S", "-200",
-		).CombinedOutput()
-		snippet := strings.TrimSpace(string(history))
+		history, _ := panes.CapturePaneHistory(target.PaneTarget, 200)
+		snippet := strings.TrimSpace(history)
 		if len(snippet) > 400 {
 			snippet = snippet[:400] + "..."
 		}
@@ -2322,40 +2278,30 @@ func (l *Launcher) trySpawnWebAgentPanes() {
 	if !l.usesPaneRuntime() {
 		return
 	}
-	if _, err := exec.LookPath("tmux"); err != nil {
+	panes := l.panes()
+	if err := panes.TmuxAvailable(); err != nil {
 		l.reportPaneFallback(false, "tmux not found on PATH", err)
 		return
 	}
 
 	// Remove any stale session from a previous run. Ignore errors — the common
 	// case is "no such session".
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+	panes.KillSession()
 
 	// Create a detached session with a placeholder pane 0. Agent panes are
 	// attached as splits afterward so agentPaneTargets() (which starts at
 	// team.1) maps correctly.
 	placeholderCmd := "sh -c 'while :; do sleep 3600; done'"
-	if err := exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "new-session", "-d",
-		"-s", l.sessionName,
-		"-n", "team",
-		"-c", l.cwd,
-		placeholderCmd,
-	).Run(); err != nil {
+	if err := panes.NewSession(l.cwd, placeholderCmd); err != nil {
 		l.reportPaneFallback(true, "tmux new-session failed", err)
 		return
 	}
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
-		"mouse", "off",
-	).Run()
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-option", "-t", l.sessionName,
-		"status", "off",
-	).Run()
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "set-window-option", "-t", l.sessionName+":team",
-		"remain-on-exit", "on",
-	).Run()
+	panes.SetSessionOption("mouse", "off")
+	panes.SetSessionOption("status", "off")
+	panes.SetTeamWindowOption("remain-on-exit", "on")
 
 	if _, err := l.spawnVisibleAgents(); err != nil {
-		_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+		panes.KillSession()
 		l.reportPaneFallback(true, "spawn visible agents failed", err)
 		return
 	}

--- a/internal/team/pane_lifecycle.go
+++ b/internal/team/pane_lifecycle.go
@@ -12,6 +12,7 @@ package team
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -195,6 +196,172 @@ func (p *paneLifecycle) RespawnChannelPane(channelCmd, cwd string) {
 		"-t", target,
 		"-T", "📢 channel",
 	)
+}
+
+// SplitFirstAgent runs `tmux split-window -h -t session:team -p 65 -c
+// cwd cmd` — the layout primitive that creates pane 1 (the first
+// agent) to the right of the channel pane (pane 0). Combined output is
+// returned so callers can surface tmux's stderr in their own error
+// messages.
+func (p *paneLifecycle) SplitFirstAgent(cwd, cmd string) ([]byte, error) {
+	return p.runner.Combined("split-window", "-h",
+		"-t", p.sessionName+":team",
+		"-p", "65",
+		"-c", cwd,
+		cmd,
+	)
+}
+
+// SplitAdditionalAgent runs `tmux split-window -t session:team.1 -c cwd
+// cmd` — adds a pane that the subsequent main-vertical layout will
+// arrange next to the existing agent panes. Combined output is returned
+// so callers can surface tmux's error text.
+func (p *paneLifecycle) SplitAdditionalAgent(cwd, cmd string) ([]byte, error) {
+	return p.runner.Combined("split-window",
+		"-t", p.sessionName+":team.1",
+		"-c", cwd,
+		cmd,
+	)
+}
+
+// NewOverflowWindow runs `tmux new-window -d -t session -n name -c cwd
+// cmd` — creates a hidden ("-d") window for an overflow agent that
+// doesn't fit in the visible team grid. Combined output is returned so
+// callers can surface tmux's error text in failure messages.
+func (p *paneLifecycle) NewOverflowWindow(windowName, cwd, cmd string) ([]byte, error) {
+	return p.runner.Combined("new-window", "-d",
+		"-t", p.sessionName,
+		"-n", windowName,
+		"-c", cwd,
+		cmd,
+	)
+}
+
+// NewSession runs `tmux new-session -d -s session -n team -c cwd cmd`
+// to create the detached session that hosts the team window. Returns
+// the exec error directly because the calling code (trySpawnWebAgentPanes)
+// converts a non-nil result into a "tmux new-session failed" fallback.
+func (p *paneLifecycle) NewSession(cwd, placeholderCmd string) error {
+	return p.runner.Run("new-session", "-d",
+		"-s", p.sessionName,
+		"-n", "team",
+		"-c", cwd,
+		placeholderCmd,
+	)
+}
+
+// SetSessionOption applies a tmux session-level option (e.g.
+// `set-option -t session mouse off`). Errors are intentionally
+// dropped — these are cosmetic / interactivity tweaks that don't gate
+// the launch.
+func (p *paneLifecycle) SetSessionOption(name, value string) {
+	_ = p.runner.Run("set-option",
+		"-t", p.sessionName,
+		name, value,
+	)
+}
+
+// SetTeamWindowOption applies a tmux window-level option scoped to the
+// "team" window (e.g. `set-window-option -t session:team
+// remain-on-exit on`). Errors dropped — same rationale as
+// SetSessionOption.
+func (p *paneLifecycle) SetTeamWindowOption(name, value string) {
+	_ = p.runner.Run("set-window-option",
+		"-t", p.sessionName+":team",
+		name, value,
+	)
+}
+
+// ApplyMainVerticalLayout selects the `main-vertical` tmux layout for
+// the team window. Re-applied after each pane add so the channel
+// (pane 0) stays on the left and agent panes tile vertically on the
+// right. Errors dropped — layout failures aren't recoverable here, and
+// retrying on the next pane add usually fixes them.
+func (p *paneLifecycle) ApplyMainVerticalLayout() {
+	_ = p.runner.Run("select-layout",
+		"-t", p.sessionName+":team",
+		"main-vertical",
+	)
+}
+
+// SetPaneTitle re-titles a pane via `select-pane -t target -T title`.
+// Errors dropped — titles are cosmetic and a transient tmux failure
+// shouldn't fail the launch.
+func (p *paneLifecycle) SetPaneTitle(target, title string) {
+	_ = p.runner.Run("select-pane",
+		"-t", target,
+		"-T", title,
+	)
+}
+
+// SelectTeamWindow runs `tmux select-window -t session:team`. Used to
+// raise the team window after pane adds so the user lands in the
+// expected place when attaching. Errors dropped.
+func (p *paneLifecycle) SelectTeamWindow() {
+	_ = p.runner.Run("select-window",
+		"-t", p.sessionName+":team",
+	)
+}
+
+// FocusPane runs `tmux select-pane -t target` (without -T). Used to
+// focus the channel pane after the spawn flow so the user lands there
+// instead of in an agent pane. Errors dropped.
+func (p *paneLifecycle) FocusPane(target string) {
+	_ = p.runner.Run("select-pane",
+		"-t", target,
+	)
+}
+
+// IsPaneDead reads `#{pane_dead}` for target via display-message.
+// Returns (true, nil) when tmux reports "1", (false, nil) when "0", and
+// the parse-or-exec error otherwise. Used by detectDeadPanesAfterSpawn
+// to decide whether a freshly-spawned agent pane crashed at startup.
+func (p *paneLifecycle) IsPaneDead(target string) (bool, error) {
+	out, err := p.runner.Combined("display-message",
+		"-t", target,
+		"-p", "#{pane_dead}",
+	)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) == "1", nil
+}
+
+// CapturePaneHistory captures the last `lines` rows of pane scrollback
+// at target via `capture-pane -t target -p -J -S -<lines>`. Used by
+// detectDeadPanesAfterSpawn to surface the last output of a dead pane
+// in the headless-fallback warning so the user has a hint about why it
+// died.
+func (p *paneLifecycle) CapturePaneHistory(target string, lines int) (string, error) {
+	out, err := p.runner.Combined("capture-pane",
+		"-t", target,
+		"-p", "-J", "-S", fmt.Sprintf("-%d", lines),
+	)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// SendEnter sends a single Enter keypress to the target pane via
+// `send-keys -t target Enter`. Used by primeVisibleAgents to clear
+// claude's startup confirmation prompts so dispatch can type into the
+// pane.
+func (p *paneLifecycle) SendEnter(target string) {
+	_ = p.runner.Run("send-keys",
+		"-t", target,
+		"Enter",
+	)
+}
+
+// TmuxAvailable returns nil when the tmux binary is on PATH, or the
+// LookPath error when not. Wrapper around exec.LookPath so the runner
+// seam is not bypassed for the "is tmux installed?" check (although
+// LookPath itself does not go through the runner — there's nothing
+// useful to fake about a binary lookup).
+func (p *paneLifecycle) TmuxAvailable() error {
+	_, err := exec.LookPath("tmux")
+	return err
 }
 
 // CaptureDeadChannelPane writes a timestamped snapshot of the channel

--- a/internal/team/pane_lifecycle_spawn_test.go
+++ b/internal/team/pane_lifecycle_spawn_test.go
@@ -1,0 +1,264 @@
+package team
+
+// Tests for the C5d migration: spawn-side tmux helpers added to
+// paneLifecycle (SplitFirstAgent, SplitAdditionalAgent, NewOverflowWindow,
+// NewSession, SetSessionOption, SetTeamWindowOption,
+// ApplyMainVerticalLayout, SetPaneTitle, SelectTeamWindow, FocusPane,
+// IsPaneDead, CapturePaneHistory, SendEnter). High-level spawn
+// orchestration (spawnVisibleAgents/etc.) is not covered here — those
+// methods need callbacks for claudeCommand/buildPrompt/broker access
+// that come in a follow-up ownership PR. The helper tests pin the exact
+// tmux args every spawn path emits, which is the value those tests
+// would have provided anyway.
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPaneLifecycle_SplitFirstAgentArgs(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["split-window"] = []byte("ok")
+	setTmuxRunnerForTest(t, fake)
+
+	out, err := newPaneLifecycle("wuphf-team").SplitFirstAgent("/repo", "claude --print")
+	if err != nil {
+		t.Fatalf("SplitFirstAgent err = %v", err)
+	}
+	if string(out) != "ok" {
+		t.Errorf("output = %q, want ok", out)
+	}
+	calls := fake.callsFor("split-window")
+	if len(calls) != 1 {
+		t.Fatalf("split-window calls = %d, want 1", len(calls))
+	}
+	want := []string{"split-window", "-h", "-t", "wuphf-team:team", "-p", "65", "-c", "/repo", "claude --print"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("split-window args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_SplitAdditionalAgentArgs(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	if _, err := newPaneLifecycle("wuphf-team").SplitAdditionalAgent("/repo", "claude"); err != nil {
+		t.Fatalf("SplitAdditionalAgent err = %v", err)
+	}
+	calls := fake.callsFor("split-window")
+	if len(calls) != 1 {
+		t.Fatalf("split-window calls = %d, want 1", len(calls))
+	}
+	// Note: no -h flag — additional agents tile vertically on the right.
+	// Note: no -p flag — additional agents take whatever default split
+	// percentage tmux gives them, then ApplyMainVerticalLayout normalizes.
+	want := []string{"split-window", "-t", "wuphf-team:team.1", "-c", "/repo", "claude"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_NewOverflowWindowArgs(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	if _, err := newPaneLifecycle("wuphf-team").NewOverflowWindow("agent-fe", "/repo", "claude"); err != nil {
+		t.Fatalf("NewOverflowWindow err = %v", err)
+	}
+	calls := fake.callsFor("new-window")
+	if len(calls) != 1 {
+		t.Fatalf("new-window calls = %d, want 1", len(calls))
+	}
+	want := []string{"new-window", "-d", "-t", "wuphf-team", "-n", "agent-fe", "-c", "/repo", "claude"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_NewSessionArgs(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	if err := newPaneLifecycle("wuphf-team").NewSession("/repo", "sleep infinity"); err != nil {
+		t.Fatalf("NewSession err = %v", err)
+	}
+	calls := fake.callsFor("new-session")
+	if len(calls) != 1 {
+		t.Fatalf("new-session calls = %d, want 1", len(calls))
+	}
+	want := []string{"new-session", "-d", "-s", "wuphf-team", "-n", "team", "-c", "/repo", "sleep infinity"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_NewSessionSurfacesError(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.errors["new-session"] = fmt.Errorf("session exists")
+	setTmuxRunnerForTest(t, fake)
+
+	if err := newPaneLifecycle("wuphf-team").NewSession("/repo", "sleep infinity"); err == nil {
+		t.Fatal("NewSession err = nil, want non-nil")
+	}
+}
+
+func TestPaneLifecycle_SetSessionOptionArgs(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	newPaneLifecycle("wuphf-team").SetSessionOption("mouse", "off")
+	calls := fake.callsFor("set-option")
+	if len(calls) != 1 {
+		t.Fatalf("set-option calls = %d, want 1", len(calls))
+	}
+	want := []string{"set-option", "-t", "wuphf-team", "mouse", "off"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_SetTeamWindowOptionArgs(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	newPaneLifecycle("wuphf-team").SetTeamWindowOption("remain-on-exit", "on")
+	calls := fake.callsFor("set-window-option")
+	if len(calls) != 1 {
+		t.Fatalf("set-window-option calls = %d, want 1", len(calls))
+	}
+	want := []string{"set-window-option", "-t", "wuphf-team:team", "remain-on-exit", "on"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_ApplyMainVerticalLayoutArgs(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	newPaneLifecycle("wuphf-team").ApplyMainVerticalLayout()
+	calls := fake.callsFor("select-layout")
+	if len(calls) != 1 {
+		t.Fatalf("select-layout calls = %d, want 1", len(calls))
+	}
+	want := []string{"select-layout", "-t", "wuphf-team:team", "main-vertical"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_SetPaneTitleArgs(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	newPaneLifecycle("wuphf-team").SetPaneTitle("wuphf-team:team.2", "🤖 ceo (@ceo)")
+	calls := fake.callsFor("select-pane")
+	if len(calls) != 1 {
+		t.Fatalf("select-pane calls = %d, want 1", len(calls))
+	}
+	want := []string{"select-pane", "-t", "wuphf-team:team.2", "-T", "🤖 ceo (@ceo)"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_SelectTeamWindowAndFocusPane(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	pl := newPaneLifecycle("wuphf-team")
+	pl.SelectTeamWindow()
+	pl.FocusPane("wuphf-team:team.0")
+
+	wins := fake.callsFor("select-window")
+	if len(wins) != 1 {
+		t.Fatalf("select-window calls = %d, want 1", len(wins))
+	}
+	if !equalStrings(wins[0], []string{"select-window", "-t", "wuphf-team:team"}) {
+		t.Errorf("select-window args = %v", wins[0])
+	}
+
+	panes := fake.callsFor("select-pane")
+	if len(panes) != 1 {
+		t.Fatalf("select-pane calls = %d, want 1", len(panes))
+	}
+	// FocusPane has no -T flag (vs SetPaneTitle)
+	if !equalStrings(panes[0], []string{"select-pane", "-t", "wuphf-team:team.0"}) {
+		t.Errorf("select-pane (focus) args = %v", panes[0])
+	}
+}
+
+func TestPaneLifecycle_IsPaneDeadParsesOutput(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["display-message"] = []byte("1\n")
+	setTmuxRunnerForTest(t, fake)
+
+	dead, err := newPaneLifecycle("wuphf-team").IsPaneDead("wuphf-team:team.2")
+	if err != nil {
+		t.Fatalf("IsPaneDead err = %v", err)
+	}
+	if !dead {
+		t.Errorf("IsPaneDead = false, want true")
+	}
+
+	calls := fake.callsFor("display-message")
+	if len(calls) != 1 {
+		t.Fatalf("display-message calls = %d, want 1", len(calls))
+	}
+	want := []string{"display-message", "-t", "wuphf-team:team.2", "-p", "#{pane_dead}"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_IsPaneDeadFalseWhenZero(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["display-message"] = []byte("0\n")
+	setTmuxRunnerForTest(t, fake)
+
+	dead, err := newPaneLifecycle("wuphf-team").IsPaneDead("wuphf-team:team.2")
+	if err != nil {
+		t.Fatalf("IsPaneDead err = %v", err)
+	}
+	if dead {
+		t.Errorf("IsPaneDead = true, want false")
+	}
+}
+
+func TestPaneLifecycle_CapturePaneHistoryArgs(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["capture-pane"] = []byte("last 200 lines\n")
+	setTmuxRunnerForTest(t, fake)
+
+	out, err := newPaneLifecycle("wuphf-team").CapturePaneHistory("wuphf-team:team.2", 200)
+	if err != nil {
+		t.Fatalf("CapturePaneHistory err = %v", err)
+	}
+	if out != "last 200 lines\n" {
+		t.Errorf("output = %q, want %q", out, "last 200 lines\n")
+	}
+	calls := fake.callsFor("capture-pane")
+	if len(calls) != 1 {
+		t.Fatalf("capture-pane calls = %d, want 1", len(calls))
+	}
+	want := []string{"capture-pane", "-t", "wuphf-team:team.2", "-p", "-J", "-S", "-200"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("args = %v, want %v", calls[0], want)
+	}
+}
+
+func TestPaneLifecycle_SendEnterArgs(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	newPaneLifecycle("wuphf-team").SendEnter("wuphf-team:team.2")
+
+	calls := fake.callsFor("send-keys")
+	if len(calls) != 1 {
+		t.Fatalf("send-keys calls = %d, want 1", len(calls))
+	}
+	want := []string{"send-keys", "-t", "wuphf-team:team.2", "Enter"}
+	if !equalStrings(calls[0], want) {
+		t.Errorf("args = %v, want %v", calls[0], want)
+	}
+}


### PR DESCRIPTION
## Summary

Stacked on **#445 (C5c, write-side migration)**. Final tmux-routing pass
for PLAN.md §C5: every direct ` + "`exec.CommandContext(\"tmux\", ...)`" + ` call
in the spawn cluster now routes through the ` + "`tmuxRunner`" + ` seam.

## What lands

### 14 new ` + "`paneLifecycle`" + ` helpers

| Helper | tmux command | Used by |
|---|---|---|
| ` + "`SplitFirstAgent(cwd, cmd)`" + ` | ` + "`split-window -h -t session:team -p 65 -c cwd cmd`" + ` | spawnVisibleAgents (one-on-one + first visible) |
| ` + "`SplitAdditionalAgent(cwd, cmd)`" + ` | ` + "`split-window -t session:team.1 -c cwd cmd`" + ` | spawnVisibleAgents loop |
| ` + "`NewOverflowWindow(name, cwd, cmd)`" + ` | ` + "`new-window -d -t session -n name -c cwd cmd`" + ` | spawnOverflowAgents |
| ` + "`NewSession(cwd, cmd)`" + ` | ` + "`new-session -d -s session -n team -c cwd cmd`" + ` | trySpawnWebAgentPanes |
| ` + "`SetSessionOption(name, value)`" + ` | ` + "`set-option -t session name value`" + ` | trySpawnWebAgentPanes (mouse, status) |
| ` + "`SetTeamWindowOption(name, value)`" + ` | ` + "`set-window-option -t session:team`" + ` | trySpawnWebAgentPanes (remain-on-exit) |
| ` + "`ApplyMainVerticalLayout()`" + ` | ` + "`select-layout -t session:team main-vertical`" + ` | spawnVisibleAgents |
| ` + "`SetPaneTitle(target, title)`" + ` | ` + "`select-pane -t target -T title`" + ` | spawnVisibleAgents (titles) |
| ` + "`SelectTeamWindow()`" + ` | ` + "`select-window -t session:team`" + ` | spawnVisibleAgents (focus) |
| ` + "`FocusPane(target)`" + ` | ` + "`select-pane -t target`" + ` (no -T) | spawnVisibleAgents (focus) |
| ` + "`IsPaneDead(target) (bool, error)`" + ` | ` + "`display-message -t target -p #{pane_dead}`" + ` | detectDeadPanesAfterSpawn |
| ` + "`CapturePaneHistory(target, lines)`" + ` | ` + "`capture-pane -t target -p -J -S -<lines>`" + ` | detectDeadPanesAfterSpawn |
| ` + "`SendEnter(target)`" + ` | ` + "`send-keys -t target Enter`" + ` | primeVisibleAgents |
| ` + "`TmuxAvailable() error`" + ` | ` + "`exec.LookPath(\"tmux\")`" + ` | trySpawnWebAgentPanes |

### Spawn methods rewritten (all on Launcher; bodies now route through helpers)

* ` + "`spawnVisibleAgents`" + ` — one-on-one path + multi-agent loop. 14 raw exec calls → 14 helper calls.
* ` + "`spawnOverflowAgents`" + ` — overflow window creation per agent.
* ` + "`detectDeadPanesAfterSpawn`" + ` — display-message + capture-pane both routed.
* ` + "`trySpawnWebAgentPanes`" + ` — LookPath, kill-session, new-session, three set-options, fail-back kill-session.
* ` + "`primeVisibleAgents`" + ` — capture-pane (already routed in C5b) + send-keys Enter.

### What stayed on Launcher (deliberately)

The high-level orchestration methods themselves stay because they also
touch:

1. **broker writes** (` + "`broker.PostSystemMessage`" + ` in detectDeadPanesAfterSpawn / reportPaneFallback)
2. **shared ` + "`failedPaneSlugs`" + ` map** (PLAN.md trap §1) — read by ` + "`officeTargeter`" + `, written by ` + "`recordPaneSpawnFailure`" + `
3. **Launcher methods** like ` + "`claudeCommand`" + ` / ` + "`buildPrompt`" + ` / ` + "`agentPaneTargets`" + ` / ` + "`memberUsesHeadlessOneShotRuntime`" + `

Moving full ownership onto ` + "`paneLifecycle`" + ` requires either threading
those callbacks (8+ for spawnVisibleAgents alone) or reshaping how the
targeter sees ` + "`failedPaneSlugs`" + ` ownership — both are bigger than this
PR's scope. They land in a focused **C5e ownership consolidation**
follow-up after this routing soaks in CI. The value of *this* PR is
that all tmux calls now flow through ` + "`runner`" + `, so the seam is complete.

## Tests (13 new)

All driven through ` + "`fakeTmuxRunner`" + ` from C5b. The tests pin the
exact tmux args each helper emits, which is the value the
high-level-method tests would have provided once we add them. Notable
asymmetries pinned:

* ` + "`SplitFirstAgent`" + ` (` + "`-h -p 65`" + `) vs ` + "`SplitAdditionalAgent`" + ` (no flags)
* ` + "`SelectTeamWindow`" + ` (` + "`select-window`" + `) vs ` + "`FocusPane`" + ` (` + "`select-pane`" + ` without -T)
* ` + "`IsPaneDead`" + ` returns true on \"1\\n\", false on \"0\\n\"

Zero ` + "`time.Sleep`" + `.

## Coverage

12 new helpers at **100%**. Two at 75%:

* ` + "`IsPaneDead`" + ` — error branch not exercised (non-error path covered)
* ` + "`CapturePaneHistory`" + ` — same

One at **0%**:

* ` + "`TmuxAvailable`" + ` — wraps ` + "`exec.LookPath`" + `; testing it would require
  manipulating ` + "`PATH`" + ` and a fake tmux binary, which adds noise without
  meaningful coverage. Production exercises it on every pane-mode launch.

Package ` + "`internal/team`" + `: 64.0% → **64.1%**.

## Diff shape

| File | Δ |
|---|---:|
| ` + "`launcher.go`" + ` | 2988 → 2934 (−54) |
| ` + "`pane_lifecycle.go`" + ` | +167 |
| ` + "`pane_lifecycle_spawn_test.go`" + ` | +264 (new) |

**Cumulative since main: 4998 → 2934 = −2064 lines (−41.3%).**

## Local CI matrix (all green)

* ` + "`gofmt -s -l`" + ` clean
* ` + "`golangci-lint run ./internal/team/...`" + ` 0 issues
* ` + "`go test -race -timeout 15m ./internal/team`" + ` 86s
* ` + "`bash scripts/test-go.sh`" + ` — **all 32 packages green**
* Cross-compile windows-amd64 + darwin-arm64 — clean
* Smoke binary OK

## Test plan

- [x] ` + "`go build ./...`" + `
- [x] All 13 new tests pass
- [x] Existing tests still green
- [x] ` + "`bash scripts/test-go.sh`" + ` (all 32 packages green)
- [ ] CI green

## What's next

**C5e — ownership consolidation**. Now that all tmux calls route
through the seam, the spawn methods can move from Launcher onto
` + "`paneLifecycle`" + ` proper. Required threading:

* claudeCommand / buildPrompt / getAgentName as callbacks
* visibleOfficeMembers / overflowOfficeMembers / agentPaneTargets as callbacks (or a ` + "`*officeTargeter`" + ` reference, since it already owns these)
* memberUsesHeadlessOneShotRuntime as callback
* recordFailure callback (so ` + "`failedPaneSlugs`" + ` writes still flow into the same map the targeter reads — PLAN.md trap §1)
* broker pointer (or a focused ` + "`PostSystemMessage`" + ` callback)
* paneBackedFlag pointer (already a ` + "`*bool`" + ` pattern in officeTargeter)

After C5e the Launcher loses spawnVisibleAgents/spawnOverflowAgents/
detectDeadPanesAfterSpawn/trySpawnWebAgentPanes/primeVisibleAgents
entirely, and the cluster is fully owned by paneLifecycle.

Then the **wrapper consolidation sweep** (PLAN.md §6) deletes the
~150 transitional one-line wrappers across C2-C7.