### PR TITLE
feat(surfaces): ship Studio surface — broker, MCP tools, React frontend, SSE wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,7 +554,8 @@ jobs:
             tests/slash-commands.spec.ts \
             tests/dm.spec.ts \
             tests/mentions.spec.ts \
-            tests/interview.spec.ts
+            tests/interview.spec.ts \
+            tests/studio.spec.ts
       - name: Stop wuphf (shell phase)
         if: always()
         run: |

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,41 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+WUPHF is for founders, operators, and builders who want AI teammates to coordinate real work while staying visible and steerable. They are usually working inside a local development or operating workspace, dropping goals into channels, checking progress, steering agents mid-task, and reviewing durable receipts instead of manually routing every handoff.
+
+Studio is for the same users when work needs a living artifact: a checklist, table, brief, dashboard, form, or custom workspace surface that agents can create, inspect, patch, and persist.
+
+## Product Purpose
+
+WUPHF is a local AI office: one shared place where AI employees claim work, argue about scope, surface blockers, use tools, remember decisions, and ship visible outcomes. Success means the user can leave the room and come back to concrete progress, with enough context and receipts to trust what happened.
+
+Studio extends that office with generative UI surfaces. Agents should be able to reshape the running workspace by writing widgets, reading their source back, checking rendered output, patching them safely, and publishing updates into the channel audit trail. The channel remains the durable conversation. Studio is the room where the artifact lives.
+
+## Brand Personality
+
+Competent, transparent, slightly absurd.
+
+The voice should feel like an effective office full of AI coworkers: terse when work is happening, funny when there is room, and never vague about state or responsibility. The humor is inspired by The Office: workplace asides, mild overconfidence, deadpan labels, and small moments of "this should not work, but somehow it does." Product UI must stay task-first. Errors, permissions, destructive actions, and dense work views should choose clarity over jokes.
+
+## Anti-references
+
+Do not make WUPHF feel like a generic AI SaaS command center, a cloud dashboard, a faceless prompt-chain builder, or an app store for widgets. Avoid hidden automation, glossy agent theater, abstract gradient blobs, decorative cards, marketing-page hero patterns inside the app, and generated UI that cannot be inspected or repaired.
+
+Do not let the humor turn into clutter. No joke should block scanning, reduce trust, or obscure what an agent did.
+
+## Design Principles
+
+1. Show the work. Every meaningful agent action should leave a visible trace, a readable artifact, or a receipt the user can inspect.
+2. Keep the office coherent. Studio surfaces, channel messages, receipts, and agent memory should feel like parts of one shared workplace rather than separate products.
+3. Make generated UI repairable. Source, rendered output, validation, history, and patches are first-class UX, not developer-only escape hatches.
+4. Prefer dense, familiar controls. WUPHF is a tool people return to during real work, so use compact product patterns, stable layouts, and predictable interaction states.
+5. Use personality as seasoning. Deadpan office humor belongs in empty states, status moments, and agent copy. It should never replace precise labels, recovery paths, or auditability.
+
+## Accessibility & Inclusion
+
+Target WCAG 2.2 AA for product surfaces. Preserve keyboard navigation, visible focus states, adequate contrast, reduced-motion behavior, and screen-reader-friendly labels for icons and generated widgets. Color must not be the only signal for status. Generated surfaces should remain usable when widget content is long, empty, partially invalid, or viewed on a narrow screen.

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -896,6 +896,8 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/studio/bootstrap-package", b.requireAuth(handleOperationBootstrapPackage))
 	mux.HandleFunc("/operations/bootstrap-package", b.requireAuth(handleOperationBootstrapPackage))
 	mux.HandleFunc("/studio/run-workflow", b.requireAuth(b.handleStudioRunWorkflow))
+	mux.HandleFunc("/surfaces", b.requireAuth(b.handleSurfaces))
+	mux.HandleFunc("/surfaces/", b.requireAuth(b.handleSurfaceSubpath))
 	mux.HandleFunc("/requests", b.requireAuth(b.handleRequests))
 	mux.HandleFunc("/requests/answer", b.requireAuth(b.handleRequestAnswer))
 	mux.HandleFunc("/interview", b.requireAuth(b.handleInterview))
@@ -1059,6 +1061,8 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 	defer unsubscribePlaybook()
 	playbookSynthEvents, unsubscribePlaybookSynth := b.SubscribePlaybookSynthesizedEvents(64)
 	defer unsubscribePlaybookSynth()
+	surfaceEvents, unsubscribeSurfaces := b.SubscribeSurfaceEvents(64)
+	defer unsubscribeSurfaces()
 	pamStarted, pamDone, pamFailed, unsubscribePam := b.SubscribePamActionEvents(64)
 	defer unsubscribePam()
 
@@ -1127,6 +1131,10 @@ func (b *Broker) handleEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		case evt, ok := <-playbookSynthEvents:
 			if !ok || writeEvent("playbook:synthesized", evt) != nil {
+				return
+			}
+		case evt, ok := <-surfaceEvents:
+			if !ok || writeEvent(evt.Type, evt) != nil {
 				return
 			}
 		case evt, ok := <-pamStarted:

--- a/internal/team/broker_surfaces.go
+++ b/internal/team/broker_surfaces.go
@@ -1,0 +1,456 @@
+package team
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const maxSurfaceRequestBodyBytes = 128 * 1024
+
+type SurfaceEvent struct {
+	Type      string `json:"type"`
+	SurfaceID string `json:"surface_id"`
+	WidgetID  string `json:"widget_id,omitempty"`
+	Channel   string `json:"channel"`
+	Actor     string `json:"actor,omitempty"`
+	Title     string `json:"title,omitempty"`
+	CreatedAt string `json:"created_at"`
+}
+
+var (
+	surfaceSubscribersMu       sync.Mutex
+	surfaceSubscribersByBroker = map[*Broker]map[int]chan SurfaceEvent{}
+)
+
+func (b *Broker) SubscribeSurfaceEvents(buffer int) (<-chan SurfaceEvent, func()) {
+	if buffer <= 0 {
+		buffer = 64
+	}
+	surfaceSubscribersMu.Lock()
+	defer surfaceSubscribersMu.Unlock()
+	subs := surfaceSubscribersByBroker[b]
+	if subs == nil {
+		subs = map[int]chan SurfaceEvent{}
+		surfaceSubscribersByBroker[b] = subs
+	}
+	b.mu.Lock()
+	id := b.nextSubscriberID
+	b.nextSubscriberID++
+	b.mu.Unlock()
+	ch := make(chan SurfaceEvent, buffer)
+	subs[id] = ch
+	return ch, func() {
+		surfaceSubscribersMu.Lock()
+		defer surfaceSubscribersMu.Unlock()
+		if subs := surfaceSubscribersByBroker[b]; subs != nil {
+			if existing, ok := subs[id]; ok {
+				delete(subs, id)
+				close(existing)
+			}
+		}
+	}
+}
+
+func (b *Broker) PublishSurfaceEvent(evt SurfaceEvent) {
+	surfaceSubscribersMu.Lock()
+	defer surfaceSubscribersMu.Unlock()
+	for key, ch := range surfaceSubscribersByBroker[b] {
+		select {
+		case ch <- evt:
+		default:
+			log.Printf("surfaces: dropping event for subscriber %d (buffer full)", key)
+		}
+	}
+}
+
+func (b *Broker) handleSurfaces(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		b.handleSurfaceList(w, r)
+	case http.MethodPost:
+		b.handleSurfaceCreate(w, r)
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}
+
+func (b *Broker) handleSurfaceSubpath(w http.ResponseWriter, r *http.Request) {
+	trimmed := strings.Trim(strings.TrimPrefix(r.URL.Path, "/surfaces/"), "/")
+	if trimmed == "" {
+		b.handleSurfaces(w, r)
+		return
+	}
+	parts := strings.Split(trimmed, "/")
+	surfaceID := parts[0]
+	switch {
+	case len(parts) == 1:
+		b.handleSurfaceResource(w, r, surfaceID)
+	case len(parts) == 2 && parts[1] == "widgets":
+		b.handleSurfaceWidgets(w, r, surfaceID)
+	case len(parts) == 3 && parts[1] == "widgets":
+		b.handleSurfaceWidgetResource(w, r, surfaceID, parts[2])
+	case len(parts) == 4 && parts[1] == "widgets" && parts[3] == "render-check":
+		b.handleSurfaceWidgetRenderCheck(w, r, surfaceID, parts[2])
+	case len(parts) == 2 && parts[1] == "history":
+		b.handleSurfaceHistory(w, r, surfaceID)
+	default:
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+	}
+}
+
+func (b *Broker) handleSurfaceList(w http.ResponseWriter, r *http.Request) {
+	viewer := surfaceViewerFromRequest(r)
+	rows, err := b.surfaceStore().ListSurfaces()
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		return
+	}
+	out := make([]SurfaceManifest, 0, len(rows))
+	b.mu.Lock()
+	for _, row := range rows {
+		if b.canAccessChannelLocked(viewer, row.Channel) {
+			out = append(out, row)
+		}
+	}
+	b.mu.Unlock()
+	writeJSON(w, http.StatusOK, map[string]any{"surfaces": out})
+}
+
+func (b *Broker) handleSurfaceCreate(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		SurfaceManifest `json:",inline"`
+		MySlug          string `json:"my_slug,omitempty"`
+		Actor           string `json:"actor,omitempty"`
+		EventID         string `json:"event_id,omitempty"`
+	}
+	if err := decodeSurfaceJSON(w, r, &body); err != nil {
+		return
+	}
+	actor := firstNonEmpty(body.Actor, body.CreatedBy, body.MySlug, r.Header.Get(agentRateLimitHeader), "human")
+	body.CreatedBy = actor
+	body.Channel = normalizeChannelSlug(body.Channel)
+	if body.Channel == "" {
+		body.Channel = "general"
+	}
+	if !b.canAccessSurfaceChannel(actor, body.Channel) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "channel access denied"})
+		return
+	}
+	if !b.channelExists(body.Channel) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "channel not found"})
+		return
+	}
+	surface, err := b.surfaceStore().CreateSurface(body.SurfaceManifest)
+	if err != nil {
+		writeSurfaceError(w, err)
+		return
+	}
+	b.afterSurfaceMutation("surface:created", "surface_created", surface, "", actor, "Created Studio surface", body.EventID)
+	writeJSON(w, http.StatusOK, map[string]any{"surface": surface})
+}
+
+func (b *Broker) handleSurfaceResource(w http.ResponseWriter, r *http.Request, surfaceID string) {
+	switch r.Method {
+	case http.MethodGet:
+		detail, ok := b.readSurfaceForRequest(w, r, surfaceID)
+		if !ok {
+			return
+		}
+		writeJSON(w, http.StatusOK, detail)
+	case http.MethodPatch:
+		var body struct {
+			SurfaceManifest `json:",inline"`
+			MySlug          string `json:"my_slug,omitempty"`
+			Actor           string `json:"actor,omitempty"`
+			EventID         string `json:"event_id,omitempty"`
+		}
+		if err := decodeSurfaceJSON(w, r, &body); err != nil {
+			return
+		}
+		current, ok := b.readSurfaceManifestForRequest(w, r, surfaceID)
+		if !ok {
+			return
+		}
+		actor := firstNonEmpty(body.Actor, body.MySlug, r.Header.Get(agentRateLimitHeader), "human")
+		body.ID = surfaceID
+		updated, err := b.surfaceStore().UpdateSurface(body.SurfaceManifest, actor)
+		if err != nil {
+			writeSurfaceError(w, err)
+			return
+		}
+		b.afterSurfaceMutation("surface:updated", "surface_updated", updated, "", actor, "Updated Studio surface", body.EventID)
+		_ = current
+		writeJSON(w, http.StatusOK, map[string]any{"surface": updated})
+	case http.MethodDelete:
+		current, ok := b.readSurfaceManifestForRequest(w, r, surfaceID)
+		if !ok {
+			return
+		}
+		actor := firstNonEmpty(r.URL.Query().Get("my_slug"), r.URL.Query().Get("actor"), r.Header.Get(agentRateLimitHeader), "human")
+		if err := b.surfaceStore().DeleteSurface(surfaceID, actor); err != nil {
+			writeSurfaceError(w, err)
+			return
+		}
+		b.afterSurfaceMutation("surface:deleted", "surface_deleted", current, "", actor, "Deleted Studio surface", "")
+		writeJSON(w, http.StatusOK, map[string]any{"deleted": true})
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}
+
+func (b *Broker) handleSurfaceWidgets(w http.ResponseWriter, r *http.Request, surfaceID string) {
+	switch r.Method {
+	case http.MethodGet:
+		if _, ok := b.readSurfaceManifestForRequest(w, r, surfaceID); !ok {
+			return
+		}
+		widgets, err := b.surfaceStore().ListWidgetRecords(surfaceID)
+		if err != nil {
+			writeSurfaceError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"widgets": widgets})
+	case http.MethodPost:
+		var body struct {
+			Widget  SurfaceWidgetFile `json:"widget"`
+			MySlug  string            `json:"my_slug,omitempty"`
+			Actor   string            `json:"actor,omitempty"`
+			EventID string            `json:"event_id,omitempty"`
+		}
+		if err := decodeSurfaceJSON(w, r, &body); err != nil {
+			return
+		}
+		current, ok := b.readSurfaceManifestForRequest(w, r, surfaceID)
+		if !ok {
+			return
+		}
+		actor := firstNonEmpty(body.Actor, body.MySlug, body.Widget.UpdatedBy, body.Widget.CreatedBy, r.Header.Get(agentRateLimitHeader), "human")
+		eventType := "surface:widget_updated"
+		if strings.TrimSpace(body.Widget.ID) != "" {
+			if _, err := b.surfaceStore().ReadWidget(surfaceID, strings.TrimSpace(body.Widget.ID)); errors.Is(err, errWidgetNotFound) {
+				eventType = "surface:widget_created"
+			}
+		}
+		record, err := b.surfaceStore().UpsertWidget(surfaceID, body.Widget, actor)
+		if err != nil {
+			writeSurfaceError(w, err)
+			return
+		}
+		b.afterSurfaceMutation(eventType, "widget_upserted", current, record.Widget.ID, actor, "Updated Studio widget", body.EventID)
+		writeJSON(w, http.StatusOK, record)
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}
+
+func (b *Broker) handleSurfaceWidgetResource(w http.ResponseWriter, r *http.Request, surfaceID, widgetID string) {
+	switch r.Method {
+	case http.MethodGet:
+		if _, ok := b.readSurfaceManifestForRequest(w, r, surfaceID); !ok {
+			return
+		}
+		record, err := b.surfaceStore().ReadWidget(surfaceID, widgetID)
+		if err != nil {
+			writeSurfaceError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, record)
+	case http.MethodPatch:
+		var body WidgetPatchRequest
+		if err := decodeSurfaceJSON(w, r, &body); err != nil {
+			return
+		}
+		current, ok := b.readSurfaceManifestForRequest(w, r, surfaceID)
+		if !ok {
+			return
+		}
+		if body.Actor == "" {
+			body.Actor = firstNonEmpty(r.Header.Get(agentRateLimitHeader), "human")
+		}
+		record, err := b.surfaceStore().PatchWidget(surfaceID, widgetID, body)
+		if err != nil {
+			writeSurfaceError(w, err)
+			return
+		}
+		b.afterSurfaceMutation("surface:widget_updated", "widget_patched", current, record.Widget.ID, body.Actor, "Patched Studio widget", "")
+		writeJSON(w, http.StatusOK, record)
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+	}
+}
+
+func (b *Broker) handleSurfaceWidgetRenderCheck(w http.ResponseWriter, r *http.Request, surfaceID, widgetID string) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	current, ok := b.readSurfaceManifestForRequest(w, r, surfaceID)
+	if !ok {
+		return
+	}
+	var body struct {
+		Widget *SurfaceWidgetFile `json:"widget,omitempty"`
+		MySlug string             `json:"my_slug,omitempty"`
+		Actor  string             `json:"actor,omitempty"`
+	}
+	if r.Body != nil {
+		if err := decodeSurfaceJSON(w, r, &body); err != nil {
+			return
+		}
+	}
+	if body.Widget != nil {
+		body.Widget.ID = firstNonEmpty(body.Widget.ID, widgetID)
+		if saved, err := b.surfaceStore().ReadWidget(surfaceID, widgetID); err == nil {
+			body.Widget.Title = firstNonEmpty(body.Widget.Title, saved.Widget.Title)
+			body.Widget.Kind = firstNonEmpty(body.Widget.Kind, saved.Widget.Kind)
+			body.Widget.SchemaVersion = firstNonEmpty(body.Widget.SchemaVersion, saved.Widget.SchemaVersion)
+		}
+	}
+	result, err := b.surfaceStore().RenderCheck(surfaceID, widgetID, body.Widget)
+	if err != nil {
+		writeSurfaceError(w, err)
+		return
+	}
+	actor := firstNonEmpty(body.Actor, body.MySlug, r.Header.Get(agentRateLimitHeader), "human")
+	b.PublishSurfaceEvent(SurfaceEvent{
+		Type:      "surface:render_checked",
+		SurfaceID: surfaceID,
+		WidgetID:  widgetID,
+		Channel:   current.Channel,
+		Actor:     actor,
+		Title:     current.Title,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+	writeJSON(w, http.StatusOK, result)
+}
+
+func (b *Broker) handleSurfaceHistory(w http.ResponseWriter, r *http.Request, surfaceID string) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+	if _, ok := b.readSurfaceManifestForRequest(w, r, surfaceID); !ok {
+		return
+	}
+	history, err := b.surfaceStore().ListHistory(surfaceID)
+	if err != nil {
+		writeSurfaceError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"history": history})
+}
+
+func (b *Broker) readSurfaceForRequest(w http.ResponseWriter, r *http.Request, surfaceID string) (SurfaceDetail, bool) {
+	detail, err := b.surfaceStore().ReadSurface(surfaceID)
+	if err != nil {
+		writeSurfaceError(w, err)
+		return SurfaceDetail{}, false
+	}
+	if !b.canAccessSurfaceChannel(surfaceViewerFromRequest(r), detail.Surface.Channel) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "channel access denied"})
+		return SurfaceDetail{}, false
+	}
+	return detail, true
+}
+
+func (b *Broker) readSurfaceManifestForRequest(w http.ResponseWriter, r *http.Request, surfaceID string) (SurfaceManifest, bool) {
+	manifest, err := b.surfaceStore().ReadSurfaceManifest(surfaceID)
+	if err != nil {
+		writeSurfaceError(w, err)
+		return SurfaceManifest{}, false
+	}
+	if !b.canAccessSurfaceChannel(surfaceViewerFromRequest(r), manifest.Channel) {
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": "channel access denied"})
+		return SurfaceManifest{}, false
+	}
+	return manifest, true
+}
+
+func (b *Broker) canAccessSurfaceChannel(actor, channel string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.canAccessChannelLocked(actor, channel)
+}
+
+func (b *Broker) channelExists(channel string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.findChannelLocked(channel) != nil
+}
+
+func (b *Broker) afterSurfaceMutation(eventType, actionKind string, surface SurfaceManifest, widgetID, actor, title, eventID string) {
+	summary := title
+	if widgetID != "" {
+		summary = fmt.Sprintf("%s %s in %s", title, widgetID, surface.Title)
+	} else {
+		summary = fmt.Sprintf("%s %s", title, surface.Title)
+	}
+	relatedID := surface.ID
+	if widgetID != "" {
+		relatedID = surface.ID + "/" + widgetID
+	}
+	if err := b.RecordAction(actionKind, "studio", surface.Channel, actor, truncateSummary(summary, 140), relatedID, nil, ""); err != nil {
+		log.Printf("surfaces: record action failed: %v", err)
+	}
+	if eventID == "" {
+		eventID = fmt.Sprintf("studio:%s:%s:%s:%d", actionKind, surface.ID, widgetID, time.Now().UnixNano())
+	}
+	content := fmt.Sprintf("%s.\n\n[Open Studio](#/apps/studio)", summary)
+	if _, _, err := b.PostAutomationMessage("studio", surface.Channel, "Studio", content, eventID, "studio", "Studio", nil, ""); err != nil {
+		log.Printf("surfaces: post automation message failed: %v", err)
+	}
+	b.PublishSurfaceEvent(SurfaceEvent{
+		Type:      eventType,
+		SurfaceID: surface.ID,
+		WidgetID:  widgetID,
+		Channel:   surface.Channel,
+		Actor:     actor,
+		Title:     surface.Title,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func decodeSurfaceJSON(w http.ResponseWriter, r *http.Request, dest any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxSurfaceRequestBodyBytes)
+	if err := json.NewDecoder(r.Body).Decode(dest); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return err
+	}
+	return nil
+}
+
+func writeSurfaceError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errSurfaceNotFound), errors.Is(err, errWidgetNotFound):
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+	case strings.Contains(err.Error(), "access denied"):
+		writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+	case strings.Contains(err.Error(), "invalid"),
+		strings.Contains(err.Error(), "requires"),
+		strings.Contains(err.Error(), "exceeds"),
+		strings.Contains(err.Error(), "not found"),
+		strings.Contains(err.Error(), "ambiguous"),
+		strings.Contains(err.Error(), "render check failed"),
+		strings.Contains(err.Error(), "outside source"):
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+	default:
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+	}
+}
+
+func surfaceViewerFromRequest(r *http.Request) string {
+	q := r.URL.Query()
+	return firstNonEmpty(
+		q.Get("viewer_slug"),
+		q.Get("my_slug"),
+		q.Get("actor"),
+		r.Header.Get(agentRateLimitHeader),
+		"human",
+	)
+}

--- a/internal/team/broker_surfaces.go
+++ b/internal/team/broker_surfaces.go
@@ -385,7 +385,7 @@ func (b *Broker) channelExists(channel string) bool {
 }
 
 func (b *Broker) afterSurfaceMutation(eventType, actionKind string, surface SurfaceManifest, widgetID, actor, title, eventID string) {
-	summary := title
+	var summary string
 	if widgetID != "" {
 		summary = fmt.Sprintf("%s %s in %s", title, widgetID, surface.Title)
 	} else {

--- a/internal/team/broker_surfaces_test.go
+++ b/internal/team/broker_surfaces_test.go
@@ -1,0 +1,152 @@
+package team
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newSurfaceTestServer(t *testing.T, b *Broker) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/surfaces", b.requireAuth(b.handleSurfaces))
+	mux.HandleFunc("/surfaces/", b.requireAuth(b.handleSurfaceSubpath))
+	return httptest.NewServer(mux)
+}
+
+func TestBrokerSurfacesFiltersByChannelAccess(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.channels = append(b.channels, teamChannel{
+		Slug:    "private-launch",
+		Name:    "Private Launch",
+		Members: []string{"pm"},
+	})
+	b.mu.Unlock()
+	srv := newSurfaceTestServer(t, b)
+	defer srv.Close()
+
+	body, _ := json.Marshal(map[string]any{
+		"title":      "Private command center",
+		"channel":    "private-launch",
+		"created_by": "pm",
+		"my_slug":    "pm",
+	})
+	req, _ := authReq(http.MethodPost, srv.URL+"/surfaces", bytes.NewReader(body), b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("create status=%d", res.StatusCode)
+	}
+
+	req, _ = authReq(http.MethodGet, srv.URL+"/surfaces?viewer_slug=eng", nil, b.Token())
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	defer res.Body.Close()
+	var list struct {
+		Surfaces []SurfaceManifest `json:"surfaces"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&list); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(list.Surfaces) != 0 {
+		t.Fatalf("eng should not see private surface: %+v", list.Surfaces)
+	}
+
+	req, _ = authReq(http.MethodGet, srv.URL+"/surfaces/private-command-center?viewer_slug=eng", nil, b.Token())
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("read denied: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", res.StatusCode)
+	}
+}
+
+func TestBrokerSurfaceWidgetMutationAuditsAndPublishes(t *testing.T) {
+	b := newTestBroker(t)
+	srv := newSurfaceTestServer(t, b)
+	defer srv.Close()
+
+	events, unsub := b.SubscribeSurfaceEvents(8)
+	defer unsub()
+
+	createBody, _ := json.Marshal(map[string]any{
+		"title":      "Launch command center",
+		"channel":    "general",
+		"created_by": "ceo",
+		"my_slug":    "ceo",
+	})
+	req, _ := authReq(http.MethodPost, srv.URL+"/surfaces", bytes.NewReader(createBody), b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("create surface: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("create surface status=%d", res.StatusCode)
+	}
+	<-events
+
+	widgetBody, _ := json.Marshal(map[string]any{
+		"my_slug": "ceo",
+		"actor":   "ceo",
+		"widget": map[string]any{
+			"id":     "notes",
+			"title":  "Notes",
+			"kind":   "markdown",
+			"source": "kind: markdown\nmarkdown: Ship the surface.\n",
+		},
+	})
+	req, _ = authReq(http.MethodPost, srv.URL+"/surfaces/launch-command-center/widgets", bytes.NewReader(widgetBody), b.Token())
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("upsert widget: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("upsert status=%d body=%s", res.StatusCode, body)
+	}
+
+	select {
+	case evt := <-events:
+		if evt.Type != "surface:widget_created" || evt.WidgetID != "notes" {
+			t.Fatalf("unexpected event: %+v", evt)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected surface widget event")
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var hasAction bool
+	for _, action := range b.actions {
+		if action.Kind == "widget_upserted" && action.Source == "studio" {
+			hasAction = true
+		}
+	}
+	if !hasAction {
+		t.Fatalf("missing studio action: %+v", b.actions)
+	}
+	var hasMessage bool
+	for _, msg := range b.messages {
+		if msg.Source == "studio" && strings.Contains(msg.Content, "#/apps/studio") {
+			hasMessage = true
+		}
+	}
+	if !hasMessage {
+		t.Fatalf("missing durable studio message: %+v", b.messages)
+	}
+}

--- a/internal/team/surfaces.go
+++ b/internal/team/surfaces.go
@@ -1,0 +1,925 @@
+package team
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/nex-crm/wuphf/internal/config"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	maxSurfacesReturned     = 100
+	maxWidgetsPerSurface    = 50
+	maxWidgetSourceBytes    = 64 * 1024
+	maxTableRowsRendered    = 200
+	maxTableColumnsRendered = 20
+	maxPreviewTextBytes     = 8 * 1024
+	maxHistoryEntriesRead   = 100
+)
+
+var (
+	errSurfaceNotFound = errors.New("surface not found")
+	errWidgetNotFound  = errors.New("widget not found")
+	surfaceFileMu      sync.Mutex
+)
+
+type SurfaceStore struct {
+	root string
+}
+
+type SurfaceManifest struct {
+	ID          string         `json:"id" yaml:"id"`
+	Title       string         `json:"title" yaml:"title"`
+	Channel     string         `json:"channel" yaml:"channel"`
+	Owner       string         `json:"owner,omitempty" yaml:"owner,omitempty"`
+	CreatedBy   string         `json:"created_by,omitempty" yaml:"created_by,omitempty"`
+	CreatedAt   string         `json:"created_at" yaml:"created_at"`
+	UpdatedAt   string         `json:"updated_at" yaml:"updated_at"`
+	Layout      map[string]any `json:"layout,omitempty" yaml:"layout,omitempty"`
+	Permissions map[string]any `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+	WidgetCount int            `json:"widget_count,omitempty" yaml:"-"`
+}
+
+type SurfaceWidgetFile struct {
+	ID            string           `json:"id" yaml:"id"`
+	Title         string           `json:"title" yaml:"title"`
+	Description   string           `json:"description,omitempty" yaml:"description,omitempty"`
+	Kind          string           `json:"kind" yaml:"kind"`
+	SchemaVersion string           `json:"schema_version,omitempty" yaml:"schema_version,omitempty"`
+	Layout        map[string]any   `json:"layout,omitempty" yaml:"layout,omitempty"`
+	Source        string           `json:"source" yaml:"source"`
+	DataBindings  map[string]any   `json:"data_bindings,omitempty" yaml:"data_bindings,omitempty"`
+	Actions       []map[string]any `json:"actions,omitempty" yaml:"actions,omitempty"`
+	CreatedBy     string           `json:"created_by,omitempty" yaml:"created_by,omitempty"`
+	UpdatedBy     string           `json:"updated_by,omitempty" yaml:"updated_by,omitempty"`
+	CreatedAt     string           `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt     string           `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+}
+
+type SurfaceDetail struct {
+	Surface SurfaceManifest       `json:"surface"`
+	Widgets []SurfaceWidgetRecord `json:"widgets"`
+	History []SurfaceHistoryEntry `json:"history,omitempty"`
+}
+
+type SurfaceWidgetRecord struct {
+	Widget      SurfaceWidgetFile  `json:"widget"`
+	SourceLines []NumberedLine     `json:"source_lines"`
+	Render      WidgetRenderResult `json:"render"`
+}
+
+type NumberedLine struct {
+	Number int    `json:"number"`
+	Text   string `json:"text"`
+}
+
+type WidgetRenderResult struct {
+	SchemaOK         bool              `json:"schema_ok"`
+	RenderOK         bool              `json:"render_ok"`
+	NormalizedWidget *NormalizedWidget `json:"normalized_widget,omitempty"`
+	PreviewText      string            `json:"preview_text,omitempty"`
+	Errors           []string          `json:"errors,omitempty"`
+}
+
+type NormalizedWidget struct {
+	ID            string           `json:"id"`
+	Title         string           `json:"title"`
+	Description   string           `json:"description,omitempty"`
+	Kind          string           `json:"kind"`
+	SchemaVersion string           `json:"schema_version"`
+	Layout        map[string]any   `json:"layout,omitempty"`
+	Checklist     []ChecklistItem  `json:"checklist,omitempty"`
+	Table         *NormalizedTable `json:"table,omitempty"`
+	Markdown      string           `json:"markdown,omitempty"`
+}
+
+type ChecklistItem struct {
+	ID      string `json:"id,omitempty"`
+	Label   string `json:"label"`
+	Checked bool   `json:"checked"`
+}
+
+type NormalizedTable struct {
+	Columns []TableColumn       `json:"columns"`
+	Rows    []map[string]string `json:"rows"`
+}
+
+type TableColumn struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+}
+
+type SurfaceHistoryEntry struct {
+	ID        string `json:"id" yaml:"id"`
+	SurfaceID string `json:"surface_id" yaml:"surface_id"`
+	WidgetID  string `json:"widget_id,omitempty" yaml:"widget_id,omitempty"`
+	Kind      string `json:"kind" yaml:"kind"`
+	Actor     string `json:"actor,omitempty" yaml:"actor,omitempty"`
+	Summary   string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	CreatedAt string `json:"created_at" yaml:"created_at"`
+}
+
+type WidgetPatchRequest struct {
+	Actor       string `json:"actor,omitempty"`
+	Mode        string `json:"mode,omitempty"`
+	StartLine   int    `json:"start_line,omitempty"`
+	EndLine     int    `json:"end_line,omitempty"`
+	Replacement string `json:"replacement,omitempty"`
+	Search      string `json:"search,omitempty"`
+	Replace     string `json:"replace,omitempty"`
+	Old         string `json:"old,omitempty"`
+	New         string `json:"new,omitempty"`
+	Snippet     string `json:"snippet,omitempty"`
+}
+
+func NewSurfaceStore(root string) *SurfaceStore {
+	return &SurfaceStore{root: strings.TrimSpace(root)}
+}
+
+func brokerSurfacesRoot(statePath string) string {
+	if p := strings.TrimSpace(os.Getenv("WUPHF_SURFACES_PATH")); p != "" {
+		return p
+	}
+	if strings.TrimSpace(statePath) != "" {
+		return filepath.Join(filepath.Dir(statePath), "surfaces")
+	}
+	home := config.RuntimeHomeDir()
+	if home == "" {
+		return filepath.Join(".wuphf", "team", "surfaces")
+	}
+	return filepath.Join(home, ".wuphf", "team", "surfaces")
+}
+
+func (b *Broker) surfaceStore() *SurfaceStore {
+	return NewSurfaceStore(brokerSurfacesRoot(b.statePath))
+}
+
+func (s *SurfaceStore) ListSurfaces() ([]SurfaceManifest, error) {
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []SurfaceManifest{}, nil
+		}
+		return nil, err
+	}
+	rows := make([]SurfaceManifest, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() || !surfaceIDValid(entry.Name()) {
+			continue
+		}
+		manifest, err := s.ReadSurfaceManifest(entry.Name())
+		if err != nil {
+			continue
+		}
+		manifest.WidgetCount = s.widgetCount(entry.Name())
+		rows = append(rows, manifest)
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].UpdatedAt > rows[j].UpdatedAt
+	})
+	if len(rows) > maxSurfacesReturned {
+		rows = rows[:maxSurfacesReturned]
+	}
+	return rows, nil
+}
+
+func (s *SurfaceStore) CreateSurface(input SurfaceManifest) (SurfaceManifest, error) {
+	surfaceFileMu.Lock()
+	defer surfaceFileMu.Unlock()
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	id := strings.TrimSpace(input.ID)
+	if id == "" {
+		id = slugFromTitle(input.Title, "surface")
+	}
+	if !surfaceIDValid(id) {
+		return SurfaceManifest{}, fmt.Errorf("invalid surface id %q", id)
+	}
+	channel := normalizeChannelSlug(input.Channel)
+	if channel == "" {
+		channel = "general"
+	}
+	title := strings.TrimSpace(input.Title)
+	if title == "" {
+		title = id
+	}
+	manifest := SurfaceManifest{
+		ID:          id,
+		Title:       title,
+		Channel:     channel,
+		Owner:       strings.TrimSpace(input.Owner),
+		CreatedBy:   strings.TrimSpace(input.CreatedBy),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Layout:      input.Layout,
+		Permissions: input.Permissions,
+	}
+	dir := s.surfaceDir(id)
+	if _, err := os.Stat(filepath.Join(dir, "surface.yaml")); err == nil {
+		return SurfaceManifest{}, fmt.Errorf("surface %q already exists", id)
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "widgets"), 0o700); err != nil {
+		return SurfaceManifest{}, err
+	}
+	if err := os.MkdirAll(filepath.Join(dir, "history"), 0o700); err != nil {
+		return SurfaceManifest{}, err
+	}
+	if err := s.writeYAML(filepath.Join(dir, "surface.yaml"), manifest); err != nil {
+		return SurfaceManifest{}, err
+	}
+	_ = s.appendHistoryLocked(id, "", "surface_created", manifest.CreatedBy, "Created surface "+manifest.Title)
+	return manifest, nil
+}
+
+func (s *SurfaceStore) ReadSurfaceManifest(id string) (SurfaceManifest, error) {
+	if !surfaceIDValid(id) {
+		return SurfaceManifest{}, fmt.Errorf("invalid surface id %q", id)
+	}
+	var manifest SurfaceManifest
+	if err := s.readYAML(filepath.Join(s.surfaceDir(id), "surface.yaml"), &manifest); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return SurfaceManifest{}, errSurfaceNotFound
+		}
+		return SurfaceManifest{}, err
+	}
+	manifest.ID = strings.TrimSpace(manifest.ID)
+	manifest.Channel = normalizeChannelSlug(manifest.Channel)
+	if manifest.Channel == "" {
+		manifest.Channel = "general"
+	}
+	manifest.WidgetCount = s.widgetCount(id)
+	return manifest, nil
+}
+
+func (s *SurfaceStore) ReadSurface(id string) (SurfaceDetail, error) {
+	manifest, err := s.ReadSurfaceManifest(id)
+	if err != nil {
+		return SurfaceDetail{}, err
+	}
+	widgets, err := s.ListWidgetRecords(id)
+	if err != nil {
+		return SurfaceDetail{}, err
+	}
+	history, _ := s.ListHistory(id)
+	return SurfaceDetail{Surface: manifest, Widgets: widgets, History: history}, nil
+}
+
+func (s *SurfaceStore) UpdateSurface(input SurfaceManifest, actor string) (SurfaceManifest, error) {
+	surfaceFileMu.Lock()
+	defer surfaceFileMu.Unlock()
+	current, err := s.ReadSurfaceManifest(input.ID)
+	if err != nil {
+		return SurfaceManifest{}, err
+	}
+	if title := strings.TrimSpace(input.Title); title != "" {
+		current.Title = title
+	}
+	if input.Layout != nil {
+		current.Layout = input.Layout
+	}
+	if input.Permissions != nil {
+		current.Permissions = input.Permissions
+	}
+	current.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+	if err := s.writeYAML(filepath.Join(s.surfaceDir(current.ID), "surface.yaml"), current); err != nil {
+		return SurfaceManifest{}, err
+	}
+	_ = s.appendHistoryLocked(current.ID, "", "surface_updated", actor, "Updated surface "+current.Title)
+	return current, nil
+}
+
+func (s *SurfaceStore) DeleteSurface(id, actor string) error {
+	if !surfaceIDValid(id) {
+		return fmt.Errorf("invalid surface id %q", id)
+	}
+	surfaceFileMu.Lock()
+	defer surfaceFileMu.Unlock()
+	if _, err := s.ReadSurfaceManifest(id); err != nil {
+		return err
+	}
+	_ = s.appendHistoryLocked(id, "", "surface_deleted", actor, "Deleted surface "+id)
+	return os.RemoveAll(s.surfaceDir(id))
+}
+
+func (s *SurfaceStore) ListWidgetRecords(surfaceID string) ([]SurfaceWidgetRecord, error) {
+	if !surfaceIDValid(surfaceID) {
+		return nil, fmt.Errorf("invalid surface id %q", surfaceID)
+	}
+	widgetDir := filepath.Join(s.surfaceDir(surfaceID), "widgets")
+	entries, err := os.ReadDir(widgetDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []SurfaceWidgetRecord{}, nil
+		}
+		return nil, err
+	}
+	rows := make([]SurfaceWidgetRecord, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		id := strings.TrimSuffix(entry.Name(), ".yaml")
+		if !surfaceIDValid(id) {
+			continue
+		}
+		record, err := s.ReadWidget(surfaceID, id)
+		if err != nil {
+			continue
+		}
+		rows = append(rows, record)
+	}
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].Widget.UpdatedAt < rows[j].Widget.UpdatedAt
+	})
+	return rows, nil
+}
+
+func (s *SurfaceStore) ReadWidget(surfaceID, widgetID string) (SurfaceWidgetRecord, error) {
+	if !surfaceIDValid(surfaceID) {
+		return SurfaceWidgetRecord{}, fmt.Errorf("invalid surface id %q", surfaceID)
+	}
+	if !surfaceIDValid(widgetID) {
+		return SurfaceWidgetRecord{}, fmt.Errorf("invalid widget id %q", widgetID)
+	}
+	var widget SurfaceWidgetFile
+	if err := s.readYAML(s.widgetPath(surfaceID, widgetID), &widget); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return SurfaceWidgetRecord{}, errWidgetNotFound
+		}
+		return SurfaceWidgetRecord{}, err
+	}
+	widget.ID = widgetID
+	render := RenderWidget(widget)
+	return SurfaceWidgetRecord{
+		Widget:      widget,
+		SourceLines: numberedLines(widget.Source),
+		Render:      render,
+	}, nil
+}
+
+func (s *SurfaceStore) UpsertWidget(surfaceID string, widget SurfaceWidgetFile, actor string) (SurfaceWidgetRecord, error) {
+	if !surfaceIDValid(surfaceID) {
+		return SurfaceWidgetRecord{}, fmt.Errorf("invalid surface id %q", surfaceID)
+	}
+	if _, err := s.ReadSurfaceManifest(surfaceID); err != nil {
+		return SurfaceWidgetRecord{}, err
+	}
+	surfaceFileMu.Lock()
+	defer surfaceFileMu.Unlock()
+	return s.upsertWidgetLocked(surfaceID, widget, actor, "widget_upserted")
+}
+
+func (s *SurfaceStore) PatchWidget(surfaceID, widgetID string, patch WidgetPatchRequest) (SurfaceWidgetRecord, error) {
+	if !surfaceIDValid(surfaceID) {
+		return SurfaceWidgetRecord{}, fmt.Errorf("invalid surface id %q", surfaceID)
+	}
+	if !surfaceIDValid(widgetID) {
+		return SurfaceWidgetRecord{}, fmt.Errorf("invalid widget id %q", widgetID)
+	}
+	surfaceFileMu.Lock()
+	defer surfaceFileMu.Unlock()
+	current, err := s.readWidgetFile(surfaceID, widgetID)
+	if err != nil {
+		return SurfaceWidgetRecord{}, err
+	}
+	source, err := applyWidgetSourcePatch(current.Source, patch)
+	if err != nil {
+		return SurfaceWidgetRecord{}, err
+	}
+	current.Source = source
+	return s.upsertWidgetLocked(surfaceID, current, patch.Actor, "widget_patched")
+}
+
+func (s *SurfaceStore) RenderCheck(surfaceID, widgetID string, candidate *SurfaceWidgetFile) (WidgetRenderResult, error) {
+	if candidate != nil {
+		return RenderWidget(*candidate), nil
+	}
+	record, err := s.ReadWidget(surfaceID, widgetID)
+	if err != nil {
+		return WidgetRenderResult{}, err
+	}
+	return record.Render, nil
+}
+
+func (s *SurfaceStore) upsertWidgetLocked(surfaceID string, widget SurfaceWidgetFile, actor, historyKind string) (SurfaceWidgetRecord, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	id := strings.TrimSpace(widget.ID)
+	if id == "" {
+		id = slugFromTitle(widget.Title, "widget")
+	}
+	if !surfaceIDValid(id) {
+		return SurfaceWidgetRecord{}, fmt.Errorf("invalid widget id %q", id)
+	}
+	if len([]byte(widget.Source)) > maxWidgetSourceBytes {
+		return SurfaceWidgetRecord{}, fmt.Errorf("widget source exceeds %d bytes", maxWidgetSourceBytes)
+	}
+	widget.ID = id
+	widget.Kind = strings.TrimSpace(strings.ToLower(widget.Kind))
+	widget.Title = strings.TrimSpace(widget.Title)
+	if widget.Title == "" {
+		widget.Title = id
+	}
+	if widget.SchemaVersion == "" {
+		widget.SchemaVersion = "surface.widget.v1"
+	}
+	if widget.CreatedAt == "" {
+		if existing, err := s.readWidgetFile(surfaceID, id); err == nil {
+			widget.CreatedAt = existing.CreatedAt
+			widget.CreatedBy = existing.CreatedBy
+		}
+	}
+	if widget.CreatedAt == "" {
+		widget.CreatedAt = now
+	}
+	if widget.CreatedBy == "" {
+		widget.CreatedBy = strings.TrimSpace(actor)
+	}
+	widget.UpdatedAt = now
+	widget.UpdatedBy = strings.TrimSpace(actor)
+	render := RenderWidget(widget)
+	if !render.SchemaOK || !render.RenderOK {
+		return SurfaceWidgetRecord{}, fmt.Errorf("widget render check failed: %s", strings.Join(render.Errors, "; "))
+	}
+	widgets, _ := s.ListWidgetRecords(surfaceID)
+	if _, err := s.readWidgetFile(surfaceID, id); errors.Is(err, errWidgetNotFound) && len(widgets) >= maxWidgetsPerSurface {
+		return SurfaceWidgetRecord{}, fmt.Errorf("surface %q already has maximum %d widgets", surfaceID, maxWidgetsPerSurface)
+	}
+	if err := os.MkdirAll(filepath.Join(s.surfaceDir(surfaceID), "widgets"), 0o700); err != nil {
+		return SurfaceWidgetRecord{}, err
+	}
+	if err := s.writeYAML(s.widgetPath(surfaceID, id), widget); err != nil {
+		return SurfaceWidgetRecord{}, err
+	}
+	if manifest, err := s.ReadSurfaceManifest(surfaceID); err == nil {
+		manifest.UpdatedAt = now
+		_ = s.writeYAML(filepath.Join(s.surfaceDir(surfaceID), "surface.yaml"), manifest)
+	}
+	_ = s.appendHistoryLocked(surfaceID, id, historyKind, actor, "Updated widget "+widget.Title)
+	return SurfaceWidgetRecord{Widget: widget, SourceLines: numberedLines(widget.Source), Render: render}, nil
+}
+
+func (s *SurfaceStore) readWidgetFile(surfaceID, widgetID string) (SurfaceWidgetFile, error) {
+	var widget SurfaceWidgetFile
+	if err := s.readYAML(s.widgetPath(surfaceID, widgetID), &widget); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return SurfaceWidgetFile{}, errWidgetNotFound
+		}
+		return SurfaceWidgetFile{}, err
+	}
+	widget.ID = widgetID
+	return widget, nil
+}
+
+func RenderWidget(widget SurfaceWidgetFile) WidgetRenderResult {
+	normalized, preview, errs := normalizeWidget(widget)
+	if len(errs) > 0 {
+		return WidgetRenderResult{SchemaOK: false, RenderOK: false, Errors: errs}
+	}
+	return WidgetRenderResult{
+		SchemaOK:         true,
+		RenderOK:         true,
+		NormalizedWidget: &normalized,
+		PreviewText:      truncateBytes(preview, maxPreviewTextBytes),
+	}
+}
+
+func normalizeWidget(widget SurfaceWidgetFile) (NormalizedWidget, string, []string) {
+	var errs []string
+	if strings.TrimSpace(widget.ID) == "" {
+		errs = append(errs, "widget id is required")
+	}
+	if strings.TrimSpace(widget.Title) == "" {
+		errs = append(errs, "widget title is required")
+	}
+	if strings.TrimSpace(widget.Source) == "" {
+		errs = append(errs, "widget source is required")
+	}
+	if len([]byte(widget.Source)) > maxWidgetSourceBytes {
+		errs = append(errs, fmt.Sprintf("widget source exceeds %d bytes", maxWidgetSourceBytes))
+	}
+	var raw map[string]any
+	if strings.TrimSpace(widget.Source) != "" {
+		if err := yaml.Unmarshal([]byte(widget.Source), &raw); err != nil {
+			errs = append(errs, "source yaml invalid: "+err.Error())
+		}
+	}
+	kind := strings.ToLower(strings.TrimSpace(widget.Kind))
+	if sourceKind, _ := rawString(raw, "kind"); sourceKind != "" {
+		kind = strings.ToLower(sourceKind)
+	}
+	if kind == "" {
+		errs = append(errs, "widget kind is required")
+	}
+	normalized := NormalizedWidget{
+		ID:            strings.TrimSpace(widget.ID),
+		Title:         strings.TrimSpace(widget.Title),
+		Description:   strings.TrimSpace(widget.Description),
+		Kind:          kind,
+		SchemaVersion: fallbackString(widget.SchemaVersion, "surface.widget.v1"),
+		Layout:        widget.Layout,
+	}
+	if len(errs) > 0 {
+		return normalized, "", errs
+	}
+	switch kind {
+	case "checklist":
+		items, itemErrs := normalizeChecklist(raw)
+		if len(itemErrs) > 0 {
+			errs = append(errs, itemErrs...)
+			break
+		}
+		normalized.Checklist = items
+		var lines []string
+		for _, item := range items {
+			mark := "[ ]"
+			if item.Checked {
+				mark = "[x]"
+			}
+			lines = append(lines, fmt.Sprintf("%s %s", mark, item.Label))
+		}
+		return normalized, strings.Join(lines, "\n"), nil
+	case "table":
+		table, tableErrs := normalizeTable(raw)
+		if len(tableErrs) > 0 {
+			errs = append(errs, tableErrs...)
+			break
+		}
+		normalized.Table = &table
+		return normalized, previewTable(table), nil
+	case "markdown":
+		body := firstRawString(raw, "markdown", "body", "text", "content")
+		if strings.TrimSpace(body) == "" {
+			errs = append(errs, "markdown widget requires markdown, body, text, or content")
+			break
+		}
+		normalized.Markdown = body
+		return normalized, body, nil
+	default:
+		errs = append(errs, fmt.Sprintf("unsupported widget kind %q", kind))
+	}
+	return normalized, "", errs
+}
+
+func normalizeChecklist(raw map[string]any) ([]ChecklistItem, []string) {
+	itemsRaw, ok := raw["items"].([]any)
+	if !ok || len(itemsRaw) == 0 {
+		return nil, []string{"checklist widget requires non-empty items"}
+	}
+	items := make([]ChecklistItem, 0, len(itemsRaw))
+	for i, itemRaw := range itemsRaw {
+		m, ok := itemRaw.(map[string]any)
+		if !ok {
+			if label, ok := itemRaw.(string); ok && strings.TrimSpace(label) != "" {
+				items = append(items, ChecklistItem{ID: fmt.Sprintf("item-%d", i+1), Label: strings.TrimSpace(label)})
+				continue
+			}
+			return nil, []string{fmt.Sprintf("checklist item %d must be an object or string", i+1)}
+		}
+		label := firstRawString(m, "label", "title", "text")
+		if strings.TrimSpace(label) == "" {
+			return nil, []string{fmt.Sprintf("checklist item %d requires label", i+1)}
+		}
+		item := ChecklistItem{
+			ID:      fallbackString(firstRawString(m, "id"), fmt.Sprintf("item-%d", i+1)),
+			Label:   strings.TrimSpace(label),
+			Checked: rawBool(m, "checked"),
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func normalizeTable(raw map[string]any) (NormalizedTable, []string) {
+	columnsRaw, ok := raw["columns"].([]any)
+	if !ok || len(columnsRaw) == 0 {
+		return NormalizedTable{}, []string{"table widget requires non-empty columns"}
+	}
+	if len(columnsRaw) > maxTableColumnsRendered {
+		return NormalizedTable{}, []string{fmt.Sprintf("table widget exceeds %d columns", maxTableColumnsRendered)}
+	}
+	columns := make([]TableColumn, 0, len(columnsRaw))
+	for i, colRaw := range columnsRaw {
+		switch col := colRaw.(type) {
+		case string:
+			key := strings.TrimSpace(col)
+			if key == "" {
+				return NormalizedTable{}, []string{fmt.Sprintf("table column %d is blank", i+1)}
+			}
+			columns = append(columns, TableColumn{Key: key, Label: key})
+		case map[string]any:
+			key := firstRawString(col, "key", "id")
+			label := fallbackString(firstRawString(col, "label", "title"), key)
+			if strings.TrimSpace(key) == "" {
+				return NormalizedTable{}, []string{fmt.Sprintf("table column %d requires key", i+1)}
+			}
+			columns = append(columns, TableColumn{Key: strings.TrimSpace(key), Label: strings.TrimSpace(label)})
+		default:
+			return NormalizedTable{}, []string{fmt.Sprintf("table column %d must be a string or object", i+1)}
+		}
+	}
+	rowsRaw, ok := raw["rows"].([]any)
+	if !ok {
+		return NormalizedTable{}, []string{"table widget requires rows"}
+	}
+	if len(rowsRaw) > maxTableRowsRendered {
+		return NormalizedTable{}, []string{fmt.Sprintf("table widget exceeds %d rows", maxTableRowsRendered)}
+	}
+	rows := make([]map[string]string, 0, len(rowsRaw))
+	for i, rowRaw := range rowsRaw {
+		m, ok := rowRaw.(map[string]any)
+		if !ok {
+			return NormalizedTable{}, []string{fmt.Sprintf("table row %d must be an object", i+1)}
+		}
+		row := map[string]string{}
+		for _, col := range columns {
+			row[col.Key] = strings.TrimSpace(fmt.Sprint(m[col.Key]))
+		}
+		rows = append(rows, row)
+	}
+	return NormalizedTable{Columns: columns, Rows: rows}, nil
+}
+
+func previewTable(table NormalizedTable) string {
+	var lines []string
+	var header []string
+	for _, col := range table.Columns {
+		header = append(header, col.Label)
+	}
+	lines = append(lines, strings.Join(header, " | "))
+	for _, row := range table.Rows {
+		var cells []string
+		for _, col := range table.Columns {
+			cells = append(cells, row[col.Key])
+		}
+		lines = append(lines, strings.Join(cells, " | "))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func applyWidgetSourcePatch(source string, patch WidgetPatchRequest) (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(patch.Mode))
+	if mode == "" {
+		if patch.StartLine > 0 || patch.EndLine > 0 {
+			mode = "line"
+		} else {
+			mode = "snippet"
+		}
+	}
+	replacement := patch.Replacement
+	if replacement == "" {
+		replacement = patch.New
+	}
+	if replacement == "" {
+		replacement = patch.Replace
+	}
+	switch mode {
+	case "line", "lines":
+		if patch.StartLine <= 0 || patch.EndLine <= 0 || patch.EndLine < patch.StartLine {
+			return "", fmt.Errorf("line patch requires valid start_line and end_line")
+		}
+		hadTrailingNewline := strings.HasSuffix(source, "\n")
+		lines := splitSourceLines(source)
+		if patch.StartLine > len(lines) || patch.EndLine > len(lines) {
+			return "", fmt.Errorf("line patch range %d-%d outside source with %d lines", patch.StartLine, patch.EndLine, len(lines))
+		}
+		replacementLines := splitSourceLines(replacement)
+		out := append([]string{}, lines[:patch.StartLine-1]...)
+		out = append(out, replacementLines...)
+		out = append(out, lines[patch.EndLine:]...)
+		joined := strings.Join(out, "\n")
+		if hadTrailingNewline {
+			joined += "\n"
+		}
+		return joined, nil
+	case "snippet":
+		search := patch.Search
+		if search == "" {
+			search = patch.Old
+		}
+		if search == "" {
+			search = patch.Snippet
+		}
+		if search == "" {
+			return "", fmt.Errorf("snippet patch requires search, old, or snippet")
+		}
+		count := strings.Count(source, search)
+		if count == 0 {
+			return "", fmt.Errorf("snippet not found")
+		}
+		if count > 1 {
+			return "", fmt.Errorf("snippet matched %d places; patch is ambiguous", count)
+		}
+		return strings.Replace(source, search, replacement, 1), nil
+	default:
+		return "", fmt.Errorf("unsupported patch mode %q", mode)
+	}
+}
+
+func (s *SurfaceStore) ListHistory(surfaceID string) ([]SurfaceHistoryEntry, error) {
+	if !surfaceIDValid(surfaceID) {
+		return nil, fmt.Errorf("invalid surface id %q", surfaceID)
+	}
+	dir := filepath.Join(s.surfaceDir(surfaceID), "history")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []SurfaceHistoryEntry{}, nil
+		}
+		return nil, err
+	}
+	sort.SliceStable(entries, func(i, j int) bool { return entries[i].Name() > entries[j].Name() })
+	if len(entries) > maxHistoryEntriesRead {
+		entries = entries[:maxHistoryEntriesRead]
+	}
+	out := make([]SurfaceHistoryEntry, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".yaml") {
+			continue
+		}
+		var h SurfaceHistoryEntry
+		if err := s.readYAML(filepath.Join(dir, entry.Name()), &h); err == nil {
+			out = append(out, h)
+		}
+	}
+	return out, nil
+}
+
+func (s *SurfaceStore) appendHistoryLocked(surfaceID, widgetID, kind, actor, summary string) error {
+	now := time.Now().UTC()
+	id := fmt.Sprintf("%s-%s", now.Format("20060102T150405.000000000Z"), slugFromTitle(kind, "event"))
+	entry := SurfaceHistoryEntry{
+		ID:        id,
+		SurfaceID: surfaceID,
+		WidgetID:  widgetID,
+		Kind:      strings.TrimSpace(kind),
+		Actor:     strings.TrimSpace(actor),
+		Summary:   strings.TrimSpace(summary),
+		CreatedAt: now.Format(time.RFC3339),
+	}
+	dir := filepath.Join(s.surfaceDir(surfaceID), "history")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	return s.writeYAML(filepath.Join(dir, id+".yaml"), entry)
+}
+
+func (s *SurfaceStore) surfaceDir(id string) string {
+	return filepath.Join(s.root, id)
+}
+
+func (s *SurfaceStore) widgetPath(surfaceID, widgetID string) string {
+	return filepath.Join(s.surfaceDir(surfaceID), "widgets", widgetID+".yaml")
+}
+
+func (s *SurfaceStore) widgetCount(surfaceID string) int {
+	entries, err := os.ReadDir(filepath.Join(s.surfaceDir(surfaceID), "widgets"))
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".yaml") {
+			n++
+		}
+	}
+	return n
+}
+
+func (s *SurfaceStore) readYAML(path string, dest any) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(data, dest)
+}
+
+func (s *SurfaceStore) writeYAML(path string, value any) error {
+	data, err := yaml.Marshal(value)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return atomicWriteFile(path, data)
+}
+
+func surfaceIDValid(id string) bool {
+	if len(id) > 63 {
+		return false
+	}
+	return slugPattern.MatchString(strings.TrimSpace(id))
+}
+
+func slugFromTitle(title, fallback string) string {
+	title = strings.ToLower(strings.TrimSpace(title))
+	var b strings.Builder
+	lastDash := false
+	for _, r := range title {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastDash = false
+		case unicode.IsSpace(r) || r == '-' || r == '_' || r == '/':
+			if b.Len() > 0 && !lastDash {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		out = fallback
+	}
+	if len(out) > 63 {
+		out = strings.Trim(out[:63], "-")
+	}
+	if out == "" {
+		return fallback
+	}
+	return out
+}
+
+func numberedLines(source string) []NumberedLine {
+	lines := splitSourceLines(source)
+	out := make([]NumberedLine, 0, len(lines))
+	for i, line := range lines {
+		out = append(out, NumberedLine{Number: i + 1, Text: line})
+	}
+	return out
+}
+
+func splitSourceLines(source string) []string {
+	source = strings.TrimRight(source, "\n")
+	if source == "" {
+		return []string{}
+	}
+	return strings.Split(source, "\n")
+}
+
+func rawString(m map[string]any, key string) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	v, ok := m[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return strings.TrimSpace(fmt.Sprint(v)), true
+	}
+	return strings.TrimSpace(s), true
+}
+
+func firstRawString(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if v, ok := rawString(m, key); ok && strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func rawBool(m map[string]any, key string) bool {
+	if m == nil {
+		return false
+	}
+	switch v := m[key].(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(strings.TrimSpace(v), "true") || strings.EqualFold(strings.TrimSpace(v), "yes")
+	default:
+		return false
+	}
+}
+
+func fallbackString(value, fallback string) string {
+	if strings.TrimSpace(value) != "" {
+		return strings.TrimSpace(value)
+	}
+	return fallback
+}
+
+func truncateBytes(value string, max int) string {
+	if len([]byte(value)) <= max {
+		return value
+	}
+	if max <= 0 {
+		return ""
+	}
+	data := []byte(value)
+	if len(data) > max {
+		data = data[:max]
+	}
+	return strings.TrimRight(string(data), "\x00") + "\n[truncated]"
+}

--- a/internal/team/surfaces.go
+++ b/internal/team/surfaces.go
@@ -11,8 +11,9 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/nex-crm/wuphf/internal/config"
 	"gopkg.in/yaml.v3"
+
+	"github.com/nex-crm/wuphf/internal/config"
 )
 
 const (

--- a/internal/team/surfaces_test.go
+++ b/internal/team/surfaces_test.go
@@ -1,0 +1,141 @@
+package team
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSurfaceStoreWidgetRenderReadAndPatch(t *testing.T) {
+	store := NewSurfaceStore(t.TempDir())
+	surface, err := store.CreateSurface(SurfaceManifest{
+		Title:     "Launch Command Center",
+		Channel:   "general",
+		CreatedBy: "ceo",
+	})
+	if err != nil {
+		t.Fatalf("create surface: %v", err)
+	}
+
+	record, err := store.UpsertWidget(surface.ID, SurfaceWidgetFile{
+		ID:    "open-blockers",
+		Title: "Open blockers",
+		Kind:  "checklist",
+		Source: `kind: checklist
+items:
+  - id: scope
+    label: Lock scope
+    checked: true
+  - id: tests
+    label: Add tests
+    checked: false
+`,
+	}, "ceo")
+	if err != nil {
+		t.Fatalf("upsert widget: %v", err)
+	}
+	if !record.Render.SchemaOK || !record.Render.RenderOK {
+		t.Fatalf("render failed: %+v", record.Render)
+	}
+	if len(record.SourceLines) < 7 {
+		t.Fatalf("expected numbered source lines, got %d", len(record.SourceLines))
+	}
+
+	patched, err := store.PatchWidget(surface.ID, "open-blockers", WidgetPatchRequest{
+		Actor:       "ceo",
+		Mode:        "snippet",
+		Search:      "label: Add tests",
+		Replacement: "label: Add render tests",
+	})
+	if err != nil {
+		t.Fatalf("patch widget: %v", err)
+	}
+	if !strings.Contains(patched.Widget.Source, "Add render tests") {
+		t.Fatalf("patch did not update source:\n%s", patched.Widget.Source)
+	}
+	if !strings.Contains(patched.Render.PreviewText, "Add render tests") {
+		t.Fatalf("preview did not reflect patch: %q", patched.Render.PreviewText)
+	}
+
+	reloaded := NewSurfaceStore(store.root)
+	detail, err := reloaded.ReadSurface(surface.ID)
+	if err != nil {
+		t.Fatalf("read from new store: %v", err)
+	}
+	if len(detail.Widgets) != 1 || !strings.Contains(detail.Widgets[0].Widget.Source, "Add render tests") {
+		t.Fatalf("persisted widget missing patch: %+v", detail.Widgets)
+	}
+}
+
+func TestSurfaceStoreRejectsMalformedWidgetBeforeWrite(t *testing.T) {
+	store := NewSurfaceStore(t.TempDir())
+	surface, err := store.CreateSurface(SurfaceManifest{Title: "Bad Source", Channel: "general", CreatedBy: "ceo"})
+	if err != nil {
+		t.Fatalf("create surface: %v", err)
+	}
+	_, err = store.UpsertWidget(surface.ID, SurfaceWidgetFile{
+		ID:     "bad",
+		Title:  "Bad",
+		Kind:   "checklist",
+		Source: "kind: checklist\nitems: [",
+	}, "ceo")
+	if err == nil {
+		t.Fatal("expected malformed widget to be rejected")
+	}
+	if _, readErr := store.ReadWidget(surface.ID, "bad"); !strings.Contains(readErr.Error(), "widget not found") {
+		t.Fatalf("widget should not have been written, got %v", readErr)
+	}
+}
+
+func TestSurfaceStoreRejectsAmbiguousSnippetPatch(t *testing.T) {
+	store := NewSurfaceStore(t.TempDir())
+	surface, err := store.CreateSurface(SurfaceManifest{Title: "Ambiguous", Channel: "general", CreatedBy: "ceo"})
+	if err != nil {
+		t.Fatalf("create surface: %v", err)
+	}
+	_, err = store.UpsertWidget(surface.ID, SurfaceWidgetFile{
+		ID:    "notes",
+		Title: "Notes",
+		Kind:  "markdown",
+		Source: `kind: markdown
+markdown: |
+  todo
+  todo
+`,
+	}, "ceo")
+	if err != nil {
+		t.Fatalf("upsert widget: %v", err)
+	}
+	_, err = store.PatchWidget(surface.ID, "notes", WidgetPatchRequest{
+		Actor:       "ceo",
+		Mode:        "snippet",
+		Search:      "todo",
+		Replacement: "done",
+	})
+	if err == nil || !strings.Contains(err.Error(), "ambiguous") {
+		t.Fatalf("expected ambiguous patch error, got %v", err)
+	}
+	record, err := store.ReadWidget(surface.ID, "notes")
+	if err != nil {
+		t.Fatalf("read widget: %v", err)
+	}
+	if strings.Contains(record.Widget.Source, "done") {
+		t.Fatalf("ambiguous patch should not write:\n%s", record.Widget.Source)
+	}
+}
+
+func TestRenderWidgetTableCapsRows(t *testing.T) {
+	var b strings.Builder
+	b.WriteString("kind: table\ncolumns: [name]\nrows:\n")
+	for i := 0; i < maxTableRowsRendered+1; i++ {
+		b.WriteString("  - name: row\n")
+	}
+	result := RenderWidget(SurfaceWidgetFile{
+		ID:     "too-big",
+		Title:  "Too big",
+		Kind:   "table",
+		Source: b.String(),
+	})
+	if result.SchemaOK || result.RenderOK {
+		t.Fatalf("expected oversized table to fail: %+v", result)
+	}
+}

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -619,6 +619,7 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 		), handleHumanMessage)
 
 		registerSharedMemoryTools(server)
+		registerSurfaceTools(server)
 
 		registerSkillAuthoringTools(server)
 
@@ -658,6 +659,7 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 			"Ask the human an interview question. If they dismiss it, or send another message in this channel/thread, the interview is canceled.",
 		), handleHumanInterview)
 		registerSharedMemoryTools(server)
+		registerSurfaceTools(server)
 		mcp.AddTool(server, officeWriteTool(
 			"team_skill_run",
 			"Invoke a named team skill. When the human's request matches an available skill, call this BEFORE replying — do not freelance. Bumps the skill's usage, logs a skill_invocation to the channel, and returns the skill's canonical step-by-step content for you to follow.",
@@ -736,6 +738,7 @@ func configureServerTools(server *mcp.Server, slug string, channel string, oneOn
 		registerImageTools(server)
 	}
 	registerSharedMemoryTools(server)
+	registerSurfaceTools(server)
 
 	mcp.AddTool(server, readOnlyTool(
 		"team_requests",

--- a/internal/teammcp/surface_tools.go
+++ b/internal/teammcp/surface_tools.go
@@ -1,0 +1,408 @@
+package teammcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type TeamSurfaceListArgs struct {
+	MySlug string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+}
+
+type TeamSurfaceCreateArgs struct {
+	MySlug  string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	ID      string `json:"id,omitempty" jsonschema:"Optional kebab-case surface ID. Omit to derive from title."`
+	Title   string `json:"title" jsonschema:"Human-readable surface title."`
+	Channel string `json:"channel,omitempty" jsonschema:"Channel this surface belongs to. Defaults to general."`
+}
+
+type TeamSurfaceReadArgs struct {
+	MySlug    string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	SurfaceID string `json:"surface_id" jsonschema:"Surface ID to read."`
+}
+
+type TeamSurfacePatchArgs struct {
+	MySlug    string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	SurfaceID string `json:"surface_id" jsonschema:"Surface ID to patch."`
+	Title     string `json:"title,omitempty" jsonschema:"New title, if changing it."`
+}
+
+type TeamWidgetListArgs struct {
+	MySlug    string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	SurfaceID string `json:"surface_id" jsonschema:"Surface ID whose widgets should be listed."`
+}
+
+type TeamWidgetReadArgs struct {
+	MySlug    string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	SurfaceID string `json:"surface_id" jsonschema:"Surface ID."`
+	WidgetID  string `json:"widget_id" jsonschema:"Widget ID."`
+}
+
+type TeamWidgetUpsertArgs struct {
+	MySlug      string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	SurfaceID   string `json:"surface_id" jsonschema:"Surface ID."`
+	WidgetID    string `json:"widget_id,omitempty" jsonschema:"Optional kebab-case widget ID. Omit to derive from title."`
+	Title       string `json:"title" jsonschema:"Widget title."`
+	Description string `json:"description,omitempty" jsonschema:"Short widget description."`
+	Kind        string `json:"kind" jsonschema:"One of checklist, table, markdown."`
+	Source      string `json:"source" jsonschema:"Declarative widget source YAML. This is the canonical patchable source block."`
+}
+
+type TeamWidgetPatchArgs struct {
+	MySlug      string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	SurfaceID   string `json:"surface_id" jsonschema:"Surface ID."`
+	WidgetID    string `json:"widget_id" jsonschema:"Widget ID."`
+	Mode        string `json:"mode,omitempty" jsonschema:"Patch mode: line or snippet. Inferred from fields when omitted."`
+	StartLine   int    `json:"start_line,omitempty" jsonschema:"1-based start line for line patch."`
+	EndLine     int    `json:"end_line,omitempty" jsonschema:"1-based inclusive end line for line patch."`
+	Search      string `json:"search,omitempty" jsonschema:"Exact snippet to replace. Must match exactly once."`
+	Replacement string `json:"replacement" jsonschema:"Replacement text."`
+}
+
+type TeamWidgetRenderCheckArgs struct {
+	MySlug    string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	SurfaceID string `json:"surface_id" jsonschema:"Surface ID."`
+	WidgetID  string `json:"widget_id" jsonschema:"Widget ID."`
+	Title     string `json:"title,omitempty" jsonschema:"Optional candidate title when checking unsaved source."`
+	Kind      string `json:"kind,omitempty" jsonschema:"Optional candidate kind when checking unsaved source."`
+	Source    string `json:"source,omitempty" jsonschema:"Optional candidate source YAML. Omit to check the saved widget."`
+}
+
+type TeamSurfacePublishUpdateArgs struct {
+	MySlug    string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	SurfaceID string `json:"surface_id" jsonschema:"Surface ID."`
+	Content   string `json:"content" jsonschema:"Compact channel update to publish with a Studio link."`
+}
+
+func registerSurfaceTools(server *mcp.Server) {
+	mcp.AddTool(server, readOnlyTool(
+		"team_surface_list",
+		"List Studio surfaces visible to you. Use before creating a new surface so you do not duplicate an existing command center.",
+	), handleTeamSurfaceList)
+	mcp.AddTool(server, officeWriteTool(
+		"team_surface_create",
+		"Create a channel-bound Studio surface. The surface persists in WUPHF and can hold agent-authored widgets.",
+	), handleTeamSurfaceCreate)
+	mcp.AddTool(server, readOnlyTool(
+		"team_surface_read",
+		"Read a Studio surface, including widgets, rendered previews, history, and numbered source lines.",
+	), handleTeamSurfaceRead)
+	mcp.AddTool(server, officeWriteTool(
+		"team_surface_patch",
+		"Patch surface metadata such as the title. Widget source edits should use team_widget_patch.",
+	), handleTeamSurfacePatch)
+	mcp.AddTool(server, readOnlyTool(
+		"team_widget_list",
+		"List widgets on a Studio surface.",
+	), handleTeamWidgetList)
+	mcp.AddTool(server, readOnlyTool(
+		"team_widget_read",
+		"Read one widget with numbered source lines and the current Go render preview.",
+	), handleTeamWidgetRead)
+	mcp.AddTool(server, readOnlyTool(
+		"team_widget_see_rendered",
+		"Inspect the current rendered preview for one widget without changing it.",
+	), handleTeamWidgetSeeRendered)
+	mcp.AddTool(server, officeWriteTool(
+		"team_widget_upsert",
+		"Create or replace a trusted declarative Studio widget. Use for new widgets and rare full rewrites.",
+	), handleTeamWidgetUpsert)
+	mcp.AddTool(server, officeWriteTool(
+		"team_widget_patch",
+		"Patch an existing widget source by line range or exact snippet. Prefer this after a widget exists.",
+	), handleTeamWidgetPatch)
+	mcp.AddTool(server, readOnlyTool(
+		"team_widget_render_check",
+		"Validate a saved or candidate widget and return schema_ok, render_ok, normalized_widget, preview_text, and errors.",
+	), handleTeamWidgetRenderCheck)
+	mcp.AddTool(server, officeWriteTool(
+		"team_surface_publish_update",
+		"Publish a compact channel update that links humans back to the Studio surface.",
+	), handleTeamSurfacePublishUpdate)
+}
+
+func handleTeamSurfaceList(ctx context.Context, _ *mcp.CallToolRequest, args TeamSurfaceListArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	var result map[string]any
+	if err := brokerGetJSON(ctx, "/surfaces?viewer_slug="+url.QueryEscape(slug), &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return jsonTextResult(result), nil, nil
+}
+
+func handleTeamSurfaceCreate(ctx context.Context, _ *mcp.CallToolRequest, args TeamSurfaceCreateArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	if strings.TrimSpace(args.Title) == "" {
+		return toolError(fmt.Errorf("title is required")), nil, nil
+	}
+	body := map[string]any{
+		"id":         strings.TrimSpace(args.ID),
+		"title":      strings.TrimSpace(args.Title),
+		"channel":    strings.TrimSpace(args.Channel),
+		"created_by": slug,
+		"my_slug":    slug,
+	}
+	var result map[string]any
+	if err := brokerPostJSON(ctx, "/surfaces", body, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return jsonTextResult(result), nil, nil
+}
+
+func handleTeamSurfaceRead(ctx context.Context, _ *mcp.CallToolRequest, args TeamSurfaceReadArgs) (*mcp.CallToolResult, any, error) {
+	path, err := surfacePathWithSlug(args.SurfaceID, args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	var result map[string]any
+	if err := brokerGetJSON(ctx, path, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return jsonTextResult(result), nil, nil
+}
+
+func handleTeamSurfacePatch(ctx context.Context, _ *mcp.CallToolRequest, args TeamSurfacePatchArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	surfaceID := strings.TrimSpace(args.SurfaceID)
+	if surfaceID == "" {
+		return toolError(fmt.Errorf("surface_id is required")), nil, nil
+	}
+	body := map[string]any{"my_slug": slug, "actor": slug}
+	if title := strings.TrimSpace(args.Title); title != "" {
+		body["title"] = title
+	}
+	var result map[string]any
+	if err := brokerDoJSON(ctx, http.MethodPatch, "/surfaces/"+url.PathEscape(surfaceID), body, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return jsonTextResult(result), nil, nil
+}
+
+func handleTeamWidgetList(ctx context.Context, _ *mcp.CallToolRequest, args TeamWidgetListArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	surfaceID := strings.TrimSpace(args.SurfaceID)
+	if surfaceID == "" {
+		return toolError(fmt.Errorf("surface_id is required")), nil, nil
+	}
+	var result map[string]any
+	path := "/surfaces/" + url.PathEscape(surfaceID) + "/widgets?viewer_slug=" + url.QueryEscape(slug)
+	if err := brokerGetJSON(ctx, path, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return jsonTextResult(result), nil, nil
+}
+
+func handleTeamWidgetRead(ctx context.Context, _ *mcp.CallToolRequest, args TeamWidgetReadArgs) (*mcp.CallToolResult, any, error) {
+	path, err := widgetPathWithSlug(args.SurfaceID, args.WidgetID, args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	var result map[string]any
+	if err := brokerGetJSON(ctx, path, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return jsonTextResult(result), nil, nil
+}
+
+func handleTeamWidgetSeeRendered(ctx context.Context, req *mcp.CallToolRequest, args TeamWidgetReadArgs) (*mcp.CallToolResult, any, error) {
+	return handleTeamWidgetRead(ctx, req, args)
+}
+
+func handleTeamWidgetUpsert(ctx context.Context, _ *mcp.CallToolRequest, args TeamWidgetUpsertArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	surfaceID := strings.TrimSpace(args.SurfaceID)
+	if surfaceID == "" {
+		return toolError(fmt.Errorf("surface_id is required")), nil, nil
+	}
+	if strings.TrimSpace(args.Title) == "" || strings.TrimSpace(args.Kind) == "" || strings.TrimSpace(args.Source) == "" {
+		return toolError(fmt.Errorf("title, kind, and source are required")), nil, nil
+	}
+	body := map[string]any{
+		"my_slug": slug,
+		"actor":   slug,
+		"widget": map[string]any{
+			"id":          strings.TrimSpace(args.WidgetID),
+			"title":       strings.TrimSpace(args.Title),
+			"description": strings.TrimSpace(args.Description),
+			"kind":        strings.TrimSpace(args.Kind),
+			"source":      args.Source,
+			"created_by":  slug,
+			"updated_by":  slug,
+		},
+	}
+	var result map[string]any
+	if err := brokerPostJSON(ctx, "/surfaces/"+url.PathEscape(surfaceID)+"/widgets", body, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return jsonTextResult(result), nil, nil
+}
+
+func handleTeamWidgetPatch(ctx context.Context, _ *mcp.CallToolRequest, args TeamWidgetPatchArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	surfaceID := strings.TrimSpace(args.SurfaceID)
+	widgetID := strings.TrimSpace(args.WidgetID)
+	if surfaceID == "" || widgetID == "" {
+		return toolError(fmt.Errorf("surface_id and widget_id are required")), nil, nil
+	}
+	if strings.TrimSpace(args.Replacement) == "" {
+		return toolError(fmt.Errorf("replacement is required")), nil, nil
+	}
+	body := map[string]any{
+		"actor":       slug,
+		"mode":        strings.TrimSpace(args.Mode),
+		"start_line":  args.StartLine,
+		"end_line":    args.EndLine,
+		"search":      args.Search,
+		"replacement": args.Replacement,
+	}
+	var result map[string]any
+	path := "/surfaces/" + url.PathEscape(surfaceID) + "/widgets/" + url.PathEscape(widgetID)
+	if err := brokerDoJSON(ctx, http.MethodPatch, path, body, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return jsonTextResult(result), nil, nil
+}
+
+func handleTeamWidgetRenderCheck(ctx context.Context, _ *mcp.CallToolRequest, args TeamWidgetRenderCheckArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	surfaceID := strings.TrimSpace(args.SurfaceID)
+	widgetID := strings.TrimSpace(args.WidgetID)
+	if surfaceID == "" || widgetID == "" {
+		return toolError(fmt.Errorf("surface_id and widget_id are required")), nil, nil
+	}
+	body := map[string]any{"my_slug": slug, "actor": slug}
+	if strings.TrimSpace(args.Source) != "" {
+		body["widget"] = map[string]any{
+			"id":     widgetID,
+			"title":  strings.TrimSpace(args.Title),
+			"kind":   strings.TrimSpace(args.Kind),
+			"source": args.Source,
+		}
+	}
+	var result map[string]any
+	path := "/surfaces/" + url.PathEscape(surfaceID) + "/widgets/" + url.PathEscape(widgetID) + "/render-check"
+	if err := brokerPostJSON(ctx, path, body, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return jsonTextResult(result), nil, nil
+}
+
+func handleTeamSurfacePublishUpdate(ctx context.Context, _ *mcp.CallToolRequest, args TeamSurfacePublishUpdateArgs) (*mcp.CallToolResult, any, error) {
+	slug, err := resolveSlug(args.MySlug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	if strings.TrimSpace(args.Content) == "" {
+		return toolError(fmt.Errorf("content is required")), nil, nil
+	}
+	path, err := surfacePathWithSlug(args.SurfaceID, slug)
+	if err != nil {
+		return toolError(err), nil, nil
+	}
+	var surface struct {
+		Surface struct {
+			Channel string `json:"channel"`
+			Title   string `json:"title"`
+		} `json:"surface"`
+	}
+	if err := brokerGetJSON(ctx, path, &surface); err != nil {
+		return toolError(err), nil, nil
+	}
+	content := strings.TrimSpace(args.Content) + "\n\nOpen Studio: #/apps/studio"
+	var result map[string]any
+	if err := brokerPostJSON(ctx, "/messages", map[string]any{
+		"from":    slug,
+		"channel": surface.Surface.Channel,
+		"kind":    "status",
+		"title":   surface.Surface.Title,
+		"content": content,
+	}, &result); err != nil {
+		return toolError(err), nil, nil
+	}
+	return jsonTextResult(result), nil, nil
+}
+
+func surfacePathWithSlug(surfaceID, slugInput string) (string, error) {
+	slug, err := resolveSlug(slugInput)
+	if err != nil {
+		return "", err
+	}
+	surfaceID = strings.TrimSpace(surfaceID)
+	if surfaceID == "" {
+		return "", fmt.Errorf("surface_id is required")
+	}
+	return "/surfaces/" + url.PathEscape(surfaceID) + "?viewer_slug=" + url.QueryEscape(slug), nil
+}
+
+func widgetPathWithSlug(surfaceID, widgetID, slugInput string) (string, error) {
+	slug, err := resolveSlug(slugInput)
+	if err != nil {
+		return "", err
+	}
+	surfaceID = strings.TrimSpace(surfaceID)
+	widgetID = strings.TrimSpace(widgetID)
+	if surfaceID == "" || widgetID == "" {
+		return "", fmt.Errorf("surface_id and widget_id are required")
+	}
+	return "/surfaces/" + url.PathEscape(surfaceID) + "/widgets/" + url.PathEscape(widgetID) + "?viewer_slug=" + url.QueryEscape(slug), nil
+}
+
+func jsonTextResult(value any) *mcp.CallToolResult {
+	payload, _ := json.Marshal(value)
+	return textResult(string(payload))
+}
+
+func brokerDoJSON(ctx context.Context, method, path string, body any, out any) error {
+	data, err := json.Marshal(body)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, brokerBaseURL()+path, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header = authHeaders()
+	req.Header.Set("Content-Type", "application/json")
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(res.Body, 4096))
+		return fmt.Errorf("broker %s %s failed: %s %s", method, path, res.Status, strings.TrimSpace(string(respBody)))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(res.Body).Decode(out)
+}

--- a/internal/teammcp/surface_tools_test.go
+++ b/internal/teammcp/surface_tools_test.go
@@ -1,0 +1,67 @@
+package teammcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestSurfaceToolsRegisteredInOfficeMode(t *testing.T) {
+	names := listRegisteredTools(t, "general", false)
+	for _, want := range []string{
+		"team_surface_list",
+		"team_surface_create",
+		"team_widget_read",
+		"team_widget_upsert",
+		"team_widget_patch",
+		"team_widget_render_check",
+	} {
+		if !slices.Contains(names, want) {
+			t.Fatalf("expected %s registered; got %v", want, names)
+		}
+	}
+}
+
+func TestHandleTeamWidgetPatchSendsBoundedPatch(t *testing.T) {
+	srv, auth := stubBroker(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch {
+			t.Fatalf("method=%s, want PATCH", r.Method)
+		}
+		if r.URL.Path != "/surfaces/launch/widgets/notes" {
+			t.Fatalf("path=%s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"widget": map[string]any{"id": "notes"},
+			"render": map[string]any{"schema_ok": true, "render_ok": true},
+		})
+	})
+	defer srv.Close()
+	withBrokerURL(t, srv.URL)
+	t.Setenv("WUPHF_AGENT_SLUG", "pm")
+
+	res, _, err := handleTeamWidgetPatch(context.Background(), nil, TeamWidgetPatchArgs{
+		SurfaceID:   "launch",
+		WidgetID:    "notes",
+		Mode:        "snippet",
+		Search:      "old",
+		Replacement: "new",
+	})
+	if err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	if isToolError(res) {
+		t.Fatalf("unexpected tool error: %s", toolErrorText(res))
+	}
+	if !strings.Contains(auth.lastAuth, "Bearer test-token") {
+		t.Fatalf("missing auth header: %q", auth.lastAuth)
+	}
+	if !strings.Contains(auth.lastBody, `"actor":"pm"`) {
+		t.Fatalf("expected actor in body, got %s", auth.lastBody)
+	}
+	if !strings.Contains(auth.lastBody, `"search":"old"`) || !strings.Contains(auth.lastBody, `"replacement":"new"`) {
+		t.Fatalf("expected snippet patch body, got %s", auth.lastBody)
+	}
+}

--- a/web/e2e/run-local.sh
+++ b/web/e2e/run-local.sh
@@ -158,9 +158,9 @@ run_shell_phase() {
 {"version":1,"completed_at":"2026-01-01T00:00:00Z","company_name":"e2e-local"}
 EOF
   start_wuphf "shell"
-  # Shell-phase specs: post-onboarding UI surfaces (smoke, settings).
+  # Shell-phase specs: post-onboarding UI surfaces (smoke, settings, studio).
   echo "[run-local] running shell-phase specs"
-  (cd web/e2e && WUPHF_E2E_BASE_URL="http://localhost:${web_port}" bunx playwright test tests/smoke.spec.ts tests/local-llm-settings.spec.ts)
+  (cd web/e2e && WUPHF_E2E_BASE_URL="http://localhost:${web_port}" bunx playwright test tests/smoke.spec.ts tests/local-llm-settings.spec.ts tests/studio.spec.ts)
   stop_wuphf
 }
 

--- a/web/e2e/tests/studio.spec.ts
+++ b/web/e2e/tests/studio.spec.ts
@@ -1,0 +1,38 @@
+import { expect, type Page, test } from "@playwright/test";
+
+async function waitForReactMount(page: Page) {
+  await page.waitForFunction(
+    () => {
+      const root = document.getElementById("root");
+      if (!root) return false;
+      if (document.getElementById("skeleton")) return false;
+      return root.children.length > 0;
+    },
+    { timeout: 10_000 },
+  );
+}
+
+test.describe("Studio app", () => {
+  test("loads the workspace route and creates a channel-bound surface", async ({
+    page,
+  }) => {
+    const requested: string[] = [];
+    page.on("request", (req) => requested.push(req.url()));
+
+    await page.goto("/#/apps/studio");
+    await waitForReactMount(page);
+
+    await expect(page.getByTestId("studio-app")).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByRole("button", { name: /New surface/i }).click();
+
+    await expect(page.getByText(/command center/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("error-boundary")).toHaveCount(0);
+    expect(requested.some((url) => url.includes("/surfaces/stream"))).toBe(
+      false,
+    );
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import { ReceiptsApp } from "./components/apps/ReceiptsApp";
 import { RequestsApp } from "./components/apps/RequestsApp";
 import { SettingsApp } from "./components/apps/SettingsApp";
 import { SkillsApp } from "./components/apps/SkillsApp";
+import { StudioApp } from "./components/apps/StudioApp";
 import { TasksApp } from "./components/apps/TasksApp";
 import { ThreadsApp } from "./components/apps/ThreadsApp";
 import { Shell } from "./components/layout/Shell";
@@ -48,6 +49,7 @@ import "./styles/agents.css";
 import "./styles/search.css";
 import "./styles/wiki-shell.css";
 import "./styles/kbd.css";
+import "./styles/studio.css";
 
 // ── Error boundary ─────────────────────────────────────────────
 
@@ -232,6 +234,7 @@ function MainContent() {
 
   if (currentApp) {
     const panels: Record<string, ComponentType> = {
+      studio: StudioApp,
       tasks: TasksApp,
       requests: RequestsApp,
       graph: GraphApp,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -119,6 +119,22 @@ export async function put<T = unknown>(
   return r.json();
 }
 
+export async function patch<T = unknown>(
+  path: string,
+  body?: unknown,
+): Promise<T> {
+  const r = await fetch(baseURL() + path, {
+    method: "PATCH",
+    headers: authHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) {
+    const text = (await r.text().catch(() => "")).trim();
+    throw new Error(text || `${r.status} ${r.statusText}`);
+  }
+  return r.json();
+}
+
 export async function postWithTimeout<T = unknown>(
   path: string,
   body: unknown,

--- a/web/src/api/surfaces.test.ts
+++ b/web/src/api/surfaces.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as client from "./client";
+import {
+  createSurface,
+  listSurfaces,
+  patchWidget,
+  subscribeSurfaceEvents,
+} from "./surfaces";
+
+describe("surfaces API", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("listSurfaces passes the human viewer slug", async () => {
+    const getSpy = vi
+      .spyOn(client, "get")
+      .mockResolvedValue({ surfaces: [] });
+
+    await listSurfaces();
+
+    expect(getSpy).toHaveBeenCalledWith("/surfaces", {
+      viewer_slug: "human",
+    });
+  });
+
+  it("createSurface writes through the broker surfaces endpoint", async () => {
+    const postSpy = vi
+      .spyOn(client, "post")
+      .mockResolvedValue({ surface: { id: "launch" } });
+
+    await createSurface({ title: "Launch", channel: "general" });
+
+    expect(postSpy).toHaveBeenCalledWith("/surfaces", {
+      title: "Launch",
+      channel: "general",
+      created_by: "human",
+      my_slug: "human",
+    });
+  });
+
+  it("patchWidget sends a bounded PATCH body", async () => {
+    const patchSpy = vi
+      .spyOn(client, "patch")
+      .mockResolvedValue({ widget: { id: "notes" } });
+
+    await patchWidget("launch", "notes", {
+      mode: "snippet",
+      search: "old",
+      replacement: "new",
+    });
+
+    expect(patchSpy).toHaveBeenCalledWith("/surfaces/launch/widgets/notes", {
+      mode: "snippet",
+      search: "old",
+      replacement: "new",
+      actor: "human",
+    });
+  });
+});
+
+describe("subscribeSurfaceEvents", () => {
+  const originalEventSource = globalThis.EventSource;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    (globalThis as { EventSource?: unknown }).EventSource = originalEventSource;
+  });
+
+  it("returns a no-op when EventSource is unavailable", () => {
+    (globalThis as { EventSource?: unknown }).EventSource = undefined;
+    const unsub = subscribeSurfaceEvents(() => {});
+    expect(typeof unsub).toBe("function");
+    unsub();
+  });
+
+  it("opens /events and listens for named surface events", () => {
+    type Listener = (ev: MessageEvent) => void;
+    const listeners: Record<string, Listener[]> = {};
+    const close = vi.fn();
+    let createdURL = "";
+    class FakeES {
+      constructor(url: string) {
+        createdURL = url;
+      }
+      addEventListener(name: string, cb: Listener) {
+        (listeners[name] ??= []).push(cb);
+      }
+      removeEventListener(name: string, cb: Listener) {
+        listeners[name] = (listeners[name] ?? []).filter((l) => l !== cb);
+      }
+      close = close;
+    }
+    (globalThis as { EventSource?: unknown }).EventSource = FakeES;
+
+    const hits: unknown[] = [];
+    const unsub = subscribeSurfaceEvents((event) => hits.push(event));
+
+    expect(createdURL).toMatch(/\/events(\?|$)/);
+    expect(createdURL).not.toContain("/surfaces/stream");
+
+    listeners["surface:widget_updated"][0](
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          type: "surface:widget_updated",
+          surface_id: "launch",
+          widget_id: "notes",
+          channel: "general",
+          created_at: "2026-04-30T00:00:00Z",
+        }),
+      }),
+    );
+    listeners["surface:widget_updated"][0](
+      new MessageEvent("message", { data: "{not-json" }),
+    );
+
+    expect(hits).toHaveLength(1);
+    unsub();
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/web/src/api/surfaces.ts
+++ b/web/src/api/surfaces.ts
@@ -1,0 +1,183 @@
+import { get, patch, post, sseURL } from "./client";
+
+export interface SurfaceManifest {
+  id: string;
+  title: string;
+  channel: string;
+  owner?: string;
+  created_by?: string;
+  created_at: string;
+  updated_at: string;
+  widget_count?: number;
+}
+
+export interface SurfaceHistoryEntry {
+  id: string;
+  surface_id: string;
+  widget_id?: string;
+  kind: string;
+  actor?: string;
+  summary?: string;
+  created_at: string;
+}
+
+export interface NumberedLine {
+  number: number;
+  text: string;
+}
+
+export interface NormalizedWidget {
+  id: string;
+  title: string;
+  description?: string;
+  kind: "checklist" | "table" | "markdown" | string;
+  schema_version: string;
+  checklist?: Array<{ id?: string; label: string; checked: boolean }>;
+  table?: {
+    columns: Array<{ key: string; label: string }>;
+    rows: Array<Record<string, string>>;
+  };
+  markdown?: string;
+}
+
+export interface WidgetRenderResult {
+  schema_ok: boolean;
+  render_ok: boolean;
+  normalized_widget?: NormalizedWidget;
+  preview_text?: string;
+  errors?: string[];
+}
+
+export interface SurfaceWidget {
+  id: string;
+  title: string;
+  description?: string;
+  kind: string;
+  schema_version?: string;
+  source: string;
+  created_by?: string;
+  updated_by?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface SurfaceWidgetRecord {
+  widget: SurfaceWidget;
+  source_lines: NumberedLine[];
+  render: WidgetRenderResult;
+}
+
+export interface SurfaceDetail {
+  surface: SurfaceManifest;
+  widgets: SurfaceWidgetRecord[];
+  history?: SurfaceHistoryEntry[];
+}
+
+export interface SurfaceEvent {
+  type: string;
+  surface_id: string;
+  widget_id?: string;
+  channel: string;
+  actor?: string;
+  title?: string;
+  created_at: string;
+}
+
+export function listSurfaces() {
+  return get<{ surfaces: SurfaceManifest[] }>("/surfaces", {
+    viewer_slug: "human",
+  });
+}
+
+export function readSurface(surfaceId: string) {
+  return get<SurfaceDetail>(`/surfaces/${encodeURIComponent(surfaceId)}`, {
+    viewer_slug: "human",
+  });
+}
+
+export function createSurface(input: {
+  title: string;
+  channel: string;
+  id?: string;
+}) {
+  return post<{ surface: SurfaceManifest }>("/surfaces", {
+    ...input,
+    created_by: "human",
+    my_slug: "human",
+  });
+}
+
+export function upsertWidget(surfaceId: string, widget: Partial<SurfaceWidget>) {
+  return post<SurfaceWidgetRecord>(
+    `/surfaces/${encodeURIComponent(surfaceId)}/widgets`,
+    {
+      my_slug: "human",
+      actor: "human",
+      widget,
+    },
+  );
+}
+
+export function patchWidget(
+  surfaceId: string,
+  widgetId: string,
+  patchBody: {
+    mode?: "line" | "snippet";
+    start_line?: number;
+    end_line?: number;
+    search?: string;
+    replacement: string;
+  },
+) {
+  return patch<SurfaceWidgetRecord>(
+    `/surfaces/${encodeURIComponent(surfaceId)}/widgets/${encodeURIComponent(widgetId)}`,
+    { ...patchBody, actor: "human" },
+  );
+}
+
+export function renderCheck(
+  surfaceId: string,
+  widgetId: string,
+  widget?: Partial<SurfaceWidget>,
+) {
+  return post<WidgetRenderResult>(
+    `/surfaces/${encodeURIComponent(surfaceId)}/widgets/${encodeURIComponent(widgetId)}/render-check`,
+    {
+      my_slug: "human",
+      actor: "human",
+      widget,
+    },
+  );
+}
+
+export function subscribeSurfaceEvents(handler: (event: SurfaceEvent) => void) {
+  const ES = (globalThis as { EventSource?: typeof EventSource }).EventSource;
+  if (!ES) return () => {};
+  const source = new ES(sseURL("/events"));
+  const names = [
+    "surface:created",
+    "surface:updated",
+    "surface:deleted",
+    "surface:widget_created",
+    "surface:widget_updated",
+    "surface:render_checked",
+  ];
+  const listeners = names.map((name) => {
+    const listener = (event: Event) => {
+      if (!("data" in event) || typeof event.data !== "string") return;
+      try {
+        handler(JSON.parse(event.data) as SurfaceEvent);
+      } catch {
+        // Ignore malformed event payloads. EventSource will keep reconnecting.
+      }
+    };
+    source.addEventListener(name, listener);
+    return [name, listener] as const;
+  });
+  return () => {
+    for (const [name, listener] of listeners) {
+      source.removeEventListener(name, listener);
+    }
+    source.close();
+  };
+}

--- a/web/src/components/apps/StudioApp.test.tsx
+++ b/web/src/components/apps/StudioApp.test.tsx
@@ -1,0 +1,167 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../api/surfaces", () => ({
+  listSurfaces: vi.fn(),
+  readSurface: vi.fn(),
+  createSurface: vi.fn(),
+  subscribeSurfaceEvents: vi.fn(() => vi.fn()),
+}));
+
+import { createSurface, listSurfaces, readSurface } from "../../api/surfaces";
+import { useAppStore } from "../../stores/app";
+import { StudioApp } from "./StudioApp";
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+describe("<StudioApp>", () => {
+  beforeEach(() => {
+    useAppStore.setState({ currentChannel: "general" });
+    vi.mocked(listSurfaces).mockResolvedValue({
+      surfaces: [
+        {
+          id: "launch",
+          title: "Launch command center",
+          channel: "general",
+          created_at: "2026-04-30T00:00:00Z",
+          updated_at: "2026-04-30T00:00:00Z",
+          widget_count: 2,
+        },
+      ],
+    });
+    vi.mocked(readSurface).mockResolvedValue({
+      surface: {
+        id: "launch",
+        title: "Launch command center",
+        channel: "general",
+        created_at: "2026-04-30T00:00:00Z",
+        updated_at: "2026-04-30T00:00:00Z",
+        widget_count: 2,
+      },
+      widgets: [
+        {
+          widget: {
+            id: "checklist",
+            title: "Open blockers",
+            kind: "checklist",
+            source: "kind: checklist\nitems: []\n",
+          },
+          source_lines: [
+            { number: 1, text: "kind: checklist" },
+            { number: 2, text: "items: []" },
+          ],
+          render: {
+            schema_ok: true,
+            render_ok: true,
+            preview_text: "[ ] Call customer",
+            normalized_widget: {
+              id: "checklist",
+              title: "Open blockers",
+              kind: "checklist",
+              schema_version: "surface.widget.v1",
+              checklist: [
+                { id: "customer", label: "Call customer", checked: false },
+              ],
+            },
+          },
+        },
+        {
+          widget: {
+            id: "notes",
+            title: "Notes",
+            kind: "markdown",
+            source: "kind: markdown\nmarkdown: Ship it.\n",
+          },
+          source_lines: [
+            { number: 1, text: "kind: markdown" },
+            { number: 2, text: "markdown: Ship it." },
+          ],
+          render: {
+            schema_ok: true,
+            render_ok: true,
+            preview_text: "Ship it.",
+            normalized_widget: {
+              id: "notes",
+              title: "Notes",
+              kind: "markdown",
+              schema_version: "surface.widget.v1",
+              markdown: "Ship it.",
+            },
+          },
+        },
+      ],
+      history: [
+        {
+          id: "history-1",
+          surface_id: "launch",
+          widget_id: "checklist",
+          kind: "widget_updated",
+          actor: "CEO",
+          summary: "Updated Open blockers.",
+          created_at: "2026-04-30T00:00:00Z",
+        },
+      ],
+    });
+    vi.mocked(createSurface).mockResolvedValue({
+      surface: {
+        id: "general-command-center-2",
+        title: "general command center 2",
+        channel: "general",
+        created_at: "2026-04-30T00:00:00Z",
+        updated_at: "2026-04-30T00:00:00Z",
+      },
+    });
+  });
+
+  it("renders the workspace, widgets, and numbered source inspector", async () => {
+    render(wrap(<StudioApp />));
+
+    await waitFor(() =>
+      expect(screen.getByText("Open blockers")).toBeInTheDocument(),
+    );
+    expect(screen.getAllByText("Launch command center").length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByText("Call customer")).toBeInTheDocument();
+    expect(screen.getByText("kind: checklist")).toBeInTheDocument();
+    expect(screen.getByText("Recent activity")).toBeInTheDocument();
+    expect(screen.getByText("Updated Open blockers.")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("creates the next available command-center title for repeat clicks", async () => {
+    vi.mocked(listSurfaces).mockResolvedValue({
+      surfaces: [
+        {
+          id: "general-command-center",
+          title: "general command center",
+          channel: "general",
+          created_at: "2026-04-30T00:00:00Z",
+          updated_at: "2026-04-30T00:00:00Z",
+          widget_count: 0,
+        },
+      ],
+    });
+
+    render(wrap(<StudioApp />));
+
+    await waitFor(() =>
+      expect(screen.getByText("general command center")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /New surface/i }));
+
+    await waitFor(() =>
+      expect(createSurface).toHaveBeenCalledWith({
+        title: "general command center 2",
+        channel: "general",
+      }),
+    );
+  });
+});

--- a/web/src/components/apps/StudioApp.tsx
+++ b/web/src/components/apps/StudioApp.tsx
@@ -1,0 +1,503 @@
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CheckCircle,
+  Code,
+  Component,
+  Eye,
+  Page,
+  PlusCircle,
+  Refresh,
+  TableRows,
+  TaskList,
+  TextSquare,
+  WarningTriangle,
+} from "iconoir-react";
+
+import {
+  createSurface,
+  listSurfaces,
+  readSurface,
+  subscribeSurfaceEvents,
+  type NormalizedWidget,
+  type SurfaceHistoryEntry,
+  type SurfaceWidgetRecord,
+} from "../../api/surfaces";
+import { formatRelativeTime } from "../../lib/format";
+import { useAppStore } from "../../stores/app";
+import { showNotice } from "../ui/Toast";
+
+export function StudioApp() {
+  const currentChannel = useAppStore((s) => s.currentChannel);
+  const queryClient = useQueryClient();
+  const [selectedSurfaceId, setSelectedSurfaceId] = useState<string | null>(
+    null,
+  );
+  const [selectedWidgetId, setSelectedWidgetId] = useState<string | null>(null);
+
+  const surfacesQuery = useQuery({
+    queryKey: ["surfaces"],
+    queryFn: listSurfaces,
+    refetchInterval: 15_000,
+  });
+
+  const surfaces = surfacesQuery.data?.surfaces ?? [];
+
+  useEffect(() => {
+    if (selectedSurfaceId && surfaces.some((s) => s.id === selectedSurfaceId)) {
+      return;
+    }
+    const channelMatch = surfaces.find((s) => s.channel === currentChannel);
+    setSelectedSurfaceId(channelMatch?.id ?? surfaces[0]?.id ?? null);
+  }, [currentChannel, selectedSurfaceId, surfaces]);
+
+  const detailQuery = useQuery({
+    queryKey: ["surface-detail", selectedSurfaceId],
+    queryFn: () => readSurface(selectedSurfaceId ?? ""),
+    enabled: selectedSurfaceId !== null,
+  });
+
+  const detail = detailQuery.data ?? null;
+  const widgets = detail?.widgets ?? [];
+
+  useEffect(() => {
+    if (selectedWidgetId && widgets.some((w) => w.widget.id === selectedWidgetId))
+      return;
+    setSelectedWidgetId(widgets[0]?.widget.id ?? null);
+  }, [selectedWidgetId, widgets]);
+
+  useEffect(() => {
+    return subscribeSurfaceEvents((event) => {
+      if (event.type === "surface:created" || event.type === "surface:deleted") {
+        void queryClient.invalidateQueries({ queryKey: ["surfaces"] });
+      }
+      if (event.type === "surface:updated") {
+        void queryClient.invalidateQueries({ queryKey: ["surfaces"] });
+        if (event.surface_id === selectedSurfaceId) {
+          void queryClient.invalidateQueries({ queryKey: ["surface-detail", event.surface_id] });
+        }
+      }
+      if (
+        (event.type === "surface:widget_created" ||
+          event.type === "surface:widget_updated" ||
+          event.type === "surface:render_checked") &&
+        event.surface_id === selectedSurfaceId
+      ) {
+        void queryClient.invalidateQueries({ queryKey: ["surface-detail", event.surface_id] });
+      }
+    });
+  }, [queryClient, selectedSurfaceId]);
+
+  const selectedWidget = useMemo(
+    () => widgets.find((w) => w.widget.id === selectedWidgetId) ?? null,
+    [selectedWidgetId, widgets],
+  );
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createSurface({
+        title: nextSurfaceTitle(currentChannel || "general", surfaces),
+        channel: currentChannel || "general",
+      }),
+    onSuccess: async (result) => {
+      setSelectedSurfaceId(result.surface.id);
+      await queryClient.invalidateQueries({ queryKey: ["surfaces"] });
+      await queryClient.invalidateQueries({ queryKey: ["messages"] });
+    },
+    onError: (err: Error) => showNotice(err.message, "error"),
+  });
+
+  return (
+    <div className="studio-surface" data-testid="studio-app">
+      <header className="studio-toolbar">
+        <div className="studio-toolbar-title">
+          <Component />
+          <div>
+            <h1>Studio</h1>
+            <span>Artifact room for #{currentChannel || "general"}</span>
+          </div>
+        </div>
+        <div className="studio-toolbar-actions">
+          <button
+            type="button"
+            className="studio-icon-button"
+            aria-label="Refresh Studio"
+            title="Refresh"
+            onClick={() => {
+              void queryClient.invalidateQueries({ queryKey: ["surfaces"] });
+              void queryClient.invalidateQueries({
+                queryKey: ["surface-detail"],
+              });
+            }}
+          >
+            <Refresh />
+          </button>
+          <button
+            type="button"
+            className="studio-command-button"
+            onClick={() => createMutation.mutate()}
+            disabled={createMutation.isPending}
+          >
+            <PlusCircle />
+            <span>{createMutation.isPending ? "Creating" : "New surface"}</span>
+          </button>
+        </div>
+      </header>
+
+      <div className="studio-grid">
+        <aside className="studio-list" aria-label="Surfaces">
+          <div className="studio-panel-head">
+            <div>
+              <h2>Surfaces</h2>
+              <span>
+                {surfaces.length} {pluralize(surfaces.length, "room")}
+              </span>
+            </div>
+          </div>
+          {surfacesQuery.isLoading && <div className="studio-muted">Loading...</div>}
+          {surfacesQuery.error && (
+            <div className="studio-error">Could not load surfaces.</div>
+          )}
+          {!surfacesQuery.isLoading && surfaces.length === 0 && (
+            <StudioEmptyState
+              icon={<Component />}
+              title="No surfaces yet."
+              copy="The conference room is booked, allegedly."
+            />
+          )}
+          {surfaces.map((surface) => (
+            <button
+              type="button"
+              key={surface.id}
+              className={`studio-list-item${
+                surface.id === selectedSurfaceId ? " is-active" : ""
+              }`}
+              onClick={() => setSelectedSurfaceId(surface.id)}
+            >
+              <span className="studio-list-title">{surface.title}</span>
+              <span className="studio-list-meta">
+                #{surface.channel} / {surface.widget_count ?? 0}{" "}
+                {pluralize(surface.widget_count ?? 0, "widget")}
+              </span>
+            </button>
+          ))}
+        </aside>
+
+        <main className="studio-canvas" aria-label="Surface canvas">
+          {detailQuery.isLoading && <div className="studio-muted">Loading...</div>}
+          {detailQuery.error && (
+            <div className="studio-error">Could not load this surface.</div>
+          )}
+          {!detailQuery.isLoading && !detail && (
+            <StudioEmptyState
+              icon={<Page />}
+              title="Select a surface."
+              copy="Pick a room to inspect what the agents left behind."
+            />
+          )}
+          {detail && (
+            <>
+              <div className="studio-surface-header">
+                <div>
+                  <div className="studio-kicker">Studio surface</div>
+                  <h2>{detail.surface.title}</h2>
+                  <span>
+                    #{detail.surface.channel} / updated{" "}
+                    {formatRelativeTime(detail.surface.updated_at)}
+                  </span>
+                </div>
+                <span className="badge badge-accent">
+                  {widgets.length} {pluralize(widgets.length, "widget")}
+                </span>
+              </div>
+
+              <div className="studio-widget-grid">
+                {widgets.length === 0 && (
+                  <StudioEmptyState
+                    icon={<Component />}
+                    title="No widgets yet."
+                    copy="The room has a name. That is currently doing most of the work."
+                  />
+                )}
+                {widgets.map((record) => (
+                  <button
+                    type="button"
+                    key={record.widget.id}
+                    className={`studio-widget-card${
+                      record.widget.id === selectedWidgetId ? " is-selected" : ""
+                    }`}
+                    onClick={() => setSelectedWidgetId(record.widget.id)}
+                  >
+                    <WidgetCard record={record} />
+                  </button>
+                ))}
+              </div>
+
+              <ActivityFeed entries={detail.history ?? []} />
+            </>
+          )}
+        </main>
+
+        <aside className="studio-inspector" aria-label="Widget inspector">
+          <Inspector record={selectedWidget} />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function pluralize(count: number, one: string, many = `${one}s`) {
+  return count === 1 ? one : many;
+}
+
+function nextSurfaceTitle(
+  channel: string,
+  surfaces: Array<{ title: string; channel: string }>,
+) {
+  const base = `${channel} command center`;
+  const taken = new Set(
+    surfaces
+      .filter((surface) => surface.channel === channel)
+      .map((surface) => surface.title),
+  );
+  if (!taken.has(base)) return base;
+  for (let index = 2; ; index += 1) {
+    const candidate = `${base} ${index}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+}
+
+function WidgetCard({ record }: { record: SurfaceWidgetRecord }) {
+  const normalized = record.render.normalized_widget;
+  const hasError =
+    record.render.errors && record.render.errors.length > 0 && !record.render.render_ok;
+  return (
+    <>
+      <div className="studio-widget-head">
+        <div className="studio-widget-heading">
+          <WidgetKindIcon kind={record.widget.kind} />
+          <div>
+            <div className="studio-widget-title">{record.widget.title}</div>
+            <div className="studio-widget-meta">{record.widget.kind}</div>
+          </div>
+        </div>
+        <span
+          className={`studio-render-pill${hasError ? " is-error" : " is-ok"}`}
+          aria-label={hasError ? "Render has errors" : "Render OK"}
+        >
+          {hasError ? (
+            <WarningTriangle className="studio-widget-status is-error" />
+          ) : (
+            <CheckCircle className="studio-widget-status" />
+          )}
+        </span>
+      </div>
+      {record.widget.description && (
+        <p className="studio-widget-description">{record.widget.description}</p>
+      )}
+      <div className="studio-widget-body">
+        {normalized ? (
+          <NormalizedWidgetView widget={normalized} compact />
+        ) : (
+          <pre className="studio-preview">{record.render.preview_text}</pre>
+        )}
+      </div>
+    </>
+  );
+}
+
+function WidgetKindIcon({ kind }: { kind: string }) {
+  if (kind === "checklist") return <TaskList className="studio-kind-icon" />;
+  if (kind === "table") return <TableRows className="studio-kind-icon" />;
+  if (kind === "markdown") return <TextSquare className="studio-kind-icon" />;
+  return <Component className="studio-kind-icon" />;
+}
+
+function StudioEmptyState({
+  icon,
+  title,
+  copy,
+}: {
+  icon: ReactNode;
+  title: string;
+  copy?: string;
+}) {
+  return (
+    <div className="studio-empty">
+      <div className="studio-empty-icon">{icon}</div>
+      <strong>{title}</strong>
+      {copy && <span>{copy}</span>}
+    </div>
+  );
+}
+
+function ActivityFeed({ entries }: { entries: SurfaceHistoryEntry[] }) {
+  if (entries.length === 0) return null;
+  const visibleEntries = entries.slice(0, 5);
+  return (
+    <section className="studio-activity" aria-label="Recent Studio activity">
+      <div className="studio-activity-head">
+        <h3>Recent activity</h3>
+        <span>
+          {entries.length} {pluralize(entries.length, "receipt")}
+        </span>
+      </div>
+      <div className="studio-activity-list">
+        {visibleEntries.map((entry) => (
+          <div key={entry.id} className="studio-activity-row">
+            <span className="studio-activity-kind">{entry.kind}</span>
+            <span className="studio-activity-summary">
+              {entry.summary || entry.widget_id || entry.surface_id}
+            </span>
+            <span className="studio-activity-time">
+              {formatRelativeTime(entry.created_at)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function NormalizedWidgetView({
+  widget,
+  compact = false,
+}: {
+  widget: NormalizedWidget;
+  compact?: boolean;
+}) {
+  if (widget.kind === "checklist") {
+    return (
+      <ul className="studio-checklist">
+        {(widget.checklist ?? []).map((item) => (
+          <li key={item.id || item.label}>
+            <span
+              className={`studio-check-mark${item.checked ? " is-checked" : ""}`}
+              aria-hidden="true"
+            >
+              {item.checked ? "x" : ""}
+            </span>
+            <span className="studio-check-label">{item.label}</span>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+  if (widget.kind === "table" && widget.table) {
+    if (compact) {
+      const [primary, ...rest] = widget.table.columns;
+      return (
+        <div className="studio-table-summary">
+          {widget.table.rows.length === 0 && (
+            <div className="studio-table-summary-empty">No rows.</div>
+          )}
+          {widget.table.rows.slice(0, 4).map((row, index) => {
+            const secondary = rest
+              .map((column) => row[column.key])
+              .filter(Boolean)
+              .join(" / ");
+            return (
+              <div
+                key={`${index}-${widget.table!.columns.map((c) => row[c.key]).join("|")}`}
+                className="studio-table-summary-row"
+              >
+                <span>{primary ? row[primary.key] : `Row ${index + 1}`}</span>
+                {secondary && <em>{secondary}</em>}
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+    return (
+      <div className="studio-table-wrap">
+        <table className="studio-table">
+          <thead>
+            <tr>
+              {widget.table.columns.map((column) => (
+                <th key={column.key}>{column.label}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {widget.table.rows.length === 0 ? (
+              <tr>
+                <td colSpan={widget.table.columns.length} className="studio-table-empty">
+                  No rows.
+                </td>
+              </tr>
+            ) : (
+              widget.table.rows.map((row, index) => (
+                <tr
+                  key={`${index}-${widget.table!.columns.map((c) => row[c.key]).join("|")}`}
+                >
+                  {widget.table?.columns.map((column) => (
+                    <td key={column.key}>{row[column.key]}</td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+  return <div className="studio-markdown">{widget.markdown}</div>;
+}
+
+function Inspector({ record }: { record: SurfaceWidgetRecord | null }) {
+  if (!record) {
+    return (
+      <StudioEmptyState
+        icon={<Page />}
+        title="No widget selected."
+        copy="Select an artifact to see what it rendered and what wrote it."
+      />
+    );
+  }
+  return (
+    <>
+      <div className="studio-inspector-head">
+        <div>
+          <h2>{record.widget.title}</h2>
+          <span>{record.widget.id}</span>
+        </div>
+        <span className="badge badge-neutral">{record.widget.kind}</span>
+      </div>
+      {record.widget.description && (
+        <p className="studio-inspector-description">{record.widget.description}</p>
+      )}
+
+      {record.render.errors && record.render.errors.length > 0 && (
+        <div className="studio-render-errors">
+          {record.render.errors.map((error) => (
+            <div key={error}>{error}</div>
+          ))}
+        </div>
+      )}
+
+      <section className="studio-inspector-section">
+        <div className="studio-section-heading">
+          <Eye />
+          <h3>Rendered preview</h3>
+        </div>
+        <pre className="studio-preview">{record.render.preview_text || ""}</pre>
+      </section>
+
+      <section className="studio-inspector-section">
+        <div className="studio-section-heading">
+          <Code />
+          <h3>Source</h3>
+        </div>
+        <div className="studio-source">
+          {record.source_lines.map((line) => (
+            <div key={line.number} className="studio-source-line">
+              <span>{line.number}</span>
+              <code>{line.text || " "}</code>
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Settings as SettingsIcon, SidebarCollapse } from "iconoir-react";
 
 import { useAppStore } from "../../stores/app";
@@ -55,11 +56,23 @@ export function Sidebar() {
   const toggleSidebarApps = useAppStore((s) => s.toggleSidebarApps);
   const sidebarCollapsed = useAppStore((s) => s.sidebarCollapsed);
   const toggleSidebarCollapsed = useAppStore((s) => s.toggleSidebarCollapsed);
+  const setSidebarCollapsed = useAppStore((s) => s.setSidebarCollapsed);
   const sidebarBg = useAppStore((s) => s.sidebarBg);
   const currentApp = useAppStore((s) => s.currentApp);
   const setCurrentApp = useAppStore((s) => s.setCurrentApp);
 
   const asideStyle = sidebarBg ? { background: sidebarBg } : undefined;
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const query = window.matchMedia("(max-width: 768px)");
+    const collapseForMobile = () => {
+      if (query.matches) setSidebarCollapsed(true);
+    };
+    collapseForMobile();
+    query.addEventListener("change", collapseForMobile);
+    return () => query.removeEventListener("change", collapseForMobile);
+  }, [setSidebarCollapsed]);
 
   return (
     <aside

--- a/web/src/hooks/useBrokerEvents.ts
+++ b/web/src/hooks/useBrokerEvents.ts
@@ -58,6 +58,19 @@ export function useBrokerEvents(enabled: boolean) {
       void queryClient.invalidateQueries({ queryKey: ["actions"] });
       void queryClient.invalidateQueries({ queryKey: ["office-tasks"] });
     });
+    for (const eventName of [
+      "surface:created",
+      "surface:updated",
+      "surface:deleted",
+      "surface:widget_created",
+      "surface:widget_updated",
+      "surface:render_checked",
+    ]) {
+      source.addEventListener(eventName, () => {
+        void queryClient.invalidateQueries({ queryKey: ["surfaces"] });
+        void queryClient.invalidateQueries({ queryKey: ["surface-detail"] });
+      });
+    }
     source.onerror = () => setBrokerConnected(false);
 
     return () => {

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -3,6 +3,7 @@
 // Each surface gets its own tab inside the Wiki app; notebooks/reviews
 // have no top-level sidebar entries of their own.
 export const SIDEBAR_APPS = [
+  { id: "studio", icon: "\u25B6", name: "Studio" },
   { id: "wiki", icon: "\uD83D\uDCD6", name: "Wiki" },
   { id: "tasks", icon: "\u2705", name: "Tasks" },
   { id: "requests", icon: "\uD83D\uDCCB", name: "Requests" },

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -137,6 +137,7 @@ export interface AppStore {
   toggleSidebarApps: () => void;
   sidebarCollapsed: boolean;
   toggleSidebarCollapsed: () => void;
+  setSidebarCollapsed: (collapsed: boolean) => void;
   sidebarBg: string | null;
   setSidebarBg: (color: string | null) => void;
 
@@ -287,6 +288,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   sidebarCollapsed: false,
   toggleSidebarCollapsed: () =>
     set({ sidebarCollapsed: !get().sidebarCollapsed }),
+  setSidebarCollapsed: (collapsed) => set({ sidebarCollapsed: collapsed }),
   sidebarBg: _storedSidebarBg,
   setSidebarBg: (color) => {
     try {

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -1761,8 +1761,11 @@ html[data-theme="nex"]
 
 /* ─── Responsive ─── */
 @media (max-width: 768px) {
-  .sidebar {
+  .sidebar:not(.sidebar-collapsed) {
     width: 240px;
+  }
+  .sidebar.sidebar-collapsed {
+    width: 56px;
   }
   .thread-panel {
     width: 100%;

--- a/web/src/styles/studio.css
+++ b/web/src/styles/studio.css
@@ -1,0 +1,676 @@
+.studio-surface {
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.studio-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 12px;
+}
+
+.studio-toolbar-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+.studio-toolbar-title > div,
+.studio-surface-header > div,
+.studio-inspector-head > div,
+.studio-widget-heading > div {
+  min-width: 0;
+}
+
+.studio-toolbar-title svg {
+  width: 22px;
+  height: 22px;
+  color: var(--accent);
+}
+
+.studio-toolbar-title h1,
+.studio-surface-header h2,
+.studio-inspector-head h2,
+.studio-panel-head h2 {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+.studio-toolbar-title span,
+.studio-surface-header span,
+.studio-inspector-head span,
+.studio-widget-meta,
+.studio-list-meta,
+.studio-panel-head span,
+.studio-activity-head span {
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+
+.studio-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.studio-icon-button,
+.studio-command-button {
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  color: var(--text);
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition:
+    background 0.16s ease-out,
+    border-color 0.16s ease-out,
+    color 0.16s ease-out;
+}
+
+.studio-icon-button:hover,
+.studio-command-button:hover {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+}
+
+.studio-icon-button:focus-visible,
+.studio-command-button:focus-visible,
+.studio-list-item:focus-visible,
+.studio-widget-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.studio-icon-button:disabled,
+.studio-command-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.62;
+}
+
+.studio-icon-button {
+  width: 32px;
+  padding: 0;
+}
+
+.studio-command-button {
+  padding: 0 10px;
+  font-size: 13px;
+}
+
+.studio-icon-button svg,
+.studio-command-button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.studio-grid {
+  min-height: 0;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(320px, 1fr) minmax(
+      280px,
+      360px
+    );
+  gap: 12px;
+  flex: 1;
+}
+
+.studio-list,
+.studio-canvas,
+.studio-inspector {
+  min-height: 0;
+  min-width: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  background: var(--bg-card);
+  border-radius: 8px;
+}
+
+.studio-list,
+.studio-inspector {
+  padding: 10px;
+}
+
+.studio-canvas {
+  padding: 14px;
+}
+
+.studio-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.studio-panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 2px 2px 8px;
+  border-bottom: 1px solid var(--border-light);
+}
+
+.studio-list-item,
+.studio-widget-card {
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 6px;
+  transition:
+    background 0.16s ease-out,
+    border-color 0.16s ease-out,
+    box-shadow 0.16s ease-out;
+}
+
+.studio-list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 9px;
+}
+
+.studio-list-item:hover,
+.studio-list-item.is-active {
+  background: var(--bg-warm);
+  border-color: var(--border);
+}
+
+.studio-list-item.is-active {
+  box-shadow: inset 0 0 0 1px var(--accent-bg-strong);
+}
+
+.studio-list-title {
+  font-size: 13px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.studio-kicker {
+  margin-bottom: 4px;
+  color: var(--accent);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.studio-surface-header .badge-accent {
+  color: var(--olive-500);
+}
+
+.studio-inspector-head .badge-neutral {
+  color: var(--neutral-600);
+}
+
+.studio-surface-header,
+.studio-inspector-head,
+.studio-widget-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.studio-widget-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.studio-widget-grid > .studio-empty {
+  grid-column: 1 / -1;
+}
+
+.studio-widget-card {
+  min-height: 140px;
+  padding: 12px;
+  background: var(--bg);
+  border-color: var(--border);
+  display: flex;
+  flex-direction: column;
+}
+
+.studio-widget-card:hover,
+.studio-widget-card.is-selected {
+  border-color: var(--accent);
+}
+
+.studio-widget-card.is-selected {
+  background: var(--bg-subtle);
+  box-shadow: 0 0 0 1px var(--accent-bg-strong);
+}
+
+.studio-widget-heading {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  min-width: 0;
+}
+
+.studio-kind-icon {
+  width: 18px;
+  height: 18px;
+  color: var(--accent);
+  flex: 0 0 auto;
+}
+
+.studio-widget-title {
+  font-size: 13px;
+  font-weight: 650;
+  overflow-wrap: anywhere;
+}
+
+.studio-widget-status {
+  width: 14px;
+  height: 14px;
+  color: var(--green);
+  flex: 0 0 auto;
+}
+
+.studio-widget-status.is-error {
+  color: var(--yellow);
+}
+
+.studio-render-pill {
+  width: 24px;
+  height: 24px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.studio-render-pill.is-ok {
+  background: var(--green-bg);
+}
+
+.studio-render-pill.is-error {
+  background: var(--yellow-bg);
+}
+
+.studio-widget-description,
+.studio-inspector-description {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.studio-widget-body {
+  min-width: 0;
+  flex: 1;
+}
+
+.studio-checklist {
+  list-style: none;
+  padding: 0;
+  margin: 12px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.studio-checklist li {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.studio-check-mark {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  color: var(--bg-card);
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.studio-check-mark.is-checked {
+  background: var(--green);
+  border-color: var(--green);
+}
+
+.studio-check-label {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.studio-table-wrap {
+  overflow-x: auto;
+  margin-top: 12px;
+}
+
+.studio-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.studio-widget-card .studio-table {
+  table-layout: fixed;
+  min-width: 0;
+}
+
+.studio-table th,
+.studio-table td {
+  border-bottom: 1px solid var(--border);
+  padding: 6px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.studio-widget-card .studio-table th,
+.studio-widget-card .studio-table td {
+  padding: 5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  word-break: normal;
+  overflow-wrap: anywhere;
+}
+
+.studio-table th {
+  color: var(--text-secondary);
+  font-weight: 650;
+}
+
+.studio-table td.studio-table-empty {
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+.studio-table-summary {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.studio-table-summary-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 0.8fr);
+  gap: 8px;
+  padding: 6px 8px;
+  border-top: 1px solid var(--border-light);
+  font-size: 12px;
+}
+
+.studio-table-summary-row:first-child {
+  border-top: 0;
+}
+
+.studio-table-summary-row span,
+.studio-table-summary-row em {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.studio-table-summary-row span {
+  color: var(--text);
+}
+
+.studio-table-summary-row em {
+  color: var(--text-tertiary);
+  font-style: normal;
+  text-align: right;
+}
+
+.studio-table-summary-empty {
+  padding: 10px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  text-align: center;
+}
+
+.studio-markdown,
+.studio-preview {
+  margin-top: 12px;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.studio-preview {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  overflow-x: auto;
+}
+
+.studio-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.studio-section-heading {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 6px;
+}
+
+.studio-section-heading svg {
+  width: 15px;
+  height: 15px;
+  color: var(--text-tertiary);
+}
+
+.studio-section-heading h3 {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.studio-inspector-section h3 {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.studio-source {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: auto;
+  background: var(--bg);
+  max-height: 360px;
+}
+
+.studio-source-line {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.studio-source-line span {
+  color: var(--text-tertiary);
+  background: var(--bg-warm);
+  border-right: 1px solid var(--border);
+  padding: 2px 8px;
+  text-align: right;
+  user-select: none;
+}
+
+.studio-source-line code {
+  min-width: 0;
+  padding: 2px 8px;
+  white-space: pre;
+}
+
+.studio-activity {
+  margin-top: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.studio-activity-head,
+.studio-activity-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.studio-activity-head {
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.studio-activity-head h3 {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.studio-activity-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.studio-activity-row {
+  padding: 7px 10px;
+  border-top: 1px solid var(--border-light);
+  font-size: 12px;
+}
+
+.studio-activity-row:first-child {
+  border-top: 0;
+}
+
+.studio-activity-kind {
+  color: var(--accent);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  flex: 0 0 auto;
+}
+
+.studio-activity-summary {
+  min-width: 0;
+  flex: 1;
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.studio-activity-time {
+  color: var(--text-tertiary);
+  flex: 0 0 auto;
+}
+
+.studio-render-errors,
+.studio-error {
+  border: 1px solid var(--yellow);
+  background: var(--yellow-bg);
+  color: var(--yellow);
+  border-radius: 6px;
+  padding: 8px;
+  font-size: 12px;
+}
+
+.studio-empty,
+.studio-muted {
+  padding: 18px;
+  color: var(--text-tertiary);
+  font-size: 13px;
+  text-align: center;
+}
+
+.studio-empty {
+  min-height: 132px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 6px;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  background: var(--bg-subtle);
+}
+
+.studio-empty strong {
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+.studio-empty span {
+  max-width: 28ch;
+  line-height: 1.45;
+}
+
+.studio-empty-icon svg {
+  width: 22px;
+  height: 22px;
+  color: var(--accent);
+}
+
+@media (max-width: 980px) {
+  .studio-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .studio-list,
+  .studio-canvas,
+  .studio-inspector {
+    min-height: 220px;
+  }
+}
+
+@media (max-width: 560px) {
+  .studio-toolbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .studio-toolbar-actions {
+    width: 100%;
+  }
+
+  .studio-command-button {
+    flex: 1;
+  }
+
+  .studio-widget-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .studio-surface-header,
+  .studio-inspector-head,
+  .studio-widget-head,
+  .studio-activity-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `SurfaceStore` + `Surface`, `Widget`, `Snippet` types in `internal/team/surfaces.go` with SQLite-backed persistence and SSE publish
- Wires `broker_surfaces.go` broker methods (`TeamSurfaceCreate/Read/List`, `TeamWidgetUpsert/Patch/Read`, `TeamWidgetSeeRendered`) into the Broker
- Exposes full surface MCP tool suite in `internal/teammcp/surface_tools.go` (create, read, list surfaces; upsert, patch, read, render-check, see-rendered widgets)
- Ships `StudioApp.tsx` + `studio.css` React frontend with SSE-powered live widget rendering
- Adds E2E test `studio.spec.ts` and unit tests for broker surface methods, surface store, and surface tools

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/team/ ./internal/teammcp/ -run Surface` — all pass
- [ ] E2E: `studio.spec.ts` — verify widget render round-trip in browser
- [ ] Smoke: open Studio tab in running office, upsert a widget, confirm SSE pushes rendered HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Studio app added to the sidebar for creating, browsing and inspecting surfaces and widgets; includes UI, styles, and render previews.
  * Real-time surface event streaming and client subscriptions; PATCH support for widget updates and render-check endpoints.
  * Sidebar auto-collapses on small screens.

* **Tests**
  * New e2e and unit tests covering Studio flows, surface APIs, widget upsert/patch and event handling.

* **Chores**
  * CI updated to run the new e2e tests.

* **Documentation**
  * New PRODUCT document describing product positioning, voice, design principles and WCAG 2.2 AA accessibility targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->