### PR TITLE
[codex] apply mechanical lint cleanup

### DIFF
--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -396,6 +396,8 @@ export function AgentPanel() {
   // instantly un-selected it and the panel never mounted (React #31 guard
   // e2e regression).
   useEffect(() => {
+    void currentChannel;
+    void currentApp;
     close();
   }, [currentChannel, currentApp, close]);
 

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -1547,7 +1547,6 @@ type DangerAction = "reset" | "shred";
 function DangerZoneSection() {
   const [open, setOpen] = useState<DangerAction | null>(null);
   const [busy, setBusy] = useState(false);
-  const queryClient = useQueryClient();
   const shred = useShredAction();
 
   const handleReset = async () => {

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -189,7 +189,7 @@ function ScheduleRow({ job, floorsRef }: ScheduleRowProps) {
         })
         .finally(() => setPending(false));
     },
-    [slug, isReadOnly, job, queryClient, initialOverride, defaultInterval],
+    [slug, isReadOnly, job, queryClient, defaultInterval],
   );
 
   const handleToggle = useCallback(() => {

--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -222,6 +222,7 @@ export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
   const [overrideReason, setOverrideReason] = useState("");
 
   useEffect(() => {
+    void task.id;
     setSelectedOwner((task.owner ?? "").trim());
     setErrorMsg(null);
     setOverrideReason("");
@@ -637,7 +638,10 @@ function MemoryWorkflowSection({ workflow }: { workflow: TaskMemoryWorkflow }) {
       )}
       <dl className="task-detail-meta">
         {rows
-          .filter(([, value]) => value != null && value !== "")
+          .filter(
+            ([, value]) =>
+              value !== null && value !== undefined && value !== "",
+          )
           .map(([key, value]) => (
             <div key={key} className="task-detail-meta-row">
               <dt>{key}</dt>
@@ -707,7 +711,7 @@ function formatWorkflowStep(step?: TaskMemoryWorkflowStepState): string | null {
     step.status
       ? displayMemoryStatus(normalizeMemoryStatus(step.status))
       : null,
-    step.count != null && step.count > 0
+    step.count !== null && step.count !== undefined && step.count > 0
       ? `${step.count} item${step.count === 1 ? "" : "s"}`
       : null,
     step.actor ? `@${step.actor}` : null,

--- a/web/src/components/notebook/Notebook.tsx
+++ b/web/src/components/notebook/Notebook.tsx
@@ -45,6 +45,7 @@ export default function Notebook({
   useEffect(() => {
     if (agentSlug) return;
     let cancelled = false;
+    void refreshTick;
     setCatalogLoading(true);
     setCatalogError(null);
     fetchCatalog()

--- a/web/src/components/wiki/CitedAnswer.test.tsx
+++ b/web/src/components/wiki/CitedAnswer.test.tsx
@@ -33,7 +33,7 @@ const STUB_GENERAL: QueryAnswer = {
   latency_ms: 5,
 }
 
-const STUB_PARTIAL: QueryAnswer = {
+const _STUB_PARTIAL: QueryAnswer = {
   ...STUB_ANSWER,
   coverage: 'partial',
   sources_cited: [],
@@ -79,7 +79,7 @@ describe('<CitedAnswer>', () => {
     // match the body text that happens to share prose with the excerpt.
     const sourcesList = document.querySelector('.wk-sources ol')
     expect(sourcesList).toBeTruthy()
-    expect(sourcesList!.textContent).toContain('Sarah Jones is VP')
+    expect(sourcesList?.textContent).toContain('Sarah Jones is VP')
   })
 
   it('preserves citation numbering when some sources are uncited (gap case)', async () => {

--- a/web/src/components/wiki/EntityRelatedPanel.test.tsx
+++ b/web/src/components/wiki/EntityRelatedPanel.test.tsx
@@ -84,14 +84,16 @@ describe("<EntityRelatedPanel>", () => {
   // with the new edge. Without this, the SSE wiring is structurally
   // present but behaviorally unverified.
   it("re-fetches the graph on entity:fact_recorded for this entity", async () => {
-    let capturedOnFact: (() => void) | null = null;
-    let capturedKind: unknown = null;
-    let capturedSlug: unknown = null;
+    const captured: {
+      onFact: (() => void) | null;
+      kind: unknown;
+      slug: unknown;
+    } = { onFact: null, kind: null, slug: null };
     vi.spyOn(api, "subscribeEntityEvents").mockImplementation(
-      (kind, slug, onFact) => {
-        capturedKind = kind;
-        capturedSlug = slug;
-        capturedOnFact = onFact as () => void;
+      (kind, slug, factHandler) => {
+        captured.kind = kind;
+        captured.slug = slug;
+        captured.onFact = factHandler as () => void;
         return () => {};
       },
     );
@@ -131,12 +133,14 @@ describe("<EntityRelatedPanel>", () => {
 
     // Confirm the subscriber was scoped to this entity's kind+slug, so the
     // broker-side filter will only hand us events for sarah/people.
-    expect(capturedKind).toBe("people");
-    expect(capturedSlug).toBe("sarah");
+    expect(captured.kind).toBe("people");
+    expect(captured.slug).toBe("sarah");
 
     // Fire the fact_recorded callback as the SSE layer would.
-    expect(capturedOnFact).not.toBeNull();
-    capturedOnFact!();
+    const { onFact } = captured;
+    expect(onFact).not.toBeNull();
+    if (!onFact) throw new Error("Expected fact callback to be captured");
+    onFact();
 
     await screen.findByText("customers/globex");
     expect(fetchSpy).toHaveBeenCalledTimes(2);

--- a/web/src/components/wiki/Pam.tsx
+++ b/web/src/components/wiki/Pam.tsx
@@ -68,6 +68,14 @@ export default function Pam({ articlePath, onActionDone }: PamProps) {
   const activeJobIdRef = useRef<number | null>(null);
   const menuRef = useRef<PamMenuEntry[] | null>(menu);
   const onActionDoneRef = useRef<(() => void) | undefined>(onActionDone);
+
+  const scheduleClear = useCallback(() => {
+    if (statusTimerRef.current) clearTimeout(statusTimerRef.current);
+    statusTimerRef.current = setTimeout(() => {
+      setStatus({ kind: "idle" });
+    }, STATUS_CLEAR_MS);
+  }, []);
+
   useEffect(() => {
     activeJobIdRef.current = activeJobId;
   }, [activeJobId]);
@@ -140,7 +148,7 @@ export default function Pam({ articlePath, onActionDone }: PamProps) {
       unsub();
     };
     // scheduleClear is stable (useCallback with empty deps) — safe to omit.
-  }, []);
+  }, [scheduleClear]);
 
   // Close menu on outside click so it doesn't linger when the user moves
   // on. Keep it simple: single global listener, cleaned up on unmount.
@@ -169,13 +177,6 @@ export default function Pam({ articlePath, onActionDone }: PamProps) {
       menuElRef.current?.querySelector<HTMLButtonElement>('[role="menuitem"]');
     firstItem?.focus();
   }, [menuOpen]);
-
-  const scheduleClear = useCallback(() => {
-    if (statusTimerRef.current) clearTimeout(statusTimerRef.current);
-    statusTimerRef.current = setTimeout(() => {
-      setStatus({ kind: "idle" });
-    }, STATUS_CLEAR_MS);
-  }, []);
 
   const closeMenuAndRefocus = useCallback(() => {
     setMenuOpen(false);
@@ -215,9 +216,11 @@ export default function Pam({ articlePath, onActionDone }: PamProps) {
       ).filter((el) => !el.disabled);
       if (items.length === 0) return;
       e.preventDefault();
-      const activeIndex = items.findIndex(
-        (el) => el === document.activeElement,
-      );
+      const activeElement = document.activeElement;
+      const activeIndex =
+        activeElement instanceof HTMLButtonElement
+          ? items.indexOf(activeElement)
+          : -1;
       const nextIndex =
         e.key === "ArrowDown"
           ? (activeIndex + 1 + items.length) % items.length

--- a/web/src/lib/messageMarkdown.test.tsx
+++ b/web/src/lib/messageMarkdown.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import ReactMarkdown from "react-markdown";
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import {


### PR DESCRIPTION
## Summary
- applies the remaining safe mechanical Biome rewrites after the CSS/style milestone
- preserves behavior where unsafe rewrites would otherwise change effect dependencies or TypeScript narrowing
- reduces the full-codebase Biome inventory from 166 warnings to 156 warnings

## Validation
- bun run check (passes with 156 warnings and 1 info)
- bun run build
- bun run test (passes; expected localhost:3000 ECONNREFUSED noise remains)
- git diff --check audit/css-style-warnings-20260502
- commitlint: ./node_modules/.bin/commitlint --from HEAD~1 --to HEAD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal dependency management and code organization across multiple components.
  * Enhanced menu keyboard navigation logic for better interaction handling.
  * Refactored workspace shredding workflow implementation.

* **Tests**
  * Updated test utilities and improved test fixture management.
  * Refined test assertions for better null-value handling.
  * Refactored real-time update test patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->