### PR TITLE
[codex] fix render leakage warnings in wiki surfaces

### DIFF
--- a/web/src/components/activity/InsightsList.tsx
+++ b/web/src/components/activity/InsightsList.tsx
@@ -47,16 +47,18 @@ export function InsightsList({
             <span className={`insight-badge insight-badge-${ins.priority}`}>
               [{PRIORITY_LABEL[ins.priority]}]
             </span>
-            {ins.category && (
+            {ins.category ? (
               <span className="insight-category">[{ins.category}]</span>
-            )}
+            ) : null}
             <span className="insight-title">{ins.title}</span>
-            {ins.time && <span className="insight-time">{ins.time}</span>}
+            {ins.time ? <span className="insight-time">{ins.time}</span> : null}
           </div>
-          {ins.body && (
+          {ins.body ? (
             <div className="insight-body">{truncate(ins.body, 220)}</div>
-          )}
-          {ins.target && <div className="insight-target">({ins.target})</div>}
+          ) : null}
+          {ins.target ? (
+            <div className="insight-target">({ins.target})</div>
+          ) : null}
         </div>
       ))}
       {overflow > 0 && <div className="insight-more">+ {overflow} more</div>}

--- a/web/src/components/activity/Timeline.tsx
+++ b/web/src/components/activity/Timeline.tsx
@@ -66,9 +66,11 @@ export function Timeline({ events, emptyLabel, limit }: TimelineProps) {
           <div className="timeline-body">
             <div className="timeline-content">{truncate(ev.content, 220)}</div>
             <div className="timeline-meta">
-              {ev.timestamp && <span>{formatRelativeTime(ev.timestamp)}</span>}
-              {ev.actor && <span>@{ev.actor}</span>}
-              {ev.meta && <span>{ev.meta}</span>}
+              {ev.timestamp ? (
+                <span>{formatRelativeTime(ev.timestamp)}</span>
+              ) : null}
+              {ev.actor ? <span>@{ev.actor}</span> : null}
+              {ev.meta ? <span>{ev.meta}</span> : null}
             </div>
           </div>
         </div>

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -266,9 +266,9 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
                 style={{ marginLeft: -2 }}
               />
             </div>
-            {agent.role && (
+            {agent.role ? (
               <span className="agent-panel-role">{agent.role}</span>
-            )}
+            ) : null}
           </div>
         </div>
         <button
@@ -297,18 +297,18 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
               </div>
             ) : null;
           })()}
-          {agent.status && (
+          {agent.status ? (
             <div className="agent-panel-info-row">
               <span className="agent-panel-info-label">status</span>
               <span className="agent-panel-info-value">{agent.status}</span>
             </div>
-          )}
-          {agent.task && (
+          ) : null}
+          {agent.task ? (
             <div className="agent-panel-info-row">
               <span className="agent-panel-info-label">task</span>
               <span className="agent-panel-info-value">{agent.task}</span>
             </div>
-          )}
+          ) : null}
         </div>
       </div>
 

--- a/web/src/components/apps/PoliciesApp.tsx
+++ b/web/src/components/apps/PoliciesApp.tsx
@@ -105,7 +105,7 @@ export function PoliciesApp() {
       </div>
 
       {/* Inline add form */}
-      {formOpen && (
+      {formOpen ? (
         <div
           style={{
             padding: "8px 20px 12px",
@@ -137,10 +137,10 @@ export function PoliciesApp() {
             </button>
           </div>
         </div>
-      )}
+      ) : null}
 
       {/* Policy list */}
-      {isLoading && (
+      {isLoading ? (
         <div
           style={{
             padding: 20,
@@ -151,9 +151,9 @@ export function PoliciesApp() {
         >
           Loading...
         </div>
-      )}
+      ) : null}
 
-      {error && (
+      {error ? (
         <div
           style={{
             padding: "40px 20px",
@@ -164,7 +164,7 @@ export function PoliciesApp() {
         >
           Failed to load policies.
         </div>
-      )}
+      ) : null}
 
       {!(isLoading || error) && activePolicies.length === 0 && (
         <div

--- a/web/src/components/apps/RequestsApp.tsx
+++ b/web/src/components/apps/RequestsApp.tsx
@@ -162,14 +162,14 @@ function RequestItem({ request, isPending, onAnswer }: RequestItemProps) {
         <span style={{ fontWeight: 600, fontSize: 13 }}>
           {request.from || "Unknown"}
         </span>
-        {request.status && (
+        {request.status ? (
           <span className="badge badge-accent">
             {request.status.toUpperCase()}
           </span>
-        )}
-        {request.blocking && (
+        ) : null}
+        {request.blocking ? (
           <span className="badge badge-yellow">BLOCKING</span>
-        )}
+        ) : null}
       </div>
 
       {request.title && request.title !== "Request" && (
@@ -182,7 +182,7 @@ function RequestItem({ request, isPending, onAnswer }: RequestItemProps) {
         {request.question || ""}
       </div>
 
-      {request.context && (
+      {request.context ? (
         <div
           style={{
             fontSize: 12,
@@ -193,13 +193,13 @@ function RequestItem({ request, isPending, onAnswer }: RequestItemProps) {
         >
           {request.context}
         </div>
-      )}
+      ) : null}
 
-      {ts && (
+      {ts ? (
         <div className="app-card-meta" style={{ marginBottom: 6 }}>
           {formatRelativeTime(ts)}
         </div>
-      )}
+      ) : null}
 
       {isPending && options.length > 0 && (
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>

--- a/web/src/components/apps/SettingsApp.imageGen.tsx
+++ b/web/src/components/apps/SettingsApp.imageGen.tsx
@@ -67,6 +67,13 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
   const [baseURL, setBaseURL] = useState(s.base_url ?? "");
   const [model, setModel] = useState(s.default_model ?? "");
   const [showKey, setShowKey] = useState(false);
+  const capabilityLabel = [
+    s.kind,
+    s.supports_video ? "video" : "",
+    s.implementation_ok ? "" : "stub",
+  ]
+    .filter(Boolean)
+    .join(" · ");
 
   const mutation = useMutation({
     mutationFn: () =>
@@ -103,9 +110,7 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
         <span
           style={{ fontSize: 11, color: "var(--text-tertiary)", marginLeft: "auto" }}
         >
-          {s.kind}
-          {s.supports_video && " · video"}
-          {s.implementation_ok ? "" : " · stub"}
+          {capabilityLabel}
         </span>
       </div>
       <p
@@ -118,7 +123,7 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
       >
         {s.blurb}
       </p>
-      {s.setup_hint && (
+      {s.setup_hint ? (
         <p
           style={{
             fontSize: 11,
@@ -131,9 +136,9 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
         >
           {s.setup_hint}
         </p>
-      )}
+      ) : null}
 
-      {s.needs_api_key && (
+      {s.needs_api_key ? (
         <div style={{ marginBottom: 10 }}>
           <label style={labelStyle}>
             API key {s.api_key_set ? "(set)" : "(unset)"}
@@ -156,7 +161,7 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
             </button>
           </div>
         </div>
-      )}
+      ) : null}
 
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 10, marginBottom: 10 }}>
         <div>

--- a/web/src/components/layout/UpgradeBanner.tsx
+++ b/web/src/components/layout/UpgradeBanner.tsx
@@ -525,14 +525,14 @@ export function UpgradeBanner() {
         className="upgrade-banner-changelog"
         hidden={!expanded}
       >
-        {expanded && (
+        {expanded ? (
           <>
-            {changelog.loading && (
+            {changelog.loading ? (
               <div className="upgrade-banner-changelog-status">
                 Loading changes…
               </div>
-            )}
-            {changelog.error && (
+            ) : null}
+            {changelog.error ? (
               <div className="upgrade-banner-changelog-status">
                 Could not load changelog ({changelog.error}).{" "}
                 <a href={compareUrl} target="_blank" rel="noopener noreferrer">
@@ -540,7 +540,7 @@ export function UpgradeBanner() {
                 </a>
                 .
               </div>
-            )}
+            ) : null}
             {!(changelog.loading || changelog.error) &&
               changelog.commits.length === 0 && (
                 <div className="upgrade-banner-changelog-status">
@@ -595,7 +595,7 @@ export function UpgradeBanner() {
               </div>
             ))}
           </>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/web/src/components/messages/HumanInterviewOverlay.tsx
+++ b/web/src/components/messages/HumanInterviewOverlay.tsx
@@ -103,16 +103,16 @@ function BlockingInterview({
         <div className="interview-meta">
           <span className="badge badge-yellow">BLOCKING</span>
           <span className="interview-from">@{request.from || "agent"}</span>
-          {request.channel && (
+          {request.channel ? (
             <span className="interview-channel">in #{request.channel}</span>
-          )}
+          ) : null}
         </div>
         <h2 id="interview-title" className="interview-title">
           {request.title && request.title !== "Request"
             ? request.title
             : "Human decision requested"}
         </h2>
-        {isEnhanceInterview && enhancesSlug && (
+        {isEnhanceInterview && enhancesSlug ? (
           <div
             className="interview-enhance-banner"
             role="note"
@@ -145,11 +145,11 @@ function BlockingInterview({
               . Enhance it or approve anyway.
             </span>
           </div>
-        )}
+        ) : null}
         <p className="interview-question">{request.question}</p>
-        {request.context && (
+        {request.context ? (
           <p className="interview-context">{request.context}</p>
-        )}
+        ) : null}
         {options.length > 0 ? (
           <div className="interview-actions">
             {options.map((opt) => (

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -233,9 +233,9 @@ export function InterviewBar() {
         <span className="interview-bar-from">
           @{current.from || "agent"} asks
         </span>
-        {current.channel && (
+        {current.channel ? (
           <span className="interview-bar-channel">in #{current.channel}</span>
-        )}
+        ) : null}
         <span className="interview-bar-counter">
           {safeCursor + 1}/{visible.length}
         </span>
@@ -274,17 +274,17 @@ export function InterviewBar() {
       </div>
 
       <div className="interview-bar-body">
-        {current.title && current.title !== "Request" && (
+        {current.title && current.title !== "Request" ? (
           <div className="interview-bar-title">{current.title}</div>
-        )}
+        ) : null}
         <div className="interview-bar-question">
           {(current.question || "")
             .replace(/\*\*/g, "")
             .replace(/^\s*\d+\.\s*/, "")}
         </div>
-        {current.context && (
+        {current.context ? (
           <div className="interview-bar-context">{current.context}</div>
-        )}
+        ) : null}
 
         {ambiguousRef ? (
           <SimilarBanner
@@ -364,9 +364,9 @@ export function InterviewBar() {
             >
               <span className="interview-bar-opt-num">{i + 1}</span>
               <span className="interview-bar-opt-label">{opt.label}</span>
-              {opt.requires_text && (
+              {opt.requires_text ? (
                 <span className="interview-bar-text-hint"> · type</span>
-              )}
+              ) : null}
             </button>
           ))}
         </div>

--- a/web/src/components/notebook/NotebookEntry.tsx
+++ b/web/src/components/notebook/NotebookEntry.tsx
@@ -116,9 +116,9 @@ export default function NotebookEntryView({
       {showDraftStamp && <DraftStamp />}
 
       <h1 className="nb-entry-title">{entry.title}</h1>
-      {entry.subtitle && (
+      {entry.subtitle ? (
         <div className="nb-entry-subtitle">{entry.subtitle}</div>
-      )}
+      ) : null}
 
       <ByLineStrip
         authorSlug={entry.agent_slug}
@@ -130,12 +130,12 @@ export default function NotebookEntryView({
 
       <EntryBody markdown={entry.body_md} onWikiNavigate={onNavigateWiki} />
 
-      {entry.promoted_back && (
+      {entry.promoted_back ? (
         <PromotedBackCallout
           link={entry.promoted_back}
           onNavigate={onNavigateWiki}
         />
-      )}
+      ) : null}
 
       <InlineReviewThread
         reviewerSlug={entry.reviewer_slug}
@@ -148,11 +148,11 @@ export default function NotebookEntryView({
         pending={pending}
         onPromote={handlePromote}
       />
-      {promoteError && (
+      {promoteError ? (
         <p className="nb-error" role="alert">
           Could not submit: {promoteError}
         </p>
-      )}
+      ) : null}
 
       <PosterityLine
         authorSlug={entry.agent_slug}

--- a/web/src/components/search/SearchModal.tsx
+++ b/web/src/components/search/SearchModal.tsx
@@ -427,7 +427,7 @@ export function SearchModal() {
             value={query}
             onChange={(e) => handleQueryChange(e.target.value)}
           />
-          {searching && <span className="search-spinner" />}
+          {searching ? <span className="search-spinner" /> : null}
         </div>
 
         <div className="cmd-palette-results">
@@ -458,17 +458,17 @@ export function SearchModal() {
                           ? highlightMatch(item.label, query.trim())
                           : item.label}
                       </span>
-                      {item.desc && (
+                      {item.desc ? (
                         <span className="cmd-palette-item-desc">
                           {item.group === "Wiki" || item.group === "Notebooks"
                             ? highlightMatch(item.desc, query.trim())
                             : item.desc}
                         </span>
-                      )}
+                      ) : null}
                     </span>
-                    {item.meta && (
+                    {item.meta ? (
                       <span className="cmd-palette-item-meta">{item.meta}</span>
-                    )}
+                    ) : null}
                   </button>
                 ))}
               </div>

--- a/web/src/components/wiki/CitedAnswer.tsx
+++ b/web/src/components/wiki/CitedAnswer.tsx
@@ -147,7 +147,7 @@ export default function CitedAnswer({ query }: CitedAnswerProps) {
       </Hatnote>
 
       {/* Body — only when there is an answer */}
-      {answer.answer_markdown && (
+      {answer.answer_markdown ? (
         <div className="wk-article-body" data-testid="wk-cited-answer-body">
           <ReactMarkdown
             remarkPlugins={remarkPlugins}
@@ -157,15 +157,15 @@ export default function CitedAnswer({ query }: CitedAnswerProps) {
             {answer.answer_markdown}
           </ReactMarkdown>
         </div>
-      )}
+      ) : null}
 
       {/* Out-of-scope: no sources block */}
-      {isOutOfScope && (
+      {isOutOfScope ? (
         <p className="wk-cited-answer-oos">
           I can help with questions about people, companies, and activities in
           your workspace.
         </p>
-      )}
+      ) : null}
 
       {/* Sources — only cited entries, only when not out-of-scope.
           Each <li> carries an explicit `value` so browser numbering matches
@@ -190,13 +190,15 @@ export default function CitedAnswer({ query }: CitedAnswerProps) {
                     value={n}
                   >
                     <span className="wk-commit-msg">{excerpt}</span>
-                    {src.title && <span className="wk-agent">{src.title}</span>}
-                    {src.valid_from && (
+                    {src.title ? (
+                      <span className="wk-agent">{src.title}</span>
+                    ) : null}
+                    {src.valid_from ? (
                       <span className="wk-dim">
                         {" "}
                         · {src.valid_from.slice(0, 10)}
                       </span>
-                    )}
+                    ) : null}
                   </li>
                 );
               })}

--- a/web/src/components/wiki/FactsOnFile.tsx
+++ b/web/src/components/wiki/FactsOnFile.tsx
@@ -104,93 +104,98 @@ export default function FactsOnFile({ kind, slug }: FactsOnFileProps) {
       ) : (
         <>
           <ol className="wk-facts-items">
-            {visibleFacts.map((f) => (
-              <li
-                key={f.id}
-                className="wk-facts-item"
-                data-fact-type={f.type ?? "observation"}
-                data-superseded={isSuperseded(f) ? "true" : undefined}
-              >
-                <PixelAvatar slug={f.recorded_by} size={14} />
-                <div className="wk-facts-body">
-                  <span className="wk-facts-text">{f.text}</span>
-                  {f.triplet && (
-                    <span
-                      className="wk-facts-triplet"
-                      aria-label="Typed triplet"
-                    >
-                      <code>{f.triplet.subject}</code>
-                      {" — "}
-                      <code>{f.triplet.predicate}</code>
-                      {" → "}
-                      <code>{f.triplet.object}</code>
+            {visibleFacts.map((f) => {
+              const validity = formatValidity(f);
+              return (
+                <li
+                  key={f.id}
+                  className="wk-facts-item"
+                  data-fact-type={f.type ?? "observation"}
+                  data-superseded={isSuperseded(f) ? "true" : undefined}
+                >
+                  <PixelAvatar slug={f.recorded_by} size={14} />
+                  <div className="wk-facts-body">
+                    <span className="wk-facts-text">{f.text}</span>
+                    {f.triplet ? (
+                      <span
+                        className="wk-facts-triplet"
+                        aria-label="Typed triplet"
+                      >
+                        <code>{f.triplet.subject}</code>
+                        {" — "}
+                        <code>{f.triplet.predicate}</code>
+                        {" → "}
+                        <code>{f.triplet.object}</code>
+                      </span>
+                    ) : null}
+                    <span className="wk-facts-meta">
+                      {f.type ? (
+                        <span className="wk-facts-type">{f.type}</span>
+                      ) : null}
+                      {typeof f.confidence === "number" ? (
+                        <>
+                          {f.type ? " · " : null}
+                          <span
+                            className="wk-facts-confidence"
+                            aria-label={`Confidence ${(f.confidence * 100).toFixed(0)} percent`}
+                          >
+                            {f.confidence.toFixed(2)}
+                          </span>
+                        </>
+                      ) : null}
+                      {f.type || typeof f.confidence === "number"
+                        ? " · "
+                        : null}
+                      {formatAgentName(f.recorded_by)}
+                      {" · "}
+                      <time dateTime={f.created_at}>
+                        {formatShortTs(f.created_at)}
+                      </time>
+                      {validity ? (
+                        <>
+                          {" · "}
+                          <span className="wk-facts-validity">{validity}</span>
+                        </>
+                      ) : null}
+                      {f.reinforced_at ? (
+                        <>
+                          {" · "}
+                          <span
+                            className="wk-facts-reinforced"
+                            aria-label={`Reinforced ${formatShortTs(f.reinforced_at)}`}
+                          >
+                            reinforced {formatShortTs(f.reinforced_at)}
+                          </span>
+                        </>
+                      ) : null}
+                      {isWikiSource(f.source_path) ? (
+                        <>
+                          {" · "}
+                          <a
+                            className="wk-facts-source"
+                            href={`#/wiki/${f.source_path}`}
+                            data-wikilink="true"
+                          >
+                            {sourceLabel(f.source_path as string)}
+                          </a>
+                        </>
+                      ) : null}
+                      {f.supersedes && f.supersedes.length > 0 ? (
+                        <>
+                          {" · "}
+                          <span
+                            className="wk-facts-supersedes"
+                            aria-label={`Supersedes ${f.supersedes.length} prior fact${f.supersedes.length === 1 ? "" : "s"}`}
+                          >
+                            supersedes {f.supersedes.length} prior
+                          </span>
+                        </>
+                      ) : null}
                     </span>
-                  )}
-                  <span className="wk-facts-meta">
-                    {f.type && <span className="wk-facts-type">{f.type}</span>}
-                    {typeof f.confidence === "number" && (
-                      <>
-                        {f.type && " · "}
-                        <span
-                          className="wk-facts-confidence"
-                          aria-label={`Confidence ${(f.confidence * 100).toFixed(0)} percent`}
-                        >
-                          {f.confidence.toFixed(2)}
-                        </span>
-                      </>
-                    )}
-                    {(f.type || typeof f.confidence === "number") && " · "}
-                    {formatAgentName(f.recorded_by)}
-                    {" · "}
-                    <time dateTime={f.created_at}>
-                      {formatShortTs(f.created_at)}
-                    </time>
-                    {formatValidity(f) && (
-                      <>
-                        {" · "}
-                        <span className="wk-facts-validity">
-                          {formatValidity(f)}
-                        </span>
-                      </>
-                    )}
-                    {f.reinforced_at && (
-                      <>
-                        {" · "}
-                        <span
-                          className="wk-facts-reinforced"
-                          aria-label={`Reinforced ${formatShortTs(f.reinforced_at)}`}
-                        >
-                          reinforced {formatShortTs(f.reinforced_at)}
-                        </span>
-                      </>
-                    )}
-                    {isWikiSource(f.source_path) && (
-                      <>
-                        {" · "}
-                        <a
-                          className="wk-facts-source"
-                          href={`#/wiki/${f.source_path}`}
-                          data-wikilink="true"
-                        >
-                          {sourceLabel(f.source_path as string)}
-                        </a>
-                      </>
-                    )}
-                    {f.supersedes && f.supersedes.length > 0 && (
-                      <>
-                        {" · "}
-                        <span
-                          className="wk-facts-supersedes"
-                          aria-label={`Supersedes ${f.supersedes.length} prior fact${f.supersedes.length === 1 ? "" : "s"}`}
-                        >
-                          supersedes {f.supersedes.length} prior
-                        </span>
-                      </>
-                    )}
-                  </span>
-                </div>
-              </li>
-            ))}
+                  </div>
+                </li>
+              );
+            })}
           </ol>
           {facts.length > INITIAL_LIMIT && (
             <button

--- a/web/src/components/wiki/PlaybookExecutionLog.tsx
+++ b/web/src/components/wiki/PlaybookExecutionLog.tsx
@@ -126,7 +126,7 @@ export default function PlaybookExecutionLog({
           {expanded ? "▾" : "▸"}
         </span>
       </button>
-      {expanded && (
+      {expanded ? (
         <div className="wk-playbook-executions__body">
           {loading ? (
             <p className="wk-playbook-executions__loading">
@@ -154,11 +154,11 @@ export default function PlaybookExecutionLog({
                       <p className="wk-playbook-execution__summary">
                         {e.summary}
                       </p>
-                      {e.notes && (
+                      {e.notes ? (
                         <p className="wk-playbook-execution__notes">
                           {e.notes}
                         </p>
-                      )}
+                      ) : null}
                       <span className="wk-playbook-execution__meta">
                         {formatAgentName(e.recorded_by)}
                         {" · "}
@@ -170,7 +170,7 @@ export default function PlaybookExecutionLog({
                   </li>
                 ))}
               </ol>
-              {entries.length > INITIAL_LIMIT && (
+              {entries.length > INITIAL_LIMIT ? (
                 <button
                   type="button"
                   className="wk-playbook-executions__more"
@@ -180,7 +180,7 @@ export default function PlaybookExecutionLog({
                     ? "show recent only"
                     : `show all (${entries.length - INITIAL_LIMIT} more)`}
                 </button>
-              )}
+              ) : null}
             </>
           )}
           <SynthesisFooter
@@ -189,7 +189,7 @@ export default function PlaybookExecutionLog({
             onResynthesize={handleResynthesize}
           />
         </div>
-      )}
+      ) : null}
     </section>
   );
 }
@@ -227,9 +227,9 @@ function SynthesisFooter({
     >
       <div className="wk-playbook-synthesis__status">
         <span className="wk-playbook-synthesis__badge">{lastLabel}</span>
-        {pendingLabel && (
+        {pendingLabel ? (
           <span className="wk-playbook-synthesis__pending">{pendingLabel}</span>
-        )}
+        ) : null}
       </div>
       <button
         type="button"

--- a/web/src/components/wiki/WikiSidebar.tsx
+++ b/web/src/components/wiki/WikiSidebar.tsx
@@ -82,12 +82,12 @@ export default function WikiSidebar({
         value={query}
         onChange={(e) => setQuery(e.target.value)}
       />
-      {bannerSlug && (
+      {bannerSlug ? (
         <AddToBlueprintBanner
           slug={bannerSlug}
           onDismiss={() => setBannerSlug(null)}
         />
-      )}
+      ) : null}
       <div className="wk-nav-sidebar-scroll">
         {usingSections
           ? sectionList.map((section) => (
@@ -133,7 +133,7 @@ export default function WikiSidebar({
               );
             })}
       </div>
-      {onNavigateAudit && (
+      {onNavigateAudit ? (
         <div className="wk-sidebar-audit">
           <button
             type="button"
@@ -146,8 +146,8 @@ export default function WikiSidebar({
             View audit log →
           </button>
         </div>
-      )}
-      {onNavigateLint && (
+      ) : null}
+      {onNavigateLint ? (
         <div className="wk-sidebar-audit">
           <button
             type="button"
@@ -160,7 +160,7 @@ export default function WikiSidebar({
             Check wiki health →
           </button>
         </div>
-      )}
+      ) : null}
     </aside>
   );
 }
@@ -198,14 +198,14 @@ function SectionGroup({
         }
       >
         <span className="wk-section-title">{section.slug}</span>
-        {!section.from_schema && (
+        {!section.from_schema ? (
           <span className="wk-section-marker" aria-label="Discovered section" />
-        )}
-        {isNew && (
+        ) : null}
+        {isNew ? (
           <span className="wk-section-new" aria-label="New section">
             new
           </span>
-        )}
+        ) : null}
       </h3>
       <ul>
         {entries.length === 0 ? (


### PR DESCRIPTION
## Summary
- Clears Biome `noLeakedRender` warnings in activity insights, requests, cited answers, facts-on-file, and wiki sidebar surfaces.
- Converts value-returning JSX `&&` guards to explicit ternaries and precomputes facts validity while rendering facts metadata.
- Stacks on PR #563 to keep the render-warning cleanup in small reviewable milestones.

## Validation
- `bun run build`
- `bun run test src/components/wiki/WikiSidebar.test.tsx src/components/wiki/FactsOnFile.test.tsx src/components/wiki/CitedAnswer.test.tsx`
- `bun run check` (passes with 380 warnings + 2 infos remaining)
- `git diff --check`

## Remaining follow-ups
- Continue remaining `noLeakedRender` cleanup in timeline, agents, policies, notebook, search, and remaining smaller app/wiki surfaces.
- Keep a11y, CSS specificity, complexity, dependency, and test-helper assertion warnings in separate milestone PRs.