### PR TITLE
feat(workspace-rail): show company_name as primary label in hover tooltip

### DIFF
--- a/web/src/components/workspaces/WorkspaceRail.tsx
+++ b/web/src/components/workspaces/WorkspaceRail.tsx
@@ -518,7 +518,20 @@ export function WorkspaceRail({
             </button>
             {showTooltip ? (
               <div role="tooltip" style={styles.tooltip}>
-                <div style={{ fontWeight: 600 }}>{ws.name}</div>
+                <div style={{ fontWeight: 600 }}>
+                  {ws.company_name ?? ws.name}
+                </div>
+                {ws.company_name && ws.company_name !== ws.name ? (
+                  <div
+                    style={{
+                      fontSize: 11,
+                      color: "var(--neutral-500)",
+                      marginTop: 1,
+                    }}
+                  >
+                    {ws.name}
+                  </div>
+                ) : null}
                 <div
                   style={{
                     fontSize: 11,

--- a/web/src/components/workspaces/__tests__/WorkspaceRail.test.tsx
+++ b/web/src/components/workspaces/__tests__/WorkspaceRail.test.tsx
@@ -225,6 +225,8 @@ describe("<WorkspaceRail>", () => {
     fireEvent.mouseEnter(demoIcon.parentElement as Element);
 
     const tooltip = screen.getByRole("tooltip");
+    // company_name shown as primary label; slug shown below when different
+    expect(tooltip.textContent).toContain("Acme Demo");
     expect(tooltip.textContent).toContain("demo-launch");
     expect(tooltip.textContent).toContain("paused");
   });


### PR DESCRIPTION
## Summary

- Workspace hover tooltip now shows `company_name` as the bold primary label (e.g. "Acme Demo") when available
- Slug (e.g. `demo-launch`) shown on a subdued line below when it differs from the display name
- Falls back to slug when `company_name` is absent or identical to the slug
- Test updated to assert the company name appears in the tooltip

## Test plan

- [ ] Hover over a workspace with a company name set — tooltip shows display name first, slug below
- [ ] Hover over a workspace with no company name / slug = name — tooltip shows slug only (no duplicate)
- [ ] `WorkspaceRail.test.tsx` — 11/11 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Workspace tooltip now shows the company name as the primary label and displays the workspace name on a second line when they differ, improving clarity.
* **Tests**
  * Tooltip tests updated to assert the company name is displayed alongside the workspace name and state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->