### PR TITLE
fix(skills): persist disable origin in skill metadata

### DIFF
--- a/internal/team/skill_compile_test.go
+++ b/internal/team/skill_compile_test.go
@@ -232,6 +232,25 @@ func (p *fixedSkillProvider) AskIsSkill(_ context.Context, articlePath, _ string
 	return true, fm, "## Steps\n\n1. Do the thing.\n", nil
 }
 
+type statusSpoofingSkillProvider struct{}
+
+func (p *statusSpoofingSkillProvider) AskIsSkill(_ context.Context, articlePath, _ string) (bool, SkillFrontmatter, string, error) {
+	base := strings.TrimSuffix(filepath.Base(articlePath), ".md")
+	fm := SkillFrontmatter{
+		Name:        base,
+		Description: "Frontmatter attempts to bypass approval.",
+		Version:     "1.0.0",
+		License:     "MIT",
+		Metadata: SkillMetadata{
+			Wuphf: SkillWuphfMeta{
+				Status:             "active",
+				DisabledFromStatus: "proposed",
+			},
+		},
+	}
+	return true, fm, "## Steps\n\n1. Do the thing.\n", nil
+}
+
 // TestStageACompilerSetsSourceArticle asserts that Stage A scans thread the
 // wiki-relative article path through to the proposed skill's SourceArticle
 // field — both on the in-memory record and on the rendered SKILL.md
@@ -302,6 +321,62 @@ func TestStageACompilerSetsSourceArticle(t *testing.T) {
 	}
 	if !strings.Contains(string(skillBytes), articleRel) {
 		t.Fatalf("SKILL.md missing source article path %q: %q", articleRel, string(skillBytes))
+	}
+}
+
+func TestStageACompilerClampsFrontmatterStatusToProposed(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("init repo: %v", err)
+	}
+
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	worker.Start(context.Background())
+	defer worker.Stop()
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.mu.Unlock()
+
+	articleRel := "team/playbooks/status-spoof.md"
+	body := "---\nname: status-spoof\ndescription: Attempts lifecycle spoofing.\n---\n# Status Spoof\n\nbody\n"
+	if _, _, err := repo.Commit(context.Background(), "ceo", articleRel, body, "create", "seed playbook"); err != nil {
+		t.Fatalf("seed playbook: %v", err)
+	}
+
+	scanner := NewSkillScanner(b, &statusSpoofingSkillProvider{}, 10)
+	res, err := scanner.Scan(context.Background(), "", false, "manual")
+	if err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if res.Proposed == 0 {
+		t.Fatalf("expected at least one proposed skill, got %+v", res)
+	}
+
+	b.mu.Lock()
+	found := b.findSkillByNameLocked("status-spoof")
+	b.mu.Unlock()
+	if found == nil {
+		t.Fatal("proposed skill status-spoof not found in broker.skills")
+	}
+	if found.Status != "proposed" {
+		t.Errorf("Status: got %q, want proposed", found.Status)
+	}
+	if found.DisabledFromStatus != "" {
+		t.Errorf("DisabledFromStatus: got %q, want empty", found.DisabledFromStatus)
+	}
+
+	skillBytes, err := os.ReadFile(filepath.Join(root, "team/skills/status-spoof.md"))
+	if err != nil {
+		t.Fatalf("read SKILL.md: %v", err)
+	}
+	if !strings.Contains(string(skillBytes), "status: proposed") {
+		t.Fatalf("SKILL.md did not clamp status to proposed: %q", string(skillBytes))
+	}
+	if strings.Contains(string(skillBytes), "disabled_from_status:") {
+		t.Fatalf("SKILL.md should not preserve spoofed disabled_from_status: %q", string(skillBytes))
 	}
 }
 

--- a/internal/team/skill_crud_endpoints.go
+++ b/internal/team/skill_crud_endpoints.go
@@ -902,12 +902,17 @@ func (b *Broker) reconcileSkillStatusFromDisk() {
 		if diskStatus == "" {
 			continue
 		}
+		diskDisabledFromStatus := strings.TrimSpace(fm.Metadata.Wuphf.DisabledFromStatus)
 		if b.skills[i].Status != diskStatus {
 			slog.Info("skill_crud: reconcile status from disk",
 				"name", b.skills[i].Name,
 				"was", b.skills[i].Status,
 				"now", diskStatus)
 			b.skills[i].Status = diskStatus
+			updated = true
+		}
+		if b.skills[i].DisabledFromStatus != diskDisabledFromStatus {
+			b.skills[i].DisabledFromStatus = diskDisabledFromStatus
 			updated = true
 		}
 	}

--- a/internal/team/skill_crud_endpoints_test.go
+++ b/internal/team/skill_crud_endpoints_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -435,6 +436,54 @@ func TestSkillDisableOriginSurvivesRestart(t *testing.T) {
 	}
 	if found.DisabledFromStatus != "proposed" {
 		t.Errorf("disabled_from_status after restart = %q, want proposed", found.DisabledFromStatus)
+	}
+}
+
+func TestSkillDisableOriginReconcilesFromDisk(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBroker(t)
+	seedProposedSkill(t, b, "proposal-pause-disk")
+	setSkillStatus(t, b, "proposal-pause-disk", "active")
+
+	root := t.TempDir()
+	repo := NewRepoAt(root, filepath.Join(t.TempDir(), "backup"))
+	b.wikiWorker = NewWikiWorker(repo, nil)
+
+	md, err := RenderSkillMarkdown(SkillFrontmatter{
+		Name:        "proposal-pause-disk",
+		Description: "A disabled proposal restored from SKILL metadata.",
+		Metadata: SkillMetadata{
+			Wuphf: SkillWuphfMeta{
+				Status:             "disabled",
+				DisabledFromStatus: "proposed",
+			},
+		},
+	}, "Step 1: wait for approval.")
+	if err != nil {
+		t.Fatalf("RenderSkillMarkdown: %v", err)
+	}
+	skillPath := filepath.Join(root, filepath.FromSlash(skillWikiPath("proposal-pause-disk")))
+	if err := os.MkdirAll(filepath.Dir(skillPath), 0o755); err != nil {
+		t.Fatalf("mkdir skill path: %v", err)
+	}
+	if err := os.WriteFile(skillPath, md, 0o644); err != nil {
+		t.Fatalf("write skill markdown: %v", err)
+	}
+
+	b.reconcileSkillStatusFromDisk()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	found := b.findSkillByNameLocked("proposal-pause-disk")
+	if found == nil {
+		t.Fatal("proposal-pause-disk skill missing after reconcile")
+	}
+	if found.Status != "disabled" {
+		t.Errorf("status after reconcile = %q, want disabled", found.Status)
+	}
+	if found.DisabledFromStatus != "proposed" {
+		t.Errorf("disabled_from_status after reconcile = %q, want proposed", found.DisabledFromStatus)
 	}
 }
 

--- a/internal/team/skill_frontmatter.go
+++ b/internal/team/skill_frontmatter.go
@@ -48,8 +48,11 @@ type SkillWuphfMeta struct {
 	SourceSignals []string `yaml:"source_signals,omitempty"`
 	// CreatedBy is the identity that wrote this proposal ("archivist", agent slug, etc.).
 	CreatedBy string `yaml:"created_by,omitempty"`
-	// Status is one of proposed | active | archived.
+	// Status is one of proposed | active | disabled | archived.
 	Status string `yaml:"status,omitempty"`
+	// DisabledFromStatus records the status a disabled skill came from so
+	// disabled proposals cannot be re-enabled as active without approval.
+	DisabledFromStatus string `yaml:"disabled_from_status,omitempty"`
 	// LastSynthesizedSHA is the repo HEAD SHA at the time of last synthesis.
 	LastSynthesizedSHA string `yaml:"last_synthesized_sha,omitempty"`
 	// LastSynthesizedTs is the RFC3339 timestamp of the last synthesis run.
@@ -179,6 +182,7 @@ func teamSkillToFrontmatter(sk teamSkill) SkillFrontmatter {
 				SourceArticles:     sourceArticles,
 				CreatedBy:          sk.CreatedBy,
 				Status:             sk.Status,
+				DisabledFromStatus: sk.DisabledFromStatus,
 				Tags:               append([]string(nil), sk.Tags...),
 				WorkflowProvider:   sk.WorkflowProvider,
 				WorkflowKey:        sk.WorkflowKey,

--- a/internal/team/skill_frontmatter_test.go
+++ b/internal/team/skill_frontmatter_test.go
@@ -45,7 +45,8 @@ func TestRenderAndParseSkillMarkdown_RoundTrip(t *testing.T) {
 						SourceArticles:       []string{"team/playbooks/retro.md"},
 						SourceSignals:        []string{"team/agents/eng/notebook/retro-notes.md"},
 						CreatedBy:            "archivist",
-						Status:               "proposed",
+						Status:               "disabled",
+						DisabledFromStatus:   "proposed",
 						LastSynthesizedSHA:   "abc1234",
 						LastSynthesizedTs:    "2026-04-28T12:00:00Z",
 						FactCountAtSynthesis: 42,
@@ -138,6 +139,9 @@ func TestRenderAndParseSkillMarkdown_RoundTrip(t *testing.T) {
 			}
 			if w.Status != "" && gw.Status != w.Status {
 				t.Errorf("Wuphf.Status: got %q, want %q", gw.Status, w.Status)
+			}
+			if w.DisabledFromStatus != "" && gw.DisabledFromStatus != w.DisabledFromStatus {
+				t.Errorf("Wuphf.DisabledFromStatus: got %q, want %q", gw.DisabledFromStatus, w.DisabledFromStatus)
 			}
 			if w.LastSynthesizedSHA != "" && gw.LastSynthesizedSHA != w.LastSynthesizedSHA {
 				t.Errorf("Wuphf.LastSynthesizedSHA: got %q, want %q", gw.LastSynthesizedSHA, w.LastSynthesizedSHA)
@@ -254,7 +258,8 @@ func TestTeamSkillToFrontmatter(t *testing.T) {
 		Description:        "Send a daily digest to the team.",
 		Content:            "## Steps\n\n1. Gather.\n2. Send.",
 		CreatedBy:          "archivist",
-		Status:             "proposed",
+		Status:             "disabled",
+		DisabledFromStatus: "proposed",
 		Tags:               []string{"comms", "daily"},
 		Trigger:            "Every morning",
 		WorkflowProvider:   "zapier",
@@ -293,6 +298,9 @@ func TestTeamSkillToFrontmatter(t *testing.T) {
 	if w.Status != sk.Status {
 		t.Errorf("Wuphf.Status: got %q, want %q", w.Status, sk.Status)
 	}
+	if w.DisabledFromStatus != sk.DisabledFromStatus {
+		t.Errorf("Wuphf.DisabledFromStatus: got %q, want %q", w.DisabledFromStatus, sk.DisabledFromStatus)
+	}
 	if w.WorkflowProvider != sk.WorkflowProvider {
 		t.Errorf("Wuphf.WorkflowProvider: got %q, want %q", w.WorkflowProvider, sk.WorkflowProvider)
 	}
@@ -304,5 +312,28 @@ func TestTeamSkillToFrontmatter(t *testing.T) {
 	}
 	if len(w.RelayEventTypes) != len(sk.RelayEventTypes) {
 		t.Errorf("Wuphf.RelayEventTypes len: got %d, want %d", len(w.RelayEventTypes), len(sk.RelayEventTypes))
+	}
+}
+
+func TestSpecToTeamSkillPreservesLifecycleStatusMetadata(t *testing.T) {
+	t.Parallel()
+
+	sk := specToTeamSkill(SkillFrontmatter{
+		Name:        "approval-required",
+		Description: "A proposal paused before approval.",
+		Metadata: SkillMetadata{
+			Wuphf: SkillWuphfMeta{
+				CreatedBy:          "archivist",
+				Status:             "disabled",
+				DisabledFromStatus: "proposed",
+			},
+		},
+	}, "Step 1: wait for approval.", "")
+
+	if sk.Status != "disabled" {
+		t.Errorf("Status: got %q, want disabled", sk.Status)
+	}
+	if sk.DisabledFromStatus != "proposed" {
+		t.Errorf("DisabledFromStatus: got %q, want proposed", sk.DisabledFromStatus)
 	}
 }

--- a/internal/team/skill_proposal_helper.go
+++ b/internal/team/skill_proposal_helper.go
@@ -131,6 +131,7 @@ func (b *Broker) writeSkillProposalLocked(spec teamSkill) (*teamSkill, error) {
 		LastExecutionStatus: strings.TrimSpace(spec.LastExecutionStatus),
 		UsageCount:          0,
 		Status:              status,
+		DisabledFromStatus:  strings.TrimSpace(spec.DisabledFromStatus),
 		CreatedAt:           now,
 		UpdatedAt:           now,
 	}

--- a/internal/team/skill_proposal_helper_test.go
+++ b/internal/team/skill_proposal_helper_test.go
@@ -241,6 +241,30 @@ func TestWriteSkillProposalLocked_DefaultsStatus(t *testing.T) {
 	}
 }
 
+func TestWriteSkillProposalLocked_PreservesDisabledFromStatus(t *testing.T) {
+	t.Parallel()
+	b := newTestBroker(t)
+
+	spec := skillProposalSpec("paused-proposal", "A paused proposal.", "archivist")
+	spec.Status = "disabled"
+	spec.DisabledFromStatus = "proposed"
+
+	sk, err := callWriteSkillProposalLocked(b, spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sk.Status != "disabled" {
+		t.Errorf("Status: got %q, want disabled", sk.Status)
+	}
+	if sk.DisabledFromStatus != "proposed" {
+		t.Errorf("DisabledFromStatus: got %q, want proposed", sk.DisabledFromStatus)
+	}
+	fm := teamSkillToFrontmatter(*sk)
+	if fm.Metadata.Wuphf.DisabledFromStatus != "proposed" {
+		t.Errorf("frontmatter disabled_from_status: got %q, want proposed", fm.Metadata.Wuphf.DisabledFromStatus)
+	}
+}
+
 // TestWriteSkillProposalLocked_GuardRejectsDangerous covers the trust-ladder
 // gate: a community-trust skill with a dangerous body is rejected outright,
 // the rejection counter is bumped, and no skill is appended to b.skills.

--- a/internal/team/skill_scanner.go
+++ b/internal/team/skill_scanner.go
@@ -244,6 +244,11 @@ func (s *SkillScanner) Scan(ctx context.Context, scopePath string, dryRun bool, 
 		fm.Metadata.Wuphf.CreatedBy = "archivist"
 		spec := specToTeamSkill(fm, body, c.relPath)
 		spec.CreatedBy = "archivist"
+		// Source-article frontmatter can opt into skill creation, but it is not
+		// authoritative for lifecycle state. Every scanner write enters the
+		// approval workflow as a proposal.
+		spec.Status = "proposed"
+		spec.DisabledFromStatus = ""
 
 		s.broker.mu.Lock()
 		_, writeErr := s.broker.writeSkillProposalLocked(spec)

--- a/internal/team/skill_scanner.go
+++ b/internal/team/skill_scanner.go
@@ -425,6 +425,10 @@ func specToTeamSkill(fm SkillFrontmatter, body, sourceArticle string) teamSkill 
 	if src == "" && len(wuphf.SourceArticles) > 0 {
 		src = strings.TrimSpace(wuphf.SourceArticles[0])
 	}
+	status := strings.TrimSpace(wuphf.Status)
+	if status == "" {
+		status = "proposed"
+	}
 	return teamSkill{
 		Name:               fm.Name,
 		Title:              wuphf.Title,
@@ -442,7 +446,8 @@ func specToTeamSkill(fm SkillFrontmatter, body, sourceArticle string) teamSkill 
 		RelayID:            wuphf.RelayID,
 		RelayPlatform:      wuphf.RelayPlatform,
 		RelayEventTypes:    append([]string(nil), wuphf.RelayEventTypes...),
-		Status:             "proposed",
+		Status:             status,
+		DisabledFromStatus: strings.TrimSpace(wuphf.DisabledFromStatus),
 	}
 }
 


### PR DESCRIPTION
## Summary
- follow up PR #559 review comments by making disabled proposal origin durable in SKILL.md metadata, not only broker-state JSON
- preserve lifecycle status metadata through frontmatter render/parse, scanner conversion, and disk reconciliation
- add regression coverage for frontmatter conversion and reconcile-from-disk behavior

## Tests
- go test ./internal/team -run 'Test(RenderAndParseSkillMarkdown_RoundTrip|TeamSkillToFrontmatter|SpecToTeamSkillPreservesLifecycleStatusMetadata|SkillDisableOriginReconcilesFromDisk|SkillDisableProposedCannotBeEnabled|SkillDisableInvalidTransitions|SkillRestoreRejectsSlugCollision)' -count=1\n- bash scripts/test-go.sh ./internal/team\n\nFollow-up to #559.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reconciliation now preserves and syncs the source-of-disablement metadata from disk, keeping skill lifecycle state consistent when reloading.

* **New Features**
  * Skill frontmatter now supports a retained "disabled from" field and recognizes "disabled" as a lifecycle status.
  * Stage processing now normalizes incoming status to the expected draft value.

* **Tests**
  * Added and updated tests covering disabled-status preservation, reconciliation from disk, and frontmatter round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->