### PR TITLE
[codex] fix render leakage warnings in core surfaces

### DIFF
--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -535,19 +535,21 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
                 {submitting ? "Reassigning..." : "Reassign"}
               </button>
             </div>
-            {errorMsg && <div className="task-detail-error">{errorMsg}</div>}
+            {errorMsg ? (
+              <div className="task-detail-error">{errorMsg}</div>
+            ) : null}
           </div>
         </section>
 
-        {(description || details) && (
+        {description || details ? (
           <section className="task-detail-section">
-            {description && (
+            {description ? (
               <>
                 <div className="task-detail-label">Description</div>
                 <div className="task-detail-body">{description}</div>
               </>
-            )}
-            {details && (
+            ) : null}
+            {details ? (
               <>
                 <div
                   className="task-detail-label"
@@ -557,9 +559,9 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
                 </div>
                 <div className="task-detail-body">{details}</div>
               </>
-            )}
+            ) : null}
           </section>
-        )}
+        ) : null}
 
         {dependsOn.length > 0 && (
           <section className="task-detail-section">
@@ -786,6 +788,7 @@ function StatusButton({
   const className =
     "btn btn-sm " +
     (danger ? "btn-ghost task-detail-status-btn-danger" : "btn-ghost");
+  const buttonLabel = isBusy ? "..." : label;
   return (
     <button
       type="button"
@@ -794,7 +797,7 @@ function StatusButton({
       disabled={disabled || isCurrent || anyBusy}
       title={isCurrent ? "Task is already in this state" : undefined}
     >
-      {isBusy ? "..." : label}
+      {buttonLabel}
     </button>
   );
 }

--- a/web/src/components/apps/TasksApp.tsx
+++ b/web/src/components/apps/TasksApp.tsx
@@ -295,12 +295,12 @@ export function TasksApp() {
           );
         })}
       </div>
-      {selectedTask && (
+      {selectedTask ? (
         <TaskDetailModal
           task={selectedTask}
           onClose={() => setSelectedTaskId(null)}
         />
-      )}
+      ) : null}
     </>
   );
 }
@@ -345,7 +345,7 @@ function TaskCard({
       style={{ marginBottom: 8, cursor: "pointer" }}
     >
       <div className="app-card-title">{task.title || "Untitled"}</div>
-      {task.description && (
+      {task.description ? (
         <div
           style={{
             fontSize: 12,
@@ -356,7 +356,7 @@ function TaskCard({
         >
           {task.description.slice(0, 160)}
         </div>
-      )}
+      ) : null}
       <div
         style={{
           display: "flex",
@@ -366,11 +366,15 @@ function TaskCard({
         }}
       >
         <span className={statusBadgeClass(status)}>{COLUMN_LABEL[status]}</span>
-        {task.owner && <span className="app-card-meta">@{task.owner}</span>}
-        {task.channel && <span className="app-card-meta">#{task.channel}</span>}
-        {timestamp && (
+        {task.owner ? (
+          <span className="app-card-meta">@{task.owner}</span>
+        ) : null}
+        {task.channel ? (
+          <span className="app-card-meta">#{task.channel}</span>
+        ) : null}
+        {timestamp ? (
           <span className="app-card-meta">{formatRelativeTime(timestamp)}</span>
-        )}
+        ) : null}
         {memoryBadge && (
           <span className={memoryBadge.className} title={memoryBadge.title}>
             {memoryBadge.label}

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -124,13 +124,13 @@ export function MessageBubble({
         ) : (
           <>
             <PixelAvatar slug={message.from} size={24} />
-            {harness && (
+            {harness ? (
               <HarnessBadge
                 kind={harness}
                 size={14}
                 className="harness-badge-on-avatar"
               />
-            )}
+            ) : null}
           </>
         )}
       </div>
@@ -221,13 +221,13 @@ export function MessageBubble({
 
       {/* Hover actions — reply in thread, quote, copy link. Absolutely
           positioned so they don't change the bubble's flow layout. */}
-      {(onOpenThread || onQuoteReply || onCopyLink) && (
+      {onOpenThread || onQuoteReply || onCopyLink ? (
         <div
           className="message-hover-actions"
           role="toolbar"
           aria-label="Message actions"
         >
-          {onOpenThread && (
+          {onOpenThread ? (
             <button
               className="message-hover-btn"
               onClick={() => onOpenThread(message.id)}
@@ -247,8 +247,8 @@ export function MessageBubble({
                 <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
               </svg>
             </button>
-          )}
-          {onQuoteReply && (
+          ) : null}
+          {onQuoteReply ? (
             <button
               className="message-hover-btn"
               onClick={() => onQuoteReply(message)}
@@ -269,8 +269,8 @@ export function MessageBubble({
                 <path d="m16 16-5-5 5-5" />
               </svg>
             </button>
-          )}
-          {onCopyLink && (
+          ) : null}
+          {onCopyLink ? (
             <button
               className="message-hover-btn"
               onClick={() => onCopyLink(message.id)}
@@ -291,9 +291,9 @@ export function MessageBubble({
                 <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.72-1.71" />
               </svg>
             </button>
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -399,7 +399,9 @@ function ToolCallCard({
       >
         <span className={`cc-tool-chevron${open ? " open" : ""}`}>▸</span>
         <span className="cc-tool-name">{toolName}</span>
-        {summaryArg && <span className="cc-tool-summary">{summaryArg}</span>}
+        {summaryArg ? (
+          <span className="cc-tool-summary">{summaryArg}</span>
+        ) : null}
       </button>
       {summaryResult && !open && (
         <div className="cc-tool-result-summary">
@@ -413,7 +415,7 @@ function ToolCallCard({
           {summaryError}
         </div>
       )}
-      {open && (
+      {open ? (
         <div className="cc-tool-body">
           {Object.keys(cleanArgs).length > 0 && (
             <>
@@ -433,16 +435,16 @@ function ToolCallCard({
                 ))}
               </>
             )}
-          {hasError && (
+          {hasError ? (
             <>
               <div className="cc-tool-section-label cc-tool-error">
                 {"\u2717 Error"}
               </div>
               <ToolErrorContent error={errorField} compact={compact} />
             </>
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
     </div>
   );
 }
@@ -565,6 +567,8 @@ function GenericEventCard({
       parsed.text ??
       parsed.summary,
   );
+  const displayDetail =
+    detail.length > 300 ? `${detail.slice(0, 300)}\u2026` : detail;
 
   const extras = useMemo<Record<string, unknown>>(() => {
     const out: Record<string, unknown> = {};
@@ -578,7 +582,7 @@ function GenericEventCard({
 
   return (
     <div className="stream-card">
-      {(phase || agent) && (
+      {phase || agent ? (
         <div className="stream-card-header">
           {phase && (
             <span
@@ -589,12 +593,10 @@ function GenericEventCard({
           )}
           {agent && <span className="stream-card-agent">{agent}</span>}
         </div>
-      )}
-      {detail && (
-        <div className="stream-card-detail">
-          {detail.length > 300 ? `${detail.slice(0, 300)}\u2026` : detail}
-        </div>
-      )}
+      ) : null}
+      {detail ? (
+        <div className="stream-card-detail">{displayDetail}</div>
+      ) : null}
       {Object.keys(extras).length > 0 && Object.keys(extras).length <= 8 && (
         <div className="stream-line-json">
           <Value value={extras} depth={0} compact={compact} />

--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -279,7 +279,7 @@ export default function WikiEditor({
       className={`wk-editor${previewOn ? " wk-editor--with-preview" : ""}`}
       data-testid="wk-editor"
     >
-      {draft && (
+      {draft ? (
         <div
           className="wk-editor-banner wk-editor-banner--draft"
           role="alert"
@@ -303,8 +303,8 @@ export default function WikiEditor({
             </button>
           </div>
         </div>
-      )}
-      {conflict && (
+      ) : null}
+      {conflict ? (
         <div
           className="wk-editor-banner wk-editor-banner--conflict"
           role="alert"
@@ -317,13 +317,13 @@ export default function WikiEditor({
             </button>
           </div>
         </div>
-      )}
+      ) : null}
       {error && !conflict && (
         <div className="wk-editor-banner wk-editor-banner--error" role="alert">
           {error}
         </div>
       )}
-      {previewOn && isMobile && (
+      {previewOn && isMobile ? (
         <div
           className="wk-editor-mobile-tabs"
           role="tablist"
@@ -356,9 +356,9 @@ export default function WikiEditor({
             Preview
           </button>
         </div>
-      )}
+      ) : null}
       <div className="wk-editor-panes">
-        {showSource && (
+        {showSource ? (
           <div className="wk-editor-pane wk-editor-pane--source">
             <label className="wk-editor-label" htmlFor="wk-editor-textarea">
               Article source ({path})
@@ -374,8 +374,8 @@ export default function WikiEditor({
               rows={28}
             />
           </div>
-        )}
-        {showPreview && (
+        ) : null}
+        {showPreview ? (
           <div
             className="wk-editor-pane wk-editor-pane--preview"
             data-testid="wk-editor-preview"
@@ -391,7 +391,7 @@ export default function WikiEditor({
               </ReactMarkdown>
             </div>
           </div>
-        )}
+        ) : null}
       </div>
       <label className="wk-editor-label" htmlFor="wk-editor-commit-msg">
         Edit summary


### PR DESCRIPTION
## Summary
- Clears Biome `noLeakedRender` warnings in the next five highest-count UI surfaces.
- Covers task detail, task list cards, message bubble actions, stream line tool cards, and the wiki editor.
- Stacks on PR #562 to keep the render-warning work reviewable in small milestones.

## Validation
- `bun run build`
- `bun run test src/components/apps/TaskDetailModal.test.tsx src/components/messages/StreamLineView.test.tsx src/components/wiki/WikiEditor.test.tsx`
- `bun run check` (passes with 400 warnings + 2 infos remaining)
- `git diff --check`

## Remaining follow-ups
- Continue remaining `noLeakedRender` cleanup in activity, requests, wiki sidebar/facts/citation, agents, and notebook surfaces.
- Address separate a11y warnings, CSS specificity warnings, complexity warnings, and test-helper non-null assertions in later scoped PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements to rendering logic across modal, messaging, and editor components. These changes maintain existing functionality and user experience while improving code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->