### PR TITLE
feat(context): add durable memory workflow harness

### DIFF
--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -395,6 +395,84 @@ func (s stateHasher) addTasks(tasks []channelui.Task) {
 	s.addInt(len(tasks))
 	for _, task := range tasks {
 		s.add(task.ID, task.Channel, task.Title, task.Owner, task.Status, task.TaskType, task.PipelineStage, task.ExecutionMode, task.ReviewState, task.DueAt, task.UpdatedAt)
+		s.addTaskMemoryWorkflow(task.MemoryWorkflow)
+	}
+}
+
+func (s stateHasher) addTaskMemoryWorkflow(workflow *channelui.TaskMemoryWorkflow) {
+	s.addBool(workflow != nil)
+	if workflow == nil {
+		return
+	}
+	s.add(workflow.Status, workflow.RequirementReason, workflow.CreatedAt, workflow.UpdatedAt, workflow.CompletedAt)
+	s.addBool(workflow.Required)
+	s.add(strings.Join(workflow.RequiredSteps, ","))
+	s.addTaskMemoryWorkflowStep(workflow.Lookup)
+	s.addTaskMemoryWorkflowStep(workflow.Capture)
+	s.addTaskMemoryWorkflowStep(workflow.Promote)
+	s.addInt(len(workflow.Citations))
+	for _, citation := range workflow.Citations {
+		s.add(
+			citation.Backend,
+			citation.Source,
+			citation.SourceID,
+			citation.Path,
+			citation.PageID,
+			citation.ChunkID,
+			citation.SourceURL,
+			citation.Title,
+			citation.Snippet,
+			citation.RetrievedAt,
+		)
+		s.addInt(citation.LineStart)
+		s.addInt(citation.LineEnd)
+		s.addBool(citation.Score != nil)
+		if citation.Score != nil {
+			s.add(fmt.Sprintf("%g", *citation.Score))
+		}
+		s.addBool(citation.Stale != nil)
+		if citation.Stale != nil {
+			s.addBool(*citation.Stale)
+		}
+	}
+	s.addTaskMemoryWorkflowArtifacts(workflow.Captures)
+	s.addTaskMemoryWorkflowArtifacts(workflow.Promotions)
+	s.addBool(workflow.Override != nil)
+	if workflow.Override != nil {
+		s.add(workflow.Override.Actor, workflow.Override.Reason, workflow.Override.Timestamp)
+	}
+	s.addInt(len(workflow.PartialErrors))
+	for _, partialErr := range workflow.PartialErrors {
+		s.add(partialErr.Step, partialErr.Code, partialErr.Message, partialErr.Detail, partialErr.Timestamp)
+	}
+}
+
+func (s stateHasher) addTaskMemoryWorkflowStep(step channelui.TaskMemoryWorkflowStepState) {
+	s.add(step.Status, step.Actor, step.Query, step.CompletedAt, step.UpdatedAt)
+	s.addBool(step.Required)
+	s.addInt(step.Count)
+}
+
+func (s stateHasher) addTaskMemoryWorkflowArtifacts(artifacts []channelui.TaskMemoryWorkflowArtifact) {
+	s.addInt(len(artifacts))
+	for _, artifact := range artifacts {
+		s.add(
+			artifact.Backend,
+			artifact.Source,
+			artifact.Path,
+			artifact.PageID,
+			artifact.PromotionID,
+			artifact.EntityKind,
+			artifact.EntitySlug,
+			artifact.PlaybookSlug,
+			artifact.Title,
+			artifact.Snippet,
+			artifact.CommitSHA,
+			artifact.State,
+			artifact.RecordedAt,
+			artifact.UpdatedAt,
+		)
+		s.addBool(artifact.Missing)
 	}
 }
 

--- a/cmd/wuphf/channel_render_cache.go
+++ b/cmd/wuphf/channel_render_cache.go
@@ -466,6 +466,7 @@ func (s stateHasher) addTaskMemoryWorkflowArtifacts(artifacts []channelui.TaskMe
 			artifact.EntitySlug,
 			artifact.PlaybookSlug,
 			artifact.Title,
+			artifact.SkipReason,
 			artifact.Snippet,
 			artifact.CommitSHA,
 			artifact.State,

--- a/cmd/wuphf/channel_test.go
+++ b/cmd/wuphf/channel_test.go
@@ -826,6 +826,74 @@ func TestBuildTaskLinesShowsTimingMetadata(t *testing.T) {
 	}
 }
 
+func TestBuildTaskLinesShowsMemoryWorkflowStatus(t *testing.T) {
+	lines := channelui.BuildTaskLines([]channelui.Task{
+		{
+			ID:     "task-1",
+			Title:  "Research reuse loop",
+			Status: "in_progress",
+			Owner:  "pm",
+			MemoryWorkflow: &channelui.TaskMemoryWorkflow{
+				Required:      true,
+				Status:        "pending",
+				RequiredSteps: []string{"lookup", "capture", "promote"},
+				Lookup: channelui.TaskMemoryWorkflowStepState{
+					Required:    true,
+					Status:      "satisfied",
+					CompletedAt: "2026-04-30T10:00:00Z",
+					Count:       1,
+				},
+				Capture: channelui.TaskMemoryWorkflowStepState{Required: true, Status: "pending"},
+				Promote: channelui.TaskMemoryWorkflowStepState{Required: true, Status: "pending"},
+			},
+		},
+	}, 80)
+
+	rendered := stripANSI(joinRenderedLines(lines))
+	if !strings.Contains(rendered, "memory 1/3") {
+		t.Fatalf("expected memory workflow status in task metadata, got %q", rendered)
+	}
+}
+
+func TestTaskRenderHashChangesWhenMemoryWorkflowChanges(t *testing.T) {
+	m := channelModel{
+		activeApp:     channelui.OfficeAppTasks,
+		activeChannel: "general",
+		tasks: []channelui.Task{
+			{
+				ID:     "task-1",
+				Title:  "Research reuse loop",
+				Status: "in_progress",
+				MemoryWorkflow: &channelui.TaskMemoryWorkflow{
+					Required:      true,
+					Status:        "pending",
+					RequiredSteps: []string{"lookup", "capture", "promote"},
+					Lookup: channelui.TaskMemoryWorkflowStepState{
+						Required:    true,
+						Status:      "satisfied",
+						CompletedAt: "2026-04-30T10:00:00Z",
+					},
+					Capture: channelui.TaskMemoryWorkflowStepState{Required: true, Status: "pending"},
+					Promote: channelui.TaskMemoryWorkflowStepState{Required: true, Status: "pending"},
+				},
+			},
+		},
+	}
+
+	before := m.hashMainLinesState(80)
+	m.tasks[0].MemoryWorkflow.Status = "satisfied"
+	m.tasks[0].MemoryWorkflow.Capture.Status = "satisfied"
+	m.tasks[0].MemoryWorkflow.Capture.CompletedAt = "2026-04-30T10:05:00Z"
+	m.tasks[0].MemoryWorkflow.Promote.Status = "satisfied"
+	m.tasks[0].MemoryWorkflow.Promote.CompletedAt = "2026-04-30T10:10:00Z"
+	m.tasks[0].MemoryWorkflow.CompletedAt = "2026-04-30T10:10:00Z"
+	after := m.hashMainLinesState(80)
+
+	if before == after {
+		t.Fatal("expected task render hash to change when memory workflow changes")
+	}
+}
+
 func TestBuildRequestLinesShowsBlockingAndTimingMetadata(t *testing.T) {
 	lines := channelui.BuildRequestLines([]channelui.Interview{
 		{

--- a/cmd/wuphf/channelui/build_lines_policy_task.go
+++ b/cmd/wuphf/channelui/build_lines_policy_task.go
@@ -1,6 +1,7 @@
 package channelui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -180,6 +181,9 @@ func BuildTaskLines(tasks []Task, contentWidth int) []RenderedLine {
 		if task.ExecutionMode != "" {
 			metaParts = append(metaParts, task.ExecutionMode)
 		}
+		if memory := TaskMemoryWorkflowMeta(task.MemoryWorkflow); memory != "" {
+			metaParts = append(metaParts, memory)
+		}
 		meta := strings.Join(metaParts, " · ")
 		lines = append(lines, RenderedLine{Text: ""})
 		lines = append(lines, RenderedLine{Text: "  " + TaskStatusPill(task.Status) + " " + lipgloss.NewStyle().Bold(true).Render(task.Title), TaskID: task.ID})
@@ -214,4 +218,171 @@ func BuildTaskLines(tasks []Task, contentWidth int) []RenderedLine {
 		lines = append(lines, RenderedLine{Text: "  " + muted.Render(taskActionHint), TaskID: task.ID})
 	}
 	return lines
+}
+
+func TaskMemoryWorkflowMeta(workflow *TaskMemoryWorkflow) string {
+	if !HasVisibleTaskMemoryWorkflow(workflow) {
+		return ""
+	}
+	status := NormalizeTaskMemoryWorkflowStatus(workflow.Status)
+	done, total := TaskMemoryWorkflowStepCount(workflow)
+	if HasTaskMemoryWorkflowOverride(workflow) {
+		return "memory override"
+	}
+	if len(workflow.PartialErrors) > 0 || HasMissingTaskMemoryWorkflowArtifact(workflow) || IsIssueTaskMemoryWorkflowStatus(status) {
+		return "memory issue"
+	}
+	if IsCompleteTaskMemoryWorkflowStatus(status) || (workflow.Required && done >= total) {
+		return "memory done"
+	}
+	if workflow.Required || done > 0 {
+		return fmt.Sprintf("memory %d/%d", done, total)
+	}
+	if status == "" {
+		status = "pending"
+	}
+	return "memory " + strings.ReplaceAll(status, "_", " ")
+}
+
+func HasVisibleTaskMemoryWorkflow(workflow *TaskMemoryWorkflow) bool {
+	if workflow == nil {
+		return false
+	}
+	status := NormalizeTaskMemoryWorkflowStatus(workflow.Status)
+	done, _ := TaskMemoryWorkflowStepCount(workflow)
+	return workflow.Required ||
+		(status != "" && status != "not_required") ||
+		strings.TrimSpace(workflow.RequirementReason) != "" ||
+		done > 0 ||
+		len(workflow.Citations) > 0 ||
+		len(workflow.Captures) > 0 ||
+		len(workflow.Promotions) > 0 ||
+		len(workflow.PartialErrors) > 0 ||
+		HasTaskMemoryWorkflowOverride(workflow)
+}
+
+func TaskMemoryWorkflowStepCount(workflow *TaskMemoryWorkflow) (int, int) {
+	if workflow == nil {
+		return 0, 3
+	}
+	steps := TaskMemoryWorkflowRequiredSteps(workflow)
+	total := len(steps)
+	if total == 0 {
+		total = 3
+	}
+	done := 0
+	for _, step := range steps {
+		if TaskMemoryWorkflowStepSatisfied(TaskMemoryWorkflowStep(workflow, step)) {
+			done++
+		}
+	}
+	return done, total
+}
+
+func TaskMemoryWorkflowRequiredSteps(workflow *TaskMemoryWorkflow) []string {
+	if workflow == nil {
+		return []string{"lookup", "capture", "promote"}
+	}
+	var steps []string
+	for _, step := range workflow.RequiredSteps {
+		normalized := NormalizeTaskMemoryWorkflowStatus(step)
+		if IsKnownTaskMemoryWorkflowStep(normalized) {
+			steps = append(steps, normalized)
+		}
+	}
+	if len(steps) > 0 {
+		return steps
+	}
+	for _, step := range []string{"lookup", "capture", "promote"} {
+		if TaskMemoryWorkflowStep(workflow, step).Required {
+			steps = append(steps, step)
+		}
+	}
+	if len(steps) > 0 {
+		return steps
+	}
+	return []string{"lookup", "capture", "promote"}
+}
+
+func TaskMemoryWorkflowStep(workflow *TaskMemoryWorkflow, step string) TaskMemoryWorkflowStepState {
+	if workflow == nil {
+		return TaskMemoryWorkflowStepState{}
+	}
+	switch NormalizeTaskMemoryWorkflowStatus(step) {
+	case "lookup":
+		return workflow.Lookup
+	case "capture":
+		return workflow.Capture
+	case "promote":
+		return workflow.Promote
+	default:
+		return TaskMemoryWorkflowStepState{}
+	}
+}
+
+func TaskMemoryWorkflowStepSatisfied(step TaskMemoryWorkflowStepState) bool {
+	return NormalizeTaskMemoryWorkflowStatus(step.Status) == "satisfied" || strings.TrimSpace(step.CompletedAt) != ""
+}
+
+func HasTaskMemoryWorkflowOverride(workflow *TaskMemoryWorkflow) bool {
+	if workflow == nil {
+		return false
+	}
+	status := NormalizeTaskMemoryWorkflowStatus(workflow.Status)
+	return status == "override" ||
+		status == "overridden" ||
+		workflow.Override != nil
+}
+
+func HasMissingTaskMemoryWorkflowArtifact(workflow *TaskMemoryWorkflow) bool {
+	if workflow == nil {
+		return false
+	}
+	for _, artifact := range workflow.Captures {
+		if artifact.Missing {
+			return true
+		}
+	}
+	for _, artifact := range workflow.Promotions {
+		if artifact.Missing {
+			return true
+		}
+	}
+	return false
+}
+
+func NormalizeTaskMemoryWorkflowStatus(status string) string {
+	normalized := strings.NewReplacer(" ", "_", "-", "_").
+		Replace(strings.ToLower(strings.TrimSpace(status)))
+	for strings.Contains(normalized, "__") {
+		normalized = strings.ReplaceAll(normalized, "__", "_")
+	}
+	return strings.Trim(normalized, "_")
+}
+
+func IsKnownTaskMemoryWorkflowStep(step string) bool {
+	switch step {
+	case "lookup", "capture", "promote":
+		return true
+	default:
+		return false
+	}
+}
+
+func IsCompleteTaskMemoryWorkflowStatus(status string) bool {
+	switch status {
+	case "satisfied", "complete", "completed", "done":
+		return true
+	default:
+		return false
+	}
+}
+
+func IsIssueTaskMemoryWorkflowStatus(status string) bool {
+	switch status {
+	case "blocked", "error", "errored", "failed", "incomplete":
+		return true
+	default:
+		return false
+	}
 }

--- a/cmd/wuphf/channelui/build_lines_policy_task.go
+++ b/cmd/wuphf/channelui/build_lines_policy_task.go
@@ -380,7 +380,7 @@ func IsCompleteTaskMemoryWorkflowStatus(status string) bool {
 
 func IsIssueTaskMemoryWorkflowStatus(status string) bool {
 	switch status {
-	case "blocked", "error", "errored", "failed", "incomplete":
+	case "blocked", "error", "errored", "failed", "incomplete", "missing_artifacts", "partial_errors":
 		return true
 	default:
 		return false

--- a/cmd/wuphf/channelui/types.go
+++ b/cmd/wuphf/channelui/types.go
@@ -257,6 +257,7 @@ type TaskMemoryWorkflowArtifact struct {
 	EntitySlug   string `json:"entity_slug,omitempty"`
 	PlaybookSlug string `json:"playbook_slug,omitempty"`
 	Title        string `json:"title,omitempty"`
+	SkipReason   string `json:"skip_reason,omitempty"`
 	Snippet      string `json:"snippet,omitempty"`
 	CommitSHA    string `json:"commit_sha,omitempty"`
 	State        string `json:"state,omitempty"`

--- a/cmd/wuphf/channelui/types.go
+++ b/cmd/wuphf/channelui/types.go
@@ -1,6 +1,9 @@
 package channelui
 
-import "strings"
+import (
+	"encoding/json"
+	"strings"
+)
 
 // BrokerReaction is a single emoji reaction on a broker message.
 type BrokerReaction struct {
@@ -164,29 +167,134 @@ type UsageState struct {
 // are populated for tasks that ride a configured pipeline; everything
 // else stays blank for free-form work.
 type Task struct {
-	ID               string `json:"id"`
-	Channel          string `json:"channel,omitempty"`
-	Title            string `json:"title"`
-	Details          string `json:"details,omitempty"`
-	Owner            string `json:"owner,omitempty"`
-	Status           string `json:"status"`
-	CreatedBy        string `json:"created_by"`
-	ThreadID         string `json:"thread_id,omitempty"`
-	TaskType         string `json:"task_type,omitempty"`
-	PipelineID       string `json:"pipeline_id,omitempty"`
-	PipelineStage    string `json:"pipeline_stage,omitempty"`
-	ExecutionMode    string `json:"execution_mode,omitempty"`
-	ReviewState      string `json:"review_state,omitempty"`
-	SourceSignalID   string `json:"source_signal_id,omitempty"`
-	SourceDecisionID string `json:"source_decision_id,omitempty"`
-	WorktreePath     string `json:"worktree_path,omitempty"`
-	WorktreeBranch   string `json:"worktree_branch,omitempty"`
-	CreatedAt        string `json:"created_at"`
-	UpdatedAt        string `json:"updated_at"`
-	DueAt            string `json:"due_at,omitempty"`
-	FollowUpAt       string `json:"follow_up_at,omitempty"`
-	ReminderAt       string `json:"reminder_at,omitempty"`
-	RecheckAt        string `json:"recheck_at,omitempty"`
+	ID               string              `json:"id"`
+	Channel          string              `json:"channel,omitempty"`
+	Title            string              `json:"title"`
+	Details          string              `json:"details,omitempty"`
+	Owner            string              `json:"owner,omitempty"`
+	Status           string              `json:"status"`
+	CreatedBy        string              `json:"created_by"`
+	ThreadID         string              `json:"thread_id,omitempty"`
+	TaskType         string              `json:"task_type,omitempty"`
+	PipelineID       string              `json:"pipeline_id,omitempty"`
+	PipelineStage    string              `json:"pipeline_stage,omitempty"`
+	ExecutionMode    string              `json:"execution_mode,omitempty"`
+	ReviewState      string              `json:"review_state,omitempty"`
+	SourceSignalID   string              `json:"source_signal_id,omitempty"`
+	SourceDecisionID string              `json:"source_decision_id,omitempty"`
+	WorktreePath     string              `json:"worktree_path,omitempty"`
+	WorktreeBranch   string              `json:"worktree_branch,omitempty"`
+	CreatedAt        string              `json:"created_at"`
+	UpdatedAt        string              `json:"updated_at"`
+	DueAt            string              `json:"due_at,omitempty"`
+	FollowUpAt       string              `json:"follow_up_at,omitempty"`
+	ReminderAt       string              `json:"reminder_at,omitempty"`
+	RecheckAt        string              `json:"recheck_at,omitempty"`
+	MemoryWorkflow   *TaskMemoryWorkflow `json:"memory_workflow,omitempty"`
+}
+
+// TaskMemoryWorkflow is the task-level context harness state returned by the
+// broker. It stays backend-neutral so markdown, Nex, and GBrain citations can
+// share one terminal projection.
+type TaskMemoryWorkflow struct {
+	Required          bool                         `json:"required"`
+	Status            string                       `json:"status,omitempty"`
+	RequirementReason string                       `json:"requirement_reason,omitempty"`
+	RequiredSteps     []string                     `json:"required_steps,omitempty"`
+	Lookup            TaskMemoryWorkflowStepState  `json:"lookup,omitempty"`
+	Capture           TaskMemoryWorkflowStepState  `json:"capture,omitempty"`
+	Promote           TaskMemoryWorkflowStepState  `json:"promote,omitempty"`
+	Citations         []TaskMemoryWorkflowCitation `json:"citations,omitempty"`
+	Captures          []TaskMemoryWorkflowArtifact `json:"captures,omitempty"`
+	Promotions        []TaskMemoryWorkflowArtifact `json:"promotions,omitempty"`
+	Override          *TaskMemoryWorkflowOverride  `json:"override,omitempty"`
+	PartialErrors     TaskMemoryWorkflowErrorList  `json:"partial_errors,omitempty"`
+	CreatedAt         string                       `json:"created_at,omitempty"`
+	UpdatedAt         string                       `json:"updated_at,omitempty"`
+	CompletedAt       string                       `json:"completed_at,omitempty"`
+}
+
+type TaskMemoryWorkflowStepState struct {
+	Required    bool   `json:"required,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Actor       string `json:"actor,omitempty"`
+	Query       string `json:"query,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
+	Count       int    `json:"count,omitempty"`
+}
+
+type TaskMemoryWorkflowOverride struct {
+	Actor     string `json:"actor"`
+	Reason    string `json:"reason"`
+	Timestamp string `json:"timestamp"`
+}
+
+type TaskMemoryWorkflowCitation struct {
+	Backend     string   `json:"backend,omitempty"`
+	Source      string   `json:"source,omitempty"`
+	SourceID    string   `json:"source_id,omitempty"`
+	Path        string   `json:"path,omitempty"`
+	PageID      string   `json:"page_id,omitempty"`
+	ChunkID     string   `json:"chunk_id,omitempty"`
+	SourceURL   string   `json:"source_url,omitempty"`
+	LineStart   int      `json:"line_start,omitempty"`
+	LineEnd     int      `json:"line_end,omitempty"`
+	Title       string   `json:"title,omitempty"`
+	Snippet     string   `json:"snippet,omitempty"`
+	Score       *float64 `json:"score,omitempty"`
+	Stale       *bool    `json:"stale,omitempty"`
+	RetrievedAt string   `json:"retrieved_at,omitempty"`
+}
+
+type TaskMemoryWorkflowArtifact struct {
+	Backend      string `json:"backend,omitempty"`
+	Source       string `json:"source,omitempty"`
+	Path         string `json:"path,omitempty"`
+	PageID       string `json:"page_id,omitempty"`
+	PromotionID  string `json:"promotion_id,omitempty"`
+	EntityKind   string `json:"entity_kind,omitempty"`
+	EntitySlug   string `json:"entity_slug,omitempty"`
+	PlaybookSlug string `json:"playbook_slug,omitempty"`
+	Title        string `json:"title,omitempty"`
+	Snippet      string `json:"snippet,omitempty"`
+	CommitSHA    string `json:"commit_sha,omitempty"`
+	State        string `json:"state,omitempty"`
+	RecordedAt   string `json:"recorded_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+	Missing      bool   `json:"missing,omitempty"`
+}
+
+type TaskMemoryWorkflowError struct {
+	Step      string `json:"step,omitempty"`
+	Code      string `json:"code,omitempty"`
+	Message   string `json:"message,omitempty"`
+	Detail    string `json:"detail,omitempty"`
+	Timestamp string `json:"timestamp,omitempty"`
+}
+
+type TaskMemoryWorkflowErrorList []TaskMemoryWorkflowError
+
+func (l *TaskMemoryWorkflowErrorList) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		*l = nil
+		return nil
+	}
+	var records []TaskMemoryWorkflowError
+	if err := json.Unmarshal(data, &records); err == nil {
+		*l = records
+		return nil
+	}
+	var messages []string
+	if err := json.Unmarshal(data, &messages); err != nil {
+		return err
+	}
+	records = make([]TaskMemoryWorkflowError, 0, len(messages))
+	for _, msg := range messages {
+		records = append(records, TaskMemoryWorkflowError{Message: msg})
+	}
+	*l = records
+	return nil
 }
 
 // Action describes an external event observed by the broker (a GitHub

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -151,32 +151,33 @@ func (req humanInterview) TitleOrDefault() string {
 }
 
 type teamTask struct {
-	ID               string   `json:"id"`
-	Channel          string   `json:"channel,omitempty"`
-	Title            string   `json:"title"`
-	Details          string   `json:"details,omitempty"`
-	Owner            string   `json:"owner,omitempty"`
-	Status           string   `json:"status"`
-	CreatedBy        string   `json:"created_by"`
-	ThreadID         string   `json:"thread_id,omitempty"`
-	TaskType         string   `json:"task_type,omitempty"`
-	PipelineID       string   `json:"pipeline_id,omitempty"`
-	PipelineStage    string   `json:"pipeline_stage,omitempty"`
-	ExecutionMode    string   `json:"execution_mode,omitempty"`
-	ReviewState      string   `json:"review_state,omitempty"`
-	SourceSignalID   string   `json:"source_signal_id,omitempty"`
-	SourceDecisionID string   `json:"source_decision_id,omitempty"`
-	WorktreePath     string   `json:"worktree_path,omitempty"`
-	WorktreeBranch   string   `json:"worktree_branch,omitempty"`
-	DependsOn        []string `json:"depends_on,omitempty"`
-	Blocked          bool     `json:"blocked,omitempty"`
-	AckedAt          string   `json:"acked_at,omitempty"`
-	DueAt            string   `json:"due_at,omitempty"`
-	FollowUpAt       string   `json:"follow_up_at,omitempty"`
-	ReminderAt       string   `json:"reminder_at,omitempty"`
-	RecheckAt        string   `json:"recheck_at,omitempty"`
-	CreatedAt        string   `json:"created_at"`
-	UpdatedAt        string   `json:"updated_at"`
+	ID               string          `json:"id"`
+	Channel          string          `json:"channel,omitempty"`
+	Title            string          `json:"title"`
+	Details          string          `json:"details,omitempty"`
+	Owner            string          `json:"owner,omitempty"`
+	Status           string          `json:"status"`
+	CreatedBy        string          `json:"created_by"`
+	ThreadID         string          `json:"thread_id,omitempty"`
+	TaskType         string          `json:"task_type,omitempty"`
+	PipelineID       string          `json:"pipeline_id,omitempty"`
+	PipelineStage    string          `json:"pipeline_stage,omitempty"`
+	ExecutionMode    string          `json:"execution_mode,omitempty"`
+	ReviewState      string          `json:"review_state,omitempty"`
+	SourceSignalID   string          `json:"source_signal_id,omitempty"`
+	SourceDecisionID string          `json:"source_decision_id,omitempty"`
+	WorktreePath     string          `json:"worktree_path,omitempty"`
+	WorktreeBranch   string          `json:"worktree_branch,omitempty"`
+	DependsOn        []string        `json:"depends_on,omitempty"`
+	Blocked          bool            `json:"blocked,omitempty"`
+	AckedAt          string          `json:"acked_at,omitempty"`
+	DueAt            string          `json:"due_at,omitempty"`
+	FollowUpAt       string          `json:"follow_up_at,omitempty"`
+	ReminderAt       string          `json:"reminder_at,omitempty"`
+	RecheckAt        string          `json:"recheck_at,omitempty"`
+	MemoryWorkflow   *MemoryWorkflow `json:"memory_workflow,omitempty"`
+	CreatedAt        string          `json:"created_at"`
+	UpdatedAt        string          `json:"updated_at"`
 }
 
 type channelSurface struct {
@@ -762,6 +763,7 @@ func (b *Broker) Start() error {
 	// IntervalOverride and Enabled choices.
 	b.registerSystemCrons()
 	b.startReviewExpiryLoop(context.Background())
+	b.startMemoryWorkflowReconcilerLoop(context.Background())
 	return b.StartOnPort(brokeraddr.ResolvePort())
 }
 
@@ -884,6 +886,8 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/members", b.requireAuth(b.handleMembers))
 	mux.HandleFunc("/tasks", b.requireAuth(b.handleTasks))
 	mux.HandleFunc("/tasks/ack", b.requireAuth(b.handleTaskAck))
+	mux.HandleFunc("/tasks/memory-workflow", b.requireAuth(b.handleTaskMemoryWorkflow))
+	mux.HandleFunc("/tasks/memory-workflow/reconcile", b.requireAuth(b.handleTaskMemoryWorkflowReconcile))
 	mux.HandleFunc("/agent-logs", b.requireAuth(b.handleAgentLogs))
 	mux.HandleFunc("/task-plan", b.requireAuth(b.handleTaskPlan))
 	mux.HandleFunc("/memory", b.requireAuth(b.handleMemory))
@@ -2689,6 +2693,7 @@ func (b *Broker) normalizeLoadedStateLocked() {
 			b.tasks[i].Channel = "general"
 		}
 		normalizeTaskPlan(&b.tasks[i])
+		syncTaskMemoryWorkflow(&b.tasks[i], "")
 		b.ensureTaskOwnerChannelMembershipLocked(b.tasks[i].Channel, b.tasks[i].Owner)
 		b.queueTaskBehindActiveOwnerLaneLocked(&b.tasks[i])
 		b.scheduleTaskLifecycleLocked(&b.tasks[i])

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -763,8 +763,20 @@ func (b *Broker) Start() error {
 	// IntervalOverride and Enabled choices.
 	b.registerSystemCrons()
 	b.startReviewExpiryLoop(context.Background())
-	b.startMemoryWorkflowReconcilerLoop(context.Background())
-	return b.StartOnPort(brokeraddr.ResolvePort())
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-b.stopCh:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	b.startMemoryWorkflowReconcilerLoop(ctx)
+	if err := b.StartOnPort(brokeraddr.ResolvePort()); err != nil {
+		cancel()
+		return err
+	}
+	return nil
 }
 
 // ensureWikiWorker initializes the markdown-backend wiki worker when the

--- a/internal/team/broker_tasks.go
+++ b/internal/team/broker_tasks.go
@@ -1247,10 +1247,10 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]any{"tasks": created})
 }
 
-func (b *Broker) RecordTaskMemoryLookup(taskID, actor, query string, citations []ContextCitation) (teamTask, bool, error) {
+func (b *Broker) RecordTaskMemoryLookup(taskID, actor, query string, citations []ContextCitation) (teamTask, bool, bool, error) {
 	taskID = strings.TrimSpace(taskID)
 	if taskID == "" {
-		return teamTask{}, false, fmt.Errorf("task id required")
+		return teamTask{}, false, false, fmt.Errorf("task id required")
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	b.mu.Lock()
@@ -1263,26 +1263,26 @@ func (b *Broker) RecordTaskMemoryLookup(taskID, actor, query string, citations [
 		if changed {
 			b.tasks[i].UpdatedAt = now
 			if err := b.saveLocked(); err != nil {
-				return teamTask{}, true, err
+				return teamTask{}, true, true, err
 			}
 		}
-		return b.tasks[i], true, nil
+		return b.tasks[i], true, changed, nil
 	}
-	return teamTask{}, false, nil
+	return teamTask{}, false, false, nil
 }
 
-func (b *Broker) RecordTaskMemoryCapture(taskID, actor string, artifact MemoryWorkflowArtifact) (teamTask, bool, error) {
+func (b *Broker) RecordTaskMemoryCapture(taskID, actor string, artifact MemoryWorkflowArtifact) (teamTask, bool, bool, error) {
 	return b.recordTaskMemoryArtifact(taskID, actor, artifact, MemoryWorkflowStepCapture)
 }
 
-func (b *Broker) RecordTaskMemoryPromotion(taskID, actor string, artifact MemoryWorkflowArtifact) (teamTask, bool, error) {
+func (b *Broker) RecordTaskMemoryPromotion(taskID, actor string, artifact MemoryWorkflowArtifact) (teamTask, bool, bool, error) {
 	return b.recordTaskMemoryArtifact(taskID, actor, artifact, MemoryWorkflowStepPromote)
 }
 
-func (b *Broker) recordTaskMemoryArtifact(taskID, actor string, artifact MemoryWorkflowArtifact, step MemoryWorkflowStep) (teamTask, bool, error) {
+func (b *Broker) recordTaskMemoryArtifact(taskID, actor string, artifact MemoryWorkflowArtifact, step MemoryWorkflowStep) (teamTask, bool, bool, error) {
 	taskID = strings.TrimSpace(taskID)
 	if taskID == "" {
-		return teamTask{}, false, fmt.Errorf("task id required")
+		return teamTask{}, false, false, fmt.Errorf("task id required")
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	b.mu.Lock()
@@ -1298,17 +1298,17 @@ func (b *Broker) recordTaskMemoryArtifact(taskID, actor string, artifact MemoryW
 		case MemoryWorkflowStepPromote:
 			changed = recordMemoryWorkflowPromotion(&b.tasks[i], actor, artifact, now)
 		default:
-			return teamTask{}, true, fmt.Errorf("unsupported memory workflow step %q", step)
+			return teamTask{}, true, false, fmt.Errorf("unsupported memory workflow step %q", step)
 		}
 		if changed {
 			b.tasks[i].UpdatedAt = now
 			if err := b.saveLocked(); err != nil {
-				return teamTask{}, true, err
+				return teamTask{}, true, true, err
 			}
 		}
-		return b.tasks[i], true, nil
+		return b.tasks[i], true, changed, nil
 	}
-	return teamTask{}, false, nil
+	return teamTask{}, false, false, nil
 }
 
 func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request) {
@@ -1336,13 +1336,14 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 		action = strings.TrimSpace(body.Event)
 	}
 	var (
-		task  teamTask
-		found bool
-		err   error
+		task    teamTask
+		found   bool
+		changed bool
+		err     error
 	)
 	switch action {
 	case "lookup":
-		task, found, err = b.RecordTaskMemoryLookup(body.TaskID, body.Actor, body.Query, body.Citations)
+		task, found, changed, err = b.RecordTaskMemoryLookup(body.TaskID, body.Actor, body.Query, body.Citations)
 	case "capture", "capture_skipped":
 		artifact := body.Artifact
 		if len(body.Artifacts) > 0 {
@@ -1355,7 +1356,7 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 			http.Error(w, "memory workflow capture artifact required", http.StatusBadRequest)
 			return
 		}
-		task, found, err = b.RecordTaskMemoryCapture(body.TaskID, body.Actor, artifact)
+		task, found, changed, err = b.RecordTaskMemoryCapture(body.TaskID, body.Actor, artifact)
 	case "promote", "promotion", "promote_skipped":
 		artifact := body.Artifact
 		if len(body.Artifacts) > 0 {
@@ -1368,7 +1369,7 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 			http.Error(w, "memory workflow promotion artifact required", http.StatusBadRequest)
 			return
 		}
-		task, found, err = b.RecordTaskMemoryPromotion(body.TaskID, body.Actor, artifact)
+		task, found, changed, err = b.RecordTaskMemoryPromotion(body.TaskID, body.Actor, artifact)
 	default:
 		http.Error(w, "unknown memory workflow action", http.StatusBadRequest)
 		return
@@ -1381,7 +1382,7 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 		http.Error(w, "task not found", http.StatusNotFound)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"task": task, "updated": true})
+	writeJSON(w, http.StatusOK, map[string]any{"task": task, "updated": changed})
 }
 
 func (b *Broker) handleTaskMemoryWorkflowReconcile(w http.ResponseWriter, r *http.Request) {
@@ -1578,6 +1579,7 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 		ThreadID: strings.TrimSpace(threadID),
 		Owner:    strings.TrimSpace(owner),
 	}); existing != nil {
+		now := time.Now().UTC().Format(time.RFC3339)
 		if existing.Details == "" && strings.TrimSpace(details) != "" {
 			existing.Details = strings.TrimSpace(details)
 		}
@@ -1590,8 +1592,9 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 		if existing.ThreadID == "" && strings.TrimSpace(threadID) != "" {
 			existing.ThreadID = strings.TrimSpace(threadID)
 		}
+		syncTaskMemoryWorkflow(existing, now)
 		b.ensureTaskOwnerChannelMembershipLocked(channel, existing.Owner)
-		existing.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		existing.UpdatedAt = now
 		b.queueTaskBehindActiveOwnerLaneLocked(existing)
 		if err := rejectTheaterTaskForLiveBusiness(existing); err != nil {
 			return teamTask{}, false, err
@@ -1625,6 +1628,7 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 	} else if task.Owner != "" {
 		task.Status = "in_progress"
 	}
+	syncTaskMemoryWorkflow(&task, now)
 	b.ensureTaskOwnerChannelMembershipLocked(channel, task.Owner)
 	b.queueTaskBehindActiveOwnerLaneLocked(&task)
 	if err := rejectTheaterTaskForLiveBusiness(&task); err != nil {
@@ -1678,6 +1682,7 @@ func (b *Broker) EnsurePlannedTask(input plannedTaskInput) (teamTask, bool, erro
 		SourceSignalID:   strings.TrimSpace(input.SourceSignalID),
 		SourceDecisionID: strings.TrimSpace(input.SourceDecisionID),
 	}); existing != nil {
+		now := time.Now().UTC().Format(time.RFC3339)
 		if existing.Details == "" && strings.TrimSpace(input.Details) != "" {
 			existing.Details = strings.TrimSpace(input.Details)
 		}
@@ -1706,8 +1711,9 @@ func (b *Broker) EnsurePlannedTask(input plannedTaskInput) (teamTask, bool, erro
 		if existing.SourceDecisionID == "" && strings.TrimSpace(input.SourceDecisionID) != "" {
 			existing.SourceDecisionID = strings.TrimSpace(input.SourceDecisionID)
 		}
+		syncTaskMemoryWorkflow(existing, now)
 		b.ensureTaskOwnerChannelMembershipLocked(channel, existing.Owner)
-		existing.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+		existing.UpdatedAt = now
 		b.queueTaskBehindActiveOwnerLaneLocked(existing)
 		if err := rejectTheaterTaskForLiveBusiness(existing); err != nil {
 			return teamTask{}, false, err
@@ -1747,6 +1753,7 @@ func (b *Broker) EnsurePlannedTask(input plannedTaskInput) (teamTask, bool, erro
 	} else if task.Owner != "" {
 		task.Status = "in_progress"
 	}
+	syncTaskMemoryWorkflow(&task, now)
 	b.ensureTaskOwnerChannelMembershipLocked(channel, task.Owner)
 	b.queueTaskBehindActiveOwnerLaneLocked(&task)
 	if err := rejectTheaterTaskForLiveBusiness(&task); err != nil {

--- a/internal/team/broker_tasks.go
+++ b/internal/team/broker_tasks.go
@@ -15,6 +15,95 @@ import (
 
 var errTaskMemoryWorkflowBadRequest = errors.New("bad memory workflow request")
 
+type brokerTaskMutationSnapshot struct {
+	tasks       []teamTask
+	channels    []teamChannel
+	messages    []channelMessage
+	agentIssues []agentIssueRecord
+	actions     []officeActionLog
+	watchdogs   []watchdogAlert
+	scheduler   []schedulerJob
+	counter     int
+}
+
+func snapshotBrokerTaskMutationLocked(b *Broker) brokerTaskMutationSnapshot {
+	return brokerTaskMutationSnapshot{
+		tasks:       cloneTeamTasksForRollback(b.tasks),
+		channels:    cloneTeamChannelsForRollback(b.channels),
+		messages:    cloneChannelMessagesForRollback(b.messages),
+		agentIssues: append([]agentIssueRecord(nil), b.agentIssues...),
+		actions:     cloneOfficeActionsForRollback(b.actions),
+		watchdogs:   append([]watchdogAlert(nil), b.watchdogs...),
+		scheduler:   append([]schedulerJob(nil), b.scheduler...),
+		counter:     b.counter,
+	}
+}
+
+func (snapshot brokerTaskMutationSnapshot) restore(b *Broker) {
+	b.tasks = cloneTeamTasksForRollback(snapshot.tasks)
+	b.channels = cloneTeamChannelsForRollback(snapshot.channels)
+	b.messages = cloneChannelMessagesForRollback(snapshot.messages)
+	b.agentIssues = append([]agentIssueRecord(nil), snapshot.agentIssues...)
+	b.actions = cloneOfficeActionsForRollback(snapshot.actions)
+	b.watchdogs = append([]watchdogAlert(nil), snapshot.watchdogs...)
+	b.scheduler = append([]schedulerJob(nil), snapshot.scheduler...)
+	b.counter = snapshot.counter
+}
+
+func cloneTeamTasksForRollback(tasks []teamTask) []teamTask {
+	if len(tasks) == 0 {
+		return nil
+	}
+	out := make([]teamTask, len(tasks))
+	for i := range tasks {
+		out[i] = cloneTeamTaskForRollback(tasks[i])
+	}
+	return out
+}
+
+func cloneTeamChannelsForRollback(channels []teamChannel) []teamChannel {
+	if len(channels) == 0 {
+		return nil
+	}
+	out := append([]teamChannel(nil), channels...)
+	for i := range out {
+		out[i].Members = append([]string(nil), channels[i].Members...)
+		out[i].Disabled = append([]string(nil), channels[i].Disabled...)
+		if channels[i].Surface != nil {
+			surface := *channels[i].Surface
+			out[i].Surface = &surface
+		}
+	}
+	return out
+}
+
+func cloneChannelMessagesForRollback(messages []channelMessage) []channelMessage {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := append([]channelMessage(nil), messages...)
+	for i := range out {
+		out[i].Tagged = append([]string(nil), messages[i].Tagged...)
+		out[i].Reactions = append([]messageReaction(nil), messages[i].Reactions...)
+		if messages[i].Usage != nil {
+			usage := *messages[i].Usage
+			out[i].Usage = &usage
+		}
+	}
+	return out
+}
+
+func cloneOfficeActionsForRollback(actions []officeActionLog) []officeActionLog {
+	if len(actions) == 0 {
+		return nil
+	}
+	out := append([]officeActionLog(nil), actions...)
+	for i := range out {
+		out[i].SignalIDs = append([]string(nil), actions[i].SignalIDs...)
+	}
+	return out
+}
+
 func taskNeedsLocalWorktree(task *teamTask) bool {
 	if task == nil {
 		return false
@@ -599,9 +688,9 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		task := &b.tasks[i]
-		previousTask := cloneTeamTaskForRollback(*task)
+		mutationSnapshot := snapshotBrokerTaskMutationLocked(b)
 		rollbackTask := func() {
-			*task = previousTask
+			mutationSnapshot.restore(b)
 		}
 		taskChannel := normalizeChannelSlug(task.Channel)
 		// Authorize against the task's ACTUAL channel, not the channel the
@@ -1353,19 +1442,12 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 	case "lookup":
 		task, found, changed, err = b.RecordTaskMemoryLookup(body.TaskID, body.Actor, body.Query, body.Citations)
 	case "capture", "capture_skipped":
-		artifacts := body.Artifacts
-		if len(artifacts) == 0 {
-			artifacts = []MemoryWorkflowArtifact{body.Artifact}
+		artifacts, validationErr := validatedMemoryWorkflowArtifacts(action, body.Artifact, body.Artifacts, body.SkipReason)
+		if validationErr != nil {
+			http.Error(w, "memory workflow capture artifact required", http.StatusBadRequest)
+			return
 		}
 		for _, artifact := range artifacts {
-			if action == "capture_skipped" && memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
-				skipReason := strings.TrimSpace(body.SkipReason)
-				artifact = MemoryWorkflowArtifact{Source: "skip", Title: skipReason, SkipReason: skipReason}
-			}
-			if memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
-				http.Error(w, "memory workflow capture artifact required", http.StatusBadRequest)
-				return
-			}
 			var artifactChanged bool
 			task, found, artifactChanged, err = b.RecordTaskMemoryCapture(body.TaskID, body.Actor, artifact)
 			changed = artifactChanged || changed
@@ -1374,19 +1456,12 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 			}
 		}
 	case "promote", "promotion", "promote_skipped":
-		artifacts := body.Artifacts
-		if len(artifacts) == 0 {
-			artifacts = []MemoryWorkflowArtifact{body.Artifact}
+		artifacts, validationErr := validatedMemoryWorkflowArtifacts(action, body.Artifact, body.Artifacts, body.SkipReason)
+		if validationErr != nil {
+			http.Error(w, "memory workflow promotion artifact required", http.StatusBadRequest)
+			return
 		}
 		for _, artifact := range artifacts {
-			if action == "promote_skipped" && memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
-				skipReason := strings.TrimSpace(body.SkipReason)
-				artifact = MemoryWorkflowArtifact{Source: "skip", Title: skipReason, SkipReason: skipReason}
-			}
-			if memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
-				http.Error(w, "memory workflow promotion artifact required", http.StatusBadRequest)
-				return
-			}
 			var artifactChanged bool
 			task, found, artifactChanged, err = b.RecordTaskMemoryPromotion(body.TaskID, body.Actor, artifact)
 			changed = artifactChanged || changed
@@ -1411,6 +1486,26 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 		return
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"task": task, "updated": changed})
+}
+
+func validatedMemoryWorkflowArtifacts(action string, artifact MemoryWorkflowArtifact, artifacts []MemoryWorkflowArtifact, skipReason string) ([]MemoryWorkflowArtifact, error) {
+	candidates := artifacts
+	if len(candidates) == 0 {
+		candidates = []MemoryWorkflowArtifact{artifact}
+	}
+	validated := make([]MemoryWorkflowArtifact, 0, len(candidates))
+	for _, candidate := range candidates {
+		normalized := normalizeMemoryWorkflowArtifact(candidate, "")
+		if strings.HasSuffix(action, "_skipped") && memoryWorkflowArtifactKey(normalized) == "" {
+			reason := strings.TrimSpace(skipReason)
+			normalized = normalizeMemoryWorkflowArtifact(MemoryWorkflowArtifact{Source: "skip", Title: reason, SkipReason: reason}, "")
+		}
+		if memoryWorkflowArtifactKey(normalized) == "" {
+			return nil, fmt.Errorf("%w: artifact required", errTaskMemoryWorkflowBadRequest)
+		}
+		validated = append(validated, normalized)
+	}
+	return validated, nil
 }
 
 func (b *Broker) handleTaskMemoryWorkflowReconcile(w http.ResponseWriter, r *http.Request) {

--- a/internal/team/broker_tasks.go
+++ b/internal/team/broker_tasks.go
@@ -13,6 +13,8 @@ import (
 	"github.com/nex-crm/wuphf/internal/agent"
 )
 
+var errTaskMemoryWorkflowBadRequest = errors.New("bad memory workflow request")
+
 func taskNeedsLocalWorktree(task *teamTask) bool {
 	if task == nil {
 		return false
@@ -598,7 +600,6 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		}
 		task := &b.tasks[i]
 		previousTask := cloneTeamTaskForRollback(*task)
-		wasDone := strings.EqualFold(strings.TrimSpace(task.Status), "done")
 		taskChannel := normalizeChannelSlug(task.Channel)
 		// Authorize against the task's ACTUAL channel, not the channel the
 		// caller put in the body. Without this, a viewer with access to
@@ -741,7 +742,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			task.WorktreeBranch = worktreeBranch
 		}
 		syncTaskMemoryWorkflow(task, now)
-		if strings.EqualFold(strings.TrimSpace(task.Status), "done") && (!wasDone || body.MemoryWorkflowOverride) {
+		if strings.EqualFold(strings.TrimSpace(task.Status), "done") {
 			overrideActor := strings.TrimSpace(body.MemoryWorkflowOverrideActor)
 			if overrideActor == "" {
 				overrideActor = strings.TrimSpace(body.CreatedBy)
@@ -1250,7 +1251,7 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 func (b *Broker) RecordTaskMemoryLookup(taskID, actor, query string, citations []ContextCitation) (teamTask, bool, bool, error) {
 	taskID = strings.TrimSpace(taskID)
 	if taskID == "" {
-		return teamTask{}, false, false, fmt.Errorf("task id required")
+		return teamTask{}, false, false, fmt.Errorf("%w: task id required", errTaskMemoryWorkflowBadRequest)
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	b.mu.Lock()
@@ -1282,7 +1283,7 @@ func (b *Broker) RecordTaskMemoryPromotion(taskID, actor string, artifact Memory
 func (b *Broker) recordTaskMemoryArtifact(taskID, actor string, artifact MemoryWorkflowArtifact, step MemoryWorkflowStep) (teamTask, bool, bool, error) {
 	taskID = strings.TrimSpace(taskID)
 	if taskID == "" {
-		return teamTask{}, false, false, fmt.Errorf("task id required")
+		return teamTask{}, false, false, fmt.Errorf("%w: task id required", errTaskMemoryWorkflowBadRequest)
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
 	b.mu.Lock()
@@ -1298,7 +1299,7 @@ func (b *Broker) recordTaskMemoryArtifact(taskID, actor string, artifact MemoryW
 		case MemoryWorkflowStepPromote:
 			changed = recordMemoryWorkflowPromotion(&b.tasks[i], actor, artifact, now)
 		default:
-			return teamTask{}, true, false, fmt.Errorf("unsupported memory workflow step %q", step)
+			return teamTask{}, true, false, fmt.Errorf("%w: unsupported memory workflow step %q", errTaskMemoryWorkflowBadRequest, step)
 		}
 		if changed {
 			b.tasks[i].UpdatedAt = now
@@ -1350,7 +1351,8 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 			artifact = body.Artifacts[0]
 		}
 		if action == "capture_skipped" && memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
-			artifact = MemoryWorkflowArtifact{Source: "skip", Title: strings.TrimSpace(body.SkipReason)}
+			skipReason := strings.TrimSpace(body.SkipReason)
+			artifact = MemoryWorkflowArtifact{Source: "skip", Title: skipReason, SkipReason: skipReason}
 		}
 		if memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
 			http.Error(w, "memory workflow capture artifact required", http.StatusBadRequest)
@@ -1363,7 +1365,8 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 			artifact = body.Artifacts[0]
 		}
 		if action == "promote_skipped" && memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
-			artifact = MemoryWorkflowArtifact{Source: "skip", Title: strings.TrimSpace(body.SkipReason)}
+			skipReason := strings.TrimSpace(body.SkipReason)
+			artifact = MemoryWorkflowArtifact{Source: "skip", Title: skipReason, SkipReason: skipReason}
 		}
 		if memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
 			http.Error(w, "memory workflow promotion artifact required", http.StatusBadRequest)
@@ -1375,7 +1378,11 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if errors.Is(err, errTaskMemoryWorkflowBadRequest) {
+			status = http.StatusBadRequest
+		}
+		http.Error(w, err.Error(), status)
 		return
 	}
 	if !found {

--- a/internal/team/broker_tasks.go
+++ b/internal/team/broker_tasks.go
@@ -600,6 +600,9 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		}
 		task := &b.tasks[i]
 		previousTask := cloneTeamTaskForRollback(*task)
+		rollbackTask := func() {
+			*task = previousTask
+		}
 		taskChannel := normalizeChannelSlug(task.Channel)
 		// Authorize against the task's ACTUAL channel, not the channel the
 		// caller put in the body. Without this, a viewer with access to
@@ -710,6 +713,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		if strings.TrimSpace(body.Details) != "" {
 			if appendDetails {
 				if err := appendTaskDetailLocked(task, body.Details); err != nil {
+					rollbackTask()
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
 				}
@@ -752,7 +756,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 				overrideReason = strings.TrimSpace(body.OverrideReason)
 			}
 			if err := applyMemoryWorkflowCompletionGate(task, overrideActor, overrideReason, body.MemoryWorkflowOverride, now); err != nil {
-				*task = previousTask
+				rollbackTask()
 				http.Error(w, err.Error(), http.StatusConflict)
 				return
 			}
@@ -761,6 +765,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		b.queueTaskBehindActiveOwnerLaneLocked(task)
 		task.UpdatedAt = now
 		if err := rejectTheaterTaskForLiveBusiness(task); err != nil {
+			rollbackTask()
 			http.Error(w, err.Error(), http.StatusConflict)
 			return
 		}
@@ -774,6 +779,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		}
 		b.scheduleTaskLifecycleLocked(task)
 		if err := b.syncTaskWorktreeLocked(task); err != nil {
+			rollbackTask()
 			http.Error(w, "failed to manage task worktree", http.StatusInternalServerError)
 			return
 		}
@@ -788,6 +794,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			b.postTaskCancelNotificationsLocked(strings.TrimSpace(body.CreatedBy), task, cancelPrevOwner)
 		}
 		if err := b.saveLocked(); err != nil {
+			rollbackTask()
 			http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
 			return
 		}
@@ -1346,33 +1353,47 @@ func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request
 	case "lookup":
 		task, found, changed, err = b.RecordTaskMemoryLookup(body.TaskID, body.Actor, body.Query, body.Citations)
 	case "capture", "capture_skipped":
-		artifact := body.Artifact
-		if len(body.Artifacts) > 0 {
-			artifact = body.Artifacts[0]
+		artifacts := body.Artifacts
+		if len(artifacts) == 0 {
+			artifacts = []MemoryWorkflowArtifact{body.Artifact}
 		}
-		if action == "capture_skipped" && memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
-			skipReason := strings.TrimSpace(body.SkipReason)
-			artifact = MemoryWorkflowArtifact{Source: "skip", Title: skipReason, SkipReason: skipReason}
+		for _, artifact := range artifacts {
+			if action == "capture_skipped" && memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
+				skipReason := strings.TrimSpace(body.SkipReason)
+				artifact = MemoryWorkflowArtifact{Source: "skip", Title: skipReason, SkipReason: skipReason}
+			}
+			if memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
+				http.Error(w, "memory workflow capture artifact required", http.StatusBadRequest)
+				return
+			}
+			var artifactChanged bool
+			task, found, artifactChanged, err = b.RecordTaskMemoryCapture(body.TaskID, body.Actor, artifact)
+			changed = artifactChanged || changed
+			if err != nil || !found {
+				break
+			}
 		}
-		if memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
-			http.Error(w, "memory workflow capture artifact required", http.StatusBadRequest)
-			return
-		}
-		task, found, changed, err = b.RecordTaskMemoryCapture(body.TaskID, body.Actor, artifact)
 	case "promote", "promotion", "promote_skipped":
-		artifact := body.Artifact
-		if len(body.Artifacts) > 0 {
-			artifact = body.Artifacts[0]
+		artifacts := body.Artifacts
+		if len(artifacts) == 0 {
+			artifacts = []MemoryWorkflowArtifact{body.Artifact}
 		}
-		if action == "promote_skipped" && memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
-			skipReason := strings.TrimSpace(body.SkipReason)
-			artifact = MemoryWorkflowArtifact{Source: "skip", Title: skipReason, SkipReason: skipReason}
+		for _, artifact := range artifacts {
+			if action == "promote_skipped" && memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
+				skipReason := strings.TrimSpace(body.SkipReason)
+				artifact = MemoryWorkflowArtifact{Source: "skip", Title: skipReason, SkipReason: skipReason}
+			}
+			if memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
+				http.Error(w, "memory workflow promotion artifact required", http.StatusBadRequest)
+				return
+			}
+			var artifactChanged bool
+			task, found, artifactChanged, err = b.RecordTaskMemoryPromotion(body.TaskID, body.Actor, artifact)
+			changed = artifactChanged || changed
+			if err != nil || !found {
+				break
+			}
 		}
-		if memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
-			http.Error(w, "memory workflow promotion artifact required", http.StatusBadRequest)
-			return
-		}
-		task, found, changed, err = b.RecordTaskMemoryPromotion(body.TaskID, body.Actor, artifact)
 	default:
 		http.Error(w, "unknown memory workflow action", http.StatusBadRequest)
 		return

--- a/internal/team/broker_tasks.go
+++ b/internal/team/broker_tasks.go
@@ -431,23 +431,27 @@ func (b *Broker) handleGetTasks(w http.ResponseWriter, r *http.Request) {
 
 func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 	var body struct {
-		Action           string   `json:"action"`
-		Channel          string   `json:"channel"`
-		ID               string   `json:"id"`
-		Title            string   `json:"title"`
-		Details          string   `json:"details"`
-		Owner            string   `json:"owner"`
-		CreatedBy        string   `json:"created_by"`
-		ThreadID         string   `json:"thread_id"`
-		TaskType         string   `json:"task_type"`
-		PipelineID       string   `json:"pipeline_id"`
-		ExecutionMode    string   `json:"execution_mode"`
-		ReviewState      string   `json:"review_state"`
-		SourceSignalID   string   `json:"source_signal_id"`
-		SourceDecisionID string   `json:"source_decision_id"`
-		WorktreePath     string   `json:"worktree_path"`
-		WorktreeBranch   string   `json:"worktree_branch"`
-		DependsOn        []string `json:"depends_on"`
+		Action                       string   `json:"action"`
+		Channel                      string   `json:"channel"`
+		ID                           string   `json:"id"`
+		Title                        string   `json:"title"`
+		Details                      string   `json:"details"`
+		Owner                        string   `json:"owner"`
+		CreatedBy                    string   `json:"created_by"`
+		ThreadID                     string   `json:"thread_id"`
+		TaskType                     string   `json:"task_type"`
+		PipelineID                   string   `json:"pipeline_id"`
+		ExecutionMode                string   `json:"execution_mode"`
+		ReviewState                  string   `json:"review_state"`
+		SourceSignalID               string   `json:"source_signal_id"`
+		SourceDecisionID             string   `json:"source_decision_id"`
+		WorktreePath                 string   `json:"worktree_path"`
+		WorktreeBranch               string   `json:"worktree_branch"`
+		DependsOn                    []string `json:"depends_on"`
+		MemoryWorkflowOverride       bool     `json:"memory_workflow_override"`
+		MemoryWorkflowOverrideActor  string   `json:"memory_workflow_override_actor"`
+		MemoryWorkflowOverrideReason string   `json:"memory_workflow_override_reason"`
+		OverrideReason               string   `json:"override_reason"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -520,6 +524,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			if existing.ThreadID == "" && strings.TrimSpace(body.ThreadID) != "" {
 				existing.ThreadID = strings.TrimSpace(body.ThreadID)
 			}
+			syncTaskMemoryWorkflow(existing, now)
 			b.ensureTaskOwnerChannelMembershipLocked(channel, existing.Owner)
 			existing.UpdatedAt = now
 			b.scheduleTaskLifecycleLocked(existing)
@@ -563,6 +568,7 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		} else if task.Owner != "" {
 			task.Status = "in_progress"
 		}
+		syncTaskMemoryWorkflow(&task, now)
 		b.ensureTaskOwnerChannelMembershipLocked(channel, task.Owner)
 		b.queueTaskBehindActiveOwnerLaneLocked(&task)
 		if err := rejectTheaterTaskForLiveBusiness(&task); err != nil {
@@ -591,6 +597,8 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		task := &b.tasks[i]
+		previousTask := cloneTeamTaskForRollback(*task)
+		wasDone := strings.EqualFold(strings.TrimSpace(task.Status), "done")
 		taskChannel := normalizeChannelSlug(task.Channel)
 		// Authorize against the task's ACTUAL channel, not the channel the
 		// caller put in the body. Without this, a viewer with access to
@@ -731,6 +739,22 @@ func (b *Broker) handlePostTask(w http.ResponseWriter, r *http.Request) {
 		}
 		if worktreeBranch := strings.TrimSpace(body.WorktreeBranch); worktreeBranch != "" {
 			task.WorktreeBranch = worktreeBranch
+		}
+		syncTaskMemoryWorkflow(task, now)
+		if strings.EqualFold(strings.TrimSpace(task.Status), "done") && (!wasDone || body.MemoryWorkflowOverride) {
+			overrideActor := strings.TrimSpace(body.MemoryWorkflowOverrideActor)
+			if overrideActor == "" {
+				overrideActor = strings.TrimSpace(body.CreatedBy)
+			}
+			overrideReason := strings.TrimSpace(body.MemoryWorkflowOverrideReason)
+			if overrideReason == "" {
+				overrideReason = strings.TrimSpace(body.OverrideReason)
+			}
+			if err := applyMemoryWorkflowCompletionGate(task, overrideActor, overrideReason, body.MemoryWorkflowOverride, now); err != nil {
+				*task = previousTask
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			}
 		}
 		b.ensureTaskOwnerChannelMembershipLocked(taskChannel, task.Owner)
 		b.queueTaskBehindActiveOwnerLaneLocked(task)
@@ -1156,6 +1180,7 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 				existing.Blocked = false
 				existing.Status = "in_progress"
 			}
+			syncTaskMemoryWorkflow(existing, now)
 			b.ensureTaskOwnerChannelMembershipLocked(taskChannel, existing.Owner)
 			b.queueTaskBehindActiveOwnerLaneLocked(existing)
 			existing.UpdatedAt = now
@@ -1197,6 +1222,7 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 		if len(resolvedDeps) > 0 && b.hasUnresolvedDepsLocked(&task) {
 			task.Blocked = true
 		}
+		syncTaskMemoryWorkflow(&task, now)
 		b.ensureTaskOwnerChannelMembershipLocked(taskChannel, task.Owner)
 		b.queueTaskBehindActiveOwnerLaneLocked(&task)
 		if err := rejectTheaterTaskForLiveBusiness(&task); err != nil {
@@ -1219,6 +1245,156 @@ func (b *Broker) handleTaskPlan(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"tasks": created})
+}
+
+func (b *Broker) RecordTaskMemoryLookup(taskID, actor, query string, citations []ContextCitation) (teamTask, bool, error) {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return teamTask{}, false, fmt.Errorf("task id required")
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := range b.tasks {
+		if b.tasks[i].ID != taskID {
+			continue
+		}
+		changed := recordMemoryWorkflowLookup(&b.tasks[i], actor, query, citations, now)
+		if changed {
+			b.tasks[i].UpdatedAt = now
+			if err := b.saveLocked(); err != nil {
+				return teamTask{}, true, err
+			}
+		}
+		return b.tasks[i], true, nil
+	}
+	return teamTask{}, false, nil
+}
+
+func (b *Broker) RecordTaskMemoryCapture(taskID, actor string, artifact MemoryWorkflowArtifact) (teamTask, bool, error) {
+	return b.recordTaskMemoryArtifact(taskID, actor, artifact, MemoryWorkflowStepCapture)
+}
+
+func (b *Broker) RecordTaskMemoryPromotion(taskID, actor string, artifact MemoryWorkflowArtifact) (teamTask, bool, error) {
+	return b.recordTaskMemoryArtifact(taskID, actor, artifact, MemoryWorkflowStepPromote)
+}
+
+func (b *Broker) recordTaskMemoryArtifact(taskID, actor string, artifact MemoryWorkflowArtifact, step MemoryWorkflowStep) (teamTask, bool, error) {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return teamTask{}, false, fmt.Errorf("task id required")
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for i := range b.tasks {
+		if b.tasks[i].ID != taskID {
+			continue
+		}
+		var changed bool
+		switch step {
+		case MemoryWorkflowStepCapture:
+			changed = recordMemoryWorkflowCapture(&b.tasks[i], actor, artifact, now)
+		case MemoryWorkflowStepPromote:
+			changed = recordMemoryWorkflowPromotion(&b.tasks[i], actor, artifact, now)
+		default:
+			return teamTask{}, true, fmt.Errorf("unsupported memory workflow step %q", step)
+		}
+		if changed {
+			b.tasks[i].UpdatedAt = now
+			if err := b.saveLocked(); err != nil {
+				return teamTask{}, true, err
+			}
+		}
+		return b.tasks[i], true, nil
+	}
+	return teamTask{}, false, nil
+}
+
+func (b *Broker) handleTaskMemoryWorkflow(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body struct {
+		Action     string                   `json:"action"`
+		Event      string                   `json:"event"`
+		TaskID     string                   `json:"task_id"`
+		Actor      string                   `json:"actor"`
+		Query      string                   `json:"query"`
+		Citations  []ContextCitation        `json:"citations"`
+		Artifact   MemoryWorkflowArtifact   `json:"artifact"`
+		Artifacts  []MemoryWorkflowArtifact `json:"artifacts"`
+		SkipReason string                   `json:"skip_reason"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	action := strings.TrimSpace(body.Action)
+	if action == "" {
+		action = strings.TrimSpace(body.Event)
+	}
+	var (
+		task  teamTask
+		found bool
+		err   error
+	)
+	switch action {
+	case "lookup":
+		task, found, err = b.RecordTaskMemoryLookup(body.TaskID, body.Actor, body.Query, body.Citations)
+	case "capture", "capture_skipped":
+		artifact := body.Artifact
+		if len(body.Artifacts) > 0 {
+			artifact = body.Artifacts[0]
+		}
+		if action == "capture_skipped" && memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
+			artifact = MemoryWorkflowArtifact{Source: "skip", Title: strings.TrimSpace(body.SkipReason)}
+		}
+		if memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
+			http.Error(w, "memory workflow capture artifact required", http.StatusBadRequest)
+			return
+		}
+		task, found, err = b.RecordTaskMemoryCapture(body.TaskID, body.Actor, artifact)
+	case "promote", "promotion", "promote_skipped":
+		artifact := body.Artifact
+		if len(body.Artifacts) > 0 {
+			artifact = body.Artifacts[0]
+		}
+		if action == "promote_skipped" && memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
+			artifact = MemoryWorkflowArtifact{Source: "skip", Title: strings.TrimSpace(body.SkipReason)}
+		}
+		if memoryWorkflowArtifactKey(normalizeMemoryWorkflowArtifact(artifact, "")) == "" {
+			http.Error(w, "memory workflow promotion artifact required", http.StatusBadRequest)
+			return
+		}
+		task, found, err = b.RecordTaskMemoryPromotion(body.TaskID, body.Actor, artifact)
+	default:
+		http.Error(w, "unknown memory workflow action", http.StatusBadRequest)
+		return
+	}
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if !found {
+		http.Error(w, "task not found", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"task": task, "updated": true})
+}
+
+func (b *Broker) handleTaskMemoryWorkflowReconcile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	report, err := b.ReconcileMemoryWorkflows(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"report": report})
 }
 
 func (b *Broker) handleMemory(w http.ResponseWriter, r *http.Request) {

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -1165,6 +1165,12 @@ func TestBrokerTaskCompleteRejectsLiveBusinessTheater(t *testing.T) {
 		raw, _ := io.ReadAll(resp.Body)
 		t.Fatalf("expected theater rejection on completion, got status %d: %s", resp.StatusCode, raw)
 	}
+	b.mu.Lock()
+	gotStatus := b.tasks[0].Status
+	b.mu.Unlock()
+	if gotStatus != "in_progress" {
+		t.Fatalf("failed completion should roll back task status, got %q", gotStatus)
+	}
 }
 
 func TestBrokerStoresLedgerAndReviewLifecycle(t *testing.T) {
@@ -2779,6 +2785,85 @@ func TestBrokerTaskMemoryWorkflowBadRequestErrorsReturn400(t *testing.T) {
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected bad request for malformed workflow event, got status=%d body=%s", resp.StatusCode, raw)
+	}
+}
+
+func TestBrokerTaskMemoryWorkflowRecordsBatchedArtifacts(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	createBody, _ := json.Marshal(map[string]any{
+		"action":     "create",
+		"title":      "Research prior context for onboarding",
+		"created_by": "ceo",
+		"owner":      "ceo",
+		"task_type":  "research",
+	})
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks", b.Addr()), bytes.NewReader(createBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create status=%d body=%s", resp.StatusCode, raw)
+	}
+	var created struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.Unmarshal(raw, &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+
+	workflowBody, _ := json.Marshal(map[string]any{
+		"event":   "capture",
+		"task_id": created.Task.ID,
+		"actor":   "pm",
+		"artifacts": []map[string]any{
+			{
+				"backend": "markdown",
+				"source":  "notebook",
+				"path":    "agents/pm/notebook/onboarding.md",
+				"title":   "Onboarding",
+			},
+			{
+				"backend": "markdown",
+				"source":  "notebook",
+				"path":    "agents/pm/notebook/checklist.md",
+				"title":   "Checklist",
+			},
+		},
+	})
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks/memory-workflow", b.Addr()), bytes.NewReader(workflowBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("record workflow: %v", err)
+	}
+	raw, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("workflow status=%d body=%s", resp.StatusCode, raw)
+	}
+	var updated struct {
+		Task    teamTask `json:"task"`
+		Updated bool     `json:"updated"`
+	}
+	if err := json.Unmarshal(raw, &updated); err != nil {
+		t.Fatalf("decode workflow: %v", err)
+	}
+	if !updated.Updated {
+		t.Fatal("expected batched workflow artifacts to update task")
+	}
+	if got := len(updated.Task.MemoryWorkflow.Captures); got != 2 {
+		t.Fatalf("expected both capture artifacts to persist, got %d: %+v", got, updated.Task.MemoryWorkflow.Captures)
 	}
 }
 

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -1173,6 +1173,79 @@ func TestBrokerTaskCompleteRejectsLiveBusinessTheater(t *testing.T) {
 	}
 }
 
+func TestBrokerTaskUpdateRollsBackBrokerSideEffectsOnSaveFailure(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "operator", "Operator")
+	ensureTestMemberAccess(b, "general", "builder", "Builder")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+	b.mu.Lock()
+	b.tasks = []teamTask{
+		{
+			ID:        "task-1",
+			Channel:   "general",
+			Title:     "Implement reusable importer",
+			Owner:     "builder",
+			Status:    "in_progress",
+			CreatedBy: "operator",
+			TaskType:  "feature",
+			CreatedAt: "2026-04-15T00:00:00Z",
+			UpdatedAt: "2026-04-15T00:00:00Z",
+		},
+		{
+			ID:        "task-2",
+			Channel:   "general",
+			Title:     "Follow-up importer docs",
+			Status:    "open",
+			CreatedBy: "operator",
+			TaskType:  "feature",
+			DependsOn: []string{"task-1"},
+			Blocked:   true,
+			CreatedAt: "2026-04-15T00:00:00Z",
+			UpdatedAt: "2026-04-15T00:00:00Z",
+		},
+	}
+	b.counter = 7
+	b.statePath = t.TempDir()
+	b.mu.Unlock()
+
+	body, _ := json.Marshal(map[string]any{
+		"action":     "complete",
+		"channel":    "general",
+		"id":         "task-1",
+		"created_by": "builder",
+	})
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks", b.Addr()), bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("task complete request failed: %v", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected save failure, got status %d: %s", resp.StatusCode, raw)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.tasks[0].Status != "in_progress" {
+		t.Fatalf("failed save should roll back completed task, got %+v", b.tasks[0])
+	}
+	if !b.tasks[1].Blocked || b.tasks[1].Status != "open" {
+		t.Fatalf("failed save should roll back dependent unblock, got %+v", b.tasks[1])
+	}
+	if b.counter != 7 {
+		t.Fatalf("failed save should roll back broker counter, got %d", b.counter)
+	}
+	if got := len(b.actions); got != 0 {
+		t.Fatalf("failed save should roll back action log, got %+v", b.actions[:got])
+	}
+}
+
 func TestBrokerStoresLedgerAndReviewLifecycle(t *testing.T) {
 	setPrepareTaskWorktreeForTest(t, func(taskID string) (string, string, error) {
 		return "/tmp/wuphf-task-" + taskID, "wuphf-" + taskID, nil
@@ -2864,6 +2937,77 @@ func TestBrokerTaskMemoryWorkflowRecordsBatchedArtifacts(t *testing.T) {
 	}
 	if got := len(updated.Task.MemoryWorkflow.Captures); got != 2 {
 		t.Fatalf("expected both capture artifacts to persist, got %d: %+v", got, updated.Task.MemoryWorkflow.Captures)
+	}
+}
+
+func TestBrokerTaskMemoryWorkflowPrevalidatesBatchedArtifacts(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	createBody, _ := json.Marshal(map[string]any{
+		"action":     "create",
+		"title":      "Research prior context for onboarding",
+		"created_by": "ceo",
+		"owner":      "ceo",
+		"task_type":  "research",
+	})
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks", b.Addr()), bytes.NewReader(createBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create status=%d body=%s", resp.StatusCode, raw)
+	}
+	var created struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.Unmarshal(raw, &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+
+	workflowBody, _ := json.Marshal(map[string]any{
+		"event":   "capture",
+		"task_id": created.Task.ID,
+		"actor":   "pm",
+		"artifacts": []map[string]any{
+			{
+				"backend": "markdown",
+				"source":  "notebook",
+				"path":    "agents/pm/notebook/onboarding.md",
+			},
+			{},
+		},
+	})
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks/memory-workflow", b.Addr()), bytes.NewReader(workflowBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("record workflow: %v", err)
+	}
+	raw, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected invalid batch to be rejected, got status=%d body=%s", resp.StatusCode, raw)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, task := range b.tasks {
+		if task.ID != created.Task.ID || task.MemoryWorkflow == nil {
+			continue
+		}
+		if got := len(task.MemoryWorkflow.Captures); got != 0 {
+			t.Fatalf("invalid batch should not partially persist captures, got %+v", task.MemoryWorkflow.Captures)
+		}
 	}
 }
 

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -2509,6 +2509,68 @@ func TestBrokerMemoryWorkflowCompletionGateAndOverride(t *testing.T) {
 	}
 }
 
+func TestBrokerMemoryWorkflowCompletionGateRerunsForExistingDoneTask(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	postTask := func(payload map[string]any) (*http.Response, []byte) {
+		t.Helper()
+		body, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks", b.Addr()), bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post task: %v", err)
+		}
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp, raw
+	}
+
+	createResp, raw := postTask(map[string]any{
+		"action":     "create",
+		"title":      "Compare pricing pages",
+		"created_by": "ceo",
+		"owner":      "ceo",
+		"task_type":  "feature",
+	})
+	if createResp.StatusCode != http.StatusOK {
+		t.Fatalf("create status=%d body=%s", createResp.StatusCode, raw)
+	}
+	var created struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.Unmarshal(raw, &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	completeResp, raw := postTask(map[string]any{
+		"action":     "complete",
+		"id":         created.Task.ID,
+		"created_by": "ceo",
+	})
+	if completeResp.StatusCode != http.StatusOK {
+		t.Fatalf("complete status=%d body=%s", completeResp.StatusCode, raw)
+	}
+
+	updateResp, raw := postTask(map[string]any{
+		"action":     "reassign",
+		"id":         created.Task.ID,
+		"created_by": "ceo",
+		"owner":      "pm",
+		"task_type":  "process_research",
+	})
+	if updateResp.StatusCode != http.StatusConflict {
+		t.Fatalf("expected done-state update to rerun memory gate, got status=%d body=%s", updateResp.StatusCode, raw)
+	}
+	if !strings.Contains(string(raw), "memory workflow incomplete") {
+		t.Fatalf("expected memory workflow gate error, got %s", raw)
+	}
+}
+
 func TestBrokerTaskPlanInitializesMemoryWorkflow(t *testing.T) {
 	b := newTestBroker(t)
 	if err := b.StartOnPort(0); err != nil {
@@ -2692,6 +2754,31 @@ func TestBrokerTaskMemoryWorkflowReportsIdempotentNoOp(t *testing.T) {
 	}
 	if postWorkflow() {
 		t.Fatal("duplicate workflow event should report updated=false")
+	}
+}
+
+func TestBrokerTaskMemoryWorkflowBadRequestErrorsReturn400(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	body, _ := json.Marshal(map[string]any{
+		"event": "lookup",
+		"query": "missing task id",
+	})
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks/memory-workflow", b.Addr()), bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("record workflow: %v", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected bad request for malformed workflow event, got status=%d body=%s", resp.StatusCode, raw)
 	}
 }
 

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -2426,3 +2426,273 @@ func TestInFlightTasksExcludesCompletedStatus(t *testing.T) {
 		}
 	}
 }
+
+func TestBrokerMemoryWorkflowCompletionGateAndOverride(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	postTask := func(payload map[string]any) (*http.Response, []byte) {
+		t.Helper()
+		body, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks", b.Addr()), bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post task: %v", err)
+		}
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return resp, raw
+	}
+
+	createResp, raw := postTask(map[string]any{
+		"action":     "create",
+		"title":      "Research prior context for onboarding",
+		"created_by": "ceo",
+		"owner":      "ceo",
+		"task_type":  "research",
+	})
+	if createResp.StatusCode != http.StatusOK {
+		t.Fatalf("create status=%d body=%s", createResp.StatusCode, raw)
+	}
+	var created struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.Unmarshal(raw, &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+	if created.Task.MemoryWorkflow == nil || !created.Task.MemoryWorkflow.Required {
+		t.Fatalf("expected required workflow on create, got %+v", created.Task.MemoryWorkflow)
+	}
+
+	completeResp, raw := postTask(map[string]any{
+		"action":     "complete",
+		"id":         created.Task.ID,
+		"created_by": "ceo",
+	})
+	if completeResp.StatusCode != http.StatusConflict {
+		t.Fatalf("expected completion conflict, got status=%d body=%s", completeResp.StatusCode, raw)
+	}
+	if !strings.Contains(string(raw), "memory workflow incomplete") {
+		t.Fatalf("expected actionable memory workflow error, got %s", raw)
+	}
+
+	overrideResp, raw := postTask(map[string]any{
+		"action":                          "complete",
+		"id":                              created.Task.ID,
+		"created_by":                      "ceo",
+		"memory_workflow_override":        true,
+		"memory_workflow_override_reason": "Human reviewed and accepted missing memory evidence.",
+	})
+	if overrideResp.StatusCode != http.StatusOK {
+		t.Fatalf("override status=%d body=%s", overrideResp.StatusCode, raw)
+	}
+	var overridden struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.Unmarshal(raw, &overridden); err != nil {
+		t.Fatalf("decode override: %v", err)
+	}
+	if overridden.Task.Status != "done" {
+		t.Fatalf("expected done after override, got %+v", overridden.Task)
+	}
+	wf := overridden.Task.MemoryWorkflow
+	if wf == nil || wf.Status != MemoryWorkflowStatusOverridden || wf.Override == nil {
+		t.Fatalf("expected recorded override, got %+v", wf)
+	}
+	if wf.Override.Actor != "ceo" || wf.Override.Reason == "" || wf.Override.Timestamp == "" {
+		t.Fatalf("override metadata missing: %+v", wf.Override)
+	}
+}
+
+func TestBrokerTaskPlanInitializesMemoryWorkflow(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	body, _ := json.Marshal(map[string]any{
+		"channel":    "general",
+		"created_by": "ceo",
+		"tasks": []map[string]any{
+			{
+				"title":     "Map support process memory",
+				"assignee":  "ceo",
+				"task_type": "process-research",
+			},
+		},
+	})
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/task-plan", b.Addr()), bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("task plan request: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("task plan status=%d body=%s", resp.StatusCode, raw)
+	}
+	var result struct {
+		Tasks []teamTask `json:"tasks"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		t.Fatalf("decode task plan: %v", err)
+	}
+	if len(result.Tasks) != 1 || result.Tasks[0].MemoryWorkflow == nil || !result.Tasks[0].MemoryWorkflow.Required {
+		t.Fatalf("expected required workflow from task_plan, got %+v", result.Tasks)
+	}
+}
+
+func TestBrokerReusedTaskPreservesAndRecomputesMemoryWorkflow(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	postTask := func(payload map[string]any) teamTask {
+		t.Helper()
+		body, _ := json.Marshal(payload)
+		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks", b.Addr()), bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post task: %v", err)
+		}
+		defer resp.Body.Close()
+		raw, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("post task status=%d body=%s", resp.StatusCode, raw)
+		}
+		var result struct {
+			Task teamTask `json:"task"`
+		}
+		if err := json.Unmarshal(raw, &result); err != nil {
+			t.Fatalf("decode task: %v", err)
+		}
+		return result.Task
+	}
+
+	created := postTask(map[string]any{
+		"action":     "create",
+		"title":      "Research prior context for onboarding",
+		"created_by": "ceo",
+		"owner":      "ceo",
+		"task_type":  "research",
+		"thread_id":  "thread-1",
+	})
+	if _, found, err := b.RecordTaskMemoryCapture(created.ID, "ceo", MemoryWorkflowArtifact{Backend: "markdown", Source: "notebook", Path: "agents/ceo/notebook/onboarding.md"}); err != nil || !found {
+		t.Fatalf("record capture found=%v err=%v", found, err)
+	}
+
+	reused := postTask(map[string]any{
+		"action":     "create",
+		"title":      "Research prior context for onboarding",
+		"created_by": "ceo",
+		"owner":      "ceo",
+		"task_type":  "feature",
+		"thread_id":  "thread-1",
+	})
+	if reused.ID != created.ID {
+		t.Fatalf("expected task reuse, got new task %s vs %s", reused.ID, created.ID)
+	}
+	if reused.TaskType != "feature" {
+		t.Fatalf("expected reused task type recomputed to feature, got %+v", reused)
+	}
+	if reused.MemoryWorkflow == nil {
+		t.Fatalf("expected existing workflow preserved")
+	}
+	if reused.MemoryWorkflow.Required {
+		t.Fatalf("expected reused feature task not to require workflow, got %+v", reused.MemoryWorkflow)
+	}
+	if len(reused.MemoryWorkflow.Captures) != 1 {
+		t.Fatalf("expected prior captures preserved, got %+v", reused.MemoryWorkflow)
+	}
+}
+
+func TestBrokerTaskMemoryWorkflowAcceptsContextToolEventShape(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	createBody, _ := json.Marshal(map[string]any{
+		"action":     "create",
+		"title":      "Research prior context for renewal process",
+		"created_by": "ceo",
+		"owner":      "ceo",
+		"task_type":  "research",
+	})
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks", b.Addr()), bytes.NewReader(createBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create status=%d body=%s", resp.StatusCode, raw)
+	}
+	var created struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.Unmarshal(raw, &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+
+	workflowBody, _ := json.Marshal(map[string]any{
+		"event":   "lookup",
+		"task_id": created.Task.ID,
+		"actor":   "pm",
+		"query":   "renewal process",
+		"citations": []map[string]any{
+			{
+				"corpus":   "shared",
+				"backend":  "gbrain",
+				"source":   "compiled_truth",
+				"slug":     "process/passport-renewal",
+				"page_id":  42,
+				"chunk_id": 7,
+				"title":    "Passport renewal process",
+				"snippet":  "Use the updated renewal checklist.",
+			},
+		},
+	})
+	req, _ = http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks/memory-workflow", b.Addr()), bytes.NewReader(workflowBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("record workflow: %v", err)
+	}
+	raw, _ = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("workflow status=%d body=%s", resp.StatusCode, raw)
+	}
+	var updated struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.Unmarshal(raw, &updated); err != nil {
+		t.Fatalf("decode workflow: %v", err)
+	}
+	wf := updated.Task.MemoryWorkflow
+	if wf == nil || wf.Lookup.Status != MemoryWorkflowStepStatusSatisfied || len(wf.Citations) != 1 {
+		t.Fatalf("expected lookup workflow update, got %+v", wf)
+	}
+	citation := wf.Citations[0]
+	if citation.PageID != "42" || citation.ChunkID != "7" || citation.SourceID != "process/passport-renewal" {
+		t.Fatalf("expected normalized gbrain citation ids, got %+v", citation)
+	}
+}

--- a/internal/team/broker_tasks_test.go
+++ b/internal/team/broker_tasks_test.go
@@ -2589,8 +2589,8 @@ func TestBrokerReusedTaskPreservesAndRecomputesMemoryWorkflow(t *testing.T) {
 		"task_type":  "research",
 		"thread_id":  "thread-1",
 	})
-	if _, found, err := b.RecordTaskMemoryCapture(created.ID, "ceo", MemoryWorkflowArtifact{Backend: "markdown", Source: "notebook", Path: "agents/ceo/notebook/onboarding.md"}); err != nil || !found {
-		t.Fatalf("record capture found=%v err=%v", found, err)
+	if _, found, changed, err := b.RecordTaskMemoryCapture(created.ID, "ceo", MemoryWorkflowArtifact{Backend: "markdown", Source: "notebook", Path: "agents/ceo/notebook/onboarding.md"}); err != nil || !found || !changed {
+		t.Fatalf("record capture found=%v changed=%v err=%v", found, changed, err)
 	}
 
 	reused := postTask(map[string]any{
@@ -2615,6 +2615,83 @@ func TestBrokerReusedTaskPreservesAndRecomputesMemoryWorkflow(t *testing.T) {
 	}
 	if len(reused.MemoryWorkflow.Captures) != 1 {
 		t.Fatalf("expected prior captures preserved, got %+v", reused.MemoryWorkflow)
+	}
+}
+
+func TestBrokerTaskMemoryWorkflowReportsIdempotentNoOp(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	createBody, _ := json.Marshal(map[string]any{
+		"action":     "create",
+		"title":      "Research prior context for onboarding",
+		"created_by": "ceo",
+		"owner":      "ceo",
+		"task_type":  "research",
+	})
+	req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks", b.Addr()), bytes.NewReader(createBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create status=%d body=%s", resp.StatusCode, raw)
+	}
+	var created struct {
+		Task teamTask `json:"task"`
+	}
+	if err := json.Unmarshal(raw, &created); err != nil {
+		t.Fatalf("decode create: %v", err)
+	}
+
+	workflowBody, _ := json.Marshal(map[string]any{
+		"event":   "lookup",
+		"task_id": created.Task.ID,
+		"actor":   "pm",
+		"query":   "onboarding context",
+		"citations": []map[string]any{
+			{
+				"backend": "markdown",
+				"source":  "notebook",
+				"path":    "agents/pm/notebook/onboarding.md",
+				"title":   "Onboarding",
+			},
+		},
+	})
+	postWorkflow := func() bool {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/tasks/memory-workflow", b.Addr()), bytes.NewReader(workflowBody))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("record workflow: %v", err)
+		}
+		raw, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("workflow status=%d body=%s", resp.StatusCode, raw)
+		}
+		var result struct {
+			Updated bool `json:"updated"`
+		}
+		if err := json.Unmarshal(raw, &result); err != nil {
+			t.Fatalf("decode workflow: %v", err)
+		}
+		return result.Updated
+	}
+	if !postWorkflow() {
+		t.Fatal("first workflow event should update state")
+	}
+	if postWorkflow() {
+		t.Fatal("duplicate workflow event should report updated=false")
 	}
 }
 

--- a/internal/team/context_harness_eval_test.go
+++ b/internal/team/context_harness_eval_test.go
@@ -1,0 +1,449 @@
+package team
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+type contextHarnessEvalFixture struct {
+	Scenario          string `json:"scenario"`
+	TaskType          string `json:"task_type"`
+	LookupQuery       string `json:"lookup_query"`
+	RetrievalContract struct {
+		RequiredCapabilities  []string `json:"required_capabilities"`
+		RequiresSemanticIndex bool     `json:"requires_semantic_index"`
+		RequiresExternalNet   bool     `json:"requires_external_network"`
+	} `json:"retrieval_contract"`
+	Runs []passportProcessEvalRun `json:"runs"`
+}
+
+type passportProcessEvalRun struct {
+	ID                             string   `json:"id"`
+	Prompt                         string   `json:"prompt"`
+	AgentSlug                      string   `json:"agent_slug"`
+	NotebookPath                   string   `json:"notebook_path"`
+	WikiPath                       string   `json:"wiki_path"`
+	OfficialSource                 string   `json:"official_source"`
+	MustStartWithoutPriorArtifacts bool     `json:"must_start_without_prior_artifacts"`
+	ExpectedPriorCitations         []string `json:"expected_prior_citations"`
+	PromotionSkipReason            string   `json:"promotion_skip_reason"`
+}
+
+type contextHarnessEvalEvent struct {
+	RunID        string
+	Tool         string
+	Path         string
+	Citations    []string
+	SkipReason   string
+	Capabilities []string
+}
+
+type contextHarnessEvalRunner struct {
+	t             *testing.T
+	worker        *WikiWorker
+	events        []contextHarnessEvalEvent
+	workflowTasks map[string]*teamTask
+}
+
+func TestContextHarnessPassportProcessEvalRequiresPriorArtifactBeforeResearch(t *testing.T) {
+	fixture := loadContextHarnessEvalFixture(t)
+	if len(fixture.Runs) != 2 {
+		t.Fatalf("fixture must contain exactly two runs, got %d", len(fixture.Runs))
+	}
+
+	worker, _, _, teardown := newStartedWorker(t)
+	defer teardown()
+	runner := &contextHarnessEvalRunner{
+		t:             t,
+		worker:        worker,
+		workflowTasks: make(map[string]*teamTask),
+	}
+
+	for _, run := range fixture.Runs {
+		runner.runPassportProcessTask(fixture.LookupQuery, run)
+	}
+
+	first := fixture.Runs[0]
+	second := fixture.Runs[1]
+	assertFirstRunCapturesPromotesAndCites(t, runner.events, first)
+	assertSecondRunCitesPriorArtifactsBeforeResearch(t, runner.events, second)
+	assertPromotedRunMemoryWorkflowSatisfied(t, runner.workflowTasks[first.ID], first)
+	assertSecondRunMemoryWorkflowRecordedPriorCitations(t, runner.workflowTasks[second.ID], second)
+}
+
+func TestContextHarnessPassportProcessEvalDoesNotRequireSemanticSearch(t *testing.T) {
+	fixture := loadContextHarnessEvalFixture(t)
+	if fixture.RetrievalContract.RequiresSemanticIndex {
+		t.Fatal("passport-process eval must pass on the markdown harness without a semantic index")
+	}
+	if fixture.RetrievalContract.RequiresExternalNet {
+		t.Fatal("passport-process eval must not make live network calls")
+	}
+
+	banned := []string{"vector", "rrf", "embedding", "embeddings", "semantic", "pgvector"}
+	for _, capability := range fixture.RetrievalContract.RequiredCapabilities {
+		normalized := strings.ToLower(capability)
+		for _, term := range banned {
+			if strings.Contains(normalized, term) {
+				t.Fatalf("required capability %q must not require %s on this branch", capability, term)
+			}
+		}
+	}
+}
+
+func (r *contextHarnessEvalRunner) runPassportProcessTask(query string, run passportProcessEvalRun) {
+	r.t.Helper()
+	task := newPassportProcessEvalWorkflowTask(run)
+	r.workflowTasks[run.ID] = task
+
+	prior := r.literalContextLookup(run.ID, query)
+	priorPaths := citationPaths(prior)
+	recordMemoryWorkflowLookup(task, run.AgentSlug, query, prior, evalTimestamp("01"))
+	if run.MustStartWithoutPriorArtifacts && len(priorPaths) != 0 {
+		r.t.Fatalf("%s should start without prior artifacts, got %v", run.ID, priorPaths)
+	}
+
+	if len(run.ExpectedPriorCitations) > 0 {
+		for _, want := range run.ExpectedPriorCitations {
+			if !slices.Contains(priorPaths, want) {
+				r.t.Fatalf("%s lookup missing prior artifact %q; got %v", run.ID, want, priorPaths)
+			}
+		}
+		r.events = append(r.events, contextHarnessEvalEvent{
+			RunID:     run.ID,
+			Tool:      "context_cite",
+			Citations: append([]string(nil), run.ExpectedPriorCitations...),
+		})
+	}
+
+	r.events = append(r.events, contextHarnessEvalEvent{
+		RunID: run.ID,
+		Tool:  "fresh_research",
+		Path:  run.OfficialSource,
+	})
+
+	notebookContent := passportProcessNotebookContent(run, query)
+	if _, _, err := r.worker.NotebookWrite(context.Background(), run.AgentSlug, run.NotebookPath, notebookContent, "create", "eval: capture passport process note"); err != nil {
+		r.t.Fatalf("%s capture notebook: %v", run.ID, err)
+	}
+	recordMemoryWorkflowCapture(task, run.AgentSlug, MemoryWorkflowArtifact{
+		Backend: "markdown",
+		Source:  "notebook",
+		Path:    run.NotebookPath,
+		Title:   "Passport Process",
+	}, evalTimestamp("02"))
+	r.events = append(r.events, contextHarnessEvalEvent{
+		RunID: run.ID,
+		Tool:  "context_capture",
+		Path:  run.NotebookPath,
+	})
+
+	if run.WikiPath != "" {
+		promotion := &Promotion{
+			ID:         "eval-" + run.ID,
+			SourceSlug: run.AgentSlug,
+			SourcePath: run.NotebookPath,
+			TargetPath: run.WikiPath,
+			Rationale:  "Promote reusable passport process research for repeated-task recall.",
+		}
+		if _, err := r.worker.Repo().ApplyPromotion(context.Background(), promotion, "human"); err != nil {
+			r.t.Fatalf("%s promote notebook: %v", run.ID, err)
+		}
+		recordMemoryWorkflowPromotion(task, run.AgentSlug, MemoryWorkflowArtifact{
+			Backend:     "markdown",
+			Source:      "promotion",
+			Path:        run.WikiPath,
+			PromotionID: promotion.ID,
+			Title:       "Passport Process",
+		}, evalTimestamp("03"))
+		r.events = append(r.events, contextHarnessEvalEvent{
+			RunID: run.ID,
+			Tool:  "context_promote",
+			Path:  run.WikiPath,
+		})
+	} else {
+		if strings.TrimSpace(run.PromotionSkipReason) == "" {
+			r.t.Fatalf("%s must either promote or record an explicit promotion skip reason", run.ID)
+		}
+		// MemoryWorkflow currently records promotion artifacts, while this eval
+		// keeps the explicit skip reason in the deterministic trace.
+		r.events = append(r.events, contextHarnessEvalEvent{
+			RunID:      run.ID,
+			Tool:       "context_promote",
+			SkipReason: run.PromotionSkipReason,
+		})
+	}
+
+	citations := []string{run.NotebookPath}
+	if run.WikiPath != "" {
+		citations = append(citations, run.WikiPath)
+	}
+	citations = append(citations, run.ExpectedPriorCitations...)
+	r.events = append(r.events, contextHarnessEvalEvent{
+		RunID:     run.ID,
+		Tool:      "final_answer",
+		Citations: uniqueStrings(citations),
+	})
+}
+
+func (r *contextHarnessEvalRunner) literalContextLookup(runID, query string) []ContextCitation {
+	r.t.Helper()
+	r.events = append(r.events, contextHarnessEvalEvent{
+		RunID:        runID,
+		Tool:         "context_lookup",
+		Capabilities: []string{"literal_notebook_search", "literal_wiki_search"},
+	})
+
+	var citations []ContextCitation
+	slugs, err := r.worker.AgentsWithNotebooks()
+	if err != nil {
+		r.t.Fatalf("%s list notebooks: %v", runID, err)
+	}
+	for _, slug := range slugs {
+		hits, err := r.worker.NotebookSearch(slug, query)
+		if err != nil {
+			r.t.Fatalf("%s notebook search %s: %v", runID, slug, err)
+		}
+		for _, hit := range hits {
+			citations = append(citations, ContextCitation{
+				Backend:   "markdown",
+				Source:    "notebook",
+				Path:      hit.Path,
+				LineStart: hit.Line,
+				LineEnd:   hit.Line,
+				Snippet:   hit.Snippet,
+			})
+		}
+	}
+
+	hits, err := searchArticles(r.worker.Repo(), query)
+	if err != nil {
+		r.t.Fatalf("%s wiki search: %v", runID, err)
+	}
+	for _, hit := range hits {
+		citations = append(citations, ContextCitation{
+			Backend:   "markdown",
+			Source:    "wiki",
+			Path:      hit.Path,
+			LineStart: hit.Line,
+			LineEnd:   hit.Line,
+			Snippet:   hit.Snippet,
+		})
+	}
+	return uniqueCitationsByPath(citations)
+}
+
+func assertFirstRunCapturesPromotesAndCites(t *testing.T, events []contextHarnessEvalEvent, run passportProcessEvalRun) {
+	t.Helper()
+	for _, tool := range []string{"context_lookup", "fresh_research", "context_capture", "context_promote", "final_answer"} {
+		if eventIndex(events, run.ID, tool) < 0 {
+			t.Fatalf("%s missing %s event in trace: %+v", run.ID, tool, events)
+		}
+	}
+	if eventIndex(events, run.ID, "context_lookup") > eventIndex(events, run.ID, "fresh_research") {
+		t.Fatalf("%s must search prior memory before fresh research", run.ID)
+	}
+	final := eventByTool(t, events, run.ID, "final_answer")
+	if !slices.Contains(final.Citations, run.NotebookPath) {
+		t.Fatalf("%s final answer must cite captured notebook %q; got %v", run.ID, run.NotebookPath, final.Citations)
+	}
+	if !slices.Contains(final.Citations, run.WikiPath) {
+		t.Fatalf("%s final answer must cite promoted wiki artifact %q; got %v", run.ID, run.WikiPath, final.Citations)
+	}
+}
+
+func assertSecondRunCitesPriorArtifactsBeforeResearch(t *testing.T, events []contextHarnessEvalEvent, run passportProcessEvalRun) {
+	t.Helper()
+	citeIdx := eventIndex(events, run.ID, "context_cite")
+	researchIdx := eventIndex(events, run.ID, "fresh_research")
+	if citeIdx < 0 {
+		t.Fatalf("%s must cite prior context before fresh research", run.ID)
+	}
+	if researchIdx < 0 {
+		t.Fatalf("%s missing fresh research event", run.ID)
+	}
+	if citeIdx > researchIdx {
+		t.Fatalf("%s cited prior context after fresh research; cite=%d research=%d", run.ID, citeIdx, researchIdx)
+	}
+	cite := eventByTool(t, events, run.ID, "context_cite")
+	final := eventByTool(t, events, run.ID, "final_answer")
+	for _, want := range run.ExpectedPriorCitations {
+		if !slices.Contains(cite.Citations, want) {
+			t.Fatalf("%s context_cite missing prior artifact %q; got %v", run.ID, want, cite.Citations)
+		}
+		if !slices.Contains(final.Citations, want) {
+			t.Fatalf("%s final answer missing prior artifact %q; got %v", run.ID, want, final.Citations)
+		}
+	}
+	promote := eventByTool(t, events, run.ID, "context_promote")
+	if strings.TrimSpace(promote.SkipReason) == "" && strings.TrimSpace(promote.Path) == "" {
+		t.Fatalf("%s must either promote a new artifact or record an explicit skip reason", run.ID)
+	}
+}
+
+func assertPromotedRunMemoryWorkflowSatisfied(t *testing.T, task *teamTask, run passportProcessEvalRun) {
+	t.Helper()
+	if task == nil || task.MemoryWorkflow == nil {
+		t.Fatalf("%s missing memory workflow", run.ID)
+	}
+	wf := task.MemoryWorkflow
+	if !wf.Required || wf.Status != MemoryWorkflowStatusSatisfied {
+		t.Fatalf("%s workflow should be satisfied after lookup/capture/promote, got %+v", run.ID, wf)
+	}
+	if wf.Lookup.Status != MemoryWorkflowStepStatusSatisfied || wf.Capture.Status != MemoryWorkflowStepStatusSatisfied || wf.Promote.Status != MemoryWorkflowStepStatusSatisfied {
+		t.Fatalf("%s workflow steps not satisfied: %+v", run.ID, wf)
+	}
+	if !memoryWorkflowHasCapturePath(wf, run.NotebookPath) {
+		t.Fatalf("%s workflow missing notebook capture %q: %+v", run.ID, run.NotebookPath, wf.Captures)
+	}
+	if !memoryWorkflowHasPromotionPath(wf, run.WikiPath) {
+		t.Fatalf("%s workflow missing wiki promotion %q: %+v", run.ID, run.WikiPath, wf.Promotions)
+	}
+}
+
+func assertSecondRunMemoryWorkflowRecordedPriorCitations(t *testing.T, task *teamTask, run passportProcessEvalRun) {
+	t.Helper()
+	if task == nil || task.MemoryWorkflow == nil {
+		t.Fatalf("%s missing memory workflow", run.ID)
+	}
+	for _, want := range run.ExpectedPriorCitations {
+		if !memoryWorkflowHasCitationPath(task.MemoryWorkflow, want) {
+			t.Fatalf("%s workflow missing prior citation %q: %+v", run.ID, want, task.MemoryWorkflow.Citations)
+		}
+	}
+}
+
+func passportProcessNotebookContent(run passportProcessEvalRun, query string) string {
+	return "# Passport Process\n\n" +
+		"Reusable task memory for the passport process.\n\n" +
+		"## Current Notes\n\n" +
+		"- Lookup query: " + query + "\n" +
+		"- Task prompt: " + run.Prompt + "\n" +
+		"- Official source fixture: " + run.OfficialSource + "\n\n" +
+		"---\n\n" +
+		"## Timeline\n\n" +
+		"- 2026-04-30: Captured deterministic process-research notes without live network calls.\n"
+}
+
+func newPassportProcessEvalWorkflowTask(run passportProcessEvalRun) *teamTask {
+	task := &teamTask{
+		ID:        run.ID,
+		Channel:   "eval",
+		Title:     run.Prompt,
+		Details:   "Repeated passport process research should consult prior notebook/wiki artifacts before fresh research.",
+		Owner:     run.AgentSlug,
+		Status:    "in_progress",
+		CreatedBy: "eval",
+		TaskType:  "process_research",
+		CreatedAt: evalTimestamp("00"),
+		UpdatedAt: evalTimestamp("00"),
+	}
+	syncTaskMemoryWorkflow(task, evalTimestamp("00"))
+	return task
+}
+
+func loadContextHarnessEvalFixture(t *testing.T) contextHarnessEvalFixture {
+	t.Helper()
+	path := filepath.Join("testdata", "context_harness", "passport_process_repeated.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", path, err)
+	}
+	var fixture contextHarnessEvalFixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("decode fixture %s: %v", path, err)
+	}
+	if fixture.Scenario == "" || fixture.LookupQuery == "" || fixture.TaskType == "" {
+		t.Fatalf("fixture missing required scenario metadata: %+v", fixture)
+	}
+	return fixture
+}
+
+func citationPaths(citations []ContextCitation) []string {
+	paths := make([]string, 0, len(citations))
+	for _, citation := range citations {
+		if citation.Path != "" {
+			paths = append(paths, citation.Path)
+		}
+	}
+	return uniqueStrings(paths)
+}
+
+func uniqueCitationsByPath(citations []ContextCitation) []ContextCitation {
+	seen := make(map[string]bool, len(citations))
+	out := make([]ContextCitation, 0, len(citations))
+	for _, citation := range citations {
+		key := citation.Path
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, citation)
+	}
+	return out
+}
+
+func memoryWorkflowHasCitationPath(wf *MemoryWorkflow, path string) bool {
+	if wf == nil {
+		return false
+	}
+	for _, citation := range wf.Citations {
+		if citation.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func memoryWorkflowHasPromotionPath(wf *MemoryWorkflow, path string) bool {
+	if wf == nil {
+		return false
+	}
+	for _, artifact := range wf.Promotions {
+		if artifact.Path == path && !artifact.Missing {
+			return true
+		}
+	}
+	return false
+}
+
+func memoryWorkflowHasCapturePath(wf *MemoryWorkflow, path string) bool {
+	if wf == nil {
+		return false
+	}
+	for _, artifact := range wf.Captures {
+		if artifact.Path == path && !artifact.Missing {
+			return true
+		}
+	}
+	return false
+}
+
+func eventIndex(events []contextHarnessEvalEvent, runID, tool string) int {
+	for i, event := range events {
+		if event.RunID == runID && event.Tool == tool {
+			return i
+		}
+	}
+	return -1
+}
+
+func eventByTool(t *testing.T, events []contextHarnessEvalEvent, runID, tool string) contextHarnessEvalEvent {
+	t.Helper()
+	for _, event := range events {
+		if event.RunID == runID && event.Tool == tool {
+			return event
+		}
+	}
+	t.Fatalf("%s missing %s event in trace: %+v", runID, tool, events)
+	return contextHarnessEvalEvent{}
+}
+
+func evalTimestamp(suffix string) string {
+	return "2026-04-30T10:00:" + suffix + "Z"
+}

--- a/internal/team/context_harness_eval_test.go
+++ b/internal/team/context_harness_eval_test.go
@@ -65,14 +65,14 @@ func TestContextHarnessPassportProcessEvalRequiresPriorArtifactBeforeResearch(t 
 	}
 
 	for _, run := range fixture.Runs {
-		runner.runPassportProcessTask(fixture.LookupQuery, run)
+		runner.runPassportProcessTask(fixture.LookupQuery, fixture.TaskType, run)
 	}
 
 	first := fixture.Runs[0]
 	second := fixture.Runs[1]
 	assertFirstRunCapturesPromotesAndCites(t, runner.events, first)
 	assertSecondRunCitesPriorArtifactsBeforeResearch(t, runner.events, second)
-	assertPromotedRunMemoryWorkflowSatisfied(t, runner.workflowTasks[first.ID], first)
+	assertFirstRunMemoryWorkflowCapturedAndPromoted(t, runner.workflowTasks[first.ID], first)
 	assertSecondRunMemoryWorkflowRecordedPriorCitations(t, runner.workflowTasks[second.ID], second)
 }
 
@@ -96,9 +96,9 @@ func TestContextHarnessPassportProcessEvalDoesNotRequireSemanticSearch(t *testin
 	}
 }
 
-func (r *contextHarnessEvalRunner) runPassportProcessTask(query string, run passportProcessEvalRun) {
+func (r *contextHarnessEvalRunner) runPassportProcessTask(query, taskType string, run passportProcessEvalRun) {
 	r.t.Helper()
-	task := newPassportProcessEvalWorkflowTask(run)
+	task := newPassportProcessEvalWorkflowTask(run, taskType)
 	r.workflowTasks[run.ID] = task
 
 	prior := r.literalContextLookup(run.ID, query)
@@ -170,8 +170,11 @@ func (r *contextHarnessEvalRunner) runPassportProcessTask(query string, run pass
 		if strings.TrimSpace(run.PromotionSkipReason) == "" {
 			r.t.Fatalf("%s must either promote or record an explicit promotion skip reason", run.ID)
 		}
-		// MemoryWorkflow currently records promotion artifacts, while this eval
-		// keeps the explicit skip reason in the deterministic trace.
+		recordMemoryWorkflowPromotion(task, run.AgentSlug, MemoryWorkflowArtifact{
+			Backend: "markdown",
+			Source:  "skip",
+			Title:   run.PromotionSkipReason,
+		}, evalTimestamp("03"))
 		r.events = append(r.events, contextHarnessEvalEvent{
 			RunID:      run.ID,
 			Tool:       "context_promote",
@@ -286,17 +289,20 @@ func assertSecondRunCitesPriorArtifactsBeforeResearch(t *testing.T, events []con
 	}
 }
 
-func assertPromotedRunMemoryWorkflowSatisfied(t *testing.T, task *teamTask, run passportProcessEvalRun) {
+func assertFirstRunMemoryWorkflowCapturedAndPromoted(t *testing.T, task *teamTask, run passportProcessEvalRun) {
 	t.Helper()
 	if task == nil || task.MemoryWorkflow == nil {
 		t.Fatalf("%s missing memory workflow", run.ID)
 	}
 	wf := task.MemoryWorkflow
-	if !wf.Required || wf.Status != MemoryWorkflowStatusSatisfied {
-		t.Fatalf("%s workflow should be satisfied after lookup/capture/promote, got %+v", run.ID, wf)
+	if !wf.Required {
+		t.Fatalf("%s workflow should be required, got %+v", run.ID, wf)
 	}
-	if wf.Lookup.Status != MemoryWorkflowStepStatusSatisfied || wf.Capture.Status != MemoryWorkflowStepStatusSatisfied || wf.Promote.Status != MemoryWorkflowStepStatusSatisfied {
-		t.Fatalf("%s workflow steps not satisfied: %+v", run.ID, wf)
+	if wf.Lookup.Status != MemoryWorkflowStepStatusPending || len(wf.Citations) != 0 {
+		t.Fatalf("%s zero-hit prior lookup should remain pending, got %+v", run.ID, wf)
+	}
+	if wf.Capture.Status != MemoryWorkflowStepStatusSatisfied || wf.Promote.Status != MemoryWorkflowStepStatusSatisfied {
+		t.Fatalf("%s capture/promote steps not satisfied: %+v", run.ID, wf)
 	}
 	if !memoryWorkflowHasCapturePath(wf, run.NotebookPath) {
 		t.Fatalf("%s workflow missing notebook capture %q: %+v", run.ID, run.NotebookPath, wf.Captures)
@@ -330,7 +336,11 @@ func passportProcessNotebookContent(run passportProcessEvalRun, query string) st
 		"- 2026-04-30: Captured deterministic process-research notes without live network calls.\n"
 }
 
-func newPassportProcessEvalWorkflowTask(run passportProcessEvalRun) *teamTask {
+func newPassportProcessEvalWorkflowTask(run passportProcessEvalRun, taskType string) *teamTask {
+	taskType = strings.TrimSpace(taskType)
+	if taskType == "" {
+		taskType = "process_research"
+	}
 	task := &teamTask{
 		ID:        run.ID,
 		Channel:   "eval",
@@ -339,7 +349,7 @@ func newPassportProcessEvalWorkflowTask(run passportProcessEvalRun) *teamTask {
 		Owner:     run.AgentSlug,
 		Status:    "in_progress",
 		CreatedBy: "eval",
-		TaskType:  "process_research",
+		TaskType:  taskType,
 		CreatedAt: evalTimestamp("00"),
 		UpdatedAt: evalTimestamp("00"),
 	}

--- a/internal/team/context_harness_eval_test.go
+++ b/internal/team/context_harness_eval_test.go
@@ -323,6 +323,9 @@ func assertSecondRunMemoryWorkflowRecordedPriorCitations(t *testing.T, task *tea
 			t.Fatalf("%s workflow missing prior citation %q: %+v", run.ID, want, task.MemoryWorkflow.Citations)
 		}
 	}
+	if task.MemoryWorkflow.Lookup.Status != MemoryWorkflowStepStatusSatisfied || task.MemoryWorkflow.Lookup.CompletedAt == "" {
+		t.Fatalf("%s workflow lookup step not satisfied after prior citations: %+v", run.ID, task.MemoryWorkflow.Lookup)
+	}
 }
 
 func passportProcessNotebookContent(run passportProcessEvalRun, query string) string {

--- a/internal/team/context_harness_eval_test.go
+++ b/internal/team/context_harness_eval_test.go
@@ -171,9 +171,10 @@ func (r *contextHarnessEvalRunner) runPassportProcessTask(query, taskType string
 			r.t.Fatalf("%s must either promote or record an explicit promotion skip reason", run.ID)
 		}
 		recordMemoryWorkflowPromotion(task, run.AgentSlug, MemoryWorkflowArtifact{
-			Backend: "markdown",
-			Source:  "skip",
-			Title:   run.PromotionSkipReason,
+			Backend:    "markdown",
+			Source:     "skip",
+			Title:      run.PromotionSkipReason,
+			SkipReason: run.PromotionSkipReason,
 		}, evalTimestamp("03"))
 		r.events = append(r.events, contextHarnessEvalEvent{
 			RunID:      run.ID,

--- a/internal/team/memory_backend.go
+++ b/internal/team/memory_backend.go
@@ -43,12 +43,19 @@ type memoryBackend interface {
 }
 
 type ScopedMemoryHit struct {
-	Scope      string
-	Backend    string
-	Identifier string
-	Title      string
-	Snippet    string
-	OwnerSlug  string
+	Scope      string   `json:"scope,omitempty"`
+	Backend    string   `json:"backend,omitempty"`
+	Identifier string   `json:"identifier,omitempty"`
+	Title      string   `json:"title,omitempty"`
+	Snippet    string   `json:"snippet,omitempty"`
+	OwnerSlug  string   `json:"owner_slug,omitempty"`
+	Slug       string   `json:"slug,omitempty"`
+	PageID     int      `json:"page_id,omitempty"`
+	ChunkID    int      `json:"chunk_id,omitempty"`
+	ChunkIndex int      `json:"chunk_index,omitempty"`
+	Source     string   `json:"source,omitempty"`
+	Score      *float64 `json:"score,omitempty"`
+	Stale      *bool    `json:"stale,omitempty"`
 }
 
 type SharedMemoryWrite struct {
@@ -233,27 +240,41 @@ func (gbrainMemoryBackend) QueryShared(ctx context.Context, query string, limit 
 			continue
 		}
 		seen[result.Slug] = struct{}{}
-		title := strings.TrimSpace(result.Title)
-		if title == "" {
-			title = strings.TrimSpace(result.Slug)
-		}
-		snippet := strings.TrimSpace(strings.ReplaceAll(result.ChunkText, "\n", " "))
-		if snippet == "" {
-			snippet = "Relevant context found in the brain."
-		}
-		hits = append(hits, ScopedMemoryHit{
-			Scope:      "shared",
-			Backend:    config.MemoryBackendGBrain,
-			Identifier: strings.TrimSpace(result.Slug),
-			Title:      title,
-			Snippet:    truncate(snippet, 220),
-			OwnerSlug:  inferSharedMemoryOwner(strings.TrimSpace(result.Slug), snippet),
-		})
+		hits = append(hits, scopedMemoryHitFromGBrainResult(result))
 		if len(hits) >= limit && limit > 0 {
 			break
 		}
 	}
 	return hits, nil
+}
+
+func scopedMemoryHitFromGBrainResult(result gbrain.SearchResult) ScopedMemoryHit {
+	title := strings.TrimSpace(result.Title)
+	if title == "" {
+		title = strings.TrimSpace(result.Slug)
+	}
+	snippet := strings.TrimSpace(strings.ReplaceAll(result.ChunkText, "\n", " "))
+	if snippet == "" {
+		snippet = "Relevant context found in the brain."
+	}
+	score := result.Score
+	stale := result.Stale
+	slug := strings.TrimSpace(result.Slug)
+	return ScopedMemoryHit{
+		Scope:      "shared",
+		Backend:    config.MemoryBackendGBrain,
+		Identifier: slug,
+		Title:      title,
+		Snippet:    truncate(snippet, 220),
+		OwnerSlug:  inferSharedMemoryOwner(slug, snippet),
+		Slug:       slug,
+		PageID:     result.PageID,
+		ChunkID:    result.ChunkID,
+		ChunkIndex: result.ChunkIndex,
+		Source:     strings.TrimSpace(result.ChunkSource),
+		Score:      &score,
+		Stale:      &stale,
+	}
 }
 func (gbrainMemoryBackend) WriteShared(ctx context.Context, note SharedMemoryWrite) (string, error) {
 	slug := slugify(firstNonEmpty(note.Key, note.Title, note.Content))

--- a/internal/team/memory_backend.go
+++ b/internal/team/memory_backend.go
@@ -229,6 +229,9 @@ func (gbrainMemoryBackend) FetchBrief(ctx context.Context, notification string) 
 	return strings.Join(lines, "\n")
 }
 func (gbrainMemoryBackend) QueryShared(ctx context.Context, query string, limit int) ([]ScopedMemoryHit, error) {
+	if limit <= 0 {
+		limit = 5
+	}
 	results, err := gbrain.Query(ctx, query, limit)
 	if err != nil {
 		return nil, err

--- a/internal/team/memory_backend_test.go
+++ b/internal/team/memory_backend_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/gbrain"
 )
 
 func TestResolveMemoryBackendStatusNoNexFallsBackToMarkdown(t *testing.T) {
@@ -110,5 +111,29 @@ func TestInferSharedMemoryOwnerFromGBrainSlug(t *testing.T) {
 	owner := inferSharedMemoryOwner("wuphf-shared--pm--launch-brief--20260416-120000", "")
 	if owner != "pm" {
 		t.Fatalf("expected owner pm from gbrain slug, got %q", owner)
+	}
+}
+
+func TestScopedMemoryHitFromGBrainResultPreservesCitationFields(t *testing.T) {
+	hit := scopedMemoryHitFromGBrainResult(gbrain.SearchResult{
+		Slug:        "people/nazz",
+		PageID:      42,
+		Title:       "Nazz",
+		ChunkText:   "Relevant compiled truth",
+		ChunkSource: "compiled_truth",
+		ChunkID:     7,
+		ChunkIndex:  3,
+		Score:       0.91,
+		Stale:       true,
+	})
+
+	if hit.Identifier != "people/nazz" || hit.Slug != "people/nazz" || hit.PageID != 42 || hit.ChunkID != 7 || hit.ChunkIndex != 3 || hit.Source != "compiled_truth" {
+		t.Fatalf("gbrain citation fields were not preserved: %+v", hit)
+	}
+	if hit.Score == nil || *hit.Score != 0.91 {
+		t.Fatalf("expected score 0.91, got %+v", hit.Score)
+	}
+	if hit.Stale == nil || !*hit.Stale {
+		t.Fatalf("expected stale=true, got %+v", hit.Stale)
 	}
 }

--- a/internal/team/memory_workflow.go
+++ b/internal/team/memory_workflow.go
@@ -692,13 +692,16 @@ func appendContextCitation(citations *[]ContextCitation, citation ContextCitatio
 }
 
 func contextCitationHasEvidence(citation ContextCitation) bool {
-	return strings.TrimSpace(citation.SourceID) != "" ||
+	return strings.TrimSpace(citation.Source) != "" ||
+		strings.TrimSpace(citation.SourceID) != "" ||
 		strings.TrimSpace(citation.Path) != "" ||
 		strings.TrimSpace(citation.PageID) != "" ||
 		strings.TrimSpace(citation.ChunkID) != "" ||
 		strings.TrimSpace(citation.SourceURL) != "" ||
 		strings.TrimSpace(citation.Title) != "" ||
-		strings.TrimSpace(citation.Snippet) != ""
+		strings.TrimSpace(citation.Snippet) != "" ||
+		citation.LineStart > 0 ||
+		citation.LineEnd > 0
 }
 
 func appendMemoryWorkflowArtifact(artifacts *[]MemoryWorkflowArtifact, artifact MemoryWorkflowArtifact) bool {
@@ -784,8 +787,12 @@ func contextCitationKey(citation ContextCitation) string {
 		citation.PageID,
 		citation.ChunkID,
 		citation.SourceURL,
-		fmt.Sprintf("%d", citation.LineStart),
-		fmt.Sprintf("%d", citation.LineEnd),
+	}
+	if citation.LineStart > 0 {
+		parts = append(parts, fmt.Sprintf("%d", citation.LineStart))
+	}
+	if citation.LineEnd > 0 {
+		parts = append(parts, fmt.Sprintf("%d", citation.LineEnd))
 	}
 	key := strings.Trim(strings.Join(parts, "|"), "|")
 	if key == "" {

--- a/internal/team/memory_workflow.go
+++ b/internal/team/memory_workflow.go
@@ -1,0 +1,906 @@
+package team
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type MemoryWorkflowStep string
+
+const (
+	MemoryWorkflowStepLookup  MemoryWorkflowStep = "lookup"
+	MemoryWorkflowStepCapture MemoryWorkflowStep = "capture"
+	MemoryWorkflowStepPromote MemoryWorkflowStep = "promote"
+)
+
+const (
+	MemoryWorkflowStatusNotRequired = "not_required"
+	MemoryWorkflowStatusPending     = "pending"
+	MemoryWorkflowStatusSatisfied   = "satisfied"
+	MemoryWorkflowStatusOverridden  = "overridden"
+)
+
+const (
+	MemoryWorkflowStepStatusPending   = "pending"
+	MemoryWorkflowStepStatusSatisfied = "satisfied"
+)
+
+// ContextCitation is the backend-neutral citation shape used by the context
+// harness. It is intentionally broad enough for markdown, Nex, and GBrain
+// sources without making any one backend canonical.
+type ContextCitation struct {
+	Backend     string   `json:"backend,omitempty"`
+	Source      string   `json:"source,omitempty"`
+	SourceID    string   `json:"source_id,omitempty"`
+	Path        string   `json:"path,omitempty"`
+	PageID      string   `json:"page_id,omitempty"`
+	ChunkID     string   `json:"chunk_id,omitempty"`
+	SourceURL   string   `json:"source_url,omitempty"`
+	LineStart   int      `json:"line_start,omitempty"`
+	LineEnd     int      `json:"line_end,omitempty"`
+	Title       string   `json:"title,omitempty"`
+	Snippet     string   `json:"snippet,omitempty"`
+	Score       *float64 `json:"score,omitempty"`
+	Stale       *bool    `json:"stale,omitempty"`
+	RetrievedAt string   `json:"retrieved_at,omitempty"`
+}
+
+func (c *ContextCitation) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Backend     string   `json:"backend"`
+		Source      string   `json:"source"`
+		Corpus      string   `json:"corpus"`
+		SourceID    any      `json:"source_id"`
+		Identifier  any      `json:"identifier"`
+		Slug        string   `json:"slug"`
+		Path        string   `json:"path"`
+		PageID      any      `json:"page_id"`
+		ChunkID     any      `json:"chunk_id"`
+		SourceURL   string   `json:"source_url"`
+		Line        int      `json:"line"`
+		LineStart   int      `json:"line_start"`
+		LineEnd     int      `json:"line_end"`
+		Title       string   `json:"title"`
+		Snippet     string   `json:"snippet"`
+		Score       *float64 `json:"score"`
+		Stale       *bool    `json:"stale"`
+		RetrievedAt string   `json:"retrieved_at"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	lineStart := raw.LineStart
+	if lineStart == 0 {
+		lineStart = raw.Line
+	}
+	lineEnd := raw.LineEnd
+	if lineEnd == 0 {
+		lineEnd = lineStart
+	}
+	*c = ContextCitation{
+		Backend:     strings.TrimSpace(raw.Backend),
+		Source:      firstNonEmptyString(strings.TrimSpace(raw.Source), strings.TrimSpace(raw.Corpus)),
+		SourceID:    firstNonEmptyString(jsonScalarString(raw.SourceID), jsonScalarString(raw.Identifier), strings.TrimSpace(raw.Slug)),
+		Path:        strings.TrimSpace(raw.Path),
+		PageID:      jsonScalarString(raw.PageID),
+		ChunkID:     jsonScalarString(raw.ChunkID),
+		SourceURL:   strings.TrimSpace(raw.SourceURL),
+		LineStart:   lineStart,
+		LineEnd:     lineEnd,
+		Title:       strings.TrimSpace(raw.Title),
+		Snippet:     strings.TrimSpace(raw.Snippet),
+		Score:       raw.Score,
+		Stale:       raw.Stale,
+		RetrievedAt: strings.TrimSpace(raw.RetrievedAt),
+	}
+	return nil
+}
+
+type MemoryWorkflowArtifact struct {
+	Backend      string `json:"backend,omitempty"`
+	Source       string `json:"source,omitempty"`
+	Path         string `json:"path,omitempty"`
+	PageID       string `json:"page_id,omitempty"`
+	PromotionID  string `json:"promotion_id,omitempty"`
+	EntityKind   string `json:"entity_kind,omitempty"`
+	EntitySlug   string `json:"entity_slug,omitempty"`
+	PlaybookSlug string `json:"playbook_slug,omitempty"`
+	Title        string `json:"title,omitempty"`
+	Snippet      string `json:"snippet,omitempty"`
+	CommitSHA    string `json:"commit_sha,omitempty"`
+	State        string `json:"state,omitempty"`
+	RecordedAt   string `json:"recorded_at,omitempty"`
+	UpdatedAt    string `json:"updated_at,omitempty"`
+	Missing      bool   `json:"missing,omitempty"`
+}
+
+func jsonScalarString(value any) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return strings.TrimSpace(typed)
+	case json.Number:
+		return strings.TrimSpace(typed.String())
+	case float64:
+		if typed == float64(int64(typed)) {
+			return fmt.Sprintf("%.0f", typed)
+		}
+		return strings.TrimSpace(fmt.Sprintf("%g", typed))
+	case int:
+		return fmt.Sprintf("%d", typed)
+	case int64:
+		return fmt.Sprintf("%d", typed)
+	case uint64:
+		return fmt.Sprintf("%d", typed)
+	default:
+		return strings.TrimSpace(fmt.Sprint(typed))
+	}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+type MemoryWorkflowStepState struct {
+	Required    bool   `json:"required,omitempty"`
+	Status      string `json:"status,omitempty"`
+	Actor       string `json:"actor,omitempty"`
+	Query       string `json:"query,omitempty"`
+	CompletedAt string `json:"completed_at,omitempty"`
+	UpdatedAt   string `json:"updated_at,omitempty"`
+	Count       int    `json:"count,omitempty"`
+}
+
+type MemoryWorkflowOverride struct {
+	Actor     string `json:"actor"`
+	Reason    string `json:"reason"`
+	Timestamp string `json:"timestamp"`
+}
+
+type MemoryWorkflow struct {
+	Required          bool                     `json:"required"`
+	Status            string                   `json:"status,omitempty"`
+	RequirementReason string                   `json:"requirement_reason,omitempty"`
+	RequiredSteps     []MemoryWorkflowStep     `json:"required_steps,omitempty"`
+	Lookup            MemoryWorkflowStepState  `json:"lookup,omitempty"`
+	Capture           MemoryWorkflowStepState  `json:"capture,omitempty"`
+	Promote           MemoryWorkflowStepState  `json:"promote,omitempty"`
+	Citations         []ContextCitation        `json:"citations,omitempty"`
+	Captures          []MemoryWorkflowArtifact `json:"captures,omitempty"`
+	Promotions        []MemoryWorkflowArtifact `json:"promotions,omitempty"`
+	Override          *MemoryWorkflowOverride  `json:"override,omitempty"`
+	CreatedAt         string                   `json:"created_at,omitempty"`
+	UpdatedAt         string                   `json:"updated_at,omitempty"`
+	CompletedAt       string                   `json:"completed_at,omitempty"`
+}
+
+type memoryWorkflowRequirement struct {
+	Required bool
+	Steps    []MemoryWorkflowStep
+	Reason   string
+}
+
+func memoryWorkflowRequirementForTask(task *teamTask) memoryWorkflowRequirement {
+	if task == nil {
+		return memoryWorkflowRequirement{Reason: "task is nil"}
+	}
+	taskType := normalizeMemoryWorkflowTaskType(task.TaskType)
+	pipelineID := normalizeMemoryWorkflowTaskType(task.PipelineID)
+	text := strings.ToLower(strings.TrimSpace(strings.Join([]string{
+		task.Channel,
+		task.Title,
+		task.Details,
+		task.TaskType,
+		task.PipelineID,
+	}, " ")))
+
+	requiredSteps := []MemoryWorkflowStep{
+		MemoryWorkflowStepLookup,
+		MemoryWorkflowStepCapture,
+		MemoryWorkflowStepPromote,
+	}
+	switch {
+	case isProcessResearchTaskType(taskType) || isProcessResearchTaskType(pipelineID):
+		return memoryWorkflowRequirement{
+			Required: true,
+			Steps:    requiredSteps,
+			Reason:   "process research requires prior context lookup, durable capture, and promotion",
+		}
+	case taskType == "research" && researchTaskNeedsPriorContext(text):
+		return memoryWorkflowRequirement{
+			Required: true,
+			Steps:    requiredSteps,
+			Reason:   "research task asks for prior organizational context",
+		}
+	default:
+		return memoryWorkflowRequirement{Reason: "task does not require the durable memory workflow"}
+	}
+}
+
+func normalizeMemoryWorkflowTaskType(raw string) string {
+	raw = strings.TrimSpace(strings.ToLower(raw))
+	raw = strings.NewReplacer("-", "_", " ", "_").Replace(raw)
+	for strings.Contains(raw, "__") {
+		raw = strings.ReplaceAll(raw, "__", "_")
+	}
+	return strings.Trim(raw, "_")
+}
+
+func isProcessResearchTaskType(taskType string) bool {
+	switch normalizeMemoryWorkflowTaskType(taskType) {
+	case "process_research", "context_research", "memory_research", "knowledge_research":
+		return true
+	default:
+		return false
+	}
+}
+
+func researchTaskNeedsPriorContext(text string) bool {
+	if text == "" {
+		return false
+	}
+	return containsAnyTaskFragment(text,
+		"prior context", "previous context", "existing context", "org context",
+		"organizational context", "shared context", "context harness",
+		"memory", "notebook", "wiki", "gbrain", "nex",
+		"past work", "previous work", "prior work", "history", "historical",
+		"lesson learned", "lessons learned", "playbook", "canonical",
+		"source of truth", "past decision", "prior decision", "previous decision",
+		"process research", "process-research", "promotion", "promote",
+	)
+}
+
+func syncTaskMemoryWorkflow(task *teamTask, timestamp string) {
+	if task == nil {
+		return
+	}
+	requirement := memoryWorkflowRequirementForTask(task)
+	timestamp = memoryWorkflowTimestamp(timestamp, task)
+	if !requirement.Required && task.MemoryWorkflow == nil {
+		return
+	}
+	if task.MemoryWorkflow == nil {
+		task.MemoryWorkflow = &MemoryWorkflow{
+			CreatedAt: timestamp,
+		}
+	}
+	changed := false
+	wf := task.MemoryWorkflow
+	if wf.CreatedAt == "" {
+		wf.CreatedAt = timestamp
+		changed = true
+	}
+	if wf.Required != requirement.Required {
+		wf.Required = requirement.Required
+		changed = true
+	}
+	if wf.RequirementReason != requirement.Reason {
+		wf.RequirementReason = requirement.Reason
+		changed = true
+	}
+	if !memoryWorkflowStepsEqual(wf.RequiredSteps, requirement.Steps) {
+		wf.RequiredSteps = append([]MemoryWorkflowStep(nil), requirement.Steps...)
+		changed = true
+	}
+	if requirement.Required {
+		changed = ensureMemoryWorkflowStepRequirements(wf) || changed
+	} else {
+		changed = clearMemoryWorkflowStepRequirements(wf) || changed
+	}
+	changed = refreshMemoryWorkflowStatus(wf, timestamp) || changed
+	if changed {
+		wf.UpdatedAt = timestamp
+	}
+}
+
+func ensureMemoryWorkflowForRecording(task *teamTask, timestamp string) *MemoryWorkflow {
+	if task == nil {
+		return nil
+	}
+	timestamp = memoryWorkflowTimestamp(timestamp, task)
+	if task.MemoryWorkflow == nil {
+		task.MemoryWorkflow = &MemoryWorkflow{
+			Status:    MemoryWorkflowStatusNotRequired,
+			CreatedAt: timestamp,
+			UpdatedAt: timestamp,
+		}
+	}
+	syncTaskMemoryWorkflow(task, timestamp)
+	return task.MemoryWorkflow
+}
+
+func ensureMemoryWorkflowStepRequirements(wf *MemoryWorkflow) bool {
+	if wf == nil {
+		return false
+	}
+	changed := false
+	if !wf.Lookup.Required {
+		wf.Lookup.Required = true
+		changed = true
+	}
+	if !wf.Capture.Required {
+		wf.Capture.Required = true
+		changed = true
+	}
+	if !wf.Promote.Required {
+		wf.Promote.Required = true
+		changed = true
+	}
+	if wf.Lookup.Status == "" {
+		wf.Lookup.Status = MemoryWorkflowStepStatusPending
+		changed = true
+	}
+	if wf.Capture.Status == "" {
+		wf.Capture.Status = MemoryWorkflowStepStatusPending
+		changed = true
+	}
+	if wf.Promote.Status == "" {
+		wf.Promote.Status = MemoryWorkflowStepStatusPending
+		changed = true
+	}
+	return changed
+}
+
+func clearMemoryWorkflowStepRequirements(wf *MemoryWorkflow) bool {
+	if wf == nil {
+		return false
+	}
+	changed := false
+	if wf.Lookup.Required {
+		wf.Lookup.Required = false
+		changed = true
+	}
+	if wf.Capture.Required {
+		wf.Capture.Required = false
+		changed = true
+	}
+	if wf.Promote.Required {
+		wf.Promote.Required = false
+		changed = true
+	}
+	return changed
+}
+
+func refreshMemoryWorkflowStatus(wf *MemoryWorkflow, timestamp string) bool {
+	if wf == nil {
+		return false
+	}
+	oldStatus := wf.Status
+	oldCompletedAt := wf.CompletedAt
+	if wf.Override != nil {
+		wf.Status = MemoryWorkflowStatusOverridden
+		if wf.CompletedAt == "" {
+			wf.CompletedAt = wf.Override.Timestamp
+		}
+		return oldStatus != wf.Status || oldCompletedAt != wf.CompletedAt
+	}
+	refreshMemoryWorkflowStepStatus(wf, MemoryWorkflowStepLookup)
+	refreshMemoryWorkflowStepStatus(wf, MemoryWorkflowStepCapture)
+	refreshMemoryWorkflowStepStatus(wf, MemoryWorkflowStepPromote)
+	if !wf.Required {
+		wf.Status = MemoryWorkflowStatusNotRequired
+		wf.CompletedAt = ""
+		return oldStatus != wf.Status || oldCompletedAt != wf.CompletedAt
+	}
+	if memoryWorkflowStepSatisfied(wf.Lookup) &&
+		memoryWorkflowStepSatisfied(wf.Capture) &&
+		memoryWorkflowStepSatisfied(wf.Promote) {
+		wf.Status = MemoryWorkflowStatusSatisfied
+		if wf.CompletedAt == "" {
+			wf.CompletedAt = timestamp
+		}
+	} else {
+		wf.Status = MemoryWorkflowStatusPending
+		wf.CompletedAt = ""
+	}
+	return oldStatus != wf.Status || oldCompletedAt != wf.CompletedAt
+}
+
+func refreshMemoryWorkflowStepStatus(wf *MemoryWorkflow, step MemoryWorkflowStep) {
+	if wf == nil {
+		return
+	}
+	switch step {
+	case MemoryWorkflowStepLookup:
+		if wf.Lookup.CompletedAt != "" || wf.Lookup.Query != "" || len(wf.Citations) > 0 {
+			wf.Lookup.Status = MemoryWorkflowStepStatusSatisfied
+			wf.Lookup.Count = len(wf.Citations)
+			return
+		}
+		if wf.Lookup.Required {
+			wf.Lookup.Status = MemoryWorkflowStepStatusPending
+		}
+	case MemoryWorkflowStepCapture:
+		count := countPresentArtifacts(wf.Captures)
+		if count > 0 || wf.Capture.CompletedAt != "" {
+			wf.Capture.Status = MemoryWorkflowStepStatusSatisfied
+			wf.Capture.Count = count
+			return
+		}
+		if wf.Capture.Required {
+			wf.Capture.Status = MemoryWorkflowStepStatusPending
+			wf.Capture.Count = 0
+		}
+	case MemoryWorkflowStepPromote:
+		count := countPresentArtifacts(wf.Promotions)
+		if count > 0 || wf.Promote.CompletedAt != "" {
+			wf.Promote.Status = MemoryWorkflowStepStatusSatisfied
+			wf.Promote.Count = count
+			return
+		}
+		if wf.Promote.Required {
+			wf.Promote.Status = MemoryWorkflowStepStatusPending
+			wf.Promote.Count = 0
+		}
+	}
+}
+
+func countPresentArtifacts(artifacts []MemoryWorkflowArtifact) int {
+	count := 0
+	for _, artifact := range artifacts {
+		if !artifact.Missing {
+			count++
+		}
+	}
+	return count
+}
+
+func memoryWorkflowStepSatisfied(step MemoryWorkflowStepState) bool {
+	return step.Status == MemoryWorkflowStepStatusSatisfied || step.CompletedAt != ""
+}
+
+func taskMemoryWorkflowReady(task *teamTask) bool {
+	if task == nil {
+		return true
+	}
+	syncTaskMemoryWorkflow(task, "")
+	wf := task.MemoryWorkflow
+	if wf == nil || !wf.Required {
+		return true
+	}
+	return wf.Status == MemoryWorkflowStatusSatisfied || wf.Status == MemoryWorkflowStatusOverridden
+}
+
+func missingMemoryWorkflowSteps(task *teamTask) []MemoryWorkflowStep {
+	if task == nil || task.MemoryWorkflow == nil || !task.MemoryWorkflow.Required {
+		return nil
+	}
+	wf := task.MemoryWorkflow
+	var missing []MemoryWorkflowStep
+	if !memoryWorkflowStepSatisfied(wf.Lookup) {
+		missing = append(missing, MemoryWorkflowStepLookup)
+	}
+	if !memoryWorkflowStepSatisfied(wf.Capture) {
+		missing = append(missing, MemoryWorkflowStepCapture)
+	}
+	if !memoryWorkflowStepSatisfied(wf.Promote) {
+		missing = append(missing, MemoryWorkflowStepPromote)
+	}
+	return missing
+}
+
+func applyMemoryWorkflowCompletionGate(task *teamTask, actor, reason string, override bool, timestamp string) error {
+	if task == nil {
+		return nil
+	}
+	syncTaskMemoryWorkflow(task, timestamp)
+	wf := task.MemoryWorkflow
+	if wf == nil || !wf.Required {
+		return nil
+	}
+	if taskMemoryWorkflowReady(task) {
+		return nil
+	}
+	if !override {
+		missing := missingMemoryWorkflowSteps(task)
+		return fmt.Errorf("memory workflow incomplete: task requires context %s before completion; provide memory_workflow_override with a human reason to override", joinMemoryWorkflowSteps(missing))
+	}
+	actor = strings.TrimSpace(actor)
+	reason = strings.TrimSpace(reason)
+	if actor == "" {
+		return fmt.Errorf("memory workflow override requires actor")
+	}
+	if reason == "" {
+		return fmt.Errorf("memory workflow override requires reason")
+	}
+	timestamp = memoryWorkflowTimestamp(timestamp, task)
+	wf.Override = &MemoryWorkflowOverride{
+		Actor:     actor,
+		Reason:    reason,
+		Timestamp: timestamp,
+	}
+	wf.Status = MemoryWorkflowStatusOverridden
+	wf.CompletedAt = timestamp
+	wf.UpdatedAt = timestamp
+	return nil
+}
+
+func joinMemoryWorkflowSteps(steps []MemoryWorkflowStep) string {
+	if len(steps) == 0 {
+		return "workflow"
+	}
+	parts := make([]string, 0, len(steps))
+	for _, step := range steps {
+		parts = append(parts, string(step))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func recordMemoryWorkflowLookup(task *teamTask, actor, query string, citations []ContextCitation, timestamp string) bool {
+	wf := ensureMemoryWorkflowForRecording(task, timestamp)
+	if wf == nil {
+		return false
+	}
+	timestamp = memoryWorkflowTimestamp(timestamp, task)
+	changed := false
+	actor = strings.TrimSpace(actor)
+	query = strings.TrimSpace(query)
+	if wf.Lookup.Actor != actor {
+		wf.Lookup.Actor = actor
+		changed = true
+	}
+	if wf.Lookup.Query != query {
+		wf.Lookup.Query = query
+		changed = true
+	}
+	if wf.Lookup.CompletedAt == "" {
+		wf.Lookup.CompletedAt = timestamp
+		changed = true
+	}
+	if wf.Lookup.UpdatedAt != timestamp {
+		wf.Lookup.UpdatedAt = timestamp
+		changed = true
+	}
+	for _, citation := range citations {
+		normalized := normalizeContextCitation(citation, timestamp)
+		if appendContextCitation(&wf.Citations, normalized) {
+			changed = true
+		}
+	}
+	changed = refreshMemoryWorkflowStatus(wf, timestamp) || changed
+	if changed {
+		wf.UpdatedAt = timestamp
+	}
+	return changed
+}
+
+func recordMemoryWorkflowCapture(task *teamTask, actor string, artifact MemoryWorkflowArtifact, timestamp string) bool {
+	return recordMemoryWorkflowArtifact(task, actor, artifact, timestamp, MemoryWorkflowStepCapture)
+}
+
+func recordMemoryWorkflowPromotion(task *teamTask, actor string, artifact MemoryWorkflowArtifact, timestamp string) bool {
+	return recordMemoryWorkflowArtifact(task, actor, artifact, timestamp, MemoryWorkflowStepPromote)
+}
+
+func recordMemoryWorkflowArtifact(task *teamTask, actor string, artifact MemoryWorkflowArtifact, timestamp string, step MemoryWorkflowStep) bool {
+	wf := ensureMemoryWorkflowForRecording(task, timestamp)
+	if wf == nil {
+		return false
+	}
+	timestamp = memoryWorkflowTimestamp(timestamp, task)
+	artifact = normalizeMemoryWorkflowArtifact(artifact, timestamp)
+	if memoryWorkflowArtifactKey(artifact) == "" {
+		return false
+	}
+	changed := false
+	switch step {
+	case MemoryWorkflowStepCapture:
+		if appendMemoryWorkflowArtifact(&wf.Captures, artifact) {
+			changed = true
+		}
+		if wf.Capture.Actor != strings.TrimSpace(actor) {
+			wf.Capture.Actor = strings.TrimSpace(actor)
+			changed = true
+		}
+		if wf.Capture.CompletedAt == "" {
+			wf.Capture.CompletedAt = timestamp
+			changed = true
+		}
+		if wf.Capture.UpdatedAt != timestamp {
+			wf.Capture.UpdatedAt = timestamp
+			changed = true
+		}
+	case MemoryWorkflowStepPromote:
+		if appendMemoryWorkflowArtifact(&wf.Promotions, artifact) {
+			changed = true
+		}
+		if wf.Promote.Actor != strings.TrimSpace(actor) {
+			wf.Promote.Actor = strings.TrimSpace(actor)
+			changed = true
+		}
+		if wf.Promote.CompletedAt == "" {
+			wf.Promote.CompletedAt = timestamp
+			changed = true
+		}
+		if wf.Promote.UpdatedAt != timestamp {
+			wf.Promote.UpdatedAt = timestamp
+			changed = true
+		}
+	}
+	changed = refreshMemoryWorkflowStatus(wf, timestamp) || changed
+	if changed {
+		wf.UpdatedAt = timestamp
+	}
+	return changed
+}
+
+func appendContextCitation(citations *[]ContextCitation, citation ContextCitation) bool {
+	for i := range *citations {
+		if contextCitationKey((*citations)[i]) == contextCitationKey(citation) {
+			merged := mergeContextCitation((*citations)[i], citation)
+			changed := !contextCitationEqual((*citations)[i], merged)
+			(*citations)[i] = merged
+			return changed
+		}
+	}
+	*citations = append(*citations, citation)
+	return true
+}
+
+func appendMemoryWorkflowArtifact(artifacts *[]MemoryWorkflowArtifact, artifact MemoryWorkflowArtifact) bool {
+	if memoryWorkflowArtifactKey(artifact) == "" {
+		return false
+	}
+	for i := range *artifacts {
+		if memoryWorkflowArtifactKey((*artifacts)[i]) == memoryWorkflowArtifactKey(artifact) {
+			merged := mergeMemoryWorkflowArtifact((*artifacts)[i], artifact)
+			changed := (*artifacts)[i] != merged
+			(*artifacts)[i] = merged
+			return changed
+		}
+	}
+	*artifacts = append(*artifacts, artifact)
+	return true
+}
+
+func contextCitationEqual(a, b ContextCitation) bool {
+	if a.Backend != b.Backend || a.Source != b.Source || a.SourceID != b.SourceID ||
+		a.Path != b.Path || a.PageID != b.PageID || a.ChunkID != b.ChunkID ||
+		a.SourceURL != b.SourceURL || a.LineStart != b.LineStart || a.LineEnd != b.LineEnd ||
+		a.Title != b.Title || a.Snippet != b.Snippet || a.RetrievedAt != b.RetrievedAt {
+		return false
+	}
+	if (a.Score == nil) != (b.Score == nil) || (a.Stale == nil) != (b.Stale == nil) {
+		return false
+	}
+	if a.Score != nil && b.Score != nil && *a.Score != *b.Score {
+		return false
+	}
+	if a.Stale != nil && b.Stale != nil && *a.Stale != *b.Stale {
+		return false
+	}
+	return true
+}
+
+func normalizeContextCitation(citation ContextCitation, timestamp string) ContextCitation {
+	citation.Backend = strings.TrimSpace(citation.Backend)
+	citation.Source = strings.TrimSpace(citation.Source)
+	citation.SourceID = strings.TrimSpace(citation.SourceID)
+	citation.Path = strings.TrimSpace(citation.Path)
+	citation.PageID = strings.TrimSpace(citation.PageID)
+	citation.ChunkID = strings.TrimSpace(citation.ChunkID)
+	citation.SourceURL = strings.TrimSpace(citation.SourceURL)
+	citation.Title = strings.TrimSpace(citation.Title)
+	citation.Snippet = strings.TrimSpace(citation.Snippet)
+	if citation.RetrievedAt == "" {
+		citation.RetrievedAt = timestamp
+	}
+	return citation
+}
+
+func normalizeMemoryWorkflowArtifact(artifact MemoryWorkflowArtifact, timestamp string) MemoryWorkflowArtifact {
+	artifact.Backend = strings.TrimSpace(artifact.Backend)
+	artifact.Source = strings.TrimSpace(artifact.Source)
+	artifact.Path = strings.TrimSpace(artifact.Path)
+	artifact.PageID = strings.TrimSpace(artifact.PageID)
+	artifact.PromotionID = strings.TrimSpace(artifact.PromotionID)
+	artifact.EntityKind = strings.TrimSpace(artifact.EntityKind)
+	artifact.EntitySlug = strings.TrimSpace(artifact.EntitySlug)
+	artifact.PlaybookSlug = strings.TrimSpace(artifact.PlaybookSlug)
+	artifact.Title = strings.TrimSpace(artifact.Title)
+	artifact.Snippet = strings.TrimSpace(artifact.Snippet)
+	artifact.CommitSHA = strings.TrimSpace(artifact.CommitSHA)
+	artifact.State = strings.TrimSpace(artifact.State)
+	if artifact.RecordedAt == "" {
+		artifact.RecordedAt = timestamp
+	}
+	if artifact.UpdatedAt == "" {
+		artifact.UpdatedAt = timestamp
+	}
+	return artifact
+}
+
+func contextCitationKey(citation ContextCitation) string {
+	parts := []string{
+		citation.Backend,
+		citation.Source,
+		citation.SourceID,
+		citation.Path,
+		citation.PageID,
+		citation.ChunkID,
+		citation.SourceURL,
+		fmt.Sprintf("%d", citation.LineStart),
+		fmt.Sprintf("%d", citation.LineEnd),
+	}
+	key := strings.Trim(strings.Join(parts, "|"), "|")
+	if key == "" {
+		key = strings.TrimSpace(citation.Title + "|" + citation.Snippet)
+	}
+	return key
+}
+
+func memoryWorkflowArtifactKey(artifact MemoryWorkflowArtifact) string {
+	parts := []string{
+		artifact.Backend,
+		artifact.Source,
+		artifact.Path,
+		artifact.PageID,
+		artifact.PromotionID,
+		artifact.EntityKind,
+		artifact.EntitySlug,
+		artifact.PlaybookSlug,
+	}
+	return strings.Trim(strings.Join(parts, "|"), "|")
+}
+
+func mergeContextCitation(existing, incoming ContextCitation) ContextCitation {
+	if existing.Backend == "" {
+		existing.Backend = incoming.Backend
+	}
+	if existing.Source == "" {
+		existing.Source = incoming.Source
+	}
+	if existing.SourceID == "" {
+		existing.SourceID = incoming.SourceID
+	}
+	if existing.Path == "" {
+		existing.Path = incoming.Path
+	}
+	if existing.PageID == "" {
+		existing.PageID = incoming.PageID
+	}
+	if existing.ChunkID == "" {
+		existing.ChunkID = incoming.ChunkID
+	}
+	if existing.SourceURL == "" {
+		existing.SourceURL = incoming.SourceURL
+	}
+	if existing.LineStart == 0 {
+		existing.LineStart = incoming.LineStart
+	}
+	if existing.LineEnd == 0 {
+		existing.LineEnd = incoming.LineEnd
+	}
+	if existing.Title == "" {
+		existing.Title = incoming.Title
+	}
+	if existing.Snippet == "" {
+		existing.Snippet = incoming.Snippet
+	}
+	if existing.Score == nil {
+		existing.Score = incoming.Score
+	}
+	if existing.Stale == nil {
+		existing.Stale = incoming.Stale
+	}
+	if existing.RetrievedAt == "" {
+		existing.RetrievedAt = incoming.RetrievedAt
+	}
+	return existing
+}
+
+func mergeMemoryWorkflowArtifact(existing, incoming MemoryWorkflowArtifact) MemoryWorkflowArtifact {
+	if existing.Backend == "" {
+		existing.Backend = incoming.Backend
+	}
+	if existing.Source == "" {
+		existing.Source = incoming.Source
+	}
+	if existing.Path == "" {
+		existing.Path = incoming.Path
+	}
+	if existing.PageID == "" {
+		existing.PageID = incoming.PageID
+	}
+	if existing.PromotionID == "" {
+		existing.PromotionID = incoming.PromotionID
+	}
+	if existing.EntityKind == "" {
+		existing.EntityKind = incoming.EntityKind
+	}
+	if existing.EntitySlug == "" {
+		existing.EntitySlug = incoming.EntitySlug
+	}
+	if existing.PlaybookSlug == "" {
+		existing.PlaybookSlug = incoming.PlaybookSlug
+	}
+	if existing.Title == "" {
+		existing.Title = incoming.Title
+	}
+	if existing.Snippet == "" {
+		existing.Snippet = incoming.Snippet
+	}
+	if existing.CommitSHA == "" {
+		existing.CommitSHA = incoming.CommitSHA
+	}
+	if incoming.State != "" {
+		existing.State = incoming.State
+	}
+	if existing.RecordedAt == "" {
+		existing.RecordedAt = incoming.RecordedAt
+	}
+	if incoming.UpdatedAt != "" {
+		existing.UpdatedAt = incoming.UpdatedAt
+	}
+	existing.Missing = incoming.Missing
+	return existing
+}
+
+func memoryWorkflowStepsEqual(a, b []MemoryWorkflowStep) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func memoryWorkflowTimestamp(timestamp string, task *teamTask) string {
+	timestamp = strings.TrimSpace(timestamp)
+	if timestamp != "" {
+		return timestamp
+	}
+	if task != nil {
+		if strings.TrimSpace(task.UpdatedAt) != "" {
+			return strings.TrimSpace(task.UpdatedAt)
+		}
+		if strings.TrimSpace(task.CreatedAt) != "" {
+			return strings.TrimSpace(task.CreatedAt)
+		}
+	}
+	return time.Now().UTC().Format(time.RFC3339)
+}
+
+func cloneTeamTaskForRollback(task teamTask) teamTask {
+	cloned := task
+	if task.DependsOn != nil {
+		cloned.DependsOn = append([]string(nil), task.DependsOn...)
+	}
+	cloned.MemoryWorkflow = cloneMemoryWorkflow(task.MemoryWorkflow)
+	return cloned
+}
+
+func cloneMemoryWorkflow(wf *MemoryWorkflow) *MemoryWorkflow {
+	if wf == nil {
+		return nil
+	}
+	cloned := *wf
+	if wf.RequiredSteps != nil {
+		cloned.RequiredSteps = append([]MemoryWorkflowStep(nil), wf.RequiredSteps...)
+	}
+	if wf.Citations != nil {
+		cloned.Citations = append([]ContextCitation(nil), wf.Citations...)
+	}
+	if wf.Captures != nil {
+		cloned.Captures = append([]MemoryWorkflowArtifact(nil), wf.Captures...)
+	}
+	if wf.Promotions != nil {
+		cloned.Promotions = append([]MemoryWorkflowArtifact(nil), wf.Promotions...)
+	}
+	if wf.Override != nil {
+		override := *wf.Override
+		cloned.Override = &override
+	}
+	return &cloned
+}

--- a/internal/team/memory_workflow.go
+++ b/internal/team/memory_workflow.go
@@ -177,6 +177,7 @@ type MemoryWorkflow struct {
 	Captures          []MemoryWorkflowArtifact `json:"captures,omitempty"`
 	Promotions        []MemoryWorkflowArtifact `json:"promotions,omitempty"`
 	Override          *MemoryWorkflowOverride  `json:"override,omitempty"`
+	PartialErrors     []string                 `json:"partial_errors,omitempty"`
 	CreatedAt         string                   `json:"created_at,omitempty"`
 	UpdatedAt         string                   `json:"updated_at,omitempty"`
 	CompletedAt       string                   `json:"completed_at,omitempty"`
@@ -375,6 +376,9 @@ func refreshMemoryWorkflowStatus(wf *MemoryWorkflow, timestamp string) bool {
 	}
 	oldStatus := wf.Status
 	oldCompletedAt := wf.CompletedAt
+	oldLookup := wf.Lookup
+	oldCapture := wf.Capture
+	oldPromote := wf.Promote
 	if wf.Override != nil {
 		wf.Status = MemoryWorkflowStatusOverridden
 		if wf.CompletedAt == "" {
@@ -401,7 +405,11 @@ func refreshMemoryWorkflowStatus(wf *MemoryWorkflow, timestamp string) bool {
 		wf.Status = MemoryWorkflowStatusPending
 		wf.CompletedAt = ""
 	}
-	return oldStatus != wf.Status || oldCompletedAt != wf.CompletedAt
+	return oldStatus != wf.Status ||
+		oldCompletedAt != wf.CompletedAt ||
+		oldLookup != wf.Lookup ||
+		oldCapture != wf.Capture ||
+		oldPromote != wf.Promote
 }
 
 func refreshMemoryWorkflowStepStatus(wf *MemoryWorkflow, step MemoryWorkflowStep) {
@@ -410,19 +418,32 @@ func refreshMemoryWorkflowStepStatus(wf *MemoryWorkflow, step MemoryWorkflowStep
 	}
 	switch step {
 	case MemoryWorkflowStepLookup:
-		if wf.Lookup.CompletedAt != "" || wf.Lookup.Query != "" || len(wf.Citations) > 0 {
+		if len(wf.Citations) > 0 {
 			wf.Lookup.Status = MemoryWorkflowStepStatusSatisfied
 			wf.Lookup.Count = len(wf.Citations)
 			return
 		}
+		wf.Lookup.CompletedAt = ""
+		wf.Lookup.Count = 0
 		if wf.Lookup.Required {
 			wf.Lookup.Status = MemoryWorkflowStepStatusPending
 		}
 	case MemoryWorkflowStepCapture:
 		count := countPresentArtifacts(wf.Captures)
-		if count > 0 || wf.Capture.CompletedAt != "" {
+		if count > 0 {
 			wf.Capture.Status = MemoryWorkflowStepStatusSatisfied
 			wf.Capture.Count = count
+			return
+		}
+		if hasMissingMemoryWorkflowArtifact(wf.Captures) {
+			wf.Capture.CompletedAt = ""
+			wf.Capture.Status = MemoryWorkflowStepStatusPending
+			wf.Capture.Count = 0
+			return
+		}
+		if wf.Capture.CompletedAt != "" {
+			wf.Capture.Status = MemoryWorkflowStepStatusSatisfied
+			wf.Capture.Count = 0
 			return
 		}
 		if wf.Capture.Required {
@@ -431,9 +452,20 @@ func refreshMemoryWorkflowStepStatus(wf *MemoryWorkflow, step MemoryWorkflowStep
 		}
 	case MemoryWorkflowStepPromote:
 		count := countPresentArtifacts(wf.Promotions)
-		if count > 0 || wf.Promote.CompletedAt != "" {
+		if count > 0 {
 			wf.Promote.Status = MemoryWorkflowStepStatusSatisfied
 			wf.Promote.Count = count
+			return
+		}
+		if hasMissingMemoryWorkflowArtifact(wf.Promotions) {
+			wf.Promote.CompletedAt = ""
+			wf.Promote.Status = MemoryWorkflowStepStatusPending
+			wf.Promote.Count = 0
+			return
+		}
+		if wf.Promote.CompletedAt != "" {
+			wf.Promote.Status = MemoryWorkflowStepStatusSatisfied
+			wf.Promote.Count = 0
 			return
 		}
 		if wf.Promote.Required {
@@ -453,8 +485,17 @@ func countPresentArtifacts(artifacts []MemoryWorkflowArtifact) int {
 	return count
 }
 
+func hasMissingMemoryWorkflowArtifact(artifacts []MemoryWorkflowArtifact) bool {
+	for _, artifact := range artifacts {
+		if artifact.Missing {
+			return true
+		}
+	}
+	return false
+}
+
 func memoryWorkflowStepSatisfied(step MemoryWorkflowStepState) bool {
-	return step.Status == MemoryWorkflowStepStatusSatisfied || step.CompletedAt != ""
+	return step.Status == MemoryWorkflowStepStatusSatisfied
 }
 
 func taskMemoryWorkflowReady(task *teamTask) bool {
@@ -541,30 +582,31 @@ func recordMemoryWorkflowLookup(task *teamTask, actor, query string, citations [
 	}
 	timestamp = memoryWorkflowTimestamp(timestamp, task)
 	changed := false
+	stepChanged := false
 	actor = strings.TrimSpace(actor)
 	query = strings.TrimSpace(query)
 	if wf.Lookup.Actor != actor {
 		wf.Lookup.Actor = actor
-		changed = true
+		stepChanged = true
 	}
 	if wf.Lookup.Query != query {
 		wf.Lookup.Query = query
-		changed = true
+		stepChanged = true
 	}
-	if wf.Lookup.CompletedAt == "" {
+	if len(citations) > 0 && wf.Lookup.CompletedAt == "" {
 		wf.Lookup.CompletedAt = timestamp
-		changed = true
-	}
-	if wf.Lookup.UpdatedAt != timestamp {
-		wf.Lookup.UpdatedAt = timestamp
-		changed = true
+		stepChanged = true
 	}
 	for _, citation := range citations {
 		normalized := normalizeContextCitation(citation, timestamp)
 		if appendContextCitation(&wf.Citations, normalized) {
-			changed = true
+			stepChanged = true
 		}
 	}
+	if stepChanged && wf.Lookup.UpdatedAt != timestamp {
+		wf.Lookup.UpdatedAt = timestamp
+	}
+	changed = stepChanged
 	changed = refreshMemoryWorkflowStatus(wf, timestamp) || changed
 	if changed {
 		wf.UpdatedAt = timestamp
@@ -591,40 +633,40 @@ func recordMemoryWorkflowArtifact(task *teamTask, actor string, artifact MemoryW
 		return false
 	}
 	changed := false
+	stepChanged := false
 	switch step {
 	case MemoryWorkflowStepCapture:
 		if appendMemoryWorkflowArtifact(&wf.Captures, artifact) {
-			changed = true
+			stepChanged = true
 		}
 		if wf.Capture.Actor != strings.TrimSpace(actor) {
 			wf.Capture.Actor = strings.TrimSpace(actor)
-			changed = true
+			stepChanged = true
 		}
 		if wf.Capture.CompletedAt == "" {
 			wf.Capture.CompletedAt = timestamp
-			changed = true
+			stepChanged = true
 		}
-		if wf.Capture.UpdatedAt != timestamp {
+		if stepChanged && wf.Capture.UpdatedAt != timestamp {
 			wf.Capture.UpdatedAt = timestamp
-			changed = true
 		}
 	case MemoryWorkflowStepPromote:
 		if appendMemoryWorkflowArtifact(&wf.Promotions, artifact) {
-			changed = true
+			stepChanged = true
 		}
 		if wf.Promote.Actor != strings.TrimSpace(actor) {
 			wf.Promote.Actor = strings.TrimSpace(actor)
-			changed = true
+			stepChanged = true
 		}
 		if wf.Promote.CompletedAt == "" {
 			wf.Promote.CompletedAt = timestamp
-			changed = true
+			stepChanged = true
 		}
-		if wf.Promote.UpdatedAt != timestamp {
+		if stepChanged && wf.Promote.UpdatedAt != timestamp {
 			wf.Promote.UpdatedAt = timestamp
-			changed = true
 		}
 	}
+	changed = stepChanged
 	changed = refreshMemoryWorkflowStatus(wf, timestamp) || changed
 	if changed {
 		wf.UpdatedAt = timestamp
@@ -798,6 +840,7 @@ func mergeContextCitation(existing, incoming ContextCitation) ContextCitation {
 }
 
 func mergeMemoryWorkflowArtifact(existing, incoming MemoryWorkflowArtifact) MemoryWorkflowArtifact {
+	before := existing
 	if existing.Backend == "" {
 		existing.Backend = incoming.Backend
 	}
@@ -837,7 +880,21 @@ func mergeMemoryWorkflowArtifact(existing, incoming MemoryWorkflowArtifact) Memo
 	if existing.RecordedAt == "" {
 		existing.RecordedAt = incoming.RecordedAt
 	}
-	if incoming.UpdatedAt != "" {
+	contentChanged := existing.Backend != before.Backend ||
+		existing.Source != before.Source ||
+		existing.Path != before.Path ||
+		existing.PageID != before.PageID ||
+		existing.PromotionID != before.PromotionID ||
+		existing.EntityKind != before.EntityKind ||
+		existing.EntitySlug != before.EntitySlug ||
+		existing.PlaybookSlug != before.PlaybookSlug ||
+		existing.Title != before.Title ||
+		existing.Snippet != before.Snippet ||
+		existing.CommitSHA != before.CommitSHA ||
+		existing.State != before.State ||
+		existing.RecordedAt != before.RecordedAt ||
+		existing.Missing != incoming.Missing
+	if incoming.UpdatedAt != "" && (existing.UpdatedAt == "" || contentChanged) {
 		existing.UpdatedAt = incoming.UpdatedAt
 	}
 	existing.Missing = incoming.Missing
@@ -897,6 +954,9 @@ func cloneMemoryWorkflow(wf *MemoryWorkflow) *MemoryWorkflow {
 	}
 	if wf.Promotions != nil {
 		cloned.Promotions = append([]MemoryWorkflowArtifact(nil), wf.Promotions...)
+	}
+	if wf.PartialErrors != nil {
+		cloned.PartialErrors = append([]string(nil), wf.PartialErrors...)
 	}
 	if wf.Override != nil {
 		override := *wf.Override

--- a/internal/team/memory_workflow.go
+++ b/internal/team/memory_workflow.go
@@ -676,6 +676,9 @@ func recordMemoryWorkflowArtifact(task *teamTask, actor string, artifact MemoryW
 }
 
 func appendContextCitation(citations *[]ContextCitation, citation ContextCitation) bool {
+	if !contextCitationHasEvidence(citation) {
+		return false
+	}
 	for i := range *citations {
 		if contextCitationKey((*citations)[i]) == contextCitationKey(citation) {
 			merged := mergeContextCitation((*citations)[i], citation)
@@ -686,6 +689,16 @@ func appendContextCitation(citations *[]ContextCitation, citation ContextCitatio
 	}
 	*citations = append(*citations, citation)
 	return true
+}
+
+func contextCitationHasEvidence(citation ContextCitation) bool {
+	return strings.TrimSpace(citation.SourceID) != "" ||
+		strings.TrimSpace(citation.Path) != "" ||
+		strings.TrimSpace(citation.PageID) != "" ||
+		strings.TrimSpace(citation.ChunkID) != "" ||
+		strings.TrimSpace(citation.SourceURL) != "" ||
+		strings.TrimSpace(citation.Title) != "" ||
+		strings.TrimSpace(citation.Snippet) != ""
 }
 
 func appendMemoryWorkflowArtifact(artifacts *[]MemoryWorkflowArtifact, artifact MemoryWorkflowArtifact) bool {

--- a/internal/team/memory_workflow.go
+++ b/internal/team/memory_workflow.go
@@ -108,6 +108,7 @@ type MemoryWorkflowArtifact struct {
 	EntitySlug   string `json:"entity_slug,omitempty"`
 	PlaybookSlug string `json:"playbook_slug,omitempty"`
 	Title        string `json:"title,omitempty"`
+	SkipReason   string `json:"skip_reason,omitempty"`
 	Snippet      string `json:"snippet,omitempty"`
 	CommitSHA    string `json:"commit_sha,omitempty"`
 	State        string `json:"state,omitempty"`
@@ -748,6 +749,7 @@ func normalizeMemoryWorkflowArtifact(artifact MemoryWorkflowArtifact, timestamp 
 	artifact.EntitySlug = strings.TrimSpace(artifact.EntitySlug)
 	artifact.PlaybookSlug = strings.TrimSpace(artifact.PlaybookSlug)
 	artifact.Title = strings.TrimSpace(artifact.Title)
+	artifact.SkipReason = strings.TrimSpace(artifact.SkipReason)
 	artifact.Snippet = strings.TrimSpace(artifact.Snippet)
 	artifact.CommitSHA = strings.TrimSpace(artifact.CommitSHA)
 	artifact.State = strings.TrimSpace(artifact.State)
@@ -789,6 +791,7 @@ func memoryWorkflowArtifactKey(artifact MemoryWorkflowArtifact) string {
 		artifact.EntityKind,
 		artifact.EntitySlug,
 		artifact.PlaybookSlug,
+		artifact.SkipReason,
 	}
 	return strings.Trim(strings.Join(parts, "|"), "|")
 }
@@ -868,6 +871,10 @@ func mergeMemoryWorkflowArtifact(existing, incoming MemoryWorkflowArtifact) Memo
 	if existing.Title == "" {
 		existing.Title = incoming.Title
 	}
+	if incoming.SkipReason != "" && incoming.SkipReason != existing.SkipReason {
+		existing.SkipReason = incoming.SkipReason
+		existing.Title = incoming.Title
+	}
 	if existing.Snippet == "" {
 		existing.Snippet = incoming.Snippet
 	}
@@ -889,6 +896,7 @@ func mergeMemoryWorkflowArtifact(existing, incoming MemoryWorkflowArtifact) Memo
 		existing.EntitySlug != before.EntitySlug ||
 		existing.PlaybookSlug != before.PlaybookSlug ||
 		existing.Title != before.Title ||
+		existing.SkipReason != before.SkipReason ||
 		existing.Snippet != before.Snippet ||
 		existing.CommitSHA != before.CommitSHA ||
 		existing.State != before.State ||

--- a/internal/team/memory_workflow_reconciler.go
+++ b/internal/team/memory_workflow_reconciler.go
@@ -1,0 +1,284 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const memoryWorkflowReconcileInterval = 10 * time.Minute
+
+type MemoryWorkflowReconcileReport struct {
+	Checked          int                                 `json:"checked"`
+	Repaired         int                                 `json:"repaired"`
+	Timestamp        string                              `json:"timestamp"`
+	Tasks            []MemoryWorkflowReconcileTaskResult `json:"tasks,omitempty"`
+	MissingArtifacts []MemoryWorkflowArtifact            `json:"missing_artifacts,omitempty"`
+}
+
+type MemoryWorkflowReconcileTaskResult struct {
+	TaskID           string                   `json:"task_id"`
+	Changed          bool                     `json:"changed"`
+	Repairs          []string                 `json:"repairs,omitempty"`
+	MissingArtifacts []MemoryWorkflowArtifact `json:"missing_artifacts,omitempty"`
+}
+
+type MemoryWorkflowReconciler struct {
+	worker *WikiWorker
+	review *ReviewLog
+	now    func() time.Time
+}
+
+func NewMemoryWorkflowReconciler(worker *WikiWorker, review *ReviewLog, now func() time.Time) *MemoryWorkflowReconciler {
+	if now == nil {
+		now = time.Now
+	}
+	return &MemoryWorkflowReconciler{worker: worker, review: review, now: now}
+}
+
+func (r *MemoryWorkflowReconciler) ReconcileTasks(ctx context.Context, tasks []teamTask) ([]teamTask, MemoryWorkflowReconcileReport, error) {
+	timestamp := r.now().UTC().Format(time.RFC3339)
+	report := MemoryWorkflowReconcileReport{Timestamp: timestamp}
+	out := make([]teamTask, len(tasks))
+	promotionsBySource := r.promotionsBySource()
+	for i, task := range tasks {
+		if err := ctx.Err(); err != nil {
+			return nil, report, err
+		}
+		before := cloneTeamTaskForRollback(task)
+		taskResult := MemoryWorkflowReconcileTaskResult{TaskID: task.ID}
+		syncTaskMemoryWorkflow(&task, timestamp)
+		r.repairTaskWorkflow(&task, promotionsBySource, &taskResult, timestamp)
+		report.Checked++
+		if !reflect.DeepEqual(before.MemoryWorkflow, task.MemoryWorkflow) {
+			task.UpdatedAt = timestamp
+			taskResult.Changed = true
+			report.Repaired++
+			report.Tasks = append(report.Tasks, taskResult)
+		}
+		report.MissingArtifacts = append(report.MissingArtifacts, taskResult.MissingArtifacts...)
+		out[i] = task
+	}
+	return out, report, nil
+}
+
+func (r *MemoryWorkflowReconciler) repairTaskWorkflow(task *teamTask, promotionsBySource map[string]*Promotion, result *MemoryWorkflowReconcileTaskResult, timestamp string) {
+	if task == nil || task.MemoryWorkflow == nil {
+		return
+	}
+	wf := task.MemoryWorkflow
+	r.repairCaptureArtifacts(wf, result)
+	r.repairPromotionArtifacts(wf, result)
+	r.repairPromotionsFromCapture(wf, promotionsBySource, result, timestamp)
+	if countPresentArtifacts(wf.Captures) == 0 && len(wf.Captures) > 0 {
+		wf.Capture.CompletedAt = ""
+		wf.Capture.Status = MemoryWorkflowStepStatusPending
+		wf.Capture.Count = 0
+	}
+	if countPresentArtifacts(wf.Promotions) == 0 && len(wf.Promotions) > 0 {
+		wf.Promote.CompletedAt = ""
+		wf.Promote.Status = MemoryWorkflowStepStatusPending
+		wf.Promote.Count = 0
+	}
+	refreshMemoryWorkflowStatus(wf, timestamp)
+}
+
+func (r *MemoryWorkflowReconciler) repairCaptureArtifacts(wf *MemoryWorkflow, result *MemoryWorkflowReconcileTaskResult) {
+	for i := range wf.Captures {
+		artifact := &wf.Captures[i]
+		if !artifactRequiresLocalFile(*artifact) {
+			continue
+		}
+		exists := r.artifactExists(*artifact)
+		if exists && artifact.Missing {
+			artifact.Missing = false
+			result.Repairs = append(result.Repairs, "capture artifact restored: "+artifact.Path)
+			continue
+		}
+		if !exists && !artifact.Missing {
+			artifact.Missing = true
+			result.Repairs = append(result.Repairs, "capture artifact missing: "+artifact.Path)
+			result.MissingArtifacts = append(result.MissingArtifacts, *artifact)
+		} else if !exists {
+			result.MissingArtifacts = append(result.MissingArtifacts, *artifact)
+		}
+	}
+}
+
+func (r *MemoryWorkflowReconciler) repairPromotionArtifacts(wf *MemoryWorkflow, result *MemoryWorkflowReconcileTaskResult) {
+	for i := range wf.Promotions {
+		artifact := &wf.Promotions[i]
+		if artifact.PromotionID != "" && r.review != nil {
+			p, err := r.review.Get(artifact.PromotionID)
+			if err == nil {
+				if artifact.Path == "" {
+					artifact.Path = p.TargetPath
+				}
+				if artifact.State != string(p.State) {
+					artifact.State = string(p.State)
+					result.Repairs = append(result.Repairs, "promotion state refreshed: "+artifact.PromotionID)
+				}
+				if artifact.CommitSHA == "" {
+					artifact.CommitSHA = p.CommitSHA
+				}
+				if !p.UpdatedAt.IsZero() {
+					artifact.UpdatedAt = p.UpdatedAt.UTC().Format(time.RFC3339)
+				}
+				artifact.Missing = false
+				continue
+			}
+			if errors.Is(err, ErrPromotionNotFound) && !artifact.Missing {
+				artifact.Missing = true
+				result.Repairs = append(result.Repairs, "promotion missing: "+artifact.PromotionID)
+				result.MissingArtifacts = append(result.MissingArtifacts, *artifact)
+				continue
+			}
+		}
+		if !artifactRequiresLocalFile(*artifact) {
+			continue
+		}
+		exists := r.artifactExists(*artifact)
+		if exists && artifact.Missing {
+			artifact.Missing = false
+			result.Repairs = append(result.Repairs, "promotion artifact restored: "+artifact.Path)
+			continue
+		}
+		if !exists && !artifact.Missing {
+			artifact.Missing = true
+			result.Repairs = append(result.Repairs, "promotion artifact missing: "+artifact.Path)
+			result.MissingArtifacts = append(result.MissingArtifacts, *artifact)
+		} else if !exists {
+			result.MissingArtifacts = append(result.MissingArtifacts, *artifact)
+		}
+	}
+}
+
+func (r *MemoryWorkflowReconciler) repairPromotionsFromCapture(wf *MemoryWorkflow, promotionsBySource map[string]*Promotion, result *MemoryWorkflowReconcileTaskResult, timestamp string) {
+	if len(promotionsBySource) == 0 {
+		return
+	}
+	for _, capture := range wf.Captures {
+		if capture.Missing || capture.Path == "" {
+			continue
+		}
+		promotion := promotionsBySource[capture.Path]
+		if promotion == nil {
+			continue
+		}
+		artifact := MemoryWorkflowArtifact{
+			Backend:     "markdown",
+			Source:      "promotion",
+			Path:        promotion.TargetPath,
+			PromotionID: promotion.ID,
+			Title:       capture.Title,
+			CommitSHA:   promotion.CommitSHA,
+			State:       string(promotion.State),
+			RecordedAt:  promotion.CreatedAt.UTC().Format(time.RFC3339),
+			UpdatedAt:   promotion.UpdatedAt.UTC().Format(time.RFC3339),
+		}
+		if appendMemoryWorkflowArtifact(&wf.Promotions, normalizeMemoryWorkflowArtifact(artifact, timestamp)) {
+			result.Repairs = append(result.Repairs, "promotion linked from capture: "+promotion.ID)
+		}
+	}
+}
+
+func (r *MemoryWorkflowReconciler) promotionsBySource() map[string]*Promotion {
+	if r.review == nil {
+		return nil
+	}
+	out := make(map[string]*Promotion)
+	for _, promotion := range r.review.List("all") {
+		if promotion == nil || strings.TrimSpace(promotion.SourcePath) == "" {
+			continue
+		}
+		out[strings.TrimSpace(promotion.SourcePath)] = promotion
+	}
+	return out
+}
+
+func (r *MemoryWorkflowReconciler) artifactExists(artifact MemoryWorkflowArtifact) bool {
+	if r.worker == nil {
+		return false
+	}
+	path := strings.TrimSpace(artifact.Path)
+	if path == "" {
+		return true
+	}
+	switch {
+	case strings.HasPrefix(path, "agents/"):
+		_, err := r.worker.NotebookRead(path)
+		return err == nil
+	case strings.HasPrefix(path, "team/"):
+		_, err := readArticle(r.worker.Repo(), path)
+		return err == nil
+	default:
+		return true
+	}
+}
+
+func artifactRequiresLocalFile(artifact MemoryWorkflowArtifact) bool {
+	path := strings.TrimSpace(artifact.Path)
+	if strings.HasPrefix(path, "agents/") || strings.HasPrefix(path, "team/") {
+		return true
+	}
+	source := strings.ToLower(strings.TrimSpace(artifact.Source))
+	return source == "notebook" || source == "wiki"
+}
+
+func (b *Broker) startMemoryWorkflowReconcilerLoop(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(memoryWorkflowReconcileInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				_, _ = b.ReconcileMemoryWorkflows(context.Background())
+			}
+		}
+	}()
+}
+
+func (b *Broker) ReconcileMemoryWorkflows(ctx context.Context) (MemoryWorkflowReconcileReport, error) {
+	b.mu.Lock()
+	tasks := make([]teamTask, len(b.tasks))
+	for i := range b.tasks {
+		tasks[i] = cloneTeamTaskForRollback(b.tasks[i])
+	}
+	worker := b.wikiWorker
+	review := b.reviewLog
+	b.mu.Unlock()
+
+	reconciler := NewMemoryWorkflowReconciler(worker, review, time.Now)
+	reconciled, report, err := reconciler.ReconcileTasks(ctx, tasks)
+	if err != nil {
+		return report, err
+	}
+	if report.Repaired == 0 {
+		return report, nil
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	byID := make(map[string]teamTask, len(reconciled))
+	for _, task := range reconciled {
+		byID[task.ID] = task
+	}
+	for i := range b.tasks {
+		if updated, ok := byID[b.tasks[i].ID]; ok {
+			b.tasks[i].MemoryWorkflow = cloneMemoryWorkflow(updated.MemoryWorkflow)
+			b.tasks[i].UpdatedAt = updated.UpdatedAt
+		}
+	}
+	if err := b.saveLocked(); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+func (b *Broker) runMemoryWorkflowReconciler() (MemoryWorkflowReconcileReport, error) {
+	return b.ReconcileMemoryWorkflows(context.Background())
+}

--- a/internal/team/memory_workflow_reconciler.go
+++ b/internal/team/memory_workflow_reconciler.go
@@ -200,7 +200,7 @@ func (r *MemoryWorkflowReconciler) promotionsBySource() map[string]*Promotion {
 
 func (r *MemoryWorkflowReconciler) artifactExists(artifact MemoryWorkflowArtifact) bool {
 	if r.worker == nil {
-		return false
+		return true
 	}
 	path := strings.TrimSpace(artifact.Path)
 	if path == "" {
@@ -236,7 +236,7 @@ func (b *Broker) startMemoryWorkflowReconcilerLoop(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				_, _ = b.ReconcileMemoryWorkflows(context.Background())
+				_, _ = b.ReconcileMemoryWorkflows(ctx)
 			}
 		}
 	}()
@@ -269,6 +269,9 @@ func (b *Broker) ReconcileMemoryWorkflows(ctx context.Context) (MemoryWorkflowRe
 	}
 	for i := range b.tasks {
 		if updated, ok := byID[b.tasks[i].ID]; ok {
+			if !reconciledTaskNewer(updated, b.tasks[i]) {
+				continue
+			}
 			b.tasks[i].MemoryWorkflow = cloneMemoryWorkflow(updated.MemoryWorkflow)
 			b.tasks[i].UpdatedAt = updated.UpdatedAt
 		}
@@ -281,4 +284,17 @@ func (b *Broker) ReconcileMemoryWorkflows(ctx context.Context) (MemoryWorkflowRe
 
 func (b *Broker) runMemoryWorkflowReconciler() (MemoryWorkflowReconcileReport, error) {
 	return b.ReconcileMemoryWorkflows(context.Background())
+}
+
+func reconciledTaskNewer(updated, current teamTask) bool {
+	updatedAt := parseBrokerTimestamp(updated.UpdatedAt)
+	currentAt := parseBrokerTimestamp(current.UpdatedAt)
+	switch {
+	case updatedAt.IsZero():
+		return strings.TrimSpace(updated.UpdatedAt) > strings.TrimSpace(current.UpdatedAt)
+	case currentAt.IsZero():
+		return true
+	default:
+		return updatedAt.After(currentAt)
+	}
 }

--- a/internal/team/memory_workflow_reconciler_test.go
+++ b/internal/team/memory_workflow_reconciler_test.go
@@ -154,6 +154,50 @@ func TestMemoryWorkflowReconcilerMarksMissingArtifacts(t *testing.T) {
 	}
 }
 
+func TestMemoryWorkflowReconcilerNilWorkerSkipsArtifactExistenceRepairs(t *testing.T) {
+	now := "2026-04-30T10:00:00Z"
+	task := teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		Status:    "in_progress",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	syncTaskMemoryWorkflow(&task, now)
+	recordMemoryWorkflowLookup(&task, "pm", "prior onboarding", []ContextCitation{{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}}, now)
+	recordMemoryWorkflowCapture(&task, "pm", MemoryWorkflowArtifact{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}, now)
+	recordMemoryWorkflowPromotion(&task, "pm", MemoryWorkflowArtifact{Backend: "markdown", Source: "wiki", Path: "team/process/onboarding.md"}, now)
+
+	reconciler := NewMemoryWorkflowReconciler(nil, nil, func() time.Time {
+		return time.Date(2026, 4, 30, 10, 5, 0, 0, time.UTC)
+	})
+	updated, report, err := reconciler.ReconcileTasks(context.Background(), []teamTask{task})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if report.Repaired != 0 || len(report.MissingArtifacts) != 0 {
+		t.Fatalf("nil worker should skip file existence repairs, got %+v", report)
+	}
+	wf := updated[0].MemoryWorkflow
+	if wf.Captures[0].Missing || wf.Promotions[0].Missing || wf.Status != MemoryWorkflowStatusSatisfied {
+		t.Fatalf("nil worker should preserve satisfied workflow, got %+v", wf)
+	}
+}
+
+func TestReconciledTaskNewerRequiresStrictlyNewerTimestamp(t *testing.T) {
+	current := teamTask{ID: "task-1", UpdatedAt: "2026-04-30T10:05:00Z"}
+	if reconciledTaskNewer(teamTask{ID: "task-1", UpdatedAt: "2026-04-30T10:05:00Z"}, current) {
+		t.Fatal("equal reconciler timestamp should not overwrite current task")
+	}
+	if reconciledTaskNewer(teamTask{ID: "task-1", UpdatedAt: "2026-04-30T10:04:59Z"}, current) {
+		t.Fatal("older reconciler timestamp should not overwrite current task")
+	}
+	if !reconciledTaskNewer(teamTask{ID: "task-1", UpdatedAt: "2026-04-30T10:05:01Z"}, current) {
+		t.Fatal("newer reconciler timestamp should apply")
+	}
+}
+
 func TestBrokerRunMemoryWorkflowReconcilerManualTrigger(t *testing.T) {
 	worker, review, _ := newMemoryWorkflowReconcilerFixture(t)
 	b := newTestBroker(t)
@@ -175,6 +219,7 @@ func TestBrokerRunMemoryWorkflowReconcilerManualTrigger(t *testing.T) {
 				Lookup:        MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusSatisfied, Query: "prior onboarding", CompletedAt: "2026-04-30T10:00:00Z"},
 				Capture:       MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusPending},
 				Promote:       MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusPending},
+				Citations:     []ContextCitation{{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}},
 				Captures:      []MemoryWorkflowArtifact{{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}},
 			},
 		},

--- a/internal/team/memory_workflow_reconciler_test.go
+++ b/internal/team/memory_workflow_reconciler_test.go
@@ -1,0 +1,195 @@
+package team
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func newMemoryWorkflowReconcilerFixture(t *testing.T) (*WikiWorker, *ReviewLog, *Promotion) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+	if _, _, err := repo.CommitNotebook(context.Background(), "pm", "agents/pm/notebook/onboarding.md", "# Onboarding\n\nReusable note.\n", "create", "seed notebook"); err != nil {
+		t.Fatalf("seed notebook: %v", err)
+	}
+	clockTime := time.Date(2026, 4, 30, 10, 0, 0, 0, time.UTC)
+	review, err := NewReviewLog(ReviewLogPath(root), func(string) string { return "ceo" }, func() time.Time { return clockTime })
+	if err != nil {
+		t.Fatalf("new review log: %v", err)
+	}
+	promotion, err := review.SubmitPromotion(SubmitPromotionRequest{
+		SourceSlug: "pm",
+		SourcePath: "agents/pm/notebook/onboarding.md",
+		TargetPath: "team/process/onboarding.md",
+		Rationale:  "promote durable onboarding note",
+	})
+	if err != nil {
+		t.Fatalf("submit promotion: %v", err)
+	}
+	return NewWikiWorker(repo, noopPublisher{}), review, promotion
+}
+
+func TestMemoryWorkflowReconcilerNoOp(t *testing.T) {
+	worker, review, promotion := newMemoryWorkflowReconcilerFixture(t)
+	now := "2026-04-30T10:00:00Z"
+	task := teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		Status:    "in_progress",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	syncTaskMemoryWorkflow(&task, now)
+	recordMemoryWorkflowLookup(&task, "pm", "prior onboarding", []ContextCitation{{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}}, now)
+	recordMemoryWorkflowCapture(&task, "pm", MemoryWorkflowArtifact{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}, now)
+	recordMemoryWorkflowPromotion(&task, "pm", MemoryWorkflowArtifact{
+		Backend:     "markdown",
+		Source:      "promotion",
+		Path:        promotion.TargetPath,
+		PromotionID: promotion.ID,
+		State:       string(promotion.State),
+		RecordedAt:  now,
+		UpdatedAt:   now,
+	}, now)
+
+	reconciler := NewMemoryWorkflowReconciler(worker, review, func() time.Time {
+		return time.Date(2026, 4, 30, 10, 0, 0, 0, time.UTC)
+	})
+	_, report, err := reconciler.ReconcileTasks(context.Background(), []teamTask{task})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if report.Checked != 1 || report.Repaired != 0 {
+		t.Fatalf("expected no-op report, got %+v", report)
+	}
+}
+
+func TestMemoryWorkflowReconcilerRepairsStaleWorkflow(t *testing.T) {
+	worker, review, promotion := newMemoryWorkflowReconcilerFixture(t)
+	task := teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		Status:    "in_progress",
+		CreatedAt: "2026-04-30T09:59:00Z",
+		UpdatedAt: "2026-04-30T09:59:00Z",
+		MemoryWorkflow: &MemoryWorkflow{
+			Required:          true,
+			Status:            MemoryWorkflowStatusPending,
+			RequirementReason: "stale",
+			RequiredSteps:     []MemoryWorkflowStep{MemoryWorkflowStepLookup, MemoryWorkflowStepCapture, MemoryWorkflowStepPromote},
+			Lookup:            MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusPending, Query: "prior onboarding"},
+			Capture:           MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusPending},
+			Promote:           MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusPending},
+			Citations:         []ContextCitation{{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}},
+			Captures:          []MemoryWorkflowArtifact{{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}},
+		},
+	}
+
+	reconciler := NewMemoryWorkflowReconciler(worker, review, func() time.Time {
+		return time.Date(2026, 4, 30, 10, 5, 0, 0, time.UTC)
+	})
+	updated, report, err := reconciler.ReconcileTasks(context.Background(), []teamTask{task})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if report.Repaired != 1 {
+		t.Fatalf("expected one repaired task, got %+v", report)
+	}
+	wf := updated[0].MemoryWorkflow
+	if wf.Status != MemoryWorkflowStatusSatisfied {
+		t.Fatalf("expected satisfied workflow, got %+v", wf)
+	}
+	if wf.Lookup.Status != MemoryWorkflowStepStatusSatisfied || wf.Capture.Status != MemoryWorkflowStepStatusSatisfied || wf.Promote.Status != MemoryWorkflowStepStatusSatisfied {
+		t.Fatalf("expected all steps satisfied, got %+v", wf)
+	}
+	if len(wf.Promotions) != 1 || wf.Promotions[0].PromotionID != promotion.ID {
+		t.Fatalf("expected promotion repair from review log, got %+v", wf.Promotions)
+	}
+}
+
+func TestMemoryWorkflowReconcilerMarksMissingArtifacts(t *testing.T) {
+	worker, review, _ := newMemoryWorkflowReconcilerFixture(t)
+	task := teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		Status:    "in_progress",
+		CreatedAt: "2026-04-30T09:59:00Z",
+		UpdatedAt: "2026-04-30T09:59:00Z",
+		MemoryWorkflow: &MemoryWorkflow{
+			Required:      true,
+			Status:        MemoryWorkflowStatusSatisfied,
+			RequiredSteps: []MemoryWorkflowStep{MemoryWorkflowStepLookup, MemoryWorkflowStepCapture, MemoryWorkflowStepPromote},
+			Lookup:        MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusSatisfied, Query: "prior onboarding", CompletedAt: "2026-04-30T10:00:00Z"},
+			Capture:       MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusSatisfied, CompletedAt: "2026-04-30T10:01:00Z"},
+			Promote:       MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusPending},
+			Captures:      []MemoryWorkflowArtifact{{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/missing.md"}},
+		},
+	}
+
+	reconciler := NewMemoryWorkflowReconciler(worker, review, func() time.Time {
+		return time.Date(2026, 4, 30, 10, 5, 0, 0, time.UTC)
+	})
+	updated, report, err := reconciler.ReconcileTasks(context.Background(), []teamTask{task})
+	if err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+	if report.Repaired != 1 || len(report.MissingArtifacts) != 1 {
+		t.Fatalf("expected missing artifact repair, got %+v", report)
+	}
+	wf := updated[0].MemoryWorkflow
+	if !wf.Captures[0].Missing {
+		t.Fatalf("expected capture marked missing: %+v", wf.Captures[0])
+	}
+	if wf.Capture.Status != MemoryWorkflowStepStatusPending || wf.Status != MemoryWorkflowStatusPending {
+		t.Fatalf("expected workflow back to pending, got %+v", wf)
+	}
+}
+
+func TestBrokerRunMemoryWorkflowReconcilerManualTrigger(t *testing.T) {
+	worker, review, _ := newMemoryWorkflowReconcilerFixture(t)
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.reviewLog = review
+	b.tasks = []teamTask{
+		{
+			ID:        "task-1",
+			TaskType:  "research",
+			Title:     "Research prior context for onboarding",
+			Status:    "in_progress",
+			CreatedAt: "2026-04-30T09:59:00Z",
+			UpdatedAt: "2026-04-30T09:59:00Z",
+			MemoryWorkflow: &MemoryWorkflow{
+				Required:      true,
+				Status:        MemoryWorkflowStatusPending,
+				RequiredSteps: []MemoryWorkflowStep{MemoryWorkflowStepLookup, MemoryWorkflowStepCapture, MemoryWorkflowStepPromote},
+				Lookup:        MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusSatisfied, Query: "prior onboarding", CompletedAt: "2026-04-30T10:00:00Z"},
+				Capture:       MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusPending},
+				Promote:       MemoryWorkflowStepState{Required: true, Status: MemoryWorkflowStepStatusPending},
+				Captures:      []MemoryWorkflowArtifact{{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}},
+			},
+		},
+	}
+	b.mu.Unlock()
+
+	report, err := b.runMemoryWorkflowReconciler()
+	if err != nil {
+		t.Fatalf("manual reconciler: %v", err)
+	}
+	if report.Repaired != 1 {
+		t.Fatalf("expected one repair from manual trigger, got %+v", report)
+	}
+	tasks := b.AllTasks()
+	if len(tasks) != 1 || tasks[0].MemoryWorkflow == nil || tasks[0].MemoryWorkflow.Status != MemoryWorkflowStatusSatisfied {
+		t.Fatalf("expected broker task repaired, got %+v", tasks)
+	}
+}

--- a/internal/team/memory_workflow_test.go
+++ b/internal/team/memory_workflow_test.go
@@ -41,6 +41,7 @@ func TestMemoryWorkflowJSONRoundTrip(t *testing.T) {
 					RetrievedAt: "2026-04-30T10:01:00Z",
 				},
 			},
+			PartialErrors: []string{"wiki search timed out"},
 		},
 	}
 
@@ -65,6 +66,14 @@ func TestMemoryWorkflowJSONRoundTrip(t *testing.T) {
 	}
 	if got.Score == nil || *got.Score != score || got.Stale == nil || *got.Stale != stale {
 		t.Fatalf("score/stale did not round trip: %+v", got)
+	}
+	if len(decoded.MemoryWorkflow.PartialErrors) != 1 || decoded.MemoryWorkflow.PartialErrors[0] != "wiki search timed out" {
+		t.Fatalf("partial_errors did not round trip: %+v", decoded.MemoryWorkflow.PartialErrors)
+	}
+	cloned := cloneMemoryWorkflow(decoded.MemoryWorkflow)
+	cloned.PartialErrors[0] = "mutated"
+	if decoded.MemoryWorkflow.PartialErrors[0] != "wiki search timed out" {
+		t.Fatalf("clone should deep-copy partial_errors, got %+v", decoded.MemoryWorkflow.PartialErrors)
 	}
 }
 
@@ -162,6 +171,61 @@ func TestMemoryWorkflowTransitionsAreIdempotent(t *testing.T) {
 	}
 	if got := len(task.MemoryWorkflow.Promotions); got != 1 {
 		t.Fatalf("expected one promotion, got %d", got)
+	}
+}
+
+func TestMemoryWorkflowLookupRequiresCitationEvidence(t *testing.T) {
+	task := &teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		CreatedAt: "2026-04-30T10:00:00Z",
+		UpdatedAt: "2026-04-30T10:00:00Z",
+	}
+	syncTaskMemoryWorkflow(task, "2026-04-30T10:00:00Z")
+
+	if !recordMemoryWorkflowLookup(task, "pm", "prior onboarding", nil, "2026-04-30T10:01:00Z") {
+		t.Fatal("first zero-hit lookup should record the attempt metadata")
+	}
+	if task.MemoryWorkflow.Lookup.Status != MemoryWorkflowStepStatusPending || task.MemoryWorkflow.Lookup.CompletedAt != "" {
+		t.Fatalf("zero-hit lookup must not satisfy the gate, got %+v", task.MemoryWorkflow.Lookup)
+	}
+	if taskMemoryWorkflowReady(task) {
+		t.Fatalf("zero-hit lookup should not make workflow ready: %+v", task.MemoryWorkflow)
+	}
+	if recordMemoryWorkflowLookup(task, "pm", "prior onboarding", nil, "2026-04-30T10:02:00Z") {
+		t.Fatal("duplicate zero-hit lookup should be idempotent")
+	}
+}
+
+func TestMemoryWorkflowMissingArtifactsReopenCompletedSteps(t *testing.T) {
+	task := &teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		CreatedAt: "2026-04-30T10:00:00Z",
+		UpdatedAt: "2026-04-30T10:00:00Z",
+	}
+	syncTaskMemoryWorkflow(task, "2026-04-30T10:00:00Z")
+	recordMemoryWorkflowLookup(task, "pm", "prior onboarding", []ContextCitation{{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}}, "2026-04-30T10:01:00Z")
+	recordMemoryWorkflowCapture(task, "pm", MemoryWorkflowArtifact{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md"}, "2026-04-30T10:02:00Z")
+	recordMemoryWorkflowPromotion(task, "pm", MemoryWorkflowArtifact{Backend: "markdown", Source: "promotion", Path: "team/process/onboarding.md", PromotionID: "rvw-1"}, "2026-04-30T10:03:00Z")
+	if task.MemoryWorkflow.Status != MemoryWorkflowStatusSatisfied {
+		t.Fatalf("expected satisfied workflow before missing repair, got %+v", task.MemoryWorkflow)
+	}
+
+	task.MemoryWorkflow.Captures[0].Missing = true
+	task.MemoryWorkflow.Promotions[0].Missing = true
+	refreshMemoryWorkflowStatus(task.MemoryWorkflow, "2026-04-30T10:04:00Z")
+
+	if task.MemoryWorkflow.Capture.Status != MemoryWorkflowStepStatusPending || task.MemoryWorkflow.Capture.CompletedAt != "" {
+		t.Fatalf("missing capture should reopen capture step, got %+v", task.MemoryWorkflow.Capture)
+	}
+	if task.MemoryWorkflow.Promote.Status != MemoryWorkflowStepStatusPending || task.MemoryWorkflow.Promote.CompletedAt != "" {
+		t.Fatalf("missing promotion should reopen promote step, got %+v", task.MemoryWorkflow.Promote)
+	}
+	if task.MemoryWorkflow.Status != MemoryWorkflowStatusPending {
+		t.Fatalf("missing durable artifacts should make workflow pending, got %+v", task.MemoryWorkflow)
 	}
 }
 

--- a/internal/team/memory_workflow_test.go
+++ b/internal/team/memory_workflow_test.go
@@ -245,7 +245,7 @@ func TestMemoryWorkflowLookupRejectsEmptyCitations(t *testing.T) {
 	}
 	syncTaskMemoryWorkflow(task, "2026-04-30T10:00:00Z")
 
-	if !recordMemoryWorkflowLookup(task, "pm", "prior onboarding", []ContextCitation{{LineStart: 1, LineEnd: 1}}, "2026-04-30T10:01:00Z") {
+	if !recordMemoryWorkflowLookup(task, "pm", "prior onboarding", []ContextCitation{{}}, "2026-04-30T10:01:00Z") {
 		t.Fatal("first lookup attempt should record query metadata")
 	}
 	if len(task.MemoryWorkflow.Citations) != 0 {
@@ -253,6 +253,40 @@ func TestMemoryWorkflowLookupRejectsEmptyCitations(t *testing.T) {
 	}
 	if task.MemoryWorkflow.Lookup.Status != MemoryWorkflowStepStatusPending || task.MemoryWorkflow.Lookup.CompletedAt != "" {
 		t.Fatalf("empty citation should not satisfy lookup: %+v", task.MemoryWorkflow.Lookup)
+	}
+}
+
+func TestMemoryWorkflowLookupAcceptsLineOnlyCitationEvidence(t *testing.T) {
+	task := &teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		CreatedAt: "2026-04-30T10:00:00Z",
+		UpdatedAt: "2026-04-30T10:00:00Z",
+	}
+	syncTaskMemoryWorkflow(task, "2026-04-30T10:00:00Z")
+
+	if !recordMemoryWorkflowLookup(task, "pm", "prior onboarding", []ContextCitation{{Source: "notebook", LineStart: 12}}, "2026-04-30T10:01:00Z") {
+		t.Fatal("line-only citation should record lookup evidence")
+	}
+	if len(task.MemoryWorkflow.Citations) != 1 {
+		t.Fatalf("line-only citation should be retained: %+v", task.MemoryWorkflow.Citations)
+	}
+	if task.MemoryWorkflow.Lookup.Status != MemoryWorkflowStepStatusSatisfied || task.MemoryWorkflow.Lookup.CompletedAt == "" {
+		t.Fatalf("line-only citation should satisfy lookup: %+v", task.MemoryWorkflow.Lookup)
+	}
+}
+
+func TestMemoryWorkflowContentOnlyCitationsKeepDistinctKeys(t *testing.T) {
+	var citations []ContextCitation
+	if !appendContextCitation(&citations, ContextCitation{Title: "First", Snippet: "Alpha"}) {
+		t.Fatal("expected first content citation to append")
+	}
+	if !appendContextCitation(&citations, ContextCitation{Title: "Second", Snippet: "Beta"}) {
+		t.Fatal("expected second content citation to append")
+	}
+	if got := len(citations); got != 2 {
+		t.Fatalf("expected content-only citations to remain distinct, got %d: %+v", got, citations)
 	}
 }
 

--- a/internal/team/memory_workflow_test.go
+++ b/internal/team/memory_workflow_test.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -69,6 +70,16 @@ func TestMemoryWorkflowJSONRoundTrip(t *testing.T) {
 	}
 	if len(decoded.MemoryWorkflow.PartialErrors) != 1 || decoded.MemoryWorkflow.PartialErrors[0] != "wiki search timed out" {
 		t.Fatalf("partial_errors did not round trip: %+v", decoded.MemoryWorkflow.PartialErrors)
+	}
+	wantSteps := []MemoryWorkflowStep{MemoryWorkflowStepLookup, MemoryWorkflowStepCapture, MemoryWorkflowStepPromote}
+	if !reflect.DeepEqual(decoded.MemoryWorkflow.RequiredSteps, wantSteps) {
+		t.Fatalf("required steps did not round trip: %+v", decoded.MemoryWorkflow.RequiredSteps)
+	}
+	if decoded.MemoryWorkflow.Lookup.Required != true ||
+		decoded.MemoryWorkflow.Lookup.Status != MemoryWorkflowStepStatusSatisfied ||
+		decoded.MemoryWorkflow.Lookup.Query != "prior onboarding context" ||
+		decoded.MemoryWorkflow.Lookup.CompletedAt != "2026-04-30T10:01:00Z" {
+		t.Fatalf("lookup state did not round trip: %+v", decoded.MemoryWorkflow.Lookup)
 	}
 	cloned := cloneMemoryWorkflow(decoded.MemoryWorkflow)
 	cloned.PartialErrors[0] = "mutated"
@@ -221,6 +232,27 @@ func TestMemoryWorkflowLookupRequiresCitationEvidence(t *testing.T) {
 	}
 	if recordMemoryWorkflowLookup(task, "pm", "prior onboarding", nil, "2026-04-30T10:02:00Z") {
 		t.Fatal("duplicate zero-hit lookup should be idempotent")
+	}
+}
+
+func TestMemoryWorkflowLookupRejectsEmptyCitations(t *testing.T) {
+	task := &teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		CreatedAt: "2026-04-30T10:00:00Z",
+		UpdatedAt: "2026-04-30T10:00:00Z",
+	}
+	syncTaskMemoryWorkflow(task, "2026-04-30T10:00:00Z")
+
+	if !recordMemoryWorkflowLookup(task, "pm", "prior onboarding", []ContextCitation{{LineStart: 1, LineEnd: 1}}, "2026-04-30T10:01:00Z") {
+		t.Fatal("first lookup attempt should record query metadata")
+	}
+	if len(task.MemoryWorkflow.Citations) != 0 {
+		t.Fatalf("empty citation should not be retained: %+v", task.MemoryWorkflow.Citations)
+	}
+	if task.MemoryWorkflow.Lookup.Status != MemoryWorkflowStepStatusPending || task.MemoryWorkflow.Lookup.CompletedAt != "" {
+		t.Fatalf("empty citation should not satisfy lookup: %+v", task.MemoryWorkflow.Lookup)
 	}
 }
 

--- a/internal/team/memory_workflow_test.go
+++ b/internal/team/memory_workflow_test.go
@@ -174,6 +174,32 @@ func TestMemoryWorkflowTransitionsAreIdempotent(t *testing.T) {
 	}
 }
 
+func TestMemoryWorkflowSkipArtifactsKeepDistinctReasons(t *testing.T) {
+	task := &teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		CreatedAt: "2026-04-30T10:00:00Z",
+		UpdatedAt: "2026-04-30T10:00:00Z",
+	}
+	syncTaskMemoryWorkflow(task, "2026-04-30T10:00:00Z")
+
+	first := MemoryWorkflowArtifact{Backend: "markdown", Source: "skip", Title: "already canonical", SkipReason: "already canonical"}
+	second := MemoryWorkflowArtifact{Backend: "markdown", Source: "skip", Title: "not reusable", SkipReason: "not reusable"}
+	if !recordMemoryWorkflowPromotion(task, "pm", first, "2026-04-30T10:01:00Z") {
+		t.Fatal("expected first skip reason to record")
+	}
+	if !recordMemoryWorkflowPromotion(task, "pm", second, "2026-04-30T10:02:00Z") {
+		t.Fatal("expected second skip reason to record distinctly")
+	}
+	if got := len(task.MemoryWorkflow.Promotions); got != 2 {
+		t.Fatalf("expected distinct skip artifacts by reason, got %d: %+v", got, task.MemoryWorkflow.Promotions)
+	}
+	if task.MemoryWorkflow.Promotions[0].SkipReason == "" || task.MemoryWorkflow.Promotions[1].SkipReason == "" {
+		t.Fatalf("expected skip reasons preserved: %+v", task.MemoryWorkflow.Promotions)
+	}
+}
+
 func TestMemoryWorkflowLookupRequiresCitationEvidence(t *testing.T) {
 	task := &teamTask{
 		ID:        "task-1",

--- a/internal/team/memory_workflow_test.go
+++ b/internal/team/memory_workflow_test.go
@@ -1,0 +1,193 @@
+package team
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestMemoryWorkflowJSONRoundTrip(t *testing.T) {
+	score := 0.91
+	stale := false
+	task := teamTask{
+		ID:        "task-1",
+		Title:     "Research prior context for onboarding",
+		Status:    "in_progress",
+		CreatedBy: "ceo",
+		CreatedAt: "2026-04-30T10:00:00Z",
+		UpdatedAt: "2026-04-30T10:00:00Z",
+		MemoryWorkflow: &MemoryWorkflow{
+			Required:          true,
+			Status:            MemoryWorkflowStatusPending,
+			RequirementReason: "research task asks for prior organizational context",
+			RequiredSteps:     []MemoryWorkflowStep{MemoryWorkflowStepLookup, MemoryWorkflowStepCapture, MemoryWorkflowStepPromote},
+			Lookup: MemoryWorkflowStepState{
+				Required:    true,
+				Status:      MemoryWorkflowStepStatusSatisfied,
+				Actor:       "pm",
+				Query:       "prior onboarding context",
+				CompletedAt: "2026-04-30T10:01:00Z",
+			},
+			Citations: []ContextCitation{
+				{
+					Backend:     "markdown",
+					Source:      "notebook",
+					Path:        "agents/pm/notebook/onboarding.md",
+					ChunkID:     "line-4",
+					Title:       "Onboarding",
+					Snippet:     "Prior onboarding work",
+					Score:       &score,
+					Stale:       &stale,
+					RetrievedAt: "2026-04-30T10:01:00Z",
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(task)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"memory_workflow"`) {
+		t.Fatalf("expected memory_workflow in JSON: %s", raw)
+	}
+
+	var decoded teamTask
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded.MemoryWorkflow == nil || !decoded.MemoryWorkflow.Required {
+		t.Fatalf("workflow did not round trip: %+v", decoded.MemoryWorkflow)
+	}
+	got := decoded.MemoryWorkflow.Citations[0]
+	if got.Backend != "markdown" || got.Source != "notebook" || got.Path != "agents/pm/notebook/onboarding.md" {
+		t.Fatalf("citation did not round trip: %+v", got)
+	}
+	if got.Score == nil || *got.Score != score || got.Stale == nil || *got.Stale != stale {
+		t.Fatalf("score/stale did not round trip: %+v", got)
+	}
+}
+
+func TestMemoryWorkflowRequirementPolicy(t *testing.T) {
+	cases := []struct {
+		name string
+		task teamTask
+		want bool
+	}{
+		{
+			name: "process research task requires workflow",
+			task: teamTask{TaskType: "process-research", Title: "Map support escalation memory"},
+			want: true,
+		},
+		{
+			name: "research task with prior context requires workflow",
+			task: teamTask{TaskType: "research", Title: "Research prior context for renewal playbook"},
+			want: true,
+		},
+		{
+			name: "plain research task does not accidentally block",
+			task: teamTask{TaskType: "research", Title: "Compare pricing pages"},
+			want: false,
+		},
+		{
+			name: "feature task does not accidentally block",
+			task: teamTask{TaskType: "feature", Title: "Implement task drawer"},
+			want: false,
+		},
+		{
+			name: "launch task does not accidentally block",
+			task: teamTask{TaskType: "launch", Title: "Launch customer webinar"},
+			want: false,
+		},
+		{
+			name: "follow up task does not accidentally block",
+			task: teamTask{TaskType: "follow_up", Title: "Follow up with Sarah"},
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := memoryWorkflowRequirementForTask(&tc.task)
+			if got.Required != tc.want {
+				t.Fatalf("required=%v want %v (%+v)", got.Required, tc.want, got)
+			}
+		})
+	}
+}
+
+func TestMemoryWorkflowTransitionsAreIdempotent(t *testing.T) {
+	task := &teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		CreatedAt: "2026-04-30T10:00:00Z",
+		UpdatedAt: "2026-04-30T10:00:00Z",
+	}
+	syncTaskMemoryWorkflow(task, "2026-04-30T10:00:00Z")
+	if task.MemoryWorkflow == nil || task.MemoryWorkflow.Status != MemoryWorkflowStatusPending {
+		t.Fatalf("expected pending required workflow, got %+v", task.MemoryWorkflow)
+	}
+
+	citation := ContextCitation{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md", Snippet: "prior work"}
+	if !recordMemoryWorkflowLookup(task, "pm", "prior onboarding", []ContextCitation{citation}, "2026-04-30T10:01:00Z") {
+		t.Fatal("expected lookup to change workflow")
+	}
+	if recordMemoryWorkflowLookup(task, "pm", "prior onboarding", []ContextCitation{citation}, "2026-04-30T10:01:00Z") {
+		t.Fatal("duplicate lookup should be idempotent")
+	}
+	if got := len(task.MemoryWorkflow.Citations); got != 1 {
+		t.Fatalf("expected one citation, got %d", got)
+	}
+
+	capture := MemoryWorkflowArtifact{Backend: "markdown", Source: "notebook", Path: "agents/pm/notebook/onboarding.md", Title: "Onboarding"}
+	if !recordMemoryWorkflowCapture(task, "pm", capture, "2026-04-30T10:02:00Z") {
+		t.Fatal("expected capture to change workflow")
+	}
+	if recordMemoryWorkflowCapture(task, "pm", capture, "2026-04-30T10:02:00Z") {
+		t.Fatal("duplicate capture should be idempotent")
+	}
+	promotion := MemoryWorkflowArtifact{Backend: "markdown", Source: "promotion", Path: "team/process/onboarding.md", PromotionID: "rvw-1"}
+	if !recordMemoryWorkflowPromotion(task, "pm", promotion, "2026-04-30T10:03:00Z") {
+		t.Fatal("expected promotion to change workflow")
+	}
+	if recordMemoryWorkflowPromotion(task, "pm", promotion, "2026-04-30T10:03:00Z") {
+		t.Fatal("duplicate promotion should be idempotent")
+	}
+	if task.MemoryWorkflow.Status != MemoryWorkflowStatusSatisfied {
+		t.Fatalf("expected satisfied workflow, got %+v", task.MemoryWorkflow)
+	}
+	if got := len(task.MemoryWorkflow.Captures); got != 1 {
+		t.Fatalf("expected one capture, got %d", got)
+	}
+	if got := len(task.MemoryWorkflow.Promotions); got != 1 {
+		t.Fatalf("expected one promotion, got %d", got)
+	}
+}
+
+func TestMemoryWorkflowCompletionGateAndOverride(t *testing.T) {
+	task := &teamTask{
+		ID:        "task-1",
+		TaskType:  "research",
+		Title:     "Research prior context for onboarding",
+		Status:    "in_progress",
+		CreatedAt: "2026-04-30T10:00:00Z",
+		UpdatedAt: "2026-04-30T10:00:00Z",
+	}
+	syncTaskMemoryWorkflow(task, "2026-04-30T10:00:00Z")
+
+	err := applyMemoryWorkflowCompletionGate(task, "ceo", "", false, "2026-04-30T10:04:00Z")
+	if err == nil || !strings.Contains(err.Error(), "memory workflow incomplete") {
+		t.Fatalf("expected incomplete workflow error, got %v", err)
+	}
+
+	if err := applyMemoryWorkflowCompletionGate(task, "ceo", "Human accepted missing memory evidence", true, "2026-04-30T10:05:00Z"); err != nil {
+		t.Fatalf("override should allow completion: %v", err)
+	}
+	if task.MemoryWorkflow.Status != MemoryWorkflowStatusOverridden || task.MemoryWorkflow.Override == nil {
+		t.Fatalf("expected override state, got %+v", task.MemoryWorkflow)
+	}
+	if task.MemoryWorkflow.Override.Actor != "ceo" || task.MemoryWorkflow.Override.Reason == "" || task.MemoryWorkflow.Override.Timestamp != "2026-04-30T10:05:00Z" {
+		t.Fatalf("override metadata missing: %+v", task.MemoryWorkflow.Override)
+	}
+}

--- a/internal/team/testdata/context_harness/passport_process_repeated.json
+++ b/internal/team/testdata/context_harness/passport_process_repeated.json
@@ -1,0 +1,37 @@
+{
+  "scenario": "repeated passport process research",
+  "task_type": "research",
+  "lookup_query": "passport process",
+  "retrieval_contract": {
+    "required_capabilities": [
+      "literal_notebook_search",
+      "literal_wiki_search",
+      "direct_artifact_citation"
+    ],
+    "requires_semantic_index": false,
+    "requires_external_network": false
+  },
+  "runs": [
+    {
+      "id": "run-1",
+      "prompt": "Research the passport process for a child renewal and leave reusable instructions.",
+      "agent_slug": "researcher",
+      "notebook_path": "agents/researcher/notebook/2026-04-30-passport-process.md",
+      "wiki_path": "team/process/passport-process.md",
+      "official_source": "fixture://official/passport-process-baseline",
+      "must_start_without_prior_artifacts": true
+    },
+    {
+      "id": "run-2",
+      "prompt": "Research the passport process again for a similar renewal request.",
+      "agent_slug": "researcher",
+      "notebook_path": "agents/researcher/notebook/2026-04-30-passport-process-followup.md",
+      "official_source": "fixture://official/passport-process-followup",
+      "expected_prior_citations": [
+        "agents/researcher/notebook/2026-04-30-passport-process.md",
+        "team/process/passport-process.md"
+      ],
+      "promotion_skip_reason": "prior shared wiki artifact already canonical for this repeated process task"
+    }
+  ]
+}

--- a/internal/teammcp/context_tools.go
+++ b/internal/teammcp/context_tools.go
@@ -1,0 +1,885 @@
+package teammcp
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+const (
+	contextDefaultLimit     = 5
+	contextMaxLimit         = 20
+	contextDefaultTimeout   = 5 * time.Second
+	contextMaxTimeout       = 30 * time.Second
+	contextSnippetMaxLength = 360
+)
+
+var (
+	contextResolveMemoryBackendStatus = team.ResolveMemoryBackendStatus
+	contextQuerySharedMemory          = team.QuerySharedMemory
+	contextNow                        = time.Now
+)
+
+type ContextLookupArgs struct {
+	Query          string `json:"query" jsonschema:"What prior context to look up"`
+	TaskID         string `json:"task_id,omitempty" jsonschema:"Optional office task ID whose memory workflow should record this lookup"`
+	TaskType       string `json:"task_type,omitempty" jsonschema:"Optional task type such as research, process, strategy, or implementation"`
+	Limit          int    `json:"limit,omitempty" jsonschema:"Maximum citations per source (default 5, max 20)"`
+	IncludePrivate bool   `json:"include_private,omitempty" jsonschema:"Include notebook/private working context when the backend supports it. Defaults to true when both include flags are omitted."`
+	IncludeShared  bool   `json:"include_shared,omitempty" jsonschema:"Include shared wiki/org context when the backend supports it. Defaults to true when both include flags are omitted."`
+	TimeoutMS      int    `json:"timeout_ms,omitempty" jsonschema:"Total lookup deadline in milliseconds (default 5000, max 30000)"`
+	MySlug         string `json:"my_slug,omitempty" jsonschema:"Agent slug for task workflow attribution. Defaults to WUPHF_AGENT_SLUG."`
+}
+
+type ContextCaptureArgs struct {
+	TaskID       string `json:"task_id,omitempty" jsonschema:"Optional office task ID whose memory workflow should record this capture"`
+	MySlug       string `json:"my_slug,omitempty" jsonschema:"Agent slug writing the notebook entry. Defaults to WUPHF_AGENT_SLUG."`
+	Title        string `json:"title,omitempty" jsonschema:"Short title for the captured note"`
+	Content      string `json:"content,omitempty" jsonschema:"Markdown note content to save to the caller's notebook"`
+	NotebookPath string `json:"notebook_path,omitempty" jsonschema:"Optional notebook path. Defaults to agents/{my_slug}/notebook/{date}-{title}.md"`
+	Mode         string `json:"mode,omitempty" jsonschema:"Notebook write mode: create, replace, or append_section. Defaults to create."`
+	SkipReason   string `json:"skip_reason,omitempty" jsonschema:"Explicit reason no notebook capture is needed for this task"`
+}
+
+type ContextPromoteArgs struct {
+	TaskID         string `json:"task_id,omitempty" jsonschema:"Optional office task ID whose memory workflow should record this promotion decision"`
+	MySlug         string `json:"my_slug,omitempty" jsonschema:"Agent slug submitting the promotion. Defaults to WUPHF_AGENT_SLUG."`
+	SourcePath     string `json:"source_path,omitempty" jsonschema:"Notebook source path, e.g. agents/{my_slug}/notebook/process.md"`
+	TargetWikiPath string `json:"target_wiki_path,omitempty" jsonschema:"Proposed wiki path, e.g. team/processes/passport.md"`
+	Rationale      string `json:"rationale,omitempty" jsonschema:"Why this notebook entry is ready for shared wiki promotion"`
+	ReviewerSlug   string `json:"reviewer_slug,omitempty" jsonschema:"Optional reviewer override"`
+	SkipReason     string `json:"skip_reason,omitempty" jsonschema:"Explicit reason no wiki promotion is needed for this task"`
+}
+
+type ContextHealthArgs struct {
+	TaskID string `json:"task_id,omitempty" jsonschema:"Optional office task ID whose memory workflow state should be returned"`
+}
+
+type ContextToolStatus struct {
+	OK        bool   `json:"ok"`
+	Code      string `json:"code"`
+	Message   string `json:"message,omitempty"`
+	Retryable bool   `json:"retryable,omitempty"`
+}
+
+type ContextBackendStatus struct {
+	SelectedKind  string `json:"selected_kind"`
+	SelectedLabel string `json:"selected_label,omitempty"`
+	ActiveKind    string `json:"active_kind"`
+	ActiveLabel   string `json:"active_label,omitempty"`
+	Active        bool   `json:"active"`
+	Detail        string `json:"detail,omitempty"`
+	NextStep      string `json:"next_step,omitempty"`
+}
+
+type ContextPartialError struct {
+	Source    string `json:"source"`
+	Backend   string `json:"backend,omitempty"`
+	Code      string `json:"code"`
+	Message   string `json:"message"`
+	Retryable bool   `json:"retryable,omitempty"`
+}
+
+type ContextCitation struct {
+	Corpus     string   `json:"corpus"`
+	Backend    string   `json:"backend"`
+	Scope      string   `json:"scope,omitempty"`
+	Identifier string   `json:"identifier,omitempty"`
+	Path       string   `json:"path,omitempty"`
+	Line       int      `json:"line,omitempty"`
+	Title      string   `json:"title,omitempty"`
+	Snippet    string   `json:"snippet,omitempty"`
+	OwnerSlug  string   `json:"owner_slug,omitempty"`
+	Slug       string   `json:"slug,omitempty"`
+	PageID     int      `json:"page_id,omitempty"`
+	ChunkID    int      `json:"chunk_id,omitempty"`
+	ChunkIndex int      `json:"chunk_index,omitempty"`
+	Source     string   `json:"source,omitempty"`
+	Score      *float64 `json:"score,omitempty"`
+	Stale      *bool    `json:"stale,omitempty"`
+}
+
+type ContextWorkflowUpdate struct {
+	Attempted bool           `json:"attempted"`
+	Updated   bool           `json:"updated"`
+	TaskID    string         `json:"task_id,omitempty"`
+	Event     string         `json:"event,omitempty"`
+	Response  map[string]any `json:"response,omitempty"`
+	Error     string         `json:"error,omitempty"`
+	Code      string         `json:"code,omitempty"`
+}
+
+type ContextLookupResult struct {
+	Tool          string                 `json:"tool"`
+	Query         string                 `json:"query"`
+	TaskID        string                 `json:"task_id,omitempty"`
+	TaskType      string                 `json:"task_type,omitempty"`
+	Limit         int                    `json:"limit"`
+	Backend       ContextBackendStatus   `json:"backend"`
+	Status        ContextToolStatus      `json:"status"`
+	Citations     []ContextCitation      `json:"citations"`
+	PartialErrors []ContextPartialError  `json:"partial_errors,omitempty"`
+	Workflow      *ContextWorkflowUpdate `json:"workflow,omitempty"`
+	ReadableText  string                 `json:"readable_text,omitempty"`
+}
+
+type ContextNotebookArtifact struct {
+	Path         string `json:"path,omitempty"`
+	CommitSHA    string `json:"commit_sha,omitempty"`
+	BytesWritten int    `json:"bytes_written,omitempty"`
+	Skipped      bool   `json:"skipped,omitempty"`
+	SkipReason   string `json:"skip_reason,omitempty"`
+}
+
+type ContextCaptureResult struct {
+	Tool          string                   `json:"tool"`
+	TaskID        string                   `json:"task_id,omitempty"`
+	Backend       ContextBackendStatus     `json:"backend"`
+	Status        ContextToolStatus        `json:"status"`
+	Notebook      *ContextNotebookArtifact `json:"notebook,omitempty"`
+	Workflow      *ContextWorkflowUpdate   `json:"workflow,omitempty"`
+	PartialErrors []ContextPartialError    `json:"partial_errors,omitempty"`
+	ReadableText  string                   `json:"readable_text,omitempty"`
+}
+
+type ContextPromotionArtifact struct {
+	PromotionID    string `json:"promotion_id,omitempty"`
+	ReviewerSlug   string `json:"reviewer_slug,omitempty"`
+	State          string `json:"state,omitempty"`
+	HumanOnly      bool   `json:"human_only,omitempty"`
+	SourcePath     string `json:"source_path,omitempty"`
+	TargetWikiPath string `json:"target_wiki_path,omitempty"`
+	Skipped        bool   `json:"skipped,omitempty"`
+	SkipReason     string `json:"skip_reason,omitempty"`
+}
+
+type ContextPromoteResult struct {
+	Tool          string                    `json:"tool"`
+	TaskID        string                    `json:"task_id,omitempty"`
+	Backend       ContextBackendStatus      `json:"backend"`
+	Status        ContextToolStatus         `json:"status"`
+	Promotion     *ContextPromotionArtifact `json:"promotion,omitempty"`
+	Workflow      *ContextWorkflowUpdate    `json:"workflow,omitempty"`
+	PartialErrors []ContextPartialError     `json:"partial_errors,omitempty"`
+	ReadableText  string                    `json:"readable_text,omitempty"`
+}
+
+type ContextHealthResult struct {
+	Tool           string                `json:"tool"`
+	Backend        ContextBackendStatus  `json:"backend"`
+	Status         ContextToolStatus     `json:"status"`
+	TaskID         string                `json:"task_id,omitempty"`
+	Task           map[string]any        `json:"task,omitempty"`
+	MemoryWorkflow any                   `json:"memory_workflow,omitempty"`
+	PartialErrors  []ContextPartialError `json:"partial_errors,omitempty"`
+	ReadableText   string                `json:"readable_text,omitempty"`
+}
+
+func registerContextTools(server *mcp.Server) {
+	mcp.AddTool(server, readOnlyTool(
+		"context_lookup",
+		"Backend-neutral context lookup. Returns typed citations plus a readable summary from the active WUPHF context backend.",
+	), handleContextLookup)
+	mcp.AddTool(server, officeWriteTool(
+		"context_capture",
+		"Capture durable task context. On markdown backend this writes a notebook entry and records task memory workflow progress.",
+	), handleContextCapture)
+	mcp.AddTool(server, officeWriteTool(
+		"context_promote",
+		"Submit a captured notebook entry through the existing notebook-to-wiki promotion flow and record task memory workflow progress.",
+	), handleContextPromote)
+	mcp.AddTool(server, readOnlyTool(
+		"context_health",
+		"Report the active context backend and, when task_id is supplied, the task memory workflow state known by the broker.",
+	), handleContextHealth)
+}
+
+func handleContextLookup(ctx context.Context, _ *mcp.CallToolRequest, args ContextLookupArgs) (*mcp.CallToolResult, any, error) {
+	query := strings.TrimSpace(args.Query)
+	if query == "" {
+		return toolError(fmt.Errorf("query is required")), nil, nil
+	}
+	limit := normalizeContextLimit(args.Limit)
+	includePrivate, includeShared := normalizeContextLookupScopes(args.IncludePrivate, args.IncludeShared)
+	lookupCtx, cancel := context.WithTimeout(ctx, normalizeContextTimeout(args.TimeoutMS))
+	defer cancel()
+
+	backend := currentContextBackendStatus()
+	result := ContextLookupResult{
+		Tool:      "context_lookup",
+		Query:     query,
+		TaskID:    strings.TrimSpace(args.TaskID),
+		TaskType:  strings.TrimSpace(args.TaskType),
+		Limit:     limit,
+		Backend:   backend,
+		Status:    ContextToolStatus{OK: true, Code: "ok"},
+		Citations: []ContextCitation{},
+	}
+
+	switch backend.ActiveKind {
+	case config.MemoryBackendMarkdown:
+		if includePrivate {
+			citations, partials := lookupMarkdownNotebooks(lookupCtx, query, limit)
+			result.Citations = append(result.Citations, citations...)
+			result.PartialErrors = append(result.PartialErrors, partials...)
+		}
+		if includeShared {
+			citations, partials := lookupMarkdownWiki(lookupCtx, query, limit)
+			result.Citations = append(result.Citations, citations...)
+			result.PartialErrors = append(result.PartialErrors, partials...)
+		}
+	case config.MemoryBackendNex, config.MemoryBackendGBrain:
+		if includeShared {
+			hits, err := contextQuerySharedMemory(lookupCtx, query, limit)
+			if err != nil {
+				result.PartialErrors = append(result.PartialErrors, partialError("shared", backend.ActiveKind, "backend_error", err, true))
+			} else {
+				for _, hit := range hits {
+					result.Citations = append(result.Citations, citationFromScopedMemoryHit(hit))
+				}
+			}
+		}
+	case config.MemoryBackendNone:
+		result.Status = inactiveContextStatus(backend)
+		result.PartialErrors = append(result.PartialErrors, ContextPartialError{
+			Source:  "backend",
+			Backend: backend.SelectedKind,
+			Code:    result.Status.Code,
+			Message: result.Status.Message,
+		})
+	default:
+		result.Status = ContextToolStatus{OK: false, Code: "unsupported_backend", Message: "context backend is not supported by context_lookup"}
+		result.PartialErrors = append(result.PartialErrors, ContextPartialError{
+			Source:  "backend",
+			Backend: backend.ActiveKind,
+			Code:    "unsupported_backend",
+			Message: result.Status.Message,
+		})
+	}
+
+	if result.Status.OK && len(result.Citations) == 0 && len(result.PartialErrors) == 0 {
+		result.Status.Message = "No relevant context found."
+	}
+	if taskID := strings.TrimSpace(args.TaskID); taskID != "" {
+		result.Workflow = recordContextWorkflowEvent(lookupCtx, contextWorkflowEvent{
+			TaskID:    taskID,
+			Actor:     strings.TrimSpace(resolveSlugOptional(args.MySlug)),
+			Event:     "lookup",
+			Query:     query,
+			TaskType:  strings.TrimSpace(args.TaskType),
+			Citations: result.Citations,
+			Backend:   backend,
+		})
+		appendWorkflowPartial(&result.PartialErrors, result.Workflow, backend.ActiveKind)
+	}
+	result.ReadableText = formatContextLookupText(result)
+	return textResult(result.ReadableText), result, nil
+}
+
+func handleContextCapture(ctx context.Context, _ *mcp.CallToolRequest, args ContextCaptureArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	backend := currentContextBackendStatus()
+	result := ContextCaptureResult{Tool: "context_capture", TaskID: strings.TrimSpace(args.TaskID), Backend: backend, Status: ContextToolStatus{OK: true, Code: "ok"}}
+	if skip := strings.TrimSpace(args.SkipReason); skip != "" {
+		result.Notebook = &ContextNotebookArtifact{Skipped: true, SkipReason: skip}
+		result.Workflow = recordContextWorkflowEvent(ctx, contextWorkflowEvent{TaskID: strings.TrimSpace(args.TaskID), Actor: slug, Event: "capture_skipped", SkipReason: skip, Backend: backend})
+		appendWorkflowPartial(&result.PartialErrors, result.Workflow, backend.ActiveKind)
+		result.ReadableText = formatContextCaptureText(result)
+		return textResult(result.ReadableText), result, nil
+	}
+	content := strings.TrimSpace(args.Content)
+	if content == "" {
+		return toolError(fmt.Errorf("content is required unless skip_reason is supplied")), nil, nil
+	}
+	if backend.ActiveKind != config.MemoryBackendMarkdown {
+		result.Status = unsupportedContextWriteStatus(backend, "context_capture writes notebook entries only on the markdown backend")
+		result.PartialErrors = append(result.PartialErrors, ContextPartialError{Source: "notebook", Backend: backend.SelectedKind, Code: result.Status.Code, Message: result.Status.Message})
+		result.ReadableText = formatContextCaptureText(result)
+		return textResult(result.ReadableText), result, nil
+	}
+
+	path := strings.TrimSpace(args.NotebookPath)
+	if path == "" {
+		path = defaultContextNotebookPath(slug, args.Title, content)
+	}
+	if err := validateContextNotebookPath(slug, path); err != nil {
+		return toolError(err), nil, nil
+	}
+	mode := strings.TrimSpace(args.Mode)
+	if mode == "" {
+		mode = "create"
+	}
+	switch mode {
+	case "create", "replace", "append_section":
+	default:
+		return toolError(fmt.Errorf("mode must be one of create | replace | append_section; got %q", mode)), nil, nil
+	}
+
+	var writeResult struct {
+		Path         string `json:"path"`
+		CommitSHA    string `json:"commit_sha"`
+		BytesWritten int    `json:"bytes_written"`
+	}
+	if err := brokerPostJSON(ctx, "/notebook/write", map[string]any{
+		"slug":           slug,
+		"path":           path,
+		"mode":           mode,
+		"content":        renderContextNotebookContent(args.Title, content),
+		"commit_message": firstNonEmptyString(strings.TrimSpace(args.Title), "Capture task context"),
+	}, &writeResult); err != nil {
+		result.Status = ContextToolStatus{OK: false, Code: "backend_error", Message: err.Error(), Retryable: true}
+		result.PartialErrors = append(result.PartialErrors, partialError("notebook", backend.ActiveKind, "backend_error", err, true))
+		result.ReadableText = formatContextCaptureText(result)
+		return textResult(result.ReadableText), result, nil
+	}
+	result.Notebook = &ContextNotebookArtifact{Path: firstNonEmptyString(writeResult.Path, path), CommitSHA: strings.TrimSpace(writeResult.CommitSHA), BytesWritten: writeResult.BytesWritten}
+	result.Workflow = recordContextWorkflowEvent(ctx, contextWorkflowEvent{
+		TaskID: strings.TrimSpace(args.TaskID),
+		Actor:  slug,
+		Event:  "capture",
+		Artifact: map[string]any{
+			"type":          "notebook",
+			"path":          result.Notebook.Path,
+			"commit_sha":    result.Notebook.CommitSHA,
+			"bytes_written": result.Notebook.BytesWritten,
+		},
+		Backend: backend,
+	})
+	appendWorkflowPartial(&result.PartialErrors, result.Workflow, backend.ActiveKind)
+	result.ReadableText = formatContextCaptureText(result)
+	return textResult(result.ReadableText), result, nil
+}
+
+func handleContextPromote(ctx context.Context, _ *mcp.CallToolRequest, args ContextPromoteArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	backend := currentContextBackendStatus()
+	result := ContextPromoteResult{Tool: "context_promote", TaskID: strings.TrimSpace(args.TaskID), Backend: backend, Status: ContextToolStatus{OK: true, Code: "ok"}}
+	if skip := strings.TrimSpace(args.SkipReason); skip != "" {
+		result.Promotion = &ContextPromotionArtifact{Skipped: true, SkipReason: skip}
+		result.Workflow = recordContextWorkflowEvent(ctx, contextWorkflowEvent{TaskID: strings.TrimSpace(args.TaskID), Actor: slug, Event: "promote_skipped", SkipReason: skip, Backend: backend})
+		appendWorkflowPartial(&result.PartialErrors, result.Workflow, backend.ActiveKind)
+		result.ReadableText = formatContextPromoteText(result)
+		return textResult(result.ReadableText), result, nil
+	}
+	if backend.ActiveKind != config.MemoryBackendMarkdown {
+		result.Status = unsupportedContextWriteStatus(backend, "context_promote uses notebook promotion and is only available on the markdown backend")
+		result.PartialErrors = append(result.PartialErrors, ContextPartialError{Source: "promotion", Backend: backend.SelectedKind, Code: result.Status.Code, Message: result.Status.Message})
+		result.ReadableText = formatContextPromoteText(result)
+		return textResult(result.ReadableText), result, nil
+	}
+
+	sourcePath := strings.TrimSpace(args.SourcePath)
+	targetPath := strings.TrimSpace(args.TargetWikiPath)
+	rationale := strings.TrimSpace(args.Rationale)
+	if err := validateContextPromotion(slug, sourcePath, targetPath, rationale); err != nil {
+		return toolError(err), nil, nil
+	}
+	var promoteResult struct {
+		PromotionID  string `json:"promotion_id"`
+		ReviewerSlug string `json:"reviewer_slug"`
+		State        string `json:"state"`
+		HumanOnly    bool   `json:"human_only"`
+	}
+	if err := brokerPostJSON(ctx, "/notebook/promote", map[string]any{
+		"my_slug":          slug,
+		"source_path":      sourcePath,
+		"target_wiki_path": targetPath,
+		"rationale":        rationale,
+		"reviewer_slug":    strings.TrimSpace(args.ReviewerSlug),
+	}, &promoteResult); err != nil {
+		result.Status = ContextToolStatus{OK: false, Code: "backend_error", Message: err.Error(), Retryable: true}
+		result.PartialErrors = append(result.PartialErrors, partialError("promotion", backend.ActiveKind, "backend_error", err, true))
+		result.ReadableText = formatContextPromoteText(result)
+		return textResult(result.ReadableText), result, nil
+	}
+	result.Promotion = &ContextPromotionArtifact{
+		PromotionID:    strings.TrimSpace(promoteResult.PromotionID),
+		ReviewerSlug:   strings.TrimSpace(promoteResult.ReviewerSlug),
+		State:          strings.TrimSpace(promoteResult.State),
+		HumanOnly:      promoteResult.HumanOnly,
+		SourcePath:     sourcePath,
+		TargetWikiPath: targetPath,
+	}
+	result.Workflow = recordContextWorkflowEvent(ctx, contextWorkflowEvent{
+		TaskID: strings.TrimSpace(args.TaskID),
+		Actor:  slug,
+		Event:  "promote",
+		Artifact: map[string]any{
+			"type":             "promotion",
+			"promotion_id":     result.Promotion.PromotionID,
+			"state":            result.Promotion.State,
+			"source_path":      sourcePath,
+			"target_wiki_path": targetPath,
+		},
+		Backend: backend,
+	})
+	appendWorkflowPartial(&result.PartialErrors, result.Workflow, backend.ActiveKind)
+	result.ReadableText = formatContextPromoteText(result)
+	return textResult(result.ReadableText), result, nil
+}
+
+func handleContextHealth(ctx context.Context, _ *mcp.CallToolRequest, args ContextHealthArgs) (*mcp.CallToolResult, any, error) {
+	backend := currentContextBackendStatus()
+	result := ContextHealthResult{Tool: "context_health", Backend: backend, Status: ContextToolStatus{OK: true, Code: "ok"}, TaskID: strings.TrimSpace(args.TaskID)}
+	if result.TaskID != "" {
+		task, workflow, err := fetchContextTaskWorkflow(ctx, result.TaskID)
+		if err != nil {
+			result.PartialErrors = append(result.PartialErrors, partialError("task_workflow", backend.ActiveKind, "backend_error", err, true))
+		} else {
+			result.Task = task
+			result.MemoryWorkflow = workflow
+		}
+	}
+	result.ReadableText = formatContextHealthText(result)
+	return textResult(result.ReadableText), result, nil
+}
+
+func lookupMarkdownWiki(ctx context.Context, query string, limit int) ([]ContextCitation, []ContextPartialError) {
+	var result struct {
+		Hits []struct {
+			Path    string `json:"path"`
+			Line    int    `json:"line"`
+			Snippet string `json:"snippet"`
+		} `json:"hits"`
+	}
+	if err := brokerGetJSON(ctx, "/wiki/search?pattern="+url.QueryEscape(query), &result); err != nil {
+		return nil, []ContextPartialError{partialError("wiki", config.MemoryBackendMarkdown, contextErrorCode(err), err, true)}
+	}
+	if limit > len(result.Hits) {
+		limit = len(result.Hits)
+	}
+	citations := make([]ContextCitation, 0, limit)
+	for _, hit := range result.Hits[:limit] {
+		path := strings.TrimSpace(hit.Path)
+		citations = append(citations, ContextCitation{
+			Corpus:     "wiki",
+			Backend:    config.MemoryBackendMarkdown,
+			Scope:      "shared",
+			Identifier: path,
+			Path:       path,
+			Line:       hit.Line,
+			Title:      titleFromContextPath(path),
+			Snippet:    truncate(strings.TrimSpace(hit.Snippet), contextSnippetMaxLength),
+		})
+	}
+	return citations, nil
+}
+
+func lookupMarkdownNotebooks(ctx context.Context, query string, limit int) ([]ContextCitation, []ContextPartialError) {
+	var catalog struct {
+		Agents []struct {
+			AgentSlug string `json:"agent_slug"`
+		} `json:"agents"`
+	}
+	if err := brokerGetJSON(ctx, "/notebook/catalog", &catalog); err != nil {
+		return nil, []ContextPartialError{partialError("notebook", config.MemoryBackendMarkdown, contextErrorCode(err), err, true)}
+	}
+	slugs := make([]string, 0, len(catalog.Agents))
+	seen := map[string]bool{}
+	for _, agent := range catalog.Agents {
+		slug := strings.TrimSpace(agent.AgentSlug)
+		if slug == "" || seen[slug] {
+			continue
+		}
+		seen[slug] = true
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+
+	citations := make([]ContextCitation, 0, limit)
+	var partials []ContextPartialError
+	for _, slug := range slugs {
+		if len(citations) >= limit {
+			break
+		}
+		values := url.Values{}
+		values.Set("slug", slug)
+		values.Set("q", query)
+		var search struct {
+			Hits []struct {
+				Path    string `json:"path"`
+				Line    int    `json:"line"`
+				Snippet string `json:"snippet"`
+			} `json:"hits"`
+		}
+		if err := brokerGetJSON(ctx, "/notebook/search?"+values.Encode(), &search); err != nil {
+			partials = append(partials, partialError("notebook:"+slug, config.MemoryBackendMarkdown, contextErrorCode(err), err, true))
+			if ctx.Err() != nil {
+				break
+			}
+			continue
+		}
+		for _, hit := range search.Hits {
+			if len(citations) >= limit {
+				break
+			}
+			path := strings.TrimSpace(hit.Path)
+			citations = append(citations, ContextCitation{
+				Corpus:     "notebook",
+				Backend:    config.MemoryBackendMarkdown,
+				Scope:      "private",
+				Identifier: path,
+				Path:       path,
+				Line:       hit.Line,
+				Title:      titleFromContextPath(path),
+				Snippet:    truncate(strings.TrimSpace(hit.Snippet), contextSnippetMaxLength),
+				OwnerSlug:  slug,
+			})
+		}
+	}
+	return citations, partials
+}
+
+func citationFromScopedMemoryHit(hit team.ScopedMemoryHit) ContextCitation {
+	identifier := strings.TrimSpace(hit.Identifier)
+	return ContextCitation{
+		Corpus:     "shared",
+		Backend:    strings.TrimSpace(hit.Backend),
+		Scope:      strings.TrimSpace(hit.Scope),
+		Identifier: identifier,
+		Title:      strings.TrimSpace(hit.Title),
+		Snippet:    truncate(strings.TrimSpace(hit.Snippet), contextSnippetMaxLength),
+		OwnerSlug:  strings.TrimSpace(hit.OwnerSlug),
+		Slug:       firstNonEmptyString(strings.TrimSpace(hit.Slug), identifier),
+		PageID:     hit.PageID,
+		ChunkID:    hit.ChunkID,
+		ChunkIndex: hit.ChunkIndex,
+		Source:     strings.TrimSpace(hit.Source),
+		Score:      hit.Score,
+		Stale:      hit.Stale,
+	}
+}
+
+type contextWorkflowEvent struct {
+	TaskID     string
+	Actor      string
+	Event      string
+	Query      string
+	TaskType   string
+	Citations  []ContextCitation
+	Artifact   map[string]any
+	Backend    ContextBackendStatus
+	SkipReason string
+}
+
+func recordContextWorkflowEvent(ctx context.Context, event contextWorkflowEvent) *ContextWorkflowUpdate {
+	taskID := strings.TrimSpace(event.TaskID)
+	if taskID == "" {
+		return nil
+	}
+	update := &ContextWorkflowUpdate{Attempted: true, TaskID: taskID, Event: strings.TrimSpace(event.Event)}
+	var response map[string]any
+	if err := brokerPostJSON(ctx, "/tasks/memory-workflow", map[string]any{
+		"task_id":     taskID,
+		"actor":       strings.TrimSpace(event.Actor),
+		"event":       strings.TrimSpace(event.Event),
+		"query":       strings.TrimSpace(event.Query),
+		"task_type":   strings.TrimSpace(event.TaskType),
+		"citations":   event.Citations,
+		"artifact":    event.Artifact,
+		"backend":     event.Backend,
+		"skip_reason": strings.TrimSpace(event.SkipReason),
+	}, &response); err != nil {
+		update.Code = workflowUpdateErrorCode(err)
+		update.Error = err.Error()
+		return update
+	}
+	update.Updated = true
+	update.Response = response
+	return update
+}
+
+func fetchContextTaskWorkflow(ctx context.Context, taskID string) (map[string]any, any, error) {
+	var response struct {
+		Tasks []map[string]any `json:"tasks"`
+	}
+	if err := brokerGetJSON(ctx, "/tasks?all_channels=true&include_done=true", &response); err != nil {
+		return nil, nil, err
+	}
+	for _, task := range response.Tasks {
+		if fmt.Sprint(task["id"]) == taskID {
+			return task, task["memory_workflow"], nil
+		}
+	}
+	return nil, nil, fmt.Errorf("task %q not found", taskID)
+}
+
+func currentContextBackendStatus() ContextBackendStatus {
+	status := contextResolveMemoryBackendStatus()
+	return ContextBackendStatus{
+		SelectedKind:  strings.TrimSpace(status.SelectedKind),
+		SelectedLabel: strings.TrimSpace(status.SelectedLabel),
+		ActiveKind:    strings.TrimSpace(status.ActiveKind),
+		ActiveLabel:   strings.TrimSpace(status.ActiveLabel),
+		Active:        strings.TrimSpace(status.ActiveKind) != "" && strings.TrimSpace(status.ActiveKind) != config.MemoryBackendNone,
+		Detail:        strings.TrimSpace(status.Detail),
+		NextStep:      strings.TrimSpace(status.NextStep),
+	}
+}
+
+func normalizeContextLimit(limit int) int {
+	if limit <= 0 {
+		return contextDefaultLimit
+	}
+	if limit > contextMaxLimit {
+		return contextMaxLimit
+	}
+	return limit
+}
+
+func normalizeContextTimeout(timeoutMS int) time.Duration {
+	if timeoutMS <= 0 {
+		return contextDefaultTimeout
+	}
+	if timeoutMS > int(contextMaxTimeout/time.Millisecond) {
+		return contextMaxTimeout
+	}
+	return time.Duration(timeoutMS) * time.Millisecond
+}
+
+func normalizeContextLookupScopes(includePrivate, includeShared bool) (bool, bool) {
+	if !includePrivate && !includeShared {
+		return true, true
+	}
+	return includePrivate, includeShared
+}
+
+func inactiveContextStatus(backend ContextBackendStatus) ContextToolStatus {
+	if backend.SelectedKind == config.MemoryBackendNone {
+		return ContextToolStatus{OK: false, Code: "backend_disabled", Message: firstNonEmptyString(backend.Detail, "External context memory is disabled for this run.")}
+	}
+	return ContextToolStatus{OK: false, Code: "backend_inactive", Message: firstNonEmptyString(backend.Detail, "Selected context backend is not active.")}
+}
+
+func unsupportedContextWriteStatus(backend ContextBackendStatus, message string) ContextToolStatus {
+	if backend.ActiveKind == config.MemoryBackendNone {
+		status := inactiveContextStatus(backend)
+		status.Message = firstNonEmptyString(message, status.Message)
+		return status
+	}
+	return ContextToolStatus{OK: false, Code: "unsupported_backend", Message: message}
+}
+
+func partialError(source, backend, code string, err error, retryable bool) ContextPartialError {
+	msg := ""
+	if err != nil {
+		msg = err.Error()
+	}
+	return ContextPartialError{Source: source, Backend: backend, Code: code, Message: msg, Retryable: retryable}
+}
+
+func appendWorkflowPartial(partials *[]ContextPartialError, update *ContextWorkflowUpdate, backend string) {
+	if update == nil || update.Error == "" {
+		return
+	}
+	*partials = append(*partials, ContextPartialError{Source: "task_workflow", Backend: backend, Code: update.Code, Message: update.Error, Retryable: update.Code != "workflow_endpoint_unavailable"})
+}
+
+func contextErrorCode(err error) string {
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "context deadline exceeded") {
+		return "timeout"
+	}
+	return "backend_error"
+}
+
+func workflowUpdateErrorCode(err error) string {
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "404") || strings.Contains(msg, "405") {
+		return "workflow_endpoint_unavailable"
+	}
+	if strings.Contains(msg, "context deadline exceeded") {
+		return "timeout"
+	}
+	return "workflow_update_failed"
+}
+
+func defaultContextNotebookPath(slug, title, content string) string {
+	base := normalizeMemoryKey(firstNonEmptyString(title, content))
+	if base == "" {
+		base = "context-note"
+	}
+	base = trimContextFilename(base, 72)
+	return fmt.Sprintf("agents/%s/notebook/%s-%s.md", slug, contextNow().UTC().Format("2006-01-02"), base)
+}
+
+func validateContextNotebookPath(slug, path string) error {
+	expectedPrefix := "agents/" + slug + "/notebook/"
+	if !strings.HasPrefix(path, expectedPrefix) {
+		return fmt.Errorf("notebook_path_not_author_owned: path %q must start with %s", path, expectedPrefix)
+	}
+	if !strings.HasSuffix(strings.ToLower(path), ".md") {
+		return fmt.Errorf("notebook_path must end in .md; got %q", path)
+	}
+	if strings.Contains(path, "..") || strings.Contains(path, "\\") {
+		return fmt.Errorf("notebook_path must not contain path traversal; got %q", path)
+	}
+	return nil
+}
+
+func validateContextPromotion(slug, sourcePath, targetPath, rationale string) error {
+	if sourcePath == "" {
+		return fmt.Errorf("source_path is required")
+	}
+	expectedSourcePrefix := "agents/" + slug + "/notebook/"
+	if !strings.HasPrefix(sourcePath, expectedSourcePrefix) {
+		return fmt.Errorf("source_path %q must start with %s", sourcePath, expectedSourcePrefix)
+	}
+	if !strings.HasSuffix(strings.ToLower(sourcePath), ".md") {
+		return fmt.Errorf("source_path must end in .md; got %q", sourcePath)
+	}
+	if targetPath == "" {
+		return fmt.Errorf("target_wiki_path is required")
+	}
+	if !strings.HasPrefix(targetPath, "team/") {
+		return fmt.Errorf("target_wiki_path %q must start with team/", targetPath)
+	}
+	if !strings.HasSuffix(strings.ToLower(targetPath), ".md") {
+		return fmt.Errorf("target_wiki_path must end in .md; got %q", targetPath)
+	}
+	if rationale == "" {
+		return fmt.Errorf("rationale is required")
+	}
+	return nil
+}
+
+func renderContextNotebookContent(title, content string) string {
+	content = strings.TrimSpace(content)
+	if strings.HasPrefix(content, "# ") || strings.HasPrefix(content, "---\n") {
+		return content + "\n"
+	}
+	title = firstNonEmptyString(title, "Context capture")
+	return "# " + title + "\n\n" + content + "\n"
+}
+
+func formatContextLookupText(result ContextLookupResult) string {
+	lines := []string{fmt.Sprintf("Context lookup: %s backend (%s active)", result.Backend.SelectedKind, result.Backend.ActiveKind)}
+	if len(result.Citations) == 0 {
+		lines = append(lines, "No context citations found.")
+	} else {
+		lines = append(lines, fmt.Sprintf("Citations (%d):", len(result.Citations)))
+		for _, c := range result.Citations {
+			ref := firstNonEmptyString(c.Path, c.Identifier, c.Slug)
+			if c.Line > 0 {
+				ref = fmt.Sprintf("%s:%d", ref, c.Line)
+			}
+			lines = append(lines, fmt.Sprintf("- %s [%s/%s] %s", firstNonEmptyString(c.Title, ref), c.Backend, c.Corpus, truncate(c.Snippet, 180)))
+		}
+	}
+	if len(result.PartialErrors) > 0 {
+		lines = append(lines, "Partial errors:")
+		for _, pe := range result.PartialErrors {
+			lines = append(lines, fmt.Sprintf("- %s: %s", pe.Source, pe.Message))
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatContextCaptureText(result ContextCaptureResult) string {
+	if result.Notebook != nil && result.Notebook.Skipped {
+		return "Context capture skipped: " + result.Notebook.SkipReason
+	}
+	if result.Status.OK && result.Notebook != nil {
+		text := "Captured context in notebook " + result.Notebook.Path
+		if result.Workflow != nil && result.Workflow.Updated {
+			text += " and updated task memory workflow."
+		}
+		if len(result.PartialErrors) > 0 {
+			text += " Partial errors: " + joinPartialErrorMessages(result.PartialErrors)
+		}
+		return text
+	}
+	return "Context capture unavailable: " + firstNonEmptyString(result.Status.Message, result.Status.Code)
+}
+
+func formatContextPromoteText(result ContextPromoteResult) string {
+	if result.Promotion != nil && result.Promotion.Skipped {
+		return "Context promotion skipped: " + result.Promotion.SkipReason
+	}
+	if result.Status.OK && result.Promotion != nil {
+		text := fmt.Sprintf("Submitted notebook promotion %s (%s) for %s.", result.Promotion.PromotionID, result.Promotion.State, result.Promotion.TargetWikiPath)
+		if result.Workflow != nil && result.Workflow.Updated {
+			text += " Updated task memory workflow."
+		}
+		if len(result.PartialErrors) > 0 {
+			text += " Partial errors: " + joinPartialErrorMessages(result.PartialErrors)
+		}
+		return text
+	}
+	return "Context promotion unavailable: " + firstNonEmptyString(result.Status.Message, result.Status.Code)
+}
+
+func formatContextHealthText(result ContextHealthResult) string {
+	lines := []string{fmt.Sprintf("Context backend: selected=%s active=%s", result.Backend.SelectedKind, result.Backend.ActiveKind)}
+	if result.Backend.Detail != "" {
+		lines = append(lines, result.Backend.Detail)
+	}
+	if result.TaskID != "" {
+		switch {
+		case result.Task == nil:
+			lines = append(lines, "Task workflow: unavailable")
+		case result.MemoryWorkflow == nil:
+			lines = append(lines, "Task workflow: not present")
+		default:
+			lines = append(lines, "Task workflow: present")
+		}
+	}
+	if len(result.PartialErrors) > 0 {
+		lines = append(lines, "Partial errors: "+joinPartialErrorMessages(result.PartialErrors))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func joinPartialErrorMessages(partials []ContextPartialError) string {
+	messages := make([]string, 0, len(partials))
+	for _, pe := range partials {
+		messages = append(messages, pe.Source+": "+pe.Message)
+	}
+	return strings.Join(messages, "; ")
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func titleFromContextPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	base := path
+	if idx := strings.LastIndex(base, "/"); idx >= 0 {
+		base = base[idx+1:]
+	}
+	base = strings.TrimSuffix(base, ".md")
+	base = strings.ReplaceAll(base, "-", " ")
+	base = strings.ReplaceAll(base, "_", " ")
+	return strings.TrimSpace(base)
+}
+
+func trimContextFilename(value string, max int) string {
+	value = strings.Trim(value, "-")
+	if len(value) <= max {
+		return value
+	}
+	value = value[:max]
+	return strings.Trim(value[:max], "-")
+}

--- a/internal/teammcp/context_tools.go
+++ b/internal/teammcp/context_tools.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -269,7 +270,9 @@ func handleContextLookup(ctx context.Context, _ *mcp.CallToolRequest, args Conte
 		result.Status.Message = "No relevant context found."
 	}
 	if taskID := strings.TrimSpace(args.TaskID); taskID != "" {
-		result.Workflow = recordContextWorkflowEvent(lookupCtx, contextWorkflowEvent{
+		workflowCtx, workflowCancel := context.WithTimeout(ctx, contextDefaultTimeout)
+		defer workflowCancel()
+		result.Workflow = recordContextWorkflowEvent(workflowCtx, contextWorkflowEvent{
 			TaskID:    taskID,
 			Actor:     strings.TrimSpace(resolveSlugOptional(args.MySlug)),
 			Event:     "lookup",
@@ -589,7 +592,7 @@ func recordContextWorkflowEvent(ctx context.Context, event contextWorkflowEvent)
 		"event":       strings.TrimSpace(event.Event),
 		"query":       strings.TrimSpace(event.Query),
 		"task_type":   strings.TrimSpace(event.TaskType),
-		"citations":   event.Citations,
+		"citations":   workflowCitations(event.Citations),
 		"artifact":    event.Artifact,
 		"backend":     event.Backend,
 		"skip_reason": strings.TrimSpace(event.SkipReason),
@@ -598,9 +601,45 @@ func recordContextWorkflowEvent(ctx context.Context, event contextWorkflowEvent)
 		update.Error = err.Error()
 		return update
 	}
-	update.Updated = true
 	update.Response = response
+	if updated, ok := response["updated"].(bool); ok {
+		update.Updated = updated
+	} else {
+		update.Updated = true
+	}
 	return update
+}
+
+func workflowCitations(citations []ContextCitation) []team.ContextCitation {
+	if len(citations) == 0 {
+		return nil
+	}
+	out := make([]team.ContextCitation, 0, len(citations))
+	for _, citation := range citations {
+		pageID := ""
+		if citation.PageID != 0 {
+			pageID = strconv.Itoa(citation.PageID)
+		}
+		chunkID := ""
+		if citation.ChunkID != 0 {
+			chunkID = strconv.Itoa(citation.ChunkID)
+		}
+		out = append(out, team.ContextCitation{
+			Backend:   strings.TrimSpace(citation.Backend),
+			Source:    firstNonEmptyString(citation.Source, citation.Corpus),
+			SourceID:  firstNonEmptyString(citation.Identifier, citation.Slug),
+			Path:      strings.TrimSpace(citation.Path),
+			PageID:    pageID,
+			ChunkID:   chunkID,
+			LineStart: citation.Line,
+			LineEnd:   citation.Line,
+			Title:     strings.TrimSpace(citation.Title),
+			Snippet:   strings.TrimSpace(citation.Snippet),
+			Score:     citation.Score,
+			Stale:     citation.Stale,
+		})
+	}
+	return out
 }
 
 func fetchContextTaskWorkflow(ctx context.Context, taskID string) (map[string]any, any, error) {
@@ -731,12 +770,18 @@ func validateContextNotebookPath(slug, path string) error {
 }
 
 func validateContextPromotion(slug, sourcePath, targetPath, rationale string) error {
+	sourcePath = strings.TrimSpace(sourcePath)
+	targetPath = strings.TrimSpace(targetPath)
+	rationale = strings.TrimSpace(rationale)
 	if sourcePath == "" {
 		return fmt.Errorf("source_path is required")
 	}
 	expectedSourcePrefix := "agents/" + slug + "/notebook/"
 	if !strings.HasPrefix(sourcePath, expectedSourcePrefix) {
 		return fmt.Errorf("source_path %q must start with %s", sourcePath, expectedSourcePrefix)
+	}
+	if strings.Contains(sourcePath, "..") || strings.Contains(sourcePath, "\\") {
+		return fmt.Errorf("source_path must not contain path traversal; got %q", sourcePath)
 	}
 	if !strings.HasSuffix(strings.ToLower(sourcePath), ".md") {
 		return fmt.Errorf("source_path must end in .md; got %q", sourcePath)
@@ -746,6 +791,9 @@ func validateContextPromotion(slug, sourcePath, targetPath, rationale string) er
 	}
 	if !strings.HasPrefix(targetPath, "team/") {
 		return fmt.Errorf("target_wiki_path %q must start with team/", targetPath)
+	}
+	if strings.Contains(targetPath, "..") || strings.Contains(targetPath, "\\") {
+		return fmt.Errorf("target_wiki_path must not contain path traversal; got %q", targetPath)
 	}
 	if !strings.HasSuffix(strings.ToLower(targetPath), ".md") {
 		return fmt.Errorf("target_wiki_path must end in .md; got %q", targetPath)

--- a/internal/teammcp/context_tools_test.go
+++ b/internal/teammcp/context_tools_test.go
@@ -1,0 +1,280 @@
+package teammcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/team"
+)
+
+func TestContextLookupMarkdownReturnsTypedNotebookAndWikiCitations(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendMarkdown)
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+	var workflowCalled bool
+	srv, _ := stubBroker(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/notebook/catalog":
+			_ = json.NewEncoder(w).Encode(map[string]any{"agents": []map[string]any{{"agent_slug": "pm"}}})
+		case "/notebook/search":
+			if r.URL.Query().Get("slug") != "pm" || r.URL.Query().Get("q") != "passport" {
+				t.Fatalf("unexpected notebook search query: %s", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"hits": []map[string]any{{
+				"path": "agents/pm/notebook/passport.md", "line": 3, "snippet": "passport checklist from prior run",
+			}}})
+		case "/wiki/search":
+			if r.URL.Query().Get("pattern") != "passport" {
+				t.Fatalf("unexpected wiki search query: %s", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"hits": []map[string]any{{
+				"path": "team/processes/passport.md", "line": 9, "snippet": "canonical passport process note",
+			}}})
+		case "/tasks/memory-workflow":
+			workflowCalled = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"updated": true})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+
+	res, data, err := handleContextLookup(context.Background(), nil, ContextLookupArgs{
+		Query: "passport", TaskID: "task-1", TaskType: "research", Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("tool error: %s", toolErrorText(res))
+	}
+	result := data.(ContextLookupResult)
+	if !workflowCalled || result.Workflow == nil || !result.Workflow.Updated {
+		t.Fatalf("expected workflow update, got called=%v workflow=%+v", workflowCalled, result.Workflow)
+	}
+	if len(result.Citations) != 2 {
+		t.Fatalf("expected notebook + wiki citation, got %+v", result.Citations)
+	}
+	corpuses := []string{result.Citations[0].Corpus, result.Citations[1].Corpus}
+	if !slices.Contains(corpuses, "notebook") || !slices.Contains(corpuses, "wiki") {
+		t.Fatalf("expected notebook and wiki corpuses, got %+v", result.Citations)
+	}
+	for _, citation := range result.Citations {
+		if citation.Snippet == "" || citation.Path == "" || citation.Line == 0 {
+			t.Fatalf("expected typed citation fields from broker JSON, got %+v", citation)
+		}
+	}
+}
+
+func TestContextLookupGBrainMapsTypedCitationFields(t *testing.T) {
+	oldStatus := contextResolveMemoryBackendStatus
+	oldQuery := contextQuerySharedMemory
+	t.Cleanup(func() {
+		contextResolveMemoryBackendStatus = oldStatus
+		contextQuerySharedMemory = oldQuery
+	})
+	contextResolveMemoryBackendStatus = func() team.MemoryBackendStatus {
+		return team.MemoryBackendStatus{SelectedKind: config.MemoryBackendGBrain, SelectedLabel: "GBrain", ActiveKind: config.MemoryBackendGBrain, ActiveLabel: "GBrain"}
+	}
+	score := 0.87
+	stale := true
+	contextQuerySharedMemory = func(context.Context, string, int) ([]team.ScopedMemoryHit, error) {
+		return []team.ScopedMemoryHit{{
+			Scope: "shared", Backend: config.MemoryBackendGBrain, Identifier: "people/nazz", Title: "Nazz", Snippet: "typed chunk",
+			Slug: "people/nazz", PageID: 42, ChunkID: 7, ChunkIndex: 3, Source: "compiled_truth", Score: &score, Stale: &stale,
+		}}, nil
+	}
+
+	_, data, err := handleContextLookup(context.Background(), nil, ContextLookupArgs{Query: "nazz", IncludeShared: true})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	citation := data.(ContextLookupResult).Citations[0]
+	if citation.Slug != "people/nazz" || citation.PageID != 42 || citation.ChunkID != 7 || citation.ChunkIndex != 3 || citation.Source != "compiled_truth" {
+		t.Fatalf("missing gbrain typed fields: %+v", citation)
+	}
+	if citation.Score == nil || *citation.Score != score || citation.Stale == nil || !*citation.Stale {
+		t.Fatalf("missing gbrain score/stale: %+v", citation)
+	}
+}
+
+func TestContextLookupInactiveBackendReturnsTypedEmptyResult(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendNone)
+	res, data, err := handleContextLookup(context.Background(), nil, ContextLookupArgs{Query: "anything"})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("inactive backend should be typed data, not tool error: %s", toolErrorText(res))
+	}
+	result := data.(ContextLookupResult)
+	if result.Status.OK || result.Status.Code != "backend_disabled" {
+		t.Fatalf("expected backend_disabled status, got %+v", result.Status)
+	}
+	if len(result.Citations) != 0 || len(result.PartialErrors) == 0 {
+		t.Fatalf("expected empty citations plus partial status, got %+v", result)
+	}
+}
+
+func TestContextCaptureWritesNotebookAndUpdatesWorkflow(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendMarkdown)
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+	oldNow := contextNow
+	contextNow = func() time.Time { return time.Date(2026, 4, 30, 12, 0, 0, 0, time.UTC) }
+	t.Cleanup(func() { contextNow = oldNow })
+
+	var paths []string
+	var workflowBody string
+	var auth *testingAuth
+	srv, auth := stubBroker(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/notebook/write":
+			_ = json.NewEncoder(w).Encode(map[string]any{"path": "agents/pm/notebook/2026-04-30-passport-notes.md", "commit_sha": "abc123", "bytes_written": 44})
+		case "/tasks/memory-workflow":
+			workflowBody = auth.lastBody
+			_ = json.NewEncoder(w).Encode(map[string]any{"updated": true})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+
+	_, data, err := handleContextCapture(context.Background(), nil, ContextCaptureArgs{TaskID: "task-1", Title: "Passport notes", Content: "Stable process details."})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	result := data.(ContextCaptureResult)
+	if !result.Status.OK || result.Notebook == nil || result.Notebook.Path == "" {
+		t.Fatalf("expected notebook capture, got %+v", result)
+	}
+	if result.Workflow == nil || !result.Workflow.Updated {
+		t.Fatalf("expected workflow update, got %+v", result.Workflow)
+	}
+	if !slices.Contains(paths, "/notebook/write") || !slices.Contains(paths, "/tasks/memory-workflow") {
+		t.Fatalf("expected notebook and workflow broker paths, got %v", paths)
+	}
+	if !strings.Contains(workflowBody, `"event":"capture"`) || !strings.Contains(workflowBody, `"task_id":"task-1"`) {
+		t.Fatalf("unexpected workflow body: %s", workflowBody)
+	}
+}
+
+func TestContextPromoteUsesNotebookPromotionAndUpdatesWorkflow(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendMarkdown)
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+	var paths []string
+	var workflowBody string
+	var auth *testingAuth
+	srv, auth := stubBroker(t, func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/notebook/promote":
+			_ = json.NewEncoder(w).Encode(map[string]any{"promotion_id": "rvw-1", "reviewer_slug": "ceo", "state": "pending", "human_only": false})
+		case "/tasks/memory-workflow":
+			workflowBody = auth.lastBody
+			_ = json.NewEncoder(w).Encode(map[string]any{"updated": true})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+
+	_, data, err := handleContextPromote(context.Background(), nil, ContextPromoteArgs{
+		TaskID: "task-1", SourcePath: "agents/pm/notebook/passport.md", TargetWikiPath: "team/processes/passport.md", Rationale: "ready",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	result := data.(ContextPromoteResult)
+	if !result.Status.OK || result.Promotion == nil || result.Promotion.PromotionID != "rvw-1" {
+		t.Fatalf("expected promotion result, got %+v", result)
+	}
+	if result.Workflow == nil || !result.Workflow.Updated {
+		t.Fatalf("expected workflow update, got %+v", result.Workflow)
+	}
+	if !slices.Contains(paths, "/notebook/promote") || !slices.Contains(paths, "/tasks/memory-workflow") {
+		t.Fatalf("expected promotion and workflow broker paths, got %v", paths)
+	}
+	if !strings.Contains(workflowBody, `"event":"promote"`) || !strings.Contains(workflowBody, `"promotion_id":"rvw-1"`) {
+		t.Fatalf("unexpected workflow body: %s", workflowBody)
+	}
+}
+
+func TestContextCaptureAndPromoteUnsupportedOnExternalBackend(t *testing.T) {
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+	oldStatus := contextResolveMemoryBackendStatus
+	t.Cleanup(func() { contextResolveMemoryBackendStatus = oldStatus })
+	contextResolveMemoryBackendStatus = func() team.MemoryBackendStatus {
+		return team.MemoryBackendStatus{SelectedKind: config.MemoryBackendGBrain, ActiveKind: config.MemoryBackendGBrain}
+	}
+
+	_, captureData, err := handleContextCapture(context.Background(), nil, ContextCaptureArgs{Content: "do not pretend this wrote a notebook"})
+	if err != nil {
+		t.Fatalf("capture handler: %v", err)
+	}
+	capture := captureData.(ContextCaptureResult)
+	if capture.Status.Code != "unsupported_backend" || len(capture.PartialErrors) == 0 {
+		t.Fatalf("expected typed unsupported capture status, got %+v", capture)
+	}
+
+	_, promoteData, err := handleContextPromote(context.Background(), nil, ContextPromoteArgs{
+		SourcePath: "agents/pm/notebook/x.md", TargetWikiPath: "team/x.md", Rationale: "ready",
+	})
+	if err != nil {
+		t.Fatalf("promote handler: %v", err)
+	}
+	promote := promoteData.(ContextPromoteResult)
+	if promote.Status.Code != "unsupported_backend" || len(promote.PartialErrors) == 0 {
+		t.Fatalf("expected typed unsupported promote status, got %+v", promote)
+	}
+}
+
+func TestContextCaptureHandlesNotebookBackendError(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendMarkdown)
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+	srv, _ := stubBroker(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":"notebook backend is not active"}`, http.StatusServiceUnavailable)
+	})
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+
+	_, data, err := handleContextCapture(context.Background(), nil, ContextCaptureArgs{Title: "x", Content: "body"})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	result := data.(ContextCaptureResult)
+	if result.Status.Code != "backend_error" || len(result.PartialErrors) == 0 {
+		t.Fatalf("expected typed backend error, got %+v", result)
+	}
+}
+
+func TestContextHealthIncludesTaskMemoryWorkflow(t *testing.T) {
+	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendMarkdown)
+	srv, _ := stubBroker(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tasks" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"tasks": []map[string]any{{
+			"id": "task-1", "title": "Research", "memory_workflow": map[string]any{"required": true, "lookup": "done"},
+		}}})
+	})
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+
+	_, data, err := handleContextHealth(context.Background(), nil, ContextHealthArgs{TaskID: "task-1"})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	workflow, ok := data.(ContextHealthResult).MemoryWorkflow.(map[string]any)
+	if !ok || workflow["lookup"] != "done" {
+		t.Fatalf("expected task memory workflow, got %+v", data.(ContextHealthResult).MemoryWorkflow)
+	}
+}

--- a/internal/teammcp/context_tools_test.go
+++ b/internal/teammcp/context_tools_test.go
@@ -104,6 +104,45 @@ func TestContextLookupGBrainMapsTypedCitationFields(t *testing.T) {
 	}
 }
 
+func TestRecordContextWorkflowEventMapsCitationsAndUpdatedFlag(t *testing.T) {
+	var workflowBody map[string]any
+	var auth *testingAuth
+	srv, auth := stubBroker(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/tasks/memory-workflow" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		if err := json.NewDecoder(strings.NewReader(auth.lastBody)).Decode(&workflowBody); err != nil {
+			t.Fatalf("decode workflow body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"updated": false})
+	})
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+
+	score := 0.82
+	update := recordContextWorkflowEvent(context.Background(), contextWorkflowEvent{
+		TaskID: "task-1",
+		Actor:  "pm",
+		Event:  "lookup",
+		Query:  "passport",
+		Citations: []ContextCitation{{
+			Corpus: "shared", Backend: config.MemoryBackendGBrain, Identifier: "process/passport", Slug: "process/passport",
+			PageID: 42, ChunkID: 7, Line: 11, Source: "compiled_truth", Title: "Passport", Snippet: "typed chunk", Score: &score,
+		}},
+	})
+	if update == nil || update.Error != "" || update.Updated {
+		t.Fatalf("expected broker updated=false to propagate, got %+v", update)
+	}
+	citations, ok := workflowBody["citations"].([]any)
+	if !ok || len(citations) != 1 {
+		t.Fatalf("expected one mapped citation, got %+v", workflowBody["citations"])
+	}
+	citation := citations[0].(map[string]any)
+	if citation["chunk_id"] != "7" || citation["page_id"] != "42" || citation["line_start"] != float64(11) || citation["line_end"] != float64(11) {
+		t.Fatalf("expected team citation wire fields, got %+v", citation)
+	}
+}
+
 func TestContextLookupInactiveBackendReturnsTypedEmptyResult(t *testing.T) {
 	t.Setenv("WUPHF_MEMORY_BACKEND", config.MemoryBackendNone)
 	res, data, err := handleContextLookup(context.Background(), nil, ContextLookupArgs{Query: "anything"})
@@ -163,6 +202,43 @@ func TestContextCaptureWritesNotebookAndUpdatesWorkflow(t *testing.T) {
 	}
 	if !strings.Contains(workflowBody, `"event":"capture"`) || !strings.Contains(workflowBody, `"task_id":"task-1"`) {
 		t.Fatalf("unexpected workflow body: %s", workflowBody)
+	}
+}
+
+func TestValidateContextPromotionRejectsTraversal(t *testing.T) {
+	cases := []struct {
+		name       string
+		sourcePath string
+		targetPath string
+	}{
+		{
+			name:       "source traversal",
+			sourcePath: "agents/pm/notebook/../../team/secret.md",
+			targetPath: "team/processes/passport.md",
+		},
+		{
+			name:       "source backslash",
+			sourcePath: `agents/pm/notebook/passport\evil.md`,
+			targetPath: "team/processes/passport.md",
+		},
+		{
+			name:       "target traversal",
+			sourcePath: "agents/pm/notebook/passport.md",
+			targetPath: "team/../agents/other/notebook/passport.md",
+		},
+		{
+			name:       "target backslash",
+			sourcePath: "agents/pm/notebook/passport.md",
+			targetPath: `team/passport\evil.md`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateContextPromotion("pm", tc.sourcePath, tc.targetPath, "ready")
+			if err == nil || !strings.Contains(err.Error(), "path traversal") {
+				t.Fatalf("expected traversal rejection, got %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -618,6 +618,7 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 			"Send a direct human-facing note into the chat when you need to present completion, recommend a decision, or tell the human what they should do next.",
 		), handleHumanMessage)
 
+		registerContextTools(server)
 		registerSharedMemoryTools(server)
 
 		registerSkillAuthoringTools(server)
@@ -657,6 +658,7 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 			"human_interview",
 			"Ask the human an interview question. If they dismiss it, or send another message in this channel/thread, the interview is canceled.",
 		), handleHumanInterview)
+		registerContextTools(server)
 		registerSharedMemoryTools(server)
 		mcp.AddTool(server, officeWriteTool(
 			"team_skill_run",
@@ -735,6 +737,7 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 	if slug == "artist" {
 		registerImageTools(server)
 	}
+	registerContextTools(server)
 	registerSharedMemoryTools(server)
 
 	mcp.AddTool(server, readOnlyTool(

--- a/internal/teammcp/server_backend_switch_test.go
+++ b/internal/teammcp/server_backend_switch_test.go
@@ -42,7 +42,7 @@ func TestConfigureServerToolsBackendMatrix(t *testing.T) {
 				"team_memory_write",
 				"team_memory_promote",
 			},
-			commonPresent: []string{"team_broadcast", "team_poll"},
+			commonPresent: []string{"team_broadcast", "team_poll", "context_lookup", "context_capture", "context_promote", "context_health"},
 		},
 		{
 			name:    "nex/office",
@@ -60,7 +60,7 @@ func TestConfigureServerToolsBackendMatrix(t *testing.T) {
 				"notebook_write",
 				"notebook_promote",
 			},
-			commonPresent: []string{"team_broadcast", "team_poll"},
+			commonPresent: []string{"team_broadcast", "team_poll", "context_lookup", "context_capture", "context_promote", "context_health"},
 		},
 		{
 			name:    "gbrain/office",
@@ -78,7 +78,7 @@ func TestConfigureServerToolsBackendMatrix(t *testing.T) {
 				"notebook_write",
 				"notebook_promote",
 			},
-			commonPresent: []string{"team_broadcast", "team_poll"},
+			commonPresent: []string{"team_broadcast", "team_poll", "context_lookup", "context_capture", "context_promote", "context_health"},
 		},
 		{
 			name:     "none/office",
@@ -95,7 +95,7 @@ func TestConfigureServerToolsBackendMatrix(t *testing.T) {
 				"notebook_write",
 				"notebook_promote",
 			},
-			commonPresent: []string{"team_broadcast", "team_poll"},
+			commonPresent: []string{"team_broadcast", "team_poll", "context_lookup", "context_capture", "context_promote", "context_health"},
 		},
 		{
 			name:     "markdown/dm",
@@ -112,7 +112,7 @@ func TestConfigureServerToolsBackendMatrix(t *testing.T) {
 				"team_memory_write",
 				"team_memory_promote",
 			},
-			commonPresent: []string{"team_broadcast", "team_poll"},
+			commonPresent: []string{"team_broadcast", "team_poll", "context_lookup", "context_capture", "context_promote", "context_health"},
 		},
 		{
 			name:     "markdown/oneOnOne",
@@ -129,7 +129,7 @@ func TestConfigureServerToolsBackendMatrix(t *testing.T) {
 				"team_memory_write",
 				"team_memory_promote",
 			},
-			commonPresent: []string{"reply", "read_conversation"},
+			commonPresent: []string{"reply", "read_conversation", "context_lookup", "context_capture", "context_promote", "context_health"},
 		},
 	}
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -512,6 +512,7 @@ export interface TaskMemoryWorkflowArtifact {
   entity_slug?: string;
   playbook_slug?: string;
   title?: string;
+  skip_reason?: string;
   snippet?: string;
   commit_sha?: string;
   state?: string;

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -485,6 +485,83 @@ export function getVersion() {
 
 // ── Tasks ──
 
+export interface TaskMemoryWorkflowCitation {
+  backend?: string;
+  source?: string;
+  source_id?: string;
+  path?: string;
+  page_id?: string;
+  chunk_id?: string;
+  source_url?: string;
+  line_start?: number;
+  line_end?: number;
+  title?: string;
+  snippet?: string;
+  score?: number;
+  stale?: boolean;
+  retrieved_at?: string;
+}
+
+export interface TaskMemoryWorkflowArtifact {
+  backend?: string;
+  source?: string;
+  path?: string;
+  page_id?: string;
+  promotion_id?: string;
+  entity_kind?: string;
+  entity_slug?: string;
+  playbook_slug?: string;
+  title?: string;
+  snippet?: string;
+  commit_sha?: string;
+  state?: string;
+  recorded_at?: string;
+  updated_at?: string;
+  missing?: boolean;
+}
+
+export interface TaskMemoryWorkflowStepState {
+  required?: boolean;
+  status?: string;
+  actor?: string;
+  query?: string;
+  completed_at?: string;
+  updated_at?: string;
+  count?: number;
+}
+
+export interface TaskMemoryWorkflowOverride {
+  actor: string;
+  reason: string;
+  timestamp: string;
+}
+
+export interface TaskMemoryWorkflowPartialError {
+  step?: string;
+  code?: string;
+  message?: string;
+  detail?: string;
+  timestamp?: string;
+}
+
+export interface TaskMemoryWorkflow {
+  required: boolean;
+  status?: string;
+  requirement_reason?: string;
+  required_steps?: string[];
+  lookup?: TaskMemoryWorkflowStepState;
+  capture?: TaskMemoryWorkflowStepState;
+  promote?: TaskMemoryWorkflowStepState;
+  citations?: TaskMemoryWorkflowCitation[];
+  captures?: TaskMemoryWorkflowArtifact[];
+  promotions?: TaskMemoryWorkflowArtifact[];
+  override?: TaskMemoryWorkflowOverride;
+  partial_errors?: Array<string | TaskMemoryWorkflowPartialError>;
+  created_at?: string;
+  updated_at?: string;
+  completed_at?: string;
+}
+
 export interface Task {
   id: string;
   title: string;
@@ -513,6 +590,7 @@ export interface Task {
   recheck_at?: string;
   created_at?: string;
   updated_at?: string;
+  memory_workflow?: TaskMemoryWorkflow;
 }
 
 export interface CreateTaskInput {
@@ -566,18 +644,38 @@ export type TaskStatusAction =
   | "complete"
   | "cancel";
 
+export interface UpdateTaskStatusOptions {
+  memoryWorkflowOverride?: boolean;
+  memoryWorkflowOverrideActor?: string;
+  memoryWorkflowOverrideReason?: string;
+  overrideReason?: string;
+}
+
 export function updateTaskStatus(
   taskId: string,
   action: TaskStatusAction,
   channel: string,
   actor = "human",
+  options?: UpdateTaskStatusOptions,
 ) {
-  return post<{ task: Task }>("/tasks", {
+  const body: Record<string, string | boolean> = {
     action,
     id: taskId,
     channel: channel || "general",
     created_by: actor,
-  });
+  };
+  if (options?.memoryWorkflowOverride) {
+    body.memory_workflow_override = true;
+    body.memory_workflow_override_actor =
+      options.memoryWorkflowOverrideActor || actor;
+  }
+  const overrideReason =
+    options?.memoryWorkflowOverrideReason || options?.overrideReason;
+  if (overrideReason) {
+    body.memory_workflow_override_reason = overrideReason;
+    body.override_reason = overrideReason;
+  }
+  return post<{ task: Task }>("/tasks", body);
 }
 
 export function getTasks(
@@ -1026,7 +1124,9 @@ export function listAgentLogTasks(opts?: { limit?: number }) {
 }
 
 export function getAgentLogEntries(taskId: string) {
-  return get<{ task: string; entries: TaskLogEntry[] }>("/agent-logs", { task: taskId });
+  return get<{ task: string; entries: TaskLogEntry[] }>("/agent-logs", {
+    task: taskId,
+  });
 }
 
 // ── Memory ──

--- a/web/src/components/apps/TaskDetailModal.test.tsx
+++ b/web/src/components/apps/TaskDetailModal.test.tsx
@@ -140,7 +140,7 @@ describe("taskMemoryWorkflowBadge", () => {
 });
 
 describe("TaskDetailModal memory override", () => {
-  it("keeps the override action visible for issue-state completed workflows", () => {
+  it("keeps the override action visible for satisfied workflows with partial errors", () => {
     getOfficeMembersMock.mockResolvedValue({
       members: [{ slug: "ceo", name: "CEO", role: "lead" }],
     });
@@ -180,6 +180,7 @@ describe("TaskDetailModal memory override", () => {
       screen.getByRole("button", { name: "Mark done with override" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Mark done" })).toBeDisabled();
+    expect(screen.getByText("workflow write failed")).toBeInTheDocument();
   });
 
   it("requires a reason and submits the human override payload", async () => {

--- a/web/src/components/apps/TaskDetailModal.test.tsx
+++ b/web/src/components/apps/TaskDetailModal.test.tsx
@@ -1,0 +1,185 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Task } from "../../api/client";
+import { getOfficeMembers, updateTaskStatus } from "../../api/client";
+import { TaskDetailModal, taskMemoryWorkflowBadge } from "./TaskDetailModal";
+
+vi.mock("../../api/client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../api/client")>();
+  return {
+    ...actual,
+    getOfficeMembers: vi.fn(),
+    updateTaskStatus: vi.fn(),
+    reassignTask: vi.fn(),
+  };
+});
+
+const getOfficeMembersMock = vi.mocked(getOfficeMembers);
+const updateTaskStatusMock = vi.mocked(updateTaskStatus);
+
+function renderTaskDetail(task: Task, onClose = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return {
+    onClose,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <TaskDetailModal task={task} onClose={onClose} />
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+describe("taskMemoryWorkflowBadge", () => {
+  it("renders compact progress for required incomplete workflow state", () => {
+    const task: Task = {
+      id: "task-1",
+      title: "Research reuse loop",
+      status: "in_progress",
+      memory_workflow: {
+        required: true,
+        status: "pending",
+        requirement_reason:
+          "process research requires prior context lookup, durable capture, and promotion",
+        required_steps: ["lookup", "capture", "promote"],
+        lookup: {
+          required: true,
+          status: "satisfied",
+          completed_at: "2026-04-30T10:00:00Z",
+          count: 1,
+        },
+        capture: { required: true, status: "pending" },
+        promote: { required: true, status: "pending" },
+        citations: [
+          {
+            title: "Prior onboarding notes",
+            path: "notebook/pm/onboarding.md",
+            source: "wiki",
+            backend: "markdown",
+            snippet: "Reuse the prior onboarding benchmark.",
+            score: 0.92,
+          },
+        ],
+        captures: [
+          {
+            source: "notebook",
+            title: "Onboarding research capture",
+            path: "notebook/research/onboarding.md",
+            state: "captured",
+          },
+        ],
+        updated_at: "2026-04-30T10:05:00Z",
+      },
+    };
+
+    expect(taskMemoryWorkflowBadge(task.memory_workflow)?.label).toBe(
+      "memory 1/3",
+    );
+  });
+
+  it("renders compact issue state for missing artifacts", () => {
+    const badge = taskMemoryWorkflowBadge({
+      required: true,
+      status: "pending",
+      required_steps: ["lookup", "capture", "promote"],
+      lookup: {
+        required: true,
+        status: "satisfied",
+        completed_at: "2026-04-30T10:00:00Z",
+      },
+      capture: {
+        required: true,
+        status: "satisfied",
+        completed_at: "2026-04-30T10:05:00Z",
+      },
+      promote: { required: true, status: "pending" },
+      promotions: [
+        { source: "wiki", path: "wiki/research/onboarding.md", missing: true },
+      ],
+    });
+
+    expect(badge?.label).toBe("memory issue");
+  });
+
+  it("prioritizes explicit human override state", () => {
+    const badge = taskMemoryWorkflowBadge({
+      required: true,
+      status: "overridden",
+      requirement_reason: "urgent customer handoff",
+      override: {
+        actor: "human",
+        reason: "Ship before promotion review",
+        timestamp: "2026-04-30T10:15:00Z",
+      },
+    });
+
+    expect(badge?.label).toBe("memory override");
+    expect(badge?.title).toContain("@human");
+  });
+
+  it("stays quiet when the workflow is absent or explicitly not required", () => {
+    expect(taskMemoryWorkflowBadge(undefined)).toBeNull();
+    expect(
+      taskMemoryWorkflowBadge({ required: false, status: "not_required" }),
+    ).toBeNull();
+  });
+});
+
+describe("TaskDetailModal memory override", () => {
+  it("requires a reason and submits the human override payload", async () => {
+    getOfficeMembersMock.mockResolvedValue({
+      members: [{ slug: "ceo", name: "CEO", role: "lead" }],
+    });
+    updateTaskStatusMock.mockResolvedValue({
+      task: { id: "task-1", title: "Done", status: "done" },
+    });
+
+    const task: Task = {
+      id: "task-1",
+      title: "Research passport renewal process",
+      status: "in_progress",
+      channel: "general",
+      owner: "ceo",
+      memory_workflow: {
+        required: true,
+        status: "pending",
+        required_steps: ["lookup", "capture", "promote"],
+        lookup: { required: true, status: "pending" },
+        capture: { required: true, status: "pending" },
+        promote: { required: true, status: "pending" },
+      },
+    };
+
+    const { onClose } = renderTaskDetail(task);
+    const button = screen.getByRole("button", {
+      name: "Mark done with override",
+    });
+    expect(button).toBeDisabled();
+
+    await userEvent.type(
+      screen.getByLabelText("Override reason"),
+      "Customer deadline accepted by founder",
+    );
+    expect(button).toBeEnabled();
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(updateTaskStatusMock).toHaveBeenCalledWith(
+        "task-1",
+        "complete",
+        "general",
+        "human",
+        {
+          memoryWorkflowOverride: true,
+          memoryWorkflowOverrideActor: "human",
+          memoryWorkflowOverrideReason: "Customer deadline accepted by founder",
+        },
+      );
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/apps/TaskDetailModal.test.tsx
+++ b/web/src/components/apps/TaskDetailModal.test.tsx
@@ -143,7 +143,7 @@ describe("TaskDetailModal memory override", () => {
       owner: "ceo",
       memory_workflow: {
         required: true,
-        status: "complete",
+        status: "satisfied",
         required_steps: ["lookup", "capture", "promote"],
         lookup: {
           required: true,
@@ -169,6 +169,7 @@ describe("TaskDetailModal memory override", () => {
     expect(
       screen.getByRole("button", { name: "Mark done with override" }),
     ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Mark done" })).toBeDisabled();
   });
 
   it("requires a reason and submits the human override payload", async () => {

--- a/web/src/components/apps/TaskDetailModal.test.tsx
+++ b/web/src/components/apps/TaskDetailModal.test.tsx
@@ -130,6 +130,47 @@ describe("taskMemoryWorkflowBadge", () => {
 });
 
 describe("TaskDetailModal memory override", () => {
+  it("keeps the override action visible for issue-state completed workflows", () => {
+    getOfficeMembersMock.mockResolvedValue({
+      members: [{ slug: "ceo", name: "CEO", role: "lead" }],
+    });
+
+    const task: Task = {
+      id: "task-issue",
+      title: "Research passport renewal process",
+      status: "in_progress",
+      channel: "general",
+      owner: "ceo",
+      memory_workflow: {
+        required: true,
+        status: "partial_errors",
+        required_steps: ["lookup", "capture", "promote"],
+        lookup: {
+          required: true,
+          status: "satisfied",
+          completed_at: "2026-04-30T10:00:00Z",
+        },
+        capture: {
+          required: true,
+          status: "satisfied",
+          completed_at: "2026-04-30T10:01:00Z",
+        },
+        promote: {
+          required: true,
+          status: "satisfied",
+          completed_at: "2026-04-30T10:02:00Z",
+        },
+        partial_errors: ["workflow write failed"],
+      },
+    };
+
+    renderTaskDetail(task);
+
+    expect(
+      screen.getByRole("button", { name: "Mark done with override" }),
+    ).toBeInTheDocument();
+  });
+
   it("requires a reason and submits the human override payload", async () => {
     getOfficeMembersMock.mockResolvedValue({
       members: [{ slug: "ceo", name: "CEO", role: "lead" }],

--- a/web/src/components/apps/TaskDetailModal.test.tsx
+++ b/web/src/components/apps/TaskDetailModal.test.tsx
@@ -143,7 +143,7 @@ describe("TaskDetailModal memory override", () => {
       owner: "ceo",
       memory_workflow: {
         required: true,
-        status: "partial_errors",
+        status: "complete",
         required_steps: ["lookup", "capture", "promote"],
         lookup: {
           required: true,

--- a/web/src/components/apps/TaskDetailModal.test.tsx
+++ b/web/src/components/apps/TaskDetailModal.test.tsx
@@ -127,6 +127,16 @@ describe("taskMemoryWorkflowBadge", () => {
       taskMemoryWorkflowBadge({ required: false, status: "not_required" }),
     ).toBeNull();
   });
+
+  it("does not infer required steps for non-required workflows with artifacts", () => {
+    const badge = taskMemoryWorkflowBadge({
+      required: false,
+      status: "pending",
+      captures: [{ source: "notebook", path: "agents/pm/notebook/notes.md" }],
+    });
+
+    expect(badge?.label).toBe("memory pending");
+  });
 });
 
 describe("TaskDetailModal memory override", () => {
@@ -221,7 +231,7 @@ describe("TaskDetailModal memory override", () => {
           memoryWorkflowOverrideReason: "Customer deadline accepted by founder",
         },
       );
+      expect(onClose).toHaveBeenCalled();
     });
-    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -6,6 +6,11 @@ import {
   type OfficeMember,
   reassignTask,
   type Task,
+  type TaskMemoryWorkflow,
+  type TaskMemoryWorkflowArtifact,
+  type TaskMemoryWorkflowCitation,
+  type TaskMemoryWorkflowPartialError,
+  type TaskMemoryWorkflowStepState,
   type TaskStatusAction,
   updateTaskStatus,
 } from "../../api/client";
@@ -18,6 +23,185 @@ interface TaskDetailModalProps {
 }
 
 const HUMAN_SLUG = "human";
+
+interface TaskMemoryWorkflowBadge {
+  label: string;
+  className: string;
+  title: string;
+}
+
+const COMPLETE_MEMORY_STATUSES = new Set([
+  "satisfied",
+  "complete",
+  "completed",
+  "done",
+]);
+const ISSUE_MEMORY_STATUSES = new Set([
+  "blocked",
+  "error",
+  "errored",
+  "failed",
+  "incomplete",
+]);
+const OVERRIDE_MEMORY_STATUSES = new Set(["overridden", "override"]);
+const WORKFLOW_STEP_NAMES = ["lookup", "capture", "promote"] as const;
+
+type WorkflowStepName = (typeof WORKFLOW_STEP_NAMES)[number];
+
+function normalizeMemoryStatus(status?: string): string {
+  return (status || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function memoryWorkflowStep(
+  workflow: TaskMemoryWorkflow,
+  step: WorkflowStepName,
+): TaskMemoryWorkflowStepState | undefined {
+  return workflow[step];
+}
+
+function isMemoryStepSatisfied(step?: TaskMemoryWorkflowStepState): boolean {
+  return (
+    normalizeMemoryStatus(step?.status) === "satisfied" ||
+    Boolean(step?.completed_at)
+  );
+}
+
+function memoryWorkflowRequiredSteps(
+  workflow: TaskMemoryWorkflow,
+): WorkflowStepName[] {
+  const fromContract = (workflow.required_steps ?? [])
+    .map((step) => normalizeMemoryStatus(step))
+    .filter((step): step is WorkflowStepName =>
+      WORKFLOW_STEP_NAMES.includes(step as WorkflowStepName),
+    );
+  if (fromContract.length > 0) return fromContract;
+
+  const fromStates = WORKFLOW_STEP_NAMES.filter(
+    (step) => memoryWorkflowStep(workflow, step)?.required,
+  );
+  if (fromStates.length > 0) return fromStates;
+
+  return WORKFLOW_STEP_NAMES.slice();
+}
+
+function memoryWorkflowStepCount(workflow: TaskMemoryWorkflow): {
+  done: number;
+  total: number;
+} {
+  const requiredSteps = memoryWorkflowRequiredSteps(workflow);
+  const total = requiredSteps.length || WORKFLOW_STEP_NAMES.length;
+  const done = requiredSteps.filter((step) =>
+    isMemoryStepSatisfied(memoryWorkflowStep(workflow, step)),
+  ).length;
+  return { done, total };
+}
+
+function memoryWorkflowArtifacts(
+  workflow: TaskMemoryWorkflow,
+): TaskMemoryWorkflowArtifact[] {
+  return [...(workflow.captures ?? []), ...(workflow.promotions ?? [])];
+}
+
+function hasMissingMemoryArtifact(workflow: TaskMemoryWorkflow): boolean {
+  return memoryWorkflowArtifacts(workflow).some((artifact) => artifact.missing);
+}
+
+function hasMemoryWorkflowOverride(workflow: TaskMemoryWorkflow): boolean {
+  return Boolean(
+    workflow.override ||
+      OVERRIDE_MEMORY_STATUSES.has(normalizeMemoryStatus(workflow.status)),
+  );
+}
+
+function hasVisibleMemoryWorkflow(
+  workflow?: TaskMemoryWorkflow | null,
+): workflow is TaskMemoryWorkflow {
+  if (!workflow) return false;
+  const status = normalizeMemoryStatus(workflow.status);
+  const stepCount = memoryWorkflowStepCount(workflow);
+  return Boolean(
+    workflow.required ||
+      (status && status !== "not_required") ||
+      workflow.requirement_reason ||
+      stepCount.done > 0 ||
+      workflow.citations?.length ||
+      memoryWorkflowArtifacts(workflow).length ||
+      workflow.partial_errors?.length ||
+      hasMemoryWorkflowOverride(workflow),
+  );
+}
+
+function displayMemoryStatus(status: string): string {
+  return status.replace(/_/g, " ");
+}
+
+export function taskMemoryWorkflowBadge(
+  workflow?: TaskMemoryWorkflow | null,
+): TaskMemoryWorkflowBadge | null {
+  if (!hasVisibleMemoryWorkflow(workflow)) return null;
+
+  const status = normalizeMemoryStatus(workflow.status);
+  const { done, total } = memoryWorkflowStepCount(workflow);
+  const errors = workflow.partial_errors?.length ?? 0;
+  const reason = workflow.requirement_reason
+    ? ` · ${workflow.requirement_reason}`
+    : "";
+
+  if (hasMemoryWorkflowOverride(workflow)) {
+    const actor = workflow.override?.actor
+      ? ` by @${workflow.override.actor}`
+      : "";
+    return {
+      label: "memory override",
+      className: "badge badge-yellow",
+      title: `Memory workflow overridden${actor}${reason}`,
+    };
+  }
+
+  if (
+    errors > 0 ||
+    hasMissingMemoryArtifact(workflow) ||
+    ISSUE_MEMORY_STATUSES.has(status)
+  ) {
+    const issueText =
+      errors > 0
+        ? `${errors} partial ${errors === 1 ? "error" : "errors"}`
+        : "an issue";
+    return {
+      label: "memory issue",
+      className: "badge badge-yellow",
+      title: `Memory workflow has ${issueText}${reason}`,
+    };
+  }
+
+  if (
+    COMPLETE_MEMORY_STATUSES.has(status) ||
+    (workflow.required && done >= total)
+  ) {
+    return {
+      label: "memory done",
+      className: "badge badge-green",
+      title: `Memory workflow complete${reason}`,
+    };
+  }
+
+  if (workflow.required || done > 0) {
+    return {
+      label: `memory ${done}/${total}`,
+      className: "badge badge-accent",
+      title: `Memory workflow ${done}/${total} steps complete${reason}`,
+    };
+  }
+
+  return {
+    label: `memory ${displayMemoryStatus(status || "pending")}`,
+    className: "badge badge-neutral",
+    title: `Memory workflow ${displayMemoryStatus(status || "pending")}${reason}`,
+  };
+}
 
 export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
   const queryClient = useQueryClient();
@@ -33,11 +217,13 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
   const [submitting, setSubmitting] = useState(false);
   const [statusBusy, setStatusBusy] = useState<TaskStatusAction | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [overrideReason, setOverrideReason] = useState("");
 
   useEffect(() => {
     setSelectedOwner((task.owner ?? "").trim());
     setErrorMsg(null);
-  }, [task.owner]);
+    setOverrideReason("");
+  }, [task.id, task.owner]);
 
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
@@ -71,6 +257,36 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : `${action} failed`;
+      setErrorMsg(message);
+    } finally {
+      setStatusBusy(null);
+    }
+  }
+
+  async function handleMemoryOverrideComplete() {
+    const reason = overrideReason.trim();
+    if (!reason) {
+      setErrorMsg("Memory workflow override requires reason");
+      return;
+    }
+    setStatusBusy("complete");
+    setErrorMsg(null);
+    try {
+      await updateTaskStatus(
+        task.id,
+        "complete",
+        task.channel || "general",
+        HUMAN_SLUG,
+        {
+          memoryWorkflowOverride: true,
+          memoryWorkflowOverrideActor: HUMAN_SLUG,
+          memoryWorkflowOverrideReason: reason,
+        },
+      );
+      await queryClient.invalidateQueries({ queryKey: ["office-tasks"] });
+      onClose();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Override failed";
       setErrorMsg(message);
     } finally {
       setStatusBusy(null);
@@ -119,6 +335,18 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
   const reviewState = (task.review_state || "").replace(/_/g, " ");
   const description = task.description?.trim() || "";
   const details = task.details?.trim() || "";
+  const memoryWorkflow = task.memory_workflow;
+  const memoryWorkflowProgress = memoryWorkflow
+    ? memoryWorkflowStepCount(memoryWorkflow)
+    : { done: 0, total: 0 };
+  const memoryWorkflowNeedsOverride = Boolean(
+    memoryWorkflow?.required &&
+      !hasMemoryWorkflowOverride(memoryWorkflow) &&
+      !COMPLETE_MEMORY_STATUSES.has(
+        normalizeMemoryStatus(memoryWorkflow.status),
+      ) &&
+      memoryWorkflowProgress.done < memoryWorkflowProgress.total,
+  );
 
   const metaRows: Array<[string, string | null | undefined]> = [
     ["Owner", task.owner ? `@${task.owner}` : "(unassigned)"],
@@ -232,6 +460,32 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
               />
             </div>
           </div>
+          {memoryWorkflowNeedsOverride && (
+            <div className="task-detail-override">
+              <label
+                className="task-detail-label"
+                htmlFor={`memory-override-${task.id}`}
+              >
+                Override reason
+              </label>
+              <textarea
+                id={`memory-override-${task.id}`}
+                className="task-detail-textarea"
+                value={overrideReason}
+                onChange={(e) => setOverrideReason(e.target.value)}
+                placeholder="Human reason required"
+                rows={3}
+              />
+              <button
+                type="button"
+                className="btn btn-primary btn-sm"
+                onClick={handleMemoryOverrideComplete}
+                disabled={!overrideReason.trim() || statusBusy !== null}
+              >
+                {statusBusy === "complete" ? "..." : "Mark done with override"}
+              </button>
+            </div>
+          )}
         </section>
 
         <section className="task-detail-section">
@@ -306,6 +560,10 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
           </section>
         )}
 
+        {hasVisibleMemoryWorkflow(memoryWorkflow) && (
+          <MemoryWorkflowSection workflow={memoryWorkflow} />
+        )}
+
         <section className="task-detail-section">
           <div className="task-detail-label">Metadata</div>
           <dl className="task-detail-meta">
@@ -321,6 +579,169 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
         </section>
       </div>
     </div>
+  );
+}
+
+function MemoryWorkflowSection({ workflow }: { workflow: TaskMemoryWorkflow }) {
+  const badge = taskMemoryWorkflowBadge(workflow);
+  const status = normalizeMemoryStatus(workflow.status);
+  const stepRows = WORKFLOW_STEP_NAMES.map((step): [string, string | null] => [
+    step[0].toUpperCase() + step.slice(1),
+    formatWorkflowStep(memoryWorkflowStep(workflow, step)),
+  ]);
+  const rows: Array<[string, string | null | undefined]> = [
+    ["Required", workflow.required ? "yes" : "no"],
+    ["Status", status ? displayMemoryStatus(status) : null],
+    ["Reason", workflow.requirement_reason || null],
+    [
+      "Required steps",
+      memoryWorkflowRequiredSteps(workflow).join(", ") || null,
+    ],
+    ...stepRows,
+    ["Completed", formatWorkflowTime(workflow.completed_at)],
+    ["Updated", formatWorkflowTime(workflow.updated_at)],
+  ];
+
+  if (hasMemoryWorkflowOverride(workflow)) {
+    rows.push(
+      [
+        "Override actor",
+        workflow.override?.actor ? `@${workflow.override.actor}` : null,
+      ],
+      ["Override reason", workflow.override?.reason || null],
+      ["Override time", formatWorkflowTime(workflow.override?.timestamp)],
+    );
+  }
+
+  return (
+    <section className="task-detail-section">
+      <div className="task-detail-label">Memory workflow</div>
+      {badge && (
+        <div style={{ marginBottom: 10 }}>
+          <span className={badge.className} title={badge.title}>
+            {badge.label}
+          </span>
+        </div>
+      )}
+      <dl className="task-detail-meta">
+        {rows
+          .filter(([, value]) => value != null && value !== "")
+          .map(([key, value]) => (
+            <div key={key} className="task-detail-meta-row">
+              <dt>{key}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+      </dl>
+      {workflow.citations && workflow.citations.length > 0 && (
+        <DetailList
+          label="Citations"
+          items={workflow.citations.map(formatWorkflowCitation)}
+        />
+      )}
+      {workflow.captures && workflow.captures.length > 0 && (
+        <DetailList
+          label="Captures"
+          items={workflow.captures.map(formatWorkflowArtifact)}
+        />
+      )}
+      {workflow.promotions && workflow.promotions.length > 0 && (
+        <DetailList
+          label="Promotions"
+          items={workflow.promotions.map(formatWorkflowArtifact)}
+        />
+      )}
+      {workflow.partial_errors && workflow.partial_errors.length > 0 && (
+        <DetailList
+          label="Partial errors"
+          items={workflow.partial_errors.map(formatWorkflowError)}
+        />
+      )}
+    </section>
+  );
+}
+
+function DetailList({ label, items }: { label: string; items: string[] }) {
+  return (
+    <div style={{ marginTop: 12 }}>
+      <div className="task-detail-label" style={{ marginBottom: 6 }}>
+        {label}
+      </div>
+      <ul className="task-detail-deps" style={{ display: "block" }}>
+        {items.map((item, index) => (
+          <li
+            key={`${label}-${index}`}
+            style={{
+              marginBottom: 6,
+              whiteSpace: "normal",
+              wordBreak: "break-word",
+            }}
+          >
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function formatWorkflowTime(value?: string): string | null {
+  return value ? formatRelativeTime(value) : null;
+}
+
+function formatWorkflowStep(step?: TaskMemoryWorkflowStepState): string | null {
+  if (!step) return null;
+  const parts = [
+    step.status
+      ? displayMemoryStatus(normalizeMemoryStatus(step.status))
+      : null,
+    step.count != null && step.count > 0
+      ? `${step.count} item${step.count === 1 ? "" : "s"}`
+      : null,
+    step.actor ? `@${step.actor}` : null,
+    formatWorkflowTime(step.completed_at),
+  ].filter(Boolean);
+  return parts.join(" · ") || null;
+}
+
+function formatWorkflowCitation(citation: TaskMemoryWorkflowCitation): string {
+  const title =
+    citation.title ||
+    citation.path ||
+    citation.source_url ||
+    citation.source_id ||
+    "citation";
+  const parts = [title];
+  if (citation.path && citation.path !== title) parts.push(citation.path);
+  if (citation.source) parts.push(citation.source);
+  if (citation.backend) parts.push(citation.backend);
+  if (citation.stale) parts.push("stale");
+  return parts.join(" · ");
+}
+
+function formatWorkflowArtifact(artifact: TaskMemoryWorkflowArtifact): string {
+  const title =
+    artifact.title ||
+    artifact.path ||
+    artifact.page_id ||
+    artifact.promotion_id ||
+    "artifact";
+  const parts = [title];
+  if (artifact.source) parts.unshift(artifact.source);
+  if (artifact.path && artifact.path !== title) parts.push(artifact.path);
+  if (artifact.state) parts.push(artifact.state);
+  if (artifact.missing) parts.push("missing");
+  return parts.join(" · ");
+}
+
+function formatWorkflowError(
+  error: string | TaskMemoryWorkflowPartialError,
+): string {
+  if (typeof error === "string") return error;
+  return (
+    [error.step, error.code, error.message || error.detail]
+      .filter(Boolean)
+      .join(" · ") || "workflow error"
   );
 }
 

--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -42,6 +42,8 @@ const ISSUE_MEMORY_STATUSES = new Set([
   "errored",
   "failed",
   "incomplete",
+  "missing_artifacts",
+  "partial_errors",
 ]);
 const OVERRIDE_MEMORY_STATUSES = new Set(["overridden", "override"]);
 const WORKFLOW_STEP_NAMES = ["lookup", "capture", "promote"] as const;
@@ -339,13 +341,22 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
   const memoryWorkflowProgress = memoryWorkflow
     ? memoryWorkflowStepCount(memoryWorkflow)
     : { done: 0, total: 0 };
+  const memoryWorkflowHasIssue = Boolean(
+    memoryWorkflow &&
+      ((memoryWorkflow.partial_errors?.length ?? 0) > 0 ||
+        hasMissingMemoryArtifact(memoryWorkflow) ||
+        ISSUE_MEMORY_STATUSES.has(
+          normalizeMemoryStatus(memoryWorkflow.status),
+        )),
+  );
   const memoryWorkflowNeedsOverride = Boolean(
     memoryWorkflow?.required &&
       !hasMemoryWorkflowOverride(memoryWorkflow) &&
       !COMPLETE_MEMORY_STATUSES.has(
         normalizeMemoryStatus(memoryWorkflow.status),
       ) &&
-      memoryWorkflowProgress.done < memoryWorkflowProgress.total,
+      (memoryWorkflowHasIssue ||
+        memoryWorkflowProgress.done < memoryWorkflowProgress.total),
   );
 
   const metaRows: Array<[string, string | null | undefined]> = [

--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -352,11 +352,11 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
   const memoryWorkflowNeedsOverride = Boolean(
     memoryWorkflow?.required &&
       !hasMemoryWorkflowOverride(memoryWorkflow) &&
-      !COMPLETE_MEMORY_STATUSES.has(
-        normalizeMemoryStatus(memoryWorkflow.status),
-      ) &&
       (memoryWorkflowHasIssue ||
-        memoryWorkflowProgress.done < memoryWorkflowProgress.total),
+        (!COMPLETE_MEMORY_STATUSES.has(
+          normalizeMemoryStatus(memoryWorkflow.status),
+        ) &&
+          memoryWorkflowProgress.done < memoryWorkflowProgress.total)),
   );
 
   const metaRows: Array<[string, string | null | undefined]> = [
@@ -739,6 +739,8 @@ function formatWorkflowArtifact(artifact: TaskMemoryWorkflowArtifact): string {
     "artifact";
   const parts = [title];
   if (artifact.source) parts.unshift(artifact.source);
+  if (artifact.skip_reason && artifact.skip_reason !== title)
+    parts.push(artifact.skip_reason);
   if (artifact.path && artifact.path !== title) parts.push(artifact.path);
   if (artifact.state) parts.push(artifact.state);
   if (artifact.missing) parts.push("missing");

--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -459,6 +459,7 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
                 disabledFor={["done"]}
                 currentStatus={currentStatus}
                 onClick={handleStatusAction}
+                disabled={memoryWorkflowNeedsOverride}
               />
               <StatusButton
                 action="cancel"
@@ -765,6 +766,7 @@ interface StatusButtonProps {
   disabledFor: string[];
   currentStatus: string;
   onClick: (action: TaskStatusAction) => void;
+  disabled?: boolean;
   danger?: boolean;
 }
 
@@ -775,6 +777,7 @@ function StatusButton({
   disabledFor,
   currentStatus,
   onClick,
+  disabled,
   danger,
 }: StatusButtonProps) {
   const isCurrent = disabledFor.includes(currentStatus);
@@ -788,7 +791,7 @@ function StatusButton({
       type="button"
       className={className}
       onClick={() => onClick(action)}
-      disabled={isCurrent || anyBusy}
+      disabled={disabled || isCurrent || anyBusy}
       title={isCurrent ? "Task is already in this state" : undefined}
     >
       {isBusy ? "..." : label}

--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -86,7 +86,7 @@ function memoryWorkflowRequiredSteps(
   );
   if (fromStates.length > 0) return fromStates;
 
-  return WORKFLOW_STEP_NAMES.slice();
+  return workflow.required ? WORKFLOW_STEP_NAMES.slice() : [];
 }
 
 function memoryWorkflowStepCount(workflow: TaskMemoryWorkflow): {
@@ -94,7 +94,7 @@ function memoryWorkflowStepCount(workflow: TaskMemoryWorkflow): {
   total: number;
 } {
   const requiredSteps = memoryWorkflowRequiredSteps(workflow);
-  const total = requiredSteps.length || WORKFLOW_STEP_NAMES.length;
+  const total = requiredSteps.length;
   const done = requiredSteps.filter((step) =>
     isMemoryStepSatisfied(memoryWorkflowStep(workflow, step)),
   ).length;

--- a/web/src/components/apps/TasksApp.tsx
+++ b/web/src/components/apps/TasksApp.tsx
@@ -4,7 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getOfficeTasks, post, type Task } from "../../api/client";
 import { formatRelativeTime } from "../../lib/format";
 import { showNotice } from "../ui/Toast";
-import { TaskDetailModal } from "./TaskDetailModal";
+import { TaskDetailModal, taskMemoryWorkflowBadge } from "./TaskDetailModal";
 
 const STATUS_ORDER = [
   "in_progress",
@@ -323,6 +323,7 @@ function TaskCard({
   const status = normalizeStatus(task.status);
   const timestamp = task.updated_at ?? task.created_at;
   const className = `app-card task-card${isDragging ? " dragging" : ""}`;
+  const memoryBadge = taskMemoryWorkflowBadge(task.memory_workflow);
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
     if (event.key === "Enter" || event.key === " ") {
@@ -369,6 +370,11 @@ function TaskCard({
         {task.channel && <span className="app-card-meta">#{task.channel}</span>}
         {timestamp && (
           <span className="app-card-meta">{formatRelativeTime(timestamp)}</span>
+        )}
+        {memoryBadge && (
+          <span className={memoryBadge.className} title={memoryBadge.title}>
+            {memoryBadge.label}
+          </span>
         )}
       </div>
     </div>

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -1504,6 +1504,34 @@ html[data-theme="nex"]
   gap: 6px;
   flex-wrap: wrap;
 }
+.task-detail-override {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px;
+  align-items: end;
+  margin-top: 12px;
+}
+.task-detail-override .task-detail-label {
+  grid-column: 1 / -1;
+  margin-bottom: -2px;
+}
+.task-detail-textarea {
+  min-height: 72px;
+  resize: vertical;
+  padding: 8px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.4;
+  font-family: var(--font-sans);
+}
+.task-detail-textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-bg);
+}
 .task-detail-status-btn-danger {
   color: var(--red);
   border-color: var(--red-bg);
@@ -1588,6 +1616,9 @@ html[data-theme="nex"]
   .task-detail-modal {
     width: 96%;
     padding: 0;
+  }
+  .task-detail-override {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -1827,7 +1858,9 @@ html[data-theme="nex"]
   padding: 0;
   cursor: pointer;
   position: relative;
-  transition: transform 0.1s, box-shadow 0.1s;
+  transition:
+    transform 0.1s,
+    box-shadow 0.1s;
 }
 .sidebar-color-swatch:hover {
   transform: scale(1.08);


### PR DESCRIPTION
## Summary
- add backend-neutral context tools for lookup, capture, promote, and health across markdown, Nex, and GBrain backends
- add task memory workflow state, completion gating, override recording, and reconciler repair for stale/missing artifacts
- surface workflow progress in TUI and web task views, including human override UX for blocked completion

## Verification
- go test ./...
- npm test -- TaskDetailModal
- npm run typecheck
- npm run build
- ./node_modules/.bin/biome check --write src/api/client.ts src/components/apps/TaskDetailModal.tsx src/components/apps/TasksApp.tsx src/components/apps/TaskDetailModal.test.tsx src/styles/layout.css (warnings remain from existing TasksApp/layout.css rules)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks gain in-task memory workflows (lookup, capture, promote) with required/pending/satisfied status, progress badges (e.g., "memory 1/3", "memory issue", "memory override"), citations/captures/promotions listing, and an override flow that lets users mark done with a reason. Context tools (lookup/capture/promote/health) are available across session types and background reconciliation repairs workflow metadata regularly.

* **Tests**
  * Extensive unit, integration, and harness tests added to validate gating, idempotency, reconciliation, tool flows, and UI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->