### PR TITLE
fix(agent): release mu before ranging over streamLLM channel

### DIFF
--- a/internal/agent/loop.go
+++ b/internal/agent/loop.go
@@ -535,7 +535,13 @@ func (l *AgentLoop) streamLLM() error {
 	ch := l.streamFn(messages, allowedTools)
 
 	var fullText strings.Builder
-	for chunk := range ch {
+	for {
+		l.mu.Unlock()
+		chunk, ok := <-ch
+		l.mu.Lock()
+		if !ok {
+			break
+		}
 		select {
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.Canceled) {


### PR DESCRIPTION
## Summary
`streamLLM` at internal/agent/loop.go:515 is called from Tick with mu held, then ranges over the stream channel without releasing it. That contradicts the in-code comment claiming mu is unlocked while waiting and deadlocks any caller that needs the lock to produce chunks.

## Fix
Replace the `for chunk := range ch` with an explicit receive loop that unlocks mu before each blocking receive and re-locks it before touching shared state. Behavior on channel close is preserved via the ok check.

## Tests
`bash scripts/test-go.sh` passes with `-race`. A dedicated epicenter test for the lock-handoff would be a good follow-up but is out of scope for this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming behavior in agent processing to prevent potential deadlocks and ensure more responsive handling of incoming chunks.
  * Now explicitly detects stream closure to stop processing promptly and avoid lingering waits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->