### PR TITLE
refactor(channelui): hoist SummarizeJSONField + TaskLogRoot

### DIFF
--- a/cmd/wuphf/channel_artifacts.go
+++ b/cmd/wuphf/channel_artifacts.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -207,22 +206,6 @@ func summarizeTaskLogRecord(record taskLogRecord) string {
 	return "Tool execution finished."
 }
 
-func summarizeJSONField(raw json.RawMessage, max int) string {
-	text := strings.TrimSpace(string(raw))
-	if text == "" || text == "null" {
-		return ""
-	}
-	var plain string
-	if err := json.Unmarshal(raw, &plain); err == nil {
-		return truncateText(strings.TrimSpace(plain), max)
-	}
-	var compact bytes.Buffer
-	if err := json.Compact(&compact, raw); err == nil {
-		return truncateText(compact.String(), max)
-	}
-	return truncateText(text, max)
-}
-
 func recentWorkflowRunArtifacts(limit int) []workflowRunArtifact {
 	root := filepath.Join(filepath.Dir(config.ConfigPath()), "workflows")
 	entries := []workflowRunArtifact{}
@@ -291,15 +274,4 @@ func readWorkflowRunArtifact(path string, info fs.FileInfo) (workflowRunArtifact
 	artifact.Path = path
 	artifact.UpdatedAt = info.ModTime()
 	return artifact, true
-}
-
-func taskLogRoot() string {
-	if root := strings.TrimSpace(os.Getenv("WUPHF_TASK_LOG_ROOT")); root != "" {
-		return root
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return filepath.Join(".wuphf", "office", "tasks")
-	}
-	return filepath.Join(home, ".wuphf", "office", "tasks")
 }

--- a/cmd/wuphf/channelui/artifact_helpers.go
+++ b/cmd/wuphf/channelui/artifact_helpers.go
@@ -1,0 +1,45 @@
+package channelui
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SummarizeJSONField returns a TruncateText'd one-line summary of a
+// JSON-encoded raw message. JSON strings are unquoted first; objects
+// and arrays are compacted via json.Compact; malformed input falls
+// through to the trimmed raw text. Returns "" for empty / "null"
+// values so callers can decide whether to emit a row at all.
+func SummarizeJSONField(raw json.RawMessage, max int) string {
+	text := strings.TrimSpace(string(raw))
+	if text == "" || text == "null" {
+		return ""
+	}
+	var plain string
+	if err := json.Unmarshal(raw, &plain); err == nil {
+		return TruncateText(strings.TrimSpace(plain), max)
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, raw); err == nil {
+		return TruncateText(compact.String(), max)
+	}
+	return TruncateText(text, max)
+}
+
+// TaskLogRoot returns the root directory where headless task tool
+// logs live. WUPHF_TASK_LOG_ROOT wins when set; otherwise it
+// resolves to ~/.wuphf/office/tasks (or .wuphf/office/tasks when
+// the home directory is unavailable).
+func TaskLogRoot() string {
+	if root := strings.TrimSpace(os.Getenv("WUPHF_TASK_LOG_ROOT")); root != "" {
+		return root
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".wuphf", "office", "tasks")
+	}
+	return filepath.Join(home, ".wuphf", "office", "tasks")
+}

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -251,6 +251,13 @@
 //     terminal statuses), CountIsolatedRuntimeTasks (counts tasks
 //     in a "local_worktree" execution mode or with a non-empty
 //     WorktreePath / WorktreeBranch).
+//   - artifact_helpers.go  — execution-artifact stdlib leaves:
+//     SummarizeJSONField (TruncateText'd one-line summary of a
+//     json.RawMessage; unquotes JSON strings, compacts objects /
+//     arrays, falls through to trimmed raw on parse errors;
+//     "" for empty / "null"), TaskLogRoot (WUPHF_TASK_LOG_ROOT
+//     env var → ~/.wuphf/office/tasks → ".wuphf/office/tasks"
+//     fallback for the headless task-tool log root).
 //   - artifact_renderers.go — execution-artifacts subsection
 //     renderers: RenderArtifactSection (date separator + per-
 //     artifact card with TaskID / RequestID click-target wiring

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -306,6 +306,9 @@ var (
 	renderArtifactSection = channelui.RenderArtifactSection
 	renderArtifactHeader  = channelui.RenderArtifactHeader
 	artifactExtraLines    = channelui.ArtifactExtraLines
+
+	summarizeJSONField = channelui.SummarizeJSONField
+	taskLogRoot        = channelui.TaskLogRoot
 )
 
 // Workspace readiness level consts.


### PR DESCRIPTION
## Summary

Stack PR #35. Two stdlib leaves move from \`channel_artifacts.go\` into a new \`channelui/artifact_helpers.go\`:

- \`SummarizeJSONField\` — \`TruncateText\`'d one-line summary of a \`json.RawMessage\`. JSON strings are unquoted; objects / arrays are compacted via \`json.Compact\`; malformed input falls through to the trimmed raw text. \`\"\"\` for empty / \`\"null\"\` so callers can elide rows.
- \`TaskLogRoot\` — \`WUPHF_TASK_LOG_ROOT\` env var wins; otherwise \`~/.wuphf/office/tasks\` (or \`.wuphf/office/tasks\` when the home directory is unavailable).

The \`bytes\` import drops from \`channel_artifacts.go\` as a side effect.

Stacked on top of \`refactor/channelui-artifact-renderers\`.

## Test plan

- [x] \`bash scripts/test-go.sh ./cmd/wuphf\` — green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)