### PR TITLE
feat(scripts): add flake-rate quarantine harness (advisory)

### DIFF
--- a/scripts/flake-rate.sh
+++ b/scripts/flake-rate.sh
@@ -10,7 +10,7 @@
 
 set -euo pipefail
 
-RUNS=5
+RUNS="${FLAKE_RUNS:-5}"
 THRESHOLD="${FLAKE_RATE_THRESHOLD:-0.20}"
 
 script_dir="$(dirname -- "${BASH_SOURCE[0]}")"
@@ -59,7 +59,7 @@ while IFS= read -r line || [[ -n "$line" ]]; do
   if [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]]; then
     continue
   fi
-  entries+=("$line")
+  entries+=("${line%$'\r'}")
 done < "$quarantine_file"
 
 if ((${#entries[@]} == 0)); then

--- a/scripts/flake-rate.sh
+++ b/scripts/flake-rate.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 RUNS=5
 THRESHOLD="${FLAKE_RATE_THRESHOLD:-0.20}"
 
-script_dir="${BASH_SOURCE[0]%/*}"
+script_dir="$(dirname -- "${BASH_SOURCE[0]}")"
 repo_root="$(cd -- "$script_dir/.." && pwd)"
 quarantine_file="${FLAKE_QUARANTINE_FILE:-$repo_root/tests/flaky/quarantine.txt}"
 dry_run=false

--- a/scripts/flake-rate.sh
+++ b/scripts/flake-rate.sh
@@ -84,7 +84,7 @@ for entry in "${entries[@]}"; do
   passes=0
   fails=0
   for ((run = 1; run <= RUNS; run++)); do
-    if (cd "$repo_root" && go test -count=1 "${test_args[@]}") >/dev/null 2>&1; then
+    if (cd "$repo_root" && go test -timeout 120s -count=1 "${test_args[@]}") 1>/dev/null; then
       passes=$((passes + 1))
     else
       fails=$((fails + 1))

--- a/scripts/flake-rate.sh
+++ b/scripts/flake-rate.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# scripts/flake-rate.sh
+#
+# Advisory flake-rate harness for suspected flaky Go tests. Reads
+# tests/flaky/quarantine.txt, re-runs each entry with test caching disabled,
+# and reports pass/fail counts as a markdown table.
+#
+# This is intentionally not wired into CI yet; it is for investigation while
+# cross-platform desktop baselines are collected.
+
+set -euo pipefail
+
+RUNS=5
+THRESHOLD="${FLAKE_RATE_THRESHOLD:-0.20}"
+
+script_dir="${BASH_SOURCE[0]%/*}"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+quarantine_file="${FLAKE_QUARANTINE_FILE:-$repo_root/tests/flaky/quarantine.txt}"
+dry_run=false
+
+usage() {
+  echo "usage: scripts/flake-rate.sh [--dry-run]"
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --dry-run)
+      dry_run=true
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "::error::unknown argument: $1"
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+if [[ ! -f "$quarantine_file" ]]; then
+  echo "::error::quarantine file not found: $quarantine_file"
+  exit 1
+fi
+
+if ! awk -v threshold="$THRESHOLD" 'BEGIN {
+  if (threshold !~ /^[0-9]+([.][0-9]+)?$/ || threshold < 0 || threshold > 1) {
+    exit 1
+  }
+}'; then
+  echo "::error::FLAKE_RATE_THRESHOLD must be a number between 0 and 1; got '$THRESHOLD'"
+  exit 2
+fi
+
+entries=()
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]]; then
+    continue
+  fi
+  entries+=("$line")
+done < "$quarantine_file"
+
+if ((${#entries[@]} == 0)); then
+  echo "flake-rate: no tests in quarantine ($quarantine_file)"
+  exit 0
+fi
+
+echo "| Test | Passes | Fails | Rate |"
+echo "|---|---:|---:|---:|"
+
+threshold_exceeded=false
+for entry in "${entries[@]}"; do
+  display_entry="${entry//|/\\|}"
+
+  if [[ "$dry_run" == true ]]; then
+    echo "| \`$display_entry\` | - | - | - |"
+    continue
+  fi
+
+  read -r -a test_args <<< "$entry"
+
+  passes=0
+  fails=0
+  for ((run = 1; run <= RUNS; run++)); do
+    if (cd "$repo_root" && go test -count=1 "${test_args[@]}") >/dev/null 2>&1; then
+      passes=$((passes + 1))
+    else
+      fails=$((fails + 1))
+    fi
+  done
+
+  rate="$(awk -v fails="$fails" -v runs="$RUNS" 'BEGIN { printf "%.2f", fails / runs }')"
+  echo "| \`$display_entry\` | $passes | $fails | $rate |"
+
+  if awk -v rate="$rate" -v threshold="$THRESHOLD" 'BEGIN { exit !(rate >= threshold) }'; then
+    threshold_exceeded=true
+  fi
+done
+
+if [[ "$threshold_exceeded" == true ]]; then
+  echo "::error::one or more quarantined tests met or exceeded flake rate threshold $THRESHOLD"
+  exit 1
+fi
+
+if [[ "$dry_run" == false ]]; then
+  echo "flake-rate check OK: all quarantined tests below $THRESHOLD failure rate over $RUNS runs."
+fi

--- a/scripts/flake-rate.sh
+++ b/scripts/flake-rate.sh
@@ -46,7 +46,7 @@ if [[ ! -f "$quarantine_file" ]]; then
 fi
 
 if ! awk -v threshold="$THRESHOLD" 'BEGIN {
-  if (threshold !~ /^[0-9]+([.][0-9]+)?$/ || threshold < 0 || threshold > 1) {
+  if (threshold !~ /^[0-9]*\.?[0-9]+$/ || threshold + 0 < 0 || threshold + 0 > 1) {
     exit 1
   }
 }'; then

--- a/tests/flaky/README.md
+++ b/tests/flaky/README.md
@@ -1,0 +1,24 @@
+# Flaky Test Quarantine
+
+`tests/flaky/quarantine.txt` is an advisory list of suspected flaky Go tests.
+Each non-empty, non-comment line is appended to `go test -count=1` by
+`scripts/flake-rate.sh`.
+
+Example:
+
+```text
+./internal/team/... -run ^TestSomethingFlaky$
+```
+
+Add a test only after CI shows non-deterministic failures across 3 or more
+runs. Do not add tests based on a single failure or without evidence.
+
+Remove a test after a fix lands and 5 consecutive `scripts/flake-rate.sh` runs
+pass for that quarantine entry.
+
+`scripts/flake-rate.sh` is not a CI gate yet. It is an investigative tool. Per
+Appendix A of the desktop platform plan, SLOs and quality gates do not become
+PR-blocking until baselines exist on macOS, Windows, and Linux.
+
+The default failure-rate threshold is `0.20`; set `FLAKE_RATE_THRESHOLD` for a
+local investigation that needs a different cutoff.

--- a/tests/flaky/quarantine.txt
+++ b/tests/flaky/quarantine.txt
@@ -1,0 +1,7 @@
+# One Go test pattern per line. Each entry is appended to:
+#   go test -count=1 <entry>
+#
+# Example:
+#   ./internal/team/... -run ^TestSomethingFlaky$
+#
+# Leave this list empty until CI shows non-deterministic failures over 3+ runs.


### PR DESCRIPTION
## Summary

- Adds \`scripts/flake-rate.sh\` — bash harness that reads \`tests/flaky/quarantine.txt\`, runs each Go test pattern 5x with \`go test -count=1\`, computes a flake rate, prints a markdown table, and exits non-zero only when any rate ≥ \`FLAKE_RATE_THRESHOLD\` (default 0.20).
- Adds \`tests/flaky/README.md\` documenting when to add/remove tests.
- Adds \`tests/flaky/quarantine.txt\` (empty, comment-only) — starting state.
- **Not wired to CI yet.** Per the desktop platform plan (#651, Appendix A): SLOs and quality gates do not become PR-blocking until baselines exist on macOS/Windows/Linux. This is an investigative tool today.

Implements the flake-rate deliverable from #651 (desktop platform plan).

## Exit codes

- \`0\` — quarantine empty, \`--dry-run\`, or all rates below threshold.
- \`1\` — any test rate ≥ threshold, or quarantine file missing.
- \`2\` — invalid CLI arg or invalid \`FLAKE_RATE_THRESHOLD\`.

## Test plan

- [ ] \`bash scripts/flake-rate.sh --dry-run\` reports no quarantine entries on the empty list
- [ ] Adding a known-passing test pattern + running shows 0 fails
- [ ] Adding a known-flaky test pattern crosses the threshold (manual smoke; not part of CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a flaky-test quarantine system and a local harness to measure pass/fail rates across repeated runs, flagging tests that exceed a configurable failure-rate threshold.
  * Supports a dry-run mode and command-line help; failing entries cause a non-zero exit when threshold is exceeded.
* **Documentation**
  * Added guidance on quarantine list format, criteria for adding/removing flaky tests, and how to override the default failure-rate threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->