### PR TITLE
refactor(channelui): hoist message-walking filter helpers

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -2570,25 +2570,6 @@ func (m channelModel) currentMainLines(contentWidth int) []renderedLine {
 	return m.cachedMainLines(contentWidth)
 }
 
-func filterInsightMessages(messages []brokerMessage) []brokerMessage {
-	filtered := make([]brokerMessage, 0, len(messages))
-	for _, msg := range messages {
-		if msg.Kind == "automation" || msg.From == "nex" {
-			filtered = append(filtered, msg)
-		}
-	}
-	return filtered
-}
-
-func latestHumanFacingMessage(messages []brokerMessage) *brokerMessage {
-	for i := len(messages) - 1; i >= 0; i-- {
-		if strings.HasPrefix(strings.TrimSpace(messages[i].Kind), "human_") {
-			return &messages[i]
-		}
-	}
-	return nil
-}
-
 type mouseAction struct {
 	Kind  string
 	Value string
@@ -2899,17 +2880,6 @@ func (m channelModel) selectedInterviewOption() *channelInterviewOption {
 		return nil
 	}
 	return &m.pending.Options[m.selectedOption]
-}
-
-func countUniqueAgents(messages []brokerMessage) int {
-	seen := make(map[string]bool)
-	for _, m := range messages {
-		if m.From == "you" || m.From == "nex" || m.Kind == "automation" {
-			continue
-		}
-		seen[m.From] = true
-	}
-	return len(seen)
 }
 
 func formatUsd(cost float64) string {

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -167,6 +167,11 @@
 //     (alt+b / alt+w word jumps), and MoveComposerCursor (key-string
 //     dispatch for left/right/home/end/word motions, with a recognized
 //     bool so callers can fall through unrecognized keys).
+//   - message_filters.go   — message-walking filters and selectors:
+//     FilterInsightMessages (automation / nex senders for the insight
+//     side panels), LatestHumanFacingMessage (newest human_*-kind
+//     pointer or nil), CountUniqueAgents (distinct senders excluding
+//     "you" / "nex" / kind=="automation").
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/message_filters.go
+++ b/cmd/wuphf/channelui/message_filters.go
@@ -1,0 +1,42 @@
+package channelui
+
+import "strings"
+
+// FilterInsightMessages returns the subset of messages that are
+// automation / context-graph entries — kind "automation" or from the
+// system "nex" sender. Used to populate the insights side panels.
+func FilterInsightMessages(messages []BrokerMessage) []BrokerMessage {
+	filtered := make([]BrokerMessage, 0, len(messages))
+	for _, msg := range messages {
+		if msg.Kind == "automation" || msg.From == "nex" {
+			filtered = append(filtered, msg)
+		}
+	}
+	return filtered
+}
+
+// LatestHumanFacingMessage returns a pointer to the most recent
+// human_*-kind message in messages, or nil if none exist. Walks newest
+// to oldest so the first match wins.
+func LatestHumanFacingMessage(messages []BrokerMessage) *BrokerMessage {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if strings.HasPrefix(strings.TrimSpace(messages[i].Kind), "human_") {
+			return &messages[i]
+		}
+	}
+	return nil
+}
+
+// CountUniqueAgents counts distinct non-system / non-user senders in
+// messages: "you" (the human), "nex" (automation), and kind=="automation"
+// rows are excluded from the tally.
+func CountUniqueAgents(messages []BrokerMessage) int {
+	seen := make(map[string]bool)
+	for _, m := range messages {
+		if m.From == "you" || m.From == "nex" || m.Kind == "automation" {
+			continue
+		}
+		seen[m.From] = true
+	}
+	return len(seen)
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -234,6 +234,10 @@ var (
 	moveCursorBackwardWord = channelui.MoveCursorBackwardWord
 	moveCursorForwardWord  = channelui.MoveCursorForwardWord
 	moveComposerCursor     = channelui.MoveComposerCursor
+
+	filterInsightMessages    = channelui.FilterInsightMessages
+	latestHumanFacingMessage = channelui.LatestHumanFacingMessage
+	countUniqueAgents        = channelui.CountUniqueAgents
 )
 
 // Channel-confirm action typed-string consts.


### PR DESCRIPTION
## Summary

Stack PR #20. Hoists three pure message-walking helpers from package main into \`channelui/message_filters.go\`:

- \`FilterInsightMessages\` — automation / nex-sender subset for the insight side panels.
- \`LatestHumanFacingMessage\` — pointer to newest \`human_*\`-kind message or nil.
- \`CountUniqueAgents\` — distinct senders excluding \`you\` / \`nex\` / kind=\`automation\`.

Stdlib-only (\`strings\`); no team / tui / channelModel coupling.

Stacked on top of \`refactor/channelui-composer-cursor\`.

## Test plan

- [x] \`bash scripts/test-go.sh ./cmd/wuphf\` — green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)