### PR TITLE
fix(ci): inline docs link check workflow

### DIFF
--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -18,11 +18,21 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Restore lychee cache
+        id: lychee-cache
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/restore@v5.0.5
+        with:
+          path: .lycheecache
+          # GitHub caches are immutable, so each run saves a fresh cache while
+          # future runs restore from this stable prefix.
+          key: lychee-${{ runner.os }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: lychee-${{ runner.os }}-
 
       - name: Link check (lychee)
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
@@ -43,3 +53,10 @@ jobs:
             --exclude "https://theoffice\.fandom\.com/wiki/WUPHF\.com_\(Website\)"
             '**/*.md' '**/*.mdx'
           fail: true
+
+      - name: Save lychee cache
+        if: ${{ always() && hashFiles('.lycheecache') != '' }}
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # ratchet:actions/cache/save@v5.0.5
+        with:
+          path: .lycheecache
+          key: ${{ steps.lychee-cache.outputs.cache-primary-key }}

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -1,9 +1,8 @@
 name: docs-link-check
 
-# Delegates to nex-crm/.github reusable. Catches dead links in Markdown
-# + MDX before they reach customers (especially relevant on this public
-# docs site). PR runs are scoped to doc paths; the weekly cron catches
-# external-link rot.
+# Catches dead links in Markdown + MDX before they reach customers
+# (especially relevant on this public docs site). PR runs are scoped
+# to doc paths; the weekly cron catches external-link rot.
 
 on:
   pull_request:
@@ -18,15 +17,25 @@ on:
 
 jobs:
   check:
-    # The reusable workflow sets job permissions to contents:read + issues:write.
-    # Grant them explicitly here; org defaults are read-only, and without this
-    # GitHub rejects the reusable call before creating any job logs.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
-      issues: write
-    # NOTE: 98294031… is the COMMIT sha v0.6.2 dereferences to. The
-    # earlier pin (34310b13…) was the annotated-tag-object sha — GitHub
-    # Actions cannot resolve `uses: …@<tag-object-sha>`, the workflow
-    # silently fails validation with conclusion=failure and zero jobs.
-    # Verified with: gh api repos/nex-crm/.github/git/tags/<tag-obj-sha> --jq .object.sha
-    uses: nex-crm/.github/.github/workflows/docs-link-check.yml@98294031b84bf07f8bdf227940225ba21e9d2678 # v0.6.2
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Link check (lychee)
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        with:
+          args: |
+            --verbose
+            --no-progress
+            --max-retries 2
+            --cache
+            --max-cache-age 1d
+            --exclude-path .git
+            --exclude-path node_modules
+            --exclude "example\.com"
+            --exclude "localhost"
+            **/*.md **/*.mdx
+          fail: true

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -42,6 +42,7 @@ jobs:
           args: |
             --verbose
             --no-progress
+            --root-dir "$(pwd)"
             --max-retries 2
             --cache
             --max-cache-age 1d

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -41,5 +41,5 @@ jobs:
             --exclude "localhost"
             --exclude "https://www\.npmjs\.com/package/wuphf"
             --exclude "https://theoffice\.fandom\.com/wiki/WUPHF\.com_\(Website\)"
-            **/*.md **/*.mdx
+            '**/*.md' '**/*.mdx'
           fail: true

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -11,12 +11,19 @@ on:
       - '**/*.md'
       - '**/*.mdx'
       - 'docs/**'
+      - '.github/workflows/docs-link-check.yml'
   schedule:
     - cron: '0 9 * * 1'  # Monday 09:00 UTC
   workflow_dispatch:
 
 jobs:
   check:
+    # The reusable workflow sets job permissions to contents:read + issues:write.
+    # Grant them explicitly here; org defaults are read-only, and without this
+    # GitHub rejects the reusable call before creating any job logs.
+    permissions:
+      contents: read
+      issues: write
     # NOTE: 98294031… is the COMMIT sha v0.6.2 dereferences to. The
     # earlier pin (34310b13…) was the annotated-tag-object sha — GitHub
     # Actions cannot resolve `uses: …@<tag-object-sha>`, the workflow

--- a/.github/workflows/docs-link-check.yml
+++ b/.github/workflows/docs-link-check.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Link check (lychee)
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
+          # npmjs.com and fandom.com return 403 to lychee in CI for these
+          # known-good links, so keep the exceptions URL-specific.
           args: |
             --verbose
             --no-progress
@@ -37,5 +39,7 @@ jobs:
             --exclude-path node_modules
             --exclude "example\.com"
             --exclude "localhost"
+            --exclude "https://www\.npmjs\.com/package/wuphf"
+            --exclude "https://theoffice\.fandom\.com/wiki/WUPHF\.com_\(Website\)"
             **/*.md **/*.mdx
           fail: true

--- a/web/src/lib/testSetupStorage.test.ts
+++ b/web/src/lib/testSetupStorage.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+describe("test localStorage polyfill", () => {
+  it("treats inherited object keys as absent until stored", () => {
+    localStorage.clear();
+
+    expect(localStorage.getItem("toString")).toBeNull();
+    expect(localStorage.getItem("__proto__")).toBeNull();
+
+    localStorage.setItem("toString", "method-name");
+    localStorage.setItem("__proto__", "prototype-name");
+
+    expect(localStorage.getItem("toString")).toBe("method-name");
+    expect(localStorage.getItem("__proto__")).toBe("prototype-name");
+  });
+});

--- a/web/tests/setup.ts
+++ b/web/tests/setup.ts
@@ -7,7 +7,7 @@ import { vi } from "vitest";
 // Storage polyfill for tests so draft-autosave logic can be exercised
 // deterministically.
 function createMemoryStorage(): Storage {
-  const data: Record<string, string> = Object.create(null);
+  const data: Record<string, string | undefined> = Object.create(null);
   const storage: Storage = {
     get length() {
       return Object.keys(data).length;

--- a/web/tests/setup.ts
+++ b/web/tests/setup.ts
@@ -15,7 +15,7 @@ function createMemoryStorage(): Storage {
     clear: () => {
       for (const k of Object.keys(data)) delete data[k];
     },
-    getItem: (key: string) => (key in data ? data[key] : null),
+    getItem: (key: string) => data[key] ?? null,
     key: (index: number) => Object.keys(data)[index] ?? null,
     removeItem: (key: string) => {
       delete data[key];


### PR DESCRIPTION
## Summary

- make `docs-link-check` self-contained with pinned checkout and lychee actions
- quote lychee input globs so Bash does not pre-expand them before lychee scans the Markdown tree
- keep `.github/workflows/docs-link-check.yml` in the PR path filter so workflow changes exercise the check
- add URL-specific excludes for known bot-blocked npmjs/Fandom links instead of accepting all 403s
- replace `Object.hasOwn` in web test setup with a TypeScript-target-safe lookup backed by a null-prototype store
- add a storage polyfill regression test for inherited/reserved keys

Fixes #585.

## Verification

- `actionlint .github/workflows/docs-link-check.yml`
- `bunx biome check web/tests/setup.ts web/src/lib/testSetupStorage.test.ts`
- `bunx vitest run src/lib/testSetupStorage.test.ts` from `web/`
- `git diff --check`
- `bash scripts/check-file-size.sh`
- `bun run typecheck` from `web/`
- `bun run build` from `web/`
- pre-commit hooks
- pre-push hooks: build, file-size, smoke, vhs
- self-review agent pass; addressed both findings

## Notes

The original docs-link-check failure mode produced a completed failure with zero jobs/logs for `.github/workflows/docs-link-check.yml`. Inlining the lychee check avoids the reusable workflow permission request and makes future failures produce normal job logs. The quoted globs now check 66 links in CI instead of the earlier 24-link Bash-expanded run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying the localStorage polyfill treats inherited/prototype keys as absent until explicitly set.

* **Chores**
  * Updated the docs link-check workflow to run inline with improved caching, retries/timeouts, and expanded PR trigger coverage.
  * Adjusted test storage setup to use a null-prototype backing and relaxed typing for storage entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->