### PR TITLE
refactor(team): regroup pane-dispatch infra + sweep thin wrappers (C15)

### DIFF
--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -16,7 +16,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/agent"
@@ -158,13 +157,11 @@ type headlessWorkerPool struct {
 	workerWg     sync.WaitGroup
 }
 
-// paneDispatchTurn is one queued notification to type into a tmux pane.
-// Held in the per-slug queue, consumed by runPaneDispatchQueue.
-type paneDispatchTurn struct {
-	PaneTarget   string
-	Notification string
-	EnqueuedAt   time.Time
-}
+// paneDispatchTurn moved to pane_dispatch.go (PLAN.md §C15) so the
+// dispatcher type and its on-the-wire turn shape sit in the same
+// file. Same for paneDispatchMinGap, paneDispatchCoalesceWindow,
+// launcherSendNotificationToPaneFn, launcherSendNotificationToPaneOverride,
+// and launcherSendNotificationToPane.
 
 // SetUnsafe enables unrestricted permissions for all agents (CLI-only flag).
 func (l *Launcher) SetUnsafe(v bool) { l.unsafe = v }
@@ -348,17 +345,11 @@ func (l *Launcher) watchdogSchedulerLoop() {
 	l.scheduler().Start(context.Background())
 }
 
-func (l *Launcher) processDueSchedulerJobs() { l.scheduler().processOnce() }
-
-func (l *Launcher) processDueTaskJob(job schedulerJob) { l.scheduler().processTaskJob(job) }
-
-func (l *Launcher) processDueRequestJob(job schedulerJob) { l.scheduler().processRequestJob(job) }
-
-func (l *Launcher) processDueWorkflowJob(job schedulerJob) { l.scheduler().processWorkflowJob(job) }
-
-func (l *Launcher) recordWatchdogLedger(channel, kind, targetID, owner, summary, sourceSignalID string) ([]string, string) {
-	return l.scheduler().recordLedger(channel, kind, targetID, owner, summary, sourceSignalID)
-}
+// processDue* / recordWatchdogLedger thin Launcher wrappers were
+// deleted by the C15 sweep — call sites use l.scheduler().processOnce()
+// / .processTaskJob(...) / .processRequestJob(...) /
+// .processWorkflowJob(...) / .recordLedger(...) directly. PLAN.md §6
+// "no compatibility shims".
 
 func (req humanInterview) TitleOrDefault() string {
 	if strings.TrimSpace(req.Title) != "" {
@@ -535,26 +526,9 @@ func (l *Launcher) notifyCtx() *notificationContextBuilder {
 // shouldUseHeadlessDispatch wrapper deleted by PLAN.md §6 sweep —
 // callers use l.targeter().ShouldUseHeadless() directly.
 
-// Minimum gap between two consecutive pane `/clear` + type cycles for the
-// same agent. Serves as a safety floor against truly back-to-back sends
-// (sub-second bursts) that could race tmux's input buffer. Not a substitute
-// for the coalesce logic below — claude turns typically take 20-60s, which
-// is much larger than any reasonable fixed gap.
-//
-// Declared as var rather than const so tests can shorten it.
-var paneDispatchMinGap = 3 * time.Second
-
-// paneDispatchCoalesceWindow: if a new notification arrives this soon after
-// the previous send, treat claude's current turn as still in flight and
-// MERGE the new content into the next dispatch instead of triggering a
-// fresh `/clear`. Mid-turn clears were wiping claude's in-progress output
-// and dropping one of two rapid @-tags entirely.
-//
-// 60s covers the p95 claude turn duration (including MCP tool calls) in
-// the observed workload. Multiple bursts in the window get concatenated
-// so claude eventually sees one prompt containing every question, answers
-// them together, and never loses one to a mid-turn clear.
-var paneDispatchCoalesceWindow = 60 * time.Second
+// paneDispatchMinGap and paneDispatchCoalesceWindow live in
+// pane_dispatch.go (PLAN.md §C15) — they're dispatcher knobs, not
+// Launcher knobs.
 
 // paneDispatch returns the lazily-constructed dispatcher (PLAN.md §C6).
 // Nil-safe: returns a fresh dispatcher even when l == nil so &Launcher{}
@@ -644,23 +618,13 @@ func (l *Launcher) runPaneDispatchQueue(slug string) {
 	l.paneDispatch().runQueue(slug)
 }
 
-// launcherSendNotificationToPaneFn is the test seam type swapped via
-// setLauncherSendNotificationToPaneForTest.
-type launcherSendNotificationToPaneFn func(l *Launcher, paneTarget, notification string)
-
-// launcherSendNotificationToPaneOverride is read by the pane-dispatch and
-// resume goroutines, so it lives behind atomic.Pointer to stay race-clean
-// against test cleanups that fire while a worker is mid-dispatch.
-// Production reads fall through to sendNotificationToPane.
-var launcherSendNotificationToPaneOverride atomic.Pointer[launcherSendNotificationToPaneFn]
-
-func launcherSendNotificationToPane(l *Launcher, paneTarget, notification string) {
-	if p := launcherSendNotificationToPaneOverride.Load(); p != nil {
-		(*p)(l, paneTarget, notification)
-		return
-	}
-	l.sendNotificationToPane(paneTarget, notification)
-}
+// launcherSendNotificationToPaneFn / launcherSendNotificationToPaneOverride /
+// launcherSendNotificationToPane live in pane_dispatch.go (PLAN.md
+// §C15) so the dispatcher's send seam sits next to the dispatcher.
+// sendNotificationToPane (the unconditional /clear + type + Enter
+// helper) stays here because it's a Launcher method used by the
+// resume path; the dispatcher itself uses launcherSendNotificationToPane
+// instead.
 
 // sendNotificationToPane delivers a notification to a persistent interactive
 // Claude session in a tmux pane. It sends /clear first so each turn starts
@@ -685,61 +649,18 @@ func (l *Launcher) sendNotificationToPane(paneTarget, notification string) {
 
 // capturePaneTargetContent / capturePaneContent / listTeamPanes /
 // channelPaneStatus delegate to paneLifecycle (PLAN.md §C5b). Thin
-// wrappers keep current callers (broker_handlers, watchdog,
-// captureDeadChannelPane, clearAgentPanes) working without a rename
-// sweep in this PR.
-func (l *Launcher) capturePaneTargetContent(target string) (string, error) {
-	return l.panes().CapturePaneTargetContent(target)
-}
-
-func (l *Launcher) capturePaneContent(paneIdx int) (string, error) {
-	return l.panes().CapturePaneContent(paneIdx)
-}
-
-// clearAgentPanes / clearOverflowAgentWindows delegate to paneLifecycle
-// (PLAN.md §C5c).
-func (l *Launcher) clearAgentPanes() error {
-	return l.panes().ClearAgentPanes()
-}
-
-func (l *Launcher) clearOverflowAgentWindows() {
-	l.panes().ClearOverflowAgentWindows()
-}
-
-func (l *Launcher) listTeamPanes() ([]int, error) {
-	return l.panes().ListTeamPanes()
-}
+// pane-method thin wrappers (capturePaneTargetContent, capturePaneContent,
+// listTeamPanes, clearAgentPanes, clearOverflowAgentWindows,
+// channelPaneStatus, captureDeadChannelPane, spawnVisibleAgents,
+// spawnOverflowAgents, detectDeadPanesAfterSpawn, trySpawnWebAgentPanes,
+// reportPaneFallback) deleted by the C15 sweep — call sites use
+// l.panes().<Method>() directly. PLAN.md §6 "no compatibility shims".
 
 // HasLiveTmuxSession returns true if a wuphf-team tmux session is
 // running. Routes through paneLifecycle (PLAN.md §C5b) so tests can
 // drive it via setTmuxRunnerForTest without a real tmux server.
 func HasLiveTmuxSession() bool {
 	return newPaneLifecycle(SessionName).HasLiveSession()
-}
-
-// spawnVisibleAgents / spawnOverflowAgents / detectDeadPanesAfterSpawn /
-// trySpawnWebAgentPanes / reportPaneFallback delegate to paneLifecycle
-// (PLAN.md §C5e). The orchestration bodies moved onto the type via
-// paneLifecycleDeps so `failedPaneSlugs` writes still flow into the
-// same map the targeter reads (PLAN.md trap §1).
-func (l *Launcher) spawnVisibleAgents() ([]string, error) {
-	return l.panes().SpawnVisibleAgents()
-}
-
-func (l *Launcher) spawnOverflowAgents() {
-	l.panes().SpawnOverflowAgents()
-}
-
-func (l *Launcher) detectDeadPanesAfterSpawn(members []officeMember) {
-	l.panes().DetectDeadPanesAfterSpawn(members)
-}
-
-func (l *Launcher) trySpawnWebAgentPanes() {
-	l.panes().TrySpawnWebAgentPanes()
-}
-
-func (l *Launcher) reportPaneFallback(tmuxInstalled bool, summary string, err error) {
-	l.panes().ReportPaneFallback(tmuxInstalled, summary, err)
 }
 
 // recordPaneSpawnFailure marks a slug so agentPaneTargets() omits it and the

--- a/internal/team/launcher_lifecycle.go
+++ b/internal/team/launcher_lifecycle.go
@@ -288,10 +288,10 @@ func (l *Launcher) ReconfigureSession() error {
 		if err := provider.ResetClaudeSessions(); err != nil {
 			return fmt.Errorf("reset Claude sessions: %w", err)
 		}
-		if err := l.clearAgentPanes(); err != nil {
+		if err := l.panes().ClearAgentPanes(); err != nil {
 			return err
 		}
-		l.clearOverflowAgentWindows()
+		l.panes().ClearOverflowAgentWindows()
 		return nil
 	}
 	return l.reconfigureVisibleAgents()
@@ -321,24 +321,24 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 
 	// Use respawn-pane to restart agent processes IN PLACE.
 	// This preserves pane sizes and positions (no layout reset).
-	panes, err := l.listTeamPanes()
+	panes, err := l.panes().ListTeamPanes()
 	if err != nil {
 		return err
 	}
-	l.clearOverflowAgentWindows()
+	l.panes().ClearOverflowAgentWindows()
 
 	// Respawn each agent pane in place, preserving layout.
 	// Never clear+recreate panes — that destroys the channel's layout.
 	visibleMembers := l.targeter().VisibleMembers()
 	if len(panes) != len(visibleMembers) {
-		if err := l.clearAgentPanes(); err != nil {
+		if err := l.panes().ClearAgentPanes(); err != nil {
 			return err
 		}
-		if _, err := l.spawnVisibleAgents(); err != nil {
+		if _, err := l.panes().SpawnVisibleAgents(); err != nil {
 			return err
 		}
-		l.spawnOverflowAgents()
-		go l.detectDeadPanesAfterSpawn(visibleMembers)
+		l.panes().SpawnOverflowAgents()
+		go l.panes().DetectDeadPanesAfterSpawn(visibleMembers)
 		if l.broker != nil {
 			go l.primeVisibleAgents()
 		}
@@ -375,8 +375,8 @@ func (l *Launcher) reconfigureVisibleAgents() error {
 			l.recordPaneSpawnFailure(slug, reason)
 		}
 	}
-	l.spawnOverflowAgents()
-	go l.detectDeadPanesAfterSpawn(visibleMembers)
+	l.panes().SpawnOverflowAgents()
+	go l.panes().DetectDeadPanesAfterSpawn(visibleMembers)
 
 	if l.broker != nil {
 		go l.primeVisibleAgents()

--- a/internal/team/launcher_loops.go
+++ b/internal/team/launcher_loops.go
@@ -27,7 +27,7 @@ func (l *Launcher) watchChannelPaneLoop(channelCmd string) {
 	for {
 		time.Sleep(2 * time.Second)
 
-		status, err := l.channelPaneStatus()
+		status, err := l.panes().ChannelPaneStatus()
 		if err != nil {
 			if isNoSessionError(err.Error()) {
 				return
@@ -48,7 +48,7 @@ func (l *Launcher) watchChannelPaneLoop(channelCmd string) {
 			deadSince = time.Now()
 		}
 		if !snapshotWritten {
-			_ = l.captureDeadChannelPane(status)
+			_ = l.panes().CaptureDeadChannelPane(status)
 			snapshotWritten = true
 		}
 		if time.Since(deadSince) < channelRespawnDelay {

--- a/internal/team/launcher_test.go
+++ b/internal/team/launcher_test.go
@@ -1473,7 +1473,7 @@ func TestRecordWatchdogLedgerCreatesSignalAndDecision(t *testing.T) {
 	b := newTestBroker(t)
 	l := &Launcher{broker: b}
 
-	signalIDs, decisionID := l.recordWatchdogLedger("general", "task_stalled", "task-1", "fe", "Task is stalled.", "signal-1")
+	signalIDs, decisionID := l.scheduler().recordLedger("general", "task_stalled", "task-1", "fe", "Task is stalled.", "signal-1")
 	if decisionID == "" || len(signalIDs) < 1 {
 		t.Fatalf("expected watchdog refs, got signalIDs=%v decisionID=%q", signalIDs, decisionID)
 	}
@@ -2448,7 +2448,7 @@ func TestProcessDueTaskJobResumesRateLimitedBlockedTask(t *testing.T) {
 	}
 
 	l := &Launcher{broker: b, sessionName: "test"}
-	l.processDueTaskJob(schedulerJob{
+	l.scheduler().processTaskJob(schedulerJob{
 		Slug:       normalizeSchedulerSlug("recheck", "client-loop", "task", task.ID),
 		Kind:       "recheck",
 		TargetType: "task",

--- a/internal/team/launcher_workflow_test.go
+++ b/internal/team/launcher_workflow_test.go
@@ -159,7 +159,7 @@ func TestProcessDueWorkflowJobUsesComposioProvider(t *testing.T) {
 	b.scheduler = append(b.scheduler, job)
 
 	l := &Launcher{broker: b}
-	l.processDueWorkflowJob(job)
+	l.scheduler().processWorkflowJob(job)
 
 	actions := b.Actions()
 	if len(actions) == 0 {

--- a/internal/team/pane_dispatch.go
+++ b/internal/team/pane_dispatch.go
@@ -24,8 +24,63 @@ package team
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 )
+
+// paneDispatchTurn is one queued notification to type into a tmux pane.
+// Held in the per-slug queue, consumed by the dispatcher worker.
+type paneDispatchTurn struct {
+	PaneTarget   string
+	Notification string
+	EnqueuedAt   time.Time
+}
+
+// paneDispatchMinGap caps how often the dispatcher will type into the
+// same pane. Two messages arriving in quick succession get coalesced
+// into one /clear + send so claude doesn't see truncated input. The
+// default is 3s — generous enough to absorb the typical "agent
+// responded then human posted" double-tag without losing either.
+var paneDispatchMinGap = 3 * time.Second
+
+// paneDispatchCoalesceWindow: if a new notification arrives this soon
+// after the previous, the queued sends merge into a single Enter+text
+// burst. 60s lets a multi-step claude turn finish before the next
+// /clear fires for a fresh prompt — without it, the dispatcher would
+// step on a still-running turn and produce truncated tool output.
+//
+// Both knobs are package-level vars (not constants) so tests can
+// override them in-process; see pane_dispatch_queue_test.go for the
+// pattern.
+var paneDispatchCoalesceWindow = 60 * time.Second
+
+// launcherSendNotificationToPaneFn is the test seam type swapped via
+// setLauncherSendNotificationToPaneForTest. Production calls
+// launcherSendNotificationToPane directly; tests intercept by
+// installing a fake closure that records or no-ops the send. Kept as
+// a named type so the atomic.Pointer below stays readable.
+type launcherSendNotificationToPaneFn func(l *Launcher, paneTarget, notification string)
+
+// launcherSendNotificationToPaneOverride is read by the pane-dispatch
+// and pane-priming code paths. Tests must never assign directly; use
+// setLauncherSendNotificationToPaneForTest in test_support.go which
+// nests t.Cleanup correctly so concurrent tests don't corrupt each
+// other's overrides.
+var launcherSendNotificationToPaneOverride atomic.Pointer[launcherSendNotificationToPaneFn]
+
+// launcherSendNotificationToPane is the default production send path.
+// The dispatcher's sendFn closure consults the override on every call
+// so tests can intercept without owning the dispatcher. Production
+// delegates to (l *Launcher).sendNotificationToPane (defined in
+// launcher.go) so the actual /clear + send-keys sequence stays
+// alongside the rest of the Launcher's tmux helpers.
+func launcherSendNotificationToPane(l *Launcher, paneTarget, notification string) {
+	if p := launcherSendNotificationToPaneOverride.Load(); p != nil {
+		(*p)(l, paneTarget, notification)
+		return
+	}
+	l.sendNotificationToPane(paneTarget, notification)
+}
 
 // paneDispatcher serializes notifications per agent slug into tmux Claude
 // panes. One goroutine per slug drains its queue with a min-gap floor


### PR DESCRIPTION
Stacked on **#465 (C14)**. Two semantic cleanups bundled — both about "things in the right file, not just things in any file."

## 1. Move pane-dispatch infrastructure into pane_dispatch.go

These declarations all support `paneDispatcher`. They lived in launcher.go for historical reasons. Now they sit next to the type they support:

| Moved | Why |
|---|---|
| `paneDispatchTurn` (struct) | the on-the-wire turn shape consumed by the dispatcher worker |
| `paneDispatchMinGap` (var) | dispatcher knob, not a launcher knob |
| `paneDispatchCoalesceWindow` (var) | same |
| `launcherSendNotificationToPaneFn` (type) | dispatcher's test-seam fn type |
| `launcherSendNotificationToPaneOverride` (atomic.Pointer var) | dispatcher's test seam |
| `launcherSendNotificationToPane` (func) | dispatcher's seam-aware send entry point |

`(l *Launcher).sendNotificationToPane` (the actual /clear + send-keys helper) stays in launcher.go because the resume path also calls it directly.

## 2. Sweep thin pane / scheduler wrappers (PLAN.md §6)

Like C9 did for the targeter wrappers. Each call site renamed via sed; wrappers deleted.

Pane wrappers swept:

| Old | New |
|---|---|
| `l.channelPaneStatus()` | `l.panes().ChannelPaneStatus()` |
| `l.captureDeadChannelPane(s)` | `l.panes().CaptureDeadChannelPane(s)` |
| `l.clearAgentPanes()` | `l.panes().ClearAgentPanes()` |
| `l.clearOverflowAgentWindows()` | `l.panes().ClearOverflowAgentWindows()` |
| `l.listTeamPanes()` | `l.panes().ListTeamPanes()` |
| `l.spawnVisibleAgents()` | `l.panes().SpawnVisibleAgents()` |
| `l.spawnOverflowAgents()` | `l.panes().SpawnOverflowAgents()` |
| `l.detectDeadPanesAfterSpawn(m)` | `l.panes().DetectDeadPanesAfterSpawn(m)` |
| `l.capturePaneTargetContent(t)` | `l.panes().CapturePaneTargetContent(t)` |
| `l.capturePaneContent(idx)` | `l.panes().CapturePaneContent(idx)` |

Scheduler wrappers swept:

| Old | New |
|---|---|
| `l.processDueSchedulerJobs()` | `l.scheduler().processOnce()` |
| `l.processDueTaskJob(j)` | `l.scheduler().processTaskJob(j)` |
| `l.processDueRequestJob(j)` | `l.scheduler().processRequestJob(j)` |
| `l.processDueWorkflowJob(j)` | `l.scheduler().processWorkflowJob(j)` |
| `l.recordWatchdogLedger(...)` | `l.scheduler().recordLedger(...)` |

`trySpawnWebAgentPanes` and `reportPaneFallback` wrappers deleted without renaming — they had zero live call sites (only doc-comment references).

## Diff shape

| File | Δ |
|---|---:|
| launcher.go | 865 → **786** (−79) |
| pane_dispatch.go | +55 |

**Cumulative since main: 4998 → 786 = −4212 lines (−84.3%).**

## Local CI matrix (all green)

- gofmt clean / golangci-lint 0 issues / 32 packages green / cross-compile / smoke binary OK
