### PR TITLE
[codex] fix render leakage warnings in message surfaces

### DIFF
--- a/web/src/components/messages/HumanInterviewOverlay.tsx
+++ b/web/src/components/messages/HumanInterviewOverlay.tsx
@@ -103,16 +103,16 @@ function BlockingInterview({
         <div className="interview-meta">
           <span className="badge badge-yellow">BLOCKING</span>
           <span className="interview-from">@{request.from || "agent"}</span>
-          {request.channel && (
+          {request.channel ? (
             <span className="interview-channel">in #{request.channel}</span>
-          )}
+          ) : null}
         </div>
         <h2 id="interview-title" className="interview-title">
           {request.title && request.title !== "Request"
             ? request.title
             : "Human decision requested"}
         </h2>
-        {isEnhanceInterview && enhancesSlug && (
+        {isEnhanceInterview && enhancesSlug ? (
           <div
             className="interview-enhance-banner"
             role="note"
@@ -145,11 +145,11 @@ function BlockingInterview({
               . Enhance it or approve anyway.
             </span>
           </div>
-        )}
+        ) : null}
         <p className="interview-question">{request.question}</p>
-        {request.context && (
+        {request.context ? (
           <p className="interview-context">{request.context}</p>
-        )}
+        ) : null}
         {options.length > 0 ? (
           <div className="interview-actions">
             {options.map((opt) => (

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -233,9 +233,9 @@ export function InterviewBar() {
         <span className="interview-bar-from">
           @{current.from || "agent"} asks
         </span>
-        {current.channel && (
+        {current.channel ? (
           <span className="interview-bar-channel">in #{current.channel}</span>
-        )}
+        ) : null}
         <span className="interview-bar-counter">
           {safeCursor + 1}/{visible.length}
         </span>
@@ -274,17 +274,17 @@ export function InterviewBar() {
       </div>
 
       <div className="interview-bar-body">
-        {current.title && current.title !== "Request" && (
+        {current.title && current.title !== "Request" ? (
           <div className="interview-bar-title">{current.title}</div>
-        )}
+        ) : null}
         <div className="interview-bar-question">
           {(current.question || "")
             .replace(/\*\*/g, "")
             .replace(/^\s*\d+\.\s*/, "")}
         </div>
-        {current.context && (
+        {current.context ? (
           <div className="interview-bar-context">{current.context}</div>
-        )}
+        ) : null}
 
         {ambiguousRef ? (
           <SimilarBanner
@@ -364,9 +364,9 @@ export function InterviewBar() {
             >
               <span className="interview-bar-opt-num">{i + 1}</span>
               <span className="interview-bar-opt-label">{opt.label}</span>
-              {opt.requires_text && (
+              {opt.requires_text ? (
                 <span className="interview-bar-text-hint"> · type</span>
-              )}
+              ) : null}
             </button>
           ))}
         </div>

--- a/web/src/components/notebook/NotebookEntry.tsx
+++ b/web/src/components/notebook/NotebookEntry.tsx
@@ -116,9 +116,9 @@ export default function NotebookEntryView({
       {showDraftStamp && <DraftStamp />}
 
       <h1 className="nb-entry-title">{entry.title}</h1>
-      {entry.subtitle && (
+      {entry.subtitle ? (
         <div className="nb-entry-subtitle">{entry.subtitle}</div>
-      )}
+      ) : null}
 
       <ByLineStrip
         authorSlug={entry.agent_slug}
@@ -130,12 +130,12 @@ export default function NotebookEntryView({
 
       <EntryBody markdown={entry.body_md} onWikiNavigate={onNavigateWiki} />
 
-      {entry.promoted_back && (
+      {entry.promoted_back ? (
         <PromotedBackCallout
           link={entry.promoted_back}
           onNavigate={onNavigateWiki}
         />
-      )}
+      ) : null}
 
       <InlineReviewThread
         reviewerSlug={entry.reviewer_slug}
@@ -148,11 +148,11 @@ export default function NotebookEntryView({
         pending={pending}
         onPromote={handlePromote}
       />
-      {promoteError && (
+      {promoteError ? (
         <p className="nb-error" role="alert">
           Could not submit: {promoteError}
         </p>
-      )}
+      ) : null}
 
       <PosterityLine
         authorSlug={entry.agent_slug}

--- a/web/src/components/search/SearchModal.tsx
+++ b/web/src/components/search/SearchModal.tsx
@@ -427,7 +427,7 @@ export function SearchModal() {
             value={query}
             onChange={(e) => handleQueryChange(e.target.value)}
           />
-          {searching && <span className="search-spinner" />}
+          {searching ? <span className="search-spinner" /> : null}
         </div>
 
         <div className="cmd-palette-results">
@@ -458,17 +458,17 @@ export function SearchModal() {
                           ? highlightMatch(item.label, query.trim())
                           : item.label}
                       </span>
-                      {item.desc && (
+                      {item.desc ? (
                         <span className="cmd-palette-item-desc">
                           {item.group === "Wiki" || item.group === "Notebooks"
                             ? highlightMatch(item.desc, query.trim())
                             : item.desc}
                         </span>
-                      )}
+                      ) : null}
                     </span>
-                    {item.meta && (
+                    {item.meta ? (
                       <span className="cmd-palette-item-meta">{item.meta}</span>
-                    )}
+                    ) : null}
                   </button>
                 ))}
               </div>

--- a/web/src/components/wiki/PlaybookExecutionLog.tsx
+++ b/web/src/components/wiki/PlaybookExecutionLog.tsx
@@ -126,7 +126,7 @@ export default function PlaybookExecutionLog({
           {expanded ? "▾" : "▸"}
         </span>
       </button>
-      {expanded && (
+      {expanded ? (
         <div className="wk-playbook-executions__body">
           {loading ? (
             <p className="wk-playbook-executions__loading">
@@ -154,11 +154,11 @@ export default function PlaybookExecutionLog({
                       <p className="wk-playbook-execution__summary">
                         {e.summary}
                       </p>
-                      {e.notes && (
+                      {e.notes ? (
                         <p className="wk-playbook-execution__notes">
                           {e.notes}
                         </p>
-                      )}
+                      ) : null}
                       <span className="wk-playbook-execution__meta">
                         {formatAgentName(e.recorded_by)}
                         {" · "}
@@ -170,7 +170,7 @@ export default function PlaybookExecutionLog({
                   </li>
                 ))}
               </ol>
-              {entries.length > INITIAL_LIMIT && (
+              {entries.length > INITIAL_LIMIT ? (
                 <button
                   type="button"
                   className="wk-playbook-executions__more"
@@ -180,7 +180,7 @@ export default function PlaybookExecutionLog({
                     ? "show recent only"
                     : `show all (${entries.length - INITIAL_LIMIT} more)`}
                 </button>
-              )}
+              ) : null}
             </>
           )}
           <SynthesisFooter
@@ -189,7 +189,7 @@ export default function PlaybookExecutionLog({
             onResynthesize={handleResynthesize}
           />
         </div>
-      )}
+      ) : null}
     </section>
   );
 }
@@ -227,9 +227,9 @@ function SynthesisFooter({
     >
       <div className="wk-playbook-synthesis__status">
         <span className="wk-playbook-synthesis__badge">{lastLabel}</span>
-        {pendingLabel && (
+        {pendingLabel ? (
           <span className="wk-playbook-synthesis__pending">{pendingLabel}</span>
-        )}
+        ) : null}
       </div>
       <button
         type="button"


### PR DESCRIPTION
## Summary
- Clears Biome `noLeakedRender` warnings in human interview overlay, interview bar, notebook entry, search modal, and playbook execution log surfaces.
- Keeps the slice limited to explicit JSX render guards and value-preserving ternaries.
- Stacks on the current render-warning branch after PR #566 was merged into the stack base.

## Validation
- `bun run build`
- `bun run test src/components/wiki/PlaybookExecutionLog.test.tsx src/components/notebook/NotebookEntry.test.tsx src/components/messages/InterviewBar.test.tsx src/components/messages/HumanInterviewOverlay.test.tsx`
- `bun run test` (95 files, 694 tests; existing localhost:3000 ECONNREFUSED noise still exits 0)
- `bun run check` (passes with 344 warnings + 2 infos remaining)
- `git diff --check`

## Remaining follow-ups
- Continue remaining `noLeakedRender` cleanup in AgentWizard, ArtifactsApp, CalendarApp, ThreadPanel, ImageEmbed, NewArticleModal, WikiCatalog, WikiLint, and one-off app/layout/message surfaces.
- Keep a11y, CSS specificity, complexity, dependency, and test-helper assertion warnings in separate milestone PRs.