### PR TITLE
fix(skills-publish): address review follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,14 +155,15 @@ wuphf skills publish deploy-frontend --to anthropics
 # Dry-run the same publish to inspect the manifest + PR body without opening the PR
 wuphf skills publish deploy-frontend --to anthropics --dry-run
 
-# Publish to a custom GitHub repo (e.g. your org's private fork of anthropics/skills)
+# Publish to a custom GitHub repo (optionally pinning a non-main branch)
 wuphf skills publish deploy-frontend --to github:nex-crm/wuphf-skills
+wuphf skills publish deploy-frontend --to github:nex-crm/wuphf-skills@master
 
 # Pull a community skill into your team's wiki
 wuphf skills install web-research --from anthropics
 ```
 
-Supported hubs: `anthropics`, `lobehub`, or any `github:owner/repo`. Publish requires `gh auth login` first; install only needs network access since it fetches public raw URLs.
+Supported hubs: `anthropics`, `lobehub`, or any `github:owner/repo[@branch]`. Custom GitHub hubs default to `main` unless a branch is specified. Publish requires `gh auth login` first; install only needs network access since it fetches public raw URLs.
 
 ## What You Should See
 

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -110,7 +110,7 @@ func printSubcommandHelp(sub string) {
 		fmt.Fprintln(os.Stderr, "  wuphf skills publish <slug-or-path> --to <hub>     Open a PR with this skill")
 		fmt.Fprintln(os.Stderr, "  wuphf skills install <name> --from <hub>           Pull a skill into your wiki")
 		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "Hubs: anthropics, lobehub, github:owner/repo")
+		fmt.Fprintln(os.Stderr, "Hubs: anthropics, lobehub, github:owner/repo[@branch]")
 	case "upgrade":
 		fmt.Fprintln(os.Stderr, "wuphf upgrade — check npm for a newer wuphf and show the changelog")
 		fmt.Fprintln(os.Stderr, "")
@@ -239,7 +239,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "  %s log          Show what your agents actually did (task receipts)\n", appName)
 		fmt.Fprintf(os.Stderr, "  %s memory migrate --from {nex,gbrain}  Port legacy memory into the team wiki\n", appName)
 		fmt.Fprintf(os.Stderr, "  %s workspace ...  Manage multiple isolated WUPHF workspaces\n", appName)
-		fmt.Fprintf(os.Stderr, "  %s skills publish <slug> --to <hub>    Publish a team skill to a public hub\n", appName)
+		fmt.Fprintf(os.Stderr, "  %s skills publish <slug-or-path> --to <hub>    Publish a team skill to a public hub\n", appName)
 		fmt.Fprintf(os.Stderr, "  %s skills install <name> --from <hub>  Pull a public skill into the team wiki\n", appName)
 		fmt.Fprintf(os.Stderr, "  %s --cmd <cmd>  Run a command non-interactively\n", appName)
 		fmt.Fprintf(os.Stderr, "\nFlags:\n")

--- a/cmd/wuphf/skills_publish.go
+++ b/cmd/wuphf/skills_publish.go
@@ -86,7 +86,7 @@ func printSkillsHelp() {
 	fmt.Fprintln(os.Stderr, "  wuphf skills publish <slug-or-path> --to <hub>     Open a PR with this skill")
 	fmt.Fprintln(os.Stderr, "  wuphf skills install <name> --from <hub>           Pull a skill into your wiki")
 	fmt.Fprintln(os.Stderr, "")
-	fmt.Fprintln(os.Stderr, "Hubs: anthropics, lobehub, github:owner/repo")
+	fmt.Fprintln(os.Stderr, "Hubs: anthropics, lobehub, github:owner/repo[@branch]")
 }
 
 // ── publish ────────────────────────────────────────────────────────────────
@@ -101,7 +101,7 @@ func printSkillsHelp() {
 //  5. Either dry-run print, or shell out to `gh` to open the PR.
 func runSkillsPublish(args []string) {
 	fs := flag.NewFlagSet("skills publish", flag.ContinueOnError)
-	to := fs.String("to", "", "Destination hub: anthropics, lobehub, or github:owner/repo")
+	to := fs.String("to", "", "Destination hub: anthropics, lobehub, or github:owner/repo[@branch]")
 	dryRun := fs.Bool("dry-run", false, "Print the manifest + would-be PR body, do not open the PR")
 	message := fs.String("message", "", "Optional addition to the PR body (defaults to the skill description)")
 	ghTokenFlag := fs.String("github-token", "", "Override gh's saved token; falls back to GH_TOKEN env when blank")
@@ -112,12 +112,12 @@ func runSkillsPublish(args []string) {
 		fmt.Fprintln(os.Stderr, "Usage:")
 		fmt.Fprintln(os.Stderr, "  wuphf skills publish <slug>          --to anthropics")
 		fmt.Fprintln(os.Stderr, "  wuphf skills publish team/skills/x.md --to lobehub")
-		fmt.Fprintln(os.Stderr, "  wuphf skills publish <slug>          --to github:owner/repo")
+		fmt.Fprintln(os.Stderr, "  wuphf skills publish <slug>          --to github:owner/repo[@branch]")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Flags:")
 		fs.PrintDefaults()
 	}
-	if err := fs.Parse(reorderFlagsFirst(args)); err != nil {
+	if err := fs.Parse(reorderFlagsFirst(fs, args)); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			os.Exit(0)
 		}
@@ -354,7 +354,7 @@ func publishViaGH(p publishParams) (string, error) {
 		"pr", "create",
 		"--repo", p.hubRepo,
 		"--base", p.baseBranch,
-		"--head", p.branch,
+		"--head", authUser+":"+p.branch,
 		"--title", p.prTitle,
 		"--body", p.prBody,
 	)
@@ -524,7 +524,7 @@ func indentBlock(s, prefix string) string {
 // runSkillsInstall handles `wuphf skills install`. Reverse of publish.
 func runSkillsInstall(args []string) {
 	fs := flag.NewFlagSet("skills install", flag.ContinueOnError)
-	from := fs.String("from", "", "Source hub: anthropics, lobehub, or github:owner/repo")
+	from := fs.String("from", "", "Source hub: anthropics, lobehub, or github:owner/repo[@branch]")
 	channel := fs.String("channel", "general", "Channel to log the install event into")
 	fs.SetOutput(os.Stderr)
 	fs.Usage = func() {
@@ -532,12 +532,12 @@ func runSkillsInstall(args []string) {
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Usage:")
 		fmt.Fprintln(os.Stderr, "  wuphf skills install <name> --from anthropics")
-		fmt.Fprintln(os.Stderr, "  wuphf skills install <name> --from github:owner/repo")
+		fmt.Fprintln(os.Stderr, "  wuphf skills install <name> --from github:owner/repo[@branch]")
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "Flags:")
 		fs.PrintDefaults()
 	}
-	if err := fs.Parse(reorderFlagsFirst(args)); err != nil {
+	if err := fs.Parse(reorderFlagsFirst(fs, args)); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			os.Exit(0)
 		}
@@ -654,7 +654,15 @@ func fetchURL(ctx context.Context, rawURL string) ([]byte, error) {
 	if res.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("HTTP %d from %s", res.StatusCode, rawURL)
 	}
-	return io.ReadAll(io.LimitReader(res.Body, 4*1024*1024))
+	const maxSkillBytes = 4 * 1024 * 1024
+	buf, err := io.ReadAll(io.LimitReader(res.Body, maxSkillBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(buf) > maxSkillBytes {
+		return nil, fmt.Errorf("response body exceeds %d bytes: %s", maxSkillBytes, rawURL)
+	}
+	return buf, nil
 }
 
 // postBrokerSkill posts to the local broker's /skills endpoint, mirroring the
@@ -696,7 +704,7 @@ func postBrokerSkill(ctx context.Context, payload map[string]any) error {
 // The reorder is deliberately conservative — anything past `--` stays in
 // place, and unknown flag-looking tokens are still treated as flags so the
 // downstream Parse can produce a friendly error message.
-func reorderFlagsFirst(args []string) []string {
+func reorderFlagsFirst(fs *flag.FlagSet, args []string) []string {
 	flags := []string{}
 	positional := []string{}
 	i := 0
@@ -708,12 +716,11 @@ func reorderFlagsFirst(args []string) []string {
 		}
 		if strings.HasPrefix(a, "-") && a != "-" {
 			flags = append(flags, a)
-			// If the flag is in `--key=value` form or is a `-h` style
-			// boolean, no value-arg follows. Otherwise, eagerly consume
-			// the next token. We can't introspect the FlagSet from here,
-			// so we apply the standard heuristic: if the next token does
-			// not itself start with `-`, treat it as the value.
-			if !strings.Contains(a, "=") && i+1 < len(args) {
+			// If the flag is in `--key=value` form or is a boolean flag,
+			// no value-arg follows. For value flags, eagerly consume the
+			// next token so Go's stdlib flag parser still accepts
+			// `wuphf skills publish slug --to anthropics`.
+			if !strings.Contains(a, "=") && !flagIsBool(fs, a) && i+1 < len(args) {
 				next := args[i+1]
 				if !strings.HasPrefix(next, "-") {
 					flags = append(flags, next)
@@ -729,12 +736,30 @@ func reorderFlagsFirst(args []string) []string {
 	return append(flags, positional...)
 }
 
+type boolFlag interface {
+	IsBoolFlag() bool
+}
+
+func flagIsBool(fs *flag.FlagSet, token string) bool {
+	name := strings.TrimLeft(token, "-")
+	if idx := strings.Index(name, "="); idx >= 0 {
+		name = name[:idx]
+	}
+	f := fs.Lookup(name)
+	if f == nil {
+		return false
+	}
+	bf, ok := f.Value.(boolFlag)
+	return ok && bf.IsBoolFlag()
+}
+
 // sanitizeHubLabel returns a hub label suitable for `created_by="hub:<label>"`.
-// `github:owner/repo` collapses to `github-owner-repo` so the broker sees a
-// stable identifier per source.
+// `github:owner/repo@branch` collapses to `github-owner-repo-branch` so the
+// broker sees a stable identifier per source.
 func sanitizeHubLabel(hub string) string {
 	hub = strings.TrimSpace(hub)
 	hub = strings.ReplaceAll(hub, ":", "-")
 	hub = strings.ReplaceAll(hub, "/", "-")
+	hub = strings.ReplaceAll(hub, "@", "-")
 	return strings.ToLower(hub)
 }

--- a/cmd/wuphf/skills_publish_test.go
+++ b/cmd/wuphf/skills_publish_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -97,6 +98,20 @@ func TestHubURL_GithubScheme(t *testing.T) {
 	}
 }
 
+// TestHubURL_GithubScheme_BranchOverride validates the branch override escape
+// hatch for custom repos whose default branch is not main.
+func TestHubURL_GithubScheme_BranchOverride(t *testing.T) {
+	t.Parallel()
+	got, err := skillpublish.HubURL("github:nex-crm/wuphf-skills@master", "review-pr")
+	if err != nil {
+		t.Fatalf("HubURL: %v", err)
+	}
+	want := "https://raw.githubusercontent.com/nex-crm/wuphf-skills/master/skills/review-pr/SKILL.md"
+	if got != want {
+		t.Fatalf("HubURL github scheme branch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
 // TestHubURL_Unknown ensures we surface a clear error for unknown hubs.
 func TestHubURL_Unknown(t *testing.T) {
 	t.Parallel()
@@ -168,6 +183,7 @@ func TestSanitizeHubLabel(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"anthropics", "anthropics"},
 		{"github:nex-crm/wuphf-skills", "github-nex-crm-wuphf-skills"},
+		{"github:nex-crm/wuphf-skills@master", "github-nex-crm-wuphf-skills-master"},
 		{"  Lobehub  ", "lobehub"},
 	}
 	for _, tc := range cases {
@@ -284,6 +300,24 @@ func TestFetchURL_RejectsRedirectOffGitHub(t *testing.T) {
 	}
 }
 
+// TestFetchURL_RejectsOversizedPayload ensures the size guard refuses, rather
+// than truncates, oversized skill payloads.
+func TestFetchURL_RejectsOversizedPayload(t *testing.T) {
+	tooLarge := strings.Repeat("x", 4*1024*1024+1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, tooLarge)
+	}))
+	defer srv.Close()
+
+	_, err := fetchURL(context.Background(), srv.URL+"/skills/x/SKILL.md")
+	if err == nil {
+		t.Fatal("expected oversized payload error, got nil")
+	}
+	if !strings.Contains(err.Error(), "response body exceeds") {
+		t.Errorf("expected size error, got %q", err.Error())
+	}
+}
+
 // TestPostBrokerSkill_4xxSurfacesBody pins the error-shape: a 4xx from
 // the broker should bubble up with the response body so the user can see
 // the broker's actual rejection reason (e.g. "name already exists" or
@@ -333,5 +367,18 @@ func TestBuildPublishPRBody(t *testing.T) {
 		if !strings.Contains(body, c) {
 			t.Fatalf("publish PR body missing %q\nbody: %s", c, body)
 		}
+	}
+}
+
+func TestReorderFlagsFirst_BoolFlagDoesNotConsumePositional(t *testing.T) {
+	t.Parallel()
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	fs.Bool("dry-run", false, "")
+	fs.String("to", "", "")
+
+	got := reorderFlagsFirst(fs, []string{"--dry-run", "deploy-frontend", "--to", "anthropics"})
+	want := []string{"--dry-run", "--to", "anthropics", "deploy-frontend"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("reorderFlagsFirst:\n got: %#v\nwant: %#v", got, want)
 	}
 }

--- a/internal/skillpublish/manifest.go
+++ b/internal/skillpublish/manifest.go
@@ -1,6 +1,6 @@
 // Package skillpublish carries the pure logic for turning a compiled WUPHF
 // skill into a publishable manifest for one of the public agent-skill hubs
-// (anthropics/skills, lobehub, or any github:owner/repo fork).
+// (anthropics/skills, lobehub, or any github:owner/repo[@branch] fork).
 //
 // All identifiers and URL templates live in this package so adding a new hub
 // is a single map entry plus one switch arm — no CLI plumbing required.
@@ -26,7 +26,7 @@ type Hub string
 const (
 	HubAnthropics Hub = "anthropics"
 	HubLobeHub    Hub = "lobehub"
-	// HubGitHubPrefix marks a one-off `github:owner/repo` target. The full
+	// HubGitHubPrefix marks a one-off `github:owner/repo[@branch]` target. The full
 	// hub string keeps the prefix attached so callers can pass it through
 	// unmodified — `IsGitHubScheme` is the canonical detector.
 	HubGitHubPrefix = "github:"
@@ -37,25 +37,27 @@ const (
 // detect it via IsGitHubScheme.
 var KnownHubs = []Hub{HubAnthropics, HubLobeHub}
 
-// IsGitHubScheme reports whether the hub string is a `github:owner/repo`
+// IsGitHubScheme reports whether the hub string is a `github:owner/repo[@branch]`
 // target rather than a named registry.
 func IsGitHubScheme(hub string) bool {
 	return strings.HasPrefix(strings.TrimSpace(hub), HubGitHubPrefix)
 }
 
-// ParseGitHubScheme splits a `github:owner/repo` hub string into (owner, repo).
-// Returns an error when the scheme is malformed.
-func ParseGitHubScheme(hub string) (owner, repo string, err error) {
+// ParseGitHubScheme splits a `github:owner/repo[@branch]` hub string into
+// (owner, repo, branch). Branch is optional; callers fall back to their hub
+// default when it is blank.
+func ParseGitHubScheme(hub string) (owner, repo, branch string, err error) {
 	hub = strings.TrimSpace(hub)
 	if !IsGitHubScheme(hub) {
-		return "", "", fmt.Errorf("skillpublish: not a github: scheme: %q", hub)
+		return "", "", "", fmt.Errorf("skillpublish: not a github: scheme: %q", hub)
 	}
 	body := strings.TrimPrefix(hub, HubGitHubPrefix)
-	parts := strings.SplitN(body, "/", 2)
-	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
-		return "", "", fmt.Errorf("skillpublish: github scheme must be github:owner/repo, got %q", hub)
+	repoPart, branch, hasBranch := strings.Cut(body, "@")
+	parts := strings.Split(repoPart, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" || (hasBranch && strings.TrimSpace(branch) == "") {
+		return "", "", "", fmt.Errorf("skillpublish: github scheme must be github:owner/repo[@branch], got %q", hub)
 	}
-	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
+	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), strings.TrimSpace(branch), nil
 }
 
 // Manifest is the wire-shape WUPHF emits per published skill. Frontmatter
@@ -175,8 +177,8 @@ func sanitizeSourceSegment(in string) string {
 }
 
 // HubURL returns the canonical raw-content base URL for a published skill on
-// the named hub. For the `github:owner/repo` scheme, this returns the raw
-// URL pointing at the default-branch (`main`) copy of the SKILL.md.
+// the named hub. For the `github:owner/repo[@branch]` scheme, this returns the
+// raw URL pointing at the selected branch copy of the SKILL.md.
 //
 // The returned URL is suitable for `wuphf skills install` — drop in `name`
 // and the install path will fetch a public, unauthenticated raw markdown
@@ -187,13 +189,16 @@ func HubURL(hub, name string) (string, error) {
 		return "", errors.New("skillpublish: name is required")
 	}
 	if IsGitHubScheme(hub) {
-		owner, repo, err := ParseGitHubScheme(hub)
+		owner, repo, branch, err := ParseGitHubScheme(hub)
 		if err != nil {
 			return "", err
 		}
+		if branch == "" {
+			branch = "main"
+		}
 		return fmt.Sprintf(
-			"https://raw.githubusercontent.com/%s/%s/main/skills/%s/SKILL.md",
-			url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(name),
+			"https://raw.githubusercontent.com/%s/%s/%s/skills/%s/SKILL.md",
+			url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(branch), url.PathEscape(name),
 		), nil
 	}
 	switch Hub(strings.TrimSpace(hub)) {
@@ -210,7 +215,7 @@ func HubURL(hub, name string) (string, error) {
 			url.PathEscape(name),
 		), nil
 	default:
-		return "", fmt.Errorf("skillpublish: unknown hub %q (known: anthropics, lobehub, github:owner/repo)", hub)
+		return "", fmt.Errorf("skillpublish: unknown hub %q (known: anthropics, lobehub, github:owner/repo[@branch])", hub)
 	}
 }
 
@@ -233,15 +238,16 @@ func HubFilePath(hub, name string) (string, error) {
 	case HubLobeHub:
 		return fmt.Sprintf("agents/%s.md", name), nil
 	default:
-		return "", fmt.Errorf("skillpublish: unknown hub %q (known: anthropics, lobehub, github:owner/repo)", hub)
+		return "", fmt.Errorf("skillpublish: unknown hub %q (known: anthropics, lobehub, github:owner/repo[@branch])", hub)
 	}
 }
 
 // HubRepo returns the `owner/repo` slug for the hub. Used by `gh pr create`
-// and PR-URL templates. github:owner/repo schemes round-trip unchanged.
+// and PR-URL templates. github:owner/repo[@branch] schemes drop the optional
+// branch because GitHub repository slugs are always owner/repo.
 func HubRepo(hub string) (string, error) {
 	if IsGitHubScheme(hub) {
-		owner, repo, err := ParseGitHubScheme(hub)
+		owner, repo, _, err := ParseGitHubScheme(hub)
 		if err != nil {
 			return "", err
 		}
@@ -253,7 +259,7 @@ func HubRepo(hub string) (string, error) {
 	case HubLobeHub:
 		return "lobehub/lobe-chat-agents", nil
 	default:
-		return "", fmt.Errorf("skillpublish: unknown hub %q (known: anthropics, lobehub, github:owner/repo)", hub)
+		return "", fmt.Errorf("skillpublish: unknown hub %q (known: anthropics, lobehub, github:owner/repo[@branch])", hub)
 	}
 }
 
@@ -263,6 +269,12 @@ func HubRepo(hub string) (string, error) {
 // made the call site look configurable when it wasn't — clearer to
 // switch when a real divergence appears.
 func HubBaseBranch(hub string) string {
+	if IsGitHubScheme(hub) {
+		_, _, branch, err := ParseGitHubScheme(hub)
+		if err == nil && branch != "" {
+			return branch
+		}
+	}
 	switch Hub(hub) {
 	case HubAnthropics, HubLobeHub:
 		return "main"

--- a/internal/skillpublish/manifest_test.go
+++ b/internal/skillpublish/manifest_test.go
@@ -184,6 +184,18 @@ func TestHubURL_GithubScheme(t *testing.T) {
 	}
 }
 
+func TestHubURL_GithubScheme_BranchOverride(t *testing.T) {
+	t.Parallel()
+	got, err := HubURL("github:nex-crm/wuphf-skills@master", "review-pr")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "https://raw.githubusercontent.com/nex-crm/wuphf-skills/master/skills/review-pr/SKILL.md"
+	if got != want {
+		t.Fatalf("HubURL github scheme branch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
 func TestHubURL_Unknown(t *testing.T) {
 	t.Parallel()
 	if _, err := HubURL("bogushub", "x"); err == nil {
@@ -198,6 +210,8 @@ func TestHubURL_GithubScheme_Malformed(t *testing.T) {
 		"github:owner",
 		"github:owner/",
 		"github:/repo",
+		"github:owner/repo/extra",
+		"github:owner/repo@",
 	}
 	for _, hub := range cases {
 		if _, err := HubURL(hub, "name"); err == nil {
@@ -279,6 +293,9 @@ func TestHubBaseBranch(t *testing.T) {
 	t.Parallel()
 	if got := HubBaseBranch("anthropics"); got != "main" {
 		t.Fatalf("HubBaseBranch: got %s want main", got)
+	}
+	if got := HubBaseBranch("github:owner/repo@master"); got != "master" {
+		t.Fatalf("HubBaseBranch github override: got %s want master", got)
 	}
 }
 

--- a/testdata/vhs/help.txt
+++ b/testdata/vhs/help.txt
@@ -11,7 +11,7 @@ Usage:
   wuphf log          Show what your agents actually did (task receipts)
   wuphf memory migrate --from {nex,gbrain}  Port legacy memory into the team wiki
   wuphf workspace ...  Manage multiple isolated WUPHF workspaces
-  wuphf skills publish <slug> --to <hub>    Publish a team skill to a public hub
+  wuphf skills publish <slug-or-path> --to <hub>    Publish a team skill to a public hub
   wuphf skills install <name> --from <hub>  Pull a public skill into the team wiki
   wuphf --cmd <cmd>  Run a command non-interactively
 


### PR DESCRIPTION
## Summary

Follow-up to #376 for unresolved CodeRabbit review comments that landed after the original PR was merged.

- reject oversized fetched `SKILL.md` payloads instead of silently truncating at 4 MiB
- make `skills publish` PR creation use `--head <fork-owner>:<branch>` for fork-backed publish PRs
- make flag reordering aware of boolean flags so `--dry-run <slug>` does not consume the slug
- reject malformed `github:owner/repo/extra` hub strings
- support explicit custom GitHub branch overrides via `github:owner/repo@branch`
- align top-level help/VHS output with `<slug-or-path>`

## Review Threads Addressed

- PR #376 oversized payload thread in `cmd/wuphf/skills_publish.go`
- PR #376 bool flag parsing thread in `cmd/wuphf/skills_publish.go`
- PR #376 fork-qualified `--head` thread in `cmd/wuphf/skills_publish.go`
- PR #376 malformed GitHub hub path thread in `internal/skillpublish/manifest.go`
- PR #376 custom GitHub branch handling thread in `internal/skillpublish/manifest.go`
- PR #376 top-level help `<slug-or-path>` thread in `cmd/wuphf/main.go`

## Test plan

- [x] `go test ./cmd/wuphf ./internal/skillpublish -count=1`
- [x] `go build -o /tmp/wuphf-followup ./cmd/wuphf`
- [x] `bash testdata/vhs/check.sh`
- [x] `bash scripts/test-go.sh`

🤖 Generated with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills can now be published to custom GitHub branches using the `github:owner/repo@branch` syntax alongside the existing `github:owner/repo` format.

* **Improvements**
  * Updated the `publish` command to accept slug-or-path arguments for greater flexibility.
  * Enhanced flag parsing to better distinguish between boolean and value flags.
  * Added file size validation to prevent oversized skill payloads.

* **Documentation**
  * Updated help text and README to reflect the new branch-pinning syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->