### PR TITLE
feat(scheduler): cron registry surfaced in Calendar app (PR 8)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -747,7 +747,7 @@ func PersistRegistration(data map[string]interface{}) error {
 }
 
 func ResolveInsightsPollInterval() int {
-	minutes := 15
+	minutes := 30
 	if raw := os.Getenv("WUPHF_INSIGHTS_INTERVAL_MINUTES"); raw != "" {
 		if n, err := strconv.Atoi(raw); err == nil {
 			minutes = n

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -347,6 +347,16 @@ type schedulerJob struct {
 	LastRun         string `json:"last_run,omitempty"`
 	Status          string `json:"status,omitempty"`
 	Payload         string `json:"payload,omitempty"`
+	// PR 8 Lane G: cron registry fields. SystemManaged crons are
+	// self-registered at broker startup and surfaced in the Calendar app's
+	// System Schedules panel; humans can disable/throttle them but cannot
+	// delete them. IntervalOverride lets the human dial the cadence without
+	// touching env / config — when non-zero, the run-loop uses it instead
+	// of the env-resolved default.
+	Enabled          bool   `json:"enabled"`
+	IntervalOverride int    `json:"interval_override,omitempty"`
+	LastRunStatus    string `json:"last_run_status,omitempty"`
+	SystemManaged    bool   `json:"system_managed,omitempty"`
 }
 
 type teamSkill struct {
@@ -736,6 +746,11 @@ func (b *Broker) Start() error {
 	b.ensureEntitySynthesizer()
 	b.ensurePlaybookExecutionLog()
 	b.ensurePlaybookSynthesizer()
+	// PR 8 Lane G: register system-managed crons AFTER review log + wiki
+	// worker init so the registry reflects subsystems that are actually up.
+	// Registration is idempotent — pre-existing entries keep their
+	// IntervalOverride and Enabled choices.
+	b.registerSystemCrons()
 	b.startReviewExpiryLoop(context.Background())
 	return b.StartOnPort(brokeraddr.ResolvePort())
 }
@@ -918,6 +933,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/watchdogs", b.requireAuth(b.handleWatchdogs))
 	mux.HandleFunc("/actions", b.requireAuth(b.handleActions))
 	mux.HandleFunc("/scheduler", b.requireAuth(b.handleScheduler))
+	mux.HandleFunc("/scheduler/", b.requireAuth(b.handleSchedulerSubpath))
 	mux.HandleFunc("/skills", b.requireAuth(b.handleSkills))
 	// /skills/compile lives ABOVE the wildcard subpath route so the
 	// ServeMux longest-match wins for the compile endpoints.

--- a/internal/team/broker_review.go
+++ b/internal/team/broker_review.go
@@ -149,20 +149,41 @@ func (b *Broker) ensureReviewLog() {
 }
 
 // startReviewExpiryLoop runs a background goroutine that fires TickExpiry
-// every 10 minutes. Auto-transitions are broadcast via the SSE event feed.
+// every 10 minutes (default). Auto-transitions are broadcast via the SSE
+// event feed. PR 8 Lane G: cadence + enabled flag honour the cron registry
+// — interval is re-read every tick so a PATCH takes effect on the next
+// scheduled fire instead of waiting for a process restart.
 func (b *Broker) startReviewExpiryLoop(ctx context.Context) {
+	const defaultInterval = 10 * time.Minute
 	go func() {
-		ticker := time.NewTicker(10 * time.Minute)
-		defer ticker.Stop()
+		// Lazy ticker so a mid-run interval change resizes naturally.
 		for {
+			enabled, interval := b.SchedulerJobControl("review-expiry", defaultInterval)
+			now := time.Now().UTC()
+			b.updateSchedulerHeartbeat("review-expiry", "Review expiry sweep",
+				int(interval/time.Minute), now.Add(interval),
+				disabledOrSleeping(enabled), "")
 			select {
 			case <-ctx.Done():
 				return
-			case <-ticker.C:
-				b.runReviewTick()
+			case <-time.After(interval):
 			}
+			if !enabled {
+				continue
+			}
+			b.runReviewTick()
+			b.updateSchedulerHeartbeat("review-expiry", "Review expiry sweep",
+				int(interval/time.Minute), time.Now().UTC().Add(interval),
+				"sleeping", "ok")
 		}
 	}()
+}
+
+func disabledOrSleeping(enabled bool) string {
+	if enabled {
+		return "sleeping"
+	}
+	return "disabled"
 }
 
 // runReviewTick fires one TickExpiry pass + publishes resulting SSE events.

--- a/internal/team/broker_scheduler.go
+++ b/internal/team/broker_scheduler.go
@@ -487,6 +487,13 @@ func (b *Broker) registerSystemCrons() {
 			}
 		}
 		if existing != nil {
+			// Migration: rows written before the cron registry had no
+			// Enabled field; JSON zero-value is false. Re-enable any
+			// system-managed row that was disabled only because it
+			// predates the registry (not by a deliberate user action).
+			if !existing.SystemManaged {
+				existing.Enabled = true
+			}
 			existing.Label = spec.Label
 			existing.SystemManaged = true
 			existing.IntervalMinutes = defaultInterval

--- a/internal/team/broker_scheduler.go
+++ b/internal/team/broker_scheduler.go
@@ -475,6 +475,9 @@ func (b *Broker) registerSystemCrons() {
 		if defaultInterval <= 0 {
 			defaultInterval = 1
 		}
+		if spec.MinFloor > 0 && defaultInterval < spec.MinFloor {
+			defaultInterval = spec.MinFloor
+		}
 		// Find existing — preserve user-controlled fields.
 		var existing *schedulerJob
 		for i := range b.scheduler {

--- a/internal/team/broker_scheduler.go
+++ b/internal/team/broker_scheduler.go
@@ -640,6 +640,9 @@ func (b *Broker) handlePatchSchedulerJob(w http.ResponseWriter, r *http.Request,
 		return
 	}
 
+	// Snapshot before mutation so we can roll back if persistence fails.
+	snapshot := *job
+
 	if body.IntervalOverride != nil {
 		override := *body.IntervalOverride
 		if override < 0 {
@@ -667,6 +670,8 @@ func (b *Broker) handlePatchSchedulerJob(w http.ResponseWriter, r *http.Request,
 		}
 	}
 	if err := b.saveLocked(); err != nil {
+		// Restore in-memory state so the broker stays consistent with disk.
+		*job = snapshot
 		http.Error(w, "failed to persist scheduler update", http.StatusInternalServerError)
 		return
 	}

--- a/internal/team/broker_scheduler.go
+++ b/internal/team/broker_scheduler.go
@@ -3,6 +3,7 @@ package team
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -388,4 +389,279 @@ func (b *Broker) handleScheduler(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+// systemCronSpec describes a self-registered cron's identity + default
+// interval (PR 8 Lane G). Read-only crons (one-relay-events for v1) refuse
+// PATCH; everything else can be throttled within its floor.
+type systemCronSpec struct {
+	Slug            string
+	Label           string
+	DefaultInterval func() int // minutes; resolved fresh at registration
+	MinFloor        int        // minutes; minimum interval_override accepted
+	ReadOnly        bool       // one-relay-events: hardcoded for v1
+}
+
+// systemCronSpecs is the v1 system cron registry. Order is alphabetical
+// for deterministic startup. Each entry SHOULD be invisible in /scheduler
+// today (or surface only sporadically); registration makes them
+// configurable from the Calendar app.
+func systemCronSpecs() []systemCronSpec {
+	return []systemCronSpec{
+		{
+			Slug:            "nex-insights",
+			Label:           "Nex insights",
+			DefaultInterval: func() int { return config.ResolveInsightsPollInterval() },
+			MinFloor:        30, // LLM-touching, quota burn — keep the floor high
+		},
+		{
+			Slug:            "nex-notifications",
+			Label:           "Nex notifications",
+			DefaultInterval: func() int { return int(notificationPollInterval() / time.Minute) },
+			MinFloor:        5,
+		},
+		{
+			Slug:            "one-relay-events",
+			Label:           "One relay events",
+			DefaultInterval: func() int { return 1 },
+			MinFloor:        1,
+			ReadOnly:        true, // hardcoded for v1 — surface only
+		},
+		{
+			Slug:            "request_follow_up",
+			Label:           "Request follow-up reminders",
+			DefaultInterval: func() int { return config.ResolveTaskFollowUpInterval() },
+			MinFloor:        5,
+		},
+		{
+			Slug:            "review-expiry",
+			Label:           "Review expiry sweep",
+			DefaultInterval: func() int { return 10 },
+			MinFloor:        5,
+		},
+		{
+			Slug:            "task_follow_up",
+			Label:           "Task follow-up reminders",
+			DefaultInterval: func() int { return config.ResolveTaskFollowUpInterval() },
+			MinFloor:        5,
+		},
+		{
+			Slug:            "task_recheck",
+			Label:           "Task recheck cadence",
+			DefaultInterval: func() int { return config.ResolveTaskRecheckInterval() },
+			MinFloor:        5,
+		},
+		{
+			Slug:            "task_reminder",
+			Label:           "Task reminder cadence",
+			DefaultInterval: func() int { return config.ResolveTaskReminderInterval() },
+			MinFloor:        5,
+		},
+	}
+}
+
+// registerSystemCrons self-registers every system cron from
+// systemCronSpecs. Idempotent: existing entries keep their Enabled and
+// IntervalOverride values; only the Label / SystemManaged / IntervalMinutes
+// (default) fields refresh, so a config change to the env-resolved default
+// shows up the next time the broker starts.
+//
+// Takes b.mu internally — DO NOT call while holding the lock.
+func (b *Broker) registerSystemCrons() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, spec := range systemCronSpecs() {
+		defaultInterval := spec.DefaultInterval()
+		if defaultInterval <= 0 {
+			defaultInterval = 1
+		}
+		// Find existing — preserve user-controlled fields.
+		var existing *schedulerJob
+		for i := range b.scheduler {
+			if b.scheduler[i].Slug == spec.Slug {
+				existing = &b.scheduler[i]
+				break
+			}
+		}
+		if existing != nil {
+			existing.Label = spec.Label
+			existing.SystemManaged = true
+			existing.IntervalMinutes = defaultInterval
+			continue
+		}
+		b.scheduler = append(b.scheduler, schedulerJob{
+			Slug:            spec.Slug,
+			Label:           spec.Label,
+			IntervalMinutes: defaultInterval,
+			Status:          "scheduled",
+			SystemManaged:   true,
+			Enabled:         true,
+		})
+	}
+	if err := b.saveLocked(); err != nil {
+		log.Printf("registerSystemCronsLocked: saveLocked failed: %v", err)
+	}
+}
+
+// updateSchedulerHeartbeat refreshes the in-memory scheduler entry for slug
+// with the latest interval / next-run / status fields (PR 8 Lane G). When
+// the slug isn't yet registered we fall through to a fresh entry so legacy
+// subsystems that surface a cron without going through registerSystemCrons
+// still appear in the Calendar app's System Schedules panel.
+func (b *Broker) updateSchedulerHeartbeat(slug, label string, intervalMinutes int, nextRun time.Time, status string, runStatus string) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	now := time.Now().UTC().Format(time.RFC3339)
+	for i := range b.scheduler {
+		if b.scheduler[i].Slug != slug {
+			continue
+		}
+		b.scheduler[i].Label = label
+		b.scheduler[i].IntervalMinutes = intervalMinutes
+		if !nextRun.IsZero() {
+			b.scheduler[i].NextRun = nextRun.UTC().Format(time.RFC3339)
+		}
+		if status != "" {
+			b.scheduler[i].Status = status
+		}
+		if status == "sleeping" || runStatus != "" {
+			b.scheduler[i].LastRun = now
+		}
+		if runStatus != "" {
+			b.scheduler[i].LastRunStatus = runStatus
+		}
+		_ = b.saveLocked()
+		return
+	}
+	// Slug missing — fall back to a fresh entry so legacy subsystems that
+	// surface a cron without registerSystemCrons still appear.
+	job := schedulerJob{
+		Slug:            slug,
+		Label:           label,
+		IntervalMinutes: intervalMinutes,
+		Status:          status,
+		Enabled:         true,
+	}
+	if !nextRun.IsZero() {
+		job.NextRun = nextRun.UTC().Format(time.RFC3339)
+	}
+	if status == "sleeping" || runStatus != "" {
+		job.LastRun = now
+	}
+	if runStatus != "" {
+		job.LastRunStatus = runStatus
+	}
+	job = normalizeSchedulerJob(job)
+	b.scheduler = append(b.scheduler, job)
+	_ = b.saveLocked()
+}
+
+// handleSchedulerSubpath dispatches /scheduler/{slug} requests. Currently
+// only PATCH is supported (PR 8 Lane G); future verbs (delete, run-now)
+// would land here too.
+func (b *Broker) handleSchedulerSubpath(w http.ResponseWriter, r *http.Request) {
+	slug := strings.TrimPrefix(r.URL.Path, "/scheduler/")
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		http.Error(w, "scheduler slug required in path", http.StatusBadRequest)
+		return
+	}
+	switch r.Method {
+	case http.MethodPatch:
+		b.handlePatchSchedulerJob(w, r, slug)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handlePatchSchedulerJob updates the Enabled flag and / or
+// IntervalOverride on a registered cron. System-managed read-only crons
+// (one-relay-events for v1) reject any change with 400.
+//
+//	PATCH /scheduler/{slug}
+//	{ "enabled"?: bool, "interval_override"?: int }
+//
+// Validation:
+//   - interval_override of 0 clears the override (fall back to default).
+//   - interval_override > 0 must be >= the spec's MinFloor; otherwise 400.
+//   - Unknown slug → 404.
+//   - Read-only spec (one-relay-events) → 400 with reason.
+func (b *Broker) handlePatchSchedulerJob(w http.ResponseWriter, r *http.Request, slug string) {
+	var body struct {
+		Enabled          *bool `json:"enabled,omitempty"`
+		IntervalOverride *int  `json:"interval_override,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if body.Enabled == nil && body.IntervalOverride == nil {
+		http.Error(w, "at least one of enabled or interval_override required", http.StatusBadRequest)
+		return
+	}
+
+	// Look up the spec for floor + read-only enforcement. System-cron specs
+	// are the source of truth; non-system jobs (workflow / task follow-ups
+	// scheduled per-instance) inherit a generic 5-minute floor.
+	var spec *systemCronSpec
+	for _, s := range systemCronSpecs() {
+		if s.Slug == slug {
+			cp := s
+			spec = &cp
+			break
+		}
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var job *schedulerJob
+	for i := range b.scheduler {
+		if b.scheduler[i].Slug == slug {
+			job = &b.scheduler[i]
+			break
+		}
+	}
+	if job == nil {
+		http.Error(w, "scheduler job not found", http.StatusNotFound)
+		return
+	}
+	if spec != nil && spec.ReadOnly {
+		http.Error(w, fmt.Sprintf("scheduler job %q is read-only in v1", slug), http.StatusBadRequest)
+		return
+	}
+
+	if body.IntervalOverride != nil {
+		override := *body.IntervalOverride
+		if override < 0 {
+			http.Error(w, "interval_override must be >= 0", http.StatusBadRequest)
+			return
+		}
+		floor := 5
+		if spec != nil {
+			floor = spec.MinFloor
+		}
+		if override > 0 && override < floor {
+			http.Error(w, fmt.Sprintf("interval_override below floor (%d minutes)", floor), http.StatusBadRequest)
+			return
+		}
+		job.IntervalOverride = override
+	}
+	if body.Enabled != nil {
+		job.Enabled = *body.Enabled
+		// Reflect in Status so /scheduler GET surfaces the disabled state
+		// without requiring callers to read Enabled separately.
+		if !job.Enabled {
+			job.Status = "disabled"
+		} else if strings.EqualFold(job.Status, "disabled") {
+			job.Status = "scheduled"
+		}
+	}
+	if err := b.saveLocked(); err != nil {
+		http.Error(w, "failed to persist scheduler update", http.StatusInternalServerError)
+		return
+	}
+
+	updated := *job
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"job": updated})
 }

--- a/internal/team/launcher_loops.go
+++ b/internal/team/launcher_loops.go
@@ -97,13 +97,22 @@ func (l *Launcher) pollOneRelayEventsLoop() {
 	if _, err := provider.ListRelays(context.Background(), action.ListRelaysOptions{Limit: 1}); err != nil {
 		return
 	}
-	interval := time.Minute
+	const defaultInterval = time.Minute
 	time.Sleep(25 * time.Second)
 	for {
-		l.updateSchedulerJob("one-relay-events", "One relay events", interval, time.Now().UTC(), "running")
+		// one-relay-events is read-only in v1 (interval_override is not
+		// user-settable), but Enabled is honored so a future admin path
+		// stays consistent with other system crons.
+		enabled, _ := l.broker.SchedulerJobControl("one-relay-events", defaultInterval)
+		if !enabled {
+			l.updateSchedulerJob("one-relay-events", "One relay events", defaultInterval, time.Now().UTC().Add(defaultInterval), "disabled")
+			time.Sleep(defaultInterval)
+			continue
+		}
+		l.updateSchedulerJob("one-relay-events", "One relay events", defaultInterval, time.Now().UTC(), "running")
 		l.fetchAndRecordOneRelayEvents(provider)
-		l.updateSchedulerJob("one-relay-events", "One relay events", interval, time.Now().UTC().Add(interval), "sleeping")
-		time.Sleep(interval)
+		l.updateSchedulerJob("one-relay-events", "One relay events", defaultInterval, time.Now().UTC().Add(defaultInterval), "sleeping")
+		time.Sleep(defaultInterval)
 	}
 }
 

--- a/internal/team/launcher_nex.go
+++ b/internal/team/launcher_nex.go
@@ -91,10 +91,17 @@ func (l *Launcher) pollNexNotificationsLoop() {
 		return
 	}
 	client := api.NewClient(apiKey)
-	interval := notificationPollInterval()
+	defaultInterval := notificationPollInterval()
 
 	time.Sleep(10 * time.Second)
 	for {
+		// PR 8 Lane G: honor enabled / interval_override from the cron registry.
+		enabled, interval := l.broker.SchedulerJobControl("nex-notifications", defaultInterval)
+		if !enabled {
+			l.updateSchedulerJob("nex-notifications", "Nex notifications", interval, time.Now().UTC().Add(interval), "disabled")
+			time.Sleep(interval)
+			continue
+		}
 		l.updateSchedulerJob("nex-notifications", "Nex notifications", interval, time.Now().UTC(), "running")
 		l.fetchAndIngestNexNotifications(client)
 		l.updateSchedulerJob("nex-notifications", "Nex notifications", interval, time.Now().UTC().Add(interval), "sleeping")
@@ -198,10 +205,17 @@ func (l *Launcher) pollNexInsightsLoop() {
 		return
 	}
 	client := api.NewClient(apiKey)
-	interval := time.Duration(config.ResolveInsightsPollInterval()) * time.Minute
+	defaultInterval := time.Duration(config.ResolveInsightsPollInterval()) * time.Minute
 
 	time.Sleep(20 * time.Second)
 	for {
+		// PR 8 Lane G: honor enabled / interval_override from the cron registry.
+		enabled, interval := l.broker.SchedulerJobControl("nex-insights", defaultInterval)
+		if !enabled {
+			l.updateSchedulerJob("nex-insights", "Nex insights", interval, time.Now().UTC().Add(interval), "disabled")
+			time.Sleep(interval)
+			continue
+		}
 		l.updateSchedulerJob("nex-insights", "Nex insights", interval, time.Now().UTC(), "running")
 		l.fetchAndPostNexInsights(client)
 		l.updateSchedulerJob("nex-insights", "Nex insights", interval, time.Now().UTC().Add(interval), "sleeping")

--- a/internal/team/scheduler.go
+++ b/internal/team/scheduler.go
@@ -59,6 +59,9 @@ type schedulerBroker interface {
 	PostAutomationMessage(from, channel, title, body, alertID, source, displayName string, ccSlugs []string, replyTo string) (channelMessage, bool, error)
 	UpdateSkillExecutionByWorkflowKey(key, status string, when time.Time) error
 	SetSchedulerJob(job schedulerJob) error
+	// PR 8 Lane G additions for cron registry support.
+	SchedulerJobControl(slug string, defaultInterval time.Duration) (bool, time.Duration)
+	updateSchedulerHeartbeat(slug, label string, intervalMinutes int, nextRun time.Time, status string, runStatus string)
 }
 
 // watchdogScheduler runs the periodic broker-driven watchdog loop. One
@@ -207,6 +210,19 @@ func (w *watchdogScheduler) processOnce() {
 		return
 	}
 	for _, job := range jobs {
+		// PR 8 Lane G: per-instance jobs (task_follow_up, request_follow_up,
+		// task_reminder, task_recheck) inherit the Enabled state of their
+		// class-level system cron. If a human disables "task_reminder" from
+		// the Calendar app, every existing per-task reminder skips its
+		// dispatch this tick. The job is rescheduled (not killed) so flipping
+		// Enabled back on resumes naturally without orphaning state.
+		if classSlug := strings.TrimSpace(job.Kind); classSlug != "" {
+			if classEnabled, _ := w.broker.SchedulerJobControl(classSlug, time.Duration(job.IntervalMinutes)*time.Minute); !classEnabled {
+				next := w.clock.Now().UTC().Add(5 * time.Minute)
+				_ = w.broker.UpdateSchedulerJobState(job.Slug, next, "disabled")
+				continue
+			}
+		}
 		switch strings.TrimSpace(job.TargetType) {
 		case "task":
 			w.processTaskJob(job)
@@ -455,23 +471,15 @@ func (w *watchdogScheduler) recordLedger(channel, kind, targetID, owner, summary
 }
 
 // updateJob is a small helper still used by the launcher's Launch() path
-// to seed the persisted job state on startup. Kept on the scheduler so
-// the broker.SetSchedulerJob call has one owner.
+// to seed the persisted job state on startup. PR 8 Lane G: routes through
+// updateSchedulerHeartbeat so the user-controlled cron-registry fields
+// (Enabled, IntervalOverride, SystemManaged, LastRunStatus) survive each
+// tick instead of being clobbered by SetSchedulerJob's full-row replace.
 func (w *watchdogScheduler) updateJob(slug, label string, interval time.Duration, nextRun time.Time, status string) {
 	if w.broker == nil {
 		return
 	}
-	job := schedulerJob{
-		Slug:            slug,
-		Label:           label,
-		IntervalMinutes: int(interval / time.Minute),
-		NextRun:         nextRun.UTC().Format(time.RFC3339),
-		Status:          status,
-	}
-	if status == "sleeping" {
-		job.LastRun = w.clock.Now().UTC().Format(time.RFC3339)
-	}
-	_ = w.broker.SetSchedulerJob(job)
+	w.broker.updateSchedulerHeartbeat(slug, label, int(interval/time.Minute), nextRun, status, "")
 }
 
 // nextWorkflowRun parses a cron expression and returns the next scheduled

--- a/internal/team/scheduler_registry_test.go
+++ b/internal/team/scheduler_registry_test.go
@@ -1,0 +1,303 @@
+package team
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"testing"
+	"time"
+)
+
+// PR 8 Lane G: cron registry tests. Five cases per the task spec, each
+// exercising a different slice of the registry contract.
+
+// startSchedulerTestBroker boots a broker on an ephemeral port and returns
+// (b, base url). Caller defers b.Stop(). Mirrors what Broker.Start() does
+// — registerSystemCrons + StartOnPort(0) — minus the fixed-port listen so
+// parallel tests don't collide.
+func startSchedulerTestBroker(t *testing.T) (*Broker, string) {
+	t.Helper()
+	b := newTestBroker(t)
+	b.registerSystemCrons()
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("StartOnPort: %v", err)
+	}
+	return b, fmt.Sprintf("http://%s", b.Addr())
+}
+
+// patchScheduler sends PATCH /scheduler/{slug} and returns the (status, body).
+func patchScheduler(t *testing.T, b *Broker, base, slug string, payload map[string]any) (int, []byte) {
+	t.Helper()
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	req, _ := http.NewRequest(http.MethodPatch, base+"/scheduler/"+slug, bytes.NewReader(raw))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH /scheduler/%s: %v", slug, err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, body
+}
+
+// TestSchedulerSelfRegistersSystemCrons asserts every spec'd system cron
+// is visible in /scheduler GET after broker startup with SystemManaged=true
+// and Enabled=true.
+func TestSchedulerSelfRegistersSystemCrons(t *testing.T) {
+	b, base := startSchedulerTestBroker(t)
+	defer b.Stop()
+
+	req, _ := http.NewRequest(http.MethodGet, base+"/scheduler", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /scheduler: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /scheduler: status %d", resp.StatusCode)
+	}
+	var listing struct {
+		Jobs []schedulerJob `json:"jobs"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listing); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	want := map[string]bool{
+		"nex-insights":      false,
+		"nex-notifications": false,
+		"one-relay-events":  false,
+		"request_follow_up": false,
+		"review-expiry":     false,
+		"task_follow_up":    false,
+		"task_recheck":      false,
+		"task_reminder":     false,
+	}
+	for _, job := range listing.Jobs {
+		if _, ok := want[job.Slug]; !ok {
+			continue
+		}
+		if !job.SystemManaged {
+			t.Errorf("%s: SystemManaged=false, want true", job.Slug)
+		}
+		if !job.Enabled {
+			t.Errorf("%s: Enabled=false, want true", job.Slug)
+		}
+		want[job.Slug] = true
+	}
+	for slug, found := range want {
+		if !found {
+			missing := make([]string, 0)
+			for s, f := range want {
+				if !f {
+					missing = append(missing, s)
+				}
+			}
+			sort.Strings(missing)
+			t.Fatalf("system cron %q missing from /scheduler. all missing: %v", slug, missing)
+		}
+	}
+}
+
+// TestPatchScheduler_UpdatesIntervalOverride covers the happy path:
+// PATCH a configurable cron with a valid interval_override, GET back to
+// confirm the field landed.
+func TestPatchScheduler_UpdatesIntervalOverride(t *testing.T) {
+	b, base := startSchedulerTestBroker(t)
+	defer b.Stop()
+
+	status, body := patchScheduler(t, b, base, "task_reminder", map[string]any{
+		"interval_override": 90,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("status %d, body %s", status, body)
+	}
+
+	var out struct {
+		Job schedulerJob `json:"job"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Job.IntervalOverride != 90 {
+		t.Errorf("IntervalOverride: got %d, want 90", out.Job.IntervalOverride)
+	}
+
+	// Confirm SchedulerJobControl now reports the override (not the default).
+	enabled, interval := b.SchedulerJobControl("task_reminder", 30*time.Minute) // 30m placeholder default
+	if !enabled {
+		t.Error("Enabled flipped unexpectedly")
+	}
+	if interval.Minutes() != 90 {
+		t.Errorf("interval: got %v, want 90m", interval)
+	}
+}
+
+// TestPatchScheduler_RejectsBelowFloor walks every system cron and asserts
+// an interval_override below its MinFloor returns 400.
+func TestPatchScheduler_RejectsBelowFloor(t *testing.T) {
+	b, base := startSchedulerTestBroker(t)
+	defer b.Stop()
+
+	tests := []struct {
+		slug    string
+		below   int
+		atFloor int
+	}{
+		{slug: "nex-insights", below: 29, atFloor: 30},
+		{slug: "nex-notifications", below: 4, atFloor: 5},
+		{slug: "task_reminder", below: 4, atFloor: 5},
+		{slug: "task_recheck", below: 4, atFloor: 5},
+		{slug: "task_follow_up", below: 4, atFloor: 5},
+		{slug: "request_follow_up", below: 4, atFloor: 5},
+		{slug: "review-expiry", below: 4, atFloor: 5},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.slug+"_below_floor", func(t *testing.T) {
+			status, body := patchScheduler(t, b, base, tc.slug, map[string]any{
+				"interval_override": tc.below,
+			})
+			if status != http.StatusBadRequest {
+				t.Errorf("%s below floor (%d): got status %d, body %s; want 400",
+					tc.slug, tc.below, status, body)
+			}
+		})
+		t.Run(tc.slug+"_at_floor", func(t *testing.T) {
+			status, body := patchScheduler(t, b, base, tc.slug, map[string]any{
+				"interval_override": tc.atFloor,
+			})
+			if status != http.StatusOK {
+				t.Errorf("%s at floor (%d): got status %d, body %s; want 200",
+					tc.slug, tc.atFloor, status, body)
+			}
+		})
+	}
+}
+
+// TestPatchScheduler_RejectsOnReadOnlyCron verifies one-relay-events
+// refuses any PATCH in v1 with a 400.
+func TestPatchScheduler_RejectsOnReadOnlyCron(t *testing.T) {
+	b, base := startSchedulerTestBroker(t)
+	defer b.Stop()
+
+	cases := []map[string]any{
+		{"interval_override": 5},
+		{"enabled": false},
+		{"interval_override": 10, "enabled": true},
+	}
+	for i, payload := range cases {
+		status, body := patchScheduler(t, b, base, "one-relay-events", payload)
+		if status != http.StatusBadRequest {
+			t.Errorf("case %d (%v): got status %d, body %s; want 400", i, payload, status, body)
+		}
+	}
+}
+
+// TestPatchScheduler_DisabledSkipsRun asserts that disabling a system cron
+// flips Enabled=false in the registry and SchedulerJobControl reports it
+// so the run-loop will skip its tick.
+func TestPatchScheduler_DisabledSkipsRun(t *testing.T) {
+	b, base := startSchedulerTestBroker(t)
+	defer b.Stop()
+
+	status, body := patchScheduler(t, b, base, "nex-insights", map[string]any{
+		"enabled": false,
+	})
+	if status != http.StatusOK {
+		t.Fatalf("PATCH disable: status %d, body %s", status, body)
+	}
+
+	enabled, _ := b.SchedulerJobControl("nex-insights", 30*time.Minute)
+	if enabled {
+		t.Error("Enabled stayed true after PATCH enabled=false")
+	}
+
+	// And re-enable round-trips.
+	if status, body := patchScheduler(t, b, base, "nex-insights", map[string]any{
+		"enabled": true,
+	}); status != http.StatusOK {
+		t.Fatalf("PATCH re-enable: status %d, body %s", status, body)
+	}
+	if enabled, _ := b.SchedulerJobControl("nex-insights", 30*time.Minute); !enabled {
+		t.Error("Enabled didn't flip back to true")
+	}
+}
+
+// TestPatchScheduler_UnknownSlugReturns404 covers the lookup miss path.
+func TestPatchScheduler_UnknownSlugReturns404(t *testing.T) {
+	b, base := startSchedulerTestBroker(t)
+	defer b.Stop()
+
+	status, _ := patchScheduler(t, b, base, "does-not-exist", map[string]any{
+		"interval_override": 10,
+	})
+	if status != http.StatusNotFound {
+		t.Errorf("status %d, want 404", status)
+	}
+}
+
+// TestSchedulerHeartbeatPreservesUserFields guards the regression where a
+// run-loop heartbeat (updateSchedulerJob) clobbered Enabled /
+// IntervalOverride / SystemManaged / LastRunStatus by fully replacing the
+// scheduler entry.
+func TestSchedulerHeartbeatPreservesUserFields(t *testing.T) {
+	b, base := startSchedulerTestBroker(t)
+	defer b.Stop()
+
+	// Operator state: interval override + LastRunStatus.
+	if status, _ := patchScheduler(t, b, base, "nex-insights", map[string]any{
+		"interval_override": 60,
+	}); status != http.StatusOK {
+		t.Fatalf("PATCH override: status %d", status)
+	}
+	b.mu.Lock()
+	for i := range b.scheduler {
+		if b.scheduler[i].Slug == "nex-insights" {
+			b.scheduler[i].LastRunStatus = "ok"
+		}
+	}
+	b.mu.Unlock()
+
+	// Simulate a heartbeat: run-loop reports it's running with the env
+	// default interval. Heartbeat must NOT clobber the override / status.
+	b.updateSchedulerHeartbeat("nex-insights", "Nex insights", 30, /* default */
+		time.Time{}, "running", "")
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var job *schedulerJob
+	for i := range b.scheduler {
+		if b.scheduler[i].Slug == "nex-insights" {
+			job = &b.scheduler[i]
+			break
+		}
+	}
+	if job == nil {
+		t.Fatal("nex-insights missing after heartbeat")
+	}
+	if job.IntervalOverride != 60 {
+		t.Errorf("IntervalOverride: got %d, want 60 (heartbeat must preserve)", job.IntervalOverride)
+	}
+	if !job.SystemManaged {
+		t.Error("SystemManaged dropped to false")
+	}
+	if !job.Enabled {
+		t.Error("Enabled dropped to false")
+	}
+	if job.LastRunStatus != "ok" {
+		t.Errorf("LastRunStatus: got %q, want ok", job.LastRunStatus)
+	}
+	if job.Status != "running" {
+		t.Errorf("Status: got %q, want running", job.Status)
+	}
+}
+

--- a/internal/team/scheduler_registry_test.go
+++ b/internal/team/scheduler_registry_test.go
@@ -300,4 +300,3 @@ func TestSchedulerHeartbeatPreservesUserFields(t *testing.T) {
 		t.Errorf("Status: got %q, want running", job.Status)
 	}
 }
-

--- a/internal/team/scheduler_runtime.go
+++ b/internal/team/scheduler_runtime.go
@@ -12,6 +12,34 @@ func (b *Broker) DueSchedulerJobs() []schedulerJob {
 	return append([]schedulerJob(nil), b.dueSchedulerJobsLocked(time.Now().UTC())...)
 }
 
+// SchedulerJobControl returns (enabled, effective interval) for the named
+// cron slug. effectiveInterval is IntervalOverride when non-zero, else the
+// caller's defaultInterval. Run-loops call this once per tick (PR 8 Lane G):
+//
+//	enabled, interval := l.broker.SchedulerJobControl("nex-insights", config-default)
+//	if !enabled { time.Sleep(interval); continue }
+//	... do work ...
+//	time.Sleep(interval)
+//
+// When the slug isn't registered (e.g. broker not yet seeded), returns
+// (true, defaultInterval) so callers fall back to legacy behavior. ok=false
+// is reserved for "slug found but caller passed an invalid default".
+func (b *Broker) SchedulerJobControl(slug string, defaultInterval time.Duration) (bool, time.Duration) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, job := range b.scheduler {
+		if job.Slug != slug {
+			continue
+		}
+		interval := defaultInterval
+		if job.IntervalOverride > 0 {
+			interval = time.Duration(job.IntervalOverride) * time.Minute
+		}
+		return job.Enabled, interval
+	}
+	return true, defaultInterval
+}
+
 func (b *Broker) UpdateSchedulerJobState(slug string, nextRun time.Time, status string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/team/scheduler_test.go
+++ b/internal/team/scheduler_test.go
@@ -571,6 +571,11 @@ func (b *schedulerFixtureBroker) UpdateSkillExecutionByWorkflowKey(key, status s
 }
 
 func (b *schedulerFixtureBroker) SetSchedulerJob(_ schedulerJob) error { return nil }
+func (b *schedulerFixtureBroker) SchedulerJobControl(_ string, defaultInterval time.Duration) (bool, time.Duration) {
+	return true, defaultInterval
+}
+func (b *schedulerFixtureBroker) updateSchedulerHeartbeat(_, _ string, _ int, _ time.Time, _, _ string) {
+}
 
 // recordingLedgerBroker is a minimal stub that captures the kind+owner
 // passed to RecordDecision. Used by recordLedger branch tests.
@@ -610,9 +615,17 @@ func (b *recordingLedgerBroker) UpdateSkillExecutionByWorkflowKey(string, string
 	return nil
 }
 func (b *recordingLedgerBroker) SetSchedulerJob(schedulerJob) error { return nil }
+func (b *recordingLedgerBroker) SchedulerJobControl(_ string, defaultInterval time.Duration) (bool, time.Duration) {
+	return true, defaultInterval
+}
+func (b *recordingLedgerBroker) updateSchedulerHeartbeat(_, _ string, _ int, _ time.Time, _, _ string) {
+}
 
 // capturingSetJobBroker wraps schedulerFixtureBroker and intercepts
 // SetSchedulerJob so updateJob persistence can be asserted on directly.
+// PR 8 Lane G: also intercepts updateSchedulerHeartbeat since updateJob
+// now routes heartbeats through that path to preserve user-controlled
+// cron-registry fields.
 type capturingSetJobBroker struct {
 	*schedulerFixtureBroker
 	captureSet func(schedulerJob)
@@ -623,6 +636,27 @@ func (b *capturingSetJobBroker) SetSchedulerJob(j schedulerJob) error {
 		b.captureSet(j)
 	}
 	return nil
+}
+
+func (b *capturingSetJobBroker) updateSchedulerHeartbeat(slug, label string, intervalMinutes int, nextRun time.Time, status string, runStatus string) {
+	if b.captureSet == nil {
+		return
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	job := schedulerJob{
+		Slug:            slug,
+		Label:           label,
+		IntervalMinutes: intervalMinutes,
+		Status:          status,
+		LastRunStatus:   runStatus,
+	}
+	if !nextRun.IsZero() {
+		job.NextRun = nextRun.UTC().Format(time.RFC3339)
+	}
+	if status == "sleeping" || runStatus != "" {
+		job.LastRun = now
+	}
+	b.captureSet(job)
 }
 
 // Sanity: assert that the launcher wires the scheduler with broker, clock,

--- a/scripts/cron_eval/eval.py
+++ b/scripts/cron_eval/eval.py
@@ -1,0 +1,794 @@
+#!/usr/bin/env python3
+"""Cron-registry end-to-end evaluation harness (PR 8 Lane I).
+
+Boots a freshly-built dev broker on :7899, drives the /scheduler surface
+through a series of contract scenarios, and asserts pass/fail per the
+spec in the cron registry test plan.
+
+Scenarios:
+  1. self-registration on cold boot — every system cron present, system_managed,
+     enabled.
+  2. PATCH happy path — interval_override lands and survives a GET.
+  3. floor rejection — sub-floor override returns 400, state unchanged.
+  4. read-only cron — one-relay-events refuses any PATCH with 400.
+  5. disable + re-enable — round-trip flips enabled and status="disabled".
+  6. disabled cron skips run — disabled cron emits no telemetry within one
+     tick window (best-effort log-line scan).
+  7. persistence across restart — caller-driven; harness writes a state
+     snapshot after PATCH, then a follow-up subcommand re-reads after the
+     broker has been restarted.
+
+Acceptance gates:
+  - cron_self_registration: 8/8 system crons present, all system_managed,
+    all enabled.
+  - cron_patch_floors_enforced: every below-floor PATCH returns 400; every
+    at-floor PATCH returns 200.
+  - cron_disabled_skips_run: disabled cron emits no run line in the
+    sampled tick window.
+  - cron_persistence: PATCH-set override survives a broker restart.
+
+Usage:
+  python3 scripts/cron_eval/eval.py \\
+      --broker http://localhost:7899 \\
+      --token-file /tmp/wuphf-broker-token-7899 \\
+      --broker-log /tmp/wuphf-dev-eval.log \\
+      --report scripts/cron_eval/last-report.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Source-of-truth mirror of internal/team/broker.go::systemCronSpecs(). Keep in
+# sync; CI surfaces a divergence as a self-registration failure.
+SYSTEM_CRONS: dict[str, dict[str, Any]] = {
+    "nex-insights": {"min_floor": 30, "read_only": False},
+    "nex-notifications": {"min_floor": 5, "read_only": False},
+    "one-relay-events": {"min_floor": 1, "read_only": True},
+    "request_follow_up": {"min_floor": 5, "read_only": False},
+    "review-expiry": {"min_floor": 5, "read_only": False},
+    "task_follow_up": {"min_floor": 5, "read_only": False},
+    "task_recheck": {"min_floor": 5, "read_only": False},
+    "task_reminder": {"min_floor": 5, "read_only": False},
+}
+
+# Token state-snapshot dir: where the harness drops PATCH state before a
+# restart so the caller can verify persistence after the broker reboots.
+PERSISTENCE_SNAPSHOT_PATH = "/tmp/wuphf-cron-eval-snapshot.json"
+
+
+# ---------- HTTP helpers ----------
+
+
+def http_request(
+    method: str,
+    url: str,
+    *,
+    token: str,
+    body: dict[str, Any] | None = None,
+    timeout: float = 15.0,
+) -> tuple[int, dict[str, Any] | str]:
+    """Wraps urllib with a Bearer-auth header. JSON-decodes both 2xx and
+    4xx/5xx bodies so callers asserting structured error shapes don't have
+    to re-parse on every status-code branch.
+    """
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode()
+            try:
+                return resp.status, json.loads(raw)
+            except json.JSONDecodeError:
+                return resp.status, raw
+    except urllib.error.HTTPError as e:
+        try:
+            payload = e.read().decode()
+        except Exception:
+            payload = str(e)
+        try:
+            return e.code, json.loads(payload)
+        except (json.JSONDecodeError, ValueError):
+            return e.code, payload
+
+
+def list_scheduler(broker: str, token: str) -> list[dict[str, Any]]:
+    code, body = http_request("GET", f"{broker}/scheduler", token=token)
+    if code != 200 or not isinstance(body, dict):
+        return []
+    jobs = body.get("jobs") or []
+    return list(jobs)
+
+
+def patch_scheduler(
+    broker: str, token: str, slug: str, payload: dict[str, Any]
+) -> tuple[int, dict[str, Any] | str]:
+    return http_request(
+        "PATCH",
+        f"{broker}/scheduler/{urllib.parse.quote(slug)}",
+        token=token,
+        body=payload,
+    )
+
+
+# ---------- Result types ----------
+
+
+@dataclass
+class ScenarioResult:
+    id: str
+    title: str
+    ok: bool
+    detail: str = ""
+    sub_results: list[tuple[str, bool, str]] = field(default_factory=list)
+
+
+@dataclass
+class CronEvalReport:
+    self_registration_pass: int = 0
+    self_registration_total: int = len(SYSTEM_CRONS)
+    floors_pass: int = 0
+    floors_total: int = 0  # 7 below-floor + 7 at-floor cases
+    disabled_skips_run: bool | None = None  # None == not exercised
+    persistence_ok: bool | None = None  # None == not exercised this run
+    scenarios: list[ScenarioResult] = field(default_factory=list)
+
+
+# ---------- Scenarios ----------
+
+
+def scenario_self_registration(
+    broker: str, token: str, report: CronEvalReport
+) -> ScenarioResult:
+    """Scenario 1: GET /scheduler returns every system cron with
+    system_managed=true and enabled=true on cold boot.
+    """
+    jobs = list_scheduler(broker, token)
+    by_slug = {j.get("slug"): j for j in jobs if j.get("slug")}
+    sub: list[tuple[str, bool, str]] = []
+    for slug in SYSTEM_CRONS:
+        job = by_slug.get(slug)
+        if job is None:
+            sub.append((slug, False, "missing from /scheduler"))
+            continue
+        if not job.get("system_managed", False):
+            sub.append((slug, False, "system_managed=false (want true)"))
+            continue
+        if not job.get("enabled", False):
+            sub.append((slug, False, "enabled=false (want true on cold boot)"))
+            continue
+        sub.append((slug, True, ""))
+    pass_count = sum(1 for _, ok, _ in sub if ok)
+    report.self_registration_pass = pass_count
+    ok = pass_count == len(SYSTEM_CRONS)
+    detail = (
+        f"{pass_count}/{len(SYSTEM_CRONS)} system crons registered with "
+        f"system_managed=true and enabled=true"
+    )
+    return ScenarioResult(
+        id="cron-01-self-registration",
+        title="Self-registration on cold boot",
+        ok=ok,
+        detail=detail,
+        sub_results=sub,
+    )
+
+
+def scenario_patch_happy_path(broker: str, token: str) -> ScenarioResult:
+    """Scenario 2: PATCH a configurable cron with a valid override and
+    confirm GET reflects it. Uses nex-notifications (floor=5) at 30 min.
+    """
+    target_slug = "nex-notifications"
+    want_override = 30
+    code, body = patch_scheduler(
+        broker, token, target_slug, {"interval_override": want_override}
+    )
+    if code != 200:
+        return ScenarioResult(
+            id="cron-02-patch-happy-path",
+            title=f"PATCH {target_slug} interval_override={want_override}",
+            ok=False,
+            detail=f"PATCH returned {code}: {body!r}",
+        )
+    # Confirm via fresh GET that the override survives the round-trip.
+    jobs = list_scheduler(broker, token)
+    found = next((j for j in jobs if j.get("slug") == target_slug), None)
+    if found is None:
+        return ScenarioResult(
+            id="cron-02-patch-happy-path",
+            title=f"PATCH {target_slug} interval_override={want_override}",
+            ok=False,
+            detail="cron disappeared from /scheduler after PATCH",
+        )
+    actual_override = int(found.get("interval_override") or 0)
+    ok = actual_override == want_override
+    detail = (
+        f"GET shows interval_override={actual_override}, want {want_override}"
+        if not ok
+        else f"interval_override={actual_override} as set"
+    )
+    return ScenarioResult(
+        id="cron-02-patch-happy-path",
+        title=f"PATCH {target_slug} interval_override={want_override}",
+        ok=ok,
+        detail=detail,
+    )
+
+
+def scenario_floor_rejection(
+    broker: str, token: str, report: CronEvalReport
+) -> ScenarioResult:
+    """Scenario 3: every configurable cron must reject below-floor PATCH (400)
+    and accept at-floor PATCH (200). Read-only crons are excluded; they're
+    covered by scenario_read_only.
+    """
+    sub: list[tuple[str, bool, str]] = []
+    cases_total = 0
+    cases_pass = 0
+    for slug, spec in SYSTEM_CRONS.items():
+        if spec["read_only"]:
+            continue
+        floor = int(spec["min_floor"])
+        below = max(1, floor - 1)
+        # Snapshot pre-PATCH state so we can confirm the below-floor PATCH
+        # left the cron untouched.
+        pre_jobs = list_scheduler(broker, token)
+        pre = next((j for j in pre_jobs if j.get("slug") == slug), None)
+        pre_override = int((pre or {}).get("interval_override") or 0)
+
+        # Below-floor → 400 expected.
+        cases_total += 1
+        code, body = patch_scheduler(
+            broker, token, slug, {"interval_override": below}
+        )
+        below_ok = code == 400
+        if below_ok:
+            cases_pass += 1
+        sub.append(
+            (
+                f"{slug} below_floor (override={below}, floor={floor})",
+                below_ok,
+                ""
+                if below_ok
+                else f"want 400 got {code}: {body!r}",
+            )
+        )
+        # State must be unchanged after a rejected PATCH.
+        post_jobs = list_scheduler(broker, token)
+        post = next((j for j in post_jobs if j.get("slug") == slug), None)
+        post_override = int((post or {}).get("interval_override") or 0)
+        if post_override != pre_override:
+            sub.append(
+                (
+                    f"{slug} state-after-reject",
+                    False,
+                    f"interval_override changed from {pre_override} to "
+                    f"{post_override} despite 400",
+                )
+            )
+            cases_total += 1  # count the state assertion too
+
+        # At-floor → 200 expected.
+        cases_total += 1
+        code, body = patch_scheduler(
+            broker, token, slug, {"interval_override": floor}
+        )
+        at_floor_ok = code == 200
+        if at_floor_ok:
+            cases_pass += 1
+        sub.append(
+            (
+                f"{slug} at_floor (override={floor})",
+                at_floor_ok,
+                ""
+                if at_floor_ok
+                else f"want 200 got {code}: {body!r}",
+            )
+        )
+    report.floors_pass = cases_pass
+    report.floors_total = cases_total
+    ok = cases_pass == cases_total and cases_total > 0
+    return ScenarioResult(
+        id="cron-03-floor-rejection",
+        title="Floor rejection (below=400, at=200)",
+        ok=ok,
+        detail=f"{cases_pass}/{cases_total} sub-cases pass",
+        sub_results=sub,
+    )
+
+
+def scenario_read_only(broker: str, token: str) -> ScenarioResult:
+    """Scenario 4: one-relay-events refuses every PATCH variant with 400."""
+    target_slug = "one-relay-events"
+    sub: list[tuple[str, bool, str]] = []
+    payloads: list[dict[str, Any]] = [
+        {"interval_override": 5},
+        {"enabled": False},
+        {"interval_override": 10, "enabled": True},
+    ]
+    pre_jobs = list_scheduler(broker, token)
+    pre = next((j for j in pre_jobs if j.get("slug") == target_slug), None)
+    pre_enabled = bool((pre or {}).get("enabled", False))
+    pre_override = int((pre or {}).get("interval_override") or 0)
+    all_ok = True
+    for i, payload in enumerate(payloads):
+        code, body = patch_scheduler(broker, token, target_slug, payload)
+        ok = code == 400
+        if not ok:
+            all_ok = False
+        sub.append(
+            (
+                f"{target_slug} payload-{i} ({payload})",
+                ok,
+                "" if ok else f"want 400 got {code}: {body!r}",
+            )
+        )
+    # State must be untouched.
+    post_jobs = list_scheduler(broker, token)
+    post = next((j for j in post_jobs if j.get("slug") == target_slug), None)
+    post_enabled = bool((post or {}).get("enabled", False))
+    post_override = int((post or {}).get("interval_override") or 0)
+    state_unchanged = post_enabled == pre_enabled and post_override == pre_override
+    sub.append(
+        (
+            f"{target_slug} state-unchanged",
+            state_unchanged,
+            ""
+            if state_unchanged
+            else f"enabled {pre_enabled}->{post_enabled}, "
+            f"override {pre_override}->{post_override}",
+        )
+    )
+    return ScenarioResult(
+        id="cron-04-read-only",
+        title=f"Read-only cron rejects PATCH ({target_slug})",
+        ok=all_ok and state_unchanged,
+        detail="rejected all 3 variants" if all_ok and state_unchanged else "see sub-results",
+        sub_results=sub,
+    )
+
+
+def scenario_disable_re_enable(broker: str, token: str) -> ScenarioResult:
+    """Scenario 5: disable + re-enable round-trip flips enabled and status."""
+    target_slug = "task_follow_up"
+    # Disable.
+    code, body = patch_scheduler(broker, token, target_slug, {"enabled": False})
+    if code != 200:
+        return ScenarioResult(
+            id="cron-05-disable-reenable",
+            title=f"Disable + re-enable ({target_slug})",
+            ok=False,
+            detail=f"PATCH disable returned {code}: {body!r}",
+        )
+    jobs = list_scheduler(broker, token)
+    job = next((j for j in jobs if j.get("slug") == target_slug), None)
+    if job is None:
+        return ScenarioResult(
+            id="cron-05-disable-reenable",
+            title=f"Disable + re-enable ({target_slug})",
+            ok=False,
+            detail="cron missing after disable",
+        )
+    if job.get("enabled", True):
+        return ScenarioResult(
+            id="cron-05-disable-reenable",
+            title=f"Disable + re-enable ({target_slug})",
+            ok=False,
+            detail=f"enabled stayed true after disable: job={job!r}",
+        )
+    if (job.get("status") or "").lower() != "disabled":
+        return ScenarioResult(
+            id="cron-05-disable-reenable",
+            title=f"Disable + re-enable ({target_slug})",
+            ok=False,
+            detail=f"status={job.get('status')!r}, want disabled",
+        )
+    # Re-enable.
+    code, body = patch_scheduler(broker, token, target_slug, {"enabled": True})
+    if code != 200:
+        return ScenarioResult(
+            id="cron-05-disable-reenable",
+            title=f"Disable + re-enable ({target_slug})",
+            ok=False,
+            detail=f"PATCH re-enable returned {code}: {body!r}",
+        )
+    jobs = list_scheduler(broker, token)
+    job = next((j for j in jobs if j.get("slug") == target_slug), None)
+    if job is None or not job.get("enabled", False):
+        return ScenarioResult(
+            id="cron-05-disable-reenable",
+            title=f"Disable + re-enable ({target_slug})",
+            ok=False,
+            detail=f"enabled didn't flip back: job={job!r}",
+        )
+    return ScenarioResult(
+        id="cron-05-disable-reenable",
+        title=f"Disable + re-enable ({target_slug})",
+        ok=True,
+        detail="round-trip clean",
+    )
+
+
+def scenario_disabled_skips_run(
+    broker: str, token: str, broker_log: Path | None, report: CronEvalReport
+) -> ScenarioResult:
+    """Scenario 6: a disabled cron emits no telemetry inside the sampled
+    window. Best-effort: snapshot last_run_at + run-loop log line count
+    before disable, wait one tick interval, then assert neither moved.
+
+    We disable nex-notifications (floor 5, real cron) and watch for ~12s.
+    The cron's run-loop is keyed on IntervalOverride, so a freshly-disabled
+    cron with no override is still "due" by clock — the harness asserts it
+    DOESN'T fire while disabled.
+    """
+    target_slug = "nex-notifications"
+    # Disable + force a tiny override so the run loop would WANT to fire
+    # often if it weren't disabled. The 5-min floor still applies, so we
+    # set interval_override=5 first (within floor) THEN disable.
+    code, body = patch_scheduler(
+        broker, token, target_slug, {"interval_override": 5}
+    )
+    if code != 200:
+        report.disabled_skips_run = False
+        return ScenarioResult(
+            id="cron-06-disabled-skips-run",
+            title=f"Disabled cron skips run ({target_slug})",
+            ok=False,
+            detail=f"PATCH override pre-step returned {code}: {body!r}",
+        )
+    code, body = patch_scheduler(broker, token, target_slug, {"enabled": False})
+    if code != 200:
+        report.disabled_skips_run = False
+        return ScenarioResult(
+            id="cron-06-disabled-skips-run",
+            title=f"Disabled cron skips run ({target_slug})",
+            ok=False,
+            detail=f"PATCH disable returned {code}: {body!r}",
+        )
+    pre_jobs = list_scheduler(broker, token)
+    pre = next((j for j in pre_jobs if j.get("slug") == target_slug), None)
+    pre_last = (pre or {}).get("last_run") or ""
+    pre_log_lines = _count_log_matches(broker_log, target_slug)
+
+    # Sample window. The fastest registry tick is 60s, so 12s is safely under
+    # one tick; we're asserting the cron does NOT fire spuriously, not that
+    # we sat through a full default cycle.
+    time.sleep(12.0)
+
+    post_jobs = list_scheduler(broker, token)
+    post = next((j for j in post_jobs if j.get("slug") == target_slug), None)
+    post_last = (post or {}).get("last_run") or ""
+    post_log_lines = _count_log_matches(broker_log, target_slug)
+
+    last_run_unchanged = post_last == pre_last
+    log_lines_unchanged = post_log_lines == pre_log_lines
+    ok = last_run_unchanged and log_lines_unchanged
+    detail = (
+        f"last_run {pre_last!r}->{post_last!r}, "
+        f"log_lines mentioning {target_slug}: {pre_log_lines}->{post_log_lines}"
+    )
+    report.disabled_skips_run = ok
+
+    # Restore so subsequent scenarios start from a clean state.
+    patch_scheduler(broker, token, target_slug, {"enabled": True})
+    patch_scheduler(broker, token, target_slug, {"interval_override": 0})
+
+    return ScenarioResult(
+        id="cron-06-disabled-skips-run",
+        title=f"Disabled cron skips run ({target_slug})",
+        ok=ok,
+        detail=detail,
+    )
+
+
+def _count_log_matches(broker_log: Path | None, slug: str) -> int:
+    """Counts log lines containing slug. Returns 0 if log is missing —
+    the disabled-skips-run check then collapses to last_run-only, which
+    is still a valid signal but not as strong.
+    """
+    if broker_log is None or not broker_log.exists():
+        return 0
+    try:
+        text = broker_log.read_text(errors="replace")
+    except OSError:
+        return 0
+    return text.count(slug)
+
+
+def scenario_persistence_snapshot(
+    broker: str, token: str
+) -> ScenarioResult:
+    """Scenario 7a: write a snapshot of the cron state after PATCHing an
+    override. Caller restarts the broker, then runs --verify-persistence
+    to compare. We choose review-expiry to avoid colliding with other
+    scenarios.
+    """
+    target_slug = "review-expiry"
+    want_override = 25  # well above the 5-min floor
+    code, body = patch_scheduler(
+        broker, token, target_slug, {"interval_override": want_override}
+    )
+    if code != 200:
+        return ScenarioResult(
+            id="cron-07a-persistence-snapshot",
+            title=f"Persistence snapshot ({target_slug})",
+            ok=False,
+            detail=f"PATCH returned {code}: {body!r}",
+        )
+    snapshot = {
+        "slug": target_slug,
+        "interval_override": want_override,
+        "captured_at": time.time(),
+    }
+    Path(PERSISTENCE_SNAPSHOT_PATH).write_text(json.dumps(snapshot))
+    return ScenarioResult(
+        id="cron-07a-persistence-snapshot",
+        title=f"Persistence snapshot ({target_slug})",
+        ok=True,
+        detail=(
+            f"snapshot written to {PERSISTENCE_SNAPSHOT_PATH}; "
+            "restart broker, then run --verify-persistence"
+        ),
+    )
+
+
+def scenario_persistence_verify(
+    broker: str, token: str, report: CronEvalReport
+) -> ScenarioResult:
+    """Scenario 7b: read the snapshot from disk and confirm a fresh GET
+    against the just-restarted broker still shows the override.
+    """
+    snapshot_path = Path(PERSISTENCE_SNAPSHOT_PATH)
+    if not snapshot_path.exists():
+        report.persistence_ok = False
+        return ScenarioResult(
+            id="cron-07b-persistence-verify",
+            title="Persistence verify",
+            ok=False,
+            detail=(
+                f"no snapshot at {PERSISTENCE_SNAPSHOT_PATH}; "
+                "did you run --persistence-snapshot first?"
+            ),
+        )
+    snapshot = json.loads(snapshot_path.read_text())
+    target_slug = snapshot["slug"]
+    want_override = int(snapshot["interval_override"])
+    jobs = list_scheduler(broker, token)
+    job = next((j for j in jobs if j.get("slug") == target_slug), None)
+    if job is None:
+        report.persistence_ok = False
+        return ScenarioResult(
+            id="cron-07b-persistence-verify",
+            title="Persistence verify",
+            ok=False,
+            detail=f"{target_slug} missing from /scheduler post-restart",
+        )
+    actual_override = int(job.get("interval_override") or 0)
+    ok = actual_override == want_override
+    report.persistence_ok = ok
+    return ScenarioResult(
+        id="cron-07b-persistence-verify",
+        title="Persistence verify",
+        ok=ok,
+        detail=(
+            f"interval_override post-restart={actual_override}, "
+            f"snapshot={want_override}"
+        ),
+    )
+
+
+# ---------- Reporting ----------
+
+
+def print_report(report: CronEvalReport) -> None:
+    print()
+    print("=" * 78)
+    print("CRON REGISTRY EVAL — PER-SCENARIO BREAKDOWN")
+    print("=" * 78)
+    for sc in report.scenarios:
+        sign = "PASS" if sc.ok else "FAIL"
+        print(f"  [{sign}] {sc.id:<32}  {sc.title}")
+        if sc.detail:
+            print(f"         {sc.detail}")
+        for sub_id, sub_ok, sub_detail in sc.sub_results:
+            sub_sign = "PASS" if sub_ok else "FAIL"
+            line = f"           - [{sub_sign}] {sub_id}"
+            if sub_detail:
+                line += f"  // {sub_detail}"
+            print(line)
+
+
+def render_markdown_report(report: CronEvalReport) -> str:
+    out: list[str] = []
+    out.append("# Cron-registry evaluation report")
+    out.append("")
+    out.append(
+        f"- **Self-registration:** {report.self_registration_pass}/"
+        f"{report.self_registration_total}"
+    )
+    out.append(
+        f"- **Floors enforced:** {report.floors_pass}/{report.floors_total}"
+    )
+    out.append(
+        f"- **Disabled-skips-run:** "
+        f"{'pass' if report.disabled_skips_run else 'fail' if report.disabled_skips_run is False else 'n/a'}"
+    )
+    out.append(
+        f"- **Persistence:** "
+        f"{'pass' if report.persistence_ok else 'fail' if report.persistence_ok is False else 'n/a (run --verify-persistence)'}"
+    )
+    out.append("")
+    out.append("## Scenarios")
+    out.append("")
+    out.append("| id | title | pass | detail |")
+    out.append("|---|---|---|---|")
+    for sc in report.scenarios:
+        sign = "PASS" if sc.ok else "FAIL"
+        detail = (sc.detail or "").replace("|", "/")
+        out.append(f"| `{sc.id}` | {sc.title} | {sign} | {detail} |")
+    # Sub-results table for scenarios that have any.
+    if any(sc.sub_results for sc in report.scenarios):
+        out.append("")
+        out.append("## Sub-results")
+        out.append("")
+        out.append("| scenario | sub | pass | detail |")
+        out.append("|---|---|---|---|")
+        for sc in report.scenarios:
+            for sub_id, sub_ok, sub_detail in sc.sub_results:
+                sign = "PASS" if sub_ok else "FAIL"
+                detail = (sub_detail or "").replace("|", "/")
+                out.append(f"| `{sc.id}` | `{sub_id}` | {sign} | {detail} |")
+    return "\n".join(out) + "\n"
+
+
+# ---------- Main ----------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--broker", default="http://localhost:7899")
+    ap.add_argument("--token-file", default="/tmp/wuphf-broker-token-7899")
+    ap.add_argument(
+        "--broker-log",
+        default="/tmp/wuphf-dev-eval.log",
+        help="Broker log path; used by scenario 6 to count run-line activity.",
+    )
+    ap.add_argument(
+        "--report",
+        default=None,
+        help="If set, also write the markdown report to this path.",
+    )
+    ap.add_argument(
+        "--persistence-snapshot",
+        action="store_true",
+        help=(
+            "Run only scenario 7a (write snapshot + PATCH). Caller restarts "
+            "the broker, then re-runs with --verify-persistence."
+        ),
+    )
+    ap.add_argument(
+        "--verify-persistence",
+        action="store_true",
+        help="Run only scenario 7b (verify the snapshot against post-restart state).",
+    )
+    args = ap.parse_args()
+
+    token_path = Path(args.token_file)
+    if not token_path.exists():
+        print(f"token file not found: {token_path}", file=sys.stderr)
+        return 2
+    token = token_path.read_text().strip()
+    broker_log = Path(args.broker_log) if args.broker_log else None
+
+    report = CronEvalReport()
+
+    if args.persistence_snapshot:
+        report.scenarios.append(scenario_persistence_snapshot(args.broker, token))
+        print_report(report)
+        if args.report:
+            Path(args.report).write_text(render_markdown_report(report), encoding="utf-8")
+        return 0 if all(sc.ok for sc in report.scenarios) else 1
+
+    if args.verify_persistence:
+        report.scenarios.append(scenario_persistence_verify(args.broker, token, report))
+        print_report(report)
+        if args.report:
+            Path(args.report).write_text(render_markdown_report(report), encoding="utf-8")
+        ok = report.persistence_ok is True
+        print()
+        print("=" * 78)
+        print("PERSISTENCE GATE")
+        print("=" * 78)
+        print(f"  cron_persistence: {'PASS' if ok else 'FAIL'}")
+        return 0 if ok else 1
+
+    # Full run: scenarios 1-6, then write the persistence snapshot last so
+    # downstream tooling can chain --verify-persistence against the restart.
+    print(f"[cron-eval] broker={args.broker}")
+    report.scenarios.append(scenario_self_registration(args.broker, token, report))
+    report.scenarios.append(scenario_patch_happy_path(args.broker, token))
+    report.scenarios.append(scenario_floor_rejection(args.broker, token, report))
+    report.scenarios.append(scenario_read_only(args.broker, token))
+    report.scenarios.append(scenario_disable_re_enable(args.broker, token))
+    report.scenarios.append(
+        scenario_disabled_skips_run(args.broker, token, broker_log, report)
+    )
+    # Always run the snapshot last so its PATCH doesn't leak into earlier
+    # state-asserting scenarios.
+    report.scenarios.append(scenario_persistence_snapshot(args.broker, token))
+
+    print_report(report)
+
+    if args.report:
+        Path(args.report).write_text(render_markdown_report(report), encoding="utf-8")
+        print(f"\n[cron-eval] markdown report written to {args.report}")
+
+    # Acceptance gates per the task spec.
+    self_reg_ok = report.self_registration_pass == report.self_registration_total
+    floors_ok = (
+        report.floors_total > 0 and report.floors_pass == report.floors_total
+    )
+    disabled_ok = report.disabled_skips_run is True
+    # Persistence gate is verified by the --verify-persistence subcommand;
+    # the in-process snapshot scenario only asserts the PATCH itself landed.
+    persistence_snapshot_ok = (
+        report.scenarios[-1].ok if report.scenarios else False
+    )
+
+    print()
+    print("=" * 78)
+    print("ACCEPTANCE GATES")
+    print("=" * 78)
+    print(
+        f"  cron_self_registration:   "
+        f"{report.self_registration_pass}/{report.self_registration_total}  "
+        f"({'PASS' if self_reg_ok else 'FAIL'})"
+    )
+    print(
+        f"  cron_patch_floors:        "
+        f"{report.floors_pass}/{report.floors_total}  "
+        f"({'PASS' if floors_ok else 'FAIL'})"
+    )
+    print(
+        f"  cron_disabled_skips_run:  "
+        f"{'PASS' if disabled_ok else 'FAIL'}"
+    )
+    print(
+        f"  cron_persistence_snap:    "
+        f"{'PASS' if persistence_snapshot_ok else 'FAIL'}  "
+        f"(restart broker + --verify-persistence to confirm gate 4)"
+    )
+
+    other_scenarios_ok = all(
+        sc.ok for sc in report.scenarios
+        if sc.id
+        not in {
+            "cron-01-self-registration",
+            "cron-03-floor-rejection",
+            "cron-06-disabled-skips-run",
+            "cron-07a-persistence-snapshot",
+        }
+    )
+    overall_ok = (
+        self_reg_ok and floors_ok and disabled_ok and persistence_snapshot_ok
+        and other_scenarios_ok
+    )
+    return 0 if overall_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cron_eval/last-report.md
+++ b/scripts/cron_eval/last-report.md
@@ -1,0 +1,49 @@
+# Cron-registry evaluation report
+
+- **Self-registration:** 8/8
+- **Floors enforced:** 14/14
+- **Disabled-skips-run:** pass
+- **Persistence:** n/a (run --verify-persistence)
+
+## Scenarios
+
+| id | title | pass | detail |
+|---|---|---|---|
+| `cron-01-self-registration` | Self-registration on cold boot | PASS | 8/8 system crons registered with system_managed=true and enabled=true |
+| `cron-02-patch-happy-path` | PATCH nex-notifications interval_override=30 | PASS | interval_override=30 as set |
+| `cron-03-floor-rejection` | Floor rejection (below=400, at=200) | PASS | 14/14 sub-cases pass |
+| `cron-04-read-only` | Read-only cron rejects PATCH (one-relay-events) | PASS | rejected all 3 variants |
+| `cron-05-disable-reenable` | Disable + re-enable (task_follow_up) | PASS | round-trip clean |
+| `cron-06-disabled-skips-run` | Disabled cron skips run (nex-notifications) | PASS | last_run ''->'', log_lines mentioning nex-notifications: 0->0 |
+| `cron-07a-persistence-snapshot` | Persistence snapshot (review-expiry) | PASS | snapshot written to /tmp/wuphf-cron-eval-snapshot.json; restart broker, then run --verify-persistence |
+
+## Sub-results
+
+| scenario | sub | pass | detail |
+|---|---|---|---|
+| `cron-01-self-registration` | `nex-insights` | PASS |  |
+| `cron-01-self-registration` | `nex-notifications` | PASS |  |
+| `cron-01-self-registration` | `one-relay-events` | PASS |  |
+| `cron-01-self-registration` | `request_follow_up` | PASS |  |
+| `cron-01-self-registration` | `review-expiry` | PASS |  |
+| `cron-01-self-registration` | `task_follow_up` | PASS |  |
+| `cron-01-self-registration` | `task_recheck` | PASS |  |
+| `cron-01-self-registration` | `task_reminder` | PASS |  |
+| `cron-03-floor-rejection` | `nex-insights below_floor (override=29, floor=30)` | PASS |  |
+| `cron-03-floor-rejection` | `nex-insights at_floor (override=30)` | PASS |  |
+| `cron-03-floor-rejection` | `nex-notifications below_floor (override=4, floor=5)` | PASS |  |
+| `cron-03-floor-rejection` | `nex-notifications at_floor (override=5)` | PASS |  |
+| `cron-03-floor-rejection` | `request_follow_up below_floor (override=4, floor=5)` | PASS |  |
+| `cron-03-floor-rejection` | `request_follow_up at_floor (override=5)` | PASS |  |
+| `cron-03-floor-rejection` | `review-expiry below_floor (override=4, floor=5)` | PASS |  |
+| `cron-03-floor-rejection` | `review-expiry at_floor (override=5)` | PASS |  |
+| `cron-03-floor-rejection` | `task_follow_up below_floor (override=4, floor=5)` | PASS |  |
+| `cron-03-floor-rejection` | `task_follow_up at_floor (override=5)` | PASS |  |
+| `cron-03-floor-rejection` | `task_recheck below_floor (override=4, floor=5)` | PASS |  |
+| `cron-03-floor-rejection` | `task_recheck at_floor (override=5)` | PASS |  |
+| `cron-03-floor-rejection` | `task_reminder below_floor (override=4, floor=5)` | PASS |  |
+| `cron-03-floor-rejection` | `task_reminder at_floor (override=5)` | PASS |  |
+| `cron-04-read-only` | `one-relay-events payload-0 ({'interval_override': 5})` | PASS |  |
+| `cron-04-read-only` | `one-relay-events payload-1 ({'enabled': False})` | PASS |  |
+| `cron-04-read-only` | `one-relay-events payload-2 ({'interval_override': 10, 'enabled': True})` | PASS |  |
+| `cron-04-read-only` | `one-relay-events state-unchanged` | PASS |  |

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -148,6 +148,22 @@ export async function postWithTimeout<T = unknown>(
   }
 }
 
+export async function patch<T = unknown>(
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const r = await fetch(baseURL() + path, {
+    method: "PATCH",
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) {
+    const text = (await r.text().catch(() => "")).trim();
+    throw new Error(text || `${r.status} ${r.statusText}`);
+  }
+  return r.json();
+}
+
 export async function del<T = unknown>(
   path: string,
   body?: unknown,
@@ -593,12 +609,54 @@ export interface SchedulerJob {
   last_run?: string;
   due_at?: string;
   status?: string;
+  /** Interval-driven cadence in minutes (system crons + interval workflows). */
+  interval_minutes?: number;
+  /** Cron expression for cron-driven workflow jobs. */
+  schedule_expr?: string;
+  /** Provider that owns this job (e.g. "system", "agent", "workflow"). */
+  provider?: string;
+  /** Target type ("workflow" | "skill" | …) when surfaced by the runtime. */
+  target_type?: string;
+  target_id?: string;
+  // PR 8 Lane G/H — cron registry surface fields.
+  /** Whether the cron is currently enabled. */
+  enabled?: boolean;
+  /** Human override for the cadence in minutes. 0/missing = use default. */
+  interval_override?: number;
+  /** "ok" | "failed" — chip on the row. */
+  last_run_status?: string;
+  /** True for crons that self-register at broker startup. */
+  system_managed?: boolean;
 }
 
 export function getScheduler(opts?: { dueOnly?: boolean }) {
   const params: Record<string, string> = {};
   if (opts?.dueOnly) params.due_only = "true";
   return get<{ jobs: SchedulerJob[] }>("/scheduler", params);
+}
+
+export interface PatchSchedulerJobBody {
+  enabled?: boolean;
+  /** Minutes; 0 clears the override. Must be >= the cron's MinFloor. */
+  interval_override?: number;
+}
+
+export interface PatchSchedulerJobResponse {
+  job: SchedulerJob;
+}
+
+/**
+ * Update the enabled flag and / or interval_override for a scheduler job.
+ * Backed by PATCH /scheduler/{slug} (PR 8 Lane G).
+ */
+export function patchSchedulerJob(
+  slug: string,
+  body: PatchSchedulerJobBody,
+): Promise<PatchSchedulerJobResponse> {
+  return patch<PatchSchedulerJobResponse>(
+    `/scheduler/${encodeURIComponent(slug)}`,
+    body,
+  );
 }
 
 // ── Skills ──

--- a/web/src/components/apps/CalendarApp.tsx
+++ b/web/src/components/apps/CalendarApp.tsx
@@ -13,7 +13,7 @@ function isCadenceJob(job: SchedulerJob): boolean {
   return (
     job.system_managed === true ||
     typeof job.interval_minutes === "number" ||
-    typeof job.schedule_expr === "string"
+    (typeof job.schedule_expr === "string" && job.schedule_expr.trim().length > 0)
   );
 }
 

--- a/web/src/components/apps/CalendarApp.tsx
+++ b/web/src/components/apps/CalendarApp.tsx
@@ -2,6 +2,20 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getScheduler, type SchedulerJob } from "../../api/client";
 import { formatRelativeTime } from "../../lib/format";
+import { SystemSchedulesPanel } from "./SystemSchedulesPanel";
+
+/**
+ * Decide whether a job belongs in the System Schedules panel (cron-style
+ * cadence) or in the timeline (one-shot due_at). Keep this in sync with
+ * SystemSchedulesPanel.filterSchedulerRows so we don't double-render.
+ */
+function isCadenceJob(job: SchedulerJob): boolean {
+  return (
+    job.system_managed === true ||
+    typeof job.interval_minutes === "number" ||
+    typeof job.schedule_expr === "string"
+  );
+}
 
 function groupJobsByDate(jobs: SchedulerJob[]): Record<string, SchedulerJob[]> {
   const groups: Record<string, SchedulerJob[]> = {};
@@ -67,7 +81,9 @@ export function CalendarApp() {
   }
 
   const jobs = data?.jobs ?? [];
-  const groups = groupJobsByDate(jobs);
+  const cadenceJobs = jobs.filter(isCadenceJob);
+  const timelineJobs = jobs.filter((j) => !isCadenceJob(j));
+  const groups = groupJobsByDate(timelineJobs);
   const groupKeys = Object.keys(groups);
 
   return (
@@ -87,6 +103,8 @@ export function CalendarApp() {
         </p>
       </div>
 
+      <SystemSchedulesPanel jobs={cadenceJobs} />
+
       {jobs.length === 0 ? (
         <div
           style={{
@@ -97,6 +115,17 @@ export function CalendarApp() {
           }}
         >
           No scheduled jobs.
+        </div>
+      ) : timelineJobs.length === 0 ? (
+        <div
+          style={{
+            padding: "20px 0",
+            textAlign: "center",
+            color: "var(--text-tertiary)",
+            fontSize: 13,
+          }}
+        >
+          No upcoming one-off jobs.
         </div>
       ) : (
         groupKeys.map((groupKey) => (

--- a/web/src/components/apps/SystemSchedulesPanel.test.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.test.tsx
@@ -1,0 +1,275 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SchedulerJob } from "../../api/client";
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return {
+    ...actual,
+    patchSchedulerJob: vi.fn(),
+  };
+});
+
+import * as clientMod from "../../api/client";
+import { SystemSchedulesPanel } from "./SystemSchedulesPanel";
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+const baseSystemJob: SchedulerJob = {
+  slug: "task_recheck",
+  label: "Task recheck cadence",
+  interval_minutes: 10,
+  enabled: true,
+  system_managed: true,
+  next_run: new Date(Date.now() + 60_000).toISOString(),
+  last_run: new Date(Date.now() - 60_000).toISOString(),
+  last_run_status: "ok",
+};
+
+const readOnlyRelay: SchedulerJob = {
+  slug: "one-relay-events",
+  label: "One relay events",
+  interval_minutes: 1,
+  enabled: true,
+  system_managed: true,
+};
+
+const insightsJob: SchedulerJob = {
+  slug: "nex-insights",
+  label: "Nex insights",
+  interval_minutes: 60,
+  enabled: true,
+  system_managed: true,
+};
+
+const workflowCronJob: SchedulerJob = {
+  slug: "weekly-digest",
+  label: "Weekly digest",
+  schedule_expr: "0 9 * * MON",
+  enabled: true,
+  system_managed: false,
+  kind: "workflow",
+};
+
+describe("<SystemSchedulesPanel> rendering", () => {
+  it("renders nothing when no cadence jobs are present", () => {
+    const { container } = render(wrap(<SystemSchedulesPanel jobs={[]} />));
+    expect(container.textContent).not.toContain("System Schedules");
+  });
+
+  it("renders each row state — system, read-only, workflow cron", () => {
+    render(
+      wrap(
+        <SystemSchedulesPanel
+          jobs={[baseSystemJob, readOnlyRelay, workflowCronJob]}
+        />,
+      ),
+    );
+
+    // Section heading present.
+    expect(screen.getByText("System Schedules")).toBeInTheDocument();
+
+    // System interval row exposes a number input.
+    expect(
+      screen.getByRole("spinbutton", {
+        name: /Interval in minutes for Task recheck cadence/i,
+      }),
+    ).toBeInTheDocument();
+
+    // Read-only row uses static text, not an input.
+    expect(screen.getByText(/Every 1m \(read-only\)/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("spinbutton", {
+        name: /Interval in minutes for One relay events/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    // Workflow cron row shows the cron string read-only.
+    expect(screen.getByText(/cron: 0 9 \* \* MON/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("spinbutton", {
+        name: /Interval in minutes for Weekly digest/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    // Source badges.
+    expect(screen.getAllByText("system").length).toBe(2);
+    expect(screen.getByText("workflow")).toBeInTheDocument();
+
+    // OK chip on last_run_status="ok".
+    expect(screen.getByText(/^OK ·/)).toBeInTheDocument();
+  });
+
+  it("disables the toggle on read-only crons", () => {
+    render(wrap(<SystemSchedulesPanel jobs={[readOnlyRelay]} />));
+    const toggle = screen.getByRole("switch", {
+      name: /Disable One relay events/i,
+    });
+    expect(toggle).toBeDisabled();
+  });
+});
+
+describe("<SystemSchedulesPanel> toggle round-trip", () => {
+  it("optimistically flips enabled and submits PATCH on toggle", async () => {
+    const patchMock = vi
+      .mocked(clientMod.patchSchedulerJob)
+      .mockResolvedValueOnce({
+        job: { ...baseSystemJob, enabled: false },
+      });
+
+    render(wrap(<SystemSchedulesPanel jobs={[baseSystemJob]} />));
+
+    const toggle = screen.getByRole("switch", {
+      name: /Disable Task recheck cadence/i,
+    });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(toggle);
+
+    // Optimistic flip is immediate.
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    await waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith("task_recheck", {
+        enabled: false,
+      });
+    });
+  });
+
+  it("rolls back optimistic state when PATCH fails", async () => {
+    vi.mocked(clientMod.patchSchedulerJob).mockRejectedValueOnce(
+      new Error("network down"),
+    );
+
+    render(wrap(<SystemSchedulesPanel jobs={[baseSystemJob]} />));
+
+    const toggle = screen.getByRole("switch", {
+      name: /Disable Task recheck cadence/i,
+    });
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute("aria-checked", "true");
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent(/network down/);
+  });
+});
+
+describe("<SystemSchedulesPanel> interval validation", () => {
+  it("blocks PATCH when override is below the per-cron floor", () => {
+    const patchMock = vi.mocked(clientMod.patchSchedulerJob);
+    patchMock.mockClear();
+
+    // nex-insights floor is 30 min. Try 10.
+    render(wrap(<SystemSchedulesPanel jobs={[insightsJob]} />));
+
+    const input = screen.getByRole("spinbutton", {
+      name: /Interval in minutes for Nex insights/i,
+    });
+    fireEvent.change(input, { target: { value: "10" } });
+    fireEvent.blur(input);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Min interval is 30 min/i,
+    );
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty / blank overrides without hitting the network", () => {
+    const patchMock = vi.mocked(clientMod.patchSchedulerJob);
+    patchMock.mockClear();
+
+    render(wrap(<SystemSchedulesPanel jobs={[baseSystemJob]} />));
+
+    const input = screen.getByRole("spinbutton", {
+      name: /Interval in minutes for Task recheck cadence/i,
+    });
+    fireEvent.change(input, { target: { value: "" } });
+    fireEvent.blur(input);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/required/i);
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects negative overrides without hitting the network", () => {
+    const patchMock = vi.mocked(clientMod.patchSchedulerJob);
+    patchMock.mockClear();
+
+    render(wrap(<SystemSchedulesPanel jobs={[baseSystemJob]} />));
+
+    const input = screen.getByRole("spinbutton", {
+      name: /Interval in minutes for Task recheck cadence/i,
+    });
+    fireEvent.change(input, { target: { value: "-5" } });
+    fireEvent.blur(input);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /non-negative whole number/i,
+    );
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+
+  it("submits a valid override above the floor", async () => {
+    const patchMock = vi
+      .mocked(clientMod.patchSchedulerJob)
+      .mockResolvedValueOnce({
+        job: { ...baseSystemJob, interval_override: 20 },
+      });
+    patchMock.mockClear();
+
+    // task_recheck default 10, floor 5. Try 20.
+    render(wrap(<SystemSchedulesPanel jobs={[baseSystemJob]} />));
+
+    const input = screen.getByRole("spinbutton", {
+      name: /Interval in minutes for Task recheck cadence/i,
+    });
+    fireEvent.change(input, { target: { value: "20" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith("task_recheck", {
+        interval_override: 20,
+      });
+    });
+  });
+
+  it("clears the override when the user types the default value", async () => {
+    const patchMock = vi.mocked(clientMod.patchSchedulerJob);
+    patchMock.mockClear();
+
+    // Job already has a 30-minute override; typing back the 10-minute
+    // default should send interval_override: 0 (clears the override).
+    const overriddenJob: SchedulerJob = {
+      ...baseSystemJob,
+      interval_override: 30,
+    };
+    patchMock.mockResolvedValueOnce({
+      job: { ...overriddenJob, interval_override: 0 },
+    });
+
+    render(wrap(<SystemSchedulesPanel jobs={[overriddenJob]} />));
+
+    const input = screen.getByRole("spinbutton", {
+      name: /Interval in minutes for Task recheck cadence/i,
+    });
+    fireEvent.change(input, { target: { value: "10" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith("task_recheck", {
+        interval_override: 0,
+      });
+    });
+  });
+});

--- a/web/src/components/apps/SystemSchedulesPanel.test.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.test.tsx
@@ -221,12 +221,11 @@ describe("<SystemSchedulesPanel> interval validation", () => {
   });
 
   it("submits a valid override above the floor", async () => {
-    const patchMock = vi
-      .mocked(clientMod.patchSchedulerJob)
-      .mockResolvedValueOnce({
-        job: { ...baseSystemJob, interval_override: 20 },
-      });
+    const patchMock = vi.mocked(clientMod.patchSchedulerJob);
     patchMock.mockClear();
+    patchMock.mockResolvedValueOnce({
+      job: { ...baseSystemJob, interval_override: 20 },
+    });
 
     // task_recheck default 10, floor 5. Try 20.
     render(wrap(<SystemSchedulesPanel jobs={[baseSystemJob]} />));

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -486,7 +486,7 @@ function describeLastRun(
   if (status === "failed" || status === "error") {
     return {
       text: `Failed · ${job.last_run ? formatRelativeTime(job.last_run) : "—"}`,
-      cls: "badge-muted",
+      cls: "badge badge-red",
     };
   }
   return { text: status, cls: "badge-neutral" };

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -115,6 +115,7 @@ function ScheduleRow({ job }: ScheduleRowProps) {
   const committedTextRef = useRef(
     initialOverride > 0 ? String(initialOverride) : String(defaultInterval),
   );
+  const committedOverrideRef = useRef(initialOverride);
   const committedEnabledRef = useRef(initialEnabled);
 
   const sourceLabel = describeSource(job);
@@ -153,6 +154,7 @@ function ScheduleRow({ job }: ScheduleRowProps) {
           }
           if (typeof res.job?.interval_override === "number") {
             const next = res.job.interval_override;
+            committedOverrideRef.current = next;
             const nextText =
               next > 0
                 ? String(next)
@@ -197,24 +199,14 @@ function ScheduleRow({ job }: ScheduleRowProps) {
       setOverrideText(committedTextRef.current);
       return;
     }
-    // Treat "same as current default" as no-op (keeps server state stable).
-    if (
-      (initialOverride === 0 && parsed === defaultInterval) ||
-      parsed === initialOverride
-    ) {
+    // No-op: parsed matches what the server already has.
+    const committedValue = Number(committedTextRef.current);
+    if (Number.isFinite(committedValue) && parsed === committedValue) {
       setError(null);
       return;
     }
     submitPatch({ interval_override: parsed === defaultInterval ? 0 : parsed });
-  }, [
-    isReadOnly,
-    isCron,
-    overrideText,
-    floor,
-    initialOverride,
-    defaultInterval,
-    submitPatch,
-  ]);
+  }, [isReadOnly, isCron, overrideText, floor, defaultInterval, submitPatch]);
 
   const lastRunChip = describeLastRun(job);
   const nextRunCountdown = describeNextRun(job);
@@ -313,7 +305,7 @@ function ScheduleRow({ job }: ScheduleRowProps) {
         </div>
       ) : null}
 
-      {!isReadOnly && isInterval && initialOverride > 0 ? (
+      {!isReadOnly && isInterval && committedOverrideRef.current > 0 ? (
         <div
           style={{
             marginTop: 6,

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -110,11 +110,12 @@ function ScheduleRow({ job }: ScheduleRowProps) {
   );
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
-  // Tracks the last value confirmed by the server so validation failures can
-  // rollback the input to a known-good state instead of leaving the bad value.
+  // Track last server-confirmed values so PATCH failures roll back to the
+  // right state rather than the stale mount-time values.
   const committedTextRef = useRef(
     initialOverride > 0 ? String(initialOverride) : String(defaultInterval),
   );
+  const committedEnabledRef = useRef(initialEnabled);
 
   const sourceLabel = describeSource(job);
 
@@ -148,6 +149,7 @@ function ScheduleRow({ job }: ScheduleRowProps) {
           // adjusted it (e.g. clamping to default).
           if (typeof res.job?.enabled === "boolean") {
             setEnabled(res.job.enabled);
+            committedEnabledRef.current = res.job.enabled;
           }
           if (typeof res.job?.interval_override === "number") {
             const next = res.job.interval_override;
@@ -160,23 +162,15 @@ function ScheduleRow({ job }: ScheduleRowProps) {
           }
         })
         .catch((e: Error) => {
-          // Roll back optimistic state to last server-confirmed value.
-          setEnabled(initialEnabled);
+          // Roll back optimistic state to last server-confirmed values.
+          setEnabled(committedEnabledRef.current);
           setOverrideText(committedTextRef.current);
           setError(e.message || "Update failed");
           showNotice(`Couldn't update ${labelOf(job)}: ${e.message}`, "error");
         })
         .finally(() => setPending(false));
     },
-    [
-      slug,
-      isReadOnly,
-      job,
-      queryClient,
-      initialEnabled,
-      initialOverride,
-      defaultInterval,
-    ],
+    [slug, isReadOnly, job, queryClient, initialOverride, defaultInterval],
   );
 
   const handleToggle = useCallback(() => {

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -287,7 +287,6 @@ function ScheduleRow({ job }: ScheduleRowProps) {
             ariaLabel={`Interval in minutes for ${labelOf(job)}`}
             floor={floor}
             defaultInterval={defaultInterval}
-            override={initialOverride}
           />
         ) : (
           <span style={{ color: "var(--text-tertiary)" }}>
@@ -343,7 +342,6 @@ interface IntervalPickerProps {
   ariaLabel: string;
   floor: number;
   defaultInterval: number;
-  override: number;
 }
 
 function IntervalPicker({

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
@@ -110,6 +110,11 @@ function ScheduleRow({ job }: ScheduleRowProps) {
   );
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  // Tracks the last value confirmed by the server so validation failures can
+  // rollback the input to a known-good state instead of leaving the bad value.
+  const committedTextRef = useRef(
+    initialOverride > 0 ? String(initialOverride) : String(defaultInterval),
+  );
 
   const sourceLabel = describeSource(job);
 
@@ -146,21 +151,18 @@ function ScheduleRow({ job }: ScheduleRowProps) {
           }
           if (typeof res.job?.interval_override === "number") {
             const next = res.job.interval_override;
-            setOverrideText(
+            const nextText =
               next > 0
                 ? String(next)
-                : String(res.job.interval_minutes ?? defaultInterval),
-            );
+                : String(res.job.interval_minutes ?? defaultInterval);
+            setOverrideText(nextText);
+            committedTextRef.current = nextText;
           }
         })
         .catch((e: Error) => {
-          // Roll back optimistic state.
+          // Roll back optimistic state to last server-confirmed value.
           setEnabled(initialEnabled);
-          setOverrideText(
-            initialOverride > 0
-              ? String(initialOverride)
-              : String(defaultInterval),
-          );
+          setOverrideText(committedTextRef.current);
           setError(e.message || "Update failed");
           showNotice(`Couldn't update ${labelOf(job)}: ${e.message}`, "error");
         })
@@ -198,6 +200,7 @@ function ScheduleRow({ job }: ScheduleRowProps) {
     }
     if (parsed > 0 && parsed < floor) {
       setError(`Min interval is ${floor} min for this cron`);
+      setOverrideText(committedTextRef.current);
       return;
     }
     // Treat "same as current default" as no-op (keeps server state stable).

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -1,0 +1,504 @@
+import { useCallback, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  type PatchSchedulerJobResponse,
+  patchSchedulerJob,
+  type SchedulerJob,
+} from "../../api/client";
+import { formatRelativeTime } from "../../lib/format";
+import { showNotice } from "../ui/Toast";
+
+/**
+ * Per-cron interval floors. Source of truth: systemCronSpecs() in
+ * internal/team/broker.go (PR 8 Lane G). Mirrored here so the UI can
+ * validate before issuing the PATCH and surface a typed error inline
+ * instead of relying on a 400 round-trip.
+ *
+ * Keep in sync when broker MinFloor changes. The non-system fallback
+ * floor (5 minutes) matches the server's `floor := 5` default for jobs
+ * outside the registry.
+ */
+const SYSTEM_CRON_FLOORS_MINUTES: Record<string, number> = {
+  "nex-insights": 30,
+  "nex-notifications": 5,
+  "one-relay-events": 1,
+  request_follow_up: 5,
+  "review-expiry": 5,
+  task_follow_up: 5,
+  task_recheck: 5,
+  task_reminder: 5,
+};
+
+const DEFAULT_FLOOR_MINUTES = 5;
+
+/** Read-only system crons (enabled toggle + interval picker disabled). */
+const READ_ONLY_SLUGS = new Set(["one-relay-events"]);
+
+interface SystemSchedulesPanelProps {
+  jobs: SchedulerJob[];
+}
+
+/**
+ * "System Schedules" section above the timeline-grouped job cards in
+ * CalendarApp. Shows every cron-style scheduler entry with its toggle,
+ * interval picker, last/next run, and source badge. Inline validation
+ * mirrors the backend's MinFloor before allowing a PATCH.
+ *
+ * Empty if the broker hasn't surfaced any system or interval crons (test
+ * environments before registerSystemCrons runs).
+ */
+export function SystemSchedulesPanel({ jobs }: SystemSchedulesPanelProps) {
+  const rows = useMemo(() => filterSchedulerRows(jobs), [jobs]);
+  if (rows.length === 0) return null;
+
+  return (
+    <section style={{ marginBottom: 16 }}>
+      <div
+        style={{
+          fontSize: 11,
+          fontWeight: 600,
+          textTransform: "uppercase",
+          letterSpacing: "0.05em",
+          color: "var(--text-tertiary)",
+          padding: "8px 0 6px",
+        }}
+      >
+        System Schedules
+      </div>
+      {rows.map((job) => (
+        <ScheduleRow key={job.slug ?? job.id} job={job} />
+      ))}
+    </section>
+  );
+}
+
+/**
+ * Return the rows that belong in the System Schedules panel. Any job
+ * that exposes `interval_minutes`, `system_managed`, or a cron expression
+ * qualifies. Pure-task scheduler entries (one-shot due_at) are excluded —
+ * they belong in the timeline view below.
+ */
+function filterSchedulerRows(jobs: SchedulerJob[]): SchedulerJob[] {
+  return jobs.filter(
+    (j) =>
+      j.system_managed ||
+      typeof j.interval_minutes === "number" ||
+      typeof j.schedule_expr === "string",
+  );
+}
+
+interface ScheduleRowProps {
+  job: SchedulerJob;
+}
+
+function ScheduleRow({ job }: ScheduleRowProps) {
+  const queryClient = useQueryClient();
+  const slug = job.slug ?? "";
+  const isReadOnly = READ_ONLY_SLUGS.has(slug);
+  const isCron = typeof job.schedule_expr === "string" && job.schedule_expr;
+  const isInterval = typeof job.interval_minutes === "number";
+
+  const floor = SYSTEM_CRON_FLOORS_MINUTES[slug] ?? DEFAULT_FLOOR_MINUTES;
+  const defaultInterval = job.interval_minutes ?? 0;
+  const initialOverride = job.interval_override ?? 0;
+  const initialEnabled = job.enabled !== false; // missing → assume enabled
+
+  const [enabled, setEnabled] = useState(initialEnabled);
+  const [overrideText, setOverrideText] = useState(
+    initialOverride > 0 ? String(initialOverride) : String(defaultInterval),
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const sourceLabel = describeSource(job);
+
+  const submitPatch = useCallback(
+    (patchBody: { enabled?: boolean; interval_override?: number }) => {
+      if (!slug || isReadOnly) return;
+      setPending(true);
+      setError(null);
+      patchSchedulerJob(slug, patchBody)
+        .then((res: PatchSchedulerJobResponse) => {
+          // Refresh the query so the row reflects server-canonical state
+          // (status, next_run, etc.) — the optimistic update we already
+          // applied stays visible while the refetch is in flight.
+          queryClient.invalidateQueries({ queryKey: ["scheduler"] });
+          if (typeof patchBody.enabled === "boolean") {
+            showNotice(
+              patchBody.enabled
+                ? `${labelOf(job)} enabled`
+                : `${labelOf(job)} disabled`,
+              "success",
+            );
+          } else if (typeof patchBody.interval_override === "number") {
+            showNotice(
+              patchBody.interval_override === 0
+                ? `${labelOf(job)} reset to default cadence`
+                : `${labelOf(job)} now runs every ${patchBody.interval_override} min`,
+              "success",
+            );
+          }
+          // Sync local state with the server response in case the broker
+          // adjusted it (e.g. clamping to default).
+          if (typeof res.job?.enabled === "boolean") {
+            setEnabled(res.job.enabled);
+          }
+          if (typeof res.job?.interval_override === "number") {
+            const next = res.job.interval_override;
+            setOverrideText(
+              next > 0
+                ? String(next)
+                : String(res.job.interval_minutes ?? defaultInterval),
+            );
+          }
+        })
+        .catch((e: Error) => {
+          // Roll back optimistic state.
+          setEnabled(initialEnabled);
+          setOverrideText(
+            initialOverride > 0
+              ? String(initialOverride)
+              : String(defaultInterval),
+          );
+          setError(e.message || "Update failed");
+          showNotice(`Couldn't update ${labelOf(job)}: ${e.message}`, "error");
+        })
+        .finally(() => setPending(false));
+    },
+    [
+      slug,
+      isReadOnly,
+      job,
+      queryClient,
+      initialEnabled,
+      initialOverride,
+      defaultInterval,
+    ],
+  );
+
+  const handleToggle = useCallback(() => {
+    if (isReadOnly || pending) return;
+    const next = !enabled;
+    setEnabled(next);
+    submitPatch({ enabled: next });
+  }, [isReadOnly, pending, enabled, submitPatch]);
+
+  const handleIntervalCommit = useCallback(() => {
+    if (isReadOnly || isCron) return;
+    const trimmed = overrideText.trim();
+    if (trimmed === "") {
+      setError("Interval is required");
+      return;
+    }
+    const parsed = Number(trimmed);
+    if (!(Number.isFinite(parsed) && Number.isInteger(parsed)) || parsed < 0) {
+      setError("Must be a non-negative whole number");
+      return;
+    }
+    if (parsed > 0 && parsed < floor) {
+      setError(`Min interval is ${floor} min for this cron`);
+      return;
+    }
+    // Treat "same as current default" as no-op (keeps server state stable).
+    if (
+      (initialOverride === 0 && parsed === defaultInterval) ||
+      parsed === initialOverride
+    ) {
+      setError(null);
+      return;
+    }
+    submitPatch({ interval_override: parsed === defaultInterval ? 0 : parsed });
+  }, [
+    isReadOnly,
+    isCron,
+    overrideText,
+    floor,
+    initialOverride,
+    defaultInterval,
+    submitPatch,
+  ]);
+
+  const lastRunChip = describeLastRun(job);
+  const nextRunCountdown = describeNextRun(job);
+
+  return (
+    <article
+      className="app-card"
+      style={{
+        marginBottom: 8,
+        opacity: enabled ? 1 : 0.7,
+      }}
+      aria-labelledby={`schedule-${slug || "row"}-label`}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 6,
+          flexWrap: "wrap",
+        }}
+      >
+        <span
+          id={`schedule-${slug || "row"}-label`}
+          className="app-card-title"
+          style={{ marginBottom: 0 }}
+        >
+          {labelOf(job)}
+        </span>
+        <SourceBadge source={sourceLabel} />
+        {!enabled ? <span className="badge badge-muted">disabled</span> : null}
+        {lastRunChip ? (
+          <span className={`badge ${lastRunChip.cls}`}>{lastRunChip.text}</span>
+        ) : null}
+      </div>
+
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
+          flexWrap: "wrap",
+          fontSize: 12,
+          color: "var(--text-secondary)",
+        }}
+      >
+        {isReadOnly ? (
+          <span style={{ fontFamily: "var(--font-mono)" }}>
+            Every {defaultInterval}m (read-only)
+          </span>
+        ) : isCron ? (
+          <span style={{ fontFamily: "var(--font-mono)" }}>
+            cron: {job.schedule_expr}
+          </span>
+        ) : isInterval ? (
+          <IntervalPicker
+            value={overrideText}
+            disabled={pending}
+            onChange={(v) => {
+              setOverrideText(v);
+              setError(null);
+            }}
+            onBlur={handleIntervalCommit}
+            ariaLabel={`Interval in minutes for ${labelOf(job)}`}
+            floor={floor}
+            defaultInterval={defaultInterval}
+            override={initialOverride}
+          />
+        ) : (
+          <span style={{ color: "var(--text-tertiary)" }}>
+            (no cadence reported)
+          </span>
+        )}
+
+        <ToggleSwitch
+          enabled={enabled}
+          disabled={isReadOnly || pending}
+          onToggle={handleToggle}
+          ariaLabel={`${enabled ? "Disable" : "Enable"} ${labelOf(job)}`}
+        />
+
+        {nextRunCountdown ? (
+          <span style={{ marginLeft: "auto" }}>{nextRunCountdown}</span>
+        ) : null}
+      </div>
+
+      {error ? (
+        <div
+          role="alert"
+          style={{
+            marginTop: 6,
+            fontSize: 12,
+            color: "var(--red, #c43e3e)",
+          }}
+        >
+          {error}
+        </div>
+      ) : null}
+
+      {!isReadOnly && isInterval && initialOverride > 0 ? (
+        <div
+          style={{
+            marginTop: 6,
+            fontSize: 11,
+            color: "var(--text-tertiary)",
+          }}
+        >
+          Override active. Default: every {defaultInterval}m.
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+interface IntervalPickerProps {
+  value: string;
+  disabled: boolean;
+  onChange: (v: string) => void;
+  onBlur: () => void;
+  ariaLabel: string;
+  floor: number;
+  defaultInterval: number;
+  override: number;
+}
+
+function IntervalPicker({
+  value,
+  disabled,
+  onChange,
+  onBlur,
+  ariaLabel,
+  floor,
+  defaultInterval,
+}: IntervalPickerProps) {
+  return (
+    <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+      <span>Every</span>
+      <input
+        type="number"
+        min={floor}
+        step={1}
+        inputMode="numeric"
+        value={value}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={onBlur}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            (e.target as HTMLInputElement).blur();
+          }
+        }}
+        aria-label={ariaLabel}
+        style={{
+          width: 60,
+          padding: "2px 6px",
+          background: "var(--bg-card, #fff)",
+          border: "1px solid var(--border)",
+          borderRadius: 4,
+          fontFamily: "var(--font-mono)",
+          fontSize: 12,
+          color: "var(--text)",
+        }}
+      />
+      <span>min</span>
+      <span
+        style={{
+          fontSize: 11,
+          color: "var(--text-tertiary)",
+        }}
+      >
+        (default: {defaultInterval}m, min: {floor}m)
+      </span>
+    </span>
+  );
+}
+
+interface ToggleSwitchProps {
+  enabled: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+  ariaLabel: string;
+}
+
+function ToggleSwitch({
+  enabled,
+  disabled,
+  onToggle,
+  ariaLabel,
+}: ToggleSwitchProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={enabled}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={onToggle}
+      style={{
+        position: "relative",
+        width: 36,
+        height: 20,
+        background: enabled ? "var(--green, #2eb472)" : "var(--neutral-300)",
+        border: "none",
+        borderRadius: 999,
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.6 : 1,
+        transition: "background 0.15s",
+        padding: 0,
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          top: 2,
+          left: enabled ? 18 : 2,
+          width: 16,
+          height: 16,
+          background: "#fff",
+          borderRadius: "50%",
+          transition: "left 0.15s",
+          boxShadow: "0 1px 2px rgba(0,0,0,0.2)",
+        }}
+      />
+    </button>
+  );
+}
+
+interface SourceBadgeProps {
+  source: "system" | "agent" | "workflow";
+}
+
+function SourceBadge({ source }: SourceBadgeProps) {
+  const cls =
+    source === "system"
+      ? "badge badge-neutral"
+      : source === "agent"
+        ? "badge badge-accent"
+        : "badge badge-yellow";
+  return <span className={cls}>{source}</span>;
+}
+
+function describeSource(job: SchedulerJob): "system" | "agent" | "workflow" {
+  if (job.system_managed) return "system";
+  if (
+    job.target_type === "workflow" ||
+    job.kind === "workflow" ||
+    typeof job.schedule_expr === "string"
+  ) {
+    return "workflow";
+  }
+  return "agent";
+}
+
+function labelOf(job: SchedulerJob): string {
+  return job.label || job.name || job.slug || "(unnamed)";
+}
+
+function describeLastRun(
+  job: SchedulerJob,
+): { text: string; cls: string } | null {
+  const status = (job.last_run_status || "").toLowerCase();
+  if (!status) return null;
+  if (status === "ok" || status === "success") {
+    return {
+      text: `OK · ${job.last_run ? formatRelativeTime(job.last_run) : "—"}`,
+      cls: "badge-green",
+    };
+  }
+  if (status === "failed" || status === "error") {
+    return {
+      text: `Failed · ${job.last_run ? formatRelativeTime(job.last_run) : "—"}`,
+      cls: "badge-muted",
+    };
+  }
+  return { text: status, cls: "badge-neutral" };
+}
+
+function describeNextRun(job: SchedulerJob): string | null {
+  const target = job.next_run || job.due_at;
+  if (!target) return null;
+  return `Next ${formatRelativeTime(target)}`;
+}


### PR DESCRIPTION
## Summary

Reopened from #470 (closed because it was stacked on #447, which landed via a different path). Rebased cleanly onto main with all conflicts resolved.

**What this PR adds:**
- `systemCronSpecs()` registry: 8 system-managed crons (nex-insights, nex-notifications, one-relay-events, review-expiry, request_follow_up, task_follow_up, task_recheck, task_reminder) register themselves on broker start
- `PATCH /scheduler/{slug}`: per-cron toggle + interval override with per-slug MinFloor enforcement and read-only guard (one-relay-events)
- `SchedulerJobControl(slug, default)`: run-loops read enabled + effective interval each tick so a PATCH takes effect on the next scheduled fire
- `SystemSchedulesPanel`: Calendar app section surfacing all 8 system rows above agent-job cards, with toggle + interval picker + last/next run display
- `scheduler_registry_test.go`: 7 contract tests (self-registration 8/8, floor enforcement 8 sub-cases/slug, read-only guard, disable-skips, persistence, heartbeat preservation)
- `cron_eval` harness: 4 acceptance gates verified post-rebase

**Polish fixes included** (found during smoke testing):
- `nex-insights` default interval raised 15→30 min to match its own MinFloor; defensive clamp added to `registerSystemCrons` so future specs can't seed below their floor
- `SystemSchedulesPanel` interval input now rolls back to last server-confirmed value on client-side floor validation failure (was leaving invalid value in field)

## Rebase notes

Conflicts resolved during rebase onto main:
1. `launcher.go` — `023e7715` targeted old monolithic layout; applied `pollOneRelayEventsLoop` Enabled gate to `launcher_loops.go` (where the fn lives post-decomposition) and accepted HEAD's short launcher.go
2. `e2f9f173` (first draft of Lane G) — skipped as fully superseded by `023e7715` (the clean re-targeted version already applied)
3. `skills_test.go` — style commit tried to add blank-line between unused mcp import and local import; HEAD version (no unused mcp import) is correct

## Test plan

- [ ] `bash scripts/test-go.sh ./internal/team/ ./internal/teammcp/` — full team suite including scheduler_registry_test.go
- [ ] `bunx vitest run src/components/apps/SystemSchedulesPanel.test.tsx` — 10/10 passing
- [ ] cron_eval harness: `python3 scripts/cron_eval/eval.py --broker http://localhost:7899 --token-file /tmp/wuphf-broker-token-7899` — 4/4 gates
- [ ] Toggle and interval-edit smoke against dev build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * System Schedules panel: view system jobs, enable/disable them, and set interval overrides with validation, optimistic updates, toasts, and rollback on error.
  * Scheduler API & web client: PATCH support for job `enabled` and `interval_override`, with read-only protections and server-side validation (floor enforcement).
  * UI: timeline now separates cadence vs. timeline jobs; background jobs honor enabled/disabled state and reflect status/next-run.

* **Chores**
  * Default insights polling interval increased to 30 minutes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->