### PR TITLE
[codex] fix render leakage warnings in secondary app surfaces

### DIFF
--- a/web/src/components/activity/Timeline.tsx
+++ b/web/src/components/activity/Timeline.tsx
@@ -66,9 +66,11 @@ export function Timeline({ events, emptyLabel, limit }: TimelineProps) {
           <div className="timeline-body">
             <div className="timeline-content">{truncate(ev.content, 220)}</div>
             <div className="timeline-meta">
-              {ev.timestamp && <span>{formatRelativeTime(ev.timestamp)}</span>}
-              {ev.actor && <span>@{ev.actor}</span>}
-              {ev.meta && <span>{ev.meta}</span>}
+              {ev.timestamp ? (
+                <span>{formatRelativeTime(ev.timestamp)}</span>
+              ) : null}
+              {ev.actor ? <span>@{ev.actor}</span> : null}
+              {ev.meta ? <span>{ev.meta}</span> : null}
             </div>
           </div>
         </div>

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -266,9 +266,9 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
                 style={{ marginLeft: -2 }}
               />
             </div>
-            {agent.role && (
+            {agent.role ? (
               <span className="agent-panel-role">{agent.role}</span>
-            )}
+            ) : null}
           </div>
         </div>
         <button
@@ -298,18 +298,18 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
               </div>
             ) : null;
           })()}
-          {agent.status && (
+          {agent.status ? (
             <div className="agent-panel-info-row">
               <span className="agent-panel-info-label">status</span>
               <span className="agent-panel-info-value">{agent.status}</span>
             </div>
-          )}
-          {agent.task && (
+          ) : null}
+          {agent.task ? (
             <div className="agent-panel-info-row">
               <span className="agent-panel-info-label">task</span>
               <span className="agent-panel-info-value">{agent.task}</span>
             </div>
-          )}
+          ) : null}
         </div>
       </div>
 

--- a/web/src/components/apps/PoliciesApp.tsx
+++ b/web/src/components/apps/PoliciesApp.tsx
@@ -106,7 +106,7 @@ export function PoliciesApp() {
       </div>
 
       {/* Inline add form */}
-      {formOpen && (
+      {formOpen ? (
         <div
           style={{
             padding: "8px 20px 12px",
@@ -143,10 +143,10 @@ export function PoliciesApp() {
             </button>
           </div>
         </div>
-      )}
+      ) : null}
 
       {/* Policy list */}
-      {isLoading && (
+      {isLoading ? (
         <div
           style={{
             padding: 20,
@@ -157,9 +157,9 @@ export function PoliciesApp() {
         >
           Loading...
         </div>
-      )}
+      ) : null}
 
-      {error && (
+      {error ? (
         <div
           style={{
             padding: "40px 20px",
@@ -170,7 +170,7 @@ export function PoliciesApp() {
         >
           Failed to load policies.
         </div>
-      )}
+      ) : null}
 
       {!(isLoading || error) && activePolicies.length === 0 && (
         <div

--- a/web/src/components/apps/SettingsApp.imageGen.tsx
+++ b/web/src/components/apps/SettingsApp.imageGen.tsx
@@ -67,6 +67,13 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
   const [baseURL, setBaseURL] = useState(s.base_url ?? "");
   const [model, setModel] = useState(s.default_model ?? "");
   const [showKey, setShowKey] = useState(false);
+  const capabilityLabel = [
+    s.kind,
+    s.supports_video ? "video" : "",
+    s.implementation_ok ? "" : "stub",
+  ]
+    .filter(Boolean)
+    .join(" · ");
 
   const mutation = useMutation({
     mutationFn: () =>
@@ -107,9 +114,7 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
             marginLeft: "auto",
           }}
         >
-          {s.kind}
-          {s.supports_video && " · video"}
-          {s.implementation_ok ? "" : " · stub"}
+          {capabilityLabel}
         </span>
       </div>
       <p
@@ -122,7 +127,7 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
       >
         {s.blurb}
       </p>
-      {s.setup_hint && (
+      {s.setup_hint ? (
         <p
           style={{
             fontSize: 11,
@@ -135,9 +140,9 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
         >
           {s.setup_hint}
         </p>
-      )}
+      ) : null}
 
-      {s.needs_api_key && (
+      {s.needs_api_key ? (
         <div style={{ marginBottom: 10 }}>
           <label style={labelStyle} htmlFor={`${s.kind}-api-key`}>
             API key {s.api_key_set ? "(set)" : "(unset)"}
@@ -161,7 +166,7 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
             </button>
           </div>
         </div>
-      )}
+      ) : null}
 
       <div
         style={{

--- a/web/src/components/layout/UpgradeBanner.tsx
+++ b/web/src/components/layout/UpgradeBanner.tsx
@@ -525,14 +525,14 @@ export function UpgradeBanner() {
         className="upgrade-banner-changelog"
         hidden={!expanded}
       >
-        {expanded && (
+        {expanded ? (
           <>
-            {changelog.loading && (
+            {changelog.loading ? (
               <div className="upgrade-banner-changelog-status">
                 Loading changes…
               </div>
-            )}
-            {changelog.error && (
+            ) : null}
+            {changelog.error ? (
               <div className="upgrade-banner-changelog-status">
                 Could not load changelog ({changelog.error}).{" "}
                 <a href={compareUrl} target="_blank" rel="noopener noreferrer">
@@ -540,7 +540,7 @@ export function UpgradeBanner() {
                 </a>
                 .
               </div>
-            )}
+            ) : null}
             {!(changelog.loading || changelog.error) &&
               changelog.commits.length === 0 && (
                 <div className="upgrade-banner-changelog-status">
@@ -595,7 +595,7 @@ export function UpgradeBanner() {
               </div>
             ))}
           </>
-        )}
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Rebases the audit stack onto latest `origin/main` first.
- Clears Biome `noLeakedRender` warnings in timeline, agent panel, policies, image generation settings, and upgrade banner surfaces.
- Stacks on PR #564 to keep render-warning cleanup split into small reviewable milestones.

## Validation
- `bun run build`
- `bun run test` (95 files, 694 tests; existing localhost:3000 ECONNREFUSED noise still exits 0)
- `bun run check` (passes with 358 warnings + 2 infos remaining)
- `git diff --check`

## Remaining follow-ups
- Continue remaining `noLeakedRender` cleanup in AgentWizard, ArtifactsApp, CalendarApp, ThreadPanel, ImageEmbed, NewArticleModal, WikiCatalog, WikiLint, and one-off app/layout/message surfaces.
- Keep a11y, CSS specificity, complexity, dependency, and test-helper assertion warnings in separate milestone PRs.