### PR TITLE
feat(transport): production-wire share adapter for in-process invite creation

### DIFF
--- a/cmd/wuphf/main.go
+++ b/cmd/wuphf/main.go
@@ -689,6 +689,7 @@ func runWeb(args []string, packSlug string, unsafe bool, webPort int, opusCEO bo
 		os.Exit(1)
 	}
 	wireBrokerWorkspaces(l, func(b *team.Broker) {
+		shareController.SetBroker(b)
 		b.SetWebShareController(shareController.start, shareController.status, shareController.stop)
 	})
 	fmt.Printf("Launching %s web view (%d agents)... the browser is the office now.\n", l.PackName(), l.AgentCount())

--- a/cmd/wuphf/share.go
+++ b/cmd/wuphf/share.go
@@ -120,7 +120,13 @@ func (c *webShareController) clearInviteLocked() {
 // the legacy HTTP path against the broker. The absolute URL formula is
 // identical in both branches so the user-facing link does not depend on which
 // path produced it. Caller must hold c.mu.
-func (c *webShareController) issueInviteLocked(ctx context.Context, bind string, port int, brokerURL, brokerToken string) (string, string, error) {
+//
+// brokerTokenFn is invoked lazily — only when the HTTP fallback path is taken.
+// This keeps the in-process adapter path independent of broker-token-file
+// availability: a missing or unreadable token file no longer blocks invite
+// creation when an adapter handle is registered. The fn shape (rather than a
+// pre-read string) makes the lazy contract explicit at every call site.
+func (c *webShareController) issueInviteLocked(ctx context.Context, bind string, port int, brokerURL string, brokerTokenFn func() (string, error)) (string, string, error) {
 	if c.broker != nil {
 		if st := c.broker.ShareTransport(); st != nil {
 			st.SetURLBuilder(func(token string) string {
@@ -132,6 +138,10 @@ func (c *webShareController) issueInviteLocked(ctx context.Context, bind string,
 			}
 			return details.URL, details.ExpiresAt, nil
 		}
+	}
+	brokerToken, err := brokerTokenFn()
+	if err != nil {
+		return "", "", err
 	}
 	invite, err := createShareInvite(brokerURL, brokerToken)
 	if err != nil {
@@ -155,15 +165,14 @@ func (c *webShareController) start() (team.WebShareStatus, error) {
 	if opts.webPort == 0 {
 		opts.webPort = 7891
 	}
-	token, err := readBrokerToken()
-	if err != nil {
-		c.err = err.Error()
-		return c.statusLocked(), err
-	}
 	brokerURL := brokeraddr.ResolveBaseURL()
 
 	if c.running && c.server != nil {
-		inviteURL, expiresAt, err := c.issueInviteLocked(context.Background(), c.bind, opts.webPort, brokerURL, token)
+		// readBrokerToken is passed by reference so the running branch only
+		// pays the file I/O when issueInviteLocked actually falls back to the
+		// HTTP path (i.e. the adapter handle is missing). With the adapter
+		// registered, a fresh invite mints with no token-file read.
+		inviteURL, expiresAt, err := c.issueInviteLocked(context.Background(), c.bind, opts.webPort, brokerURL, readBrokerToken)
 		if err != nil {
 			c.err = err.Error()
 			return c.statusLocked(), err
@@ -175,6 +184,15 @@ func (c *webShareController) start() (team.WebShareStatus, error) {
 		return c.statusLocked(), nil
 	}
 
+	// Fresh start: the token is needed for newShareHTTPServer regardless of
+	// which invite-creation path issueInviteLocked picks, so read it once here
+	// and reuse the value via a constant closure for the invite path.
+	token, err := readBrokerToken()
+	if err != nil {
+		c.err = err.Error()
+		return c.statusLocked(), err
+	}
+
 	bind, iface, err := resolveShareBind(opts)
 	if err != nil {
 		c.running = false
@@ -183,7 +201,7 @@ func (c *webShareController) start() (team.WebShareStatus, error) {
 		c.err = webShareErrorMessage(err)
 		return c.statusLocked(), err
 	}
-	inviteURL, expiresAt, err := c.issueInviteLocked(context.Background(), bind.String(), opts.webPort, brokerURL, token)
+	inviteURL, expiresAt, err := c.issueInviteLocked(context.Background(), bind.String(), opts.webPort, brokerURL, func() (string, error) { return token, nil })
 	if err != nil {
 		c.running = false
 		c.server = nil

--- a/cmd/wuphf/share.go
+++ b/cmd/wuphf/share.go
@@ -65,6 +65,13 @@ type webShareController struct {
 	inviteURL string
 	expiresAt string
 	err       string
+	// broker is the in-process broker handle, set via SetBroker before the
+	// controller's first start(). When non-nil and the broker has registered
+	// a ShareTransport, start() routes invite creation through the adapter so
+	// admit + revoke + invite-create all flow through the same surface. When
+	// nil (e.g. the standalone `wuphf share` subcommand has no in-process
+	// broker), start() falls back to the legacy HTTP path.
+	broker *team.Broker
 }
 
 func newWebShareController(webPort int) *webShareController {
@@ -73,6 +80,16 @@ func newWebShareController(webPort int) *webShareController {
 			webPort: webPort,
 		},
 	}
+}
+
+// SetBroker installs the in-process broker handle. Idempotent. Passing nil
+// clears the handle so the controller falls back to the HTTP invite path.
+// Called by main.go after the broker is up but before the controller's first
+// start() invocation.
+func (c *webShareController) SetBroker(b *team.Broker) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.broker = b
 }
 
 func (c *webShareController) status() team.WebShareStatus {
@@ -97,6 +114,39 @@ func (c *webShareController) clearInviteLocked() {
 	c.expiresAt = ""
 }
 
+// issueInviteLocked returns a fresh invite URL and its RFC3339 expiry. When an
+// in-process broker handle with a registered ShareTransport is available it
+// goes through the adapter (CreateInviteDetailed); otherwise it falls back to
+// the legacy HTTP path against the broker. The absolute URL formula is
+// identical in both branches so the user-facing link does not depend on which
+// path produced it. Caller must hold c.mu.
+func (c *webShareController) issueInviteLocked(ctx context.Context, bind string, port int, brokerURL, brokerToken string) (string, string, error) {
+	if c.broker != nil {
+		if st := c.broker.ShareTransport(); st != nil {
+			st.SetURLBuilder(func(token string) string {
+				return shareJoinURL(bind, port, token)
+			})
+			details, err := st.CreateInviteDetailed(ctx)
+			if err != nil {
+				return "", "", err
+			}
+			return details.URL, details.ExpiresAt, nil
+		}
+	}
+	invite, err := createShareInvite(brokerURL, brokerToken)
+	if err != nil {
+		return "", "", err
+	}
+	return shareJoinURL(bind, port, invite.Token), invite.Invite.ExpiresAt, nil
+}
+
+// shareJoinURL is the canonical "http://<bind>:<port>/join/<token>" formatter
+// used by both the adapter and HTTP invite paths so the user-facing URL shape
+// stays in one place.
+func shareJoinURL(bind string, port int, token string) string {
+	return fmt.Sprintf("http://%s:%d/join/%s", bind, port, token)
+}
+
 func (c *webShareController) start() (team.WebShareStatus, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -113,14 +163,14 @@ func (c *webShareController) start() (team.WebShareStatus, error) {
 	brokerURL := brokeraddr.ResolveBaseURL()
 
 	if c.running && c.server != nil {
-		invite, err := createShareInvite(brokerURL, token)
+		inviteURL, expiresAt, err := c.issueInviteLocked(context.Background(), c.bind, opts.webPort, brokerURL, token)
 		if err != nil {
 			c.err = err.Error()
 			return c.statusLocked(), err
 		}
 		c.brokerURL = brokerURL
-		c.inviteURL = fmt.Sprintf("http://%s:%d/join/%s", c.bind, opts.webPort, invite.Token)
-		c.expiresAt = invite.Invite.ExpiresAt
+		c.inviteURL = inviteURL
+		c.expiresAt = expiresAt
 		c.err = ""
 		return c.statusLocked(), nil
 	}
@@ -133,7 +183,7 @@ func (c *webShareController) start() (team.WebShareStatus, error) {
 		c.err = webShareErrorMessage(err)
 		return c.statusLocked(), err
 	}
-	invite, err := createShareInvite(brokerURL, token)
+	inviteURL, expiresAt, err := c.issueInviteLocked(context.Background(), bind.String(), opts.webPort, brokerURL, token)
 	if err != nil {
 		c.running = false
 		c.server = nil
@@ -158,8 +208,8 @@ func (c *webShareController) start() (team.WebShareStatus, error) {
 	c.bind = bind.String()
 	c.iface = iface
 	c.brokerURL = brokerURL
-	c.inviteURL = fmt.Sprintf("http://%s:%d/join/%s", c.bind, opts.webPort, invite.Token)
-	c.expiresAt = invite.Invite.ExpiresAt
+	c.inviteURL = inviteURL
+	c.expiresAt = expiresAt
 	c.err = ""
 
 	go func() {
@@ -269,7 +319,7 @@ func runShareServer(opts shareOptions) error {
 	if err != nil {
 		return err
 	}
-	inviteURL := fmt.Sprintf("http://%s:%d/join/%s", bind.String(), opts.webPort, invite.Token)
+	inviteURL := shareJoinURL(bind.String(), opts.webPort, invite.Token)
 	out := shareJSONOutput{
 		OK:        true,
 		Bind:      bind.String(),

--- a/cmd/wuphf/share_test.go
+++ b/cmd/wuphf/share_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -555,4 +556,73 @@ func containsAll(s string, wants ...string) bool {
 		}
 	}
 	return true
+}
+
+// TestWebShareControllerIssueInviteUsesAdapter confirms the controller routes
+// invite creation through the registered ShareTransport when an in-process
+// broker handle is available. The test broker is never started as an HTTP
+// server, so any fallback to createShareInvite would fail with a transport
+// error — a successful URL therefore proves the adapter path executed.
+func TestWebShareControllerIssueInviteUsesAdapter(t *testing.T) {
+	b := team.NewBrokerAt(t.TempDir() + "/broker-state.json")
+	st := team.NewShareTransport(b, team.RelativeJoinURL)
+	b.SetShareTransport(st)
+
+	c := newWebShareController(7891)
+	c.SetBroker(b)
+
+	c.mu.Lock()
+	url, expiresAt, err := c.issueInviteLocked(context.Background(), "10.0.0.5", 7891, "http://broker.invalid", "ignored-token")
+	c.mu.Unlock()
+	if err != nil {
+		t.Fatalf("issueInviteLocked: %v", err)
+	}
+
+	wantPrefix := "http://10.0.0.5:7891/join/"
+	if !strings.HasPrefix(url, wantPrefix) {
+		t.Errorf("invite URL = %q, want prefix %q (controller did not honor SetURLBuilder)", url, wantPrefix)
+	}
+	if url == wantPrefix {
+		t.Error("invite URL has empty token")
+	}
+	if expiresAt == "" {
+		t.Error("ExpiresAt empty: broker did not return invite metadata via adapter")
+	}
+}
+
+// TestWebShareControllerIssueInviteFallsBackToHTTP confirms that when no
+// in-process broker handle is available (the standalone `wuphf share`
+// subcommand path), issueInviteLocked uses the HTTP createShareInvite call.
+// We verify by pointing the controller at an httptest server that mimics the
+// broker's POST /humans/invites response shape.
+func TestWebShareControllerIssueInviteFallsBackToHTTP(t *testing.T) {
+	const wantToken = "fallback-token-xyz"
+	const wantExpiresAt = "2026-05-06T00:00:00Z"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/humans/invites" || r.Method != http.MethodPost {
+			http.Error(w, "unexpected", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"token":"` + wantToken + `","invite":{"id":"inv-1","expires_at":"` + wantExpiresAt + `"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newWebShareController(7891)
+	// Intentionally no SetBroker — exercises the HTTP fallback branch.
+	c.mu.Lock()
+	url, expiresAt, err := c.issueInviteLocked(context.Background(), "192.168.1.10", 7891, srv.URL, "broker-token")
+	c.mu.Unlock()
+	if err != nil {
+		t.Fatalf("issueInviteLocked: %v", err)
+	}
+
+	want := "http://192.168.1.10:7891/join/" + wantToken
+	if url != want {
+		t.Errorf("invite URL = %q, want %q", url, want)
+	}
+	if expiresAt != wantExpiresAt {
+		t.Errorf("expiresAt = %q, want %q", expiresAt, wantExpiresAt)
+	}
 }

--- a/cmd/wuphf/share_test.go
+++ b/cmd/wuphf/share_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -571,8 +572,15 @@ func TestWebShareControllerIssueInviteUsesAdapter(t *testing.T) {
 	c := newWebShareController(7891)
 	c.SetBroker(b)
 
+	// brokerTokenFn deliberately errors so the test fails loudly if the
+	// adapter branch silently regresses into the HTTP fallback. The adapter
+	// path must never call this fn.
+	tokenFn := func() (string, error) {
+		t.Fatal("brokerTokenFn invoked: adapter path must not read the broker token")
+		return "", nil
+	}
 	c.mu.Lock()
-	url, expiresAt, err := c.issueInviteLocked(context.Background(), "10.0.0.5", 7891, "http://broker.invalid", "ignored-token")
+	url, expiresAt, err := c.issueInviteLocked(context.Background(), "10.0.0.5", 7891, "http://broker.invalid", tokenFn)
 	c.mu.Unlock()
 	if err != nil {
 		t.Fatalf("issueInviteLocked: %v", err)
@@ -611,8 +619,9 @@ func TestWebShareControllerIssueInviteFallsBackToHTTP(t *testing.T) {
 
 	c := newWebShareController(7891)
 	// Intentionally no SetBroker — exercises the HTTP fallback branch.
+	tokenFn := func() (string, error) { return "broker-token", nil }
 	c.mu.Lock()
-	url, expiresAt, err := c.issueInviteLocked(context.Background(), "192.168.1.10", 7891, srv.URL, "broker-token")
+	url, expiresAt, err := c.issueInviteLocked(context.Background(), "192.168.1.10", 7891, srv.URL, tokenFn)
 	c.mu.Unlock()
 	if err != nil {
 		t.Fatalf("issueInviteLocked: %v", err)
@@ -624,5 +633,21 @@ func TestWebShareControllerIssueInviteFallsBackToHTTP(t *testing.T) {
 	}
 	if expiresAt != wantExpiresAt {
 		t.Errorf("expiresAt = %q, want %q", expiresAt, wantExpiresAt)
+	}
+}
+
+// TestWebShareControllerIssueInviteHTTPFallbackPropagatesTokenError confirms
+// that when the adapter handle is absent and the lazy token getter fails, the
+// error is surfaced rather than swallowed. Locks in the contract that
+// issueInviteLocked treats brokerTokenFn errors as terminal for the HTTP path.
+func TestWebShareControllerIssueInviteHTTPFallbackPropagatesTokenError(t *testing.T) {
+	c := newWebShareController(7891)
+	tokenErr := errors.New("token file unreadable")
+	tokenFn := func() (string, error) { return "", tokenErr }
+	c.mu.Lock()
+	_, _, err := c.issueInviteLocked(context.Background(), "10.0.0.5", 7891, "http://broker.invalid", tokenFn)
+	c.mu.Unlock()
+	if !errors.Is(err, tokenErr) {
+		t.Fatalf("issueInviteLocked error: got %v, want %v wrapped", err, tokenErr)
 	}
 }

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -155,7 +155,14 @@ type Broker struct {
 	// contending on b.mu. Installed and cleared by ShareTransport.Run; nil
 	// when no adapter is registered (e.g. legacy launches that bypass
 	// RegisterTransports).
-	humanAdmitHook     atomic.Pointer[humanAdmitHookFn]
+	humanAdmitHook atomic.Pointer[humanAdmitHookFn]
+	// shareTransport is the registered office-bound share adapter, set by
+	// RegisterTransports when wiring is enabled. The in-process share
+	// controller looks this up to route invite creation through the adapter
+	// (so admit + revoke + invite-create all flow through the same surface)
+	// instead of the legacy HTTP path. Atomic so the controller's read does
+	// not contend with adapter registration on a different goroutine.
+	shareTransport     atomic.Pointer[ShareTransport]
 	generateMemberFn   func(prompt string) (generatedMemberTemplate, error)
 	generateChannelFn  func(prompt string) (generatedChannelTemplate, error)
 	policies           []officePolicy // active office operating rules

--- a/internal/team/broker_human_share.go
+++ b/internal/team/broker_human_share.go
@@ -47,6 +47,33 @@ func (b *Broker) SetHumanAdmitHook(hook humanAdmitHookFn) {
 	b.humanAdmitHook.Store(&hook)
 }
 
+// SetShareTransport registers (or clears, when t is nil) the office-bound
+// share adapter so the in-process share controller can route invite creation
+// through it. Called by RegisterTransports during launcher boot and cleared on
+// shutdown. Stored atomically because the controller reads it on its start
+// path while RegisterTransports may still be installing other adapters.
+func (b *Broker) SetShareTransport(t *ShareTransport) {
+	if b == nil {
+		return
+	}
+	if t == nil {
+		b.shareTransport.Store(nil)
+		return
+	}
+	b.shareTransport.Store(t)
+}
+
+// ShareTransport returns the registered office-bound share adapter, or nil
+// when no adapter has been registered yet. Used by the in-process share
+// controller to obtain a handle for invite creation; callers must tolerate a
+// nil return and fall back to their legacy path.
+func (b *Broker) ShareTransport() *ShareTransport {
+	if b == nil {
+		return nil
+	}
+	return b.shareTransport.Load()
+}
+
 // fireHumanAdmitHook invokes the installed hook with the new session, if any.
 // Called from handleHumanInviteAccept *after* persistence succeeds so an
 // adapter cannot observe a session that was rolled back by a save failure. A

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -96,12 +96,15 @@ func RegisterTransports(b *Broker) (func(), error) {
 	// Human-share: always registered. The adapter wraps the in-process
 	// invite/session surface in broker_human_share.go so RegisterTransports
 	// owns the OfficeBoundTransport lifecycle alongside Telegram and OpenClaw.
-	// RelativeJoinURL is the explicit degenerate builder used here because the
-	// launcher does not know the share controller's bind address (the share
-	// controller lives in cmd/wuphf and boots independently). When the share
-	// controller adopts the adapter for invite creation it will supply an
-	// absolute-URL builder via NewShareTransport.
+	// RelativeJoinURL is the constructor builder; the in-process share
+	// controller (cmd/wuphf/share.go) installs an absolute-URL builder via
+	// ShareTransport.SetURLBuilder once it knows its bind address. The
+	// constructor builder remains the safe default for any caller that reads
+	// CreateInvite before the controller has started. Registering the handle
+	// on the broker via SetShareTransport lets the controller obtain the
+	// adapter without a separate plumbing channel.
 	share := NewShareTransport(b, RelativeJoinURL)
+	b.SetShareTransport(share)
 	shareCtx, shareCancel := context.WithCancel(context.Background())
 	shareDone := make(chan struct{})
 	shareHost := &brokerTransportHost{broker: b}
@@ -114,6 +117,7 @@ func RegisterTransports(b *Broker) (func(), error) {
 	stops = append(stops, func() {
 		shareCancel()
 		<-shareDone
+		b.SetShareTransport(nil)
 	})
 	log.Printf("[transport] share: registered (human-share)")
 

--- a/internal/team/launcher_transports.go
+++ b/internal/team/launcher_transports.go
@@ -115,9 +115,16 @@ func RegisterTransports(b *Broker) (func(), error) {
 		}
 	}()
 	stops = append(stops, func() {
+		// Reverse install order: unpublish the transport handle BEFORE
+		// cancelling Run. The reverse order would let a concurrent controller
+		// fetch the still-published ShareTransport and mint an invite in the
+		// gap between Run's defer clearing the admit hook and SetShareTransport
+		// publishing nil — that invite's eventual accept would fire no host
+		// UpsertParticipant. Unpublishing first forces the controller into the
+		// HTTP fallback path immediately, while the admit hook is still live.
+		b.SetShareTransport(nil)
 		shareCancel()
 		<-shareDone
-		b.SetShareTransport(nil)
 	})
 	log.Printf("[transport] share: registered (human-share)")
 

--- a/internal/team/share_transport.go
+++ b/internal/team/share_transport.go
@@ -53,12 +53,21 @@ func RelativeJoinURL(token string) string { return "/join/" + token }
 
 // ShareTransport adapts the broker's human-share surface to the
 // transport.OfficeBoundTransport contract. It holds no state of its own beyond
-// the broker reference, the URL builder, and the host pointer set by Run.
+// the broker reference, the URL builders, and the host pointer set by Run.
+//
+// Two URL builders exist: the immutable constructor builder (urlBuilder) and
+// an optional override (urlBuilderOverride) that the in-process share
+// controller installs once it knows its bind address. CreateInvite reads the
+// override first; absent an override it falls back to the constructor builder.
+// This split keeps the constructor builder (typically RelativeJoinURL) safe as
+// a default while letting the controller upgrade to absolute URLs without a
+// re-construction dance.
 type ShareTransport struct {
-	broker     *Broker
-	urlBuilder JoinURLBuilder
-	host       atomic.Pointer[transport.Host]
-	startedAt  atomic.Int64 // unix nanos; zero before Run, set on Run entry
+	broker             *Broker
+	urlBuilder         JoinURLBuilder
+	urlBuilderOverride atomic.Pointer[JoinURLBuilder]
+	host               atomic.Pointer[transport.Host]
+	startedAt          atomic.Int64 // unix nanos; zero before Run, set on Run entry
 }
 
 // Compile-time assertion that ShareTransport satisfies OfficeBoundTransport.
@@ -74,6 +83,21 @@ func NewShareTransport(broker *Broker, urlBuilder JoinURLBuilder) *ShareTranspor
 		panic("team: NewShareTransport: urlBuilder is required (use RelativeJoinURL for the degenerate case)")
 	}
 	return &ShareTransport{broker: broker, urlBuilder: urlBuilder}
+}
+
+// SetURLBuilder installs an override URL builder. Passing nil clears the
+// override so CreateInvite falls back to the constructor builder. Atomic so
+// the broker hot path that calls CreateInvite does not contend with the
+// controller installing the override on start.
+func (s *ShareTransport) SetURLBuilder(b JoinURLBuilder) {
+	if s == nil {
+		return
+	}
+	if b == nil {
+		s.urlBuilderOverride.Store(nil)
+		return
+	}
+	s.urlBuilderOverride.Store(&b)
 }
 
 // Name returns the stable adapter identifier.
@@ -173,10 +197,13 @@ func (s *ShareTransport) Health() transport.Health {
 }
 
 // CreateInvite creates a new human-share invite via Broker.createHumanInvite
-// and returns the join URL produced by the injected JoinURLBuilder. The
-// network argument is part of the OfficeBoundTransport contract but
-// ShareTransport ignores it: URL construction is controlled by the builder,
-// which the share controller selects based on its own bind logic.
+// and returns the join URL produced by the active JoinURLBuilder. The override
+// builder (set via SetURLBuilder) wins over the constructor builder so the
+// in-process share controller can upgrade from RelativeJoinURL to an absolute
+// URL once its bind address is known. The network argument is part of the
+// OfficeBoundTransport contract but ShareTransport ignores it: URL
+// construction is controlled by the builder, which the share controller
+// selects based on its own bind logic.
 func (s *ShareTransport) CreateInvite(_ context.Context, _ string) (string, error) {
 	if s == nil || s.broker == nil {
 		return "", fmt.Errorf("share: CreateInvite: nil broker")
@@ -185,7 +212,45 @@ func (s *ShareTransport) CreateInvite(_ context.Context, _ string) (string, erro
 	if err != nil {
 		return "", fmt.Errorf("share: CreateInvite: %w", err)
 	}
-	return s.urlBuilder(token), nil
+	builder := s.urlBuilder
+	if override := s.urlBuilderOverride.Load(); override != nil {
+		builder = *override
+	}
+	return builder(token), nil
+}
+
+// ShareInviteDetails carries the join URL and broker-issued metadata for a
+// freshly created invite. Callers that need more than the URL (e.g. the
+// in-process share controller surfacing the expiry timestamp) should prefer
+// CreateInviteDetailed over CreateInvite. ExpiresAt is the same RFC3339 string
+// the broker stores so callers cannot drift in formatting.
+type ShareInviteDetails struct {
+	URL       string
+	InviteID  string
+	ExpiresAt string
+}
+
+// CreateInviteDetailed creates an invite and returns the join URL plus
+// broker-issued metadata (invite ID and RFC3339 expiry). Identical to
+// CreateInvite for URL construction; see CreateInvite for the override
+// precedence rule.
+func (s *ShareTransport) CreateInviteDetailed(_ context.Context) (ShareInviteDetails, error) {
+	if s == nil || s.broker == nil {
+		return ShareInviteDetails{}, fmt.Errorf("share: CreateInviteDetailed: nil broker")
+	}
+	token, invite, err := s.broker.createHumanInvite()
+	if err != nil {
+		return ShareInviteDetails{}, fmt.Errorf("share: CreateInviteDetailed: %w", err)
+	}
+	builder := s.urlBuilder
+	if override := s.urlBuilderOverride.Load(); override != nil {
+		builder = *override
+	}
+	return ShareInviteDetails{
+		URL:       builder(token),
+		InviteID:  invite.ID,
+		ExpiresAt: invite.ExpiresAt,
+	}, nil
 }
 
 // RevokeInvite revokes the invite and every session it admitted. Per the

--- a/internal/team/share_transport_test.go
+++ b/internal/team/share_transport_test.go
@@ -659,3 +659,115 @@ func inviteRevoked(b *Broker, inviteID string) bool {
 	}
 	return false
 }
+
+// TestShareTransportSetURLBuilderOverridesConstructor confirms the override
+// builder installed via SetURLBuilder wins over the constructor builder when
+// CreateInvite runs. Guards the contract that the in-process share controller
+// can upgrade from RelativeJoinURL to an absolute URL once it knows its bind
+// address without reconstructing the transport.
+func TestShareTransportSetURLBuilderOverridesConstructor(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, RelativeJoinURL)
+	st.SetURLBuilder(func(token string) string {
+		return "http://10.0.0.5:7891/join/" + token
+	})
+	got, err := st.CreateInvite(context.Background(), "")
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if !strings.HasPrefix(got, "http://10.0.0.5:7891/join/") {
+		t.Errorf("CreateInvite: got %q, want override builder's prefix", got)
+	}
+}
+
+// TestShareTransportSetURLBuilderNilClearsOverride confirms passing nil to
+// SetURLBuilder restores the constructor builder. Lets the controller detach
+// cleanly on shutdown without leaving a stale closure that captures a now-
+// invalid bind address.
+func TestShareTransportSetURLBuilderNilClearsOverride(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, RelativeJoinURL)
+	st.SetURLBuilder(func(token string) string { return "http://x/" + token })
+	st.SetURLBuilder(nil)
+	got, err := st.CreateInvite(context.Background(), "")
+	if err != nil {
+		t.Fatalf("CreateInvite: %v", err)
+	}
+	if !strings.HasPrefix(got, "/join/") {
+		t.Errorf("after SetURLBuilder(nil), got %q, want fallback to RelativeJoinURL", got)
+	}
+}
+
+// TestShareTransportCreateInviteDetailedReturnsBrokerMetadata confirms the
+// detailed variant surfaces the broker-issued invite ID and RFC3339 expiry
+// alongside the URL — fields the in-process controller needs to render its
+// "expires in 24h" hint without parsing the URL itself.
+func TestShareTransportCreateInviteDetailedReturnsBrokerMetadata(t *testing.T) {
+	b := newTestBroker(t)
+	st := NewShareTransport(b, RelativeJoinURL)
+	st.SetURLBuilder(func(token string) string { return "http://office/join/" + token })
+
+	details, err := st.CreateInviteDetailed(context.Background())
+	if err != nil {
+		t.Fatalf("CreateInviteDetailed: %v", err)
+	}
+	if !strings.HasPrefix(details.URL, "http://office/join/") {
+		t.Errorf("URL: got %q, want override prefix", details.URL)
+	}
+	if details.InviteID == "" {
+		t.Error("InviteID: empty, broker should have minted one")
+	}
+	if details.ExpiresAt == "" {
+		t.Error("ExpiresAt: empty, broker should have set RFC3339 timestamp")
+	}
+	if got := lastHumanInviteID(b); got != details.InviteID {
+		t.Errorf("InviteID mismatch: got %q, broker last %q", details.InviteID, got)
+	}
+}
+
+// TestBrokerShareTransportAccessor confirms SetShareTransport / ShareTransport
+// round-trip the registered handle and tolerate nil clears. The in-process
+// share controller relies on this accessor to obtain the adapter without a
+// separate plumbing channel.
+func TestBrokerShareTransportAccessor(t *testing.T) {
+	b := newTestBroker(t)
+	if got := b.ShareTransport(); got != nil {
+		t.Errorf("ShareTransport before SetShareTransport: got %v, want nil", got)
+	}
+	st := NewShareTransport(b, RelativeJoinURL)
+	b.SetShareTransport(st)
+	if got := b.ShareTransport(); got != st {
+		t.Errorf("ShareTransport after SetShareTransport: got %p, want %p", got, st)
+	}
+	b.SetShareTransport(nil)
+	if got := b.ShareTransport(); got != nil {
+		t.Errorf("ShareTransport after SetShareTransport(nil): got %v, want nil", got)
+	}
+}
+
+// TestRegisterTransportsRegistersShareHandle confirms RegisterTransports
+// publishes the constructed *ShareTransport on the broker so the in-process
+// controller can find it. Without this the controller's adapter path silently
+// degrades to the legacy HTTP path.
+func TestRegisterTransportsRegistersShareHandle(t *testing.T) {
+	b := newTestBroker(t)
+	if got := b.ShareTransport(); got != nil {
+		t.Fatalf("precondition: ShareTransport should be nil before RegisterTransports, got %v", got)
+	}
+	stop, err := RegisterTransports(b)
+	if err != nil {
+		t.Fatalf("RegisterTransports: %v", err)
+	}
+	t.Cleanup(stop)
+
+	st := b.ShareTransport()
+	if st == nil {
+		t.Fatal("ShareTransport: nil after RegisterTransports — share handle was not published")
+	}
+	// Cleanup must clear the handle so a subsequent RegisterTransports cycle
+	// starts from a known-empty state.
+	stop()
+	if got := b.ShareTransport(); got != nil {
+		t.Errorf("ShareTransport after cleanup: got %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary

Routes invite creation through the registered `ShareTransport.CreateInvite` for the in-process web share controller (`wuphf web`), closing the dual-surface that phase 4 slice C (#663) deliberately left open. The standalone `wuphf share` subcommand process keeps its HTTP path because it has no in-process broker handle.

After this PR, all three halves of the share lifecycle — invite create, admit (UpsertParticipant), and revoke fan-out — flow through `ShareTransport` for the in-process case. The legacy HTTP `/humans/invites` handler stays for the cross-process subcommand.

## Changes

### `internal/team` (contract additions)
- `ShareTransport.SetURLBuilder` — atomic override URL builder so the controller can upgrade from `RelativeJoinURL` to an absolute URL once it knows its bind address, without re-construction.
- `ShareTransport.CreateInviteDetailed` — returns broker-issued metadata (invite ID + RFC3339 expiry) alongside the URL so the controller can surface expiry hints without parsing the URL.
- `Broker.SetShareTransport` / `Broker.ShareTransport` — publish/read the registered handle.
- `RegisterTransports` installs the share handle on entry and clears it on cleanup so a subsequent register cycle starts from a known-empty state.

### `cmd/wuphf` (controller wiring)
- `webShareController.SetBroker(b)` hook called from `main.go`'s web launch wiring before the controller's first `start()`.
- New `issueInviteLocked` helper picks the adapter path when a broker handle is present, otherwise falls back to the legacy `createShareInvite` HTTP call. Both paths produce the identical `http://<bind>:<port>/join/<token>` URL via the new `shareJoinURL` formatter.

## Test plan

- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `golangci-lint run ./internal/team/... ./cmd/wuphf/...` — 0 issues
- [x] Full `internal/team` suite (~82s)
- [x] Full `cmd/wuphf` suite
- [x] `-race -count=3` on share-transport + new controller suites
- [x] `BASE_SHA=...` sleep-lint check passed
- [ ] Manual smoke: launch `wuphf web`, click Create Invite, confirm joiner can accept; restart and re-create

## Coverage

New tests:
- `TestShareTransportSetURLBuilderOverridesConstructor`
- `TestShareTransportSetURLBuilderNilClearsOverride`
- `TestShareTransportCreateInviteDetailedReturnsBrokerMetadata`
- `TestBrokerShareTransportAccessor`
- `TestRegisterTransportsRegistersShareHandle`
- `TestWebShareControllerIssueInviteUsesAdapter`
- `TestWebShareControllerIssueInviteFallsBackToHTTP`

Co-Authored-By: Claude Opus 4.7 (1M context)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-process broker support for share invites with automatic HTTP fallback and unified invite URL/expiry surface.
  * Web share controller now accepts a broker handle so running servers refresh or create invites automatically.
  * Pluggable URL builder for invite construction with runtime override support.

* **Tests**
  * Added tests for broker-backed vs HTTP-fallback invite issuance, URL-builder overrides, and transport lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->