### PR TITLE
chore(web): upgrade tsconfig to ES2024

### DIFF
--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2024",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",


### PR DESCRIPTION
Closes #588.

Upgrade the web TypeScript config to `ES2024` for both `target` and `lib`, so the compiler and emitted syntax stay aligned and the project is ready for newer TS/lib features.

Validation:
- `bun run build` in `web/`
- `bun run test:coverage` in `web/`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compilation configuration to target a more recent ECMAScript version, enabling enhanced support for modern JavaScript language features and improving tooling compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->