### PR TITLE
[codex] document css style warning exceptions

### DIFF
--- a/web/src/hooks/useCommands.ts
+++ b/web/src/hooks/useCommands.ts
@@ -93,8 +93,8 @@ const DEFAULT_ICON = '›'
  */
 function toAutocomplete(commands: SlashCommandDescriptor[]): SlashCommand[] {
   return commands
-      .filter((c) => c.webSupported)
-      .map((c) => ({
+    .filter((c) => c.webSupported)
+    .map((c) => ({
       name: `/${c.name}`,
       desc: c.description,
       icon: COMMAND_ICONS[c.name] ?? DEFAULT_ICON,

--- a/web/src/hooks/useCommands.ts
+++ b/web/src/hooks/useCommands.ts
@@ -93,9 +93,9 @@ const DEFAULT_ICON = '›'
  */
 function toAutocomplete(commands: SlashCommandDescriptor[]): SlashCommand[] {
   return commands
-    .filter((c) => c.webSupported)
-    .map((c) => ({
-      name: '/' + c.name,
+      .filter((c) => c.webSupported)
+      .map((c) => ({
+      name: `/${c.name}`,
       desc: c.description,
       icon: COMMAND_ICONS[c.name] ?? DEFAULT_ICON,
     }))

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -1,3 +1,4 @@
+/* biome-ignore-all lint/complexity/noImportantStyles: Responsive panel sizing and reduced-motion overrides must win over component CSS. */
 /* ═══════════════════════════════════════════════════════════════
    WUPHF Web — Global Styles (React)
    Ported from index.legacy.html design system CSS.

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -1,3 +1,4 @@
+/* biome-ignore-all lint/style/noDescendingSpecificity: Layout CSS is organized by surface sections; selector order is intentional and visually covered by app tests/build. */
 /* ═══════════════════════════════════════════════════════════════
    Layout — Office shell, sidebar, channel header, thread panel
    Ported from index.legacy.html

--- a/web/src/styles/messages.css
+++ b/web/src/styles/messages.css
@@ -1,3 +1,4 @@
+/* biome-ignore-all lint/style/noDescendingSpecificity: Message CSS groups base and state selectors by component for cascade readability. */
 /* ═══════════════════════════════════════════════════════════════
    Messages — Bubbles, composer, reactions, typing indicator
    Ported from index.legacy.html

--- a/web/src/styles/search.css
+++ b/web/src/styles/search.css
@@ -1,3 +1,4 @@
+/* biome-ignore-all lint/style/noDescendingSpecificity: Search modal selectors are section-grouped so state overrides stay near their component rules. */
 /* ═══════════════════════════════════════════════════════════════
    Search Modal + Channel Wizard + Disconnect Banner
    ═══════════════════════════════════════════════════════════════ */

--- a/web/src/styles/shadcn.css
+++ b/web/src/styles/shadcn.css
@@ -1,3 +1,4 @@
+/* biome-ignore-all lint/suspicious/noUnknownAtRules: Tailwind at-rules are consumed by the PostCSS/Tailwind pipeline. */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1,3 +1,4 @@
+/* biome-ignore-all lint/style/noDescendingSpecificity: Wiki stylesheet is organized by page region; moving selectors would risk broad visual regressions. */
 /* Wiki surface — scoped to .wiki-root.
  * Aligned to the Nex design system: cyan accent, neutral palette.
  * Keeps Wikipedia IA + editorial serif hierarchy for articles only.


### PR DESCRIPTION
## Summary
- Documents stylesheet-level exceptions for descending specificity where CSS is intentionally grouped by app surface.
- Documents Tailwind at-rules in the shadcn stylesheet and responsive/reduced-motion `!important` overrides.
- Fixes the remaining template-literal style warning in command autocomplete mapping.

## Validation
- `bun run check` passes with 166 warnings and 2 infos remaining
- `bun run build`
- `bun run test`
- `git diff --check`

## Follow-ups
- Continue with the mechanical correctness/nursery/suspicious cleanup bucket.
- Then handle complexity refactors in separate reviewable milestones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Code quality and linting improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->