### PR TITLE
[codex] clear residual lint warnings

### DIFF
--- a/scripts/check-file-size-self-test.sh
+++ b/scripts/check-file-size-self-test.sh
@@ -42,7 +42,7 @@ expect_failure_containing() {
   local needle="$2"
   local output="$repo/check.out"
 
-  if FILE_SIZE_BASE_REF=main bash "$repo/scripts/check-file-size.sh" > "$output" 2>&1; then
+  if GITHUB_BASE_REF='' FILE_SIZE_BASE_REF=main bash "$repo/scripts/check-file-size.sh" > "$output" 2>&1; then
     echo "expected file-size check to fail in $repo" >&2
     cat "$output" >&2
     exit 1
@@ -58,7 +58,7 @@ expect_success() {
   local repo="$1"
   local output="$repo/check.out"
 
-  if ! bash "$repo/scripts/check-file-size.sh" > "$output" 2>&1; then
+  if ! GITHUB_BASE_REF='' FILE_SIZE_BASE_REF='' bash "$repo/scripts/check-file-size.sh" > "$output" 2>&1; then
     echo "expected file-size check to pass in $repo" >&2
     cat "$output" >&2
     exit 1

--- a/web/biome.json
+++ b/web/biome.json
@@ -18,7 +18,9 @@
       "!playwright-report",
       "!test-results",
       "!**/*.gen.ts",
-      "!**/*.gen.tsx"
+      "!**/*.gen.tsx",
+      "!**/*.generated.ts",
+      "!**/*.generated.tsx"
     ]
   },
   "formatter": {

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -20,6 +20,7 @@
         "remark-gfm": "^4.0.1",
         "remark-wiki-link": "^2.0.1",
         "tailwind-merge": "^3.5.0",
+        "unified": "^11.0.5",
         "zustand": "^5.0.5",
       },
       "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "remark-gfm": "^4.0.1",
     "remark-wiki-link": "^2.0.1",
     "tailwind-merge": "^3.5.0",
+    "unified": "^11.0.5",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -107,6 +107,7 @@ class ErrorBoundary extends Component<
             {this.state.error.stack}
           </pre>
           <button
+            type="button"
             onClick={() => this.setState({ error: null })}
             style={{
               marginTop: 12,

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -15,9 +15,10 @@ export async function initApi(): Promise<void> {
   try {
     const r = await fetch("/api-token");
     const data = await r.json();
-    token = data.token;
-    if (data.broker_url) {
-      brokerDirect = String(data.broker_url).replace(/\/+$/, "");
+    const { token: nextToken, broker_url: brokerUrl } = data;
+    token = nextToken;
+    if (brokerUrl) {
+      brokerDirect = String(brokerUrl).replace(/\/+$/, "");
     }
     useProxy = true;
   } catch {
@@ -25,7 +26,8 @@ export async function initApi(): Promise<void> {
     try {
       const r = await fetch(`${brokerDirect}/web-token`);
       const data = await r.json();
-      token = data.token;
+      const { token: nextToken } = data;
+      token = nextToken;
     } catch {
       // broker unreachable — will fail on first request
     }
@@ -1111,10 +1113,10 @@ export interface UndoRejectSkillResponse {
 }
 
 export function undoRejectSkill(
-  token: string,
+  undoToken: string,
 ): Promise<UndoRejectSkillResponse> {
   return post<UndoRejectSkillResponse>(`/skills/reject/undo`, {
-    undo_token: token,
+    undo_token: undoToken,
   });
 }
 
@@ -1329,8 +1331,8 @@ export function getConfig() {
   return get<ConfigSnapshot>("/config");
 }
 
-export function updateConfig(patch: ConfigUpdate) {
-  return post<{ status: string }>("/config", patch);
+export function updateConfig(configPatch: ConfigUpdate) {
+  return post<{ status: string }>("/config", configPatch);
 }
 
 // Doctor endpoint — one entry per registered local OpenAI-compatible

--- a/web/src/api/entity.test.ts
+++ b/web/src/api/entity.test.ts
@@ -152,7 +152,8 @@ describe("entity api client", () => {
       constructor(public url: string) {}
       onerror: ((ev: Event) => void) | null = null;
       addEventListener(name: string, cb: Listener) {
-        (listeners[name] ??= []).push(cb);
+        listeners[name] ??= [];
+        listeners[name].push(cb);
       }
       removeEventListener(name: string, cb: Listener) {
         listeners[name] = (listeners[name] ?? []).filter((l) => l !== cb);

--- a/web/src/api/sse-dead-path.test.ts
+++ b/web/src/api/sse-dead-path.test.ts
@@ -27,7 +27,8 @@ class FakeEventSource {
     FakeEventSource.lastURL = url;
   }
   addEventListener(name: string, fn: EventListener) {
-    (this.listeners[name] ??= []).push(fn);
+    this.listeners[name] ??= [];
+    this.listeners[name].push(fn);
   }
   removeEventListener(name: string, fn: EventListener) {
     const arr = this.listeners[name];
@@ -65,9 +66,11 @@ describe("SSE dead-path fix", () => {
 
   it("subscribeEditLog opens /events (not /wiki/stream)", () => {
     const unsub = subscribeEditLog(() => {});
-    expect(FakeEventSource.lastURL).not.toBeNull();
-    expect(FakeEventSource.lastURL!).not.toContain("/wiki/stream");
-    expect(FakeEventSource.lastURL!).toMatch(/\/events(\?|$)/);
+    const { lastURL } = FakeEventSource;
+    expect(lastURL).not.toBeNull();
+    if (!lastURL) throw new Error("Expected EventSource URL to be captured");
+    expect(lastURL).not.toContain("/wiki/stream");
+    expect(lastURL).toMatch(/\/events(\?|$)/);
     unsub();
   });
 
@@ -75,7 +78,8 @@ describe("SSE dead-path fix", () => {
     const handler = vi.fn();
     const unsub = subscribeEditLog(handler);
     expect(created).toHaveLength(1);
-    const src = created[0];
+    const [src] = created;
+    if (!src) throw new Error("Expected EventSource to be created");
     // Broker sends an onmessage for the heartbeat `ready` event — handler
     // MUST NOT fire for that. Only the named `wiki:write` event counts.
     src.emit("message", { type: "ready" });
@@ -92,16 +96,19 @@ describe("SSE dead-path fix", () => {
 
   it("subscribeNotebookEvents opens /events (not /notebooks/stream)", () => {
     const unsub = subscribeNotebookEvents(() => {});
-    expect(FakeEventSource.lastURL).not.toBeNull();
-    expect(FakeEventSource.lastURL!).not.toContain("/notebooks/stream");
-    expect(FakeEventSource.lastURL!).toMatch(/\/events(\?|$)/);
+    const { lastURL } = FakeEventSource;
+    expect(lastURL).not.toBeNull();
+    if (!lastURL) throw new Error("Expected EventSource URL to be captured");
+    expect(lastURL).not.toContain("/notebooks/stream");
+    expect(lastURL).toMatch(/\/events(\?|$)/);
     unsub();
   });
 
   it("subscribeNotebookEvents wires both notebook:write and review:state_change listeners", () => {
     const handler = vi.fn();
     const unsub = subscribeNotebookEvents(handler);
-    const src = created[0];
+    const [src] = created;
+    if (!src) throw new Error("Expected EventSource to be created");
     src.emit("notebook:write", {
       slug: "pm",
       path: "agents/pm/notebook/foo.md",

--- a/web/src/components/activity/InsightsList.tsx
+++ b/web/src/components/activity/InsightsList.tsx
@@ -41,8 +41,11 @@ export function InsightsList({
 
   return (
     <div className="insight-list">
-      {visible.map((ins, i) => (
-        <div key={i} className={`insight-row insight-${ins.priority}`}>
+      {visible.map((ins) => (
+        <div
+          key={`${ins.priority}-${ins.category ?? ""}-${ins.title}`}
+          className={`insight-row insight-${ins.priority}`}
+        >
           <div className="insight-head">
             <span className={`insight-badge insight-badge-${ins.priority}`}>
               [{PRIORITY_LABEL[ins.priority]}]

--- a/web/src/components/activity/InsightsList.tsx
+++ b/web/src/components/activity/InsightsList.tsx
@@ -1,3 +1,5 @@
+import { keyedByOccurrence } from "../../lib/reactKeys";
+
 export type InsightPriority = "critical" | "high" | "medium" | "low";
 
 export interface Insight {
@@ -37,15 +39,16 @@ export function InsightsList({
   }
   const visible =
     typeof limit === "number" ? insights.slice(0, limit) : insights;
+  const keyedInsights = keyedByOccurrence(
+    visible,
+    (ins) => `${ins.priority}-${ins.category ?? ""}-${ins.title}`,
+  );
   const overflow = insights.length - visible.length;
 
   return (
     <div className="insight-list">
-      {visible.map((ins) => (
-        <div
-          key={`${ins.priority}-${ins.category ?? ""}-${ins.title}`}
-          className={`insight-row insight-${ins.priority}`}
-        >
+      {keyedInsights.map(({ key, value: ins }) => (
+        <div key={key} className={`insight-row insight-${ins.priority}`}>
           <div className="insight-head">
             <span className={`insight-badge insight-badge-${ins.priority}`}>
               [{PRIORITY_LABEL[ins.priority]}]

--- a/web/src/components/activity/Timeline.tsx
+++ b/web/src/components/activity/Timeline.tsx
@@ -1,4 +1,5 @@
 import { formatRelativeTime } from "../../lib/format";
+import { keyedByOccurrence } from "../../lib/reactKeys";
 
 export type TimelineEventType =
   | "created"
@@ -54,14 +55,15 @@ export function Timeline({ events, emptyLabel, limit }: TimelineProps) {
     b.timestamp.localeCompare(a.timestamp),
   );
   const visible = typeof limit === "number" ? sorted.slice(0, limit) : sorted;
+  const keyedEvents = keyedByOccurrence(
+    visible,
+    (ev) => `${ev.type}-${ev.timestamp}-${ev.content}`,
+  );
 
   return (
     <div className="timeline">
-      {visible.map((ev, i) => (
-        <div
-          key={`${ev.type}-${ev.timestamp}-${ev.content}`}
-          className={`timeline-row timeline-${ev.type}`}
-        >
+      {keyedEvents.map(({ key, value: ev, index: i }) => (
+        <div key={key} className={`timeline-row timeline-${ev.type}`}>
           <div className="timeline-rail">
             <span className="timeline-icon">{ICONS[ev.type] || "\u00B7"}</span>
             {i < visible.length - 1 && <span className="timeline-connector" />}

--- a/web/src/components/activity/Timeline.tsx
+++ b/web/src/components/activity/Timeline.tsx
@@ -58,7 +58,10 @@ export function Timeline({ events, emptyLabel, limit }: TimelineProps) {
   return (
     <div className="timeline">
       {visible.map((ev, i) => (
-        <div key={i} className={`timeline-row timeline-${ev.type}`}>
+        <div
+          key={`${ev.type}-${ev.timestamp}-${ev.content}`}
+          className={`timeline-row timeline-${ev.type}`}
+        >
           <div className="timeline-rail">
             <span className="timeline-icon">{ICONS[ev.type] || "\u00B7"}</span>
             {i < visible.length - 1 && <span className="timeline-connector" />}

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -272,6 +272,7 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
           </div>
         </div>
         <button
+          type="button"
           className="agent-panel-close"
           onClick={onClose}
           aria-label="Close agent panel"
@@ -338,6 +339,7 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
       {/* Primary actions */}
       <div className="agent-panel-actions">
         <button
+          type="button"
           className="btn btn-primary btn-sm"
           onClick={handleOpenDM}
           disabled={dmLoading}
@@ -345,6 +347,7 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
           {dmLoading ? "Opening..." : "Open DM"}
         </button>
         <button
+          type="button"
           className="btn btn-ghost btn-sm"
           onClick={() => setView(view === "logs" ? "stream" : "logs")}
         >
@@ -356,6 +359,7 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
       {canRemove && (
         <div className="agent-panel-actions-stack">
           <button
+            type="button"
             className="btn btn-ghost btn-sm"
             onClick={handleRemove}
             disabled={removing}

--- a/web/src/components/agents/AgentWizard.test.tsx
+++ b/web/src/components/agents/AgentWizard.test.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const postMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return {
+    ...actual,
+    generateAgent: vi.fn(),
+    post: postMock,
+  };
+});
+
+import { AgentWizard } from "./AgentWizard";
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+describe("<AgentWizard>", () => {
+  beforeEach(() => {
+    postMock.mockReset();
+  });
+
+  it("closes on Escape from the window while open", () => {
+    const onClose = vi.fn();
+    render(wrap(<AgentWizard open={true} onClose={onClose} />));
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close on Escape while creating an agent", async () => {
+    postMock.mockImplementation(
+      () =>
+        new Promise(() => {
+          /* never resolves */
+        }),
+    );
+    const onClose = vi.fn();
+    render(wrap(<AgentWizard open={true} onClose={onClose} />));
+
+    fireEvent.click(screen.getByRole("button", { name: "Manual" }));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Revenue Ops" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(postMock).toHaveBeenCalled());
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -157,10 +157,20 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
     }
   }
 
+  function handleOverlayKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      handleCancel();
+    }
+  }
+
   if (!open) return null;
 
   return (
-    <div className="agent-wizard-overlay" onClick={handleOverlayClick}>
+    <div
+      className="agent-wizard-overlay"
+      onClick={handleOverlayClick}
+      onKeyDown={handleOverlayKeyDown}
+    >
       <div className="agent-wizard-modal card">
         <div className="agent-wizard-title">Create agent</div>
 

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -1,8 +1,10 @@
 // biome-ignore-all lint/a11y/noStaticElementInteractions: Modal backdrop uses pointer hit-testing while dialog controls retain keyboard handling.
+// biome-ignore-all lint/a11y/useKeyWithClickEvents: Backdrop pointer dismissal is paired with a window Escape listener while the modal is open.
 import { useCallback, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { generateAgent, post } from "../../api/client";
+import { useWindowEscape } from "../../hooks/useWindowEscape";
 
 type Provider = "inherit" | "claude-code" | "codex" | "opencode";
 type WizardMode = "describe" | "manual";
@@ -142,14 +144,15 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
     }
   }
 
-  function handleCancel() {
+  const handleCancel = useCallback(() => {
+    if (generating || submitting) return;
     setForm(INITIAL_FORM);
     setSlugEdited(false);
     setError(null);
     setMode("describe");
     setPrompt("");
     onClose();
-  }
+  }, [generating, onClose, submitting]);
 
   function handleOverlayClick(e: React.MouseEvent) {
     if (e.target === e.currentTarget) {
@@ -157,20 +160,12 @@ export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
     }
   }
 
-  function handleOverlayKeyDown(e: React.KeyboardEvent) {
-    if (e.key === "Escape") {
-      handleCancel();
-    }
-  }
+  useWindowEscape(open, handleCancel);
 
   if (!open) return null;
 
   return (
-    <div
-      className="agent-wizard-overlay"
-      onClick={handleOverlayClick}
-      onKeyDown={handleOverlayKeyDown}
-    >
+    <div className="agent-wizard-overlay" onClick={handleOverlayClick}>
       <div className="agent-wizard-modal card">
         <div className="agent-wizard-title">Create agent</div>
 

--- a/web/src/components/apps/ArtifactsApp.tsx
+++ b/web/src/components/apps/ArtifactsApp.tsx
@@ -12,6 +12,7 @@ import {
   type OfficeMember,
 } from "../../api/client";
 import { formatTokens } from "../../lib/format";
+import { keyedByOccurrence } from "../../lib/reactKeys";
 import { type Insight, InsightsList } from "../activity/InsightsList";
 import { Timeline, type TimelineEvent } from "../activity/Timeline";
 
@@ -400,27 +401,29 @@ export function ArtifactsApp() {
             {allActions.length === 0 ? (
               <EmptyState>No actions recorded yet.</EmptyState>
             ) : (
-              allActions
-                .slice(0, 12)
-                .map((action) => (
-                  <ActivityItem
-                    key={`${action.name ?? ""}-${action.title ?? ""}-${action.related_id ?? ""}-${action.summary ?? ""}`}
-                    title={
-                      action.summary || action.name || action.title || "Action"
-                    }
-                    body={
-                      action.related_id ? `Related: ${action.related_id}` : ""
-                    }
-                    meta={[
-                      action.channel ? `#${action.channel}` : "",
-                      action.actor ? `@${action.actor}` : "",
-                      action.created_at
-                        ? new Date(action.created_at).toLocaleString()
-                        : "",
-                    ].filter(Boolean)}
-                    kindLabel={action.kind || action.type || "action"}
-                  />
-                ))
+              keyedByOccurrence(
+                allActions.slice(0, 12),
+                (action) =>
+                  `${action.name ?? ""}-${action.title ?? ""}-${action.related_id ?? ""}-${action.summary ?? ""}`,
+              ).map(({ key, value: action }) => (
+                <ActivityItem
+                  key={key}
+                  title={
+                    action.summary || action.name || action.title || "Action"
+                  }
+                  body={
+                    action.related_id ? `Related: ${action.related_id}` : ""
+                  }
+                  meta={[
+                    action.channel ? `#${action.channel}` : "",
+                    action.actor ? `@${action.actor}` : "",
+                    action.created_at
+                      ? new Date(action.created_at).toLocaleString()
+                      : "",
+                  ].filter(Boolean)}
+                  kindLabel={action.kind || action.type || "action"}
+                />
+              ))
             )}
           </ActivitySection>
         </div>

--- a/web/src/components/apps/ArtifactsApp.tsx
+++ b/web/src/components/apps/ArtifactsApp.tsx
@@ -402,9 +402,9 @@ export function ArtifactsApp() {
             ) : (
               allActions
                 .slice(0, 12)
-                .map((action, i) => (
+                .map((action) => (
                   <ActivityItem
-                    key={i}
+                    key={`${action.name ?? ""}-${action.title ?? ""}-${action.related_id ?? ""}-${action.summary ?? ""}`}
                     title={
                       action.summary || action.name || action.title || "Action"
                     }

--- a/web/src/components/apps/CalendarApp.tsx
+++ b/web/src/components/apps/CalendarApp.tsx
@@ -3,21 +3,12 @@ import { useQuery } from "@tanstack/react-query";
 import { getScheduler, type SchedulerJob } from "../../api/client";
 import { formatRelativeTime } from "../../lib/format";
 import { SystemSchedulesPanel } from "./SystemSchedulesPanel";
+import { isCadenceSchedulerJob } from "./schedulerJobClassification";
 
 /**
- * Decide whether a job belongs in the System Schedules panel (cron-style
- * cadence) or in the timeline (one-shot due_at). Keep this in sync with
- * SystemSchedulesPanel.filterSchedulerRows so we don't double-render.
+ * Calendar shows cadence jobs in the System Schedules panel and one-shot due_at
+ * entries in the timeline.
  */
-function isCadenceJob(job: SchedulerJob): boolean {
-  return (
-    job.system_managed === true ||
-    typeof job.interval_minutes === "number" ||
-    (typeof job.schedule_expr === "string" &&
-      job.schedule_expr.trim().length > 0)
-  );
-}
-
 function groupJobsByDate(jobs: SchedulerJob[]): Record<string, SchedulerJob[]> {
   const groups: Record<string, SchedulerJob[]> = {};
   for (const job of jobs) {
@@ -82,8 +73,8 @@ export function CalendarApp() {
   }
 
   const jobs = data?.jobs ?? [];
-  const cadenceJobs = jobs.filter(isCadenceJob);
-  const timelineJobs = jobs.filter((j) => !isCadenceJob(j));
+  const cadenceJobs = jobs.filter(isCadenceSchedulerJob);
+  const timelineJobs = jobs.filter((j) => !isCadenceSchedulerJob(j));
   const groups = groupJobsByDate(timelineJobs);
   const groupKeys = Object.keys(groups);
 

--- a/web/src/components/apps/GraphApp.tsx
+++ b/web/src/components/apps/GraphApp.tsx
@@ -120,14 +120,14 @@ function runSimulation(
   // Scale forces with node count so a 6-node graph spreads across the canvas
   // the same way a 30-node graph does. Empirically: repulse grows with n,
   // link length with √n.
-  const n = nodes.length;
-  const idealLink = Math.min(280, 140 + n * 8);
-  const repulse = 18000 + n * 600;
+  const nodeCount = nodes.length;
+  const idealLink = Math.min(280, 140 + nodeCount * 8);
+  const repulse = 18000 + nodeCount * 600;
   const centerPull = 0.008;
 
   // Adjacency for quick neighbor lookup.
   const adjacency = new Map<string, string[]>();
-  for (const n of nodes) adjacency.set(n.id, []);
+  for (const node of nodes) adjacency.set(node.id, []);
   for (const e of edges) {
     adjacency.get(e.from)?.push(e.to);
     adjacency.get(e.to)?.push(e.from);
@@ -138,9 +138,9 @@ function runSimulation(
     // Reset forces.
     const fx = new Map<string, number>();
     const fy = new Map<string, number>();
-    for (const n of nodes) {
-      fx.set(n.id, 0);
-      fy.set(n.id, 0);
+    for (const node of nodes) {
+      fx.set(node.id, 0);
+      fy.set(node.id, 0);
     }
 
     // Repulsion between every pair of nodes (O(n²) — fine for v1 scale).
@@ -169,7 +169,7 @@ function runSimulation(
 
     // Attraction along edges (Hooke's law toward idealLink).
     const byId = new Map<string, SimNode>();
-    for (const n of nodes) byId.set(n.id, n);
+    for (const node of nodes) byId.set(node.id, node);
     for (const e of edges) {
       const a = byId.get(e.from);
       const b = byId.get(e.to);
@@ -187,28 +187,28 @@ function runSimulation(
     }
 
     // Center pull keeps disconnected nodes from drifting off-canvas.
-    for (const n of nodes) {
-      fx.set(n.id, (fx.get(n.id) ?? 0) + (cx - n.x) * centerPull);
-      fy.set(n.id, (fy.get(n.id) ?? 0) + (cy - n.y) * centerPull);
+    for (const node of nodes) {
+      fx.set(node.id, (fx.get(node.id) ?? 0) + (cx - node.x) * centerPull);
+      fy.set(node.id, (fy.get(node.id) ?? 0) + (cy - node.y) * centerPull);
     }
 
     // Integrate + clamp to canvas.
     const damping = 0.85;
     const maxVel = 30;
-    for (const n of nodes) {
-      n.vx = (n.vx + (fx.get(n.id) ?? 0)) * damping * cooling;
-      n.vy = (n.vy + (fy.get(n.id) ?? 0)) * damping * cooling;
-      if (n.vx > maxVel) n.vx = maxVel;
-      if (n.vx < -maxVel) n.vx = -maxVel;
-      if (n.vy > maxVel) n.vy = maxVel;
-      if (n.vy < -maxVel) n.vy = -maxVel;
-      n.x += n.vx;
-      n.y += n.vy;
+    for (const node of nodes) {
+      node.vx = (node.vx + (fx.get(node.id) ?? 0)) * damping * cooling;
+      node.vy = (node.vy + (fy.get(node.id) ?? 0)) * damping * cooling;
+      if (node.vx > maxVel) node.vx = maxVel;
+      if (node.vx < -maxVel) node.vx = -maxVel;
+      if (node.vy > maxVel) node.vy = maxVel;
+      if (node.vy < -maxVel) node.vy = -maxVel;
+      node.x += node.vx;
+      node.y += node.vy;
       const pad = NODE_RADIUS + 8;
-      if (n.x < pad) n.x = pad;
-      if (n.x > width - pad) n.x = width - pad;
-      if (n.y < pad) n.y = pad;
-      if (n.y > height - pad) n.y = height - pad;
+      if (node.x < pad) node.x = pad;
+      if (node.x > width - pad) node.x = width - pad;
+      if (node.y < pad) node.y = pad;
+      if (node.y > height - pad) node.y = height - pad;
     }
   }
 }
@@ -436,7 +436,7 @@ export function GraphApp() {
                 const y2 = b.y - (dy / dist) * shrink;
                 return (
                   <g
-                    key={i}
+                    key={`${e.from}->${e.to}`}
                     onMouseEnter={() => setHoveredEdge(i)}
                     onMouseLeave={() => setHoveredEdge(null)}
                   >

--- a/web/src/components/apps/PoliciesApp.tsx
+++ b/web/src/components/apps/PoliciesApp.tsx
@@ -94,6 +94,7 @@ export function PoliciesApp() {
           patterns.
         </div>
         <button
+          type="button"
           className="btn btn-secondary btn-sm"
           onClick={() => {
             setFormOpen((v) => !v);
@@ -123,10 +124,15 @@ export function PoliciesApp() {
             style={{ marginBottom: 8 }}
           />
           <div style={{ display: "flex", gap: 8 }}>
-            <button className="btn btn-primary btn-sm" onClick={handleSave}>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={handleSave}
+            >
               Save
             </button>
             <button
+              type="button"
               className="btn btn-secondary btn-sm"
               onClick={() => {
                 setFormOpen(false);
@@ -244,6 +250,7 @@ function PolicyRow({ policy, onDelete }: PolicyRowProps) {
         </div>
       </div>
       <button
+        type="button"
         style={{
           background: "none",
           border: "none",

--- a/web/src/components/apps/ReceiptsApp.tsx
+++ b/web/src/components/apps/ReceiptsApp.tsx
@@ -273,7 +273,7 @@ function ReceiptDetail({
         <div style={{ overflow: "auto", flex: 1, padding: "0 20px 20px" }}>
           {entries.map((entry, i) => (
             <EntryRow
-              key={`${entry.started_at ?? 0}-${i}`}
+              key={`${entry.started_at ?? 0}-${entry.agent_slug}-${entry.tool_name}`}
               index={i}
               entry={entry}
             />

--- a/web/src/components/apps/ReceiptsApp.tsx
+++ b/web/src/components/apps/ReceiptsApp.tsx
@@ -7,6 +7,7 @@ import {
   type TaskLogEntry,
   type TaskLogSummary,
 } from "../../api/client";
+import { keyedByOccurrence } from "../../lib/reactKeys";
 
 export function ReceiptsApp() {
   const [selectedTask, setSelectedTask] = useState<string | null>(null);
@@ -208,6 +209,7 @@ function ReceiptDetail({
   });
 
   const entries = data?.entries ?? [];
+  const keyedEntries = keyedTaskLogEntries(entries);
 
   return (
     <>
@@ -271,17 +273,26 @@ function ReceiptDetail({
 
       {!(isLoading || error) && entries.length > 0 && (
         <div style={{ overflow: "auto", flex: 1, padding: "0 20px 20px" }}>
-          {entries.map((entry, i) => (
-            <EntryRow
-              key={`${entry.started_at ?? 0}-${entry.agent_slug}-${entry.tool_name}`}
-              index={i}
-              entry={entry}
-            />
+          {keyedEntries.map(({ entry, key }, i) => (
+            <EntryRow key={key} index={i} entry={entry} />
           ))}
         </div>
       )}
     </>
   );
+}
+
+function keyedTaskLogEntries(entries: TaskLogEntry[]) {
+  return keyedByOccurrence(entries, (entry) =>
+    [
+      entry.task_id,
+      entry.started_at ?? 0,
+      entry.completed_at ?? 0,
+      entry.agent_slug,
+      entry.tool_name,
+      entry.error ? "error" : "ok",
+    ].join(":"),
+  ).map(({ key, value: entry }) => ({ entry, key }));
 }
 
 function EntryRow({ index, entry }: { index: number; entry: TaskLogEntry }) {

--- a/web/src/components/apps/RequestsApp.tsx
+++ b/web/src/components/apps/RequestsApp.tsx
@@ -205,6 +205,7 @@ function RequestItem({ request, isPending, onAnswer }: RequestItemProps) {
         <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
           {options.map((opt) => (
             <button
+              type="button"
               key={opt.id}
               className={`btn btn-sm ${opt.id === request.recommended_id ? "btn-primary" : "btn-ghost"}`}
               title={opt.description}

--- a/web/src/components/apps/SettingsApp.imageGen.tsx
+++ b/web/src/components/apps/SettingsApp.imageGen.tsx
@@ -67,6 +67,9 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
   const [baseURL, setBaseURL] = useState(s.base_url ?? "");
   const [model, setModel] = useState(s.default_model ?? "");
   const [showKey, setShowKey] = useState(false);
+  const apiKeyId = `image-provider-${s.kind}-api-key`;
+  const baseUrlId = `image-provider-${s.kind}-base-url`;
+  const modelId = `image-provider-${s.kind}-model`;
   const capabilityLabel = [
     s.kind,
     s.supports_video ? "video" : "",
@@ -144,11 +147,12 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
 
       {s.needs_api_key ? (
         <div style={{ marginBottom: 10 }}>
-          <label style={labelStyle}>
+          <label style={labelStyle} htmlFor={apiKeyId}>
             API key {s.api_key_set ? "(set)" : "(unset)"}
           </label>
           <div style={{ display: "flex", gap: 8 }}>
             <input
+              id={apiKeyId}
               type={showKey ? "text" : "password"}
               value={apiKey}
               placeholder={s.api_key_set ? "•••••• (replace)" : "paste here"}
@@ -176,8 +180,11 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
         }}
       >
         <div>
-          <label style={labelStyle}>Base URL (optional)</label>
+          <label style={labelStyle} htmlFor={baseUrlId}>
+            Base URL (optional)
+          </label>
           <input
+            id={baseUrlId}
             type="text"
             value={baseURL}
             onChange={(e) => setBaseURL(e.target.value)}
@@ -186,8 +193,11 @@ function ProviderCard({ s }: { s: ImageProviderStatus }) {
           />
         </div>
         <div>
-          <label style={labelStyle}>Default model</label>
+          <label style={labelStyle} htmlFor={modelId}>
+            Default model
+          </label>
           <input
+            id={modelId}
             type="text"
             value={model}
             onChange={(e) => setModel(e.target.value)}

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -1401,7 +1401,7 @@ export function SettingsApp() {
           <div key={group.label}>
             <p style={styles.navGroupLabel}>{group.label}</p>
             {group.items.map((sec) => {
-              const Icon = sec.Icon;
+              const { Icon } = sec;
               return (
                 <button
                   key={sec.id}

--- a/web/src/components/apps/SkillsApp.tsx
+++ b/web/src/components/apps/SkillsApp.tsx
@@ -24,6 +24,7 @@ import {
 import { useTeamLeadSlug } from "../../hooks/useConfig";
 import { useOfficeMembers } from "../../hooks/useMembers";
 import { useAppStore } from "../../stores/app";
+import { confirm as confirmDialog } from "../ui/ConfirmDialog";
 import { LightningIcon } from "../ui/LightningIcon";
 import { SidePanel } from "../ui/SidePanel";
 import { showNotice, showUndoToast } from "../ui/Toast";
@@ -226,20 +227,22 @@ export function SkillsApp() {
     setPreviewDirty(false);
   }, []);
 
-  // Closes the SidePanel; prompts the user to confirm when there are
-  // unsaved edits (proposed skills can be edited inline). The browser
-  // confirm() is fine here — we already use it elsewhere for danger-zone
-  // confirmations, and the destructive consequence (lost edits) maps cleanly
-  // onto the binary OK/Cancel UX.
   const handlePreviewClose = useCallback(() => {
+    const closePreview = () => {
+      setPreviewSkill(null);
+      setPreviewDirty(false);
+    };
     if (previewDirty) {
-      const ok = window.confirm(
-        "You have unsaved edits. Discard them and close?",
-      );
-      if (!ok) return;
+      confirmDialog({
+        title: "Discard edits?",
+        message: "You have unsaved edits. Discard them and close?",
+        confirmLabel: "Discard",
+        danger: true,
+        onConfirm: closePreview,
+      });
+      return;
     }
-    setPreviewSkill(null);
-    setPreviewDirty(false);
+    closePreview();
   }, [previewDirty]);
 
   const handlePreviewSaved = useCallback(

--- a/web/src/components/apps/SkillsApp.tsx
+++ b/web/src/components/apps/SkillsApp.tsx
@@ -132,9 +132,8 @@ interface OwnersChipProps {
 }
 
 /**
- * Small pill rendering the agent slugs that own a skill. Empty/missing
- * slugs render as "lead-routable" (italic, dim) to make ownership status
- * legible at a glance without the user squinting at a missing field.
+ * Renders owner slugs. Empty/missing slugs render as "lead-routable"
+ * so ownership stays legible when the backing field is empty.
  */
 export function OwnersChip({ slugs }: OwnersChipProps) {
   const list = (slugs ?? []).filter((s) => s.trim().length > 0);
@@ -162,10 +161,8 @@ export function SkillsApp() {
   const queryClient = useQueryClient();
   const [previewSkill, setPreviewSkill] = useState<Skill | null>(null);
   const [previewDirty, setPreviewDirty] = useState(false);
-  // Pause the 30s background refetch while the editor is open. Otherwise
-  // a refetch can replace the previewed skill mid-edit, swap the closed-
-  // over `originalContent` under the user, and invalidate the patchSkill
-  // old_string. The editor still reflects fresh data on next open.
+  // Pause background refetch while the editor is open so it cannot replace
+  // `originalContent` mid-edit and break patchSkill old_string matching.
   const previewOpen = previewSkill !== null;
   const { data, isLoading, error } = useQuery({
     queryKey: ["skills", "all"],

--- a/web/src/components/apps/SystemSchedulesPanel.test.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.test.tsx
@@ -28,7 +28,7 @@ vi.mock("../../api/client", async () => {
     );
   return {
     ...actual,
-    patchSchedulerJob: vi.fn(),
+    patchSchedulerJob: vi.fn().mockResolvedValue({ job: {} }),
     getSystemCronSpecs: vi.fn().mockResolvedValue(MOCK_SPECS),
     runSchedulerJob: vi.fn().mockResolvedValue({
       triggered: true,

--- a/web/src/components/apps/SystemSchedulesPanel.test.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.test.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { SchedulerJob } from "../../api/client";
 import { ToastContainer } from "../ui/Toast";
@@ -41,6 +41,19 @@ vi.mock("../../api/client", async () => {
 import * as clientMod from "../../api/client";
 import { SystemSchedulesPanel } from "./SystemSchedulesPanel";
 
+beforeEach(() => {
+  vi.mocked(clientMod.getSystemCronSpecs).mockReset();
+  vi.mocked(clientMod.getSystemCronSpecs).mockResolvedValue(MOCK_SPECS);
+  vi.mocked(clientMod.patchSchedulerJob).mockReset();
+  vi.mocked(clientMod.patchSchedulerJob).mockResolvedValue({ job: {} });
+  vi.mocked(clientMod.runSchedulerJob).mockReset();
+  vi.mocked(clientMod.runSchedulerJob).mockResolvedValue({
+    triggered: true,
+    slug: "task_recheck",
+    at: new Date().toISOString(),
+  });
+});
+
 function wrap(ui: ReactNode) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -58,6 +71,14 @@ function wrapWithToast(ui: ReactNode) {
       <ToastContainer />
     </QueryClientProvider>
   );
+}
+
+async function waitForIntervalInput(name: RegExp) {
+  const input = screen.getByRole("spinbutton", { name });
+  await waitFor(() => {
+    expect(input).not.toBeDisabled();
+  });
+  return input;
 }
 
 const baseSystemJob: SchedulerJob = {
@@ -201,6 +222,28 @@ describe("<SystemSchedulesPanel> toggle round-trip", () => {
 });
 
 describe("<SystemSchedulesPanel> interval validation", () => {
+  it("blocks interval PATCH while scheduler floors are still loading", () => {
+    const patchMock = vi.mocked(clientMod.patchSchedulerJob);
+    patchMock.mockClear();
+    vi.mocked(clientMod.getSystemCronSpecs).mockReturnValueOnce(
+      new Promise(() => {}),
+    );
+
+    render(wrap(<SystemSchedulesPanel jobs={[insightsJob]} />));
+
+    const input = screen.getByRole("spinbutton", {
+      name: /Interval in minutes for Nex insights/i,
+    });
+    expect(input).toBeDisabled();
+    fireEvent.change(input, { target: { value: "10" } });
+    fireEvent.blur(input);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /Scheduler floors are still loading/i,
+    );
+    expect(patchMock).not.toHaveBeenCalled();
+  });
+
   it("blocks PATCH when override is below the per-cron floor", async () => {
     const patchMock = vi.mocked(clientMod.patchSchedulerJob);
     patchMock.mockClear();
@@ -223,15 +266,15 @@ describe("<SystemSchedulesPanel> interval validation", () => {
     expect(patchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects empty / blank overrides without hitting the network", () => {
+  it("rejects empty / blank overrides without hitting the network", async () => {
     const patchMock = vi.mocked(clientMod.patchSchedulerJob);
     patchMock.mockClear();
 
     render(wrap(<SystemSchedulesPanel jobs={[baseSystemJob]} />));
 
-    const input = screen.getByRole("spinbutton", {
-      name: /Interval in minutes for Task recheck cadence/i,
-    });
+    const input = await waitForIntervalInput(
+      /Interval in minutes for Task recheck cadence/i,
+    );
     fireEvent.change(input, { target: { value: "" } });
     fireEvent.blur(input);
 
@@ -239,15 +282,15 @@ describe("<SystemSchedulesPanel> interval validation", () => {
     expect(patchMock).not.toHaveBeenCalled();
   });
 
-  it("rejects negative overrides without hitting the network", () => {
+  it("rejects negative overrides without hitting the network", async () => {
     const patchMock = vi.mocked(clientMod.patchSchedulerJob);
     patchMock.mockClear();
 
     render(wrap(<SystemSchedulesPanel jobs={[baseSystemJob]} />));
 
-    const input = screen.getByRole("spinbutton", {
-      name: /Interval in minutes for Task recheck cadence/i,
-    });
+    const input = await waitForIntervalInput(
+      /Interval in minutes for Task recheck cadence/i,
+    );
     fireEvent.change(input, { target: { value: "-5" } });
     fireEvent.blur(input);
 
@@ -267,9 +310,9 @@ describe("<SystemSchedulesPanel> interval validation", () => {
     // task_recheck default 10, floor 5. Try 20.
     render(wrap(<SystemSchedulesPanel jobs={[baseSystemJob]} />));
 
-    const input = screen.getByRole("spinbutton", {
-      name: /Interval in minutes for Task recheck cadence/i,
-    });
+    const input = await waitForIntervalInput(
+      /Interval in minutes for Task recheck cadence/i,
+    );
     fireEvent.change(input, { target: { value: "20" } });
     fireEvent.blur(input);
 
@@ -296,9 +339,9 @@ describe("<SystemSchedulesPanel> interval validation", () => {
 
     render(wrap(<SystemSchedulesPanel jobs={[overriddenJob]} />));
 
-    const input = screen.getByRole("spinbutton", {
-      name: /Interval in minutes for Task recheck cadence/i,
-    });
+    const input = await waitForIntervalInput(
+      /Interval in minutes for Task recheck cadence/i,
+    );
     fireEvent.change(input, { target: { value: "10" } });
     fireEvent.blur(input);
 

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -21,6 +21,11 @@ interface SystemSchedulesPanelProps {
   jobs: SchedulerJob[];
 }
 
+type FloorState =
+  | { status: "loading"; values: Record<string, number> }
+  | { status: "ready"; values: Record<string, number> }
+  | { status: "fallback"; values: Record<string, number> };
+
 /**
  * "System Schedules" section above the timeline-grouped job cards in
  * CalendarApp. Shows every cron-style scheduler entry with its toggle,
@@ -36,8 +41,10 @@ interface SystemSchedulesPanelProps {
 export function SystemSchedulesPanel({ jobs }: SystemSchedulesPanelProps) {
   const rows = useMemo(() => filterSchedulerRows(jobs), [jobs]);
   // floors: slug → min_floor_minutes, populated from the API on mount.
-  // Stored in state so the rows rerender once the async floor data arrives.
-  const [floors, setFloors] = useState<Record<string, number>>({});
+  const [floorState, setFloorState] = useState<FloorState>({
+    status: "loading",
+    values: {},
+  });
 
   useEffect(() => {
     let aborted = false;
@@ -48,7 +55,7 @@ export function SystemSchedulesPanel({ jobs }: SystemSchedulesPanelProps) {
         for (const s of specs) {
           map[s.slug] = s.min_floor_minutes;
         }
-        setFloors(map);
+        setFloorState({ status: "ready", values: map });
       })
       .catch((err: unknown) => {
         if (aborted) return;
@@ -56,6 +63,7 @@ export function SystemSchedulesPanel({ jobs }: SystemSchedulesPanelProps) {
           "SystemSchedulesPanel: could not fetch system-specs; falling back to default floor",
           err,
         );
+        setFloorState({ status: "fallback", values: {} });
       });
     return () => {
       aborted = true;
@@ -79,7 +87,11 @@ export function SystemSchedulesPanel({ jobs }: SystemSchedulesPanelProps) {
         System Schedules
       </div>
       {rows.map((job) => (
-        <ScheduleRow key={job.slug ?? job.id} job={job} floors={floors} />
+        <ScheduleRow
+          key={job.slug ?? job.id}
+          job={job}
+          floorState={floorState}
+        />
       ))}
     </section>
   );
@@ -97,17 +109,18 @@ function filterSchedulerRows(jobs: SchedulerJob[]): SchedulerJob[] {
 
 interface ScheduleRowProps {
   job: SchedulerJob;
-  floors: Record<string, number>;
+  floorState: FloorState;
 }
 
-function ScheduleRow({ job, floors }: ScheduleRowProps) {
+function ScheduleRow({ job, floorState }: ScheduleRowProps) {
   const queryClient = useQueryClient();
   const slug = job.slug ?? "";
   const isReadOnly = READ_ONLY_SLUGS.has(slug);
   const isCron = typeof job.schedule_expr === "string" && job.schedule_expr;
   const isInterval = typeof job.interval_minutes === "number";
 
-  const floor = floors[slug] ?? DEFAULT_FLOOR_MINUTES;
+  const floorReady = floorState.status !== "loading";
+  const floor = floorState.values[slug] ?? DEFAULT_FLOOR_MINUTES;
   const defaultInterval = job.interval_minutes ?? 0;
   const initialOverride = job.interval_override ?? 0;
   const initialEnabled = job.enabled !== false; // missing → assume enabled
@@ -193,6 +206,10 @@ function ScheduleRow({ job, floors }: ScheduleRowProps) {
 
   const handleIntervalCommit = useCallback(() => {
     if (isReadOnly || isCron) return;
+    if (!floorReady) {
+      setError("Scheduler floors are still loading");
+      return;
+    }
     const trimmed = overrideText.trim();
     if (trimmed === "") {
       setError("Interval is required");
@@ -215,7 +232,15 @@ function ScheduleRow({ job, floors }: ScheduleRowProps) {
       return;
     }
     submitPatch({ interval_override: parsed === defaultInterval ? 0 : parsed });
-  }, [isReadOnly, isCron, overrideText, floor, defaultInterval, submitPatch]);
+  }, [
+    isReadOnly,
+    isCron,
+    floorReady,
+    overrideText,
+    floor,
+    defaultInterval,
+    submitPatch,
+  ]);
 
   const handleRunNow = useCallback(() => {
     if (!slug || runPending) return;
@@ -287,7 +312,7 @@ function ScheduleRow({ job, floors }: ScheduleRowProps) {
         ) : isInterval ? (
           <IntervalPicker
             value={overrideText}
-            disabled={pending}
+            disabled={pending || !floorReady}
             onChange={(v) => {
               setOverrideText(v);
               setError(null);

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../api/client";
 import { formatRelativeTime } from "../../lib/format";
 import { showNotice } from "../ui/Toast";
+import { isCadenceSchedulerJob } from "./schedulerJobClassification";
 
 const DEFAULT_FLOOR_MINUTES = 5;
 
@@ -91,12 +92,7 @@ export function SystemSchedulesPanel({ jobs }: SystemSchedulesPanelProps) {
  * they belong in the timeline view below.
  */
 function filterSchedulerRows(jobs: SchedulerJob[]): SchedulerJob[] {
-  return jobs.filter(
-    (j) =>
-      j.system_managed ||
-      typeof j.interval_minutes === "number" ||
-      typeof j.schedule_expr === "string",
-  );
+  return jobs.filter(isCadenceSchedulerJob);
 }
 
 interface ScheduleRowProps {

--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -687,9 +687,9 @@ function DetailList({ label, items }: { label: string; items: string[] }) {
         {label}
       </div>
       <ul className="task-detail-deps" style={{ display: "block" }}>
-        {items.map((item, index) => (
+        {items.map((item) => (
           <li
-            key={`${label}-${index}`}
+            key={`${label}-${item}`}
             style={{
               marginBottom: 6,
               whiteSpace: "normal",

--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -16,6 +16,7 @@ import {
   updateTaskStatus,
 } from "../../api/client";
 import { formatRelativeTime } from "../../lib/format";
+import { keyedByOccurrence } from "../../lib/reactKeys";
 import { confirm } from "../ui/ConfirmDialog";
 
 interface TaskDetailModalProps {
@@ -687,18 +688,20 @@ function DetailList({ label, items }: { label: string; items: string[] }) {
         {label}
       </div>
       <ul className="task-detail-deps" style={{ display: "block" }}>
-        {items.map((item) => (
-          <li
-            key={`${label}-${item}`}
-            style={{
-              marginBottom: 6,
-              whiteSpace: "normal",
-              wordBreak: "break-word",
-            }}
-          >
-            {item}
-          </li>
-        ))}
+        {keyedByOccurrence(items, (item) => `${label}-${item}`).map(
+          ({ key, value: item }) => (
+            <li
+              key={key}
+              style={{
+                marginBottom: 6,
+                whiteSpace: "normal",
+                wordBreak: "break-word",
+              }}
+            >
+              {item}
+            </li>
+          ),
+        )}
       </ul>
     </div>
   );

--- a/web/src/components/apps/schedulerJobClassification.test.ts
+++ b/web/src/components/apps/schedulerJobClassification.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import type { SchedulerJob } from "../../api/client";
+import { isCadenceSchedulerJob } from "./schedulerJobClassification";
+
+function job(overrides: Partial<SchedulerJob>): SchedulerJob {
+  return {
+    slug: "job",
+    label: "Job",
+    enabled: true,
+    ...overrides,
+  };
+}
+
+describe("isCadenceSchedulerJob", () => {
+  it("classifies system, interval, and non-empty cron jobs as cadence jobs", () => {
+    expect(isCadenceSchedulerJob(job({ system_managed: true }))).toBe(true);
+    expect(isCadenceSchedulerJob(job({ interval_minutes: 5 }))).toBe(true);
+    expect(isCadenceSchedulerJob(job({ schedule_expr: "0 9 * * MON" }))).toBe(
+      true,
+    );
+  });
+
+  it("keeps one-shot and blank-cron jobs in the timeline", () => {
+    expect(isCadenceSchedulerJob(job({ due_at: "2026-05-02T12:00:00Z" }))).toBe(
+      false,
+    );
+    expect(isCadenceSchedulerJob(job({ schedule_expr: "   " }))).toBe(false);
+  });
+});

--- a/web/src/components/apps/schedulerJobClassification.ts
+++ b/web/src/components/apps/schedulerJobClassification.ts
@@ -1,0 +1,15 @@
+import type { SchedulerJob } from "../../api/client";
+
+export function isCadenceSchedulerJob(job: SchedulerJob): boolean {
+  return (
+    job.system_managed === true ||
+    typeof job.interval_minutes === "number" ||
+    hasCronExpression(job)
+  );
+}
+
+function hasCronExpression(job: SchedulerJob): boolean {
+  return (
+    typeof job.schedule_expr === "string" && job.schedule_expr.trim().length > 0
+  );
+}

--- a/web/src/components/channels/ChannelWizard.test.tsx
+++ b/web/src/components/channels/ChannelWizard.test.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createChannelMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return {
+    ...actual,
+    createChannel: createChannelMock,
+    generateChannel: vi.fn(),
+  };
+});
+
+import { ChannelWizard } from "./ChannelWizard";
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+describe("<ChannelWizard>", () => {
+  beforeEach(() => {
+    createChannelMock.mockReset();
+  });
+
+  it("closes on Escape from the window while open", () => {
+    const onClose = vi.fn();
+    render(wrap(<ChannelWizard open={true} onClose={onClose} />));
+
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close on Escape while creating a channel", async () => {
+    createChannelMock.mockImplementation(
+      () =>
+        new Promise(() => {
+          /* never resolves */
+        }),
+    );
+    const onClose = vi.fn();
+    render(wrap(<ChannelWizard open={true} onClose={onClose} />));
+
+    fireEvent.click(screen.getByRole("button", { name: "Manual" }));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Revenue Ops" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(createChannelMock).toHaveBeenCalled());
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/channels/ChannelWizard.tsx
+++ b/web/src/components/channels/ChannelWizard.tsx
@@ -75,6 +75,12 @@ export function ChannelWizard({ open, onClose }: ChannelWizardProps) {
     }
   }
 
+  function handleOverlayKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      handleCancel();
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setSubmitting(true);
@@ -117,7 +123,11 @@ export function ChannelWizard({ open, onClose }: ChannelWizardProps) {
   if (!open) return null;
 
   return (
-    <div className="channel-wizard-overlay" onClick={handleOverlayClick}>
+    <div
+      className="channel-wizard-overlay"
+      onClick={handleOverlayClick}
+      onKeyDown={handleOverlayKeyDown}
+    >
       <div className="channel-wizard-modal card">
         <div className="channel-wizard-title">Create channel</div>
 

--- a/web/src/components/channels/ChannelWizard.tsx
+++ b/web/src/components/channels/ChannelWizard.tsx
@@ -1,8 +1,10 @@
 // biome-ignore-all lint/a11y/noStaticElementInteractions: Intentional wrapper/backdrop or SVG hover target; interactive child controls and keyboard paths are handled nearby.
+// biome-ignore-all lint/a11y/useKeyWithClickEvents: Backdrop pointer dismissal is paired with a window Escape listener while the modal is open.
 import { useCallback, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
 import { createChannel, generateChannel } from "../../api/client";
+import { useWindowEscape } from "../../hooks/useWindowEscape";
 import { useAppStore } from "../../stores/app";
 
 type WizardMode = "describe" | "manual";
@@ -56,18 +58,19 @@ export function ChannelWizard({ open, onClose }: ChannelWizardProps) {
     [slugEdited],
   );
 
-  function resetState() {
+  const resetState = useCallback(() => {
     setMode("describe");
     setPrompt("");
     setManual(INITIAL_MANUAL);
     setSlugEdited(false);
     setError(null);
-  }
+  }, []);
 
-  function handleCancel() {
+  const handleCancel = useCallback(() => {
+    if (submitting) return;
     resetState();
     onClose();
-  }
+  }, [onClose, resetState, submitting]);
 
   function handleOverlayClick(e: React.MouseEvent) {
     if (e.target === e.currentTarget) {
@@ -75,11 +78,7 @@ export function ChannelWizard({ open, onClose }: ChannelWizardProps) {
     }
   }
 
-  function handleOverlayKeyDown(e: React.KeyboardEvent) {
-    if (e.key === "Escape") {
-      handleCancel();
-    }
-  }
+  useWindowEscape(open, handleCancel);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -123,11 +122,7 @@ export function ChannelWizard({ open, onClose }: ChannelWizardProps) {
   if (!open) return null;
 
   return (
-    <div
-      className="channel-wizard-overlay"
-      onClick={handleOverlayClick}
-      onKeyDown={handleOverlayKeyDown}
-    >
+    <div className="channel-wizard-overlay" onClick={handleOverlayClick}>
       <div className="channel-wizard-modal card">
         <div className="channel-wizard-title">Create channel</div>
 

--- a/web/src/components/layout/ChannelHeader.test.tsx
+++ b/web/src/components/layout/ChannelHeader.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStore } from "../../stores/app";
+import { ChannelHeader } from "./ChannelHeader";
+
+vi.mock("../../hooks/useChannels", () => ({
+  useChannels: () => ({ data: [] }),
+}));
+
+afterEach(() => {
+  useAppStore.setState({
+    currentApp: null,
+    currentChannel: "general",
+    theme: "nex",
+  });
+  document.documentElement.setAttribute("data-theme", "nex");
+});
+
+describe("<ChannelHeader>", () => {
+  it("labels the theme toggle with the next theme action", () => {
+    useAppStore.setState({ theme: "nex-dark" });
+
+    render(<ChannelHeader />);
+
+    const button = screen.getByRole("button", {
+      name: "Switch theme to Noir Gold",
+    });
+    expect(button).toHaveAttribute("title", "Switch theme to Noir Gold");
+
+    fireEvent.click(button);
+
+    expect(useAppStore.getState().theme).toBe("noir-gold");
+  });
+});

--- a/web/src/components/layout/ChannelHeader.tsx
+++ b/web/src/components/layout/ChannelHeader.tsx
@@ -27,6 +27,7 @@ export function ChannelHeader() {
     ? currentApp.charAt(0).toUpperCase() + currentApp.slice(1)
     : `# ${currentChannel}`;
   const desc = currentApp ? "" : channel?.description || "";
+  const targetTheme = nextTheme(theme);
 
   return (
     <div className="channel-header">
@@ -38,12 +39,12 @@ export function ChannelHeader() {
         <button
           type="button"
           className="sidebar-btn"
-          title={`Theme: ${themeLabel(theme)} — click to cycle`}
-          aria-label={`Theme: ${themeLabel(theme)}, click to cycle`}
-          onClick={() => setTheme(nextTheme(theme))}
+          title={`Switch theme to ${themeLabel(targetTheme)}`}
+          aria-label={`Switch theme to ${themeLabel(targetTheme)}`}
+          onClick={() => setTheme(targetTheme)}
         >
-          {theme === "noir-gold" ? (
-            // Sparkle / star — for the gold theme
+          {targetTheme === "noir-gold" ? (
+            // Sparkle / star — switch to the gold theme
             <svg
               aria-hidden="true"
               focusable="false"
@@ -58,8 +59,8 @@ export function ChannelHeader() {
             >
               <path d="M12 3l1.8 5.5H19l-4.6 3.4 1.8 5.6L12 14l-4.2 3.5 1.8-5.6L5 8.5h5.2L12 3z" />
             </svg>
-          ) : theme === "nex-dark" ? (
-            // Sun — currently dark, click to go light
+          ) : targetTheme === "nex" ? (
+            // Sun — switch to the light theme
             <svg
               aria-hidden="true"
               focusable="false"
@@ -76,7 +77,7 @@ export function ChannelHeader() {
               <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
             </svg>
           ) : (
-            // Moon — currently light, click to go noir-gold
+            // Moon — switch to the dark theme
             <svg
               aria-hidden="true"
               focusable="false"

--- a/web/src/components/layout/upgradeBanner.utils.ts
+++ b/web/src/components/layout/upgradeBanner.utils.ts
@@ -125,7 +125,7 @@ export function parseCommit(message: string, sha: string): CommitEntry {
   const type = m[1].toLowerCase();
   const scope = (m[2] ?? "").replace(/[()]/g, "");
   const breaking = m[3] === "!";
-  const rest = m[4];
+  const [, , , , rest] = m;
   return {
     type,
     scope,

--- a/web/src/components/layout/upgradeBanner.utils.ts
+++ b/web/src/components/layout/upgradeBanner.utils.ts
@@ -125,7 +125,7 @@ export function parseCommit(message: string, sha: string): CommitEntry {
   const type = m[1].toLowerCase();
   const scope = (m[2] ?? "").replace(/[()]/g, "");
   const breaking = m[3] === "!";
-  const [, , , , rest] = m;
+  const rest = m[4] ?? "";
   return {
     type,
     scope,

--- a/web/src/components/messages/HumanInterviewOverlay.test.tsx
+++ b/web/src/components/messages/HumanInterviewOverlay.test.tsx
@@ -12,7 +12,9 @@ vi.mock("../../hooks/useRequests", () => ({
 
 vi.mock("../../api/client", async () => {
   const actual =
-    await vi.importActual<typeof import("../../api/client")>("../../api/client");
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
   return {
     ...actual,
     answerRequest: vi.fn().mockResolvedValue({}),

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -50,12 +50,6 @@ export function MessageBubble({
     ? resolveHarness(agent?.provider, defaultHarness)
     : null;
 
-  // Status messages — compact
-  if (message.content?.startsWith("[STATUS]")) {
-    const statusText = message.content.replace(/^\[STATUS\]\s*/, "");
-    return <div className="message-status animate-fade">{statusText}</div>;
-  }
-
   const usageTotal = message.usage
     ? (message.usage.total_tokens ??
       (message.usage.input_tokens ?? 0) +
@@ -94,6 +88,12 @@ export function MessageBubble({
     () => (isHuman ? renderMentions(message.content || "", knownSlugs) : null),
     [isHuman, message.content, knownSlugs],
   );
+
+  // Status messages — compact
+  if (message.content?.startsWith("[STATUS]")) {
+    const statusText = message.content.replace(/^\[STATUS\]\s*/, "");
+    return <div className="message-status animate-fade">{statusText}</div>;
+  }
 
   return (
     <div

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -124,9 +124,10 @@ function ClaudeAssistantEvent({
   compact: boolean;
 }) {
   const blocks = messageContentBlocks(parsed);
+  const blockKey = uniqueSiblingKeyer();
   const rendered = blocks
     .map((block) => {
-      const key = streamBlockKey(block);
+      const key = blockKey(block);
       const blockType = stringish(block.type);
       if (blockType === "text") {
         const text = stringish(block.text).trim();
@@ -174,12 +175,13 @@ function ClaudeUserEvent({
   compact: boolean;
 }) {
   const blocks = messageContentBlocks(parsed);
+  const blockKey = uniqueSiblingKeyer();
   const rendered = blocks
     .map((block) => {
       if (stringish(block.type) !== "tool_result") return null;
       const { content } = block;
       return (
-        <div key={streamBlockKey(block)} className="cc-tool-call">
+        <div key={blockKey(block)} className="cc-tool-call">
           <div className="cc-tool-section-label">Tool result</div>
           <ToolResultContent
             text={stringFromToolContent(content)}
@@ -389,6 +391,7 @@ function ToolCallCard({
     }
     return out;
   }, [args]);
+  const resultContentKey = uniqueSiblingKeyer();
 
   return (
     <div className="cc-tool-call">
@@ -432,7 +435,7 @@ function ToolCallCard({
                 </div>
                 {result.content.map((c) => (
                   <ToolResultContent
-                    key={streamBlockKey(c)}
+                    key={resultContentKey(c)}
                     text={c.text}
                     compact={compact}
                   />
@@ -624,6 +627,16 @@ function streamBlockKey(value: unknown): string {
   }
 }
 
+function uniqueSiblingKeyer(): (value: unknown) => string {
+  const counts = new Map<string, number>();
+  return (value: unknown) => {
+    const base = streamBlockKey(value);
+    const count = counts.get(base) ?? 0;
+    counts.set(base, count + 1);
+    return count === 0 ? base : `${base}#${count}`;
+  };
+}
+
 /* ───── JSON tree primitive (shared by both card and fallback paths) ───── */
 
 function Value({
@@ -666,11 +679,12 @@ function Value({
     if (value.length === 0) return <span className="sv-null">[]</span>;
     if ((compact && depth >= 1) || depth > 3)
       return <span className="sv-str">[{value.length} items]</span>;
+    const itemKey = uniqueSiblingKeyer();
     return (
       <Collapsible label={`[${value.length}]`} startOpen={depth === 0}>
         <div className="sv-array">
           {value.map((item) => (
-            <div key={streamBlockKey(item)} className="sv-array-item">
+            <div key={itemKey(item)} className="sv-array-item">
               <Value value={item} depth={depth + 1} compact={compact} />
             </div>
           ))}

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useMemo, useState } from "react";
 
 import type { StreamLine } from "../../hooks/useAgentStream";
+import { keyedByOccurrence } from "../../lib/reactKeys";
 
 interface StreamLineViewProps {
   line: StreamLine;
@@ -124,10 +125,8 @@ function ClaudeAssistantEvent({
   compact: boolean;
 }) {
   const blocks = messageContentBlocks(parsed);
-  const blockKey = uniqueSiblingKeyer();
-  const rendered = blocks
-    .map((block) => {
-      const key = blockKey(block);
+  const rendered = keyedStreamValues(blocks)
+    .map(({ key, value: block }) => {
       const blockType = stringish(block.type);
       if (blockType === "text") {
         const text = stringish(block.text).trim();
@@ -175,13 +174,12 @@ function ClaudeUserEvent({
   compact: boolean;
 }) {
   const blocks = messageContentBlocks(parsed);
-  const blockKey = uniqueSiblingKeyer();
-  const rendered = blocks
-    .map((block) => {
+  const rendered = keyedStreamValues(blocks)
+    .map(({ key, value: block }) => {
       if (stringish(block.type) !== "tool_result") return null;
       const { content } = block;
       return (
-        <div key={blockKey(block)} className="cc-tool-call">
+        <div key={key} className="cc-tool-call">
           <div className="cc-tool-section-label">Tool result</div>
           <ToolResultContent
             text={stringFromToolContent(content)}
@@ -391,8 +389,6 @@ function ToolCallCard({
     }
     return out;
   }, [args]);
-  const resultContentKey = uniqueSiblingKeyer();
-
   return (
     <div className="cc-tool-call">
       <button
@@ -433,9 +429,9 @@ function ToolCallCard({
                 <div className="cc-tool-section-label cc-tool-result-label">
                   {"\u2713 Response"}
                 </div>
-                {result.content.map((c) => (
+                {keyedStreamValues(result.content).map(({ key, value: c }) => (
                   <ToolResultContent
-                    key={resultContentKey(c)}
+                    key={key}
                     text={c.text}
                     compact={compact}
                   />
@@ -627,14 +623,8 @@ function streamBlockKey(value: unknown): string {
   }
 }
 
-function uniqueSiblingKeyer(): (value: unknown) => string {
-  const counts = new Map<string, number>();
-  return (value: unknown) => {
-    const base = streamBlockKey(value);
-    const count = counts.get(base) ?? 0;
-    counts.set(base, count + 1);
-    return count === 0 ? base : `${base}#${count}`;
-  };
+function keyedStreamValues<T>(values: readonly T[]) {
+  return keyedByOccurrence(values, streamBlockKey);
 }
 
 /* ───── JSON tree primitive (shared by both card and fallback paths) ───── */
@@ -679,12 +669,11 @@ function Value({
     if (value.length === 0) return <span className="sv-null">[]</span>;
     if ((compact && depth >= 1) || depth > 3)
       return <span className="sv-str">[{value.length} items]</span>;
-    const itemKey = uniqueSiblingKeyer();
     return (
       <Collapsible label={`[${value.length}]`} startOpen={depth === 0}>
         <div className="sv-array">
-          {value.map((item) => (
-            <div key={itemKey(item)} className="sv-array-item">
+          {keyedStreamValues(value).map(({ key, value: item }) => (
+            <div key={key} className="sv-array-item">
               <Value value={item} depth={depth + 1} compact={compact} />
             </div>
           ))}

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -15,18 +15,17 @@ interface StreamLineViewProps {
  * a single line. Everything else falls back to pretty-printed JSON.
  */
 export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
-  if (!line.parsed) {
+  const { data, parsed } = line;
+  if (!parsed) {
     // Raw chunks from agentStream.Push (local-LLM streaming text). The
     // useAgentStream hook coalesces consecutive raw events into a
     // single StreamLine, so this branch renders the running model
     // output as a continuous text block \u2014 not one chunk per row.
     // Trailing ellipsis keeps the live-output panel visually capped.
-    const text =
-      line.data.length > 1200 ? `${line.data.slice(0, 1200)}\u2026` : line.data;
+    const text = data.length > 1200 ? `${data.slice(0, 1200)}\u2026` : data;
     return <div className="stream-line stream-line-raw">{text}</div>;
   }
 
-  const parsed = line.parsed;
   const evtType = typeof parsed.type === "string" ? parsed.type : "";
 
   // Skip noise events entirely
@@ -126,12 +125,13 @@ function ClaudeAssistantEvent({
 }) {
   const blocks = messageContentBlocks(parsed);
   const rendered = blocks
-    .map((block, index) => {
+    .map((block) => {
+      const key = streamBlockKey(block);
       const blockType = stringish(block.type);
       if (blockType === "text") {
         const text = stringish(block.text).trim();
         return text ? (
-          <div key={index} className="cc-thinking">
+          <div key={key} className="cc-thinking">
             {text}
           </div>
         ) : null;
@@ -139,7 +139,7 @@ function ClaudeAssistantEvent({
       if (blockType === "thinking") {
         const text = stringish(block.thinking).trim();
         return text ? (
-          <div key={index} className="stream-card-detail">
+          <div key={key} className="stream-card-detail">
             {text}
           </div>
         ) : null;
@@ -147,7 +147,7 @@ function ClaudeAssistantEvent({
       if (blockType === "tool_use") {
         return (
           <ToolCallCard
-            key={index}
+            key={key}
             item={{
               type: "tool_call",
               name: block.name,
@@ -175,11 +175,11 @@ function ClaudeUserEvent({
 }) {
   const blocks = messageContentBlocks(parsed);
   const rendered = blocks
-    .map((block, index) => {
+    .map((block) => {
       if (stringish(block.type) !== "tool_result") return null;
-      const content = block.content;
+      const { content } = block;
       return (
-        <div key={index} className="cc-tool-call">
+        <div key={streamBlockKey(block)} className="cc-tool-call">
           <div className="cc-tool-section-label">Tool result</div>
           <ToolResultContent
             text={stringFromToolContent(content)}
@@ -214,9 +214,9 @@ function ClaudeUserEvent({
 function messageContentBlocks(
   parsed: Record<string, unknown>,
 ): Record<string, unknown>[] {
-  const message = parsed.message;
+  const { message } = parsed;
   if (!message || typeof message !== "object") return [];
-  const content = (message as Record<string, unknown>).content;
+  const { content } = message as Record<string, unknown>;
   if (!Array.isArray(content)) return [];
   return content.filter(
     (block): block is Record<string, unknown> =>
@@ -227,7 +227,7 @@ function messageContentBlocks(
 function codexItemText(item: Record<string, unknown>): string {
   const direct = stringish(item.text).trim();
   if (direct) return direct;
-  const content = item.content;
+  const { content } = item;
   if (!Array.isArray(content)) return "";
   return content
     .map((part) => {
@@ -430,8 +430,12 @@ function ToolCallCard({
                 <div className="cc-tool-section-label cc-tool-result-label">
                   {"\u2713 Response"}
                 </div>
-                {result.content.map((c, i) => (
-                  <ToolResultContent key={i} text={c.text} compact={compact} />
+                {result.content.map((c) => (
+                  <ToolResultContent
+                    key={streamBlockKey(c)}
+                    text={c.text}
+                    compact={compact}
+                  />
                 ))}
               </>
             )}
@@ -610,6 +614,16 @@ function stringish(v: unknown): string {
   return typeof v === "string" ? v : "";
 }
 
+function streamBlockKey(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value !== "object") return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return Object.prototype.toString.call(value);
+  }
+}
+
 /* ───── JSON tree primitive (shared by both card and fallback paths) ───── */
 
 function Value({
@@ -655,8 +669,8 @@ function Value({
     return (
       <Collapsible label={`[${value.length}]`} startOpen={depth === 0}>
         <div className="sv-array">
-          {value.map((item, idx) => (
-            <div key={idx} className="sv-array-item">
+          {value.map((item) => (
+            <div key={streamBlockKey(item)} className="sv-array-item">
               <Value value={item} depth={depth + 1} compact={compact} />
             </div>
           ))}

--- a/web/src/components/messages/ThreadPanel.tsx
+++ b/web/src/components/messages/ThreadPanel.tsx
@@ -32,13 +32,13 @@ export function ThreadPanel() {
   // returns both in the same list because thread_id matches either id or
   // reply_to.
   const { parent, replies } = useMemo(() => {
-    let parent: Message | null = null;
-    const replies: Message[] = [];
+    let threadParent: Message | null = null;
+    const threadReplies: Message[] = [];
     for (const m of messages) {
-      if (m.id === activeThreadId) parent = m;
-      else if (m.reply_to) replies.push(m);
+      if (m.id === activeThreadId) threadParent = m;
+      else if (m.reply_to) threadReplies.push(m);
     }
-    return { parent, replies };
+    return { parent: threadParent, replies: threadReplies };
   }, [messages, activeThreadId]);
 
   // Auto-scroll to the bottom when a new reply arrives. Anchoring at the

--- a/web/src/components/search/SearchModal.tsx
+++ b/web/src/components/search/SearchModal.tsx
@@ -42,11 +42,14 @@ function highlightMatch(text: string, query: string): ReactNode {
   const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const regex = new RegExp(`(${escaped})`, "gi");
   const parts = text.split(regex);
-  return parts.map((part, i) => {
+  let offset = 0;
+  return parts.map((part) => {
+    const key = `${part}-${offset}`;
+    offset += part.length;
     const isMatch =
       regex.test(part) && part.toLowerCase() === query.toLowerCase();
     regex.lastIndex = 0;
-    return isMatch ? <mark key={i}>{part}</mark> : part;
+    return isMatch ? <mark key={key}>{part}</mark> : part;
   });
 }
 
@@ -122,8 +125,8 @@ export function SearchModal() {
               return [] as MessageHit[];
             }
           }),
-        ).then((grouped) =>
-          grouped
+        ).then((messageGroups) =>
+          messageGroups
             .flat()
             .sort(
               (a, b) =>
@@ -150,7 +153,7 @@ export function SearchModal() {
               () => [] as NotebookSearchHit[],
             ),
           ),
-        ).then((grouped) => grouped.flat().slice(0, 8));
+        ).then((notebookGroups) => notebookGroups.flat().slice(0, 8));
 
         const [msg, wiki, nb] = await Promise.all([
           messagesP,

--- a/web/src/components/ui/ConfirmDialog.tsx
+++ b/web/src/components/ui/ConfirmDialog.tsx
@@ -12,6 +12,7 @@ interface ConfirmOptions {
 }
 
 let requestConfirm: ((opts: ConfirmOptions) => void) | null = null;
+let queuedConfirm: ConfirmOptions | null = null;
 
 /**
  * Imperative confirm, callable from anywhere.
@@ -20,10 +21,9 @@ let requestConfirm: ((opts: ConfirmOptions) => void) | null = null;
  */
 export function confirm(opts: ConfirmOptions) {
   if (!requestConfirm) {
-    // Host never mounted; fall back to native confirm so work isn't silently dropped.
-    if (window.confirm(opts.message)) {
-      void opts.onConfirm();
-    }
+    // Host is not mounted yet. Queue the latest request so the action still
+    // requires the app modal instead of falling back to native confirm().
+    queuedConfirm = opts;
     return;
   }
   requestConfirm(opts);
@@ -46,6 +46,10 @@ export function ConfirmHost() {
       setOpts(o);
       setOpen(true);
     };
+    if (queuedConfirm) {
+      requestConfirm(queuedConfirm);
+      queuedConfirm = null;
+    }
     return () => {
       if (requestConfirm !== null) requestConfirm = null;
     };

--- a/web/src/components/ui/Kbd.test.tsx
+++ b/web/src/components/ui/Kbd.test.tsx
@@ -1,7 +1,19 @@
 import { render } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { Kbd, KbdSequence, MOD_KEY } from "./Kbd";
+
+function hasDuplicateKeyWarning(calls: unknown[][]) {
+  return calls.some((args) =>
+    args.some((arg) =>
+      String(arg).includes("Encountered two children with the same key"),
+    ),
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("<Kbd>", () => {
   it("renders a semantic <kbd> with the base .kbd class", () => {
@@ -76,6 +88,14 @@ describe("<KbdSequence>", () => {
     const { container } = render(<KbdSequence keys={[["g"], ["g"]]} />);
     const then = container.querySelector(".kbd-then");
     expect(then?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("renders duplicate suffix-shaped keys without duplicate React keys", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { container } = render(<KbdSequence keys={["K", "K", "K#1"]} />);
+
+    expect(container.querySelectorAll("kbd")).toHaveLength(3);
+    expect(hasDuplicateKeyWarning(errorSpy.mock.calls)).toBe(false);
   });
 });
 

--- a/web/src/components/ui/Kbd.test.tsx
+++ b/web/src/components/ui/Kbd.test.tsx
@@ -57,7 +57,9 @@ describe("<KbdSequence>", () => {
   it("propagates size to every rendered <kbd>", () => {
     const { container } = render(<KbdSequence keys={["⌘", "K"]} size="sm" />);
     const kbds = container.querySelectorAll("kbd");
-    kbds.forEach((k) => expect(k.className).toContain("kbd-sm"));
+    for (const kbd of kbds) {
+      expect(kbd.className).toContain("kbd-sm");
+    }
   });
 
   it("propagates inverse variant to every rendered <kbd>", () => {
@@ -65,7 +67,9 @@ describe("<KbdSequence>", () => {
       <KbdSequence keys={["⌘", "K"]} variant="inverse" />,
     );
     const kbds = container.querySelectorAll("kbd");
-    kbds.forEach((k) => expect(k.className).toContain("kbd-inverse"));
+    for (const kbd of kbds) {
+      expect(kbd.className).toContain("kbd-inverse");
+    }
   });
 
   it('marks the "then" separator aria-hidden so screen readers skip it', () => {

--- a/web/src/components/ui/Kbd.test.tsx
+++ b/web/src/components/ui/Kbd.test.tsx
@@ -69,6 +69,7 @@ describe("<KbdSequence>", () => {
   it("propagates size to every rendered <kbd>", () => {
     const { container } = render(<KbdSequence keys={["⌘", "K"]} size="sm" />);
     const kbds = container.querySelectorAll("kbd");
+    expect(kbds).toHaveLength(2);
     for (const kbd of kbds) {
       expect(kbd.className).toContain("kbd-sm");
     }
@@ -79,6 +80,7 @@ describe("<KbdSequence>", () => {
       <KbdSequence keys={["⌘", "K"]} variant="inverse" />,
     );
     const kbds = container.querySelectorAll("kbd");
+    expect(kbds).toHaveLength(2);
     for (const kbd of kbds) {
       expect(kbd.className).toContain("kbd-inverse");
     }

--- a/web/src/components/ui/Kbd.tsx
+++ b/web/src/components/ui/Kbd.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { keyedByOccurrence } from "../../lib/reactKeys";
+
 /**
  * Shared keyboard-key badge. Renders real <kbd> semantics so assistive
  * tech announces the key, and uses a single visual treatment across the
@@ -45,29 +47,26 @@ export function KbdSequence({
   const chords: string[][] = Array.isArray(keys[0])
     ? (keys as string[][])
     : [keys as string[]];
-  const chordKeys = new Map<string, number>();
-  const keyKeys = new Map<string, number>();
-  const uniqueKey = (seen: Map<string, number>, value: string) => {
-    const occurrence = seen.get(value) ?? 0;
-    seen.set(value, occurrence + 1);
-    return occurrence === 0 ? value : `${value}-${occurrence}`;
-  };
   return (
     <span className={`kbd-sequence ${className}`.trim()}>
-      {chords.map((chord, i) => (
-        <span key={uniqueKey(chordKeys, chord.join("+"))} className="kbd-chord">
-          {i > 0 && (
-            <span className="kbd-then" aria-hidden="true">
-              then
-            </span>
-          )}
-          {chord.map((k) => (
-            <Kbd key={uniqueKey(keyKeys, k)} size={size} variant={variant}>
-              {k}
-            </Kbd>
-          ))}
-        </span>
-      ))}
+      {keyedByOccurrence(chords, (chord) => chord.join("+")).map(
+        ({ key: chordKey, value: chord, index: i }) => (
+          <span key={chordKey} className="kbd-chord">
+            {i > 0 && (
+              <span className="kbd-then" aria-hidden="true">
+                then
+              </span>
+            )}
+            {keyedByOccurrence(chord, (k) => k).map(
+              ({ key: keyKey, value: k }) => (
+                <Kbd key={keyKey} size={size} variant={variant}>
+                  {k}
+                </Kbd>
+              ),
+            )}
+          </span>
+        ),
+      )}
     </span>
   );
 }

--- a/web/src/components/ui/Kbd.tsx
+++ b/web/src/components/ui/Kbd.tsx
@@ -45,17 +45,24 @@ export function KbdSequence({
   const chords: string[][] = Array.isArray(keys[0])
     ? (keys as string[][])
     : [keys as string[]];
+  const chordKeys = new Map<string, number>();
+  const keyKeys = new Map<string, number>();
+  const uniqueKey = (seen: Map<string, number>, value: string) => {
+    const occurrence = seen.get(value) ?? 0;
+    seen.set(value, occurrence + 1);
+    return occurrence === 0 ? value : `${value}-${occurrence}`;
+  };
   return (
     <span className={`kbd-sequence ${className}`.trim()}>
       {chords.map((chord, i) => (
-        <span key={i} className="kbd-chord">
+        <span key={uniqueKey(chordKeys, chord.join("+"))} className="kbd-chord">
           {i > 0 && (
             <span className="kbd-then" aria-hidden="true">
               then
             </span>
           )}
-          {chord.map((k, j) => (
-            <Kbd key={j} size={size} variant={variant}>
+          {chord.map((k) => (
+            <Kbd key={uniqueKey(keyKeys, k)} size={size} variant={variant}>
               {k}
             </Kbd>
           ))}

--- a/web/src/components/ui/SidePanel.tsx
+++ b/web/src/components/ui/SidePanel.tsx
@@ -72,7 +72,7 @@ export function SidePanel({
     if (panel) {
       const focusables =
         panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
-      const first = focusables[0];
+      const [first] = focusables;
       if (first) {
         first.focus();
       } else {
@@ -89,7 +89,7 @@ export function SidePanel({
         e.preventDefault();
         return;
       }
-      const first = focusables[0];
+      const [first] = focusables;
       const last = focusables[focusables.length - 1];
       if (e.shiftKey && document.activeElement === first) {
         e.preventDefault();

--- a/web/src/components/ui/WipeModal.tsx
+++ b/web/src/components/ui/WipeModal.tsx
@@ -116,6 +116,7 @@ export function WipeModal({
   const enabled = !busy && value.trim().toLowerCase() === WIPE_CONFIRM_PHRASE;
   const titleId = useId();
   const bodyId = useId();
+  const inputId = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
   // Track where the press started so accidental drag-out from the input to
   // the backdrop (common while selecting the displayed phrase to copy) does
@@ -168,10 +169,11 @@ export function WipeModal({
         <div id={bodyId} style={styles.body}>
           {intro}
         </div>
-        <label style={styles.inputLabel}>
+        <label htmlFor={inputId} style={styles.inputLabel}>
           Type <code>{WIPE_CONFIRM_PHRASE}</code> to confirm
         </label>
         <input
+          id={inputId}
           ref={inputRef}
           type="text"
           style={styles.input}
@@ -195,7 +197,7 @@ export function WipeModal({
             onClick={enabled ? onConfirm : undefined}
             disabled={!enabled}
           >
-            {busy === true ? "Working…" : confirmLabel}
+            {busy === true ? "Working…" : String(confirmLabel)}
           </button>
         </div>
       </div>

--- a/web/src/components/ui/WipeModal.tsx
+++ b/web/src/components/ui/WipeModal.tsx
@@ -195,7 +195,7 @@ export function WipeModal({
             onClick={enabled ? onConfirm : undefined}
             disabled={!enabled}
           >
-            {busy === true ? "Working…" : <>{confirmLabel}</>}
+            {busy === true ? "Working…" : confirmLabel}
           </button>
         </div>
       </div>

--- a/web/src/components/wiki/EditLogFooter.test.tsx
+++ b/web/src/components/wiki/EditLogFooter.test.tsx
@@ -4,6 +4,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as api from "../../api/wiki";
 import EditLogFooter from "./EditLogFooter";
 
+function hasDuplicateKeyWarning(calls: unknown[][]) {
+  return calls.some((args) =>
+    args.some((arg) =>
+      String(arg).includes("Encountered two children with the same key"),
+    ),
+  );
+}
+
 describe("<EditLogFooter>", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -33,6 +41,34 @@ describe("<EditLogFooter>", () => {
     expect(live).toHaveClass("wk-live");
     expect(screen.getByText("Customer X")).toBeInTheDocument();
     expect(screen.getByText("Churn")).toBeInTheDocument();
+  });
+
+  it("renders duplicate commit-shaped entries without duplicate React keys", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const timestamp = new Date().toISOString();
+    const initial: api.WikiEditLogEntry[] = [
+      {
+        who: "CEO",
+        action: "edited",
+        article_path: "people/customer-x",
+        article_title: "Customer X",
+        timestamp,
+        commit_sha: "same",
+      },
+      {
+        who: "PM",
+        action: "edited",
+        article_path: "people/customer-x",
+        article_title: "Customer X",
+        timestamp,
+        commit_sha: "same",
+      },
+    ];
+
+    render(<EditLogFooter initialEntries={initial} />);
+
+    expect(screen.getAllByText("Customer X")).toHaveLength(2);
+    expect(hasDuplicateKeyWarning(errorSpy.mock.calls)).toBe(false);
   });
 
   it("invokes onNavigate on entry click instead of navigating", () => {

--- a/web/src/components/wiki/EditLogFooter.tsx
+++ b/web/src/components/wiki/EditLogFooter.tsx
@@ -41,7 +41,7 @@ export default function EditLogFooter({
         const isLive = idx === 0;
         return (
           <span
-            key={`${entry.commit_sha}-${idx}`}
+            key={entry.commit_sha}
             className={isLive ? "wk-entry wk-live" : "wk-entry"}
             data-testid={isLive ? "wk-live-entry" : undefined}
           >

--- a/web/src/components/wiki/EditLogFooter.tsx
+++ b/web/src/components/wiki/EditLogFooter.tsx
@@ -7,6 +7,7 @@ import {
   type WikiEditLogEntry,
 } from "../../api/wiki";
 import { formatRelativeTime } from "../../lib/format";
+import { keyedByOccurrence } from "../../lib/reactKeys";
 import PixelAvatar from "./PixelAvatar";
 
 /** Fixed-bottom live edit-log: streams wiki:write events, newest on the left. */
@@ -37,11 +38,15 @@ export default function EditLogFooter({
   return (
     <div className="wk-edit-log" aria-label="Live wiki edit log">
       <span className="wk-label">Live</span>
-      {entries.map((entry, idx) => {
+      {keyedByOccurrence(
+        entries,
+        (entry) =>
+          `${entry.commit_sha}-${entry.article_path}-${entry.timestamp}`,
+      ).map(({ key, value: entry, index: idx }) => {
         const isLive = idx === 0;
         return (
           <span
-            key={entry.commit_sha}
+            key={key}
             className={isLive ? "wk-entry wk-live" : "wk-entry"}
             data-testid={isLive ? "wk-live-entry" : undefined}
           >

--- a/web/src/components/wiki/HatBar.test.tsx
+++ b/web/src/components/wiki/HatBar.test.tsx
@@ -63,7 +63,8 @@ describe("<HatBar>", () => {
       <HatBar active="article" rightRail={["Draft", "Draft", "Draft#1"]} />,
     );
 
-    expect(screen.getAllByText(/Draft/)).toHaveLength(3);
+    expect(screen.getAllByText("Draft")).toHaveLength(2);
+    expect(screen.getByText("Draft#1")).toBeInTheDocument();
     expect(hasDuplicateKeyWarning(errorSpy.mock.calls)).toBe(false);
   });
 });

--- a/web/src/components/wiki/HatBar.test.tsx
+++ b/web/src/components/wiki/HatBar.test.tsx
@@ -1,7 +1,19 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import HatBar from "./HatBar";
+
+function hasDuplicateKeyWarning(calls: unknown[][]) {
+  return calls.some((args) =>
+    args.some((arg) =>
+      String(arg).includes("Encountered two children with the same key"),
+    ),
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("<HatBar>", () => {
   it("marks the active tab and disables the Talk tab by default", () => {
@@ -43,5 +55,15 @@ describe("<HatBar>", () => {
     );
     expect(screen.getByText(/Cincinnati, OH/)).toBeInTheDocument();
     expect(screen.getByText(/Mid-market Logistics/)).toBeInTheDocument();
+  });
+
+  it("renders duplicate suffix-shaped right-rail items without duplicate React keys", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <HatBar active="article" rightRail={["Draft", "Draft", "Draft#1"]} />,
+    );
+
+    expect(screen.getAllByText(/Draft/)).toHaveLength(3);
+    expect(hasDuplicateKeyWarning(errorSpy.mock.calls)).toBe(false);
   });
 });

--- a/web/src/components/wiki/HatBar.tsx
+++ b/web/src/components/wiki/HatBar.tsx
@@ -45,7 +45,7 @@ export default function HatBar({
       {rightRail && rightRail.length > 0 && (
         <span className="wk-rail-right">
           {rightRail.map((item, i) => (
-            <span key={`${item}-${i}`}>
+            <span key={item}>
               {i > 0 && <span>•</span>} {item}
             </span>
           ))}

--- a/web/src/components/wiki/HatBar.tsx
+++ b/web/src/components/wiki/HatBar.tsx
@@ -1,5 +1,7 @@
 /** Wikipedia-style tabs at the top of the article (Article / Talk / Edit / History / Raw). */
 
+import { keyedByOccurrence } from "../../lib/reactKeys";
+
 export type HatBarTab = "article" | "talk" | "edit" | "history" | "raw";
 
 interface HatBarProps {
@@ -44,11 +46,13 @@ export default function HatBar({
       })}
       {rightRail && rightRail.length > 0 && (
         <span className="wk-rail-right">
-          {rightRail.map((item, i) => (
-            <span key={item}>
-              {i > 0 && <span>•</span>} {item}
-            </span>
-          ))}
+          {keyedByOccurrence(rightRail, (item) => item).map(
+            ({ key, value: item, index: i }) => (
+              <span key={key}>
+                {i > 0 && <span>•</span>} {item}
+              </span>
+            ),
+          )}
         </span>
       )}
     </nav>

--- a/web/src/components/wiki/Infobox.tsx
+++ b/web/src/components/wiki/Infobox.tsx
@@ -25,8 +25,11 @@ export default function Infobox({ title, fields, sections }: InfoboxProps) {
             <FieldRow key={f.dt} field={f} />
           ))}
         </dl>
-        {sections?.map((section, i) => (
-          <div key={`ib-section-${i}`} className="wk-ib-section">
+        {sections?.map((section) => (
+          <div
+            key={section.fields.map((field) => field.dt).join("|")}
+            className="wk-ib-section"
+          >
             <dl>
               {section.fields.map((f) => (
                 <FieldRow key={f.dt} field={f} />

--- a/web/src/components/wiki/Infobox.tsx
+++ b/web/src/components/wiki/Infobox.tsx
@@ -1,5 +1,7 @@
 /** Right-floated Wikipedia-style infobox: dark title band + structured dt/dd. */
 
+import { keyedByOccurrence } from "../../lib/reactKeys";
+
 export interface InfoboxField {
   dt: string;
   dd: string;
@@ -21,19 +23,22 @@ export default function Infobox({ title, fields, sections }: InfoboxProps) {
       <div className="wk-ib-title">{title}</div>
       <div className="wk-ib-body">
         <dl>
-          {fields.map((f) => (
-            <FieldRow key={f.dt} field={f} />
-          ))}
+          {keyedByOccurrence(fields, (field) => field.dt).map(
+            ({ key, value: field }) => (
+              <FieldRow key={key} field={field} />
+            ),
+          )}
         </dl>
-        {sections?.map((section) => (
-          <div
-            key={section.fields.map((field) => field.dt).join("|")}
-            className="wk-ib-section"
-          >
+        {keyedByOccurrence(sections ?? [], (section) =>
+          section.fields.map((field) => field.dt).join("|"),
+        ).map(({ key, value: section }) => (
+          <div key={key} className="wk-ib-section">
             <dl>
-              {section.fields.map((f) => (
-                <FieldRow key={f.dt} field={f} />
-              ))}
+              {keyedByOccurrence(section.fields, (field) => field.dt).map(
+                ({ key: fieldKey, value: field }) => (
+                  <FieldRow key={fieldKey} field={field} />
+                ),
+              )}
             </dl>
           </div>
         ))}

--- a/web/src/components/wiki/Pam.tsx
+++ b/web/src/components/wiki/Pam.tsx
@@ -116,7 +116,7 @@ export default function Pam({ articlePath, onActionDone }: PamProps) {
   // `started` event fired between POST and the next effect pass.
   useEffect(() => {
     const unsub = subscribePamEvents((evt: PamActionEvent) => {
-      const current = activeJobIdRef.current;
+      const { current } = activeJobIdRef;
       if (current === null || evt.job_id !== current) return;
       if (evt.kind === "started") {
         setStatus({
@@ -216,7 +216,7 @@ export default function Pam({ articlePath, onActionDone }: PamProps) {
       ).filter((el) => !el.disabled);
       if (items.length === 0) return;
       e.preventDefault();
-      const activeElement = document.activeElement;
+      const { activeElement } = document;
       const activeIndex =
         activeElement instanceof HTMLButtonElement
           ? items.indexOf(activeElement)

--- a/web/src/components/wiki/ResolveContradictionModal.test.tsx
+++ b/web/src/components/wiki/ResolveContradictionModal.test.tsx
@@ -60,44 +60,12 @@ describe("<ResolveContradictionModal>", () => {
     expect(pickA.querySelector(".wk-spinner")).toBeTruthy();
     expect(pickB.querySelector(".wk-spinner")).toBeNull();
     expect(pickA.textContent).toContain("Resolving");
-    // Pick buttons are disabled; cancel remains available because it aborts
-    // the in-flight request before closing the modal.
+    // All three pick buttons are disabled; cancel is also disabled while
+    // the request is in flight so the user can't drop the modal mid-write.
     expect(pickA).toBeDisabled();
     expect(pickB).toBeDisabled();
     expect(screen.getByTestId("wk-resolve-pick-both")).toBeDisabled();
-    expect(screen.getByTestId("wk-resolve-cancel")).not.toBeDisabled();
-  });
-
-  it("aborts the in-flight request when cancel closes the modal", async () => {
-    let signal: AbortSignal | undefined;
-    vi.spyOn(wikiApi, "resolveContradiction").mockImplementation(
-      (_args, options) => {
-        signal = options?.signal;
-        return new Promise(() => {
-          /* never resolves */
-        });
-      },
-    );
-    const onClose = vi.fn();
-
-    render(
-      <ResolveContradictionModal
-        finding={FINDING}
-        findingIdx={0}
-        reportDate="2026-04-22"
-        onClose={onClose}
-        onResolved={vi.fn()}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("wk-resolve-pick-a"));
-    await waitFor(() => expect(signal).toBeDefined());
-    expect(signal?.aborted).toBe(false);
-
-    fireEvent.click(screen.getByTestId("wk-resolve-cancel"));
-
-    expect(signal?.aborted).toBe(true);
-    expect(onClose).toHaveBeenCalled();
+    expect(screen.getByTestId("wk-resolve-cancel")).toBeDisabled();
   });
 
   it("surfaces errors inline (no toast) and re-enables the buttons", async () => {

--- a/web/src/components/wiki/ResolveContradictionModal.test.tsx
+++ b/web/src/components/wiki/ResolveContradictionModal.test.tsx
@@ -68,6 +68,36 @@ describe("<ResolveContradictionModal>", () => {
     expect(screen.getByTestId("wk-resolve-cancel")).toBeDisabled();
   });
 
+  it("does not close from Escape or backdrop while resolving", async () => {
+    vi.spyOn(wikiApi, "resolveContradiction").mockImplementation(
+      () =>
+        new Promise(() => {
+          /* never resolves */
+        }),
+    );
+    const onClose = vi.fn();
+
+    render(
+      <ResolveContradictionModal
+        finding={FINDING}
+        findingIdx={0}
+        reportDate="2026-04-22"
+        onClose={onClose}
+        onResolved={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("wk-resolve-pick-a"));
+    await waitFor(() => {
+      expect(screen.getByTestId("wk-resolve-pick-a")).toBeDisabled();
+    });
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    fireEvent.click(screen.getByTestId("wk-resolve-modal"));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it("surfaces errors inline (no toast) and re-enables the buttons", async () => {
     vi.spyOn(wikiApi, "resolveContradiction").mockRejectedValue(
       new Error("broker offline"),

--- a/web/src/components/wiki/ResolveContradictionModal.tsx
+++ b/web/src/components/wiki/ResolveContradictionModal.tsx
@@ -47,6 +47,15 @@ export default function ResolveContradictionModal({
   );
   const [error, setError] = useState<string | null>(null);
   const backdropRef = useRef<HTMLDivElement>(null);
+  const requestRef = useRef<AbortController | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+      requestRef.current?.abort();
+    };
+  }, []);
 
   // Escape closes only while no write is in flight.
   useEffect(() => {
@@ -66,36 +75,78 @@ export default function ResolveContradictionModal({
     }
   }
 
-  async function handlePick(winner: "A" | "B" | "Both") {
-    setError(null);
-    setSubmitting(true);
-    setPendingWinner(winner);
-    try {
-      const res = await resolveContradiction({
+  function beginRequest() {
+    const controller = new AbortController();
+    requestRef.current?.abort();
+    requestRef.current = controller;
+    return controller;
+  }
+
+  function finishRequest(controller: AbortController) {
+    if (requestRef.current === controller) {
+      requestRef.current = null;
+    }
+  }
+
+  function withCurrentRequest(
+    controller: AbortController,
+    callback: () => void,
+  ) {
+    if (!mountedRef.current || controller.signal.aborted) {
+      return;
+    }
+    callback();
+  }
+
+  function handleResolveError(err: unknown) {
+    setError(
+      err instanceof Error ? err.message : "Failed to resolve contradiction.",
+    );
+    setSubmitting(false);
+    setPendingWinner(null);
+  }
+
+  async function submitResolution(
+    winner: "A" | "B" | "Both",
+    signal: AbortSignal,
+  ) {
+    return await resolveContradiction(
+      {
         report_date: reportDate,
         finding_idx: findingIdx,
         finding,
         winner,
-      });
+      },
+      { signal },
+    );
+  }
+
+  async function handlePick(winner: "A" | "B" | "Both") {
+    setError(null);
+    setSubmitting(true);
+    setPendingWinner(winner);
+    const controller = beginRequest();
+    try {
+      const res = await submitResolution(winner, controller.signal);
       // There is no commit-viewer route today, so the sha rides inside the
       // toast copy in mono-style rather than as a link (spec §4). Short
       // sha mirrors git's default display width.
-      const shortSha = (res.commit_sha || "").slice(0, 7);
-      showNotice(
-        shortSha ? `Resolved. Commit ${shortSha}.` : "Resolved.",
-        "success",
-      );
-      onResolved();
+      withCurrentRequest(controller, () => {
+        const shortSha = (res.commit_sha || "").slice(0, 7);
+        showNotice(
+          shortSha ? `Resolved. Commit ${shortSha}.` : "Resolved.",
+          "success",
+        );
+        onResolved();
+      });
       // WikiLint refreshes on success, which unmounts this modal. Return
       // early so we don't setState on an unmounted component (React 18
       // tolerates it today, but it's a latent footgun).
       return;
     } catch (err: unknown) {
-      setError(
-        err instanceof Error ? err.message : "Failed to resolve contradiction.",
-      );
-      setSubmitting(false);
-      setPendingWinner(null);
+      withCurrentRequest(controller, () => handleResolveError(err));
+    } finally {
+      finishRequest(controller);
     }
   }
 

--- a/web/src/components/wiki/ResolveContradictionModal.tsx
+++ b/web/src/components/wiki/ResolveContradictionModal.tsx
@@ -48,20 +48,20 @@ export default function ResolveContradictionModal({
   const [error, setError] = useState<string | null>(null);
   const backdropRef = useRef<HTMLDivElement>(null);
 
-  // Escape key closes without submitting.
+  // Escape closes only while no write is in flight.
   useEffect(() => {
     function onKeyDown(ev: KeyboardEvent) {
-      if (ev.key === "Escape") {
+      if (ev.key === "Escape" && !submitting) {
         onClose();
       }
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onClose]);
+  }, [onClose, submitting]);
 
-  // Click outside (on backdrop) closes without submitting.
+  // Click outside (on backdrop) closes only while no write is in flight.
   function handleBackdropClick(ev: React.MouseEvent<HTMLDivElement>) {
-    if (ev.target === backdropRef.current) {
+    if (ev.target === backdropRef.current && !submitting) {
       onClose();
     }
   }

--- a/web/src/components/wiki/ResolveContradictionModal.tsx
+++ b/web/src/components/wiki/ResolveContradictionModal.tsx
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/a11y/useAriaPropsSupportedByRole: Passive metadata uses accessible labels queried by screen-reader tests; visual text remains unchanged.
 // biome-ignore-all lint/a11y/useKeyWithClickEvents: Pointer handler is paired with an existing modal, image, or routed-control keyboard path; preserving current interaction model.
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { type LintFinding, resolveContradiction } from "../../api/wiki";
 import { showNotice } from "../ui/Toast";
@@ -28,17 +28,6 @@ interface ResolveContradictionModalProps {
   onResolved: () => void;
 }
 
-function resolveErrorMessage(err: unknown) {
-  return err instanceof Error
-    ? err.message
-    : "Failed to resolve contradiction.";
-}
-
-function resolvedNotice(commitSha: string) {
-  const shortSha = commitSha.slice(0, 7);
-  return shortSha ? `Resolved. Commit ${shortSha}.` : "Resolved.";
-}
-
 export default function ResolveContradictionModal({
   finding,
   findingIdx,
@@ -58,72 +47,55 @@ export default function ResolveContradictionModal({
   );
   const [error, setError] = useState<string | null>(null);
   const backdropRef = useRef<HTMLDivElement>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
 
-  const closeAfterAbort = useCallback(() => {
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = null;
-    onClose();
-  }, [onClose]);
-
-  // Escape key aborts any in-flight resolution and closes.
+  // Escape key closes without submitting.
   useEffect(() => {
     function onKeyDown(ev: KeyboardEvent) {
       if (ev.key === "Escape") {
-        closeAfterAbort();
+        onClose();
       }
     }
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [closeAfterAbort]);
+  }, [onClose]);
 
-  // Click outside (on backdrop) aborts any in-flight resolution and closes.
+  // Click outside (on backdrop) closes without submitting.
   function handleBackdropClick(ev: React.MouseEvent<HTMLDivElement>) {
     if (ev.target === backdropRef.current) {
-      closeAfterAbort();
+      onClose();
     }
   }
 
   async function handlePick(winner: "A" | "B" | "Both") {
-    abortControllerRef.current?.abort();
-    const controller = new AbortController();
-    abortControllerRef.current = controller;
     setError(null);
     setSubmitting(true);
     setPendingWinner(winner);
     try {
-      const res = await resolveContradiction(
-        {
-          report_date: reportDate,
-          finding_idx: findingIdx,
-          finding,
-          winner,
-        },
-        { signal: controller.signal },
-      );
+      const res = await resolveContradiction({
+        report_date: reportDate,
+        finding_idx: findingIdx,
+        finding,
+        winner,
+      });
       // There is no commit-viewer route today, so the sha rides inside the
       // toast copy in mono-style rather than as a link (spec §4). Short
       // sha mirrors git's default display width.
-      showNotice(resolvedNotice(res.commit_sha || ""), "success");
-      if (abortControllerRef.current === controller) {
-        abortControllerRef.current = null;
-      }
+      const shortSha = (res.commit_sha || "").slice(0, 7);
+      showNotice(
+        shortSha ? `Resolved. Commit ${shortSha}.` : "Resolved.",
+        "success",
+      );
       onResolved();
       // WikiLint refreshes on success, which unmounts this modal. Return
       // early so we don't setState on an unmounted component (React 18
       // tolerates it today, but it's a latent footgun).
       return;
     } catch (err: unknown) {
-      if (controller.signal.aborted) {
-        return;
-      }
-      setError(resolveErrorMessage(err));
+      setError(
+        err instanceof Error ? err.message : "Failed to resolve contradiction.",
+      );
       setSubmitting(false);
       setPendingWinner(null);
-    } finally {
-      if (abortControllerRef.current === controller) {
-        abortControllerRef.current = null;
-      }
     }
   }
 
@@ -232,7 +204,8 @@ export default function ResolveContradictionModal({
             type="button"
             className="wk-editor-cancel"
             data-testid="wk-resolve-cancel"
-            onClick={closeAfterAbort}
+            onClick={onClose}
+            disabled={submitting}
           >
             Cancel
           </button>

--- a/web/src/components/wiki/WikiArticle.test.tsx
+++ b/web/src/components/wiki/WikiArticle.test.tsx
@@ -27,13 +27,13 @@ const STUB_ARTICLE: api.WikiArticle = {
   categories: [],
 };
 
-describe("<WikiArticle>", () => {
-  beforeEach(() => {
-    vi.restoreAllMocks();
-    // Default history stub — individual tests override as needed.
-    vi.spyOn(api, "fetchHistory").mockResolvedValue({ commits: [] });
-  });
+beforeEach(() => {
+  vi.restoreAllMocks();
+  // Default history stub — individual tests override as needed.
+  vi.spyOn(api, "fetchHistory").mockResolvedValue({ commits: [] });
+});
 
+describe("<WikiArticle content>", () => {
   it("fetches an article, renders its markdown, and distinguishes broken wikilinks", async () => {
     // Arrange
     vi.spyOn(api, "fetchArticle").mockResolvedValue({
@@ -139,7 +139,9 @@ describe("<WikiArticle>", () => {
       expect(screen.queryByText(/Loading article/i)).not.toBeInTheDocument(),
     );
   });
+});
 
+describe("<WikiArticle history and refresh>", () => {
   it("renders Sources populated from fetchHistory with author slugs visible", async () => {
     // Arrange
     vi.spyOn(api, "fetchArticle").mockResolvedValue(STUB_ARTICLE);
@@ -192,6 +194,40 @@ describe("<WikiArticle>", () => {
     expect(sourcesSection.textContent).toContain("aaaaaaa");
   });
 
+  it("refetches article and history when externalRefreshNonce changes", async () => {
+    const fetchArticle = vi.spyOn(api, "fetchArticle").mockResolvedValue({
+      ...STUB_ARTICLE,
+      title: "Customer X",
+    });
+    const fetchHistory = vi
+      .spyOn(api, "fetchHistory")
+      .mockResolvedValue({ commits: [] });
+
+    const { rerender } = render(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={CATALOG}
+        onNavigate={() => {}}
+        externalRefreshNonce={0}
+      />,
+    );
+
+    await waitFor(() => expect(fetchArticle).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(fetchHistory).toHaveBeenCalledTimes(1));
+
+    rerender(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={CATALOG}
+        onNavigate={() => {}}
+        externalRefreshNonce={1}
+      />,
+    );
+
+    await waitFor(() => expect(fetchArticle).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(fetchHistory).toHaveBeenCalledTimes(2));
+  });
+
   it("renders a loading placeholder in Sources while history is fetching", async () => {
     // Arrange
     vi.spyOn(api, "fetchArticle").mockResolvedValue(STUB_ARTICLE);
@@ -225,7 +261,9 @@ describe("<WikiArticle>", () => {
     const finish = resolveHistory as Resolve | null;
     finish?.({ commits: [] });
   });
+});
 
+describe("<WikiArticle staleness badges>", () => {
   it("shows 'agents only' badge when agent_read_count > 0 and human_read_count = 0", async () => {
     vi.spyOn(api, "fetchArticle").mockResolvedValue({
       ...STUB_ARTICLE,
@@ -233,9 +271,17 @@ describe("<WikiArticle>", () => {
       human_read_count: 0,
       days_unread: 0,
     });
-    render(<WikiArticle path="people/customer-x" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.getByText("agents only")).toBeInTheDocument();
   });
@@ -247,9 +293,17 @@ describe("<WikiArticle>", () => {
       human_read_count: 2,
       days_unread: 45,
     });
-    render(<WikiArticle path="people/customer-x" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.getByText("unread 30d+")).toBeInTheDocument();
   });
@@ -261,9 +315,17 @@ describe("<WikiArticle>", () => {
       human_read_count: 1,
       days_unread: 14,
     });
-    render(<WikiArticle path="people/customer-x" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.getByText("unread 7d+")).toBeInTheDocument();
   });
@@ -275,9 +337,17 @@ describe("<WikiArticle>", () => {
       human_read_count: 1,
       days_unread: 30,
     });
-    render(<WikiArticle path="people/customer-x" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.getByText("unread 30d+")).toBeInTheDocument();
     expect(screen.queryByText("unread 7d+")).not.toBeInTheDocument();
@@ -290,9 +360,17 @@ describe("<WikiArticle>", () => {
       human_read_count: 1,
       days_unread: 30,
     });
-    render(<WikiArticle path="people/customer-x" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.getByText("unread 30d+")).toBeInTheDocument();
     expect(screen.queryByText("unread 7d+")).not.toBeInTheDocument();
@@ -305,9 +383,17 @@ describe("<WikiArticle>", () => {
       human_read_count: 1,
       days_unread: 31,
     });
-    render(<WikiArticle path="people/customer-x" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.getByText("unread 30d+")).toBeInTheDocument();
     expect(screen.queryByText("unread 7d+")).not.toBeInTheDocument();
@@ -320,9 +406,17 @@ describe("<WikiArticle>", () => {
       human_read_count: 1,
       days_unread: 7,
     });
-    render(<WikiArticle path="people/customer-x" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.getByText("unread 7d+")).toBeInTheDocument();
     expect(screen.queryByText("unread 30d+")).not.toBeInTheDocument();
@@ -335,15 +429,25 @@ describe("<WikiArticle>", () => {
       human_read_count: 2,
       days_unread: 3,
     });
-    render(<WikiArticle path="people/customer-x" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.queryByText("agents only")).not.toBeInTheDocument();
     expect(screen.queryByText("unread 30d+")).not.toBeInTheDocument();
     expect(screen.queryByText("unread 7d+")).not.toBeInTheDocument();
   });
+});
 
+describe("<WikiArticle history fallback>", () => {
   it("renders nothing for Sources when fetchHistory rejects", async () => {
     // Arrange
     vi.spyOn(api, "fetchArticle").mockResolvedValue(STUB_ARTICLE);
@@ -371,16 +475,26 @@ describe("<WikiArticle>", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/loading sources/i)).not.toBeInTheDocument();
   });
+});
 
+describe("<WikiArticle synthesis status>", () => {
   it("shows 'generating brief…' badge when synthesis_queued is true (ICP Example 1 & 2)", async () => {
     vi.spyOn(api, "fetchArticle").mockResolvedValue({
       ...STUB_ARTICLE,
       ghost: true,
       synthesis_queued: true,
     });
-    render(<WikiArticle path="company/acme-corp" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="company/acme-corp"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.getByText("generating brief…")).toBeInTheDocument();
     expect(screen.getByRole("status")).toBeInTheDocument();
@@ -392,9 +506,17 @@ describe("<WikiArticle>", () => {
       ghost: true,
       synthesis_queued: false,
     });
-    render(<WikiArticle path="company/cloudvault-inc" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="company/cloudvault-inc"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.queryByText("generating brief…")).not.toBeInTheDocument();
   });
@@ -405,9 +527,17 @@ describe("<WikiArticle>", () => {
       ghost: false,
       synthesis_queued: false,
     });
-    render(<WikiArticle path="company/acme-corp" catalog={[]} onNavigate={() => {}} />);
+    render(
+      <WikiArticle
+        path="company/acme-corp"
+        catalog={[]}
+        onNavigate={() => {}}
+      />,
+    );
     await waitFor(() =>
-      expect(screen.getByRole("heading", { name: "Customer X" })).toBeInTheDocument(),
+      expect(
+        screen.getByRole("heading", { name: "Customer X" }),
+      ).toBeInTheDocument(),
     );
     expect(screen.queryByText("generating brief…")).not.toBeInTheDocument();
   });

--- a/web/src/components/wiki/WikiArticle.test.tsx
+++ b/web/src/components/wiki/WikiArticle.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as api from "../../api/wiki";
@@ -260,6 +260,51 @@ describe("<WikiArticle history and refresh>", () => {
     // Finalize so cleanup is clean
     const finish = resolveHistory as Resolve | null;
     finish?.({ commits: [] });
+  });
+
+  it("refetches article and history after an inline editor save", async () => {
+    const fetchArticleSpy = vi
+      .spyOn(api, "fetchArticle")
+      .mockResolvedValueOnce({
+        ...STUB_ARTICLE,
+        content: "Original body",
+        commit_sha: "oldsha1",
+      })
+      .mockResolvedValueOnce({
+        ...STUB_ARTICLE,
+        content: "Updated body",
+        commit_sha: "newsha1",
+      });
+    const fetchHistorySpy = vi
+      .spyOn(api, "fetchHistory")
+      .mockResolvedValue({ commits: [] });
+    vi.spyOn(api, "writeHumanArticle").mockResolvedValue({
+      path: STUB_ARTICLE.path,
+      commit_sha: "newsha1",
+      bytes_written: 12,
+    });
+
+    render(
+      <WikiArticle
+        path="people/customer-x"
+        catalog={CATALOG}
+        onNavigate={() => {}}
+      />,
+    );
+
+    await screen.findByText("Original body");
+    fireEvent.click(screen.getByRole("button", { name: "Edit source" }));
+    fireEvent.change(screen.getByTestId("wk-editor-textarea"), {
+      target: { value: "Updated body" },
+    });
+    fireEvent.change(screen.getByTestId("wk-editor-commit"), {
+      target: { value: "refresh article" },
+    });
+    fireEvent.click(screen.getByTestId("wk-editor-save"));
+
+    await waitFor(() => expect(fetchArticleSpy).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(fetchHistorySpy).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText("Updated body")).toBeInTheDocument();
   });
 });
 

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -152,6 +152,7 @@ export default function WikiArticle({
 
   useEffect(() => {
     let cancelled = false;
+    void externalRefreshNonce;
     setLoading(true);
     setError(null);
     fetchArticle(path)
@@ -169,10 +170,11 @@ export default function WikiArticle({
     return () => {
       cancelled = true;
     };
-  }, [path]);
+  }, [path, externalRefreshNonce]);
 
   useEffect(() => {
     let cancelled = false;
+    void externalRefreshNonce;
     setHistoryCommits(null);
     setHistoryLoading(true);
     setHistoryError(false);
@@ -193,7 +195,7 @@ export default function WikiArticle({
     return () => {
       cancelled = true;
     };
-  }, [path]);
+  }, [path, externalRefreshNonce]);
 
   useEffect(() => {
     setLiveAgent(null);
@@ -295,7 +297,7 @@ export default function WikiArticle({
             Team Wiki
           </a>
           {breadcrumbSegments.map((seg, i) => (
-            <span key={`${seg}-${i}`} style={{ display: "contents" }}>
+            <span key={seg} style={{ display: "contents" }}>
               <span className="sep">›</span>
               {i < breadcrumbSegments.length - 1 ? (
                 <a href="#">{seg}</a>

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -16,6 +16,7 @@ import {
   type WikiHistoryCommit,
 } from "../../api/wiki";
 import { formatAgentName } from "../../lib/agentName";
+import { keyedByOccurrence } from "../../lib/reactKeys";
 import {
   buildMarkdownComponents,
   buildRehypePlugins,
@@ -156,8 +157,10 @@ export default function WikiArticle({
 
   useEffect(() => {
     let cancelled = false;
-    void refreshNonce;
+    // These nonce values are explicit refetch triggers. The effect body only
+    // needs their change notification, not their numeric value.
     void externalRefreshNonce;
+    void refreshNonce;
     setLoading(true);
     setError(null);
     fetchArticle(path)
@@ -175,12 +178,14 @@ export default function WikiArticle({
     return () => {
       cancelled = true;
     };
-  }, [path, refreshNonce, externalRefreshNonce]);
+  }, [path, externalRefreshNonce, refreshNonce]);
 
   useEffect(() => {
     let cancelled = false;
-    void refreshNonce;
+    // These nonce values are explicit refetch triggers. The effect body only
+    // needs their change notification, not their numeric value.
     void externalRefreshNonce;
+    void refreshNonce;
     setHistoryCommits(null);
     setHistoryLoading(true);
     setHistoryError(false);
@@ -201,7 +206,7 @@ export default function WikiArticle({
     return () => {
       cancelled = true;
     };
-  }, [path, refreshNonce, externalRefreshNonce]);
+  }, [path, externalRefreshNonce, refreshNonce]);
 
   useEffect(() => {
     setLiveAgent(null);
@@ -407,16 +412,18 @@ function ArticleBreadcrumb({
       >
         Team Wiki
       </a>
-      {segments.map((seg, i) => (
-        <span key={seg} style={{ display: "contents" }}>
-          <span className="sep">›</span>
-          {i < segments.length - 1 ? (
-            <a href="#">{seg}</a>
-          ) : (
-            <span>{article.title}</span>
-          )}
-        </span>
-      ))}
+      {keyedByOccurrence(segments, (seg) => seg).map(
+        ({ key, value: seg, index: i }) => (
+          <span key={key} style={{ display: "contents" }}>
+            <span className="sep">›</span>
+            {i < segments.length - 1 ? (
+              <a href="#">{seg}</a>
+            ) : (
+              <span>{article.title}</span>
+            )}
+          </span>
+        ),
+      )}
     </div>
   );
 }

--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -113,6 +113,10 @@ interface WikiArticleProps {
   externalRefreshNonce?: number;
 }
 
+type MarkdownComponents = ReturnType<typeof buildMarkdownComponents>;
+type DetectedEntity = { kind: EntityKind; slug: string };
+type DetectedPlaybook = NonNullable<ReturnType<typeof detectPlaybook>>;
+
 export default function WikiArticle({
   path,
   catalog,
@@ -129,7 +133,7 @@ export default function WikiArticle({
   const [historyLoading, setHistoryLoading] = useState(true);
   const [historyError, setHistoryError] = useState(false);
   const [liveAgent, setLiveAgent] = useState<string | null>(null);
-  const [_refreshNonce, setRefreshNonce] = useState(0);
+  const [refreshNonce, setRefreshNonce] = useState(0);
   const [humans, setHumans] = useState<HumanIdentity[]>([]);
 
   // Fetch the human registry once per mount. The list is small (a handful
@@ -152,6 +156,7 @@ export default function WikiArticle({
 
   useEffect(() => {
     let cancelled = false;
+    void refreshNonce;
     void externalRefreshNonce;
     setLoading(true);
     setError(null);
@@ -170,10 +175,11 @@ export default function WikiArticle({
     return () => {
       cancelled = true;
     };
-  }, [path, externalRefreshNonce]);
+  }, [path, refreshNonce, externalRefreshNonce]);
 
   useEffect(() => {
     let cancelled = false;
+    void refreshNonce;
     void externalRefreshNonce;
     setHistoryCommits(null);
     setHistoryLoading(true);
@@ -195,7 +201,7 @@ export default function WikiArticle({
     return () => {
       cancelled = true;
     };
-  }, [path, externalRefreshNonce]);
+  }, [path, refreshNonce, externalRefreshNonce]);
 
   useEffect(() => {
     setLiveAgent(null);
@@ -260,132 +266,56 @@ export default function WikiArticle({
       humans={humans}
     />
   );
+  const handleEditorSaved = (newSha: string) => {
+    // Refetch after every save — covers both happy path and the
+    // conflict-then-reload path, which passes the server current_sha back.
+    void newSha;
+    setRefreshNonce((n) => n + 1);
+    setTab("article");
+  };
+  const handleEditorCancel = () => setTab("article");
 
   return (
     <>
       <main className="wk-article-col">
-        {liveAgent ? (
-          <ArticleStatusBanner
-            message={`${formatAgentName(liveAgent)} is editing this article right now.`}
-            liveAgent={liveAgent}
-            revisions={article.revisions}
-            contributors={article.contributors.length}
-            wordCount={article.word_count}
-          />
-        ) : null}
-        {entity && (
-          <EntityBriefBar
-            kind={entity.kind}
-            slug={entity.slug}
-            onSynthesized={() => setRefreshNonce((n) => n + 1)}
-          />
-        )}
-        {playbook && <PlaybookSkillBadge slug={playbook.slug} />}
+        <LiveEditingBanner liveAgent={liveAgent} article={article} />
+        <ArticleSetupPanels
+          entity={entity}
+          playbook={playbook}
+          onEntitySynthesized={() => setRefreshNonce((n) => n + 1)}
+        />
         <HatBar
           active={tab}
           onChange={setTab}
           rightRail={context ? [context] : undefined}
         />
-        <div className="wk-breadcrumb">
-          <a
-            href="#/wiki"
-            onClick={(e) => {
-              e.preventDefault();
-              onNavigate("");
-            }}
-          >
-            Team Wiki
-          </a>
-          {breadcrumbSegments.map((seg, i) => (
-            <span key={seg} style={{ display: "contents" }}>
-              <span className="sep">›</span>
-              {i < breadcrumbSegments.length - 1 ? (
-                <a href="#">{seg}</a>
-              ) : (
-                <span>{article.title}</span>
-              )}
-            </span>
-          ))}
-        </div>
+        <ArticleBreadcrumb
+          article={article}
+          segments={breadcrumbSegments}
+          onNavigate={onNavigate}
+        />
         <ArticleTitle title={article.title} />
         {byline}
-        <StalenessIndicator article={article} />
-        {article.synthesis_queued && (
-          <span
-            className="wk-staleness-badge wk-synthesis-queued"
-            role="status"
-            aria-label="Brief is being generated from recent activity"
-          >
-            generating brief…
-          </span>
-        )}
+        <ArticleBadges article={article} />
         <Hatnote>
           This article is auto-generated from team activity. See the commit
           history for the full trail.
         </Hatnote>
-        {tab === "article" && (
-          <div className="wk-article-body" data-testid="wk-article-body">
-            <ReactMarkdown
-              remarkPlugins={remarkPlugins}
-              rehypePlugins={rehypePlugins}
-              components={markdownComponents}
-            >
-              {article.content}
-            </ReactMarkdown>
-          </div>
-        )}
-        {tab === "edit" && (
-          <WikiEditor
-            path={article.path}
-            initialContent={article.content}
-            expectedSha={article.commit_sha ?? ""}
-            serverLastEditedTs={article.last_edited_ts}
-            catalog={catalog}
-            onSaved={(newSha) => {
-              // Refetch after every save — covers both happy path and
-              // the conflict-then-reload path (which passes the server's
-              // current_sha back as newSha).
-              void newSha;
-              setRefreshNonce((n) => n + 1);
-              setTab("article");
-            }}
-            onCancel={() => setTab("article")}
-          />
-        )}
-        {tab === "raw" && (
-          <pre
-            style={{
-              fontFamily: "var(--wk-mono)",
-              background: "var(--wk-code-bg)",
-              padding: 16,
-              border: "1px solid var(--wk-border)",
-              overflowX: "auto",
-              fontSize: 13,
-              lineHeight: 1.5,
-              whiteSpace: "pre-wrap",
-            }}
-          >
-            {article.content}
-          </pre>
-        )}
-        {tab === "history" && (
-          <div className="wk-loading">
-            History view streams from <code>git log</code>. Wiring pending Lane
-            A.
-          </div>
-        )}
-        {entity && tab === "article" && (
-          <FactsOnFile kind={entity.kind} slug={entity.slug} />
-        )}
-        {entity && tab === "article" && (
-          <EntityRelatedPanel kind={entity.kind} slug={entity.slug} />
-        )}
-        {playbook && tab === "article" && (
-          <PlaybookExecutionLog slug={playbook.slug} />
-        )}
-        {playbook && tab === "article" && (
-          <TeamLearningPanel playbookSlug={playbook.slug} />
-        )}
+        <ArticleTabPanels
+          tab={tab}
+          article={article}
+          catalog={catalog}
+          remarkPlugins={remarkPlugins}
+          rehypePlugins={rehypePlugins}
+          markdownComponents={markdownComponents}
+          onEditorSaved={handleEditorSaved}
+          onEditorCancel={handleEditorCancel}
+        />
+        <ArticleRelatedPanels
+          visible={tab === "article"}
+          entity={entity}
+          playbook={playbook}
+        />
         <SeeAlso
           items={article.backlinks.map((b) => ({
             slug: b.path,
@@ -393,9 +323,11 @@ export default function WikiArticle({
           }))}
           onNavigate={onNavigate}
         />
-        {historyError ? null : (
-          <Sources items={sourceItems} loading={historyLoading} />
-        )}
+        <SourcesPanel
+          historyError={historyError}
+          sourceItems={sourceItems}
+          historyLoading={historyLoading}
+        />
         <CategoriesFooter tags={article.categories} />
         <PageFooter
           lastEditedBy={formatAgentName(article.last_edited_by)}
@@ -403,19 +335,242 @@ export default function WikiArticle({
           articlePath={article.path}
         />
       </main>
-      <aside className="wk-right-sidebar">
-        <TocBox entries={toc} />
-        <PageStatsPanel
-          revisions={article.revisions}
-          contributors={article.contributors.length}
-          wordCount={article.word_count}
-          created={article.last_edited_ts}
-          lastEdit={article.last_edited_ts}
-        />
-        <CiteThisPagePanel slug={article.path} />
-        <ReferencedBy backlinks={article.backlinks} onNavigate={onNavigate} />
-      </aside>
+      <ArticleRightSidebar
+        article={article}
+        toc={toc}
+        onNavigate={onNavigate}
+      />
     </>
+  );
+}
+
+function LiveEditingBanner({
+  liveAgent,
+  article,
+}: {
+  liveAgent: string | null;
+  article: WikiArticleT;
+}) {
+  if (!liveAgent) return null;
+  return (
+    <ArticleStatusBanner
+      message={`${formatAgentName(liveAgent)} is editing this article right now.`}
+      liveAgent={liveAgent}
+      revisions={article.revisions}
+      contributors={article.contributors.length}
+      wordCount={article.word_count}
+    />
+  );
+}
+
+function ArticleSetupPanels({
+  entity,
+  playbook,
+  onEntitySynthesized,
+}: {
+  entity: DetectedEntity | null;
+  playbook: DetectedPlaybook | null;
+  onEntitySynthesized: () => void;
+}) {
+  if (!(entity || playbook)) return null;
+  return (
+    <>
+      {entity ? (
+        <EntityBriefBar
+          kind={entity.kind}
+          slug={entity.slug}
+          onSynthesized={onEntitySynthesized}
+        />
+      ) : null}
+      {playbook ? <PlaybookSkillBadge slug={playbook.slug} /> : null}
+    </>
+  );
+}
+
+function ArticleBreadcrumb({
+  article,
+  segments,
+  onNavigate,
+}: {
+  article: WikiArticleT;
+  segments: string[];
+  onNavigate: (path: string) => void;
+}) {
+  return (
+    <div className="wk-breadcrumb">
+      <a
+        href="#/wiki"
+        onClick={(e) => {
+          e.preventDefault();
+          onNavigate("");
+        }}
+      >
+        Team Wiki
+      </a>
+      {segments.map((seg, i) => (
+        <span key={seg} style={{ display: "contents" }}>
+          <span className="sep">›</span>
+          {i < segments.length - 1 ? (
+            <a href="#">{seg}</a>
+          ) : (
+            <span>{article.title}</span>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function ArticleBadges({ article }: { article: WikiArticleT }) {
+  return (
+    <>
+      <StalenessIndicator article={article} />
+      <SynthesisQueuedBadge queued={article.synthesis_queued} />
+    </>
+  );
+}
+
+function SynthesisQueuedBadge({ queued }: { queued?: boolean }) {
+  if (queued !== true) return null;
+  return (
+    <span
+      className="wk-staleness-badge wk-synthesis-queued"
+      role="status"
+      aria-label="Brief is being generated from recent activity"
+    >
+      generating brief…
+    </span>
+  );
+}
+
+function ArticleTabPanels({
+  tab,
+  article,
+  catalog,
+  remarkPlugins,
+  rehypePlugins,
+  markdownComponents,
+  onEditorSaved,
+  onEditorCancel,
+}: {
+  tab: HatBarTab;
+  article: WikiArticleT;
+  catalog: WikiCatalogEntry[];
+  remarkPlugins: PluggableList;
+  rehypePlugins: PluggableList;
+  markdownComponents: MarkdownComponents;
+  onEditorSaved: (newSha: string) => void;
+  onEditorCancel: () => void;
+}) {
+  switch (tab) {
+    case "article":
+      return (
+        <div className="wk-article-body" data-testid="wk-article-body">
+          <ReactMarkdown
+            remarkPlugins={remarkPlugins}
+            rehypePlugins={rehypePlugins}
+            components={markdownComponents}
+          >
+            {article.content}
+          </ReactMarkdown>
+        </div>
+      );
+    case "edit":
+      return (
+        <WikiEditor
+          path={article.path}
+          initialContent={article.content}
+          expectedSha={article.commit_sha ?? ""}
+          serverLastEditedTs={article.last_edited_ts}
+          catalog={catalog}
+          onSaved={onEditorSaved}
+          onCancel={onEditorCancel}
+        />
+      );
+    case "raw":
+      return (
+        <pre
+          style={{
+            fontFamily: "var(--wk-mono)",
+            background: "var(--wk-code-bg)",
+            padding: 16,
+            border: "1px solid var(--wk-border)",
+            overflowX: "auto",
+            fontSize: 13,
+            lineHeight: 1.5,
+            whiteSpace: "pre-wrap",
+          }}
+        >
+          {article.content}
+        </pre>
+      );
+    case "history":
+      return (
+        <div className="wk-loading">
+          History view streams from <code>git log</code>. Wiring pending Lane A.
+        </div>
+      );
+  }
+  return null;
+}
+
+function ArticleRelatedPanels({
+  visible,
+  entity,
+  playbook,
+}: {
+  visible: boolean;
+  entity: DetectedEntity | null;
+  playbook: DetectedPlaybook | null;
+}) {
+  if (!visible) return null;
+  return (
+    <>
+      {entity ? <FactsOnFile kind={entity.kind} slug={entity.slug} /> : null}
+      {entity ? (
+        <EntityRelatedPanel kind={entity.kind} slug={entity.slug} />
+      ) : null}
+      {playbook ? <PlaybookExecutionLog slug={playbook.slug} /> : null}
+      {playbook ? <TeamLearningPanel playbookSlug={playbook.slug} /> : null}
+    </>
+  );
+}
+
+function SourcesPanel({
+  historyError,
+  sourceItems,
+  historyLoading,
+}: {
+  historyError: boolean;
+  sourceItems: SourceItem[];
+  historyLoading: boolean;
+}) {
+  if (historyError) return null;
+  return <Sources items={sourceItems} loading={historyLoading} />;
+}
+
+function ArticleRightSidebar({
+  article,
+  toc,
+  onNavigate,
+}: {
+  article: WikiArticleT;
+  toc: TocEntry[];
+  onNavigate: (path: string) => void;
+}) {
+  return (
+    <aside className="wk-right-sidebar">
+      <TocBox entries={toc} />
+      <PageStatsPanel
+        revisions={article.revisions}
+        contributors={article.contributors.length}
+        wordCount={article.word_count}
+        created={article.last_edited_ts}
+        lastEdit={article.last_edited_ts}
+      />
+      <CiteThisPagePanel slug={article.path} />
+      <ReferencedBy backlinks={article.backlinks} onNavigate={onNavigate} />
+    </aside>
   );
 }
 

--- a/web/src/components/wiki/WikiLint.test.tsx
+++ b/web/src/components/wiki/WikiLint.test.tsx
@@ -24,6 +24,14 @@ const REPORT_WITH_CRITICAL: wikiApi.LintReport = {
   findings: [CRITICAL_FINDING],
 };
 
+function hasDuplicateKeyWarning(calls: unknown[][]) {
+  return calls.some((args) =>
+    args.some((arg) =>
+      String(arg).includes("Encountered two children with the same key"),
+    ),
+  );
+}
+
 describe("<WikiLint>", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -47,6 +55,21 @@ describe("<WikiLint>", () => {
     );
     expect(severityBadge).toBeInTheDocument();
     expect(severityBadge.textContent).toBe("Needs attention");
+  });
+
+  it("renders duplicate finding-shaped rows without duplicate React keys", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(wikiApi, "runLint").mockResolvedValue({
+      date: "2026-04-22",
+      findings: [CRITICAL_FINDING, CRITICAL_FINDING],
+    });
+
+    render(<WikiLint onNavigate={vi.fn()} />);
+
+    expect(await screen.findAllByText(CRITICAL_FINDING.summary)).toHaveLength(
+      2,
+    );
+    expect(hasDuplicateKeyWarning(errorSpy.mock.calls)).toBe(false);
   });
 
   it("clicking Resolve opens modal, picking A calls resolveContradiction with winner=A", async () => {

--- a/web/src/components/wiki/WikiLint.tsx
+++ b/web/src/components/wiki/WikiLint.tsx
@@ -2,6 +2,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { type LintFinding, type LintReport, runLint } from "../../api/wiki";
+import { keyedByOccurrence } from "../../lib/reactKeys";
 import ResolveContradictionModal from "./ResolveContradictionModal";
 
 /**
@@ -123,9 +124,12 @@ export default function WikiLint({ onNavigate }: WikiLintProps) {
             </tr>
           </thead>
           <tbody>
-            {report.findings.map((f, idx) => (
+            {keyedByOccurrence(
+              report.findings,
+              (f) => `${f.type}-${f.entity_slug ?? ""}-${f.summary}`,
+            ).map(({ key, value: f, index: idx }) => (
               <tr
-                key={`${f.type}-${f.entity_slug ?? ""}-${f.summary}`}
+                key={key}
                 className={`wk-audit-row ${findingRowClass(f.severity)}`}
               >
                 <td className="wk-audit-when">

--- a/web/src/components/wiki/WikiLint.tsx
+++ b/web/src/components/wiki/WikiLint.tsx
@@ -125,7 +125,7 @@ export default function WikiLint({ onNavigate }: WikiLintProps) {
           <tbody>
             {report.findings.map((f, idx) => (
               <tr
-                key={`${f.type}-${f.entity_slug ?? ""}-${idx}`}
+                key={`${f.type}-${f.entity_slug ?? ""}-${f.summary}`}
                 className={`wk-audit-row ${findingRowClass(f.severity)}`}
               >
                 <td className="wk-audit-when">

--- a/web/src/components/wiki/WikiSidebar.test.tsx
+++ b/web/src/components/wiki/WikiSidebar.test.tsx
@@ -168,7 +168,8 @@ describe("<WikiSidebar> — dynamic sections", () => {
       />,
     );
     expect(screen.queryByTestId("section-banner")).toBeNull();
-    const retroHeader = screen.getByText(/retrospectives/i).closest("h3")!;
+    const retroHeader = screen.getByText(/retrospectives/i).closest("h3");
+    if (!retroHeader) throw new Error("Expected retrospectives header");
     fireEvent.click(retroHeader);
     expect(screen.getByTestId("section-banner")).toBeInTheDocument();
     expect(screen.getByTestId("section-banner")).toHaveTextContent(
@@ -184,7 +185,8 @@ describe("<WikiSidebar> — dynamic sections", () => {
         onNavigate={() => {}}
       />,
     );
-    const peopleHeader = screen.getByText(/people/i).closest("h3")!;
+    const peopleHeader = screen.getByText(/people/i).closest("h3");
+    if (!peopleHeader) throw new Error("Expected people header");
     fireEvent.click(peopleHeader);
     expect(screen.queryByTestId("section-banner")).toBeNull();
   });

--- a/web/src/components/workspaces/StatusPill.tsx
+++ b/web/src/components/workspaces/StatusPill.tsx
@@ -95,7 +95,9 @@ export function StatusPill({
       <span className="workspace-pill-name">{name}</span>
       <span className="status-bar-sep"> · </span>
       <span className="workspace-pill-cost">
-        {usagePending ? "— tokens today" : `${formatTokens(totalTokens)} tokens today`}
+        {usagePending
+          ? "— tokens today"
+          : `${formatTokens(totalTokens)} tokens today`}
       </span>
     </span>
   );

--- a/web/src/components/workspaces/StatusPill.tsx
+++ b/web/src/components/workspaces/StatusPill.tsx
@@ -83,7 +83,7 @@ export function StatusPill({
   // misleading because the broker has not yet replied. Once usage data is
   // available the counter switches to the real number. The override path
   // (tests/storybook) skips this entirely so existing assertions stay stable.
-  const usagePending = !usageOverride && usageQuery.data === undefined;
+  const usagePending = !usageOverride && usageQuery.isLoading;
 
   return (
     <span

--- a/web/src/components/workspaces/WorkspaceRail.tsx
+++ b/web/src/components/workspaces/WorkspaceRail.tsx
@@ -397,7 +397,7 @@ export function WorkspaceRail({
 
   const shredMutation = useShredWorkspace({
     onSuccess: (resp, vars) => {
-      const name = vars.name;
+      const { name } = vars;
       setShredTarget(null);
       if (vars.permanent) {
         showNotice(`Workspace '${name}' shredded permanently.`, "info");

--- a/web/src/components/workspaces/__tests__/CreateWorkspaceModal.test.tsx
+++ b/web/src/components/workspaces/__tests__/CreateWorkspaceModal.test.tsx
@@ -126,46 +126,47 @@ describe("<CreateWorkspaceModal>", () => {
       value: { assign },
       writable: true,
     });
-    afterEach(() => {
+
+    try {
+      useCreateWorkspaceMock.mockImplementation(((
+        opts?: Parameters<typeof useCreateWorkspace>[0],
+      ) => ({
+        mutate: (workspaceInput: CreateWorkspaceInput) => {
+          opts?.onSuccess?.(
+            {
+              name: "side-project",
+              broker_port: 7910,
+              web_port: 7911,
+              runtime_home: "/tmp/x",
+              state: "running",
+            },
+            workspaceInput,
+            undefined,
+            {} as never,
+          );
+        },
+        isPending: false,
+      })) as unknown as typeof useCreateWorkspace);
+
+      renderModal();
+
+      const input = screen.getByTestId(
+        "workspace-slug-input",
+      ) as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "side-project" } });
+      fireEvent.click(screen.getByTestId("workspace-create-submit"));
+
+      await waitFor(() => {
+        expect(assign).toHaveBeenCalledWith(
+          "http://localhost:7911/onboarding?skip_identity=1",
+        );
+      });
+    } finally {
       Object.defineProperty(window, "location", {
         value: originalLocation,
         writable: true,
       });
-    });
-
-    useCreateWorkspaceMock.mockImplementation(((
-      opts?: Parameters<typeof useCreateWorkspace>[0],
-    ) => ({
-      mutate: (workspaceInput: CreateWorkspaceInput) => {
-        opts?.onSuccess?.(
-          {
-            name: "side-project",
-            broker_port: 7910,
-            web_port: 7911,
-            runtime_home: "/tmp/x",
-            state: "running",
-          },
-          workspaceInput,
-          undefined,
-          {} as never,
-        );
-      },
-      isPending: false,
-    })) as unknown as typeof useCreateWorkspace);
-
-    renderModal();
-
-    const input = screen.getByTestId(
-      "workspace-slug-input",
-    ) as HTMLInputElement;
-    fireEvent.change(input, { target: { value: "side-project" } });
-    fireEvent.click(screen.getByTestId("workspace-create-submit"));
-
-    await waitFor(() => {
-      expect(assign).toHaveBeenCalledWith(
-        "http://localhost:7911/onboarding?skip_identity=1",
-      );
-    });
+    }
   });
 
   it("Esc key closes the modal in form phase", () => {

--- a/web/src/components/workspaces/__tests__/CreateWorkspaceModal.test.tsx
+++ b/web/src/components/workspaces/__tests__/CreateWorkspaceModal.test.tsx
@@ -1,4 +1,8 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  type MutationFunctionContext,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -128,6 +132,11 @@ describe("<CreateWorkspaceModal>", () => {
     });
 
     try {
+      const mutationContext: MutationFunctionContext = {
+        client: new QueryClient(),
+        meta: undefined,
+      };
+
       useCreateWorkspaceMock.mockImplementation(((
         opts?: Parameters<typeof useCreateWorkspace>[0],
       ) => ({
@@ -142,7 +151,7 @@ describe("<CreateWorkspaceModal>", () => {
             },
             workspaceInput,
             undefined,
-            {} as never,
+            mutationContext,
           );
         },
         isPending: false,

--- a/web/src/components/workspaces/__tests__/CreateWorkspaceModal.test.tsx
+++ b/web/src/components/workspaces/__tests__/CreateWorkspaceModal.test.tsx
@@ -14,7 +14,10 @@ vi.mock("../../../api/workspaces", async () => {
   };
 });
 
-import { useCreateWorkspace } from "../../../api/workspaces";
+import {
+  type CreateWorkspaceInput,
+  useCreateWorkspace,
+} from "../../../api/workspaces";
 
 const useCreateWorkspaceMock = vi.mocked(useCreateWorkspace);
 
@@ -130,9 +133,10 @@ describe("<CreateWorkspaceModal>", () => {
       });
     });
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    useCreateWorkspaceMock.mockImplementation(((opts?: any) => ({
-      mutate: (input: unknown) => {
+    useCreateWorkspaceMock.mockImplementation(((
+      opts?: Parameters<typeof useCreateWorkspace>[0],
+    ) => ({
+      mutate: (workspaceInput: CreateWorkspaceInput) => {
         opts?.onSuccess?.(
           {
             name: "side-project",
@@ -141,13 +145,12 @@ describe("<CreateWorkspaceModal>", () => {
             runtime_home: "/tmp/x",
             state: "running",
           },
-          input,
+          workspaceInput,
           undefined,
           {} as never,
         );
       },
       isPending: false,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     })) as unknown as typeof useCreateWorkspace);
 
     renderModal();

--- a/web/src/components/workspaces/__tests__/StatusPill.test.tsx
+++ b/web/src/components/workspaces/__tests__/StatusPill.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { UsageData } from "../../../api/client";
@@ -155,5 +155,30 @@ describe("<StatusPill>", () => {
     const pill = screen.getByTestId("workspace-status-pill");
     expect(pill.textContent).toContain("— tokens today");
     expect(pill.textContent).not.toContain("0 tokens today");
+  });
+
+  it("does not leave the loading placeholder when the usage query fails", async () => {
+    setListData(
+      [
+        {
+          name: "main",
+          runtime_home: "/r",
+          broker_port: 7890,
+          web_port: 7891,
+          state: "running",
+          is_active: true,
+        },
+      ],
+      "main",
+    );
+    getUsageMock.mockRejectedValue(new Error("usage unavailable"));
+
+    renderPill();
+
+    const pill = screen.getByTestId("workspace-status-pill");
+    await waitFor(() => {
+      expect(pill.textContent).toContain("0 tokens today");
+    });
+    expect(pill.textContent).not.toContain("— tokens today");
   });
 });

--- a/web/src/hooks/useAgentStream.test.ts
+++ b/web/src/hooks/useAgentStream.test.ts
@@ -20,8 +20,9 @@ describe("appendStreamLine", () => {
     let nextId = 1;
     for (const chunk of ["I'm ", "the ", "planner — ", "what next?"]) {
       const result = appendStreamLine(lines, chunk, undefined, nextId);
-      lines = result.lines;
-      if (result.usedId) nextId += 1;
+      const { lines: nextLines, usedId } = result;
+      lines = nextLines;
+      if (usedId) nextId += 1;
     }
     expect(lines).toHaveLength(1);
     expect(lines[0].data).toBe("I'm the planner — what next?");
@@ -96,8 +97,9 @@ describe("appendStreamLine", () => {
         isStructured ? { i } : undefined,
         nextId,
       );
-      lines = result.lines;
-      if (result.usedId) nextId += 1;
+      const { lines: nextLines, usedId } = result;
+      lines = nextLines;
+      if (usedId) nextId += 1;
     }
     expect(lines.length).toBeLessThanOrEqual(50);
   });

--- a/web/src/hooks/useAgentStream.ts
+++ b/web/src/hooks/useAgentStream.ts
@@ -75,7 +75,7 @@ export function useAgentStream(slug: string | null) {
       }
 
       setLines((prev) => {
-        const { lines, usedId } = appendStreamLine(
+        const { lines: nextLines, usedId } = appendStreamLine(
           prev,
           e.data,
           parsed,
@@ -84,7 +84,7 @@ export function useAgentStream(slug: string | null) {
         if (usedId) {
           counterRef.current += 1;
         }
-        return lines;
+        return nextLines;
       });
 
       // Auto-stop on idle

--- a/web/src/hooks/useCommands.test.ts
+++ b/web/src/hooks/useCommands.test.ts
@@ -93,8 +93,12 @@ describe("FALLBACK_SLASH_COMMANDS", () => {
       "/threads",
       "/provider",
       "/connect",
-    ].sort();
-    expect(FALLBACK_SLASH_COMMANDS.map((c) => c.name).sort()).toEqual(expected);
+    ].sort((a, b) => a.localeCompare(b));
+    expect(
+      FALLBACK_SLASH_COMMANDS.map((c) => c.name).sort((a, b) =>
+        a.localeCompare(b),
+      ),
+    ).toEqual(expected);
   });
 
   it("never ships an empty icon — every fallback entry has a glyph", () => {

--- a/web/src/hooks/useMessages.ts
+++ b/web/src/hooks/useMessages.ts
@@ -15,7 +15,10 @@ export function useMessages(channel: string, sinceId?: string | null) {
 export function useThreadMessages(channel: string, threadId: string | null) {
   return useQuery({
     queryKey: ["thread-messages", channel, threadId],
-    queryFn: () => getThreadMessages(channel, threadId!),
+    queryFn: () => {
+      if (!threadId) throw new Error("threadId is required");
+      return getThreadMessages(channel, threadId);
+    },
     enabled: !!threadId,
     refetchInterval: 3000,
     select: (data) => data.messages ?? [],

--- a/web/src/hooks/useWindowEscape.ts
+++ b/web/src/hooks/useWindowEscape.ts
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+
+export function useWindowEscape(enabled: boolean, onEscape: () => void): void {
+  useEffect(() => {
+    if (!enabled) return;
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onEscape();
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [enabled, onEscape]);
+}

--- a/web/src/lib/mentions.tsx
+++ b/web/src/lib/mentions.tsx
@@ -54,7 +54,7 @@ export function parseMentions(
   // matchAll over a fresh regex avoids lastIndex leaking between invocations.
   const re = new RegExp(MENTION_RE.source, "g");
   for (const m of content.matchAll(re)) {
-    const slug = m[1];
+    const [, slug] = m;
     if (m.index === undefined) continue;
     if (!known.has(slug.toLowerCase())) continue;
     // The pattern captures an optional leading boundary char; preserve it
@@ -104,10 +104,14 @@ export function extractTaggedMentions(
 }
 
 export function renderMentionTokens(tokens: MentionToken[]): ReactNode[] {
-  return tokens.map((t, i) => {
+  const seen = new Map<string, number>();
+  return tokens.map((t) => {
+    const occurrence = seen.get(t.value) ?? 0;
+    seen.set(t.value, occurrence + 1);
+    const key = `${t.kind}-${t.value}-${occurrence}`;
     if (t.kind === "mention") {
       return (
-        <span key={`m-${i}-${t.value}`} className="mention">
+        <span key={key} className="mention">
           @{t.value}
         </span>
       );

--- a/web/src/lib/mentions.tsx
+++ b/web/src/lib/mentions.tsx
@@ -90,7 +90,7 @@ export function extractTaggedMentions(
   const re = new RegExp(MENTION_RE.source, "g");
   for (const match of content.matchAll(re)) {
     const slug = match[1]?.toLowerCase();
-    if (!slug || !known.has(slug)) continue;
+    if (!(slug && known.has(slug))) continue;
     if (slug === "all") {
       wantsAll = true;
       continue;

--- a/web/src/lib/mentions.tsx
+++ b/web/src/lib/mentions.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { keyedByOccurrence } from "./reactKeys";
+
 /**
  * Shared @-mention pattern. Matches `@slug` where slug is lowercase
  * alphanumeric-plus-hyphens and starts with a letter or digit. Mirrors the
@@ -104,11 +106,10 @@ export function extractTaggedMentions(
 }
 
 export function renderMentionTokens(tokens: MentionToken[]): ReactNode[] {
-  const seen = new Map<string, number>();
-  return tokens.map((t) => {
-    const occurrence = seen.get(t.value) ?? 0;
-    seen.set(t.value, occurrence + 1);
-    const key = `${t.kind}-${t.value}-${occurrence}`;
+  return keyedByOccurrence(
+    tokens,
+    (token) => `${token.kind}-${token.value}`,
+  ).map(({ key, value: t }) => {
     if (t.kind === "mention") {
       return (
         <span key={key} className="mention">

--- a/web/src/lib/messageMarkdown.tsx
+++ b/web/src/lib/messageMarkdown.tsx
@@ -77,7 +77,7 @@ export function mentionRemarkPlugin() {
   return function plugin() {
     return function transformer(tree: unknown) {
       walk(tree as MdAnyNode, (parent) => {
-        const children = parent.children;
+        const { children } = parent;
         for (let i = 0; i < children.length; i++) {
           const child = children[i];
           if (
@@ -85,7 +85,7 @@ export function mentionRemarkPlugin() {
             typeof (child as MdTextNode).value !== "string"
           )
             continue;
-          const value = (child as MdTextNode).value;
+          const { value } = child as MdTextNode;
           if (!value.includes("@")) continue;
 
           const replacements = buildMentionReplacements(value);
@@ -105,7 +105,7 @@ function buildMentionReplacements(value: string): MdAnyNode[] {
   const out: MdAnyNode[] = [];
   let cursor = 0;
   for (const m of matches) {
-    const slug = m[1];
+    const [, slug] = m;
     if (!slug) continue;
     // The regex captures one optional prefix char (boundary). Find the actual
     // '@' position so we slice the surrounding text correctly.
@@ -140,7 +140,7 @@ function buildMentionReplacements(value: string): MdAnyNode[] {
 
 function walk(node: MdAnyNode, onParent: (parent: MdParent) => void) {
   const maybeParent = node as { children?: MdAnyNode[]; type?: string };
-  const children = maybeParent.children;
+  const { children } = maybeParent;
   if (!Array.isArray(children)) return;
   // Don't transform text inside link nodes:
   //  - the user wrote link text deliberately; chipping @slug there would surprise them

--- a/web/src/lib/pixelAvatar.test.ts
+++ b/web/src/lib/pixelAvatar.test.ts
@@ -1,61 +1,72 @@
-import { describe, expect, it } from 'vitest'
-import { resolveKnownPortraitSprite } from './avatarSprites.generated'
-import { getAgentColor, resolvePortraitSprite } from './pixelAvatar'
+import { describe, expect, it } from "vitest";
 
-describe('pixel avatar sprite resolution', () => {
-  it('maps operation-created agent slugs into the generated avatar catalog', () => {
+import { resolveKnownPortraitSprite } from "./avatarSprites.generated";
+import { getAgentColor, resolvePortraitSprite } from "./pixelAvatar";
+
+describe("pixel avatar sprite resolution", () => {
+  it("maps operation-created agent slugs into the generated avatar catalog", () => {
     const mappings = new Map([
-      ['planner', 'hybridPm'],
-      ['builder', 'hybridEng'],
-      ['growth', 'hybridGtm'],
-      ['reviewer', 'hybridQa'],
-      ['operator', 'hybridNex'],
-    ])
+      ["planner", "hybridPm"],
+      ["builder", "hybridEng"],
+      ["growth", "hybridGtm"],
+      ["reviewer", "hybridQa"],
+      ["operator", "hybridNex"],
+    ]);
 
     for (const [slug, id] of mappings) {
-      expect(resolveKnownPortraitSprite(slug)?.id).toBe(id)
+      expect(resolveKnownPortraitSprite(slug)?.id).toBe(id);
     }
-  })
+  });
 
-  it('normalizes slugs before resolving portraits', () => {
-    expect(resolvePortraitSprite(' Planner ')?.id).toBe('hybridPm')
+  it("normalizes slugs before resolving portraits", () => {
+    expect(resolvePortraitSprite(" Planner ")?.id).toBe("hybridPm");
 
-    const mixedCase = resolvePortraitSprite('Custom-Ops-Agent')
-    const normalized = resolvePortraitSprite(' custom-ops-agent ')
-    expect(mixedCase.id).toBe(normalized.id)
-    expect(mixedCase.palette).toEqual(normalized.palette)
-  })
+    const mixedCase = resolvePortraitSprite("Custom-Ops-Agent");
+    const normalized = resolvePortraitSprite(" custom-ops-agent ");
+    expect(mixedCase.id).toBe(normalized.id);
+    expect(mixedCase.palette).toEqual(normalized.palette);
+  });
 
-  it('keeps arbitrary new-agent slugs on generated office sprites', () => {
-    const avatar = resolvePortraitSprite('custom-ops-agent')
-    const idParts = avatar.id.split(':')
-    const baseID = idParts[idParts.length - 1]
+  it("keeps arbitrary new-agent slugs on generated office sprites", () => {
+    const avatar = resolvePortraitSprite("custom-ops-agent");
+    const idParts = avatar.id.split(":");
+    const baseID = idParts[idParts.length - 1];
 
-    expect(avatar.id).toMatch(/^procedural:custom-ops-agent:hybrid/)
-    expect(['hybridCeo', 'hybridGeneric', 'hybridHuman', 'hybridPam', 'hybridPamCute']).not.toContain(baseID)
-    expect(avatar.portrait.length).toBeGreaterThan(0)
-  })
+    expect(avatar.id).toMatch(/^procedural:custom-ops-agent:hybrid/);
+    expect([
+      "hybridCeo",
+      "hybridGeneric",
+      "hybridHuman",
+      "hybridPam",
+      "hybridPamCute",
+    ]).not.toContain(baseID);
+    expect(avatar.portrait.length).toBeGreaterThan(0);
+  });
 
-  it('procedurally varies generated office palettes by slug', () => {
-    const first = resolvePortraitSprite('custom-ops-agent')
-    const again = resolvePortraitSprite('custom-ops-agent')
-    const second = resolvePortraitSprite('custom-sales-agent')
+  it("procedurally varies generated office palettes by slug", () => {
+    const first = resolvePortraitSprite("custom-ops-agent");
+    const again = resolvePortraitSprite("custom-ops-agent");
+    const second = resolvePortraitSprite("custom-sales-agent");
 
-    expect(first.id).toBe(again.id)
-    expect(first.palette).toEqual(again.palette)
-    expect(`${first.id}:${first.palette.join(',')}`).not.toBe(`${second.id}:${second.palette.join(',')}`)
-  })
+    expect(first.id).toBe(again.id);
+    expect(first.palette).toEqual(again.palette);
+    expect(`${first.id}:${first.palette.join(",")}`).not.toBe(
+      `${second.id}:${second.palette.join(",")}`,
+    );
+  });
 
-  it('keeps procedural agent colors stable and accent-like', () => {
-    expect(getAgentColor('ceo')).toBe('#E8A838')
-    expect(getAgentColor('custom-ops-agent')).toMatch(/^#[0-9A-F]{6}$/i)
-    expect(getAgentColor('custom-ops-agent')).toBe(getAgentColor('custom-ops-agent'))
-  })
+  it("keeps procedural agent colors stable and accent-like", () => {
+    expect(getAgentColor("ceo")).toBe("#E8A838");
+    expect(getAgentColor("custom-ops-agent")).toMatch(/^#[0-9A-F]{6}$/i);
+    expect(getAgentColor("custom-ops-agent")).toBe(
+      getAgentColor("custom-ops-agent"),
+    );
+  });
 
-  it('keeps known role aliases on canonical role colors', () => {
-    expect(getAgentColor('planner')).toBe(getAgentColor('pm'))
-    expect(getAgentColor('builder')).toBe(getAgentColor('eng'))
-    expect(getAgentColor('growth')).toBe(getAgentColor('gtm'))
-    expect(getAgentColor('operator')).toBe(getAgentColor('nex'))
-  })
-})
+  it("keeps known role aliases on canonical role colors", () => {
+    expect(getAgentColor("planner")).toBe(getAgentColor("pm"));
+    expect(getAgentColor("builder")).toBe(getAgentColor("eng"));
+    expect(getAgentColor("growth")).toBe(getAgentColor("gtm"));
+    expect(getAgentColor("operator")).toBe(getAgentColor("nex"));
+  });
+});

--- a/web/src/lib/pixelAvatar.test.ts
+++ b/web/src/lib/pixelAvatar.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import { resolveKnownPortraitSprite } from "./avatarSprites.generated";
-import { getAgentColor, resolvePortraitSprite } from "./pixelAvatar";
+import {
+  getAgentColor,
+  paintPixelAvatarData,
+  resolvePortraitSprite,
+} from "./pixelAvatar";
 
 describe("pixel avatar sprite resolution", () => {
   it("maps operation-created agent slugs into the generated avatar catalog", () => {
@@ -68,5 +72,16 @@ describe("pixel avatar sprite resolution", () => {
     expect(getAgentColor("builder")).toBe(getAgentColor("eng"));
     expect(getAgentColor("growth")).toBe(getAgentColor("gtm"));
     expect(getAgentColor("operator")).toBe(getAgentColor("nex"));
+  });
+
+  it("treats missing cells in short sprite rows as transparent", () => {
+    const data = new Uint8ClampedArray(2 * 2 * 4);
+
+    paintPixelAvatarData(data, [[1], [0, 1]], { 1: [10, 20, 30] }, 2);
+
+    expect(Array.from(data.slice(0, 4))).toEqual([10, 20, 30, 255]);
+    expect(Array.from(data.slice(4, 8))).toEqual([0, 0, 0, 0]);
+    expect(Array.from(data.slice(8, 12))).toEqual([0, 0, 0, 0]);
+    expect(Array.from(data.slice(12, 16))).toEqual([10, 20, 30, 255]);
   });
 });

--- a/web/src/lib/pixelAvatar.ts
+++ b/web/src/lib/pixelAvatar.ts
@@ -4,169 +4,179 @@
 
 import {
   KNOWN_AVATAR_SPRITES,
-  resolveKnownPortraitSprite,
   type KnownAvatarSprite,
-} from './avatarSprites.generated'
+  resolveKnownPortraitSprite,
+} from "./avatarSprites.generated";
 
 const AGENT_COLORS: Record<string, string> = {
-  ceo: '#E8A838',
-  eng: '#3FB950',
-  gtm: '#FFA657',
-  human: '#38BDF8',
-  pm: '#58A6FF',
-  fe: '#A371F7',
-  frontend: '#A371F7',
-  be: '#3FB950',
-  backend: '#3FB950',
-  ai: '#D2A8FF',
-  'ai-eng': '#D2A8FF',
-  ai_eng: '#D2A8FF',
-  designer: '#F778BA',
-  cmo: '#FFA657',
-  cro: '#79C0FF',
-  pam: '#F4B6C2',
-  nex: '#56D4DD',
-}
+  ceo: "#E8A838",
+  eng: "#3FB950",
+  gtm: "#FFA657",
+  human: "#38BDF8",
+  pm: "#58A6FF",
+  fe: "#A371F7",
+  frontend: "#A371F7",
+  be: "#3FB950",
+  backend: "#3FB950",
+  ai: "#D2A8FF",
+  "ai-eng": "#D2A8FF",
+  ai_eng: "#D2A8FF",
+  designer: "#F778BA",
+  cmo: "#FFA657",
+  cro: "#79C0FF",
+  pam: "#F4B6C2",
+  nex: "#56D4DD",
+};
 
 const AGENT_COLOR_ALIASES: Record<string, string> = {
-  planner: 'pm',
-  product: 'pm',
-  'product-manager': 'pm',
-  builder: 'eng',
-  'founding-engineer': 'eng',
-  'workflow-architect': 'eng',
-  'automation-builder': 'eng',
-  growth: 'gtm',
-  'growth-ops': 'gtm',
-  monetization: 'cro',
-  revenue: 'cro',
-  invoicing: 'cro',
-  operator: 'nex',
-  ops: 'nex',
-  operations: 'nex',
-}
+  planner: "pm",
+  product: "pm",
+  "product-manager": "pm",
+  builder: "eng",
+  "founding-engineer": "eng",
+  "workflow-architect": "eng",
+  "automation-builder": "eng",
+  growth: "gtm",
+  "growth-ops": "gtm",
+  monetization: "cro",
+  revenue: "cro",
+  invoicing: "cro",
+  operator: "nex",
+  ops: "nex",
+  operations: "nex",
+};
 
-type Rgb = readonly [number, number, number]
+type Rgb = readonly [number, number, number];
 
 function hexToRgb(hex: string): Rgb {
   return [
     Number.parseInt(hex.slice(1, 3), 16),
     Number.parseInt(hex.slice(3, 5), 16),
     Number.parseInt(hex.slice(5, 7), 16),
-  ]
+  ];
 }
 
 function paletteFromHexes(palette: string[]): Record<number, Rgb> {
-  return Object.fromEntries(palette.map((hex, index) => [index + 1, hexToRgb(hex)]))
+  return Object.fromEntries(
+    palette.map((hex, index) => [index + 1, hexToRgb(hex)]),
+  );
 }
 
 export function getAgentColor(slug: string): string {
-  const normalized = slug.trim().toLowerCase()
-  const key = AGENT_COLOR_ALIASES[normalized] ?? normalized
-  return AGENT_COLORS[key] ?? proceduralAccentForSlug(key)
+  const normalized = slug.trim().toLowerCase();
+  const key = AGENT_COLOR_ALIASES[normalized] ?? normalized;
+  return AGENT_COLORS[key] ?? proceduralAccentForSlug(key);
 }
 
 const RESERVED_DYNAMIC_AVATAR_IDS = new Set([
-  'hybridCeo',
-  'hybridGeneric',
-  'hybridHuman',
-  'hybridPam',
-  'hybridPamCute',
-])
+  "hybridCeo",
+  "hybridGeneric",
+  "hybridHuman",
+  "hybridPam",
+  "hybridPamCute",
+]);
 
 const DYNAMIC_AVATAR_IDS = Object.keys(KNOWN_AVATAR_SPRITES)
-  .filter((id) => id.startsWith('hybrid') && !RESERVED_DYNAMIC_AVATAR_IDS.has(id))
-  .sort()
+  .filter(
+    (id) => id.startsWith("hybrid") && !RESERVED_DYNAMIC_AVATAR_IDS.has(id),
+  )
+  .sort();
 
 const PROCEDURAL_ACCENTS = [
-  '#E8A838',
-  '#58A6FF',
-  '#A371F7',
-  '#3FB950',
-  '#D2A8FF',
-  '#F778BA',
-  '#FFA657',
-  '#79C0FF',
-  '#FF7B72',
-  '#56D4DD',
-  '#FFD866',
-  '#C9D1D9',
-]
+  "#E8A838",
+  "#58A6FF",
+  "#A371F7",
+  "#3FB950",
+  "#D2A8FF",
+  "#F778BA",
+  "#FFA657",
+  "#79C0FF",
+  "#FF7B72",
+  "#56D4DD",
+  "#FFD866",
+  "#C9D1D9",
+];
 
 function hashSlug(slug: string): number {
-  let h = 0x811c9dc5
+  let h = 0x811c9dc5;
   for (let i = 0; i < slug.length; i++) {
-    h ^= slug.charCodeAt(i)
-    h = Math.imul(h, 0x01000193)
+    h ^= slug.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
   }
-  return h >>> 0
+  return h >>> 0;
 }
 
 function pick(hash: number, salt: number, modulo: number): number {
-  let h = hash ^ (salt * 0x9e3779b1)
-  h = Math.imul(h ^ (h >>> 16), 0x85ebca6b)
-  h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35)
-  h ^= h >>> 16
-  return (h >>> 0) % modulo
+  let h = hash ^ (salt * 0x9e3779b1);
+  h = Math.imul(h ^ (h >>> 16), 0x85ebca6b);
+  h = Math.imul(h ^ (h >>> 13), 0xc2b2ae35);
+  h ^= h >>> 16;
+  return (h >>> 0) % modulo;
 }
 
 function proceduralAccentForSlug(slug: string): string {
-  const hash = hashSlug(slug || 'unknown')
-  return PROCEDURAL_ACCENTS[pick(hash, 9, PROCEDURAL_ACCENTS.length)] ?? '#56D4DD'
+  const hash = hashSlug(slug || "unknown");
+  return (
+    PROCEDURAL_ACCENTS[pick(hash, 9, PROCEDURAL_ACCENTS.length)] ?? "#56D4DD"
+  );
 }
 
 function rgbToHex([r, g, b]: Rgb): string {
-  return `#${[r, g, b].map((v) => Math.max(0, Math.min(255, v)).toString(16).padStart(2, '0')).join('')}`
+  return `#${[r, g, b].map((v) => Math.max(0, Math.min(255, v)).toString(16).padStart(2, "0")).join("")}`;
 }
 
 function luminance([r, g, b]: Rgb): number {
-  return (0.2126 * r) + (0.7152 * g) + (0.0722 * b)
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
 
 function isSkinLike([r, g, b]: Rgb): boolean {
-  return r >= 120 && g >= 70 && b <= 190 && r >= g && g >= b
+  return r >= 120 && g >= 70 && b <= 190 && r >= g && g >= b;
 }
 
 function blend(a: Rgb, b: Rgb, amount: number): Rgb {
   return [
-    Math.round(a[0] + ((b[0] - a[0]) * amount)),
-    Math.round(a[1] + ((b[1] - a[1]) * amount)),
-    Math.round(a[2] + ((b[2] - a[2]) * amount)),
-  ]
+    Math.round(a[0] + (b[0] - a[0]) * amount),
+    Math.round(a[1] + (b[1] - a[1]) * amount),
+    Math.round(a[2] + (b[2] - a[2]) * amount),
+  ];
 }
 
 function buildProceduralOfficePortrait(slug: string): KnownAvatarSprite {
-  const hash = hashSlug(slug || 'unknown')
-  const ids = DYNAMIC_AVATAR_IDS.length > 0 ? DYNAMIC_AVATAR_IDS : ['hybridGeneric']
-  const baseID = ids[pick(hash, 8, ids.length)]
-  const base = KNOWN_AVATAR_SPRITES[baseID] ?? KNOWN_AVATAR_SPRITES.hybridGeneric ?? Object.values(KNOWN_AVATAR_SPRITES)[0]
+  const hash = hashSlug(slug || "unknown");
+  const ids =
+    DYNAMIC_AVATAR_IDS.length > 0 ? DYNAMIC_AVATAR_IDS : ["hybridGeneric"];
+  const baseID = ids[pick(hash, 8, ids.length)];
+  const base =
+    KNOWN_AVATAR_SPRITES[baseID] ??
+    KNOWN_AVATAR_SPRITES.hybridGeneric ??
+    Object.values(KNOWN_AVATAR_SPRITES)[0];
   if (!base) {
-    throw new Error('avatar sprite catalog is empty')
+    throw new Error("avatar sprite catalog is empty");
   }
 
-  const accent = hexToRgb(proceduralAccentForSlug(slug))
-  const tintStrength = 0.22 + (pick(hash, 10, 18) / 100)
+  const accent = hexToRgb(proceduralAccentForSlug(slug));
+  const tintStrength = 0.22 + pick(hash, 10, 18) / 100;
   const palette = base.palette.map((hex) => {
-    const rgb = hexToRgb(hex)
+    const rgb = hexToRgb(hex);
     if (luminance(rgb) < 38 || isSkinLike(rgb)) {
-      return hex
+      return hex;
     }
-    return rgbToHex(blend(rgb, accent, tintStrength))
-  })
+    return rgbToHex(blend(rgb, accent, tintStrength));
+  });
 
   return {
     ...base,
-    id: `procedural:${slug || 'unknown'}:${base.id}`,
+    id: `procedural:${slug || "unknown"}:${base.id}`,
     palette,
-  }
+  };
 }
 
 export function resolvePortraitSprite(slug: string): KnownAvatarSprite {
-  const normalized = slug.trim().toLowerCase()
-  const known = resolveKnownPortraitSprite(normalized)
-  if (known) return known
+  const normalized = slug.trim().toLowerCase();
+  const known = resolveKnownPortraitSprite(normalized);
+  if (known) return known;
 
-  return buildProceduralOfficePortrait(normalized)
+  return buildProceduralOfficePortrait(normalized);
 }
 
 /**
@@ -179,42 +189,42 @@ export function drawPixelAvatar(
   slug: string,
   size: number,
 ): void {
-  const avatar = resolvePortraitSprite(slug)
-  const sprite = avatar.portrait
-  const palette = paletteFromHexes(avatar.palette)
+  const avatar = resolvePortraitSprite(slug);
+  const sprite = avatar.portrait;
+  const palette = paletteFromHexes(avatar.palette);
 
-  const rows = sprite.length
-  const cols = sprite[0]?.length ?? 0
-  if (rows === 0 || cols === 0) return
+  const rows = sprite.length;
+  const cols = sprite[0]?.length ?? 0;
+  if (rows === 0 || cols === 0) return;
 
-  canvas.width = cols
-  canvas.height = rows
-  canvas.style.width = `${size}px`
-  canvas.style.height = `${(size * rows) / cols}px`
+  canvas.width = cols;
+  canvas.height = rows;
+  canvas.style.width = `${size}px`;
+  canvas.style.height = `${(size * rows) / cols}px`;
 
-  const ctx = canvas.getContext('2d')
-  if (!ctx) return
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
 
-  const imgData = ctx.createImageData(cols, rows)
+  const imgData = ctx.createImageData(cols, rows);
   for (let r = 0; r < rows; r++) {
     for (let c = 0; c < cols; c++) {
-      const px = sprite[r][c]
-      const idx = (r * cols + c) * 4
+      const px = sprite[r][c];
+      const idx = (r * cols + c) * 4;
       if (px === 0) {
-        imgData.data[idx] = 0
-        imgData.data[idx + 1] = 0
-        imgData.data[idx + 2] = 0
-        imgData.data[idx + 3] = 0
-        continue
+        imgData.data[idx] = 0;
+        imgData.data[idx + 1] = 0;
+        imgData.data[idx + 2] = 0;
+        imgData.data[idx + 3] = 0;
+        continue;
       }
 
-      const rgb = palette[px] ?? ([128, 128, 128] as const)
-      imgData.data[idx] = rgb[0]
-      imgData.data[idx + 1] = rgb[1]
-      imgData.data[idx + 2] = rgb[2]
-      imgData.data[idx + 3] = 255
+      const rgb = palette[px] ?? ([128, 128, 128] as const);
+      imgData.data[idx] = rgb[0];
+      imgData.data[idx + 1] = rgb[1];
+      imgData.data[idx + 2] = rgb[2];
+      imgData.data[idx + 3] = 255;
     }
   }
 
-  ctx.putImageData(imgData, 0, 0)
+  ctx.putImageData(imgData, 0, 0);
 }

--- a/web/src/lib/pixelAvatar.ts
+++ b/web/src/lib/pixelAvatar.ts
@@ -179,6 +179,33 @@ export function resolvePortraitSprite(slug: string): KnownAvatarSprite {
   return buildProceduralOfficePortrait(normalized);
 }
 
+export function paintPixelAvatarData(
+  data: Uint8ClampedArray,
+  sprite: readonly (readonly number[])[],
+  palette: Record<number, Rgb>,
+  cols: number,
+): void {
+  for (let r = 0; r < sprite.length; r++) {
+    for (let c = 0; c < cols; c++) {
+      const px = sprite[r]?.[c] ?? 0;
+      const idx = (r * cols + c) * 4;
+      if (px === 0) {
+        data[idx] = 0;
+        data[idx + 1] = 0;
+        data[idx + 2] = 0;
+        data[idx + 3] = 0;
+        continue;
+      }
+
+      const rgb = palette[px] ?? ([128, 128, 128] as const);
+      data[idx] = rgb[0];
+      data[idx + 1] = rgb[1];
+      data[idx + 2] = rgb[2];
+      data[idx + 3] = 255;
+    }
+  }
+}
+
 /**
  * Paint a pixel-art agent avatar into an existing canvas element.
  * Known agents render from the generated avatar catalog; everything else gets
@@ -206,25 +233,6 @@ export function drawPixelAvatar(
   if (!ctx) return;
 
   const imgData = ctx.createImageData(cols, rows);
-  for (let r = 0; r < rows; r++) {
-    for (let c = 0; c < cols; c++) {
-      const px = sprite[r][c];
-      const idx = (r * cols + c) * 4;
-      if (px === 0) {
-        imgData.data[idx] = 0;
-        imgData.data[idx + 1] = 0;
-        imgData.data[idx + 2] = 0;
-        imgData.data[idx + 3] = 0;
-        continue;
-      }
-
-      const rgb = palette[px] ?? ([128, 128, 128] as const);
-      imgData.data[idx] = rgb[0];
-      imgData.data[idx + 1] = rgb[1];
-      imgData.data[idx + 2] = rgb[2];
-      imgData.data[idx + 3] = 255;
-    }
-  }
-
+  paintPixelAvatarData(imgData.data, sprite, palette, cols);
   ctx.putImageData(imgData, 0, 0);
 }

--- a/web/src/lib/reactKeys.test.ts
+++ b/web/src/lib/reactKeys.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { keyedByOccurrence } from "./reactKeys";
+
+describe("keyedByOccurrence", () => {
+  it("keeps semantic keys unchanged when they are unique", () => {
+    expect(keyedByOccurrence(["a", "b"], (value) => value)).toEqual([
+      { key: "a", value: "a", index: 0 },
+      { key: "b", value: "b", index: 1 },
+    ]);
+  });
+
+  it("suffixes repeated semantic keys by occurrence", () => {
+    expect(keyedByOccurrence(["repeat", "repeat"], (value) => value)).toEqual([
+      { key: "repeat", value: "repeat", index: 0 },
+      { key: "repeat#1", value: "repeat", index: 1 },
+    ]);
+  });
+
+  it("avoids collisions between duplicate suffixes and literal bases", () => {
+    expect(keyedByOccurrence(["x", "x", "x#1"], (value) => value)).toEqual([
+      { key: "x", value: "x", index: 0 },
+      { key: "x#1", value: "x", index: 1 },
+      { key: "x#1#1", value: "x#1", index: 2 },
+    ]);
+  });
+});

--- a/web/src/lib/reactKeys.ts
+++ b/web/src/lib/reactKeys.ts
@@ -1,0 +1,35 @@
+export interface KeyedOccurrence<T> {
+  key: string;
+  value: T;
+  index: number;
+}
+
+/**
+ * Builds React keys from a semantic base while preserving duplicate
+ * occurrences. Use this when an index-only key was removed but the remaining
+ * data is not guaranteed to be globally unique.
+ */
+export function keyedByOccurrence<T>(
+  values: readonly T[],
+  baseKey: (value: T, index: number) => string,
+): KeyedOccurrence<T>[] {
+  const seen = new Map<string, number>();
+  const emitted = new Set<string>();
+  return values.map((value, index) => {
+    const base = baseKey(value, index) || "item";
+    const occurrence = seen.get(base) ?? 0;
+    seen.set(base, occurrence + 1);
+    let key = occurrence === 0 ? base : `${base}#${occurrence}`;
+    let collision = occurrence + 1;
+    while (emitted.has(key)) {
+      key = `${base}#${collision}`;
+      collision += 1;
+    }
+    emitted.add(key);
+    return {
+      key,
+      value,
+      index,
+    };
+  });
+}

--- a/web/src/lib/wikilink.test.ts
+++ b/web/src/lib/wikilink.test.ts
@@ -12,7 +12,7 @@ describe("parseWikiLink", () => {
   for (const entry of fixtures as Fixture[]) {
     it(`handles ${JSON.stringify(entry.input)}`, () => {
       // Arrange
-      const input = entry.input;
+      const { input } = entry;
       // Act
       const result = parseWikiLink(input);
       // Assert

--- a/web/src/lib/wikilink.ts
+++ b/web/src/lib/wikilink.ts
@@ -55,7 +55,7 @@ export function parseWikiLinkInner(raw: string): WikiLink | null {
   if (slug.includes("..")) return null;
   if (slug.startsWith("/")) return null;
   // Control chars / NUL.
-  if (/[\x00-\x1f]/.test(slug)) return null;
+  if ([...slug].some((char) => char.charCodeAt(0) <= 0x1f)) return null;
 
   return { slug, display };
 }
@@ -94,7 +94,7 @@ export function wikiLinkRemarkPlugin(resolver: (slug: string) => boolean) {
   return function plugin() {
     return function transformer(tree: unknown) {
       walk(tree as MdAnyNode, (parent) => {
-        const children = parent.children;
+        const { children } = parent;
         for (let i = 0; i < children.length; i++) {
           const child = children[i];
           if (
@@ -102,7 +102,7 @@ export function wikiLinkRemarkPlugin(resolver: (slug: string) => boolean) {
             typeof (child as MdTextNode).value !== "string"
           )
             continue;
-          const value = (child as MdTextNode).value;
+          const { value } = child as MdTextNode;
           if (!value.includes("[[")) continue;
 
           const replacements = buildReplacements(value, resolver);
@@ -122,11 +122,16 @@ function buildReplacements(
   const re = /\[\[([^\]\n]+)\]\]/g;
   const out: MdAnyNode[] = [];
   let lastIndex = 0;
-  let match: RegExpExecArray | null;
   let changed = false;
-  while ((match = re.exec(value)) !== null) {
-    const link = parseWikiLinkInner(match[1]);
-    if (!link) continue;
+  let match = re.exec(value);
+  while (match !== null) {
+    const [, rawLink] = match;
+    const { lastIndex: nextLastIndex } = re;
+    const link = parseWikiLinkInner(rawLink);
+    if (!link) {
+      match = re.exec(value);
+      continue;
+    }
     changed = true;
     if (match.index > lastIndex) {
       out.push({ type: "text", value: value.slice(lastIndex, match.index) });
@@ -145,7 +150,8 @@ function buildReplacements(
         },
       },
     });
-    lastIndex = re.lastIndex;
+    lastIndex = nextLastIndex;
+    match = re.exec(value);
   }
   if (!changed) return [];
   if (lastIndex < value.length) {
@@ -156,7 +162,7 @@ function buildReplacements(
 
 function walk(node: MdAnyNode, onParent: (parent: MdParent) => void) {
   const maybeParent = node as { children?: MdAnyNode[] };
-  const children = maybeParent.children;
+  const { children } = maybeParent;
   if (!Array.isArray(children)) return;
   onParent(node as MdParent);
   // Walk a snapshot because onParent may have mutated children.

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -1,5 +1,3 @@
-/* biome-ignore-all lint/complexity/noImportantStyles: Responsive panel sizing and reduced-motion overrides must win over component CSS. */
-/* biome-ignore-all lint/suspicious/noDuplicateProperties: Image-rendering fallbacks intentionally target multiple browser engines. */
 /* ═══════════════════════════════════════════════════════════════
    WUPHF Web — Global Styles (React)
    Ported from index.legacy.html design system CSS.
@@ -341,6 +339,7 @@ body {
    upscale and the sprites lose their pixel-art edges. */
 .pixel-avatar {
   image-rendering: crisp-edges;
+  /* biome-ignore lint/suspicious/noDuplicateProperties: Pixel-art fallback targets engines with different crisp-rendering support. */
   image-rendering: pixelated;
   border-radius: 4px;
   display: block;
@@ -476,11 +475,13 @@ body {
 /* ─── Side panel responsive ─── */
 @media (max-width: 900px) {
   .side-panel {
+    /* biome-ignore lint/complexity/noImportantStyles: Responsive panel width override must win over fixed desktop sizing. */
     width: 60vw !important;
   }
 }
 @media (max-width: 600px) {
   .side-panel {
+    /* biome-ignore lint/complexity/noImportantStyles: Mobile full-width panel override must win over wider breakpoints. */
     width: 100vw !important;
   }
 }
@@ -502,7 +503,9 @@ body {
   .skill-suggest-expander,
   .side-panel,
   .animate-fade {
+    /* biome-ignore lint/complexity/noImportantStyles: Reduced-motion override must beat animation declarations. */
     animation: none !important;
+    /* biome-ignore lint/complexity/noImportantStyles: Reduced-motion override must beat transition declarations. */
     transition: none !important;
   }
 }

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -1,4 +1,5 @@
 /* biome-ignore-all lint/complexity/noImportantStyles: Responsive panel sizing and reduced-motion overrides must win over component CSS. */
+/* biome-ignore-all lint/suspicious/noDuplicateProperties: Image-rendering fallbacks intentionally target multiple browser engines. */
 /* ═══════════════════════════════════════════════════════════════
    WUPHF Web — Global Styles (React)
    Ported from index.legacy.html design system CSS.

--- a/web/src/styles/notebook.css
+++ b/web/src/styles/notebook.css
@@ -1,3 +1,4 @@
+/* biome-ignore-all lint/suspicious/noDuplicateProperties: Image-rendering fallbacks intentionally target multiple browser engines. */
 /* Notebook surface — scoped to `.notebook-surface`.
  * Per DESIGN-NOTEBOOK.md: physical-notebook metaphor with tan ruled paper,
  * Caveat handwritten display, IBM Plex Serif body, rotated DRAFT stamp.

--- a/web/src/styles/notebook.css
+++ b/web/src/styles/notebook.css
@@ -1,4 +1,3 @@
-/* biome-ignore-all lint/suspicious/noDuplicateProperties: Image-rendering fallbacks intentionally target multiple browser engines. */
 /* Notebook surface — scoped to `.notebook-surface`.
  * Per DESIGN-NOTEBOOK.md: physical-notebook metaphor with tan ruled paper,
  * Caveat handwritten display, IBM Plex Serif body, rotated DRAFT stamp.
@@ -890,6 +889,7 @@
 /* Avatars — reuse pixel-art canvas convention. */
 .notebook-surface canvas {
   image-rendering: pixelated;
+  /* biome-ignore lint/suspicious/noDuplicateProperties: Pixel-art fallback targets engines with different crisp-rendering support. */
   image-rendering: -moz-crisp-edges;
   image-rendering: crisp-edges;
 }

--- a/web/tests/setup.ts
+++ b/web/tests/setup.ts
@@ -7,7 +7,7 @@ import { vi } from "vitest";
 // Storage polyfill for tests so draft-autosave logic can be exercised
 // deterministically.
 function createMemoryStorage(): Storage {
-  const data: Record<string, string> = {};
+  const data: Record<string, string> = Object.create(null);
   const storage: Storage = {
     get length() {
       return Object.keys(data).length;
@@ -15,7 +15,7 @@ function createMemoryStorage(): Storage {
     clear: () => {
       for (const k of Object.keys(data)) delete data[k];
     },
-    getItem: (key: string) => (Object.hasOwn(data, key) ? data[key] : null),
+    getItem: (key: string) => (key in data ? data[key] : null),
     key: (index: number) => Object.keys(data)[index] ?? null,
     removeItem: (key: string) => {
       delete data[key];


### PR DESCRIPTION
## Summary
- clears every non-complexity Biome warning category remaining after the mechanical cleanup
- adds the direct unified dependency for markdown plugin type imports
- replaces native confirm usage with the app confirm host, removes non-null assertions/index keys/shadowing, and preserves CSS fallback exceptions explicitly

## Validation
- bun run check (passes with only 64 complexity warnings)
- bun run build
- bun run test (passes; expected localhost:3000 ECONNREFUSED noise remains)
- git diff --check audit/mechanical-lint-warnings-20260502
- commitlint: ./node_modules/.bin/commitlint --from HEAD~1 --to HEAD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wiki articles can be externally refreshed to trigger refetches

* **Bug Fixes**
  * Confirmation dialogs queue reliably when host isn't ready
  * Event-streams and related UI flows hardened
  * Reduced duplicate-key warnings; list rendering more stable
  * Improved focus/keyboard handling and buttons avoiding accidental submits

* **Refactor**
  * Consistent, stable keying across lists and components

* **Tests**
  * Expanded tests for streams, keying, and list rendering

* **Chores**
  * Added unified dependency and linting/format tweaks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->