### PR TITLE
[codex] test(web): add route migration phase 0 coverage

### DIFF
--- a/docs/experiments/2026-05-04-web-path-forward.md
+++ b/docs/experiments/2026-05-04-web-path-forward.md
@@ -1,0 +1,268 @@
+# Web Path Forward
+
+Date: 2026-05-04
+Branch: `research/web-path-forward-20260504`
+Base: `origin/main` at `735c3619`
+
+## Goal
+
+Improve the Web surface so new product areas can be added without fragile
+navigation glue, wide central files, or hidden state coupling. The main
+candidate is a real TanStack Router migration, but the broader goal is route
+ownership, typed data contracts, and repeatable test evidence.
+
+## Current Findings
+
+- `@tanstack/react-router` is already a dependency, and
+  `web/src/lib/router.ts` defines a small route tree, but it is not mounted.
+  `web/src/main.tsx` renders `<App />` directly inside `QueryClientProvider`
+  and never uses `RouterProvider`.
+- Real navigation is `web/src/hooks/useHashRouter.ts`: manual hash parsing,
+  manual hash serialization, and two-way sync with Zustand using ignore flags.
+  That makes the URL and store competing sources of truth.
+- Route state lives in `web/src/stores/app.ts` as `currentApp`,
+  `currentChannel`, `wikiPath`, `wikiLookupQuery`, `notebookAgentSlug`, and
+  `notebookEntrySlug`. The same store also owns legitimate ephemeral UI state
+  like modals, sidebar state, unread counts, and thread panel state.
+- `web/src/App.tsx` is the route switchboard. It imports every app panel,
+  special-cases wiki/notebooks/reviews, and maps app IDs to components in one
+  central block. Adding a product area means touching global navigation state,
+  the central switch, sidebar constants, tests, and often route hash code.
+- Hash URLs are still the right starting point. The Go Web UI server currently
+  serves static files through `http.FileServer` at `/`; it does not provide a
+  SPA fallback for arbitrary browser-history routes. Moving off hashes should
+  be a later server change, not part of the first router migration.
+- The data layer is partially on the right path. `web/src/api/workspaces.ts`
+  has typed hooks and key factories; other domains still mix ad hoc query keys
+  and large catch-all API helpers. The router work should reinforce domain
+  slices instead of creating another cross-cutting layer.
+- Existing E2E coverage has a useful `app-routes.spec.ts` guard for app route
+  isolation. What is missing is a route contract test that proves every
+  registered route can render, parse params/search, and navigate without going
+  through the old Zustand bridge.
+
+## Recommendation
+
+Adopt TanStack Router, but do it as a source-of-truth migration instead of a
+wrapper around the existing hash hook.
+
+Use `createHashHistory()` first so the URL shape remains compatible with the
+current static file server and external links. TanStack's docs explicitly
+support hash history for servers that do not rewrite all paths to
+`index.html`.
+
+Make the URL own navigation state:
+
+- Route params own channel, DM agent, app ID, wiki article path, notebook agent,
+  notebook entry, and review route.
+- Search params own query-like state such as wiki lookup `q`.
+- Zustand keeps session UI state only: sidebar open/collapsed state, modal
+  state, unread counters, active thread, active agent panel, theme, connection
+  state, onboarding state, and transient composer state.
+
+Start with code-based route modules rather than immediately adding file-based
+route generation. TanStack's docs recommend file-based routes in general, but
+this repo already has a code-based stub and no router plugin wiring. A first
+code-based migration reduces build-tool churn and still gives typed params,
+typed search, nested layouts, route errors, and route-local loaders. Revisit
+file-based routes after the route ownership model has settled.
+
+## Target Route Shape
+
+Initial hash routes should preserve current URLs:
+
+| Route | Owns |
+|---|---|
+| `/` | redirect/default to `/channels/general` |
+| `/channels/$channelSlug` | channel message feed |
+| `/dm/$agentSlug` | DM view, deriving broker direct channel slug |
+| `/apps/$appId` | generic app panel route with validated app IDs |
+| `/console` | legacy alias redirect to `/apps/console` |
+| `/threads` | legacy alias redirect to `/apps/threads` |
+| `/wiki` | wiki catalog/root |
+| `/wiki/lookup?q=...` | wiki lookup answer route |
+| `/wiki/$` | splat article path |
+| `/notebooks` | notebook catalog |
+| `/notebooks/$agentSlug` | agent notebook |
+| `/notebooks/$agentSlug/$entrySlug` | notebook entry |
+| `/reviews` | promotion review queue |
+
+Shell layout should be a route layout, not an `App.tsx` switch. Global hosts
+such as toast, confirm, provider switcher, Telegram connect, search, help, and
+thread/agent panels can remain mounted at the root or shell layout.
+
+## Migration Sequence
+
+1. Route inventory and invariant tests
+   - Introduce a `web/src/routes/` directory and route ID/app ID types.
+   - Add tests that compile the route tree, validate app IDs, and preserve
+     current hash URLs.
+   - Keep `useHashRouter` active during this step.
+
+2. Mount TanStack Router with a temporary adapter
+   - Replace `<App />` entry with `<RouterProvider router={router} />`.
+   - Use `createHashHistory()` and keep current visual output.
+   - Route components may initially write into the existing store one-way so
+     old components keep working. Do not keep store-to-hash sync.
+
+3. Convert navigators to typed navigation
+   - Replace `setCurrentApp`, `setCurrentChannel`, `setWikiPath`, and
+     `setNotebookRoute` calls in sidebar/search/composer shortcuts with
+     `<Link>` or `router.navigate`.
+   - Add small navigation helpers only where route APIs would otherwise leak
+     into non-route utilities.
+
+4. Move route-owned state out of Zustand
+   - Channel message components read `channelSlug` from route params.
+   - DM components read `agentSlug` and derive the direct channel slug.
+   - Wiki/notebook/review components read params/search directly.
+   - Remove `currentApp`, `currentChannel`, `wikiPath`, `wikiLookupQuery`,
+     `notebookAgentSlug`, and `notebookEntrySlug` from the store after the last
+     consumer is converted.
+
+5. Split route panels and add route boundaries
+   - Move the large panel map out of `App.tsx` into route modules.
+   - Add route-level pending/error boundaries so one panel can fail without
+     blanking the whole office.
+   - Lazy-load heavy panels such as Skills, Settings, Graph, Artifacts, and
+     wiki/notebook surfaces.
+
+6. Optional browser-history follow-up
+   - Add an explicit Go SPA fallback that serves `index.html` for non-API,
+     non-asset routes.
+   - Only then consider `createBrowserHistory()`.
+
+## Reliability Work Beyond Router
+
+- Standardize query keys per domain. Use key factories like
+  `workspaceKeys` for tasks, messages, office, wiki, notebook, reviews,
+  skills, platform, and providers. SSE invalidation should target these
+  factories instead of ad hoc string prefixes.
+- Continue extracting API contracts by domain. The existing docs already track
+  `WEB-ROUTER-001` as deferred until contract slices mature; the router PRs
+  should not add new implicit response shapes.
+- Create a shared Web test harness for `QueryClientProvider`, router provider,
+  store reset, and common API mocks. Several tests currently hand-roll
+  `QueryClient` wrappers.
+- Add a route matrix E2E test after migration. It should visit every public
+  route, assert no React errors, assert shell stability, and assert active
+  sidebar state.
+- Centralize event types for `/events`. Route-level data will be more reliable
+  if SSE invalidation is typed by domain instead of matching anonymous event
+  strings in one hook.
+- Keep workspace switching as full-page navigation. The current security model
+  intentionally avoids cross-broker tokens inside the SPA.
+
+## Open Questions To Resolve Before Step 2
+
+These are gaps in the current plan, surfaced during review:
+
+1. **Replace the existing router stub, do not extend it.** `web/src/lib/router.ts`
+   currently calls `createRouter({ routeTree })` with default (browser) history
+   and a comment that incorrectly claims it works with Go's FileServer. The
+   stub is missing the shell layout and the wiki/notebooks/dm/reviews routes.
+   Step 2 must rewrite this file with `createHashHistory()` and the full route
+   table from the Target Route Shape section, not build on top of the stub.
+
+2. **The temporary store-write bridge in step 2 is debt with a deadline.** If
+   route components write one-way into the existing store while old components
+   keep reading it, that recreates the `ignoreNextHashChange` /
+   `ignoreNextStoreSync` failure mode. The bridge must be removed by the end
+   of step 4 in the same PR train; do not let it ship as a stable layer.
+
+3. **DM hydration ownership.** `enterDM(agent, directChannelSlug(agent))` in
+   the current hook mutates `channelMeta` so the rest of the UI can resolve
+   the DM channel. Once `agentSlug` lives in the route, something else has to
+   guarantee `channelMeta` is populated — either the DM route loader hydrates
+   it from the API, or DM channel meta moves out of the store entirely. Decide
+   before step 4 starts; otherwise that step stalls.
+
+4. **Wiki lookup search params under hash history.** TanStack search params on
+   hash history serialize as `#/wiki/lookup?q=foo`. The wiki lookup route's
+   `validateSearch` should accept that shape directly. We do not need to
+   support legacy URL formats — switch cleanly to the TanStack-native shape.
+
+5. **E2E scope wording.** Step 2 mounts the router in product code, so its
+   PR must run the full shell E2E matrix. The "first PR can skip full E2E"
+   sentence in Evidence Per PR only applies to step 1.
+
+6. **Step sizing.** Step 4 (draining `currentApp`, `currentChannel`,
+   `wikiPath`, `wikiLookupQuery`, `notebookAgentSlug`, `notebookEntrySlug`
+   from the store) touches every panel consumer and is the long pole of this
+   migration. Plan it as multiple PRs, one domain at a time.
+
+7. **Split the non-router reliability work into its own track.** Query-key
+   standardization, the shared test harness, and centralized `/events` types
+   are independent of the router migration and should not bloat its PR train.
+   Land them before or after, not inside.
+
+8. **No legacy URL aliases.** Drop the current `#/threads` →
+   `apps/threads` mapping and the silent malformed-hash fallback to
+   `channels/general`. Routes go straight to the new format; unknown routes
+   should render an explicit not-found instead of redirecting silently.
+
+## Things Not To Do
+
+- Do not wrap the current `useHashRouter` in TanStack Router and call it done.
+  That keeps the two-source-of-truth problem.
+- Do not move to browser history before the Go Web UI server has a tested SPA
+  fallback.
+- Do not make TanStack Router loaders replace TanStack Query globally. Use
+  route loaders for route prerequisites and preloading; keep server state in
+  React Query where polling, invalidation, and mutations are already established.
+- Do not combine this with a large visual redesign. Router migration should be
+  behavior-preserving.
+
+## Evidence Per PR
+
+Focused route PRs should run:
+
+- `bash scripts/test-web.sh web/src/path/to/focused.test.ts`
+- `bash scripts/test-web.sh`
+- from `web/`: `bunx tsc --noEmit`
+- from `web/`: `bun run build`
+- for route behavior: `web/e2e/run-local.sh shell`
+
+The first PR can skip full E2E only if it does not mount the router in product
+code. Any PR that changes real navigation should include the shell E2E route
+matrix.
+
+## Phase 0 Implemented
+
+Phase 0 landed as behavior-preserving scaffolding:
+
+- `web/src/routes/legacyHash.ts` extracts the current hash parser/serializer
+  from `useHashRouter` into pure functions.
+- `web/src/routes/legacyHash.test.ts` pins legacy route behavior for channels,
+  DMs, app routes, wiki, wiki lookup, notebooks, reviews, malformed hashes,
+  DM slug derivation, and serialization round trips.
+- `web/src/routes/routeRegistry.ts` defines the planned route inventory,
+  app-panel IDs, first-class sidebar surfaces, and route-owned state fields.
+- `web/src/routes/routeRegistry.test.ts` proves sidebar apps are classified,
+  route contracts stay unique, TanStack's unmounted route tree matches every
+  planned route, wiki splat params are captured, and default hash history keeps
+  static-file-server compatibility.
+- `web/src/lib/router.ts` now exposes the fuller unmounted TanStack route tree
+  plus `createAppRouter()` for tests and the future `RouterProvider` mount.
+- `web/e2e/tests/telegram-connect.spec.ts` now asserts the current
+  token-verify -> mode-selection -> group-pick/DM behavior instead of expecting
+  verify to jump directly to the group picker.
+
+Phase 0 also caught two useful migration details before runtime routing changed:
+
+- Wiki splat routes must be nested behind a wiki index route, otherwise the
+  splat route steals `/wiki`.
+- TanStack hash history creates browser hrefs like `/#/channels/general`; that
+  is compatible with the current static server, but tests should not expect a
+  bare `#/...` href from Router links.
+- The shell E2E suite had stale Telegram wizard expectations around the
+  intermediate mode-selection step. Updating those tests keeps the migration
+  evidence trustworthy instead of letting unrelated expected-flow drift block
+  router work later.
+
+## External Docs Checked
+
+- TanStack Router route trees: `https://tanstack.com/router/latest/docs/routing/route-trees`
+- TanStack Router history types: `https://tanstack.com/router/latest/docs/guide/history-types`
+- TanStack Router search params: `https://tanstack.com/router/latest/docs/guide/search-params`
+- TanStack Router data loading: `https://tanstack.com/router/latest/docs/guide/data-loading`

--- a/web/e2e/tests/telegram-connect.spec.ts
+++ b/web/e2e/tests/telegram-connect.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 
 import {
   collectReactErrors,
@@ -19,12 +19,13 @@ import {
 //   3. Submitting empty token shows an inline validation error.
 //   4. Verify failure (broker says ok:false) keeps the user on the token step
 //      with an editable input and an inline error banner.
-//   5. Verify success advances to discovery and renders the picker step.
+//   5. Verify success advances to mode selection, then group mode discovers
+//      chats and renders the picker step.
 //   6. Empty group list shows "no groups" copy + retry/manual/dm controls.
 //   7. Picking a group fires POST /telegram/connect with the right body and
 //      lands on the done step showing the new channel slug.
 //   8. Manual chat ID flow validates the input and posts an integer chat_id.
-//   9. "Use as DM" posts chat_id=0.
+//   9. Choosing DM mode posts chat_id=0.
 //  10. Connect failure keeps the picker step active with the error visible.
 //  10b. Modal renders with a visible card surface (regression: wk-* CSS
 //       variables must resolve outside `.wiki-root`).
@@ -95,7 +96,7 @@ const connectFail = {
 // Open the Telegram wizard directly via `/connect telegram` so the tests
 // don't have to click through the provider picker first. The bare-`/connect`
 // path that lands on the provider picker has its own dedicated test below.
-async function openTelegramWizard(page: import("@playwright/test").Page) {
+async function openTelegramWizard(page: Page) {
   const composer = page.locator(".composer-input");
   await composer.click();
   // Trailing space defeats the autocomplete picker so Enter dispatches the
@@ -107,6 +108,22 @@ async function openTelegramWizard(page: import("@playwright/test").Page) {
     timeout: 5_000,
   });
   await expect(page.getByTestId("tg-step-token")).toBeVisible();
+}
+
+async function verifyTokenToMode(page: Page, token = "123456:ABC") {
+  await page.getByTestId("tg-token-input").fill(token);
+  await page.getByTestId("tg-token-submit").click();
+  await expect(page.getByTestId("tg-step-mode")).toBeVisible({
+    timeout: 5_000,
+  });
+}
+
+async function verifyTokenAndOpenGroupPicker(page: Page, token = "123456:ABC") {
+  await verifyTokenToMode(page, token);
+  await page.getByTestId("tg-mode-group").click();
+  await expect(page.getByTestId("tg-step-pick")).toBeVisible({
+    timeout: 5_000,
+  });
 }
 
 test.describe("wuphf web /connect Telegram wizard", () => {
@@ -233,12 +250,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
     });
 
     await openTelegramWizard(page);
-    await page.getByTestId("tg-token-input").fill("123456:ABC");
-    await page.getByTestId("tg-token-submit").click();
-
-    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
-      timeout: 5_000,
-    });
+    await verifyTokenAndOpenGroupPicker(page);
     await expect(page.getByTestId("tg-group-list")).toBeVisible();
 
     await page.getByTestId("tg-group--123456").click();
@@ -269,17 +281,16 @@ test.describe("wuphf web /connect Telegram wizard", () => {
     );
 
     await openTelegramWizard(page);
-    await page.getByTestId("tg-token-input").fill("123456:ABC");
-    await page.getByTestId("tg-token-submit").click();
-
-    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
-      timeout: 5_000,
-    });
+    await verifyTokenAndOpenGroupPicker(page);
     await expect(page.getByTestId("tg-retry-discover")).toBeVisible();
     await expect(page.getByTestId("tg-manual-chat-id")).toBeVisible();
-    await expect(page.getByTestId("tg-connect-dm")).toBeVisible();
+    await page.getByText("Back", { exact: true }).click();
+    await expect(page.getByTestId("tg-step-mode")).toBeVisible();
+    await expect(page.getByTestId("tg-mode-dm")).toBeVisible();
   });
+});
 
+test.describe("wuphf web /connect Telegram wizard connect modes", () => {
   test("[8] manual chat ID validates and posts integer chat_id", async ({
     page,
   }) => {
@@ -298,11 +309,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
     });
 
     await openTelegramWizard(page);
-    await page.getByTestId("tg-token-input").fill("123456:ABC");
-    await page.getByTestId("tg-token-submit").click();
-    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
-      timeout: 5_000,
-    });
+    await verifyTokenAndOpenGroupPicker(page);
 
     await page.getByTestId("tg-manual-chat-id").click();
     await expect(page.getByTestId("tg-step-manual")).toBeVisible();
@@ -345,11 +352,7 @@ test.describe("wuphf web /connect Telegram wizard", () => {
     );
 
     await openTelegramWizard(page);
-    await page.getByTestId("tg-token-input").fill("123456:ABC");
-    await page.getByTestId("tg-token-submit").click();
-    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
-      timeout: 5_000,
-    });
+    await verifyTokenAndOpenGroupPicker(page);
 
     await page.getByTestId("tg-manual-chat-id").click();
     await page.getByTestId("tg-manual-id-input").fill("-5093020979");
@@ -359,14 +362,11 @@ test.describe("wuphf web /connect Telegram wizard", () => {
     await expect(page.getByRole("alert")).toContainText(/chat not found/i);
   });
 
-  test('[9] "Use as DM" posts chat_id=0', async ({ page }) => {
+  test("[9] choosing DM mode posts chat_id=0", async ({ page }) => {
     await page.goto("/");
     await waitForShellReady(page);
 
     await page.route("**/telegram/verify", (route) => route.fulfill(verifyOK));
-    await page.route("**/telegram/discover", (route) =>
-      route.fulfill(discoverEmpty),
-    );
 
     let connectBody: { chat_id?: number; type?: string } | null = null;
     await page.route("**/telegram/connect", async (route, req) => {
@@ -375,13 +375,8 @@ test.describe("wuphf web /connect Telegram wizard", () => {
     });
 
     await openTelegramWizard(page);
-    await page.getByTestId("tg-token-input").fill("123456:ABC");
-    await page.getByTestId("tg-token-submit").click();
-    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
-      timeout: 5_000,
-    });
-
-    await page.getByTestId("tg-connect-dm").click();
+    await verifyTokenToMode(page);
+    await page.getByTestId("tg-mode-dm").click();
     await expect(page.getByTestId("tg-step-done")).toBeVisible({
       timeout: 5_000,
     });
@@ -404,18 +399,16 @@ test.describe("wuphf web /connect Telegram wizard", () => {
     );
 
     await openTelegramWizard(page);
-    await page.getByTestId("tg-token-input").fill("123456:ABC");
-    await page.getByTestId("tg-token-submit").click();
-    await expect(page.getByTestId("tg-step-pick")).toBeVisible({
-      timeout: 5_000,
-    });
+    await verifyTokenAndOpenGroupPicker(page);
 
     await page.getByTestId("tg-group--123456").click();
 
     await expect(page.getByTestId("tg-step-pick")).toBeVisible();
     await expect(page.getByRole("alert")).toContainText(/chat not found/i);
   });
+});
 
+test.describe("wuphf web /connect Telegram wizard regressions", () => {
   test("[10b] modal renders with a visible card surface (regression: wk-* CSS vars must resolve outside .wiki-root)", async ({
     page,
   }) => {
@@ -452,18 +445,20 @@ test.describe("wuphf web /connect Telegram wizard", () => {
         cardBorderWidth: cs.borderTopWidth,
       };
     });
-    expect(styles, "modal DOM should be present").not.toBeNull();
+    if (!styles) {
+      throw new Error("modal DOM should be present");
+    }
     // Backdrop must dim the page (non-zero alpha) and be position:fixed.
-    expect(styles!.backdropPosition).toBe("fixed");
-    expect(styles!.backdropBg).not.toBe("rgba(0, 0, 0, 0)");
-    expect(styles!.backdropBg).not.toBe("transparent");
+    expect(styles.backdropPosition).toBe("fixed");
+    expect(styles.backdropBg).not.toBe("rgba(0, 0, 0, 0)");
+    expect(styles.backdropBg).not.toBe("transparent");
     // Card must have an opaque background — the original bug had this as
     // rgba(0,0,0,0) because var(--wk-paper) didn't resolve.
-    expect(styles!.cardBg).not.toBe("rgba(0, 0, 0, 0)");
-    expect(styles!.cardBg).not.toBe("transparent");
+    expect(styles.cardBg).not.toBe("rgba(0, 0, 0, 0)");
+    expect(styles.cardBg).not.toBe("transparent");
     // Card must have a visible border (non-zero width). Original bug:
     // border-width was 0px because var(--wk-border) didn't resolve.
-    expect(styles!.cardBorderWidth).not.toBe("0px");
+    expect(styles.cardBorderWidth).not.toBe("0px");
   });
 
   test("[10c] verify the wizard renders styled when opened from a non-wiki route (regression)", async ({
@@ -533,6 +528,10 @@ test.describe("wuphf web /connect Telegram wizard", () => {
 
     await page.getByTestId("tg-token-input").fill("123456:GOOD");
     await page.getByTestId("tg-token-submit").click();
+    await expect(page.getByTestId("tg-step-mode")).toBeVisible({
+      timeout: 5_000,
+    });
+    await page.getByTestId("tg-mode-group").click();
     await expect(page.getByTestId("tg-step-pick")).toBeVisible({
       timeout: 5_000,
     });

--- a/web/src/hooks/useHashRouter.ts
+++ b/web/src/hooks/useHashRouter.ts
@@ -1,103 +1,11 @@
 import { useEffect, useRef } from "react";
 
 import {
-  type ChannelMeta,
-  directChannelSlug,
-  isDMChannel,
-  useAppStore,
-} from "../stores/app";
-
-type Route =
-  | { view: "channel"; channel: string }
-  | { view: "dm"; agent: string }
-  | { view: "app"; app: string }
-  | { view: "wiki"; articlePath: string | null }
-  | { view: "wiki-lookup"; query: string }
-  | { view: "notebooks"; agentSlug: string | null; entrySlug: string | null }
-  | { view: "reviews" };
-
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
-function parseHash(hash: string): Route {
-  const cleaned = hash.replace(/^#\/?/, "");
-  const parts = cleaned.split("/").filter(Boolean);
-  if (parts[0] === "channels" && parts[1]) {
-    return { view: "channel", channel: decodeURIComponent(parts[1]) };
-  }
-  if (parts[0] === "dm" && parts[1]) {
-    return { view: "dm", agent: decodeURIComponent(parts[1]) };
-  }
-  if (parts[0] === "apps" && parts[1]) {
-    return { view: "app", app: decodeURIComponent(parts[1]) };
-  }
-  if (parts[0] === "console") {
-    return { view: "app", app: "console" };
-  }
-  if (parts[0] === "threads") {
-    return { view: "app", app: "threads" };
-  }
-  if (parts[0] === "wiki" && parts[1] === "lookup") {
-    const params = new URLSearchParams(
-      window.location.search.slice(1) || cleaned.split("?")[1] || "",
-    );
-    const q = params.get("q") || "";
-    return { view: "wiki-lookup", query: decodeURIComponent(q) };
-  }
-  if (parts[0] === "wiki") {
-    const rest = parts.slice(1).map(decodeURIComponent).join("/");
-    return { view: "wiki", articlePath: rest || null };
-  }
-  if (parts[0] === "notebooks") {
-    const agent = parts[1] ? decodeURIComponent(parts[1]) : null;
-    const entry = parts[2] ? decodeURIComponent(parts[2]) : null;
-    return { view: "notebooks", agentSlug: agent, entrySlug: entry };
-  }
-  if (parts[0] === "reviews") {
-    return { view: "reviews" };
-  }
-  return { view: "channel", channel: "general" };
-}
-
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: Existing cognitive complexity is baselined for a focused follow-up refactor.
-function stateToHash(state: {
-  currentApp: string | null;
-  currentChannel: string;
-  channelMeta: Record<string, ChannelMeta>;
-  wikiPath: string | null;
-  wikiLookupQuery: string | null;
-  notebookAgentSlug: string | null;
-  notebookEntrySlug: string | null;
-}): string {
-  if (state.currentApp === "wiki-lookup") {
-    return state.wikiLookupQuery
-      ? `#/wiki/lookup?q=${encodeURIComponent(state.wikiLookupQuery)}`
-      : "#/wiki/lookup";
-  }
-  if (state.currentApp === "wiki") {
-    return state.wikiPath
-      ? `#/wiki/${state.wikiPath.split("/").map(encodeURIComponent).join("/")}`
-      : "#/wiki";
-  }
-  if (state.currentApp === "notebooks") {
-    const parts: string[] = ["notebooks"];
-    if (state.notebookAgentSlug)
-      parts.push(encodeURIComponent(state.notebookAgentSlug));
-    if (state.notebookAgentSlug && state.notebookEntrySlug) {
-      parts.push(encodeURIComponent(state.notebookEntrySlug));
-    }
-    return `#/${parts.join("/")}`;
-  }
-  if (state.currentApp === "reviews") {
-    return "#/reviews";
-  }
-  if (state.currentApp) {
-    return `#/apps/${encodeURIComponent(state.currentApp)}`;
-  }
-  const dm = isDMChannel(state.currentChannel, state.channelMeta);
-  if (dm) {
-    return `#/dm/${encodeURIComponent(dm.agentSlug)}`;
-  }
-  return `#/channels/${encodeURIComponent(state.currentChannel || "general")}`;
-}
+  legacyRouteToStatePatch,
+  legacyStateToHash,
+  parseLegacyHash,
+} from "../routes/legacyHash";
+import { useAppStore } from "../stores/app";
 
 /**
  * Two-way sync between the Zustand app store and the location hash.
@@ -142,26 +50,30 @@ export function useHashRouter() {
         ignoreNextHashChange.current = false;
         return;
       }
-      const route = parseHash(window.location.hash);
+      const route = parseLegacyHash(
+        window.location.hash,
+        window.location.search,
+      );
+      const patch = legacyRouteToStatePatch(route);
       ignoreNextStoreSync.current = true;
-      if (route.view === "dm") {
-        enterDM(route.agent, directChannelSlug(route.agent));
-      } else if (route.view === "app") {
-        setCurrentApp(route.app);
-      } else if (route.view === "wiki-lookup") {
-        setWikiLookupQuery(route.query);
+      if (patch.kind === "dm") {
+        enterDM(patch.agentSlug, patch.channelSlug);
+      } else if (patch.kind === "app") {
+        setCurrentApp(patch.app);
+      } else if (patch.kind === "wiki-lookup") {
+        setWikiLookupQuery(patch.query);
         setCurrentApp("wiki-lookup");
-      } else if (route.view === "wiki") {
-        setWikiPath(route.articlePath);
+      } else if (patch.kind === "wiki") {
+        setWikiPath(patch.articlePath);
         setCurrentApp("wiki");
-      } else if (route.view === "notebooks") {
-        setNotebookRoute(route.agentSlug, route.entrySlug);
+      } else if (patch.kind === "notebooks") {
+        setNotebookRoute(patch.agentSlug, patch.entrySlug);
         setCurrentApp("notebooks");
-      } else if (route.view === "reviews") {
+      } else if (patch.kind === "reviews") {
         setCurrentApp("reviews");
       } else {
         setCurrentApp(null);
-        setCurrentChannel(route.channel);
+        setCurrentChannel(patch.channel);
         setLastMessageId(null);
       }
     }
@@ -185,7 +97,7 @@ export function useHashRouter() {
       ignoreNextStoreSync.current = false;
       return;
     }
-    const next = stateToHash({
+    const next = legacyStateToHash({
       currentApp,
       currentChannel,
       channelMeta,

--- a/web/src/lib/router.ts
+++ b/web/src/lib/router.ts
@@ -1,50 +1,116 @@
 import {
+  createHashHistory,
   createRootRoute,
   createRoute,
   createRouter,
+  type RouterHistory,
 } from "@tanstack/react-router";
 
-// Root route — the app shell wraps everything
+import { ROUTE_PATHS } from "../routes/routeRegistry";
+
+// Root route - the app shell will wrap everything once RouterProvider mounts.
 export const rootRoute = createRootRoute();
 
 // /channels/$channelSlug — main message view
 export const channelRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/channels/$channelSlug",
+  path: ROUTE_PATHS.channel,
+});
+
+// /dm/$agentSlug — direct-message view
+export const dmRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROUTE_PATHS.dm,
 });
 
 // /apps/$appId — app panel view (tasks, policies, calendar, etc.)
 export const appRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/apps/$appId",
+  path: ROUTE_PATHS.app,
 });
 
-// /agents/$agentSlug — agent detail panel
-export const agentRoute = createRoute({
+// /console and /threads — legacy aliases preserved during migration
+export const consoleAliasRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/agents/$agentSlug",
+  path: ROUTE_PATHS.consoleAlias,
+});
+
+export const threadsAliasRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROUTE_PATHS.threadsAlias,
+});
+
+// Wiki, notebook, and review routes.
+export const wikiRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROUTE_PATHS.wiki,
+});
+
+export const wikiIndexRoute = createRoute({
+  getParentRoute: () => wikiRoute,
+  path: "/",
+});
+
+export const wikiLookupRoute = createRoute({
+  getParentRoute: () => wikiRoute,
+  path: "lookup",
+});
+
+export const wikiArticleRoute = createRoute({
+  getParentRoute: () => wikiRoute,
+  path: "$",
+});
+
+export const notebooksRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROUTE_PATHS.notebooks,
+});
+
+export const notebookAgentRoute = createRoute({
+  getParentRoute: () => notebooksRoute,
+  path: "$agentSlug",
+});
+
+export const notebookEntryRoute = createRoute({
+  getParentRoute: () => notebookAgentRoute,
+  path: "$entrySlug",
+});
+
+export const reviewsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: ROUTE_PATHS.reviews,
 });
 
 // / — index route (defaults to #general)
 export const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: "/",
+  path: ROUTE_PATHS.index,
 });
 
 // Route tree
-const routeTree = rootRoute.addChildren([
+export const routeTree = rootRoute.addChildren([
   indexRoute,
   channelRoute,
+  dmRoute,
   appRoute,
-  agentRoute,
+  consoleAliasRoute,
+  threadsAliasRoute,
+  wikiRoute.addChildren([wikiIndexRoute, wikiLookupRoute, wikiArticleRoute]),
+  notebooksRoute.addChildren([
+    notebookAgentRoute.addChildren([notebookEntryRoute]),
+  ]),
+  reviewsRoute,
 ]);
 
-export const router = createRouter({
-  routeTree,
-  defaultPreload: "intent",
-  // Use hash-based routing to match the legacy behavior and work with Go's FileServer
-  // which always serves index.html for all routes
-});
+export function createAppRouter(history: RouterHistory = createHashHistory()) {
+  return createRouter({
+    routeTree,
+    history,
+    defaultPreload: "intent",
+  });
+}
+
+export const router = createAppRouter();
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/web/src/routes/legacyHash.test.ts
+++ b/web/src/routes/legacyHash.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type LegacyRouteState,
+  legacyRouteToStatePatch,
+  legacyStateToHash,
+  parseLegacyHash,
+} from "./legacyHash";
+
+const baseState: LegacyRouteState = {
+  currentApp: null,
+  currentChannel: "general",
+  channelMeta: {},
+  wikiPath: null,
+  wikiLookupQuery: null,
+  notebookAgentSlug: null,
+  notebookEntrySlug: null,
+};
+
+describe("parseLegacyHash", () => {
+  it.each([
+    ["#/channels/launch%20plan", { view: "channel", channel: "launch plan" }],
+    ["#/dm/pm", { view: "dm", agent: "pm" }],
+    ["#/apps/health-check", { view: "app", app: "health-check" }],
+    ["#/console", { view: "app", app: "console" }],
+    ["#/threads", { view: "app", app: "threads" }],
+    ["#/wiki/companies/acme", { view: "wiki", articlePath: "companies/acme" }],
+    ["#/wiki", { view: "wiki", articlePath: null }],
+    [
+      "#/wiki/lookup?q=renewal%20owner",
+      { view: "wiki-lookup", query: "renewal owner" },
+    ],
+    [
+      "#/notebooks/pm/handoff",
+      { view: "notebooks", agentSlug: "pm", entrySlug: "handoff" },
+    ],
+    ["#/notebooks/pm", { view: "notebooks", agentSlug: "pm", entrySlug: null }],
+    ["#/notebooks", { view: "notebooks", agentSlug: null, entrySlug: null }],
+    ["#/reviews", { view: "reviews" }],
+    ["#/unknown", { view: "channel", channel: "general" }],
+  ])("parses %s", (hash, expected) => {
+    expect(parseLegacyHash(hash)).toEqual(expected);
+  });
+
+  it("prefers page search params for the current wiki lookup compatibility path", () => {
+    expect(parseLegacyHash("#/wiki/lookup?q=hash", "?q=page")).toEqual({
+      view: "wiki-lookup",
+      query: "page",
+    });
+  });
+});
+
+describe("legacyStateToHash", () => {
+  it.each([
+    [{ currentChannel: "launch plan" }, "#/channels/launch%20plan"],
+    [
+      {
+        currentChannel: "ceo__human",
+      },
+      "#/dm/ceo",
+    ],
+    [{ currentApp: "settings" }, "#/apps/settings"],
+    [
+      { currentApp: "wiki", wikiPath: "companies/acme" },
+      "#/wiki/companies/acme",
+    ],
+    [
+      { currentApp: "wiki", wikiPath: "people/sarah chen.md" },
+      "#/wiki/people/sarah%20chen.md",
+    ],
+    [
+      { currentApp: "wiki-lookup", wikiLookupQuery: "renewal owner" },
+      "#/wiki/lookup?q=renewal%20owner",
+    ],
+    [{ currentApp: "notebooks" }, "#/notebooks"],
+    [{ currentApp: "notebooks", notebookAgentSlug: "pm" }, "#/notebooks/pm"],
+    [
+      {
+        currentApp: "notebooks",
+        notebookAgentSlug: "pm",
+        notebookEntrySlug: "handoff notes",
+      },
+      "#/notebooks/pm/handoff%20notes",
+    ],
+    [{ currentApp: "reviews" }, "#/reviews"],
+  ])("serializes %# to %s", (state, expected) => {
+    expect(
+      legacyStateToHash({
+        ...baseState,
+        channelMeta: {
+          ceo__human: { type: "D", agentSlug: "ceo" },
+        },
+        ...state,
+      }),
+    ).toBe(expected);
+  });
+
+  it("round-trips the canonical wiki lookup hash emitted by state serialization", () => {
+    const hash = legacyStateToHash({
+      ...baseState,
+      currentApp: "wiki-lookup",
+      wikiLookupQuery: "who owns renewal?",
+    });
+
+    expect(parseLegacyHash(hash)).toEqual({
+      view: "wiki-lookup",
+      query: "who owns renewal?",
+    });
+  });
+});
+
+describe("legacyRouteToStatePatch", () => {
+  it("derives the broker direct-channel slug for DM routes", () => {
+    expect(legacyRouteToStatePatch({ view: "dm", agent: "pm" })).toEqual({
+      kind: "dm",
+      agentSlug: "pm",
+      channelSlug: "human__pm",
+    });
+  });
+});

--- a/web/src/routes/legacyHash.ts
+++ b/web/src/routes/legacyHash.ts
@@ -1,0 +1,205 @@
+import {
+  type ChannelMeta,
+  directChannelSlug,
+  isDMChannel,
+} from "../stores/app";
+
+export type LegacyRoute =
+  | { view: "channel"; channel: string }
+  | { view: "dm"; agent: string }
+  | { view: "app"; app: string }
+  | { view: "wiki"; articlePath: string | null }
+  | { view: "wiki-lookup"; query: string }
+  | { view: "notebooks"; agentSlug: string | null; entrySlug: string | null }
+  | { view: "reviews" };
+
+export interface LegacyRouteState {
+  currentApp: string | null;
+  currentChannel: string;
+  channelMeta: Record<string, ChannelMeta>;
+  wikiPath: string | null;
+  wikiLookupQuery: string | null;
+  notebookAgentSlug: string | null;
+  notebookEntrySlug: string | null;
+}
+
+function searchWithoutQuestion(search: string): string {
+  return search.replace(/^\?/, "");
+}
+
+function defaultRoute(): LegacyRoute {
+  return { view: "channel", channel: "general" };
+}
+
+function parseWikiRoute(
+  parts: string[],
+  hashQuery: string,
+  search: string,
+): LegacyRoute {
+  if (parts[1] === "lookup") {
+    const params = new URLSearchParams(
+      searchWithoutQuestion(search) || hashQuery,
+    );
+    const q = params.get("q") || "";
+    return { view: "wiki-lookup", query: decodeURIComponent(q) };
+  }
+
+  const rest = parts.slice(1).map(decodeURIComponent).join("/");
+  return { view: "wiki", articlePath: rest || null };
+}
+
+function parseNotebooksRoute(parts: string[]): LegacyRoute {
+  const agent = parts[1] ? decodeURIComponent(parts[1]) : null;
+  const entry = parts[2] ? decodeURIComponent(parts[2]) : null;
+  return { view: "notebooks", agentSlug: agent, entrySlug: entry };
+}
+
+/**
+ * Parse today's hash URL contract into the route shape the current Zustand
+ * navigation store expects. Kept pure so Phase 0 can pin behavior before the
+ * TanStack Router migration changes the source of truth.
+ */
+export function parseLegacyHash(hash: string, search = ""): LegacyRoute {
+  const cleaned = hash.replace(/^#\/?/, "");
+  const [pathPart, hashQuery = ""] = cleaned.split("?");
+  const parts = pathPart.split("/").filter(Boolean);
+
+  switch (parts[0]) {
+    case "channels":
+      return parts[1]
+        ? { view: "channel", channel: decodeURIComponent(parts[1]) }
+        : defaultRoute();
+    case "dm":
+      return parts[1]
+        ? { view: "dm", agent: decodeURIComponent(parts[1]) }
+        : defaultRoute();
+    case "apps":
+      return parts[1]
+        ? { view: "app", app: decodeURIComponent(parts[1]) }
+        : defaultRoute();
+    case "console":
+      return { view: "app", app: "console" };
+    case "threads":
+      return { view: "app", app: "threads" };
+    case "wiki":
+      return parseWikiRoute(parts, hashQuery, search);
+    case "notebooks":
+      return parseNotebooksRoute(parts);
+    case "reviews":
+      return { view: "reviews" };
+    default:
+      return defaultRoute();
+  }
+}
+
+export function legacyRouteToStatePatch(route: LegacyRoute):
+  | {
+      kind: "dm";
+      agentSlug: string;
+      channelSlug: string;
+    }
+  | {
+      kind: "app";
+      app: string;
+    }
+  | {
+      kind: "wiki-lookup";
+      query: string;
+    }
+  | {
+      kind: "wiki";
+      articlePath: string | null;
+    }
+  | {
+      kind: "notebooks";
+      agentSlug: string | null;
+      entrySlug: string | null;
+    }
+  | {
+      kind: "reviews";
+    }
+  | {
+      kind: "channel";
+      channel: string;
+    } {
+  if (route.view === "dm") {
+    return {
+      kind: "dm",
+      agentSlug: route.agent,
+      channelSlug: directChannelSlug(route.agent),
+    };
+  }
+  if (route.view === "app") {
+    return { kind: "app", app: route.app };
+  }
+  if (route.view === "wiki-lookup") {
+    return { kind: "wiki-lookup", query: route.query };
+  }
+  if (route.view === "wiki") {
+    return { kind: "wiki", articlePath: route.articlePath };
+  }
+  if (route.view === "notebooks") {
+    return {
+      kind: "notebooks",
+      agentSlug: route.agentSlug,
+      entrySlug: route.entrySlug,
+    };
+  }
+  if (route.view === "reviews") {
+    return { kind: "reviews" };
+  }
+  return { kind: "channel", channel: route.channel };
+}
+
+/**
+ * Serialize today's Zustand route state back into the current hash URL
+ * contract. This is intentionally behavior-preserving until TanStack Router
+ * becomes the source of truth.
+ */
+export function legacyStateToHash(state: LegacyRouteState): string {
+  switch (state.currentApp) {
+    case "wiki-lookup":
+      return wikiLookupStateToHash(state);
+    case "wiki":
+      return wikiStateToHash(state);
+    case "notebooks":
+      return notebookStateToHash(state);
+    case "reviews":
+      return "#/reviews";
+    case null:
+      return channelStateToHash(state);
+    default:
+      return `#/apps/${encodeURIComponent(state.currentApp)}`;
+  }
+}
+
+function wikiLookupStateToHash(state: LegacyRouteState): string {
+  return state.wikiLookupQuery
+    ? `#/wiki/lookup?q=${encodeURIComponent(state.wikiLookupQuery)}`
+    : "#/wiki/lookup";
+}
+
+function wikiStateToHash(state: LegacyRouteState): string {
+  return state.wikiPath
+    ? `#/wiki/${state.wikiPath.split("/").map(encodeURIComponent).join("/")}`
+    : "#/wiki";
+}
+
+function notebookStateToHash(state: LegacyRouteState): string {
+  const parts: string[] = ["notebooks"];
+  if (state.notebookAgentSlug) {
+    parts.push(encodeURIComponent(state.notebookAgentSlug));
+  }
+  if (state.notebookAgentSlug && state.notebookEntrySlug) {
+    parts.push(encodeURIComponent(state.notebookEntrySlug));
+  }
+  return `#/${parts.join("/")}`;
+}
+
+function channelStateToHash(state: LegacyRouteState): string {
+  const dm = isDMChannel(state.currentChannel, state.channelMeta);
+  if (dm) {
+    return `#/dm/${encodeURIComponent(dm.agentSlug)}`;
+  }
+  return `#/channels/${encodeURIComponent(state.currentChannel || "general")}`;
+}

--- a/web/src/routes/routeRegistry.test.ts
+++ b/web/src/routes/routeRegistry.test.ts
@@ -1,0 +1,106 @@
+import { createMemoryHistory } from "@tanstack/react-router";
+import { describe, expect, it } from "vitest";
+
+import {
+  appRoute,
+  channelRoute,
+  consoleAliasRoute,
+  createAppRouter,
+  dmRoute,
+  indexRoute,
+  notebookAgentRoute,
+  notebookEntryRoute,
+  notebooksRoute,
+  reviewsRoute,
+  threadsAliasRoute,
+  wikiArticleRoute,
+  wikiIndexRoute,
+  wikiLookupRoute,
+} from "../lib/router";
+import {
+  APP_PANEL_IDS,
+  isAppPanelId,
+  ROUTE_CONTRACTS,
+  ROUTE_PATHS,
+  SIDEBAR_APP_IDS,
+  sidebarAppRouteKind,
+} from "./routeRegistry";
+
+function unique<T>(values: readonly T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+describe("route registry", () => {
+  it("keeps app panel ids unique and validated", () => {
+    expect(unique(APP_PANEL_IDS)).toHaveLength(APP_PANEL_IDS.length);
+    expect(isAppPanelId("tasks")).toBe(true);
+    expect(isAppPanelId("wiki")).toBe(false);
+    expect(isAppPanelId("notebooks")).toBe(false);
+  });
+
+  it("classifies every sidebar app as either a routed panel or a first-class surface", () => {
+    expect(SIDEBAR_APP_IDS).toContain("wiki");
+    expect(SIDEBAR_APP_IDS).toContain("settings");
+
+    for (const id of SIDEBAR_APP_IDS) {
+      expect(sidebarAppRouteKind(id), id).not.toBeNull();
+    }
+  });
+
+  it("keeps the planned route contracts unique", () => {
+    const keys = ROUTE_CONTRACTS.map((route) => route.key);
+    const paths = ROUTE_CONTRACTS.map((route) => route.path);
+
+    expect(unique(keys)).toHaveLength(keys.length);
+    expect(unique(paths)).toHaveLength(paths.length);
+    expect(keys).toEqual(Object.keys(ROUTE_PATHS));
+  });
+});
+
+describe("TanStack route tree", () => {
+  const expectedLeafRoutes = [
+    ["/", indexRoute.id],
+    ["/channels/launch", channelRoute.id],
+    ["/dm/pm", dmRoute.id],
+    ["/apps/tasks", appRoute.id],
+    ["/console", consoleAliasRoute.id],
+    ["/threads", threadsAliasRoute.id],
+    ["/wiki", wikiIndexRoute.id],
+    ["/wiki/lookup", wikiLookupRoute.id],
+    ["/wiki/companies/acme", wikiArticleRoute.id],
+    ["/notebooks", notebooksRoute.id],
+    ["/notebooks/pm", notebookAgentRoute.id],
+    ["/notebooks/pm/handoff", notebookEntryRoute.id],
+    ["/reviews", reviewsRoute.id],
+  ] as const;
+
+  it.each(
+    expectedLeafRoutes,
+  )("matches %s to the expected leaf route", (path, routeId) => {
+    const router = createAppRouter(
+      createMemoryHistory({ initialEntries: ["/"] }),
+    );
+    const leaf = router.matchRoutes(path).at(-1);
+
+    expect(leaf?.routeId).toBe(routeId);
+  });
+
+  it("captures wiki article splats for nested article paths", () => {
+    const router = createAppRouter(
+      createMemoryHistory({ initialEntries: ["/"] }),
+    );
+    const leaf = router.matchRoutes("/wiki/companies/acme").at(-1);
+
+    expect(leaf?.routeId).toBe(wikiArticleRoute.id);
+    expect(leaf?.params).toMatchObject({
+      _splat: "companies/acme",
+      "*": "companies/acme",
+    });
+  });
+
+  it("uses hash history by default for static-file-server compatibility", () => {
+    const href = createAppRouter().history.createHref("/channels/general");
+
+    expect(href).toBe("/#/channels/general");
+  });
+});

--- a/web/src/routes/routeRegistry.ts
+++ b/web/src/routes/routeRegistry.ts
@@ -1,0 +1,146 @@
+import { SIDEBAR_APPS } from "../lib/constants";
+
+export const APP_PANEL_IDS = [
+  "activity",
+  "calendar",
+  "console",
+  "graph",
+  "health-check",
+  "policies",
+  "receipts",
+  "requests",
+  "settings",
+  "skills",
+  "tasks",
+  "threads",
+] as const;
+
+export type AppPanelId = (typeof APP_PANEL_IDS)[number];
+
+export const FIRST_CLASS_APP_IDS = ["wiki"] as const;
+export type FirstClassAppId = (typeof FIRST_CLASS_APP_IDS)[number];
+
+export const WIKI_SURFACE_APP_IDS = ["wiki", "notebooks", "reviews"] as const;
+
+const APP_PANEL_ID_SET = new Set<string>(APP_PANEL_IDS);
+const FIRST_CLASS_APP_ID_SET = new Set<string>(FIRST_CLASS_APP_IDS);
+
+export function isAppPanelId(value: string): value is AppPanelId {
+  return APP_PANEL_ID_SET.has(value);
+}
+
+export function sidebarAppRouteKind(
+  id: string,
+): "app-panel" | "first-class" | null {
+  if (APP_PANEL_ID_SET.has(id)) return "app-panel";
+  if (FIRST_CLASS_APP_ID_SET.has(id)) return "first-class";
+  return null;
+}
+
+export const ROUTE_PATHS = {
+  index: "/",
+  channel: "/channels/$channelSlug",
+  dm: "/dm/$agentSlug",
+  app: "/apps/$appId",
+  consoleAlias: "/console",
+  threadsAlias: "/threads",
+  wiki: "/wiki",
+  wikiLookup: "/wiki/lookup",
+  wikiArticle: "/wiki/$",
+  notebooks: "/notebooks",
+  notebookAgent: "/notebooks/$agentSlug",
+  notebookEntry: "/notebooks/$agentSlug/$entrySlug",
+  reviews: "/reviews",
+} as const;
+
+export type RouteKey = keyof typeof ROUTE_PATHS;
+
+export interface RouteContract {
+  key: RouteKey;
+  path: (typeof ROUTE_PATHS)[RouteKey];
+  owns: readonly string[];
+  legacyHashExamples: readonly string[];
+}
+
+export const ROUTE_CONTRACTS: readonly RouteContract[] = [
+  {
+    key: "index",
+    path: ROUTE_PATHS.index,
+    owns: ["default-route"],
+    legacyHashExamples: ["#/channels/general"],
+  },
+  {
+    key: "channel",
+    path: ROUTE_PATHS.channel,
+    owns: ["currentChannel"],
+    legacyHashExamples: ["#/channels/general", "#/channels/launch"],
+  },
+  {
+    key: "dm",
+    path: ROUTE_PATHS.dm,
+    owns: ["dmAgentSlug"],
+    legacyHashExamples: ["#/dm/pm"],
+  },
+  {
+    key: "app",
+    path: ROUTE_PATHS.app,
+    owns: ["currentApp"],
+    legacyHashExamples: ["#/apps/tasks", "#/apps/settings"],
+  },
+  {
+    key: "consoleAlias",
+    path: ROUTE_PATHS.consoleAlias,
+    owns: ["legacy-alias"],
+    legacyHashExamples: ["#/console"],
+  },
+  {
+    key: "threadsAlias",
+    path: ROUTE_PATHS.threadsAlias,
+    owns: ["legacy-alias"],
+    legacyHashExamples: ["#/threads"],
+  },
+  {
+    key: "wiki",
+    path: ROUTE_PATHS.wiki,
+    owns: ["wikiPath"],
+    legacyHashExamples: ["#/wiki"],
+  },
+  {
+    key: "wikiLookup",
+    path: ROUTE_PATHS.wikiLookup,
+    owns: ["wikiLookupQuery"],
+    legacyHashExamples: ["#/wiki/lookup?q=renewal"],
+  },
+  {
+    key: "wikiArticle",
+    path: ROUTE_PATHS.wikiArticle,
+    owns: ["wikiPath"],
+    legacyHashExamples: ["#/wiki/companies/acme"],
+  },
+  {
+    key: "notebooks",
+    path: ROUTE_PATHS.notebooks,
+    owns: ["notebookAgentSlug", "notebookEntrySlug"],
+    legacyHashExamples: ["#/notebooks"],
+  },
+  {
+    key: "notebookAgent",
+    path: ROUTE_PATHS.notebookAgent,
+    owns: ["notebookAgentSlug"],
+    legacyHashExamples: ["#/notebooks/pm"],
+  },
+  {
+    key: "notebookEntry",
+    path: ROUTE_PATHS.notebookEntry,
+    owns: ["notebookAgentSlug", "notebookEntrySlug"],
+    legacyHashExamples: ["#/notebooks/pm/handoff"],
+  },
+  {
+    key: "reviews",
+    path: ROUTE_PATHS.reviews,
+    owns: ["currentApp"],
+    legacyHashExamples: ["#/reviews"],
+  },
+] as const;
+
+export const SIDEBAR_APP_IDS = SIDEBAR_APPS.map((app) => app.id);


### PR DESCRIPTION
## Summary

Adds Phase 0 coverage for the planned TanStack Router migration without mounting the router in product code yet.

- Extracts the current hash parser/serializer into pure legacy route helpers and pins current channel, DM, app, wiki, notebook, and review URL behavior with tests.
- Adds a route registry plus TanStack route-tree tests so the migration has a concrete inventory and route contract guardrails.
- Expands the unmounted TanStack Router skeleton to include the planned route surface with hash-history compatibility.
- Updates the Telegram wizard E2E spec to match the current token -> mode -> group/DM flow surfaced by the full shell run.
- Documents the web path-forward plan and Phase 0 findings.

## Impact

This PR is intended to make the router migration safer before product routing changes. It gives us tests that verify current behavior, detect route contract drift, and document migration-specific decisions such as wiki splats and hash-history hrefs.

## Validation

- `bash scripts/test-web.sh web/src/routes/legacyHash.test.ts web/src/routes/routeRegistry.test.ts` passed, 44 tests.
- `bunx tsc --noEmit` passed.
- `bunx biome check web/src/routes/legacyHash.ts web/src/routes/routeRegistry.test.ts web/e2e/tests/telegram-connect.spec.ts` passed.
- `bash scripts/test-web.sh` passed, 110 files / 799 tests.
- `bun run build` passed with the existing large-chunk warning.
- `web/e2e/run-local.sh shell` passed, 31 tests.
- Pre-push hook passed: build, complexity-baseline, file-size, Go unit, smoke, VHS, and web-unit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced navigation routing infrastructure with improved URL state management and support for legacy hash-based URLs.

* **Tests**
  * Added comprehensive test coverage for legacy hash routing patterns and route registry validation.
  * Refactored Telegram integration E2E tests with reusable helper functions.

* **Documentation**
  * Added detailed migration plan for web app navigation architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->