### PR TITLE
feat(web): React-based team-member invite acceptance

### DIFF
--- a/cmd/wuphf/share.go
+++ b/cmd/wuphf/share.go
@@ -493,11 +493,22 @@ type shareJoinError struct {
 	Message string `json:"message"`
 }
 
+// maxShareJoinBodyBytes caps the unauthenticated POST body so a stranger
+// holding only an invite link cannot exhaust memory by streaming gigabytes
+// into the JSON decoder. 8 KiB is ample for a display_name payload.
+const maxShareJoinBodyBytes = 8 << 10
+
 func handleShareJoinSubmit(w http.ResponseWriter, r *http.Request, brokerURL, token string, onJoin func()) {
 	var submission struct {
 		DisplayName string `json:"display_name"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&submission); err != nil {
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxShareJoinBodyBytes))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&submission); err != nil {
+		writeShareJoinError(w, http.StatusBadRequest, "invalid_request", "We could not read your invite submission. Reload and try again.")
+		return
+	}
+	if err := dec.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
 		writeShareJoinError(w, http.StatusBadRequest, "invalid_request", "We could not read your invite submission. Reload and try again.")
 		return
 	}

--- a/cmd/wuphf/share.go
+++ b/cmd/wuphf/share.go
@@ -450,10 +450,8 @@ func newShareHandler(brokerURL, brokerToken string, onJoin func()) http.Handler 
 		}
 		switch r.Method {
 		case http.MethodGet:
-			// Hand off to the React app. The SPA reads ?invite=<token> on
-			// boot and renders the JoinPage. Redirecting (instead of
-			// proxying index.html under /join/) keeps the SPA's relative
-			// asset URLs working without a path rewrite.
+			// Redirect (rather than serve index.html under /join/) so the
+			// SPA's relative asset URLs do not need a path rewrite.
 			http.Redirect(w, r, "/?invite="+url.QueryEscape(token), http.StatusFound)
 		case http.MethodPost:
 			handleShareJoinSubmit(w, r, brokerURL, token, onJoin)
@@ -474,10 +472,27 @@ func newShareHandler(brokerURL, brokerToken string, onJoin func()) http.Handler 
 	return mux
 }
 
-// handleShareJoinSubmit accepts a JSON {display_name} body, exchanges it with
-// the broker for a human session cookie, and returns a JSON envelope the
-// React JoinPage consumes. Errors map to a stable error code so the client
-// can render specific copy per state without re-parsing prose.
+// shareJoinRedirect is the post-acceptance landing path for a freshly
+// invited team member. Lives next to the broker exchange so renaming the
+// route updates the response shape in one place.
+const shareJoinRedirect = "/#/channels/general"
+
+// shareJoinSuccess and shareJoinError mirror the joiner-side
+// JoinInviteSuccess/JoinInviteFailure types in
+// web/src/api/joinInvite.ts. Keep the JSON tags and the field set in sync
+// with that file. Error codes are the closed set the React client
+// recognises; anything else collapses to "unknown" client-side.
+type shareJoinSuccess struct {
+	OK          bool   `json:"ok"`
+	Redirect    string `json:"redirect"`
+	DisplayName string `json:"display_name"`
+}
+
+type shareJoinError struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}
+
 func handleShareJoinSubmit(w http.ResponseWriter, r *http.Request, brokerURL, token string, onJoin func()) {
 	var submission struct {
 		DisplayName string `json:"display_name"`
@@ -490,11 +505,15 @@ func handleShareJoinSubmit(w http.ResponseWriter, r *http.Request, brokerURL, to
 	if displayName == "" {
 		displayName = "Team member"
 	}
-	payload, _ := json.Marshal(map[string]string{
+	payload, err := json.Marshal(map[string]string{
 		"token":        token,
 		"display_name": displayName,
 		"device":       r.UserAgent(),
 	})
+	if err != nil {
+		writeShareJoinError(w, http.StatusInternalServerError, "invalid_request", "WUPHF could not encode your invite submission.")
+		return
+	}
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, brokerURL+"/humans/invites/accept", bytes.NewReader(payload))
 	if err != nil {
 		writeShareJoinError(w, http.StatusBadGateway, "broker_unreachable", "WUPHF is not reachable from this invite. Ask the host to restart sharing.")
@@ -526,20 +545,17 @@ func handleShareJoinSubmit(w http.ResponseWriter, r *http.Request, brokerURL, to
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(map[string]any{
-		"ok":           true,
-		"redirect":     "/#/channels/general",
-		"display_name": displayName,
+	_ = json.NewEncoder(w).Encode(shareJoinSuccess{
+		OK:          true,
+		Redirect:    shareJoinRedirect,
+		DisplayName: displayName,
 	})
 }
 
 func writeShareJoinError(w http.ResponseWriter, status int, code, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{
-		"error":   code,
-		"message": message,
-	})
+	_ = json.NewEncoder(w).Encode(shareJoinError{Error: code, Message: message})
 }
 
 func shareRequestHasSession(r *http.Request, brokerURL string) bool {

--- a/cmd/wuphf/share.go
+++ b/cmd/wuphf/share.go
@@ -7,10 +7,10 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"html"
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -448,58 +448,18 @@ func newShareHandler(brokerURL, brokerToken string, onJoin func()) http.Handler 
 			http.Error(w, "invite token required", http.StatusBadRequest)
 			return
 		}
-		if r.Method == http.MethodGet {
-			writeShareJoinPage(w, http.StatusOK, token, "")
-			return
-		}
-		if r.Method != http.MethodPost {
+		switch r.Method {
+		case http.MethodGet:
+			// Hand off to the React app. The SPA reads ?invite=<token> on
+			// boot and renders the JoinPage. Redirecting (instead of
+			// proxying index.html under /join/) keeps the SPA's relative
+			// asset URLs working without a path rewrite.
+			http.Redirect(w, r, "/?invite="+url.QueryEscape(token), http.StatusFound)
+		case http.MethodPost:
+			handleShareJoinSubmit(w, r, brokerURL, token, onJoin)
+		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-			return
 		}
-		if err := r.ParseForm(); err != nil {
-			writeShareJoinPage(w, http.StatusBadRequest, token, "Could not read the form. Reload the invite and try again.")
-			return
-		}
-		displayName := strings.TrimSpace(r.FormValue("display_name"))
-		if displayName == "" {
-			displayName = "Team member"
-		}
-		body := map[string]string{
-			"token":        token,
-			"display_name": displayName,
-			"device":       r.UserAgent(),
-		}
-		raw, _ := json.Marshal(body)
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, brokerURL+"/humans/invites/accept", bytes.NewReader(raw))
-		if err != nil {
-			http.Error(w, "invite failed", http.StatusBadGateway)
-			return
-		}
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := shareHTTPClient.Do(req)
-		if err != nil {
-			writeShareJoinPage(w, http.StatusBadGateway, token, "WUPHF is not reachable from this invite. Ask the host to restart sharing.")
-			return
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			switch {
-			case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone:
-				writeShareJoinPage(w, http.StatusGone, token, "This invite is no longer valid. Ask the host for a new team-member invite.")
-			case resp.StatusCode >= 500:
-				writeShareJoinPage(w, http.StatusBadGateway, token, "WUPHF could not accept this invite right now. Ask the host to retry sharing.")
-			default:
-				writeShareJoinPage(w, resp.StatusCode, token, "This invite could not be accepted. Ask the host for a fresh team-member invite.")
-			}
-			return
-		}
-		for _, cookie := range resp.Cookies() {
-			http.SetCookie(w, cookie)
-		}
-		if onJoin != nil {
-			onJoin()
-		}
-		http.Redirect(w, r, "/#/channels/general", http.StatusFound)
 	})
 	mux.HandleFunc("/api-token", func(w http.ResponseWriter, r *http.Request) {
 		if !shareRequestHasSession(r, brokerURL) {
@@ -514,54 +474,72 @@ func newShareHandler(brokerURL, brokerToken string, onJoin func()) http.Handler 
 	return mux
 }
 
-func writeShareJoinPage(w http.ResponseWriter, status int, token, errorMessage string) {
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if status > 0 {
-		w.WriteHeader(status)
+// handleShareJoinSubmit accepts a JSON {display_name} body, exchanges it with
+// the broker for a human session cookie, and returns a JSON envelope the
+// React JoinPage consumes. Errors map to a stable error code so the client
+// can render specific copy per state without re-parsing prose.
+func handleShareJoinSubmit(w http.ResponseWriter, r *http.Request, brokerURL, token string, onJoin func()) {
+	var submission struct {
+		DisplayName string `json:"display_name"`
 	}
-	errorHTML := ""
-	if strings.TrimSpace(errorMessage) != "" {
-		errorHTML = fmt.Sprintf(`<div class="error">%s</div>`, htmlEscape(errorMessage))
+	if err := json.NewDecoder(r.Body).Decode(&submission); err != nil {
+		writeShareJoinError(w, http.StatusBadRequest, "invalid_request", "We could not read your invite submission. Reload and try again.")
+		return
 	}
-	_, _ = fmt.Fprintf(w, `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Join WUPHF</title>
-  <style>
-    :root { color-scheme: light; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
-    body { margin: 0; min-height: 100vh; display: grid; place-items: center; background: #f8f8f9; color: #28292a; }
-    main { width: min(92vw, 460px); background: white; border: 1px solid #e9eaeb; border-radius: 16px; padding: 28px; box-shadow: 0 24px 80px rgba(30, 31, 31, 0.08); }
-    .eyebrow { margin: 0 0 10px; color: #686c6e; font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
-    h1 { margin: 0 0 10px; font-size: 28px; line-height: 1.1; letter-spacing: 0; }
-    p { margin: 0 0 20px; color: #575a5c; line-height: 1.55; }
-    label { display: block; margin: 0 0 8px; font-size: 13px; font-weight: 700; }
-    input { width: 100%%; min-height: 46px; border: 1px solid #cfd1d2; border-radius: 10px; padding: 0 12px; font: inherit; }
-    button { width: 100%%; min-height: 46px; margin-top: 14px; border: 0; border-radius: 999px; background: #28292a; color: white; font: inherit; font-weight: 700; cursor: pointer; }
-    .note { margin-top: 18px; font-size: 12px; color: #85898b; }
-    .error { margin: 0 0 16px; padding: 10px 12px; border-radius: 10px; background: #ffeeeb; color: #8c1727; font-size: 13px; }
-  </style>
-</head>
-<body>
-  <main>
-    <p class="eyebrow">Team member invite</p>
-    <h1>Join this WUPHF office</h1>
-    <p>Use the name your teammate should see in messages, requests, and office activity.</p>
-    %s
-    <form method="post" action="/join/%s">
-      <label for="display_name">Display name</label>
-      <input id="display_name" name="display_name" autocomplete="name" placeholder="e.g. Maya" autofocus>
-      <button type="submit">Enter office</button>
-    </form>
-    <p class="note">This creates a scoped team-member browser session. It does not expose the host's broker token.</p>
-  </main>
-</body>
-</html>`, errorHTML, htmlEscape(token))
+	displayName := strings.TrimSpace(submission.DisplayName)
+	if displayName == "" {
+		displayName = "Team member"
+	}
+	payload, _ := json.Marshal(map[string]string{
+		"token":        token,
+		"display_name": displayName,
+		"device":       r.UserAgent(),
+	})
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, brokerURL+"/humans/invites/accept", bytes.NewReader(payload))
+	if err != nil {
+		writeShareJoinError(w, http.StatusBadGateway, "broker_unreachable", "WUPHF is not reachable from this invite. Ask the host to restart sharing.")
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := shareHTTPClient.Do(req)
+	if err != nil {
+		writeShareJoinError(w, http.StatusBadGateway, "broker_unreachable", "WUPHF is not reachable from this invite. Ask the host to restart sharing.")
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		switch {
+		case resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusGone:
+			writeShareJoinError(w, http.StatusGone, "invite_expired_or_used", "This invite is no longer valid. Ask the host for a new team-member invite.")
+		case resp.StatusCode >= 500:
+			writeShareJoinError(w, http.StatusBadGateway, "broker_failed", "WUPHF could not accept this invite right now. Ask the host to retry sharing.")
+		default:
+			writeShareJoinError(w, resp.StatusCode, "invite_invalid", "This invite could not be accepted. Ask the host for a fresh team-member invite.")
+		}
+		return
+	}
+	for _, cookie := range resp.Cookies() {
+		http.SetCookie(w, cookie)
+	}
+	if onJoin != nil {
+		onJoin()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"ok":           true,
+		"redirect":     "/#/channels/general",
+		"display_name": displayName,
+	})
 }
 
-func htmlEscape(s string) string {
-	return html.EscapeString(s)
+func writeShareJoinError(w http.ResponseWriter, status int, code, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error":   code,
+		"message": message,
+	})
 }
 
 func shareRequestHasSession(r *http.Request, brokerURL string) bool {

--- a/cmd/wuphf/share_test.go
+++ b/cmd/wuphf/share_test.go
@@ -216,6 +216,69 @@ func TestShareJoinMalformedBodyReturnsInvalidRequest(t *testing.T) {
 	}
 }
 
+func TestShareJoinRejectsOversizedBody(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("broker should not be called for oversized body: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(broker.Close)
+
+	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
+	t.Cleanup(shareSrv.Close)
+
+	// Construct a body larger than the 8 KiB cap. The decoder should error
+	// out before ever reaching the broker, so an unauthenticated invite link
+	// cannot be used to stream gigabytes into the share handler.
+	huge := strings.Repeat("a", 16<<10)
+	body := `{"display_name":"` + huge + `"}`
+	req, err := http.NewRequest(http.MethodPost, shareSrv.URL+"/join/abc", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build oversized request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("oversized request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	var errBody struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errBody); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if errBody.Error != "invalid_request" {
+		t.Fatalf("error code = %q, want invalid_request", errBody.Error)
+	}
+}
+
+func TestShareJoinRejectsUnknownFields(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("broker should not be called when unknown fields are present: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(broker.Close)
+
+	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
+	t.Cleanup(shareSrv.Close)
+
+	body := `{"display_name":"Maya","admin":true}`
+	req, err := http.NewRequest(http.MethodPost, shareSrv.URL+"/join/abc", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("unknown-field request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
 func TestShareJoinBrokerFailureReturnsBadGateway(t *testing.T) {
 	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/humans/invites/accept" {

--- a/cmd/wuphf/share_test.go
+++ b/cmd/wuphf/share_test.go
@@ -182,6 +182,40 @@ func TestShareJoinInvalidInviteReturnsGone(t *testing.T) {
 	}
 }
 
+func TestShareJoinMalformedBodyReturnsInvalidRequest(t *testing.T) {
+	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("broker should not be called for malformed body: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(broker.Close)
+
+	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
+	t.Cleanup(shareSrv.Close)
+
+	req, err := http.NewRequest(http.MethodPost, shareSrv.URL+"/join/abc", strings.NewReader("not json"))
+	if err != nil {
+		t.Fatalf("build malformed request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("malformed request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400 body=%s", resp.StatusCode, string(body))
+	}
+	var errBody struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errBody); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if errBody.Error != "invalid_request" {
+		t.Fatalf("error code = %q, want invalid_request", errBody.Error)
+	}
+}
+
 func TestShareJoinBrokerFailureReturnsBadGateway(t *testing.T) {
 	broker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/humans/invites/accept" {

--- a/cmd/wuphf/share_test.go
+++ b/cmd/wuphf/share_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"net"
@@ -11,6 +12,33 @@ import (
 
 	"github.com/nex-crm/wuphf/internal/team"
 )
+
+// joinSubmit posts a JSON invite-acceptance to the share server. Tests use
+// this to exercise the same path the React JoinPage takes.
+func joinSubmit(t *testing.T, client *http.Client, baseURL, token, displayName string) *http.Response {
+	t.Helper()
+	if client == nil {
+		client = http.DefaultClient
+	}
+	body := []byte("{}")
+	if displayName != "" {
+		raw, err := json.Marshal(map[string]string{"display_name": displayName})
+		if err != nil {
+			t.Fatalf("marshal join body: %v", err)
+		}
+		body = raw
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/join/"+token, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("build join request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("join submit: %v", err)
+	}
+	return resp
+}
 
 func TestValidateShareIPAllowsTailscaleByDefault(t *testing.T) {
 	ip := net.ParseIP("100.82.14.6")
@@ -67,24 +95,34 @@ func TestShareJoinFlowEndToEnd(t *testing.T) {
 	}))
 	t.Cleanup(shareSrv.Close)
 
-	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
+	noFollow := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}}
-	resp, err := client.Get(shareSrv.URL + "/join/" + invite.Token)
+	resp, err := noFollow.Get(shareSrv.URL + "/join/" + invite.Token)
 	if err != nil {
 		t.Fatalf("join request: %v", err)
 	}
 	_ = resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("join form status = %d, want 200", resp.StatusCode)
-	}
-	resp, err = client.PostForm(shareSrv.URL+"/join/"+invite.Token, nil)
-	if err != nil {
-		t.Fatalf("join submit: %v", err)
-	}
-	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusFound {
-		t.Fatalf("join status = %d, want 302", resp.StatusCode)
+		t.Fatalf("join GET status = %d, want 302", resp.StatusCode)
+	}
+	if loc := resp.Header.Get("Location"); loc != "/?invite="+invite.Token {
+		t.Fatalf("join GET redirect = %q, want /?invite=%s", loc, invite.Token)
+	}
+	resp = joinSubmit(t, nil, shareSrv.URL, invite.Token, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("join status = %d, want 200", resp.StatusCode)
+	}
+	var submitBody struct {
+		OK       bool   `json:"ok"`
+		Redirect string `json:"redirect"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&submitBody); err != nil {
+		t.Fatalf("decode join response: %v", err)
+	}
+	if !submitBody.OK || submitBody.Redirect != "/#/channels/general" {
+		t.Fatalf("unexpected join body: %+v", submitBody)
 	}
 	if !joined {
 		t.Fatalf("join callback was not called")
@@ -127,14 +165,20 @@ func TestShareJoinInvalidInviteReturnsGone(t *testing.T) {
 	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
 	t.Cleanup(shareSrv.Close)
 
-	resp, err := http.PostForm(shareSrv.URL+"/join/missing-token", nil)
-	if err != nil {
-		t.Fatalf("join submit: %v", err)
-	}
+	resp := joinSubmit(t, nil, shareSrv.URL, "missing-token", "")
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusGone {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("join status = %d, want 410 body=%s", resp.StatusCode, string(body))
+	}
+	var errBody struct {
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errBody); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if errBody.Error != "invite_expired_or_used" {
+		t.Fatalf("error code = %q, want invite_expired_or_used", errBody.Error)
 	}
 }
 
@@ -150,10 +194,7 @@ func TestShareJoinBrokerFailureReturnsBadGateway(t *testing.T) {
 	shareSrv := httptest.NewServer(newShareHandler(broker.URL, "broker-token", nil))
 	t.Cleanup(shareSrv.Close)
 
-	resp, err := http.PostForm(shareSrv.URL+"/join/retry-token", nil)
-	if err != nil {
-		t.Fatalf("join submit: %v", err)
-	}
+	resp := joinSubmit(t, nil, shareSrv.URL, "retry-token", "")
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadGateway {
 		body, _ := io.ReadAll(resp.Body)
@@ -175,13 +216,7 @@ func TestShareProxyDoesNotExposeBrokerToken(t *testing.T) {
 	shareSrv := httptest.NewServer(newShareHandler("http://"+b.Addr(), b.Token(), nil))
 	t.Cleanup(shareSrv.Close)
 
-	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	}}
-	joinResp, err := client.PostForm(shareSrv.URL+"/join/"+invite.Token, nil)
-	if err != nil {
-		t.Fatalf("join request: %v", err)
-	}
+	joinResp := joinSubmit(t, nil, shareSrv.URL, invite.Token, "")
 	_ = joinResp.Body.Close()
 	cookies := joinResp.Cookies()
 	if len(cookies) == 0 {
@@ -320,13 +355,7 @@ func TestShareProxyStampsHumanActor(t *testing.T) {
 	shareSrv := httptest.NewServer(newShareHandler("http://"+b.Addr(), b.Token(), nil))
 	t.Cleanup(shareSrv.Close)
 
-	client := &http.Client{CheckRedirect: func(*http.Request, []*http.Request) error {
-		return http.ErrUseLastResponse
-	}}
-	joinResp, err := client.PostForm(shareSrv.URL+"/join/"+invite.Token, nil)
-	if err != nil {
-		t.Fatalf("join request: %v", err)
-	}
+	joinResp := joinSubmit(t, nil, shareSrv.URL, invite.Token, "")
 	_ = joinResp.Body.Close()
 	cookies := joinResp.Cookies()
 	if len(cookies) == 0 {

--- a/docs/tutorials/share-with-team-member.md
+++ b/docs/tutorials/share-with-team-member.md
@@ -86,7 +86,9 @@ The team member opens the invite URL in a browser:
 http://100.82.14.6:7891/join/wphf_...
 ```
 
-They will see a short join screen. They enter the display name teammates should see in messages and office activity.
+The browser is redirected to the WUPHF web UI in invite-acceptance mode. They see a short join screen and enter the display name teammates should see in messages and office activity.
+
+The join screen surfaces specific copy when the invite is no longer accepting joiners — for example "This invite is no longer valid" if the host already revoked it or someone else accepted it first — so the team member can ask for a fresh invite without guessing.
 
 After submitting, WUPHF redirects them to:
 

--- a/web/src/api/joinInvite.test.ts
+++ b/web/src/api/joinInvite.test.ts
@@ -118,4 +118,26 @@ describe("submitJoinInvite", () => {
       expect(result.code).toBe("unknown");
     }
   });
+
+  it("tells the joiner to reload when the server returns 200 with an unreadable body", async () => {
+    // The broker may have already set the session cookie before the body
+    // got mangled — the user is potentially in, but cannot be told yes.
+    fetchMock.mockResolvedValue(
+      new Response("not json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const result = await submitJoinInvite({
+      token: "abc",
+      displayName: "Maya",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("unknown");
+      expect(result.message).toMatch(/reload/i);
+    }
+  });
 });

--- a/web/src/api/joinInvite.test.ts
+++ b/web/src/api/joinInvite.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { submitJoinInvite } from "./joinInvite";
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("submitJoinInvite", () => {
+  it("posts the trimmed token + display_name with same-origin credentials", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(200, {
+        ok: true,
+        redirect: "/#/channels/general",
+        display_name: "Maya",
+      }),
+    );
+
+    const result = await submitJoinInvite({
+      token: "abc/def",
+      displayName: "Maya",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [path, init] = fetchMock.mock.calls[0];
+    expect(path).toBe("/join/abc%2Fdef");
+    expect(init?.method).toBe("POST");
+    expect(init?.credentials).toBe("same-origin");
+    expect(JSON.parse(init?.body as string)).toEqual({ display_name: "Maya" });
+    expect(result).toEqual({
+      ok: true,
+      redirect: "/#/channels/general",
+      display_name: "Maya",
+    });
+  });
+
+  it("normalises a known server error code", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(410, {
+        error: "invite_expired_or_used",
+        message: "This invite is no longer valid.",
+      }),
+    );
+
+    const result = await submitJoinInvite({
+      token: "expired",
+      displayName: "Maya",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "invite_expired_or_used",
+      message: "This invite is no longer valid.",
+    });
+  });
+
+  it("falls back to 'unknown' when the server returns an unexpected error code", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(418, { error: "teapot", message: "I am a teapot." }),
+    );
+
+    const result = await submitJoinInvite({
+      token: "anything",
+      displayName: "Maya",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      code: "unknown",
+      message: "I am a teapot.",
+    });
+  });
+
+  it("returns a network failure when fetch itself rejects", async () => {
+    fetchMock.mockRejectedValue(new Error("offline"));
+
+    const result = await submitJoinInvite({
+      token: "abc",
+      displayName: "Maya",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("network");
+      expect(result.message).toContain("offline");
+    }
+  });
+
+  it("falls back to 'unknown' when the server returns a non-JSON or malformed response", async () => {
+    fetchMock.mockResolvedValue(
+      new Response("upstream rejected", {
+        status: 502,
+        headers: { "Content-Type": "text/plain" },
+      }),
+    );
+
+    const result = await submitJoinInvite({
+      token: "abc",
+      displayName: "Maya",
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe("unknown");
+    }
+  });
+});

--- a/web/src/api/joinInvite.ts
+++ b/web/src/api/joinInvite.ts
@@ -1,0 +1,131 @@
+// Joiner-side invite acceptance. The host machine's share handler accepts
+// the JSON body, exchanges it for a human session cookie, and returns
+// either {ok, redirect, display_name} or {error, message}.
+//
+// This module deliberately does not use the regular `/api/*` proxy: the
+// joiner has no broker token and no session cookie yet, so the request
+// must hit the share handler's `/join/<token>` endpoint directly.
+
+export type JoinInviteErrorCode =
+  | "invite_expired_or_used"
+  | "invite_invalid"
+  | "broker_unreachable"
+  | "broker_failed"
+  | "invalid_request"
+  | "network"
+  | "unknown";
+
+export interface JoinInviteSuccess {
+  ok: true;
+  redirect: string;
+  display_name: string;
+}
+
+export interface JoinInviteFailure {
+  ok: false;
+  code: JoinInviteErrorCode;
+  message: string;
+}
+
+export type JoinInviteResult = JoinInviteSuccess | JoinInviteFailure;
+
+interface SubmitOptions {
+  token: string;
+  displayName: string;
+  signal?: AbortSignal;
+}
+
+export async function submitJoinInvite({
+  token,
+  displayName,
+  signal,
+}: SubmitOptions): Promise<JoinInviteResult> {
+  let response: Response;
+  try {
+    response = await fetch(`/join/${encodeURIComponent(token)}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ display_name: displayName }),
+      credentials: "same-origin",
+      signal,
+    });
+  } catch (err) {
+    if (signal?.aborted) {
+      return {
+        ok: false,
+        code: "network",
+        message: "Cancelled.",
+      };
+    }
+    return {
+      ok: false,
+      code: "network",
+      message:
+        err instanceof Error && err.message
+          ? `Could not reach WUPHF: ${err.message}`
+          : "Could not reach WUPHF. Check your network and try again.",
+    };
+  }
+
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+
+  if (response.ok && isSuccessBody(body)) {
+    return {
+      ok: true,
+      redirect: body.redirect,
+      display_name: body.display_name,
+    };
+  }
+
+  if (isErrorBody(body)) {
+    return {
+      ok: false,
+      code: normalizeErrorCode(body.error),
+      message: body.message,
+    };
+  }
+
+  return {
+    ok: false,
+    code: "unknown",
+    message: `WUPHF returned an unexpected response (${response.status}). Ask the host for a new invite.`,
+  };
+}
+
+function isSuccessBody(
+  body: unknown,
+): body is { ok: true; redirect: string; display_name: string } {
+  if (!body || typeof body !== "object") return false;
+  const record = body as Record<string, unknown>;
+  return (
+    record.ok === true &&
+    typeof record.redirect === "string" &&
+    typeof record.display_name === "string"
+  );
+}
+
+function isErrorBody(
+  body: unknown,
+): body is { error: string; message: string } {
+  if (!body || typeof body !== "object") return false;
+  const record = body as Record<string, unknown>;
+  return typeof record.error === "string" && typeof record.message === "string";
+}
+
+function normalizeErrorCode(raw: string): JoinInviteErrorCode {
+  switch (raw) {
+    case "invite_expired_or_used":
+    case "invite_invalid":
+    case "broker_unreachable":
+    case "broker_failed":
+    case "invalid_request":
+      return raw;
+    default:
+      return "unknown";
+  }
+}

--- a/web/src/api/joinInvite.ts
+++ b/web/src/api/joinInvite.ts
@@ -1,10 +1,6 @@
-// Joiner-side invite acceptance. The host machine's share handler accepts
-// the JSON body, exchanges it for a human session cookie, and returns
-// either {ok, redirect, display_name} or {error, message}.
-//
-// This module deliberately does not use the regular `/api/*` proxy: the
-// joiner has no broker token and no session cookie yet, so the request
-// must hit the share handler's `/join/<token>` endpoint directly.
+// The joiner has no broker token or session cookie yet, so requests cannot
+// flow through the authenticated `/api/*` share proxy — they must hit the
+// share handler's `/join/<token>` endpoint directly.
 
 export type JoinInviteErrorCode =
   | "invite_expired_or_used"
@@ -14,6 +10,16 @@ export type JoinInviteErrorCode =
   | "invalid_request"
   | "network"
   | "unknown";
+
+// Keep this set in sync with cmd/wuphf/share.go writeShareJoinError. Codes
+// not present here collapse to "unknown" on the client.
+const SERVER_ERROR_CODES: ReadonlySet<JoinInviteErrorCode> = new Set([
+  "invite_expired_or_used",
+  "invite_invalid",
+  "broker_unreachable",
+  "broker_failed",
+  "invalid_request",
+]);
 
 export interface JoinInviteSuccess {
   ok: true;
@@ -51,11 +57,7 @@ export async function submitJoinInvite({
     });
   } catch (err) {
     if (signal?.aborted) {
-      return {
-        ok: false,
-        code: "network",
-        message: "Cancelled.",
-      };
+      return { ok: false, code: "network", message: "Cancelled." };
     }
     return {
       ok: false,
@@ -67,27 +69,57 @@ export async function submitJoinInvite({
     };
   }
 
-  let body: unknown;
+  return interpretJoinResponse(response);
+}
+
+async function interpretJoinResponse(
+  response: Response,
+): Promise<JoinInviteResult> {
+  let body: unknown = null;
   try {
     body = await response.json();
   } catch {
     body = null;
   }
 
-  if (response.ok && isSuccessBody(body)) {
+  const record =
+    body && typeof body === "object" ? (body as Record<string, unknown>) : null;
+
+  if (
+    response.ok &&
+    record?.ok === true &&
+    typeof record.redirect === "string" &&
+    typeof record.display_name === "string"
+  ) {
     return {
       ok: true,
-      redirect: body.redirect,
-      display_name: body.display_name,
+      redirect: record.redirect,
+      display_name: record.display_name,
     };
   }
 
-  if (isErrorBody(body)) {
+  // The broker may have already set a session cookie before the response
+  // body got mangled. Tell the joiner to reload rather than show "unknown".
+  if (response.ok && body === null) {
     return {
       ok: false,
-      code: normalizeErrorCode(body.error),
-      message: body.message,
+      code: "unknown",
+      message:
+        "WUPHF accepted the invite but the response was unreadable. Reload — you may already be in.",
     };
+  }
+
+  if (
+    record &&
+    typeof record.error === "string" &&
+    typeof record.message === "string"
+  ) {
+    const code: JoinInviteErrorCode = SERVER_ERROR_CODES.has(
+      record.error as JoinInviteErrorCode,
+    )
+      ? (record.error as JoinInviteErrorCode)
+      : "unknown";
+    return { ok: false, code, message: record.message };
   }
 
   return {
@@ -95,37 +127,4 @@ export async function submitJoinInvite({
     code: "unknown",
     message: `WUPHF returned an unexpected response (${response.status}). Ask the host for a new invite.`,
   };
-}
-
-function isSuccessBody(
-  body: unknown,
-): body is { ok: true; redirect: string; display_name: string } {
-  if (!body || typeof body !== "object") return false;
-  const record = body as Record<string, unknown>;
-  return (
-    record.ok === true &&
-    typeof record.redirect === "string" &&
-    typeof record.display_name === "string"
-  );
-}
-
-function isErrorBody(
-  body: unknown,
-): body is { error: string; message: string } {
-  if (!body || typeof body !== "object") return false;
-  const record = body as Record<string, unknown>;
-  return typeof record.error === "string" && typeof record.message === "string";
-}
-
-function normalizeErrorCode(raw: string): JoinInviteErrorCode {
-  switch (raw) {
-    case "invite_expired_or_used":
-    case "invite_invalid":
-    case "broker_unreachable":
-    case "broker_failed":
-    case "invalid_request":
-      return raw;
-    default:
-      return "unknown";
-  }
 }

--- a/web/src/components/join/JoinPage.test.tsx
+++ b/web/src/components/join/JoinPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -11,11 +11,11 @@ vi.mock("../../api/joinInvite", () => ({
 
 const submitJoinInviteMock = vi.mocked(submitJoinInvite);
 
-beforeEach(() => {
-  vi.clearAllMocks();
-});
-
 describe("JoinPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("renders an empty-state when the token is blank", () => {
     render(<JoinPage token="   " />);
     expect(
@@ -101,11 +101,30 @@ describe("JoinPage", () => {
     expect(pendingButton).toBeDisabled();
     expect(pendingButton).toHaveAttribute("aria-busy", "true");
 
-    resolveSubmit({
-      ok: false,
-      code: "invite_invalid",
-      message: "Invite could not be accepted.",
+    await act(async () => {
+      resolveSubmit({
+        ok: false,
+        code: "invite_invalid",
+        message: "Invite could not be accepted.",
+      });
     });
     await screen.findByRole("alert");
+  });
+
+  // submitJoinInvite is contractually never-rejecting (it catches fetch
+  // failures and returns a `network` JoinInviteFailure), but if a future
+  // refactor lets a rejection escape we want JoinPage to recover instead of
+  // hanging the user on a disabled button.
+  it("recovers from an unexpected rejection in submitJoinInvite", async () => {
+    const user = userEvent.setup();
+    submitJoinInviteMock.mockRejectedValueOnce(new Error("boom"));
+    render(<JoinPage token="invite-1" />);
+
+    await user.type(screen.getByLabelText(/display name/i), "Maya");
+    await user.click(screen.getByRole("button", { name: /enter office/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /enter office/i })).toBeEnabled();
   });
 });

--- a/web/src/components/join/JoinPage.test.tsx
+++ b/web/src/components/join/JoinPage.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { submitJoinInvite } from "../../api/joinInvite";
+import { JoinPage } from "./JoinPage";
+
+vi.mock("../../api/joinInvite", () => ({
+  submitJoinInvite: vi.fn(),
+}));
+
+const submitJoinInviteMock = vi.mocked(submitJoinInvite);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("JoinPage", () => {
+  it("renders an empty-state when the token is blank", () => {
+    render(<JoinPage token="   " />);
+    expect(
+      screen.getByText("Invite link is missing its token"),
+    ).toBeInTheDocument();
+  });
+
+  it("requires a display name before submitting", async () => {
+    const user = userEvent.setup();
+    render(<JoinPage token="invite-1" />);
+
+    await user.click(screen.getByRole("button", { name: /enter office/i }));
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Add a display name");
+    expect(submitJoinInviteMock).not.toHaveBeenCalled();
+  });
+
+  it("submits the trimmed display name and calls onAccepted with the redirect", async () => {
+    const user = userEvent.setup();
+    submitJoinInviteMock.mockResolvedValue({
+      ok: true,
+      redirect: "/#/channels/general",
+      display_name: "Maya",
+    });
+    const onAccepted = vi.fn();
+    render(<JoinPage token="invite-1" onAccepted={onAccepted} />);
+
+    await user.type(screen.getByLabelText(/display name/i), "  Maya  ");
+    await user.click(screen.getByRole("button", { name: /enter office/i }));
+
+    expect(submitJoinInviteMock).toHaveBeenCalledWith({
+      token: "invite-1",
+      displayName: "Maya",
+    });
+    expect(onAccepted).toHaveBeenCalledWith("/#/channels/general");
+  });
+
+  it("renders the server error message when the invite is no longer valid", async () => {
+    const user = userEvent.setup();
+    submitJoinInviteMock.mockResolvedValue({
+      ok: false,
+      code: "invite_expired_or_used",
+      message: "This invite is no longer valid.",
+    });
+    render(<JoinPage token="invite-1" />);
+
+    await user.type(screen.getByLabelText(/display name/i), "Maya");
+    await user.click(screen.getByRole("button", { name: /enter office/i }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("This invite is no longer valid.");
+    expect(alert).toHaveAttribute("data-error-code", "invite_expired_or_used");
+    // The submit button should be re-enabled so the joiner can retry once
+    // the host hands them a fresh invite.
+    expect(screen.getByRole("button", { name: /enter office/i })).toBeEnabled();
+  });
+
+  it("disables the submit button while a request is in flight", async () => {
+    const user = userEvent.setup();
+    let resolveSubmit: (value: {
+      ok: false;
+      code: "invite_invalid";
+      message: string;
+    }) => void = () => {};
+    submitJoinInviteMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveSubmit = resolve;
+      }),
+    );
+    render(<JoinPage token="invite-1" />);
+
+    await user.type(screen.getByLabelText(/display name/i), "Maya");
+    await user.click(screen.getByRole("button", { name: /enter office/i }));
+
+    const pendingButton = screen.getByRole("button", { name: /entering/i });
+    expect(pendingButton).toBeDisabled();
+    expect(pendingButton).toHaveAttribute("aria-busy", "true");
+
+    resolveSubmit({
+      ok: false,
+      code: "invite_invalid",
+      message: "Invite could not be accepted.",
+    });
+    await screen.findByRole("alert");
+  });
+});

--- a/web/src/components/join/JoinPage.test.tsx
+++ b/web/src/components/join/JoinPage.test.tsx
@@ -23,6 +23,13 @@ describe("JoinPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders an empty-state when the token is the empty string", () => {
+    render(<JoinPage token="" />);
+    expect(
+      screen.getByText("Invite link is missing its token"),
+    ).toBeInTheDocument();
+  });
+
   it("requires a display name before submitting", async () => {
     const user = userEvent.setup();
     render(<JoinPage token="invite-1" />);

--- a/web/src/components/join/JoinPage.tsx
+++ b/web/src/components/join/JoinPage.tsx
@@ -60,10 +60,23 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
       return;
     }
     setStatus({ kind: "submitting" });
-    const result = await submitJoinInvite({
-      token: trimmedToken,
-      displayName: trimmed,
-    });
+    let result: Awaited<ReturnType<typeof submitJoinInvite>>;
+    try {
+      result = await submitJoinInvite({
+        token: trimmedToken,
+        displayName: trimmed,
+      });
+    } catch (err) {
+      // submitJoinInvite is contractually never-rejecting, so reaching this
+      // branch means a programmer error or a future refactor regression.
+      // Treat it as a generic network failure so the joiner can retry.
+      const message =
+        err instanceof Error && err.message
+          ? `Could not reach WUPHF: ${err.message}`
+          : "Something went wrong submitting the invite. Try again.";
+      setStatus({ kind: "error", code: "network", message });
+      return;
+    }
     if (result.ok) {
       if (onAccepted) {
         onAccepted(result.redirect);

--- a/web/src/components/join/JoinPage.tsx
+++ b/web/src/components/join/JoinPage.tsx
@@ -1,19 +1,23 @@
 import { type FormEvent, useEffect, useId, useRef, useState } from "react";
 
-import { submitJoinInvite } from "../../api/joinInvite";
+import {
+  type JoinInviteErrorCode,
+  submitJoinInvite,
+} from "../../api/joinInvite";
 import "./join.css";
+
+type ErrorCode = JoinInviteErrorCode | "name_required";
 
 interface JoinPageProps {
   token: string;
-  // Indirection so tests can replace the redirect with a spy.
+  // Test-only seam: replaces the production window.location.assign call.
   onAccepted?: (redirectTo: string) => void;
 }
 
 type Status =
   | { kind: "idle" }
   | { kind: "submitting" }
-  | { kind: "error"; code: string; message: string }
-  | { kind: "accepted" };
+  | { kind: "error"; code: ErrorCode; message: string };
 
 export function JoinPage({ token, onAccepted }: JoinPageProps) {
   const nameId = useId();
@@ -61,7 +65,6 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
       displayName: trimmed,
     });
     if (result.ok) {
-      setStatus({ kind: "accepted" });
       if (onAccepted) {
         onAccepted(result.redirect);
         return;

--- a/web/src/components/join/JoinPage.tsx
+++ b/web/src/components/join/JoinPage.tsx
@@ -1,4 +1,11 @@
-import { type FormEvent, useEffect, useId, useRef, useState } from "react";
+import {
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from "react";
 
 import {
   type JoinInviteErrorCode,
@@ -145,7 +152,7 @@ export function JoinPage({ token, onAccepted }: JoinPageProps) {
   );
 }
 
-function JoinShell({ children }: { children: React.ReactNode }) {
+function JoinShell({ children }: { children: ReactNode }) {
   return (
     <div className="join-page">
       <main className="join-card">{children}</main>

--- a/web/src/components/join/JoinPage.tsx
+++ b/web/src/components/join/JoinPage.tsx
@@ -1,0 +1,138 @@
+import { type FormEvent, useEffect, useId, useRef, useState } from "react";
+
+import { submitJoinInvite } from "../../api/joinInvite";
+import "./join.css";
+
+interface JoinPageProps {
+  token: string;
+  // Indirection so tests can replace the redirect with a spy.
+  onAccepted?: (redirectTo: string) => void;
+}
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "error"; code: string; message: string }
+  | { kind: "accepted" };
+
+export function JoinPage({ token, onAccepted }: JoinPageProps) {
+  const nameId = useId();
+  const errorId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [displayName, setDisplayName] = useState("");
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const trimmedToken = token.trim();
+  if (!trimmedToken) {
+    return (
+      <JoinShell>
+        <p className="join-eyebrow">Team member invite</p>
+        <h1 className="join-heading">Invite link is missing its token</h1>
+        <p className="join-copy">
+          Ask the host to send you a fresh invite link from Access &amp; Health.
+        </p>
+      </JoinShell>
+    );
+  }
+
+  const submitting = status.kind === "submitting";
+  const errorMessage = status.kind === "error" ? status.message : null;
+  const errorCode = status.kind === "error" ? status.code : null;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitting) return;
+    const trimmed = displayName.trim();
+    if (!trimmed) {
+      setStatus({
+        kind: "error",
+        code: "name_required",
+        message: "Add a display name so the team knows who is joining.",
+      });
+      return;
+    }
+    setStatus({ kind: "submitting" });
+    const result = await submitJoinInvite({
+      token: trimmedToken,
+      displayName: trimmed,
+    });
+    if (result.ok) {
+      setStatus({ kind: "accepted" });
+      if (onAccepted) {
+        onAccepted(result.redirect);
+        return;
+      }
+      window.location.assign(result.redirect);
+      return;
+    }
+    setStatus({ kind: "error", code: result.code, message: result.message });
+  }
+
+  return (
+    <JoinShell>
+      <p className="join-eyebrow">Team member invite</p>
+      <h1 className="join-heading">Join this WUPHF office</h1>
+      <p className="join-copy">
+        Pick the name your teammate should see in messages, requests, and office
+        activity. WUPHF will not share the host's broker token with this browser
+        session.
+      </p>
+
+      {errorMessage ? (
+        <div
+          className="join-error"
+          id={errorId}
+          role="alert"
+          data-error-code={errorCode ?? undefined}
+        >
+          {errorMessage}
+        </div>
+      ) : null}
+
+      <form className="join-form" onSubmit={handleSubmit} noValidate={true}>
+        <label htmlFor={nameId} className="join-label">
+          Display name
+        </label>
+        <input
+          ref={inputRef}
+          id={nameId}
+          name="display_name"
+          autoComplete="name"
+          placeholder="e.g. Maya"
+          className="join-input"
+          value={displayName}
+          onChange={(event) => setDisplayName(event.target.value)}
+          disabled={submitting}
+          aria-invalid={errorCode === "name_required"}
+          aria-describedby={errorMessage ? errorId : undefined}
+        />
+        <button
+          type="submit"
+          className="join-submit"
+          disabled={submitting}
+          aria-busy={submitting}
+        >
+          {submitting ? "Entering…" : "Enter office"}
+        </button>
+      </form>
+
+      <p className="join-note">
+        This creates a scoped team-member browser session. Sessions show up
+        under Access &amp; Health on the host machine and can be revoked at any
+        time.
+      </p>
+    </JoinShell>
+  );
+}
+
+function JoinShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="join-page">
+      <main className="join-card">{children}</main>
+    </div>
+  );
+}

--- a/web/src/components/join/join.css
+++ b/web/src/components/join/join.css
@@ -1,0 +1,109 @@
+/* JoinPage — invite acceptance landing.
+   Standalone layout: this view is the entire page when the SPA boots
+   from /?invite=<token>; no sidebar, no shell chrome. */
+
+.join-page {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--neutral-10, #f8f8f9);
+  color: var(--neutral-900, #28292a);
+  padding: 32px 16px;
+}
+
+.join-card {
+  width: min(92vw, 460px);
+  background: white;
+  border: 1px solid var(--neutral-100, #e9eaeb);
+  border-radius: 16px;
+  padding: 28px;
+  box-shadow: 0 24px 80px rgba(30, 31, 31, 0.08);
+}
+
+.join-eyebrow {
+  margin: 0 0 10px;
+  color: var(--neutral-500, #686c6e);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.join-heading {
+  margin: 0 0 10px;
+  font-size: 28px;
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.join-copy {
+  margin: 0 0 20px;
+  color: var(--neutral-600, #575a5c);
+  line-height: 1.55;
+}
+
+.join-error {
+  margin: 0 0 16px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #ffeeeb;
+  color: #8c1727;
+  font-size: 13px;
+}
+
+.join-form {
+  display: flex;
+  flex-direction: column;
+}
+
+.join-label {
+  margin: 0 0 8px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.join-input {
+  width: 100%;
+  min-height: 46px;
+  border: 1px solid var(--neutral-200, #cfd1d2);
+  border-radius: 10px;
+  padding: 0 12px;
+  font: inherit;
+  background: white;
+  color: inherit;
+}
+
+.join-input[aria-invalid="true"] {
+  border-color: #d23a47;
+  outline: 2px solid rgba(210, 58, 71, 0.18);
+  outline-offset: 1px;
+}
+
+.join-input:focus-visible {
+  outline: 2px solid var(--cyan-400, #00ccff);
+  outline-offset: 1px;
+}
+
+.join-submit {
+  width: 100%;
+  min-height: 46px;
+  margin-top: 14px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--neutral-900, #28292a);
+  color: white;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.join-submit:disabled {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.join-note {
+  margin-top: 18px;
+  font-size: 12px;
+  color: var(--neutral-400, #85898b);
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -4,6 +4,7 @@ import { RouterProvider } from "@tanstack/react-router";
 
 import { rootRoute, router } from "./lib/router";
 import RootRoute from "./routes/RootRoute";
+import { JoinPage } from "./components/join/JoinPage";
 import "./styles/shadcn.css";
 import "./styles/global.css";
 import "./styles/layout.css";
@@ -55,14 +56,32 @@ function showFatalError(title: string, detail: string) {
   document.body.appendChild(box);
 }
 
+// Team-member invite acceptance lives at /?invite=<token>. The share
+// handler redirects /join/<token> here. Mount JoinPage instead of the
+// main app so the joiner doesn't need a broker token to render the form.
+function inviteTokenFromLocation(): string | null {
+  try {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get("invite");
+    return raw ? raw.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
 try {
   const root = document.getElementById("root");
   if (!root) {
     throw new Error("#root element not found in DOM");
   }
+  const inviteToken = inviteTokenFromLocation();
   createRoot(root).render(
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      {inviteToken ? (
+        <JoinPage token={inviteToken} />
+      ) : (
+        <RouterProvider router={router} />
+      )}
     </QueryClientProvider>,
   );
   window.__wuphfBootDone?.();

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -56,31 +56,23 @@ function showFatalError(title: string, detail: string) {
   document.body.appendChild(box);
 }
 
-// Team-member invite acceptance lives at /?invite=<token>. The share
-// handler redirects /join/<token> here. Mount JoinPage instead of the
-// main app so the joiner doesn't need a broker token to render the form.
-function inviteTokenFromLocation(): string | null {
-  try {
-    const params = new URLSearchParams(window.location.search);
-    const raw = params.get("invite");
-    return raw ? raw.trim() : null;
-  } catch {
-    return null;
-  }
-}
-
 try {
   const root = document.getElementById("root");
   if (!root) {
     throw new Error("#root element not found in DOM");
   }
-  const inviteToken = inviteTokenFromLocation();
+  // The share handler redirects /join/<token> to /?invite=<token> so the
+  // SPA's relative asset URLs need no path rewrite. A present-but-empty
+  // value means the link was truncated; pass it through so JoinPage can
+  // show the missing-token state instead of mounting the main app.
+  const rawInvite = new URLSearchParams(window.location.search).get("invite");
+  const inviteToken = rawInvite === null ? null : rawInvite.trim();
   createRoot(root).render(
     <QueryClientProvider client={queryClient}>
-      {inviteToken ? (
-        <JoinPage token={inviteToken} />
-      ) : (
+      {inviteToken === null ? (
         <RouterProvider router={router} />
+      ) : (
+        <JoinPage token={inviteToken} />
       )}
     </QueryClientProvider>,
   );


### PR DESCRIPTION
## Summary
- redirect `GET /join/<token>` to `/?invite=<token>` so the SPA owns acceptance UI
- return JSON `{ok, redirect, display_name}` / `{error, message}` from `POST /join/<token>` with stable error codes
- new `JoinPage` (React) plus `joinInvite.ts` API client with input validation, code-aware error copy, and disabled-while-pending submit
- delete the inline HTML form and `html` import from `share.go`

## Why
The hand-rendered `writeShareJoinPage` duplicated design tokens, produced a single generic error banner, and put the joiner UI in the share handler. Moving acceptance into the React app reuses the design system, lets us render specific copy per server error code (expired, revoked, broker unreachable), and keeps the cookie + broker exchange in one round trip.

## Validation
- `bash scripts/test-go.sh ./cmd/wuphf` — all share tests green
- `bash scripts/test-web.sh` — 116/116 files, 825/825 tests
- `bunx tsc --noEmit`
- `bunx biome check --write` ran clean

Manual:
- [ ] Run `wuphf share`, click the invite URL on a second device, see the React Join page render
- [ ] Submit with empty name → inline validation error
- [ ] Submit with valid name → redirected to `#/channels/general` with a session cookie set
- [ ] Have host revoke the invite mid-flow → server returns 410, page shows "This invite is no longer valid"

## Notes
- Backwards-incompatible for any external client posting `application/x-www-form-urlencoded` to `/join/<token>`. The only known consumer was the deleted inline form.
- Tutorial `docs/tutorials/share-with-team-member.md` updated to mention the new state-specific copy on the join screen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invite URLs now redirect into a standalone join page that accepts a display name and completes join via JSON; client API exposes typed success/failure results and normalized error codes.

* **UX / Bug Fixes**
  * Consistent JSON error responses with mapped HTTP statuses; prevents double-submits, shows busy/error states, and supports retry for failures.

* **Tests**
  * Expanded tests covering join flows, malformed requests, network/server errors, and client parsing/behavior.

* **Documentation**
  * Tutorial updated to describe the redirect-based join flow and explicit invite-invalid messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->