### PR TITLE
Wire live-chat relay into all headless runners

### DIFF
--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -147,6 +147,11 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	relay := newHeadlessLiveChatRelay(l, slug, target, notification, func(line string) {
 		appendHeadlessClaudeLog(slug, line)
 	})
+	// Defer the flush so error/parseErr exit paths still surface the
+	// trailing buffered sentence. The explicit Flush before the final
+	// post stays — once the buffer is empty, the deferred call is a
+	// no-op.
+	defer relay.Flush()
 
 	var firstEventAt time.Time
 	var firstTextAt time.Time

--- a/internal/team/headless_claude.go
+++ b/internal/team/headless_claude.go
@@ -136,6 +136,18 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	}
 	l.updateHeadlessProgress(slug, "active", "thinking", "reviewing work packet", metrics)
 
+	// Live-chat relay streams the agent's user-facing `text` output to the
+	// channel as it's generated, so a long turn doesn't sit silent until the
+	// final summary. Claude's `thinking` blocks are intentionally not piped:
+	// those are private chain-of-thought, not "items that concern the user
+	// and other agents". The model's `text` output is what the agent has
+	// chosen to surface, and the relay's sentence/paragraph flush boundaries
+	// keep the channel from being flooded with mid-token chunks.
+	target := firstNonEmpty(channel...)
+	relay := newHeadlessLiveChatRelay(l, slug, target, notification, func(line string) {
+		appendHeadlessClaudeLog(slug, line)
+	})
+
 	var firstEventAt time.Time
 	var firstTextAt time.Time
 	var firstToolAt time.Time
@@ -158,7 +170,9 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 				textStarted = true
 				l.updateHeadlessProgress(slug, "active", "text", "drafting response", metrics)
 			}
+			relay.OnText(event.Text)
 		case "tool_use":
+			relay.Flush()
 			if firstToolAt.IsZero() {
 				firstToolAt = time.Now()
 				metrics.FirstToolMs = durationMillis(startedAt, firstToolAt)
@@ -218,9 +232,9 @@ func (l *Launcher) runHeadlessClaudeTurn(ctx context.Context, slug string, notif
 	if l.broker != nil {
 		l.broker.RecordAgentUsage(slug, l.headlessClaudeModel(slug), result.Usage)
 	}
+	relay.Flush()
 	if text := strings.TrimSpace(result.FinalMessage); text != "" {
 		appendHeadlessClaudeLog(slug, "result: "+text)
-		target := firstNonEmpty(channel...)
 		msg, posted, err := l.postHeadlessFinalMessageIfSilent(slug, target, notification, text, startedAt)
 		if err != nil {
 			appendHeadlessClaudeLog(slug, "fallback-post-error: "+err.Error())

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -163,6 +163,12 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	relay := newHeadlessLiveChatRelay(l, slug, target, notification, func(line string) {
 		appendHeadlessCodexLog(slug, line)
 	})
+	// Defer the flush so error/parseErr exit paths still surface the
+	// trailing buffered sentence. The explicit Flush before the final
+	// post stays — once the buffer is empty, the deferred call is a
+	// no-op. Without this, a turn that streams "checking the database…"
+	// and then dies in cmd.Wait() loses that user-facing breadcrumb.
+	defer relay.Flush()
 
 	var firstEventAt time.Time
 	var firstTextAt time.Time
@@ -217,11 +223,11 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 			appendHeadlessCodexLog(slug, "stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
 			if isCodexAuthError(detail) && l.broker != nil {
-				target := firstNonEmpty(channel...)
-				if strings.TrimSpace(target) == "" {
-					target = "general"
+				sysTarget := target
+				if strings.TrimSpace(sysTarget) == "" {
+					sysTarget = "general"
 				}
-				l.broker.PostSystemMessage(target,
+				l.broker.PostSystemMessage(sysTarget,
 					fmt.Sprintf("@%s hit an auth error talking to the model (%s). Run `codex login` on this machine, or set OPENAI_API_KEY, then retry.", slug, truncate(detail, 180)),
 					"error",
 				)

--- a/internal/team/headless_codex_runner.go
+++ b/internal/team/headless_codex_runner.go
@@ -151,6 +151,19 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 		FirstToolMs:  -1,
 	}
 	l.updateHeadlessProgress(slug, "active", "thinking", "reviewing work packet", metrics)
+
+	// Live-chat relay surfaces the model's user-facing text to the channel
+	// at sentence/paragraph boundaries while the turn is still running.
+	// Codex doesn't expose a separate `thinking` event type — its `text`
+	// stream is the assistant's spoken output, which is exactly the
+	// surface "items that concern the user and other agents" should land
+	// on. Tool calls flush the buffer so a partial sentence doesn't get
+	// stranded across tool invocations.
+	target := firstNonEmpty(channel...)
+	relay := newHeadlessLiveChatRelay(l, slug, target, notification, func(line string) {
+		appendHeadlessCodexLog(slug, line)
+	})
+
 	var firstEventAt time.Time
 	var firstTextAt time.Time
 	var firstToolAt time.Time
@@ -170,7 +183,9 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 				textStarted = true
 				l.updateHeadlessProgress(slug, "active", "text", "drafting response", metrics)
 			}
+			relay.OnText(event.Text)
 		case "tool_use":
+			relay.Flush()
 			if firstToolAt.IsZero() {
 				firstToolAt = time.Now()
 				metrics.FirstToolMs = durationMillis(startedAt, firstToolAt)
@@ -245,9 +260,9 @@ func (l *Launcher) runHeadlessCodexTurn(ctx context.Context, slug string, notifi
 	if l.broker != nil && (result.Usage.InputTokens != 0 || result.Usage.OutputTokens != 0 || result.Usage.CacheReadTokens != 0 || result.Usage.CacheCreationTokens != 0 || result.Usage.CostUSD != 0) {
 		l.broker.RecordAgentUsage(slug, config.ResolveCodexModel(l.cwd), result.Usage)
 	}
+	relay.Flush()
 	if text := strings.TrimSpace(firstNonEmpty(result.FinalMessage, result.LastPlainLine)); text != "" {
 		appendHeadlessCodexLog(slug, "result: "+text)
-		target := firstNonEmpty(channel...)
 		msg, posted, err := l.postHeadlessFinalMessageIfSilent(slug, target, notification, text, startedAt)
 		if err != nil {
 			appendHeadlessCodexLog(slug, "fallback-post-error: "+err.Error())

--- a/internal/team/headless_live_chat_relay_test.go
+++ b/internal/team/headless_live_chat_relay_test.go
@@ -5,10 +5,36 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
 )
+
+// TestHeadlessRunnersWireLiveChatRelay guards against the regression where
+// headlessLiveChatRelay exists but no production runner actually constructs
+// one. Symptom: agents stay silent during a turn — only the end-of-turn
+// final message lands in the channel, so the room sees a multi-minute gap
+// followed by a single summary post. The relay infrastructure was added
+// but its wire-up to the four runners regressed once before; this test
+// keeps the connection visible at build time.
+func TestHeadlessRunnersWireLiveChatRelay(t *testing.T) {
+	runners := []string{
+		"headless_claude.go",
+		"headless_codex_runner.go",
+		"headless_opencode.go",
+		"headless_openai_compat.go",
+	}
+	for _, file := range runners {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if !strings.Contains(string(data), "newHeadlessLiveChatRelay") {
+			t.Errorf("%s: missing newHeadlessLiveChatRelay wiring — without it the agent goes silent during a turn and only the final summary lands in-channel", file)
+		}
+	}
+}
 
 func TestHeadlessLiveChatRelayPostsStreamedTextToChannel(t *testing.T) {
 	b := newTestBroker(t)

--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -131,6 +131,11 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		stream:  agentStream,
 		metrics: &metrics,
 	}, relay)
+	// Defer the flush so the loop's `if err != nil { return err }` and
+	// other early exits still surface the trailing buffered sentence.
+	// The explicit flushes before the partial-post and final-post hooks
+	// stay — they're idempotent once the buffer is drained.
+	defer state.flushLiveChat()
 
 	// taskID is unique per turn so the Receipts panel groups each
 	// agent's turn into its own row. Format mirrors agent.nextTaskID.

--- a/internal/team/headless_openai_compat.go
+++ b/internal/team/headless_openai_compat.go
@@ -109,6 +109,16 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	modelOverride := strings.TrimSpace(l.broker.MemberProviderBinding(slug).Model)
 	streamFn := provider.NewOpenAICompatStreamFnWithCtxAndModel(ctx, kind, modelOverride)
 
+	// Live-chat relay streams the model's user-facing text to the channel
+	// at sentence/paragraph boundaries, so the room sees the agent's reply
+	// taking shape rather than waiting for the final summary post. The
+	// state machine's pushLiveText / onToolUseChunk paths drive
+	// relay.OnText / relay.Flush internally; without a relay attached
+	// those calls are no-ops and only the final post lands in the channel.
+	relay := newHeadlessLiveChatRelay(l, slug, target, notification, func(line string) {
+		appendHeadlessCodexLog(slug, line)
+	})
+
 	// All policy-bearing per-turn state is owned by openAICompatTurnState
 	// (see openai_compat_turn_state.go). The state machine is
 	// independently unit-tested via openai_compat_turn_state_test.go.
@@ -120,7 +130,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		// machine stays oblivious.
 		stream:  agentStream,
 		metrics: &metrics,
-	})
+	}, relay)
 
 	// taskID is unique per turn so the Receipts panel groups each
 	// agent's turn into its own row. Format mirrors agent.nextTaskID.
@@ -179,6 +189,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 		// produced when maxIters tripped) before propagating the error,
 		// so the user sees something on-channel rather than a silent
 		// failure. Without this, finalText is computed and discarded.
+		state.flushLiveChat()
 		if text := strings.TrimSpace(finalText); text != "" {
 			if msg, posted, postErr := l.postHeadlessFinalMessageIfSilent(slug, target, notification, text, startedAt); postErr != nil {
 				appendHeadlessCodexLog(slug, kind+"_partial-post-error: "+postErr.Error())
@@ -214,6 +225,7 @@ func (l *Launcher) runHeadlessOpenAICompatTurn(ctx context.Context, slug string,
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
 
+	state.flushLiveChat()
 	if text != "" && state.shouldPostFinalText() {
 		// Suppress when the agent already posted via team_broadcast /
 		// reply / etc this turn. Posting finalText here would

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -140,6 +140,11 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 	relay := newHeadlessLiveChatRelay(l, slug, target, notification, func(line string) {
 		appendHeadlessCodexLog(slug, line)
 	})
+	// Defer the flush so error/scanErr exit paths still surface the
+	// trailing buffered sentence. The explicit Flush before the final
+	// post stays — once the buffer is empty, the deferred call is a
+	// no-op.
+	defer relay.Flush()
 
 	var firstEventAt, firstTextAt, firstToolAt time.Time
 	textStarted := false
@@ -212,11 +217,11 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 			appendHeadlessCodexLog(slug, "opencode_stderr: "+detail)
 			l.updateHeadlessProgress(slug, "error", "error", truncate(detail, 180), metrics)
 			if isOpencodeAuthError(detail) && l.broker != nil {
-				target := firstNonEmpty(channel...)
-				if strings.TrimSpace(target) == "" {
-					target = "general"
+				sysTarget := target
+				if strings.TrimSpace(sysTarget) == "" {
+					sysTarget = "general"
 				}
-				l.broker.PostSystemMessage(target,
+				l.broker.PostSystemMessage(sysTarget,
 					fmt.Sprintf("@%s hit an auth error talking to the model (%s). Configure your Opencode provider credentials and retry.", slug, truncate(detail, 180)),
 					"error",
 				)

--- a/internal/team/headless_opencode.go
+++ b/internal/team/headless_opencode.go
@@ -131,6 +131,16 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 	}
 	l.updateHeadlessProgress(slug, "active", "thinking", "reviewing work packet", metrics)
 
+	// Live-chat relay surfaces the model's user-facing text to the
+	// channel at sentence/paragraph boundaries during the turn. Opencode
+	// emits one `text` event type for the assistant's spoken output;
+	// piping it through the relay is what turns the agent's reply from
+	// a single end-of-turn post into a visible live conversation.
+	target := firstNonEmpty(channel...)
+	relay := newHeadlessLiveChatRelay(l, slug, target, notification, func(line string) {
+		appendHeadlessCodexLog(slug, line)
+	})
+
 	var firstEventAt, firstTextAt, firstToolAt time.Time
 	textStarted := false
 	var lastError string
@@ -159,7 +169,9 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 				l.updateHeadlessProgress(slug, "active", "text", "drafting response", metrics)
 			}
 			pushStream(ev.Text)
+			relay.OnText(ev.Text)
 		case "tool_use":
+			relay.Flush()
 			if firstToolAt.IsZero() {
 				firstToolAt = time.Now()
 				metrics.FirstToolMs = durationMillis(startedAt, firstToolAt)
@@ -245,9 +257,9 @@ func (l *Launcher) runHeadlessOpencodeTurn(ctx context.Context, slug string, not
 		summary = "reply ready · " + summary
 	}
 	l.updateHeadlessProgress(slug, "idle", "idle", summary, metrics)
+	relay.Flush()
 	if text != "" {
 		appendHeadlessCodexLog(slug, "opencode_result: "+text)
-		target := firstNonEmpty(channel...)
 		msg, posted, err := l.postHeadlessFinalMessageIfSilent(slug, target, notification, text, startedAt)
 		if err != nil {
 			appendHeadlessCodexLog(slug, "opencode_fallback-post-error: "+err.Error())


### PR DESCRIPTION
## Summary
This PR connects the `headlessLiveChatRelay` infrastructure to all four headless runner implementations (Claude, Codex, OpenAI-compatible, and Opencode), enabling agents to stream their responses to chat channels in real-time rather than posting only a final summary at the end of a turn.

## Changes
- **Test guard**: Added `TestHeadlessRunnersWireLiveChatRelay` to prevent regression where the relay infrastructure exists but isn't wired into production runners. The test verifies that all four runner files contain the `newHeadlessLiveChatRelay` wiring.

- **headless_claude.go**: 
  - Initialize relay at turn start with text output callback
  - Pipe text events through `relay.OnText()` (excluding thinking blocks, which are private chain-of-thought)
  - Flush relay on tool use and at turn end before posting final message

- **headless_codex_runner.go**:
  - Initialize relay at turn start
  - Pipe text events through `relay.OnText()`
  - Flush relay on tool use and at turn end
  - Move `target` variable declaration earlier to avoid duplication

- **headless_openai_compat.go**:
  - Initialize relay at turn start
  - Pass relay to `newOpenAICompatTurnState()` constructor
  - Call `state.flushLiveChat()` at error handling and turn completion points

- **headless_opencode.go**:
  - Initialize relay at turn start
  - Pipe text events through `relay.OnText()`
  - Flush relay on tool use and at turn end
  - Move `target` variable declaration earlier

## Implementation Details
The relay uses sentence/paragraph boundaries to batch streamed text, preventing the channel from being flooded with mid-token chunks while ensuring users see the agent's response taking shape in real-time. Tool invocations trigger explicit flushes to avoid partial sentences stranding across tool calls. The relay is flushed at turn completion to ensure any buffered text reaches the channel before the final summary post.

https://claude.ai/code/session_01Q9Nzhm3QYygMq9QNi8rHNt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model responses now stream live to the target chat channel as they're generated; buffered output is flushed around tool calls and on turn completion or errors to preserve message boundaries.
  * Consistent live-text relay behavior applied across all headless runners; final postings reuse the precomputed target channel and ensure any trailing text is emitted.

* **Tests**
  * Added a regression test to verify live-chat relay wiring across headless runner implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->