### PR TITLE
refactor(team): regroup type defs + remaining wrappers (C16)

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -201,6 +201,16 @@ type humanInterview struct {
 	Answered      *interviewAnswer  `json:"answered,omitempty"`
 }
 
+// TitleOrDefault returns req.Title trimmed, or "Request" if the field
+// is empty or whitespace. Used by the watchdog scheduler when
+// announcing a stalled interview.
+func (req humanInterview) TitleOrDefault() string {
+	if strings.TrimSpace(req.Title) != "" {
+		return req.Title
+	}
+	return "Request"
+}
+
 type teamTask struct {
 	ID               string   `json:"id"`
 	Channel          string   `json:"channel,omitempty"`

--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -130,6 +130,25 @@ type headlessCodexActiveTurn struct {
 	WorkspaceSnapshot string
 }
 
+// headlessWorkerPool groups the per-launcher headless-dispatch state
+// (PLAN.md §C7). All fields are lowercase package-internal — the pool
+// is never used outside `internal/team` and stays an embedded value
+// on Launcher rather than its own pointer so zero-value &Launcher{}
+// in tests gets a usable pool with sane lazy-allocated maps. PR #320's
+// goroutine-leak fix relies on stopCh being lazily allocated under mu
+// before any worker can read it; that contract is preserved here.
+type headlessWorkerPool struct {
+	mu           sync.Mutex
+	ctx          context.Context
+	cancel       context.CancelFunc
+	workers      map[string]bool
+	active       map[string]*headlessCodexActiveTurn
+	queues       map[string][]headlessCodexTurn
+	deferredLead *headlessCodexTurn
+	stopCh       chan struct{}
+	workerWg     sync.WaitGroup
+}
+
 // headlessCodexWorkspaceStatusSnapshotFn is the seam type swapped by tests
 // via setHeadlessCodexWorkspaceStatusSnapshotForTest. Kept as a named type so
 // the atomic.Pointer below stays readable.

--- a/internal/team/launcher.go
+++ b/internal/team/launcher.go
@@ -138,24 +138,11 @@ type Launcher struct {
 	paneLC *paneLifecycle
 }
 
-// headlessWorkerPool groups the per-launcher headless-dispatch state
-// (PLAN.md §C7). All fields are lowercase package-internal — the pool is
-// never used outside `internal/team` and stays an embedded value on
-// Launcher rather than its own pointer so zero-value &Launcher{} in
-// tests gets a usable pool with sane lazy-allocated maps. PR #320's
-// goroutine-leak fix relies on stopCh being lazily allocated under mu
-// before any worker can read it; that contract is preserved here.
-type headlessWorkerPool struct {
-	mu           sync.Mutex
-	ctx          context.Context
-	cancel       context.CancelFunc
-	workers      map[string]bool
-	active       map[string]*headlessCodexActiveTurn
-	queues       map[string][]headlessCodexTurn
-	deferredLead *headlessCodexTurn
-	stopCh       chan struct{}
-	workerWg     sync.WaitGroup
-}
+// headlessWorkerPool moved to headless_codex.go (PLAN.md §C16) so the
+// type sits next to the queue methods that operate on its fields.
+// Launcher embeds it by value via the headless field; the embed is
+// declared on the Launcher struct above so zero-value &Launcher{}
+// fixtures still get a usable pool with sane lazy-allocated maps.
 
 // paneDispatchTurn moved to pane_dispatch.go (PLAN.md §C15) so the
 // dispatcher type and its on-the-wire turn shape sit in the same
@@ -351,12 +338,8 @@ func (l *Launcher) watchdogSchedulerLoop() {
 // .processWorkflowJob(...) / .recordLedger(...) directly. PLAN.md §6
 // "no compatibility shims".
 
-func (req humanInterview) TitleOrDefault() string {
-	if strings.TrimSpace(req.Title) != "" {
-		return req.Title
-	}
-	return "Request"
-}
+// humanInterview.TitleOrDefault moved to broker.go (PLAN.md §C16)
+// next to the type definition.
 
 // targeter returns the office-targeter, lazily constructing it on first
 // access. PLAN.md trap §5.4: tests build &Launcher{} directly and rely on
@@ -464,14 +447,8 @@ func (l *Launcher) OneOnOneAgent() string {
 // ClearPersistedBrokerState, resetBrokerState, brokerBaseURL, and
 // Launcher.BrokerBaseURL live in broker_lifecycle.go per PLAN.md §C8.
 
-func containsSlug(items []string, want string) bool {
-	for _, item := range items {
-		if item == want {
-			return true
-		}
-	}
-	return false
-}
+// containsSlug moved to notifier_targets.go (PLAN.md §C16) — its only
+// in-package caller is the notification routing decision tree.
 
 // notifyCtx returns the notification-context builder, lazily constructing
 // it on first access (PLAN.md §C3). The builder shares state with Launcher
@@ -603,49 +580,14 @@ func (l *Launcher) panes() *paneLifecycle {
 	return l.paneLC
 }
 
-// queuePaneNotification is a thin wrapper around paneDispatcher.Enqueue
-// (PLAN.md §C6). Kept as a Launcher method so existing call sites and
-// the pane_dispatch_queue_test.go safety net don't need a rename sweep
-// in this PR.
-func (l *Launcher) queuePaneNotification(slug, paneTarget, notification string) {
-	l.paneDispatch().Enqueue(slug, paneTarget, notification)
-}
-
-// runPaneDispatchQueue is retained as a Launcher method for compatibility
-// with any in-package goroutine spawn that might still reference the
-// historical name. Internally it just invokes the dispatcher's runQueue.
-func (l *Launcher) runPaneDispatchQueue(slug string) {
-	l.paneDispatch().runQueue(slug)
-}
-
-// launcherSendNotificationToPaneFn / launcherSendNotificationToPaneOverride /
-// launcherSendNotificationToPane live in pane_dispatch.go (PLAN.md
-// §C15) so the dispatcher's send seam sits next to the dispatcher.
-// sendNotificationToPane (the unconditional /clear + type + Enter
-// helper) stays here because it's a Launcher method used by the
-// resume path; the dispatcher itself uses launcherSendNotificationToPane
-// instead.
-
-// sendNotificationToPane delivers a notification to a persistent interactive
-// Claude session in a tmux pane. It sends /clear first so each turn starts
-// with a fresh context window — the work packet carries all required context,
-// so accumulated history is not needed and only causes drift over time.
-// --append-system-prompt is a CLI flag and survives /clear intact.
+// queuePaneNotification + runPaneDispatchQueue thin wrappers deleted by
+// the C16 sweep — call sites use l.paneDispatch().Enqueue(...) and
+// l.paneDispatch().runQueue(...) directly. PLAN.md §6 "no compatibility
+// shims".
 //
-// Callers should prefer queuePaneNotification — this function runs /clear +
-// type + Enter unconditionally, so rapid direct calls will race each other.
-// queuePaneNotification serializes per-slug and inserts the minimum gap.
-func (l *Launcher) sendNotificationToPane(paneTarget, notification string) {
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
-		"-t", paneTarget, "/clear", "Enter",
-	).Run()
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
-		"-t", paneTarget, "-l", notification,
-	).Run()
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
-		"-t", paneTarget, "Enter",
-	).Run()
-}
+// sendNotificationToPane (the actual /clear + send-keys body) and the
+// launcherSendNotificationToPane* seam live in pane_dispatch.go
+// (PLAN.md §C15/§C16) so the dispatcher's send path is co-located.
 
 // capturePaneTargetContent / capturePaneContent / listTeamPanes /
 // channelPaneStatus delegate to paneLifecycle (PLAN.md §C5b). Thin

--- a/internal/team/notifier_delivery.go
+++ b/internal/team/notifier_delivery.go
@@ -120,7 +120,7 @@ func (l *Launcher) sendTaskUpdate(target notificationTarget, action officeAction
 		l.enqueueHeadlessCodexTurn(target.Slug, headlessSandboxNote()+notification, channel)
 		return
 	}
-	l.queuePaneNotification(target.Slug, target.PaneTarget, notification)
+	l.paneDispatch().Enqueue(target.Slug, target.PaneTarget, notification)
 }
 
 // activeHeadlessSlugs returns the slugs that have non-empty headless
@@ -208,5 +208,5 @@ func (l *Launcher) sendChannelUpdate(target notificationTarget, msg channelMessa
 		l.enqueueHeadlessCodexTurn(target.Slug, headlessSandboxNote()+notification, channel)
 		return
 	}
-	l.queuePaneNotification(target.Slug, target.PaneTarget, notification)
+	l.paneDispatch().Enqueue(target.Slug, target.PaneTarget, notification)
 }

--- a/internal/team/notifier_targets.go
+++ b/internal/team/notifier_targets.go
@@ -12,6 +12,19 @@ import (
 	"time"
 )
 
+// containsSlug reports whether the slug list contains want. Moved
+// here from launcher.go (PLAN.md §C16) — the routing decision tree
+// is the only in-package caller. teammcp/server.go has its own copy
+// by the same name; the packages don't share helpers.
+func containsSlug(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
 type officeChangeTaskNotification struct {
 	Target  notificationTarget
 	Action  officeActionLog

--- a/internal/team/pane_dispatch.go
+++ b/internal/team/pane_dispatch.go
@@ -22,6 +22,8 @@ package team
 // the future.
 
 import (
+	"context"
+	"os/exec"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -70,16 +72,36 @@ var launcherSendNotificationToPaneOverride atomic.Pointer[launcherSendNotificati
 
 // launcherSendNotificationToPane is the default production send path.
 // The dispatcher's sendFn closure consults the override on every call
-// so tests can intercept without owning the dispatcher. Production
-// delegates to (l *Launcher).sendNotificationToPane (defined in
-// launcher.go) so the actual /clear + send-keys sequence stays
-// alongside the rest of the Launcher's tmux helpers.
+// so tests can intercept without owning the dispatcher.
 func launcherSendNotificationToPane(l *Launcher, paneTarget, notification string) {
 	if p := launcherSendNotificationToPaneOverride.Load(); p != nil {
 		(*p)(l, paneTarget, notification)
 		return
 	}
 	l.sendNotificationToPane(paneTarget, notification)
+}
+
+// sendNotificationToPane delivers a notification to a persistent
+// interactive Claude session in a tmux pane. It sends /clear first so
+// each turn starts with a fresh context window — the work packet
+// carries all required context, so accumulated history is not needed
+// and only causes drift over time. --append-system-prompt is a CLI
+// flag and survives /clear intact.
+//
+// Callers should prefer paneDispatch().Enqueue — this function runs
+// /clear + type + Enter unconditionally, so rapid direct calls will
+// race each other. The dispatcher serializes per-slug and inserts
+// the minimum gap.
+func (l *Launcher) sendNotificationToPane(paneTarget, notification string) {
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
+		"-t", paneTarget, "/clear", "Enter",
+	).Run()
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
+		"-t", paneTarget, "-l", notification,
+	).Run()
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "send-keys",
+		"-t", paneTarget, "Enter",
+	).Run()
 }
 
 // paneDispatcher serializes notifications per agent slug into tmux Claude

--- a/internal/team/pane_dispatch_queue_test.go
+++ b/internal/team/pane_dispatch_queue_test.go
@@ -49,9 +49,9 @@ func TestQueuePaneNotification_CoalescesBurstsIntoOneDispatch(t *testing.T) {
 	// First enqueue dispatches immediately. Second arrives during its
 	// coalesce window and should be merged into the pending follow-up,
 	// which itself waits out the window before sending.
-	l.queuePaneNotification("pm", "team:1", "what are you working on?")
+	l.paneDispatch().Enqueue("pm", "team:1", "what are you working on?")
 	time.Sleep(20 * time.Millisecond) // let first dispatch complete
-	l.queuePaneNotification("pm", "team:1", "you doing fine?")
+	l.paneDispatch().Enqueue("pm", "team:1", "you doing fine?")
 
 	// Wait out the coalesce window plus slack for the second dispatch.
 	deadline := time.Now().Add(paneDispatchCoalesceWindow + 300*time.Millisecond)
@@ -103,7 +103,7 @@ func TestQueuePaneNotification_SingleTagDispatchesImmediately(t *testing.T) {
 	})
 
 	startedAt := time.Now()
-	l.queuePaneNotification("pm", "team:1", "solo tag")
+	l.paneDispatch().Enqueue("pm", "team:1", "solo tag")
 
 	select {
 	case <-dispatched:
@@ -142,8 +142,8 @@ func TestQueuePaneNotification_DifferentSlugsRunInParallel(t *testing.T) {
 	})
 
 	startedAt := time.Now()
-	l.queuePaneNotification("alpha", "team:a", "first")
-	l.queuePaneNotification("beta", "team:b", "first")
+	l.paneDispatch().Enqueue("alpha", "team:a", "first")
+	l.paneDispatch().Enqueue("beta", "team:b", "first")
 
 	deadline := time.Now().Add(200 * time.Millisecond)
 	for (atomic.LoadInt64(&countA) == 0 || atomic.LoadInt64(&countB) == 0) && time.Now().Before(deadline) {


### PR DESCRIPTION
Stacked on **#469 (C15)**. Continued semantic regrouping. Each declaration moved to where its peers live; remaining thin wrappers swept.

## Type moves

| Moved | To | Why |
|---|---|---|
| `headlessWorkerPool` struct | `headless_codex.go` | belongs next to `headlessCodexTurn` / `headlessCodexActiveTurn` — one conceptual unit |
| `humanInterview.TitleOrDefault` method | `broker.go` | next to the `humanInterview` type definition; was orphaned in launcher.go |
| `containsSlug` helper | `notifier_targets.go` | the only in-package caller is the routing decision tree |

## Method moves

| Moved | To | Why |
|---|---|---|
| `(l *Launcher).sendNotificationToPane` | `pane_dispatch.go` | sits next to `launcherSendNotificationToPane` (which delegates to it) and the rest of the dispatcher's send path |

## Wrapper sweep

| Old | New |
|---|---|
| `l.queuePaneNotification(slug, target, notif)` | `l.paneDispatch().Enqueue(...)` |

`queuePaneNotification` + `runPaneDispatchQueue` Launcher wrappers deleted. Test call sites in `pane_dispatch_queue_test.go` updated via sed.

## launcher.go shrinkage

| Before | After | Δ |
|---:|---:|---:|
| 786 | **728** | −58 |

**Cumulative since main: 4998 → 728 = −4270 lines (−85.4%).**

## Local CI matrix (all green)

- gofmt clean / golangci-lint 0 issues / 32 packages green
