### PR TITLE
refactor(channelui): hoist platform + small CLI helpers

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -4793,50 +4792,6 @@ func tickChannel() tea.Cmd {
 	})
 }
 
-func mapString(m map[string]any, key string) string {
-	if m == nil {
-		return ""
-	}
-	v, ok := m[key]
-	if !ok || v == nil {
-		return ""
-	}
-	switch val := v.(type) {
-	case string:
-		return val
-	default:
-		return fmt.Sprintf("%v", val)
-	}
-}
-
-func openBrowserURL(url string) error {
-	// openBrowserURL spawns a detached helper that hands the URL to the OS.
-	// We use context.Background() because the child must outlive this call —
-	// the user keeps interacting with the browser long after we return — and
-	// noctx's "use CommandContext" recommendation is satisfied by the
-	// background ctx. Cancellation isn't meaningful for a fire-and-forget
-	// open-in-browser handoff.
-	ctx := context.Background()
-	var cmd *exec.Cmd
-	switch {
-	case url == "":
-		return nil
-	case isDarwin():
-		cmd = exec.CommandContext(ctx, "open", url)
-	case isLinux():
-		cmd = exec.CommandContext(ctx, "xdg-open", url)
-	case isWindows():
-		cmd = exec.CommandContext(ctx, "cmd", "/c", "start", "", url)
-	default:
-		return fmt.Errorf("unsupported platform")
-	}
-	return cmd.Start()
-}
-
-func isDarwin() bool  { return runtime.GOOS == "darwin" }
-func isLinux() bool   { return runtime.GOOS == "linux" }
-func isWindows() bool { return runtime.GOOS == "windows" }
-
 // killTeamSession kills the entire wuphf-team tmux session and all agent processes.
 func killTeamSession() {
 	// Best-effort cleanup at process exit; cap each step so a hung tmux or
@@ -4852,19 +4807,6 @@ func killTeamSession() {
 	}
 	if resp, err := http.DefaultClient.Do(req); err == nil {
 		_ = resp.Body.Close()
-	}
-}
-
-func resolveInitialOfficeApp(name string) officeApp {
-	normalized := strings.ToLower(strings.TrimSpace(name))
-	if normalized == "insights" {
-		return officeAppPolicies
-	}
-	switch officeApp(normalized) {
-	case officeAppMessages, officeAppInbox, officeAppOutbox, officeAppRecovery, officeAppTasks, officeAppRequests, officeAppPolicies, officeAppCalendar, officeAppArtifacts:
-		return officeApp(normalized)
-	default:
-		return officeAppMessages
 	}
 }
 

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -204,6 +204,18 @@
 //     and OfficeMembersFallback / ChannelInfosFallback (load the
 //     manifest from disk — falling back to DefaultManifest on
 //     error — when the broker hasn't reported a roster yet).
+//   - platform.go          — IsDarwin / IsLinux / IsWindows
+//     (runtime.GOOS predicates) and OpenBrowserURL (spawns
+//     "open" / "xdg-open" / "cmd /c start" with a background
+//     context for fire-and-forget browser handoff).
+//   - map_string.go        — MapString safely reads a string
+//     field from a map[string]any (used to parse JSON-decoded
+//     broker responses where the shape isn't statically known);
+//     non-string values fall back to fmt.Sprintf("%v").
+//   - initial_app.go       — ResolveInitialOfficeApp normalizes
+//     a CLI-flag string into a known OfficeApp value with the
+//     legacy "insights" alias mapped to OfficeAppPolicies and an
+//     OfficeAppMessages fallback.
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/initial_app.go
+++ b/cmd/wuphf/channelui/initial_app.go
@@ -1,0 +1,20 @@
+package channelui
+
+import "strings"
+
+// ResolveInitialOfficeApp normalizes a CLI-flag string into a known
+// OfficeApp value. Empty / unknown / whitespace input falls back to
+// OfficeAppMessages. The legacy alias "insights" maps to
+// OfficeAppPolicies (which absorbed the old insights surface).
+func ResolveInitialOfficeApp(name string) OfficeApp {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "insights" {
+		return OfficeAppPolicies
+	}
+	switch OfficeApp(normalized) {
+	case OfficeAppMessages, OfficeAppInbox, OfficeAppOutbox, OfficeAppRecovery, OfficeAppTasks, OfficeAppRequests, OfficeAppPolicies, OfficeAppCalendar, OfficeAppArtifacts:
+		return OfficeApp(normalized)
+	default:
+		return OfficeAppMessages
+	}
+}

--- a/cmd/wuphf/channelui/map_string.go
+++ b/cmd/wuphf/channelui/map_string.go
@@ -1,0 +1,23 @@
+package channelui
+
+import "fmt"
+
+// MapString reads key from m as a string. Missing / nil values yield
+// "". String values are returned as-is. Other types are formatted via
+// %v. Used to safely extract fields from JSON-decoded broker
+// responses where the shape isn't statically known.
+func MapString(m map[string]any, key string) string {
+	if m == nil {
+		return ""
+	}
+	v, ok := m[key]
+	if !ok || v == nil {
+		return ""
+	}
+	switch val := v.(type) {
+	case string:
+		return val
+	default:
+		return fmt.Sprintf("%v", val)
+	}
+}

--- a/cmd/wuphf/channelui/platform.go
+++ b/cmd/wuphf/channelui/platform.go
@@ -1,0 +1,43 @@
+package channelui
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// IsDarwin reports whether the current build is running on macOS.
+func IsDarwin() bool { return runtime.GOOS == "darwin" }
+
+// IsLinux reports whether the current build is running on Linux.
+func IsLinux() bool { return runtime.GOOS == "linux" }
+
+// IsWindows reports whether the current build is running on Windows.
+func IsWindows() bool { return runtime.GOOS == "windows" }
+
+// OpenBrowserURL spawns a detached OS helper to open url in the
+// default browser. We use context.Background() because the child must
+// outlive this call — the user keeps interacting with the browser
+// long after we return — and noctx's "use CommandContext"
+// recommendation is satisfied by the background ctx. Cancellation
+// isn't meaningful for a fire-and-forget open-in-browser handoff.
+// Empty url is a no-op. Returns an error on unsupported platforms or
+// if the helper fails to start.
+func OpenBrowserURL(url string) error {
+	ctx := context.Background()
+	var cmd *exec.Cmd
+	switch {
+	case url == "":
+		return nil
+	case IsDarwin():
+		cmd = exec.CommandContext(ctx, "open", url)
+	case IsLinux():
+		cmd = exec.CommandContext(ctx, "xdg-open", url)
+	case IsWindows():
+		cmd = exec.CommandContext(ctx, "cmd", "/c", "start", "", url)
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+	return cmd.Start()
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -254,6 +254,13 @@ var (
 	channelInfosFromManifest  = channelui.ChannelInfosFromManifest
 	officeMembersFallback     = channelui.OfficeMembersFallback
 	channelInfosFallback      = channelui.ChannelInfosFallback
+
+	mapString               = channelui.MapString
+	openBrowserURL          = channelui.OpenBrowserURL
+	isDarwin                = channelui.IsDarwin
+	isLinux                 = channelui.IsLinux
+	isWindows               = channelui.IsWindows
+	resolveInitialOfficeApp = channelui.ResolveInitialOfficeApp
 )
 
 // Channel-confirm action typed-string consts.


### PR DESCRIPTION
## Summary

Stack PR #26. Three small unrelated leaves move into channelui:

- \`platform.go\` — \`IsDarwin\` / \`IsLinux\` / \`IsWindows\` (runtime.GOOS predicates) and \`OpenBrowserURL\` (spawns \`open\`/\`xdg-open\`/\`cmd /c start\` with a background context, since the child must outlive this call).
- \`map_string.go\` — \`MapString\` safely reads a string field from a \`map[string]any\`. Used to parse JSON-decoded broker responses where the shape isn't statically known.
- \`initial_app.go\` — \`ResolveInitialOfficeApp\` normalizes a CLI flag into a known \`OfficeApp\` value, with the legacy \`insights\` alias mapped to \`OfficeAppPolicies\` and an \`OfficeAppMessages\` fallback.

The \`runtime\` import drops from \`channel.go\` as a side effect (\`runtime/debug\` stays for the \`debug.Stack()\` call in \`reportChannelCrash\`).

Stacked on top of \`refactor/channelui-manifest-helpers\`.

## Test plan

- [x] \`bash scripts/test-go.sh ./cmd/wuphf\` — green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)