### PR TITLE
Deduplicate approval requests by dedupe_key to prevent stacking

### DIFF
--- a/internal/team/broker_requests_interviews.go
+++ b/internal/team/broker_requests_interviews.go
@@ -380,6 +380,7 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		Required      bool              `json:"required"`
 		Secret        bool              `json:"secret"`
 		ReplyTo       string            `json:"reply_to"`
+		DedupeKey     string            `json:"dedupe_key"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid json", http.StatusBadRequest)
@@ -411,6 +412,36 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "channel access denied", http.StatusForbidden)
 			return
 		}
+		// Dedupe: if a dedupe_key is set and an active request with the
+		// same key already exists in this channel, return that existing
+		// request instead of stacking a duplicate. Without this, agent
+		// retries of the same external action (or multiple agents
+		// hitting the same gate) pile up dozens of identical pending
+		// approvals — observed as 100+ stacked "Approve gmail action"
+		// requests after a single connect-and-retry sequence.
+		dedupeKey := strings.TrimSpace(body.DedupeKey)
+		if dedupeKey != "" {
+			for i := range b.requests {
+				if !requestIsActive(b.requests[i]) {
+					continue
+				}
+				if normalizeChannelSlug(b.requests[i].Channel) != channel {
+					continue
+				}
+				if strings.TrimSpace(b.requests[i].DedupeKey) != dedupeKey {
+					continue
+				}
+				existing := b.requests[i]
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"request":    existing,
+					"id":         existing.ID,
+					"deduped":    true,
+					"dedupe_key": dedupeKey,
+				})
+				return
+			}
+		}
 		b.counter++
 		req := humanInterview{
 			ID:            fmt.Sprintf("request-%d", b.counter),
@@ -427,6 +458,7 @@ func (b *Broker) handlePostRequest(w http.ResponseWriter, r *http.Request) {
 			Required:      body.Required,
 			Secret:        body.Secret,
 			ReplyTo:       strings.TrimSpace(body.ReplyTo),
+			DedupeKey:     dedupeKey,
 			CreatedAt:     time.Now().UTC().Format(time.RFC3339),
 			UpdatedAt:     time.Now().UTC().Format(time.RFC3339),
 		}

--- a/internal/team/broker_requests_interviews_test.go
+++ b/internal/team/broker_requests_interviews_test.go
@@ -342,6 +342,74 @@ func TestBrokerPostRequestDedupeKeyRecreatesAfterAnswer(t *testing.T) {
 	}
 }
 
+// TestBrokerPostRequestDedupeKeyRecreatesAfterCancel pins the cancel
+// branch of the terminal-state contract: cancelRequestLocked sets
+// Status="canceled" and requestIsActive returns false for it, so a
+// subsequent POST with the same dedupe_key must create a fresh
+// request rather than silently mapping to the canceled one.
+func TestBrokerPostRequestDedupeKeyRecreatesAfterCancel(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "ceo", "CEO")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	post := func() (string, bool) {
+		t.Helper()
+		body, _ := json.Marshal(map[string]any{
+			"kind":       "approval",
+			"from":       "ceo",
+			"channel":    "general",
+			"title":      "Approve",
+			"question":   "Approve?",
+			"blocking":   true,
+			"required":   true,
+			"dedupe_key": "action:ceo:gmail:send:k",
+		})
+		req, _ := http.NewRequest(http.MethodPost, base+"/requests", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+		var out struct {
+			ID      string `json:"id"`
+			Deduped bool   `json:"deduped"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&out)
+		return out.ID, out.Deduped
+	}
+
+	first, _ := post()
+	if first == "" {
+		t.Fatal("expected first request id")
+	}
+
+	// Cancel the first request → terminal state.
+	cancelBody, _ := json.Marshal(map[string]any{"action": "cancel", "id": first, "from": "ceo"})
+	req, _ := http.NewRequest(http.MethodPost, base+"/requests", bytes.NewReader(cancelBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("cancel: %v", err)
+	}
+	resp.Body.Close()
+
+	// Same dedupe key after cancel → new request, not the canceled one.
+	second, deduped := post()
+	if second == "" || second == first {
+		t.Fatalf("expected fresh request after cancel, got first=%q second=%q", first, second)
+	}
+	if deduped {
+		t.Fatal("expected deduped=false for fresh request after cancel")
+	}
+}
+
 func TestHumanRequestAnswerUsesSessionActor(t *testing.T) {
 	b := newTestBroker(t)
 	b.mu.Lock()

--- a/internal/team/broker_requests_interviews_test.go
+++ b/internal/team/broker_requests_interviews_test.go
@@ -311,7 +311,9 @@ func TestBrokerPostRequestDedupeKeyRecreatesAfterAnswer(t *testing.T) {
 		var out struct {
 			ID string `json:"id"`
 		}
-		_ = json.NewDecoder(resp.Body).Decode(&out)
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
 		return out.ID
 	}
 
@@ -383,7 +385,9 @@ func TestBrokerPostRequestDedupeKeyRecreatesAfterCancel(t *testing.T) {
 			ID      string `json:"id"`
 			Deduped bool   `json:"deduped"`
 		}
-		_ = json.NewDecoder(resp.Body).Decode(&out)
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
 		return out.ID, out.Deduped
 	}
 

--- a/internal/team/broker_requests_interviews_test.go
+++ b/internal/team/broker_requests_interviews_test.go
@@ -299,7 +299,8 @@ func TestBrokerPostRequestDedupeKeyRecreatesAfterAnswer(t *testing.T) {
 		"required":   true,
 		"dedupe_key": "action:ceo:gmail:send:k",
 	})
-	post := func() string {
+	post := func() (string, bool) {
+		t.Helper()
 		req, _ := http.NewRequest(http.MethodPost, base+"/requests", bytes.NewReader(body))
 		req.Header.Set("Authorization", "Bearer "+b.Token())
 		req.Header.Set("Content-Type", "application/json")
@@ -308,16 +309,21 @@ func TestBrokerPostRequestDedupeKeyRecreatesAfterAnswer(t *testing.T) {
 			t.Fatalf("post: %v", err)
 		}
 		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200 posting request, got %d: %s", resp.StatusCode, raw)
+		}
 		var out struct {
-			ID string `json:"id"`
+			ID      string `json:"id"`
+			Deduped bool   `json:"deduped"`
 		}
 		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 			t.Fatalf("decode: %v", err)
 		}
-		return out.ID
+		return out.ID, out.Deduped
 	}
 
-	first := post()
+	first, _ := post()
 	if first == "" {
 		t.Fatal("expected first request id")
 	}
@@ -341,9 +347,12 @@ func TestBrokerPostRequestDedupeKeyRecreatesAfterAnswer(t *testing.T) {
 	}
 
 	// Same dedupe key after answer → new request, not the terminal one.
-	second := post()
+	second, deduped := post()
 	if second == "" || second == first {
 		t.Fatalf("expected fresh request after answer, got first=%q second=%q", first, second)
+	}
+	if deduped {
+		t.Fatal("expected deduped=false for fresh request after answer")
 	}
 }
 
@@ -381,6 +390,10 @@ func TestBrokerPostRequestDedupeKeyRecreatesAfterCancel(t *testing.T) {
 			t.Fatalf("post: %v", err)
 		}
 		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200 posting request, got %d: %s", resp.StatusCode, raw)
+		}
 		var out struct {
 			ID      string `json:"id"`
 			Deduped bool   `json:"deduped"`

--- a/internal/team/broker_requests_interviews_test.go
+++ b/internal/team/broker_requests_interviews_test.go
@@ -334,6 +334,9 @@ func TestBrokerPostRequestDedupeKeyRecreatesAfterAnswer(t *testing.T) {
 		t.Fatalf("answer: %v", err)
 	}
 	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 answering request, got %d", resp.StatusCode)
+	}
 
 	// Same dedupe key after answer → new request, not the terminal one.
 	second := post()
@@ -399,6 +402,9 @@ func TestBrokerPostRequestDedupeKeyRecreatesAfterCancel(t *testing.T) {
 		t.Fatalf("cancel: %v", err)
 	}
 	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 canceling request, got %d", resp.StatusCode)
+	}
 
 	// Same dedupe key after cancel → new request, not the canceled one.
 	second, deduped := post()

--- a/internal/team/broker_requests_interviews_test.go
+++ b/internal/team/broker_requests_interviews_test.go
@@ -189,6 +189,159 @@ func TestBrokerRequestsLifecycle(t *testing.T) {
 	}
 }
 
+// TestBrokerPostRequestDedupeKeyCollapsesDuplicates locks in the fix
+// for the 117-stacked-approval bug: when an agent retries a mutating
+// external action, every call into the approval gate POSTs /requests
+// with the same dedupe_key. The broker must return the existing
+// active request instead of stacking duplicates.
+func TestBrokerPostRequestDedupeKeyCollapsesDuplicates(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "integration-ops", "Integration Ops")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	post := func() (string, bool) {
+		t.Helper()
+		body, _ := json.Marshal(map[string]any{
+			"kind":       "approval",
+			"from":       "integration-ops",
+			"channel":    "general",
+			"title":      "Approve gmail action: send",
+			"question":   "@integration-ops wants to send. Approve?",
+			"blocking":   true,
+			"required":   true,
+			"dedupe_key": "action:integration-ops:gmail:gmail_send_email:conn-key",
+		})
+		req, _ := http.NewRequest(http.MethodPost, base+"/requests", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post request: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("expected 200, got %d: %s", resp.StatusCode, raw)
+		}
+		var out struct {
+			ID      string `json:"id"`
+			Deduped bool   `json:"deduped"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return out.ID, out.Deduped
+	}
+
+	firstID, firstDeduped := post()
+	if firstID == "" || firstDeduped {
+		t.Fatalf("first post: id=%q deduped=%v (expected fresh request)", firstID, firstDeduped)
+	}
+
+	// Five retries of the same dedupe_key must all collapse onto the
+	// first request — not stack five new ones.
+	for i := 0; i < 5; i++ {
+		id, deduped := post()
+		if id != firstID {
+			t.Fatalf("retry %d: id=%q want %q", i, id, firstID)
+		}
+		if !deduped {
+			t.Fatalf("retry %d: expected deduped=true", i)
+		}
+	}
+
+	// Sanity check via GET /requests: only one pending entry exists.
+	req, _ := http.NewRequest(http.MethodGet, base+"/requests?channel=general", nil)
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	defer resp.Body.Close()
+	var listing struct {
+		Requests []humanInterview `json:"requests"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listing); err != nil {
+		t.Fatalf("decode listing: %v", err)
+	}
+	if len(listing.Requests) != 1 {
+		t.Fatalf("expected 1 pending request after 6 dedup-keyed POSTs, got %d", len(listing.Requests))
+	}
+	if listing.Requests[0].DedupeKey == "" {
+		t.Fatalf("expected DedupeKey to be persisted, got %+v", listing.Requests[0])
+	}
+}
+
+// TestBrokerPostRequestDedupeKeyRecreatesAfterAnswer pins that once
+// the human answers (or cancels) the original request, a new POST
+// with the same dedupe_key creates a fresh request instead of
+// silently mapping to the now-terminal one.
+func TestBrokerPostRequestDedupeKeyRecreatesAfterAnswer(t *testing.T) {
+	b := newTestBroker(t)
+	ensureTestMemberAccess(b, "general", "ceo", "CEO")
+	if err := b.StartOnPort(0); err != nil {
+		t.Fatalf("failed to start broker: %v", err)
+	}
+	defer b.Stop()
+
+	base := fmt.Sprintf("http://%s", b.Addr())
+	body, _ := json.Marshal(map[string]any{
+		"kind":       "approval",
+		"from":       "ceo",
+		"channel":    "general",
+		"title":      "Approve",
+		"question":   "Approve?",
+		"blocking":   true,
+		"required":   true,
+		"dedupe_key": "action:ceo:gmail:send:k",
+	})
+	post := func() string {
+		req, _ := http.NewRequest(http.MethodPost, base+"/requests", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+b.Token())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+		var out struct {
+			ID string `json:"id"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&out)
+		return out.ID
+	}
+
+	first := post()
+	if first == "" {
+		t.Fatal("expected first request id")
+	}
+
+	// Answer the first request → terminal state.
+	answerBody, _ := json.Marshal(map[string]any{
+		"id":          first,
+		"choice_id":   "approve",
+		"choice_text": "Approve",
+	})
+	req, _ := http.NewRequest(http.MethodPost, base+"/requests/answer", bytes.NewReader(answerBody))
+	req.Header.Set("Authorization", "Bearer "+b.Token())
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("answer: %v", err)
+	}
+	resp.Body.Close()
+
+	// Same dedupe key after answer → new request, not the terminal one.
+	second := post()
+	if second == "" || second == first {
+		t.Fatalf("expected fresh request after answer, got first=%q second=%q", first, second)
+	}
+}
+
 func TestHumanRequestAnswerUsesSessionActor(t *testing.T) {
 	b := newTestBroker(t)
 	b.mu.Lock()

--- a/internal/team/broker_types.go
+++ b/internal/team/broker_types.go
@@ -106,13 +106,19 @@ type humanInterview struct {
 	Required      bool              `json:"required,omitempty"`
 	Secret        bool              `json:"secret,omitempty"`
 	ReplyTo       string            `json:"reply_to,omitempty"`
-	DueAt         string            `json:"due_at,omitempty"`
-	FollowUpAt    string            `json:"follow_up_at,omitempty"`
-	ReminderAt    string            `json:"reminder_at,omitempty"`
-	RecheckAt     string            `json:"recheck_at,omitempty"`
-	CreatedAt     string            `json:"created_at"`
-	UpdatedAt     string            `json:"updated_at,omitempty"`
-	Answered      *interviewAnswer  `json:"answered,omitempty"`
+	// DedupeKey collapses duplicate POSTs with the same key onto the
+	// existing active request. Used by the action approval gate so a
+	// retry of the same (agent, platform, action_id, connection_key)
+	// tuple does not produce a fresh blocking request each time the
+	// agent loop reconnects.
+	DedupeKey  string           `json:"dedupe_key,omitempty"`
+	DueAt      string           `json:"due_at,omitempty"`
+	FollowUpAt string           `json:"follow_up_at,omitempty"`
+	ReminderAt string           `json:"reminder_at,omitempty"`
+	RecheckAt  string           `json:"recheck_at,omitempty"`
+	CreatedAt  string           `json:"created_at"`
+	UpdatedAt  string           `json:"updated_at,omitempty"`
+	Answered   *interviewAnswer `json:"answered,omitempty"`
 }
 
 type humanInvite struct {

--- a/internal/teammcp/actions.go
+++ b/internal/teammcp/actions.go
@@ -135,6 +135,17 @@ func requireTeamActionApproval(ctx context.Context, slug, channel string, args T
 
 	options, recommendedID := normalizeHumanRequestOptions("approval", "", nil)
 
+	// Collapse retries onto a single approval. Without this dedupe key,
+	// every agent loop reconnect or retry of the same external-action
+	// call posts a fresh /requests entry, and the human ends up staring
+	// at 100+ stacked "Approve gmail action" cards for the same intent.
+	dedupeKey := fmt.Sprintf("action:%s:%s:%s:%s",
+		strings.ToLower(slug),
+		strings.ToLower(platform),
+		strings.ToLower(actionID),
+		strings.ToLower(strings.TrimSpace(args.ConnectionKey)),
+	)
+
 	var created struct {
 		ID string `json:"id"`
 	}
@@ -149,6 +160,7 @@ func requireTeamActionApproval(ctx context.Context, slug, channel string, args T
 		"recommended_id": recommendedID,
 		"blocking":       true,
 		"required":       true,
+		"dedupe_key":     dedupeKey,
 	}, &created); err != nil {
 		return fmt.Errorf("create approval request: %w", err)
 	}

--- a/web/src/components/apps/RequestsApp.test.tsx
+++ b/web/src/components/apps/RequestsApp.test.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../api/client", async () => {
+  const actual =
+    await vi.importActual<typeof import("../../api/client")>(
+      "../../api/client",
+    );
+  return {
+    ...actual,
+    getRequests: vi.fn().mockResolvedValue({ requests: [] }),
+    answerRequest: vi.fn().mockResolvedValue({}),
+    cancelRequest: vi.fn().mockResolvedValue({}),
+  };
+});
+
+import * as clientMod from "../../api/client";
+import { RequestsApp } from "./RequestsApp";
+
+function wrap(ui: ReactNode) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={qc}>{ui}</QueryClientProvider>;
+}
+
+const blockingApprovalOption = {
+  id: "approve",
+  label: "Approve",
+  description: "Approve",
+};
+
+function makeBlockingRequest(id: string, action: string) {
+  return {
+    id,
+    from: "integration-ops",
+    question: `Approve ${action}?`,
+    title: `Approve gmail action: ${action}`,
+    blocking: true,
+    status: "pending",
+    options: [blockingApprovalOption],
+    kind: "approval",
+  };
+}
+
+function makeNonBlockingRequest(id: string, title: string) {
+  return {
+    id,
+    from: "integration-ops",
+    question: `Activate ${title}?`,
+    title: `Approve skill: ${title}`,
+    blocking: false,
+    status: "pending",
+    options: [{ id: "accept", label: "Accept", description: "Accept" }],
+    kind: "skill_proposal",
+  };
+}
+
+describe("<RequestsApp> blocking requests do not stack", () => {
+  it("renders only the first blocking request and shows a queued count for the rest", async () => {
+    vi.mocked(clientMod.getRequests).mockResolvedValueOnce({
+      requests: [
+        makeBlockingRequest("request-1", "send-email-1"),
+        makeBlockingRequest("request-2", "send-email-2"),
+        makeBlockingRequest("request-3", "send-email-3"),
+      ],
+    });
+
+    render(wrap(<RequestsApp />));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Approve gmail action: send-email-1/),
+      ).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(/Approve gmail action: send-email-2/),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Approve gmail action: send-email-3/),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/2 more queued/)).toBeInTheDocument();
+  });
+});
+
+describe("<RequestsApp> non-blocking dismiss-all", () => {
+  it("renders a Dismiss all button that cancels every non-blocking pending request", async () => {
+    vi.mocked(clientMod.getRequests).mockResolvedValueOnce({
+      requests: [
+        makeNonBlockingRequest("request-10", "broker-readiness"),
+        makeNonBlockingRequest("request-11", "external-action-handoff"),
+        makeNonBlockingRequest("request-12", "blocker-handoff"),
+      ],
+    });
+    const cancelSpy = vi.mocked(clientMod.cancelRequest);
+    cancelSpy.mockClear();
+
+    render(wrap(<RequestsApp />));
+
+    const dismissAll = await screen.findByRole("button", {
+      name: /Dismiss all/i,
+    });
+    fireEvent.click(dismissAll);
+
+    await waitFor(() => {
+      expect(cancelSpy).toHaveBeenCalledTimes(3);
+    });
+    const calledIds = cancelSpy.mock.calls.map((c) => c[0]).sort();
+    expect(calledIds).toEqual(["request-10", "request-11", "request-12"]);
+  });
+
+  it("does not cancel a blocking request when Dismiss all is clicked", async () => {
+    vi.mocked(clientMod.getRequests).mockResolvedValueOnce({
+      requests: [
+        makeBlockingRequest("request-100", "send-email"),
+        makeNonBlockingRequest("request-101", "skill-1"),
+      ],
+    });
+    const cancelSpy = vi.mocked(clientMod.cancelRequest);
+    cancelSpy.mockClear();
+
+    render(wrap(<RequestsApp />));
+
+    const dismissAll = await screen.findByRole("button", {
+      name: /Dismiss all/i,
+    });
+    fireEvent.click(dismissAll);
+
+    await waitFor(() => {
+      expect(cancelSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(cancelSpy).toHaveBeenCalledWith("request-101");
+  });
+});

--- a/web/src/components/apps/RequestsApp.tsx
+++ b/web/src/components/apps/RequestsApp.tsx
@@ -77,15 +77,15 @@ export function RequestsApp() {
 
   const dismissAllNonBlocking = () => {
     if (nonBlockingPending.length === 0) return;
-    Promise.allSettled(nonBlockingPending.map((r) => cancelRequest(r.id)))
-      .then((results) => {
+    Promise.allSettled(nonBlockingPending.map((r) => cancelRequest(r.id))).then(
+      (results) => {
         const failed = results.filter((r) => r.status === "rejected").length;
         if (failed > 0) {
           showNotice(`Dismissed with ${failed} error(s)`, "error");
         }
         queryClient.invalidateQueries({ queryKey: ["requests"] });
-      })
-      .catch((e: Error) => showNotice(`Dismiss failed: ${e.message}`, "error"));
+      },
+    );
   };
 
   if (allRequests.length === 0) {

--- a/web/src/components/apps/RequestsApp.tsx
+++ b/web/src/components/apps/RequestsApp.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   type AgentRequest,
   answerRequest,
+  cancelRequest,
   getRequests,
 } from "../../api/client";
 import { formatRelativeTime } from "../../lib/format";
@@ -57,6 +58,36 @@ export function RequestsApp() {
     (r) => r.status && r.status !== "open" && r.status !== "pending",
   );
 
+  // Blocking requests are surfaced one at a time so a flood of agent
+  // approvals (e.g. retries of the same external action) cannot bury the
+  // human under a stack of identical cards. The next blocking request
+  // becomes visible as soon as the active one is answered or canceled.
+  const blockingPending = pending.filter((r) => r.blocking);
+  const nonBlockingPending = pending.filter((r) => !r.blocking);
+  const [activeBlocking] = blockingPending;
+  const queuedBlockingCount = Math.max(blockingPending.length - 1, 0);
+
+  const onAnswer = (id: string, choiceId: string) => {
+    answerRequest(id, choiceId)
+      .then(() => {
+        queryClient.invalidateQueries({ queryKey: ["requests"] });
+      })
+      .catch((e: Error) => showNotice(`Answer failed: ${e.message}`, "error"));
+  };
+
+  const dismissAllNonBlocking = () => {
+    if (nonBlockingPending.length === 0) return;
+    Promise.allSettled(nonBlockingPending.map((r) => cancelRequest(r.id)))
+      .then((results) => {
+        const failed = results.filter((r) => r.status === "rejected").length;
+        if (failed > 0) {
+          showNotice(`Dismissed with ${failed} error(s)`, "error");
+        }
+        queryClient.invalidateQueries({ queryKey: ["requests"] });
+      })
+      .catch((e: Error) => showNotice(`Dismiss failed: ${e.message}`, "error"));
+  };
+
   if (allRequests.length === 0) {
     return (
       <div
@@ -74,32 +105,75 @@ export function RequestsApp() {
 
   return (
     <>
-      {pending.length > 0 && (
+      {activeBlocking ? (
         <>
           <div
             style={{
-              fontSize: 13,
-              fontWeight: 600,
-              color: "var(--text-secondary)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 8,
               padding: "8px 0 4px",
             }}
           >
-            Pending ({pending.length})
+            <div
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: "var(--text-secondary)",
+              }}
+            >
+              Blocking
+            </div>
+            {queuedBlockingCount > 0 ? (
+              <div style={{ fontSize: 12, color: "var(--text-tertiary)" }}>
+                {queuedBlockingCount} more queued
+              </div>
+            ) : null}
           </div>
-          {pending.map((req) => (
+          <RequestItem
+            key={activeBlocking.id}
+            request={activeBlocking}
+            isPending={true}
+            onAnswer={(choiceId) => onAnswer(activeBlocking.id, choiceId)}
+          />
+        </>
+      ) : null}
+
+      {nonBlockingPending.length > 0 && (
+        <>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              gap: 8,
+              padding: "8px 0 4px",
+            }}
+          >
+            <div
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: "var(--text-secondary)",
+              }}
+            >
+              Pending ({nonBlockingPending.length})
+            </div>
+            <button
+              type="button"
+              className="btn btn-sm btn-ghost"
+              onClick={dismissAllNonBlocking}
+            >
+              Dismiss all
+            </button>
+          </div>
+          {nonBlockingPending.map((req) => (
             <RequestItem
               key={req.id}
               request={req}
               isPending={true}
-              onAnswer={(choiceId) => {
-                answerRequest(req.id, choiceId)
-                  .then(() => {
-                    queryClient.invalidateQueries({ queryKey: ["requests"] });
-                  })
-                  .catch((e: Error) =>
-                    showNotice(`Answer failed: ${e.message}`, "error"),
-                  );
-              }}
+              onAnswer={(choiceId) => onAnswer(req.id, choiceId)}
             />
           ))}
         </>


### PR DESCRIPTION
## Summary
Fixes the "117-stacked-approval bug" where agent retries of the same external action would create duplicate approval requests instead of reusing the existing one. This change implements request deduplication using a `dedupe_key` field to collapse multiple identical approval requests into a single pending request.

## Key Changes

- **Broker request deduplication** (`broker_requests_interviews.go`):
  - Added `dedupe_key` field to request POST body parsing
  - Implemented deduplication logic that returns existing active requests with matching `dedupe_key` in the same channel instead of creating duplicates
  - Returns a `deduped: true` flag in the response to indicate a request was reused

- **Request model** (`broker_types.go`):
  - Added `DedupeKey` field to `humanInterview` struct with documentation explaining its purpose for collapsing retries of the same action

- **Action approval gate** (`actions.go`):
  - Generates a deterministic `dedupe_key` from the tuple of (agent slug, platform, action ID, connection key)
  - Passes the `dedupe_key` when creating approval requests to the broker

- **Frontend UI** (`RequestsApp.tsx`):
  - Separated blocking and non-blocking requests into distinct sections
  - Blocking requests now display one at a time with a queued count indicator to prevent overwhelming the user
  - Added "Dismiss all" button for non-blocking requests
  - Refactored request handling to properly manage blocking request lifecycle

- **Test coverage** (`broker_requests_interviews_test.go`, `RequestsApp.test.tsx`):
  - Added `TestBrokerPostRequestDedupeKeyCollapsesDuplicates` to verify that multiple POSTs with the same dedupe_key return the same request ID
  - Added `TestBrokerPostRequestDedupeKeyRecreatesAfterAnswer` to verify that answered/canceled requests allow fresh requests with the same dedupe_key
  - Added comprehensive React component tests for blocking request stacking and non-blocking dismiss-all functionality

## Implementation Details

The deduplication works by checking if an active request exists in the target channel with the same `dedupe_key` before creating a new request. If found, the existing request is returned with `deduped: true`. Once a request reaches a terminal state (answered or canceled), subsequent POSTs with the same key will create a fresh request, allowing the approval flow to restart if needed.

The dedupe_key format is intentionally deterministic so that the same external action call (even from different agent instances) will map to the same approval request, preventing the stacking issue observed during agent reconnects and retries.

https://claude.ai/code/session_015aYz9sgjMFV8a2dFqYWvHh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request de-duplication: POSTing with a dedupe key collapses duplicate pending requests, persists the key, and allows new requests after the original is answered or canceled.
  * Approval de-duplication: repeated approval attempts collapse into a single approval request.
  * Blocking request queue & "Dismiss all": show one blocking request with a queued count; "Dismiss all" cancels non-blocking pending requests.

* **Tests**
  * Added end-to-end and UI tests for deduplication, recreate-after-completion/cancel, queueing, and dismiss behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->