### PR TITLE
[codex] restore notebook memory workflow tools

### DIFF
--- a/internal/team/broker_notebook.go
+++ b/internal/team/broker_notebook.go
@@ -162,13 +162,8 @@ func (b *Broker) handleNotebookWrite(w http.ResponseWriter, r *http.Request) {
 			Path:      body.Path,
 			CommitSHA: sha,
 		})
-		if recordErr != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": recordErr.Error()})
-			return
-		}
-		if !found {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
-			return
+		if recordErr != nil || !found {
+			log.Printf("notebook: write committed but task memory capture not recorded (task_id=%q, found=%v, err=%v)", taskID, found, recordErr)
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/internal/team/broker_notebook.go
+++ b/internal/team/broker_notebook.go
@@ -120,6 +120,7 @@ func (b *Broker) handleNotebookWrite(w http.ResponseWriter, r *http.Request) {
 	}
 	var body struct {
 		Slug          string `json:"slug"`
+		TaskID        string `json:"task_id"`
 		Path          string `json:"path"`
 		Content       string `json:"content"`
 		Mode          string `json:"mode"`
@@ -127,6 +128,11 @@ func (b *Broker) handleNotebookWrite(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, `{"error":"invalid json"}`, http.StatusBadRequest)
+		return
+	}
+	taskID := strings.TrimSpace(body.TaskID)
+	if taskID != "" && !b.notebookTaskExists(taskID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
 		return
 	}
 	sha, n, err := worker.NotebookWrite(r.Context(), body.Slug, body.Path, body.Content, body.Mode, body.CommitMessage)
@@ -148,6 +154,22 @@ func (b *Broker) handleNotebookWrite(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 		}
 		return
+	}
+	if taskID != "" {
+		_, found, _, recordErr := b.RecordTaskMemoryCapture(taskID, body.Slug, MemoryWorkflowArtifact{
+			Backend:   "markdown",
+			Source:    "notebook",
+			Path:      body.Path,
+			CommitSHA: sha,
+		})
+		if recordErr != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": recordErr.Error()})
+			return
+		}
+		if !found {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+			return
+		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"path":          body.Path,
@@ -419,7 +441,8 @@ func (b *Broker) handleNotebookCatalog(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// handleNotebookSearch runs a literal substring search scoped to one agent.
+// handleNotebookSearch runs a literal substring search scoped to one agent, or
+// to every notebook shelf when slug=all.
 //
 //	GET /notebook/search?slug={slug}&q={pattern}
 func (b *Broker) handleNotebookSearch(w http.ResponseWriter, r *http.Request) {
@@ -442,16 +465,95 @@ func (b *Broker) handleNotebookSearch(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "q is required"})
 		return
 	}
-	hits, err := worker.NotebookSearch(slug, pattern)
-	if err != nil {
-		if isNotebookValidationError(err) {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+	var hits []WikiSearchHit
+	if strings.EqualFold(slug, "all") {
+		for _, searchSlug := range b.notebookSearchSlugs(worker) {
+			slugHits, err := worker.NotebookSearch(searchSlug, pattern)
+			if err != nil {
+				if isNotebookValidationError(err) {
+					writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+					return
+				}
+				writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+				return
+			}
+			hits = append(hits, slugHits...)
+		}
+	} else {
+		slugHits, err := worker.NotebookSearch(slug, pattern)
+		if err != nil {
+			if isNotebookValidationError(err) {
+				writeJSON(w, http.StatusBadRequest, map[string]string{"error": err.Error()})
+				return
+			}
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
 			return
 		}
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
-		return
+		hits = slugHits
+	}
+	if taskID := strings.TrimSpace(r.URL.Query().Get("task_id")); taskID != "" {
+		actor := strings.TrimSpace(r.URL.Query().Get("actor"))
+		citations := make([]ContextCitation, 0, len(hits))
+		for _, hit := range hits {
+			citations = append(citations, ContextCitation{
+				Backend:   "markdown",
+				Source:    "notebook",
+				Path:      hit.Path,
+				LineStart: hit.Line,
+				LineEnd:   hit.Line,
+				Snippet:   hit.Snippet,
+			})
+		}
+		_, found, _, recordErr := b.RecordTaskMemoryLookup(taskID, actor, pattern, citations)
+		if recordErr != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": recordErr.Error()})
+			return
+		}
+		if !found {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+			return
+		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"hits": hits})
+}
+
+func (b *Broker) notebookTaskExists(taskID string) bool {
+	taskID = strings.TrimSpace(taskID)
+	if taskID == "" {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, task := range b.tasks {
+		if task.ID == taskID {
+			return true
+		}
+	}
+	return false
+}
+
+func (b *Broker) notebookSearchSlugs(worker *WikiWorker) []string {
+	seen := map[string]struct{}{}
+	if worker != nil {
+		if notebookSlugs, err := worker.AgentsWithNotebooks(); err == nil {
+			for _, slug := range notebookSlugs {
+				if strings.TrimSpace(slug) != "" {
+					seen[slug] = struct{}{}
+				}
+			}
+		}
+	}
+	for _, member := range b.OfficeMembers() {
+		if strings.TrimSpace(member.Slug) != "" {
+			seen[member.Slug] = struct{}{}
+		}
+	}
+	slugs := make([]string, 0, len(seen))
+	for slug := range seen {
+		slugs = append(slugs, slug)
+	}
+	sort.Strings(slugs)
+	return slugs
 }
 
 // isNotebookValidationError returns true for errors produced by the notebook

--- a/internal/team/broker_notebook.go
+++ b/internal/team/broker_notebook.go
@@ -460,9 +460,19 @@ func (b *Broker) handleNotebookSearch(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "q is required"})
 		return
 	}
+	taskID := strings.TrimSpace(r.URL.Query().Get("task_id"))
+	if taskID != "" && !b.notebookTaskExists(taskID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+		return
+	}
 	var hits []WikiSearchHit
 	if strings.EqualFold(slug, "all") {
-		for _, searchSlug := range b.notebookSearchSlugs(worker) {
+		searchSlugs, err := b.notebookSearchSlugs(worker)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+			return
+		}
+		for _, searchSlug := range searchSlugs {
 			slugHits, err := worker.NotebookSearch(searchSlug, pattern)
 			if err != nil {
 				if isNotebookValidationError(err) {
@@ -486,7 +496,7 @@ func (b *Broker) handleNotebookSearch(w http.ResponseWriter, r *http.Request) {
 		}
 		hits = slugHits
 	}
-	if taskID := strings.TrimSpace(r.URL.Query().Get("task_id")); taskID != "" {
+	if taskID != "" {
 		actor := strings.TrimSpace(r.URL.Query().Get("actor"))
 		citations := make([]ContextCitation, 0, len(hits))
 		for _, hit := range hits {
@@ -527,20 +537,22 @@ func (b *Broker) notebookTaskExists(taskID string) bool {
 	return false
 }
 
-func (b *Broker) notebookSearchSlugs(worker *WikiWorker) []string {
+func (b *Broker) notebookSearchSlugs(worker *WikiWorker) ([]string, error) {
 	seen := map[string]struct{}{}
 	if worker != nil {
-		if notebookSlugs, err := worker.AgentsWithNotebooks(); err == nil {
-			for _, slug := range notebookSlugs {
-				if strings.TrimSpace(slug) != "" {
-					seen[slug] = struct{}{}
-				}
+		notebookSlugs, err := worker.AgentsWithNotebooks()
+		if err != nil {
+			return nil, err
+		}
+		for _, slug := range notebookSlugs {
+			if trimmed := strings.TrimSpace(slug); trimmed != "" {
+				seen[trimmed] = struct{}{}
 			}
 		}
 	}
 	for _, member := range b.OfficeMembers() {
-		if strings.TrimSpace(member.Slug) != "" {
-			seen[member.Slug] = struct{}{}
+		if trimmed := strings.TrimSpace(member.Slug); trimmed != "" {
+			seen[trimmed] = struct{}{}
 		}
 	}
 	slugs := make([]string, 0, len(seen))
@@ -548,7 +560,7 @@ func (b *Broker) notebookSearchSlugs(worker *WikiWorker) []string {
 		slugs = append(slugs, slug)
 	}
 	sort.Strings(slugs)
-	return slugs
+	return slugs, nil
 }
 
 // isNotebookValidationError returns true for errors produced by the notebook

--- a/internal/team/broker_notebook_test.go
+++ b/internal/team/broker_notebook_test.go
@@ -346,6 +346,111 @@ func TestEnsureNotebookDirsForRosterCreatesBlankShelves(t *testing.T) {
 	}
 }
 
+func TestBrokerNotebookWriteRecordsTaskMemoryCapture(t *testing.T) {
+	srv, b, teardown := newNotebookTestServer(t)
+	defer teardown()
+	token := b.Token()
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	b.tasks = []teamTask{{
+		ID:        "task-1",
+		Channel:   "general",
+		Title:     "Research passport process",
+		TaskType:  "process_research",
+		Status:    "in_progress",
+		CreatedBy: "ceo",
+		Owner:     "pm",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}}
+	syncTaskMemoryWorkflow(&b.tasks[0], now)
+	b.mu.Unlock()
+
+	writeBody, _ := json.Marshal(map[string]any{
+		"slug":           "pm",
+		"task_id":        "task-1",
+		"path":           "agents/pm/notebook/passport.md",
+		"content":        "# Passport\n\nReusable process notes.\n",
+		"mode":           "create",
+		"commit_message": "capture passport process",
+	})
+	req, _ := authReq(http.MethodPost, srv.URL+"/notebook/write", bytes.NewReader(writeBody), token)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, string(body))
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	wf := b.tasks[0].MemoryWorkflow
+	if wf == nil || wf.Capture.CompletedAt == "" {
+		t.Fatalf("expected capture workflow to be satisfied, got %+v", wf)
+	}
+	if len(wf.Captures) != 1 || wf.Captures[0].Path != "agents/pm/notebook/passport.md" {
+		t.Fatalf("expected notebook capture artifact, got %+v", wf.Captures)
+	}
+}
+
+func TestBrokerNotebookSearchAllRecordsTaskMemoryLookup(t *testing.T) {
+	srv, b, teardown := newNotebookTestServer(t)
+	defer teardown()
+	token := b.Token()
+	now := time.Now().UTC().Format(time.RFC3339)
+	b.mu.Lock()
+	b.members = []officeMember{{Slug: "pm", Name: "PM"}, {Slug: "ceo", Name: "CEO"}}
+	b.tasks = []teamTask{{
+		ID:        "task-1",
+		Channel:   "general",
+		Title:     "Research passport process",
+		TaskType:  "process_research",
+		Status:    "in_progress",
+		CreatedBy: "ceo",
+		Owner:     "pm",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}}
+	syncTaskMemoryWorkflow(&b.tasks[0], now)
+	b.mu.Unlock()
+	if _, _, err := b.WikiWorker().NotebookWrite(context.Background(), "pm", "agents/pm/notebook/passport.md", "# Passport\n\nRenewal evidence.\n", "create", "capture passport"); err != nil {
+		t.Fatalf("seed notebook: %v", err)
+	}
+
+	req, _ := authReq(http.MethodGet, srv.URL+"/notebook/search?slug=all&q=Renewal&task_id=task-1&actor=pm", nil, token)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 200, got %d: %s", res.StatusCode, string(body))
+	}
+	var parsed struct {
+		Hits []WikiSearchHit `json:"hits"`
+	}
+	if err := json.NewDecoder(res.Body).Decode(&parsed); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(parsed.Hits) != 1 {
+		t.Fatalf("expected one hit, got %+v", parsed.Hits)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	wf := b.tasks[0].MemoryWorkflow
+	if wf == nil || wf.Lookup.Query != "Renewal" || len(wf.Citations) != 1 {
+		t.Fatalf("expected lookup workflow citation, got %+v", wf)
+	}
+	if wf.Citations[0].Path != "agents/pm/notebook/passport.md" {
+		t.Fatalf("expected notebook citation path, got %+v", wf.Citations[0])
+	}
+}
+
 func TestEnsureBridgedMemberInitializesNotebookAfterUnlock(t *testing.T) {
 	_, b, teardown := newNotebookTestServer(t)
 	defer teardown()

--- a/internal/team/broker_notebook_test.go
+++ b/internal/team/broker_notebook_test.go
@@ -451,6 +451,56 @@ func TestBrokerNotebookSearchAllRecordsTaskMemoryLookup(t *testing.T) {
 	}
 }
 
+func TestBrokerNotebookSearchRejectsMissingTaskBeforeDiscovery(t *testing.T) {
+	srv, b, teardown := newNotebookTestServer(t)
+	defer teardown()
+	corruptAgentsDir(t, b.WikiWorker().Repo())
+
+	req, _ := authReq(http.MethodGet, srv.URL+"/notebook/search?slug=all&q=Renewal&task_id=missing", nil, b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(res.Body)
+		t.Fatalf("expected 404 before notebook discovery, got %d: %s", res.StatusCode, string(body))
+	}
+}
+
+func TestBrokerNotebookSearchAllSurfacesDiscoveryFailure(t *testing.T) {
+	srv, b, teardown := newNotebookTestServer(t)
+	defer teardown()
+	corruptAgentsDir(t, b.WikiWorker().Repo())
+
+	req, _ := authReq(http.MethodGet, srv.URL+"/notebook/search?slug=all&q=Renewal", nil, b.Token())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for notebook discovery failure, got %d: %s", res.StatusCode, string(body))
+	}
+	if !strings.Contains(string(body), "read agents dir") {
+		t.Fatalf("expected discovery error in response, got %s", string(body))
+	}
+}
+
+func corruptAgentsDir(t *testing.T, repo *Repo) {
+	t.Helper()
+	agentsPath := filepath.Join(repo.Root(), "agents")
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	if err := os.RemoveAll(agentsPath); err != nil {
+		t.Fatalf("remove agents dir: %v", err)
+	}
+	if err := os.WriteFile(agentsPath, []byte("not a directory"), 0o600); err != nil {
+		t.Fatalf("write agents file: %v", err)
+	}
+}
+
 func TestEnsureBridgedMemberInitializesNotebookAfterUnlock(t *testing.T) {
 	_, b, teardown := newNotebookTestServer(t)
 	defer teardown()

--- a/internal/team/broker_review.go
+++ b/internal/team/broker_review.go
@@ -224,6 +224,7 @@ func (b *Broker) handleNotebookPromote(w http.ResponseWriter, r *http.Request) {
 	}
 	var body struct {
 		MySlug         string `json:"my_slug"`
+		TaskID         string `json:"task_id"`
 		SourcePath     string `json:"source_path"`
 		TargetWikiPath string `json:"target_wiki_path"`
 		Rationale      string `json:"rationale"`
@@ -231,6 +232,11 @@ func (b *Broker) handleNotebookPromote(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid json"})
+		return
+	}
+	taskID := strings.TrimSpace(body.TaskID)
+	if taskID != "" && !b.notebookTaskExists(taskID) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
 		return
 	}
 	// Pre-flight: target must not already exist (state machine re-checks
@@ -263,6 +269,23 @@ func (b *Broker) handleNotebookPromote(w http.ResponseWriter, r *http.Request) {
 		ActorSlug: promotion.SourceSlug,
 		Timestamp: promotion.CreatedAt.Format(time.RFC3339),
 	})
+	if taskID != "" {
+		_, found, _, recordErr := b.RecordTaskMemoryPromotion(taskID, promotion.SourceSlug, MemoryWorkflowArtifact{
+			Backend:     "markdown",
+			Source:      "promotion",
+			Path:        promotion.TargetPath,
+			PromotionID: promotion.ID,
+			State:       string(promotion.State),
+		})
+		if recordErr != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": recordErr.Error()})
+			return
+		}
+		if !found {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
+			return
+		}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"promotion_id":  promotion.ID,
 		"reviewer_slug": promotion.ReviewerSlug,

--- a/internal/team/broker_review.go
+++ b/internal/team/broker_review.go
@@ -277,13 +277,8 @@ func (b *Broker) handleNotebookPromote(w http.ResponseWriter, r *http.Request) {
 			PromotionID: promotion.ID,
 			State:       string(promotion.State),
 		})
-		if recordErr != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": recordErr.Error()})
-			return
-		}
-		if !found {
-			writeJSON(w, http.StatusNotFound, map[string]string{"error": "task not found"})
-			return
+		if recordErr != nil || !found {
+			log.Printf("notebook: promotion submitted but task memory promotion not recorded (task_id=%q, promotion_id=%q, found=%v, err=%v)", taskID, promotion.ID, found, recordErr)
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{

--- a/internal/teammcp/notebook_tools.go
+++ b/internal/teammcp/notebook_tools.go
@@ -28,6 +28,7 @@ import (
 // TeamNotebookWriteArgs is the contract for notebook_write.
 type TeamNotebookWriteArgs struct {
 	MySlug      string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	TaskID      string `json:"task_id,omitempty" jsonschema:"Task ID this notebook write supports. Required when the task has a required memory workflow."`
 	ArticlePath string `json:"article_path" jsonschema:"Path within wiki root — MUST be agents/{my_slug}/notebook/{filename}.md"`
 	Mode        string `json:"mode" jsonschema:"One of: create | replace | append_section"`
 	Content     string `json:"content" jsonschema:"Full entry content (create/replace) or new section text (append_section)"`
@@ -47,8 +48,10 @@ type TeamNotebookListArgs struct {
 
 // TeamNotebookSearchArgs is the contract for notebook_search.
 type TeamNotebookSearchArgs struct {
-	TargetSlug string `json:"target_slug" jsonschema:"Agent whose notebook to search."`
+	TargetSlug string `json:"target_slug" jsonschema:"Agent whose notebook to search, or all to search every notebook shelf."`
 	Pattern    string `json:"pattern" jsonschema:"Literal substring to search (not regex)."`
+	TaskID     string `json:"task_id,omitempty" jsonschema:"Task ID this prior-memory search supports. Required when the task has a required memory workflow."`
+	MySlug     string `json:"my_slug,omitempty" jsonschema:"Your agent slug for task workflow attribution. Defaults to WUPHF_AGENT_SLUG env."`
 }
 
 // TeamNotebookPromoteArgs is the contract for notebook_promote. Used to
@@ -57,6 +60,7 @@ type TeamNotebookSearchArgs struct {
 // preserved with a back-link frontmatter block once approved.
 type TeamNotebookPromoteArgs struct {
 	MySlug         string `json:"my_slug,omitempty" jsonschema:"Your agent slug. Defaults to WUPHF_AGENT_SLUG env."`
+	TaskID         string `json:"task_id,omitempty" jsonschema:"Task ID this promotion decision supports. Required when the task has a required memory workflow."`
 	SourcePath     string `json:"source_path" jsonschema:"Notebook source path — MUST be agents/{my_slug}/notebook/{filename}.md"`
 	TargetWikiPath string `json:"target_wiki_path" jsonschema:"Proposed wiki path — MUST start with team/ and end in .md (e.g. team/playbooks/q2-launch.md)"`
 	Rationale      string `json:"rationale" jsonschema:"Why this entry is ready for promotion — the reviewer sees this as the commit message rationale."`
@@ -69,7 +73,7 @@ type TeamNotebookPromoteArgs struct {
 func registerNotebookTools(server *mcp.Server) {
 	mcp.AddTool(server, officeWriteTool(
 		"notebook_write",
-		"Write a draft entry to your personal notebook at agents/{my_slug}/notebook/{filename}.md. Use this for half-baked thoughts, working notes, and draft playbooks before anything is reviewed and promoted to the team wiki. Author-only: you cannot write to another agent's notebook.",
+		"Write a draft entry to your personal notebook at agents/{my_slug}/notebook/{filename}.md. Use this for half-baked thoughts, working notes, and draft playbooks before anything is reviewed and promoted to the team wiki. Pass task_id when this write supports a task with a required memory workflow. Author-only: you cannot write to another agent's notebook.",
 	), handleTeamNotebookWrite)
 	mcp.AddTool(server, readOnlyTool(
 		"notebook_read",
@@ -81,11 +85,11 @@ func registerNotebookTools(server *mcp.Server) {
 	), handleTeamNotebookList)
 	mcp.AddTool(server, readOnlyTool(
 		"notebook_search",
-		"Literal substring search scoped to one agent's notebook subtree. Pattern is matched as a substring (not a regex).",
+		"Literal substring search scoped to one agent's notebook subtree, or every notebook when target_slug=all. Pattern is matched as a substring (not a regex). Pass task_id when this is the prior-memory search for a task with a required memory workflow.",
 	), handleTeamNotebookSearch)
 	mcp.AddTool(server, officeWriteTool(
 		"notebook_promote",
-		"Submit a notebook entry for reviewer approval + promotion to the team wiki. Copy-not-move: once approved the source entry is retained with a back-link frontmatter block. Target path must start with team/ and end in .md.",
+		"Submit a notebook entry for reviewer approval + promotion to the team wiki. Copy-not-move: once approved the source entry is retained with a back-link frontmatter block. Pass task_id when this is the promotion decision for a task with a required memory workflow. Target path must start with team/ and end in .md.",
 	), handleTeamNotebookPromote)
 }
 
@@ -124,6 +128,7 @@ func handleTeamNotebookWrite(ctx context.Context, _ *mcp.CallToolRequest, args T
 	}
 	err = brokerPostJSON(ctx, "/notebook/write", map[string]any{
 		"slug":           slug,
+		"task_id":        strings.TrimSpace(args.TaskID),
 		"path":           path,
 		"mode":           mode,
 		"content":        args.Content,
@@ -217,6 +222,7 @@ func handleTeamNotebookPromote(ctx context.Context, _ *mcp.CallToolRequest, args
 	}
 	err = brokerPostJSON(ctx, "/notebook/promote", map[string]any{
 		"my_slug":          slug,
+		"task_id":          strings.TrimSpace(args.TaskID),
 		"source_path":      sourcePath,
 		"target_wiki_path": targetPath,
 		"rationale":        args.Rationale,
@@ -241,6 +247,14 @@ func handleTeamNotebookSearch(ctx context.Context, _ *mcp.CallToolRequest, args 
 	q := url.Values{}
 	q.Set("slug", target)
 	q.Set("q", pattern)
+	if taskID := strings.TrimSpace(args.TaskID); taskID != "" {
+		q.Set("task_id", taskID)
+	}
+	if actor := strings.TrimSpace(args.MySlug); actor != "" {
+		q.Set("actor", actor)
+	} else if actor := resolveSlugOptional(""); actor != "" {
+		q.Set("actor", actor)
+	}
 	var result struct {
 		Hits []map[string]any `json:"hits"`
 	}

--- a/internal/teammcp/notebook_tools_test.go
+++ b/internal/teammcp/notebook_tools_test.go
@@ -108,6 +108,7 @@ func TestHandleTeamNotebookWrite(t *testing.T) {
 
 	res, _, err := handleTeamNotebookWrite(context.Background(), nil, TeamNotebookWriteArgs{
 		ArticlePath: "agents/pm/notebook/x.md",
+		TaskID:      "task-1",
 		Mode:        "create",
 		Content:     "# x\nbody\n",
 		CommitMsg:   "draft x",
@@ -123,6 +124,9 @@ func TestHandleTeamNotebookWrite(t *testing.T) {
 	}
 	if !strings.Contains(auth.lastBody, "\"slug\":\"pm\"") {
 		t.Fatalf("expected slug=pm in body, got %s", auth.lastBody)
+	}
+	if !strings.Contains(auth.lastBody, "\"task_id\":\"task-1\"") {
+		t.Fatalf("expected task_id in body, got %s", auth.lastBody)
 	}
 	if !strings.Contains(auth.lastAuth, "Bearer test-token") {
 		t.Fatalf("expected auth header, got %q", auth.lastAuth)
@@ -281,12 +285,16 @@ func TestHandleTeamNotebookSearch(t *testing.T) {
 	_, _, err := handleTeamNotebookSearch(context.Background(), nil, TeamNotebookSearchArgs{
 		TargetSlug: "pm",
 		Pattern:    "Retro",
+		TaskID:     "task-1",
 	})
 	if err != nil {
 		t.Fatalf("handler: %v", err)
 	}
 	if !strings.Contains(auth.lastRaw, "slug=pm") || !strings.Contains(auth.lastRaw, "q=Retro") {
 		t.Fatalf("expected slug+q query params, got %q", auth.lastRaw)
+	}
+	if !strings.Contains(auth.lastRaw, "task_id=task-1") || !strings.Contains(auth.lastRaw, "actor=pm") {
+		t.Fatalf("expected task workflow query params, got %q", auth.lastRaw)
 	}
 }
 
@@ -343,6 +351,7 @@ func TestHandleTeamNotebookPromote_Happy(t *testing.T) {
 
 	res, _, err := handleTeamNotebookPromote(context.Background(), nil, TeamNotebookPromoteArgs{
 		SourcePath:     "agents/pm/notebook/retro.md",
+		TaskID:         "task-1",
 		TargetWikiPath: "team/playbooks/retro.md",
 		Rationale:      "canonical",
 	})
@@ -357,6 +366,9 @@ func TestHandleTeamNotebookPromote_Happy(t *testing.T) {
 	}
 	if !strings.Contains(auth.lastBody, "\"my_slug\":\"pm\"") {
 		t.Fatalf("expected my_slug in body: %s", auth.lastBody)
+	}
+	if !strings.Contains(auth.lastBody, "\"task_id\":\"task-1\"") {
+		t.Fatalf("expected task_id in body: %s", auth.lastBody)
 	}
 	if !strings.Contains(auth.lastBody, "\"target_wiki_path\":\"team/playbooks/retro.md\"") {
 		t.Fatalf("expected target path in body: %s", auth.lastBody)

--- a/internal/teammcp/server.go
+++ b/internal/teammcp/server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/nex-crm/wuphf/internal/action"
+	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/team"
 )
 
@@ -64,8 +65,8 @@ func Run(ctx context.Context) error {
 // nex/gbrain installs expose the legacy team_memory_* tools; `none` skips
 // them entirely. Both tool sets NEVER coexist — agents see exactly one.
 func registerSharedMemoryTools(server *mcp.Server) {
-	switch strings.TrimSpace(os.Getenv("WUPHF_MEMORY_BACKEND")) {
-	case "markdown":
+	switch config.ResolveMemoryBackend("") {
+	case config.MemoryBackendMarkdown:
 		mcp.AddTool(server, officeWriteTool(
 			"team_wiki_write",
 			"Write directly to the canonical team wiki git repo. Use this for already-approved canonical edits, bootstrap/admin updates, or explicit human requests. For agent-authored working notes, observations, draft playbooks, and proposed new wiki knowledge, write to notebook_write first and submit with notebook_promote so the review gate runs. The content you pass becomes the article bytes; this tool does not rewrite for you. Picks author identity from my_slug so git log shows which agent wrote each article. Images are supported via standard markdown: embed a remote URL with `![alt text](https://example.com/diagram.png)` and the wiki renderer will show it inline. Use images you found on the web while researching the article; do not upload bytes — only reference URLs.",
@@ -108,7 +109,7 @@ func registerSharedMemoryTools(server *mcp.Server) {
 			"resolve_contradiction",
 			"Resolve a contradiction finding from a prior run_lint call. winner must be A (first fact wins), B (second fact wins), or Both (acknowledge both as valid).",
 		), handleResolveContradiction)
-	case "none":
+	case config.MemoryBackendNone:
 		// Nothing — user explicitly disabled shared memory.
 	default:
 		// nex / gbrain (default): legacy tool set unchanged.

--- a/internal/teammcp/server_backend_switch_test.go
+++ b/internal/teammcp/server_backend_switch_test.go
@@ -2,6 +2,7 @@ package teammcp
 
 import (
 	"context"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -29,6 +30,24 @@ func TestConfigureServerToolsBackendMatrix(t *testing.T) {
 		{
 			name:    "markdown/office",
 			backend: "markdown",
+			mustHave: []string{
+				"team_wiki_read",
+				"team_wiki_write",
+				"team_wiki_search",
+				"team_wiki_list",
+				"notebook_write",
+				"notebook_promote",
+			},
+			mustNotHave: []string{
+				"team_memory_query",
+				"team_memory_write",
+				"team_memory_promote",
+			},
+			commonPresent: []string{"team_broadcast", "team_poll", "context_lookup", "context_capture", "context_promote", "context_health"},
+		},
+		{
+			name:    "default/office",
+			backend: "",
 			mustHave: []string{
 				"team_wiki_read",
 				"team_wiki_write",
@@ -137,6 +156,7 @@ func TestConfigureServerToolsBackendMatrix(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// Arrange
 			t.Setenv("WUPHF_MEMORY_BACKEND", tc.backend)
+			t.Setenv("WUPHF_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
 
 			channel := "general"
 			if tc.name == "markdown/dm" {


### PR DESCRIPTION
## Summary
- Resolve MCP shared-memory tool registration through the same backend resolver used by the broker, so the default markdown backend exposes `notebook_write`, `notebook_promote`, and wiki tools even when `WUPHF_MEMORY_BACKEND` is unset.
- Thread `task_id` through notebook write/search/promote MCP calls and record matching task memory workflow evidence in the broker.
- Allow `notebook_search` with `target_slug=all`/`slug=all` so required prior-memory searches can cover every agent shelf.

## Root cause
PR #600 landed notebook shelf bootstrap, but MCP tool registration still switched on the raw `WUPHF_MEMORY_BACKEND` environment variable. Since the app default is resolved through config to `markdown`, an unset env could start the markdown wiki worker while the MCP server exposed legacy memory tools instead of notebook tools. Direct `notebook_write` also accepted no `task_id`, so required memory workflows were not satisfied by the tool agents were instructed to use.

## Verification
- `go test ./internal/teammcp -run 'TestConfigureServerToolsBackendMatrix|TestNotebookTools|TestHandleTeamNotebook'`
- `go test ./internal/team -run 'TestBrokerNotebookWriteRecordsTaskMemoryCapture|TestBrokerNotebookSearchAllRecordsTaskMemoryLookup|TestBrokerNotebook|TestEnsureNotebookDirs'`
- `bash scripts/test-go.sh ./internal/team ./internal/teammcp`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notebook operations (write, search, promote) now accept an optional task association to link entries to workflows.
  * Search supports aggregating results across all notebooks via a slug=all option.
  * Task memory capture and lookup are recorded automatically during notebook operations (no change to user-facing responses on record failures).

* **Tests**
  * Added integration tests verifying task-memory recording for notebook writes and searches.

* **Chores**
  * Improved shared-memory tool registration behavior and test coverage for backend selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->