### PR TITLE
[codex] initialize notebook shelves and remove wiki mocks

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -664,6 +664,12 @@ func (b *Broker) EnsureBridgedMember(slug, name, createdBy string) error {
 	if slug == "" {
 		return fmt.Errorf("slug required")
 	}
+	ensureNotebookDirsAfterUnlock := false
+	defer func() {
+		if ensureNotebookDirsAfterUnlock {
+			b.ensureNotebookDirsForRoster()
+		}
+	}()
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.findMemberLocked(slug) != nil {
@@ -694,6 +700,7 @@ func (b *Broker) EnsureBridgedMember(slug, name, createdBy string) error {
 		return err
 	}
 	b.publishOfficeChangeLocked(officeChangeEvent{Kind: "member_created", Slug: slug})
+	ensureNotebookDirsAfterUnlock = true
 	return nil
 }
 

--- a/internal/team/broker_notebook.go
+++ b/internal/team/broker_notebook.go
@@ -8,10 +8,13 @@ package team
 // single-writer guarantee that protects the wiki also protects notebooks.
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -52,6 +55,43 @@ func (b *Broker) PublishNotebookEvent(evt notebookWriteEvent) {
 		case ch <- evt:
 		default:
 		}
+	}
+}
+
+// ensureNotebookDirsForRoster creates blank notebook shelves for the current
+// office roster. It is best-effort: shelves are bootstrap metadata, so failure
+// should not block onboarding or hiring.
+func (b *Broker) ensureNotebookDirsForRoster() {
+	worker := b.WikiWorker()
+	if worker == nil {
+		return
+	}
+	members := b.OfficeMembers()
+	seen := make(map[string]struct{}, len(members))
+	slugs := make([]string, 0, len(members))
+	for _, member := range members {
+		slug := strings.TrimSpace(member.Slug)
+		if slug == "" {
+			continue
+		}
+		if _, ok := seen[slug]; ok {
+			continue
+		}
+		seen[slug] = struct{}{}
+		slugs = append(slugs, slug)
+	}
+	if len(slugs) == 0 {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	sha, err := worker.EnsureNotebookDirs(ctx, slugs)
+	if err != nil {
+		log.Printf("notebook: initialize roster shelves failed: %v", err)
+		return
+	}
+	if sha != "" {
+		log.Printf("notebook: initialized roster shelves %s", sha)
 	}
 }
 
@@ -199,8 +239,9 @@ func (b *Broker) handleNotebookList(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleNotebookCatalog returns a team-wide rollup for the bookshelf view:
-// every agent that has a notebook dir, their most-recent entries, and the
-// count of pending promotions so the sidebar badge reflects reality.
+// every current roster agent (even before their first entry), plus any former
+// agent that still has notebook entries, and the count of pending promotions
+// so the sidebar badge reflects reality.
 //
 //	GET /notebook/catalog
 //
@@ -227,7 +268,7 @@ func (b *Broker) handleNotebookCatalog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slugs, err := worker.AgentsWithNotebooks()
+	notebookSlugs, err := worker.AgentsWithNotebooks()
 	if err != nil {
 		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		return
@@ -241,6 +282,18 @@ func (b *Broker) handleNotebookCatalog(w http.ResponseWriter, r *http.Request) {
 	for _, m := range b.OfficeMembers() {
 		rosterBySlug[m.Slug] = m
 	}
+	slugSet := make(map[string]struct{}, len(notebookSlugs)+len(rosterBySlug))
+	for _, slug := range notebookSlugs {
+		slugSet[slug] = struct{}{}
+	}
+	for slug := range rosterBySlug {
+		slugSet[slug] = struct{}{}
+	}
+	slugs := make([]string, 0, len(slugSet))
+	for slug := range slugSet {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
 
 	// Cross-reference active reviews so entry status reflects what's happening
 	// right now. One List call, scan-once, reused across all agents.
@@ -281,25 +334,26 @@ func (b *Broker) handleNotebookCatalog(w http.ResponseWriter, r *http.Request) {
 			// catalog — partial data beats a 500 for the bookshelf.
 			continue
 		}
-		if len(entries) == 0 {
-			continue
-		}
 
 		member, known := rosterBySlug[slug]
+		if len(entries) == 0 && !known {
+			continue
+		}
 		name := slug
 		role := ""
+		lastEdited := ""
 		if known {
 			if strings.TrimSpace(member.Name) != "" {
 				name = member.Name
 			}
 			role = member.Role
+			lastEdited = strings.TrimSpace(member.CreatedAt)
 		} else {
 			role = "former teammate"
 		}
 
 		mapped := make([]entrySummary, 0, len(entries))
 		promoted := 0
-		var lastEdited string
 		for _, e := range entries {
 			entrySlug := strings.TrimSuffix(filepath.Base(e.Path), ".md")
 			status := "draft"

--- a/internal/team/broker_notebook_test.go
+++ b/internal/team/broker_notebook_test.go
@@ -7,9 +7,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // newNotebookTestServer wires a full httptest server with the auth-gated
@@ -34,6 +36,7 @@ func newNotebookTestServer(t *testing.T) (*httptest.Server, *Broker, func()) {
 	mux.HandleFunc("/notebook/write", b.requireAuth(b.handleNotebookWrite))
 	mux.HandleFunc("/notebook/read", b.requireAuth(b.handleNotebookRead))
 	mux.HandleFunc("/notebook/list", b.requireAuth(b.handleNotebookList))
+	mux.HandleFunc("/notebook/catalog", b.requireAuth(b.handleNotebookCatalog))
 	mux.HandleFunc("/notebook/search", b.requireAuth(b.handleNotebookSearch))
 	srv := httptest.NewServer(mux)
 
@@ -171,6 +174,19 @@ func TestBrokerNotebookListAuthRequired(t *testing.T) {
 	}
 }
 
+func TestBrokerNotebookCatalogAuthRequired(t *testing.T) {
+	srv, _, teardown := newNotebookTestServer(t)
+	defer teardown()
+	res, err := http.Get(srv.URL + "/notebook/catalog")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", res.StatusCode)
+	}
+}
+
 func TestBrokerNotebookSearchAuthRequired(t *testing.T) {
 	srv, _, teardown := newNotebookTestServer(t)
 	defer teardown()
@@ -261,6 +277,104 @@ func TestBrokerNotebookListEmptyReturnsEmptyArray(t *testing.T) {
 	}
 	if len(parsed.Entries) != 0 {
 		t.Fatalf("expected 0 entries, got %d", len(parsed.Entries))
+	}
+}
+
+func TestBrokerNotebookCatalogIncludesRosterAgentsWithoutEntries(t *testing.T) {
+	srv, b, teardown := newNotebookTestServer(t)
+	defer teardown()
+	b.mu.Lock()
+	b.members = []officeMember{
+		{Slug: "ceo", Name: "CEO", Role: "lead", CreatedAt: "2026-04-20T10:00:00Z"},
+		{Slug: "pm", Name: "PM", Role: "product", CreatedAt: "2026-04-20T10:01:00Z"},
+	}
+	b.mu.Unlock()
+
+	req, _ := authReq(http.MethodGet, srv.URL+"/notebook/catalog", nil, b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("catalog: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, string(body))
+	}
+	var parsed struct {
+		Agents []struct {
+			AgentSlug string           `json:"agent_slug"`
+			Entries   []map[string]any `json:"entries"`
+			Total     int              `json:"total"`
+		} `json:"agents"`
+		TotalAgents  int `json:"total_agents"`
+		TotalEntries int `json:"total_entries"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if parsed.TotalAgents != 2 || len(parsed.Agents) != 2 {
+		t.Fatalf("expected two roster shelves, got total=%d agents=%+v", parsed.TotalAgents, parsed.Agents)
+	}
+	if parsed.TotalEntries != 0 {
+		t.Fatalf("expected no entries, got %d", parsed.TotalEntries)
+	}
+	for _, agent := range parsed.Agents {
+		if agent.Total != 0 || len(agent.Entries) != 0 {
+			t.Fatalf("expected blank shelf for %s, got %+v", agent.AgentSlug, agent)
+		}
+	}
+}
+
+func TestEnsureNotebookDirsForRosterCreatesBlankShelves(t *testing.T) {
+	_, b, teardown := newNotebookTestServer(t)
+	defer teardown()
+	b.mu.Lock()
+	b.members = []officeMember{
+		{Slug: "ceo", Name: "CEO"},
+		{Slug: "pm", Name: "PM"},
+	}
+	b.mu.Unlock()
+
+	b.ensureNotebookDirsForRoster()
+
+	root := b.WikiWorker().Repo().Root()
+	for _, slug := range []string{"ceo", "pm"} {
+		marker := filepath.Join(root, "agents", slug, "notebook", ".gitkeep")
+		if _, err := os.Stat(marker); err != nil {
+			t.Fatalf("expected notebook shelf marker for %s: %v", slug, err)
+		}
+	}
+}
+
+func TestEnsureBridgedMemberInitializesNotebookAfterUnlock(t *testing.T) {
+	_, b, teardown := newNotebookTestServer(t)
+	defer teardown()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- b.EnsureBridgedMember("openclaw-bot", "OpenClaw Bot", "openclaw")
+	}()
+
+	deadline, ok := t.Deadline()
+	if !ok {
+		t.Fatal("test deadline unavailable")
+	}
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		t.Fatal("test deadline exceeded")
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("ensure bridged member: %v", err)
+		}
+	case <-time.After(remaining):
+		t.Fatal("EnsureBridgedMember deadlocked while initializing notebook shelves")
+	}
+
+	marker := filepath.Join(b.WikiWorker().Repo().Root(), "agents", "openclaw-bot", "notebook", ".gitkeep")
+	if _, err := os.Stat(marker); err != nil {
+		t.Fatalf("expected bridged member notebook shelf marker: %v", err)
 	}
 }
 
@@ -369,6 +483,7 @@ func TestBrokerNotebookServiceUnavailable(t *testing.T) {
 	mux.HandleFunc("/notebook/write", b.handleNotebookWrite)
 	mux.HandleFunc("/notebook/read", b.handleNotebookRead)
 	mux.HandleFunc("/notebook/list", b.handleNotebookList)
+	mux.HandleFunc("/notebook/catalog", b.handleNotebookCatalog)
 	mux.HandleFunc("/notebook/search", b.handleNotebookSearch)
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
@@ -380,6 +495,7 @@ func TestBrokerNotebookServiceUnavailable(t *testing.T) {
 		{http.MethodPost, "/notebook/write"},
 		{http.MethodGet, "/notebook/read?path=agents/pm/notebook/x.md"},
 		{http.MethodGet, "/notebook/list?slug=pm"},
+		{http.MethodGet, "/notebook/catalog"},
 		{http.MethodGet, "/notebook/search?slug=pm&q=x"},
 	}
 	for _, tc := range cases {

--- a/internal/team/broker_office_members.go
+++ b/internal/team/broker_office_members.go
@@ -43,9 +43,10 @@ type officeMemberMutationBody struct {
 }
 
 type officeMemberMutationResult struct {
-	payload map[string]any
-	events  []officeChangeEvent
-	write   brokerStateWrite
+	payload            map[string]any
+	events             []officeChangeEvent
+	write              brokerStateWrite
+	ensureNotebookDirs bool
 }
 
 type officeMemberMutationError struct {
@@ -168,6 +169,9 @@ func (b *Broker) serveOfficeMemberMutation(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	b.publishOfficeChanges(result.events)
+	if result.ensureNotebookDirs {
+		b.ensureNotebookDirsForRoster()
+	}
 
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(result.payload)
@@ -332,9 +336,10 @@ func (b *Broker) createOfficeMember(r *http.Request, slug string, body officeMem
 		events = append(events, officeChangeEvent{Kind: "channel_updated", Slug: chSlug})
 	}
 	return officeMemberMutationResult{
-		payload: map[string]any{"member": member},
-		events:  events,
-		write:   write,
+		payload:            map[string]any{"member": member},
+		events:             events,
+		write:              write,
+		ensureNotebookDirs: true,
 	}, nil
 }
 

--- a/internal/team/broker_onboarding.go
+++ b/internal/team/broker_onboarding.go
@@ -83,6 +83,7 @@ func (b *Broker) onboardingCompleteFn(task string, skipTask bool, blueprintID st
 	if seedErr != nil {
 		return seedErr
 	}
+	b.ensureNotebookDirsForRoster()
 
 	// Materialize the blueprint's LLM wiki outside the broker lock. Lane A
 	// owns the git repo at ~/.wuphf/wiki; we write the skeleton files, commit

--- a/internal/team/broker_wiki_lifecycle.go
+++ b/internal/team/broker_wiki_lifecycle.go
@@ -75,6 +75,8 @@ func (b *Broker) initWikiWorker() {
 	b.readLog = NewReadLog(repo.Root())
 	b.mu.Unlock()
 
+	b.ensureNotebookDirsForRoster()
+
 	// Skill status reconciliation: now that the wiki worker is wired,
 	// prefer the on-disk SKILL.md frontmatter status over the potentially
 	// stale broker-state.json snapshot. This closes the race window where a

--- a/internal/team/notebook_worker.go
+++ b/internal/team/notebook_worker.go
@@ -196,6 +196,16 @@ func (w *WikiWorker) AgentsWithNotebooks() ([]string, error) {
 	return out, nil
 }
 
+// EnsureNotebookDirs creates the on-disk notebook shelf for each roster slug.
+// It commits only .gitkeep files, never sample content, so a fresh office has
+// visible per-agent notebooks without pretending any agent has written notes.
+func (w *WikiWorker) EnsureNotebookDirs(ctx context.Context, slugs []string) (string, error) {
+	if w == nil || w.repo == nil {
+		return "", ErrWorkerStopped
+	}
+	return w.repo.EnsureNotebookDirs(ctx, slugs)
+}
+
 // NotebookRead returns raw entry bytes for any agent's notebook. Cross-agent
 // reads are intentional: notebooks are private-by-convention, not by access
 // control.
@@ -372,6 +382,67 @@ func (r *Repo) CommitNotebook(ctx context.Context, slug, relPath, content, mode,
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.commitNotebookLocked(ctx, slug, relPath, content, mode, message)
+}
+
+// EnsureNotebookDirs materializes agents/{slug}/notebook/.gitkeep for every
+// valid slug and commits the shelves as bootstrap metadata. It is idempotent
+// and intentionally writes no notebook entries.
+func (r *Repo) EnsureNotebookDirs(ctx context.Context, slugs []string) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	seen := make(map[string]struct{}, len(slugs))
+	markers := make([]string, 0, len(slugs))
+	for _, raw := range slugs {
+		slug := strings.TrimSpace(raw)
+		if slug == "" {
+			continue
+		}
+		if _, ok := seen[slug]; ok {
+			continue
+		}
+		seen[slug] = struct{}{}
+		if err := validateNotebookSlug(slug); err != nil {
+			continue
+		}
+		rel := filepath.ToSlash(filepath.Join("agents", slug, "notebook", ".gitkeep"))
+		full := filepath.Join(r.root, rel)
+		if _, err := os.Stat(full); err == nil {
+			markers = append(markers, rel)
+			continue
+		} else if err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("notebook: stat shelf %s: %w", rel, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+			return "", fmt.Errorf("notebook: mkdir shelf %s: %w", filepath.Dir(full), err)
+		}
+		if err := os.WriteFile(full, []byte(""), 0o600); err != nil {
+			return "", fmt.Errorf("notebook: write shelf marker %s: %w", rel, err)
+		}
+		markers = append(markers, rel)
+	}
+	if len(markers) == 0 {
+		return "", nil
+	}
+	args := append([]string{"add", "--"}, markers...)
+	if out, err := r.runGitLocked(ctx, "wuphf-bootstrap", args...); err != nil {
+		return "", fmt.Errorf("notebook: git add shelves: %w: %s", err, out)
+	}
+	cachedDiff, err := r.runGitLocked(ctx, "system", "diff", "--cached", "--name-only")
+	if err != nil {
+		return "", fmt.Errorf("notebook: git diff --cached: %w", err)
+	}
+	if strings.TrimSpace(cachedDiff) == "" {
+		return "", nil
+	}
+	if out, err := r.runGitLocked(ctx, "wuphf-bootstrap", "commit", "-q", "-m", "notebook: initialize agent shelves"); err != nil {
+		return "", fmt.Errorf("notebook: git commit shelves: %w: %s", err, out)
+	}
+	sha, err := r.runGitLocked(ctx, "system", "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("notebook: resolve HEAD sha: %w", err)
+	}
+	return strings.TrimSpace(sha), nil
 }
 
 // validateNotebookWritePath enforces that the path lives under

--- a/internal/team/notebook_worker_test.go
+++ b/internal/team/notebook_worker_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -96,6 +97,38 @@ func TestNotebookWriteHappyPath(t *testing.T) {
 	pub.mu.Unlock()
 	if wikiCount != 0 {
 		t.Fatalf("expected 0 wiki events, got %d", wikiCount)
+	}
+}
+
+func TestEnsureNotebookDirsStagesExistingShelfMarker(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	rel := filepath.Join("agents", "pm", "notebook", ".gitkeep")
+	full := filepath.Join(root, rel)
+	if err := os.MkdirAll(filepath.Dir(full), 0o700); err != nil {
+		t.Fatalf("mkdir existing shelf: %v", err)
+	}
+	if err := os.WriteFile(full, nil, 0o600); err != nil {
+		t.Fatalf("write existing shelf: %v", err)
+	}
+
+	sha, err := repo.EnsureNotebookDirs(context.Background(), []string{"pm"})
+	if err != nil {
+		t.Fatalf("ensure notebook dirs: %v", err)
+	}
+	if sha == "" {
+		t.Fatal("expected existing untracked shelf to be committed")
+	}
+	out, err := exec.Command("git", "-C", root, "ls-files", filepath.ToSlash(rel)).Output()
+	if err != nil {
+		t.Fatalf("git ls-files: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != filepath.ToSlash(rel) {
+		t.Fatalf("expected shelf marker tracked, got %q", string(out))
 	}
 }
 

--- a/web/src/api/wiki.test.ts
+++ b/web/src/api/wiki.test.ts
@@ -3,7 +3,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as client from "./client";
 import * as api from "./wiki";
 
-// biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
 describe("wiki api client", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -31,10 +30,9 @@ describe("wiki api client", () => {
     expect(result).toEqual(article);
   });
 
-  it("fetchArticle falls back to a mock on network error", async () => {
+  it("fetchArticle rethrows the last backend error", async () => {
     vi.spyOn(client, "get").mockRejectedValue(new Error("boom"));
-    const result = await api.fetchArticle("people/customer-x");
-    expect(result.title).toBe("Customer X");
+    await expect(api.fetchArticle("people/customer-x")).rejects.toThrow("boom");
   });
 
   it("fetchArticle resolves a bare slug by trying the standard group dirs", async () => {
@@ -120,22 +118,16 @@ describe("wiki api client", () => {
     expect(result).toEqual(entries);
   });
 
-  it("fetchCatalog falls back to MOCK_CATALOG on error", async () => {
+  it("fetchCatalog returns an empty array on error", async () => {
     vi.spyOn(client, "get").mockRejectedValue(new Error("boom"));
     const result = await api.fetchCatalog();
-    expect(result.length).toBeGreaterThan(0);
+    expect(result).toEqual([]);
   });
 
-  it("fetchHistory returns mock commits on error", async () => {
+  it("fetchHistory returns empty commits on error", async () => {
     vi.spyOn(client, "get").mockRejectedValue(new Error("boom"));
     const result = await api.fetchHistory("people/customer-x");
-    expect(result.commits.length).toBeGreaterThan(0);
-  });
-
-  it("mockArticle generates a fallback article for unknown paths", () => {
-    const result = api.mockArticle("unknown/thing");
-    expect(result.path).toBe("unknown/thing");
-    expect(result.title).toMatch(/Thing/i);
+    expect(result.commits).toEqual([]);
   });
 
   it("fetchCatalog treats a non-array response as empty", async () => {
@@ -151,12 +143,6 @@ describe("wiki api client", () => {
     vi.spyOn(client, "get").mockResolvedValue({ commits });
     const result = await api.fetchHistory("a");
     expect(result.commits).toEqual(commits);
-  });
-
-  it("mockArticle generates the Customer X fixture for the canonical path", () => {
-    const result = api.mockArticle("customer-x");
-    expect(result.title).toBe("Customer X");
-    expect(result.contributors.length).toBeGreaterThan(0);
   });
 
   it("fetchSections returns the server response when the endpoint succeeds", async () => {

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -1,7 +1,5 @@
 /**
  * Wiki API client — thin wrapper over the shared fetch helper in `client.ts`.
- * Falls back to local mock fixtures when Lane A's endpoints are not yet wired,
- * so the UI renders during development.
  */
 
 import { get, post, sseURL } from "./client";
@@ -232,18 +230,21 @@ export async function compressArticle(
 
 export async function fetchArticle(path: string): Promise<WikiArticle> {
   const tried: string[] = [];
+  let lastError: unknown = null;
   for (const candidate of candidatePaths(path)) {
     tried.push(candidate);
     try {
       return await get<WikiArticle>(
         `/wiki/article?path=${encodeURIComponent(candidate)}&reader=web`,
       );
-    } catch {
+    } catch (err) {
+      lastError = err;
       // Try next candidate. Real 404s and bare-slug misses look identical
-      // from the client — fall through and mock at the end.
+      // from the client, so the first successful canonical path wins.
     }
   }
-  return mockArticle(tried[tried.length - 1] ?? path);
+  if (lastError instanceof Error) throw lastError;
+  throw new Error(`Article not found: ${tried[tried.length - 1] ?? path}`);
 }
 
 /**
@@ -345,7 +346,7 @@ export async function fetchCatalog(): Promise<WikiCatalogEntry[]> {
     const res = await get<{ articles: WikiCatalogEntry[] }>("/wiki/catalog");
     return Array.isArray(res?.articles) ? res.articles : [];
   } catch {
-    return MOCK_CATALOG;
+    return [];
   }
 }
 
@@ -465,14 +466,7 @@ export async function fetchHistory(
       `/wiki/history/${encodeURI(path)}`,
     );
   } catch {
-    return {
-      commits: mockArticle(path).contributors.map((slug, i) => ({
-        sha: `mock${i}`,
-        author_slug: slug,
-        msg: `Edit ${i + 1} by ${slug}`,
-        date: new Date(Date.now() - i * 86400000).toISOString(),
-      })),
-    };
+    return { commits: [] };
   }
 }
 
@@ -544,231 +538,3 @@ export function subscribeEditLog(
     }
   };
 }
-
-// ── Mock fixtures — pulled from V3 preview content. ──
-
-export const MOCK_CATALOG: WikiCatalogEntry[] = [
-  {
-    path: "people/customer-x",
-    title: "Customer X",
-    author_slug: "ceo",
-    last_edited_ts: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
-    group: "people",
-  },
-  {
-    path: "people/nazz",
-    title: "Nazz (founder)",
-    author_slug: "pm",
-    last_edited_ts: new Date(Date.now() - 2 * 3600 * 1000).toISOString(),
-    group: "people",
-  },
-  {
-    path: "people/sarah-chen",
-    title: "Sarah Chen",
-    author_slug: "ceo",
-    last_edited_ts: new Date(Date.now() - 12 * 3600 * 1000).toISOString(),
-    group: "people",
-  },
-  {
-    path: "people/david-kim",
-    title: "David Kim",
-    author_slug: "cmo",
-    last_edited_ts: new Date(Date.now() - 18 * 3600 * 1000).toISOString(),
-    group: "people",
-  },
-  {
-    path: "companies/acme-logistics",
-    title: "Acme Logistics",
-    author_slug: "cro",
-    last_edited_ts: new Date(Date.now() - 26 * 3600 * 1000).toISOString(),
-    group: "companies",
-  },
-  {
-    path: "companies/meridian-freight",
-    title: "Meridian Freight",
-    author_slug: "cro",
-    last_edited_ts: new Date(Date.now() - 48 * 3600 * 1000).toISOString(),
-    group: "companies",
-  },
-  {
-    path: "projects/customer-x-onboarding",
-    title: "Customer X — Onboarding",
-    author_slug: "pm",
-    last_edited_ts: new Date(Date.now() - 4 * 3600 * 1000).toISOString(),
-    group: "projects",
-  },
-  {
-    path: "projects/q1-pilot-retrospective",
-    title: "Q1 Pilot Retrospective",
-    author_slug: "pm",
-    last_edited_ts: new Date(Date.now() - 6 * 86400 * 1000).toISOString(),
-    group: "projects",
-  },
-  {
-    path: "playbooks/churn-prevention",
-    title: "Churn prevention",
-    author_slug: "cmo",
-    last_edited_ts: new Date(Date.now() - 2 * 86400 * 1000).toISOString(),
-    group: "playbooks",
-  },
-  {
-    path: "playbooks/mid-market-onboarding",
-    title: "Mid-market onboarding",
-    author_slug: "pm",
-    last_edited_ts: new Date(Date.now() - 9 * 86400 * 1000).toISOString(),
-    group: "playbooks",
-  },
-  {
-    path: "playbooks/pricing-negotiations",
-    title: "Pricing negotiations",
-    author_slug: "cro",
-    last_edited_ts: new Date(Date.now() - 14 * 86400 * 1000).toISOString(),
-    group: "playbooks",
-  },
-  {
-    path: "decisions/2026-q1-pricing",
-    title: "2026-Q1 pricing",
-    author_slug: "ceo",
-    last_edited_ts: new Date(Date.now() - 31 * 86400 * 1000).toISOString(),
-    group: "decisions",
-  },
-  {
-    path: "decisions/migration-v1-1",
-    title: "Migration to v1.1",
-    author_slug: "be",
-    last_edited_ts: new Date(Date.now() - 22 * 86400 * 1000).toISOString(),
-    group: "decisions",
-  },
-  {
-    path: "inbox/raw-customer-x-transcript",
-    title: "raw — Customer X call transcript",
-    author_slug: "pm",
-    last_edited_ts: new Date(Date.now() - 6 * 3600 * 1000).toISOString(),
-    group: "inbox",
-  },
-];
-
-export function mockArticle(path: string): WikiArticle {
-  if (
-    path === "people/customer-x" ||
-    path === "" ||
-    path === "customer-x" ||
-    path === "team/people/customer-x.md"
-  ) {
-    return {
-      path: "people/customer-x",
-      title: "Customer X",
-      content: MOCK_CUSTOMER_X_MD,
-      last_edited_by: "ceo",
-      last_edited_ts: new Date(Date.now() - 3 * 60 * 1000).toISOString(),
-      revisions: 47,
-      contributors: ["ceo", "pm", "cro", "cmo", "designer", "be"],
-      backlinks: [
-        {
-          path: "playbooks/churn-prevention",
-          title: "Playbook — Churn prevention",
-          author_slug: "cmo",
-        },
-        {
-          path: "projects/q1-pilot-retrospective",
-          title: "Q1 Pilot Retrospective",
-          author_slug: "pm",
-        },
-        {
-          path: "playbooks/pricing-negotiations",
-          title: "Pricing negotiations",
-          author_slug: "cro",
-        },
-        { path: "people/sarah-chen", title: "Sarah Chen", author_slug: "ceo" },
-      ],
-      word_count: 2347,
-      categories: [
-        "Active pilot",
-        "Mid-market",
-        "Logistics",
-        "Q1 2026",
-        "North America",
-        "Sarah Chen",
-      ],
-    };
-  }
-  // Generic fallback for unknown paths.
-  const title = path.split("/").pop() || path;
-  return {
-    path,
-    title: title.charAt(0).toUpperCase() + title.slice(1).replace(/-/g, " "),
-    content: `*Article not found in mock fixtures.*\n\nThe API endpoint for \`${path}\` is not yet wired. When Lane A completes its endpoints this view will populate with real content.\n`,
-    last_edited_by: "pm",
-    last_edited_ts: new Date().toISOString(),
-    revisions: 1,
-    contributors: ["pm"],
-    backlinks: [],
-    word_count: 42,
-    categories: [],
-  };
-}
-
-const MOCK_CUSTOMER_X_MD = `**Customer X** is a mid-market logistics company running a 47-person operations team out of Cincinnati. They came to us through our [[projects/q1-outbound|Q1 outbound pipeline]] after [[people/sarah-chen|Sarah Chen]] (Director of Ops) saw a demo at the March logistics summit. Signed the pilot three weeks later.
-
-Sarah is the champion. Her boss is Mike Reyes, VP Operations, who has seen the product twice but doesn't engage directly. The procurement process went through their legal team ([[templates/msa|MSA template we haven't written yet]]) — contract took nine days, which is fast for this segment.
-
-## What they want
-
-Their primary pain is route optimization at the dispatcher level: six dispatchers, each manually rebuilding route schedules every morning in spreadsheets. They've looked at three competitors; the deal-breaker with each was onboarding friction, not feature gaps. That confirms the [[playbooks/onboarding-wedge|onboarding-wedge thesis]] we developed in Q4.
-
-### Stated goals
-
-- Cut dispatcher morning prep from 2 hours to 20 minutes
-- Reduce route reshuffle thrash (currently 4-7 reshuffles/day per dispatcher)
-- Surface exception patterns to Sarah weekly (their "ops review" meeting)
-
-### Unstated goals (inferred)
-
-Sarah wants this to be a visible win for her team before her Q3 performance review. See [[playbooks/churn-prevention|Churn prevention]].
-
-## Open issues
-
-Two things are currently blocking expansion past the pilot seat count:
-
-- **Training data boundary.** Their ops data is classified as internal-sensitive; they need a signed addendum specifying no cross-tenant training. Legal has a template we're close to finalizing, see [[templates/data-handling|data handling addendum]].
-- **Pricing model for dispatcher seats vs viewer seats.** Sarah asked about read-only seats at 30% of dispatcher price. Depends on [[decisions/q2-pricing|Q2 pricing review]].
-
-## Next steps
-
-Sarah's next check-in is on \`2026-05-02\`. CEO will send a renewal-prep email two weeks before. If the addendum lands by mid-April we can expand seats at the same meeting. If not, we renew as-is and expand at Q3.
-`;
-
-export const MOCK_EDIT_LOG: WikiEditLogEntry[] = [
-  {
-    who: "CEO",
-    action: "edited",
-    article_path: "people/customer-x",
-    article_title: "Customer X",
-    timestamp: new Date().toISOString(),
-    commit_sha: "9a0f113",
-  },
-  {
-    who: "PM",
-    action: "updated",
-    article_path: "playbooks/churn-prevention",
-    article_title: "Playbook — Churn",
-    timestamp: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
-    commit_sha: "b1d5e22",
-  },
-  {
-    who: "Designer",
-    action: "created",
-    article_path: "brand/voice",
-    article_title: "Brand Voice",
-    timestamp: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
-    commit_sha: "3f9a21b",
-  },
-  {
-    who: "Eng-1",
-    action: "wrote",
-    article_path: "tech/broker-architecture",
-    article_title: "Tech — broker architecture",
-    timestamp: new Date(Date.now() - 12 * 60 * 1000).toISOString(),
-    commit_sha: "7c2e881",
-  },
-];

--- a/web/src/components/wiki/EditLogFooter.test.tsx
+++ b/web/src/components/wiki/EditLogFooter.test.tsx
@@ -43,7 +43,7 @@ describe("<EditLogFooter>", () => {
     expect(screen.getByText("Churn")).toBeInTheDocument();
   });
 
-  it("renders duplicate commit-shaped entries without duplicate React keys", () => {
+  it("deduplicates commit-shaped entries without duplicate React keys", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const timestamp = new Date().toISOString();
     const initial: api.WikiEditLogEntry[] = [
@@ -67,7 +67,7 @@ describe("<EditLogFooter>", () => {
 
     render(<EditLogFooter initialEntries={initial} />);
 
-    expect(screen.getAllByText("Customer X")).toHaveLength(2);
+    expect(screen.getAllByText("Customer X")).toHaveLength(1);
     expect(hasDuplicateKeyWarning(errorSpy.mock.calls)).toBe(false);
   });
 
@@ -124,5 +124,69 @@ describe("<EditLogFooter>", () => {
     const live = screen.getByTestId("wk-live-entry");
     expect(live).toHaveTextContent("Brand Voice");
     expect(screen.getByText("Churn")).toBeInTheDocument();
+  });
+
+  it("hydrates entries from article history", async () => {
+    vi.spyOn(api, "subscribeEditLog").mockImplementation(() => () => {});
+    vi.spyOn(api, "fetchHistory").mockResolvedValue({
+      commits: [
+        {
+          sha: "abc123",
+          author_slug: "pm",
+          msg: "wiki: update customer",
+          date: new Date().toISOString(),
+        },
+      ],
+    });
+
+    render(<EditLogFooter historyPath="team/people/customer-x.md" />);
+
+    expect(await screen.findByText("customer x")).toBeInTheDocument();
+    expect(screen.getByText("pm")).toBeInTheDocument();
+  });
+
+  it("keeps live entries that arrive while history hydrates", async () => {
+    type Handler = (e: api.WikiEditLogEntry) => void;
+    let handler: Handler | null = null;
+    vi.spyOn(api, "subscribeEditLog").mockImplementation((h: Handler) => {
+      handler = h;
+      return () => {};
+    });
+    let resolveHistory: (value: { commits: api.WikiHistoryCommit[] }) => void =
+      () => {};
+    vi.spyOn(api, "fetchHistory").mockReturnValue(
+      new Promise((resolve) => {
+        resolveHistory = resolve;
+      }),
+    );
+
+    render(<EditLogFooter historyPath="team/people/customer-x.md" />);
+
+    act(() => {
+      handler?.({
+        who: "Designer",
+        action: "created",
+        article_path: "team/brand/voice.md",
+        article_title: "Brand Voice",
+        timestamp: new Date().toISOString(),
+        commit_sha: "live1",
+      });
+    });
+
+    act(() => {
+      resolveHistory({
+        commits: [
+          {
+            sha: "hist1",
+            author_slug: "pm",
+            msg: "wiki: update customer",
+            date: new Date().toISOString(),
+          },
+        ],
+      });
+    });
+
+    expect(await screen.findByText("Brand Voice")).toBeInTheDocument();
+    expect(await screen.findByText("customer x")).toBeInTheDocument();
   });
 });

--- a/web/src/components/wiki/EditLogFooter.tsx
+++ b/web/src/components/wiki/EditLogFooter.tsx
@@ -2,12 +2,11 @@
 import { useEffect, useState } from "react";
 
 import {
-  MOCK_EDIT_LOG,
+  fetchHistory,
   subscribeEditLog,
   type WikiEditLogEntry,
 } from "../../api/wiki";
 import { formatRelativeTime } from "../../lib/format";
-import { keyedByOccurrence } from "../../lib/reactKeys";
 import PixelAvatar from "./PixelAvatar";
 
 /** Fixed-bottom live edit-log: streams wiki:write events, newest on the left. */
@@ -17,36 +16,69 @@ const MAX_ENTRIES = 20;
 interface EditLogFooterProps {
   /** Override stream source — primarily for tests. */
   initialEntries?: WikiEditLogEntry[];
+  /** Article path used to hydrate the footer from real git history. */
+  historyPath?: string | null;
   onNavigate?: (path: string) => void;
 }
 
 export default function EditLogFooter({
   initialEntries,
+  historyPath,
   onNavigate,
 }: EditLogFooterProps) {
-  const [entries, setEntries] = useState<WikiEditLogEntry[]>(
-    initialEntries ?? MOCK_EDIT_LOG,
+  const [entries, setEntries] = useState<WikiEditLogEntry[]>(() =>
+    mergeEditLogEntries([], initialEntries?.slice(0, MAX_ENTRIES) ?? []),
   );
 
   useEffect(() => {
-    const unsubscribe = subscribeEditLog((entry) => {
-      setEntries((prev) => [entry, ...prev].slice(0, MAX_ENTRIES));
-    });
-    return unsubscribe;
-  }, []);
+    let cancelled = false;
+    let unsubscribe: (() => void) | null = null;
+    let bufferedLiveEntries: WikiEditLogEntry[] = [];
+    const seedEntries = initialEntries?.slice(0, MAX_ENTRIES) ?? [];
+
+    setEntries(mergeEditLogEntries([], seedEntries));
+
+    async function start() {
+      unsubscribe = subscribeEditLog((entry) => {
+        bufferedLiveEntries = [entry, ...bufferedLiveEntries].slice(
+          0,
+          MAX_ENTRIES,
+        );
+        setEntries((prev) => mergeEditLogEntries([entry], prev));
+      });
+      if (cancelled) return;
+      if (seedEntries.length > 0) {
+        setEntries(mergeEditLogEntries(bufferedLiveEntries, seedEntries));
+        bufferedLiveEntries = [];
+      } else if (historyPath) {
+        const history = await fetchHistory(historyPath);
+        if (cancelled) return;
+        const historyEntries = history.commits.map((commit) =>
+          historyCommitToEditLog(historyPath, commit),
+        );
+        setEntries(mergeEditLogEntries(bufferedLiveEntries, historyEntries));
+        bufferedLiveEntries = [];
+      } else {
+        setEntries(mergeEditLogEntries([], bufferedLiveEntries));
+        bufferedLiveEntries = [];
+      }
+    }
+
+    void start();
+    return () => {
+      cancelled = true;
+      unsubscribe?.();
+    };
+  }, [historyPath, initialEntries]);
 
   return (
     <div className="wk-edit-log" aria-label="Live wiki edit log">
       <span className="wk-label">Live</span>
-      {keyedByOccurrence(
-        entries,
-        (entry) =>
-          `${entry.commit_sha}-${entry.article_path}-${entry.timestamp}`,
-      ).map(({ key, value: entry, index: idx }) => {
+      {entries.map((entry, idx) => {
         const isLive = idx === 0;
         return (
           <span
-            key={key}
+            key={editLogEntryKey(entry)}
             className={isLive ? "wk-entry wk-live" : "wk-entry"}
             data-testid={isLive ? "wk-live-entry" : undefined}
           >
@@ -81,4 +113,50 @@ function safeRelative(iso: string): string {
   } catch {
     return iso;
   }
+}
+
+function mergeEditLogEntries(
+  priorityEntries: WikiEditLogEntry[],
+  entries: WikiEditLogEntry[],
+): WikiEditLogEntry[] {
+  const seen = new Set<string>();
+  const merged: WikiEditLogEntry[] = [];
+  for (const entry of [...priorityEntries, ...entries]) {
+    const key = editLogEntryKey(entry);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(entry);
+    if (merged.length >= MAX_ENTRIES) break;
+  }
+  return merged;
+}
+
+function editLogEntryKey(entry: WikiEditLogEntry): string {
+  if (entry.commit_sha) return `sha:${entry.commit_sha}`;
+  return [
+    "entry",
+    entry.article_path,
+    entry.timestamp,
+    entry.who,
+    entry.action,
+  ].join(":");
+}
+
+function historyCommitToEditLog(
+  path: string,
+  commit: { sha: string; author_slug: string; msg: string; date: string },
+): WikiEditLogEntry {
+  return {
+    who: commit.author_slug,
+    action: "edited",
+    article_path: path,
+    article_title: titleFromPath(path),
+    timestamp: commit.date,
+    commit_sha: commit.sha,
+  };
+}
+
+function titleFromPath(path: string): string {
+  const base = path.split("/").pop() ?? path;
+  return base.replace(/\.md$/, "").replace(/-/g, " ");
 }

--- a/web/src/components/wiki/Wiki.test.tsx
+++ b/web/src/components/wiki/Wiki.test.tsx
@@ -8,6 +8,7 @@ describe("<Wiki>", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(api, "subscribeEditLog").mockImplementation(() => () => {});
+    vi.spyOn(api, "fetchHistory").mockResolvedValue({ commits: [] });
   });
 
   it("shows the catalog when no article is selected", async () => {

--- a/web/src/components/wiki/Wiki.tsx
+++ b/web/src/components/wiki/Wiki.tsx
@@ -20,6 +20,7 @@ import "../../styles/wiki.css";
 const AUDIT_PATH = "_audit";
 // Reserved pseudo-path for the lint view.
 const LINT_PATH = "_lint";
+type WikiView = "audit" | "lint" | "article" | "catalog";
 
 interface WikiProps {
   /** When set, renders the article view for this path; otherwise renders the catalog. */
@@ -72,15 +73,10 @@ export default function Wiki({
     return () => unsubscribe();
   }, []);
 
-  const isAudit = articlePath === AUDIT_PATH;
-  const isLint = articlePath === LINT_PATH;
-  const view = isAudit
-    ? "audit"
-    : isLint
-      ? "lint"
-      : articlePath
-        ? "article"
-        : "catalog";
+  const view = wikiViewFor(articlePath);
+  const isAudit = view === "audit";
+  const isLint = view === "lint";
+  const editLogHistoryPath = wikiHistoryPath(articlePath, view);
 
   return (
     <div className="wiki-root" data-testid="wiki-root">
@@ -112,7 +108,25 @@ export default function Wiki({
           />
         )}
       </div>
-      {!loading && <EditLogFooter onNavigate={(path) => onNavigate(path)} />}
+      {!loading && (
+        <EditLogFooter
+          historyPath={editLogHistoryPath}
+          onNavigate={(path) => onNavigate(path)}
+        />
+      )}
     </div>
   );
+}
+
+function wikiViewFor(articlePath: string | null | undefined): WikiView {
+  if (articlePath === AUDIT_PATH) return "audit";
+  if (articlePath === LINT_PATH) return "lint";
+  return articlePath ? "article" : "catalog";
+}
+
+function wikiHistoryPath(
+  articlePath: string | null | undefined,
+  view: WikiView,
+): string | null | undefined {
+  return view === "article" ? articlePath : null;
 }


### PR DESCRIPTION
## Summary
- Port the useful notebook/wiki portion of PR #395 onto current main without the stale stacked commits.
- Create blank per-agent notebook shelves for current roster members after wiki startup, onboarding, web-created hires, and bridged-agent creation.
- Include roster members in /notebook/catalog even before they have entries, while preserving former agents that still have notebook history.
- Remove production wiki mock/sample fallbacks and hydrate the edit footer from real wiki history.

## Validation
- bash scripts/test-go.sh ./internal/team
- bunx biome check --write src/api/wiki.ts src/api/wiki.test.ts src/components/wiki/EditLogFooter.tsx src/components/wiki/EditLogFooter.test.tsx src/components/wiki/Wiki.tsx src/components/wiki/Wiki.test.tsx
- bun run test -- src/components/wiki/EditLogFooter.test.tsx src/components/wiki/Wiki.test.tsx src/api/wiki.test.ts
- bun run typecheck
- bun run test
- bun run build
- git diff --check

## Notes
- PR #395 is still open but conflicts with main and includes stacked changes from #475 and #513. This PR keeps the original notebook shelf + wiki real-data scope only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notebook directories are now automatically initialized for all team members
  * Catalog now displays all roster members, including those without existing notebook entries
  * Edit log can hydrate historical commit data from real history instead of initial mock data

* **Bug Fixes**
  * API endpoints now properly return empty results on errors instead of falling back to mock data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->