### PR TITLE
chore(quality): enforce file-size allowlist forward-only at CI time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,16 @@ jobs:
         # (see CONTRIBUTING.md, docs/CODE-QUALITY.md, ADR-0001). Skips
         # generated files and tests.
         run: bash scripts/check-file-size.sh
+      - name: File-size allowlist forward-only check
+        # Companion to the file-size gate: enforces the forward-only
+        # rule at CI time. The allowlist may shrink (decomposition done)
+        # or remove entries (file deleted), but no PR may add a new line
+        # that grants exemption to a not-currently-listed file. Without
+        # this, the allowlist becomes a quiet escape hatch — every CI
+        # failure tempts an "I'll just allowlist it" fix.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: bash scripts/check-allowlist-forward-only.sh
       - name: Reject unix-only exec.Command shapes outside tmux/tui paths
         # Windows guard: bash/sh/chmod/ln/mkfifo/killall don't exist there.
         # Code that needs them must be in a _unix.go file with a build tag,

--- a/scripts/check-allowlist-forward-only.sh
+++ b/scripts/check-allowlist-forward-only.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# scripts/check-allowlist-forward-only.sh
+#
+# Enforces CONTRIBUTING.md's "forward-only allowlist" rule at CI time:
+# the file-size allowlist must never gain entries. Entries can be
+# removed (decomposition done) or commented out (stale), but no PR may
+# introduce a NEW line that grants exemption to a not-currently-listed
+# file.
+#
+# Usage: BASE_SHA=<sha> bash scripts/check-allowlist-forward-only.sh
+#
+# In GitHub Actions, BASE_SHA is github.event.pull_request.base.sha.
+# Locally, fall back to origin/main.
+
+set -euo pipefail
+
+ALLOWLIST="scripts/file-size-allowlist.txt"
+BASE_SHA="${BASE_SHA:-$(git merge-base HEAD origin/main 2>/dev/null || echo "")}"
+
+if [[ -z "$BASE_SHA" ]]; then
+  echo "warn: no base sha; cannot check allowlist drift"
+  exit 0
+fi
+
+if ! git show "$BASE_SHA:$ALLOWLIST" >/dev/null 2>&1; then
+  # Allowlist didn't exist at base — first PR to introduce it.
+  exit 0
+fi
+
+# Active path entries: lines that aren't blank and don't start with #
+# (after leading whitespace strip). Exclude trailing comments via the
+# same sed used in check-file-size.sh.
+extract_paths() {
+  sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//' "$1" \
+    | grep -v '^$' \
+    | sort -u
+}
+
+before_tmp="$(mktemp)"
+after_tmp="$(mktemp)"
+trap 'rm -f "$before_tmp" "$after_tmp"' EXIT
+
+git show "$BASE_SHA:$ALLOWLIST" > "$before_tmp"
+
+before_paths="$(extract_paths "$before_tmp")"
+after_paths="$(extract_paths "$ALLOWLIST")"
+
+added=$(comm -13 <(echo "$before_paths") <(echo "$after_paths") || true)
+
+if [[ -n "$added" ]]; then
+  echo "::error::file-size-allowlist.txt is forward-only (CONTRIBUTING.md)."
+  echo "The following entries are NEW in this PR and must be removed:"
+  while IFS= read -r line; do
+    printf '  %s\n' "$line"
+  done <<< "$added"
+  echo
+  echo "If a file truly cannot be decomposed in this PR, decompose it"
+  echo "in a separate PR first and merge that one. The allowlist exists"
+  echo "to track legacy debt, not to grant new exemptions."
+  exit 1
+fi
+
+echo "allowlist forward-only check OK (no new entries)"


### PR DESCRIPTION
Stack base: #527.

## Summary

Phase 9 first slice. The file-size allowlist (`scripts/file-size-allowlist.txt`) was already forward-only by tone in CONTRIBUTING.md; this PR makes the rule load-bearing at CI time.

## Files added

- `scripts/check-allowlist-forward-only.sh` (new) — extracts active path entries from base SHA and HEAD, fails if HEAD adds any new path
- New step in `.github/workflows/ci.yml` lint job

## Effect

A future PR that hits the file-size fail line and tries to fix it by adding a new allowlist entry will be **blocked at CI**. The escape route (decompose the file, or land an allowlist entry in a separate PR that earns its place via review) is the only path forward.

Companion to the existing `check-file-size.sh` stale-entry warning, which also surfaces forward-only violations from the other direction (a file shrunk below the threshold but the entry still sits in the allowlist).

## Verification

- `shellcheck scripts/check-allowlist-forward-only.sh` clean
- `BASE_SHA=e26e23f1 bash scripts/check-allowlist-forward-only.sh` returns 0 with "no new entries" — the happy path

## Cumulative Phase 9 progress

- ✅ file-size warn 800 / fail 1500 (#511)
- ✅ allowlist forward-only ratchet (this PR)

## Next slices

Each its own PR (chosen by reviewability vs. tooling availability):

- gocognit warning at threshold 30
- bundle-size budget for `bun run build`
- goleak in internal/team TestMain
- depguard import layering rules
- test-time budget gate (>10s without slow tag = fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)