### PR TITLE
refactor(channelui): hoist composer cursor motion + mention helpers

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -17,7 +17,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -3933,74 +3932,6 @@ func (m *channelModel) restoreThreadSnapshot(snapshot channelui.Snapshot) {
 	m.threadInput = append([]rune(nil), snapshot.Input...)
 	m.threadInputPos = normalizeCursorPos(m.threadInput, snapshot.Pos)
 	m.updateThreadOverlays()
-}
-
-func replaceMentionInInput(input []rune, pos int, mention string) ([]rune, int) {
-	text := string(input)
-	if pos < 0 {
-		pos = 0
-	}
-	if pos > len(input) {
-		pos = len(input)
-	}
-	atIdx := strings.LastIndex(text[:pos], "@")
-	if atIdx < 0 {
-		return input, pos
-	}
-	updated := []rune(text[:atIdx] + mention + " " + text[pos:])
-	return updated, atIdx + len([]rune(mention)) + 1
-}
-
-func isComposerWordRune(r rune) bool {
-	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-'
-}
-
-func moveCursorBackwardWord(input []rune, pos int) int {
-	pos = normalizeCursorPos(input, pos)
-	for pos > 0 && !isComposerWordRune(input[pos-1]) {
-		pos--
-	}
-	for pos > 0 && isComposerWordRune(input[pos-1]) {
-		pos--
-	}
-	return pos
-}
-
-func moveCursorForwardWord(input []rune, pos int) int {
-	pos = normalizeCursorPos(input, pos)
-	for pos < len(input) && isComposerWordRune(input[pos]) {
-		pos++
-	}
-	for pos < len(input) && !isComposerWordRune(input[pos]) {
-		pos++
-	}
-	return pos
-}
-
-func moveComposerCursor(input []rune, pos int, key string) (int, bool) {
-	pos = normalizeCursorPos(input, pos)
-	switch key {
-	case "left", "ctrl+b", "alt+h":
-		if pos > 0 {
-			pos--
-		}
-		return pos, true
-	case "right", "ctrl+f", "alt+l":
-		if pos < len(input) {
-			pos++
-		}
-		return pos, true
-	case "ctrl+a", "alt+0":
-		return 0, true
-	case "ctrl+e", "alt+$":
-		return len(input), true
-	case "alt+b":
-		return moveCursorBackwardWord(input, pos), true
-	case "alt+w":
-		return moveCursorForwardWord(input, pos), true
-	default:
-		return pos, false
-	}
 }
 
 func composerMotionKey(msg tea.KeyMsg) (string, bool) {

--- a/cmd/wuphf/channelui/composer_cursor.go
+++ b/cmd/wuphf/channelui/composer_cursor.go
@@ -1,0 +1,90 @@
+package channelui
+
+import (
+	"strings"
+	"unicode"
+)
+
+// ReplaceMentionInInput replaces the in-progress "@…" token at or before
+// pos with mention plus a trailing space. The new cursor position lands
+// just after the inserted space. If no "@" is found before pos the input
+// and pos are returned unchanged.
+func ReplaceMentionInInput(input []rune, pos int, mention string) ([]rune, int) {
+	text := string(input)
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > len(input) {
+		pos = len(input)
+	}
+	atIdx := strings.LastIndex(text[:pos], "@")
+	if atIdx < 0 {
+		return input, pos
+	}
+	updated := []rune(text[:atIdx] + mention + " " + text[pos:])
+	return updated, atIdx + len([]rune(mention)) + 1
+}
+
+// IsComposerWordRune reports whether r is part of a composer "word"
+// for word-motion purposes — letters, digits, '_' and '-'.
+func IsComposerWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-'
+}
+
+// MoveCursorBackwardWord returns the cursor position one word to the
+// left of pos, skipping a leading run of non-word runes then a run of
+// word runes.
+func MoveCursorBackwardWord(input []rune, pos int) int {
+	pos = NormalizeCursorPos(input, pos)
+	for pos > 0 && !IsComposerWordRune(input[pos-1]) {
+		pos--
+	}
+	for pos > 0 && IsComposerWordRune(input[pos-1]) {
+		pos--
+	}
+	return pos
+}
+
+// MoveCursorForwardWord returns the cursor position one word to the
+// right of pos, skipping a run of word runes then a run of non-word
+// runes.
+func MoveCursorForwardWord(input []rune, pos int) int {
+	pos = NormalizeCursorPos(input, pos)
+	for pos < len(input) && IsComposerWordRune(input[pos]) {
+		pos++
+	}
+	for pos < len(input) && !IsComposerWordRune(input[pos]) {
+		pos++
+	}
+	return pos
+}
+
+// MoveComposerCursor maps a key string ("left", "ctrl+a", "alt+b", …)
+// to a new cursor position. The bool return reports whether the key was
+// recognized as a motion; callers use this to decide whether to consume
+// the keypress as a motion or fall through to other handling.
+func MoveComposerCursor(input []rune, pos int, key string) (int, bool) {
+	pos = NormalizeCursorPos(input, pos)
+	switch key {
+	case "left", "ctrl+b", "alt+h":
+		if pos > 0 {
+			pos--
+		}
+		return pos, true
+	case "right", "ctrl+f", "alt+l":
+		if pos < len(input) {
+			pos++
+		}
+		return pos, true
+	case "ctrl+a", "alt+0":
+		return 0, true
+	case "ctrl+e", "alt+$":
+		return len(input), true
+	case "alt+b":
+		return MoveCursorBackwardWord(input, pos), true
+	case "alt+w":
+		return MoveCursorForwardWord(input, pos), true
+	default:
+		return pos, false
+	}
+}

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -161,6 +161,12 @@
 //   - composer_input.go    — composer cursor/insertion primitives:
 //     NormalizeCursorPos (clamp to [0, len]), InsertComposerRunes
 //     (rune-aware insert at pos returning new pos).
+//   - composer_cursor.go   — composer cursor motion + mention helpers:
+//     ReplaceMentionInInput (substitute the in-progress "@…" token),
+//     IsComposerWordRune, MoveCursorBackwardWord / MoveCursorForwardWord
+//     (alt+b / alt+w word jumps), and MoveComposerCursor (key-string
+//     dispatch for left/right/home/end/word motions, with a recognized
+//     bool so callers can fall through unrecognized keys).
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -228,6 +228,12 @@ var (
 	channelExists       = channelui.ChannelExists
 	normalizeCursorPos  = channelui.NormalizeCursorPos
 	insertComposerRunes = channelui.InsertComposerRunes
+
+	replaceMentionInInput  = channelui.ReplaceMentionInInput
+	isComposerWordRune     = channelui.IsComposerWordRune
+	moveCursorBackwardWord = channelui.MoveCursorBackwardWord
+	moveCursorForwardWord  = channelui.MoveCursorForwardWord
+	moveComposerCursor     = channelui.MoveComposerCursor
 )
 
 // Channel-confirm action typed-string consts.


### PR DESCRIPTION
## Summary

Stack PR #19. Hoists five pure composer cursor helpers from package main into `channelui/composer_cursor.go`:

- \`ReplaceMentionInInput\` — substitute the in-progress \`@…\` token with \`mention + space\`.
- \`IsComposerWordRune\` — classify letters/digits/_/- for word-motion.
- \`MoveCursorBackwardWord\` / \`MoveCursorForwardWord\` — alt+b / alt+w word jumps.
- \`MoveComposerCursor\` — key-string dispatcher (left/right/home/end/word) returning new pos + recognized bool.

These are stdlib-only (\`strings\`, \`unicode\`) and have no team / tui / channelModel coupling — natural follow-up to the earlier \`NormalizeCursorPos\` / \`InsertComposerRunes\` extraction in #468 (composer_input.go).

Lowercase aliases keep every existing callsite compiling unchanged. The \`unicode\` import drops out of \`channel.go\` as a side effect.

Stacked on top of \`refactor/channelui-misc-leaves\`.

## Test plan

- [x] \`bash scripts/test-go.sh\` — all 34 packages green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean
- [x] lefthook pre-commit + pre-push hooks green (build / smoke / vhs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)