### PR TITLE
feat(workspaces): create-workspace opens wizard; show active workspace in rail

### DIFF
--- a/internal/team/broker_workspaces.go
+++ b/internal/team/broker_workspaces.go
@@ -72,6 +72,7 @@ type Workspace struct {
 	CreatedAt   string  `json:"created_at,omitempty"`
 	LastUsedAt  string  `json:"last_used_at,omitempty"`
 	PausedAt    *string `json:"paused_at,omitempty"`
+	IsActive    bool    `json:"is_active,omitempty"`
 }
 
 // CreateRequest is the POST body for /workspaces/create. Fields beyond
@@ -363,6 +364,12 @@ func (b *Broker) handleWorkspacesList(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		writeOrchestratorError(w, err)
 		return
+	}
+	selfHome := filepath.Clean(config.RuntimeHomeDir())
+	for i := range ws {
+		if filepath.Clean(ws[i].RuntimeHome) == selfHome {
+			ws[i].IsActive = true
+		}
 	}
 	writeWorkspaceJSON(w, http.StatusOK, map[string]any{
 		"workspaces": ws,

--- a/internal/team/broker_workspaces.go
+++ b/internal/team/broker_workspaces.go
@@ -335,6 +335,22 @@ func writeOrchestratorError(w http.ResponseWriter, err error) {
 	writeWorkspaceError(w, errorToStatus(err), err.Error())
 }
 
+func canonicalWorkspaceRuntimeHome(raw string) (string, bool) {
+	path := strings.TrimSpace(raw)
+	if path == "" {
+		return "", false
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path), true
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err == nil {
+		return resolved, true
+	}
+	return filepath.Clean(abs), true
+}
+
 // requireMethod returns true and lets the handler proceed if r.Method matches
 // expected. Otherwise writes 405 and returns false.
 func requireMethod(w http.ResponseWriter, r *http.Request, expected string) bool {
@@ -365,9 +381,16 @@ func (b *Broker) handleWorkspacesList(w http.ResponseWriter, r *http.Request) {
 		writeOrchestratorError(w, err)
 		return
 	}
-	selfHome := filepath.Clean(config.RuntimeHomeDir())
+	selfHome, ok := canonicalWorkspaceRuntimeHome(config.RuntimeHomeDir())
+	if !ok {
+		writeWorkspaceJSON(w, http.StatusOK, map[string]any{
+			"workspaces": ws,
+		})
+		return
+	}
 	for i := range ws {
-		if filepath.Clean(ws[i].RuntimeHome) == selfHome {
+		candidate, ok := canonicalWorkspaceRuntimeHome(ws[i].RuntimeHome)
+		if ok && candidate == selfHome {
 			ws[i].IsActive = true
 		}
 	}

--- a/internal/team/broker_workspaces_test.go
+++ b/internal/team/broker_workspaces_test.go
@@ -273,6 +273,47 @@ func TestHandleWorkspacesList_ReturnsJSONShape(t *testing.T) {
 	}
 }
 
+func TestHandleWorkspacesList_MarksActiveWorkspaceWithCanonicalRuntimeHome(t *testing.T) {
+	runtimeHome := t.TempDir()
+	parent := t.TempDir()
+	linkPath := filepath.Join(parent, "runtime-link")
+	if err := os.Symlink(runtimeHome, linkPath); err != nil {
+		t.Fatalf("symlink runtime home: %v", err)
+	}
+	t.Setenv("WUPHF_RUNTIME_HOME", linkPath)
+
+	b, o, _ := newWorkspaceTestBroker(t)
+	o.listResp = []Workspace{
+		{Name: "main", RuntimeHome: runtimeHome, BrokerPort: 7890, WebPort: 7891, State: "running"},
+		{Name: "demo", RuntimeHome: t.TempDir(), BrokerPort: 7910, WebPort: 7911, State: "paused"},
+	}
+
+	srv := httptest.NewServer(b.withAuth(b.handleWorkspacesList))
+	defer srv.Close()
+
+	resp := mustGet(t, srv.URL, b.Token())
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: %d body: %s", resp.StatusCode, string(body))
+	}
+	var payload struct {
+		Workspaces []Workspace `json:"workspaces"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Workspaces) != 2 {
+		t.Fatalf("workspaces: want 2, got %d", len(payload.Workspaces))
+	}
+	if !payload.Workspaces[0].IsActive {
+		t.Fatalf("main workspace should be active after symlink canonicalization")
+	}
+	if payload.Workspaces[1].IsActive {
+		t.Fatalf("demo workspace should not be active")
+	}
+}
+
 func TestHandleWorkspacesList_NoOrchestratorReturns503(t *testing.T) {
 	b := newTestBroker(t)
 	srv := httptest.NewServer(b.withAuth(b.handleWorkspacesList))

--- a/web/src/components/onboarding/Wizard.test.tsx
+++ b/web/src/components/onboarding/Wizard.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useAppStore } from "../../stores/app";
@@ -38,15 +44,14 @@ function pressEnterOn(
 
 beforeEach(() => {
   postMock.mockClear();
+  window.history.replaceState({}, "", "/");
   useAppStore.setState({
     onboardingComplete: false,
   });
 });
 
 afterEach(() => {
-  while (document.body.firstChild) {
-    document.body.removeChild(document.body.firstChild);
-  }
+  cleanup();
 });
 
 describe("Wizard keyboard advancement", () => {
@@ -95,6 +100,31 @@ describe("Wizard keyboard advancement", () => {
 
     // Should move to templates step — "What should your office run?" is the
     // templates headline.
+    await waitFor(() => {
+      expect(
+        screen.getByText(/What should your office run\?/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("only skips identity when skip_identity is explicitly 1", async () => {
+    window.history.replaceState({}, "", "/onboarding?skip_identity=0");
+    render(<Wizard onComplete={vi.fn()} />);
+
+    pressEnterOn(window);
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/Company or project name/i),
+      ).toBeInTheDocument();
+    });
+
+    cleanup();
+    window.history.replaceState({}, "", "/onboarding?skip_identity=1");
+    render(<Wizard onComplete={vi.fn()} />);
+
+    pressEnterOn(window);
+
     await waitFor(() => {
       expect(
         screen.getByText(/What should your office run\?/i),

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -1840,9 +1840,8 @@ export function Wizard({ onComplete }: WizardProps) {
 
   // When creating a new workspace from an existing one, identity is skipped —
   // the user already exists, they just need blueprint/team/setup/task.
-  const skipIdentity = new URLSearchParams(window.location.search).has(
-    "skip_identity",
-  );
+  const skipIdentity =
+    new URLSearchParams(window.location.search).get("skip_identity") === "1";
   const activeSteps: readonly WizardStep[] = skipIdentity
     ? STEP_ORDER.filter((s) => s !== "identity")
     : STEP_ORDER;

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -352,10 +352,16 @@ function EnterHint({ modifier }: { modifier?: string } = {}) {
    Sub-components
    ═══════════════════════════════════════════ */
 
-function ProgressDots({ current }: { current: WizardStep }) {
+function ProgressDots({
+  current,
+  steps,
+}: {
+  current: WizardStep;
+  steps: readonly WizardStep[];
+}) {
   return (
     <div className="wizard-progress">
-      {STEP_ORDER.map((step) => (
+      {steps.map((step) => (
         <div
           key={step}
           className={`wizard-progress-dot ${step === current ? "active" : "inactive"}`}
@@ -1832,6 +1838,15 @@ interface WizardProps {
 export function Wizard({ onComplete }: WizardProps) {
   const setOnboardingComplete = useAppStore((s) => s.setOnboardingComplete);
 
+  // When creating a new workspace from an existing one, identity is skipped —
+  // the user already exists, they just need blueprint/team/setup/task.
+  const skipIdentity = new URLSearchParams(window.location.search).has(
+    "skip_identity",
+  );
+  const activeSteps: readonly WizardStep[] = skipIdentity
+    ? STEP_ORDER.filter((s) => s !== "identity")
+    : STEP_ORDER;
+
   // Navigation
   const [step, setStep] = useState<WizardStep>("welcome");
 
@@ -2056,18 +2071,18 @@ export function Wizard({ onComplete }: WizardProps) {
   }, []);
 
   const nextStep = useCallback(() => {
-    const idx = STEP_ORDER.indexOf(step);
-    if (idx < STEP_ORDER.length - 1) {
-      setStep(STEP_ORDER[idx + 1]);
+    const idx = activeSteps.indexOf(step);
+    if (idx < activeSteps.length - 1) {
+      setStep(activeSteps[idx + 1]);
     }
-  }, [step]);
+  }, [step, activeSteps]);
 
   const prevStep = useCallback(() => {
-    const idx = STEP_ORDER.indexOf(step);
+    const idx = activeSteps.indexOf(step);
     if (idx > 0) {
-      setStep(STEP_ORDER[idx - 1]);
+      setStep(activeSteps[idx - 1]);
     }
-  }, [step]);
+  }, [step, activeSteps]);
 
   // Toggle agent selection. The lead agent (built_in) is locked: TeamStep
   // disables its button, and this guard prevents any programmatic path
@@ -2477,7 +2492,7 @@ export function Wizard({ onComplete }: WizardProps) {
       switch (step) {
         case "welcome":
           e.preventDefault();
-          goTo("identity");
+          goTo(activeSteps[1] ?? "templates");
           return;
         case "templates":
           e.preventDefault();
@@ -2519,6 +2534,7 @@ export function Wizard({ onComplete }: WizardProps) {
     };
   }, [
     step,
+    activeSteps,
     company,
     description,
     runtimePriority,
@@ -2538,9 +2554,11 @@ export function Wizard({ onComplete }: WizardProps) {
   return (
     <div className="wizard-container">
       <div className="wizard-body">
-        <ProgressDots current={step} />
+        <ProgressDots current={step} steps={activeSteps} />
 
-        {step === "welcome" && <WelcomeStep onNext={() => goTo("identity")} />}
+        {step === "welcome" && (
+          <WelcomeStep onNext={() => goTo(activeSteps[1] ?? "templates")} />
+        )}
 
         {step === "templates" && (
           <TemplatesStep

--- a/web/src/components/workspaces/CreateWorkspaceModal.tsx
+++ b/web/src/components/workspaces/CreateWorkspaceModal.tsx
@@ -1,27 +1,15 @@
 /**
- * CreateWorkspaceModal — inline modal that creates a new WUPHF workspace.
+ * CreateWorkspaceModal — minimal name-capture modal for new workspace creation.
  *
- * Two paths (CodeRabbit #3164366659 + #3164366660):
- *   1. Inherit from current (default): pre-fills blueprint, company info,
- *      LLM provider, team lead. After /workspaces/create succeeds, the
- *      rich onboarding fields (company_description/priority/llm_provider/
- *      team_lead_slug) are forwarded to the new broker via
- *      POST /workspaces/onboarding before the page reload — the broker's
- *      strict CreateRequest decoder rejects them inline so the apply step
- *      runs separately.
- *   2. From-scratch: toggles off inherit. POST /workspaces/create with
- *      from_scratch=true, then full-page-navigate to the NEW broker's
- *      /onboarding URL so the wizard runs scoped to the new workspace's
- *      runtime, NOT the active broker. Previously this ran the wizard
- *      inline against the active broker, which mutated the wrong workspace.
+ * Always creates from scratch and navigates to the new broker's /onboarding
+ * URL with ?skip_identity=1 so the wizard skips the identity step (company
+ * info) — you're an existing user, not a first-time setup.
  */
 import { useEffect, useId, useMemo, useState } from "react";
 
-import { type ConfigSnapshot, getConfig } from "../../api/client";
 import {
   type CreateWorkspaceInput,
   type Workspace,
-  useApplyOnboarding,
   useCreateWorkspace,
   validateWorkspaceSlug,
 } from "../../api/workspaces";
@@ -43,9 +31,7 @@ const styles = {
     padding: 20,
   },
   panel: {
-    width: "min(620px, calc(100vw - 40px))",
-    maxHeight: "calc(100vh - 80px)",
-    overflowY: "auto" as const,
+    width: "min(440px, calc(100vw - 40px))",
     background: "var(--bg-card)",
     border: "1px solid var(--border)",
     borderRadius: "var(--radius-md)",
@@ -87,27 +73,6 @@ const styles = {
     outline: "none",
     fontFamily: "var(--font-mono)",
   },
-  textarea: {
-    width: "100%",
-    background: "var(--bg-warm)",
-    border: "1px solid var(--border)",
-    color: "var(--text)",
-    borderRadius: "var(--radius-sm)",
-    fontSize: 13,
-    padding: "8px 12px",
-    outline: "none",
-    fontFamily: "var(--font-sans)",
-    minHeight: 60,
-    resize: "vertical" as const,
-  },
-  toggleRow: {
-    display: "flex" as const,
-    alignItems: "center" as const,
-    gap: 8,
-    fontSize: 13,
-    color: "var(--text)",
-    marginBottom: 16,
-  },
   errorText: {
     color: "var(--red)",
     fontSize: 12,
@@ -118,28 +83,22 @@ const styles = {
     fontSize: 12,
     marginTop: 6,
   },
-  row: {
-    display: "flex" as const,
-    gap: 8,
-    justifyContent: "flex-end" as const,
-    marginTop: 18,
-  },
   progress: {
     fontSize: 13,
     color: "var(--text-secondary)",
     margin: "12px 0",
     fontFamily: "var(--font-mono)",
   },
+  row: {
+    display: "flex" as const,
+    gap: 8,
+    justifyContent: "flex-end" as const,
+    marginTop: 18,
+  },
 };
 
-type Phase = "form" | "spawning" | "ready" | "error";
+type Phase = "form" | "spawning" | "error";
 
-/**
- * Tiny copy helper for the progress UI. We don't have an SSE stream
- * for create (that was deferred from the smooth-switch design), so the
- * stages are time-based hints rather than truth — the user gets a sense
- * of motion until /workspaces/create returns.
- */
 const SPAWN_STAGES: readonly string[] = [
   "allocating ports",
   "writing registry entry",
@@ -148,134 +107,42 @@ const SPAWN_STAGES: readonly string[] = [
   "ready",
 ];
 
-interface FormState {
-  name: string;
-  inherit: boolean;
-  blueprint: string;
-  company_name: string;
-  company_description: string;
-  company_priority: string;
-  llm_provider: string;
-  team_lead_slug: string;
-}
-
-function defaultsFromConfig(config?: ConfigSnapshot): FormState {
-  return {
-    name: "",
-    inherit: true,
-    blueprint: config?.blueprint ?? "",
-    company_name: config?.company_name ?? "",
-    company_description: config?.company_description ?? "",
-    company_priority: config?.company_priority ?? "",
-    llm_provider: config?.llm_provider ?? "",
-    team_lead_slug: config?.team_lead_slug ?? "",
-  };
-}
-
 export function CreateWorkspaceModal({
   open,
   onClose,
 }: CreateWorkspaceModalProps) {
   const titleId = useId();
-  const [config, setConfig] = useState<ConfigSnapshot | undefined>(undefined);
-  const [form, setForm] = useState<FormState>(defaultsFromConfig());
+  const [name, setName] = useState("");
   const [phase, setPhase] = useState<Phase>("form");
   const [stageIdx, setStageIdx] = useState(0);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
-  const applyOnboarding = useApplyOnboarding();
-
-  const navigateToWorkspace = (ws: Workspace, fromScratch: boolean) => {
-    setPhase("ready");
-    // Full page reload to the new workspace — page-reload-on-switch.
-    // From-scratch path lands on /onboarding so the wizard runs scoped to
-    // the new broker, not the active one (CodeRabbit #3164366660).
-    const path = fromScratch ? "/onboarding" : "/";
-    window.location.assign(`http://localhost:${ws.web_port}${path}`);
+  const navigateToWorkspace = (ws: Workspace) => {
+    setPhase("ready" as Phase);
+    window.location.assign(
+      `http://localhost:${ws.web_port}/onboarding?skip_identity=1`,
+    );
   };
 
   const create = useCreateWorkspace({
-    onSuccess: (ws, vars) => {
-      const fromScratch = Boolean(vars.from_scratch);
-      // Inherit path: forward the rich onboarding fields the broker's
-      // strict CreateRequest decoder can't accept (company_description,
-      // company_priority, llm_provider, team_lead_slug) via the new
-      // /workspaces/onboarding proxy. From-scratch path skips this — the
-      // wizard running on the new broker will collect them itself.
-      if (
-        !fromScratch &&
-        (form.company_description ||
-          form.company_priority ||
-          form.llm_provider ||
-          form.team_lead_slug)
-      ) {
-        applyOnboarding.mutate(
-          {
-            name: ws.name,
-            company_description: form.company_description || undefined,
-            company_priority: form.company_priority || undefined,
-            llm_provider: form.llm_provider || undefined,
-            team_lead_slug: form.team_lead_slug || undefined,
-          },
-          {
-            onSuccess: () => navigateToWorkspace(ws, false),
-            onError: (err) => {
-              // Don't block navigation — the user can re-run onboarding
-              // inside the new workspace. Surface the failure but proceed.
-              // eslint-disable-next-line no-console
-              console.warn("[CreateWorkspaceModal] onboarding apply failed:", err);
-              navigateToWorkspace(ws, false);
-            },
-          },
-        );
-        return;
-      }
-      navigateToWorkspace(ws, fromScratch);
-    },
+    onSuccess: (ws) => navigateToWorkspace(ws),
     onError: (err) => {
       setPhase("error");
       setErrorMsg(err instanceof Error ? err.message : String(err));
     },
   });
 
-  // Pre-fill inheritable fields from the active broker's /config when the
-  // modal opens. We deliberately preserve `name` and `inherit` because the
-  // user may have started typing before /config resolves.
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    void getConfig()
-      .then((c) => {
-        if (cancelled) return;
-        setConfig(c);
-        setForm((prev) => ({
-          ...defaultsFromConfig(c),
-          name: prev.name,
-          inherit: prev.inherit,
-        }));
-      })
-      .catch((err) => {
-        // Non-fatal — let the user fill in the form manually.
-        if (cancelled) return;
-        // eslint-disable-next-line no-console
-        console.warn("[CreateWorkspaceModal] /config fetch failed:", err);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open]);
-
-  // Reset to a clean form whenever the modal re-opens.
+  // Reset on open.
   useEffect(() => {
     if (open) {
+      setName("");
       setPhase("form");
       setStageIdx(0);
       setErrorMsg(null);
-      setForm(defaultsFromConfig());
     }
   }, [open]);
 
-  // Animated stage hint while we wait on /workspaces/create.
+  // Animated stage hints while waiting on /workspaces/create.
   useEffect(() => {
     if (phase !== "spawning") return;
     setStageIdx(0);
@@ -285,7 +152,7 @@ export function CreateWorkspaceModal({
     return () => window.clearInterval(tick);
   }, [phase]);
 
-  // Esc closes — only when the form isn't busy.
+  // Esc closes when idle.
   useEffect(() => {
     if (!open) return;
     function onKey(e: KeyboardEvent) {
@@ -297,133 +164,24 @@ export function CreateWorkspaceModal({
     return () => document.removeEventListener("keydown", onKey);
   }, [open, phase, onClose]);
 
-  const slugValidation = useMemo(
-    () => validateWorkspaceSlug(form.name),
-    [form.name],
-  );
+  const slugValidation = useMemo(() => validateWorkspaceSlug(name), [name]);
   const canSubmit =
     (phase === "form" || phase === "error") &&
-    form.inherit &&
     slugValidation.ok &&
     !create.isPending;
 
   if (!open) return null;
 
-  // From-scratch path: spawn a blank broker and navigate to its
-  // /onboarding route, where the wizard runs scoped to the new workspace's
-  // runtime instead of mutating the active workspace (CodeRabbit
-  // #3164366660). The active broker's /onboarding endpoints are NOT used.
-  if (form.inherit === false) {
-    return (
-      <div
-        style={styles.backdrop}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        onClick={(e) => {
-          if (e.target === e.currentTarget && phase !== "spawning") onClose();
-        }}
-      >
-        <div style={styles.panel} className="card">
-          <h3 id={titleId} style={styles.title}>
-            New workspace from scratch
-          </h3>
-          <p style={styles.subtitle}>
-            Spawns a blank workspace, then drops you into the onboarding
-            wizard scoped to the new broker. Nothing inherits from the
-            current workspace.
-          </p>
+  const handleSubmit = () => {
+    setErrorMsg(null);
+    setPhase("spawning");
+    const payload: CreateWorkspaceInput = {
+      name: name.trim(),
+      from_scratch: true,
+    };
+    create.mutate(payload);
+  };
 
-          <label style={styles.toggleRow}>
-            <input
-              type="checkbox"
-              checked={form.inherit}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, inherit: e.target.checked }))
-              }
-              data-testid="inherit-toggle"
-              disabled={phase === "spawning"}
-            />
-            Inherit from current
-          </label>
-
-          <div style={styles.field}>
-            <label style={styles.label} htmlFor={`${titleId}-slug`}>
-              Workspace name
-            </label>
-            <input
-              id={`${titleId}-slug`}
-              style={styles.input}
-              value={form.name}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, name: e.target.value.toLowerCase() }))
-              }
-              placeholder="e.g. scratchpad"
-              autoComplete="off"
-              spellCheck={false}
-              data-testid="workspace-slug-input"
-              disabled={phase === "spawning"}
-            />
-            {form.name.length > 0 && !slugValidation.ok ? (
-              <div style={styles.errorText} data-testid="workspace-slug-error">
-                {slugValidation.reason}
-              </div>
-            ) : (
-              <div style={styles.hintText}>
-                Lowercase letters, digits, hyphens. Must start with a letter.
-                Reserved: main, dev, prod, default, current, tokens, trash.
-              </div>
-            )}
-          </div>
-
-          {phase === "spawning" ? (
-            <div style={styles.progress} data-testid="workspace-create-progress">
-              ⏳ {SPAWN_STAGES[stageIdx]}…
-            </div>
-          ) : null}
-          {phase === "error" && errorMsg ? (
-            <div style={styles.errorText} data-testid="workspace-create-error">
-              {errorMsg}
-            </div>
-          ) : null}
-
-          <div style={styles.row}>
-            <button
-              type="button"
-              className="btn btn-ghost btn-sm"
-              onClick={onClose}
-              disabled={phase === "spawning"}
-            >
-              Cancel
-            </button>
-            <button
-              type="button"
-              className="btn btn-primary btn-sm"
-              disabled={
-                !slugValidation.ok || phase === "spawning" || create.isPending
-              }
-              data-testid="workspace-create-from-scratch-submit"
-              onClick={() => {
-                setErrorMsg(null);
-                setPhase("spawning");
-                const payload: CreateWorkspaceInput = {
-                  name: form.name.trim(),
-                  from_scratch: true,
-                };
-                create.mutate(payload);
-              }}
-            >
-              {phase === "spawning"
-                ? "Creating..."
-                : "Spawn and open onboarding"}
-            </button>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Inherit path (default).
   return (
     <div
       style={styles.backdrop}
@@ -439,23 +197,8 @@ export function CreateWorkspaceModal({
           New workspace
         </h3>
         <p style={styles.subtitle}>
-          Forks blueprint, company identity, LLM config, and agent roster from
-          the current workspace. Wiki, tasks, notebooks, and broker state start
-          empty.
+          Spawns a fresh broker, then drops you into the setup wizard.
         </p>
-
-        <label style={styles.toggleRow}>
-          <input
-            type="checkbox"
-            checked={form.inherit}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, inherit: e.target.checked }))
-            }
-            data-testid="inherit-toggle"
-            disabled={phase === "spawning"}
-          />
-          Inherit from current
-        </label>
 
         <div style={styles.field}>
           <label style={styles.label} htmlFor={`${titleId}-slug`}>
@@ -464,122 +207,27 @@ export function CreateWorkspaceModal({
           <input
             id={`${titleId}-slug`}
             style={styles.input}
-            value={form.name}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, name: e.target.value.toLowerCase() }))
-            }
+            value={name}
+            onChange={(e) => setName(e.target.value.toLowerCase())}
             placeholder="e.g. acme-demo"
             autoComplete="off"
             spellCheck={false}
+            autoFocus
             data-testid="workspace-slug-input"
             disabled={phase === "spawning"}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canSubmit) handleSubmit();
+            }}
           />
-          {form.name.length > 0 && !slugValidation.ok ? (
+          {name.length > 0 && !slugValidation.ok ? (
             <div style={styles.errorText} data-testid="workspace-slug-error">
               {slugValidation.reason}
             </div>
           ) : (
             <div style={styles.hintText}>
               Lowercase letters, digits, hyphens. Must start with a letter.
-              Reserved: main, dev, prod, default, current, tokens, trash.
             </div>
           )}
-        </div>
-
-        <div style={styles.field}>
-          <label style={styles.label} htmlFor={`${titleId}-blueprint`}>
-            Blueprint
-          </label>
-          <input
-            id={`${titleId}-blueprint`}
-            style={styles.input}
-            value={form.blueprint}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, blueprint: e.target.value }))
-            }
-            placeholder="e.g. founding-team"
-            autoComplete="off"
-            spellCheck={false}
-            disabled={phase === "spawning"}
-          />
-        </div>
-
-        <div style={styles.field}>
-          <label style={styles.label} htmlFor={`${titleId}-company`}>
-            Company name
-          </label>
-          <input
-            id={`${titleId}-company`}
-            style={styles.input}
-            value={form.company_name}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, company_name: e.target.value }))
-            }
-            disabled={phase === "spawning"}
-          />
-        </div>
-
-        <div style={styles.field}>
-          <label style={styles.label} htmlFor={`${titleId}-description`}>
-            Company description
-          </label>
-          <textarea
-            id={`${titleId}-description`}
-            style={styles.textarea}
-            value={form.company_description}
-            onChange={(e) =>
-              setForm((f) => ({
-                ...f,
-                company_description: e.target.value,
-              }))
-            }
-            disabled={phase === "spawning"}
-          />
-        </div>
-
-        <div style={styles.field}>
-          <label style={styles.label} htmlFor={`${titleId}-priority`}>
-            Top priority right now
-          </label>
-          <input
-            id={`${titleId}-priority`}
-            style={styles.input}
-            value={form.company_priority}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, company_priority: e.target.value }))
-            }
-            disabled={phase === "spawning"}
-          />
-        </div>
-
-        <div style={styles.field}>
-          <label style={styles.label} htmlFor={`${titleId}-llm`}>
-            LLM provider
-          </label>
-          <input
-            id={`${titleId}-llm`}
-            style={styles.input}
-            value={form.llm_provider}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, llm_provider: e.target.value }))
-            }
-            disabled={phase === "spawning"}
-          />
-        </div>
-
-        <div style={styles.field}>
-          <label style={styles.label} htmlFor={`${titleId}-lead`}>
-            Team lead slug
-          </label>
-          <input
-            id={`${titleId}-lead`}
-            style={styles.input}
-            value={form.team_lead_slug}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, team_lead_slug: e.target.value }))
-            }
-            disabled={phase === "spawning"}
-          />
         </div>
 
         {phase === "spawning" ? (
@@ -607,32 +255,11 @@ export function CreateWorkspaceModal({
             className="btn btn-primary btn-sm"
             disabled={!canSubmit}
             data-testid="workspace-create-submit"
-            onClick={() => {
-              setErrorMsg(null);
-              setPhase("spawning");
-              // Broker's CreateRequest only accepts {name, blueprint?,
-              // inherit_from?, company_name?, from_scratch?}. Richer
-              // onboarding fields (company_description, company_priority,
-              // llm_provider, team_lead_slug) are scoped to the subsequent
-              // /onboarding/* calls — see TODOS.md "two-step create+onboard".
-              const payload: CreateWorkspaceInput = {
-                name: form.name.trim(),
-                from_scratch: !form.inherit,
-                blueprint: form.blueprint || undefined,
-                company_name: form.company_name || undefined,
-              };
-              create.mutate(payload);
-            }}
+            onClick={handleSubmit}
           >
             {phase === "spawning" ? "Creating..." : "Create workspace"}
           </button>
         </div>
-        {config?.config_path ? (
-          <div style={{ ...styles.hintText, marginTop: 12 }}>
-            API keys, agent roster, and onboarding state will be forked from{" "}
-            <code>{config.config_path}</code>.
-          </div>
-        ) : null}
       </div>
     </div>
   );

--- a/web/src/components/workspaces/CreateWorkspaceModal.tsx
+++ b/web/src/components/workspaces/CreateWorkspaceModal.tsx
@@ -118,7 +118,6 @@ export function CreateWorkspaceModal({
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const navigateToWorkspace = (ws: Workspace) => {
-    setPhase("ready" as Phase);
     window.location.assign(
       `http://localhost:${ws.web_port}/onboarding?skip_identity=1`,
     );

--- a/web/src/components/workspaces/__tests__/CreateWorkspaceModal.test.tsx
+++ b/web/src/components/workspaces/__tests__/CreateWorkspaceModal.test.tsx
@@ -4,33 +4,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CreateWorkspaceModal } from "../CreateWorkspaceModal";
 
-vi.mock("../../../api/client", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../../api/client")>();
-  return {
-    ...actual,
-    getConfig: vi.fn(),
-  };
-});
-
-vi.mock("../../../api/workspaces", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("../../../api/workspaces")>();
+vi.mock("../../../api/workspaces", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../api/workspaces")
+  >("../../../api/workspaces");
   return {
     ...actual,
     useCreateWorkspace: vi.fn(),
-    useApplyOnboarding: vi.fn(),
   };
 });
 
-import { getConfig } from "../../../api/client";
-import {
-  useApplyOnboarding,
-  useCreateWorkspace,
-} from "../../../api/workspaces";
+import { useCreateWorkspace } from "../../../api/workspaces";
 
-const getConfigMock = vi.mocked(getConfig);
 const useCreateWorkspaceMock = vi.mocked(useCreateWorkspace);
-const useApplyOnboardingMock = vi.mocked(useApplyOnboarding);
 
 function renderModal(open = true) {
   const onClose = vi.fn();
@@ -47,23 +33,10 @@ function renderModal(open = true) {
 
 describe("<CreateWorkspaceModal>", () => {
   beforeEach(() => {
-    getConfigMock.mockResolvedValue({
-      blueprint: "founding-team",
-      company_name: "Nex",
-      company_description: "Synthesis",
-      company_priority: "Ship multi-workspace",
-      llm_provider: "claude-code",
-      team_lead_slug: "michael",
-      config_path: "/Users/me/.wuphf/config.json",
-    });
     useCreateWorkspaceMock.mockReturnValue({
       mutate: vi.fn(),
       isPending: false,
     } as unknown as ReturnType<typeof useCreateWorkspace>);
-    useApplyOnboardingMock.mockReturnValue({
-      mutate: vi.fn(),
-      isPending: false,
-    } as unknown as ReturnType<typeof useApplyOnboarding>);
   });
   afterEach(() => {
     vi.clearAllMocks();
@@ -74,25 +47,17 @@ describe("<CreateWorkspaceModal>", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders inherit form by default with pre-filled fields", async () => {
+  it("renders just the name input by default", () => {
     renderModal();
-
-    await waitFor(() => {
-      expect(
-        (screen.getByLabelText(/Company name/i) as HTMLInputElement).value,
-      ).toBe("Nex");
-    });
-    expect(
-      (screen.getByLabelText(/Blueprint/i) as HTMLInputElement).value,
-    ).toBe("founding-team");
-    expect(
-      (screen.getByLabelText(/LLM provider/i) as HTMLInputElement).value,
-    ).toBe("claude-code");
+    expect(screen.getByTestId("workspace-slug-input")).toBeInTheDocument();
+    // No inherit toggle, no blueprint/company/LLM fields
+    expect(screen.queryByTestId("inherit-toggle")).toBeNull();
+    expect(screen.queryByLabelText(/Company name/i)).toBeNull();
+    expect(screen.queryByLabelText(/Blueprint/i)).toBeNull();
   });
 
-  it("validates the slug inline and disables submit when invalid", async () => {
+  it("validates the slug inline and disables submit when invalid", () => {
     renderModal();
-
     const input = screen.getByTestId(
       "workspace-slug-input",
     ) as HTMLInputElement;
@@ -113,7 +78,6 @@ describe("<CreateWorkspaceModal>", () => {
       "workspace-slug-input",
     ) as HTMLInputElement;
     fireEvent.change(input, { target: { value: "main" } });
-
     expect(screen.getByTestId("workspace-slug-error").textContent).toMatch(
       /reserved/i,
     );
@@ -124,7 +88,7 @@ describe("<CreateWorkspaceModal>", () => {
     );
   });
 
-  it("enables submit and calls the create mutation with form values", async () => {
+  it("calls create mutation with from_scratch=true on submit", async () => {
     const mutate = vi.fn();
     useCreateWorkspaceMock.mockReturnValue({
       mutate,
@@ -146,37 +110,29 @@ describe("<CreateWorkspaceModal>", () => {
 
     fireEvent.click(screen.getByTestId("workspace-create-submit"));
 
-    expect(mutate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "side-project",
-        // Inherit toggle is true → from_scratch must be false. The
-        // legacy `inherit_from_current` key was removed because broker's
-        // strict CreateRequest decoder rejects unknown fields.
-        from_scratch: false,
-      }),
-    );
+    expect(mutate).toHaveBeenCalledWith({
+      name: "side-project",
+      from_scratch: true,
+    });
   });
 
-  it("toggling 'Inherit from current' switches to the from-scratch panel", () => {
-    renderModal();
+  it("navigates to /onboarding?skip_identity=1 on the new broker after success", async () => {
+    const assign = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, "location", {
+      value: { assign },
+      writable: true,
+    });
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        value: originalLocation,
+        writable: true,
+      });
+    });
 
-    fireEvent.click(screen.getByTestId("inherit-toggle"));
-
-    // The from-scratch panel keeps the slug input (the wizard runs on the
-    // new broker, not inline) and exposes a dedicated submit affordance.
-    expect(screen.getByTestId("workspace-slug-input")).toBeInTheDocument();
-    expect(
-      screen.getByTestId("workspace-create-from-scratch-submit"),
-    ).toBeInTheDocument();
-  });
-
-  it("inherit submit forwards rich fields through useApplyOnboarding", async () => {
-    const createMutate = vi.fn();
-    const applyMutate = vi.fn();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     useCreateWorkspaceMock.mockImplementation(((opts?: any) => ({
       mutate: (input: unknown) => {
-        createMutate(input);
         opts?.onSuccess?.(
           {
             name: "side-project",
@@ -193,98 +149,20 @@ describe("<CreateWorkspaceModal>", () => {
       isPending: false,
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     })) as unknown as typeof useCreateWorkspace);
-    useApplyOnboardingMock.mockReturnValue({
-      mutate: applyMutate,
-      isPending: false,
-    } as unknown as ReturnType<typeof useApplyOnboarding>);
-
-    // Stub window.location.assign so the test doesn't actually navigate.
-    const assign = vi.fn();
-    const originalLocation = window.location;
-    Object.defineProperty(window, "location", {
-      value: { assign },
-      writable: true,
-    });
-    afterEach(() => {
-      Object.defineProperty(window, "location", {
-        value: originalLocation,
-        writable: true,
-      });
-    });
 
     renderModal();
 
-    await waitFor(() => {
-      expect(
-        (screen.getByLabelText(/Company description/i) as HTMLTextAreaElement)
-          .value,
-      ).toBe("Synthesis");
-    });
-
-    const slug = screen.getByTestId(
+    const input = screen.getByTestId(
       "workspace-slug-input",
     ) as HTMLInputElement;
-    fireEvent.change(slug, { target: { value: "side-project" } });
-
+    fireEvent.change(input, { target: { value: "side-project" } });
     fireEvent.click(screen.getByTestId("workspace-create-submit"));
 
-    expect(createMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ name: "side-project", from_scratch: false }),
-    );
-    expect(applyMutate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: "side-project",
-        company_description: "Synthesis",
-        company_priority: "Ship multi-workspace",
-        llm_provider: "claude-code",
-        team_lead_slug: "michael",
-      }),
-      expect.any(Object),
-    );
-  });
-
-  it("from-scratch submit creates with from_scratch=true (no inline wizard, no apply)", async () => {
-    const createMutate = vi.fn();
-    const applyMutate = vi.fn();
-    useCreateWorkspaceMock.mockReturnValue({
-      mutate: createMutate,
-      isPending: false,
-    } as unknown as ReturnType<typeof useCreateWorkspace>);
-    useApplyOnboardingMock.mockReturnValue({
-      mutate: applyMutate,
-      isPending: false,
-    } as unknown as ReturnType<typeof useApplyOnboarding>);
-
-    renderModal();
-
-    fireEvent.click(screen.getByTestId("inherit-toggle"));
-
-    const slug = screen.getByTestId(
-      "workspace-slug-input",
-    ) as HTMLInputElement;
-    fireEvent.change(slug, { target: { value: "scratchpad" } });
-
     await waitFor(() => {
-      expect(
-        (
-          screen.getByTestId(
-            "workspace-create-from-scratch-submit",
-          ) as HTMLButtonElement
-        ).disabled,
-      ).toBe(false);
+      expect(assign).toHaveBeenCalledWith(
+        "http://localhost:7911/onboarding?skip_identity=1",
+      );
     });
-
-    fireEvent.click(
-      screen.getByTestId("workspace-create-from-scratch-submit"),
-    );
-
-    expect(createMutate).toHaveBeenCalledWith({
-      name: "scratchpad",
-      from_scratch: true,
-    });
-    // From-scratch path must not run the apply-onboarding mutation against
-    // the active workspace — the new broker's wizard collects the fields.
-    expect(applyMutate).not.toHaveBeenCalled();
   });
 
   it("Esc key closes the modal in form phase", () => {


### PR DESCRIPTION
## Summary

- **Create workspace → wizard**: The `+` button now shows a name-only modal. After creating, it navigates to the new broker's `/onboarding?skip_identity=1` — the setup wizard runs scoped to the new workspace, skipping the identity (company info) step since you're an existing user
- **Active workspace visible in rail**: `GET /workspaces/list` now marks the serving broker's own workspace with `is_active: true` (matched via `config.RuntimeHomeDir()`). The `WorkspaceRail` already checks `ws.is_active` to apply the accent border — it just had no data before

## Changes

**`internal/team/broker_workspaces.go`**
- Added `IsActive bool json:"is_active,omitempty"` to `Workspace` wire type
- `handleWorkspacesList` finds the workspace whose `RuntimeHome` matches `config.RuntimeHomeDir()` and sets `IsActive = true`

**`web/src/components/workspaces/CreateWorkspaceModal.tsx`**
- Stripped from a 640-line two-path form to a ~220-line name-only modal
- Always submits `from_scratch: true`, navigates to `/onboarding?skip_identity=1`

**`web/src/components/onboarding/Wizard.tsx`**
- Reads `?skip_identity` URL param at component init
- Derives `activeSteps` (filtered `STEP_ORDER`) and uses it in `nextStep`, `prevStep`, `ProgressDots`, and the Welcome step's next handler

**`web/src/components/workspaces/__tests__/CreateWorkspaceModal.test.tsx`**
- Updated tests to match the simplified modal (removed inherit/pre-fill/apply-onboarding tests, added wizard-navigation assertion)

## Test plan

- [ ] Click `+` in workspace rail → name-only modal appears (no blueprint/company fields)
- [ ] Type a name, click Create → modal shows spawning stages → browser navigates to new workspace's `/onboarding?skip_identity=1`
- [ ] Wizard on new workspace skips identity step, shows welcome → templates → team → setup → task → ready
- [ ] Progress dots show 6 dots (not 7) when `?skip_identity=1` is in URL
- [ ] Workspace rail highlights the current workspace with accent border
- [ ] All 629 vitest tests pass (`bunx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Workspace list now displays which workspace is currently active
* Onboarding wizard supports skipping the identity verification step
* Workspace creation streamlined to name input only with automatic from-scratch creation and onboarding redirect
<!-- end of auto-generated comment: release notes by coderabbit.ai -->