### PR TITLE
feat(transport): add unified transport contract (phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 !/docs/architecture/**
 !/docs/dogfood/
 !/docs/dogfood/**
+!/docs/ADD-A-TRANSPORT.md
 /termwright-artifacts/
 .worktrees/
 .vexp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,8 @@ Run [`scripts/bootstrap.sh`](scripts/bootstrap.sh) to install lefthook hooks. Do
 
 Read [`ARCHITECTURE.md`](ARCHITECTURE.md). One page. Read it before you touch core packages.
 
+Adding an external integration (Slack, Discord, Hermes, …)? Read [`docs/ADD-A-TRANSPORT.md`](docs/ADD-A-TRANSPORT.md) first. The transport contract defines the interfaces, errors, registration site, and contributor pitfalls. TTHW ~30 min.
+
 ## File size
 
 | Range | Action |

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Inside the office, run `/connect openclaw`, paste your gateway URL (default `ws:
 
 WUPHF authenticates to the gateway using an Ed25519 keypair (persisted at `~/.wuphf/openclaw/identity.json`, 0600), signed against the server-issued nonce during every connect. OpenClaw grants zero scopes to token-only clients, so device pairing is mandatory — on loopback the gateway approves silently on first use.
 
+Want to add a new integration? See [docs/ADD-A-TRANSPORT.md](docs/ADD-A-TRANSPORT.md).
+
 ## External Actions
 
 To let agents take real actions (send emails, update CRMs, etc.), WUPHF ships with two action providers. Pick whichever fits your style.

--- a/docs/ADD-A-TRANSPORT.md
+++ b/docs/ADD-A-TRANSPORT.md
@@ -23,7 +23,7 @@ Pick the scope that matches how your integration behaves:
 
 ## Package layout
 
-```
+```text
 internal/team/transport/
   types.go          — Scope, Binding, Participant, Message, Outbound, Health
   transport.go      — Transport, MemberBoundTransport, OfficeBoundTransport, Host interfaces

--- a/docs/ADD-A-TRANSPORT.md
+++ b/docs/ADD-A-TRANSPORT.md
@@ -1,0 +1,219 @@
+# Add a Transport to WUPHF
+
+This guide walks you through wiring a new external integration (Slack, Discord,
+WhatsApp, Hermes, …) into WUPHF as a typed transport adapter. The whole process
+takes about 30 minutes once you have read this page.
+
+## What is a transport?
+
+A transport bridges an external messaging service with the WUPHF office broker.
+Three scopes exist:
+
+| Scope | Example | One external chat/session maps to… |
+|---|---|---|
+| **Channel-bound** | Telegram | One office channel (`#standup`) |
+| **Member-bound** | OpenClaw | One office member per bridged session |
+| **Office-bound** | Human-share | The whole office (admitted human) |
+
+Pick the scope that matches how your integration behaves:
+
+- One external chat → one team channel? → **Channel-bound** (`Transport`)
+- Each bridged session becomes an agent/human member? → **Member-bound** (`MemberBoundTransport`)
+- External human joins the whole office? → **Office-bound** (`OfficeBoundTransport`)
+
+## Package layout
+
+```
+internal/team/transport/
+  types.go          — Scope, Binding, Participant, Message, Outbound, Health
+  transport.go      — Transport, MemberBoundTransport, OfficeBoundTransport, Host interfaces
+  errors.go         — typed sentinel errors + wrapped error types
+  webhook_fake_test.go — canonical fake adapters (start here when reading)
+  host_misuse_test.go  — 6 misuse-case tests; your adapter should pass all 6
+
+internal/team/
+  broker_transport.go    — transport.Host implementation (backed by Broker)
+  launcher_transports.go — RegisterTransports() — the single adapter registration site
+```
+
+**Package boundary:** `internal/team/transport` imports only the standard
+library and external SDKs. It does NOT import `internal/team`. Go's import rules
+make this a compile-time invariant: if your adapter needs something from the
+broker, add a method to `transport.Host` instead of reaching into `internal/team`.
+
+## Step 1: Implement the interface
+
+Create `internal/team/transport/slack.go` (or wherever makes sense):
+
+```go
+package transport
+
+import (
+    "context"
+    "time"
+)
+
+type SlackTransport struct {
+    Token       string
+    ChannelID   string
+    OfficeChan  string // office channel slug, e.g. "general"
+    // ... Slack API client, health fields ...
+}
+
+func (s *SlackTransport) Name() string { return "slack" }
+
+func (s *SlackTransport) Binding() Binding {
+    return Binding{Scope: ScopeChannel, ChannelSlug: s.OfficeChan}
+}
+
+func (s *SlackTransport) Run(ctx context.Context, host Host) error {
+    // Connect to Slack RTM or Events API.
+    // For each inbound message:
+    //   1. UpsertParticipant (ALWAYS before ReceiveMessage for new users)
+    //   2. ReceiveMessage
+    // Block until ctx.Done().
+    return nil
+}
+
+func (s *SlackTransport) Send(ctx context.Context, msg Outbound) error {
+    // Post msg.Text to the Slack channel.
+    return nil
+}
+
+func (s *SlackTransport) Health() Health {
+    // Return a cached Health snapshot. Do NOT make a network call here.
+    return Health{State: HealthConnected, LastSuccessAt: time.Now()}
+}
+```
+
+### Interface contract: method by method
+
+**`Name() string`**
+- Must be a stable, lowercase identifier (e.g. `"slack"`). Never change this between releases — it is the namespace key for all participant identities. Changing it orphans existing participants.
+
+**`Binding() Binding`**
+- Called once at registration. For channel-bound: set `ChannelSlug` to the office channel the external chat maps to. Verify that channel exists before registering.
+
+**`Run(ctx context.Context, host Host) error`**
+- Your main polling/event loop. Block until `ctx.Done()`. The Host supervises Run in a goroutine: non-nil return triggers reconnect with backoff; nil return means intentional shutdown (no reconnect).
+- Call `host.UpsertParticipant` before the first `host.ReceiveMessage` for any new external identity. Skipping this returns `ErrParticipantUnknown`.
+
+**`Send(ctx context.Context, msg Outbound) error`**
+- Deliver one outbound message. Respect `ctx` for timeouts. The Host calls this from a per-transport worker goroutine so a slow Send does not block other adapters.
+
+**`Health() Health`**
+- Return a cached struct, not a live network probe. Called on every channel-header render.
+
+## Step 2: Register the adapter
+
+Open `internal/team/launcher_transports.go` and add your adapter to `RegisterTransports`:
+
+```go
+func RegisterTransports(host transport.Host) error {
+    token := os.Getenv("SLACK_BOT_TOKEN")
+    channelID := os.Getenv("SLACK_CHANNEL_ID")
+    if token != "" && channelID != "" {
+        slack := &transport.SlackTransport{
+            Token:      token,
+            ChannelID:  channelID,
+            OfficeChan: "general",
+        }
+        // Phase 2b: host.Register(slack) — available after Phase 2b lands.
+        _ = slack
+    }
+    return nil
+}
+```
+
+This is the **only** registration site. Both `Launch()` (tmux-mode) and
+`LaunchWeb()` (web-mode) call `RegisterTransports` after `broker.Start()`,
+so your adapter automatically runs in both surfaces.
+
+## Step 3: Wire `UpsertParticipant` before `ReceiveMessage`
+
+This is the most common mistake. In your `Run` loop:
+
+```go
+// Wrong — ReceiveMessage before UpsertParticipant:
+host.ReceiveMessage(ctx, transport.Message{ ... }) // returns ErrParticipantUnknown
+
+// Correct:
+host.UpsertParticipant(ctx, transport.Participant{
+    AdapterName: s.Name(),
+    Key:         strconv.FormatInt(slackUser.ID, 10), // stable, content-addressed
+    DisplayName: slackUser.Name,
+    Human:       true,
+}, s.Binding())
+host.ReceiveMessage(ctx, transport.Message{
+    Participant: transport.Participant{AdapterName: s.Name(), Key: ...},
+    Binding:     s.Binding(),
+    Text:        event.Text,
+})
+```
+
+Call `UpsertParticipant` on **every** inbound event, not just the first. It is
+idempotent — the second call is a no-op if nothing changed.
+
+## Host contract
+
+`transport.Host` is the only surface an adapter uses to touch the broker:
+
+| Method | When to call | Error | Remediation |
+|---|---|---|---|
+| `UpsertParticipant` | Before first `ReceiveMessage` for any new identity | `ErrRegistrationConflict` | Use stable content-addressed keys |
+| `ReceiveMessage` | For each inbound message | `ErrParticipantUnknown` | Call UpsertParticipant first |
+| `ReceiveMessage` | For each inbound message | `ErrBindingChannelMissing` | Verify channel slug at startup |
+| `DetachParticipant` | When a session/invite expires | — | Idempotent; no-op if not known |
+| `RevokeParticipant` | Office-bound only: invite revoked | — | Permanent; member record deleted |
+
+## Error contract
+
+```go
+import "errors"
+import "github.com/nex-crm/wuphf/internal/team/transport"
+
+if errors.Is(err, transport.ErrParticipantUnknown) {
+    // Call UpsertParticipant first, then retry.
+}
+if errors.Is(err, transport.ErrBindingChannelMissing) {
+    // Channel was deleted. Shut down cleanly; log for the user.
+}
+if errors.Is(err, transport.ErrSendTimeout) {
+    // Message dropped. Check upstream API latency.
+}
+if errors.Is(err, transport.ErrHealthDegraded) {
+    // Broker is pausing inbound from this adapter. Run reconnect logic.
+}
+if errors.Is(err, transport.ErrRegistrationConflict) {
+    // Unstable participant key. Use a content-addressed identifier.
+}
+```
+
+## Common pitfalls
+
+1. **`ReceiveMessage` before `UpsertParticipant`** → `ErrParticipantUnknown`. Always upsert first for new identities.
+2. **Declaring a non-existent channel slug in `Binding`** → `ErrBindingChannelMissing` at first message. Verify the slug at startup.
+3. **Unstable participant keys** (e.g. row auto-increment IDs that reset after restart) → `ErrRegistrationConflict`. Use the upstream service's stable identifier (Slack user ID, OpenClaw session key).
+4. **Making a network call inside `Health()`** → channel-header renders hang. Cache the health state; update it in your polling loop.
+5. **Importing `internal/team` from your adapter** → compile error (one-way boundary). Extend `transport.Host` instead.
+6. **Registering in only one launcher** — not possible if you use `RegisterTransports`. Only one site; both surfaces covered automatically.
+
+## Running the contract tests
+
+```bash
+bash scripts/test-go.sh ./internal/team/transport/...
+```
+
+All 8 tests in `host_misuse_test.go` should be green before opening a PR. The
+compile-time assertions in `TestFakeAdaptersSatisfyInterfaces` will catch
+missing interface methods immediately.
+
+## Reference implementations
+
+- **`webhook_fake_test.go`** — canonical minimal adapters for all three scopes.
+- **`internal/team/telegram.go`** — the existing channel-bound implementation (pre-contract).
+- **`internal/team/openclaw.go`** — the existing member-bound implementation (pre-contract).
+
+The Telegram and OpenClaw implementations are being migrated onto the contract in
+Phases 2b and 3b. Use the fake adapters as your template, not the pre-contract
+implementations.

--- a/docs/ADD-A-TRANSPORT.md
+++ b/docs/ADD-A-TRANSPORT.md
@@ -29,7 +29,7 @@ internal/team/transport/
   transport.go      — Transport, MemberBoundTransport, OfficeBoundTransport, Host interfaces
   errors.go         — typed sentinel errors + wrapped error types
   webhook_fake_test.go — canonical fake adapters (start here when reading)
-  host_misuse_test.go  — 6 misuse-case tests; your adapter should pass all 6
+  host_misuse_test.go  — 9 tests: 6 misuse paths + compile-time assertions + constant uniqueness checks
 
 internal/team/
   broker_transport.go    — transport.Host implementation (backed by Broker)
@@ -204,7 +204,7 @@ if errors.Is(err, transport.ErrRegistrationConflict) {
 bash scripts/test-go.sh ./internal/team/transport/...
 ```
 
-All 8 tests in `host_misuse_test.go` should be green before opening a PR. The
+All 9 tests in `host_misuse_test.go` should be green before opening a PR. The
 compile-time assertions in `TestFakeAdaptersSatisfyInterfaces` will catch
 missing interface methods immediately.
 

--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -1,0 +1,77 @@
+package team
+
+// broker_transport.go implements transport.Host on the Broker. This is the
+// only file in internal/team that imports internal/team/transport — the
+// one-way compile boundary (team → transport) is enforced here.
+//
+// Phase 1 ships the Host interface and the stub implementation. The real
+// routing logic (message fan-out, participant upsert into broker member store,
+// per-transport worker goroutines) lands in Phase 2b when Telegram is refactored
+// onto the contract. Until then every method returns a descriptive stub error
+// so contributors wiring a new adapter against this Host see a clear "not yet
+// wired" message rather than a silent no-op.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// brokerTransportHost implements transport.Host for the Broker.
+// One instance is created per Broker via newBrokerTransportHost.
+type brokerTransportHost struct {
+	broker *Broker
+}
+
+// newBrokerTransportHost returns a Host implementation backed by b.
+// Called by launcher.RegisterTransports when adapters are registered.
+func newBrokerTransportHost(b *Broker) transport.Host {
+	return &brokerTransportHost{broker: b}
+}
+
+// ReceiveMessage delivers an inbound message from an external adapter to the
+// office. Phase 1 stub — returns an informative error until Phase 2b wires the
+// real routing.
+func (h *brokerTransportHost) ReceiveMessage(_ context.Context, msg transport.Message) error {
+	// Phase 2b TODO: resolve binding → channel, write message to broker under
+	// h.broker.mu, deduplicate by (AdapterName+Key+ExternalID).
+	return fmt.Errorf("transport: ReceiveMessage not yet implemented (phase 2b) — adapter=%q participant=%q text=%q",
+		msg.Participant.AdapterName, msg.Participant.Key, truncateText(msg.Text, 40))
+}
+
+// UpsertParticipant registers or refreshes an external identity in the broker.
+// Phase 1 stub — returns an informative error until Phase 2b wires the real
+// member upsert.
+func (h *brokerTransportHost) UpsertParticipant(_ context.Context, p transport.Participant, b transport.Binding) error {
+	// Phase 2b TODO: look up (p.AdapterName, p.Key) in broker member store;
+	// create member if new; update DisplayName on revisit; return
+	// ErrRegistrationConflict if key maps to a different existing slug.
+	return fmt.Errorf("transport: UpsertParticipant not yet implemented (phase 2b) — adapter=%q key=%q scope=%q",
+		p.AdapterName, p.Key, b.Scope)
+}
+
+// DetachParticipant marks a participant as offline. Phase 1 stub.
+func (h *brokerTransportHost) DetachParticipant(_ context.Context, adapterName, key string) error {
+	// Phase 2b TODO: mark the member corresponding to (adapterName, key) as
+	// offline in the broker member store.
+	return fmt.Errorf("transport: DetachParticipant not yet implemented (phase 2b) — adapter=%q key=%q",
+		adapterName, key)
+}
+
+// RevokeParticipant removes an admitted human from the broker. Phase 1 stub.
+func (h *brokerTransportHost) RevokeParticipant(_ context.Context, adapterName, key string) error {
+	// Phase 4 TODO: delete the member record for (adapterName, key) from the
+	// broker member store and close any open sessions associated with this key.
+	return fmt.Errorf("transport: RevokeParticipant not yet implemented (phase 4) — adapter=%q key=%q",
+		adapterName, key)
+}
+
+// truncateText shortens s to at most n runes, appending "…" if truncated.
+func truncateText(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "…"
+}

--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -10,6 +10,12 @@ package team
 // onto the contract. Until then every method returns a descriptive stub error
 // so contributors wiring a new adapter against this Host see a clear "not yet
 // wired" message rather than a silent no-op.
+//
+// Note on cleanup: RegisterTransports (called by Launch, LaunchWeb, and
+// launchHeadlessCodex) is a Phase 1 stub that starts no goroutines and opens
+// no connections, so the launchers' early-abort paths require no teardown.
+// When Phase 2a wires real adapters, RegisterTransports will return a cleanup
+// function and the launchers will call it on abort — tracked in launcher_transports.go.
 
 import (
 	"context"
@@ -36,42 +42,33 @@ func newBrokerTransportHost(b *Broker) transport.Host {
 func (h *brokerTransportHost) ReceiveMessage(_ context.Context, msg transport.Message) error {
 	// Phase 2b TODO: resolve binding → channel, write message to broker under
 	// h.broker.mu, deduplicate by (AdapterName+Key+ExternalID).
-	return fmt.Errorf("transport: ReceiveMessage not yet implemented (phase 2b) — adapter=%q participant=%q text=%q",
-		msg.Participant.AdapterName, msg.Participant.Key, truncateText(msg.Text, 40))
+	return fmt.Errorf("transport: ReceiveMessage not yet implemented (phase 2b): adapter=%q",
+		msg.Participant.AdapterName)
 }
 
 // UpsertParticipant registers or refreshes an external identity in the broker.
 // Phase 1 stub — returns an informative error until Phase 2b wires the real
 // member upsert.
-func (h *brokerTransportHost) UpsertParticipant(_ context.Context, p transport.Participant, b transport.Binding) error {
+func (h *brokerTransportHost) UpsertParticipant(_ context.Context, p transport.Participant, _ transport.Binding) error {
 	// Phase 2b TODO: look up (p.AdapterName, p.Key) in broker member store;
 	// create member if new; update DisplayName on revisit; return
 	// ErrRegistrationConflict if key maps to a different existing slug.
-	return fmt.Errorf("transport: UpsertParticipant not yet implemented (phase 2b) — adapter=%q key=%q scope=%q",
-		p.AdapterName, p.Key, b.Scope)
+	return fmt.Errorf("transport: UpsertParticipant not yet implemented (phase 2b): adapter=%q",
+		p.AdapterName)
 }
 
 // DetachParticipant marks a participant as offline. Phase 1 stub.
-func (h *brokerTransportHost) DetachParticipant(_ context.Context, adapterName, key string) error {
+func (h *brokerTransportHost) DetachParticipant(_ context.Context, adapterName, _ string) error {
 	// Phase 2b TODO: mark the member corresponding to (adapterName, key) as
 	// offline in the broker member store.
-	return fmt.Errorf("transport: DetachParticipant not yet implemented (phase 2b) — adapter=%q key=%q",
-		adapterName, key)
+	return fmt.Errorf("transport: DetachParticipant not yet implemented (phase 2b): adapter=%q",
+		adapterName)
 }
 
 // RevokeParticipant removes an admitted human from the broker. Phase 1 stub.
-func (h *brokerTransportHost) RevokeParticipant(_ context.Context, adapterName, key string) error {
+func (h *brokerTransportHost) RevokeParticipant(_ context.Context, adapterName, _ string) error {
 	// Phase 4 TODO: delete the member record for (adapterName, key) from the
 	// broker member store and close any open sessions associated with this key.
-	return fmt.Errorf("transport: RevokeParticipant not yet implemented (phase 4) — adapter=%q key=%q",
-		adapterName, key)
-}
-
-// truncateText shortens s to at most n runes, appending "…" if truncated.
-func truncateText(s string, n int) string {
-	runes := []rune(s)
-	if len(runes) <= n {
-		return s
-	}
-	return string(runes[:n]) + "…"
+	return fmt.Errorf("transport: RevokeParticipant not yet implemented (phase 4): adapter=%q",
+		adapterName)
 }

--- a/internal/team/launcher_boot.go
+++ b/internal/team/launcher_boot.go
@@ -216,6 +216,11 @@ func (l *Launcher) launchHeadlessCodex() error {
 	if err := l.broker.Start(); err != nil {
 		return fmt.Errorf("start broker: %w", err)
 	}
+
+	if err := RegisterTransports(newBrokerTransportHost(l.broker)); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: transport registration: %v\n", err)
+	}
+
 	if l.pack != nil {
 		l.broker.SeedDefaultSkills(agent.AppendProductivitySkills(l.pack.DefaultSkills))
 	} else {

--- a/internal/team/launcher_boot.go
+++ b/internal/team/launcher_boot.go
@@ -64,7 +64,8 @@ func (l *Launcher) Launch() error {
 		return fmt.Errorf("start broker: %w", err)
 	}
 
-	if err := RegisterTransports(newBrokerTransportHost(l.broker)); err != nil {
+	stopTransports, err := RegisterTransports(newBrokerTransportHost(l.broker))
+	if err != nil {
 		// Non-fatal: a misconfigured optional adapter (e.g. bad Telegram token)
 		// should not prevent the office from starting.
 		fmt.Fprintf(os.Stderr, "warning: transport registration: %v\n", err)
@@ -87,9 +88,8 @@ func (l *Launcher) Launch() error {
 	// Resolve wuphf binary path for the channel view
 	wuphfBinary, _ := os.Executable()
 	if err := os.MkdirAll(filepath.Dir(channelStderrLogPath()), 0o700); err != nil {
-		// Stop the broker we already started so we don't leak a
-		// listener on an aborted Launch. Same unwind reason as the
-		// PID-file failure path in launcher_web.go.
+		// Stop adapters before the broker so they can flush in-flight sends.
+		stopTransports()
 		l.broker.Stop()
 		return fmt.Errorf("prepare channel log dir: %w", err)
 	}
@@ -114,6 +114,7 @@ func (l *Launcher) Launch() error {
 		channelCmd,
 	).Run()
 	if err != nil {
+		stopTransports()
 		l.broker.Stop()
 		return fmt.Errorf("create tmux session: %w", err)
 	}
@@ -217,7 +218,8 @@ func (l *Launcher) launchHeadlessCodex() error {
 		return fmt.Errorf("start broker: %w", err)
 	}
 
-	if err := RegisterTransports(newBrokerTransportHost(l.broker)); err != nil {
+	stopTransports, err := RegisterTransports(newBrokerTransportHost(l.broker))
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: transport registration: %v\n", err)
 	}
 
@@ -227,6 +229,7 @@ func (l *Launcher) launchHeadlessCodex() error {
 		l.broker.SeedDefaultSkills(agent.AppendProductivitySkills(nil))
 	}
 	if err := writeOfficePIDFile(); err != nil {
+		stopTransports()
 		l.broker.Stop()
 		return fmt.Errorf("write office pid: %w", err)
 	}

--- a/internal/team/launcher_boot.go
+++ b/internal/team/launcher_boot.go
@@ -64,6 +64,12 @@ func (l *Launcher) Launch() error {
 		return fmt.Errorf("start broker: %w", err)
 	}
 
+	if err := RegisterTransports(newBrokerTransportHost(l.broker)); err != nil {
+		// Non-fatal: a misconfigured optional adapter (e.g. bad Telegram token)
+		// should not prevent the office from starting.
+		fmt.Fprintf(os.Stderr, "warning: transport registration: %v\n", err)
+	}
+
 	// Pre-seed any default skills declared by the pack (idempotent).
 	// Always seed the cross-cutting productivity skills (grill-me, tdd,
 	// diagnose, etc., adapted from github.com/mattpocock/skills) on top of

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -7,8 +7,8 @@ package team
 // wire it to one and miss the other.
 //
 // Phase 1: RegisterTransports is the stub. No real adapters are registered yet.
-// The function signature and call sites in Launch/LaunchWeb are established so
-// Phase 2a can add the Telegram wiring in a single diff (one adapter, one line).
+// The function signature and call sites in Launch/LaunchWeb/launchHeadlessCodex
+// are established so Phase 2a can add the Telegram wiring in a single diff.
 //
 // See docs/ADD-A-TRANSPORT.md for the full contributor guide.
 
@@ -17,19 +17,22 @@ import (
 )
 
 // RegisterTransports registers all configured transport adapters against host.
-// Called once per launch after broker.Start() succeeds. Returns a non-nil error
-// only when a required adapter (one whose config is present but invalid) fails
-// to register; optional adapters that are not configured are silently skipped.
+// Called once per launch after broker.Start() succeeds. Returns a cleanup
+// function and an optional error. The cleanup function stops all registered
+// adapters and must be called before broker.Stop() on any early-abort path.
+// It is always non-nil and safe to call even when err is non-nil.
 //
-// Callers (Launch, LaunchWeb) log the error and continue — a misconfigured
+// A non-nil error means a required adapter (one whose config is present but
+// invalid) failed to register; optional adapters that are not configured are
+// silently skipped. Callers log the error and continue — a misconfigured
 // Telegram token should not prevent the office from starting.
-func RegisterTransports(_ transport.Host) error {
+func RegisterTransports(_ transport.Host) (func(), error) {
 	// Phase 2a TODO: check cfg for TELEGRAM_BOT_TOKEN; if set, construct
-	// TelegramTransport and call host.Register (once Host gains that method).
+	// TelegramTransport, start its Run goroutine, and add its Stop to cleanup.
 	//
 	// Phase 3a TODO: check cfg for OpenClaw gateway URL + token; if set,
-	// construct OpenclawBridge adapter and register.
+	// construct OpenclawBridge adapter and add to cleanup.
 	//
 	// Phase 4 TODO: register human-share adapter when share is enabled.
-	return nil
+	return func() {}, nil
 }

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -1,0 +1,35 @@
+package team
+
+// launcher_transports.go is the single registration site for all transport
+// adapters. Both Launch() (tmux-mode) and LaunchWeb() (web-mode) call
+// RegisterTransports after the broker is up. Adding a transport here
+// automatically makes it available in both surfaces — you cannot accidentally
+// wire it to one and miss the other.
+//
+// Phase 1: RegisterTransports is the stub. No real adapters are registered yet.
+// The function signature and call sites in Launch/LaunchWeb are established so
+// Phase 2a can add the Telegram wiring in a single diff (one adapter, one line).
+//
+// See docs/ADD-A-TRANSPORT.md for the full contributor guide.
+
+import (
+	"github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// RegisterTransports registers all configured transport adapters against host.
+// Called once per launch after broker.Start() succeeds. Returns a non-nil error
+// only when a required adapter (one whose config is present but invalid) fails
+// to register; optional adapters that are not configured are silently skipped.
+//
+// Callers (Launch, LaunchWeb) log the error and continue — a misconfigured
+// Telegram token should not prevent the office from starting.
+func RegisterTransports(_ transport.Host) error {
+	// Phase 2a TODO: check cfg for TELEGRAM_BOT_TOKEN; if set, construct
+	// TelegramTransport and call host.Register (once Host gains that method).
+	//
+	// Phase 3a TODO: check cfg for OpenClaw gateway URL + token; if set,
+	// construct OpenclawBridge adapter and register.
+	//
+	// Phase 4 TODO: register human-share adapter when share is enabled.
+	return nil
+}

--- a/internal/team/launcher_web.go
+++ b/internal/team/launcher_web.go
@@ -106,19 +106,18 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		return fmt.Errorf("start broker: %w", err)
 	}
 
-	if err := RegisterTransports(newBrokerTransportHost(l.broker)); err != nil {
+	stopTransports, err := RegisterTransports(newBrokerTransportHost(l.broker))
+	if err != nil {
 		// Non-fatal: a misconfigured optional adapter should not prevent the
 		// web UI from starting.
 		fmt.Fprintf(os.Stderr, "warning: transport registration: %v\n", err)
 	}
 
 	if err := writeOfficePIDFile(); err != nil {
-		// Stop the broker we just started so we don't leave an
-		// orphaned listener bound to the broker port. Without this,
-		// a PID-file write failure (full disk, perms, …) leaves
-		// the broker accepting requests with no PID record — the
-		// next launch can't kill it cleanly.
+		// Stop adapters before the broker so they can flush in-flight sends.
+		stopTransports()
 		l.broker.Stop()
+		_ = clearOfficePIDFile()
 		return fmt.Errorf("write office pid: %w", err)
 	}
 
@@ -141,6 +140,7 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		// down — leaving the broker accepting requests on a "wuphf has
 		// failed to start" path is worse than a clean exit, and a stale
 		// PID file would block the next launch attempt's writeOfficePID.
+		stopTransports()
 		l.broker.Stop()
 		_ = clearOfficePIDFile()
 		return fmt.Errorf("web UI failed to start: %w\n\nIs port %d already in use? Try: wuphf --web-port %d", err, webPort, webPort+1)

--- a/internal/team/launcher_web.go
+++ b/internal/team/launcher_web.go
@@ -105,6 +105,13 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 	if err := l.broker.Start(); err != nil {
 		return fmt.Errorf("start broker: %w", err)
 	}
+
+	if err := RegisterTransports(newBrokerTransportHost(l.broker)); err != nil {
+		// Non-fatal: a misconfigured optional adapter should not prevent the
+		// web UI from starting.
+		fmt.Fprintf(os.Stderr, "warning: transport registration: %v\n", err)
+	}
+
 	if err := writeOfficePIDFile(); err != nil {
 		// Stop the broker we just started so we don't leave an
 		// orphaned listener bound to the broker port. Without this,

--- a/internal/team/transport/errors.go
+++ b/internal/team/transport/errors.go
@@ -1,0 +1,100 @@
+package transport
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors returned by [Host] methods. Adapters should use [errors.Is]
+// to test for these; the Host wraps them with context via fmt.Errorf("%w").
+//
+// See docs/ADD-A-TRANSPORT.md §Error contract for remediation guidance.
+var (
+	// ErrParticipantUnknown is returned by [Host.ReceiveMessage] when the
+	// adapter did not call [Host.UpsertParticipant] before sending the message.
+	// Remediation: call UpsertParticipant(ctx, p, b) immediately when a new
+	// external identity first contacts the adapter, then retry ReceiveMessage.
+	ErrParticipantUnknown = errors.New("transport: participant unknown — call UpsertParticipant first")
+
+	// ErrBindingChannelMissing is returned by [Host.ReceiveMessage] or at
+	// adapter registration time when the channel declared in [Binding.ChannelSlug]
+	// does not exist in the broker. Remediation: verify the channel slug in
+	// the adapter's configuration and reconnect the Telegram channel via the
+	// web UI.
+	ErrBindingChannelMissing = errors.New("transport: binding channel not found")
+
+	// ErrAdapterCrashed is returned by the Host when a broker panic was
+	// recovered during message dispatch. The adapter should log the error and
+	// attempt reconnection via its normal backoff path; the broker has recovered
+	// and is still running.
+	ErrAdapterCrashed = errors.New("transport: adapter dispatch panicked and was recovered")
+
+	// ErrSendTimeout is returned by the Host worker when [Transport.Send] did
+	// not return within the configured timeout. The message has been dropped.
+	// Remediation: check the adapter's upstream connectivity and reduce message
+	// payload size if the upstream API has a latency limit.
+	ErrSendTimeout = errors.New("transport: send timed out — message dropped")
+
+	// ErrHealthDegraded is returned by [Host.ReceiveMessage] when the broker
+	// has marked the adapter as degraded (e.g. repeated send failures) and is
+	// refusing further inbound messages until the adapter self-heals. The
+	// adapter should pause polling, run its reconnect logic, and retry.
+	ErrHealthDegraded = errors.New("transport: adapter health degraded — pause and reconnect")
+
+	// ErrRegistrationConflict is returned by [Host.UpsertParticipant] when
+	// the (AdapterName, Key) pair maps to a different member slug than already
+	// registered. This typically indicates the adapter restarted with a new key
+	// assignment while the old mapping still exists. Remediation: use stable,
+	// content-addressed keys (e.g. upstream session ID) rather than ephemeral
+	// identifiers.
+	ErrRegistrationConflict = errors.New("transport: participant key conflicts with existing member slug")
+)
+
+// ParticipantUnknownError wraps [ErrParticipantUnknown] with the adapter name
+// and participant key so the log message points directly at the cause.
+type ParticipantUnknownError struct {
+	AdapterName string
+	Key         string
+}
+
+func (e *ParticipantUnknownError) Error() string {
+	return fmt.Sprintf("transport: participant unknown for adapter %q key %q — call UpsertParticipant first", e.AdapterName, e.Key)
+}
+
+func (e *ParticipantUnknownError) Is(target error) bool {
+	return target == ErrParticipantUnknown
+}
+
+// BindingChannelMissingError wraps [ErrBindingChannelMissing] with the channel
+// slug that was not found.
+type BindingChannelMissingError struct {
+	ChannelSlug string
+}
+
+func (e *BindingChannelMissingError) Error() string {
+	return fmt.Sprintf("transport: binding channel %q not found in broker", e.ChannelSlug)
+}
+
+func (e *BindingChannelMissingError) Is(target error) bool {
+	return target == ErrBindingChannelMissing
+}
+
+// RegistrationConflictError wraps [ErrRegistrationConflict] with the
+// conflicting slugs.
+type RegistrationConflictError struct {
+	AdapterName     string
+	Key             string
+	ExistingSlug    string
+	ConflictingSlug string
+}
+
+func (e *RegistrationConflictError) Error() string {
+	return fmt.Sprintf(
+		"transport: adapter %q key %q already mapped to member %q; cannot remap to %q",
+		e.AdapterName, e.Key, e.ExistingSlug, e.ConflictingSlug,
+	)
+}
+
+func (e *RegistrationConflictError) Is(target error) bool {
+	return target == ErrRegistrationConflict
+}

--- a/internal/team/transport/errors.go
+++ b/internal/team/transport/errors.go
@@ -14,7 +14,7 @@ var (
 	// adapter did not call [Host.UpsertParticipant] before sending the message.
 	// Remediation: call UpsertParticipant(ctx, p, b) immediately when a new
 	// external identity first contacts the adapter, then retry ReceiveMessage.
-	ErrParticipantUnknown = errors.New("transport: participant unknown — call UpsertParticipant first")
+	ErrParticipantUnknown = errors.New("transport: participant unknown: call UpsertParticipant first")
 
 	// ErrBindingChannelMissing is returned by [Host.ReceiveMessage] or at
 	// adapter registration time when the channel declared in [Binding.ChannelSlug]
@@ -33,13 +33,13 @@ var (
 	// not return within the configured timeout. The message has been dropped.
 	// Remediation: check the adapter's upstream connectivity and reduce message
 	// payload size if the upstream API has a latency limit.
-	ErrSendTimeout = errors.New("transport: send timed out — message dropped")
+	ErrSendTimeout = errors.New("transport: send timed out: message dropped")
 
 	// ErrHealthDegraded is returned by [Host.ReceiveMessage] when the broker
 	// has marked the adapter as degraded (e.g. repeated send failures) and is
 	// refusing further inbound messages until the adapter self-heals. The
 	// adapter should pause polling, run its reconnect logic, and retry.
-	ErrHealthDegraded = errors.New("transport: adapter health degraded — pause and reconnect")
+	ErrHealthDegraded = errors.New("transport: adapter health degraded: pause and reconnect")
 
 	// ErrRegistrationConflict is returned by [Host.UpsertParticipant] when
 	// the (AdapterName, Key) pair maps to a different member slug than already
@@ -58,7 +58,7 @@ type ParticipantUnknownError struct {
 }
 
 func (e *ParticipantUnknownError) Error() string {
-	return fmt.Sprintf("transport: participant unknown for adapter %q key %q — call UpsertParticipant first", e.AdapterName, e.Key)
+	return fmt.Sprintf("transport: participant unknown for adapter %q key %q: call UpsertParticipant first", e.AdapterName, e.Key)
 }
 
 func (e *ParticipantUnknownError) Is(target error) bool {

--- a/internal/team/transport/host_misuse_test.go
+++ b/internal/team/transport/host_misuse_test.go
@@ -12,6 +12,7 @@ package transport_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	. "github.com/nex-crm/wuphf/internal/team/transport"
@@ -92,32 +93,34 @@ func TestMisuse3_RegistrationConflict(t *testing.T) {
 	}
 }
 
-// TestMisuse4_SendTimeoutSentinel verifies that ErrSendTimeout can be detected
-// with errors.Is. Real enforcement happens in the Host worker; this test ensures
-// the sentinel is correctly defined and testable in adapter code. Pitfall #4.
+// TestMisuse4_SendTimeoutSentinel verifies that ErrSendTimeout survives wrapping
+// with fmt.Errorf. The Host worker wraps it before returning to the adapter, so
+// adapter code that does errors.Is(err, ErrSendTimeout) must match the wrapped form.
+// Pitfall #4.
 func TestMisuse4_SendTimeoutSentinel(t *testing.T) {
 	// Simulate the Host worker wrapping ErrSendTimeout with context.
-	wrapped := ErrSendTimeout
+	wrapped := fmt.Errorf("worker dropped message after 10s: %w", ErrSendTimeout)
 
 	if !errors.Is(wrapped, ErrSendTimeout) {
-		t.Fatalf("errors.Is(ErrSendTimeout): expected true, got false")
+		t.Fatalf("wrapped ErrSendTimeout: errors.Is expected true, got false")
 	}
 	// Confirm it does not accidentally match unrelated sentinels.
 	if errors.Is(wrapped, ErrParticipantUnknown) {
-		t.Fatal("ErrSendTimeout must not match ErrParticipantUnknown")
+		t.Fatal("wrapped ErrSendTimeout must not match ErrParticipantUnknown")
 	}
 }
 
-// TestMisuse5_HealthDegradedSentinel verifies ErrHealthDegraded is correctly
-// defined and errors.Is-matchable. Pitfall #5 — adapter ignoring degraded state.
+// TestMisuse5_HealthDegradedSentinel verifies ErrHealthDegraded survives wrapping
+// with fmt.Errorf. Pitfall #5 — adapter code must detect degraded state via
+// errors.Is even when the Host adds context to the error.
 func TestMisuse5_HealthDegradedSentinel(t *testing.T) {
-	wrapped := ErrHealthDegraded
+	wrapped := fmt.Errorf("host pausing inbound: %w", ErrHealthDegraded)
 
 	if !errors.Is(wrapped, ErrHealthDegraded) {
-		t.Fatalf("errors.Is(ErrHealthDegraded): expected true, got false")
+		t.Fatalf("wrapped ErrHealthDegraded: errors.Is expected true, got false")
 	}
 	if errors.Is(wrapped, ErrAdapterCrashed) {
-		t.Fatal("ErrHealthDegraded must not match ErrAdapterCrashed")
+		t.Fatal("wrapped ErrHealthDegraded must not match ErrAdapterCrashed")
 	}
 }
 

--- a/internal/team/transport/host_misuse_test.go
+++ b/internal/team/transport/host_misuse_test.go
@@ -1,0 +1,190 @@
+package transport_test
+
+// host_misuse_test.go asserts that the transport contract surfaces actionable
+// errors for the six most common adapter-authoring mistakes. Each test name
+// maps directly to a pitfall in docs/ADD-A-TRANSPORT.md §Common pitfalls so
+// contributors running `go test ./internal/team/transport/...` against their
+// adapter see exactly which contract they violated.
+//
+// These tests use fakeHost and the fake adapters from webhook_fake_test.go.
+// They do NOT start a real broker — they test the contract shape only.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	. "github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// TestMisuse1_ReceiveWithoutUpsert verifies that a host correctly returns
+// ErrParticipantUnknown when ReceiveMessage is called without a prior
+// UpsertParticipant. This is pitfall #1 in ADD-A-TRANSPORT.md.
+func TestMisuse1_ReceiveWithoutUpsert(t *testing.T) {
+	host := &fakeHost{
+		receiveErr: &ParticipantUnknownError{AdapterName: "telegram", Key: "12345"},
+	}
+
+	err := host.ReceiveMessage(context.Background(), Message{
+		Participant: Participant{AdapterName: "telegram", Key: "12345", DisplayName: "Alice"},
+		Binding:     Binding{Scope: ScopeChannel, ChannelSlug: "general"},
+		Text:        "hello",
+	})
+
+	if err == nil {
+		t.Fatal("expected ErrParticipantUnknown, got nil")
+	}
+	if !errors.Is(err, ErrParticipantUnknown) {
+		t.Fatalf("expected ErrParticipantUnknown, got %v", err)
+	}
+}
+
+// TestMisuse2_BindingChannelMissing verifies that declaring a non-existent
+// channel in Binding produces ErrBindingChannelMissing. This is pitfall #2.
+func TestMisuse2_BindingChannelMissing(t *testing.T) {
+	host := &fakeHost{
+		receiveErr: &BindingChannelMissingError{ChannelSlug: "nonexistent"},
+	}
+
+	// Upsert succeeds (channel check happens at ReceiveMessage time).
+	if err := host.UpsertParticipant(context.Background(),
+		Participant{AdapterName: "telegram", Key: "42", DisplayName: "Bob"},
+		Binding{Scope: ScopeChannel, ChannelSlug: "nonexistent"},
+	); err != nil {
+		t.Fatalf("upsert: unexpected error: %v", err)
+	}
+
+	err := host.ReceiveMessage(context.Background(), Message{
+		Participant: Participant{AdapterName: "telegram", Key: "42"},
+		Binding:     Binding{Scope: ScopeChannel, ChannelSlug: "nonexistent"},
+		Text:        "msg",
+	})
+	if err == nil {
+		t.Fatal("expected ErrBindingChannelMissing, got nil")
+	}
+	if !errors.Is(err, ErrBindingChannelMissing) {
+		t.Fatalf("expected ErrBindingChannelMissing, got %v", err)
+	}
+}
+
+// TestMisuse3_RegistrationConflict verifies that re-registering an
+// (AdapterName, Key) pair with a different member slug returns
+// ErrRegistrationConflict. This is pitfall #3 — unstable session keys.
+func TestMisuse3_RegistrationConflict(t *testing.T) {
+	host := &fakeHost{
+		upsertErr: &RegistrationConflictError{
+			AdapterName:     "openclaw",
+			Key:             "sess-abc",
+			ExistingSlug:    "alice",
+			ConflictingSlug: "bob",
+		},
+	}
+
+	err := host.UpsertParticipant(context.Background(),
+		Participant{AdapterName: "openclaw", Key: "sess-abc", DisplayName: "Bob"},
+		Binding{Scope: ScopeMember},
+	)
+	if err == nil {
+		t.Fatal("expected ErrRegistrationConflict, got nil")
+	}
+	if !errors.Is(err, ErrRegistrationConflict) {
+		t.Fatalf("expected ErrRegistrationConflict, got %v", err)
+	}
+}
+
+// TestMisuse4_SendTimeoutSentinel verifies that ErrSendTimeout can be detected
+// with errors.Is. Real enforcement happens in the Host worker; this test ensures
+// the sentinel is correctly defined and testable in adapter code. Pitfall #4.
+func TestMisuse4_SendTimeoutSentinel(t *testing.T) {
+	// Simulate the Host worker wrapping ErrSendTimeout with context.
+	wrapped := ErrSendTimeout
+
+	if !errors.Is(wrapped, ErrSendTimeout) {
+		t.Fatalf("errors.Is(ErrSendTimeout): expected true, got false")
+	}
+	// Confirm it does not accidentally match unrelated sentinels.
+	if errors.Is(wrapped, ErrParticipantUnknown) {
+		t.Fatal("ErrSendTimeout must not match ErrParticipantUnknown")
+	}
+}
+
+// TestMisuse5_HealthDegradedSentinel verifies ErrHealthDegraded is correctly
+// defined and errors.Is-matchable. Pitfall #5 — adapter ignoring degraded state.
+func TestMisuse5_HealthDegradedSentinel(t *testing.T) {
+	wrapped := ErrHealthDegraded
+
+	if !errors.Is(wrapped, ErrHealthDegraded) {
+		t.Fatalf("errors.Is(ErrHealthDegraded): expected true, got false")
+	}
+	if errors.Is(wrapped, ErrAdapterCrashed) {
+		t.Fatal("ErrHealthDegraded must not match ErrAdapterCrashed")
+	}
+}
+
+// TestMisuse6_UpsertBeforeReceive verifies the correct flow: UpsertParticipant
+// followed by ReceiveMessage succeeds with a compliant fakeHost. This is the
+// positive control — if this test fails the fakeHost or contract type has a bug.
+func TestMisuse6_UpsertBeforeReceive(t *testing.T) {
+	host := &fakeHost{}
+	ctx := context.Background()
+
+	p := Participant{AdapterName: "telegram", Key: "99", DisplayName: "Carol", Human: true}
+	b := Binding{Scope: ScopeChannel, ChannelSlug: "general"}
+
+	if err := host.UpsertParticipant(ctx, p, b); err != nil {
+		t.Fatalf("UpsertParticipant: unexpected error: %v", err)
+	}
+	if err := host.ReceiveMessage(ctx, Message{
+		Participant: p,
+		Binding:     b,
+		Text:        "ping",
+	}); err != nil {
+		t.Fatalf("ReceiveMessage: unexpected error: %v", err)
+	}
+
+	host.mu.Lock()
+	defer host.mu.Unlock()
+	if len(host.upserted) != 1 {
+		t.Fatalf("expected 1 upsert, got %d", len(host.upserted))
+	}
+	if len(host.received) != 1 {
+		t.Fatalf("expected 1 received message, got %d", len(host.received))
+	}
+	if host.received[0].Text != "ping" {
+		t.Fatalf("expected message text %q, got %q", "ping", host.received[0].Text)
+	}
+}
+
+// TestFakeAdaptersSatisfyInterfaces is a compile-time assertion that the three
+// fake adapters implement their respective Transport interfaces. The test body
+// is empty — the var block fails at compile time if any interface is unmet.
+func TestFakeAdaptersSatisfyInterfaces(t *testing.T) {
+	var _ Transport = (*fakeChannelTransport)(nil)
+	var _ MemberBoundTransport = (*fakeMemberTransport)(nil)
+	var _ OfficeBoundTransport = (*fakeOfficeTransport)(nil)
+	var _ Host = (*fakeHost)(nil)
+}
+
+// TestHealthStateConstants verifies all HealthState constants are distinct.
+func TestHealthStateConstants(t *testing.T) {
+	states := []HealthState{HealthConnected, HealthDegraded, HealthDisconnected}
+	seen := make(map[HealthState]bool)
+	for _, s := range states {
+		if seen[s] {
+			t.Fatalf("duplicate HealthState value: %q", s)
+		}
+		seen[s] = true
+	}
+}
+
+// TestScopeConstants verifies all Scope constants are distinct.
+func TestScopeConstants(t *testing.T) {
+	scopes := []Scope{ScopeChannel, ScopeMember, ScopeOffice}
+	seen := make(map[Scope]bool)
+	for _, s := range scopes {
+		if seen[s] {
+			t.Fatalf("duplicate Scope value: %q", s)
+		}
+		seen[s] = true
+	}
+}

--- a/internal/team/transport/transport.go
+++ b/internal/team/transport/transport.go
@@ -8,7 +8,7 @@ import "context"
 // implement [MemberBoundTransport] or [OfficeBoundTransport], which embed
 // Transport.
 //
-// Implementing Transport
+// # Implementing Transport
 //
 // An adapter must:
 //  1. Return a stable, unique name from [Name] (used as the AdapterName key
@@ -73,7 +73,7 @@ type Transport interface {
 // identity becomes an office member (e.g. OpenClaw). The adapter manages
 // session lifecycle; the Host manages member identity in the broker.
 //
-// Implementing MemberBoundTransport
+// # Implementing MemberBoundTransport
 //
 // In addition to [Transport] requirements:
 //  1. Call [Host.UpsertParticipant] when a new session is created or
@@ -110,7 +110,7 @@ type MemberBoundTransport interface {
 // the whole office (e.g. human-share invite links). The adapter manages invite
 // tokens and session cookies; the Host manages admitted-human identity.
 //
-// Implementing OfficeBoundTransport
+// # Implementing OfficeBoundTransport
 //
 // In addition to [Transport] requirements:
 //  1. Call [Host.UpsertParticipant] when a new human is admitted. The Host

--- a/internal/team/transport/transport.go
+++ b/internal/team/transport/transport.go
@@ -157,7 +157,9 @@ type Host interface {
 	// writes the message to the broker under the broker mutex, and returns nil
 	// on success. Possible errors: [ErrParticipantUnknown] (adapter forgot to
 	// call UpsertParticipant first), [ErrBindingChannelMissing] (the declared
-	// channel no longer exists), [ErrAdapterCrashed] (broker panic recovered).
+	// channel no longer exists). [ErrAdapterCrashed] (broker panic recovered)
+	// is reserved for Phase 2b when the real dispatch path adds a recover()
+	// wrapper — the Phase 1 stub does not return it.
 	//
 	// Pitfall: always call UpsertParticipant before the first ReceiveMessage
 	// for a new external identity. Skipping this returns ErrParticipantUnknown.

--- a/internal/team/transport/transport.go
+++ b/internal/team/transport/transport.go
@@ -131,9 +131,11 @@ type OfficeBoundTransport interface {
 	// The adapter is responsible for persisting the token across restarts.
 	CreateInvite(ctx context.Context, network string) (inviteURL string, err error)
 
-	// RevokeInvite invalidates the invite identified by inviteID. Active
-	// sessions that were admitted via this invite are terminated by the adapter.
-	// The Host calls [Host.RevokeParticipant] for each affected admitted human.
+	// RevokeInvite invalidates the invite identified by inviteID. The adapter
+	// terminates any active sessions admitted via this invite and calls
+	// [Host.RevokeParticipant] for each affected admitted human before returning.
+	// The Host does not call RevokeParticipant automatically — the adapter is
+	// responsible for the full teardown sequence.
 	RevokeInvite(ctx context.Context, inviteID string) error
 }
 

--- a/internal/team/transport/transport.go
+++ b/internal/team/transport/transport.go
@@ -1,0 +1,185 @@
+package transport
+
+import "context"
+
+// Transport is the base adapter interface — implemented by all external
+// message adapters regardless of scope. Channel-bound adapters (Telegram)
+// implement this interface directly. Member-bound and office-bound adapters
+// implement [MemberBoundTransport] or [OfficeBoundTransport], which embed
+// Transport.
+//
+// Implementing Transport
+//
+// An adapter must:
+//  1. Return a stable, unique name from [Name] (used as the AdapterName key
+//     in every [Participant] the adapter creates — changing it between
+//     releases loses participant identity across restarts).
+//  2. Return the scope declaration from [Binding]. The Host uses Binding.Scope
+//     to route inbound messages; an incorrect scope causes silent misrouting.
+//  3. Block in [Run] until ctx is cancelled. The Host supervises Run in a
+//     dedicated goroutine; if Run returns a non-nil error the Host applies
+//     backoff and calls Run again. Run returning nil means intentional shutdown.
+//  4. Send one outbound message per [Send] call. Send should respect ctx for
+//     timeouts. If Send blocks longer than the Host-configured timeout the
+//     Host logs the delay and drops the message (visible failure, not silent).
+//  5. Return a non-stale [Health] snapshot from [Health]. This is called on
+//     every channel-header render — it must be O(1) (read from a cached field,
+//     not a network call).
+//
+// Pitfalls (see docs/ADD-A-TRANSPORT.md for full list):
+//   - Call [Host.UpsertParticipant] before the first [Host.ReceiveMessage] for
+//     any new external identity. Skipping this causes [ErrParticipantUnknown].
+//   - Do not import internal/team from inside this package. The one-way
+//     compile boundary (team → transport) is the core contract invariant.
+//   - Channel-bound adapters: declare the bound channel slug in [Binding] and
+//     verify it exists in the broker before calling [Run]. If the channel was
+//     deleted, [Run] will receive [ErrBindingChannelMissing] on its first
+//     [Host.ReceiveMessage] call and should shut down gracefully.
+type Transport interface {
+	// Name returns the stable, unique adapter name (e.g. "telegram", "openclaw",
+	// "share"). Used as AdapterName in all Participant values the adapter creates.
+	// Must be a valid Go identifier (lowercase, no spaces).
+	Name() string
+
+	// Binding returns the scope and anchor of this adapter within the office.
+	// Called once at registration; the result is cached by the Host. If the
+	// binding references a channel or member that does not exist the Host returns
+	// [ErrBindingChannelMissing] or [ErrParticipantUnknown] at registration time.
+	Binding() Binding
+
+	// Run starts the adapter and blocks until ctx is cancelled or an
+	// unrecoverable error occurs. The Host calls Run in a dedicated goroutine;
+	// returning a non-nil error triggers supervised reconnection with backoff.
+	// Returning nil means intentional shutdown — the Host will not reconnect.
+	//
+	// The adapter calls host.ReceiveMessage for each inbound message and keeps
+	// host.UpsertParticipant current for each external identity it encounters.
+	Run(ctx context.Context, host Host) error
+
+	// Send delivers one outbound message from the office to the external network.
+	// The Host calls Send from a per-transport worker goroutine (not the broker's
+	// hot path). Send should time-out or return an error rather than block
+	// indefinitely; the Host will log and discard messages that exceed the
+	// configured send timeout.
+	Send(ctx context.Context, msg Outbound) error
+
+	// Health returns a point-in-time snapshot of adapter connectivity. Called
+	// on every channel-header render — must be O(1) (read from a cached field).
+	// Never make a network call inside Health.
+	Health() Health
+}
+
+// MemberBoundTransport is implemented by adapters where each bridged external
+// identity becomes an office member (e.g. OpenClaw). The adapter manages
+// session lifecycle; the Host manages member identity in the broker.
+//
+// Implementing MemberBoundTransport
+//
+// In addition to [Transport] requirements:
+//  1. Call [Host.UpsertParticipant] when a new session is created or
+//     reconnected. The Host creates (or finds) the corresponding office member.
+//  2. Call [Host.DetachParticipant] when a session ends permanently. The Host
+//     marks the member offline in the broker.
+//  3. [CreateSession]: the Host calls this when a user hires a new agent from
+//     the web UI. The adapter creates the upstream session and returns its key.
+//  4. [AttachSlug] / [DetachSlug]: called by the Host when an office member
+//     slug is bound to or unbound from an adapter session. The adapter uses
+//     these to maintain its slug→key and key→slug maps for routing outbound
+//     messages to the correct session.
+type MemberBoundTransport interface {
+	Transport
+
+	// CreateSession creates a new upstream session for the given agentID and
+	// human-readable label. Returns the opaque session key the adapter will use
+	// to correlate future events. The Host stores the key and calls [AttachSlug]
+	// immediately after.
+	CreateSession(ctx context.Context, agentID, label string) (sessionKey string, err error)
+
+	// AttachSlug binds an office member slug to a session key. The adapter
+	// should update its internal slug→key and key→slug maps under its own lock.
+	// Called by the Host after [CreateSession] and on reconnect.
+	AttachSlug(slug, sessionKey string)
+
+	// DetachSlug removes the binding between slug and its session key. Called
+	// by the Host when the office member is removed or the session is terminated
+	// by the upstream service.
+	DetachSlug(slug string)
+}
+
+// OfficeBoundTransport is implemented by adapters that admit external humans to
+// the whole office (e.g. human-share invite links). The adapter manages invite
+// tokens and session cookies; the Host manages admitted-human identity.
+//
+// Implementing OfficeBoundTransport
+//
+// In addition to [Transport] requirements:
+//  1. Call [Host.UpsertParticipant] when a new human is admitted. The Host
+//     creates a temporary office member for the admitted human.
+//  2. Call [Host.RevokeParticipant] when an invite is revoked or the session
+//     cookie expires. The Host removes the admitted human from the broker.
+//  3. [CreateInvite]: the Host calls this when an office admin creates a new
+//     invite link. The adapter generates the token, stores it, and returns the
+//     shareable URL.
+//  4. [RevokeInvite]: the Host calls this when the admin revokes an existing
+//     invite. The adapter invalidates the token and closes any active sessions
+//     using it.
+type OfficeBoundTransport interface {
+	Transport
+
+	// CreateInvite creates a new invite token for the given network binding
+	// (e.g. Tailscale, LAN, public). Returns the shareable invite URL.
+	// The adapter is responsible for persisting the token across restarts.
+	CreateInvite(ctx context.Context, network string) (inviteURL string, err error)
+
+	// RevokeInvite invalidates the invite identified by inviteID. Active
+	// sessions that were admitted via this invite are terminated by the adapter.
+	// The Host calls [Host.RevokeParticipant] for each affected admitted human.
+	RevokeInvite(ctx context.Context, inviteID string) error
+}
+
+// Host is the broker-side interface that adapters use to interact with the
+// office. The Host implementation lives in internal/team/broker_transport.go.
+// Adapters receive a Host when [Transport.Run] is called and use only this
+// interface — they never import internal/team directly.
+//
+// The Host guarantees:
+//   - [ReceiveMessage] is goroutine-safe. Multiple adapter goroutines may call
+//     it concurrently.
+//   - [UpsertParticipant] is idempotent. Call it every time you encounter a
+//     participant, not just on first contact. The Host coalesces by (AdapterName, Key).
+//   - All methods respect the ctx passed to [Transport.Run]. When ctx is
+//     cancelled the Host returns promptly so the adapter can shut down cleanly.
+//
+// See docs/ADD-A-TRANSPORT.md §Host contract for the full invariant table.
+type Host interface {
+	// ReceiveMessage delivers an inbound message from an external participant
+	// to the office. The Host resolves the binding to the correct channel,
+	// writes the message to the broker under the broker mutex, and returns nil
+	// on success. Possible errors: [ErrParticipantUnknown] (adapter forgot to
+	// call UpsertParticipant first), [ErrBindingChannelMissing] (the declared
+	// channel no longer exists), [ErrAdapterCrashed] (broker panic recovered).
+	//
+	// Pitfall: always call UpsertParticipant before the first ReceiveMessage
+	// for a new external identity. Skipping this returns ErrParticipantUnknown.
+	ReceiveMessage(ctx context.Context, msg Message) error
+
+	// UpsertParticipant registers or refreshes an external identity in the
+	// broker. Idempotent: safe to call on every inbound event. The Host creates
+	// a broker member for new identities and updates DisplayName/Human for
+	// existing ones. Returns nil on success; returns [ErrRegistrationConflict]
+	// if (AdapterName, Key) maps to a different member slug than the one already
+	// registered (adapter restart with a conflicting key assignment).
+	UpsertParticipant(ctx context.Context, p Participant, b Binding) error
+
+	// DetachParticipant marks the participant identified by (adapterName, key)
+	// as offline in the broker. Called by member-bound and office-bound adapters
+	// when a session or invite expires. Idempotent: no-op if the participant is
+	// not known.
+	DetachParticipant(ctx context.Context, adapterName, key string) error
+
+	// RevokeParticipant removes the admitted human identified by (adapterName,
+	// key) from the broker. Called by office-bound adapters when an invite is
+	// revoked. More permanent than DetachParticipant: the member record is
+	// deleted, not just marked offline.
+	RevokeParticipant(ctx context.Context, adapterName, key string) error
+}

--- a/internal/team/transport/types.go
+++ b/internal/team/transport/types.go
@@ -1,7 +1,7 @@
 // Package transport defines the contract between the WUPHF broker and external
 // message adapters (Telegram, OpenClaw, human-share, and future integrations).
 //
-// Architecture summary
+// # Architecture summary
 //
 // The broker is the authority for office state. Adapters are reactive: they
 // emit inbound messages via [Host.ReceiveMessage] and receive outbound messages
@@ -18,7 +18,7 @@
 //   - [OfficeBoundTransport] — office-bound (e.g. human-share). Admitted
 //     humans interact with the whole office, not a single channel or member.
 //
-// Package boundary
+// # Package boundary
 //
 // This package imports only the standard library and external SDKs. It does
 // NOT import internal/team. The broker imports this package and implements

--- a/internal/team/transport/types.go
+++ b/internal/team/transport/types.go
@@ -1,0 +1,154 @@
+// Package transport defines the contract between the WUPHF broker and external
+// message adapters (Telegram, OpenClaw, human-share, and future integrations).
+//
+// Architecture summary
+//
+// The broker is the authority for office state. Adapters are reactive: they
+// emit inbound messages via [Host.ReceiveMessage] and receive outbound messages
+// via [Transport.Send]. The Host owns the subscriber loop and per-transport
+// worker goroutines so a slow adapter never blocks another.
+//
+// Three adapter scopes:
+//
+//   - [Transport] — channel-bound (e.g. Telegram). One external chat maps to
+//     one office channel.
+//   - [MemberBoundTransport] — member-bound (e.g. OpenClaw). Each bridged
+//     session becomes an office member; the adapter manages its own session
+//     lifecycle.
+//   - [OfficeBoundTransport] — office-bound (e.g. human-share). Admitted
+//     humans interact with the whole office, not a single channel or member.
+//
+// Package boundary
+//
+// This package imports only the standard library and external SDKs. It does
+// NOT import internal/team. The broker imports this package and implements
+// [Host]. Adapters implement one of the Transport sub-interfaces. Go's import
+// rules make the one-way arrow (team → transport) a compile-time invariant:
+// any future PR that needs broker internals from inside an adapter MUST extend
+// [Host] instead, keeping the boundary visible at review time.
+//
+// See docs/ADD-A-TRANSPORT.md for a step-by-step contributor guide.
+package transport
+
+import "time"
+
+// Scope declares where an adapter binds within the office.
+type Scope string
+
+const (
+	// ScopeChannel is for adapters that map one external chat to one office
+	// channel (e.g. Telegram group → #standup).
+	ScopeChannel Scope = "channel"
+
+	// ScopeMember is for adapters where each bridged session becomes an office
+	// member (e.g. OpenClaw agent hired via the web UI).
+	ScopeMember Scope = "member"
+
+	// ScopeOffice is for adapters that admit an external human to the whole
+	// office (e.g. human-share invite link).
+	ScopeOffice Scope = "office"
+)
+
+// Binding declares how an adapter attaches to the office. The fields that
+// apply depend on Scope:
+//
+//   - ScopeChannel: ChannelSlug is required; MemberSlug is empty.
+//   - ScopeMember:  MemberSlug is required; ChannelSlug is empty.
+//   - ScopeOffice:  both are empty (office-wide scope has no single anchor).
+type Binding struct {
+	Scope       Scope
+	ChannelSlug string
+	MemberSlug  string
+}
+
+// Participant identifies the external identity behind a message. The Host uses
+// (AdapterName, Key) as a stable composite key across restarts to deduplicate
+// participants and avoid creating duplicate members.
+type Participant struct {
+	// AdapterName must match [Transport.Name]. The Host uses this to namespace
+	// participant keys across adapter types.
+	AdapterName string
+	// Key is the adapter-internal, stable identifier for this participant
+	// (e.g. Telegram user ID as string, OpenClaw session key, share token).
+	// Must be stable across broker restarts.
+	Key string
+	// DisplayName is the human-readable name shown in the office. The Host
+	// may override this from its member store if the participant has connected
+	// before.
+	DisplayName string
+	// Human is true when the participant is a human (as opposed to an AI agent
+	// or automated bot). The broker uses this for attribution and rate-limiting.
+	Human bool
+}
+
+// Message is an inbound message from an external participant to the office.
+// The adapter constructs this and passes it to [Host.ReceiveMessage].
+type Message struct {
+	// Participant is who sent the message. For channel-bound adapters this is
+	// the Telegram user; for member-bound this is the OpenClaw session acting
+	// as a member; for office-bound this is the admitted human.
+	Participant Participant
+	// Binding is where the message should land in the office. The Host uses
+	// Binding.Scope to decide routing: channel-bound posts into ChannelSlug;
+	// member-bound routes to the last channel the member addressed; office-bound
+	// posts as the admitted human into whatever channel they addressed.
+	Binding Binding
+	// Text is the message body. Adapters perform any network-layer decoding
+	// (e.g. HTML entity unescaping from Telegram) before setting this field.
+	Text string
+	// ExternalID is an opaque, adapter-specific message identifier used by the
+	// Host to deduplicate at-least-once delivery across restarts. Adapters that
+	// guarantee at-most-once delivery may leave this empty; the Host will not
+	// apply deduplication.
+	ExternalID string
+	// ThreadKey is optional and opaque to the contract. Adapters that support
+	// threading (e.g. Telegram reply-to message_id) populate this field; it
+	// travels with the message so the Host can echo it back on [Outbound] for
+	// the adapter to use when sending a threaded reply.
+	ThreadKey string
+}
+
+// Outbound is a message from the office to an external participant. The Host
+// constructs this and delivers it to the per-transport worker goroutine, which
+// calls [Transport.Send].
+type Outbound struct {
+	// Participant is who the office is replying to. Channel-bound adapters may
+	// ignore this (reply goes to the bound chat); member-bound and office-bound
+	// adapters use it to find the right session or admitted-human socket.
+	Participant Participant
+	// Binding matches the Binding that produced the original inbound message,
+	// so the adapter can correlate the reply to the correct chat/session.
+	Binding Binding
+	// Text is the message body to deliver.
+	Text string
+	// ThreadKey is echoed from the inbound [Message.ThreadKey]. Adapters that
+	// support threading use this to send a threaded reply; adapters that do not
+	// support threading ignore it.
+	ThreadKey string
+}
+
+// HealthState is the connection state of an adapter.
+type HealthState string
+
+const (
+	// HealthConnected means the adapter is actively polling or subscribed and
+	// has received a successful response within the expected polling window.
+	HealthConnected HealthState = "connected"
+	// HealthDegraded means the adapter is running but has experienced recent
+	// errors. It may recover without intervention (transient network issue) or
+	// may require user action (token revoked).
+	HealthDegraded HealthState = "degraded"
+	// HealthDisconnected means the adapter is not running or has given up
+	// reconnecting (circuit breaker open).
+	HealthDisconnected HealthState = "disconnected"
+)
+
+// Health is a point-in-time snapshot of adapter health. The Host reads this
+// via [Transport.Health] to surface a per-channel status indicator in the UI.
+type Health struct {
+	State         HealthState
+	LastSuccessAt time.Time
+	// LastError is the most recent error the adapter encountered, or nil if
+	// the adapter has never errored or has recovered.
+	LastError error
+}

--- a/internal/team/transport/webhook_fake_test.go
+++ b/internal/team/transport/webhook_fake_test.go
@@ -1,0 +1,265 @@
+package transport_test
+
+// webhook_fake_test.go provides minimal fake adapters for each Transport scope
+// used as canonical examples in host_misuse_test.go. Reading this file alongside
+// docs/ADD-A-TRANSPORT.md is the recommended starting point for contributors
+// implementing a new integration.
+//
+// Each fake covers the minimum contract surface:
+//   - fakeChannelTransport — channel-bound (ScopeChannel), mirrors Telegram.
+//   - fakeMemberTransport  — member-bound (ScopeMember), mirrors OpenClaw.
+//   - fakeOfficeTransport  — office-bound (ScopeOffice), mirrors human-share.
+//
+// All fakes are intentionally minimal and do NOT simulate reconnect, backoff,
+// or deduplication — those are adapter-specific concerns, not contract concerns.
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	. "github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// ---- channel-bound fake ------------------------------------------------
+
+type fakeChannelTransport struct {
+	name        string
+	channelSlug string
+
+	mu          sync.Mutex
+	sent        []Outbound
+	healthState HealthState
+}
+
+func newFakeChannelTransport(name, channelSlug string) *fakeChannelTransport {
+	return &fakeChannelTransport{
+		name:        name,
+		channelSlug: channelSlug,
+		healthState: HealthConnected,
+	}
+}
+
+func (f *fakeChannelTransport) Name() string { return f.name }
+
+func (f *fakeChannelTransport) Binding() Binding {
+	return Binding{Scope: ScopeChannel, ChannelSlug: f.channelSlug}
+}
+
+// Run blocks until ctx is cancelled. In a real adapter this is where the
+// long-poll or WebSocket loop lives. The fake accepts an optional inject
+// channel so tests can drive inbound messages.
+func (f *fakeChannelTransport) Run(ctx context.Context, host Host) error {
+	// Fake: nothing to poll. Block until shutdown.
+	<-ctx.Done()
+	return nil
+}
+
+func (f *fakeChannelTransport) Send(_ context.Context, msg Outbound) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, msg)
+	return nil
+}
+
+func (f *fakeChannelTransport) Health() Health {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return Health{
+		State:         f.healthState,
+		LastSuccessAt: time.Now(),
+	}
+}
+
+func (f *fakeChannelTransport) sentMessages() []Outbound {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]Outbound, len(f.sent))
+	copy(out, f.sent)
+	return out
+}
+
+// ---- member-bound fake -------------------------------------------------
+
+type fakeMemberTransport struct {
+	name string
+
+	mu          sync.Mutex
+	sessions    map[string]string // sessionKey -> slug
+	slugs       map[string]string // slug -> sessionKey
+	sent        []Outbound
+	healthState HealthState
+}
+
+func newFakeMemberTransport(name string) *fakeMemberTransport {
+	return &fakeMemberTransport{
+		name:        name,
+		sessions:    make(map[string]string),
+		slugs:       make(map[string]string),
+		healthState: HealthConnected,
+	}
+}
+
+func (f *fakeMemberTransport) Name() string { return f.name }
+
+func (f *fakeMemberTransport) Binding() Binding {
+	// Member-bound adapters have no channel anchor; slug is resolved per-session.
+	return Binding{Scope: ScopeMember}
+}
+
+func (f *fakeMemberTransport) Run(ctx context.Context, host Host) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (f *fakeMemberTransport) Send(_ context.Context, msg Outbound) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, msg)
+	return nil
+}
+
+func (f *fakeMemberTransport) Health() Health {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return Health{State: f.healthState, LastSuccessAt: time.Now()}
+}
+
+// CreateSession satisfies MemberBoundTransport. The fake returns a deterministic
+// key so tests can assert routing without real upstream calls.
+func (f *fakeMemberTransport) CreateSession(_ context.Context, agentID, label string) (string, error) {
+	key := "fake-session-" + agentID + "-" + label
+	return key, nil
+}
+
+func (f *fakeMemberTransport) AttachSlug(slug, sessionKey string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.slugs[slug] = sessionKey
+	f.sessions[sessionKey] = slug
+}
+
+func (f *fakeMemberTransport) DetachSlug(slug string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := f.slugs[slug]
+	delete(f.slugs, slug)
+	delete(f.sessions, key)
+}
+
+// ---- office-bound fake -------------------------------------------------
+
+type fakeOfficeTransport struct {
+	name string
+
+	mu          sync.Mutex
+	invites     map[string]string // inviteID -> URL
+	sent        []Outbound
+	healthState HealthState
+}
+
+func newFakeOfficeTransport(name string) *fakeOfficeTransport {
+	return &fakeOfficeTransport{
+		name:        name,
+		invites:     make(map[string]string),
+		healthState: HealthConnected,
+	}
+}
+
+func (f *fakeOfficeTransport) Name() string { return f.name }
+
+func (f *fakeOfficeTransport) Binding() Binding {
+	return Binding{Scope: ScopeOffice}
+}
+
+func (f *fakeOfficeTransport) Run(ctx context.Context, host Host) error {
+	<-ctx.Done()
+	return nil
+}
+
+func (f *fakeOfficeTransport) Send(_ context.Context, msg Outbound) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, msg)
+	return nil
+}
+
+func (f *fakeOfficeTransport) Health() Health {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return Health{State: f.healthState, LastSuccessAt: time.Now()}
+}
+
+func (f *fakeOfficeTransport) CreateInvite(_ context.Context, network string) (string, error) {
+	id := "invite-" + network + "-1"
+	url := "https://office.example.com/join/" + id
+	f.mu.Lock()
+	f.invites[id] = url
+	f.mu.Unlock()
+	return url, nil
+}
+
+func (f *fakeOfficeTransport) RevokeInvite(_ context.Context, inviteID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.invites, inviteID)
+	return nil
+}
+
+// ---- fakeHost ----------------------------------------------------------
+// fakeHost records calls so misuse tests can assert which Host methods were
+// called and in what order.
+
+type fakeHost struct {
+	mu                sync.Mutex
+	upserted          []upsertCall
+	received          []Message
+	detached          []detachCall
+	revoked           []detachCall
+	receiveErr        error // if set, returned from ReceiveMessage
+	upsertErr         error // if set, returned from UpsertParticipant
+}
+
+type upsertCall struct {
+	Participant Participant
+	Binding     Binding
+}
+
+type detachCall struct {
+	AdapterName string
+	Key         string
+}
+
+func (h *fakeHost) ReceiveMessage(_ context.Context, msg Message) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.receiveErr != nil {
+		return h.receiveErr
+	}
+	h.received = append(h.received, msg)
+	return nil
+}
+
+func (h *fakeHost) UpsertParticipant(_ context.Context, p Participant, b Binding) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.upsertErr != nil {
+		return h.upsertErr
+	}
+	h.upserted = append(h.upserted, upsertCall{p, b})
+	return nil
+}
+
+func (h *fakeHost) DetachParticipant(_ context.Context, adapterName, key string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.detached = append(h.detached, detachCall{adapterName, key})
+	return nil
+}
+
+func (h *fakeHost) RevokeParticipant(_ context.Context, adapterName, key string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.revoked = append(h.revoked, detachCall{adapterName, key})
+	return nil
+}

--- a/internal/team/transport/webhook_fake_test.go
+++ b/internal/team/transport/webhook_fake_test.go
@@ -47,10 +47,8 @@ func (f *fakeChannelTransport) Binding() Binding {
 }
 
 // Run blocks until ctx is cancelled. In a real adapter this is where the
-// long-poll or WebSocket loop lives. The fake accepts an optional inject
-// channel so tests can drive inbound messages.
+// long-poll or WebSocket loop lives.
 func (f *fakeChannelTransport) Run(ctx context.Context, host Host) error {
-	// Fake: nothing to poll. Block until shutdown.
 	<-ctx.Done()
 	return nil
 }

--- a/internal/team/transport/webhook_fake_test.go
+++ b/internal/team/transport/webhook_fake_test.go
@@ -135,6 +135,11 @@ func (f *fakeMemberTransport) CreateSession(_ context.Context, agentID, label st
 func (f *fakeMemberTransport) AttachSlug(slug, sessionKey string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	// Remove stale reverse entry before overwriting, so a slug reassignment
+	// does not leave the old sessionKey mapped to this slug indefinitely.
+	if oldKey, ok := f.slugs[slug]; ok {
+		delete(f.sessions, oldKey)
+	}
 	f.slugs[slug] = sessionKey
 	f.sessions[sessionKey] = slug
 }
@@ -233,20 +238,20 @@ type detachCall struct {
 func (h *fakeHost) ReceiveMessage(_ context.Context, msg Message) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	h.received = append(h.received, msg)
 	if h.receiveErr != nil {
 		return h.receiveErr
 	}
-	h.received = append(h.received, msg)
 	return nil
 }
 
 func (h *fakeHost) UpsertParticipant(_ context.Context, p Participant, b Binding) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	h.upserted = append(h.upserted, upsertCall{p, b})
 	if h.upsertErr != nil {
 		return h.upsertErr
 	}
-	h.upserted = append(h.upserted, upsertCall{p, b})
 	return nil
 }
 

--- a/internal/team/transport/webhook_fake_test.go
+++ b/internal/team/transport/webhook_fake_test.go
@@ -211,13 +211,13 @@ func (f *fakeOfficeTransport) RevokeInvite(_ context.Context, inviteID string) e
 // called and in what order.
 
 type fakeHost struct {
-	mu                sync.Mutex
-	upserted          []upsertCall
-	received          []Message
-	detached          []detachCall
-	revoked           []detachCall
-	receiveErr        error // if set, returned from ReceiveMessage
-	upsertErr         error // if set, returned from UpsertParticipant
+	mu         sync.Mutex
+	upserted   []upsertCall
+	received   []Message
+	detached   []detachCall
+	revoked    []detachCall
+	receiveErr error // if set, returned from ReceiveMessage
+	upsertErr  error // if set, returned from UpsertParticipant
 }
 
 type upsertCall struct {


### PR DESCRIPTION
## Summary

Phase 1 of the unified gateway refactor ([design doc](https://github.com/nex-crm/wuphf/blob/feat/transport-contract/docs/ADD-A-TRANSPORT.md), approved 2026-05-04). Establishes the typed `transport` contract that Telegram, OpenClaw, and human-share will migrate onto in subsequent phases.

**broker.go diff: zero.** No existing behaviour changes in this PR.

### What ships

| File | Role |
|---|---|
| `internal/team/transport/types.go` | `Scope`, `Binding`, `Participant`, `Message`, `Outbound`, `Health` types |
| `internal/team/transport/transport.go` | `Transport`, `MemberBoundTransport`, `OfficeBoundTransport`, `Host` interfaces + full godoc |
| `internal/team/transport/errors.go` | 6 typed sentinel errors + wrapped types with `errors.Is` support |
| `internal/team/transport/webhook_fake_test.go` | Canonical fake adapters for all 3 scopes — reading start-point for contributors |
| `internal/team/transport/host_misuse_test.go` | 8 tests: 6 misuse paths + compile-time interface assertions |
| `internal/team/broker_transport.go` | `transport.Host` stub backed by `Broker`; stubs return informative errors until phase 2b |
| `internal/team/launcher_transports.go` | `RegisterTransports(host)` — single registration site for both `Launch()` and `LaunchWeb()` |
| `docs/ADD-A-TRANSPORT.md` | Contributor guide: scope decision tree, interface contract, error table, common pitfalls, ~30 min TTHW |

### Phase sequence

- **Phase 1 (this PR):** contract + tests + docs. broker.go zero diff.
- **Phase 2a:** wire existing `TelegramTransport` into `launcher.RegisterTransports`. Standalone PR.
- **Phase 2b:** refactor Telegram onto the contract. Channel-bound case proven.
- **Phase 3a:** move `StartOpenclawBridgeFromConfig` callsite into launcher.
- **Phase 3b:** refactor OpenClaw onto `MemberBoundTransport`.
- **Phase 4:** human-share onto `OfficeBoundTransport` + full share web UI.

### Design decisions preserved from the approved doc

- One-way compile boundary `team → transport`: enforced by Go import rules. Adapters cannot reach into `internal/team`; any broker access must go through `Host`.
- Per-scope sub-interfaces (`MemberBoundTransport`, `OfficeBoundTransport`) so `OpenclawBridge.CreateSession`/`AttachSlug` and share admission don't pollute the base `Transport`.
- `RegisterTransports` is the single registration site — wiring to one surface and missing the other is impossible.
- Stub errors are informative ("not yet implemented, phase 2b") not silent no-ops.

### Net LOC delta

+1243 insertions, 0 deletions of production code. No allowlist changes needed (all new files, none exceed 800 LOC individually).

### Bug-hunt

No pre-existing bugs found in the files touched (launcher_boot.go, launcher_web.go). The `RegisterTransports` insertion points are pure additions after `broker.Start()`.

## Test plan

- [x] `bash scripts/test-go.sh ./internal/team/transport/...` — 8 tests, all green
- [x] `bash scripts/test-go.sh ./internal/team/...` — full team suite green
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [ ] Phase 2a smoke test (Telegram messages in `wuphf-dev`) — deferred to Phase 2a PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extensible transport-adapter framework with launch-time adapter registration; registration failures now warn but do not block startup.

* **Documentation**
  * Added a comprehensive "Add a Transport" integration guide and linked it from the README and CONTRIBUTING; included in source.

* **Tests**
  * Added contract tests and in-memory fakes to validate adapter-host interactions and sentinel error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->