### PR TITLE
fix(eval): prevent state contamination and HOME path doubling in eval harnesses

### DIFF
--- a/scripts/cron_eval/eval.py
+++ b/scripts/cron_eval/eval.py
@@ -655,6 +655,31 @@ def render_markdown_report(report: CronEvalReport) -> str:
     return "\n".join(out) + "\n"
 
 
+# ---------- State reset ----------
+
+
+def reset_scheduler_state(broker: str, token: str) -> None:
+    """Reset all system crons to their default state before a full run.
+
+    Clears any interval_override and re-enables any disabled cron so that
+    each run starts from a deterministic baseline.  Without this, overrides
+    written by scenario_floor_rejection, scenario_patch_happy_path, and
+    scenario_persistence_snapshot bleed into the next invocation and cause
+    spurious failures (e.g. floor checks starting from a pre-patched value,
+    self-registration failing because a cron was left disabled).
+    """
+    for slug, spec in SYSTEM_CRONS.items():
+        if spec.get("read_only"):
+            # Read-only crons reject any PATCH — nothing to reset.
+            continue
+        http_request(
+            "PATCH",
+            f"{broker}/scheduler/{urllib.parse.quote(slug)}",
+            token=token,
+            body={"interval_override": 0, "enabled": True},
+        )
+
+
 # ---------- Main ----------
 
 
@@ -715,6 +740,16 @@ def main() -> int:
         print("=" * 78)
         print(f"  cron_persistence: {'PASS' if ok else 'FAIL'}")
         return 0 if ok else 1
+
+    # Full run: reset broker state first so each invocation starts from a
+    # deterministic baseline (clears overrides left by the previous run).
+    # Also remove a stale snapshot so --verify-persistence won't pick up
+    # a result from a different broker boot.
+    print(f"[cron-eval] resetting scheduler state before run…")
+    reset_scheduler_state(args.broker, token)
+    snapshot_path = Path(PERSISTENCE_SNAPSHOT_PATH)
+    if snapshot_path.exists():
+        snapshot_path.unlink()
 
     # Full run: scenarios 1-6, then write the persistence snapshot last so
     # downstream tooling can chain --verify-persistence against the restart.

--- a/scripts/cron_eval/eval.py
+++ b/scripts/cron_eval/eval.py
@@ -672,12 +672,16 @@ def reset_scheduler_state(broker: str, token: str) -> None:
         if spec.get("read_only"):
             # Read-only crons reject any PATCH — nothing to reset.
             continue
-        http_request(
+        code, body = http_request(
             "PATCH",
             f"{broker}/scheduler/{urllib.parse.quote(slug)}",
             token=token,
             body={"interval_override": 0, "enabled": True},
         )
+        if code < 200 or code >= 300:
+            raise RuntimeError(
+                f"reset_scheduler_state: PATCH {slug} returned {code}: {body!r}"
+            )
 
 
 # ---------- Main ----------

--- a/scripts/cron_eval/eval.py
+++ b/scripts/cron_eval/eval.py
@@ -177,7 +177,7 @@ def scenario_self_registration(
     ok = pass_count == len(SYSTEM_CRONS)
     detail = (
         f"{pass_count}/{len(SYSTEM_CRONS)} system crons registered with "
-        f"system_managed=true and enabled=true"
+        "system_managed=true and enabled=true"
     )
     return ScenarioResult(
         id="cron-01-self-registration",
@@ -624,11 +624,11 @@ def render_markdown_report(report: CronEvalReport) -> str:
         f"- **Floors enforced:** {report.floors_pass}/{report.floors_total}"
     )
     out.append(
-        f"- **Disabled-skips-run:** "
+        "- **Disabled-skips-run:** "
         f"{'pass' if report.disabled_skips_run else 'fail' if report.disabled_skips_run is False else 'n/a'}"
     )
     out.append(
-        f"- **Persistence:** "
+        "- **Persistence:** "
         f"{'pass' if report.persistence_ok else 'fail' if report.persistence_ok is False else 'n/a (run --verify-persistence)'}"
     )
     out.append("")
@@ -749,7 +749,7 @@ def main() -> int:
     # deterministic baseline (clears overrides left by the previous run).
     # Also remove a stale snapshot so --verify-persistence won't pick up
     # a result from a different broker boot.
-    print(f"[cron-eval] resetting scheduler state before run…")
+    print("[cron-eval] resetting scheduler state before run…")
     reset_scheduler_state(args.broker, token)
     snapshot_path = Path(PERSISTENCE_SNAPSHOT_PATH)
     if snapshot_path.exists():
@@ -793,23 +793,23 @@ def main() -> int:
     print("ACCEPTANCE GATES")
     print("=" * 78)
     print(
-        f"  cron_self_registration:   "
+        "  cron_self_registration:   "
         f"{report.self_registration_pass}/{report.self_registration_total}  "
         f"({'PASS' if self_reg_ok else 'FAIL'})"
     )
     print(
-        f"  cron_patch_floors:        "
+        "  cron_patch_floors:        "
         f"{report.floors_pass}/{report.floors_total}  "
         f"({'PASS' if floors_ok else 'FAIL'})"
     )
     print(
-        f"  cron_disabled_skips_run:  "
+        "  cron_disabled_skips_run:  "
         f"{'PASS' if disabled_ok else 'FAIL'}"
     )
     print(
-        f"  cron_persistence_snap:    "
+        "  cron_persistence_snap:    "
         f"{'PASS' if persistence_snapshot_ok else 'FAIL'}  "
-        f"(restart broker + --verify-persistence to confirm gate 4)"
+        "(restart broker + --verify-persistence to confirm gate 4)"
     )
 
     other_scenarios_ok = all(

--- a/scripts/skill_eval/eval.py
+++ b/scripts/skill_eval/eval.py
@@ -110,6 +110,8 @@ def http_request(
             return e.code, json.loads(payload)
         except (json.JSONDecodeError, ValueError):
             return e.code, payload
+    except urllib.error.URLError as e:
+        return 0, f"request failed: {e.reason}"
 
 
 # ---------- Result types ----------
@@ -164,6 +166,13 @@ def scenario_list_empty(broker: str, token: str) -> ScenarioResult:
             detail="non-JSON response body",
         )
     skills = body.get("skills", [])
+    if not isinstance(skills, list) or any(not isinstance(s, dict) for s in skills):
+        return ScenarioResult(
+            id="skill-01-list",
+            title="GET /skills succeeds",
+            ok=False,
+            detail="invalid skills payload shape",
+        )
     probe = next((s for s in skills if s.get("name") == _EVAL_SKILL_NAME), None)
     if probe is not None:
         return ScenarioResult(
@@ -282,6 +291,13 @@ def scenario_archive(broker: str, token: str) -> ScenarioResult:
             detail=f"verification GET failed (status={list_code})",
         )
     skills = list_body.get("skills", [])
+    if not isinstance(skills, list) or any(not isinstance(s, dict) for s in skills):
+        return ScenarioResult(
+            id="skill-05-archive",
+            title="DELETE /skills (archive)",
+            ok=False,
+            detail="invalid skills payload shape",
+        )
     probe = next((s for s in skills if s.get("name") == _EVAL_SKILL_NAME), None)
     ok = probe is None
     return ScenarioResult(

--- a/scripts/skill_eval/eval.py
+++ b/scripts/skill_eval/eval.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Skill end-to-end evaluation harness.
+
+Drives the /skills surface through a series of contract scenarios against
+a running broker and asserts pass/fail per the skill lifecycle spec.
+
+Scenarios:
+  1. list-empty   — GET /skills returns an empty or baseline list on a
+                    fresh-state broker.
+  2. create       — POST /skills with action=create succeeds and the skill
+                    appears in GET /skills.
+  3. duplicate    — A second POST with the same name returns 409.
+  4. invoke       — POST /skills/{name}/invoke returns 200 and increments
+                    usage_count.
+  5. archive      — DELETE /skills removes the skill from GET /skills.
+
+HOME isolation
+--------------
+The harness optionally rewrites HOME before spawning any subprocess so that
+a broker launched as a side-effect of the eval doesn't pollute the real
+~/.wuphf directory.  The guard prevents the familiar path-doubling bug that
+occurs when the caller's shell already has HOME pointed at the dev-home
+directory:
+
+  BAD (doubles when HOME is already ~/.wuphf-dev-home):
+      home = os.path.join(os.getenv("HOME"), ".wuphf-dev-home")
+
+  GOOD (idempotent):
+      home = _dev_home()   # see below — checks suffix before appending
+
+Usage:
+  python3 scripts/skill_eval/eval.py \\
+      --broker http://localhost:7899 \\
+      --token-file /tmp/wuphf-broker-token-7899 \\
+      --home                      # enable HOME isolation (dev broker)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+# ---------- HOME isolation ----------
+
+
+_DEV_HOME_SUFFIX = "/.wuphf-dev-home"
+
+
+def _dev_home() -> str:
+    """Return the dev-isolated HOME path without doubling.
+
+    If HOME already ends with ``/.wuphf-dev-home`` (e.g. the caller is
+    running inside the wuphf-dev shell alias that sets
+    ``HOME=~/.wuphf-dev-home``) we return it unchanged.  Otherwise we
+    append the suffix so the broker subprocess writes into the isolated
+    directory instead of the real ``~/.wuphf``.
+    """
+    home = os.environ.get("HOME", os.path.expanduser("~"))
+    if home.endswith(_DEV_HOME_SUFFIX):
+        return home
+    return home + _DEV_HOME_SUFFIX
+
+
+def apply_home_isolation() -> str:
+    """Set HOME to the dev-isolated path and return the resolved value."""
+    isolated = _dev_home()
+    os.environ["HOME"] = isolated
+    return isolated
+
+
+# ---------- HTTP helpers ----------
+
+
+def http_request(
+    method: str,
+    url: str,
+    *,
+    token: str,
+    body: dict[str, Any] | None = None,
+    timeout: float = 15.0,
+) -> tuple[int, dict[str, Any] | str]:
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if data is not None:
+        req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode()
+            try:
+                return resp.status, json.loads(raw)
+            except json.JSONDecodeError:
+                return resp.status, raw
+    except urllib.error.HTTPError as e:
+        try:
+            payload = e.read().decode()
+        except Exception:
+            payload = str(e)
+        try:
+            return e.code, json.loads(payload)
+        except (json.JSONDecodeError, ValueError):
+            return e.code, payload
+
+
+# ---------- Result types ----------
+
+
+@dataclass
+class ScenarioResult:
+    id: str
+    title: str
+    ok: bool
+    detail: str = ""
+
+
+@dataclass
+class SkillEvalReport:
+    scenarios: list[ScenarioResult] = field(default_factory=list)
+
+
+# ---------- State reset ----------
+
+
+_EVAL_SKILL_NAME = "skill-eval-probe"
+
+
+def reset_skill_state(broker: str, token: str) -> None:
+    """Delete the eval probe skill if it was left behind by a previous run."""
+    http_request(
+        "DELETE",
+        f"{broker}/skills",
+        token=token,
+        body={"name": _EVAL_SKILL_NAME},
+    )
+
+
+# ---------- Scenarios ----------
+
+
+def scenario_list_empty(broker: str, token: str) -> ScenarioResult:
+    code, body = http_request("GET", f"{broker}/skills", token=token)
+    if code != 200:
+        return ScenarioResult(
+            id="skill-01-list",
+            title="GET /skills succeeds",
+            ok=False,
+            detail=f"status={code}",
+        )
+    skills = body.get("skills", []) if isinstance(body, dict) else []
+    probe = next((s for s in skills if s.get("name") == _EVAL_SKILL_NAME), None)
+    if probe is not None:
+        return ScenarioResult(
+            id="skill-01-list",
+            title="GET /skills succeeds",
+            ok=False,
+            detail=f"stale probe skill present; reset_skill_state failed",
+        )
+    return ScenarioResult(
+        id="skill-01-list",
+        title="GET /skills succeeds",
+        ok=True,
+        detail=f"{len(skills)} skill(s) in list",
+    )
+
+
+def scenario_create(broker: str, token: str) -> ScenarioResult:
+    code, body = http_request(
+        "POST",
+        f"{broker}/skills",
+        token=token,
+        body={
+            "action": "create",
+            "name": _EVAL_SKILL_NAME,
+            "title": "Skill Eval Probe",
+            "description": "Transient skill created by the skill_eval harness.",
+            "content": "Step 1: probe. Step 2: assert. Step 3: clean up.",
+            "created_by": "eval-harness",
+            "channel": "general",
+            "tags": ["eval"],
+        },
+    )
+    ok = code in (200, 201)
+    return ScenarioResult(
+        id="skill-02-create",
+        title=f"POST /skills action=create",
+        ok=ok,
+        detail=f"status={code}" if not ok else "",
+    )
+
+
+def scenario_duplicate(broker: str, token: str) -> ScenarioResult:
+    code, _ = http_request(
+        "POST",
+        f"{broker}/skills",
+        token=token,
+        body={
+            "action": "create",
+            "name": _EVAL_SKILL_NAME,
+            "title": "Duplicate",
+            "content": "duplicate",
+            "created_by": "eval-harness",
+        },
+    )
+    ok = code == 409
+    return ScenarioResult(
+        id="skill-03-duplicate",
+        title="Duplicate name returns 409",
+        ok=ok,
+        detail=f"want 409, got {code}" if not ok else "",
+    )
+
+
+def scenario_invoke(broker: str, token: str) -> ScenarioResult:
+    code, body = http_request(
+        "POST",
+        f"{broker}/skills/{urllib.parse.quote(_EVAL_SKILL_NAME)}/invoke",
+        token=token,
+        body={"invoked_by": "eval-harness", "channel": "general"},
+    )
+    if code != 200:
+        return ScenarioResult(
+            id="skill-04-invoke",
+            title=f"POST /skills/{_EVAL_SKILL_NAME}/invoke",
+            ok=False,
+            detail=f"status={code}",
+        )
+    usage = 0
+    if isinstance(body, dict):
+        skill_obj = body.get("skill") or {}
+        usage = int(skill_obj.get("usage_count") or 0)
+    ok = usage >= 1
+    return ScenarioResult(
+        id="skill-04-invoke",
+        title=f"POST /skills/{_EVAL_SKILL_NAME}/invoke",
+        ok=ok,
+        detail=f"usage_count={usage}" if not ok else f"usage_count={usage}",
+    )
+
+
+def scenario_archive(broker: str, token: str) -> ScenarioResult:
+    code, _ = http_request(
+        "DELETE",
+        f"{broker}/skills",
+        token=token,
+        body={"name": _EVAL_SKILL_NAME},
+    )
+    if code != 200:
+        return ScenarioResult(
+            id="skill-05-archive",
+            title="DELETE /skills (archive)",
+            ok=False,
+            detail=f"status={code}",
+        )
+    # Confirm it is gone from GET.
+    _, list_body = http_request("GET", f"{broker}/skills", token=token)
+    skills = list_body.get("skills", []) if isinstance(list_body, dict) else []
+    probe = next((s for s in skills if s.get("name") == _EVAL_SKILL_NAME), None)
+    ok = probe is None
+    return ScenarioResult(
+        id="skill-05-archive",
+        title="DELETE /skills (archive)",
+        ok=ok,
+        detail="archived skill still visible in GET /skills" if not ok else "",
+    )
+
+
+# ---------- Reporting ----------
+
+
+def print_report(report: SkillEvalReport) -> None:
+    print()
+    print("=" * 78)
+    print("SKILL EVAL — PER-SCENARIO BREAKDOWN")
+    print("=" * 78)
+    for sc in report.scenarios:
+        sign = "PASS" if sc.ok else "FAIL"
+        print(f"  [{sign}] {sc.id:<32}  {sc.title}")
+        if sc.detail:
+            print(f"         {sc.detail}")
+
+
+# ---------- Main ----------
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--broker", default="http://localhost:7899")
+    ap.add_argument("--token-file", default="/tmp/wuphf-broker-token-7899")
+    ap.add_argument(
+        "--home",
+        action="store_true",
+        help=(
+            "Isolate HOME to ~/.wuphf-dev-home before running.  Safe to pass "
+            "even when HOME already points there — the guard prevents doubling."
+        ),
+    )
+    args = ap.parse_args()
+
+    if args.home:
+        isolated = apply_home_isolation()
+        print(f"[skill-eval] HOME isolation active: {isolated}")
+
+    token_path = Path(args.token_file)
+    if not token_path.exists():
+        print(f"token file not found: {token_path}", file=sys.stderr)
+        return 2
+    token = token_path.read_text().strip()
+
+    # Reset any state left by a previous run before executing scenarios so
+    # each invocation starts from a deterministic baseline.
+    print(f"[skill-eval] resetting state before run…")
+    reset_skill_state(args.broker, token)
+
+    report = SkillEvalReport()
+    report.scenarios.append(scenario_list_empty(args.broker, token))
+    report.scenarios.append(scenario_create(args.broker, token))
+    report.scenarios.append(scenario_duplicate(args.broker, token))
+    report.scenarios.append(scenario_invoke(args.broker, token))
+    report.scenarios.append(scenario_archive(args.broker, token))
+
+    print_report(report)
+
+    passed = sum(1 for sc in report.scenarios if sc.ok)
+    total = len(report.scenarios)
+    print()
+    print("=" * 78)
+    print("ACCEPTANCE GATES")
+    print("=" * 78)
+    print(f"  skill_lifecycle: {passed}/{total} ({'PASS' if passed == total else 'FAIL'})")
+
+    return 0 if passed == total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/skill_eval/eval.py
+++ b/scripts/skill_eval/eval.py
@@ -63,7 +63,7 @@ def _dev_home() -> str:
     append the suffix so the broker subprocess writes into the isolated
     directory instead of the real ``~/.wuphf``.
     """
-    home = os.environ.get("HOME", os.path.expanduser("~"))
+    home = os.path.normpath(os.environ.get("HOME", os.path.expanduser("~")))
     if home.endswith(_DEV_HOME_SUFFIX):
         return home
     return home + _DEV_HOME_SUFFIX
@@ -237,7 +237,11 @@ def scenario_invoke(broker: str, token: str) -> ScenarioResult:
     usage = 0
     if isinstance(body, dict):
         skill_obj = body.get("skill") or {}
-        usage = int(skill_obj.get("usage_count") or 0)
+        raw = skill_obj.get("usage_count")
+        try:
+            usage = int(raw)
+        except (TypeError, ValueError):
+            usage = 0
     ok = usage >= 1
     return ScenarioResult(
         id="skill-04-invoke",
@@ -305,6 +309,14 @@ def main() -> int:
         ),
     )
     args = ap.parse_args()
+
+    parsed_url = urllib.parse.urlparse(args.broker)
+    if parsed_url.scheme not in ("http", "https"):
+        print(
+            f"error: --broker must use http or https scheme, got {args.broker!r}",
+            file=sys.stderr,
+        )
+        return 2
 
     if args.home:
         isolated = apply_home_isolation()

--- a/scripts/skill_eval/eval.py
+++ b/scripts/skill_eval/eval.py
@@ -156,7 +156,14 @@ def scenario_list_empty(broker: str, token: str) -> ScenarioResult:
             ok=False,
             detail=f"status={code}",
         )
-    skills = body.get("skills", []) if isinstance(body, dict) else []
+    if not isinstance(body, dict):
+        return ScenarioResult(
+            id="skill-01-list",
+            title="GET /skills succeeds",
+            ok=False,
+            detail="non-JSON response body",
+        )
+    skills = body.get("skills", [])
     probe = next((s for s in skills if s.get("name") == _EVAL_SKILL_NAME), None)
     if probe is not None:
         return ScenarioResult(
@@ -266,8 +273,15 @@ def scenario_archive(broker: str, token: str) -> ScenarioResult:
             detail=f"status={code}",
         )
     # Confirm it is gone from GET.
-    _, list_body = http_request("GET", f"{broker}/skills", token=token)
-    skills = list_body.get("skills", []) if isinstance(list_body, dict) else []
+    list_code, list_body = http_request("GET", f"{broker}/skills", token=token)
+    if list_code != 200 or not isinstance(list_body, dict):
+        return ScenarioResult(
+            id="skill-05-archive",
+            title="DELETE /skills (archive)",
+            ok=False,
+            detail=f"verification GET failed (status={list_code})",
+        )
+    skills = list_body.get("skills", [])
     probe = next((s for s in skills if s.get("name") == _EVAL_SKILL_NAME), None)
     ok = probe is None
     return ScenarioResult(

--- a/scripts/skill_eval/eval_test.py
+++ b/scripts/skill_eval/eval_test.py
@@ -13,7 +13,7 @@ class TestDevHome(unittest.TestCase):
     """_dev_home() must never produce a doubled path."""
 
     def setUp(self) -> None:
-        self._original_home = os.environ.get("HOME", "")
+        self._original_home = os.environ.get("HOME")
 
     def test_plain_home_appends_suffix(self) -> None:
         """When HOME is a normal user home, suffix is appended."""
@@ -50,7 +50,10 @@ class TestDevHome(unittest.TestCase):
         self.assertEqual(os.environ["HOME"], "/Users/testuser/.wuphf-dev-home")
 
     def tearDown(self) -> None:
-        os.environ["HOME"] = self._original_home
+        if self._original_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._original_home
 
 
 if __name__ == "__main__":

--- a/scripts/skill_eval/eval_test.py
+++ b/scripts/skill_eval/eval_test.py
@@ -12,6 +12,9 @@ import eval as skill_eval  # noqa: E402
 class TestDevHome(unittest.TestCase):
     """_dev_home() must never produce a doubled path."""
 
+    def setUp(self) -> None:
+        self._original_home = os.environ.get("HOME", "")
+
     def test_plain_home_appends_suffix(self) -> None:
         """When HOME is a normal user home, suffix is appended."""
         os.environ["HOME"] = "/Users/testuser"
@@ -47,8 +50,7 @@ class TestDevHome(unittest.TestCase):
         self.assertEqual(os.environ["HOME"], "/Users/testuser/.wuphf-dev-home")
 
     def tearDown(self) -> None:
-        # Restore HOME to a neutral value so other tests are unaffected.
-        os.environ["HOME"] = os.path.expanduser("~")
+        os.environ["HOME"] = self._original_home
 
 
 if __name__ == "__main__":

--- a/scripts/skill_eval/eval_test.py
+++ b/scripts/skill_eval/eval_test.py
@@ -1,0 +1,55 @@
+"""Unit tests for scripts/skill_eval/eval.py — HOME isolation guard."""
+import os
+import sys
+import unittest
+from pathlib import Path
+
+# Allow importing eval.py as a module from the same directory.
+sys.path.insert(0, str(Path(__file__).parent))
+import eval as skill_eval  # noqa: E402
+
+
+class TestDevHome(unittest.TestCase):
+    """_dev_home() must never produce a doubled path."""
+
+    def test_plain_home_appends_suffix(self) -> None:
+        """When HOME is a normal user home, suffix is appended."""
+        os.environ["HOME"] = "/Users/testuser"
+        result = skill_eval._dev_home()
+        self.assertEqual(result, "/Users/testuser/.wuphf-dev-home")
+
+    def test_already_dev_home_is_idempotent(self) -> None:
+        """When HOME already ends with /.wuphf-dev-home, no doubling occurs."""
+        os.environ["HOME"] = "/Users/testuser/.wuphf-dev-home"
+        result = skill_eval._dev_home()
+        self.assertEqual(result, "/Users/testuser/.wuphf-dev-home")
+
+    def test_nested_doubling_is_prevented(self) -> None:
+        """Calling _dev_home() twice returns the same value both times."""
+        os.environ["HOME"] = "/Users/testuser"
+        first = skill_eval._dev_home()
+        os.environ["HOME"] = first  # simulate shell that already set HOME
+        second = skill_eval._dev_home()
+        self.assertEqual(first, second)
+
+    def test_apply_home_isolation_sets_env(self) -> None:
+        """apply_home_isolation() mutates os.environ['HOME'] correctly."""
+        os.environ["HOME"] = "/Users/testuser"
+        result = skill_eval.apply_home_isolation()
+        self.assertEqual(result, "/Users/testuser/.wuphf-dev-home")
+        self.assertEqual(os.environ["HOME"], "/Users/testuser/.wuphf-dev-home")
+
+    def test_apply_home_isolation_idempotent(self) -> None:
+        """Calling apply_home_isolation() when HOME is already isolated is safe."""
+        os.environ["HOME"] = "/Users/testuser/.wuphf-dev-home"
+        result = skill_eval.apply_home_isolation()
+        self.assertEqual(result, "/Users/testuser/.wuphf-dev-home")
+        self.assertEqual(os.environ["HOME"], "/Users/testuser/.wuphf-dev-home")
+
+    def tearDown(self) -> None:
+        # Restore HOME to a neutral value so other tests are unaffected.
+        os.environ["HOME"] = os.path.expanduser("~")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **cron_eval state contamination**: Added `reset_scheduler_state()` to `scripts/cron_eval/eval.py` that resets all configurable system crons (clears `interval_override`, re-enables) and deletes any stale persistence snapshot at the start of every full run. Without this, PATCH overrides written by scenario 2 (`nex-notifications`), scenario 3 (all floor values), and scenario 7a (`review-expiry`) bled into subsequent invocations causing spurious self-registration and floor-check failures.
- **skill_eval HOME path doubling**: Added new harness `scripts/skill_eval/eval.py` with a `_dev_home()` guard that prevents `HOME` from doubling when the caller shell already has `HOME=~/.wuphf-dev-home` (e.g. the `wuphf-dev` alias). Also includes `reset_skill_state()` for the same run-to-run isolation. Five unit tests in `eval_test.py` cover both the plain-home and already-isolated cases.

## Test plan

- [ ] Run `python3 -m pytest scripts/skill_eval/eval_test.py -v` — 5 tests should pass
- [ ] Run `python3 scripts/cron_eval/eval.py` twice in succession against a live dev broker (`:7899`) — second run should produce identical results to first (no spurious floor/self-registration failures)
- [ ] Confirm `python3 scripts/skill_eval/eval.py --home` against a live dev broker completes all 5 scenarios without error
- [ ] Confirm running `skill_eval/eval.py` with `HOME` already set to `~/.wuphf-dev-home` does not produce a doubled path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reset broker scheduler state and remove stale persistence snapshots before running cron scenarios to ensure deterministic evaluations.

* **New Features**
  * Added a CLI harness that runs ordered HTTP contract checks against the skills API (list/create/duplicate/invoke/archive) with per-scenario reporting and pass/fail exit status.
  * Optional HOME isolation for the harness to avoid local side effects.

* **Tests**
  * Added unit tests covering HOME isolation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->