### PR TITLE
fix(mobile): prevent skill name clipping at 390px viewport

### DIFF
--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -1101,6 +1101,10 @@ html[data-theme="nex"]
   font-size: 13px;
   font-weight: 600;
   margin-bottom: 4px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .app-card-meta {
   font-size: 11px;
@@ -1770,6 +1774,21 @@ html[data-theme="nex"]
     right: 0;
     top: 0;
     z-index: 10;
+  }
+}
+
+/* ─── Narrow mobile (≤430px): sidebar overlays instead of pushing content ─── */
+@media (max-width: 430px) {
+  .sidebar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    height: 100%;
+    z-index: 20;
+  }
+  .main {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
## Summary

- At 390px viewport (iPhone SE / 12 mini), the sidebar's fixed 240px width consumed most of the screen, leaving `.main` with ~150px and causing skill names in `SkillsApp` to clip at the left edge or appear off-screen
- Added `min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap` to `.app-card-title` so skill names truncate cleanly inside their flex container
- Added `@media (max-width: 430px)` that switches `.sidebar` to `position: absolute` (overlay pattern), giving `.main` the full viewport width on narrow phones; sidebar slides on top of content rather than squeezing it

## What was unchanged

- Desktop and tablet layouts (>430px) are unaffected — the sidebar still occupies its fixed column as before
- No new React state introduced; CSS-only change
- `.app-card-title` ellipsis is only visible when the container is genuinely too narrow; at normal widths text renders in full

## Test plan

- [ ] iPhone SE (390px): open Skills app, verify skill names are visible and truncate with ellipsis if long
- [ ] iPhone SE (390px): open sidebar, confirm it overlays content (content behind it is full-width, not squished)
- [ ] Desktop (1280px+): confirm sidebar and skills layout unchanged
- [ ] 768px breakpoint: confirm sidebar is still 240px in column mode (not absolute)
- [ ] Skill cards with short names: confirm no visual regression at any breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved card title display with text truncation to prevent layout overflow
  * Enhanced mobile responsiveness with optimized sidebar behavior for narrow screens
  * Main content now properly adapts to fill available space on mobile devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->