### PR TITLE
refactor(channelui): hoist FlattenThreadMessages into threads.go

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -3224,74 +3223,6 @@ func (m *channelModel) syncSidebarCursorToActive() {
 		}
 	}
 	m.clampSidebarCursor()
-}
-
-func flattenThreadMessages(messages []brokerMessage, expanded map[string]bool) []threadedMessage {
-	if len(messages) == 0 {
-		return nil
-	}
-
-	// Sort all messages by timestamp first
-	sorted := make([]brokerMessage, len(messages))
-	copy(sorted, messages)
-	sort.SliceStable(sorted, func(i, j int) bool {
-		return sorted[i].Timestamp < sorted[j].Timestamp
-	})
-
-	byID := make(map[string]brokerMessage, len(sorted))
-	children := make(map[string][]brokerMessage)
-	var roots []brokerMessage
-
-	for _, msg := range sorted {
-		byID[msg.ID] = msg
-	}
-	for _, msg := range sorted {
-		if msg.ReplyTo != "" {
-			if _, ok := byID[msg.ReplyTo]; ok {
-				children[msg.ReplyTo] = append(children[msg.ReplyTo], msg)
-				continue
-			}
-		}
-		roots = append(roots, msg)
-	}
-
-	var out []threadedMessage
-	var walk func(msg brokerMessage, depth int)
-	walk = func(msg brokerMessage, depth int) {
-		parentLabel := ""
-		if msg.ReplyTo != "" {
-			parentLabel = msg.ReplyTo
-			if parent, ok := byID[msg.ReplyTo]; ok {
-				parentLabel = "@" + parent.From
-			}
-		}
-		tm := threadedMessage{
-			Message:     msg,
-			Depth:       depth,
-			ParentLabel: parentLabel,
-		}
-		// Threads are expanded by default. Only collapse if explicitly set to false.
-		if len(children[msg.ID]) > 0 {
-			isExpanded, explicit := expanded[msg.ID]
-			if explicit && !isExpanded {
-				tm.Collapsed = true
-				tm.HiddenReplies = countThreadReplies(children, msg.ID)
-				tm.ThreadParticipants = threadParticipants(children, msg.ID)
-			}
-		}
-		out = append(out, tm)
-		if tm.Collapsed {
-			return
-		}
-		for _, child := range children[msg.ID] {
-			walk(child, depth+1)
-		}
-	}
-
-	for _, root := range roots {
-		walk(root, 0)
-	}
-	return out
 }
 
 // buildThreadPickerOptions returns picker options for all root messages that have replies.

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -82,9 +82,13 @@
 //     ThreadRootMessageID walks ReplyTo to the root,
 //     HasThreadReplies reports whether any message replies to a
 //     given id, CountThreadReplies / ThreadParticipants recurse
-//     the children-by-ID adjacency map (built by
-//     flattenThreadMessages) to count descendants and collect
-//     distinct reply-author display names in walk-order.
+//     the children-by-ID adjacency map to count descendants and
+//     collect distinct reply-author display names in walk-order,
+//     and FlattenThreadMessages produces the office-feed thread
+//     layout (timestamp-sorted ThreadedMessage list with depth /
+//     parent-label / collapse state populated; honors expanded[id]
+//     == false to collapse a root and surface HiddenReplies +
+//     ThreadParticipants for the collapsed-summary line).
 //   - recovery.go          — recovery leaf helpers:
 //     TrimRecoverySentence, RenderAwayStrip,
 //     RecoverySurgeryOption struct + BuildRecoverySurgeryOptions

--- a/cmd/wuphf/channelui/threads.go
+++ b/cmd/wuphf/channelui/threads.go
@@ -1,6 +1,9 @@
 package channelui
 
-import "strings"
+import (
+	"sort"
+	"strings"
+)
 
 // ThreadRootMessageID walks up the ReplyTo chain from messageID and
 // returns the root message's ID. Returns the input ID (trimmed) when
@@ -44,6 +47,79 @@ func CountThreadReplies(children map[string][]BrokerMessage, rootID string) int 
 		count += CountThreadReplies(children, child.ID)
 	}
 	return count
+}
+
+// FlattenThreadMessages produces the office-feed thread layout: a
+// timestamp-sorted list of messages where each entry is a
+// ThreadedMessage with Depth, ParentLabel, and (when collapsed)
+// HiddenReplies / ThreadParticipants populated. Threads default to
+// expanded; expanded[msg.ID] == false collapses a thread root and
+// hides its descendants from the output. Dangling ReplyTo targets
+// (parent missing from messages) promote the orphan to a root.
+func FlattenThreadMessages(messages []BrokerMessage, expanded map[string]bool) []ThreadedMessage {
+	if len(messages) == 0 {
+		return nil
+	}
+
+	sorted := make([]BrokerMessage, len(messages))
+	copy(sorted, messages)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return sorted[i].Timestamp < sorted[j].Timestamp
+	})
+
+	byID := make(map[string]BrokerMessage, len(sorted))
+	children := make(map[string][]BrokerMessage)
+	var roots []BrokerMessage
+
+	for _, msg := range sorted {
+		byID[msg.ID] = msg
+	}
+	for _, msg := range sorted {
+		if msg.ReplyTo != "" {
+			if _, ok := byID[msg.ReplyTo]; ok {
+				children[msg.ReplyTo] = append(children[msg.ReplyTo], msg)
+				continue
+			}
+		}
+		roots = append(roots, msg)
+	}
+
+	var out []ThreadedMessage
+	var walk func(msg BrokerMessage, depth int)
+	walk = func(msg BrokerMessage, depth int) {
+		parentLabel := ""
+		if msg.ReplyTo != "" {
+			parentLabel = msg.ReplyTo
+			if parent, ok := byID[msg.ReplyTo]; ok {
+				parentLabel = "@" + parent.From
+			}
+		}
+		tm := ThreadedMessage{
+			Message:     msg,
+			Depth:       depth,
+			ParentLabel: parentLabel,
+		}
+		if len(children[msg.ID]) > 0 {
+			isExpanded, explicit := expanded[msg.ID]
+			if explicit && !isExpanded {
+				tm.Collapsed = true
+				tm.HiddenReplies = CountThreadReplies(children, msg.ID)
+				tm.ThreadParticipants = ThreadParticipants(children, msg.ID)
+			}
+		}
+		out = append(out, tm)
+		if tm.Collapsed {
+			return
+		}
+		for _, child := range children[msg.ID] {
+			walk(child, depth+1)
+		}
+	}
+
+	for _, root := range roots {
+		walk(root, 0)
+	}
+	return out
 }
 
 // ThreadParticipants returns the distinct display names of every

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -145,10 +145,11 @@ var (
 	cloneThreadedMessages = channelui.CloneThreadedMessages
 	renderTimeBucket      = channelui.RenderTimeBucket
 
-	threadRootMessageID = channelui.ThreadRootMessageID
-	hasThreadReplies    = channelui.HasThreadReplies
-	countThreadReplies  = channelui.CountThreadReplies
-	threadParticipants  = channelui.ThreadParticipants
+	threadRootMessageID   = channelui.ThreadRootMessageID
+	hasThreadReplies      = channelui.HasThreadReplies
+	countThreadReplies    = channelui.CountThreadReplies
+	threadParticipants    = channelui.ThreadParticipants
+	flattenThreadMessages = channelui.FlattenThreadMessages
 
 	trimRecoverySentence          = channelui.TrimRecoverySentence
 	renderAwayStrip               = channelui.RenderAwayStrip


### PR DESCRIPTION
## Summary

Stack PR #23. Moves the office-feed thread layout walker from package main into \`channelui/threads.go\` alongside the other thread walkers it depends on (\`CountThreadReplies\`, \`ThreadParticipants\`).

\`FlattenThreadMessages\` produces the office-feed thread layout: a timestamp-sorted \`ThreadedMessage\` list with depth, parent label, and (when collapsed) \`HiddenReplies\` + \`ThreadParticipants\` populated. Threads default to expanded; an explicit \`expanded[id]==false\` collapses a root. Dangling \`ReplyTo\` targets (parent missing) promote the orphan to a root.

The \`sort\` import drops from \`channel.go\` as a side effect.

Stacked on top of \`refactor/channelui-misc-pure-helpers\`.

## Test plan

- [x] \`bash scripts/test-go.sh ./cmd/wuphf\` — green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)