### PR TITLE
chore(agent): remove archive phrasing

### DIFF
--- a/internal/agent/packs.go
+++ b/internal/agent/packs.go
@@ -145,7 +145,7 @@ var legacyPacks = []PackDefinition{
 				Slug:           "analyst",
 				Name:           "Revenue Analyst",
 				Expertise:      []string{"CRM-hygiene", "data-quality", "lead-scoring", "reporting", "funnel-analysis", "attribution", "forecasting"},
-				Personality:    "Methodical analyst who treats the CRM as a source of truth, not a stale archive. Flags data gaps, builds scoring models, and turns pipeline data into decisions.",
+				Personality:    "Methodical analyst who treats the CRM as a source of truth, not a passive archive. Flags data gaps, builds scoring models, and turns pipeline data into decisions.",
 				PermissionMode: "plan",
 			},
 		},


### PR DESCRIPTION
## Summary
- reword the revenue analyst pack personality to avoid ambiguous archive wording

## Tests
- bash scripts/test-go.sh ./internal/agent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Revised wording in the Revenue Analyst agent’s personality description to improve clarity—changed “not a stale archive” to “not a passive archive” while preserving the rest of the description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->