### PR TITLE
fix(devex): harden source builds and provider onboarding

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,10 +3,14 @@
 ## Office Build
 
 ```bash
+cd web
+bun install
+bun run build
+cd ..
 go build -o wuphf ./cmd/wuphf
 ```
 
-For normal app usage you do not need Bun. The local office/team MCP tools now run from the main Go binary through the hidden `wuphf mcp-team` subcommand.
+Release and npm binaries already include the web UI assets. Source builds need Bun once to generate `web/dist/`; otherwise the Go binary will show the missing-assets setup page instead of serving raw Vite source files. The local office/team MCP tools now run from the main Go binary through the hidden `wuphf mcp-team` subcommand.
 
 ## First-time setup
 

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ Prefer a global install?
 npm install -g wuphf && wuphf
 ```
 
-Building from source (requires Go):
+Building from source (requires Go and Bun):
 
 ```bash
 git clone https://github.com/nex-crm/wuphf.git
 cd wuphf
+cd web
+bun install
+bun run build
+cd ..
 go build -o wuphf ./cmd/wuphf
 ./wuphf
 ```
@@ -87,13 +91,13 @@ if I say yes. If I am not logged in, just open https://wuphf.team.
 
 | Flag | What it does |
 |------|-------------|
-| `--memory-backend <name>` | Pick the organizational memory backend (`nex`, `gbrain`, `none`) |
+| `--memory-backend <name>` | Pick the organizational memory backend (`markdown`, `nex`, `gbrain`, `none`) |
 | `--no-nex` | Skip the Nex backend (no context graph, no Nex-managed integrations) |
 | `--tui` | Use the tmux TUI instead of the web UI |
 | `--no-open` | Don't auto-open the browser |
 | `--pack <name>` | Pick an agent pack (`starter`, `founding-team`, `coding-team`, `lead-gen-agency`, `revops`) |
 | `--opus-ceo` | Upgrade CEO from Sonnet to Opus |
-| `--provider <name>` | LLM provider override (`claude-code`, `codex`) |
+| `--provider <name>` | LLM provider override (`claude-code`, `codex`, `opencode`) |
 | `--collab` | Start in collaborative mode — all agents see all messages (this is the default) |
 | `--unsafe` | Bypass agent permission checks (local dev only) |
 | `--web-port <n>` | Change the web UI port (default 7891) |

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -356,7 +356,11 @@ func main() {
 		}
 		if wantsHelp {
 			if sub == "skills" {
-				runSkillsCmd(args[1:])
+				if len(args) > 1 && isFamilyHelp(args[1]) {
+					printSkillsHelp()
+				} else {
+					runSkillsCmd(args[1:])
+				}
 			} else {
 				printSubcommandHelp(sub)
 			}

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -348,6 +348,9 @@ func main() {
 	if len(args) > 0 {
 		sub := args[0]
 		wantsHelp := subcommandWantsHelp(args[1:])
+		// isFamilyHelp additionally catches the bare word "help" (for
+		// example `wuphf skills help`); dash-prefixed help flags are covered
+		// by subcommandWantsHelp above.
 		if sub == "skills" && len(args) > 1 && isFamilyHelp(args[1]) {
 			wantsHelp = true
 		}

--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -341,6 +341,26 @@ func main() {
 		os.Exit(0)
 	}
 
+	// Handle read-only subcommand help before workspace migrations and PATH
+	// shadow warnings. Help should be side-effect-free even when a user's
+	// local ~/.wuphf state needs repair.
+	args := flag.Args()
+	if len(args) > 0 {
+		sub := args[0]
+		wantsHelp := subcommandWantsHelp(args[1:])
+		if sub == "skills" && len(args) > 1 && isFamilyHelp(args[1]) {
+			wantsHelp = true
+		}
+		if wantsHelp {
+			if sub == "skills" {
+				runSkillsCmd(args[1:])
+			} else {
+				printSubcommandHelp(sub)
+			}
+			return
+		}
+	}
+
 	// Wire the workspaces orchestrator + run the symmetric-layout migration.
 	// Placed after --help-all and --version early exits so read-only
 	// invocations skip the filesystem migration entirely.
@@ -351,9 +371,6 @@ func main() {
 		runChannelView(*threadsCollapsed, channelui.ResolveInitialOfficeApp(*channelApp), strings.TrimSpace(*channelApp) != "")
 		return
 	}
-
-	// Handle subcommands
-	args := flag.Args()
 
 	// Warn if another wuphf binary is on PATH and may shadow this one. Interactive
 	// only — scripted and stdio-subprocess entrypoints keep their output clean.
@@ -367,13 +384,6 @@ func main() {
 
 	if len(args) > 0 {
 		sub := args[0]
-		// `skills` owns its own per-verb help routing (publish/install have
-		// flag-set-level docs), so we never short-circuit to the family
-		// help when there is a verb between `skills` and `--help`.
-		if sub != "skills" && subcommandWantsHelp(args[1:]) {
-			printSubcommandHelp(sub)
-			return
-		}
 		switch sub {
 		case "mcp-team":
 			if err := teammcp.Run(context.Background()); err != nil {

--- a/internal/team/broker_config_provider_endpoints_test.go
+++ b/internal/team/broker_config_provider_endpoints_test.go
@@ -47,6 +47,43 @@ func configRequest(t *testing.T, b *Broker, method, body string) *httptest.Respo
 	return rec
 }
 
+func TestHandleConfigReportsProviderConfiguredSource(t *testing.T) {
+	withWuphfHomeDir(t)
+	t.Setenv("WUPHF_LLM_PROVIDER", "")
+	b := newTestBroker(t)
+
+	rec := configRequest(t, b, http.MethodGet, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode GET /config: %v", err)
+	}
+	if provider, _ := cfg["llm_provider"].(string); provider != "claude-code" {
+		t.Fatalf("expected default provider claude-code, got %q", provider)
+	}
+	if configured, _ := cfg["llm_provider_configured"].(bool); configured {
+		t.Fatalf("expected default provider to be reported as not configured: %s", rec.Body.String())
+	}
+
+	t.Setenv("WUPHF_LLM_PROVIDER", "codex")
+	rec = configRequest(t, b, http.MethodGet, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET with env status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	cfg = map[string]any{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode GET /config with env: %v", err)
+	}
+	if provider, _ := cfg["llm_provider"].(string); provider != "codex" {
+		t.Fatalf("expected env provider codex, got %q", provider)
+	}
+	if configured, _ := cfg["llm_provider_configured"].(bool); !configured {
+		t.Fatalf("expected env provider to be reported as configured: %s", rec.Body.String())
+	}
+}
+
 // TestHandleConfig_ProviderEndpointsRoundTrip is the load-bearing test
 // for the Settings UI: the provider_endpoints map must persist through
 // POST → config.json → GET so the Local LLMs section can save and

--- a/internal/team/broker_config_provider_endpoints_test.go
+++ b/internal/team/broker_config_provider_endpoints_test.go
@@ -82,6 +82,25 @@ func TestHandleConfigReportsProviderConfiguredSource(t *testing.T) {
 	if configured, _ := cfg["llm_provider_configured"].(bool); !configured {
 		t.Fatalf("expected env provider to be reported as configured: %s", rec.Body.String())
 	}
+
+	t.Setenv("WUPHF_LLM_PROVIDER", "")
+	if rec := configRequest(t, b, http.MethodPost, `{"llm_provider":"codex"}`); rec.Code != http.StatusOK {
+		t.Fatalf("POST seed provider: %d %s", rec.Code, rec.Body.String())
+	}
+	rec = configRequest(t, b, http.MethodGet, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET after file provider status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	cfg = map[string]any{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &cfg); err != nil {
+		t.Fatalf("decode GET /config with file provider: %v", err)
+	}
+	if provider, _ := cfg["llm_provider"].(string); provider != "codex" {
+		t.Fatalf("expected file provider codex, got %q", provider)
+	}
+	if configured, _ := cfg["llm_provider_configured"].(bool); !configured {
+		t.Fatalf("expected file provider to be reported as configured: %s", rec.Body.String())
+	}
 }
 
 // TestHandleConfig_ProviderEndpointsRoundTrip is the load-bearing test

--- a/internal/team/broker_config_provider_endpoints_test.go
+++ b/internal/team/broker_config_provider_endpoints_test.go
@@ -84,7 +84,8 @@ func TestHandleConfigReportsProviderConfiguredSource(t *testing.T) {
 	}
 
 	t.Setenv("WUPHF_LLM_PROVIDER", "")
-	if rec := configRequest(t, b, http.MethodPost, `{"llm_provider":"codex"}`); rec.Code != http.StatusOK {
+	rec = configRequest(t, b, http.MethodPost, `{"llm_provider":"codex"}`)
+	if rec.Code != http.StatusOK {
 		t.Fatalf("POST seed provider: %d %s", rec.Code, rec.Body.String())
 	}
 	rec = configRequest(t, b, http.MethodGet, "")

--- a/internal/team/broker_office_channels.go
+++ b/internal/team/broker_office_channels.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -137,19 +138,24 @@ func (b *Broker) handleConfig(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "failed to read config", http.StatusInternalServerError)
 			return
 		}
+		envLLMProvider := strings.TrimSpace(os.Getenv("WUPHF_LLM_PROVIDER"))
+		configLLMProvider := strings.TrimSpace(cfg.LLMProvider)
+		llmProviderConfigured := (envLLMProvider != "" && config.IsLLMProviderKindAllowed(envLLMProvider)) ||
+			(configLLMProvider != "" && config.IsLLMProviderKindAllowed(configLLMProvider))
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			// Runtime
-			"llm_provider":          config.ResolveLLMProvider(""),
-			"llm_provider_priority": cfg.LLMProviderPriority,
-			"provider_endpoints":    cfg.ProviderEndpoints,
-			"memory_backend":        config.ResolveMemoryBackend(""),
-			"action_provider":       config.ResolveActionProvider(),
-			"team_lead_slug":        cfg.TeamLeadSlug,
-			"max_concurrent_agents": cfg.MaxConcurrent,
-			"default_format":        config.ResolveFormat(""),
-			"default_timeout":       config.ResolveTimeout(""),
-			"blueprint":             cfg.ActiveBlueprint(),
+			"llm_provider":            config.ResolveLLMProvider(""),
+			"llm_provider_configured": llmProviderConfigured,
+			"llm_provider_priority":   cfg.LLMProviderPriority,
+			"provider_endpoints":      cfg.ProviderEndpoints,
+			"memory_backend":          config.ResolveMemoryBackend(""),
+			"action_provider":         config.ResolveActionProvider(),
+			"team_lead_slug":          cfg.TeamLeadSlug,
+			"max_concurrent_agents":   cfg.MaxConcurrent,
+			"default_format":          config.ResolveFormat(""),
+			"default_timeout":         config.ResolveTimeout(""),
+			"blueprint":               cfg.ActiveBlueprint(),
 			// Workspace
 			"email":          cfg.Email,
 			"workspace_id":   cfg.WorkspaceID,

--- a/internal/team/broker_web_proxy.go
+++ b/internal/team/broker_web_proxy.go
@@ -47,7 +47,7 @@ func (b *Broker) ServeWebUI(port int) error {
 	}
 
 	// Resolution order for the web UI assets:
-	//   1. filesystem web/dist/ (local dev after `npm run build`)
+	//   1. filesystem web/dist/ (local dev after `bun run build`)
 	//   2. embedded FS (single-binary installs via curl | bash)
 	exePath, _ := os.Executable()
 	webDir := filepath.Join(filepath.Dir(exePath), "web")
@@ -64,8 +64,10 @@ func (b *Broker) ServeWebUI(port int) error {
 		// No on-disk build; use embedded assets.
 		fileServer = http.FileServer(http.FS(embeddedFS))
 	} else {
-		// Nothing available; serve webDir as-is so 404s come from the actual FS.
-		fileServer = http.FileServer(http.Dir(webDir))
+		// Source checkout without web/dist. Do not serve raw Vite source files:
+		// browsers load /src/main.tsx as text/plain and the page stalls on
+		// "Loading WUPHF". Return an actionable setup page instead.
+		fileServer = missingWebAssetsHandler()
 	}
 	mux := http.NewServeMux()
 	brokerURL := brokeraddr.ResolveBaseURL()
@@ -129,6 +131,42 @@ func (b *Broker) ServeWebUI(port int) error {
 		}
 	}()
 	return nil
+}
+
+func missingWebAssetsHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>WUPHF web UI assets missing</title>
+  <style>
+    body { margin: 0; font: 16px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #1f2933; background: #f5f3ef; }
+    main { max-width: 760px; margin: 10vh auto; padding: 0 24px; }
+    h1 { font-size: 28px; line-height: 1.2; margin: 0 0 12px; }
+    p { margin: 0 0 16px; }
+    pre { overflow-x: auto; padding: 16px; border: 1px solid #d7d0c6; border-radius: 8px; background: #fffaf2; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 14px; }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>WUPHF web UI assets are missing</h1>
+    <p>This source build did not include <code>web/dist/index.html</code>, and the embedded bundle is empty.</p>
+    <p>Build the frontend bundle before rebuilding the Go binary:</p>
+    <pre><code>cd web
+bun install
+bun run build
+cd ..
+go build -o wuphf ./cmd/wuphf
+./wuphf</code></pre>
+  </main>
+</body>
+</html>`)
+	})
 }
 
 // cacheControlMiddleware sets conservative cache headers on the web UI so

--- a/internal/team/broker_web_test.go
+++ b/internal/team/broker_web_test.go
@@ -48,6 +48,30 @@ func TestWebUIProxyHandlerForwardsOnboardingRoutes(t *testing.T) {
 	}
 }
 
+func TestMissingWebAssetsHandlerExplainsSourceBuild(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	missingWebAssetsHandler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "text/html") {
+		t.Fatalf("expected text/html content type, got %q", ct)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"web/dist/index.html",
+		"bun run build",
+		"go build -o wuphf ./cmd/wuphf",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected missing-assets page to contain %q, got:\n%s", want, body)
+		}
+	}
+}
+
 func TestWorkspaceShredRouteResetsBrokerWithoutShutdown(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("WUPHF_RUNTIME_HOME", home)

--- a/npm/README.md
+++ b/npm/README.md
@@ -43,28 +43,30 @@ Supported platforms: macOS, Linux, and Windows 10+ on x64 or arm64. The native b
 
 | Flag | What it does |
 |------|-------------|
-| `--memory-backend <name>` | Pick the organizational memory backend (`nex`, `gbrain`, `none`) |
+| `--memory-backend <name>` | Pick the organizational memory backend (`markdown`, `nex`, `gbrain`, `none`) |
 | `--no-nex` | Skip the Nex backend (no context graph, no Nex-managed integrations) |
 | `--tui` | Use the tmux TUI instead of the web UI |
 | `--no-open` | Don't auto-open the browser |
 | `--pack <name>` | Pick an agent pack (`starter`, `founding-team`, `coding-team`, `lead-gen-agency`, `revops`) |
 | `--opus-ceo` | Upgrade CEO from Sonnet to Opus |
-| `--provider <name>` | LLM provider override (`claude-code`, `codex`) |
+| `--provider <name>` | LLM provider override (`claude-code`, `codex`, `opencode`) |
 | `--collab` | Start in collaborative mode — all agents see all messages (this is the default) |
 | `--unsafe` | Bypass agent permission checks (local dev only) |
 | `--web-port <n>` | Change the web UI port (default 7891) |
 
 ## Memory: Notebooks and the Wiki
 
-Every agent gets its own **notebook**. The team shares a **wiki**. When a conclusion in an agent's notebook holds up, it gets promoted to the wiki so the whole office benefits. Both are knowledge graphs under the hood, on Garry Tan's GBrain or Nex.
+Every agent gets its own **notebook**. The team shares a **wiki**. New installs get the wiki as a local git repo of markdown articles. Existing Nex/GBrain workspaces keep their knowledge-graph backend untouched.
 
 **Backends for the wiki:**
 
-- `nex` is the default. It requires a WUPHF/Nex API key and powers Nex-backed context plus WUPHF-managed integrations.
+- `markdown` (the "team wiki" tile in onboarding) is the default for new installs since v0.0.6. It stores typed facts, entity briefs, cited lookup answers, and lintable wiki articles in a local git repo at `~/.wuphf/wiki/`. No API key required.
+- `nex` was the previous default. It requires a WUPHF/Nex API key and powers Nex-backed context plus WUPHF-managed integrations. Existing users stay on `nex` via persisted config.
 - `gbrain` mounts `gbrain serve` as the wiki backend.
-- `none` disables the external wiki entirely. Notebooks still work locally.
+- `none` disables the shared wiki entirely. Notebooks still work locally.
 
 ```bash
+wuphf --memory-backend markdown
 wuphf --memory-backend nex
 wuphf --memory-backend gbrain
 wuphf --memory-backend none

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -913,7 +913,7 @@ export type LLMProvider =
   | "mlx-lm"
   | "ollama"
   | "exo";
-export type MemoryBackend = "nex" | "gbrain" | "none";
+export type MemoryBackend = "markdown" | "nex" | "gbrain" | "none";
 export type ActionProvider = "auto" | "one" | "composio" | "";
 
 export interface ProviderEndpoint {
@@ -946,6 +946,7 @@ export interface LocalProviderStatus {
 export interface ConfigSnapshot {
   // Runtime
   llm_provider?: LLMProvider;
+  llm_provider_configured?: boolean;
   llm_provider_priority?: string[];
   provider_endpoints?: Record<string, ProviderEndpoint>;
   memory_backend?: MemoryBackend;

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -168,6 +168,7 @@ export function Wizard({ onComplete }: WizardProps) {
   // applied as llm_provider on /onboarding/complete.
   const [localProvider, setLocalProvider] = useState<string>("");
   const [apiKeys, setApiKeys] = useState<Record<string, string>>({});
+  const userEditedRuntimeRef = useRef(false);
 
   // Step 6: first task
   const [taskTemplates, setTaskTemplates] = useState<TaskTemplate[]>([]);
@@ -220,17 +221,18 @@ export function Wizard({ onComplete }: WizardProps) {
 
         setPrereqs(prereqState.list);
         setPrereqsError(prereqState.error);
-        if (configState.localProvider) {
-          setLocalProvider(configState.localProvider);
+        if (!userEditedRuntimeRef.current) {
+          if (configState.localProvider) {
+            setLocalProvider(configState.localProvider);
+          }
+          setRuntimePriority((current) =>
+            initialRuntimePriority(
+              current,
+              configState.runtimePriority,
+              prereqState.list,
+            ),
+          );
         }
-
-        setRuntimePriority((current) =>
-          initialRuntimePriority(
-            current,
-            configState.runtimePriority,
-            prereqState.list,
-          ),
-        );
       })
       .finally(() => {
         if (!cancelled) setPrereqsLoading(false);
@@ -242,6 +244,7 @@ export function Wizard({ onComplete }: WizardProps) {
   }, []);
 
   const toggleRuntime = useCallback((label: string) => {
+    userEditedRuntimeRef.current = true;
     setRuntimePriority((prev) => {
       if (prev.includes(label)) return prev.filter((l) => l !== label);
       return [...prev, label];
@@ -269,6 +272,7 @@ export function Wizard({ onComplete }: WizardProps) {
   // to my local Qwen" without paying for the pay-as-you-go tier
   // implicit in a bare API-key fallback.
   const selectLocalProvider = useCallback((kind: string) => {
+    userEditedRuntimeRef.current = true;
     const labels = LOCAL_PROVIDER_LABELS.map((m) => m.label);
     setRuntimePriority((prev) => {
       // Remove any prior local entry first so picking a different
@@ -285,6 +289,7 @@ export function Wizard({ onComplete }: WizardProps) {
   }, []);
 
   const reorderRuntime = useCallback((label: string, direction: -1 | 1) => {
+    userEditedRuntimeRef.current = true;
     setRuntimePriority((prev) => {
       const idx = prev.indexOf(label);
       if (idx < 0) return prev;

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { get, post } from "../../api/client";
+import type { ConfigSnapshot } from "../../api/client";
+import { get, getConfig, post } from "../../api/client";
 import { useAppStore } from "../../stores/app";
 import "../../styles/onboarding.css";
 
@@ -18,6 +19,7 @@ import {
   canSetupContinue,
   detectedBinary,
   runtimeIsReady,
+  runtimeLabelsFromProviderConfig,
 } from "./wizard/runtime-helpers";
 import { WelcomeStep } from "./wizard/Step1Welcome";
 import { TemplatesStep } from "./wizard/Step2Templates";
@@ -32,7 +34,6 @@ import type {
   NexSignupStatus,
   PrereqResult,
   ReadinessCheck,
-  ReadinessStatus,
   TaskTemplate,
   WizardStep,
 } from "./wizard/types";
@@ -46,6 +47,72 @@ import type {
 
 interface WizardProps {
   onComplete?: () => void;
+}
+
+type PrereqsPayload = { prereqs?: PrereqResult[] } | PrereqResult[];
+type PrereqsSettled = PromiseSettledResult<PrereqsPayload>;
+type ConfigSettled = PromiseSettledResult<ConfigSnapshot>;
+
+interface PrereqsBootstrap {
+  list: PrereqResult[];
+  error: string;
+}
+
+interface ConfigBootstrap {
+  runtimePriority: string[];
+  localProvider: string | null;
+}
+
+function prereqsFromPayload(data: PrereqsPayload): PrereqResult[] {
+  return Array.isArray(data) ? data : (data.prereqs ?? []);
+}
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason);
+}
+
+function runtimePriorityFromInstalledPrereqs(list: PrereqResult[]): string[] {
+  const firstInstalled = RUNTIMES.find((spec) => {
+    if (spec.provider === null) return false;
+    const det = list.find((p) => p.name === spec.binary);
+    return Boolean(det?.found);
+  });
+  return firstInstalled ? [firstInstalled.label] : [];
+}
+
+function localProviderKindFromRuntimePriority(labels: readonly string[]) {
+  return (
+    LOCAL_PROVIDER_LABELS.find((meta) => labels.includes(meta.label))?.kind ??
+    null
+  );
+}
+
+function prereqsBootstrapFromResult(result: PrereqsSettled): PrereqsBootstrap {
+  if (result.status === "fulfilled") {
+    return { list: prereqsFromPayload(result.value), error: "" };
+  }
+  return { list: [], error: errorMessage(result.reason) };
+}
+
+function configBootstrapFromResult(result: ConfigSettled): ConfigBootstrap {
+  if (result.status !== "fulfilled") {
+    return { runtimePriority: [], localProvider: null };
+  }
+  const runtimePriority = runtimeLabelsFromProviderConfig(result.value);
+  return {
+    runtimePriority,
+    localProvider: localProviderKindFromRuntimePriority(runtimePriority),
+  };
+}
+
+function initialRuntimePriority(
+  current: string[],
+  configured: string[],
+  prereqs: PrereqResult[],
+): string[] {
+  if (current.length > 0) return current;
+  if (configured.length > 0) return configured;
+  return runtimePriorityFromInstalledPrereqs(prereqs);
 }
 
 // biome-ignore lint/complexity/noExcessiveLinesPerFunction: Existing function length is baselined for a focused follow-up refactor.
@@ -91,9 +158,9 @@ export function Wizard({ onComplete }: WizardProps) {
   const [prereqsLoading, setPrereqsLoading] = useState(true);
   const [prereqsError, setPrereqsError] = useState("");
   // Ordered list of runtime labels (matches RUNTIMES[].label). Position in
-  // the array is the fallback priority. Initially empty — we auto-populate
-  // with the first installed CLI once prereqs land so the happy path still
-  // works with zero clicks.
+  // the array is the fallback priority. Initially empty — we prefer explicit
+  // config/launch choices, then auto-populate with the first installed CLI so
+  // the happy path still works with zero clicks.
   const [runtimePriority, setRuntimePriority] = useState<string[]>([]);
   // localProvider is the local OpenAI-compat kind the user opted into in
   // the SetupStep subsection (mlx-lm | ollama | exo | "" for none).
@@ -135,32 +202,35 @@ export function Wizard({ onComplete }: WizardProps) {
     };
   }, []);
 
-  // Fetch prereqs on mount so the runtime picker shows which CLIs are
-  // actually installed. Auto-select the first detected runtime so users
-  // with a single CLI installed don't have to click.
+  // Fetch prereqs + current config on mount so the runtime picker shows which
+  // CLIs are installed while still honoring explicit launch/config choices
+  // such as `wuphf --provider codex`.
   useEffect(() => {
     let cancelled = false;
     setPrereqsLoading(true);
 
-    get<{ prereqs?: PrereqResult[] } | PrereqResult[]>("/onboarding/prereqs")
-      .then((data) => {
+    Promise.allSettled([
+      get<PrereqsPayload>("/onboarding/prereqs"),
+      getConfig(),
+    ])
+      .then(([prereqsResult, configResult]) => {
         if (cancelled) return;
-        const list = Array.isArray(data) ? data : (data.prereqs ?? []);
-        setPrereqs(list);
-        setRuntimePriority((current) => {
-          if (current.length > 0) return current;
-          const firstInstalled = RUNTIMES.find((spec) => {
-            if (spec.provider === null) return false;
-            const det = list.find((p) => p.name === spec.binary);
-            return Boolean(det?.found);
-          });
-          return firstInstalled ? [firstInstalled.label] : [];
-        });
-      })
-      .catch((err: unknown) => {
-        if (cancelled) return;
-        const msg = err instanceof Error ? err.message : String(err);
-        setPrereqsError(msg);
+        const prereqState = prereqsBootstrapFromResult(prereqsResult);
+        const configState = configBootstrapFromResult(configResult);
+
+        setPrereqs(prereqState.list);
+        setPrereqsError(prereqState.error);
+        if (configState.localProvider) {
+          setLocalProvider(configState.localProvider);
+        }
+
+        setRuntimePriority((current) =>
+          initialRuntimePriority(
+            current,
+            configState.runtimePriority,
+            prereqState.list,
+          ),
+        );
       })
       .finally(() => {
         if (!cancelled) setPrereqsLoading(false);

--- a/web/src/components/onboarding/Wizard.tsx
+++ b/web/src/components/onboarding/Wizard.tsx
@@ -18,6 +18,7 @@ import {
 import {
   canSetupContinue,
   detectedBinary,
+  localProviderKindFromRuntimePriority,
   runtimeIsReady,
   runtimeLabelsFromProviderConfig,
 } from "./wizard/runtime-helpers";
@@ -78,13 +79,6 @@ function runtimePriorityFromInstalledPrereqs(list: PrereqResult[]): string[] {
     return Boolean(det?.found);
   });
   return firstInstalled ? [firstInstalled.label] : [];
-}
-
-function localProviderKindFromRuntimePriority(labels: readonly string[]) {
-  return (
-    LOCAL_PROVIDER_LABELS.find((meta) => labels.includes(meta.label))?.kind ??
-    null
-  );
 }
 
 function prereqsBootstrapFromResult(result: PrereqsSettled): PrereqsBootstrap {

--- a/web/src/components/onboarding/wizard/runtime-helpers.test.ts
+++ b/web/src/components/onboarding/wizard/runtime-helpers.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { runtimeLabelsFromProviderConfig } from "./runtime-helpers";
+import {
+  localProviderKindFromRuntimePriority,
+  runtimeLabelsFromProviderConfig,
+} from "./runtime-helpers";
 
 describe("runtimeLabelsFromProviderConfig", () => {
   it("prefers an explicit provider before a saved fallback chain", () => {
@@ -28,5 +31,19 @@ describe("runtimeLabelsFromProviderConfig", () => {
         llm_provider_priority: ["ollama", "codex", "ollama", ""],
       }),
     ).toEqual(["Ollama", "Codex"]);
+  });
+});
+
+describe("localProviderKindFromRuntimePriority", () => {
+  it("uses the first local provider in runtime priority order", () => {
+    expect(
+      localProviderKindFromRuntimePriority(["Exo", "Codex", "Ollama"]),
+    ).toBe("exo");
+  });
+
+  it("returns null when the priority contains no local provider", () => {
+    expect(localProviderKindFromRuntimePriority(["Codex", "Claude Code"])).toBe(
+      null,
+    );
   });
 });

--- a/web/src/components/onboarding/wizard/runtime-helpers.test.ts
+++ b/web/src/components/onboarding/wizard/runtime-helpers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { runtimeLabelsFromProviderConfig } from "./runtime-helpers";
+
+describe("runtimeLabelsFromProviderConfig", () => {
+  it("prefers an explicit provider before a saved fallback chain", () => {
+    expect(
+      runtimeLabelsFromProviderConfig({
+        llm_provider: "codex",
+        llm_provider_configured: true,
+        llm_provider_priority: ["claude-code", "codex"],
+      }),
+    ).toEqual(["Codex", "Claude Code"]);
+  });
+
+  it("ignores the install default when no provider was explicitly configured", () => {
+    expect(
+      runtimeLabelsFromProviderConfig({
+        llm_provider: "claude-code",
+        llm_provider_configured: false,
+      }),
+    ).toEqual([]);
+  });
+
+  it("maps local providers and removes duplicates", () => {
+    expect(
+      runtimeLabelsFromProviderConfig({
+        llm_provider_priority: ["ollama", "codex", "ollama", ""],
+      }),
+    ).toEqual(["Ollama", "Codex"]);
+  });
+});

--- a/web/src/components/onboarding/wizard/runtime-helpers.ts
+++ b/web/src/components/onboarding/wizard/runtime-helpers.ts
@@ -70,6 +70,18 @@ export function runtimeLabelsFromProviderConfig(
   return labels;
 }
 
+export function localProviderKindFromRuntimePriority(
+  labels: readonly string[],
+): string | null {
+  for (const label of labels) {
+    const kind = LOCAL_PROVIDER_LABELS.find(
+      (meta) => meta.label === label,
+    )?.kind;
+    if (kind) return kind;
+  }
+  return null;
+}
+
 interface SetupContinueInput {
   runtimePriority: string[];
   prereqs: PrereqResult[];

--- a/web/src/components/onboarding/wizard/runtime-helpers.ts
+++ b/web/src/components/onboarding/wizard/runtime-helpers.ts
@@ -1,4 +1,4 @@
-import { RUNTIMES } from "./constants";
+import { LOCAL_PROVIDER_LABELS, RUNTIMES } from "./constants";
 import type { PrereqResult } from "./types";
 
 // Find the prereq detection record for a binary (e.g. "claude", "codex").
@@ -35,6 +35,39 @@ export function runtimeIsReady(
   if (!spec || spec.provider === null) return false;
   if (prereqsError) return true;
   return Boolean(detectedBinary(prereqs, spec.binary)?.found);
+}
+
+interface ProviderConfigSnapshot {
+  llm_provider?: string;
+  llm_provider_configured?: boolean;
+  llm_provider_priority?: readonly string[];
+}
+
+// Convert the broker's persisted/effective provider config into wizard labels.
+// The broker always returns an effective llm_provider, even when it is just
+// the install default. Only trust llm_provider when the server says it came
+// from env/config; otherwise let CLI auto-detection choose the first installed
+// runtime so Codex-only machines do not get prefilled with Claude.
+export function runtimeLabelsFromProviderConfig(
+  config: ProviderConfigSnapshot,
+): string[] {
+  const providers = [
+    ...(config.llm_provider_configured ? [config.llm_provider] : []),
+    ...(config.llm_provider_priority ?? []),
+  ];
+  const labels: string[] = [];
+  const seen = new Set<string>();
+  for (const rawProvider of providers) {
+    const provider = rawProvider?.trim().toLowerCase();
+    if (!provider) continue;
+    const label =
+      RUNTIMES.find((runtime) => runtime.provider === provider)?.label ??
+      LOCAL_PROVIDER_LABELS.find((runtime) => runtime.kind === provider)?.label;
+    if (!label || seen.has(label)) continue;
+    seen.add(label);
+    labels.push(label);
+  }
+  return labels;
 }
 
 interface SetupContinueInput {


### PR DESCRIPTION
## Summary
- show an actionable missing-assets page for source builds without web/dist instead of serving raw Vite source files
- keep subcommand help side-effect free before workspace migration/path warnings
- let onboarding honor explicit provider config/env such as --provider codex before CLI auto-detection
- align README/npm docs for source builds, markdown memory, and provider options

## Verification
- go test ./internal/team ./cmd/wuphf
- bun run test -- src/components/onboarding/wizard/runtime-helpers.test.ts src/components/onboarding/Wizard.test.tsx
- bunx tsc --noEmit
- bunx biome check src/api/client.ts src/components/onboarding/Wizard.tsx src/components/onboarding/wizard/runtime-helpers.ts src/components/onboarding/wizard/runtime-helpers.test.ts
- go build -buildvcs=false -o /tmp/wuphf-devex-rebased ./cmd/wuphf
- manual launch: source checkout returns missing-assets 503 page and /api/config reports llm_provider=codex with llm_provider_configured=true

Note: TODOS.md has a pre-existing local edit and is intentionally not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "markdown" memory backend (default for new installs) and "opencode" provider option
  * Onboarding now respects configured provider/priorities and better derives initial runtime choice without overwriting user edits
  * Help requests show subcommand help without triggering workspace initialization

* **Bug Fixes**
  * Missing web assets now return a helpful 503 setup page with build/source instructions

* **Documentation**
  * Updated source-build instructions to require a front-end build step and refreshed CLI docs

* **Tests**
  * Added tests covering provider reporting, missing-assets messaging, and onboarding helpers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->