### PR TITLE
feat(transport): drive openclaw inbound via host.ReceiveMessage (phase 4)

### DIFF
--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -81,6 +81,7 @@ func RegisterTransports(b *Broker) (func(), error) {
 			ocCancel()
 			<-routerDone // wait for router goroutine to exit before tearing down
 			<-runDone    // bridge.Run returns after Stop; ensures clean broker shutdown
+			b.AttachOpenclawBridge(nil)
 		})
 		log.Printf("[transport] openclaw: started (%d session(s))", len(bridge.SnapshotBindings()))
 	}

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -6,16 +6,10 @@ package team
 // automatically makes it available in both surfaces — you cannot accidentally
 // wire it to one and miss the other.
 //
-// Phase 2b: TelegramTransport satisfies transport.Transport. RegisterTransports
-// constructs a brokerTransportHost and passes it to Run so inbound messages flow
-// through the Host contract instead of writing to the broker directly.
-//
-// Phase 4: OpenClaw bridge is built here via BuildOpenclawBridgeFromConfig and
-// driven via OpenclawBridge.Run with the same brokerTransportHost so inbound
-// assistant messages flow through host.ReceiveMessage. The build returns
-// (nil, nil) when no openclaw members and no gateway URL are configured, so
-// the integration remains strictly opt-in. Future phases will wire human-share
-// via OfficeBoundTransport.
+// Each adapter is driven via Run(ctx, host) on a per-transport goroutine using
+// a shared brokerTransportHost so inbound messages flow through the Host
+// contract instead of writing to the broker directly. Adapters whose
+// configuration is absent are skipped silently; their absence is not an error.
 //
 // See docs/ADD-A-TRANSPORT.md for the full contributor guide.
 
@@ -67,11 +61,7 @@ func RegisterTransports(b *Broker) (func(), error) {
 		}
 	}
 
-	// OpenClaw: build when openclaw members exist or a gateway URL is configured.
-	// BuildOpenclawBridgeFromConfig returns (nil, nil) when neither condition
-	// holds — the bridge is strictly opt-in and its absence is not an error.
-	// Drive via Run(ctx, host) so inbound assistant messages flow through the
-	// transport.Host contract rather than writing to the broker directly.
+	// OpenClaw: opt-in when members exist or a gateway URL is configured.
 	bridge, ocErr := BuildOpenclawBridgeFromConfig(b)
 	if ocErr != nil {
 		log.Printf("[transport] openclaw: bootstrap error — %v", ocErr)

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -10,11 +10,12 @@ package team
 // constructs a brokerTransportHost and passes it to Run so inbound messages flow
 // through the Host contract instead of writing to the broker directly.
 //
-// Phase 3a: OpenClaw bridge is started here via StartOpenclawBridgeFromConfig.
-// It returns (nil, nil) when no openclaw members and no gateway URL are
-// configured, so the integration remains strictly opt-in. Phase 3b will
-// refactor OpenclawBridge onto MemberBoundTransport.
-// Phase 4 will wire human-share via OfficeBoundTransport.
+// Phase 4: OpenClaw bridge is built here via BuildOpenclawBridgeFromConfig and
+// driven via OpenclawBridge.Run with the same brokerTransportHost so inbound
+// assistant messages flow through host.ReceiveMessage. The build returns
+// (nil, nil) when no openclaw members and no gateway URL are configured, so
+// the integration remains strictly opt-in. Future phases will wire human-share
+// via OfficeBoundTransport.
 //
 // See docs/ADD-A-TRANSPORT.md for the full contributor guide.
 
@@ -66,28 +67,35 @@ func RegisterTransports(b *Broker) (func(), error) {
 		}
 	}
 
-	// OpenClaw: start when openclaw members exist or a gateway URL is configured.
-	// StartOpenclawBridgeFromConfig returns (nil, nil) when neither condition
+	// OpenClaw: build when openclaw members exist or a gateway URL is configured.
+	// BuildOpenclawBridgeFromConfig returns (nil, nil) when neither condition
 	// holds — the bridge is strictly opt-in and its absence is not an error.
-	ocCtx, ocCancel := context.WithCancel(context.Background())
-	bridge, ocErr := StartOpenclawBridgeFromConfig(ocCtx, b)
+	// Drive via Run(ctx, host) so inbound assistant messages flow through the
+	// transport.Host contract rather than writing to the broker directly.
+	bridge, ocErr := BuildOpenclawBridgeFromConfig(b)
 	if ocErr != nil {
-		ocCancel()
 		log.Printf("[transport] openclaw: bootstrap error — %v", ocErr)
 	} else if bridge != nil {
 		b.AttachOpenclawBridge(bridge)
+		ocCtx, ocCancel := context.WithCancel(context.Background())
 		routerDone := StartOpenclawRouter(ocCtx, b, bridge)
+		runDone := make(chan struct{})
+		host := &brokerTransportHost{broker: b}
+		go func() {
+			defer close(runDone)
+			if err := bridge.Run(ocCtx, host); err != nil && ocCtx.Err() == nil {
+				log.Printf("[transport] openclaw: exited with error: %v", err)
+			}
+		}()
 		stops = append(stops, func() {
 			ocCancel()
-			<-routerDone // wait for router goroutine to exit before bridge.Stop()
-			bridge.Stop()
+			<-routerDone // wait for router goroutine to exit before tearing down
+			<-runDone    // bridge.Run returns after Stop; ensures clean broker shutdown
 		})
 		log.Printf("[transport] openclaw: started (%d session(s))", len(bridge.SnapshotBindings()))
-	} else {
-		ocCancel()
 	}
 
-	// Phase 4 TODO: start human-share adapter when share is enabled.
+	// Future: wire human-share adapter via OfficeBoundTransport.
 
 	return cleanup, nil
 }

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -67,20 +67,27 @@ func RegisterTransports(b *Broker) (func(), error) {
 		log.Printf("[transport] openclaw: bootstrap error — %v", ocErr)
 	} else if bridge != nil {
 		b.AttachOpenclawBridge(bridge)
-		ocCtx, ocCancel := context.WithCancel(context.Background())
-		routerDone := StartOpenclawRouter(ocCtx, b, bridge)
+		// Router and bridge get independent contexts so the cleanup can drain
+		// the router (in-flight broker writes) before cancelling the bridge.
+		// Sharing one context would let bridge.Run trigger b.Stop() while the
+		// router still has messages mid-flight — exactly the race the
+		// StartOpenclawRouter doc warns against.
+		routerCtx, routerCancel := context.WithCancel(context.Background())
+		bridgeCtx, bridgeCancel := context.WithCancel(context.Background())
+		routerDone := StartOpenclawRouter(routerCtx, b, bridge)
 		runDone := make(chan struct{})
 		host := &brokerTransportHost{broker: b}
 		go func() {
 			defer close(runDone)
-			if err := bridge.Run(ocCtx, host); err != nil && ocCtx.Err() == nil {
+			if err := bridge.Run(bridgeCtx, host); err != nil && bridgeCtx.Err() == nil {
 				log.Printf("[transport] openclaw: exited with error: %v", err)
 			}
 		}()
 		stops = append(stops, func() {
-			ocCancel()
-			<-routerDone // wait for router goroutine to exit before tearing down
-			<-runDone    // bridge.Run returns after Stop; ensures clean broker shutdown
+			routerCancel()
+			<-routerDone // drain router before tearing down the bridge
+			bridgeCancel()
+			<-runDone // bridge.Run returns after Stop; ensures clean broker shutdown
 			b.AttachOpenclawBridge(nil)
 		})
 		log.Printf("[transport] openclaw: started (%d session(s))", len(bridge.SnapshotBindings()))

--- a/internal/team/openclaw.go
+++ b/internal/team/openclaw.go
@@ -632,20 +632,28 @@ func (b *OpenclawBridge) postBridgeMessage(slug, channel, sessionKey, text strin
 	ctx := b.ctx
 	b.mu.RUnlock()
 	if hp := b.host.Load(); hp != nil {
-		err := (*hp).ReceiveMessage(ctx, transport.Message{
-			Participant: transport.Participant{
-				AdapterName: openclawAdapterName,
-				Key:         sessionKey,
-				DisplayName: slug,
-			},
-			Binding: transport.Binding{
-				Scope:       transport.ScopeMember,
-				MemberSlug:  slug,
-				ChannelSlug: channel,
-			},
-			Text: text,
-		})
-		if err != nil && ctx != nil && ctx.Err() == nil {
+		host := *hp
+		participant := transport.Participant{
+			AdapterName: openclawAdapterName,
+			Key:         sessionKey,
+			DisplayName: slug,
+		}
+		binding := transport.Binding{
+			Scope:       transport.ScopeMember,
+			MemberSlug:  slug,
+			ChannelSlug: channel,
+		}
+		if err := host.UpsertParticipant(ctx, participant, binding); err != nil {
+			if ctx != nil && ctx.Err() == nil {
+				b.postSystemMessage(fmt.Sprintf("upsert @%s: %v", slug, err))
+			}
+			return
+		}
+		if err := host.ReceiveMessage(ctx, transport.Message{
+			Participant: participant,
+			Binding:     binding,
+			Text:        text,
+		}); err != nil && ctx != nil && ctx.Err() == nil {
 			b.postSystemMessage(fmt.Sprintf("inbound from @%s: %v", slug, err))
 		}
 		return

--- a/internal/team/openclaw.go
+++ b/internal/team/openclaw.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/nex-crm/wuphf/internal/config"
 	"github.com/nex-crm/wuphf/internal/openclaw"
+	"github.com/nex-crm/wuphf/internal/team/transport"
 )
 
 var defaultOpenclawRetryDelays = []time.Duration{1 * time.Second, 5 * time.Second, 30 * time.Second}
@@ -70,6 +71,37 @@ type OpenclawBridge struct {
 	healthMu      sync.RWMutex
 	lastSuccessAt time.Time
 	lastError     error
+
+	// hostMu guards host. Set once by Run() before the supervised loop calls
+	// handleClientEvent; reads are O(1) on the hot inbound path. When nil,
+	// postBridgeMessage falls back to the direct broker entrypoint so legacy
+	// callers (probes, tests) that drive the bridge via Start() continue to work.
+	hostMu sync.RWMutex
+	host   transport.Host
+}
+
+// attachHost binds a transport.Host to the bridge. Called by Run() before the
+// supervised loop starts so handleClientEvent can route inbound assistant
+// messages through the host contract instead of writing to the broker
+// directly. Idempotent: repeated calls overwrite the host pointer atomically.
+func (b *OpenclawBridge) attachHost(h transport.Host) {
+	if b == nil {
+		return
+	}
+	b.hostMu.Lock()
+	b.host = h
+	b.hostMu.Unlock()
+}
+
+// getHost returns the currently attached transport.Host, or nil when the
+// bridge is being driven via Start() instead of Run().
+func (b *OpenclawBridge) getHost() transport.Host {
+	if b == nil {
+		return nil
+	}
+	b.hostMu.RLock()
+	defer b.hostMu.RUnlock()
+	return b.host
 }
 
 // HasSlug reports whether the given slug is bound to a bridged OpenClaw
@@ -520,7 +552,7 @@ func (b *OpenclawBridge) handleClientEvent(evt openclaw.ClientEvent) {
 			if channel == "" {
 				channel = "general"
 			}
-			b.postBridgeMessage(slug, channel, text)
+			b.postBridgeMessage(slug, channel, evt.SessionMessage.SessionKey, text)
 		}
 	case openclaw.EventKindChanged:
 		if evt.SessionsChanged != nil && evt.SessionsChanged.Reason == "ended" {
@@ -611,14 +643,39 @@ func (b *OpenclawBridge) OnOfficeMessage(ctx context.Context, slug, channel, mes
 	return lastErr
 }
 
-// postBridgeMessage posts a bridged-agent chat message into the given channel
-// via the same broker entrypoint telegram.go uses for incoming chat.
-func (b *OpenclawBridge) postBridgeMessage(slug, channel, text string) {
-	if b.broker == nil {
-		return
-	}
+// postBridgeMessage posts a bridged-agent chat message into the given channel.
+// Prefers the transport.Host contract (set by Run) so the host owns the
+// per-transport worker boundary; falls back to the direct broker entrypoint
+// when the bridge is being driven via Start (probes, integration tests).
+func (b *OpenclawBridge) postBridgeMessage(slug, channel, sessionKey, text string) {
 	if channel == "" {
 		channel = "general"
+	}
+	if host := b.getHost(); host != nil {
+		ctx := b.ctx
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		err := host.ReceiveMessage(ctx, transport.Message{
+			Participant: transport.Participant{
+				AdapterName: openclawAdapterName,
+				Key:         sessionKey,
+				DisplayName: slug,
+			},
+			Binding: transport.Binding{
+				Scope:       transport.ScopeMember,
+				MemberSlug:  slug,
+				ChannelSlug: channel,
+			},
+			Text: text,
+		})
+		if err != nil && b.ctx != nil && b.ctx.Err() == nil {
+			b.postSystemMessage(fmt.Sprintf("inbound from @%s: %v", slug, err))
+		}
+		return
+	}
+	if b.broker == nil {
+		return
 	}
 	_, _ = b.broker.PostInboundSurfaceMessage(slug, channel, text, "openclaw")
 }

--- a/internal/team/openclaw.go
+++ b/internal/team/openclaw.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -72,36 +74,11 @@ type OpenclawBridge struct {
 	lastSuccessAt time.Time
 	lastError     error
 
-	// hostMu guards host. Set once by Run() before the supervised loop calls
-	// handleClientEvent; reads are O(1) on the hot inbound path. When nil,
-	// postBridgeMessage falls back to the direct broker entrypoint so legacy
-	// callers (probes, tests) that drive the bridge via Start() continue to work.
-	hostMu sync.RWMutex
-	host   transport.Host
-}
-
-// attachHost binds a transport.Host to the bridge. Called by Run() before the
-// supervised loop starts so handleClientEvent can route inbound assistant
-// messages through the host contract instead of writing to the broker
-// directly. Idempotent: repeated calls overwrite the host pointer atomically.
-func (b *OpenclawBridge) attachHost(h transport.Host) {
-	if b == nil {
-		return
-	}
-	b.hostMu.Lock()
-	b.host = h
-	b.hostMu.Unlock()
-}
-
-// getHost returns the currently attached transport.Host, or nil when the
-// bridge is being driven via Start() instead of Run().
-func (b *OpenclawBridge) getHost() transport.Host {
-	if b == nil {
-		return nil
-	}
-	b.hostMu.RLock()
-	defer b.hostMu.RUnlock()
-	return b.host
+	// host is set once by Run before the supervised loop starts. A nil load
+	// means the bridge was driven via Start (probes, integration tests) rather
+	// than Run, in which case postBridgeMessage falls back to the direct broker
+	// entrypoint.
+	host atomic.Pointer[transport.Host]
 }
 
 // HasSlug reports whether the given slug is bound to a bridged OpenClaw
@@ -651,12 +628,11 @@ func (b *OpenclawBridge) postBridgeMessage(slug, channel, sessionKey, text strin
 	if channel == "" {
 		channel = "general"
 	}
-	if host := b.getHost(); host != nil {
-		ctx := b.ctx
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		err := host.ReceiveMessage(ctx, transport.Message{
+	b.mu.RLock()
+	ctx := b.ctx
+	b.mu.RUnlock()
+	if hp := b.host.Load(); hp != nil {
+		err := (*hp).ReceiveMessage(ctx, transport.Message{
 			Participant: transport.Participant{
 				AdapterName: openclawAdapterName,
 				Key:         sessionKey,
@@ -669,7 +645,7 @@ func (b *OpenclawBridge) postBridgeMessage(slug, channel, sessionKey, text strin
 			},
 			Text: text,
 		})
-		if err != nil && b.ctx != nil && b.ctx.Err() == nil {
+		if err != nil && ctx != nil && ctx.Err() == nil {
 			b.postSystemMessage(fmt.Sprintf("inbound from @%s: %v", slug, err))
 		}
 		return
@@ -677,7 +653,9 @@ func (b *OpenclawBridge) postBridgeMessage(slug, channel, sessionKey, text strin
 	if b.broker == nil {
 		return
 	}
-	_, _ = b.broker.PostInboundSurfaceMessage(slug, channel, text, "openclaw")
+	if _, err := b.broker.PostInboundSurfaceMessage(slug, channel, text, "openclaw"); err != nil {
+		log.Printf("[openclaw] postBridgeMessage: broker rejected message for @%s in #%s: %v", slug, channel, err)
+	}
 }
 
 // postSystemMessage posts a `system`-authored notice into #general.

--- a/internal/team/openclaw_bootstrap.go
+++ b/internal/team/openclaw_bootstrap.go
@@ -88,10 +88,11 @@ func BuildOpenclawBridgeFromConfig(broker *Broker) (*OpenclawBridge, error) {
 	return NewOpenclawBridgeWithDialer(broker, nil, dialer, bindings), nil
 }
 
-// StartOpenclawBridgeFromConfig is the legacy direct-Start entrypoint kept for
-// probe binaries and integration tests that drive the bridge without the
-// host-driven Run() path. The production launcher uses [BuildOpenclawBridgeFromConfig]
-// + [OpenclawBridge.Run] instead so inbound messages flow through transport.Host.
+// StartOpenclawBridgeFromConfig builds the bridge and Starts it directly,
+// bypassing transport.Host attachment. Inbound messages route via
+// broker.PostInboundSurfaceMessage rather than host.ReceiveMessage. Use
+// [BuildOpenclawBridgeFromConfig] + [OpenclawBridge.Run] to opt into the
+// host-driven path.
 func StartOpenclawBridgeFromConfig(ctx context.Context, broker *Broker) (*OpenclawBridge, error) {
 	bridge, err := BuildOpenclawBridgeFromConfig(broker)
 	if err != nil || bridge == nil {

--- a/internal/team/openclaw_bootstrap.go
+++ b/internal/team/openclaw_bootstrap.go
@@ -15,14 +15,16 @@ import (
 // used instead of dialing the real gateway. Never set in production paths.
 var openclawBootstrapDialer openclawDialer
 
-// StartOpenclawBridgeFromConfig reads persisted OpenClaw bridge bindings from
-// config and, if any are configured, dials the gateway and starts a supervised
+// BuildOpenclawBridgeFromConfig reads persisted OpenClaw bridge bindings from
+// config and, if any are configured, constructs (but does not Start) an
 // OpenclawBridge. Returns (nil, nil) when no bindings are configured so callers
 // can treat the integration as strictly opt-in.
 //
-// The returned bridge's Stop should be called at shutdown to drain the event
-// loop and close the gateway connection cleanly.
-func StartOpenclawBridgeFromConfig(ctx context.Context, broker *Broker) (*OpenclawBridge, error) {
+// Build is the host-driven entrypoint: callers (the launcher) own the bridge
+// lifecycle via [OpenclawBridge.Run], which attaches a transport.Host before
+// the supervised loop starts. The legacy [StartOpenclawBridgeFromConfig] wraps
+// Build + Start for callers that drive the bridge directly (probes, tests).
+func BuildOpenclawBridgeFromConfig(broker *Broker) (*OpenclawBridge, error) {
 	if broker == nil {
 		return nil, fmt.Errorf("openclaw bootstrap: broker is required")
 	}
@@ -60,7 +62,7 @@ func StartOpenclawBridgeFromConfig(ctx context.Context, broker *Broker) (*Opencl
 		bridged = append(bridged, bridgedSlug{Slug: m.Slug, SessionKey: m.Provider.Openclaw.SessionKey})
 	}
 
-	// Decide whether to start the bridge. We start it when EITHER there are
+	// Decide whether to build the bridge. We build it when EITHER there are
 	// already openclaw members (the classic case) OR the gateway is reachable
 	// via configured URL + token (so /office-members POST can live-hire a new
 	// openclaw agent without requiring a pre-existing one). Without this, the
@@ -83,7 +85,18 @@ func StartOpenclawBridgeFromConfig(ctx context.Context, broker *Broker) (*Opencl
 	for _, b := range bridged {
 		bindings = append(bindings, config.OpenclawBridgeBinding{Slug: b.Slug, SessionKey: b.SessionKey})
 	}
-	bridge := NewOpenclawBridgeWithDialer(broker, nil, dialer, bindings)
+	return NewOpenclawBridgeWithDialer(broker, nil, dialer, bindings), nil
+}
+
+// StartOpenclawBridgeFromConfig is the legacy direct-Start entrypoint kept for
+// probe binaries and integration tests that drive the bridge without the
+// host-driven Run() path. The production launcher uses [BuildOpenclawBridgeFromConfig]
+// + [OpenclawBridge.Run] instead so inbound messages flow through transport.Host.
+func StartOpenclawBridgeFromConfig(ctx context.Context, broker *Broker) (*OpenclawBridge, error) {
+	bridge, err := BuildOpenclawBridgeFromConfig(broker)
+	if err != nil || bridge == nil {
+		return bridge, err
+	}
 	if err := bridge.Start(ctx); err != nil {
 		return nil, fmt.Errorf("openclaw bridge start: %w", err)
 	}

--- a/internal/team/openclaw_host_test.go
+++ b/internal/team/openclaw_host_test.go
@@ -14,18 +14,29 @@ import (
 
 // fakeHost captures every ReceiveMessage call so tests can assert the bridge
 // routes inbound assistant events through transport.Host with the expected
-// Participant + Binding fields.
+// Participant + Binding fields. Each ReceiveMessage call also signals on
+// `received` so callers can wait deterministically without polling.
 type fakeHost struct {
 	mu       sync.Mutex
-	received []transport.Message
+	messages []transport.Message
 	err      error
+	received chan struct{}
+}
+
+func newFakeHost() *fakeHost {
+	return &fakeHost{received: make(chan struct{}, 8)}
 }
 
 func (h *fakeHost) ReceiveMessage(_ context.Context, msg transport.Message) error {
 	h.mu.Lock()
-	defer h.mu.Unlock()
-	h.received = append(h.received, msg)
-	return h.err
+	h.messages = append(h.messages, msg)
+	err := h.err
+	h.mu.Unlock()
+	select {
+	case h.received <- struct{}{}:
+	default:
+	}
+	return err
 }
 
 func (h *fakeHost) UpsertParticipant(context.Context, transport.Participant, transport.Binding) error {
@@ -39,9 +50,39 @@ func (h *fakeHost) RevokeParticipant(context.Context, string, string) error { re
 func (h *fakeHost) snapshot() []transport.Message {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	out := make([]transport.Message, len(h.received))
-	copy(out, h.received)
+	out := make([]transport.Message, len(h.messages))
+	copy(out, h.messages)
 	return out
+}
+
+// waitForFakeOCSubscribe blocks until the fake openclaw client has recorded at
+// least one Subscribe call or the deadline fires. The fakeOCClient already
+// exposes a subscribeHook; install one that closes a channel so callers can
+// rendezvous deterministically instead of polling fake.subscribed in a loop.
+func waitForFakeOCSubscribe(t *testing.T, fake *fakeOCClient, timeout time.Duration) {
+	t.Helper()
+	subscribed := make(chan struct{}, 1)
+	fake.mu.Lock()
+	prior := fake.subscribeHook
+	fake.subscribeHook = func() {
+		if prior != nil {
+			prior()
+		}
+		select {
+		case subscribed <- struct{}{}:
+		default:
+		}
+	}
+	already := len(fake.subscribed) > 0
+	fake.mu.Unlock()
+	if already {
+		return
+	}
+	select {
+	case <-subscribed:
+	case <-time.After(timeout):
+		t.Fatalf("fake openclaw never received Subscribe within %s", timeout)
+	}
 }
 
 // TestPostBridgeMessageRoutesToHost confirms that when a transport.Host is
@@ -54,7 +95,7 @@ func TestPostBridgeMessageRoutesToHost(t *testing.T) {
 	broker := newTestBroker(t)
 	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k-host", Slug: "openclaw-host"}}
 	bridge := NewOpenclawBridge(broker, fake, bindings)
-	host := &fakeHost{}
+	host := newFakeHost()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -62,18 +103,9 @@ func TestPostBridgeMessageRoutesToHost(t *testing.T) {
 	runErr := make(chan error, 1)
 	go func() { runErr <- bridge.Run(ctx, host) }()
 
-	// Wait until the supervised loop subscribes the seeded binding so the
+	// Block until the supervised loop subscribes the seeded binding so the
 	// assistant event is not racing the initial subscribe.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		fake.mu.Lock()
-		ready := len(fake.subscribed) > 0
-		fake.mu.Unlock()
-		if ready {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	waitForFakeOCSubscribe(t, fake, time.Second)
 
 	beforeBroker := len(broker.AllMessages())
 
@@ -88,14 +120,12 @@ func TestPostBridgeMessageRoutesToHost(t *testing.T) {
 		},
 	}
 
-	// Poll until ReceiveMessage is observed; bounded so a regression that
-	// silently routes through the broker fails fast.
-	hostDeadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(hostDeadline) {
-		if len(host.snapshot()) > 0 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	// Wait for ReceiveMessage; bounded so a regression that silently routes
+	// through the broker fails fast rather than hitting the test timeout.
+	select {
+	case <-host.received:
+	case <-time.After(time.Second):
+		t.Fatalf("host.ReceiveMessage was not called within 1s; broker had %d msgs", len(broker.AllMessages())-beforeBroker)
 	}
 
 	got := host.snapshot()
@@ -172,17 +202,8 @@ func TestRegisterTransportsShutdownOrdering(t *testing.T) {
 		t.Fatalf("RegisterTransports: %v", err)
 	}
 
-	// Wait until the bridge has subscribed so we know Run actually started.
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		fake.mu.Lock()
-		ready := len(fake.subscribed) > 0
-		fake.mu.Unlock()
-		if ready {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	// Block until the bridge has subscribed so we know Run actually started.
+	waitForFakeOCSubscribe(t, fake, time.Second)
 
 	done := make(chan struct{})
 	go func() {

--- a/internal/team/openclaw_host_test.go
+++ b/internal/team/openclaw_host_test.go
@@ -14,21 +14,40 @@ import (
 
 // fakeHost captures every ReceiveMessage call so tests can assert the bridge
 // routes inbound assistant events through transport.Host with the expected
-// Participant + Binding fields. Each ReceiveMessage call also signals on
-// `received` so callers can wait deterministically without polling.
+// Participant + Binding fields. It enforces the Host contract: ReceiveMessage
+// returns transport.ErrParticipantUnknown until UpsertParticipant has been
+// called for the participant, so a regression that drops the upsert call would
+// surface as a test failure rather than a silent contract violation. Each
+// ReceiveMessage call also signals on `received` so callers can wait
+// deterministically without polling.
 type fakeHost struct {
 	mu       sync.Mutex
 	messages []transport.Message
+	upserted map[string]struct{}
 	err      error
 	received chan struct{}
 }
 
 func newFakeHost() *fakeHost {
-	return &fakeHost{received: make(chan struct{}, 8)}
+	return &fakeHost{
+		upserted: make(map[string]struct{}),
+		received: make(chan struct{}, 8),
+	}
+}
+
+// participantKey is the shape used to detect "did you call UpsertParticipant
+// for this identity yet?". \x00 separator avoids any chance of collision
+// between adapter names and keys.
+func participantKey(p transport.Participant) string {
+	return p.AdapterName + "\x00" + p.Key
 }
 
 func (h *fakeHost) ReceiveMessage(_ context.Context, msg transport.Message) error {
 	h.mu.Lock()
+	if _, ok := h.upserted[participantKey(msg.Participant)]; !ok {
+		h.mu.Unlock()
+		return transport.ErrParticipantUnknown
+	}
 	h.messages = append(h.messages, msg)
 	err := h.err
 	h.mu.Unlock()
@@ -39,7 +58,10 @@ func (h *fakeHost) ReceiveMessage(_ context.Context, msg transport.Message) erro
 	return err
 }
 
-func (h *fakeHost) UpsertParticipant(context.Context, transport.Participant, transport.Binding) error {
+func (h *fakeHost) UpsertParticipant(_ context.Context, p transport.Participant, _ transport.Binding) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.upserted[participantKey(p)] = struct{}{}
 	return nil
 }
 

--- a/internal/team/openclaw_host_test.go
+++ b/internal/team/openclaw_host_test.go
@@ -90,7 +90,8 @@ func TestPostBridgeMessageRoutesToHost(t *testing.T) {
 
 	// Poll until ReceiveMessage is observed; bounded so a regression that
 	// silently routes through the broker fails fast.
-	for time.Now().Add(500 * time.Millisecond).After(time.Now()) {
+	hostDeadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(hostDeadline) {
 		if len(host.snapshot()) > 0 {
 			break
 		}
@@ -163,7 +164,7 @@ func TestRegisterTransportsShutdownOrdering(t *testing.T) {
 
 	fake := newFakeOC()
 	openclawBootstrapDialer = func(context.Context) (openclawClient, error) { return fake, nil }
-	defer func() { openclawBootstrapDialer = nil }()
+	t.Cleanup(func() { openclawBootstrapDialer = nil })
 
 	broker := newTestBroker(t)
 	stop, err := RegisterTransports(broker)

--- a/internal/team/openclaw_host_test.go
+++ b/internal/team/openclaw_host_test.go
@@ -177,6 +177,10 @@ func TestPostBridgeMessageRoutesToHost(t *testing.T) {
 		t.Errorf("Binding.ChannelSlug: got %q want %q", msg.Binding.ChannelSlug, "general")
 	}
 
+	if delta := len(broker.AllMessages()) - beforeBroker; delta != 0 {
+		t.Fatalf("broker fallback unexpectedly received %d message(s); host path must not double-deliver", delta)
+	}
+
 	cancel()
 	select {
 	case err := <-runErr:

--- a/internal/team/openclaw_host_test.go
+++ b/internal/team/openclaw_host_test.go
@@ -1,0 +1,197 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/config"
+	"github.com/nex-crm/wuphf/internal/openclaw"
+	"github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// fakeHost captures every ReceiveMessage call so tests can assert the bridge
+// routes inbound assistant events through transport.Host with the expected
+// Participant + Binding fields.
+type fakeHost struct {
+	mu       sync.Mutex
+	received []transport.Message
+	err      error
+}
+
+func (h *fakeHost) ReceiveMessage(_ context.Context, msg transport.Message) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.received = append(h.received, msg)
+	return h.err
+}
+
+func (h *fakeHost) UpsertParticipant(context.Context, transport.Participant, transport.Binding) error {
+	return nil
+}
+
+func (h *fakeHost) DetachParticipant(context.Context, string, string) error { return nil }
+
+func (h *fakeHost) RevokeParticipant(context.Context, string, string) error { return nil }
+
+func (h *fakeHost) snapshot() []transport.Message {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]transport.Message, len(h.received))
+	copy(out, h.received)
+	return out
+}
+
+// TestPostBridgeMessageRoutesToHost confirms that when a transport.Host is
+// attached via Run, an assistant reply lands in host.ReceiveMessage with a
+// fully populated transport.Message rather than going through the broker
+// fallback. Guards against silent regressions in the host branch of
+// postBridgeMessage.
+func TestPostBridgeMessageRoutesToHost(t *testing.T) {
+	fake := newFakeOC()
+	broker := newTestBroker(t)
+	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k-host", Slug: "openclaw-host"}}
+	bridge := NewOpenclawBridge(broker, fake, bindings)
+	host := &fakeHost{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- bridge.Run(ctx, host) }()
+
+	// Wait until the supervised loop subscribes the seeded binding so the
+	// assistant event is not racing the initial subscribe.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		fake.mu.Lock()
+		ready := len(fake.subscribed) > 0
+		fake.mu.Unlock()
+		if ready {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	beforeBroker := len(broker.AllMessages())
+
+	seq := int64(2)
+	fake.events <- openclaw.ClientEvent{
+		Kind: openclaw.EventKindMessage,
+		SessionMessage: &openclaw.SessionMessageEvent{
+			SessionKey:  "k-host",
+			MessageSeq:  &seq,
+			Role:        "assistant",
+			MessageText: "host-routed reply",
+		},
+	}
+
+	// Poll until ReceiveMessage is observed; bounded so a regression that
+	// silently routes through the broker fails fast.
+	for time.Now().Add(500 * time.Millisecond).After(time.Now()) {
+		if len(host.snapshot()) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	got := host.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("host.ReceiveMessage call count: got %d want 1; broker had %d msgs", len(got), len(broker.AllMessages())-beforeBroker)
+	}
+	msg := got[0]
+	if msg.Text != "host-routed reply" {
+		t.Errorf("Text: got %q want %q", msg.Text, "host-routed reply")
+	}
+	if msg.Participant.AdapterName != openclawAdapterName {
+		t.Errorf("Participant.AdapterName: got %q want %q", msg.Participant.AdapterName, openclawAdapterName)
+	}
+	if msg.Participant.Key != "k-host" {
+		t.Errorf("Participant.Key: got %q want %q", msg.Participant.Key, "k-host")
+	}
+	if msg.Participant.DisplayName != "openclaw-host" {
+		t.Errorf("Participant.DisplayName: got %q want %q", msg.Participant.DisplayName, "openclaw-host")
+	}
+	if msg.Binding.Scope != transport.ScopeMember {
+		t.Errorf("Binding.Scope: got %q want %q", msg.Binding.Scope, transport.ScopeMember)
+	}
+	if msg.Binding.MemberSlug != "openclaw-host" {
+		t.Errorf("Binding.MemberSlug: got %q want %q", msg.Binding.MemberSlug, "openclaw-host")
+	}
+	if msg.Binding.ChannelSlug != "general" {
+		t.Errorf("Binding.ChannelSlug: got %q want %q", msg.Binding.ChannelSlug, "general")
+	}
+
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// TestOpenclawBridgeRunRequiresHost confirms Run rejects a nil host so a
+// misconfigured launcher fails loudly instead of silently degrading to the
+// legacy broker entrypoint.
+func TestOpenclawBridgeRunRequiresHost(t *testing.T) {
+	bridge := NewOpenclawBridge(newTestBroker(t), newFakeOC(), nil)
+	err := bridge.Run(context.Background(), nil)
+	if err == nil {
+		t.Fatal("Run(nil host) returned nil error; want guard error")
+	}
+}
+
+// TestRegisterTransportsShutdownOrdering wires the openclaw bridge through
+// RegisterTransports + Run(ctx, host) and confirms the returned cleanup
+// drains both the router and the Run goroutines without deadlocking.
+func TestRegisterTransportsShutdownOrdering(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	cfg := config.Config{
+		OpenclawBridges: []config.OpenclawBridgeBinding{
+			{SessionKey: "shutdown-k", Slug: "openclaw-shutdown", DisplayName: "Shutdown"},
+		},
+	}
+	if err := config.Save(cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	fake := newFakeOC()
+	openclawBootstrapDialer = func(context.Context) (openclawClient, error) { return fake, nil }
+	defer func() { openclawBootstrapDialer = nil }()
+
+	broker := newTestBroker(t)
+	stop, err := RegisterTransports(broker)
+	if err != nil {
+		t.Fatalf("RegisterTransports: %v", err)
+	}
+
+	// Wait until the bridge has subscribed so we know Run actually started.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		fake.mu.Lock()
+		ready := len(fake.subscribed) > 0
+		fake.mu.Unlock()
+		if ready {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RegisterTransports cleanup did not return within 2s; router or Run goroutine deadlocked")
+	}
+}

--- a/internal/team/openclaw_transport.go
+++ b/internal/team/openclaw_transport.go
@@ -42,14 +42,15 @@ func (b *OpenclawBridge) Binding() transport.Binding {
 }
 
 // Run starts the supervised bridge and blocks until ctx is cancelled. The
-// host parameter is currently unused — Phase 4 will route inbound assistant
-// messages through host.ReceiveMessage instead of the direct broker call in
-// handleClientEvent. For now Run preserves the existing supervised-loop
-// behavior so RegisterTransports can drive both lifecycle paths uniformly.
-func (b *OpenclawBridge) Run(ctx context.Context, _ transport.Host) error {
+// host is attached before Start so handleClientEvent routes inbound assistant
+// messages through host.ReceiveMessage instead of writing to the broker
+// directly. Callers that drive the bridge via Start (probes, integration
+// tests) bypass the host and fall back to the legacy broker entrypoint.
+func (b *OpenclawBridge) Run(ctx context.Context, host transport.Host) error {
 	if b == nil {
 		return fmt.Errorf("openclaw: nil bridge")
 	}
+	b.attachHost(host)
 	if err := b.Start(ctx); err != nil {
 		return err
 	}

--- a/internal/team/openclaw_transport.go
+++ b/internal/team/openclaw_transport.go
@@ -1,17 +1,17 @@
 package team
 
 // openclaw_transport.go implements transport.MemberBoundTransport on
-// OpenclawBridge. This is the Phase 3b adapter contract — Name/Binding/Run/
-// Send/Health satisfy the base Transport interface; AttachSlug, DetachSlug,
-// and CreateSession satisfy the member-bound extension. The contract-level
-// AttachSlug/DetachSlug are defined in openclaw.go alongside their
-// synchronous error-returning siblings (AttachSlugAndSubscribe /
-// DetachSlugAndUnsubscribe) used by HTTP handlers.
+// OpenclawBridge. Name/Binding/Run/Send/Health satisfy the base Transport
+// interface; AttachSlug, DetachSlug, and CreateSession satisfy the
+// member-bound extension. The contract-level AttachSlug/DetachSlug are defined
+// in openclaw.go alongside their synchronous error-returning siblings
+// (AttachSlugAndSubscribe / DetachSlugAndUnsubscribe) used by HTTP handlers.
 //
-// Phase 4 will move the launcher's StartOpenclawBridgeFromConfig wiring onto
-// the Host contract via Run(); for now Run() is a thin shim around the
-// existing supervised loop so RegisterTransports can treat the bridge like
-// any other Transport implementation.
+// Run is the host-driven entrypoint: it stores the supplied transport.Host on
+// the bridge before Start so handleClientEvent routes inbound messages through
+// host.ReceiveMessage. The legacy Start entrypoint remains for probe binaries
+// and integration tests, in which case postBridgeMessage falls back to writing
+// to the broker directly.
 
 import (
 	"context"
@@ -44,13 +44,16 @@ func (b *OpenclawBridge) Binding() transport.Binding {
 // Run starts the supervised bridge and blocks until ctx is cancelled. The
 // host is attached before Start so handleClientEvent routes inbound assistant
 // messages through host.ReceiveMessage instead of writing to the broker
-// directly. Callers that drive the bridge via Start (probes, integration
-// tests) bypass the host and fall back to the legacy broker entrypoint.
+// directly. A nil host is rejected so a misconfigured launcher fails loudly
+// rather than silently degrading to the legacy broker entrypoint.
 func (b *OpenclawBridge) Run(ctx context.Context, host transport.Host) error {
 	if b == nil {
 		return fmt.Errorf("openclaw: nil bridge")
 	}
-	b.attachHost(host)
+	if host == nil {
+		return fmt.Errorf("openclaw: Run requires a non-nil host")
+	}
+	b.host.Store(&host)
 	if err := b.Start(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Routes OpenClaw assistant replies through `transport.Host.ReceiveMessage` instead of the direct `broker.PostInboundSurfaceMessage` call so the bridge follows the same contract as Telegram (channel-bound) and the future human-share adapter (office-bound).
- Splits the bootstrap into `BuildOpenclawBridgeFromConfig` (unstarted, host-driven) and a thin `StartOpenclawBridgeFromConfig` shim that preserves legacy Start-driven callers (`cmd/wuphf-oc-probe/*`, integration tests).
- `RegisterTransports` now drives the bridge via `bridge.Run(ctx, host)` with the same `brokerTransportHost` used for Telegram.

## Why
Phase 4 of the transport-contract migration. Removes the last channel-bound adapter that bypassed the Host contract on the inbound path, eliminating the asymmetry between Telegram (Host-driven) and OpenClaw (broker-direct). Sets the precedent for the next slice (`OfficeBoundTransport` for human-share).

## Behavior preserved
- `getHost()` is nil when the bridge is driven via `Start()` (probe binaries, integration tests), in which case `postBridgeMessage` falls back to the existing `broker.PostInboundSurfaceMessage` path. This keeps `cmd/wuphf-oc-probe/{bridge,pack}` working without changes.
- `Health()` still reads cached fields under `healthMu` and is O(1).
- `AttachSlug`/`DetachSlug` semantics from PR #642 (race-safe + nil-client error in the synchronous variants) untouched.

## Verification
- `go build ./...` clean
- `bash scripts/test-go.sh ./internal/team` green in 89s
- `go vet ./...` clean
- `golangci-lint run ./internal/team/...` reports 0 issues
- Compile-time assertion `var _ transport.MemberBoundTransport = (*OpenclawBridge)(nil)` still satisfied

## Test plan
- [ ] Boot WUPHF with an OpenClaw gateway configured; confirm assistant replies still land in the same channel as before.
- [ ] Hire a new OpenClaw agent via `POST /office-members`; confirm the AttachSlug subscribe still surfaces 502 on gateway failure.
- [ ] Run `cmd/wuphf-oc-probe/bridge` and `cmd/wuphf-oc-probe/pack` against a live gateway; both should still post replies into `#general` via the legacy fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * OpenClaw bridge is now strictly opt-in and can route assistant replies through a configurable host, with broker delivery as a fallback for better integration and observability.
  * Startup/shutdown ordering refined to attach, monitor, and detach the bridge cleanly, reducing race conditions during teardown.
* **Bug Fixes**
  * Bootstrap failures are logged without cancelling unrelated contexts; delivery failures surface as system messages when active.
* **Tests**
  * Added tests for host routing, required-host validation, and shutdown ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->