### PR TITLE
[codex] fix unread store blank channel handling

### DIFF
--- a/web/src/stores/app.test.ts
+++ b/web/src/stores/app.test.ts
@@ -88,6 +88,15 @@ describe("channel unread state", () => {
     expect(useAppStore.getState().unreadByChannel.general).toBe(1);
   });
 
+  it("ignores blank channel names for unread actions", () => {
+    useAppStore.setState({ unreadByChannel: { general: 1 } });
+
+    useAppStore.getState().incrementUnread("   ");
+    useAppStore.getState().clearUnread("");
+
+    expect(useAppStore.getState().unreadByChannel).toEqual({ general: 1 });
+  });
+
   it("clears a channel when navigating to its message view", () => {
     useAppStore.setState({
       currentChannel: "general",

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -323,7 +323,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setLastMessageId: (id) => set({ lastMessageId: id }),
   unreadByChannel: {},
   incrementUnread: (channel) => {
-    const ch = channel.trim() || "general";
+    const ch = channel.trim();
+    if (!ch) return;
     set((state) => ({
       unreadByChannel: {
         ...state.unreadByChannel,
@@ -332,7 +333,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }));
   },
   clearUnread: (channel) => {
-    const ch = channel.trim() || "general";
+    const ch = channel.trim();
+    if (!ch) return;
     set((state) => {
       if ((state.unreadByChannel[ch] ?? 0) === 0) return state;
       return {


### PR DESCRIPTION
## Summary
- ignore blank or whitespace channel names in unread store actions
- add regression coverage so blank unread actions do not mutate `general`

## Why
PR #426 left a CodeRabbit follow-up where store-level unread actions could still coerce malformed channel names to `general`, creating phantom unread badges from bad callers.

## Validation
- `bun run test src/stores/app.test.ts src/hooks/useBrokerEvents.test.tsx`
- `bunx biome check src/stores/app.ts src/stores/app.test.ts`
- `bun run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blank or whitespace channel identifiers are now ignored by unread count operations and no longer affect or create unread entries.

* **Tests**
  * Added unit test to validate blank/whitespace channel identifiers do not alter unread count behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->