### PR TITLE
[codex] Guard unknown web slash commands

### DIFF
--- a/internal/team/notebook_worker_test.go
+++ b/internal/team/notebook_worker_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/nex-crm/wuphf/internal/gitexec"
 )
 
 // recordingNotebookPublisher captures both wiki and notebook events.
@@ -123,12 +124,12 @@ func TestEnsureNotebookDirsStagesExistingShelfMarker(t *testing.T) {
 	if sha == "" {
 		t.Fatal("expected existing untracked shelf to be committed")
 	}
-	out, err := exec.Command("git", "-C", root, "ls-files", filepath.ToSlash(rel)).Output()
+	out, err := gitexec.Run(context.Background(), root, "ls-files", filepath.ToSlash(rel))
 	if err != nil {
 		t.Fatalf("git ls-files: %v", err)
 	}
-	if strings.TrimSpace(string(out)) != filepath.ToSlash(rel) {
-		t.Fatalf("expected shelf marker tracked, got %q", string(out))
+	if strings.TrimSpace(out) != filepath.ToSlash(rel) {
+		t.Fatalf("expected shelf marker tracked, got %q", out)
 	}
 }
 

--- a/web/src/components/messages/Composer.test.tsx
+++ b/web/src/components/messages/Composer.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import * as Toast from "../ui/Toast";
 import { __test__ } from "./Composer";
 
 const {
@@ -108,6 +109,7 @@ describe("unknown slash commands", () => {
 
   it("are consumed instead of sent as chat messages", () => {
     const sendAsMessage = vi.fn();
+    const showNotice = vi.spyOn(Toast, "showNotice").mockReturnValue();
 
     const consumed = handleSlashCommand("/object list", {
       leadSlug: "ceo",
@@ -116,5 +118,9 @@ describe("unknown slash commands", () => {
 
     expect(consumed).toBe(true);
     expect(sendAsMessage).not.toHaveBeenCalled();
+    expect(showNotice).toHaveBeenCalledWith(
+      "Unknown command: /object. Try /help.",
+      "info",
+    );
   });
 });

--- a/web/src/components/messages/Composer.test.tsx
+++ b/web/src/components/messages/Composer.test.tsx
@@ -7,6 +7,8 @@ const {
   readHistory,
   pushHistory,
   resolveLeadSlug,
+  unknownSlashCommandMessage,
+  handleSlashCommand,
   askPrefix,
   COMPOSER_HISTORY_LIMIT,
 } = __test__;
@@ -94,5 +96,25 @@ describe("askPrefix", () => {
   it("defaults to @ceo", () => {
     expect(askPrefix(undefined)).toBe("@ceo ");
     expect(askPrefix("")).toBe("@ceo ");
+  });
+});
+
+describe("unknown slash commands", () => {
+  it("names the command and points to help", () => {
+    expect(unknownSlashCommandMessage("/object list")).toBe(
+      "Unknown command: /object. Try /help.",
+    );
+  });
+
+  it("are consumed instead of sent as chat messages", () => {
+    const sendAsMessage = vi.fn();
+
+    const consumed = handleSlashCommand("/object list", {
+      leadSlug: "ceo",
+      sendAsMessage,
+    });
+
+    expect(consumed).toBe(true);
+    expect(sendAsMessage).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/messages/Composer.tsx
+++ b/web/src/components/messages/Composer.tsx
@@ -77,6 +77,11 @@ function askPrefix(leadSlug: string | undefined): string {
   return `@${slug} `;
 }
 
+function unknownSlashCommandMessage(command: string): string {
+  const name = command.trim().split(/\s+/)[0] || "/";
+  return `Unknown command: ${name}. Try /help.`;
+}
+
 /** Pick the team-lead slug: configured first, else first built-in agent, else 'ceo'. */
 function resolveLeadSlug(
   configured: string | undefined,
@@ -317,7 +322,8 @@ function handleSlashCommand(input: string, handlers: SlashHandlers): boolean {
       return true;
     }
     default:
-      return false;
+      showNotice(unknownSlashCommandMessage(cmd), "info");
+      return true;
   }
 }
 
@@ -693,6 +699,8 @@ export const __test__ = {
   readHistory,
   writeHistory,
   pushHistory,
+  unknownSlashCommandMessage,
+  handleSlashCommand,
   resolveLeadSlug,
   askPrefix,
   COMPOSER_HISTORY_LIMIT,


### PR DESCRIPTION
## Summary

- Consume unknown web composer slash commands instead of falling through to normal chat sends.
- Show a clear `Unknown command: /name. Try /help.` notice for unsupported slash commands.
- Add Composer regression coverage for the unknown-command guard.
- Fix a hook-specific notebook shelf test by using `gitexec.Run` so `git ls-files` does not inherit `GIT_DIR` / `GIT_WORK_TREE` from pre-push.

Closes #387.

## Root Cause

`handleSlashCommand` returned `false` for unknown slash commands, so `handleSend` treated inputs like `/object list` as normal messages and posted them to the channel.

The pre-push blocker was a test-only raw `exec.Command("git", ...)` call that inherited Git hook environment and queried the outer repository instead of the temp wiki repo.

## Validation

- `bash scripts/test-web.sh web/src/components/messages/Composer.test.tsx`
- `bunx tsc --noEmit` from `web/`
- `bash scripts/test-web.sh`
- `go test -race ./internal/team -run TestEnsureNotebookDirsStagesExistingShelfMarker -count=1`
- `bash scripts/test-go.sh ./internal/team`
- Pre-push hook: build, complexity-baseline, file-size, go-unit, smoke, vhs, web-unit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown slash commands now display a helpful notice ("Unknown command: /[command]. Try /help.") and are treated as handled, preventing them from being processed as messages.

* **Tests**
  * Improved tests around notebook shelf-marker tracking and message composer behavior; added coverage for unknown slash-command handling and related notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->