### PR TITLE
refactor(channelui): hoist doctor types + render helpers

### DIFF
--- a/cmd/wuphf/channel_doctor.go
+++ b/cmd/wuphf/channel_doctor.go
@@ -1,38 +1,12 @@
 package main
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 
 	"github.com/nex-crm/wuphf/internal/team"
 )
-
-type doctorSeverity string
-
-const (
-	doctorOK   doctorSeverity = "ok"
-	doctorWarn doctorSeverity = "warn"
-	doctorFail doctorSeverity = "fail"
-	doctorInfo doctorSeverity = "info"
-)
-
-type doctorCheck struct {
-	Label     string
-	Severity  doctorSeverity
-	Lifecycle team.CapabilityLifecycle
-	Detail    string
-	NextStep  string
-}
-
-type channelDoctorReport struct {
-	GeneratedAt time.Time
-	Checks      []doctorCheck
-	Registry    team.CapabilityRegistry
-}
 
 type channelDoctorDoneMsg struct {
 	report channelDoctorReport
@@ -41,32 +15,6 @@ type channelDoctorDoneMsg struct {
 
 var detectRuntimeCapabilitiesFn = func(opts team.CapabilityProbeOptions) team.RuntimeCapabilities {
 	return team.DetectRuntimeCapabilitiesWithOptions(opts)
-}
-
-func (r channelDoctorReport) counts() (ok, warn, fail int) {
-	for _, check := range r.Checks {
-		switch check.Severity {
-		case doctorOK:
-			ok++
-		case doctorWarn:
-			warn++
-		case doctorFail:
-			fail++
-		}
-	}
-	return ok, warn, fail
-}
-
-func (r channelDoctorReport) StatusLine() string {
-	ok, warn, fail := r.counts()
-	switch {
-	case fail > 0:
-		return fmt.Sprintf("%d healthy · %d warning · %d blocked", ok, warn, fail)
-	case warn > 0:
-		return fmt.Sprintf("%d healthy · %d warning", ok, warn)
-	default:
-		return fmt.Sprintf("%d healthy · ready to work", ok)
-	}
 }
 
 func runDoctorChecks() tea.Cmd {
@@ -96,79 +44,4 @@ func inspectDoctor() (channelDoctorReport, error) {
 		})
 	}
 	return report, nil
-}
-
-func doctorSeverityForCapability(entry team.CapabilityDescriptor) doctorSeverity {
-	switch entry.Level {
-	case team.CapabilityReady:
-		return doctorOK
-	case team.CapabilityWarn:
-		switch entry.Lifecycle {
-		case team.CapabilityLifecycleNeedsSetup:
-			return doctorFail
-		default:
-			return doctorWarn
-		}
-	default:
-		return doctorInfo
-	}
-}
-
-func renderDoctorCard(report channelDoctorReport, width int) string {
-	cardWidth := maxInt(48, width)
-	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F8FAFC")).Render("Doctor")
-	meta := lipgloss.NewStyle().Foreground(lipgloss.Color(slackMuted)).Render(report.GeneratedAt.Format("Jan 2 15:04"))
-	lines := []string{
-		title + "  " + subtlePill(report.StatusLine(), "#E5E7EB", "#334155") + "  " + meta,
-		mutedText("This is the live readiness check for setup, integrations, and the agent runtime."),
-		"",
-	}
-
-	for _, check := range report.Checks {
-		label := renderDoctorLabel(check)
-		if strings.TrimSpace(string(check.Lifecycle)) != "" {
-			label += " " + renderDoctorLifecycle(check.Lifecycle)
-		}
-		lines = append(lines, label+" "+check.Detail)
-		if strings.TrimSpace(check.NextStep) != "" {
-			lines = append(lines, "  "+mutedText("Next: "+check.NextStep))
-		}
-		lines = append(lines, "")
-	}
-	lines = append(lines, mutedText("Esc or /cancel closes this panel."))
-
-	return lipgloss.NewStyle().
-		Width(cardWidth).
-		Border(lipgloss.RoundedBorder()).
-		BorderForeground(lipgloss.Color("#334155")).
-		Background(lipgloss.Color("#14151B")).
-		Padding(0, 1).
-		Render(strings.Join(lines, "\n"))
-}
-
-func renderDoctorLabel(check doctorCheck) string {
-	switch check.Severity {
-	case doctorOK:
-		return accentPill(check.Label, "#15803D")
-	case doctorWarn:
-		return accentPill(check.Label, "#B45309")
-	case doctorFail:
-		return accentPill(check.Label, "#B91C1C")
-	default:
-		return subtlePill(check.Label, "#E2E8F0", "#334155")
-	}
-}
-
-func renderDoctorLifecycle(lifecycle team.CapabilityLifecycle) string {
-	label := strings.ReplaceAll(string(lifecycle), "_", " ")
-	switch lifecycle {
-	case team.CapabilityLifecycleReady:
-		return subtlePill(label, "#DCFCE7", "#166534")
-	case team.CapabilityLifecycleDisabled:
-		return subtlePill(label, "#E2E8F0", "#334155")
-	case team.CapabilityLifecycleDeferred, team.CapabilityLifecyclePartial, team.CapabilityLifecycleProvisioning:
-		return subtlePill(label, "#FEF3C7", "#92400E")
-	default:
-		return subtlePill(label, "#FEE2E2", "#991B1B")
-	}
 }

--- a/cmd/wuphf/channel_workspace_state.go
+++ b/cmd/wuphf/channel_workspace_state.go
@@ -145,7 +145,7 @@ func deriveWorkspaceReadiness(state workspaceUIState, doctor *channelDoctorRepor
 		}
 	}
 	if doctor != nil {
-		ok, warn, fail := doctor.counts()
+		ok, warn, fail := doctor.Counts()
 		switch {
 		case fail > 0:
 			return workspaceReadinessState{

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -223,6 +223,17 @@
 //     iteration order; "" when no agents tracked or width < 40).
 //     SidebarShortcutLabel returns the "1".."9" digit shortcut
 //     for sidebar item indexes 0..8 (or "" when out of range).
+//   - doctor.go            — DoctorSeverity typed-string + the four
+//     consts, DoctorCheck / DoctorReport types with the counts /
+//     StatusLine / Counts methods, DoctorSeverityForCapability
+//     (capability descriptor → severity), and the rendering
+//     helpers RenderDoctorCard (rounded slate card with status
+//     pill + per-check rows), RenderDoctorLabel (severity pill),
+//     RenderDoctorLifecycle (lifecycle pill). Imports
+//     internal/team for the CapabilityRegistry / Lifecycle types.
+//     The team-coupled tea.Cmd entry runDoctorChecks /
+//     inspectDoctor and the test mock-point detectRuntimeCapabilitiesFn
+//     stay in package main.
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/doctor.go
+++ b/cmd/wuphf/channelui/doctor.go
@@ -1,0 +1,166 @@
+package channelui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// DoctorSeverity classifies a doctor check's outcome. Used to drive
+// the per-row pill color and the report's headline counts.
+type DoctorSeverity string
+
+const (
+	DoctorOK   DoctorSeverity = "ok"
+	DoctorWarn DoctorSeverity = "warn"
+	DoctorFail DoctorSeverity = "fail"
+	DoctorInfo DoctorSeverity = "info"
+)
+
+// DoctorCheck is one row of the doctor card: a label, a severity, the
+// underlying capability lifecycle, and free-form Detail / NextStep
+// text.
+type DoctorCheck struct {
+	Label     string
+	Severity  DoctorSeverity
+	Lifecycle team.CapabilityLifecycle
+	Detail    string
+	NextStep  string
+}
+
+// DoctorReport is the report rendered into the doctor card. It pairs
+// the check rows with the capability registry they were derived from
+// and the report's generation time.
+type DoctorReport struct {
+	GeneratedAt time.Time
+	Checks      []DoctorCheck
+	Registry    team.CapabilityRegistry
+}
+
+// counts tallies the report's checks by severity. Reused by
+// StatusLine and by readiness selectors that surface the worst row.
+func (r DoctorReport) counts() (ok, warn, fail int) {
+	for _, check := range r.Checks {
+		switch check.Severity {
+		case DoctorOK:
+			ok++
+		case DoctorWarn:
+			warn++
+		case DoctorFail:
+			fail++
+		}
+	}
+	return ok, warn, fail
+}
+
+// StatusLine renders the human-friendly counts headline used at the
+// top of the doctor card and in the readiness summary.
+func (r DoctorReport) StatusLine() string {
+	ok, warn, fail := r.counts()
+	switch {
+	case fail > 0:
+		return fmt.Sprintf("%d healthy · %d warning · %d blocked", ok, warn, fail)
+	case warn > 0:
+		return fmt.Sprintf("%d healthy · %d warning", ok, warn)
+	default:
+		return fmt.Sprintf("%d healthy · ready to work", ok)
+	}
+}
+
+// Counts is the exported counterpart of counts() for callers in
+// package main that need the same totals to drive readiness state.
+func (r DoctorReport) Counts() (ok, warn, fail int) { return r.counts() }
+
+// DoctorSeverityForCapability maps a capability descriptor's level +
+// lifecycle to the matching doctor severity. CapabilityWarn at the
+// "needs setup" lifecycle escalates to DoctorFail because the user
+// can't proceed without acting; everything else maps to its natural
+// level.
+func DoctorSeverityForCapability(entry team.CapabilityDescriptor) DoctorSeverity {
+	switch entry.Level {
+	case team.CapabilityReady:
+		return DoctorOK
+	case team.CapabilityWarn:
+		switch entry.Lifecycle {
+		case team.CapabilityLifecycleNeedsSetup:
+			return DoctorFail
+		default:
+			return DoctorWarn
+		}
+	default:
+		return DoctorInfo
+	}
+}
+
+// RenderDoctorCard renders the rounded slate doctor card: a title +
+// status pill + generated-at meta line, a one-line description, then
+// one row per check (label pill, optional lifecycle pill, Detail body,
+// optional "Next: …" hint), and a closing /cancel hint. cardWidth is
+// clamped to a 48-column floor.
+func RenderDoctorCard(report DoctorReport, width int) string {
+	cardWidth := MaxInt(48, width)
+	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#F8FAFC")).Render("Doctor")
+	meta := lipgloss.NewStyle().Foreground(lipgloss.Color(SlackMuted)).Render(report.GeneratedAt.Format("Jan 2 15:04"))
+	lines := []string{
+		title + "  " + SubtlePill(report.StatusLine(), "#E5E7EB", "#334155") + "  " + meta,
+		MutedText("This is the live readiness check for setup, integrations, and the agent runtime."),
+		"",
+	}
+
+	for _, check := range report.Checks {
+		label := RenderDoctorLabel(check)
+		if strings.TrimSpace(string(check.Lifecycle)) != "" {
+			label += " " + RenderDoctorLifecycle(check.Lifecycle)
+		}
+		lines = append(lines, label+" "+check.Detail)
+		if strings.TrimSpace(check.NextStep) != "" {
+			lines = append(lines, "  "+MutedText("Next: "+check.NextStep))
+		}
+		lines = append(lines, "")
+	}
+	lines = append(lines, MutedText("Esc or /cancel closes this panel."))
+
+	return lipgloss.NewStyle().
+		Width(cardWidth).
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color("#334155")).
+		Background(lipgloss.Color("#14151B")).
+		Padding(0, 1).
+		Render(strings.Join(lines, "\n"))
+}
+
+// RenderDoctorLabel returns the colored severity pill for a check.
+// Info-level checks fall back to the neutral subtle pill.
+func RenderDoctorLabel(check DoctorCheck) string {
+	switch check.Severity {
+	case DoctorOK:
+		return AccentPill(check.Label, "#15803D")
+	case DoctorWarn:
+		return AccentPill(check.Label, "#B45309")
+	case DoctorFail:
+		return AccentPill(check.Label, "#B91C1C")
+	default:
+		return SubtlePill(check.Label, "#E2E8F0", "#334155")
+	}
+}
+
+// RenderDoctorLifecycle returns the lifecycle pill that sits beside
+// each check's severity pill. Underscores in the lifecycle name are
+// rewritten as spaces for readability.
+func RenderDoctorLifecycle(lifecycle team.CapabilityLifecycle) string {
+	label := strings.ReplaceAll(string(lifecycle), "_", " ")
+	switch lifecycle {
+	case team.CapabilityLifecycleReady:
+		return SubtlePill(label, "#DCFCE7", "#166534")
+	case team.CapabilityLifecycleDisabled:
+		return SubtlePill(label, "#E2E8F0", "#334155")
+	case team.CapabilityLifecycleDeferred, team.CapabilityLifecyclePartial, team.CapabilityLifecycleProvisioning:
+		return SubtlePill(label, "#FEF3C7", "#92400E")
+	default:
+		return SubtlePill(label, "#FEE2E2", "#991B1B")
+	}
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -42,6 +42,9 @@ type (
 	channelConfirm         = channelui.ChannelConfirm
 	composerPopupOption    = channelui.ComposerPopupOption
 	officeSidebarApp       = channelui.OfficeSidebarApp
+	doctorSeverity         = channelui.DoctorSeverity
+	doctorCheck            = channelui.DoctorCheck
+	channelDoctorReport    = channelui.DoctorReport
 )
 
 // Function aliases keep the lowercase names callable from package main
@@ -264,6 +267,19 @@ var (
 
 	renderUsageStrip     = channelui.RenderUsageStrip
 	sidebarShortcutLabel = channelui.SidebarShortcutLabel
+
+	doctorSeverityForCapability = channelui.DoctorSeverityForCapability
+	renderDoctorCard            = channelui.RenderDoctorCard
+	renderDoctorLabel           = channelui.RenderDoctorLabel
+	renderDoctorLifecycle       = channelui.RenderDoctorLifecycle
+)
+
+// Doctor severity consts mirror channelui's exported names.
+const (
+	doctorOK   = channelui.DoctorOK
+	doctorWarn = channelui.DoctorWarn
+	doctorFail = channelui.DoctorFail
+	doctorInfo = channelui.DoctorInfo
 )
 
 // Channel-confirm action typed-string consts.


### PR DESCRIPTION
## Summary

Stack PR #28. Moves the doctor card data model and rendering layer from package main into \`channelui/doctor.go\`. \`channelui\` now imports \`internal/team\` for the \`CapabilityRegistry\` / \`Lifecycle\` types — same pattern used by \`internal/avatar\` and \`internal/company\` in earlier PRs.

**Hoisted into channelui:**
- \`DoctorSeverity\` typed-string + four \`DoctorOK\`/\`Warn\`/\`Fail\`/\`Info\` consts.
- \`DoctorCheck\` struct (label + severity + lifecycle + detail + next step).
- \`DoctorReport\` struct with \`counts()\` / \`StatusLine()\` methods plus a \`Counts()\` exported counterpart for cross-package callers.
- \`DoctorSeverityForCapability\` — capability descriptor → severity, with the \`needs setup\` warn-→-fail escalation preserved.
- \`RenderDoctorCard\` / \`RenderDoctorLabel\` / \`RenderDoctorLifecycle\`.

**Stays in package main:**
- \`channelDoctorDoneMsg\` (a \`tea.Msg\`).
- \`runDoctorChecks\` (returns \`tea.Cmd\`).
- \`inspectDoctor\` (uses the package-main test mock-point).
- \`detectRuntimeCapabilitiesFn\` (overridden in doctor tests).

Stacked on top of \`refactor/channelui-usage-strip-shortcut\`.

## Test plan

- [x] \`bash scripts/test-go.sh ./cmd/wuphf\` — green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)