### PR TITLE
refactor(channelui): hoist sidebar apps + misc helpers

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -3152,24 +3152,6 @@ type sidebarItem struct {
 	Label string
 }
 
-type officeSidebarApp struct {
-	App   officeApp
-	Label string
-}
-
-func officeSidebarApps() []officeSidebarApp {
-	return []officeSidebarApp{
-		{App: officeAppMessages, Label: "Messages"},
-		{App: officeAppRecovery, Label: "Recovery"},
-		{App: officeAppTasks, Label: "Tasks"},
-		{App: officeAppRequests, Label: "Requests"},
-		{App: officeAppPolicies, Label: "Policies"},
-		{App: officeAppCalendar, Label: "Calendar"},
-		{App: officeAppArtifacts, Label: "Artifacts"},
-		{App: officeAppSkills, Label: "Skills"},
-	}
-}
-
 func (m channelModel) sidebarItems() []sidebarItem {
 	if m.isOneOnOne() {
 		return nil
@@ -3606,25 +3588,6 @@ func (m *channelModel) openRequestActionPicker(req channelInterview) tea.Cmd {
 	return nil
 }
 
-func containsSlug(items []string, want string) bool {
-	for _, item := range items {
-		if item == want {
-			return true
-		}
-	}
-	return false
-}
-
-func pluralizeWord(count int, singular, plural string) string {
-	if count == 1 {
-		return singular
-	}
-	if strings.TrimSpace(plural) != "" {
-		return plural
-	}
-	return singular + "s"
-}
-
 // mergeOfficeMembers returns all current channel members enriched with office roster
 // metadata and broker activity. Members who have not posted yet still appear as idle.
 func mergeOfficeMembers(officeMembers []officeMemberInfo, brokerMembers []channelMember, channel *channelInfo) []channelMember {
@@ -3988,16 +3951,6 @@ func replaceMentionInInput(input []rune, pos int, mention string) ([]rune, int) 
 	return updated, atIdx + len([]rune(mention)) + 1
 }
 
-func normalizeCursorPos(input []rune, pos int) int {
-	if pos < 0 {
-		return 0
-	}
-	if pos > len(input) {
-		return len(input)
-	}
-	return pos
-}
-
 func isComposerWordRune(r rune) bool {
 	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-'
 }
@@ -4086,17 +4039,6 @@ func composerInsertRunes(msg tea.KeyMsg) []rune {
 		return msg.Runes
 	}
 	return nil
-}
-
-func insertComposerRunes(input []rune, pos int, ch []rune) ([]rune, int) {
-	pos = normalizeCursorPos(input, pos)
-	if len(ch) == 0 {
-		return input, pos
-	}
-	tail := make([]rune, len(input[pos:]))
-	copy(tail, input[pos:])
-	input = append(input[:pos], append(ch, tail...)...)
-	return input, pos + len(ch)
 }
 
 func (m *channelModel) maybeActivateChannelPickerFromInput() bool {
@@ -4829,26 +4771,6 @@ func (m channelModel) runCommand(trimmed, threadTarget string) (tea.Model, tea.C
 		}
 		return m, nil
 	}
-}
-
-func extractTagsFromText(text string) []string {
-	var tags []string
-	for _, word := range strings.Fields(text) {
-		if strings.HasPrefix(word, "@") && len(word) > 1 {
-			tag := strings.TrimRight(word[1:], ".,!?;:")
-			tags = append(tags, tag)
-		}
-	}
-	return tags
-}
-
-func channelExists(channels []channelInfo, slug string) bool {
-	for _, ch := range channels {
-		if ch.Slug == slug {
-			return true
-		}
-	}
-	return false
 }
 
 func (m channelModel) currentChannelInfo() *channelInfo {

--- a/cmd/wuphf/channel_sidebar.go
+++ b/cmd/wuphf/channel_sidebar.go
@@ -9,28 +9,6 @@ import (
 	"github.com/charmbracelet/x/ansi"
 )
 
-func visibleSidebarApps(apps []officeSidebarApp, activeApp officeApp, maxRows int) []officeSidebarApp {
-	if maxRows <= 0 || len(apps) == 0 {
-		return nil
-	}
-	if len(apps) <= maxRows {
-		return apps
-	}
-	visible := append([]officeSidebarApp(nil), apps[:maxRows]...)
-	for _, app := range visible {
-		if app.App == activeApp {
-			return visible
-		}
-	}
-	for _, app := range apps {
-		if app.App == activeApp {
-			visible[len(visible)-1] = app
-			return visible
-		}
-	}
-	return visible
-}
-
 // renderSidebar renders the Slack-style sidebar with channels and team members.
 func renderSidebar(channels []channelInfo, members []channelMember, tasks []channelTask, activeChannel string, activeApp officeApp, cursor int, rosterOffset int, focused bool, quickJump quickJumpTarget, workspace workspaceUIState, width, height int, checklist ...onboardingChecklist) string {
 	if width < 2 {

--- a/cmd/wuphf/channelui/composer_input.go
+++ b/cmd/wuphf/channelui/composer_input.go
@@ -1,0 +1,29 @@
+package channelui
+
+// NormalizeCursorPos clamps pos to the valid rune-cursor range
+// [0, len(input)]. Used everywhere the composer's cursor is reset
+// from outside (paste, history recall, slash command insertion).
+func NormalizeCursorPos(input []rune, pos int) int {
+	if pos < 0 {
+		return 0
+	}
+	if pos > len(input) {
+		return len(input)
+	}
+	return pos
+}
+
+// InsertComposerRunes inserts ch into input at pos and returns the
+// updated slice and the new cursor position (just after the
+// inserted runes). pos is normalized via NormalizeCursorPos before
+// insertion. Empty ch is a no-op.
+func InsertComposerRunes(input []rune, pos int, ch []rune) ([]rune, int) {
+	pos = NormalizeCursorPos(input, pos)
+	if len(ch) == 0 {
+		return input, pos
+	}
+	tail := make([]rune, len(input[pos:]))
+	copy(tail, input[pos:])
+	input = append(input[:pos], append(ch, tail...)...)
+	return input, pos + len(ch)
+}

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -151,6 +151,16 @@
 //     (request_/external_/interrupt_/human_ kinds, newest first),
 //     ArtifactClock (HH:MM with fallback), ArtifactTime
 //     (RFC3339 emit string).
+//   - sidebar_apps.go      — sidebar app-stack data:
+//     OfficeSidebarApp struct, OfficeSidebarApps (canonical
+//     8-row stack), VisibleSidebarApps (max-rows fit that always
+//     keeps the active app visible).
+//   - text_misc.go         — small string utilities:
+//     ContainsSlug, PluralizeWord, ExtractTagsFromText (from
+//     "@slug" mentions), ChannelExists.
+//   - composer_input.go    — composer cursor/insertion primitives:
+//     NormalizeCursorPos (clamp to [0, len]), InsertComposerRunes
+//     (rune-aware insert at pos returning new pos).
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/sidebar_apps.go
+++ b/cmd/wuphf/channelui/sidebar_apps.go
@@ -1,0 +1,52 @@
+package channelui
+
+// OfficeSidebarApp is one row in the sidebar's "apps" stack — a
+// typed app id (Messages / Recovery / Tasks / etc.) and its display
+// label.
+type OfficeSidebarApp struct {
+	App   OfficeApp
+	Label string
+}
+
+// OfficeSidebarApps returns the canonical sidebar app stack in the
+// order they render. The Recovery app sits second by design so the
+// "see what changed while you were away" UI is one click below
+// Messages.
+func OfficeSidebarApps() []OfficeSidebarApp {
+	return []OfficeSidebarApp{
+		{App: OfficeAppMessages, Label: "Messages"},
+		{App: OfficeAppRecovery, Label: "Recovery"},
+		{App: OfficeAppTasks, Label: "Tasks"},
+		{App: OfficeAppRequests, Label: "Requests"},
+		{App: OfficeAppPolicies, Label: "Policies"},
+		{App: OfficeAppCalendar, Label: "Calendar"},
+		{App: OfficeAppArtifacts, Label: "Artifacts"},
+		{App: OfficeAppSkills, Label: "Skills"},
+	}
+}
+
+// VisibleSidebarApps returns up to maxRows apps, always keeping the
+// app with App == activeApp visible. When the active app would
+// otherwise be cut off it replaces the last visible row so the user
+// always sees what they have selected.
+func VisibleSidebarApps(apps []OfficeSidebarApp, activeApp OfficeApp, maxRows int) []OfficeSidebarApp {
+	if maxRows <= 0 || len(apps) == 0 {
+		return nil
+	}
+	if len(apps) <= maxRows {
+		return apps
+	}
+	visible := append([]OfficeSidebarApp(nil), apps[:maxRows]...)
+	for _, app := range visible {
+		if app.App == activeApp {
+			return visible
+		}
+	}
+	for _, app := range apps {
+		if app.App == activeApp {
+			visible[len(visible)-1] = app
+			return visible
+		}
+	}
+	return visible
+}

--- a/cmd/wuphf/channelui/text_misc.go
+++ b/cmd/wuphf/channelui/text_misc.go
@@ -1,0 +1,53 @@
+package channelui
+
+import "strings"
+
+// ContainsSlug reports whether items contains want by exact match.
+// Mirrors ContainsString but kept as a distinct name to make slug
+// comparisons read clearly at the callsite.
+func ContainsSlug(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+// PluralizeWord returns singular for count == 1, otherwise plural
+// when non-empty, otherwise singular + "s". Used for "1 reply" /
+// "5 replies", "1 task run" / "5 task runs", etc.
+func PluralizeWord(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	if strings.TrimSpace(plural) != "" {
+		return plural
+	}
+	return singular + "s"
+}
+
+// ExtractTagsFromText returns the slugs after each "@…" mention in
+// text, stripping trailing punctuation (".,!?;:"). Whitespace-split,
+// so "Hi @ceo, can you?" yields []{"ceo"}.
+func ExtractTagsFromText(text string) []string {
+	var tags []string
+	for _, word := range strings.Fields(text) {
+		if strings.HasPrefix(word, "@") && len(word) > 1 {
+			tag := strings.TrimRight(word[1:], ".,!?;:")
+			tags = append(tags, tag)
+		}
+	}
+	return tags
+}
+
+// ChannelExists reports whether channels contains a ChannelInfo with
+// matching Slug.
+func ChannelExists(channels []ChannelInfo, slug string) bool {
+	for _, ch := range channels {
+		if ch.Slug == slug {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -41,6 +41,7 @@ type (
 	channelConfirmAction   = channelui.ChannelConfirmAction
 	channelConfirm         = channelui.ChannelConfirm
 	composerPopupOption    = channelui.ComposerPopupOption
+	officeSidebarApp       = channelui.OfficeSidebarApp
 )
 
 // Function aliases keep the lowercase names callable from package main
@@ -218,6 +219,15 @@ var (
 	recentExecutionArtifactActions = channelui.RecentExecutionArtifactActions
 	artifactClock                  = channelui.ArtifactClock
 	artifactTime                   = channelui.ArtifactTime
+
+	officeSidebarApps   = channelui.OfficeSidebarApps
+	visibleSidebarApps  = channelui.VisibleSidebarApps
+	containsSlug        = channelui.ContainsSlug
+	pluralizeWord       = channelui.PluralizeWord
+	extractTagsFromText = channelui.ExtractTagsFromText
+	channelExists       = channelui.ChannelExists
+	normalizeCursorPos  = channelui.NormalizeCursorPos
+	insertComposerRunes = channelui.InsertComposerRunes
 )
 
 // Channel-confirm action typed-string consts.


### PR DESCRIPTION
## Summary

Three small clusters off cmd/wuphf and into channelui. Stacks on top of #466.

\`channelui/sidebar_apps.go\`:
- \`OfficeSidebarApp\` struct + \`OfficeSidebarApps\` — the canonical Messages/Recovery/Tasks/Requests/Policies/Calendar/Artifacts/Skills stack
- \`VisibleSidebarApps\` — max-rows fit that always keeps the active app on screen (replaces the last row when the active app would otherwise be cut off)

\`channelui/text_misc.go\`:
- \`ContainsSlug\` — exact-match slice contains
- \`PluralizeWord\` — count-aware singular/plural picker
- \`ExtractTagsFromText\` — "@slug" mentions, trailing punctuation stripped
- \`ChannelExists\` — slug match in \`[]ChannelInfo\`

\`channelui/composer_input.go\`:
- \`NormalizeCursorPos\` — clamp \`pos\` to \`[0, len(input)]\`
- \`InsertComposerRunes\` — rune-aware insert at pos with new cursor pos returned

Aliases preserve every existing lowercase callsite.

## Test plan

- [x] \`go build ./cmd/wuphf\`
- [x] \`go vet ./...\`
- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`golangci-lint run ./cmd/wuphf/...\` — 0 issues
- [x] gofmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)