### PR TITLE
refactor(channelui): hoist usage strip + sidebar shortcut

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -2846,52 +2846,6 @@ func (m channelModel) selectedInterviewOption() *channelInterviewOption {
 	return &m.pending.Options[m.selectedOption]
 }
 
-func renderUsageStrip(usage channelUsageState, members []channelMember, width int) string {
-	if len(usage.Agents) == 0 || width < 40 {
-		return ""
-	}
-
-	var ordered []string
-	seen := make(map[string]bool)
-	for _, member := range members {
-		if _, ok := usage.Agents[member.Slug]; ok && !seen[member.Slug] {
-			ordered = append(ordered, member.Slug)
-			seen[member.Slug] = true
-		}
-	}
-	for _, slug := range []string{"ceo", "pm", "fe", "be", "ai", "designer", "cmo", "cro"} {
-		if _, ok := usage.Agents[slug]; ok && !seen[slug] {
-			ordered = append(ordered, slug)
-			seen[slug] = true
-		}
-	}
-	for slug := range usage.Agents {
-		if !seen[slug] {
-			ordered = append(ordered, slug)
-		}
-	}
-
-	pillStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color("#CBD5E1")).
-		Background(lipgloss.Color("#111827")).
-		Padding(0, 1)
-
-	var pills []string
-	for _, slug := range ordered {
-		totals := usage.Agents[slug]
-		if totals.TotalTokens == 0 && totals.CostUsd == 0 {
-			continue
-		}
-		label := fmt.Sprintf("%s %s · %s", agentAvatar(slug), formatTokenCount(totals.TotalTokens), formatUsd(totals.CostUsd))
-		pills = append(pills, pillStyle.Render(label))
-	}
-	if len(pills) == 0 {
-		return ""
-	}
-	prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted)).Render("  Spend by teammate")
-	return prefix + "  " + strings.Join(pills, " ")
-}
-
 // nextFocus cycles through visible panels: main → sidebar → thread → main.
 func (m channelModel) nextFocus() focusArea {
 	order := []focusArea{focusMain}
@@ -3110,13 +3064,6 @@ func (m channelModel) appSidebarItems() []sidebarItem {
 		items = append(items, sidebarItem{Kind: "app", Value: string(app.App), Label: app.Label})
 	}
 	return items
-}
-
-func sidebarShortcutLabel(index int) string {
-	if index < 0 || index > 8 {
-		return ""
-	}
-	return fmt.Sprintf("%d", index+1)
 }
 
 func (m channelModel) quickJumpItems() []sidebarItem {

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -216,6 +216,13 @@
 //     a CLI-flag string into a known OfficeApp value with the
 //     legacy "insights" alias mapped to OfficeAppPolicies and an
 //     OfficeAppMessages fallback.
+//   - usage_strip.go       — RenderUsageStrip renders the
+//     "Spend by teammate" pill row beneath the office feed
+//     (avatar + token count + dollar cost per agent, ordered by
+//     channel-member appearance, then canonical roster, then map
+//     iteration order; "" when no agents tracked or width < 40).
+//     SidebarShortcutLabel returns the "1".."9" digit shortcut
+//     for sidebar item indexes 0..8 (or "" when out of range).
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/usage_strip.go
+++ b/cmd/wuphf/channelui/usage_strip.go
@@ -1,0 +1,72 @@
+package channelui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// RenderUsageStrip renders the "Spend by teammate" strip below the
+// office feed: one pill per agent showing avatar, formatted token
+// count, and dollar cost. Agents are ordered by appearance in members
+// first (preserving channel order), then by the canonical office
+// roster, then anything left in usage.Agents in map iteration order.
+// Returns "" when there are no agents tracked or width is below the
+// 40-column readability floor.
+func RenderUsageStrip(usage UsageState, members []Member, width int) string {
+	if len(usage.Agents) == 0 || width < 40 {
+		return ""
+	}
+
+	var ordered []string
+	seen := make(map[string]bool)
+	for _, member := range members {
+		if _, ok := usage.Agents[member.Slug]; ok && !seen[member.Slug] {
+			ordered = append(ordered, member.Slug)
+			seen[member.Slug] = true
+		}
+	}
+	for _, slug := range []string{"ceo", "pm", "fe", "be", "ai", "designer", "cmo", "cro"} {
+		if _, ok := usage.Agents[slug]; ok && !seen[slug] {
+			ordered = append(ordered, slug)
+			seen[slug] = true
+		}
+	}
+	for slug := range usage.Agents {
+		if !seen[slug] {
+			ordered = append(ordered, slug)
+		}
+	}
+
+	pillStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("#CBD5E1")).
+		Background(lipgloss.Color("#111827")).
+		Padding(0, 1)
+
+	var pills []string
+	for _, slug := range ordered {
+		totals := usage.Agents[slug]
+		if totals.TotalTokens == 0 && totals.CostUsd == 0 {
+			continue
+		}
+		label := fmt.Sprintf("%s %s · %s", AgentAvatar(slug), FormatTokenCount(totals.TotalTokens), FormatUSD(totals.CostUsd))
+		pills = append(pills, pillStyle.Render(label))
+	}
+	if len(pills) == 0 {
+		return ""
+	}
+	prefix := lipgloss.NewStyle().Foreground(lipgloss.Color(SlackMuted)).Render("  Spend by teammate")
+	return prefix + "  " + strings.Join(pills, " ")
+}
+
+// SidebarShortcutLabel returns the digit shortcut for sidebar item
+// index ("1".."9") for index 0..8, or "" when out of range. Keys
+// 1-9 jump to the corresponding sidebar item via the quick-jump
+// overlay.
+func SidebarShortcutLabel(index int) string {
+	if index < 0 || index > 8 {
+		return ""
+	}
+	return fmt.Sprintf("%d", index+1)
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -261,6 +261,9 @@ var (
 	isLinux                 = channelui.IsLinux
 	isWindows               = channelui.IsWindows
 	resolveInitialOfficeApp = channelui.ResolveInitialOfficeApp
+
+	renderUsageStrip     = channelui.RenderUsageStrip
+	sidebarShortcutLabel = channelui.SidebarShortcutLabel
 )
 
 // Channel-confirm action typed-string consts.


### PR DESCRIPTION
## Summary

Stack PR #27. Two more pure rendering helpers move into \`channelui/usage_strip.go\`:

- \`RenderUsageStrip\` — \"Spend by teammate\" pill row beneath the office feed (avatar + token count + dollar cost per agent, ordered by channel-member appearance, then canonical roster, then map iteration order). Returns \`\"\"\` when no agents tracked or width < 40.
- \`SidebarShortcutLabel\` — returns the \`1\"..\"9\"\` digit shortcut for sidebar item indexes 0..8 (or \`\"\"\` when out of range). The quick-jump overlay uses these to teleport to channel/app rows.

Both rely entirely on helpers already in channelui (\`AgentAvatar\`, \`FormatTokenCount\`, \`FormatUSD\`, \`SlackMuted\`).

Stacked on top of \`refactor/channelui-platform-helpers\`.

## Test plan

- [x] \`bash scripts/test-go.sh ./cmd/wuphf\` — green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)