### PR TITLE
feat(web): joiner first-run welcome card and persistent session badge

### DIFF
--- a/web/src/api/platform.ts
+++ b/web/src/api/platform.ts
@@ -75,6 +75,11 @@ export interface HumanMe {
   };
 }
 
+// Shared TanStack Query identity for /humans/me. Both useSessionRole and
+// HealthCheckApp must import these so the cache dedupes a single poll cycle.
+export const HUMAN_ME_QUERY_KEY = ["humans", "me"] as const;
+export const HUMAN_ME_REFETCH_MS = 30_000;
+
 export function getHumanMe() {
   return get<HumanMe>("/humans/me");
 }

--- a/web/src/components/apps/HealthCheckApp.test.tsx
+++ b/web/src/components/apps/HealthCheckApp.test.tsx
@@ -24,6 +24,8 @@ vi.mock("../../api/platform", () => ({
   revokeHumanSession: vi.fn(),
   startShare: vi.fn(),
   stopShare: vi.fn(),
+  HUMAN_ME_QUERY_KEY: ["humans", "me"] as const,
+  HUMAN_ME_REFETCH_MS: 30_000,
 }));
 
 const getHealthMock = vi.mocked(getHealth);

--- a/web/src/components/apps/HealthCheckApp.tsx
+++ b/web/src/components/apps/HealthCheckApp.tsx
@@ -7,6 +7,8 @@ import {
   getHumanSessions,
   getShareStatus,
   type HealthResponse,
+  HUMAN_ME_QUERY_KEY,
+  HUMAN_ME_REFETCH_MS,
   type HumanMe,
   type HumanSession,
   revokeHumanSession,
@@ -590,9 +592,9 @@ export function HealthCheckApp() {
     refetchInterval: 10_000,
   });
   const { data: me } = useQuery({
-    queryKey: ["humans", "me"],
+    queryKey: HUMAN_ME_QUERY_KEY,
     queryFn: () => getHumanMe(),
-    refetchInterval: 30_000,
+    refetchInterval: HUMAN_ME_REFETCH_MS,
   });
   const human = me?.human;
   const isHost = human?.role === "host";

--- a/web/src/components/join/TeamMemberBadge.test.tsx
+++ b/web/src/components/join/TeamMemberBadge.test.tsx
@@ -8,6 +8,8 @@ import { TeamMemberBadge } from "./TeamMemberBadge";
 
 vi.mock("../../api/platform", () => ({
   getHumanMe: vi.fn(),
+  HUMAN_ME_QUERY_KEY: ["humans", "me"] as const,
+  HUMAN_ME_REFETCH_MS: 30_000,
 }));
 
 const getHumanMeMock = vi.mocked(getHumanMe);

--- a/web/src/components/join/TeamMemberBadge.test.tsx
+++ b/web/src/components/join/TeamMemberBadge.test.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getHumanMe } from "../../api/platform";
+import { TeamMemberBadge } from "./TeamMemberBadge";
+
+vi.mock("../../api/platform", () => ({
+  getHumanMe: vi.fn(),
+}));
+
+const getHumanMeMock = vi.mocked(getHumanMe);
+
+function wrap(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>;
+}
+
+describe("TeamMemberBadge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders for a team-member session", async () => {
+    getHumanMeMock.mockResolvedValue({
+      human: { role: "member", display_name: "Maya" },
+    });
+    render(wrap(<TeamMemberBadge />));
+
+    expect(
+      await screen.findByLabelText("Team-member session"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render for a host session", async () => {
+    getHumanMeMock.mockResolvedValue({
+      human: { role: "host", display_name: "Sam" },
+    });
+    render(wrap(<TeamMemberBadge />));
+
+    await waitFor(() => {
+      expect(getHumanMeMock).toHaveBeenCalled();
+    });
+    expect(
+      screen.queryByLabelText("Team-member session"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render while role is unknown (loading)", () => {
+    getHumanMeMock.mockReturnValue(new Promise(() => {}));
+    render(wrap(<TeamMemberBadge />));
+    expect(
+      screen.queryByLabelText("Team-member session"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/join/TeamMemberBadge.tsx
+++ b/web/src/components/join/TeamMemberBadge.tsx
@@ -1,0 +1,16 @@
+import { useSessionRole } from "../../hooks/useSessionRole";
+
+export function TeamMemberBadge() {
+  const { role } = useSessionRole();
+  if (role !== "member") return null;
+  return (
+    <span
+      className="team-member-badge"
+      role="status"
+      aria-label="Team-member session"
+      title="You are signed in as a team member of this office. The host can revoke your session at any time."
+    >
+      team-member session
+    </span>
+  );
+}

--- a/web/src/components/join/TeamMemberWelcome.test.tsx
+++ b/web/src/components/join/TeamMemberWelcome.test.tsx
@@ -1,0 +1,125 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getHumanMe } from "../../api/platform";
+import { TeamMemberWelcome } from "./TeamMemberWelcome";
+
+vi.mock("../../api/platform", () => ({
+  getHumanMe: vi.fn(),
+}));
+
+const getHumanMeMock = vi.mocked(getHumanMe);
+
+function wrap(ui: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>;
+}
+
+describe("TeamMemberWelcome", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("renders welcome card for a team-member session", async () => {
+    getHumanMeMock.mockResolvedValue({
+      human: {
+        role: "member",
+        display_name: "Maya",
+        invite_id: "invite-1",
+      },
+    });
+    render(wrap(<TeamMemberWelcome />));
+
+    expect(
+      await screen.findByLabelText("Team member session welcome"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Maya")).toBeInTheDocument();
+    expect(
+      screen.getByText(/scoped team-member browser session/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render for a host session", async () => {
+    getHumanMeMock.mockResolvedValue({
+      human: {
+        role: "host",
+        display_name: "Sam",
+      },
+    });
+    render(wrap(<TeamMemberWelcome />));
+
+    // Wait for the query to resolve, then assert nothing rendered.
+    await waitFor(() => {
+      expect(getHumanMeMock).toHaveBeenCalled();
+    });
+    expect(
+      screen.queryByLabelText("Team member session welcome"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render while role is unknown (loading)", () => {
+    getHumanMeMock.mockReturnValue(new Promise(() => {})); // never resolves
+    render(wrap(<TeamMemberWelcome />));
+
+    expect(
+      screen.queryByLabelText("Team member session welcome"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("dismisses and persists the dismissal across remounts", async () => {
+    getHumanMeMock.mockResolvedValue({
+      human: {
+        role: "member",
+        display_name: "Maya",
+        invite_id: "invite-1",
+      },
+    });
+    const user = userEvent.setup();
+    const { unmount } = render(wrap(<TeamMemberWelcome />));
+
+    await user.click(
+      await screen.findByRole("button", { name: /dismiss welcome message/i }),
+    );
+    expect(
+      screen.queryByLabelText("Team member session welcome"),
+    ).not.toBeInTheDocument();
+
+    unmount();
+    render(wrap(<TeamMemberWelcome />));
+
+    // Wait for the new query to resolve before asserting the welcome stays
+    // hidden — otherwise we are asserting on the pre-data state.
+    await waitFor(() => {
+      expect(getHumanMeMock).toHaveBeenCalledTimes(2);
+    });
+    expect(
+      screen.queryByLabelText("Team member session welcome"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to a default name when display_name is empty", async () => {
+    getHumanMeMock.mockResolvedValue({
+      human: {
+        role: "member",
+        display_name: "   ",
+        invite_id: "invite-2",
+      },
+    });
+    render(wrap(<TeamMemberWelcome />));
+
+    expect(await screen.findByText("team member")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/join/TeamMemberWelcome.test.tsx
+++ b/web/src/components/join/TeamMemberWelcome.test.tsx
@@ -9,6 +9,8 @@ import { TeamMemberWelcome } from "./TeamMemberWelcome";
 
 vi.mock("../../api/platform", () => ({
   getHumanMe: vi.fn(),
+  HUMAN_ME_QUERY_KEY: ["humans", "me"] as const,
+  HUMAN_ME_REFETCH_MS: 30_000,
 }));
 
 const getHumanMeMock = vi.mocked(getHumanMe);

--- a/web/src/components/join/TeamMemberWelcome.tsx
+++ b/web/src/components/join/TeamMemberWelcome.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useMemo, useState } from "react";
+
+import { useSessionRole } from "../../hooks/useSessionRole";
+
+const STORAGE_PREFIX = "wuphf:team-welcome-dismissed:";
+
+// Pick the most stable identifier the broker exposes for this joiner
+// session. invite_id is the ideal key (one per invite use), but if the
+// broker has not surfaced it on /humans/me yet we degrade gracefully.
+function dismissalKey(human: {
+  invite_id?: string;
+  id?: string;
+  human_slug?: string;
+}): string | null {
+  const id = human.invite_id ?? human.id ?? human.human_slug;
+  if (!id) return null;
+  return `${STORAGE_PREFIX}${id}`;
+}
+
+function hasDismissed(key: string): boolean {
+  try {
+    return window.localStorage.getItem(key) === "1";
+  } catch {
+    // localStorage can throw in private-mode Safari or when quota is full.
+    // Treat the welcome card as not-yet-dismissed so the joiner still sees
+    // it — losing the suppression is preferable to crashing the shell.
+    return false;
+  }
+}
+
+function markDismissed(key: string): void {
+  try {
+    window.localStorage.setItem(key, "1");
+  } catch {
+    // Same fallback as hasDismissed: silently accept that the dismiss will
+    // not survive a refresh, rather than block the close action.
+  }
+}
+
+export function TeamMemberWelcome() {
+  const { role, human } = useSessionRole();
+  const key = useMemo(() => (human ? dismissalKey(human) : null), [human]);
+  const [dismissedThisRender, setDismissedThisRender] = useState(false);
+
+  const onDismiss = useCallback(() => {
+    if (key) markDismissed(key);
+    setDismissedThisRender(true);
+  }, [key]);
+
+  if (role !== "member" || !human) return null;
+  if (dismissedThisRender) return null;
+  if (key && hasDismissed(key)) return null;
+
+  const displayName = human.display_name?.trim() || "team member";
+
+  return (
+    <aside
+      className="team-welcome"
+      role="status"
+      aria-label="Team member session welcome"
+    >
+      <div className="team-welcome-body">
+        <p className="team-welcome-title">
+          You&apos;re in. You joined this office as{" "}
+          <strong>{displayName}</strong>.
+        </p>
+        <p className="team-welcome-copy">
+          This is a scoped team-member browser session. The host can revoke
+          access at any time from Access &amp; Health.
+        </p>
+      </div>
+      <button
+        type="button"
+        className="team-welcome-dismiss"
+        onClick={onDismiss}
+        aria-label="Dismiss welcome message"
+      >
+        Got it
+      </button>
+    </aside>
+  );
+}

--- a/web/src/components/layout/Shell.tsx
+++ b/web/src/components/layout/Shell.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 import { useCurrentRoute } from "../../routes/useCurrentRoute";
 import { AgentPanel } from "../agents/AgentPanel";
+import { TeamMemberWelcome } from "../join/TeamMemberWelcome";
 import { ThreadPanel } from "../messages/ThreadPanel";
 import { SearchModal } from "../search/SearchModal";
 import { HelpModalHost } from "../ui/HelpModal";
@@ -30,6 +31,7 @@ export function Shell({ children }: ShellProps) {
       <Sidebar />
       <main className="main">
         <DisconnectBanner />
+        <TeamMemberWelcome />
         {!inDM && <ChannelHeader />}
         {!inDM && <RuntimeStrip />}
         {children}

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -3,6 +3,7 @@ import { Settings as SettingsIcon, SidebarCollapse } from "iconoir-react";
 import { router } from "../../lib/router";
 import { useCurrentApp } from "../../routes/useCurrentRoute";
 import { useAppStore } from "../../stores/app";
+import { TeamMemberBadge } from "../join/TeamMemberBadge";
 import { AgentList } from "../sidebar/AgentList";
 import { AppList } from "../sidebar/AppList";
 import { ChannelList } from "../sidebar/ChannelList";
@@ -76,6 +77,7 @@ export function Sidebar() {
         <>
           <div className="sidebar-header">
             <span className="sidebar-logo">WUPHF</span>
+            <TeamMemberBadge />
             <div className="sidebar-header-actions">
               <button
                 type="button"

--- a/web/src/hooks/useSessionRole.ts
+++ b/web/src/hooks/useSessionRole.ts
@@ -1,11 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { getHumanMe, type HumanMe } from "../api/platform";
-
-// Shared key + cadence with HealthCheckApp so TanStack dedupes the
-// /humans/me request. If you change either side, change both.
-const HUMAN_ME_QUERY_KEY = ["humans", "me"] as const;
-const HUMAN_ME_REFETCH_MS = 30_000;
+import {
+  getHumanMe,
+  HUMAN_ME_QUERY_KEY,
+  HUMAN_ME_REFETCH_MS,
+  type HumanMe,
+} from "../api/platform";
 
 export type SessionRole = "host" | "member" | "unknown";
 

--- a/web/src/hooks/useSessionRole.ts
+++ b/web/src/hooks/useSessionRole.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getHumanMe, type HumanMe } from "../api/platform";
+
+// Shared key + cadence with HealthCheckApp so TanStack dedupes the
+// /humans/me request. If you change either side, change both.
+const HUMAN_ME_QUERY_KEY = ["humans", "me"] as const;
+const HUMAN_ME_REFETCH_MS = 30_000;
+
+export type SessionRole = "host" | "member" | "unknown";
+
+export interface SessionInfo {
+  role: SessionRole;
+  human: HumanMe["human"] | undefined;
+  isLoading: boolean;
+}
+
+export function useSessionRole(): SessionInfo {
+  const { data, isLoading } = useQuery({
+    queryKey: HUMAN_ME_QUERY_KEY,
+    queryFn: () => getHumanMe(),
+    refetchInterval: HUMAN_ME_REFETCH_MS,
+  });
+  const human = data?.human;
+  const role: SessionRole =
+    human?.role === "host"
+      ? "host"
+      : human?.role === "member"
+        ? "member"
+        : "unknown";
+  return { role, human, isLoading };
+}

--- a/web/src/hooks/useSessionRole.ts
+++ b/web/src/hooks/useSessionRole.ts
@@ -12,11 +12,11 @@ export type SessionRole = "host" | "member" | "unknown";
 export interface SessionInfo {
   role: SessionRole;
   human: HumanMe["human"] | undefined;
-  isLoading: boolean;
+  isPending: boolean;
 }
 
 export function useSessionRole(): SessionInfo {
-  const { data, isLoading } = useQuery({
+  const { data, isPending } = useQuery({
     queryKey: HUMAN_ME_QUERY_KEY,
     queryFn: () => getHumanMe(),
     refetchInterval: HUMAN_ME_REFETCH_MS,
@@ -28,5 +28,5 @@ export function useSessionRole(): SessionInfo {
       : human?.role === "member"
         ? "member"
         : "unknown";
-  return { role, human, isLoading };
+  return { role, human, isPending };
 }

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -2036,13 +2036,13 @@ html[data-theme="nex"]
   font-weight: 500;
   border-radius: 6px;
   border: 1px solid var(--border-strong);
-  background: var(--bg-elev, #fff);
+  background: var(--bg-card);
   color: var(--text);
   cursor: pointer;
   transition: background 0.12s;
 }
 .team-welcome-dismiss:hover {
-  background: var(--accent-bg-strong, rgba(0, 0, 0, 0.04));
+  background: var(--accent-bg-strong);
 }
 .team-welcome-dismiss:focus-visible {
   outline: 2px solid var(--accent);

--- a/web/src/styles/layout.css
+++ b/web/src/styles/layout.css
@@ -1989,3 +1989,88 @@ html[data-theme="nex"]
   cursor: pointer;
   opacity: 0;
 }
+
+/*
+ * Team-member session surfaces.
+ *
+ * Rendered only when /humans/me reports role === "member" — host sessions
+ * never see these. The welcome card is one-shot per invite (dismissal
+ * persists in localStorage), the badge is permanent for the session so the
+ * joiner is never confused which office they are in.
+ */
+.team-welcome {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin: 12px 16px 0;
+  padding: 14px 16px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--accent-bg);
+  color: var(--text);
+}
+.team-welcome-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.team-welcome-title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+.team-welcome-copy {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+.team-welcome-dismiss {
+  flex-shrink: 0;
+  align-self: center;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 6px;
+  border: 1px solid var(--border-strong);
+  background: var(--bg-elev, #fff);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.team-welcome-dismiss:hover {
+  background: var(--accent-bg-strong, rgba(0, 0, 0, 0.04));
+}
+.team-welcome-dismiss:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .team-welcome {
+    flex-direction: column;
+    align-items: stretch;
+    margin: 10px 10px 0;
+  }
+  .team-welcome-dismiss {
+    align-self: flex-end;
+  }
+}
+
+.team-member-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  background: var(--accent-bg);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary

After #649 shipped the React join page, a freshly-joined team member lands at `#/channels/general` with no signal that the join succeeded — the channel is just empty.

This PR adds two surfaces driven by `/humans/me`'s `role` field:

- **One-shot welcome card** at the top of the main pane confirming the joiner is in and explaining the scoped session.
- **Persistent sidebar badge** (`team-member session`) so a joiner who also runs their own WUPHF locally is never confused which office they are in.

Both surfaces are hidden for host sessions and while `role` is unknown. The `/humans/me` query reuses the same key (`["humans", "me"]`) and 30s refetch cadence as `HealthCheckApp`, so TanStack dedupes the request — no extra broker traffic.

Dismissal of the welcome card persists in `localStorage` keyed by `invite_id` (or `id`/`human_slug` fallback), so refresh or backgrounded tab does not replay the card. localStorage failures (private-mode Safari, quota full) degrade gracefully — the card is still dismissible in-memory for the current render.

## ICP scenarios this is built against

1. **Maya (cofounder, macOS Safari)** — joins via iMessage link, lands in office, sees welcome card naming her, refreshes, card stays dismissed.
2. **Devesh (contractor, Linux Chrome, 2-week scope)** — joins via Slack link, dismisses welcome, badge stays visible for the full 2 weeks across his other WUPHF tabs.
3. **Priya (PM, iPad Safari, launch warroom)** — taps Linear link, card renders legibly at narrow width (`@media (max-width: 640px)` stacks the dismiss button), backgrounds and resumes Safari without replaying card.

## Test plan

- [x] `bash scripts/test-web.sh` — full web suite (913 tests, all passing)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check` — clean
- [ ] Manual: create invite from Access & Health, open `?invite=<token>` in second browser, complete join, verify welcome card appears with display name and is one-shot per dismissal
- [ ] Manual: refresh joiner tab, confirm welcome does not replay
- [ ] Manual: confirm sidebar badge persists across navigation and is absent for host session
- [ ] Manual: narrow viewport (<= 640px) — welcome card stacks correctly

## Out of scope (deferred)

- Host display name on the welcome card. `/humans/me` does not currently expose host name; the card says "the host" rather than naming them. Adding host name would need a broker-side change. Calling that a follow-up rather than blocking this PR.
- Welcome card in collapsed-sidebar mode for the badge. Welcome card is in the main pane (visible regardless of sidebar state); badge in collapsed sidebar deferred until there is a clear icon-only design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team members see a personalized welcome card in the main UI that uses the display name (falls back to “team member”); dismissals persist across refreshes and remounts.
  * A team-member status badge appears in the expanded sidebar header (hidden when collapsed).

* **Style**
  * New styling for the welcome card and badge, including responsive layout and accessible focus/hover states.

* **Tests**
  * Added tests covering member/host/loading states and dismissal behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->