### PR TITLE
refactor(channelui): hoist workspace + recovery leaf helpers

### DIFF
--- a/cmd/wuphf/channel_recovery.go
+++ b/cmd/wuphf/channel_recovery.go
@@ -81,26 +81,6 @@ func runtimeMessagesFromChannel(messages []brokerMessage, limit int) []team.Runt
 	return out
 }
 
-func summarizeAwayRecovery(unreadCount int, recovery team.SessionRecovery) string {
-	parts := make([]string, 0, 3)
-	if focus := trimRecoverySentence(recovery.Focus); focus != "" {
-		parts = append(parts, focus)
-	}
-	if len(recovery.NextSteps) > 0 {
-		if next := trimRecoverySentence(recovery.NextSteps[0]); next != "" {
-			parts = append(parts, "Next: "+next)
-		}
-	}
-	if len(parts) == 0 {
-		return fmt.Sprintf("%d new since you looked. Open /recover for the full summary.", unreadCount)
-	}
-	summary := strings.Join(parts, " ")
-	if unreadCount > 0 {
-		summary = fmt.Sprintf("%d new since you looked. %s", unreadCount, summary)
-	}
-	return truncateText(summary, 120)
-}
-
 func (m channelModel) currentAwaySummary() string {
 	return m.currentWorkspaceUIState().AwaySummary
 }

--- a/cmd/wuphf/channel_workspace_state.go
+++ b/cmd/wuphf/channel_workspace_state.go
@@ -114,11 +114,6 @@ func resolveWorkspaceAwaySummary(cached string, unreadCount int, recovery team.S
 	return summarizeAwayRecovery(unreadCount, recovery)
 }
 
-func runtimeRequestIsOpen(req team.RuntimeRequest) bool {
-	status := strings.ToLower(strings.TrimSpace(req.Status))
-	return status == "" || status == "pending" || status == "open" || status == "draft"
-}
-
 func deriveWorkspaceReadiness(state workspaceUIState, doctor *channelDoctorReport) workspaceReadinessState {
 	if !state.BrokerConnected {
 		return workspaceReadinessState{
@@ -177,27 +172,6 @@ func deriveWorkspaceReadiness(state workspaceUIState, doctor *channelDoctorRepor
 		Detail:   fmt.Sprintf("The live office runtime is attached and ready for collaboration with %s memory.", state.Memory.ActiveLabel),
 		NextStep: "Use /switcher to move through the office, or /recover to regain context before replying.",
 	}
-}
-
-func firstDoctorNextStep(report channelDoctorReport, fallback string) string {
-	for _, check := range report.Checks {
-		if strings.TrimSpace(check.NextStep) == "" {
-			continue
-		}
-		if check.Severity == doctorFail || check.Severity == doctorWarn {
-			return check.NextStep
-		}
-	}
-	return fallback
-}
-
-func firstWorkspaceString(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
 }
 
 func (s workspaceUIState) readinessCard() (title, body, accent string, extra []string) {
@@ -345,27 +319,6 @@ func (s workspaceUIState) sidebarHintLine() string {
 		return "Focus: " + s.Focus
 	default:
 		return "Use /switcher or /recover to move through live office context"
-	}
-}
-
-func sidebarViewLabel(activeApp officeApp) string {
-	switch activeApp {
-	case officeAppRecovery:
-		return "Recovery view"
-	case officeAppTasks:
-		return "Task board"
-	case officeAppRequests:
-		return "Decision queue"
-	case officeAppPolicies:
-		return "Insights view"
-	case officeAppCalendar:
-		return "Calendar view"
-	case officeAppArtifacts:
-		return "Artifacts view"
-	case officeAppSkills:
-		return "Skills view"
-	default:
-		return "Message lane"
 	}
 }
 

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -234,6 +234,14 @@
 //     The team-coupled tea.Cmd entry runDoctorChecks /
 //     inspectDoctor and the test mock-point detectRuntimeCapabilitiesFn
 //     stay in package main.
+//   - workspace_helpers.go — pure / team-typed leaves used by the
+//     workspace state machinery: SummarizeAwayRecovery (the
+//     "while away" one-liner combining unread count + recovery
+//     focus + first next step), RuntimeRequestIsOpen
+//     (open/pending/draft/empty status predicate), the
+//     FirstWorkspaceString chain helper, FirstDoctorNextStep
+//     (first non-empty NextStep on a fail/warn check), and
+//     SidebarViewLabel (OfficeApp → short sidebar summary label).
 //
 // Subsequent extraction PRs will land the workspace / recovery / cache
 // cluster, the sidebar / splash, the broker integrations, and finally

--- a/cmd/wuphf/channelui/workspace_helpers.go
+++ b/cmd/wuphf/channelui/workspace_helpers.go
@@ -1,0 +1,94 @@
+package channelui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+// SummarizeAwayRecovery renders the "while away" one-liner shown
+// above the office feed when the human returns to a session with
+// new activity. Picks the recovery focus + first next-step sentence
+// (each trimmed via TrimRecoverySentence) and prepends the unread
+// count when non-zero. Falls back to a generic prompt when both the
+// focus and next-step are empty. Output is truncated to 120 columns.
+func SummarizeAwayRecovery(unreadCount int, recovery team.SessionRecovery) string {
+	parts := make([]string, 0, 3)
+	if focus := TrimRecoverySentence(recovery.Focus); focus != "" {
+		parts = append(parts, focus)
+	}
+	if len(recovery.NextSteps) > 0 {
+		if next := TrimRecoverySentence(recovery.NextSteps[0]); next != "" {
+			parts = append(parts, "Next: "+next)
+		}
+	}
+	if len(parts) == 0 {
+		return fmt.Sprintf("%d new since you looked. Open /recover for the full summary.", unreadCount)
+	}
+	summary := strings.Join(parts, " ")
+	if unreadCount > 0 {
+		summary = fmt.Sprintf("%d new since you looked. %s", unreadCount, summary)
+	}
+	return TruncateText(summary, 120)
+}
+
+// RuntimeRequestIsOpen reports whether a runtime request is in an
+// open state (pending / open / draft / unknown). Closed states
+// (answered / cancelled / resolved / etc.) return false.
+func RuntimeRequestIsOpen(req team.RuntimeRequest) bool {
+	status := strings.ToLower(strings.TrimSpace(req.Status))
+	return status == "" || status == "pending" || status == "open" || status == "draft"
+}
+
+// FirstWorkspaceString returns the first non-empty trimmed value, or
+// "" when none is found. Used to chain candidate next-step sentences
+// where any of them might be empty.
+func FirstWorkspaceString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+// SidebarViewLabel maps an OfficeApp to a short human-friendly label
+// used in the sidebar workspace summary line. Unknown / empty apps
+// fall back to "Message lane".
+func SidebarViewLabel(activeApp OfficeApp) string {
+	switch activeApp {
+	case OfficeAppRecovery:
+		return "Recovery view"
+	case OfficeAppTasks:
+		return "Task board"
+	case OfficeAppRequests:
+		return "Decision queue"
+	case OfficeAppPolicies:
+		return "Insights view"
+	case OfficeAppCalendar:
+		return "Calendar view"
+	case OfficeAppArtifacts:
+		return "Artifacts view"
+	case OfficeAppSkills:
+		return "Skills view"
+	default:
+		return "Message lane"
+	}
+}
+
+// FirstDoctorNextStep returns the first non-empty NextStep on a
+// fail- or warn-severity check, or fallback when none is found.
+// Used to surface the most urgent actionable hint in the readiness
+// card without showing the full doctor report.
+func FirstDoctorNextStep(report DoctorReport, fallback string) string {
+	for _, check := range report.Checks {
+		if strings.TrimSpace(check.NextStep) == "" {
+			continue
+		}
+		if check.Severity == DoctorFail || check.Severity == DoctorWarn {
+			return check.NextStep
+		}
+	}
+	return fallback
+}

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -272,6 +272,12 @@ var (
 	renderDoctorCard            = channelui.RenderDoctorCard
 	renderDoctorLabel           = channelui.RenderDoctorLabel
 	renderDoctorLifecycle       = channelui.RenderDoctorLifecycle
+
+	summarizeAwayRecovery = channelui.SummarizeAwayRecovery
+	runtimeRequestIsOpen  = channelui.RuntimeRequestIsOpen
+	firstWorkspaceString  = channelui.FirstWorkspaceString
+	sidebarViewLabel      = channelui.SidebarViewLabel
+	firstDoctorNextStep   = channelui.FirstDoctorNextStep
 )
 
 // Doctor severity consts mirror channelui's exported names.


### PR DESCRIPTION
## Summary

Stack PR #29. Five pure / team-typed leaf helpers move into a new \`channelui/workspace_helpers.go\`:

- \`SummarizeAwayRecovery\` — \"while away\" one-liner combining unread count + recovery focus + first next-step sentence; falls back to a generic prompt and truncates to 120 columns.
- \`RuntimeRequestIsOpen\` — open/pending/draft/empty status predicate over \`team.RuntimeRequest\`.
- \`FirstWorkspaceString\` — first non-empty trimmed value chain helper.
- \`FirstDoctorNextStep\` — first non-empty \`NextStep\` on a fail or warn check (or fallback).
- \`SidebarViewLabel\` — \`OfficeApp\` → short sidebar summary label.

The \`fmt\` import drops from \`channel_recovery.go\` as a side effect.

Stacked on top of \`refactor/channelui-doctor-types-renderers\`.

## Test plan

- [x] \`bash scripts/test-go.sh ./cmd/wuphf\` — green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)