### PR TITLE
Add broker restart capability via web UI

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -504,6 +504,7 @@ func (b *Broker) StartOnPort(port int) error {
 	mux.HandleFunc("/workspaces/trash", b.withAuth(b.handleWorkspacesTrash))
 	mux.HandleFunc("/workspaces/onboarding", b.withAuth(b.handleWorkspacesOnboarding))
 	mux.HandleFunc("/admin/pause", b.withAuth(b.handleAdminPause))
+	mux.HandleFunc("/broker/restart", b.requireAuth(b.handleBrokerRestart))
 	// Onboarding: state/progress/complete + prereqs/templates/validate-key + checklist.
 	// completeFn posts the first task as a human message and seeds the team.
 	onboarding.RegisterRoutes(mux, b.onboardingCompleteFn, b.packSlug, b.requireAuth)

--- a/internal/team/broker_restart_handler.go
+++ b/internal/team/broker_restart_handler.go
@@ -1,0 +1,60 @@
+package team
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// handleBrokerRestart handles POST /broker/restart.
+//
+// It responds immediately with 202 Accepted, then spawns a fresh copy of the
+// binary with the same arguments and exits the current process. The new process
+// starts up cleanly, binds to the same port, and the browser's existing SSE
+// EventSource reconnects automatically.
+//
+// The restart is soft-destructive: in-flight agent turns are abandoned. Persisted
+// broker-state.json is not modified, so the roster, channels, and skills survive.
+//
+// The handler is intentionally not loopback-restricted (unlike /admin/pause) so
+// the web UI can invoke it directly without the user needing shell access.
+func (b *Broker) handleBrokerRestart(w http.ResponseWriter, r *http.Request) {
+	if !requireMethod(w, r, http.MethodPost) {
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"ok":      true,
+		"message": "restart accepted; broker will restart shortly",
+	})
+
+	go func() {
+		// Let the response flush before tearing down.
+		time.Sleep(adminPauseSelfShutdownDelay)
+		b.execRestart()
+	}()
+}
+
+// execRestart spawns a replacement process then exits the current one.
+// On success this function never returns; on failure it falls back to os.Exit.
+func (b *Broker) execRestart() {
+	exe, err := os.Executable()
+	if err != nil {
+		log.Printf("broker/restart: get executable: %v — falling back to exit", err)
+		b.adminPauseExit(1)
+		return
+	}
+	cmd := exec.Command(exe, os.Args[1:]...) //nolint:gosec // intentional self-restart
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if startErr := cmd.Start(); startErr != nil {
+		log.Printf("broker/restart: spawn replacement: %v — falling back to exit", startErr)
+		b.adminPauseExit(1)
+		return
+	}
+	b.adminPauseExit(0)
+}

--- a/internal/team/broker_restart_handler.go
+++ b/internal/team/broker_restart_handler.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -40,20 +41,18 @@ func (b *Broker) handleBrokerRestart(w http.ResponseWriter, r *http.Request) {
 }
 
 // execRestart spawns a replacement process then exits the current one.
-// On success this function never returns; on failure it falls back to os.Exit.
+// If spawning fails the current broker keeps running — no downtime on error.
 func (b *Broker) execRestart() {
 	exe, err := os.Executable()
 	if err != nil {
-		log.Printf("broker/restart: get executable: %v — falling back to exit", err)
-		b.adminPauseExit(1)
+		log.Printf("broker/restart: get executable: %v — keeping current process alive", err)
 		return
 	}
-	cmd := exec.Command(exe, os.Args[1:]...) //nolint:gosec // intentional self-restart
+	cmd := exec.CommandContext(context.Background(), exe, os.Args[1:]...) //nolint:gosec // intentional self-restart
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if startErr := cmd.Start(); startErr != nil {
-		log.Printf("broker/restart: spawn replacement: %v — falling back to exit", startErr)
-		b.adminPauseExit(1)
+		log.Printf("broker/restart: spawn replacement: %v — keeping current process alive", startErr)
 		return
 	}
 	b.adminPauseExit(0)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1097,6 +1097,14 @@ export function shredWorkspace() {
   return postWithTimeout<WorkspaceWipeResult>("/workspace/shred", {}, 20_000);
 }
 
+// restartBroker asks the broker to spawn a fresh copy of itself and exit.
+// The broker responds with 202 before tearing down, so the promise resolves
+// before the process is replaced. The browser's SSE EventSource reconnects
+// automatically once the new process is ready.
+export function restartBroker() {
+  return post<{ ok: boolean; message: string }>("/broker/restart");
+}
+
 // ── Telegram /connect wizard ──
 // These mirror the TUI's `/connect telegram` flow but drive it from the web.
 // Pass an explicit `token` to override what the broker has on disk; pass an

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1100,30 +1100,11 @@ export function shredWorkspace() {
 // restartBroker asks the broker to spawn a fresh copy of itself and exit.
 // The broker responds with 202 before tearing down, so the promise resolves
 // before the process is replaced. The browser's SSE EventSource reconnects
-// automatically once the new process is ready.
-//
-// After the 202 lands, a background loop retries initApi() until the new
-// process is reachable. In proxy mode this re-syncs the stored token; in
-// direct mode it refreshes the bearer so subsequent API calls use the new
-// credential issued by the replacement process.
-export function restartBroker(): Promise<{ ok: boolean; message: string }> {
-  return post<{ ok: boolean; message: string }>("/broker/restart").then(
-    (res) => {
-      const tryRefresh = async () => {
-        for (let i = 0; i < 15; i++) {
-          await new Promise<void>((r) => setTimeout(r, 500));
-          try {
-            await initApi();
-            return;
-          } catch {
-            // new process still starting — keep trying
-          }
-        }
-      };
-      void tryRefresh();
-      return res;
-    },
-  );
+// automatically once the new process is ready; useBrokerEvents calls initApi()
+// inside the "ready" handler to refresh the auth token before marking the
+// broker as connected.
+export function restartBroker() {
+  return post<{ ok: boolean; message: string }>("/broker/restart");
 }
 
 // ── Telegram /connect wizard ──

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1101,8 +1101,29 @@ export function shredWorkspace() {
 // The broker responds with 202 before tearing down, so the promise resolves
 // before the process is replaced. The browser's SSE EventSource reconnects
 // automatically once the new process is ready.
-export function restartBroker() {
-  return post<{ ok: boolean; message: string }>("/broker/restart");
+//
+// After the 202 lands, a background loop retries initApi() until the new
+// process is reachable. In proxy mode this re-syncs the stored token; in
+// direct mode it refreshes the bearer so subsequent API calls use the new
+// credential issued by the replacement process.
+export function restartBroker(): Promise<{ ok: boolean; message: string }> {
+  return post<{ ok: boolean; message: string }>("/broker/restart").then(
+    (res) => {
+      const tryRefresh = async () => {
+        for (let i = 0; i < 15; i++) {
+          await new Promise<void>((r) => setTimeout(r, 500));
+          try {
+            await initApi();
+            return;
+          } catch {
+            // new process still starting — keep trying
+          }
+        }
+      };
+      void tryRefresh();
+      return res;
+    },
+  );
 }
 
 // ── Telegram /connect wizard ──

--- a/web/src/components/layout/DisconnectBanner.tsx
+++ b/web/src/components/layout/DisconnectBanner.tsx
@@ -11,11 +11,12 @@ export function DisconnectBanner() {
   const [retrying, setRetrying] = useState(false);
   const dismissedForRef = useRef<boolean | null>(null);
 
-  // Track that we previously had a connection
+  // Track that we previously had a connection; also clear retrying state on reconnect.
   useEffect(() => {
     if (brokerConnected) {
       setHadConnection(true);
       setDismissed(false);
+      setRetrying(false);
       dismissedForRef.current = null;
     }
   }, [brokerConnected]);
@@ -31,9 +32,9 @@ export function DisconnectBanner() {
     setRetrying(true);
     try {
       await restartBroker();
+      // 202 received — keep retrying=true until brokerConnected flips back.
     } catch {
-      // Broker unreachable; SSE will reconnect on its own once it's back.
-    } finally {
+      // Broker unreachable: reset immediately so Retry stays clickable.
       setRetrying(false);
     }
   }, []);

--- a/web/src/components/layout/DisconnectBanner.tsx
+++ b/web/src/components/layout/DisconnectBanner.tsx
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { initApi } from "../../api/client";
+import { restartBroker } from "../../api/client";
 import { useAppStore } from "../../stores/app";
 
 export function DisconnectBanner() {
   const brokerConnected = useAppStore((s) => s.brokerConnected);
-  const setBrokerConnected = useAppStore((s) => s.setBrokerConnected);
 
   const [hadConnection, setHadConnection] = useState(false);
   const [dismissed, setDismissed] = useState(false);
@@ -31,14 +30,13 @@ export function DisconnectBanner() {
   const handleRetry = useCallback(async () => {
     setRetrying(true);
     try {
-      await initApi();
-      setBrokerConnected(true);
+      await restartBroker();
     } catch {
-      // Still disconnected
+      // Broker unreachable; SSE will reconnect on its own once it's back.
     } finally {
       setRetrying(false);
     }
-  }, [setBrokerConnected]);
+  }, []);
 
   const handleDismiss = useCallback(() => {
     dismissedForRef.current = brokerConnected;

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { restartBroker } from "../../api/client";
@@ -22,17 +22,20 @@ export function StatusBar() {
 
   const [retrying, setRetrying] = useState(false);
 
+  // Clear the in-progress state once the broker reconnects.
+  useEffect(() => {
+    if (brokerConnected) setRetrying(false);
+  }, [brokerConnected]);
+
   const handleRestart = useCallback(async () => {
     setRetrying(true);
     try {
       await restartBroker();
-      // Broker accepted the restart — it will exit and respawn.
-      // The SSE EventSource reconnects automatically; clear the
-      // disconnected flag optimistically so the label reflects the
-      // in-progress restart rather than the stale disconnected state.
+      // 202 received — broker is exiting and will respawn. Keep retrying=true
+      // until brokerConnected flips back via the useEffect above.
     } catch {
-      // Broker unreachable: nothing to do, SSE will reconnect on its own.
-    } finally {
+      // Broker unreachable or spawn failed: reset immediately so the button
+      // is clickable again.
       setRetrying(false);
     }
   }, []);

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -110,6 +110,7 @@ export function StatusBar() {
           onClick={handleRestart}
           disabled={retrying}
           title="Click to restart broker"
+          aria-label={retrying ? "Restarting broker…" : "Restart broker"}
         >
           {retrying ? "restarting…" : "disconnected"}
         </button>

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
 
+import { initApi } from "../../api/client";
 import { getHealth, type HealthResponse } from "../../api/platform";
 import { useOfficeMembers } from "../../hooks/useMembers";
 import { appTitle } from "../../lib/constants";
@@ -16,7 +18,22 @@ export function StatusBar() {
   const currentApp = useAppStore((s) => s.currentApp);
   const channelMeta = useAppStore((s) => s.channelMeta);
   const brokerConnected = useAppStore((s) => s.brokerConnected);
+  const setBrokerConnected = useAppStore((s) => s.setBrokerConnected);
   const setComposerHelpOpen = useAppStore((s) => s.setComposerHelpOpen);
+
+  const [retrying, setRetrying] = useState(false);
+
+  const handleRetry = useCallback(async () => {
+    setRetrying(true);
+    try {
+      await initApi();
+      setBrokerConnected(true);
+    } catch {
+      // still disconnected
+    } finally {
+      setRetrying(false);
+    }
+  }, [setBrokerConnected]);
   const { data: members = [] } = useOfficeMembers();
   const dm = !currentApp ? isDMChannel(currentChannel, channelMeta) : null;
 
@@ -79,11 +96,19 @@ export function StatusBar() {
           ) : null}
         </span>
       ) : null}
-      <span
-        className={`status-bar-item status-bar-conn${brokerConnected ? "" : " disconnected"}`}
-      >
-        {brokerConnected ? "connected" : "disconnected"}
-      </span>
+      {brokerConnected ? (
+        <span className="status-bar-item status-bar-conn">connected</span>
+      ) : (
+        <button
+          type="button"
+          className="status-bar-item status-bar-conn status-bar-conn-retry disconnected"
+          onClick={handleRetry}
+          disabled={retrying}
+          title="Click to reconnect"
+        >
+          {retrying ? "retrying…" : "disconnected"}
+        </button>
+      )}
     </div>
   );
 }

--- a/web/src/components/layout/StatusBar.tsx
+++ b/web/src/components/layout/StatusBar.tsx
@@ -1,7 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
-import { initApi } from "../../api/client";
+import { restartBroker } from "../../api/client";
 import { getHealth, type HealthResponse } from "../../api/platform";
 import { useOfficeMembers } from "../../hooks/useMembers";
 import { appTitle } from "../../lib/constants";
@@ -18,22 +18,24 @@ export function StatusBar() {
   const currentApp = useAppStore((s) => s.currentApp);
   const channelMeta = useAppStore((s) => s.channelMeta);
   const brokerConnected = useAppStore((s) => s.brokerConnected);
-  const setBrokerConnected = useAppStore((s) => s.setBrokerConnected);
   const setComposerHelpOpen = useAppStore((s) => s.setComposerHelpOpen);
 
   const [retrying, setRetrying] = useState(false);
 
-  const handleRetry = useCallback(async () => {
+  const handleRestart = useCallback(async () => {
     setRetrying(true);
     try {
-      await initApi();
-      setBrokerConnected(true);
+      await restartBroker();
+      // Broker accepted the restart — it will exit and respawn.
+      // The SSE EventSource reconnects automatically; clear the
+      // disconnected flag optimistically so the label reflects the
+      // in-progress restart rather than the stale disconnected state.
     } catch {
-      // still disconnected
+      // Broker unreachable: nothing to do, SSE will reconnect on its own.
     } finally {
       setRetrying(false);
     }
-  }, [setBrokerConnected]);
+  }, []);
   const { data: members = [] } = useOfficeMembers();
   const dm = !currentApp ? isDMChannel(currentChannel, channelMeta) : null;
 
@@ -102,11 +104,11 @@ export function StatusBar() {
         <button
           type="button"
           className="status-bar-item status-bar-conn status-bar-conn-retry disconnected"
-          onClick={handleRetry}
+          onClick={handleRestart}
           disabled={retrying}
-          title="Click to reconnect"
+          title="Click to restart broker"
         >
-          {retrying ? "retrying…" : "disconnected"}
+          {retrying ? "restarting…" : "disconnected"}
         </button>
       )}
     </div>

--- a/web/src/hooks/useBrokerEvents.ts
+++ b/web/src/hooks/useBrokerEvents.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 
-import { sseURL } from "../api/client";
+import { initApi, sseURL } from "../api/client";
 import { useAppStore } from "../stores/app";
 
 function messageChannelFromEvent(event: Event): string | null {
@@ -29,7 +29,13 @@ export function useBrokerEvents(enabled: boolean) {
     if (!ES) return;
 
     const source = new ES(sseURL("/events"));
-    source.addEventListener("ready", () => setBrokerConnected(true));
+    source.addEventListener("ready", () => {
+      // Refresh the module-level auth token before marking the broker as
+      // connected. In direct mode the broker issues a fresh /web-token on
+      // each startup, so subsequent API calls would use a stale bearer if
+      // we don't re-handshake here. initApi() is a no-op in proxy mode.
+      void initApi().finally(() => setBrokerConnected(true));
+    });
     source.addEventListener("message", (event) => {
       const channel = messageChannelFromEvent(event);
       if (channel) {

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -763,6 +763,23 @@ html[data-theme="nex"]
 .status-bar-conn.disconnected::before {
   background: var(--red);
 }
+.status-bar-conn-retry {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+}
+.status-bar-conn-retry:hover:not(:disabled) {
+  color: var(--red);
+  text-decoration: underline;
+}
+.status-bar-conn-retry:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
 
 .sidebar-scroll-wrap {
   position: relative;


### PR DESCRIPTION
## Summary
This PR adds a soft-restart feature for the broker that can be triggered from the web UI. When the broker is disconnected, users can now click the "disconnected" status indicator to request a restart, which spawns a fresh process while preserving persisted state.

## Key Changes

- **Backend restart handler** (`internal/team/broker_restart_handler.go`): New handler for `POST /broker/restart` that responds with 202 Accepted, then spawns a replacement process with the same arguments and exits cleanly. The new process binds to the same port and allows SSE EventSource to reconnect automatically.

- **API client function** (`web/src/api/client.ts`): Added `restartBroker()` function to call the new `/broker/restart` endpoint.

- **StatusBar component** (`web/src/components/layout/StatusBar.tsx`): Converted the disconnected status indicator from a static span to an interactive button that triggers the restart handler. Shows "restarting…" state while the request is in flight.

- **DisconnectBanner component** (`web/src/components/layout/DisconnectBanner.tsx`): Updated retry logic to call `restartBroker()` instead of `initApi()`, aligning with the new restart strategy.

- **Styling** (`web/src/styles/layout.css`): Added `.status-bar-conn-retry` styles for the restart button with hover and disabled states.

## Implementation Details

- The restart is "soft-destructive": in-flight agent turns are abandoned, but `broker-state.json` is not modified, so roster, channels, and skills persist across restarts.
- The handler is intentionally not loopback-restricted (unlike `/admin/pause`) to allow direct invocation from the web UI without requiring shell access.
- The response is sent before the restart occurs (202 Accepted), allowing the browser to receive confirmation before the process exits.
- SSE EventSource reconnection is automatic and requires no explicit client-side handling.

https://claude.ai/code/session_01RPfWQfCMk1rZGwDwtn2RyR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI can trigger a broker restart when disconnected (status bar button and disconnect banner retry)
  * Client API to request a broker restart; UI begins background reconnect attempts after requesting restart

* **Bug Fixes**
  * Restart request returns immediately and proceeds asynchronously; system preserves current operation if restart fails

* **Style**
  * New retry styling for the status bar retry action
<!-- end of auto-generated comment: release notes by coderabbit.ai -->