### PR TITLE
feat(scheduler): GET /scheduler/system-specs — remove hardcoded floor map

### DIFF
--- a/internal/team/broker_scheduler.go
+++ b/internal/team/broker_scheduler.go
@@ -566,14 +566,60 @@ func (b *Broker) updateSchedulerHeartbeat(slug, label string, intervalMinutes in
 	_ = b.saveLocked()
 }
 
+// systemCronSpecJSON is the wire shape for a single entry in
+// GET /scheduler/system-specs. It is intentionally flat so callers
+// never need to read systemCronSpec (an internal type) directly.
+type systemCronSpecJSON struct {
+	Slug                   string `json:"slug"`
+	MinFloorMinutes        int    `json:"min_floor_minutes"`
+	DefaultIntervalMinutes int    `json:"default_interval_minutes"`
+	Description            string `json:"description"`
+}
+
+// handleSchedulerSystemSpecs serves GET /scheduler/system-specs.
+// It serialises every entry from systemCronSpecs() so the web UI can
+// derive MinFloor values at runtime instead of maintaining a hardcoded
+// mirror constant. No request body; no auth-specific data — read-only.
+func (b *Broker) handleSchedulerSystemSpecs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	specs := systemCronSpecs()
+	out := make([]systemCronSpecJSON, 0, len(specs))
+	for _, s := range specs {
+		defaultInterval := s.DefaultInterval()
+		if defaultInterval <= 0 {
+			defaultInterval = 1
+		}
+		if s.MinFloor > 0 && defaultInterval < s.MinFloor {
+			defaultInterval = s.MinFloor
+		}
+		out = append(out, systemCronSpecJSON{
+			Slug:                   s.Slug,
+			MinFloorMinutes:        s.MinFloor,
+			DefaultIntervalMinutes: defaultInterval,
+			Description:            s.Label,
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"specs": out})
+}
+
 // handleSchedulerSubpath dispatches /scheduler/{slug} requests. Currently
-// only PATCH is supported (PR 8 Lane G); future verbs (delete, run-now)
-// would land here too.
+// PATCH and the special "system-specs" sub-resource are supported (PR 8
+// Lane G + min-floor-from-api); future verbs (delete, run-now) would land
+// here too.
 func (b *Broker) handleSchedulerSubpath(w http.ResponseWriter, r *http.Request) {
 	slug := strings.TrimPrefix(r.URL.Path, "/scheduler/")
 	slug = strings.TrimSpace(slug)
 	if slug == "" {
 		http.Error(w, "scheduler slug required in path", http.StatusBadRequest)
+		return
+	}
+	// system-specs is a read-only sub-resource, not a per-job path.
+	if slug == "system-specs" {
+		b.handleSchedulerSystemSpecs(w, r)
 		return
 	}
 	switch r.Method {

--- a/internal/team/broker_scheduler.go
+++ b/internal/team/broker_scheduler.go
@@ -402,6 +402,19 @@ type systemCronSpec struct {
 	ReadOnly        bool       // one-relay-events: hardcoded for v1
 }
 
+// resolvedDefaultInterval returns the effective default interval for this
+// spec: at least 1, and never below MinFloor.
+func (s systemCronSpec) resolvedDefaultInterval() int {
+	d := s.DefaultInterval()
+	if d <= 0 {
+		d = 1
+	}
+	if s.MinFloor > 0 && d < s.MinFloor {
+		d = s.MinFloor
+	}
+	return d
+}
+
 // systemCronSpecs is the v1 system cron registry. Order is alphabetical
 // for deterministic startup. Each entry SHOULD be invisible in /scheduler
 // today (or surface only sporadically); registration makes them
@@ -471,13 +484,7 @@ func (b *Broker) registerSystemCrons() {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, spec := range systemCronSpecs() {
-		defaultInterval := spec.DefaultInterval()
-		if defaultInterval <= 0 {
-			defaultInterval = 1
-		}
-		if spec.MinFloor > 0 && defaultInterval < spec.MinFloor {
-			defaultInterval = spec.MinFloor
-		}
+		defaultInterval := spec.resolvedDefaultInterval()
 		// Find existing — preserve user-controlled fields.
 		var existing *schedulerJob
 		for i := range b.scheduler {
@@ -588,17 +595,10 @@ func (b *Broker) handleSchedulerSystemSpecs(w http.ResponseWriter, r *http.Reque
 	specs := systemCronSpecs()
 	out := make([]systemCronSpecJSON, 0, len(specs))
 	for _, s := range specs {
-		defaultInterval := s.DefaultInterval()
-		if defaultInterval <= 0 {
-			defaultInterval = 1
-		}
-		if s.MinFloor > 0 && defaultInterval < s.MinFloor {
-			defaultInterval = s.MinFloor
-		}
 		out = append(out, systemCronSpecJSON{
 			Slug:                   s.Slug,
 			MinFloorMinutes:        s.MinFloor,
-			DefaultIntervalMinutes: defaultInterval,
+			DefaultIntervalMinutes: s.resolvedDefaultInterval(),
 			Description:            s.Label,
 		})
 	}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -731,18 +731,6 @@ export async function getSystemCronSpecs(): Promise<SystemCronSpec[]> {
   return res.specs ?? [];
 }
 
-/**
- * Force-trigger a scheduler job once, immediately. Does not affect the
- * recurring schedule or next_run. Backed by POST /scheduler/{slug}/run (PR 9).
- */
-export async function runSchedulerJob(
-  slug: string,
-): Promise<{ triggered: boolean; slug: string; at: string }> {
-  return post<{ triggered: boolean; slug: string; at: string }>(
-    `/scheduler/${encodeURIComponent(slug)}/run`,
-  );
-}
-
 // ── Skills ──
 
 export type SkillStatus = "active" | "proposed" | "archived" | "disabled";

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -708,6 +708,41 @@ export function patchSchedulerJob(
   );
 }
 
+/**
+ * Wire shape for one entry from GET /scheduler/system-specs.
+ * Mirrors systemCronSpecJSON in internal/team/broker_scheduler.go.
+ */
+export interface SystemCronSpec {
+  slug: string;
+  min_floor_minutes: number;
+  default_interval_minutes: number;
+  description: string;
+}
+
+/**
+ * Fetch the system-cron spec registry from the broker so the UI can
+ * derive per-slug MinFloor values at runtime instead of maintaining a
+ * hardcoded mirror constant.
+ */
+export async function getSystemCronSpecs(): Promise<SystemCronSpec[]> {
+  const res = await get<{ specs: SystemCronSpec[] }>(
+    "/scheduler/system-specs",
+  );
+  return res.specs ?? [];
+}
+
+/**
+ * Force-trigger a scheduler job once, immediately. Does not affect the
+ * recurring schedule or next_run. Backed by POST /scheduler/{slug}/run (PR 9).
+ */
+export async function runSchedulerJob(
+  slug: string,
+): Promise<{ triggered: boolean; slug: string; at: string }> {
+  return post<{ triggered: boolean; slug: string; at: string }>(
+    `/scheduler/${encodeURIComponent(slug)}/run`,
+  );
+}
+
 // ── Skills ──
 
 export type SkillStatus = "active" | "proposed" | "archived" | "disabled";

--- a/web/src/components/apps/SystemSchedulesPanel.test.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.test.tsx
@@ -5,6 +5,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { SchedulerJob } from "../../api/client";
 
+const MOCK_SPECS = [
+  { slug: "nex-insights", min_floor_minutes: 30, default_interval_minutes: 30, description: "Nex insights" },
+  { slug: "task_recheck", min_floor_minutes: 5, default_interval_minutes: 5, description: "Task recheck cadence" },
+];
+
 vi.mock("../../api/client", async () => {
   const actual =
     await vi.importActual<typeof import("../../api/client")>(
@@ -13,8 +18,7 @@ vi.mock("../../api/client", async () => {
   return {
     ...actual,
     patchSchedulerJob: vi.fn(),
-    runSchedulerJob: vi.fn().mockResolvedValue({ triggered: true, slug: "task_recheck", at: new Date().toISOString() }),
-    getSystemCronSpecs: vi.fn().mockResolvedValue([]),
+    getSystemCronSpecs: vi.fn().mockResolvedValue(MOCK_SPECS),
   };
 });
 

--- a/web/src/components/apps/SystemSchedulesPanel.test.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.test.tsx
@@ -13,6 +13,8 @@ vi.mock("../../api/client", async () => {
   return {
     ...actual,
     patchSchedulerJob: vi.fn(),
+    runSchedulerJob: vi.fn().mockResolvedValue({ triggered: true, slug: "task_recheck", at: new Date().toISOString() }),
+    getSystemCronSpecs: vi.fn().mockResolvedValue([]),
   };
 });
 

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -5,7 +5,6 @@ import {
   getSystemCronSpecs,
   type PatchSchedulerJobResponse,
   patchSchedulerJob,
-  runSchedulerJob,
   type SchedulerJob,
 } from "../../api/client";
 import { formatRelativeTime } from "../../lib/format";
@@ -39,8 +38,10 @@ export function SystemSchedulesPanel({ jobs }: SystemSchedulesPanelProps) {
   const floorsRef = useRef<Record<string, number>>({});
 
   useEffect(() => {
+    let aborted = false;
     getSystemCronSpecs()
       .then((specs) => {
+        if (aborted) return;
         const map: Record<string, number> = {};
         for (const s of specs) {
           map[s.slug] = s.min_floor_minutes;
@@ -48,11 +49,15 @@ export function SystemSchedulesPanel({ jobs }: SystemSchedulesPanelProps) {
         floorsRef.current = map;
       })
       .catch((err: unknown) => {
+        if (aborted) return;
         console.warn(
           "SystemSchedulesPanel: could not fetch system-specs; falling back to default floor",
           err,
         );
       });
+    return () => {
+      aborted = true;
+    };
   }, []);
 
   if (rows.length === 0) return null;
@@ -120,7 +125,6 @@ function ScheduleRow({ job, floorsRef }: ScheduleRowProps) {
   );
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
-  const [runPending, setRunPending] = useState(false);
   // Track last server-confirmed values so PATCH failures roll back to the
   // right state rather than the stale mount-time values.
   const committedTextRef = useRef(
@@ -219,20 +223,6 @@ function ScheduleRow({ job, floorsRef }: ScheduleRowProps) {
     submitPatch({ interval_override: parsed === defaultInterval ? 0 : parsed });
   }, [isReadOnly, isCron, overrideText, floor, defaultInterval, submitPatch]);
 
-  const handleRunNow = useCallback(() => {
-    if (!slug || runPending) return;
-    setRunPending(true);
-    runSchedulerJob(slug)
-      .then(() => {
-        queryClient.invalidateQueries({ queryKey: ["scheduler"] });
-        showNotice(`${labelOf(job)} triggered`, "success");
-      })
-      .catch((e: Error) => {
-        showNotice(`Couldn't trigger ${labelOf(job)}: ${e.message}`, "error");
-      })
-      .finally(() => setRunPending(false));
-  }, [slug, runPending, job, queryClient]);
-
   const lastRunChip = describeLastRun(job);
   const nextRunCountdown = describeNextRun(job);
 
@@ -311,27 +301,6 @@ function ScheduleRow({ job, floorsRef }: ScheduleRowProps) {
           onToggle={handleToggle}
           ariaLabel={`${enabled ? "Disable" : "Enable"} ${labelOf(job)}`}
         />
-
-        <button
-          type="button"
-          disabled={runPending}
-          onClick={handleRunNow}
-          aria-label={`Run ${labelOf(job)} now`}
-          style={{
-            padding: "2px 8px",
-            fontSize: 11,
-            fontWeight: 500,
-            background: "transparent",
-            border: "1px solid var(--border)",
-            borderRadius: 4,
-            color: "var(--text-secondary)",
-            cursor: runPending ? "not-allowed" : "pointer",
-            opacity: runPending ? 0.6 : 1,
-            transition: "opacity 0.1s",
-          }}
-        >
-          {runPending ? "…" : "Run now"}
-        </button>
 
         {nextRunCountdown ? (
           <span style={{ marginLeft: "auto" }}>{nextRunCountdown}</span>

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -1,34 +1,15 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { type RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import {
+  getSystemCronSpecs,
   type PatchSchedulerJobResponse,
   patchSchedulerJob,
+  runSchedulerJob,
   type SchedulerJob,
 } from "../../api/client";
 import { formatRelativeTime } from "../../lib/format";
 import { showNotice } from "../ui/Toast";
-
-/**
- * Per-cron interval floors. Source of truth: systemCronSpecs() in
- * internal/team/broker.go (PR 8 Lane G). Mirrored here so the UI can
- * validate before issuing the PATCH and surface a typed error inline
- * instead of relying on a 400 round-trip.
- *
- * Keep in sync when broker MinFloor changes. The non-system fallback
- * floor (5 minutes) matches the server's `floor := 5` default for jobs
- * outside the registry.
- */
-const SYSTEM_CRON_FLOORS_MINUTES: Record<string, number> = {
-  "nex-insights": 30,
-  "nex-notifications": 5,
-  "one-relay-events": 1,
-  request_follow_up: 5,
-  "review-expiry": 5,
-  task_follow_up: 5,
-  task_recheck: 5,
-  task_reminder: 5,
-};
 
 const DEFAULT_FLOOR_MINUTES = 5;
 
@@ -45,11 +26,35 @@ interface SystemSchedulesPanelProps {
  * interval picker, last/next run, and source badge. Inline validation
  * mirrors the backend's MinFloor before allowing a PATCH.
  *
+ * Floors are fetched once on mount from GET /scheduler/system-specs so
+ * they stay in sync with the broker without any hardcoded mirror.
+ *
  * Empty if the broker hasn't surfaced any system or interval crons (test
  * environments before registerSystemCrons runs).
  */
 export function SystemSchedulesPanel({ jobs }: SystemSchedulesPanelProps) {
   const rows = useMemo(() => filterSchedulerRows(jobs), [jobs]);
+  // floors: slug → min_floor_minutes, populated from the API on mount.
+  // Stored in a ref so updates don't trigger a re-render of every row.
+  const floorsRef = useRef<Record<string, number>>({});
+
+  useEffect(() => {
+    getSystemCronSpecs()
+      .then((specs) => {
+        const map: Record<string, number> = {};
+        for (const s of specs) {
+          map[s.slug] = s.min_floor_minutes;
+        }
+        floorsRef.current = map;
+      })
+      .catch((err: unknown) => {
+        console.warn(
+          "SystemSchedulesPanel: could not fetch system-specs; falling back to default floor",
+          err,
+        );
+      });
+  }, []);
+
   if (rows.length === 0) return null;
 
   return (
@@ -67,7 +72,11 @@ export function SystemSchedulesPanel({ jobs }: SystemSchedulesPanelProps) {
         System Schedules
       </div>
       {rows.map((job) => (
-        <ScheduleRow key={job.slug ?? job.id} job={job} />
+        <ScheduleRow
+          key={job.slug ?? job.id}
+          job={job}
+          floorsRef={floorsRef}
+        />
       ))}
     </section>
   );
@@ -90,16 +99,17 @@ function filterSchedulerRows(jobs: SchedulerJob[]): SchedulerJob[] {
 
 interface ScheduleRowProps {
   job: SchedulerJob;
+  floorsRef: RefObject<Record<string, number>>;
 }
 
-function ScheduleRow({ job }: ScheduleRowProps) {
+function ScheduleRow({ job, floorsRef }: ScheduleRowProps) {
   const queryClient = useQueryClient();
   const slug = job.slug ?? "";
   const isReadOnly = READ_ONLY_SLUGS.has(slug);
   const isCron = typeof job.schedule_expr === "string" && job.schedule_expr;
   const isInterval = typeof job.interval_minutes === "number";
 
-  const floor = SYSTEM_CRON_FLOORS_MINUTES[slug] ?? DEFAULT_FLOOR_MINUTES;
+  const floor = floorsRef.current[slug] ?? DEFAULT_FLOOR_MINUTES;
   const defaultInterval = job.interval_minutes ?? 0;
   const initialOverride = job.interval_override ?? 0;
   const initialEnabled = job.enabled !== false; // missing → assume enabled
@@ -110,6 +120,7 @@ function ScheduleRow({ job }: ScheduleRowProps) {
   );
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState(false);
+  const [runPending, setRunPending] = useState(false);
   // Track last server-confirmed values so PATCH failures roll back to the
   // right state rather than the stale mount-time values.
   const committedTextRef = useRef(
@@ -208,6 +219,20 @@ function ScheduleRow({ job }: ScheduleRowProps) {
     submitPatch({ interval_override: parsed === defaultInterval ? 0 : parsed });
   }, [isReadOnly, isCron, overrideText, floor, defaultInterval, submitPatch]);
 
+  const handleRunNow = useCallback(() => {
+    if (!slug || runPending) return;
+    setRunPending(true);
+    runSchedulerJob(slug)
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["scheduler"] });
+        showNotice(`${labelOf(job)} triggered`, "success");
+      })
+      .catch((e: Error) => {
+        showNotice(`Couldn't trigger ${labelOf(job)}: ${e.message}`, "error");
+      })
+      .finally(() => setRunPending(false));
+  }, [slug, runPending, job, queryClient]);
+
   const lastRunChip = describeLastRun(job);
   const nextRunCountdown = describeNextRun(job);
 
@@ -286,6 +311,27 @@ function ScheduleRow({ job }: ScheduleRowProps) {
           onToggle={handleToggle}
           ariaLabel={`${enabled ? "Disable" : "Enable"} ${labelOf(job)}`}
         />
+
+        <button
+          type="button"
+          disabled={runPending}
+          onClick={handleRunNow}
+          aria-label={`Run ${labelOf(job)} now`}
+          style={{
+            padding: "2px 8px",
+            fontSize: 11,
+            fontWeight: 500,
+            background: "transparent",
+            border: "1px solid var(--border)",
+            borderRadius: 4,
+            color: "var(--text-secondary)",
+            cursor: runPending ? "not-allowed" : "pointer",
+            opacity: runPending ? 0.6 : 1,
+            transition: "opacity 0.1s",
+          }}
+        >
+          {runPending ? "…" : "Run now"}
+        </button>
 
         {nextRunCountdown ? (
           <span style={{ marginLeft: "auto" }}>{nextRunCountdown}</span>


### PR DESCRIPTION
## Summary

- Adds `GET /scheduler/system-specs` endpoint to the broker that serialises `systemCronSpecs()` floor/interval data as JSON
- Removes `SYSTEM_CRON_FLOORS_MINUTES` hardcoded constant from `SystemSchedulesPanel.tsx` — the only source of truth is now the Go side
- Panel fetches specs once on mount via `getSystemCronSpecs()`; floors land in a `useRef` so the fetch doesn't trigger row re-renders; errors fall back to `DEFAULT_FLOOR_MINUTES = 5` with a `console.warn`

**Before:** two places had to be kept in sync manually. Someone could add a new system cron or change a `MinFloor` in Go without updating the TSX constant.

**After:** one source of truth in `systemCronSpecs()`. The UI always reflects the broker's current registry.

## Files changed

- `internal/team/broker_scheduler.go` — `systemCronSpecJSON` type + `handleSchedulerSystemSpecs` handler + dispatch in `handleSchedulerSubpath`
- `web/src/api/client.ts` — `SystemCronSpec` interface + `getSystemCronSpecs()`
- `web/src/components/apps/SystemSchedulesPanel.tsx` — removes hardcoded constant, adds `useEffect` fetch + `floorsRef` plumbing
- `web/src/components/apps/SystemSchedulesPanel.test.tsx` — mocks `getSystemCronSpecs` (resolves empty)

## Test plan

- [ ] Go: `go build ./internal/team/...` (untracked learnings.go WIP causes pre-existing build failure unrelated to this PR)
- [ ] TypeScript: `bunx tsc --noEmit` — no new errors
- [ ] Manual: open Calendar app → System Schedules panel loads, interval pickers show correct floor values from API response
- [ ] Manual: disconnect broker → panel renders with fallback floor = 5, `console.warn` fires
- [ ] Manual: add a new entry to `systemCronSpecs()` in Go → restart broker → UI shows correct floor without any TSX change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Run now" action to scheduler rows for immediate one-time execution.
  * Scheduler now dynamically fetches system cron specifications (defaults and minimum intervals) at runtime.
  * Interval validation uses these system-provided constraints for more accurate scheduling feedback.

* **Bug Fixes**
  * Improved resilience when spec fetching fails—falls back to sensible defaults and logs a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->