### PR TITLE
feat(onboarding): remove memory backend selector

### DIFF
--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -10,7 +10,6 @@ export { ApiKeyRow } from "./wizard/ApiKeyRow";
 import { ProgressDots } from "./wizard/components";
 import {
   LOCAL_PROVIDER_LABELS,
-  MEMORY_BACKEND_OPTIONS,
   RUNTIMES,
   SCRATCH_FOUNDING_TEAM,
   STEP_ORDER,
@@ -30,7 +29,6 @@ import { ReadyStep } from "./wizard/Step7Ready";
 import type {
   BlueprintAgent,
   BlueprintTemplate,
-  MemoryBackend,
   NexSignupStatus,
   PrereqResult,
   ReadinessCheck,
@@ -103,21 +101,6 @@ export function Wizard({ onComplete }: WizardProps) {
   // applied as llm_provider on /onboarding/complete.
   const [localProvider, setLocalProvider] = useState<string>("");
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
-  // Matches MEMORY_BACKEND_OPTIONS[0] (the "Markdown (default)" tile) and the
-  // server-side `config.ResolveMemoryBackend` default. Shipping 'nex' here
-  // contradicted the label and meant a user who clicked through got a
-  // different backend than the one marked default.
-  const [memoryBackend, setMemoryBackend] = useState<MemoryBackend>("markdown");
-  // Nex API key (maps to `api_key` on /config). Parity with TUI's InitAPIKey
-  // phase. Kept separate from `apiKeys` because the latter is the per-runtime
-  // fallback set (Anthropic/OpenAI/Google) while this one unlocks hosted
-  // memory and managed integrations. Empty = skipped, not an error.
-  const [nexApiKey, setNexApiKey] = useState("");
-  // GBrain-specific key inputs. Only rendered when memoryBackend === 'gbrain'.
-  // Mirrors the TUI's InitGBrainOpenAIKey (required) + InitGBrainAnthropKey
-  // (optional) phases.
-  const [gbrainOpenAIKey, setGbrainOpenAIKey] = useState("");
-  const [gbrainAnthropicKey, setGbrainAnthropicKey] = useState("");
 
   // Step 6: first task
   const [taskTemplates, setTaskTemplates] = useState<TaskTemplate[]>([]);
@@ -377,17 +360,7 @@ export function Wizard({ onComplete }: WizardProps) {
   const readinessChecks: ReadinessCheck[] = (() => {
     const checks: ReadinessCheck[] = [];
 
-    // 1. Nex API key
-    const hasNexKey = nexApiKey.trim().length > 0;
-    checks.push({
-      label: "Nex API key",
-      status: hasNexKey ? "ready" : "next",
-      detail: hasNexKey
-        ? "Configured. Hosted memory and integrations unlocked."
-        : "Skipped. Paste a key later from Settings to enable hosted memory.",
-    });
-
-    // 2. Tmux / web session. The web app doesn't need tmux — that's the
+    // 1. Tmux / web session. The web app doesn't need tmux — that's the
     // TUI's office runtime. Surface it as a positive "web session" rather
     // than flagging a missing dependency.
     checks.push({
@@ -460,37 +433,11 @@ export function Wizard({ onComplete }: WizardProps) {
       });
     }
 
-    // 4. Memory backend
-    const memoryLabel =
-      MEMORY_BACKEND_OPTIONS.find((o) => o.value === memoryBackend)?.label ??
-      memoryBackend;
-    let memoryStatus: ReadinessStatus = "ready";
-    let memoryDetail = memoryLabel;
-    if (memoryBackend === "gbrain") {
-      if (gbrainOpenAIKey.trim().length === 0) {
-        memoryStatus = "missing";
-        memoryDetail = "GBrain selected but OpenAI key is missing.";
-      } else {
-        memoryDetail = "GBrain with OpenAI embeddings.";
-      }
-    } else if (memoryBackend === "nex") {
-      if (!hasNexKey) {
-        memoryStatus = "next";
-        memoryDetail =
-          "Nex selected — add a Nex API key to enable hosted memory.";
-      } else {
-        memoryDetail = "Hosted memory via Nex.";
-      }
-    } else if (memoryBackend === "markdown") {
-      memoryDetail = "Git-native team wiki in ~/.wuphf/wiki.";
-    } else {
-      memoryStatus = "next";
-      memoryDetail = "No shared memory — agents only see per-turn context.";
-    }
+    // 4. Memory backend — always markdown (built-in, no configuration needed)
     checks.push({
       label: "Memory backend",
-      status: memoryStatus,
-      detail: memoryDetail,
+      status: "ready",
+      detail: "Git-native team wiki in ~/.wuphf/wiki.",
     });
 
     // 5. Blueprint
@@ -510,10 +457,9 @@ export function Wizard({ onComplete }: WizardProps) {
     }
 
     // 6. Integrations count
-    const keyCount =
-      Object.values(apiKeys).filter((v) => v.trim().length > 0).length +
-      (gbrainOpenAIKey.trim().length > 0 ? 1 : 0) +
-      (gbrainAnthropicKey.trim().length > 0 ? 1 : 0);
+    const keyCount = Object.values(apiKeys).filter(
+      (v) => v.trim().length > 0,
+    ).length;
     checks.push({
       label: "Integrations",
       status: keyCount > 0 ? "ready" : "next",
@@ -558,46 +504,19 @@ export function Wizard({ onComplete }: WizardProps) {
         // broker's /config endpoint is the canonical persistence surface
         // for config.APIKey, OpenAIAPIKey, AnthropicAPIKey, etc.
         const configPayload: Record<string, unknown> = {
-          memory_backend: memoryBackend,
+          memory_backend: "markdown",
         };
         if (providerPriority.length > 0) {
-          // First entry is the active provider; the full ordered list
-          // is the fallback chain. The user controls the order via the
-          // arrow buttons — if they move a local kind to slot 0 it
-          // becomes the primary; if they keep it last it's the
-          // out-of-credits fallback.
           configPayload.llm_provider = providerPriority[0];
           configPayload.llm_provider_priority = providerPriority;
         }
-        // Nex API key (optional — empty string not sent so we don't clobber
-        // an existing value with a blank one).
-        const trimmedNex = nexApiKey.trim();
-        if (trimmedNex.length > 0) {
-          configPayload.api_key = trimmedNex;
-        }
-        // GBrain-conditional keys. Only forwarded when GBrain is the active
-        // backend; other backends don't need these and sending would
-        // overwrite any user-configured values on GET.
-        if (memoryBackend === "gbrain") {
-          const trimmedOAI = gbrainOpenAIKey.trim();
-          if (trimmedOAI.length > 0) {
-            configPayload.openai_api_key = trimmedOAI;
-          }
-          const trimmedAnthropic = gbrainAnthropicKey.trim();
-          if (trimmedAnthropic.length > 0) {
-            configPayload.anthropic_api_key = trimmedAnthropic;
-          }
-        }
-        // Generic per-provider API keys from the fallback grid. Legacy
-        // env-var-style keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, GOOGLE_API_KEY)
-        // mapped to the broker's config field names. Google key has no
-        // /config field yet — drop it silently rather than fail.
+        // Generic per-provider API keys from the fallback grid.
         const genericAnthropic = (apiKeys.ANTHROPIC_API_KEY ?? "").trim();
-        if (genericAnthropic.length > 0 && memoryBackend !== "gbrain") {
+        if (genericAnthropic.length > 0) {
           configPayload.anthropic_api_key = genericAnthropic;
         }
         const genericOpenAI = (apiKeys.OPENAI_API_KEY ?? "").trim();
-        if (genericOpenAI.length > 0 && memoryBackend !== "gbrain") {
+        if (genericOpenAI.length > 0) {
           configPayload.openai_api_key = genericOpenAI;
         }
         const genericGemini = (apiKeys.GOOGLE_API_KEY ?? "").trim();
@@ -623,7 +542,7 @@ export function Wizard({ onComplete }: WizardProps) {
           priority,
           runtime: primaryRuntime,
           runtime_priority: runtimePriority,
-          memory_backend: memoryBackend,
+          memory_backend: "markdown",
           blueprint: selectedBlueprint,
           agents: agents.filter((a) => a.checked).map((a) => a.slug),
           api_keys: apiKeys,
@@ -646,13 +565,9 @@ export function Wizard({ onComplete }: WizardProps) {
       description,
       priority,
       runtimePriority,
-      memoryBackend,
       selectedBlueprint,
       agents,
       apiKeys,
-      nexApiKey,
-      gbrainOpenAIKey,
-      gbrainAnthropicKey,
       taskText,
       setOnboardingComplete,
       onComplete,
@@ -696,8 +611,6 @@ export function Wizard({ onComplete }: WizardProps) {
         prereqsError,
         apiKeys,
         localProvider,
-        memoryBackend,
-        gbrainOpenAIKey,
       });
 
       switch (step) {
@@ -752,8 +665,6 @@ export function Wizard({ onComplete }: WizardProps) {
     prereqs,
     prereqsError,
     apiKeys,
-    memoryBackend,
-    gbrainOpenAIKey,
     submitting,
     taskText,
     goTo,
@@ -826,16 +737,6 @@ export function Wizard({ onComplete }: WizardProps) {
             apiKeyState={{
               values: apiKeys,
               onChange: handleApiKeyChange,
-            }}
-            memoryState={{
-              backend: memoryBackend,
-              onChangeBackend: setMemoryBackend,
-              nexApiKey,
-              onChangeNexApiKey: setNexApiKey,
-              gbrainOpenAIKey,
-              onChangeGBrainOpenAIKey: setGbrainOpenAIKey,
-              gbrainAnthropicKey,
-              onChangeGBrainAnthropicKey: setGbrainAnthropicKey,
             }}
             localLLMState={{
               provider: localProvider,

--- a/web/src/components/onboarding/wizard/Step5Setup.test.tsx
+++ b/web/src/components/onboarding/wizard/Step5Setup.test.tsx
@@ -6,7 +6,7 @@ vi.mock("../../../api/client", () => ({
 }));
 
 import { SetupStep } from "./Step5Setup";
-import type { MemoryBackend, PrereqResult } from "./types";
+import type { PrereqResult } from "./types";
 
 interface Overrides {
   prereqs?: PrereqResult[];
@@ -14,10 +14,6 @@ interface Overrides {
   prereqsError?: string;
   runtimePriority?: string[];
   apiKeys?: Record<string, string>;
-  memoryBackend?: MemoryBackend;
-  nexApiKey?: string;
-  gbrainOpenAIKey?: string;
-  gbrainAnthropicKey?: string;
   localProvider?: string;
   onSelectLocalProvider?: (kind: string) => void;
 }
@@ -29,10 +25,6 @@ function setupProps(overrides: Overrides = {}) {
     prereqsError = "",
     runtimePriority = [],
     apiKeys = {},
-    memoryBackend = "markdown",
-    nexApiKey = "",
-    gbrainOpenAIKey = "",
-    gbrainAnthropicKey = "",
     localProvider = "",
     onSelectLocalProvider = () => {},
   } = overrides;
@@ -50,16 +42,6 @@ function setupProps(overrides: Overrides = {}) {
     apiKeyState: {
       values: apiKeys,
       onChange: () => {},
-    },
-    memoryState: {
-      backend: memoryBackend as MemoryBackend,
-      onChangeBackend: () => {},
-      nexApiKey,
-      onChangeNexApiKey: () => {},
-      gbrainOpenAIKey,
-      onChangeGBrainOpenAIKey: () => {},
-      gbrainAnthropicKey,
-      onChangeGBrainAnthropicKey: () => {},
     },
     localLLMState: {
       provider: localProvider,
@@ -111,41 +93,12 @@ describe("SetupStep — canContinue gate", () => {
     expect(screen.getByRole("button", { name: ctaName })).toBeEnabled();
   });
 
-  it("disables Continue when GBrain is selected without an OpenAI key — even with an installed runtime", () => {
-    renderSetup({
-      prereqs: [{ name: "claude", required: true, found: true }],
-      runtimePriority: ["Claude Code"],
-      memoryBackend: "gbrain",
-      gbrainOpenAIKey: "",
-    });
-    expect(screen.getByRole("button", { name: ctaName })).toBeDisabled();
-  });
-
-  it("re-enables Continue once the GBrain OpenAI key is filled in", () => {
-    renderSetup({
-      prereqs: [{ name: "claude", required: true, found: true }],
-      runtimePriority: ["Claude Code"],
-      memoryBackend: "gbrain",
-      gbrainOpenAIKey: "sk-openai",
-    });
-    expect(screen.getByRole("button", { name: ctaName })).toBeEnabled();
-  });
 });
 
 describe("SetupStep — surfaces", () => {
   it("renders the prereqs error banner when detection fails", () => {
     renderSetup({ prereqsError: "exec: command not found" });
     expect(screen.getByTestId("prereqs-error-banner")).toBeInTheDocument();
-  });
-
-  it("hides the Nex API key panel unless memoryBackend === 'nex'", () => {
-    const { rerender } = renderSetup({ memoryBackend: "markdown" });
-    expect(
-      screen.queryByTestId("wizard-nex-api-key-panel"),
-    ).not.toBeInTheDocument();
-
-    rerender(<SetupStep {...setupProps({ memoryBackend: "nex" })} />);
-    expect(screen.getByTestId("wizard-nex-api-key-panel")).toBeInTheDocument();
   });
 
   it("toggling the local-LLM tile off clears localProvider via callback", () => {

--- a/web/src/components/onboarding/wizard/Step5Setup.tsx
+++ b/web/src/components/onboarding/wizard/Step5Setup.tsx
@@ -3,19 +3,14 @@ import { useEffect, useRef, useState } from "react";
 import { ONBOARDING_COPY } from "../../../lib/constants";
 import { ApiKeyRow } from "./ApiKeyRow";
 import { ArrowIcon, EnterHint } from "./components";
-import {
-  API_KEY_FIELDS,
-  LOCAL_PROVIDER_LABELS,
-  MEMORY_BACKEND_OPTIONS,
-  RUNTIMES,
-} from "./constants";
+import { API_KEY_FIELDS, LOCAL_PROVIDER_LABELS, RUNTIMES } from "./constants";
 import { LocalLLMPicker } from "./LocalLLMPicker";
 import {
   canSetupContinue,
   detectedBinary,
   runtimeIsReady,
 } from "./runtime-helpers";
-import type { MemoryBackend, PrereqResult, RuntimeSpec } from "./types";
+import type { PrereqResult, RuntimeSpec } from "./types";
 
 interface PrereqStatus {
   items: PrereqResult[];
@@ -34,17 +29,6 @@ interface ApiKeyState {
   onChange: (key: string, value: string) => void;
 }
 
-interface MemoryState {
-  backend: MemoryBackend;
-  onChangeBackend: (value: MemoryBackend) => void;
-  nexApiKey: string;
-  onChangeNexApiKey: (v: string) => void;
-  gbrainOpenAIKey: string;
-  onChangeGBrainOpenAIKey: (v: string) => void;
-  gbrainAnthropicKey: string;
-  onChangeGBrainAnthropicKey: (v: string) => void;
-}
-
 interface LocalLLMState {
   // Local-LLM opt-in chosen here; submitted with the rest of the wizard
   // payload at /onboarding/complete and applied to llm_provider so the
@@ -57,7 +41,6 @@ interface SetupStepProps {
   prereqStatus: PrereqStatus;
   runtimeSelection: RuntimeSelection;
   apiKeyState: ApiKeyState;
-  memoryState: MemoryState;
   localLLMState: LocalLLMState;
   onNext: () => void;
   onBack: () => void;
@@ -193,121 +176,10 @@ function RuntimeTile({
   );
 }
 
-interface MemoryBackendPanelProps {
-  memoryBackend: MemoryBackend;
-  onChangeMemoryBackend: (value: MemoryBackend) => void;
-  gbrainOpenAIKey: string;
-  onChangeGBrainOpenAIKey: (v: string) => void;
-  gbrainAnthropicKey: string;
-  onChangeGBrainAnthropicKey: (v: string) => void;
-}
-
-function MemoryBackendPanel({
-  memoryBackend,
-  onChangeMemoryBackend,
-  gbrainOpenAIKey,
-  onChangeGBrainOpenAIKey,
-  gbrainAnthropicKey,
-  onChangeGBrainAnthropicKey,
-}: MemoryBackendPanelProps) {
-  const gbrainSelected = memoryBackend === "gbrain";
-  const gbrainOpenAIMissing =
-    gbrainSelected && gbrainOpenAIKey.trim().length === 0;
-
-  return (
-    <div className="wizard-panel">
-      <p className="wizard-panel-title">Organizational memory</p>
-      <p
-        style={{
-          fontSize: 12,
-          color: "var(--text-secondary)",
-          margin: "-8px 0 12px 0",
-        }}
-      >
-        Where agents store shared context, relationships, and learnings across
-        sessions. You can change this later in Settings or via{" "}
-        <code>--memory-backend</code>.
-      </p>
-      <div className="runtime-grid">
-        {MEMORY_BACKEND_OPTIONS.map((opt) => (
-          <button
-            key={opt.value}
-            className={`runtime-tile ${memoryBackend === opt.value ? "selected" : ""}`}
-            onClick={() => onChangeMemoryBackend(opt.value)}
-            aria-pressed={memoryBackend === opt.value}
-            type="button"
-            title={opt.hint}
-          >
-            <div style={{ fontWeight: 600 }}>{opt.label}</div>
-            <div
-              style={{
-                fontSize: 11,
-                color: "var(--text-tertiary)",
-                marginTop: 4,
-                fontWeight: 400,
-              }}
-            >
-              {opt.hint}
-            </div>
-          </button>
-        ))}
-      </div>
-
-      {gbrainSelected ? (
-        <div className="wiz-backend-keys">
-          <p className="wiz-backend-keys-title">GBrain keys</p>
-          <p className="wiz-backend-keys-hint">
-            GBrain uses OpenAI for embeddings (required) and optionally
-            Anthropic for reasoning.
-          </p>
-          <div className="form-group">
-            <label className="label" htmlFor="wiz-gbrain-openai">
-              OpenAI API key <span style={{ color: "var(--red)" }}>*</span>
-            </label>
-            <input
-              className="input"
-              id="wiz-gbrain-openai"
-              type="password"
-              placeholder="sk-..."
-              value={gbrainOpenAIKey}
-              onChange={(e) => onChangeGBrainOpenAIKey(e.target.value)}
-              autoComplete="off"
-            />
-            {gbrainOpenAIMissing ? (
-              <p style={{ color: "var(--red)", fontSize: 11, marginTop: 4 }}>
-                Required: GBrain can&apos;t create embeddings without an OpenAI
-                key.
-              </p>
-            ) : null}
-          </div>
-          <div className="form-group" style={{ marginBottom: 0 }}>
-            <label className="label" htmlFor="wiz-gbrain-anthropic">
-              Anthropic API key{" "}
-              <span style={{ fontSize: 11, color: "var(--text-tertiary)" }}>
-                (optional)
-              </span>
-            </label>
-            <input
-              className="input"
-              id="wiz-gbrain-anthropic"
-              type="password"
-              placeholder="sk-ant-..."
-              value={gbrainAnthropicKey}
-              onChange={(e) => onChangeGBrainAnthropicKey(e.target.value)}
-              autoComplete="off"
-            />
-          </div>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
 export function SetupStep({
   prereqStatus,
   runtimeSelection,
   apiKeyState,
-  memoryState,
   localLLMState,
   onNext,
   onBack,
@@ -323,16 +195,6 @@ export function SetupStep({
     onReorder: onReorderRuntime,
   } = runtimeSelection;
   const { values: apiKeys, onChange: onChangeApiKey } = apiKeyState;
-  const {
-    backend: memoryBackend,
-    onChangeBackend: onChangeMemoryBackend,
-    nexApiKey,
-    onChangeNexApiKey,
-    gbrainOpenAIKey,
-    onChangeGBrainOpenAIKey,
-    gbrainAnthropicKey,
-    onChangeGBrainAnthropicKey,
-  } = memoryState;
   const { provider: localProvider, onSelectProvider: onSelectLocalProvider } =
     localLLMState;
 
@@ -366,8 +228,6 @@ export function SetupStep({
     prereqsError,
     apiKeys,
     localProvider,
-    memoryBackend,
-    gbrainOpenAIKey,
   });
 
   return (
@@ -552,54 +412,6 @@ export function SetupStep({
           ))}
         </div>
       </div>
-
-      <MemoryBackendPanel
-        memoryBackend={memoryBackend}
-        onChangeMemoryBackend={onChangeMemoryBackend}
-        gbrainOpenAIKey={gbrainOpenAIKey}
-        onChangeGBrainOpenAIKey={onChangeGBrainOpenAIKey}
-        gbrainAnthropicKey={gbrainAnthropicKey}
-        onChangeGBrainAnthropicKey={onChangeGBrainAnthropicKey}
-      />
-
-      {memoryBackend === "nex" && (
-        // Only show the Nex API key panel when the chosen memory backend
-        // actually needs it. Team wiki, GBrain, and "None" don't talk to
-        // Nex's hosted memory — surfacing the input would suggest the
-        // user has a missing piece when they don't.
-        <div className="wizard-panel" data-testid="wizard-nex-api-key-panel">
-          <p className="wizard-panel-title">Nex API key</p>
-          <p
-            style={{
-              fontSize: 12,
-              color: "var(--text-secondary)",
-              margin: "-8px 0 12px 0",
-            }}
-          >
-            Unlocks the hosted memory graph plus managed integrations (HubSpot,
-            Slack, Gmail, Calendar, …) so agents can read your tools without you
-            wiring each one up. You can skip this and paste later from Settings.
-            Don&apos;t have one? Sign up on the Identity step above.
-          </p>
-          <div className="form-group" style={{ marginBottom: 0 }}>
-            <label className="label" htmlFor="wiz-nex-api-key">
-              Nex API key{" "}
-              <span style={{ fontSize: 11, color: "var(--text-tertiary)" }}>
-                (optional during onboarding)
-              </span>
-            </label>
-            <input
-              className="input"
-              id="wiz-nex-api-key"
-              type="password"
-              placeholder="nex-..."
-              value={nexApiKey}
-              onChange={(e) => onChangeNexApiKey(e.target.value)}
-              autoComplete="off"
-            />
-          </div>
-        </div>
-      )}
 
       <div className="wizard-nav">
         <button className="btn btn-ghost" onClick={onBack} type="button">

--- a/web/src/components/onboarding/wizard/runtime-helpers.ts
+++ b/web/src/components/onboarding/wizard/runtime-helpers.ts
@@ -1,5 +1,5 @@
 import { RUNTIMES } from "./constants";
-import type { MemoryBackend, PrereqResult } from "./types";
+import type { PrereqResult } from "./types";
 
 // Find the prereq detection record for a binary (e.g. "claude", "codex").
 // Pure helper used by both runtimeIsReady and the SetupStep tile renderer.
@@ -43,8 +43,6 @@ interface SetupContinueInput {
   prereqsError: string;
   apiKeys: Record<string, string>;
   localProvider: string;
-  memoryBackend: MemoryBackend;
-  gbrainOpenAIKey: string;
 }
 
 export function canSetupContinue({
@@ -53,18 +51,11 @@ export function canSetupContinue({
   prereqsError,
   apiKeys,
   localProvider,
-  memoryBackend,
-  gbrainOpenAIKey,
 }: SetupContinueInput): boolean {
   const hasInstalledSelection = runtimePriority.some((label) =>
     runtimeIsReady(label, prereqs, prereqsError),
   );
   const hasAnyApiKey = Object.values(apiKeys).some((v) => v.trim().length > 0);
   const hasLocalProvider = localProvider.trim().length > 0;
-  const gbrainOpenAIMissing =
-    memoryBackend === "gbrain" && gbrainOpenAIKey.trim().length === 0;
-  return (
-    (hasInstalledSelection || hasAnyApiKey || hasLocalProvider) &&
-    !gbrainOpenAIMissing
-  );
+  return hasInstalledSelection || hasAnyApiKey || hasLocalProvider;
 }


### PR DESCRIPTION
## Summary

- Removes the "Organizational memory" tile grid (markdown / Nex / GBrain / None) from the Setup step — no more selector UI
- Built-in markdown backend is hardcoded in `/config` and `/onboarding/complete` payloads
- Drops `MemoryBackendPanel`, `MemoryState` interface, GBrain/Nex key state, conditional Nex API key panel, and GBrain/Nex readiness checks on the Ready step
- `canSetupContinue` no longer gates on memory backend
- 50/50 onboarding tests pass

## Test plan

- [ ] Open onboarding wizard Setup step — no "Organizational memory" section visible
- [ ] Complete onboarding — broker receives `memory_backend: "markdown"`
- [ ] Ready step shows memory backend as "Git-native team wiki in ~/.wuphf/wiki."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Onboarding no longer offers memory backend selection or GBrain/Nex key inputs; memory backend is fixed to markdown, readiness now always shows memory as ready and integrations count excludes GBrain-specific keys. Enter-key advance and setup gating updated accordingly.

* **Tests**
  * Onboarding tests updated to match the simplified setup surface and removed memory-backend/GBrain scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->