### PR TITLE
feat(wiki): rich editor MVP behind per-article toggle (Phase 3 PR 5)

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -5,6 +5,15 @@
     "": {
       "name": "wuphf-web",
       "dependencies": {
+        "@milkdown/core": "^7.20.0",
+        "@milkdown/ctx": "^7.20.0",
+        "@milkdown/plugin-listener": "^7.20.0",
+        "@milkdown/preset-commonmark": "^7.20.0",
+        "@milkdown/preset-gfm": "^7.20.0",
+        "@milkdown/prose": "^7.20.0",
+        "@milkdown/react": "^7.20.0",
+        "@milkdown/transformer": "^7.20.0",
+        "@milkdown/utils": "^7.20.0",
         "@tanstack/react-query": "^5.80.7",
         "@tanstack/react-router": "^1.121.3",
         "@xterm/addon-fit": "^0.11.0",
@@ -88,6 +97,68 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.14", "", { "os": "win32", "cpu": "x64" }, "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA=="],
 
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.1", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.6.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q=="],
+
+    "@codemirror/lang-angular": ["@codemirror/lang-angular@0.1.4", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-javascript": "^6.1.2", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.3" } }, "sha512-oap+gsltb/fzdlTQWD6BFF4bSLKcDnlxDsLdePiJpCVNKWXSTAbiiQeYI3UmES+BLAdkmIC1WjyztC1pi/bX4g=="],
+
+    "@codemirror/lang-cpp": ["@codemirror/lang-cpp@6.0.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/cpp": "^1.0.0" } }, "sha512-URM26M3vunFFn9/sm6rzqrBzDgfWuDixp85uTY49wKudToc2jTHUrKIGGKs+QWND+YLofNNZpxcNGRynFJfvgA=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-go": ["@codemirror/lang-go@6.0.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/go": "^1.0.0" } }, "sha512-7fNvbyNylvqCphW9HD6WFnRpcDjr+KXX/FgqXy5H5ZS0eC5edDljukm/yNgYkwTsgp2busdod50AOTIy6Jikfg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw=="],
+
+    "@codemirror/lang-java": ["@codemirror/lang-java@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/java": "^1.0.0" } }, "sha512-m5Nt1mQ/cznJY7tMfQTJchmrjdjQ71IDs+55d1GAa8DGaB8JXWsVCkVT284C3RTASaY43YknrK2X3hPO/J3MOQ=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-jinja": ["@codemirror/lang-jinja@6.0.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.2.0", "@lezer/lr": "^1.4.0" } }, "sha512-P5kyHLObzjtbGj16h+hyvZTxJhSjBEeSx4wMjbnAf3b0uwTy2+F0zGjMZL4PQOm/mh2eGZ5xUDVZXgwP783Nsw=="],
+
+    "@codemirror/lang-json": ["@codemirror/lang-json@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/json": "^1.0.0" } }, "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ=="],
+
+    "@codemirror/lang-less": ["@codemirror/lang-less@6.0.2", "", { "dependencies": { "@codemirror/lang-css": "^6.2.0", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-EYdQTG22V+KUUk8Qq582g7FMnCZeEHsyuOJisHRft/mQ+ZSZ2w51NupvDUHiqtsOy7It5cHLPGfHQLpMh9bqpQ=="],
+
+    "@codemirror/lang-liquid": ["@codemirror/lang-liquid@6.3.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.1" } }, "sha512-6PDVU3ZnfeYyz1at1E/ttorErZvZFXXt1OPhtfe1EZJ2V2iDFa0CwPqPgG5F7NXN0yONGoBogKmFAafKTqlwIw=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw=="],
+
+    "@codemirror/lang-php": ["@codemirror/lang-php@6.0.2", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/php": "^1.0.0" } }, "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA=="],
+
+    "@codemirror/lang-python": ["@codemirror/lang-python@6.2.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.3.2", "@codemirror/language": "^6.8.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/python": "^1.1.4" } }, "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw=="],
+
+    "@codemirror/lang-rust": ["@codemirror/lang-rust@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/rust": "^1.0.0" } }, "sha512-EZaGjCUegtiU7kSMvOfEZpaCReowEf3yNidYu7+vfuGTm9ow4mthAparY5hisJqOHmJowVH3Upu+eJlUji6qqA=="],
+
+    "@codemirror/lang-sass": ["@codemirror/lang-sass@6.0.2", "", { "dependencies": { "@codemirror/lang-css": "^6.2.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/sass": "^1.0.0" } }, "sha512-l/bdzIABvnTo1nzdY6U+kPAC51czYQcOErfzQ9zSm9D8GmNPD0WTW8st/CJwBTPLO8jlrbyvlSEcN20dc4iL0Q=="],
+
+    "@codemirror/lang-sql": ["@codemirror/lang-sql@6.10.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w=="],
+
+    "@codemirror/lang-vue": ["@codemirror/lang-vue@0.1.3", "", { "dependencies": { "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-javascript": "^6.1.2", "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.1" } }, "sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug=="],
+
+    "@codemirror/lang-wast": ["@codemirror/lang-wast@6.0.2", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-Imi2KTpVGm7TKuUkqyJ5NRmeFWF7aMpNiwHnLQe0x9kmrxElndyH0K6H/gXtWwY6UshMRAhpENsgfpSwsgmC6Q=="],
+
+    "@codemirror/lang-xml": ["@codemirror/lang-xml@6.1.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.0.0", "@lezer/xml": "^1.0.0" } }, "sha512-3z0blhicHLfwi2UgkZYRPioSgVTo9PV5GP5ducFH6FaHy0IAJRg+ixj5gTR1gnT/glAIC8xv4w2VL1LoZfs+Jg=="],
+
+    "@codemirror/lang-yaml": ["@codemirror/lang-yaml@6.1.3", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.2.0", "@lezer/lr": "^1.0.0", "@lezer/yaml": "^1.0.0" } }, "sha512-AZ8DJBuXGVHybpBQhmZtgew5//4hv3tdkXnr3vDmOUMJRuB6vn/uuwtmTOTlqEaQFg3hQSVeA90NmvIQyUV6FQ=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
+
+    "@codemirror/language-data": ["@codemirror/language-data@6.5.2", "", { "dependencies": { "@codemirror/lang-angular": "^0.1.0", "@codemirror/lang-cpp": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-go": "^6.0.0", "@codemirror/lang-html": "^6.0.0", "@codemirror/lang-java": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/lang-jinja": "^6.0.0", "@codemirror/lang-json": "^6.0.0", "@codemirror/lang-less": "^6.0.0", "@codemirror/lang-liquid": "^6.0.0", "@codemirror/lang-markdown": "^6.0.0", "@codemirror/lang-php": "^6.0.0", "@codemirror/lang-python": "^6.0.0", "@codemirror/lang-rust": "^6.0.0", "@codemirror/lang-sass": "^6.0.0", "@codemirror/lang-sql": "^6.0.0", "@codemirror/lang-vue": "^0.1.1", "@codemirror/lang-wast": "^6.0.0", "@codemirror/lang-xml": "^6.0.0", "@codemirror/lang-yaml": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/legacy-modes": "^6.4.0" } }, "sha512-CPkWBKrNS8stYbEU5kwBwTf3JB1kghlbh4FSAwzGW2TEscdeHHH4FGysREW86Mqnj3Qn09s0/6Ea/TutmoTobg=="],
+
+    "@codemirror/legacy-modes": ["@codemirror/legacy-modes@6.5.2", "", { "dependencies": { "@codemirror/language": "^6.0.0" } }, "sha512-/jJbwSTazlQEDOQw2FJ8LEEKVS72pU0lx6oM54kGpL8t/NJ2Jda3CZ4pcltiKTdqYSRk3ug1B3pil1gsjA6+8Q=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.5", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.35.0", "crelt": "^1.0.5" } }, "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA=="],
+
+    "@codemirror/search": ["@codemirror/search@6.7.0", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.37.0", "crelt": "^1.0.5" } }, "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg=="],
+
+    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+
+    "@codemirror/theme-one-dark": ["@codemirror/theme-one-dark@6.1.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/highlight": "^1.0.0" } }, "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA=="],
+
+    "@codemirror/view": ["@codemirror/view@6.41.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg=="],
+
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
@@ -146,6 +217,12 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -156,7 +233,89 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, ""],
 
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/cpp": ["@lezer/cpp@1.1.5", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-DIhSXmYtJKLehrjzDFN+2cPt547ySQ41nA8yqcDf/GxMc+YM736xqltFkvADL2M0VebU5I+3+4ks2Vv+Kyq3Aw=="],
+
+    "@lezer/css": ["@lezer/css@1.3.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg=="],
+
+    "@lezer/go": ["@lezer/go@1.0.1", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-xToRsYxwsgJNHTgNdStpcvmbVuKxTapV0dM0wey1geMMRc9aggoVyKgzYp41D2/vVOx+Ii4hmE206kvxIXBVXQ=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/java": ["@lezer/java@1.1.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-yHquUfujwg6Yu4Fd1GNHCvidIvJwi/1Xu2DaKl/pfWIA2c1oXkVvawH3NyXhCaFx4OdlYBVX5wvz2f7Aoa/4Xw=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/json": ["@lezer/json@1.0.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.6.3", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw=="],
+
+    "@lezer/php": ["@lezer/php@1.0.5", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.1.0" } }, "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA=="],
+
+    "@lezer/python": ["@lezer/python@1.1.18", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-31FiUrU7z9+d/ElGQLJFXl+dKOdx0jALlP3KEOsGTex8mvj+SoE1FgItcHWK/axkxCHGUSpqIHt6JAWfWu9Rhg=="],
+
+    "@lezer/rust": ["@lezer/rust@1.0.2", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-Lz5sIPBdF2FUXcWeCu1//ojFAZqzTQNRga0aYv6dYXqJqPfMdCAI0NzajWUd4Xijj1IKJLtjoXRPMvTKWBcqKg=="],
+
+    "@lezer/sass": ["@lezer/sass@1.1.0", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-3mMGdCTUZ/84ArHOuXWQr37pnf7f+Nw9ycPUeKX+wu19b7pSMcZGLbaXwvD2APMBDOGxPmpK/O6S1v1EvLoqgQ=="],
+
+    "@lezer/xml": ["@lezer/xml@1.0.6", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww=="],
+
+    "@lezer/yaml": ["@lezer/yaml@1.0.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.4.0" } }, "sha512-2lrrHqxalACEbxIbsjhqGpSW8kWpUKuY6RHgnSAFZa6qK62wvnPxA8hGOwOoDbwHcOFs5M4o27mjGu+P7TvBmw=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
+
+    "@milkdown/components": ["@milkdown/components@7.20.0", "", { "dependencies": { "@floating-ui/dom": "^1.5.1", "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/plugin-tooltip": "7.20.0", "@milkdown/preset-commonmark": "7.20.0", "@milkdown/preset-gfm": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "@milkdown/utils": "7.20.0", "@types/lodash-es": "^4.17.12", "clsx": "^2.0.0", "dompurify": "^3.2.5", "lodash-es": "^4.17.21", "nanoid": "^5.0.9", "unist-util-visit": "^5.0.0", "vue": "^3.5.20" }, "peerDependencies": { "@codemirror/language": "^6", "@codemirror/state": "^6", "@codemirror/view": "^6" } }, "sha512-Qn91/oZugGjf17ARE51nbEsH4YklZQaomRSsfxOAtIcwGEJe5osq+zhhKGtgAYFfUb6rU3W86Pe4XDlXN6vFjg=="],
+
+    "@milkdown/core": ["@milkdown/core@7.20.0", "", { "dependencies": { "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.3" } }, "sha512-X9LaUcIR4Y2oiY2J5tslavlPVOwIB3X8/9z1bOeBjlIPtr+urbkY7YEX86EeLV9LyRQ3+t+jXaLMCIjW1wsV6w=="],
+
+    "@milkdown/crepe": ["@milkdown/crepe@7.20.0", "", { "dependencies": { "@codemirror/commands": "^6.2.4", "@codemirror/language": "^6.10.1", "@codemirror/language-data": "^6.3.1", "@codemirror/state": "^6.4.1", "@codemirror/theme-one-dark": "^6.1.2", "@codemirror/view": "^6.16.0", "@milkdown/kit": "7.20.0", "@types/lodash-es": "^4.17.12", "clsx": "^2.0.0", "codemirror": "^6.0.1", "katex": "^0.16.0", "lodash-es": "^4.17.21", "prosemirror-virtual-cursor": "^0.4.2", "remark-math": "^6.0.0", "unist-util-visit": "^5.0.0", "vue": "^3.5.20" } }, "sha512-KT+oFF6Q7mI41z01c9v/wUUCyQ2f908TgOsa6mwi25yuxnxQxISZFCjRvlh0sc9p9D3CrMeuJWGCN6DialQdig=="],
+
+    "@milkdown/ctx": ["@milkdown/ctx@7.20.0", "", { "dependencies": { "@milkdown/exception": "7.20.0" } }, "sha512-LUK4xdsUngY2xCCvPTyHPifjAknJ5rE6VBjgsP+LySIUKeFUrhqzo/zz2vaOODKzm3DBMIhpZAoW3MAqxoMGIQ=="],
+
+    "@milkdown/exception": ["@milkdown/exception@7.20.0", "", {}, "sha512-u8EL7rbqgrWrPpkDhrxUYXauw2DO52JUQmuokrUZvqezmflo7pgIDCr+Rk6AQslzB4Xw+n9eYik5rXX3RXC7Qg=="],
+
+    "@milkdown/kit": ["@milkdown/kit@7.20.0", "", { "dependencies": { "@milkdown/components": "7.20.0", "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/plugin-block": "7.20.0", "@milkdown/plugin-clipboard": "7.20.0", "@milkdown/plugin-cursor": "7.20.0", "@milkdown/plugin-history": "7.20.0", "@milkdown/plugin-indent": "7.20.0", "@milkdown/plugin-listener": "7.20.0", "@milkdown/plugin-slash": "7.20.0", "@milkdown/plugin-tooltip": "7.20.0", "@milkdown/plugin-trailing": "7.20.0", "@milkdown/plugin-upload": "7.20.0", "@milkdown/preset-commonmark": "7.20.0", "@milkdown/preset-gfm": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-X74KMa0tcDAAMOE9aFtBRN+RCdD/HMXor5YN18e7d0pe4a65MGFklUGlcg1U6zEfeMMYeC3msNvMKLMwk3O5RA=="],
+
+    "@milkdown/plugin-block": ["@milkdown/plugin-block@7.20.0", "", { "dependencies": { "@floating-ui/dom": "^1.5.1", "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0", "@types/lodash-es": "^4.17.12", "lodash-es": "^4.17.21" } }, "sha512-jIXfzJ8Zje+6+9ZwQuVmNeYE8KfzqL9YJ/YdMvWQIEiKhy2x9pZMAkkufgmUlq1aouxOV+gk5fX+ovxzEzfSrA=="],
+
+    "@milkdown/plugin-clipboard": ["@milkdown/plugin-clipboard@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-PyokNvwgWcO6/I/0LxDRnATpnxvs5upFRlp6eO8PhjwBFZftCIU6D15Wg4JAxwW7Y0NyTWfViWjc9TwiBd6KOQ=="],
+
+    "@milkdown/plugin-cursor": ["@milkdown/plugin-cursor@7.20.0", "", { "dependencies": { "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0", "prosemirror-drop-indicator": "^0.1.0" } }, "sha512-goCPwUARBzGV6Hvnr3P57Bj5TnyFjYIfDFLvgWTIlsm/dR2Wr4Syy4HDOtaKO9YL/VtZ8gtiZVgeo0vhc4CzMA=="],
+
+    "@milkdown/plugin-history": ["@milkdown/plugin-history@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-lqOYQBrxKj4px/i0Cav3zRkCArwnkv8o7fGMh3NtnUXMLSE7/xojK5GFPS4EaS/UKK7/+i1oV2+HRA6+6Ezy7w=="],
+
+    "@milkdown/plugin-indent": ["@milkdown/plugin-indent@7.20.0", "", { "dependencies": { "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-KfdIztQMuHv4Rx1JmSQe2vooN4+Zm7MhjQkNolGyiI7BPZbu855hVIC/s96x3Dk04tkbb+M/i9MJhxCazxfd6Q=="],
+
+    "@milkdown/plugin-listener": ["@milkdown/plugin-listener@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@types/lodash-es": "^4.17.12", "lodash-es": "^4.17.21" } }, "sha512-Sj+B63JfM3NVVS3uGXTPkoz8xx8MQYrR28pI9AaqX5q60tvCvOJw9E1ODvSsBEjeqnN4kablDthIugLlBhOlwQ=="],
+
+    "@milkdown/plugin-slash": ["@milkdown/plugin-slash@7.20.0", "", { "dependencies": { "@floating-ui/dom": "^1.5.1", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0", "@types/lodash-es": "^4.17.12", "lodash-es": "^4.17.21" } }, "sha512-Qm3/ZxkGYd5XN+J/X91lGGu7SBzuQBOTOLjuJdg4qDBZmdEHlGojB+5BhCSAMB3WGyCpQQGbSqKOelUrXtj68w=="],
+
+    "@milkdown/plugin-tooltip": ["@milkdown/plugin-tooltip@7.20.0", "", { "dependencies": { "@floating-ui/dom": "^1.5.1", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0", "@types/lodash-es": "^4.17.12", "lodash-es": "^4.17.21" } }, "sha512-BVaXorpmA6ZAS3+xv0rgrtjV1h2K39G5Z9Wun4RxT1YXJTTbzIuFQ3hwBAGLjLMwTsosp7YhRLaMJJAC0jEY5Q=="],
+
+    "@milkdown/plugin-trailing": ["@milkdown/plugin-trailing@7.20.0", "", { "dependencies": { "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-AxDeMSAZfj0Er7RYLvLRf6FKdQtLVmotxML6Se6zgqIa++bFeIXCU22/FC+9r/6d1eUtraTva9ez5K2qPy8qig=="],
+
+    "@milkdown/plugin-upload": ["@milkdown/plugin-upload@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-g3UQrD2zfpm86r3BcBDfOdEAyQHhay1nf5wUQgNf4zn6IgRttfEF8tosQsL1B/WBnZB05hH5scLWo4DR2bFhUw=="],
+
+    "@milkdown/preset-commonmark": ["@milkdown/preset-commonmark@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "@milkdown/utils": "7.20.0", "remark-inline-links": "^7.0.0", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1" } }, "sha512-+mPcONXfdjaXdx8JMxDIOT3PWHfy5vewK8iY8j8bUiYD8Iw7YfyWTUh9JHOf4vmOpiKGCJd7+iz7e93u95bQRw=="],
+
+    "@milkdown/preset-gfm": ["@milkdown/preset-gfm@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/preset-commonmark": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "@milkdown/utils": "7.20.0", "prosemirror-safari-ime-span": "^1.0.1", "remark-gfm": "^4.0.1" } }, "sha512-ulErTWDqrGYYqto4kQO9dPTMRp+q44pdRTPW4MTeiSO7eJ6JIBUKSqtCm1zf7MX6nZPaPhuscmg5CU2moXOwxQ=="],
+
+    "@milkdown/prose": ["@milkdown/prose@7.20.0", "", { "dependencies": { "@milkdown/exception": "7.20.0", "prosemirror-changeset": "^2.3.1", "prosemirror-commands": "^1.7.1", "prosemirror-dropcursor": "^1.8.2", "prosemirror-gapcursor": "^1.4.0", "prosemirror-history": "^1.5.0", "prosemirror-inputrules": "^1.5.1", "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.4", "prosemirror-schema-list": "^1.5.1", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.1", "prosemirror-transform": "^1.10.5", "prosemirror-view": "^1.41.3" } }, "sha512-Qe6jmKcXsjOfpk8duDFdkLCEo5044L8HSyKVn7ewAe7XJJPUM6bPQaP130UAznq75/+TiKxFCzurcrBO3LzNRg=="],
+
+    "@milkdown/react": ["@milkdown/react@7.20.0", "", { "dependencies": { "@milkdown/crepe": "7.20.0", "@milkdown/kit": "7.20.0" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-uuMuMfTmp2SZJtmKhX+tmVkJNasKnzxlYoHtUwjxuZcy90cWQVYpGXnmwpFgjcXY38lMLsAOLx2jjXrqe7ZOuQ=="],
+
+    "@milkdown/transformer": ["@milkdown/transformer@7.20.0", "", { "dependencies": { "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "remark": "^15.0.1", "unified": "^11.0.3" } }, "sha512-h7KGFr1o5AYwc+hEfnA3Dldo4jRrYOB/7KExaqelcjUz++KYI/9LXMOsV7CpgjtLI3Xtf2IIRTZND1+p2nsOaw=="],
+
+    "@milkdown/utils": ["@milkdown/utils@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "nanoid": "^5.0.9" } }, "sha512-ciEhtLKhIW/Kaz/NRE5DUXVoMCdenn7S4mClrO7sZ/nXtmObnk3okJzSDnamQoDOcLOIbpOu1V3E1Btkvc5x9w=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@ocavue/utils": ["@ocavue/utils@1.6.0", "", {}, "sha512-8W3q1hxx9qFdrYgPtbElllG/tqYkO/dMhlRUiqasO0SuDFTj78azSQjhIrBTFWxlBPPsSZN6zXYHmb3RwN2Jtg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
@@ -314,6 +473,12 @@
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
+    "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
+
+    "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
+
+    "@types/lodash-es": ["@types/lodash-es@4.17.12", "", { "dependencies": { "@types/lodash": "*" } }, "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ=="],
+
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
@@ -351,6 +516,24 @@
     "@vitest/spy": ["@vitest/spy@4.1.4", "", {}, "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ=="],
 
     "@vitest/utils": ["@vitest/utils@4.1.4", "", { "dependencies": { "@vitest/pretty-format": "4.1.4", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw=="],
+
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.33", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.33", "", { "dependencies": { "@vue/compiler-core": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.33", "@vue/compiler-dom": "3.5.33", "@vue/compiler-ssr": "3.5.33", "@vue/shared": "3.5.33", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.10", "source-map-js": "^1.2.1" } }, "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.33", "", { "dependencies": { "@vue/compiler-dom": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.33", "", { "dependencies": { "@vue/shared": "3.5.33" } }, "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.33", "", { "dependencies": { "@vue/reactivity": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.33", "", { "dependencies": { "@vue/reactivity": "3.5.33", "@vue/runtime-core": "3.5.33", "@vue/shared": "3.5.33", "csstype": "^3.2.3" } }, "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.33", "", { "dependencies": { "@vue/compiler-ssr": "3.5.33", "@vue/shared": "3.5.33" }, "peerDependencies": { "vue": "3.5.33" } }, "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw=="],
+
+    "@vue/shared": ["@vue/shared@3.5.33", "", {}, "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
@@ -392,11 +575,17 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "codemirror": ["codemirror@6.0.2", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/commands": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/lint": "^6.0.0", "@codemirror/search": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0" } }, "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw=="],
+
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, ""],
 
     "cookie-es": ["cookie-es@3.1.1", "", {}, ""],
+
+    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
@@ -494,6 +683,8 @@
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
+    "katex": ["katex@0.16.45", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA=="],
+
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
@@ -518,6 +709,8 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": "bin/bin.js" }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
@@ -529,6 +722,8 @@
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "mdast-util-definitions": ["mdast-util-definitions@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -545,6 +740,8 @@
     "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
 
     "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-math": ["mdast-util-math@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "longest-streak": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.1.0", "unist-util-remove-position": "^5.0.0" } }, "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w=="],
 
     "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
 
@@ -579,6 +776,8 @@
     "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
 
     "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-extension-math": ["micromark-extension-math@3.1.0", "", { "dependencies": { "@types/katex": "^0.16.0", "devlop": "^1.0.0", "katex": "^0.16.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg=="],
 
     "micromark-extension-wiki-link": ["micromark-extension-wiki-link@0.0.4", "", { "dependencies": { "@babel/runtime": "^7.12.1" } }, "sha512-dJc8AfnoU8BHkN+7fWZvIS20SMsMS1ZlxQUn6We67MqeKbOiEDZV5eEvCpwqGBijbJbxX3Kxz879L4K9HIiOvw=="],
 
@@ -630,6 +829,8 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "orderedmap": ["orderedmap@2.1.1", "", {}, "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
@@ -646,6 +847,38 @@
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
+    "prosemirror-changeset": ["prosemirror-changeset@2.4.1", "", { "dependencies": { "prosemirror-transform": "^1.0.0" } }, "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw=="],
+
+    "prosemirror-commands": ["prosemirror-commands@1.7.1", "", { "dependencies": { "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.10.2" } }, "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w=="],
+
+    "prosemirror-drop-indicator": ["prosemirror-drop-indicator@0.1.3", "", { "dependencies": { "@ocavue/utils": "^1.0.0", "prosemirror-model": "^1.25.4", "prosemirror-state": "^1.4.4", "prosemirror-view": "^1.41.3" } }, "sha512-fJV6G2tHIVXZLUuc60fS9ly1/GuGOlAZUm67S1El+kGFUYh27Hyv6hcGx3rrJ+Q/JZL5jnyAibIZYYWpPqE45g=="],
+
+    "prosemirror-dropcursor": ["prosemirror-dropcursor@1.8.2", "", { "dependencies": { "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0", "prosemirror-view": "^1.1.0" } }, "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw=="],
+
+    "prosemirror-gapcursor": ["prosemirror-gapcursor@1.4.1", "", { "dependencies": { "prosemirror-keymap": "^1.0.0", "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-view": "^1.0.0" } }, "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw=="],
+
+    "prosemirror-history": ["prosemirror-history@1.5.0", "", { "dependencies": { "prosemirror-state": "^1.2.2", "prosemirror-transform": "^1.0.0", "prosemirror-view": "^1.31.0", "rope-sequence": "^1.3.0" } }, "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg=="],
+
+    "prosemirror-inputrules": ["prosemirror-inputrules@1.5.1", "", { "dependencies": { "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.0.0" } }, "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw=="],
+
+    "prosemirror-keymap": ["prosemirror-keymap@1.2.3", "", { "dependencies": { "prosemirror-state": "^1.0.0", "w3c-keyname": "^2.2.0" } }, "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw=="],
+
+    "prosemirror-model": ["prosemirror-model@1.25.4", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA=="],
+
+    "prosemirror-safari-ime-span": ["prosemirror-safari-ime-span@1.0.2", "", { "dependencies": { "prosemirror-state": "^1.4.3", "prosemirror-view": "^1.33.8" } }, "sha512-QJqD8s1zE/CuK56kDsUhndh5hiHh/gFnAuPOA9ytva2s85/ZEt2tNWeALTJN48DtWghSKOmiBsvVn2OlnJ5H2w=="],
+
+    "prosemirror-schema-list": ["prosemirror-schema-list@1.5.1", "", { "dependencies": { "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.7.3" } }, "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q=="],
+
+    "prosemirror-state": ["prosemirror-state@1.4.4", "", { "dependencies": { "prosemirror-model": "^1.0.0", "prosemirror-transform": "^1.0.0", "prosemirror-view": "^1.27.0" } }, "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw=="],
+
+    "prosemirror-tables": ["prosemirror-tables@1.8.5", "", { "dependencies": { "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.4", "prosemirror-state": "^1.4.4", "prosemirror-transform": "^1.10.5", "prosemirror-view": "^1.41.4" } }, "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw=="],
+
+    "prosemirror-transform": ["prosemirror-transform@1.12.0", "", { "dependencies": { "prosemirror-model": "^1.21.0" } }, "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w=="],
+
+    "prosemirror-view": ["prosemirror-view@1.41.8", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA=="],
+
+    "prosemirror-virtual-cursor": ["prosemirror-virtual-cursor@0.4.2", "", { "peerDependencies": { "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-view": "^1.0.0" }, "optionalPeers": ["prosemirror-model", "prosemirror-state", "prosemirror-view"] }, "sha512-pUMKnIuOhhnMcgIJUjhIQTVJruBEGxfMBVQSrK0g2qhGPDm1i12KdsVaFw15dYk+29tZcxjMeR7P5VDKwmbwJg=="],
+
     "react": ["react@19.2.5", "", {}, ""],
 
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, ""],
@@ -660,7 +893,13 @@
 
     "rehype-slug": ["rehype-slug@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "github-slugger": "^2.0.0", "hast-util-heading-rank": "^3.0.0", "hast-util-to-string": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A=="],
 
+    "remark": ["remark@15.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A=="],
+
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-inline-links": ["remark-inline-links@7.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-definitions": "^6.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-4uj1pPM+F495ySZhTIB6ay2oSkTsKgmYaKk/q5HIdhX2fuyLEegpjWa0VdJRJ01sgOqAFo7MBKdDUejIYBMVMQ=="],
+
+    "remark-math": ["remark-math@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-math": "^3.0.0", "micromark-extension-math": "^3.0.0", "unified": "^11.0.0" } }, "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
@@ -675,6 +914,8 @@
     "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, ""],
+
+    "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, ""],
 
@@ -697,6 +938,8 @@
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
@@ -736,6 +979,8 @@
 
     "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
 
+    "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
+
     "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
 
     "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
@@ -754,6 +999,10 @@
 
     "vitest": ["vitest@4.1.4", "", { "dependencies": { "@vitest/expect": "4.1.4", "@vitest/mocker": "4.1.4", "@vitest/pretty-format": "4.1.4", "@vitest/runner": "4.1.4", "@vitest/snapshot": "4.1.4", "@vitest/spy": "4.1.4", "@vitest/utils": "4.1.4", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.4", "@vitest/browser-preview": "4.1.4", "@vitest/browser-webdriverio": "4.1.4", "@vitest/coverage-istanbul": "4.1.4", "@vitest/coverage-v8": "4.1.4", "@vitest/ui": "4.1.4", "happy-dom": "*", "jsdom": "*", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/ui", "jsdom"], "bin": "vitest.mjs" }, "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg=="],
 
+    "vue": ["vue@3.5.33", "", { "dependencies": { "@vue/compiler-dom": "3.5.33", "@vue/compiler-sfc": "3.5.33", "@vue/runtime-dom": "3.5.33", "@vue/server-renderer": "3.5.33", "@vue/shared": "3.5.33" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
+
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": "cli.js" }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
@@ -765,6 +1014,10 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, ""],
+
+    "@milkdown/components/nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
+
+    "@milkdown/utils/nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
 
     "@tailwindcss/node/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -781,6 +1034,10 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "mdast-util-wiki-link/mdast-util-to-markdown": ["mdast-util-to-markdown@0.6.5", "", { "dependencies": { "@types/unist": "^2.0.0", "longest-streak": "^2.0.0", "mdast-util-to-string": "^2.0.0", "parse-entities": "^2.0.0", "repeat-string": "^1.0.0", "zwitch": "^1.0.0" } }, "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,15 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@milkdown/core": "^7.20.0",
+    "@milkdown/ctx": "^7.20.0",
+    "@milkdown/plugin-listener": "^7.20.0",
+    "@milkdown/preset-commonmark": "^7.20.0",
+    "@milkdown/preset-gfm": "^7.20.0",
+    "@milkdown/prose": "^7.20.0",
+    "@milkdown/react": "^7.20.0",
+    "@milkdown/transformer": "^7.20.0",
+    "@milkdown/utils": "^7.20.0",
     "@tanstack/react-query": "^5.80.7",
     "@tanstack/react-router": "^1.121.3",
     "@xterm/addon-fit": "^0.11.0",

--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -109,10 +109,13 @@ function SourcePane({
   return (
     <div className="wk-editor-pane wk-editor-pane--source">
       <label
+        id="wk-editor-source-label"
         className="wk-editor-label"
-        // The textarea only mounts in source mode, so `htmlFor` must drop
-        // when rich is active. The rich wrapper carries an `aria-label`
-        // instead so screen readers can still identify the editor surface.
+        // The textarea only mounts in source mode, so `htmlFor` only points
+        // to it when relevant. In rich mode the wrapper uses
+        // `aria-labelledby` against this label's id so the visible text
+        // both labels the editor *and* clicks through, instead of being a
+        // detached caption with a duplicated `aria-label`.
         htmlFor={editorMode === "source" ? "wk-editor-textarea" : undefined}
       >
         {labelText}
@@ -131,7 +134,7 @@ function SourcePane({
           <div
             className="wk-editor-rich"
             data-testid="wk-editor-rich"
-            aria-label={labelText}
+            aria-labelledby="wk-editor-source-label"
           >
             <RichWikiEditor content={content} onChange={setContent} />
           </div>

--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -1,5 +1,13 @@
 // biome-ignore-all lint/a11y/useAriaPropsSupportedByRole: Passive metadata uses accessible labels queried by screen-reader tests; visual text remains unchanged.
-import { useCallback, useMemo, useRef } from "react";
+import {
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import ReactMarkdown from "react-markdown";
 
 import type { WikiCatalogEntry } from "../../api/wiki";
@@ -9,6 +17,129 @@ import {
   buildRehypePlugins,
   buildRemarkPlugins,
 } from "../../lib/wikiMarkdownConfig";
+
+/**
+ * Milkdown lives in a lazy chunk (~100kB gzipped). Users who never toggle
+ * Rich mode never download it.
+ */
+const RichWikiEditor = lazy(() => import("./editor/RichWikiEditor"));
+
+type EditorMode = "source" | "rich";
+const EDITOR_MODE_KEY_PREFIX = "wuphf:editor-mode:";
+
+function readEditorMode(path: string): EditorMode {
+  if (typeof window === "undefined") return "source";
+  try {
+    const raw = window.localStorage.getItem(EDITOR_MODE_KEY_PREFIX + path);
+    return raw === "rich" ? "rich" : "source";
+  } catch {
+    return "source";
+  }
+}
+
+function writeEditorMode(path: string, mode: EditorMode): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(EDITOR_MODE_KEY_PREFIX + path, mode);
+  } catch {
+    // Storage disabled / out of quota — toggle still works for the session.
+  }
+}
+
+interface MobileTabsProps {
+  mobileView: "source" | "preview";
+  setMobileView: (next: "source" | "preview") => void;
+}
+
+function MobileTabs({ mobileView, setMobileView }: MobileTabsProps) {
+  return (
+    <div
+      className="wk-editor-mobile-tabs"
+      role="tablist"
+      data-testid="wk-editor-mobile-tabs"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mobileView === "source"}
+        className={`wk-editor-mobile-tab${mobileView === "source" ? " is-active" : ""}`}
+        onClick={() => setMobileView("source")}
+        data-testid="wk-editor-mobile-source"
+      >
+        Source
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mobileView === "preview"}
+        className={
+          "wk-editor-mobile-tab" +
+          (mobileView === "preview" ? " is-active" : "")
+        }
+        onClick={() => setMobileView("preview")}
+        data-testid="wk-editor-mobile-preview"
+      >
+        Preview
+      </button>
+    </div>
+  );
+}
+
+interface SourcePaneProps {
+  path: string;
+  editorMode: EditorMode;
+  content: string;
+  setContent: (next: string) => void;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+/**
+ * The left/source pane swaps between the textarea and the lazy Milkdown
+ * surface based on `editorMode`. Pulled out of `WikiEditor` so the parent
+ * stays under Biome's cognitive-complexity ceiling.
+ */
+function SourcePane({
+  path,
+  editorMode,
+  content,
+  setContent,
+  textareaRef,
+}: SourcePaneProps) {
+  return (
+    <div className="wk-editor-pane wk-editor-pane--source">
+      <label className="wk-editor-label" htmlFor="wk-editor-textarea">
+        Article source ({path})
+      </label>
+      {editorMode === "rich" ? (
+        <Suspense
+          fallback={
+            <div
+              className="wk-editor-rich-fallback"
+              data-testid="wk-editor-rich-loading"
+            >
+              Loading rich editor…
+            </div>
+          }
+        >
+          <div className="wk-editor-rich" data-testid="wk-editor-rich">
+            <RichWikiEditor content={content} onChange={setContent} />
+          </div>
+        </Suspense>
+      ) : (
+        <textarea
+          id="wk-editor-textarea"
+          ref={textareaRef}
+          className="wk-editor-textarea"
+          data-testid="wk-editor-textarea"
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          spellCheck={true}
+          rows={28}
+        />
+      )}
+    </div>
+  );
+}
 
 interface WikiEditorProps {
   /** Target article path, e.g. `team/people/nazz.md`. */
@@ -108,6 +239,22 @@ export default function WikiEditor({
     [resolver],
   );
 
+  // Per-article editor mode — persists across sessions so a user who picks
+  // Rich on a page they edit often gets it back next time without resetting.
+  const [editorMode, setEditorMode] = useState<EditorMode>(() =>
+    readEditorMode(path),
+  );
+  useEffect(() => {
+    setEditorMode(readEditorMode(path));
+  }, [path]);
+  const toggleEditorMode = useCallback(() => {
+    setEditorMode((prev) => {
+      const next: EditorMode = prev === "rich" ? "source" : "rich";
+      writeEditorMode(path, next);
+      return next;
+    });
+  }, [path]);
+
   return (
     <div
       className={`wk-editor${previewOn ? " wk-editor--with-preview" : ""}`}
@@ -158,56 +305,17 @@ export default function WikiEditor({
         </div>
       )}
       {previewOn && isMobile ? (
-        <div
-          className="wk-editor-mobile-tabs"
-          role="tablist"
-          data-testid="wk-editor-mobile-tabs"
-        >
-          <button
-            type="button"
-            role="tab"
-            aria-selected={mobileView === "source"}
-            className={
-              "wk-editor-mobile-tab" +
-              (mobileView === "source" ? " is-active" : "")
-            }
-            onClick={() => setMobileView("source")}
-            data-testid="wk-editor-mobile-source"
-          >
-            Source
-          </button>
-          <button
-            type="button"
-            role="tab"
-            aria-selected={mobileView === "preview"}
-            className={
-              "wk-editor-mobile-tab" +
-              (mobileView === "preview" ? " is-active" : "")
-            }
-            onClick={() => setMobileView("preview")}
-            data-testid="wk-editor-mobile-preview"
-          >
-            Preview
-          </button>
-        </div>
+        <MobileTabs mobileView={mobileView} setMobileView={setMobileView} />
       ) : null}
       <div className="wk-editor-panes">
         {showSource ? (
-          <div className="wk-editor-pane wk-editor-pane--source">
-            <label className="wk-editor-label" htmlFor="wk-editor-textarea">
-              Article source ({path})
-            </label>
-            <textarea
-              id="wk-editor-textarea"
-              ref={textareaRef}
-              className="wk-editor-textarea"
-              data-testid="wk-editor-textarea"
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              spellCheck={true}
-              rows={28}
-            />
-          </div>
+          <SourcePane
+            path={path}
+            editorMode={editorMode}
+            content={content}
+            setContent={setContent}
+            textareaRef={textareaRef}
+          />
         ) : null}
         {showPreview ? (
           <div
@@ -265,6 +373,15 @@ export default function WikiEditor({
           onClick={() => setPreviewOn((v) => !v)}
         >
           {previewOn ? "Hide preview" : "Preview"}
+        </button>
+        <button
+          type="button"
+          className={`wk-editor-mode-toggle${editorMode === "rich" ? " is-on" : ""}`}
+          data-testid="wk-editor-mode-toggle"
+          aria-pressed={editorMode === "rich"}
+          onClick={toggleEditorMode}
+        >
+          {editorMode === "rich" ? "Source" : "Rich"}
         </button>
       </div>
       <p className="wk-editor-help">

--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -105,10 +105,17 @@ function SourcePane({
   setContent,
   textareaRef,
 }: SourcePaneProps) {
+  const labelText = `Article source (${path})`;
   return (
     <div className="wk-editor-pane wk-editor-pane--source">
-      <label className="wk-editor-label" htmlFor="wk-editor-textarea">
-        Article source ({path})
+      <label
+        className="wk-editor-label"
+        // The textarea only mounts in source mode, so `htmlFor` must drop
+        // when rich is active. The rich wrapper carries an `aria-label`
+        // instead so screen readers can still identify the editor surface.
+        htmlFor={editorMode === "source" ? "wk-editor-textarea" : undefined}
+      >
+        {labelText}
       </label>
       {editorMode === "rich" ? (
         <Suspense
@@ -121,7 +128,11 @@ function SourcePane({
             </div>
           }
         >
-          <div className="wk-editor-rich" data-testid="wk-editor-rich">
+          <div
+            className="wk-editor-rich"
+            data-testid="wk-editor-rich"
+            aria-label={labelText}
+          >
             <RichWikiEditor content={content} onChange={setContent} />
           </div>
         </Suspense>
@@ -378,10 +389,14 @@ export default function WikiEditor({
           type="button"
           className={`wk-editor-mode-toggle${editorMode === "rich" ? " is-on" : ""}`}
           data-testid="wk-editor-mode-toggle"
+          // Visible label names the *current* mode so it agrees with
+          // `aria-pressed`. Screen readers announce e.g. "Rich, pressed"
+          // when rich is active rather than the contradictory pairing of
+          // "Source, pressed" the previous implementation produced.
           aria-pressed={editorMode === "rich"}
           onClick={toggleEditorMode}
         >
-          {editorMode === "rich" ? "Source" : "Rich"}
+          {editorMode === "rich" ? "Rich" : "Source"}
         </button>
       </div>
       <p className="wk-editor-help">

--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -255,17 +255,30 @@ export default function WikiEditor({
 
   // Per-article editor mode — persists across sessions so a user who picks
   // Rich on a page they edit often gets it back next time without resetting.
-  const [editorMode, setEditorMode] = useState<EditorMode>(() =>
-    readEditorMode(path),
-  );
+  //
+  // The mode is keyed to `path` *synchronously*: when the parent navigates
+  // to a different article, the new article's stored mode must apply on
+  // the very first render. A previous version held mode in `useState` and
+  // reset it via `useEffect`, which left mode one render behind path —
+  // a `rich -> source` navigation would mount Milkdown for one paint
+  // before correcting itself. Storing `{ path, mode }` lets us detect the
+  // stale snapshot and read storage inline when it doesn't match.
+  const [storedMode, setStoredMode] = useState<{
+    path: string;
+    mode: EditorMode;
+  }>(() => ({ path, mode: readEditorMode(path) }));
+  const editorMode: EditorMode =
+    storedMode.path === path ? storedMode.mode : readEditorMode(path);
   useEffect(() => {
-    setEditorMode(readEditorMode(path));
+    setStoredMode({ path, mode: readEditorMode(path) });
   }, [path]);
   const toggleEditorMode = useCallback(() => {
-    setEditorMode((prev) => {
-      const next: EditorMode = prev === "rich" ? "source" : "rich";
+    setStoredMode((prev) => {
+      const current: EditorMode =
+        prev.path === path ? prev.mode : readEditorMode(path);
+      const next: EditorMode = current === "rich" ? "source" : "rich";
       writeEditorMode(path, next);
-      return next;
+      return { path, mode: next };
     });
   }, [path]);
 

--- a/web/src/components/wiki/editor/RichWikiEditor.roundtrip.test.tsx
+++ b/web/src/components/wiki/editor/RichWikiEditor.roundtrip.test.tsx
@@ -79,24 +79,26 @@ async function roundTrip(initial: string): Promise<string> {
   }
 }
 
+// Each test asserts full normalised equality (`toBe`) — looser substring
+// checks would let regressions like list-flattening or table-shape change
+// slip through.
+//
+// Where Milkdown deterministically *normalises* the source (loose-form
+// nested lists, padded table cells), the test uses an explicit canonical
+// expected value. That IS the round-trip contract: edits settle on the
+// canonical shape after one save and remain stable thereafter.
+
 // ─── headings + paragraphs ─────────────────────────────────────────────────
 
 describe("RichWikiEditor round-trip — headings + paragraphs", () => {
   it("preserves an H1 + paragraph", async () => {
-    const out = normalise(
-      await roundTrip("# Alex Chen\n\nEngineering lead.\n"),
-    );
-    expect(out).toContain("# Alex Chen");
-    expect(out).toContain("Engineering lead.");
+    const md = "# Alex Chen\n\nEngineering lead.\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
   });
 
   it("preserves H2/H3 hierarchy", async () => {
-    const out = normalise(
-      await roundTrip("## Role\n\n### Background\n\nDetails here.\n"),
-    );
-    expect(out).toContain("## Role");
-    expect(out).toContain("### Background");
-    expect(out).toContain("Details here.");
+    const md = "## Role\n\n### Background\n\nDetails here.\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
   });
 });
 
@@ -104,31 +106,28 @@ describe("RichWikiEditor round-trip — headings + paragraphs", () => {
 
 describe("RichWikiEditor round-trip — inline emphasis", () => {
   it("preserves bold + italic + inline code", async () => {
-    const out = normalise(
-      await roundTrip("Mix of **bold**, _italic_, and `inline code`.\n"),
-    );
-    expect(out).toContain("**bold**");
-    expect(out).toContain("_italic_");
-    expect(out).toContain("`inline code`");
+    const md = "Mix of **bold**, _italic_, and `inline code`.\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
   });
 });
 
 // ─── lists + checklists ────────────────────────────────────────────────────
+//
+// Milkdown's commonmark serializer renders nested and checklist lists in
+// loose form (a blank line between siblings). Content survives intact,
+// structure is preserved, and the shape stabilises after one save.
 
 describe("RichWikiEditor round-trip — lists", () => {
-  it("preserves bullet list with nested items", async () => {
-    const out = normalise(
-      await roundTrip("- Parent\n  - Child A\n  - Child B\n"),
-    );
-    expect(out).toContain("Parent");
-    expect(out).toContain("Child A");
-    expect(out).toContain("Child B");
+  it("preserves bullet list with nested items in canonical loose form", async () => {
+    const md = "- Parent\n  - Child A\n  - Child B\n";
+    const canonical = "- Parent\n\n  - Child A\n\n  - Child B\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(canonical));
   });
 
-  it("preserves GFM checklist", async () => {
-    const out = normalise(await roundTrip("- [x] Done\n- [ ] Todo\n"));
-    expect(out).toContain("[x] Done");
-    expect(out).toContain("[ ] Todo");
+  it("preserves GFM checklist in canonical loose form", async () => {
+    const md = "- [x] Done\n- [ ] Todo\n";
+    const canonical = "- [x] Done\n\n- [ ] Todo\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(canonical));
   });
 });
 
@@ -136,33 +135,26 @@ describe("RichWikiEditor round-trip — lists", () => {
 
 describe("RichWikiEditor round-trip — code blocks", () => {
   it("preserves fenced code with language", async () => {
-    const out = normalise(
-      await roundTrip("```typescript\nconst x = 1;\n```\n"),
-    );
-    expect(out).toContain("```typescript");
-    expect(out).toContain("const x = 1;");
+    const md = "```typescript\nconst x = 1;\n```\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
   });
 
-  it("preserves multi-line code body", async () => {
-    const out = normalise(
-      await roundTrip('```go\nfunc main() {\n\tfmt.Println("hi")\n}\n```\n'),
-    );
-    expect(out).toContain("func main()");
-    expect(out).toContain("fmt.Println");
+  it("preserves multi-line code body with tabs and quotes", async () => {
+    const md = '```go\nfunc main() {\n\tfmt.Println("hi")\n}\n```\n';
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
   });
 });
 
 // ─── GFM tables ────────────────────────────────────────────────────────────
+//
+// Milkdown aligns columns and pads cells to the widest entry. That's
+// canonical GFM table output and stabilises on first save.
 
 describe("RichWikiEditor round-trip — tables", () => {
-  it("preserves a simple table", async () => {
-    const out = normalise(
-      await roundTrip("| Name | Role |\n| --- | --- |\n| Alex | Eng |\n"),
-    );
-    expect(out).toContain("Name");
-    expect(out).toContain("Role");
-    expect(out).toContain("Alex");
-    expect(out).toContain("|");
+  it("preserves a simple table with canonical column padding", async () => {
+    const md = "| Name | Role |\n| --- | --- |\n| Alex | Eng |\n";
+    const canonical = "| Name | Role |\n| ---- | ---- |\n| Alex | Eng  |\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(canonical));
   });
 });
 
@@ -170,24 +162,18 @@ describe("RichWikiEditor round-trip — tables", () => {
 
 describe("RichWikiEditor round-trip — wiki-links", () => {
   it("preserves [[slug]]", async () => {
-    const out = normalise(await roundTrip("See [[alex]] for details.\n"));
-    expect(out).toContain("[[alex]]");
+    const md = "See [[alex]] for details.\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
   });
 
   it("preserves [[slug|Display]]", async () => {
-    const out = normalise(
-      await roundTrip("See [[people/alex|Alex Chen]] for details.\n"),
-    );
-    expect(out).toContain("[[people/alex|Alex Chen]]");
+    const md = "See [[people/alex|Alex Chen]] for details.\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
   });
 
   it("preserves multiple wiki-links in one paragraph", async () => {
-    const out = normalise(
-      await roundTrip("[[alex]] works with [[sarah]] on [[project-x]].\n"),
-    );
-    expect(out).toContain("[[alex]]");
-    expect(out).toContain("[[sarah]]");
-    expect(out).toContain("[[project-x]]");
+    const md = "[[alex]] works with [[sarah]] on [[project-x]].\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
   });
 });
 
@@ -195,19 +181,12 @@ describe("RichWikiEditor round-trip — wiki-links", () => {
 
 describe("RichWikiEditor round-trip — standard links", () => {
   it("preserves [text](url)", async () => {
-    const out = normalise(
-      await roundTrip("See [the docs](https://example.com) for details.\n"),
-    );
-    expect(out).toContain("[the docs](https://example.com)");
+    const md = "See [the docs](https://example.com) for details.\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
   });
 
   it("preserves wiki-link and standard link in the same paragraph", async () => {
-    const out = normalise(
-      await roundTrip(
-        "See [[alex]] and [the docs](https://docs.example.com) here.\n",
-      ),
-    );
-    expect(out).toContain("[[alex]]");
-    expect(out).toContain("[the docs](https://docs.example.com)");
+    const md = "See [[alex]] and [the docs](https://docs.example.com) here.\n";
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
   });
 });

--- a/web/src/components/wiki/editor/RichWikiEditor.roundtrip.test.tsx
+++ b/web/src/components/wiki/editor/RichWikiEditor.roundtrip.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Round-trip tests: markdown in → render through RichWikiEditor → markdown out.
+ * Round-trip tests: markdown in → Milkdown parse → serialize → markdown out.
  *
  * The contract this PR commits to: switching a wiki article between source
  * and rich modes must not corrupt structure. These tests pin the markdown
@@ -7,19 +7,33 @@
  * lists/checklists, code blocks, tables, wiki-links, standard links) so a
  * future Milkdown upgrade or schema change cannot silently regress.
  *
- * Approach: mount the lazy-loaded RichWikiEditor in happy-dom, capture
- * `onChange` emissions from the listener, and assert that the canonical
- * markdown after a parse → serialize round-trip matches the input shape.
+ * Approach: run Milkdown's parser + serializer headlessly via
+ * `Editor.make()` and `getMarkdown()` — the same pipeline the rich editor
+ * mounts in production, minus the React/DOM layer. This avoids brittle
+ * dependence on the `markdownUpdated` listener (which only fires on edits,
+ * not on initial parse) and gives a deterministic round-trip primitive.
  *
- * Tolerances applied via `normalise`:
- *   - trailing whitespace and trailing newline differences
- *   - emphasis-strong character choice — STRINGIFY_DEFAULTS pin these but
- *     we also assert against the canonicalised input
+ * The test mirrors `RichWikiEditor`'s exact configuration:
+ *   - `wikiLinkRemarkPlugin` registered for `[[slug]]` parsing
+ *   - `STRINGIFY_DEFAULTS` applied for canonical output formatting
+ *   - `postProcessWikilinks` run on the emitted markdown to restore
+ *     `[[slug]]` syntax that Milkdown's commonmark serializer would
+ *     otherwise emit as `[Display](#/wiki/slug)`
  */
-import { act, render, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import {
+  defaultValueCtx,
+  Editor,
+  remarkPluginsCtx,
+  remarkStringifyOptionsCtx,
+} from "@milkdown/core";
+import { commonmark } from "@milkdown/preset-commonmark";
+import { gfm } from "@milkdown/preset-gfm";
+import { getMarkdown } from "@milkdown/utils";
+import { describe, expect, it } from "vitest";
 
-import RichWikiEditor from "./RichWikiEditor";
+import { wikiLinkRemarkPlugin } from "../../../lib/wikilink";
+import { STRINGIFY_DEFAULTS } from "../../../lib/wikilinkStringify";
+import { postProcessWikilinks } from "./wikilinkPostProcess";
 
 function normalise(s: string): string {
   return s
@@ -29,75 +43,57 @@ function normalise(s: string): string {
     .trim();
 }
 
-interface Capture {
-  emissions: string[];
-  latest: () => string;
-}
-
-function mountWithCapture(initial: string): {
-  capture: Capture;
-  unmount: () => void;
-} {
-  const emissions: string[] = [];
-  const handleChange = (next: string) => {
-    emissions.push(next);
-  };
-  const result = render(
-    <RichWikiEditor content={initial} onChange={handleChange} />,
-  );
-  return {
-    capture: {
-      emissions,
-      latest: () => emissions[emissions.length - 1] ?? "",
-    },
-    unmount: () => result.unmount(),
-  };
-}
-
 async function roundTrip(initial: string): Promise<string> {
-  const { capture, unmount } = mountWithCapture(initial);
+  // Milkdown still needs a DOM root even when we never render a view —
+  // happy-dom provides one. The editor never paints because we tear it
+  // down before any view code runs, but `make` requires the slot.
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(defaultValueCtx, initial);
+      ctx.update(remarkPluginsCtx, (prev) => [
+        ...prev,
+        {
+          plugin: wikiLinkRemarkPlugin(() => true),
+          options: {},
+        },
+      ]);
+      ctx.update(remarkStringifyOptionsCtx, (prev) => ({
+        ...prev,
+        ...STRINGIFY_DEFAULTS,
+      }));
+      // The editor only attaches a view when `rootCtx` is provided. We
+      // skip that — `getMarkdown` reads from the editor state directly,
+      // so a headless editor is sufficient for round-trip purposes.
+    })
+    .use(commonmark)
+    .use(gfm)
+    .create();
   try {
-    // Milkdown's listener fires the first markdownUpdated asynchronously
-    // after parse. Wait for at least one emission. If the parser produces
-    // no diff vs prevMarkdown the listener is silent — fall back to the
-    // input itself, normalised, after a short grace period.
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 0));
-    });
-    try {
-      await waitFor(() => expect(capture.emissions.length).toBeGreaterThan(0), {
-        timeout: 1000,
-      });
-      return capture.latest();
-    } catch {
-      return initial;
-    }
+    const md = editor.action(getMarkdown());
+    return postProcessWikilinks(md);
   } finally {
-    unmount();
+    await editor.destroy();
+    root.remove();
   }
 }
-
-const cleanups: Array<() => void> = [];
-afterEach(() => {
-  while (cleanups.length) {
-    const fn = cleanups.pop();
-    fn?.();
-  }
-});
 
 // ─── headings + paragraphs ─────────────────────────────────────────────────
 
 describe("RichWikiEditor round-trip — headings + paragraphs", () => {
   it("preserves an H1 + paragraph", async () => {
-    const md = "# Alex Chen\n\nEngineering lead.\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip("# Alex Chen\n\nEngineering lead.\n"),
+    );
     expect(out).toContain("# Alex Chen");
     expect(out).toContain("Engineering lead.");
   });
 
   it("preserves H2/H3 hierarchy", async () => {
-    const md = "## Role\n\n### Background\n\nDetails here.\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip("## Role\n\n### Background\n\nDetails here.\n"),
+    );
     expect(out).toContain("## Role");
     expect(out).toContain("### Background");
     expect(out).toContain("Details here.");
@@ -108,8 +104,9 @@ describe("RichWikiEditor round-trip — headings + paragraphs", () => {
 
 describe("RichWikiEditor round-trip — inline emphasis", () => {
   it("preserves bold + italic + inline code", async () => {
-    const md = "Mix of **bold**, _italic_, and `inline code`.\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip("Mix of **bold**, _italic_, and `inline code`.\n"),
+    );
     expect(out).toContain("**bold**");
     expect(out).toContain("_italic_");
     expect(out).toContain("`inline code`");
@@ -120,16 +117,16 @@ describe("RichWikiEditor round-trip — inline emphasis", () => {
 
 describe("RichWikiEditor round-trip — lists", () => {
   it("preserves bullet list with nested items", async () => {
-    const md = "- Parent\n  - Child A\n  - Child B\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip("- Parent\n  - Child A\n  - Child B\n"),
+    );
     expect(out).toContain("Parent");
     expect(out).toContain("Child A");
     expect(out).toContain("Child B");
   });
 
   it("preserves GFM checklist", async () => {
-    const md = "- [x] Done\n- [ ] Todo\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(await roundTrip("- [x] Done\n- [ ] Todo\n"));
     expect(out).toContain("[x] Done");
     expect(out).toContain("[ ] Todo");
   });
@@ -139,15 +136,17 @@ describe("RichWikiEditor round-trip — lists", () => {
 
 describe("RichWikiEditor round-trip — code blocks", () => {
   it("preserves fenced code with language", async () => {
-    const md = "```typescript\nconst x = 1;\n```\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip("```typescript\nconst x = 1;\n```\n"),
+    );
     expect(out).toContain("```typescript");
     expect(out).toContain("const x = 1;");
   });
 
   it("preserves multi-line code body", async () => {
-    const md = '```go\nfunc main() {\n\tfmt.Println("hi")\n}\n```\n';
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip('```go\nfunc main() {\n\tfmt.Println("hi")\n}\n```\n'),
+    );
     expect(out).toContain("func main()");
     expect(out).toContain("fmt.Println");
   });
@@ -157,8 +156,9 @@ describe("RichWikiEditor round-trip — code blocks", () => {
 
 describe("RichWikiEditor round-trip — tables", () => {
   it("preserves a simple table", async () => {
-    const md = "| Name | Role |\n| --- | --- |\n| Alex | Eng |\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip("| Name | Role |\n| --- | --- |\n| Alex | Eng |\n"),
+    );
     expect(out).toContain("Name");
     expect(out).toContain("Role");
     expect(out).toContain("Alex");
@@ -170,38 +170,43 @@ describe("RichWikiEditor round-trip — tables", () => {
 
 describe("RichWikiEditor round-trip — wiki-links", () => {
   it("preserves [[slug]]", async () => {
-    const md = "See [[alex]] for details.\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(await roundTrip("See [[alex]] for details.\n"));
     expect(out).toContain("[[alex]]");
   });
 
   it("preserves [[slug|Display]]", async () => {
-    const md = "See [[people/alex|Alex Chen]] for details.\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip("See [[people/alex|Alex Chen]] for details.\n"),
+    );
     expect(out).toContain("[[people/alex|Alex Chen]]");
   });
 
   it("preserves multiple wiki-links in one paragraph", async () => {
-    const md = "[[alex]] works with [[sarah]] on [[project-x]].\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip("[[alex]] works with [[sarah]] on [[project-x]].\n"),
+    );
     expect(out).toContain("[[alex]]");
     expect(out).toContain("[[sarah]]");
     expect(out).toContain("[[project-x]]");
   });
 });
 
-// ─── standard markdown links — must not get hijacked by the wiki post-process ─
+// ─── standard markdown links — must not get hijacked by post-process ───────
 
 describe("RichWikiEditor round-trip — standard links", () => {
   it("preserves [text](url)", async () => {
-    const md = "See [the docs](https://example.com) for details.\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip("See [the docs](https://example.com) for details.\n"),
+    );
     expect(out).toContain("[the docs](https://example.com)");
   });
 
   it("preserves wiki-link and standard link in the same paragraph", async () => {
-    const md = "See [[alex]] and [the docs](https://docs.example.com) here.\n";
-    const out = normalise(await roundTrip(md));
+    const out = normalise(
+      await roundTrip(
+        "See [[alex]] and [the docs](https://docs.example.com) here.\n",
+      ),
+    );
     expect(out).toContain("[[alex]]");
     expect(out).toContain("[the docs](https://docs.example.com)");
   });

--- a/web/src/components/wiki/editor/RichWikiEditor.roundtrip.test.tsx
+++ b/web/src/components/wiki/editor/RichWikiEditor.roundtrip.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Round-trip tests: markdown in → render through RichWikiEditor → markdown out.
+ *
+ * The contract this PR commits to: switching a wiki article between source
+ * and rich modes must not corrupt structure. These tests pin the markdown
+ * shapes the wiki actually uses (headings, paragraphs, inline emphasis,
+ * lists/checklists, code blocks, tables, wiki-links, standard links) so a
+ * future Milkdown upgrade or schema change cannot silently regress.
+ *
+ * Approach: mount the lazy-loaded RichWikiEditor in happy-dom, capture
+ * `onChange` emissions from the listener, and assert that the canonical
+ * markdown after a parse → serialize round-trip matches the input shape.
+ *
+ * Tolerances applied via `normalise`:
+ *   - trailing whitespace and trailing newline differences
+ *   - emphasis-strong character choice — STRINGIFY_DEFAULTS pin these but
+ *     we also assert against the canonicalised input
+ */
+import { act, render, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import RichWikiEditor from "./RichWikiEditor";
+
+function normalise(s: string): string {
+  return s
+    .split("\n")
+    .map((l) => l.trimEnd())
+    .join("\n")
+    .trim();
+}
+
+interface Capture {
+  emissions: string[];
+  latest: () => string;
+}
+
+function mountWithCapture(initial: string): {
+  capture: Capture;
+  unmount: () => void;
+} {
+  const emissions: string[] = [];
+  const handleChange = (next: string) => {
+    emissions.push(next);
+  };
+  const result = render(
+    <RichWikiEditor content={initial} onChange={handleChange} />,
+  );
+  return {
+    capture: {
+      emissions,
+      latest: () => emissions[emissions.length - 1] ?? "",
+    },
+    unmount: () => result.unmount(),
+  };
+}
+
+async function roundTrip(initial: string): Promise<string> {
+  const { capture, unmount } = mountWithCapture(initial);
+  try {
+    // Milkdown's listener fires the first markdownUpdated asynchronously
+    // after parse. Wait for at least one emission. If the parser produces
+    // no diff vs prevMarkdown the listener is silent — fall back to the
+    // input itself, normalised, after a short grace period.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0));
+    });
+    try {
+      await waitFor(() => expect(capture.emissions.length).toBeGreaterThan(0), {
+        timeout: 1000,
+      });
+      return capture.latest();
+    } catch {
+      return initial;
+    }
+  } finally {
+    unmount();
+  }
+}
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  while (cleanups.length) {
+    const fn = cleanups.pop();
+    fn?.();
+  }
+});
+
+// ─── headings + paragraphs ─────────────────────────────────────────────────
+
+describe("RichWikiEditor round-trip — headings + paragraphs", () => {
+  it("preserves an H1 + paragraph", async () => {
+    const md = "# Alex Chen\n\nEngineering lead.\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("# Alex Chen");
+    expect(out).toContain("Engineering lead.");
+  });
+
+  it("preserves H2/H3 hierarchy", async () => {
+    const md = "## Role\n\n### Background\n\nDetails here.\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("## Role");
+    expect(out).toContain("### Background");
+    expect(out).toContain("Details here.");
+  });
+});
+
+// ─── inline emphasis ────────────────────────────────────────────────────────
+
+describe("RichWikiEditor round-trip — inline emphasis", () => {
+  it("preserves bold + italic + inline code", async () => {
+    const md = "Mix of **bold**, _italic_, and `inline code`.\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("**bold**");
+    expect(out).toContain("_italic_");
+    expect(out).toContain("`inline code`");
+  });
+});
+
+// ─── lists + checklists ────────────────────────────────────────────────────
+
+describe("RichWikiEditor round-trip — lists", () => {
+  it("preserves bullet list with nested items", async () => {
+    const md = "- Parent\n  - Child A\n  - Child B\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("Parent");
+    expect(out).toContain("Child A");
+    expect(out).toContain("Child B");
+  });
+
+  it("preserves GFM checklist", async () => {
+    const md = "- [x] Done\n- [ ] Todo\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("[x] Done");
+    expect(out).toContain("[ ] Todo");
+  });
+});
+
+// ─── fenced code blocks ────────────────────────────────────────────────────
+
+describe("RichWikiEditor round-trip — code blocks", () => {
+  it("preserves fenced code with language", async () => {
+    const md = "```typescript\nconst x = 1;\n```\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("```typescript");
+    expect(out).toContain("const x = 1;");
+  });
+
+  it("preserves multi-line code body", async () => {
+    const md = '```go\nfunc main() {\n\tfmt.Println("hi")\n}\n```\n';
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("func main()");
+    expect(out).toContain("fmt.Println");
+  });
+});
+
+// ─── GFM tables ────────────────────────────────────────────────────────────
+
+describe("RichWikiEditor round-trip — tables", () => {
+  it("preserves a simple table", async () => {
+    const md = "| Name | Role |\n| --- | --- |\n| Alex | Eng |\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("Name");
+    expect(out).toContain("Role");
+    expect(out).toContain("Alex");
+    expect(out).toContain("|");
+  });
+});
+
+// ─── wiki-links — the contract this PR exists to enforce ───────────────────
+
+describe("RichWikiEditor round-trip — wiki-links", () => {
+  it("preserves [[slug]]", async () => {
+    const md = "See [[alex]] for details.\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("[[alex]]");
+  });
+
+  it("preserves [[slug|Display]]", async () => {
+    const md = "See [[people/alex|Alex Chen]] for details.\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("[[people/alex|Alex Chen]]");
+  });
+
+  it("preserves multiple wiki-links in one paragraph", async () => {
+    const md = "[[alex]] works with [[sarah]] on [[project-x]].\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("[[alex]]");
+    expect(out).toContain("[[sarah]]");
+    expect(out).toContain("[[project-x]]");
+  });
+});
+
+// ─── standard markdown links — must not get hijacked by the wiki post-process ─
+
+describe("RichWikiEditor round-trip — standard links", () => {
+  it("preserves [text](url)", async () => {
+    const md = "See [the docs](https://example.com) for details.\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("[the docs](https://example.com)");
+  });
+
+  it("preserves wiki-link and standard link in the same paragraph", async () => {
+    const md = "See [[alex]] and [the docs](https://docs.example.com) here.\n";
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain("[[alex]]");
+    expect(out).toContain("[the docs](https://docs.example.com)");
+  });
+});

--- a/web/src/components/wiki/editor/RichWikiEditor.roundtrip.test.tsx
+++ b/web/src/components/wiki/editor/RichWikiEditor.roundtrip.test.tsx
@@ -47,34 +47,43 @@ async function roundTrip(initial: string): Promise<string> {
   // Milkdown still needs a DOM root even when we never render a view —
   // happy-dom provides one. The editor never paints because we tear it
   // down before any view code runs, but `make` requires the slot.
+  //
+  // The root must always be removed even if `Editor.make().create()`
+  // rejects, otherwise an init failure on the first test would leak an
+  // orphan <div> into document.body for every subsequent test in the
+  // file. Outer try/finally guarantees cleanup regardless of where
+  // construction fails.
   const root = document.createElement("div");
   document.body.appendChild(root);
-  const editor = await Editor.make()
-    .config((ctx) => {
-      ctx.set(defaultValueCtx, initial);
-      ctx.update(remarkPluginsCtx, (prev) => [
-        ...prev,
-        {
-          plugin: wikiLinkRemarkPlugin(() => true),
-          options: {},
-        },
-      ]);
-      ctx.update(remarkStringifyOptionsCtx, (prev) => ({
-        ...prev,
-        ...STRINGIFY_DEFAULTS,
-      }));
-      // The editor only attaches a view when `rootCtx` is provided. We
-      // skip that — `getMarkdown` reads from the editor state directly,
-      // so a headless editor is sufficient for round-trip purposes.
-    })
-    .use(commonmark)
-    .use(gfm)
-    .create();
   try {
-    const md = editor.action(getMarkdown());
-    return postProcessWikilinks(md);
+    const editor = await Editor.make()
+      .config((ctx) => {
+        ctx.set(defaultValueCtx, initial);
+        ctx.update(remarkPluginsCtx, (prev) => [
+          ...prev,
+          {
+            plugin: wikiLinkRemarkPlugin(() => true),
+            options: {},
+          },
+        ]);
+        ctx.update(remarkStringifyOptionsCtx, (prev) => ({
+          ...prev,
+          ...STRINGIFY_DEFAULTS,
+        }));
+        // The editor only attaches a view when `rootCtx` is provided. We
+        // skip that — `getMarkdown` reads from the editor state directly,
+        // so a headless editor is sufficient for round-trip purposes.
+      })
+      .use(commonmark)
+      .use(gfm)
+      .create();
+    try {
+      const md = editor.action(getMarkdown());
+      return postProcessWikilinks(md);
+    } finally {
+      await editor.destroy();
+    }
   } finally {
-    await editor.destroy();
     root.remove();
   }
 }

--- a/web/src/components/wiki/editor/RichWikiEditor.tsx
+++ b/web/src/components/wiki/editor/RichWikiEditor.tsx
@@ -1,0 +1,111 @@
+/**
+ * Milkdown-backed rich editor for wiki articles.
+ *
+ * Lazy-loaded behind the per-article "Rich" toggle in `WikiEditor`. Keeps
+ * the default textarea path zero-cost; only users who opt into rich mode
+ * pay the ~100kB-gzipped Milkdown bundle.
+ *
+ * Round-trip contract:
+ *   - On parse, we register `wikiLinkRemarkPlugin` so `[[slug]]` becomes a
+ *     standard `link` mdast node with `url = "#/wiki/<slug>"`. ProseMirror
+ *     stores that as a regular link mark and round-trips it cleanly.
+ *   - On serialize, Milkdown's commonmark/gfm preset emits standard
+ *     markdown. `postProcessWikilinks` rewrites `[Display](#/wiki/slug)`
+ *     back to `[[slug]]` (or `[[slug|Display]]`) so the saved markdown
+ *     matches what the textarea editor would have produced.
+ *
+ * State ownership: controller (in `useWikiEditorController`) holds the
+ * source-of-truth markdown. This component is a controlled-ish view: it
+ * receives `content` and pushes changes via `onChange`. External content
+ * updates (conflict reload, draft restore) are pushed back into Milkdown
+ * via `replaceAll`; we de-dup against the last value we emitted to avoid
+ * an edit→serialize→reset feedback loop.
+ */
+
+import { useEffect, useRef } from "react";
+import {
+  defaultValueCtx,
+  Editor,
+  remarkPluginsCtx,
+  remarkStringifyOptionsCtx,
+  rootCtx,
+} from "@milkdown/core";
+import { listener, listenerCtx } from "@milkdown/plugin-listener";
+import { commonmark } from "@milkdown/preset-commonmark";
+import { gfm } from "@milkdown/preset-gfm";
+import { Milkdown, MilkdownProvider, useEditor } from "@milkdown/react";
+import { replaceAll } from "@milkdown/utils";
+
+import { wikiLinkRemarkPlugin } from "../../../lib/wikilink";
+import { STRINGIFY_DEFAULTS } from "../../../lib/wikilinkStringify";
+import { postProcessWikilinks } from "./wikilinkPostProcess";
+
+export interface RichWikiEditorProps {
+  /** Current markdown source from the controller. */
+  content: string;
+  /** Called when the user edits — receives canonical markdown with
+   *  `[[wikilink]]` syntax restored. */
+  onChange: (next: string) => void;
+}
+
+function RichWikiEditorInner({ content, onChange }: RichWikiEditorProps) {
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  const lastEmittedRef = useRef<string>(content);
+
+  const { get } = useEditor((root) =>
+    Editor.make()
+      .config((ctx) => {
+        ctx.set(rootCtx, root);
+        ctx.set(defaultValueCtx, content);
+        ctx.update(remarkPluginsCtx, (prev) => [
+          ...prev,
+          {
+            // The resolver always returns true here because Milkdown only
+            // uses this plugin for parsing — it strips the `data-broken`
+            // class once content reaches ProseMirror anyway. Broken-link
+            // surfacing happens in the read-only view.
+            plugin: wikiLinkRemarkPlugin(() => true),
+            options: {},
+          },
+        ]);
+        ctx.update(remarkStringifyOptionsCtx, (prev) => ({
+          ...prev,
+          ...STRINGIFY_DEFAULTS,
+        }));
+        ctx.get(listenerCtx).markdownUpdated((_, md, prev) => {
+          if (md === prev) return;
+          const canonical = postProcessWikilinks(md);
+          lastEmittedRef.current = canonical;
+          onChangeRef.current(canonical);
+        });
+      })
+      .use(commonmark)
+      .use(gfm)
+      .use(listener),
+  );
+
+  // Push external content changes (conflict reload, draft restore) back
+  // into Milkdown. Skip when `content` matches what we just emitted —
+  // otherwise every keystroke would trigger a self-replaceAll loop.
+  useEffect(() => {
+    if (content === lastEmittedRef.current) return;
+    const editor = get();
+    if (!editor) return;
+    editor.action(replaceAll(content));
+    lastEmittedRef.current = content;
+  }, [content, get]);
+
+  return <Milkdown />;
+}
+
+export default function RichWikiEditor(props: RichWikiEditorProps) {
+  return (
+    <MilkdownProvider>
+      <RichWikiEditorInner {...props} />
+    </MilkdownProvider>
+  );
+}

--- a/web/src/components/wiki/editor/RichWikiEditor.tsx
+++ b/web/src/components/wiki/editor/RichWikiEditor.tsx
@@ -79,6 +79,12 @@ function RichWikiEditorInner({ content, onChange }: RichWikiEditorProps) {
         ctx.get(listenerCtx).markdownUpdated((_, md, prev) => {
           if (md === prev) return;
           const canonical = postProcessWikilinks(md);
+          // The external-content effect sets `lastEmittedRef.current = content`
+          // *before* dispatching `replaceAll`, so the listener fires with the
+          // value we just pushed. Skip emitting onChange in that case — the
+          // canonical form is identical to what the controller already holds,
+          // and a redundant onChange would race with autosave/draft state.
+          if (canonical === lastEmittedRef.current) return;
           lastEmittedRef.current = canonical;
           onChangeRef.current(canonical);
         });

--- a/web/src/components/wiki/editor/RichWikiEditor.tsx
+++ b/web/src/components/wiki/editor/RichWikiEditor.tsx
@@ -91,12 +91,19 @@ function RichWikiEditorInner({ content, onChange }: RichWikiEditorProps) {
   // Push external content changes (conflict reload, draft restore) back
   // into Milkdown. Skip when `content` matches what we just emitted —
   // otherwise every keystroke would trigger a self-replaceAll loop.
+  //
+  // Mark the value as "seen" *before* dispatching the transaction. The
+  // markdownUpdated listener fires synchronously inside `editor.action`
+  // and writes the canonical (post-processed) markdown into the ref; if
+  // we wrote `content` afterward, we'd overwrite that canonical value
+  // with the raw input and the next render would re-trigger replaceAll,
+  // resetting the ProseMirror cursor on every external update.
   useEffect(() => {
     if (content === lastEmittedRef.current) return;
     const editor = get();
     if (!editor) return;
-    editor.action(replaceAll(content));
     lastEmittedRef.current = content;
+    editor.action(replaceAll(content));
   }, [content, get]);
 
   return <Milkdown />;

--- a/web/src/components/wiki/editor/wikilinkPostProcess.test.ts
+++ b/web/src/components/wiki/editor/wikilinkPostProcess.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { postProcessWikilinks } from "./wikilinkPostProcess";
+
+describe("postProcessWikilinks", () => {
+  it("rewrites a bare wikilink whose display matches the slug", () => {
+    expect(postProcessWikilinks("See [alex](#/wiki/alex) for details.")).toBe(
+      "See [[alex]] for details.",
+    );
+  });
+
+  it("rewrites a wikilink with a distinct display label", () => {
+    expect(
+      postProcessWikilinks("See [Alex Chen](#/wiki/people/alex) for details."),
+    ).toBe("See [[people/alex|Alex Chen]] for details.");
+  });
+
+  it("decodes percent-encoded slugs", () => {
+    expect(
+      postProcessWikilinks("Owner: [people/alex](#/wiki/people/alex)."),
+    ).toBe("Owner: [[people/alex]].");
+  });
+
+  it("rewrites every wikilink in a paragraph", () => {
+    expect(
+      postProcessWikilinks(
+        "[alex](#/wiki/alex) works with [sarah](#/wiki/sarah) on [project-x](#/wiki/project-x).",
+      ),
+    ).toBe("[[alex]] works with [[sarah]] on [[project-x]].");
+  });
+
+  it("preserves a trailing title attribute by dropping it", () => {
+    // Title metadata has no wikilink equivalent; emit canonical form.
+    expect(
+      postProcessWikilinks('See [alex](#/wiki/alex "person page") today.'),
+    ).toBe("See [[alex]] today.");
+  });
+
+  it("leaves standard external links untouched", () => {
+    expect(
+      postProcessWikilinks("See [the docs](https://example.com) for details."),
+    ).toBe("See [the docs](https://example.com) for details.");
+  });
+
+  it("leaves anchor links untouched when not /wiki/", () => {
+    expect(postProcessWikilinks("Jump to [intro](#intro).")).toBe(
+      "Jump to [intro](#intro).",
+    );
+  });
+
+  it("leaves a malformed percent-escape as a standard link rather than corrupt wikilink", () => {
+    const malformed = "See [alex](#/wiki/bad%E0) here.";
+    expect(postProcessWikilinks(malformed)).toBe(malformed);
+  });
+
+  it("rewrites wikilinks inside list items", () => {
+    expect(
+      postProcessWikilinks(
+        "- Owner: [alex](#/wiki/alex)\n- See: [docs](https://x.com)\n",
+      ),
+    ).toBe("- Owner: [[alex]]\n- See: [docs](https://x.com)\n");
+  });
+
+  it("rewrites wikilinks inside table cells", () => {
+    const md =
+      "| Owner | Status |\n| --- | --- |\n| [alex](#/wiki/alex) | Active |\n";
+    expect(postProcessWikilinks(md)).toBe(
+      "| Owner | Status |\n| --- | --- |\n| [[alex]] | Active |\n",
+    );
+  });
+});

--- a/web/src/components/wiki/editor/wikilinkPostProcess.test.ts
+++ b/web/src/components/wiki/editor/wikilinkPostProcess.test.ts
@@ -17,8 +17,8 @@ describe("postProcessWikilinks", () => {
 
   it("decodes percent-encoded slugs", () => {
     expect(
-      postProcessWikilinks("Owner: [people/alex](#/wiki/people/alex)."),
-    ).toBe("Owner: [[people/alex]].");
+      postProcessWikilinks("Owner: [Alex Chen](#/wiki/Alex%20Chen)."),
+    ).toBe("Owner: [[Alex Chen]].");
   });
 
   it("rewrites every wikilink in a paragraph", () => {

--- a/web/src/components/wiki/editor/wikilinkPostProcess.test.ts
+++ b/web/src/components/wiki/editor/wikilinkPostProcess.test.ts
@@ -94,4 +94,25 @@ describe("postProcessWikilinks", () => {
       "[[alex]] wrote `[bob](#/wiki/bob)` then [[carol]].",
     );
   });
+
+  // Guard against rewrites the wikilink grammar would reject on next parse.
+  // The bare markdown link survives so the round-trip is lossless even when
+  // the label or slug contains characters wikilinks cannot represent.
+
+  it("leaves a link with a pipe in the display label as a standard link", () => {
+    // `[[foo|A | B]]` would parse with two pipes — parseWikiLinkInner
+    // returns null. Round-trip must keep the standard link intact.
+    const md = "See [A | B](#/wiki/foo) here.";
+    expect(postProcessWikilinks(md)).toBe(md);
+  });
+
+  it("leaves a link whose slug contains path traversal as a standard link", () => {
+    const md = "See [escape](#/wiki/../etc/passwd) here.";
+    expect(postProcessWikilinks(md)).toBe(md);
+  });
+
+  it("leaves a link whose slug starts with / as a standard link", () => {
+    const md = "See [absolute](#/wiki//root) here.";
+    expect(postProcessWikilinks(md)).toBe(md);
+  });
 });

--- a/web/src/components/wiki/editor/wikilinkPostProcess.test.ts
+++ b/web/src/components/wiki/editor/wikilinkPostProcess.test.ts
@@ -68,4 +68,30 @@ describe("postProcessWikilinks", () => {
       "| Owner | Status |\n| --- | --- |\n| [[alex]] | Active |\n",
     );
   });
+
+  it("does not rewrite wikilink-shaped text inside an inline code span", () => {
+    const md = "Use the syntax `[alex](#/wiki/alex)` to link.";
+    expect(postProcessWikilinks(md)).toBe(md);
+  });
+
+  it("does not rewrite wikilink-shaped text inside a fenced code block", () => {
+    const md = "```markdown\n[alex](#/wiki/alex)\n```\n";
+    expect(postProcessWikilinks(md)).toBe(md);
+  });
+
+  it("rewrites prose wikilinks even when a code block is present elsewhere", () => {
+    const md =
+      "See [alex](#/wiki/alex) below.\n\n```markdown\n[bob](#/wiki/bob)\n```\n";
+    expect(postProcessWikilinks(md)).toBe(
+      "See [[alex]] below.\n\n```markdown\n[bob](#/wiki/bob)\n```\n",
+    );
+  });
+
+  it("rewrites prose wikilinks separated by an inline code span", () => {
+    const md =
+      "[alex](#/wiki/alex) wrote `[bob](#/wiki/bob)` then [carol](#/wiki/carol).";
+    expect(postProcessWikilinks(md)).toBe(
+      "[[alex]] wrote `[bob](#/wiki/bob)` then [[carol]].",
+    );
+  });
 });

--- a/web/src/components/wiki/editor/wikilinkPostProcess.ts
+++ b/web/src/components/wiki/editor/wikilinkPostProcess.ts
@@ -15,7 +15,15 @@
  *
  * Detection is by URL prefix `#/wiki/`, which `wikiLinkRemarkPlugin`
  * deterministically assigns. Standard external links survive untouched.
+ *
+ * The constructed `[[slug|display]]` candidate is validated with
+ * `parseWikiLinkInner` before emission so labels containing pipe chars,
+ * `..`, leading `/`, or control bytes (which the wikilink grammar
+ * rejects) fall back to the original markdown link instead of being
+ * rewritten into syntax the next parse would discard as literal text.
  */
+
+import { parseWikiLinkInner } from "../../../lib/wikilink";
 
 const WIKI_URL_RE = /\[([^\]\n]+)\]\(#\/wiki\/([^\s)]+?)(?:\s+"[^"]*")?\)/g;
 
@@ -39,7 +47,15 @@ function rewriteWikilinks(segment: string): string {
         // emit corrupt wikilink syntax.
         return match;
       }
-      return slug === display ? `[[${slug}]]` : `[[${slug}|${display}]]`;
+      // Validate against the wikilink grammar before rewriting. A label
+      // containing pipes (e.g. `[A | B](#/wiki/foo)`) or a slug with
+      // path traversal would otherwise emit `[[foo|A | B]]`, which
+      // `parseWikiLinkInner` rejects on the next read — so the link
+      // would degrade into literal text after one save. Falling back to
+      // the standard markdown link keeps the round-trip lossless.
+      const inner = slug === display ? slug : `${slug}|${display}`;
+      if (!parseWikiLinkInner(inner)) return match;
+      return `[[${inner}]]`;
     },
   );
 }

--- a/web/src/components/wiki/editor/wikilinkPostProcess.ts
+++ b/web/src/components/wiki/editor/wikilinkPostProcess.ts
@@ -7,10 +7,11 @@
  * save through the rich editor would silently corrupt wikilink syntax.
  *
  * This module rewrites those standard links back to `[[slug]]` /
- * `[[slug|Display]]` form. It works on the markdown string after Milkdown
- * serialization, so it cannot be confused by surrounding whitespace, lists,
- * or table cells — the regex matches the exact `[text](#/wiki/...)` shape
- * in any context.
+ * `[[slug|Display]]` form. It runs on the markdown string after Milkdown
+ * serialization. Code spans and fenced code blocks are skipped so an
+ * article that documents wikilink syntax verbatim (e.g. a how-to page
+ * teaching `[foo](`#/wiki/bar`)`) does not get its examples silently
+ * rewritten on every save.
  *
  * Detection is by URL prefix `#/wiki/`, which `wikiLinkRemarkPlugin`
  * deterministically assigns. Standard external links survive untouched.
@@ -18,19 +19,37 @@
 
 const WIKI_URL_RE = /\[([^\]\n]+)\]\(#\/wiki\/([^\s)]+?)(?:\s+"[^"]*")?\)/g;
 
-export function postProcessWikilinks(markdown: string): string {
-  return markdown.replace(
+/**
+ * Matches fenced code blocks (``` … ```) and inline code spans (` … `).
+ * Used to split markdown so the wikilink rewrite skips verbatim regions.
+ * Fenced blocks are matched first (longer alternative) to avoid an inline
+ * span from greedily consuming a fenced opener.
+ */
+const CODE_SEGMENT_RE = /(`{3,}[\s\S]*?`{3,}|`[^`\n]+`)/g;
+
+function rewriteWikilinks(segment: string): string {
+  return segment.replace(
     WIKI_URL_RE,
-    (_match, display: string, encoded: string) => {
+    (match, display: string, encoded: string) => {
       let slug: string;
       try {
         slug = decodeURI(encoded);
       } catch {
         // Malformed escape — leave the standard link in place rather than
         // emit corrupt wikilink syntax.
-        return _match;
+        return match;
       }
       return slug === display ? `[[${slug}]]` : `[[${slug}|${display}]]`;
     },
   );
+}
+
+export function postProcessWikilinks(markdown: string): string {
+  // String.split with a capturing group preserves the matched code regions
+  // at odd indices. Even indices are non-code prose where rewrite is safe.
+  const parts = markdown.split(CODE_SEGMENT_RE);
+  for (let i = 0; i < parts.length; i += 2) {
+    parts[i] = rewriteWikilinks(parts[i]);
+  }
+  return parts.join("");
 }

--- a/web/src/components/wiki/editor/wikilinkPostProcess.ts
+++ b/web/src/components/wiki/editor/wikilinkPostProcess.ts
@@ -1,0 +1,36 @@
+/**
+ * Wiki-link post-processing for the rich editor.
+ *
+ * Milkdown's commonmark serializer emits wikilinks as standard markdown
+ * links — `[Display](#/wiki/slug)` — because that's the URL `wikiLinkRemarkPlugin`
+ * gave the parser when it ingested `[[slug]]`. Without a fix-up step every
+ * save through the rich editor would silently corrupt wikilink syntax.
+ *
+ * This module rewrites those standard links back to `[[slug]]` /
+ * `[[slug|Display]]` form. It works on the markdown string after Milkdown
+ * serialization, so it cannot be confused by surrounding whitespace, lists,
+ * or table cells — the regex matches the exact `[text](#/wiki/...)` shape
+ * in any context.
+ *
+ * Detection is by URL prefix `#/wiki/`, which `wikiLinkRemarkPlugin`
+ * deterministically assigns. Standard external links survive untouched.
+ */
+
+const WIKI_URL_RE = /\[([^\]\n]+)\]\(#\/wiki\/([^\s)]+?)(?:\s+"[^"]*")?\)/g;
+
+export function postProcessWikilinks(markdown: string): string {
+  return markdown.replace(
+    WIKI_URL_RE,
+    (_match, display: string, encoded: string) => {
+      let slug: string;
+      try {
+        slug = decodeURI(encoded);
+      } catch {
+        // Malformed escape — leave the standard link in place rather than
+        // emit corrupt wikilink syntax.
+        return _match;
+      }
+      return slug === display ? `[[${slug}]]` : `[[${slug}|${display}]]`;
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Lazy-loads a Milkdown-backed `RichWikiEditor` behind a per-article "Rich" toggle in `WikiEditor`. Default textarea path stays zero-cost; only users who flip the toggle pay the **~100 kB gzipped** chunk (audited via baseline-vs-after build comparison).
- Reuses `useWikiEditorController` (#648) so draft, autosave, conflict, expected-SHA, and reload semantics are identical across both editor surfaces.
- Round-trips `[[wikilinks]]` cleanly: `wikiLinkRemarkPlugin` is registered on Milkdown's parse pipeline; `postProcessWikilinks` rewrites the serialized `[Display](#/wiki/slug)` back to `[[slug]]` / `[[slug|Display]]` on every emission. URL-prefix detection is robust to ProseMirror round-trips that drop `data.hProperties`.
- Per-article mode persisted to `wuphf:editor-mode:<path>` localStorage so a returning user gets the same mode they picked.
- External content updates (conflict reload, draft restore) push back into Milkdown via `replaceAll`, de-duped against the last-emitted value to prevent edit→serialize→reset feedback loops.

## Bundle audit

| Build | Main `index` chunk (gzip) | Lazy `RichWikiEditor` chunk (gzip) |
| --- | --- | --- |
| Before this PR | 304.78 kB | — |
| After this PR | 304.84 kB | 100.32 kB |

## Tests

- `RichWikiEditor.roundtrip.test.tsx` — 13 happy-dom tests covering headings, paragraphs, bold/italic/code, lists+checklists, code blocks, tables, wiki-links (all three forms), standard markdown links, mixed wiki+standard.
- `wikilinkPostProcess.test.ts` — 10 unit tests on the post-process regex: bare slug, slug|Display, encoded slugs, multiple per paragraph, title attribute drop, external links untouched, anchor links untouched, malformed escape preserved as standard link, list items, table cells.
- Existing 13 `WikiEditor.test.tsx` tests still pass (toggle does not regress textarea path).
- Full web suite: **915 / 915 passing**.

## Deferred

Per phase doc: slash menu, toolbar, citation/fact inserts, agent mentions, and decision blocks ship in PR 6 (`feat/wiki-editor-inserts`).

## Test plan

- [ ] Open a wiki article, click "Rich" — verify Milkdown loads, content renders WYSIWYG, edits flow through controller (autosave + save).
- [ ] Edit an article containing `[[wikilink]]`, save, reopen in Source mode — confirm wikilink syntax preserved.
- [ ] Type a wiki-link in Rich mode (`[[slug]]`) — confirm it parses live.
- [ ] Mix wiki-links and standard `[text](url)` links — confirm both round-trip without corruption.
- [ ] Toggle Rich on/off mid-edit — confirm draft state survives the swap.
- [ ] Trigger a 409 conflict (concurrent edit) in Rich mode — confirm conflict banner appears and "Reload latest" pushes new content into Milkdown.
- [ ] Refresh a page with Rich on — confirm mode persists per article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rich Markdown editor with canonical wiki-link conversion, improved sync between Rich and Source views, and a lazily loaded rich surface for better performance
  * Dual-mode editor toggle (Rich/Source) persisted per-article and improved mobile Source/Preview tabs for clearer editing workflows

* **Tests**
  * Added comprehensive round-trip and wiki-link post-processing tests to ensure markdown fidelity and stable serialization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->