### PR TITLE
feat(onboarding): trim step 1 headline

### DIFF
--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -17,7 +17,7 @@ export const SIDEBAR_APPS = [
 ] as const;
 
 export const ONBOARDING_COPY = {
-  step1_headline: "Virtual office of AI employees with a shared brain",
+  step1_headline: "AI employees with a shared brain",
   step1_subhead:
     "A collaborative office where AI agents like Claude Code, Codex, and OpenClaw learn your work playbooks, build personalized skills, and execute, 24x7. Each agent backed by its own knowledge graph.",
   step1_cta: "Open the office",


### PR DESCRIPTION
## Summary

- Changes `step1_headline` in `ONBOARDING_COPY` from `"Virtual office of AI employees with a shared brain"` to `"AI employees with a shared brain"`
- Shorter, leads with what matters, drops the framing prefix

## Test plan

- [ ] Open onboarding wizard — first slide shows "AI employees with a shared brain"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refined onboarding headline text for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->