### PR TITLE
feat(transport): refactor OpenclawBridge onto MemberBoundTransport (phase 3b)

### DIFF
--- a/internal/team/broker_office_members.go
+++ b/internal/team/broker_office_members.go
@@ -248,7 +248,7 @@ func (b *Broker) createOfficeMember(r *http.Request, slug string, body officeMem
 			}
 			member.Provider.Openclaw.SessionKey = key
 		}
-		if err := bridge.AttachSlug(r.Context(), slug, member.Provider.Openclaw.SessionKey); err != nil {
+		if err := bridge.AttachSlugAndSubscribe(r.Context(), slug, member.Provider.Openclaw.SessionKey); err != nil {
 			return officeMemberMutationResult{}, newOfficeMemberMutationError(http.StatusBadGateway, fmt.Sprintf("openclaw subscribe: %v", err))
 		}
 	} else {
@@ -408,7 +408,7 @@ func (b *Broker) updateOfficeMember(r *http.Request, slug string, body officeMem
 		// attach would return 502 with member.Provider still pointing
 		// at the old binding but no live subscription on the gateway.
 		if toOpenclaw {
-			if err := bridge.AttachSlug(r.Context(), slug, newBinding.Openclaw.SessionKey); err != nil {
+			if err := bridge.AttachSlugAndSubscribe(r.Context(), slug, newBinding.Openclaw.SessionKey); err != nil {
 				return officeMemberMutationResult{}, newOfficeMemberMutationError(http.StatusBadGateway, fmt.Sprintf("openclaw subscribe: %v", err))
 			}
 		}
@@ -505,7 +505,7 @@ func (b *Broker) removeOfficeMember(r *http.Request, slug string) (officeMemberM
 	// lingers daemon-side and the user can clean it up via the
 	// OpenClaw CLI if they want to reclaim the slot.
 	if memberSnapshot.Provider.Kind == provider.KindOpenclaw && bridge != nil {
-		if err := bridge.DetachSlug(r.Context(), memberSnapshot.Slug); err != nil {
+		if err := bridge.DetachSlugAndUnsubscribe(r.Context(), memberSnapshot.Slug); err != nil {
 			go bridge.postSystemMessage(fmt.Sprintf("agent %q removed: detach warning: %v", memberSnapshot.Slug, err))
 		}
 	}

--- a/internal/team/openclaw.go
+++ b/internal/team/openclaw.go
@@ -103,17 +103,16 @@ func (b *OpenclawBridge) AttachSlug(slug, sessionKey string) {
 	if slug == "" || sessionKey == "" {
 		return
 	}
-	b.mu.RLock()
-	existingKey, already := b.keyBySlug[slug]
+	b.mu.Lock()
 	bridgeCtx := b.ctx
-	b.mu.RUnlock()
-	if already && existingKey == sessionKey {
+	currentKey, alreadyBound := b.keyBySlug[slug]
+	if alreadyBound && currentKey == sessionKey {
+		b.mu.Unlock()
 		return
 	}
-	b.mu.Lock()
-	if already && existingKey != sessionKey {
-		delete(b.slugByKey, existingKey)
-		delete(b.lastChannelByKey, existingKey)
+	if alreadyBound && currentKey != sessionKey {
+		delete(b.slugByKey, currentKey)
+		delete(b.lastChannelByKey, currentKey)
 	}
 	b.slugByKey[sessionKey] = slug
 	b.keyBySlug[slug] = sessionKey
@@ -150,19 +149,24 @@ func (b *OpenclawBridge) AttachSlugAndSubscribe(ctx context.Context, slug, sessi
 		return nil
 	}
 	client := b.getClient()
-	if client != nil {
-		if err := client.SessionsMessagesSubscribe(ctx, sessionKey); err != nil {
-			return fmt.Errorf("openclaw: subscribe %q: %w", slug, err)
-		}
+	if client == nil {
+		return fmt.Errorf("openclaw: no active client for %q", slug)
+	}
+	if err := client.SessionsMessagesSubscribe(ctx, sessionKey); err != nil {
+		return fmt.Errorf("openclaw: subscribe %q: %w", slug, err)
 	}
 	b.mu.Lock()
-	if already && existingKey != sessionKey {
-		delete(b.slugByKey, existingKey)
-		delete(b.lastChannelByKey, existingKey)
+	defer b.mu.Unlock()
+	currentKey, currentlyBound := b.keyBySlug[slug]
+	if currentlyBound && currentKey == sessionKey {
+		return nil
+	}
+	if currentlyBound && currentKey != sessionKey {
+		delete(b.slugByKey, currentKey)
+		delete(b.lastChannelByKey, currentKey)
 	}
 	b.slugByKey[sessionKey] = slug
 	b.keyBySlug[slug] = sessionKey
-	b.mu.Unlock()
 	return nil
 }
 
@@ -200,9 +204,11 @@ func (b *OpenclawBridge) DetachSlug(slug string) {
 }
 
 // DetachSlugAndUnsubscribe is the synchronous, error-returning variant used by
-// HTTP handlers. Best-effort on the network call: local state is always
-// cleared so the slug frees up; the returned error informs the caller that
-// the remote session may be leaked.
+// HTTP handlers. Local state is always cleared so the slug frees up regardless
+// of network outcome; the returned error informs the caller that the remote
+// session may be leaked. Returns an error when no bridge client is connected
+// so the caller can surface the failed remote teardown rather than silently
+// orphan the upstream subscription.
 func (b *OpenclawBridge) DetachSlugAndUnsubscribe(ctx context.Context, slug string) error {
 	if b == nil {
 		return nil
@@ -221,7 +227,7 @@ func (b *OpenclawBridge) DetachSlugAndUnsubscribe(ctx context.Context, slug stri
 
 	client := b.getClient()
 	if client == nil {
-		return nil
+		return fmt.Errorf("openclaw: no active client for %q", slug)
 	}
 	if err := client.SessionsMessagesUnsubscribe(ctx, sessionKey); err != nil {
 		return fmt.Errorf("openclaw: unsubscribe %q: %w", slug, err)

--- a/internal/team/openclaw.go
+++ b/internal/team/openclaw.go
@@ -64,6 +64,12 @@ type OpenclawBridge struct {
 	// each offline episode posts exactly one notice (not one per 5-minute
 	// supervise tick).
 	noticedOffline bool
+
+	// healthMu guards the health snapshot fields. Kept separate from mu so
+	// Health() can read without contending with map updates on hot paths.
+	healthMu      sync.RWMutex
+	lastSuccessAt time.Time
+	lastError     error
 }
 
 // HasSlug reports whether the given slug is bound to a bridged OpenClaw
@@ -80,20 +86,62 @@ func (b *OpenclawBridge) HasSlug(slug string) bool {
 	return ok
 }
 
-// AttachSlug subscribes the bridge to a session and registers the slug→key
-// mapping so inbound events route to the right member. Called at startup for
-// every openclaw-bound office member and at runtime from handleOfficeMembers
-// when a new openclaw agent is created. Idempotent: attaching an already-
-// attached slug is a no-op. Broker-side member mutations serialize separately;
-// this method takes only the bridge's own mu.
-func (b *OpenclawBridge) AttachSlug(ctx context.Context, slug, sessionKey string) error {
+// AttachSlug binds an office member slug to a session key. It updates the
+// bridge's slug→key and key→slug maps so inbound events route to the right
+// member. The contract requires no error/ctx return: callers that need to
+// surface subscribe failures (HTTP handlers) must use [AttachSlugAndSubscribe]
+// instead. AttachSlug performs a best-effort async subscribe via the bridge's
+// stored ctx so the contract-level call still establishes the gateway
+// subscription, but failures are logged via system message rather than
+// returned. Idempotent: re-attaching the same pair is a no-op.
+func (b *OpenclawBridge) AttachSlug(slug, sessionKey string) {
+	if b == nil {
+		return
+	}
+	slug = strings.TrimSpace(slug)
+	sessionKey = strings.TrimSpace(sessionKey)
+	if slug == "" || sessionKey == "" {
+		return
+	}
+	b.mu.RLock()
+	existingKey, already := b.keyBySlug[slug]
+	bridgeCtx := b.ctx
+	b.mu.RUnlock()
+	if already && existingKey == sessionKey {
+		return
+	}
+	b.mu.Lock()
+	if already && existingKey != sessionKey {
+		delete(b.slugByKey, existingKey)
+		delete(b.lastChannelByKey, existingKey)
+	}
+	b.slugByKey[sessionKey] = slug
+	b.keyBySlug[slug] = sessionKey
+	b.mu.Unlock()
+
+	client := b.getClient()
+	if client == nil || bridgeCtx == nil {
+		return
+	}
+	go func() {
+		if err := client.SessionsMessagesSubscribe(bridgeCtx, sessionKey); err != nil && bridgeCtx.Err() == nil {
+			b.postSystemMessage(fmt.Sprintf("subscribe @%s failed: %v", slug, err))
+		}
+	}()
+}
+
+// AttachSlugAndSubscribe is the synchronous, error-returning variant used by
+// HTTP handlers that need to fail the request when the gateway subscription
+// fails. Updates the slug→key/key→slug maps and synchronously subscribes via
+// the supplied ctx. Idempotent: re-attaching the same pair is a no-op.
+func (b *OpenclawBridge) AttachSlugAndSubscribe(ctx context.Context, slug, sessionKey string) error {
 	if b == nil {
 		return fmt.Errorf("openclaw: nil bridge")
 	}
 	slug = strings.TrimSpace(slug)
 	sessionKey = strings.TrimSpace(sessionKey)
 	if slug == "" || sessionKey == "" {
-		return fmt.Errorf("openclaw: AttachSlug requires non-empty slug and sessionKey")
+		return fmt.Errorf("openclaw: AttachSlugAndSubscribe requires non-empty slug and sessionKey")
 	}
 	b.mu.RLock()
 	existingKey, already := b.keyBySlug[slug]
@@ -118,12 +166,44 @@ func (b *OpenclawBridge) AttachSlug(ctx context.Context, slug, sessionKey string
 	return nil
 }
 
-// DetachSlug unsubscribes and removes the slug from bridge maps. Best-effort
-// on the network call: if the gateway is unreachable we still clear local
-// state so the slug frees up; the returned error informs the caller that the
-// remote session may be leaked. Used by handleOfficeMembers on member remove
-// and by provider-switch flows when a member migrates off openclaw.
-func (b *OpenclawBridge) DetachSlug(ctx context.Context, slug string) error {
+// DetachSlug removes the binding between slug and its session key. The
+// contract requires no error/ctx return: callers that need to surface
+// unsubscribe failures must use [DetachSlugAndUnsubscribe] instead. DetachSlug
+// performs a best-effort async unsubscribe via the bridge's stored ctx;
+// failures are logged via system message rather than returned.
+func (b *OpenclawBridge) DetachSlug(slug string) {
+	if b == nil {
+		return
+	}
+	slug = strings.TrimSpace(slug)
+	b.mu.Lock()
+	sessionKey := b.keyBySlug[slug]
+	if sessionKey == "" {
+		b.mu.Unlock()
+		return
+	}
+	delete(b.keyBySlug, slug)
+	delete(b.slugByKey, sessionKey)
+	delete(b.lastChannelByKey, sessionKey)
+	bridgeCtx := b.ctx
+	b.mu.Unlock()
+
+	client := b.getClient()
+	if client == nil || bridgeCtx == nil {
+		return
+	}
+	go func() {
+		if err := client.SessionsMessagesUnsubscribe(bridgeCtx, sessionKey); err != nil && bridgeCtx.Err() == nil {
+			b.postSystemMessage(fmt.Sprintf("unsubscribe @%s failed: %v", slug, err))
+		}
+	}()
+}
+
+// DetachSlugAndUnsubscribe is the synchronous, error-returning variant used by
+// HTTP handlers. Best-effort on the network call: local state is always
+// cleared so the slug frees up; the returned error informs the caller that
+// the remote session may be leaked.
+func (b *OpenclawBridge) DetachSlugAndUnsubscribe(ctx context.Context, slug string) error {
 	if b == nil {
 		return nil
 	}
@@ -158,7 +238,7 @@ func (b *OpenclawBridge) DetachSession(ctx context.Context, slug, sessionKey str
 	slug = strings.TrimSpace(slug)
 	sessionKey = strings.TrimSpace(sessionKey)
 	if sessionKey == "" {
-		return b.DetachSlug(ctx, slug)
+		return b.DetachSlugAndUnsubscribe(ctx, slug)
 	}
 	b.mu.Lock()
 	if boundSlug := b.slugByKey[sessionKey]; boundSlug != "" && boundSlug != slug {
@@ -301,6 +381,7 @@ func (b *OpenclawBridge) supervise() {
 		b.noticedOffline = false
 		err := b.runOnce()
 		if err != nil && !errors.Is(err, context.Canceled) {
+			b.recordHealthFailure(err)
 			if b.breaker != nil {
 				b.breaker.RecordFailure()
 			}
@@ -379,6 +460,7 @@ func (b *OpenclawBridge) runOnce() error {
 	if b.backoff != nil {
 		b.backoff.Reset()
 	}
+	b.recordHealthSuccess()
 
 	events := client.Events()
 	for {
@@ -541,4 +623,20 @@ func (b *OpenclawBridge) postSystemMessage(text string) {
 		return
 	}
 	b.broker.PostSystemMessage("general", "[openclaw] "+text, "openclaw")
+}
+
+// recordHealthSuccess updates the cached health snapshot after a successful
+// runOnce establishes a session and clears any prior error.
+func (b *OpenclawBridge) recordHealthSuccess() {
+	b.healthMu.Lock()
+	b.lastSuccessAt = time.Now()
+	b.lastError = nil
+	b.healthMu.Unlock()
+}
+
+// recordHealthFailure caches the most recent error so Health() can surface it.
+func (b *OpenclawBridge) recordHealthFailure(err error) {
+	b.healthMu.Lock()
+	b.lastError = err
+	b.healthMu.Unlock()
 }

--- a/internal/team/openclaw_transport.go
+++ b/internal/team/openclaw_transport.go
@@ -1,0 +1,102 @@
+package team
+
+// openclaw_transport.go implements transport.MemberBoundTransport on
+// OpenclawBridge. This is the Phase 3b adapter contract — Name/Binding/Run/
+// Send/Health satisfy the base Transport interface; AttachSlug, DetachSlug,
+// and CreateSession satisfy the member-bound extension. The contract-level
+// AttachSlug/DetachSlug are defined in openclaw.go alongside their
+// synchronous error-returning siblings (AttachSlugAndSubscribe /
+// DetachSlugAndUnsubscribe) used by HTTP handlers.
+//
+// Phase 4 will move the launcher's StartOpenclawBridgeFromConfig wiring onto
+// the Host contract via Run(); for now Run() is a thin shim around the
+// existing supervised loop so RegisterTransports can treat the bridge like
+// any other Transport implementation.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// adapterName is the stable identifier the broker uses to namespace
+// participant keys created by this adapter. Changing this between releases
+// would lose participant identity across restarts (per Transport.Name docs).
+const openclawAdapterName = "openclaw"
+
+// Compile-time assertion that OpenclawBridge satisfies MemberBoundTransport.
+// If the contract changes, the build breaks here, not at the registration site.
+var _ transport.MemberBoundTransport = (*OpenclawBridge)(nil)
+
+// Name returns the stable adapter identifier.
+func (b *OpenclawBridge) Name() string { return openclawAdapterName }
+
+// Binding declares the adapter scope. OpenClaw is member-bound: each bridged
+// session becomes an office member, but the bridge itself does not anchor to
+// a single member slug (it manages many). Like Telegram's multi-channel
+// pattern, we return a zero MemberSlug — honest declaration that no static
+// member is bound at the adapter level.
+func (b *OpenclawBridge) Binding() transport.Binding {
+	return transport.Binding{Scope: transport.ScopeMember}
+}
+
+// Run starts the supervised bridge and blocks until ctx is cancelled. The
+// host parameter is currently unused — Phase 4 will route inbound assistant
+// messages through host.ReceiveMessage instead of the direct broker call in
+// handleClientEvent. For now Run preserves the existing supervised-loop
+// behavior so RegisterTransports can drive both lifecycle paths uniformly.
+func (b *OpenclawBridge) Run(ctx context.Context, _ transport.Host) error {
+	if b == nil {
+		return fmt.Errorf("openclaw: nil bridge")
+	}
+	if err := b.Start(ctx); err != nil {
+		return err
+	}
+	<-ctx.Done()
+	b.Stop()
+	return nil
+}
+
+// Send delivers one outbound message from the office to the bridged agent.
+// Routes via OnOfficeMessage, which handles retries with a single reused
+// idempotency key. The Outbound.Binding.MemberSlug identifies the target
+// agent; ChannelSlug carries the reply-routing hint that handleClientEvent
+// uses when the assistant reply arrives via the async event stream.
+func (b *OpenclawBridge) Send(ctx context.Context, msg transport.Outbound) error {
+	if b == nil {
+		return fmt.Errorf("openclaw: nil bridge")
+	}
+	slug := msg.Binding.MemberSlug
+	if slug == "" {
+		return fmt.Errorf("openclaw: Send requires Binding.MemberSlug")
+	}
+	return b.OnOfficeMessage(ctx, slug, msg.Binding.ChannelSlug, msg.Text)
+}
+
+// Health returns a point-in-time connectivity snapshot. Reads only the cached
+// health fields under healthMu so it is O(1) and safe to call on every
+// channel-header render (per Transport.Health contract).
+func (b *OpenclawBridge) Health() transport.Health {
+	if b == nil {
+		return transport.Health{State: transport.HealthDisconnected}
+	}
+	b.healthMu.RLock()
+	lastSuccess := b.lastSuccessAt
+	lastErr := b.lastError
+	b.healthMu.RUnlock()
+
+	state := transport.HealthDisconnected
+	if b.breaker != nil && b.breaker.Open() {
+		state = transport.HealthDisconnected
+	} else if !lastSuccess.IsZero() && lastErr == nil {
+		state = transport.HealthConnected
+	} else if !lastSuccess.IsZero() && lastErr != nil {
+		state = transport.HealthDegraded
+	}
+	return transport.Health{
+		State:         state,
+		LastSuccessAt: lastSuccess,
+		LastError:     lastErr,
+	}
+}


### PR DESCRIPTION
## Summary

Phase 3b of the transport-contract migration: `OpenclawBridge` now implements `transport.MemberBoundTransport`. A compile-time assertion in `openclaw_transport.go` guarantees the contract stays satisfied as the interface evolves.

### Signature changes

To match the contract (no ctx, no error):
- `AttachSlug(slug, key)` — was `AttachSlug(ctx, slug, key) error`
- `DetachSlug(slug)` — was `DetachSlug(ctx, slug) error`

HTTP handlers in `broker_office_members.go` that need to surface gateway subscribe failures now call `AttachSlugAndSubscribe` / `DetachSlugAndUnsubscribe` — synchronous, error-returning siblings retained explicitly for that path. The contract-level `AttachSlug`/`DetachSlug` perform a best-effort async subscribe/unsubscribe via the bridge's stored ctx; failures are surfaced via system message rather than returned.

### New Transport methods

- `Name()` → `"openclaw"` (stable adapter identifier)
- `Binding()` → `transport.Binding{Scope: ScopeMember}` — bridge manages many slugs, no static anchor (mirrors Telegram's zero-channel pattern)
- `Run(ctx, host)` → thin shim around `Start` + `Stop` for now; Phase 4 will route inbound assistant messages through `host.ReceiveMessage`
- `Send(ctx, Outbound)` → wraps `OnOfficeMessage`, uses `Binding.MemberSlug` for target and `Binding.ChannelSlug` as reply-routing hint
- `Health()` → reads cached `lastSuccessAt`/`lastError` under `healthMu` (O(1) per contract); supervise loop records both

### Out of scope

- Phase 4 will switch `handleClientEvent` to use `host.ReceiveMessage` instead of the direct broker call.
- `RegisterTransports` still wires the bridge via `StartOpenclawBridgeFromConfig` (unchanged from #639). Migrating it to the host-driven `Run` path is also Phase 4.

## Test plan

- [x] `bash scripts/test-go.sh ./internal/team` green (80s)
- [x] `golangci-lint run ./internal/team/...` 0 issues
- [x] Compile-time `var _ transport.MemberBoundTransport = (*OpenclawBridge)(nil)` satisfied
- [ ] Manual: hire openclaw agent via web UI, verify subscribe still works through `AttachSlugAndSubscribe` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Made subscription attach/detach operations reliable so subscribing/unsubscribing occurs automatically during member attach, update, and removal.
  * Added richer connection health snapshots for clearer Connected/Degraded/Disconnected status.
* **New Features**
  * Registered OpenClaw as a selectable transport with standardized send/run/health behavior to improve message delivery and observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->