### PR TITLE
fix(quality): enforce file-size allowlist ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
           # The file-size ratchet compares the current allowlist to the PR
           # base. Keep enough history for `git merge-base HEAD origin/<base>`.
           fetch-depth: 0
+      - name: File-size ratchet self-test
+        run: bash scripts/check-file-size-self-test.sh
       - name: File-size budget (CONTRIBUTING.md)
         # Warn at 800 LOC, fail at 1500 LOC unless allowlisted in
         # scripts/file-size-allowlist.txt. The allowlist is forward-only

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,17 @@ jobs:
       GOBIN: ${{ github.workspace }}/.gobin
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # ratchet:actions/checkout@v6
+        with:
+          # The file-size ratchet compares the current allowlist to the PR
+          # base. Keep enough history for `git merge-base HEAD origin/<base>`.
+          fetch-depth: 0
+      - name: File-size budget (CONTRIBUTING.md)
+        # Warn at 800 LOC, fail at 1500 LOC unless allowlisted in
+        # scripts/file-size-allowlist.txt. The allowlist is forward-only
+        # (see CONTRIBUTING.md, docs/CODE-QUALITY.md, ADR-0001): new
+        # entries and growth of current offenders fail against the PR base.
+        # Skips generated files, tests, and documented fixture/vendor dirs.
+        run: bash scripts/check-file-size.sh
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # ratchet:actions/setup-go@v6
         with:
           go-version-file: go.mod
@@ -156,12 +167,6 @@ jobs:
             echo "See internal/brokeraddr/addr.go for the runtime.GOOS pattern." >&2
             exit 1
           fi
-      - name: File-size budget (CONTRIBUTING.md)
-        # Warn at 800 LOC, fail at 1500 LOC unless allowlisted in
-        # scripts/file-size-allowlist.txt. The allowlist is forward-only
-        # (see CONTRIBUTING.md, docs/CODE-QUALITY.md, ADR-0001). Skips
-        # generated files and tests.
-        run: bash scripts/check-file-size.sh
       - name: Reject unix-only exec.Command shapes outside tmux/tui paths
         # Windows guard: bash/sh/chmod/ln/mkfifo/killall don't exist there.
         # Code that needs them must be in a _unix.go file with a build tag,

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -7,6 +7,7 @@ This doc is the canonical map. If you ship a feature on one surface, update the 
 ## Status legend
 
 - `✓` — feature exists and is supported on this surface
+- `partial` — a deliberately narrower version exists on this surface
 - `—` — feature does not exist on this surface
 - `⏳` — planned, tracked
 - `⊘` — intentionally not on this surface (see Reasoning)

--- a/scripts/check-file-size-self-test.sh
+++ b/scripts/check-file-size-self-test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Self-test for scripts/check-file-size.sh.
+#
+# The CI gate proves this repository currently passes the file-size budget.
+# These fixture repos prove the ratchet fails in the cases it exists to catch.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source_script="$script_dir/check-file-size.sh"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/file-size-self-test.XXXXXX")"
+trap 'rm -rf "$tmp_root"' EXIT
+
+write_lines() {
+  local path="$1"
+  local count="$2"
+  mkdir -p "$(dirname -- "$path")"
+  awk -v n="$count" 'BEGIN { for (i = 1; i <= n; i++) print "// line " i }' > "$path"
+}
+
+init_fixture_repo() {
+  local repo="$1"
+  mkdir -p "$repo/scripts"
+  cp "$source_script" "$repo/scripts/check-file-size.sh"
+  chmod +x "$repo/scripts/check-file-size.sh"
+  : > "$repo/scripts/file-size-allowlist.txt"
+
+  git -C "$repo" init >/dev/null 2>&1
+  git -C "$repo" checkout -b main >/dev/null 2>&1
+  git -C "$repo" config user.email "file-size-self-test@example.invalid"
+  git -C "$repo" config user.name "file-size self-test"
+}
+
+commit_fixture_base() {
+  local repo="$1"
+  git -C "$repo" add .
+  git -C "$repo" commit -m "base" >/dev/null
+}
+
+expect_failure_containing() {
+  local repo="$1"
+  local needle="$2"
+  local output="$repo/check.out"
+
+  if FILE_SIZE_BASE_REF=main bash "$repo/scripts/check-file-size.sh" > "$output" 2>&1; then
+    echo "expected file-size check to fail in $repo" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+  if ! grep -Fq "$needle" "$output"; then
+    echo "expected file-size check output to contain: $needle" >&2
+    cat "$output" >&2
+    exit 1
+  fi
+}
+
+test_first_allowlist_addition_fails() {
+  local repo="$tmp_root/first-allowlist-addition"
+  init_fixture_repo "$repo"
+  write_lines "$repo/pkg/small.go" 10
+  commit_fixture_base "$repo"
+
+  write_lines "$repo/pkg/large.go" 1500
+  printf '%s\n' "pkg/large.go" >> "$repo/scripts/file-size-allowlist.txt"
+  git -C "$repo" add .
+
+  expect_failure_containing "$repo" "file-size allowlist grew"
+}
+
+test_allowlisted_growth_fails() {
+  local repo="$tmp_root/allowlisted-growth"
+  init_fixture_repo "$repo"
+  write_lines "$repo/pkg/large.go" 1500
+  printf '%s\n' "pkg/large.go" >> "$repo/scripts/file-size-allowlist.txt"
+  commit_fixture_base "$repo"
+
+  write_lines "$repo/pkg/large.go" 1501
+  git -C "$repo" add .
+
+  expect_failure_containing "$repo" "allowlisted files grew"
+}
+
+test_first_allowlist_addition_fails
+test_allowlisted_growth_fails
+
+echo "file-size self-test OK"

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -3,8 +3,8 @@
 #
 # - Warn at 800 LOC.
 # - Fail at 1500 LOC, unless the file is on scripts/file-size-allowlist.txt.
-# - The allowlist is FORWARD-ONLY: entries can shrink or disappear, never
-#   appear or grow. Adding a new entry is a CONTRIBUTING.md violation.
+# - The allowlist is FORWARD-ONLY in PRs: entries can shrink or disappear,
+#   never appear or grow. Adding a new entry is a CONTRIBUTING.md violation.
 #
 # See docs/CODE-QUALITY.md for the rationale and decomposition patterns.
 #
@@ -17,7 +17,8 @@
 #
 # Exit codes:
 #   0  no failures (warnings allowed)
-#   1  one or more files exceed 1500 LOC and are not allowlisted
+#   1  one or more files exceed 1500 LOC and are not allowlisted, or the
+#      allowlist grows relative to the PR base
 
 set -euo pipefail
 
@@ -31,19 +32,46 @@ script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 allowlist="$repo_root/scripts/file-size-allowlist.txt"
 
-# Stage 1: normalize the allowlist into a tmp file with one path per line,
-# comments and blanks stripped. We grep against this file.
 allow_norm="$(mktemp)"
-trap 'rm -f "$allow_norm" "$allow_seen" "$failures_f" "$warnings_f"' EXIT
+base_allow_norm="$(mktemp)"
 allow_seen="$(mktemp)"
 failures_f="$(mktemp)"
 warnings_f="$(mktemp)"
+allowlist_added_f="$(mktemp)"
+allowlist_growth_f="$(mktemp)"
+trap 'rm -f "$allow_norm" "$base_allow_norm" "$allow_seen" "$failures_f" "$warnings_f" "$allowlist_added_f" "$allowlist_growth_f"' EXIT
+
+normalize_allowlist() {
+  # Strip comments (# to end of line), trim whitespace, drop blank lines.
+  sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//' \
+    | grep -v '^$' || true
+}
 
 if [[ -f "$allowlist" ]]; then
-  # Strip comments (# to end of line), trim whitespace, drop blank lines.
-  sed -E 's/[[:space:]]*#.*$//; s/^[[:space:]]+//; s/[[:space:]]+$//' "$allowlist" \
-    | grep -v '^$' \
-    > "$allow_norm" || true
+  normalize_allowlist < "$allowlist" > "$allow_norm"
+fi
+
+base_ref="${FILE_SIZE_BASE_REF:-}"
+if [[ -z "$base_ref" && -n "${GITHUB_BASE_REF:-}" ]]; then
+  base_ref="origin/${GITHUB_BASE_REF}"
+fi
+if [[ -z "$base_ref" ]]; then
+  base_ref="$(git -C "$repo_root" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null || true)"
+fi
+
+base_commit=""
+if [[ -n "$base_ref" ]]; then
+  base_commit="$(git -C "$repo_root" merge-base HEAD "$base_ref" 2>/dev/null || true)"
+fi
+if [[ -n "$base_commit" ]] && git -C "$repo_root" cat-file -e "$base_commit:scripts/file-size-allowlist.txt" 2>/dev/null; then
+  git -C "$repo_root" show "$base_commit:scripts/file-size-allowlist.txt" | normalize_allowlist > "$base_allow_norm"
+fi
+
+if [[ -s "$allow_norm" && -s "$base_allow_norm" ]]; then
+  added_allowlist_entries=$(sort -u "$allow_norm" | comm -13 <(sort -u "$base_allow_norm") - || true)
+  if [[ -n "$added_allowlist_entries" ]]; then
+    printf '%s\n' "$added_allowlist_entries" > "$allowlist_added_f"
+  fi
 fi
 
 is_generated() {
@@ -62,11 +90,12 @@ is_generated() {
 }
 
 # Build the candidate list. We use `git ls-files` so the check is scoped
-# to tracked files in this worktree only — naturally excludes node_modules,
-# dist/, vendor/, other worktrees, and untracked scratch files. We gate
-# *.go, *.ts, *.tsx; other languages are not size-budgeted yet.
+# to tracked files in this worktree only — naturally excludes other
+# worktrees and untracked scratch files. We gate *.go, *.ts, *.tsx; other
+# languages are not size-budgeted yet.
 while IFS= read -r rel; do
   case "$rel" in
+    vendor/*|*/vendor/*|node_modules/*|*/node_modules/*|dist/*|*/dist/*|testdata/*|*/testdata/*) continue ;;
     *_test.go|*.test.ts|*.test.tsx|*.spec.ts|*.spec.tsx) continue ;;
   esac
   f="$repo_root/$rel"
@@ -77,6 +106,13 @@ while IFS= read -r rel; do
   if (( loc >= FAIL )); then
     if [[ -s "$allow_norm" ]] && grep -Fxq "$rel" "$allow_norm"; then
       printf '%s\n' "$rel" >> "$allow_seen"
+      if [[ -s "$base_allow_norm" ]] && grep -Fxq "$rel" "$base_allow_norm"; then
+        if base_loc=$(git -C "$repo_root" show "$base_commit:$rel" 2>/dev/null | wc -l | tr -d ' '); then
+          if [[ -n "$base_loc" ]] && (( loc > base_loc )); then
+            printf '%s  %d > %d\n' "$rel" "$loc" "$base_loc" >> "$allowlist_growth_f"
+          fi
+        fi
+      fi
       continue
     fi
     printf '%s  %d\n' "$rel" "$loc" >> "$failures_f"
@@ -89,6 +125,21 @@ if [[ -s "$warnings_f" ]]; then
   echo "::group::file-size warnings (between $WARN and $FAIL LOC)"
   sort -k2 -rn "$warnings_f" | sed 's/^/  /'
   echo "::endgroup::"
+fi
+
+if [[ -s "$allowlist_added_f" ]]; then
+  echo "::error::file-size allowlist grew relative to ${base_ref:-the base ref}:"
+  sort -u "$allowlist_added_f" | sed 's/^/  /'
+  echo
+  echo "The allowlist is forward-only. Decompose the file instead of adding"
+  echo "a new exemption."
+fi
+
+if [[ -s "$allowlist_growth_f" ]]; then
+  echo "::error::allowlisted files grew relative to ${base_ref:-the base ref}:"
+  sort -k4 -rn "$allowlist_growth_f" | sed 's/^/  /'
+  echo
+  echo "Allowlisted files may shrink or disappear; they must not grow."
 fi
 
 # Stale allowlist entries: still listed but file is no longer over budget
@@ -112,6 +163,9 @@ if [[ -s "$failures_f" ]]; then
   echo "a documented reason - add it to scripts/file-size-allowlist.txt."
   echo "Adding a new allowlist entry without justification is a CONTRIBUTING.md"
   echo "violation. The allowlist is forward-only."
+fi
+
+if [[ -s "$failures_f" || -s "$allowlist_added_f" || -s "$allowlist_growth_f" ]]; then
   exit 1
 fi
 

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -67,7 +67,7 @@ if [[ -n "$base_commit" ]] && git -C "$repo_root" cat-file -e "$base_commit:scri
   git -C "$repo_root" show "$base_commit:scripts/file-size-allowlist.txt" | normalize_allowlist > "$base_allow_norm"
 fi
 
-if [[ -s "$allow_norm" && -s "$base_allow_norm" ]]; then
+if [[ -s "$allow_norm" ]]; then
   added_allowlist_entries=$(sort -u "$allow_norm" | comm -13 <(sort -u "$base_allow_norm") - || true)
   if [[ -n "$added_allowlist_entries" ]]; then
     printf '%s\n' "$added_allowlist_entries" > "$allowlist_added_f"
@@ -107,7 +107,8 @@ while IFS= read -r rel; do
     if [[ -s "$allow_norm" ]] && grep -Fxq "$rel" "$allow_norm"; then
       printf '%s\n' "$rel" >> "$allow_seen"
       if [[ -s "$base_allow_norm" ]] && grep -Fxq "$rel" "$base_allow_norm"; then
-        if base_loc=$(git -C "$repo_root" show "$base_commit:$rel" 2>/dev/null | wc -l | tr -d ' '); then
+        if [[ -n "$base_commit" ]] && git -C "$repo_root" cat-file -e "$base_commit:$rel" 2>/dev/null; then
+          base_loc=$(git -C "$repo_root" show "$base_commit:$rel" | wc -l | tr -d ' ')
           if [[ -n "$base_loc" ]] && (( loc > base_loc )); then
             printf '%s  %d > %d\n' "$rel" "$loc" "$base_loc" >> "$allowlist_growth_f"
           fi


### PR DESCRIPTION
## Summary

Follow-up to #511 staff review findings.

- Enforce the file-size allowlist as a real forward-only ratchet in PR CI:
  - new allowlist entries fail against the PR base
  - existing allowlisted files fail if they grow against the PR base
- Skip documented fixture/vendor directories by path segment: `vendor/`, `node_modules/`, `dist/`, and `testdata/`.
- Run the file-size budget immediately after checkout in the lint job, with full history so the script can compare against the PR base.
- Define the `partial` status token used in `docs/surfaces.md`.

## Root Cause

#511 documented the allowlist as forward-only, but the script only checked whether an oversized file appeared in the current allowlist. A PR could add a new oversized file and a matching allowlist line, and CI would pass.

## Test Plan

- [x] `bash -n scripts/check-file-size.sh`
- [x] `shellcheck scripts/check-file-size.sh`
- [x] `bash scripts/check-file-size.sh`
- [x] Temporary local verification: adding a fake allowlist line fails with `file-size allowlist grew relative to origin/main`
- [x] `git diff --check`
- [x] pre-push hook: build, file-size, smoke, vhs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "partial" status to the surface support legend to clarify reduced or asymmetric support across surfaces.

* **Chores**
  * Strengthened CI file-size validation to compare changes against the PR/base reference, tightened scanning exclusions for generated/vendor outputs, and made the check fail on budget breaches or when allowlist entries or allowed-file sizes increase.

* **Tests**
  * Added a self-test that verifies the file-size check behavior using temporary fixture repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->