### PR TITLE
[codex] route notebook promotions to reviewer tasks

### DIFF
--- a/internal/team/broker_review.go
+++ b/internal/team/broker_review.go
@@ -31,6 +31,8 @@ import (
 	"time"
 )
 
+const notebookPromotionTaskPipeline = "notebook_promotion"
+
 // ReviewStateChangeEvent is the SSE payload for every promotion transition.
 // Kept narrow on purpose — the frontend re-fetches the full review to get
 // comment threads and such.
@@ -259,12 +261,110 @@ func (b *Broker) handleNotebookPromote(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
 	}
+	reviewTaskID := ""
+	if task, _, taskErr := b.ensureNotebookPromotionReviewTask(promotion); taskErr != nil {
+		log.Printf("notebook promotion review task create failed promotion=%s reviewer=%s: %v", promotion.ID, promotion.ReviewerSlug, taskErr)
+	} else {
+		reviewTaskID = task.ID
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
-		"promotion_id":  promotion.ID,
-		"reviewer_slug": promotion.ReviewerSlug,
-		"state":         promotion.State,
-		"human_only":    promotion.HumanOnly,
+		"promotion_id":   promotion.ID,
+		"reviewer_slug":  promotion.ReviewerSlug,
+		"state":          promotion.State,
+		"human_only":     promotion.HumanOnly,
+		"review_task_id": reviewTaskID,
 	})
+}
+
+func (b *Broker) ensureNotebookPromotionReviewTask(p *Promotion) (teamTask, bool, error) {
+	if p == nil {
+		return teamTask{}, false, nil
+	}
+	if p.HumanOnly {
+		return teamTask{}, false, nil
+	}
+	reviewer := strings.TrimSpace(p.ReviewerSlug)
+	if reviewer == "" || reviewer == "human-only" {
+		return teamTask{}, false, nil
+	}
+	titleSubject := strings.TrimSpace(notebookEntrySlug(p.SourcePath))
+	if titleSubject == "" {
+		titleSubject = strings.TrimSpace(p.TargetPath)
+	}
+	title := "Review notebook promotion: " + titleSubject
+	details := strings.TrimSpace(strings.Join([]string{
+		fmt.Sprintf("Notebook promotion %s from @%s needs review.", p.ID, p.SourceSlug),
+		fmt.Sprintf("Source notebook: %s", p.SourcePath),
+		fmt.Sprintf("Target wiki path: %s", p.TargetPath),
+		fmt.Sprintf("Rationale: %s", firstLine(p.Rationale)),
+		"Use team_reviews to inspect the queue, then call team_review action=approve with this review_id to write it into the team wiki, or action=request_changes with rationale if the note is not ready.",
+	}, "\n"))
+	return b.EnsurePlannedTask(plannedTaskInput{
+		Channel:          "general",
+		Title:            title,
+		Details:          details,
+		Owner:            reviewer,
+		CreatedBy:        "system",
+		TaskType:         "review",
+		PipelineID:       notebookPromotionTaskPipeline,
+		ExecutionMode:    "office",
+		ReviewState:      "not_required",
+		SourceDecisionID: p.ID,
+	})
+}
+
+func (b *Broker) closeNotebookPromotionReviewTask(p *Promotion, actorSlug string, reviewState string, rationale string) {
+	if p == nil {
+		return
+	}
+	promotionID := strings.TrimSpace(p.ID)
+	if promotionID == "" {
+		return
+	}
+	actor := strings.TrimSpace(actorSlug)
+	if actor == "" {
+		actor = "system"
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	summary := fmt.Sprintf("Notebook promotion %s %s", promotionID, strings.TrimSpace(reviewState))
+	if strings.TrimSpace(rationale) != "" {
+		summary += ": " + firstLine(rationale)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	changed := false
+	for i := range b.tasks {
+		task := &b.tasks[i]
+		if strings.TrimSpace(task.SourceDecisionID) != promotionID ||
+			strings.TrimSpace(task.PipelineID) != notebookPromotionTaskPipeline {
+			continue
+		}
+		if isTerminalTeamTaskStatus(task.Status) && strings.EqualFold(strings.TrimSpace(task.ReviewState), reviewState) {
+			continue
+		}
+		task.Status = "done"
+		task.Blocked = false
+		task.ReviewState = strings.TrimSpace(reviewState)
+		task.UpdatedAt = now
+		b.scheduleTaskLifecycleLocked(task)
+		b.appendActionWithRefsLocked(
+			"task_updated",
+			"office",
+			normalizeChannelSlug(task.Channel),
+			actor,
+			truncateSummary(summary, 140),
+			task.ID,
+			nil,
+			promotionID,
+		)
+		changed = true
+	}
+	if changed {
+		if err := b.saveLocked(); err != nil {
+			log.Printf("notebook promotion review task close failed promotion=%s: %v", promotionID, err)
+		}
+	}
 }
 
 // handleReviewList returns all active reviews or a scoped slice.
@@ -504,6 +604,7 @@ func (b *Broker) reviewApprove(w http.ResponseWriter, r *http.Request, id string
 					ActorSlug: body.ActorSlug,
 					Timestamp: updated.UpdatedAt.Format(time.RFC3339),
 				})
+				b.closeNotebookPromotionReviewTask(updated, body.ActorSlug, "changes_requested", "target path already exists: "+p.TargetPath)
 			}
 			writeJSON(w, http.StatusConflict, map[string]string{"error": commitErr.Error()})
 			return
@@ -524,6 +625,7 @@ func (b *Broker) reviewApprove(w http.ResponseWriter, r *http.Request, id string
 		ActorSlug: body.ActorSlug,
 		Timestamp: t.Timestamp.Format(time.RFC3339),
 	})
+	b.closeNotebookPromotionReviewTask(updated, body.ActorSlug, "approved", body.Rationale)
 	writeJSON(w, http.StatusOK, updated)
 }
 
@@ -553,6 +655,7 @@ func (b *Broker) reviewRequestChanges(w http.ResponseWriter, r *http.Request, id
 		ActorSlug: body.ActorSlug,
 		Timestamp: t.Timestamp.Format(time.RFC3339),
 	})
+	b.closeNotebookPromotionReviewTask(updated, body.ActorSlug, "changes_requested", body.Rationale)
 	writeJSON(w, http.StatusOK, updated)
 }
 
@@ -577,6 +680,7 @@ func (b *Broker) reviewReject(w http.ResponseWriter, r *http.Request, id string)
 		ActorSlug: body.ActorSlug,
 		Timestamp: t.Timestamp.Format(time.RFC3339),
 	})
+	b.closeNotebookPromotionReviewTask(updated, body.ActorSlug, "rejected", "")
 	writeJSON(w, http.StatusOK, updated)
 }
 
@@ -601,6 +705,9 @@ func (b *Broker) reviewResubmit(w http.ResponseWriter, r *http.Request, id strin
 		ActorSlug: body.ActorSlug,
 		Timestamp: t.Timestamp.Format(time.RFC3339),
 	})
+	if _, _, taskErr := b.ensureNotebookPromotionReviewTask(updated); taskErr != nil {
+		log.Printf("notebook promotion review task recreate failed promotion=%s reviewer=%s: %v", updated.ID, updated.ReviewerSlug, taskErr)
+	}
 	writeJSON(w, http.StatusOK, updated)
 }
 

--- a/internal/team/broker_review_test.go
+++ b/internal/team/broker_review_test.go
@@ -98,6 +98,7 @@ func TestPromotionHandlers_EndToEnd(t *testing.T) {
 		PromotionID  string `json:"promotion_id"`
 		ReviewerSlug string `json:"reviewer_slug"`
 		State        string `json:"state"`
+		ReviewTaskID string `json:"review_task_id"`
 	}
 	_ = json.NewDecoder(res.Body).Decode(&submitRes)
 	if submitRes.PromotionID == "" {
@@ -105,6 +106,20 @@ func TestPromotionHandlers_EndToEnd(t *testing.T) {
 	}
 	if submitRes.State != "pending" {
 		t.Fatalf("state=%s", submitRes.State)
+	}
+	if submitRes.ReviewTaskID == "" {
+		t.Fatalf("expected reviewer task id in response: %+v", submitRes)
+	}
+	task := findTaskByIDForTest(t, b, submitRes.ReviewTaskID)
+	if task.Owner != "ceo" || task.Status != "in_progress" || task.SourceDecisionID != submitRes.PromotionID {
+		t.Fatalf("review task not assigned to reviewer/promotion: %+v", task)
+	}
+	if task.PipelineID != notebookPromotionTaskPipeline {
+		t.Fatalf("review task pipeline=%q", task.PipelineID)
+	}
+	if !strings.Contains(task.Details, "team_review action=approve") ||
+		!strings.Contains(task.Details, "team/playbooks/retro.md") {
+		t.Fatalf("review task details do not give approval path: %q", task.Details)
 	}
 
 	// Verify an SSE event was emitted.
@@ -201,6 +216,10 @@ func TestPromotionHandlers_EndToEnd(t *testing.T) {
 	target := filepath.Join(b.wikiWorker.Repo().Root(), "team/playbooks/retro.md")
 	if _, err := readArticle(b.wikiWorker.Repo(), "team/playbooks/retro.md"); err != nil {
 		t.Fatalf("target missing: %v (path=%s)", err, target)
+	}
+	task = findTaskByIDForTest(t, b, submitRes.ReviewTaskID)
+	if task.Status != "done" || task.ReviewState != "approved" {
+		t.Fatalf("review task not closed after approval: %+v", task)
 	}
 }
 
@@ -313,4 +332,17 @@ func drainEvents(ch <-chan ReviewStateChangeEvent) {
 			return
 		}
 	}
+}
+
+func findTaskByIDForTest(t *testing.T, b *Broker, id string) teamTask {
+	t.Helper()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, task := range b.tasks {
+		if task.ID == id {
+			return task
+		}
+	}
+	t.Fatalf("task %s not found", id)
+	return teamTask{}
 }

--- a/internal/team/prompt_builder.go
+++ b/internal/team/prompt_builder.go
@@ -348,6 +348,7 @@ func (p *promptBuilder) Build(slug string) string {
 func markdownKnowledgeToolBlock() string {
 	return "- notebook_write: Save your own working notes, rough observations, draft decisions, draft playbooks, and task learnings at agents/{my_slug}/notebook/{date-or-topic}.md. This is the default write path for agent-authored knowledge.\n" +
 		"- notebook_promote: Submit a durable notebook entry for reviewer approval into the team wiki. Use this when the team should rely on the note as canonical knowledge.\n" +
+		"- team_reviews / team_review: Inspect and act on notebook promotion reviews assigned to you. Approval is what writes a submitted notebook entry into the team wiki.\n" +
 		"- notebook_read / notebook_list / notebook_search: Inspect agent notebooks for fresh working context before asking someone to repeat themselves.\n" +
 		"- team_wiki_read / team_wiki_search / team_wiki_list / wuphf_wiki_lookup: Read the canonical shared wiki.\n" +
 		"- team_wiki_write: Direct canonical wiki writes only for already-approved edits, bootstrap/admin maintenance, or explicit human requests. Do not bypass notebook_promote for new agent-authored knowledge.\n" +
@@ -355,7 +356,7 @@ func markdownKnowledgeToolBlock() string {
 }
 
 func markdownKnowledgeMemoryBlock() string {
-	return "Markdown notebook/wiki memory is active. Keep scratch and draft knowledge in notebook_write first; promote durable conclusions with notebook_promote when they are ready for review. For memory_policy=required tasks, pass task_id to search/write/promote tools and record a skipped promotion decision with a reason if the note should stay notebook-only. Do not claim something is in the team wiki unless notebook_promote was submitted and approved, or team_wiki_write was explicitly appropriate and succeeded.\n\n"
+	return "Markdown notebook/wiki memory is active. Keep scratch and draft knowledge in notebook_write first; promote durable conclusions with notebook_promote when they are ready for review. A submitted promotion is not canonical until a reviewer approves it with team_review or the web review UI. For memory_policy=required tasks, pass task_id to search/write/promote tools and record a skipped promotion decision with a reason if the note should stay notebook-only. Do not claim something is in the team wiki unless notebook_promote was submitted and approved, or team_wiki_write was explicitly appropriate and succeeded.\n\n"
 }
 
 func headlessSandboxNote() string {

--- a/internal/teammcp/notebook_tools.go
+++ b/internal/teammcp/notebook_tools.go
@@ -219,6 +219,7 @@ func handleTeamNotebookPromote(ctx context.Context, _ *mcp.CallToolRequest, args
 		ReviewerSlug string `json:"reviewer_slug"`
 		State        string `json:"state"`
 		HumanOnly    bool   `json:"human_only"`
+		ReviewTaskID string `json:"review_task_id,omitempty"`
 	}
 	err = brokerPostJSON(ctx, "/notebook/promote", map[string]any{
 		"my_slug":          slug,

--- a/internal/teammcp/review_tools.go
+++ b/internal/teammcp/review_tools.go
@@ -1,0 +1,127 @@
+package teammcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TeamReviewsArgs lists notebook promotion reviews. Defaults to the caller's
+// assigned queue so reviewer agents can discover pending promotions from task
+// context without needing the web UI.
+type TeamReviewsArgs struct {
+	MySlug string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	Scope  string `json:"scope,omitempty" jsonschema:"Review scope: mine, all, or a reviewer slug. Defaults to mine."`
+}
+
+// TeamReviewArgs acts on one notebook promotion review.
+type TeamReviewArgs struct {
+	MySlug    string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	Action    string `json:"action" jsonschema:"One of: approve | request_changes | comment | resubmit | withdraw"`
+	ReviewID  string `json:"review_id" jsonschema:"Review/promotion ID returned by notebook_promote or team_reviews."`
+	Rationale string `json:"rationale,omitempty" jsonschema:"Reviewer rationale. Required for request_changes; optional for approve."`
+	Body      string `json:"body,omitempty" jsonschema:"Comment body. Required when action=comment."`
+}
+
+func registerReviewTools(server *mcp.Server) {
+	mcp.AddTool(server, readOnlyTool(
+		"team_reviews",
+		"List notebook promotion reviews. Defaults to your assigned queue; use scope=all only when coordinating the whole review backlog.",
+	), handleTeamReviews)
+	mcp.AddTool(server, officeWriteTool(
+		"team_review",
+		"Approve, request changes, comment on, resubmit, or withdraw a notebook promotion review. Approval is the action that writes an approved notebook entry into the canonical team wiki.",
+	), handleTeamReview)
+}
+
+func handleTeamReviews(ctx context.Context, _ *mcp.CallToolRequest, args TeamReviewsArgs) (*mcp.CallToolResult, any, error) {
+	scope := strings.TrimSpace(args.Scope)
+	if scope == "" || scope == "mine" {
+		if slug := strings.TrimSpace(resolveSlugOptional(args.MySlug)); slug != "" {
+			scope = slug
+		} else {
+			scope = "mine"
+		}
+	}
+	q := url.Values{}
+	q.Set("scope", scope)
+	var result struct {
+		Reviews []map[string]any `json:"reviews"`
+	}
+	if err := brokerGetJSON(ctx, "/review/list?"+q.Encode(), &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	if result.Reviews == nil {
+		result.Reviews = []map[string]any{}
+	}
+	payload, _ := json.Marshal(result.Reviews)
+	return textResult(string(payload)), nil, nil
+}
+
+func handleTeamReview(ctx context.Context, _ *mcp.CallToolRequest, args TeamReviewArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	reviewID := strings.TrimSpace(args.ReviewID)
+	if reviewID == "" {
+		return toolError(fmt.Errorf("review_id is required")), nil, nil
+	}
+	action := strings.TrimSpace(strings.ToLower(args.Action))
+	verb, err := reviewActionVerb(action)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	body := map[string]string{"actor_slug": slug}
+	switch verb {
+	case "request-changes":
+		rationale := strings.TrimSpace(args.Rationale)
+		if rationale == "" {
+			return toolError(fmt.Errorf("rationale is required for action=request_changes")), nil, nil
+		}
+		body["rationale"] = rationale
+	case "approve":
+		if rationale := strings.TrimSpace(args.Rationale); rationale != "" {
+			body["rationale"] = rationale
+		}
+	case "comment":
+		comment := strings.TrimSpace(args.Body)
+		if comment == "" {
+			return toolError(fmt.Errorf("body is required for action=comment")), nil, nil
+		}
+		body["body"] = comment
+	}
+	var result map[string]any
+	if err := brokerPostJSON(ctx, "/review/"+url.PathEscape(reviewID)+"/"+verb, body, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"review_id":        reviewID,
+		"action":           action,
+		"state":            result["state"],
+		"target_wiki_path": result["target_path"],
+		"commit_sha":       result["commit_sha"],
+	})
+	return textResult(string(payload)), nil, nil
+}
+
+func reviewActionVerb(action string) (string, error) {
+	switch action {
+	case "approve":
+		return "approve", nil
+	case "request_changes", "request-changes":
+		return "request-changes", nil
+	case "comment":
+		return "comment", nil
+	case "resubmit":
+		return "resubmit", nil
+	case "withdraw", "reject":
+		return "reject", nil
+	default:
+		return "", fmt.Errorf("action must be one of approve | request_changes | comment | resubmit | withdraw; got %q", action)
+	}
+}

--- a/internal/teammcp/review_tools_test.go
+++ b/internal/teammcp/review_tools_test.go
@@ -1,0 +1,128 @@
+package teammcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestReviewToolsRegisteredOnlyInMarkdownBackend(t *testing.T) {
+	reviewTools := []string{"team_reviews", "team_review"}
+	cases := []struct {
+		name     string
+		backend  string
+		mustHave bool
+	}{
+		{"markdown registers review tools", "markdown", true},
+		{"nex excludes review tools", "nex", false},
+		{"gbrain excludes review tools", "gbrain", false},
+		{"none excludes review tools", "none", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("WUPHF_MEMORY_BACKEND", tc.backend)
+			names := listRegisteredTools(t, "general", false)
+			for _, name := range reviewTools {
+				if tc.mustHave && !slices.Contains(names, name) {
+					t.Errorf("backend=%s expected %q registered; got %v", tc.backend, name, names)
+				}
+				if !tc.mustHave && slices.Contains(names, name) {
+					t.Errorf("backend=%s expected %q NOT registered; got %v", tc.backend, name, names)
+				}
+			}
+		})
+	}
+}
+
+func TestHandleTeamReviewsDefaultsToCallerQueue(t *testing.T) {
+	srv, auth := stubBroker(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"reviews": []map[string]any{
+				{"id": "rvw-1", "reviewer_slug": "ceo", "state": "pending"},
+			},
+		})
+	})
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+
+	res, _, err := handleTeamReviews(context.Background(), nil, TeamReviewsArgs{})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("unexpected tool error: %s", toolErrorText(res))
+	}
+	if auth.lastPath != "/review/list" {
+		t.Fatalf("wrong path: %s", auth.lastPath)
+	}
+	if !strings.Contains(auth.lastRaw, "scope=ceo") {
+		t.Fatalf("expected caller scope, got %q", auth.lastRaw)
+	}
+	if !strings.Contains(toolErrorText(res), "rvw-1") {
+		t.Fatalf("expected review id in response, got %s", toolErrorText(res))
+	}
+}
+
+func TestHandleTeamReviewApprove(t *testing.T) {
+	srv, auth := stubBroker(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/review/rvw-1/approve" {
+			t.Fatalf("wrong path: %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":          "rvw-1",
+			"state":       "approved",
+			"target_path": "team/processes/passport.md",
+			"commit_sha":  "abc1234",
+		})
+	})
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+
+	res, _, err := handleTeamReview(context.Background(), nil, TeamReviewArgs{
+		Action:    "approve",
+		ReviewID:  "rvw-1",
+		Rationale: "ready for the wiki",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("unexpected tool error: %s", toolErrorText(res))
+	}
+	if !strings.Contains(auth.lastBody, "\"actor_slug\":\"ceo\"") {
+		t.Fatalf("expected actor slug in body: %s", auth.lastBody)
+	}
+	if !strings.Contains(auth.lastBody, "\"rationale\":\"ready for the wiki\"") {
+		t.Fatalf("expected rationale in body: %s", auth.lastBody)
+	}
+	if !strings.Contains(toolErrorText(res), "\"state\":\"approved\"") ||
+		!strings.Contains(toolErrorText(res), "team/processes/passport.md") {
+		t.Fatalf("unexpected result text: %s", toolErrorText(res))
+	}
+}
+
+func TestHandleTeamReviewValidation(t *testing.T) {
+	t.Setenv("WUPHF_AGENT_SLUG", "ceo")
+	cases := []struct {
+		name string
+		args TeamReviewArgs
+	}{
+		{"missing id", TeamReviewArgs{Action: "approve"}},
+		{"unknown action", TeamReviewArgs{Action: "banana", ReviewID: "rvw-1"}},
+		{"request changes needs rationale", TeamReviewArgs{Action: "request_changes", ReviewID: "rvw-1"}},
+		{"comment needs body", TeamReviewArgs{Action: "comment", ReviewID: "rvw-1"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, _, _ := handleTeamReview(context.Background(), nil, tc.args)
+			if !isToolError(res) {
+				t.Fatalf("expected tool error for %s", tc.name)
+			}
+		})
+	}
+}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -581,6 +581,7 @@ func registerSharedMemoryTools(server *mcp.Server) {
 		// Notebook tools ride on the same markdown backend. Registered here
 		// so they share the WUPHF_MEMORY_BACKEND gate with team_wiki_*.
 		registerNotebookTools(server)
+		registerReviewTools(server)
 		// Entity brief tools (v1.2) — fact log + broker-level synthesis.
 		// Same backend gate: entity briefs live in the wiki subtree.
 		registerEntityTools(server)


### PR DESCRIPTION
## Summary
- create a durable reviewer-owned task when notebook_promote submits a promotion
- add team_reviews/team_review MCP tools so reviewer agents can approve/request changes without the web UI
- close/reopen the reviewer task as promotions are approved, sent back, withdrawn, or resubmitted
- update prompt guidance so submitted promotions are not treated as canonical until approval

## Tests
- go test ./internal/team ./internal/teammcp
- CI-shaped Go race suite for all packages except internal/teammcp
- CI-shaped non-race Go suite for internal/teammcp
- web: bun install --frozen-lockfile && bun run typecheck && bun run build