### PR TITLE
fix(website): swap PH and HN badge order in hero

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1228,8 +1228,8 @@
     </div>
 
     <div class="hero-badges">
-      <a href="https://www.producthunt.com/products/wuphf-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-wuphf-by-nex-ai" target="_blank" rel="noopener noreferrer" class="ph-badge"><img alt="WUPHF by Nex.ai - AI employees who build their own knowledge base | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1132040&amp;theme=neutral&amp;t=1777385299660"></a>
       <a href="https://news.ycombinator.com/item?id=47899844" target="_blank" rel="noopener noreferrer" class="hn-badge" aria-label="Hacker News Life of Product Week's #1"><img src="hn-badge.svg" alt="Hacker News Life of Product Week's #1" width="223" height="48"></a>
+      <a href="https://www.producthunt.com/products/wuphf-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-wuphf-by-nex-ai" target="_blank" rel="noopener noreferrer" class="ph-badge"><img alt="WUPHF by Nex.ai - AI employees who build their own knowledge base | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1132040&amp;theme=neutral&amp;t=1777385299660"></a>
     </div>
 
   </div>


### PR DESCRIPTION
Swap the order of the Product Hunt and Hacker News badges in the hero so HN appears on the left and PH on the right.

## Summary
- `website/index.html`: reorder the two `<a>` elements inside `.hero-badges`

## Test plan
- [ ] Open `website/index.html` and confirm HN badge renders left, PH right

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered hero section badges for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->