### PR TITLE
follow-ups: agent-event-bubbles deferred TODOs from PR #664

### DIFF
--- a/internal/team/broker_bootstrap_human_posted_test.go
+++ b/internal/team/broker_bootstrap_human_posted_test.go
@@ -1,0 +1,201 @@
+package team
+
+// Tests for bootstrapHumanHasPostedLocked — the function that re-seeds
+// b.humanHasPosted from the persisted message log when a broker restarts.
+// Four cases:
+//
+//  1. Empty log → restart → humanHasPosted == false.
+//  2. Human message in log → restart → humanHasPosted == true.
+//  3. Empty/whitespace From → restart → humanHasPosted stays false
+//     (pins the adversarial-fix: isHumanMessageSender("") returns true,
+//     but the empty-From guard in appendMessageLocked and bootstrap must
+//     prevent a false positive).
+//  4. Agent-only message in log → restart → humanHasPosted == false.
+//
+// Each test uses the standard newTestBroker/saveLocked/reloadedBroker
+// pattern (same as TestBrokerSurfaceMetadataPersists and friends) so
+// there is no need to touch production code.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// metaHumanHasPosted GETs /office-members on the given broker via the
+// real handler and decodes meta.humanHasPosted from the JSON response.
+// It is a strict helper: any unexpected status or decode failure is
+// fatal, not just an error.
+func metaHumanHasPosted(t *testing.T, b *Broker) bool {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	b.handleOfficeMembers(rec, httptest.NewRequest(http.MethodGet, "/office-members", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("handleOfficeMembers: expected 200, got %d (body=%s)", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		Meta struct {
+			HumanHasPosted bool `json:"humanHasPosted"`
+		} `json:"meta"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode /office-members response: %v (body=%s)", err, rec.Body.String())
+	}
+	return resp.Meta.HumanHasPosted
+}
+
+// seedAndReload saves the broker state to disk (using the standard
+// saveLocked path under b.mu) and returns a fresh broker that fully
+// replicates a production restart: NewBrokerAt on the same path →
+// loadState → bootstrapHumanHasPostedLocked. This is the "restart" in
+// all four test cases.
+//
+// Why not use reloadedBroker? reloadedBroker calls NewBrokerAt (which
+// runs bootstrapHumanHasPostedLocked against an empty message slice
+// because skipBrokerStateLoadOnConstruct is true in tests) and then
+// calls loadState() a second time to fill b.messages — but at that
+// point bootstrapHumanHasPostedLocked has already run and won't run
+// again. The explicit call below mirrors exactly what NewBrokerAt does
+// in production (lines 330-337 of broker.go), producing a broker whose
+// humanHasPosted reflects the reloaded message log.
+func seedAndReload(t *testing.T, b *Broker) *Broker {
+	t.Helper()
+	b.mu.Lock()
+	if err := b.saveLocked(); err != nil {
+		b.mu.Unlock()
+		t.Fatalf("saveLocked: %v", err)
+	}
+	b.mu.Unlock()
+
+	fresh := NewBrokerAt(b.statePath)
+	if err := fresh.loadState(); err != nil {
+		t.Fatalf("loadState: %v", err)
+	}
+	// Re-run bootstrap after the explicit loadState so humanHasPosted
+	// reflects the reloaded message slice, not the empty slice present
+	// when NewBrokerAt ran it the first time (test-mode skips auto-load).
+	fresh.mu.Lock()
+	fresh.bootstrapHumanHasPostedLocked()
+	fresh.mu.Unlock()
+	return fresh
+}
+
+// TestBootstrapHumanHasPosted_EmptyLog verifies that an empty message log
+// leaves humanHasPosted false after a broker restart.
+func TestBootstrapHumanHasPosted_EmptyLog(t *testing.T) {
+	b := newTestBroker(t)
+	// No messages seeded — log is empty.
+	reloaded := seedAndReload(t, b)
+
+	if reloaded.HumanHasPosted() {
+		t.Fatal("empty log: expected humanHasPosted=false after restart, got true")
+	}
+	if metaHumanHasPosted(t, reloaded) {
+		t.Fatal("empty log: expected meta.humanHasPosted=false on /office-members, got true")
+	}
+}
+
+// TestBootstrapHumanHasPosted_HumanMessage verifies that a persisted
+// human-authored message flips humanHasPosted true after a broker restart.
+func TestBootstrapHumanHasPosted_HumanMessage(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.counter = 1
+	b.messages = []channelMessage{
+		{
+			ID:        "msg-1",
+			From:      "human:najm",
+			Channel:   "general",
+			Content:   "hello from a human",
+			Timestamp: "2026-05-06T10:00:00Z",
+		},
+	}
+	b.mu.Unlock()
+
+	reloaded := seedAndReload(t, b)
+
+	if !reloaded.HumanHasPosted() {
+		t.Fatal("human message persisted: expected humanHasPosted=true after restart, got false")
+	}
+	if !metaHumanHasPosted(t, reloaded) {
+		t.Fatal("human message persisted: expected meta.humanHasPosted=true on /office-members, got false")
+	}
+}
+
+// TestBootstrapHumanHasPosted_EmptyFromLatch pins the adversarial fix:
+// a message with an empty (or whitespace-only) From field must NOT set
+// humanHasPosted, even though isHumanMessageSender("") historically
+// returns true. The guard in both appendMessageLocked and
+// bootstrapHumanHasPostedLocked must hold across restarts.
+func TestBootstrapHumanHasPosted_EmptyFromLatch(t *testing.T) {
+	cases := []struct {
+		name string
+		from string
+	}{
+		{"empty-string", ""},
+		{"whitespace-only", "   "},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			b := newTestBroker(t)
+			b.mu.Lock()
+			b.counter = 1
+			b.messages = []channelMessage{
+				{
+					ID:        "msg-1",
+					From:      tc.from,
+					Channel:   "general",
+					Content:   "mysterious origin",
+					Timestamp: "2026-05-06T10:00:00Z",
+				},
+			}
+			b.mu.Unlock()
+
+			reloaded := seedAndReload(t, b)
+
+			if reloaded.HumanHasPosted() {
+				t.Fatalf("from=%q: expected humanHasPosted=false (empty-From latch), got true", tc.from)
+			}
+			if metaHumanHasPosted(t, reloaded) {
+				t.Fatalf("from=%q: expected meta.humanHasPosted=false (empty-From latch), got true", tc.from)
+			}
+		})
+	}
+}
+
+// TestBootstrapHumanHasPosted_AgentOnlyMessages verifies that a log
+// containing only agent-authored messages leaves humanHasPosted false
+// after a broker restart.
+func TestBootstrapHumanHasPosted_AgentOnlyMessages(t *testing.T) {
+	b := newTestBroker(t)
+	b.mu.Lock()
+	b.counter = 2
+	b.messages = []channelMessage{
+		{
+			ID:        "msg-1",
+			From:      "ceo",
+			Channel:   "general",
+			Content:   "agent message one",
+			Timestamp: "2026-05-06T10:00:00Z",
+		},
+		{
+			ID:        "msg-2",
+			From:      "eng",
+			Channel:   "general",
+			Content:   "agent message two",
+			Timestamp: "2026-05-06T10:01:00Z",
+		},
+	}
+	b.mu.Unlock()
+
+	reloaded := seedAndReload(t, b)
+
+	if reloaded.HumanHasPosted() {
+		t.Fatal("agent-only log: expected humanHasPosted=false after restart, got true")
+	}
+	if metaHumanHasPosted(t, reloaded) {
+		t.Fatal("agent-only log: expected meta.humanHasPosted=false on /office-members, got true")
+	}
+}

--- a/internal/team/broker_messages.go
+++ b/internal/team/broker_messages.go
@@ -392,7 +392,11 @@ func (b *Broker) bootstrapHumanHasPostedLocked() {
 		return
 	}
 	for _, msg := range b.messages {
-		if isHumanMessageSender(msg.From) {
+		// Mirror the empty-From guard in appendMessageLocked:
+		// isHumanMessageSender("") returns true (legacy), so an empty
+		// From field must be rejected here too or a corrupted/legacy
+		// persisted message would falsely flip the bit on restart.
+		if strings.TrimSpace(msg.From) != "" && isHumanMessageSender(msg.From) {
 			b.humanHasPosted = true
 			return
 		}

--- a/internal/team/watchdog_activity_stuck_test.go
+++ b/internal/team/watchdog_activity_stuck_test.go
@@ -1,0 +1,184 @@
+package team
+
+import (
+	"testing"
+	"time"
+)
+
+// drainActivityKind reads from ch until it sees a snapshot for slug with
+// Kind == wantKind or the deadline passes. Returns true on match.
+func drainActivityKind(ch <-chan agentActivitySnapshot, slug, wantKind string, deadline time.Duration) bool {
+	limit := time.After(deadline)
+	for {
+		select {
+		case snap, ok := <-ch:
+			if !ok {
+				return false
+			}
+			if snap.Slug == slug && snap.Kind == wantKind {
+				return true
+			}
+		case <-limit:
+			return false
+		}
+	}
+}
+
+// activityKindNow reads the in-memory activity map under the broker lock.
+// The mutation helpers (markAgentStuckFromWatchdogLocked etc.) write to
+// b.activity synchronously before returning, so a post-call lock read is
+// the authoritative check without channel timing.
+func activityKindNow(b *Broker, slug string) string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.activity[slug].Kind
+}
+
+// TestWatchdogActivityStuck_SingleAlertFlipsKindToStuck verifies that
+// CreateWatchdogAlert stamps the owner's activity snapshot with Kind="stuck"
+// immediately and that the subscription channel receives the event.
+func TestWatchdogActivityStuck_SingleAlertFlipsKindToStuck(t *testing.T) {
+	b := newTestBroker(t)
+
+	actCh, unsub := b.SubscribeActivity(16)
+	defer unsub()
+
+	const owner = "eng"
+	_, _, err := b.CreateWatchdogAlert("task_stalled", "general", "task", "task-1", owner, "Waiting for unblock")
+	if err != nil {
+		t.Fatalf("CreateWatchdogAlert: %v", err)
+	}
+
+	// In-memory map must be updated synchronously.
+	if got := activityKindNow(b, owner); got != "stuck" {
+		t.Errorf("activity Kind after alert = %q, want stuck", got)
+	}
+
+	// The publish must arrive on the subscription channel.
+	if !drainActivityKind(actCh, owner, "stuck", 2*time.Second) {
+		t.Error("did not receive Kind=stuck on activity channel within 2s")
+	}
+}
+
+// TestWatchdogActivityStuck_ResolveLastAlertFlipsKindToRoutine verifies that
+// resolving the only active watchdog on an owner restores Kind="routine".
+func TestWatchdogActivityStuck_ResolveLastAlertFlipsKindToRoutine(t *testing.T) {
+	b := newTestBroker(t)
+
+	actCh, unsub := b.SubscribeActivity(16)
+	defer unsub()
+
+	const owner = "fe"
+	_, _, err := b.CreateWatchdogAlert("task_stalled", "general", "task", "task-2", owner, "Waiting")
+	if err != nil {
+		t.Fatalf("CreateWatchdogAlert: %v", err)
+	}
+
+	// Drain the "stuck" event so the channel is fresh for the "routine" one.
+	if !drainActivityKind(actCh, owner, "stuck", 2*time.Second) {
+		t.Fatal("did not receive Kind=stuck before resolving")
+	}
+
+	// Resolve the only alert — must flip back to routine.
+	b.mu.Lock()
+	b.resolveWatchdogAlertsLocked("task", "task-2", "general")
+	b.mu.Unlock()
+
+	if got := activityKindNow(b, owner); got != "routine" {
+		t.Errorf("activity Kind after resolve = %q, want routine", got)
+	}
+
+	if !drainActivityKind(actCh, owner, "routine", 2*time.Second) {
+		t.Error("did not receive Kind=routine on activity channel within 2s")
+	}
+}
+
+// TestWatchdogActivityStuck_TwoAlertsResolveOneKindStaysStuck pins the
+// concurrent-guard fix: if two watchdogs are active on the same owner and
+// only one is resolved, Kind must remain "stuck" because the second alert
+// is still active. This is the CodeRabbit fix shipped in PR #664.
+func TestWatchdogActivityStuck_TwoAlertsResolveOneKindStaysStuck(t *testing.T) {
+	b := newTestBroker(t)
+
+	actCh, unsub := b.SubscribeActivity(32)
+	defer unsub()
+
+	const owner = "be"
+
+	// First alert: task-3
+	_, _, err := b.CreateWatchdogAlert("task_stalled", "general", "task", "task-3", owner, "Waiting on task-3")
+	if err != nil {
+		t.Fatalf("CreateWatchdogAlert task-3: %v", err)
+	}
+	// Second alert: task-4 (different targetID, same owner)
+	_, _, err = b.CreateWatchdogAlert("task_stalled", "general", "task", "task-4", owner, "Waiting on task-4")
+	if err != nil {
+		t.Fatalf("CreateWatchdogAlert task-4: %v", err)
+	}
+
+	// Both alerts are up; Kind must be stuck.
+	if got := activityKindNow(b, owner); got != "stuck" {
+		t.Fatalf("expected stuck before resolve, got %q", got)
+	}
+
+	// Drain any queued events so the channel is settled.
+	drainActivityKind(actCh, owner, "stuck", 500*time.Millisecond)
+
+	// Resolve only the first alert. The second is still active.
+	b.mu.Lock()
+	b.resolveWatchdogAlertsLocked("task", "task-3", "general")
+	b.mu.Unlock()
+
+	// Kind must remain "stuck" because task-4's alert is still active.
+	if got := activityKindNow(b, owner); got != "stuck" {
+		t.Errorf("activity Kind after partial resolve = %q, want still stuck", got)
+	}
+
+	// Sanity: the second watchdog is genuinely still active.
+	dogs := b.Watchdogs()
+	activeCount := 0
+	for _, w := range dogs {
+		if w.Owner == owner && w.Status != "resolved" {
+			activeCount++
+		}
+	}
+	if activeCount != 1 {
+		t.Errorf("expected 1 active watchdog remaining after partial resolve, got %d", activeCount)
+	}
+
+	// Now resolve the second alert — only now should Kind drop to routine.
+	b.mu.Lock()
+	b.resolveWatchdogAlertsLocked("task", "task-4", "general")
+	b.mu.Unlock()
+
+	if got := activityKindNow(b, owner); got != "routine" {
+		t.Errorf("activity Kind after full resolve = %q, want routine", got)
+	}
+
+	if !drainActivityKind(actCh, owner, "routine", 2*time.Second) {
+		t.Error("did not receive Kind=routine after resolving all alerts")
+	}
+}
+
+// TestWatchdogActivityStuck_NoCollisionWithStalenessReaper confirms the
+// test-path isolation requirement from the PR spec: the watchdog mutation
+// path must not interfere with the stale-while-active reaper in
+// broker_streams.go. We verify this by checking that a directly-created
+// watchdog alert (no running broker HTTP server, no reaper goroutine) still
+// sets Kind="stuck" without waiting for the 90s stale timeout.
+func TestWatchdogActivityStuck_NoCollisionWithStalenessReaper(t *testing.T) {
+	// newTestBroker does NOT start the broker's background goroutines
+	// (that requires StartOnPort), so no reaper is running. Any Kind="stuck"
+	// result must come exclusively from the watchdog path.
+	b := newTestBroker(t)
+
+	const owner = "data"
+	_, _, err := b.CreateWatchdogAlert("task_stalled", "general", "task", "task-5", owner, "Direct watchdog test")
+	if err != nil {
+		t.Fatalf("CreateWatchdogAlert: %v", err)
+	}
+
+	if got := activityKindNow(b, owner); got != "stuck" {
+		t.Errorf("expected stuck from watchdog path only (no reaper), got %q", got)
+	}
+}

--- a/web/src/components/sidebar/AgentEventPill.tsx
+++ b/web/src/components/sidebar/AgentEventPill.tsx
@@ -93,11 +93,7 @@ function pillTextFor(
     return snapshotActivity ?? snapshotDetail ?? "stuck";
   }
   if (state === "idle") {
-    if (
-      !hasSnapshot &&
-      typeof fallbackTask === "string" &&
-      fallbackTask.trim()
-    ) {
+    if (!hasSnapshot && fallbackTask) {
       return fallbackTask;
     }
     return idleCopy;

--- a/web/src/hooks/useMembers.ts
+++ b/web/src/hooks/useMembers.ts
@@ -8,7 +8,14 @@ export function useOfficeMembers() {
     queryKey: ["office-members"],
     queryFn: () => getOfficeMembers(),
     refetchInterval: 5000,
-    select: (data) => data.members ?? [],
+    select: (data) =>
+      (data.members ?? []).map((m) => {
+        const trimmed = m.task?.trim();
+        // Normalise at the source: coerce whitespace-only task strings to
+        // undefined so every consumer gets a clean value without defensive
+        // .trim() calls downstream.
+        return trimmed ? { ...m, task: trimmed } : { ...m, task: undefined };
+      }),
   });
 }
 

--- a/web/src/lib/agentEventTimer.test.ts
+++ b/web/src/lib/agentEventTimer.test.ts
@@ -115,6 +115,78 @@ describe("computePillState", () => {
   });
 });
 
+describe("dim-state transitions (prefers-reduced-motion smoke)", () => {
+  // The timer and pure derivation are motion-agnostic: CSS applies the
+  // reduced-motion guard, not JS. These tests pin the JS behaviour so that
+  // when prefers-reduced-motion:reduce is active in a real browser, the
+  // data-state attribute still reaches "dim" / "idle" at the right moment
+  // and the CSS media query has something correct to act on.
+
+  const BASE = 2_000_000;
+
+  it("routine event: returns dim at ROUTINE_HOLD_MS + 1ms", () => {
+    expect(
+      computePillState({
+        lastEventMs: BASE,
+        nowMs: BASE + 60_000 + 1,
+        kind: "routine",
+      }),
+    ).toBe("dim");
+  });
+
+  it("routine event: returns idle at ROUTINE_HOLD_MS + DIM_WINDOW_MS + 1ms", () => {
+    expect(
+      computePillState({
+        lastEventMs: BASE,
+        nowMs: BASE + 60_000 + 60_000 + 1,
+        kind: "routine",
+      }),
+    ).toBe("idle");
+  });
+
+  it("milestone event: returns dim at MILESTONE_HOLD_MS + 1ms", () => {
+    expect(
+      computePillState({
+        lastEventMs: BASE,
+        nowMs: BASE + 120_000 + 1,
+        kind: "milestone",
+      }),
+    ).toBe("dim");
+  });
+
+  it("milestone event: returns idle at MILESTONE_HOLD_MS + DIM_WINDOW_MS + 1ms", () => {
+    expect(
+      computePillState({
+        lastEventMs: BASE,
+        nowMs: BASE + 120_000 + 60_000 + 1,
+        kind: "milestone",
+      }),
+    ).toBe("idle");
+  });
+
+  it("TICK_INTERVAL_MS boundary: state is still holding at exact hold expiry, flips to dim on next tick", () => {
+    const TICK = 1_000;
+
+    // At the exact hold boundary: holding (sinceEvent === holdMs, <= holds)
+    expect(
+      computePillState({
+        lastEventMs: BASE,
+        nowMs: BASE + 60_000,
+        kind: "routine",
+      }),
+    ).toBe("holding");
+
+    // One tick later: crosses into dim
+    expect(
+      computePillState({
+        lastEventMs: BASE,
+        nowMs: BASE + 60_000 + TICK,
+        kind: "routine",
+      }),
+    ).toBe("dim");
+  });
+});
+
 describe("startEventTimer", () => {
   beforeEach(() => {
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary

Closes 4 of the 5 deferred TODOs from PR #664 (agent event bubbles). The 5th (Tier 2 hover peek card) remains design-deferred and is intentionally not in scope.

- **fix(broker):** mirror the empty-From guard from `appendMessageLocked` into `bootstrapHumanHasPostedLocked` so a corrupted/legacy persisted message with empty `From` cannot falsely flip `humanHasPosted=true` on broker restart. Caught while writing the restart test below — it would have shipped silently.
- **test(broker):** pin watchdog → `agentActivitySnapshot.Kind="stuck"` end-to-end, including the concurrent-alert guard (resolving one alert leaves Kind=stuck while another alert on the same owner is still active).
- **test(broker):** pin `bootstrapHumanHasPostedLocked` durable-restart behavior across close + reopen, with explicit empty-string and whitespace-only From cases.
- **refactor(web):** move the `fallbackTask` whitespace-trim defense from `AgentEventPill` to the `useOfficeMembers` `select` callback. Single source of truth; consumer guard removed.
- **test(web):** add `computePillState` dim-state coverage for routine + milestone hold boundaries and the tick-interval edge at exact hold expiry. CSS handles `prefers-reduced-motion` itself; the JS guarantee tested here is that `data-state="dim"` is emitted at the correct wall-clock offset for the media query to act on.

Per the PR #664 ship plan, the **Tier 2 hover peek card** TODO stays deferred — it needs a `/design-consultation` pass before any code lands.

## Test plan

- [x] `bash scripts/test-go.sh ./internal/team` (full package, 168s, all green)
- [x] Watchdog/bootstrap tests pass with `-race -count=2`
- [x] `bunx tsc --noEmit` clean
- [x] `bash scripts/test-web.sh` for touched files (30/30 passed across `agentEventTimer.test.ts`, `officeIdleDictionary.test.ts`, `AgentEventPill.test.tsx`)
- [x] `bunx biome check src/` — no new warnings on touched files (pre-existing baseline noise on unrelated files unchanged)
- [ ] CI green
- [ ] CodeRabbit review addressed

## Notes for reviewer

- The bootstrap test had to call `bootstrapHumanHasPostedLocked()` explicitly after `loadState()` because `NewBrokerAt` skips `loadState` in test mode (`skipBrokerStateLoadOnConstruct`), so the in-constructor bootstrap call sees an empty slice. Worth a separate cleanup at some point — out of scope here.
- Bisectable commit ordering: production fix → its test → next test → web refactor → its smoke. Each commit is independently revertable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect human-activity detection after restarts when messages had empty or whitespace-only sender fields.
  * Prevented whitespace-only fallback tasks from showing as idle copy.

* **Improvements**
  * Normalize member task values so blank/whitespace tasks are treated as empty.
  * Refined UI idle/dim transition timing to better respect reduced-motion preferences.

* **Tests**
  * Added test coverage for restart/persistence, watchdog activity state transitions, and UI timer state boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->