### PR TITLE
refactor(team): regroup headless utilities by concern (C21)

### DIFF
--- a/internal/team/headless_codex.go
+++ b/internal/team/headless_codex.go
@@ -2,10 +2,8 @@ package team
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -177,121 +175,4 @@ func defaultHeadlessCodexWorkspaceStatusSnapshot(path string) string {
 		return ""
 	}
 	return string(out)
-}
-
-func (l *Launcher) launchHeadlessCodex() error {
-	killStaleBroker()
-	killStaleHeadlessTaskRunners()
-	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
-
-	l.broker = NewBroker()
-	l.broker.packSlug = l.packSlug
-	l.broker.blankSlateLaunch = l.blankSlateLaunch
-	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
-		return fmt.Errorf("set session mode: %w", err)
-	}
-	if err := l.broker.Start(); err != nil {
-		return fmt.Errorf("start broker: %w", err)
-	}
-	if err := writeOfficePIDFile(); err != nil {
-		return fmt.Errorf("write office pid: %w", err)
-	}
-
-	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
-
-	l.resumeInFlightWork()
-	go l.notifyAgentsLoop()
-	if !l.isOneOnOne() {
-		go l.notifyTaskActionsLoop()
-		go l.notifyOfficeChangesLoop()
-		go l.pollNexNotificationsLoop()
-		go l.watchdogSchedulerLoop()
-	}
-
-	return nil
-}
-
-func headlessCodexTaskID(prompt string) string {
-	prefixes := []string{"#task-", "#blank-slate-"}
-	for _, prefix := range prefixes {
-		idx := strings.Index(prompt, prefix)
-		if idx == -1 {
-			continue
-		}
-		start := idx + 1
-		end := start
-		for end < len(prompt) {
-			ch := prompt[end]
-			if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' {
-				end++
-				continue
-			}
-			break
-		}
-		return strings.TrimSpace(prompt[start:end])
-	}
-	return ""
-}
-
-// wuphfLogDirOverride is a test hook for redirecting headless log writes to
-// an isolated path. Stored as atomic.Pointer so reads on the headless write
-// path don't take a lock; nil in production. Tests set this via TestMain so
-// log files don't pollute the user's real ~/.wuphf/logs while the suite
-// runs. The previous WUPHF_LOG_DIR environment variable was retired in
-// favour of this in-process hook — env vars leak into spawned codex/claude
-// subprocesses, which is not what tests want.
-var wuphfLogDirOverride atomic.Pointer[string]
-
-func wuphfLogDir() string {
-	if p := wuphfLogDirOverride.Load(); p != nil {
-		override := strings.TrimSpace(*p)
-		if override == "" {
-			return ""
-		}
-		if err := os.MkdirAll(override, 0o700); err != nil {
-			fmt.Fprintf(os.Stderr, "wuphf: log dir override %q unwritable: %v — headless logging disabled\n", override, err)
-			return ""
-		}
-		return override
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ""
-	}
-	dir := filepath.Join(home, ".wuphf", "logs")
-	_ = os.MkdirAll(dir, 0o700)
-	return dir
-}
-
-func appendHeadlessCodexLog(slug string, line string) {
-	dir := wuphfLogDir()
-	if dir == "" {
-		return
-	}
-	f, err := os.OpenFile(filepath.Join(dir, "headless-codex-"+slug+".log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-	if err != nil {
-		return
-	}
-	defer func() { _ = f.Close() }()
-	_, _ = fmt.Fprintf(f, "[%s] %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(line))
-}
-
-func appendHeadlessCodexLatency(slug string, line string) {
-	dir := wuphfLogDir()
-	if dir == "" {
-		return
-	}
-	f, err := os.OpenFile(filepath.Join(dir, "headless-codex-latency.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
-	if err != nil {
-		return
-	}
-	defer func() { _ = f.Close() }()
-	_, _ = fmt.Fprintf(f, "[%s] agent=%s %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(slug), strings.TrimSpace(line))
-}
-
-func durationMillis(start, mark time.Time) int64 {
-	if start.IsZero() || mark.IsZero() {
-		return -1
-	}
-	return mark.Sub(start).Milliseconds()
 }

--- a/internal/team/headless_codex_queue.go
+++ b/internal/team/headless_codex_queue.go
@@ -579,3 +579,25 @@ func (l *Launcher) headlessCodexStaleCancelAfterForTurn(turn headlessCodexTurn) 
 	}
 	return headlessCodexStaleCancelAfter
 }
+
+func headlessCodexTaskID(prompt string) string {
+	prefixes := []string{"#task-", "#blank-slate-"}
+	for _, prefix := range prefixes {
+		idx := strings.Index(prompt, prefix)
+		if idx == -1 {
+			continue
+		}
+		start := idx + 1
+		end := start
+		for end < len(prompt) {
+			ch := prompt[end]
+			if (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '-' {
+				end++
+				continue
+			}
+			break
+		}
+		return strings.TrimSpace(prompt[start:end])
+	}
+	return ""
+}

--- a/internal/team/headless_logging.go
+++ b/internal/team/headless_logging.go
@@ -1,0 +1,74 @@
+package team
+
+// headless_logging.go owns the file-based logging utilities used by
+// every headless turn runner (codex, claude, opencode, openai-compat).
+// Logs land under ~/.wuphf/logs by default; tests redirect via the
+// wuphfLogDirOverride atomic.Pointer (set in TestMain) so suites
+// don't pollute the developer's real log directory. The previous
+// WUPHF_LOG_DIR env var was retired because env leaks into spawned
+// CLI subprocesses — the in-process pointer doesn't.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// wuphfLogDirOverride is a test hook for redirecting headless log writes to
+// an isolated path. Stored as atomic.Pointer so reads on the headless write
+// path don't take a lock; nil in production. Tests set this via TestMain so
+// log files don't pollute the user's real ~/.wuphf/logs while the suite
+// runs. The previous WUPHF_LOG_DIR environment variable was retired in
+// favour of this in-process hook — env vars leak into spawned codex/claude
+// subprocesses, which is not what tests want.
+var wuphfLogDirOverride atomic.Pointer[string]
+
+func wuphfLogDir() string {
+	if p := wuphfLogDirOverride.Load(); p != nil {
+		override := strings.TrimSpace(*p)
+		if override == "" {
+			return ""
+		}
+		if err := os.MkdirAll(override, 0o700); err != nil {
+			fmt.Fprintf(os.Stderr, "wuphf: log dir override %q unwritable: %v — headless logging disabled\n", override, err)
+			return ""
+		}
+		return override
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	dir := filepath.Join(home, ".wuphf", "logs")
+	_ = os.MkdirAll(dir, 0o700)
+	return dir
+}
+
+func appendHeadlessCodexLog(slug string, line string) {
+	dir := wuphfLogDir()
+	if dir == "" {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "headless-codex-"+slug+".log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "[%s] %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(line))
+}
+
+func appendHeadlessCodexLatency(slug string, line string) {
+	dir := wuphfLogDir()
+	if dir == "" {
+		return
+	}
+	f, err := os.OpenFile(filepath.Join(dir, "headless-codex-latency.log"), os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return
+	}
+	defer func() { _ = f.Close() }()
+	_, _ = fmt.Fprintf(f, "[%s] agent=%s %s\n", time.Now().Format(time.RFC3339), strings.TrimSpace(slug), strings.TrimSpace(line))
+}

--- a/internal/team/headless_progress.go
+++ b/internal/team/headless_progress.go
@@ -45,3 +45,10 @@ func formatHeadlessLatencySummary(metrics headlessProgressMetrics) string {
 	}
 	return strings.Join(parts, " · ")
 }
+
+func durationMillis(start, mark time.Time) int64 {
+	if start.IsZero() || mark.IsZero() {
+		return -1
+	}
+	return mark.Sub(start).Milliseconds()
+}

--- a/internal/team/launcher_boot.go
+++ b/internal/team/launcher_boot.go
@@ -169,3 +169,35 @@ func (l *Launcher) Launch() error {
 
 	return nil
 }
+
+func (l *Launcher) launchHeadlessCodex() error {
+	killStaleBroker()
+	killStaleHeadlessTaskRunners()
+	_ = exec.CommandContext(context.Background(), "tmux", "-L", tmuxSocketName, "kill-session", "-t", l.sessionName).Run()
+
+	l.broker = NewBroker()
+	l.broker.packSlug = l.packSlug
+	l.broker.blankSlateLaunch = l.blankSlateLaunch
+	if err := l.broker.SetSessionMode(l.sessionMode, l.oneOnOne); err != nil {
+		return fmt.Errorf("set session mode: %w", err)
+	}
+	if err := l.broker.Start(); err != nil {
+		return fmt.Errorf("start broker: %w", err)
+	}
+	if err := writeOfficePIDFile(); err != nil {
+		return fmt.Errorf("write office pid: %w", err)
+	}
+
+	l.headless.ctx, l.headless.cancel = context.WithCancel(context.Background())
+
+	l.resumeInFlightWork()
+	go l.notifyAgentsLoop()
+	if !l.isOneOnOne() {
+		go l.notifyTaskActionsLoop()
+		go l.notifyOfficeChangesLoop()
+		go l.pollNexNotificationsLoop()
+		go l.watchdogSchedulerLoop()
+	}
+
+	return nil
+}


### PR DESCRIPTION
Stacked on **#485 (C20)**. Apply the "helpers next to their state" learning to `headless_codex.go`. Four moves shrink it from 297 to 178 lines and put each helper next to the code that calls it.

## Moves

| Moved | To | Why |
|---|---|---|
| `launchHeadlessCodex` | `launcher_boot.go` | It's a Launcher boot path, parallel to `Launch` (tmux) and `LaunchWeb` (web). Belongs with the other boots, not buried in the codex dispatch file. |
| `wuphfLogDir`, `wuphfLogDirOverride`, `appendHeadlessCodexLog`, `appendHeadlessCodexLatency` | new `headless_logging.go` (74 lines) | File-based logging used by every headless runner (codex, claude, opencode, openai-compat). The `Codex` prefix in the function names reflects history, not current scope. |
| `durationMillis` | `headless_progress.go` | Computes the millisecond delta the `headlessProgressMetrics` struct stores. The two pieces are one conceptual unit. |
| `headlessCodexTaskID` | `headless_codex_queue.go` | The queue is the only caller — it parses the prompt for `#task-`/`#blank-slate-` prefixes to drive dedup in `enqueueHeadlessCodexTurnRecord` and `replaceDuplicateTaskTurnLocked`. |

## What headless_codex.go owns now

After the moves, the file holds exactly the cross-provider dispatch entry + scaffolding:

- `defaultHeadlessCodexRunTurn` / `headlessCodexRunTurn` — dispatch entry that routes by provider kind (codex / opencode / claude / openai-compat)
- The override seams (`headlessCodexRunTurnOverride`, `headlessWakeLeadFn`, `headlessCodexLookPath`, `headlessCodexCommandContext`, `headlessCodexExecutablePath`)
- `headlessCodexTurnTimeoutEnv` + the timeout consts
- Shared queue types: `headlessCodexTurn`, `headlessCodexActiveTurn`, `headlessWorkerPool`
- `headlessCodexWorkspaceStatusSnapshot` seam used by the durability check

Pure scaffolding for the dispatch layer. The actual codex-CLI invocation lives in `headless_codex_runner.go`; the queue worker in `headless_codex_queue.go`; the recovery layer in `headless_codex_recovery.go`.

## Local CI matrix (all green)

- gofmt clean / golangci-lint 0 issues / 32 packages green
