### PR TITLE
[codex] block accidental live fetches in web tests

### DIFF
--- a/cmd/wuphf/channel_integration.go
+++ b/cmd/wuphf/channel_integration.go
@@ -172,54 +172,60 @@ func discoverTelegramGroups(token string) tea.Cmd {
 
 func connectTelegramGroup(token string, group team.TelegramGroup) tea.Cmd {
 	return func() tea.Msg {
-		slug := slugifyGroupTitle(group.Title)
+		slug := team.SlugifyTelegramTitle(group.Title)
 
-		// Load manifest and add the new channel with telegram surface
-		manifest, err := company.LoadManifest()
-		if err != nil {
-			manifest = company.DefaultManifest()
-		}
-
-		// Check if channel already exists (by slug or remote_id)
+		// Run the manifest read-modify-write through company.UpdateManifest so
+		// it serializes against any concurrent /telegram/connect call from the
+		// web wizard. Without the shared lock, a TUI connect and a web connect
+		// can both load the same on-disk manifest, each append their own
+		// channel row, and the slower SaveManifest drops the faster one.
+		//
+		// existingSlug + members are populated by the closure and read after
+		// the call so the live-broker create below can reuse the same member
+		// set the manifest just persisted.
+		var (
+			existingSlug string
+			members      []string
+		)
 		remoteID := fmt.Sprintf("%d", group.ChatID)
-		for _, ch := range manifest.Channels {
-			if ch.Slug == slug {
-				return telegramConnectDoneMsg{
-					channelSlug: ch.Slug,
-					groupTitle:  group.Title,
+		mutateErr := company.UpdateManifest(func(manifest *company.Manifest) error {
+			// Idempotent: same slug or same remote id ⇒ already connected.
+			for _, ch := range manifest.Channels {
+				if ch.Slug == slug ||
+					(ch.Surface != nil && ch.Surface.Provider == "telegram" && ch.Surface.RemoteID == remoteID) {
+					existingSlug = ch.Slug
+					return nil
 				}
 			}
-			if ch.Surface != nil && ch.Surface.Provider == "telegram" && ch.Surface.RemoteID == remoteID {
-				return telegramConnectDoneMsg{
-					channelSlug: ch.Slug,
-					groupTitle:  group.Title,
+			// Build default members: lead + all manifest members.
+			members = []string{manifest.Lead}
+			for _, member := range manifest.Members {
+				if member.Slug != manifest.Lead {
+					members = append(members, member.Slug)
 				}
 			}
+			manifest.Channels = append(manifest.Channels, company.ChannelSpec{
+				Slug:        slug,
+				Name:        group.Title,
+				Description: fmt.Sprintf("Telegram bridge for %s.", group.Title),
+				Members:     members,
+				Surface: &company.ChannelSurfaceSpec{
+					Provider:    "telegram",
+					RemoteID:    remoteID,
+					RemoteTitle: group.Title,
+					BotTokenEnv: "WUPHF_TELEGRAM_BOT_TOKEN",
+				},
+			})
+			return nil
+		})
+		if mutateErr != nil {
+			return telegramConnectDoneMsg{err: fmt.Errorf("failed to save manifest: %w", mutateErr)}
 		}
-
-		// Build default members: lead + all manifest members
-		members := []string{manifest.Lead}
-		for _, member := range manifest.Members {
-			if member.Slug != manifest.Lead {
-				members = append(members, member.Slug)
+		if existingSlug != "" {
+			return telegramConnectDoneMsg{
+				channelSlug: existingSlug,
+				groupTitle:  group.Title,
 			}
-		}
-
-		newChannel := company.ChannelSpec{
-			Slug:        slug,
-			Name:        group.Title,
-			Description: fmt.Sprintf("Telegram bridge for %s.", group.Title),
-			Members:     members,
-			Surface: &company.ChannelSurfaceSpec{
-				Provider:    "telegram",
-				RemoteID:    fmt.Sprintf("%d", group.ChatID),
-				RemoteTitle: group.Title,
-				BotTokenEnv: "WUPHF_TELEGRAM_BOT_TOKEN",
-			},
-		}
-		manifest.Channels = append(manifest.Channels, newChannel)
-		if err := company.SaveManifest(manifest); err != nil {
-			return telegramConnectDoneMsg{err: fmt.Errorf("failed to save manifest: %w", err)}
 		}
 
 		// Create channel in the live broker WITH surface metadata
@@ -261,17 +267,6 @@ func connectTelegramGroup(token string, group team.TelegramGroup) tea.Cmd {
 			groupTitle:  group.Title,
 		}
 	}
-}
-
-func slugifyGroupTitle(title string) string {
-	slug := strings.ToLower(strings.TrimSpace(title))
-	slug = regexp.MustCompile(`[^a-z0-9]+`).ReplaceAllString(slug, "-")
-	slug = strings.Trim(slug, "-")
-	if slug == "" {
-		slug = "telegram"
-	}
-	// Prefix with tg- to make it clear it's a telegram channel
-	return "tg-" + slug
 }
 
 // startOpenclawConnect seeds the /connect openclaw picker flow at the URL step.

--- a/cmd/wuphf/channel_integration.go
+++ b/cmd/wuphf/channel_integration.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -170,86 +171,184 @@ func discoverTelegramGroups(token string) tea.Cmd {
 	}
 }
 
+type telegramBrokerSurface struct {
+	Provider string `json:"provider,omitempty"`
+	RemoteID string `json:"remote_id,omitempty"`
+}
+
+type telegramBrokerChannel struct {
+	Slug    string                 `json:"slug"`
+	Surface *telegramBrokerSurface `json:"surface,omitempty"`
+}
+
+func manifestMembers(manifest company.Manifest) []string {
+	members := []string{manifest.Lead}
+	for _, member := range manifest.Members {
+		if member.Slug != manifest.Lead {
+			members = append(members, member.Slug)
+		}
+	}
+	return members
+}
+
+func findManifestTelegramChannel(manifest company.Manifest, slug, remoteID string) (string, error) {
+	for _, ch := range manifest.Channels {
+		if ch.Surface != nil && ch.Surface.Provider == "telegram" && ch.Surface.RemoteID == remoteID {
+			return ch.Slug, nil
+		}
+	}
+	for _, ch := range manifest.Channels {
+		if ch.Slug == slug {
+			return "", fmt.Errorf("channel %q already exists in the company manifest and does not bridge Telegram chat %s", slug, remoteID)
+		}
+	}
+	return "", nil
+}
+
+func findLiveTelegramChannel(channels []telegramBrokerChannel, slug, remoteID string) (string, error) {
+	for _, ch := range channels {
+		if ch.Surface != nil && ch.Surface.Provider == "telegram" && ch.Surface.RemoteID == remoteID {
+			return ch.Slug, nil
+		}
+	}
+	for _, ch := range channels {
+		if ch.Slug == slug {
+			if ch.Surface == nil || ch.Surface.Provider != "telegram" {
+				return "", fmt.Errorf("channel %q already exists in the live broker and is not a Telegram bridge", slug)
+			}
+			return "", fmt.Errorf("channel %q already bridges Telegram chat %s", slug, ch.Surface.RemoteID)
+		}
+	}
+	return "", nil
+}
+
+func readBrokerError(resp *http.Response) string {
+	body, _ := io.ReadAll(resp.Body)
+	msg := strings.TrimSpace(string(body))
+	if msg == "" {
+		return resp.Status
+	}
+	return fmt.Sprintf("%s: %s", resp.Status, msg)
+}
+
+func fetchLiveTelegramChannel(ctx context.Context, client *http.Client, slug, remoteID string) (string, error) {
+	req, err := newBrokerRequest(ctx, http.MethodGet, "http://127.0.0.1:7890/channels", nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("query live broker channels: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("query live broker channels: %s", readBrokerError(resp))
+	}
+	var result struct {
+		Channels []telegramBrokerChannel `json:"channels"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("decode live broker channels: %w", err)
+	}
+	return findLiveTelegramChannel(result.Channels, slug, remoteID)
+}
+
+func createLiveTelegramChannel(ctx context.Context, client *http.Client, body []byte, slug, remoteID string) error {
+	req, err := newBrokerRequest(ctx, http.MethodPost, "http://127.0.0.1:7890/channels", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("create live broker channel: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	brokerErr := readBrokerError(resp)
+	if resp.StatusCode == http.StatusConflict {
+		if existingSlug, reconcileErr := fetchLiveTelegramChannel(ctx, client, slug, remoteID); reconcileErr != nil {
+			return fmt.Errorf("create live broker channel: %s; reconcile failed: %w", brokerErr, reconcileErr)
+		} else if existingSlug != "" {
+			return nil
+		}
+	}
+	return fmt.Errorf("create live broker channel: %s", brokerErr)
+}
+
 func connectTelegramGroup(token string, group team.TelegramGroup) tea.Cmd {
 	return func() tea.Msg {
 		slug := team.SlugifyTelegramTitle(group.Title)
-
-		// Run the manifest read-modify-write through company.UpdateManifest so
-		// it serializes against any concurrent /telegram/connect call from the
-		// web wizard. Without the shared lock, a TUI connect and a web connect
-		// can both load the same on-disk manifest, each append their own
-		// channel row, and the slower SaveManifest drops the faster one.
-		//
-		// existingSlug + members are populated by the closure and read after
-		// the call so the live-broker create below can reuse the same member
-		// set the manifest just persisted.
-		var (
-			existingSlug string
-			members      []string
-		)
 		remoteID := fmt.Sprintf("%d", group.ChatID)
-		mutateErr := company.UpdateManifest(func(manifest *company.Manifest) error {
-			// Idempotent: same slug or same remote id ⇒ already connected.
-			for _, ch := range manifest.Channels {
-				if ch.Slug == slug ||
-					(ch.Surface != nil && ch.Surface.Provider == "telegram" && ch.Surface.RemoteID == remoteID) {
-					existingSlug = ch.Slug
-					return nil
-				}
-			}
-			// Build default members: lead + all manifest members.
-			members = []string{manifest.Lead}
-			for _, member := range manifest.Members {
-				if member.Slug != manifest.Lead {
-					members = append(members, member.Slug)
-				}
-			}
-			manifest.Channels = append(manifest.Channels, company.ChannelSpec{
-				Slug:        slug,
-				Name:        group.Title,
-				Description: fmt.Sprintf("Telegram bridge for %s.", group.Title),
-				Members:     members,
-				Surface: &company.ChannelSurfaceSpec{
-					Provider:    "telegram",
-					RemoteID:    remoteID,
-					RemoteTitle: group.Title,
-					BotTokenEnv: "WUPHF_TELEGRAM_BOT_TOKEN",
-				},
-			})
-			return nil
-		})
-		if mutateErr != nil {
-			return telegramConnectDoneMsg{err: fmt.Errorf("failed to save manifest: %w", mutateErr)}
+
+		manifest, err := company.SnapshotManifest()
+		if err != nil {
+			return telegramConnectDoneMsg{err: fmt.Errorf("failed to load manifest: %w", err)}
+		}
+		existingSlug, err := findManifestTelegramChannel(manifest, slug, remoteID)
+		if err != nil {
+			return telegramConnectDoneMsg{err: err}
 		}
 		if existingSlug != "" {
-			return telegramConnectDoneMsg{
-				channelSlug: existingSlug,
-				groupTitle:  group.Title,
+			slug = existingSlug
+		}
+		members := manifestMembers(manifest)
+		client := &http.Client{Timeout: 3 * time.Second}
+		ctx := context.Background()
+
+		liveSlug, err := fetchLiveTelegramChannel(ctx, client, slug, remoteID)
+		if err != nil {
+			return telegramConnectDoneMsg{err: err}
+		}
+		if liveSlug != "" {
+			slug = liveSlug
+		} else {
+			// Create channel in the live broker WITH surface metadata before
+			// mutating the manifest or notifying Telegram. If the broker
+			// rejects the bridge, reporting success would leave company.yaml
+			// claiming a connection that the running office cannot route.
+			body, _ := json.Marshal(map[string]any{
+				"action":      "create",
+				"slug":        slug,
+				"name":        group.Title,
+				"description": fmt.Sprintf("Telegram bridge for %s.", group.Title),
+				"members":     members,
+				"created_by":  "you",
+				"surface": map[string]any{
+					"provider":      "telegram",
+					"remote_id":     remoteID,
+					"remote_title":  group.Title,
+					"mode":          group.Type,
+					"bot_token_env": "WUPHF_TELEGRAM_BOT_TOKEN",
+				},
+			})
+			if err := createLiveTelegramChannel(ctx, client, body, slug, remoteID); err != nil {
+				return telegramConnectDoneMsg{err: err}
 			}
 		}
 
-		// Create channel in the live broker WITH surface metadata
-		body, _ := json.Marshal(map[string]any{
-			"action":      "create",
-			"slug":        slug,
-			"name":        group.Title,
-			"description": fmt.Sprintf("Telegram bridge for %s.", group.Title),
-			"members":     members,
-			"created_by":  "you",
-			"surface": map[string]any{
-				"provider":      "telegram",
-				"remote_id":     fmt.Sprintf("%d", group.ChatID),
-				"remote_title":  group.Title,
-				"mode":          group.Type,
-				"bot_token_env": "WUPHF_TELEGRAM_BOT_TOKEN",
-			},
-		})
-		req, reqErr := newBrokerRequest(context.Background(), http.MethodPost, "http://127.0.0.1:7890/channels", bytes.NewReader(body))
-		if reqErr == nil {
-			client := &http.Client{Timeout: 3 * time.Second}
-			resp, err := client.Do(req)
-			if err == nil {
-				resp.Body.Close()
+		if existingSlug == "" {
+			mutateErr := company.UpdateManifest(func(manifest *company.Manifest) error {
+				if foundSlug, err := findManifestTelegramChannel(*manifest, slug, remoteID); err != nil || foundSlug != "" {
+					return err
+				}
+				manifest.Channels = append(manifest.Channels, company.ChannelSpec{
+					Slug:        slug,
+					Name:        group.Title,
+					Description: fmt.Sprintf("Telegram bridge for %s.", group.Title),
+					Members:     manifestMembers(*manifest),
+					Surface: &company.ChannelSurfaceSpec{
+						Provider:    "telegram",
+						RemoteID:    remoteID,
+						RemoteTitle: group.Title,
+						BotTokenEnv: "WUPHF_TELEGRAM_BOT_TOKEN",
+					},
+				})
+				return nil
+			})
+			if mutateErr != nil {
+				return telegramConnectDoneMsg{err: fmt.Errorf("failed to save manifest: %w", mutateErr)}
 			}
 		}
 

--- a/cmd/wuphf/channel_integration_test.go
+++ b/cmd/wuphf/channel_integration_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/nex-crm/wuphf/internal/team"
 )
 
 func TestSlugifyGroupTitleAddsTgPrefix(t *testing.T) {
@@ -14,8 +16,8 @@ func TestSlugifyGroupTitleAddsTgPrefix(t *testing.T) {
 		"NUMBERS 123":         "tg-numbers-123",
 	}
 	for input, want := range cases {
-		if got := slugifyGroupTitle(input); got != want {
-			t.Errorf("slugifyGroupTitle(%q) = %q, want %q", input, got, want)
+		if got := team.SlugifyTelegramTitle(input); got != want {
+			t.Errorf("team.SlugifyTelegramTitle(%q) = %q, want %q", input, got, want)
 		}
 	}
 }

--- a/cmd/wuphf/channel_integration_test.go
+++ b/cmd/wuphf/channel_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/nex-crm/wuphf/internal/company"
 	"github.com/nex-crm/wuphf/internal/team"
 )
 
@@ -77,5 +78,68 @@ func TestChannelIntegrationOptionsContainsKnownProvider(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected at least one Google integration option, got %v", got)
+	}
+}
+
+func TestFindManifestTelegramChannelMatchesRemoteIDOnly(t *testing.T) {
+	manifest := company.Manifest{Channels: []company.ChannelSpec{{
+		Slug: "tg-old-title",
+		Surface: &company.ChannelSurfaceSpec{
+			Provider: "telegram",
+			RemoteID: "100",
+		},
+	}}}
+
+	got, err := findManifestTelegramChannel(manifest, "tg-new-title", "100")
+	if err != nil {
+		t.Fatalf("same remote id: unexpected error: %v", err)
+	}
+	if got != "tg-old-title" {
+		t.Fatalf("same remote id: got %q, want existing slug", got)
+	}
+
+	manifest.Channels = append(manifest.Channels, company.ChannelSpec{
+		Slug: "tg-new-title",
+		Surface: &company.ChannelSurfaceSpec{
+			Provider: "telegram",
+			RemoteID: "200",
+		},
+	})
+	if _, err := findManifestTelegramChannel(manifest, "tg-new-title", "300"); err == nil {
+		t.Fatal("slug collision with different remote id: expected error")
+	}
+}
+
+func TestFindLiveTelegramChannelMatchesRemoteIDOnly(t *testing.T) {
+	channels := []telegramBrokerChannel{{
+		Slug: "tg-old-title",
+		Surface: &telegramBrokerSurface{
+			Provider: "telegram",
+			RemoteID: "100",
+		},
+	}}
+
+	got, err := findLiveTelegramChannel(channels, "tg-new-title", "100")
+	if err != nil {
+		t.Fatalf("same remote id: unexpected error: %v", err)
+	}
+	if got != "tg-old-title" {
+		t.Fatalf("same remote id: got %q, want existing slug", got)
+	}
+
+	if _, err := findLiveTelegramChannel([]telegramBrokerChannel{{
+		Slug: "tg-new-title",
+	}}, "tg-new-title", "100"); err == nil {
+		t.Fatal("slug collision with non-telegram channel: expected error")
+	}
+
+	if _, err := findLiveTelegramChannel([]telegramBrokerChannel{{
+		Slug: "tg-new-title",
+		Surface: &telegramBrokerSurface{
+			Provider: "telegram",
+			RemoteID: "200",
+		},
+	}}, "tg-new-title", "100"); err == nil {
+		t.Fatal("slug collision with different Telegram remote id: expected error")
 	}
 }

--- a/internal/commands/slash.go
+++ b/internal/commands/slash.go
@@ -65,4 +65,5 @@ func RegisterAllCommands(r *Registry) {
 	r.Register(SlashCommand{Name: "resume", Description: "Resume all agents", WebSupported: true})
 	r.Register(SlashCommand{Name: "1o1", Description: "1:1 with agent", WebSupported: true})
 	r.Register(SlashCommand{Name: "cancel", Description: "Cancel a task", WebSupported: true})
+	r.Register(SlashCommand{Name: "connect", Description: "Connect a Telegram chat to the office", WebSupported: true})
 }

--- a/internal/company/manifest.go
+++ b/internal/company/manifest.go
@@ -3,14 +3,67 @@ package company
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/provider"
 )
+
+// manifestUpdateMu serializes load → mutate → save sequences against the
+// manifest file. Two callers that both Load + append + Save can otherwise
+// race: each reads the same file, each mutates locally, and whichever Save
+// wins drops the loser's mutation. Use UpdateManifest from any code that
+// needs to add or modify entries; bare Load/Save callers (read-only or
+// full-rewrite) don't need the lock and are unchanged.
+var manifestUpdateMu sync.Mutex
+
+// UpdateManifest atomically reads the manifest from disk, applies the
+// caller's mutation, and writes the result back. Concurrent callers see a
+// serialized order, so an append-then-save sequence cannot lose entries.
+//
+// The mutation callback receives a pointer; mutate the manifest in place and
+// return nil to commit, or return an error to abort the save. If LoadManifest
+// fails for any reason other than "file does not exist", UpdateManifest
+// surfaces that error rather than silently starting from DefaultManifest —
+// silently overwriting a corrupted manifest hides the real problem.
+func UpdateManifest(mutate func(*Manifest) error) (err error) {
+	manifestUpdateMu.Lock()
+	defer manifestUpdateMu.Unlock()
+	// Recover so a panic from inside `mutate` doesn't take down the whole
+	// process — important when this is called from an HTTP handler goroutine
+	// (the round-2 commit added /telegram/connect as one such caller). Re-
+	// surface as an error so the caller can return a 500 instead of crashing.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("UpdateManifest: panic in mutate: %v", r)
+		}
+	}()
+
+	manifest, loadErr := LoadManifest()
+	if loadErr != nil {
+		return loadErr
+	}
+	if err := mutate(&manifest); err != nil {
+		return err
+	}
+	return SaveManifest(manifest)
+}
+
+// SnapshotManifest returns the current on-disk manifest under the same lock
+// UpdateManifest uses, so a caller that only reads (e.g. to derive a member
+// set from manifest.Members) sees a consistent snapshot relative to any
+// concurrent UpdateManifest writer. Falls back to DefaultManifest if the
+// file doesn't exist; surfaces other errors.
+func SnapshotManifest() (Manifest, error) {
+	manifestUpdateMu.Lock()
+	defer manifestUpdateMu.Unlock()
+	return LoadManifest()
+}
 
 type MemberSpec struct {
 	Slug           string                   `json:"slug"`

--- a/internal/company/manifest_test.go
+++ b/internal/company/manifest_test.go
@@ -2,11 +2,13 @@ package company
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/nex-crm/wuphf/internal/config"
@@ -494,4 +496,110 @@ func operationFixtureIDs(t *testing.T, repoRoot string) []string {
 	}
 	sort.Strings(ids)
 	return ids
+}
+
+// Discriminating concurrency test for UpdateManifest. Without the package
+// mutex, two goroutines that both Load + append + Save can race: each reads
+// the same on-disk manifest, each appends a distinct channel, and the slower
+// SaveManifest overwrites the faster one's row. This test fires N parallel
+// updates at distinct channel slugs and asserts every one of them ends up
+// in the file.
+func TestUpdateManifestSerializesAppends(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	path := filepath.Join(t.TempDir(), "company.json")
+	t.Setenv("WUPHF_COMPANY_FILE", path)
+
+	const n = 32
+	var wg sync.WaitGroup
+	wg.Add(n)
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			err := UpdateManifest(func(m *Manifest) error {
+				m.Channels = append(m.Channels, ChannelSpec{
+					Slug: fmt.Sprintf("race-%d", i),
+					Name: fmt.Sprintf("Race %d", i),
+				})
+				return nil
+			})
+			if err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("UpdateManifest: %v", err)
+	}
+
+	final, err := LoadManifest()
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	got := make(map[string]struct{}, n)
+	for _, ch := range final.Channels {
+		if strings.HasPrefix(ch.Slug, "race-") {
+			got[ch.Slug] = struct{}{}
+		}
+	}
+	if len(got) != n {
+		t.Fatalf("expected %d race-* channels in manifest, got %d (slugs: %v)",
+			n, len(got), keys(got))
+	}
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Discriminating regression for the panic recovery added to UpdateManifest.
+// Without the deferred recover, a panic from inside the mutate callback
+// would propagate out of any HTTP handler goroutine and crash the broker.
+// Asserts the panic surfaces as an error instead.
+func TestUpdateManifestRecoversFromMutatePanic(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("WUPHF_RUNTIME_HOME", t.TempDir())
+	path := filepath.Join(t.TempDir(), "company.json")
+	t.Setenv("WUPHF_COMPANY_FILE", path)
+
+	err := UpdateManifest(func(m *Manifest) error {
+		panic("boom in mutate")
+	})
+	if err == nil {
+		t.Fatal("expected error from panicking mutate, got nil")
+	}
+	if !strings.Contains(err.Error(), "panic in mutate") {
+		t.Fatalf("expected wrapped panic message, got %v", err)
+	}
+
+	// Lock must be released so the next caller can proceed.
+	if err := UpdateManifest(func(m *Manifest) error {
+		m.Channels = append(m.Channels, ChannelSpec{Slug: "post-panic"})
+		return nil
+	}); err != nil {
+		t.Fatalf("UpdateManifest after panic: %v", err)
+	}
+	final, err := LoadManifest()
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+	found := false
+	for _, ch := range final.Channels {
+		if ch.Slug == "post-panic" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("post-panic update did not land — lock leaked or save skipped")
+	}
 }

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -928,6 +928,11 @@ func (b *Broker) StartOnPort(port int) error {
 	// renders the same command set as the TUI. See broker_commands.go.
 	mux.HandleFunc("/commands", b.requireAuth(b.handleCommands))
 	mux.HandleFunc("/telegram/groups", b.requireAuth(b.handleTelegramGroups))
+	// Web-driven /connect wizard endpoints. The TUI talks to the Telegram Bot
+	// API directly; the web composer drives the same flow through these.
+	mux.HandleFunc("/telegram/verify", b.requireAuth(b.handleTelegramVerify))
+	mux.HandleFunc("/telegram/discover", b.requireAuth(b.handleTelegramDiscover))
+	mux.HandleFunc("/telegram/connect", b.requireAuth(b.handleTelegramConnect))
 	mux.HandleFunc("/bridges", b.requireAuth(b.handleBridge))
 	mux.HandleFunc("/queue", b.requireAuth(b.handleQueue))
 	mux.HandleFunc("/company", b.requireAuth(b.handleCompany))
@@ -2996,6 +3001,12 @@ var reservedChannelSlugs = map[string]bool{
 	"nex":    true,
 	"you":    true,
 	"human":  true,
+	// "ceo" is a universally trusted sender (canAccessChannelLocked treats it
+	// the same as "system"/"nex"). Without reserving the slug here a user
+	// could mint a "#ceo" channel and shadow that trust — every actor in the
+	// trust list would read every message in it without an explicit member
+	// row.
+	"ceo": true,
 }
 
 func (b *Broker) canAccessChannelLocked(slug, channel string) bool {

--- a/internal/team/broker_office_channels.go
+++ b/internal/team/broker_office_channels.go
@@ -1096,54 +1096,18 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 		}
 		switch action {
 		case "create":
-			if slug == "" {
-				http.Error(w, "slug required", http.StatusBadRequest)
-				return
-			}
-			if reservedChannelSlugs[slug] {
-				// Reject slugs that canAccessChannelLocked treats as universally
-				// trusted senders. Without this gate, a user-created channel
-				// named e.g. "system" would let every trusted-sender slug read
-				// + post in it without an explicit Members entry — defeating
-				// the membership check the rest of the auth path relies on.
-				http.Error(w, "slug is reserved", http.StatusBadRequest)
-				return
-			}
-			if b.findChannelLocked(slug) != nil {
-				http.Error(w, "channel already exists", http.StatusConflict)
-				return
-			}
-			members, missing := validateMembers(body.Members)
-			if missing != "" {
-				http.Error(w, "unknown members: "+missing, http.StatusNotFound)
-				return
-			}
-			members = append([]string{"ceo"}, members...)
-			if creator := normalizeChannelSlug(body.CreatedBy); creator != "" && creator != "ceo" && b.findMemberLocked(creator) != nil {
-				members = append(members, creator)
-			}
-			ch := teamChannel{
-				Slug:        slug,
-				Name:        strings.TrimSpace(body.Name),
-				Description: strings.TrimSpace(body.Description),
-				Members:     uniqueSlugs(members),
+			ch, cerr := b.createChannelLocked(channelCreateInput{
+				Slug:        body.Slug,
+				Name:        body.Name,
+				Description: body.Description,
+				Members:     body.Members,
+				CreatedBy:   body.CreatedBy,
 				Surface:     body.Surface,
-				CreatedBy:   strings.TrimSpace(body.CreatedBy),
-				CreatedAt:   now,
-				UpdatedAt:   now,
-			}
-			if ch.Name == "" {
-				ch.Name = slug
-			}
-			if ch.Description == "" {
-				ch.Description = defaultTeamChannelDescription(ch.Slug, ch.Name)
-			}
-			b.channels = append(b.channels, ch)
-			if err := b.saveLocked(); err != nil {
-				http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
+			})
+			if cerr != nil {
+				http.Error(w, cerr.Msg, cerr.Code)
 				return
 			}
-			b.publishOfficeChangeLocked(officeChangeEvent{Kind: "channel_created", Slug: slug})
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{"channel": ch})
 		case "update":
@@ -1249,6 +1213,110 @@ func (b *Broker) handleChannels(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+// channelCreateInput is the input shape for createChannelLocked. It mirrors
+// the bits of the POST /channels body that drive a "create" action so the
+// Telegram-connect handler (and any future integration handler) can reuse the
+// canonical create path without re-implementing the validation rules.
+type channelCreateInput struct {
+	Slug        string
+	Name        string
+	Description string
+	Members     []string
+	CreatedBy   string
+	Surface     *channelSurface
+}
+
+// channelCreateError pairs an HTTP status with a user-facing message so the
+// caller can write it back through http.Error without rebuilding the
+// status-code → message mapping in every handler.
+type channelCreateError struct {
+	Code int
+	Msg  string
+}
+
+func (e *channelCreateError) Error() string { return e.Msg }
+
+// createChannelLocked is the canonical channel-create path. It validates the
+// slug, applies the reserved-slug guard, validates members against
+// b.findMemberLocked, prepends "ceo", optionally adds the creator, persists,
+// and publishes the change event. Caller MUST hold b.mu.
+//
+// All of this used to be inlined in handleChannels' "create" case; pulling it
+// out lets the Telegram-connect web flow share the exact same validation
+// rather than reimplementing them and drifting (the original copy in
+// handleTelegramConnect skipped member validation, the reserved-slug guard,
+// and the creator-self-add — all silent gaps that this consolidation closes).
+func (b *Broker) createChannelLocked(in channelCreateInput) (*teamChannel, *channelCreateError) {
+	// Validate the raw slug before normalizing — normalizeChannelSlug rewrites
+	// "" / whitespace to "general" and would have skipped the "slug required"
+	// branch entirely, falling through to "channel already exists" because
+	// #general always exists. Surface the missing-slug case as 400 with a
+	// useful message instead.
+	if strings.TrimSpace(in.Slug) == "" {
+		return nil, &channelCreateError{Code: http.StatusBadRequest, Msg: "slug required"}
+	}
+	slug := normalizeChannelSlug(in.Slug)
+	if slug == "" {
+		return nil, &channelCreateError{Code: http.StatusBadRequest, Msg: "slug required"}
+	}
+	if reservedChannelSlugs[slug] {
+		return nil, &channelCreateError{Code: http.StatusBadRequest, Msg: "slug is reserved"}
+	}
+	if b.findChannelLocked(slug) != nil {
+		return nil, &channelCreateError{Code: http.StatusConflict, Msg: "channel already exists"}
+	}
+
+	requested := uniqueSlugs(in.Members)
+	validated := make([]string, 0, len(requested))
+	var missing []string
+	for _, m := range requested {
+		if b.findMemberLocked(m) == nil {
+			missing = append(missing, m)
+			continue
+		}
+		validated = append(validated, m)
+	}
+	if len(missing) > 0 {
+		return nil, &channelCreateError{
+			Code: http.StatusNotFound,
+			Msg:  "unknown members: " + strings.Join(missing, ", "),
+		}
+	}
+
+	final := append([]string{"ceo"}, validated...)
+	// CreatedBy is an actor slug, not a channel slug. normalizeChannelSlug
+	// rewrites "" to "general", which would silently auto-add a real office
+	// member named "general" as a channel member whenever CreatedBy was
+	// empty. normalizeActorSlug preserves "" so the guard below short-circuits.
+	if creator := normalizeActorSlug(in.CreatedBy); creator != "" && creator != "ceo" && b.findMemberLocked(creator) != nil {
+		final = append(final, creator)
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	ch := teamChannel{
+		Slug:        slug,
+		Name:        strings.TrimSpace(in.Name),
+		Description: strings.TrimSpace(in.Description),
+		Members:     uniqueSlugs(final),
+		Surface:     in.Surface,
+		CreatedBy:   strings.TrimSpace(in.CreatedBy),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if ch.Name == "" {
+		ch.Name = slug
+	}
+	if ch.Description == "" {
+		ch.Description = defaultTeamChannelDescription(ch.Slug, ch.Name)
+	}
+	b.channels = append(b.channels, ch)
+	if err := b.saveLocked(); err != nil {
+		return nil, &channelCreateError{Code: http.StatusInternalServerError, Msg: "failed to persist broker state"}
+	}
+	b.publishOfficeChangeLocked(officeChangeEvent{Kind: "channel_created", Slug: slug})
+	return &b.channels[len(b.channels)-1], nil
 }
 
 // handleCreateDM creates or returns an existing DM channel.

--- a/internal/team/broker_office_channels_test.go
+++ b/internal/team/broker_office_channels_test.go
@@ -420,7 +420,7 @@ func TestChannelCreateRejectsReservedSlugs(t *testing.T) {
 
 	base := fmt.Sprintf("http://%s", b.Addr())
 
-	for _, reserved := range []string{"system", "nex", "you", "human"} {
+	for _, reserved := range []string{"system", "nex", "you", "human", "ceo"} {
 		t.Run(reserved, func(t *testing.T) {
 			body, _ := json.Marshal(map[string]any{
 				"action":     "create",
@@ -459,6 +459,45 @@ func TestChannelCreateRejectsReservedSlugs(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("create feature-launch: expected 200, got %d", resp.StatusCode)
+	}
+}
+
+// Regression for "empty slug normalized to general, falls through to
+// 'channel already exists' instead of 'slug required'". The fix validates
+// the raw slug before normalizeChannelSlug rewrites whitespace to "general".
+func TestChannelCreateRejectsEmptySlug(t *testing.T) {
+	b := newTestBroker(t)
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+
+	for _, raw := range []string{"", "   ", "\t"} {
+		body, _ := json.Marshal(map[string]any{
+			"action":     "create",
+			"slug":       raw,
+			"name":       "anything",
+			"created_by": "ceo",
+		})
+		req, _ := http.NewRequest(http.MethodPost, base+"/channels", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("create empty slug %q: %v", raw, err)
+		}
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("create empty slug %q: expected 400, got %d (body=%s)",
+				raw, resp.StatusCode, string(bodyBytes))
+		}
+		if !strings.Contains(strings.ToLower(string(bodyBytes)), "slug") {
+			t.Fatalf("create empty slug %q: expected error to mention 'slug', got %q",
+				raw, string(bodyBytes))
+		}
 	}
 }
 

--- a/internal/team/broker_telegram_connect.go
+++ b/internal/team/broker_telegram_connect.go
@@ -1,0 +1,357 @@
+package team
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/nex-crm/wuphf/internal/company"
+	"github.com/nex-crm/wuphf/internal/config"
+)
+
+// Sentinel errors returned by createTelegramChannel so the HTTP handler can
+// discriminate cases without fragile substring matching against free-text
+// error messages. Any future refactor that touches the wording can't silently
+// reroute "already exists" into "already bridges" or vice versa.
+var (
+	errChannelAlreadyBridges = errors.New("channel already bridges a different telegram chat")
+	errChannelAlreadyExists  = errors.New("channel already exists")
+)
+
+// Telegram connect endpoints used by the web wizard. The TUI talks to the
+// Telegram Bot API directly; the web does it through these handlers so the
+// flow can be completed end-to-end inside the office UI.
+//
+//	POST /telegram/verify   { token }                       → { ok, bot_name }
+//	POST /telegram/discover { token }                       → { groups: [...] }
+//	POST /telegram/connect  { token, chat_id, title, type } → { channel_slug, group_title }
+
+type telegramConnectRequest struct {
+	Token  string `json:"token,omitempty"`
+	ChatID int64  `json:"chat_id,omitempty"`
+	Title  string `json:"title,omitempty"`
+	Type   string `json:"type,omitempty"`
+}
+
+func (b *Broker) handleTelegramVerify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body telegramConnectRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	rawBodyToken := strings.TrimSpace(body.Token)
+	token := resolveTelegramTokenFromBody(body.Token)
+	if token == "" {
+		http.Error(w, "telegram bot token required", http.StatusBadRequest)
+		return
+	}
+	name, err := VerifyBot(token)
+	if err != nil {
+		writeJSON(w, http.StatusOK, map[string]any{"ok": false, "error": err.Error()})
+		return
+	}
+	// Persist on first successful verify so a verify-then-abandon flow leaves
+	// the user with a usable token in config. Two correctness notes:
+	//
+	//   1. Only save when nothing is already *persisted*. We read
+	//      cfg.TelegramBotToken directly rather than going through
+	//      ResolveTelegramBotToken — the latter short-circuits on
+	//      WUPHF_TELEGRAM_BOT_TOKEN, which would mean a developer who
+	//      exported the env to test bot A would never persist bot B's token
+	//      through the wizard. Persistence is config-state; env-as-override
+	//      is a runtime concern. SaveTelegramBotToken still stores a single
+	//      global field, so we don't overwrite — multi-bot support needs a
+	//      per-channel token map and is out of scope for this PR.
+	//
+	//   2. Don't os.Setenv. The Telegram transport caches the token at
+	//      construction time (telegram.go: BotToken is captured into the
+	//      struct), so a mutated env var never reaches the live bridge —
+	//      and process-global env mutation races with any concurrent reader.
+	//      The save above is what actually matters for the next restart.
+	//
+	if rawBodyToken != "" {
+		if cfg, _ := config.Load(); strings.TrimSpace(cfg.TelegramBotToken) == "" {
+			config.SaveTelegramBotToken(rawBodyToken)
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"ok": true, "bot_name": name})
+}
+
+func (b *Broker) handleTelegramDiscover(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body telegramConnectRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	token := resolveTelegramTokenFromBody(body.Token)
+	if token == "" {
+		http.Error(w, "telegram bot token required", http.StatusBadRequest)
+		return
+	}
+	groups, err := DiscoverGroups(token)
+	if err != nil {
+		// Surfacing the error (rather than treating it as "no groups") keeps
+		// the wizard from pushing the user into the manual/DM fallback when
+		// the real failure is transient (Telegram 5xx, DNS, rate limit). The
+		// frontend renders the body inside the picker-step error banner.
+		http.Error(w, fmt.Sprintf("could not discover groups: %v", err), http.StatusBadGateway)
+		return
+	}
+
+	// Merge in groups the live transport has seen so the picker shows everything.
+	seen := make(map[int64]bool, len(groups))
+	for _, g := range groups {
+		seen[g.ChatID] = true
+	}
+	for chatID, title := range b.SeenTelegramGroups() {
+		if seen[chatID] {
+			continue
+		}
+		groups = append(groups, TelegramGroup{ChatID: chatID, Title: title, Type: "group"})
+	}
+
+	out := make([]map[string]any, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, map[string]any{
+			"chat_id": g.ChatID,
+			"title":   g.Title,
+			"type":    g.Type,
+		})
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"groups": out})
+}
+
+func (b *Broker) handleTelegramConnect(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var body telegramConnectRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	token := resolveTelegramTokenFromBody(body.Token)
+	if token == "" {
+		http.Error(w, "telegram bot token required", http.StatusBadRequest)
+		return
+	}
+
+	title := strings.TrimSpace(body.Title)
+	chatID := body.ChatID
+
+	// chat_id == 0 is reserved for the "DM" pseudo-group (the TUI uses it the
+	// same way). For anything else, verify the chat exists before we create
+	// a channel pointed at it.
+	if chatID != 0 {
+		verified, err := VerifyChat(token, chatID)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("could not verify chat: %v", err), http.StatusBadRequest)
+			return
+		}
+		if title == "" {
+			title = verified
+		}
+	}
+	if title == "" {
+		if chatID == 0 {
+			title = "Telegram DM"
+		} else {
+			title = fmt.Sprintf("Telegram %d", chatID)
+		}
+	}
+
+	slug := SlugifyTelegramTitle(title)
+	chType := strings.TrimSpace(body.Type)
+	if chType == "" {
+		if chatID == 0 {
+			chType = "private"
+		} else {
+			chType = "group"
+		}
+	}
+
+	ch, err := b.createTelegramChannel(slug, title, chatID, chType)
+	if err != nil {
+		switch {
+		// errChannelAlreadyExists with a matching remote id is idempotent —
+		// the user just asked for the same chat twice. ch holds the existing
+		// channel, so fall through to the 200 response.
+		case errors.Is(err, errChannelAlreadyExists):
+			// fall through
+		// errChannelAlreadyBridges means the slug already maps to a different
+		// chat (or to a non-telegram channel). 409 Conflict so the wizard
+		// keeps the picker step open with the error visible — see
+		// telegram-connect.spec.ts checkpoint [10].
+		case errors.Is(err, errChannelAlreadyBridges):
+			http.Error(w, err.Error(), http.StatusConflict)
+			return
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	if ch == nil {
+		// Defence-in-depth: the only path that returns a non-nil error AND a
+		// nil channel today is the "already bridges" case handled above. If a
+		// future refactor introduces another nil-channel error, this guard
+		// stops a downstream nil-deref on ch.Slug.
+		http.Error(w, "channel create returned nil channel", http.StatusInternalServerError)
+		return
+	}
+
+	// Best-effort welcome message + manifest sync. Failures here are logged
+	// but don't fail the request — the channel exists and the bridge will
+	// catch up on the next poll.
+	if chatID != 0 {
+		if sendErr := SendTelegramMessage(token, chatID,
+			"Connected to WUPHF Office. Messages here will be visible to the team."); sendErr != nil {
+			log.Printf("[telegram] welcome send failed for chat %d: %v", chatID, sendErr)
+		}
+	}
+	syncManifestForTelegramChannel(slug, title, chatID)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"channel_slug": ch.Slug,
+		"group_title":  title,
+	})
+}
+
+// createTelegramChannel routes the Telegram-bridged channel through the
+// canonical createChannelLocked helper so member validation, the
+// reserved-slug guard, and the creator-self-add rules apply the same way they
+// do for /channels POST. Members come from company.yaml — same set the TUI
+// seeds in cmd/wuphf/channel_integration.go's connectTelegramGroup.
+func (b *Broker) createTelegramChannel(slug, title string, chatID int64, chType string) (*teamChannel, error) {
+	// Read the manifest under the same lock UpdateManifest uses, so the
+	// member list we derive here is consistent with whatever
+	// syncManifestForTelegramChannel writes a few lines later. A bare
+	// LoadManifest would race with concurrent UpdateManifest writers and
+	// could let the broker's in-memory channel diverge from the persisted
+	// manifest's member list. Snapshot, then proceed under b.mu.
+	manifest, err := company.SnapshotManifest()
+	if err != nil {
+		manifest = company.DefaultManifest()
+	}
+	// Mirror the TUI exactly: lead first, then every other manifest member.
+	// "ceo" is prepended by createChannelLocked itself, so we don't add it here.
+	members := []string{manifest.Lead}
+	for _, m := range manifest.Members {
+		if m.Slug != "" && m.Slug != manifest.Lead {
+			members = append(members, m.Slug)
+		}
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if existing := b.findChannelLocked(slug); existing != nil {
+		// SlugifyTelegramTitle is title-only, so two distinct Telegram chats
+		// with the same display name collide on slug. If we returned the
+		// existing channel here, the caller would think the new chat was
+		// connected even though the channel's surface still points at the
+		// previous chat — messages would route to the wrong conversation.
+		newRemoteID := fmt.Sprintf("%d", chatID)
+		// Surface == nil or Provider != "telegram" means a hand-created or
+		// other-provider channel happens to share the slug. Treat that as a
+		// conflict — silently reusing it would bridge a Telegram chat into a
+		// non-Telegram channel.
+		if existing.Surface == nil || existing.Surface.Provider != "telegram" {
+			return nil, fmt.Errorf("%w: %q already exists as a non-telegram channel",
+				errChannelAlreadyBridges, slug)
+		}
+		if existing.Surface.RemoteID != "" && existing.Surface.RemoteID != newRemoteID {
+			return nil, fmt.Errorf(
+				"%w: %q already bridges Telegram chat %s; rename the new chat or pick a different slug",
+				errChannelAlreadyBridges, slug, existing.Surface.RemoteID,
+			)
+		}
+		return existing, errChannelAlreadyExists
+	}
+
+	ch, cerr := b.createChannelLocked(channelCreateInput{
+		Slug:        slug,
+		Name:        title,
+		Description: fmt.Sprintf("Telegram bridge for %s.", title),
+		Members:     members,
+		CreatedBy:   "you",
+		Surface: &channelSurface{
+			Provider:    "telegram",
+			RemoteID:    fmt.Sprintf("%d", chatID),
+			RemoteTitle: title,
+			Mode:        chType,
+			BotTokenEnv: "WUPHF_TELEGRAM_BOT_TOKEN",
+		},
+	})
+	if cerr != nil {
+		return nil, cerr
+	}
+	return ch, nil
+}
+
+// syncManifestForTelegramChannel adds the new channel to company.yaml so that
+// a future broker restart picks it up before the broker-state.json is reread.
+// This mirrors what the TUI does in connectTelegramGroup.
+//
+// Goes through company.UpdateManifest so the load → append → save sequence is
+// atomic against concurrent web/web AND web/TUI updates — without that lock,
+// two parallel connects could both LoadManifest, each append, and the slower
+// SaveManifest would silently drop the faster one's row.
+func syncManifestForTelegramChannel(slug, title string, chatID int64) {
+	err := company.UpdateManifest(func(manifest *company.Manifest) error {
+		for _, ch := range manifest.Channels {
+			if ch.Slug == slug {
+				return nil
+			}
+		}
+		members := []string{manifest.Lead}
+		for _, m := range manifest.Members {
+			if m.Slug != "" && m.Slug != manifest.Lead {
+				members = append(members, m.Slug)
+			}
+		}
+		manifest.Channels = append(manifest.Channels, company.ChannelSpec{
+			Slug:        slug,
+			Name:        title,
+			Description: fmt.Sprintf("Telegram bridge for %s.", title),
+			Members:     members,
+			Surface: &company.ChannelSurfaceSpec{
+				Provider:    "telegram",
+				RemoteID:    fmt.Sprintf("%d", chatID),
+				RemoteTitle: title,
+				BotTokenEnv: "WUPHF_TELEGRAM_BOT_TOKEN",
+			},
+		})
+		return nil
+	})
+	if err != nil {
+		// Don't fail the connect — the in-memory channel is already created
+		// and persisted via b.saveLocked(). The manifest sync is just so that
+		// a future restart re-reads from company.yaml. Log it loudly so a
+		// disk-full / permission bug surfaces in the broker log instead of
+		// silently rotting until someone restarts.
+		log.Printf("[telegram] manifest sync failed for %s: %v", slug, err)
+	}
+}
+
+func resolveTelegramTokenFromBody(token string) string {
+	if t := strings.TrimSpace(token); t != "" {
+		return t
+	}
+	if env := strings.TrimSpace(os.Getenv("WUPHF_TELEGRAM_BOT_TOKEN")); env != "" {
+		return env
+	}
+	return strings.TrimSpace(config.ResolveTelegramBotToken())
+}

--- a/internal/team/broker_telegram_connect.go
+++ b/internal/team/broker_telegram_connect.go
@@ -243,7 +243,7 @@ func (b *Broker) createTelegramChannel(slug, title string, chatID int64, chType 
 	// manifest's member list. Snapshot, then proceed under b.mu.
 	manifest, err := company.SnapshotManifest()
 	if err != nil {
-		manifest = company.DefaultManifest()
+		return nil, fmt.Errorf("load company manifest: %w", err)
 	}
 	// Mirror the TUI exactly: lead first, then every other manifest member.
 	// "ceo" is prepended by createChannelLocked itself, so we don't add it here.

--- a/internal/team/broker_telegram_connect_test.go
+++ b/internal/team/broker_telegram_connect_test.go
@@ -2,6 +2,9 @@ package team
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -69,5 +72,24 @@ func TestCreateTelegramChannelRejectsNonTelegramSurface(t *testing.T) {
 	}
 	if ch := b.findChannelLocked("standup"); ch == nil || ch.Surface != nil {
 		t.Fatalf("connect into non-telegram channel: surface mutated: %+v", ch)
+	}
+}
+
+func TestCreateTelegramChannelSurfacesManifestReadError(t *testing.T) {
+	b := newTestBroker(t)
+	defer b.Stop()
+
+	manifestPath := filepath.Join(t.TempDir(), "company.json")
+	if err := os.WriteFile(manifestPath, []byte("{not-json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WUPHF_COMPANY_FILE", manifestPath)
+
+	_, err := b.createTelegramChannel("standup", "Standup", 100, "group")
+	if err == nil {
+		t.Fatal("expected manifest read error, got nil")
+	}
+	if !strings.Contains(err.Error(), "load company manifest") {
+		t.Fatalf("expected manifest load context, got %v", err)
 	}
 }

--- a/internal/team/broker_telegram_connect_test.go
+++ b/internal/team/broker_telegram_connect_test.go
@@ -1,0 +1,73 @@
+package team
+
+import (
+	"errors"
+	"testing"
+)
+
+// Regression for the title-collision bug: SlugifyTelegramTitle is title-only,
+// so two distinct Telegram chats with the same display name collide on slug.
+// Without this guard the second connect would return the existing channel as
+// "success" even though the channel still pointed at the first chat —
+// messages would route to the wrong conversation. Asserts the second connect
+// reports a conflict instead of silently rebinding.
+func TestCreateTelegramChannelRejectsTitleCollision(t *testing.T) {
+	b := newTestBroker(t)
+	defer b.Stop()
+
+	if _, err := b.createTelegramChannel("standup", "Standup", 100, "group"); err != nil {
+		t.Fatalf("first connect: unexpected error: %v", err)
+	}
+
+	// Same title (and therefore same slug) but a different chat id.
+	_, err := b.createTelegramChannel("standup", "Standup", 200, "group")
+	if err == nil {
+		t.Fatal("second connect with colliding title: expected error, got nil")
+	}
+	if !errors.Is(err, errChannelAlreadyBridges) {
+		t.Fatalf("second connect with colliding title: expected errChannelAlreadyBridges, got %v",
+			err)
+	}
+
+	// Same chat id is idempotent — the user just asked for the same chat
+	// twice. Should return the existing channel + the errChannelAlreadyExists
+	// sentinel so the handler can fall through to a 200 response.
+	ch, err := b.createTelegramChannel("standup", "Standup", 100, "group")
+	if !errors.Is(err, errChannelAlreadyExists) {
+		t.Fatalf("idempotent re-connect: expected errChannelAlreadyExists, got %v", err)
+	}
+	if ch == nil || ch.Slug != "standup" {
+		t.Fatalf("idempotent re-connect: expected existing channel, got %+v", ch)
+	}
+}
+
+// Regression for the "existing channel has nil/non-telegram surface"
+// branch of the title-collision guard. A user-created or hand-edited channel
+// that happens to share a slug with the new Telegram chat must NOT be
+// silently rebound to a Telegram surface — that would make a non-telegram
+// channel start receiving messages from a remote chat. Asserts that case
+// yields errChannelAlreadyBridges (409) like the cross-chat collision does.
+func TestCreateTelegramChannelRejectsNonTelegramSurface(t *testing.T) {
+	b := newTestBroker(t)
+	defer b.Stop()
+
+	// Seed a channel with no surface (mimics a hand-created channel).
+	b.mu.Lock()
+	b.channels = append(b.channels, teamChannel{
+		Slug:    "standup",
+		Name:    "Standup",
+		Members: []string{"ceo"},
+	})
+	b.mu.Unlock()
+
+	_, err := b.createTelegramChannel("standup", "Standup", 100, "group")
+	if err == nil {
+		t.Fatal("connect into non-telegram channel: expected error, got nil")
+	}
+	if !errors.Is(err, errChannelAlreadyBridges) {
+		t.Fatalf("connect into non-telegram channel: expected errChannelAlreadyBridges, got %v", err)
+	}
+	if ch := b.findChannelLocked("standup"); ch == nil || ch.Surface != nil {
+		t.Fatalf("connect into non-telegram channel: surface mutated: %+v", ch)
+	}
+}

--- a/internal/team/telegram.go
+++ b/internal/team/telegram.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -682,6 +683,21 @@ func VerifyChat(token string, chatID int64) (string, error) {
 		return "", nil
 	}
 	return chat.Title, nil
+}
+
+var telegramSlugRegexp = regexp.MustCompile(`[^a-z0-9]+`)
+
+// SlugifyTelegramTitle is the canonical slug rule for Telegram-bridged channels.
+// Both the TUI's `/connect telegram` and the web wizard route through this so
+// the two paths can never produce different slugs for the same chat title.
+func SlugifyTelegramTitle(title string) string {
+	slug := strings.ToLower(strings.TrimSpace(title))
+	slug = telegramSlugRegexp.ReplaceAllString(slug, "-")
+	slug = strings.Trim(slug, "-")
+	if slug == "" {
+		slug = "telegram"
+	}
+	return "tg-" + slug
 }
 
 // DiscoverGroupsFromBroker returns groups the transport has seen during polling.

--- a/web/e2e/run-local.sh
+++ b/web/e2e/run-local.sh
@@ -158,9 +158,10 @@ run_shell_phase() {
 {"version":1,"completed_at":"2026-01-01T00:00:00Z","company_name":"e2e-local"}
 EOF
   start_wuphf "shell"
-  # Shell-phase specs: post-onboarding UI surfaces (smoke, settings).
+  # Shell-phase specs: post-onboarding UI surfaces (smoke, settings,
+  # /connect telegram wizard).
   echo "[run-local] running shell-phase specs"
-  (cd web/e2e && WUPHF_E2E_BASE_URL="http://localhost:${web_port}" bunx playwright test tests/smoke.spec.ts tests/local-llm-settings.spec.ts)
+  (cd web/e2e && WUPHF_E2E_BASE_URL="http://localhost:${web_port}" bunx playwright test tests/smoke.spec.ts tests/local-llm-settings.spec.ts tests/telegram-connect.spec.ts)
   stop_wuphf
 }
 

--- a/web/e2e/tests/telegram-connect.spec.ts
+++ b/web/e2e/tests/telegram-connect.spec.ts
@@ -1,0 +1,514 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  collectReactErrors,
+  expectNoReactErrors,
+  resetBroker,
+  waitForShellReady,
+} from "./_helpers";
+
+// Drives the web /connect Telegram wizard end to end. The wizard talks to
+// three new broker endpoints (POST /telegram/{verify,discover,connect}) that
+// proxy the Telegram Bot API. We stub them with page.route() so the suite
+// never touches t.me/api.telegram.org and never needs a live BotFather token.
+//
+// Checkpoints (some may be marked .fixme until the wiring lands):
+//
+//   1. /connect command runs and opens the Telegram modal.
+//   2. The modal renders the token-entry step with a visible token input.
+//   3. Submitting empty token shows an inline validation error.
+//   4. Verify failure (broker says ok:false) keeps the user on the token step
+//      with an editable input and an inline error banner.
+//   5. Verify success advances to discovery and renders the picker step.
+//   6. Empty group list shows "no groups" copy + retry/manual/dm controls.
+//   7. Picking a group fires POST /telegram/connect with the right body and
+//      lands on the done step showing the new channel slug.
+//   8. Manual chat ID flow validates the input and posts an integer chat_id.
+//   9. "Use as DM" posts chat_id=0.
+//  10. Connect failure keeps the picker step active with the error visible.
+//  10b. Modal renders with a visible card surface (regression: wk-* CSS
+//       variables must resolve outside `.wiki-root`).
+//  10c. Modal renders styled when opened from a non-wiki route (regression).
+//  11. Stale error from a failed verify clears on a successful retry.
+//
+// All steps assert no React errors so a render-time crash mid-wizard fails
+// the test rather than degrading silently.
+
+// Every test gets the React-error guard. Without this, error-state branches
+// (verify-failed, connect-failed, manual-id-validation) would silently render
+// undefined-deref bugs and the suite would still go green.
+let getErrors: () => string[];
+
+test.beforeEach(async ({ page }) => {
+  getErrors = collectReactErrors(page);
+});
+
+test.afterEach(async ({ page, request }, info) => {
+  await expectNoReactErrors(page, getErrors, `during ${info.title}`);
+  await resetBroker(request);
+});
+
+const verifyOK = {
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ ok: true, bot_name: "wuphf-test-bot" }),
+};
+
+const verifyFail = {
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ ok: false, error: "401 Unauthorized" }),
+};
+
+const discoverEmpty = {
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({ groups: [] }),
+};
+
+const discoverGroups = {
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({
+    groups: [
+      { chat_id: -123456, title: "Test Group A", type: "group" },
+      { chat_id: -789012, title: "Test Group B", type: "supergroup" },
+    ],
+  }),
+};
+
+const connectOK = {
+  status: 200,
+  contentType: "application/json",
+  body: JSON.stringify({
+    channel_slug: "tg-test-group-a",
+    group_title: "Test Group A",
+  }),
+};
+
+const connectFail = {
+  status: 500,
+  contentType: "text/plain",
+  body: "could not verify chat: chat not found",
+};
+
+// Open the Telegram wizard directly via `/connect telegram` so the tests
+// don't have to click through the provider picker first. The bare-`/connect`
+// path that lands on the provider picker has its own dedicated test below.
+async function openTelegramWizard(page: import("@playwright/test").Page) {
+  const composer = page.locator(".composer-input");
+  await composer.click();
+  // Trailing space defeats the autocomplete picker so Enter dispatches the
+  // command instead of inserting the highlighted item — same trick the
+  // slash-commands spec uses for /help.
+  await composer.fill("/connect telegram ");
+  await composer.press("Enter");
+  await expect(page.getByTestId("tg-connect-modal")).toBeVisible({
+    timeout: 5_000,
+  });
+  await expect(page.getByTestId("tg-step-token")).toBeVisible();
+}
+
+test.describe("wuphf web /connect Telegram wizard", () => {
+  test("[1] /connect telegram opens the Telegram wizard at the token step", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    await openTelegramWizard(page);
+    await expect(page.getByTestId("tg-step-token")).toBeVisible();
+  });
+
+  test("[1a] bare /connect opens the provider picker with TUI parity", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    const composer = page.locator(".composer-input");
+    await composer.click();
+    await composer.fill("/connect ");
+    await composer.press("Enter");
+
+    await expect(page.getByTestId("tg-connect-modal")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("tg-step-provider")).toBeVisible();
+    // All four options the TUI offers (cmd/wuphf/channel.go:4871-4880)
+    // are surfaced — no silent shortcut to Telegram.
+    await expect(page.getByTestId("tg-provider-telegram")).toBeVisible();
+    await expect(page.getByTestId("tg-provider-openclaw")).toBeVisible();
+    await expect(page.getByTestId("tg-provider-slack")).toBeVisible();
+    await expect(page.getByTestId("tg-provider-discord")).toBeVisible();
+    // Slack/Discord are placeholders today — confirm they're disabled so
+    // the user can see what's coming without a confusing "click does nothing".
+    await expect(page.getByTestId("tg-provider-slack")).toBeDisabled();
+    await expect(page.getByTestId("tg-provider-discord")).toBeDisabled();
+  });
+
+  test("[1b] picker → Telegram advances to the token step", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    const composer = page.locator(".composer-input");
+    await composer.click();
+    await composer.fill("/connect ");
+    await composer.press("Enter");
+
+    await page.getByTestId("tg-provider-telegram").click();
+    await expect(page.getByTestId("tg-step-token")).toBeVisible();
+  });
+
+  test("[1c] picker → OpenClaw closes the modal and tells the user to use the TUI", async ({
+    page,
+  }) => {
+    // OpenClaw works in the TUI today but doesn't have a web wizard yet.
+    // Surfacing that gap honestly is the whole point of this picker — the
+    // previous behaviour silently routed every /connect to Telegram, which
+    // was the bug bornaware reported. This test guards against regressing
+    // back to that.
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    const composer = page.locator(".composer-input");
+    await composer.click();
+    await composer.fill("/connect ");
+    await composer.press("Enter");
+
+    await page.getByTestId("tg-provider-openclaw").click();
+    await expect(page.getByTestId("tg-connect-modal")).toBeHidden({
+      timeout: 5_000,
+    });
+  });
+
+  test("[2,3] empty token shows inline validation", async ({ page }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+    await openTelegramWizard(page);
+
+    // Click verify with the input still empty — should NOT call the broker.
+    let verifyCalled = false;
+    await page.route("**/telegram/verify", async (route) => {
+      verifyCalled = true;
+      await route.fulfill(verifyOK);
+    });
+
+    await page.getByTestId("tg-token-submit").click();
+    await expect(page.getByRole("alert")).toContainText(/required/i);
+    expect(verifyCalled).toBe(false);
+  });
+
+  test("[4] verify failure keeps user on token step", async ({ page }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    await page.route("**/telegram/verify", (route) =>
+      route.fulfill(verifyFail),
+    );
+    await openTelegramWizard(page);
+
+    await page.getByTestId("tg-token-input").fill("bogus");
+    await page.getByTestId("tg-token-submit").click();
+
+    await expect(page.getByTestId("tg-step-token")).toBeVisible();
+    await expect(page.getByRole("alert")).toContainText(/401/);
+  });
+
+  test("[5,7] verify success → pick → connect → done", async ({ page }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
+    await page.route("**/telegram/discover", (route) =>
+      route.fulfill(discoverGroups),
+    );
+
+    let connectBody: unknown = null;
+    await page.route("**/telegram/connect", async (route, req) => {
+      connectBody = req.postDataJSON();
+      await route.fulfill(connectOK);
+    });
+
+    await openTelegramWizard(page);
+    await page.getByTestId("tg-token-input").fill("123456:ABC");
+    await page.getByTestId("tg-token-submit").click();
+
+    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("tg-group-list")).toBeVisible();
+
+    await page.getByTestId("tg-group--123456").click();
+
+    await expect(page.getByTestId("tg-step-done")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("tg-created-slug")).toContainText(
+      "tg-test-group-a",
+    );
+
+    expect(connectBody).toMatchObject({
+      token: "123456:ABC",
+      chat_id: -123456,
+      title: "Test Group A",
+    });
+  });
+
+  test("[6] empty group list shows retry/manual/dm controls", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
+    await page.route("**/telegram/discover", (route) =>
+      route.fulfill(discoverEmpty),
+    );
+
+    await openTelegramWizard(page);
+    await page.getByTestId("tg-token-input").fill("123456:ABC");
+    await page.getByTestId("tg-token-submit").click();
+
+    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByTestId("tg-retry-discover")).toBeVisible();
+    await expect(page.getByTestId("tg-manual-chat-id")).toBeVisible();
+    await expect(page.getByTestId("tg-connect-dm")).toBeVisible();
+  });
+
+  test("[8] manual chat ID validates and posts integer chat_id", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
+    await page.route("**/telegram/discover", (route) =>
+      route.fulfill(discoverEmpty),
+    );
+
+    let connectBody: { chat_id?: number } | null = null;
+    await page.route("**/telegram/connect", async (route, req) => {
+      connectBody = req.postDataJSON();
+      await route.fulfill(connectOK);
+    });
+
+    await openTelegramWizard(page);
+    await page.getByTestId("tg-token-input").fill("123456:ABC");
+    await page.getByTestId("tg-token-submit").click();
+    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByTestId("tg-manual-chat-id").click();
+    await expect(page.getByTestId("tg-step-manual")).toBeVisible();
+
+    // Non-numeric input → inline error, no POST.
+    await page.getByTestId("tg-manual-id-input").fill("not-a-number");
+    await page.getByTestId("tg-manual-submit").click();
+    await expect(page.getByRole("alert")).toContainText(/integer/i);
+    expect(connectBody).toBeNull();
+
+    // Regression for "Number.parseInt accepts trailing junk": "-12abc" used to
+    // be silently accepted as -12, which would bridge the wrong chat id. The
+    // strict regex check now rejects any non-digit suffix.
+    await page.getByTestId("tg-manual-id-input").fill("-12abc");
+    await page.getByTestId("tg-manual-submit").click();
+    await expect(page.getByRole("alert")).toContainText(/integer/i);
+    expect(connectBody).toBeNull();
+
+    // Valid integer → posts chat_id as a number.
+    await page.getByTestId("tg-manual-id-input").fill("-5093020979");
+    await page.getByTestId("tg-manual-submit").click();
+    await expect(page.getByTestId("tg-step-done")).toBeVisible({
+      timeout: 5_000,
+    });
+    expect(connectBody?.chat_id).toBe(-5093020979);
+  });
+
+  test('[9] "Use as DM" posts chat_id=0', async ({ page }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
+    await page.route("**/telegram/discover", (route) =>
+      route.fulfill(discoverEmpty),
+    );
+
+    let connectBody: { chat_id?: number; type?: string } | null = null;
+    await page.route("**/telegram/connect", async (route, req) => {
+      connectBody = req.postDataJSON();
+      await route.fulfill(connectOK);
+    });
+
+    await openTelegramWizard(page);
+    await page.getByTestId("tg-token-input").fill("123456:ABC");
+    await page.getByTestId("tg-token-submit").click();
+    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByTestId("tg-connect-dm").click();
+    await expect(page.getByTestId("tg-step-done")).toBeVisible({
+      timeout: 5_000,
+    });
+    expect(connectBody?.chat_id).toBe(0);
+    expect(connectBody?.type).toBe("private");
+  });
+
+  test("[10] connect failure keeps picker step active with error", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
+    await page.route("**/telegram/discover", (route) =>
+      route.fulfill(discoverGroups),
+    );
+    await page.route("**/telegram/connect", (route) =>
+      route.fulfill(connectFail),
+    );
+
+    await openTelegramWizard(page);
+    await page.getByTestId("tg-token-input").fill("123456:ABC");
+    await page.getByTestId("tg-token-submit").click();
+    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByTestId("tg-group--123456").click();
+
+    await expect(page.getByTestId("tg-step-pick")).toBeVisible();
+    await expect(page.getByRole("alert")).toContainText(/chat not found/i);
+  });
+
+  test("[10b] modal renders with a visible card surface (regression: wk-* CSS vars must resolve outside .wiki-root)", async ({
+    page,
+  }) => {
+    // Regression for the "wiki.css imported but variables don't resolve"
+    // class of bug. The wizard reuses wk-modal-* / wk-editor-* primitives
+    // that read CSS custom properties (--wk-paper, --wk-border) — those
+    // were originally scoped to .wiki-root, so when the modal opened from
+    // anywhere except the Wiki page it rendered as transparent text on
+    // top of the underlying view: heading and buttons floating with no
+    // card, no border, no backdrop.
+    //
+    // Visibility-only assertions (toBeVisible / toContainText) couldn't
+    // catch this — the testids were present, just unstyled. We assert the
+    // computed background and border on the modal card so any future
+    // "class exists but variables undefined" regression fails loudly.
+    await page.goto("/");
+    await waitForShellReady(page);
+    await page.route("**/telegram/verify", (r) => r.fulfill(verifyOK));
+    await openTelegramWizard(page);
+
+    const styles = await page.evaluate(() => {
+      const backdrop = document.querySelector(
+        ".wk-modal-backdrop",
+      ) as HTMLElement | null;
+      const card = document.querySelector(".wk-modal") as HTMLElement | null;
+      if (!(backdrop && card)) return null;
+      const bs = getComputedStyle(backdrop);
+      const cs = getComputedStyle(card);
+      return {
+        backdropPosition: bs.position,
+        backdropBg: bs.backgroundColor,
+        cardBg: cs.backgroundColor,
+        cardBorderColor: cs.borderColor,
+        cardBorderWidth: cs.borderTopWidth,
+      };
+    });
+    expect(styles, "modal DOM should be present").not.toBeNull();
+    // Backdrop must dim the page (non-zero alpha) and be position:fixed.
+    expect(styles!.backdropPosition).toBe("fixed");
+    expect(styles!.backdropBg).not.toBe("rgba(0, 0, 0, 0)");
+    expect(styles!.backdropBg).not.toBe("transparent");
+    // Card must have an opaque background — the original bug had this as
+    // rgba(0,0,0,0) because var(--wk-paper) didn't resolve.
+    expect(styles!.cardBg).not.toBe("rgba(0, 0, 0, 0)");
+    expect(styles!.cardBg).not.toBe("transparent");
+    // Card must have a visible border (non-zero width). Original bug:
+    // border-width was 0px because var(--wk-border) didn't resolve.
+    expect(styles!.cardBorderWidth).not.toBe("0px");
+  });
+
+  test("[10c] verify the wizard renders styled when opened from a non-wiki route (regression)", async ({
+    page,
+  }) => {
+    // The original bug only manifested when the wizard was opened from
+    // outside the Wiki page (where wiki.css is imported as a side effect).
+    // After the fix, the relevant CSS vars live on :root, so the modal
+    // styles correctly regardless of route. This test guards against a
+    // regression where a contributor scopes the variables back to
+    // .wiki-root, which would re-introduce the unstyled-modal bug.
+    await page.goto("/");
+    await waitForShellReady(page);
+    await page.route("**/telegram/verify", (r) => r.fulfill(verifyOK));
+    await openTelegramWizard(page);
+
+    // Confirm we're NOT inside a .wiki-root ancestor (which would mask the
+    // bug under test).
+    const insideWikiRoot = await page.evaluate(() => {
+      return Boolean(
+        document.querySelector(".wk-modal")?.closest(".wiki-root"),
+      );
+    });
+    expect(insideWikiRoot).toBe(false);
+
+    // And confirm the variables still resolve. CSS custom properties are
+    // inherited, so reading from the modal root tells us whether :root has
+    // them defined.
+    const paperColor = await page.evaluate(() => {
+      const card = document.querySelector(".wk-modal") as HTMLElement | null;
+      if (!card) return "";
+      return getComputedStyle(card).getPropertyValue("--wk-paper").trim();
+    });
+    expect(
+      paperColor,
+      "--wk-paper must be defined globally so the modal renders styled outside .wiki-root",
+    ).not.toBe("");
+  });
+
+  test("[11] verify ok:false then retry with valid token clears the error and proceeds", async ({
+    page,
+  }) => {
+    // Guards the "stale error state" class of bug: the user types a bad
+    // token, sees 401, types a good token, and the modal advances. If
+    // verifyAndDiscover doesn't clear `error` on the new attempt, the
+    // banner sticks around on the picker step — confusing at best.
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    let verifyCallCount = 0;
+    await page.route("**/telegram/verify", async (route) => {
+      verifyCallCount += 1;
+      if (verifyCallCount === 1) {
+        await route.fulfill(verifyFail);
+      } else {
+        await route.fulfill(verifyOK);
+      }
+    });
+    await page.route("**/telegram/discover", (route) =>
+      route.fulfill(discoverEmpty),
+    );
+
+    await openTelegramWizard(page);
+    await page.getByTestId("tg-token-input").fill("bogus");
+    await page.getByTestId("tg-token-submit").click();
+    await expect(page.getByRole("alert")).toContainText(/401/);
+
+    await page.getByTestId("tg-token-input").fill("123456:GOOD");
+    await page.getByTestId("tg-token-submit").click();
+    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
+      timeout: 5_000,
+    });
+    // Error banner from the prior attempt must be gone — a stale `error`
+    // state would render here and break the user's mental model.
+    await expect(page.getByRole("alert")).toHaveCount(0);
+  });
+});

--- a/web/e2e/tests/telegram-connect.spec.ts
+++ b/web/e2e/tests/telegram-connect.spec.ts
@@ -330,6 +330,35 @@ test.describe("wuphf web /connect Telegram wizard", () => {
     expect(connectBody?.chat_id).toBe(-5093020979);
   });
 
+  test("[8b] manual connect failure stays on the manual step", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await waitForShellReady(page);
+
+    await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
+    await page.route("**/telegram/discover", (route) =>
+      route.fulfill(discoverEmpty),
+    );
+    await page.route("**/telegram/connect", (route) =>
+      route.fulfill(connectFail),
+    );
+
+    await openTelegramWizard(page);
+    await page.getByTestId("tg-token-input").fill("123456:ABC");
+    await page.getByTestId("tg-token-submit").click();
+    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
+      timeout: 5_000,
+    });
+
+    await page.getByTestId("tg-manual-chat-id").click();
+    await page.getByTestId("tg-manual-id-input").fill("-5093020979");
+    await page.getByTestId("tg-manual-submit").click();
+
+    await expect(page.getByTestId("tg-step-manual")).toBeVisible();
+    await expect(page.getByRole("alert")).toContainText(/chat not found/i);
+  });
+
   test('[9] "Use as DM" posts chat_id=0', async ({ page }) => {
     await page.goto("/");
     await waitForShellReady(page);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import { SettingsApp } from "./components/apps/SettingsApp";
 import { SkillsApp } from "./components/apps/SkillsApp";
 import { TasksApp } from "./components/apps/TasksApp";
 import { ThreadsApp } from "./components/apps/ThreadsApp";
+import { TelegramConnectHost } from "./components/integrations/TelegramConnectModal";
 import { Shell } from "./components/layout/Shell";
 import { UpgradeBanner } from "./components/layout/UpgradeBanner";
 import { Composer } from "./components/messages/Composer";
@@ -391,6 +392,7 @@ export default function App() {
       <ToastContainer />
       <ConfirmHost />
       <ProviderSwitcherHost />
+      <TelegramConnectHost />
     </ErrorBoundary>
   );
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -90,11 +90,13 @@ export async function getText(
 export async function post<T = unknown>(
   path: string,
   body?: unknown,
+  opts?: { signal?: AbortSignal },
 ): Promise<T> {
   const r = await fetch(baseURL() + path, {
     method: "POST",
     headers: authHeaders(),
     body: JSON.stringify(body),
+    signal: opts?.signal,
   });
   if (!r.ok) {
     const text = (await r.text().catch(() => "")).trim();
@@ -770,7 +772,9 @@ export function listAgentLogTasks(opts?: { limit?: number }) {
 }
 
 export function getAgentLogEntries(taskId: string) {
-  return get<{ task: string; entries: TaskLogEntry[] }>("/agent-logs", { task: taskId });
+  return get<{ task: string; entries: TaskLogEntry[] }>("/agent-logs", {
+    task: taskId,
+  });
 }
 
 // ── Memory ──
@@ -1000,4 +1004,64 @@ export interface UpgradeRunResult {
 // "fetch timed out".
 export function runUpgrade() {
   return postWithTimeout<UpgradeRunResult>("/upgrade/run", {}, 130_000);
+}
+
+// ── Telegram /connect wizard ──
+// These mirror the TUI's `/connect telegram` flow but drive it from the web.
+// Pass an explicit `token` to override what the broker has on disk; pass an
+// empty string to use the saved token from config / WUPHF_TELEGRAM_BOT_TOKEN.
+
+export interface TelegramVerifyResponse {
+  ok: boolean;
+  bot_name?: string;
+  error?: string;
+}
+
+export interface TelegramGroup {
+  // chat_id comes from Go's int64 on the wire. Telegram's API docs say chat
+  // IDs may have at most 52 significant bits — exactly inside JS's
+  // Number.MAX_SAFE_INTEGER (53 bits). Today's supergroup IDs (~13 digits)
+  // are well below that, so a plain `number` is safe. If Telegram ever
+  // widens past 52 bits this needs to become a string (or bigint with an
+  // explicit serialiser) to avoid silent precision loss on the round-trip.
+  chat_id: number;
+  title: string;
+  type: string;
+}
+
+export interface TelegramDiscoverResponse {
+  groups: TelegramGroup[];
+}
+
+export interface TelegramConnectResponse {
+  channel_slug: string;
+  group_title: string;
+}
+
+export function verifyTelegramBot(token: string, signal?: AbortSignal) {
+  return post<TelegramVerifyResponse>(
+    "/telegram/verify",
+    { token },
+    { signal },
+  );
+}
+
+export function discoverTelegramChats(token: string, signal?: AbortSignal) {
+  return post<TelegramDiscoverResponse>(
+    "/telegram/discover",
+    { token },
+    { signal },
+  );
+}
+
+export function connectTelegramChannel(
+  opts: {
+    token?: string;
+    chat_id: number;
+    title?: string;
+    type?: string;
+  },
+  signal?: AbortSignal,
+) {
+  return post<TelegramConnectResponse>("/telegram/connect", opts, { signal });
 }

--- a/web/src/components/integrations/TelegramConnectModal.tsx
+++ b/web/src/components/integrations/TelegramConnectModal.tsx
@@ -93,13 +93,17 @@ export function TelegramConnectModal({
     abortRef.current = null;
   }, [initialStep]);
 
-  // Reset only on open transitions. The previous `if (open) reset(); else
-  // reset();` was a no-op ternary that ran reset on close too, which is
-  // technically fine (the hidden modal short-circuits on `if (!open) return
-  // null`) but misleading. The new shape makes the intent explicit: reset
-  // when the wizard is freshly opened.
+  // Reset when the wizard opens, and invalidate requests when it closes. The
+  // component stays mounted by the host, so closing must still abort fetches
+  // and bump the request id or a late response can update hidden state.
   useEffect(() => {
-    if (open) reset();
+    if (open) {
+      reset();
+      return;
+    }
+    requestIdRef.current += 1;
+    abortRef.current?.abort();
+    abortRef.current = null;
   }, [open, reset]);
 
   useEffect(() => {
@@ -167,11 +171,14 @@ export function TelegramConnectModal({
     }
   }
 
-  async function connect(opts: {
-    chat_id: number;
-    title?: string;
-    type?: string;
-  }) {
+  async function connect(
+    opts: {
+      chat_id: number;
+      title?: string;
+      type?: string;
+    },
+    fallbackStep: "pick" | "manual" = "pick",
+  ) {
     const { id: myReq, signal } = beginRequest();
     setError(null);
     setStep("connecting");
@@ -185,7 +192,7 @@ export function TelegramConnectModal({
       if (myReq !== requestIdRef.current || isAbortError(e)) return;
       const msg = e instanceof Error ? e.message : String(e);
       setError(msg);
-      setStep("pick");
+      setStep(fallbackStep);
     }
   }
 
@@ -467,7 +474,7 @@ export function TelegramConnectModal({
                     setError("Chat ID must be a non-zero integer.");
                     return;
                   }
-                  void connect({ chat_id: parsed });
+                  void connect({ chat_id: parsed }, "manual");
                 }}
               >
                 Connect

--- a/web/src/components/integrations/TelegramConnectModal.tsx
+++ b/web/src/components/integrations/TelegramConnectModal.tsx
@@ -1,0 +1,527 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  connectTelegramChannel,
+  discoverTelegramChats,
+  type TelegramGroup,
+  verifyTelegramBot,
+} from "../../api/client";
+import { useAppStore } from "../../stores/app";
+import { showNotice } from "../ui/Toast";
+
+// The wk-modal-* / wk-editor-* primitives this wizard renders are defined in
+// wiki.css, which is otherwise only pulled in when the user navigates to the
+// Wiki page. The Telegram wizard is mounted globally via TelegramConnectHost
+// and triggered from anywhere via /connect, so we import the stylesheet here
+// to guarantee the modal has its card surface, backdrop, and form controls
+// regardless of route. Vite/Rollup dedupes the import — no double-load cost.
+import "../../styles/wiki.css";
+
+type Step =
+  | "provider"
+  | "token"
+  | "verifying"
+  | "discovering"
+  | "pick"
+  | "manual"
+  | "connecting"
+  | "done";
+
+interface TelegramConnectModalProps {
+  /** When false, the modal renders nothing — checked by the host. */
+  open: boolean;
+  /** Where to enter the wizard. "provider" shows the integration picker
+   *  (parity with the TUI's `/connect` 4-option picker); "telegram" skips
+   *  the picker and lands on the bot-token entry step. */
+  initialStep: "provider" | "token";
+  /** Called when the user closes or finishes the wizard. */
+  onClose: () => void;
+}
+
+/**
+ * Web port of the TUI's `/connect telegram` flow. Walks the user from a
+ * pasted bot token → group discovery → channel creation, all without
+ * leaving the browser. Failures keep the user on the same step with the
+ * inputs still editable so they can retry.
+ *
+ * E2E-targeted hooks: every step root carries `data-testid="tg-step-<step>"`
+ * and primary controls carry `data-testid="tg-..."` so the Playwright
+ * suite can drive the wizard without depending on copy.
+ */
+export function TelegramConnectModal({
+  open,
+  initialStep,
+  onClose,
+}: TelegramConnectModalProps) {
+  const [step, setStep] = useState<Step>(initialStep);
+  const [token, setToken] = useState("");
+  const [botName, setBotName] = useState<string | null>(null);
+  const [groups, setGroups] = useState<TelegramGroup[]>([]);
+  const [manualChatID, setManualChatID] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [createdSlug, setCreatedSlug] = useState<string | null>(null);
+
+  // requestIdRef gates state updates after an `await`; abortRef cancels the
+  // underlying fetch. The combo handles two distinct bug classes:
+  //
+  //   1. Stale state writes — if the user clicks Cancel mid-verify, the late
+  //      response must not push the (now hidden) modal back to "pick" or fire
+  //      a "Connected #…" toast. The id check before each setState handles
+  //      that.
+  //
+  //   2. Wasted server-side work — even if we ignore the response, the broker
+  //      keeps running: SendTelegramMessage to the chat, manifest sync, the
+  //      whole channel create. A rapid Cancel → reopen → connect-different-
+  //      chat sequence would otherwise create two channels racing each other.
+  //      AbortController makes the server see the disconnect and shed the
+  //      request.
+  const requestIdRef = useRef(0);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const reset = useCallback(() => {
+    setStep(initialStep);
+    setToken("");
+    setBotName(null);
+    setGroups([]);
+    setManualChatID("");
+    setError(null);
+    setCreatedSlug(null);
+    // Bump so any in-flight verify/connect from this session is ignored,
+    // and abort the live fetch so the broker stops processing it.
+    requestIdRef.current += 1;
+    abortRef.current?.abort();
+    abortRef.current = null;
+  }, [initialStep]);
+
+  // Reset only on open transitions. The previous `if (open) reset(); else
+  // reset();` was a no-op ternary that ran reset on close too, which is
+  // technically fine (the hidden modal short-circuits on `if (!open) return
+  // null`) but misleading. The new shape makes the intent explicit: reset
+  // when the wizard is freshly opened.
+  useEffect(() => {
+    if (open) reset();
+  }, [open, reset]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  // beginRequest cancels any in-flight wizard fetch and returns a fresh
+  // (id, signal) pair tied to a new AbortController. Callers compare the
+  // captured id against requestIdRef.current after each `await` to skip
+  // state writes from stale responses. AbortError caught below is swallowed
+  // — that's exactly what we want, since reset() was the trigger.
+  function beginRequest(): { id: number; signal: AbortSignal } {
+    requestIdRef.current += 1;
+    const id = requestIdRef.current;
+    abortRef.current?.abort();
+    const ctrl = new AbortController();
+    abortRef.current = ctrl;
+    return { id, signal: ctrl.signal };
+  }
+
+  function isAbortError(e: unknown): boolean {
+    return (
+      typeof e === "object" &&
+      e !== null &&
+      "name" in e &&
+      (e as { name?: string }).name === "AbortError"
+    );
+  }
+
+  async function verifyAndDiscover(rawToken: string) {
+    const trimmed = rawToken.trim();
+    if (!trimmed) {
+      setError("Bot token is required.");
+      return;
+    }
+    const { id: myReq, signal } = beginRequest();
+    setError(null);
+    setStep("verifying");
+    try {
+      const verify = await verifyTelegramBot(trimmed, signal);
+      if (myReq !== requestIdRef.current) return;
+      if (!verify.ok) {
+        setError(verify.error ?? "Bot verification failed.");
+        setStep("token");
+        return;
+      }
+      setBotName(verify.bot_name ?? null);
+      setStep("discovering");
+      const found = await discoverTelegramChats(trimmed, signal);
+      if (myReq !== requestIdRef.current) return;
+      setGroups(found.groups ?? []);
+      setStep("pick");
+    } catch (e: unknown) {
+      if (myReq !== requestIdRef.current || isAbortError(e)) return;
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      setStep("token");
+    }
+  }
+
+  async function connect(opts: {
+    chat_id: number;
+    title?: string;
+    type?: string;
+  }) {
+    const { id: myReq, signal } = beginRequest();
+    setError(null);
+    setStep("connecting");
+    try {
+      const result = await connectTelegramChannel({ token, ...opts }, signal);
+      if (myReq !== requestIdRef.current) return;
+      setCreatedSlug(result.channel_slug);
+      setStep("done");
+      showNotice(`Connected #${result.channel_slug}`, "success");
+    } catch (e: unknown) {
+      if (myReq !== requestIdRef.current || isAbortError(e)) return;
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      setStep("pick");
+    }
+  }
+
+  return (
+    <div
+      className="wk-modal-backdrop"
+      data-testid="tg-connect-modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tg-connect-title"
+    >
+      <div className="wk-modal" style={{ maxWidth: 480 }}>
+        <h2 id="tg-connect-title">
+          {step === "provider" ? "Connect an integration" : "Connect Telegram"}
+        </h2>
+
+        {step === "provider" && (
+          <div data-testid="tg-step-provider">
+            <p className="wk-editor-help">
+              Pick an integration to bring into the office.
+            </p>
+            <ul style={{ listStyle: "none", padding: 0, marginTop: 8 }}>
+              <li style={{ marginBottom: 4 }}>
+                <button
+                  type="button"
+                  data-testid="tg-provider-telegram"
+                  className="wk-editor-cancel"
+                  style={{ width: "100%", textAlign: "left" }}
+                  onClick={() => setStep("token")}
+                >
+                  Telegram{" "}
+                  <span style={{ opacity: 0.6 }}>— bridge a group or DM</span>
+                </button>
+              </li>
+              <li style={{ marginBottom: 4 }}>
+                <button
+                  type="button"
+                  data-testid="tg-provider-openclaw"
+                  className="wk-editor-cancel"
+                  style={{ width: "100%", textAlign: "left" }}
+                  onClick={() => {
+                    showNotice(
+                      "OpenClaw connect lives in the TUI today. Run ./wuphf in your terminal, then /connect openclaw. Web wizard coming soon.",
+                      "info",
+                    );
+                    onClose();
+                  }}
+                >
+                  OpenClaw{" "}
+                  <span style={{ opacity: 0.6 }}>— TUI only for now</span>
+                </button>
+              </li>
+              <li style={{ marginBottom: 4 }}>
+                <button
+                  type="button"
+                  data-testid="tg-provider-slack"
+                  className="wk-editor-cancel"
+                  style={{ width: "100%", textAlign: "left", opacity: 0.5 }}
+                  disabled={true}
+                >
+                  Slack <span style={{ opacity: 0.6 }}>— coming soon</span>
+                </button>
+              </li>
+              <li style={{ marginBottom: 4 }}>
+                <button
+                  type="button"
+                  data-testid="tg-provider-discord"
+                  className="wk-editor-cancel"
+                  style={{ width: "100%", textAlign: "left", opacity: 0.5 }}
+                  disabled={true}
+                >
+                  Discord <span style={{ opacity: 0.6 }}>— coming soon</span>
+                </button>
+              </li>
+            </ul>
+            <div className="wk-editor-actions">
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                onClick={onClose}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === "token" && (
+          <div data-testid="tg-step-token">
+            <label className="wk-editor-label" htmlFor="tg-token">
+              Bot token from @BotFather
+            </label>
+            <input
+              id="tg-token"
+              data-testid="tg-token-input"
+              className="wk-editor-commit"
+              type="password"
+              autoComplete="off"
+              placeholder="123456:ABC..."
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") void verifyAndDiscover(token);
+              }}
+            />
+            {error && (
+              <div
+                className="wk-editor-banner wk-editor-banner--error"
+                role="alert"
+              >
+                {error}
+              </div>
+            )}
+            <div className="wk-editor-actions">
+              <button
+                type="button"
+                className="wk-editor-save"
+                data-testid="tg-token-submit"
+                onClick={() => void verifyAndDiscover(token)}
+              >
+                Verify
+              </button>
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                onClick={onClose}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === "verifying" && (
+          <p data-testid="tg-step-verifying">Verifying bot token…</p>
+        )}
+
+        {step === "discovering" && (
+          <p data-testid="tg-step-discovering">
+            Discovering groups{botName ? ` for ${botName}` : ""}…
+          </p>
+        )}
+
+        {step === "pick" && (
+          <div data-testid="tg-step-pick">
+            <p className="wk-editor-help">
+              {botName ? `Bot: ${botName}. ` : ""}
+              {groups.length === 0
+                ? "No groups found yet. Send a message in the group while the bot is a member, then retry — or enter the chat ID manually."
+                : "Choose a chat to bridge into the office."}
+            </p>
+
+            {groups.length > 0 && (
+              <ul
+                data-testid="tg-group-list"
+                style={{ listStyle: "none", padding: 0, marginTop: 8 }}
+              >
+                {groups.map((g) => (
+                  <li key={g.chat_id} style={{ marginBottom: 4 }}>
+                    <button
+                      type="button"
+                      data-testid={`tg-group-${g.chat_id}`}
+                      className="wk-editor-cancel"
+                      style={{ width: "100%", textAlign: "left" }}
+                      onClick={() =>
+                        void connect({
+                          chat_id: g.chat_id,
+                          title: g.title,
+                          type: g.type,
+                        })
+                      }
+                    >
+                      {g.title || `Chat ${g.chat_id}`}{" "}
+                      <span style={{ opacity: 0.6 }}>({g.chat_id})</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {error && (
+              <div
+                className="wk-editor-banner wk-editor-banner--error"
+                role="alert"
+              >
+                {error}
+              </div>
+            )}
+
+            <div className="wk-editor-actions">
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                data-testid="tg-retry-discover"
+                onClick={() => void verifyAndDiscover(token)}
+              >
+                Retry discovery
+              </button>
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                data-testid="tg-manual-chat-id"
+                onClick={() => setStep("manual")}
+              >
+                Enter chat ID manually
+              </button>
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                data-testid="tg-connect-dm"
+                onClick={() =>
+                  void connect({
+                    chat_id: 0,
+                    title: "Telegram DM",
+                    type: "private",
+                  })
+                }
+              >
+                Use as DM
+              </button>
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                onClick={onClose}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === "manual" && (
+          <div data-testid="tg-step-manual">
+            <label className="wk-editor-label" htmlFor="tg-manual-id">
+              Chat ID (e.g. -5093020979)
+            </label>
+            <input
+              id="tg-manual-id"
+              data-testid="tg-manual-id-input"
+              className="wk-editor-commit"
+              type="text"
+              // Telegram group IDs are negative integers and mobile numeric
+              // keypads typically omit the minus sign, so inputMode="numeric"
+              // would make this field unreachable on touch without paste. Keep
+              // text and validate the value with the strict regex below.
+              inputMode="text"
+              pattern="-?[0-9]+"
+              placeholder="-5093020979"
+              value={manualChatID}
+              onChange={(e) => setManualChatID(e.target.value)}
+            />
+            {error && (
+              <div
+                className="wk-editor-banner wk-editor-banner--error"
+                role="alert"
+              >
+                {error}
+              </div>
+            )}
+            <div className="wk-editor-actions">
+              <button
+                type="button"
+                className="wk-editor-save"
+                data-testid="tg-manual-submit"
+                onClick={() => {
+                  // Number.parseInt accepts trailing junk ("-12abc" → -12),
+                  // which would silently bridge the wrong chat. Require the
+                  // entire trimmed string to be an optional minus + digits
+                  // before converting, and use Number.isSafeInteger so chat
+                  // IDs that exceed 2^53 (Telegram allows them) surface as
+                  // a validation error rather than a silently-rounded id.
+                  const raw = manualChatID.trim();
+                  if (!/^-?\d+$/.test(raw)) {
+                    setError("Chat ID must be a non-zero integer.");
+                    return;
+                  }
+                  const parsed = Number(raw);
+                  if (!Number.isSafeInteger(parsed) || parsed === 0) {
+                    setError("Chat ID must be a non-zero integer.");
+                    return;
+                  }
+                  void connect({ chat_id: parsed });
+                }}
+              >
+                Connect
+              </button>
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                onClick={() => setStep("pick")}
+              >
+                Back
+              </button>
+            </div>
+          </div>
+        )}
+
+        {step === "connecting" && (
+          <p data-testid="tg-step-connecting">Connecting…</p>
+        )}
+
+        {step === "done" && (
+          <div data-testid="tg-step-done">
+            <p>
+              Connected. New channel:{" "}
+              <code data-testid="tg-created-slug">#{createdSlug}</code>
+            </p>
+            <div className="wk-editor-actions">
+              <button
+                type="button"
+                className="wk-editor-save"
+                data-testid="tg-done-close"
+                onClick={onClose}
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Mounted once near the app root. Reads the open flag + mode from the
+ *  store and translates the mode into the wizard's initial step. */
+export function TelegramConnectHost() {
+  const open = useAppStore((s) => s.telegramConnectOpen);
+  const mode = useAppStore((s) => s.telegramConnectMode);
+  const setOpen = useAppStore((s) => s.setTelegramConnectOpen);
+  const initialStep = mode === "telegram" ? "token" : "provider";
+  return (
+    <TelegramConnectModal
+      open={open}
+      initialStep={initialStep}
+      onClose={() => setOpen(false)}
+    />
+  );
+}

--- a/web/src/components/messages/Composer.tsx
+++ b/web/src/components/messages/Composer.tsx
@@ -295,6 +295,26 @@ function handleSlashCommand(input: string, handlers: SlashHandlers): boolean {
         .catch(() => showNotice("Cancel failed", "error"));
       return true;
     }
+    case "/connect": {
+      // Bare `/connect` opens the provider picker (parity with the TUI's
+      // `/connect` 4-option picker — see cmd/wuphf/channel.go:4871). Direct
+      // forms like `/connect telegram` skip the picker and land straight in
+      // the integration's wizard, also matching TUI behaviour.
+      const target = args.trim().toLowerCase();
+      if (!target) {
+        store.openConnectWizard("provider");
+        return true;
+      }
+      if (target === "telegram") {
+        store.openConnectWizard("telegram");
+        return true;
+      }
+      showNotice(
+        `Integration "${target}" doesn't have a web wizard yet — try /connect on its own to see what's available.`,
+        "info",
+      );
+      return true;
+    }
     default:
       return false;
   }

--- a/web/src/hooks/useCommands.test.ts
+++ b/web/src/hooks/useCommands.test.ts
@@ -1,94 +1,123 @@
-import { describe, expect, it } from 'vitest'
-import type { SlashCommandDescriptor } from '../api/client'
-import { __test__, FALLBACK_SLASH_COMMANDS } from './useCommands'
+import { describe, expect, it } from "vitest";
 
-const { toAutocomplete, COMMAND_ICONS, DEFAULT_ICON } = __test__
+import type { SlashCommandDescriptor } from "../api/client";
+import { __test__, FALLBACK_SLASH_COMMANDS } from "./useCommands";
 
-describe('toAutocomplete', () => {
-  it('filters out TUI-only commands and prefixes slash to the name', () => {
+const { toAutocomplete, COMMAND_ICONS, DEFAULT_ICON } = __test__;
+
+describe("toAutocomplete", () => {
+  it("filters out TUI-only commands and prefixes slash to the name", () => {
     const broker: SlashCommandDescriptor[] = [
-      { name: 'ask', description: 'Ask the team lead', webSupported: true },
-      { name: 'object', description: 'Object commands', webSupported: false },
-      { name: 'clear', description: 'Clear messages', webSupported: true },
-    ]
-    const mapped = toAutocomplete(broker)
-    expect(mapped.map((c) => c.name)).toEqual(['/ask', '/clear'])
-  })
+      { name: "ask", description: "Ask the team lead", webSupported: true },
+      { name: "object", description: "Object commands", webSupported: false },
+      { name: "clear", description: "Clear messages", webSupported: true },
+    ];
+    const mapped = toAutocomplete(broker);
+    expect(mapped.map((c) => c.name)).toEqual(["/ask", "/clear"]);
+  });
 
-  it('maps known commands to their icon', () => {
+  it("maps known commands to their icon", () => {
     const broker: SlashCommandDescriptor[] = [
-      { name: 'ask', description: 'Ask', webSupported: true },
-      { name: 'calendar', description: 'Calendar', webSupported: true },
-    ]
-    const mapped = toAutocomplete(broker)
-    expect(mapped[0].icon).toBe(COMMAND_ICONS.ask)
-    expect(mapped[1].icon).toBe(COMMAND_ICONS.calendar)
-  })
+      { name: "ask", description: "Ask", webSupported: true },
+      { name: "calendar", description: "Calendar", webSupported: true },
+    ];
+    const mapped = toAutocomplete(broker);
+    expect(mapped[0].icon).toBe(COMMAND_ICONS.ask);
+    expect(mapped[1].icon).toBe(COMMAND_ICONS.calendar);
+  });
 
-  it('assigns the default icon to unknown commands so autocomplete never shows a blank glyph', () => {
+  it("assigns the default icon to unknown commands so autocomplete never shows a blank glyph", () => {
     const broker: SlashCommandDescriptor[] = [
-      { name: 'brand-new-command', description: 'Future command', webSupported: true },
-    ]
-    const mapped = toAutocomplete(broker)
-    expect(mapped[0].icon).toBe(DEFAULT_ICON)
-  })
+      {
+        name: "brand-new-command",
+        description: "Future command",
+        webSupported: true,
+      },
+    ];
+    const mapped = toAutocomplete(broker);
+    expect(mapped[0].icon).toBe(DEFAULT_ICON);
+  });
 
-  it('preserves the broker description verbatim — broker is the source of truth', () => {
+  it("preserves the broker description verbatim — broker is the source of truth", () => {
     const broker: SlashCommandDescriptor[] = [
-      { name: 'ask', description: 'Custom override description', webSupported: true },
-    ]
-    const mapped = toAutocomplete(broker)
-    expect(mapped[0].desc).toBe('Custom override description')
-  })
+      {
+        name: "ask",
+        description: "Custom override description",
+        webSupported: true,
+      },
+    ];
+    const mapped = toAutocomplete(broker);
+    expect(mapped[0].desc).toBe("Custom override description");
+  });
 
-  it('returns an empty array when every command is TUI-only', () => {
+  it("returns an empty array when every command is TUI-only", () => {
     const broker: SlashCommandDescriptor[] = [
-      { name: 'object', description: 'TUI', webSupported: false },
-      { name: 'record', description: 'TUI', webSupported: false },
-    ]
-    expect(toAutocomplete(broker)).toEqual([])
-  })
+      { name: "object", description: "TUI", webSupported: false },
+      { name: "record", description: "TUI", webSupported: false },
+    ];
+    expect(toAutocomplete(broker)).toEqual([]);
+  });
 
-  it('returns an empty array for an empty broker response', () => {
-    expect(toAutocomplete([])).toEqual([])
-  })
-})
+  it("returns an empty array for an empty broker response", () => {
+    expect(toAutocomplete([])).toEqual([]);
+  });
+});
 
-describe('FALLBACK_SLASH_COMMANDS', () => {
+describe("FALLBACK_SLASH_COMMANDS", () => {
   // This locks in the fallback contract: if the broker is unreachable, the
   // autocomplete still populates with the web-supported command set the
   // composer knows how to execute.
-  it('covers every command the composer handler currently implements', () => {
+  it("covers every command the composer handler currently implements", () => {
     const expected = [
-      '/ask', '/lookup', '/lint', '/search', '/remember', '/help', '/clear', '/reset',
-      '/tasks', '/requests', '/recover', '/1o1', '/task', '/cancel',
-      '/policies', '/calendar', '/skills', '/focus', '/collab',
-      '/pause', '/resume', '/threads', '/provider',
-    ].sort()
-    expect(FALLBACK_SLASH_COMMANDS.map((c) => c.name).sort()).toEqual(expected)
-  })
+      "/ask",
+      "/lookup",
+      "/lint",
+      "/search",
+      "/remember",
+      "/help",
+      "/clear",
+      "/reset",
+      "/tasks",
+      "/requests",
+      "/recover",
+      "/1o1",
+      "/task",
+      "/cancel",
+      "/policies",
+      "/calendar",
+      "/skills",
+      "/focus",
+      "/collab",
+      "/pause",
+      "/resume",
+      "/threads",
+      "/provider",
+      "/connect",
+    ].sort();
+    expect(FALLBACK_SLASH_COMMANDS.map((c) => c.name).sort()).toEqual(expected);
+  });
 
-  it('never ships an empty icon — every fallback entry has a glyph', () => {
+  it("never ships an empty icon — every fallback entry has a glyph", () => {
     for (const cmd of FALLBACK_SLASH_COMMANDS) {
-      expect(cmd.icon).not.toBe('')
+      expect(cmd.icon).not.toBe("");
     }
-  })
+  });
 
   // Wiki intelligence commands ship in the fallback so the autocomplete
   // still lists them when the broker is unreachable. Descriptions match
   // the Slice 2 Thread E copy spec verbatim so a regression on either
   // side (fallback drift, broker description edit) fails loudly.
-  it('includes /lookup with the expected operator-language description', () => {
-    const lookup = FALLBACK_SLASH_COMMANDS.find((c) => c.name === '/lookup')
-    expect(lookup).toBeDefined()
-    expect(lookup?.desc).toBe('Cited answer from the team wiki')
-  })
+  it("includes /lookup with the expected operator-language description", () => {
+    const lookup = FALLBACK_SLASH_COMMANDS.find((c) => c.name === "/lookup");
+    expect(lookup).toBeDefined();
+    expect(lookup?.desc).toBe("Cited answer from the team wiki");
+  });
 
-  it('includes /lint with the expected operator-language description', () => {
-    const lint = FALLBACK_SLASH_COMMANDS.find((c) => c.name === '/lint')
-    expect(lint).toBeDefined()
-    expect(lint?.desc).toBe('Review wiki for contradictions and stale facts')
-  })
+  it("includes /lint with the expected operator-language description", () => {
+    const lint = FALLBACK_SLASH_COMMANDS.find((c) => c.name === "/lint");
+    expect(lint).toBeDefined();
+    expect(lint?.desc).toBe("Review wiki for contradictions and stale facts");
+  });
 
   // Real-world bug: useCommands returned a fresh array on every render, so
   // the Autocomplete effect that watches `commands` + items fired on every
@@ -97,15 +126,15 @@ describe('FALLBACK_SLASH_COMMANDS', () => {
   // array... React bailed with "Maximum update depth exceeded" and the UI
   // thrashed into unresponsiveness. Referential stability of the returned
   // list is load-bearing, not cosmetic.
-  it('toAutocomplete returns a stable result shape for identical input', () => {
+  it("toAutocomplete returns a stable result shape for identical input", () => {
     const broker: SlashCommandDescriptor[] = [
-      { name: 'ask', description: 'Ask the team lead', webSupported: true },
-    ]
-    const a = toAutocomplete(broker)
-    const b = toAutocomplete(broker)
+      { name: "ask", description: "Ask the team lead", webSupported: true },
+    ];
+    const a = toAutocomplete(broker);
+    const b = toAutocomplete(broker);
     // Same-content input → equal shape. The useMemo in useCommands takes
     // care of referential identity across renders; this pins the pure
     // helper's deterministic output contract.
-    expect(a).toEqual(b)
-  })
-})
+    expect(a).toEqual(b);
+  });
+});

--- a/web/src/hooks/useCommands.ts
+++ b/web/src/hooks/useCommands.ts
@@ -1,6 +1,7 @@
-import { useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { fetchCommands, type SlashCommandDescriptor } from '../api/client'
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchCommands, type SlashCommandDescriptor } from "../api/client";
 
 /**
  * Web-autocomplete view of one slash command. Mirrors the legacy
@@ -9,9 +10,9 @@ import { fetchCommands, type SlashCommandDescriptor } from '../api/client'
  * fallback.
  */
 export interface SlashCommand {
-  name: string
-  desc: string
-  icon: string
+  name: string;
+  desc: string;
+  icon: string;
 }
 
 /**
@@ -27,30 +28,35 @@ export interface SlashCommand {
  * emoji literals in source).
  */
 export const FALLBACK_SLASH_COMMANDS: SlashCommand[] = [
-  { name: '/ask', desc: 'Ask the team lead', icon: '💬' },
-  { name: '/lookup', desc: 'Cited answer from the team wiki', icon: '📖' },
-  { name: '/lint', desc: 'Review wiki for contradictions and stale facts', icon: '🩺' },
-  { name: '/search', desc: 'Search messages + KB', icon: '🔎' },
-  { name: '/remember', desc: 'Store a fact in memory', icon: '🧠' },
-  { name: '/help', desc: 'Show all commands + keys', icon: '❓' },
-  { name: '/clear', desc: 'Clear messages', icon: '🧹' },
-  { name: '/reset', desc: 'Reset the office', icon: '🔄' },
-  { name: '/tasks', desc: 'Open task board', icon: '📋' },
-  { name: '/requests', desc: 'Open requests', icon: '🔔' },
-  { name: '/recover', desc: 'Health Check view', icon: '🔁' },
-  { name: '/1o1', desc: '1:1 with agent', icon: '💬' },
-  { name: '/task', desc: 'Task actions', icon: '✅' },
-  { name: '/cancel', desc: 'Cancel a task', icon: '❌' },
-  { name: '/policies', desc: 'View policies', icon: '📜' },
-  { name: '/calendar', desc: 'View schedule', icon: '📅' },
-  { name: '/skills', desc: 'View skills', icon: '⚡' },
-  { name: '/focus', desc: 'Switch to delegation mode', icon: '🎯' },
-  { name: '/collab', desc: 'Switch to collaborative mode', icon: '🤝' },
-  { name: '/pause', desc: 'Pause all agents', icon: '⏸' },
-  { name: '/resume', desc: 'Resume all agents', icon: '▶' },
-  { name: '/threads', desc: 'See every active thread', icon: '🧵' },
-  { name: '/provider', desc: 'Switch runtime provider', icon: '⚙' },
-]
+  { name: "/ask", desc: "Ask the team lead", icon: "💬" },
+  { name: "/lookup", desc: "Cited answer from the team wiki", icon: "📖" },
+  {
+    name: "/lint",
+    desc: "Review wiki for contradictions and stale facts",
+    icon: "🩺",
+  },
+  { name: "/search", desc: "Search messages + KB", icon: "🔎" },
+  { name: "/remember", desc: "Store a fact in memory", icon: "🧠" },
+  { name: "/help", desc: "Show all commands + keys", icon: "❓" },
+  { name: "/clear", desc: "Clear messages", icon: "🧹" },
+  { name: "/reset", desc: "Reset the office", icon: "🔄" },
+  { name: "/tasks", desc: "Open task board", icon: "📋" },
+  { name: "/requests", desc: "Open requests", icon: "🔔" },
+  { name: "/recover", desc: "Health Check view", icon: "🔁" },
+  { name: "/1o1", desc: "1:1 with agent", icon: "💬" },
+  { name: "/task", desc: "Task actions", icon: "✅" },
+  { name: "/cancel", desc: "Cancel a task", icon: "❌" },
+  { name: "/policies", desc: "View policies", icon: "📜" },
+  { name: "/calendar", desc: "View schedule", icon: "📅" },
+  { name: "/skills", desc: "View skills", icon: "⚡" },
+  { name: "/focus", desc: "Switch to delegation mode", icon: "🎯" },
+  { name: "/collab", desc: "Switch to collaborative mode", icon: "🤝" },
+  { name: "/pause", desc: "Pause all agents", icon: "⏸" },
+  { name: "/resume", desc: "Resume all agents", icon: "▶" },
+  { name: "/threads", desc: "See every active thread", icon: "🧵" },
+  { name: "/provider", desc: "Switch runtime provider", icon: "⚙" },
+  { name: "/connect", desc: "Connect a Telegram chat", icon: "🔌" },
+];
 
 /**
  * Icon map for commands returned by the broker. Keyed by bare command name
@@ -59,32 +65,33 @@ export const FALLBACK_SLASH_COMMANDS: SlashCommand[] = [
  * and flips webSupported before updating this list.
  */
 const COMMAND_ICONS: Record<string, string> = {
-  ask: '💬',
-  lookup: '📖',
-  lint: '🩺',
-  search: '🔎',
-  remember: '🧠',
-  help: '❓',
-  clear: '🧹',
-  reset: '🔄',
-  tasks: '📋',
-  requests: '🔔',
-  recover: '🔁',
-  '1o1': '💬',
-  task: '✅',
-  cancel: '❌',
-  policies: '📜',
-  calendar: '📅',
-  skills: '⚡',
-  focus: '🎯',
-  collab: '🤝',
-  pause: '⏸',
-  resume: '▶',
-  threads: '🧵',
-  provider: '⚙',
-}
+  ask: "💬",
+  lookup: "📖",
+  lint: "🩺",
+  search: "🔎",
+  remember: "🧠",
+  help: "❓",
+  clear: "🧹",
+  reset: "🔄",
+  tasks: "📋",
+  requests: "🔔",
+  recover: "🔁",
+  "1o1": "💬",
+  task: "✅",
+  cancel: "❌",
+  policies: "📜",
+  calendar: "📅",
+  skills: "⚡",
+  focus: "🎯",
+  collab: "🤝",
+  pause: "⏸",
+  resume: "▶",
+  threads: "🧵",
+  provider: "⚙",
+  connect: "🔌",
+};
 
-const DEFAULT_ICON = '›'
+const DEFAULT_ICON = "›";
 
 /**
  * Convert the broker's payload into the shape the autocomplete renderer
@@ -95,10 +102,10 @@ function toAutocomplete(commands: SlashCommandDescriptor[]): SlashCommand[] {
   return commands
     .filter((c) => c.webSupported)
     .map((c) => ({
-      name: '/' + c.name,
+      name: "/" + c.name,
       desc: c.description,
       icon: COMMAND_ICONS[c.name] ?? DEFAULT_ICON,
-    }))
+    }));
 }
 
 /**
@@ -112,14 +119,14 @@ function toAutocomplete(commands: SlashCommandDescriptor[]): SlashCommand[] {
  */
 export function useCommands(): SlashCommand[] {
   const { data, isError } = useQuery({
-    queryKey: ['commands'],
+    queryKey: ["commands"],
     queryFn: fetchCommands,
     // Registry only changes on rebuild. Five minutes is enough to absorb a
     // dev loop without hammering the broker.
     staleTime: 5 * 60_000,
     // Failures fall through to the fallback — don't retry aggressively.
     retry: 1,
-  })
+  });
 
   // Memoize the derived view so consumers relying on the returned array as
   // a dependency (e.g. the autocomplete effect) don't see a fresh reference
@@ -129,14 +136,14 @@ export function useCommands(): SlashCommand[] {
   // "Maximum update depth exceeded."
   return useMemo(() => {
     if (isError || !data) {
-      return FALLBACK_SLASH_COMMANDS
+      return FALLBACK_SLASH_COMMANDS;
     }
-    const mapped = toAutocomplete(data)
+    const mapped = toAutocomplete(data);
     // Defensive: if the broker returns an empty webSupported set (e.g. an
     // older broker without the flag), prefer the fallback rather than an
     // empty autocomplete.
-    return mapped.length > 0 ? mapped : FALLBACK_SLASH_COMMANDS
-  }, [data, isError])
+    return mapped.length > 0 ? mapped : FALLBACK_SLASH_COMMANDS;
+  }, [data, isError]);
 }
 
 // Exported for tests.
@@ -144,4 +151,4 @@ export const __test__ = {
   toAutocomplete,
   COMMAND_ICONS,
   DEFAULT_ICON,
-}
+};

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -179,6 +179,16 @@ export interface AppStore {
   composerHelpOpen: boolean;
   setComposerHelpOpen: (v: boolean) => void;
 
+  // /connect integration wizard. Bare /connect opens the provider picker
+  // (mode = "provider", parity with the TUI's `/connect` 4-option picker).
+  // `/connect telegram` skips the picker and lands on the Telegram token
+  // step (mode = "telegram"). Other modes can be added when more
+  // integrations get web wizards.
+  telegramConnectOpen: boolean;
+  telegramConnectMode: "provider" | "telegram";
+  openConnectWizard: (mode: "provider" | "telegram") => void;
+  setTelegramConnectOpen: (v: boolean) => void;
+
   // Onboarding
   onboardingComplete: boolean;
   setOnboardingComplete: (v: boolean) => void;
@@ -354,6 +364,12 @@ export const useAppStore = create<AppStore>((set, get) => ({
   composerHelpOpen: false,
   setComposerHelpOpen: (v) => set({ composerHelpOpen: v }),
 
+  telegramConnectOpen: false,
+  telegramConnectMode: "provider",
+  openConnectWizard: (mode) =>
+    set({ telegramConnectOpen: true, telegramConnectMode: mode }),
+  setTelegramConnectOpen: (v) => set({ telegramConnectOpen: v }),
+
   onboardingComplete: false,
   setOnboardingComplete: (v) => set({ onboardingComplete: v }),
   resetForOnboarding: () =>
@@ -367,6 +383,10 @@ export const useAppStore = create<AppStore>((set, get) => ({
       searchOpen: false,
       composerSearchInitialQuery: "",
       composerHelpOpen: false,
+      // Close the /connect wizard during an onboarding reset for the same
+      // reason searchOpen / composerHelpOpen are: any modal left open here
+      // would float over the onboarding flow.
+      telegramConnectOpen: false,
       onboardingComplete: false,
       wikiPath: null,
       wikiLookupQuery: null,

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1,30 +1,39 @@
-/* Wiki surface — scoped to .wiki-root.
- * Aligned to the Nex design system: cyan accent, neutral palette.
- * Keeps Wikipedia IA + editorial serif hierarchy for articles only.
+/* Wiki surface — articles + sidebar are scoped to .wiki-root, but the
+ * wk-modal-* / wk-editor-* primitives further down are global selectors
+ * intentionally reused outside the wiki (e.g. the Telegram /connect
+ * wizard, mounted from App.tsx). The variables they read therefore have
+ * to be defined at :root, not on .wiki-root, or the modal renders with a
+ * transparent background and no border outside the wiki page.
+ *
+ * Each --wk-* below is an alias of an already-global token (--bg,
+ * --border, etc.), so promoting the declarations to :root doesn't change
+ * any wiki rendering — it just makes the aliases resolve everywhere.
  */
-.wiki-root {
-  --wk-paper:           var(--bg);
-  --wk-paper-dark:      var(--bg-warm);
-  --wk-surface:         var(--bg-card);
-  --wk-text:            var(--text);
-  --wk-text-muted:      var(--text-secondary);
-  --wk-text-tertiary:   var(--text-tertiary);
-  --wk-border:          var(--border);
-  --wk-border-light:    var(--border-light);
-  --wk-border-strong:   var(--border-dark);
-  --wk-wikilink:        var(--olive-500);
+:root {
+  --wk-paper: var(--bg);
+  --wk-paper-dark: var(--bg-warm);
+  --wk-surface: var(--bg-card);
+  --wk-text: var(--text);
+  --wk-text-muted: var(--text-secondary);
+  --wk-text-tertiary: var(--text-tertiary);
+  --wk-border: var(--border);
+  --wk-border-light: var(--border-light);
+  --wk-border-strong: var(--border-dark);
+  --wk-wikilink: var(--olive-500);
   --wk-wikilink-broken: var(--red);
-  --wk-amber:           var(--olive-500);
-  --wk-amber-bg:        var(--olive-200);
-  --wk-amber-banner:    var(--olive-100);
-  --wk-code-bg:         var(--bg-warm);
-  --wk-display:    var(--font-sans);
-  --wk-body-serif: 'Source Serif 4', ui-serif, Georgia, serif;
-  --wk-chrome:     var(--font-sans);
-  --wk-mono:       var(--font-mono);
+  --wk-amber: var(--olive-500);
+  --wk-amber-bg: var(--olive-200);
+  --wk-amber-banner: var(--olive-100);
+  --wk-code-bg: var(--bg-warm);
+  --wk-display: var(--font-sans);
+  --wk-body-serif: "Source Serif 4", ui-serif, georgia, serif;
+  --wk-chrome: var(--font-sans);
+  --wk-mono: var(--font-mono);
   --wk-sidebar-left: 240px;
   --wk-sidebar-right: 280px;
   --wk-article-max: 640px;
+}
+.wiki-root {
   background: var(--wk-paper);
   color: var(--wk-text);
   line-height: 1.6;
@@ -36,20 +45,30 @@
   flex-direction: column;
   min-height: 0;
 }
-.wiki-root * { box-sizing: border-box; }
-.wiki-root a { color: var(--wk-wikilink); text-decoration: none; }
+.wiki-root * {
+  box-sizing: border-box;
+}
+.wiki-root a {
+  color: var(--wk-wikilink);
+  text-decoration: none;
+}
 
 /* ─── 3-column layout ─── */
 .wiki-layout {
   display: grid;
-  grid-template-columns: var(--wk-sidebar-left) minmax(0, 1fr) var(--wk-sidebar-right);
+  grid-template-columns: var(--wk-sidebar-left) minmax(0, 1fr) var(
+      --wk-sidebar-right
+    );
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
 }
 .wiki-layout > .wk-catalog,
 .wiki-layout > .wk-article-col,
-.wiki-layout > .wk-toc-col { min-height: 0; overflow-y: auto; }
+.wiki-layout > .wk-toc-col {
+  min-height: 0;
+  overflow-y: auto;
+}
 /* Catalog has no right rail — give the main column all the remaining space. */
 .wiki-layout[data-view="catalog"] {
   grid-template-columns: var(--wk-sidebar-left) minmax(0, 1fr);
@@ -77,8 +96,15 @@
   padding: 16px 0 16px;
   scrollbar-width: none;
 }
-.wk-nav-sidebar-scroll::-webkit-scrollbar { width: 0; height: 0; }
-.wk-nav-sidebar-scroll > div { display: flex; flex-direction: column; gap: 2px; }
+.wk-nav-sidebar-scroll::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+.wk-nav-sidebar-scroll > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
 .wk-nav-sidebar h3 {
   font-family: var(--wk-chrome);
   font-size: 10px;
@@ -89,7 +115,14 @@
   margin: 0 0 4px;
   padding: 0 10px;
 }
-.wk-nav-sidebar ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; }
+.wk-nav-sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
 .wk-nav-sidebar li a {
   display: flex;
   align-items: center;
@@ -101,7 +134,10 @@
   line-height: 1.3;
   cursor: pointer;
 }
-.wk-nav-sidebar li a:hover { background: var(--wk-paper-dark); color: var(--wk-text); }
+.wk-nav-sidebar li a:hover {
+  background: var(--wk-paper-dark);
+  color: var(--wk-text);
+}
 .wk-nav-sidebar li.current a {
   background: var(--wk-amber-bg);
   color: var(--wk-text);
@@ -119,10 +155,16 @@
   outline: none;
   transition: border-color 0.15s;
 }
-.wk-nav-sidebar .search:focus { border-color: var(--wk-wikilink); }
-.wk-nav-sidebar .tools-sep { border: 0; border-top: 1px solid var(--wk-border); margin: 8px 0 0; }
+.wk-nav-sidebar .search:focus {
+  border-color: var(--wk-wikilink);
+}
+.wk-nav-sidebar .tools-sep {
+  border: 0;
+  border-top: 1px solid var(--wk-border);
+  margin: 8px 0 0;
+}
 .wk-nav-sidebar .tools li a::before {
-  content: '→ ';
+  content: "→ ";
   color: var(--wk-text-tertiary);
   font-family: var(--wk-mono);
 }
@@ -130,7 +172,10 @@
 /* ─── CENTER article column ─── */
 /* position: relative creates the positioning context for .pam-wrap (see
  * styles/pam.css) — Pam's desk hangs off the top-right of the column. */
-.wk-article-col { padding: 0 64px 120px; position: relative; }
+.wk-article-col {
+  padding: 0 64px 120px;
+  position: relative;
+}
 
 /* ─── Status banner ─── */
 .wk-status-banner {
@@ -146,20 +191,31 @@
   gap: 12px;
 }
 .wk-status-banner .wk-icon {
-  width: 6px; height: 6px;
+  width: 6px;
+  height: 6px;
   background: var(--wk-amber);
   border-radius: 50%;
   animation: wk-pulse 1.8s ease-in-out infinite;
   flex-shrink: 0;
 }
-.wk-status-banner strong { font-weight: 600; }
+.wk-status-banner strong {
+  font-weight: 600;
+}
 .wk-status-banner .wk-meta {
   margin-left: auto;
   color: var(--wk-text-muted);
   font-family: var(--wk-mono);
   font-size: 11px;
 }
-@keyframes wk-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+@keyframes wk-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+}
 
 /* ─── Hat-bar ─── */
 .wk-hatbar {
@@ -189,8 +245,13 @@
   font-weight: 500;
   background: var(--wk-paper);
 }
-.wk-hatbar .wk-tab:hover:not(.active):not(:disabled) { color: var(--wk-text); }
-.wk-hatbar .wk-tab:disabled { opacity: 0.45; cursor: not-allowed; }
+.wk-hatbar .wk-tab:hover:not(.active):not(:disabled) {
+  color: var(--wk-text);
+}
+.wk-hatbar .wk-tab:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
 .wk-hatbar .wk-rail-right {
   margin-left: auto;
   display: flex;
@@ -211,9 +272,16 @@
   align-items: center;
   gap: 6px;
 }
-.wk-breadcrumb a { color: var(--wk-text-muted); cursor: pointer; }
-.wk-breadcrumb a:hover { color: var(--wk-wikilink); }
-.wk-breadcrumb .sep { color: var(--wk-text-tertiary); }
+.wk-breadcrumb a {
+  color: var(--wk-text-muted);
+  cursor: pointer;
+}
+.wk-breadcrumb a:hover {
+  color: var(--wk-wikilink);
+}
+.wk-breadcrumb .sep {
+  color: var(--wk-text-tertiary);
+}
 
 /* ─── Title ─── */
 .wk-article-title {
@@ -258,7 +326,10 @@
   width: 22px;
   height: 22px;
 }
-.wk-byline .wk-name { color: var(--wk-text); font-weight: 500; }
+.wk-byline .wk-name {
+  color: var(--wk-text);
+  font-weight: 500;
+}
 .wk-byline .wk-ts {
   background: var(--wk-amber-bg);
   padding: 2px 8px;
@@ -271,7 +342,7 @@
   gap: 6px;
 }
 .wk-byline .wk-ts::before {
-  content: '';
+  content: "";
   width: 6px;
   height: 6px;
   background: var(--wk-amber);
@@ -279,8 +350,12 @@
   display: inline-block;
   animation: wk-pulse 1.8s ease-in-out infinite;
 }
-.wk-byline .wk-dot { color: var(--wk-text-tertiary); }
-.wk-byline .wk-started-date { color: var(--wk-text); }
+.wk-byline .wk-dot {
+  color: var(--wk-text-tertiary);
+}
+.wk-byline .wk-started-date {
+  color: var(--wk-text);
+}
 
 /* ─── Hatnote ─── */
 .wk-hatnote {
@@ -307,7 +382,9 @@
   color: var(--wk-text);
   max-width: var(--wk-article-max);
 }
-.wk-article-body p { margin: 0 0 18px; }
+.wk-article-body p {
+  margin: 0 0 18px;
+}
 .wk-article-body h2 {
   font-family: var(--wk-display);
   font-size: 28px;
@@ -327,9 +404,17 @@
   margin: 28px 0 10px;
   font-variation-settings: "opsz" 24;
 }
-.wk-article-body ul, .wk-article-body ol { margin: 0 0 18px 24px; padding: 0; }
-.wk-article-body li { margin-bottom: 6px; }
-.wk-article-body strong { font-weight: 600; }
+.wk-article-body ul,
+.wk-article-body ol {
+  margin: 0 0 18px 24px;
+  padding: 0;
+}
+.wk-article-body li {
+  margin-bottom: 6px;
+}
+.wk-article-body strong {
+  font-weight: 600;
+}
 .wk-article-body a.wk-wikilink,
 .wk-article-body a[data-wikilink="true"] {
   color: var(--wk-wikilink);
@@ -350,7 +435,7 @@
 }
 .wk-article-body a.wk-wikilink.wk-broken::after,
 .wk-article-body a[data-wikilink="true"][data-broken="true"]::after {
-  content: ' ⚬';
+  content: " ⚬";
   font-size: 0.7em;
   opacity: 0.6;
 }
@@ -375,15 +460,17 @@
   padding: 8px 12px;
   text-align: left;
   vertical-align: top;
-  border-bottom: 1px solid var(--wk-border, rgba(0,0,0,0.08));
+  border-bottom: 1px solid var(--wk-border, rgba(0, 0, 0, 0.08));
 }
 .wk-article-body table th {
   font-weight: 600;
   color: var(--wk-text, inherit);
-  border-bottom: 1px solid var(--wk-text, rgba(0,0,0,0.35));
+  border-bottom: 1px solid var(--wk-text, rgba(0, 0, 0, 0.35));
   background: transparent;
 }
-.wk-article-body table tbody tr:hover { background: rgba(0,0,0,0.02); }
+.wk-article-body table tbody tr:hover {
+  background: rgba(0, 0, 0, 0.02);
+}
 
 /* ─── Infobox ─── */
 .wk-infobox {
@@ -406,14 +493,20 @@
   padding: 8px 12px;
   text-align: center;
 }
-.wk-infobox .wk-ib-body { padding: 12px; }
+.wk-infobox .wk-ib-body {
+  padding: 12px;
+}
 .wk-infobox dl {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 6px 10px;
   margin: 0;
 }
-.wk-infobox dt { color: var(--wk-text-muted); font-family: var(--wk-chrome); font-weight: 500; }
+.wk-infobox dt {
+  color: var(--wk-text-muted);
+  font-family: var(--wk-chrome);
+  font-weight: 500;
+}
 .wk-infobox dd {
   color: var(--wk-text);
   font-variant-numeric: tabular-nums;
@@ -427,7 +520,9 @@
 }
 
 /* ─── See also ─── */
-.wk-see-also { margin: 48px 0 24px; }
+.wk-see-also {
+  margin: 48px 0 24px;
+}
 .wk-see-also h2 {
   font-family: var(--wk-display);
   font-size: 22px;
@@ -444,7 +539,10 @@
   font-size: 16px;
   font-style: italic;
 }
-.wk-see-also li { margin-bottom: 4px; line-height: 1.5; }
+.wk-see-also li {
+  margin-bottom: 4px;
+  line-height: 1.5;
+}
 .wk-see-also a {
   color: var(--wk-wikilink);
   text-decoration: underline;
@@ -468,14 +566,23 @@
   padding-bottom: 6px;
   color: var(--wk-text);
 }
-.wk-sources ol { list-style: decimal; margin: 0 0 0 24px; padding: 0; }
-.wk-sources li { margin-bottom: 6px; }
+.wk-sources ol {
+  list-style: decimal;
+  margin: 0 0 0 24px;
+  padding: 0;
+}
+.wk-sources li {
+  margin-bottom: 6px;
+}
 .wk-sources li a {
   color: var(--wk-wikilink);
   font-family: var(--wk-mono);
   font-size: 12px;
 }
-.wk-sources li .wk-commit-msg { color: var(--wk-text); font-family: var(--wk-body-serif); }
+.wk-sources li .wk-commit-msg {
+  color: var(--wk-text);
+  font-family: var(--wk-body-serif);
+}
 .wk-sources li .wk-agent {
   display: inline-flex;
   align-items: center;
@@ -512,7 +619,11 @@
   align-items: center;
   gap: 6px 4px;
 }
-.wk-categories .wk-label { font-weight: 600; margin-right: 6px; color: var(--wk-text); }
+.wk-categories .wk-label {
+  font-weight: 600;
+  margin-right: 6px;
+  color: var(--wk-text);
+}
 .wk-categories a {
   background: var(--wk-paper-dark);
   color: var(--wk-text);
@@ -521,7 +632,9 @@
   border: 1px solid var(--wk-border);
   font-size: 12px;
 }
-.wk-categories a:hover { background: var(--wk-amber-bg); }
+.wk-categories a:hover {
+  background: var(--wk-amber-bg);
+}
 
 /* ─── Page footer ─── */
 .wk-page-footer {
@@ -539,10 +652,22 @@
   flex-wrap: wrap;
   gap: 0 14px;
 }
-.wk-page-footer .wk-actions a { color: var(--wk-wikilink); cursor: pointer; }
-.wk-page-footer .wk-dim { color: var(--wk-text-tertiary); font-style: italic; margin-top: 8px; }
-.wk-page-footer .wk-last-edit-name { color: var(--wk-text); font-weight: 500; }
-.wk-page-footer .wk-last-edit-ts { color: var(--wk-text); }
+.wk-page-footer .wk-actions a {
+  color: var(--wk-wikilink);
+  cursor: pointer;
+}
+.wk-page-footer .wk-dim {
+  color: var(--wk-text-tertiary);
+  font-style: italic;
+  margin-top: 8px;
+}
+.wk-page-footer .wk-last-edit-name {
+  color: var(--wk-text);
+  font-weight: 500;
+}
+.wk-page-footer .wk-last-edit-ts {
+  color: var(--wk-text);
+}
 
 /* ─── RIGHT SIDEBAR ─── */
 .wk-right-sidebar {
@@ -616,10 +741,23 @@
   color: var(--wk-text);
   cursor: pointer;
 }
-.wk-toc-nested a.wk-lvl-1 { font-weight: 500; }
-.wk-toc-nested a.wk-lvl-2 { padding-left: 20px; font-size: 12px; color: var(--wk-text-muted); }
-.wk-toc-nested a.wk-lvl-3 { padding-left: 36px; font-size: 12px; color: var(--wk-text-tertiary); }
-.wk-toc-nested a.wk-lvl-1:hover, .wk-toc-nested a.wk-lvl-2:hover { color: var(--wk-wikilink); }
+.wk-toc-nested a.wk-lvl-1 {
+  font-weight: 500;
+}
+.wk-toc-nested a.wk-lvl-2 {
+  padding-left: 20px;
+  font-size: 12px;
+  color: var(--wk-text-muted);
+}
+.wk-toc-nested a.wk-lvl-3 {
+  padding-left: 36px;
+  font-size: 12px;
+  color: var(--wk-text-tertiary);
+}
+.wk-toc-nested a.wk-lvl-1:hover,
+.wk-toc-nested a.wk-lvl-2:hover {
+  color: var(--wk-wikilink);
+}
 .wk-toc-nested a .wk-num {
   color: var(--wk-text-tertiary);
   font-variant-numeric: tabular-nums;
@@ -641,7 +779,10 @@
   font-size: 12px;
   margin: 0;
 }
-.wk-stats-panel dt { color: var(--wk-text-tertiary); font-family: var(--wk-chrome); }
+.wk-stats-panel dt {
+  color: var(--wk-text-tertiary);
+  font-family: var(--wk-chrome);
+}
 .wk-stats-panel dd {
   color: var(--wk-text);
   font-family: var(--wk-mono);
@@ -668,7 +809,10 @@
   gap: 8px;
   margin-bottom: 6px;
 }
-.wk-cite-panel .wk-wikilink-code code { background: transparent; padding: 0; }
+.wk-cite-panel .wk-wikilink-code code {
+  background: transparent;
+  padding: 0;
+}
 .wk-cite-panel .wk-copy-btn {
   margin-left: auto;
   background: var(--wk-text);
@@ -697,7 +841,9 @@
   font-size: 13px;
   cursor: pointer;
 }
-.wk-backlinks a:hover { color: var(--wk-wikilink); }
+.wk-backlinks a:hover {
+  color: var(--wk-wikilink);
+}
 .wk-backlinks a .wk-avatar {
   image-rendering: pixelated;
   border-radius: 4px;
@@ -728,10 +874,20 @@
   scrollbar-width: thin;
   scrollbar-color: var(--wk-border-strong) transparent;
 }
-.wk-edit-log::-webkit-scrollbar { height: 6px; width: 6px; }
-.wk-edit-log::-webkit-scrollbar-track { background: transparent; }
-.wk-edit-log::-webkit-scrollbar-thumb { background: var(--wk-border-strong); border-radius: 3px; }
-.wk-edit-log::-webkit-scrollbar-thumb:hover { background: var(--wk-text-tertiary); }
+.wk-edit-log::-webkit-scrollbar {
+  height: 6px;
+  width: 6px;
+}
+.wk-edit-log::-webkit-scrollbar-track {
+  background: transparent;
+}
+.wk-edit-log::-webkit-scrollbar-thumb {
+  background: var(--wk-border-strong);
+  border-radius: 3px;
+}
+.wk-edit-log::-webkit-scrollbar-thumb:hover {
+  background: var(--wk-text-tertiary);
+}
 .wk-edit-log .wk-label {
   font-weight: 600;
   color: var(--wk-text-tertiary);
@@ -752,16 +908,24 @@
   width: 14px;
   height: 14px;
 }
-.wk-edit-log .wk-entry .wk-who { color: var(--wk-text); font-weight: 500; }
-.wk-edit-log .wk-entry .wk-action { color: var(--wk-text-muted); }
-.wk-edit-log .wk-entry .wk-what { color: var(--wk-wikilink); cursor: pointer; }
+.wk-edit-log .wk-entry .wk-who {
+  color: var(--wk-text);
+  font-weight: 500;
+}
+.wk-edit-log .wk-entry .wk-action {
+  color: var(--wk-text-muted);
+}
+.wk-edit-log .wk-entry .wk-what {
+  color: var(--wk-wikilink);
+  cursor: pointer;
+}
 .wk-edit-log .wk-entry .wk-when {
   color: var(--wk-text-tertiary);
   font-family: var(--wk-mono);
   font-size: 11px;
 }
 .wk-edit-log .wk-entry.wk-live::before {
-  content: '';
+  content: "";
   width: 6px;
   height: 6px;
   background: var(--wk-amber);
@@ -794,8 +958,12 @@
   padding-bottom: 14px;
   border-bottom: 1px solid var(--wk-border);
 }
-.wk-catalog-title { grid-area: title; }
-.wk-catalog-stats { grid-area: stats; }
+.wk-catalog-title {
+  grid-area: title;
+}
+.wk-catalog-stats {
+  grid-area: stats;
+}
 .wk-catalog-clone {
   grid-area: clone;
   font-size: 13px;
@@ -830,10 +998,14 @@
   gap: 24px;
 }
 @media (max-width: 1024px) {
-  .wk-catalog-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .wk-catalog-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }
 @media (max-width: 720px) {
-  .wk-catalog-grid { grid-template-columns: 1fr; }
+  .wk-catalog-grid {
+    grid-template-columns: 1fr;
+  }
 }
 .wk-catalog-card {
   background: var(--wk-surface);
@@ -860,7 +1032,11 @@
   font-family: var(--wk-mono);
   font-size: 11px;
 }
-.wk-catalog-card ul { list-style: none; margin: 0; padding: 0; }
+.wk-catalog-card ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
 .wk-catalog-card li {
   display: grid;
   grid-template-columns: 16px 1fr auto;
@@ -871,7 +1047,9 @@
   border-bottom: 1px dashed var(--wk-border-light);
   font-size: 14px;
 }
-.wk-catalog-card li:last-child { border-bottom: 0; }
+.wk-catalog-card li:last-child {
+  border-bottom: 0;
+}
 .wk-catalog-card li .wk-avatar {
   image-rendering: pixelated;
   width: 16px;
@@ -888,7 +1066,9 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.wk-catalog-card li .wk-title:hover { color: var(--wk-wikilink); }
+.wk-catalog-card li .wk-title:hover {
+  color: var(--wk-wikilink);
+}
 .wk-catalog-card li .wk-when {
   font-family: var(--wk-mono);
   font-size: 11px;
@@ -897,10 +1077,17 @@
 }
 /* Narrow cards: drop the timestamp so the title gets full width. */
 @container wk-cat (max-width: 200px) {
-  .wk-catalog-card li { grid-template-columns: 16px 1fr; }
-  .wk-catalog-card li .wk-when { display: none; }
+  .wk-catalog-card li {
+    grid-template-columns: 16px 1fr;
+  }
+  .wk-catalog-card li .wk-when {
+    display: none;
+  }
 }
-.wk-catalog-card { container-type: inline-size; container-name: wk-cat; }
+.wk-catalog-card {
+  container-type: inline-size;
+  container-name: wk-cat;
+}
 
 /* ─── Loading / error states ─── */
 .wk-loading,
@@ -911,7 +1098,9 @@
   font-family: var(--wk-chrome);
   font-size: 14px;
 }
-.wk-error { color: var(--wk-wikilink-broken); }
+.wk-error {
+  color: var(--wk-wikilink-broken);
+}
 
 /* Subtle spinner used for in-flight modal actions. Sized to sit inline with
  * 13px button text without forcing a layout reflow. Wiki-surface scoped —
@@ -930,7 +1119,11 @@
   margin-right: 6px;
   flex-shrink: 0;
 }
-@keyframes wk-spin { to { transform: rotate(360deg); } }
+@keyframes wk-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
 
 /* "Searching the wiki…" status line shown below the (virtual) lookup input
  * while the /wiki/lookup request is in flight. Fraunces-italic per
@@ -1115,7 +1308,10 @@
   padding: 1px 8px;
   margin-left: 4px;
 }
-.wk-audit-row.is-bootstrap .wk-audit-tag { color: var(--wk-accent-ink); border-color: var(--wk-accent); }
+.wk-audit-row.is-bootstrap .wk-audit-tag {
+  color: var(--wk-accent-ink);
+  border-color: var(--wk-accent);
+}
 .wk-audit-msg {
   font-family: var(--wk-body);
   font-size: 13px;
@@ -1214,15 +1410,16 @@
   opacity: 0.7;
 }
 .wk-section-new {
-  font-family: Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family:
+    Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 9px;
   font-weight: 500;
   text-transform: uppercase;
   letter-spacing: 0.06em;
   padding: 1px 5px;
   border-radius: 3px;
-  background: #CFF5F5;
-  color: #0F5C5C;
+  background: #cff5f5;
+  color: #0f5c5c;
 }
 .wk-section-empty {
   padding: 4px 10px;
@@ -1244,7 +1441,9 @@
   color: var(--wk-text);
   line-height: 1.4;
 }
-.wk-section-banner-body { flex: 1; }
+.wk-section-banner-body {
+  flex: 1;
+}
 .wk-section-banner-dismiss {
   background: transparent;
   border: none;
@@ -1254,7 +1453,9 @@
   line-height: 1;
   padding: 0 2px;
 }
-.wk-section-banner-dismiss:hover { color: var(--wk-text); }
+.wk-section-banner-dismiss:hover {
+  color: var(--wk-text);
+}
 
 /* Catalog header audit link */
 .wk-catalog-audit-link {
@@ -1284,7 +1485,9 @@
   text-decoration: underline dashed;
   text-underline-offset: 2px;
 }
-.wk-catalog-new-link:hover { text-decoration-style: solid; }
+.wk-catalog-new-link:hover {
+  text-decoration-style: solid;
+}
 
 .wk-editor {
   display: flex;
@@ -1348,7 +1551,10 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
-.wk-editor-cancel { background: var(--wk-paper); color: var(--wk-text); }
+.wk-editor-cancel {
+  background: var(--wk-paper);
+  color: var(--wk-text);
+}
 .wk-editor-help {
   font-family: var(--wk-chrome);
   font-size: 12px;
@@ -1526,7 +1732,9 @@
 .wk-entity-brief-bar--clean {
   color: var(--wk-text-muted);
 }
-.wk-entity-brief-bar__label { flex: 1 1 auto; }
+.wk-entity-brief-bar__label {
+  flex: 1 1 auto;
+}
 .wk-entity-brief-bar__label strong {
   font-weight: 600;
   color: var(--wk-text);
@@ -1587,7 +1795,9 @@
   padding: 8px 0;
   border-bottom: 1px dashed var(--wk-border-light);
 }
-.wk-facts-item:last-child { border-bottom: none; }
+.wk-facts-item:last-child {
+  border-bottom: none;
+}
 .wk-facts-item .wk-avatar {
   image-rendering: pixelated;
   width: 14px;
@@ -1628,7 +1838,10 @@
   color: var(--wk-text-tertiary);
   margin: 0;
 }
-.wk-facts-error { color: var(--wk-wikilink-broken); font-style: normal; }
+.wk-facts-error {
+  color: var(--wk-wikilink-broken);
+  font-style: normal;
+}
 .wk-facts-showall {
   margin-top: 10px;
   font-family: var(--wk-chrome);
@@ -1673,7 +1886,9 @@
   padding: 4px 0;
   border-bottom: 1px dashed var(--wk-border-light);
 }
-.wk-related-item:last-child { border-bottom: none; }
+.wk-related-item:last-child {
+  border-bottom: none;
+}
 .wk-related-link {
   color: var(--wk-wikilink);
   text-decoration: underline dashed;
@@ -1693,7 +1908,10 @@
   color: var(--wk-text-tertiary);
   margin: 0;
 }
-.wk-related-error { color: var(--wk-wikilink-broken); font-style: normal; }
+.wk-related-error {
+  color: var(--wk-wikilink-broken);
+  font-style: normal;
+}
 
 /* ─── Playbook compilation (v1.3) ─── */
 .wk-playbook-badge {
@@ -1797,7 +2015,9 @@
   padding: 10px 0;
   border-bottom: 1px dashed var(--wk-border-light);
 }
-.wk-playbook-execution:last-child { border-bottom: none; }
+.wk-playbook-execution:last-child {
+  border-bottom: none;
+}
 .wk-playbook-execution__pill {
   font-family: var(--wk-chrome);
   font-size: 10px;
@@ -1845,7 +2065,9 @@
   font-size: 11px;
   color: var(--wk-text-tertiary);
 }
-.wk-playbook-execution__meta time { font-family: var(--wk-mono); }
+.wk-playbook-execution__meta time {
+  font-family: var(--wk-mono);
+}
 .wk-playbook-executions__more {
   margin-top: 10px;
   font-family: var(--wk-chrome);
@@ -1900,7 +2122,9 @@
   color: var(--wk-body, #111);
   cursor: pointer;
   border-radius: 2px;
-  transition: background 150ms ease, opacity 150ms ease;
+  transition:
+    background 150ms ease,
+    opacity 150ms ease;
 }
 .wk-playbook-synthesis__button:hover:not([disabled]) {
   background: rgba(0, 0, 0, 0.04);
@@ -1909,11 +2133,11 @@
   opacity: 0.6;
   cursor: progress;
 }
-.wk-playbook-synthesis[data-state='success'] .wk-playbook-synthesis__button {
+.wk-playbook-synthesis[data-state="success"] .wk-playbook-synthesis__button {
   color: #2a7d2a;
   border-color: #2a7d2a;
 }
-.wk-playbook-synthesis[data-state='error'] .wk-playbook-synthesis__button {
+.wk-playbook-synthesis[data-state="error"] .wk-playbook-synthesis__button {
   color: #c94a4a;
   border-color: #c94a4a;
 }
@@ -1968,8 +2192,12 @@
   }
 }
 @keyframes image-embed-fade {
-  from { opacity: 0; }
-  to   { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 .image-embed__full {
   max-width: 90vw;

--- a/web/tests/setup.ts
+++ b/web/tests/setup.ts
@@ -1,4 +1,5 @@
-import '@testing-library/jest-dom/vitest'
+import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
 
 // Node 25+ exposes a built-in `globalThis.localStorage` with no real Storage
 // API (empty object prototype). happy-dom's window.localStorage then gets
@@ -6,34 +7,40 @@ import '@testing-library/jest-dom/vitest'
 // Storage polyfill for tests so draft-autosave logic can be exercised
 // deterministically.
 function createMemoryStorage(): Storage {
-  const data: Record<string, string> = {}
+  const data: Record<string, string> = {};
   const storage: Storage = {
     get length() {
-      return Object.keys(data).length
+      return Object.keys(data).length;
     },
     clear: () => {
-      for (const k of Object.keys(data)) delete data[k]
+      for (const k of Object.keys(data)) delete data[k];
     },
-    getItem: (key: string) =>
-      Object.prototype.hasOwnProperty.call(data, key) ? data[key] : null,
+    getItem: (key: string) => (Object.hasOwn(data, key) ? data[key] : null),
     key: (index: number) => Object.keys(data)[index] ?? null,
     removeItem: (key: string) => {
-      delete data[key]
+      delete data[key];
     },
     setItem: (key: string, value: string) => {
-      data[key] = String(value)
+      data[key] = String(value);
     },
-  }
-  return storage
+  };
+  return storage;
 }
 
-const memoryStorage = createMemoryStorage()
+const memoryStorage = createMemoryStorage();
 // Override on window AND globalThis so both lookup paths see the same store.
-Object.defineProperty(window, 'localStorage', {
+Object.defineProperty(window, "localStorage", {
   configurable: true,
   value: memoryStorage,
-})
-Object.defineProperty(globalThis, 'localStorage', {
+});
+Object.defineProperty(globalThis, "localStorage", {
   configurable: true,
   value: memoryStorage,
-})
+});
+
+vi.stubGlobal(
+  "fetch",
+  vi.fn(async () => {
+    throw new Error("Unexpected fetch in test environment");
+  }),
+);


### PR DESCRIPTION
## What changed
- Stub `fetch` in `web/tests/setup.ts` for the Vitest environment.
- Keep the existing in-memory `localStorage` polyfill intact.

## Why
- The web test suite was quietly reaching for localhost during setup, which produced noisy output and made real failures harder to see.
- This keeps tests deterministic and fail-fast when something unexpectedly tries to call the network.

## Validation
- `bun run test` in `web/`
- `git diff --check`
- push hooks: `build`, `smoke`, `vhs`

## Notes
- A staff-level self-review was performed before publishing; no blocking issues were found.