### PR TITLE
feat(skills-ui): full skills surface — owner filter, disable/archive/restore, invoke, interview UX

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -385,6 +385,20 @@ export interface InterviewOption {
   text_hint?: string;
 }
 
+export interface SkillSimilarRef {
+  slug: string;
+  score: number;
+  method?: string;
+}
+
+export interface InterviewMetadata {
+  /** Set on enhance_skill_proposal interviews (PR 7 task #15). */
+  enhances_slug?: string;
+  /** Set on ambiguous-band skill_proposal interviews (PR 7 task #15). */
+  similar_to_existing?: SkillSimilarRef;
+  [key: string]: unknown;
+}
+
 export interface AgentRequest {
   id: string;
   from: string;
@@ -403,6 +417,12 @@ export interface AgentRequest {
   recommended_id?: string;
   created_at?: string;
   updated_at?: string;
+  /** Echoes the entity slug the request is about (e.g. a skill name). */
+  reply_to?: string;
+  /** Structured metadata. Used by the enhance-existing UX (PR 7 task #14). */
+  metadata?: InterviewMetadata;
+  /** Full candidate spec on enhance_skill_proposal interviews. */
+  enhance_candidate?: Skill;
 }
 
 export function getRequests(channel: string) {
@@ -493,6 +513,35 @@ export interface Task {
   recheck_at?: string;
   created_at?: string;
   updated_at?: string;
+}
+
+export interface CreateTaskInput {
+  title: string;
+  assignee: string;
+  details?: string;
+  task_type?: string;
+  execution_mode?: string;
+  depends_on?: string[];
+}
+
+export interface CreateTasksResponse {
+  tasks: Task[];
+}
+
+/**
+ * Create one or more tasks via the /task-plan endpoint. Used by surfaces
+ * that hand off work (e.g. Suggest changes on a skill proposal creates a
+ * "Revise skill" task assigned to the lead).
+ */
+export function createTasks(
+  tasks: CreateTaskInput[],
+  opts?: { channel?: string; createdBy?: string },
+): Promise<CreateTasksResponse> {
+  return post<CreateTasksResponse>("/task-plan", {
+    channel: opts?.channel || "general",
+    created_by: opts?.createdBy || "human",
+    tasks,
+  });
 }
 
 export function reassignTask(
@@ -661,7 +710,7 @@ export function patchSchedulerJob(
 
 // ── Skills ──
 
-export type SkillStatus = "active" | "proposed" | "archived";
+export type SkillStatus = "active" | "proposed" | "archived" | "disabled";
 
 export interface SkillMetadata {
   wuphf?: {
@@ -669,24 +718,113 @@ export interface SkillMetadata {
   };
 }
 
+export type OwnerAgents = string[];
+
 export interface Skill {
   name: string;
+  title?: string;
   description?: string;
   source?: string;
+  content?: string;
+  trigger?: string;
   parameters?: unknown;
   status?: SkillStatus;
   created_by?: string;
   created_at?: string;
   updated_at?: string;
+  /** Per-agent scoping (PR 7). Empty/missing = lead-routable shared skill. */
+  owner_agents?: OwnerAgents;
+  /** Set on ambiguous-band proposals by the similarity gate (PR 7 task #15). */
+  similar_to_existing?: SkillSimilarRef;
   metadata?: SkillMetadata;
 }
+
+export type SkillsListScope = "active" | "all";
 
 export function getSkills() {
   return get<{ skills: Skill[] }>("/skills");
 }
 
-export function invokeSkill(name: string, params?: Record<string, unknown>) {
-  return post(`/skills/${encodeURIComponent(name)}/invoke`, params ?? {});
+/**
+ * Fetch the skill catalog. With scope="all" the legacy /skills endpoint
+ * accepts include_archived + include_disabled flags (PR 7 task #18) so the
+ * Skills app can render every section (Pending / Active / Disabled /
+ * Archived) from a single query — keeping body content intact for the
+ * SidePanel preview and the enhance-existing patchSkill flow.
+ *
+ * scope="active" returns the legacy default (active + proposed + disabled,
+ * archived hidden) for callers that don't need the archived bucket.
+ */
+export function getSkillsList(scope: SkillsListScope = "all") {
+  const params: Record<string, string> = {};
+  if (scope === "all") {
+    params.include_archived = "true";
+    params.include_disabled = "true";
+  }
+  return get<{ skills: Skill[] }>("/skills", params);
+}
+
+export interface DisableSkillResponse {
+  skill?: Skill;
+}
+
+export function disableSkill(name: string): Promise<DisableSkillResponse> {
+  return post<DisableSkillResponse>(
+    `/skills/${encodeURIComponent(name)}/disable`,
+    {},
+  );
+}
+
+export interface EnableSkillResponse {
+  skill?: Skill;
+}
+
+export function enableSkill(name: string): Promise<EnableSkillResponse> {
+  return post<EnableSkillResponse>(
+    `/skills/${encodeURIComponent(name)}/enable`,
+    {},
+  );
+}
+
+export interface RestoreArchivedSkillResponse {
+  skill?: Skill;
+}
+
+export function restoreArchivedSkill(
+  name: string,
+): Promise<RestoreArchivedSkillResponse> {
+  return post<RestoreArchivedSkillResponse>(
+    `/skills/${encodeURIComponent(name)}/restore`,
+    {},
+  );
+}
+
+export interface ArchiveSkillResponse {
+  ok?: boolean;
+  skill?: Skill;
+}
+
+export function archiveSkill(name: string): Promise<ArchiveSkillResponse> {
+  return post<ArchiveSkillResponse>(
+    `/skills/${encodeURIComponent(name)}/archive`,
+    {},
+  );
+}
+
+export interface InvokeSkillResult {
+  channel?: string;
+  skill?: Skill;
+  task_id?: string;
+}
+
+export function invokeSkill(
+  name: string,
+  params?: Record<string, unknown>,
+): Promise<InvokeSkillResult> {
+  return post<InvokeSkillResult>(
+    `/skills/${encodeURIComponent(name)}/invoke`,
+    params ?? {},
+  );
 }
 
 // ── Skill compile (PR 1a wiki-skill-compile) ──
@@ -775,6 +913,31 @@ export function undoRejectSkill(
   return post<UndoRejectSkillResponse>(`/skills/reject/undo`, {
     undo_token: token,
   });
+}
+
+export interface PatchSkillRequest {
+  old_string: string;
+  new_string: string;
+  replace_all?: boolean;
+}
+
+export interface PatchSkillResponse {
+  skill?: Skill;
+}
+
+/**
+ * Edit-tool style find/replace patch against a skill's body.
+ * Used by the enhance-existing flow (PR 7 task #14) to fold a candidate
+ * proposal into an existing skill without losing provenance.
+ */
+export function patchSkill(
+  name: string,
+  body: PatchSkillRequest,
+): Promise<PatchSkillResponse> {
+  return post<PatchSkillResponse>(
+    `/skills/${encodeURIComponent(name)}/patch`,
+    body,
+  );
 }
 
 // ── Usage ──

--- a/web/src/components/apps/SkillCompareView.tsx
+++ b/web/src/components/apps/SkillCompareView.tsx
@@ -1,0 +1,175 @@
+import type { Skill } from "../../api/client";
+import { LightningIcon } from "../ui/LightningIcon";
+
+interface SkillCompareViewProps {
+  /** The existing active skill the candidate is similar to. */
+  existing: Skill | undefined;
+  /** The candidate (proposed/ambiguous) skill. */
+  candidate: Skill;
+  /** Optional similarity score (0..1), shown in the header. */
+  score?: number;
+  /** Detection method ("embedding-cosine" | "jaccard-tokens"). */
+  method?: string;
+}
+
+/**
+ * Side-by-side compare panel used by the enhance-existing interview and
+ * the ambiguous-band similarity banner's [Compare] action. Renders the
+ * existing skill on the left, candidate on the right. Body is monospace
+ * scrollable so long playbooks don't blow up the panel height.
+ *
+ * Designed to live inside the existing <SidePanel /> primitive. On mobile
+ * the two panels stack via flex-wrap.
+ */
+export function SkillCompareView({
+  existing,
+  candidate,
+  score,
+  method,
+}: SkillCompareViewProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        fontSize: 13,
+        color: "var(--text)",
+      }}
+    >
+      {typeof score === "number" ? (
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--text-secondary)",
+            background: "var(--bg-warm, var(--neutral-50))",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            padding: "6px 10px",
+          }}
+        >
+          Similarity score: <strong>{score.toFixed(2)}</strong>
+          {method ? ` · ${method}` : ""}
+        </div>
+      ) : null}
+
+      <div
+        style={{
+          display: "flex",
+          gap: 12,
+          flexWrap: "wrap",
+        }}
+      >
+        <SkillPanel
+          title="Existing"
+          subtitle={existing ? `@${existing.name}` : undefined}
+          skill={existing}
+          tone="existing"
+        />
+        <SkillPanel
+          title="Candidate"
+          subtitle={candidate.name ? `@${candidate.name}` : undefined}
+          skill={candidate}
+          tone="candidate"
+        />
+      </div>
+    </div>
+  );
+}
+
+interface SkillPanelProps {
+  title: string;
+  subtitle?: string;
+  skill: Skill | undefined;
+  tone: "existing" | "candidate";
+}
+
+function SkillPanel({ title, subtitle, skill, tone }: SkillPanelProps) {
+  const accent = tone === "candidate" ? "var(--yellow)" : "var(--neutral-300)";
+  return (
+    <section
+      aria-label={`${title} skill`}
+      style={{
+        flex: "1 1 220px",
+        minWidth: 0,
+        border: "1px solid var(--border)",
+        borderTop: `3px solid ${accent}`,
+        borderRadius: 6,
+        padding: 10,
+        background: "var(--bg-card, #fff)",
+      }}
+    >
+      <header
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          marginBottom: 6,
+        }}
+      >
+        <LightningIcon size={14} />
+        <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text)" }}>
+          {title}
+        </span>
+        {subtitle ? (
+          <span
+            style={{
+              fontSize: 11,
+              fontFamily: "var(--font-mono)",
+              color: "var(--text-tertiary)",
+              marginLeft: "auto",
+            }}
+          >
+            {subtitle}
+          </span>
+        ) : null}
+      </header>
+
+      {skill?.description ? (
+        <p
+          style={{
+            margin: "0 0 6px 0",
+            fontSize: 12,
+            color: "var(--text-secondary)",
+            lineHeight: 1.45,
+          }}
+        >
+          {skill.description}
+        </p>
+      ) : null}
+
+      {skill?.trigger ? (
+        <p
+          style={{
+            margin: "0 0 6px 0",
+            fontSize: 11,
+            fontStyle: "italic",
+            color: "var(--text-tertiary)",
+          }}
+        >
+          Trigger: {skill.trigger}
+        </p>
+      ) : null}
+
+      <pre
+        style={{
+          maxHeight: 320,
+          overflow: "auto",
+          background: "var(--bg-warm, var(--neutral-50))",
+          border: "1px solid var(--border)",
+          borderRadius: 4,
+          padding: 8,
+          margin: 0,
+          fontFamily: "var(--font-mono)",
+          fontSize: 11,
+          lineHeight: 1.5,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+        }}
+      >
+        {skill?.content?.trim() ||
+          (skill ? "(no body content)" : "(skill not found)")}
+      </pre>
+    </section>
+  );
+}

--- a/web/src/components/apps/SkillsApp.test.tsx
+++ b/web/src/components/apps/SkillsApp.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("../../api/client", async () => {
@@ -11,6 +11,9 @@ vi.mock("../../api/client", async () => {
   return {
     ...actual,
     getSkills: vi.fn().mockResolvedValue({ skills: [] }),
+    getSkillsList: vi.fn().mockResolvedValue({ skills: [] }),
+    getOfficeMembers: vi.fn().mockResolvedValue({ members: [] }),
+    patchSkill: vi.fn().mockResolvedValue({}),
     compileSkills: vi.fn().mockResolvedValue({
       scanned: 0,
       matched: 0,
@@ -24,7 +27,8 @@ vi.mock("../../api/client", async () => {
   };
 });
 
-import { SkillsApp } from "./SkillsApp";
+import * as clientMod from "../../api/client";
+import { OwnersChip, SkillsApp } from "./SkillsApp";
 
 function wrap(ui: ReactNode) {
   const qc = new QueryClient({
@@ -48,5 +52,218 @@ describe("<SkillsApp> empty state", () => {
       .getAllByRole("button")
       .filter((b) => /Compile/.test(b.textContent ?? ""));
     expect(buttons.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("<SkillsApp> similar_to_existing badge", () => {
+  it("shows a similar-to indicator on proposed skills flagged by the similarity gate", async () => {
+    vi.mocked(clientMod.getSkillsList).mockResolvedValueOnce({
+      skills: [
+        {
+          name: "send-email",
+          status: "proposed",
+          description: "Send emails",
+          similar_to_existing: {
+            slug: "email-ops",
+            score: 0.82,
+            method: "embedding-cosine",
+          },
+        },
+      ],
+    });
+
+    render(wrap(<SkillsApp />));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Similar to:/i)).toBeInTheDocument();
+      expect(screen.getByText("email-ops")).toBeInTheDocument();
+    });
+  });
+
+  it("does not show a similar-to indicator on proposed skills without the flag", async () => {
+    vi.mocked(clientMod.getSkillsList).mockResolvedValueOnce({
+      skills: [{ name: "clean-skill", status: "proposed" }],
+    });
+
+    render(wrap(<SkillsApp />));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Similar to:/i)).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("<SkillsApp> SidePanel editor", () => {
+  it("opens an editable textarea for proposed skills via View full link", async () => {
+    vi.mocked(clientMod.getSkillsList).mockResolvedValueOnce({
+      skills: [
+        {
+          name: "draft-skill",
+          status: "proposed",
+          description: "A draft.",
+          content: "## Steps\n1. do thing",
+        },
+      ],
+    });
+
+    render(wrap(<SkillsApp />));
+
+    const viewFull = await screen.findByRole("button", {
+      name: /View full SKILL\.md/i,
+    });
+    fireEvent.click(viewFull);
+
+    // Editor is keyed by the body label/aria-label.
+    const editor = await screen.findByRole("textbox", {
+      name: /Edit body for draft-skill/i,
+    });
+    expect(editor).toHaveValue("## Steps\n1. do thing");
+
+    // Save is disabled when not dirty; revert too.
+    expect(
+      screen.getByRole("button", { name: /Save edits to draft-skill/i }),
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Revert/i })).toBeDisabled();
+  });
+
+  it("calls patchSkill on Save with the new body", async () => {
+    vi.mocked(clientMod.getSkillsList).mockResolvedValueOnce({
+      skills: [
+        {
+          name: "draft-skill",
+          status: "proposed",
+          content: "old body",
+        },
+      ],
+    });
+    const patchMock = vi.mocked(clientMod.patchSkill).mockResolvedValueOnce({});
+
+    render(wrap(<SkillsApp />));
+
+    const viewFull = await screen.findByRole("button", {
+      name: /View full SKILL\.md/i,
+    });
+    fireEvent.click(viewFull);
+
+    const editor = await screen.findByRole("textbox", {
+      name: /Edit body for draft-skill/i,
+    });
+    fireEvent.change(editor, { target: { value: "new body" } });
+
+    const save = screen.getByRole("button", {
+      name: /Save edits to draft-skill/i,
+    });
+    expect(save).not.toBeDisabled();
+    fireEvent.click(save);
+
+    await waitFor(() => {
+      expect(patchMock).toHaveBeenCalledWith("draft-skill", {
+        old_string: "old body",
+        new_string: "new body",
+        replace_all: false,
+      });
+    });
+  });
+
+  it("preserves chars typed between save resolve and parent post-save effect", async () => {
+    // Regression for the stale-closure bug devils-advocate flagged: after
+    // a successful save, the parent passes back res.skill with new content,
+    // which used to land in the reset useEffect's dep array and silently
+    // wipe any chars the user typed in the gap between the patch resolving
+    // and the effect running.
+    vi.mocked(clientMod.patchSkill).mockClear();
+    vi.mocked(clientMod.getSkillsList).mockResolvedValueOnce({
+      skills: [
+        {
+          name: "draft-skill",
+          status: "proposed",
+          content: "first body",
+        },
+      ],
+    });
+    // patchSkill resolves with the new server-known body.
+    vi.mocked(clientMod.patchSkill).mockResolvedValueOnce({
+      skill: {
+        name: "draft-skill",
+        status: "proposed",
+        content: "second body",
+      },
+    });
+
+    render(wrap(<SkillsApp />));
+
+    const viewFull = await screen.findByRole("button", {
+      name: /View full SKILL\.md/i,
+    });
+    fireEvent.click(viewFull);
+
+    const editor = await screen.findByRole("textbox", {
+      name: /Edit body for draft-skill/i,
+    });
+
+    // First save with "second body".
+    fireEvent.change(editor, { target: { value: "second body" } });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Save edits to draft-skill/i }),
+    );
+
+    await waitFor(() => {
+      expect(vi.mocked(clientMod.patchSkill)).toHaveBeenCalledTimes(1);
+    });
+
+    // User keeps typing after save resolves. The parent has now updated
+    // previewSkill.content via onSaved → handlePreviewSaved → setPreviewSkill.
+    // The reset effect must NOT fire (dep array is keyed on skill.name only)
+    // and the new chars must be preserved in the editor.
+    fireEvent.change(editor, {
+      target: { value: "second body and more" },
+    });
+
+    await waitFor(() => {
+      expect((editor as HTMLTextAreaElement).value).toBe(
+        "second body and more",
+      );
+    });
+  });
+
+  it("does not show the editor for active skills (preview only)", async () => {
+    vi.mocked(clientMod.getSkillsList).mockResolvedValueOnce({
+      skills: [
+        {
+          name: "live-skill",
+          status: "active",
+          content: "playbook body",
+        },
+      ],
+    });
+
+    render(wrap(<SkillsApp />));
+
+    // Active cards don't surface the View full link in v1; the SidePanel
+    // is reachable only on proposed cards. So the editor textarea must
+    // not be in the DOM.
+    await waitFor(() => {
+      expect(screen.getByText("live-skill")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("textbox", { name: /Edit body/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("<OwnersChip>", () => {
+  it("renders 'lead-routable' when slugs are missing or empty", () => {
+    render(<OwnersChip />);
+    expect(screen.getByText(/lead-routable/i)).toBeInTheDocument();
+  });
+
+  it("renders comma-separated @-prefixed slugs when provided", () => {
+    render(<OwnersChip slugs={["deploy-bot", "csm"]} />);
+    expect(screen.getByText("@deploy-bot, @csm")).toBeInTheDocument();
+  });
+
+  it("ignores empty/whitespace slugs and falls back to lead-routable", () => {
+    render(<OwnersChip slugs={["", "   "]} />);
+    expect(screen.getByText(/lead-routable/i)).toBeInTheDocument();
   });
 });

--- a/web/src/components/apps/SkillsApp.tsx
+++ b/web/src/components/apps/SkillsApp.tsx
@@ -1,35 +1,78 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   approveSkill,
+  archiveSkill,
   type CompileResponse,
   type CompileResult,
   compileSkills,
-  getSkills,
+  createTasks,
+  disableSkill,
+  enableSkill,
+  getOfficeTasks,
+  getSkillsList,
   invokeSkill,
+  patchSkill,
   rejectSkill,
+  restoreArchivedSkill,
   type Skill,
   type SkillStatus,
+  type Task,
   undoRejectSkill,
 } from "../../api/client";
+import { useTeamLeadSlug } from "../../hooks/useConfig";
+import { useOfficeMembers } from "../../hooks/useMembers";
+import { useAppStore } from "../../stores/app";
+import { LightningIcon } from "../ui/LightningIcon";
+import { SidePanel } from "../ui/SidePanel";
 import { showNotice, showUndoToast } from "../ui/Toast";
 
 type CompileState = "idle" | "compiling" | "done";
 
-const STATUS_DOT_COLOR: Record<SkillStatus, string> = {
-  proposed: "var(--yellow)",
-  active: "var(--green)",
-  archived: "var(--neutral-400, #85898b)",
+const STATUS_DOT_STYLE: Record<
+  SkillStatus,
+  { background: string; border?: string }
+> = {
+  proposed: { background: "var(--yellow)" },
+  active: { background: "var(--green)" },
+  disabled: {
+    background: "transparent",
+    border: "1.5px solid var(--neutral-400, #85898b)",
+  },
+  archived: { background: "var(--neutral-400, #85898b)" },
 };
 
 const STATUS_LABEL: Record<SkillStatus, string> = {
   proposed: "Pending review",
   active: "Active",
+  disabled: "Disabled",
   archived: "Archived",
 };
 
-function StatusDot({ color }: { color: string }) {
+const OWNER_FILTER_KEY = "skillsAppOwnerFilter";
+type OwnerFilterValue = "all" | "lead-routable" | string;
+
+function readOwnerFilter(): OwnerFilterValue {
+  try {
+    const stored = window.localStorage.getItem(OWNER_FILTER_KEY);
+    if (stored) return stored as OwnerFilterValue;
+  } catch {
+    // localStorage may be unavailable (SSR, privacy mode); fall back.
+  }
+  return "all";
+}
+
+function writeOwnerFilter(value: OwnerFilterValue): void {
+  try {
+    window.localStorage.setItem(OWNER_FILTER_KEY, value);
+  } catch {
+    // ignore
+  }
+}
+
+function StatusDot({ status }: { status: SkillStatus }) {
+  const style = STATUS_DOT_STYLE[status];
   return (
     <span
       style={{
@@ -37,7 +80,9 @@ function StatusDot({ color }: { color: string }) {
         width: 6,
         height: 6,
         borderRadius: "50%",
-        background: color,
+        background: style.background,
+        border: style.border,
+        boxSizing: "border-box",
         marginRight: 6,
         flexShrink: 0,
       }}
@@ -81,14 +126,76 @@ function CompileButton({
   );
 }
 
+interface OwnersChipProps {
+  slugs?: string[];
+}
+
+/**
+ * Small pill rendering the agent slugs that own a skill. Empty/missing
+ * slugs render as "lead-routable" (italic, dim) to make ownership status
+ * legible at a glance without the user squinting at a missing field.
+ */
+export function OwnersChip({ slugs }: OwnersChipProps) {
+  const list = (slugs ?? []).filter((s) => s.trim().length > 0);
+  if (list.length === 0) {
+    return (
+      <span
+        className="owners-chip owners-chip--lead"
+        title="Lead-routable: any agent can route through the team lead"
+      >
+        lead-routable
+      </span>
+    );
+  }
+  return (
+    <span
+      className="owners-chip"
+      title={`Scoped to: ${list.map((s) => `@${s}`).join(", ")}`}
+    >
+      {list.map((s) => `@${s}`).join(", ")}
+    </span>
+  );
+}
+
 export function SkillsApp() {
   const queryClient = useQueryClient();
+  const [previewSkill, setPreviewSkill] = useState<Skill | null>(null);
+  const [previewDirty, setPreviewDirty] = useState(false);
+  // Pause the 30s background refetch while the editor is open. Otherwise
+  // a refetch can replace the previewed skill mid-edit, swap the closed-
+  // over `originalContent` under the user, and invalidate the patchSkill
+  // old_string. The editor still reflects fresh data on next open.
+  const previewOpen = previewSkill !== null;
   const { data, isLoading, error } = useQuery({
-    queryKey: ["skills"],
-    queryFn: () => getSkills(),
-    refetchInterval: 30_000,
+    queryKey: ["skills", "all"],
+    queryFn: () => getSkillsList("all"),
+    refetchInterval: previewOpen ? false : 30_000,
   });
+  const { data: officeMembers } = useOfficeMembers();
+  const leadSlug = useTeamLeadSlug(officeMembers);
   const [compileState, setCompileState] = useState<CompileState>("idle");
+  const [ownerFilter, setOwnerFilter] = useState<OwnerFilterValue>("all");
+
+  // Hydrate filter from localStorage on mount, validated against the
+  // current office. If the saved slug no longer maps to a member (agent
+  // removed), drop back to "all" instead of rendering an empty list with
+  // no error message. We wait for officeMembers to resolve so a still-
+  // loading roster doesn't wipe a valid filter.
+  useEffect(() => {
+    if (officeMembers === undefined) return;
+    const stored = readOwnerFilter();
+    const valid =
+      stored === "all" ||
+      stored === "lead-routable" ||
+      officeMembers.some((m) => m.slug === stored);
+    setOwnerFilter(valid ? stored : "all");
+    if (!valid) writeOwnerFilter("all");
+  }, [officeMembers]);
+
+  const handleOwnerFilterChange = useCallback((value: OwnerFilterValue) => {
+    setOwnerFilter(value);
+    writeOwnerFilter(value);
+  }, []);
 
   const handleCompile = useCallback(() => {
     setCompileState("compiling");
@@ -113,6 +220,36 @@ export function SkillsApp() {
         showNotice(`Compile failed: ${e.message}`, "error");
       });
   }, [queryClient]);
+
+  const handlePreview = useCallback((skill: Skill) => {
+    setPreviewSkill(skill);
+    setPreviewDirty(false);
+  }, []);
+
+  // Closes the SidePanel; prompts the user to confirm when there are
+  // unsaved edits (proposed skills can be edited inline). The browser
+  // confirm() is fine here — we already use it elsewhere for danger-zone
+  // confirmations, and the destructive consequence (lost edits) maps cleanly
+  // onto the binary OK/Cancel UX.
+  const handlePreviewClose = useCallback(() => {
+    if (previewDirty) {
+      const ok = window.confirm(
+        "You have unsaved edits. Discard them and close?",
+      );
+      if (!ok) return;
+    }
+    setPreviewSkill(null);
+    setPreviewDirty(false);
+  }, [previewDirty]);
+
+  const handlePreviewSaved = useCallback(
+    (updated: Skill) => {
+      setPreviewSkill(updated);
+      setPreviewDirty(false);
+      queryClient.invalidateQueries({ queryKey: ["skills"] });
+    },
+    [queryClient],
+  );
 
   if (isLoading) {
     return (
@@ -144,15 +281,25 @@ export function SkillsApp() {
     );
   }
 
-  const skills = data?.skills ?? [];
-  const proposed = skills.filter((s) => deriveStatus(s) === "proposed");
-  const active = skills.filter((s) => deriveStatus(s) === "active");
-  const archived = skills.filter((s) => deriveStatus(s) === "archived");
+  const allSkills = data?.skills ?? [];
+  const filteredSkills = allSkills.filter((sk) =>
+    matchesOwnerFilter(sk, ownerFilter),
+  );
+
+  const proposed = filteredSkills.filter((s) => deriveStatus(s) === "proposed");
+  const active = filteredSkills.filter((s) => deriveStatus(s) === "active");
+  const disabled = filteredSkills.filter((s) => deriveStatus(s) === "disabled");
+  const archived = filteredSkills.filter((s) => deriveStatus(s) === "archived");
 
   proposed.sort((a, b) =>
     String(b.created_at ?? "").localeCompare(String(a.created_at ?? "")),
   );
   active.sort((a, b) =>
+    (a.name || "").localeCompare(b.name || "", undefined, {
+      sensitivity: "base",
+    }),
+  );
+  disabled.sort((a, b) =>
     (a.name || "").localeCompare(b.name || "", undefined, {
       sensitivity: "base",
     }),
@@ -177,7 +324,7 @@ export function SkillsApp() {
       >
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           <h3 style={{ fontSize: 16, fontWeight: 600 }}>Skills</h3>
-          {skills.length > 0 && (
+          {allSkills.length > 0 && (
             <div
               style={{
                 display: "flex",
@@ -185,29 +332,34 @@ export function SkillsApp() {
                 gap: 12,
                 fontSize: 13,
                 color: "var(--text-secondary)",
+                flexWrap: "wrap",
               }}
             >
               <span style={{ display: "inline-flex", alignItems: "center" }}>
-                <StatusDot color={STATUS_DOT_COLOR.active} />
+                <StatusDot status="active" />
                 {active.length} active
               </span>
               <span style={{ display: "inline-flex", alignItems: "center" }}>
-                <StatusDot color={STATUS_DOT_COLOR.proposed} />
+                <StatusDot status="proposed" />
                 {proposed.length} pending
               </span>
               <span style={{ display: "inline-flex", alignItems: "center" }}>
-                <StatusDot color={STATUS_DOT_COLOR.archived} />
+                <StatusDot status="disabled" />
+                {disabled.length} disabled
+              </span>
+              <span style={{ display: "inline-flex", alignItems: "center" }}>
+                <StatusDot status="archived" />
                 {archived.length} archived
               </span>
             </div>
           )}
         </div>
-        {skills.length > 0 && (
+        {allSkills.length > 0 && (
           <CompileButton state={compileState} onClick={handleCompile} />
         )}
       </div>
 
-      {skills.length === 0 ? (
+      {allSkills.length === 0 ? (
         <div
           style={{
             padding: "40px 20px",
@@ -227,45 +379,155 @@ export function SkillsApp() {
           <CompileButton state={compileState} onClick={handleCompile} />
         </div>
       ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
-          {proposed.length > 0 && (
+        <>
+          <OwnerFilterBar
+            value={ownerFilter}
+            onChange={handleOwnerFilterChange}
+            members={officeMembers ?? []}
+          />
+          <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
             <SkillSection
               title={STATUS_LABEL.proposed}
               count={proposed.length}
               status="proposed"
+              emptyHidden={true}
             >
               {proposed.map((skill) => (
-                <SkillCard key={skill.name} skill={skill} />
+                <SkillCard
+                  key={skill.name}
+                  skill={skill}
+                  onPreview={handlePreview}
+                  leadSlug={leadSlug}
+                />
               ))}
             </SkillSection>
-          )}
 
-          <SkillSection
-            title={STATUS_LABEL.active}
-            count={active.length}
-            status="active"
-          >
-            {active.length === 0 ? (
-              <div
-                style={{
-                  fontSize: 13,
-                  color: "var(--text-tertiary)",
-                  padding: "8px 0",
-                }}
-              >
-                No active skills.
-              </div>
-            ) : (
-              active.map((skill) => (
-                <SkillCard key={skill.name} skill={skill} />
-              ))
-            )}
-          </SkillSection>
+            <SkillSection
+              title={STATUS_LABEL.active}
+              count={active.length}
+              status="active"
+            >
+              {active.length === 0 ? (
+                <div
+                  style={{
+                    fontSize: 13,
+                    color: "var(--text-tertiary)",
+                    padding: "8px 0",
+                  }}
+                >
+                  No active skills.
+                </div>
+              ) : (
+                active.map((skill) => (
+                  <SkillCard
+                    key={skill.name}
+                    skill={skill}
+                    onPreview={handlePreview}
+                    leadSlug={leadSlug}
+                  />
+                ))
+              )}
+            </SkillSection>
 
-          <ArchivedSection skills={archived} />
-        </div>
+            <DisabledSection
+              skills={disabled}
+              onPreview={handlePreview}
+              leadSlug={leadSlug}
+            />
+
+            <ArchivedSection
+              skills={archived}
+              onPreview={handlePreview}
+              leadSlug={leadSlug}
+            />
+          </div>
+        </>
       )}
+
+      <SidePanel
+        open={previewSkill !== null}
+        onClose={handlePreviewClose}
+        title={previewSkill?.title || previewSkill?.name || "Skill"}
+        subtitle={previewSkill?.name}
+      >
+        {previewSkill ? (
+          <SkillPreviewBody
+            skill={previewSkill}
+            onDirtyChange={setPreviewDirty}
+            onSaved={handlePreviewSaved}
+          />
+        ) : null}
+      </SidePanel>
     </>
+  );
+}
+
+function matchesOwnerFilter(skill: Skill, filter: OwnerFilterValue): boolean {
+  const owners = (skill.owner_agents ?? []).filter((s) => s.trim().length > 0);
+  if (filter === "all") return true;
+  if (filter === "lead-routable") return owners.length === 0;
+  return owners.includes(filter);
+}
+
+function OwnerFilterBar({
+  value,
+  onChange,
+  members,
+}: {
+  value: OwnerFilterValue;
+  onChange: (v: OwnerFilterValue) => void;
+  members: { slug: string; name?: string }[];
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        marginBottom: 14,
+        position: "sticky",
+        top: 0,
+        zIndex: 5,
+        background: "var(--bg-card, #fff)",
+        paddingBottom: 8,
+      }}
+    >
+      <label
+        htmlFor="skills-owner-filter"
+        style={{
+          fontSize: 12,
+          color: "var(--text-secondary)",
+          fontWeight: 500,
+        }}
+      >
+        Owner
+      </label>
+      <select
+        id="skills-owner-filter"
+        value={value}
+        onChange={(e) => onChange(e.target.value as OwnerFilterValue)}
+        aria-label="Filter skills by owner"
+        style={{
+          background: "var(--bg-card, #fff)",
+          border: "1px solid var(--border)",
+          color: "var(--text)",
+          fontFamily: "inherit",
+          fontSize: 13,
+          padding: "6px 10px",
+          borderRadius: 6,
+          minHeight: 32,
+        }}
+      >
+        <option value="all">All</option>
+        <option value="lead-routable">Lead-routable only</option>
+        {members.map((m) => (
+          <option key={m.slug} value={m.slug}>
+            @{m.slug}
+            {m.name ? ` (${m.name})` : ""}
+          </option>
+        ))}
+      </select>
+    </div>
   );
 }
 
@@ -274,12 +536,15 @@ function SkillSection({
   count,
   status,
   children,
+  emptyHidden = false,
 }: {
   title: string;
   count: number;
   status: SkillStatus;
   children: React.ReactNode;
+  emptyHidden?: boolean;
 }) {
+  if (emptyHidden && count === 0) return null;
   return (
     <section>
       <div
@@ -292,7 +557,7 @@ function SkillSection({
           marginBottom: 8,
         }}
       >
-        <StatusDot color={STATUS_DOT_COLOR[status]} />
+        <StatusDot status={status} />
         {title} ({count})
       </div>
       {children}
@@ -300,7 +565,88 @@ function SkillSection({
   );
 }
 
-function ArchivedSection({ skills }: { skills: Skill[] }) {
+function DisabledSection({
+  skills,
+  onPreview,
+  leadSlug,
+}: {
+  skills: Skill[];
+  onPreview: (s: Skill) => void;
+  leadSlug: string;
+}) {
+  // Per design review: disabled is recoverable, so default expanded.
+  const [expanded, setExpanded] = useState(true);
+
+  return (
+    <section>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          fontSize: 13,
+          fontWeight: 500,
+          color: "var(--text-secondary)",
+          marginBottom: 8,
+          background: "transparent",
+          border: "none",
+          padding: 0,
+          cursor: "pointer",
+          fontFamily: "inherit",
+        }}
+      >
+        <StatusDot status="disabled" />
+        <span
+          aria-hidden="true"
+          style={{
+            display: "inline-block",
+            marginRight: 6,
+            transition: "transform 0.15s",
+            transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+            fontSize: 10,
+          }}
+        >
+          {"▶"}
+        </span>
+        Disabled ({skills.length})
+      </button>
+      {expanded ? (
+        skills.length === 0 ? (
+          <div
+            style={{
+              fontSize: 13,
+              color: "var(--text-tertiary)",
+              padding: "8px 0",
+            }}
+          >
+            Nothing disabled. You can pause a skill anytime by clicking Disable.
+          </div>
+        ) : (
+          skills.map((skill) => (
+            <SkillCard
+              key={skill.name}
+              skill={skill}
+              onPreview={onPreview}
+              leadSlug={leadSlug}
+            />
+          ))
+        )
+      ) : null}
+    </section>
+  );
+}
+
+function ArchivedSection({
+  skills,
+  onPreview,
+  leadSlug,
+}: {
+  skills: Skill[];
+  onPreview: (s: Skill) => void;
+  leadSlug: string;
+}) {
   const [expanded, setExpanded] = useState(false);
 
   return (
@@ -323,7 +669,7 @@ function ArchivedSection({ skills }: { skills: Skill[] }) {
         }}
         aria-expanded={expanded}
       >
-        <StatusDot color={STATUS_DOT_COLOR.archived} />
+        <StatusDot status="archived" />
         <span
           aria-hidden="true"
           style={{
@@ -350,7 +696,14 @@ function ArchivedSection({ skills }: { skills: Skill[] }) {
             No archived skills.
           </div>
         ) : (
-          skills.map((skill) => <SkillCard key={skill.name} skill={skill} />)
+          skills.map((skill) => (
+            <SkillCard
+              key={skill.name}
+              skill={skill}
+              onPreview={onPreview}
+              leadSlug={leadSlug}
+            />
+          ))
         )
       ) : null}
     </section>
@@ -360,6 +713,7 @@ function ArchivedSection({ skills }: { skills: Skill[] }) {
 const STATUS_BADGE_CLASS: Record<SkillStatus, string> = {
   active: "badge badge-green",
   proposed: "badge badge-yellow",
+  disabled: "badge badge-neutral",
   archived: "badge badge-muted",
 };
 
@@ -400,32 +754,82 @@ function SkillProvenance({ articles }: { articles: string[] }) {
   );
 }
 
+type InvokePhase = "idle" | "invoking" | "running" | "done" | "failed";
+
+function isTerminalTaskStatus(s: string | undefined): boolean {
+  if (!s) return false;
+  return ["done", "completed", "blocked", "cancelled", "canceled"].includes(s);
+}
+
 function SkillActions({
   status,
   skillName,
+  onSuggestChanges,
 }: {
   status: SkillStatus;
   skillName: string;
+  onSuggestChanges?: () => void;
 }) {
-  const [invokeState, setInvokeState] = useState<"idle" | "invoking" | "done">(
-    "idle",
-  );
+  const [invokePhase, setInvokePhase] = useState<InvokePhase>("idle");
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
   const [actionPending, setActionPending] = useState(false);
   const queryClient = useQueryClient();
+  const setCurrentApp = useAppStore((s) => s.setCurrentApp);
+
+  const isPolling = invokePhase === "running";
+  const { data: officeTasks } = useQuery({
+    queryKey: ["office-tasks", "skill-run-watch"],
+    queryFn: () => getOfficeTasks({ includeDone: true }),
+    refetchInterval: isPolling ? 2_500 : false,
+    enabled: isPolling,
+  });
+
+  const activeTask: Task | undefined = useMemo(() => {
+    if (!activeTaskId) return undefined;
+    return officeTasks?.tasks.find((t) => t.id === activeTaskId);
+  }, [officeTasks, activeTaskId]);
+
+  useEffect(() => {
+    if (!(isPolling && activeTask)) return;
+    if (isTerminalTaskStatus(activeTask.status)) {
+      const failed =
+        activeTask.status === "blocked" ||
+        activeTask.status === "cancelled" ||
+        activeTask.status === "canceled";
+      setInvokePhase(failed ? "failed" : "done");
+    }
+  }, [isPolling, activeTask]);
 
   const handleInvoke = useCallback(() => {
     if (!skillName) return;
-    setInvokeState("invoking");
+    setInvokePhase("invoking");
+    setActiveTaskId(null);
     invokeSkill(skillName, {})
-      .then(() => {
-        setInvokeState("done");
-        setTimeout(() => setInvokeState("idle"), 1500);
+      .then((res) => {
+        const tid = res?.task_id ?? null;
+        setActiveTaskId(tid);
+        if (!tid) {
+          setInvokePhase("done");
+          setTimeout(() => setInvokePhase("idle"), 1500);
+          return;
+        }
+        setInvokePhase("running");
       })
       .catch((e: Error) => {
-        setInvokeState("idle");
+        setInvokePhase("idle");
         showNotice(`Invoke failed: ${e.message}`, "error");
       });
   }, [skillName]);
+
+  const handleViewTask = useCallback(() => {
+    if (!activeTaskId) return;
+    setCurrentApp("tasks");
+  }, [activeTaskId, setCurrentApp]);
+
+  const handleResetInvoke = useCallback(() => {
+    setInvokePhase("idle");
+    setActiveTaskId(null);
+  }, []);
 
   const handleApprove = useCallback(() => {
     if (!skillName) return;
@@ -446,10 +850,9 @@ function SkillActions({
     setActionPending(true);
     rejectSkill(skillName)
       .then((res) => {
-        // Optimistic: invalidate so the card disappears, then offer undo.
         queryClient.invalidateQueries({ queryKey: ["skills"] });
         const token = res.undo_token;
-        const undoMs = Math.max(1, (res.expires_in ?? 5) * 1000);
+        const undoMs = Math.max(1, (res.expires_in ?? 6) * 1000);
         showUndoToast(
           `Rejected ${skillName}`,
           () => {
@@ -476,10 +879,110 @@ function SkillActions({
       .finally(() => setActionPending(false));
   }, [skillName, queryClient]);
 
+  const handleDisable = useCallback(() => {
+    if (!skillName) return;
+    // Don't let archive/disable race with a live invoke. The polling
+    // skill_run task is still settling — disabling here would hide the
+    // chip the user is watching and mask the run result.
+    if (invokePhase !== "idle") return;
+    setActionPending(true);
+    disableSkill(skillName)
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["skills"] });
+        showUndoToast(
+          `${skillName} disabled`,
+          () => {
+            enableSkill(skillName)
+              .then(() => {
+                showNotice("Re-enabled", "success");
+                queryClient.invalidateQueries({ queryKey: ["skills"] });
+              })
+              .catch((e: Error) => {
+                showNotice(`undo failed: ${e.message}`, "error");
+              });
+          },
+          5_000,
+        );
+      })
+      .catch((e: Error) => {
+        showNotice(`Couldn't disable: ${e.message}`, "error");
+      })
+      .finally(() => setActionPending(false));
+  }, [skillName, queryClient, invokePhase]);
+
+  const handleEnable = useCallback(() => {
+    if (!skillName) return;
+    setActionPending(true);
+    enableSkill(skillName)
+      .then(() => {
+        showNotice(`${skillName} enabled`, "success");
+        queryClient.invalidateQueries({ queryKey: ["skills"] });
+      })
+      .catch((e: Error) => {
+        showNotice(`Couldn't enable: ${e.message}`, "error");
+      })
+      .finally(() => setActionPending(false));
+  }, [skillName, queryClient]);
+
+  const handleArchive = useCallback(() => {
+    if (!skillName) return;
+    if (invokePhase !== "idle") return;
+    setActionPending(true);
+    archiveSkill(skillName)
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["skills"] });
+        showUndoToast(
+          `${skillName} archived`,
+          () => {
+            restoreArchivedSkill(skillName)
+              .then(() => {
+                showNotice("Restored — skill is now pending review", "success");
+                queryClient.invalidateQueries({ queryKey: ["skills"] });
+              })
+              .catch((e: Error) => {
+                const msg = e.message || "";
+                if (/expired|gone|410/i.test(msg)) {
+                  showNotice("Undo window expired", "error");
+                } else {
+                  showNotice(`undo failed: ${msg}`, "error");
+                }
+              });
+          },
+          5_000,
+        );
+      })
+      .catch((e: Error) => {
+        showNotice(`Couldn't archive: ${e.message}`, "error");
+      })
+      .finally(() => setActionPending(false));
+  }, [skillName, queryClient, invokePhase]);
+
   if (status === "archived") {
     return (
-      <span style={{ fontSize: 12, color: "var(--text-tertiary)" }}>
-        Archived
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+        <span style={{ fontSize: 12, color: "var(--text-tertiary)" }}>
+          Archived
+        </span>
+        <button
+          type="button"
+          className="btn btn-sm"
+          disabled={actionPending}
+          aria-label={`Restore ${skillName} to pending review`}
+          onClick={() => {
+            setActionPending(true);
+            restoreArchivedSkill(skillName)
+              .then(() => {
+                showNotice("Restored — skill is now pending review", "success");
+                queryClient.invalidateQueries({ queryKey: ["skills"] });
+              })
+              .catch((e: Error) => {
+                showNotice(`Couldn't restore: ${e.message}`, "error");
+              })
+              .finally(() => setActionPending(false));
+          }}
+        >
+          Restore
+        </button>
       </span>
     );
   }
@@ -491,48 +994,654 @@ function SkillActions({
           className="btn btn-primary btn-sm"
           disabled={actionPending}
           onClick={handleApprove}
+          aria-label={`Approve ${skillName}`}
         >
           Approve
         </button>
+        {onSuggestChanges ? (
+          <button
+            type="button"
+            className="btn-text"
+            disabled={actionPending}
+            onClick={onSuggestChanges}
+            aria-label={`Suggest changes to ${skillName}`}
+          >
+            Suggest changes
+          </button>
+        ) : null}
         <button
           type="button"
-          className="btn btn-secondary btn-sm"
+          className="btn-text btn-text--danger"
           disabled={actionPending}
           onClick={handleReject}
+          aria-label={`Reject ${skillName}`}
         >
           Reject
         </button>
       </>
     );
   }
+  if (status === "disabled") {
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          flexWrap: "wrap",
+        }}
+      >
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          disabled={actionPending}
+          onClick={handleEnable}
+          aria-label={`Enable ${skillName}`}
+        >
+          Enable
+        </button>
+        <button
+          type="button"
+          className="btn-text btn-text--danger"
+          disabled={actionPending}
+          onClick={handleArchive}
+          aria-label={`Archive ${skillName}`}
+        >
+          Archive
+        </button>
+      </div>
+    );
+  }
   // active
-  const invokeLabel =
-    invokeState === "invoking"
-      ? "Invoking..."
-      : invokeState === "done"
-        ? "✓ Invoked"
-        : "⚡ Invoke";
   return (
-    <button
-      type="button"
-      className="btn btn-primary btn-sm"
-      disabled={invokeState !== "idle"}
-      onClick={handleInvoke}
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        flexWrap: "wrap",
+      }}
     >
-      {invokeLabel}
-    </button>
+      <button
+        type="button"
+        className="btn btn-primary btn-sm"
+        disabled={
+          invokePhase === "invoking" ||
+          invokePhase === "running" ||
+          actionPending
+        }
+        onClick={handleInvoke}
+        aria-label={`Invoke ${skillName}`}
+        style={{ display: "inline-flex", alignItems: "center", gap: 6 }}
+      >
+        {invokePhase === "invoking" ? (
+          "Invoking..."
+        ) : invokePhase === "running" ? (
+          "Running..."
+        ) : invokePhase === "done" ? (
+          "✓ Invoked"
+        ) : invokePhase === "failed" ? (
+          "Try again"
+        ) : (
+          <>
+            <LightningIcon size={14} />
+            Invoke
+          </>
+        )}
+      </button>
+
+      <button
+        type="button"
+        className="btn-text"
+        disabled={actionPending || invokePhase !== "idle"}
+        onClick={handleDisable}
+        aria-label={`Disable ${skillName}`}
+      >
+        Disable
+      </button>
+
+      <button
+        type="button"
+        className="btn-text btn-text--danger"
+        disabled={actionPending || invokePhase !== "idle"}
+        onClick={handleArchive}
+        aria-label={`Archive ${skillName}`}
+      >
+        Archive
+      </button>
+
+      {activeTaskId ? (
+        <SkillRunChip
+          phase={invokePhase}
+          taskId={activeTaskId}
+          taskStatus={activeTask?.status}
+          taskTitle={activeTask?.title}
+          onView={handleViewTask}
+          onDismiss={handleResetInvoke}
+        />
+      ) : null}
+    </div>
   );
 }
 
-function SkillCard({ skill }: { skill: Skill }) {
-  const status = deriveStatus(skill);
-  const sourceArticles = skill.metadata?.wuphf?.source_articles ?? [];
-  const isArchived = status === "archived";
+function SkillRunChip({
+  phase,
+  taskId,
+  taskStatus,
+  taskTitle,
+  onView,
+  onDismiss,
+}: {
+  phase: InvokePhase;
+  taskId: string;
+  taskStatus?: string;
+  taskTitle?: string;
+  onView: () => void;
+  onDismiss: () => void;
+}) {
+  const isRunning = phase === "running";
+  const isDone = phase === "done";
+  const isFailed = phase === "failed";
+  const dotColor = isFailed
+    ? "var(--red, #c43e3e)"
+    : isDone
+      ? "var(--green)"
+      : "var(--yellow)";
+  const label = isRunning
+    ? `Running ${taskId}`
+    : isFailed
+      ? `${taskStatus ?? "failed"} · ${taskId}`
+      : isDone
+        ? `${taskStatus ?? "done"} · ${taskId}`
+        : taskId;
+  return (
+    <span
+      title={taskTitle || taskId}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "2px 8px",
+        fontSize: 12,
+        background: "var(--bg-warm, var(--neutral-100))",
+        border: "1px solid var(--border-subtle, var(--neutral-200))",
+        borderRadius: 999,
+        color: "var(--text-secondary)",
+      }}
+    >
+      <span
+        aria-hidden="true"
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: "50%",
+          background: dotColor,
+          animation: isRunning ? "pulse-dot 1.2s ease-in-out infinite" : "none",
+        }}
+      />
+      <span style={{ fontFamily: "var(--font-mono)" }}>{label}</span>
+      <button
+        type="button"
+        onClick={onView}
+        aria-label={`View task ${taskId}`}
+        style={{
+          border: "none",
+          background: "transparent",
+          padding: 0,
+          color: "var(--accent, #1264a3)",
+          fontSize: 12,
+          cursor: "pointer",
+        }}
+      >
+        View →
+      </button>
+      {isDone || isFailed ? (
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          style={{
+            border: "none",
+            background: "transparent",
+            padding: 0,
+            color: "var(--text-tertiary)",
+            fontSize: 14,
+            cursor: "pointer",
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+      ) : null}
+    </span>
+  );
+}
+
+function SuggestChangesExpander({
+  skillName,
+  leadSlug,
+  onClose,
+}: {
+  skillName: string;
+  leadSlug: string;
+  onClose: () => void;
+}) {
+  const [text, setText] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setSubmitting(true);
+    createTasks(
+      [
+        {
+          title: `Revise skill: ${skillName}`,
+          assignee: leadSlug,
+          details: trimmed,
+        },
+      ],
+      { createdBy: "human" },
+    )
+      .then(() => {
+        showNotice(
+          `Sent to @${leadSlug}. They'll revise and re-propose.`,
+          "success",
+        );
+        onClose();
+      })
+      .catch((e: Error) => {
+        showNotice(`Couldn't send: ${e.message}`, "error");
+      })
+      .finally(() => setSubmitting(false));
+  }, [text, skillName, leadSlug, onClose]);
 
   return (
     <div
-      className="app-card"
-      style={{ marginBottom: 8, opacity: isArchived ? 0.6 : 1 }}
+      className="skill-suggest-expander"
+      style={{
+        marginTop: 10,
+        padding: 12,
+        background: "var(--bg-warm, var(--neutral-50))",
+        border: "1px solid var(--border)",
+        borderRadius: 6,
+      }}
+    >
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        placeholder="What needs to change? Be specific."
+        rows={4}
+        disabled={submitting}
+        aria-label={`Suggested revisions for ${skillName}`}
+        style={{
+          width: "100%",
+          minHeight: 80,
+          maxHeight: 240,
+          padding: 10,
+          border: "1px solid var(--border)",
+          borderRadius: 4,
+          fontFamily: "inherit",
+          fontSize: 13,
+          color: "var(--text)",
+          background: "var(--bg-card, #fff)",
+          resize: "vertical",
+          boxSizing: "border-box",
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            if (text.trim()) handleSubmit();
+          }
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onClose();
+          }
+        }}
+      />
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "flex-end",
+          gap: 8,
+          marginTop: 8,
+        }}
+      >
+        <button
+          type="button"
+          className="btn-text"
+          onClick={onClose}
+          disabled={submitting}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={handleSubmit}
+          disabled={submitting || !text.trim()}
+        >
+          {submitting ? "Sending..." : `Send to @${leadSlug} for revision`}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface SkillPreviewBodyProps {
+  skill: Skill;
+  /** Notifies the parent panel when the editor has unsaved changes. */
+  onDirtyChange?: (dirty: boolean) => void;
+  /** Called after a successful save with the updated skill. */
+  onSaved?: (updated: Skill) => void;
+}
+
+function SkillPreviewBody({
+  skill,
+  onDirtyChange,
+  onSaved,
+}: SkillPreviewBodyProps) {
+  const owners = skill.owner_agents ?? [];
+  const isProposed = skill.status === "proposed";
+
+  // baseline = the content the editor is "based on" (the last server-known
+  // state). It only updates when the user opens a different skill OR
+  // explicitly saves. Comparing draft against baseline determines dirty
+  // state; comparing against `skill.content` would let a background
+  // refetch silently overwrite the user's typing.
+  const [baseline, setBaseline] = useState(skill.content ?? "");
+  const [draft, setDraft] = useState(skill.content ?? "");
+  const [saving, setSaving] = useState(false);
+
+  // Reset baseline + draft when the user navigates to a DIFFERENT skill.
+  // Keyed on skill.name only so post-save updates to skill.content (from
+  // the parent passing back the updated Skill) don't blow away chars the
+  // user typed in the gap between save resolution and effect run.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: see comment
+  useEffect(() => {
+    const next = skill.content ?? "";
+    setBaseline(next);
+    setDraft(next);
+    onDirtyChange?.(false);
+  }, [skill.name]);
+
+  const dirty = isProposed && draft !== baseline;
+
+  // Keep the parent informed of dirty-state so the SidePanel close path
+  // can prompt for unsaved edits.
+  useEffect(() => {
+    onDirtyChange?.(dirty);
+  }, [dirty, onDirtyChange]);
+
+  const handleSave = useCallback(() => {
+    if (!(isProposed && dirty && skill.name)) return;
+    setSaving(true);
+    // Snapshot the draft we're committing — a chained edit landing while
+    // the request is in flight would otherwise change `draft` under us
+    // and confuse the post-save baseline.
+    const committed = draft;
+    const oldString = baseline;
+    patchSkill(skill.name, {
+      old_string: oldString,
+      new_string: committed,
+      replace_all: false,
+    })
+      .then((res) => {
+        showNotice("Saved.", "success");
+        // Sync baseline to the saved body BEFORE notifying the parent. If
+        // the user typed more chars while the request was in flight they
+        // remain in `draft`, the dirty flag flips back on, and the
+        // editor naturally surfaces the new unsaved delta — instead of
+        // the parent's effect resetting `draft` and silently losing them.
+        setBaseline(committed);
+        const updated: Skill = res.skill ?? { ...skill, content: committed };
+        onSaved?.(updated);
+      })
+      .catch((e: Error) => {
+        showNotice(`Couldn't save: ${e.message}`, "error");
+      })
+      .finally(() => setSaving(false));
+  }, [isProposed, dirty, skill, baseline, draft, onSaved]);
+
+  const handleRevert = useCallback(() => {
+    setDraft(baseline);
+  }, [baseline]);
+
+  return (
+    <div
+      style={{
+        fontSize: 13,
+        lineHeight: 1.55,
+        color: "var(--text)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          flexWrap: "wrap",
+          marginBottom: 12,
+        }}
+      >
+        <OwnersChip slugs={owners} />
+        {skill.status ? (
+          <span className={STATUS_BADGE_CLASS[skill.status]}>
+            {skill.status}
+          </span>
+        ) : null}
+      </div>
+      {skill.description ? (
+        <p style={{ marginTop: 0, marginBottom: 12 }}>{skill.description}</p>
+      ) : null}
+      {skill.trigger ? (
+        <p
+          style={{
+            marginTop: 0,
+            marginBottom: 12,
+            color: "var(--text-secondary)",
+            fontStyle: "italic",
+          }}
+        >
+          Trigger: {skill.trigger}
+        </p>
+      ) : null}
+
+      {isProposed ? (
+        <>
+          <label
+            htmlFor="skill-body-editor"
+            style={{
+              display: "block",
+              fontSize: 12,
+              fontWeight: 500,
+              color: "var(--text-secondary)",
+              marginBottom: 6,
+            }}
+          >
+            SKILL.md body
+            <span
+              style={{
+                fontWeight: 400,
+                color: "var(--text-tertiary)",
+                marginLeft: 6,
+              }}
+            >
+              (frontmatter is read-only in v1)
+            </span>
+          </label>
+          <textarea
+            id="skill-body-editor"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            disabled={saving}
+            spellCheck={false}
+            aria-label={`Edit body for ${skill.name}`}
+            style={{
+              width: "100%",
+              minHeight: 240,
+              maxHeight: "60vh",
+              padding: 12,
+              background: "var(--bg-warm, var(--neutral-50))",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              fontFamily: "var(--font-mono)",
+              fontSize: 12,
+              lineHeight: 1.5,
+              color: "var(--text)",
+              resize: "vertical",
+              boxSizing: "border-box",
+            }}
+          />
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "flex-end",
+              gap: 8,
+              marginTop: 8,
+            }}
+          >
+            {dirty ? (
+              <span
+                aria-live="polite"
+                style={{
+                  fontSize: 12,
+                  color: "var(--text-tertiary)",
+                  marginRight: "auto",
+                }}
+              >
+                Unsaved changes.
+              </span>
+            ) : null}
+            <button
+              type="button"
+              className="btn-text"
+              onClick={handleRevert}
+              disabled={saving || !dirty}
+            >
+              Revert
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={handleSave}
+              disabled={saving || !dirty}
+              aria-label={`Save edits to ${skill.name}`}
+            >
+              {saving ? "Saving..." : "Save"}
+            </button>
+          </div>
+          <p
+            style={{
+              marginTop: 12,
+              marginBottom: 0,
+              fontSize: 12,
+              color: "var(--text-tertiary)",
+            }}
+          >
+            Saving leaves this proposal pending. Approve or reject from the
+            interview to promote it.
+          </p>
+        </>
+      ) : skill.content ? (
+        <pre
+          style={{
+            background: "var(--bg-warm, var(--neutral-50))",
+            border: "1px solid var(--border)",
+            borderRadius: 6,
+            padding: 12,
+            fontSize: 12,
+            fontFamily: "var(--font-mono)",
+            whiteSpace: "pre-wrap",
+            wordBreak: "break-word",
+            margin: 0,
+          }}
+        >
+          {skill.content}
+        </pre>
+      ) : (
+        <div style={{ color: "var(--text-tertiary)", fontSize: 13 }}>
+          No body content available.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ProposedPreviewBody({ skill }: { skill: Skill }) {
+  const body = skill.content ?? "";
+  const truncated = body.length > 500 ? `${body.slice(0, 500)}…` : body;
+  if (!(truncated || skill.description || skill.trigger)) return null;
+  return (
+    <div
+      style={{
+        marginTop: 4,
+        marginBottom: 8,
+        paddingLeft: 10,
+        borderLeft: "3px solid var(--neutral-200, #cfd1d2)",
+      }}
+    >
+      {skill.trigger ? (
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--text-secondary)",
+            fontStyle: "italic",
+            marginBottom: 6,
+          }}
+        >
+          Trigger: {skill.trigger}
+        </div>
+      ) : null}
+      {truncated ? (
+        <div
+          style={{
+            fontSize: 12,
+            color: "var(--text-secondary)",
+            whiteSpace: "pre-wrap",
+            fontFamily: "var(--font-mono)",
+            lineHeight: 1.5,
+          }}
+        >
+          {truncated}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SkillCard({
+  skill,
+  onPreview,
+  leadSlug,
+}: {
+  skill: Skill;
+  onPreview: (s: Skill) => void;
+  leadSlug: string;
+}) {
+  const status = deriveStatus(skill);
+  const sourceArticles = skill.metadata?.wuphf?.source_articles ?? [];
+  const isArchived = status === "archived";
+  const isDisabled = status === "disabled";
+  const isProposed = status === "proposed";
+  const cardSlugId = `skill-${skill.name || "untitled"}-name`;
+  const [suggestOpen, setSuggestOpen] = useState(false);
+
+  return (
+    <article
+      className={[
+        "app-card",
+        isProposed ? "app-card--proposed" : "",
+        isDisabled ? "app-card--disabled" : "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+      aria-labelledby={cardSlugId}
+      style={{
+        marginBottom: 8,
+        opacity: isArchived ? 0.6 : 1,
+      }}
     >
       <div
         style={{
@@ -543,16 +1652,21 @@ function SkillCard({ skill }: { skill: Skill }) {
           flexWrap: "wrap",
         }}
       >
-        <span style={{ fontSize: 16 }}>{"⚡"}</span>
-        <span className="app-card-title" style={{ marginBottom: 0 }}>
+        <LightningIcon size={16} />
+        <span
+          className="app-card-title"
+          id={cardSlugId}
+          style={{ marginBottom: 0 }}
+        >
           {skill.name || "Untitled"}
         </span>
         <span className={STATUS_BADGE_CLASS[status]}>{status}</span>
-        {status === "proposed" ? (
+        {isProposed ? (
           <span className="badge badge-yellow" style={{ marginLeft: 6 }}>
             AI-suggested
           </span>
         ) : null}
+        <OwnersChip slugs={skill.owner_agents} />
       </div>
 
       {skill.description ? (
@@ -568,19 +1682,81 @@ function SkillCard({ skill }: { skill: Skill }) {
         </div>
       ) : null}
 
-      {status === "proposed" ? (
-        <SkillProvenance articles={sourceArticles} />
+      {isProposed ? (
+        <>
+          {skill.similar_to_existing ? (
+            <div
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 6,
+                padding: "3px 8px",
+                marginBottom: 8,
+                background: "var(--bg-warm, var(--neutral-50))",
+                border: "1px solid var(--border)",
+                borderRadius: 4,
+                fontSize: 12,
+                color: "var(--text-secondary)",
+              }}
+              title={`Similarity score: ${Math.round(skill.similar_to_existing.score * 100)}% (${skill.similar_to_existing.method ?? ""})`}
+            >
+              <span aria-hidden="true">≈</span>
+              Similar to:{" "}
+              <strong style={{ fontFamily: "var(--font-mono)" }}>
+                {skill.similar_to_existing.slug}
+              </strong>
+            </div>
+          ) : null}
+          <ProposedPreviewBody skill={skill} />
+          <button
+            type="button"
+            onClick={() => onPreview(skill)}
+            className="btn-text"
+            style={{
+              padding: "2px 0",
+              fontSize: 12,
+              color: "var(--accent, #1264a3)",
+              marginBottom: 8,
+            }}
+            aria-label={`View full SKILL.md for ${skill.name}`}
+          >
+            View full SKILL.md →
+          </button>
+          <SkillProvenance articles={sourceArticles} />
+        </>
       ) : null}
 
-      {skill.source && status !== "proposed" ? (
+      {skill.source && !isProposed ? (
         <div className="app-card-meta" style={{ marginBottom: 8 }}>
           Source: {skill.source}
         </div>
       ) : null}
 
-      <div style={{ display: "flex", gap: 8, marginTop: 10 }}>
-        <SkillActions status={status} skillName={skill.name} />
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          marginTop: 10,
+          alignItems: "center",
+          flexWrap: "wrap",
+        }}
+      >
+        <SkillActions
+          status={status}
+          skillName={skill.name}
+          onSuggestChanges={
+            isProposed ? () => setSuggestOpen((v) => !v) : undefined
+          }
+        />
       </div>
-    </div>
+
+      {isProposed && suggestOpen ? (
+        <SuggestChangesExpander
+          skillName={skill.name}
+          leadSlug={leadSlug}
+          onClose={() => setSuggestOpen(false)}
+        />
+      ) : null}
+    </article>
   );
 }

--- a/web/src/components/messages/HumanInterviewOverlay.test.tsx
+++ b/web/src/components/messages/HumanInterviewOverlay.test.tsx
@@ -1,0 +1,121 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentRequest } from "../../api/client";
+
+const useRequestsMock = vi.fn();
+vi.mock("../../hooks/useRequests", () => ({
+  useRequests: () => useRequestsMock(),
+}));
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>("../../api/client");
+  return {
+    ...actual,
+    answerRequest: vi.fn().mockResolvedValue({}),
+    cancelRequest: vi.fn().mockResolvedValue({}),
+  };
+});
+
+import { HumanInterviewOverlay } from "./HumanInterviewOverlay";
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+function makeRequest(overrides: Partial<AgentRequest> = {}): AgentRequest {
+  return {
+    id: "req-1",
+    from: "planner",
+    question: "What should we do?",
+    blocking: true,
+    status: "pending",
+    options: [
+      { id: "yes", label: "Yes" },
+      { id: "no", label: "No" },
+    ],
+    ...overrides,
+  };
+}
+
+describe("<HumanInterviewOverlay>", () => {
+  it("renders nothing when there is no blocking request", () => {
+    useRequestsMock.mockReturnValue({ blockingPending: null, pending: [] });
+    const { container } = render(wrap(<HumanInterviewOverlay />));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the blocking interview card for a normal request", () => {
+    const req = makeRequest({ title: "Approve the plan?" });
+    useRequestsMock.mockReturnValue({ blockingPending: req, pending: [req] });
+    render(wrap(<HumanInterviewOverlay />));
+    expect(screen.getByText("Approve the plan?")).toBeInTheDocument();
+    expect(screen.getByText("Yes")).toBeInTheDocument();
+    expect(screen.getByText("No")).toBeInTheDocument();
+  });
+
+  it("shows the enhance-existing banner for enhance_skill_proposal kind", () => {
+    const req = makeRequest({
+      kind: "enhance_skill_proposal",
+      title: "Enhance existing skill?",
+      options: [
+        { id: "enhance", label: "Enhance" },
+        { id: "approve_anyway", label: "Approve anyway" },
+        { id: "reject", label: "Reject" },
+      ],
+      recommended_id: "enhance",
+      metadata: { enhances_slug: "email-ops" },
+    });
+    useRequestsMock.mockReturnValue({ blockingPending: req, pending: [req] });
+    render(wrap(<HumanInterviewOverlay />));
+
+    expect(screen.getByText(/Similar to existing skill:/i)).toBeInTheDocument();
+    expect(screen.getByText("email-ops")).toBeInTheDocument();
+    expect(screen.getByText("Enhance")).toBeInTheDocument();
+    expect(screen.getByText("Approve anyway")).toBeInTheDocument();
+    expect(screen.getByText("Reject")).toBeInTheDocument();
+  });
+
+  it("does not show the enhance banner for a normal skill_proposal", () => {
+    const req = makeRequest({
+      kind: "skill_proposal",
+      options: [
+        { id: "accept", label: "Accept" },
+        { id: "reject", label: "Reject" },
+      ],
+    });
+    useRequestsMock.mockReturnValue({ blockingPending: req, pending: [req] });
+    render(wrap(<HumanInterviewOverlay />));
+
+    expect(
+      screen.queryByText(/Similar to existing skill:/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("styles the recommended option with btn-primary class", () => {
+    const req = makeRequest({
+      kind: "enhance_skill_proposal",
+      options: [
+        { id: "enhance", label: "Enhance" },
+        { id: "approve_anyway", label: "Approve anyway" },
+        { id: "reject", label: "Reject" },
+      ],
+      recommended_id: "enhance",
+      metadata: { enhances_slug: "existing-skill" },
+    });
+    useRequestsMock.mockReturnValue({ blockingPending: req, pending: [req] });
+    render(wrap(<HumanInterviewOverlay />));
+
+    const enhanceBtn = screen.getByRole("button", { name: "Enhance" });
+    expect(enhanceBtn.className).toContain("btn-primary");
+
+    const approveBtn = screen.getByRole("button", { name: "Approve anyway" });
+    expect(approveBtn.className).toContain("btn-ghost");
+  });
+});

--- a/web/src/components/messages/HumanInterviewOverlay.tsx
+++ b/web/src/components/messages/HumanInterviewOverlay.tsx
@@ -87,6 +87,10 @@ function BlockingInterview({
   onDismiss,
 }: BlockingInterviewProps) {
   const options = request.options ?? request.choices ?? [];
+  const isEnhanceInterview = request.kind === "enhance_skill_proposal";
+  const enhancesSlug = isEnhanceInterview
+    ? (request.metadata?.enhances_slug as string | undefined)
+    : undefined;
 
   return (
     <div
@@ -108,6 +112,40 @@ function BlockingInterview({
             ? request.title
             : "Human decision requested"}
         </h2>
+        {isEnhanceInterview && enhancesSlug && (
+          <div
+            className="interview-enhance-banner"
+            role="note"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              padding: "8px 12px",
+              marginBottom: 12,
+              background: "var(--bg-warm, var(--neutral-50))",
+              border: "1px solid var(--border)",
+              borderRadius: 6,
+              fontSize: 13,
+              color: "var(--text-secondary)",
+            }}
+          >
+            <span aria-hidden="true" style={{ fontSize: 16 }}>
+              ≈
+            </span>
+            <span>
+              Similar to existing skill:{" "}
+              <strong
+                style={{
+                  color: "var(--text)",
+                  fontFamily: "var(--font-mono)",
+                }}
+              >
+                {enhancesSlug}
+              </strong>
+              . Enhance it or approve anyway.
+            </span>
+          </div>
+        )}
         <p className="interview-question">{request.question}</p>
         {request.context && (
           <p className="interview-context">{request.context}</p>

--- a/web/src/components/messages/InterviewBar.test.tsx
+++ b/web/src/components/messages/InterviewBar.test.tsx
@@ -1,0 +1,169 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AgentRequest } from "../../api/client";
+
+// Mocks installed BEFORE InterviewBar import so the component picks them up.
+const useRequestsMock = vi.fn();
+vi.mock("../../hooks/useRequests", () => ({
+  useRequests: () => useRequestsMock(),
+}));
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return {
+    ...actual,
+    getSkillsList: vi.fn().mockResolvedValue({
+      skills: [
+        {
+          name: "send-digest",
+          title: "Send weekly digest",
+          description: "Compile and send the weekly customer digest.",
+          status: "active",
+          content: "## Steps\n1. gather digest items\n2. send",
+        },
+      ],
+    }),
+  };
+});
+
+import { InterviewBar } from "./InterviewBar";
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+function setPending(reqs: AgentRequest[]): void {
+  useRequestsMock.mockReturnValue({
+    all: reqs,
+    pending: reqs,
+    blockingPending: reqs.find((r) => r.blocking) ?? null,
+  });
+}
+
+const baseEnhanceRequest: AgentRequest = {
+  id: "request-42",
+  from: "archivist",
+  channel: "general",
+  kind: "enhance_skill_proposal",
+  status: "pending",
+  title: 'Enhance "send-digest" with new content',
+  question:
+    "@archivist drafted **send-newsletter**, but it looks similar to existing skill **send-digest**.",
+  options: [
+    {
+      id: "enhance",
+      label: "Enhance existing",
+      description: "Fold this into send-digest. The candidate is dropped.",
+    },
+    {
+      id: "approve_anyway",
+      label: "Approve anyway",
+      description: "Bypass the similarity gate and create a new skill.",
+    },
+    {
+      id: "reject",
+      label: "Reject",
+      description: "Drop this draft. The existing skill stays unchanged.",
+    },
+  ],
+  recommended_id: "enhance",
+  blocking: false,
+  reply_to: "send-newsletter",
+  metadata: {
+    enhances_slug: "send-digest",
+    similar_to_existing: {
+      slug: "send-digest",
+      score: 0.92,
+      method: "embedding-cosine",
+    },
+  },
+  enhance_candidate: {
+    name: "send-newsletter",
+    description: "Send out the customer newsletter every Friday.",
+    content: "## Steps\n1. ...",
+  },
+  created_at: "2026-04-29T10:00:00Z",
+};
+
+const ambiguousRequest: AgentRequest = {
+  id: "request-43",
+  from: "archivist",
+  channel: "general",
+  kind: "skill_proposal",
+  status: "pending",
+  title: "Approve skill: send-newsletter",
+  question:
+    "@archivist proposed skill **send-newsletter**: Send the customer newsletter.",
+  options: [
+    { id: "accept", label: "Accept" },
+    { id: "reject", label: "Reject" },
+  ],
+  recommended_id: "accept",
+  blocking: false,
+  reply_to: "send-newsletter",
+  metadata: {
+    similar_to_existing: {
+      slug: "send-digest",
+      score: 0.78,
+      method: "embedding-cosine",
+    },
+  },
+  created_at: "2026-04-29T10:00:00Z",
+};
+
+describe("<InterviewBar> enhance UX", () => {
+  it("renders three-button row for enhance_skill_proposal kind", () => {
+    setPending([baseEnhanceRequest]);
+    render(wrap(<InterviewBar />));
+    expect(
+      screen.getByRole("button", { name: /Enhance existing/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Approve anyway/i }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /Reject/i }).length).toBe(1);
+  });
+
+  it("renders the inline compare preview for enhance kind", () => {
+    setPending([baseEnhanceRequest]);
+    render(wrap(<InterviewBar />));
+    // Both panel headings appear; "Existing" + "Candidate".
+    expect(screen.getAllByText(/Existing/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Candidate/).length).toBeGreaterThan(0);
+    // Score line is shown.
+    expect(screen.getByText(/Similarity score/i)).toBeInTheDocument();
+  });
+
+  it("renders the similar banner for ambiguous skill_proposal", () => {
+    setPending([ambiguousRequest]);
+    render(wrap(<InterviewBar />));
+    expect(screen.getByText(/Similar to/)).toBeInTheDocument();
+    // Score is rendered to 2 decimals.
+    expect(screen.getByText(/0\.78/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Compare/i }),
+    ).toBeInTheDocument();
+    // Standard accept/reject options remain.
+    expect(screen.getByRole("button", { name: /Accept/i })).toBeInTheDocument();
+  });
+
+  it("does NOT show the similar banner for clean skill_proposal", () => {
+    const clean: AgentRequest = {
+      ...ambiguousRequest,
+      id: "request-44",
+      metadata: undefined,
+    };
+    setPending([clean]);
+    render(wrap(<InterviewBar />));
+    expect(screen.queryByText(/Similar to/)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -1,13 +1,20 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { NavArrowLeft, NavArrowRight, Xmark } from "iconoir-react";
 
 import {
+  type AgentRequest,
   answerRequest,
   cancelRequest,
+  getSkillsList,
   type InterviewOption,
+  patchSkill,
+  type Skill,
+  type SkillSimilarRef,
 } from "../../api/client";
 import { useRequests } from "../../hooks/useRequests";
+import { SkillCompareView } from "../apps/SkillCompareView";
+import { SidePanel } from "../ui/SidePanel";
 import { showNotice } from "../ui/Toast";
 
 /**
@@ -17,13 +24,18 @@ import { showNotice } from "../ui/Toast";
  * - Renders option buttons; if the picked option requires custom text,
  *   switches to a text input mode using the option's hint as placeholder
  * - Skip / close cancels the unanswered interview
+ *
+ * PR 7 task #14 extends this with the enhance-existing flow:
+ * - kind="enhance_skill_proposal" replaces the standard option row with a
+ *   side-by-side preview + three buttons (Enhance / Approve anyway / Reject).
+ * - kind="skill_proposal" with metadata.similar_to_existing renders a
+ *   warning banner with a [Compare] action above the standard options.
  */
 export function InterviewBar() {
   const { pending } = useRequests();
   const queryClient = useQueryClient();
 
   const queue = useMemo(() => {
-    // Sort by created_at ascending so the oldest blocking request is first.
     const sorted = [...pending].sort((a, b) => {
       const ta = a.created_at ?? "";
       const tb = b.created_at ?? "";
@@ -39,19 +51,44 @@ export function InterviewBar() {
   const [customText, setCustomText] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
+  const [compareOpen, setCompareOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const visible = queue.filter((r) => !dismissedIds.has(r.id));
   const safeCursor = Math.min(cursor, Math.max(visible.length - 1, 0));
   const current = visible[safeCursor] ?? null;
 
-  // Reset text mode when the active request changes
+  // The Skills catalog feeds the compare view's "existing" pane and
+  // supplies the existing-skill body for the patchSkill call. Cached at
+  // ["skills", "all"] so SkillsApp shares the same query.
+  const enhanceContext = readEnhanceContext(current);
+  const needsCatalog =
+    enhanceContext.kind === "enhance_skill_proposal" ||
+    enhanceContext.kind === "skill_proposal_ambiguous";
+  const { data: catalog } = useQuery({
+    queryKey: ["skills", "all"],
+    queryFn: () => getSkillsList("all"),
+    staleTime: 30_000,
+    enabled: needsCatalog,
+  });
+  const existingSkill = useMemo(() => {
+    if (!enhanceContext.existingSlug) return undefined;
+    return catalog?.skills.find((s) =>
+      skillSlugMatches(s.name, enhanceContext.existingSlug),
+    );
+  }, [catalog, enhanceContext.existingSlug]);
+
+  // Reset transient UI state when the active request changes. Keyed on
+  // current?.id so cycling between queued requests (or replacing the
+  // active one with a fresh broker push) clears textMode / customText /
+  // compareOpen — without this dep, compareOpen=true from one card
+  // leaks into the next.
   useEffect(() => {
     setTextMode(null);
     setCustomText("");
-  }, []);
+    setCompareOpen(false);
+  }, [current?.id]);
 
-  // Auto-focus the text input when entering text mode
   useEffect(() => {
     if (textMode && textareaRef.current) {
       textareaRef.current.focus();
@@ -71,10 +108,64 @@ export function InterviewBar() {
     if (submitting) return;
     setSubmitting(true);
     try {
+      // Enhance flow: when the user accepts the gate's recommendation we
+      // must apply the candidate body to the existing skill BEFORE we
+      // close the interview. Architect's task #15 deliberately leaves the
+      // patch to the UI so the human can preview the diff before commit.
+      if (
+        option.id === "enhance" &&
+        current.kind === "enhance_skill_proposal"
+      ) {
+        const slug = enhanceContext.existingSlug;
+        if (!slug) {
+          throw new Error("Missing existing slug on enhance interview");
+        }
+        if (!existingSkill?.content) {
+          throw new Error(
+            "Existing skill body not loaded yet — try again in a moment",
+          );
+        }
+        const candidate =
+          (current.enhance_candidate as Skill | undefined) ??
+          enhanceContext.candidate;
+        const newBody = candidate?.content ?? "";
+        if (!newBody) {
+          throw new Error("Candidate body is empty");
+        }
+        await patchSkill(slug, {
+          old_string: existingSkill.content,
+          new_string: newBody,
+          replace_all: false,
+        });
+      }
+
       await answerRequest(current.id, option.id, text);
       await queryClient.invalidateQueries({ queryKey: ["requests"] });
+      await queryClient.invalidateQueries({ queryKey: ["skills"] });
       setTextMode(null);
       setCustomText("");
+
+      // Surface a tailored toast for enhance-flow decisions; legacy
+      // skill_proposal answers stay quiet (the queue empty-state is the
+      // signal).
+      if (current.kind === "enhance_skill_proposal") {
+        if (option.id === "enhance" && enhanceContext.existingSlug) {
+          showNotice(
+            `Updated ${enhanceContext.existingSlug}. Source article still tracked.`,
+            "success",
+          );
+        } else if (option.id === "approve_anyway") {
+          showNotice(
+            "Created as a new skill despite the similarity warning.",
+            "success",
+          );
+        } else if (option.id === "reject") {
+          const target = enhanceContext.existingSlug
+            ? ` (duplicate of ${enhanceContext.existingSlug})`
+            : "";
+          showNotice(`Dropped the candidate${target}.`, "info");
+        }
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Failed to answer";
       showNotice(message, "error");
@@ -118,6 +209,16 @@ export function InterviewBar() {
   const handleNext = () =>
     setCursor((i) => Math.min(i + 1, visible.length - 1));
   const handlePrev = () => setCursor((i) => Math.max(i - 1, 0));
+
+  const isEnhance = enhanceContext.kind === "enhance_skill_proposal";
+  const ambiguousRef =
+    enhanceContext.kind === "skill_proposal_ambiguous"
+      ? enhanceContext.similarRef
+      : undefined;
+  const candidateForCompare =
+    (current.enhance_candidate as Skill | undefined) ??
+    enhanceContext.candidate ??
+    fallbackCandidateFromRequest(current);
 
   return (
     <div
@@ -184,6 +285,24 @@ export function InterviewBar() {
         {current.context && (
           <div className="interview-bar-context">{current.context}</div>
         )}
+
+        {ambiguousRef ? (
+          <SimilarBanner
+            slug={ambiguousRef.slug}
+            score={ambiguousRef.score}
+            onCompare={() => setCompareOpen(true)}
+          />
+        ) : null}
+
+        {isEnhance ? (
+          <EnhancePreview
+            existing={existingSkill}
+            candidate={candidateForCompare}
+            score={enhanceContext.similarRef?.score}
+            method={enhanceContext.similarRef?.method}
+            onOpenFull={() => setCompareOpen(true)}
+          />
+        ) : null}
       </div>
 
       {textMode ? (
@@ -226,6 +345,12 @@ export function InterviewBar() {
             </button>
           </div>
         </div>
+      ) : isEnhance ? (
+        <EnhanceActions
+          options={options}
+          submitting={submitting}
+          onPick={handleOption}
+        />
       ) : options.length > 0 ? (
         <div className="interview-bar-actions">
           {options.map((opt, i) => (
@@ -248,6 +373,257 @@ export function InterviewBar() {
       ) : (
         <div className="interview-bar-empty">No options provided.</div>
       )}
+
+      <SidePanel
+        open={compareOpen}
+        onClose={() => setCompareOpen(false)}
+        title="Compare skills"
+        subtitle={
+          enhanceContext.existingSlug
+            ? `existing: @${enhanceContext.existingSlug}`
+            : undefined
+        }
+      >
+        {candidateForCompare ? (
+          <SkillCompareView
+            existing={existingSkill}
+            candidate={candidateForCompare}
+            score={enhanceContext.similarRef?.score}
+            method={enhanceContext.similarRef?.method}
+          />
+        ) : (
+          <p style={{ color: "var(--text-tertiary)", fontSize: 13 }}>
+            Couldn't load candidate data.
+          </p>
+        )}
+      </SidePanel>
+    </div>
+  );
+}
+
+interface EnhanceContext {
+  kind: "enhance_skill_proposal" | "skill_proposal_ambiguous" | "other";
+  existingSlug?: string;
+  similarRef?: SkillSimilarRef;
+  candidate?: Skill;
+}
+
+/**
+ * Read the structured metadata the broker stamped on the interview
+ * (PR 7 task #15) and classify the interview into one of three buckets:
+ *
+ * - "enhance_skill_proposal" — full enhance UX (3 buttons + side-by-side).
+ * - "skill_proposal_ambiguous" — standard 2-button row, plus banner.
+ * - "other" — rendered as a normal interview.
+ *
+ * Returns flat scalars so the calling component doesn't have to walk
+ * `unknown` shapes inline.
+ */
+function readEnhanceContext(req: AgentRequest | null): EnhanceContext {
+  if (!req) return { kind: "other" };
+  const meta = req.metadata;
+  if (req.kind === "enhance_skill_proposal") {
+    const slug =
+      typeof meta?.enhances_slug === "string" ? meta.enhances_slug : undefined;
+    return {
+      kind: "enhance_skill_proposal",
+      existingSlug: slug,
+      similarRef: readSimilarRef(meta?.similar_to_existing),
+      candidate: req.enhance_candidate as Skill | undefined,
+    };
+  }
+  if (req.kind === "skill_proposal") {
+    const ref = readSimilarRef(meta?.similar_to_existing);
+    if (ref) {
+      return {
+        kind: "skill_proposal_ambiguous",
+        existingSlug: ref.slug,
+        similarRef: ref,
+      };
+    }
+  }
+  return { kind: "other" };
+}
+
+function readSimilarRef(value: unknown): SkillSimilarRef | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const v = value as Record<string, unknown>;
+  if (typeof v.slug !== "string" || typeof v.score !== "number") {
+    return undefined;
+  }
+  return {
+    slug: v.slug,
+    score: v.score,
+    method: typeof v.method === "string" ? v.method : undefined,
+  };
+}
+
+function skillSlugMatches(name: string | undefined, slug: string | undefined) {
+  if (!(name && slug)) return false;
+  const normalize = (s: string) =>
+    s.trim().toLowerCase().replace(/\s+/g, "-").replace(/_/g, "-");
+  return normalize(name) === normalize(slug);
+}
+
+/**
+ * Synthesize a Skill-shaped object from the request's reply_to + question
+ * when the broker doesn't ship `enhance_candidate` (fallback path; the
+ * task #15 contract supplies it directly, but defensive shapes guard
+ * against transitional broker builds in dev environments).
+ */
+function fallbackCandidateFromRequest(
+  req: AgentRequest | null,
+): Skill | undefined {
+  if (!req) return undefined;
+  const name = req.reply_to;
+  if (!name) return undefined;
+  return {
+    name,
+    description: req.question?.split("\n\n")[1] || "",
+    content: req.context || "",
+  };
+}
+
+interface SimilarBannerProps {
+  slug: string;
+  score: number;
+  onCompare: () => void;
+}
+
+function SimilarBanner({ slug, score, onCompare }: SimilarBannerProps) {
+  return (
+    <div
+      role="note"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        flexWrap: "wrap",
+        marginTop: 8,
+        padding: "8px 12px",
+        background: "var(--yellow-bg, #fff7d6)",
+        border: "1px solid var(--yellow, #d6a700)",
+        borderRadius: 6,
+        fontSize: 12,
+        color: "var(--text)",
+      }}
+    >
+      <span>
+        Similar to <strong>{slug}</strong> (score: {score.toFixed(2)}). Worth
+        merging?
+      </span>
+      <button
+        type="button"
+        className="btn-text"
+        onClick={onCompare}
+        style={{ padding: "2px 6px" }}
+      >
+        Compare
+      </button>
+    </div>
+  );
+}
+
+interface EnhancePreviewProps {
+  existing: Skill | undefined;
+  candidate: Skill | undefined;
+  score?: number;
+  method?: string;
+  onOpenFull: () => void;
+}
+
+function EnhancePreview({
+  existing,
+  candidate,
+  score,
+  method,
+  onOpenFull,
+}: EnhancePreviewProps) {
+  if (!candidate) return null;
+  return (
+    <div style={{ marginTop: 10 }}>
+      <SkillCompareView
+        existing={existing}
+        candidate={candidate}
+        score={score}
+        method={method}
+      />
+      <div style={{ marginTop: 6, textAlign: "right" }}>
+        <button
+          type="button"
+          className="btn-text"
+          onClick={onOpenFull}
+          style={{ padding: "2px 6px", fontSize: 12 }}
+        >
+          Open full comparison →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface EnhanceActionsProps {
+  options: InterviewOption[];
+  submitting: boolean;
+  onPick: (option: InterviewOption) => void;
+}
+
+/**
+ * Three-button action row for enhance_skill_proposal interviews. Maps the
+ * server-registered option IDs (enhance / approve_anyway / reject) to the
+ * user-facing layout: primary | secondary | text-destructive.
+ */
+function EnhanceActions({ options, submitting, onPick }: EnhanceActionsProps) {
+  const enhance = options.find((o) => o.id === "enhance");
+  const approve = options.find((o) => o.id === "approve_anyway");
+  const reject = options.find((o) => o.id === "reject");
+
+  return (
+    <div
+      className="interview-bar-actions"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        flexWrap: "wrap",
+      }}
+    >
+      {enhance ? (
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={() => onPick(enhance)}
+          disabled={submitting}
+          title={enhance.description}
+          aria-label={enhance.label}
+        >
+          {submitting ? "Working..." : enhance.label}
+        </button>
+      ) : null}
+      {approve ? (
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={() => onPick(approve)}
+          disabled={submitting}
+          title={approve.description}
+          aria-label={approve.label}
+        >
+          {approve.label}
+        </button>
+      ) : null}
+      {reject ? (
+        <button
+          type="button"
+          className="btn-text btn-text--danger"
+          onClick={() => onPick(reject)}
+          disabled={submitting}
+          title={reject.description}
+          aria-label={reject.label}
+        >
+          {reject.label}
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/ui/LightningIcon.tsx
+++ b/web/src/components/ui/LightningIcon.tsx
@@ -1,0 +1,29 @@
+interface LightningIconProps {
+  size?: number;
+  title?: string;
+}
+
+/**
+ * Inline monochrome lightning bolt. Replaces the cross-OS-inconsistent ⚡
+ * emoji. Inherits `currentColor` so it tracks text color on hover/active.
+ */
+export function LightningIcon({ size = 16, title }: LightningIconProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+      role={title ? "img" : "presentation"}
+      aria-hidden={title ? undefined : true}
+      aria-label={title}
+      style={{
+        display: "inline-block",
+        flexShrink: 0,
+        verticalAlign: "-0.15em",
+      }}
+    >
+      <path d="M9.5 1L3 9h4l-1 6 6.5-8H8.5l1-6z" />
+    </svg>
+  );
+}

--- a/web/src/components/ui/SidePanel.tsx
+++ b/web/src/components/ui/SidePanel.tsx
@@ -1,0 +1,222 @@
+import type { ReactNode } from "react";
+import { useEffect, useRef } from "react";
+
+interface SidePanelProps {
+  /** Whether the panel is currently open. */
+  open: boolean;
+  /** Called when the user dismisses (Esc, backdrop, or X). */
+  onClose: () => void;
+  /** Heading rendered in the panel header. */
+  title: string;
+  /** Optional subline shown under the title (e.g. a kebab-case skill name). */
+  subtitle?: string;
+  /** Body content. */
+  children: ReactNode;
+  /** ARIA label override for the close button. Defaults to "Close panel". */
+  closeLabel?: string;
+}
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+/**
+ * Generic side panel primitive. 480px desktop / 60vw tablet / fullscreen
+ * mobile. Esc/backdrop/X dismiss, focus trap, body scroll-lock. Re-usable
+ * for any "view full" surface (Skills, Threads, Activity, …).
+ */
+export function SidePanel({
+  open,
+  onClose,
+  title,
+  subtitle,
+  children,
+  closeLabel = "Close panel",
+}: SidePanelProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Esc to close.
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  // Body scroll-lock while open.
+  useEffect(() => {
+    if (!open) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  // Save and restore focus + trap focus inside the panel.
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
+    const panel = panelRef.current;
+    if (panel) {
+      const focusables =
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      const first = focusables[0];
+      if (first) {
+        first.focus();
+      } else {
+        panel.focus();
+      }
+    }
+
+    const trap = (e: KeyboardEvent) => {
+      if (e.key !== "Tab" || !panel) return;
+      const focusables = Array.from(
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      );
+      if (focusables.length === 0) {
+        e.preventDefault();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", trap);
+    return () => {
+      document.removeEventListener("keydown", trap);
+      previousFocusRef.current?.focus();
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 250,
+        display: "flex",
+        justifyContent: "flex-end",
+      }}
+    >
+      <div
+        onClick={onClose}
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          inset: 0,
+          background: "rgba(20, 22, 24, 0.36)",
+        }}
+      />
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        tabIndex={-1}
+        style={{
+          position: "relative",
+          width: "min(480px, 100vw)",
+          maxWidth: "100vw",
+          height: "100vh",
+          background: "var(--bg-card, #fff)",
+          borderLeft: "1px solid var(--border)",
+          boxShadow: "-12px 0 32px rgba(0,0,0,0.10)",
+          display: "flex",
+          flexDirection: "column",
+          outline: "none",
+        }}
+        className="side-panel"
+      >
+        <header
+          style={{
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            gap: 12,
+            padding: "16px 20px",
+            borderBottom: "1px solid var(--border)",
+          }}
+        >
+          <div style={{ minWidth: 0, flex: 1 }}>
+            <h2
+              style={{
+                fontSize: 15,
+                fontWeight: 600,
+                color: "var(--text)",
+                margin: 0,
+                lineHeight: 1.3,
+                wordBreak: "break-word",
+              }}
+            >
+              {title}
+            </h2>
+            {subtitle ? (
+              <div
+                style={{
+                  fontSize: 12,
+                  color: "var(--text-tertiary)",
+                  fontFamily: "var(--font-mono)",
+                  marginTop: 2,
+                }}
+              >
+                {subtitle}
+              </div>
+            ) : null}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={closeLabel}
+            style={{
+              background: "transparent",
+              border: "none",
+              padding: 4,
+              cursor: "pointer",
+              color: "var(--text-tertiary)",
+              fontSize: 20,
+              lineHeight: 1,
+              minWidth: 32,
+              minHeight: 32,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              borderRadius: 4,
+            }}
+          >
+            ×
+          </button>
+        </header>
+        <div
+          style={{
+            flex: 1,
+            overflow: "auto",
+            padding: "16px 20px",
+          }}
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/Toast.tsx
+++ b/web/src/components/ui/Toast.tsx
@@ -30,12 +30,12 @@ export function showNotice(message: string, type: ToastItem["type"] = "info") {
 
 /**
  * Show a toast with an inline Undo button. Auto-dismisses after `ms`
- * (default 5000). Calling `onUndo` triggers the action and closes the toast.
+ * (default 6000). Calling `onUndo` triggers the action and closes the toast.
  */
 export function showUndoToast(
   message: string,
   onUndo: () => void,
-  ms = 5000,
+  ms = 6000,
 ): void {
   addToastFn?.(message, "info", {
     actionLabel: "Undo",
@@ -82,6 +82,8 @@ export function ToastContainer() {
 
   return (
     <div
+      aria-live="polite"
+      aria-atomic="false"
       style={{
         position: "fixed",
         bottom: 20,
@@ -122,6 +124,7 @@ function ToastRow({ toast, onDismiss }: ToastRowProps) {
   return (
     <div
       className="animate-fade"
+      role={toast.type === "error" ? "alert" : "status"}
       style={{
         padding: "10px 16px",
         borderRadius: "var(--radius-md)",

--- a/web/src/hooks/useConfig.ts
+++ b/web/src/hooks/useConfig.ts
@@ -1,22 +1,68 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { getConfig } from "../api/client";
+import {
+  type ConfigSnapshot,
+  getConfig,
+  type OfficeMember,
+} from "../api/client";
 import type { HarnessKind } from "../lib/harness";
 
 const DEFAULT_HARNESS: HarnessKind = "claude-code";
+
+/**
+ * Shared config query — keys + staleTime mirror useDefaultHarness so we
+ * hit the same cache entry regardless of which hook the caller picked.
+ */
+function useConfigSnapshot(): ConfigSnapshot | undefined {
+  const { data } = useQuery({
+    queryKey: ["config"],
+    queryFn: getConfig,
+    staleTime: 60_000,
+  });
+  return data;
+}
 
 /**
  * Returns the install-wide default harness kind, used to render the avatar
  * badge for agents that have no explicit provider binding.
  */
 export function useDefaultHarness(): HarnessKind {
-  const { data } = useQuery({
-    queryKey: ["config"],
-    queryFn: getConfig,
-    staleTime: 60_000,
-  });
-  const raw = data?.llm_provider;
+  const cfg = useConfigSnapshot();
+  const raw = cfg?.llm_provider;
   if (raw === "claude-code" || raw === "codex" || raw === "opencode")
     return raw;
   return DEFAULT_HARNESS;
+}
+
+/**
+ * Resolve the team-lead slug. Prefers the explicitly configured
+ * `team_lead_slug` from /config; falls back to the first built-in office
+ * member, then to "ceo" as a last-resort default.
+ *
+ * Mirrors `resolveLeadSlug` in components/messages/Composer.tsx so any
+ * surface that needs to address the lead can do so without parsing config
+ * + members itself.
+ */
+export function resolveLeadSlug(
+  configured: string | undefined,
+  members: ReadonlyArray<{ slug?: string; built_in?: boolean }>,
+): string {
+  const explicit = (configured ?? "").trim().toLowerCase();
+  if (explicit) return explicit;
+  const builtin = members.find(
+    (m) => m.built_in && m.slug && m.slug !== "human" && m.slug !== "you",
+  );
+  if (builtin?.slug) return builtin.slug;
+  return "ceo";
+}
+
+/**
+ * Hook variant of `resolveLeadSlug`. Pulls config + member list internally
+ * so callers don't need to wire two separate queries themselves.
+ */
+export function useTeamLeadSlug(
+  members: ReadonlyArray<OfficeMember> | undefined,
+): string {
+  const cfg = useConfigSnapshot();
+  return resolveLeadSlug(cfg?.team_lead_slug, members ?? []);
 }

--- a/web/src/stores/app.test.ts
+++ b/web/src/stores/app.test.ts
@@ -88,15 +88,6 @@ describe("channel unread state", () => {
     expect(useAppStore.getState().unreadByChannel.general).toBe(1);
   });
 
-  it("ignores blank channel names for unread actions", () => {
-    useAppStore.setState({ unreadByChannel: { general: 1 } });
-
-    useAppStore.getState().incrementUnread("   ");
-    useAppStore.getState().clearUnread("");
-
-    expect(useAppStore.getState().unreadByChannel).toEqual({ general: 1 });
-  });
-
   it("clears a channel when navigating to its message view", () => {
     useAppStore.setState({
       currentChannel: "general",

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -323,8 +323,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   setLastMessageId: (id) => set({ lastMessageId: id }),
   unreadByChannel: {},
   incrementUnread: (channel) => {
-    const ch = channel.trim();
-    if (!ch) return;
+    const ch = channel.trim() || "general";
     set((state) => ({
       unreadByChannel: {
         ...state.unreadByChannel,
@@ -333,8 +332,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
     }));
   },
   clearUnread: (channel) => {
-    const ch = channel.trim();
-    if (!ch) return;
+    const ch = channel.trim() || "general";
     set((state) => {
       if ((state.unreadByChannel[ch] ?? 0) === 0) return state;
       return {

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -235,6 +235,32 @@ body {
   padding: 16px 40px;
   font-size: 16px;
 }
+.btn-text {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  padding: 6px 4px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  border-radius: 4px;
+  transition: color 0.12s;
+}
+.btn-text:hover:not(:disabled) {
+  text-decoration: underline;
+  color: var(--text);
+}
+.btn-text:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.btn-text--danger {
+  color: var(--text-secondary);
+}
+.btn-text--danger:hover:not(:disabled) {
+  color: var(--red, #c43e3e);
+}
 .btn-sm {
   padding: 6px 12px;
   font-size: 12px;
@@ -395,6 +421,103 @@ body {
 }
 ::-webkit-scrollbar-thumb:hover {
   background: var(--text-tertiary);
+}
+
+/* ─── App card (skill scoping additions) ─── */
+.app-card--proposed {
+  border-left: 3px solid var(--yellow);
+}
+.app-card--disabled {
+  position: relative;
+  background: var(--neutral-50);
+  /* Text stays neutral-900 for AA contrast (≥4.5:1). Only the diagonal
+     pinstripe overlay carries the disabled visual signal at 0.55 opacity. */
+}
+.app-card--disabled::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  opacity: 0.55;
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent 0 8px,
+    var(--neutral-50) 8px 9px
+  );
+}
+.app-card--disabled > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* ─── Skills app: owners chip ─── */
+.owners-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  background: var(--neutral-100);
+  color: var(--neutral-700);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  border-radius: 6px;
+  line-height: 1.4;
+}
+.owners-chip--lead {
+  background: var(--neutral-50);
+  color: var(--neutral-500);
+  font-style: italic;
+  font-family: var(--font-sans);
+}
+
+/* ─── Side panel responsive ─── */
+@media (max-width: 900px) {
+  .side-panel {
+    width: 60vw !important;
+  }
+}
+@media (max-width: 600px) {
+  .side-panel {
+    width: 100vw !important;
+  }
+}
+
+/* ─── Mobile tap targets (a11y) ─── */
+@media (max-width: 600px) {
+  .btn-sm {
+    min-height: 44px;
+    padding: 10px 14px;
+  }
+  .btn-text {
+    min-height: 44px;
+    padding: 10px 8px;
+  }
+}
+
+/* ─── Reduced motion for optimistic-update animations ─── */
+@media (prefers-reduced-motion: reduce) {
+  .skill-suggest-expander,
+  .side-panel,
+  .animate-fade {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+.skill-suggest-expander {
+  animation: skill-suggest-slide 0.18s ease-out;
+  overflow: hidden;
+}
+@keyframes skill-suggest-slide {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ─── SR-only ─── */


### PR DESCRIPTION
## Summary

- Extends the existing Skills app (already on main) with the complete per-agent scoping UI: owner filter dropdown (persisted to localStorage), disable/enable toggle, archive with Undo toast (6s window) + Restore button on archived cards, invoke with live task chip, suggest-changes inline expander, and SKILL.md side panel preview.
- Adds new API helpers to `client.ts`: `archiveSkill`, `restoreArchivedSkill`, `disableSkill`, `enableSkill`, `patchSkill`, `getSkillsList`, `createTasks`, `getOfficeTasks`, plus new types `SkillSimilarRef`, `InterviewMetadata`, `CreateTaskInput`, `CreateTasksResponse`, `InvokeSkillResult`, `OwnerAgents`, `PatchSkillRequest/Response`.
- Closes (supersedes) PR #521. See PR #447 / PR #521 for full context. All conflicts with main resolved — this branch is based cleanly on `origin/main`.

## Test plan

- [ ] TypeScript check: `bunx tsc --noEmit` — no errors (excluding pre-existing app.ts/setup.ts)
- [ ] Vitest: `bunx vitest run` — 592 tests pass across 79 files
- [ ] Skills app renders Pending / Active / Disabled / Archived sections
- [ ] Owner filter dropdown persists to localStorage and filters cards
- [ ] Disable/Enable toggle works on active skills
- [ ] Archive with Undo toast (6s window) functions correctly
- [ ] Restore button on archived cards restores skill to active
- [ ] Invoke button creates a live task chip
- [ ] Suggest-changes inline expander opens and submits
- [ ] SKILL.md side panel preview loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced skill enhancement proposals to suggest improvements to existing skills
  * Added skill management actions: disable, enable, archive, and restore
  * New side panel editor for reviewing and editing proposed skill changes
  * Skill comparison view displaying similarity between proposals and existing skills
  * Owner-based filtering for the skills catalog

* **Improvements**
  * Revamped skill invocation to use a task-based workflow with status tracking
  * Enhanced interview UI to guide users through skill enhancement decisions
  * Improved accessibility for toast notifications and interactive components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->