### PR TITLE
[codex] baseline complexity warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,6 +207,10 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         run: bash scripts/check-no-new-sleeps-in-tests.sh
+      - name: Complexity ignore baseline
+        # Keep Biome complexity suppressions explicit during the migration:
+        # stale entries are reported, new ignores must update the baseline.
+        run: bash scripts/check-complexity-baseline.sh
       - name: Reject unix-only exec.Command shapes outside tmux/tui paths
         # Windows guard: bash/sh/chmod/ln/mkfifo/killall don't exist there.
         # Code that needs them must be in a _unix.go file with a build tag,

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -139,3 +139,8 @@ pre-push:
       # patterns. Cheap to run (git ls-files + wc -l), so it lives in
       # pre-push alongside the other smoke checks.
       run: bash scripts/check-file-size.sh
+    complexity-baseline:
+      # Keep Biome complexity suppressions forward-only. This lets the
+      # migration baseline land while forcing future broad complexity ignores
+      # to show up as explicit debt diffs.
+      run: bash scripts/check-complexity-baseline.sh

--- a/scripts/check-complexity-baseline.sh
+++ b/scripts/check-complexity-baseline.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# scripts/check-complexity-baseline.sh — forward-only baseline for Biome
+# complexity suppressions.
+#
+# The baseline lets migration PRs land existing complexity debt without making
+# future `biome-ignore lint/complexity/...` additions invisible. Removing an
+# ignore is encouraged and reported as stale baseline drift; adding one requires
+# an explicit scripts/complexity-baseline.txt diff.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+baseline="$repo_root/scripts/complexity-baseline.txt"
+
+current_f="$(mktemp)"
+baseline_norm="$(mktemp)"
+trap 'rm -f "$current_f" "$baseline_norm"' EXIT
+
+collect_current() {
+  { git -C "$repo_root" grep -nE 'biome-ignore(-all)?[[:space:]]+lint/complexity/' -- 'web/src' || true; } |
+    while IFS=: read -r rel_path _line_no text; do
+      [[ -n "${rel_path:-}" ]] || continue
+      rule=$(
+        printf '%s\n' "$text" |
+          sed -E 's/.*biome-ignore(-all)?[[:space:]]+(lint\/complexity\/[^:[:space:]}]+).*/\2/'
+      )
+      [[ "$rule" == lint/complexity/* ]] || continue
+      reason=$(
+        printf '%s\n' "$text" |
+          sed -E 's/.*biome-ignore(-all)?[[:space:]]+lint\/complexity\/[^:]+:[[:space:]]*//; s/[[:space:]]*\*\/\}?$//; s/[[:space:]]*\}$//; s/[[:space:]]+$//'
+      )
+      printf '%s|%s|%s\n' "$rel_path" "$rule" "$reason"
+    done |
+    awk -F '|' '{ key = $0; seen[key]++; printf "%s|%s|%d|%s\n", $1, $2, seen[key], $3 }'
+}
+
+if [[ "${1:-}" == "--print-current" ]]; then
+  collect_current
+  exit 0
+fi
+
+collect_current > "$current_f"
+
+if [[ -f "$baseline" ]]; then
+  sed -E '/^[[:space:]]*(#|$)/d; s/[[:space:]]+$//' "$baseline" > "$baseline_norm"
+else
+  : > "$baseline_norm"
+fi
+
+new_entries=$(sort "$current_f" | comm -23 - <(sort "$baseline_norm") || true)
+stale_entries=$(sort "$baseline_norm" | comm -23 - <(sort "$current_f") || true)
+
+if [[ -n "$stale_entries" ]]; then
+  echo "::group::stale complexity baseline entries"
+  printf '%s\n' "$stale_entries" | sed 's/^/  /'
+  echo "  -> remove these from scripts/complexity-baseline.txt"
+  echo "::endgroup::"
+fi
+
+if [[ -n "$new_entries" ]]; then
+  echo "::error::new Biome complexity ignores outside scripts/complexity-baseline.txt:"
+  printf '%s\n' "$new_entries" | sed 's/^/  /'
+  echo
+  echo "Either refactor the new complexity, or add a justified baseline entry."
+  exit 1
+fi
+
+count=$(wc -l < "$current_f" | tr -d ' ')
+echo "complexity baseline check OK ($count tracked complexity ignores)"

--- a/scripts/complexity-baseline.txt
+++ b/scripts/complexity-baseline.txt
@@ -1,0 +1,75 @@
+# Biome complexity suppression baseline.
+#
+# Format:
+#   path|rule|occurrence|reason
+#
+# The occurrence is per identical path+rule+reason tuple so duplicated scoped
+# suppressions in one file remain tracked without tying the baseline to line
+# numbers. This file is forward-only during the migration: entries can become
+# stale and be removed, but new entries require an explicit debt diff.
+
+web/src/api/wiki.test.ts|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/agents/AgentPanel.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/agents/AgentWizard.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/ArtifactsApp.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/apps/GraphApp.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/GraphApp.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/apps/GraphApp.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/SettingsApp.imageGen.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/SettingsApp.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/SkillsApp.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/SkillsApp.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/apps/SkillsApp.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/SkillsApp.tsx|lint/complexity/noExcessiveCognitiveComplexity|3|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/SystemSchedulesPanel.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/SystemSchedulesPanel.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/SystemSchedulesPanel.tsx|lint/complexity/noExcessiveCognitiveComplexity|3|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/TaskDetailModal.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/TaskDetailModal.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/apps/TaskDetailModal.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/apps/ThreadsApp.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/layout/CollapsedSidebar.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/layout/Sidebar.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/layout/UpgradeBanner.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/layout/UpgradeBanner.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/messages/Composer.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/messages/Composer.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/messages/Composer.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/messages/InterviewBar.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/messages/InterviewBar.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/messages/InterviewBar.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/messages/MessageBubble.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/messages/MessageFeed.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/messages/MessageFeed.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/messages/StreamLineView.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/messages/StreamLineView.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/messages/StreamLineView.tsx|lint/complexity/noExcessiveCognitiveComplexity|3|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/onboarding/Wizard.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/onboarding/Wizard.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/onboarding/Wizard.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/onboarding/Wizard.tsx|lint/complexity/noExcessiveCognitiveComplexity|3|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/onboarding/wizard/LocalLLMPicker.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/onboarding/wizard/Step4Team.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/search/SearchModal.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/search/SearchModal.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/search/SearchModal.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/search/SearchModal.tsx|lint/complexity/noExcessiveCognitiveComplexity|3|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/wiki/EntityBriefBar.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/wiki/EntityBriefBar.tsx|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/wiki/FactsOnFile.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/wiki/Pam.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/wiki/PlaybookExecutionLog.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/wiki/WikiAudit.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/wiki/WikiEditor.test.tsx|lint/complexity/noExcessiveLinesPerFunction|1|Existing function length is baselined for a focused follow-up refactor.
+web/src/components/wiki/WikiEditor.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/components/wiki/WikiLint.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/hooks/useHashRouter.ts|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/hooks/useHashRouter.ts|lint/complexity/noExcessiveCognitiveComplexity|2|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/hooks/useHashRouter.ts|lint/complexity/noExcessiveCognitiveComplexity|3|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/hooks/useKeyboardShortcuts.ts|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/lib/messageMarkdown.tsx|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/lib/wikilink.ts|lint/complexity/noExcessiveCognitiveComplexity|1|Existing cognitive complexity is baselined for a focused follow-up refactor.
+web/src/styles/global.css|lint/complexity/noImportantStyles|1|Responsive panel width override must win over fixed desktop sizing.
+web/src/styles/global.css|lint/complexity/noImportantStyles|1|Mobile full-width panel override must win over wider breakpoints.
+web/src/styles/global.css|lint/complexity/noImportantStyles|1|Reduced-motion override must beat animation declarations.
+web/src/styles/global.css|lint/complexity/noImportantStyles|1|Reduced-motion override must beat transition declarations.

--- a/web/src/api/wiki.test.ts
+++ b/web/src/api/wiki.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as client from "./client";
 import * as api from "./wiki";
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 describe("wiki api client", () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -170,6 +170,7 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
     }
   }
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
   async function handleToggleEnabled(next: boolean) {
     if (!canToggle || toggling) return;
     setToggling(true);

--- a/web/src/components/agents/AgentWizard.tsx
+++ b/web/src/components/agents/AgentWizard.tsx
@@ -47,6 +47,7 @@ interface AgentWizardProps {
   onCreated?: () => void;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export function AgentWizard({ open, onClose, onCreated }: AgentWizardProps) {
   const [mode, setMode] = useState<WizardMode>("describe");
   const [prompt, setPrompt] = useState("");

--- a/web/src/components/apps/ArtifactsApp.tsx
+++ b/web/src/components/apps/ArtifactsApp.tsx
@@ -83,6 +83,7 @@ function classifyMemberActivity(member: OfficeMember): {
   return { state: "lurking", label: "Idle" };
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 export function ArtifactsApp() {
   const tasks = useQuery({
     queryKey: ["activity-tasks"],

--- a/web/src/components/apps/GraphApp.tsx
+++ b/web/src/components/apps/GraphApp.tsx
@@ -109,6 +109,7 @@ interface SimOpts {
   iterations: number;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function runSimulation(
   nodes: SimNode[],
   edges: SimEdge[],
@@ -215,6 +216,7 @@ function runSimulation(
 
 // ── Component ────────────────────────────────────────────────────
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 export function GraphApp() {
   const setCurrentApp = useAppStore((s) => s.setCurrentApp);
   const setWikiPath = useAppStore((s) => s.setWikiPath);
@@ -417,6 +419,7 @@ export function GraphApp() {
               </defs>
 
               {/* Edges first so nodes paint on top. */}
+              {/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor. */}
               {simResult.edges.map((e, i) => {
                 const a = nodesById.get(e.from);
                 const b = nodesById.get(e.to);

--- a/web/src/components/apps/SettingsApp.imageGen.tsx
+++ b/web/src/components/apps/SettingsApp.imageGen.tsx
@@ -61,6 +61,7 @@ function StatusDot({ s }: { s: ImageProviderStatus }) {
   );
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function ProviderCard({ s }: { s: ImageProviderStatus }) {
   const qc = useQueryClient();
   const [apiKey, setApiKey] = useState("");

--- a/web/src/components/apps/SettingsApp.tsx
+++ b/web/src/components/apps/SettingsApp.tsx
@@ -362,6 +362,7 @@ interface LocalProviderCardProps {
   hostPlatform: ReturnType<typeof detectHostPlatform>;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function LocalProviderCard({
   meta,
   status,

--- a/web/src/components/apps/SkillsApp.tsx
+++ b/web/src/components/apps/SkillsApp.tsx
@@ -761,6 +761,8 @@ function isTerminalTaskStatus(s: string | undefined): boolean {
   return ["done", "completed", "blocked", "cancelled", "canceled"].includes(s);
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 function SkillActions({
   status,
   skillName,
@@ -1336,6 +1338,7 @@ interface SkillPreviewBodyProps {
   onSaved?: (updated: Skill) => void;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function SkillPreviewBody({
   skill,
   onDirtyChange,
@@ -1611,6 +1614,7 @@ function ProposedPreviewBody({ skill }: { skill: Skill }) {
   );
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function SkillCard({
   skill,
   onPreview,

--- a/web/src/components/apps/SkillsApp.tsx
+++ b/web/src/components/apps/SkillsApp.tsx
@@ -174,11 +174,8 @@ export function SkillsApp() {
   const [compileState, setCompileState] = useState<CompileState>("idle");
   const [ownerFilter, setOwnerFilter] = useState<OwnerFilterValue>("all");
 
-  // Hydrate filter from localStorage on mount, validated against the
-  // current office. If the saved slug no longer maps to a member (agent
-  // removed), drop back to "all" instead of rendering an empty list with
-  // no error message. We wait for officeMembers to resolve so a still-
-  // loading roster doesn't wipe a valid filter.
+  // Hydrate filter after officeMembers loads; if the saved slug no longer
+  // exists, fall back to "all" instead of rendering an empty owner result.
   useEffect(() => {
     if (officeMembers === undefined) return;
     const stored = readOwnerFilter();
@@ -883,9 +880,7 @@ function SkillActions({
 
   const handleDisable = useCallback(() => {
     if (!skillName) return;
-    // Don't let archive/disable race with a live invoke. The polling
-    // skill_run task is still settling — disabling here would hide the
-    // chip the user is watching and mask the run result.
+    // Do not hide the live run chip while the polling task is still settling.
     if (invokePhase !== "idle") return;
     setActionPending(true);
     disableSkill(skillName)

--- a/web/src/components/apps/SystemSchedulesPanel.tsx
+++ b/web/src/components/apps/SystemSchedulesPanel.tsx
@@ -112,6 +112,7 @@ interface ScheduleRowProps {
   floorState: FloorState;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function ScheduleRow({ job, floorState }: ScheduleRowProps) {
   const queryClient = useQueryClient();
   const slug = job.slug ?? "";
@@ -148,6 +149,7 @@ function ScheduleRow({ job, floorState }: ScheduleRowProps) {
       setPending(true);
       setError(null);
       patchSchedulerJob(slug, patchBody)
+        // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
         .then((res: PatchSchedulerJobResponse) => {
           // Refresh the query so the row reflects server-canonical state
           // (status, next_run, etc.) — the optimistic update we already
@@ -204,6 +206,7 @@ function ScheduleRow({ job, floorState }: ScheduleRowProps) {
     submitPatch({ enabled: next });
   }, [isReadOnly, pending, enabled, submitPatch]);
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
   const handleIntervalCommit = useCallback(() => {
     if (isReadOnly || isCron) return;
     if (!floorReady) {

--- a/web/src/components/apps/TaskDetailModal.tsx
+++ b/web/src/components/apps/TaskDetailModal.tsx
@@ -142,6 +142,7 @@ function displayMemoryStatus(status: string): string {
   return status.replace(/_/g, " ");
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export function taskMemoryWorkflowBadge(
   workflow?: TaskMemoryWorkflow | null,
 ): TaskMemoryWorkflowBadge | null {
@@ -207,6 +208,8 @@ export function taskMemoryWorkflowBadge(
   };
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 export function TaskDetailModal({ task, onClose }: TaskDetailModalProps) {
   const queryClient = useQueryClient();
   const { data: memberData } = useQuery({

--- a/web/src/components/apps/ThreadsApp.tsx
+++ b/web/src/components/apps/ThreadsApp.tsx
@@ -81,6 +81,7 @@ export function ThreadsApp() {
         </div>
       ) : (
         <div className="threads-view-list">
+          {/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor. */}
           {threads.map((t) => {
             const agent = members.find((m) => m.slug === t.message.from);
             const preview =

--- a/web/src/components/layout/CollapsedSidebar.tsx
+++ b/web/src/components/layout/CollapsedSidebar.tsx
@@ -51,6 +51,7 @@ const APP_ICONS: Record<string, ComponentType<{ className?: string }>> = {
 type Popover = "team" | "channels" | "usage" | null;
 type HintState = { label: string; y: number } | null;
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export function CollapsedSidebar() {
   const toggleCollapsed = useAppStore((s) => s.toggleSidebarCollapsed);
   const currentApp = useAppStore((s) => s.currentApp);

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -48,6 +48,7 @@ function SectionToggle({
   );
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export function Sidebar() {
   const sidebarAgentsOpen = useAppStore((s) => s.sidebarAgentsOpen);
   const toggleSidebarAgents = useAppStore((s) => s.toggleSidebarAgents);

--- a/web/src/components/layout/UpgradeBanner.tsx
+++ b/web/src/components/layout/UpgradeBanner.tsx
@@ -78,6 +78,8 @@ type RunState =
   | { phase: "running" }
   | { phase: "done"; result: UpgradeRunResult };
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 export function UpgradeBanner() {
   const forced = useMemo(readForcedPair, []);
   // Suppress in dev so local devs aren't nagged by the placeholder VERSION.

--- a/web/src/components/messages/Composer.tsx
+++ b/web/src/components/messages/Composer.tsx
@@ -109,6 +109,7 @@ interface OutboundMessage {
  * Some commands (e.g. `/ask`) rewrite the input and invoke sendAsMessage so
  * the broker sees a normal user message with the right @mention routing.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function handleSlashCommand(input: string, handlers: SlashHandlers): boolean {
   const parts = input.split(/\s+/);
   const cmd = parts[0].toLowerCase();
@@ -338,6 +339,7 @@ function emptyHistoryState(): HistoryState {
   return { index: -1, draftStash: null, entries: [] };
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 export function Composer() {
   const currentChannel = useAppStore((s) => s.currentChannel);
   const [text, setText] = useState("");
@@ -510,6 +512,7 @@ export function Composer() {
   }, []);
 
   const handleKeyDown = useCallback(
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
     (e: React.KeyboardEvent) => {
       // Autocomplete navigation runs first
       if (acItems.length > 0) {

--- a/web/src/components/messages/InterviewBar.tsx
+++ b/web/src/components/messages/InterviewBar.tsx
@@ -31,6 +31,8 @@ import { showNotice } from "../ui/Toast";
  * - kind="skill_proposal" with metadata.similar_to_existing renders a
  *   warning banner with a [Compare] action above the standard options.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 export function InterviewBar() {
   const { pending } = useRequests();
   const queryClient = useQueryClient();
@@ -104,6 +106,7 @@ export function InterviewBar() {
     return ar - br;
   });
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
   const submit = async (option: InterviewOption, text?: string) => {
     if (submitting) return;
     setSubmitting(true);

--- a/web/src/components/messages/MessageBubble.tsx
+++ b/web/src/components/messages/MessageBubble.tsx
@@ -32,6 +32,7 @@ interface MessageBubbleProps {
   onCopyLink?: (id: string) => void;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export function MessageBubble({
   message,
   grouped = false,

--- a/web/src/components/messages/MessageFeed.tsx
+++ b/web/src/components/messages/MessageFeed.tsx
@@ -25,6 +25,7 @@ type FeedElement =
       replies: ThreadMessage[];
     };
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export function MessageFeed() {
   const currentChannel = useAppStore((s) => s.currentChannel);
   const setActiveThreadId = useAppStore((s) => s.setActiveThreadId);
@@ -164,6 +165,7 @@ export function MessageFeed() {
 
   return (
     <div className="messages" ref={containerRef}>
+      {/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor. */}
       {elements.map((el) => {
         if (el.type === "date") {
           return (

--- a/web/src/components/messages/StreamLineView.tsx
+++ b/web/src/components/messages/StreamLineView.tsx
@@ -15,6 +15,7 @@ interface StreamLineViewProps {
  * lines, tool calls render as collapsible cards, token totals render as
  * a single line. Everything else falls back to pretty-printed JSON.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export function StreamLineView({ line, compact = false }: StreamLineViewProps) {
   const { data, parsed } = line;
   if (!parsed) {
@@ -330,6 +331,7 @@ function ToolCallCard({
     item.error !== null && item.error !== undefined && item.error !== "";
   const errorField = hasError ? item.error : null;
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
   const { summaryArg, summaryResult, summaryError } = useMemo(() => {
     const pick = [
       args.content,
@@ -629,6 +631,7 @@ function keyedStreamValues<T>(values: readonly T[]) {
 
 /* ───── JSON tree primitive (shared by both card and fallback paths) ───── */
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function Value({
   value,
   depth,

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -50,6 +50,7 @@ interface WizardProps {
   onComplete?: () => void;
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 export function Wizard({ onComplete }: WizardProps) {
   const setOnboardingComplete = useAppStore((s) => s.setOnboardingComplete);
 
@@ -372,6 +373,7 @@ export function Wizard({ onComplete }: WizardProps) {
   // useMemo because the surface is small (6 checks) and recomputation only
   // happens when one of these inputs changes. Matches the TUI's six-item
   // list in init_flow.go readinessChecks().
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
   const readinessChecks: ReadinessCheck[] = (() => {
     const checks: ReadinessCheck[] = [];
 
@@ -526,6 +528,7 @@ export function Wizard({ onComplete }: WizardProps) {
 
   // Complete onboarding
   const finishOnboarding = useCallback(
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
     async (skipTask: boolean) => {
       setSubmitting(true);
       setSubmitError("");
@@ -662,6 +665,7 @@ export function Wizard({ onComplete }: WizardProps) {
   // The NexSignupPanel handles its own Enter inside the email input via an
   // onKeyDown below, so we bail out when that's the focused target.
   useEffect(() => {
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
         closeNexSignup();

--- a/web/src/components/onboarding/wizard/LocalLLMPicker.tsx
+++ b/web/src/components/onboarding/wizard/LocalLLMPicker.tsx
@@ -118,6 +118,7 @@ export function LocalLLMPicker({ selected, onSelect }: LocalLLMPickerProps) {
       )}
       {!loading && (
         <div className="runtime-grid">
+          {/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor. */}
           {LOCAL_PROVIDER_LABELS.map((meta) => {
             const s = byKind.get(meta.kind);
             // When `s` is undefined the status probe didn't return a

--- a/web/src/components/onboarding/wizard/Step4Team.tsx
+++ b/web/src/components/onboarding/wizard/Step4Team.tsx
@@ -31,6 +31,7 @@ export function TeamStep({ agents, onToggle, onNext, onBack }: TeamStepProps) {
           </div>
         ) : (
           <div className="wiz-team-grid">
+            {/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor. */}
             {agents.map((a) => {
               // Lead agent is always included and cannot be unchecked here.
               // The backend also refuses to remove or disable any BuiltIn

--- a/web/src/components/search/SearchModal.tsx
+++ b/web/src/components/search/SearchModal.tsx
@@ -72,6 +72,7 @@ function parseNotebookPath(
   return { agent, entry };
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 export function SearchModal() {
   const searchOpen = useAppStore((s) => s.searchOpen);
   const setSearchOpen = useAppStore((s) => s.setSearchOpen);
@@ -201,6 +202,7 @@ export function SearchModal() {
     setComposerSearchInitialQuery,
   ]);
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
   const items = useMemo<PaletteItem[]>(() => {
     const q = query.trim().toLowerCase();
     const list: PaletteItem[] = [];
@@ -354,6 +356,7 @@ export function SearchModal() {
 
   useEffect(() => {
     if (!searchOpen) return;
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === "Escape") {
         e.preventDefault();
@@ -448,6 +451,7 @@ export function SearchModal() {
             grouped.map((g) => (
               <div key={g.group} className="cmd-palette-group">
                 <div className="cmd-palette-group-title">{g.group}</div>
+                {/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor. */}
                 {g.items.map(({ item, flatIdx }) => (
                   <button
                     key={item.id}

--- a/web/src/components/wiki/EntityBriefBar.tsx
+++ b/web/src/components/wiki/EntityBriefBar.tsx
@@ -52,6 +52,7 @@ export default function EntityBriefBar({
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
     (async () => {
       try {
         const rows = await fetchBriefs();
@@ -164,6 +165,7 @@ export default function EntityBriefBar({
   );
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function formatRelativeTime(iso: string): string {
   const t = Date.parse(iso);
   if (Number.isNaN(t)) return iso;

--- a/web/src/components/wiki/FactsOnFile.tsx
+++ b/web/src/components/wiki/FactsOnFile.tsx
@@ -105,6 +105,7 @@ export default function FactsOnFile({ kind, slug }: FactsOnFileProps) {
       ) : (
         <>
           <ol className="wk-facts-items">
+            {/* biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor. */}
             {visibleFacts.map((f) => {
               const validity = formatValidity(f);
               return (

--- a/web/src/components/wiki/Pam.tsx
+++ b/web/src/components/wiki/Pam.tsx
@@ -48,6 +48,7 @@ const STATUS_CLEAR_MS = 4000;
  * so we update the status line without polling. Article-scoped actions
  * disable themselves when no article is open.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export default function Pam({ articlePath, onActionDone }: PamProps) {
   const [menu, setMenu] = useState<PamMenuEntry[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);

--- a/web/src/components/wiki/PlaybookExecutionLog.tsx
+++ b/web/src/components/wiki/PlaybookExecutionLog.tsx
@@ -31,6 +31,7 @@ type SynthState = "idle" | "pending" | "success" | "error";
  * SSE event when synthesis commits; this component listens for
  * playbook:synthesized specifically to refresh its own status strip.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export default function PlaybookExecutionLog({
   slug,
 }: PlaybookExecutionLogProps) {

--- a/web/src/components/wiki/WikiArticle.test.tsx
+++ b/web/src/components/wiki/WikiArticle.test.tsx
@@ -541,8 +541,11 @@ describe("<WikiArticle synthesis status>", () => {
         screen.getByRole("heading", { name: "Customer X" }),
       ).toBeInTheDocument(),
     );
-    expect(screen.getByText("generating brief…")).toBeInTheDocument();
-    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(
+      screen.getByRole("status", {
+        name: "Brief is being generated from recent activity",
+      }),
+    ).toHaveTextContent("generating brief…");
   });
 
   it("shows no 'generating brief…' badge when synthesis_queued is false (ICP Example 3)", async () => {

--- a/web/src/components/wiki/WikiAudit.tsx
+++ b/web/src/components/wiki/WikiAudit.tsx
@@ -28,6 +28,7 @@ interface WikiAuditProps {
 
 type AuthorBucket = "all" | "agents" | "system" | string;
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export default function WikiAudit({ onNavigate }: WikiAuditProps) {
   const [entries, setEntries] = useState<WikiAuditEntry[] | null>(null);
   const [loading, setLoading] = useState(true);

--- a/web/src/components/wiki/WikiEditor.test.tsx
+++ b/web/src/components/wiki/WikiEditor.test.tsx
@@ -25,6 +25,7 @@ function setLocalStorageDraft(
   );
 }
 
+// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 describe("<WikiEditor>", () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -138,6 +138,7 @@ function useIsMobileViewport(): boolean {
  * pipeline as `WikiArticle` so wikilinks, tables, and image embeds render
  * identically.
  */
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export default function WikiEditor({
   path,
   initialContent,

--- a/web/src/components/wiki/WikiLint.tsx
+++ b/web/src/components/wiki/WikiLint.tsx
@@ -20,6 +20,7 @@ interface WikiLintProps {
   onNavigate: (path: string | null) => void;
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 export default function WikiLint({ onNavigate }: WikiLintProps) {
   const [report, setReport] = useState<LintReport | null>(null);
   const [loading, setLoading] = useState(false);

--- a/web/src/hooks/useHashRouter.ts
+++ b/web/src/hooks/useHashRouter.ts
@@ -16,6 +16,7 @@ type Route =
   | { view: "notebooks"; agentSlug: string | null; entrySlug: string | null }
   | { view: "reviews" };
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function parseHash(hash: string): Route {
   const cleaned = hash.replace(/^#\/?/, "");
   const parts = cleaned.split("/").filter(Boolean);
@@ -53,6 +54,7 @@ function parseHash(hash: string): Route {
   return { view: "channel", channel: "general" };
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
 function stateToHash(state: {
   currentApp: string | null;
   currentChannel: string;
@@ -130,6 +132,7 @@ export function useHashRouter() {
 
   // Apply current hash on mount and when it changes
   useEffect(() => {
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
     function applyHash() {
       if (ignoreNextHashChange.current) {
         ignoreNextHashChange.current = false;

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -29,6 +29,7 @@ export function useKeyboardShortcuts() {
   const queryClient = useQueryClient();
 
   useEffect(() => {
+    // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
     function handleKeyDown(e: KeyboardEvent) {
       // Cmd+K or Ctrl+K → command palette
       if ((e.metaKey || e.ctrlKey) && e.key === "k") {

--- a/web/src/lib/messageMarkdown.tsx
+++ b/web/src/lib/messageMarkdown.tsx
@@ -76,6 +76,7 @@ interface MdParent {
 export function mentionRemarkPlugin() {
   return function plugin() {
     return function transformer(tree: unknown) {
+      // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
       walk(tree as MdAnyNode, (parent) => {
         const { children } = parent;
         for (let i = 0; i < children.length; i++) {

--- a/web/src/lib/wikilink.ts
+++ b/web/src/lib/wikilink.ts
@@ -93,6 +93,7 @@ interface MdParent {
 export function wikiLinkRemarkPlugin(resolver: (slug: string) => boolean) {
   return function plugin() {
     return function transformer(tree: unknown) {
+      // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
       walk(tree as MdAnyNode, (parent) => {
         const { children } = parent;
         for (let i = 0; i < children.length; i++) {


### PR DESCRIPTION
## Summary
- documents the remaining complexity and line-count diagnostics as an explicit baseline
- keeps the audit stack behavior-preserving by avoiding broad UI refactors in the lint cleanup path
- brings `bun run check` to zero diagnostics across the web source tree

## Validation
- bun run check
- bun run build
- bun run test (passes; expected localhost:3000 ECONNREFUSED noise remains)
- git diff --check audit/residual-lint-warnings-20260502
- commitlint: ./node_modules/.bin/commitlint --from HEAD~1 --to HEAD
