### PR TITLE
refactor(team): move spawn orchestration onto paneLifecycle (C5e)

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -1265,36 +1265,12 @@ func (l *Launcher) captureDeadChannelPane(status string) error {
 
 // primeVisibleAgents clears Claude startup interactivity in newly spawned panes and
 // replays a catch-up channel nudge once they are actually ready to read it.
+// primeVisibleAgents delegates the pane-priming loop to paneLifecycle
+// (PLAN.md §C5e), then runs the launcher-side replay-catchup so the
+// first message that arrived during claude's startup window isn't lost
+// behind the trust prompt.
 func (l *Launcher) primeVisibleAgents() {
-	time.Sleep(1 * time.Second)
-
-	targets := l.agentPaneTargets()
-	if len(targets) == 0 {
-		return
-	}
-
-	panes := l.panes()
-	for attempt := 0; attempt < 3; attempt++ {
-		allReady := true
-		for _, target := range targets {
-			content, err := panes.CapturePaneTargetContent(target.PaneTarget)
-			if err != nil {
-				allReady = false
-				continue
-			}
-			if shouldPrimeClaudePane(content) {
-				panes.SendEnter(target.PaneTarget)
-				allReady = false
-			}
-		}
-		if allReady {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
-
-	// If the human already posted while Claude was still booting, replay a catch-up nudge
-	// so the first visible message is not lost forever behind the startup interactivity.
+	l.panes().PrimeVisibleAgents()
 	if l.broker == nil {
 		return
 	}
@@ -1963,6 +1939,12 @@ func (l *Launcher) paneDispatch() *paneDispatcher {
 // paneLifecycle bound to the package-level SessionName so the
 // HasLiveTmuxSession free function can route through the same path
 // without a Launcher.
+//
+// Spawn orchestration (PLAN.md §C5e) requires the full paneLifecycleDeps
+// callbacks. Building those closures here means Launcher state (broker,
+// failedPaneSlugs, paneBackedAgents flag, targeter delegates) flows
+// into paneLifecycle without paneLifecycle reaching back into the
+// Launcher type.
 func (l *Launcher) panes() *paneLifecycle {
 	if l == nil {
 		return newPaneLifecycle(SessionName)
@@ -1974,7 +1956,33 @@ func (l *Launcher) panes() *paneLifecycle {
 	if name == "" {
 		name = SessionName
 	}
-	l.paneLC = newPaneLifecycle(name)
+	deps := paneLifecycleDeps{
+		cwd:                              l.cwd,
+		isOneOnOne:                       l.isOneOnOne,
+		oneOnOneAgent:                    l.oneOnOneAgent,
+		usesPaneRuntime:                  l.usesPaneRuntime,
+		visibleOfficeMembers:             l.visibleOfficeMembers,
+		overflowOfficeMembers:            l.overflowOfficeMembers,
+		agentPaneTargets:                 l.agentPaneTargets,
+		memberUsesHeadlessOneShotRuntime: l.memberUsesHeadlessOneShotRuntime,
+		claudeCommand:                    l.claudeCommand,
+		buildPrompt:                      l.buildPrompt,
+		agentName:                        l.getAgentName,
+		recordFailure:                    l.recordPaneSpawnFailure,
+		paneBackedFlag:                   &l.paneBackedAgents,
+	}
+	if l.broker != nil {
+		// Capture the pointer at construction so the deps closure
+		// remains stable even if `l.broker` is reassigned later.
+		// Production never reassigns broker after Launch(), but tests
+		// build &Launcher{} fixtures and want the captured pointer to
+		// match the broker they wired.
+		broker := l.broker
+		deps.postSystemMessage = func(channel, body, kind string) {
+			broker.PostSystemMessage(channel, body, kind)
+		}
+	}
+	l.paneLC = newPaneLifecycleWithDeps(name, deps)
 	return l.paneLC
 }
 
@@ -2066,178 +2074,29 @@ func HasLiveTmuxSession() bool {
 	return newPaneLifecycle(SessionName).HasLiveSession()
 }
 
+// spawnVisibleAgents / spawnOverflowAgents / detectDeadPanesAfterSpawn /
+// trySpawnWebAgentPanes / reportPaneFallback delegate to paneLifecycle
+// (PLAN.md §C5e). The orchestration bodies moved onto the type via
+// paneLifecycleDeps so `failedPaneSlugs` writes still flow into the
+// same map the targeter reads (PLAN.md trap §1).
 func (l *Launcher) spawnVisibleAgents() ([]string, error) {
-	panes := l.panes()
-	channelPane := l.sessionName + ":team.0"
-	if l.isOneOnOne() {
-		slug := l.oneOnOneAgent()
-		firstCmd, err := l.claudeCommand(slug, l.buildPrompt(slug))
-		if err != nil {
-			return nil, err
-		}
-		out, err := panes.SplitFirstAgent(l.cwd, firstCmd)
-		if err != nil {
-			detail := strings.TrimSpace(string(out))
-			if detail == "" {
-				return nil, fmt.Errorf("spawn one-on-one agent: %w", err)
-			}
-			return nil, fmt.Errorf("spawn one-on-one agent: %w (tmux: %s)", err, detail)
-		}
-		panes.ApplyMainVerticalLayout()
-		panes.SetPaneTitle(channelPane, "📢 direct")
-		panes.SetPaneTitle(fmt.Sprintf("%s:team.1", l.sessionName),
-			fmt.Sprintf("🤖 %s (@%s)", l.getAgentName(slug), slug),
-		)
-		panes.SelectTeamWindow()
-		panes.FocusPane(channelPane)
-		return []string{slug}, nil
-	}
-
-	// Layout: channel (left 35%) | agents in 2-column grid (right 65%)
-	//
-	// ┌─ channel ──┬─ CEO ───┬─ PM ────┐
-	// │            │         │         │
-	// │            ├─ FE ────┼─ BE ────┤
-	// │            │         │         │
-	// └────────────┴─────────┴─────────┘
-
-	visible := l.visibleOfficeMembers()
-
-	// First agent: split right from channel (horizontal split)
-	if len(visible) == 0 {
-		return nil, nil
-	}
-	firstCmd, err := l.claudeCommand(visible[0].Slug, l.buildPrompt(visible[0].Slug))
-	if err != nil {
-		return nil, err
-	}
-	out, err := panes.SplitFirstAgent(l.cwd, firstCmd)
-	if err != nil {
-		detail := strings.TrimSpace(string(out))
-		if detail == "" {
-			return nil, fmt.Errorf("spawn first agent: %w", err)
-		}
-		return nil, fmt.Errorf("spawn first agent: %w (tmux: %s)", err, detail)
-	}
-
-	// Remaining agents: split from agent area, then use "tiled" layout. First
-	// agent (pane 1) is mandatory — a failure there aborts the whole launch.
-	// Subsequent splits can fail individually (e.g. terminal too small to
-	// accommodate another tile); record the failure and fall those agents
-	// back to headless dispatch so the capture loop doesn't hunt ghost panes.
-	for i := 1; i < len(visible); i++ {
-		agentCmd, err := l.claudeCommand(visible[i].Slug, l.buildPrompt(visible[i].Slug))
-		if err != nil {
-			l.recordPaneSpawnFailure(visible[i].Slug, fmt.Sprintf("claudeCommand: %v", err))
-			continue
-		}
-		out, err := panes.SplitAdditionalAgent(l.cwd, agentCmd)
-		if err != nil {
-			detail := strings.TrimSpace(string(out))
-			reason := err.Error()
-			if detail != "" {
-				reason = fmt.Sprintf("%s (tmux: %s)", reason, detail)
-			}
-			fmt.Fprintf(os.Stderr,
-				"  Agents:  visible pane for %s failed to spawn; falling back to headless (%s)\n",
-				visible[i].Slug, reason,
-			)
-			l.recordPaneSpawnFailure(visible[i].Slug, reason)
-		}
-	}
-
-	// Apply tiled layout to agent panes, but keep channel (pane 0) as main-vertical
-	// Use main-vertical first to keep channel on the left
-	panes.ApplyMainVerticalLayout()
-
-	// Now set pane titles
-	var visibleSlugs []string
-	panes.SetPaneTitle(channelPane, "📢 channel")
-	for i, a := range visible {
-		paneIdx := i + 1 // pane 0 is channel
-		name := l.getAgentName(a.Slug)
-		panes.SetPaneTitle(
-			fmt.Sprintf("%s:team.%d", l.sessionName, paneIdx),
-			fmt.Sprintf("🤖 %s (@%s)", name, a.Slug),
-		)
-		visibleSlugs = append(visibleSlugs, a.Slug)
-	}
-
-	// Focus channel pane
-	panes.SelectTeamWindow()
-	panes.FocusPane(channelPane)
-
-	return visibleSlugs, nil
+	return l.panes().SpawnVisibleAgents()
 }
 
 func (l *Launcher) spawnOverflowAgents() {
-	panes := l.panes()
-	for _, member := range l.overflowOfficeMembers() {
-		// Codex/Opencode-bound agents use the headless one-shot pipeline; they
-		// don't need a claude pane. Creating one would launch `claude` with
-		// the wrong model and quota semantics.
-		if l.memberUsesHeadlessOneShotRuntime(member.Slug) {
-			continue
-		}
-		agentCmd, err := l.claudeCommand(member.Slug, l.buildPrompt(member.Slug))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "spawn overflow agent %s: %v\n", member.Slug, err)
-			l.recordPaneSpawnFailure(member.Slug, fmt.Sprintf("claudeCommand: %v", err))
-			continue
-		}
-		windowName := overflowWindowName(member.Slug)
-		out, err := panes.NewOverflowWindow(windowName, l.cwd, agentCmd)
-		if err != nil {
-			detail := strings.TrimSpace(string(out))
-			reason := err.Error()
-			if detail != "" {
-				reason = fmt.Sprintf("%s (tmux: %s)", reason, detail)
-			}
-			fmt.Fprintf(os.Stderr,
-				"  Agents:  overflow pane for %s failed to spawn; falling back to headless for this agent (%s)\n",
-				member.Slug, reason,
-			)
-			l.recordPaneSpawnFailure(member.Slug, reason)
-		}
-	}
+	l.panes().SpawnOverflowAgents()
 }
 
-// detectDeadPanesAfterSpawn waits briefly for fresh panes to either settle
-// into claude or die on launch. Dead panes are marked failed so subsequent
-// notifications fall back to the headless path instead of polling ghost panes.
 func (l *Launcher) detectDeadPanesAfterSpawn(members []officeMember) {
-	if l == nil || l.sessionName == "" {
-		return
-	}
-	time.Sleep(1500 * time.Millisecond)
-	panes := l.panes()
-	targets := l.agentPaneTargets()
-	for _, m := range members {
-		target, ok := targets[m.Slug]
-		if !ok || target.PaneTarget == "" {
-			continue
-		}
-		dead, err := panes.IsPaneDead(target.PaneTarget)
-		if err != nil || !dead {
-			continue
-		}
-		history, _ := panes.CapturePaneHistory(target.PaneTarget, 200)
-		snippet := strings.TrimSpace(history)
-		if len(snippet) > 400 {
-			snippet = snippet[:400] + "..."
-		}
-		fmt.Fprintf(os.Stderr,
-			"  Agents:  pane for %s (%s) died on launch; falling back to headless. Last output: %q\n",
-			m.Slug, target.PaneTarget, snippet,
-		)
-		l.recordPaneSpawnFailure(m.Slug, "pane died on launch; last output: "+snippet)
-		if l.broker != nil {
-			l.broker.PostSystemMessage("general",
-				fmt.Sprintf("Agent @%s did not start cleanly; running in headless fallback. Check the launcher log for details.", m.Slug),
-				"runtime",
-			)
-		}
-	}
+	l.panes().DetectDeadPanesAfterSpawn(members)
+}
+
+func (l *Launcher) trySpawnWebAgentPanes() {
+	l.panes().TrySpawnWebAgentPanes()
+}
+
+func (l *Launcher) reportPaneFallback(tmuxInstalled bool, summary string, err error) {
+	l.panes().ReportPaneFallback(tmuxInstalled, summary, err)
 }
 
 // recordPaneSpawnFailure marks a slug so agentPaneTargets() omits it and the
@@ -2252,81 +2111,6 @@ func (l *Launcher) recordPaneSpawnFailure(slug, reason string) {
 		l.failedPaneSlugs = make(map[string]string)
 	}
 	l.failedPaneSlugs[slug] = reason
-}
-
-// trySpawnWebAgentPanes attempts to create a detached tmux session with one
-// interactive `claude` pane per agent so message dispatch can type into a live
-// session. This is the internal fallback primitive for web and TUI modes —
-// the default is headless `claude --print` per turn, which Anthropic
-// re-sanctioned in the 2026-04 OpenClaw policy note and runs on the normal
-// subscription quota without a separate extra-usage charge. Nothing in the
-// startup path calls this today; it is reachable for a runtime-promotion
-// fallback (e.g. repeated headless failures) without needing to be wired in
-// advance.
-//
-// On success, l.paneBackedAgents is set to true and dispatch routes through
-// sendNotificationToPane. On any failure (tmux missing, session create failure,
-// spawn error) the method logs the tradeoff, posts a system message to
-// #general, and leaves paneBackedAgents false so the default headless path
-// continues to work.
-func (l *Launcher) trySpawnWebAgentPanes() {
-	if l.broker == nil {
-		return
-	}
-	// Non-pane runtimes (Codex, future Ollama/vLLM/exo/openai-compat) use the
-	// headless pipeline; panes don't apply.
-	if !l.usesPaneRuntime() {
-		return
-	}
-	panes := l.panes()
-	if err := panes.TmuxAvailable(); err != nil {
-		l.reportPaneFallback(false, "tmux not found on PATH", err)
-		return
-	}
-
-	// Remove any stale session from a previous run. Ignore errors — the common
-	// case is "no such session".
-	panes.KillSession()
-
-	// Create a detached session with a placeholder pane 0. Agent panes are
-	// attached as splits afterward so agentPaneTargets() (which starts at
-	// team.1) maps correctly.
-	placeholderCmd := "sh -c 'while :; do sleep 3600; done'"
-	if err := panes.NewSession(l.cwd, placeholderCmd); err != nil {
-		l.reportPaneFallback(true, "tmux new-session failed", err)
-		return
-	}
-	panes.SetSessionOption("mouse", "off")
-	panes.SetSessionOption("status", "off")
-	panes.SetTeamWindowOption("remain-on-exit", "on")
-
-	if _, err := l.spawnVisibleAgents(); err != nil {
-		panes.KillSession()
-		l.reportPaneFallback(true, "spawn visible agents failed", err)
-		return
-	}
-	l.spawnOverflowAgents()
-
-	l.paneBackedAgents = true
-	go l.detectDeadPanesAfterSpawn(append(l.visibleOfficeMembers(), l.overflowOfficeMembers()...))
-	fmt.Printf("  Agents:  interactive Claude panes in tmux session %q (pane-backed fallback active)\n", l.sessionName)
-}
-
-// reportPaneFallback logs a pane-spawn failure and surfaces the billing
-// tradeoff to the web user via a #general system message. Pass
-// tmuxInstalled=false only when the failure was "tmux not on PATH"; any
-// other failure implies tmux IS installed and rejected our command, which
-// needs different remediation advice.
-func (l *Launcher) reportPaneFallback(tmuxInstalled bool, summary string, err error) {
-	detail := summary
-	if err != nil {
-		detail = fmt.Sprintf("%s: %v", summary, err)
-	}
-	stderrMsg, brokerMsg := paneFallbackMessages(tmuxInstalled, detail)
-	fmt.Fprint(os.Stderr, stderrMsg)
-	if l.broker != nil {
-		l.broker.PostSystemMessage("general", brokerMsg, "runtime")
-	}
 }
 
 // buildPrompt generates the system prompt for an agent. The body lives on

--- a/internal/team/pane_lifecycle.go
+++ b/internal/team/pane_lifecycle.go
@@ -22,25 +22,92 @@ import (
 	"github.com/nex-crm/wuphf/internal/config"
 )
 
+// paneLifecycleDeps wires the Launcher state and methods that the spawn
+// orchestration methods (SpawnVisibleAgents/SpawnOverflowAgents/
+// DetectDeadPanesAfterSpawn/TrySpawnWebAgentPanes/PrimeVisibleAgents)
+// need to consult. All fields are optional — read-only operations that
+// don't touch a particular dependency leave it nil. The deps struct is
+// captured at paneLifecycle construction time so callers (tests + the
+// Launcher) can supply only what they need.
+//
+// Why a struct instead of a wide constructor: the spawn methods need
+// 8+ callbacks each, and a flat constructor would be unreadable at
+// call sites. PLAN.md trap §1 (failedPaneSlugs) is addressed by
+// recordFailure being a callback that writes back into the Launcher's
+// shared map — the targeter still reads from the same map, so its
+// view is unchanged.
+type paneLifecycleDeps struct {
+	// cwd is the working directory tmux uses when spawning agent
+	// processes. Empty in nil-safe / read-only paths.
+	cwd string
+	// isOneOnOne / oneOnOneAgent gate the one-on-one spawn shape.
+	isOneOnOne    func() bool
+	oneOnOneAgent func() string
+	// usesPaneRuntime gates TrySpawnWebAgentPanes. Headless runtimes
+	// short-circuit to nil-op without consulting tmux.
+	usesPaneRuntime func() bool
+	// visibleOfficeMembers / overflowOfficeMembers / agentPaneTargets
+	// come from the targeter (PLAN.md §C2). The targeter already owns
+	// the pane-eligible members + slug→target map; paneLifecycle
+	// reads them through these closures.
+	visibleOfficeMembers  func() []officeMember
+	overflowOfficeMembers func() []officeMember
+	agentPaneTargets      func() map[string]notificationTarget
+	// memberUsesHeadlessOneShotRuntime distinguishes Codex/Opencode
+	// agents (no claude pane) from claude agents inside the spawn loop.
+	memberUsesHeadlessOneShotRuntime func(slug string) bool
+	// claudeCommand / buildPrompt / agentName are Launcher methods
+	// that the spawn loop needs per agent. Wired as callbacks so the
+	// promptBuilder / officeTargeter ownership stays on Launcher.
+	claudeCommand func(slug, prompt string) (string, error)
+	buildPrompt   func(slug string) string
+	agentName     func(slug string) string
+	// recordFailure writes into Launcher.failedPaneSlugs (PLAN.md
+	// trap §1: shared map between targeter and paneLifecycle). Keeping
+	// the write as a callback preserves the targeter's existing read
+	// path through the same map.
+	recordFailure func(slug, reason string)
+	// postSystemMessage forwards to broker.PostSystemMessage when the
+	// broker is set. Nil = no broker available; spawn methods skip
+	// the broker-side notification.
+	postSystemMessage func(channel, body, kind string)
+	// paneBackedFlag is a back-pointer to Launcher.paneBackedAgents.
+	// TrySpawnWebAgentPanes flips it true on success; the targeter
+	// reads it via its own paneBackedFlag *bool to decide routing.
+	paneBackedFlag *bool
+}
+
 // paneLifecycle owns the tmux pane lifecycle (PLAN.md §C5). The runner
 // field is the test seam — production gets realTmuxRunner via
 // newTmuxRunner; tests inject a fakeTmuxRunner via setTmuxRunnerForTest.
-// The type is intentionally tiny in this PR (sessionName + runner) and
-// grows as the spawn/clear methods migrate over.
+// deps wires the spawn orchestration callbacks; they're nil for the
+// nil-safe / read-only paths.
 type paneLifecycle struct {
 	runner      tmuxRunner
 	sessionName string
+	deps        paneLifecycleDeps
 }
 
 // newPaneLifecycle constructs a paneLifecycle bound to a specific tmux
 // session name. The runner is resolved through the package-global
 // override seam at construction time, so a test that calls
 // setTmuxRunnerForTest before constructing the launcher gets its fake
-// runner installed transparently.
+// runner installed transparently. deps is empty (nil callbacks);
+// callers that need spawn orchestration use newPaneLifecycleWithDeps.
 func newPaneLifecycle(sessionName string) *paneLifecycle {
 	return &paneLifecycle{
 		runner:      newTmuxRunner(),
 		sessionName: sessionName,
+	}
+}
+
+// newPaneLifecycleWithDeps is the spawn-capable constructor used by the
+// Launcher. The runner still routes through the override seam.
+func newPaneLifecycleWithDeps(sessionName string, deps paneLifecycleDeps) *paneLifecycle {
+	return &paneLifecycle{
+		runner:      newTmuxRunner(),
+		sessionName: sessionName,
+		deps:        deps,
 	}
 }
 
@@ -362,6 +429,274 @@ func (p *paneLifecycle) SendEnter(target string) {
 func (p *paneLifecycle) TmuxAvailable() error {
 	_, err := exec.LookPath("tmux")
 	return err
+}
+
+// SpawnVisibleAgents creates the visible agent panes (PLAN.md §C5e).
+// One-on-one mode: a single split, channel-pane title becomes "📢
+// direct". Multi-agent mode: first agent split-h-65, additional agents
+// split vertically off pane 1, then main-vertical layout normalizes
+// the column. Returns the slugs of agents whose first split succeeded;
+// later splits may individually fail (recorded via recordFailure
+// callback so the targeter routes those agents headless).
+func (p *paneLifecycle) SpawnVisibleAgents() ([]string, error) {
+	channelPane := p.sessionName + ":team.0"
+	if p.deps.isOneOnOne != nil && p.deps.isOneOnOne() {
+		slug := p.deps.oneOnOneAgent()
+		firstCmd, err := p.deps.claudeCommand(slug, p.deps.buildPrompt(slug))
+		if err != nil {
+			return nil, err
+		}
+		out, err := p.SplitFirstAgent(p.deps.cwd, firstCmd)
+		if err != nil {
+			detail := strings.TrimSpace(string(out))
+			if detail == "" {
+				return nil, fmt.Errorf("spawn one-on-one agent: %w", err)
+			}
+			return nil, fmt.Errorf("spawn one-on-one agent: %w (tmux: %s)", err, detail)
+		}
+		p.ApplyMainVerticalLayout()
+		p.SetPaneTitle(channelPane, "📢 direct")
+		p.SetPaneTitle(fmt.Sprintf("%s:team.1", p.sessionName),
+			fmt.Sprintf("🤖 %s (@%s)", p.deps.agentName(slug), slug),
+		)
+		p.SelectTeamWindow()
+		p.FocusPane(channelPane)
+		return []string{slug}, nil
+	}
+
+	// Layout: channel (left 35%) | agents in 2-column grid (right 65%)
+	//
+	// ┌─ channel ──┬─ CEO ───┬─ PM ────┐
+	// │            │         │         │
+	// │            ├─ FE ────┼─ BE ────┤
+	// │            │         │         │
+	// └────────────┴─────────┴─────────┘
+	visible := p.deps.visibleOfficeMembers()
+	if len(visible) == 0 {
+		return nil, nil
+	}
+	firstCmd, err := p.deps.claudeCommand(visible[0].Slug, p.deps.buildPrompt(visible[0].Slug))
+	if err != nil {
+		return nil, err
+	}
+	out, err := p.SplitFirstAgent(p.deps.cwd, firstCmd)
+	if err != nil {
+		detail := strings.TrimSpace(string(out))
+		if detail == "" {
+			return nil, fmt.Errorf("spawn first agent: %w", err)
+		}
+		return nil, fmt.Errorf("spawn first agent: %w (tmux: %s)", err, detail)
+	}
+
+	// Remaining agents: split from agent area, then use "tiled" layout. First
+	// agent (pane 1) is mandatory — a failure there aborts the whole launch.
+	// Subsequent splits can fail individually (e.g. terminal too small to
+	// accommodate another tile); record the failure and fall those agents
+	// back to headless dispatch so the capture loop doesn't hunt ghost panes.
+	for i := 1; i < len(visible); i++ {
+		agentCmd, err := p.deps.claudeCommand(visible[i].Slug, p.deps.buildPrompt(visible[i].Slug))
+		if err != nil {
+			p.deps.recordFailure(visible[i].Slug, fmt.Sprintf("claudeCommand: %v", err))
+			continue
+		}
+		out, err := p.SplitAdditionalAgent(p.deps.cwd, agentCmd)
+		if err != nil {
+			detail := strings.TrimSpace(string(out))
+			reason := err.Error()
+			if detail != "" {
+				reason = fmt.Sprintf("%s (tmux: %s)", reason, detail)
+			}
+			fmt.Fprintf(os.Stderr,
+				"  Agents:  visible pane for %s failed to spawn; falling back to headless (%s)\n",
+				visible[i].Slug, reason,
+			)
+			p.deps.recordFailure(visible[i].Slug, reason)
+		}
+	}
+
+	p.ApplyMainVerticalLayout()
+
+	var visibleSlugs []string
+	p.SetPaneTitle(channelPane, "📢 channel")
+	for i, a := range visible {
+		paneIdx := i + 1 // pane 0 is channel
+		name := p.deps.agentName(a.Slug)
+		p.SetPaneTitle(
+			fmt.Sprintf("%s:team.%d", p.sessionName, paneIdx),
+			fmt.Sprintf("🤖 %s (@%s)", name, a.Slug),
+		)
+		visibleSlugs = append(visibleSlugs, a.Slug)
+	}
+	p.SelectTeamWindow()
+	p.FocusPane(channelPane)
+	return visibleSlugs, nil
+}
+
+// SpawnOverflowAgents creates a hidden tmux window per overflow agent
+// (PLAN.md §C5e). Overflow agents are members beyond the visible team
+// grid; they still need a live claude pane in pane-backed mode.
+// Codex/Opencode-bound members are skipped because they use the
+// headless one-shot pipeline. Failures are recorded but don't abort —
+// each agent falls back to headless individually.
+func (p *paneLifecycle) SpawnOverflowAgents() {
+	for _, member := range p.deps.overflowOfficeMembers() {
+		if p.deps.memberUsesHeadlessOneShotRuntime(member.Slug) {
+			continue
+		}
+		agentCmd, err := p.deps.claudeCommand(member.Slug, p.deps.buildPrompt(member.Slug))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "spawn overflow agent %s: %v\n", member.Slug, err)
+			p.deps.recordFailure(member.Slug, fmt.Sprintf("claudeCommand: %v", err))
+			continue
+		}
+		windowName := overflowWindowName(member.Slug)
+		out, err := p.NewOverflowWindow(windowName, p.deps.cwd, agentCmd)
+		if err != nil {
+			detail := strings.TrimSpace(string(out))
+			reason := err.Error()
+			if detail != "" {
+				reason = fmt.Sprintf("%s (tmux: %s)", reason, detail)
+			}
+			fmt.Fprintf(os.Stderr,
+				"  Agents:  overflow pane for %s failed to spawn; falling back to headless for this agent (%s)\n",
+				member.Slug, reason,
+			)
+			p.deps.recordFailure(member.Slug, reason)
+		}
+	}
+}
+
+// DetectDeadPanesAfterSpawn waits 1.5s for fresh panes to either settle
+// into claude or die on launch (PLAN.md §C5e). Dead panes are recorded
+// via recordFailure and surface to the user via stderr + a #general
+// system message. The fixed sleep is the same one the original
+// Launcher method had; clock injection is deferred to a follow-up.
+func (p *paneLifecycle) DetectDeadPanesAfterSpawn(members []officeMember) {
+	if p == nil || p.sessionName == "" {
+		return
+	}
+	time.Sleep(1500 * time.Millisecond)
+	targets := p.deps.agentPaneTargets()
+	for _, m := range members {
+		target, ok := targets[m.Slug]
+		if !ok || target.PaneTarget == "" {
+			continue
+		}
+		dead, err := p.IsPaneDead(target.PaneTarget)
+		if err != nil || !dead {
+			continue
+		}
+		history, _ := p.CapturePaneHistory(target.PaneTarget, 200)
+		snippet := strings.TrimSpace(history)
+		if len(snippet) > 400 {
+			snippet = snippet[:400] + "..."
+		}
+		fmt.Fprintf(os.Stderr,
+			"  Agents:  pane for %s (%s) died on launch; falling back to headless. Last output: %q\n",
+			m.Slug, target.PaneTarget, snippet,
+		)
+		p.deps.recordFailure(m.Slug, "pane died on launch; last output: "+snippet)
+		if p.deps.postSystemMessage != nil {
+			p.deps.postSystemMessage("general",
+				fmt.Sprintf("Agent @%s did not start cleanly; running in headless fallback. Check the launcher log for details.", m.Slug),
+				"runtime",
+			)
+		}
+	}
+}
+
+// TrySpawnWebAgentPanes attempts to spawn the full pane-backed
+// fallback session (PLAN.md §C5e). On success flips the
+// paneBackedFlag *bool true so the targeter routes through pane
+// dispatch. On failure, calls reportPaneFallback which prints the
+// stderr banner and posts the broker-side advisory.
+func (p *paneLifecycle) TrySpawnWebAgentPanes() {
+	if p.deps.postSystemMessage == nil {
+		// Production wires postSystemMessage from a non-nil broker;
+		// nil here matches the legacy "broker == nil" early return.
+		return
+	}
+	if p.deps.usesPaneRuntime != nil && !p.deps.usesPaneRuntime() {
+		return
+	}
+	if err := p.TmuxAvailable(); err != nil {
+		p.ReportPaneFallback(false, "tmux not found on PATH", err)
+		return
+	}
+	p.KillSession()
+	placeholderCmd := "sh -c 'while :; do sleep 3600; done'"
+	if err := p.NewSession(p.deps.cwd, placeholderCmd); err != nil {
+		p.ReportPaneFallback(true, "tmux new-session failed", err)
+		return
+	}
+	p.SetSessionOption("mouse", "off")
+	p.SetSessionOption("status", "off")
+	p.SetTeamWindowOption("remain-on-exit", "on")
+
+	if _, err := p.SpawnVisibleAgents(); err != nil {
+		p.KillSession()
+		p.ReportPaneFallback(true, "spawn visible agents failed", err)
+		return
+	}
+	p.SpawnOverflowAgents()
+
+	if p.deps.paneBackedFlag != nil {
+		*p.deps.paneBackedFlag = true
+	}
+	go p.DetectDeadPanesAfterSpawn(append(p.deps.visibleOfficeMembers(), p.deps.overflowOfficeMembers()...))
+	fmt.Printf("  Agents:  interactive Claude panes in tmux session %q (pane-backed fallback active)\n", p.sessionName)
+}
+
+// PrimeVisibleAgents waits for visible agent panes to clear claude's
+// startup interactivity (folder-trust, security-guide, "press Enter")
+// so dispatch can type into the pane. Returns once all panes report
+// ready or after 3 attempts. Replay of the latest broker message
+// (the "first message lost behind startup" recovery) stays on
+// Launcher.primeVisibleAgents because it depends on broker
+// state and the headless-resume path.
+func (p *paneLifecycle) PrimeVisibleAgents() {
+	time.Sleep(1 * time.Second)
+
+	targets := p.deps.agentPaneTargets()
+	if len(targets) == 0 {
+		return
+	}
+
+	for attempt := 0; attempt < 3; attempt++ {
+		allReady := true
+		for _, target := range targets {
+			content, err := p.CapturePaneTargetContent(target.PaneTarget)
+			if err != nil {
+				allReady = false
+				continue
+			}
+			if shouldPrimeClaudePane(content) {
+				p.SendEnter(target.PaneTarget)
+				allReady = false
+			}
+		}
+		if allReady {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+// ReportPaneFallback prints the stderr banner and posts the
+// broker-side fallback advisory (PLAN.md §C5e). Pure thin wrapper
+// around paneFallbackMessages + the postSystemMessage callback so
+// trySpawnWebAgentPanes can surface failures without re-reaching
+// into Launcher state.
+func (p *paneLifecycle) ReportPaneFallback(tmuxInstalled bool, summary string, err error) {
+	detail := summary
+	if err != nil {
+		detail = fmt.Sprintf("%s: %v", summary, err)
+	}
+	stderrMsg, brokerMsg := paneFallbackMessages(tmuxInstalled, detail)
+	fmt.Fprint(os.Stderr, stderrMsg)
+	if p.deps.postSystemMessage != nil {
+		p.deps.postSystemMessage("general", brokerMsg, "runtime")
+	}
 }
 
 // CaptureDeadChannelPane writes a timestamped snapshot of the channel

--- a/internal/team/pane_lifecycle_orchestration_test.go
+++ b/internal/team/pane_lifecycle_orchestration_test.go
@@ -1,0 +1,271 @@
+package team
+
+// Tests for the C5e ownership consolidation: the spawn orchestration
+// methods (SpawnVisibleAgents, SpawnOverflowAgents, ReportPaneFallback,
+// TrySpawnWebAgentPanes) now live on paneLifecycle and consult deps
+// via the paneLifecycleDeps struct. These tests construct paneLifecycle
+// directly with stubbed deps + fakeTmuxRunner, exercising the
+// orchestration logic without the full Launcher.
+//
+// The simpler helper tests (one tmux call per assertion) live in
+// pane_lifecycle_spawn_test.go; this file is for end-to-end paths
+// where we want to assert on the *sequence* of tmux args.
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSpawnVisibleAgents_OneOnOneMode(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["split-window"] = []byte("ok")
+	setTmuxRunnerForTest(t, fake)
+
+	deps := paneLifecycleDeps{
+		cwd:           "/repo",
+		isOneOnOne:    func() bool { return true },
+		oneOnOneAgent: func() string { return "ceo" },
+		claudeCommand: func(slug, prompt string) (string, error) {
+			return fmt.Sprintf("claude --slug=%s", slug), nil
+		},
+		buildPrompt:   func(slug string) string { return "<prompt:" + slug + ">" },
+		agentName:     func(slug string) string { return "Boss" },
+		recordFailure: func(slug, reason string) { t.Fatalf("unexpected recordFailure: slug=%s reason=%s", slug, reason) },
+	}
+	pl := newPaneLifecycleWithDeps("wuphf-team", deps)
+
+	got, err := pl.SpawnVisibleAgents()
+	if err != nil {
+		t.Fatalf("SpawnVisibleAgents err = %v", err)
+	}
+	if len(got) != 1 || got[0] != "ceo" {
+		t.Fatalf("returned slugs = %v, want [ceo]", got)
+	}
+
+	// Sequence pinning: 1 split-window, 1 select-layout, 2 select-pane (titles),
+	// 1 select-window, 1 select-pane (focus). 6 total tmux calls.
+	splits := fake.callsFor("split-window")
+	if len(splits) != 1 || splits[0][1] != "-h" {
+		t.Errorf("expected 1 split-window with -h, got %v", splits)
+	}
+	titles := fake.callsFor("select-pane")
+	if len(titles) != 3 {
+		// 2 SetPaneTitle (-T) + 1 FocusPane (no -T) = 3
+		t.Errorf("expected 3 select-pane calls (2 titles + 1 focus), got %d: %v", len(titles), titles)
+	}
+	if len(fake.callsFor("select-layout")) != 1 {
+		t.Errorf("expected 1 select-layout, got %v", fake.callsFor("select-layout"))
+	}
+	if len(fake.callsFor("select-window")) != 1 {
+		t.Errorf("expected 1 select-window, got %v", fake.callsFor("select-window"))
+	}
+}
+
+func TestSpawnVisibleAgents_FirstSplitFailureAborts(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	fake.outputs["split-window"] = []byte("tmux: terminal too small\n")
+	fake.errors["split-window"] = fmt.Errorf("exit 1")
+	setTmuxRunnerForTest(t, fake)
+
+	deps := paneLifecycleDeps{
+		cwd:                  "/repo",
+		isOneOnOne:           func() bool { return false },
+		visibleOfficeMembers: func() []officeMember { return []officeMember{{Slug: "ceo"}, {Slug: "fe"}} },
+		claudeCommand:        func(slug, prompt string) (string, error) { return "claude", nil },
+		buildPrompt:          func(slug string) string { return "" },
+		agentName:            func(slug string) string { return slug },
+		recordFailure:        func(slug, reason string) {},
+	}
+	pl := newPaneLifecycleWithDeps("wuphf-team", deps)
+
+	if _, err := pl.SpawnVisibleAgents(); err == nil {
+		t.Fatalf("SpawnVisibleAgents err = nil, want error from first split failure")
+	}
+	// Only one split-window call should have been made: the failed first.
+	// Subsequent agents are not attempted because the first split is mandatory.
+	if got := len(fake.callsFor("split-window")); got != 1 {
+		t.Errorf("split-window calls = %d, want 1 (first failed -> abort)", got)
+	}
+}
+
+func TestSpawnVisibleAgents_AdditionalSplitFailureRecordsAndContinues(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	// First split (the -h variant) succeeds; subsequent splits (no -h)
+	// cannot be distinguished by sub-command alone — they all share
+	// "split-window". Use a hook on the fake to fail only the second call.
+	callIdx := 0
+	fake.outputs["split-window"] = []byte("ok")
+	originalRun := fake // unused; we extend via a wrapper instead
+	_ = originalRun
+	setTmuxRunnerForTest(t, &countingRunner{
+		inner:            fake,
+		failOnNthCommand: 2, // fail the second split-window
+		failingSubcmd:    "split-window",
+		callIdx:          &callIdx,
+	})
+
+	recorded := map[string]string{}
+	deps := paneLifecycleDeps{
+		cwd:                  "/repo",
+		isOneOnOne:           func() bool { return false },
+		visibleOfficeMembers: func() []officeMember { return []officeMember{{Slug: "ceo"}, {Slug: "fe"}, {Slug: "be"}} },
+		claudeCommand:        func(slug, prompt string) (string, error) { return "claude --" + slug, nil },
+		buildPrompt:          func(slug string) string { return "" },
+		agentName:            func(slug string) string { return slug },
+		recordFailure: func(slug, reason string) {
+			recorded[slug] = reason
+		},
+	}
+	pl := newPaneLifecycleWithDeps("wuphf-team", deps)
+
+	got, err := pl.SpawnVisibleAgents()
+	if err != nil {
+		t.Fatalf("SpawnVisibleAgents err = %v, want nil (later split failures don't abort)", err)
+	}
+	// All three slugs are returned (the recorded failure doesn't remove them
+	// from the visibleSlugs list — that's the targeter's job through
+	// failedPaneSlugs).
+	if len(got) != 3 {
+		t.Errorf("returned slugs = %v, want 3 entries", got)
+	}
+	// "fe" is the second agent, which is the one we made fail.
+	if _, ok := recorded["fe"]; !ok {
+		t.Errorf("recordFailure was not called for fe; recorded = %v", recorded)
+	}
+}
+
+func TestSpawnOverflowAgents_SkipsHeadlessOneShotMembers(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	deps := paneLifecycleDeps{
+		cwd: "/repo",
+		overflowOfficeMembers: func() []officeMember {
+			return []officeMember{
+				{Slug: "ceo-extra"}, // claude — should spawn
+				{Slug: "codex-bot"}, // codex — should skip
+				{Slug: "extra-eng"}, // claude — should spawn
+			}
+		},
+		memberUsesHeadlessOneShotRuntime: func(slug string) bool {
+			return slug == "codex-bot"
+		},
+		claudeCommand: func(slug, prompt string) (string, error) { return "claude", nil },
+		buildPrompt:   func(slug string) string { return "" },
+		recordFailure: func(slug, reason string) { t.Fatalf("unexpected failure for %s: %s", slug, reason) },
+	}
+	pl := newPaneLifecycleWithDeps("wuphf-team", deps)
+	pl.SpawnOverflowAgents()
+
+	news := fake.callsFor("new-window")
+	if len(news) != 2 {
+		t.Fatalf("new-window calls = %d, want 2 (codex-bot skipped)", len(news))
+	}
+	// First call should be ceo-extra; second extra-eng. The window name
+	// is at args index 5 (-d -t session -n NAME -c cwd cmd).
+	if news[0][5] != overflowWindowName("ceo-extra") {
+		t.Errorf("new-window[0] window name = %q, want %q", news[0][5], overflowWindowName("ceo-extra"))
+	}
+	if news[1][5] != overflowWindowName("extra-eng") {
+		t.Errorf("new-window[1] window name = %q, want %q", news[1][5], overflowWindowName("extra-eng"))
+	}
+}
+
+func TestReportPaneFallback_BrokerlessIsStderrOnly(t *testing.T) {
+	pl := newPaneLifecycleWithDeps("wuphf-team", paneLifecycleDeps{})
+	// No postSystemMessage wired — should not panic, should not error.
+	pl.ReportPaneFallback(false, "tmux missing", fmt.Errorf("not found"))
+}
+
+func TestReportPaneFallback_BrokerCallsPostSystemMessage(t *testing.T) {
+	var posted []string
+	pl := newPaneLifecycleWithDeps("wuphf-team", paneLifecycleDeps{
+		postSystemMessage: func(channel, body, kind string) {
+			posted = append(posted, channel+"|"+kind+"|"+body)
+		},
+	})
+	pl.ReportPaneFallback(true, "spawn failed", fmt.Errorf("exit 1"))
+
+	if len(posted) != 1 {
+		t.Fatalf("posted = %v, want 1 entry", posted)
+	}
+	// The exact body comes from paneFallbackMessages; just spot-check the
+	// channel / kind pinning.
+	if want := "general|runtime|"; len(posted[0]) <= len(want) || posted[0][:len(want)] != want {
+		t.Errorf("posted entry = %q, want prefix %q", posted[0], want)
+	}
+}
+
+func TestTrySpawnWebAgentPanes_NilBrokerNoOp(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	pl := newPaneLifecycleWithDeps("wuphf-team", paneLifecycleDeps{
+		// postSystemMessage nil simulates l.broker == nil.
+		usesPaneRuntime: func() bool { return true },
+	})
+	pl.TrySpawnWebAgentPanes()
+
+	if got := len(fake.calls); got != 0 {
+		t.Errorf("expected zero tmux calls when broker is nil, got %d", got)
+	}
+}
+
+func TestTrySpawnWebAgentPanes_HeadlessRuntimeNoOp(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	posted := 0
+	pl := newPaneLifecycleWithDeps("wuphf-team", paneLifecycleDeps{
+		postSystemMessage: func(channel, body, kind string) { posted++ },
+		usesPaneRuntime:   func() bool { return false },
+	})
+	pl.TrySpawnWebAgentPanes()
+
+	if got := len(fake.calls); got != 0 {
+		t.Errorf("expected zero tmux calls in headless runtime, got %d", got)
+	}
+	if posted != 0 {
+		t.Errorf("expected zero broker posts when bailing on headless, got %d", posted)
+	}
+}
+
+// countingRunner wraps a fakeTmuxRunner to inject a one-shot failure on
+// the Nth call to a specific tmux subcommand. Used by the
+// "additional split failure" test where we need success on the first
+// split-window and failure on the second.
+type countingRunner struct {
+	inner            *fakeTmuxRunner
+	failOnNthCommand int
+	failingSubcmd    string
+	callIdx          *int
+}
+
+func (c *countingRunner) shouldFail(args []string) bool {
+	if len(args) == 0 || args[0] != c.failingSubcmd {
+		return false
+	}
+	*c.callIdx++
+	return *c.callIdx == c.failOnNthCommand
+}
+
+func (c *countingRunner) Run(args ...string) error {
+	if c.shouldFail(args) {
+		return fmt.Errorf("synthetic failure on %s call %d", c.failingSubcmd, c.failOnNthCommand)
+	}
+	return c.inner.Run(args...)
+}
+
+func (c *countingRunner) Output(args ...string) ([]byte, error) {
+	if c.shouldFail(args) {
+		return []byte("synthetic stderr"), fmt.Errorf("synthetic failure")
+	}
+	return c.inner.Output(args...)
+}
+
+func (c *countingRunner) Combined(args ...string) ([]byte, error) {
+	if c.shouldFail(args) {
+		return []byte("synthetic stderr"), fmt.Errorf("synthetic failure")
+	}
+	return c.inner.Combined(args...)
+}


### PR DESCRIPTION
Stacked on **#448 (C5d)**. PLAN.md §C5 ownership consolidation — the five spawn-orchestration methods that lived on Launcher in C5d (and just routed their tmux calls through paneLifecycle helpers) now live on the type itself.

`paneLifecycleDeps` wires the Launcher state + methods the orchestration needs (cwd, isOneOnOne, claudeCommand, buildPrompt, agentName, recordFailure, postSystemMessage, paneBackedFlag, etc.). PLAN.md trap §1 (shared `failedPaneSlugs`) is addressed by `recordFailure` being a callback that writes back into Launcher's existing map — the targeter's read view is unchanged.

## Migrated

| Before (Launcher method) | After (paneLifecycle method) |
|---|---|
| spawnVisibleAgents | SpawnVisibleAgents |
| spawnOverflowAgents | SpawnOverflowAgents |
| detectDeadPanesAfterSpawn | DetectDeadPanesAfterSpawn |
| trySpawnWebAgentPanes | TrySpawnWebAgentPanes |
| primeVisibleAgents priming loop | PrimeVisibleAgents |
| reportPaneFallback | ReportPaneFallback |

primeVisibleAgents on Launcher keeps the broker replay-catchup (latest-message replay + resumeInFlightWork) because that depends on broker state.

## Tests (9 new)

- `TestSpawnVisibleAgents_OneOnOneMode` pins the 6-call sequence
- `TestSpawnVisibleAgents_FirstSplitFailureAborts` confirms abort path
- `TestSpawnVisibleAgents_AdditionalSplitFailureRecordsAndContinues` pins recordFailure semantics
- `TestSpawnOverflowAgents_SkipsHeadlessOneShotMembers` exercises the Codex skip
- `TestReportPaneFallback_*` × 2 (brokerless + with broker)
- `TestTrySpawnWebAgentPanes_*` × 2 (nil broker no-op + headless runtime no-op)

Plus a `countingRunner` test helper for "fail the Nth call to subcmd" scenarios.

## Coverage on new orchestration methods

| Method | Coverage |
|---|---:|
| SpawnVisibleAgents | 81.5% |
| SpawnOverflowAgents | 47.1% |
| TrySpawnWebAgentPanes | 16.7% |
| PrimeVisibleAgents | 23.5% |
| DetectDeadPanesAfterSpawn | 0.0% |
| ReportPaneFallback | 100.0% |

The lower coverage on the time.Sleep-heavy methods is expected — adding clock injection to paneLifecycle (matching the paneDispatcher / watchdogScheduler pattern) is the C5f follow-up.

## Diff shape

| File | Δ |
|---|---:|
| launcher.go | 2934 → 2718 (−216) |
| pane_lifecycle.go | +335 |
| pane_lifecycle_orchestration_test.go | +271 (new) |

**Cumulative since main: 4998 → 2718 = −2280 lines (−45.6%).**

## Local CI matrix (all green)

- gofmt clean
- golangci-lint 0 issues
- go test -race ./internal/team
- bash scripts/test-go.sh — all 32 packages green
- Cross-compile windows-amd64 + darwin-arm64
- Smoke binary OK

## What's next

**C5f — clock injection for time.Sleep-heavy methods** (DetectDeadPanesAfterSpawn 1.5s, PrimeVisibleAgents 1s × N) so they get full coverage parity with the rest of paneLifecycle.

Then the **wrapper consolidation sweep** (PLAN.md §6: rename ~150 in-package call sites, delete transitional one-line wrappers across C2–C7).
