### PR TITLE
feat(wiki): WUPHF-specific editor inserts (Phase 3 PR 6)

### DIFF
--- a/web/src/components/wiki/WikiEditor.tsx
+++ b/web/src/components/wiki/WikiEditor.tsx
@@ -91,6 +91,9 @@ interface SourcePaneProps {
   content: string;
   setContent: (next: string) => void;
   textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+  /** Catalog passed through to the rich editor for the mention picker
+   *  and broken-link detection. The textarea path doesn't use it. */
+  catalog: WikiCatalogEntry[];
 }
 
 /**
@@ -104,6 +107,7 @@ function SourcePane({
   content,
   setContent,
   textareaRef,
+  catalog,
 }: SourcePaneProps) {
   const labelText = `Article source (${path})`;
   return (
@@ -136,7 +140,11 @@ function SourcePane({
             data-testid="wk-editor-rich"
             aria-labelledby="wk-editor-source-label"
           >
-            <RichWikiEditor content={content} onChange={setContent} />
+            <RichWikiEditor
+              content={content}
+              onChange={setContent}
+              catalog={catalog}
+            />
           </div>
         </Suspense>
       ) : (
@@ -342,6 +350,7 @@ export default function WikiEditor({
             content={content}
             setContent={setContent}
             textareaRef={textareaRef}
+            catalog={catalog}
           />
         ) : null}
         {showPreview ? (
@@ -417,7 +426,18 @@ export default function WikiEditor({
       </div>
       <p className="wk-editor-help">
         Plain markdown. <code>[[slug]]</code> creates a wikilink. Saved as
-        commit author <strong>Human &lt;human@wuphf.local&gt;</strong>.
+        commit author <strong>Human &lt;human@wuphf.local&gt;</strong>.{" "}
+        {editorMode === "rich" ? (
+          <>
+            Type <code>/</code> for inserts; <code>@</code> opens the mention
+            picker.
+          </>
+        ) : (
+          <>
+            Toggle <strong>Rich</strong> for slash commands and the mention
+            picker.
+          </>
+        )}
       </p>
     </div>
   );

--- a/web/src/components/wiki/editor/RichWikiEditor.tsx
+++ b/web/src/components/wiki/editor/RichWikiEditor.tsx
@@ -196,6 +196,18 @@ export default function RichWikiEditor({
     contentRef.current = content;
   }, [content]);
 
+  // Wrap the raw onChange so editor-originated edits also sync contentRef.
+  // Without this, plain typing bypasses the ref until the controlled
+  // `content` prop round-trips through the parent, leaving a window where
+  // a concurrent confirm reads stale markdown.
+  const handleEditorChange = useCallback(
+    (next: string) => {
+      contentRef.current = next;
+      onChange(next);
+    },
+    [onChange],
+  );
+
   const insertController = useInsertController({
     getView: () => viewRef.current,
     pushContent: (next) => {
@@ -255,7 +267,7 @@ export default function RichWikiEditor({
       <div className="wk-rich-editor-host">
         <RichWikiEditorInner
           content={content}
-          onChange={onChange}
+          onChange={handleEditorChange}
           setTrigger={setTrigger}
           setView={setView}
         />
@@ -302,7 +314,7 @@ export default function RichWikiEditor({
         ) : null}
         {insertController.dialog === "citation" ? (
           <CitationDialog
-            currentMarkdown={contentRef.current}
+            currentMarkdown={content}
             onConfirm={insertController.onCitationConfirm}
             onCancel={insertController.closeDialog}
           />

--- a/web/src/components/wiki/editor/RichWikiEditor.tsx
+++ b/web/src/components/wiki/editor/RichWikiEditor.tsx
@@ -202,7 +202,7 @@ export default function RichWikiEditor({
       contentRef.current = next;
       onChange(next);
     },
-    currentContent: contentRef.current,
+    getCurrentContent: () => contentRef.current,
   });
   // The controller owns the trigger state so a single source feeds both
   // the floating menus and the action handlers.
@@ -218,17 +218,31 @@ export default function RichWikiEditor({
     return out;
   }, [catalog]);
 
+  // Precompute the set of catalog paths once per catalog change so the
+  // broken-link resolver is O(1) per lookup. Each entry contributes both
+  // its raw path and the `${path}.md` variant so a slug typed without
+  // the `.md` extension (the common case) still resolves.
+  const catalogPathSet = useMemo<Set<string> | null>(() => {
+    if (!catalog) return null;
+    const set = new Set<string>();
+    for (const e of catalog) {
+      set.add(e.path);
+      set.add(`${e.path}.md`);
+    }
+    return set;
+  }, [catalog]);
+
   const resolver = useCallback(
     (slug: string) => {
-      if (!catalog) return true; // No catalog -> no detection signal.
-      return catalog.some((e) => e.path === slug || e.path === `${slug}.md`);
+      if (!catalogPathSet) return true; // No catalog -> no detection signal.
+      return catalogPathSet.has(slug) || catalogPathSet.has(`${slug}.md`);
     },
-    [catalog],
+    [catalogPathSet],
   );
 
   const brokenLinks = useMemo(
-    () => (catalog ? findBrokenWikilinks(content, resolver) : []),
-    [catalog, content, resolver],
+    () => (catalogPathSet ? findBrokenWikilinks(content, resolver) : []),
+    [catalogPathSet, content, resolver],
   );
 
   const showSlashMenu =
@@ -279,7 +293,7 @@ export default function RichWikiEditor({
           <MentionMenu
             items={mentionItems}
             query=""
-            position={{ top: 120, left: 120 }}
+            position={insertController.mentionPickerState.position}
             categoryFilter={insertController.mentionPickerState.categoryFilter}
             heading={insertController.mentionPickerState.heading}
             onSelect={insertController.onMentionSelect}

--- a/web/src/components/wiki/editor/RichWikiEditor.tsx
+++ b/web/src/components/wiki/editor/RichWikiEditor.tsx
@@ -19,13 +19,20 @@
  * receives `content` and pushes changes via `onChange`. External content
  * updates (conflict reload, draft restore) are pushed back into Milkdown
  * via `replaceAll`; we de-dup against the last value we emitted to avoid
- * an edit→serialize→reset feedback loop.
+ * an edit -> serialize -> reset feedback loop.
+ *
+ * Inserts (PR 6): The editor mounts a custom ProseMirror plugin that
+ * watches for `/` and `@` triggers. When active, React renders a floating
+ * SlashMenu / MentionMenu against the trigger position. Slash actions
+ * route to dialog components (citation / fact / decision / related) or
+ * the mention picker; on confirm, markdown is inserted at the caret.
  */
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
   defaultValueCtx,
   Editor,
+  prosePluginsCtx,
   remarkPluginsCtx,
   remarkStringifyOptionsCtx,
   rootCtx,
@@ -33,11 +40,23 @@ import {
 import { listener, listenerCtx } from "@milkdown/plugin-listener";
 import { commonmark } from "@milkdown/preset-commonmark";
 import { gfm } from "@milkdown/preset-gfm";
+import type { EditorView } from "@milkdown/prose/view";
 import { Milkdown, MilkdownProvider, useEditor } from "@milkdown/react";
 import { replaceAll } from "@milkdown/utils";
 
+import type { WikiCatalogEntry } from "../../../api/wiki";
 import { wikiLinkRemarkPlugin } from "../../../lib/wikilink";
 import { STRINGIFY_DEFAULTS } from "../../../lib/wikilinkStringify";
+import { findBrokenWikilinks } from "./inserts/brokenLinks";
+import { CitationDialog } from "./inserts/CitationDialog";
+import { DecisionDialog } from "./inserts/DecisionDialog";
+import { FactDialog } from "./inserts/FactDialog";
+import { MentionMenu } from "./inserts/MentionMenu";
+import { type MentionItem, toMentionItem } from "./inserts/mentionCatalog";
+import { RelatedDialog } from "./inserts/RelatedDialog";
+import { SlashMenu } from "./inserts/SlashMenu";
+import { buildTriggerPlugin, type TriggerState } from "./inserts/triggerPlugin";
+import { useInsertController } from "./inserts/useInsertController";
 import { postProcessWikilinks } from "./wikilinkPostProcess";
 
 export interface RichWikiEditorProps {
@@ -46,13 +65,44 @@ export interface RichWikiEditorProps {
   /** Called when the user edits — receives canonical markdown with
    *  `[[wikilink]]` syntax restored. */
   onChange: (next: string) => void;
+  /** Catalog used by the mention picker + broken-link detection. The
+   *  same list `WikiEditor` already passes to the preview pane. */
+  catalog?: WikiCatalogEntry[];
 }
 
-function RichWikiEditorInner({ content, onChange }: RichWikiEditorProps) {
+interface InnerProps {
+  /** Current markdown source from the controller. */
+  content: string;
+  /** Called when the user edits — receives canonical markdown with
+   *  `[[wikilink]]` syntax restored. */
+  onChange: (next: string) => void;
+  /** Latest TriggerState emitted by the ProseMirror plugin. */
+  setTrigger: (next: TriggerState | null) => void;
+  /** Stash the live ProseMirror view so the controller can dispatch
+   *  insert transactions from outside the editor closure. */
+  setView: (view: EditorView | null) => void;
+}
+
+function RichWikiEditorInner({
+  content,
+  onChange,
+  setTrigger,
+  setView,
+}: InnerProps) {
   const onChangeRef = useRef(onChange);
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
+
+  const setTriggerRef = useRef(setTrigger);
+  useEffect(() => {
+    setTriggerRef.current = setTrigger;
+  }, [setTrigger]);
+
+  const setViewRef = useRef(setView);
+  useEffect(() => {
+    setViewRef.current = setView;
+  }, [setView]);
 
   const lastEmittedRef = useRef<string>(content);
 
@@ -76,6 +126,19 @@ function RichWikiEditorInner({ content, onChange }: RichWikiEditorProps) {
           ...prev,
           ...STRINGIFY_DEFAULTS,
         }));
+        // Mount the trigger-watching ProseMirror plugin. Stable refs so
+        // the closure can reach the latest React setters without
+        // rebuilding the editor when props change. The plugin's `view`
+        // hook calls `onViewReady` on mount/destroy so the parent can
+        // dispatch insert transactions without polling.
+        ctx.update(prosePluginsCtx, (prev) => [
+          ...prev,
+          buildTriggerPlugin({
+            triggers: ["/", "@"],
+            onChange: (next) => setTriggerRef.current(next),
+            onViewReady: (view) => setViewRef.current(view),
+          }),
+        ]);
         ctx.get(listenerCtx).markdownUpdated((_, md, prev) => {
           if (md === prev) return;
           const canonical = postProcessWikilinks(md);
@@ -115,10 +178,141 @@ function RichWikiEditorInner({ content, onChange }: RichWikiEditorProps) {
   return <Milkdown />;
 }
 
-export default function RichWikiEditor(props: RichWikiEditorProps) {
+export default function RichWikiEditor({
+  content,
+  onChange,
+  catalog,
+}: RichWikiEditorProps) {
+  const viewRef = useRef<EditorView | null>(null);
+  const setView = useCallback((view: EditorView | null) => {
+    viewRef.current = view;
+  }, []);
+
+  // Latest content snapshot for the controller — kept in sync with the
+  // `content` prop so the citation appender always works against the
+  // canonical bytes.
+  const contentRef = useRef(content);
+  useEffect(() => {
+    contentRef.current = content;
+  }, [content]);
+
+  const insertController = useInsertController({
+    getView: () => viewRef.current,
+    pushContent: (next) => {
+      contentRef.current = next;
+      onChange(next);
+    },
+    currentContent: contentRef.current,
+  });
+  // The controller owns the trigger state so a single source feeds both
+  // the floating menus and the action handlers.
+  const { trigger, setTrigger } = insertController;
+
+  const mentionItems = useMemo<MentionItem[]>(() => {
+    if (!catalog) return [];
+    const out: MentionItem[] = [];
+    for (const entry of catalog) {
+      const item = toMentionItem(entry);
+      if (item) out.push(item);
+    }
+    return out;
+  }, [catalog]);
+
+  const resolver = useCallback(
+    (slug: string) => {
+      if (!catalog) return true; // No catalog -> no detection signal.
+      return catalog.some((e) => e.path === slug || e.path === `${slug}.md`);
+    },
+    [catalog],
+  );
+
+  const brokenLinks = useMemo(
+    () => (catalog ? findBrokenWikilinks(content, resolver) : []),
+    [catalog, content, resolver],
+  );
+
+  const showSlashMenu =
+    trigger?.trigger === "/" && insertController.dialog === null;
+  const showMentionMenu =
+    trigger?.trigger === "@" && insertController.dialog === null;
+
   return (
     <MilkdownProvider>
-      <RichWikiEditorInner {...props} />
+      <div className="wk-rich-editor-host">
+        <RichWikiEditorInner
+          content={content}
+          onChange={onChange}
+          setTrigger={setTrigger}
+          setView={setView}
+        />
+        {brokenLinks.length > 0 ? (
+          <div
+            className="wk-editor-banner wk-editor-banner--warn"
+            role="alert"
+            data-testid="wk-rich-broken-links"
+          >
+            <strong>Unresolved wikilinks:</strong>{" "}
+            {brokenLinks.map((b) => `[[${b.slug}]]`).join(", ")}. Save will
+            still succeed, but these links will render as broken until the
+            target page exists.
+          </div>
+        ) : null}
+        {showSlashMenu ? (
+          <SlashMenu
+            query={trigger.query}
+            position={{ top: trigger.rect.bottom + 4, left: trigger.rect.left }}
+            onSelect={insertController.onSlashSelect}
+            onClose={insertController.closeTrigger}
+          />
+        ) : null}
+        {showMentionMenu ? (
+          <MentionMenu
+            items={mentionItems}
+            query={trigger.query}
+            position={{ top: trigger.rect.bottom + 4, left: trigger.rect.left }}
+            onSelect={insertController.onMentionSelect}
+            onClose={insertController.closeTrigger}
+          />
+        ) : null}
+        {insertController.dialog === "mention-picker" &&
+        insertController.mentionPickerState ? (
+          <MentionMenu
+            items={mentionItems}
+            query=""
+            position={{ top: 120, left: 120 }}
+            categoryFilter={insertController.mentionPickerState.categoryFilter}
+            heading={insertController.mentionPickerState.heading}
+            onSelect={insertController.onMentionSelect}
+            onClose={insertController.closeDialog}
+          />
+        ) : null}
+        {insertController.dialog === "citation" ? (
+          <CitationDialog
+            currentMarkdown={contentRef.current}
+            onConfirm={insertController.onCitationConfirm}
+            onCancel={insertController.closeDialog}
+          />
+        ) : null}
+        {insertController.dialog === "fact" ? (
+          <FactDialog
+            onConfirm={insertController.onFactConfirm}
+            onCancel={insertController.closeDialog}
+          />
+        ) : null}
+        {insertController.dialog === "decision" ? (
+          <DecisionDialog
+            onConfirm={insertController.onDecisionConfirm}
+            onCancel={insertController.closeDialog}
+          />
+        ) : null}
+        {insertController.dialog === "related" ? (
+          <RelatedDialog
+            items={mentionItems}
+            onConfirm={insertController.onRelatedConfirm}
+            onCancel={insertController.closeDialog}
+          />
+        ) : null}
+      </div>
     </MilkdownProvider>
   );
 }

--- a/web/src/components/wiki/editor/inserts/CitationDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/CitationDialog.tsx
@@ -106,10 +106,9 @@ export function CitationDialog({
         ) : null}
         <div className="wk-insert-dialog__actions">
           <button
-            type="button"
+            type="submit"
             data-testid="wk-citation-confirm"
             className="wk-editor-save"
-            onClick={() => handleSubmit()}
           >
             Insert citation
           </button>

--- a/web/src/components/wiki/editor/inserts/CitationDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/CitationDialog.tsx
@@ -1,0 +1,122 @@
+/**
+ * Modal form for inserting a footnote-style citation.
+ *
+ * The user supplies a URL and optional title; the dialog computes the
+ * next available footnote id from the current document so identifiers
+ * never collide. Submitting calls `onConfirm` with both the inline
+ * reference and the block definition; the controller is responsible
+ * for inserting the reference at the caret and appending the
+ * definition to the document tail.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import {
+  type BuiltCitation,
+  buildCitation,
+  nextFootnoteId,
+} from "./markdownShapes";
+
+export interface CitationDialogProps {
+  currentMarkdown: string;
+  onConfirm: (built: BuiltCitation) => void;
+  onCancel: () => void;
+}
+
+export function CitationDialog({
+  currentMarkdown,
+  onConfirm,
+  onCancel,
+}: CitationDialogProps): React.ReactElement {
+  const [url, setUrl] = useState("");
+  const [title, setTitle] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const urlRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    urlRef.current?.focus();
+  }, []);
+
+  function handleSubmit(e?: React.FormEvent): void {
+    e?.preventDefault();
+    const trimmedUrl = url.trim();
+    if (!trimmedUrl) {
+      setError("URL is required.");
+      return;
+    }
+    if (!/^https?:\/\//.test(trimmedUrl)) {
+      setError("URL must start with http:// or https://.");
+      return;
+    }
+    const id = nextFootnoteId(currentMarkdown);
+    const built = buildCitation({ id, title, url: trimmedUrl });
+    onConfirm(built);
+  }
+
+  return (
+    <div
+      className="wk-modal-backdrop"
+      data-testid="wk-citation-dialog-backdrop"
+      role="dialog"
+      aria-modal="true"
+    >
+      <form
+        className="wk-modal wk-insert-dialog"
+        data-testid="wk-citation-dialog"
+        onSubmit={handleSubmit}
+      >
+        <h2>Cite source</h2>
+        <label htmlFor="wk-citation-url" className="wk-editor-label">
+          URL
+        </label>
+        <input
+          id="wk-citation-url"
+          ref={urlRef}
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder="https://example.com/article"
+          data-testid="wk-citation-url"
+        />
+        <label htmlFor="wk-citation-title" className="wk-editor-label">
+          Title (optional)
+        </label>
+        <input
+          id="wk-citation-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Source headline"
+          data-testid="wk-citation-title"
+        />
+        {error ? (
+          <div
+            className="wk-editor-banner wk-editor-banner--error"
+            role="alert"
+            data-testid="wk-citation-error"
+          >
+            {error}
+          </div>
+        ) : null}
+        <div className="wk-insert-dialog__actions">
+          <button
+            type="button"
+            data-testid="wk-citation-confirm"
+            className="wk-editor-save"
+            onClick={() => handleSubmit()}
+          >
+            Insert citation
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            data-testid="wk-citation-cancel"
+            className="wk-editor-cancel"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/wiki/editor/inserts/CitationDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/CitationDialog.tsx
@@ -59,6 +59,12 @@ export function CitationDialog({
       data-testid="wk-citation-dialog-backdrop"
       role="dialog"
       aria-modal="true"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onCancel();
+        }
+      }}
     >
       <form
         className="wk-modal wk-insert-dialog"

--- a/web/src/components/wiki/editor/inserts/DecisionDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/DecisionDialog.tsx
@@ -1,0 +1,153 @@
+/**
+ * Modal form for the decision-block insert.
+ *
+ * Captures title, rationale, ISO date, and a comma-separated list of
+ * alternatives. Defaults the date field to today's local-time ISO date
+ * (`YYYY-MM-DD`) so most authors only need to fill out the title and
+ * rationale to ship a decision record.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { buildDecisionBlock, type DecisionDraft } from "./markdownShapes";
+
+export interface DecisionDialogProps {
+  onConfirm: (block: string) => void;
+  onCancel: () => void;
+}
+
+function todayLocalIsoDate(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function DecisionDialog({
+  onConfirm,
+  onCancel,
+}: DecisionDialogProps): React.ReactElement {
+  const [draft, setDraft] = useState<DecisionDraft>({
+    title: "",
+    rationale: "",
+    date: todayLocalIsoDate(),
+    alternatives: [],
+  });
+  const [alternativesText, setAlternativesText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const titleRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  function handleSubmit(e?: React.FormEvent): void {
+    e?.preventDefault();
+    if (!draft.title.trim()) {
+      setError("Title is required.");
+      return;
+    }
+    if (!draft.rationale.trim()) {
+      setError("Rationale is required.");
+      return;
+    }
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(draft.date.trim())) {
+      setError("Date must be YYYY-MM-DD.");
+      return;
+    }
+    const alts = alternativesText
+      .split(",")
+      .map((a) => a.trim())
+      .filter((a) => a.length > 0);
+    const block = buildDecisionBlock({
+      ...draft,
+      alternatives: alts,
+    });
+    onConfirm(block);
+  }
+
+  return (
+    <div
+      className="wk-modal-backdrop"
+      data-testid="wk-decision-dialog-backdrop"
+      role="dialog"
+      aria-modal="true"
+    >
+      <form
+        className="wk-modal wk-insert-dialog"
+        data-testid="wk-decision-dialog"
+        onSubmit={handleSubmit}
+      >
+        <h2>Insert decision block</h2>
+        <label htmlFor="wk-decision-title" className="wk-editor-label">
+          Title
+        </label>
+        <input
+          id="wk-decision-title"
+          ref={titleRef}
+          value={draft.title}
+          onChange={(e) => setDraft({ ...draft, title: e.target.value })}
+          data-testid="wk-decision-title"
+        />
+        <label htmlFor="wk-decision-date" className="wk-editor-label">
+          Date
+        </label>
+        <input
+          id="wk-decision-date"
+          type="date"
+          value={draft.date}
+          onChange={(e) => setDraft({ ...draft, date: e.target.value })}
+          data-testid="wk-decision-date"
+        />
+        <label htmlFor="wk-decision-rationale" className="wk-editor-label">
+          Rationale
+        </label>
+        <textarea
+          id="wk-decision-rationale"
+          value={draft.rationale}
+          rows={4}
+          onChange={(e) => setDraft({ ...draft, rationale: e.target.value })}
+          data-testid="wk-decision-rationale"
+        />
+        <label htmlFor="wk-decision-alternatives" className="wk-editor-label">
+          Alternatives considered (comma-separated)
+        </label>
+        <input
+          id="wk-decision-alternatives"
+          value={alternativesText}
+          onChange={(e) => setAlternativesText(e.target.value)}
+          placeholder="Option A, Option B"
+          data-testid="wk-decision-alternatives"
+        />
+        {error ? (
+          <div
+            className="wk-editor-banner wk-editor-banner--error"
+            role="alert"
+            data-testid="wk-decision-error"
+          >
+            {error}
+          </div>
+        ) : null}
+        <div className="wk-insert-dialog__actions">
+          <button
+            type="button"
+            data-testid="wk-decision-confirm"
+            className="wk-editor-save"
+            onClick={() => handleSubmit()}
+          >
+            Insert decision
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="wk-editor-cancel"
+            data-testid="wk-decision-cancel"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/wiki/editor/inserts/DecisionDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/DecisionDialog.tsx
@@ -73,6 +73,12 @@ export function DecisionDialog({
       data-testid="wk-decision-dialog-backdrop"
       role="dialog"
       aria-modal="true"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onCancel();
+        }
+      }}
     >
       <form
         className="wk-modal wk-insert-dialog"

--- a/web/src/components/wiki/editor/inserts/DecisionDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/DecisionDialog.tsx
@@ -73,6 +73,7 @@ export function DecisionDialog({
       data-testid="wk-decision-dialog-backdrop"
       role="dialog"
       aria-modal="true"
+      aria-labelledby="wk-decision-dialog-title"
       onKeyDown={(e) => {
         if (e.key === "Escape") {
           e.stopPropagation();
@@ -85,7 +86,7 @@ export function DecisionDialog({
         data-testid="wk-decision-dialog"
         onSubmit={handleSubmit}
       >
-        <h2>Insert decision block</h2>
+        <h2 id="wk-decision-dialog-title">Insert decision block</h2>
         <label htmlFor="wk-decision-title" className="wk-editor-label">
           Title
         </label>
@@ -137,10 +138,9 @@ export function DecisionDialog({
         ) : null}
         <div className="wk-insert-dialog__actions">
           <button
-            type="button"
+            type="submit"
             data-testid="wk-decision-confirm"
             className="wk-editor-save"
-            onClick={() => handleSubmit()}
           >
             Insert decision
           </button>

--- a/web/src/components/wiki/editor/inserts/FactDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/FactDialog.tsx
@@ -1,0 +1,230 @@
+/**
+ * Modal form for the fact / triple insert.
+ *
+ * Critical contract: this dialog NEVER silently writes a fact to the
+ * fact log. The two-step flow is intentional:
+ *   1. Editing — user fills out subject / predicate / object plus the
+ *      optional confidence field.
+ *   2. Preview — same dialog flips to a read-only render of the fact
+ *      block exactly as it will land in the document. The confirm
+ *      button is the only path that triggers `onConfirm`.
+ *
+ * The preview is the contract the phase doc requires ("Fact/triple
+ * insert never silently writes facts — always shows a reviewable
+ * preview"). Closing the dialog at any point before confirm leaves
+ * the document untouched.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { buildFactBlock, type FactDraft } from "./markdownShapes";
+
+export interface FactDialogProps {
+  /** Optional default source citation reference (e.g. `[^1]`) — used
+   *  when the user opens the fact dialog after inserting a citation. */
+  defaultSource?: string;
+  onConfirm: (block: string) => void;
+  onCancel: () => void;
+}
+
+type Stage = "edit" | "preview";
+
+export function FactDialog({
+  defaultSource,
+  onConfirm,
+  onCancel,
+}: FactDialogProps): React.ReactElement {
+  const [draft, setDraft] = useState<FactDraft>({
+    subject: "",
+    predicate: "",
+    object: "",
+    confidence: 0.9,
+    source: defaultSource ?? "",
+  });
+  const [stage, setStage] = useState<Stage>("edit");
+  const [error, setError] = useState<string | null>(null);
+  const subjectRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (stage === "edit") subjectRef.current?.focus();
+  }, [stage]);
+
+  function handleProceedToPreview(e?: React.FormEvent): void {
+    e?.preventDefault();
+    if (!draft.subject.trim()) {
+      setError("Subject is required.");
+      return;
+    }
+    if (!draft.predicate.trim()) {
+      setError("Predicate is required.");
+      return;
+    }
+    if (!draft.object.trim()) {
+      setError("Object is required.");
+      return;
+    }
+    setError(null);
+    setStage("preview");
+  }
+
+  const previewBlock =
+    stage === "preview"
+      ? buildFactBlock({
+          ...draft,
+          source: draft.source?.trim() || undefined,
+        })
+      : "";
+
+  return (
+    <div
+      className="wk-modal-backdrop"
+      data-testid="wk-fact-dialog-backdrop"
+      role="dialog"
+      aria-modal="true"
+    >
+      <form
+        className="wk-modal wk-insert-dialog"
+        data-testid="wk-fact-dialog"
+        onSubmit={handleProceedToPreview}
+      >
+        <h2>{stage === "edit" ? "Add fact" : "Review fact"}</h2>
+
+        {stage === "edit" ? (
+          <>
+            <p className="wk-insert-dialog__hint">
+              Captures a subject + predicate + object claim. Nothing is written
+              until you confirm on the next screen.
+            </p>
+            <label htmlFor="wk-fact-subject" className="wk-editor-label">
+              Subject
+            </label>
+            <input
+              id="wk-fact-subject"
+              ref={subjectRef}
+              value={draft.subject}
+              onChange={(e) => setDraft({ ...draft, subject: e.target.value })}
+              data-testid="wk-fact-subject"
+            />
+            <label htmlFor="wk-fact-predicate" className="wk-editor-label">
+              Predicate
+            </label>
+            <input
+              id="wk-fact-predicate"
+              value={draft.predicate}
+              onChange={(e) =>
+                setDraft({ ...draft, predicate: e.target.value })
+              }
+              data-testid="wk-fact-predicate"
+            />
+            <label htmlFor="wk-fact-object" className="wk-editor-label">
+              Object
+            </label>
+            <input
+              id="wk-fact-object"
+              value={draft.object}
+              onChange={(e) => setDraft({ ...draft, object: e.target.value })}
+              data-testid="wk-fact-object"
+            />
+            <label htmlFor="wk-fact-confidence" className="wk-editor-label">
+              Confidence (0..1)
+            </label>
+            <input
+              id="wk-fact-confidence"
+              type="number"
+              min={0}
+              max={1}
+              step={0.1}
+              value={draft.confidence ?? ""}
+              onChange={(e) =>
+                setDraft({
+                  ...draft,
+                  confidence:
+                    e.target.value === ""
+                      ? undefined
+                      : Number.parseFloat(e.target.value),
+                })
+              }
+              data-testid="wk-fact-confidence"
+            />
+            <label htmlFor="wk-fact-source" className="wk-editor-label">
+              Source (optional)
+            </label>
+            <input
+              id="wk-fact-source"
+              value={draft.source ?? ""}
+              onChange={(e) => setDraft({ ...draft, source: e.target.value })}
+              placeholder="[^1]"
+              data-testid="wk-fact-source"
+            />
+            {error ? (
+              <div
+                className="wk-editor-banner wk-editor-banner--error"
+                role="alert"
+                data-testid="wk-fact-error"
+              >
+                {error}
+              </div>
+            ) : null}
+            <div className="wk-insert-dialog__actions">
+              <button
+                type="button"
+                data-testid="wk-fact-preview"
+                className="wk-editor-save"
+                onClick={() => handleProceedToPreview()}
+              >
+                Preview
+              </button>
+              <button
+                type="button"
+                onClick={onCancel}
+                className="wk-editor-cancel"
+                data-testid="wk-fact-cancel"
+              >
+                Cancel
+              </button>
+            </div>
+          </>
+        ) : (
+          <>
+            <p className="wk-insert-dialog__hint">
+              The block below will be inserted at your cursor. Nothing else is
+              written until you click Confirm insert.
+            </p>
+            <pre
+              className="wk-insert-dialog__preview"
+              data-testid="wk-fact-preview-block"
+            >
+              {previewBlock}
+            </pre>
+            <div className="wk-insert-dialog__actions">
+              <button
+                type="button"
+                className="wk-editor-save"
+                data-testid="wk-fact-confirm"
+                onClick={() => onConfirm(previewBlock)}
+              >
+                Confirm insert
+              </button>
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                data-testid="wk-fact-back"
+                onClick={() => setStage("edit")}
+              >
+                Back
+              </button>
+              <button
+                type="button"
+                className="wk-editor-cancel"
+                onClick={onCancel}
+                data-testid="wk-fact-cancel-2"
+              >
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/web/src/components/wiki/editor/inserts/FactDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/FactDialog.tsx
@@ -81,6 +81,12 @@ export function FactDialog({
       data-testid="wk-fact-dialog-backdrop"
       role="dialog"
       aria-modal="true"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onCancel();
+        }
+      }}
     >
       <form
         className="wk-modal wk-insert-dialog"

--- a/web/src/components/wiki/editor/inserts/FactDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/FactDialog.tsx
@@ -81,6 +81,7 @@ export function FactDialog({
       data-testid="wk-fact-dialog-backdrop"
       role="dialog"
       aria-modal="true"
+      aria-labelledby="wk-fact-dialog-title"
       onKeyDown={(e) => {
         if (e.key === "Escape") {
           e.stopPropagation();
@@ -93,7 +94,9 @@ export function FactDialog({
         data-testid="wk-fact-dialog"
         onSubmit={handleProceedToPreview}
       >
-        <h2>{stage === "edit" ? "Add fact" : "Review fact"}</h2>
+        <h2 id="wk-fact-dialog-title">
+          {stage === "edit" ? "Add fact" : "Review fact"}
+        </h2>
 
         {stage === "edit" ? (
           <>

--- a/web/src/components/wiki/editor/inserts/MentionMenu.test.tsx
+++ b/web/src/components/wiki/editor/inserts/MentionMenu.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Component tests for the @-mention picker.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { MentionMenu } from "./MentionMenu";
+import type { MentionItem } from "./mentionCatalog";
+
+const ITEMS: MentionItem[] = [
+  { slug: "team/people/alex", title: "Alex Chen", category: "people" },
+  { slug: "team/people/sarah", title: "Sarah Lee", category: "people" },
+  {
+    slug: "team/projects/backend",
+    title: "Backend rewrite",
+    category: "projects",
+  },
+  {
+    slug: "agents/operator/notebook/today",
+    title: "Operator notebook",
+    category: "agents",
+  },
+];
+
+describe("<MentionMenu>", () => {
+  const position = { top: 100, left: 100 };
+
+  it("groups results by category", () => {
+    render(
+      <MentionMenu
+        items={ITEMS}
+        query=""
+        position={position}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText("People")).toBeInTheDocument();
+    expect(screen.getByText("Projects")).toBeInTheDocument();
+    expect(screen.getByText("Agents")).toBeInTheDocument();
+  });
+
+  it("filters items by query", () => {
+    render(
+      <MentionMenu
+        items={ITEMS}
+        query="alex"
+        position={position}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(
+      screen.getByTestId("wk-mention-team/people/alex"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("wk-mention-team/people/sarah")).toBeNull();
+  });
+
+  it("respects categoryFilter for sliced pickers", () => {
+    render(
+      <MentionMenu
+        items={ITEMS}
+        query=""
+        position={position}
+        categoryFilter="agents"
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(
+      screen.getByTestId("wk-mention-agents/operator/notebook/today"),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("wk-mention-team/people/alex")).toBeNull();
+  });
+
+  it("emits the picked item on click", () => {
+    const onSelect = vi.fn();
+    render(
+      <MentionMenu
+        items={ITEMS}
+        query=""
+        position={position}
+        onSelect={onSelect}
+        onClose={() => {}}
+      />,
+    );
+    fireEvent.mouseDown(screen.getByTestId("wk-mention-team/people/alex"));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].slug).toBe("team/people/alex");
+  });
+
+  it("renders the empty state when nothing matches", () => {
+    render(
+      <MentionMenu
+        items={ITEMS}
+        query="nonexistent"
+        position={position}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("wk-mention-menu-empty")).toBeInTheDocument();
+  });
+
+  it("renders the heading when provided", () => {
+    render(
+      <MentionMenu
+        items={ITEMS}
+        query=""
+        position={position}
+        heading="Insert task reference"
+        categoryFilter="agents"
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByText("Insert task reference")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/wiki/editor/inserts/MentionMenu.tsx
+++ b/web/src/components/wiki/editor/inserts/MentionMenu.tsx
@@ -62,8 +62,8 @@ export function MentionMenu({
   const [activeIdx, setActiveIdx] = useState(0);
 
   useEffect(() => {
-    if (activeIdx >= flat.length) setActiveIdx(Math.max(0, flat.length - 1));
-  }, [flat.length, activeIdx]);
+    setActiveIdx((prev) => Math.min(prev, Math.max(0, flat.length - 1)));
+  }, [flat.length]);
 
   useMenuKeyNav<MentionItem>({
     items: flat,

--- a/web/src/components/wiki/editor/inserts/MentionMenu.tsx
+++ b/web/src/components/wiki/editor/inserts/MentionMenu.tsx
@@ -80,6 +80,7 @@ export function MentionMenu({
         data-testid="wk-mention-menu-empty"
         style={floatingStyle(position)}
         role="listbox"
+        aria-label={heading ?? "Insert mention"}
       >
         <div className="wk-insert-menu__empty">No matches</div>
       </div>,
@@ -87,7 +88,10 @@ export function MentionMenu({
     );
   }
 
-  let runningIdx = 0;
+  // Precompute slug -> flat index so the render is pure (no mutable
+  // counter walked across the grouped map). Order matches `flat`, which
+  // is what `useMenuKeyNav` uses for keyboard navigation.
+  const slugToFlatIdx = new Map(flat.map((item, i) => [item.slug, i]));
   return createPortal(
     <div
       className="wk-insert-menu wk-insert-menu--mention"
@@ -106,8 +110,7 @@ export function MentionMenu({
           </div>
           <ul className="wk-insert-menu__list">
             {g.items.map((item) => {
-              const idx = runningIdx;
-              runningIdx += 1;
+              const idx = slugToFlatIdx.get(item.slug) ?? 0;
               return (
                 <li
                   key={item.slug}

--- a/web/src/components/wiki/editor/inserts/MentionMenu.tsx
+++ b/web/src/components/wiki/editor/inserts/MentionMenu.tsx
@@ -1,0 +1,143 @@
+/**
+ * Floating mention picker shown when the user types `@` in the rich editor.
+ *
+ * Renders catalog entries grouped by `MentionCategory` and filters by the
+ * substring the user has typed since the trigger. Selecting an item
+ * inserts a wikilink at the trigger's position. Keyboard nav matches
+ * `SlashMenu` (ArrowUp/Down, Enter, Escape).
+ *
+ * The picker is also reused for the slash-menu actions that need a wiki
+ * page picker (link, task ref, agent mention) — `categoryFilter` narrows
+ * the surfaced bucket and lets the slash flow re-use the same UI.
+ */
+
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import {
+  categoryLabel,
+  groupMentionItems,
+  type MentionCategory,
+  type MentionItem,
+  searchMentionItems,
+} from "./mentionCatalog";
+import { floatingStyle } from "./SlashMenu";
+import { useMenuKeyNav } from "./useMenuKeyNav";
+
+export interface MentionMenuProps {
+  /** All wiki entries available to mention. */
+  items: MentionItem[];
+  /** Substring filter typed after the trigger character. */
+  query: string;
+  /** Top-left corner where the menu should float. */
+  position: { top: number; left: number };
+  /** Optional category constraint. When set, only items in this bucket
+   *  are shown — used by slash actions like "Insert task reference"
+   *  that intentionally want a single bucket. */
+  categoryFilter?: MentionCategory | null;
+  /** Optional title displayed at the top of the menu. */
+  heading?: string;
+  onSelect: (item: MentionItem) => void;
+  onClose: () => void;
+}
+
+export function MentionMenu({
+  items,
+  query,
+  position,
+  categoryFilter,
+  heading,
+  onSelect,
+  onClose,
+}: MentionMenuProps): React.ReactElement | null {
+  const filtered = categoryFilter
+    ? items.filter((i) => i.category === categoryFilter)
+    : items;
+  const ranked = searchMentionItems(filtered, query, 50);
+  const grouped = groupMentionItems(ranked);
+  // Flatten to a single array of [categoryHeader, items...] so keyboard
+  // nav iterates predictably across buckets.
+  const flat: MentionItem[] = [];
+  for (const g of grouped) flat.push(...g.items);
+  const [activeIdx, setActiveIdx] = useState(0);
+
+  useEffect(() => {
+    if (activeIdx >= flat.length) setActiveIdx(Math.max(0, flat.length - 1));
+  }, [flat.length, activeIdx]);
+
+  useMenuKeyNav<MentionItem>({
+    items: flat,
+    activeIdx,
+    setActiveIdx,
+    onCommit: onSelect,
+    onClose,
+  });
+
+  if (flat.length === 0) {
+    return createPortal(
+      <div
+        className="wk-insert-menu wk-insert-menu--empty"
+        data-testid="wk-mention-menu-empty"
+        style={floatingStyle(position)}
+        role="listbox"
+      >
+        <div className="wk-insert-menu__empty">No matches</div>
+      </div>,
+      document.body,
+    );
+  }
+
+  let runningIdx = 0;
+  return createPortal(
+    <div
+      className="wk-insert-menu wk-insert-menu--mention"
+      data-testid="wk-mention-menu"
+      style={floatingStyle(position)}
+      role="listbox"
+      aria-label={heading ?? "Insert mention"}
+    >
+      {heading ? (
+        <div className="wk-insert-menu__heading">{heading}</div>
+      ) : null}
+      {grouped.map((g) => (
+        <div key={g.category} className="wk-insert-menu__group">
+          <div className="wk-insert-menu__group-label">
+            {categoryLabel(g.category)}
+          </div>
+          <ul className="wk-insert-menu__list">
+            {g.items.map((item) => {
+              const idx = runningIdx;
+              runningIdx += 1;
+              return (
+                <li
+                  key={item.slug}
+                  className={
+                    "wk-insert-menu__item" +
+                    (idx === activeIdx ? " is-active" : "")
+                  }
+                >
+                  <button
+                    type="button"
+                    className="wk-insert-menu__btn"
+                    role="option"
+                    aria-selected={idx === activeIdx}
+                    data-testid={`wk-mention-${item.slug}`}
+                    onMouseEnter={() => setActiveIdx(idx)}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      onSelect(item);
+                    }}
+                  >
+                    <span className="wk-insert-menu__title">{item.title}</span>
+                    <span className="wk-insert-menu__desc">{item.slug}</span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ))}
+    </div>,
+    document.body,
+  );
+}

--- a/web/src/components/wiki/editor/inserts/RelatedDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/RelatedDialog.tsx
@@ -1,0 +1,137 @@
+/**
+ * Modal multi-picker for the "Insert related pages" action.
+ *
+ * Shows the catalog grouped by category with a checkbox per entry. The
+ * "Insert" button stitches the selected entries into a `## Related`
+ * markdown block and hands it back to the controller.
+ */
+
+import { useMemo, useRef, useState } from "react";
+
+import { buildRelatedBlock } from "./markdownShapes";
+import {
+  categoryLabel,
+  groupMentionItems,
+  type MentionItem,
+  searchMentionItems,
+} from "./mentionCatalog";
+
+export interface RelatedDialogProps {
+  items: MentionItem[];
+  onConfirm: (block: string) => void;
+  onCancel: () => void;
+}
+
+export function RelatedDialog({
+  items,
+  onConfirm,
+  onCancel,
+}: RelatedDialogProps): React.ReactElement {
+  const [query, setQuery] = useState("");
+  const [picked, setPicked] = useState<Set<string>>(new Set());
+  const queryRef = useRef<HTMLInputElement | null>(null);
+
+  const filtered = useMemo(
+    () => searchMentionItems(items, query, 200),
+    [items, query],
+  );
+  const grouped = useMemo(() => groupMentionItems(filtered), [filtered]);
+
+  function togglePick(slug: string): void {
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  }
+
+  function handleConfirm(): void {
+    const entries = Array.from(picked).map((slug) => {
+      const item = items.find((i) => i.slug === slug);
+      return { slug, display: item?.title };
+    });
+    const block = buildRelatedBlock(entries);
+    if (block.length === 0) return;
+    onConfirm(block);
+  }
+
+  return (
+    <div
+      className="wk-modal-backdrop"
+      data-testid="wk-related-dialog-backdrop"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div
+        className="wk-modal wk-insert-dialog"
+        data-testid="wk-related-dialog"
+      >
+        <h2>Insert related pages</h2>
+        <label htmlFor="wk-related-search" className="wk-editor-label">
+          Filter
+        </label>
+        <input
+          id="wk-related-search"
+          ref={queryRef}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search wiki pages"
+          data-testid="wk-related-search"
+        />
+        <div className="wk-insert-dialog__pickers">
+          {grouped.length === 0 ? (
+            <div className="wk-insert-menu__empty">No matching pages</div>
+          ) : (
+            grouped.map((g) => (
+              <div key={g.category} className="wk-insert-menu__group">
+                <div className="wk-insert-menu__group-label">
+                  {categoryLabel(g.category)}
+                </div>
+                <ul className="wk-related-list">
+                  {g.items.map((item) => (
+                    <li key={item.slug}>
+                      <label className="wk-related-row">
+                        <input
+                          type="checkbox"
+                          checked={picked.has(item.slug)}
+                          onChange={() => togglePick(item.slug)}
+                          data-testid={`wk-related-check-${item.slug}`}
+                        />
+                        <span className="wk-related-row__title">
+                          {item.title}
+                        </span>
+                        <span className="wk-related-row__slug">
+                          {item.slug}
+                        </span>
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))
+          )}
+        </div>
+        <div className="wk-insert-dialog__actions">
+          <button
+            type="button"
+            className="wk-editor-save"
+            disabled={picked.size === 0}
+            onClick={handleConfirm}
+            data-testid="wk-related-confirm"
+          >
+            Insert ({picked.size})
+          </button>
+          <button
+            type="button"
+            className="wk-editor-cancel"
+            onClick={onCancel}
+            data-testid="wk-related-cancel"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/wiki/editor/inserts/RelatedDialog.tsx
+++ b/web/src/components/wiki/editor/inserts/RelatedDialog.tsx
@@ -6,7 +6,7 @@
  * markdown block and hands it back to the controller.
  */
 
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { buildRelatedBlock } from "./markdownShapes";
 import {
@@ -30,6 +30,13 @@ export function RelatedDialog({
   const [query, setQuery] = useState("");
   const [picked, setPicked] = useState<Set<string>>(new Set());
   const queryRef = useRef<HTMLInputElement | null>(null);
+
+  // Auto-focus the search input on mount, matching CitationDialog,
+  // DecisionDialog, and FactDialog so all four dialogs share the same
+  // first-input focus behavior.
+  useEffect(() => {
+    queryRef.current?.focus();
+  }, []);
 
   const filtered = useMemo(
     () => searchMentionItems(items, query, 200),
@@ -62,6 +69,12 @@ export function RelatedDialog({
       data-testid="wk-related-dialog-backdrop"
       role="dialog"
       aria-modal="true"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          onCancel();
+        }
+      }}
     >
       <div
         className="wk-modal wk-insert-dialog"

--- a/web/src/components/wiki/editor/inserts/SlashMenu.test.tsx
+++ b/web/src/components/wiki/editor/inserts/SlashMenu.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Component tests for the slash menu.
+ *
+ * Verifies query filtering, keyboard navigation (Arrow keys + Enter +
+ * Escape), and that selection emits the canonical `SlashAction` id.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SlashMenu } from "./SlashMenu";
+
+describe("<SlashMenu>", () => {
+  const position = { top: 100, left: 100 };
+
+  it("shows every action when the query is empty", () => {
+    render(
+      <SlashMenu
+        query=""
+        position={position}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("wk-slash-action-wiki-link")).toBeInTheDocument();
+    expect(screen.getByTestId("wk-slash-action-citation")).toBeInTheDocument();
+    expect(screen.getByTestId("wk-slash-action-fact")).toBeInTheDocument();
+    expect(screen.getByTestId("wk-slash-action-task-ref")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("wk-slash-action-agent-mention"),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("wk-slash-action-decision")).toBeInTheDocument();
+    expect(screen.getByTestId("wk-slash-action-related")).toBeInTheDocument();
+  });
+
+  it("filters by title or keyword substring", () => {
+    render(
+      <SlashMenu
+        query="cite"
+        position={position}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("wk-slash-action-citation")).toBeInTheDocument();
+    expect(screen.queryByTestId("wk-slash-action-fact")).toBeNull();
+  });
+
+  it("renders the empty state when no actions match", () => {
+    render(
+      <SlashMenu
+        query="absolutely-nothing"
+        position={position}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    expect(screen.getByTestId("wk-slash-menu-empty")).toBeInTheDocument();
+  });
+
+  it("emits the action id on click", () => {
+    const onSelect = vi.fn();
+    render(
+      <SlashMenu
+        query=""
+        position={position}
+        onSelect={onSelect}
+        onClose={() => {}}
+      />,
+    );
+    fireEvent.mouseDown(screen.getByTestId("wk-slash-action-fact"));
+    expect(onSelect).toHaveBeenCalledWith("fact");
+  });
+
+  it("commits the active action on Enter", () => {
+    const onSelect = vi.fn();
+    render(
+      <SlashMenu
+        query=""
+        position={position}
+        onSelect={onSelect}
+        onClose={() => {}}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    fireEvent.keyDown(window, { key: "ArrowDown" });
+    fireEvent.keyDown(window, { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    // First action was wiki-link (idx 0); two ArrowDowns -> fact (idx 2).
+    expect(onSelect).toHaveBeenCalledWith("fact");
+  });
+
+  it("calls onClose on Escape", () => {
+    const onClose = vi.fn();
+    render(
+      <SlashMenu
+        query=""
+        position={position}
+        onSelect={() => {}}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/wiki/editor/inserts/SlashMenu.tsx
+++ b/web/src/components/wiki/editor/inserts/SlashMenu.tsx
@@ -58,6 +58,7 @@ export function SlashMenu({
         data-testid="wk-slash-menu-empty"
         style={floatingStyle(position)}
         role="listbox"
+        aria-label="Insert action"
       >
         <div className="wk-insert-menu__empty">No matching actions</div>
       </div>,

--- a/web/src/components/wiki/editor/inserts/SlashMenu.tsx
+++ b/web/src/components/wiki/editor/inserts/SlashMenu.tsx
@@ -1,0 +1,117 @@
+/**
+ * Floating slash menu shown when the user types `/` in the rich editor.
+ *
+ * Renders the list of available WUPHF-specific actions filtered by the
+ * trigger query. Keyboard navigation: ArrowUp/ArrowDown moves the active
+ * row, Enter commits, Escape closes. The menu mounts via portal so it
+ * floats above the editor surface without disturbing the document flow.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import {
+  filterSlashActions,
+  type SlashAction,
+  type SlashActionDef,
+} from "./types";
+import { useMenuKeyNav } from "./useMenuKeyNav";
+
+export interface SlashMenuProps {
+  query: string;
+  position: { top: number; left: number };
+  onSelect: (action: SlashAction) => void;
+  onClose: () => void;
+}
+
+export function SlashMenu({
+  query,
+  position,
+  onSelect,
+  onClose,
+}: SlashMenuProps): React.ReactElement | null {
+  const [activeIdx, setActiveIdx] = useState(0);
+  const items: SlashActionDef[] = filterSlashActions(query);
+
+  // Clamp the active index when filtering shrinks the list past it,
+  // otherwise Enter would commit a stale selection or out-of-bounds row.
+  useEffect(() => {
+    if (activeIdx >= items.length) setActiveIdx(Math.max(0, items.length - 1));
+  }, [items.length, activeIdx]);
+
+  const onCommit = useCallback(
+    (item: SlashActionDef) => onSelect(item.id),
+    [onSelect],
+  );
+  useMenuKeyNav<SlashActionDef>({
+    items,
+    activeIdx,
+    setActiveIdx,
+    onCommit,
+    onClose,
+  });
+
+  if (items.length === 0) {
+    return createPortal(
+      <div
+        className="wk-insert-menu wk-insert-menu--empty"
+        data-testid="wk-slash-menu-empty"
+        style={floatingStyle(position)}
+        role="listbox"
+      >
+        <div className="wk-insert-menu__empty">No matching actions</div>
+      </div>,
+      document.body,
+    );
+  }
+
+  return createPortal(
+    <div
+      className="wk-insert-menu"
+      data-testid="wk-slash-menu"
+      style={floatingStyle(position)}
+      role="listbox"
+      aria-label="Insert action"
+    >
+      <ul className="wk-insert-menu__list">
+        {items.map((item, idx) => (
+          <li
+            key={item.id}
+            className={`wk-insert-menu__item${idx === activeIdx ? " is-active" : ""}`}
+          >
+            <button
+              type="button"
+              className="wk-insert-menu__btn"
+              role="option"
+              aria-selected={idx === activeIdx}
+              data-testid={`wk-slash-action-${item.id}`}
+              onMouseEnter={() => setActiveIdx(idx)}
+              onMouseDown={(e) => {
+                // mousedown so the editor doesn't blur first and lose
+                // the caret position we need to insert at.
+                e.preventDefault();
+                onSelect(item.id);
+              }}
+            >
+              <span className="wk-insert-menu__title">{item.title}</span>
+              <span className="wk-insert-menu__desc">{item.description}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>,
+    document.body,
+  );
+}
+
+export function floatingStyle(position: {
+  top: number;
+  left: number;
+}): React.CSSProperties {
+  return {
+    position: "fixed",
+    top: `${position.top}px`,
+    left: `${position.left}px`,
+    zIndex: 50,
+  };
+}

--- a/web/src/components/wiki/editor/inserts/brokenLinks.test.ts
+++ b/web/src/components/wiki/editor/inserts/brokenLinks.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { findBrokenWikilinks } from "./brokenLinks";
+
+describe("findBrokenWikilinks", () => {
+  it("returns the slugs missing from the catalog", () => {
+    const md = "See [[alex]] and [[ghost]]. Also [[sarah]].";
+    const known = new Set(["alex", "sarah"]);
+    const broken = findBrokenWikilinks(md, (s) => known.has(s));
+    expect(broken.map((b) => b.slug)).toEqual(["ghost"]);
+  });
+
+  it("returns empty when every slug resolves", () => {
+    const md = "[[alex]] worked with [[sarah]].";
+    const broken = findBrokenWikilinks(md, () => true);
+    expect(broken).toEqual([]);
+  });
+
+  it("ignores wikilinks inside fenced code blocks", () => {
+    const md = "Real [[alex]].\n\n```\n[[ghost]]\n```\n";
+    const broken = findBrokenWikilinks(md, (s) => s === "alex");
+    expect(broken).toEqual([]);
+  });
+
+  it("ignores wikilinks inside inline code spans", () => {
+    const md = "See `[[ghost]]` for syntax. Real link [[alex]].";
+    const broken = findBrokenWikilinks(md, (s) => s === "alex");
+    expect(broken).toEqual([]);
+  });
+
+  it("dedupes repeated broken slugs", () => {
+    const md = "[[ghost]] then [[ghost]] again.";
+    const broken = findBrokenWikilinks(md, () => false);
+    expect(broken.map((b) => b.slug)).toEqual(["ghost"]);
+  });
+
+  it("ignores malformed wikilink shapes", () => {
+    const md = "[[..]] [[/abs]] [[good]]";
+    const broken = findBrokenWikilinks(md, () => false);
+    expect(broken.map((b) => b.slug)).toEqual(["good"]);
+  });
+});

--- a/web/src/components/wiki/editor/inserts/brokenLinks.test.ts
+++ b/web/src/components/wiki/editor/inserts/brokenLinks.test.ts
@@ -39,4 +39,16 @@ describe("findBrokenWikilinks", () => {
     const broken = findBrokenWikilinks(md, () => false);
     expect(broken.map((b) => b.slug)).toEqual(["good"]);
   });
+
+  it("ignores wikilinks inside tilde-fenced code blocks", () => {
+    const md = "Real [[alex]].\n\n~~~\n[[ghost]]\n~~~\n";
+    const broken = findBrokenWikilinks(md, (s) => s === "alex");
+    expect(broken).toEqual([]);
+  });
+
+  it("ignores wikilinks inside multi-backtick inline spans", () => {
+    const md = "Use ``[[ghost]]`` for examples. Real [[alex]].";
+    const broken = findBrokenWikilinks(md, (s) => s === "alex");
+    expect(broken).toEqual([]);
+  });
 });

--- a/web/src/components/wiki/editor/inserts/brokenLinks.ts
+++ b/web/src/components/wiki/editor/inserts/brokenLinks.ts
@@ -14,7 +14,7 @@ import { parseWikiLinkInner } from "../../../../lib/wikilink";
 // tilde-fence and multi-backtick branches, valid Markdown code that wraps
 // `[[wikilink]]` examples would still be scanned and produce false
 // unresolved-link warnings.
-const CODE_SEGMENT_RE = /(`{3,}[\s\S]*?`{3,}|~{3,}[\s\S]*?~{3,}|`+[^`\n]*`+)/g;
+const CODE_SEGMENT_RE = /((`{3,}|~{3,})[\s\S]*?\2|(`+)[^`\n]*\3)/g;
 const WIKILINK_RE = /\[\[([^\]\n]+)\]\]/g;
 
 export interface BrokenLink {

--- a/web/src/components/wiki/editor/inserts/brokenLinks.ts
+++ b/web/src/components/wiki/editor/inserts/brokenLinks.ts
@@ -1,0 +1,41 @@
+/**
+ * Scans markdown for `[[slug]]` wikilinks and reports any that fail the
+ * catalog resolver. Used by the rich editor's broken-link banner so an
+ * unresolved insert is visible before the user saves.
+ *
+ * Skips fenced code blocks and inline code spans so an article that
+ * documents wikilink syntax verbatim does not light up the warning.
+ */
+
+import { parseWikiLinkInner } from "../../../../lib/wikilink";
+
+const CODE_SEGMENT_RE = /(`{3,}[\s\S]*?`{3,}|`[^`\n]+`)/g;
+const WIKILINK_RE = /\[\[([^\]\n]+)\]\]/g;
+
+export interface BrokenLink {
+  slug: string;
+  display: string;
+}
+
+export function findBrokenWikilinks(
+  markdown: string,
+  resolver: (slug: string) => boolean,
+): BrokenLink[] {
+  const broken: BrokenLink[] = [];
+  const seen = new Set<string>();
+  const parts = markdown.split(CODE_SEGMENT_RE);
+  for (let i = 0; i < parts.length; i += 2) {
+    const segment = parts[i];
+    let match = WIKILINK_RE.exec(segment);
+    while (match !== null) {
+      const parsed = parseWikiLinkInner(match[1]);
+      if (parsed && !resolver(parsed.slug) && !seen.has(parsed.slug)) {
+        seen.add(parsed.slug);
+        broken.push(parsed);
+      }
+      match = WIKILINK_RE.exec(segment);
+    }
+    WIKILINK_RE.lastIndex = 0;
+  }
+  return broken;
+}

--- a/web/src/components/wiki/editor/inserts/brokenLinks.ts
+++ b/web/src/components/wiki/editor/inserts/brokenLinks.ts
@@ -9,7 +9,12 @@
 
 import { parseWikiLinkInner } from "../../../../lib/wikilink";
 
-const CODE_SEGMENT_RE = /(`{3,}[\s\S]*?`{3,}|`[^`\n]+`)/g;
+// Matches fenced blocks (``` or ~~~ of length 3+) and inline code spans
+// (any run of one or more backticks, balanced on both sides). Without the
+// tilde-fence and multi-backtick branches, valid Markdown code that wraps
+// `[[wikilink]]` examples would still be scanned and produce false
+// unresolved-link warnings.
+const CODE_SEGMENT_RE = /(`{3,}[\s\S]*?`{3,}|~{3,}[\s\S]*?~{3,}|`+[^`\n]*`+)/g;
 const WIKILINK_RE = /\[\[([^\]\n]+)\]\]/g;
 
 export interface BrokenLink {

--- a/web/src/components/wiki/editor/inserts/dialogs.test.tsx
+++ b/web/src/components/wiki/editor/inserts/dialogs.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Component tests for the insert dialogs.
+ *
+ * Covers the contracts that the phase doc commits to:
+ *   - Fact dialog never auto-writes; the preview stage is mandatory.
+ *   - Citation dialog requires a URL.
+ *   - Decision dialog defaults the date and validates required fields.
+ *   - Related dialog stitches a `## Related` block from picked entries.
+ *
+ * The dialogs are framework-agnostic — they don't touch ProseMirror
+ * directly — so we can render them in isolation with happy-dom.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CitationDialog } from "./CitationDialog";
+import { DecisionDialog } from "./DecisionDialog";
+import { FactDialog } from "./FactDialog";
+import type { MentionItem } from "./mentionCatalog";
+import { RelatedDialog } from "./RelatedDialog";
+
+describe("<CitationDialog>", () => {
+  it("rejects an empty URL and surfaces an error", () => {
+    const onConfirm = vi.fn();
+    render(
+      <CitationDialog
+        currentMarkdown=""
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("wk-citation-confirm"));
+    expect(screen.getByTestId("wk-citation-error")).toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("emits a footnote pair with an allocated id", () => {
+    const onConfirm = vi.fn();
+    render(
+      <CitationDialog
+        currentMarkdown="Body has [^1] in use already."
+        onConfirm={onConfirm}
+        onCancel={() => {}}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("wk-citation-url"), {
+      target: { value: "https://example.com" },
+    });
+    fireEvent.change(screen.getByTestId("wk-citation-title"), {
+      target: { value: "Source" },
+    });
+    fireEvent.click(screen.getByTestId("wk-citation-confirm"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    const built = onConfirm.mock.calls[0][0];
+    expect(built.reference).toBe("[^2]");
+    expect(built.definition).toContain("[^2]: Source - https://example.com");
+  });
+});
+
+describe("<FactDialog> — review-required contract", () => {
+  it("does not call onConfirm from the edit stage even when fields are valid", () => {
+    const onConfirm = vi.fn();
+    render(<FactDialog onConfirm={onConfirm} onCancel={() => {}} />);
+    fireEvent.change(screen.getByTestId("wk-fact-subject"), {
+      target: { value: "alex" },
+    });
+    fireEvent.change(screen.getByTestId("wk-fact-predicate"), {
+      target: { value: "works_at" },
+    });
+    fireEvent.change(screen.getByTestId("wk-fact-object"), {
+      target: { value: "nex" },
+    });
+    fireEvent.click(screen.getByTestId("wk-fact-preview"));
+    // Now in preview stage — preview block visible but onConfirm has not run.
+    expect(screen.getByTestId("wk-fact-preview-block")).toHaveTextContent(
+      /subject: alex/,
+    );
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("only writes the fact after the user confirms the preview", () => {
+    const onConfirm = vi.fn();
+    render(<FactDialog onConfirm={onConfirm} onCancel={() => {}} />);
+    fireEvent.change(screen.getByTestId("wk-fact-subject"), {
+      target: { value: "alex" },
+    });
+    fireEvent.change(screen.getByTestId("wk-fact-predicate"), {
+      target: { value: "works_at" },
+    });
+    fireEvent.change(screen.getByTestId("wk-fact-object"), {
+      target: { value: "nex" },
+    });
+    fireEvent.click(screen.getByTestId("wk-fact-preview"));
+    fireEvent.click(screen.getByTestId("wk-fact-confirm"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm.mock.calls[0][0]).toContain("```fact");
+    expect(onConfirm.mock.calls[0][0]).toContain("subject: alex");
+  });
+
+  it("rejects empty fields with a banner instead of advancing", () => {
+    const onConfirm = vi.fn();
+    render(<FactDialog onConfirm={onConfirm} onCancel={() => {}} />);
+    fireEvent.click(screen.getByTestId("wk-fact-preview"));
+    expect(screen.getByTestId("wk-fact-error")).toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});
+
+describe("<DecisionDialog>", () => {
+  it("requires a non-empty title and rationale", () => {
+    const onConfirm = vi.fn();
+    render(<DecisionDialog onConfirm={onConfirm} onCancel={() => {}} />);
+    fireEvent.click(screen.getByTestId("wk-decision-confirm"));
+    expect(screen.getByTestId("wk-decision-error")).toBeInTheDocument();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("emits a decision block with the user's inputs", () => {
+    const onConfirm = vi.fn();
+    render(<DecisionDialog onConfirm={onConfirm} onCancel={() => {}} />);
+    fireEvent.change(screen.getByTestId("wk-decision-title"), {
+      target: { value: "Adopt Milkdown" },
+    });
+    fireEvent.change(screen.getByTestId("wk-decision-rationale"), {
+      target: { value: "Round-trip-clean wikilinks." },
+    });
+    fireEvent.change(screen.getByTestId("wk-decision-alternatives"), {
+      target: { value: "TipTap, ProseMirror raw" },
+    });
+    fireEvent.click(screen.getByTestId("wk-decision-confirm"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    const block = onConfirm.mock.calls[0][0];
+    expect(block).toContain("```decision");
+    expect(block).toContain("title: Adopt Milkdown");
+    expect(block).toContain("rationale: Round-trip-clean wikilinks.");
+    expect(block).toContain("alternatives: TipTap, ProseMirror raw");
+  });
+});
+
+describe("<RelatedDialog>", () => {
+  const items: MentionItem[] = [
+    { slug: "team/people/alex", title: "Alex Chen", category: "people" },
+    { slug: "team/people/sarah", title: "Sarah Lee", category: "people" },
+    {
+      slug: "team/projects/backend",
+      title: "Backend rewrite",
+      category: "projects",
+    },
+  ];
+
+  it("disables Insert until at least one entry is picked", () => {
+    const onConfirm = vi.fn();
+    render(
+      <RelatedDialog items={items} onConfirm={onConfirm} onCancel={() => {}} />,
+    );
+    const button = screen.getByTestId("wk-related-confirm");
+    expect(button).toBeDisabled();
+    fireEvent.click(screen.getByTestId("wk-related-check-team/people/alex"));
+    expect(button).not.toBeDisabled();
+  });
+
+  it("emits a Related block with picked wikilinks", () => {
+    const onConfirm = vi.fn();
+    render(
+      <RelatedDialog items={items} onConfirm={onConfirm} onCancel={() => {}} />,
+    );
+    fireEvent.click(screen.getByTestId("wk-related-check-team/people/alex"));
+    fireEvent.click(
+      screen.getByTestId("wk-related-check-team/projects/backend"),
+    );
+    fireEvent.click(screen.getByTestId("wk-related-confirm"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    const block = onConfirm.mock.calls[0][0];
+    expect(block).toContain("## Related");
+    expect(block).toContain("- [[team/people/alex|Alex Chen]]");
+    expect(block).toContain("- [[team/projects/backend|Backend rewrite]]");
+  });
+});

--- a/web/src/components/wiki/editor/inserts/markdownShapes.test.ts
+++ b/web/src/components/wiki/editor/inserts/markdownShapes.test.ts
@@ -273,9 +273,12 @@ describe("buildFactBlock", () => {
       // Adversarial input: try to terminate the enclosing fence.
       object: "evil ``` payload",
     });
-    // The literal triple-backtick payload has been replaced.
-    expect(block).not.toMatch(/^```\nsubject: alex/);
-    expect(block.split("```").length).toBe(3); // exactly the opener + closer
+    // The embedded triple-backtick must be escaped so the fence has
+    // exactly one opener and one closer (split produces 3 parts).
+    expect(block.split("```").length).toBe(3); // opener + closer only
+    // No bare ``` on a line by itself inside the block content.
+    const lines = block.split("\n").slice(1, -2); // strip opener/closer
+    expect(lines.every((l) => l !== "```")).toBe(true);
   });
 
   it("survives round-trip through Milkdown", async () => {

--- a/web/src/components/wiki/editor/inserts/markdownShapes.test.ts
+++ b/web/src/components/wiki/editor/inserts/markdownShapes.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Round-trip tests for the WUPHF-specific insert shapes.
+ *
+ * Each insert action emits a fragment that gets concatenated into article
+ * markdown. This file proves that:
+ *   1. The fragment alone survives Milkdown parse then serialize then
+ *      `postProcessWikilinks` unchanged.
+ *   2. The fragment composed with surrounding article content also
+ *      survives (no parse interaction with neighbouring blocks).
+ *
+ * The harness mirrors `RichWikiEditor.roundtrip.test.tsx` exactly so the
+ * test stays a faithful proxy for the production editor pipeline.
+ */
+import {
+  defaultValueCtx,
+  Editor,
+  remarkPluginsCtx,
+  remarkStringifyOptionsCtx,
+} from "@milkdown/core";
+import { commonmark } from "@milkdown/preset-commonmark";
+import { gfm } from "@milkdown/preset-gfm";
+import { getMarkdown } from "@milkdown/utils";
+import { describe, expect, it } from "vitest";
+
+import { wikiLinkRemarkPlugin } from "../../../../lib/wikilink";
+import { STRINGIFY_DEFAULTS } from "../../../../lib/wikilinkStringify";
+import { postProcessWikilinks } from "../wikilinkPostProcess";
+import {
+  appendCitationDefinition,
+  buildCitation,
+  buildDecisionBlock,
+  buildFactBlock,
+  buildRelatedBlock,
+  buildWikilink,
+  nextFootnoteId,
+} from "./markdownShapes";
+
+function normalise(s: string): string {
+  return s
+    .split("\n")
+    .map((l) => l.trimEnd())
+    .join("\n")
+    .trim();
+}
+
+async function roundTrip(initial: string): Promise<string> {
+  const root = document.createElement("div");
+  document.body.appendChild(root);
+  try {
+    const editor = await Editor.make()
+      .config((ctx) => {
+        ctx.set(defaultValueCtx, initial);
+        ctx.update(remarkPluginsCtx, (prev) => [
+          ...prev,
+          {
+            plugin: wikiLinkRemarkPlugin(() => true),
+            options: {},
+          },
+        ]);
+        ctx.update(remarkStringifyOptionsCtx, (prev) => ({
+          ...prev,
+          ...STRINGIFY_DEFAULTS,
+        }));
+      })
+      .use(commonmark)
+      .use(gfm)
+      .create();
+    try {
+      const md = editor.action(getMarkdown());
+      return postProcessWikilinks(md);
+    } finally {
+      await editor.destroy();
+    }
+  } finally {
+    root.remove();
+  }
+}
+
+// ─── buildWikilink ─────────────────────────────────────────────────────────
+
+describe("buildWikilink", () => {
+  it("emits bare slug form when display matches slug", () => {
+    expect(buildWikilink("alex")).toBe("[[alex]]");
+  });
+
+  it("emits piped form when display differs from slug", () => {
+    expect(buildWikilink("team/people/alex", "Alex Chen")).toBe(
+      "[[team/people/alex|Alex Chen]]",
+    );
+  });
+
+  it("rejects path traversal", () => {
+    expect(buildWikilink("../escape")).toBeNull();
+  });
+
+  it("rejects empty slug", () => {
+    expect(buildWikilink("   ")).toBeNull();
+  });
+
+  it("survives round-trip in a paragraph", async () => {
+    const md = `See ${buildWikilink("alex")} for details.\n`;
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
+  });
+
+  it("survives round-trip with display text in a paragraph", async () => {
+    const md = `Owner: ${buildWikilink("team/people/alex", "Alex Chen")}.\n`;
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
+  });
+});
+
+// ─── buildCitation ─────────────────────────────────────────────────────────
+
+describe("buildCitation", () => {
+  it("returns inline reference plus block definition", () => {
+    const built = buildCitation({
+      id: "1",
+      title: "WUPHF launch",
+      url: "https://example.com/launch",
+    });
+    expect(built.reference).toBe("[^1]");
+    expect(built.definition).toBe(
+      "[^1]: WUPHF launch - https://example.com/launch\n",
+    );
+  });
+
+  it("falls back to URL when title is empty", () => {
+    const built = buildCitation({
+      id: "1",
+      title: "",
+      url: "https://example.com",
+    });
+    expect(built.definition).toBe(
+      "[^1]: https://example.com - https://example.com\n",
+    );
+  });
+
+  it("strips disallowed footnote-id characters", () => {
+    const built = buildCitation({
+      id: "weird id",
+      title: "x",
+      url: "https://x.com",
+    });
+    expect(built.reference).toBe("[^weirdid]");
+  });
+
+  it("survives round-trip when reference and definition coexist", async () => {
+    const cite = buildCitation({
+      id: "1",
+      title: "Source",
+      url: "https://example.com",
+    });
+    const md = `Body${cite.reference}.\n\n${cite.definition}`;
+    const out = normalise(await roundTrip(md));
+    expect(out).toContain(cite.reference);
+    expect(out).toContain("[^1]:");
+    expect(out).toContain("https://example.com");
+  });
+});
+
+describe("nextFootnoteId", () => {
+  it("returns 1 when no footnotes exist", () => {
+    expect(nextFootnoteId("plain markdown")).toBe("1");
+  });
+
+  it("skips ids already in use", () => {
+    expect(nextFootnoteId("ref [^1] and [^2]\n[^1]: a\n[^2]: b\n")).toBe("3");
+  });
+
+  it("keeps numbering even when ids are non-numeric", () => {
+    expect(nextFootnoteId("see [^source-a]")).toBe("1");
+  });
+});
+
+describe("appendCitationDefinition", () => {
+  it("appends when the id is new", () => {
+    const out = appendCitationDefinition(
+      "Body of article.\n",
+      "[^1]: Title - https://example.com\n",
+    );
+    expect(out).toContain("[^1]: Title - https://example.com");
+    expect(out.endsWith("\n")).toBe(true);
+  });
+
+  it("does not append when the id already exists", () => {
+    const before = "Body.\n\n[^1]: Existing - https://existing.com\n";
+    const out = appendCitationDefinition(
+      before,
+      "[^1]: Different - https://different.com\n",
+    );
+    expect(out).toBe(before);
+  });
+
+  it("preserves a single trailing newline", () => {
+    const out = appendCitationDefinition(
+      "Body.\n\n\n",
+      "[^1]: T - https://x.com\n",
+    );
+    expect(out.endsWith("\n")).toBe(true);
+    expect(out.endsWith("\n\n")).toBe(false);
+  });
+});
+
+// ─── buildFactBlock ────────────────────────────────────────────────────────
+
+describe("buildFactBlock", () => {
+  it("emits a fenced block with the required keys", () => {
+    const block = buildFactBlock({
+      subject: "alex",
+      predicate: "works_at",
+      object: "nex",
+    });
+    expect(block).toBe(
+      "```fact\nsubject: alex\npredicate: works_at\nobject: nex\n```\n",
+    );
+  });
+
+  it("includes confidence when provided", () => {
+    const block = buildFactBlock({
+      subject: "alex",
+      predicate: "works_at",
+      object: "nex",
+      confidence: 0.9,
+    });
+    expect(block).toContain("confidence: 0.9");
+  });
+
+  it("clamps confidence to [0, 1]", () => {
+    expect(
+      buildFactBlock({
+        subject: "a",
+        predicate: "b",
+        object: "c",
+        confidence: 1.5,
+      }),
+    ).toContain("confidence: 1");
+    expect(
+      buildFactBlock({
+        subject: "a",
+        predicate: "b",
+        object: "c",
+        confidence: -0.4,
+      }),
+    ).toContain("confidence: 0");
+  });
+
+  it("escapes embedded fences so the surrounding fence stays intact", () => {
+    const block = buildFactBlock({
+      subject: "alex",
+      predicate: "works_at",
+      // Adversarial input: try to terminate the enclosing fence.
+      object: "evil ``` payload",
+    });
+    // The literal triple-backtick payload has been replaced.
+    expect(block).not.toMatch(/^```\nsubject: alex/);
+    expect(block.split("```").length).toBe(3); // exactly the opener + closer
+  });
+
+  it("survives round-trip through Milkdown", async () => {
+    const block = buildFactBlock({
+      subject: "alex",
+      predicate: "works_at",
+      object: "nex",
+      confidence: 0.9,
+    });
+    const md = `Some prose.\n\n${block}\nMore prose.\n`;
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
+  });
+});
+
+// ─── buildDecisionBlock ────────────────────────────────────────────────────
+
+describe("buildDecisionBlock", () => {
+  it("emits a fenced block with title, date, rationale", () => {
+    const block = buildDecisionBlock({
+      title: "Adopt Milkdown for rich editor",
+      date: "2026-05-06",
+      rationale: "Smallest workable surface for round-trip wikilinks.",
+    });
+    expect(block).toContain("```decision");
+    expect(block).toContain("title: Adopt Milkdown for rich editor");
+    expect(block).toContain("date: 2026-05-06");
+    expect(block).toContain(
+      "rationale: Smallest workable surface for round-trip wikilinks.",
+    );
+  });
+
+  it("appends comma-joined alternatives when provided", () => {
+    const block = buildDecisionBlock({
+      title: "x",
+      date: "2026-05-06",
+      rationale: "y",
+      alternatives: ["TipTap", "ProseMirror raw", " "],
+    });
+    expect(block).toContain("alternatives: TipTap, ProseMirror raw");
+  });
+
+  it("survives round-trip through Milkdown", async () => {
+    const block = buildDecisionBlock({
+      title: "Adopt Milkdown",
+      date: "2026-05-06",
+      rationale: "Smallest workable surface.",
+      alternatives: ["TipTap", "ProseMirror"],
+    });
+    const md = `# Engineering log\n\n${block}\n`;
+    expect(normalise(await roundTrip(md))).toBe(normalise(md));
+  });
+});
+
+// ─── buildRelatedBlock ─────────────────────────────────────────────────────
+
+describe("buildRelatedBlock", () => {
+  it("emits a heading + bullet list of wikilinks", () => {
+    const block = buildRelatedBlock([
+      { slug: "team/people/alex", display: "Alex Chen" },
+      { slug: "team/projects/backend" },
+    ]);
+    expect(block).toBe(
+      "## Related\n\n- [[team/people/alex|Alex Chen]]\n- [[team/projects/backend]]\n",
+    );
+  });
+
+  it("returns empty string when no entries are valid", () => {
+    expect(buildRelatedBlock([{ slug: ".." }])).toBe("");
+  });
+
+  it("drops malformed entries without aborting the block", () => {
+    const block = buildRelatedBlock([
+      { slug: "alex" },
+      { slug: ".." },
+      { slug: "/abs" },
+      { slug: "team/projects/backend" },
+    ]);
+    expect(block).toContain("- [[alex]]");
+    expect(block).toContain("- [[team/projects/backend]]");
+    expect(block).not.toContain("..");
+  });
+
+  it("survives round-trip through Milkdown in canonical loose-list form", async () => {
+    // Milkdown's commonmark serializer renders bullet lists in loose form
+    // (a blank line between siblings) — the same shape the existing
+    // RichWikiEditor.roundtrip.test.tsx pins for nested lists. Edits
+    // settle on this canonical shape after one save and remain stable.
+    const block = buildRelatedBlock([
+      { slug: "team/people/alex", display: "Alex Chen" },
+      { slug: "team/projects/backend" },
+    ]);
+    const canonical =
+      "# Page\n\nSome prose.\n\n## Related\n\n- [[team/people/alex|Alex Chen]]\n\n- [[team/projects/backend]]\n";
+    const md = `# Page\n\nSome prose.\n\n${block}`;
+    expect(normalise(await roundTrip(md))).toBe(normalise(canonical));
+  });
+});

--- a/web/src/components/wiki/editor/inserts/markdownShapes.test.ts
+++ b/web/src/components/wiki/editor/inserts/markdownShapes.test.ts
@@ -26,6 +26,7 @@ import { wikiLinkRemarkPlugin } from "../../../../lib/wikilink";
 import { STRINGIFY_DEFAULTS } from "../../../../lib/wikilinkStringify";
 import { postProcessWikilinks } from "../wikilinkPostProcess";
 import {
+  appendBlockToTail,
   appendCitationDefinition,
   buildCitation,
   buildDecisionBlock,
@@ -197,6 +198,28 @@ describe("appendCitationDefinition", () => {
     );
     expect(out.endsWith("\n")).toBe(true);
     expect(out.endsWith("\n\n")).toBe(false);
+  });
+});
+
+describe("appendBlockToTail", () => {
+  it("appends a block separated by a blank line", () => {
+    const out = appendBlockToTail("Body.\n", "```fact\nx\n```\n");
+    expect(out).toBe("Body.\n\n```fact\nx\n```\n");
+  });
+
+  it("returns just the block when the document is empty", () => {
+    const out = appendBlockToTail("", "```fact\nx\n```\n");
+    expect(out).toBe("```fact\nx\n```\n");
+  });
+
+  it("ignores empty blocks", () => {
+    const out = appendBlockToTail("Body.\n", "");
+    expect(out).toBe("Body.\n");
+  });
+
+  it("collapses any trailing whitespace before the separator", () => {
+    const out = appendBlockToTail("Body.\n\n\n", "```fact\nx\n```");
+    expect(out).toBe("Body.\n\n```fact\nx\n```\n");
   });
 });
 

--- a/web/src/components/wiki/editor/inserts/markdownShapes.ts
+++ b/web/src/components/wiki/editor/inserts/markdownShapes.ts
@@ -1,0 +1,233 @@
+/**
+ * Canonical markdown emitters for the WUPHF-specific editor inserts.
+ *
+ * Each insert action produces a deterministic markdown fragment that survives
+ * the rich editor's parse then serialize then `postProcessWikilinks` round
+ * trip without mutation. The functions here are pure so we can unit-test the
+ * shapes against the headless Milkdown pipeline used by the existing
+ * `RichWikiEditor.roundtrip.test.tsx`.
+ *
+ * Shape choices:
+ *   - Wikilinks (`buildWikilink`): mirror the textarea's `[[slug]]` /
+ *     `[[slug|Display]]` syntax so any insert that resolves to a wiki page
+ *     reuses the same parser/resolver chain. Validated through
+ *     `parseWikiLinkInner` so a malformed slug never reaches the editor.
+ *   - Citations (`buildCitation`): GFM footnotes. The reference is
+ *     inserted at the caret; the matching definition lives in a
+ *     dedicated block we append to the document end. Footnote IDs are
+ *     allocated to avoid collisions with existing markers.
+ *   - Fact / decision blocks (`buildFactBlock`, `buildDecisionBlock`):
+ *     fenced code blocks with the language tag `fact` or `decision`. Both
+ *     serialize losslessly through `commonmark` as the existing round-trip
+ *     test for fenced code already proves. The body is YAML-ish key/value
+ *     so a future broker-side parser can lift the structure without a new
+ *     mdast extension.
+ *   - Related pages (`buildRelatedBlock`): a `## Related` heading
+ *     followed by a bullet list of wikilinks. Plain markdown, no special
+ *     parser required.
+ *
+ * All emitters always finish with a trailing newline so consecutive inserts
+ * compose cleanly when concatenated.
+ */
+
+import { parseWikiLinkInner } from "../../../../lib/wikilink";
+
+/**
+ * Build a `[[slug]]` or `[[slug|Display]]` wikilink. Returns null when the
+ * slug fails wikilink-grammar validation (path traversal, empty string,
+ * control bytes, etc.) so callers can surface a warning instead of writing
+ * a fragment the next parse would discard as literal text.
+ */
+export function buildWikilink(slug: string, display?: string): string | null {
+  const trimmedSlug = slug.trim();
+  const trimmedDisplay = display?.trim() ?? "";
+  const inner =
+    trimmedDisplay && trimmedDisplay !== trimmedSlug
+      ? `${trimmedSlug}|${trimmedDisplay}`
+      : trimmedSlug;
+  if (!parseWikiLinkInner(inner)) return null;
+  return `[[${inner}]]`;
+}
+
+export interface CitationDraft {
+  /** Footnote identifier — must be unique within the document. Lowercased,
+   *  ASCII-only, no whitespace. Caller is expected to allocate via
+   *  `nextFootnoteId`. */
+  id: string;
+  /** Human-readable title. Falls back to the URL when empty. */
+  title: string;
+  /** Source URL. Required. */
+  url: string;
+}
+
+export interface BuiltCitation {
+  /** What goes at the caret — the `[^id]` reference. */
+  reference: string;
+  /** What gets appended to the doc — the `[^id]: Title - URL` definition.
+   *  Always ends with a newline so the appended block stays one footnote
+   *  per line. */
+  definition: string;
+}
+
+/**
+ * GFM footnote pair. The reference is inline; the definition belongs at the
+ * end of the article. `appendCitationDefinition` below stitches the
+ * definition into existing markdown without duplicating an existing entry.
+ */
+export function buildCitation(draft: CitationDraft): BuiltCitation {
+  const id = sanitizeFootnoteId(draft.id);
+  const title = draft.title.trim() || draft.url.trim();
+  const url = draft.url.trim();
+  return {
+    reference: `[^${id}]`,
+    definition: `[^${id}]: ${title} - ${url}\n`,
+  };
+}
+
+/**
+ * Allocate the next available footnote id given the markdown that already
+ * exists in the document. Returns the `id` portion (without the `[^...]`
+ * brackets) so callers can format references consistently.
+ */
+export function nextFootnoteId(existingMarkdown: string): string {
+  const used = new Set<string>();
+  const re = /\[\^([A-Za-z0-9_-]+)\]/g;
+  let match = re.exec(existingMarkdown);
+  while (match !== null) {
+    used.add(match[1]);
+    match = re.exec(existingMarkdown);
+  }
+  let n = 1;
+  while (used.has(String(n))) n += 1;
+  return String(n);
+}
+
+/**
+ * Footnote ids are restricted to `[A-Za-z0-9_-]` because GFM does not
+ * tolerate spaces or other punctuation in the bracket label.
+ */
+function sanitizeFootnoteId(raw: string): string {
+  const cleaned = raw.replace(/[^A-Za-z0-9_-]/g, "").slice(0, 64);
+  return cleaned.length > 0 ? cleaned : "1";
+}
+
+/**
+ * Append a citation definition to the existing markdown. If a definition
+ * with the same id already exists, returns the markdown unchanged so we do
+ * not stack duplicates each time the user re-inserts the same source.
+ */
+export function appendCitationDefinition(
+  markdown: string,
+  definition: string,
+): string {
+  const idMatch = definition.match(/^\[\^([A-Za-z0-9_-]+)\]:/);
+  if (!idMatch) return markdown;
+  const idRe = new RegExp(`(^|\\n)\\[\\^${escapeRegExp(idMatch[1])}\\]:`);
+  if (idRe.test(markdown)) return markdown;
+  const trimmed = markdown.replace(/\s+$/, "");
+  return `${trimmed}\n\n${definition.replace(/\s+$/, "")}\n`;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export interface FactDraft {
+  subject: string;
+  predicate: string;
+  object: string;
+  /** Optional confidence score (0..1). Omitted from the block when undefined. */
+  confidence?: number;
+  /** Optional source citation reference (e.g. `[^1]`). */
+  source?: string;
+}
+
+/**
+ * Fenced ```fact block. Empty fields (other than confidence) are kept
+ * as blank values so the structure stays parseable even when partially
+ * filled out - the preview dialog enforces the required fields before it
+ * lets the user confirm.
+ */
+export function buildFactBlock(draft: FactDraft): string {
+  const lines = [
+    "```fact",
+    `subject: ${escapeBlockValue(draft.subject)}`,
+    `predicate: ${escapeBlockValue(draft.predicate)}`,
+    `object: ${escapeBlockValue(draft.object)}`,
+  ];
+  if (
+    typeof draft.confidence === "number" &&
+    Number.isFinite(draft.confidence)
+  ) {
+    const clamped = Math.max(0, Math.min(1, draft.confidence));
+    lines.push(`confidence: ${clamped}`);
+  }
+  if (draft.source?.trim()) {
+    lines.push(`source: ${escapeBlockValue(draft.source)}`);
+  }
+  lines.push("```");
+  return `${lines.join("\n")}\n`;
+}
+
+export interface DecisionDraft {
+  title: string;
+  rationale: string;
+  /** ISO date - `YYYY-MM-DD`. */
+  date: string;
+  /** Optional list of alternatives that were considered and not chosen. */
+  alternatives?: string[];
+}
+
+/**
+ * Fenced ```decision block. Alternatives render as a single comma-
+ * separated value to keep the body line-oriented and avoid a YAML parser
+ * dependency. Future maintenance can lift this to proper YAML once a
+ * broker-side reader exists.
+ */
+export function buildDecisionBlock(draft: DecisionDraft): string {
+  const lines = [
+    "```decision",
+    `title: ${escapeBlockValue(draft.title)}`,
+    `date: ${escapeBlockValue(draft.date)}`,
+    `rationale: ${escapeBlockValue(draft.rationale)}`,
+  ];
+  if (draft.alternatives && draft.alternatives.length > 0) {
+    const filtered = draft.alternatives
+      .map((a) => a.trim())
+      .filter((a) => a.length > 0);
+    if (filtered.length > 0) {
+      lines.push(`alternatives: ${filtered.join(", ")}`);
+    }
+  }
+  lines.push("```");
+  return `${lines.join("\n")}\n`;
+}
+
+/**
+ * Block values must not contain newlines or backtick fences (which would
+ * break the enclosing code fence). The replacement keeps the value
+ * round-trippable through commonmark while preventing accidental fence
+ * termination.
+ */
+function escapeBlockValue(raw: string): string {
+  return raw.replace(/```/g, "'''").replace(/\r?\n/g, " ").trim();
+}
+
+export interface RelatedBlockEntry {
+  slug: string;
+  display?: string;
+}
+
+/**
+ * `## Related` heading + bullet list. Each entry is filtered through
+ * `buildWikilink` so a malformed slug is silently dropped from the block
+ * rather than corrupting the whole insert.
+ */
+export function buildRelatedBlock(entries: RelatedBlockEntry[]): string {
+  const links = entries
+    .map((e) => buildWikilink(e.slug, e.display))
+    .filter((s): s is string => s !== null);
+  if (links.length === 0) return "";
+  const body = links.map((l) => `- ${l}`).join("\n");
+  return `## Related\n\n${body}\n`;
+}

--- a/web/src/components/wiki/editor/inserts/markdownShapes.ts
+++ b/web/src/components/wiki/editor/inserts/markdownShapes.ts
@@ -212,7 +212,7 @@ export function buildDecisionBlock(draft: DecisionDraft): string {
   ];
   if (draft.alternatives && draft.alternatives.length > 0) {
     const filtered = draft.alternatives
-      .map((a) => a.trim())
+      .map((a) => escapeBlockValue(a))
       .filter((a) => a.length > 0);
     if (filtered.length > 0) {
       lines.push(`alternatives: ${filtered.join(", ")}`);

--- a/web/src/components/wiki/editor/inserts/markdownShapes.ts
+++ b/web/src/components/wiki/editor/inserts/markdownShapes.ts
@@ -132,6 +132,25 @@ function escapeRegExp(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * Append a block fragment (fact, decision, related, etc.) to the document
+ * tail with a single blank line separator. Used in place of
+ * `tr.insertText(\\n${block})` because ProseMirror keeps inserted text
+ * inside the active paragraph node — fenced blocks would round-trip as
+ * literal backticks rather than dedicated block nodes. Routing block
+ * inserts through the controller's `pushContent` re-parses the markdown
+ * at the document level so fenced blocks land as real block nodes.
+ */
+export function appendBlockToTail(markdown: string, block: string): string {
+  const trimmedBlock = block.replace(/^\s+|\s+$/g, "");
+  if (trimmedBlock.length === 0) return markdown;
+  const trimmedDoc = markdown.replace(/\s+$/, "");
+  if (trimmedDoc.length === 0) {
+    return `${trimmedBlock}\n`;
+  }
+  return `${trimmedDoc}\n\n${trimmedBlock}\n`;
+}
+
 export interface FactDraft {
   subject: string;
   predicate: string;

--- a/web/src/components/wiki/editor/inserts/mentionCatalog.test.ts
+++ b/web/src/components/wiki/editor/inserts/mentionCatalog.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import type { WikiCatalogEntry } from "../../../../api/wiki";
+import {
+  categoryOrder,
+  groupMentionItems,
+  searchMentionItems,
+  toMentionItem,
+} from "./mentionCatalog";
+
+function entry(
+  partial: Partial<WikiCatalogEntry> & { path: string; group: string },
+): WikiCatalogEntry {
+  return {
+    title: partial.path.split("/").pop()?.replace(/\.md$/, "") ?? "",
+    author_slug: "human",
+    last_edited_ts: "2026-01-01T00:00:00Z",
+    ...partial,
+  } as WikiCatalogEntry;
+}
+
+/**
+ * Test helper that throws when an entry fails wikilink validation. Lets
+ * the test list stay readable without scattered non-null assertions.
+ */
+function mentionFromEntry(
+  partial: Partial<WikiCatalogEntry> & { path: string; group: string },
+) {
+  const item = toMentionItem(entry(partial));
+  if (!item)
+    throw new Error(`fixture path is not a valid mention: ${partial.path}`);
+  return item;
+}
+
+describe("toMentionItem", () => {
+  it("strips the .md extension from the slug", () => {
+    const item = toMentionItem(
+      entry({ path: "team/people/alex.md", group: "people", title: "Alex" }),
+    );
+    expect(item).not.toBeNull();
+    expect(item?.slug).toBe("team/people/alex");
+    expect(item?.category).toBe("people");
+    expect(item?.title).toBe("Alex");
+  });
+
+  it("classifies legacy agents/ paths as agents even when group is empty", () => {
+    const item = toMentionItem(
+      entry({ path: "agents/operator/notebook/index.md", group: "" }),
+    );
+    expect(item?.category).toBe("agents");
+  });
+
+  it("falls back to pages bucket for unknown groups", () => {
+    const item = toMentionItem(
+      entry({ path: "team/playbooks/onboarding.md", group: "playbooks" }),
+    );
+    expect(item?.category).toBe("pages");
+  });
+
+  it("rejects entries whose path is not a legal wikilink slug", () => {
+    expect(
+      toMentionItem(entry({ path: "../escape.md", group: "x" })),
+    ).toBeNull();
+    expect(
+      toMentionItem(entry({ path: "/leading-slash.md", group: "x" })),
+    ).toBeNull();
+  });
+});
+
+describe("searchMentionItems", () => {
+  const items = [
+    mentionFromEntry({
+      path: "team/people/alex.md",
+      group: "people",
+      title: "Alex Chen",
+    }),
+    mentionFromEntry({
+      path: "team/people/sarah.md",
+      group: "people",
+      title: "Sarah Lee",
+    }),
+    mentionFromEntry({
+      path: "team/projects/backend.md",
+      group: "projects",
+      title: "Backend rewrite",
+    }),
+    mentionFromEntry({
+      path: "agents/operator/notebook/today.md",
+      group: "agents",
+      title: "Operator today",
+    }),
+  ];
+
+  it("returns all items when query is empty (limited)", () => {
+    const out = searchMentionItems(items, "");
+    expect(out).toHaveLength(4);
+  });
+
+  it("ranks title-prefix matches highest", () => {
+    const out = searchMentionItems(items, "alex");
+    expect(out[0]?.title).toBe("Alex Chen");
+  });
+
+  it("falls through to substring matches", () => {
+    const out = searchMentionItems(items, "rewrite");
+    expect(out.map((i) => i.title)).toContain("Backend rewrite");
+  });
+
+  it("respects the limit", () => {
+    const out = searchMentionItems(items, "", 2);
+    expect(out).toHaveLength(2);
+  });
+});
+
+describe("groupMentionItems", () => {
+  it("groups items by category in canonical order", () => {
+    const items = [
+      mentionFromEntry({ path: "team/projects/backend.md", group: "projects" }),
+      mentionFromEntry({ path: "team/people/alex.md", group: "people" }),
+      mentionFromEntry({
+        path: "agents/operator/notebook/today.md",
+        group: "agents",
+      }),
+    ];
+    const grouped = groupMentionItems(items);
+    expect(grouped.map((g) => g.category)).toEqual([
+      "people",
+      "projects",
+      "agents",
+    ]);
+  });
+
+  it("omits empty buckets", () => {
+    const items = [
+      mentionFromEntry({ path: "team/people/alex.md", group: "people" }),
+    ];
+    const grouped = groupMentionItems(items);
+    expect(grouped.map((g) => g.category)).toEqual(["people"]);
+  });
+});
+
+describe("categoryOrder", () => {
+  it("includes every supported category", () => {
+    const cats = categoryOrder();
+    expect(cats).toContain("pages");
+    expect(cats).toContain("agents");
+    expect(cats).toContain("tasks");
+    expect(cats).toContain("people");
+    expect(cats).toContain("companies");
+    expect(cats).toContain("projects");
+  });
+});

--- a/web/src/components/wiki/editor/inserts/mentionCatalog.ts
+++ b/web/src/components/wiki/editor/inserts/mentionCatalog.ts
@@ -1,0 +1,174 @@
+/**
+ * Helpers for grouping the wiki catalog into mention-picker categories.
+ *
+ * The wiki catalog already includes wiki pages, agents, tasks, people,
+ * companies, projects, etc. — they share a single `WikiCatalogEntry`
+ * shape and resolve through the same `[[slug]]` wikilink path. To make
+ * the slash and `@` mention pickers feel structured, we project entries
+ * into stable category buckets keyed off the entry's `group` field
+ * (which the broker populates from the path prefix `team/<group>/...`).
+ *
+ * Grouping rules:
+ *   - `agents`: entries whose path starts with `agents/` (the legacy
+ *     v1.2 per-agent notebook namespace) OR whose `group` is `agents`
+ *     in newer blueprints. Agents are tracked separately so a "@"
+ *     mention can default to them.
+ *   - `tasks`: `group === "tasks"`.
+ *   - `people` / `companies` / `projects`: matched on `group` directly.
+ *   - `pages`: everything else — playbooks, decisions, inbox notes,
+ *     anything blueprint-specific.
+ *
+ * Inputs that never resolve into a valid wikilink (because `parseWikiLinkInner`
+ * rejects the path) are silently dropped so the picker never offers a slug
+ * the editor would later refuse.
+ */
+
+import type { WikiCatalogEntry } from "../../../../api/wiki";
+import { parseWikiLinkInner } from "../../../../lib/wikilink";
+
+export type MentionCategory =
+  | "pages"
+  | "agents"
+  | "tasks"
+  | "people"
+  | "companies"
+  | "projects";
+
+export interface MentionItem {
+  /** Canonical wiki path used by `[[…]]` resolution. */
+  slug: string;
+  /** Title from the catalog. */
+  title: string;
+  /** Pre-bucketed category for grouped rendering. */
+  category: MentionCategory;
+}
+
+const CATEGORY_LABELS: Record<MentionCategory, string> = {
+  pages: "Pages",
+  agents: "Agents",
+  tasks: "Tasks",
+  people: "People",
+  companies: "Companies",
+  projects: "Projects",
+};
+
+const CATEGORY_ORDER: MentionCategory[] = [
+  "pages",
+  "people",
+  "companies",
+  "projects",
+  "agents",
+  "tasks",
+];
+
+export function categoryLabel(c: MentionCategory): string {
+  return CATEGORY_LABELS[c];
+}
+
+export function categoryOrder(): readonly MentionCategory[] {
+  return CATEGORY_ORDER;
+}
+
+/**
+ * Project a catalog entry into a `MentionItem`. Returns null when the
+ * entry's path cannot be reduced to a valid wikilink slug.
+ *
+ * The conversion strips the trailing `.md` extension because wikilinks
+ * are written without it. `parseWikiLinkInner` enforces the slug grammar
+ * so a path containing `..` or other illegal sequences is rejected.
+ */
+export function toMentionItem(entry: WikiCatalogEntry): MentionItem | null {
+  const slug = entry.path.replace(/\.md$/, "");
+  if (!parseWikiLinkInner(slug)) return null;
+  return {
+    slug,
+    title: entry.title || slug,
+    category: classify(entry),
+  };
+}
+
+function classify(entry: WikiCatalogEntry): MentionCategory {
+  if (entry.path.startsWith("agents/")) return "agents";
+  switch (entry.group) {
+    case "people":
+      return "people";
+    case "companies":
+      return "companies";
+    case "projects":
+      return "projects";
+    case "agents":
+      return "agents";
+    case "tasks":
+      return "tasks";
+    default:
+      return "pages";
+  }
+}
+
+/**
+ * Filter and rank mention items against a query. Empty queries return all
+ * items (bucketed). Non-empty queries match on title + slug substring, then
+ * sort by:
+ *   1. Title prefix match (highest)
+ *   2. Slug prefix match
+ *   3. Substring match anywhere
+ * Ties broken by title alpha.
+ *
+ * The picker UI renders the result top-N (caller-controlled) so very large
+ * catalogs (1000+ entries) still render in a single frame.
+ */
+export function searchMentionItems(
+  items: MentionItem[],
+  query: string,
+  limit = 50,
+): MentionItem[] {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    // No query: return items in the configured category order, alpha
+    // within each bucket. Truncate so the picker stays responsive.
+    return [...items]
+      .sort((a, b) => {
+        const ai = CATEGORY_ORDER.indexOf(a.category);
+        const bi = CATEGORY_ORDER.indexOf(b.category);
+        if (ai !== bi) return ai - bi;
+        return a.title.localeCompare(b.title);
+      })
+      .slice(0, limit);
+  }
+  const scored: { item: MentionItem; score: number }[] = [];
+  for (const item of items) {
+    const titleLc = item.title.toLowerCase();
+    const slugLc = item.slug.toLowerCase();
+    let score = 0;
+    if (titleLc.startsWith(q)) score = 3;
+    else if (slugLc.startsWith(q)) score = 2;
+    else if (titleLc.includes(q) || slugLc.includes(q)) score = 1;
+    if (score > 0) scored.push({ item, score });
+  }
+  scored.sort((a, b) => {
+    if (a.score !== b.score) return b.score - a.score;
+    return a.item.title.localeCompare(b.item.title);
+  });
+  return scored.slice(0, limit).map((s) => s.item);
+}
+
+/**
+ * Group mention items by category for menu rendering. Categories are
+ * returned in `CATEGORY_ORDER`, omitting empty buckets.
+ */
+export function groupMentionItems(
+  items: MentionItem[],
+): { category: MentionCategory; items: MentionItem[] }[] {
+  const buckets = new Map<MentionCategory, MentionItem[]>();
+  for (const item of items) {
+    const bucket = buckets.get(item.category) ?? [];
+    bucket.push(item);
+    buckets.set(item.category, bucket);
+  }
+  const out: { category: MentionCategory; items: MentionItem[] }[] = [];
+  for (const cat of CATEGORY_ORDER) {
+    const bucket = buckets.get(cat);
+    if (bucket && bucket.length > 0) out.push({ category: cat, items: bucket });
+  }
+  return out;
+}

--- a/web/src/components/wiki/editor/inserts/triggerPlugin.ts
+++ b/web/src/components/wiki/editor/inserts/triggerPlugin.ts
@@ -107,7 +107,9 @@ function triggerStateEquals(
     a.to === b.to &&
     a.query === b.query &&
     a.rect.top === b.rect.top &&
-    a.rect.left === b.rect.left
+    a.rect.left === b.rect.left &&
+    a.rect.bottom === b.rect.bottom &&
+    a.rect.right === b.rect.right
   );
 }
 
@@ -124,8 +126,9 @@ function computeTriggerState(
   // large paragraphs.
   const parentOffset = $pos.parentOffset;
   if (parentOffset === 0) return null;
+  const windowStart = Math.max(0, parentOffset - 200);
   const text = $pos.parent.textBetween(
-    Math.max(0, parentOffset - 200),
+    windowStart,
     parentOffset,
     undefined,
     "￼",
@@ -146,15 +149,18 @@ function computeTriggerState(
   if (triggerIdx === -1 || !trigger) return null;
   // The trigger must be at the start of the paragraph or preceded by
   // whitespace, so a `/` inside `http://` or an email's `@` does not
-  // pop the menu. When `triggerIdx === 0`, the scan reached the start of
-  // the 200-char window — that's "start of paragraph" since the window
-  // is anchored at `parentOffset - text.length` and we never look past
-  // a non-trigger non-whitespace character (the loop breaks first).
+  // pop the menu. When `triggerIdx === 0`, the scan hit the start of the
+  // 200-char lookback window. If the window starts mid-paragraph
+  // (windowStart > 0) we cannot prove the trigger is whitespace-preceded,
+  // so reject — otherwise a `/` exactly 200 chars before the caret inside
+  // a long URL would spuriously activate the menu.
   if (triggerIdx > 0) {
     const charBeforeTrigger = text[triggerIdx - 1];
     if (charBeforeTrigger !== " " && charBeforeTrigger !== "\t") {
       return null;
     }
+  } else if (windowStart > 0) {
+    return null;
   }
   const query = text.slice(triggerIdx + 1);
   // Position state in document coordinates. `from` is the position of

--- a/web/src/components/wiki/editor/inserts/triggerPlugin.ts
+++ b/web/src/components/wiki/editor/inserts/triggerPlugin.ts
@@ -1,0 +1,212 @@
+/**
+ * ProseMirror plugin that watches the editor for trigger characters
+ * (`/` for slash menu, `@` for mention picker) and exposes the active
+ * trigger state to the React layer.
+ *
+ * Why a custom plugin instead of `@milkdown/plugin-slash`'s SlashProvider?
+ * The provider mounts its own floating element and computes positions via
+ * `@floating-ui/dom`. We want React to own the menu DOM (so we can render
+ * dialogs, manage keyboard nav, and lazy-load forms) — the provider's
+ * lifecycle would fight that. This plugin only emits state; positioning
+ * happens by reading `EditorView.coordsAtPos` synchronously when the
+ * caller renders the menu.
+ *
+ * A single plugin instance handles both triggers because the state shapes
+ * are identical (start position + query string + viewport rect). The
+ * caller passes a list of trigger characters and gets the matched one
+ * back so the React menu can branch on it.
+ */
+
+import { Plugin, PluginKey } from "@milkdown/prose/state";
+import type { EditorView } from "@milkdown/prose/view";
+
+export type TriggerChar = "/" | "@";
+
+export interface TriggerState {
+  trigger: TriggerChar;
+  /** Document position immediately after the trigger character. */
+  from: number;
+  /** Document position at the caret (where the user is currently typing). */
+  to: number;
+  /** The substring between the trigger and the caret, used as the menu's
+   *  filter query. */
+  query: string;
+  /** Viewport-relative bounding rect for the trigger character, used to
+   *  position the React menu. */
+  rect: { top: number; left: number; bottom: number; right: number };
+}
+
+export interface TriggerPluginOptions {
+  triggers: readonly TriggerChar[];
+  /** Called every time the trigger state changes. Pass `null` to clear. */
+  onChange: (state: TriggerState | null) => void;
+  /** Called once when the editor view mounts and again with `null` on
+   *  destroy. Lets the React layer dispatch insert transactions without
+   *  polling for the view. */
+  onViewReady?: (view: EditorView | null) => void;
+}
+
+const triggerPluginKey = new PluginKey("wuphf-insert-trigger");
+
+/**
+ * Build the ProseMirror plugin. State lives on the React side via the
+ * `onChange` callback — ProseMirror only needs to observe view updates
+ * and dispatch the latest derived `TriggerState` to React.
+ *
+ * The plugin checks the text immediately preceding the caret on every
+ * transaction. A trigger activates when:
+ *   - the previous character is one of the trigger chars, AND
+ *   - that trigger is at start-of-line OR follows whitespace
+ *
+ * Once active, it tracks the query string (everything typed after the
+ * trigger up to the caret) and deactivates when the caret moves out of
+ * the trigger's text run, the user types whitespace, or backspaces past
+ * the trigger.
+ */
+export function buildTriggerPlugin(options: TriggerPluginOptions): Plugin {
+  const triggerSet = new Set<string>(options.triggers);
+  let lastEmitted: TriggerState | null = null;
+
+  return new Plugin({
+    key: triggerPluginKey,
+    view: (view: EditorView) => {
+      options.onViewReady?.(view);
+      const update = (): void => {
+        const next = computeTriggerState(view, triggerSet);
+        if (!triggerStateEquals(lastEmitted, next)) {
+          lastEmitted = next;
+          options.onChange(next);
+        }
+      };
+      update();
+      return {
+        update: () => {
+          update();
+        },
+        destroy: () => {
+          if (lastEmitted !== null) {
+            lastEmitted = null;
+            options.onChange(null);
+          }
+          options.onViewReady?.(null);
+        },
+      };
+    },
+  });
+}
+
+function triggerStateEquals(
+  a: TriggerState | null,
+  b: TriggerState | null,
+): boolean {
+  if (a === null && b === null) return true;
+  if (a === null || b === null) return false;
+  return (
+    a.trigger === b.trigger &&
+    a.from === b.from &&
+    a.to === b.to &&
+    a.query === b.query &&
+    a.rect.top === b.rect.top &&
+    a.rect.left === b.rect.left
+  );
+}
+
+function computeTriggerState(
+  view: EditorView,
+  triggerSet: Set<string>,
+): TriggerState | null {
+  const { state } = view;
+  const { selection } = state;
+  if (!selection.empty) return null;
+  const $pos = selection.$from;
+  // Walk backwards from the caret looking for the most recent trigger
+  // character. We bound the scan to 200 chars to keep the work O(1) on
+  // large paragraphs.
+  const parentOffset = $pos.parentOffset;
+  if (parentOffset === 0) return null;
+  const text = $pos.parent.textBetween(
+    Math.max(0, parentOffset - 200),
+    parentOffset,
+    undefined,
+    "￼",
+  );
+  let triggerIdx = -1;
+  let trigger: TriggerChar | null = null;
+  // Scan backwards for the trigger. Reject if any whitespace is between
+  // the caret and the trigger — that means the user moved to a new word.
+  for (let i = text.length - 1; i >= 0; i--) {
+    const ch = text[i];
+    if (ch === " " || ch === "\t" || ch === "\n") return null;
+    if (triggerSet.has(ch)) {
+      triggerIdx = i;
+      trigger = ch as TriggerChar;
+      break;
+    }
+  }
+  if (triggerIdx === -1 || !trigger) return null;
+  // The trigger must be at the start of the paragraph or preceded by
+  // whitespace, so a `/` inside `http://` or an email's `@` does not
+  // pop the menu. When `triggerIdx === 0`, the scan reached the start of
+  // the 200-char window — that's "start of paragraph" since the window
+  // is anchored at `parentOffset - text.length` and we never look past
+  // a non-trigger non-whitespace character (the loop breaks first).
+  if (triggerIdx > 0) {
+    const charBeforeTrigger = text[triggerIdx - 1];
+    if (charBeforeTrigger !== " " && charBeforeTrigger !== "\t") {
+      return null;
+    }
+  }
+  const query = text.slice(triggerIdx + 1);
+  // Position state in document coordinates. `from` is the position of
+  // the trigger character itself; `to` is the caret. Replacing the range
+  // `[from, to]` deletes the trigger + query when an action commits.
+  const from = $pos.pos - (text.length - triggerIdx);
+  const to = $pos.pos;
+  // Rect of the trigger character — used to anchor the React menu.
+  const rect = view.coordsAtPos(from);
+  return {
+    trigger,
+    from,
+    to,
+    query,
+    rect: {
+      top: rect.top,
+      left: rect.left,
+      bottom: rect.bottom,
+      right: rect.right,
+    },
+  };
+}
+
+/**
+ * Replace the text between `from` and `to` with `replacement` and dispatch
+ * the resulting transaction. Used by the React menu to commit an action
+ * (delete the trigger + query, then either insert content or open a
+ * dialog).
+ */
+export function replaceRange(
+  view: EditorView,
+  from: number,
+  to: number,
+  replacement: string,
+): void {
+  const { state } = view;
+  let tr = state.tr.delete(from, to);
+  if (replacement.length > 0) {
+    tr = tr.insertText(replacement, from);
+  }
+  view.dispatch(tr);
+  view.focus();
+}
+
+/**
+ * Insert markdown text at the current selection without consuming any
+ * range. Used after a dialog closes — by then the trigger range was
+ * already deleted, so we just append at the caret.
+ */
+export function insertAtSelection(view: EditorView, replacement: string): void {
+  const { state } = view;
+  const tr = state.tr.insertText(replacement, state.selection.from);
+  view.dispatch(tr);
+  view.focus();
+}

--- a/web/src/components/wiki/editor/inserts/types.ts
+++ b/web/src/components/wiki/editor/inserts/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared types for the WUPHF-specific editor inserts.
+ *
+ * Central definitions live here so the slash menu, mention picker, the
+ * dialog components, and the controller hook all reference the same
+ * action identifiers without circular imports.
+ */
+
+import type { MentionItem } from "./mentionCatalog";
+
+export type SlashAction =
+  | "wiki-link"
+  | "citation"
+  | "fact"
+  | "task-ref"
+  | "agent-mention"
+  | "decision"
+  | "related";
+
+export interface SlashActionDef {
+  /** Stable identifier referenced by the controller. */
+  id: SlashAction;
+  /** Title shown in the slash menu. */
+  title: string;
+  /** One-line description shown beside the title. */
+  description: string;
+  /** Lowercase keywords used for filtering. */
+  keywords: string[];
+}
+
+export const SLASH_ACTIONS: SlashActionDef[] = [
+  {
+    id: "wiki-link",
+    title: "Link wiki page",
+    description: "Pick an existing page and insert a [[wikilink]].",
+    keywords: ["link", "wiki", "page", "ref"],
+  },
+  {
+    id: "citation",
+    title: "Cite source",
+    description: "Insert a footnote pointing to an external URL.",
+    keywords: ["cite", "source", "footnote", "url"],
+  },
+  {
+    id: "fact",
+    title: "Add fact / triple",
+    description:
+      "Capture a subject + predicate + object claim (review required).",
+    keywords: ["fact", "triple", "claim"],
+  },
+  {
+    id: "task-ref",
+    title: "Insert task reference",
+    description: "Link to an open task wiki page.",
+    keywords: ["task", "ref", "todo"],
+  },
+  {
+    id: "agent-mention",
+    title: "Insert agent mention",
+    description: "Reference an agent by their wiki page.",
+    keywords: ["agent", "mention", "@"],
+  },
+  {
+    id: "decision",
+    title: "Insert decision block",
+    description: "Capture a decision with rationale and alternatives.",
+    keywords: ["decision", "adr", "rationale"],
+  },
+  {
+    id: "related",
+    title: "Insert related pages",
+    description: "Append a Related section linking to picked pages.",
+    keywords: ["related", "see also", "links"],
+  },
+];
+
+/**
+ * Filter the slash actions against a query. Empty query returns all
+ * actions in the canonical order.
+ */
+export function filterSlashActions(query: string): SlashActionDef[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return SLASH_ACTIONS;
+  return SLASH_ACTIONS.filter((a) => {
+    if (a.title.toLowerCase().includes(q)) return true;
+    if (a.description.toLowerCase().includes(q)) return true;
+    return a.keywords.some((k) => k.includes(q));
+  });
+}
+
+export type ResolverFn = (slug: string) => boolean;
+
+export interface InsertMenuPosition {
+  /** Viewport-relative pixel coordinates for the menu's top-left corner. */
+  top: number;
+  left: number;
+}
+
+export type SelectMentionFn = (item: MentionItem) => void;

--- a/web/src/components/wiki/editor/inserts/types.ts
+++ b/web/src/components/wiki/editor/inserts/types.ts
@@ -84,7 +84,7 @@ export function filterSlashActions(query: string): SlashActionDef[] {
   return SLASH_ACTIONS.filter((a) => {
     if (a.title.toLowerCase().includes(q)) return true;
     if (a.description.toLowerCase().includes(q)) return true;
-    return a.keywords.some((k) => k.includes(q));
+    return a.keywords.some((k) => k.toLowerCase().includes(q));
   });
 }
 

--- a/web/src/components/wiki/editor/inserts/useInsertController.test.tsx
+++ b/web/src/components/wiki/editor/inserts/useInsertController.test.tsx
@@ -49,7 +49,7 @@ describe("useInsertController", () => {
             NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
           >,
         pushContent,
-        currentContent: "Body of article.\n",
+        getCurrentContent: () => "Body of article.\n",
       }),
     );
 
@@ -78,7 +78,7 @@ describe("useInsertController", () => {
             NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
           >,
         pushContent,
-        currentContent: "Body of article.\n",
+        getCurrentContent: () => "Body of article.\n",
       }),
     );
 
@@ -105,7 +105,7 @@ describe("useInsertController", () => {
             NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
           >,
         pushContent,
-        currentContent: "x",
+        getCurrentContent: () => "x",
       }),
     );
 
@@ -125,16 +125,20 @@ describe("useInsertController", () => {
     // No write yet — the dialog is open but nothing is inserted.
     expect(view.state.tr.insertText).not.toHaveBeenCalled();
     expect(pushContent).not.toHaveBeenCalled();
-    // Confirm.
+    // Confirm. Block inserts go through pushContent (re-parsed at the
+    // document level) so a fenced block round-trips as a real block
+    // node — `tr.insertText` would keep it as inline text inside the
+    // current paragraph and break serialization.
     act(() => {
       result.current.onFactConfirm(
         "```fact\nsubject: a\npredicate: b\nobject: c\n```\n",
       );
     });
-    expect(view.state.tr.insertText).toHaveBeenCalled();
-    const text = view.state.tr.insertText.mock.calls[0][0] as string;
-    expect(text).toContain("```fact");
-    expect(text).toContain("subject: a");
+    expect(view.state.tr.insertText).not.toHaveBeenCalled();
+    expect(pushContent).toHaveBeenCalled();
+    const next = pushContent.mock.calls[0][0] as string;
+    expect(next).toContain("```fact");
+    expect(next).toContain("subject: a");
   });
 
   it("inserts a wikilink at the trigger range when the @ picker is used", () => {
@@ -147,7 +151,7 @@ describe("useInsertController", () => {
             NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
           >,
         pushContent,
-        currentContent: "x",
+        getCurrentContent: () => "x",
       }),
     );
 
@@ -185,7 +189,7 @@ describe("useInsertController", () => {
             NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
           >,
         pushContent,
-        currentContent: "x",
+        getCurrentContent: () => "x",
       }),
     );
 
@@ -216,7 +220,7 @@ describe("useInsertController", () => {
             NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
           >,
         pushContent,
-        currentContent: "x",
+        getCurrentContent: () => "x",
       }),
     );
 
@@ -245,7 +249,7 @@ describe("useInsertController", () => {
             NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
           >,
         pushContent,
-        currentContent: "x",
+        getCurrentContent: () => "x",
       }),
     );
 

--- a/web/src/components/wiki/editor/inserts/useInsertController.test.tsx
+++ b/web/src/components/wiki/editor/inserts/useInsertController.test.tsx
@@ -1,0 +1,266 @@
+/**
+ * Integration tests for the insert controller.
+ *
+ * Drives the controller through realistic flows (slash trigger -> action ->
+ * dialog -> insert) without spinning up the full Milkdown editor. A fake
+ * `EditorView` records the transactions the controller would dispatch so
+ * we can assert on the final markdown without ProseMirror's overhead.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useInsertController } from "./useInsertController";
+
+type FakeView = {
+  dispatch: ReturnType<typeof vi.fn>;
+  state: {
+    tr: {
+      delete: ReturnType<typeof vi.fn>;
+      insertText: ReturnType<typeof vi.fn>;
+    };
+    selection: { from: number };
+  };
+  focus: ReturnType<typeof vi.fn>;
+};
+
+function makeFakeView(): FakeView {
+  // The controller's `replaceRange` / `insertAtSelection` chain through
+  // `state.tr.delete().insertText()`. We mirror that fluent shape so the
+  // calls don't blow up; we don't model real document state.
+  const tr = {
+    delete: vi.fn((_from: number, _to: number) => tr),
+    insertText: vi.fn((_text: string, _from?: number) => tr),
+  };
+  return {
+    dispatch: vi.fn(),
+    state: { tr, selection: { from: 0 } },
+    focus: vi.fn(),
+  };
+}
+
+describe("useInsertController", () => {
+  it("opens the citation dialog when the citation slash action is selected", () => {
+    const view = makeFakeView();
+    const pushContent = vi.fn();
+    const { result } = renderHook(() =>
+      useInsertController({
+        getView: () =>
+          view as unknown as ReturnType<
+            NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
+          >,
+        pushContent,
+        currentContent: "Body of article.\n",
+      }),
+    );
+
+    act(() => {
+      result.current.setTrigger({
+        trigger: "/",
+        from: 0,
+        to: 4,
+        query: "cite",
+        rect: { top: 0, left: 0, bottom: 0, right: 0 },
+      });
+    });
+    act(() => {
+      result.current.onSlashSelect("citation");
+    });
+    expect(result.current.dialog).toBe("citation");
+  });
+
+  it("appends a citation definition to the document tail on confirm", () => {
+    const view = makeFakeView();
+    const pushContent = vi.fn();
+    const { result } = renderHook(() =>
+      useInsertController({
+        getView: () =>
+          view as unknown as ReturnType<
+            NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
+          >,
+        pushContent,
+        currentContent: "Body of article.\n",
+      }),
+    );
+
+    act(() => {
+      result.current.onCitationConfirm({
+        reference: "[^1]",
+        definition: "[^1]: Source - https://example.com\n",
+      });
+    });
+    // The reference should have been inserted at the caret.
+    expect(view.state.tr.insertText).toHaveBeenCalledWith("[^1]", 0);
+    // And the definition appended via pushContent.
+    const next = pushContent.mock.calls[0][0] as string;
+    expect(next).toContain("[^1]: Source - https://example.com");
+  });
+
+  it("inserts a fact block on confirm without auto-writing", () => {
+    const view = makeFakeView();
+    const pushContent = vi.fn();
+    const { result } = renderHook(() =>
+      useInsertController({
+        getView: () =>
+          view as unknown as ReturnType<
+            NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
+          >,
+        pushContent,
+        currentContent: "x",
+      }),
+    );
+
+    act(() => {
+      result.current.setTrigger({
+        trigger: "/",
+        from: 0,
+        to: 5,
+        query: "fact",
+        rect: { top: 0, left: 0, bottom: 0, right: 0 },
+      });
+    });
+    act(() => {
+      result.current.onSlashSelect("fact");
+    });
+    expect(result.current.dialog).toBe("fact");
+    // No write yet — the dialog is open but nothing is inserted.
+    expect(view.state.tr.insertText).not.toHaveBeenCalled();
+    expect(pushContent).not.toHaveBeenCalled();
+    // Confirm.
+    act(() => {
+      result.current.onFactConfirm(
+        "```fact\nsubject: a\npredicate: b\nobject: c\n```\n",
+      );
+    });
+    expect(view.state.tr.insertText).toHaveBeenCalled();
+    const text = view.state.tr.insertText.mock.calls[0][0] as string;
+    expect(text).toContain("```fact");
+    expect(text).toContain("subject: a");
+  });
+
+  it("inserts a wikilink at the trigger range when the @ picker is used", () => {
+    const view = makeFakeView();
+    const pushContent = vi.fn();
+    const { result } = renderHook(() =>
+      useInsertController({
+        getView: () =>
+          view as unknown as ReturnType<
+            NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
+          >,
+        pushContent,
+        currentContent: "x",
+      }),
+    );
+
+    act(() => {
+      result.current.setTrigger({
+        trigger: "@",
+        from: 5,
+        to: 8,
+        query: "ale",
+        rect: { top: 0, left: 0, bottom: 0, right: 0 },
+      });
+    });
+    act(() => {
+      result.current.onMentionSelect({
+        slug: "team/people/alex",
+        title: "Alex Chen",
+        category: "people",
+      });
+    });
+    // Replace the trigger range with the wikilink.
+    expect(view.state.tr.delete).toHaveBeenCalledWith(5, 8);
+    expect(view.state.tr.insertText).toHaveBeenCalledWith(
+      "[[team/people/alex|Alex Chen]]",
+      5,
+    );
+  });
+
+  it("opens the mention picker dialog for the wiki-link slash action", () => {
+    const view = makeFakeView();
+    const pushContent = vi.fn();
+    const { result } = renderHook(() =>
+      useInsertController({
+        getView: () =>
+          view as unknown as ReturnType<
+            NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
+          >,
+        pushContent,
+        currentContent: "x",
+      }),
+    );
+
+    act(() => {
+      result.current.setTrigger({
+        trigger: "/",
+        from: 0,
+        to: 5,
+        query: "link",
+        rect: { top: 0, left: 0, bottom: 0, right: 0 },
+      });
+    });
+    act(() => {
+      result.current.onSlashSelect("wiki-link");
+    });
+    expect(result.current.dialog).toBe("mention-picker");
+    expect(result.current.mentionPickerState?.categoryFilter).toBeNull();
+    expect(result.current.mentionPickerState?.heading).toBe("Link wiki page");
+  });
+
+  it("filters the picker to tasks for the task-ref action", () => {
+    const view = makeFakeView();
+    const pushContent = vi.fn();
+    const { result } = renderHook(() =>
+      useInsertController({
+        getView: () =>
+          view as unknown as ReturnType<
+            NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
+          >,
+        pushContent,
+        currentContent: "x",
+      }),
+    );
+
+    act(() => {
+      result.current.setTrigger({
+        trigger: "/",
+        from: 0,
+        to: 5,
+        query: "task",
+        rect: { top: 0, left: 0, bottom: 0, right: 0 },
+      });
+    });
+    act(() => {
+      result.current.onSlashSelect("task-ref");
+    });
+    expect(result.current.mentionPickerState?.categoryFilter).toBe("tasks");
+  });
+
+  it("filters the picker to agents for the agent-mention action", () => {
+    const view = makeFakeView();
+    const pushContent = vi.fn();
+    const { result } = renderHook(() =>
+      useInsertController({
+        getView: () =>
+          view as unknown as ReturnType<
+            NonNullable<Parameters<typeof useInsertController>[0]["getView"]>
+          >,
+        pushContent,
+        currentContent: "x",
+      }),
+    );
+
+    act(() => {
+      result.current.setTrigger({
+        trigger: "/",
+        from: 0,
+        to: 5,
+        query: "agent",
+        rect: { top: 0, left: 0, bottom: 0, right: 0 },
+      });
+    });
+    act(() => {
+      result.current.onSlashSelect("agent-mention");
+    });
+    expect(result.current.mentionPickerState?.categoryFilter).toBe("agents");
+  });
+});

--- a/web/src/components/wiki/editor/inserts/useInsertController.ts
+++ b/web/src/components/wiki/editor/inserts/useInsertController.ts
@@ -1,0 +1,271 @@
+/**
+ * Coordinates the WUPHF-specific inserts on top of the rich editor.
+ *
+ * Responsibilities:
+ *   - Track the active trigger (`/` slash menu, `@` mention picker) emitted
+ *     by `triggerPlugin`.
+ *   - Track which dialog (if any) should be open after the user picks a
+ *     slash action.
+ *   - On commit, delete the trigger range from ProseMirror and either:
+ *       a) insert markdown at the caret, or
+ *       b) open the appropriate dialog (which inserts on confirm).
+ *   - For citations, also append the footnote definition to the document
+ *     tail through the controller's `setContent`. This is the only path
+ *     that writes outside the caret position; everything else is local.
+ *
+ * The controller stays UI-framework-agnostic — it accepts the editor
+ * view ref + the controller-level setContent + the catalog and exposes
+ * pure handlers consumed by `RichWikiEditor`. No DOM access lives here.
+ */
+
+import { useCallback, useState } from "react";
+import type { EditorView } from "@milkdown/prose/view";
+
+import {
+  appendCitationDefinition,
+  type BuiltCitation,
+  buildWikilink,
+} from "./markdownShapes";
+import type { MentionItem } from "./mentionCatalog";
+import {
+  insertAtSelection,
+  replaceRange,
+  type TriggerState,
+} from "./triggerPlugin";
+import type { SlashAction } from "./types";
+
+export type DialogKind =
+  | "citation"
+  | "fact"
+  | "decision"
+  | "related"
+  | "mention-picker";
+
+export interface MentionPickerState {
+  /** Restrict the picker to one category, or null for "any wiki page". */
+  categoryFilter: import("./mentionCatalog").MentionCategory | null;
+  /** Heading rendered at the top of the picker. */
+  heading: string;
+}
+
+export interface UseInsertControllerArgs {
+  /** Live ProseMirror view from the editor — null until the editor mounts. */
+  getView: () => EditorView | null;
+  /** Controller-level setter so we can append citation definitions to the
+   *  document tail without going through ProseMirror. */
+  pushContent: (next: string) => void;
+  /** The latest content held by the controller. */
+  currentContent: string;
+}
+
+export interface InsertController {
+  trigger: TriggerState | null;
+  setTrigger: (next: TriggerState | null) => void;
+  /** Open dialog kind, or null when no dialog is active. */
+  dialog: DialogKind | null;
+  /** Mention picker state (heading + category filter) when active. */
+  mentionPickerState: MentionPickerState | null;
+  /** Open a dialog without going through the slash menu — used by the
+   *  controller itself once a slash action commits and the trigger range
+   *  has been deleted. Exposed for tests. */
+  openDialog: (kind: DialogKind, mention?: MentionPickerState) => void;
+  closeDialog: () => void;
+  /** Slash menu callbacks. */
+  onSlashSelect: (action: SlashAction) => void;
+  onMentionSelect: (item: MentionItem) => void;
+  closeTrigger: () => void;
+  /** Dialog confirm callbacks — forwarded by RichWikiEditor to the dialog
+   *  components. They remove the dialog and insert the produced markdown. */
+  onCitationConfirm: (built: BuiltCitation) => void;
+  onFactConfirm: (block: string) => void;
+  onDecisionConfirm: (block: string) => void;
+  onRelatedConfirm: (block: string) => void;
+}
+
+export function useInsertController(
+  args: UseInsertControllerArgs,
+): InsertController {
+  const [trigger, setTriggerState] = useState<TriggerState | null>(null);
+  const [dialog, setDialog] = useState<DialogKind | null>(null);
+  const [mentionPickerState, setMentionPickerState] =
+    useState<MentionPickerState | null>(null);
+
+  const setTrigger = useCallback((next: TriggerState | null) => {
+    setTriggerState(next);
+  }, []);
+
+  const closeTrigger = useCallback(() => {
+    setTriggerState(null);
+  }, []);
+
+  const openDialog = useCallback(
+    (kind: DialogKind, mention?: MentionPickerState) => {
+      setDialog(kind);
+      setMentionPickerState(mention ?? null);
+    },
+    [],
+  );
+
+  const closeDialog = useCallback(() => {
+    setDialog(null);
+    setMentionPickerState(null);
+  }, []);
+
+  /**
+   * Delete the trigger range (e.g. `/cit`) so the action does not leave
+   * stray characters behind, then either insert markdown at the caret or
+   * open the appropriate dialog.
+   */
+  const consumeTrigger = useCallback(
+    (active: TriggerState, replacement: string) => {
+      const view = args.getView();
+      if (!view) return;
+      replaceRange(view, active.from, active.to, replacement);
+      setTriggerState(null);
+    },
+    [args],
+  );
+
+  const onSlashSelect = useCallback(
+    (action: SlashAction) => {
+      const active = trigger;
+      if (!active) return;
+      // For inserts that need a dialog, delete the trigger range first
+      // (no replacement) and then open the dialog. The user's caret is
+      // left where the trigger used to be, so the dialog's confirm
+      // inserts at exactly the right spot.
+      const openWithEmptyConsume = (
+        kind: DialogKind,
+        mention?: MentionPickerState,
+      ) => {
+        consumeTrigger(active, "");
+        openDialog(kind, mention);
+      };
+      switch (action) {
+        case "wiki-link":
+          openWithEmptyConsume("mention-picker", {
+            categoryFilter: null,
+            heading: "Link wiki page",
+          });
+          break;
+        case "task-ref":
+          openWithEmptyConsume("mention-picker", {
+            categoryFilter: "tasks",
+            heading: "Insert task reference",
+          });
+          break;
+        case "agent-mention":
+          openWithEmptyConsume("mention-picker", {
+            categoryFilter: "agents",
+            heading: "Insert agent mention",
+          });
+          break;
+        case "citation":
+          openWithEmptyConsume("citation");
+          break;
+        case "fact":
+          openWithEmptyConsume("fact");
+          break;
+        case "decision":
+          openWithEmptyConsume("decision");
+          break;
+        case "related":
+          openWithEmptyConsume("related");
+          break;
+      }
+    },
+    [trigger, consumeTrigger, openDialog],
+  );
+
+  const onMentionSelect = useCallback(
+    (item: MentionItem) => {
+      const view = args.getView();
+      if (!view) return;
+      const link = buildWikilink(item.slug, item.title);
+      if (!link) return;
+      // Two paths:
+      //   1. Triggered from `@` — replace the trigger range with the link.
+      //   2. Triggered from a slash action via mention-picker dialog —
+      //      the trigger range was already deleted; insert at caret and
+      //      close the dialog.
+      if (trigger && dialog === null) {
+        replaceRange(view, trigger.from, trigger.to, link);
+        setTriggerState(null);
+        return;
+      }
+      insertAtSelection(view, link);
+      closeDialog();
+    },
+    [args, trigger, dialog, closeDialog],
+  );
+
+  const onCitationConfirm = useCallback(
+    (built: BuiltCitation) => {
+      const view = args.getView();
+      if (!view) {
+        closeDialog();
+        return;
+      }
+      // Inline reference goes at the caret (where the trigger lived).
+      insertAtSelection(view, built.reference);
+      closeDialog();
+      // Append the footnote definition through the controller's
+      // setContent so it sits at the document tail. We read the
+      // most-recent canonical content the editor has emitted so the
+      // append doesn't race with an in-flight markdownUpdated tick.
+      // ProseMirror's transaction has already settled by the time the
+      // callback fires, so `args.currentContent` reflects the
+      // post-insert state when the controller is wired correctly.
+      const next = appendCitationDefinition(
+        args.currentContent,
+        built.definition,
+      );
+      args.pushContent(next);
+    },
+    [args, closeDialog],
+  );
+
+  const insertBlock = useCallback(
+    (block: string) => {
+      const view = args.getView();
+      if (!view) {
+        closeDialog();
+        return;
+      }
+      // Block inserts (fact / decision / related) need to start on a new
+      // line so the surrounding paragraph doesn't absorb the fence.
+      insertAtSelection(view, `\n${block}`);
+      closeDialog();
+    },
+    [args, closeDialog],
+  );
+
+  const onFactConfirm = useCallback(
+    (block: string) => insertBlock(block),
+    [insertBlock],
+  );
+  const onDecisionConfirm = useCallback(
+    (block: string) => insertBlock(block),
+    [insertBlock],
+  );
+  const onRelatedConfirm = useCallback(
+    (block: string) => insertBlock(block),
+    [insertBlock],
+  );
+
+  return {
+    trigger,
+    setTrigger,
+    dialog,
+    mentionPickerState,
+    openDialog,
+    closeDialog,
+    onSlashSelect,
+    onMentionSelect,
+    closeTrigger,
+    onCitationConfirm,
+    onFactConfirm,
+    onDecisionConfirm,
+    onRelatedConfirm,
+  };
+}

--- a/web/src/components/wiki/editor/inserts/useInsertController.ts
+++ b/web/src/components/wiki/editor/inserts/useInsertController.ts
@@ -94,9 +94,11 @@ export interface InsertController {
   onRelatedConfirm: (block: string) => void;
 }
 
-export function useInsertController(
-  args: UseInsertControllerArgs,
-): InsertController {
+export function useInsertController({
+  getView,
+  pushContent,
+  getCurrentContent,
+}: UseInsertControllerArgs): InsertController {
   const [trigger, setTriggerState] = useState<TriggerState | null>(null);
   const [dialog, setDialog] = useState<DialogKind | null>(null);
   const [mentionPickerState, setMentionPickerState] =
@@ -130,12 +132,12 @@ export function useInsertController(
    */
   const consumeTrigger = useCallback(
     (active: TriggerState, replacement: string) => {
-      const view = args.getView();
+      const view = getView();
       if (!view) return;
       replaceRange(view, active.from, active.to, replacement);
       setTriggerState(null);
     },
-    [args],
+    [getView],
   );
 
   const onSlashSelect = useCallback(
@@ -201,7 +203,7 @@ export function useInsertController(
 
   const onMentionSelect = useCallback(
     (item: MentionItem) => {
-      const view = args.getView();
+      const view = getView();
       if (!view) return;
       const link = buildWikilink(item.slug, item.title);
       if (!link) return;
@@ -218,12 +220,12 @@ export function useInsertController(
       insertAtSelection(view, link);
       closeDialog();
     },
-    [args, trigger, dialog, closeDialog],
+    [getView, trigger, dialog, closeDialog],
   );
 
   const onCitationConfirm = useCallback(
     (built: BuiltCitation) => {
-      const view = args.getView();
+      const view = getView();
       if (!view) {
         closeDialog();
         return;
@@ -239,12 +241,12 @@ export function useInsertController(
       // callback fires, so the live getter reflects the post-insert
       // state when the controller is wired correctly.
       const next = appendCitationDefinition(
-        args.getCurrentContent(),
+        getCurrentContent(),
         built.definition,
       );
-      args.pushContent(next);
+      pushContent(next);
     },
-    [args, closeDialog],
+    [getView, getCurrentContent, pushContent, closeDialog],
   );
 
   const insertBlock = useCallback(
@@ -255,11 +257,11 @@ export function useInsertController(
       // would emit literal backticks instead of a block node. Routing
       // through `pushContent` re-parses the markdown and produces real
       // block nodes for the round trip.
-      const next = appendBlockToTail(args.getCurrentContent(), block);
-      args.pushContent(next);
+      const next = appendBlockToTail(getCurrentContent(), block);
+      pushContent(next);
       closeDialog();
     },
-    [args, closeDialog],
+    [getCurrentContent, pushContent, closeDialog],
   );
 
   const onFactConfirm = useCallback(

--- a/web/src/components/wiki/editor/inserts/useInsertController.ts
+++ b/web/src/components/wiki/editor/inserts/useInsertController.ts
@@ -9,9 +9,13 @@
  *   - On commit, delete the trigger range from ProseMirror and either:
  *       a) insert markdown at the caret, or
  *       b) open the appropriate dialog (which inserts on confirm).
- *   - For citations, also append the footnote definition to the document
- *     tail through the controller's `setContent`. This is the only path
- *     that writes outside the caret position; everything else is local.
+ *   - For citations, the inline reference goes at the caret and the
+ *     footnote definition is appended to the document tail via
+ *     `pushContent` (re-parses at the document level).
+ *   - Fact / decision / related blocks are also appended via
+ *     `pushContent`, not inserted with `tr.insertText`, because
+ *     ProseMirror would otherwise keep the fenced markdown as inline
+ *     text inside the active paragraph and break the round-trip.
  *
  * The controller stays UI-framework-agnostic — it accepts the editor
  * view ref + the controller-level setContent + the catalog and exposes
@@ -22,6 +26,7 @@ import { useCallback, useState } from "react";
 import type { EditorView } from "@milkdown/prose/view";
 
 import {
+  appendBlockToTail,
   appendCitationDefinition,
   type BuiltCitation,
   buildWikilink,
@@ -46,6 +51,10 @@ export interface MentionPickerState {
   categoryFilter: import("./mentionCatalog").MentionCategory | null;
   /** Heading rendered at the top of the picker. */
   heading: string;
+  /** Caret-anchored screen position to render the picker at. Stashed
+   *  from the active trigger before it is consumed so the picker shows
+   *  near where the user was typing rather than a hardcoded corner. */
+  position: { top: number; left: number };
 }
 
 export interface UseInsertControllerArgs {
@@ -54,8 +63,11 @@ export interface UseInsertControllerArgs {
   /** Controller-level setter so we can append citation definitions to the
    *  document tail without going through ProseMirror. */
   pushContent: (next: string) => void;
-  /** The latest content held by the controller. */
-  currentContent: string;
+  /** Reads the latest content held by the controller. We pass a getter
+   *  rather than a snapshot string so the citation appender always sees
+   *  the live document state at confirm time, not whatever value the
+   *  React tree happened to render with when the dialog opened. */
+  getCurrentContent: () => string;
 }
 
 export interface InsertController {
@@ -141,23 +153,33 @@ export function useInsertController(
         consumeTrigger(active, "");
         openDialog(kind, mention);
       };
+      // Anchor any mention-picker dialog at the trigger's caret rect so
+      // the picker shows where the user was typing — not a hardcoded
+      // viewport corner.
+      const pickerPosition = {
+        top: active.rect.bottom + 4,
+        left: active.rect.left,
+      };
       switch (action) {
         case "wiki-link":
           openWithEmptyConsume("mention-picker", {
             categoryFilter: null,
             heading: "Link wiki page",
+            position: pickerPosition,
           });
           break;
         case "task-ref":
           openWithEmptyConsume("mention-picker", {
             categoryFilter: "tasks",
             heading: "Insert task reference",
+            position: pickerPosition,
           });
           break;
         case "agent-mention":
           openWithEmptyConsume("mention-picker", {
             categoryFilter: "agents",
             heading: "Insert agent mention",
+            position: pickerPosition,
           });
           break;
         case "citation":
@@ -214,10 +236,10 @@ export function useInsertController(
       // most-recent canonical content the editor has emitted so the
       // append doesn't race with an in-flight markdownUpdated tick.
       // ProseMirror's transaction has already settled by the time the
-      // callback fires, so `args.currentContent` reflects the
-      // post-insert state when the controller is wired correctly.
+      // callback fires, so the live getter reflects the post-insert
+      // state when the controller is wired correctly.
       const next = appendCitationDefinition(
-        args.currentContent,
+        args.getCurrentContent(),
         built.definition,
       );
       args.pushContent(next);
@@ -227,14 +249,14 @@ export function useInsertController(
 
   const insertBlock = useCallback(
     (block: string) => {
-      const view = args.getView();
-      if (!view) {
-        closeDialog();
-        return;
-      }
-      // Block inserts (fact / decision / related) need to start on a new
-      // line so the surrounding paragraph doesn't absorb the fence.
-      insertAtSelection(view, `\n${block}`);
+      // Block inserts (fact / decision / related) must be parsed at the
+      // document level — `tr.insertText` would keep fenced markdown as
+      // inline text inside the current paragraph, so the next serialize
+      // would emit literal backticks instead of a block node. Routing
+      // through `pushContent` re-parses the markdown and produces real
+      // block nodes for the round trip.
+      const next = appendBlockToTail(args.getCurrentContent(), block);
+      args.pushContent(next);
       closeDialog();
     },
     [args, closeDialog],

--- a/web/src/components/wiki/editor/inserts/useMenuKeyNav.ts
+++ b/web/src/components/wiki/editor/inserts/useMenuKeyNav.ts
@@ -48,7 +48,10 @@ function dispatchKey<T>(
   key: string,
   state: MenuKeyNavArgs<T>,
 ): (() => void) | null {
-  if (key === "Escape") return () => state.onClose();
+  // Tab is treated as Escape so focusing-out of the editor closes the
+  // floating menu instead of leaving it mounted with a live keydown
+  // listener.
+  if (key === "Escape" || key === "Tab") return () => state.onClose();
   const len = state.items.length;
   if (len === 0) return null;
   if (key === "ArrowDown") {

--- a/web/src/components/wiki/editor/inserts/useMenuKeyNav.ts
+++ b/web/src/components/wiki/editor/inserts/useMenuKeyNav.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared keyboard navigation hook for the slash and mention menus.
+ *
+ * Wires ArrowUp / ArrowDown / Enter / Escape to a stable item list. The
+ * caller passes the current items, the active index state, and the
+ * commit/close handlers; the hook attaches/removes a global keydown
+ * listener that respects React's stale-closure rules without forcing
+ * either menu to memoise its derived list.
+ */
+
+import { useEffect, useRef } from "react";
+
+export interface MenuKeyNavArgs<T> {
+  items: T[];
+  activeIdx: number;
+  setActiveIdx: (next: number | ((prev: number) => number)) => void;
+  onCommit: (item: T) => void;
+  onClose: () => void;
+}
+
+export function useMenuKeyNav<T>(args: MenuKeyNavArgs<T>): void {
+  // The keydown handler reads the latest values from refs so we don't
+  // need every menu to wrap its derived `items` array in `useMemo` just
+  // to satisfy useEffect's dependency rule.
+  const ref = useRef(args);
+  useEffect(() => {
+    ref.current = args;
+  });
+
+  useEffect(() => {
+    function handle(e: KeyboardEvent): void {
+      const next = dispatchKey(e.key, ref.current);
+      if (next === null) return;
+      e.preventDefault();
+      next();
+    }
+    window.addEventListener("keydown", handle, true);
+    return () => window.removeEventListener("keydown", handle, true);
+  }, []);
+}
+
+/**
+ * Returns a thunk that performs the action for `key`, or null if the key
+ * is not bound. Splitting the dispatch table out of `handle` keeps the
+ * keydown branch low-complexity and easy to extend with new shortcuts.
+ */
+function dispatchKey<T>(
+  key: string,
+  state: MenuKeyNavArgs<T>,
+): (() => void) | null {
+  if (key === "Escape") return () => state.onClose();
+  const len = state.items.length;
+  if (len === 0) return null;
+  if (key === "ArrowDown") {
+    return () => state.setActiveIdx((i) => (i + 1) % len);
+  }
+  if (key === "ArrowUp") {
+    return () => state.setActiveIdx((i) => (i - 1 + len) % len);
+  }
+  if (key === "Enter") {
+    const picked = state.items[state.activeIdx];
+    return picked ? () => state.onCommit(picked) : null;
+  }
+  return null;
+}

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -2429,7 +2429,9 @@
 /* ─── Rich-editor inserts (Phase 3 PR 6) ─────────────────────────────────── */
 
 .wk-rich-editor-host {
-  position: relative;
+  /* `display: contents` removes the host's own box, so a positioning
+     property would have nothing to apply to. Floating menus portal to
+     `document.body` with explicit fixed coordinates. */
   display: contents;
 }
 

--- a/web/src/styles/wiki.css
+++ b/web/src/styles/wiki.css
@@ -2425,3 +2425,148 @@
   color: #6c4fc6;
   border: 1px solid rgba(108, 79, 198, 0.3);
 }
+
+/* ─── Rich-editor inserts (Phase 3 PR 6) ─────────────────────────────────── */
+
+.wk-rich-editor-host {
+  position: relative;
+  display: contents;
+}
+
+.wk-insert-menu {
+  background: var(--wk-paper);
+  border: 1px solid var(--wk-border);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  min-width: 280px;
+  max-width: 360px;
+  max-height: 360px;
+  overflow-y: auto;
+  font-family: var(--wk-chrome);
+  font-size: 13px;
+}
+.wk-insert-menu--mention {
+  min-width: 320px;
+}
+.wk-insert-menu--empty {
+  padding: 12px 16px;
+}
+.wk-insert-menu__heading {
+  padding: 8px 12px 4px;
+  font-weight: 600;
+  color: var(--wk-text);
+  border-bottom: 1px solid var(--wk-border-light);
+}
+.wk-insert-menu__group {
+  padding: 4px 0;
+}
+.wk-insert-menu__group + .wk-insert-menu__group {
+  border-top: 1px solid var(--wk-border-light);
+}
+.wk-insert-menu__group-label {
+  padding: 4px 12px 2px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--wk-text-tertiary);
+}
+.wk-insert-menu__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.wk-insert-menu__item {
+  margin: 0;
+}
+.wk-insert-menu__item.is-active .wk-insert-menu__btn,
+.wk-insert-menu__btn:hover {
+  background: var(--wk-amber-banner);
+}
+.wk-insert-menu__btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  padding: 8px 12px;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+.wk-insert-menu__title {
+  font-weight: 600;
+  color: var(--wk-text);
+}
+.wk-insert-menu__desc {
+  font-size: 12px;
+  color: var(--wk-text-muted);
+}
+.wk-insert-menu__empty {
+  padding: 8px 12px;
+  color: var(--wk-text-muted);
+  font-style: italic;
+}
+
+.wk-insert-dialog {
+  width: min(540px, 92vw);
+}
+.wk-insert-dialog__hint {
+  margin: 0 0 4px;
+  font-size: 12px;
+  color: var(--wk-text-muted);
+}
+.wk-insert-dialog__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+.wk-insert-dialog__preview {
+  background: var(--wk-code-bg);
+  border: 1px solid var(--wk-border);
+  padding: 10px 12px;
+  font-family: var(--wk-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  margin: 6px 0;
+  max-height: 220px;
+  overflow: auto;
+}
+.wk-insert-dialog__pickers {
+  max-height: 280px;
+  overflow-y: auto;
+  border: 1px solid var(--wk-border-light);
+  margin: 6px 0;
+}
+.wk-related-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.wk-related-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 8px;
+  align-items: center;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+.wk-related-row:hover {
+  background: var(--wk-amber-banner);
+}
+.wk-related-row__title {
+  font-weight: 500;
+}
+.wk-related-row__slug {
+  font-family: var(--wk-mono);
+  font-size: 11px;
+  color: var(--wk-text-tertiary);
+}
+
+.wk-editor-banner--warn {
+  background: var(--wk-amber-banner);
+  border-left: 3px solid var(--wk-amber);
+  color: var(--wk-text);
+}


### PR DESCRIPTION
## Summary

Phase 3 PR 6 adds a slash menu (`/`) and `@`-mention picker on top of the
rich wiki editor that landed in Phase 3 PR 5 (#652). Authors can link
wiki pages, cite sources, capture facts, reference tasks, mention agents,
record decisions, and stitch related-pages blocks without remembering
markdown syntax.

## Scope (from phase doc PR 6)

Slash menu actions:
- Link wiki page (opens mention picker, inserts `[[slug]]`)
- Cite source (footnote pair: inline `[^id]` plus block definition)
- Add fact / triple (structured form with mandatory preview stage)
- Insert task reference (mention picker scoped to tasks)
- Insert agent mention (mention picker scoped to agents)
- Insert decision block (fenced ```decision block with title, date, rationale, alternatives)
- Insert related pages (multi-pick into a `## Related` section)

Mention picker categories: pages, people, companies, projects, agents, tasks.

## Acceptance criteria

- [x] Inserts produce valid markdown that survives parse, serialize, and `postProcessWikilinks` round trip through the existing Milkdown pipeline. Round-trip tests cover every shape using the same headless `Editor.make()` plus `getMarkdown()` harness as `RichWikiEditor.roundtrip.test.tsx`.
- [x] Wiki links resolve through the existing catalog logic (`parseWikiLinkInner` plus the resolver passed into `WikiEditor`).
- [x] Broken inserts (mentions to slugs not in the catalog) show a warning banner above the editor before save.
- [x] Fact / triple insert never silently writes a fact. The dialog has an explicit two-stage flow: edit, then preview, then a final Confirm button that is the only path to insertion.

## Files changed

New module under `web/src/components/wiki/editor/inserts/`:
- `markdownShapes.ts` plus `.test.ts` (28 tests covering every emitter and round-trip)
- `mentionCatalog.ts` plus `.test.ts` (catalog-to-mention projection, search, grouping)
- `triggerPlugin.ts` (ProseMirror plugin watching `/` and `@`)
- `useInsertController.ts` plus `.test.tsx` (state machine for trigger, dialog, and insert dispatch)
- `useMenuKeyNav.ts` (shared keyboard nav hook used by both menus)
- `SlashMenu.tsx`, `MentionMenu.tsx` plus `.test.tsx` (floating React menus)
- `CitationDialog.tsx`, `FactDialog.tsx`, `DecisionDialog.tsx`, `RelatedDialog.tsx`
- `dialogs.test.tsx` (covers the review-required contract for facts plus the form validation paths)
- `brokenLinks.ts` plus `.test.ts` (catalog-aware unresolved-wikilink scanner)
- `types.ts` (slash action registry)

Modified:
- `web/src/components/wiki/editor/RichWikiEditor.tsx`: mounts the trigger plugin, threads catalog through, and renders menus and dialogs above the Milkdown surface
- `web/src/components/wiki/WikiEditor.tsx`: passes catalog into the rich editor and updates the help-text hint between modes
- `web/src/styles/wiki.css`: insert-menu and dialog styles (scoped to `wk-insert-*`)

## Manual test plan

Tested headlessly through 128 new Vitest tests covering the round-trip
contract, shape correctness, dialog form behaviour, the controller flow
(slash trigger to dialog to insert), and the mention picker filter and
ranking. Browser-driven validation pending in a follow-up session, using
the recipe below against `bun run dev` from the `web/` directory.

- [ ] Open any wiki article, toggle to Rich mode
- [ ] Type `/` and verify the slash menu appears at the caret with all seven actions
- [ ] Filter the menu by typing `cite`, verify only the Cite source action remains
- [ ] Pick Cite source, fill out a URL, confirm, and verify the inline `[^1]` reference plus the appended `[^1]:` definition land in the saved markdown
- [ ] Pick Add fact, fill subject + predicate + object, click Preview, confirm preview shows the block, then click Confirm insert and verify the fenced block lands at the caret
- [ ] Cancel the fact dialog from the Preview stage and verify nothing is written
- [ ] Pick Insert decision, fill the form, confirm, and verify the decision block round-trips after a save and reload
- [ ] Pick Insert related pages, multi-select two pages, confirm, and verify the `## Related` section renders with the expected wikilinks
- [ ] Type `@`, pick a wiki page, and verify the wikilink lands at the trigger position (replacing the trigger range)
- [ ] Insert a wikilink to a slug that is not in the catalog and verify the broken-link banner appears above the editor before save
- [ ] Toggle back to Source mode and verify the help text reads "Toggle Rich for slash commands and the mention picker"

## Reference

Phase doc: PR 6 in `phase-03-wiki-ux.md` (lines 302-336). Builds on:
- PR 5 (#652) — rich editor MVP behind per-article toggle
- PR 4 (#641, #643, #648) — wiki UX folder navigation, sections, and editor controller

Tests: full Vitest suite passes at 1063 tests (935 baseline plus 128 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slash command menu (/) and mention picker (@) in the rich wiki editor with category-filtered search
  * Insert dialogs: Citation (footnotes), Fact, Decision, and Related Pages
  * Mention/related pickers, grouped results, and empty-state handling
* **Enhancements**
  * Live broken-wikilink detection in rich mode
  * Markdown emitters for wikilinks, citations, facts, decisions, and related blocks
  * Improved keyboard navigation and accessible menu behaviors
* **Style**
  * New rich-editor insert menu and dialog styling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->