### PR TITLE
fix(wiki): address post-merge review issues from PR #555

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -170,7 +170,7 @@ Tracking work that is deliberately deferred from the current branch. Each item n
 
 ### 15. SystemSchedulesPanel.test.tsx — vi.mock top-level variable bug
 
-**What:** `src/components/apps/SystemSchedulesPanel.test.tsx` crashes vitest with `ReferenceError: Cannot access 'MOCK_SPECS' before initialization` because `vi.mock` hoisting runs before the top-level `MOCK_SPECS` const is initialized.
+**What:** `web/src/components/apps/SystemSchedulesPanel.test.tsx` crashes vitest with `ReferenceError: Cannot access 'MOCK_SPECS' before initialization` because `vi.mock` hoisting runs before the top-level `MOCK_SPECS` const is initialized.
 
 **Why:** Pre-existing bug in the file as merged. The fix is to move `MOCK_SPECS` inside the factory callback or use `vi.hoisted()`. Out of scope for the wiki read-tracking feature.
 

--- a/internal/team/wiki_article.go
+++ b/internal/team/wiki_article.go
@@ -212,6 +212,9 @@ func (r *Repo) BuildCatalog(ctx context.Context, sortBy string, readLog *ReadLog
 			if lj == nil {
 				return false
 			}
+			if li.Equal(*lj) {
+				return entries[i].Path < entries[j].Path
+			}
 			return li.Before(*lj)
 		})
 	} else {

--- a/web/src/components/wiki/WikiArticle.test.tsx
+++ b/web/src/components/wiki/WikiArticle.test.tsx
@@ -283,6 +283,21 @@ describe("<WikiArticle>", () => {
     expect(screen.queryByText("unread 7d+")).not.toBeInTheDocument();
   });
 
+  it("shows 'unread 30d+' badge at exact 30-day boundary", async () => {
+    vi.spyOn(api, "fetchArticle").mockResolvedValue({
+      ...STUB_ARTICLE,
+      agent_read_count: 0,
+      human_read_count: 1,
+      days_unread: 30,
+    });
+    render(<WikiArticle path="people/customer-x" catalog={[]} onNavigate={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+    );
+    expect(screen.getByText("unread 30d+")).toBeInTheDocument();
+    expect(screen.queryByText("unread 7d+")).not.toBeInTheDocument();
+  });
+
   it("shows 'unread 30d+' badge for days_unread=31 (above stale threshold)", async () => {
     vi.spyOn(api, "fetchArticle").mockResolvedValue({
       ...STUB_ARTICLE,


### PR DESCRIPTION
## Summary

Three fixes from CodeRabbit's post-merge review pass on #555 (wiki JIT attention layer). All other flagged items were already resolved pre-merge.

- **`internal/team/wiki_article.go`** — Add path tie-break when two catalog entries share the same `LastRead` timestamp. `sort.Slice` was nondeterministic on equal times; now falls back to `entries[i].Path < entries[j].Path`.
- **`web/src/components/wiki/WikiArticle.test.tsx`** — Add exact 30-day boundary test (`days_unread=30` should trigger `unread 30d+`). Previously only tested `days_unread=31`.
- **`TODOS.md`** — Correct file path for item #15 (`src/components/` → `web/src/components/`).

## Test plan

- [ ] `bash scripts/test-go.sh ./internal/team/...` — passes (includes catalog sort coverage)
- [ ] `bunx vitest run web/src/components/wiki/WikiArticle.test.tsx` — 16 tests pass (15 existing + new boundary test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in article sorting when access times are identical
  * Enhanced accuracy of read-status badge display at specific time boundaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->