### PR TITLE
[codex] fix render leakage warnings in setup surfaces

### DIFF
--- a/web/src/components/apps/ReceiptsApp.tsx
+++ b/web/src/components/apps/ReceiptsApp.tsx
@@ -51,13 +51,13 @@ function ReceiptList({
         </div>
       </div>
 
-      {isLoading && (
+      {isLoading ? (
         <div style={{ padding: 20, color: "var(--text-tertiary)" }}>
           Loading...
         </div>
-      )}
+      ) : null}
 
-      {error && (
+      {error ? (
         <div
           style={{
             padding: "40px 20px",
@@ -68,7 +68,7 @@ function ReceiptList({
         >
           Could not load receipts.
         </div>
-      )}
+      ) : null}
 
       {!(isLoading || error) && (
         <TaskTable tasks={data?.tasks ?? []} onSelectTask={onSelectTask} />
@@ -145,7 +145,7 @@ function TaskTable({
                 }}
               >
                 {t.taskId}
-                {t.hasError && (
+                {t.hasError ? (
                   <span
                     title="Contains a tool error"
                     style={{
@@ -156,7 +156,7 @@ function TaskTable({
                   >
                     {"⚠"}
                   </span>
-                )}
+                ) : null}
               </td>
               <td
                 style={{
@@ -237,13 +237,13 @@ function ReceiptDetail({
         </div>
       </div>
 
-      {isLoading && (
+      {isLoading ? (
         <div style={{ padding: "16px 20px", color: "var(--text-tertiary)" }}>
           Loading...
         </div>
-      )}
+      ) : null}
 
-      {error && (
+      {error ? (
         <div
           style={{
             padding: "40px 20px",
@@ -254,7 +254,7 @@ function ReceiptDetail({
         >
           Could not load task trace.
         </div>
-      )}
+      ) : null}
 
       {!(isLoading || error) && entries.length === 0 && (
         <div
@@ -283,6 +283,8 @@ function ReceiptDetail({
 function EntryRow({ index, entry }: { index: number; entry: TaskLogEntry }) {
   const isError = Boolean(entry.error);
   const snippet = entry.error || entry.result || "";
+  const displaySnippet =
+    snippet.length > 400 ? `${snippet.slice(0, 400)}…` : snippet;
   return (
     <div
       style={{
@@ -314,11 +316,11 @@ function EntryRow({ index, entry }: { index: number; entry: TaskLogEntry }) {
         >
           {entry.tool_name || "(unknown)"}
         </span>
-        {entry.agent_slug && (
+        {entry.agent_slug ? (
           <span style={{ fontSize: 11, color: "var(--text-secondary)" }}>
             @{entry.agent_slug}
           </span>
-        )}
+        ) : null}
         {typeof entry.completed_at === "number" &&
           typeof entry.started_at === "number" && (
             <span
@@ -333,7 +335,7 @@ function EntryRow({ index, entry }: { index: number; entry: TaskLogEntry }) {
             </span>
           )}
       </div>
-      {snippet && (
+      {snippet ? (
         <div
           style={{
             fontSize: 12,
@@ -343,9 +345,9 @@ function EntryRow({ index, entry }: { index: number; entry: TaskLogEntry }) {
             wordBreak: "break-word",
           }}
         >
-          {snippet.length > 400 ? `${snippet.slice(0, 400)}…` : snippet}
+          {displaySnippet}
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -303,7 +303,7 @@ function Field({ label, hint, children }: FieldProps) {
     <div style={styles.row}>
       <div style={styles.rowLabel}>
         <div style={styles.rowLabelName}>{label}</div>
-        {hint && <div style={styles.rowLabelHint}>{hint}</div>}
+        {hint ? <div style={styles.rowLabelHint}>{hint}</div> : null}
       </div>
       <div style={styles.rowField}>{children}</div>
     </div>
@@ -582,12 +582,12 @@ function GeneralSection({ cfg, save }: SectionProps) {
         <SaveButton label="Save general settings" onSave={onSave} />
       </div>
 
-      {cfg.config_path && (
+      {cfg.config_path ? (
         <div style={{ marginTop: 24 }}>
           <div style={styles.groupTitle}>Config file</div>
           <div style={styles.filePath}>{cfg.config_path}</div>
         </div>
-      )}
+      ) : null}
     </div>
   );
 }
@@ -810,7 +810,7 @@ function LocalProviderCard({
               Default
             </span>
           )}
-          {status?.binary_version && (
+          {status?.binary_version ? (
             <span
               style={{
                 marginLeft: 8,
@@ -821,7 +821,7 @@ function LocalProviderCard({
             >
               {status.binary_version}
             </span>
-          )}
+          ) : null}
         </div>
         {!isDefault && (
           <button
@@ -844,12 +844,12 @@ function LocalProviderCard({
         {meta.blurb}
       </p>
 
-      {status?.windows_note && (
+      {status?.windows_note ? (
         <div style={{ ...styles.banner, fontSize: 12 }}>
           <span style={{ fontSize: 14, flexShrink: 0 }}>{"⚠"}</span>
           <div>{status.windows_note}</div>
         </div>
-      )}
+      ) : null}
 
       <Field
         label="Base URL"
@@ -877,7 +877,7 @@ function LocalProviderCard({
       </Field>
       <SaveButton label="Save endpoint" onSave={onSaveEndpoint} />
 
-      {!status?.binary_installed && installCmd && (
+      {!status?.binary_installed && installCmd ? (
         <div
           style={{
             marginTop: 12,
@@ -896,7 +896,7 @@ function LocalProviderCard({
             Install
           </div>
           <CommandRow command={installCmd} />
-          {startCmd && (
+          {startCmd ? (
             <>
               <div
                 style={{
@@ -911,10 +911,10 @@ function LocalProviderCard({
               </div>
               <CommandRow command={startCmd} />
             </>
-          )}
+          ) : null}
         </div>
-      )}
-      {status?.binary_installed && !status.reachable && startCmd && (
+      ) : null}
+      {status?.binary_installed && !status.reachable && startCmd ? (
         <div
           style={{
             marginTop: 12,
@@ -937,7 +937,7 @@ function LocalProviderCard({
           </div>
           <CommandRow command={startCmd} />
         </div>
-      )}
+      ) : null}
       {(status?.notes ?? []).map((note) => (
         <p
           key={note}
@@ -1012,17 +1012,17 @@ function LocalLLMsSection({ cfg, save }: SectionProps) {
         </button>
       </div>
 
-      {isLoading && (
+      {isLoading ? (
         <div style={{ color: "var(--text-tertiary)", fontSize: 13 }}>
           Detecting installed runtimes…
         </div>
-      )}
-      {error && (
+      ) : null}
+      {error ? (
         <div style={{ color: "var(--danger-500, #c33)", fontSize: 13 }}>
           Failed to load status:{" "}
           {error instanceof Error ? error.message : String(error)}
         </div>
-      )}
+      ) : null}
 
       {!(isLoading || error) &&
         LOCAL_PROVIDERS.map((meta) => (

--- a/web/src/components/onboarding/wizard/components.tsx
+++ b/web/src/components/onboarding/wizard/components.tsx
@@ -53,11 +53,11 @@ export function CheckIcon() {
 export function EnterHint({ modifier }: { modifier?: string } = {}) {
   return (
     <span className="kbd-hint" aria-hidden="true">
-      {modifier && (
+      {modifier ? (
         <Kbd size="sm" variant="inverse">
           {modifier}
         </Kbd>
-      )}
+      ) : null}
       <Kbd size="sm" variant="inverse">
         ↵
       </Kbd>


### PR DESCRIPTION
## Summary
- Fixes Biome `noLeakedRender` warnings in the onboarding wizard, receipts app, and settings app.
- Converts value-returning JSX `&&` guards to explicit ternaries.
- Keeps this as a stacked, focused follow-up to PR #561 to avoid growing the baseline audit PR.

## Validation
- `bun run build`
- `bun run test src/components/onboarding/Wizard.test.tsx`
- `bun run check` (passes with 425 warnings + 2 infos remaining)
- `git diff --check`

## Remaining follow-ups
- Continue `noLeakedRender` cleanup in the next highest-count UI surfaces.
- Address separate a11y warnings, CSS specificity warnings, complexity warnings, and test-helper non-null assertions in their own milestone PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated conditional rendering logic in the receipts app (list and detail views), settings app (field hints, configuration display, provider cards, and loading states), and onboarding wizard components.

* **Improvements**
  * Receipt snippets now truncate at 400 characters with ellipsis when displayed in the receipts list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->