### PR TITLE
feat(web): show host display name on joiner welcome card

### DIFF
--- a/internal/team/broker_human_share.go
+++ b/internal/team/broker_human_share.go
@@ -191,7 +191,11 @@ func (b *Broker) handleHumanMe(w http.ResponseWriter, r *http.Request) {
 	}
 	session, ok := b.humanSessionFromRequest(r)
 	if ok {
-		writeJSON(w, http.StatusOK, map[string]any{"human": humanSessionToResponse(session)})
+		body := map[string]any{"human": humanSessionToResponse(session)}
+		if name := resolveHostDisplayName(); name != "" {
+			body["host_display_name"] = name
+		}
+		writeJSON(w, http.StatusOK, body)
 		return
 	}
 	if b.requestHasBrokerAuth(r) {
@@ -205,6 +209,19 @@ func (b *Broker) handleHumanMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeShareError(w, http.StatusUnauthorized, "session_required", "Your session expired.", "Ask the host for a new team-member invite.")
+}
+
+// resolveHostDisplayName returns the host's local git identity name so the
+// joiner welcome card can read "You joined Sam's office" instead of "this
+// office". Falls back to "" when only the FallbackHumanIdentity is available
+// (fresh install, no `git config user.name`) so the web client keeps its
+// generic copy and we never surface the literal "wuphf" placeholder.
+func resolveHostDisplayName() string {
+	id := brokerHumanIdentityRegistry().Local()
+	if id.Email == FallbackHumanIdentity.Email {
+		return ""
+	}
+	return strings.TrimSpace(id.Name)
 }
 
 var errHumanInviteExpiredOrUsed = errors.New("invite expired or used")

--- a/internal/team/broker_human_share_test.go
+++ b/internal/team/broker_human_share_test.go
@@ -168,6 +168,80 @@ func TestHumanMeRejectsExpiredSessionServerSide(t *testing.T) {
 	}
 }
 
+func TestHumanMeIncludesHostDisplayNameForMemberSessions(t *testing.T) {
+	dir := t.TempDir()
+	reg := NewHumanIdentityRegistryAt(dir)
+	id, _ := buildIdentity("Sam Sender", "sam@example.com")
+	reg.mu.Lock()
+	reg.localCache = &id
+	reg.mu.Unlock()
+	setHumanIdentityRegistry(reg)
+	t.Cleanup(func() { setHumanIdentityRegistry(NewHumanIdentityRegistry()) })
+
+	b := newTestBroker(t)
+	token, _, err := b.createHumanInvite()
+	if err != nil {
+		t.Fatalf("create invite: %v", err)
+	}
+	sessionToken, _, err := b.acceptHumanInvite(token, "Mira", "browser")
+	if err != nil {
+		t.Fatalf("accept invite: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/humans/me", nil)
+	req.AddCookie(&http.Cookie{Name: humanSessionCookie, Value: sessionToken})
+	rec := httptest.NewRecorder()
+	b.handleHumanMe(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("me status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Human           humanSessionResponse `json:"human"`
+		HostDisplayName string               `json:"host_display_name"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode me: %v", err)
+	}
+	if got.HostDisplayName != "Sam Sender" {
+		t.Fatalf("host_display_name = %q, want %q (body=%s)", got.HostDisplayName, "Sam Sender", rec.Body.String())
+	}
+	if got.Human.DisplayName != "Mira" {
+		t.Fatalf("human.display_name = %q, want Mira", got.Human.DisplayName)
+	}
+}
+
+func TestHumanMeOmitsHostDisplayNameWhenIdentityIsFallback(t *testing.T) {
+	dir := t.TempDir()
+	reg := NewHumanIdentityRegistryAt(dir)
+	fallback := FallbackHumanIdentity
+	reg.mu.Lock()
+	reg.localCache = &fallback
+	reg.mu.Unlock()
+	setHumanIdentityRegistry(reg)
+	t.Cleanup(func() { setHumanIdentityRegistry(NewHumanIdentityRegistry()) })
+
+	b := newTestBroker(t)
+	token, _, err := b.createHumanInvite()
+	if err != nil {
+		t.Fatalf("create invite: %v", err)
+	}
+	sessionToken, _, err := b.acceptHumanInvite(token, "Mira", "browser")
+	if err != nil {
+		t.Fatalf("accept invite: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/humans/me", nil)
+	req.AddCookie(&http.Cookie{Name: humanSessionCookie, Value: sessionToken})
+	rec := httptest.NewRecorder()
+	b.handleHumanMe(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("me status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if bytes.Contains(rec.Body.Bytes(), []byte(`"host_display_name"`)) {
+		t.Fatalf("expected host_display_name omitted on fallback identity, got: %s", rec.Body.String())
+	}
+}
+
 func TestResetClearsHumanShareState(t *testing.T) {
 	b := newTestBroker(t)
 	token, _, err := b.createHumanInvite()

--- a/web/src/api/platform.ts
+++ b/web/src/api/platform.ts
@@ -73,6 +73,11 @@ export interface HumanMe {
     revoked_at?: string;
     last_seen_at?: string;
   };
+  // host_display_name is the host's local git-config name. The broker only
+  // emits it for member sessions when a real identity is registered, so the
+  // welcome card can swap "this office" for "Sam's office" without leaking
+  // the literal "wuphf" fallback when no identity is set.
+  host_display_name?: string;
 }
 
 // Shared TanStack Query identity for /humans/me. Both useSessionRole and

--- a/web/src/components/join/TeamMemberWelcome.test.tsx
+++ b/web/src/components/join/TeamMemberWelcome.test.tsx
@@ -54,6 +54,50 @@ describe("TeamMemberWelcome", () => {
     ).toBeInTheDocument();
   });
 
+  it("uses the host display name in the office label when available", async () => {
+    getHumanMeMock.mockResolvedValue({
+      human: {
+        role: "member",
+        display_name: "Maya",
+        invite_id: "invite-host-1",
+      },
+      host_display_name: "Sam Sender",
+    });
+    render(wrap(<TeamMemberWelcome />));
+
+    const card = await screen.findByLabelText("Team member session welcome");
+    expect(card).toHaveTextContent(/joined Sam Sender's office as/i);
+  });
+
+  it("falls back to 'this office' when host display name is missing", async () => {
+    getHumanMeMock.mockResolvedValue({
+      human: {
+        role: "member",
+        display_name: "Maya",
+        invite_id: "invite-host-2",
+      },
+    });
+    render(wrap(<TeamMemberWelcome />));
+
+    const card = await screen.findByLabelText("Team member session welcome");
+    expect(card).toHaveTextContent(/joined this office as/i);
+  });
+
+  it("falls back to 'this office' when host display name is whitespace", async () => {
+    getHumanMeMock.mockResolvedValue({
+      human: {
+        role: "member",
+        display_name: "Maya",
+        invite_id: "invite-host-3",
+      },
+      host_display_name: "   ",
+    });
+    render(wrap(<TeamMemberWelcome />));
+
+    const card = await screen.findByLabelText("Team member session welcome");
+    expect(card).toHaveTextContent(/joined this office as/i);
+  });
+
   it("does not render for a host session", async () => {
     getHumanMeMock.mockResolvedValue({
       human: {

--- a/web/src/components/join/TeamMemberWelcome.tsx
+++ b/web/src/components/join/TeamMemberWelcome.tsx
@@ -38,7 +38,7 @@ function markDismissed(key: string): void {
 }
 
 export function TeamMemberWelcome() {
-  const { role, human } = useSessionRole();
+  const { role, human, hostDisplayName } = useSessionRole();
   const key = useMemo(() => (human ? dismissalKey(human) : null), [human]);
   const [dismissedThisRender, setDismissedThisRender] = useState(false);
 
@@ -52,6 +52,10 @@ export function TeamMemberWelcome() {
   if (key && hasDismissed(key)) return null;
 
   const displayName = human.display_name?.trim() || "team member";
+  // Possessive form: "Sam" → "Sam's", "Chris" → "Chris's". Names ending in
+  // "s" still get an apostrophe-s — Strunk & White, and easier to read than
+  // "Chris' office" which trips up scan-readers on a small card.
+  const officeLabel = hostDisplayName ? `${hostDisplayName}'s office` : "this office";
 
   return (
     <aside
@@ -61,7 +65,7 @@ export function TeamMemberWelcome() {
     >
       <div className="team-welcome-body">
         <p className="team-welcome-title">
-          You&apos;re in. You joined this office as{" "}
+          You&apos;re in. You joined {officeLabel} as{" "}
           <strong>{displayName}</strong>.
         </p>
         <p className="team-welcome-copy">

--- a/web/src/hooks/useSessionRole.ts
+++ b/web/src/hooks/useSessionRole.ts
@@ -12,6 +12,7 @@ export type SessionRole = "host" | "member" | "unknown";
 export interface SessionInfo {
   role: SessionRole;
   human: HumanMe["human"] | undefined;
+  hostDisplayName: string | undefined;
   isPending: boolean;
 }
 
@@ -22,11 +23,12 @@ export function useSessionRole(): SessionInfo {
     refetchInterval: HUMAN_ME_REFETCH_MS,
   });
   const human = data?.human;
+  const hostDisplayName = data?.host_display_name?.trim() || undefined;
   const role: SessionRole =
     human?.role === "host"
       ? "host"
       : human?.role === "member"
         ? "member"
         : "unknown";
-  return { role, human, isPending };
+  return { role, human, hostDisplayName, isPending };
 }


### PR DESCRIPTION
## Summary

- Welcome card on the joiner shell now reads "You joined Sam's office as Maya" instead of "this office", using the host's local git identity name.
- Broker exposes `host_display_name` on `/humans/me` for member sessions only, and only when a real `git config user.name` is registered. Fresh installs that still resolve to `FallbackHumanIdentity` get nothing on the wire and the card keeps its old copy.
- Smallest follow-up from the #661 deferred queue — ties off the welcome card properly so members landing from a Slack/iMessage invite know whose office they are in.

## ICP scenarios

1. **Maya** opens the join URL on macOS Safari from Sam's iMessage. `/humans/me` returns `host_display_name: "Sam Sender"`. Card reads "You joined Sam Sender's office as Maya."
2. **Devesh** opens his own WUPHF on Linux Chrome before clicking the contractor invite Priya sent him. He sees both badges. Old session card said "this office" with no way to disambiguate; new card surfaces "Priya Patel's office".
3. **Fresh install host** has no `git config user.name`. Joiner sees the old "this office" copy and we never surface the literal "wuphf" placeholder.

## Test plan

- [x] `go test ./internal/team/` — green (`TestHumanMeIncludesHostDisplayNameForMemberSessions`, `TestHumanMeOmitsHostDisplayNameWhenIdentityIsFallback` added).
- [x] `bash scripts/test-web.sh` — 993/993 passing (`TeamMemberWelcome` test suite up to 8 cases including new host-name + whitespace fallback paths).
- [x] `bunx tsc --noEmit -p web/tsconfig.json` clean.
- [x] `bunx biome check` clean on touched files.
- [x] `go vet ./...` clean.
- [x] `go build ./cmd/wuphf` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team members now see personalized office labels displaying the host's name when joining (e.g., "Sam Sender's office"), with graceful fallback to "this office" when unavailable.

* **Tests**
  * Added tests to verify host display name functionality in member sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->