### PR TITLE
[codex] fix render leakage warnings in small surfaces

### DIFF
--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -223,7 +223,7 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
               </span>
             </div>
 
-            {error && <div className="agent-wizard-error">{error}</div>}
+            {error ? <div className="agent-wizard-error">{error}</div> : null}
 
             <div className="agent-wizard-footer">
               <button
@@ -360,7 +360,7 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
               )}
             </div>
 
-            {error && <div className="agent-wizard-error">{error}</div>}
+            {error ? <div className="agent-wizard-error">{error}</div> : null}
 
             {/* Footer */}
             <div className="agent-wizard-footer">

--- a/web/src/components/apps/ArtifactsApp.tsx
+++ b/web/src/components/apps/ArtifactsApp.tsx
@@ -565,7 +565,7 @@ function ActivitySection({
         }}
       >
         <div style={{ fontSize: 14, fontWeight: 600 }}>{title}</div>
-        {meta && <div className="app-card-meta">{meta}</div>}
+        {meta ? <div className="app-card-meta">{meta}</div> : null}
       </div>
       {children}
     </section>
@@ -598,7 +598,7 @@ function ActivityItem({
           {title}
         </span>
       </div>
-      {body && (
+      {body ? (
         <div
           style={{
             fontSize: 12,
@@ -608,10 +608,10 @@ function ActivityItem({
         >
           {body}
         </div>
-      )}
-      {meta.length > 0 && (
+      ) : null}
+      {meta.length > 0 ? (
         <div className="app-card-meta">{meta.join(" \u2022 ")}</div>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/apps/CalendarApp.tsx
+++ b/web/src/components/apps/CalendarApp.tsx
@@ -191,7 +191,7 @@ function JobCard({ job }: { job: SchedulerJob }) {
         <span className="app-card-title" style={{ marginBottom: 0 }}>
           {job.label || job.name || job.slug || "Job"}
         </span>
-        {job.status && (
+        {job.status ? (
           <span
             className={
               job.status === "active"
@@ -201,9 +201,9 @@ function JobCard({ job }: { job: SchedulerJob }) {
           >
             {job.status.toUpperCase()}
           </span>
-        )}
+        ) : null}
       </div>
-      {job.next_run && (
+      {job.next_run ? (
         <div
           className="app-card-meta"
           style={{
@@ -214,7 +214,7 @@ function JobCard({ job }: { job: SchedulerJob }) {
         >
           {formatRelativeTime(job.next_run)}
         </div>
-      )}
+      ) : null}
       {metaParts.length > 0 && (
         <div className="app-card-meta">{metaParts.join(" \u2022 ")}</div>
       )}

--- a/web/src/components/layout/CollapsedSidebar.tsx
+++ b/web/src/components/layout/CollapsedSidebar.tsx
@@ -191,42 +191,44 @@ export function CollapsedSidebar() {
         active={popover === "usage"}
       />
 
-      {popover &&
-        createPortal(
-          <div
-            ref={popoverRef}
-            className={`sidebar-rail-popover sidebar-rail-popover-${popover}`}
-            role="dialog"
-            onMouseEnter={() => openPopover(popover)}
-            onMouseLeave={scheduleClose}
-          >
-            <div className="sidebar-rail-popover-title">
-              {popover === "team"
-                ? "Team"
-                : popover === "channels"
-                  ? "Channels"
-                  : "Usage"}
-            </div>
-            <div className="sidebar-rail-popover-body">
-              {popover === "team" && <AgentList />}
-              {popover === "channels" && <ChannelList />}
-              {popover === "usage" && <UsageBody />}
-            </div>
-          </div>,
-          document.body,
-        )}
+      {popover
+        ? createPortal(
+            <div
+              ref={popoverRef}
+              className={`sidebar-rail-popover sidebar-rail-popover-${popover}`}
+              role="dialog"
+              onMouseEnter={() => openPopover(popover)}
+              onMouseLeave={scheduleClose}
+            >
+              <div className="sidebar-rail-popover-title">
+                {popover === "team"
+                  ? "Team"
+                  : popover === "channels"
+                    ? "Channels"
+                    : "Usage"}
+              </div>
+              <div className="sidebar-rail-popover-body">
+                {popover === "team" ? <AgentList /> : null}
+                {popover === "channels" ? <ChannelList /> : null}
+                {popover === "usage" ? <UsageBody /> : null}
+              </div>
+            </div>,
+            document.body,
+          )
+        : null}
 
-      {hint &&
-        createPortal(
-          <div
-            className="sidebar-rail-hint"
-            style={{ top: hint.y }}
-            role="tooltip"
-          >
-            {hint.label}
-          </div>,
-          document.body,
-        )}
+      {hint
+        ? createPortal(
+            <div
+              className="sidebar-rail-hint"
+              style={{ top: hint.y }}
+              role="tooltip"
+            >
+              {hint.label}
+            </div>,
+            document.body,
+          )
+        : null}
     </>
   );
 }

--- a/web/src/components/messages/ThreadPanel.tsx
+++ b/web/src/components/messages/ThreadPanel.tsx
@@ -145,16 +145,16 @@ export function ThreadPanel() {
       </div>
 
       <div ref={messagesRef} className="thread-panel-body">
-        {parent && (
+        {parent ? (
           <div className="thread-panel-parent">
             <MessageBubble message={parent} />
           </div>
-        )}
-        {replies.length > 0 && (
+        ) : null}
+        {replies.length > 0 ? (
           <div className="thread-panel-replies-count">
             {replies.length} {replies.length === 1 ? "reply" : "replies"}
           </div>
-        )}
+        ) : null}
         {replies.length === 0 ? (
           <div className="thread-panel-empty">
             No replies yet. Start the conversation below.
@@ -178,7 +178,7 @@ export function ThreadPanel() {
           offers a dismiss. This mirrors Slack's "Replying to …" affordance
           and makes the active reply_to target visible. */}
       <div className="composer">
-        {quoting && (
+        {quoting ? (
           <div className="thread-quote-chip">
             <svg
               width="12"
@@ -220,7 +220,7 @@ export function ThreadPanel() {
               </svg>
             </button>
           </div>
-        )}
+        ) : null}
         <div className="composer-inner">
           <textarea
             ref={textareaRef}

--- a/web/src/components/wiki/ImageEmbed.tsx
+++ b/web/src/components/wiki/ImageEmbed.tsx
@@ -79,9 +79,11 @@ export function ImageEmbed({
             className="image-embed__img"
           />
         </button>
-        {alt && <figcaption className="image-embed__caption">{alt}</figcaption>}
+        {alt ? (
+          <figcaption className="image-embed__caption">{alt}</figcaption>
+        ) : null}
       </figure>
-      {open && (
+      {open ? (
         <div
           className="image-embed__lightbox"
           role="dialog"
@@ -109,7 +111,7 @@ export function ImageEmbed({
             onClick={(e) => e.stopPropagation()}
           />
         </div>
-      )}
+      ) : null}
     </>
   );
 }

--- a/web/src/components/wiki/NewArticleModal.tsx
+++ b/web/src/components/wiki/NewArticleModal.tsx
@@ -145,20 +145,20 @@ export default function NewArticleModal({
           onChange={(e) => setTitle(e.target.value)}
         />
 
-        {path && (
+        {path ? (
           <p className="wk-editor-help">
             Will create <code>{path}</code>
           </p>
-        )}
+        ) : null}
 
-        {error && (
+        {error ? (
           <div
             className="wk-editor-banner wk-editor-banner--error"
             role="alert"
           >
             {error}
           </div>
-        )}
+        ) : null}
 
         <div className="wk-editor-actions">
           <button

--- a/web/src/components/wiki/WikiCatalog.tsx
+++ b/web/src/components/wiki/WikiCatalog.tsx
@@ -61,7 +61,7 @@ export default function WikiCatalog({
           >
             + New article
           </button>
-          {onOpenAudit && (
+          {onOpenAudit ? (
             <>
               {" · "}
               <button
@@ -75,10 +75,10 @@ export default function WikiCatalog({
                 Audit log
               </button>
             </>
-          )}
+          ) : null}
         </div>
       </header>
-      {showNew && (
+      {showNew ? (
         <NewArticleModal
           catalog={catalog}
           onCancel={() => setShowNew(false)}
@@ -87,7 +87,7 @@ export default function WikiCatalog({
             onNavigate(path);
           }}
         />
-      )}
+      ) : null}
       <div className="wk-catalog-grid">
         {groupOrder.map((group) => {
           const items = grouped[group];

--- a/web/src/components/wiki/WikiLint.tsx
+++ b/web/src/components/wiki/WikiLint.tsx
@@ -95,11 +95,11 @@ export default function WikiLint({ onNavigate }: WikiLintProps) {
         >
           {loading ? "Checking…" : "Check again now"}
         </button>
-        {report && (
+        {report ? (
           <span className="wk-audit-strapline" style={{ alignSelf: "center" }}>
             Last checked: {report.date}
           </span>
-        )}
+        ) : null}
       </section>
 
       {loading && !report ? (
@@ -174,7 +174,7 @@ export default function WikiLint({ onNavigate }: WikiLintProps) {
         </table>
       ) : null}
 
-      {resolveTarget && report && (
+      {resolveTarget && report ? (
         <ResolveContradictionModal
           finding={resolveTarget.finding}
           findingIdx={resolveTarget.idx}
@@ -185,7 +185,7 @@ export default function WikiLint({ onNavigate }: WikiLintProps) {
             loadReport();
           }}
         />
-      )}
+      ) : null}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Clears `noLeakedRender` warnings in AgentWizard, ArtifactsApp, CalendarApp, CollapsedSidebar, ThreadPanel, ImageEmbed, NewArticleModal, WikiCatalog, and WikiLint.
- Keeps this milestone scoped to render leakage cleanup and stacked on the current secondary-surfaces render-warning branch.

## Validation
- `bun run check` passes with 328 warnings and 2 infos remaining
- `bun run test src/components/wiki/WikiCatalog.test.tsx src/components/wiki/WikiLint.test.tsx`
- `bun run test`
- `bun run build`
- `git diff --check`

## Follow-ups
- Continue remaining one-off `noLeakedRender` warnings, starting with HealthCheckApp.
- Then move to a11y, CSS specificity, and complexity buckets in separate PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements across multiple components to enhance consistency and long-term maintainability. No changes to user-facing features or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->