### PR TITLE
feat(transport): phase 4 slice C — DetachParticipant + share UpsertParticipant

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -132,22 +132,29 @@ type Broker struct {
 	// background cron tick could both archive the same articles, with the
 	// second sweep reading tombstone content (written by the first) into the
 	// .archive/ copy — silently destroying the original.
-	archiveSweepMu     sync.Mutex
-	server             *http.Server
-	listener           net.Listener
-	lifecycleCtx       context.Context
-	lifecycleCancel    context.CancelFunc
-	token              string   // shared secret for authenticating requests
-	addr               string   // actual listen address (useful when port=0)
-	webUIOrigins       []string // allowed CORS origins for web UI (set by ServeWebUI)
-	webShareStart      func() (WebShareStatus, error)
-	webShareStatus     func() WebShareStatus
-	webShareStop       func() error
-	brokerRestartMu    sync.Mutex
-	runtimeProvider    string          // "codex" or "claude" — set by launcher
-	packSlug           string          // active agent pack slug ("founding-team", "revops", ...) — set by launcher
-	blankSlateLaunch   bool            // start without a saved blueprint and synthesize the first operation
-	openclawBridge     *OpenclawBridge // nil until the bridge attaches itself; used by handleOfficeMembers for live add/remove
+	archiveSweepMu   sync.Mutex
+	server           *http.Server
+	listener         net.Listener
+	lifecycleCtx     context.Context
+	lifecycleCancel  context.CancelFunc
+	token            string   // shared secret for authenticating requests
+	addr             string   // actual listen address (useful when port=0)
+	webUIOrigins     []string // allowed CORS origins for web UI (set by ServeWebUI)
+	webShareStart    func() (WebShareStatus, error)
+	webShareStatus   func() WebShareStatus
+	webShareStop     func() error
+	brokerRestartMu  sync.Mutex
+	runtimeProvider  string          // "codex" or "claude" — set by launcher
+	packSlug         string          // active agent pack slug ("founding-team", "revops", ...) — set by launcher
+	blankSlateLaunch bool            // start without a saved blueprint and synthesize the first operation
+	openclawBridge   *OpenclawBridge // nil until the bridge attaches itself; used by handleOfficeMembers for live add/remove
+	// humanAdmitHook fires once per successful invite acceptance so the
+	// office-bound share adapter can call Host.UpsertParticipant for the new
+	// admitted human. Stored atomically so the HTTP hot path can read without
+	// contending on b.mu. Installed and cleared by ShareTransport.Run; nil
+	// when no adapter is registered (e.g. legacy launches that bypass
+	// RegisterTransports).
+	humanAdmitHook     atomic.Pointer[humanAdmitHookFn]
 	generateMemberFn   func(prompt string) (generatedMemberTemplate, error)
 	generateChannelFn  func(prompt string) (generatedChannelTemplate, error)
 	policies           []officePolicy // active office operating rules

--- a/internal/team/broker_human_share.go
+++ b/internal/team/broker_human_share.go
@@ -1,6 +1,7 @@
 package team
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -21,6 +22,45 @@ const (
 	humanShareEventFrom = "system"
 	humanLastSeenFlush  = time.Minute
 )
+
+// humanAdmitHookFn fires after acceptHumanInvite succeeds and the new session
+// is persisted. The office-bound share adapter installs this hook in
+// ShareTransport.Run so it can call Host.UpsertParticipant for the admitted
+// human — closing the v1 lifecycle gap where only the revoke half flowed
+// through the transport host. Hook signature accepts only exported scalars so
+// share_transport.go does not need to reach into humanSession internals.
+type humanAdmitHookFn func(ctx context.Context, sessionID, slug, displayName string)
+
+// SetHumanAdmitHook installs (or clears, when hook is nil) the per-broker
+// callback fired after handleHumanInviteAccept admits a session. Called from
+// ShareTransport.Run on adapter startup and shutdown. The pointer is read
+// atomically on the HTTP hot path; passing nil is the documented way for the
+// adapter to detach on shutdown.
+func (b *Broker) SetHumanAdmitHook(hook humanAdmitHookFn) {
+	if b == nil {
+		return
+	}
+	if hook == nil {
+		b.humanAdmitHook.Store(nil)
+		return
+	}
+	b.humanAdmitHook.Store(&hook)
+}
+
+// fireHumanAdmitHook invokes the installed hook with the new session, if any.
+// Called from handleHumanInviteAccept *after* persistence succeeds so an
+// adapter cannot observe a session that was rolled back by a save failure. A
+// nil hook (no adapter registered, or shutdown in progress) is a silent no-op.
+func (b *Broker) fireHumanAdmitHook(ctx context.Context, session humanSession) {
+	if b == nil {
+		return
+	}
+	hp := b.humanAdmitHook.Load()
+	if hp == nil {
+		return
+	}
+	(*hp)(ctx, session.ID, session.HumanSlug, session.DisplayName)
+}
 
 type humanInviteResponse struct {
 	ID         string `json:"id"`
@@ -102,6 +142,11 @@ func (b *Broker) handleHumanInviteAccept(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	http.SetCookie(w, humanSessionCookieForToken(sessionToken, sessionExpiresAt(session)))
+	// Notify the office-bound share adapter so it can call
+	// Host.UpsertParticipant for the admitted human. Fired after persistence
+	// succeeds (acceptHumanInvite returned no error) so a rolled-back invite
+	// never produces a phantom upsert.
+	b.fireHumanAdmitHook(r.Context(), session)
 	writeJSON(w, http.StatusOK, map[string]any{"session": humanSessionToResponse(session)})
 }
 

--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -7,12 +7,19 @@ package team
 // ReceiveMessage and UpsertParticipant route to PostInboundSurfaceMessage for
 // channel-bound (Telegram) adapters; UpsertParticipant is a no-op there because
 // participant attribution is handled inside PostInboundSurfaceMessage by
-// display name.
+// display name. The share adapter takes the same no-op path: admitted-human
+// identity already exists in the broker as a humanSession before the adapter
+// fires the contract call, so UpsertParticipant just confirms the contract
+// without duplicating broker state.
 //
 // RevokeParticipant routes the office-bound (human-share) revoke flow to
 // Broker.revokeHumanSession so an adapter calling Host.RevokeParticipant after
-// an invite is revoked tears down the corresponding session. Member-bound
-// DetachParticipant remains a stub until the openclaw lifecycle adds it.
+// an invite is revoked tears down the corresponding session.
+//
+// DetachParticipant routes the member-bound (openclaw) detach flow to a
+// session-end notice. The broker has no per-member presence flag today, so the
+// hook validates the call and returns nil — future presence work plugs in
+// here without further adapter changes.
 
 import (
 	"context"
@@ -46,20 +53,35 @@ func (h *brokerTransportHost) ReceiveMessage(_ context.Context, msg transport.Me
 	return nil
 }
 
-// UpsertParticipant is a no-op for channel-bound adapters (Telegram). Channel-
-// bound participant identity is resolved by display name inside
-// PostInboundSurfaceMessage. A real member-store lookup for member-bound
-// adapters (OpenClaw) is not yet wired here.
+// UpsertParticipant registers an external identity. For channel-bound adapters
+// (Telegram) participant attribution is handled inside PostInboundSurfaceMessage
+// by display name, so the call is a no-op. For the office-bound share adapter
+// the admitted-human record already exists in the broker as a humanSession by
+// the time this fires (see broker_human_share.handleHumanInviteAccept), so the
+// contract is satisfied without a duplicate broker write. Member-bound
+// adapters (OpenClaw) take the same no-op path until the broker grows a
+// per-member registration store.
 func (h *brokerTransportHost) UpsertParticipant(_ context.Context, _ transport.Participant, _ transport.Binding) error {
 	return nil
 }
 
-// DetachParticipant marks a participant as offline. Not yet implemented for
-// member-bound adapters (OpenClaw); inbound calls return an explicit
-// unsupported error so a misconfigured caller fails loudly.
-func (h *brokerTransportHost) DetachParticipant(_ context.Context, adapterName, _ string) error {
-	return fmt.Errorf("transport: DetachParticipant not yet implemented: adapter=%q",
-		adapterName)
+// DetachParticipant marks a participant as offline. Recognized adapters
+// (openclaw) take a no-op success path: the bridge has already cleared its
+// own slug binding by the time this is called and the broker has no
+// per-member presence flag yet. Wiring the call site now means future
+// presence work can extend this without touching adapters. An unknown
+// adapterName is rejected so a misnamed call surfaces loudly rather than
+// silently no-op'ing.
+func (h *brokerTransportHost) DetachParticipant(_ context.Context, adapterName, key string) error {
+	if h == nil || h.broker == nil {
+		return errors.New("transport: DetachParticipant: nil broker")
+	}
+	switch adapterName {
+	case openclawAdapterName:
+		return nil
+	default:
+		return fmt.Errorf("transport: DetachParticipant: unsupported adapter %q (key=%q)", adapterName, key)
+	}
 }
 
 // RevokeParticipant removes an admitted human from the broker. For the

--- a/internal/team/openclaw.go
+++ b/internal/team/openclaw.go
@@ -201,6 +201,8 @@ func (b *OpenclawBridge) DetachSlug(slug string) {
 	bridgeCtx := b.ctx
 	b.mu.Unlock()
 
+	b.notifyHostDetached(bridgeCtx, slug, sessionKey)
+
 	client := b.getClient()
 	if client == nil || bridgeCtx == nil {
 		return
@@ -210,6 +212,29 @@ func (b *OpenclawBridge) DetachSlug(slug string) {
 			b.postSystemMessage(fmt.Sprintf("unsubscribe @%s failed: %v", slug, err))
 		}
 	}()
+}
+
+// notifyHostDetached fires Host.DetachParticipant for sessionKey when the
+// bridge is host-driven. Best-effort: a host error is logged via system
+// message but does not stall further teardown. Skipped silently when no host
+// is attached (legacy Start mode for probes / integration tests). Centralised
+// so all three Detach* paths funnel through the same call site — adding a
+// fourth detach path means adding one notifyHostDetached call, not three.
+func (b *OpenclawBridge) notifyHostDetached(ctx context.Context, slug, sessionKey string) {
+	if b == nil || sessionKey == "" {
+		return
+	}
+	hp := b.host.Load()
+	if hp == nil {
+		return
+	}
+	host := *hp
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := host.DetachParticipant(ctx, openclawAdapterName, sessionKey); err != nil && ctx.Err() == nil {
+		b.postSystemMessage(fmt.Sprintf("detach @%s: %v", slug, err))
+	}
 }
 
 // DetachSlugAndUnsubscribe is the synchronous, error-returning variant used by
@@ -233,6 +258,8 @@ func (b *OpenclawBridge) DetachSlugAndUnsubscribe(ctx context.Context, slug stri
 	delete(b.slugByKey, sessionKey)
 	delete(b.lastChannelByKey, sessionKey)
 	b.mu.Unlock()
+
+	b.notifyHostDetached(ctx, slug, sessionKey)
 
 	client := b.getClient()
 	if client == nil {
@@ -266,6 +293,8 @@ func (b *OpenclawBridge) DetachSession(ctx context.Context, slug, sessionKey str
 	delete(b.slugByKey, sessionKey)
 	delete(b.lastChannelByKey, sessionKey)
 	b.mu.Unlock()
+
+	b.notifyHostDetached(ctx, slug, sessionKey)
 
 	client := b.getClient()
 	if client == nil {

--- a/internal/team/openclaw_host_test.go
+++ b/internal/team/openclaw_host_test.go
@@ -192,6 +192,112 @@ func TestPostBridgeMessageRoutesToHost(t *testing.T) {
 	}
 }
 
+// TestDetachSlugCallsHostDetachParticipant confirms the bridge fires
+// Host.DetachParticipant for the bound sessionKey when DetachSlug runs under
+// a host-driven Run. Guards the slice-C contract closure: every detach path
+// in the bridge must funnel through notifyHostDetached so future presence
+// work hooks one place, not three.
+func TestDetachSlugCallsHostDetachParticipant(t *testing.T) {
+	fake := newFakeOC()
+	broker := newTestBroker(t)
+	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k-detach", Slug: "openclaw-detach"}}
+	bridge := NewOpenclawBridge(broker, fake, bindings)
+	host := newRecordingDetachHost()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- bridge.Run(ctx, host) }()
+	waitForFakeOCSubscribe(t, fake, time.Second)
+
+	bridge.DetachSlug("openclaw-detach")
+
+	select {
+	case <-host.detached:
+	case <-time.After(time.Second):
+		t.Fatalf("host.DetachParticipant was not called within 1s")
+	}
+
+	got := host.detachSnapshot()
+	if len(got) != 1 {
+		t.Fatalf("DetachParticipant call count: got %d want 1", len(got))
+	}
+	if got[0].adapter != openclawAdapterName {
+		t.Errorf("DetachParticipant adapter: got %q want %q", got[0].adapter, openclawAdapterName)
+	}
+	if got[0].key != "k-detach" {
+		t.Errorf("DetachParticipant key: got %q want %q", got[0].key, "k-detach")
+	}
+
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// TestDetachSlugAndUnsubscribeCallsHostDetachParticipant covers the
+// HTTP-handler detach path. notifyHostDetached fires before the synchronous
+// unsubscribe so a later unsubscribe error does not gate the host
+// notification (the host should learn the session is gone even if the gateway
+// teardown fails).
+func TestDetachSlugAndUnsubscribeCallsHostDetachParticipant(t *testing.T) {
+	fake := newFakeOC()
+	broker := newTestBroker(t)
+	bindings := []config.OpenclawBridgeBinding{{SessionKey: "k-detach-sync", Slug: "openclaw-detach-sync"}}
+	bridge := NewOpenclawBridge(broker, fake, bindings)
+	host := newRecordingDetachHost()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- bridge.Run(ctx, host) }()
+	waitForFakeOCSubscribe(t, fake, time.Second)
+
+	if err := bridge.DetachSlugAndUnsubscribe(ctx, "openclaw-detach-sync"); err != nil {
+		t.Fatalf("DetachSlugAndUnsubscribe: %v", err)
+	}
+
+	select {
+	case <-host.detached:
+	case <-time.After(time.Second):
+		t.Fatalf("host.DetachParticipant was not called within 1s")
+	}
+	if got := host.detachSnapshot(); len(got) != 1 || got[0].key != "k-detach-sync" {
+		t.Fatalf("DetachParticipant calls: %+v", got)
+	}
+
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run returned: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+// TestBrokerTransportHostDetachParticipantOpenclaw pins the host
+// implementation: openclaw routes to a no-op success and an unknown adapter
+// surfaces an explicit unsupported-adapter error rather than silently
+// no-op'ing (which would mask a launcher misconfiguration).
+func TestBrokerTransportHostDetachParticipantOpenclaw(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+
+	if err := host.DetachParticipant(context.Background(), openclawAdapterName, "any-key"); err != nil {
+		t.Errorf("DetachParticipant(openclaw): got %v want nil", err)
+	}
+	if err := host.DetachParticipant(context.Background(), "made-up", "key"); err == nil {
+		t.Error("DetachParticipant(unknown adapter) returned nil; want unsupported-adapter error")
+	}
+}
+
 // TestOpenclawBridgeRunRequiresHost confirms Run rejects a nil host so a
 // misconfigured launcher fails loudly instead of silently degrading to the
 // legacy broker entrypoint.
@@ -242,4 +348,47 @@ func TestRegisterTransportsShutdownOrdering(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("RegisterTransports cleanup did not return within 2s; router or Run goroutine deadlocked")
 	}
+}
+
+// recordingDetachHost extends fakeHost-style recording to DetachParticipant so
+// the slice-C tests can rendezvous on host calls without polling. Embeds a
+// channel so callers wait on the first detach deterministically.
+type recordingDetachHost struct {
+	mu       sync.Mutex
+	calls    []detachCall
+	detached chan struct{}
+}
+
+type detachCall struct {
+	adapter string
+	key     string
+}
+
+func newRecordingDetachHost() *recordingDetachHost {
+	return &recordingDetachHost{detached: make(chan struct{}, 8)}
+}
+
+func (h *recordingDetachHost) ReceiveMessage(context.Context, transport.Message) error { return nil }
+func (h *recordingDetachHost) UpsertParticipant(context.Context, transport.Participant, transport.Binding) error {
+	return nil
+}
+func (h *recordingDetachHost) RevokeParticipant(context.Context, string, string) error { return nil }
+
+func (h *recordingDetachHost) DetachParticipant(_ context.Context, adapterName, key string) error {
+	h.mu.Lock()
+	h.calls = append(h.calls, detachCall{adapter: adapterName, key: key})
+	h.mu.Unlock()
+	select {
+	case h.detached <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (h *recordingDetachHost) detachSnapshot() []detachCall {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]detachCall, len(h.calls))
+	copy(out, h.calls)
+	return out
 }

--- a/internal/team/share_transport.go
+++ b/internal/team/share_transport.go
@@ -13,20 +13,20 @@ package team
 // that the adapter (not the Host) drives the per-session teardown after invite
 // revocation.
 //
-// v1 lifecycle invariant: only the revoke half of the OfficeBoundTransport
-// admit/revoke pair is wired through the transport host. Admit happens via the
-// in-process /humans/invites/accept HTTP handler, which calls
-// Broker.acceptHumanInvite directly; the transport host's UpsertParticipant is
-// never invoked for share-admitted humans. This is intentional — admitted
-// humans poll the broker via /api/* routes rather than through the transport
-// contract — but a future phase that wants Host.ReceiveMessage for share
-// participants must close this gap by also calling Host.UpsertParticipant from
-// the accept path.
+// Admit lifecycle: Run installs Broker.SetHumanAdmitHook so every successful
+// invite acceptance via the in-process /humans/invites/accept HTTP handler
+// fans out to Host.UpsertParticipant for the new admitted human. The hook is
+// cleared on Run exit so a stale closure cannot keep firing after shutdown.
+// With both halves of admit/revoke flowing through the transport host,
+// Host.ReceiveMessage for share participants is no longer blocked on a
+// missing UpsertParticipant call — admitted humans are first-class
+// transport.Host participants.
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 	"sync/atomic"
 	"time"
 
@@ -86,15 +86,15 @@ func (s *ShareTransport) Binding() transport.Binding {
 	return transport.Binding{Scope: transport.ScopeOffice}
 }
 
-// Run stores the host atomically and blocks until ctx is cancelled. The
-// human-share surface is in-process — the existing handlers in
-// broker_human_share.go drive accept directly, so Run does not subscribe to
-// anything external. A nil host is rejected so a misconfigured launcher fails
-// loudly rather than silently degrading.
+// Run stores the host atomically, installs the broker's human-admit hook so
+// the in-process accept handler fans out to Host.UpsertParticipant, and then
+// blocks until ctx is cancelled. The human-share surface is in-process — the
+// existing handlers in broker_human_share.go drive accept directly — so Run
+// does not subscribe to anything external. A nil host is rejected so a
+// misconfigured launcher fails loudly rather than silently degrading.
 //
-// See the file header for the v1 lifecycle invariant: only the revoke half of
-// the OfficeBoundTransport admit/revoke pair flows through the transport host
-// today.
+// The admit hook is cleared on Run exit so a stale closure (capturing the now-
+// stopped host) cannot keep firing if a second adapter installs itself later.
 func (s *ShareTransport) Run(ctx context.Context, host transport.Host) error {
 	if s == nil {
 		return fmt.Errorf("share: nil transport")
@@ -104,8 +104,43 @@ func (s *ShareTransport) Run(ctx context.Context, host transport.Host) error {
 	}
 	s.host.Store(&host)
 	s.startedAt.Store(time.Now().UnixNano())
+	if s.broker != nil {
+		s.broker.SetHumanAdmitHook(s.onHumanAdmit)
+		defer s.broker.SetHumanAdmitHook(nil)
+	}
 	<-ctx.Done()
 	return nil
+}
+
+// onHumanAdmit forwards a successful invite acceptance to Host.UpsertParticipant
+// so the admitted human becomes a first-class transport.Host participant. The
+// host pointer is read via the same atomic the rest of the adapter uses; if
+// Run has not yet stored the pointer (or the adapter is mid-shutdown) the call
+// is a silent no-op — the broker-level humanSession already exists either way.
+//
+// Errors from the host are logged rather than returned: the broker has already
+// persisted the session and replied 200 to the HTTP caller by the time this
+// fires, so an upsert failure cannot be surfaced to the human anymore. Logging
+// keeps it visible without inventing a synthetic admit-failure path.
+func (s *ShareTransport) onHumanAdmit(ctx context.Context, sessionID, slug, displayName string) {
+	if s == nil {
+		return
+	}
+	hp := s.host.Load()
+	if hp == nil {
+		return
+	}
+	host := *hp
+	participant := transport.Participant{
+		AdapterName: shareAdapterName,
+		Key:         sessionID,
+		DisplayName: displayName,
+		Human:       true,
+	}
+	binding := transport.Binding{Scope: transport.ScopeOffice, MemberSlug: slug}
+	if err := host.UpsertParticipant(ctx, participant, binding); err != nil && (ctx == nil || ctx.Err() == nil) {
+		log.Printf("[transport] share: UpsertParticipant for %s: %v", sessionID, err)
+	}
 }
 
 // Send is a no-op for the human-share adapter. Office-wide messages reach

--- a/internal/team/share_transport_test.go
+++ b/internal/team/share_transport_test.go
@@ -370,6 +370,111 @@ func TestBrokerTransportHostRevokeParticipantShare(t *testing.T) {
 	}
 }
 
+// TestShareTransportRunInstallsAdmitHook is the slice-C contract test:
+// when ShareTransport.Run is live and the broker accepts a human invite, the
+// admit hook fires Host.UpsertParticipant once with the new session's
+// (adapter, key) pair and the admitted display name. Closes the v1 lifecycle
+// gap where only RevokeParticipant flowed through the host.
+func TestShareTransportRunInstallsAdmitHook(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, RelativeJoinURL)
+	host := newRecordingUpsertHost()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- st.Run(ctx, host) }()
+	waitForShareConnected(t, st, runErr)
+
+	token, _, err := b.createHumanInvite()
+	if err != nil {
+		t.Fatalf("createHumanInvite: %v", err)
+	}
+	_, session, err := b.acceptHumanInvite(token, "Devon", "")
+	if err != nil {
+		t.Fatalf("acceptHumanInvite: %v", err)
+	}
+
+	// acceptHumanInvite is the broker-internal helper; the production HTTP
+	// path also fires the hook. Drive it explicitly here so the test does not
+	// need an HTTP server up.
+	b.fireHumanAdmitHook(ctx, session)
+
+	select {
+	case <-host.upserted:
+	case <-time.After(time.Second):
+		t.Fatalf("host.UpsertParticipant was not called within 1s")
+	}
+
+	calls := host.upsertSnapshot()
+	if len(calls) != 1 {
+		t.Fatalf("UpsertParticipant call count: got %d want 1", len(calls))
+	}
+	got := calls[0]
+	if got.participant.AdapterName != shareAdapterName {
+		t.Errorf("AdapterName: got %q want %q", got.participant.AdapterName, shareAdapterName)
+	}
+	if got.participant.Key != session.ID {
+		t.Errorf("Key: got %q want %q", got.participant.Key, session.ID)
+	}
+	if got.participant.DisplayName != "Devon" {
+		t.Errorf("DisplayName: got %q want %q", got.participant.DisplayName, "Devon")
+	}
+	if !got.participant.Human {
+		t.Errorf("Human: got false want true (admitted humans must be marked Human=true)")
+	}
+	if got.binding.Scope != transport.ScopeOffice {
+		t.Errorf("Scope: got %q want %q", got.binding.Scope, transport.ScopeOffice)
+	}
+	if got.binding.MemberSlug != session.HumanSlug {
+		t.Errorf("MemberSlug: got %q want %q", got.binding.MemberSlug, session.HumanSlug)
+	}
+
+	cancel()
+	awaitRunReturn(t, runErr)
+}
+
+// TestShareTransportAdmitHookClearedOnRunExit confirms the admit hook is
+// removed when Run returns so a stale closure cannot keep firing against a
+// stopped host. Without this teardown a second adapter installed later would
+// see the old pointer and would (silently) double-fire.
+func TestShareTransportAdmitHookClearedOnRunExit(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, RelativeJoinURL)
+	host := newRecordingUpsertHost()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- st.Run(ctx, host) }()
+	waitForShareConnected(t, st, runErr)
+
+	cancel()
+	awaitRunReturn(t, runErr)
+
+	// After Run returns, fireHumanAdmitHook should be a silent no-op.
+	b.fireHumanAdmitHook(context.Background(), humanSession{ID: "session-after-stop", HumanSlug: "after"})
+
+	if got := len(host.upsertSnapshot()); got != 0 {
+		t.Errorf("UpsertParticipant called after Run exit: got %d calls want 0", got)
+	}
+}
+
+// TestShareTransportAdmitHookSilentWhenNoHost asserts the adapter does not
+// crash if the admit hook fires after host.Load() returns nil (e.g. a teardown
+// race where SetHumanAdmitHook(nil) has not yet completed). The hook is
+// installed inside Run after host.Store, so this should be a near-impossible
+// race in practice — the test pins the defensive nil check anyway because
+// transitive failure (panic in an HTTP handler goroutine) would crash the
+// broker process.
+func TestShareTransportAdmitHookSilentWhenNoHost(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, RelativeJoinURL)
+
+	// Manually invoke onHumanAdmit without ever calling Run; host pointer is nil.
+	st.onHumanAdmit(context.Background(), "session-1", "slug", "Display")
+	// Reaching here without panic is the assertion.
+}
+
 // TestShareTransportSendIsNoop pins the no-op Send semantics. Office-bound
 // human-share has no external network to push to (admitted humans poll the
 // broker directly), so Send accepts the message and returns nil. Locking this
@@ -488,6 +593,48 @@ func (h *erroringHost) revokeCalls() []revokeCall {
 	defer h.mu.Unlock()
 	out := make([]revokeCall, len(h.revoked))
 	copy(out, h.revoked)
+	return out
+}
+
+// recordingUpsertHost records every UpsertParticipant call for the slice-C
+// admit-hook tests. ReceiveMessage / DetachParticipant / RevokeParticipant are
+// no-ops; the share admit path only needs UpsertParticipant.
+type recordingUpsertHost struct {
+	mu       sync.Mutex
+	calls    []upsertCall
+	upserted chan struct{}
+}
+
+type upsertCall struct {
+	participant transport.Participant
+	binding     transport.Binding
+}
+
+func newRecordingUpsertHost() *recordingUpsertHost {
+	return &recordingUpsertHost{upserted: make(chan struct{}, 8)}
+}
+
+func (h *recordingUpsertHost) ReceiveMessage(context.Context, transport.Message) error { return nil }
+
+func (h *recordingUpsertHost) UpsertParticipant(_ context.Context, p transport.Participant, b transport.Binding) error {
+	h.mu.Lock()
+	h.calls = append(h.calls, upsertCall{participant: p, binding: b})
+	h.mu.Unlock()
+	select {
+	case h.upserted <- struct{}{}:
+	default:
+	}
+	return nil
+}
+
+func (h *recordingUpsertHost) DetachParticipant(context.Context, string, string) error { return nil }
+func (h *recordingUpsertHost) RevokeParticipant(context.Context, string, string) error { return nil }
+
+func (h *recordingUpsertHost) upsertSnapshot() []upsertCall {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]upsertCall, len(h.calls))
+	copy(out, h.calls)
 	return out
 }
 


### PR DESCRIPTION
## Summary

Closes the two documented contract debts left by phase-4 slices A (#646) and B (#650) so both halves of the `transport.Host` lifecycle flow through the contract for both adapters.

- **OpenClaw → Host.DetachParticipant.** Replaces the `not yet implemented` stub on `brokerTransportHost` with a no-op success for openclaw + explicit unsupported-adapter error for unknown names. All three `OpenclawBridge.Detach*` paths now funnel through one `notifyHostDetached` helper.
- **Share → Host.UpsertParticipant on admit.** Adds an atomic admit hook on `Broker`, fired by `handleHumanInviteAccept` only after persistence succeeds. `ShareTransport.Run` installs the hook on entry and clears it on exit; the hook calls `Host.UpsertParticipant` with `Human=true`. The v1 lifecycle-split caveat is gone — admitted humans are first-class `transport.Host` participants.

## Test plan

- [x] `go vet ./...`
- [x] `gofmt -l .`
- [x] `golangci-lint run ./internal/team/...`
- [x] `bash scripts/test-go.sh ./internal/team` (full suite, 81s)
- [x] `go test -race -count=3 ./internal/team -run "ShareTransport|BrokerTransportHost|OpenclawBridge|PostBridgeMessage|RegisterTransports|DetachSlug|DetachParticipant|HumanInvite"`
- [x] `BASE_SHA=… bash scripts/check-no-new-sleeps-in-tests.sh` (no new `time.Sleep` in tests)
- [ ] Manual smoke once merged: invite → accept → revoke through web share controller

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Human participants joining sessions are now properly tracked as first-class participants in the transport system.

* **Improvements**
  * Enhanced session lifecycle and participant management with improved cleanup notifications when participants disconnect.
  * Strengthened detachment handling and resource cleanup across different connection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->