### PR TITLE
[codex] clear remaining render leakage warnings

### DIFF
--- a/web/src/components/apps/HealthCheckApp.tsx
+++ b/web/src/components/apps/HealthCheckApp.tsx
@@ -126,9 +126,9 @@ export function HealthCheckApp() {
                 />
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ fontWeight: 500, fontSize: 13 }}>{slug}</div>
-                  {agentStatus && (
+                  {agentStatus ? (
                     <div className="app-card-meta">{agentStatus}</div>
-                  )}
+                  ) : null}
                 </div>
               </div>
             );

--- a/web/src/components/apps/ThreadsApp.tsx
+++ b/web/src/components/apps/ThreadsApp.tsx
@@ -107,11 +107,11 @@ export function ThreadsApp() {
                     <span className="thread-list-item-replies">
                       {t.replyCount} repl{t.replyCount === 1 ? "y" : "ies"}
                     </span>
-                    {agent && <span>{agent.name}</span>}
+                    {agent ? <span>{agent.name}</span> : null}
                     <span>#{t.channel}</span>
-                    {t.message.timestamp && (
+                    {t.message.timestamp ? (
                       <span>{formatRelativeTime(t.message.timestamp)}</span>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               </button>

--- a/web/src/components/channels/ChannelWizard.tsx
+++ b/web/src/components/channels/ChannelWizard.tsx
@@ -214,7 +214,7 @@ export function ChannelWizard({ open, onClose }: ChannelWizardProps) {
             </>
           )}
 
-          {error && <div className="channel-wizard-error">{error}</div>}
+          {error ? <div className="channel-wizard-error">{error}</div> : null}
 
           <div className="channel-wizard-footer">
             <button

--- a/web/src/components/layout/ChannelHeader.tsx
+++ b/web/src/components/layout/ChannelHeader.tsx
@@ -34,7 +34,7 @@ export function ChannelHeader() {
     <div className="channel-header">
       <div style={{ display: "flex", alignItems: "center" }}>
         <span className="channel-title">{title}</span>
-        {desc && <span className="channel-desc">{desc}</span>}
+        {desc ? <span className="channel-desc">{desc}</span> : null}
       </div>
       <div className="channel-actions">
         <button

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -66,7 +66,7 @@ export function StatusBar() {
       <span className="status-bar-item">
         {agentCount} agent{agentCount === 1 ? "" : "s"}
       </span>
-      {provider && (
+      {provider ? (
         <span
           className="status-bar-item"
           title={
@@ -77,14 +77,14 @@ export function StatusBar() {
         >
           {"⚙ "}
           {provider}
-          {providerModel && (
+          {providerModel ? (
             <>
               <span className="status-bar-sep"> · </span>
               <span className="status-bar-model">{providerModel}</span>
             </>
-          )}
+          ) : null}
         </span>
-      )}
+      ) : null}
       <span
         className={`status-bar-item status-bar-conn${brokerConnected ? "" : " disconnected"}`}
       >

--- a/web/src/components/messages/Autocomplete.tsx
+++ b/web/src/components/messages/Autocomplete.tsx
@@ -111,9 +111,9 @@ export function Autocomplete({
         >
           <span className="autocomplete-item-icon">{item.icon}</span>
           <span className="autocomplete-item-label">{item.label}</span>
-          {item.desc && (
+          {item.desc ? (
             <span className="autocomplete-item-desc">{item.desc}</span>
-          )}
+          ) : null}
         </button>
       ))}
     </div>

--- a/web/src/components/onboarding/wizard/LocalLLMPicker.tsx
+++ b/web/src/components/onboarding/wizard/LocalLLMPicker.tsx
@@ -86,7 +86,7 @@ export function LocalLLMPicker({ selected, onSelect }: LocalLLMPickerProps) {
         doctor panel with copy-paste shell snippets.
       </p>
 
-      {loading && (
+      {loading ? (
         <div
           style={{
             fontSize: 12,
@@ -96,7 +96,7 @@ export function LocalLLMPicker({ selected, onSelect }: LocalLLMPickerProps) {
         >
           Detecting local runtimes…
         </div>
-      )}
+      ) : null}
       {!loading && fetchError && (
         <div
           data-testid="onboarding-local-llm-fetch-error"

--- a/web/src/components/onboarding/wizard/NexSignupPanel.tsx
+++ b/web/src/components/onboarding/wizard/NexSignupPanel.tsx
@@ -91,14 +91,14 @@ export function NexSignupPanel({
               {status === "submitting" ? "Registering..." : "Register"}
             </button>
           </div>
-          {error && (
+          {error ? (
             <p
               style={{ color: "var(--red)", fontSize: 12, marginTop: 6 }}
               role="alert"
             >
               {error}
             </p>
-          )}
+          ) : null}
         </div>
       )}
     </div>

--- a/web/src/components/sidebar/AgentList.tsx
+++ b/web/src/components/sidebar/AgentList.tsx
@@ -86,9 +86,9 @@ export function AgentList() {
                     <span className="sidebar-agent-name">
                       {agent.name || agent.slug}
                     </span>
-                    {agent.task && (
+                    {agent.task ? (
                       <span className="sidebar-agent-task">{agent.task}</span>
-                    )}
+                    ) : null}
                   </div>
                   <span className={`status-dot ${ac.dotClass}`} />
                 </button>

--- a/web/src/components/sidebar/UsagePanel.tsx
+++ b/web/src/components/sidebar/UsagePanel.tsx
@@ -39,7 +39,7 @@ export function UsagePanel() {
           {formatUSD(totalCost)}
         </span>
       </button>
-      {open && (
+      {open ? (
         <div className="usage-panel open">
           {slugs.length === 0 && totalCost === 0 ? (
             <p
@@ -86,7 +86,7 @@ export function UsagePanel() {
             </>
           )}
         </div>
-      )}
+      ) : null}
     </>
   );
 }

--- a/web/src/components/ui/InlineCommand.tsx
+++ b/web/src/components/ui/InlineCommand.tsx
@@ -131,7 +131,7 @@ export function InlineCommand({
         />
         <span>{command}</span>
       </button>
-      {open && destructive && (
+      {open && destructive ? (
         <WipeModal
           title={destructive.title}
           severity={destructive.severity || "critical"}
@@ -143,7 +143,7 @@ export function InlineCommand({
             if (!busy) setOpen(false);
           }}
         />
-      )}
+      ) : null}
     </>
   );
 }

--- a/web/src/components/ui/WipeModal.tsx
+++ b/web/src/components/ui/WipeModal.tsx
@@ -195,7 +195,7 @@ export function WipeModal({
             onClick={enabled ? onConfirm : undefined}
             disabled={!enabled}
           >
-            {busy ? "Working…" : confirmLabel}
+            {busy === true ? "Working…" : <>{confirmLabel}</>}
           </button>
         </div>
       </div>

--- a/web/src/components/wiki/Byline.tsx
+++ b/web/src/components/wiki/Byline.tsx
@@ -54,7 +54,7 @@ export default function Byline({
       <span className="wk-ts" data-testid="wk-ts">
         {formatBylineTime(lastEditedTs)}
       </span>
-      {startedDate && (
+      {startedDate ? (
         <>
           <span className="wk-dot">•</span>
           <span>
@@ -62,7 +62,7 @@ export default function Byline({
             {startedBy ? <> by {startedBy}</> : null}
           </span>
         </>
-      )}
+      ) : null}
       {typeof revisions === "number" && revisions > 0 && (
         <>
           <span className="wk-dot">•</span>

--- a/web/src/components/wiki/EntityBriefBar.tsx
+++ b/web/src/components/wiki/EntityBriefBar.tsx
@@ -157,7 +157,9 @@ export default function EntityBriefBar({
           {state === "synthesizing" ? "Synthesizing…" : "Refresh brief"}
         </button>
       )}
-      {error && <span className="wk-entity-brief-bar__error">{error}</span>}
+      {error ? (
+        <span className="wk-entity-brief-bar__error">{error}</span>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/wiki/Pam.tsx
+++ b/web/src/components/wiki/Pam.tsx
@@ -246,7 +246,7 @@ export default function Pam({ articlePath, onActionDone }: PamProps) {
       </button>
       <div className="pam-desk" aria-hidden="true" />
 
-      {menuOpen && (
+      {menuOpen ? (
         <div
           ref={menuElRef}
           className="pam-menu"
@@ -282,7 +282,7 @@ export default function Pam({ articlePath, onActionDone }: PamProps) {
             ))
           )}
         </div>
-      )}
+      ) : null}
 
       {status.kind !== "idle" && (
         <div

--- a/web/src/components/wiki/PlaybookSkillBadge.tsx
+++ b/web/src/components/wiki/PlaybookSkillBadge.tsx
@@ -66,12 +66,12 @@ export default function PlaybookSkillBadge({ slug }: PlaybookSkillBadgeProps) {
           <>Compiled skill pending — recompiling…</>
         )}
       </span>
-      {compiled && playbook && (
+      {compiled && playbook ? (
         <span className="wk-playbook-badge__meta">
           {playbook.execution_count} execution
           {playbook.execution_count === 1 ? "" : "s"} logged
         </span>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/wiki/ResolveContradictionModal.tsx
+++ b/web/src/components/wiki/ResolveContradictionModal.tsx
@@ -127,11 +127,14 @@ export default function ResolveContradictionModal({
           </div>
         </div>
 
-        {error && (
-          <div className="wk-editor-banner wk-editor-banner--error" role="alert">
+        {error ? (
+          <div
+            className="wk-editor-banner wk-editor-banner--error"
+            role="alert"
+          >
             {error}
           </div>
-        )}
+        ) : null}
 
         <p className="wk-editor-help">
           Pick which fact is authoritative. The other will be marked superseded.

--- a/web/src/components/wiki/TocBox.tsx
+++ b/web/src/components/wiki/TocBox.tsx
@@ -36,7 +36,7 @@ export default function TocBox({ entries }: TocBoxProps) {
               href={`#${entry.anchor}`}
               className={`wk-lvl-${entry.level}`}
             >
-              {entry.num && <span className="wk-num">{entry.num}</span>}
+              {entry.num ? <span className="wk-num">{entry.num}</span> : null}
               {entry.title}
             </a>
           ))}

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -261,7 +261,7 @@ export default function WikiArticle({
   return (
     <>
       <main className="wk-article-col">
-        {liveAgent && (
+        {liveAgent ? (
           <ArticleStatusBanner
             message={`${formatAgentName(liveAgent)} is editing this article right now.`}
             liveAgent={liveAgent}
@@ -269,7 +269,7 @@ export default function WikiArticle({
             contributors={article.contributors.length}
             wordCount={article.word_count}
           />
-        )}
+        ) : null}
         {entity && (
           <EntityBriefBar
             kind={entity.kind}


### PR DESCRIPTION
## Summary
- Clears the remaining `noLeakedRender` diagnostics across the one-off app, layout, sidebar, UI, onboarding, and wiki surfaces.
- Leaves the cleanup as a narrow stacked milestone on top of PR #570.

## Validation
- `bun run check` passes with 310 warnings and 3 infos remaining
- `bun run build`
- `bun run test`
- `git diff --check`

## Follow-ups
- Continue with the a11y warning bucket.
- Then handle CSS specificity, mechanical correctness/nursery/suspicious cleanup, and complexity refactors in separate reviewable PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated conditional rendering patterns across multiple components to use explicit ternary expressions instead of short-circuit operators. All functionality and user-visible behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->