### PR TITLE
chore(quality): add bundle-size budget for the web build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,12 @@ jobs:
           bun install --frozen-lockfile
           bun run typecheck
           bun run build
+      - name: Bundle-size budget
+        # Forward-only ratchet against accidental bundle bloat. Warn at
+        # 950 KB, fail at 1200 KB on the JS bundle total. To raise the
+        # ceiling intentionally, edit constants in scripts/check-bundle-size.sh
+        # in the same PR. See CONTRIBUTING.md "no perf degradations" rule.
+        run: bash scripts/check-bundle-size.sh
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # ratchet:actions/upload-artifact@v7
         with:
           name: web-dist

--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/check-bundle-size.sh
+#
+# Bundle-size budget for the web build. Runs after `bun run build` and
+# asserts the JS bundle hasn't grown past the documented ceiling.
+#
+# Two thresholds, both forward-only ratchets:
+#   - WARN_KB: warning at this size; next PR should justify the growth
+#   - FAIL_KB: hard fail; new PRs cannot push the bundle past here
+#
+# To raise the ceiling intentionally (e.g. a new feature pulls in a
+# library), update the constants below in the SAME PR that introduces
+# the regression and document why in the commit message. Without an
+# explicit raise, the gate catches accidental bloat (a stray
+# import-the-world or a moment.js where date-fns would do).
+#
+# CONTRIBUTING.md anchors this in the "no perf degradations" rule.
+
+set -euo pipefail
+
+# Calibrated against the current minified bundle (~854 KB).
+# Warn band gives ~10% headroom; fail line gives ~40% — past that,
+# something has gone seriously wrong (or a major feature has shipped
+# that warrants raising the ceiling explicitly).
+WARN_KB=950
+FAIL_KB=1200
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+dist_assets="$repo_root/web/dist/assets"
+
+if [[ ! -d "$dist_assets" ]]; then
+  echo "::error::web/dist/assets/ not found — did 'bun run build' run first?"
+  exit 1
+fi
+
+# Sum sizes of all .js bundles. We deliberately skip .css and source
+# maps — JS is what blocks the main thread on first paint and is the
+# axis the chunkSizeWarningLimit rolldown warning already targets.
+total_bytes=0
+shopt -s nullglob
+for f in "$dist_assets"/*.js; do
+  size=$(stat -f '%z' "$f" 2>/dev/null || stat -c '%s' "$f")
+  total_bytes=$(( total_bytes + size ))
+done
+
+if (( total_bytes == 0 )); then
+  echo "::error::no .js files found in $dist_assets — the build artifact layout changed?"
+  exit 1
+fi
+
+total_kb=$(( total_bytes / 1024 ))
+
+if (( total_kb >= FAIL_KB )); then
+  echo "::error::JS bundle is ${total_kb} KB — over the ${FAIL_KB} KB fail line."
+  echo
+  echo "Either reduce bundle size (audit recent imports, prefer named"
+  echo "imports over default-everything, replace heavyweight libs with"
+  echo "lighter alternatives) or raise FAIL_KB in this script with a"
+  echo "documented justification in the same PR."
+  exit 1
+fi
+
+if (( total_kb >= WARN_KB )); then
+  echo "::warning::JS bundle is ${total_kb} KB — over the ${WARN_KB} KB warn line."
+  echo "  Headroom to fail: $(( FAIL_KB - total_kb )) KB."
+  echo "  Audit recent imports if this jumped unexpectedly."
+fi
+
+echo "bundle-size check OK: ${total_kb} KB (warn ${WARN_KB}, fail ${FAIL_KB})"

--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -39,7 +39,9 @@ fi
 total_bytes=0
 shopt -s nullglob
 for f in "$dist_assets"/*.js; do
-  size=$(stat -f '%z' "$f" 2>/dev/null || stat -c '%s' "$f")
+  # `wc -c` is portable across BSD/macOS and GNU/Linux; `stat -f`/`-c`
+  # divergence between the two trips `set -u` inside `(( ))`.
+  size=$(wc -c < "$f" | tr -d '[:space:]')
   total_bytes=$(( total_bytes + size ))
 done
 


### PR DESCRIPTION
Stack base: #528.

## Summary

Phase 9 second slice. Forward-only ratchet against accidental web bundle bloat.

## How it works

- `scripts/check-bundle-size.sh` (new): sums the size of `web/dist/assets/*.js`, fails if total exceeds `FAIL_KB`, warns if it exceeds `WARN_KB`.
- New step in the CI `web` job, runs after `bun run build`.

## Calibration

Current JS bundle is ~834 KB (single chunk). Thresholds:

| Level | KB | Headroom |
|---|---:|---:|
| WARN | 950 | ~14% |
| FAIL | 1,200 | ~44% |

To raise intentionally: edit `WARN_KB`/`FAIL_KB` in the script in the **same PR** as the regression, with justification in the commit message. Without an explicit raise, the gate catches accidental bloat (stray import-the-world, moment.js where date-fns would do, etc.).

## Why JS only

JS is what blocks the main thread on first paint — same axis the rolldown `chunkSizeWarningLimit` warning already targets. CSS and source maps are out of scope.

## Verification

- `shellcheck scripts/check-bundle-size.sh` clean
- Local dry-run after `bun run build`: "bundle-size check OK: 834 KB (warn 950, fail 1200)"

## Cumulative Phase 9 progress

- ✅ file-size warn 800 / fail 1500 (#511)
- ✅ allowlist forward-only ratchet (#528)
- ✅ bundle-size budget (this PR)

Anchored in CONTRIBUTING.md's "no performance degradations" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)