### PR TITLE
feat(transport): wire OpenClaw bridge into RegisterTransports (phase 3a)

### DIFF
--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -10,7 +10,10 @@ package team
 // constructs a brokerTransportHost and passes it to Run so inbound messages flow
 // through the Host contract instead of writing to the broker directly.
 //
-// Phase 3a/3b will wire OpenClaw via MemberBoundTransport.
+// Phase 3a: OpenClaw bridge is started here via StartOpenclawBridgeFromConfig.
+// It returns (nil, nil) when no openclaw members and no gateway URL are
+// configured, so the integration remains strictly opt-in. Phase 3b will
+// refactor OpenclawBridge onto MemberBoundTransport.
 // Phase 4 will wire human-share via OfficeBoundTransport.
 //
 // See docs/ADD-A-TRANSPORT.md for the full contributor guide.
@@ -63,7 +66,26 @@ func RegisterTransports(b *Broker) (func(), error) {
 		}
 	}
 
-	// Phase 3a TODO: start OpenClaw bridge when gateway URL + token are configured.
+	// OpenClaw: start when openclaw members exist or a gateway URL is configured.
+	// StartOpenclawBridgeFromConfig returns (nil, nil) when neither condition
+	// holds — the bridge is strictly opt-in and its absence is not an error.
+	ocCtx, ocCancel := context.WithCancel(context.Background())
+	bridge, ocErr := StartOpenclawBridgeFromConfig(ocCtx, b)
+	if ocErr != nil {
+		ocCancel()
+		log.Printf("[transport] openclaw: bootstrap error — %v", ocErr)
+	} else if bridge != nil {
+		b.AttachOpenclawBridge(bridge)
+		StartOpenclawRouter(ocCtx, b, bridge)
+		stops = append(stops, func() {
+			ocCancel()
+			bridge.Stop()
+		})
+		log.Printf("[transport] openclaw: started (%d session(s))", len(bridge.SnapshotBindings()))
+	} else {
+		ocCancel()
+	}
+
 	// Phase 4 TODO: start human-share adapter when share is enabled.
 
 	return cleanup, nil

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -76,9 +76,10 @@ func RegisterTransports(b *Broker) (func(), error) {
 		log.Printf("[transport] openclaw: bootstrap error — %v", ocErr)
 	} else if bridge != nil {
 		b.AttachOpenclawBridge(bridge)
-		StartOpenclawRouter(ocCtx, b, bridge)
+		routerDone := StartOpenclawRouter(ocCtx, b, bridge)
 		stops = append(stops, func() {
 			ocCancel()
+			<-routerDone // wait for router goroutine to exit before bridge.Stop()
 			bridge.Stop()
 		})
 		log.Printf("[transport] openclaw: started (%d session(s))", len(bridge.SnapshotBindings()))

--- a/internal/team/openclaw_bootstrap.go
+++ b/internal/team/openclaw_bootstrap.go
@@ -93,9 +93,16 @@ func StartOpenclawBridgeFromConfig(ctx context.Context, broker *Broker) (*Opencl
 // StartOpenclawRouter starts the mention+DM routing goroutine. Exported so
 // out-of-package callers (e.g. bridge probes) can opt into the same routing
 // behavior production WUPHF runs via launcher.go. The goroutine exits when
-// ctx is cancelled.
-func StartOpenclawRouter(ctx context.Context, broker *Broker, bridge *OpenclawBridge) {
-	go routeOpenclawMentionsLoop(ctx, broker, bridge)
+// ctx is cancelled. The returned channel is closed when the goroutine has
+// fully exited — callers should block on it before stopping the bridge to
+// avoid races between in-flight broker writes and broker shutdown.
+func StartOpenclawRouter(ctx context.Context, broker *Broker, bridge *OpenclawBridge) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		routeOpenclawMentionsLoop(ctx, broker, bridge)
+	}()
+	return done
 }
 
 // routeOpenclawMentionsLoop subscribes to broker messages and forwards


### PR DESCRIPTION
## Summary

- `StartOpenclawBridgeFromConfig` + `AttachOpenclawBridge` + `StartOpenclawRouter` are now called from `RegisterTransports`, so OpenClaw starts automatically in both tmux-mode and web-mode — same as Telegram
- Bridge is strictly opt-in: `StartOpenclawBridgeFromConfig` returns `(nil, nil)` when no openclaw members exist and no gateway URL is configured
- Cleanup cancels the router context and calls `bridge.Stop()` to drain the event loop before the broker shuts down
- Previously these calls only existed in `cmd/wuphf-oc-probe/` (diagnostic tools), not the main launchers

## What this is not

Phase 3b (refactoring `OpenclawBridge` onto `MemberBoundTransport`) is a separate PR. This change is purely wiring — `OpenclawBridge` implementation is untouched.

## Test plan

- [ ] `bash scripts/test-go.sh ./internal/team` — green (81s)
- [ ] `golangci-lint run ./internal/team/...` — 0 issues
- [ ] Manual: start with openclaw members configured → bridge starts and logs `[transport] openclaw: started`
- [ ] Manual: start without openclaw config → no log line, no error, office starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional OpenClaw integration added for extended transport capabilities.
* **Bug Fixes / Reliability**
  * Initialization errors for the integration are logged without failing transport startup.
* **Stability / Shutdown**
  * Improved shutdown: integration startup is cancellable and the routing component now signals when fully stopped for reliable cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->