### PR TITLE
fix(telegram): skip unadopted manifest members when connecting a channel

### DIFF
--- a/internal/team/broker_telegram_connect.go
+++ b/internal/team/broker_telegram_connect.go
@@ -257,6 +257,33 @@ func (b *Broker) createTelegramChannel(slug, title string, chatID int64, chType 
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
+	// The manifest is desired state; the broker's in-memory member set is
+	// current state. Manifest slugs that haven't been adopted yet (e.g.
+	// "planner", "executor", "reviewer") would cause createChannelLocked to
+	// return "unknown members". Skip them with a log entry so the Telegram
+	// connect succeeds — they join the channel when they are adopted.
+	adopted := make([]string, 0, len(members))
+	for _, m := range members {
+		if b.findMemberLocked(m) != nil {
+			adopted = append(adopted, m)
+		}
+	}
+	if len(adopted) < len(members) {
+		var skipped []string
+		adoptedSet := make(map[string]bool, len(adopted))
+		for _, m := range adopted {
+			adoptedSet[m] = true
+		}
+		for _, m := range members {
+			if !adoptedSet[m] {
+				skipped = append(skipped, m)
+			}
+		}
+		log.Printf("[telegram] connect: skipping %d unadopted member(s): %s",
+			len(skipped), strings.Join(skipped, ", "))
+	}
+	members = adopted
+
 	if existing := b.findChannelLocked(slug); existing != nil {
 		// SlugifyTelegramTitle is title-only, so two distinct Telegram chats
 		// with the same display name collide on slug. If we returned the

--- a/internal/team/broker_telegram_connect_test.go
+++ b/internal/team/broker_telegram_connect_test.go
@@ -124,12 +124,11 @@ func TestCreateTelegramChannelSkipsUnadoptedManifestMembers(t *testing.T) {
 		t.Fatal("createTelegramChannel returned nil channel")
 	}
 
-	// Unadopted slugs must be absent from the channel — only "ceo" (always
-	// prepended by createChannelLocked) should be present.
-	for _, slug := range ch.Members {
-		if slug == "planner" || slug == "executor" {
-			t.Errorf("channel members contain unadopted slug %q: %v", slug, ch.Members)
-		}
+	// Unadopted slugs must be absent and the exact adopted set must match.
+	// Checking only for absence would let a broken path that returns an empty
+	// member list pass silently.
+	if len(ch.Members) != 1 || ch.Members[0] != "ceo" {
+		t.Fatalf("expected channel members [ceo], got %v", ch.Members)
 	}
 }
 

--- a/internal/team/broker_telegram_connect_test.go
+++ b/internal/team/broker_telegram_connect_test.go
@@ -1,11 +1,14 @@
 package team
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nex-crm/wuphf/internal/company"
 )
 
 // Regression for the title-collision bug: SlugifyTelegramTitle is title-only,
@@ -72,6 +75,61 @@ func TestCreateTelegramChannelRejectsNonTelegramSurface(t *testing.T) {
 	}
 	if ch := b.findChannelLocked("standup"); ch == nil || ch.Surface != nil {
 		t.Fatalf("connect into non-telegram channel: surface mutated: %+v", ch)
+	}
+}
+
+// Regression for the "unknown members" bug: the manifest lists agents like
+// "planner", "executor", "reviewer" that may not yet be adopted as broker
+// members. Before the fix, createTelegramChannel passed all manifest slugs
+// to createChannelLocked, which rejected any unadopted slug with a 404.
+// After the fix, unadopted slugs are silently dropped and the connect
+// succeeds with only the adopted members.
+func TestCreateTelegramChannelSkipsUnadoptedManifestMembers(t *testing.T) {
+	b := newTestBroker(t)
+	defer b.Stop()
+
+	// Simulate a broker that was seeded with a custom member set — only "ceo".
+	// "planner" and "executor" are desired-state in the manifest but have not
+	// yet been adopted (e.g. the office was bootstrapped from a custom
+	// blueprint, or agents haven't connected yet).
+	b.mu.Lock()
+	b.members = []officeMember{{Slug: "ceo", Name: "CEO", BuiltIn: true}}
+	b.memberIndex = nil // force lazy rebuild on next findMemberLocked
+	b.mu.Unlock()
+
+	// Write a manifest that lists "planner" and "executor" as desired members.
+	manifestPath := filepath.Join(t.TempDir(), "company.json")
+	raw, err := json.Marshal(company.Manifest{
+		Lead: "ceo",
+		Members: []company.MemberSpec{
+			{Slug: "planner"},
+			{Slug: "executor"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("WUPHF_COMPANY_FILE", manifestPath)
+
+	// The connect must succeed — no "unknown members" error — even though
+	// "planner" and "executor" are not adopted in the broker.
+	ch, err := b.createTelegramChannel("standup", "Standup", 100, "group")
+	if err != nil {
+		t.Fatalf("createTelegramChannel with unadopted manifest members: unexpected error: %v", err)
+	}
+	if ch == nil {
+		t.Fatal("createTelegramChannel returned nil channel")
+	}
+
+	// Unadopted slugs must be absent from the channel — only "ceo" (always
+	// prepended by createChannelLocked) should be present.
+	for _, slug := range ch.Members {
+		if slug == "planner" || slug == "executor" {
+			t.Errorf("channel members contain unadopted slug %q: %v", slug, ch.Members)
+		}
 	}
 }
 

--- a/internal/team/broker_telegram_connect_test.go
+++ b/internal/team/broker_telegram_connect_test.go
@@ -78,32 +78,28 @@ func TestCreateTelegramChannelRejectsNonTelegramSurface(t *testing.T) {
 	}
 }
 
-// Regression for the "unknown members" bug: the manifest lists agents like
-// "planner", "executor", "reviewer" that may not yet be adopted as broker
-// members. Before the fix, createTelegramChannel passed all manifest slugs
-// to createChannelLocked, which rejected any unadopted slug with a 404.
-// After the fix, unadopted slugs are silently dropped and the connect
-// succeeds with only the adopted members.
+// Regression: manifest lists members not yet adopted in the broker. Before
+// the fix, createTelegramChannel passed all manifest slugs to
+// createChannelLocked, which rejected any unadopted slug with a 404. After
+// the fix, unadopted slugs are silently dropped and the connect succeeds.
 func TestCreateTelegramChannelSkipsUnadoptedManifestMembers(t *testing.T) {
 	b := newTestBroker(t)
 	defer b.Stop()
 
-	// Simulate a broker that was seeded with a custom member set — only "ceo".
-	// "planner" and "executor" are desired-state in the manifest but have not
-	// yet been adopted (e.g. the office was bootstrapped from a custom
-	// blueprint, or agents haven't connected yet).
+	// Broker has only "ceo". The manifest lists two additional desired-state
+	// members that haven't connected yet — use neutral slugs so the test
+	// isn't coupled to any particular agent set.
 	b.mu.Lock()
 	b.members = []officeMember{{Slug: "ceo", Name: "CEO", BuiltIn: true}}
 	b.memberIndex = nil // force lazy rebuild on next findMemberLocked
 	b.mu.Unlock()
 
-	// Write a manifest that lists "planner" and "executor" as desired members.
 	manifestPath := filepath.Join(t.TempDir(), "company.json")
 	raw, err := json.Marshal(company.Manifest{
 		Lead: "ceo",
 		Members: []company.MemberSpec{
-			{Slug: "planner"},
-			{Slug: "executor"},
+			{Slug: "agent-a"},
+			{Slug: "agent-b"},
 		},
 	})
 	if err != nil {
@@ -114,19 +110,17 @@ func TestCreateTelegramChannelSkipsUnadoptedManifestMembers(t *testing.T) {
 	}
 	t.Setenv("WUPHF_COMPANY_FILE", manifestPath)
 
-	// The connect must succeed — no "unknown members" error — even though
-	// "planner" and "executor" are not adopted in the broker.
+	// Must succeed despite the unadopted manifest members.
 	ch, err := b.createTelegramChannel("standup", "Standup", 100, "group")
 	if err != nil {
-		t.Fatalf("createTelegramChannel with unadopted manifest members: unexpected error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
 	if ch == nil {
-		t.Fatal("createTelegramChannel returned nil channel")
+		t.Fatal("got nil channel")
 	}
 
-	// Unadopted slugs must be absent and the exact adopted set must match.
-	// Checking only for absence would let a broken path that returns an empty
-	// member list pass silently.
+	// Only the adopted "ceo" must be present. Checking exact set catches a
+	// broken path that returns an empty list.
 	if len(ch.Members) != 1 || ch.Members[0] != "ceo" {
 		t.Fatalf("expected channel members [ceo], got %v", ch.Members)
 	}

--- a/web/src/components/integrations/TelegramConnectModal.tsx
+++ b/web/src/components/integrations/TelegramConnectModal.tsx
@@ -368,7 +368,7 @@ export function TelegramConnectModal({
                     chat_id: 0,
                     title: "Telegram DM",
                     type: "private",
-                  })
+                  }, "mode")
                 }
               >
                 DM{" "}

--- a/web/src/components/integrations/TelegramConnectModal.tsx
+++ b/web/src/components/integrations/TelegramConnectModal.tsx
@@ -191,7 +191,7 @@ export function TelegramConnectModal({
       title?: string;
       type?: string;
     },
-    fallbackStep: "pick" | "manual" = "pick",
+    fallbackStep: "mode" | "pick" | "manual" = "pick",
   ) {
     const { id: myReq, signal } = beginRequest();
     setError(null);

--- a/web/src/components/integrations/TelegramConnectModal.tsx
+++ b/web/src/components/integrations/TelegramConnectModal.tsx
@@ -350,6 +350,14 @@ export function TelegramConnectModal({
               {botName ? `Bot: ${botName}. ` : ""}How do you want to use this
               bot?
             </p>
+            {error && (
+              <div
+                className="wk-editor-banner wk-editor-banner--error"
+                role="alert"
+              >
+                {error}
+              </div>
+            )}
             <div className="wk-editor-actions" style={{ flexDirection: "column", alignItems: "stretch" }}>
               <button
                 type="button"

--- a/web/src/components/integrations/TelegramConnectModal.tsx
+++ b/web/src/components/integrations/TelegramConnectModal.tsx
@@ -21,6 +21,7 @@ type Step =
   | "provider"
   | "token"
   | "verifying"
+  | "mode"
   | "discovering"
   | "pick"
   | "manual"
@@ -140,7 +141,7 @@ export function TelegramConnectModal({
     );
   }
 
-  async function verifyAndDiscover(rawToken: string) {
+  async function verify(rawToken: string) {
     const trimmed = rawToken.trim();
     if (!trimmed) {
       setError("Bot token is required.");
@@ -150,16 +151,29 @@ export function TelegramConnectModal({
     setError(null);
     setStep("verifying");
     try {
-      const verify = await verifyTelegramBot(trimmed, signal);
+      const result = await verifyTelegramBot(trimmed, signal);
       if (myReq !== requestIdRef.current) return;
-      if (!verify.ok) {
-        setError(verify.error ?? "Bot verification failed.");
+      if (!result.ok) {
+        setError(result.error ?? "Bot verification failed.");
         setStep("token");
         return;
       }
-      setBotName(verify.bot_name ?? null);
-      setStep("discovering");
-      const found = await discoverTelegramChats(trimmed, signal);
+      setBotName(result.bot_name ?? null);
+      setStep("mode");
+    } catch (e: unknown) {
+      if (myReq !== requestIdRef.current || isAbortError(e)) return;
+      const msg = e instanceof Error ? e.message : String(e);
+      setError(msg);
+      setStep("token");
+    }
+  }
+
+  async function discover() {
+    const { id: myReq, signal } = beginRequest();
+    setError(null);
+    setStep("discovering");
+    try {
+      const found = await discoverTelegramChats(token, signal);
       if (myReq !== requestIdRef.current) return;
       setGroups(found.groups ?? []);
       setStep("pick");
@@ -167,7 +181,7 @@ export function TelegramConnectModal({
       if (myReq !== requestIdRef.current || isAbortError(e)) return;
       const msg = e instanceof Error ? e.message : String(e);
       setError(msg);
-      setStep("token");
+      setStep("mode");
     }
   }
 
@@ -295,7 +309,7 @@ export function TelegramConnectModal({
               value={token}
               onChange={(e) => setToken(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter") void verifyAndDiscover(token);
+                if (e.key === "Enter") void verify(token);
               }}
             />
             {error && (
@@ -311,7 +325,7 @@ export function TelegramConnectModal({
                 type="button"
                 className="wk-editor-save"
                 data-testid="tg-token-submit"
-                onClick={() => void verifyAndDiscover(token)}
+                onClick={() => void verify(token)}
               >
                 Verify
               </button>
@@ -328,6 +342,50 @@ export function TelegramConnectModal({
 
         {step === "verifying" && (
           <p data-testid="tg-step-verifying">Verifying bot token…</p>
+        )}
+
+        {step === "mode" && (
+          <div data-testid="tg-step-mode">
+            <p className="wk-editor-help">
+              {botName ? `Bot: ${botName}. ` : ""}How do you want to use this
+              bot?
+            </p>
+            <div className="wk-editor-actions" style={{ flexDirection: "column", alignItems: "stretch" }}>
+              <button
+                type="button"
+                className="wk-editor-save"
+                data-testid="tg-mode-dm"
+                onClick={() =>
+                  void connect({
+                    chat_id: 0,
+                    title: "Telegram DM",
+                    type: "private",
+                  })
+                }
+              >
+                DM{" "}
+                <span style={{ opacity: 0.6, fontWeight: "normal" }}>
+                  — messages go straight to the bot inbox
+                </span>
+              </button>
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                data-testid="tg-mode-group"
+                onClick={() => void discover()}
+              >
+                Group chat{" "}
+                <span style={{ opacity: 0.6 }}>— bridge a group or channel</span>
+              </button>
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                onClick={onClose}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
         )}
 
         {step === "discovering" && (
@@ -387,7 +445,7 @@ export function TelegramConnectModal({
                 type="button"
                 className="wk-editor-cancel"
                 data-testid="tg-retry-discover"
-                onClick={() => void verifyAndDiscover(token)}
+                onClick={() => void discover()}
               >
                 Retry discovery
               </button>
@@ -402,16 +460,9 @@ export function TelegramConnectModal({
               <button
                 type="button"
                 className="wk-editor-cancel"
-                data-testid="tg-connect-dm"
-                onClick={() =>
-                  void connect({
-                    chat_id: 0,
-                    title: "Telegram DM",
-                    type: "private",
-                  })
-                }
+                onClick={() => setStep("mode")}
               >
-                Use as DM
+                Back
               </button>
               <button
                 type="button"


### PR DESCRIPTION
## Summary

- **Bug**: Telegram Connect modal showed "unknown members: planner, executor, reviewer" when the broker's in-memory member set didn't match the company manifest's desired-state agents
- **Root cause**: `createTelegramChannel` passed all manifest member slugs directly to `createChannelLocked`, which validates each against `b.findMemberLocked`. Unadopted slugs (not yet registered as office members) caused a 404 error
- **Fix**: Pre-filter the manifest member list against `b.findMemberLocked` while the broker lock is already held. Unadopted slugs are logged and skipped; they join the channel when agents are later adopted

## Test plan

- [ ] New regression test `TestCreateTelegramChannelSkipsUnadoptedManifestMembers`: seeds broker with only "ceo", writes a manifest listing unadopted "planner" and "executor", asserts `createTelegramChannel` succeeds and the channel contains neither unadopted slug
- [ ] All 4 `TestCreateTelegramChannel*` tests pass
- [ ] Full `./internal/team` suite passes

## Manual verification

1. Run `wuphf-dev` (port 7899)
2. Open Settings → Integrations → Connect Telegram
3. Enter a valid bot token → verify step passes
4. Click "Discover groups" → no "unknown members" error in response
5. Pick a group → channel created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Telegram channel creation now skips manifest members that aren't adopted; skipped entries are logged.

* **New Features**
  * Added a "mode" step in the Telegram connect wizard to choose immediate DM or proceed to group discovery.
  * Separated token verification and group discovery into distinct steps with improved navigation, retry, and error handling.

* **Tests**
  * Added a regression test ensuring unadopted manifest members are excluded from created channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->