### PR TITLE
fix(web): harden workspace rail tooltip and wiki live-refresh

### DIFF
--- a/web/src/components/wiki/WikiArticle.tsx
+++ b/web/src/components/wiki/WikiArticle.tsx
@@ -284,6 +284,11 @@ export default function WikiArticle({
     const unsubscribe = subscribeEditLog((entry) => {
       if (entry.article_path !== path) return;
       setLiveAgent(entry.who);
+      // Refetch the article body when an out-of-band wiki:write lands for
+      // the currently open article (e.g. background synthesis or a staged
+      // demo write). Without this the live editor's banner updates but the
+      // rendered body stays stale.
+      setRefreshNonce((n) => n + 1);
       if (clearTimer) clearTimeout(clearTimer);
       clearTimer = setTimeout(() => setLiveAgent(null), 10_000);
     });

--- a/web/src/components/workspaces/WorkspaceRail.tsx
+++ b/web/src/components/workspaces/WorkspaceRail.tsx
@@ -519,9 +519,10 @@ export function WorkspaceRail({
             {showTooltip ? (
               <div role="tooltip" style={styles.tooltip}>
                 <div style={{ fontWeight: 600 }}>
-                  {ws.company_name ?? ws.name}
+                  {ws.company_name?.trim() || ws.name}
                 </div>
-                {ws.company_name && ws.company_name !== ws.name ? (
+                {ws.company_name?.trim() &&
+                ws.company_name.trim() !== ws.name ? (
                   <div
                     style={{
                       fontSize: 11,

--- a/web/src/components/workspaces/__tests__/WorkspaceRail.test.tsx
+++ b/web/src/components/workspaces/__tests__/WorkspaceRail.test.tsx
@@ -231,6 +231,60 @@ describe("<WorkspaceRail>", () => {
     expect(tooltip.textContent).toContain("paused");
   });
 
+  it("falls back to the workspace name when company_name is missing", () => {
+    const slugOnlyWorkspace: Workspace = {
+      ...demoWorkspace,
+      company_name: "",
+      state: "running",
+    };
+    setListData([mainWorkspace, slugOnlyWorkspace], "main");
+    renderRail();
+
+    const icon = screen.getByTestId("workspace-icon-demo-launch");
+    fireEvent.mouseEnter(icon.parentElement as Element);
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip.textContent).toContain("demo-launch");
+    expect(tooltip.textContent).not.toContain("Acme Demo");
+    expect(tooltip.textContent).toContain("running");
+  });
+
+  it("falls back to the workspace name when company_name is whitespace", () => {
+    const whitespaceWorkspace: Workspace = {
+      ...demoWorkspace,
+      company_name: "   ",
+      state: "running",
+    };
+    setListData([mainWorkspace, whitespaceWorkspace], "main");
+    renderRail();
+
+    const icon = screen.getByTestId("workspace-icon-demo-launch");
+    fireEvent.mouseEnter(icon.parentElement as Element);
+
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip.textContent).toContain("demo-launch");
+    expect(tooltip.textContent).not.toContain("Acme Demo");
+    expect(tooltip.textContent).toContain("running");
+  });
+
+  it("does not duplicate the label when company_name matches name", () => {
+    const sameLabelWorkspace: Workspace = {
+      ...demoWorkspace,
+      company_name: "demo-launch",
+      state: "running",
+    };
+    setListData([mainWorkspace, sameLabelWorkspace], "main");
+    renderRail();
+
+    const icon = screen.getByTestId("workspace-icon-demo-launch");
+    fireEvent.mouseEnter(icon.parentElement as Element);
+
+    const tooltip = screen.getByRole("tooltip");
+    const matches = tooltip.textContent?.match(/demo-launch/g) ?? [];
+    expect(matches).toHaveLength(1);
+    expect(tooltip.textContent).toContain("running");
+  });
+
   it("error-state workspaces show a notice instead of navigating", () => {
     setListData([mainWorkspace, errorWorkspace], "main");
     const navigate = vi.fn();


### PR DESCRIPTION
## Summary

- Tooltip now falls back to `ws.name` when `company_name` is empty or whitespace (`?.trim() || ws.name`), and suppresses the secondary subtitle when `company_name` matches `name` exactly — prevents duplicate labels and blank primaries.
- `WikiArticle` increments `refreshNonce` on incoming `wiki:write` SSE events so the rendered body refetches after out-of-band agent writes (e.g. background synthesis, demo writes). Previously only the live-agent banner updated; the body stayed stale.

## Test plan

- [ ] Hover workspace icon with empty `company_name` → shows slug, no subtitle
- [ ] Hover workspace icon with whitespace-only `company_name` → shows slug, no subtitle  
- [ ] Hover workspace icon where `company_name === name` → shows label once, no duplicate
- [ ] Open a wiki article, trigger an agent write to it → rendered body updates without a manual refresh
- [ ] Existing WorkspaceRail tooltip tests pass (14/14)
- [ ] Existing WikiArticle tests pass (20/20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Wiki articles now auto-refresh when related edit logs arrive, keeping content and history in sync.
  * Workspace tooltips use the trimmed company name as the primary label, fall back to workspace name when empty/whitespace, and avoid duplicating identical names.

* **Tests**
  * Added tooltip tests covering company-name display, fallback behavior, whitespace-only names, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->