### PR TITLE
feat(web): show live agent output in terminal

### DIFF
--- a/internal/agent/packs.go
+++ b/internal/agent/packs.go
@@ -145,7 +145,7 @@ var legacyPacks = []PackDefinition{
 				Slug:           "analyst",
 				Name:           "Revenue Analyst",
 				Expertise:      []string{"CRM-hygiene", "data-quality", "lead-scoring", "reporting", "funnel-analysis", "attribution", "forecasting"},
-				Personality:    "Methodical analyst who treats the CRM as a source of truth, not a filing cabinet. Flags data gaps, builds scoring models, and turns pipeline data into decisions.",
+				Personality:    "Methodical analyst who treats the CRM as a source of truth, not a stale archive. Flags data gaps, builds scoring models, and turns pipeline data into decisions.",
 				PermissionMode: "plan",
 			},
 		},

--- a/scripts/check-bundle-size.sh
+++ b/scripts/check-bundle-size.sh
@@ -23,7 +23,10 @@ set -euo pipefail
 # something has gone seriously wrong (or a major feature has shipped
 # that warrants raising the ceiling explicitly).
 WARN_KB=950
-FAIL_KB=1200
+# Live agent output renders a full terminal emulator in the web UI. That is
+# intentional product weight, not an accidental import, so the fail line gives
+# this feature room while keeping the ratchet tight around the new bundle.
+FAIL_KB=1300
 
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 dist_assets="$repo_root/web/dist/assets"

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -7,6 +7,8 @@
       "dependencies": {
         "@tanstack/react-query": "^5.80.7",
         "@tanstack/react-router": "^1.121.3",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/xterm": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "dompurify": "^3.4.0",
@@ -345,6 +347,10 @@
     "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ=="],
 
     "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -19,6 +19,8 @@
   "dependencies": {
     "@tanstack/react-query": "^5.80.7",
     "@tanstack/react-router": "^1.121.3",
+    "@xterm/addon-fit": "^0.11.0",
+    "@xterm/xterm": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "dompurify": "^3.4.0",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -49,6 +49,7 @@ import "./styles/agents.css";
 import "./styles/search.css";
 import "./styles/wiki-shell.css";
 import "./styles/kbd.css";
+import "@xterm/xterm/css/xterm.css";
 
 // ── Error boundary ─────────────────────────────────────────────
 

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -5,16 +5,15 @@ import { Xmark } from "iconoir-react";
 import type { OfficeMember } from "../../api/client";
 import { createDM, post } from "../../api/client";
 import { listAgentLogTasks, type TaskLogSummary } from "../../api/tasks";
-import { useAgentStream } from "../../hooks/useAgentStream";
 import { useDefaultHarness } from "../../hooks/useConfig";
 import { useChannelMembers, useOfficeMembers } from "../../hooks/useMembers";
 import { resolveHarness } from "../../lib/harness";
 import { directChannelSlug, useAppStore } from "../../stores/app";
-import { StreamLineView } from "../messages/StreamLineView";
 import { confirm } from "../ui/ConfirmDialog";
 import { HarnessBadge } from "../ui/HarnessBadge";
 import { PixelAvatar } from "../ui/PixelAvatar";
 import { showNotice } from "../ui/Toast";
+import { AgentTerminal } from "./AgentTerminal";
 
 interface AgentPanelViewProps {
   agent: OfficeMember;
@@ -22,34 +21,13 @@ interface AgentPanelViewProps {
 }
 
 function StreamSection({ slug }: { slug: string }) {
-  const { lines, connected } = useAgentStream(slug);
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el) {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, []);
-
   return (
     <div className="agent-panel-section">
-      <div className="agent-panel-section-title">Live stream</div>
-      <div className="agent-stream-status">
-        <span
-          className={`status-dot ${connected ? "active pulse" : "lurking"}`}
-        />
-        {connected ? "Connected" : "Disconnected"}
-      </div>
-      <div className="agent-stream-log" ref={scrollRef}>
-        {lines.length === 0 ? (
-          <div className="agent-stream-empty">No output yet</div>
-        ) : (
-          lines.map((line) => (
-            <StreamLineView key={line.id} line={line} compact={true} />
-          ))
-        )}
-      </div>
+      <AgentTerminal
+        slug={slug}
+        title="Live stream"
+        emptyLabel="No output yet"
+      />
     </div>
   );
 }

--- a/web/src/components/agents/AgentTerminal.tsx
+++ b/web/src/components/agents/AgentTerminal.tsx
@@ -84,14 +84,29 @@ export function AgentTerminal({
           });
     resizeObserver?.observe(host);
 
+    let renderedChunks = 0;
     const buffer = createTerminalWriteBuffer((text) => terminal.write(text));
     const subscription = subscribeAgentStream(slug, {
       onOpen: () => setConnectionState(true),
       onLine: (line) => {
+        let parsed: Record<string, unknown> | undefined;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          // Raw terminal output.
+        }
+
         const formatted = formatAgentTerminalChunk(line);
-        if (!formatted) return;
-        setOutputState(true);
-        buffer.enqueue(formatted);
+        if (formatted) {
+          renderedChunks += 1;
+          setOutputState(true);
+          buffer.enqueue(formatted);
+        }
+
+        if (parsed?.status === "idle" && renderedChunks > 0) {
+          subscription.close();
+          setConnectionState(false);
+        }
       },
       onError: () => setConnectionState(false),
       onClose: () => setConnectionState(false),

--- a/web/src/components/agents/AgentTerminal.tsx
+++ b/web/src/components/agents/AgentTerminal.tsx
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+
+import { subscribeAgentStream } from "../../lib/agentStreamClient";
+import {
+  createTerminalWriteBuffer,
+  formatAgentTerminalChunk,
+} from "../../lib/agentTerminalBuffer";
+
+interface AgentTerminalProps {
+  slug: string | null;
+  title?: string;
+  emptyLabel?: string;
+}
+
+export function AgentTerminal({
+  slug,
+  title = "Live output",
+  emptyLabel = "Waiting for output...",
+}: AgentTerminalProps) {
+  const terminalHostRef = useRef<HTMLDivElement>(null);
+  const [connected, setConnected] = useState(false);
+  const [hasOutput, setHasOutput] = useState(false);
+  const connectedRef = useRef(false);
+  const hasOutputRef = useRef(false);
+
+  const setConnectionState = useCallback((next: boolean) => {
+    if (connectedRef.current === next) return;
+    connectedRef.current = next;
+    setConnected(next);
+  }, []);
+
+  const setOutputState = useCallback((next: boolean) => {
+    if (hasOutputRef.current === next) return;
+    hasOutputRef.current = next;
+    setHasOutput(next);
+  }, []);
+
+  useEffect(() => {
+    const host = terminalHostRef.current;
+    if (!(host && slug)) {
+      setConnectionState(false);
+      setOutputState(false);
+      return;
+    }
+
+    setConnectionState(false);
+    setOutputState(false);
+    const terminal = new Terminal({
+      allowProposedApi: false,
+      convertEol: true,
+      cursorBlink: false,
+      disableStdin: true,
+      fontFamily: "var(--font-mono)",
+      fontSize: 11,
+      lineHeight: 1.35,
+      scrollback: 3000,
+      theme: {
+        background: "#0b0f14",
+        foreground: "#d8dee9",
+        cursor: "#d8dee9",
+        selectionBackground: "#2d3748",
+        black: "#0b0f14",
+        blue: "#7aa2f7",
+        cyan: "#7dcfff",
+        green: "#9ece6a",
+        magenta: "#bb9af7",
+        red: "#f7768e",
+        white: "#d8dee9",
+        yellow: "#e0af68",
+      },
+    });
+    const fitAddon = new FitAddon();
+    terminal.loadAddon(fitAddon);
+    terminal.open(host);
+    fitAddon.fit();
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => {
+            fitAddon.fit();
+          });
+    resizeObserver?.observe(host);
+
+    const buffer = createTerminalWriteBuffer((text) => terminal.write(text));
+    const subscription = subscribeAgentStream(slug, {
+      onOpen: () => setConnectionState(true),
+      onLine: (line) => {
+        const formatted = formatAgentTerminalChunk(line);
+        if (!formatted) return;
+        setOutputState(true);
+        buffer.enqueue(formatted);
+      },
+      onError: () => setConnectionState(false),
+      onClose: () => setConnectionState(false),
+    });
+
+    return () => {
+      subscription.close();
+      buffer.dispose();
+      resizeObserver?.disconnect();
+      terminal.dispose();
+    };
+  }, [setConnectionState, setOutputState, slug]);
+
+  return (
+    <div className="agent-terminal-shell">
+      <div className="agent-terminal-header">
+        <div className="agent-terminal-title">
+          <span
+            className={`status-dot ${connected ? "active pulse" : "lurking"}`}
+          />
+          <span>{title}</span>
+        </div>
+        <span className="agent-terminal-meta">
+          {connected ? "live" : "idle"}
+        </span>
+      </div>
+      <div className="agent-terminal-frame">
+        {!hasOutput ? (
+          <div className="agent-terminal-empty">{emptyLabel}</div>
+        ) : null}
+        <div
+          className="agent-terminal-host"
+          ref={terminalHostRef}
+          role="log"
+          aria-label={title}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/messages/DMView.tsx
+++ b/web/src/components/messages/DMView.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useRef } from "react";
 
-import { useAgentStream } from "../../hooks/useAgentStream";
 import { useMessages } from "../../hooks/useMessages";
 import { isDMChannel, useAppStore } from "../../stores/app";
+import { AgentTerminal } from "../agents/AgentTerminal";
 import { Composer } from "./Composer";
 import { InterviewBar } from "./InterviewBar";
 import { MessageBubble } from "./MessageBubble";
-import { StreamLineView } from "./StreamLineView";
 import { TypingIndicator } from "./TypingIndicator";
 
 export function DMView() {
@@ -15,21 +14,12 @@ export function DMView() {
   const dm = isDMChannel(currentChannel, channelMeta);
   const dmAgentSlug = dm?.agentSlug ?? null;
   const { data: messages = [] } = useMessages(currentChannel);
-  const { lines, connected } = useAgentStream(dmAgentSlug);
   const messagesRef = useRef<HTMLDivElement>(null);
-  const streamRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll messages
   useEffect(() => {
     if (messagesRef.current) {
       messagesRef.current.scrollTop = messagesRef.current.scrollHeight;
-    }
-  }, []);
-
-  // Auto-scroll stream
-  useEffect(() => {
-    if (streamRef.current) {
-      streamRef.current.scrollTop = streamRef.current.scrollHeight;
     }
   }, []);
 
@@ -67,44 +57,7 @@ export function DMView() {
             overflow: "hidden",
           }}
         >
-          <div
-            style={{
-              padding: "8px 12px",
-              borderBottom: "1px solid var(--border)",
-              display: "flex",
-              alignItems: "center",
-              gap: 8,
-              fontSize: 13,
-              fontWeight: 600,
-            }}
-          >
-            <span
-              className={`status-dot ${connected ? "active pulse" : "lurking"}`}
-            />
-            <span>Live output</span>
-          </div>
-          <div
-            ref={streamRef}
-            style={{
-              flex: 1,
-              overflowY: "auto",
-              padding: 8,
-              fontFamily: "var(--font-mono)",
-              fontSize: 11,
-              lineHeight: 1.5,
-              color: "var(--text-secondary)",
-            }}
-          >
-            {lines.length === 0 ? (
-              <div style={{ color: "var(--text-tertiary)", padding: 8 }}>
-                {connected ? "Waiting for output..." : "Stream idle"}
-              </div>
-            ) : (
-              lines.map((line) => (
-                <StreamLineView key={line.id} line={line} compact={true} />
-              ))
-            )}
-          </div>
+          <AgentTerminal slug={dmAgentSlug} title="Live output" />
         </div>
       </div>
     </>

--- a/web/src/hooks/useAgentStream.ts
+++ b/web/src/hooks/useAgentStream.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { sseURL } from "../api/client";
+import { subscribeAgentStream } from "../lib/agentStreamClient";
 
 export interface StreamLine {
   id: number;
@@ -51,7 +51,6 @@ export function useAgentStream(slug: string | null) {
   const [lines, setLines] = useState<StreamLine[]>([]);
   const [connected, setConnected] = useState(false);
   const counterRef = useRef(0);
-  const sourceRef = useRef<EventSource | null>(null);
 
   useEffect(() => {
     if (!slug) {
@@ -60,48 +59,43 @@ export function useAgentStream(slug: string | null) {
       return;
     }
 
-    const url = sseURL(`/agent-stream/${encodeURIComponent(slug)}`);
-    const source = new EventSource(url);
-    sourceRef.current = source;
-
-    source.onopen = () => setConnected(true);
-
-    source.onmessage = (e) => {
-      let parsed: Record<string, unknown> | undefined;
-      try {
-        parsed = JSON.parse(e.data);
-      } catch {
-        // raw text line
-      }
-
-      setLines((prev) => {
-        const { lines: nextLines, usedId } = appendStreamLine(
-          prev,
-          e.data,
-          parsed,
-          counterRef.current + 1,
-        );
-        if (usedId) {
-          counterRef.current += 1;
+    setLines([]);
+    counterRef.current = 0;
+    const subscription = subscribeAgentStream(slug, {
+      onOpen: () => setConnected(true),
+      onLine: (eventData) => {
+        let parsed: Record<string, unknown> | undefined;
+        try {
+          parsed = JSON.parse(eventData);
+        } catch {
+          // raw text line
         }
-        return nextLines;
-      });
 
-      // Auto-stop on idle
-      if (parsed?.status === "idle" && counterRef.current > 1) {
-        source.close();
-        setConnected(false);
-      }
-    };
+        setLines((prev) => {
+          const { lines: nextLines, usedId } = appendStreamLine(
+            prev,
+            eventData,
+            parsed,
+            counterRef.current + 1,
+          );
+          if (usedId) {
+            counterRef.current += 1;
+          }
+          return nextLines;
+        });
 
-    source.onerror = () => {
-      source.close();
-      setConnected(false);
-    };
+        // Auto-stop on idle
+        if (parsed?.status === "idle" && counterRef.current > 1) {
+          subscription.close();
+          setConnected(false);
+        }
+      },
+      onError: () => setConnected(false),
+      onClose: () => setConnected(false),
+    });
 
     return () => {
-      source.close();
-      sourceRef.current = null;
+      subscription.close();
       setConnected(false);
     };
   }, [slug]);

--- a/web/src/hooks/useAgentStream.ts
+++ b/web/src/hooks/useAgentStream.ts
@@ -51,16 +51,20 @@ export function useAgentStream(slug: string | null) {
   const [lines, setLines] = useState<StreamLine[]>([]);
   const [connected, setConnected] = useState(false);
   const counterRef = useRef(0);
+  const linesRef = useRef<StreamLine[]>([]);
 
   useEffect(() => {
     if (!slug) {
+      linesRef.current = [];
+      counterRef.current = 0;
       setLines([]);
       setConnected(false);
       return;
     }
 
-    setLines([]);
+    linesRef.current = [];
     counterRef.current = 0;
+    setLines([]);
     const subscription = subscribeAgentStream(slug, {
       onOpen: () => setConnected(true),
       onLine: (eventData) => {
@@ -71,18 +75,17 @@ export function useAgentStream(slug: string | null) {
           // raw text line
         }
 
-        setLines((prev) => {
-          const { lines: nextLines, usedId } = appendStreamLine(
-            prev,
-            eventData,
-            parsed,
-            counterRef.current + 1,
-          );
-          if (usedId) {
-            counterRef.current += 1;
-          }
-          return nextLines;
-        });
+        const { lines: nextLines, usedId } = appendStreamLine(
+          linesRef.current,
+          eventData,
+          parsed,
+          counterRef.current + 1,
+        );
+        linesRef.current = nextLines;
+        if (usedId) {
+          counterRef.current += 1;
+        }
+        setLines(nextLines);
 
         // Auto-stop on idle
         if (parsed?.status === "idle" && counterRef.current > 1) {

--- a/web/src/lib/agentStreamClient.test.ts
+++ b/web/src/lib/agentStreamClient.test.ts
@@ -65,6 +65,19 @@ describe("agent stream client", () => {
     expect(source.closed).toBe(true);
   });
 
+  it("closes immediately without an error when slug is empty", () => {
+    const events: string[] = [];
+
+    const subscription = subscribeAgentStream("  ", {
+      onError: () => events.push("error"),
+      onClose: () => events.push("close"),
+    });
+    subscription.close();
+
+    expect(events).toEqual(["close"]);
+    expect(FakeEventSource.instances).toHaveLength(0);
+  });
+
   it("keeps transient EventSource errors reconnectable", () => {
     const onError = vi.fn();
     subscribeAgentStream(
@@ -99,6 +112,28 @@ describe("agent stream client", () => {
 
     expect(events).toEqual(["error", "close"]);
     expect(source.closed).toBe(true);
+  });
+
+  it("treats errors without readyState as terminal", () => {
+    const events: string[] = [];
+    const sourceWithoutReadyState: AgentStreamEventSource = {
+      onopen: null,
+      onmessage: null,
+      onerror: null,
+      close: () => events.push("source-close"),
+    };
+    subscribeAgentStream(
+      "builder",
+      {
+        onError: () => events.push("error"),
+        onClose: () => events.push("close"),
+      },
+      { eventSourceFactory: () => sourceWithoutReadyState },
+    );
+
+    sourceWithoutReadyState.onerror?.({} as Event);
+
+    expect(events).toEqual(["error", "source-close", "close"]);
   });
 
   it("returns a closed no-op when EventSource is unavailable", () => {

--- a/web/src/lib/agentStreamClient.test.ts
+++ b/web/src/lib/agentStreamClient.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type AgentStreamEventSource,
+  agentStreamPath,
+  subscribeAgentStream,
+} from "./agentStreamClient";
+
+class FakeEventSource implements AgentStreamEventSource {
+  static instances: FakeEventSource[] = [];
+
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  readyState = 1;
+  closed = false;
+
+  constructor(readonly url: string) {
+    FakeEventSource.instances.push(this);
+  }
+
+  close() {
+    this.closed = true;
+    this.readyState = 2;
+  }
+
+  emitLine(data: string) {
+    this.onmessage?.({ data } as MessageEvent<string>);
+  }
+}
+
+describe("agent stream client", () => {
+  const originalEventSource = globalThis.EventSource;
+
+  afterEach(() => {
+    FakeEventSource.instances = [];
+    (globalThis as { EventSource?: typeof EventSource }).EventSource =
+      originalEventSource;
+  });
+
+  it("builds encoded stream paths", () => {
+    expect(agentStreamPath("builder one")).toBe("/agent-stream/builder%20one");
+  });
+
+  it("opens one EventSource and forwards lifecycle callbacks", () => {
+    const events: string[] = [];
+    const subscription = subscribeAgentStream(
+      "builder",
+      {
+        onOpen: () => events.push("open"),
+        onLine: (line) => events.push(`line:${line}`),
+        onClose: () => events.push("close"),
+      },
+      { eventSourceFactory: (url) => new FakeEventSource(url) },
+    );
+
+    const [source] = FakeEventSource.instances;
+    expect(source.url).toBe("/api/agent-stream/builder");
+    source.onopen?.({} as Event);
+    source.emitLine("hello");
+    subscription.close();
+    source.emitLine("ignored");
+
+    expect(events).toEqual(["open", "line:hello", "close"]);
+    expect(source.closed).toBe(true);
+  });
+
+  it("keeps transient EventSource errors reconnectable", () => {
+    const onError = vi.fn();
+    subscribeAgentStream(
+      "builder",
+      { onError },
+      { eventSourceFactory: (url) => new FakeEventSource(url) },
+    );
+
+    const [source] = FakeEventSource.instances;
+    source.readyState = 0;
+    source.onerror?.({} as Event);
+
+    expect(onError).toHaveBeenCalledOnce();
+    expect(source.closed).toBe(false);
+  });
+
+  it("closes once on terminal EventSource errors", () => {
+    const events: string[] = [];
+    subscribeAgentStream(
+      "builder",
+      {
+        onError: () => events.push("error"),
+        onClose: () => events.push("close"),
+      },
+      { eventSourceFactory: (url) => new FakeEventSource(url) },
+    );
+
+    const [source] = FakeEventSource.instances;
+    source.readyState = 2;
+    source.onerror?.({} as Event);
+    source.onerror?.({} as Event);
+
+    expect(events).toEqual(["error", "close"]);
+    expect(source.closed).toBe(true);
+  });
+
+  it("returns a closed no-op when EventSource is unavailable", () => {
+    (globalThis as { EventSource?: typeof EventSource }).EventSource =
+      undefined;
+    const events: string[] = [];
+
+    const subscription = subscribeAgentStream("builder", {
+      onError: () => events.push("error"),
+      onClose: () => events.push("close"),
+    });
+    subscription.close();
+
+    expect(events).toEqual(["error", "close"]);
+  });
+});

--- a/web/src/lib/agentStreamClient.test.ts
+++ b/web/src/lib/agentStreamClient.test.ts
@@ -149,4 +149,24 @@ describe("agent stream client", () => {
 
     expect(events).toEqual(["error", "close"]);
   });
+
+  it("routes factory failures through error and close handlers", () => {
+    const events: string[] = [];
+
+    const subscription = subscribeAgentStream(
+      "builder",
+      {
+        onError: () => events.push("error"),
+        onClose: () => events.push("close"),
+      },
+      {
+        eventSourceFactory: () => {
+          throw new Error("factory failed");
+        },
+      },
+    );
+    subscription.close();
+
+    expect(events).toEqual(["error", "close"]);
+  });
 });

--- a/web/src/lib/agentStreamClient.ts
+++ b/web/src/lib/agentStreamClient.ts
@@ -50,9 +50,17 @@ export function subscribeAgentStream(
     return { close: () => undefined };
   }
 
-  const createSource = options.eventSourceFactory ?? defaultEventSourceFactory;
-  const source = createSource(sseURL(agentStreamPath(trimmedSlug)));
   let closed = false;
+  const createSource = options.eventSourceFactory ?? defaultEventSourceFactory;
+  let source: AgentStreamEventSource;
+  try {
+    source = createSource(sseURL(agentStreamPath(trimmedSlug)));
+  } catch {
+    closed = true;
+    handlers.onError?.();
+    handlers.onClose?.();
+    return { close: () => undefined };
+  }
 
   source.onopen = () => {
     if (!closed) handlers.onOpen?.();

--- a/web/src/lib/agentStreamClient.ts
+++ b/web/src/lib/agentStreamClient.ts
@@ -1,0 +1,87 @@
+import { sseURL } from "../api/client";
+
+export interface AgentStreamHandlers {
+  onOpen?: () => void;
+  onLine?: (line: string) => void;
+  onError?: () => void;
+  onClose?: () => void;
+}
+
+export interface AgentStreamEventSource {
+  onopen: ((event: Event) => void) | null;
+  onmessage: ((event: MessageEvent<string>) => void) | null;
+  onerror: ((event: Event) => void) | null;
+  readyState?: number;
+  close: () => void;
+}
+
+export type AgentStreamEventSourceFactory = (
+  url: string,
+) => AgentStreamEventSource;
+
+export interface AgentStreamSubscription {
+  close: () => void;
+}
+
+export interface AgentStreamSubscriptionOptions {
+  eventSourceFactory?: AgentStreamEventSourceFactory;
+}
+
+export function agentStreamPath(slug: string): string {
+  return `/agent-stream/${encodeURIComponent(slug)}`;
+}
+
+export function subscribeAgentStream(
+  slug: string,
+  handlers: AgentStreamHandlers,
+  options: AgentStreamSubscriptionOptions = {},
+): AgentStreamSubscription {
+  const trimmedSlug = slug.trim();
+  if (!trimmedSlug) {
+    handlers.onClose?.();
+    return { close: () => undefined };
+  }
+
+  if (!(options.eventSourceFactory || globalThis.EventSource)) {
+    handlers.onError?.();
+    handlers.onClose?.();
+    return { close: () => undefined };
+  }
+
+  const createSource = options.eventSourceFactory ?? defaultEventSourceFactory;
+  const source = createSource(sseURL(agentStreamPath(trimmedSlug)));
+  let closed = false;
+
+  source.onopen = () => {
+    if (!closed) handlers.onOpen?.();
+  };
+
+  source.onmessage = (event) => {
+    if (!closed) handlers.onLine?.(event.data);
+  };
+
+  source.onerror = () => {
+    if (closed) return;
+    handlers.onError?.();
+    if (source.readyState === 2) {
+      close();
+    }
+  };
+
+  function close() {
+    if (closed) return;
+    closed = true;
+    source.close();
+    handlers.onClose?.();
+  }
+
+  return { close };
+}
+
+function defaultEventSourceFactory(url: string): AgentStreamEventSource {
+  const ES = (globalThis as { EventSource?: typeof EventSource }).EventSource;
+  if (!ES) {
+    throw new Error("EventSource is not available in this environment");
+  }
+  return new ES(url);
+}

--- a/web/src/lib/agentStreamClient.ts
+++ b/web/src/lib/agentStreamClient.ts
@@ -11,6 +11,8 @@ export interface AgentStreamEventSource {
   onopen: ((event: Event) => void) | null;
   onmessage: ((event: MessageEvent<string>) => void) | null;
   onerror: ((event: Event) => void) | null;
+  // 0 = CONNECTING, 1 = OPEN, 2 = CLOSED. Some test factories omit it,
+  // so the error path treats undefined as terminal instead of reconnectable.
   readyState?: number;
   close: () => void;
 }
@@ -63,7 +65,7 @@ export function subscribeAgentStream(
   source.onerror = () => {
     if (closed) return;
     handlers.onError?.();
-    if (source.readyState === 2) {
+    if (source.readyState === undefined || source.readyState === 2) {
       close();
     }
   };

--- a/web/src/lib/agentTerminalBuffer.test.ts
+++ b/web/src/lib/agentTerminalBuffer.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createTerminalWriteBuffer,
+  formatAgentTerminalChunk,
+  type TerminalScheduler,
+} from "./agentTerminalBuffer";
+
+function manualScheduler() {
+  let callback: (() => void) | null = null;
+  const schedule: TerminalScheduler = (next) => {
+    callback = next;
+    return () => {
+      callback = null;
+    };
+  };
+  return {
+    schedule,
+    flush: () => callback?.(),
+    hasPending: () => callback !== null,
+  };
+}
+
+describe("agent terminal output formatting", () => {
+  it("skips stream handshake lines", () => {
+    expect(formatAgentTerminalChunk("[connected]")).toBeNull();
+  });
+
+  it("adds terminal newlines to line-based SSE chunks", () => {
+    expect(formatAgentTerminalChunk("hello")).toBe("hello\r\n");
+  });
+
+  it("preserves chunks that already include line endings", () => {
+    expect(formatAgentTerminalChunk("hello\n")).toBe("hello\n");
+  });
+});
+
+describe("terminal write buffer", () => {
+  it("batches multiple chunks into one scheduled write", () => {
+    const scheduler = manualScheduler();
+    const write = vi.fn();
+    const buffer = createTerminalWriteBuffer(write, {
+      schedule: scheduler.schedule,
+    });
+
+    buffer.enqueue("one");
+    buffer.enqueue("two");
+    expect(write).not.toHaveBeenCalled();
+
+    scheduler.flush();
+    expect(write).toHaveBeenCalledOnce();
+    expect(write).toHaveBeenCalledWith("onetwo");
+  });
+
+  it("drops older pending output when the terminal falls behind", () => {
+    const scheduler = manualScheduler();
+    const write = vi.fn();
+    const buffer = createTerminalWriteBuffer(write, {
+      maxPendingChars: 5,
+      schedule: scheduler.schedule,
+    });
+
+    buffer.enqueue("12345");
+    buffer.enqueue("67890");
+    scheduler.flush();
+
+    const written = String(write.mock.calls[0]?.[0]);
+    expect(written).toContain("output dropped");
+    expect(written.endsWith("67890")).toBe(true);
+  });
+
+  it("cancels scheduled writes on dispose", () => {
+    const scheduler = manualScheduler();
+    const write = vi.fn();
+    const buffer = createTerminalWriteBuffer(write, {
+      schedule: scheduler.schedule,
+    });
+
+    buffer.enqueue("hello");
+    expect(scheduler.hasPending()).toBe(true);
+    buffer.dispose();
+    scheduler.flush();
+
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/lib/agentTerminalBuffer.ts
+++ b/web/src/lib/agentTerminalBuffer.ts
@@ -1,0 +1,72 @@
+const DEFAULT_MAX_PENDING_CHARS = 80_000;
+const TRUNCATED_NOTICE =
+  "\r\n[older output dropped while the terminal caught up]\r\n";
+
+export type TerminalWriter = (text: string) => void;
+export type TerminalScheduler = (callback: () => void) => () => void;
+
+export interface TerminalWriteBufferOptions {
+  maxPendingChars?: number;
+  schedule?: TerminalScheduler;
+}
+
+export interface TerminalWriteBuffer {
+  enqueue: (text: string) => void;
+  flush: () => void;
+  dispose: () => void;
+}
+
+export function formatAgentTerminalChunk(line: string): string | null {
+  if (line === "[connected]") return null;
+  if (line.length === 0) return null;
+  return line.includes("\n") || line.includes("\r") ? line : `${line}\r\n`;
+}
+
+export function createTerminalWriteBuffer(
+  write: TerminalWriter,
+  options: TerminalWriteBufferOptions = {},
+): TerminalWriteBuffer {
+  const maxPendingChars = options.maxPendingChars ?? DEFAULT_MAX_PENDING_CHARS;
+  const schedule = options.schedule ?? animationFrameScheduler;
+  let pending = "";
+  let cancelScheduled: (() => void) | null = null;
+  let disposed = false;
+
+  function flush() {
+    if (disposed) return;
+    cancelScheduled = null;
+    if (!pending) return;
+    const next = pending;
+    pending = "";
+    write(next);
+  }
+
+  function enqueue(text: string) {
+    if (disposed || !text) return;
+    pending += text;
+    if (pending.length > maxPendingChars) {
+      pending = TRUNCATED_NOTICE + pending.slice(-maxPendingChars);
+    }
+    if (!cancelScheduled) {
+      cancelScheduled = schedule(flush);
+    }
+  }
+
+  function dispose() {
+    disposed = true;
+    pending = "";
+    cancelScheduled?.();
+    cancelScheduled = null;
+  }
+
+  return { enqueue, flush, dispose };
+}
+
+function animationFrameScheduler(callback: () => void): () => void {
+  if (typeof window === "undefined" || !window.requestAnimationFrame) {
+    const id = globalThis.setTimeout(callback, 16);
+    return () => globalThis.clearTimeout(id);
+  }
+  const id = window.requestAnimationFrame(callback);
+  return () => window.cancelAnimationFrame(id);
+}

--- a/web/src/styles/agents.css
+++ b/web/src/styles/agents.css
@@ -162,6 +162,85 @@
 }
 
 /* ─── Stream log ─── */
+.agent-terminal-shell {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 220px;
+  overflow: hidden;
+  background: #0b0f14;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+}
+
+.agent-terminal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  height: 34px;
+  padding: 0 10px;
+  color: #d8dee9;
+  background: #111827;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 11px;
+}
+
+.agent-terminal-title {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.agent-terminal-meta {
+  color: #8b949e;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.agent-terminal-frame {
+  position: relative;
+  flex: 1;
+  min-height: 186px;
+  overflow: hidden;
+}
+
+.agent-terminal-host {
+  width: 100%;
+  height: 100%;
+  min-height: 186px;
+  padding: 8px;
+}
+
+.agent-terminal-host .xterm {
+  height: 100%;
+}
+
+.agent-terminal-empty {
+  position: absolute;
+  inset: 8px;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #6b7280;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  pointer-events: none;
+}
+
+.agent-panel-section .agent-terminal-shell {
+  min-height: 300px;
+}
+
+.agent-panel-section .agent-terminal-frame,
+.agent-panel-section .agent-terminal-host {
+  min-height: 266px;
+}
+
 .agent-stream-log {
   font-family: var(--font-mono);
   font-size: 11px;


### PR DESCRIPTION
## Summary
- add an xterm-backed live output panel for agent stream output
- share the agent SSE subscription lifecycle between existing stream consumers and the terminal
- batch terminal writes and cap pending output so fast streams do not overwhelm the UI
- guard terminal state updates so stream reconnect/open events do not trigger render loops

## Verification
- GStack Browser smoke: loaded http://127.0.0.1:5273, opened Builder agent panel, opened Builder DM, verified xterm terminal rendered and displayed a synthetic agent stream line with no console errors
- bunx biome check --write src/components/agents/AgentTerminal.tsx
- bunx tsc --noEmit
- bun test src/hooks/useAgentStream.test.ts src/lib/agentStreamClient.test.ts src/lib/agentTerminalBuffer.test.ts
- bun run test
- bun run build

## Notes
- direct `bun test` still fails on existing Bun runner incompatibilities in unrelated tests; the package Vitest script passes.
- Vite build still reports the existing large chunk warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live agent output now displays in an embedded terminal interface with connection status, auto-resize, and empty-state messaging

* **Improvements**
  * Robust output buffering and formatting for large/fragmented streams
  * Stream subscription moved to a consolidated SSE client

* **Style**
  * Added terminal-specific styling for the agents panel

* **Tests**
  * Added unit tests for stream subscription logic and terminal buffering

* **Chores**
  * Added runtime terminal dependencies and bumped bundle-size fail threshold; tweaked an internal prompt wording
<!-- end of auto-generated comment: release notes by coderabbit.ai -->