### PR TITLE
feat(web): add wiki folder navigation

### DIFF
--- a/internal/team/wiki_sections.go
+++ b/internal/team/wiki_sections.go
@@ -127,6 +127,10 @@ func DiscoverSections(ctx context.Context, repo *Repo, blueprint *operations.Blu
 			return fmt.Errorf("walk %s: %w", path, err)
 		}
 		if d.IsDir() {
+			rel, relErr := filepath.Rel(repo.Root(), path)
+			if relErr == nil && isExcludedWikiSectionDir(filepath.ToSlash(rel)) {
+				return filepath.SkipDir
+			}
 			// Hide compiler-output subtrees (e.g. playbooks/.compiled/**)
 			// so machine-generated SKILL.md files never appear as their
 			// own section entries or inflate counts.
@@ -195,6 +199,10 @@ func DiscoverSections(ctx context.Context, repo *Repo, blueprint *operations.Blu
 	}
 
 	return out, nil
+}
+
+func isExcludedWikiSectionDir(rel string) bool {
+	return rel == "team/inbox" || rel == "team/skills"
 }
 
 // blueprintSectionSlugs extracts the first-segment section slugs from the

--- a/internal/team/wiki_sections_test.go
+++ b/internal/team/wiki_sections_test.go
@@ -158,6 +158,37 @@ func TestDiscoverSectionsDiscoveredOnlyAlphabetical(t *testing.T) {
 	}
 }
 
+func TestDiscoverSectionsSkipsSystemSubtrees(t *testing.T) {
+	repo, worker := sectionsTestRepo(t)
+	writeArticle(t, worker, "ceo", "team/people/nazz.md", "# Nazz\n")
+
+	for _, rel := range []string{
+		"team/inbox/raw-import.md",
+		"team/inbox/raw/source.md",
+		"team/skills/customer-refund/SKILL.md",
+		"team/people/.compiled/SKILL.md",
+	} {
+		full := filepath.Join(repo.Root(), filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(full, []byte("# system\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	sections, err := DiscoverSections(context.Background(), repo, nil)
+	if err != nil {
+		t.Fatalf("DiscoverSections: %v", err)
+	}
+	if len(sections) != 1 || sections[0].Slug != "people" {
+		t.Fatalf("sections=%+v want only people", sections)
+	}
+	if sections[0].ArticleCount != 1 {
+		t.Fatalf("people ArticleCount=%d want 1", sections[0].ArticleCount)
+	}
+}
+
 func TestBlueprintDirToSlug(t *testing.T) {
 	cases := []struct {
 		in, want string

--- a/web/src/api/wiki.test.ts
+++ b/web/src/api/wiki.test.ts
@@ -124,6 +124,11 @@ describe("wiki api client", () => {
     expect(result).toEqual([]);
   });
 
+  it("fetchCatalogStrict surfaces request errors", async () => {
+    vi.spyOn(client, "get").mockRejectedValue(new Error("boom"));
+    await expect(api.fetchCatalogStrict()).rejects.toThrow("boom");
+  });
+
   it("fetchHistory returns empty commits on error", async () => {
     vi.spyOn(client, "get").mockRejectedValue(new Error("boom"));
     const result = await api.fetchHistory("people/customer-x");

--- a/web/src/api/wiki.ts
+++ b/web/src/api/wiki.ts
@@ -353,10 +353,20 @@ export async function fetchHumans(): Promise<HumanIdentity[]> {
   }
 }
 
+function parseCatalogResponse(res: {
+  articles: WikiCatalogEntry[];
+}): WikiCatalogEntry[] {
+  return Array.isArray(res?.articles) ? res.articles : [];
+}
+
+export async function fetchCatalogStrict(): Promise<WikiCatalogEntry[]> {
+  const res = await get<{ articles: WikiCatalogEntry[] }>("/wiki/catalog");
+  return parseCatalogResponse(res);
+}
+
 export async function fetchCatalog(): Promise<WikiCatalogEntry[]> {
   try {
-    const res = await get<{ articles: WikiCatalogEntry[] }>("/wiki/catalog");
-    return Array.isArray(res?.articles) ? res.articles : [];
+    return await fetchCatalogStrict();
   } catch {
     return [];
   }

--- a/web/src/components/wiki/Wiki.test.tsx
+++ b/web/src/components/wiki/Wiki.test.tsx
@@ -80,7 +80,7 @@ describe("<Wiki>", () => {
       expect(screen.getByTestId("wk-catalog")).toBeInTheDocument(),
     );
 
-    act(() => {
+    await act(async () => {
       sectionHandler?.({
         sections: [
           {
@@ -95,6 +95,7 @@ describe("<Wiki>", () => {
         ],
         timestamp: new Date().toISOString(),
       });
+      await Promise.resolve();
     });
 
     await waitFor(() =>

--- a/web/src/components/wiki/Wiki.test.tsx
+++ b/web/src/components/wiki/Wiki.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import * as api from "../../api/wiki";
@@ -8,6 +8,10 @@ describe("<Wiki>", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.spyOn(api, "subscribeEditLog").mockImplementation(() => () => {});
+    vi.spyOn(api, "subscribeSectionsUpdated").mockImplementation(
+      () => () => {},
+    );
+    vi.spyOn(api, "fetchSections").mockResolvedValue([]);
     vi.spyOn(api, "fetchHistory").mockResolvedValue({ commits: [] });
   });
 
@@ -49,6 +53,52 @@ describe("<Wiki>", () => {
       expect(
         screen.getByRole("heading", { name: "Customer X" }),
       ).toBeInTheDocument(),
+    );
+  });
+
+  it("refreshes the article catalog after a live section update", async () => {
+    let sectionHandler: ((event: api.WikiSectionsUpdatedEvent) => void) | null =
+      null;
+    vi.spyOn(api, "subscribeSectionsUpdated").mockImplementation((handler) => {
+      sectionHandler = handler;
+      return () => {};
+    });
+    vi.spyOn(api, "fetchCatalog")
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          path: "team/templates/brief.md",
+          title: "Brief Template",
+          author_slug: "pm",
+          last_edited_ts: new Date().toISOString(),
+          group: "templates",
+        },
+      ]);
+
+    render(<Wiki articlePath={null} onNavigate={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-catalog")).toBeInTheDocument(),
+    );
+
+    act(() => {
+      sectionHandler?.({
+        sections: [
+          {
+            slug: "templates",
+            title: "Templates",
+            article_paths: ["team/templates/brief.md"],
+            article_count: 1,
+            first_seen_ts: new Date().toISOString(),
+            last_update_ts: new Date().toISOString(),
+            from_schema: false,
+          },
+        ],
+        timestamp: new Date().toISOString(),
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getAllByText("Brief Template").length).toBeGreaterThan(0),
     );
   });
 });

--- a/web/src/components/wiki/Wiki.test.tsx
+++ b/web/src/components/wiki/Wiki.test.tsx
@@ -63,17 +63,16 @@ describe("<Wiki>", () => {
       sectionHandler = handler;
       return () => {};
     });
-    vi.spyOn(api, "fetchCatalog")
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([
-        {
-          path: "team/templates/brief.md",
-          title: "Brief Template",
-          author_slug: "pm",
-          last_edited_ts: new Date().toISOString(),
-          group: "templates",
-        },
-      ]);
+    vi.spyOn(api, "fetchCatalog").mockResolvedValue([]);
+    vi.spyOn(api, "fetchCatalogStrict").mockResolvedValue([
+      {
+        path: "team/templates/brief.md",
+        title: "Brief Template",
+        author_slug: "pm",
+        last_edited_ts: new Date().toISOString(),
+        group: "templates",
+      },
+    ]);
 
     render(<Wiki articlePath={null} onNavigate={() => {}} />);
     await waitFor(() =>
@@ -101,5 +100,51 @@ describe("<Wiki>", () => {
     await waitFor(() =>
       expect(screen.getAllByText("Brief Template").length).toBeGreaterThan(0),
     );
+  });
+
+  it("keeps the current catalog when a live refresh fails", async () => {
+    let sectionHandler: ((event: api.WikiSectionsUpdatedEvent) => void) | null =
+      null;
+    vi.spyOn(api, "subscribeSectionsUpdated").mockImplementation((handler) => {
+      sectionHandler = handler;
+      return () => {};
+    });
+    vi.spyOn(api, "fetchCatalog").mockResolvedValue([
+      {
+        path: "team/playbooks/pricing.md",
+        title: "Pricing Playbook",
+        author_slug: "pm",
+        last_edited_ts: new Date().toISOString(),
+        group: "playbooks",
+      },
+    ]);
+    vi.spyOn(api, "fetchCatalogStrict").mockRejectedValue(
+      new Error("broker down"),
+    );
+
+    render(<Wiki articlePath={null} onNavigate={() => {}} />);
+    await waitFor(() =>
+      expect(screen.getAllByText("Pricing Playbook").length).toBeGreaterThan(0),
+    );
+
+    await act(async () => {
+      sectionHandler?.({
+        sections: [
+          {
+            slug: "playbooks",
+            title: "Playbooks",
+            article_paths: ["team/playbooks/pricing.md"],
+            article_count: 1,
+            first_seen_ts: new Date().toISOString(),
+            last_update_ts: new Date().toISOString(),
+            from_schema: true,
+          },
+        ],
+        timestamp: new Date().toISOString(),
+      });
+      await Promise.resolve();
+    });
+
+    expect(screen.getAllByText("Pricing Playbook").length).toBeGreaterThan(0);
   });
 });

--- a/web/src/components/wiki/Wiki.tsx
+++ b/web/src/components/wiki/Wiki.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import {
   type DiscoveredSection,
@@ -62,16 +62,27 @@ export default function Wiki({
     };
   }, []);
 
+  const refreshCatalog = useCallback(() => {
+    fetchCatalog()
+      .then((c) => setCatalog(c))
+      .catch(() => {
+        // Keep the last known catalog; a transient refresh miss should not
+        // blank navigation while the live section event is still useful.
+      });
+  }, []);
+
   // Live-update sections when the broker emits wiki:sections_updated.
-  // The event payload carries the full list so no refetch is needed.
+  // The event payload carries the full section list; the article list still
+  // comes from /wiki/catalog, so refresh it after a write-created section.
   useEffect(() => {
     const unsubscribe = subscribeSectionsUpdated((event) => {
       if (Array.isArray(event.sections)) {
         setSections(event.sections);
+        refreshCatalog();
       }
     });
     return () => unsubscribe();
-  }, []);
+  }, [refreshCatalog]);
 
   const view = wikiViewFor(articlePath);
   const isAudit = view === "audit";

--- a/web/src/components/wiki/Wiki.tsx
+++ b/web/src/components/wiki/Wiki.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import {
   type DiscoveredSection,
   fetchCatalog,
+  fetchCatalogStrict,
   fetchSections,
   subscribeSectionsUpdated,
   type WikiCatalogEntry,
@@ -63,7 +64,7 @@ export default function Wiki({
   }, []);
 
   const refreshCatalog = useCallback(() => {
-    fetchCatalog()
+    fetchCatalogStrict()
       .then((c) => setCatalog(c))
       .catch(() => {
         // Keep the last known catalog; a transient refresh miss should not

--- a/web/src/components/wiki/WikiSidebar.test.tsx
+++ b/web/src/components/wiki/WikiSidebar.test.tsx
@@ -6,21 +6,21 @@ import WikiSidebar from "./WikiSidebar";
 
 const CATALOG: WikiCatalogEntry[] = [
   {
-    path: "people/nazz",
+    path: "team/people/nazz.md",
     title: "Nazz",
     author_slug: "pm",
     last_edited_ts: new Date().toISOString(),
     group: "people",
   },
   {
-    path: "people/sarah",
+    path: "team/people/sarah.md",
     title: "Sarah",
     author_slug: "ceo",
     last_edited_ts: new Date().toISOString(),
     group: "people",
   },
   {
-    path: "playbooks/churn",
+    path: "team/playbooks/churn.md",
     title: "Churn prevention",
     author_slug: "cmo",
     last_edited_ts: new Date().toISOString(),
@@ -52,7 +52,7 @@ describe("<WikiSidebar> — legacy catalog-grouping path", () => {
     const onNavigate = vi.fn();
     render(<WikiSidebar catalog={CATALOG} onNavigate={onNavigate} />);
     fireEvent.click(screen.getByText("Churn prevention"));
-    expect(onNavigate).toHaveBeenCalledWith("playbooks/churn");
+    expect(onNavigate).toHaveBeenCalledWith("team/playbooks/churn.md");
   });
 
   it("filters articles by the search query", () => {
@@ -117,6 +117,43 @@ describe("<WikiSidebar> — dynamic sections", () => {
           h.closest("[data-section-slug]")?.getAttribute("data-section-slug"),
       ),
     ).toEqual(["people", "playbooks", "retrospectives"]);
+  });
+
+  it("renders nested folders from canonical article paths", () => {
+    const nested: WikiCatalogEntry[] = [
+      ...CATALOG,
+      {
+        path: "team/people/customers/acme.md",
+        title: "Acme",
+        author_slug: "pm",
+        last_edited_ts: new Date().toISOString(),
+        group: "people",
+      },
+    ];
+    const sections: DiscoveredSection[] = [
+      {
+        ...SECTIONS[0],
+        article_paths: [
+          "team/people/nazz.md",
+          "team/people/sarah.md",
+          "team/people/customers/acme.md",
+        ],
+        article_count: 3,
+      },
+    ];
+    render(
+      <WikiSidebar
+        catalog={nested}
+        sections={sections}
+        currentPath="team/people/customers/acme.md"
+        onNavigate={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /customers 1/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Acme").closest("li")).toHaveClass("current");
   });
 
   it("distinguishes schema-declared from discovered sections via class", () => {

--- a/web/src/components/wiki/WikiSidebar.test.tsx
+++ b/web/src/components/wiki/WikiSidebar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import type { DiscoveredSection, WikiCatalogEntry } from "../../api/wiki";
@@ -154,6 +154,54 @@ describe("<WikiSidebar> — dynamic sections", () => {
       screen.getByRole("button", { name: /customers 1/i }),
     ).toBeInTheDocument();
     expect(screen.getByText("Acme").closest("li")).toHaveClass("current");
+  });
+
+  it("reopens a collapsed folder when navigation selects an article inside it", async () => {
+    const nested: WikiCatalogEntry[] = [
+      ...CATALOG,
+      {
+        path: "team/people/customers/acme.md",
+        title: "Acme",
+        author_slug: "pm",
+        last_edited_ts: new Date().toISOString(),
+        group: "people",
+      },
+    ];
+    const sections: DiscoveredSection[] = [
+      {
+        ...SECTIONS[0],
+        article_paths: [
+          "team/people/nazz.md",
+          "team/people/sarah.md",
+          "team/people/customers/acme.md",
+        ],
+        article_count: 3,
+      },
+    ];
+    const { rerender } = render(
+      <WikiSidebar
+        catalog={nested}
+        sections={sections}
+        currentPath={null}
+        onNavigate={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /customers 1/i }));
+    expect(screen.queryByText("Acme")).toBeNull();
+
+    rerender(
+      <WikiSidebar
+        catalog={nested}
+        sections={sections}
+        currentPath="team/people/customers/acme.md"
+        onNavigate={() => {}}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText("Acme").closest("li")).toHaveClass("current"),
+    );
   });
 
   it("distinguishes schema-declared from discovered sections via class", () => {

--- a/web/src/components/wiki/WikiSidebar.tsx
+++ b/web/src/components/wiki/WikiSidebar.tsx
@@ -117,7 +117,12 @@ export default function WikiSidebar({
                     {items.map((item) => (
                       <li
                         key={item.path}
-                        className={currentPath === item.path ? "current" : ""}
+                        className={
+                          articlePathKey(currentPath ?? "") ===
+                          articlePathKey(item.path)
+                            ? "current"
+                            : ""
+                        }
                       >
                         <a
                           href={`#/wiki/${encodeURI(item.path)}`}
@@ -188,6 +193,12 @@ function SectionGroup({
   onNavigate,
   onSectionHeaderClick,
 }: SectionGroupProps) {
+  const tree = useMemo(
+    () => buildSectionTree(section.slug, entries),
+    [section.slug, entries],
+  );
+  const currentKey = articlePathKey(currentPath ?? "");
+
   return (
     <div className="wk-section-group" data-section-slug={section.slug}>
       <h3
@@ -199,7 +210,10 @@ function SectionGroup({
             : "Discovered from articles your team has written"
         }
       >
-        <span className="wk-section-title">{section.slug}</span>
+        <span className="wk-section-title">
+          {section.title || section.slug}
+        </span>
+        <span className="wk-section-count">{section.article_count}</span>
         {!section.from_schema ? (
           <span className="wk-section-marker" aria-label="Discovered section" />
         ) : null}
@@ -209,28 +223,18 @@ function SectionGroup({
           </span>
         ) : null}
       </h3>
-      <ul>
+      <ul className="wk-tree" aria-label={`${section.slug} articles`}>
         {entries.length === 0 ? (
           <li className="wk-section-empty">
             <em>No articles yet</em>
           </li>
         ) : (
-          entries.map((item) => (
-            <li
-              key={item.path}
-              className={currentPath === item.path ? "current" : ""}
-            >
-              <a
-                href={`#/wiki/${encodeURI(item.path)}`}
-                onClick={(e) => {
-                  e.preventDefault();
-                  onNavigate(item.path);
-                }}
-              >
-                {item.title}
-              </a>
-            </li>
-          ))
+          <TreeBranch
+            node={tree}
+            currentKey={currentKey}
+            onNavigate={onNavigate}
+            root={true}
+          />
         )}
       </ul>
     </div>
@@ -283,6 +287,189 @@ function groupCatalog(
     out[entry.group].push(entry);
   }
   return out;
+}
+
+interface WikiTreeNode {
+  name: string;
+  key: string;
+  folders: WikiTreeNode[];
+  articles: WikiCatalogEntry[];
+}
+
+function buildSectionTree(
+  sectionSlug: string,
+  entries: WikiCatalogEntry[],
+): WikiTreeNode {
+  const root: WikiTreeNode = {
+    name: sectionSlug,
+    key: sectionSlug,
+    folders: [],
+    articles: [],
+  };
+  const folderIndex = new Map<string, WikiTreeNode>([[root.key, root]]);
+  const sorted = [...entries].sort((a, b) =>
+    normalizePathKey(a.path).localeCompare(normalizePathKey(b.path)),
+  );
+
+  for (const entry of sorted) {
+    const segments = displayPathSegments(sectionSlug, entry);
+    if (segments.length <= 1) {
+      root.articles.push(entry);
+      continue;
+    }
+    let parent = root;
+    let { key } = root;
+    for (const segment of segments.slice(0, -1)) {
+      key = `${key}/${segment}`;
+      let next = folderIndex.get(key);
+      if (!next) {
+        next = { name: segment, key, folders: [], articles: [] };
+        folderIndex.set(key, next);
+        parent.folders.push(next);
+        parent.folders.sort((a, b) => a.name.localeCompare(b.name));
+      }
+      parent = next;
+    }
+    parent.articles.push(entry);
+  }
+
+  sortTree(root);
+  return root;
+}
+
+function sortTree(node: WikiTreeNode): void {
+  node.folders.sort((a, b) => a.name.localeCompare(b.name));
+  node.articles.sort((a, b) => a.title.localeCompare(b.title));
+  for (const child of node.folders) sortTree(child);
+}
+
+function displayPathSegments(
+  sectionSlug: string,
+  entry: WikiCatalogEntry,
+): string[] {
+  const segments = normalizePathKey(entry.path).split("/").filter(Boolean);
+  if (segments[0] === "team") segments.shift();
+  if (segments[0] === sectionSlug) segments.shift();
+  return segments.length > 0 ? segments : [entry.title];
+}
+
+function normalizePathKey(path: string): string {
+  return path.replace(/^\/+/, "").replace(/\.md$/, "");
+}
+
+function articlePathKey(path: string): string {
+  const normalized = normalizePathKey(path);
+  return normalized.startsWith("team/")
+    ? normalized.slice("team/".length)
+    : normalized;
+}
+
+function TreeBranch({
+  node,
+  currentKey,
+  onNavigate,
+  root = false,
+}: {
+  node: WikiTreeNode;
+  currentKey: string;
+  onNavigate: (path: string) => void;
+  root?: boolean;
+}) {
+  return (
+    <>
+      {node.folders.map((folder) => (
+        <TreeFolder
+          key={folder.key}
+          node={folder}
+          currentKey={currentKey}
+          onNavigate={onNavigate}
+        />
+      ))}
+      {node.articles.map((item) => (
+        <TreeArticle
+          key={item.path}
+          item={item}
+          current={articlePathKey(item.path) === currentKey}
+          onNavigate={onNavigate}
+          nested={!root}
+        />
+      ))}
+    </>
+  );
+}
+
+function TreeFolder({
+  node,
+  currentKey,
+  onNavigate,
+}: {
+  node: WikiTreeNode;
+  currentKey: string;
+  onNavigate: (path: string) => void;
+}) {
+  const [open, setOpen] = useState(true);
+  const articleCount = countArticles(node);
+  return (
+    <li className="wk-tree-folder">
+      <button
+        type="button"
+        className="wk-tree-folder-btn"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <span className="wk-tree-chevron" aria-hidden="true">
+          {open ? "▾" : "▸"}
+        </span>
+        <span className="wk-tree-folder-name">{node.name}</span>
+        <span className="wk-tree-count">{articleCount}</span>
+      </button>
+      {open ? (
+        <ul className="wk-tree-children">
+          <TreeBranch
+            node={node}
+            currentKey={currentKey}
+            onNavigate={onNavigate}
+          />
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+function TreeArticle({
+  item,
+  current,
+  onNavigate,
+  nested,
+}: {
+  item: WikiCatalogEntry;
+  current: boolean;
+  onNavigate: (path: string) => void;
+  nested: boolean;
+}) {
+  return (
+    <li className={current ? "current wk-tree-article" : "wk-tree-article"}>
+      <a
+        href={`#/wiki/${encodeURI(item.path)}`}
+        className={nested ? "wk-tree-article-link is-nested" : undefined}
+        title={item.path}
+        onClick={(e) => {
+          e.preventDefault();
+          onNavigate(item.path);
+        }}
+      >
+        <span className="wk-tree-file-dot" aria-hidden="true" />
+        <span className="wk-tree-article-title">{item.title}</span>
+      </a>
+    </li>
+  );
+}
+
+function countArticles(node: WikiTreeNode): number {
+  return (
+    node.articles.length +
+    node.folders.reduce((count, child) => count + countArticles(child), 0)
+  );
 }
 
 /**

--- a/web/src/components/wiki/WikiSidebar.tsx
+++ b/web/src/components/wiki/WikiSidebar.tsx
@@ -450,7 +450,7 @@ function TreeArticle({
     <li className={current ? "current wk-tree-article" : "wk-tree-article"}>
       <a
         href={`#/wiki/${encodeURI(item.path)}`}
-        className={nested ? "wk-tree-article-link is-nested" : undefined}
+        className={`wk-tree-article-link${nested ? " is-nested" : ""}`}
         title={item.path}
         onClick={(e) => {
           e.preventDefault();

--- a/web/src/components/wiki/WikiSidebar.tsx
+++ b/web/src/components/wiki/WikiSidebar.tsx
@@ -326,7 +326,6 @@ function buildSectionTree(
         next = { name: segment, key, folders: [], articles: [] };
         folderIndex.set(key, next);
         parent.folders.push(next);
-        parent.folders.sort((a, b) => a.name.localeCompare(b.name));
       }
       parent = next;
     }

--- a/web/src/components/wiki/WikiSidebar.tsx
+++ b/web/src/components/wiki/WikiSidebar.tsx
@@ -1,6 +1,6 @@
 // biome-ignore-all lint/a11y/useAriaPropsSupportedByRole: Passive metadata uses accessible labels queried by screen-reader tests; visual text remains unchanged.
 // biome-ignore-all lint/a11y/useKeyWithClickEvents: Pointer handler is paired with an existing modal, image, or routed-control keyboard path; preserving current interaction model.
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import type { DiscoveredSection, WikiCatalogEntry } from "../../api/wiki";
 import { resolveGroupOrder } from "../../lib/groupOrder";
@@ -408,6 +408,12 @@ function TreeFolder({
 }) {
   const [open, setOpen] = useState(true);
   const articleCount = countArticles(node);
+  const containsCurrent = branchContainsCurrent(node, currentKey);
+
+  useEffect(() => {
+    if (containsCurrent) setOpen(true);
+  }, [containsCurrent]);
+
   return (
     <li className="wk-tree-folder">
       <button
@@ -468,6 +474,17 @@ function countArticles(node: WikiTreeNode): number {
   return (
     node.articles.length +
     node.folders.reduce((count, child) => count + countArticles(child), 0)
+  );
+}
+
+function branchContainsCurrent(
+  node: WikiTreeNode,
+  currentKey: string,
+): boolean {
+  if (!currentKey) return false;
+  return (
+    node.articles.some((item) => articlePathKey(item.path) === currentKey) ||
+    node.folders.some((child) => branchContainsCurrent(child, currentKey))
   );
 }
 

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1400,6 +1400,13 @@
   gap: 6px;
   cursor: default;
 }
+.wk-section-count,
+.wk-tree-count {
+  color: var(--wk-text-tertiary);
+  font-family: var(--wk-mono);
+  font-size: 10px;
+  font-weight: 500;
+}
 .wk-section-discovered {
   cursor: pointer;
 }
@@ -1431,6 +1438,79 @@
   color: var(--wk-text-tertiary);
   font-size: 11px;
   font-family: var(--wk-chrome);
+}
+.wk-nav-sidebar ul.wk-tree,
+.wk-nav-sidebar .wk-tree-children {
+  gap: 0;
+}
+.wk-tree-folder {
+  display: flex;
+  flex-direction: column;
+}
+.wk-tree-folder-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: 100%;
+  min-height: 28px;
+  padding: 5px 10px;
+  color: var(--wk-text-muted);
+  background: transparent;
+  border: 0;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-family: var(--wk-chrome);
+  font-size: 12px;
+  line-height: 1.3;
+  text-align: left;
+}
+.wk-tree-folder-btn:hover {
+  background: var(--wk-paper-dark);
+  color: var(--wk-text);
+}
+.wk-tree-folder-btn:focus-visible,
+.wk-tree-article a:focus-visible {
+  outline: 2px solid var(--wk-wikilink);
+  outline-offset: 1px;
+}
+.wk-tree-chevron {
+  width: 10px;
+  color: var(--wk-text-tertiary);
+  font-family: var(--wk-mono);
+  font-size: 10px;
+  line-height: 1;
+  text-align: center;
+}
+.wk-tree-folder-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wk-tree-count {
+  margin-left: auto;
+}
+.wk-tree-children {
+  margin-left: 12px;
+  padding-left: 8px;
+  border-left: 1px solid var(--wk-border-light);
+}
+.wk-tree-article-link {
+  gap: 6px;
+}
+.wk-tree-article-link.is-nested {
+  padding-left: 8px;
+}
+.wk-tree-file-dot {
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--wk-border-strong);
+  flex: 0 0 auto;
+}
+.wk-tree-article-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .wk-section-banner {
   margin: 6px 0 8px;


### PR DESCRIPTION
## Summary
- add collapsible folder navigation to the wiki sidebar from existing article paths
- show section display titles and article counts while preserving empty blueprint sections
- refresh the wiki catalog after live section updates so newly written articles appear without a full reload
- skip system wiki subtrees from dynamic section discovery

## Tests
- bash scripts/test-web.sh web/src/components/wiki/WikiSidebar.test.tsx web/src/components/wiki/Wiki.test.tsx
- cd web && bunx tsc --noEmit
- bash scripts/test-go.sh ./internal/team
- cd web && bunx biome check src/components/wiki/Wiki.tsx src/components/wiki/Wiki.test.tsx src/components/wiki/WikiSidebar.tsx src/components/wiki/WikiSidebar.test.tsx src/styles/wiki.css
- git diff --check
- prohibited-term scan
- bash scripts/test-web.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar shows hierarchical folder/tree with current-article highlighting and canonical team paths.
  * Live section updates now trigger automatic catalog refreshes.
  * System wiki directories are excluded from discovery.
  * Section and folder article count badges displayed.

* **Style**
  * Updated wiki styles for tree layout, counts, truncation, focus outlines, folder/chevron visuals.

* **Tests**
  * Added tests for section discovery exclusions, live-update-driven refresh, and sidebar rendering/interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->