### PR TITLE
feat(web): add agent workbench

### DIFF
--- a/docs/specs/agent-workbench-icp-examples.md
+++ b/docs/specs/agent-workbench-icp-examples.md
@@ -1,0 +1,107 @@
+# Agent Workbench ICP Live QA Tutorial
+
+This tutorial frames the three ICP examples as live QA steps for the Phase 2
+agent workbench. The browser surface should keep task context, evidence, and
+live terminal output together so a reviewer can inspect what an agent did
+without jumping across apps.
+
+## Before You Start
+
+Build and start WUPHF from the repo root:
+
+```bash
+go build -o wuphf ./cmd/wuphf
+./wuphf
+```
+
+In another terminal, run the web app:
+
+```bash
+cd web
+bun run dev
+```
+
+Open the WUPHF web UI. These checks assume the workbench route is available at
+`#/apps/workbench`, with optional agent and task segments:
+
+```text
+#/apps/workbench/<agent-slug>/tasks/<task-id>
+```
+
+## ICP Example 1: Alex Reviews A Long-Running Task
+
+Scenario: Alex opens the workbench from an agent profile to understand what the
+agent is doing now.
+
+Live QA steps:
+
+1. Open an agent profile for an agent with recent task activity.
+2. Click `Open workbench`.
+3. Confirm the workbench header shows the agent name and `@agent-slug`.
+4. Confirm `Context` shows the current task title, owner, status, channel, and
+   latest run.
+5. Confirm `Evidence and artifacts` shows the memory workflow state, including
+   lookup, capture, and promote progress when those steps exist.
+6. Confirm the live terminal is scoped to the selected agent.
+7. Confirm `Recent runs` only lists runs for that agent.
+
+Expected result: Alex can review task context, evidence, recent runs, and live
+terminal output in one place.
+
+## ICP Example 2: Jordan Opens A Specific Task
+
+Scenario: Jordan starts from a task card and needs the workbench locked to that
+task, not just the owning agent.
+
+Live QA steps:
+
+1. Open the Tasks app.
+2. Choose a task owned by an agent rather than the human user.
+3. Click `Workbench` on that task card.
+4. Confirm the hash route includes both the agent and task:
+   `#/apps/workbench/<agent-slug>/tasks/<task-id>`.
+5. Confirm the workbench header includes `#<task-id>`.
+6. Confirm `Tasks` lists only the selected task when a task id is present.
+7. Confirm `Recent runs` is filtered to the same agent and task.
+
+Expected result: Jordan lands directly on the selected task's workbench context
+and does not have to reselect it.
+
+## ICP Example 3: Marcus Deep-Links From A Run
+
+Scenario: Marcus receives or opens a workbench URL with a task id and expects
+the view to resolve the agent from run or task data.
+
+Live QA steps:
+
+1. Open `#/apps/workbench/<agent-slug>/tasks/<task-id>` for a task with a known
+   run.
+2. Refresh the browser.
+3. Confirm the workbench still resolves the selected agent and task.
+4. Confirm the run list highlights or includes the target task id.
+5. Remove the agent segment in a test harness and render with only `taskId`.
+6. Confirm the workbench can derive the agent from the matching run first, or
+   from the task owner when no run exists.
+
+Expected result: Marcus can share and reopen a task-specific workbench URL
+without losing the agent context.
+
+## Focused Test Coverage
+
+Workbench coverage lives in `web/src/components/workbench/AgentWorkbench.test.tsx`.
+Run it with:
+
+```bash
+bash scripts/test-web.sh web/src/components/workbench/AgentWorkbench.test.tsx
+```
+
+The focused tests should cover:
+
+- Rendering task context, memory evidence, recent runs, and live terminal output.
+- Switching context from the recent-runs list.
+- Resolving the selected agent from task/run data for task-specific deep links.
+- Showing the empty state when there is no agent, task, or run data.
+
+If the workbench component is absent in a future workspace, keep this tutorial
+as scaffolding and add the tests when the component export exists. Do not add
+production component code from the docs/test ownership lane.

--- a/docs/specs/agent-workbench-icp-examples.md
+++ b/docs/specs/agent-workbench-icp-examples.md
@@ -28,6 +28,10 @@ Open the WUPHF web UI. These checks assume the workbench route is available at
 #/apps/workbench/<agent-slug>/tasks/<task-id>
 ```
 
+For the task-only validation path in Example 3, render `AgentWorkbench` in a
+test harness with `taskId` set and `agentSlug` unset. The browser URL still uses
+the full workbench route shape.
+
 ## ICP Example 1: Alex Reviews A Long-Running Task
 
 Scenario: Alex opens the workbench from an agent profile to understand what the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,7 @@ import CitedAnswer from "./components/wiki/CitedAnswer";
 import Wiki from "./components/wiki/Wiki";
 import type { WikiTab } from "./components/wiki/WikiTabs";
 import WikiTabs from "./components/wiki/WikiTabs";
+import { AgentWorkbench } from "./components/workbench/AgentWorkbench";
 import { useBrokerEvents } from "./hooks/useBrokerEvents";
 import { useHashRouter } from "./hooks/useHashRouter";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
@@ -141,6 +142,8 @@ function MainContent() {
   const notebookAgentSlug = useAppStore((s) => s.notebookAgentSlug);
   const notebookEntrySlug = useAppStore((s) => s.notebookEntrySlug);
   const setNotebookRoute = useAppStore((s) => s.setNotebookRoute);
+  const workbenchAgentSlug = useAppStore((s) => s.workbenchAgentSlug);
+  const workbenchTaskId = useAppStore((s) => s.workbenchTaskId);
   // Pam's onActionDone bumps this; Wiki re-fetches article + history when
   // the prop changes. Lifted up here because Pam lives inside the tab bar
   // (so her desk can rest on the divider line).
@@ -158,13 +161,9 @@ function MainContent() {
       <div className="wiki-shell">
         <WikiTabs
           current="wiki"
-          onSelect={(tab) => {
-            if (tab === "wiki") setCurrentApp("wiki");
-            else if (tab === "notebooks") {
-              setNotebookRoute(null, null);
-              setCurrentApp("notebooks");
-            } else setCurrentApp("reviews");
-          }}
+          onSelect={(tab) =>
+            selectWikiShellTab(tab, setCurrentApp, setNotebookRoute)
+          }
         />
         <div className="wiki-shell-body">
           <CitedAnswer query={wikiLookupQuery || ""} />
@@ -173,22 +172,7 @@ function MainContent() {
     );
   }
 
-  if (
-    currentApp === "wiki" ||
-    currentApp === "notebooks" ||
-    currentApp === "reviews"
-  ) {
-    const handleTabChange = (tab: WikiTab) => {
-      if (tab === "wiki") {
-        setCurrentApp("wiki");
-      } else if (tab === "notebooks") {
-        setNotebookRoute(null, null);
-        setCurrentApp("notebooks");
-      } else {
-        setCurrentApp("reviews");
-      }
-    };
-
+  if (isWikiShellApp(currentApp)) {
     // Pam only belongs on the wiki surface (notebooks + reviews are
     // separate contexts). When we're not on the wiki tab, articlePath is
     // null so she renders as disabled scenery without actionable state.
@@ -198,7 +182,9 @@ function MainContent() {
       <div className="wiki-shell">
         <WikiTabs
           current={currentApp}
-          onSelect={handleTabChange}
+          onSelect={(tab) =>
+            selectWikiShellTab(tab, setCurrentApp, setNotebookRoute)
+          }
           pamArticlePath={pamArticlePath}
           onPamActionDone={() => setArticleRefreshNonce((n) => n + 1)}
         />
@@ -232,6 +218,16 @@ function MainContent() {
           {currentApp === "reviews" && <ReviewQueueKanban />}
         </div>
       </div>
+    );
+  }
+
+  if (currentApp === "workbench") {
+    return (
+      <WorkbenchPanel
+        agentSlug={workbenchAgentSlug}
+        taskId={workbenchTaskId}
+        onClose={() => setCurrentApp(workbenchTaskId ? "tasks" : null)}
+      />
     );
   }
 
@@ -281,6 +277,40 @@ function MainContent() {
       <Composer />
     </>
   );
+}
+
+function WorkbenchPanel({
+  agentSlug,
+  taskId,
+  onClose,
+}: {
+  agentSlug: string | null;
+  taskId: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <div className="app-panel active">
+      <AgentWorkbench agentSlug={agentSlug} taskId={taskId} onClose={onClose} />
+    </div>
+  );
+}
+
+function isWikiShellApp(app: string | null): app is WikiTab {
+  return app === "wiki" || app === "notebooks" || app === "reviews";
+}
+
+function selectWikiShellTab(
+  tab: WikiTab,
+  setCurrentApp: (app: string | null) => void,
+  setNotebookRoute: (
+    agentSlug: string | null,
+    entrySlug: string | null,
+  ) => void,
+) {
+  if (tab === "notebooks") {
+    setNotebookRoute(null, null);
+  }
+  setCurrentApp(tab === "reviews" ? "reviews" : tab);
 }
 
 // ── App root ────────────────────────────────────────────────────

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -144,6 +144,7 @@ function MainContent() {
   const setNotebookRoute = useAppStore((s) => s.setNotebookRoute);
   const workbenchAgentSlug = useAppStore((s) => s.workbenchAgentSlug);
   const workbenchTaskId = useAppStore((s) => s.workbenchTaskId);
+  const setWorkbenchRoute = useAppStore((s) => s.setWorkbenchRoute);
   // Pam's onActionDone bumps this; Wiki re-fetches article + history when
   // the prop changes. Lifted up here because Pam lives inside the tab bar
   // (so her desk can rest on the divider line).
@@ -226,6 +227,7 @@ function MainContent() {
       <WorkbenchPanel
         agentSlug={workbenchAgentSlug}
         taskId={workbenchTaskId}
+        onSelectionChange={setWorkbenchRoute}
         onClose={() => setCurrentApp(workbenchTaskId ? "tasks" : null)}
       />
     );
@@ -282,15 +284,22 @@ function MainContent() {
 function WorkbenchPanel({
   agentSlug,
   taskId,
+  onSelectionChange,
   onClose,
 }: {
   agentSlug: string | null;
   taskId: string | null;
+  onSelectionChange: (agentSlug: string | null, taskId: string | null) => void;
   onClose: () => void;
 }) {
   return (
     <div className="app-panel active">
-      <AgentWorkbench agentSlug={agentSlug} taskId={taskId} onClose={onClose} />
+      <AgentWorkbench
+        agentSlug={agentSlug}
+        taskId={taskId}
+        onSelectionChange={onSelectionChange}
+        onClose={onClose}
+      />
     </div>
   );
 }

--- a/web/src/components/agents/AgentPanel.tsx
+++ b/web/src/components/agents/AgentPanel.tsx
@@ -102,6 +102,7 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
   const currentApp = useAppStore((s) => s.currentApp);
   const setCurrentChannel = useAppStore((s) => s.setCurrentChannel);
   const setCurrentApp = useAppStore((s) => s.setCurrentApp);
+  const openAgentWorkbench = useAppStore((s) => s.openAgentWorkbench);
   const queryClient = useQueryClient();
   const [dmLoading, setDmLoading] = useState(false);
   const [view, setView] = useState<"stream" | "logs">("stream");
@@ -325,6 +326,13 @@ function AgentPanelView({ agent, onClose }: AgentPanelViewProps) {
           disabled={dmLoading}
         >
           {dmLoading ? "Opening..." : "Open DM"}
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm"
+          onClick={() => openAgentWorkbench(agent.slug)}
+        >
+          Open workbench
         </button>
         <button
           type="button"

--- a/web/src/components/apps/TasksApp.tsx
+++ b/web/src/components/apps/TasksApp.tsx
@@ -6,6 +6,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { post } from "../../api/client";
 import { getOfficeTasks, type Task } from "../../api/tasks";
 import { formatRelativeTime } from "../../lib/format";
+import { useAppStore } from "../../stores/app";
 import { showNotice } from "../ui/Toast";
 import { TaskDetailModal, taskMemoryWorkflowBadge } from "./TaskDetailModal";
 
@@ -126,6 +127,7 @@ function useTaskMove() {
 }
 
 export function TasksApp() {
+  const openAgentWorkbench = useAppStore((s) => s.openAgentWorkbench);
   const { data, isLoading, error } = useQuery({
     queryKey: ["office-tasks"],
     queryFn: () => getOfficeTasks({ includeDone: true }),
@@ -290,16 +292,24 @@ export function TasksApp() {
                 <span>{COLUMN_LABEL[status]}</span>
                 <span className="task-column-count">{column.length}</span>
               </div>
-              {column.map((task) => (
-                <TaskCard
-                  key={task.id}
-                  task={task}
-                  isDragging={draggingId === task.id}
-                  onDragStart={handleDragStart(task.id)}
-                  onDragEnd={handleDragEnd}
-                  onOpen={() => setSelectedTaskId(task.id)}
-                />
-              ))}
+              {column.map((task) => {
+                const ownerSlug = task.owner;
+                return (
+                  <TaskCard
+                    key={task.id}
+                    task={task}
+                    isDragging={draggingId === task.id}
+                    onDragStart={handleDragStart(task.id)}
+                    onDragEnd={handleDragEnd}
+                    onOpen={() => setSelectedTaskId(task.id)}
+                    onOpenWorkbench={
+                      ownerSlug && ownerSlug !== HUMAN_SLUG
+                        ? () => openAgentWorkbench(ownerSlug, task.id)
+                        : undefined
+                    }
+                  />
+                );
+              })}
             </div>
           );
         })}
@@ -320,6 +330,7 @@ interface TaskCardProps {
   onDragStart: (event: DragEvent<HTMLDivElement>) => void;
   onDragEnd: (event: DragEvent<HTMLDivElement>) => void;
   onOpen: () => void;
+  onOpenWorkbench?: () => void;
 }
 
 function TaskCard({
@@ -328,6 +339,7 @@ function TaskCard({
   onDragStart,
   onDragEnd,
   onOpen,
+  onOpenWorkbench,
 }: TaskCardProps) {
   const status = normalizeStatus(task.status);
   const timestamp = task.updated_at ?? task.created_at;
@@ -339,6 +351,12 @@ function TaskCard({
       event.preventDefault();
       onOpen();
     }
+  }
+
+  function handleOpenWorkbench(event: React.MouseEvent<HTMLButtonElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    onOpenWorkbench?.();
   }
 
   return (
@@ -389,6 +407,15 @@ function TaskCard({
             {memoryBadge.label}
           </span>
         )}
+        {onOpenWorkbench ? (
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm task-card-workbench"
+            onClick={handleOpenWorkbench}
+          >
+            Workbench
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/web/src/components/apps/TasksApp.tsx
+++ b/web/src/components/apps/TasksApp.tsx
@@ -362,9 +362,6 @@ function TaskCard({
   function handleWorkbenchKeyDown(
     event: React.KeyboardEvent<HTMLButtonElement>,
   ) {
-    if (event.key === "Enter" || event.key === " ") {
-      event.preventDefault();
-    }
     event.stopPropagation();
   }
 

--- a/web/src/components/apps/TasksApp.tsx
+++ b/web/src/components/apps/TasksApp.tsx
@@ -359,6 +359,15 @@ function TaskCard({
     onOpenWorkbench?.();
   }
 
+  function handleWorkbenchKeyDown(
+    event: React.KeyboardEvent<HTMLButtonElement>,
+  ) {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+    }
+    event.stopPropagation();
+  }
+
   return (
     <div
       className={className}
@@ -412,6 +421,7 @@ function TaskCard({
             type="button"
             className="btn btn-ghost btn-sm task-card-workbench"
             onClick={handleOpenWorkbench}
+            onKeyDown={handleWorkbenchKeyDown}
           >
             Workbench
           </button>

--- a/web/src/components/layout/CollapsedSidebar.tsx
+++ b/web/src/components/layout/CollapsedSidebar.tsx
@@ -39,6 +39,7 @@ const APP_ICONS: Record<string, ComponentType<{ className?: string }>> = {
   wiki: BookStack,
   console: Terminal,
   tasks: CheckCircle,
+  workbench: Terminal,
   requests: ClipboardCheck,
   graph: ShareAndroid,
   policies: Shield,

--- a/web/src/components/sidebar/AppList.tsx
+++ b/web/src/components/sidebar/AppList.tsx
@@ -32,6 +32,7 @@ const APP_ICONS: Record<string, ComponentType<{ className?: string }>> = {
   wiki: BookStack,
   console: Terminal,
   tasks: CheckCircle,
+  workbench: Terminal,
   requests: ClipboardCheck,
   graph: ShareAndroid,
   policies: Shield,

--- a/web/src/components/workbench/AgentWorkbench.css
+++ b/web/src/components/workbench/AgentWorkbench.css
@@ -1,0 +1,362 @@
+.awb-shell {
+  box-sizing: border-box;
+  min-height: 100%;
+  padding: 18px 20px 24px;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.awb-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+}
+
+.awb-header h2 {
+  margin: 2px 0 0;
+  font-size: 20px;
+  line-height: 1.25;
+  font-weight: 700;
+}
+
+.awb-kicker {
+  margin: 0;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  text-transform: uppercase;
+}
+
+.awb-header-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+
+.awb-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.awb-status,
+.awb-memory,
+.awb-count {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-full);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.awb-close {
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.awb-close:hover {
+  background: var(--bg);
+  color: var(--text);
+}
+
+.awb-status-ready,
+.awb-memory-done {
+  border-color: rgba(16, 185, 129, 0.28);
+  background: rgba(16, 185, 129, 0.08);
+  color: var(--green);
+}
+
+.awb-status-error,
+.awb-memory-warn {
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.1);
+  color: var(--yellow);
+}
+
+.awb-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+  gap: 16px;
+  align-items: start;
+}
+
+.awb-main,
+.awb-side {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 0;
+}
+
+.awb-panel {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  padding: 14px;
+}
+
+.awb-side-panel {
+  padding: 12px;
+}
+
+.awb-panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.awb-panel-heading h3 {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.3;
+  font-weight: 700;
+}
+
+.awb-summary {
+  margin: 0 0 12px;
+  max-width: 760px;
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.awb-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 10px 14px;
+  margin: 0;
+}
+
+.awb-meta div {
+  min-width: 0;
+}
+
+.awb-meta dt {
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.awb-meta dd {
+  margin: 4px 0 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.awb-evidence-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.awb-evidence-group {
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+
+.awb-evidence-group-wide {
+  grid-column: 1 / -1;
+}
+
+.awb-evidence-group h4 {
+  margin: 0 0 8px;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.awb-evidence-group p {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.awb-evidence-group ul {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.awb-evidence-group li {
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.awb-step-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.awb-step {
+  display: inline-flex;
+  align-items: center;
+  height: 22px;
+  padding: 0 8px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-full);
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.awb-step-done {
+  border-color: rgba(16, 185, 129, 0.24);
+  color: var(--green);
+}
+
+.awb-run-list,
+.awb-task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.awb-run,
+.awb-task {
+  width: 100%;
+  min-width: 0;
+  padding: 9px 10px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.awb-run:hover,
+.awb-task:hover,
+.awb-run.active,
+.awb-task.active {
+  border-color: var(--accent);
+  background: var(--accent-bg);
+}
+
+.awb-run {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.awb-run span,
+.awb-task span {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 3px;
+}
+
+.awb-run strong,
+.awb-task span {
+  overflow: hidden;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.awb-run small,
+.awb-task small,
+.awb-run-meta,
+.awb-muted {
+  color: var(--text-tertiary);
+  font-size: 11px;
+}
+
+.awb-task small {
+  display: block;
+  margin-top: 4px;
+}
+
+.awb-terminal-wrap .agent-terminal-shell {
+  min-height: 360px;
+}
+
+.awb-terminal-wrap .agent-terminal-frame,
+.awb-terminal-wrap .agent-terminal-host {
+  min-height: 326px;
+}
+
+.awb-state,
+.awb-mini-empty {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+.awb-state {
+  padding: 48px 20px;
+}
+
+.awb-state-mark {
+  width: 36px;
+  height: 36px;
+  margin: 0 auto 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+}
+
+.awb-state h3 {
+  margin: 0 0 6px;
+  color: var(--text);
+  font-size: 15px;
+}
+
+.awb-state p,
+.awb-mini-empty {
+  margin: 0;
+  font-size: 13px;
+}
+
+.awb-mini-empty {
+  padding: 18px 12px;
+}
+
+@media (max-width: 900px) {
+  .awb-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .awb-evidence-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/web/src/components/workbench/AgentWorkbench.test.tsx
+++ b/web/src/components/workbench/AgentWorkbench.test.tsx
@@ -1,0 +1,204 @@
+import type { ComponentProps } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getOfficeMembers } from "../../api/client";
+import { getOfficeTasks, listAgentLogTasks, type Task } from "../../api/tasks";
+import { AgentWorkbench } from "./AgentWorkbench";
+
+vi.mock("../../api/client", () => ({
+  getOfficeMembers: vi.fn(),
+}));
+
+vi.mock("../../api/tasks", () => ({
+  getOfficeTasks: vi.fn(),
+  listAgentLogTasks: vi.fn(),
+}));
+
+vi.mock("../agents/AgentTerminal", () => ({
+  AgentTerminal: ({ slug }: { slug: string | null }) => (
+    <div data-testid="agent-terminal">terminal:{slug}</div>
+  ),
+}));
+
+const getOfficeMembersMock = getOfficeMembers as ReturnType<typeof vi.fn>;
+const getOfficeTasksMock = getOfficeTasks as ReturnType<typeof vi.fn>;
+const listAgentLogTasksMock = listAgentLogTasks as ReturnType<typeof vi.fn>;
+
+function renderWorkbench(props?: ComponentProps<typeof AgentWorkbench>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentWorkbench {...props} />
+    </QueryClientProvider>,
+  );
+}
+
+const researchTask: Task = {
+  id: "task-123",
+  title: "Map onboarding evidence",
+  description: "Collect prior decisions and record a reusable summary.",
+  status: "in_progress",
+  owner: "alpha",
+  channel: "ops",
+  updated_at: "2026-05-01T10:00:00Z",
+  memory_workflow: {
+    required: true,
+    status: "pending",
+    requirement_reason: "Durable context is required before review.",
+    required_steps: ["lookup", "capture", "promote"],
+    lookup: {
+      required: true,
+      status: "satisfied",
+      count: 2,
+      completed_at: "2026-05-01T09:30:00Z",
+    },
+    capture: {
+      required: true,
+      status: "satisfied",
+      count: 1,
+      completed_at: "2026-05-01T09:45:00Z",
+    },
+    promote: { required: true, status: "pending" },
+    citations: [
+      {
+        title: "Onboarding notes",
+        path: "team/onboarding.md",
+        source: "wiki",
+      },
+    ],
+    captures: [
+      {
+        title: "Workbench capture",
+        path: "agents/alpha/workbench.md",
+        source: "notebook",
+        state: "captured",
+      },
+    ],
+    promotions: [
+      {
+        title: "Review brief",
+        path: "team/review.md",
+        source: "wiki",
+        state: "ready",
+      },
+    ],
+    updated_at: "2026-05-01T10:05:00Z",
+  },
+};
+
+describe("AgentWorkbench", () => {
+  beforeEach(() => {
+    getOfficeMembersMock.mockResolvedValue({
+      members: [{ slug: "alpha", name: "Alpha", role: "Research" }],
+    });
+    getOfficeTasksMock.mockResolvedValue({ tasks: [researchTask] });
+    listAgentLogTasksMock.mockResolvedValue({
+      tasks: [
+        {
+          taskId: "task-123",
+          agentSlug: "alpha",
+          toolCallCount: 4,
+          lastToolAt: Date.UTC(2026, 4, 1, 10, 10),
+          sizeBytes: 2048,
+        },
+      ],
+    });
+  });
+
+  it("renders task context, evidence, recent runs, and terminal", async () => {
+    renderWorkbench({ agentSlug: "alpha", taskId: "task-123" });
+
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Alpha" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Map onboarding evidence").length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText("memory 2/3")).toBeInTheDocument();
+    expect(screen.getByText(/Onboarding notes/)).toBeInTheDocument();
+    expect(screen.getByText(/Workbench capture/)).toBeInTheDocument();
+    expect(screen.getByText(/Review brief/)).toBeInTheDocument();
+    expect(screen.getByTestId("agent-terminal")).toHaveTextContent(
+      "terminal:alpha",
+    );
+
+    const recentRuns = screen.getByRole("heading", { name: "Recent runs" })
+      .parentElement?.parentElement;
+    expect(recentRuns).toBeTruthy();
+    expect(
+      within(recentRuns as HTMLElement).getByText("task-123"),
+    ).toBeInTheDocument();
+  });
+
+  it("switches context when a task is selected from recent runs", async () => {
+    const secondTask: Task = {
+      id: "task-456",
+      title: "Ship review packet",
+      status: "review",
+      owner: "alpha",
+    };
+    getOfficeTasksMock.mockResolvedValue({
+      tasks: [researchTask, secondTask],
+    });
+    listAgentLogTasksMock.mockResolvedValue({
+      tasks: [
+        {
+          taskId: "task-456",
+          agentSlug: "alpha",
+          toolCallCount: 1,
+          lastToolAt: Date.UTC(2026, 4, 1, 11, 0),
+          sizeBytes: 512,
+        },
+        {
+          taskId: "task-123",
+          agentSlug: "alpha",
+          toolCallCount: 4,
+          lastToolAt: Date.UTC(2026, 4, 1, 10, 10),
+          sizeBytes: 2048,
+        },
+      ],
+    });
+
+    renderWorkbench({ agentSlug: "alpha" });
+
+    await screen.findByRole("button", { name: /task-123/i });
+    expect(screen.getAllByText("Ship review packet").length).toBeGreaterThan(0);
+    await userEvent.click(screen.getByRole("button", { name: /task-123/i }));
+    expect(
+      screen.getAllByText("Map onboarding evidence").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("derives the agent from run data for a task-specific deep link", async () => {
+    renderWorkbench({ taskId: "task-123" });
+
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Alpha" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("@alpha").length).toBeGreaterThan(0);
+    expect(screen.getByText("#task-123")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-terminal")).toHaveTextContent(
+      "terminal:alpha",
+    );
+  });
+
+  it("shows a polished empty state when no data is available", async () => {
+    getOfficeMembersMock.mockResolvedValue({ members: [] });
+    getOfficeTasksMock.mockResolvedValue({ tasks: [] });
+    listAgentLogTasksMock.mockResolvedValue({ tasks: [] });
+
+    renderWorkbench();
+
+    expect(await screen.findByText("No workbench data")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Pick an agent or task with recent activity to populate this view.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/workbench/AgentWorkbench.test.tsx
+++ b/web/src/components/workbench/AgentWorkbench.test.tsx
@@ -176,7 +176,8 @@ describe("AgentWorkbench", () => {
       ],
     });
 
-    renderWorkbench({ agentSlug: "alpha" });
+    const onSelectionChange = vi.fn();
+    renderWorkbench({ agentSlug: "alpha", onSelectionChange });
 
     await screen.findByRole("button", { name: /task-123/i });
     expect(screen.getAllByText("Ship review packet").length).toBeGreaterThan(0);
@@ -185,6 +186,7 @@ describe("AgentWorkbench", () => {
     expect(
       screen.getAllByText("Map onboarding evidence").length,
     ).toBeGreaterThan(0);
+    expect(onSelectionChange).toHaveBeenCalledWith("alpha", "task-123");
   });
 
   it("derives the agent from run data for a task-specific deep link", async () => {
@@ -197,6 +199,30 @@ describe("AgentWorkbench", () => {
     expect(screen.getByText("#task-123")).toBeInTheDocument();
     expect(screen.getByTestId("agent-terminal")).toHaveTextContent(
       "terminal:alpha",
+    );
+  });
+
+  it("derives the agent from task ownership when a task deep link has no run", async () => {
+    const ownerTask: Task = {
+      id: "task-owner",
+      title: "Owner fallback task",
+      status: "todo",
+      owner: "beta",
+    };
+    getOfficeMembersMock.mockResolvedValue({
+      members: [{ slug: "beta", name: "Beta", role: "Builder" }],
+    });
+    getOfficeTasksMock.mockResolvedValue({ tasks: [ownerTask] });
+    listAgentLogTasksMock.mockResolvedValue({ tasks: [] });
+
+    renderWorkbench({ taskId: "task-owner" });
+
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Beta" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("#task-owner")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-terminal")).toHaveTextContent(
+      "terminal:beta",
     );
   });
 
@@ -270,6 +296,13 @@ describe("AgentWorkbench", () => {
     expect(await screen.findByText("No workbench data")).toBeInTheDocument();
     expect(screen.queryAllByText("Map onboarding evidence").length).toBe(0);
     expect(screen.queryByText("@alpha")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state for a stale task deep link with an explicit agent", async () => {
+    renderWorkbench({ agentSlug: "alpha", taskId: "missing-task" });
+
+    expect(await screen.findByText("No workbench data")).toBeInTheDocument();
+    expect(screen.queryAllByText("Map onboarding evidence").length).toBe(0);
   });
 
   it("shows a polished empty state when no data is available", async () => {

--- a/web/src/components/workbench/AgentWorkbench.test.tsx
+++ b/web/src/components/workbench/AgentWorkbench.test.tsx
@@ -142,8 +142,13 @@ describe("AgentWorkbench", () => {
       status: "review",
       owner: "alpha",
     };
+    const unownedTask: Task = {
+      id: "task-789",
+      title: "Unowned backlog item",
+      status: "todo",
+    };
     getOfficeTasksMock.mockResolvedValue({
-      tasks: [researchTask, secondTask],
+      tasks: [researchTask, secondTask, unownedTask],
     });
     listAgentLogTasksMock.mockResolvedValue({
       tasks: [
@@ -168,6 +173,7 @@ describe("AgentWorkbench", () => {
 
     await screen.findByRole("button", { name: /task-123/i });
     expect(screen.getAllByText("Ship review packet").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Unowned backlog item")).not.toBeInTheDocument();
     await userEvent.click(screen.getByRole("button", { name: /task-123/i }));
     expect(
       screen.getAllByText("Map onboarding evidence").length,
@@ -185,6 +191,78 @@ describe("AgentWorkbench", () => {
     expect(screen.getByTestId("agent-terminal")).toHaveTextContent(
       "terminal:alpha",
     );
+  });
+
+  it("does not reuse the selected task when switching agents", async () => {
+    const betaTask: Task = {
+      id: "task-beta",
+      title: "Review beta launch",
+      status: "todo",
+      owner: "beta",
+    };
+    getOfficeMembersMock.mockResolvedValue({
+      members: [
+        { slug: "alpha", name: "Alpha", role: "Research" },
+        { slug: "beta", name: "Beta", role: "Builder" },
+      ],
+    });
+    getOfficeTasksMock.mockResolvedValue({ tasks: [researchTask, betaTask] });
+    listAgentLogTasksMock.mockResolvedValue({
+      tasks: [
+        {
+          taskId: "task-123",
+          agentSlug: "alpha",
+          toolCallCount: 4,
+          lastToolAt: Date.UTC(2026, 4, 1, 10, 10),
+          sizeBytes: 2048,
+        },
+        {
+          taskId: "task-beta",
+          agentSlug: "beta",
+          toolCallCount: 2,
+          lastToolAt: Date.UTC(2026, 4, 1, 11, 10),
+          sizeBytes: 1024,
+        },
+      ],
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <AgentWorkbench agentSlug="alpha" />
+      </QueryClientProvider>,
+    );
+
+    expect(
+      (await screen.findAllByText("Map onboarding evidence")).length,
+    ).toBeGreaterThan(0);
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <AgentWorkbench agentSlug="beta" />
+      </QueryClientProvider>,
+    );
+
+    expect(
+      (await screen.findAllByText("Review beta launch")).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Map onboarding evidence").length).toBe(0);
+    expect(screen.getByTestId("agent-terminal")).toHaveTextContent(
+      "terminal:beta",
+    );
+  });
+
+  it("does not guess another agent or task for a stale task deep link", async () => {
+    renderWorkbench({ taskId: "missing-task" });
+
+    expect(await screen.findByText("No workbench data")).toBeInTheDocument();
+    expect(screen.queryAllByText("Map onboarding evidence").length).toBe(0);
+    expect(screen.queryByText("@alpha")).not.toBeInTheDocument();
   });
 
   it("shows a polished empty state when no data is available", async () => {

--- a/web/src/components/workbench/AgentWorkbench.test.tsx
+++ b/web/src/components/workbench/AgentWorkbench.test.tsx
@@ -153,6 +153,13 @@ describe("AgentWorkbench", () => {
     listAgentLogTasksMock.mockResolvedValue({
       tasks: [
         {
+          taskId: "task-orphaned",
+          agentSlug: "alpha",
+          toolCallCount: 3,
+          lastToolAt: Date.UTC(2026, 4, 1, 12, 0),
+          sizeBytes: 256,
+        },
+        {
           taskId: "task-456",
           agentSlug: "alpha",
           toolCallCount: 1,

--- a/web/src/components/workbench/AgentWorkbench.tsx
+++ b/web/src/components/workbench/AgentWorkbench.tsx
@@ -123,7 +123,11 @@ function useAgentWorkbenchModel(
 
   useEffect(() => {
     if (taskId || activeTaskId || visibleTasks.length === 0) return;
-    setActiveTaskId(relevantRuns[0]?.taskId ?? visibleTasks[0].id);
+    const visibleTaskIds = new Set(visibleTasks.map((task) => task.id));
+    const nextRunTaskId = relevantRuns.find((run) =>
+      visibleTaskIds.has(run.taskId),
+    )?.taskId;
+    setActiveTaskId(nextRunTaskId ?? visibleTasks[0].id);
   }, [activeTaskId, relevantRuns, taskId, visibleTasks]);
 
   const agent = selectedAgentSlug

--- a/web/src/components/workbench/AgentWorkbench.tsx
+++ b/web/src/components/workbench/AgentWorkbench.tsx
@@ -20,6 +20,7 @@ import "./AgentWorkbench.css";
 export interface AgentWorkbenchProps {
   agentSlug?: string | null;
   taskId?: string | null;
+  onSelectionChange?: (agentSlug: string | null, taskId: string | null) => void;
   onClose?: () => void;
 }
 
@@ -30,9 +31,17 @@ const WORKFLOW_STEPS = ["lookup", "capture", "promote"] as const;
 export function AgentWorkbench({
   agentSlug = null,
   taskId = null,
+  onSelectionChange,
   onClose,
 }: AgentWorkbenchProps) {
   const model = useAgentWorkbenchModel(agentSlug, taskId);
+  const handleSelectTask = (nextTaskId: string | null) => {
+    model.setActiveTaskId(nextTaskId);
+    onSelectionChange?.(
+      resolveSelectionAgentSlug(nextTaskId, model) ?? model.selectedAgentSlug,
+      nextTaskId,
+    );
+  };
 
   return (
     <section className="awb-shell" aria-label="Agent workbench">
@@ -44,7 +53,7 @@ export function AgentWorkbench({
         loadState={model.loadState}
         onClose={onClose}
       />
-      <WorkbenchBody model={model} onSelectTask={model.setActiveTaskId} />
+      <WorkbenchBody model={model} onSelectTask={handleSelectTask} />
     </section>
   );
 }
@@ -143,6 +152,7 @@ function useAgentWorkbenchModel(
     logsQuery.isLoading || tasksQuery.isLoading,
     logsQuery.isError || tasksQuery.isError,
     selectedAgentSlug,
+    requestedTaskId,
     visibleTasks,
     relevantRuns,
   );
@@ -536,6 +546,19 @@ function resolveAgentSlug(
   return runs[0]?.agentSlug || tasks.find((task) => task.owner)?.owner || null;
 }
 
+function resolveSelectionAgentSlug(
+  taskId: string | null,
+  model: WorkbenchModel,
+): string | null {
+  if (!taskId) return model.selectedAgentSlug;
+  const run = model.relevantRuns.find(
+    (candidate) => candidate.taskId === taskId,
+  );
+  if (run?.agentSlug) return run.agentSlug;
+  const task = model.visibleTasks.find((candidate) => candidate.id === taskId);
+  return task?.owner ?? model.selectedAgentSlug;
+}
+
 function filterRuns(
   runs: TaskLogSummary[],
   agentSlug: string | null,
@@ -583,11 +606,13 @@ function getLoadState(
   loading: boolean,
   error: boolean,
   agentSlug: string | null,
+  taskId: string | null,
   tasks: Task[],
   runs: TaskLogSummary[],
 ): LoadState {
   if (loading) return "loading";
   if (error) return "error";
+  if (taskId && tasks.length === 0 && runs.length === 0) return "empty";
   if (!agentSlug && tasks.length === 0 && runs.length === 0) return "empty";
   return "ready";
 }

--- a/web/src/components/workbench/AgentWorkbench.tsx
+++ b/web/src/components/workbench/AgentWorkbench.tsx
@@ -1,0 +1,694 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { getOfficeMembers } from "../../api/client";
+import {
+  getOfficeTasks,
+  listAgentLogTasks,
+  type Task,
+  type TaskLogSummary,
+  type TaskMemoryWorkflow,
+  type TaskMemoryWorkflowArtifact,
+  type TaskMemoryWorkflowCitation,
+  type TaskMemoryWorkflowPartialError,
+  type TaskMemoryWorkflowStepState,
+} from "../../api/tasks";
+import { formatRelativeTime } from "../../lib/format";
+import { AgentTerminal } from "../agents/AgentTerminal";
+import "./AgentWorkbench.css";
+
+export interface AgentWorkbenchProps {
+  agentSlug?: string | null;
+  taskId?: string | null;
+  onClose?: () => void;
+}
+
+type LoadState = "loading" | "error" | "empty" | "ready";
+
+const WORKFLOW_STEPS = ["lookup", "capture", "promote"] as const;
+
+export function AgentWorkbench({
+  agentSlug = null,
+  taskId = null,
+  onClose,
+}: AgentWorkbenchProps) {
+  const model = useAgentWorkbenchModel(agentSlug, taskId);
+
+  return (
+    <section className="awb-shell" aria-label="Agent workbench">
+      <WorkbenchHeader
+        agentName={model.agent?.name}
+        agentSlug={model.selectedAgentSlug}
+        taskId={model.selectedTask?.id ?? null}
+        agentStatus={model.agent?.status}
+        loadState={model.loadState}
+        onClose={onClose}
+      />
+      <WorkbenchBody model={model} onSelectTask={model.setActiveTaskId} />
+    </section>
+  );
+}
+
+interface WorkbenchModel {
+  setActiveTaskId: (taskId: string | null) => void;
+  selectedAgentSlug: string | null;
+  selectedTask: Task | null;
+  selectedRun?: TaskLogSummary;
+  visibleTasks: Task[];
+  relevantRuns: TaskLogSummary[];
+  agent?: { name?: string; status?: string } | null;
+  loadState: LoadState;
+  errorMessage: string | null;
+}
+
+function useAgentWorkbenchModel(
+  agentSlug: string | null,
+  taskId: string | null,
+): WorkbenchModel {
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(
+    taskId ?? null,
+  );
+
+  const logsQuery = useQuery({
+    queryKey: ["agent-workbench", "agent-log-tasks"],
+    queryFn: () => listAgentLogTasks({ limit: 80 }),
+    refetchInterval: 8_000,
+  });
+  const tasksQuery = useQuery({
+    queryKey: ["agent-workbench", "office-tasks"],
+    queryFn: () => getOfficeTasks({ includeDone: true }),
+    refetchInterval: 10_000,
+  });
+  const membersQuery = useQuery({
+    queryKey: ["agent-workbench", "office-members"],
+    queryFn: getOfficeMembers,
+    staleTime: 30_000,
+  });
+
+  const tasks = useMemo(() => tasksQuery.data?.tasks ?? [], [tasksQuery.data]);
+  const runs = useMemo(() => logsQuery.data?.tasks ?? [], [logsQuery.data]);
+  const members = membersQuery.data?.members ?? [];
+
+  const selectedAgentSlug = useMemo(
+    () => resolveAgentSlug(agentSlug, taskId, activeTaskId, tasks, runs),
+    [agentSlug, taskId, activeTaskId, tasks, runs],
+  );
+
+  const relevantRuns = useMemo(
+    () => filterRuns(runs, selectedAgentSlug, taskId ?? null),
+    [runs, selectedAgentSlug, taskId],
+  );
+
+  const visibleTasks = useMemo(
+    () => filterTasks(tasks, selectedAgentSlug, taskId),
+    [tasks, selectedAgentSlug, taskId],
+  );
+
+  const selectedTask = useMemo(
+    () => resolveTask(taskId, activeTaskId, visibleTasks, tasks, relevantRuns),
+    [taskId, activeTaskId, visibleTasks, tasks, relevantRuns],
+  );
+
+  useEffect(() => {
+    setActiveTaskId(taskId ?? null);
+  }, [taskId]);
+
+  useEffect(() => {
+    if (taskId || activeTaskId || visibleTasks.length === 0) return;
+    setActiveTaskId(relevantRuns[0]?.taskId ?? visibleTasks[0].id);
+  }, [activeTaskId, relevantRuns, taskId, visibleTasks]);
+
+  const agent = selectedAgentSlug
+    ? members.find((member) => member.slug === selectedAgentSlug)
+    : null;
+  const selectedRun =
+    relevantRuns.find((run) => run.taskId === selectedTask?.id) ??
+    relevantRuns[0];
+  const loadState = getLoadState(
+    logsQuery.isLoading || tasksQuery.isLoading,
+    logsQuery.isError || tasksQuery.isError,
+    selectedAgentSlug,
+    visibleTasks,
+    relevantRuns,
+  );
+  const errorMessage =
+    errorText(logsQuery.error) || errorText(tasksQuery.error);
+
+  return {
+    setActiveTaskId,
+    selectedAgentSlug,
+    selectedTask,
+    selectedRun,
+    visibleTasks,
+    relevantRuns,
+    agent,
+    loadState,
+    errorMessage,
+  };
+}
+
+function WorkbenchHeader({
+  agentName,
+  agentSlug,
+  taskId,
+  agentStatus,
+  loadState,
+  onClose,
+}: {
+  agentName?: string;
+  agentSlug: string | null;
+  taskId: string | null;
+  agentStatus?: string;
+  loadState: LoadState;
+  onClose?: () => void;
+}) {
+  return (
+    <header className="awb-header">
+      <div>
+        <p className="awb-kicker">Agent workbench</p>
+        <h2>{agentName || agentSlug || "Unassigned agent"}</h2>
+        <div className="awb-header-meta">
+          {agentSlug ? <span>@{agentSlug}</span> : null}
+          {taskId ? <span>#{taskId}</span> : null}
+          {agentStatus ? <span>{agentStatus}</span> : null}
+        </div>
+      </div>
+      <div className="awb-header-actions">
+        <StatusPill state={loadState} />
+        {onClose ? (
+          <button
+            type="button"
+            className="awb-close"
+            onClick={onClose}
+            aria-label="Close workbench"
+          >
+            Close
+          </button>
+        ) : null}
+      </div>
+    </header>
+  );
+}
+
+function WorkbenchBody({
+  model,
+  onSelectTask,
+}: {
+  model: WorkbenchModel;
+  onSelectTask: (taskId: string | null) => void;
+}) {
+  if (model.loadState === "loading") {
+    return (
+      <WorkbenchState
+        title="Loading workbench"
+        body="Gathering runs, tasks, and context."
+      />
+    );
+  }
+  if (model.loadState === "error") {
+    return (
+      <WorkbenchState
+        title="Could not load workbench"
+        body={model.errorMessage || "The broker did not return workbench data."}
+      />
+    );
+  }
+  if (model.loadState === "empty") {
+    return (
+      <WorkbenchState
+        title="No workbench data"
+        body="Pick an agent or task with recent activity to populate this view."
+      />
+    );
+  }
+  return (
+    <div className="awb-grid">
+      <main className="awb-main">
+        <ContextPanel
+          agentSlug={model.selectedAgentSlug}
+          agentName={model.agent?.name}
+          task={model.selectedTask}
+          run={model.selectedRun}
+        />
+        <EvidencePanel task={model.selectedTask} />
+        <div className="awb-terminal-wrap">
+          <AgentTerminal
+            slug={model.selectedAgentSlug}
+            title="Live terminal"
+            emptyLabel="No live output for this agent yet"
+          />
+        </div>
+      </main>
+      <aside className="awb-side">
+        <RunList
+          runs={model.relevantRuns}
+          selectedTaskId={model.selectedTask?.id ?? null}
+          onSelectTask={onSelectTask}
+        />
+        <TaskList
+          tasks={model.visibleTasks}
+          selectedTaskId={model.selectedTask?.id ?? null}
+          onSelectTask={onSelectTask}
+        />
+      </aside>
+    </div>
+  );
+}
+
+function StatusPill({ state }: { state: LoadState }) {
+  const label =
+    state === "ready"
+      ? "ready"
+      : state === "loading"
+        ? "loading"
+        : state === "error"
+          ? "needs attention"
+          : "empty";
+  return <span className={`awb-status awb-status-${state}`}>{label}</span>;
+}
+
+function WorkbenchState({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="awb-state">
+      <div className="awb-state-mark" />
+      <h3>{title}</h3>
+      <p>{body}</p>
+    </div>
+  );
+}
+
+function ContextPanel({
+  agentSlug,
+  agentName,
+  task,
+  run,
+}: {
+  agentSlug: string | null;
+  agentName?: string;
+  task?: Task | null;
+  run?: TaskLogSummary;
+}) {
+  const rows: Array<[string, string | null | undefined]> = [
+    ["Agent", agentName || agentSlug],
+    ["Task", task?.title],
+    ["Owner", task?.owner ? `@${task.owner}` : null],
+    ["Status", task?.status ? displayStatus(task.status) : null],
+    ["Channel", task?.channel ? `#${task.channel}` : null],
+    ["Updated", task?.updated_at ? formatRelativeTime(task.updated_at) : null],
+    [
+      "Latest run",
+      run?.lastToolAt ? formatEpochTime(run.lastToolAt) : run?.taskId,
+    ],
+  ];
+
+  return (
+    <section className="awb-panel">
+      <div className="awb-panel-heading">
+        <h3>Context</h3>
+        {task?.memory_workflow ? (
+          <span className={memoryBadgeClass(task.memory_workflow)}>
+            {memoryBadgeLabel(task.memory_workflow)}
+          </span>
+        ) : null}
+      </div>
+      {task?.description || task?.details ? (
+        <p className="awb-summary">{task.description || task.details}</p>
+      ) : null}
+      <dl className="awb-meta">
+        {rows
+          .filter(([, value]) => value)
+          .map(([label, value]) => (
+            <div key={label}>
+              <dt>{label}</dt>
+              <dd>{value}</dd>
+            </div>
+          ))}
+      </dl>
+    </section>
+  );
+}
+
+function EvidencePanel({ task }: { task?: Task | null }) {
+  const workflow = task?.memory_workflow;
+  const citations = workflow?.citations ?? [];
+  const captures = workflow?.captures ?? [];
+  const promotions = workflow?.promotions ?? [];
+  const errors = workflow?.partial_errors ?? [];
+  const hasEvidence =
+    citations.length > 0 ||
+    captures.length > 0 ||
+    promotions.length > 0 ||
+    errors.length > 0 ||
+    hasWorkflowSteps(workflow);
+
+  return (
+    <section className="awb-panel">
+      <div className="awb-panel-heading">
+        <h3>Evidence and artifacts</h3>
+        {workflow?.updated_at ? (
+          <span className="awb-muted">
+            updated {formatRelativeTime(workflow.updated_at)}
+          </span>
+        ) : null}
+      </div>
+      {!hasEvidence ? (
+        <div className="awb-mini-empty">
+          No linked evidence or artifacts for this task yet.
+        </div>
+      ) : (
+        <div className="awb-evidence-grid">
+          <WorkflowSteps workflow={workflow} />
+          <EvidenceGroup
+            title="Citations"
+            items={citations.map(formatCitation)}
+          />
+          <EvidenceGroup
+            title="Captures"
+            items={captures.map(formatArtifact)}
+          />
+          <EvidenceGroup
+            title="Promotions"
+            items={promotions.map(formatArtifact)}
+          />
+          <EvidenceGroup
+            title="Partial errors"
+            items={errors.map(formatError)}
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function WorkflowSteps({ workflow }: { workflow?: TaskMemoryWorkflow }) {
+  if (!hasWorkflowSteps(workflow)) return null;
+  return (
+    <div className="awb-evidence-group awb-evidence-group-wide">
+      <h4>Workflow</h4>
+      <div className="awb-step-row">
+        {WORKFLOW_STEPS.map((step) => {
+          const state = workflow?.[step];
+          const satisfied = isStepSatisfied(state);
+          return (
+            <span
+              key={step}
+              className={`awb-step ${satisfied ? "awb-step-done" : ""}`}
+            >
+              {step}
+              {state?.count ? ` ${state.count}` : ""}
+            </span>
+          );
+        })}
+      </div>
+      {workflow?.requirement_reason ? (
+        <p>{workflow.requirement_reason}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function EvidenceGroup({ title, items }: { title: string; items: string[] }) {
+  if (items.length === 0) return null;
+  return (
+    <div className="awb-evidence-group">
+      <h4>{title}</h4>
+      <ul>
+        {items.slice(0, 4).map((item) => (
+          <li key={`${title}-${item}`}>{item}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function RunList({
+  runs,
+  selectedTaskId,
+  onSelectTask,
+}: {
+  runs: TaskLogSummary[];
+  selectedTaskId: string | null;
+  onSelectTask: (taskId: string) => void;
+}) {
+  return (
+    <section className="awb-panel awb-side-panel">
+      <div className="awb-panel-heading">
+        <h3>Recent runs</h3>
+        <span className="awb-count">{runs.length}</span>
+      </div>
+      {runs.length === 0 ? (
+        <div className="awb-mini-empty">No recent runs match this view.</div>
+      ) : (
+        <div className="awb-run-list">
+          {runs.slice(0, 12).map((run) => (
+            <button
+              type="button"
+              key={`${run.agentSlug}-${run.taskId}`}
+              className={`awb-run ${selectedTaskId === run.taskId ? "active" : ""}`}
+              onClick={() => onSelectTask(run.taskId)}
+            >
+              <span>
+                <strong>{run.taskId}</strong>
+                <small>@{run.agentSlug}</small>
+              </span>
+              <span className="awb-run-meta">
+                {run.toolCallCount} tools
+                {run.hasError ? " · error" : ""}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function TaskList({
+  tasks,
+  selectedTaskId,
+  onSelectTask,
+}: {
+  tasks: Task[];
+  selectedTaskId: string | null;
+  onSelectTask: (taskId: string) => void;
+}) {
+  return (
+    <section className="awb-panel awb-side-panel">
+      <div className="awb-panel-heading">
+        <h3>Tasks</h3>
+        <span className="awb-count">{tasks.length}</span>
+      </div>
+      {tasks.length === 0 ? (
+        <div className="awb-mini-empty">No tasks match this workbench.</div>
+      ) : (
+        <div className="awb-task-list">
+          {tasks.slice(0, 12).map((task) => (
+            <button
+              type="button"
+              key={task.id}
+              className={`awb-task ${selectedTaskId === task.id ? "active" : ""}`}
+              onClick={() => onSelectTask(task.id)}
+            >
+              <span>{task.title || task.id}</span>
+              <small>
+                {displayStatus(task.status)}
+                {task.owner ? ` · @${task.owner}` : ""}
+              </small>
+            </button>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function resolveAgentSlug(
+  agentSlug: string | null | undefined,
+  taskId: string | null | undefined,
+  activeTaskId: string | null,
+  tasks: Task[],
+  runs: TaskLogSummary[],
+): string | null {
+  if (agentSlug) return agentSlug;
+  const selectedTaskId = taskId || activeTaskId;
+  if (selectedTaskId) {
+    const run = runs.find((candidate) => candidate.taskId === selectedTaskId);
+    if (run?.agentSlug) return run.agentSlug;
+    const task = tasks.find((candidate) => candidate.id === selectedTaskId);
+    if (task?.owner) return task.owner;
+  }
+  return runs[0]?.agentSlug || tasks.find((task) => task.owner)?.owner || null;
+}
+
+function filterRuns(
+  runs: TaskLogSummary[],
+  agentSlug: string | null,
+  taskId: string | null,
+): TaskLogSummary[] {
+  return runs
+    .filter((run) => {
+      if (agentSlug && run.agentSlug !== agentSlug) return false;
+      if (taskId && run.taskId !== taskId) return false;
+      return true;
+    })
+    .sort((a, b) => (b.lastToolAt ?? 0) - (a.lastToolAt ?? 0));
+}
+
+function filterTasks(
+  tasks: Task[],
+  agentSlug: string | null,
+  taskId: string | null | undefined,
+): Task[] {
+  return tasks.filter((task) => {
+    if (taskId && task.id !== taskId) return false;
+    if (agentSlug && task.owner && task.owner !== agentSlug) return false;
+    return true;
+  });
+}
+
+function resolveTask(
+  propTaskId: string | null | undefined,
+  activeTaskId: string | null,
+  visibleTasks: Task[],
+  allTasks: Task[],
+  runs: TaskLogSummary[],
+): Task | null {
+  const selectedTaskId = propTaskId || activeTaskId || runs[0]?.taskId || null;
+  if (!selectedTaskId) return visibleTasks[0] ?? null;
+  return (
+    visibleTasks.find((task) => task.id === selectedTaskId) ||
+    allTasks.find((task) => task.id === selectedTaskId) ||
+    visibleTasks[0] ||
+    null
+  );
+}
+
+function getLoadState(
+  loading: boolean,
+  error: boolean,
+  agentSlug: string | null,
+  tasks: Task[],
+  runs: TaskLogSummary[],
+): LoadState {
+  if (loading) return "loading";
+  if (error) return "error";
+  if (!agentSlug && tasks.length === 0 && runs.length === 0) return "empty";
+  return "ready";
+}
+
+function errorText(error: unknown): string | null {
+  return error instanceof Error ? error.message : null;
+}
+
+function displayStatus(status: string): string {
+  return status.replace(/[_-]+/g, " ");
+}
+
+function formatEpochTime(value: number): string {
+  return new Date(value).toLocaleTimeString([], {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function hasWorkflowSteps(
+  workflow?: TaskMemoryWorkflow | null,
+): workflow is TaskMemoryWorkflow {
+  return Boolean(
+    workflow &&
+      (workflow.required ||
+        workflow.status ||
+        WORKFLOW_STEPS.some((step) => workflow[step])),
+  );
+}
+
+function isStepSatisfied(step?: TaskMemoryWorkflowStepState): boolean {
+  const status = normalizeStatus(step?.status);
+  return Boolean(
+    step?.completed_at ||
+      status === "satisfied" ||
+      status === "complete" ||
+      status === "completed",
+  );
+}
+
+function memoryBadgeClass(workflow: TaskMemoryWorkflow): string {
+  const status = normalizeStatus(workflow.status);
+  if (workflow.partial_errors?.length || status.includes("error")) {
+    return "awb-memory awb-memory-warn";
+  }
+  if (workflow.override || status === "overridden") {
+    return "awb-memory awb-memory-warn";
+  }
+  if (status === "satisfied" || status === "complete" || status === "done") {
+    return "awb-memory awb-memory-done";
+  }
+  return "awb-memory";
+}
+
+function memoryBadgeLabel(workflow: TaskMemoryWorkflow): string {
+  const requiredSteps = WORKFLOW_STEPS.filter(
+    (step) => workflow.required_steps?.includes(step) || workflow[step],
+  );
+  const total = requiredSteps.length;
+  const done = requiredSteps.filter((step) =>
+    isStepSatisfied(workflow[step]),
+  ).length;
+  if (workflow.override) return "memory override";
+  if (workflow.partial_errors?.length) return "memory issue";
+  if (total > 0) return `memory ${done}/${total}`;
+  return workflow.status
+    ? `memory ${displayStatus(workflow.status)}`
+    : "memory";
+}
+
+function normalizeStatus(status?: string): string {
+  return (status || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
+}
+
+function formatCitation(citation: TaskMemoryWorkflowCitation): string {
+  const title =
+    citation.title ||
+    citation.path ||
+    citation.source_url ||
+    citation.source_id ||
+    "citation";
+  return [
+    title,
+    citation.path && citation.path !== title ? citation.path : null,
+    citation.source,
+    citation.stale ? "stale" : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function formatArtifact(artifact: TaskMemoryWorkflowArtifact): string {
+  const title =
+    artifact.title ||
+    artifact.path ||
+    artifact.page_id ||
+    artifact.promotion_id ||
+    "artifact";
+  return [
+    artifact.source,
+    title,
+    artifact.path && artifact.path !== title ? artifact.path : null,
+    artifact.state,
+    artifact.missing ? "missing" : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+}
+
+function formatError(error: string | TaskMemoryWorkflowPartialError): string {
+  if (typeof error === "string") return error;
+  return (
+    [error.step, error.code, error.message || error.detail]
+      .filter(Boolean)
+      .join(" · ") || "workflow error"
+  );
+}

--- a/web/src/components/workbench/AgentWorkbench.tsx
+++ b/web/src/components/workbench/AgentWorkbench.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getOfficeMembers } from "../../api/client";
@@ -68,6 +68,7 @@ function useAgentWorkbenchModel(
   const [activeTaskId, setActiveTaskId] = useState<string | null>(
     taskId ?? null,
   );
+  const previousAgentSlug = useRef(agentSlug);
 
   const logsQuery = useQuery({
     queryKey: ["agent-workbench", "agent-log-tasks"],
@@ -110,8 +111,15 @@ function useAgentWorkbenchModel(
   );
 
   useEffect(() => {
-    setActiveTaskId(taskId ?? null);
-  }, [taskId]);
+    setActiveTaskId((current) => {
+      const nextTaskId = taskId ?? null;
+      if (previousAgentSlug.current === agentSlug && current === nextTaskId) {
+        return current;
+      }
+      previousAgentSlug.current = agentSlug;
+      return nextTaskId;
+    });
+  }, [agentSlug, taskId]);
 
   useEffect(() => {
     if (taskId || activeTaskId || visibleTasks.length === 0) return;
@@ -121,9 +129,12 @@ function useAgentWorkbenchModel(
   const agent = selectedAgentSlug
     ? members.find((member) => member.slug === selectedAgentSlug)
     : null;
-  const selectedRun =
-    relevantRuns.find((run) => run.taskId === selectedTask?.id) ??
-    relevantRuns[0];
+  const requestedTaskId = taskId ?? activeTaskId;
+  const selectedRun = requestedTaskId
+    ? relevantRuns.find((run) => run.taskId === requestedTaskId)
+    : ((selectedTask
+        ? relevantRuns.find((run) => run.taskId === selectedTask.id)
+        : undefined) ?? relevantRuns[0]);
   const loadState = getLoadState(
     logsQuery.isLoading || tasksQuery.isLoading,
     logsQuery.isError || tasksQuery.isError,
@@ -516,6 +527,7 @@ function resolveAgentSlug(
     if (run?.agentSlug) return run.agentSlug;
     const task = tasks.find((candidate) => candidate.id === selectedTaskId);
     if (task?.owner) return task.owner;
+    return null;
   }
   return runs[0]?.agentSlug || tasks.find((task) => task.owner)?.owner || null;
 }
@@ -541,6 +553,7 @@ function filterTasks(
 ): Task[] {
   return tasks.filter((task) => {
     if (taskId && task.id !== taskId) return false;
+    if (agentSlug && !taskId && task.owner !== agentSlug) return false;
     if (agentSlug && task.owner && task.owner !== agentSlug) return false;
     return true;
   });
@@ -558,7 +571,6 @@ function resolveTask(
   return (
     visibleTasks.find((task) => task.id === selectedTaskId) ||
     allTasks.find((task) => task.id === selectedTaskId) ||
-    visibleTasks[0] ||
     null
   );
 }

--- a/web/src/components/workbench/index.ts
+++ b/web/src/components/workbench/index.ts
@@ -1,0 +1,1 @@
+export { AgentWorkbench, type AgentWorkbenchProps } from "./AgentWorkbench";

--- a/web/src/hooks/useHashRouter.ts
+++ b/web/src/hooks/useHashRouter.ts
@@ -11,6 +11,11 @@ type Route =
   | { view: "channel"; channel: string }
   | { view: "dm"; agent: string }
   | { view: "app"; app: string }
+  | {
+      view: "workbench";
+      agentSlug: string | null;
+      taskId: string | null;
+    }
   | { view: "wiki"; articlePath: string | null }
   | { view: "wiki-lookup"; query: string }
   | { view: "notebooks"; agentSlug: string | null; entrySlug: string | null }
@@ -27,6 +32,13 @@ function parseHash(hash: string): Route {
     return { view: "dm", agent: decodeURIComponent(parts[1]) };
   }
   if (parts[0] === "apps" && parts[1]) {
+    const app = decodeURIComponent(parts[1]);
+    if (app === "workbench") {
+      const agentSlug = parts[2] ? decodeURIComponent(parts[2]) : null;
+      const taskId =
+        parts[3] === "tasks" && parts[4] ? decodeURIComponent(parts[4]) : null;
+      return { view: "workbench", agentSlug, taskId };
+    }
     return { view: "app", app: decodeURIComponent(parts[1]) };
   }
   if (parts[0] === "console") {
@@ -66,6 +78,8 @@ function stateToHash(state: {
   wikiLookupQuery: string | null;
   notebookAgentSlug: string | null;
   notebookEntrySlug: string | null;
+  workbenchAgentSlug: string | null;
+  workbenchTaskId: string | null;
 }): string {
   if (state.currentApp === "wiki-lookup") {
     return state.wikiLookupQuery
@@ -88,6 +102,16 @@ function stateToHash(state: {
   }
   if (state.currentApp === "reviews") {
     return "#/reviews";
+  }
+  if (state.currentApp === "workbench") {
+    const parts = ["apps", "workbench"];
+    if (state.workbenchAgentSlug) {
+      parts.push(encodeURIComponent(state.workbenchAgentSlug));
+      if (state.workbenchTaskId) {
+        parts.push("tasks", encodeURIComponent(state.workbenchTaskId));
+      }
+    }
+    return `#/${parts.join("/")}`;
   }
   if (state.currentApp) {
     return `#/apps/${encodeURIComponent(state.currentApp)}`;
@@ -128,6 +152,9 @@ export function useHashRouter() {
   const notebookAgentSlug = useAppStore((s) => s.notebookAgentSlug);
   const notebookEntrySlug = useAppStore((s) => s.notebookEntrySlug);
   const setNotebookRoute = useAppStore((s) => s.setNotebookRoute);
+  const workbenchAgentSlug = useAppStore((s) => s.workbenchAgentSlug);
+  const workbenchTaskId = useAppStore((s) => s.workbenchTaskId);
+  const setWorkbenchRoute = useAppStore((s) => s.setWorkbenchRoute);
 
   // Avoid ping-ponging: skip the next hashchange or store-sync when we
   // were the one that caused it.
@@ -148,6 +175,8 @@ export function useHashRouter() {
         enterDM(route.agent, directChannelSlug(route.agent));
       } else if (route.view === "app") {
         setCurrentApp(route.app);
+      } else if (route.view === "workbench") {
+        setWorkbenchRoute(route.agentSlug, route.taskId);
       } else if (route.view === "wiki-lookup") {
         setWikiLookupQuery(route.query);
         setCurrentApp("wiki-lookup");
@@ -177,6 +206,7 @@ export function useHashRouter() {
     setWikiPath,
     setWikiLookupQuery,
     setNotebookRoute,
+    setWorkbenchRoute,
   ]);
 
   // Push store changes back into the hash
@@ -193,6 +223,8 @@ export function useHashRouter() {
       wikiLookupQuery,
       notebookAgentSlug,
       notebookEntrySlug,
+      workbenchAgentSlug,
+      workbenchTaskId,
     });
     if (next !== window.location.hash) {
       // replaceState does not emit `hashchange`, so do not arm
@@ -208,5 +240,7 @@ export function useHashRouter() {
     wikiLookupQuery,
     notebookAgentSlug,
     notebookEntrySlug,
+    workbenchAgentSlug,
+    workbenchTaskId,
   ]);
 }

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -6,6 +6,7 @@ export const SIDEBAR_APPS = [
   { id: "wiki", icon: "\uD83D\uDCD6", name: "Wiki" },
   { id: "console", icon: ">", name: "Console" },
   { id: "tasks", icon: "\u2705", name: "Tasks" },
+  { id: "workbench", icon: "\uD83D\uDCBB", name: "Workbench" },
   { id: "requests", icon: "\uD83D\uDCCB", name: "Requests" },
   { id: "graph", icon: "\uD83D\uDD78", name: "Graph" },
   { id: "policies", icon: "\uD83D\uDEE1", name: "Policies" },

--- a/web/src/stores/app.test.ts
+++ b/web/src/stores/app.test.ts
@@ -19,6 +19,8 @@ afterEach(() => {
     wikiLookupQuery: null,
     notebookAgentSlug: null,
     notebookEntrySlug: null,
+    workbenchAgentSlug: null,
+    workbenchTaskId: null,
   });
 });
 
@@ -120,6 +122,26 @@ describe("channel unread state", () => {
     expect(useAppStore.getState().currentApp).toBeNull();
     expect(useAppStore.getState().unreadByChannel.general).toBe(0);
     expect(useAppStore.getState().unreadByChannel.launch).toBe(1);
+  });
+});
+
+describe("workbench navigation state", () => {
+  it("clears scoped workbench context for generic app navigation", () => {
+    useAppStore.getState().openAgentWorkbench("builder", "task-7");
+
+    expect(useAppStore.getState()).toMatchObject({
+      currentApp: "workbench",
+      workbenchAgentSlug: "builder",
+      workbenchTaskId: "task-7",
+    });
+
+    useAppStore.getState().setCurrentApp("workbench");
+
+    expect(useAppStore.getState()).toMatchObject({
+      currentApp: "workbench",
+      workbenchAgentSlug: null,
+      workbenchTaskId: null,
+    });
   });
 });
 

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -119,6 +119,10 @@ export interface AppStore {
   setCurrentChannel: (ch: string) => void;
   currentApp: string | null; // null = messages view
   setCurrentApp: (app: string | null) => void;
+  workbenchAgentSlug: string | null;
+  workbenchTaskId: string | null;
+  openAgentWorkbench: (agentSlug: string, taskId?: string | null) => void;
+  setWorkbenchRoute: (agentSlug: string | null, taskId: string | null) => void;
 
   // Channel metadata (DM info, etc.)
   channelMeta: Record<string, ChannelMeta>;
@@ -241,6 +245,22 @@ export const useAppStore = create<AppStore>((set, get) => ({
 
     set({ currentApp: app });
   },
+  workbenchAgentSlug: null,
+  workbenchTaskId: null,
+  openAgentWorkbench: (agentSlug, taskId = null) =>
+    set({
+      currentApp: "workbench",
+      workbenchAgentSlug: agentSlug,
+      workbenchTaskId: taskId,
+      activeAgentSlug: null,
+    }),
+  setWorkbenchRoute: (agentSlug, taskId) =>
+    set({
+      currentApp: "workbench",
+      workbenchAgentSlug: agentSlug,
+      workbenchTaskId: taskId,
+      activeAgentSlug: null,
+    }),
 
   channelMeta: {},
   setChannelMeta: (slug, meta) =>
@@ -404,6 +424,8 @@ export const useAppStore = create<AppStore>((set, get) => ({
       wikiLookupQuery: null,
       notebookAgentSlug: null,
       notebookEntrySlug: null,
+      workbenchAgentSlug: null,
+      workbenchTaskId: null,
     }),
 
   wikiPath: null,

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -237,13 +237,17 @@ export const useAppStore = create<AppStore>((set, get) => ({
       return;
     }
 
+    const scopedAppState =
+      app === "workbench"
+        ? { workbenchAgentSlug: null, workbenchTaskId: null }
+        : {};
     const { currentChannel, channelMeta } = get();
     if (isDMChannel(currentChannel, channelMeta)) {
-      set({ currentApp: app, currentChannel: "general" });
+      set({ currentApp: app, currentChannel: "general", ...scopedAppState });
       return;
     }
 
-    set({ currentApp: app });
+    set({ currentApp: app, ...scopedAppState });
   },
   workbenchAgentSlug: null,
   workbenchTaskId: null,

--- a/web/src/stores/app.ts
+++ b/web/src/stores/app.ts
@@ -252,12 +252,7 @@ export const useAppStore = create<AppStore>((set, get) => ({
   workbenchAgentSlug: null,
   workbenchTaskId: null,
   openAgentWorkbench: (agentSlug, taskId = null) =>
-    set({
-      currentApp: "workbench",
-      workbenchAgentSlug: agentSlug,
-      workbenchTaskId: taskId,
-      activeAgentSlug: null,
-    }),
+    get().setWorkbenchRoute(agentSlug, taskId),
   setWorkbenchRoute: (agentSlug, taskId) =>
     set({
       currentApp: "workbench",


### PR DESCRIPTION
## Summary
- add a focused agent workbench with task context, memory evidence, recent runs, and live terminal output\n- add workbench entry points from agent panels, task cards, sidebar app navigation, and hash deep links\n- document three ICP live QA scenarios for Phase 2 validation\n\n## Verification\n- bash scripts/test-web.sh web/src/components/workbench/AgentWorkbench.test.tsx\n- cd web && bunx tsc --noEmit\n- cd web && bunx biome check src/components/workbench src/App.tsx src/components/agents/AgentPanel.tsx src/components/apps/TasksApp.tsx src/components/sidebar/AppList.tsx src/hooks/useHashRouter.ts src/lib/constants.ts src/stores/app.ts\n- bash scripts/test-web.sh\n- cd web && bun run build\n- bash scripts/check-bundle-size.sh\n- go build -o /tmp/wuphf-phase2 ./cmd/wuphf\n- browser smoke: isolated runtime on :5281/:5280, opened #/apps/tasks and #/apps/workbench/builder/tasks/task-3\n\n## Screenshots\n- /tmp/wuphf-phase2-tasks.png\n- /tmp/wuphf-phase2-workbench-task.png

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workbench app in the sidebar for inspecting agent context, task evidence, runs, workflow steps, and an integrated terminal
  * “Open workbench” actions on agent panels and eligible task cards; supports deep-linking to agent and task contexts via URL/hash and route state

* **Style**
  * New responsive Workbench layout and visual styles

* **Documentation**
  * Added Phase 2 Workbench examples and Live QA testing guide

* **Tests**
  * Added UI tests covering rendering, deep-links, context switching, empty states, and run/task selection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->