### PR TITLE
fix(wiki-to-skills): preserve frontmatter on promote + persist source_article on compile

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -361,12 +361,19 @@ type schedulerJob struct {
 }
 
 type teamSkill struct {
-	ID                  string   `json:"id"`
-	Name                string   `json:"name"`
-	Title               string   `json:"title"`
-	Description         string   `json:"description,omitempty"`
-	Content             string   `json:"content"`
-	CreatedBy           string   `json:"created_by"`
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
+	Content     string `json:"content"`
+	CreatedBy   string `json:"created_by"`
+	// SourceArticle is the wiki-relative path of the article that drove
+	// this skill (e.g. "team/playbooks/customer-refund.md"). Stage A
+	// (article-rooted) compiles populate it; Stage B (signal-derived)
+	// synthesised skills legitimately leave it empty. Surfaces as
+	// metadata.wuphf.source_articles[0] in the rendered SKILL.md and as
+	// source_article in the /skills JSON response.
+	SourceArticle       string   `json:"source_article,omitempty"`
 	Channel             string   `json:"channel,omitempty"`
 	Tags                []string `json:"tags,omitempty"`
 	Trigger             string   `json:"trigger,omitempty"`

--- a/internal/team/broker_review_test.go
+++ b/internal/team/broker_review_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -303,6 +304,83 @@ func TestReviewTargetExists_BouncesToChangesRequested(t *testing.T) {
 	if res.StatusCode != http.StatusConflict {
 		t.Fatalf("want 409 at submit, got %d", res.StatusCode)
 	}
+}
+
+func TestPromoteToPlaybookPreservesFrontmatter(t *testing.T) {
+	srv, b, teardown := newReviewTestServer(t)
+	defer teardown()
+	token := b.Token()
+
+	// Notebook entry begins with valid Anthropic Agent Skills frontmatter
+	// (name + description). After promotion to a team/playbooks/ path the
+	// target wiki article must keep the frontmatter intact, otherwise the
+	// LLM-free fast path in skill_scanner.go's defaultLLMProvider can't
+	// match the article.
+	notebookBody := "---\n" +
+		"name: customer-refund\n" +
+		"description: Issue a refund for a customer order.\n" +
+		"version: 1.0.0\n" +
+		"---\n" +
+		"# Customer Refund\n\nSteps go here.\n"
+	seedNotebookViaHTTP(t, srv, token, "pm",
+		"agents/pm/notebook/customer-refund.md", notebookBody)
+
+	res := submitPromotion(t, srv, token, map[string]any{
+		"my_slug":          "pm",
+		"source_path":      "agents/pm/notebook/customer-refund.md",
+		"target_wiki_path": "team/playbooks/customer-refund.md",
+		"rationale":        "Promote skill",
+	})
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("submit status=%d body=%s", res.StatusCode, string(body))
+	}
+	var submitRes struct {
+		PromotionID string `json:"promotion_id"`
+	}
+	_ = json.NewDecoder(res.Body).Decode(&submitRes)
+	if submitRes.PromotionID == "" {
+		t.Fatalf("no promotion ID")
+	}
+
+	// Approve to trigger the on-disk promote commit.
+	approveBody, _ := json.Marshal(map[string]any{"actor_slug": "ceo"})
+	req, _ := authReq(http.MethodPost, srv.URL+"/review/"+submitRes.PromotionID+"/approve",
+		bytes.NewReader(approveBody), token)
+	approveRes, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	approveRes.Body.Close()
+	if approveRes.StatusCode != http.StatusOK {
+		t.Fatalf("approve status=%d", approveRes.StatusCode)
+	}
+
+	// Wait briefly for the commit to land — ApplyPromotion is synchronous
+	// from the approve handler so the file should already exist.
+	target := filepath.Join(b.wikiWorker.Repo().Root(), "team/playbooks/customer-refund.md")
+	contents, err := readFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if !strings.HasPrefix(contents, "---\nname: customer-refund\n") {
+		t.Fatalf("target missing skill frontmatter prefix: %q", contents)
+	}
+	if !strings.Contains(contents, "description: Issue a refund for a customer order.") {
+		t.Fatalf("target missing description: %q", contents)
+	}
+	if !strings.Contains(contents, "# Customer Refund") {
+		t.Fatalf("target dropped markdown body: %q", contents)
+	}
+}
+
+func readFile(path string) (string, error) {
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(bs), nil
 }
 
 func drainEvents(ch <-chan ReviewStateChangeEvent) {

--- a/internal/team/promotion_commit.go
+++ b/internal/team/promotion_commit.go
@@ -297,9 +297,35 @@ func stripPromotionFrontmatterForTarget(body, targetPath string) string {
 	if !frontmatterHasSkillKeys(yamlBlock) {
 		return stripFrontmatter(body)
 	}
-	// Preserve as-is. Returning body unchanged keeps the leading "---\n",
-	// the YAML block, the closing "\n---\n", and the body intact.
-	return body
+	// Preserve the skill frontmatter, but filter back-link keys that only
+	// belong on the source notebook. Without this, a re-promoted notebook
+	// inherits stale `promoted_to`/`promoted_at`/`promoted_by`/
+	// `promoted_commit_sha` values pointing back at the previous target.
+	cleaned := stripPromotionKeys(yamlBlock)
+	return "---\n" + cleaned + "\n---\n" + rest[idx+len("\n---\n"):]
+}
+
+// stripPromotionKeys removes the back-link metadata keys archivists stamp on
+// the source notebook after a promotion. Operates on the YAML text so it
+// preserves comments, key ordering, and any unknown keys downstream readers
+// rely on. Tolerates leading whitespace (YAML allows it) so an indented
+// `  promoted_to: x` is filtered too.
+func stripPromotionKeys(yamlBlock string) string {
+	lines := strings.Split(yamlBlock, "\n")
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "promoted_to:"),
+			strings.HasPrefix(trimmed, "promoted_at:"),
+			strings.HasPrefix(trimmed, "promoted_by:"),
+			strings.HasPrefix(trimmed, "promoted_commit_sha:"):
+			continue
+		default:
+			out = append(out, line)
+		}
+	}
+	return strings.Join(out, "\n")
 }
 
 // isSkillBearingTargetPath reports whether the wiki-relative target path

--- a/internal/team/promotion_commit.go
+++ b/internal/team/promotion_commit.go
@@ -74,9 +74,20 @@ func (r *Repo) ApplyPromotion(ctx context.Context, p *Promotion, approverSlug st
 		return "", fmt.Errorf("promotion: read source: %w", err)
 	}
 	// The target body is the source body MINUS any existing promotion
-	// frontmatter. Otherwise the target ends up with a self-referencing
-	// back-link that points to its own source — confusing for readers.
-	targetBody := stripFrontmatter(string(sourceBytes))
+	// back-link frontmatter. Otherwise the target ends up with a
+	// self-referencing back-link that points to its own source — confusing
+	// for readers.
+	//
+	// Exception (skill-frontmatter preservation, 2026-05-01): when the
+	// target lives under team/playbooks/ or team/skills/ AND the source
+	// already carries an Anthropic-Agent-Skills-shaped frontmatter block
+	// (both `name` and `description` keys present), preserve that block
+	// verbatim on the target. This keeps the LLM-free fast path in
+	// skill_scanner.go working: agent-authored skills with explicit
+	// frontmatter must promote without losing the YAML, otherwise the
+	// scanner falls back to a CLI-LLM round-trip that fails in
+	// no-auth environments.
+	targetBody := stripPromotionFrontmatterForTarget(string(sourceBytes), p.TargetPath)
 
 	if err := os.MkdirAll(filepath.Dir(targetFull), 0o700); err != nil {
 		return "", fmt.Errorf("promotion: mkdir target: %w", err)
@@ -250,6 +261,102 @@ func stripFrontmatter(body string) string {
 		return body
 	}
 	return strings.TrimLeft(rest[idx+len("\n---\n"):], "\n")
+}
+
+// stripPromotionFrontmatterForTarget strips a leading frontmatter block from
+// the source notebook content before it is written as the target wiki
+// article — UNLESS the target is a skill-bearing path AND the frontmatter
+// already carries Anthropic Agent Skills-shaped keys (both `name` and
+// `description` present at the top level of the YAML block).
+//
+// The rule exists so agent-authored playbooks/skills that explicitly opt
+// into skill frontmatter survive the notebook→wiki promotion intact. Stage
+// A's skill_scanner.go has a fast path that promotes such articles without
+// an LLM call; stripping the YAML here would break that path and force a
+// CLI-LLM round-trip that fails in environments without configured auth.
+//
+// We deliberately preserve the YAML block as-is rather than parsing and
+// re-serialising it: that preserves comments, key ordering, and unknown
+// keys that future readers may rely on.
+func stripPromotionFrontmatterForTarget(body, targetPath string) string {
+	if !strings.HasPrefix(body, "---\n") {
+		return body
+	}
+	if !isSkillBearingTargetPath(targetPath) {
+		return stripFrontmatter(body)
+	}
+	rest := body[len("---\n"):]
+	idx := strings.Index(rest, "\n---\n")
+	if idx < 0 {
+		// Malformed frontmatter (no closing delimiter): fall through to the
+		// existing strip behaviour, which returns body unchanged when no
+		// closing delimiter exists. Safer than guessing.
+		return stripFrontmatter(body)
+	}
+	yamlBlock := rest[:idx]
+	if !frontmatterHasSkillKeys(yamlBlock) {
+		return stripFrontmatter(body)
+	}
+	// Preserve as-is. Returning body unchanged keeps the leading "---\n",
+	// the YAML block, the closing "\n---\n", and the body intact.
+	return body
+}
+
+// isSkillBearingTargetPath reports whether the wiki-relative target path
+// lives in a directory whose articles are scanned for skill frontmatter.
+// Mirrored from skill_scanner.go's walk roots; must stay in sync.
+func isSkillBearingTargetPath(targetPath string) bool {
+	clean := strings.TrimPrefix(targetPath, "/")
+	if strings.HasPrefix(clean, "team/playbooks/") {
+		return true
+	}
+	if strings.HasPrefix(clean, "team/skills/") {
+		return true
+	}
+	return false
+}
+
+// frontmatterHasSkillKeys reports whether the YAML block (without the
+// surrounding --- delimiters) carries top-level `name` and `description`
+// keys. We do a textual scan rather than a full YAML decode to keep the
+// detection cheap and to avoid any chance of mutating the block via
+// re-serialisation.
+func frontmatterHasSkillKeys(yamlBlock string) bool {
+	hasName := false
+	hasDescription := false
+	for _, line := range strings.Split(yamlBlock, "\n") {
+		// Skip indented lines: a `name:` nested under another key (e.g.
+		// metadata.wuphf.name) is not the top-level skill name.
+		if line == "" || line[0] == ' ' || line[0] == '\t' {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		colonIdx := strings.Index(trimmed, ":")
+		if colonIdx <= 0 {
+			continue
+		}
+		key := strings.TrimSpace(trimmed[:colonIdx])
+		value := strings.TrimSpace(trimmed[colonIdx+1:])
+		// Require a non-empty value so `name:` with no content doesn't
+		// satisfy the gate. Quoted values stay quoted; we only need to
+		// know the key carries SOMETHING.
+		if value == "" {
+			continue
+		}
+		switch key {
+		case "name":
+			hasName = true
+		case "description":
+			hasDescription = true
+		}
+		if hasName && hasDescription {
+			return true
+		}
+	}
+	return false
 }
 
 // headerLineFrom returns the first markdown H1 line from a body, or "" when

--- a/internal/team/promotion_commit_test.go
+++ b/internal/team/promotion_commit_test.go
@@ -359,6 +359,76 @@ func TestStripPromotionFrontmatterForTarget(t *testing.T) {
 	}
 }
 
+func TestStripPromotionFrontmatterForTarget_FiltersPromotedKeys(t *testing.T) {
+	body := "---\n" +
+		"name: send-digest\n" +
+		"description: Send the daily digest.\n" +
+		"promoted_to: team/playbooks/old.md\n" +
+		"promoted_at: 2026-01-01T00:00:00Z\n" +
+		"promoted_by: builder\n" +
+		"promoted_commit_sha: abc123\n" +
+		"---\n" +
+		"# body\n"
+
+	got := stripPromotionFrontmatterForTarget(body, "team/skills/send-digest.md")
+
+	mustContain := []string{
+		"name: send-digest",
+		"description: Send the daily digest.",
+		"# body",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+
+	mustNotContain := []string{
+		"promoted_to:",
+		"promoted_at:",
+		"promoted_by:",
+		"promoted_commit_sha:",
+	}
+	for _, banned := range mustNotContain {
+		if strings.Contains(got, banned) {
+			t.Errorf("output should not contain %q\nfull output:\n%s", banned, got)
+		}
+	}
+
+	// Frontmatter delimiters preserved.
+	if !strings.HasPrefix(got, "---\n") {
+		t.Errorf("output should start with frontmatter delimiter, got:\n%s", got)
+	}
+	if !strings.Contains(got, "\n---\n") {
+		t.Errorf("output should contain closing frontmatter delimiter, got:\n%s", got)
+	}
+}
+
+func TestStripPromotionKeys_HandlesIndentedAndCommentVariants(t *testing.T) {
+	yamlBlock := "name: x\n" +
+		"description: y\n" +
+		"  promoted_to: leading-space\n" +
+		"\tpromoted_at: leading-tab\n" +
+		"promoted_by: builder\n" +
+		"promoted_commit_sha: abc\n" +
+		"keep_me: still-here\n"
+
+	got := stripPromotionKeys(yamlBlock)
+
+	if strings.Contains(got, "promoted_to:") {
+		t.Errorf("indented promoted_to should be stripped, got:\n%s", got)
+	}
+	if strings.Contains(got, "promoted_at:") {
+		t.Errorf("tab-indented promoted_at should be stripped, got:\n%s", got)
+	}
+	if strings.Contains(got, "promoted_by:") || strings.Contains(got, "promoted_commit_sha:") {
+		t.Errorf("promoted_by/commit_sha should be stripped, got:\n%s", got)
+	}
+	if !strings.Contains(got, "name: x") || !strings.Contains(got, "description: y") || !strings.Contains(got, "keep_me: still-here") {
+		t.Errorf("non-promotion keys should be preserved, got:\n%s", got)
+	}
+}
+
 func TestStripFrontmatter(t *testing.T) {
 	cases := map[string]string{
 		"# hi\n":                       "# hi\n",

--- a/internal/team/promotion_commit_test.go
+++ b/internal/team/promotion_commit_test.go
@@ -161,6 +161,204 @@ func TestUpsertPromotionFrontmatter_UpdatesExistingKeys(t *testing.T) {
 	}
 }
 
+func TestApplyPromotion_PreservesSkillFrontmatterOnPlaybookPath(t *testing.T) {
+	repo := newPromotionRepo(t)
+	source := "---\n" +
+		"name: customer-refund\n" +
+		"description: Issue a refund for a customer order.\n" +
+		"version: 1.0.0\n" +
+		"# trailing comment kept verbatim\n" +
+		"---\n" +
+		"# Customer Refund\n\nSteps go here.\n"
+	src := seedNotebookEntry(t, repo, "pm", "customer-refund.md", source)
+
+	p := &Promotion{
+		ID:         "rvw-skill-1",
+		SourceSlug: "pm",
+		SourcePath: src,
+		TargetPath: "team/playbooks/customer-refund.md",
+		Rationale:  "Promote skill",
+	}
+	if _, err := repo.ApplyPromotion(context.Background(), p, "ceo"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(repo.Root(), p.TargetPath))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	body := string(got)
+	if !strings.HasPrefix(body, "---\nname: customer-refund\n") {
+		t.Fatalf("target missing skill frontmatter prefix: %q", body)
+	}
+	if !strings.Contains(body, "description: Issue a refund for a customer order.") {
+		t.Fatalf("target missing description: %q", body)
+	}
+	// Comments and unknown keys MUST survive (we do not parse-and-
+	// reserialise).
+	if !strings.Contains(body, "# trailing comment kept verbatim") {
+		t.Fatalf("target lost YAML comment: %q", body)
+	}
+	if !strings.Contains(body, "# Customer Refund") {
+		t.Fatalf("target dropped markdown body: %q", body)
+	}
+}
+
+func TestApplyPromotion_PreservesSkillFrontmatterOnSkillsPath(t *testing.T) {
+	repo := newPromotionRepo(t)
+	source := "---\n" +
+		"name: incident-response\n" +
+		"description: Triage and resolve a production incident.\n" +
+		"---\n" +
+		"# Incident\n\nbody\n"
+	src := seedNotebookEntry(t, repo, "ops", "incident.md", source)
+
+	p := &Promotion{
+		ID:         "rvw-skill-2",
+		SourceSlug: "ops",
+		SourcePath: src,
+		TargetPath: "team/skills/incident-response.md",
+		Rationale:  "Promote skill",
+	}
+	if _, err := repo.ApplyPromotion(context.Background(), p, "ceo"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(repo.Root(), p.TargetPath))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if !strings.HasPrefix(string(got), "---\nname: incident-response\n") {
+		t.Fatalf("target missing skill frontmatter on team/skills/ path: %q", string(got))
+	}
+}
+
+func TestApplyPromotion_StripsBackLinkOnlyFrontmatterOnPlaybookPath(t *testing.T) {
+	// Source carries promoted_* keys (a re-promotion scenario where the
+	// notebook entry was previously promoted somewhere else) but no
+	// `name`/`description` keys. The target should have the back-link
+	// frontmatter stripped — preserving it would self-reference the
+	// previous target.
+	repo := newPromotionRepo(t)
+	source := "---\n" +
+		"promoted_to: team/playbooks/old-target.md\n" +
+		"promoted_at: 2026-04-01T00:00:00Z\n" +
+		"promoted_by: ceo\n" +
+		"promoted_commit_sha: abc1234\n" +
+		"---\n" +
+		"# Retro\n\nbody\n"
+	src := seedNotebookEntry(t, repo, "pm", "retro.md", source)
+
+	p := &Promotion{
+		ID: "rvw-strip-1", SourceSlug: "pm", SourcePath: src,
+		TargetPath: "team/playbooks/new-target.md", Rationale: "r",
+	}
+	if _, err := repo.ApplyPromotion(context.Background(), p, "ceo"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(repo.Root(), p.TargetPath))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if strings.HasPrefix(string(got), "---") {
+		t.Fatalf("target should NOT inherit back-link-only frontmatter: %q", string(got))
+	}
+	if strings.Contains(string(got), "promoted_to") {
+		t.Fatalf("target leaked back-link key: %q", string(got))
+	}
+}
+
+func TestApplyPromotion_StripsFrontmatterOnNonSkillPath(t *testing.T) {
+	// Even with skill-shaped name/description keys, the rule does NOT apply
+	// to non-skill paths (e.g. team/people/, team/decisions/). We keep the
+	// pre-existing strip behaviour so those wiki sections continue to look
+	// the way they did.
+	repo := newPromotionRepo(t)
+	source := "---\n" +
+		"name: jane-doe\n" +
+		"description: Engineer.\n" +
+		"---\n" +
+		"# Jane Doe\n\nbody\n"
+	src := seedNotebookEntry(t, repo, "pm", "jane.md", source)
+
+	p := &Promotion{
+		ID: "rvw-people-1", SourceSlug: "pm", SourcePath: src,
+		TargetPath: "team/people/jane-doe.md", Rationale: "r",
+	}
+	if _, err := repo.ApplyPromotion(context.Background(), p, "ceo"); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(repo.Root(), p.TargetPath))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if strings.HasPrefix(string(got), "---") {
+		t.Fatalf("non-skill target should not preserve frontmatter: %q", string(got))
+	}
+}
+
+func TestStripPromotionFrontmatterForTarget(t *testing.T) {
+	cases := []struct {
+		name       string
+		body       string
+		targetPath string
+		want       string
+	}{
+		{
+			name:       "no frontmatter passes through",
+			body:       "# hi\n",
+			targetPath: "team/playbooks/x.md",
+			want:       "# hi\n",
+		},
+		{
+			name:       "skill frontmatter preserved on team/playbooks/",
+			body:       "---\nname: x\ndescription: y\n---\n# body\n",
+			targetPath: "team/playbooks/x.md",
+			want:       "---\nname: x\ndescription: y\n---\n# body\n",
+		},
+		{
+			name:       "skill frontmatter preserved on team/skills/",
+			body:       "---\nname: x\ndescription: y\n---\n# body\n",
+			targetPath: "team/skills/x.md",
+			want:       "---\nname: x\ndescription: y\n---\n# body\n",
+		},
+		{
+			name:       "skill frontmatter stripped on team/people/",
+			body:       "---\nname: x\ndescription: y\n---\n# body\n",
+			targetPath: "team/people/x.md",
+			want:       "# body\n",
+		},
+		{
+			name:       "back-link only frontmatter stripped on team/playbooks/",
+			body:       "---\npromoted_to: team/playbooks/old.md\npromoted_by: ceo\n---\n# body\n",
+			targetPath: "team/playbooks/new.md",
+			want:       "# body\n",
+		},
+		{
+			name:       "name without description stripped on team/playbooks/",
+			body:       "---\nname: x\n---\n# body\n",
+			targetPath: "team/playbooks/x.md",
+			want:       "# body\n",
+		},
+		{
+			name:       "indented name does not satisfy preservation gate",
+			body:       "---\nmetadata:\n  name: nested\n  description: nested\n---\n# body\n",
+			targetPath: "team/playbooks/x.md",
+			want:       "# body\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripPromotionFrontmatterForTarget(tc.body, tc.targetPath)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestStripFrontmatter(t *testing.T) {
 	cases := map[string]string{
 		"# hi\n":                       "# hi\n",

--- a/internal/team/skill_compile_test.go
+++ b/internal/team/skill_compile_test.go
@@ -8,6 +8,9 @@ package team
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -211,6 +214,119 @@ func TestSkillCompileEnv_DefaultsAndOverrides(t *testing.T) {
 			t.Fatalf("invalid budget should fall back: got %d", got)
 		}
 	})
+}
+
+// fixedSkillProvider is a stub llmProvider that classifies every article as
+// a skill with a deterministic frontmatter derived from the path. Used to
+// exercise Stage A's proposal write path without an LLM round-trip.
+type fixedSkillProvider struct{}
+
+func (p *fixedSkillProvider) AskIsSkill(_ context.Context, articlePath, _ string) (bool, SkillFrontmatter, string, error) {
+	base := strings.TrimSuffix(filepath.Base(articlePath), ".md")
+	fm := SkillFrontmatter{
+		Name:        base,
+		Description: "Auto-classified skill for " + base + ".",
+		Version:     "1.0.0",
+		License:     "MIT",
+	}
+	return true, fm, "## Steps\n\n1. Do the thing.\n", nil
+}
+
+// TestStageACompilerSetsSourceArticle asserts that Stage A scans thread the
+// wiki-relative article path through to the proposed skill's SourceArticle
+// field — both on the in-memory record and on the rendered SKILL.md
+// frontmatter (metadata.wuphf.source_articles[0]). The provenance chain
+// (notebook → wiki → skill) is what drift detection, the UI source link,
+// and read-based staleness all key off, so this regression test guards
+// against the field being silently dropped on the write path.
+func TestStageACompilerSetsSourceArticle(t *testing.T) {
+	// Build a real wiki repo and seed an article that the scanner will
+	// classify as a skill via the deterministic stub provider.
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	worker.Start(context.Background())
+	defer worker.Stop()
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+
+	// Seed a playbook article. Frontmatter not strictly required for this
+	// test (the stub provider returns is_skill=true regardless), but
+	// matching the agent-authored shape keeps the test scenario realistic.
+	articleRel := "team/playbooks/customer-refund.md"
+	body := "---\nname: customer-refund\ndescription: Issue a refund.\n---\n# Customer Refund\n\nbody\n"
+	if _, _, err := repo.Commit(context.Background(), "ceo", articleRel, body, "create", "seed playbook"); err != nil {
+		t.Fatalf("seed playbook: %v", err)
+	}
+
+	scanner := NewSkillScanner(b, &fixedSkillProvider{}, 10)
+	res, err := scanner.Scan(context.Background(), "", false, "manual")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if res.Proposed == 0 {
+		t.Fatalf("expected at least one proposed skill, got %+v", res)
+	}
+
+	// In-memory proposal carries SourceArticle.
+	b.mu.Lock()
+	var found *teamSkill
+	for i := range b.skills {
+		if b.skills[i].Name == "customer-refund" {
+			found = &b.skills[i]
+			break
+		}
+	}
+	b.mu.Unlock()
+	if found == nil {
+		t.Fatalf("proposed skill customer-refund not found in broker.skills")
+	}
+	if found.SourceArticle != articleRel {
+		t.Fatalf("SourceArticle: got %q, want %q", found.SourceArticle, articleRel)
+	}
+
+	// On-disk SKILL.md surfaces it under metadata.wuphf.source_articles.
+	skillBytes, err := os.ReadFile(filepath.Join(root, "team/skills/customer-refund.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(skillBytes), "source_articles:") {
+		t.Fatalf("SKILL.md missing source_articles key: %q", string(skillBytes))
+	}
+	if !strings.Contains(string(skillBytes), articleRel) {
+		t.Fatalf("SKILL.md missing source article path %q: %q", articleRel, string(skillBytes))
+	}
+}
+
+// TestStageBSynthLeavesSourceArticleEmpty asserts that the Stage B synth
+// path — which is signal-derived rather than rooted in a specific wiki
+// page — does NOT set SourceArticle. Stage B's provenance lives in
+// metadata.wuphf.source_signals + the Signals body footer; coupling it to
+// a single source article would be incorrect.
+func TestStageBSynthLeavesSourceArticleEmpty(t *testing.T) {
+	fm := SkillFrontmatter{
+		Name:        "synth-skill",
+		Description: "A synthesized skill.",
+	}
+	cand := SkillCandidate{
+		Source:        SourceNotebookCluster,
+		SuggestedName: "synth-skill",
+		SignalCount:   2,
+		Excerpts: []SkillCandidateExcerpt{
+			{Path: "team/agents/eng/notebook/x.md", Snippet: "x", Author: "eng"},
+		},
+	}
+	spec := stageBCandToSpec(fm, "## Body\n", cand)
+	if spec.SourceArticle != "" {
+		t.Fatalf("Stage B spec.SourceArticle should be empty, got %q", spec.SourceArticle)
+	}
 }
 
 func TestParseSkillJSON_TolerantDecoder(t *testing.T) {

--- a/internal/team/skill_frontmatter.go
+++ b/internal/team/skill_frontmatter.go
@@ -156,7 +156,17 @@ func ParseSkillMarkdown(content []byte) (SkillFrontmatter, string, error) {
 
 // teamSkillToFrontmatter converts a teamSkill into its SkillFrontmatter
 // representation. All fields are populated so the emitted YAML is hub-ready.
+//
+// SourceArticle (Stage A wiki-rooted compiles) lands at
+// metadata.wuphf.source_articles[0] so the on-disk SKILL.md preserves the
+// wiki provenance chain across binary restarts. Stage B synth paths leave
+// SourceArticle empty and the slice stays nil — that path emits skills with
+// metadata.wuphf.source_signals instead, populated at the synth layer.
 func teamSkillToFrontmatter(sk teamSkill) SkillFrontmatter {
+	var sourceArticles []string
+	if s := strings.TrimSpace(sk.SourceArticle); s != "" {
+		sourceArticles = []string{s}
+	}
 	return SkillFrontmatter{
 		Name:        sk.Name,
 		Description: sk.Description,
@@ -166,6 +176,7 @@ func teamSkillToFrontmatter(sk teamSkill) SkillFrontmatter {
 			Wuphf: SkillWuphfMeta{
 				Title:              sk.Title,
 				Trigger:            sk.Trigger,
+				SourceArticles:     sourceArticles,
 				CreatedBy:          sk.CreatedBy,
 				Status:             sk.Status,
 				Tags:               append([]string(nil), sk.Tags...),

--- a/internal/team/skill_proposal_helper.go
+++ b/internal/team/skill_proposal_helper.go
@@ -70,8 +70,26 @@ func (b *Broker) writeSkillProposalLocked(spec teamSkill) (*teamSkill, error) {
 
 	// --- Step 3: Pre-lock dedup ---
 	if existing := b.findSkillByNameLocked(name); existing != nil {
-		slog.Debug("writeSkillProposalLocked: skill already exists, skipping",
-			"name", name, "existing_status", existing.Status)
+		// Backfill missing source_article on existing skills. Stage A skills
+		// created before the provenance fix landed will not heal otherwise:
+		// the dedup short-circuit returns before Step 4 ever copies
+		// spec.SourceArticle into the new struct, so /skills and the
+		// rendered SKILL.md stay permanently empty until the skill is
+		// deleted and recreated.
+		incoming := strings.TrimSpace(spec.SourceArticle)
+		if existing.SourceArticle == "" && incoming != "" {
+			existing.SourceArticle = incoming
+			existing.UpdatedAt = time.Now().UTC().Format(time.RFC3339)
+			slog.Info("skill_proposal: backfilled source_article on existing dedup",
+				"name", name, "source_article", incoming)
+			if err := b.saveLocked(); err != nil {
+				slog.Warn("skill_proposal: saveLocked after source_article backfill failed",
+					"name", name, "err", err)
+			}
+		} else {
+			slog.Debug("writeSkillProposalLocked: skill already exists, skipping",
+				"name", name, "existing_status", existing.Status)
+		}
 		return existing, nil
 	}
 

--- a/internal/team/skill_proposal_helper.go
+++ b/internal/team/skill_proposal_helper.go
@@ -98,6 +98,7 @@ func (b *Broker) writeSkillProposalLocked(spec teamSkill) (*teamSkill, error) {
 		Description:         strings.TrimSpace(spec.Description),
 		Content:             strings.TrimSpace(spec.Content),
 		CreatedBy:           createdBy,
+		SourceArticle:       strings.TrimSpace(spec.SourceArticle),
 		Channel:             channel,
 		Tags:                append([]string(nil), spec.Tags...),
 		Trigger:             strings.TrimSpace(spec.Trigger),

--- a/internal/team/skill_proposal_helper_test.go
+++ b/internal/team/skill_proposal_helper_test.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -324,6 +325,101 @@ func TestWriteSkillProposalLocked_GuardStampsSafetyScan(t *testing.T) {
 	b.mu.Unlock()
 	if rejected != 0 {
 		t.Errorf("expected zero rejections for safe verdict, got %d", rejected)
+	}
+}
+
+// TestWriteSkillProposalLocked_BackfillsSourceArticleOnDedup covers the
+// healing path for Stage A skills created before the provenance fix landed.
+// The existing skill carries an empty SourceArticle; the incoming spec has
+// it populated; dedup should copy the value through, persist, and surface a
+// log without creating a second skill.
+func TestWriteSkillProposalLocked_BackfillsSourceArticleOnDedup(t *testing.T) {
+	t.Parallel()
+	b := newTestBroker(t)
+
+	// Seed an existing skill with empty SourceArticle (simulates a
+	// pre-fix Stage A proposal).
+	first := skillProposalSpec("provenance-skill", "Backfill provenance.", "archivist")
+	first.SourceArticle = ""
+	sk1, err := callWriteSkillProposalLocked(b, first)
+	if err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+	if sk1.SourceArticle != "" {
+		t.Fatalf("seed precondition: SourceArticle should be empty, got %q", sk1.SourceArticle)
+	}
+
+	// Snapshot the count before the dedup call.
+	b.mu.Lock()
+	beforeCount := 0
+	for _, s := range b.skills {
+		if skillSlug(s.Name) == "provenance-skill" {
+			beforeCount++
+		}
+	}
+	b.mu.Unlock()
+
+	// Re-propose with provenance populated.
+	second := skillProposalSpec("provenance-skill", "Backfill provenance (again).", "archivist")
+	second.SourceArticle = "team/playbooks/provenance-skill.md"
+	sk2, err := callWriteSkillProposalLocked(b, second)
+	if err != nil {
+		t.Fatalf("dedup write: %v", err)
+	}
+	if sk2 == nil {
+		t.Fatal("dedup: expected non-nil skill")
+	}
+	if sk2.SourceArticle != "team/playbooks/provenance-skill.md" {
+		t.Errorf("SourceArticle: got %q, want %q (backfill did not run)",
+			sk2.SourceArticle, "team/playbooks/provenance-skill.md")
+	}
+
+	// No duplicate skill was created.
+	b.mu.Lock()
+	afterCount := 0
+	for _, s := range b.skills {
+		if skillSlug(s.Name) == "provenance-skill" {
+			afterCount++
+		}
+	}
+	found := b.findSkillByNameLocked("provenance-skill")
+	b.mu.Unlock()
+	if afterCount != beforeCount {
+		t.Errorf("dedup: skill count changed (before=%d, after=%d)", beforeCount, afterCount)
+	}
+	if found == nil || found.SourceArticle != "team/playbooks/provenance-skill.md" {
+		t.Errorf("in-memory skill SourceArticle not persisted: %+v", found)
+	}
+
+	// Saved state file exists (proves saveLocked was invoked). The state
+	// file was empty before the seed because newTestBroker pins statePath
+	// to a tmpdir; saveLocked wrote it during the seed write and again
+	// during backfill. We assert it exists rather than re-reading content.
+	if _, statErr := os.Stat(b.statePath); statErr != nil {
+		t.Errorf("expected state file at %q to exist after backfill, got: %v", b.statePath, statErr)
+	}
+}
+
+// TestWriteSkillProposalLocked_DedupNoBackfillWhenAlreadySet ensures we do
+// NOT overwrite an existing non-empty SourceArticle on the dedup path.
+func TestWriteSkillProposalLocked_DedupNoBackfillWhenAlreadySet(t *testing.T) {
+	t.Parallel()
+	b := newTestBroker(t)
+
+	first := skillProposalSpec("already-set", "Has provenance.", "archivist")
+	first.SourceArticle = "team/playbooks/original.md"
+	if _, err := callWriteSkillProposalLocked(b, first); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	second := skillProposalSpec("already-set", "Different.", "archivist")
+	second.SourceArticle = "team/playbooks/different.md"
+	sk, err := callWriteSkillProposalLocked(b, second)
+	if err != nil {
+		t.Fatalf("dedup: %v", err)
+	}
+	if sk.SourceArticle != "team/playbooks/original.md" {
+		t.Errorf("backfill should not overwrite a non-empty SourceArticle: got %q", sk.SourceArticle)
 	}
 }
 

--- a/internal/team/skill_scanner.go
+++ b/internal/team/skill_scanner.go
@@ -408,14 +408,30 @@ func (s *SkillScanner) loadTombstone() (slugs, sources map[string]bool) {
 // specToTeamSkill folds a SkillFrontmatter + body + source article into the
 // teamSkill shape that writeSkillProposalLocked expects. Only the fields the
 // frontmatter actually carries get set; the helper fills in defaults.
+//
+// sourceArticle threads the wiki-relative path of the article that drove the
+// proposal so the wiki provenance chain (notebook → wiki → skill) survives
+// onto the in-memory record and the rendered SKILL.md frontmatter. Per the
+// "archivist is a commit-author name, not an agent" decision (see
+// project_entity_briefs_v1_2.md) we leave CreatedBy = archivist on the
+// Stage A path. Drift detection, the UI source link, and read-based
+// staleness all key off SourceArticle.
 func specToTeamSkill(fm SkillFrontmatter, body, sourceArticle string) teamSkill {
 	wuphf := fm.Metadata.Wuphf
+	// Prefer the explicit sourceArticle argument; fall back to the first
+	// frontmatter source_article entry so existing callers that route
+	// provenance through the frontmatter still work.
+	src := strings.TrimSpace(sourceArticle)
+	if src == "" && len(wuphf.SourceArticles) > 0 {
+		src = strings.TrimSpace(wuphf.SourceArticles[0])
+	}
 	return teamSkill{
 		Name:               fm.Name,
 		Title:              wuphf.Title,
 		Description:        fm.Description,
 		Content:            body,
 		CreatedBy:          stringOr(wuphf.CreatedBy, "archivist"),
+		SourceArticle:      src,
 		Channel:            "general",
 		Tags:               append([]string(nil), wuphf.Tags...),
 		Trigger:            wuphf.Trigger,


### PR DESCRIPTION
## Summary

Two real bugs surfaced running the Priya end-to-end eval against the wiki-to-skills pipeline. Each lands as its own conventional commit so the diff stays reviewable per finding.

### Finding 1 - notebook -> promote strips skill YAML frontmatter

`ApplyPromotion` in `internal/team/promotion_commit.go` (line ~79) was unconditionally calling `stripFrontmatter` on the source notebook body before writing the target wiki article. Result: agent-authored playbooks/skills with explicit Anthropic Agent Skills frontmatter (`---\nname: foo\ndescription: bar\n---`) had their YAML dropped on promotion. That breaks the LLM-free Stage A fast path in `internal/team/skill_scanner.go` (`defaultLLMProvider.AskIsSkill` line ~564) which short-circuits via `ParseSkillMarkdown` when explicit frontmatter is present. Without that fast path the scanner falls back to a CLI-LLM round-trip that exits 1 in any environment without configured auth (CI, dev sandboxes, fresh installs).

Fix: detect skill-shaped frontmatter (top-level `name` + `description`) textually and preserve the YAML block verbatim when the target path is under `team/playbooks/` or `team/skills/`. Other paths (e.g. `team/people/`, `team/decisions/`) keep the prior strip behaviour. Detection is textual rather than parse-and-reserialise so comments, key ordering, and unknown keys all survive.

### Finding 2 - auto-compiled skills don't carry source_article provenance

The Stage A scanner (`SkillScanner.Scan` in `internal/team/skill_scanner.go` line ~243) was setting `fm.Metadata.Wuphf.SourceArticles` on the in-flight frontmatter, but `specToTeamSkill` dropped it when folding into `teamSkill` (no field for it), and `writeSkillProposalLocked` then rebuilt the frontmatter from `teamSkill` alone via `teamSkillToFrontmatter`. The on-disk SKILL.md ended up without `metadata.wuphf.source_articles`, and the `/skills` JSON response had `source_article: null`. That breaks the wiki provenance chain (notebook -> wiki -> skill) that drift detection, the UI source link, and read-based staleness all key off.

Fix: add a `SourceArticle` field to `teamSkill` (`json:"source_article,omitempty"`), populate it from `c.relPath` in `specToTeamSkill`, copy it through `writeSkillProposalLocked`, and emit it under `metadata.wuphf.source_articles[0]` in `teamSkillToFrontmatter`. Stage B paths (`stageBCandToSpec` in `skill_synthesizer.go`) that aren't rooted in a specific wiki page legitimately leave the field empty.

## Commits

- `fix(notebook): preserve YAML frontmatter when promoting to team/playbooks or team/skills`
- `fix(skill-compile): persist source_article on Stage A proposals`

## Test plan

- [x] `TestApplyPromotion_PreservesSkillFrontmatterOnPlaybookPath` - skill frontmatter preserved on `team/playbooks/`.
- [x] `TestApplyPromotion_PreservesSkillFrontmatterOnSkillsPath` - skill frontmatter preserved on `team/skills/`.
- [x] `TestApplyPromotion_StripsBackLinkOnlyFrontmatterOnPlaybookPath` - re-promotion case (back-link-only frontmatter) still strips.
- [x] `TestApplyPromotion_StripsFrontmatterOnNonSkillPath` - non-skill path keeps prior strip behaviour even with name/description.
- [x] `TestStripPromotionFrontmatterForTarget` - 7-case table covering edge cases (no frontmatter, indented keys, missing description, etc).
- [x] `TestPromoteToPlaybookPreservesFrontmatter` - end-to-end via the broker HTTP handler (notebook write -> promote -> approve -> read target).
- [x] `TestStageACompilerSetsSourceArticle` - Stage A scan against a real wiki repo writes `source_article` onto the in-memory record AND `metadata.wuphf.source_articles` onto the on-disk SKILL.md.
- [x] `TestStageBSynthLeavesSourceArticleEmpty` - Stage B synth path legitimately leaves `SourceArticle` empty.
- [x] Pre-existing `TestApplyPromotion_HappyPath` and `TestStripFrontmatter` still green (no regression).
- [x] Full `bash scripts/test-go.sh ./internal/team` green (~75s).
- [x] `gofmt -l internal/team/`, `go vet ./internal/team/...`, `golangci-lint run ./internal/team/...` all clean.

## Notes

Lands cleanly on top of `fix/skills-disable-enable-restore` (PR #559) - they touch different files and don't conflict.

Per memory `project_entity_briefs_v1_2.md`, `created_by=archivist` on auto-compiled skills is correct (archivist is a commit-author name, not an agent). This PR doesn't change that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added source-article provenance for skills and surface it with emitted skill metadata.
  * Promotion now preserves skill-specific YAML frontmatter (name/description) when promoting to playbook/skill targets.

* **Bug Fixes**
  * Prevents promotion back-link keys from leaking into preserved frontmatter.
  * Ensures non-skill destinations strip frontmatter as before.

* **Tests**
  * Added end-to-end and unit tests covering promotion/frontmatter behavior, dedupe/backfill, and skill provenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->