### PR TITLE
ci(dependabot): grant access to private nex-crm/.github reusables

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,25 @@
 version: 2
+# Grant Dependabot read access to private GitHub repos in the org.
+# Required because workflows under .github/workflows/ consume reusable
+# workflows from the private nex-crm/.github repo (see `uses:
+# nex-crm/.github/...` refs). Without this, every weekly Dependabot
+# run fails closed with `git_dependencies_not_reachable`.
+#
+# `DEPENDABOT_PRIVATE_REPO_TOKEN` is provisioned at the org level —
+# see nex-crm/docs#37 for the original rollout + the gh command to
+# create it.
+registries:
+  nex-crm-github:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{secrets.DEPENDABOT_PRIVATE_REPO_TOKEN}}
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    registries:
+      - nex-crm-github
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
Mirrors [`nex-crm/docs#37`](https://github.com/nex-crm/docs/pull/37) — same dependabot.yml change, same root cause, same one-time secret requirement (already provisioned at the org level).

This repo references the private `nex-crm/.github` repo for reusable workflows, so Dependabot's weekly run hits `git_dependencies_not_reachable` whenever it tries to bump anything that touches one of those refs. Adding the `git` registry config + `DEPENDABOT_PRIVATE_REPO_TOKEN` reference unblocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration with authenticated access to private repositories, enabling automated dependency updates for private reusable workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->