### PR TITLE
refactor(channelui): hoist small misc pure helpers

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -84,32 +84,6 @@ type channelUsageMsg struct {
 	usage channelUsageState
 }
 
-func appendUniqueMessages(existing, incoming []brokerMessage) ([]brokerMessage, int) {
-	if len(incoming) == 0 {
-		return existing, 0
-	}
-	seen := make(map[string]struct{}, len(existing)+len(incoming))
-	out := make([]brokerMessage, 0, len(existing)+len(incoming))
-	for _, msg := range existing {
-		out = append(out, msg)
-		if strings.TrimSpace(msg.ID) != "" {
-			seen[msg.ID] = struct{}{}
-		}
-	}
-	added := 0
-	for _, msg := range incoming {
-		if id := strings.TrimSpace(msg.ID); id != "" {
-			if _, ok := seen[id]; ok {
-				continue
-			}
-			seen[id] = struct{}{}
-		}
-		out = append(out, msg)
-		added++
-	}
-	return out, added
-}
-
 type channelHealthMsg struct {
 	Connected     bool
 	SessionMode   string
@@ -2575,14 +2549,6 @@ type mouseAction struct {
 	Value string
 }
 
-func popupActionIndex(raw string) (int, bool) {
-	var idx int
-	if _, err := fmt.Sscanf(raw, "%d", &idx); err != nil || idx < 0 {
-		return 0, false
-	}
-	return idx, true
-}
-
 func (m channelModel) mouseActionAt(x, y int) (mouseAction, bool) {
 	if m.width == 0 || m.height == 0 || y >= m.height-1 {
 		return mouseAction{}, false
@@ -2880,10 +2846,6 @@ func (m channelModel) selectedInterviewOption() *channelInterviewOption {
 		return nil
 	}
 	return &m.pending.Options[m.selectedOption]
-}
-
-func formatUsd(cost float64) string {
-	return fmt.Sprintf("$%.2f", cost)
 }
 
 func renderUsageStrip(usage channelUsageState, members []channelMember, width int) string {

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -175,6 +175,11 @@
 //     side panels), LatestHumanFacingMessage (newest human_*-kind
 //     pointer or nil), CountUniqueAgents (distinct senders excluding
 //     "you" / "nex" / kind=="automation").
+//   - misc_helpers.go      — small pure helpers:
+//     AppendUniqueMessages (dedup-by-trimmed-ID merge, returns the
+//     added count), PopupActionIndex (parses the numeric token of a
+//     "popup_action_N" value), FormatUSD (two-decimal "$X.YZ"
+//     dollar-cost formatter).
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/misc_helpers.go
+++ b/cmd/wuphf/channelui/misc_helpers.go
@@ -1,0 +1,55 @@
+package channelui
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AppendUniqueMessages returns existing extended with the entries of
+// incoming whose IDs are not already present, plus the count actually
+// added. Empty / whitespace-only IDs are appended unconditionally — the
+// dedup index is keyed on trimmed IDs only. Order is preserved:
+// existing first, then new arrivals in their incoming order.
+func AppendUniqueMessages(existing, incoming []BrokerMessage) ([]BrokerMessage, int) {
+	if len(incoming) == 0 {
+		return existing, 0
+	}
+	seen := make(map[string]struct{}, len(existing)+len(incoming))
+	out := make([]BrokerMessage, 0, len(existing)+len(incoming))
+	for _, msg := range existing {
+		out = append(out, msg)
+		if strings.TrimSpace(msg.ID) != "" {
+			seen[msg.ID] = struct{}{}
+		}
+	}
+	added := 0
+	for _, msg := range incoming {
+		if id := strings.TrimSpace(msg.ID); id != "" {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+		}
+		out = append(out, msg)
+		added++
+	}
+	return out, added
+}
+
+// PopupActionIndex parses a numeric popup-action token (e.g. the "3"
+// in a "popup_action_3" mouse target) and returns it. Returns
+// (0, false) on a parse error or a negative value, so callers can
+// safely fall through.
+func PopupActionIndex(raw string) (int, bool) {
+	var idx int
+	if _, err := fmt.Sscanf(raw, "%d", &idx); err != nil || idx < 0 {
+		return 0, false
+	}
+	return idx, true
+}
+
+// FormatUSD renders a dollar cost with two decimal places (e.g.
+// "$0.04", "$12.50"). Used in the usage strip / token meta lines.
+func FormatUSD(cost float64) string {
+	return fmt.Sprintf("$%.2f", cost)
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -240,6 +240,10 @@ var (
 	filterInsightMessages    = channelui.FilterInsightMessages
 	latestHumanFacingMessage = channelui.LatestHumanFacingMessage
 	countUniqueAgents        = channelui.CountUniqueAgents
+
+	appendUniqueMessages = channelui.AppendUniqueMessages
+	popupActionIndex     = channelui.PopupActionIndex
+	formatUsd            = channelui.FormatUSD
 )
 
 // Channel-confirm action typed-string consts.


### PR DESCRIPTION
## Summary

Stack PR #22. Three small unrelated-but-pure helpers moved into a new \`channelui/misc_helpers.go\`:

- \`AppendUniqueMessages\` — dedup-by-trimmed-ID merge of two \`BrokerMessage\` slices, returns the added count. Empty/whitespace IDs are appended unconditionally.
- \`PopupActionIndex\` — parses the numeric token of a \`popup_action_N\` mouse-target string; negatives and parse errors return \`(0, false)\`.
- \`FormatUSD\` — \`fmt.Sprintf(\"\$%.2f\")\` formatter used by the usage strip.

Stacked on top of \`refactor/channelui-thread-walkers\`.

## Test plan

- [x] \`bash scripts/test-go.sh ./cmd/wuphf\` — green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)