### PR TITLE
fix(release): populate changelog from conventional commits

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,7 +36,44 @@ checksum:
   name_template: checksums.txt
 
 changelog:
-  disable: true
+  use: git
+  sort: asc
+  abbrev: -1
+  format: "{{ .Message }}"
+  groups:
+    - title: Breaking changes
+      regexp: '^.*?(feat|fix|perf|refactor|docs|chore|test|build|ci|style|revert)(\([^)]+\))?!:.+$'
+      order: 0
+    - title: New features
+      regexp: '^.*?feat(\([^)]+\))?(!)?:.+$'
+      order: 1
+    - title: Bug fixes
+      regexp: '^.*?fix(\([^)]+\))?(!)?:.+$'
+      order: 2
+    - title: Performance
+      regexp: '^.*?perf(\([^)]+\))?(!)?:.+$'
+      order: 3
+    - title: Refactoring
+      regexp: '^.*?refactor(\([^)]+\))?(!)?:.+$'
+      order: 4
+    - title: Documentation
+      regexp: '^.*?docs(\([^)]+\))?(!)?:.+$'
+      order: 5
+    - title: Build and CI
+      regexp: '^.*?(build|ci)(\([^)]+\))?(!)?:.+$'
+      order: 6
+    - title: Maintenance
+      regexp: '^.*?(chore|test|style)(\([^)]+\))?(!)?:.+$'
+      order: 7
+    - title: Reverts
+      regexp: '^.*?revert(\([^)]+\))?(!)?:.+$'
+      order: 8
+    - title: Other changes
+      order: 999
+  filters:
+    exclude:
+      - "^Merge pull request"
+      - "^Merge remote-tracking branch"
 
 release:
   github:


### PR DESCRIPTION
## Summary

- enable GoReleaser changelog generation for GitHub Releases
- group release notes by Conventional Commit type, including breaking changes, features, fixes, performance, docs, CI/build, maintenance, and reverts
- filter merge commits out of generated release notes so the release body shows shipped changes instead of merge noise

## Why

GitHub Releases were being published with `changelog.disable: true`, so users had to inspect commits manually to understand what shipped. This lets the release workflow populate the GitHub Release body automatically from the semantic commit history between tags.

## Validation

- `goreleaser check`
- `goreleaser release --snapshot --clean --skip=publish`
- `bash scripts/test-go.sh`
- `bun install --frozen-lockfile` in `web/`
- `bun run typecheck` in `web/`
- `bun run test` in `web/`
- pre-push hook: build, complexity-baseline, file-size, go-unit, smoke, vhs, web-unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automatic changelog generation with improved organization and formatting. Changelogs now include categorized sections for breaking changes, new features, bug fixes, performance improvements, refactoring, documentation, build/CI updates, maintenance, reverts, and other changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->