### PR TITLE
refactor(channelui): hoist channel crash log helpers

### DIFF
--- a/cmd/wuphf/channel.go
+++ b/cmd/wuphf/channel.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -4805,28 +4804,4 @@ func reportChannelCrash(details string) {
 		fmt.Fprintln(os.Stderr, "then restart WUPHF when ready.")
 	}
 	select {}
-}
-
-func appendChannelCrashLog(details string) error {
-	path := channelCrashLogPath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
-		return err
-	}
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
-	if err != nil {
-		return err
-	}
-	if _, err := fmt.Fprintf(f, "\n[%s]\n%s\n", time.Now().Format(time.RFC3339), details); err != nil {
-		_ = f.Close()
-		return err
-	}
-	return f.Close()
-}
-
-func channelCrashLogPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return ".wuphf-channel-crash.log"
-	}
-	return filepath.Join(home, ".wuphf", "logs", "channel-crash.log")
 }

--- a/cmd/wuphf/channelui/crash_log.go
+++ b/cmd/wuphf/channelui/crash_log.go
@@ -1,0 +1,40 @@
+package channelui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// AppendChannelCrashLog appends an RFC3339-stamped crash entry to
+// the channel crash log at ChannelCrashLogPath, creating the
+// containing directory (mode 0o700) and the log file (mode 0o600)
+// when missing. Used by the bubble-tea panic recovery hook.
+func AppendChannelCrashLog(details string) error {
+	path := ChannelCrashLogPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(f, "\n[%s]\n%s\n", time.Now().Format(time.RFC3339), details); err != nil {
+		_ = f.Close()
+		return err
+	}
+	return f.Close()
+}
+
+// ChannelCrashLogPath returns the absolute path to the channel
+// crash log: ~/.wuphf/logs/channel-crash.log when a home directory
+// is available, otherwise a working-directory fallback so the
+// log is still capturable in restricted environments.
+func ChannelCrashLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".wuphf-channel-crash.log"
+	}
+	return filepath.Join(home, ".wuphf", "logs", "channel-crash.log")
+}

--- a/cmd/wuphf/channelui/doc.go
+++ b/cmd/wuphf/channelui/doc.go
@@ -279,6 +279,10 @@
 //     ""). The package-main task / workflow / orphan-log builders
 //     stay there since they touch package-main types like
 //     taskLogArtifact and workflowRunArtifact.
+//   - crash_log.go         — AppendChannelCrashLog (RFC3339-stamped
+//     append to the crash log; mode 0o700 dir + 0o600 file) and
+//     ChannelCrashLogPath (~/.wuphf/logs/channel-crash.log with
+//     a working-directory fallback).
 //   - artifact_helpers.go  — execution-artifact stdlib leaves:
 //     SummarizeJSONField (TruncateText'd one-line summary of a
 //     json.RawMessage; unquotes JSON strings, compacts objects /

--- a/cmd/wuphf/channelui_aliases.go
+++ b/cmd/wuphf/channelui_aliases.go
@@ -314,6 +314,9 @@ var (
 	summarizeJSONField = channelui.SummarizeJSONField
 	taskLogRoot        = channelui.TaskLogRoot
 
+	appendChannelCrashLog = channelui.AppendChannelCrashLog
+	channelCrashLogPath   = channelui.ChannelCrashLogPath
+
 	recentArtifactTasks           = channelui.RecentArtifactTasks
 	buildRequestRuntimeArtifact   = channelui.BuildRequestRuntimeArtifact
 	buildActionRuntimeArtifact    = channelui.BuildActionRuntimeArtifact


### PR DESCRIPTION
## Summary

Stack PR #38. Two pure stdlib disk-IO leaves move from \`channel.go\` into a new \`channelui/crash_log.go\`:

- \`AppendChannelCrashLog\` — RFC3339-stamped append to the crash log. Creates the directory (mode \`0o700\`) and file (mode \`0o600\`) when missing.
- \`ChannelCrashLogPath\` — \`~/.wuphf/logs/channel-crash.log\` when a home directory is available, otherwise a working-directory fallback.

The \`path/filepath\` import drops from \`channel.go\` as a side effect.

Stacked on top of \`refactor/channelui-task-workflow-builders\`.

## Test plan

- [x] \`bash scripts/test-go.sh ./cmd/wuphf\` — green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`gofmt -l cmd/wuphf/\` — clean
- [x] \`go build ./cmd/wuphf\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)