### PR TITLE
refactor(team): delete transitional Launcher wrappers (C9)

### DIFF
--- a/internal/team/dispatch_test.go
+++ b/internal/team/dispatch_test.go
@@ -39,7 +39,7 @@ func TestMemberEffectiveProviderKind_PerAgentWins(t *testing.T) {
 	b.mu.Unlock()
 
 	l := &Launcher{broker: b, provider: "claude-code"}
-	if got := l.memberEffectiveProviderKind("pm-codex"); got != provider.KindCodex {
+	if got := l.targeter().MemberEffectiveProviderKind("pm-codex"); got != provider.KindCodex {
 		t.Fatalf("per-agent should win over global, got %q", got)
 	}
 }
@@ -55,12 +55,12 @@ func TestMemberEffectiveProviderKind_FallsBackToGlobal(t *testing.T) {
 	b.mu.Unlock()
 
 	l := &Launcher{broker: b, provider: "codex"}
-	if got := l.memberEffectiveProviderKind("no-binding"); got != provider.KindCodex {
+	if got := l.targeter().MemberEffectiveProviderKind("no-binding"); got != provider.KindCodex {
 		t.Fatalf("empty Kind should fall back to global=codex, got %q", got)
 	}
 
 	// Unknown member also falls back to global (dispatch then errors if global is bad).
-	if got := l.memberEffectiveProviderKind("nobody"); got != provider.KindCodex {
+	if got := l.targeter().MemberEffectiveProviderKind("nobody"); got != provider.KindCodex {
 		t.Fatalf("unknown slug should fall back to global=codex, got %q", got)
 	}
 }
@@ -70,7 +70,7 @@ func TestMemberEffectiveProviderKind_DefaultsToClaudeWhenAllEmpty(t *testing.T) 
 	l := &Launcher{broker: b, provider: ""}
 	// Fully empty globals fall through to claude-code. This preserves the
 	// install-default behavior that predated per-agent providers.
-	if got := l.memberEffectiveProviderKind("anybody"); got != provider.KindClaudeCode {
+	if got := l.targeter().MemberEffectiveProviderKind("anybody"); got != provider.KindClaudeCode {
 		t.Fatalf("default fallback should be claude-code, got %q", got)
 	}
 }
@@ -100,7 +100,7 @@ func TestShouldUseHeadlessDispatch(t *testing.T) {
 			webMode:          tt.webMode,
 			paneBackedAgents: tt.paneBackedAgents,
 		}
-		if got := l.shouldUseHeadlessDispatch(); got != tt.want {
+		if got := l.targeter().ShouldUseHeadless(); got != tt.want {
 			t.Errorf("%s: shouldUseHeadlessDispatch() = %v, want %v", tt.name, got, tt.want)
 		}
 	}

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -234,7 +234,7 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 }
 
 func (l *Launcher) headlessClaudeModel(slug string) string {
-	if l.opusCEO && slug == l.officeLeadSlug() {
+	if l.opusCEO && slug == l.targeter().LeadSlug() {
 		return "claude-opus-4-6"
 	}
 	return "claude-sonnet-4-6"
@@ -245,7 +245,7 @@ func (l *Launcher) headlessClaudeModel(slug string) string {
 // members, and posting an assignment — easily more than 5 turns. Specialists
 // get a smaller budget since they focus on a single task.
 func (l *Launcher) headlessClaudeMaxTurns(slug string) string {
-	if slug == l.officeLeadSlug() {
+	if slug == l.targeter().LeadSlug() {
 		return "30"
 	}
 	return "15"

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -45,7 +45,7 @@ var (
 // turn runner. Tests substitute via setHeadlessCodexRunTurnForTest.
 func defaultHeadlessCodexRunTurn(l *Launcher, ctx context.Context, slug, notification string, channel ...string) error {
 	if l != nil {
-		kind := l.memberEffectiveProviderKind(slug)
+		kind := l.targeter().MemberEffectiveProviderKind(slug)
 		switch {
 		case kind == provider.KindCodex:
 			return l.runHeadlessCodexTurn(ctx, slug, notification, channel...)
@@ -248,9 +248,9 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	urgentLeadTurn := l.headlessLeadTurnNeedsImmediateWakeLocked(slug, turn.Prompt)
 	if turn.TaskID != "" {
 		if active := l.headless.active[slug]; active != nil && strings.TrimSpace(active.Turn.TaskID) == turn.TaskID {
-			if !(slug == l.officeLeadSlug() && urgentLeadTurn) && turn.Attempts <= active.Turn.Attempts {
+			if !(slug == l.targeter().LeadSlug() && urgentLeadTurn) && turn.Attempts <= active.Turn.Attempts {
 				l.headless.mu.Unlock()
-				if slug == l.officeLeadSlug() {
+				if slug == l.targeter().LeadSlug() {
 					appendHeadlessCodexLog(slug, "queue-drop: lead already handling same task")
 				} else {
 					appendHeadlessCodexLog(slug, "queue-drop: agent already handling same task")
@@ -264,7 +264,7 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 				startWorker = true
 			}
 			l.headless.mu.Unlock()
-			if slug == l.officeLeadSlug() {
+			if slug == l.targeter().LeadSlug() {
 				appendHeadlessCodexLog(slug, "queue-replace: refreshed pending lead turn for same task")
 			} else {
 				appendHeadlessCodexLog(slug, "queue-replace: refreshed pending turn for same task")
@@ -280,7 +280,7 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	// parallel work is done — not when one specialist finishes while others are
 	// still running. This eliminates the race condition where CEO fires after the
 	// first specialist completes and redundantly re-routes to still-running agents.
-	if slug == l.officeLeadSlug() && !urgentLeadTurn {
+	if slug == l.targeter().LeadSlug() && !urgentLeadTurn {
 		for workerSlug, queue := range l.headless.queues {
 			if workerSlug == slug {
 				continue
@@ -309,7 +309,7 @@ func (l *Launcher) enqueueHeadlessCodexTurnRecord(slug string, turn headlessCode
 	// stack up redundant CEO turns that each re-route the same task. One pending
 	// turn is enough to catch the latest state; extras are dropped.
 	const leadMaxPending = 1
-	if slug == l.officeLeadSlug() && len(l.headless.queues[slug]) >= leadMaxPending {
+	if slug == l.targeter().LeadSlug() && len(l.headless.queues[slug]) >= leadMaxPending {
 		if urgentLeadTurn {
 			l.headless.queues[slug][len(l.headless.queues[slug])-1] = turn
 			if !l.headless.workers[slug] {
@@ -363,7 +363,7 @@ func (l *Launcher) replaceDuplicateTaskTurnLocked(slug string, turn headlessCode
 		l.headless.queues[slug][i] = turn
 		return true
 	}
-	if slug == l.officeLeadSlug() && l.headless.deferredLead != nil && strings.TrimSpace(l.headless.deferredLead.TaskID) == turn.TaskID {
+	if slug == l.targeter().LeadSlug() && l.headless.deferredLead != nil && strings.TrimSpace(l.headless.deferredLead.TaskID) == turn.TaskID {
 		cp := turn
 		l.headless.deferredLead = &cp
 		return true
@@ -375,7 +375,7 @@ func (l *Launcher) headlessLeadTurnNeedsImmediateWakeLocked(slug, prompt string)
 	if l == nil || l.broker == nil {
 		return false
 	}
-	if strings.TrimSpace(slug) != l.officeLeadSlug() {
+	if strings.TrimSpace(slug) != l.targeter().LeadSlug() {
 		return false
 	}
 	taskID := strings.TrimSpace(headlessCodexTaskID(prompt))
@@ -672,7 +672,7 @@ func (l *Launcher) finishHeadlessTurn(slug string) {
 		active.Cancel()
 	}
 	delete(l.headless.active, slug)
-	lead := l.officeLeadSlug()
+	lead := l.targeter().LeadSlug()
 	var deferredLead *headlessCodexTurn
 	// Determine if this was a specialist finishing (not the lead), and if so whether
 	// any other specialists are still active or queued. If the slate is clear, we
@@ -739,11 +739,11 @@ func (l *Launcher) wakeLeadAfterSpecialist(specialistSlug string) {
 	if l.broker == nil {
 		return
 	}
-	lead := l.officeLeadSlug()
+	lead := l.targeter().LeadSlug()
 	if lead == "" {
 		return
 	}
-	targets := l.agentNotificationTargets()
+	targets := l.targeter().NotificationTargets()
 	target, ok := targets[lead]
 	if !ok {
 		return

--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -39,7 +39,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		return fmt.Errorf("broker is not running")
 	}
 
-	kind := l.memberEffectiveProviderKind(slug)
+	kind := l.targeter().MemberEffectiveProviderKind(slug)
 	entry := provider.Lookup(kind)
 	if entry == nil || entry.StreamFn == nil {
 		return fmt.Errorf("openai-compat runtime %q is not registered", kind)

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -640,7 +640,7 @@ func (l *Launcher) officeChangeTaskNotifications(evt officeChangeEvent) []office
 		return nil
 	}
 
-	targetMap := l.agentPaneTargets()
+	targetMap := l.targeter().PaneTargets()
 	if len(targetMap) == 0 {
 		return nil
 	}
@@ -732,7 +732,7 @@ func (l *Launcher) deliverMessageNotification(msg channelMessage) {
 
 	// Debounce: use shorter cooldown for human/CEO messages, longer for agent-originated
 	// to prevent agent-to-agent feedback loops (devil's advocate finding #3)
-	isHumanOrCEO := msg.From == "you" || msg.From == "human" || msg.From == "nex" || msg.From == l.officeLeadSlug()
+	isHumanOrCEO := msg.From == "you" || msg.From == "human" || msg.From == "nex" || msg.From == l.targeter().LeadSlug()
 	cooldown := agentNotifyCooldownAgent
 	if isHumanOrCEO {
 		cooldown = agentNotifyCooldown
@@ -799,11 +799,11 @@ type notificationTarget struct {
 }
 
 func (l *Launcher) taskNotificationTargets(action officeActionLog, task teamTask) (immediate []notificationTarget, delayed []notificationTarget) {
-	targetMap := l.agentNotificationTargets()
+	targetMap := l.targeter().NotificationTargets()
 	if len(targetMap) == 0 {
 		return nil, nil
 	}
-	lead := l.officeLeadSlug()
+	lead := l.targeter().LeadSlug()
 	enabledMembers := map[string]struct{}{}
 	disabledMembers := map[string]struct{}{}
 	if l.broker != nil {
@@ -942,10 +942,10 @@ func (l *Launcher) shouldDeliverDelayedTaskNotification(targetSlug string, actio
 	if strings.EqualFold(strings.TrimSpace(current.Status), "done") {
 		return false
 	}
-	if strings.TrimSpace(current.Owner) != "" && strings.TrimSpace(current.Owner) != targetSlug && targetSlug != l.officeLeadSlug() {
+	if strings.TrimSpace(current.Owner) != "" && strings.TrimSpace(current.Owner) != targetSlug && targetSlug != l.targeter().LeadSlug() {
 		return false
 	}
-	if strings.TrimSpace(current.Owner) == "" && targetSlug != l.officeLeadSlug() {
+	if strings.TrimSpace(current.Owner) == "" && targetSlug != l.targeter().LeadSlug() {
 		return false
 	}
 	return true
@@ -963,7 +963,7 @@ func (l *Launcher) sendTaskUpdate(target notificationTarget, action officeAction
 		channel = "general"
 	}
 	notification := l.buildTaskExecutionPacket(target.Slug, action, task, content)
-	if l.shouldUseHeadlessDispatchForTarget(target) {
+	if l.targeter().ShouldUseHeadlessForTarget(target) {
 		l.enqueueHeadlessCodexTurn(target.Slug, headlessSandboxNote()+notification, channel)
 		return
 	}
@@ -1003,7 +1003,7 @@ func (l *Launcher) isChannelDMRaw(channelSlug string) (isDM bool, agentTarget st
 }
 
 func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate []notificationTarget, delayed []notificationTarget) {
-	targetMap := l.agentNotificationTargets()
+	targetMap := l.targeter().NotificationTargets()
 	if len(targetMap) == 0 {
 		return nil, nil
 	}
@@ -1041,7 +1041,7 @@ func (l *Launcher) notificationTargetsForMessage(msg channelMessage) (immediate 
 		}
 		return []notificationTarget{target}, nil
 	}
-	lead := l.officeLeadSlug()
+	lead := l.targeter().LeadSlug()
 	owner := ""
 	if l.broker != nil {
 		owner = l.taskOwnerForMessage(msg)
@@ -1439,51 +1439,13 @@ func (l *Launcher) brokerMemberProviderKind(slug string) string {
 	return l.broker.MemberProviderKind(slug)
 }
 
-// agentPaneSlugs and friends are thin wrappers that delegate to the
-// targeter. Kept as Launcher methods so the ~110 callers across
-// internal/team don't need a sweep in this PR; consolidation is a
-// follow-up. PLAN.md §6 wants the call sites renamed eventually but the
-// bulk of the diff would be call-site churn rather than logic changes.
-
-func (l *Launcher) agentPaneSlugs() []string { return l.targeter().PaneSlugs() }
-
-func (l *Launcher) officeAgentOrder() []officeMember { return l.targeter().AgentOrder() }
-
-func (l *Launcher) visibleOfficeMembers() []officeMember {
-	return l.targeter().VisibleMembers()
-}
-
-func (l *Launcher) overflowOfficeMembers() []officeMember {
-	return l.targeter().OverflowMembers()
-}
-
-func (l *Launcher) paneEligibleOfficeMembers() []officeMember {
-	return l.targeter().PaneEligibleMembers()
-}
-
-func (l *Launcher) resolvePaneTargetForSlug(slug string) (string, bool) {
-	return l.targeter().ResolvePaneTarget(slug)
-}
-
-func (l *Launcher) agentPaneTargets() map[string]notificationTarget {
-	return l.targeter().PaneTargets()
-}
-
-func (l *Launcher) agentNotificationTargets() map[string]notificationTarget {
-	return l.targeter().NotificationTargets()
-}
-
-func (l *Launcher) shouldUseHeadlessDispatchForSlug(slug string) bool {
-	return l.targeter().ShouldUseHeadlessForSlug(slug)
-}
-
-func (l *Launcher) shouldUseHeadlessDispatchForTarget(target notificationTarget) bool {
-	return l.targeter().ShouldUseHeadlessForTarget(target)
-}
-
-func (l *Launcher) skipPaneForSlug(slug string) bool {
-	return l.targeter().SkipPane(slug)
-}
+// agentPaneSlugs / officeAgentOrder / visibleOfficeMembers /
+// overflowOfficeMembers / paneEligibleOfficeMembers /
+// resolvePaneTargetForSlug / agentPaneTargets / agentNotificationTargets /
+// shouldUseHeadlessDispatchForSlug / shouldUseHeadlessDispatchForTarget /
+// skipPaneForSlug — historically thin Launcher wrappers around the
+// targeter (PLAN.md §C2). PLAN.md §6 sweep deleted them; in-package
+// call sites now use l.targeter().<Method>() directly.
 
 func (l *Launcher) isOneOnOne() bool {
 	if l.broker != nil {
@@ -1523,28 +1485,17 @@ func (l *Launcher) usesOpencodeRuntime() bool {
 	return strings.EqualFold(strings.TrimSpace(l.provider), "opencode")
 }
 
-// usesPaneRuntime / requiresClaudeSessionReset / memberEffectiveProviderKind /
-// memberUsesHeadlessOneShotRuntime live on officeTargeter (PLAN.md §C2);
-// these wrappers keep ~30 in-package callers compiling without a rename
-// sweep in this PR.
-func (l *Launcher) usesPaneRuntime() bool { return l.targeter().UsesPaneRuntime() }
+// usesPaneRuntime / requiresClaudeSessionReset /
+// memberEffectiveProviderKind / memberUsesHeadlessOneShotRuntime
+// live on officeTargeter (PLAN.md §C2). PLAN.md §6 sweep deleted the
+// transitional wrappers; in-package callers use
+// l.targeter().<Method>() directly. UsesTmuxRuntime stays because
+// cmd/wuphf/main.go imports it.
 
-func (l *Launcher) requiresClaudeSessionReset() bool {
-	return l.targeter().RequiresClaudeSessionReset()
-}
-
-func (l *Launcher) memberEffectiveProviderKind(slug string) string {
-	return l.targeter().MemberEffectiveProviderKind(slug)
-}
-
-func (l *Launcher) memberUsesHeadlessOneShotRuntime(slug string) bool {
-	return l.targeter().MemberUsesHeadlessOneShotRuntime(slug)
-}
-
-// UsesTmuxRuntime reports whether agents run in tmux panes. Equivalent to
-// usesPaneRuntime — exported for cmd/wuphf/main.go and tests.
+// UsesTmuxRuntime reports whether agents run in tmux panes. Exported
+// for cmd/wuphf/main.go and tests; thin delegator over the targeter.
 func (l *Launcher) UsesTmuxRuntime() bool {
-	return l.usesPaneRuntime()
+	return l.targeter().UsesPaneRuntime()
 }
 
 func (l *Launcher) BrokerToken() string {
@@ -1606,7 +1557,7 @@ func (l *Launcher) Kill() error {
 	// still alive to release any open handles (harmless, but principle of
 	// least surprise).
 	l.cleanupAgentTempFiles()
-	if !l.usesPaneRuntime() {
+	if !l.targeter().UsesPaneRuntime() {
 		if err := killPersistedOfficeProcess(); err != nil {
 			return err
 		}
@@ -1627,7 +1578,7 @@ func (l *Launcher) Kill() error {
 }
 
 func (l *Launcher) ResetSession() error {
-	if !l.requiresClaudeSessionReset() {
+	if !l.targeter().RequiresClaudeSessionReset() {
 		if l != nil && l.broker != nil {
 			l.broker.Reset()
 			return nil
@@ -1651,7 +1602,7 @@ func (l *Launcher) ResetSession() error {
 }
 
 func (l *Launcher) ReconfigureSession() error {
-	if !l.usesPaneRuntime() {
+	if !l.targeter().UsesPaneRuntime() {
 		if err := provider.ResetClaudeSessions(); err != nil {
 			return fmt.Errorf("reset Claude sessions: %w", err)
 		}
@@ -1666,7 +1617,7 @@ func (l *Launcher) ReconfigureSession() error {
 
 func (l *Launcher) reconfigureVisibleAgents() error {
 	l.provider = config.ResolveLLMProvider("")
-	if !l.usesPaneRuntime() {
+	if !l.targeter().UsesPaneRuntime() {
 		if l.paneBackedAgents {
 			l.panes().KillSession()
 			l.paneBackedAgents = false
@@ -1696,7 +1647,7 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 
 	// Respawn each agent pane in place, preserving layout.
 	// Never clear+recreate panes — that destroys the channel's layout.
-	visibleMembers := l.visibleOfficeMembers()
+	visibleMembers := l.targeter().VisibleMembers()
 	if len(panes) != len(visibleMembers) {
 		if err := l.clearAgentPanes(); err != nil {
 			return err
@@ -1881,7 +1832,7 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 		)
 	}
 
-	if l.shouldUseHeadlessDispatchForTarget(target) {
+	if l.targeter().ShouldUseHeadlessForTarget(target) {
 		l.enqueueHeadlessCodexTurn(target.Slug, headlessSandboxNote()+notification, channel)
 		return
 	}
@@ -1890,7 +1841,8 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 
 // shouldUseHeadlessDispatch is a thin wrapper around the targeter; see
 // officeTargeter.ShouldUseHeadless for semantics.
-func (l *Launcher) shouldUseHeadlessDispatch() bool { return l.targeter().ShouldUseHeadless() }
+// shouldUseHeadlessDispatch wrapper deleted by PLAN.md §6 sweep —
+// callers use l.targeter().ShouldUseHeadless() directly.
 
 // Minimum gap between two consecutive pane `/clear` + type cycles for the
 // same agent. Serves as a safety floor against truly back-to-back sends
@@ -1960,14 +1912,14 @@ func (l *Launcher) panes() *paneLifecycle {
 		cwd:                              l.cwd,
 		isOneOnOne:                       l.isOneOnOne,
 		oneOnOneAgent:                    l.oneOnOneAgent,
-		usesPaneRuntime:                  l.usesPaneRuntime,
-		visibleOfficeMembers:             l.visibleOfficeMembers,
-		overflowOfficeMembers:            l.overflowOfficeMembers,
-		agentPaneTargets:                 l.agentPaneTargets,
-		memberUsesHeadlessOneShotRuntime: l.memberUsesHeadlessOneShotRuntime,
+		usesPaneRuntime:                  l.targeter().UsesPaneRuntime,
+		visibleOfficeMembers:             l.targeter().VisibleMembers,
+		overflowOfficeMembers:            l.targeter().OverflowMembers,
+		agentPaneTargets:                 l.targeter().PaneTargets,
+		memberUsesHeadlessOneShotRuntime: l.targeter().MemberUsesHeadlessOneShotRuntime,
 		claudeCommand:                    l.claudeCommand,
 		buildPrompt:                      l.buildPrompt,
-		agentName:                        l.getAgentName,
+		agentName:                        l.targeter().NameFor,
 		recordFailure:                    l.recordPaneSpawnFailure,
 		paneBackedFlag:                   &l.paneBackedAgents,
 	}
@@ -2132,7 +2084,7 @@ func (l *Launcher) newPromptBuilder() *promptBuilder {
 		isOneOnOne:  l.isOneOnOne,
 		isFocusMode: l.isFocusModeEnabled,
 		packName:    l.PackName,
-		leadSlug:    l.officeLeadSlug,
+		leadSlug:    l.targeter().LeadSlug,
 		members:     l.officeMembersSnapshot,
 		policies: func() []officePolicy {
 			if l == nil || l.broker == nil {
@@ -2144,7 +2096,7 @@ func (l *Launcher) newPromptBuilder() *promptBuilder {
 			sort.Slice(policies, func(i, j int) bool { return policies[i].ID < policies[j].ID })
 			return policies
 		},
-		nameFor:        l.getAgentName,
+		nameFor:        l.targeter().NameFor,
 		markdownMemory: memoryBackend == config.MemoryBackendMarkdown,
 		nexDisabled:    noNex,
 	}
@@ -2178,7 +2130,7 @@ func (l *Launcher) claudeCommand(slug, systemPrompt string) (string, error) {
 	}
 	promptPathQuoted := strings.ReplaceAll(promptPath, "'", "'\\''")
 
-	name := strings.ReplaceAll(l.getAgentName(slug), "'", "'\\''")
+	name := strings.ReplaceAll(l.targeter().NameFor(slug), "'", "'\\''")
 	permFlags := l.resolvePermissionFlags(slug)
 
 	brokerToken := ""
@@ -2630,7 +2582,8 @@ func (l *Launcher) officeMemberBySlug(slug string) officeMember {
 	return l.targeter().MemberBySlug(slug)
 }
 
-func (l *Launcher) officeLeadSlug() string { return l.targeter().LeadSlug() }
+// officeLeadSlug wrapper deleted by PLAN.md §6 sweep — callers use
+// l.targeter().LeadSlug() directly.
 
 func agentConfigFromMember(member officeMember) agent.AgentConfig {
 	cfg := agent.AgentConfig{
@@ -2660,7 +2613,7 @@ func (l *Launcher) activeSessionMembers() []officeMember {
 // PackName returns the display name of the pack.
 func (l *Launcher) PackName() string {
 	if l.isOneOnOne() {
-		return "1:1 with " + l.getAgentName(l.oneOnOneAgent())
+		return "1:1 with " + l.targeter().NameFor(l.oneOnOneAgent())
 	}
 	return "WUPHF Office"
 }
@@ -2685,9 +2638,8 @@ func filterEnv(env []string, key string) []string {
 	return out
 }
 
-// getAgentName returns the display name for an agent slug. Delegates to
-// the targeter (PLAN.md §C2).
-func (l *Launcher) getAgentName(slug string) string { return l.targeter().NameFor(slug) }
+// getAgentName wrapper deleted by PLAN.md §6 sweep — callers use
+// l.targeter().NameFor(slug) directly.
 
 // Web-mode entry points (PreflightWeb, LaunchWeb, maybeOfferNex,
 // waitForWebReady, stdinIsTTY, openBrowser) live in launcher_web.go per

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -81,7 +81,7 @@ func TestAgentPaneSlugsOneOnOneUsesOnlySelectedAgent(t *testing.T) {
 		oneOnOne:    "pm",
 	}
 
-	got := l.agentPaneSlugs()
+	got := l.targeter().PaneSlugs()
 	if len(got) != 1 || got[0] != "pm" {
 		t.Fatalf("expected only pm in 1o1 pane list, got %v", got)
 	}
@@ -144,7 +144,7 @@ func TestAgentPaneSlugsUsesOfficeRosterNotStaticPack(t *testing.T) {
 		},
 	}
 
-	got := l.agentPaneSlugs()
+	got := l.targeter().PaneSlugs()
 	want := []string{"ceo", "pm", "fe", "growthops"}
 	if len(got) != len(want) {
 		t.Fatalf("expected %d pane slugs, got %v", len(want), got)

--- a/internal/team/mention_routing_bug_test.go
+++ b/internal/team/mention_routing_bug_test.go
@@ -187,9 +187,9 @@ func TestBug_HumanTagsSpecialist_Dispatch_SpecialistReceivesTurn(t *testing.T) {
 
 	immediate, _ := l.notificationTargetsForMessage(msg)
 	t.Logf("notification targets: %+v", immediate)
-	t.Logf("agentNotificationTargets: %+v", l.agentNotificationTargets())
+	t.Logf("agentNotificationTargets: %+v", l.targeter().NotificationTargets())
 	t.Logf("activeSessionMembers: %+v", l.activeSessionMembers())
-	t.Logf("officeLeadSlug: %q", l.officeLeadSlug())
+	t.Logf("officeLeadSlug: %q", l.targeter().LeadSlug())
 
 	l.deliverMessageNotification(msg)
 
@@ -432,7 +432,7 @@ func TestBug_DMToWizardHiredPM_Dispatch(t *testing.T) {
 		},
 	}
 
-	targetMap := l.agentNotificationTargets()
+	targetMap := l.targeter().NotificationTargets()
 	t.Logf("targetMap after hiring pm: %+v", targetMap)
 
 	immediate, _ := l.notificationTargetsForMessage(channelMessage{
@@ -487,7 +487,7 @@ func TestBug_TagWizardHiredPM_InGeneral_Dispatch(t *testing.T) {
 		t.Fatalf(
 			"bug reproduced: @pm in #general did not reach pm. targetMap=%+v immediate=%+v. "+
 				"Wizard-hired agents must be reachable via explicit @-tag.",
-			l.agentNotificationTargets(), immediate,
+			l.targeter().NotificationTargets(), immediate,
 		)
 	}
 }
@@ -524,7 +524,7 @@ func TestBug_RootCause_ChannelMembershipFilterDropsExplicitMention(t *testing.T)
 	}
 
 	// Sanity: fe IS in the target map (pane/headless resolution is correct).
-	targetMap := l.agentNotificationTargets()
+	targetMap := l.targeter().NotificationTargets()
 	if _, ok := targetMap["fe"]; !ok {
 		t.Fatalf("pre-condition failed: fe should be in agentNotificationTargets: %+v", targetMap)
 	}

--- a/internal/team/office_targets_test.go
+++ b/internal/team/office_targets_test.go
@@ -444,7 +444,7 @@ func TestLauncher_TargeterWiringMatchesPaneTargets(t *testing.T) {
 		},
 		failedPaneSlugs: map[string]string{},
 	}
-	got := l.agentPaneTargets()
+	got := l.targeter().PaneTargets()
 	if _, ok := got["ceo"]; !ok {
 		t.Fatalf("expected ceo in launcher pane targets, got %v", got)
 	}

--- a/internal/team/pane_capture.go
+++ b/internal/team/pane_capture.go
@@ -90,7 +90,7 @@ func (l *Launcher) startPaneCaptureLoops(ctx context.Context) {
 	if !l.paneBackedAgents || l.broker == nil {
 		return
 	}
-	targets := l.agentPaneTargets()
+	targets := l.targeter().PaneTargets()
 	for slug, target := range targets {
 		if slug == "" || target.PaneTarget == "" {
 			continue
@@ -141,7 +141,7 @@ func (l *Launcher) paneCaptureLoop(ctx context.Context, slug, paneTarget string)
 					return
 				case <-time.After(paneCaptureRetryAfterDeath):
 				}
-				if newTarget, ok := l.resolvePaneTargetForSlug(slug); ok && newTarget != "" {
+				if newTarget, ok := l.targeter().ResolvePaneTarget(slug); ok && newTarget != "" {
 					paneTarget = newTarget
 				}
 				// Clear prev-line cache so the re-surfaced pane pushes a

--- a/internal/team/resume.go
+++ b/internal/team/resume.go
@@ -126,7 +126,7 @@ func (l *Launcher) buildResumePackets() map[string]string {
 	}
 
 	// Determine office lead slug.
-	lead := l.officeLeadSlug()
+	lead := l.targeter().LeadSlug()
 
 	// Collect in-flight tasks per owner — skip owners not in the pack.
 	tasksByAgent := make(map[string][]teamTask)
@@ -225,9 +225,9 @@ func (l *Launcher) resumeInFlightWork() {
 		return
 	}
 
-	paneTargets := l.agentPaneTargets()
+	paneTargets := l.targeter().PaneTargets()
 	routePacket := func(slug, packet string) {
-		if l.memberUsesHeadlessOneShotRuntime(slug) || !l.paneBackedAgents {
+		if l.targeter().MemberUsesHeadlessOneShotRuntime(slug) || !l.paneBackedAgents {
 			l.enqueueHeadlessCodexTurn(slug, packet)
 			return
 		}
@@ -239,7 +239,7 @@ func (l *Launcher) resumeInFlightWork() {
 		launcherSendNotificationToPane(l, target.PaneTarget, packet)
 	}
 
-	lead := l.officeLeadSlug()
+	lead := l.targeter().LeadSlug()
 	if packet, ok := packets[lead]; ok {
 		routePacket(lead, packet)
 	}

--- a/internal/team/template.go
+++ b/internal/team/template.go
@@ -26,7 +26,7 @@ func (l *Launcher) GenerateMemberTemplateFromPrompt(request string) (generatedMe
 	if stub := strings.TrimSpace(os.Getenv("WUPHF_AGENT_TEMPLATE_STUB")); stub != "" {
 		return parseGeneratedMemberTemplate(stub)
 	}
-	systemPrompt := l.buildPrompt(l.officeLeadSlug()) + `
+	systemPrompt := l.buildPrompt(l.targeter().LeadSlug()) + `
 
 You are designing a NEW office teammate template for WUPHF.
 Return exactly one JSON object and nothing else.
@@ -104,7 +104,7 @@ func (l *Launcher) GenerateChannelTemplateFromPrompt(request string) (generatedC
 	if stub := strings.TrimSpace(os.Getenv("WUPHF_CHANNEL_TEMPLATE_STUB")); stub != "" {
 		return parseGeneratedChannelTemplate(stub)
 	}
-	systemPrompt := l.buildPrompt(l.officeLeadSlug()) + `
+	systemPrompt := l.buildPrompt(l.targeter().LeadSlug()) + `
 
 You are designing a NEW office channel for WUPHF.
 Return exactly one JSON object and nothing else.


### PR DESCRIPTION
Stacked on **#452 (C5f)**. PLAN.md §6 sweep — deletes the 18 one-line Launcher methods that the C2–C7 stack introduced as compatibility shims, and renames the ~50 in-package call sites to use the sub-type method directly.

## Wrappers deleted (all delegated to `l.targeter().X()`)

| Old | New |
|---|---|
| `agentPaneSlugs()` | `targeter().PaneSlugs()` |
| `officeAgentOrder()` | `targeter().AgentOrder()` |
| `visibleOfficeMembers()` | `targeter().VisibleMembers()` |
| `overflowOfficeMembers()` | `targeter().OverflowMembers()` |
| `paneEligibleOfficeMembers()` | `targeter().PaneEligibleMembers()` |
| `resolvePaneTargetForSlug()` | `targeter().ResolvePaneTarget()` |
| `agentPaneTargets()` | `targeter().PaneTargets()` |
| `agentNotificationTargets()` | `targeter().NotificationTargets()` |
| `shouldUseHeadlessDispatchForSlug()` | `targeter().ShouldUseHeadlessForSlug()` |
| `shouldUseHeadlessDispatchForTarget()` | `targeter().ShouldUseHeadlessForTarget()` |
| `skipPaneForSlug()` | `targeter().SkipPane()` |
| `usesPaneRuntime()` | `targeter().UsesPaneRuntime()` |
| `requiresClaudeSessionReset()` | `targeter().RequiresClaudeSessionReset()` |
| `memberEffectiveProviderKind()` | `targeter().MemberEffectiveProviderKind()` |
| `memberUsesHeadlessOneShotRuntime()` | `targeter().MemberUsesHeadlessOneShotRuntime()` |
| `shouldUseHeadlessDispatch()` | `targeter().ShouldUseHeadless()` |
| `officeLeadSlug()` | `targeter().LeadSlug()` |
| `getAgentName()` | `targeter().NameFor()` |

## What stays

- **`UsesTmuxRuntime`** (capital U) is the exported wrapper used by `cmd/wuphf/main.go`. PLAN.md §6 explicitly scopes the sweep to internal callers; this stays.
- Lazy accessors (`l.targeter()`, `l.panes()`, `l.scheduler()`, `l.notifyCtx()`, `l.paneDispatch()`) stay — they're the construction seams, not the wrappers.

## Method-value references

Deps wiring previously used `agentName: l.getAgentName,`. Renamed to `agentName: l.targeter().NameFor,` — a method value bound at construction time to the cached targeter instance (which is reused across calls).

## Diff shape

11 files touched. Mostly mechanical rename via `sed` followed by wrapper deletion in launcher.go.

| File | Δ |
|---|---:|
| launcher.go | 2718 → 2670 (−48) |
| Other 10 files | (call-site renames only) |

**Cumulative since main: 4998 → 2670 = −2328 lines (−46.6%).**

## Local CI matrix (all green)

- gofmt clean
- golangci-lint 0 issues
- bash scripts/test-go.sh — all 32 packages green
- Cross-compile windows-amd64 + darwin-arm64 — clean
- Smoke binary OK

## What's next

The launcher decomposition is structurally complete:

| Definition of done | Status |
|---|---|
| launcher.go < 1000 lines | 2670 (in progress; long way to go on the headless-codex / message-routing clusters which are NOT part of PLAN.md §C scope) |
| Per-file ≥85% on extracted files | ✅ |
| Package coverage ≥75% | 64.4% (was 62.9%; remaining gain comes from continuing to extract logic out of launcher.go) |
| Zero `time.Sleep` in tests we wrote | ✅ |
| Launcher mutex count | ✅ (only `notifyMu` remains; pane / headless / scheduler all moved off) |

Future opportunities (out of PLAN.md §C scope but mentioned for triage):

1. **Headless-codex extraction**: `headless_codex.go` is ~700 lines of headless-turn dispatch logic. A focused C10 cluster could move it onto a `headlessDispatcher` type with its own runner.
2. **Message-routing extraction**: the `deliverMessageNotification` / `deliverTaskNotification` block (~700 lines on Launcher) could become a `notifier` type analogous to `paneDispatcher`.
3. **`launcher.go` residual cleanup**: with C9 done, the remaining 2670 lines are mostly notification orchestration + lifecycle methods (`Launch`, `Attach`, `Kill`, `ResetSession`, `ReconfigureSession`). Splitting into `launcher_lifecycle.go` + `launcher_notifications.go` would make ownership obvious.
