### PR TITLE
feat(transport): refactor TelegramTransport onto Transport contract (phase 2b)

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -17,6 +18,10 @@ import (
 	"github.com/nex-crm/wuphf/internal/onboarding"
 	"github.com/nex-crm/wuphf/internal/workspace"
 )
+
+// ErrChannelNotFound is returned by PostInboundSurfaceMessage when the
+// declared channel does not exist in the broker.
+var ErrChannelNotFound = errors.New("channel not found")
 
 const BrokerPort = brokeraddr.DefaultPort
 
@@ -756,7 +761,7 @@ func (b *Broker) PostInboundSurfaceMessage(from, channel, content, provider stri
 				channel = dm.Slug
 			}
 		} else {
-			return channelMessage{}, fmt.Errorf("channel not found: %s", channel)
+			return channelMessage{}, fmt.Errorf("%w: %s", ErrChannelNotFound, channel)
 		}
 	}
 	b.counter++

--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -4,51 +4,62 @@ package team
 // only file in internal/team that imports internal/team/transport — the
 // one-way compile boundary (team → transport) is enforced here.
 //
-// Phase 2a wires the existing TelegramTransport directly against *Broker (not
-// through this Host). The Host and brokerTransportHost are preserved for Phase
-// 2b when TelegramTransport is refactored onto the transport.Transport contract
-// and will call Host.ReceiveMessage / Host.UpsertParticipant instead of writing
-// to the broker directly.
+// Phase 2b wires ReceiveMessage and UpsertParticipant for the channel-bound
+// (Telegram) case. Inbound messages are delivered via PostInboundSurfaceMessage;
+// UpsertParticipant is a no-op for channel-bound adapters because participant
+// attribution is handled inside PostInboundSurfaceMessage by display name.
 //
-// Until Phase 2b, every Host method returns a descriptive stub error so any
-// contributor who wires a new adapter against this Host sees a clear
-// "not yet wired" message rather than a silent no-op.
+// DetachParticipant (phase 3b) and RevokeParticipant (phase 4) remain stubs.
 
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/nex-crm/wuphf/internal/team/transport"
 )
 
 // brokerTransportHost implements transport.Host for the Broker.
-// Constructed in Phase 2b when adapters start using the contract interfaces.
 type brokerTransportHost struct {
 	broker *Broker
 }
 
-// ReceiveMessage delivers an inbound message from an external adapter to the
-// office. Phase 2b TODO: resolve binding → channel, write message to broker
-// under h.broker.mu, deduplicate by (AdapterName+Key+ExternalID).
+// ReceiveMessage delivers an inbound message from a channel-bound adapter to
+// the office by calling PostInboundSurfaceMessage. Returns
+// transport.ErrBindingChannelMissing if the declared channel does not exist.
 func (h *brokerTransportHost) ReceiveMessage(_ context.Context, msg transport.Message) error {
-	return fmt.Errorf("transport: ReceiveMessage not yet implemented (phase 2b): adapter=%q",
-		msg.Participant.AdapterName)
+	_, err := h.broker.PostInboundSurfaceMessage(
+		msg.Participant.DisplayName,
+		msg.Binding.ChannelSlug,
+		msg.Text,
+		msg.Participant.AdapterName,
+	)
+	if err != nil {
+		if strings.Contains(err.Error(), "channel not found") {
+			return &transport.BindingChannelMissingError{ChannelSlug: msg.Binding.ChannelSlug}
+		}
+		return fmt.Errorf("transport: ReceiveMessage: %w", err)
+	}
+	return nil
 }
 
-// UpsertParticipant registers or refreshes an external identity in the broker.
-// Phase 2b TODO: look up (p.AdapterName, p.Key) in broker member store.
-func (h *brokerTransportHost) UpsertParticipant(_ context.Context, p transport.Participant, _ transport.Binding) error {
-	return fmt.Errorf("transport: UpsertParticipant not yet implemented (phase 2b): adapter=%q",
-		p.AdapterName)
+// UpsertParticipant is a no-op for channel-bound adapters (Telegram). Channel-
+// bound participant identity is resolved by display name inside
+// PostInboundSurfaceMessage. Phase 3b will add a real member-store lookup for
+// member-bound adapters (OpenClaw).
+func (h *brokerTransportHost) UpsertParticipant(_ context.Context, _ transport.Participant, _ transport.Binding) error {
+	return nil
 }
 
-// DetachParticipant marks a participant as offline. Phase 2b TODO.
+// DetachParticipant marks a participant as offline. Phase 3b TODO for
+// member-bound adapters (OpenClaw).
 func (h *brokerTransportHost) DetachParticipant(_ context.Context, adapterName, _ string) error {
-	return fmt.Errorf("transport: DetachParticipant not yet implemented (phase 2b): adapter=%q",
+	return fmt.Errorf("transport: DetachParticipant not yet implemented (phase 3b): adapter=%q",
 		adapterName)
 }
 
-// RevokeParticipant removes an admitted human from the broker. Phase 4 TODO.
+// RevokeParticipant removes an admitted human from the broker. Phase 4 TODO
+// for office-bound adapters (human-share).
 func (h *brokerTransportHost) RevokeParticipant(_ context.Context, adapterName, _ string) error {
 	return fmt.Errorf("transport: RevokeParticipant not yet implemented (phase 4): adapter=%q",
 		adapterName)

--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -13,8 +13,8 @@ package team
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/nex-crm/wuphf/internal/team/transport"
 )
@@ -35,7 +35,7 @@ func (h *brokerTransportHost) ReceiveMessage(_ context.Context, msg transport.Me
 		msg.Participant.AdapterName,
 	)
 	if err != nil {
-		if strings.Contains(err.Error(), "channel not found") {
+		if errors.Is(err, ErrChannelNotFound) {
 			return &transport.BindingChannelMissingError{ChannelSlug: msg.Binding.ChannelSlug}
 		}
 		return fmt.Errorf("transport: ReceiveMessage: %w", err)

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -6,13 +6,12 @@ package team
 // automatically makes it available in both surfaces — you cannot accidentally
 // wire it to one and miss the other.
 //
-// Phase 2a: wires the existing TelegramTransport when a bot token is present.
-// The transport is started in a supervised goroutine; the returned cleanup
-// function cancels it and must be called before broker.Stop() on any abort path.
+// Phase 2b: TelegramTransport satisfies transport.Transport. RegisterTransports
+// constructs a brokerTransportHost and passes it to Run so inbound messages flow
+// through the Host contract instead of writing to the broker directly.
 //
-// Phase 2b will refactor TelegramTransport onto the transport.Transport contract.
-// Phase 3a/3b will do the same for OpenClaw.
-// Phase 4 will do the same for human-share.
+// Phase 3a/3b will wire OpenClaw via MemberBoundTransport.
+// Phase 4 will wire human-share via OfficeBoundTransport.
 //
 // See docs/ADD-A-TRANSPORT.md for the full contributor guide.
 
@@ -47,15 +46,16 @@ func RegisterTransports(b *Broker) (func(), error) {
 		if len(t.ChatMap) == 0 && t.DMChannel == "" {
 			log.Printf("[transport] telegram: token present but no channels connected yet — skipping")
 		} else {
+			host := &brokerTransportHost{broker: b}
 			ctx, cancel := context.WithCancel(context.Background())
 			done := make(chan struct{})
 			stops = append(stops, func() {
 				cancel()
-				<-done // wait for Start to return before broker.Stop()
+				<-done // wait for Run to return before broker.Stop()
 			})
 			go func() {
 				defer close(done)
-				if err := t.Start(ctx); err != nil && ctx.Err() == nil {
+				if err := t.Run(ctx, host); err != nil && ctx.Err() == nil {
 					log.Printf("[transport] telegram: exited with error: %v", err)
 				}
 			}()

--- a/internal/team/telegram.go
+++ b/internal/team/telegram.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -76,6 +77,10 @@ type TelegramTransport struct {
 	UserMap map[string]string
 	client  *http.Client
 
+	// chatMapMu protects ChatMap against concurrent reads from drainOutbound /
+	// typingLoop and writes from routeInbound (learning new DM chats).
+	chatMapMu sync.RWMutex
+
 	// health fields — written by pollInbound, read by Health(). Protected by mu.
 	mu            sync.Mutex
 	healthState   transport.HealthState
@@ -114,11 +119,12 @@ func NewTelegramTransport(broker *Broker, botToken string) *TelegramTransport {
 // every Participant value this transport creates.
 func (t *TelegramTransport) Name() string { return "telegram" }
 
-// Binding declares this adapter as channel-bound. ChannelSlug is left empty
-// because a single TelegramTransport instance can cover multiple channels via
-// ChatMap; the per-message channel is carried in each transport.Message.Binding.
+// Binding returns an empty binding because a single TelegramTransport instance
+// covers multiple channels via ChatMap. There is no single static ChannelSlug
+// to declare here; the per-message channel is carried in each
+// transport.Message.Binding constructed by routeInbound.
 func (t *TelegramTransport) Binding() transport.Binding {
-	return transport.Binding{Scope: transport.ScopeChannel}
+	return transport.Binding{}
 }
 
 // Health returns a point-in-time snapshot of adapter connectivity. O(1) — reads
@@ -144,15 +150,22 @@ func (t *TelegramTransport) Run(ctx context.Context, host transport.Host) error 
 		return fmt.Errorf("no telegram channels configured")
 	}
 
+	ctx2, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	errCh := make(chan error, 2)
-	go func() { errCh <- t.pollInbound(ctx, host) }()
-	go func() { errCh <- t.drainOutbound(ctx) }()
-	go t.typingLoop(ctx)
+	go func() { errCh <- t.pollInbound(ctx2, host) }()
+	go func() { errCh <- t.drainOutbound(ctx2) }()
+	go t.typingLoop(ctx2)
 
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return nil
 	case err := <-errCh:
+		cancel() // stop siblings
+		if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+			return nil
+		}
 		return err
 	}
 }
@@ -178,6 +191,8 @@ func (t *TelegramTransport) Send(ctx context.Context, msg transport.Outbound) er
 // chatIDForSlug returns the Telegram chat_id string for the given office channel
 // slug, or "" if no mapping exists.
 func (t *TelegramTransport) chatIDForSlug(slug string) string {
+	t.chatMapMu.RLock()
+	defer t.chatMapMu.RUnlock()
 	for chatID, s := range t.ChatMap {
 		if s == slug && chatID != "0" {
 			return chatID
@@ -235,24 +250,32 @@ func (t *TelegramTransport) pollInbound(ctx context.Context, host transport.Host
 			log.Printf("[telegram] inbound: chat=%d type=%s text=%q",
 				upd.Message.Chat.ID, upd.Message.Chat.Type,
 				upd.Message.Text[:min(len(upd.Message.Text), 50)])
-			t.routeInbound(ctx, host, upd.Message)
+			if err := t.routeInbound(ctx, host, upd.Message); err != nil {
+				return err
+			}
 		}
 	}
 }
 
 // routeInbound resolves the channel for msg, then delivers it to the office via
-// host.UpsertParticipant + host.ReceiveMessage.
-func (t *TelegramTransport) routeInbound(ctx context.Context, host transport.Host, msg *telegramMsg) {
+// host.UpsertParticipant + host.ReceiveMessage. Returns a non-nil error when
+// the host signals a contract-level failure (e.g. ErrBindingChannelMissing);
+// the caller (pollInbound) propagates this to Run which exits the transport.
+func (t *TelegramTransport) routeInbound(ctx context.Context, host transport.Host, msg *telegramMsg) error {
 	chatIDStr := strconv.FormatInt(msg.Chat.ID, 10)
+
+	t.chatMapMu.Lock()
 	channel, ok := t.ChatMap[chatIDStr]
+	if !ok && msg.Chat.Type == "private" && t.DMChannel != "" {
+		channel = t.DMChannel
+		t.ChatMap[chatIDStr] = t.DMChannel
+		ok = true
+	}
+	t.chatMapMu.Unlock()
+
 	if !ok {
-		if msg.Chat.Type == "private" && t.DMChannel != "" {
-			channel = t.DMChannel
-			t.ChatMap[chatIDStr] = t.DMChannel
-		} else {
-			log.Printf("[telegram] inbound: unmapped chat %s", chatIDStr)
-			return
-		}
+		log.Printf("[telegram] inbound: unmapped chat %s", chatIDStr)
+		return nil
 	}
 
 	fromName := t.resolveUser(msg.From)
@@ -273,7 +296,7 @@ func (t *TelegramTransport) routeInbound(ctx context.Context, host transport.Hos
 	}
 
 	if err := host.UpsertParticipant(ctx, p, b); err != nil {
-		log.Printf("[telegram] upsert participant key=%s: %v", key, err)
+		return fmt.Errorf("telegram upsert participant: %w", err)
 	}
 	if err := host.ReceiveMessage(ctx, transport.Message{
 		Participant: p,
@@ -281,8 +304,9 @@ func (t *TelegramTransport) routeInbound(ctx context.Context, host transport.Hos
 		Text:        msg.Text,
 		ExternalID:  strconv.FormatInt(msg.MessageID, 10),
 	}); err != nil {
-		log.Printf("[telegram] receive message: %v", err)
+		return fmt.Errorf("telegram receive message: %w", err)
 	}
+	return nil
 }
 
 // drainOutbound periodically checks the broker's external queue and sends
@@ -296,6 +320,7 @@ func (t *TelegramTransport) drainOutbound(ctx context.Context) error {
 		}
 
 		// Rebuild reverse map each cycle (picks up dynamically added DM chats)
+		t.chatMapMu.RLock()
 		slugToChat := make(map[string]string, len(t.ChatMap))
 		for chatID, slug := range t.ChatMap {
 			if chatID == "0" {
@@ -303,6 +328,7 @@ func (t *TelegramTransport) drainOutbound(ctx context.Context) error {
 			}
 			slugToChat[slug] = chatID
 		}
+		t.chatMapMu.RUnlock()
 
 		msgs := t.Broker.ExternalQueue("telegram")
 		if len(msgs) > 0 {
@@ -352,7 +378,13 @@ func (t *TelegramTransport) typingLoop(ctx context.Context) {
 		}
 
 		// Send typing to all mapped Telegram chats
+		t.chatMapMu.RLock()
+		chatIDs := make([]string, 0, len(t.ChatMap))
 		for chatIDStr := range t.ChatMap {
+			chatIDs = append(chatIDs, chatIDStr)
+		}
+		t.chatMapMu.RUnlock()
+		for _, chatIDStr := range chatIDs {
 			chatID, err := strconv.ParseInt(chatIDStr, 10, 64)
 			if err != nil {
 				continue
@@ -371,7 +403,9 @@ func (t *TelegramTransport) HandleInbound(chatID int64, chatType string, from *t
 		if (chatType == "private") && t.DMChannel != "" {
 			channel = t.DMChannel
 			// Store the chat ID so we can reply to this user
+			t.chatMapMu.Lock()
 			t.ChatMap[chatIDStr] = t.DMChannel
+			t.chatMapMu.Unlock()
 		} else {
 			return fmt.Errorf("unmapped telegram chat: %s", chatIDStr)
 		}

--- a/internal/team/telegram.go
+++ b/internal/team/telegram.go
@@ -6,11 +6,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+
+	"github.com/nex-crm/wuphf/internal/team/transport"
 )
 
 const (
@@ -51,14 +55,18 @@ type telegramAPIResponse struct {
 	Desc   string          `json:"description,omitempty"`
 }
 
+// compile-time assertion: TelegramTransport must satisfy transport.Transport.
+var _ transport.Transport = (*TelegramTransport)(nil)
+
 // TelegramTransport bridges Telegram chats with the office broker.
 // Each mapped Telegram chat corresponds to an office channel with a
-// "telegram" surface. Inbound Telegram messages are posted to the broker;
-// outbound broker messages on surface channels are sent to Telegram.
+// "telegram" surface. Inbound Telegram messages are posted to the broker
+// via transport.Host; outbound broker messages on surface channels are
+// sent to Telegram via Send.
 type TelegramTransport struct {
 	BotToken string
 	Broker   *Broker
-	// ChatMap maps telegram chat_id (as string) -> office channel slug
+	// ChatMap maps telegram chat_id (as string) -> office channel slug.
 	ChatMap map[string]string
 	// DMChannel is the office channel slug for direct messages (private chats).
 	// When set, any private message to the bot routes to this channel.
@@ -67,6 +75,12 @@ type TelegramTransport struct {
 	// If empty, display names are used verbatim as the "from" field.
 	UserMap map[string]string
 	client  *http.Client
+
+	// health fields — written by pollInbound, read by Health(). Protected by mu.
+	mu            sync.Mutex
+	healthState   transport.HealthState
+	lastSuccessAt time.Time
+	lastErr       error
 }
 
 // NewTelegramTransport creates a transport from the broker's surface channels.
@@ -86,19 +100,43 @@ func NewTelegramTransport(broker *Broker, botToken string) *TelegramTransport {
 		}
 	}
 	return &TelegramTransport{
-		BotToken:  botToken,
-		Broker:    broker,
-		ChatMap:   chatMap,
-		DMChannel: dmChannel,
-		UserMap:   make(map[string]string),
-		client:    &http.Client{Timeout: time.Duration(telegramPollTimeout+10) * time.Second},
+		BotToken:    botToken,
+		Broker:      broker,
+		ChatMap:     chatMap,
+		DMChannel:   dmChannel,
+		UserMap:     make(map[string]string),
+		client:      &http.Client{Timeout: time.Duration(telegramPollTimeout+10) * time.Second},
+		healthState: transport.HealthDisconnected,
 	}
 }
 
-// Start begins the bidirectional bridge: polling Telegram for inbound messages
-// and draining the broker's external queue for outbound delivery.
-// It blocks until ctx is cancelled.
-func (t *TelegramTransport) Start(ctx context.Context) error {
+// Name returns "telegram" — the stable adapter name used as AdapterName in
+// every Participant value this transport creates.
+func (t *TelegramTransport) Name() string { return "telegram" }
+
+// Binding declares this adapter as channel-bound. ChannelSlug is left empty
+// because a single TelegramTransport instance can cover multiple channels via
+// ChatMap; the per-message channel is carried in each transport.Message.Binding.
+func (t *TelegramTransport) Binding() transport.Binding {
+	return transport.Binding{Scope: transport.ScopeChannel}
+}
+
+// Health returns a point-in-time snapshot of adapter connectivity. O(1) — reads
+// from cached fields updated by pollInbound.
+func (t *TelegramTransport) Health() transport.Health {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return transport.Health{
+		State:         t.healthState,
+		LastSuccessAt: t.lastSuccessAt,
+		LastError:     t.lastErr,
+	}
+}
+
+// Run starts the bidirectional bridge and blocks until ctx is cancelled. Inbound
+// Telegram messages are delivered to the office via host; outbound broker messages
+// are polled from the broker queue and sent via Send. Implements transport.Transport.
+func (t *TelegramTransport) Run(ctx context.Context, host transport.Host) error {
 	if t.BotToken == "" {
 		return fmt.Errorf("telegram bot token is empty")
 	}
@@ -107,7 +145,7 @@ func (t *TelegramTransport) Start(ctx context.Context) error {
 	}
 
 	errCh := make(chan error, 2)
-	go func() { errCh <- t.pollInbound(ctx) }()
+	go func() { errCh <- t.pollInbound(ctx, host) }()
 	go func() { errCh <- t.drainOutbound(ctx) }()
 	go t.typingLoop(ctx)
 
@@ -119,8 +157,38 @@ func (t *TelegramTransport) Start(ctx context.Context) error {
 	}
 }
 
-// pollInbound long-polls Telegram for new messages and routes them to the broker.
-func (t *TelegramTransport) pollInbound(ctx context.Context) error {
+// Start is a compatibility shim for callers that predate the transport.Transport
+// contract. It creates a brokerTransportHost and delegates to Run.
+func (t *TelegramTransport) Start(ctx context.Context) error {
+	host := &brokerTransportHost{broker: t.Broker}
+	return t.Run(ctx, host)
+}
+
+// Send delivers one outbound message to the Telegram chat mapped to
+// msg.Binding.ChannelSlug. Returns an error if no chat is mapped for that slug
+// or if the Telegram API call fails. Implements transport.Transport.
+func (t *TelegramTransport) Send(ctx context.Context, msg transport.Outbound) error {
+	chatID := t.chatIDForSlug(msg.Binding.ChannelSlug)
+	if chatID == "" {
+		return fmt.Errorf("telegram: no chat mapped for channel %q", msg.Binding.ChannelSlug)
+	}
+	return t.sendMessageHTML(ctx, chatID, msg.Text)
+}
+
+// chatIDForSlug returns the Telegram chat_id string for the given office channel
+// slug, or "" if no mapping exists.
+func (t *TelegramTransport) chatIDForSlug(slug string) string {
+	for chatID, s := range t.ChatMap {
+		if s == slug && chatID != "0" {
+			return chatID
+		}
+	}
+	return ""
+}
+
+// pollInbound long-polls Telegram for new messages and routes them to the office
+// via host. Updates health state on each successful or failed poll cycle.
+func (t *TelegramTransport) pollInbound(ctx context.Context, host transport.Host) error {
 	var offset int64
 	for {
 		select {
@@ -131,7 +199,11 @@ func (t *TelegramTransport) pollInbound(ctx context.Context) error {
 
 		updates, err := t.getUpdates(ctx, offset)
 		if err != nil {
-			fmt.Printf("[telegram] poll error: %v\n", err)
+			t.mu.Lock()
+			t.healthState = transport.HealthDegraded
+			t.lastErr = err
+			t.mu.Unlock()
+			log.Printf("[telegram] poll error: %v", err)
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
@@ -140,6 +212,12 @@ func (t *TelegramTransport) pollInbound(ctx context.Context) error {
 			}
 		}
 
+		t.mu.Lock()
+		t.healthState = transport.HealthConnected
+		t.lastSuccessAt = time.Now()
+		t.lastErr = nil
+		t.mu.Unlock()
+
 		for _, upd := range updates {
 			if upd.UpdateID >= offset {
 				offset = upd.UpdateID + 1
@@ -147,21 +225,63 @@ func (t *TelegramTransport) pollInbound(ctx context.Context) error {
 			if upd.Message == nil {
 				continue
 			}
-			// Record every group/supergroup we see for /connect discovery
+			// Record every group/supergroup we see for /connect discovery.
 			if upd.Message.Chat.Type == "group" || upd.Message.Chat.Type == "supergroup" {
 				t.Broker.RecordTelegramGroup(upd.Message.Chat.ID, upd.Message.Chat.Title)
 			}
 			if upd.Message.Text == "" {
 				continue
 			}
-			fmt.Printf("[telegram] inbound: chat=%d type=%s from=%s text=%q\n",
+			log.Printf("[telegram] inbound: chat=%d type=%s text=%q",
 				upd.Message.Chat.ID, upd.Message.Chat.Type,
-				upd.Message.From.FirstName, upd.Message.Text[:min(len(upd.Message.Text), 50)])
-			if err := t.HandleInbound(upd.Message.Chat.ID, upd.Message.Chat.Type, upd.Message.From, upd.Message.Text); err != nil {
-				fmt.Printf("[telegram] inbound error: %v\n", err)
-				continue
-			}
+				upd.Message.Text[:min(len(upd.Message.Text), 50)])
+			t.routeInbound(ctx, host, upd.Message)
 		}
+	}
+}
+
+// routeInbound resolves the channel for msg, then delivers it to the office via
+// host.UpsertParticipant + host.ReceiveMessage.
+func (t *TelegramTransport) routeInbound(ctx context.Context, host transport.Host, msg *telegramMsg) {
+	chatIDStr := strconv.FormatInt(msg.Chat.ID, 10)
+	channel, ok := t.ChatMap[chatIDStr]
+	if !ok {
+		if msg.Chat.Type == "private" && t.DMChannel != "" {
+			channel = t.DMChannel
+			t.ChatMap[chatIDStr] = t.DMChannel
+		} else {
+			log.Printf("[telegram] inbound: unmapped chat %s", chatIDStr)
+			return
+		}
+	}
+
+	fromName := t.resolveUser(msg.From)
+	key := "0"
+	if msg.From != nil {
+		key = strconv.FormatInt(msg.From.ID, 10)
+	}
+
+	p := transport.Participant{
+		AdapterName: "telegram",
+		Key:         key,
+		DisplayName: fromName,
+		Human:       true,
+	}
+	b := transport.Binding{
+		Scope:       transport.ScopeChannel,
+		ChannelSlug: channel,
+	}
+
+	if err := host.UpsertParticipant(ctx, p, b); err != nil {
+		log.Printf("[telegram] upsert participant key=%s: %v", key, err)
+	}
+	if err := host.ReceiveMessage(ctx, transport.Message{
+		Participant: p,
+		Binding:     b,
+		Text:        msg.Text,
+		ExternalID:  strconv.FormatInt(msg.MessageID, 10),
+	}); err != nil {
+		log.Printf("[telegram] receive message: %v", err)
 	}
 }
 
@@ -186,23 +306,27 @@ func (t *TelegramTransport) drainOutbound(ctx context.Context) error {
 
 		msgs := t.Broker.ExternalQueue("telegram")
 		if len(msgs) > 0 {
-			fmt.Printf("[telegram] outbound queue: %d messages, slugToChat=%v\n", len(msgs), slugToChat)
+			log.Printf("[telegram] outbound queue: %d message(s)", len(msgs))
 		}
 		for _, msg := range msgs {
 			ch := normalizeChannelSlug(msg.Channel)
 			chatID, ok := slugToChat[ch]
 			if !ok {
-				fmt.Printf("[telegram] outbound skip: no chat for channel %q\n", ch)
+				log.Printf("[telegram] outbound skip: no chat for channel %q", ch)
 				continue
 			}
-			// Send typing indicator before the message
+			// Send typing indicator before the message (Telegram-specific UX).
 			if chatIDInt, err := strconv.ParseInt(chatID, 10, 64); err == nil {
 				_ = SendTypingAction(ctx, t.BotToken, chatIDInt)
 			}
-			if err := t.SendToTelegram(ctx, chatID, msg); err != nil {
+			out := transport.Outbound{
+				Binding: transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: ch},
+				Text:    formatTelegramOutbound(msg),
+			}
+			if err := t.Send(ctx, out); err != nil {
 				// Transient send failure — message was already dequeued,
-				// so we log and move on. In a future version we could
-				// implement retry with dead-letter semantics.
+				// so we log and move on.
+				log.Printf("[telegram] outbound send error for %q: %v", ch, err)
 				continue
 			}
 		}

--- a/internal/team/telegram_test.go
+++ b/internal/team/telegram_test.go
@@ -360,10 +360,11 @@ func TestTelegramTransportContractInterface(t *testing.T) {
 		t.Fatalf("Name() = %q, want %q", tr.Name(), "telegram")
 	}
 
-	// Binding must declare channel scope.
+	// Binding must be empty: Telegram is multi-channel so there is no static
+	// ChannelSlug to declare at the transport level.
 	binding := tr.Binding()
-	if binding.Scope != teamTransport.ScopeChannel {
-		t.Fatalf("Binding().Scope = %q, want %q", binding.Scope, teamTransport.ScopeChannel)
+	if binding.ChannelSlug != "" || binding.MemberSlug != "" {
+		t.Fatalf("Binding() should be zero-value for multi-channel adapter, got %+v", binding)
 	}
 
 	// Health before Run returns disconnected (not yet connected).
@@ -398,7 +399,9 @@ func TestTelegramRouteInboundViaHost(t *testing.T) {
 		Text:      "hello via host",
 	}
 
-	tr.routeInbound(context.Background(), host, msg)
+	if err := tr.routeInbound(context.Background(), host, msg); err != nil {
+		t.Fatalf("routeInbound: %v", err)
+	}
 
 	msgs := b.ChannelMessages("telegram-general")
 	if len(msgs) != 1 {

--- a/internal/team/telegram_test.go
+++ b/internal/team/telegram_test.go
@@ -3,12 +3,15 @@ package team
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	teamTransport "github.com/nex-crm/wuphf/internal/team/transport"
 )
 
 func newTestBrokerWithTelegramChannel(t *testing.T, chatID string) *Broker {
@@ -318,12 +321,12 @@ func TestTelegramSendToTelegramMocked(t *testing.T) {
 
 func TestTelegramStartFailsWithoutToken(t *testing.T) {
 	b := newTestBrokerWithTelegramChannel(t, "-100")
-	transport := NewTelegramTransport(b, "")
+	tr := NewTelegramTransport(b, "")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := transport.Start(ctx)
+	err := tr.Start(ctx)
 	if err == nil || !strings.Contains(err.Error(), "bot token is empty") {
 		t.Fatalf("expected token error, got %v", err)
 	}
@@ -335,14 +338,121 @@ func TestTelegramStartFailsWithoutChannels(t *testing.T) {
 	b.mu.Lock()
 	b.channels = []teamChannel{{Slug: "general", Name: "general", Members: []string{"ceo"}}}
 	b.mu.Unlock()
-	transport := NewTelegramTransport(b, "fake-token")
+	tr := NewTelegramTransport(b, "fake-token")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
-	err := transport.Start(ctx)
+	err := tr.Start(ctx)
 	if err == nil || !strings.Contains(err.Error(), "no telegram channels") {
 		t.Fatalf("expected no channels error, got %v", err)
+	}
+}
+
+// TestTelegramTransportContractInterface verifies that TelegramTransport correctly
+// implements the transport.Transport contract methods.
+func TestTelegramTransportContractInterface(t *testing.T) {
+	b := newTestBrokerWithTelegramChannel(t, "-100999")
+	tr := NewTelegramTransport(b, "fake-token")
+
+	// Name must be stable and match the AdapterName used in Participants.
+	if tr.Name() != "telegram" {
+		t.Fatalf("Name() = %q, want %q", tr.Name(), "telegram")
+	}
+
+	// Binding must declare channel scope.
+	binding := tr.Binding()
+	if binding.Scope != teamTransport.ScopeChannel {
+		t.Fatalf("Binding().Scope = %q, want %q", binding.Scope, teamTransport.ScopeChannel)
+	}
+
+	// Health before Run returns disconnected (not yet connected).
+	h := tr.Health()
+	if h.State != teamTransport.HealthDisconnected {
+		t.Fatalf("Health().State before Run = %q, want %q", h.State, teamTransport.HealthDisconnected)
+	}
+
+	// Run fails without a token (same guard as Start).
+	noToken := NewTelegramTransport(b, "")
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	host := &brokerTransportHost{broker: b}
+	err := noToken.Run(ctx, host)
+	if err == nil || !strings.Contains(err.Error(), "bot token is empty") {
+		t.Fatalf("Run without token: expected token error, got %v", err)
+	}
+}
+
+// TestTelegramRouteInboundViaHost verifies that routeInbound calls
+// host.UpsertParticipant and host.ReceiveMessage and that ReceiveMessage
+// delivers the message to the broker channel.
+func TestTelegramRouteInboundViaHost(t *testing.T) {
+	b := newTestBrokerWithTelegramChannel(t, "-100999")
+	tr := NewTelegramTransport(b, "fake-token")
+	host := &brokerTransportHost{broker: b}
+
+	msg := &telegramMsg{
+		MessageID: 42,
+		Chat:      telegramChat{ID: -100999, Type: "group", Title: "Test"},
+		From:      &telegramUser{ID: 7, FirstName: "Alice", Username: "alice_dev"},
+		Text:      "hello via host",
+	}
+
+	tr.routeInbound(context.Background(), host, msg)
+
+	msgs := b.ChannelMessages("telegram-general")
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message in channel, got %d", len(msgs))
+	}
+	if msgs[0].Content != "hello via host" {
+		t.Fatalf("expected content %q, got %q", "hello via host", msgs[0].Content)
+	}
+	if msgs[0].Source != "telegram" {
+		t.Fatalf("expected source=telegram, got %q", msgs[0].Source)
+	}
+}
+
+// TestBrokerTransportHostReceiveMessage verifies that brokerTransportHost.ReceiveMessage
+// delivers a message to the broker via PostInboundSurfaceMessage.
+func TestBrokerTransportHostReceiveMessage(t *testing.T) {
+	b := newTestBrokerWithTelegramChannel(t, "-100777")
+	host := &brokerTransportHost{broker: b}
+
+	err := host.ReceiveMessage(context.Background(), teamTransport.Message{
+		Participant: teamTransport.Participant{AdapterName: "telegram", Key: "42", DisplayName: "Bob", Human: true},
+		Binding:     teamTransport.Binding{Scope: teamTransport.ScopeChannel, ChannelSlug: "telegram-general"},
+		Text:        "host test message",
+		ExternalID:  "msg-1",
+	})
+	if err != nil {
+		t.Fatalf("ReceiveMessage: %v", err)
+	}
+
+	msgs := b.ChannelMessages("telegram-general")
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	if msgs[0].Content != "host test message" {
+		t.Fatalf("expected %q, got %q", "host test message", msgs[0].Content)
+	}
+}
+
+// TestBrokerTransportHostReceiveMessageChannelMissing verifies that
+// ReceiveMessage returns ErrBindingChannelMissing for a non-existent channel.
+func TestBrokerTransportHostReceiveMessageChannelMissing(t *testing.T) {
+	b := newTestBrokerWithTelegramChannel(t, "-100777")
+	host := &brokerTransportHost{broker: b}
+
+	err := host.ReceiveMessage(context.Background(), teamTransport.Message{
+		Participant: teamTransport.Participant{AdapterName: "telegram", Key: "1", DisplayName: "X"},
+		Binding:     teamTransport.Binding{Scope: teamTransport.ScopeChannel, ChannelSlug: "does-not-exist"},
+		Text:        "lost",
+	})
+	if err == nil {
+		t.Fatal("expected ErrBindingChannelMissing, got nil")
+	}
+	if !errors.Is(err, teamTransport.ErrBindingChannelMissing) {
+		t.Fatalf("expected ErrBindingChannelMissing, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `TelegramTransport` now satisfies `transport.Transport` — `Name()`, `Binding()`, `Run(ctx, host)`, `Send(ctx, Outbound)`, `Health()` added with a compile-time interface assertion
- Inbound messages route through `host.UpsertParticipant` + `host.ReceiveMessage` instead of writing to the broker directly — the direct `PostInboundSurfaceMessage` call moved into `brokerTransportHost.ReceiveMessage`
- `RegisterTransports` calls `t.Run(ctx, host)` with a `brokerTransportHost`; `Start()` becomes a one-line shim for backward compat
- Health tracking added: poll cycles write connected/degraded state; `Health()` is O(1) read from cached fields
- Outbound pull model preserved: `drainOutbound` still polls `ExternalQueue` but delivers via `t.Send(ctx, Outbound)` — push model deferred to phase 3

## What changes per file

| File | Change |
|---|---|
| `telegram.go` | Add `Transport` interface methods; `pollInbound` → `routeInbound` via host; `drainOutbound` calls `Send`; `Start` delegates to `Run` |
| `broker_transport.go` | `ReceiveMessage`: real impl via `PostInboundSurfaceMessage`; `UpsertParticipant`: no-op for channel-bound; stubs updated to phase 3b/4 |
| `launcher_transports.go` | Call `t.Run(ctx, host)` instead of `t.Start(ctx)` |
| `telegram_test.go` | 4 new tests: contract interface, `routeInbound` via host, `ReceiveMessage` host, `ErrBindingChannelMissing` |

## Test plan

- [ ] `bash scripts/test-go.sh ./internal/team` — all green (verified locally)
- [ ] `golangci-lint run ./internal/team/...` — 0 issues (verified locally)
- [ ] Smoke: `wuphf` binary starts, Telegram token present → `[transport] telegram: started` in logs
- [ ] Smoke: send Telegram message → appears in office channel (same as before, now via Host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram transport now exposes health state and improved Send/Run behavior.

* **Refactor**
  * Telegram inbound/outbound flow and adapter lifecycle were reworked for host-based routing and cleaner shutdown sequencing.
  * Concurrency and logging around channel mappings and message handling improved.

* **Bug Fixes**
  * Inbound messages reliably route through the host and surface missing-channel errors distinctly.

* **Tests**
  * Expanded tests covering transport contract, routing, and missing-channel error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->