### PR TITLE
feat(transport): wire TelegramTransport into launcher (phase 2a)

### DIFF
--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -4,18 +4,15 @@ package team
 // only file in internal/team that imports internal/team/transport — the
 // one-way compile boundary (team → transport) is enforced here.
 //
-// Phase 1 ships the Host interface and the stub implementation. The real
-// routing logic (message fan-out, participant upsert into broker member store,
-// per-transport worker goroutines) lands in Phase 2b when Telegram is refactored
-// onto the contract. Until then every method returns a descriptive stub error
-// so contributors wiring a new adapter against this Host see a clear "not yet
-// wired" message rather than a silent no-op.
+// Phase 2a wires the existing TelegramTransport directly against *Broker (not
+// through this Host). The Host and brokerTransportHost are preserved for Phase
+// 2b when TelegramTransport is refactored onto the transport.Transport contract
+// and will call Host.ReceiveMessage / Host.UpsertParticipant instead of writing
+// to the broker directly.
 //
-// Note on cleanup: RegisterTransports (called by Launch, LaunchWeb, and
-// launchHeadlessCodex) is a Phase 1 stub that starts no goroutines and opens
-// no connections, so the launchers' early-abort paths require no teardown.
-// When Phase 2a wires real adapters, RegisterTransports will return a cleanup
-// function and the launchers will call it on abort — tracked in launcher_transports.go.
+// Until Phase 2b, every Host method returns a descriptive stub error so any
+// contributor who wires a new adapter against this Host sees a clear
+// "not yet wired" message rather than a silent no-op.
 
 import (
 	"context"
@@ -25,50 +22,34 @@ import (
 )
 
 // brokerTransportHost implements transport.Host for the Broker.
-// One instance is created per Broker via newBrokerTransportHost.
+// Constructed in Phase 2b when adapters start using the contract interfaces.
 type brokerTransportHost struct {
 	broker *Broker
 }
 
-// newBrokerTransportHost returns a Host implementation backed by b.
-// Called by launcher.RegisterTransports when adapters are registered.
-func newBrokerTransportHost(b *Broker) transport.Host {
-	return &brokerTransportHost{broker: b}
-}
-
 // ReceiveMessage delivers an inbound message from an external adapter to the
-// office. Phase 1 stub — returns an informative error until Phase 2b wires the
-// real routing.
+// office. Phase 2b TODO: resolve binding → channel, write message to broker
+// under h.broker.mu, deduplicate by (AdapterName+Key+ExternalID).
 func (h *brokerTransportHost) ReceiveMessage(_ context.Context, msg transport.Message) error {
-	// Phase 2b TODO: resolve binding → channel, write message to broker under
-	// h.broker.mu, deduplicate by (AdapterName+Key+ExternalID).
 	return fmt.Errorf("transport: ReceiveMessage not yet implemented (phase 2b): adapter=%q",
 		msg.Participant.AdapterName)
 }
 
 // UpsertParticipant registers or refreshes an external identity in the broker.
-// Phase 1 stub — returns an informative error until Phase 2b wires the real
-// member upsert.
+// Phase 2b TODO: look up (p.AdapterName, p.Key) in broker member store.
 func (h *brokerTransportHost) UpsertParticipant(_ context.Context, p transport.Participant, _ transport.Binding) error {
-	// Phase 2b TODO: look up (p.AdapterName, p.Key) in broker member store;
-	// create member if new; update DisplayName on revisit; return
-	// ErrRegistrationConflict if key maps to a different existing slug.
 	return fmt.Errorf("transport: UpsertParticipant not yet implemented (phase 2b): adapter=%q",
 		p.AdapterName)
 }
 
-// DetachParticipant marks a participant as offline. Phase 1 stub.
+// DetachParticipant marks a participant as offline. Phase 2b TODO.
 func (h *brokerTransportHost) DetachParticipant(_ context.Context, adapterName, _ string) error {
-	// Phase 2b TODO: mark the member corresponding to (adapterName, key) as
-	// offline in the broker member store.
 	return fmt.Errorf("transport: DetachParticipant not yet implemented (phase 2b): adapter=%q",
 		adapterName)
 }
 
-// RevokeParticipant removes an admitted human from the broker. Phase 1 stub.
+// RevokeParticipant removes an admitted human from the broker. Phase 4 TODO.
 func (h *brokerTransportHost) RevokeParticipant(_ context.Context, adapterName, _ string) error {
-	// Phase 4 TODO: delete the member record for (adapterName, key) from the
-	// broker member store and close any open sessions associated with this key.
 	return fmt.Errorf("transport: RevokeParticipant not yet implemented (phase 4): adapter=%q",
 		adapterName)
 }

--- a/internal/team/launcher_boot.go
+++ b/internal/team/launcher_boot.go
@@ -62,7 +62,7 @@ func (l *Launcher) Launch() error {
 		return fmt.Errorf("start broker: %w", err)
 	}
 
-	stopTransports, err := RegisterTransports(newBrokerTransportHost(l.broker))
+	stopTransports, err := RegisterTransports(l.broker)
 	if err != nil {
 		// Non-fatal: a misconfigured optional adapter (e.g. bad Telegram token)
 		// should not prevent the office from starting.
@@ -202,7 +202,7 @@ func (l *Launcher) launchHeadlessCodex() error {
 		return fmt.Errorf("start broker: %w", err)
 	}
 
-	stopTransports, err := RegisterTransports(newBrokerTransportHost(l.broker))
+	stopTransports, err := RegisterTransports(l.broker)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: transport registration: %v\n", err)
 	}

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -48,8 +48,13 @@ func RegisterTransports(b *Broker) (func(), error) {
 			log.Printf("[transport] telegram: token present but no channels connected yet — skipping")
 		} else {
 			ctx, cancel := context.WithCancel(context.Background())
-			stops = append(stops, cancel)
+			done := make(chan struct{})
+			stops = append(stops, func() {
+				cancel()
+				<-done // wait for Start to return before broker.Stop()
+			})
 			go func() {
+				defer close(done)
 				if err := t.Start(ctx); err != nil && ctx.Err() == nil {
 					log.Printf("[transport] telegram: exited with error: %v", err)
 				}

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -18,24 +18,17 @@ package team
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"os"
 
 	"github.com/nex-crm/wuphf/internal/config"
 )
 
 // RegisterTransports registers all configured transport adapters against the
 // broker. Called once per launch after broker.Start() succeeds. Returns a
-// cleanup function and an optional error. The cleanup function cancels all
-// running adapters and must be called before broker.Stop() on any early-abort
-// path so adapters can flush in-flight sends. It is always non-nil and safe to
-// call even when err is non-nil.
-//
-// A non-nil error means a required adapter (one whose config is present but
-// invalid) failed to start; optional adapters that are not configured are
-// silently skipped. Callers log the error and continue — a misconfigured
-// Telegram token should not prevent the office from starting.
+// cleanup function that cancels all running adapters; always non-nil and safe to
+// call even on the error path. The error return is reserved for future required
+// adapters; all current adapters are optional and log failures rather than
+// returning them.
 func RegisterTransports(b *Broker) (func(), error) {
 	var stops []func()
 	cleanup := func() {
@@ -46,9 +39,9 @@ func RegisterTransports(b *Broker) (func(), error) {
 
 	// Telegram: start if a bot token is configured and the broker has at least
 	// one telegram surface channel. If the token is set but there are no
-	// surface channels yet (user hasn't connected via /connect), skip silently —
-	// the transport will start on the next launch after a channel is connected.
-	token := resolveTelegramToken()
+	// surface channels yet (user hasn't run /connect), skip silently — the
+	// transport will start on the next launch after a channel is connected.
+	token := config.ResolveTelegramBotToken()
 	if token != "" {
 		t := NewTelegramTransport(b, token)
 		if len(t.ChatMap) == 0 && t.DMChannel == "" {
@@ -70,26 +63,3 @@ func RegisterTransports(b *Broker) (func(), error) {
 
 	return cleanup, nil
 }
-
-// resolveTelegramToken returns the bot token from the environment or persisted
-// config. Prefers WUPHF_TELEGRAM_BOT_TOKEN so CI/dev overrides work without
-// touching config.json.
-func resolveTelegramToken() string {
-	if v := os.Getenv("WUPHF_TELEGRAM_BOT_TOKEN"); v != "" {
-		return v
-	}
-	return config.ResolveTelegramBotToken()
-}
-
-// startupTransportError wraps an adapter startup failure with the adapter name
-// so the caller's warning log identifies which transport failed.
-type startupTransportError struct {
-	adapter string
-	err     error
-}
-
-func (e *startupTransportError) Error() string {
-	return fmt.Sprintf("transport %q failed to start: %v", e.adapter, e.err)
-}
-
-func (e *startupTransportError) Unwrap() error { return e.err }

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -6,33 +6,90 @@ package team
 // automatically makes it available in both surfaces — you cannot accidentally
 // wire it to one and miss the other.
 //
-// Phase 1: RegisterTransports is the stub. No real adapters are registered yet.
-// The function signature and call sites in Launch/LaunchWeb/launchHeadlessCodex
-// are established so Phase 2a can add the Telegram wiring in a single diff.
+// Phase 2a: wires the existing TelegramTransport when a bot token is present.
+// The transport is started in a supervised goroutine; the returned cleanup
+// function cancels it and must be called before broker.Stop() on any abort path.
+//
+// Phase 2b will refactor TelegramTransport onto the transport.Transport contract.
+// Phase 3a/3b will do the same for OpenClaw.
+// Phase 4 will do the same for human-share.
 //
 // See docs/ADD-A-TRANSPORT.md for the full contributor guide.
 
 import (
-	"github.com/nex-crm/wuphf/internal/team/transport"
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/nex-crm/wuphf/internal/config"
 )
 
-// RegisterTransports registers all configured transport adapters against host.
-// Called once per launch after broker.Start() succeeds. Returns a cleanup
-// function and an optional error. The cleanup function stops all registered
-// adapters and must be called before broker.Stop() on any early-abort path.
-// It is always non-nil and safe to call even when err is non-nil.
+// RegisterTransports registers all configured transport adapters against the
+// broker. Called once per launch after broker.Start() succeeds. Returns a
+// cleanup function and an optional error. The cleanup function cancels all
+// running adapters and must be called before broker.Stop() on any early-abort
+// path so adapters can flush in-flight sends. It is always non-nil and safe to
+// call even when err is non-nil.
 //
 // A non-nil error means a required adapter (one whose config is present but
-// invalid) failed to register; optional adapters that are not configured are
+// invalid) failed to start; optional adapters that are not configured are
 // silently skipped. Callers log the error and continue — a misconfigured
 // Telegram token should not prevent the office from starting.
-func RegisterTransports(_ transport.Host) (func(), error) {
-	// Phase 2a TODO: check cfg for TELEGRAM_BOT_TOKEN; if set, construct
-	// TelegramTransport, start its Run goroutine, and add its Stop to cleanup.
-	//
-	// Phase 3a TODO: check cfg for OpenClaw gateway URL + token; if set,
-	// construct OpenclawBridge adapter and add to cleanup.
-	//
-	// Phase 4 TODO: register human-share adapter when share is enabled.
-	return func() {}, nil
+func RegisterTransports(b *Broker) (func(), error) {
+	var stops []func()
+	cleanup := func() {
+		for _, stop := range stops {
+			stop()
+		}
+	}
+
+	// Telegram: start if a bot token is configured and the broker has at least
+	// one telegram surface channel. If the token is set but there are no
+	// surface channels yet (user hasn't connected via /connect), skip silently —
+	// the transport will start on the next launch after a channel is connected.
+	token := resolveTelegramToken()
+	if token != "" {
+		t := NewTelegramTransport(b, token)
+		if len(t.ChatMap) == 0 && t.DMChannel == "" {
+			log.Printf("[transport] telegram: token present but no channels connected yet — skipping")
+		} else {
+			ctx, cancel := context.WithCancel(context.Background())
+			stops = append(stops, cancel)
+			go func() {
+				if err := t.Start(ctx); err != nil && ctx.Err() == nil {
+					log.Printf("[transport] telegram: exited with error: %v", err)
+				}
+			}()
+			log.Printf("[transport] telegram: started (%d group(s), dm=%v)", len(t.ChatMap), t.DMChannel != "")
+		}
+	}
+
+	// Phase 3a TODO: start OpenClaw bridge when gateway URL + token are configured.
+	// Phase 4 TODO: start human-share adapter when share is enabled.
+
+	return cleanup, nil
 }
+
+// resolveTelegramToken returns the bot token from the environment or persisted
+// config. Prefers WUPHF_TELEGRAM_BOT_TOKEN so CI/dev overrides work without
+// touching config.json.
+func resolveTelegramToken() string {
+	if v := os.Getenv("WUPHF_TELEGRAM_BOT_TOKEN"); v != "" {
+		return v
+	}
+	return config.ResolveTelegramBotToken()
+}
+
+// startupTransportError wraps an adapter startup failure with the adapter name
+// so the caller's warning log identifies which transport failed.
+type startupTransportError struct {
+	adapter string
+	err     error
+}
+
+func (e *startupTransportError) Error() string {
+	return fmt.Sprintf("transport %q failed to start: %v", e.adapter, e.err)
+}
+
+func (e *startupTransportError) Unwrap() error { return e.err }

--- a/internal/team/launcher_web.go
+++ b/internal/team/launcher_web.go
@@ -105,7 +105,7 @@ func (l *Launcher) LaunchWeb(webPort int) error {
 		return fmt.Errorf("start broker: %w", err)
 	}
 
-	stopTransports, err := RegisterTransports(newBrokerTransportHost(l.broker))
+	stopTransports, err := RegisterTransports(l.broker)
 	if err != nil {
 		// Non-fatal: a misconfigured optional adapter should not prevent the
 		// web UI from starting.


### PR DESCRIPTION
## Summary

Phase 2a of the unified transport refactor. Wires the **existing** `TelegramTransport` into `RegisterTransports` so Telegram runs in the main `wuphf` binary for all boot paths. No architectural changes — this is "turn it on", not "refactor it."

**What changes for users:** if you have a bot token configured (via `WUPHF_TELEGRAM_BOT_TOKEN` or `/connect`), the bridge starts automatically on `wuphf` and `wuphf --web`. Previously it only ran in the TUI channel-integration flow.

### What ships

| File | Change |
|---|---|
| `launcher_transports.go` | `RegisterTransports(*Broker)` now starts `TelegramTransport` when token + channels are present |
| `launcher_boot.go` / `launcher_web.go` | Call sites updated to pass `l.broker` directly |
| `broker_transport.go` | Removed `newBrokerTransportHost` (no longer called); updated comment for Phase 2b |

### Behaviour matrix

| Token | Channels connected | Result |
|---|---|---|
| absent | — | no-op (silent) |
| present | none yet | skips with log line, office starts normally |
| present | ≥1 | bridge starts, logs group count |
| present | ≥1, crashes | logs error, office continues |

### What this is NOT

- No refactor of `TelegramTransport` onto `transport.Transport` contract — that is Phase 2b.
- `TelegramTransport` still writes to `*Broker` directly, same as before.
- `brokerTransportHost` retained for Phase 2b; no behaviour change to `Host` stubs.

### Phase sequence

- ~~Phase 1: contract + tests + docs~~ ✓ (#616)
- **Phase 2a: Telegram launcher wiring (this PR)**
- Phase 2b: refactor Telegram onto `transport.Transport` contract
- Phase 3a: OpenClaw launcher wiring
- Phase 3b: OpenClaw onto `MemberBoundTransport`
- Phase 4: human-share onto `OfficeBoundTransport` + share web UI

## Test plan

- [x] `bash scripts/test-go.sh ./internal/team/...` — green
- [x] `go build ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Smoke test: set `WUPHF_TELEGRAM_BOT_TOKEN`, connect a group via `/connect`, restart `wuphf-dev`, confirm messages route both ways

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram transport now registers and starts automatically when a bot token and chat config are available; empty/chatless configs are skipped.
  * Environment-variable support added for supplying the Telegram bot token.

* **Bug Fixes**
  * Improved transport startup and supervised lifecycle so active adapters are started and cleanly stopped; transport registration failures remain non-fatal.

* **Documentation**
  * Updated internal docs to reflect current transport wiring and planned refactor phases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->