### PR TITLE
refactor(channelui): hoist thread descendant walkers

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -3332,33 +3332,6 @@ func flattenThreadMessages(messages []brokerMessage, expanded map[string]bool) [
 	return out
 }
 
-func countThreadReplies(children map[string][]brokerMessage, rootID string) int {
-	count := 0
-	for _, child := range children[rootID] {
-		count++
-		count += countThreadReplies(children, child.ID)
-	}
-	return count
-}
-
-func threadParticipants(children map[string][]brokerMessage, rootID string) []string {
-	seen := make(map[string]bool)
-	var participants []string
-	var walk func(id string)
-	walk = func(id string) {
-		for _, child := range children[id] {
-			name := displayName(child.From)
-			if !seen[name] {
-				seen[name] = true
-				participants = append(participants, name)
-			}
-			walk(child.ID)
-		}
-	}
-	walk(rootID)
-	return participants
-}
-
 // buildThreadPickerOptions returns picker options for all root messages that have replies.
 func (m channelModel) buildThreadPickerOptions() []tui.PickerOption {
 	// Find root messages with replies

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -78,10 +78,13 @@
 //     for cached snapshots) and RenderTimeBucket (per-second
 //     bucket for direct DMs and the messages app, per-30s
 //     elsewhere).
-//   - threads.go           — thread navigation helpers:
+//   - threads.go           — thread navigation + walker helpers:
 //     ThreadRootMessageID walks ReplyTo to the root,
 //     HasThreadReplies reports whether any message replies to a
-//     given id.
+//     given id, CountThreadReplies / ThreadParticipants recurse
+//     the children-by-ID adjacency map (built by
+//     flattenThreadMessages) to count descendants and collect
+//     distinct reply-author display names in walk-order.
 //   - recovery.go          — recovery leaf helpers:
 //     TrimRecoverySentence, RenderAwayStrip,
 //     RecoverySurgeryOption struct + BuildRecoverySurgeryOptions

--- a/cmd/wuphf/channelui/threads.go
+++ b/cmd/wuphf/channelui/threads.go
@@ -33,3 +33,38 @@ func HasThreadReplies(messages []BrokerMessage, id string) bool {
 	}
 	return false
 }
+
+// CountThreadReplies returns the total number of descendants of rootID
+// in the children adjacency map (built by flattenThreadMessages). The
+// root itself is not counted.
+func CountThreadReplies(children map[string][]BrokerMessage, rootID string) int {
+	count := 0
+	for _, child := range children[rootID] {
+		count++
+		count += CountThreadReplies(children, child.ID)
+	}
+	return count
+}
+
+// ThreadParticipants returns the distinct display names of every
+// descendant sender under rootID in walk-order (depth-first, children
+// in slice order). Names are resolved via the package's office
+// directory so a "ceo" slug becomes its display name. The root sender
+// is intentionally excluded — only replies count.
+func ThreadParticipants(children map[string][]BrokerMessage, rootID string) []string {
+	seen := make(map[string]bool)
+	var participants []string
+	var walk func(id string)
+	walk = func(id string) {
+		for _, child := range children[id] {
+			name := DisplayName(child.From)
+			if !seen[name] {
+				seen[name] = true
+				participants = append(participants, name)
+			}
+			walk(child.ID)
+		}
+	}
+	walk(rootID)
+	return participants
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -147,6 +147,8 @@ var (
 
 	threadRootMessageID = channelui.ThreadRootMessageID
 	hasThreadReplies    = channelui.HasThreadReplies
+	countThreadReplies  = channelui.CountThreadReplies
+	threadParticipants  = channelui.ThreadParticipants
 
 	trimRecoverySentence          = channelui.TrimRecoverySentence
 	renderAwayStrip               = channelui.RenderAwayStrip


### PR DESCRIPTION
## Summary

Stack PR #21. Extends \`channelui/threads.go\` with two pure thread-walker helpers moved from package main:

- \`CountThreadReplies\` — recurses the children-by-ID adjacency map (built by \`flattenThreadMessages\`) to count descendants.
- \`ThreadParticipants\` — walks the same map and returns distinct reply-author display names in walk-order, resolved through \`DisplayName\`.

Stacked on top of \`refactor/channelui-message-filters\`.

## Test plan

- [x] \`bash scripts/test-go.sh ./cmd/wuphf\` — green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)