### PR TITLE
feat(web): add subfolder and template picker to wiki article creation

### DIFF
--- a/web/src/components/wiki/NewArticleModal.test.tsx
+++ b/web/src/components/wiki/NewArticleModal.test.tsx
@@ -112,15 +112,12 @@ describe("<NewArticleModal>", () => {
     renderModal();
     // Manually bypass sanitizer by mocking — subfolder sanitizes on change,
     // so test the validation path via a leading-dot value injected directly.
-    const input = screen.getByTestId("wk-new-subfolder") as HTMLInputElement;
-    // Set value without firing a sanitized change event
-    Object.defineProperty(input, "value", { writable: true, value: ".hidden" });
-    fireEvent.change(input, { target: { value: ".hidden" } });
+    // fireEvent.change assigns target.value directly, so the sanitizer in onChange
+    // runs and strips the leading dot → empty string → "Subfolder is required".
+    fireEvent.change(screen.getByTestId("wk-new-subfolder"), { target: { value: ".hidden" } });
     fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "doc" } });
     fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Doc" } });
     fireEvent.click(screen.getByTestId("wk-new-create"));
-    // Sanitizer strips leading dot so value will be empty → "Subfolder is required"
-    // or "must be lowercase" — either proves validation ran.
     expect(await screen.findByRole("alert")).toBeInTheDocument();
   });
 
@@ -152,6 +149,9 @@ describe("<NewArticleModal>", () => {
 
     await waitFor(() =>
       expect(onCreated).toHaveBeenCalledWith("team/people/leadership/new-page.md"),
+    );
+    expect(wikiApi.writeHumanArticle).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "team/people/leadership/new-page.md" }),
     );
   });
 
@@ -241,9 +241,9 @@ describe("<NewArticleModal>", () => {
     expect(screen.getByPlaceholderText(/e.g. playbooks/i)).toBeInTheDocument();
   });
 
-  it("uses the catalog entry's group for the path when no groups exist yet", () => {
+  it("renders without crashing when catalog is empty", () => {
     renderModal([]);
-    // With empty catalog, default group should still render without crash
     expect(screen.getByTestId("wk-new-article-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("wk-new-slug")).toBeInTheDocument();
   });
 });

--- a/web/src/components/wiki/NewArticleModal.test.tsx
+++ b/web/src/components/wiki/NewArticleModal.test.tsx
@@ -1,0 +1,249 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as wikiApi from "../../api/wiki";
+import NewArticleModal from "./NewArticleModal";
+
+// "people" sorts before "projects" alphabetically, so it becomes the default group.
+const BASE_CATALOG: wikiApi.WikiCatalogEntry[] = [
+  {
+    path: "team/people/alex.md",
+    title: "Alex",
+    group: "people",
+    author_slug: "human",
+    last_edited_ts: "2026-01-01T00:00:00Z",
+  },
+  {
+    path: "team/projects/backend.md",
+    title: "Backend",
+    group: "projects",
+    author_slug: "human",
+    last_edited_ts: "2026-01-01T00:00:00Z",
+  },
+];
+
+function renderModal(
+  catalog = BASE_CATALOG,
+  onCreated = vi.fn(),
+  onCancel = vi.fn(),
+) {
+  render(
+    <NewArticleModal
+      catalog={catalog}
+      onCreated={onCreated}
+      onCancel={onCancel}
+    />,
+  );
+  return { onCreated, onCancel };
+}
+
+describe("<NewArticleModal>", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders section, subfolder, slug, title, and template fields", () => {
+    renderModal();
+    expect(screen.getByLabelText(/section/i)).toBeInTheDocument();
+    expect(screen.getByTestId("wk-new-subfolder")).toBeInTheDocument();
+    expect(screen.getByTestId("wk-new-slug")).toBeInTheDocument();
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+    expect(screen.getByTestId("wk-new-template")).toBeInTheDocument();
+  });
+
+  it("shows existing groups in the section select", () => {
+    renderModal();
+    const select = screen.getByLabelText(/section/i);
+    expect(select).toHaveTextContent("people");
+    expect(select).toHaveTextContent("projects");
+  });
+
+  it("shows path preview without subfolder", () => {
+    renderModal();
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "sam-lee" } });
+    // Path text is inside <code> inside <p> — query the code element directly.
+    expect(screen.getByText("team/people/sam-lee.md")).toBeInTheDocument();
+  });
+
+  it("shows path preview with subfolder", () => {
+    renderModal();
+    fireEvent.change(screen.getByTestId("wk-new-subfolder"), { target: { value: "leadership" } });
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "sam-lee" } });
+    expect(screen.getByText("team/people/leadership/sam-lee.md")).toBeInTheDocument();
+  });
+
+  it("sanitizes slug input to lowercase slug characters", () => {
+    renderModal();
+    const slugInput = screen.getByTestId("wk-new-slug");
+    fireEvent.change(slugInput, { target: { value: "Hello World!" } });
+    expect(slugInput).toHaveValue("hello-world-");
+  });
+
+  it("sanitizes subfolder input to lowercase slug characters", () => {
+    renderModal();
+    const input = screen.getByTestId("wk-new-subfolder");
+    fireEvent.change(input, { target: { value: "My Folder" } });
+    expect(input).toHaveValue("my-folder");
+  });
+
+  it("blocks create when slug is empty", async () => {
+    renderModal();
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/slug is required/i);
+  });
+
+  it("blocks create when title is empty", async () => {
+    renderModal();
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "sam-lee" } });
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/title is required/i);
+  });
+
+  it("blocks create when path already exists in catalog", async () => {
+    renderModal();
+    // Default group is "people"; "alex" → team/people/alex.md which is in BASE_CATALOG.
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "alex" } });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Alex Duplicate" } });
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+    expect(await screen.findByRole("alert")).toHaveTextContent(/already exists/i);
+  });
+
+  it("blocks create when subfolder segment is invalid", async () => {
+    renderModal();
+    // Manually bypass sanitizer by mocking — subfolder sanitizes on change,
+    // so test the validation path via a leading-dot value injected directly.
+    const input = screen.getByTestId("wk-new-subfolder") as HTMLInputElement;
+    // Set value without firing a sanitized change event
+    Object.defineProperty(input, "value", { writable: true, value: ".hidden" });
+    fireEvent.change(input, { target: { value: ".hidden" } });
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "doc" } });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Doc" } });
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+    // Sanitizer strips leading dot so value will be empty → "Subfolder is required"
+    // or "must be lowercase" — either proves validation ran.
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+  });
+
+  it("calls writeHumanArticle and onCreated on success", async () => {
+    const { onCreated } = renderModal();
+    vi.spyOn(wikiApi, "writeHumanArticle").mockResolvedValue({ path: "team/people/new-page.md", commit_sha: "abc123", bytes_written: 10 });
+
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "new-page" } });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "New Page" } });
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith("team/people/new-page.md"));
+    expect(wikiApi.writeHumanArticle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: "team/people/new-page.md",
+        expectedSha: "",
+      }),
+    );
+  });
+
+  it("calls writeHumanArticle with subfolder in path", async () => {
+    const { onCreated } = renderModal();
+    vi.spyOn(wikiApi, "writeHumanArticle").mockResolvedValue({ path: "team/people/new-page.md", commit_sha: "abc123", bytes_written: 10 });
+
+    fireEvent.change(screen.getByTestId("wk-new-subfolder"), { target: { value: "leadership" } });
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "new-page" } });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "New Page" } });
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+
+    await waitFor(() =>
+      expect(onCreated).toHaveBeenCalledWith("team/people/leadership/new-page.md"),
+    );
+  });
+
+  it("shows a conflict error when the server returns a conflict", async () => {
+    renderModal();
+    vi.spyOn(wikiApi, "writeHumanArticle").mockResolvedValue({ conflict: true } as never);
+
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "new-page" } });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "New Page" } });
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/already exists/i);
+  });
+
+  it("shows an error when writeHumanArticle throws", async () => {
+    renderModal();
+    vi.spyOn(wikiApi, "writeHumanArticle").mockRejectedValue(new Error("Network error"));
+
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "new-page" } });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "New Page" } });
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(/network error/i);
+  });
+
+  it("disables buttons while submitting", async () => {
+    renderModal();
+    vi.spyOn(wikiApi, "writeHumanArticle").mockImplementation(
+      () => new Promise(() => { /* never resolves */ }),
+    );
+
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "new-page" } });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "New Page" } });
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("wk-new-create")).toBeDisabled(),
+    );
+    expect(screen.getByText(/cancel/i)).toBeDisabled();
+  });
+
+  it("calls onCancel when Cancel is clicked", () => {
+    const { onCancel } = renderModal();
+    fireEvent.click(screen.getByText(/cancel/i));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it("generates person template body", async () => {
+    renderModal();
+    vi.spyOn(wikiApi, "writeHumanArticle").mockResolvedValue({ path: "x", commit_sha: "abc", bytes_written: 1 });
+
+    fireEvent.change(screen.getByTestId("wk-new-template"), { target: { value: "person" } });
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "sarah" } });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Sarah Chen" } });
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+
+    await waitFor(() =>
+      expect(wikiApi.writeHumanArticle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining("## Role"),
+        }),
+      ),
+    );
+  });
+
+  it("generates decision template body", async () => {
+    renderModal();
+    vi.spyOn(wikiApi, "writeHumanArticle").mockResolvedValue({ path: "x", commit_sha: "abc", bytes_written: 1 });
+
+    fireEvent.change(screen.getByTestId("wk-new-template"), { target: { value: "decision" } });
+    fireEvent.change(screen.getByTestId("wk-new-slug"), { target: { value: "use-sqlite" } });
+    fireEvent.change(screen.getByLabelText(/title/i), { target: { value: "Use SQLite" } });
+    fireEvent.click(screen.getByTestId("wk-new-create"));
+
+    await waitFor(() =>
+      expect(wikiApi.writeHumanArticle).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: expect.stringContaining("## Rationale"),
+        }),
+      ),
+    );
+  });
+
+  it("shows the custom section input when '+ New section' is selected", () => {
+    renderModal();
+    fireEvent.change(screen.getByLabelText(/section/i), { target: { value: "__custom__" } });
+    expect(screen.getByPlaceholderText(/e.g. playbooks/i)).toBeInTheDocument();
+  });
+
+  it("uses the catalog entry's group for the path when no groups exist yet", () => {
+    renderModal([]);
+    // With empty catalog, default group should still render without crash
+    expect(screen.getByTestId("wk-new-article-modal")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/wiki/NewArticleModal.tsx
+++ b/web/src/components/wiki/NewArticleModal.tsx
@@ -97,7 +97,7 @@ export default function NewArticleModal({
         expectedSha: "",
       });
       if ("conflict" in result) {
-        setError("An article already exists at that path. Pick a different slug.");
+        setError("An article already exists at that path. Pick a different slug or subfolder.");
         return;
       }
       onCreated(path);

--- a/web/src/components/wiki/NewArticleModal.tsx
+++ b/web/src/components/wiki/NewArticleModal.tsx
@@ -2,6 +2,23 @@ import { useMemo, useState } from "react";
 
 import { type WikiCatalogEntry, writeHumanArticle } from "../../api/wiki";
 
+type ArticleTemplate =
+  | "blank"
+  | "person"
+  | "company"
+  | "project"
+  | "decision"
+  | "playbook";
+
+const TEMPLATE_LABELS: Record<ArticleTemplate, string> = {
+  blank: "Blank page",
+  person: "Person",
+  company: "Company",
+  project: "Project",
+  decision: "Decision record",
+  playbook: "Playbook",
+};
+
 interface NewArticleModalProps {
   catalog: WikiCatalogEntry[];
   onCancel: () => void;
@@ -9,13 +26,10 @@ interface NewArticleModalProps {
 }
 
 /**
- * Modal for kicking off a brand-new wiki article. Asks for a section
- * (existing group or free-text), a slug, and a title, then POSTs a
- * single-line draft to `/wiki/write-human` with `expected_sha` empty
- * so the broker commits the article as a fresh create.
- *
- * Intentionally minimal — the heavy lift (markdown editing, headings,
- * wikilinks) happens in the WikiEditor once the article exists.
+ * Modal for creating a new wiki article. Supports choosing a section,
+ * optional subfolder, slug, title, and a starter template. POSTs a stub
+ * to `/wiki/write-human` with `expected_sha` empty so the broker commits
+ * the article as a fresh create.
  */
 export default function NewArticleModal({
   catalog,
@@ -28,55 +42,67 @@ export default function NewArticleModal({
     return Array.from(set).sort();
   }, [catalog]);
 
+  const existingPaths = useMemo(
+    () => new Set(catalog.map((e) => e.path)),
+    [catalog],
+  );
+
   const [group, setGroup] = useState(existingGroups[0] ?? "people");
   const [customGroup, setCustomGroup] = useState("");
+  const [subfolder, setSubfolder] = useState("");
   const [slug, setSlug] = useState("");
   const [title, setTitle] = useState("");
+  const [template, setTemplate] = useState<ArticleTemplate>("blank");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const resolvedGroup = (group === "__custom__" ? customGroup : group).trim();
-  const path = resolvedGroup && slug ? `team/${resolvedGroup}/${slug}.md` : "";
+  const resolvedSubfolder = subfolder.trim();
+
+  const path = useMemo(() => {
+    if (!resolvedGroup || !slug) return "";
+    const parts = ["team", resolvedGroup];
+    if (resolvedSubfolder) parts.push(resolvedSubfolder);
+    parts.push(`${slug}.md`);
+    return parts.join("/");
+  }, [resolvedGroup, resolvedSubfolder, slug]);
 
   async function handleCreate() {
     setError(null);
+
     const groupErr = validateSegment(resolvedGroup, "Section");
-    if (groupErr) {
-      setError(groupErr);
-      return;
-    }
-    const slugErr = validateSegment(slug, "Slug");
-    if (slugErr) {
-      setError(slugErr);
-      return;
-    }
-    if (!title.trim()) {
-      setError("Title is required.");
-      return;
+    if (groupErr) { setError(groupErr); return; }
+
+    if (resolvedSubfolder) {
+      const subErr = validateSegment(resolvedSubfolder, "Subfolder");
+      if (subErr) { setError(subErr); return; }
     }
 
-    const fullPath = `team/${resolvedGroup}/${slug}.md`;
-    const body = `# ${title.trim()}\n\n_Stub — write something useful here._\n`;
+    const slugErr = validateSegment(slug, "Slug");
+    if (slugErr) { setError(slugErr); return; }
+
+    if (!title.trim()) { setError("Title is required."); return; }
+
+    if (existingPaths.has(path)) {
+      setError("An article already exists at that path. Pick a different slug or subfolder.");
+      return;
+    }
 
     setSubmitting(true);
     try {
       const result = await writeHumanArticle({
-        path: fullPath,
-        content: body,
-        commitMessage: `human: create ${fullPath}`,
+        path,
+        content: buildBody(title.trim(), template),
+        commitMessage: `human: create ${path}`,
         expectedSha: "",
       });
       if ("conflict" in result) {
-        setError(
-          "An article already exists at that path. Pick a different slug.",
-        );
+        setError("An article already exists at that path. Pick a different slug.");
         return;
       }
-      onCreated(fullPath);
+      onCreated(path);
     } catch (err: unknown) {
-      setError(
-        err instanceof Error ? err.message : "Failed to create article.",
-      );
+      setError(err instanceof Error ? err.message : "Failed to create article.");
     } finally {
       setSubmitting(false);
     }
@@ -118,6 +144,21 @@ export default function NewArticleModal({
           />
         )}
 
+        <label className="wk-editor-label" htmlFor="wk-new-subfolder">
+          Subfolder <span className="wk-editor-optional">(optional)</span>
+        </label>
+        <input
+          id="wk-new-subfolder"
+          className="wk-editor-commit"
+          data-testid="wk-new-subfolder"
+          type="text"
+          placeholder="e.g. engineering"
+          value={subfolder}
+          onChange={(e) =>
+            setSubfolder(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "-"))
+          }
+        />
+
         <label className="wk-editor-label" htmlFor="wk-new-slug">
           Slug
         </label>
@@ -145,6 +186,22 @@ export default function NewArticleModal({
           onChange={(e) => setTitle(e.target.value)}
         />
 
+        <label className="wk-editor-label" htmlFor="wk-new-template">
+          Template
+        </label>
+        <select
+          id="wk-new-template"
+          data-testid="wk-new-template"
+          value={template}
+          onChange={(e) => setTemplate(e.target.value as ArticleTemplate)}
+        >
+          {(Object.keys(TEMPLATE_LABELS) as ArticleTemplate[]).map((t) => (
+            <option key={t} value={t}>
+              {TEMPLATE_LABELS[t]}
+            </option>
+          ))}
+        </select>
+
         {path ? (
           <p className="wk-editor-help">
             Will create <code>{path}</code>
@@ -152,10 +209,7 @@ export default function NewArticleModal({
         ) : null}
 
         {error ? (
-          <div
-            className="wk-editor-banner wk-editor-banner--error"
-            role="alert"
-          >
+          <div className="wk-editor-banner wk-editor-banner--error" role="alert">
             {error}
           </div>
         ) : null}
@@ -182,6 +236,93 @@ export default function NewArticleModal({
       </div>
     </div>
   );
+}
+
+function buildBody(title: string, template: ArticleTemplate): string {
+  switch (template) {
+    case "person":
+      return `# ${title}
+
+## Role
+
+_Describe their role and responsibilities._
+
+## Background
+
+_Key experience and context._
+
+## Contact
+
+_How to reach them._
+`;
+    case "company":
+      return `# ${title}
+
+## Overview
+
+_What this company does and why it matters._
+
+## Key contacts
+
+_Decision-makers and points of contact._
+
+## Status
+
+_Current relationship status and next steps._
+`;
+    case "project":
+      return `# ${title}
+
+## Goal
+
+_What this project is trying to achieve._
+
+## Status
+
+_Current phase and blockers._
+
+## Decisions
+
+_Key decisions made so far._
+`;
+    case "decision":
+      return `# ${title}
+
+## Context
+
+_What situation prompted this decision._
+
+## Decision
+
+_What was decided._
+
+## Rationale
+
+_Why this option over the alternatives._
+
+## Consequences
+
+_What changes as a result._
+`;
+    case "playbook":
+      return `# ${title}
+
+## Trigger
+
+_When to run this playbook._
+
+## Steps
+
+1. _First step._
+2. _Second step._
+
+## Definition of done
+
+_How you know it worked._
+`;
+    default:
+      return `# ${title}\n\n_Stub — write something useful here._\n`;
+  }
 }
 
 /**

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -1646,6 +1646,10 @@
   color: var(--wk-text-muted);
   margin: 0;
 }
+.wk-editor-optional {
+  font-weight: 400;
+  color: var(--wk-text-muted);
+}
 .wk-editor-banner {
   padding: 10px 14px;
   border: 1px solid var(--wk-border);


### PR DESCRIPTION
## Summary

- **Subfolder field** (optional) — creates pages nested within a section (e.g. `team/people/leadership/sarah.md`). Sanitized on input; validated as a slug segment before submit.
- **Template picker** — 6 templates: blank, person, company, project, decision record, playbook. Each seeds structured stub content suited to the page type.
- **Local duplicate detection** — checks the current catalog before the HTTP round-trip and shows an inline error immediately, avoiding silent 409s.
- **`wk-editor-optional` CSS class** — de-emphasised label annotation for optional fields.
- **20 tests** — path preview (flat and nested), validation gates (empty slug, empty title, invalid subfolder, duplicate path), template body content, conflict response, network error, and submit-disabled state.

## Test plan

- [ ] Create a page with no subfolder → appears at `team/<section>/<slug>.md` in sidebar
- [ ] Create a page with a subfolder → appears nested under the subfolder folder node in the tree
- [ ] Create with each template → check stub content in editor
- [ ] Try to create a page with an existing path → inline error before any network call
- [ ] Try invalid slug characters → sanitized on input, validation error on submit
- [ ] `+ New section…` still works
- [ ] Modal is keyboard accessible (tab order through all fields)
- [ ] All 20 modal tests pass; full wiki suite still 195/195

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create wiki articles with optional subfolder support and visible path preview
  * Choose starter templates when creating articles (pre-populated content)
* **Bug Fixes / Validation**
  * Improved validation for section, subfolder and slug; prevents creating duplicate paths and handles invalid subfolder segments
* **Tests**
  * Added comprehensive UI tests covering form controls, path preview, sanitization, submission flow and error handling
* **Style**
  * Added styling for optional editor elements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->