### PR TITLE
refactor(team): inject clock into paneLifecycle (C5f)

### DIFF
--- a/internal/team/pane_lifecycle.go
+++ b/internal/team/pane_lifecycle.go
@@ -78,12 +78,15 @@ type paneLifecycleDeps struct {
 }
 
 // paneLifecycle owns the tmux pane lifecycle (PLAN.md §C5). The runner
-// field is the test seam — production gets realTmuxRunner via
-// newTmuxRunner; tests inject a fakeTmuxRunner via setTmuxRunnerForTest.
-// deps wires the spawn orchestration callbacks; they're nil for the
-// nil-safe / read-only paths.
+// field is the test seam for tmux invocations; production gets
+// realTmuxRunner via newTmuxRunner. The clock field is the test seam
+// for time.Sleep — production gets realClock{}, tests inject a
+// manualClock via withClock so the sleep-heavy spawn orchestration
+// methods (DetectDeadPanesAfterSpawn, PrimeVisibleAgents) can be
+// driven without real wall-clock waits.
 type paneLifecycle struct {
 	runner      tmuxRunner
+	clock       clock
 	sessionName string
 	deps        paneLifecycleDeps
 }
@@ -94,21 +97,35 @@ type paneLifecycle struct {
 // setTmuxRunnerForTest before constructing the launcher gets its fake
 // runner installed transparently. deps is empty (nil callbacks);
 // callers that need spawn orchestration use newPaneLifecycleWithDeps.
+// Production clock is realClock; tests override via withClock.
 func newPaneLifecycle(sessionName string) *paneLifecycle {
 	return &paneLifecycle{
 		runner:      newTmuxRunner(),
+		clock:       realClock{},
 		sessionName: sessionName,
 	}
 }
 
 // newPaneLifecycleWithDeps is the spawn-capable constructor used by the
-// Launcher. The runner still routes through the override seam.
+// Launcher. The runner still routes through the override seam, and
+// the clock defaults to realClock so production timing matches the
+// pre-C5f behaviour exactly.
 func newPaneLifecycleWithDeps(sessionName string, deps paneLifecycleDeps) *paneLifecycle {
 	return &paneLifecycle{
 		runner:      newTmuxRunner(),
+		clock:       realClock{},
 		sessionName: sessionName,
 		deps:        deps,
 	}
+}
+
+// withClock swaps the clock used by sleep-heavy orchestration methods.
+// Returns the same paneLifecycle so the call can be chained off a
+// constructor in test setup. Production code never calls this — it's
+// only useful from _test.go files that build a manualClock.
+func (p *paneLifecycle) withClock(c clock) *paneLifecycle {
+	p.clock = c
+	return p
 }
 
 // HasLiveSession returns true when a wuphf-team tmux session is running.
@@ -575,7 +592,7 @@ func (p *paneLifecycle) DetectDeadPanesAfterSpawn(members []officeMember) {
 	if p == nil || p.sessionName == "" {
 		return
 	}
-	time.Sleep(1500 * time.Millisecond)
+	<-p.clock.After(1500 * time.Millisecond)
 	targets := p.deps.agentPaneTargets()
 	for _, m := range members {
 		target, ok := targets[m.Slug]
@@ -655,7 +672,7 @@ func (p *paneLifecycle) TrySpawnWebAgentPanes() {
 // Launcher.primeVisibleAgents because it depends on broker
 // state and the headless-resume path.
 func (p *paneLifecycle) PrimeVisibleAgents() {
-	time.Sleep(1 * time.Second)
+	<-p.clock.After(1 * time.Second)
 
 	targets := p.deps.agentPaneTargets()
 	if len(targets) == 0 {
@@ -678,7 +695,7 @@ func (p *paneLifecycle) PrimeVisibleAgents() {
 		if allReady {
 			break
 		}
-		time.Sleep(1 * time.Second)
+		<-p.clock.After(1 * time.Second)
 	}
 }
 

--- a/internal/team/pane_lifecycle_clock_test.go
+++ b/internal/team/pane_lifecycle_clock_test.go
@@ -1,0 +1,164 @@
+package team
+
+// Tests for the C5f clock-injected paneLifecycle methods. The 1.5s
+// sleep in DetectDeadPanesAfterSpawn and the 1s sleeps in
+// PrimeVisibleAgents previously made these methods un-testable
+// without time.Sleep in the test (the hard "no sleeps in tests"
+// rule). Now that paneLifecycle takes a clock interface the tests
+// drive them through manualClock.Advance — same pattern as
+// scheduler_test.go.
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDetectDeadPanesAfterSpawn_RecordsDeadPanesUnderManualClock(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	// First display-message returns "1" (dead); capture-pane returns the
+	// last 200 lines as the snippet. fakeTmuxRunner keys off the
+	// sub-command so we can return both via the same call sequence.
+	fake.outputs["display-message"] = []byte("1\n")
+	fake.outputs["capture-pane"] = []byte("error: model unavailable\n")
+	setTmuxRunnerForTest(t, fake)
+
+	posted := 0
+	recorded := map[string]string{}
+	deps := paneLifecycleDeps{
+		agentPaneTargets: func() map[string]notificationTarget {
+			return map[string]notificationTarget{
+				"ceo": {PaneTarget: "wuphf-team:team.1"},
+				"fe":  {PaneTarget: "wuphf-team:team.2"},
+			}
+		},
+		recordFailure: func(slug, reason string) {
+			recorded[slug] = reason
+		},
+		postSystemMessage: func(channel, body, kind string) { posted++ },
+	}
+
+	clk := newManualClock(time.Unix(0, 0))
+	pl := newPaneLifecycleWithDeps("wuphf-team", deps).withClock(clk)
+
+	// Run DetectDeadPanesAfterSpawn in a goroutine so we can advance the
+	// clock past its 1500ms guard without the test goroutine blocking.
+	done := make(chan struct{})
+	go func() {
+		pl.DetectDeadPanesAfterSpawn([]officeMember{{Slug: "ceo"}, {Slug: "fe"}})
+		close(done)
+	}()
+	// Wait for the After registration before advancing — same pattern
+	// as scheduler_test.go (race-free synchronization).
+	<-clk.registered
+	clk.Advance(1500 * time.Millisecond)
+	<-done
+
+	// Both panes are reported dead -> both should be recorded + each
+	// should have posted a system message.
+	if len(recorded) != 2 {
+		t.Errorf("recorded = %v, want 2 entries (ceo, fe)", recorded)
+	}
+	if posted != 2 {
+		t.Errorf("postSystemMessage calls = %d, want 2", posted)
+	}
+	for _, slug := range []string{"ceo", "fe"} {
+		if reason, ok := recorded[slug]; !ok {
+			t.Errorf("recordFailure missing for %s", slug)
+		} else if !stringContains(reason, "pane died on launch") {
+			t.Errorf("recordFailure[%s] = %q, want 'pane died on launch...' prefix", slug, reason)
+		}
+	}
+}
+
+func TestPrimeVisibleAgents_NoTargetsExitsImmediately(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	setTmuxRunnerForTest(t, fake)
+
+	deps := paneLifecycleDeps{
+		agentPaneTargets: func() map[string]notificationTarget { return nil },
+	}
+
+	clk := newManualClock(time.Unix(0, 0))
+	pl := newPaneLifecycleWithDeps("wuphf-team", deps).withClock(clk)
+
+	done := make(chan struct{})
+	go func() {
+		pl.PrimeVisibleAgents()
+		close(done)
+	}()
+	<-clk.registered
+	clk.Advance(1 * time.Second)
+	<-done
+
+	// Empty agentPaneTargets short-circuits — no capture-pane / send-keys
+	// should fire.
+	if got := len(fake.callsFor("capture-pane")); got != 0 {
+		t.Errorf("capture-pane calls = %d, want 0 (no targets)", got)
+	}
+	if got := len(fake.callsFor("send-keys")); got != 0 {
+		t.Errorf("send-keys calls = %d, want 0", got)
+	}
+}
+
+func TestPrimeVisibleAgents_SendsEnterWhenPaneNeedsPriming(t *testing.T) {
+	fake := newFakeTmuxRunner()
+	// First capture returns the trust-prompt text; second returns clean.
+	// fakeTmuxRunner is keyed off subcommand so all capture-pane calls
+	// share the same canned output. To get the "first prime, then ready"
+	// flow we'd need a sequenced fake — overkill for this test. Instead,
+	// pin the simpler invariant: when capture returns priming text, we
+	// send Enter, and we keep doing it for up to 3 attempts.
+	fake.outputs["capture-pane"] = []byte("Trust this folder?")
+	setTmuxRunnerForTest(t, fake)
+
+	deps := paneLifecycleDeps{
+		agentPaneTargets: func() map[string]notificationTarget {
+			return map[string]notificationTarget{
+				"ceo": {PaneTarget: "wuphf-team:team.1"},
+			}
+		},
+	}
+
+	clk := newManualClock(time.Unix(0, 0))
+	pl := newPaneLifecycleWithDeps("wuphf-team", deps).withClock(clk)
+
+	done := make(chan struct{})
+	go func() {
+		pl.PrimeVisibleAgents()
+		close(done)
+	}()
+
+	// First sleep: 1s warmup. PrimeVisibleAgents loops up to 3 times,
+	// sleeping 1s between iterations when not ready. So the goroutine
+	// will register at most 4 sleeps total (warmup + 3 between). Drive
+	// each in turn.
+	for i := 0; i < 4; i++ {
+		select {
+		case <-clk.registered:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("never registered sleeper %d", i)
+		}
+		clk.Advance(1 * time.Second)
+	}
+	<-done
+
+	sends := fake.callsFor("send-keys")
+	if len(sends) != 3 {
+		// Each of the 3 attempts saw priming text and sent Enter.
+		t.Errorf("send-keys calls = %d, want 3 (3 attempts × 1 priming pane)", len(sends))
+	}
+	for _, call := range sends {
+		if len(call) < 4 || call[3] != "Enter" {
+			t.Errorf("send-keys args = %v, want last arg Enter", call)
+		}
+	}
+}
+
+func stringContains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Stacked on **#451 (C5e)**. Closes the C5e coverage gap on the time.Sleep-heavy spawn methods.

## Coverage jumps

| Method | Before | After |
|---|---:|---:|
| DetectDeadPanesAfterSpawn | 0.0% | **78.9%** |
| PrimeVisibleAgents | 23.5% | **82.4%** |
| Package internal/team | 64.2% | **64.4%** |

## Changes

1. `paneLifecycle` gains a `clock` field. Both constructors default to `realClock{}` so production timing is byte-identical.
2. `withClock(c clock)` setter for test injection (chainable off the constructor).
3. `time.Sleep(d)` in `DetectDeadPanesAfterSpawn` (1.5s) and `PrimeVisibleAgents` (3 × 1s loop) replaced with `<-p.clock.After(d)`.

## Tests (3 new, all using existing `manualClock` from scheduler_test.go)

- `TestDetectDeadPanesAfterSpawn_RecordsDeadPanesUnderManualClock` drives the 1.5s wait via `Advance`, asserts both dead panes get `recordFailure` + `postSystemMessage` hits
- `TestPrimeVisibleAgents_NoTargetsExitsImmediately` confirms the empty-targets short-circuit after warmup
- `TestPrimeVisibleAgents_SendsEnterWhenPaneNeedsPriming` pins the 3-attempt retry loop sending Enter when capture-pane shows the trust-folder prompt

Zero `time.Sleep` in tests. Race-free synchronization via the `<-clk.registered` pattern from scheduler_test.go.

## Local CI all green

- gofmt clean
- golangci-lint 0 issues
- bash scripts/test-go.sh — all 32 packages green
- Cross-compile windows-amd64 — clean
- Smoke binary OK

## What's next

**Wrapper consolidation sweep** (PLAN.md §6): rename ~150 in-package call sites from `l.officeLeadSlug()` → `l.targets.LeadSlug()` etc. across C2-C7, then delete the transitional one-line wrappers. That's the last housekeeping pass before the migration is fully done.
