### PR TITLE
refactor(channelui): hoist artifact leaf helpers

### DIFF
--- a/cmd/wuphf/channel_artifacts.go
+++ b/cmd/wuphf/channel_artifacts.go
@@ -175,45 +175,6 @@ func artifactExtraLines(artifact team.RuntimeArtifact) []string {
 	return extra
 }
 
-func artifactLifecyclePill(state, runningColor, pendingColor, failedColor, completedColor string) string {
-	label := strings.ReplaceAll(fallbackString(strings.TrimSpace(state), "retained"), "_", " ")
-	switch strings.ToLower(strings.TrimSpace(state)) {
-	case "blocked", "failed", "canceled", "cancelled":
-		return accentPill(label, failedColor)
-	case "pending", "review", "started":
-		return subtlePill(label, "#FEF3C7", pendingColor)
-	case "completed":
-		return subtlePill(label, "#DCFCE7", completedColor)
-	default:
-		return subtlePill(label, "#DBEAFE", runningColor)
-	}
-}
-
-func artifactAccentColor(state, fallback string) string {
-	switch strings.ToLower(strings.TrimSpace(state)) {
-	case "blocked", "failed", "canceled", "cancelled":
-		return "#B91C1C"
-	case "pending", "review", "started":
-		return "#B45309"
-	case "completed":
-		return "#15803D"
-	default:
-		return fallback
-	}
-}
-
-func parseArtifactTimestamp(primary, fallback string) time.Time {
-	for _, candidate := range []string{strings.TrimSpace(primary), strings.TrimSpace(fallback)} {
-		if candidate == "" {
-			continue
-		}
-		if ts, ok := parseChannelTime(candidate); ok {
-			return ts
-		}
-	}
-	return time.Time{}
-}
-
 func (m channelModel) recentTaskLogArtifacts(limit int) []taskLogArtifact {
 	root := taskLogRoot()
 	entries, err := os.ReadDir(root)
@@ -408,51 +369,6 @@ func readWorkflowRunArtifact(path string, info fs.FileInfo) (workflowRunArtifact
 	return artifact, true
 }
 
-func recentHumanArtifactRequests(requests []channelInterview, limit int) []channelInterview {
-	filtered := make([]channelInterview, 0, len(requests))
-	for _, req := range requests {
-		kind := strings.TrimSpace(req.Kind)
-		switch kind {
-		case "approval", "confirm", "choice", "interview":
-			filtered = append(filtered, req)
-		}
-	}
-	sort.Slice(filtered, func(i, j int) bool {
-		left, lok := parseChannelTime(filtered[i].CreatedAt)
-		right, rok := parseChannelTime(filtered[j].CreatedAt)
-		switch {
-		case lok && rok:
-			return left.After(right)
-		case lok:
-			return true
-		case rok:
-			return false
-		default:
-			return filtered[i].ID > filtered[j].ID
-		}
-	})
-	if limit > 0 && len(filtered) > limit {
-		filtered = filtered[:limit]
-	}
-	return filtered
-}
-
-func recentExecutionArtifactActions(actions []channelAction, limit int) []channelAction {
-	filtered := make([]channelAction, 0, len(actions))
-	for _, action := range actions {
-		kind := strings.TrimSpace(action.Kind)
-		if strings.HasPrefix(kind, "request_") || strings.HasPrefix(kind, "external_") || strings.HasPrefix(kind, "interrupt_") || strings.HasPrefix(kind, "human_") {
-			filtered = append(filtered, action)
-		}
-	}
-	if limit > 0 && len(filtered) > limit {
-		filtered = filtered[len(filtered)-limit:]
-	}
-	out := append([]channelAction(nil), filtered...)
-	reverseAny(out)
-	return out
-}
-
 func taskLogRoot() string {
 	if root := strings.TrimSpace(os.Getenv("WUPHF_TASK_LOG_ROOT")); root != "" {
 		return root
@@ -462,24 +378,4 @@ func taskLogRoot() string {
 		return filepath.Join(".wuphf", "office", "tasks")
 	}
 	return filepath.Join(home, ".wuphf", "office", "tasks")
-}
-
-func artifactClock(timestamp string, fallback time.Time) string {
-	if clock := strings.TrimSpace(shortClock(timestamp)); clock != "" {
-		return clock
-	}
-	if !fallback.IsZero() {
-		return fallback.Local().Format("15:04")
-	}
-	return "artifact"
-}
-
-func artifactTime(timestamp string, fallback time.Time) string {
-	if strings.TrimSpace(timestamp) != "" {
-		return timestamp
-	}
-	if !fallback.IsZero() {
-		return fallback.Format(time.RFC3339)
-	}
-	return ""
 }

--- a/cmd/wuphf/channelui/artifacts.go
+++ b/cmd/wuphf/channelui/artifacts.go
@@ -1,0 +1,135 @@
+package channelui
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// ArtifactLifecyclePill renders an artifact lifecycle state as a
+// colored pill. The four color args are accents that callers pick
+// from the surrounding theme: runningColor (default running),
+// pendingColor (yellow-ish), failedColor (red-ish), completedColor
+// (green-ish). Empty / unknown states fall back to "retained".
+func ArtifactLifecyclePill(state, runningColor, pendingColor, failedColor, completedColor string) string {
+	label := strings.ReplaceAll(FallbackString(strings.TrimSpace(state), "retained"), "_", " ")
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "blocked", "failed", "canceled", "cancelled":
+		return AccentPill(label, failedColor)
+	case "pending", "review", "started":
+		return SubtlePill(label, "#FEF3C7", pendingColor)
+	case "completed":
+		return SubtlePill(label, "#DCFCE7", completedColor)
+	default:
+		return SubtlePill(label, "#DBEAFE", runningColor)
+	}
+}
+
+// ArtifactAccentColor returns the artifact card border color matching
+// state — red for blocked/failed/canceled, amber for
+// pending/review/started, green for completed, fallback otherwise.
+func ArtifactAccentColor(state, fallback string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "blocked", "failed", "canceled", "cancelled":
+		return "#B91C1C"
+	case "pending", "review", "started":
+		return "#B45309"
+	case "completed":
+		return "#15803D"
+	default:
+		return fallback
+	}
+}
+
+// ParseArtifactTimestamp tries to parse primary first, then fallback,
+// returning the first parseable time or the zero time when both fail
+// or are empty. Strings are trimmed before parsing.
+func ParseArtifactTimestamp(primary, fallback string) time.Time {
+	for _, candidate := range []string{strings.TrimSpace(primary), strings.TrimSpace(fallback)} {
+		if candidate == "" {
+			continue
+		}
+		if ts, ok := ParseChannelTime(candidate); ok {
+			return ts
+		}
+	}
+	return time.Time{}
+}
+
+// RecentHumanArtifactRequests filters requests to the human-decision
+// kinds (approval / confirm / choice / interview), sorts by CreatedAt
+// newest-first, and caps to limit. limit <= 0 keeps all matches.
+func RecentHumanArtifactRequests(requests []Interview, limit int) []Interview {
+	filtered := make([]Interview, 0, len(requests))
+	for _, req := range requests {
+		kind := strings.TrimSpace(req.Kind)
+		switch kind {
+		case "approval", "confirm", "choice", "interview":
+			filtered = append(filtered, req)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		left, lok := ParseChannelTime(filtered[i].CreatedAt)
+		right, rok := ParseChannelTime(filtered[j].CreatedAt)
+		switch {
+		case lok && rok:
+			return left.After(right)
+		case lok:
+			return true
+		case rok:
+			return false
+		default:
+			return filtered[i].ID > filtered[j].ID
+		}
+	})
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	return filtered
+}
+
+// RecentExecutionArtifactActions returns up to limit actions whose
+// Kind starts with request_/external_/interrupt_/human_, in
+// newest-first order.
+func RecentExecutionArtifactActions(actions []Action, limit int) []Action {
+	filtered := make([]Action, 0, len(actions))
+	for _, action := range actions {
+		kind := strings.TrimSpace(action.Kind)
+		if strings.HasPrefix(kind, "request_") || strings.HasPrefix(kind, "external_") || strings.HasPrefix(kind, "interrupt_") || strings.HasPrefix(kind, "human_") {
+			filtered = append(filtered, action)
+		}
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[len(filtered)-limit:]
+	}
+	out := append([]Action(nil), filtered...)
+	reverseAny(out)
+	return out
+}
+
+// ArtifactClock returns a short HH:MM time label — preferring the
+// timestamp string parsed via ShortClock, then a local-formatted
+// fallback time, finally the literal "artifact" when neither is
+// available.
+func ArtifactClock(timestamp string, fallback time.Time) string {
+	if clock := strings.TrimSpace(ShortClock(timestamp)); clock != "" {
+		return clock
+	}
+	if !fallback.IsZero() {
+		return fallback.Local().Format("15:04")
+	}
+	return "artifact"
+}
+
+// ArtifactTime returns timestamp when non-empty, else fallback in
+// RFC3339, else "". Used as the canonical timestamp string when
+// emitting artifacts.
+func ArtifactTime(timestamp string, fallback time.Time) string {
+	if strings.TrimSpace(timestamp) != "" {
+		return timestamp
+	}
+	if !fallback.IsZero() {
+		return fallback.Format(time.RFC3339)
+	}
+	return ""
+}

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -143,6 +143,14 @@
 //     ExecutionMetaLine, LatestRelevantAction, DescribeActionState,
 //     ActivityPill (member-activity → colored pill),
 //     ActionStatePill (action kind → colored pill).
+//   - artifacts.go         — artifact-card leaf helpers:
+//     ArtifactLifecyclePill, ArtifactAccentColor (state →
+//     border color), ParseArtifactTimestamp,
+//     RecentHumanArtifactRequests (filter+sort decision-kind
+//     interviews), RecentExecutionArtifactActions
+//     (request_/external_/interrupt_/human_ kinds, newest first),
+//     ArtifactClock (HH:MM with fallback), ArtifactTime
+//     (RFC3339 emit string).
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -210,6 +210,14 @@ var (
 	describeActionState          = channelui.DescribeActionState
 	activityPill                 = channelui.ActivityPill
 	actionStatePill              = channelui.ActionStatePill
+
+	artifactLifecyclePill          = channelui.ArtifactLifecyclePill
+	artifactAccentColor            = channelui.ArtifactAccentColor
+	parseArtifactTimestamp         = channelui.ParseArtifactTimestamp
+	recentHumanArtifactRequests    = channelui.RecentHumanArtifactRequests
+	recentExecutionArtifactActions = channelui.RecentExecutionArtifactActions
+	artifactClock                  = channelui.ArtifactClock
+	artifactTime                   = channelui.ArtifactTime
 )
 
 // Channel-confirm action typed-string consts.


### PR DESCRIPTION
## Summary

Moves the pure artifact-card leaf helpers off \`channel_artifacts.go\` and into \`channelui/artifacts.go\`. Stacks on top of #461.

- \`ArtifactLifecyclePill\` — state → \`AccentPill\` / \`SubtlePill\`
- \`ArtifactAccentColor\` — state → border color
- \`ParseArtifactTimestamp\` — primary-then-fallback time parse
- \`RecentHumanArtifactRequests\` — filter to approval/confirm/choice/interview kinds, sort by \`CreatedAt\` newest-first, cap
- \`RecentExecutionArtifactActions\` — \`request_\` / \`external_\` / \`interrupt_\` / \`human_\` kinds, newest-first, cap
- \`ArtifactClock\` — HH:MM with fallback time, then "artifact"
- \`ArtifactTime\` — preferred timestamp, RFC3339 fallback, ""

The \`team\`-bound channelModel methods (\`buildArtifactLines\`, \`currentArtifactSummary\`, \`currentRuntimeArtifacts\`), the IO-heavy helpers (\`recentTaskLogArtifacts\`, \`readTaskLogArtifact\`, \`recentWorkflowRunArtifacts\`, \`readWorkflowRunArtifact\`, \`summarizeTaskLogRecord\`, \`summarizeJSONField\`, \`taskLogRoot\`), and the \`team.RuntimeArtifact\`-bound renderers (\`renderArtifactSection\`, \`renderArtifactHeader\`, \`artifactExtraLines\`) stay in package main.

Aliases preserve every existing lowercase callsite.

## Test plan

- [x] \`go build ./cmd/wuphf\`
- [x] \`go vet ./...\`
- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`golangci-lint run ./cmd/wuphf/...\` — 0 issues
- [x] gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)