### PR TITLE
feat(notebook): auto-write per-agent notebook entries on broker events (PR 1)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -188,6 +188,60 @@ Tracking work that is deliberately deferred from the current branch. Each item n
 
 ---
 
+### 18. Wiki worker queue depth monitoring + alert thresholds (post-PR 1 notebook auto-writer)
+
+**What:** Instrument `wiki_worker.go` to emit queue depth and time-in-queue metrics, plus a warn log at 80% of the 64-buffer capacity. Track the dropped-event counter from `auto_notebook_writer.go` alongside.
+
+**Why:** PR 1 of the notebook-wiki-promise effort adds a new write source (every agent message + every task transition) that competes with real wiki, artifact, fact, lint, playbook, and learning writes through the same shared queue. Codex flagged this as the most likely operational failure mode. Without observability we discover starvation only when a real wiki write fails or times out.
+
+**Pros:** Confirms PR 1 didn't quietly DoS real wiki writes. Gives a concrete signal for tuning the auto-writer's enqueue capacity or for triggering the OV7B event-log migration (TODO #20).
+
+**Cons:** Adds a small metrics surface; needs to land somewhere in the existing analytics path.
+
+**Context:** PR 1 design doc: `~/.gstack/projects/nex-crm-wuphf/najmuzzaman-main-design-20260505-131620-notebook-wiki-promise.md`. Eng review: same dir, dated 2026-05-05. Decision OV7A locked the per-event commit model with bounded enqueue; finding #8 from the Codex outside voice is the underlying concern.
+
+**Depends on / blocked by:** PR 1 must ship first (introduces the new write source).
+
+**Trigger to revisit:** First week of real PR 1 traffic, OR if any real wiki write ever times out.
+
+---
+
+### 19. Premise #3 closure design pass: memory workflow gate auto-satisfaction or removal
+
+**What:** Fresh `/office-hours` design pass on closing the memory workflow gate semantically. Today the gate requires `lookup + capture + promote` all satisfied to mark a task complete (`memory_workflow.go:398`). The eng review had originally planned to satisfy it inline from the auto-writer, but Codex flagged two killers: (a) the gate needs all three steps, not just capture; (b) calling `RecordTaskMemoryCapture` inline holds `b.mu` and would deadlock with the broker API path.
+
+**Why:** Premise #3 of the notebook-wiki-promise design says "kill the narrow `process_research` filter so the gate applies to all tasks, auto-satisfied by the writer." With OV3A we deferred this from PR 1 because the implementation path was wrong. Two possible exit ramps: (1) auto-satisfy all three steps deterministically with proper locking (raw helper holding existing lock + queueing the file write async); (2) kill the gate entirely — once writes are deterministic the gate is dead weight, but we lose its override-tracking and partial-error surfaces.
+
+**Pros:** Closes premise #3 honestly. Either direction simplifies the broker.
+
+**Cons:** A real design pass, not a one-line filter removal. Potentially touches `memory_workflow.go`, `broker_tasks_memory_workflow.go`, and `memory_workflow_reconciler.go`.
+
+**Context:** Notebook-wiki-promise design doc PR 8 row was originally "5-line filter removal at memory_workflow.go:212-227." Codex outside voice (2026-05-05) showed why that's wrong. Locked decisions OV3A, OV3B (rejected), OV3D (deadlock).
+
+**Depends on / blocked by:** PR 1 + PR 2 should ship first so we can observe the writer's real behavior before deciding which exit ramp is right.
+
+**Trigger to revisit:** After PRs 1, 2, 3 ship and the auto-writer behavior is observable in real WUPHF traffic.
+
+---
+
+### 20. Evaluate event-log architecture migration after notebook-wiki-promise PR 1 screenshot test
+
+**What:** After PR 1 ships and one full WUPHF session populates shelves, evaluate whether the per-event direct-commit model (OV7A) creates the predicted problems: wiki worker queue saturation, NotebookSignalScanner garbage on noisy files, PR 3 clustering quality. If yes, plan migration to the alternative architecture (OV7B): append-only event log per agent (`agents/{slug}/notebook/.events.jsonl`) plus a renderer pass that materializes markdown files on cadence or on-demand.
+
+**Why:** Codex outside voice (2026-05-05, finding #11) argued the event-log architecture is fundamentally simpler than per-event commits and avoids problems PRs 3-6 will have to unwind. We chose OV7A for PR 1 because it gives instant visible shelf fill (the screenshot is the demand test). If the prediction holds, the migration option needs to be alive, not re-derived from scratch.
+
+**Pros:** Far fewer git commits (1/min batched vs 1/event). Lighter long-term cost as agent activity scales. Cleaner separation between durable raw stream and rendered surface.
+
+**Cons:** Bigger refactor than designing it right once. Migration must preserve existing markdown files or accept that historical writes stay in the original layout.
+
+**Context:** Notebook-wiki-promise design 2026-05-05. OV7A vs OV7B in the eng review. Codex flagged OV7B as the simpler architecture; we picked OV7A for the demo path with this TODO as the safety net.
+
+**Depends on / blocked by:** PR 1 must ship and one full session must populate shelves. TODO #18's queue-depth metric is a leading signal.
+
+**Trigger to revisit:** After the screenshot post in founder channel + one week of PR 1 production traffic, OR if TODO #18 alerts fire repeatedly, OR if PR 3 ranking quality is poor.
+
+---
+
 ## Deferred
 
 Items with known fixes but out of scope for this branch. Each names the trigger that would unblock revisiting.

--- a/internal/team/auto_notebook_writer.go
+++ b/internal/team/auto_notebook_writer.go
@@ -92,9 +92,23 @@ type AutoNotebookWriter struct {
 	wiki   autoNotebookWriterClient
 	roster autoNotebookRoster
 	queue  chan autoNotebookEvent
+	// stopCh signals shutdown without closing w.queue. Closing the queue
+	// would race with concurrent Handle() callers that already cleared the
+	// running.Load() fast-path check and panic on send-to-closed-chan.
+	// CodeRabbit-flagged race fixed by leaving the queue intact and tearing
+	// down via this dedicated signal channel instead.
+	stopCh chan struct{}
 
 	mu      sync.Mutex
 	buckets map[string]*autoNotebookDedupeBucket
+
+	// progressMu + progressCond fan out a "something was processed" signal so
+	// tests can wait deterministically on a counter or a notebook entry
+	// without resorting to sleep loops (the repo's check-no-new-sleeps lint
+	// blocks them in tests, and this is the same pattern as scheduler.go's
+	// manual clock — push state changes, never poll real time).
+	progressMu   sync.Mutex
+	progressCond *sync.Cond
 
 	running atomic.Bool
 	done    chan struct{}
@@ -120,13 +134,16 @@ type autoNotebookDedupeBucket struct {
 // processing. Either argument may be nil for tests; nil wiki disables writes,
 // nil roster disables the membership filter.
 func NewAutoNotebookWriter(wiki autoNotebookWriterClient, roster autoNotebookRoster) *AutoNotebookWriter {
-	return &AutoNotebookWriter{
+	w := &AutoNotebookWriter{
 		wiki:    wiki,
 		roster:  roster,
 		queue:   make(chan autoNotebookEvent, autoNotebookQueueSize),
+		stopCh:  make(chan struct{}),
 		buckets: make(map[string]*autoNotebookDedupeBucket),
 		done:    make(chan struct{}),
 	}
+	w.progressCond = sync.NewCond(&w.progressMu)
+	return w
 }
 
 // Start launches the drain goroutine. Idempotent: a second call is a no-op.
@@ -140,14 +157,25 @@ func (w *AutoNotebookWriter) Start(ctx context.Context) {
 	go w.run(ctx)
 }
 
-// Stop closes the queue and waits up to timeout for the drain goroutine to
+// Stop signals the drain goroutine to exit and waits up to timeout for it to
 // finish. Idempotent. Returns even if the deadline elapses with events still
 // in flight — caller may inspect counters to detect drops.
+//
+// Implementation note: w.queue is intentionally NOT closed. Concurrent
+// Handle() callers may already be past the running.Load() fast-path check
+// when Stop runs, and a send-to-closed-chan would panic. Closing stopCh and
+// letting run() bail on it covers shutdown without that hazard. The queue
+// itself becomes garbage once all references are gone.
 func (w *AutoNotebookWriter) Stop(timeout time.Duration) {
 	if w == nil || !w.running.Swap(false) {
 		return
 	}
-	close(w.queue)
+	close(w.stopCh)
+	// Wake any test waiters parked on progressCond so they observe the
+	// stopped state and bail out of WaitForCondition without timing out.
+	w.progressMu.Lock()
+	w.progressCond.Broadcast()
+	w.progressMu.Unlock()
 	if timeout <= 0 {
 		<-w.done
 		return
@@ -188,13 +216,74 @@ func (w *AutoNotebookWriter) Handle(evt autoNotebookEvent) {
 	} else {
 		evt.Timestamp = evt.Timestamp.UTC()
 	}
+	// stopCh closes before the queue would (which it never does); selecting
+	// on it first lets a Handle racing with Stop bail out cleanly instead of
+	// blocking or — worse, with the old close(queue) implementation — sending
+	// on a closed channel.
 	select {
+	case <-w.stopCh:
+		return
+	default:
+	}
+	select {
+	case <-w.stopCh:
 	case w.queue <- evt:
 		w.enqueued.Add(1)
 	default:
 		w.queueSaturated.Add(1)
 		log.Printf("auto_notebook_writer: queue saturated, dropping event slug=%s kind=%s", evt.Slug, evt.Kind)
+		w.signalProgress()
 	}
+}
+
+// signalProgress fans out a "something happened" notification so tests can
+// wait deterministically without sleep loops. Cheap: cond.Broadcast on an
+// uncontended mutex is essentially a memory barrier when nobody is parked.
+func (w *AutoNotebookWriter) signalProgress() {
+	w.progressMu.Lock()
+	w.progressCond.Broadcast()
+	w.progressMu.Unlock()
+}
+
+// WaitForCondition blocks until predicate returns true, ctx is cancelled, or
+// the writer stops. Returns ctx.Err() on timeout/cancel and nil on success.
+// Test-only entry point — production code never waits on the writer.
+func (w *AutoNotebookWriter) WaitForCondition(ctx context.Context, predicate func() bool) error {
+	if w == nil {
+		return nil
+	}
+	if predicate() {
+		return nil
+	}
+	cancelWatcher := make(chan struct{})
+	defer close(cancelWatcher)
+	go func() {
+		select {
+		case <-ctx.Done():
+			w.progressMu.Lock()
+			w.progressCond.Broadcast()
+			w.progressMu.Unlock()
+		case <-cancelWatcher:
+		}
+	}()
+	w.progressMu.Lock()
+	defer w.progressMu.Unlock()
+	for !predicate() {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !w.running.Load() {
+			// Writer has been stopped. Re-check predicate one last time
+			// (a final event may have been processed before shutdown) and
+			// return whatever the predicate says.
+			if predicate() {
+				return nil
+			}
+			return ErrWorkerStopped
+		}
+		w.progressCond.Wait()
+	}
+	return nil
 }
 
 func (w *AutoNotebookWriter) run(ctx context.Context) {
@@ -203,28 +292,29 @@ func (w *AutoNotebookWriter) run(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case evt, ok := <-w.queue:
-			if !ok {
-				return
-			}
+		case <-w.stopCh:
+			return
+		case evt := <-w.queue:
 			w.process(ctx, evt)
 		}
 	}
 }
 
 func (w *AutoNotebookWriter) process(ctx context.Context, evt autoNotebookEvent) {
+	defer w.signalProgress()
 	body := renderAutoNotebookSection(evt)
 	if autoNotebookContainsSecret(body) {
 		w.redacted.Add(1)
 		log.Printf("auto_notebook_writer: secret pattern matched, dropping event slug=%s kind=%s", evt.Slug, evt.Kind)
 		return
 	}
-	// Dedupe key is the raw content + transition delta, not the rendered body
-	// — two events with identical message text but different timestamps render
-	// differently, and we want them to collapse into a single shelf entry per
-	// decision 4A. Including the kind+status pair distinguishes a status churn
-	// from a chat repeat.
-	dedupeBasis := string(evt.Kind) + "|" + evt.BeforeStatus + "→" + evt.AfterStatus + "|" + strings.TrimSpace(evt.Content)
+	// Dedupe key folds in the full transition identity — kind, before/after
+	// status, owning task, and trimmed content — not just content. Without
+	// TaskID two distinct tasks owned by the same agent and sharing a title
+	// (or two consecutive transitions on the same task) would collapse into
+	// one shelf entry. Decision 4A pinned per-(slug, day) sha256(content);
+	// "content" here is the dedupe basis, not the rendered body.
+	dedupeBasis := string(evt.Kind) + "|" + evt.TaskID + "|" + evt.BeforeStatus + "→" + evt.AfterStatus + "|" + strings.TrimSpace(evt.Content)
 	if w.isDuplicate(evt.Slug, evt.Timestamp, dedupeBasis) {
 		w.deduped.Add(1)
 		return

--- a/internal/team/auto_notebook_writer.go
+++ b/internal/team/auto_notebook_writer.go
@@ -1,0 +1,457 @@
+package team
+
+// auto_notebook_writer.go is PR 1 of the notebook-wiki-promise design
+// (~/.gstack/projects/nex-crm-wuphf/najmuzzaman-main-design-20260505-131620-notebook-wiki-promise.md).
+//
+// It populates per-agent notebook shelves deterministically: every roster-agent
+// PostMessage and every task transition emits one notebook entry under
+// agents/{slug}/notebook/{YYYY-MM-DD-HHMMSS}-{kind}-{shortHash}.md.
+//
+// Hot-path constraints (locked by eng review 2026-05-05):
+//   - PostMessage stays sub-microsecond. Handle() is a non-blocking enqueue.
+//   - Drop on queue saturation; never block the broker. Counter + warn log.
+//   - In-memory LRU dedupe per (slug, day) keyed by sha256(content). Ring of 50.
+//   - Pre-write secretlint regex scrub. Match → drop with redacted_event counter.
+//   - Roster-membership filter at ingress. Non-agents bypass.
+//   - One file per event (file-as-entry — aligns with NotebookSignalScanner).
+//   - On NotebookWrite error: structured warn + counter + drop. No retry.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// AutoNotebookEventKind identifies which broker hook produced an event. The
+// string values are written into entry filenames and section headers, so they
+// participate in the public format and must stay stable.
+type AutoNotebookEventKind string
+
+const (
+	AutoNotebookEventMessagePosted    AutoNotebookEventKind = "message_posted"
+	AutoNotebookEventTaskTransitioned AutoNotebookEventKind = "task_transitioned"
+)
+
+// autoNotebookQueueSize is the buffered-channel capacity (decision 6A). 256
+// gives ~minutes of headroom under realistic burst loads while keeping the
+// drop-on-saturation tail short enough to surface in logs quickly.
+const autoNotebookQueueSize = 256
+
+// autoNotebookDedupeRing bounds the per-bucket sha256 history. 50 covers a
+// reasonable rolling window of "same content posted twice" without unbounded
+// memory growth on a long-running session (decision 4A).
+const autoNotebookDedupeRing = 50
+
+// autoNotebookContentLimit truncates the blockquote rendered into each entry
+// (decision S1A). The notebook is meant to be a navigable shelf, not a verbatim
+// transcript — full content lives in the broker's message log.
+const autoNotebookContentLimit = 500
+
+// autoNotebookWriteTimeout bounds a single NotebookWrite call so a stuck git
+// process never wedges the writer goroutine.
+const autoNotebookWriteTimeout = 10 * time.Second
+
+// autoNotebookEvent is the in-memory event submitted to the writer's queue.
+// Constructed inline at hook sites; never persisted.
+type autoNotebookEvent struct {
+	Kind         AutoNotebookEventKind
+	Slug         string // owning agent — the notebook shelf the entry lands on
+	Actor        string // who acted; usually equals Slug
+	Channel      string
+	TaskID       string
+	TaskTitle    string
+	BeforeStatus string
+	AfterStatus  string
+	Content      string
+	Timestamp    time.Time
+}
+
+// autoNotebookWriterClient is the slice of WikiWorker the writer needs. Kept as
+// an interface so tests can substitute a fake without spinning the real worker.
+type autoNotebookWriterClient interface {
+	NotebookWrite(ctx context.Context, slug, path, content, mode, commitMsg string) (string, int, error)
+}
+
+// autoNotebookRoster filters events to roster-member senders only (OV6A).
+// Broker satisfies this via IsAgentMemberSlug.
+type autoNotebookRoster interface {
+	IsAgentMemberSlug(slug string) bool
+}
+
+// AutoNotebookWriter ingests broker events and writes notebook entries.
+// Lifecycle mirrors WikiWorker: NewAutoNotebookWriter → Start(ctx) → Stop(timeout).
+// Safe for concurrent Handle() callers.
+type AutoNotebookWriter struct {
+	wiki   autoNotebookWriterClient
+	roster autoNotebookRoster
+	queue  chan autoNotebookEvent
+
+	mu      sync.Mutex
+	buckets map[string]*autoNotebookDedupeBucket
+
+	running atomic.Bool
+	done    chan struct{}
+
+	enqueued       atomic.Int64
+	deduped        atomic.Int64
+	redacted       atomic.Int64
+	nonRoster      atomic.Int64
+	written        atomic.Int64
+	writeFailed    atomic.Int64
+	queueSaturated atomic.Int64
+	noopTransition atomic.Int64
+}
+
+// autoNotebookDedupeBucket is a small ring buffer of recent content hashes,
+// keyed by (slug, YYYY-MM-DD). Day boundaries are natural section breaks in
+// the bookshelf so per-day buckets are the right granularity.
+type autoNotebookDedupeBucket struct {
+	hashes []string
+}
+
+// NewAutoNotebookWriter constructs an idle writer. Call Start to begin
+// processing. Either argument may be nil for tests; nil wiki disables writes,
+// nil roster disables the membership filter.
+func NewAutoNotebookWriter(wiki autoNotebookWriterClient, roster autoNotebookRoster) *AutoNotebookWriter {
+	return &AutoNotebookWriter{
+		wiki:    wiki,
+		roster:  roster,
+		queue:   make(chan autoNotebookEvent, autoNotebookQueueSize),
+		buckets: make(map[string]*autoNotebookDedupeBucket),
+		done:    make(chan struct{}),
+	}
+}
+
+// Start launches the drain goroutine. Idempotent: a second call is a no-op.
+func (w *AutoNotebookWriter) Start(ctx context.Context) {
+	if w == nil {
+		return
+	}
+	if w.running.Swap(true) {
+		return
+	}
+	go w.run(ctx)
+}
+
+// Stop closes the queue and waits up to timeout for the drain goroutine to
+// finish. Idempotent. Returns even if the deadline elapses with events still
+// in flight — caller may inspect counters to detect drops.
+func (w *AutoNotebookWriter) Stop(timeout time.Duration) {
+	if w == nil || !w.running.Swap(false) {
+		return
+	}
+	close(w.queue)
+	if timeout <= 0 {
+		<-w.done
+		return
+	}
+	select {
+	case <-w.done:
+	case <-time.After(timeout):
+	}
+}
+
+// Handle is the broker-side ingress. Roster-filters and validates, then does a
+// non-blocking enqueue. Drops with a counter increment when the queue is full
+// (decision S3A). Always cheap to call from a hot path.
+func (w *AutoNotebookWriter) Handle(evt autoNotebookEvent) {
+	if w == nil || !w.running.Load() {
+		return
+	}
+	evt.Slug = strings.TrimSpace(evt.Slug)
+	if evt.Slug == "" {
+		return
+	}
+	if w.roster != nil && !w.roster.IsAgentMemberSlug(evt.Slug) {
+		w.nonRoster.Add(1)
+		return
+	}
+	if evt.Kind == AutoNotebookEventTaskTransitioned && strings.EqualFold(evt.BeforeStatus, evt.AfterStatus) {
+		w.noopTransition.Add(1)
+		return
+	}
+	if strings.TrimSpace(evt.Content) == "" && evt.Kind == AutoNotebookEventMessagePosted {
+		// A truly empty agent message has nothing worth shelving. Task
+		// transitions still record even with empty content because the
+		// status delta itself is the signal.
+		return
+	}
+	if evt.Timestamp.IsZero() {
+		evt.Timestamp = time.Now().UTC()
+	} else {
+		evt.Timestamp = evt.Timestamp.UTC()
+	}
+	select {
+	case w.queue <- evt:
+		w.enqueued.Add(1)
+	default:
+		w.queueSaturated.Add(1)
+		log.Printf("auto_notebook_writer: queue saturated, dropping event slug=%s kind=%s", evt.Slug, evt.Kind)
+	}
+}
+
+func (w *AutoNotebookWriter) run(ctx context.Context) {
+	defer close(w.done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case evt, ok := <-w.queue:
+			if !ok {
+				return
+			}
+			w.process(ctx, evt)
+		}
+	}
+}
+
+func (w *AutoNotebookWriter) process(ctx context.Context, evt autoNotebookEvent) {
+	body := renderAutoNotebookSection(evt)
+	if autoNotebookContainsSecret(body) {
+		w.redacted.Add(1)
+		log.Printf("auto_notebook_writer: secret pattern matched, dropping event slug=%s kind=%s", evt.Slug, evt.Kind)
+		return
+	}
+	// Dedupe key is the raw content + transition delta, not the rendered body
+	// — two events with identical message text but different timestamps render
+	// differently, and we want them to collapse into a single shelf entry per
+	// decision 4A. Including the kind+status pair distinguishes a status churn
+	// from a chat repeat.
+	dedupeBasis := string(evt.Kind) + "|" + evt.BeforeStatus + "→" + evt.AfterStatus + "|" + strings.TrimSpace(evt.Content)
+	if w.isDuplicate(evt.Slug, evt.Timestamp, dedupeBasis) {
+		w.deduped.Add(1)
+		return
+	}
+	relPath := autoNotebookEntryPath(evt, body)
+	commitMsg := fmt.Sprintf("notebook: auto-write %s for @%s", evt.Kind, evt.Slug)
+
+	if w.wiki == nil {
+		w.writeFailed.Add(1)
+		return
+	}
+	writeCtx, cancel := context.WithTimeout(ctx, autoNotebookWriteTimeout)
+	defer cancel()
+	_, _, err := w.wiki.NotebookWrite(writeCtx, evt.Slug, relPath, body, "create", commitMsg)
+	if err != nil {
+		w.writeFailed.Add(1)
+		log.Printf("auto_notebook_writer: write failed slug=%s path=%s: %v", evt.Slug, relPath, err)
+		return
+	}
+	w.written.Add(1)
+}
+
+// isDuplicate consults the per-(slug, day) ring buffer. A hit returns true and
+// does NOT add the hash again. A miss appends and returns false.
+func (w *AutoNotebookWriter) isDuplicate(slug string, ts time.Time, content string) bool {
+	key := autoNotebookDedupeKey(slug, ts)
+	hash := autoNotebookSha256Hex(content)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	bucket, ok := w.buckets[key]
+	if !ok {
+		bucket = &autoNotebookDedupeBucket{}
+		w.buckets[key] = bucket
+	}
+	for _, h := range bucket.hashes {
+		if h == hash {
+			return true
+		}
+	}
+	bucket.hashes = append(bucket.hashes, hash)
+	if len(bucket.hashes) > autoNotebookDedupeRing {
+		bucket.hashes = bucket.hashes[len(bucket.hashes)-autoNotebookDedupeRing:]
+	}
+	// Cheap GC: drop yesterday's bucket once a new day rolls over so we do not
+	// retain stale day buckets across long-running sessions.
+	w.gcOldBucketsLocked(ts)
+	return false
+}
+
+func (w *AutoNotebookWriter) gcOldBucketsLocked(ts time.Time) {
+	today := ts.UTC().Format("2006-01-02")
+	for k := range w.buckets {
+		if !strings.HasSuffix(k, today) {
+			// Keep buckets whose key day matches today. Drop everything else.
+			// Same-day keys end in today; mismatching keys are old.
+			parts := strings.SplitN(k, "|", 2)
+			if len(parts) != 2 || parts[1] != today {
+				delete(w.buckets, k)
+			}
+		}
+	}
+}
+
+// AutoNotebookCounters is a snapshot of the writer's observability counters.
+// Returned by Counters() for tests and (eventually) the TODO #18 metrics surface.
+type AutoNotebookCounters struct {
+	Enqueued       int64
+	Written        int64
+	Deduped        int64
+	Redacted       int64
+	NonRoster      int64
+	WriteFailed    int64
+	QueueSaturated int64
+	NoopTransition int64
+}
+
+// Counters returns a thread-safe snapshot of the writer's atomic counters.
+func (w *AutoNotebookWriter) Counters() AutoNotebookCounters {
+	if w == nil {
+		return AutoNotebookCounters{}
+	}
+	return AutoNotebookCounters{
+		Enqueued:       w.enqueued.Load(),
+		Written:        w.written.Load(),
+		Deduped:        w.deduped.Load(),
+		Redacted:       w.redacted.Load(),
+		NonRoster:      w.nonRoster.Load(),
+		WriteFailed:    w.writeFailed.Load(),
+		QueueSaturated: w.queueSaturated.Load(),
+		NoopTransition: w.noopTransition.Load(),
+	}
+}
+
+// renderAutoNotebookSection produces the markdown body for one entry. Format
+// is locked by decision S1A: H1 with kind, bullet list of metadata, blockquote
+// of the first autoNotebookContentLimit chars of content. Any markdown-special
+// characters in content are forced into the blockquote so they cannot inject
+// new H2 sections or break the catalog reader.
+func renderAutoNotebookSection(evt autoNotebookEvent) string {
+	ts := evt.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	} else {
+		ts = ts.UTC()
+	}
+	var b strings.Builder
+	switch evt.Kind {
+	case AutoNotebookEventTaskTransitioned:
+		fmt.Fprintf(&b, "# task_transitioned — %s → %s\n\n",
+			autoNotebookFallback(evt.BeforeStatus, "(unset)"),
+			autoNotebookFallback(evt.AfterStatus, "(unset)"))
+	case AutoNotebookEventMessagePosted:
+		fmt.Fprintf(&b, "# message_posted in #%s\n\n", autoNotebookFallback(evt.Channel, "general"))
+	default:
+		fmt.Fprintf(&b, "# %s\n\n", string(evt.Kind))
+	}
+	fmt.Fprintf(&b, "- timestamp: %s\n", ts.Format(time.RFC3339))
+	fmt.Fprintf(&b, "- kind: %s\n", evt.Kind)
+	fmt.Fprintf(&b, "- actor: @%s\n", autoNotebookFallback(evt.Actor, evt.Slug))
+	if evt.Channel != "" {
+		fmt.Fprintf(&b, "- channel: #%s\n", evt.Channel)
+	}
+	if evt.TaskID != "" {
+		title := strings.TrimSpace(evt.TaskTitle)
+		if title != "" {
+			fmt.Fprintf(&b, "- task: %s %q\n", evt.TaskID, title)
+		} else {
+			fmt.Fprintf(&b, "- task: %s\n", evt.TaskID)
+		}
+	}
+	if evt.Kind == AutoNotebookEventTaskTransitioned {
+		fmt.Fprintf(&b, "- status: %s → %s\n",
+			autoNotebookFallback(evt.BeforeStatus, "(unset)"),
+			autoNotebookFallback(evt.AfterStatus, "(unset)"))
+	}
+	body := autoNotebookTruncate(strings.TrimSpace(evt.Content), autoNotebookContentLimit)
+	if body != "" {
+		b.WriteString("\n")
+		for _, line := range strings.Split(body, "\n") {
+			b.WriteString("> ")
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+func autoNotebookFallback(s, fallback string) string {
+	if strings.TrimSpace(s) == "" {
+		return fallback
+	}
+	return s
+}
+
+// autoNotebookTruncate trims s to at most n bytes while preserving valid UTF-8
+// at the cut. Appends a "…" marker when truncation occurs.
+func autoNotebookTruncate(s string, n int) string {
+	if n <= 0 || len(s) <= n {
+		return s
+	}
+	cut := n
+	for cut > 0 && (s[cut]&0xC0) == 0x80 {
+		cut--
+	}
+	return s[:cut] + "…"
+}
+
+// autoNotebookEntryPath builds agents/{slug}/notebook/{YYYY-MM-DD-HHMMSS}-{kind}-{shortHash}.md.
+// The shortHash mixes timestamp nanoseconds into the digest so two events with
+// identical content but different times still get distinct filenames; dedupe
+// elsewhere (isDuplicate) protects against true duplicates.
+func autoNotebookEntryPath(evt autoNotebookEvent, body string) string {
+	ts := evt.Timestamp
+	if ts.IsZero() {
+		ts = time.Now().UTC()
+	} else {
+		ts = ts.UTC()
+	}
+	stamp := ts.Format("2006-01-02-150405")
+	mix := fmt.Sprintf("%d|%s|%s", ts.UnixNano(), evt.Kind, body)
+	short := autoNotebookSha256Hex(mix)[:8]
+	kind := strings.ReplaceAll(string(evt.Kind), "_", "-")
+	if kind == "" {
+		kind = "event"
+	}
+	return fmt.Sprintf("agents/%s/notebook/%s-%s-%s.md", evt.Slug, stamp, kind, short)
+}
+
+func autoNotebookDedupeKey(slug string, ts time.Time) string {
+	return slug + "|" + ts.UTC().Format("2006-01-02")
+}
+
+func autoNotebookSha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// autoNotebookSecretPatterns is the OV5A pre-write scrub set. Patterns are
+// high-confidence (typed prefixes, fixed lengths). Generic substring rules like
+// "password=" are intentionally omitted to avoid false-positive drops on agent
+// chatter that happens to mention the word "password".
+var autoNotebookSecretPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`AKIA[0-9A-Z]{16}`),                                                 // AWS access key
+	regexp.MustCompile(`ASIA[0-9A-Z]{16}`),                                                 // AWS STS access key
+	regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{36,}`),                                       // GitHub personal/OAuth/server token
+	regexp.MustCompile(`github_pat_[A-Za-z0-9_]{20,}`),                                     // GitHub fine-grained PAT
+	regexp.MustCompile(`sk_live_[A-Za-z0-9]{24,}`),                                         // Stripe secret key (live)
+	regexp.MustCompile(`rk_live_[A-Za-z0-9]{24,}`),                                         // Stripe restricted key (live)
+	regexp.MustCompile(`sk-ant-[A-Za-z0-9_\-]{20,}`),                                       // Anthropic API key
+	regexp.MustCompile(`sk-[A-Za-z0-9]{32,}`),                                              // OpenAI-style secret key
+	regexp.MustCompile(`SG\.[A-Za-z0-9_\-]{22}\.[A-Za-z0-9_\-]{43}`),                       // SendGrid API key
+	regexp.MustCompile(`xox[baprs]-[A-Za-z0-9-]{10,}`),                                     // Slack token
+	regexp.MustCompile(`AIza[0-9A-Za-z\-_]{35}`),                                           // Google API key
+	regexp.MustCompile(`-----BEGIN ((RSA|EC|OPENSSH|DSA|PGP) )?PRIVATE KEY( BLOCK)?-----`), // Private key block
+}
+
+// autoNotebookContainsSecret returns true when any locked secret pattern
+// matches anywhere in s. Errs on the side of dropping ambiguous content;
+// the broker still has the raw message in its log, so nothing is lost.
+func autoNotebookContainsSecret(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, re := range autoNotebookSecretPatterns {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/team/auto_notebook_writer_test.go
+++ b/internal/team/auto_notebook_writer_test.go
@@ -1,0 +1,415 @@
+package team
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeNotebookClient records each NotebookWrite call. It is intentionally
+// permissive — validation is the WikiWorker's job; here we test the writer's
+// own logic (dedupe, redaction, roster, queue saturation, formatting).
+type fakeNotebookClient struct {
+	mu    sync.Mutex
+	calls []fakeNotebookCall
+	err   error
+}
+
+type fakeNotebookCall struct {
+	Slug    string
+	Path    string
+	Content string
+	Mode    string
+}
+
+func (f *fakeNotebookClient) NotebookWrite(_ context.Context, slug, path, content, mode, _ string) (string, int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.err != nil {
+		return "", 0, f.err
+	}
+	f.calls = append(f.calls, fakeNotebookCall{Slug: slug, Path: path, Content: content, Mode: mode})
+	return "deadbeef", len(content), nil
+}
+
+func (f *fakeNotebookClient) snapshot() []fakeNotebookCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]fakeNotebookCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+// allowAllRoster mimics a broker where every slug is a registered agent.
+type allowAllRoster struct{}
+
+func (allowAllRoster) IsAgentMemberSlug(string) bool { return true }
+
+// allowSetRoster gates membership on a small set of slugs.
+type allowSetRoster struct {
+	allowed map[string]struct{}
+}
+
+func (r allowSetRoster) IsAgentMemberSlug(slug string) bool {
+	_, ok := r.allowed[strings.TrimSpace(slug)]
+	return ok
+}
+
+func startWriter(t *testing.T, client autoNotebookWriterClient, roster autoNotebookRoster) *AutoNotebookWriter {
+	t.Helper()
+	w := NewAutoNotebookWriter(client, roster)
+	ctx, cancel := context.WithCancel(context.Background())
+	w.Start(ctx)
+	t.Cleanup(func() {
+		cancel()
+		w.Stop(2 * time.Second)
+	})
+	return w
+}
+
+func waitForCalls(t *testing.T, client *fakeNotebookClient, n int) []fakeNotebookCall {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(client.snapshot()) >= n {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	calls := client.snapshot()
+	if len(calls) < n {
+		t.Fatalf("expected at least %d calls, got %d", n, len(calls))
+	}
+	return calls
+}
+
+func waitForCounter(t *testing.T, get func() int64, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if get() >= want {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("counter never reached %d (got %d)", want, get())
+}
+
+func TestAutoNotebookWriter_HandleEnqueuesAndWrites(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	w.Handle(autoNotebookEvent{
+		Kind:      AutoNotebookEventMessagePosted,
+		Slug:      "ceo",
+		Actor:     "ceo",
+		Channel:   "general",
+		Content:   "hello team",
+		Timestamp: time.Date(2026, 5, 5, 13, 14, 15, 0, time.UTC),
+	})
+
+	calls := waitForCalls(t, client, 1)
+	if calls[0].Slug != "ceo" {
+		t.Fatalf("slug: got %q want ceo", calls[0].Slug)
+	}
+	if calls[0].Mode != "create" {
+		t.Fatalf("mode: got %q want create", calls[0].Mode)
+	}
+	if !strings.HasPrefix(calls[0].Path, "agents/ceo/notebook/2026-05-05-131415-message-posted-") {
+		t.Fatalf("unexpected path: %q", calls[0].Path)
+	}
+	if !strings.HasSuffix(calls[0].Path, ".md") {
+		t.Fatalf("path missing .md suffix: %q", calls[0].Path)
+	}
+	if !strings.Contains(calls[0].Content, "# message_posted in #general") {
+		t.Fatalf("body missing header:\n%s", calls[0].Content)
+	}
+	if !strings.Contains(calls[0].Content, "> hello team") {
+		t.Fatalf("body missing blockquote:\n%s", calls[0].Content)
+	}
+}
+
+func TestAutoNotebookWriter_RosterFilterDropsNonAgents(t *testing.T) {
+	client := &fakeNotebookClient{}
+	roster := allowSetRoster{allowed: map[string]struct{}{"ceo": {}}}
+	w := startWriter(t, client, roster)
+
+	w.Handle(autoNotebookEvent{Kind: AutoNotebookEventMessagePosted, Slug: "human:nazz", Content: "hi"})
+	w.Handle(autoNotebookEvent{Kind: AutoNotebookEventMessagePosted, Slug: "ceo", Content: "yo"})
+
+	calls := waitForCalls(t, client, 1)
+	if len(calls) != 1 {
+		t.Fatalf("only the agent message should land; got %d", len(calls))
+	}
+	if w.Counters().NonRoster != 1 {
+		t.Fatalf("nonRoster counter: got %d want 1", w.Counters().NonRoster)
+	}
+}
+
+func TestAutoNotebookWriter_DedupeWithinDay(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	evt := autoNotebookEvent{
+		Kind:      AutoNotebookEventMessagePosted,
+		Slug:      "ceo",
+		Channel:   "general",
+		Content:   "shipping pr 1 today",
+		Timestamp: time.Date(2026, 5, 5, 13, 14, 15, 0, time.UTC),
+	}
+	w.Handle(evt)
+	evt2 := evt
+	evt2.Timestamp = evt.Timestamp.Add(2 * time.Second)
+	w.Handle(evt2)
+
+	waitForCalls(t, client, 1)
+	waitForCounter(t, func() int64 { return w.Counters().Deduped }, 1)
+	if got := len(client.snapshot()); got != 1 {
+		t.Fatalf("expected exactly 1 write, got %d", got)
+	}
+}
+
+func TestAutoNotebookWriter_DedupePerDayBucket(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	common := autoNotebookEvent{
+		Kind:    AutoNotebookEventMessagePosted,
+		Slug:    "ceo",
+		Channel: "general",
+		Content: "weekly retro: shipped pr 1",
+	}
+	day1 := common
+	day1.Timestamp = time.Date(2026, 5, 5, 23, 59, 59, 0, time.UTC)
+	day2 := common
+	day2.Timestamp = time.Date(2026, 5, 6, 0, 0, 1, 0, time.UTC)
+
+	w.Handle(day1)
+	w.Handle(day2)
+
+	calls := waitForCalls(t, client, 2)
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 writes (different day buckets), got %d", len(calls))
+	}
+}
+
+func TestAutoNotebookWriter_RedactsSecretContent(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	// Build the fake-looking key at runtime so GitHub's secret scanner does
+	// not flag the source line. The pattern still matches the writer's
+	// regex set at the byte level, which is the property under test.
+	fakeKey := "sk" + "_" + "live" + "_" + strings.Repeat("A", 24)
+	w.Handle(autoNotebookEvent{
+		Kind:    AutoNotebookEventMessagePosted,
+		Slug:    "ceo",
+		Channel: "general",
+		Content: "found a stripe key " + fakeKey + " in the logs",
+	})
+
+	waitForCounter(t, func() int64 { return w.Counters().Redacted }, 1)
+	if got := len(client.snapshot()); got != 0 {
+		t.Fatalf("expected zero writes after redaction, got %d", got)
+	}
+}
+
+func TestAutoNotebookWriter_TaskTransitionUsesOwnerShelf(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	w.Handle(autoNotebookEvent{
+		Kind:         AutoNotebookEventTaskTransitioned,
+		Slug:         "eng",
+		Actor:        "ceo",
+		Channel:      "engineering",
+		TaskID:       "task-42",
+		TaskTitle:    "Ship PR 1",
+		BeforeStatus: "review",
+		AfterStatus:  "done",
+		Content:      "Ship PR 1",
+		Timestamp:    time.Date(2026, 5, 5, 13, 14, 15, 0, time.UTC),
+	})
+
+	calls := waitForCalls(t, client, 1)
+	if calls[0].Slug != "eng" {
+		t.Fatalf("expected owner shelf 'eng', got %q", calls[0].Slug)
+	}
+	if !strings.Contains(calls[0].Content, "review → done") {
+		t.Fatalf("missing transition delta in body:\n%s", calls[0].Content)
+	}
+	if !strings.Contains(calls[0].Content, "task: task-42 \"Ship PR 1\"") {
+		t.Fatalf("missing task ref in body:\n%s", calls[0].Content)
+	}
+	if !strings.Contains(calls[0].Path, "task-transitioned") {
+		t.Fatalf("path missing kind segment: %q", calls[0].Path)
+	}
+}
+
+func TestAutoNotebookWriter_NoopTransitionDropped(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := startWriter(t, client, allowAllRoster{})
+
+	w.Handle(autoNotebookEvent{
+		Kind:         AutoNotebookEventTaskTransitioned,
+		Slug:         "eng",
+		BeforeStatus: "in_progress",
+		AfterStatus:  "in_progress",
+	})
+
+	// Counter is updated synchronously in Handle, so no wait needed.
+	if w.Counters().NoopTransition != 1 {
+		t.Fatalf("noopTransition: want 1, got %d", w.Counters().NoopTransition)
+	}
+	if got := len(client.snapshot()); got != 0 {
+		t.Fatalf("no-op transitions must not write; got %d", got)
+	}
+}
+
+func TestAutoNotebookWriter_QueueSaturationDropsNotBlocks(t *testing.T) {
+	// Block the writer goroutine by giving it a slow client. Once the queue
+	// fills, additional Handle() calls must drop without blocking.
+	release := make(chan struct{})
+	client := &slowClient{release: release}
+	w := startWriter(t, client, allowAllRoster{})
+
+	// First N events fill the buffered channel + the in-process slot.
+	for i := 0; i < autoNotebookQueueSize+2; i++ {
+		w.Handle(autoNotebookEvent{
+			Kind:    AutoNotebookEventMessagePosted,
+			Slug:    "ceo",
+			Channel: "general",
+			Content: "msg-" + strings.Repeat("x", i+1), // unique content per call
+		})
+	}
+
+	if w.Counters().QueueSaturated == 0 {
+		t.Fatalf("expected at least one queue-saturated drop")
+	}
+	close(release)
+}
+
+func TestAutoNotebookWriter_HandleAfterStopIsNoop(t *testing.T) {
+	client := &fakeNotebookClient{}
+	w := NewAutoNotebookWriter(client, allowAllRoster{})
+	ctx := context.Background()
+	w.Start(ctx)
+	w.Stop(time.Second)
+
+	w.Handle(autoNotebookEvent{Kind: AutoNotebookEventMessagePosted, Slug: "ceo", Content: "after stop"})
+
+	if got := len(client.snapshot()); got != 0 {
+		t.Fatalf("Handle after Stop must drop; got %d writes", got)
+	}
+}
+
+func TestAutoNotebookWriter_WriteFailureCountedNotPropagated(t *testing.T) {
+	client := &fakeNotebookClient{err: errors.New("simulated git contention")}
+	w := startWriter(t, client, allowAllRoster{})
+
+	w.Handle(autoNotebookEvent{
+		Kind:    AutoNotebookEventMessagePosted,
+		Slug:    "ceo",
+		Channel: "general",
+		Content: "transient error",
+	})
+
+	waitForCounter(t, func() int64 { return w.Counters().WriteFailed }, 1)
+	if w.Counters().Written != 0 {
+		t.Fatalf("written counter should stay 0; got %d", w.Counters().Written)
+	}
+}
+
+func TestAutoNotebookSecretPatterns(t *testing.T) {
+	t.Parallel()
+	// Build fixtures at runtime so GitHub's secret scanner does not flag the
+	// source. Each value still satisfies the corresponding regex.
+	awsKey := "AKIA" + strings.Repeat("A", 16)
+	ghpKey := "ghp_" + strings.Repeat("a", 36)
+	openaiKey := "sk-" + strings.Repeat("A", 32)
+	slackKey := "xoxb-" + strings.Repeat("1", 10) + "-abcde"
+	cases := []struct {
+		name string
+		in   string
+		hit  bool
+	}{
+		{"aws access key", awsKey, true},
+		{"github pat", ghpKey, true},
+		{"openai key", openaiKey, true},
+		{"slack token", slackKey, true},
+		{"private key block", "-----BEGIN RSA PRIVATE KEY-----", true},
+		{"plain word password", "password is fine to mention", false},
+		{"normal sentence", "shipping notebook auto-writer pr1", false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			if got := autoNotebookContainsSecret(tc.in); got != tc.hit {
+				t.Fatalf("autoNotebookContainsSecret(%q) = %v, want %v", tc.in, got, tc.hit)
+			}
+		})
+	}
+}
+
+func TestAutoNotebookTruncate(t *testing.T) {
+	t.Parallel()
+	// Ascii within limit
+	if got := autoNotebookTruncate("hello", 10); got != "hello" {
+		t.Fatalf("short string changed: %q", got)
+	}
+	// Ascii over limit
+	if got := autoNotebookTruncate("abcdefghij", 5); got != "abcde…" {
+		t.Fatalf("ascii truncate: got %q", got)
+	}
+	// UTF-8 boundary
+	got := autoNotebookTruncate("héllo", 3)
+	// "h" (1 byte) + "é" (2 bytes) = 3 bytes; cut at 3 lands cleanly.
+	if !strings.HasSuffix(got, "…") {
+		t.Fatalf("expected truncation marker; got %q", got)
+	}
+	for i, r := range got {
+		if r == 0xFFFD {
+			t.Fatalf("invalid utf-8 introduced at byte %d in %q", i, got)
+		}
+	}
+}
+
+func TestRenderAutoNotebookSection_MarkdownEscape(t *testing.T) {
+	body := renderAutoNotebookSection(autoNotebookEvent{
+		Kind:      AutoNotebookEventMessagePosted,
+		Slug:      "ceo",
+		Actor:     "ceo",
+		Channel:   "general",
+		Content:   "## not a section\n# definitely not\n- list",
+		Timestamp: time.Date(2026, 5, 5, 13, 0, 0, 0, time.UTC),
+	})
+	// Each content line should be blockquoted, never promoted to a header.
+	for _, line := range strings.Split(strings.TrimSpace(body), "\n") {
+		if strings.HasPrefix(line, "##") {
+			t.Fatalf("content line was promoted to H2 header:\n%s", body)
+		}
+	}
+	if !strings.Contains(body, "> ## not a section") {
+		t.Fatalf("expected blockquoted content line; body:\n%s", body)
+	}
+}
+
+// slowClient simulates a NotebookWrite that blocks until release is closed.
+type slowClient struct {
+	release chan struct{}
+	calls   atomic.Int32
+}
+
+func (s *slowClient) NotebookWrite(ctx context.Context, slug, path, content, mode, msg string) (string, int, error) {
+	s.calls.Add(1)
+	select {
+	case <-s.release:
+	case <-ctx.Done():
+		return "", 0, ctx.Err()
+	}
+	return "deadbeef", len(content), nil
+}

--- a/internal/team/auto_notebook_writer_test.go
+++ b/internal/team/auto_notebook_writer_test.go
@@ -71,32 +71,25 @@ func startWriter(t *testing.T, client autoNotebookWriterClient, roster autoNoteb
 	return w
 }
 
-func waitForCalls(t *testing.T, client *fakeNotebookClient, n int) []fakeNotebookCall {
+func waitForCalls(t *testing.T, w *AutoNotebookWriter, client *fakeNotebookClient, n int) []fakeNotebookCall {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(client.snapshot()) >= n {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := w.WaitForCondition(ctx, func() bool {
+		return len(client.snapshot()) >= n
+	}); err != nil {
+		t.Fatalf("waiting for %d calls: %v (got %d)", n, err, len(client.snapshot()))
 	}
-	calls := client.snapshot()
-	if len(calls) < n {
-		t.Fatalf("expected at least %d calls, got %d", n, len(calls))
-	}
-	return calls
+	return client.snapshot()
 }
 
-func waitForCounter(t *testing.T, get func() int64, want int64) {
+func waitForCounter(t *testing.T, w *AutoNotebookWriter, get func() int64, want int64) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if get() >= want {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := w.WaitForCondition(ctx, func() bool { return get() >= want }); err != nil {
+		t.Fatalf("counter never reached %d: %v (got %d)", want, err, get())
 	}
-	t.Fatalf("counter never reached %d (got %d)", want, get())
 }
 
 func TestAutoNotebookWriter_HandleEnqueuesAndWrites(t *testing.T) {
@@ -112,7 +105,7 @@ func TestAutoNotebookWriter_HandleEnqueuesAndWrites(t *testing.T) {
 		Timestamp: time.Date(2026, 5, 5, 13, 14, 15, 0, time.UTC),
 	})
 
-	calls := waitForCalls(t, client, 1)
+	calls := waitForCalls(t, w, client, 1)
 	if calls[0].Slug != "ceo" {
 		t.Fatalf("slug: got %q want ceo", calls[0].Slug)
 	}
@@ -141,7 +134,7 @@ func TestAutoNotebookWriter_RosterFilterDropsNonAgents(t *testing.T) {
 	w.Handle(autoNotebookEvent{Kind: AutoNotebookEventMessagePosted, Slug: "human:nazz", Content: "hi"})
 	w.Handle(autoNotebookEvent{Kind: AutoNotebookEventMessagePosted, Slug: "ceo", Content: "yo"})
 
-	calls := waitForCalls(t, client, 1)
+	calls := waitForCalls(t, w, client, 1)
 	if len(calls) != 1 {
 		t.Fatalf("only the agent message should land; got %d", len(calls))
 	}
@@ -166,8 +159,8 @@ func TestAutoNotebookWriter_DedupeWithinDay(t *testing.T) {
 	evt2.Timestamp = evt.Timestamp.Add(2 * time.Second)
 	w.Handle(evt2)
 
-	waitForCalls(t, client, 1)
-	waitForCounter(t, func() int64 { return w.Counters().Deduped }, 1)
+	waitForCalls(t, w, client, 1)
+	waitForCounter(t, w, func() int64 { return w.Counters().Deduped }, 1)
 	if got := len(client.snapshot()); got != 1 {
 		t.Fatalf("expected exactly 1 write, got %d", got)
 	}
@@ -191,7 +184,7 @@ func TestAutoNotebookWriter_DedupePerDayBucket(t *testing.T) {
 	w.Handle(day1)
 	w.Handle(day2)
 
-	calls := waitForCalls(t, client, 2)
+	calls := waitForCalls(t, w, client, 2)
 	if len(calls) != 2 {
 		t.Fatalf("expected 2 writes (different day buckets), got %d", len(calls))
 	}
@@ -212,7 +205,7 @@ func TestAutoNotebookWriter_RedactsSecretContent(t *testing.T) {
 		Content: "found a stripe key " + fakeKey + " in the logs",
 	})
 
-	waitForCounter(t, func() int64 { return w.Counters().Redacted }, 1)
+	waitForCounter(t, w, func() int64 { return w.Counters().Redacted }, 1)
 	if got := len(client.snapshot()); got != 0 {
 		t.Fatalf("expected zero writes after redaction, got %d", got)
 	}
@@ -235,7 +228,7 @@ func TestAutoNotebookWriter_TaskTransitionUsesOwnerShelf(t *testing.T) {
 		Timestamp:    time.Date(2026, 5, 5, 13, 14, 15, 0, time.UTC),
 	})
 
-	calls := waitForCalls(t, client, 1)
+	calls := waitForCalls(t, w, client, 1)
 	if calls[0].Slug != "eng" {
 		t.Fatalf("expected owner shelf 'eng', got %q", calls[0].Slug)
 	}
@@ -318,7 +311,7 @@ func TestAutoNotebookWriter_WriteFailureCountedNotPropagated(t *testing.T) {
 		Content: "transient error",
 	})
 
-	waitForCounter(t, func() int64 { return w.Counters().WriteFailed }, 1)
+	waitForCounter(t, w, func() int64 { return w.Counters().WriteFailed }, 1)
 	if w.Counters().Written != 0 {
 		t.Fatalf("written counter should stay 0; got %d", w.Counters().Written)
 	}

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -100,6 +100,7 @@ type Broker struct {
 	wikiSectionsSubscribers map[int]chan WikiSectionsUpdatedEvent
 	wikiWorker              *WikiWorker
 	wikiOnce                sync.Once
+	autoNotebookWriter      *AutoNotebookWriter
 	wikiIndex               *WikiIndex
 	wikiExtractor           *Extractor
 	wikiDLQ                 *DLQ
@@ -591,6 +592,7 @@ func (b *Broker) Stop() {
 	pbSynth := b.playbookSynthesizer
 	pamDisp := b.pamDispatcher
 	compressor := b.wikiCompressor
+	autoWriter := b.autoNotebookWriter
 	b.mu.Unlock()
 	if synth != nil {
 		synth.Stop()
@@ -603,6 +605,9 @@ func (b *Broker) Stop() {
 	}
 	if compressor != nil {
 		compressor.Stop()
+	}
+	if autoWriter != nil {
+		autoWriter.Stop(2 * time.Second)
 	}
 }
 
@@ -623,6 +628,79 @@ func (b *Broker) Stop() {
 // Returns an error if the port cannot be bound (e.g. already in use).
 // Web UI server (ServeWebUI, cacheControlMiddleware, webUIProxyHandler)
 // moved to broker_web_proxy.go.
+
+// emitTaskTransitionAutoNotebook is the canonical seam for the OV2A locked
+// hook: a single after-saveLocked task-transition event, emitted from
+// MutateTask, BlockTask, ResumeTask, EnsureTask, and the self-healing path.
+// Caller passes the pre-mutation status snapshot; the writer records the
+// before/after pair and routes the entry to the task owner's shelf.
+//
+// Caller must hold b.mu. Roster filtering happens here (lock-free predicate)
+// because the writer cannot re-enter b.mu — see isAgentMemberSlugLocked.
+func (b *Broker) emitTaskTransitionAutoNotebook(task *teamTask, beforeStatus, actor string) {
+	if b == nil || b.autoNotebookWriter == nil || task == nil {
+		return
+	}
+	owner := strings.TrimSpace(task.Owner)
+	if owner == "" {
+		// No owner means no shelf to land on. Skipping here avoids feeding
+		// the writer an event it would just drop and keeps counters clean.
+		return
+	}
+	if !b.isAgentMemberSlugLocked(owner) {
+		return
+	}
+	b.autoNotebookWriter.Handle(autoNotebookEvent{
+		Kind:         AutoNotebookEventTaskTransitioned,
+		Slug:         owner,
+		Actor:        strings.TrimSpace(actor),
+		Channel:      normalizeChannelSlug(task.Channel),
+		TaskID:       task.ID,
+		TaskTitle:    task.Title,
+		BeforeStatus: strings.TrimSpace(beforeStatus),
+		AfterStatus:  strings.TrimSpace(task.Status),
+		Content:      strings.TrimSpace(task.Title),
+		Timestamp:    time.Now().UTC(),
+	})
+}
+
+// IsAgentMemberSlug returns true when `slug` matches a registered office
+// member and is not a human/system slug. Acquires b.mu — DO NOT call from a
+// path that already holds it; use isAgentMemberSlugLocked instead.
+func (b *Broker) IsAgentMemberSlug(slug string) bool {
+	if b == nil {
+		return false
+	}
+	slug = normalizeActorSlug(slug)
+	if slug == "" || isHumanMessageSender(slug) {
+		return false
+	}
+	switch slug {
+	case "system", "nex":
+		return false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.findMemberLocked(slug) != nil
+}
+
+// isAgentMemberSlugLocked is the hook-site variant: it assumes b.mu is held.
+// Used by the auto-notebook writer hooks to filter senders without re-entering
+// the broker's mutex (which would deadlock).
+func (b *Broker) isAgentMemberSlugLocked(slug string) bool {
+	if b == nil {
+		return false
+	}
+	slug = normalizeActorSlug(slug)
+	if slug == "" || isHumanMessageSender(slug) {
+		return false
+	}
+	switch slug {
+	case "system", "nex":
+		return false
+	}
+	return b.findMemberLocked(slug) != nil
+}
 
 // senderMayAutoPromoteLocked reports whether a `from` value is allowed to have
 // its @slug body text auto-promoted into the tagged array. Allowlist shape:

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -637,6 +637,11 @@ func (b *Broker) Stop() {
 //
 // Caller must hold b.mu. Roster filtering happens here (lock-free predicate)
 // because the writer cannot re-enter b.mu — see isAgentMemberSlugLocked.
+//
+// No-op transitions (beforeStatus == afterStatus) are short-circuited at the
+// source: the writer would also drop them via NoopTransition, but pruning
+// here avoids the enqueue + roster lookup on a path where many of the
+// existing call sites can legitimately be called with no actual delta.
 func (b *Broker) emitTaskTransitionAutoNotebook(task *teamTask, beforeStatus, actor string) {
 	if b == nil || b.autoNotebookWriter == nil || task == nil {
 		return
@@ -645,6 +650,11 @@ func (b *Broker) emitTaskTransitionAutoNotebook(task *teamTask, beforeStatus, ac
 	if owner == "" {
 		// No owner means no shelf to land on. Skipping here avoids feeding
 		// the writer an event it would just drop and keeps counters clean.
+		return
+	}
+	beforeTrimmed := strings.TrimSpace(beforeStatus)
+	afterTrimmed := strings.TrimSpace(task.Status)
+	if strings.EqualFold(beforeTrimmed, afterTrimmed) {
 		return
 	}
 	if !b.isAgentMemberSlugLocked(owner) {
@@ -657,11 +667,40 @@ func (b *Broker) emitTaskTransitionAutoNotebook(task *teamTask, beforeStatus, ac
 		Channel:      normalizeChannelSlug(task.Channel),
 		TaskID:       task.ID,
 		TaskTitle:    task.Title,
-		BeforeStatus: strings.TrimSpace(beforeStatus),
-		AfterStatus:  strings.TrimSpace(task.Status),
+		BeforeStatus: beforeTrimmed,
+		AfterStatus:  afterTrimmed,
 		Content:      strings.TrimSpace(task.Title),
 		Timestamp:    time.Now().UTC(),
 	})
+}
+
+// pendingTaskTransition captures a status delta that an under-mutex helper
+// (e.g. unblockDependentsLocked) wants to publish, but only AFTER the caller
+// has persisted via saveLocked. Without this two-step, a saveLocked failure
+// would still leak notebook entries for transitions the broker rolled back.
+type pendingTaskTransition struct {
+	taskID       string
+	beforeStatus string
+}
+
+// flushPendingAutoNotebookTransitionsLocked publishes a batch of cascade
+// transitions to the writer using the current status of each task in
+// b.tasks. Caller holds b.mu and has just successfully saveLocked'd. The
+// per-event no-op guard inside emitTaskTransitionAutoNotebook handles the
+// case where a subsequent mutation reverted the status back to its prior
+// value before we got here.
+func (b *Broker) flushPendingAutoNotebookTransitionsLocked(pending []pendingTaskTransition, actor string) {
+	if b == nil || len(pending) == 0 {
+		return
+	}
+	for _, p := range pending {
+		for i := range b.tasks {
+			if b.tasks[i].ID == p.taskID {
+				b.emitTaskTransitionAutoNotebook(&b.tasks[i], p.beforeStatus, actor)
+				break
+			}
+		}
+	}
 }
 
 // IsAgentMemberSlug returns true when `slug` matches a registered office

--- a/internal/team/broker_auto_notebook_writer_bench_test.go
+++ b/internal/team/broker_auto_notebook_writer_bench_test.go
@@ -7,34 +7,32 @@ import (
 	"time"
 )
 
+// benchNotebookClient is a no-op writer client used by the benchmark — git
+// commits would otherwise dominate runtime and the writer's queue would
+// saturate, pushing the benchmark onto the drop path instead of the enqueue
+// path it is trying to measure.
+type benchNotebookClient struct{}
+
+func (benchNotebookClient) NotebookWrite(context.Context, string, string, string, string, string) (string, int, error) {
+	return "deadbeef", 0, nil
+}
+
 // BenchmarkPostMessage_WithAutoNotebook measures the added latency of the
 // auto-notebook writer hook on the PostMessage hot path. Target: <1ms p50
-// per the eng review test plan (T1A). The writer runs but its internal
-// goroutine processes events asynchronously, so this benchmark exercises the
-// enqueue cost only — exactly the surface that mattered to the eng review.
+// per the eng review test plan (T1A). Uses a no-op writer client so the
+// benchmark stays on the steady-state enqueue path; the consumer drains
+// fast enough that QueueSaturated stays at 0 even at large b.N. Asserted
+// after the loop so a regression that re-introduces drops fails loudly.
 func BenchmarkPostMessage_WithAutoNotebook(b *testing.B) {
-	root := filepath.Join(b.TempDir(), "wiki")
-	backup := filepath.Join(b.TempDir(), "wiki.bak")
-	repo := NewRepoAt(root, backup)
-	if err := repo.Init(context.Background()); err != nil {
-		b.Fatalf("repo init: %v", err)
-	}
-
 	br := NewBrokerAt(filepath.Join(b.TempDir(), "broker-state.json"))
-	worker := NewWikiWorker(repo, br)
 	ctx, cancel := context.WithCancel(context.Background())
-	worker.Start(ctx)
-	defer func() {
-		cancel()
-		<-worker.Done()
-	}()
+	defer cancel()
 
-	writer := NewAutoNotebookWriter(worker, nil)
+	writer := NewAutoNotebookWriter(benchNotebookClient{}, nil)
 	writer.Start(ctx)
 	defer writer.Stop(2 * time.Second)
 
 	br.mu.Lock()
-	br.wikiWorker = worker
 	br.autoNotebookWriter = writer
 	br.mu.Unlock()
 
@@ -47,6 +45,10 @@ func BenchmarkPostMessage_WithAutoNotebook(b *testing.B) {
 		if _, err := br.PostMessage("ceo", "general", "benchmark traffic", nil, ""); err != nil {
 			b.Fatalf("PostMessage: %v", err)
 		}
+	}
+	b.StopTimer()
+	if got := writer.Counters().QueueSaturated; got != 0 {
+		b.Fatalf("benchmark drifted into saturated-drop path; QueueSaturated=%d", got)
 	}
 }
 

--- a/internal/team/broker_auto_notebook_writer_bench_test.go
+++ b/internal/team/broker_auto_notebook_writer_bench_test.go
@@ -1,0 +1,67 @@
+package team
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// BenchmarkPostMessage_WithAutoNotebook measures the added latency of the
+// auto-notebook writer hook on the PostMessage hot path. Target: <1ms p50
+// per the eng review test plan (T1A). The writer runs but its internal
+// goroutine processes events asynchronously, so this benchmark exercises the
+// enqueue cost only — exactly the surface that mattered to the eng review.
+func BenchmarkPostMessage_WithAutoNotebook(b *testing.B) {
+	root := filepath.Join(b.TempDir(), "wiki")
+	backup := filepath.Join(b.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		b.Fatalf("repo init: %v", err)
+	}
+
+	br := NewBrokerAt(filepath.Join(b.TempDir(), "broker-state.json"))
+	worker := NewWikiWorker(repo, br)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+	defer func() {
+		cancel()
+		<-worker.Done()
+	}()
+
+	writer := NewAutoNotebookWriter(worker, nil)
+	writer.Start(ctx)
+	defer writer.Stop(2 * time.Second)
+
+	br.mu.Lock()
+	br.wikiWorker = worker
+	br.autoNotebookWriter = writer
+	br.mu.Unlock()
+
+	if !br.IsAgentMemberSlug("ceo") {
+		b.Skip("default manifest missing 'ceo'")
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := br.PostMessage("ceo", "general", "benchmark traffic", nil, ""); err != nil {
+			b.Fatalf("PostMessage: %v", err)
+		}
+	}
+}
+
+// BenchmarkPostMessage_WithoutAutoNotebook is the baseline — same broker
+// without the writer attached. Compare these two to attribute the writer's
+// cost on the hot path.
+func BenchmarkPostMessage_WithoutAutoNotebook(b *testing.B) {
+	br := NewBrokerAt(filepath.Join(b.TempDir(), "broker-state.json"))
+	if !br.IsAgentMemberSlug("ceo") {
+		b.Skip("default manifest missing 'ceo'")
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := br.PostMessage("ceo", "general", "benchmark traffic", nil, ""); err != nil {
+			b.Fatalf("PostMessage: %v", err)
+		}
+	}
+}

--- a/internal/team/broker_auto_notebook_writer_test.go
+++ b/internal/team/broker_auto_notebook_writer_test.go
@@ -1,0 +1,179 @@
+package team
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// brokerWithAutoNotebookWriter wires a real WikiWorker on a temp git repo and
+// installs an AutoNotebookWriter on the broker. Returns a teardown that cancels
+// the worker's context and stops the writer.
+func brokerWithAutoNotebookWriter(t *testing.T) (*Broker, func()) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "wiki")
+	backup := filepath.Join(t.TempDir(), "wiki.bak")
+	repo := NewRepoAt(root, backup)
+	if err := repo.Init(context.Background()); err != nil {
+		t.Fatalf("repo init: %v", err)
+	}
+	b := newTestBroker(t)
+	worker := NewWikiWorker(repo, b)
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.Start(ctx)
+
+	// Roster filtering happens at the broker hook sites under b.mu; the writer
+	// gets nil here so calling Handle from inside a b.mu critical section does
+	// not re-enter the broker mutex.
+	writer := NewAutoNotebookWriter(worker, nil)
+	writer.Start(ctx)
+
+	b.mu.Lock()
+	b.wikiWorker = worker
+	b.autoNotebookWriter = writer
+	b.mu.Unlock()
+
+	return b, func() {
+		writer.Stop(2 * time.Second)
+		cancel()
+		<-worker.Done()
+	}
+}
+
+func waitForNotebookEntry(t *testing.T, b *Broker, slug string) []NotebookEntry {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		entries, err := b.wikiWorker.NotebookList(slug)
+		if err == nil && len(entries) > 0 {
+			return entries
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("no notebook entries appeared for slug=%s", slug)
+	return nil
+}
+
+// Real broker + real WikiWorker. PostMessage from the ceo agent must produce a
+// notebook entry under agents/ceo/notebook/ within seconds.
+func TestAutoNotebookWriter_PostMessage_LandsOnShelf(t *testing.T) {
+	b, teardown := brokerWithAutoNotebookWriter(t)
+	defer teardown()
+
+	if !b.IsAgentMemberSlug("ceo") {
+		t.Skip("default manifest missing 'ceo'; cannot exercise integration path")
+	}
+
+	if _, err := b.PostMessage("ceo", "general", "shipping pr 1 of the auto-notebook writer", nil, ""); err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	entries := waitForNotebookEntry(t, b, "ceo")
+	if !strings.Contains(entries[0].Path, "agents/ceo/notebook/") {
+		t.Fatalf("entry not on ceo shelf: %q", entries[0].Path)
+	}
+	if !strings.Contains(entries[0].Path, "message-posted") {
+		t.Fatalf("expected message-posted in filename: %q", entries[0].Path)
+	}
+}
+
+// Human-authored messages must NOT populate the agent shelf. The roster filter
+// (decision OV6A) gates this at the writer's ingress.
+func TestAutoNotebookWriter_HumanMessage_DoesNotLandOnShelf(t *testing.T) {
+	b, teardown := brokerWithAutoNotebookWriter(t)
+	defer teardown()
+
+	if _, err := b.PostMessage("human", "general", "hi from a human", nil, ""); err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+
+	// Give the writer a chance to (incorrectly) write something. We expect no
+	// entries at all on any shelf.
+	time.Sleep(150 * time.Millisecond)
+
+	slugs, err := b.wikiWorker.AgentsWithNotebooks()
+	if err != nil {
+		t.Fatalf("AgentsWithNotebooks: %v", err)
+	}
+	for _, s := range slugs {
+		entries, _ := b.wikiWorker.NotebookList(s)
+		if len(entries) > 0 {
+			t.Fatalf("human message produced an entry on %s shelf", s)
+		}
+	}
+	// Roster filter runs at the broker hook site (lock-free predicate) before
+	// the writer ever sees the event, so the writer's NonRoster counter stays
+	// 0. The "no entries on any shelf" assertion above is the binding check.
+}
+
+// Two consecutive identical messages collapse to one shelf entry via the LRU.
+func TestAutoNotebookWriter_DuplicatePostMessageDeduped(t *testing.T) {
+	b, teardown := brokerWithAutoNotebookWriter(t)
+	defer teardown()
+	if !b.IsAgentMemberSlug("ceo") {
+		t.Skip("default manifest missing 'ceo'")
+	}
+
+	if _, err := b.PostMessage("ceo", "general", "exactly the same thing", nil, ""); err != nil {
+		t.Fatalf("PostMessage 1: %v", err)
+	}
+	waitForNotebookEntry(t, b, "ceo")
+	if _, err := b.PostMessage("ceo", "general", "exactly the same thing", nil, ""); err != nil {
+		t.Fatalf("PostMessage 2: %v", err)
+	}
+
+	// Wait a beat to ensure the second event has been processed and (we hope)
+	// dropped by dedupe.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if b.autoNotebookWriter.Counters().Deduped >= 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if b.autoNotebookWriter.Counters().Deduped < 1 {
+		t.Fatalf("expected dedupe to fire on identical repost")
+	}
+	entries, _ := b.wikiWorker.NotebookList("ceo")
+	if len(entries) != 1 {
+		t.Fatalf("expected exactly 1 entry after dedupe; got %d", len(entries))
+	}
+}
+
+// Task transitions populate the owner's shelf, distinct kind in filename.
+func TestAutoNotebookWriter_TaskMutationLandsOnOwnerShelf(t *testing.T) {
+	b, teardown := brokerWithAutoNotebookWriter(t)
+	defer teardown()
+	if !b.IsAgentMemberSlug("ceo") {
+		t.Skip("default manifest missing 'ceo'")
+	}
+
+	resp, err := b.MutateTask(TaskPostRequest{
+		Action:    "create",
+		Channel:   "general",
+		Title:     "Ship PR 1",
+		Owner:     "ceo",
+		CreatedBy: "ceo",
+	})
+	if err != nil {
+		t.Fatalf("MutateTask create: %v", err)
+	}
+	taskID := resp.Task.ID
+	if taskID == "" {
+		t.Fatalf("created task missing id")
+	}
+
+	entries := waitForNotebookEntry(t, b, "ceo")
+	var transitionEntry *NotebookEntry
+	for i := range entries {
+		if strings.Contains(entries[i].Path, "task-transitioned") {
+			transitionEntry = &entries[i]
+			break
+		}
+	}
+	if transitionEntry == nil {
+		t.Fatalf("expected task-transitioned entry on ceo shelf; got entries: %v", entries)
+	}
+}

--- a/internal/team/broker_auto_notebook_writer_test.go
+++ b/internal/team/broker_auto_notebook_writer_test.go
@@ -44,16 +44,19 @@ func brokerWithAutoNotebookWriter(t *testing.T) (*Broker, func()) {
 
 func waitForNotebookEntry(t *testing.T, b *Broker, slug string) []NotebookEntry {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
-	for time.Now().Before(deadline) {
-		entries, err := b.wikiWorker.NotebookList(slug)
-		if err == nil && len(entries) > 0 {
-			return entries
-		}
-		time.Sleep(20 * time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := b.autoNotebookWriter.WaitForCondition(ctx, func() bool {
+		entries, listErr := b.wikiWorker.NotebookList(slug)
+		return listErr == nil && len(entries) > 0
+	}); err != nil {
+		t.Fatalf("no notebook entries appeared for slug=%s: %v", slug, err)
 	}
-	t.Fatalf("no notebook entries appeared for slug=%s", slug)
-	return nil
+	entries, err := b.wikiWorker.NotebookList(slug)
+	if err != nil {
+		t.Fatalf("NotebookList(%s): %v", slug, err)
+	}
+	return entries
 }
 
 // Real broker + real WikiWorker. PostMessage from the ceo agent must produce a
@@ -85,27 +88,35 @@ func TestAutoNotebookWriter_HumanMessage_DoesNotLandOnShelf(t *testing.T) {
 	b, teardown := brokerWithAutoNotebookWriter(t)
 	defer teardown()
 
+	// Post a sentinel agent message AFTER the human one so we have a
+	// deterministic signal that the writer pipeline drained: when the agent
+	// entry lands on the ceo shelf, every prior PostMessage hook has already
+	// run to completion. If the human PostMessage incorrectly produced a
+	// shelf entry, NotebookList for any non-ceo agent will be non-empty.
 	if _, err := b.PostMessage("human", "general", "hi from a human", nil, ""); err != nil {
-		t.Fatalf("PostMessage: %v", err)
+		t.Fatalf("PostMessage human: %v", err)
 	}
-
-	// Give the writer a chance to (incorrectly) write something. We expect no
-	// entries at all on any shelf.
-	time.Sleep(150 * time.Millisecond)
+	if !b.IsAgentMemberSlug("ceo") {
+		t.Skip("default manifest missing 'ceo'; cannot drain via agent sentinel")
+	}
+	if _, err := b.PostMessage("ceo", "general", "drain sentinel", nil, ""); err != nil {
+		t.Fatalf("PostMessage ceo sentinel: %v", err)
+	}
+	waitForNotebookEntry(t, b, "ceo")
 
 	slugs, err := b.wikiWorker.AgentsWithNotebooks()
 	if err != nil {
 		t.Fatalf("AgentsWithNotebooks: %v", err)
 	}
 	for _, s := range slugs {
+		if s == "ceo" {
+			continue
+		}
 		entries, _ := b.wikiWorker.NotebookList(s)
 		if len(entries) > 0 {
 			t.Fatalf("human message produced an entry on %s shelf", s)
 		}
 	}
-	// Roster filter runs at the broker hook site (lock-free predicate) before
-	// the writer ever sees the event, so the writer's NonRoster counter stays
-	// 0. The "no entries on any shelf" assertion above is the binding check.
 }
 
 // Two consecutive identical messages collapse to one shelf entry via the LRU.
@@ -124,17 +135,12 @@ func TestAutoNotebookWriter_DuplicatePostMessageDeduped(t *testing.T) {
 		t.Fatalf("PostMessage 2: %v", err)
 	}
 
-	// Wait a beat to ensure the second event has been processed and (we hope)
-	// dropped by dedupe.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if b.autoNotebookWriter.Counters().Deduped >= 1 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-	if b.autoNotebookWriter.Counters().Deduped < 1 {
-		t.Fatalf("expected dedupe to fire on identical repost")
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := b.autoNotebookWriter.WaitForCondition(ctx, func() bool {
+		return b.autoNotebookWriter.Counters().Deduped >= 1
+	}); err != nil {
+		t.Fatalf("expected dedupe to fire on identical repost: %v", err)
 	}
 	entries, _ := b.wikiWorker.NotebookList("ceo")
 	if len(entries) != 1 {

--- a/internal/team/broker_messages.go
+++ b/internal/team/broker_messages.go
@@ -436,6 +436,20 @@ func (b *Broker) PostMessage(from, channel, content string, tagged []string, rep
 	if err := b.saveLocked(); err != nil {
 		return channelMessage{}, err
 	}
+	// 2A: every roster-agent PostMessage triggers one notebook event. Roster
+	// filter is applied here under b.mu (lock-free predicate); calling Handle
+	// itself never re-enters b.mu, so this is safe to do while still locked.
+	// Handle is non-blocking per decision S3A.
+	if b.autoNotebookWriter != nil && b.isAgentMemberSlugLocked(msg.From) {
+		b.autoNotebookWriter.Handle(autoNotebookEvent{
+			Kind:      AutoNotebookEventMessagePosted,
+			Slug:      msg.From,
+			Actor:     msg.From,
+			Channel:   msg.Channel,
+			Content:   msg.Content,
+			Timestamp: time.Now().UTC(),
+		})
+	}
 	return msg, nil
 }
 

--- a/internal/team/broker_messages_test.go
+++ b/internal/team/broker_messages_test.go
@@ -92,13 +92,10 @@ func TestPostMessage_TriggersAutoNotebookWriter(t *testing.T) {
 	// not produce a writer event.
 	b.PostSystemMessage("general", "system msg", "system")
 
-	// Wait for the agent message to flow through.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if len(stub.snapshot()) > 0 {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer waitCancel()
+	if err := writer.WaitForCondition(waitCtx, func() bool { return len(stub.snapshot()) >= 1 }); err != nil {
+		t.Fatalf("waiting for writer event: %v", err)
 	}
 	calls := stub.snapshot()
 	if len(calls) != 1 {

--- a/internal/team/broker_messages_test.go
+++ b/internal/team/broker_messages_test.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/agent"
 )
@@ -49,6 +51,61 @@ func TestPostMessage_SetsTimestampAndChannel(t *testing.T) {
 	all := b.Messages()
 	if len(all) == 0 || all[len(all)-1].ID != got.ID {
 		t.Errorf("posted message not visible in b.Messages()")
+	}
+}
+
+// TestPostMessage_TriggersAutoNotebookWriter pins the locked PR-1 hook (2A):
+// every roster-agent PostMessage feeds exactly one event into the auto-notebook
+// writer, while non-roster senders (humans, system) are filtered at ingress.
+// Uses a stub writer client to keep the assertion focused on the hook seam.
+func TestPostMessage_TriggersAutoNotebookWriter(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.members = append(b.members, officeMember{Slug: "ceo", Name: "CEO", Role: "lead"})
+	for i := range b.channels {
+		if b.channels[i].Slug == "general" {
+			b.channels[i].Members = append(b.channels[i].Members, "ceo", "human")
+		}
+	}
+	b.mu.Unlock()
+
+	stub := &fakeNotebookClient{}
+	// Broker pre-filters via isAgentMemberSlugLocked before calling Handle,
+	// so the writer's roster is unused on the production code path; pass nil
+	// here to avoid re-entering b.mu inside Handle.
+	writer := NewAutoNotebookWriter(stub, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	writer.Start(ctx)
+	t.Cleanup(func() { cancel(); writer.Stop(time.Second) })
+
+	b.mu.Lock()
+	b.autoNotebookWriter = writer
+	b.mu.Unlock()
+
+	if _, err := b.PostMessage("ceo", "general", "agent message", nil, ""); err != nil {
+		t.Fatalf("PostMessage agent: %v", err)
+	}
+	if _, err := b.PostMessage("human", "general", "human message", nil, ""); err != nil {
+		t.Fatalf("PostMessage human: %v", err)
+	}
+	// Process the system path: PostSystemMessage bypasses PostMessage and must
+	// not produce a writer event.
+	b.PostSystemMessage("general", "system msg", "system")
+
+	// Wait for the agent message to flow through.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(stub.snapshot()) > 0 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	calls := stub.snapshot()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 notebook write (only the agent message); got %d", len(calls))
+	}
+	if calls[0].Slug != "ceo" {
+		t.Fatalf("expected slug=ceo, got %q", calls[0].Slug)
 	}
 }
 

--- a/internal/team/broker_requests_interviews.go
+++ b/internal/team/broker_requests_interviews.go
@@ -630,7 +630,7 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 		b.completeSchedulerJobsLocked("request", b.requests[i].ID, b.requests[i].Channel)
 		pendingCascade := b.unblockDependentsLocked(b.requests[i].ID)
 		b.pendingInterview = firstBlockingRequest(b.requests)
-		b.unblockTasksForAnsweredRequestLocked(b.requests[i])
+		pendingCascade = append(pendingCascade, b.unblockTasksForAnsweredRequestLocked(b.requests[i])...)
 
 		// Skill proposal callback: accept activates the skill, reject archives it.
 		if b.requests[i].Kind == "skill_proposal" {
@@ -689,11 +689,12 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 	http.Error(w, "request not found", http.StatusNotFound)
 }
 
-func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) {
+func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) []pendingTaskTransition {
 	reqID := strings.TrimSpace(req.ID)
 	if reqID == "" {
-		return
+		return nil
 	}
+	var pending []pendingTaskTransition
 	now := time.Now().UTC().Format(time.RFC3339)
 	answerText := strings.TrimSpace(reqAnswerSummary(req.Answered))
 	for i := range b.tasks {
@@ -713,6 +714,7 @@ func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) {
 		// needs.
 		stillBlocked := b.hasUnresolvedDepsLocked(task)
 		if !stillBlocked {
+			beforeStatus := task.Status
 			task.Blocked = false
 			if strings.EqualFold(strings.TrimSpace(task.Status), "blocked") {
 				if strings.TrimSpace(task.Owner) != "" {
@@ -722,6 +724,10 @@ func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) {
 				}
 			}
 			b.queueTaskBehindActiveOwnerLaneLocked(task)
+			pending = append(pending, pendingTaskTransition{
+				taskID:       task.ID,
+				beforeStatus: beforeStatus,
+			})
 		}
 		if answerText != "" && !strings.Contains(task.Details, answerText) {
 			task.Details = strings.TrimSpace(task.Details)
@@ -742,6 +748,7 @@ func (b *Broker) unblockTasksForAnsweredRequestLocked(req humanInterview) {
 			)
 		}
 	}
+	return pending
 }
 
 // taskMentionsRequestID returns true when haystack contains needle as a

--- a/internal/team/broker_requests_interviews.go
+++ b/internal/team/broker_requests_interviews.go
@@ -628,7 +628,7 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 		b.requests[i].RecheckAt = ""
 		b.requests[i].DueAt = ""
 		b.completeSchedulerJobsLocked("request", b.requests[i].ID, b.requests[i].Channel)
-		b.unblockDependentsLocked(b.requests[i].ID)
+		pendingCascade := b.unblockDependentsLocked(b.requests[i].ID)
 		b.pendingInterview = firstBlockingRequest(b.requests)
 		b.unblockTasksForAnsweredRequestLocked(b.requests[i])
 
@@ -678,6 +678,7 @@ func (b *Broker) handlePostRequestAnswer(w http.ResponseWriter, r *http.Request)
 			http.Error(w, "failed to persist broker state", http.StatusInternalServerError)
 			return
 		}
+		b.flushPendingAutoNotebookTransitionsLocked(pendingCascade, "system")
 		b.mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/team/broker_tasks_lifecycle.go
+++ b/internal/team/broker_tasks_lifecycle.go
@@ -37,6 +37,7 @@ func (b *Broker) BlockTask(taskID, actor, reason string) (teamTask, bool, error)
 		if err := rejectFalseLocalWorktreeBlock(task, reason); err != nil {
 			return *task, false, err
 		}
+		beforeStatus := task.Status
 		if reason != "" {
 			switch existing := strings.TrimSpace(task.Details); {
 			case existing == "":
@@ -60,6 +61,7 @@ func (b *Broker) BlockTask(taskID, actor, reason string) (teamTask, bool, error)
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, false, err
 		}
+		b.emitTaskTransitionAutoNotebook(task, beforeStatus, actor)
 		return *task, true, nil
 	}
 
@@ -86,6 +88,7 @@ func (b *Broker) ResumeTask(taskID, actor, reason string) (teamTask, bool, error
 		if task.ID != id {
 			continue
 		}
+		beforeStatus := task.Status
 		changed := false
 		if task.Blocked {
 			task.Blocked = false
@@ -120,6 +123,7 @@ func (b *Broker) ResumeTask(taskID, actor, reason string) (teamTask, bool, error
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, false, err
 		}
+		b.emitTaskTransitionAutoNotebook(task, beforeStatus, actor)
 		return *task, true, nil
 	}
 
@@ -180,6 +184,7 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 		Owner:    strings.TrimSpace(owner),
 	}); existing != nil {
 		now := time.Now().UTC().Format(time.RFC3339)
+		beforeStatus := existing.Status
 		if existing.Details == "" && strings.TrimSpace(details) != "" {
 			existing.Details = strings.TrimSpace(details)
 		}
@@ -206,6 +211,7 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, false, err
 		}
+		b.emitTaskTransitionAutoNotebook(existing, beforeStatus, createdBy)
 		return *existing, true, nil
 	}
 	now := time.Now().UTC().Format(time.RFC3339)
@@ -243,6 +249,7 @@ func (b *Broker) EnsureTask(channel, title, details, owner, createdBy, threadID 
 	if err := b.saveLocked(); err != nil {
 		return teamTask{}, false, err
 	}
+	b.emitTaskTransitionAutoNotebook(&task, "", createdBy)
 	return task, false, nil
 }
 

--- a/internal/team/broker_tasks_lifecycle.go
+++ b/internal/team/broker_tasks_lifecycle.go
@@ -356,6 +356,7 @@ func (b *Broker) unblockDependentsLocked(completedTaskID string) {
 			continue
 		}
 		if !b.hasUnresolvedDepsLocked(&b.tasks[i]) {
+			beforeStatus := b.tasks[i].Status
 			b.tasks[i].Blocked = false
 			if strings.TrimSpace(b.tasks[i].Owner) != "" {
 				b.tasks[i].Status = "in_progress"
@@ -374,6 +375,11 @@ func (b *Broker) unblockDependentsLocked(completedTaskID string) {
 				truncateSummary(b.tasks[i].Title+" unblocked by "+completedTaskID, 140),
 				b.tasks[i].ID,
 			)
+			// Caller (MutateTask / lifecycle) holds b.mu and persists via its
+			// own saveLocked, so we don't write here — but every other status
+			// mutation in this PR emits a transition event, and the cascade
+			// path needs to match or PR 3's clustering signal will be skewed.
+			b.emitTaskTransitionAutoNotebook(&b.tasks[i], beforeStatus, "system")
 		}
 	}
 }

--- a/internal/team/broker_tasks_lifecycle.go
+++ b/internal/team/broker_tasks_lifecycle.go
@@ -339,8 +339,14 @@ func (b *Broker) hasUnresolvedDepsLocked(task *teamTask) bool {
 // unblockDependentsLocked checks all blocked tasks and unblocks those whose
 // dependencies are now resolved. For each newly unblocked task, it appends a
 // "task_unblocked" action so the launcher can deliver a notification to the owner.
-func (b *Broker) unblockDependentsLocked(completedTaskID string) {
+//
+// Returns the list of cascade transitions that the caller must publish to the
+// auto-notebook writer AFTER its own saveLocked succeeds. Emitting under
+// b.mu before the persist would leak notebook entries for transitions the
+// broker subsequently rolled back on save failure (CodeRabbit, major).
+func (b *Broker) unblockDependentsLocked(completedTaskID string) []pendingTaskTransition {
 	now := time.Now().UTC().Format(time.RFC3339)
+	var pending []pendingTaskTransition
 	for i := range b.tasks {
 		if !b.tasks[i].Blocked {
 			continue
@@ -375,13 +381,13 @@ func (b *Broker) unblockDependentsLocked(completedTaskID string) {
 				truncateSummary(b.tasks[i].Title+" unblocked by "+completedTaskID, 140),
 				b.tasks[i].ID,
 			)
-			// Caller (MutateTask / lifecycle) holds b.mu and persists via its
-			// own saveLocked, so we don't write here — but every other status
-			// mutation in this PR emits a transition event, and the cascade
-			// path needs to match or PR 3's clustering signal will be skewed.
-			b.emitTaskTransitionAutoNotebook(&b.tasks[i], beforeStatus, "system")
+			pending = append(pending, pendingTaskTransition{
+				taskID:       b.tasks[i].ID,
+				beforeStatus: beforeStatus,
+			})
 		}
 	}
+	return pending
 }
 
 type taskReuseMatch struct {

--- a/internal/team/broker_tasks_mutation_service.go
+++ b/internal/team/broker_tasks_mutation_service.go
@@ -447,8 +447,9 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 		}
 		// Any terminal status releases waiting dependents. isTerminalTeamTaskStatus
 		// matches hasUnresolvedDepsLocked so cancelled parents do not orphan dependents.
+		var pendingCascade []pendingTaskTransition
 		if isTerminalTeamTaskStatus(task.Status) {
-			b.unblockDependentsLocked(task.ID)
+			pendingCascade = b.unblockDependentsLocked(task.ID)
 		}
 		b.scheduleTaskLifecycleLocked(task)
 		if err := b.syncTaskWorktreeLocked(task); err != nil {
@@ -470,6 +471,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			return TaskResponse{}, taskMutationError(TaskMutationPersistFailed, "failed to persist broker state", err)
 		}
 		b.emitTaskTransitionAutoNotebook(task, beforeStatus, actor)
+		b.flushPendingAutoNotebookTransitionsLocked(pendingCascade, "system")
 		return TaskResponse{Task: *task}, nil
 	}
 

--- a/internal/team/broker_tasks_mutation_service.go
+++ b/internal/team/broker_tasks_mutation_service.go
@@ -161,6 +161,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			SourceSignalID:   strings.TrimSpace(body.SourceSignalID),
 			SourceDecisionID: strings.TrimSpace(body.SourceDecisionID),
 		}); existing != nil {
+			beforeStatus := existing.Status
 			if details := strings.TrimSpace(body.Details); details != "" {
 				existing.Details = details
 			}
@@ -213,6 +214,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 				rollbackTask()
 				return TaskResponse{}, taskMutationError(TaskMutationPersistFailed, "failed to persist broker state", err)
 			}
+			b.emitTaskTransitionAutoNotebook(existing, beforeStatus, actor)
 			return TaskResponse{Task: *existing}, nil
 		}
 		b.counter++
@@ -261,6 +263,9 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			rollbackTask()
 			return TaskResponse{}, taskMutationError(TaskMutationPersistFailed, "failed to persist broker state", err)
 		}
+		// Treat creation as a transition from "" → task.Status so the owner's
+		// shelf records the moment a task lands in their lane.
+		b.emitTaskTransitionAutoNotebook(&task, "", actor)
 		return TaskResponse{Task: task}, nil
 	}
 
@@ -290,6 +295,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 		reassignTriggered := false
 		cancelTriggered := false
 		cancelPrevOwner := ""
+		beforeStatus := task.Status
 		switch action {
 		case "claim", "assign":
 			if strings.TrimSpace(body.Owner) == "" {
@@ -463,6 +469,7 @@ func (b *Broker) MutateTask(body TaskPostRequest) (TaskResponse, error) {
 			rollbackTask()
 			return TaskResponse{}, taskMutationError(TaskMutationPersistFailed, "failed to persist broker state", err)
 		}
+		b.emitTaskTransitionAutoNotebook(task, beforeStatus, actor)
 		return TaskResponse{Task: *task}, nil
 	}
 

--- a/internal/team/broker_wiki_lifecycle.go
+++ b/internal/team/broker_wiki_lifecycle.go
@@ -67,12 +67,20 @@ func (b *Broker) initWikiWorker() {
 	extractor := NewExtractor(brokerQueryProvider{}, worker, dlq, idx)
 	worker.SetExtractor(extractor)
 
+	// Roster filter is applied at the broker hook sites (under b.mu) via
+	// isAgentMemberSlugLocked, so the writer itself takes nil here — passing
+	// the broker as roster would deadlock when Handle is called from inside a
+	// b.mu critical section.
+	autoWriter := NewAutoNotebookWriter(worker, nil)
+	autoWriter.Start(lifecycleCtx)
+
 	b.mu.Lock()
 	b.wikiWorker = worker
 	b.wikiIndex = idx
 	b.wikiExtractor = extractor
 	b.wikiDLQ = dlq
 	b.readLog = NewReadLog(repo.Root())
+	b.autoNotebookWriter = autoWriter
 	b.mu.Unlock()
 
 	b.ensureNotebookDirsForRoster()

--- a/internal/team/self_healing.go
+++ b/internal/team/self_healing.go
@@ -55,6 +55,7 @@ func (b *Broker) requestSelfHealingLocked(agentSlug, taskID string, reason agent
 		Owner:      owner,
 		PipelineID: "incident",
 	}); existing != nil {
+		beforeStatus := existing.Status
 		if existing.Details == "" {
 			existing.Details = details
 		} else if err := appendTaskDetailLocked(existing, selfHealingIncidentUpdate(reason, detail)); err != nil {
@@ -87,6 +88,7 @@ func (b *Broker) requestSelfHealingLocked(agentSlug, taskID string, reason agent
 		if err := b.saveLocked(); err != nil {
 			return teamTask{}, true, err
 		}
+		b.emitTaskTransitionAutoNotebook(existing, beforeStatus, createdBy)
 		return *existing, true, nil
 	}
 
@@ -123,6 +125,7 @@ func (b *Broker) requestSelfHealingLocked(agentSlug, taskID string, reason agent
 	if err := b.saveLocked(); err != nil {
 		return teamTask{}, false, err
 	}
+	b.emitTaskTransitionAutoNotebook(&task, "", createdBy)
 	return task, false, nil
 }
 


### PR DESCRIPTION
## Summary

PR 1 of the notebook-wiki-promise design. Empty notebook shelves stop being empty: every roster-agent `Broker.PostMessage` and every task transition deterministically writes one markdown entry under `agents/{slug}/notebook/{YYYY-MM-DD-HHMMSS}-{kind}-{shortHash}.md`. No LLM on the hot path; no agent-judgment dependency.

- New `AutoNotebookWriter` (async buffered channel + dedicated goroutine, Start/Stop lifecycle that mirrors `WikiWorker`).
- Hooks attach **after** `b.saveLocked()` succeeds in `mutation_service.go`, `lifecycle.go`, `self_healing.go`, and on `Broker.PostMessage`.
- In-memory LRU dedupe per (slug, day) keyed by `sha256(content)`, ring buffer of 50.
- Pre-write secretlint regex scrub (AWS/GitHub/Stripe/OpenAI/Anthropic/SendGrid/Slack/Google/PEM private-key block).
- Roster-membership filter at the broker hook site (lock-free `isAgentMemberSlugLocked`) — required to avoid re-entering `b.mu` from `writer.Handle`.
- Errors and queue saturation are logged + counted + dropped. Never block the broker.

Source of truth: design doc at `~/.gstack/projects/nex-crm-wuphf/najmuzzaman-main-design-20260505-131620-notebook-wiki-promise.md` (13 locked decisions: OV2A, 2A, OV4A, 4A, OV3A, 6A, 7A, S1A, S2A, S3A, T1A, OV5A, OV6A, OV7A).

Memory-workflow gate (premise #3 closure) is **not** wired in this PR — deferred to TODO #19 per OV3A.

## Test plan

- [x] `go test -count=1 ./internal/team/...` — green
- [x] `go test -count=1 -race -timeout 600s ./internal/team/` — green (84s)
- [x] `bash scripts/test-go.sh ./internal/team` — all 1 packages green
- [x] `go vet ./internal/team/...` — clean
- [x] Unit tests in `auto_notebook_writer_test.go`: enqueue path, roster filter, dedupe within day, dedupe per-day buckets, redaction, task transition kind/path, no-op transition drop, queue saturation drop-not-block, Handle-after-Stop no-op, write-failure counted-not-propagated, secret regex set, UTF-8 truncate, markdown escape.
- [x] Integration tests in `broker_auto_notebook_writer_test.go` against a real `WikiWorker` + temp git repo: PostMessage lands on shelf, human message does not, duplicate post deduped, task mutation lands on owner shelf with `task-transitioned` filename.
- [x] Benchmarks in `broker_auto_notebook_writer_bench_test.go`: `BenchmarkPostMessage_WithAutoNotebook` vs baseline (run locally with `go test -bench .`).
- [x] `broker_messages_test.go` extended with `TestPostMessage_TriggersAutoNotebookWriter` to pin the hook seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic per-agent notebook entries for agent messages and task transitions: dated notes, per-day dedupe, secret redaction, roster filtering, non‑blocking enqueue with saturation handling, lifecycle-aware start/stop, runtime counters/inspection, and transitions emitted after state persistence.

* **Tests**
  * Extensive unit and integration tests covering writes, dedupe, redaction, roster filtering, queue saturation, transition semantics, and shutdown behavior.

* **Benchmarks**
  * Benchmarks measuring message latency with and without the notebook writer attached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->