### PR TITLE
feat(transport): wire human-share via OfficeBoundTransport (phase 4 slice B)

### DIFF
--- a/internal/team/broker_human_share.go
+++ b/internal/team/broker_human_share.go
@@ -259,6 +259,53 @@ func (b *Broker) acceptHumanInvite(token, displayName, device string) (string, h
 	return "", humanSession{}, errHumanInviteExpiredOrUsed
 }
 
+// RevokeHumanInvite marks the invite RevokedAt (so no further accepts can
+// admit a new session against it) and returns the IDs of sessions that were
+// still active under this invite at revoke time. It does NOT revoke the
+// sessions themselves — that belongs to the caller (typically
+// transport.Host.RevokeParticipant via the OfficeBoundTransport adapter), so
+// the same per-session teardown path runs whether triggered through the
+// adapter or directly via revokeHumanSession.
+//
+// Returns an error only when the invite is unknown; an already-revoked invite
+// is a no-op success that still returns any sessions still active under it
+// (caller can decide whether to retry teardown).
+func (b *Broker) RevokeHumanInvite(inviteID string) ([]string, error) {
+	inviteID = strings.TrimSpace(inviteID)
+	if inviteID == "" {
+		return nil, errors.New("invite id required")
+	}
+	now := time.Now().UTC()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	found := false
+	for i := range b.humanInvites {
+		if b.humanInvites[i].ID != inviteID {
+			continue
+		}
+		found = true
+		if b.humanInvites[i].RevokedAt == "" {
+			b.humanInvites[i].RevokedAt = now.Format(time.RFC3339)
+		}
+		break
+	}
+	if !found {
+		return nil, errors.New("invite not found")
+	}
+	var affected []string
+	for i := range b.humanSessions {
+		s := &b.humanSessions[i]
+		if s.InviteID != inviteID || s.RevokedAt != "" {
+			continue
+		}
+		affected = append(affected, s.ID)
+	}
+	if err := b.saveLocked(); err != nil {
+		return affected, err
+	}
+	return affected, nil
+}
+
 func (b *Broker) revokeHumanSession(id string) error {
 	id = strings.TrimSpace(id)
 	if id == "" {

--- a/internal/team/broker_human_share.go
+++ b/internal/team/broker_human_share.go
@@ -267,9 +267,12 @@ func (b *Broker) acceptHumanInvite(token, displayName, device string) (string, h
 // the same per-session teardown path runs whether triggered through the
 // adapter or directly via revokeHumanSession.
 //
-// Returns an error only when the invite is unknown; an already-revoked invite
-// is a no-op success that still returns any sessions still active under it
-// (caller can decide whether to retry teardown).
+// Returns an error when the invite is unknown or when persisting the mutation
+// fails. On a save failure the in-memory mutation is rolled back so a restart
+// will not see a half-revoked state — without this rollback an attacker who
+// still has the invite token could re-join after the next restart because the
+// persisted state would still show the invite live. An already-revoked invite
+// is a no-op success that returns any sessions still active under it.
 func (b *Broker) RevokeHumanInvite(inviteID string) ([]string, error) {
 	inviteID = strings.TrimSpace(inviteID)
 	if inviteID == "" {
@@ -278,19 +281,19 @@ func (b *Broker) RevokeHumanInvite(inviteID string) ([]string, error) {
 	now := time.Now().UTC()
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	found := false
+	idx := -1
 	for i := range b.humanInvites {
-		if b.humanInvites[i].ID != inviteID {
-			continue
+		if b.humanInvites[i].ID == inviteID {
+			idx = i
+			break
 		}
-		found = true
-		if b.humanInvites[i].RevokedAt == "" {
-			b.humanInvites[i].RevokedAt = now.Format(time.RFC3339)
-		}
-		break
 	}
-	if !found {
+	if idx < 0 {
 		return nil, errors.New("invite not found")
+	}
+	prevRevokedAt := b.humanInvites[idx].RevokedAt
+	if prevRevokedAt == "" {
+		b.humanInvites[idx].RevokedAt = now.Format(time.RFC3339)
 	}
 	var affected []string
 	for i := range b.humanSessions {
@@ -301,7 +304,10 @@ func (b *Broker) RevokeHumanInvite(inviteID string) ([]string, error) {
 		affected = append(affected, s.ID)
 	}
 	if err := b.saveLocked(); err != nil {
-		return affected, err
+		// Roll back the in-memory mutation so a restart cannot see a state
+		// where the invite was marked revoked in memory but never persisted.
+		b.humanInvites[idx].RevokedAt = prevRevokedAt
+		return nil, fmt.Errorf("share: RevokeHumanInvite save: %w", err)
 	}
 	return affected, nil
 }

--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -4,12 +4,15 @@ package team
 // only file in internal/team that imports internal/team/transport — the
 // one-way compile boundary (team → transport) is enforced here.
 //
-// Phase 2b wires ReceiveMessage and UpsertParticipant for the channel-bound
-// (Telegram) case. Inbound messages are delivered via PostInboundSurfaceMessage;
-// UpsertParticipant is a no-op for channel-bound adapters because participant
-// attribution is handled inside PostInboundSurfaceMessage by display name.
+// ReceiveMessage and UpsertParticipant route to PostInboundSurfaceMessage for
+// channel-bound (Telegram) adapters; UpsertParticipant is a no-op there because
+// participant attribution is handled inside PostInboundSurfaceMessage by
+// display name.
 //
-// DetachParticipant (phase 3b) and RevokeParticipant (phase 4) remain stubs.
+// RevokeParticipant routes the office-bound (human-share) revoke flow to
+// Broker.revokeHumanSession so an adapter calling Host.RevokeParticipant after
+// an invite is revoked tears down the corresponding session. Member-bound
+// DetachParticipant remains a stub until the openclaw lifecycle adds it.
 
 import (
 	"context"
@@ -58,9 +61,22 @@ func (h *brokerTransportHost) DetachParticipant(_ context.Context, adapterName, 
 		adapterName)
 }
 
-// RevokeParticipant removes an admitted human from the broker. Phase 4 TODO
-// for office-bound adapters (human-share).
-func (h *brokerTransportHost) RevokeParticipant(_ context.Context, adapterName, _ string) error {
-	return fmt.Errorf("transport: RevokeParticipant not yet implemented (phase 4): adapter=%q",
-		adapterName)
+// RevokeParticipant removes an admitted human from the broker. For the
+// office-bound human-share adapter the key is a humanSession.ID and the
+// implementation routes to Broker.revokeHumanSession so the session is marked
+// revoked and any active wait channels are closed. Other adapter names are
+// rejected so a misnamed call surfaces loudly rather than silently no-op'ing.
+func (h *brokerTransportHost) RevokeParticipant(_ context.Context, adapterName, key string) error {
+	if h == nil || h.broker == nil {
+		return errors.New("transport: RevokeParticipant: nil broker")
+	}
+	switch adapterName {
+	case shareAdapterName:
+		if err := h.broker.revokeHumanSession(key); err != nil {
+			return fmt.Errorf("transport: RevokeParticipant %s/%s: %w", adapterName, key, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("transport: RevokeParticipant: unsupported adapter %q (key=%q)", adapterName, key)
+	}
 }

--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -48,16 +48,17 @@ func (h *brokerTransportHost) ReceiveMessage(_ context.Context, msg transport.Me
 
 // UpsertParticipant is a no-op for channel-bound adapters (Telegram). Channel-
 // bound participant identity is resolved by display name inside
-// PostInboundSurfaceMessage. Phase 3b will add a real member-store lookup for
-// member-bound adapters (OpenClaw).
+// PostInboundSurfaceMessage. A real member-store lookup for member-bound
+// adapters (OpenClaw) is not yet wired here.
 func (h *brokerTransportHost) UpsertParticipant(_ context.Context, _ transport.Participant, _ transport.Binding) error {
 	return nil
 }
 
-// DetachParticipant marks a participant as offline. Phase 3b TODO for
-// member-bound adapters (OpenClaw).
+// DetachParticipant marks a participant as offline. Not yet implemented for
+// member-bound adapters (OpenClaw); inbound calls return an explicit
+// unsupported error so a misconfigured caller fails loudly.
 func (h *brokerTransportHost) DetachParticipant(_ context.Context, adapterName, _ string) error {
-	return fmt.Errorf("transport: DetachParticipant not yet implemented (phase 3b): adapter=%q",
+	return fmt.Errorf("transport: DetachParticipant not yet implemented: adapter=%q",
 		adapterName)
 }
 

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -96,12 +96,12 @@ func RegisterTransports(b *Broker) (func(), error) {
 	// Human-share: always registered. The adapter wraps the in-process
 	// invite/session surface in broker_human_share.go so RegisterTransports
 	// owns the OfficeBoundTransport lifecycle alongside Telegram and OpenClaw.
-	// urlBuilder is nil here because the launcher does not know the share
-	// controller's bind address (the share controller lives in cmd/wuphf and
-	// boots independently); CreateInvite returns the relative "/join/<token>"
-	// path until the share controller adopts the adapter and supplies a
-	// builder.
-	share := NewShareTransport(b, nil)
+	// RelativeJoinURL is the explicit degenerate builder used here because the
+	// launcher does not know the share controller's bind address (the share
+	// controller lives in cmd/wuphf and boots independently). When the share
+	// controller adopts the adapter for invite creation it will supply an
+	// absolute-URL builder via NewShareTransport.
+	share := NewShareTransport(b, RelativeJoinURL)
 	shareCtx, shareCancel := context.WithCancel(context.Background())
 	shareDone := make(chan struct{})
 	shareHost := &brokerTransportHost{broker: b}

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -93,7 +93,29 @@ func RegisterTransports(b *Broker) (func(), error) {
 		log.Printf("[transport] openclaw: started (%d session(s))", len(bridge.SnapshotBindings()))
 	}
 
-	// Future: wire human-share adapter via OfficeBoundTransport.
+	// Human-share: always registered. The adapter wraps the in-process
+	// invite/session surface in broker_human_share.go so RegisterTransports
+	// owns the OfficeBoundTransport lifecycle alongside Telegram and OpenClaw.
+	// urlBuilder is nil here because the launcher does not know the share
+	// controller's bind address (the share controller lives in cmd/wuphf and
+	// boots independently); CreateInvite returns the relative "/join/<token>"
+	// path until the share controller adopts the adapter and supplies a
+	// builder.
+	share := NewShareTransport(b, nil)
+	shareCtx, shareCancel := context.WithCancel(context.Background())
+	shareDone := make(chan struct{})
+	shareHost := &brokerTransportHost{broker: b}
+	go func() {
+		defer close(shareDone)
+		if err := share.Run(shareCtx, shareHost); err != nil && shareCtx.Err() == nil {
+			log.Printf("[transport] share: exited with error: %v", err)
+		}
+	}()
+	stops = append(stops, func() {
+		shareCancel()
+		<-shareDone
+	})
+	log.Printf("[transport] share: registered (human-share)")
 
 	return cleanup, nil
 }

--- a/internal/team/share_transport.go
+++ b/internal/team/share_transport.go
@@ -6,18 +6,26 @@ package team
 // live on Broker; this file gives that surface an OfficeBoundTransport face so
 // it can be registered alongside Telegram and OpenClaw via RegisterTransports.
 //
-// CreateInvite delegates to Broker.createHumanInvite and formats a join URL
-// using an injected builder. The launcher does not currently know the share
-// controller's bind address (the share controller lives in cmd/wuphf), so the
-// builder is optional — when nil, CreateInvite returns the relative path
-// "/join/<token>" so the contract is satisfied and callers can prepend their
-// own host. RevokeInvite delegates to Broker.RevokeHumanInvite, then fans out
-// host.RevokeParticipant for each session that was actually revoked, fulfilling
-// the OfficeBoundTransport contract that the adapter (not the Host) drives the
-// per-session teardown.
+// CreateInvite delegates to Broker.createHumanInvite and asks the injected
+// JoinURLBuilder to format the shareable URL. RevokeInvite calls
+// Broker.RevokeHumanInvite, then fans out host.RevokeParticipant for each
+// session that was active under the invite — fulfilling the contract clause
+// that the adapter (not the Host) drives the per-session teardown after invite
+// revocation.
+//
+// v1 lifecycle invariant: only the revoke half of the OfficeBoundTransport
+// admit/revoke pair is wired through the transport host. Admit happens via the
+// in-process /humans/invites/accept HTTP handler, which calls
+// Broker.acceptHumanInvite directly; the transport host's UpsertParticipant is
+// never invoked for share-admitted humans. This is intentional — admitted
+// humans poll the broker via /api/* routes rather than through the transport
+// contract — but a future phase that wants Host.ReceiveMessage for share
+// participants must close this gap by also calling Host.UpsertParticipant from
+// the accept path.
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -26,18 +34,26 @@ import (
 )
 
 // shareAdapterName is the stable identifier the broker uses to namespace
-// participant keys created by this adapter. Changing this between releases
-// would lose admitted-human identity across restarts.
-const shareAdapterName = "human-share"
+// participant keys created by this adapter. Per Transport.Name() it must be a
+// valid Go identifier (lowercase, no spaces or hyphens). Changing this between
+// releases would lose admitted-human identity across restarts.
+const shareAdapterName = "share"
 
-// JoinURLBuilder maps an invite token to a shareable URL. Optional — when nil,
-// ShareTransport.CreateInvite returns the relative path "/join/<token>".
+// JoinURLBuilder maps an invite token to a shareable URL. Required —
+// NewShareTransport panics on a nil builder so a misconfigured launcher fails
+// loudly rather than producing relative-path URLs that look fine until a
+// remote user tries to click them.
 type JoinURLBuilder func(token string) string
+
+// RelativeJoinURL is the degenerate builder used when no absolute host is
+// known (e.g. the launcher does not yet know the share controller's bind
+// address). It returns "/join/<token>" so callers can prepend their own host
+// and the contract is satisfied with a non-empty result.
+func RelativeJoinURL(token string) string { return "/join/" + token }
 
 // ShareTransport adapts the broker's human-share surface to the
 // transport.OfficeBoundTransport contract. It holds no state of its own beyond
-// the broker reference, the optional URL builder, and the host pointer set by
-// Run.
+// the broker reference, the URL builder, and the host pointer set by Run.
 type ShareTransport struct {
 	broker     *Broker
 	urlBuilder JoinURLBuilder
@@ -50,9 +66,13 @@ type ShareTransport struct {
 var _ transport.OfficeBoundTransport = (*ShareTransport)(nil)
 
 // NewShareTransport constructs a ShareTransport bound to the given broker.
-// urlBuilder is optional and used by CreateInvite to produce absolute join
-// URLs; pass nil to fall back to a relative "/join/<token>" path.
+// urlBuilder must be non-nil; pass [RelativeJoinURL] when no absolute base is
+// known so callers see an explicit relative-path choice rather than a silent
+// nil-builder fallback.
 func NewShareTransport(broker *Broker, urlBuilder JoinURLBuilder) *ShareTransport {
+	if urlBuilder == nil {
+		panic("team: NewShareTransport: urlBuilder is required (use RelativeJoinURL for the degenerate case)")
+	}
 	return &ShareTransport{broker: broker, urlBuilder: urlBuilder}
 }
 
@@ -68,9 +88,13 @@ func (s *ShareTransport) Binding() transport.Binding {
 
 // Run stores the host atomically and blocks until ctx is cancelled. The
 // human-share surface is in-process — the existing handlers in
-// broker_human_share.go drive accept/revoke directly, so Run does not subscribe
-// to anything external. A nil host is rejected so a misconfigured launcher
-// fails loudly rather than silently degrading.
+// broker_human_share.go drive accept directly, so Run does not subscribe to
+// anything external. A nil host is rejected so a misconfigured launcher fails
+// loudly rather than silently degrading.
+//
+// See the file header for the v1 lifecycle invariant: only the revoke half of
+// the OfficeBoundTransport admit/revoke pair flows through the transport host
+// today.
 func (s *ShareTransport) Run(ctx context.Context, host transport.Host) error {
 	if s == nil {
 		return fmt.Errorf("share: nil transport")
@@ -89,7 +113,9 @@ func (s *ShareTransport) Run(ctx context.Context, host transport.Host) error {
 // polls /api/* routes on the same broker), so there is no external network for
 // the adapter to push to. Returning nil keeps the OfficeBoundTransport contract
 // honest: the adapter accepts the message and trusts the broker to deliver via
-// its existing channel-message machinery.
+// its existing channel-message machinery. This is a conscious contract choice,
+// not an oversight — a future push transport (WebSocket, SSE) for share-
+// admitted humans would replace this no-op with real delivery.
 func (s *ShareTransport) Send(_ context.Context, _ transport.Outbound) error {
 	return nil
 }
@@ -98,19 +124,24 @@ func (s *ShareTransport) Send(_ context.Context, _ transport.Outbound) error {
 // returns Disconnected. The share surface is in-process and has no upstream
 // dependency to fail, so once Run is live the state is steady.
 func (s *ShareTransport) Health() transport.Health {
-	if s == nil || s.startedAt.Load() == 0 {
+	if s == nil {
+		return transport.Health{State: transport.HealthDisconnected}
+	}
+	nano := s.startedAt.Load()
+	if nano == 0 {
 		return transport.Health{State: transport.HealthDisconnected}
 	}
 	return transport.Health{
 		State:         transport.HealthConnected,
-		LastSuccessAt: time.Unix(0, s.startedAt.Load()),
+		LastSuccessAt: time.Unix(0, nano),
 	}
 }
 
 // CreateInvite creates a new human-share invite via Broker.createHumanInvite
-// and returns the join URL. The network argument is accepted to satisfy the
-// OfficeBoundTransport contract but is informational in v1 — the share
-// controller decides bind address out-of-band when it boots.
+// and returns the join URL produced by the injected JoinURLBuilder. The
+// network argument is part of the OfficeBoundTransport contract but
+// ShareTransport ignores it: URL construction is controlled by the builder,
+// which the share controller selects based on its own bind logic.
 func (s *ShareTransport) CreateInvite(_ context.Context, _ string) (string, error) {
 	if s == nil || s.broker == nil {
 		return "", fmt.Errorf("share: CreateInvite: nil broker")
@@ -119,10 +150,7 @@ func (s *ShareTransport) CreateInvite(_ context.Context, _ string) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("share: CreateInvite: %w", err)
 	}
-	if s.urlBuilder != nil {
-		return s.urlBuilder(token), nil
-	}
-	return "/join/" + token, nil
+	return s.urlBuilder(token), nil
 }
 
 // RevokeInvite revokes the invite and every session it admitted. Per the
@@ -133,6 +161,11 @@ func (s *ShareTransport) CreateInvite(_ context.Context, _ string) (string, erro
 // revocation idempotent: if Host.RevokeParticipant errors mid-fan-out the
 // invite is already marked revoked, so a retry will only fan out the remaining
 // sessions.
+//
+// Errors from individual host.RevokeParticipant calls are accumulated via
+// errors.Join so a partial fan-out does not silently hide later failures
+// behind the first one. The loop runs to completion on every call; failing
+// fast on the first error would leave later sessions live.
 func (s *ShareTransport) RevokeInvite(ctx context.Context, inviteID string) error {
 	if s == nil || s.broker == nil {
 		return fmt.Errorf("share: RevokeInvite: nil broker")
@@ -148,11 +181,11 @@ func (s *ShareTransport) RevokeInvite(ctx context.Context, inviteID string) erro
 		return nil
 	}
 	host := *hp
-	var firstErr error
+	var errs []error
 	for _, sid := range revokedSessions {
-		if err := host.RevokeParticipant(ctx, shareAdapterName, sid); err != nil && firstErr == nil {
-			firstErr = fmt.Errorf("share: RevokeParticipant %s: %w", sid, err)
+		if err := host.RevokeParticipant(ctx, shareAdapterName, sid); err != nil {
+			errs = append(errs, fmt.Errorf("share: RevokeParticipant %s: %w", sid, err))
 		}
 	}
-	return firstErr
+	return errors.Join(errs...)
 }

--- a/internal/team/share_transport.go
+++ b/internal/team/share_transport.go
@@ -1,0 +1,158 @@
+package team
+
+// share_transport.go implements transport.OfficeBoundTransport on top of the
+// existing human-share invite/session surface (broker_human_share.go). The
+// adapter is a thin wrapper: invite + session storage and revocation already
+// live on Broker; this file gives that surface an OfficeBoundTransport face so
+// it can be registered alongside Telegram and OpenClaw via RegisterTransports.
+//
+// CreateInvite delegates to Broker.createHumanInvite and formats a join URL
+// using an injected builder. The launcher does not currently know the share
+// controller's bind address (the share controller lives in cmd/wuphf), so the
+// builder is optional — when nil, CreateInvite returns the relative path
+// "/join/<token>" so the contract is satisfied and callers can prepend their
+// own host. RevokeInvite delegates to Broker.RevokeHumanInvite, then fans out
+// host.RevokeParticipant for each session that was actually revoked, fulfilling
+// the OfficeBoundTransport contract that the adapter (not the Host) drives the
+// per-session teardown.
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// shareAdapterName is the stable identifier the broker uses to namespace
+// participant keys created by this adapter. Changing this between releases
+// would lose admitted-human identity across restarts.
+const shareAdapterName = "human-share"
+
+// JoinURLBuilder maps an invite token to a shareable URL. Optional — when nil,
+// ShareTransport.CreateInvite returns the relative path "/join/<token>".
+type JoinURLBuilder func(token string) string
+
+// ShareTransport adapts the broker's human-share surface to the
+// transport.OfficeBoundTransport contract. It holds no state of its own beyond
+// the broker reference, the optional URL builder, and the host pointer set by
+// Run.
+type ShareTransport struct {
+	broker     *Broker
+	urlBuilder JoinURLBuilder
+	host       atomic.Pointer[transport.Host]
+	startedAt  atomic.Int64 // unix nanos; zero before Run, set on Run entry
+}
+
+// Compile-time assertion that ShareTransport satisfies OfficeBoundTransport.
+// If the contract changes, the build breaks here, not at the registration site.
+var _ transport.OfficeBoundTransport = (*ShareTransport)(nil)
+
+// NewShareTransport constructs a ShareTransport bound to the given broker.
+// urlBuilder is optional and used by CreateInvite to produce absolute join
+// URLs; pass nil to fall back to a relative "/join/<token>" path.
+func NewShareTransport(broker *Broker, urlBuilder JoinURLBuilder) *ShareTransport {
+	return &ShareTransport{broker: broker, urlBuilder: urlBuilder}
+}
+
+// Name returns the stable adapter identifier.
+func (s *ShareTransport) Name() string { return shareAdapterName }
+
+// Binding declares the office scope. The adapter admits humans into the office
+// itself rather than a specific channel or member, so MemberSlug and
+// ChannelSlug are intentionally empty.
+func (s *ShareTransport) Binding() transport.Binding {
+	return transport.Binding{Scope: transport.ScopeOffice}
+}
+
+// Run stores the host atomically and blocks until ctx is cancelled. The
+// human-share surface is in-process — the existing handlers in
+// broker_human_share.go drive accept/revoke directly, so Run does not subscribe
+// to anything external. A nil host is rejected so a misconfigured launcher
+// fails loudly rather than silently degrading.
+func (s *ShareTransport) Run(ctx context.Context, host transport.Host) error {
+	if s == nil {
+		return fmt.Errorf("share: nil transport")
+	}
+	if host == nil {
+		return fmt.Errorf("share: Run requires a non-nil host")
+	}
+	s.host.Store(&host)
+	s.startedAt.Store(time.Now().UnixNano())
+	<-ctx.Done()
+	return nil
+}
+
+// Send is a no-op for the human-share adapter. Office-wide messages reach
+// admitted humans through the existing broker channels (the shared web UI
+// polls /api/* routes on the same broker), so there is no external network for
+// the adapter to push to. Returning nil keeps the OfficeBoundTransport contract
+// honest: the adapter accepts the message and trusts the broker to deliver via
+// its existing channel-message machinery.
+func (s *ShareTransport) Send(_ context.Context, _ transport.Outbound) error {
+	return nil
+}
+
+// Health reports Connected once Run has started; before Run is called Health
+// returns Disconnected. The share surface is in-process and has no upstream
+// dependency to fail, so once Run is live the state is steady.
+func (s *ShareTransport) Health() transport.Health {
+	if s == nil || s.startedAt.Load() == 0 {
+		return transport.Health{State: transport.HealthDisconnected}
+	}
+	return transport.Health{
+		State:         transport.HealthConnected,
+		LastSuccessAt: time.Unix(0, s.startedAt.Load()),
+	}
+}
+
+// CreateInvite creates a new human-share invite via Broker.createHumanInvite
+// and returns the join URL. The network argument is accepted to satisfy the
+// OfficeBoundTransport contract but is informational in v1 — the share
+// controller decides bind address out-of-band when it boots.
+func (s *ShareTransport) CreateInvite(_ context.Context, _ string) (string, error) {
+	if s == nil || s.broker == nil {
+		return "", fmt.Errorf("share: CreateInvite: nil broker")
+	}
+	token, _, err := s.broker.createHumanInvite()
+	if err != nil {
+		return "", fmt.Errorf("share: CreateInvite: %w", err)
+	}
+	if s.urlBuilder != nil {
+		return s.urlBuilder(token), nil
+	}
+	return "/join/" + token, nil
+}
+
+// RevokeInvite revokes the invite and every session it admitted. Per the
+// OfficeBoundTransport contract the adapter is responsible for calling
+// host.RevokeParticipant for each affected admitted human before returning;
+// host.RevokeParticipant in turn closes the session in the broker. The two-step
+// dance (broker.RevokeHumanInvite + host.RevokeParticipant) keeps the broker's
+// revocation idempotent: if Host.RevokeParticipant errors mid-fan-out the
+// invite is already marked revoked, so a retry will only fan out the remaining
+// sessions.
+func (s *ShareTransport) RevokeInvite(ctx context.Context, inviteID string) error {
+	if s == nil || s.broker == nil {
+		return fmt.Errorf("share: RevokeInvite: nil broker")
+	}
+	revokedSessions, err := s.broker.RevokeHumanInvite(inviteID)
+	if err != nil {
+		return fmt.Errorf("share: RevokeInvite %q: %w", inviteID, err)
+	}
+	hp := s.host.Load()
+	if hp == nil {
+		// Adapter not running under a host (e.g. Run never called) — the
+		// broker-level revoke still happened above; nothing more to do.
+		return nil
+	}
+	host := *hp
+	var firstErr error
+	for _, sid := range revokedSessions {
+		if err := host.RevokeParticipant(ctx, shareAdapterName, sid); err != nil && firstErr == nil {
+			firstErr = fmt.Errorf("share: RevokeParticipant %s: %w", sid, err)
+		}
+	}
+	return firstErr
+}

--- a/internal/team/share_transport_test.go
+++ b/internal/team/share_transport_test.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -97,6 +98,13 @@ func TestShareTransportRevokeInviteFansOutToHost(t *testing.T) {
 
 	runErr := make(chan error, 1)
 	go func() { runErr <- st.Run(ctx, host) }()
+
+	// Wait for Run to store the host before calling RevokeInvite; without
+	// this, RevokeInvite may see a nil host pointer and silently skip the
+	// per-session fan-out, making the test a false positive.
+	for st.Health().State != transport.HealthConnected {
+		runtime.Gosched()
+	}
 
 	token, _, err := b.createHumanInvite()
 	if err != nil {

--- a/internal/team/share_transport_test.go
+++ b/internal/team/share_transport_test.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"strings"
 	"sync"
@@ -13,20 +14,37 @@ import (
 // TestShareTransportRunRequiresHost confirms Run rejects a nil host so a
 // misconfigured launcher fails loudly instead of silently degrading.
 func TestShareTransportRunRequiresHost(t *testing.T) {
-	st := NewShareTransport(newTestBroker(t), nil)
+	st := NewShareTransport(newTestBroker(t), RelativeJoinURL)
 	err := st.Run(context.Background(), nil)
 	if err == nil {
 		t.Fatal("Run(nil host) returned nil error; want guard error")
 	}
 }
 
+// TestNewShareTransportRequiresBuilder confirms a nil JoinURLBuilder panics on
+// construction. The launcher must pass an explicit builder (RelativeJoinURL
+// for the degenerate case) so future contract consumers cannot get a silent
+// relative-path URL where they expected an absolute one.
+func TestNewShareTransportRequiresBuilder(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("NewShareTransport(_, nil) did not panic")
+		}
+	}()
+	_ = NewShareTransport(newTestBroker(t), nil)
+}
+
 // TestShareTransportNameAndBinding pins the stable adapter identity and scope
 // declaration. Changing either is a contract break — admitted-human identity
-// is keyed off shareAdapterName across restarts.
+// is keyed off shareAdapterName across restarts. The name must also be a
+// valid Go identifier per Transport.Name() (no hyphens, no spaces).
 func TestShareTransportNameAndBinding(t *testing.T) {
-	st := NewShareTransport(newTestBroker(t), nil)
-	if got, want := st.Name(), "human-share"; got != want {
+	st := NewShareTransport(newTestBroker(t), RelativeJoinURL)
+	if got, want := st.Name(), "share"; got != want {
 		t.Errorf("Name(): got %q want %q", got, want)
+	}
+	if strings.ContainsAny(st.Name(), "- ") {
+		t.Errorf("Name() %q must be a valid Go identifier (no hyphens, no spaces)", st.Name())
 	}
 	binding := st.Binding()
 	if binding.Scope != transport.ScopeOffice {
@@ -37,13 +55,13 @@ func TestShareTransportNameAndBinding(t *testing.T) {
 	}
 }
 
-// TestShareTransportCreateInviteFallback verifies CreateInvite returns a
-// relative /join/<token> path when no urlBuilder is injected. This is the
-// path the launcher takes today; production wiring of an absolute URL will
-// arrive when the share controller adopts the adapter.
-func TestShareTransportCreateInviteFallback(t *testing.T) {
+// TestShareTransportCreateInviteRelativeBuilder verifies the degenerate
+// RelativeJoinURL builder produces /join/<token>. This is the path the
+// launcher takes today; an absolute-URL builder will arrive when the share
+// controller adopts the adapter.
+func TestShareTransportCreateInviteRelativeBuilder(t *testing.T) {
 	b := newTestBroker(t)
-	st := NewShareTransport(b, nil)
+	st := NewShareTransport(b, RelativeJoinURL)
 	got, err := st.CreateInvite(context.Background(), "tailscale")
 	if err != nil {
 		t.Fatalf("CreateInvite: %v", err)
@@ -90,7 +108,7 @@ func TestShareTransportCreateInviteUsesBuilder(t *testing.T) {
 // teardown that the OfficeBoundTransport contract requires.
 func TestShareTransportRevokeInviteFansOutToHost(t *testing.T) {
 	b := newTestBroker(t)
-	st := NewShareTransport(b, nil)
+	st := NewShareTransport(b, RelativeJoinURL)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -125,8 +143,8 @@ func TestShareTransportRevokeInviteFansOutToHost(t *testing.T) {
 		t.Fatalf("host.RevokeParticipant call count: got %d want %d", got, want)
 	}
 	call := host.revokeCalls()[0]
-	if call.adapter != "human-share" {
-		t.Errorf("RevokeParticipant adapter: got %q want %q", call.adapter, "human-share")
+	if call.adapter != shareAdapterName {
+		t.Errorf("RevokeParticipant adapter: got %q want %q", call.adapter, shareAdapterName)
 	}
 	if call.key != session.ID {
 		t.Errorf("RevokeParticipant key: got %q want %q", call.key, session.ID)
@@ -153,17 +171,144 @@ func TestShareTransportRevokeInviteFansOutToHost(t *testing.T) {
 // broker error for an unknown invite ID rather than silently succeeding.
 func TestShareTransportRevokeInviteUnknown(t *testing.T) {
 	b := newTestBroker(t)
-	st := NewShareTransport(b, nil)
+	st := NewShareTransport(b, RelativeJoinURL)
 	err := st.RevokeInvite(context.Background(), "invite-does-not-exist")
 	if err == nil {
 		t.Fatal("RevokeInvite(unknown) returned nil; want error")
 	}
 }
 
-// TestBrokerTransportHostRevokeParticipantHumanShare confirms the host stub
-// added in this slice routes human-share keys to revokeHumanSession and
-// rejects unknown adapter names.
-func TestBrokerTransportHostRevokeParticipantHumanShare(t *testing.T) {
+// TestShareTransportRevokeInviteWithoutRun pins the silent-success branch in
+// RevokeInvite: when Run has never been called, host.Load() returns nil and
+// the broker-level revoke must still happen. Guards against a refactor that
+// reorders the broker call after the nil-host check (which would skip the
+// invite revoke entirely when Run is not yet up).
+func TestShareTransportRevokeInviteWithoutRun(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, RelativeJoinURL)
+
+	if _, _, err := b.createHumanInvite(); err != nil {
+		t.Fatalf("createHumanInvite: %v", err)
+	}
+	inviteID := lastHumanInviteID(b)
+
+	if err := st.RevokeInvite(context.Background(), inviteID); err != nil {
+		t.Fatalf("RevokeInvite without Run: %v", err)
+	}
+	if !inviteRevoked(b, inviteID) {
+		t.Errorf("invite %q not marked revoked despite RevokeInvite returning nil", inviteID)
+	}
+}
+
+// TestShareTransportRevokeInviteIdempotent calls RevokeInvite twice on the
+// same invite. The second call must succeed and not re-fan-out to the host —
+// the affected-sessions list returned by Broker.RevokeHumanInvite is empty on
+// a second call (the only session was already revoked), so host.
+// RevokeParticipant must not be invoked again. Guards the retry contract that
+// RevokeInvite's docstring describes.
+func TestShareTransportRevokeInviteIdempotent(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, RelativeJoinURL)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	host := &recordingHost{broker: b}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- st.Run(ctx, host) }()
+
+	token, _, err := b.createHumanInvite()
+	if err != nil {
+		t.Fatalf("createHumanInvite: %v", err)
+	}
+	inviteID := lastHumanInviteID(b)
+	if _, _, err := b.acceptHumanInvite(token, "Mira", ""); err != nil {
+		t.Fatalf("acceptHumanInvite: %v", err)
+	}
+
+	if err := st.RevokeInvite(ctx, inviteID); err != nil {
+		t.Fatalf("RevokeInvite #1: %v", err)
+	}
+	firstCallCount := len(host.revokeCalls())
+
+	if err := st.RevokeInvite(ctx, inviteID); err != nil {
+		t.Fatalf("RevokeInvite #2: %v", err)
+	}
+	if got := len(host.revokeCalls()); got != firstCallCount {
+		t.Errorf("RevokeInvite #2 fanned out again: call count went %d -> %d", firstCallCount, got)
+	}
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run returned: %v", err)
+	}
+}
+
+// TestShareTransportRevokeInviteAccumulatesErrors verifies that when more than
+// one session is admitted under a single invite (impossible via the current
+// acceptHumanInvite single-accept rule, but exercised here by appending a
+// second session directly to broker state) a host error on the first session
+// does not stop the second from being revoked, and both errors are returned
+// via errors.Join. Without this loop guard a partial fan-out would leave
+// later sessions live under a revoked invite.
+func TestShareTransportRevokeInviteAccumulatesErrors(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, RelativeJoinURL)
+
+	token, _, err := b.createHumanInvite()
+	if err != nil {
+		t.Fatalf("createHumanInvite: %v", err)
+	}
+	inviteID := lastHumanInviteID(b)
+	if _, _, err := b.acceptHumanInvite(token, "Mira", ""); err != nil {
+		t.Fatalf("acceptHumanInvite: %v", err)
+	}
+	// Inject a second session under the same invite so we can exercise a
+	// multi-session fan-out. Bypasses acceptHumanInvite's single-accept rule
+	// because the production code today never produces this state — we test
+	// the loop semantics, not the broker policy.
+	b.mu.Lock()
+	b.humanSessions = append(b.humanSessions, humanSession{
+		ID:        "session-injected",
+		InviteID:  inviteID,
+		HumanSlug: "extra",
+	})
+	if b.humanSessionRevoke == nil {
+		b.humanSessionRevoke = make(map[string]chan struct{})
+	}
+	b.humanSessionRevoke["session-injected"] = make(chan struct{})
+	b.mu.Unlock()
+
+	failFirst := &erroringHost{
+		broker:   b,
+		failOnce: errors.New("synthetic revoke failure"),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- st.Run(ctx, failFirst) }()
+
+	err = st.RevokeInvite(ctx, inviteID)
+	if err == nil {
+		t.Fatal("RevokeInvite returned nil; want joined error")
+	}
+	if !strings.Contains(err.Error(), "synthetic revoke failure") {
+		t.Errorf("RevokeInvite error %v should include first-call failure", err)
+	}
+	if got := len(failFirst.revokeCalls()); got != 2 {
+		t.Errorf("RevokeParticipant call count: got %d want 2 (loop must continue past first error)", got)
+	}
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run returned: %v", err)
+	}
+}
+
+// TestBrokerTransportHostRevokeParticipantShare confirms the host stub added
+// in this slice routes share-adapter keys to revokeHumanSession and rejects
+// unknown adapter names.
+func TestBrokerTransportHostRevokeParticipantShare(t *testing.T) {
 	b := newTestBroker(t)
 	host := &brokerTransportHost{broker: b}
 
@@ -176,7 +321,7 @@ func TestBrokerTransportHostRevokeParticipantHumanShare(t *testing.T) {
 		t.Fatalf("acceptHumanInvite: %v", err)
 	}
 
-	if err := host.RevokeParticipant(context.Background(), "human-share", session.ID); err != nil {
+	if err := host.RevokeParticipant(context.Background(), shareAdapterName, session.ID); err != nil {
 		t.Fatalf("RevokeParticipant: %v", err)
 	}
 	if b.humanSessionIDActive(session.ID) {
@@ -195,7 +340,7 @@ func TestBrokerTransportHostRevokeParticipantHumanShare(t *testing.T) {
 // in stops a future refactor from making Send error and breaking outbound
 // office broadcasts.
 func TestShareTransportSendIsNoop(t *testing.T) {
-	st := NewShareTransport(newTestBroker(t), nil)
+	st := NewShareTransport(newTestBroker(t), RelativeJoinURL)
 	if err := st.Send(context.Background(), transport.Outbound{Text: "hello"}); err != nil {
 		t.Errorf("Send returned %v; want nil for human-share", err)
 	}
@@ -203,7 +348,7 @@ func TestShareTransportSendIsNoop(t *testing.T) {
 
 // TestShareTransportHealthBeforeRun pins the pre-Run health state.
 func TestShareTransportHealthBeforeRun(t *testing.T) {
-	st := NewShareTransport(newTestBroker(t), nil)
+	st := NewShareTransport(newTestBroker(t), RelativeJoinURL)
 	if got := st.Health().State; got != transport.HealthDisconnected {
 		t.Errorf("Health() before Run: got %q want %q", got, transport.HealthDisconnected)
 	}
@@ -215,7 +360,7 @@ func TestShareTransportHealthBeforeRun(t *testing.T) {
 // so a regression that always reports Disconnected would silently degrade the
 // UI).
 func TestShareTransportHealthAfterRun(t *testing.T) {
-	st := NewShareTransport(newTestBroker(t), nil)
+	st := NewShareTransport(newTestBroker(t), RelativeJoinURL)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	if err := st.Run(ctx, &recordingHost{}); err != nil {
@@ -264,6 +409,45 @@ func (h *recordingHost) RevokeParticipant(ctx context.Context, adapterName, key 
 }
 
 func (h *recordingHost) revokeCalls() []revokeCall {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]revokeCall, len(h.revoked))
+	copy(out, h.revoked)
+	return out
+}
+
+// erroringHost returns failOnce as the error from the first RevokeParticipant
+// call, then delegates subsequent calls to the broker. Used to verify the
+// fan-out loop continues past errors and accumulates them via errors.Join.
+type erroringHost struct {
+	broker   *Broker
+	failOnce error
+	mu       sync.Mutex
+	revoked  []revokeCall
+}
+
+func (h *erroringHost) ReceiveMessage(_ context.Context, _ transport.Message) error { return nil }
+func (h *erroringHost) UpsertParticipant(_ context.Context, _ transport.Participant, _ transport.Binding) error {
+	return nil
+}
+func (h *erroringHost) DetachParticipant(_ context.Context, _, _ string) error { return nil }
+
+func (h *erroringHost) RevokeParticipant(ctx context.Context, adapterName, key string) error {
+	h.mu.Lock()
+	h.revoked = append(h.revoked, revokeCall{adapter: adapterName, key: key})
+	first := h.failOnce
+	h.failOnce = nil
+	h.mu.Unlock()
+	if first != nil {
+		return first
+	}
+	if h.broker == nil {
+		return nil
+	}
+	return (&brokerTransportHost{broker: h.broker}).RevokeParticipant(ctx, adapterName, key)
+}
+
+func (h *erroringHost) revokeCalls() []revokeCall {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	out := make([]revokeCall, len(h.revoked))

--- a/internal/team/share_transport_test.go
+++ b/internal/team/share_transport_test.go
@@ -7,9 +7,51 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/team/transport"
 )
+
+// shareTestRunDeadline bounds the polling rendezvous and Run-return waits in
+// share-transport tests. Each test should complete in milliseconds; a 2s cap
+// keeps a real regression visible as a fast Fatal rather than a CI timeout.
+const shareTestRunDeadline = 2 * time.Second
+
+// waitForShareConnected polls st.Health() until it reports HealthConnected,
+// failing the test with a deterministic message if the deadline elapses or if
+// Run exited early. Used to rendezvous with the goroutine running st.Run
+// before exercising RevokeInvite — the host pointer is published in the same
+// atomic store that flips Health to Connected, so this is the right gate.
+func waitForShareConnected(t *testing.T, st *ShareTransport, runErr <-chan error) {
+	t.Helper()
+	deadline := time.Now().Add(shareTestRunDeadline)
+	for st.Health().State != transport.HealthConnected {
+		select {
+		case err := <-runErr:
+			t.Fatalf("Run returned before HealthConnected: %v", err)
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for HealthConnected after %s", shareTestRunDeadline)
+		}
+		runtime.Gosched()
+	}
+}
+
+// awaitRunReturn drains runErr after a test cancels its context, with a
+// bounded timeout so a hung Run surfaces as a Fatal rather than the Go test
+// framework's default 10-minute timeout.
+func awaitRunReturn(t *testing.T, runErr <-chan error) {
+	t.Helper()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run returned: %v", err)
+		}
+	case <-time.After(shareTestRunDeadline):
+		t.Fatalf("Run did not return within %s after cancel", shareTestRunDeadline)
+	}
+}
 
 // TestShareTransportRunRequiresHost confirms Run rejects a nil host so a
 // misconfigured launcher fails loudly instead of silently degrading.
@@ -120,9 +162,7 @@ func TestShareTransportRevokeInviteFansOutToHost(t *testing.T) {
 	// Wait for Run to store the host before calling RevokeInvite; without
 	// this, RevokeInvite may see a nil host pointer and silently skip the
 	// per-session fan-out, making the test a false positive.
-	for st.Health().State != transport.HealthConnected {
-		runtime.Gosched()
-	}
+	waitForShareConnected(t, st, runErr)
 
 	token, _, err := b.createHumanInvite()
 	if err != nil {
@@ -162,9 +202,7 @@ func TestShareTransportRevokeInviteFansOutToHost(t *testing.T) {
 	}
 
 	cancel()
-	if err := <-runErr; err != nil {
-		t.Fatalf("Run returned: %v", err)
-	}
+	awaitRunReturn(t, runErr)
 }
 
 // TestShareTransportRevokeInviteUnknown asserts RevokeInvite surfaces the
@@ -239,9 +277,7 @@ func TestShareTransportRevokeInviteIdempotent(t *testing.T) {
 	}
 
 	cancel()
-	if err := <-runErr; err != nil {
-		t.Fatalf("Run returned: %v", err)
-	}
+	awaitRunReturn(t, runErr)
 }
 
 // TestShareTransportRevokeInviteAccumulatesErrors verifies that when more than
@@ -300,9 +336,7 @@ func TestShareTransportRevokeInviteAccumulatesErrors(t *testing.T) {
 	}
 
 	cancel()
-	if err := <-runErr; err != nil {
-		t.Fatalf("Run returned: %v", err)
-	}
+	awaitRunReturn(t, runErr)
 }
 
 // TestBrokerTransportHostRevokeParticipantShare confirms the host stub added

--- a/internal/team/share_transport_test.go
+++ b/internal/team/share_transport_test.go
@@ -1,0 +1,286 @@
+package team
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// TestShareTransportRunRequiresHost confirms Run rejects a nil host so a
+// misconfigured launcher fails loudly instead of silently degrading.
+func TestShareTransportRunRequiresHost(t *testing.T) {
+	st := NewShareTransport(newTestBroker(t), nil)
+	err := st.Run(context.Background(), nil)
+	if err == nil {
+		t.Fatal("Run(nil host) returned nil error; want guard error")
+	}
+}
+
+// TestShareTransportNameAndBinding pins the stable adapter identity and scope
+// declaration. Changing either is a contract break — admitted-human identity
+// is keyed off shareAdapterName across restarts.
+func TestShareTransportNameAndBinding(t *testing.T) {
+	st := NewShareTransport(newTestBroker(t), nil)
+	if got, want := st.Name(), "human-share"; got != want {
+		t.Errorf("Name(): got %q want %q", got, want)
+	}
+	binding := st.Binding()
+	if binding.Scope != transport.ScopeOffice {
+		t.Errorf("Binding().Scope: got %q want %q", binding.Scope, transport.ScopeOffice)
+	}
+	if binding.MemberSlug != "" || binding.ChannelSlug != "" {
+		t.Errorf("Binding(): expected empty MemberSlug/ChannelSlug for office scope, got %+v", binding)
+	}
+}
+
+// TestShareTransportCreateInviteFallback verifies CreateInvite returns a
+// relative /join/<token> path when no urlBuilder is injected. This is the
+// path the launcher takes today; production wiring of an absolute URL will
+// arrive when the share controller adopts the adapter.
+func TestShareTransportCreateInviteFallback(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, nil)
+	got, err := st.CreateInvite(context.Background(), "tailscale")
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if !strings.HasPrefix(got, "/join/") {
+		t.Errorf("CreateInvite: got %q, want /join/<token>", got)
+	}
+	if got == "/join/" {
+		t.Error("CreateInvite: empty token in returned URL")
+	}
+}
+
+// TestShareTransportCreateInviteUsesBuilder confirms the injected URL builder
+// is invoked with the same token the broker minted.
+func TestShareTransportCreateInviteUsesBuilder(t *testing.T) {
+	b := newTestBroker(t)
+	var seenToken string
+	builder := func(token string) string {
+		seenToken = token
+		return "https://office.example/join/" + token
+	}
+	st := NewShareTransport(b, builder)
+	got, err := st.CreateInvite(context.Background(), "")
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if !strings.HasPrefix(got, "https://office.example/join/") {
+		t.Errorf("CreateInvite: got %q, want https://office.example/join/<token>", got)
+	}
+	if seenToken == "" {
+		t.Error("urlBuilder was not invoked")
+	}
+	if !strings.HasSuffix(got, seenToken) {
+		t.Errorf("returned URL %q does not include builder-seen token %q", got, seenToken)
+	}
+}
+
+// TestShareTransportRevokeInviteFansOutToHost is the central correctness test:
+// after CreateInvite + accept (simulating a human joining), RevokeInvite must
+// (a) mark the invite revoked in the broker, (b) call host.RevokeParticipant
+// for every active session under that invite, and (c) leave the affected
+// sessions revoked in the broker (because Host.RevokeParticipant routes to
+// revokeHumanSession). Guards against silently dropping the per-session
+// teardown that the OfficeBoundTransport contract requires.
+func TestShareTransportRevokeInviteFansOutToHost(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	host := &recordingHost{broker: b}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- st.Run(ctx, host) }()
+
+	token, _, err := b.createHumanInvite()
+	if err != nil {
+		t.Fatalf("createHumanInvite: %v", err)
+	}
+	inviteID := lastHumanInviteID(b)
+
+	_, session, err := b.acceptHumanInvite(token, "Mira", "laptop")
+	if err != nil {
+		t.Fatalf("acceptHumanInvite: %v", err)
+	}
+
+	if err := st.RevokeInvite(ctx, inviteID); err != nil {
+		t.Fatalf("RevokeInvite: %v", err)
+	}
+
+	if got, want := len(host.revokeCalls()), 1; got != want {
+		t.Fatalf("host.RevokeParticipant call count: got %d want %d", got, want)
+	}
+	call := host.revokeCalls()[0]
+	if call.adapter != "human-share" {
+		t.Errorf("RevokeParticipant adapter: got %q want %q", call.adapter, "human-share")
+	}
+	if call.key != session.ID {
+		t.Errorf("RevokeParticipant key: got %q want %q", call.key, session.ID)
+	}
+
+	// Session must now be revoked at the broker level (the recordingHost
+	// passes RevokeParticipant through to revokeHumanSession).
+	if b.humanSessionIDActive(session.ID) {
+		t.Errorf("session %q still active after RevokeInvite", session.ID)
+	}
+
+	// Invite itself is marked revoked.
+	if !inviteRevoked(b, inviteID) {
+		t.Errorf("invite %q not marked revoked", inviteID)
+	}
+
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run returned: %v", err)
+	}
+}
+
+// TestShareTransportRevokeInviteUnknown asserts RevokeInvite surfaces the
+// broker error for an unknown invite ID rather than silently succeeding.
+func TestShareTransportRevokeInviteUnknown(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, nil)
+	err := st.RevokeInvite(context.Background(), "invite-does-not-exist")
+	if err == nil {
+		t.Fatal("RevokeInvite(unknown) returned nil; want error")
+	}
+}
+
+// TestBrokerTransportHostRevokeParticipantHumanShare confirms the host stub
+// added in this slice routes human-share keys to revokeHumanSession and
+// rejects unknown adapter names.
+func TestBrokerTransportHostRevokeParticipantHumanShare(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+
+	token, _, err := b.createHumanInvite()
+	if err != nil {
+		t.Fatalf("createHumanInvite: %v", err)
+	}
+	_, session, err := b.acceptHumanInvite(token, "Devon", "")
+	if err != nil {
+		t.Fatalf("acceptHumanInvite: %v", err)
+	}
+
+	if err := host.RevokeParticipant(context.Background(), "human-share", session.ID); err != nil {
+		t.Fatalf("RevokeParticipant: %v", err)
+	}
+	if b.humanSessionIDActive(session.ID) {
+		t.Errorf("session %q still active after RevokeParticipant", session.ID)
+	}
+
+	// Unknown adapter must not silently no-op.
+	if err := host.RevokeParticipant(context.Background(), "made-up", "key"); err == nil {
+		t.Error("RevokeParticipant(unknown adapter) returned nil; want unsupported-adapter error")
+	}
+}
+
+// TestShareTransportSendIsNoop pins the no-op Send semantics. Office-bound
+// human-share has no external network to push to (admitted humans poll the
+// broker directly), so Send accepts the message and returns nil. Locking this
+// in stops a future refactor from making Send error and breaking outbound
+// office broadcasts.
+func TestShareTransportSendIsNoop(t *testing.T) {
+	st := NewShareTransport(newTestBroker(t), nil)
+	if err := st.Send(context.Background(), transport.Outbound{Text: "hello"}); err != nil {
+		t.Errorf("Send returned %v; want nil for human-share", err)
+	}
+}
+
+// TestShareTransportHealthBeforeRun pins the pre-Run health state.
+func TestShareTransportHealthBeforeRun(t *testing.T) {
+	st := NewShareTransport(newTestBroker(t), nil)
+	if got := st.Health().State; got != transport.HealthDisconnected {
+		t.Errorf("Health() before Run: got %q want %q", got, transport.HealthDisconnected)
+	}
+}
+
+// TestShareTransportHealthAfterRun runs Run with a pre-cancelled context so
+// Run returns synchronously after setting startedAt. After Run returns Health
+// must report Connected (the launcher renders Health on every channel header,
+// so a regression that always reports Disconnected would silently degrade the
+// UI).
+func TestShareTransportHealthAfterRun(t *testing.T) {
+	st := NewShareTransport(newTestBroker(t), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := st.Run(ctx, &recordingHost{}); err != nil {
+		t.Fatalf("Run(cancelled): %v", err)
+	}
+	if got := st.Health().State; got != transport.HealthConnected {
+		t.Errorf("Health() after Run: got %q want %q", got, transport.HealthConnected)
+	}
+}
+
+// recordingHost is a transport.Host that records every RevokeParticipant call
+// and (when broker is non-nil) delegates to brokerTransportHost so the broker
+// actually revokes the session. UpsertParticipant and ReceiveMessage are
+// no-ops; the share adapter never calls them in slice B.
+type recordingHost struct {
+	broker  *Broker
+	mu      sync.Mutex
+	revoked []revokeCall
+}
+
+type revokeCall struct {
+	adapter string
+	key     string
+}
+
+func (h *recordingHost) ReceiveMessage(_ context.Context, _ transport.Message) error {
+	return nil
+}
+
+func (h *recordingHost) UpsertParticipant(_ context.Context, _ transport.Participant, _ transport.Binding) error {
+	return nil
+}
+
+func (h *recordingHost) DetachParticipant(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+func (h *recordingHost) RevokeParticipant(ctx context.Context, adapterName, key string) error {
+	h.mu.Lock()
+	h.revoked = append(h.revoked, revokeCall{adapter: adapterName, key: key})
+	h.mu.Unlock()
+	if h.broker == nil {
+		return nil
+	}
+	return (&brokerTransportHost{broker: h.broker}).RevokeParticipant(ctx, adapterName, key)
+}
+
+func (h *recordingHost) revokeCalls() []revokeCall {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]revokeCall, len(h.revoked))
+	copy(out, h.revoked)
+	return out
+}
+
+// lastHumanInviteID returns the most recently created invite ID. Test-only.
+func lastHumanInviteID(b *Broker) string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.humanInvites) == 0 {
+		return ""
+	}
+	return b.humanInvites[len(b.humanInvites)-1].ID
+}
+
+// inviteRevoked reports whether the invite with the given ID has RevokedAt set.
+func inviteRevoked(b *Broker, inviteID string) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, inv := range b.humanInvites {
+		if inv.ID == inviteID {
+			return inv.RevokedAt != ""
+		}
+	}
+	return false
+}

--- a/internal/team/share_transport_test.go
+++ b/internal/team/share_transport_test.go
@@ -254,6 +254,7 @@ func TestShareTransportRevokeInviteIdempotent(t *testing.T) {
 
 	runErr := make(chan error, 1)
 	go func() { runErr <- st.Run(ctx, host) }()
+	waitForShareConnected(t, st, runErr)
 
 	token, _, err := b.createHumanInvite()
 	if err != nil {
@@ -323,6 +324,7 @@ func TestShareTransportRevokeInviteAccumulatesErrors(t *testing.T) {
 	defer cancel()
 	runErr := make(chan error, 1)
 	go func() { runErr <- st.Run(ctx, failFirst) }()
+	waitForShareConnected(t, st, runErr)
 
 	err = st.RevokeInvite(ctx, inviteID)
 	if err == nil {


### PR DESCRIPTION
## Summary

- Add \`ShareTransport\` implementing \`transport.OfficeBoundTransport\` on top of the existing human-share invite/session surface.
- Implement \`brokerTransportHost.RevokeParticipant\` (was a \"not yet implemented (phase 4)\" stub).
- Add \`Broker.RevokeHumanInvite\` so an invite can be revoked without immediately tearing down sessions; the adapter fans out \`host.RevokeParticipant\` per the contract.
- Register \`ShareTransport\` in \`RegisterTransports\` unconditionally — it has no opt-in config.

This closes the OfficeBoundTransport gap left after slice A (#646) and removes the \"Future:\" comment in \`launcher_transports.go\`.

## Design notes

\`CreateInvite\` accepts an optional \`JoinURLBuilder\` injected at construction. The launcher passes nil because it does not know the share controller's bind address (the share controller lives in \`cmd/wuphf\` and boots independently); CreateInvite returns \`/join/<token>\` until the share controller adopts the adapter and supplies a builder. This keeps slice B narrow and avoids cross-cutting changes to the share controller's lifecycle.

\`Send\` is a deliberate no-op: admitted humans poll the broker directly via \`/api/*\` routes, so there is no external network for the adapter to push to. A test pins this so a future refactor cannot silently break outbound office broadcasts by making Send error.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`bash scripts/test-go.sh ./internal/team\` — green (89s)
- [x] \`go test -race -run \"TestShareTransport|TestBrokerTransportHostRevokeParticipantHumanShare\" ./internal/team/...\` — green
- [x] \`golangci-lint run ./internal/team/...\` — 0 issues
- [ ] Smoke: launch wuphf-dev, create invite, accept it, revoke it via adapter, verify session terminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Human-share transport: create invites with configurable join URLs, revoke invites (collecting affected sessions and notifying hosts), and health reporting (Disconnected → Connected). Transport auto-registers at startup.

* **Bug Fixes**
  * Invite revocation validates input, is idempotent, returns clear errors for unknown invites, and reliably routes revoke requests; fan-out to multiple sessions continues past individual failures while aggregating errors.

* **Tests**
  * Extensive tests for invite lifecycle, revocation fan-out/aggregation, routing, send no-op, and health transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->