### PR TITLE
feat(transport): per-member presence on UpsertParticipant/DetachParticipant

### DIFF
--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -976,6 +976,8 @@ func (b *Broker) Reset() {
 	b.scheduler = nil
 	b.pendingInterview = nil
 	b.activity = make(map[string]agentActivitySnapshot)
+	b.memberPresence = make(map[string]memberPresenceRecord)
+	b.presenceKeyToSlug = make(map[string]string)
 	b.counter = 0
 	b.notificationSince = ""
 	b.insightsSince = ""

--- a/internal/team/broker.go
+++ b/internal/team/broker.go
@@ -61,7 +61,9 @@ type Broker struct {
 	messages                []channelMessage
 	agentIssues             []agentIssueRecord
 	members                 []officeMember
-	memberIndex             map[string]int // slug → index into members; guarded by mu
+	memberIndex             map[string]int                  // slug → index into members; guarded by mu
+	memberPresence          map[string]memberPresenceRecord // slug → presence; guarded by mu, populated via brokerTransportHost
+	presenceKeyToSlug       map[string]string               // "adapter:key" → slug; guarded by mu
 	channels                []teamChannel
 	sessionMode             string
 	oneOnOneAgent           string
@@ -327,6 +329,8 @@ func NewBrokerAt(statePath string) *Broker {
 		entitySubscribers:   make(map[int]chan EntityBriefSynthesizedEvent),
 		factSubscribers:     make(map[int]chan EntityFactRecordedEvent),
 		agentStreams:        make(map[string]*agentStreamBuffer),
+		memberPresence:      make(map[string]memberPresenceRecord),
+		presenceKeyToSlug:   make(map[string]string),
 		rateLimitBuckets:    make(map[string]ipRateLimitBucket),
 		rateLimitWindow:     defaultRateLimitWindow,
 		rateLimitRequests:   defaultRateLimitRequestsPerWindow,

--- a/internal/team/broker_office_members.go
+++ b/internal/team/broker_office_members.go
@@ -32,9 +32,13 @@ type officeMemberListEntry struct {
 	// "is the agent processing right now". Online tracks "does the adapter
 	// still have a live session for this slug"; LastSeenAt is preserved on
 	// flip-off so the UI can render "last seen 5m ago" for offline members.
-	// Both are zero-valued for members that no adapter has ever upserted
-	// (e.g. the built-in CEO without an openclaw provider).
-	Online     bool   `json:"online,omitempty"`
+	//
+	// Online has no omitempty: detached members must serialize as `online:false`
+	// so clients can reliably distinguish "offline" from "field missing because
+	// the member has no presence record at all". LastSeenAt keeps omitempty
+	// because empty-string is a real distinct state ("we have never seen this
+	// member online") that the UI renders differently from a stale timestamp.
+	Online     bool   `json:"online"`
 	LastSeenAt string `json:"last_seen_at,omitempty"`
 }
 

--- a/internal/team/broker_office_members.go
+++ b/internal/team/broker_office_members.go
@@ -27,6 +27,15 @@ type officeMemberListEntry struct {
 	Task         string `json:"task,omitempty"`
 	LiveActivity string `json:"liveActivity,omitempty"`
 	LastTime     string `json:"lastTime,omitempty"`
+	// Online + LastSeenAt are presence fields populated from b.memberPresence
+	// (broker_presence.go), distinct from Status/Activity above which describe
+	// "is the agent processing right now". Online tracks "does the adapter
+	// still have a live session for this slug"; LastSeenAt is preserved on
+	// flip-off so the UI can render "last seen 5m ago" for offline members.
+	// Both are zero-valued for members that no adapter has ever upserted
+	// (e.g. the built-in CEO without an openclaw provider).
+	Online     bool   `json:"online,omitempty"`
+	LastSeenAt string `json:"last_seen_at,omitempty"`
 }
 
 type officeMemberMutationBody struct {
@@ -98,6 +107,10 @@ func (b *Broker) serveOfficeMemberList(w http.ResponseWriter) {
 		}
 		if entry.Activity == "" {
 			entry.Activity = "idle"
+		}
+		if presence, ok := b.presenceForSlugLocked(member.Slug); ok {
+			entry.Online = presence.Online
+			entry.LastSeenAt = presence.LastSeenAt.UTC().Format(time.RFC3339)
 		}
 		members = append(members, entry)
 	}

--- a/internal/team/broker_presence.go
+++ b/internal/team/broker_presence.go
@@ -40,14 +40,24 @@ type memberPresenceRecord struct {
 // markMemberPresenceOnline records that an adapter session is now live for slug.
 // Caller must already hold b.mu. Updates both maps so a follow-up
 // DetachParticipant (which only carries adapter+key) can resolve the slug.
+//
+// The slug is canonicalized via normalizeChannelSlug to match findMemberLocked's
+// canonicalization (broker.go:1084) so a binding that arrives as "Eng" or
+// " eng " keys the presence record under the same "eng" the /office-members
+// read path uses. Without this canonicalization, a non-canonical Upsert would
+// create an orphan row that the API never reads and the member would render
+// as offline despite an active session. The TrimSpace + empty-check above the
+// normalize call guards against normalizeChannelSlug's "general" fallback for
+// empty inputs — an empty MemberSlug on the binding is "no member to mark
+// online", not "mark the general channel".
 func (b *Broker) markMemberPresenceOnlineLocked(slug, adapterName, sessionKey string, at time.Time) {
 	if b == nil {
 		return
 	}
-	slug = strings.TrimSpace(slug)
-	if slug == "" {
+	if strings.TrimSpace(slug) == "" {
 		return
 	}
+	slug = normalizeChannelSlug(slug)
 	if b.memberPresence == nil {
 		b.memberPresence = make(map[string]memberPresenceRecord)
 	}

--- a/internal/team/broker_presence.go
+++ b/internal/team/broker_presence.go
@@ -1,0 +1,121 @@
+package team
+
+// broker_presence.go owns per-member presence state derived from
+// transport.Host calls. UpsertParticipant flips a slug online; DetachParticipant
+// flips it offline. The /office-members handler reads this map to render a live
+// connection indicator next to each member, distinct from agentActivitySnapshot
+// (which tracks "is the agent processing right now"); presence tracks "does the
+// adapter still have a live session for this slug".
+//
+// Two maps are kept in lockstep under b.mu:
+//   - memberPresence map[slug]record: read path for the API surface.
+//   - presenceKeyToSlug map[adapter:key]slug: needed because Host.DetachParticipant
+//     only carries (adapter, key); the bridge has already cleared its own slug→key
+//     map by the time the host call fires, so the host needs its own reverse
+//     lookup to know which slug to mark offline.
+//
+// Presence is in-memory only — restart re-derives it from the next Upsert wave
+// (each adapter calls UpsertParticipant on bootstrap-replay or first message).
+// Persisting it would invite stale "online" indicators after a crash; the
+// adapter-driven re-flip is the source of truth.
+
+import (
+	"strings"
+	"time"
+)
+
+// memberPresenceRecord is the per-slug presence snapshot. Online flips on
+// UpsertParticipant and clears on DetachParticipant; LastSeenAt is bumped on
+// every Upsert so the UI can show "last seen 5m ago" when a member is offline.
+// AdapterName + SessionKey identify which adapter session last touched the
+// member — useful for diagnostics and for the future case where a single slug
+// might be served by more than one adapter.
+type memberPresenceRecord struct {
+	Online      bool
+	LastSeenAt  time.Time
+	AdapterName string
+	SessionKey  string
+}
+
+// markMemberPresenceOnline records that an adapter session is now live for slug.
+// Caller must already hold b.mu. Updates both maps so a follow-up
+// DetachParticipant (which only carries adapter+key) can resolve the slug.
+func (b *Broker) markMemberPresenceOnlineLocked(slug, adapterName, sessionKey string, at time.Time) {
+	if b == nil {
+		return
+	}
+	slug = strings.TrimSpace(slug)
+	if slug == "" {
+		return
+	}
+	if b.memberPresence == nil {
+		b.memberPresence = make(map[string]memberPresenceRecord)
+	}
+	if b.presenceKeyToSlug == nil {
+		b.presenceKeyToSlug = make(map[string]string)
+	}
+	prev := b.memberPresence[slug]
+	if prev.AdapterName != "" && prev.SessionKey != "" &&
+		(prev.AdapterName != adapterName || prev.SessionKey != sessionKey) {
+		// A different adapter session previously held this slug. Clear its
+		// reverse-lookup entry so a stale Detach against the old key cannot
+		// flip the slug offline once the new session is live.
+		delete(b.presenceKeyToSlug, presenceLookupKey(prev.AdapterName, prev.SessionKey))
+	}
+	b.memberPresence[slug] = memberPresenceRecord{
+		Online:      true,
+		LastSeenAt:  at,
+		AdapterName: adapterName,
+		SessionKey:  sessionKey,
+	}
+	b.presenceKeyToSlug[presenceLookupKey(adapterName, sessionKey)] = slug
+}
+
+// markMemberPresenceOfflineByKey resolves slug from the adapter+key reverse map
+// and flips that slug offline. LastSeenAt is preserved so the UI can render a
+// "last online" timestamp instead of erasing the history. Caller must already
+// hold b.mu. Returns the slug that was cleared (empty if no match — useful for
+// tests and for diagnostics).
+func (b *Broker) markMemberPresenceOfflineByKeyLocked(adapterName, sessionKey string) string {
+	if b == nil || b.presenceKeyToSlug == nil {
+		return ""
+	}
+	lookup := presenceLookupKey(adapterName, sessionKey)
+	slug, ok := b.presenceKeyToSlug[lookup]
+	if !ok {
+		return ""
+	}
+	delete(b.presenceKeyToSlug, lookup)
+	if b.memberPresence == nil {
+		return slug
+	}
+	rec := b.memberPresence[slug]
+	if rec.AdapterName != adapterName || rec.SessionKey != sessionKey {
+		// The reverse map pointed at this slug, but the slug's record has
+		// already moved on to another session. Don't clobber the newer
+		// session's Online flag — the reverse-map entry is just stale.
+		return slug
+	}
+	rec.Online = false
+	b.memberPresence[slug] = rec
+	return slug
+}
+
+// presenceForSlug returns a copy of the presence record for slug. Caller must
+// already hold b.mu. The bool result is false when no record exists (e.g. the
+// slug has never been touched by an adapter); callers should treat this as
+// "presence unknown", not "offline".
+func (b *Broker) presenceForSlugLocked(slug string) (memberPresenceRecord, bool) {
+	if b == nil || b.memberPresence == nil {
+		return memberPresenceRecord{}, false
+	}
+	rec, ok := b.memberPresence[slug]
+	return rec, ok
+}
+
+// presenceLookupKey builds the composite key used in presenceKeyToSlug.
+// Adapter names are stable Go identifiers per Transport.Name() so a colon
+// separator is collision-free.
+func presenceLookupKey(adapterName, sessionKey string) string {
+	return adapterName + ":" + sessionKey
+}

--- a/internal/team/broker_presence_test.go
+++ b/internal/team/broker_presence_test.go
@@ -141,6 +141,32 @@ func TestHostDetachParticipantUnknownKeyIsNoop(t *testing.T) {
 	}
 }
 
+// TestHostUpsertParticipantUnknownAdapterErrorsAtMemberScope asserts that an
+// adapter without a matching DetachParticipant allowlist entry is rejected at
+// member scope. Without this symmetry an Upsert could set online=true with no
+// valid detach path, leaving a permanent stale "online" indicator. The
+// allowlists in Upsert and Detach must move together — this test fails first
+// when a future adapter is added to one without the other.
+func TestHostUpsertParticipantUnknownAdapterErrorsAtMemberScope(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+	err := host.UpsertParticipant(context.Background(),
+		transport.Participant{AdapterName: "future-bound", Key: "k"},
+		transport.Binding{Scope: transport.ScopeMember, MemberSlug: "eng"},
+	)
+	if err == nil {
+		t.Fatal("UpsertParticipant with unknown adapter at member scope: got nil, want error")
+	}
+	if !strings.Contains(err.Error(), "unsupported adapter") {
+		t.Errorf("error message missing context: %v", err)
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.memberPresence) != 0 {
+		t.Errorf("memberPresence got rows from a rejected upsert: %d", len(b.memberPresence))
+	}
+}
+
 // TestHostDetachParticipantUnknownAdapterErrors asserts that a misnamed
 // adapter (typo, version skew) surfaces loudly instead of silently dropping
 // the call. A silent no-op here would mask a regression where an adapter is

--- a/internal/team/broker_presence_test.go
+++ b/internal/team/broker_presence_test.go
@@ -55,22 +55,28 @@ func TestHostUpsertParticipantMarksMemberOnline(t *testing.T) {
 // record. Telegram attribution lives in PostInboundSurfaceMessage by display
 // name; admitted humans have their own LastSeenAt on humanSession. Touching
 // memberPresence for either would lie about who is an office member.
+//
+// Each case constructs its own broker so a leak in case N cannot inflate
+// memberPresence for case N+1 — failures bisect to the responsible case
+// instead of cascading. The "member with empty slug" case uses
+// openclawAdapterName (not shareAdapterName) because the intent is a
+// member-scope binding with an empty slug; share is office-scope by contract.
 func TestHostUpsertParticipantSkipsNonMemberScope(t *testing.T) {
-	b := newTestBroker(t)
-	host := &brokerTransportHost{broker: b}
-
 	cases := []struct {
 		name    string
+		adapter string
 		binding transport.Binding
 	}{
-		{"office (share)", transport.Binding{Scope: transport.ScopeOffice, MemberSlug: "team-member"}},
-		{"channel (telegram)", transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: "general"}},
-		{"member with empty slug", transport.Binding{Scope: transport.ScopeMember, MemberSlug: ""}},
+		{"office (share)", shareAdapterName, transport.Binding{Scope: transport.ScopeOffice, MemberSlug: "team-member"}},
+		{"channel (telegram)", "telegram", transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: "general"}},
+		{"member with empty slug", openclawAdapterName, transport.Binding{Scope: transport.ScopeMember, MemberSlug: ""}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			b := newTestBroker(t)
+			host := &brokerTransportHost{broker: b}
 			err := host.UpsertParticipant(context.Background(),
-				transport.Participant{AdapterName: shareAdapterName, Key: "session-x", DisplayName: "x"},
+				transport.Participant{AdapterName: tc.adapter, Key: "session-x", DisplayName: "x"},
 				tc.binding,
 			)
 			if err != nil {

--- a/internal/team/broker_presence_test.go
+++ b/internal/team/broker_presence_test.go
@@ -1,0 +1,243 @@
+package team
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nex-crm/wuphf/internal/team/transport"
+)
+
+// TestHostUpsertParticipantMarksMemberOnline asserts that a member-bound
+// UpsertParticipant call (the openclaw shape) flips presence on for the slug
+// declared in the binding. The reverse-lookup map is populated as a side effect
+// so a follow-up DetachParticipant carrying only (adapter, key) can resolve
+// back to the slug.
+func TestHostUpsertParticipantMarksMemberOnline(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+
+	before := time.Now()
+	err := host.UpsertParticipant(context.Background(),
+		transport.Participant{AdapterName: openclawAdapterName, Key: "session-abc", DisplayName: "eng"},
+		transport.Binding{Scope: transport.ScopeMember, MemberSlug: "eng", ChannelSlug: "general"},
+	)
+	if err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	b.mu.Lock()
+	rec, ok := b.presenceForSlugLocked("eng")
+	keyLookup := b.presenceKeyToSlug[presenceLookupKey(openclawAdapterName, "session-abc")]
+	b.mu.Unlock()
+	if !ok {
+		t.Fatalf("presence record missing for slug %q", "eng")
+	}
+	if !rec.Online {
+		t.Errorf("Online: got false, want true")
+	}
+	if rec.LastSeenAt.Before(before) {
+		t.Errorf("LastSeenAt %v is before test start %v", rec.LastSeenAt, before)
+	}
+	if rec.AdapterName != openclawAdapterName || rec.SessionKey != "session-abc" {
+		t.Errorf("adapter/key: got (%q, %q) want (%q, %q)", rec.AdapterName, rec.SessionKey, openclawAdapterName, "session-abc")
+	}
+	if keyLookup != "eng" {
+		t.Errorf("presenceKeyToSlug: got %q, want %q", keyLookup, "eng")
+	}
+}
+
+// TestHostUpsertParticipantSkipsNonMemberScope asserts that office-bound (share)
+// and channel-bound (telegram) participants do not produce a member-presence
+// record. Telegram attribution lives in PostInboundSurfaceMessage by display
+// name; admitted humans have their own LastSeenAt on humanSession. Touching
+// memberPresence for either would lie about who is an office member.
+func TestHostUpsertParticipantSkipsNonMemberScope(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+
+	cases := []struct {
+		name    string
+		binding transport.Binding
+	}{
+		{"office (share)", transport.Binding{Scope: transport.ScopeOffice, MemberSlug: "team-member"}},
+		{"channel (telegram)", transport.Binding{Scope: transport.ScopeChannel, ChannelSlug: "general"}},
+		{"member with empty slug", transport.Binding{Scope: transport.ScopeMember, MemberSlug: ""}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := host.UpsertParticipant(context.Background(),
+				transport.Participant{AdapterName: shareAdapterName, Key: "session-x", DisplayName: "x"},
+				tc.binding,
+			)
+			if err != nil {
+				t.Fatalf("UpsertParticipant: %v", err)
+			}
+			b.mu.Lock()
+			n := len(b.memberPresence)
+			b.mu.Unlock()
+			if n != 0 {
+				t.Errorf("memberPresence size: got %d, want 0 (binding %+v should not produce a record)", n, tc.binding)
+			}
+		})
+	}
+}
+
+// TestHostDetachParticipantClearsOnlinePreservesLastSeen asserts that detach
+// flips Online off but leaves LastSeenAt intact so the API can render a
+// "last seen 5m ago" indicator. The reverse-lookup entry is removed so a
+// second Detach with the same (adapter, key) is a clean no-op.
+func TestHostDetachParticipantClearsOnlinePreservesLastSeen(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+
+	if err := host.UpsertParticipant(context.Background(),
+		transport.Participant{AdapterName: openclawAdapterName, Key: "session-abc"},
+		transport.Binding{Scope: transport.ScopeMember, MemberSlug: "eng"},
+	); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+	b.mu.Lock()
+	upsertSeen := b.memberPresence["eng"].LastSeenAt
+	b.mu.Unlock()
+
+	if err := host.DetachParticipant(context.Background(), openclawAdapterName, "session-abc"); err != nil {
+		t.Fatalf("DetachParticipant: %v", err)
+	}
+
+	b.mu.Lock()
+	rec := b.memberPresence["eng"]
+	_, lookupRemains := b.presenceKeyToSlug[presenceLookupKey(openclawAdapterName, "session-abc")]
+	b.mu.Unlock()
+
+	if rec.Online {
+		t.Errorf("Online after detach: got true, want false")
+	}
+	if !rec.LastSeenAt.Equal(upsertSeen) {
+		t.Errorf("LastSeenAt mutated by detach: was %v, now %v (must preserve)", upsertSeen, rec.LastSeenAt)
+	}
+	if lookupRemains {
+		t.Errorf("presenceKeyToSlug entry not cleared after detach")
+	}
+}
+
+// TestHostDetachParticipantUnknownKeyIsNoop asserts that a Detach without a
+// prior Upsert (e.g. an adapter sending shutdown teardown for a session that
+// never produced a message) returns nil cleanly. Surfacing this as an error
+// would cascade into adapter shutdown noise that no operator can act on.
+func TestHostDetachParticipantUnknownKeyIsNoop(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+	if err := host.DetachParticipant(context.Background(), openclawAdapterName, "never-upserted"); err != nil {
+		t.Fatalf("DetachParticipant for unknown key: %v (want nil)", err)
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.memberPresence) != 0 {
+		t.Errorf("memberPresence got rows from a no-op detach: %d", len(b.memberPresence))
+	}
+}
+
+// TestHostDetachParticipantUnknownAdapterErrors asserts that a misnamed
+// adapter (typo, version skew) surfaces loudly instead of silently dropping
+// the call. A silent no-op here would mask a regression where an adapter is
+// renamed without updating the host's switch.
+func TestHostDetachParticipantUnknownAdapterErrors(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+	err := host.DetachParticipant(context.Background(), "unknown-adapter", "k")
+	if err == nil {
+		t.Fatal("DetachParticipant with unknown adapter: got nil, want error")
+	}
+	if !strings.Contains(err.Error(), "unsupported adapter") {
+		t.Errorf("error message missing context: %v", err)
+	}
+}
+
+// TestHostUpsertReplacingSessionKeyClearsOldReverseEntry asserts that when a
+// slug's session key changes (reconnect with a new gateway session) the old
+// reverse-map entry is cleared so a stale Detach against the old key cannot
+// flip the slug offline once the new session is live. Without this guard, an
+// in-flight detach from the prior session would race the new upsert.
+func TestHostUpsertReplacingSessionKeyClearsOldReverseEntry(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+
+	if err := host.UpsertParticipant(context.Background(),
+		transport.Participant{AdapterName: openclawAdapterName, Key: "old-session"},
+		transport.Binding{Scope: transport.ScopeMember, MemberSlug: "eng"},
+	); err != nil {
+		t.Fatalf("first UpsertParticipant: %v", err)
+	}
+	if err := host.UpsertParticipant(context.Background(),
+		transport.Participant{AdapterName: openclawAdapterName, Key: "new-session"},
+		transport.Binding{Scope: transport.ScopeMember, MemberSlug: "eng"},
+	); err != nil {
+		t.Fatalf("second UpsertParticipant: %v", err)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, stillThere := b.presenceKeyToSlug[presenceLookupKey(openclawAdapterName, "old-session")]; stillThere {
+		t.Errorf("stale reverse-map entry for old-session not cleared after key swap")
+	}
+	if got := b.presenceKeyToSlug[presenceLookupKey(openclawAdapterName, "new-session")]; got != "eng" {
+		t.Errorf("new-session reverse entry: got %q, want %q", got, "eng")
+	}
+	rec := b.memberPresence["eng"]
+	if rec.SessionKey != "new-session" || !rec.Online {
+		t.Errorf("presence record after key swap: %+v", rec)
+	}
+}
+
+// TestOfficeMembersListIncludesPresence is the API-surface test: after an
+// adapter UpsertParticipant flips presence on, /office-members must surface
+// online=true and a non-empty last_seen_at for that slug.
+func TestOfficeMembersListIncludesPresence(t *testing.T) {
+	b := newTestBroker(t)
+
+	// CEO is seeded by ensureDefaultOfficeMembersLocked, so we can mark it
+	// online without going through the office-member create flow.
+	host := &brokerTransportHost{broker: b}
+	if err := host.UpsertParticipant(context.Background(),
+		transport.Participant{AdapterName: openclawAdapterName, Key: "session-ceo"},
+		transport.Binding{Scope: transport.ScopeMember, MemberSlug: "ceo"},
+	); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	b.serveOfficeMemberList(rec)
+	if rec.Code != 200 {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+
+	var resp struct {
+		Members []officeMemberListEntry `json:"members"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var ceo *officeMemberListEntry
+	for i := range resp.Members {
+		if resp.Members[i].Slug == "ceo" {
+			ceo = &resp.Members[i]
+			break
+		}
+	}
+	if ceo == nil {
+		t.Fatal("ceo not in /office-members response")
+	}
+	if !ceo.Online {
+		t.Errorf("ceo.online: got false, want true after UpsertParticipant")
+	}
+	if ceo.LastSeenAt == "" {
+		t.Errorf("ceo.last_seen_at: got empty, want RFC3339 timestamp")
+	}
+	if _, err := time.Parse(time.RFC3339, ceo.LastSeenAt); err != nil {
+		t.Errorf("last_seen_at not RFC3339: %v (got %q)", err, ceo.LastSeenAt)
+	}
+}

--- a/internal/team/broker_presence_test.go
+++ b/internal/team/broker_presence_test.go
@@ -241,3 +241,106 @@ func TestOfficeMembersListIncludesPresence(t *testing.T) {
 		t.Errorf("last_seen_at not RFC3339: %v (got %q)", err, ceo.LastSeenAt)
 	}
 }
+
+// TestOfficeMembersListSerializesOnlineFalseExplicitly asserts that members
+// without a presence record (and detached members) serialize with an explicit
+// `online: false` rather than omitting the field. Clients must be able to
+// distinguish "offline" from "field missing because the build is older" — the
+// difference matters for any UI that wants to render an offline indicator
+// rather than silently no-op when presence data is absent.
+func TestOfficeMembersListSerializesOnlineFalseExplicitly(t *testing.T) {
+	b := newTestBroker(t)
+
+	rec := httptest.NewRecorder()
+	b.serveOfficeMemberList(rec)
+	if rec.Code != 200 {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+
+	// Decode into a generic shape so we can assert on the JSON key's presence,
+	// not just the Go zero value (which a typed decode would hide).
+	var raw struct {
+		Members []map[string]any `json:"members"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(raw.Members) == 0 {
+		t.Fatal("no members in response")
+	}
+	for _, m := range raw.Members {
+		online, ok := m["online"]
+		if !ok {
+			t.Errorf("member %q: missing `online` key — omitempty regression on offline members", m["slug"])
+			continue
+		}
+		if online != false {
+			t.Errorf("member %q: online=%v, want false (no Upsert was issued)", m["slug"], online)
+		}
+	}
+}
+
+// TestHostUpsertCanonicalizesNonCanonicalSlug asserts that a binding arriving
+// with a mixed-case or trim-required MemberSlug keys the presence record
+// under the same canonical slug the /office-members read path uses. Without
+// this canonicalization, an "Eng" Upsert would create an orphan presence row
+// the API never reads, and the member would render as offline despite an
+// active session.
+func TestHostUpsertCanonicalizesNonCanonicalSlug(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+
+	if err := host.UpsertParticipant(context.Background(),
+		transport.Participant{AdapterName: openclawAdapterName, Key: "session-1"},
+		transport.Binding{Scope: transport.ScopeMember, MemberSlug: "  Eng  "},
+	); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.memberPresence["eng"]; !ok {
+		gotKeys := make([]string, 0, len(b.memberPresence))
+		for k := range b.memberPresence {
+			gotKeys = append(gotKeys, k)
+		}
+		t.Errorf("memberPresence missing canonical key %q (got keys: %v)", "eng", gotKeys)
+	}
+	if _, ok := b.memberPresence["  Eng  "]; ok {
+		t.Errorf("memberPresence contains uncanonicalized key %q — canonicalization regressed", "  Eng  ")
+	}
+}
+
+// TestResetClearsPresenceMaps asserts that /workspace/reset clears the
+// presence maps so the rebuilt default roster does not surface stale `online`
+// or `last_seen_at` from the prior session. Without this guard, a reset
+// followed by a fresh launch shows lingering "online" indicators until
+// another adapter detach/upsert arrives or the process restarts.
+func TestResetClearsPresenceMaps(t *testing.T) {
+	b := newTestBroker(t)
+	host := &brokerTransportHost{broker: b}
+
+	if err := host.UpsertParticipant(context.Background(),
+		transport.Participant{AdapterName: openclawAdapterName, Key: "session-x"},
+		transport.Binding{Scope: transport.ScopeMember, MemberSlug: "ceo"},
+	); err != nil {
+		t.Fatalf("UpsertParticipant: %v", err)
+	}
+	b.mu.Lock()
+	if _, ok := b.memberPresence["ceo"]; !ok {
+		b.mu.Unlock()
+		t.Fatal("precondition: presence record not stored")
+	}
+	b.mu.Unlock()
+
+	b.Reset()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.memberPresence) != 0 {
+		t.Errorf("memberPresence after Reset: got %d rows, want 0", len(b.memberPresence))
+	}
+	if len(b.presenceKeyToSlug) != 0 {
+		t.Errorf("presenceKeyToSlug after Reset: got %d rows, want 0", len(b.presenceKeyToSlug))
+	}
+}

--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -4,27 +4,30 @@ package team
 // only file in internal/team that imports internal/team/transport — the
 // one-way compile boundary (team → transport) is enforced here.
 //
-// ReceiveMessage and UpsertParticipant route to PostInboundSurfaceMessage for
-// channel-bound (Telegram) adapters; UpsertParticipant is a no-op there because
-// participant attribution is handled inside PostInboundSurfaceMessage by
-// display name. The share adapter takes the same no-op path: admitted-human
-// identity already exists in the broker as a humanSession before the adapter
-// fires the contract call, so UpsertParticipant just confirms the contract
-// without duplicating broker state.
+// ReceiveMessage routes inbound channel-bound traffic to PostInboundSurfaceMessage.
+//
+// UpsertParticipant flips per-member presence on for member-bound bindings
+// (binding.Scope == ScopeMember and binding.MemberSlug non-empty). Channel-bound
+// (Telegram) and office-bound (share) bindings are presence-irrelevant and take
+// a no-op path: telegram participants aren't members, and admitted-human
+// presence is tracked separately via humanSession.LastSeenAt + RevokedAt.
+//
+// DetachParticipant flips per-member presence off by reverse-looking-up the
+// adapter+key pair against the slug map populated on UpsertParticipant. The
+// bridge has already cleared its own slug binding by the time this fires, so
+// the broker maintains its own reverse map (broker_presence.go) — the host
+// cannot ask the bridge.
 //
 // RevokeParticipant routes the office-bound (human-share) revoke flow to
 // Broker.revokeHumanSession so an adapter calling Host.RevokeParticipant after
 // an invite is revoked tears down the corresponding session.
-//
-// DetachParticipant routes the member-bound (openclaw) detach flow to a
-// session-end notice. The broker has no per-member presence flag today, so the
-// hook validates the call and returns nil — future presence work plugs in
-// here without further adapter changes.
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/nex-crm/wuphf/internal/team/transport"
 )
@@ -53,31 +56,63 @@ func (h *brokerTransportHost) ReceiveMessage(_ context.Context, msg transport.Me
 	return nil
 }
 
-// UpsertParticipant registers an external identity. For channel-bound adapters
-// (Telegram) participant attribution is handled inside PostInboundSurfaceMessage
-// by display name, so the call is a no-op. For the office-bound share adapter
-// the admitted-human record already exists in the broker as a humanSession by
-// the time this fires (see broker_human_share.handleHumanInviteAccept), so the
-// contract is satisfied without a duplicate broker write. Member-bound
-// adapters (OpenClaw) take the same no-op path until the broker grows a
-// per-member registration store.
-func (h *brokerTransportHost) UpsertParticipant(_ context.Context, _ transport.Participant, _ transport.Binding) error {
+// UpsertParticipant registers an external identity. For member-bound bindings
+// (openclaw today, future member-bound adapters tomorrow) the call flips the
+// slug's presence on and stamps LastSeenAt. Channel-bound (Telegram)
+// participants and office-bound (share) admitted humans are presence-irrelevant
+// here: telegram attribution lives in PostInboundSurfaceMessage by display
+// name, and humanSession owns admitted-human presence via its own LastSeenAt.
+//
+// A nil broker is rejected so a misconfigured host fails loudly rather than
+// silently dropping presence updates. A binding without ScopeMember/MemberSlug
+// is treated as "no member to mark online" and returns nil — the contract is
+// satisfied; nothing to do.
+func (h *brokerTransportHost) UpsertParticipant(_ context.Context, p transport.Participant, b transport.Binding) error {
+	if h == nil || h.broker == nil {
+		return errors.New("transport: UpsertParticipant: nil broker")
+	}
+	if b.Scope != transport.ScopeMember {
+		return nil
+	}
+	slug := strings.TrimSpace(b.MemberSlug)
+	if slug == "" {
+		return nil
+	}
+	adapter := strings.TrimSpace(p.AdapterName)
+	if adapter == "" {
+		return fmt.Errorf("transport: UpsertParticipant: empty AdapterName for slug %q", slug)
+	}
+	key := strings.TrimSpace(p.Key)
+	if key == "" {
+		return fmt.Errorf("transport: UpsertParticipant: empty Key for slug %q (adapter=%q)", slug, adapter)
+	}
+	h.broker.mu.Lock()
+	h.broker.markMemberPresenceOnlineLocked(slug, adapter, key, time.Now())
+	h.broker.mu.Unlock()
 	return nil
 }
 
-// DetachParticipant marks a participant as offline. Recognized adapters
-// (openclaw) take a no-op success path: the bridge has already cleared its
-// own slug binding by the time this is called and the broker has no
-// per-member presence flag yet. Wiring the call site now means future
-// presence work can extend this without touching adapters. An unknown
-// adapterName is rejected so a misnamed call surfaces loudly rather than
-// silently no-op'ing.
+// DetachParticipant marks a participant offline. Resolves slug from the
+// (adapter, key) pair via the reverse map populated on UpsertParticipant. The
+// bridge has already cleared its own slug↔key binding by the time this fires,
+// so the broker cannot ask the bridge — it owns its own reverse lookup. An
+// unknown (adapter, key) pair is not an error: it just means the host never
+// saw an UpsertParticipant for that pair (e.g. the adapter sends Detach on
+// shutdown for a session that never produced a message).
+//
+// LastSeenAt is preserved on flip-off so the API can render "last seen 5m
+// ago"; only Online flips. An unknown adapterName is rejected to keep
+// misnamed calls visible. A nil broker is rejected so a misconfigured host
+// fails loudly rather than silently dropping detach updates.
 func (h *brokerTransportHost) DetachParticipant(_ context.Context, adapterName, key string) error {
 	if h == nil || h.broker == nil {
 		return errors.New("transport: DetachParticipant: nil broker")
 	}
 	switch adapterName {
 	case openclawAdapterName:
+		h.broker.mu.Lock()
+		h.broker.markMemberPresenceOfflineByKeyLocked(adapterName, key)
+		h.broker.mu.Unlock()
 		return nil
 	default:
 		return fmt.Errorf("transport: DetachParticipant: unsupported adapter %q (key=%q)", adapterName, key)

--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -74,10 +74,16 @@ func (h *brokerTransportHost) UpsertParticipant(_ context.Context, p transport.P
 	if b.Scope != transport.ScopeMember {
 		return nil
 	}
-	slug := strings.TrimSpace(b.MemberSlug)
-	if slug == "" {
+	// Trim and reject empty before canonicalizing: normalizeChannelSlug falls
+	// back to "general" on empty input, which would silently mark the general
+	// channel as online for an empty MemberSlug binding. The helper applies
+	// the same canonicalization on its end, but doing it here too keeps the
+	// empty-check above the adapter/key validation so the error messages
+	// report a non-empty slug.
+	if strings.TrimSpace(b.MemberSlug) == "" {
 		return nil
 	}
+	slug := normalizeChannelSlug(b.MemberSlug)
 	adapter := strings.TrimSpace(p.AdapterName)
 	if adapter == "" {
 		return fmt.Errorf("transport: UpsertParticipant: empty AdapterName for slug %q", slug)

--- a/internal/team/broker_transport.go
+++ b/internal/team/broker_transport.go
@@ -67,6 +67,13 @@ func (h *brokerTransportHost) ReceiveMessage(_ context.Context, msg transport.Me
 // silently dropping presence updates. A binding without ScopeMember/MemberSlug
 // is treated as "no member to mark online" and returns nil — the contract is
 // satisfied; nothing to do.
+//
+// Adapter validation mirrors DetachParticipant's allowlist: only adapters that
+// also have a valid detach path are accepted at member scope. Without this
+// symmetry, a non-openclaw member-scope upsert would set online=true with no
+// way to ever clear it (DetachParticipant would error on the unknown adapter
+// name), leaving a permanent stale "online" indicator. New member-bound
+// adapters must be added to BOTH switches together.
 func (h *brokerTransportHost) UpsertParticipant(_ context.Context, p transport.Participant, b transport.Binding) error {
 	if h == nil || h.broker == nil {
 		return errors.New("transport: UpsertParticipant: nil broker")
@@ -87,6 +94,12 @@ func (h *brokerTransportHost) UpsertParticipant(_ context.Context, p transport.P
 	adapter := strings.TrimSpace(p.AdapterName)
 	if adapter == "" {
 		return fmt.Errorf("transport: UpsertParticipant: empty AdapterName for slug %q", slug)
+	}
+	switch adapter {
+	case openclawAdapterName:
+		// recognized member-bound adapter; falls through
+	default:
+		return fmt.Errorf("transport: UpsertParticipant: unsupported adapter %q at member scope (slug=%q)", adapter, slug)
 	}
 	key := strings.TrimSpace(p.Key)
 	if key == "" {


### PR DESCRIPTION
## Summary

Closes a real gap in the transport contract: `brokerTransportHost.UpsertParticipant` and `DetachParticipant` were no-ops with comments admitting "no per-member presence flag yet." This PR makes them flip a real `Online` + `LastSeenAt` per member slug, surfaced via two new fields on the `/office-members` JSON response.

## What changed

**`internal/team/broker_presence.go` (new)**
- `memberPresenceRecord{Online, LastSeenAt, AdapterName, SessionKey}`
- `markMemberPresenceOnlineLocked` / `markMemberPresenceOfflineByKeyLocked` / `presenceForSlugLocked` — all `mu`-locked.
- Reverse map `presenceKeyToSlug["adapter:key"] → slug` so `DetachParticipant` (which only carries adapter+key) can resolve the slug after the openclaw bridge has already cleared its own slug↔key binding.
- Key-swap guard: re-upsert with a different session key clears the old reverse entry so a stale Detach from the prior session cannot race the new Upsert.

**`internal/team/broker_transport.go`**
- `UpsertParticipant` now flips presence on for `Scope == ScopeMember && MemberSlug != ""`. Office (share) and channel (telegram) bindings stay no-ops: telegram attribution lives in `PostInboundSurfaceMessage` by display name, and `humanSession` already owns admitted-human presence via its own `LastSeenAt + RevokedAt`.
- `DetachParticipant` flips Online off but preserves `LastSeenAt` so the UI can show "last seen 5m ago" for offline members. Unknown adapter names still error (loud); unknown (adapter, key) pairs are clean no-ops (an adapter sending teardown for a session that never produced a message should not surface as an error).

**`internal/team/broker.go`**
- Two new map fields on `Broker`, initialized in `NewBrokerAt`. In-memory only; not persisted (next Upsert wave re-derives presence on restart, so a crash cannot leave stale "online" indicators).

**`internal/team/broker_office_members.go`**
- `officeMemberListEntry` adds `online` (bool) + `last_seen_at` (RFC3339 string), populated from `b.presenceForSlugLocked` inside the existing `b.mu` window.

## Tests

`internal/team/broker_presence_test.go` (new), 6 host tests + 1 API-surface test:
- `TestHostUpsertParticipantMarksMemberOnline` — happy path: openclaw upsert → presence record + reverse map populated.
- `TestHostUpsertParticipantSkipsNonMemberScope` — table over share/telegram/empty-slug; asserts `memberPresence` stays empty.
- `TestHostDetachParticipantClearsOnlinePreservesLastSeen` — detach flips Online off, leaves LastSeenAt unchanged, removes reverse entry.
- `TestHostDetachParticipantUnknownKeyIsNoop` — Detach without prior Upsert returns nil; presence map stays empty.
- `TestHostDetachParticipantUnknownAdapterErrors` — typo in adapter name surfaces loudly.
- `TestHostUpsertReplacingSessionKeyClearsOldReverseEntry` — key-swap race protection.
- `TestOfficeMembersListIncludesPresence` — full HTTP-shape assertion: `/office-members` JSON includes `online: true` + valid RFC3339 `last_seen_at` after Upsert.

## Why this slice (and not the others)

Of the three real leftovers in the transport contract migration after Phase 4 closed:
1. ✅ **This PR** — closes the no-op `UpsertParticipant/DetachParticipant` gap with real product value (presence indicators).
2. **ShareTransport.Send is a no-op** — needs a push protocol design (WebSocket vs SSE, auth model, reconnect, message replay). Not a one-PR slice.
3. **Telegram outbound bypasses Host-driven dispatch** — should follow (2) once the Send pattern is settled.

This is the only one of the three that's narrow enough for a single review.

## Follow-up (separate PR)

Web frontend rendering — small dot next to office members in the sidebar, "last seen Xm ago" on the member card. The API now carries the data; the web change is purely visual and isolates the design choices (color, animation, copy) from this contract change.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `bash scripts/test-go.sh ./internal/team` (full team package green, 98s)
- [x] `golangci-lint run ./internal/team/...` (0 issues)
- [x] All 7 new tests pass with `-race`
- [ ] Manual: launch `wuphf-dev`, hire an openclaw agent, observe `/office-members` returns `online: true` for that slug; restart the agent's session and observe `online` goes false then true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Office member list now shows real-time online/offline status and last-seen timestamps.
  * Presence tracking now maintains per-member online state and session mappings, updating when participants connect, disconnect, or replace sessions.

* **Tests**
  * Added unit tests covering presence creation, session replacement, detach/offline behavior, canonicalization, reset clearing, and office-member list presence reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->