### PR TITLE
refactor(team): extract auth + pub/sub fanout from broker.go

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -2,8 +2,6 @@ package team
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -611,16 +609,6 @@ func parseBrokerTimestamp(raw string) time.Time {
 	return ts.UTC()
 }
 
-// generateToken returns a cryptographically random hex token.
-func generateToken() string {
-	b := make([]byte, 16)
-	if _, err := rand.Read(b); err != nil {
-		// Fallback: this should never happen on modern systems
-		return fmt.Sprintf("wuphf-%d", time.Now().UnixNano())
-	}
-	return hex.EncodeToString(b)
-}
-
 // skipBrokerStateLoadOnConstruct gates the auto-load of disk state
 // inside NewBrokerAt. Production keeps it false so the CLI resumes from
 // disk state. A *_test.go init flips it to true so tests that call
@@ -700,38 +688,6 @@ func NewBrokerAt(statePath string) *Broker {
 	return b
 }
 
-func (b *Broker) appendMessageLocked(msg channelMessage) {
-	b.messages = append(b.messages, msg)
-	b.publishMessageLocked(msg)
-}
-
-func (b *Broker) publishMessageLocked(msg channelMessage) {
-	for _, ch := range b.messageSubscribers {
-		select {
-		case ch <- msg:
-		default:
-		}
-	}
-}
-
-func (b *Broker) publishActionLocked(action officeActionLog) {
-	for _, ch := range b.actionSubscribers {
-		select {
-		case ch <- action:
-		default:
-		}
-	}
-}
-
-func (b *Broker) publishActivityLocked(activity agentActivitySnapshot) {
-	for _, ch := range b.activitySubscribers {
-		select {
-		case ch <- activity:
-		default:
-		}
-	}
-}
-
 // Token returns the shared secret that agents must include in requests.
 func (b *Broker) Token() string {
 	return b.token
@@ -745,17 +701,6 @@ func (b *Broker) Addr() string {
 // ChannelStore returns the channel store for DM type checks and member lookups.
 func (b *Broker) ChannelStore() *channel.Store {
 	return b.channelStore
-}
-
-// requireAuth wraps a handler to enforce Bearer token authentication.
-// Accepts token via Authorization header or ?token= query parameter (for EventSource which can't set headers).
-//
-// Backed by withAuth (broker_auth.go); kept as the legacy name on the
-// existing route registrations so a full sweep of HandleFunc lines is
-// not required by this PR. Both names produce identical behavior — the
-// auth-route assertion test covers both.
-func (b *Broker) requireAuth(next http.HandlerFunc) http.HandlerFunc {
-	return b.withAuth(next)
 }
 
 // Start launches the broker on the configured localhost port.
@@ -1097,14 +1042,6 @@ func (b *Broker) Stop() {
 // after the browser's origin check passes. Go's default mux routes purely
 // on path, so without an explicit Host check the response would flow back
 // to the attacker's origin. Validate both RemoteAddr AND Host here.
-func (b *Broker) handleWebToken(w http.ResponseWriter, r *http.Request) {
-	if !isLoopbackRemote(r) || !hostHeaderIsLoopback(r) {
-		http.Error(w, "forbidden", http.StatusForbidden)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"token": b.token})
-}
 
 func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 	if !b.requestHasBrokerAuth(r) {

--- a/internal/team/broker_auth.go
+++ b/internal/team/broker_auth.go
@@ -34,16 +34,31 @@ package team
 //     handleEvents calls requestHasBrokerAuth at the top.
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"time"
 )
+
+// generateToken returns a cryptographically random hex token.
+func generateToken() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback: this should never happen on modern systems.
+		return fmt.Sprintf("wuphf-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
+}
 
 // withAuth wraps a handler to require Bearer-token authentication.
 //
 // This is the canonical middleware for protected broker routes. The older
-// requireAuth method (above on Broker) is kept as a thin alias so that the
-// existing 100+ route registrations don't all churn in this PR; new routes
-// should call b.withAuth directly.
+// requireAuth method is kept as a thin alias so that the existing 100+ route
+// registrations don't all churn in this PR; new routes should call b.withAuth
+// directly.
 //
 // Both names share an implementation, so the auth-route assertion in
 // broker_workspaces_test.go covers both call sites.
@@ -59,4 +74,28 @@ func (b *Broker) withAuth(next http.HandlerFunc) http.HandlerFunc {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = io.WriteString(w, `{"error":"unauthorized"}`)
 	}
+}
+
+// requireAuth wraps a handler to enforce Bearer token authentication.
+// Accepts token via Authorization header or ?token= query parameter for
+// EventSource, which can't set headers.
+func (b *Broker) requireAuth(next http.HandlerFunc) http.HandlerFunc {
+	return b.withAuth(next)
+}
+
+// handleWebToken returns the broker token to localhost clients without requiring auth.
+// This lets the web UI fetch the token to authenticate subsequent API calls.
+//
+// DNS rebinding: even though the listener binds 127.0.0.1, an attacker's
+// DNS record with a short TTL can point rebind.example.com at 127.0.0.1
+// after the browser's origin check passes. Go's default mux routes purely
+// on path, so without an explicit Host check the response would flow back
+// to the attacker's origin. Validate both RemoteAddr AND Host here.
+func (b *Broker) handleWebToken(w http.ResponseWriter, r *http.Request) {
+	if !isLoopbackRemote(r) || !hostHeaderIsLoopback(r) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"token": b.token})
 }

--- a/internal/team/broker_publish.go
+++ b/internal/team/broker_publish.go
@@ -1,0 +1,49 @@
+package team
+
+// Pub/sub fanout to broker subscribers. Owns:
+//   - appendMessageLocked: convenience wrapper that persists +
+//     publishes a channel message in one step
+//   - publishMessageLocked / publishActionLocked / publishActivityLocked:
+//     the three "always-on" channels that every broker subscriber
+//     receives. Each is a non-blocking send (default branch on a
+//     full channel drops the event) so a slow subscriber can't stall
+//     the publisher.
+//
+// Other publish*Locked helpers live alongside their owners (e.g.
+// publishOfficeChangeLocked next to office channel CRUD); these three
+// are core enough to live in their own kin file.
+//
+// All entries require the caller to hold b.mu — the *Locked suffix
+// is the contract.
+
+func (b *Broker) appendMessageLocked(msg channelMessage) {
+	b.messages = append(b.messages, msg)
+	b.publishMessageLocked(msg)
+}
+
+func (b *Broker) publishMessageLocked(msg channelMessage) {
+	for _, ch := range b.messageSubscribers {
+		select {
+		case ch <- msg:
+		default:
+		}
+	}
+}
+
+func (b *Broker) publishActionLocked(action officeActionLog) {
+	for _, ch := range b.actionSubscribers {
+		select {
+		case ch <- action:
+		default:
+		}
+	}
+}
+
+func (b *Broker) publishActivityLocked(activity agentActivitySnapshot) {
+	for _, ch := range b.activitySubscribers {
+		select {
+		case ch <- activity:
+		default:
+		}
+	}
+}


### PR DESCRIPTION
Stack base: #530.

## Summary

Phase 3 second slice. Two small cohesive extractions from broker.go.

## Files added

**`broker_auth.go` (62 LOC)** — auth surface
- `generateToken` — cryptographically random shared secret
- `requireAuth` — Bearer-token middleware (also accepts `?token=` for EventSource)
- `handleWebToken` — localhost-only token endpoint (gated by RemoteAddr + Host loopback to defeat DNS rebinding)

**`broker_publish.go` (49 LOC)** — pub/sub fanout
- `appendMessageLocked` — persist + publish in one step
- `publishMessageLocked` / `publishActionLocked` / `publishActivityLocked` — three always-on channels with non-blocking sends (default-on-full so a slow subscriber can't stall the publisher)

## Net LOC delta

| File | Before | After | Δ |
|---|---:|---:|---:|
| broker.go | 2,859 | 2,800 | **-59** |

## Cumulative Phase 3 progress

| PR | broker.go | Δ |
|---|---:|---:|
| baseline | 3,404 | — |
| #519 (web proxy + sse) | 2,859 | -545 |
| **this** | **2,800** | **-59** |
| total | | **-604** |

Broker.go down 18%. Continued slices target: rate-limit, wiki worker lifecycle, telemetry, defaults/state-normalization, bridge handler.

## Verification

- `go build ./...` clean
- `go test ./internal/team/` passes (~82s)
- `bash scripts/check-file-size.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)